### PR TITLE
#51: Kubernetes cname only tries the first ip address on GKE

### DIFF
--- a/cloud/kubernetes/yugabyte-statefulset.yaml
+++ b/cloud/kubernetes/yugabyte-statefulset.yaml
@@ -173,6 +173,7 @@ spec:
           - "/home/yugabyte/bin/yb-tserver"
           - "--fs_data_dirs=/mnt/data0"
           - "--tserver_master_addrs=yb-masters.default.svc.cluster.local:7100"
+          - "--tserver_master_replication_factor=3"
         ports:
         - containerPort: 9000
           name: tserver-ui


### PR DESCRIPTION
Fixes https://github.com/YugaByte/yugabyte-db/issues/51