### PR TITLE
Make helm chart support multiple namespaces

### DIFF
--- a/cloud/kubernetes/helm/README.md
+++ b/cloud/kubernetes/helm/README.md
@@ -21,7 +21,7 @@ If not already created, you can create a new kubernetes cluster by running the b
 gcloud container clusters create yugabyte --zone us-west1-b
 ```
 #### Creating node pool to use
-If not created already, you can create a new node pool 
+If not created already, you can create a new node pool
 ```
 gcloud container node-pools create node-pool-8cpu-2ssd \
       --cluster=yugabyte \

--- a/cloud/kubernetes/helm/yugabyte/Chart.yaml
+++ b/cloud/kubernetes/helm/yugabyte/Chart.yaml
@@ -2,4 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for YugaByte CE
 name: yugabyte
-version: 1.0.3.0
+version: 1.0.3
+icon: https://avatars0.githubusercontent.com/u/17074854?s=200&v=4

--- a/cloud/kubernetes/helm/yugabyte/templates/NOTES.txt
+++ b/cloud/kubernetes/helm/yugabyte/templates/NOTES.txt
@@ -2,12 +2,11 @@
   kubectl --namespace {{ .Release.Namespace }} get pods
 
 2. Get list of YugaByte services that are running:
-  kubectl --name {{ .Release.Namespace }} get services
+  kubectl --namespace {{ .Release.Namespace }} get services
 
 {{- $root := . -}}
 {{- range .Values.Services }}
 {{- if .hasLoadBalancer }}
-
 3. Get information about the master UI load balancer:
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
   You can watch the status of by running 'kubectl get svc -w "{{ $root.Release.Name }}-{{ .label }}-ui"'
@@ -15,11 +14,10 @@
 {{- end }}
 
 4. Connect to one of the tablet server:
-  kubectl exec -it yb-tserver-0 bash
+  kubectl exec -it {{ .Release.Name }}-yb-tserver-0 bash
 
 5. Run CQL shell from inside of a tablet server:
-  kubectl exec -it yb-tserver-0 bin/cqlsh
-
+  kubectl exec -it {{ .Release.Name }}-yb-tserver-0 bin/cqlsh
 
 6. Cleanup YugaByte Pods
   helm delete <namespace>

--- a/cloud/kubernetes/helm/yugabyte/templates/NOTES.txt
+++ b/cloud/kubernetes/helm/yugabyte/templates/NOTES.txt
@@ -4,12 +4,13 @@
 2. Get list of YugaByte services that are running:
   kubectl --name {{ .Release.Namespace }} get services
 
+{{- $root := . -}}
 {{- range .Values.Services }}
 {{- if .hasLoadBalancer }}
 
 3. Get information about the master UI load balancer:
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-  You can watch the status of by running 'kubectl get svc -w "{{ .label }}-ui"'
+  You can watch the status of by running 'kubectl get svc -w "{{ $root.Release.Name }}-{{ .label }}-ui"'
 {{- end }}
 {{- end }}
 
@@ -19,10 +20,11 @@
 5. Run CQL shell from inside of a tablet server:
   kubectl exec -it yb-tserver-0 bin/cqlsh
 
+
 6. Cleanup YugaByte Pods
   helm delete <namespace>
   NOTE: You need to manually delete the statefulset and persistent volume
-  kubectl delete statefulset yb-master
-  kubectl delete pvc -l app=yb-master
-  kubectl delete statefulset yb-tserver
-  kubectl delete pvc -l app=yb-tserver
+  {{- range .Values.Services }}
+  kubectl delete statefulset {{ $root.Release.Name }}-{{.name}}
+  kubectl delete pvc -l app={{ $root.Release.Name }}-{{.label}}
+  {{- end }}

--- a/cloud/kubernetes/helm/yugabyte/templates/service.yaml
+++ b/cloud/kubernetes/helm/yugabyte/templates/service.yaml
@@ -49,7 +49,7 @@ spec:
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
-  name: "{{ $root.Release.Name }}-{{ .name }}"
+  name: "{{ $root.Release.Name }}-{{ .label }}"
   labels:
     app: "{{ $root.Release.Name }}-{{ .label }}"
     heritage: {{ $root.Release.Service | quote }}
@@ -125,12 +125,12 @@ spec:
         {{ if eq .name "yb-masters" }}
           - "/home/yugabyte/bin/yb-master"
           - "--fs_data_dirs={{range $index := until (int ($root.Values.persistentVolume.count))}}{{if ne $index 0}},{{end}}/mnt/disk{{ $index }}{{end}}"
-          - "--master_addresses={{ $root.Release.Name }}-{{ .name }}:7100"
+          - "--master_addresses={{ $root.Release.Name }}-yb-masters:7100"
           - "--master_replication_factor={{ .replicas }}"
         {{ else }}
           - "/home/yugabyte/bin/yb-tserver"
           - "--fs_data_dirs={{range $index := until (int ($root.Values.persistentVolume.count))}}{{if ne $index 0}},{{end}}/mnt/disk{{ $index }}{{end}}"
-          - "--tserver_master_addrs={{ $root.Release.Name }}-{{ .name }}:7100"
+          - "--tserver_master_addrs={{ $root.Release.Name }}-yb-masters:7100"
           - "--tserver_master_replication_factor={{ .replicas }}"
         {{ end }}
         ports:

--- a/cloud/kubernetes/helm/yugabyte/templates/service.yaml
+++ b/cloud/kubernetes/helm/yugabyte/templates/service.yaml
@@ -8,9 +8,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .name }}
+  name: "{{ $root.Release.Name }}-{{ .name }}"
   labels:
-    app: {{ .label }}
+    app: "{{ $root.Release.Name }}-{{ .label }}"
     heritage: {{ $root.Release.Service | quote }}
     release: {{ $root.Release.Name | quote }}
     chart: "{{ $root.Chart.Name }}-{{ $root.Chart.Version }}"
@@ -23,16 +23,16 @@ spec:
       port: {{ $port }}
     {{- end}}
   selector:
-    app: {{ .label }}
+    app: "{{ $root.Release.Name }}-{{ .label }}"
 
 {{- if .hasLoadBalancer }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ .label }}-ui"
+  name: "{{ $root.Release.Name }}-{{ .label }}-ui"
   labels:
-    app: {{ .label }}
+    app: "{{ $root.Release.Name }}-{{ .label }}"
     heritage: {{ $root.Release.Service | quote }}
     release: {{ $root.Release.Name | quote }}
     chart: "{{ $root.Chart.Name }}-{{ $root.Chart.Version }}"
@@ -43,7 +43,7 @@ spec:
     - name: ui
       port: 7000
   selector:
-    app: {{ .label }}
+    app: "{{ $root.Release.Name }}-{{ .label }}"
   type: LoadBalancer
 {{- end }}
 
@@ -51,15 +51,15 @@ spec:
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
-  name: {{ .label }}
+  name: "{{ $root.Release.Name }}-{{ .name }}"
   labels:
-    app: {{ .label }}
+    app: "{{ $root.Release.Name }}-{{ .label }}"
     heritage: {{ $root.Release.Service | quote }}
     release: {{ $root.Release.Name | quote }}
     chart: "{{ $root.Chart.Name }}-{{ $root.Chart.Version }}"
     component: "{{ $root.Release.Name }}-{{ $root.Values.Component }}"
 spec:
-  serviceName: {{ .name }}
+  serviceName: "{{ $root.Release.Name }}-{{ .name }}"
   podManagementPolicy: {{ $root.Values.PodManagementPolicy }}
   replicas: {{ .replicas }}
   volumeClaimTemplates:
@@ -86,11 +86,11 @@ spec:
     type: RollingUpdate
   selector:
     matchLabels:
-      app: {{ .label }}
+      app: "{{ $root.Release.Name }}-{{ .label }}"
   template:
     metadata:
       labels:
-        app: {{ .label }}
+        app: "{{ $root.Release.Name }}-{{ .label }}"
         heritage: {{ $root.Release.Service | quote }}
         release: {{ $root.Release.Name | quote }}
         chart: "{{ $root.Chart.Name }}-{{ $root.Chart.Version }}"
@@ -111,10 +111,10 @@ spec:
                 - key: app
                   operator: In
                   values:
-                  - {{ .label }}
+                  - "{{ $root.Release.Name }}-{{ .label }}"
               topologyKey: kubernetes.io/hostname
       containers:
-      - name: {{ .label }}
+      - name: "{{ $root.Release.Name }}-{{ .label }}"
         image: "{{ $root.Values.Image.repository }}:{{ $root.Values.Image.tag }}"
         imagePullPolicy: {{ $root.Values.Image.pullPolicy }}
         metadata:
@@ -124,15 +124,15 @@ spec:
             chart: "{{ $root.Chart.Name }}-{{ $root.Chart.Version }}"
             component: "{{ $root.Release.Name }}-{{ $root.Values.Component }}"
         command:
-        {{ if eq .name "yb-masters" }}
+        {{ if eq .name "masters" }}
           - "/home/yugabyte/bin/yb-master"
           - "--fs_data_dirs={{range $index := until (int ($root.Values.persistentVolume.count))}}{{if ne $index 0}},{{end}}/mnt/disk{{ $index }}{{end}}"
-          - "--master_addresses=yb-masters.default.svc.cluster.local:7100"
+          - "--master_addresses={{ $root.Release.Name }}-{{ .name }}:7100"
           - "--master_replication_factor={{ .replicas }}"
         {{ else }}
           - "/home/yugabyte/bin/yb-tserver"
           - "--fs_data_dirs={{range $index := until (int ($root.Values.persistentVolume.count))}}{{if ne $index 0}},{{end}}/mnt/disk{{ $index }}{{end}}"
-          - "--tserver_master_addrs=yb-masters.default.svc.cluster.local:7100"
+          - "--tserver_master_addrs={{ $root.Release.Name }}-{{ .name }}:7100"
           - "--tserver_master_replication_factor={{ .replicas }}"
         {{ end }}
         ports:

--- a/cloud/kubernetes/helm/yugabyte/templates/service.yaml
+++ b/cloud/kubernetes/helm/yugabyte/templates/service.yaml
@@ -1,5 +1,3 @@
-# Since we cannot reference .Values inside the loop we just create a root
-# variable to store the root object.
 {{- $root := . -}}
 
 {{- range .Values.Services }}
@@ -124,7 +122,7 @@ spec:
             chart: "{{ $root.Chart.Name }}-{{ $root.Chart.Version }}"
             component: "{{ $root.Release.Name }}-{{ $root.Values.Component }}"
         command:
-        {{ if eq .name "masters" }}
+        {{ if eq .name "yb-masters" }}
           - "/home/yugabyte/bin/yb-master"
           - "--fs_data_dirs={{range $index := until (int ($root.Values.persistentVolume.count))}}{{if ne $index 0}},{{end}}/mnt/disk{{ $index }}{{end}}"
           - "--master_addresses={{ $root.Release.Name }}-{{ .name }}:7100"

--- a/cloud/kubernetes/helm/yugabyte/values.yaml
+++ b/cloud/kubernetes/helm/yugabyte/values.yaml
@@ -15,16 +15,16 @@ persistentVolume:
 PodManagementPolicy: Parallel
 
 Services:
-  - name: "yb-masters"
-    label: "yb-master"
+  - name: "masters"
+    label: "master"
     replicas: 3
     ports:
       ui: "7000"
       rpc-port: "7100"
     hasLoadBalancer: true
 
-  - name: "yb-tservers"
-    label: "yb-tserver"
+  - name: "tservers"
+    label: "tserver"
     replicas: 3
     ports:
       ui: "9000"

--- a/cloud/kubernetes/helm/yugabyte/values.yaml
+++ b/cloud/kubernetes/helm/yugabyte/values.yaml
@@ -15,16 +15,16 @@ persistentVolume:
 PodManagementPolicy: Parallel
 
 Services:
-  - name: "masters"
-    label: "master"
+  - name: "yb-masters"
+    label: "yb-master"
     replicas: 3
     ports:
       ui: "7000"
       rpc-port: "7100"
     hasLoadBalancer: true
 
-  - name: "tservers"
-    label: "tserver"
+  - name: "yb-tservers"
+    label: "yb-tserver"
     replicas: 3
     ports:
       ui: "9000"


### PR DESCRIPTION
Update helm chart to support multiple namespaces 
@rkarthik007 

In order to run helm charts to create multiple instances of YugaByte DB you would run the following command.
`helm install yugabyte --name dev`
That would bring up yugabyte in `dev` namespace

`helm install yugabyte --name staging`
That would bring up yugabyte in `staging` namespace

And you can independently cleanup
`helm delete dev`
 