### PR TITLE
Fix StatefulSet delete issue

### DIFF
--- a/cloud/kubernetes/helm/yugabyte/templates/NOTES.txt
+++ b/cloud/kubernetes/helm/yugabyte/templates/NOTES.txt
@@ -20,9 +20,8 @@
   kubectl exec -it {{ .Release.Name }}-yb-tserver-0 bin/cqlsh
 
 6. Cleanup YugaByte Pods
-  helm delete <namespace>
-  NOTE: You need to manually delete the statefulset and persistent volume
+  helm delete <namespace> --purge
+  NOTE: You need to manually delete the persistent volume
   {{- range .Values.Services }}
-  kubectl delete statefulset {{ $root.Release.Name }}-{{.name}}
   kubectl delete pvc -l app={{ $root.Release.Name }}-{{.label}}
   {{- end }}

--- a/cloud/kubernetes/helm/yugabyte/templates/service.yaml
+++ b/cloud/kubernetes/helm/yugabyte/templates/service.yaml
@@ -46,7 +46,7 @@ spec:
 {{- end }}
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: "{{ $root.Release.Name }}-{{ .label }}"


### PR DESCRIPTION
Switch to using the v1 api instead of beta fixes this issue. Now that statefulset is actually GA.

tested by running
`helm install yugabyte --name yb-demo --wait`
and then
`helm delete yb-demo --purge`

Offcourse PVC's are something we need to cleanup manually after the fact.