### PR TITLE
ENG-3574: Kubernetes functionality broken by master addresses check

### DIFF
--- a/cloud/kubernetes/helm/yugabyte/Chart.yaml
+++ b/cloud/kubernetes/helm/yugabyte/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for YugaByte CE
 name: yugabyte
-version: 1.0.4 
+version: 1.0.5
 icon: https://avatars0.githubusercontent.com/u/17074854?s=200&v=4

--- a/cloud/kubernetes/helm/yugabyte/templates/service.yaml
+++ b/cloud/kubernetes/helm/yugabyte/templates/service.yaml
@@ -115,6 +115,11 @@ spec:
       - name: "{{ $root.Release.Name }}-{{ .label }}"
         image: "{{ $root.Values.Image.repository }}:{{ $root.Values.Image.tag }}"
         imagePullPolicy: {{ $root.Values.Image.pullPolicy }}
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         metadata:
           labels:
             heritage: {{ $root.Release.Service | quote }}
@@ -125,6 +130,7 @@ spec:
         {{ if eq .name "yb-masters" }}
           - "/home/yugabyte/bin/yb-master"
           - "--fs_data_dirs={{range $index := until (int ($root.Values.persistentVolume.count))}}{{if ne $index 0}},{{end}}/mnt/disk{{ $index }}{{end}}"
+          - "--rpc_bind_addresses=$(POD_IP)"
           - "--master_addresses={{ $root.Release.Name }}-yb-masters:7100"
           - "--master_replication_factor={{ .replicas }}"
         {{ else }}

--- a/cloud/kubernetes/helm/yugabyte/values.yaml
+++ b/cloud/kubernetes/helm/yugabyte/values.yaml
@@ -4,7 +4,7 @@
 Component: "yugabytedb"
 Image:
   repository: "yugabytedb/yugabyte"
-  tag: 1.0.4.0-b24 
+  tag: latest
   pullPolicy: IfNotPresent
 
 persistentVolume:

--- a/cloud/kubernetes/helm/yugabyte/values.yaml
+++ b/cloud/kubernetes/helm/yugabyte/values.yaml
@@ -4,7 +4,7 @@
 Component: "yugabytedb"
 Image:
   repository: "yugabytedb/yugabyte"
-  tag: latest
+  tag: 1.0.5.0-b20
   pullPolicy: IfNotPresent
 
 persistentVolume:

--- a/cloud/kubernetes/yugabyte-statefulset-local-ssd-gke.yaml
+++ b/cloud/kubernetes/yugabyte-statefulset-local-ssd-gke.yaml
@@ -87,9 +87,15 @@ spec:
       - name: yb-master
         image: yugabytedb/yugabyte:latest
         imagePullPolicy: Always
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         command:
           - "/home/yugabyte/bin/yb-master"
           - "--fs_data_dirs=/mnt/disk0,/mnt/disk1"
+          - "--rpc_bind_addresses=$(POD_IP)"
           - "--master_addresses=yb-masters.default.svc.cluster.local:7100"
           - "--master_replication_factor=3"
         ports:

--- a/cloud/kubernetes/yugabyte-statefulset.yaml
+++ b/cloud/kubernetes/yugabyte-statefulset.yaml
@@ -86,9 +86,15 @@ spec:
       - name: yb-master
         image: yugabytedb/yugabyte:latest
         imagePullPolicy: Always
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         command:
           - "/home/yugabyte/bin/yb-master"
           - "--fs_data_dirs=/mnt/data0"
+          - "--rpc_bind_addresses=$(POD_IP)"
           - "--master_addresses=yb-masters.default.svc.cluster.local:7100"
           - "--master_replication_factor=3"
         ports:


### PR DESCRIPTION
Added detection of master POD IP and passing it to `yb-master` as `--rpc_bind_addresses`, so `yb-master` is listening on POD IP instead of `0.0.0.0`.