### PR TITLE
Update Helm Chart to take replica, cpu and memory as parameters

### DIFF
--- a/cloud/kubernetes/helm/yugabyte/Chart.yaml
+++ b/cloud/kubernetes/helm/yugabyte/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for YugaByte CE
 name: yugabyte
-version: 1.0.5
+version: 1.0.6
 icon: https://avatars0.githubusercontent.com/u/17074854?s=200&v=4

--- a/cloud/kubernetes/helm/yugabyte/templates/service.yaml
+++ b/cloud/kubernetes/helm/yugabyte/templates/service.yaml
@@ -59,7 +59,11 @@ metadata:
 spec:
   serviceName: "{{ .name }}"
   podManagementPolicy: {{ $root.Values.PodManagementPolicy }}
-  replicas: {{ .replicas }}
+  {{ if eq .name "yb-masters" }}
+  replicas: {{ $root.Values.replica.masters }}
+  {{ else }}
+  replicas: {{ $root.Values.replica.tservers  }}
+  {{ end }}
   volumeClaimTemplates:
     {{- range $index := until (int ($root.Values.persistentVolume.count )) }}
     - metadata:
@@ -120,6 +124,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        resources:
+          requests:
+            cpu: {{ $root.Values.instanceType.cpu }}
+            memory: {{ $root.Values.instanceType.memory }}
         metadata:
           labels:
             heritage: {{ $root.Release.Service | quote }}
@@ -132,12 +140,12 @@ spec:
           - "--fs_data_dirs={{range $index := until (int ($root.Values.persistentVolume.count))}}{{if ne $index 0}},{{end}}/mnt/disk{{ $index }}{{end}}"
           - "--rpc_bind_addresses=$(POD_IP)"
           - "--master_addresses=yb-masters:7100"
-          - "--master_replication_factor={{ .replicas }}"
+          - "--master_replication_factor= {{ $root.Values.replica.masters }}"
         {{ else }}
           - "/home/yugabyte/bin/yb-tserver"
           - "--fs_data_dirs={{range $index := until (int ($root.Values.persistentVolume.count))}}{{if ne $index 0}},{{end}}/mnt/disk{{ $index }}{{end}}"
           - "--tserver_master_addrs=yb-masters:7100"
-          - "--tserver_master_replication_factor={{ .replicas }}"
+          - "--tserver_master_replication_factor={{ $root.Values.replica.masters }}"
         {{ end }}
         ports:
           {{- range $label, $port := .ports }}

--- a/cloud/kubernetes/helm/yugabyte/values.yaml
+++ b/cloud/kubernetes/helm/yugabyte/values.yaml
@@ -10,14 +10,21 @@ Image:
 persistentVolume:
   count: 2
   storage: 10Gi
-  storageClass: standard 
+  storageClass: standard
+
+instanceType:
+  cpu: 3
+  memory: 10Gi
 
 PodManagementPolicy: Parallel
+
+replica:
+  masters: 3
+  tservers: 3
 
 Services:
   - name: "yb-masters"
     label: "yb-master"
-    replicas: 3
     ports:
       ui: "7000"
       rpc-port: "7100"
@@ -25,7 +32,6 @@ Services:
 
   - name: "yb-tservers"
     label: "yb-tserver"
-    replicas: 3
     ports:
       ui: "9000"
       rpc-port: "7100"


### PR DESCRIPTION
Tested by running helm install 

`helm install yugabyte --set instanceType.cpu=2 --set instanceType.memory=7.5Gi --set replica.tservers=5 --name demo`