### PR TITLE
add SimpleQueryTest CQL testsuite

### DIFF
--- a/java/yb-cql/src/test/java/org/yb/cql/CQLTester.java
+++ b/java/yb-cql/src/test/java/org/yb/cql/CQLTester.java
@@ -1,20 +1,20 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 package org.yb.cql;
 
 import com.datastax.driver.core.ResultSet;
@@ -36,172 +36,195 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
- * Base class for CQL tests.
- */
+* Base class for CQL tests.
+*/
 public class CQLTester extends BaseCQLTest
 {
-    public static final String KEYSPACE = "cql_test_keyspace";
-    private static final AtomicInteger seqNumber = new AtomicInteger();
+  public static final String KEYSPACE = "cql_test_keyspace";
+  private static final AtomicInteger seqNumber = new AtomicInteger();
 
-    private List<String> tables = new ArrayList<>();
+  private List<String> tables = new ArrayList<>();
+  private List<String> indexes = new ArrayList<>();
 
-    protected void createTable(String query)
+  protected void createTable(String query)
+  {
+    createTable(KEYSPACE, query);
+  }
+
+  protected void createIndex(String query)
+  {
+    createIndex(KEYSPACE, query);
+  }
+
+  protected void createTable(String keyspace, String query)
+  {
+    String currentTable = createTableName();
+    String fullQuery = formatQuery(keyspace, query);
+    final long startTimeMs = System.currentTimeMillis();
+    session.execute(fullQuery);
+    long elapsedTimeMs = System.currentTimeMillis() - startTimeMs;
+    LOG.info("After createTable execute: {} took {}ms", fullQuery, elapsedTimeMs);
+  }
+
+  protected void createIndex(String keyspace, String query)
+  {
+    String fullQuery = String.format(query, keyspace + "_" + createIndexName(), keyspace + "." + currentTable());
+    final long startTimeMs = System.currentTimeMillis();
+    session.execute(fullQuery);
+    long elapsedTimeMs = System.currentTimeMillis() - startTimeMs;
+    LOG.info("After createIndex execute: {} took {}ms", fullQuery, elapsedTimeMs);
+  }
+
+  protected String createTableName()
+  {
+    String currentTable = "table_" + seqNumber.getAndIncrement();
+    tables.add(currentTable);
+    return currentTable;
+  }
+
+  protected String createIndexName()
+  {
+    String currentIndex = "index_" + seqNumber.getAndIncrement();
+    indexes.add(currentIndex);
+    return currentIndex;
+  }
+
+  protected String formatQuery(String query)
+  {
+    return formatQuery(KEYSPACE, query);
+  }
+
+  protected final String formatQuery(String keyspace, String query)
+  {
+    String currentTable = currentTable();
+    return currentTable == null ? query : String.format(query, keyspace + "." + currentTable);
+  }
+
+  protected String keyspace()
+  {
+    return KEYSPACE;
+  }
+
+  protected String currentTable()
+  {
+    if (tables.isEmpty())
+      return null;
+    return tables.get(tables.size() - 1);
+  }
+
+  public ResultSet execute(String query, Object... values) throws Exception {
+    String fullQuery = formatQuery(KEYSPACE, query);
+    final ResultSet result = session.execute(fullQuery, values);
+    LOG.info("EXEC CQL FINISHED: {}", fullQuery);
+    return result;
+  }
+
+
+  public ResultSet execute(String query) throws Exception {
+    String fullQuery = formatQuery(KEYSPACE, query);
+    final ResultSet result = session.execute(fullQuery);
+    LOG.info("EXEC CQL FINISHED: {}", fullQuery);
+    return result;
+  }
+
+  protected void assertAllRows(Object[]... rows) throws Throwable
+  {
+    assertRows(execute("SELECT * FROM %s"), rows);
+  }
+
+  protected void assertEmpty(ResultSet result) throws Throwable
+  {
+    if (result != null && !result.isExhausted())
     {
-        createTable(KEYSPACE, query);
+      List<String> rows = makeRowStrings(result);
+      throw new AssertionError(String.format("Expected empty result but got %d rows: %s \n", rows.size(), rows));
     }
+  }
 
-    protected void createTable(String keyspace, String query)
+  public static Object[] row(Object... expected)
+  {
+    return expected;
+  }
+
+  protected static List<String> makeRowStrings(ResultSet resultSet)
+  {
+    List<String> rows = new ArrayList<>();
+    int i = 0;
+    for (Row row : resultSet)
     {
-        String currentTable = createTableName();
-        String fullQuery = formatQuery(keyspace, query);
-        final long startTimeMs = System.currentTimeMillis();
-        session.execute(fullQuery);
-        long elapsedTimeMs = System.currentTimeMillis() - startTimeMs;
-        LOG.info("After execute: {} took {}ms", fullQuery, elapsedTimeMs);
+      rows.add(String.format("Row {} = {}", i, row.toString()));
+      i++;
     }
 
-    protected String createTableName()
+    return rows;
+  }
+
+  public static int displayRows(ResultSet result)
+  {
+    if (result == null)
     {
-        String currentTable = "table_" + seqNumber.getAndIncrement();
-        tables.add(currentTable);
-        return currentTable;
+      LOG.info("Resultset has zero rows");
+      return 0;
     }
 
-    protected String formatQuery(String query)
+    ColumnDefinitions colDef = result.getColumnDefinitions();
+    List<ColumnDefinitions.Definition> meta = colDef.asList();
+    int i = 0;
+    for (Row actual : result)
     {
-        return formatQuery(KEYSPACE, query);
+      LOG.info("Row {} = {}", i, actual.toString());
+      i++;
     }
+    return i;
+  }
 
-    protected final String formatQuery(String keyspace, String query)
+  public static void assertRows(ResultSet result, Object[]... rows)
+  {
+    if (result == null)
     {
-        String currentTable = currentTable();
-        return currentTable == null ? query : String.format(query, keyspace + "." + currentTable);
+      if (rows.length > 0)
+        fail(String.format("No rows returned by query but %d expected", rows.length));
+      return;
     }
-
-    protected String keyspace()
+    ColumnDefinitions colDef = result.getColumnDefinitions();
+    List<ColumnDefinitions.Definition> meta = colDef.asList();
+    Iterator<Row> iter = result.iterator();
+    int i = 0;
+    while (iter.hasNext() && i < rows.length)
     {
-        return KEYSPACE;
-    }
+      Object[] expected = rows[i];
+      Row actual = iter.next();
 
-    protected String currentTable()
-    {
-        if (tables.isEmpty())
-            return null;
-        return tables.get(tables.size() - 1);
-    }
+      assertEquals(String.format("Invalid number of (expected) values provided for row %d", i), expected == null ? 1 : expected.length, meta.size());
 
-    public ResultSet execute(String query, Object... values) throws Exception {
-        String fullQuery = formatQuery(KEYSPACE, query);
-        final ResultSet result = session.execute(fullQuery, values);
-        LOG.info("EXEC CQL FINISHED: {}", fullQuery);
-        return result;
-    }
-
-
-    public ResultSet execute(String query) throws Exception {
-        String fullQuery = formatQuery(KEYSPACE, query);
-        final ResultSet result = session.execute(fullQuery);
-        LOG.info("EXEC CQL FINISHED: {}", fullQuery);
-        return result;
-    }
-
-    protected void assertAllRows(Object[]... rows) throws Throwable
-    {
-        assertRows(execute("SELECT * FROM %s"), rows);
-    }
-
-    protected void assertEmpty(ResultSet result) throws Throwable
-    {
-        if (result != null && !result.isExhausted())
+      for (int j = 0; j < meta.size(); j++)
+      {
+        ColumnDefinitions.Definition column = meta.get(j);
+        DataType.Name type = column.getType().getName();
+        switch (type) 
         {
-            List<String> rows = makeRowStrings(result);
-            throw new AssertionError(String.format("Expected empty result but got %d rows: %s \n", rows.size(), rows));
+          case INT:
+            LOG.info("Row[{}, {}] = {}", i, j, actual.getInt(j));
+            assertEquals((Integer)expected[j], (Integer)actual.getInt(j));
+            break;
+
+          case VARCHAR:
+          case TEXT:
+            LOG.info("Row[{}, {}] = {}", i, j, actual.getString(j));
+            assertEquals((String)expected[j], actual.getString(j));
+            break;
+
+          default:
+            fail(String.format("Expect INT or VARCHAR or TEXT type but got: %s", type.toString()));
+            break;
         }
+      }
+      i++;
     }
 
-    public static Object[] row(Object... expected)
-    {
-        return expected;
-    }
-
-    protected static List<String> makeRowStrings(ResultSet resultSet)
-    {
-        List<String> rows = new ArrayList<>();
-        int i = 0;
-        for (Row row : resultSet)
-        {
-            rows.add(String.format("Row {} = {}", i, row.toString()));
-            i++;
-        }
-
-        return rows;
-    }
-
-    public static int displayRows(ResultSet result)
-    {
-        if (result == null)
-        {
-            LOG.info("Resultset has zero rows");
-            return 0;
-        }
-
-        ColumnDefinitions colDef = result.getColumnDefinitions();
-        List<ColumnDefinitions.Definition> meta = colDef.asList();
-        int i = 0;
-        for (Row actual : result)
-        {
-            LOG.info("Row {} = {}", i, actual.toString());
-            i++;
-        }
-	return i;
-    }
-
-    public static void assertRows(ResultSet result, Object[]... rows)
-    {
-        if (result == null)
-        {
-            if (rows.length > 0)
-                fail(String.format("No rows returned by query but %d expected", rows.length));
-            return;
-        }
-        ColumnDefinitions colDef = result.getColumnDefinitions();
-        List<ColumnDefinitions.Definition> meta = colDef.asList();
-        Iterator<Row> iter = result.iterator();
-        int i = 0;
-        while (iter.hasNext() && i < rows.length)
-        {
-            Object[] expected = rows[i];
-            Row actual = iter.next();
-
-            assertEquals(String.format("Invalid number of (expected) values provided for row %d", i), expected == null ? 1 : expected.length, meta.size());
-
-            for (int j = 0; j < meta.size(); j++)
-            {
-                ColumnDefinitions.Definition column = meta.get(j);
-                DataType.Name type = column.getType().getName();
-                switch (type) {
-                    case INT:
-                        LOG.info("Row[{}, {}] = {}", i, j, actual.getInt(j));
-                        assertEquals((Integer)expected[j], (Integer)actual.getInt(j));
-                        break;
-
-                    case VARCHAR:
-                    case TEXT:
-                        LOG.info("Row[{}, {}] = {}", i, j, actual.getString(j));
-                        assertEquals((String)expected[j], actual.getString(j));
-                        break;
-
-                    default:
-                        fail(String.format("Expect INT or VARCHAR or TEXT type but got: %s", type.toString()));
-                        break;
-		}
-            }
-            i++;
-        }
-
-        if (iter.hasNext())
-            fail(String.format("Query returned more than %d rows expected", rows.length));
-        if (i != rows.length)
-            fail(String.format("Query returned %d rows but expected %d rows", i, rows.length));
-    }
+    if (iter.hasNext())
+      fail(String.format("Query returned more than %d rows expected", rows.length));
+    if (i != rows.length)
+      fail(String.format("Query returned %d rows but expected %d rows", i, rows.length));
+  }
 }

--- a/java/yb-cql/src/test/java/org/yb/cql/CQLTester.java
+++ b/java/yb-cql/src/test/java/org/yb/cql/CQLTester.java
@@ -110,9 +110,31 @@ public class CQLTester extends BaseCQLTest
         assertRows(execute("SELECT * FROM %s"), rows);
     }
 
+    protected void assertEmpty(ResultSet result) throws Throwable
+    {
+        if (result != null && !result.isExhausted())
+        {
+            List<String> rows = makeRowStrings(result);
+            throw new AssertionError(String.format("Expected empty result but got %d rows: %s \n", rows.size(), rows));
+        }
+    }
+
     public static Object[] row(Object... expected)
     {
         return expected;
+    }
+
+    protected static List<String> makeRowStrings(ResultSet resultSet)
+    {
+        List<String> rows = new ArrayList<>();
+        int i = 0;
+        for (Row row : resultSet)
+        {
+            rows.add(String.format("Row {} = {}", i, row.toString()));
+            i++;
+        }
+
+        return rows;
     }
 
     public static int displayRows(ResultSet result)

--- a/java/yb-cql/src/test/java/org/yb/cql/CQLTester.java
+++ b/java/yb-cql/src/test/java/org/yb/cql/CQLTester.java
@@ -116,6 +116,47 @@ public class CQLTester extends BaseCQLTest
         return expected;
     }
 
+    public static int displayRows(ResultSet result)
+    {
+        if (result == null)
+        {
+	    LOG.info("Resultset has zero rows");
+	    return 0;
+	}
+
+	ColumnDefinitions colDef = result.getColumnDefinitions();
+	List<ColumnDefinitions.Definition> meta = colDef.asList();
+        Iterator<Row> iter = result.iterator();
+	int i = 0;
+        while (iter.hasNext())
+        {
+            Row actual = iter.next();
+            for (int j = 0; j < meta.size(); j++)
+            {
+                ColumnDefinitions.Definition column = meta.get(j);
+		DataType.Name type = column.getType().getName();
+		switch (type) {
+		  case INT:
+		    int intActual = actual.getInt(j);
+		    LOG.info("Row[" + i + ", " + j + "] = " + intActual);
+		    break;
+
+		  case VARCHAR:
+		  case TEXT:
+		    String strActual = actual.getString(j);
+		    LOG.info("Row[" + i + ", " + j + "] = " + strActual);
+		    break;
+
+		  default:
+		    fail("Expect INT or VARCHAR or TEXT type but got: " + type.toString());
+		    break;
+		}
+            }
+	    i++;
+	}
+	return i;
+    }
+
     public static void assertRows(ResultSet result, Object[]... rows)
     {
         if (result == null)
@@ -128,6 +169,8 @@ public class CQLTester extends BaseCQLTest
 	List<ColumnDefinitions.Definition> meta = colDef.asList();
         Iterator<Row> iter = result.iterator();
         int i = 0;
+        if (!iter.hasNext() && rows.length > 0)
+	    fail(String.format("No rows returned by query but %d expected", rows.length));
         while (iter.hasNext() && i < rows.length)
         {
             Object[] expected = rows[i];

--- a/java/yb-cql/src/test/java/org/yb/cql/CQLTester.java
+++ b/java/yb-cql/src/test/java/org/yb/cql/CQLTester.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.yb.cql;
+
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.ColumnDefinitions;
+import com.datastax.driver.core.ColumnDefinitions.Definition;
+import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.DataType.Name;
+
+import org.junit.Test;
+import org.yb.client.TestUtils;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
+
+/**
+ * Base class for CQL tests.
+ */
+public class CQLTester extends BaseCQLTest
+{
+    public static final String KEYSPACE = "cql_test_keyspace";
+    private static final AtomicInteger seqNumber = new AtomicInteger();
+
+    private List<String> tables = new ArrayList<>();
+
+    protected void createTable(String query)
+    {
+        createTable(KEYSPACE, query);
+    }
+
+    protected void createTable(String keyspace, String query)
+    {
+        String currentTable = createTableName();
+        String fullQuery = formatQuery(keyspace, query);
+        final long startTimeMs = System.currentTimeMillis();
+        session.execute(fullQuery);
+        long elapsedTimeMs = System.currentTimeMillis() - startTimeMs;
+        LOG.info("After execute: " + fullQuery + " took " + elapsedTimeMs + "ms");
+    }
+
+    protected String createTableName()
+    {
+        String currentTable = "table_" + seqNumber.getAndIncrement();
+        tables.add(currentTable);
+        return currentTable;
+    }
+
+    protected String formatQuery(String query)
+    {
+        return formatQuery(KEYSPACE, query);
+    }
+
+    protected final String formatQuery(String keyspace, String query)
+    {
+        String currentTable = currentTable();
+        return currentTable == null ? query : String.format(query, keyspace + "." + currentTable);
+    }
+
+    protected String keyspace()
+    {
+        return KEYSPACE;
+    }
+
+    protected String currentTable()
+    {
+        if (tables.isEmpty())
+            return null;
+        return tables.get(tables.size() - 1);
+    }
+
+    public ResultSet execute(String query, Object... values) throws Exception {
+      String fullQuery = formatQuery(KEYSPACE, query);
+      final ResultSet result = session.execute(fullQuery, values);
+      LOG.info("EXEC CQL FINISHED: " + fullQuery);
+      return result;
+    }
+
+
+    public ResultSet execute(String query) throws Exception {
+      String fullQuery = formatQuery(KEYSPACE, query);
+      final ResultSet result = session.execute(fullQuery);
+      LOG.info("EXEC CQL FINISHED: " + fullQuery);
+      return result;
+    }
+
+    protected void assertAllRows(Object[]... rows) throws Throwable
+    {
+        assertRows(execute("SELECT * FROM %s"), rows);
+    }
+
+    public static Object[] row(Object... expected)
+    {
+        return expected;
+    }
+
+    public static void assertRows(ResultSet result, Object[]... rows)
+    {
+        if (result == null)
+        {
+            if (rows.length > 0)
+                fail(String.format("No rows returned by query but %d expected", rows.length));
+            return;
+        }
+	ColumnDefinitions colDef = result.getColumnDefinitions();
+	List<ColumnDefinitions.Definition> meta = colDef.asList();
+        Iterator<Row> iter = result.iterator();
+        int i = 0;
+        while (iter.hasNext() && i < rows.length)
+        {
+            Object[] expected = rows[i];
+            Row actual = iter.next();
+
+            assertEquals(String.format("Invalid number of (expected) values provided for row %d", i), expected == null ? 1 : expected.length, meta.size());
+
+            for (int j = 0; j < meta.size(); j++)
+            {
+                ColumnDefinitions.Definition column = meta.get(j);
+		DataType.Name type = column.getType().getName();
+		switch (type) {
+		  case INT:
+		    int intActual = actual.getInt(j);
+		    int intExpected = (Integer)expected[j];
+		    assertEquals(intActual, intExpected);
+		    LOG.info("Row[" + i + ", " + j + "] = " + intActual);
+		    break;
+
+		  case VARCHAR:
+		  case TEXT:
+		    String strActual = actual.getString(j);
+		    String strExpected = (String)expected[j];
+		    assertEquals(strActual, strExpected);
+		    LOG.info("Row[" + i + ", " + j + "] = " + strActual);
+		    break;
+
+		  default:
+		    fail("Expect INT or VARCHAR or TEXT type but got: " + type.toString());
+		    break;
+		}
+
+            }
+            i++;
+        }
+
+        if (iter.hasNext())
+	  fail("Got more rows than expected");
+        if (i != rows.length)
+	  fail("Got less rows than expected");
+    }
+
+}

--- a/java/yb-cql/src/test/java/org/yb/cql/CQLTester.java
+++ b/java/yb-cql/src/test/java/org/yb/cql/CQLTester.java
@@ -57,7 +57,7 @@ public class CQLTester extends BaseCQLTest
         final long startTimeMs = System.currentTimeMillis();
         session.execute(fullQuery);
         long elapsedTimeMs = System.currentTimeMillis() - startTimeMs;
-	LOG.info("After execute: {} took {}ms", fullQuery, elapsedTimeMs);
+        LOG.info("After execute: {} took {}ms", fullQuery, elapsedTimeMs);
     }
 
     protected String createTableName()
@@ -123,8 +123,8 @@ public class CQLTester extends BaseCQLTest
             return 0;
         }
 
-	ColumnDefinitions colDef = result.getColumnDefinitions();
-	List<ColumnDefinitions.Definition> meta = colDef.asList();
+        ColumnDefinitions colDef = result.getColumnDefinitions();
+        List<ColumnDefinitions.Definition> meta = colDef.asList();
         int i = 0;
         for (Row actual : result)
         {
@@ -158,22 +158,22 @@ public class CQLTester extends BaseCQLTest
             for (int j = 0; j < meta.size(); j++)
             {
                 ColumnDefinitions.Definition column = meta.get(j);
-		DataType.Name type = column.getType().getName();
-		switch (type) {
-		    case INT:
-			assertEquals((Integer)expected[j], (Integer)actual.getInt(j));
-		        LOG.info("Row[{}, {}] = {}", i, j, actual.getInt(j));
-		        break;
+                DataType.Name type = column.getType().getName();
+                switch (type) {
+                    case INT:
+                        assertEquals((Integer)expected[j], (Integer)actual.getInt(j));
+                        LOG.info("Row[{}, {}] = {}", i, j, actual.getInt(j));
+                        break;
 
-		    case VARCHAR:
-		    case TEXT:
-			assertEquals((String)expected[j], actual.getString(j));
-		        LOG.info("Row[{}, {}] = {}", i, j, actual.getString(j));
-		        break;
+                    case VARCHAR:
+                    case TEXT:
+                        assertEquals((String)expected[j], actual.getString(j));
+                        LOG.info("Row[{}, {}] = {}", i, j, actual.getString(j));
+                        break;
 
-		    default:
-		        fail(String.format("Expect INT or VARCHAR or TEXT type but got: %s", type.toString()));
-		        break;
+                    default:
+                        fail(String.format("Expect INT or VARCHAR or TEXT type but got: %s", type.toString()));
+                        break;
 		}
             }
             i++;

--- a/java/yb-cql/src/test/java/org/yb/cql/CQLTester.java
+++ b/java/yb-cql/src/test/java/org/yb/cql/CQLTester.java
@@ -146,8 +146,6 @@ public class CQLTester extends BaseCQLTest
         List<ColumnDefinitions.Definition> meta = colDef.asList();
         Iterator<Row> iter = result.iterator();
         int i = 0;
-        if (!iter.hasNext() && rows.length > 0)
-	    fail(String.format("No rows returned by query but %d expected", rows.length));
         while (iter.hasNext() && i < rows.length)
         {
             Object[] expected = rows[i];
@@ -161,14 +159,14 @@ public class CQLTester extends BaseCQLTest
                 DataType.Name type = column.getType().getName();
                 switch (type) {
                     case INT:
-                        assertEquals((Integer)expected[j], (Integer)actual.getInt(j));
                         LOG.info("Row[{}, {}] = {}", i, j, actual.getInt(j));
+                        assertEquals((Integer)expected[j], (Integer)actual.getInt(j));
                         break;
 
                     case VARCHAR:
                     case TEXT:
-                        assertEquals((String)expected[j], actual.getString(j));
                         LOG.info("Row[{}, {}] = {}", i, j, actual.getString(j));
+                        assertEquals((String)expected[j], actual.getString(j));
                         break;
 
                     default:
@@ -180,8 +178,8 @@ public class CQLTester extends BaseCQLTest
         }
 
         if (iter.hasNext())
-            fail("Got more rows than expected");
+            fail(String.format("Query returned more than %d rows expected", rows.length));
         if (i != rows.length)
-            fail("Got less rows than expected");
+            fail(String.format("Query returned %d rows but expected %d rows", i, rows.length));
     }
 }

--- a/java/yb-cql/src/test/java/org/yb/cql/CQLTester.java
+++ b/java/yb-cql/src/test/java/org/yb/cql/CQLTester.java
@@ -77,7 +77,7 @@ public class CQLTester extends BaseCQLTest
 
   protected void createIndex(String keyspace, String query)
   {
-    String fullQuery = String.format(query, keyspace + "_" + createIndexName(), keyspace + "." + currentTable());
+    String fullQuery = String.format(query, createIndexName(), keyspace + "." + currentTable());
     final long startTimeMs = System.currentTimeMillis();
     session.execute(fullQuery);
     long elapsedTimeMs = System.currentTimeMillis() - startTimeMs;
@@ -168,12 +168,12 @@ public class CQLTester extends BaseCQLTest
   protected Object map(Object...values)
   {
     if (values.length % 2 != 0)
-        throw new IllegalArgumentException("Invalid number of arguments, got " + values.length);
+      throw new IllegalArgumentException("Invalid number of arguments, got " + values.length);
 
     int size = values.length / 2;
     Map m = new LinkedHashMap(size);
     for (int i = 0; i < size; i++)
-        m.put(values[2 * i], values[(2 * i) + 1]);
+      m.put(values[2 * i], values[(2 * i) + 1]);
     return m;
   }
 
@@ -258,8 +258,7 @@ public class CQLTester extends BaseCQLTest
                 ImmutableSet<Integer> expIntSet = (ImmutableSet<Integer>)expected[j];
                 setValue = intSet.stream().map(String::valueOf).collect(Collectors.joining(","));
                 LOG.info("Row[{}, {}] = {}", i, j, setValue);
-                assertEquals(intSet.size(), expIntSet.size());
-                assertTrue(intSet.containsAll(expIntSet));
+                assertTrue(intSet.equals(expIntSet));
                 break;
 
               case VARCHAR:
@@ -268,8 +267,7 @@ public class CQLTester extends BaseCQLTest
                 ImmutableSet<String> expStrSet = (ImmutableSet<String>)expected[j];
                 setValue = strSet.stream().map(String::valueOf).collect(Collectors.joining(","));
                 LOG.info("Row[{}, {}] = {}", i, j, setValue);
-                assertEquals(strSet.size(), expStrSet.size());
-                assertTrue(strSet.containsAll(expStrSet));
+                assertTrue(strSet.equals(expStrSet));
                 break;
 
               default:

--- a/java/yb-cql/src/test/java/org/yb/cql/SimpleQueryTest.java
+++ b/java/yb-cql/src/test/java/org/yb/cql/SimpleQueryTest.java
@@ -1,0 +1,571 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.yb.cql;
+
+import org.junit.Test;
+
+public class SimpleQueryTest extends CQLTester
+{
+    @Test
+    public void testDynamicCompactTables() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k text, t int, v text, PRIMARY KEY (k, t));");
+
+        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key", 1, "v11");
+        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key", 2, "v12");
+        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key", 3, "v13");
+
+        // flush();
+
+        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key", 4, "v14");
+        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key", 5, "v15");
+
+        assertRows(execute("SELECT * FROM %s"),
+            row("key",  1, "v11"),
+            row("key",  2, "v12"),
+            row("key",  3, "v13"),
+            row("key",  4, "v14"),
+            row("key",  5, "v15")
+        );
+
+        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t > ?", "key", 3),
+            row("key",  4, "v14"),
+            row("key",  5, "v15")
+        );
+
+        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t >= ? AND t < ?", "key", 2, 4),
+            row("key",  2, "v12"),
+            row("key",  3, "v13")
+        );
+
+        // Reversed queries
+
+        assertRows(execute("SELECT * FROM %s WHERE k = ? ORDER BY t DESC", "key"),
+            row("key",  5, "v15"),
+            row("key",  4, "v14"),
+            row("key",  3, "v13"),
+            row("key",  2, "v12"),
+            row("key",  1, "v11")
+        );
+
+        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t > ? ORDER BY t DESC", "key", 3),
+            row("key",  5, "v15"),
+            row("key",  4, "v14")
+        );
+
+        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t >= ? AND t < ? ORDER BY t DESC", "key", 2, 4),
+            row("key",  3, "v13"),
+            row("key",  2, "v12")
+        );
+    }
+
+    @Test
+    public void testTableWithoutClustering() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k text PRIMARY KEY, v1 int, v2 text);");
+
+        execute("INSERT INTO %s (k, v1, v2) values (?, ?, ?)", "first", 1, "value1");
+        execute("INSERT INTO %s (k, v1, v2) values (?, ?, ?)", "second", 2, "value2");
+        execute("INSERT INTO %s (k, v1, v2) values (?, ?, ?)", "third", 3, "value3");
+
+        // flush();
+
+        assertRows(execute("SELECT * FROM %s WHERE k = ?", "first"),
+            row("first", 1, "value1")
+        );
+
+        assertRows(execute("SELECT v2 FROM %s WHERE k = ?", "second"),
+            row("value2")
+        );
+
+        assertRows(execute("SELECT * FROM %s"),
+            row("third",  3, "value3"),
+            row("second", 2, "value2"),
+            row("first",  1, "value1")
+        );
+    }
+
+    @Test
+    public void testTableWithOneClustering() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k text, t int, v1 text, v2 text, PRIMARY KEY (k, t));");
+
+        execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 1, "v11", "v21");
+        execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 2, "v12", "v22");
+        execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 3, "v13", "v23");
+
+        // flush();
+
+        execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 4, "v14", "v24");
+        execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 5, "v15", "v25");
+
+        assertRows(execute("SELECT * FROM %s"),
+            row("key",  1, "v11", "v21"),
+            row("key",  2, "v12", "v22"),
+            row("key",  3, "v13", "v23"),
+            row("key",  4, "v14", "v24"),
+            row("key",  5, "v15", "v25")
+        );
+
+        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t > ?", "key", 3),
+            row("key",  4, "v14", "v24"),
+            row("key",  5, "v15", "v25")
+        );
+
+        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t >= ? AND t < ?", "key", 2, 4),
+            row("key",  2, "v12", "v22"),
+            row("key",  3, "v13", "v23")
+        );
+
+        // Reversed queries
+
+        assertRows(execute("SELECT * FROM %s WHERE k = ? ORDER BY t DESC", "key"),
+            row("key",  5, "v15", "v25"),
+            row("key",  4, "v14", "v24"),
+            row("key",  3, "v13", "v23"),
+            row("key",  2, "v12", "v22"),
+            row("key",  1, "v11", "v21")
+        );
+
+        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t > ? ORDER BY t DESC", "key", 3),
+            row("key",  5, "v15", "v25"),
+            row("key",  4, "v14", "v24")
+        );
+
+        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t >= ? AND t < ? ORDER BY t DESC", "key", 2, 4),
+            row("key",  3, "v13", "v23"),
+            row("key",  2, "v12", "v22")
+        );
+    }
+
+    @Test
+    public void testTableWithReverseClusteringOrder() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k text, t int, v1 text, v2 text, PRIMARY KEY (k, t)) WITH CLUSTERING ORDER BY (t DESC);");
+
+        execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 1, "v11", "v21");
+        execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 2, "v12", "v22");
+        execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 3, "v13", "v23");
+
+        // flush();
+
+        execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 4, "v14", "v24");
+        execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 5, "v15", "v25");
+
+        assertRows(execute("SELECT * FROM %s"),
+            row("key",  5, "v15", "v25"),
+            row("key",  4, "v14", "v24"),
+            row("key",  3, "v13", "v23"),
+            row("key",  2, "v12", "v22"),
+            row("key",  1, "v11", "v21")
+        );
+
+        assertRows(execute("SELECT * FROM %s WHERE k = ? ORDER BY t ASC", "key"),
+            row("key",  1, "v11", "v21"),
+            row("key",  2, "v12", "v22"),
+            row("key",  3, "v13", "v23"),
+            row("key",  4, "v14", "v24"),
+            row("key",  5, "v15", "v25")
+        );
+
+        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t > ?", "key", 3),
+            row("key",  5, "v15", "v25"),
+            row("key",  4, "v14", "v24")
+        );
+
+        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t >= ? AND t < ?", "key", 2, 4),
+            row("key",  3, "v13", "v23"),
+            row("key",  2, "v12", "v22")
+        );
+
+        // Reversed queries
+
+        assertRows(execute("SELECT * FROM %s WHERE k = ? ORDER BY t DESC", "key"),
+            row("key",  5, "v15", "v25"),
+            row("key",  4, "v14", "v24"),
+            row("key",  3, "v13", "v23"),
+            row("key",  2, "v12", "v22"),
+            row("key",  1, "v11", "v21")
+        );
+
+        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t > ? ORDER BY t DESC", "key", 3),
+            row("key",  5, "v15", "v25"),
+            row("key",  4, "v14", "v24")
+        );
+
+        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t >= ? AND t < ? ORDER BY t DESC", "key", 2, 4),
+            row("key",  3, "v13", "v23"),
+            row("key",  2, "v12", "v22")
+        );
+    }
+
+    @Test
+    public void testTableWithTwoClustering() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k text, t1 text, t2 int, v text, PRIMARY KEY (k, t1, t2));");
+
+        execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", "v1", 1, "v1");
+        execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", "v1", 2, "v2");
+        execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", "v2", 1, "v3");
+        execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", "v2", 2, "v4");
+        execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", "v2", 3, "v5");
+        // flush();
+
+        assertRows(execute("SELECT * FROM %s"),
+            row("key",  "v1", 1, "v1"),
+            row("key",  "v1", 2, "v2"),
+            row("key",  "v2", 1, "v3"),
+            row("key",  "v2", 2, "v4"),
+            row("key",  "v2", 3, "v5")
+        );
+
+        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t1 >= ?", "key", "v2"),
+            row("key",  "v2", 1, "v3"),
+            row("key",  "v2", 2, "v4"),
+            row("key",  "v2", 3, "v5")
+        );
+
+        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t1 >= ? ORDER BY t1 DESC", "key", "v2"),
+            row("key",  "v2", 3, "v5"),
+            row("key",  "v2", 2, "v4"),
+            row("key",  "v2", 1, "v3")
+        );
+    }
+
+    @Test
+    public void testTableWithLargePartition() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k text, t1 int, t2 int, v text, PRIMARY KEY (k, t1, t2));");
+
+        for (int t1 = 0; t1 < 20; t1++)
+            for (int t2 = 0; t2 < 10; t2++)
+                execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", t1, t2, "someSemiLargeTextForValue_" + t1 + "_" + t2);
+
+        // flush();
+
+        Object[][] expected = new Object[10][];
+        for (int t2 = 0; t2 < 10; t2++)
+            expected[t2] = row("key", 15, t2);
+
+        assertRows(execute("SELECT k, t1, t2 FROM %s WHERE k=? AND t1=?", "key", 15), expected);
+
+        Object[][] expectedReverse = new Object[10][];
+        for (int t2 = 9; t2 >= 0; t2--)
+            expectedReverse[9 - t2] = row("key", 15, t2);
+
+        assertRows(execute("SELECT k, t1, t2 FROM %s WHERE k=? AND t1=? ORDER BY t1 DESC, t2 DESC", "key", 15), expectedReverse);
+    }
+
+    @Test
+    public void testRowDeletion() throws Throwable
+    {
+        int N = 4;
+
+        createTable("CREATE TABLE %s (k text, t int, v1 text, v2 int, PRIMARY KEY (k, t));");
+
+        for (int t = 0; t < N; t++)
+            execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", t, "v" + t, t + 10);
+
+        // flush();
+
+        for (int i = 0; i < N / 2; i++)
+            execute("DELETE FROM %s WHERE k=? AND t=?", "key", i * 2);
+
+        Object[][] expected = new Object[N/2][];
+        for (int i = 0; i < N / 2; i++)
+        {
+            int t = i * 2 + 1;
+            expected[i] = row("key", t, "v" + t, t + 10);
+        }
+
+        assertRows(execute("SELECT * FROM %s"), expected);
+    }
+/*
+ * The inidividual tests that follow are currently commented out. They will be
+ * enabled in a subsequent pull request after they have been tested.
+ */
+
+/*
+    @Test
+    public void testRangeTombstones() throws Throwable
+    {
+        int N = 100;
+
+        createTable("CREATE TABLE %s (k text, t1 int, t2 int, v text, PRIMARY KEY (k, t1, t2));");
+
+        for (int t1 = 0; t1 < 3; t1++)
+            for (int t2 = 0; t2 < N; t2++)
+                execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", t1, t2, "someSemiLargeTextForValue_" + t1 + "_" + t2);
+
+        // flush();
+
+        execute("DELETE FROM %s WHERE k=? AND t1=?", "key", 1);
+
+        // flush();
+
+        Object[][] expected = new Object[2*N][];
+        for (int t2 = 0; t2 < N; t2++)
+        {
+            expected[t2] = row("key", 0, t2, "someSemiLargeTextForValue_0_" + t2);
+            expected[N + t2] = row("key", 2, t2, "someSemiLargeTextForValue_2_" + t2);
+        }
+
+        assertRows(execute("SELECT * FROM %s"), expected);
+    }
+
+    @Test
+    public void test2ndaryIndexes() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k text, t int, v text, PRIMARY KEY (k, t));");
+
+        execute("CREATE INDEX ON %s(v)");
+
+        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 1, "foo");
+        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 2, "bar");
+        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key2", 1, "foo");
+
+        flush();
+
+        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key2", 2, "foo");
+        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key2", 3, "bar");
+
+        assertRows(execute("SELECT * FROM %s WHERE v = ?", "foo"),
+            row("key1",  1, "foo"),
+            row("key2",  1, "foo"),
+            row("key2",  2, "foo")
+        );
+
+        assertRows(execute("SELECT * FROM %s WHERE v = ?", "bar"),
+            row("key1",  2, "bar"),
+            row("key2",  3, "bar")
+        );
+    }
+
+    @Test
+    public void testStaticColumns() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k text, t int, s text static, v text, PRIMARY KEY (k, t));");
+
+        execute("INSERT INTO %s (k, t, v, s) values (?, ?, ?, ?)", "key1", 1, "foo1", "st1");
+        execute("INSERT INTO %s (k, t, v, s) values (?, ?, ?, ?)", "key1", 2, "foo2", "st2");
+
+        flush();
+
+        execute("INSERT INTO %s (k, t, v, s) values (?, ?, ?, ?)", "key1", 3, "foo3", "st3");
+        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 4, "foo4");
+        execute("INSERT INTO %s (k, t, v, s) values (?, ?, ?, ?)", "key1", 2, "foo2", "st2-repeat");
+
+        flush();
+
+        execute("INSERT INTO %s (k, t, v, s) values (?, ?, ?, ?)", "key1", 5, "foo5", "st5");
+        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 6, "foo6");
+
+
+        assertRows(execute("SELECT * FROM %s"),
+            row("key1",  1, "st5", "foo1"),
+            row("key1",  2, "st5", "foo2"),
+            row("key1",  3, "st5", "foo3"),
+            row("key1",  4, "st5", "foo4"),
+            row("key1",  5, "st5", "foo5"),
+            row("key1",  6, "st5", "foo6")
+        );
+
+        assertRows(execute("SELECT s FROM %s WHERE k = ?", "key1"),
+            row("st5"),
+            row("st5"),
+            row("st5"),
+            row("st5"),
+            row("st5"),
+            row("st5")
+        );
+
+        assertRows(execute("SELECT DISTINCT s FROM %s WHERE k = ?", "key1"),
+            row("st5")
+        );
+
+        assertEmpty(execute("SELECT * FROM %s WHERE k = ? AND t > ? AND t < ?", "key1", 7, 5));
+        assertEmpty(execute("SELECT * FROM %s WHERE k = ? AND t > ? AND t < ? ORDER BY t DESC", "key1", 7, 5));
+
+        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t = ?", "key1", 2),
+            row("key1", 2, "st5", "foo2"));
+
+        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t = ? ORDER BY t DESC", "key1", 2),
+            row("key1", 2, "st5", "foo2"));
+    }
+
+    @Test
+    public void testDistinct() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k text, t int, v text, PRIMARY KEY (k, t));");
+
+        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 1, "foo1");
+        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 2, "foo2");
+
+        flush();
+
+        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 3, "foo3");
+        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key2", 4, "foo4");
+        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key2", 5, "foo5");
+
+        assertRows(execute("SELECT DISTINCT k FROM %s"),
+            row("key1"),
+            row("key2")
+        );
+    }
+
+    @Test
+    public void collectionDeletionTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, s set<int>);");
+
+        execute("INSERT INTO %s (k, s) VALUES (?, ?)", 1, set(1));
+
+        flush();
+
+        execute("INSERT INTO %s (k, s) VALUES (?, ?)", 1, set(2));
+
+        assertRows(execute("SELECT s FROM %s WHERE k = ?", 1),
+            row(set(2))
+        );
+    }
+
+    @Test
+    public void limitWithMultigetTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v int);");
+
+        execute("INSERT INTO %s (k, v) VALUES (?, ?)", 0, 0);
+        execute("INSERT INTO %s (k, v) VALUES (?, ?)", 1, 1);
+        execute("INSERT INTO %s (k, v) VALUES (?, ?)", 2, 2);
+        execute("INSERT INTO %s (k, v) VALUES (?, ?)", 3, 3);
+
+        assertRows(execute("SELECT v FROM %s WHERE k IN ? LIMIT ?", list(0, 1, 2, 3), 2),
+            row(0),
+            row(1)
+        );
+    }
+
+    @Test
+    public void staticDistinctTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s ( k int, p int, s int static, PRIMARY KEY (k, p))");
+
+        execute("INSERT INTO %s (k, p) VALUES (?, ?)", 1, 1);
+        execute("INSERT INTO %s (k, p) VALUES (?, ?)", 1, 2);
+
+        assertRows(execute("SELECT k, s FROM %s"),
+            row(1, null),
+            row(1, null)
+        );
+        assertRows(execute("SELECT DISTINCT k, s FROM %s"),
+            row(1, null)
+        );
+        assertRows(execute("SELECT DISTINCT s FROM %s WHERE k=?", 1),
+            row((Object)null)
+        );
+        assertEmpty(execute("SELECT DISTINCT s FROM %s WHERE k=?", 2));
+    }
+
+    @Test
+    public void test2ndaryIndexBug() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int, c1 int, c2 int, v int, PRIMARY KEY(k, c1, c2))");
+
+        execute("CREATE INDEX v_idx ON %s(v)");
+
+        execute("INSERT INTO %s (k, c1, c2, v) VALUES (?, ?, ?, ?)", 0, 0, 0, 0);
+        execute("INSERT INTO %s (k, c1, c2, v) VALUES (?, ?, ?, ?)", 0, 1, 0, 0);
+
+        assertRows(execute("SELECT * FROM %s WHERE v=?", 0),
+            row(0, 0, 0, 0),
+            row(0, 1, 0, 0)
+        );
+
+        flush();
+
+        execute("DELETE FROM %s WHERE k=? AND c1=?", 0, 1);
+
+        flush();
+
+        assertRows(execute("SELECT * FROM %s WHERE v=?", 0),
+            row(0, 0, 0, 0)
+        );
+    }
+*/
+
+    /** Test for Cassandra issue 10958 **/
+/*
+    @Test
+    public void restrictionOnRegularColumnWithStaticColumnPresentTest() throws Throwable
+    {
+        createTable("CREATE TABLE %s (id int, id2 int, age int static, extra int, PRIMARY KEY(id, id2))");
+
+        execute("INSERT INTO %s (id, id2, age, extra) VALUES (?, ?, ?, ?)", 1, 1, 1, 1);
+        execute("INSERT INTO %s (id, id2, age, extra) VALUES (?, ?, ?, ?)", 2, 2, 2, 2);
+        execute("UPDATE %s SET age=? WHERE id=?", 3, 3);
+
+        assertRows(execute("SELECT * FROM %s"),
+            row(1, 1, 1, 1),
+            row(2, 2, 2, 2),
+            row(3, null, 3, null)
+        );
+
+        assertRows(execute("SELECT * FROM %s WHERE extra > 1 ALLOW FILTERING"),
+            row(2, 2, 2, 2)
+        );
+    }
+
+    @Test
+    public void testRowFilteringOnStaticColumn() throws Throwable
+    {
+        createTable("CREATE TABLE %s (id int, name text, age int static, PRIMARY KEY (id, name))");
+        for (int i = 0; i < 5; i++)
+        {
+            execute("INSERT INTO %s (id, name, age) VALUES (?, ?, ?)", i, "NameDoesNotMatter", i);
+        }
+
+        assertInvalid("SELECT id, age FROM %s WHERE age < 1");
+        assertRows(execute("SELECT id, age FROM %s WHERE age < 1 ALLOW FILTERING"),
+                   row(0, 0));
+        assertRows(execute("SELECT id, age FROM %s WHERE age > 0 AND age < 3 ALLOW FILTERING"),
+                   row(1, 1), row(2, 2));
+        assertRows(execute("SELECT id, age FROM %s WHERE age > 3 ALLOW FILTERING"),
+                   row(4, 4));
+    }
+
+    @Test
+    public void testSStableTimestampOrdering() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k1 int, v1 int, v2 int, PRIMARY KEY (k1))");
+        disableCompaction();
+
+        // sstable1
+        execute("INSERT INTO %s(k1,v1,v2) VALUES(1,1,1)  USING TIMESTAMP 5");
+        flush();
+
+        // sstable2
+        execute("INSERT INTO %s(k1,v1,v2) VALUES(1,1,2)  USING TIMESTAMP 8");
+        flush();
+
+        execute("INSERT INTO %s(k1) VALUES(1)  USING TIMESTAMP 7");
+        execute("DELETE FROM %s USING TIMESTAMP 6 WHERE k1 = 1");
+
+        assertRows(execute("SELECT * FROM %s WHERE k1=1"), row(1, 1, 2));
+    } 
+*/
+}

--- a/java/yb-cql/src/test/java/org/yb/cql/SimpleQueryTest.java
+++ b/java/yb-cql/src/test/java/org/yb/cql/SimpleQueryTest.java
@@ -17,6 +17,7 @@
 */
 package org.yb.cql;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class SimpleQueryTest extends CQLTester
@@ -333,6 +334,7 @@ public class SimpleQueryTest extends CQLTester
   }
 
   @Test
+  @Ignore ("Disabled for issue #465")
   public void testStaticColumns() throws Throwable
   {
     createTable("CREATE TABLE %s (k text, t int, s text static, v text, PRIMARY KEY (k, t));");
@@ -376,12 +378,12 @@ public class SimpleQueryTest extends CQLTester
     assertRows(execute("SELECT * FROM %s WHERE k = ? AND t = ?", "key1", 2),
       row("key1", 2, "st5", "foo2"));
 
-    displayRows(execute("SELECT * FROM %s WHERE k = ? AND t = ? ORDER BY t DESC", "key1", 2));
     assertRows(execute("SELECT * FROM %s WHERE k = ? AND t = ? ORDER BY t DESC", "key1", 2),
       row("key1", 2, "st5", "foo2"));
   }
 
   @Test
+  @Ignore ("Disabled for issue #466")
   public void testDistinct() throws Throwable
   {
     createTable("CREATE TABLE %s (k text, t int, v text, PRIMARY KEY (k, t));");
@@ -393,17 +395,11 @@ public class SimpleQueryTest extends CQLTester
     execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key2", 4, "foo4");
     execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key2", 5, "foo5");
 
-    displayRows(execute("SELECT DISTINCT k FROM %s"));
     assertRows(execute("SELECT DISTINCT k FROM %s"),
       row("key1"),
       row("key2")
     );
   }
-
-/*
-* The inidividual tests that follow are currently commented out. They will be
-* enabled in a subsequent pull request after they have been tested.
-*/
 
   @Test
   public void collectionDeletionTest() throws Throwable
@@ -460,7 +456,6 @@ public class SimpleQueryTest extends CQLTester
   public void test2ndaryIndexBug() throws Throwable
   {
     createTable("CREATE TABLE %s (k int, c1 int, c2 int, v int, PRIMARY KEY(k, c1, c2)) WITH transactions = { 'enabled' : true };");
-    // createTable("CREATE TABLE %s (k int, c1 int, c2 int, v int, PRIMARY KEY(k, c1, c2))");
 
     execute("CREATE INDEX v_idx ON %s(v)");
 
@@ -487,9 +482,7 @@ public class SimpleQueryTest extends CQLTester
 
     execute("INSERT INTO %s (id, id2, age, extra) VALUES (?, ?, ?, ?)", 1, 1, 1, 1);
     execute("INSERT INTO %s (id, id2, age, extra) VALUES (?, ?, ?, ?)", 2, 2, 2, 2);
-    displayRows(execute("SELECT * FROM %s"));
     execute("UPDATE %s SET age=? WHERE id=?", 3, 3);
-    displayRows(execute("SELECT * FROM %s"));
 
     assertRows(execute("SELECT * FROM %s"),
       row(1, 1, 1, 1),
@@ -524,7 +517,6 @@ public class SimpleQueryTest extends CQLTester
   public void testSStableTimestampOrdering() throws Throwable
   {
     createTable("CREATE TABLE %s (k1 int, v1 int, v2 int, PRIMARY KEY (k1))");
-    // disableCompaction();
 
     // sstable1
     execute("INSERT INTO %s(k1,v1,v2) VALUES(1,1,1)  USING TIMESTAMP 5");

--- a/java/yb-cql/src/test/java/org/yb/cql/SimpleQueryTest.java
+++ b/java/yb-cql/src/test/java/org/yb/cql/SimpleQueryTest.java
@@ -376,6 +376,7 @@ public class SimpleQueryTest extends CQLTester
     assertRows(execute("SELECT * FROM %s WHERE k = ? AND t = ?", "key1", 2),
       row("key1", 2, "st5", "foo2"));
 
+    displayRows(execute("SELECT * FROM %s WHERE k = ? AND t = ? ORDER BY t DESC", "key1", 2));
     assertRows(execute("SELECT * FROM %s WHERE k = ? AND t = ? ORDER BY t DESC", "key1", 2),
       row("key1", 2, "st5", "foo2"));
   }
@@ -392,6 +393,7 @@ public class SimpleQueryTest extends CQLTester
     execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key2", 4, "foo4");
     execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key2", 5, "foo5");
 
+    displayRows(execute("SELECT DISTINCT k FROM %s"));
     assertRows(execute("SELECT DISTINCT k FROM %s"),
       row("key1"),
       row("key2")
@@ -403,7 +405,6 @@ public class SimpleQueryTest extends CQLTester
 * enabled in a subsequent pull request after they have been tested.
 */
 
-/*
   @Test
   public void collectionDeletionTest() throws Throwable
   {
@@ -458,7 +459,8 @@ public class SimpleQueryTest extends CQLTester
   @Test
   public void test2ndaryIndexBug() throws Throwable
   {
-    createTable("CREATE TABLE %s (k int, c1 int, c2 int, v int, PRIMARY KEY(k, c1, c2))");
+    createTable("CREATE TABLE %s (k int, c1 int, c2 int, v int, PRIMARY KEY(k, c1, c2)) WITH transactions = { 'enabled' : true };");
+    // createTable("CREATE TABLE %s (k int, c1 int, c2 int, v int, PRIMARY KEY(k, c1, c2))");
 
     execute("CREATE INDEX v_idx ON %s(v)");
 
@@ -476,10 +478,8 @@ public class SimpleQueryTest extends CQLTester
       row(0, 0, 0, 0)
     );
   }
-*/
 
   /** Test for Cassandra issue 10958 **/
-/*
   @Test
   public void restrictionOnRegularColumnWithStaticColumnPresentTest() throws Throwable
   {
@@ -487,7 +487,9 @@ public class SimpleQueryTest extends CQLTester
 
     execute("INSERT INTO %s (id, id2, age, extra) VALUES (?, ?, ?, ?)", 1, 1, 1, 1);
     execute("INSERT INTO %s (id, id2, age, extra) VALUES (?, ?, ?, ?)", 2, 2, 2, 2);
+    displayRows(execute("SELECT * FROM %s"));
     execute("UPDATE %s SET age=? WHERE id=?", 3, 3);
+    displayRows(execute("SELECT * FROM %s"));
 
     assertRows(execute("SELECT * FROM %s"),
       row(1, 1, 1, 1),
@@ -509,7 +511,7 @@ public class SimpleQueryTest extends CQLTester
       execute("INSERT INTO %s (id, name, age) VALUES (?, ?, ?)", i, "NameDoesNotMatter", i);
     }
 
-    assertInvalid("SELECT id, age FROM %s WHERE age < 1");
+    // assertInvalid("SELECT id, age FROM %s WHERE age < 1");
     assertRows(execute("SELECT id, age FROM %s WHERE age < 1 ALLOW FILTERING"),
          row(0, 0));
     assertRows(execute("SELECT id, age FROM %s WHERE age > 0 AND age < 3 ALLOW FILTERING"),
@@ -522,7 +524,7 @@ public class SimpleQueryTest extends CQLTester
   public void testSStableTimestampOrdering() throws Throwable
   {
     createTable("CREATE TABLE %s (k1 int, v1 int, v2 int, PRIMARY KEY (k1))");
-    disableCompaction();
+    // disableCompaction();
 
     // sstable1
     execute("INSERT INTO %s(k1,v1,v2) VALUES(1,1,1)  USING TIMESTAMP 5");
@@ -535,5 +537,4 @@ public class SimpleQueryTest extends CQLTester
 
     assertRows(execute("SELECT * FROM %s WHERE k1=1"), row(1, 1, 2));
   } 
-*/
 }

--- a/java/yb-cql/src/test/java/org/yb/cql/SimpleQueryTest.java
+++ b/java/yb-cql/src/test/java/org/yb/cql/SimpleQueryTest.java
@@ -306,12 +306,6 @@ public class SimpleQueryTest extends CQLTester
         assertRows(execute("SELECT * FROM %s"), expected);
     }
 
-/*
- * The inidividual tests that follow are currently commented out. They will be
- * enabled in a subsequent pull request after they have been tested.
- */
-
-/*
     @Test
     public void test2ndaryIndexes() throws Throwable
     {
@@ -404,6 +398,12 @@ public class SimpleQueryTest extends CQLTester
         );
     }
 
+/*
+ * The inidividual tests that follow are currently commented out. They will be
+ * enabled in a subsequent pull request after they have been tested.
+ */
+
+/*
     @Test
     public void collectionDeletionTest() throws Throwable
     {

--- a/java/yb-cql/src/test/java/org/yb/cql/SimpleQueryTest.java
+++ b/java/yb-cql/src/test/java/org/yb/cql/SimpleQueryTest.java
@@ -1,539 +1,539 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 package org.yb.cql;
 
 import org.junit.Test;
 
 public class SimpleQueryTest extends CQLTester
 {
-    @Test
-    public void testDynamicCompactTables() throws Throwable
+  @Test
+  public void testDynamicCompactTables() throws Throwable
+  {
+    createTable("CREATE TABLE %s (k text, t int, v text, PRIMARY KEY (k, t));");
+
+    execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key", 1, "v11");
+    execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key", 2, "v12");
+    execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key", 3, "v13");
+
+    execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key", 4, "v14");
+    execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key", 5, "v15");
+
+    assertRows(execute("SELECT * FROM %s"),
+      row("key",  1, "v11"),
+      row("key",  2, "v12"),
+      row("key",  3, "v13"),
+      row("key",  4, "v14"),
+      row("key",  5, "v15")
+    );
+
+    assertRows(execute("SELECT * FROM %s WHERE k = ? AND t > ?", "key", 3),
+      row("key",  4, "v14"),
+      row("key",  5, "v15")
+    );
+
+    assertRows(execute("SELECT * FROM %s WHERE k = ? AND t >= ? AND t < ?", "key", 2, 4),
+      row("key",  2, "v12"),
+      row("key",  3, "v13")
+    );
+
+    // Reversed queries
+
+    assertRows(execute("SELECT * FROM %s WHERE k = ? ORDER BY t DESC", "key"),
+      row("key",  5, "v15"),
+      row("key",  4, "v14"),
+      row("key",  3, "v13"),
+      row("key",  2, "v12"),
+      row("key",  1, "v11")
+    );
+
+    assertRows(execute("SELECT * FROM %s WHERE k = ? AND t > ? ORDER BY t DESC", "key", 3),
+      row("key",  5, "v15"),
+      row("key",  4, "v14")
+    );
+
+    assertRows(execute("SELECT * FROM %s WHERE k = ? AND t >= ? AND t < ? ORDER BY t DESC", "key", 2, 4),
+      row("key",  3, "v13"),
+      row("key",  2, "v12")
+    );
+  }
+
+  @Test
+  public void testTableWithoutClustering() throws Throwable
+  {
+    createTable("CREATE TABLE %s (k text PRIMARY KEY, v1 int, v2 text);");
+
+    execute("INSERT INTO %s (k, v1, v2) values (?, ?, ?)", "first", 1, "value1");
+    execute("INSERT INTO %s (k, v1, v2) values (?, ?, ?)", "second", 2, "value2");
+    execute("INSERT INTO %s (k, v1, v2) values (?, ?, ?)", "third", 3, "value3");
+
+    assertRows(execute("SELECT * FROM %s WHERE k = ?", "first"),
+      row("first", 1, "value1")
+    );
+
+    assertRows(execute("SELECT v2 FROM %s WHERE k = ?", "second"),
+      row("value2")
+    );
+
+    assertRows(execute("SELECT * FROM %s"),
+      row("third",  3, "value3"),
+      row("second", 2, "value2"),
+      row("first",  1, "value1")
+    );
+  }
+
+  @Test
+  public void testTableWithOneClustering() throws Throwable
+  {
+    createTable("CREATE TABLE %s (k text, t int, v1 text, v2 text, PRIMARY KEY (k, t));");
+
+    execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 1, "v11", "v21");
+    execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 2, "v12", "v22");
+    execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 3, "v13", "v23");
+
+    execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 4, "v14", "v24");
+    execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 5, "v15", "v25");
+
+    assertRows(execute("SELECT * FROM %s"),
+      row("key",  1, "v11", "v21"),
+      row("key",  2, "v12", "v22"),
+      row("key",  3, "v13", "v23"),
+      row("key",  4, "v14", "v24"),
+      row("key",  5, "v15", "v25")
+    );
+
+    assertRows(execute("SELECT * FROM %s WHERE k = ? AND t > ?", "key", 3),
+      row("key",  4, "v14", "v24"),
+      row("key",  5, "v15", "v25")
+    );
+
+    assertRows(execute("SELECT * FROM %s WHERE k = ? AND t >= ? AND t < ?", "key", 2, 4),
+      row("key",  2, "v12", "v22"),
+      row("key",  3, "v13", "v23")
+    );
+
+    // Reversed queries
+
+    assertRows(execute("SELECT * FROM %s WHERE k = ? ORDER BY t DESC", "key"),
+      row("key",  5, "v15", "v25"),
+      row("key",  4, "v14", "v24"),
+      row("key",  3, "v13", "v23"),
+      row("key",  2, "v12", "v22"),
+      row("key",  1, "v11", "v21")
+    );
+
+    assertRows(execute("SELECT * FROM %s WHERE k = ? AND t > ? ORDER BY t DESC", "key", 3),
+      row("key",  5, "v15", "v25"),
+      row("key",  4, "v14", "v24")
+    );
+
+    assertRows(execute("SELECT * FROM %s WHERE k = ? AND t >= ? AND t < ? ORDER BY t DESC", "key", 2, 4),
+      row("key",  3, "v13", "v23"),
+      row("key",  2, "v12", "v22")
+    );
+  }
+
+  @Test
+  public void testTableWithReverseClusteringOrder() throws Throwable
+  {
+    createTable("CREATE TABLE %s (k text, t int, v1 text, v2 text, PRIMARY KEY (k, t)) WITH CLUSTERING ORDER BY (t DESC);");
+
+    execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 1, "v11", "v21");
+    execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 2, "v12", "v22");
+    execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 3, "v13", "v23");
+
+    execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 4, "v14", "v24");
+    execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 5, "v15", "v25");
+
+    assertRows(execute("SELECT * FROM %s"),
+      row("key",  5, "v15", "v25"),
+      row("key",  4, "v14", "v24"),
+      row("key",  3, "v13", "v23"),
+      row("key",  2, "v12", "v22"),
+      row("key",  1, "v11", "v21")
+    );
+
+    assertRows(execute("SELECT * FROM %s WHERE k = ? ORDER BY t ASC", "key"),
+      row("key",  1, "v11", "v21"),
+      row("key",  2, "v12", "v22"),
+      row("key",  3, "v13", "v23"),
+      row("key",  4, "v14", "v24"),
+      row("key",  5, "v15", "v25")
+    );
+
+    assertRows(execute("SELECT * FROM %s WHERE k = ? AND t > ?", "key", 3),
+      row("key",  5, "v15", "v25"),
+      row("key",  4, "v14", "v24")
+    );
+
+    assertRows(execute("SELECT * FROM %s WHERE k = ? AND t >= ? AND t < ?", "key", 2, 4),
+      row("key",  3, "v13", "v23"),
+      row("key",  2, "v12", "v22")
+    );
+
+    // Reversed queries
+
+    assertRows(execute("SELECT * FROM %s WHERE k = ? ORDER BY t DESC", "key"),
+      row("key",  5, "v15", "v25"),
+      row("key",  4, "v14", "v24"),
+      row("key",  3, "v13", "v23"),
+      row("key",  2, "v12", "v22"),
+      row("key",  1, "v11", "v21")
+    );
+
+    assertRows(execute("SELECT * FROM %s WHERE k = ? AND t > ? ORDER BY t DESC", "key", 3),
+      row("key",  5, "v15", "v25"),
+      row("key",  4, "v14", "v24")
+    );
+
+    assertRows(execute("SELECT * FROM %s WHERE k = ? AND t >= ? AND t < ? ORDER BY t DESC", "key", 2, 4),
+      row("key",  3, "v13", "v23"),
+      row("key",  2, "v12", "v22")
+    );
+  }
+
+  @Test
+  public void testTableWithTwoClustering() throws Throwable
+  {
+    createTable("CREATE TABLE %s (k text, t1 text, t2 int, v text, PRIMARY KEY (k, t1, t2));");
+
+    execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", "v1", 1, "v1");
+    execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", "v1", 2, "v2");
+    execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", "v2", 1, "v3");
+    execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", "v2", 2, "v4");
+    execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", "v2", 3, "v5");
+
+    assertRows(execute("SELECT * FROM %s"),
+      row("key",  "v1", 1, "v1"),
+      row("key",  "v1", 2, "v2"),
+      row("key",  "v2", 1, "v3"),
+      row("key",  "v2", 2, "v4"),
+      row("key",  "v2", 3, "v5")
+    );
+
+    assertRows(execute("SELECT * FROM %s WHERE k = ? AND t1 >= ?", "key", "v2"),
+      row("key",  "v2", 1, "v3"),
+      row("key",  "v2", 2, "v4"),
+      row("key",  "v2", 3, "v5")
+    );
+
+    assertRows(execute("SELECT * FROM %s WHERE k = ? AND t1 >= ? ORDER BY t1 DESC", "key", "v2"),
+      row("key",  "v2", 3, "v5"),
+      row("key",  "v2", 2, "v4"),
+      row("key",  "v2", 1, "v3")
+    );
+  }
+
+  @Test
+  public void testTableWithLargePartition() throws Throwable
+  {
+    createTable("CREATE TABLE %s (k text, t1 int, t2 int, v text, PRIMARY KEY (k, t1, t2));");
+
+    for (int t1 = 0; t1 < 20; t1++)
+      for (int t2 = 0; t2 < 10; t2++)
+        execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", t1, t2, "someSemiLargeTextForValue_" + t1 + "_" + t2);
+
+    Object[][] expected = new Object[10][];
+    for (int t2 = 0; t2 < 10; t2++)
+      expected[t2] = row("key", 15, t2);
+
+    assertRows(execute("SELECT k, t1, t2 FROM %s WHERE k=? AND t1=?", "key", 15), expected);
+
+    Object[][] expectedReverse = new Object[10][];
+    for (int t2 = 9; t2 >= 0; t2--)
+      expectedReverse[9 - t2] = row("key", 15, t2);
+
+    assertRows(execute("SELECT k, t1, t2 FROM %s WHERE k=? AND t1=? ORDER BY t1 DESC, t2 DESC", "key", 15), expectedReverse);
+  }
+
+  @Test
+  public void testRowDeletion() throws Throwable
+  {
+    int N = 4;
+
+    createTable("CREATE TABLE %s (k text, t int, v1 text, v2 int, PRIMARY KEY (k, t));");
+
+    for (int t = 0; t < N; t++)
+      execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", t, "v" + t, t + 10);
+
+    for (int i = 0; i < N / 2; i++)
+      execute("DELETE FROM %s WHERE k=? AND t=?", "key", i * 2);
+
+    Object[][] expected = new Object[N/2][];
+    for (int i = 0; i < N / 2; i++)
     {
-        createTable("CREATE TABLE %s (k text, t int, v text, PRIMARY KEY (k, t));");
-
-        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key", 1, "v11");
-        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key", 2, "v12");
-        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key", 3, "v13");
-
-        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key", 4, "v14");
-        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key", 5, "v15");
-
-        assertRows(execute("SELECT * FROM %s"),
-            row("key",  1, "v11"),
-            row("key",  2, "v12"),
-            row("key",  3, "v13"),
-            row("key",  4, "v14"),
-            row("key",  5, "v15")
-        );
-
-        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t > ?", "key", 3),
-            row("key",  4, "v14"),
-            row("key",  5, "v15")
-        );
-
-        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t >= ? AND t < ?", "key", 2, 4),
-            row("key",  2, "v12"),
-            row("key",  3, "v13")
-        );
-
-        // Reversed queries
-
-        assertRows(execute("SELECT * FROM %s WHERE k = ? ORDER BY t DESC", "key"),
-            row("key",  5, "v15"),
-            row("key",  4, "v14"),
-            row("key",  3, "v13"),
-            row("key",  2, "v12"),
-            row("key",  1, "v11")
-        );
-
-        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t > ? ORDER BY t DESC", "key", 3),
-            row("key",  5, "v15"),
-            row("key",  4, "v14")
-        );
-
-        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t >= ? AND t < ? ORDER BY t DESC", "key", 2, 4),
-            row("key",  3, "v13"),
-            row("key",  2, "v12")
-        );
+      int t = i * 2 + 1;
+      expected[i] = row("key", t, "v" + t, t + 10);
     }
 
-    @Test
-    public void testTableWithoutClustering() throws Throwable
+    assertRows(execute("SELECT * FROM %s"), expected);
+  }
+
+  @Test
+  public void testRangeTombstones() throws Throwable
+  {
+    int N = 100;
+
+    createTable("CREATE TABLE %s (k text, t1 int, t2 int, v text, PRIMARY KEY (k, t1, t2));");
+
+    for (int t1 = 0; t1 < 3; t1++)
+      for (int t2 = 0; t2 < N; t2++)
+        execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", t1, t2, "someSemiLargeTextForValue_" + t1 + "_" + t2);
+
+    execute("DELETE FROM %s WHERE k=? AND t1=?", "key", 1);
+
+    Object[][] expected = new Object[2*N][];
+    for (int t2 = 0; t2 < N; t2++)
     {
-        createTable("CREATE TABLE %s (k text PRIMARY KEY, v1 int, v2 text);");
-
-        execute("INSERT INTO %s (k, v1, v2) values (?, ?, ?)", "first", 1, "value1");
-        execute("INSERT INTO %s (k, v1, v2) values (?, ?, ?)", "second", 2, "value2");
-        execute("INSERT INTO %s (k, v1, v2) values (?, ?, ?)", "third", 3, "value3");
-
-        assertRows(execute("SELECT * FROM %s WHERE k = ?", "first"),
-            row("first", 1, "value1")
-        );
-
-        assertRows(execute("SELECT v2 FROM %s WHERE k = ?", "second"),
-            row("value2")
-        );
-
-        assertRows(execute("SELECT * FROM %s"),
-            row("third",  3, "value3"),
-            row("second", 2, "value2"),
-            row("first",  1, "value1")
-        );
+      expected[t2] = row("key", 0, t2, "someSemiLargeTextForValue_0_" + t2);
+      expected[N + t2] = row("key", 2, t2, "someSemiLargeTextForValue_2_" + t2);
     }
 
-    @Test
-    public void testTableWithOneClustering() throws Throwable
-    {
-        createTable("CREATE TABLE %s (k text, t int, v1 text, v2 text, PRIMARY KEY (k, t));");
-
-        execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 1, "v11", "v21");
-        execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 2, "v12", "v22");
-        execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 3, "v13", "v23");
-
-        execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 4, "v14", "v24");
-        execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 5, "v15", "v25");
-
-        assertRows(execute("SELECT * FROM %s"),
-            row("key",  1, "v11", "v21"),
-            row("key",  2, "v12", "v22"),
-            row("key",  3, "v13", "v23"),
-            row("key",  4, "v14", "v24"),
-            row("key",  5, "v15", "v25")
-        );
-
-        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t > ?", "key", 3),
-            row("key",  4, "v14", "v24"),
-            row("key",  5, "v15", "v25")
-        );
-
-        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t >= ? AND t < ?", "key", 2, 4),
-            row("key",  2, "v12", "v22"),
-            row("key",  3, "v13", "v23")
-        );
-
-        // Reversed queries
-
-        assertRows(execute("SELECT * FROM %s WHERE k = ? ORDER BY t DESC", "key"),
-            row("key",  5, "v15", "v25"),
-            row("key",  4, "v14", "v24"),
-            row("key",  3, "v13", "v23"),
-            row("key",  2, "v12", "v22"),
-            row("key",  1, "v11", "v21")
-        );
-
-        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t > ? ORDER BY t DESC", "key", 3),
-            row("key",  5, "v15", "v25"),
-            row("key",  4, "v14", "v24")
-        );
-
-        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t >= ? AND t < ? ORDER BY t DESC", "key", 2, 4),
-            row("key",  3, "v13", "v23"),
-            row("key",  2, "v12", "v22")
-        );
-    }
-
-    @Test
-    public void testTableWithReverseClusteringOrder() throws Throwable
-    {
-        createTable("CREATE TABLE %s (k text, t int, v1 text, v2 text, PRIMARY KEY (k, t)) WITH CLUSTERING ORDER BY (t DESC);");
-
-        execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 1, "v11", "v21");
-        execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 2, "v12", "v22");
-        execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 3, "v13", "v23");
-
-        execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 4, "v14", "v24");
-        execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 5, "v15", "v25");
-
-        assertRows(execute("SELECT * FROM %s"),
-            row("key",  5, "v15", "v25"),
-            row("key",  4, "v14", "v24"),
-            row("key",  3, "v13", "v23"),
-            row("key",  2, "v12", "v22"),
-            row("key",  1, "v11", "v21")
-        );
-
-        assertRows(execute("SELECT * FROM %s WHERE k = ? ORDER BY t ASC", "key"),
-            row("key",  1, "v11", "v21"),
-            row("key",  2, "v12", "v22"),
-            row("key",  3, "v13", "v23"),
-            row("key",  4, "v14", "v24"),
-            row("key",  5, "v15", "v25")
-        );
-
-        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t > ?", "key", 3),
-            row("key",  5, "v15", "v25"),
-            row("key",  4, "v14", "v24")
-        );
-
-        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t >= ? AND t < ?", "key", 2, 4),
-            row("key",  3, "v13", "v23"),
-            row("key",  2, "v12", "v22")
-        );
-
-        // Reversed queries
-
-        assertRows(execute("SELECT * FROM %s WHERE k = ? ORDER BY t DESC", "key"),
-            row("key",  5, "v15", "v25"),
-            row("key",  4, "v14", "v24"),
-            row("key",  3, "v13", "v23"),
-            row("key",  2, "v12", "v22"),
-            row("key",  1, "v11", "v21")
-        );
-
-        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t > ? ORDER BY t DESC", "key", 3),
-            row("key",  5, "v15", "v25"),
-            row("key",  4, "v14", "v24")
-        );
-
-        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t >= ? AND t < ? ORDER BY t DESC", "key", 2, 4),
-            row("key",  3, "v13", "v23"),
-            row("key",  2, "v12", "v22")
-        );
-    }
-
-    @Test
-    public void testTableWithTwoClustering() throws Throwable
-    {
-        createTable("CREATE TABLE %s (k text, t1 text, t2 int, v text, PRIMARY KEY (k, t1, t2));");
-
-        execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", "v1", 1, "v1");
-        execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", "v1", 2, "v2");
-        execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", "v2", 1, "v3");
-        execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", "v2", 2, "v4");
-        execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", "v2", 3, "v5");
-
-        assertRows(execute("SELECT * FROM %s"),
-            row("key",  "v1", 1, "v1"),
-            row("key",  "v1", 2, "v2"),
-            row("key",  "v2", 1, "v3"),
-            row("key",  "v2", 2, "v4"),
-            row("key",  "v2", 3, "v5")
-        );
-
-        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t1 >= ?", "key", "v2"),
-            row("key",  "v2", 1, "v3"),
-            row("key",  "v2", 2, "v4"),
-            row("key",  "v2", 3, "v5")
-        );
-
-        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t1 >= ? ORDER BY t1 DESC", "key", "v2"),
-            row("key",  "v2", 3, "v5"),
-            row("key",  "v2", 2, "v4"),
-            row("key",  "v2", 1, "v3")
-        );
-    }
-
-    @Test
-    public void testTableWithLargePartition() throws Throwable
-    {
-        createTable("CREATE TABLE %s (k text, t1 int, t2 int, v text, PRIMARY KEY (k, t1, t2));");
-
-        for (int t1 = 0; t1 < 20; t1++)
-            for (int t2 = 0; t2 < 10; t2++)
-                execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", t1, t2, "someSemiLargeTextForValue_" + t1 + "_" + t2);
-
-        Object[][] expected = new Object[10][];
-        for (int t2 = 0; t2 < 10; t2++)
-            expected[t2] = row("key", 15, t2);
-
-        assertRows(execute("SELECT k, t1, t2 FROM %s WHERE k=? AND t1=?", "key", 15), expected);
-
-        Object[][] expectedReverse = new Object[10][];
-        for (int t2 = 9; t2 >= 0; t2--)
-            expectedReverse[9 - t2] = row("key", 15, t2);
-
-        assertRows(execute("SELECT k, t1, t2 FROM %s WHERE k=? AND t1=? ORDER BY t1 DESC, t2 DESC", "key", 15), expectedReverse);
-    }
-
-    @Test
-    public void testRowDeletion() throws Throwable
-    {
-        int N = 4;
-
-        createTable("CREATE TABLE %s (k text, t int, v1 text, v2 int, PRIMARY KEY (k, t));");
-
-        for (int t = 0; t < N; t++)
-            execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", t, "v" + t, t + 10);
-
-        for (int i = 0; i < N / 2; i++)
-            execute("DELETE FROM %s WHERE k=? AND t=?", "key", i * 2);
-
-        Object[][] expected = new Object[N/2][];
-        for (int i = 0; i < N / 2; i++)
-        {
-            int t = i * 2 + 1;
-            expected[i] = row("key", t, "v" + t, t + 10);
-        }
-
-        assertRows(execute("SELECT * FROM %s"), expected);
-    }
-
-    @Test
-    public void testRangeTombstones() throws Throwable
-    {
-        int N = 100;
-
-        createTable("CREATE TABLE %s (k text, t1 int, t2 int, v text, PRIMARY KEY (k, t1, t2));");
-
-        for (int t1 = 0; t1 < 3; t1++)
-            for (int t2 = 0; t2 < N; t2++)
-                execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", t1, t2, "someSemiLargeTextForValue_" + t1 + "_" + t2);
-
-        execute("DELETE FROM %s WHERE k=? AND t1=?", "key", 1);
-
-        Object[][] expected = new Object[2*N][];
-        for (int t2 = 0; t2 < N; t2++)
-        {
-            expected[t2] = row("key", 0, t2, "someSemiLargeTextForValue_0_" + t2);
-            expected[N + t2] = row("key", 2, t2, "someSemiLargeTextForValue_2_" + t2);
-        }
-
-        assertRows(execute("SELECT * FROM %s"), expected);
-    }
-
-    @Test
-    public void test2ndaryIndexes() throws Throwable
-    {
-        createTable("CREATE TABLE %s (k text, t int, v text, PRIMARY KEY (k, t));");
-
-        execute("CREATE INDEX ON %s(v)");
-
-        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 1, "foo");
-        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 2, "bar");
-        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key2", 1, "foo");
-
-        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key2", 2, "foo");
-        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key2", 3, "bar");
-
-        assertRows(execute("SELECT * FROM %s WHERE v = ?", "foo"),
-            row("key1",  1, "foo"),
-            row("key2",  1, "foo"),
-            row("key2",  2, "foo")
-        );
-
-        assertRows(execute("SELECT * FROM %s WHERE v = ?", "bar"),
-            row("key1",  2, "bar"),
-            row("key2",  3, "bar")
-        );
-    }
-
-    @Test
-    public void testStaticColumns() throws Throwable
-    {
-        createTable("CREATE TABLE %s (k text, t int, s text static, v text, PRIMARY KEY (k, t));");
-
-        execute("INSERT INTO %s (k, t, v, s) values (?, ?, ?, ?)", "key1", 1, "foo1", "st1");
-        execute("INSERT INTO %s (k, t, v, s) values (?, ?, ?, ?)", "key1", 2, "foo2", "st2");
-
-        execute("INSERT INTO %s (k, t, v, s) values (?, ?, ?, ?)", "key1", 3, "foo3", "st3");
-        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 4, "foo4");
-        execute("INSERT INTO %s (k, t, v, s) values (?, ?, ?, ?)", "key1", 2, "foo2", "st2-repeat");
-
-        execute("INSERT INTO %s (k, t, v, s) values (?, ?, ?, ?)", "key1", 5, "foo5", "st5");
-        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 6, "foo6");
-
-
-        assertRows(execute("SELECT * FROM %s"),
-            row("key1",  1, "st5", "foo1"),
-            row("key1",  2, "st5", "foo2"),
-            row("key1",  3, "st5", "foo3"),
-            row("key1",  4, "st5", "foo4"),
-            row("key1",  5, "st5", "foo5"),
-            row("key1",  6, "st5", "foo6")
-        );
-
-        assertRows(execute("SELECT s FROM %s WHERE k = ?", "key1"),
-            row("st5"),
-            row("st5"),
-            row("st5"),
-            row("st5"),
-            row("st5"),
-            row("st5")
-        );
-
-        assertRows(execute("SELECT DISTINCT s FROM %s WHERE k = ?", "key1"),
-            row("st5")
-        );
-
-        assertEmpty(execute("SELECT * FROM %s WHERE k = ? AND t > ? AND t < ?", "key1", 7, 5));
-        assertEmpty(execute("SELECT * FROM %s WHERE k = ? AND t > ? AND t < ? ORDER BY t DESC", "key1", 7, 5));
-
-        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t = ?", "key1", 2),
-            row("key1", 2, "st5", "foo2"));
-
-        assertRows(execute("SELECT * FROM %s WHERE k = ? AND t = ? ORDER BY t DESC", "key1", 2),
-            row("key1", 2, "st5", "foo2"));
-    }
-
-    @Test
-    public void testDistinct() throws Throwable
-    {
-        createTable("CREATE TABLE %s (k text, t int, v text, PRIMARY KEY (k, t));");
-
-        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 1, "foo1");
-        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 2, "foo2");
-
-        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 3, "foo3");
-        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key2", 4, "foo4");
-        execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key2", 5, "foo5");
-
-        assertRows(execute("SELECT DISTINCT k FROM %s"),
-            row("key1"),
-            row("key2")
-        );
-    }
+    assertRows(execute("SELECT * FROM %s"), expected);
+  }
+
+  @Test
+  public void test2ndaryIndexes() throws Throwable
+  {
+    createTable("CREATE TABLE %s (k text, t int, v text, PRIMARY KEY (k, t)) WITH transactions = { 'enabled' : true };");
+
+    createIndex("CREATE INDEX %s ON %s(v);");
+
+    execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 1, "foo");
+    execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 2, "bar");
+    execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key2", 1, "foo");
+
+    execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key2", 2, "foo");
+    execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key2", 3, "bar");
+
+    assertRows(execute("SELECT * FROM %s WHERE v = ?", "foo"),
+      row("key1",  1, "foo"),
+      row("key2",  1, "foo"),
+      row("key2",  2, "foo")
+    );
+
+    assertRows(execute("SELECT * FROM %s WHERE v = ?", "bar"),
+      row("key1",  2, "bar"),
+      row("key2",  3, "bar")
+    );
+  }
+
+  @Test
+  public void testStaticColumns() throws Throwable
+  {
+    createTable("CREATE TABLE %s (k text, t int, s text static, v text, PRIMARY KEY (k, t));");
+
+    execute("INSERT INTO %s (k, t, v, s) values (?, ?, ?, ?)", "key1", 1, "foo1", "st1");
+    execute("INSERT INTO %s (k, t, v, s) values (?, ?, ?, ?)", "key1", 2, "foo2", "st2");
+
+    execute("INSERT INTO %s (k, t, v, s) values (?, ?, ?, ?)", "key1", 3, "foo3", "st3");
+    execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 4, "foo4");
+    execute("INSERT INTO %s (k, t, v, s) values (?, ?, ?, ?)", "key1", 2, "foo2", "st2-repeat");
+
+    execute("INSERT INTO %s (k, t, v, s) values (?, ?, ?, ?)", "key1", 5, "foo5", "st5");
+    execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 6, "foo6");
+
+
+    assertRows(execute("SELECT * FROM %s"),
+      row("key1",  1, "st5", "foo1"),
+      row("key1",  2, "st5", "foo2"),
+      row("key1",  3, "st5", "foo3"),
+      row("key1",  4, "st5", "foo4"),
+      row("key1",  5, "st5", "foo5"),
+      row("key1",  6, "st5", "foo6")
+    );
+
+    assertRows(execute("SELECT s FROM %s WHERE k = ?", "key1"),
+      row("st5"),
+      row("st5"),
+      row("st5"),
+      row("st5"),
+      row("st5"),
+      row("st5")
+    );
+
+    assertRows(execute("SELECT DISTINCT s FROM %s WHERE k = ?", "key1"),
+      row("st5")
+    );
+
+    assertEmpty(execute("SELECT * FROM %s WHERE k = ? AND t > ? AND t < ?", "key1", 7, 5));
+    assertEmpty(execute("SELECT * FROM %s WHERE k = ? AND t > ? AND t < ? ORDER BY t DESC", "key1", 7, 5));
+
+    assertRows(execute("SELECT * FROM %s WHERE k = ? AND t = ?", "key1", 2),
+      row("key1", 2, "st5", "foo2"));
+
+    assertRows(execute("SELECT * FROM %s WHERE k = ? AND t = ? ORDER BY t DESC", "key1", 2),
+      row("key1", 2, "st5", "foo2"));
+  }
+
+  @Test
+  public void testDistinct() throws Throwable
+  {
+    createTable("CREATE TABLE %s (k text, t int, v text, PRIMARY KEY (k, t));");
+
+    execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 1, "foo1");
+    execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 2, "foo2");
+
+    execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 3, "foo3");
+    execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key2", 4, "foo4");
+    execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key2", 5, "foo5");
+
+    assertRows(execute("SELECT DISTINCT k FROM %s"),
+      row("key1"),
+      row("key2")
+    );
+  }
 
 /*
- * The inidividual tests that follow are currently commented out. They will be
- * enabled in a subsequent pull request after they have been tested.
- */
-
-/*
-    @Test
-    public void collectionDeletionTest() throws Throwable
-    {
-        createTable("CREATE TABLE %s (k int PRIMARY KEY, s set<int>);");
-
-        execute("INSERT INTO %s (k, s) VALUES (?, ?)", 1, set(1));
-
-        execute("INSERT INTO %s (k, s) VALUES (?, ?)", 1, set(2));
-
-        assertRows(execute("SELECT s FROM %s WHERE k = ?", 1),
-            row(set(2))
-        );
-    }
-
-    @Test
-    public void limitWithMultigetTest() throws Throwable
-    {
-        createTable("CREATE TABLE %s (k int PRIMARY KEY, v int);");
-
-        execute("INSERT INTO %s (k, v) VALUES (?, ?)", 0, 0);
-        execute("INSERT INTO %s (k, v) VALUES (?, ?)", 1, 1);
-        execute("INSERT INTO %s (k, v) VALUES (?, ?)", 2, 2);
-        execute("INSERT INTO %s (k, v) VALUES (?, ?)", 3, 3);
-
-        assertRows(execute("SELECT v FROM %s WHERE k IN ? LIMIT ?", list(0, 1, 2, 3), 2),
-            row(0),
-            row(1)
-        );
-    }
-
-    @Test
-    public void staticDistinctTest() throws Throwable
-    {
-        createTable("CREATE TABLE %s ( k int, p int, s int static, PRIMARY KEY (k, p))");
-
-        execute("INSERT INTO %s (k, p) VALUES (?, ?)", 1, 1);
-        execute("INSERT INTO %s (k, p) VALUES (?, ?)", 1, 2);
-
-        assertRows(execute("SELECT k, s FROM %s"),
-            row(1, null),
-            row(1, null)
-        );
-        assertRows(execute("SELECT DISTINCT k, s FROM %s"),
-            row(1, null)
-        );
-        assertRows(execute("SELECT DISTINCT s FROM %s WHERE k=?", 1),
-            row((Object)null)
-        );
-        assertEmpty(execute("SELECT DISTINCT s FROM %s WHERE k=?", 2));
-    }
-
-    @Test
-    public void test2ndaryIndexBug() throws Throwable
-    {
-        createTable("CREATE TABLE %s (k int, c1 int, c2 int, v int, PRIMARY KEY(k, c1, c2))");
-
-        execute("CREATE INDEX v_idx ON %s(v)");
-
-        execute("INSERT INTO %s (k, c1, c2, v) VALUES (?, ?, ?, ?)", 0, 0, 0, 0);
-        execute("INSERT INTO %s (k, c1, c2, v) VALUES (?, ?, ?, ?)", 0, 1, 0, 0);
-
-        assertRows(execute("SELECT * FROM %s WHERE v=?", 0),
-            row(0, 0, 0, 0),
-            row(0, 1, 0, 0)
-        );
-
-        execute("DELETE FROM %s WHERE k=? AND c1=?", 0, 1);
-
-        assertRows(execute("SELECT * FROM %s WHERE v=?", 0),
-            row(0, 0, 0, 0)
-        );
-    }
+* The inidividual tests that follow are currently commented out. They will be
+* enabled in a subsequent pull request after they have been tested.
 */
 
-    /** Test for Cassandra issue 10958 **/
 /*
-    @Test
-    public void restrictionOnRegularColumnWithStaticColumnPresentTest() throws Throwable
+  @Test
+  public void collectionDeletionTest() throws Throwable
+  {
+    createTable("CREATE TABLE %s (k int PRIMARY KEY, s set<int>);");
+
+    execute("INSERT INTO %s (k, s) VALUES (?, ?)", 1, set(1));
+
+    execute("INSERT INTO %s (k, s) VALUES (?, ?)", 1, set(2));
+
+    assertRows(execute("SELECT s FROM %s WHERE k = ?", 1),
+      row(set(2))
+    );
+  }
+
+  @Test
+  public void limitWithMultigetTest() throws Throwable
+  {
+    createTable("CREATE TABLE %s (k int PRIMARY KEY, v int);");
+
+    execute("INSERT INTO %s (k, v) VALUES (?, ?)", 0, 0);
+    execute("INSERT INTO %s (k, v) VALUES (?, ?)", 1, 1);
+    execute("INSERT INTO %s (k, v) VALUES (?, ?)", 2, 2);
+    execute("INSERT INTO %s (k, v) VALUES (?, ?)", 3, 3);
+
+    assertRows(execute("SELECT v FROM %s WHERE k IN ? LIMIT ?", list(0, 1, 2, 3), 2),
+      row(0),
+      row(1)
+    );
+  }
+
+  @Test
+  public void staticDistinctTest() throws Throwable
+  {
+    createTable("CREATE TABLE %s ( k int, p int, s int static, PRIMARY KEY (k, p))");
+
+    execute("INSERT INTO %s (k, p) VALUES (?, ?)", 1, 1);
+    execute("INSERT INTO %s (k, p) VALUES (?, ?)", 1, 2);
+
+    assertRows(execute("SELECT k, s FROM %s"),
+      row(1, null),
+      row(1, null)
+    );
+    assertRows(execute("SELECT DISTINCT k, s FROM %s"),
+      row(1, null)
+    );
+    assertRows(execute("SELECT DISTINCT s FROM %s WHERE k=?", 1),
+      row((Object)null)
+    );
+    assertEmpty(execute("SELECT DISTINCT s FROM %s WHERE k=?", 2));
+  }
+
+  @Test
+  public void test2ndaryIndexBug() throws Throwable
+  {
+    createTable("CREATE TABLE %s (k int, c1 int, c2 int, v int, PRIMARY KEY(k, c1, c2))");
+
+    execute("CREATE INDEX v_idx ON %s(v)");
+
+    execute("INSERT INTO %s (k, c1, c2, v) VALUES (?, ?, ?, ?)", 0, 0, 0, 0);
+    execute("INSERT INTO %s (k, c1, c2, v) VALUES (?, ?, ?, ?)", 0, 1, 0, 0);
+
+    assertRows(execute("SELECT * FROM %s WHERE v=?", 0),
+      row(0, 0, 0, 0),
+      row(0, 1, 0, 0)
+    );
+
+    execute("DELETE FROM %s WHERE k=? AND c1=?", 0, 1);
+
+    assertRows(execute("SELECT * FROM %s WHERE v=?", 0),
+      row(0, 0, 0, 0)
+    );
+  }
+*/
+
+  /** Test for Cassandra issue 10958 **/
+/*
+  @Test
+  public void restrictionOnRegularColumnWithStaticColumnPresentTest() throws Throwable
+  {
+    createTable("CREATE TABLE %s (id int, id2 int, age int static, extra int, PRIMARY KEY(id, id2))");
+
+    execute("INSERT INTO %s (id, id2, age, extra) VALUES (?, ?, ?, ?)", 1, 1, 1, 1);
+    execute("INSERT INTO %s (id, id2, age, extra) VALUES (?, ?, ?, ?)", 2, 2, 2, 2);
+    execute("UPDATE %s SET age=? WHERE id=?", 3, 3);
+
+    assertRows(execute("SELECT * FROM %s"),
+      row(1, 1, 1, 1),
+      row(2, 2, 2, 2),
+      row(3, null, 3, null)
+    );
+
+    assertRows(execute("SELECT * FROM %s WHERE extra > 1 ALLOW FILTERING"),
+      row(2, 2, 2, 2)
+    );
+  }
+
+  @Test
+  public void testRowFilteringOnStaticColumn() throws Throwable
+  {
+    createTable("CREATE TABLE %s (id int, name text, age int static, PRIMARY KEY (id, name))");
+    for (int i = 0; i < 5; i++)
     {
-        createTable("CREATE TABLE %s (id int, id2 int, age int static, extra int, PRIMARY KEY(id, id2))");
-
-        execute("INSERT INTO %s (id, id2, age, extra) VALUES (?, ?, ?, ?)", 1, 1, 1, 1);
-        execute("INSERT INTO %s (id, id2, age, extra) VALUES (?, ?, ?, ?)", 2, 2, 2, 2);
-        execute("UPDATE %s SET age=? WHERE id=?", 3, 3);
-
-        assertRows(execute("SELECT * FROM %s"),
-            row(1, 1, 1, 1),
-            row(2, 2, 2, 2),
-            row(3, null, 3, null)
-        );
-
-        assertRows(execute("SELECT * FROM %s WHERE extra > 1 ALLOW FILTERING"),
-            row(2, 2, 2, 2)
-        );
+      execute("INSERT INTO %s (id, name, age) VALUES (?, ?, ?)", i, "NameDoesNotMatter", i);
     }
 
-    @Test
-    public void testRowFilteringOnStaticColumn() throws Throwable
-    {
-        createTable("CREATE TABLE %s (id int, name text, age int static, PRIMARY KEY (id, name))");
-        for (int i = 0; i < 5; i++)
-        {
-            execute("INSERT INTO %s (id, name, age) VALUES (?, ?, ?)", i, "NameDoesNotMatter", i);
-        }
+    assertInvalid("SELECT id, age FROM %s WHERE age < 1");
+    assertRows(execute("SELECT id, age FROM %s WHERE age < 1 ALLOW FILTERING"),
+         row(0, 0));
+    assertRows(execute("SELECT id, age FROM %s WHERE age > 0 AND age < 3 ALLOW FILTERING"),
+         row(1, 1), row(2, 2));
+    assertRows(execute("SELECT id, age FROM %s WHERE age > 3 ALLOW FILTERING"),
+         row(4, 4));
+  }
 
-        assertInvalid("SELECT id, age FROM %s WHERE age < 1");
-        assertRows(execute("SELECT id, age FROM %s WHERE age < 1 ALLOW FILTERING"),
-                   row(0, 0));
-        assertRows(execute("SELECT id, age FROM %s WHERE age > 0 AND age < 3 ALLOW FILTERING"),
-                   row(1, 1), row(2, 2));
-        assertRows(execute("SELECT id, age FROM %s WHERE age > 3 ALLOW FILTERING"),
-                   row(4, 4));
-    }
+  @Test
+  public void testSStableTimestampOrdering() throws Throwable
+  {
+    createTable("CREATE TABLE %s (k1 int, v1 int, v2 int, PRIMARY KEY (k1))");
+    disableCompaction();
 
-    @Test
-    public void testSStableTimestampOrdering() throws Throwable
-    {
-        createTable("CREATE TABLE %s (k1 int, v1 int, v2 int, PRIMARY KEY (k1))");
-        disableCompaction();
+    // sstable1
+    execute("INSERT INTO %s(k1,v1,v2) VALUES(1,1,1)  USING TIMESTAMP 5");
 
-        // sstable1
-        execute("INSERT INTO %s(k1,v1,v2) VALUES(1,1,1)  USING TIMESTAMP 5");
+    // sstable2
+    execute("INSERT INTO %s(k1,v1,v2) VALUES(1,1,2)  USING TIMESTAMP 8");
 
-        // sstable2
-        execute("INSERT INTO %s(k1,v1,v2) VALUES(1,1,2)  USING TIMESTAMP 8");
+    execute("INSERT INTO %s(k1) VALUES(1)  USING TIMESTAMP 7");
+    execute("DELETE FROM %s USING TIMESTAMP 6 WHERE k1 = 1");
 
-        execute("INSERT INTO %s(k1) VALUES(1)  USING TIMESTAMP 7");
-        execute("DELETE FROM %s USING TIMESTAMP 6 WHERE k1 = 1");
-
-        assertRows(execute("SELECT * FROM %s WHERE k1=1"), row(1, 1, 2));
-    } 
+    assertRows(execute("SELECT * FROM %s WHERE k1=1"), row(1, 1, 2));
+  } 
 */
 }

--- a/java/yb-cql/src/test/java/org/yb/cql/SimpleQueryTest.java
+++ b/java/yb-cql/src/test/java/org/yb/cql/SimpleQueryTest.java
@@ -295,12 +295,7 @@ public class SimpleQueryTest extends CQLTester
 
         assertRows(execute("SELECT * FROM %s"), expected);
     }
-/*
- * The inidividual tests that follow are currently commented out. They will be
- * enabled in a subsequent pull request after they have been tested.
- */
 
-/*
     @Test
     public void testRangeTombstones() throws Throwable
     {
@@ -328,6 +323,12 @@ public class SimpleQueryTest extends CQLTester
         assertRows(execute("SELECT * FROM %s"), expected);
     }
 
+/*
+ * The inidividual tests that follow are currently commented out. They will be
+ * enabled in a subsequent pull request after they have been tested.
+ */
+
+/*
     @Test
     public void test2ndaryIndexes() throws Throwable
     {

--- a/java/yb-cql/src/test/java/org/yb/cql/SimpleQueryTest.java
+++ b/java/yb-cql/src/test/java/org/yb/cql/SimpleQueryTest.java
@@ -383,7 +383,6 @@ public class SimpleQueryTest extends CQLTester
   }
 
   @Test
-  @Ignore ("Disabled for issue #466")
   public void testDistinct() throws Throwable
   {
     createTable("CREATE TABLE %s (k text, t int, v text, PRIMARY KEY (k, t));");
@@ -396,8 +395,8 @@ public class SimpleQueryTest extends CQLTester
     execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key2", 5, "foo5");
 
     assertRows(execute("SELECT DISTINCT k FROM %s"),
-      row("key1"),
-      row("key2")
+      row("key2"),
+      row("key1")
     );
   }
 

--- a/java/yb-cql/src/test/java/org/yb/cql/SimpleQueryTest.java
+++ b/java/yb-cql/src/test/java/org/yb/cql/SimpleQueryTest.java
@@ -30,8 +30,6 @@ public class SimpleQueryTest extends CQLTester
         execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key", 2, "v12");
         execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key", 3, "v13");
 
-        // flush();
-
         execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key", 4, "v14");
         execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key", 5, "v15");
 
@@ -83,8 +81,6 @@ public class SimpleQueryTest extends CQLTester
         execute("INSERT INTO %s (k, v1, v2) values (?, ?, ?)", "second", 2, "value2");
         execute("INSERT INTO %s (k, v1, v2) values (?, ?, ?)", "third", 3, "value3");
 
-        // flush();
-
         assertRows(execute("SELECT * FROM %s WHERE k = ?", "first"),
             row("first", 1, "value1")
         );
@@ -108,8 +104,6 @@ public class SimpleQueryTest extends CQLTester
         execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 1, "v11", "v21");
         execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 2, "v12", "v22");
         execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 3, "v13", "v23");
-
-        // flush();
 
         execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 4, "v14", "v24");
         execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 5, "v15", "v25");
@@ -161,8 +155,6 @@ public class SimpleQueryTest extends CQLTester
         execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 1, "v11", "v21");
         execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 2, "v12", "v22");
         execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 3, "v13", "v23");
-
-        // flush();
 
         execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 4, "v14", "v24");
         execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", 5, "v15", "v25");
@@ -224,7 +216,6 @@ public class SimpleQueryTest extends CQLTester
         execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", "v2", 1, "v3");
         execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", "v2", 2, "v4");
         execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", "v2", 3, "v5");
-        // flush();
 
         assertRows(execute("SELECT * FROM %s"),
             row("key",  "v1", 1, "v1"),
@@ -256,8 +247,6 @@ public class SimpleQueryTest extends CQLTester
             for (int t2 = 0; t2 < 10; t2++)
                 execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", t1, t2, "someSemiLargeTextForValue_" + t1 + "_" + t2);
 
-        // flush();
-
         Object[][] expected = new Object[10][];
         for (int t2 = 0; t2 < 10; t2++)
             expected[t2] = row("key", 15, t2);
@@ -280,8 +269,6 @@ public class SimpleQueryTest extends CQLTester
 
         for (int t = 0; t < N; t++)
             execute("INSERT INTO %s (k, t, v1, v2) values (?, ?, ?, ?)", "key", t, "v" + t, t + 10);
-
-        // flush();
 
         for (int i = 0; i < N / 2; i++)
             execute("DELETE FROM %s WHERE k=? AND t=?", "key", i * 2);
@@ -307,11 +294,7 @@ public class SimpleQueryTest extends CQLTester
             for (int t2 = 0; t2 < N; t2++)
                 execute("INSERT INTO %s (k, t1, t2, v) values (?, ?, ?, ?)", "key", t1, t2, "someSemiLargeTextForValue_" + t1 + "_" + t2);
 
-        // flush();
-
         execute("DELETE FROM %s WHERE k=? AND t1=?", "key", 1);
-
-        // flush();
 
         Object[][] expected = new Object[2*N][];
         for (int t2 = 0; t2 < N; t2++)
@@ -340,8 +323,6 @@ public class SimpleQueryTest extends CQLTester
         execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 2, "bar");
         execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key2", 1, "foo");
 
-        flush();
-
         execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key2", 2, "foo");
         execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key2", 3, "bar");
 
@@ -365,13 +346,9 @@ public class SimpleQueryTest extends CQLTester
         execute("INSERT INTO %s (k, t, v, s) values (?, ?, ?, ?)", "key1", 1, "foo1", "st1");
         execute("INSERT INTO %s (k, t, v, s) values (?, ?, ?, ?)", "key1", 2, "foo2", "st2");
 
-        flush();
-
         execute("INSERT INTO %s (k, t, v, s) values (?, ?, ?, ?)", "key1", 3, "foo3", "st3");
         execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 4, "foo4");
         execute("INSERT INTO %s (k, t, v, s) values (?, ?, ?, ?)", "key1", 2, "foo2", "st2-repeat");
-
-        flush();
 
         execute("INSERT INTO %s (k, t, v, s) values (?, ?, ?, ?)", "key1", 5, "foo5", "st5");
         execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 6, "foo6");
@@ -417,8 +394,6 @@ public class SimpleQueryTest extends CQLTester
         execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 1, "foo1");
         execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 2, "foo2");
 
-        flush();
-
         execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key1", 3, "foo3");
         execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key2", 4, "foo4");
         execute("INSERT INTO %s (k, t, v) values (?, ?, ?)", "key2", 5, "foo5");
@@ -435,8 +410,6 @@ public class SimpleQueryTest extends CQLTester
         createTable("CREATE TABLE %s (k int PRIMARY KEY, s set<int>);");
 
         execute("INSERT INTO %s (k, s) VALUES (?, ?)", 1, set(1));
-
-        flush();
 
         execute("INSERT INTO %s (k, s) VALUES (?, ?)", 1, set(2));
 
@@ -497,11 +470,7 @@ public class SimpleQueryTest extends CQLTester
             row(0, 1, 0, 0)
         );
 
-        flush();
-
         execute("DELETE FROM %s WHERE k=? AND c1=?", 0, 1);
-
-        flush();
 
         assertRows(execute("SELECT * FROM %s WHERE v=?", 0),
             row(0, 0, 0, 0)
@@ -557,11 +526,9 @@ public class SimpleQueryTest extends CQLTester
 
         // sstable1
         execute("INSERT INTO %s(k1,v1,v2) VALUES(1,1,1)  USING TIMESTAMP 5");
-        flush();
 
         // sstable2
         execute("INSERT INTO %s(k1,v1,v2) VALUES(1,1,2)  USING TIMESTAMP 8");
-        flush();
 
         execute("INSERT INTO %s(k1) VALUES(1)  USING TIMESTAMP 7");
         execute("DELETE FROM %s USING TIMESTAMP 6 WHERE k1 = 1");


### PR DESCRIPTION
This pull request is for adding SimpleQueryTest suite to Yugabyte-DB's CQL testsuite. I have successfully run the first 7 tests of Cassandra's CQL test suite SimpleQueryTest.java (under Apache license) with Yugabyte-DB. The changes I had to make are as follows:

**SimpleQueryTest.java**  

This is a testsuite with many individual tests. The first 7 tests currently run fine, the rest are commented out for now. Goal was to keep the changes to this file to the minimum so that new individual tests can be run easily. The changes to this file are:

- replaced the inclusion of cassandra package with org.yb.cql
- calls to flush() has been commented out, as I do not know the equivalent in Yugabyte-DB. The flush() in Cassandra's testsuite is a public method of CQLTester base class that calls the ColumnFamilyStore method forceBlockingFlush()

**CQLTester.java**
The class SimpleQueryTest inherits from CQLTester. I modified CQLTester.java (also under Apache license) much more to only include the minimum necessary to successfully compile and run SimpleQueryTest. These modifications were important for  keeping the changes in SimpleQueryTest to be minimum. The CQLTester.java changes are:

- import yugabyte-db relevant classes/package
- made CQLTester a sub-class of BaseCQLTest to pull in yugabyte-db boilerplate
- modified createTable and execute methods to provide the behavior expected by the individual tests in SimpleQueryTest. For example, the individual tests do not hardcode the table name instead it gets generated. During execution of statements (e.g. select, insert) the CQL statement string gets built with the looked up table name
- modified assertRows() methods which is an easy way to verify the rows inserted/deleted match the rows selected. This method required more modifications
- a comparison with Cassandra's CQLTester.java can be used to understand the modifications

Thanks!