### PR TITLE
Change resource defaults for master/tservers

### DIFF
--- a/cloud/kubernetes/helm/yugabyte/values.yaml
+++ b/cloud/kubernetes/helm/yugabyte/values.yaml
@@ -16,11 +16,11 @@ resource:
   master:
     requests:
       cpu: 2
-      memory: 7.5Gi
+      memory: 2Gi
   tserver:
     requests:
       cpu: 2
-      memory: 7.5Gi
+      memory: 4Gi
 
 replicas:
   master: 3


### PR DESCRIPTION
Reduced the default resource requirement for master and tserver pods, 
tested by running 
`helm install yugabyte --namespace yb-demo --name yb-demo --wait`
and validating the pod resource use the new defaults.
