### PR TITLE
Add gflags override option for helm

### DIFF
--- a/cloud/kubernetes/helm/README.md
+++ b/cloud/kubernetes/helm/README.md
@@ -67,6 +67,11 @@ helm install yugabyte --set resource.tserver.requests.cpu=8,resource.tserver.req
 helm install yugabyte --set resource.tserver.limits.cpu=16,resource.tserver.limits.memory=30Gi --namespace yb-demo --name yb-demo --wait
 ```
 
+#### Creating YugaByte cluster with Cassandra authentication enabled.
+```
+helm install yugabyte --set gflags.tserver.use_cassandra_authentication=true --namespace yb-demo --name yb-demo --wait
+```
+
 ### Exposing YugaByte service endpoints using LoadBalancer
 By default YugaByte helm would expose the master ui endpoint alone via LoadBalancer. If you wish to expose yql, yedis services
 via LoadBalancer for your app to use, you could do that in couple of different ways.

--- a/cloud/kubernetes/helm/expose-all.yaml
+++ b/cloud/kubernetes/helm/expose-all.yaml
@@ -16,3 +16,8 @@ serviceEndpoints:
     app: "yb-tserver"
     ports:
       yedis-port: "6379"
+
+gflags:
+  tserver:
+    use_cassandra_authentication: True
+

--- a/cloud/kubernetes/helm/expose-all.yaml
+++ b/cloud/kubernetes/helm/expose-all.yaml
@@ -16,8 +16,3 @@ serviceEndpoints:
     app: "yb-tserver"
     ports:
       yedis-port: "6379"
-
-gflags:
-  tserver:
-    use_cassandra_authentication: True
-

--- a/cloud/kubernetes/helm/yugabyte/templates/service.yaml
+++ b/cloud/kubernetes/helm/yugabyte/templates/service.yaml
@@ -163,13 +163,18 @@ spec:
           - "--server_broadcast_addresses=$(HOSTNAME).yb-masters:7100"
           - "--master_addresses={{range $index := until (int ($root.Values.replicas.master))}}{{if ne $index 0}},{{end}}yb-master-{{ $index }}.yb-masters:7100{{end}}"
           - "--master_replication_factor={{ $root.Values.replicas.master }}"
-          - "--default_memory_limit_to_ram_ratio={{ .memory_limit_to_ram_ratio }}"
+          {{- range $flag, $override := $root.Values.gflags.master }}
+          - "--{{ $flag }}={{ $override }}"
+          {{- end}}
         {{ else }}
           - "/home/yugabyte/bin/yb-tserver"
           - "--fs_data_dirs={{range $index := until (int ($root.Values.persistentVolume.count))}}{{if ne $index 0}},{{end}}/mnt/disk{{ $index }}{{end}}"
           - "--server_broadcast_addresses=$(HOSTNAME).yb-tservers:9100"
           - "--tserver_master_addrs={{range $index := until (int ($root.Values.replicas.master))}}{{if ne $index 0}},{{end}}yb-master-{{ $index }}.yb-masters:7100{{end}}"
           - "--tserver_master_replication_factor={{ $root.Values.replicas.master }}"
+          {{- range $flag, $override := $root.Values.gflags.tserver }}
+          - "--{{ $flag }}={{ $override }}"
+          {{- end}}
         {{ end }}
         ports:
           {{- range $label, $port := .ports }}

--- a/cloud/kubernetes/helm/yugabyte/values.yaml
+++ b/cloud/kubernetes/helm/yugabyte/values.yaml
@@ -30,6 +30,12 @@ partition:
   master: 3
   tserver: 3
 
+gflags:
+  master:
+    default_memory_limit_to_ram_ratio: 0.85
+  tserver:
+    use_cassandra_authentication: False
+
 PodManagementPolicy: Parallel
 
 serviceEndpoints:


### PR DESCRIPTION
Tried to create a YB universe via helm with expose all override yaml. And validated the cassandra authentication was enabled.

`helm install yugabyte -f expose-all.yaml --namespace yb-demo --name yb-demo --wait`