### PR TITLE
Add Metric Node Name to helm chart

### DIFF
--- a/cloud/kubernetes/helm/yugabyte/templates/service.yaml
+++ b/cloud/kubernetes/helm/yugabyte/templates/service.yaml
@@ -163,6 +163,7 @@ spec:
           - "--server_broadcast_addresses=$(HOSTNAME).yb-masters:7100"
           - "--master_addresses={{range $index := until (int ($root.Values.replicas.master))}}{{if ne $index 0}},{{end}}yb-master-{{ $index }}.yb-masters:7100{{end}}"
           - "--master_replication_factor={{ $root.Values.replicas.master }}"
+          - "--metric_node_name=$(HOSTNAME)"
           {{- range $flag, $override := $root.Values.gflags.master }}
           - "--{{ $flag }}={{ $override }}"
           {{- end}}
@@ -172,6 +173,7 @@ spec:
           - "--server_broadcast_addresses=$(HOSTNAME).yb-tservers:9100"
           - "--tserver_master_addrs={{range $index := until (int ($root.Values.replicas.master))}}{{if ne $index 0}},{{end}}yb-master-{{ $index }}.yb-masters:7100{{end}}"
           - "--tserver_master_replication_factor={{ $root.Values.replicas.master }}"
+          - "--metric_node_name=$(HOSTNAME)"
           {{- range $flag, $override := $root.Values.gflags.tserver }}
           - "--{{ $flag }}={{ $override }}"
           {{- end}}


### PR DESCRIPTION
Add metric node name parameter for both master and tserver, this is needed if we want the correct exported_instance name to be populated for prometheus metrics

Tested by bring up a YB cluster
`helm install yugabyte -f expose-all-shared.yaml --namespace yb-demo --name yb-demo --wait`

And in the tserver service expose port 9000 as well. then hit the LB endpoint 
`curl http://<LB IP>:9000/prometheus-metrics`

This PR fixes #586 
