### PR TITLE
Github issue#599 - add universename to host spec and add --logtostderr

### DIFF
--- a/cloud/kubernetes/helm/yugabyte/templates/service.yaml
+++ b/cloud/kubernetes/helm/yugabyte/templates/service.yaml
@@ -71,6 +71,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: "{{ .label }}"
+  namespace: "{{ $root.Release.Namespace }}"
   labels:
     app: "{{ .label }}"
     heritage: {{ $root.Release.Service | quote }}
@@ -159,6 +160,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         resources:
         {{ if eq .name "yb-masters" }}
 {{ toYaml $root.Values.resource.master | indent 10 }}
@@ -176,20 +181,22 @@ spec:
           - "/home/yugabyte/bin/yb-master"
           - "--fs_data_dirs={{range $index := until (int ($root.Values.persistentVolume.count))}}{{if ne $index 0}},{{end}}/mnt/disk{{ $index }}{{end}}"
           - "--rpc_bind_addresses=$(POD_IP)"
-          - "--server_broadcast_addresses=$(HOSTNAME).yb-masters:7100"
-          - "--master_addresses={{range $index := until (int ($root.Values.replicas.master))}}{{if ne $index 0}},{{end}}yb-master-{{ $index }}.yb-masters:7100{{end}}"
+          - "--server_broadcast_addresses=$(HOSTNAME).yb-masters.$(NAMESPACE):7100"
+          - "--master_addresses={{range $index := until (int ($root.Values.replicas.master))}}{{if ne $index 0}},{{end}}yb-master-{{ $index }}.yb-masters.$(NAMESPACE):7100{{end}}"
           - "--master_replication_factor={{ $root.Values.replicas.master }}"
           - "--metric_node_name=$(HOSTNAME)"
+          - "--logtostderr"
           {{- range $flag, $override := $root.Values.gflags.master }}
           - "--{{ $flag }}={{ $override }}"
           {{- end}}
         {{ else }}
           - "/home/yugabyte/bin/yb-tserver"
           - "--fs_data_dirs={{range $index := until (int ($root.Values.persistentVolume.count))}}{{if ne $index 0}},{{end}}/mnt/disk{{ $index }}{{end}}"
-          - "--server_broadcast_addresses=$(HOSTNAME).yb-tservers:9100"
-          - "--tserver_master_addrs={{range $index := until (int ($root.Values.replicas.master))}}{{if ne $index 0}},{{end}}yb-master-{{ $index }}.yb-masters:7100{{end}}"
+          - "--server_broadcast_addresses=$(HOSTNAME).yb-tservers.$(NAMESPACE):9100"
+          - "--tserver_master_addrs={{range $index := until (int ($root.Values.replicas.master))}}{{if ne $index 0}},{{end}}yb-master-{{ $index }}.yb-masters.$(NAMESPACE):7100{{end}}"
           - "--tserver_master_replication_factor={{ $root.Values.replicas.master }}"
           - "--metric_node_name=$(HOSTNAME)"
+          - "--logtostderr"
           {{- range $flag, $override := $root.Values.gflags.tserver }}
           - "--{{ $flag }}={{ $override }}"
           {{- end}}


### PR DESCRIPTION
Added universename to yb-master and yb-tserver master addresses and server_broadcast_addresses. Necessary for multi-universe environments in k8s. Also added --logtostderr flag to enable logging.