### PR TITLE
Adding postgres support to statefulset and helm

### DIFF
--- a/cloud/kubernetes/helm/yugabyte/templates/service.yaml
+++ b/cloud/kubernetes/helm/yugabyte/templates/service.yaml
@@ -193,6 +193,10 @@ spec:
           - "/home/yugabyte/bin/yb-tserver"
           - "--fs_data_dirs={{range $index := until (int ($root.Values.persistentVolume.count))}}{{if ne $index 0}},{{end}}/mnt/disk{{ $index }}{{end}}"
           - "--server_broadcast_addresses=$(HOSTNAME).yb-tservers.$(NAMESPACE):9100"
+          {{ if $root.Values.enablePostgres }}
+          - "--start_pgsql_proxy"
+          - "--pgsql_proxy_bind_address=$(POD_IP):5433"
+          {{ end }}
           - "--tserver_master_addrs={{range $index := until (int ($root.Values.replicas.master))}}{{if ne $index 0}},{{end}}yb-master-{{ $index }}.yb-masters.$(NAMESPACE):7100{{end}}"
           - "--metric_node_name=$(HOSTNAME)"
           - "--memory_limit_hard_bytes={{ template "yugabyte.memory_hard_limit" $root.Values.resource.tserver }}"

--- a/cloud/kubernetes/helm/yugabyte/values.yaml
+++ b/cloud/kubernetes/helm/yugabyte/values.yaml
@@ -44,6 +44,9 @@ gflags:
 
 PodManagementPolicy: Parallel
 
+# Flag to use to enable postgres support on tservers.
+# enablePostgres: false
+
 serviceEndpoints:
   - name: "yb-master-ui"
     type: LoadBalancer

--- a/cloud/kubernetes/yugabyte-statefulset.yaml
+++ b/cloud/kubernetes/yugabyte-statefulset.yaml
@@ -217,6 +217,8 @@ spec:
           - "--fs_data_dirs=/mnt/data0"
           - "--rpc_bind_addresses=$(POD_IP):9100"
           - "--server_broadcast_addresses=$(POD_NAME).yb-tservers:9100"
+          - "--start_pgsql_proxy"
+          - "--pgsql_proxy_bind_address=$(POD_IP):5433"
           - "--use_private_ip=never"
           - "--tserver_master_addrs=yb-masters.default.svc.cluster.local:7100"
           - "--tserver_master_replication_factor=3"

--- a/cloud/kubernetes/yugabyte-statefulset.yaml
+++ b/cloud/kubernetes/yugabyte-statefulset.yaml
@@ -217,8 +217,9 @@ spec:
           - "--fs_data_dirs=/mnt/data0"
           - "--rpc_bind_addresses=$(POD_IP):9100"
           - "--server_broadcast_addresses=$(POD_NAME).yb-tservers:9100"
-          - "--start_pgsql_proxy"
-          - "--pgsql_proxy_bind_address=$(POD_IP):5433"
+          # To support postgres functionality, uncomment the following flags.
+          # - "--start_pgsql_proxy"
+          # - "--pgsql_proxy_bind_address=$(POD_IP):5433"
           - "--use_private_ip=never"
           - "--tserver_master_addrs=yb-masters.default.svc.cluster.local:7100"
           - "--tserver_master_replication_factor=3"


### PR DESCRIPTION
Adding support for enabling postgres in both the stateful set and helm.

For statefulset yml:
- install: `kubectl apply -f yugabyte-statefulset.yaml`
- run initdb: `kubectl exec -it yb-tserver-0 bash --  -c "YB_ENABLED_IN_POSTGRES=1 FLAGS_pggate_master_addresses=yb-master-0.yb-masters.default.svc.cluster.local:7100,yb-master-1.yb-masters.default.svc.cluster.local:7100,yb-master-2.yb-masters.default.svc.cluster.local:7100 /home/yugabyte/postgres/bin/initdb -D /tmp/yb_pg_initdb_tmp_data_dir -U postgres"`
- connect: `kubectl exec -it yb-tserver-0 /home/yugabyte/postgres/bin/psql -- -U postgres -d postgres -h yb-tserver-0 -p 5433`

For helm:
- install: `helm install yugabyte --wait --namespace yb-demo --name yb-demo --set "enablePostgres=true"`
- run initdb: `kubectl exec -it -n yb-demo yb-tserver-0 bash --  -c "YB_ENABLED_IN_POSTGRES=1 FLAGS_pggate_master_addresses=yb-master-0.yb-masters.yb-demo.svc.cluster.local:7100,yb-master-1.yb-masters.yb-demo.svc.cluster.local:7100,yb-master-2.yb-masters.yb-demo.svc.cluster.local:7100 /home/yugabyte/postgres/bin/initdb -D /tmp/yb_pg_initdb_tmp_data_dir -U postgres"`
- connect: `kubectl exec -n yb-demo -it yb-tserver-0 /home/yugabyte/postgres/bin/psql -- -U postgres -d postgres -h yb-tserver-0.yb-tservers.yb-demo -p 5433`