### PR TITLE
#648 Removed gflags for replication factor

### DIFF
--- a/cloud/kubernetes/helm/yugabyte/templates/service.yaml
+++ b/cloud/kubernetes/helm/yugabyte/templates/service.yaml
@@ -182,7 +182,6 @@ spec:
           - "--rpc_bind_addresses=$(POD_IP)"
           - "--server_broadcast_addresses=$(HOSTNAME).yb-masters.$(NAMESPACE):7100"
           - "--master_addresses={{range $index := until (int ($root.Values.replicas.master))}}{{if ne $index 0}},{{end}}yb-master-{{ $index }}.yb-masters.$(NAMESPACE):7100{{end}}"
-          - "--master_replication_factor={{ $root.Values.replicas.master }}"
           - "--metric_node_name=$(HOSTNAME)"
           - "--memory_limit_hard_bytes={{ template "yugabyte.memory_hard_limit" $root.Values.resource.master }}"
           - "--logtostderr"
@@ -200,7 +199,6 @@ spec:
           - "--tserver_master_addrs={{range $index := until (int ($root.Values.replicas.master))}}{{if ne $index 0}},{{end}}yb-master-{{ $index }}.yb-masters.$(NAMESPACE):7100{{end}}"
           - "--metric_node_name=$(HOSTNAME)"
           - "--memory_limit_hard_bytes={{ template "yugabyte.memory_hard_limit" $root.Values.resource.tserver }}"
-          - "--tserver_master_replication_factor=0"
           - "--logtostderr"
           {{- range $flag, $override := $root.Values.gflags.tserver }}
           - "--{{ $flag }}={{ $override }}"


### PR DESCRIPTION
Removing gflags setting the number of masters so that ybase explicitly uses the broadcast addresses to resolve IPs.

Tested by creating a universe and deleting the masters and seeing the new master pod is registered with the other masters. Also tested killing tservers and checking if they respawned correctly and got the balanced tablets.