### PR TITLE
Split the volume claim override for master and tserver

### DIFF
--- a/cloud/kubernetes/helm/README.md
+++ b/cloud/kubernetes/helm/README.md
@@ -72,6 +72,17 @@ helm install yugabyte --set resource.tserver.limits.cpu=16,resource.tserver.limi
 helm install yugabyte --set gflags.tserver.use_cassandra_authentication=true --namespace yb-demo --name yb-demo --wait
 ```
 
+#### Create YugaByte cluster with larger disk.
+The default helm chart brings up a YugaByte DB with 10Gi for master nodes and 10Gi for tserver nodes. You override those defaults as below.
+```
+helm install yugabyte --set storage.tserver.size=100Gi --namespace yb-demo --name yb-demo --wait
+```
+
+#### Create YugaByte cluster with different storage class.
+```
+helm install yugabyte --set storage.tserver.storageClass=custom-storage,storage.master.storageClass=custom-storage --namespace yb-demo --name yb-demo --wait
+```
+
 ### Exposing YugaByte service endpoints using LoadBalancer
 By default YugaByte helm would expose the master ui endpoint alone via LoadBalancer. If you wish to expose yql, yedis services
 via LoadBalancer for your app to use, you could do that in couple of different ways.

--- a/cloud/kubernetes/helm/yugabyte/templates/service.yaml
+++ b/cloud/kubernetes/helm/yugabyte/templates/service.yaml
@@ -87,7 +87,8 @@ spec:
   replicas: {{ $root.Values.replicas.tserver  }}
   {{ end }}
   volumeClaimTemplates:
-    {{- range $index := until (int ($root.Values.persistentVolume.count )) }}
+    {{- $storageInfo := (eq .name "yb-masters") | ternary $root.Values.storage.master $root.Values.storage.tserver -}}
+    {{- range $index := until (int ($storageInfo.count )) }}
     - metadata:
         name: datadir{{ $index }}
         labels:
@@ -98,12 +99,12 @@ spec:
       spec:
         accessModes:
           - "ReadWriteOnce"
-        {{- if $root.Values.persistentVolume.storageClass }}
-        storageClassName: {{ $root.Values.persistentVolume.storageClass }}
+        {{- if $storageInfo.storageClass }}
+        storageClassName: {{ $storageInfo.storageClass }}
         {{- end }}
         resources:
           requests:
-            storage: {{ $root.Values.persistentVolume.storage }}
+            storage: {{ $storageInfo.size }}
     {{- end }}
   updateStrategy:
     type: RollingUpdate
@@ -178,7 +179,7 @@ spec:
         command:
         {{ if eq .name "yb-masters" }}
           - "/home/yugabyte/bin/yb-master"
-          - "--fs_data_dirs={{range $index := until (int ($root.Values.persistentVolume.count))}}{{if ne $index 0}},{{end}}/mnt/disk{{ $index }}{{end}}"
+          - "--fs_data_dirs={{range $index := until (int ($storageInfo.count))}}{{if ne $index 0}},{{end}}/mnt/disk{{ $index }}{{end}}"
           - "--rpc_bind_addresses=$(POD_IP)"
           - "--server_broadcast_addresses=$(HOSTNAME).yb-masters.$(NAMESPACE):7100"
           - "--master_addresses={{range $index := until (int ($root.Values.replicas.master))}}{{if ne $index 0}},{{end}}yb-master-{{ $index }}.yb-masters.$(NAMESPACE):7100{{end}}"
@@ -190,7 +191,7 @@ spec:
           {{- end}}
         {{ else }}
           - "/home/yugabyte/bin/yb-tserver"
-          - "--fs_data_dirs={{range $index := until (int ($root.Values.persistentVolume.count))}}{{if ne $index 0}},{{end}}/mnt/disk{{ $index }}{{end}}"
+          - "--fs_data_dirs={{range $index := until (int ($storageInfo.count))}}{{if ne $index 0}},{{end}}/mnt/disk{{ $index }}{{end}}"
           - "--server_broadcast_addresses=$(HOSTNAME).yb-tservers.$(NAMESPACE):9100"
           {{ if $root.Values.enablePostgres }}
           - "--start_pgsql_proxy"
@@ -210,12 +211,12 @@ spec:
             name: {{ $label | quote }}
           {{- end}}
         volumeMounts:
-          {{- range $index := until (int ($root.Values.persistentVolume.count)) }}
+          {{- range $index := until (int ($storageInfo.count)) }}
           - name: datadir{{ $index }}
             mountPath: /mnt/disk{{ $index }}
           {{- end }}
       volumes:
-        {{- range $index := until (int ($root.Values.persistentVolume.count)) }}
+        {{- range $index := until (int ($storageInfo.count)) }}
         - name: datadir{{ $index }}
           hostPath:
             path: /mnt/disks/ssd{{ $index }}

--- a/cloud/kubernetes/helm/yugabyte/values.yaml
+++ b/cloud/kubernetes/helm/yugabyte/values.yaml
@@ -7,10 +7,15 @@ Image:
   tag: latest
   pullPolicy: IfNotPresent
 
-persistentVolume:
-  count: 2
-  storage: 10Gi
-  storageClass: standard
+storage:
+  master:
+    count: 2
+    size: 10Gi
+    storageClass: standard
+  tserver:
+    count: 3
+    size: 10Gi
+    storageClass: standard
 
 resource:
   master:
@@ -19,7 +24,7 @@ resource:
       memory: 2Gi
     limits:
       cpu: 2
-      memory: 2Gi 
+      memory: 2Gi
   tserver:
     requests:
       cpu: 2

--- a/cloud/kubernetes/helm/yugabyte/values.yaml
+++ b/cloud/kubernetes/helm/yugabyte/values.yaml
@@ -13,7 +13,7 @@ storage:
     size: 10Gi
     storageClass: standard
   tserver:
-    count: 3
+    count: 2
     size: 10Gi
     storageClass: standard
 


### PR DESCRIPTION
Make the volume claim to be overridable at master and tserver separately

Tested by overriding the default storage size for tserver and the storage count for master.
```
helm install yugabyte --set "storage.tserver.size=30Gi,storage.master.count=1" --namespace yb-demo --name yb-demo --wait
```
Tested by launch cluster with defaults.
```
helm install yugabyte --namespace yb-demo --name yb-demo --wait
```
fixes #678 