### PR TITLE
#840 Create table fails on an helm created cluster with 1 master replica.

### DIFF
--- a/cloud/kubernetes/helm/yugabyte/templates/service.yaml
+++ b/cloud/kubernetes/helm/yugabyte/templates/service.yaml
@@ -185,6 +185,7 @@ spec:
           - "--rpc_bind_addresses=$(POD_IP)"
           - "--server_broadcast_addresses=$(HOSTNAME).yb-masters.$(NAMESPACE):7100"
           - "--master_addresses={{range $index := until (int ($root.Values.replicas.master))}}{{if ne $index 0}},{{end}}yb-master-{{ $index }}.yb-masters.$(NAMESPACE):7100{{end}}"
+          - "--replication_factor={{ $root.Values.replicas.master }}"
           - "--metric_node_name=$(HOSTNAME)"
           - "--memory_limit_hard_bytes={{ template "yugabyte.memory_hard_limit" $root.Values.resource.master }}"
           - "--stderrthreshold=0"


### PR DESCRIPTION
Fix RF=1 case to not hit table creation errors complaining about RF being 3 (as that is the default) by always passing in the `replication_factor` parameter to master startup.

Tested via:
```
$ helm install --name yb-iot-test --set replicas.master=1,replicas.tserver=1 . --wait
$ kubectl exec -it yb-tserver-0 /home/yugabyte/bin/cqlsh
cqlsh> CREATE KEYSPACE IF NOT EXISTS TrafficKeySpace;
cqlsh> CREATE TABLE IF NOT EXISTS TrafficKeySpace.Poi_Traffic(vehicleid text, vehicletype text, distance bigint, timeStamp timestamp, PRIMARY KEY (vehicleid));
```