### PR TITLE
Added enableYsql alias for enablePostgres

### DIFF
--- a/cloud/kubernetes/helm/yugabyte/templates/service.yaml
+++ b/cloud/kubernetes/helm/yugabyte/templates/service.yaml
@@ -230,7 +230,7 @@ spec:
           - "--server_broadcast_addresses=$(HOSTNAME).yb-tservers.$(NAMESPACE):9100"
           - "--rpc_bind_addresses=$(HOSTNAME).yb-tservers.$(NAMESPACE).svc.cluster.local"
           - "--cql_proxy_bind_address=$(HOSTNAME).yb-tservers.$(NAMESPACE).svc.cluster.local"
-          {{ if $root.Values.enablePostgres }}
+          {{ if or $root.Values.enableYsql $root.Values.enablePostgres }}
           - "--start_pgsql_proxy"
           - "--pgsql_proxy_bind_address=$(POD_IP):5433"
           {{ end }}

--- a/cloud/kubernetes/helm/yugabyte/values.yaml
+++ b/cloud/kubernetes/helm/yugabyte/values.yaml
@@ -55,8 +55,8 @@ gflags:
 
 PodManagementPolicy: Parallel
 
-# Flag to use to enable postgres support on tservers.
-# enablePostgres: false
+# Flag to use to enable YSQL postgres support on tservers.
+# enableYsql: true
 
 enableLoadBalancer: True
 

--- a/cloud/kubernetes/yugabyte-statefulset.yaml
+++ b/cloud/kubernetes/yugabyte-statefulset.yaml
@@ -217,7 +217,7 @@ spec:
           - "--fs_data_dirs=/mnt/data0"
           - "--rpc_bind_addresses=$(POD_IP):9100"
           - "--server_broadcast_addresses=$(POD_NAME).yb-tservers:9100"
-          # To support postgres functionality, uncomment the following flags.
+          # To support YSQL postgres functionality, uncomment the following flags.
           # - "--start_pgsql_proxy"
           # - "--pgsql_proxy_bind_address=$(POD_IP):5433"
           - "--use_private_ip=never"


### PR DESCRIPTION
Added enableYsql alias
For helm:

- install: `helm install yugabyte --wait --namespace yb-demo --name yb-demo --set "enableYsql=true"`

- run initdb: `kubectl exec -it -n yb-demo yb-tserver-0 bash --  -c "YB_ENABLED_IN_POSTGRES=1 FLAGS_pggate_master_addresses=yb-master-0.yb-masters.yb-demo.svc.cluster.local:7100,yb-master-1.yb-masters.yb-demo.svc.cluster.local:7100,yb-master-2.yb-masters.yb-demo.svc.cluster.local:7100 /home/yugabyte/postgres/bin/initdb -D /tmp/yb_pg_initdb_tmp_data_dir -U postgres"`

- connect: `kubectl exec -n yb-demo -it yb-tserver-0 /home/yugabyte/postgres/bin/psql -- -U postgres -d postgres -h yb-tserver-0.yb-tservers.yb-demo -p 5433`

- Also, tested the above with --set "enablePostgres=true"

For statefulset yaml:

- install: `kubectl apply -f yugabyte-statefulset.yaml`

- run initdb: `kubectl exec -it yb-tserver-0 bash --  -c "YB_ENABLED_IN_POSTGRES=1 FLAGS_pggate_master_addresses=yb-master-0.yb-masters.default.svc.cluster.local:7100,yb-master-1.yb-masters.default.svc.cluster.local:7100,yb-master-2.yb-masters.default.svc.cluster.local:7100 /home/yugabyte/postgres/bin/initdb -D /tmp/yb_pg_initdb_tmp_data_dir -U postgres"`

- connect: `kubectl exec -it yb-tserver-0 /home/yugabyte/postgres/bin/psql -- -U postgres -d postgres -h yb-tserver-0 -p 5433`

