### PR TITLE
Helm add domain

### DIFF
--- a/cloud/kubernetes/helm/yugabyte/templates/NOTES.txt
+++ b/cloud/kubernetes/helm/yugabyte/templates/NOTES.txt
@@ -11,7 +11,7 @@
   kubectl exec --namespace {{ .Release.Namespace }} -it yb-tserver-0 bash
 
 5. Run CQL shell from inside of a tablet server:
-  kubectl exec --namespace {{ .Release.Namespace }} -it yb-tserver-0 bin/cqlsh
+  kubectl exec --namespace {{ .Release.Namespace }} -it yb-tserver-0 bin/cqlsh yb-tserver-0
 
 6. Cleanup YugaByte Pods
   helm delete {{ .Release.Name }} --purge

--- a/cloud/kubernetes/helm/yugabyte/templates/_helpers.tpl
+++ b/cloud/kubernetes/helm/yugabyte/templates/_helpers.tpl
@@ -50,7 +50,13 @@ Create chart name and version as used by the chart label.
   Get YugaByte master addresses
 */}}
 {{- define "yugabyte.master_addresses" -}}
-{{range $index := until (int (.Values.replicas.master))}}{{if ne $index 0}},{{end}}yb-master-{{ $index }}.yb-masters.$(NAMESPACE):7100{{end}}
+{{- $master_replicas := .Values.replicas.master | int -}}
+  {{- range .Values.Services }}
+    {{- if eq .name "yb-masters" }}
+      {{- $domain_name := .domainName -}}
+      {{range $index := until $master_replicas }}{{if ne $index 0}},{{end}}yb-master-{{ $index }}.yb-masters.$(NAMESPACE).svc.{{ $domain_name }}:7100{{end}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}
 
 {{/*

--- a/cloud/kubernetes/helm/yugabyte/templates/_helpers.tpl
+++ b/cloud/kubernetes/helm/yugabyte/templates/_helpers.tpl
@@ -38,3 +38,9 @@ Create chart name and version as used by the chart label.
 {{- define "yugabyte.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+*/}}
+{{- define "yugabyte.server_addr" -}}
+{{- printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" . -}}
+{{- end -}}

--- a/cloud/kubernetes/helm/yugabyte/templates/_helpers.tpl
+++ b/cloud/kubernetes/helm/yugabyte/templates/_helpers.tpl
@@ -40,7 +40,22 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+  Get YugaByte fs data directories
 */}}
-{{- define "yugabyte.server_addr" -}}
-{{- printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" . -}}
+{{- define "yugabyte.fs_data_dirs" -}}
+{{range $index := until (int (.count))}}{{if ne $index 0}},{{end}}/mnt/disk{{ $index }}{{end}}
+{{- end -}}
+
+{{/*
+  Get YugaByte master addresses
+*/}}
+{{- define "yugabyte.master_addresses" -}}
+{{range $index := until (int (.Values.replicas.master))}}{{if ne $index 0}},{{end}}yb-master-{{ $index }}.yb-masters.$(NAMESPACE):7100{{end}}
+{{- end -}}
+
+{{/*
+Get the fully qualified server address
+*/}}
+{{- define "yugabyte.server_address" -}}
+{{- printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name .domainName }}
 {{- end -}}

--- a/cloud/kubernetes/helm/yugabyte/templates/service.yaml
+++ b/cloud/kubernetes/helm/yugabyte/templates/service.yaml
@@ -21,9 +21,9 @@ data:
 {{- $rootCA := buildCustomCert $root.Values.tls.rootCA.cert $root.Values.tls.rootCA.key -}}
 {{- $replicas := (eq .name "yb-masters") | ternary $root.Values.replicas.master $root.Values.replicas.tserver -}}
 {{- range $index := until ( int ( $replicas ) ) }}
-{{- $node := printf "%s-%d.%s.%s.svc.cluster.local" $service.label $index $service.name $root.Release.Namespace }}
+{{- $node := printf "%s-%d.%s.%s.svc.($root.domainName)" $service.label $index $service.name $root.Release.Namespace }}
 {{- $dns1 := printf "*.*.%s" $root.Release.Namespace }}
-{{- $dns2 := printf "%s.svc.cluster.local" $dns1 }}
+{{- $dns2 := printf "%s.svc.($root.domainName)" $dns1 }}
 {{- $server := genSignedCert $node ( default nil ) (list $dns1 $dns2 ) 3650 $rootCA }}
   node.{{$node}}.crt: {{ $server.Cert | b64enc }}
   node.{{$node}}.key: {{ $server.Key | b64enc }}
@@ -210,7 +210,7 @@ spec:
         {{ if eq .name "yb-masters" }}
           - "/home/yugabyte/bin/yb-master"
           - "--fs_data_dirs={{range $index := until (int ($storageInfo.count))}}{{if ne $index 0}},{{end}}/mnt/disk{{ $index }}{{end}}"
-          - "--rpc_bind_addresses=$(HOSTNAME).yb-masters.$(NAMESPACE).svc.cluster.local"
+          - "--rpc_bind_addresses=$(HOSTNAME).yb-masters.$(NAMESPACE).svc.($root.domainName)"
           - "--server_broadcast_addresses=$(HOSTNAME).yb-masters.$(NAMESPACE):7100"
           - "--master_addresses={{range $index := until (int ($root.Values.replicas.master))}}{{if ne $index 0}},{{end}}yb-master-{{ $index }}.yb-masters.$(NAMESPACE):7100{{end}}"
           - "--replication_factor={{ $root.Values.replicas.master }}"
@@ -227,10 +227,11 @@ spec:
           {{- end }}
         {{ else }}
           - "/home/yugabyte/bin/yb-tserver"
+          - "--foo={{ template "yugabyte.server_addr" | .name | $root.domainName ) }}"
           - "--fs_data_dirs={{range $index := until (int ($storageInfo.count))}}{{if ne $index 0}},{{end}}/mnt/disk{{ $index }}{{end}}"
           - "--server_broadcast_addresses=$(HOSTNAME).yb-tservers.$(NAMESPACE):9100"
-          - "--rpc_bind_addresses=$(HOSTNAME).yb-tservers.$(NAMESPACE).svc.cluster.local"
-          - "--cql_proxy_bind_address=$(HOSTNAME).yb-tservers.$(NAMESPACE).svc.cluster.local"
+          - "--rpc_bind_addresses=$(HOSTNAME).yb-tservers.$(NAMESPACE).svc.($root.domainName)"
+          - "--cql_proxy_bind_address=$(HOSTNAME).yb-tservers.$(NAMESPACE).svc.($root.domainName)"
           {{ if or $root.Values.enableYsql $root.Values.enablePostgres }}
           - "--start_pgsql_proxy"
           - "--pgsql_proxy_bind_address=$(POD_IP):5433"

--- a/cloud/kubernetes/helm/yugabyte/templates/service.yaml
+++ b/cloud/kubernetes/helm/yugabyte/templates/service.yaml
@@ -21,9 +21,9 @@ data:
 {{- $rootCA := buildCustomCert $root.Values.tls.rootCA.cert $root.Values.tls.rootCA.key -}}
 {{- $replicas := (eq .name "yb-masters") | ternary $root.Values.replicas.master $root.Values.replicas.tserver -}}
 {{- range $index := until ( int ( $replicas ) ) }}
-{{- $node := printf "%s-%d.%s.%s.svc.($root.domainName)" $service.label $index $service.name $root.Release.Namespace }}
+{{- $node := printf "%s-%d.%s.%s.svc.%s" $service.label $index $service.name $root.Release.Namespace $service.domainName }}
 {{- $dns1 := printf "*.*.%s" $root.Release.Namespace }}
-{{- $dns2 := printf "%s.svc.($root.domainName)" $dns1 }}
+{{- $dns2 := printf "%s.svc.%s" $dns1 $service.domainName }}
 {{- $server := genSignedCert $node ( default nil ) (list $dns1 $dns2 ) 3650 $rootCA }}
   node.{{$node}}.crt: {{ $server.Cert | b64enc }}
   node.{{$node}}.key: {{ $server.Key | b64enc }}
@@ -209,10 +209,10 @@ spec:
         command:
         {{ if eq .name "yb-masters" }}
           - "/home/yugabyte/bin/yb-master"
-          - "--fs_data_dirs={{range $index := until (int ($storageInfo.count))}}{{if ne $index 0}},{{end}}/mnt/disk{{ $index }}{{end}}"
-          - "--rpc_bind_addresses=$(HOSTNAME).yb-masters.$(NAMESPACE).svc.($root.domainName)"
-          - "--server_broadcast_addresses=$(HOSTNAME).yb-masters.$(NAMESPACE):7100"
-          - "--master_addresses={{range $index := until (int ($root.Values.replicas.master))}}{{if ne $index 0}},{{end}}yb-master-{{ $index }}.yb-masters.$(NAMESPACE):7100{{end}}"
+          - "--fs_data_dirs={{ template "yugabyte.fs_data_dirs" $storageInfo }}"
+          - "--rpc_bind_addresses={{ template "yugabyte.server_address" . }}"
+          - "--server_broadcast_addresses={{ template "yugabyte.server_address" . }}:7100"
+          - "--master_addresses={{ template "yugabyte.master_addresses" $root }}"
           - "--replication_factor={{ $root.Values.replicas.master }}"
           - "--metric_node_name=$(HOSTNAME)"
           - "--memory_limit_hard_bytes={{ template "yugabyte.memory_hard_limit" $root.Values.resource.master }}"
@@ -227,16 +227,15 @@ spec:
           {{- end }}
         {{ else }}
           - "/home/yugabyte/bin/yb-tserver"
-          - "--foo={{ template "yugabyte.server_addr" | .name | $root.domainName ) }}"
-          - "--fs_data_dirs={{range $index := until (int ($storageInfo.count))}}{{if ne $index 0}},{{end}}/mnt/disk{{ $index }}{{end}}"
-          - "--server_broadcast_addresses=$(HOSTNAME).yb-tservers.$(NAMESPACE):9100"
-          - "--rpc_bind_addresses=$(HOSTNAME).yb-tservers.$(NAMESPACE).svc.($root.domainName)"
-          - "--cql_proxy_bind_address=$(HOSTNAME).yb-tservers.$(NAMESPACE).svc.($root.domainName)"
+          - "--fs_data_dirs={{ template "yugabyte.fs_data_dirs" $storageInfo }}"
+          - "--server_broadcast_addresses={{ template "yugabyte.server_address" . }}:9100"
+          - "--rpc_bind_addresses={{ template "yugabyte.server_address" . }}"
+          - "--cql_proxy_bind_address={{ template "yugabyte.server_address" . }}"
           {{ if or $root.Values.enableYsql $root.Values.enablePostgres }}
           - "--start_pgsql_proxy"
-          - "--pgsql_proxy_bind_address=$(POD_IP):5433"
+          - "--pgsql_proxy_bind_address={{ template "yugabyte.server_address" . }}:5433"
           {{ end }}
-          - "--tserver_master_addrs={{range $index := until (int ($root.Values.replicas.master))}}{{if ne $index 0}},{{end}}yb-master-{{ $index }}.yb-masters.$(NAMESPACE):7100{{end}}"
+          - "--tserver_master_addrs={{ template "yugabyte.master_addresses" $root }}"
           - "--metric_node_name=$(HOSTNAME)"
           - "--memory_limit_hard_bytes={{ template "yugabyte.memory_hard_limit" $root.Values.resource.tserver }}"
           - "--stderrthreshold=0"

--- a/cloud/kubernetes/helm/yugabyte/values.yaml
+++ b/cloud/kubernetes/helm/yugabyte/values.yaml
@@ -59,6 +59,7 @@ PodManagementPolicy: Parallel
 # enableYsql: true
 
 enableLoadBalancer: True
+domainName: "cluster.local"
 
 serviceEndpoints:
   - name: "yb-master-ui"

--- a/cloud/kubernetes/helm/yugabyte/values.yaml
+++ b/cloud/kubernetes/helm/yugabyte/values.yaml
@@ -59,7 +59,6 @@ PodManagementPolicy: Parallel
 # enableYsql: true
 
 enableLoadBalancer: True
-domainName: "cluster.local"
 
 serviceEndpoints:
   - name: "yb-master-ui"
@@ -71,6 +70,7 @@ serviceEndpoints:
 Services:
   - name: "yb-masters"
     label: "yb-master"
+    domainName: "cluster.local"
     memory_limit_to_ram_ratio: 0.85
     ports:
       ui: "7000"
@@ -78,6 +78,7 @@ Services:
 
   - name: "yb-tservers"
     label: "yb-tserver"
+    domainName: "cluster.local"
     ports:
       ui: "9000"
       rpc-port: "7100"


### PR DESCRIPTION
- Added an override param `domainName` at each of the service level. 
- Moved some common code into the _helpers.tpl file and use template calls

Tested by bring up a TLS enabled cluster.

`helm install yugabyte --namespace yb-demo --name yb-demo --set=tls.enabled=true --set=Image.repository=quay.io/yugabyte/yugabyte --set=Image.pullSecretName=yugabyte-k8s-pull-secret --wait`

Also tested by bring up non TLS enabled cluster.
`helm install yugabyte --namespace yb-demo --name yb-demo --set=Image.repository=quay.io/yugabyte/yugabyte --set=Image.pullSecretName=yugabyte-k8s-pull-secret --wait`

fixes #883 