### PR TITLE
Enable YSQL by default and add yaml for replication factor 1

### DIFF
--- a/cloud/kubernetes/helm/expose-all-shared.yaml
+++ b/cloud/kubernetes/helm/expose-all-shared.yaml
@@ -11,3 +11,4 @@ serviceEndpoints:
     ports:
       yql-port: "9042"
       yedis-port: "6379"
+      ysql-port: "5433"

--- a/cloud/kubernetes/helm/expose-all.yaml
+++ b/cloud/kubernetes/helm/expose-all.yaml
@@ -16,3 +16,9 @@ serviceEndpoints:
     app: "yb-tserver"
     ports:
       yedis-port: "6379"
+
+  - name: "ysql-service"
+    type: LoadBalancer
+    app: "yb-tserver"
+    ports:
+      ysql-port: "5433"

--- a/cloud/kubernetes/helm/yugabyte/templates/service.yaml
+++ b/cloud/kubernetes/helm/yugabyte/templates/service.yaml
@@ -231,7 +231,7 @@ spec:
           - "--server_broadcast_addresses={{ template "yugabyte.server_address" . }}:9100"
           - "--rpc_bind_addresses={{ template "yugabyte.server_address" . }}"
           - "--cql_proxy_bind_address={{ template "yugabyte.server_address" . }}"
-          {{ if or $root.Values.enableYsql $root.Values.enablePostgres }}
+          {{ if not $root.Values.disableYsql }}
           - "--start_pgsql_proxy"
           - "--pgsql_proxy_bind_address={{ template "yugabyte.server_address" . }}:5433"
           {{ end }}

--- a/cloud/kubernetes/helm/yugabyte/values.yaml
+++ b/cloud/kubernetes/helm/yugabyte/values.yaml
@@ -55,8 +55,8 @@ gflags:
 
 PodManagementPolicy: Parallel
 
-# Flag to use to enable YSQL postgres support on tservers.
-# enableYsql: true
+# Flag to use to disable YugaByte SQL support on tservers.
+# disableYsql: true
 
 enableLoadBalancer: True
 
@@ -84,6 +84,7 @@ Services:
       rpc-port: "7100"
       yql-port: "9042"
       yedis-port: "6379"
+      ysql-port: "5433"
 
 resources: {}
 

--- a/cloud/kubernetes/yugabyte-statefulset-rf-1.yaml
+++ b/cloud/kubernetes/yugabyte-statefulset-rf-1.yaml
@@ -15,9 +15,7 @@
 #    - Run psql          :
 #      - Init Postgres DB: kubectl exec -it yb-tserver-0 bash -- -c "YB_ENABLED_IN_POSTGRES=1
 #                             FLAGS_pggate_master_addresses=
-#                             yb-master-0.yb-masters.default.svc.cluster.local:7100,
-#                             yb-master-1.yb-masters.default.svc.cluster.local:7100,
-#                             yb-master-2.yb-masters.default.svc.cluster.local:7100
+#                             yb-master-0.yb-masters.default.svc.cluster.local:7100
 #                             /home/yugabyte/postgres/bin/initdb
 #                             -D /tmp/yb_pg_initdb_tmp_data_dir -U postgres"
 #      - Run psql        : kubectl exec -it yb-tserver-0 /home/yugabyte/postgres/bin/psql --
@@ -70,7 +68,7 @@ metadata:
 spec:
   serviceName: yb-masters
   podManagementPolicy: "Parallel"
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app: yb-master
@@ -114,7 +112,8 @@ spec:
           - "--server_broadcast_addresses=$(POD_NAME).yb-masters:7100"
           - "--use_private_ip=never"
           - "--master_addresses=yb-masters.default.svc.cluster.local:7100"
-          - "--master_replication_factor=3"
+          - "--master_replication_factor=1"
+          - "--replication_factor=1"
           - "--logtostderr"
         ports:
         - containerPort: 7000
@@ -187,7 +186,7 @@ metadata:
 spec:
   serviceName: yb-tservers
   podManagementPolicy: "Parallel"
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app: yb-tserver
@@ -234,7 +233,7 @@ spec:
           - "--pgsql_proxy_bind_address=$(POD_IP):5433"
           - "--use_private_ip=never"
           - "--tserver_master_addrs=yb-masters.default.svc.cluster.local:7100"
-          - "--tserver_master_replication_factor=3"
+          - "--tserver_master_replication_factor=1"
           - "--logtostderr"
         ports:
         - containerPort: 9000


### PR DESCRIPTION
Changes include:
1. Enable YSQL by default.
2. Added yaml for replication factor 1.

Testing:
For helm:
install: `helm install yugabyte --wait --namespace yb-demo --name yb-demo`

run initdb: `kubectl exec -it -n yb-demo yb-tserver-0 bash -- -c "YB_ENABLED_IN_POSTGRES=1 FLAGS_pggate_master_addresses=yb-master-0.yb-masters.yb-demo.svc.cluster.local:7100 /home/yugabyte/postgres/bin/initdb -D /tmp/yb_pg_initdb_tmp_data_dir -U postgres"`

connect: `kubectl exec -n yb-demo -it yb-tserver-0 /home/yugabyte/postgres/bin/psql -- -U postgres -d postgres -h yb-tserver-0.yb-tservers.yb-demo -p 5433`

Also, tested the above with --set "disableYsql=true"

For statefulset yaml:

install: `kubectl apply -f yugabyte-statefulset-rf-1.yaml`

run initdb: `kubectl exec -it yb-tserver-0 bash -- -c "YB_ENABLED_IN_POSTGRES=1 FLAGS_pggate_master_addresses=yb-master-0.yb-masters.default.svc.cluster.local:7100 /home/yugabyte/postgres/bin/initdb -D /tmp/yb_pg_initdb_tmp_data_dir -U postgres"`

connect: `kubectl exec -it yb-tserver-0 /home/yugabyte/postgres/bin/psql -- -U postgres -d postgres -h yb-tserver-0 -p 5433`