### PR TITLE
Added initdb support in helm

### DIFF
--- a/cloud/kubernetes/helm/yugabyte/templates/_helpers.tpl
+++ b/cloud/kubernetes/helm/yugabyte/templates/_helpers.tpl
@@ -60,6 +60,19 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+  Get YugaByte master addresses for PostStart
+*/}}
+{{- define "yugabyte.master_addresses_ps" -}}
+{{- $master_replicas := .Values.replicas.master | int -}}
+  {{- range .Values.Services }}
+    {{- if eq .name "yb-masters" }}
+      {{- $domain_name := .domainName -}}
+      {{range $index := until $master_replicas }}{{if ne $index 0}},{{end}}yb-master-{{ $index }}.yb-masters.$NAMESPACE.svc.{{ $domain_name }}:7100{{end}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Get the fully qualified server address
 */}}
 {{- define "yugabyte.server_address" -}}

--- a/cloud/kubernetes/helm/yugabyte/templates/service.yaml
+++ b/cloud/kubernetes/helm/yugabyte/templates/service.yaml
@@ -180,6 +180,22 @@ spec:
       containers:
       - name: "{{ .label }}"
         image: "{{ $root.Values.Image.repository }}:{{ $root.Values.Image.tag }}"
+        {{ if $root.Values.initDb}}
+        {{ if eq .name "yb-tservers" }}
+        lifecycle:
+          postStart:
+            exec:
+              command:
+                - "sh"
+                - "-c"
+                - >
+                  if [ "$HOSTNAME" == "yb-tserver-0" ]; then
+                  while ! ./bin/yb-admin -master_addresses {{ template "yugabyte.master_addresses_ps" $root }} list_all_masters | grep -q "LEADER"; do true; done;
+                  YB_ENABLED_IN_POSTGRES=1 FLAGS_pggate_master_addresses={{ template "yugabyte.master_addresses_ps" $root }} /home/yugabyte/tserver/postgres/bin/initdb -D /tmp/yb_pg_initdb_tmp_data_dir -U postgres > /tmp/initdb.log;
+                  ./bin/yb-admin -master_addresses {{ template "yugabyte.master_addresses_ps" $root }} setup_redis_table;
+                  fi
+        {{ end }}
+        {{ end }}
         imagePullPolicy: {{ $root.Values.Image.pullPolicy }}
         env:
         - name: POD_IP

--- a/cloud/kubernetes/helm/yugabyte/templates/service.yaml
+++ b/cloud/kubernetes/helm/yugabyte/templates/service.yaml
@@ -189,10 +189,12 @@ spec:
                 - "sh"
                 - "-c"
                 - >
+                  if ! ./bin/yb-admin -master_addresses {{ template "yugabyte.master_addresses_ps" $root }} list_tables | grep -q "postgres.pg_enum"; then
                   if [ "$HOSTNAME" == "yb-tserver-0" ]; then
                   while ! ./bin/yb-admin -master_addresses {{ template "yugabyte.master_addresses_ps" $root }} list_all_masters | grep -q "LEADER"; do true; done;
                   YB_ENABLED_IN_POSTGRES=1 FLAGS_pggate_master_addresses={{ template "yugabyte.master_addresses_ps" $root }} /home/yugabyte/tserver/postgres/bin/initdb -D /tmp/yb_pg_initdb_tmp_data_dir -U postgres > /tmp/initdb.log;
                   ./bin/yb-admin -master_addresses {{ template "yugabyte.master_addresses_ps" $root }} setup_redis_table;
+                  fi;
                   fi
         {{ end }}
         {{ end }}

--- a/cloud/kubernetes/helm/yugabyte/values.yaml
+++ b/cloud/kubernetes/helm/yugabyte/values.yaml
@@ -58,6 +58,8 @@ PodManagementPolicy: Parallel
 # Flag to use to disable YugaByte SQL support on tservers.
 # disableYsql: true
 
+initDb: False
+
 enableLoadBalancer: True
 
 serviceEndpoints:


### PR DESCRIPTION
Updated helm chart to add ability to initialize redis and postgres if required by the user. Verified by running the following helm install command:
`helm install yugabyte --namespace yb-demo --name yb-demo --set initDb=True --wait`