### PR TITLE
Added support for Network annotations for the Statefulset deployements.

### DIFF
--- a/cloud/kubernetes/helm/yugabyte/templates/service.yaml
+++ b/cloud/kubernetes/helm/yugabyte/templates/service.yaml
@@ -61,7 +61,7 @@ kind: Service
 metadata:
   name: "{{ $endpoint.name }}"
   annotations:
-    {{ toYaml $endpoint.annotations | indent 4 }}
+{{ toYaml $endpoint.annotations | indent 4 }}
   labels:
     app: "{{ $endpoint.app }}"
     heritage: {{ $root.Release.Service | quote }}
@@ -137,16 +137,16 @@ spec:
       app: "{{ .label }}"
   template:
     metadata:
+      {{ if $root.Values.networkAnnotation }}
+      annotations:
+{{ toYaml $root.Values.networkAnnotation | indent 8}}
+      {{ end }}
       labels:
         app: "{{ .label }}"
         heritage: {{ $root.Release.Service | quote }}
         release: {{ $root.Release.Name | quote }}
         chart: "{{ $root.Chart.Name }}-{{ $root.Chart.Version }}"
         component: "{{ $root.Values.Component }}"
-      {{- if $root.Values.networkAnnotation }}
-      annotations:
-        {{ toYaml $root.Values.networkAnnotation | indent 8 }}
-      {{- end }}
     spec:
       {{- if $root.Values.Image.pullSecretName }}
       imagePullSecrets:

--- a/cloud/kubernetes/helm/yugabyte/templates/service.yaml
+++ b/cloud/kubernetes/helm/yugabyte/templates/service.yaml
@@ -60,22 +60,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ $endpoint.name }}"
-{{- if $root.Values.annotations }}
   annotations:
-  {{ if eq .name "yb-master-service" }}
-    {{- if $root.Values.annotations.master }}
-    {{- if $root.Values.annotations.master.loadbalancer }}
-{{ toYaml $root.Values.annotations.master.loadbalancer | indent 4 }}
-    {{- end}}
-    {{- end}}
-  {{ else }}
-    {{- if $root.Values.annotations.tserver }}
-    {{- if $root.Values.annotations.tserver.loadbalancer }}
-{{ toYaml $root.Values.annotations.tserver.loadbalancer | indent 4 }}
-    {{- end}}
-    {{- end}}
-  {{- end}}
-  {{- end }}
+    {{ toYaml $endpoint.annotations | indent 4 }}
   labels:
     app: "{{ $endpoint.app }}"
     heritage: {{ $root.Release.Service | quote }}
@@ -157,6 +143,10 @@ spec:
         release: {{ $root.Release.Name | quote }}
         chart: "{{ $root.Chart.Name }}-{{ $root.Chart.Version }}"
         component: "{{ $root.Values.Component }}"
+      {{- if $root.Values.networkAnnotation }}
+      annotations:
+        {{ toYaml $root.Values.networkAnnotation | indent 8 }}
+      {{- end }}
     spec:
       {{- if $root.Values.Image.pullSecretName }}
       imagePullSecrets:


### PR DESCRIPTION
Also modified the annotations for the services to now be populated with the service endpoints.

Tested the helm chart by creating a statefulset deployment with the network annotation and also checked the service annotations after editing the serviceEndpoint values in Values.yaml.
Fixes for: #1179 and #797 