### PR TITLE
Added support for custom domain names

### DIFF
--- a/cloud/kubernetes/helm/yugabyte/templates/_helpers.tpl
+++ b/cloud/kubernetes/helm/yugabyte/templates/_helpers.tpl
@@ -51,9 +51,9 @@ Create chart name and version as used by the chart label.
 */}}
 {{- define "yugabyte.master_addresses" -}}
 {{- $master_replicas := .Values.replicas.master | int -}}
+{{- $domain_name := .Values.domainName -}}
   {{- range .Values.Services }}
     {{- if eq .name "yb-masters" }}
-      {{- $domain_name := .domainName -}}
       {{range $index := until $master_replicas }}{{if ne $index 0}},{{end}}yb-master-{{ $index }}.yb-masters.$(NAMESPACE).svc.{{ $domain_name }}:7100{{end}}
     {{- end -}}
   {{- end -}}

--- a/cloud/kubernetes/helm/yugabyte/templates/_helpers.tpl
+++ b/cloud/kubernetes/helm/yugabyte/templates/_helpers.tpl
@@ -60,13 +60,6 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
-Get the fully qualified server address
-*/}}
-{{- define "yugabyte.server_address" -}}
-{{- printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name .domainName }}
-{{- end -}}
-
-{{/*
 Compute the maximum number of unavailable pods based on the number of master replicas
 */}}
 {{- define "yugabyte.max_unavailable_for_quorum" -}}

--- a/cloud/kubernetes/helm/yugabyte/templates/service.yaml
+++ b/cloud/kubernetes/helm/yugabyte/templates/service.yaml
@@ -21,9 +21,9 @@ data:
 {{- $rootCA := buildCustomCert $root.Values.tls.rootCA.cert $root.Values.tls.rootCA.key -}}
 {{- $replicas := (eq .name "yb-masters") | ternary $root.Values.replicas.master $root.Values.replicas.tserver -}}
 {{- range $index := until ( int ( $replicas ) ) }}
-{{- $node := printf "%s-%d.%s.%s.svc.%s" $service.label $index $service.name $root.Release.Namespace $service.domainName }}
+{{- $node := printf "%s-%d.%s.%s.svc.%s" $service.label $index $service.name $root.Release.Namespace $root.Values.domainName }}
 {{- $dns1 := printf "*.*.%s" $root.Release.Namespace }}
-{{- $dns2 := printf "%s.svc.%s" $dns1 $service.domainName }}
+{{- $dns2 := printf "%s.svc.%s" $dns1 $root.Values.domainName }}
 {{- $server := genSignedCert $node ( default nil ) (list $dns1 $dns2 ) 3650 $rootCA }}
   node.{{$node}}.crt: {{ $server.Cert | b64enc }}
   node.{{$node}}.key: {{ $server.Key | b64enc }}
@@ -212,8 +212,8 @@ spec:
         {{ if eq .name "yb-masters" }}
           - "/home/yugabyte/bin/yb-master"
           - "--fs_data_dirs={{ template "yugabyte.fs_data_dirs" $storageInfo }}"
-          - "--rpc_bind_addresses={{ template "yugabyte.server_address" . }}"
-          - "--server_broadcast_addresses={{ template "yugabyte.server_address" . }}:7100"
+          - "--rpc_bind_addresses={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}"
+          - "--server_broadcast_addresses={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}:7100"
           {{ if $root.Values.isMultiAz }}
           - "--master_addresses={{ $root.Values.masterAddresses}}"
           - "--replication_factor={{ $root.Values.replicas.totalMasters }}"
@@ -235,12 +235,12 @@ spec:
         {{ else }}
           - "/home/yugabyte/bin/yb-tserver"
           - "--fs_data_dirs={{ template "yugabyte.fs_data_dirs" $storageInfo }}"
-          - "--server_broadcast_addresses={{ template "yugabyte.server_address" . }}:9100"
-          - "--rpc_bind_addresses={{ template "yugabyte.server_address" . }}"
-          - "--cql_proxy_bind_address={{ template "yugabyte.server_address" . }}"
+          - "--server_broadcast_addresses={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}:9100"
+          - "--rpc_bind_addresses={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}"
+          - "--cql_proxy_bind_address={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}"
           {{ if not $root.Values.disableYsql }}
           - "--start_pgsql_proxy"
-          - "--pgsql_proxy_bind_address={{ template "yugabyte.server_address" . }}:5433"
+          - "--pgsql_proxy_bind_address={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}:5433"
           {{ end }}
           {{ if $root.Values.isMultiAz }}
           - "--tserver_master_addrs={{ $root.Values.masterAddresses}}"

--- a/cloud/kubernetes/helm/yugabyte/values.yaml
+++ b/cloud/kubernetes/helm/yugabyte/values.yaml
@@ -62,6 +62,8 @@ enableLoadBalancer: True
 
 isMultiAz: False
 
+domainName: "cluster.local"
+
 serviceEndpoints:
   - name: "yb-master-ui"
     type: LoadBalancer
@@ -72,7 +74,6 @@ serviceEndpoints:
 Services:
   - name: "yb-masters"
     label: "yb-master"
-    domainName: "cluster.local"
     memory_limit_to_ram_ratio: 0.85
     ports:
       ui: "7000"
@@ -80,7 +81,6 @@ Services:
 
   - name: "yb-tservers"
     label: "yb-tserver"
-    domainName: "cluster.local"
     ports:
       ui: "9000"
       rpc-port: "7100"


### PR DESCRIPTION
Change to support custom domains for k8s deployments.
Tested using `helm install yugabyte --name yb-demo --namespace yb-demo --dry-run --debug` to verify that all the addresses are as expected and then used `helm install yugabyte --name yb-demo --namespace yb-demo --wait` to check that the deployment went through correctly and created a YB universe.