### PR TITLE
[Docs] Fix formatting of name in search bar to uppercase 'Byte'

### DIFF
--- a/docs/layouts/partials/search.html
+++ b/docs/layouts/partials/search.html
@@ -1,6 +1,6 @@
 <form class="search-container" action="/search/">
   <i class="fas fa-search search-icon"></i>
-  <input class="form-control search-input" id="search-input" name="q" placeholder="Search Yugabyte DB Docs">
+  <input class="form-control search-input" id="search-input" name="q" placeholder="Search YugaByte DB Docs">
 </form>
 
 <script>


### PR DESCRIPTION
Should be 'Yuga**Byte** DB Docs'