### PR TITLE
[Docs] Add mobile view for navbar menu and fix sizing of home page tiles

### DIFF
--- a/docs/content/_index.html
+++ b/docs/content/_index.html
@@ -171,7 +171,7 @@ weight: 1
 
 <h2> RELEASES </h2>
 <div class="row">
-  <div class="col-6 col-md-6">
+  <div class="col-12 col-md-6 col-lg-6">
     <a class="section-link icon-offset" href="/latest/releases/">
       <div class="head">
         <img class="icon" src="/images/section_icons/quick_start/install.png" aria-hidden="true" />
@@ -186,7 +186,7 @@ weight: 1
 
 <h2> CONCEPTS </h2>
 <div class="row">
-  <div class="col-6 col-md-6">
+  <div class="col-12 col-md-6 col-lg-6">
     <a class="section-link icon-offset" href="/latest/architecture/">
       <div class="head">
         <img class="icon" src="/images/section_icons/index/architecture.png" aria-hidden="true" />

--- a/docs/layouts/partials/footer_links.html
+++ b/docs/layouts/partials/footer_links.html
@@ -1,44 +1,5 @@
 
 <div class="footer-links">
-  <!--
-  <div class="row">
-    <div class="col"> 
-      <div class="tile">
-        <div class="title">
-          Have a technical question?
-        </div>
-        <div class="body">
-          <a href="https://www.yugabyte.com/slack" target="_blank">
-            <i class="fab fa-slack"></i>
-            Slack
-          </a>
-          <a href="https://forum.yugabyte.com/" target="_blank">
-            <i class="fas fa-comment-alt"></i>
-            Forum
-          </a>
-          <a href="https://stackoverflow.com/questions/tagged/yugabyte-db" target="_blank">
-            <i class="fab fa-stack-overflow"></i>
-            StackOverflow
-          </a>
-        </div>
-      </div>
-    </div>
-
-    <div class="col">
-      <div class="tile">
-        <div class="title">
-          Found a bug or have an enchancement request?
-        </div>
-        <div class="body">
-          <a href="https://github.com/yugabyte/yugabyte-db/issues" target="_blank">
-            <i class="fab fa-github"></i>
-            GitHub
-          </a>
-        </div>
-      </div>
-    </div>
-  </div>
--->
   <div>
     <div class="help-footer-btn">
       <i class="fas fa-question-circle"></i> Talk to Community

--- a/docs/layouts/partials/header.html
+++ b/docs/layouts/partials/header.html
@@ -43,6 +43,23 @@
             </a>
           </div>
         </div>
+        <div class="navbar-misc mobile">
+          <div>
+            <a href="https://www.yugabyte.com/slack" target="_blank">
+              <i class="fab fa-slack"></i> Slack
+            </a>
+          </div>
+          <div>
+            <a href="https://github.com/yugabyte/yugabyte-db" target="_blank">
+              <i class="fab fa-github"></i> Github
+            </a>
+          </div>
+          <div>
+            <a href="/latest/quick-start/">
+              Get Started
+            </a>
+          </div>
+        </div>
       </div>
     </div>
   </nav>

--- a/docs/styles/_navbar.scss
+++ b/docs/styles/_navbar.scss
@@ -450,6 +450,17 @@ body {
       align-items: center;
     }
 
+    .navbar-misc.mobile {
+      padding: 15px 30px 0 30px;
+      text-align: left;
+      display: none;
+
+      div {
+        margin-top: 15px;
+        font-size: 20px;
+      }
+    }
+
     .navbar-link-btn {
       border: 1px solid #cbcdd0;
       color: #202951;
@@ -498,7 +509,11 @@ body {
         }
       }
       .navbar-misc {
-        justify-content: center;
+        display: none;
+      }
+
+      .navbar-misc.mobile {
+        display: block;
       }
     }
     @media screen and (max-width: 659px) {


### PR DESCRIPTION
Add mobile specific view for navbar that appears in hamburger menu. Add bootstrap breakpoint sizes for Release and Architecture tiles.

Output:
![docs-mobile-view-360p](https://user-images.githubusercontent.com/50115930/61319245-b0e48500-a7bb-11e9-9e52-ef2efc7fc221.png)
