### PR TITLE
Fixed issues in local SSD deployment YAML for GKE (Kubernetes)

### DIFF
--- a/cloud/kubernetes/yugabyte-statefulset-local-ssd-gke.yaml
+++ b/cloud/kubernetes/yugabyte-statefulset-local-ssd-gke.yaml
@@ -8,13 +8,16 @@
 #    - a load-balancer service to view the universe dashboard UI
 #
 # Using YB with k8s
-#    - Create cluster    : kubectl apply -f yugabyte-statefulset.yaml
+#    - Create cluster    : kubectl apply -f yugabyte-statefulset-local-ssd-gke.yaml
 #    - List the pods     : kubectl get pods
 #    - Run cqlsh         : kubectl exec -it yb-tserver-0 /home/yugabyte/bin/cqlsh
+#    - Setup Redis      : kubectl exec -it yb-master-0 /home/yugabyte/bin/yb-admin -- --master_addresses yb-master-0.yb-masters.default.svc.cluster.local:7100 setup_redis_table
+#      replace 'yb-master-0' in master_addresses with the leader (yb-master-1 etc), you can check which master instance is the leader by viewing the UI.
+#      replace 'default' with your namespace if you're not using the default namespace for YB
 #    - Run Redis cli     : kubectl exec -it yb-tserver-0 /home/yugabyte/bin/redis-cli
 #    - Connect to the ui : kubectl port-forward yb-master-0 7000
 #                          You can now view the UI at http://localhost:7000
-#    - Destroy cluster   : kubectl delete -f yugabyte-statefulset.yaml
+#    - Destroy cluster   : kubectl delete -f yugabyte-statefulset-local-ssd-gke.yaml
 
 
 apiVersion: v1
@@ -88,6 +91,10 @@ spec:
         image: yugabytedb/yugabyte:latest
         imagePullPolicy: Always
         env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+                fieldPath: metadata.namespace
         - name: POD_IP
           valueFrom:
             fieldRef:
@@ -96,8 +103,9 @@ spec:
           - "/home/yugabyte/bin/yb-master"
           - "--fs_data_dirs=/mnt/disk0,/mnt/disk1"
           - "--rpc_bind_addresses=$(POD_IP)"
-          - "--master_addresses=yb-masters.default.svc.cluster.local:7100"
+          - "--master_addresses=yb-masters.$(POD_NAMESPACE).svc.cluster.local:7100"
           - "--master_replication_factor=3"
+          - "--replication_factor=3"
         ports:
         - containerPort: 7000
           name: master-ui
@@ -189,10 +197,15 @@ spec:
       - name: yb-tserver
         image: yugabytedb/yugabyte:latest
         imagePullPolicy: Always
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+                fieldPath: metadata.namespace
         command:
           - "/home/yugabyte/bin/yb-tserver"
           - "--fs_data_dirs=/mnt/disk0,/mnt/disk1"
-          - "--tserver_master_addrs=yb-masters.default.svc.cluster.local:7100"
+          - "--tserver_master_addrs=yb-masters.$(POD_NAMESPACE).svc.cluster.local:7100"
           - "--tserver_master_replication_factor=3"
         ports:
         - containerPort: 9000


### PR DESCRIPTION
- fixed issue in local SSD deployment where namespaces other than default did not work

- added explicit replication_factor=3 to allow the user to customize number of replicas easily in the yb-master StatefulSet
- fixed inconsistencies in opening docs to refer to the correct yaml file name (yugabyte-statefulset-local-ssd-gke.yaml)
- added some instructions on setting up Redis (user must manually run a setup_redis script)