### PR TITLE
Remove dual action Add Universe button and replace

### DIFF
--- a/managed/ui/src/components/dashboard/Dashboard.js
+++ b/managed/ui/src/components/dashboard/Dashboard.js
@@ -15,14 +15,9 @@ export default class Dashboard extends Component {
 
     return (
       <div id="page-wrapper">
-        <Row className="header-row">
-          <Col xs={6}>
-            <h2 className="content-title">Universes</h2>
-          {isAvailable(currentCustomer.data.features, "main.stats") && <div className="dashboard-stats">
-            <HighlightedStatsPanelContainer />
-          </div>}
-          </Col>
-        </Row>
+        {isAvailable(currentCustomer.data.features, "main.stats") && <div className="dashboard-stats">
+          <HighlightedStatsPanelContainer />
+        </div>}
         <UniverseDisplayPanelContainer {...this.props}/>
         <Row>
           <Col lg={12}>

--- a/managed/ui/src/components/dashboard/Dashboard.js
+++ b/managed/ui/src/components/dashboard/Dashboard.js
@@ -15,9 +15,14 @@ export default class Dashboard extends Component {
 
     return (
       <div id="page-wrapper">
-        {isAvailable(currentCustomer.data.features, "main.stats") && <div className="dashboard-stats">
-          <HighlightedStatsPanelContainer />
-        </div>}
+        <Row className="header-row">
+          <Col xs={6}>
+            <h2 className="content-title">Universes</h2>
+          {isAvailable(currentCustomer.data.features, "main.stats") && <div className="dashboard-stats">
+            <HighlightedStatsPanelContainer />
+          </div>}
+          </Col>
+        </Row>
         <UniverseDisplayPanelContainer {...this.props}/>
         <Row>
           <Col lg={12}>

--- a/managed/ui/src/components/panels/UniverseDisplayPanel/UniverseDisplayPanel.js
+++ b/managed/ui/src/components/panels/UniverseDisplayPanel/UniverseDisplayPanel.js
@@ -131,16 +131,21 @@ export default class UniverseDisplayPanel extends Component {
 
       return (
         <div className="universe-display-panel-container">
-          <Row xs={6} className="universe-table-header-action dashboard-universe-actions ">
-            {isNotHidden(currentCustomer.data.features, "universe.import") &&
-            <Link to="/importer"><YBButton btnClass="universe-button btn btn-lg btn-default"
-              disabled={isDisabled(currentCustomer.data.features, "universe.import")}
-              btnText="Import Universe" btnIcon="fa fa-mail-forward"/></Link>}
-            {isNotHidden(currentCustomer.data.features, "universe.create") &&
-              <YBButton btnClass="universe-button btn btn-lg btn-orange"
-                disabled={isDisabled(currentCustomer.data.features, "universe.create")}
-                btnText="Create Universe" btnIcon="fa fa-pencil"
-                onClick={this.createNewUniverse} />}
+          <Row xs={6} >
+            <Col xs={3}>
+              <h2>Universes</h2>
+            </Col>
+            <Col className="universe-table-header-action dashboard-universe-actions">
+              {isNotHidden(currentCustomer.data.features, "universe.import") &&
+              <Link to="/importer"><YBButton btnClass="universe-button btn btn-lg btn-default"
+                disabled={isDisabled(currentCustomer.data.features, "universe.import")}
+                btnText="Import Universe" btnIcon="fa fa-mail-forward"/></Link>}
+              {isNotHidden(currentCustomer.data.features, "universe.create") &&
+                <YBButton btnClass="universe-button btn btn-lg btn-orange"
+                  disabled={isDisabled(currentCustomer.data.features, "universe.create")}
+                  btnText="Create Universe" btnIcon="fa fa-plus"
+                  onClick={this.createNewUniverse} />}
+            </Col>
           </Row>
           <Row className="list-group">
             {universeDisplayList}

--- a/managed/ui/src/components/panels/UniverseDisplayPanel/UniverseDisplayPanel.js
+++ b/managed/ui/src/components/panels/UniverseDisplayPanel/UniverseDisplayPanel.js
@@ -10,7 +10,7 @@ import { YBCost, DescriptionItem } from 'components/common/descriptors';
 import { UniverseStatusContainer } from 'components/universes';
 import './UniverseDisplayPanel.scss';
 import { isNonEmptyObject } from "../../../utils/ObjectUtils";
-import { YBModal } from '../../common/forms/fields';
+import { YBModal, YBButton } from '../../common/forms/fields';
 import { getPrimaryCluster, getReadOnlyCluster, getClusterProviderUUIDs, getProviderMetadata } from "../../../utils/UniverseUtils";
 import { isNotHidden, isDisabled } from 'utils/LayoutUtils';
 
@@ -31,73 +31,6 @@ class CTAButton extends Component {
           </div>
         </div>
       </Link>
-    );
-  }
-}
-
-class CTAButtonAnimated extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      hover: false
-    };
-
-    this.plusIcon = null;
-    this.mainLabel = null;
-    this.addUniverseElems = [];
-    this.feature = null;
-    this.description = null;
-    this.icons = [];
-  }
-
-
-  mouseEnter = () => {
-    this.setState({hover: true});
-  }
-
-  mouseLeave = () => {
-    this.setState({hover: false});
-  }
-
-  disableLink = (e) => {
-    e.preventDefault();
-  }
-
-  render() {
-    const { labelText, onClick, otherProps, className, currentCustomer } = this.props;
-
-    const createDisabled = isDisabled(currentCustomer.data.features, "universe.create");
-    const importDisabled = isDisabled(currentCustomer.data.features, "universe.import");
-
-    return (
-      <div>
-        <div ref={ div => this.content = div } onMouseEnter={this.mouseEnter} onMouseLeave={this.mouseLeave} className={className ? "create-universe-button "+className : "create-universe-button"} {...otherProps}>
-          <div ref={ div => this.plusIcon = div } className="btn-icon">
-            <i className="fa fa-plus"/>
-          </div>
-          <div ref={ div => this.mainLabel = div } className="display-name text-center">
-            {labelText}
-          </div>
-          <div className="button-group">
-            {isNotHidden(currentCustomer.data.features, "universe.create") &&
-            <Link className="btn btn-default" to={"/universes/create"}
-              disabled={createDisabled}
-              onClick={createDisabled ? this.disableLink: onClick}>
-              <div ref={ block => this.addUniverseElems[0] = block }>
-                <span className="fa fa-plus"></span> Create Universe
-              </div>
-            </Link>}
-            {isNotHidden(currentCustomer.data.features, "universe.import") &&
-            <Link to={"/importer"} className="btn btn-default"
-              disabled={importDisabled}
-              onClick={importDisabled ? this.disableLink: onClick}>
-              <div ref={ block => this.addUniverseElems[1] = block }>
-                <span className="fa fa-mail-forward"></span> Import Universe
-              </div>
-            </Link>}
-          </div>
-        </div>
-      </div>
     );
   }
 }
@@ -195,19 +128,22 @@ export default class UniverseDisplayPanel extends Component {
                                        refreshUniverseData={self.props.fetchUniverseMetadata} />);
         });
       }
-      const createUniverseButton =
-        (<Col sm={4} md={3} lg={2}><CTAButtonAnimated
-          labelText={"Add Universe"}
-          className={self.state.addUniverseModal? "active" : ""}
-          onClick={() => 0}
-          currentCustomer={currentCustomer}
-        /></Col>);
+
       return (
         <div className="universe-display-panel-container">
-          <h2>Universes</h2>
-          <Row>
+          <Row xs={6} className="universe-table-header-action dashboard-universe-actions ">
+            {isNotHidden(currentCustomer.data.features, "universe.import") &&
+            <Link to="/importer"><YBButton btnClass="universe-button btn btn-lg btn-default"
+              disabled={isDisabled(currentCustomer.data.features, "universe.import")}
+              btnText="Import Universe" btnIcon="fa fa-mail-forward"/></Link>}
+            {isNotHidden(currentCustomer.data.features, "universe.create") &&
+              <YBButton btnClass="universe-button btn btn-lg btn-orange"
+                disabled={isDisabled(currentCustomer.data.features, "universe.create")}
+                btnText="Create Universe" btnIcon="fa fa-pencil"
+                onClick={this.createNewUniverse} />}
+          </Row>
+          <Row className="list-group">
             {universeDisplayList}
-            {createUniverseButton}
           </Row>
           <YBModal
             className="mymodal"

--- a/managed/ui/src/components/panels/UniverseDisplayPanel/UniverseDisplayPanel.scss
+++ b/managed/ui/src/components/panels/UniverseDisplayPanel/UniverseDisplayPanel.scss
@@ -120,8 +120,8 @@ a:hover >  .universe-display-item-container, .create-universe-button:hover {
     margin-bottom: 10px;
   }
 
-  .row {
-    margin: 0 -12px;
+  .list-group.row {
+    margin: 20px -12px 0 -12px;
 
     .col-lg-2, .col-md-3 {
       padding: 0 12px;

--- a/managed/ui/src/components/universes/ListUniverse/ListUniverse.js
+++ b/managed/ui/src/components/universes/ListUniverse/ListUniverse.js
@@ -35,7 +35,7 @@ export default class ListUniverse extends Component {
             {isNotHidden(currentCustomer.data.features, "universe.create") &&
               <YBButton btnClass="universe-button btn btn-lg btn-orange"
                 disabled={isDisabled(currentCustomer.data.features, "universe.create")}
-                btnText="Create Universe" btnIcon="fa fa-pencil"
+                btnText="Create Universe" btnIcon="fa fa-plus"
                 onClick={this.createNewUniverse} />}
           </Col>
         </Row>

--- a/managed/ui/src/components/universes/ListUniverse/ListUniverse.scss
+++ b/managed/ui/src/components/universes/ListUniverse/ListUniverse.scss
@@ -11,6 +11,10 @@
     padding: 11px 12px;
 }
 
+.universe-table-header-action.dashboard-universe-actions {
+    padding-right: 15px;
+}
+
 .universe-button {
     
     &.btn-orange {


### PR DESCRIPTION
Fixes #1583

We want to replace with similar layout as List Universes page, where the header is on the navbar and the two action buttons are on the top right.