### PR TITLE
Issue #1367 expose number of dead/unresponsive tservers as yb-master metric

### DIFF
--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -5930,7 +5930,7 @@ void CatalogManager::ReportMetrics() {
   master_->ts_manager()->GetAllLiveDescriptors(&ts_descs);
   const int32 num_live_servers = ts_descs.size();
   metric_num_tablet_servers_live_->set_value(num_live_servers);
-  
+
   master_->ts_manager()->GetAllDescriptors(&ts_descs);
   metric_num_tablet_servers_dead_->set_value(ts_descs.size() - num_live_servers);
 }

--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -205,6 +205,12 @@ METRIC_DEFINE_gauge_uint32(cluster, num_tablet_servers_live,
                            "in the time interval defined by the gflag "
                            "FLAGS_tserver_unresponsive_timeout_ms.");
 
+METRIC_DEFINE_gauge_uint32(cluster, num_tablet_servers_dead,
+                           "Number of dead tservers in the cluster", yb::MetricUnit::kUnits,
+                           "The number of tablet servers that have not responded or done a "
+                           "heartbeat in the time interval defined by the gflag "
+                           "FLAGS_tserver_unresponsive_timeout_ms.");
+
 DEFINE_test_flag(uint64, inject_latency_during_remote_bootstrap_secs, 0,
                  "Number of seconds to sleep during a remote bootstrap.");
 
@@ -472,6 +478,9 @@ Status CatalogManager::Init(bool is_first_run) {
   // Initialize the metrics emitted by the catalog manager.
   metric_num_tablet_servers_live_ =
     METRIC_num_tablet_servers_live.Instantiate(master_->metric_entity_cluster(), 0);
+
+  metric_num_tablet_servers_dead_ =
+    METRIC_num_tablet_servers_dead.Instantiate(master_->metric_entity_cluster(), 0);
 
   RETURN_NOT_OK_PREPEND(InitSysCatalogAsync(is_first_run),
                         "Failed to initialize sys tables async");
@@ -5919,7 +5928,11 @@ void CatalogManager::ReportMetrics() {
   // Report metrics on how many tservers are alive.
   TSDescriptorVector ts_descs;
   master_->ts_manager()->GetAllLiveDescriptors(&ts_descs);
-  metric_num_tablet_servers_live_->set_value(ts_descs.size());
+  const int32 num_live_servers = ts_descs.size();
+  metric_num_tablet_servers_live_->set_value(num_live_servers);
+  
+  master_->ts_manager()->GetAllDescriptors(&ts_descs);
+  metric_num_tablet_servers_dead_->set_value(ts_descs.size() - num_live_servers);
 }
 
 std::string CatalogManager::LogPrefix() const {

--- a/src/yb/master/catalog_manager.h
+++ b/src/yb/master/catalog_manager.h
@@ -1058,6 +1058,9 @@ class CatalogManager : public tserver::TabletPeerLookupIf {
   // Number of live tservers metric.
   scoped_refptr<AtomicGauge<uint32_t>> metric_num_tablet_servers_live_;
 
+  // Number of dead tservers metric.
+  scoped_refptr<AtomicGauge<uint32_t>> metric_num_tablet_servers_dead_;
+
   friend class ClusterLoadBalancer;
 
   // Policy for load balancing tablets on tablet servers.


### PR DESCRIPTION
The yb-master leader tracks yb-tserver heartbeats and knows which
TServers haven't been able to heartbeat/have been unresponsive

The yb-master process exposes (via http://<master-ip>:7000/prometheus-metrics)
a num_tablet_servers_live metric, but a num_tablet_servers_dead
might be more useful/easier for setting up alerts. This number being greater
than 0 could be set to result in an alert.

To do this, expose another metric num_tablet_servers_dead from the catalog
manager similar to the num_tablet_servers_live. This metric tracks the
number of total tablet servers - live tablet servers.

Test plan:
1) Set up local yugabyte cluster with 3 nodes with prometheus monitoring
2) Verify that num_tablet_servers_live = 3 and num_tablet_servers_dead=0
   on the :7000 prometheus metrics page
3) Use yb-ctl commands to stop one of the nodes
4) Verify that num_tablet_servers_live=2 and num_tablet_servers_dead=1