### PR TITLE
Quick start and CDC cleanup

### DIFF
--- a/docs/content/latest/deploy/cdc/cdc-to-kafka.md
+++ b/docs/content/latest/deploy/cdc/cdc-to-kafka.md
@@ -35,7 +35,7 @@ The Confluent Platform currently only supports Java 8 and 11. If you do not use 
 
 A local install of the Confluent Platform should be up and running. The [Confluent Platform](https://docs.confluent.io/current/platform.html) includes [Apache Kafka](https://docs.confluent.io/current/kafka/introduction.html) and additional tools and services (including Zookeeper and Avro), making it easy for you to quickly get started using the Kafka event streaming platform.
 
-To quickly get a local Confluent Platform (with Apache Kafka) up and running, follow the steps in the [Confluent Platform Quick Start (Local)](https://docs.confluent.io/current/quickstart/ce-quickstart.html#ce-quickstart).
+To get a local Confluent Platform (with Apache Kafka) up and running quickly, follow the steps in the [Confluent Platform Quick Start (Local)](https://docs.confluent.io/current/quickstart/ce-quickstart.html#ce-quickstart).
 
 ## Step 1 — Add the `users` table
 
@@ -85,15 +85,15 @@ You can use the following two Avro schema examples that will work with the `user
 
 1. Create a Kafka topic.
 
-```bash
-./bin/kafka-topics --create --partitions 1 --topic users_topic --bootstrap-server localhost:9092 --replication-factor 1
-```
+    ```bash
+    ./bin/kafka-topics --create --partitions 1 --topic users_topic --bootstrap-server localhost:9092 --replication-factor 1
+    ```
 
 2. Start the Kafka consumer service.
 
-```bash
-bin/kafka-avro-console-consumer --bootstrap-server localhost:9092 --topic users_topic --key-deserializer=io.confluent.kafka.serializers.KafkaAvroDeserializer --value-deserializer=io.confluent.kafka.serializers.KafkaAvroDeserializer
-```
+    ```bash
+    bin/kafka-avro-console-consumer --bootstrap-server localhost:9092 --topic users_topic --key-deserializer=io.confluent.kafka.serializers.KafkaAvroDeserializer     --value-deserializer=io.confluent.kafka.serializers.KafkaAvroDeserializer
+    ```
 
 ## Step 4 — Download the Yugabyte CDC connector
 

--- a/docs/content/latest/deploy/cdc/cdc-to-stdout.md
+++ b/docs/content/latest/deploy/cdc/cdc-to-stdout.md
@@ -44,7 +44,7 @@ Run the command below to to start the YugabyteDB CDC connector and stream the ou
 ```bash
 java -jar yb_cdc_connector.jar
 --table_name yugabyte.users
---log_only // Flag to log to console.
+--log_only
 ```
 
 For details on the available options, see [Using the Yugabyte CDC connector](./use-cdc).

--- a/docs/content/latest/deploy/cdc/use-cdc.md
+++ b/docs/content/latest/deploy/cdc/use-cdc.md
@@ -68,13 +68,13 @@ To use the Yugabyte CDC connector, run the `yb_cdc_connector` JAR file.
 ```bash
 java -jar target/yb_cdc_connector.jar
 --table_name <namespace>.<table>
---master_addrs <yb master addresses>
-[ --[stream_id] <optional existing stream id> ]
---kafka_addrs <kafka cluster addresses> [default 127.0.0.1:9092]
---schema_registry_addrs [default 127.0.0.1:8081]
---topic_name <topic name to write to>
---table_schema_path <avro table schema>
---primary_key_schema_path <avro primary key schema>
+--master_addrs <yb-master-addresses>
+[ --stream_id <existing-stream-id> ]
+--kafka_addrs <kafka-cluster-addresses>
+--schema_registry_addrs
+--topic_name <topic-name>
+--table_schema_path <avro-table-schema>
+--primary_key_schema_path <avro-primary-key-schema>
 ```
 
 ### Syntax for stdout
@@ -82,9 +82,9 @@ java -jar target/yb_cdc_connector.jar
 ```bash
 java -jar yb_cdc_connector.jar
 --table_name <namespace>.<table>
---master_addrs <yb master addresses> [default 127.0.0.1:7100]
-[ --stream_id <stream-id> ]
-[ --log_only ]
+--master_addrs <yb-master-addresses>
+--stream_id <stream-id>
+--log_only
 ```
 
 ## Parameters
@@ -138,7 +138,7 @@ The following command will start the Yugabyte CDC connector and send an output s
 ```bash
 java -jar yb_cdc_connector.jar
 --master_addrs 127.0.0.1,127.0.0.2,127.0.0.3
---table_name users
+--table_name yugabyte.users
 --log_only
 ```
 

--- a/docs/content/latest/quick-start/binary/linux-install.md
+++ b/docs/content/latest/quick-start/binary/linux-install.md
@@ -1,36 +1,52 @@
 ## Prerequisites
 
-a) One of the following operating systems
+1. One of the following operating systems
 
-<i class="icon-centos"></i> CentOS 7
+    <i class="icon-centos"></i> CentOS 7
 
-<i class="icon-ubuntu"></i> Ubuntu 16.04+
+    <i class="icon-ubuntu"></i> Ubuntu 16.04+
 
-b) Verify that you have Python 2 installed. Support for Python 3 is in the works.
+2. Verify that you have Python 2 installed. Support for Python 3 is in the works.
 
-```sh
-$ python --version
-```
+    ```sh
+    $ python --version
+    ```
 
-```
-Python 2.7.10
-```
+    ```
+    Python 2.7.10
+    ```
+
+3. `wget` or `curl` is available.
+
+    The instructions use the `wget` command to download files. If you prefer to use `curl`, you can replace `wget` with `curl -O`.
+
+    To install `wget`:
+
+    - CentOS: `yum install wget`
+    - Ubuntu: `apt install wget`
+
+    To install `curl`:
+
+    - CentOS: `yum install curl`
+    - Ubuntu: `apt install curl`
 
 ## Download
 
-Download the YugabyteDB package as shown below.
+1. Download the YugabyteDB package using the following `wget` command.
 
-```sh
-$ wget https://downloads.yugabyte.com/yugabyte-2.0.0.0-linux.tar.gz
-```
+    ```sh
+    $ wget https://downloads.yugabyte.com/yugabyte-2.0.0.0-linux.tar.gz
+    ```
 
-```sh
-$ tar xvfz yugabyte-2.0.0.0-linux.tar.gz && cd yugabyte-2.0.0.0/
-```
+2. Extract the YugabyteDB package and then change directories to the YugabyteDB home.
+
+    ```sh
+    $ tar xvfz yugabyte-2.0.0.0-linux.tar.gz && cd yugabyte-2.0.0.0/
+    ```
 
 ## Configure
 
-You can do this as shown below.
+To configure YugabyteDB, run the following shell script.
 
 ```sh
 $ ./bin/post_install.sh

--- a/docs/content/latest/quick-start/binary/macos-install.md
+++ b/docs/content/latest/quick-start/binary/macos-install.md
@@ -1,66 +1,75 @@
 ## Prerequisites
 
-a) <i class="fab fa-apple" aria-hidden="true"></i> macOS 10.12 (Sierra) or later.
+1. <i class="fab fa-apple" aria-hidden="true"></i> macOS 10.12 (Sierra) or later.
 
-b) Verify that you have Python 2 installed. Support for Python 3 is in the works.
+2. Verify that you have Python 2 installed. Support for Python 3 is in the works.
 
-```sh
-$ python --version
-```
+    ```sh
+    $ python --version
+    ```
+    
+    ```
+    Python 2.7.10
+    ```
+3. `wget` or `curl` is available.
 
-```
-Python 2.7.10
-```
+    The instructions use the `wget` command to download files. If you prefer to use `curl` (included in macOS), you can replace `wget` with `curl -O`.
 
-c) Each tablet maps to its own file, so if you experiment with a few hundred tables and a few tablets per table, you can soon end up creating a large number of files in the current shell. Make sure that this command shows a big enough value.
+    To install `wget` on your Mac, you can run the following command if you use Homebrew:
 
-```sh
-$ launchctl limit maxfiles
-```
+    ```sh
+    $ brew install wget`
+    ```     
 
-We recommend simply setting the soft and hard limits to 1048576.
+4. Each tablet maps to its own file, so if you experiment with a few hundred tables and a few tablets per table, you can soon end up creating a large number of files in the current shell. Make sure that this command shows a big enough value.
 
-- Edit `/etc/sysctl.conf` with the following contents.
+    ```sh
+    $ launchctl limit maxfiles
+    ```
 
-```sh
-kern.maxfiles=1048576
-kern.maxproc=2500
-kern.maxprocperuid=2500
-kern.maxfilesperproc=1048576
-```
+    We recommend setting the soft and hard limits to 1048576.
 
-- If your macOS version does not have the `/etc/sysctl.conf` file, then ensure that the file `/Library/LaunchDaemons/limit.maxfiles.plist` has the following content.
+    Edit `/etc/sysctl.conf`, if it exists, to include the following:
 
-```sh
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-  <plist version="1.0">
-    <dict>
-      <key>Label</key>
-        <string>limit.maxfiles</string>
-      <key>ProgramArguments</key>
-        <array>
-          <string>launchctl</string>
-          <string>limit</string>
-          <string>maxfiles</string>
-          <string>1048576</string>
-          <string>1048576</string>
-        </array>
-      <key>RunAtLoad</key>
-        <true/>
-      <key>ServiceIPC</key>
-        <false/>
-    </dict>
-  </plist>
-```
+    ```sh
+    kern.maxfiles=1048576
+    kern.maxproc=2500
+    kern.maxprocperuid=2500
+    kern.maxfilesperproc=1048576
+    ```
 
-Enure that the `plist` file is owned by `root:wheel` and has permissions `-rw-r--r--`. Reboot your computer for this to take effect. Or, to avoid this effort, enter this command:
+    If this file does not exist, then create the file `/Library/LaunchDaemons/limit.maxfiles.plist` and insert the following:
 
-```sh
-$ sudo launchctl load -w /Library/LaunchDaemons/limit.maxfiles.plist
-```
+    ```sh
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
+          <key>Label</key>
+            <string>limit.maxfiles</string>
+          <key>ProgramArguments</key>
+            <array>
+              <string>launchctl</string>
+              <string>limit</string>
+              <string>maxfiles</string>
+              <string>1048576</string>
+              <string>1048576</string>
+            </array>
+          <key>RunAtLoad</key>
+            <true/>
+          <key>ServiceIPC</key>
+            <false/>
+        </dict>
+      </plist>
+    ```
 
-You might have to `unload` the service before loading it.
+    Enure that the `plist` file is owned by `root:wheel` and has permissions `-rw-r--r--`. To take effect, you need to reboot your computer or run this command:
+
+    ```sh
+    $ sudo launchctl load -w /Library/LaunchDaemons/limit.maxfiles.plist
+    ```
+
+    You might have to `unload` the service before loading it.
 
 ## Download
 
@@ -78,7 +87,7 @@ $ tar xvfz yugabyte-2.0.0.0-darwin.tar.gz && cd yugabyte-2.0.0.0/
 
 ## Configure
 
-Add a few loopback IP addresses to cover the add node scenarios of the [Explore core features](../../explore/) section.
+Add the following loopback IP addresses for use in the add node scenarios of the [Explore core features](../../explore/) section.
 
 ```sh
 sudo ifconfig lo0 alias 127.0.0.2

--- a/docs/content/latest/quick-start/explore-ysql.md
+++ b/docs/content/latest/quick-start/explore-ysql.md
@@ -25,13 +25,13 @@ After [creating a local cluster](../create-local-cluster/), follow the steps her
 
 Follow the steps to create a database and load sample data.
 
-1. Download the sample schema using the following `wget` command.
+1. Download the sample schema using the following `curl` command.
 
     ```sh
-    $ wget https://raw.githubusercontent.com/yugabyte/yb-sql-workshop/master/  query-using-bi-tools/schema.sql
+    $ wget https://raw.githubusercontent.com/yugabyte/yb-sql-workshop/master/query-using-bi-tools/schema.sql
     ```
 
-2. Download the sample data archive by running the following `wget` command.
+2. Download the sample data archive by running the following `curl` command.
 
     ```sh
     $ wget https://github.com/yugabyte/yb-sql-workshop/raw/master/query-using-bi-tools/sample-data.tgz

--- a/docs/content/latest/secure/tls-encryption/_index.md
+++ b/docs/content/latest/secure/tls-encryption/_index.md
@@ -16,7 +16,7 @@ menu:
 YugabyteDB supports Transport Layer Security (TLS) encryption using [OpenSSL](https://www.openssl.org), which is natively available for Linux, BSD, and macOS operating systems. You can configure YugabyteDB to encrypt network communication, including:
 
 * Server-server — between YB-Masters and YB-TServers
-* Client-server — using CLIs and APIs for YSQL and YCQL
+* Client-server — using CLIs and APIs for YCQL (YSQL support in progress)
 
 {{< note title="Note" >}}
 


### PR DESCRIPTION
Quick start

- Added prerequisite note about using `wget` or `curl`, and how to install `wget`.
- Replaced some "bullet" steps with numbered steps and improved layout.

CDC

- Fixed some syntax issues.

TLS

- Changed note to say "Client-server — using CLIs and APIs for YCQL (YSQL support in progress)" instead of "Client-server — using CLIs and APIs for YSQL and YCQL"