### PR TITLE
Fixed distorted O/p of describe products table command

### DIFF
--- a/docs/content/latest/quick-start/explore-ysql.md
+++ b/docs/content/latest/quick-start/explore-ysql.md
@@ -149,19 +149,20 @@ You should see an output like the following:
 
 ```
                                         Table "public.products"
-   Column   │            Type             │ Collation │ Nullable │               Default
-════════════╪═════════════════════════════╪═══════════╪══════════╪══════════════════════════════════════
- id         │ bigint                      │           │ not null │ nextval('products_id_seq'::regclass)
- created_at │ timestamp without time zone │           │          │
- category   │ text                        │           │          │
- ean        │ text                        │           │          │
- price      │ double precision            │           │          │
- quantity   │ integer                     │           │          │ 5000
- rating     │ double precision            │           │          │
- title      │ text                        │           │          │
- vendor     │ text                        │           │          │
+   Column   |            Type             | Collation | Nullable |               Default                
+------------+-----------------------------+-----------+----------+--------------------------------------
+ id         | bigint                      |           | not null | nextval('products_id_seq'::regclass)
+ created_at | timestamp without time zone |           |          | 
+ category   | text                        |           |          | 
+ ean        | text                        |           |          | 
+ price      | double precision            |           |          | 
+ quantity   | integer                     |           |          | 5000
+ rating     | double precision            |           |          | 
+ title      | text                        |           |          | 
+ vendor     | text                        |           |          | 
 Indexes:
     "products_pkey" PRIMARY KEY, lsm (id HASH)
+
 ```
 
 To see how many products there are in this table, you can run the following query.


### PR DESCRIPTION
The O/p of describe products tables in following section is distorted. 
``` 
https://docs.yugabyte.com/latest/quick-start/explore-ysql/#docker
```

Changes are done to fix the same.

