### PR TITLE
Correct location of yugabyte-data directory

### DIFF
--- a/docs/content/latest/admin/yb-ctl.md
+++ b/docs/content/latest/admin/yb-ctl.md
@@ -74,7 +74,7 @@ Here are the default values for all the optional arguments.
 | Optional argument                | Default                               | Description                                                  |
 | -------------------------------- | ------------------------------------- | ------------------------------------------------------------ |
 | `--binary_dir`                   | Same directory as the `yb-ctl` binary | Location of the `yb-master` and the `yb-tserver` binaries    |
-| `--data_dir`                     | `/tmp/yugabyte-local-cluster`         | Location of the data directory for the YugabyteDB           |
+| `--data_dir`                     | `/yugabyte-data`         | Location of the data directory for YugabyteDB           |
 | `--replication_factor` or `--rf` | `1`                                   | Number of replicas for each tablet, should be an odd number (e.g. `1`,`3`,`5`) so that majority consensus can be established |
 | `--require_clock_sync`           | `false`                               | Tells YugabyteDB whether to depend on clock synchronization between the nodes in the cluster |
 | `--num_shards_per_tserver`       | `2`                                   | Number of shards (tablets) per tablet server for each table  |
@@ -123,7 +123,7 @@ Cluster data is installed in `$HOME/yugabyte-data/`.
 
 #### Node directories
 
-`yugabyte-data/node-#/` directory created for node #.
+`/yugabyte-data/node-#/` directory created for node #.
 
 This directory contains the following.
 
@@ -135,7 +135,7 @@ cluster_config.json
 
 #### Disk directories
 
-`yugabyte-data/node-#/disk-#/` directory created for each disk.
+`/yugabyte-data/node-#/disk-#/` directory created for each disk.
 
 This directory contains the following.
 

--- a/docs/content/latest/troubleshoot/nodes/check-logs.md
+++ b/docs/content/latest/troubleshoot/nodes/check-logs.md
@@ -14,32 +14,31 @@ showAsideToc: true
 
 ## YugabyteDB base folder
 
-The logs for each node are found in the yugabyte base directory which may depend on the details of your deployment:
+The logs for each node are written to a sub-directory of the YugabyteDB `yugabyte-data` directory and may vary depending on your deployment:
 
-- When using the `yb-ctl` the default locations for each node is `/tmp/yugabyte-local-cluster/node-<node_nr>/`.
-For instance, for 3 nodes (default) `yb-ctl` will generate three folders `node-1`, `node-2` and `node-3`.
-- For a multi-node cluster the location where YugabyteDB disks are set up (e.g. `/home/centos/` or `/mnt/`) for each node.
+- When you use `yb-ctl` to create local YugabyteDB clusters on a single host (for example, your laptop), the default location for each node is `/yugabyte-data/node-<node_nr>/`. For a 3-node cluster, `yb-ctl` utility creates three directories: `node-1`, `node-2` and `node-3`.
+- For a multi-node cluster deployment to multiple hosts, the location where YugabyteDB disks are set up can vary (for example, `/home/centos/`, `/mnt/`, or another directory) on each node (host).
 
-We will refer to the YugabyteDB base folder as `<yugabyte-base-folder>` below.
+In the sections below, the YugabyteDB `yugabyte-data` directory is represented by `<yugabyte-data-directory>`.
 
-## Master logs
+## YB-Master logs
 
-Masters manage system meta-data such as keyspaces, tables and types: they handle DDL statements (e.g. `CREATE/DROP/ALTER TABLE/KEYSPACE/TYPE`).  Masters also manage users, permissions, and coordinate background operations such as load balancing.
+YB-Master services manage system meta-data, such as namespaces (databases or keyspaces), tables, and types: they handle DDL statements (for example, `CREATE TABLE`, `DROP TABLE`, `ALTER TABLE` KEYSPACE/TYPE`).  YB-Master services also manage users, permissions, and coordinate background operations, such as load balancing.
 Master logs can be found at:
 
 ```sh
-$ cd <yugabyte-base-folder>/disk1/yb-data/master/logs/
+$ cd <yugabyte-data-directory>/disk1/yb-data/master/logs/
 ```
 
 Logs are organized by error severity: `FATAL`, `ERROR`, `WARNING`, `INFO`. In case of issues, the `FATAL` and `ERROR` logs are most likely to be relevant.
 
-## TServer logs
+## YB-TServer logs
 
-TServers do the actual IO for end-user requests: they handle DML statements (e.g. `INSERT`, `UPDATE`, `DELETE`, `SELECT`)  and Redis commands.
-Tserver logs can be found at:
+YB-TServer services perform the actual I/O for end-user requests: they handle DML statements (for example, `INSERT`, `UPDATE`, `DELETE`, and `SELECT`) and Redis commands.
+YB-TServer logs can be found at:
 
 ```sh
-$ cd <yugabyte-base-folder>/disk1/yb-data/tserver/logs/
+$ cd <yugabyte-data-directory>/disk1/yb-data/tserver/logs/
 ```
 
 Logs are organized by error severity: `FATAL`, `ERROR`, `WARNING`, `INFO`. In case of issues, the `FATAL` and `ERROR` logs are most likely to be relevant.


### PR DESCRIPTION
Found many references to an older `/tmp/yugabyte-local-cluster/` directory — fixed with corrected location of `yugabyte-data` directory.