### PR TITLE
Update syntax highlighting

### DIFF
--- a/docs/content/latest/api/ysql/commands/cmd_do.md
+++ b/docs/content/latest/api/ysql/commands/cmd_do.md
@@ -59,7 +59,7 @@ If `DO` is executed in a transaction block, then the procedure code cannot execu
 
 ## Examples
 
-```sql
+```postgresql
 DO $$DECLARE r record;
 BEGIN
     FOR r IN SELECT table_schema, table_name FROM information_schema.tables

--- a/docs/content/latest/api/ysql/commands/dcl_alter_default_privileges.md
+++ b/docs/content/latest/api/ysql/commands/dcl_alter_default_privileges.md
@@ -52,13 +52,13 @@ Users can change default privileges only for objects that are created by them or
 
 - Grant SELECT privilege to all tables that are created in schema marketing to all users.
 
-```sql
+```postgresql
 yugabyte=# ALTER DEFAULT PRIVILEGES IN SCHEMA marketing GRANT SELECT ON TABLES TO PUBLIC;
 ```
 
 - Revoke INSERT privilege on all tables from user john.
 
-```sql
+```postgresql
 yugabyte=# ALTER DEFAULT PRIVILEGES REVOKE INSERT ON TABLES FROM john;
 ```
 

--- a/docs/content/latest/api/ysql/commands/dcl_alter_role.md
+++ b/docs/content/latest/api/ysql/commands/dcl_alter_role.md
@@ -74,19 +74,19 @@ Because MD5-encrypted passwords use the role name as cryptographic salt, renamin
 
 - Change a role's password.
 
-```sql
+```postgresql
 yugabyte=# ALTER ROLE John WITH PASSWORD 'new_password';
 ```
 
 - Rename a role.
 
-```sql
+```postgresql
 yugabyte=# ALTER ROLE John RENAME TO Jane;
 ```
 
 - Change default_transaction_isolation session parameter for a role.
 
-```sql
+```postgresql
 yugabyte=# ALTER ROLE Jane SET default_transaction_isolation='serializable';
 ```
 

--- a/docs/content/latest/api/ysql/commands/dcl_create_group.md
+++ b/docs/content/latest/api/ysql/commands/dcl_create_group.md
@@ -49,7 +49,7 @@ See [`CREATE ROLE`](../dcl_create_role) for more details.
 
 - Create a sample group that can manage databases and roles.
 
-```sql
+```postgresql
 yugabyte=# CREATE GROUP SysAdmin WITH CREATEDB CREATEROLE;
 ```
 

--- a/docs/content/latest/api/ysql/commands/dcl_create_role.md
+++ b/docs/content/latest/api/ysql/commands/dcl_create_role.md
@@ -74,19 +74,19 @@ Note that password is always stored encrypted in system catalogs and the optiona
 
 - Create a role that can login.
 
-```sql
+```postgresql
 yugabyte=# CREATE ROLE John LOGIN;
 ```
 
 - Create a role that can login and has a password.
 
-```sql
+```postgresql
 yugabyte=# CREATE ROLE Jane LOGIN PASSWORD 'password';
 ```
 
 - Create a role that can manage databases and roles.
 
-```sql
+```postgresql
 yugabyte=# CREATE ROLE SysAdmin CREATEDB CREATEROLE;
 ```
 

--- a/docs/content/latest/api/ysql/commands/dcl_create_user.md
+++ b/docs/content/latest/api/ysql/commands/dcl_create_user.md
@@ -51,19 +51,19 @@ See [`CREATE ROLE`](../dcl_create_role) for more details.
 
 - Create a sample user with password.
 
-```sql
+```postgresql
 yugabyte=# CREATE USER John WITH PASSWORD 'password';
 ```
 
 - Grant John all permissions on the `postgres` database.
 
-```sql
+```postgresql
 yugabyte=# GRANT ALL ON DATABASE postgres TO John;
 ```
 
 - Remove John's permissions from the `postgres` database.
 
-```sql
+```postgresql
 yugabyte=# REVOKE ALL ON DATABASE postgres FROM John;
 ```
 

--- a/docs/content/latest/api/ysql/commands/dcl_drop_group.md
+++ b/docs/content/latest/api/ysql/commands/dcl_drop_group.md
@@ -51,7 +51,7 @@ See [`DROP ROLE`](../dcl_drop_role) for more details.
 
 - Drop a group.
 
-```sql
+```postgresql
 yugabyte=# DROP GROUP SysAdmin;
 ```
 

--- a/docs/content/latest/api/ysql/commands/dcl_drop_owned.md
+++ b/docs/content/latest/api/ysql/commands/dcl_drop_owned.md
@@ -57,7 +57,7 @@ This is the default mode and will raise an error if there are other database obj
 
 - Drop all objects owned by john.
 
-```sql
+```postgresql
 yugabyte=# drop owned by john;
 ```
 

--- a/docs/content/latest/api/ysql/commands/dcl_drop_role.md
+++ b/docs/content/latest/api/ysql/commands/dcl_drop_role.md
@@ -56,7 +56,7 @@ It is, however, not necessary to remove role memberships involving the role. `DR
 
 - Drop a role.
 
-```sql
+```postgresql
 yugabyte=# DROP ROLE John;
 ```
 

--- a/docs/content/latest/api/ysql/commands/dcl_drop_user.md
+++ b/docs/content/latest/api/ysql/commands/dcl_drop_user.md
@@ -51,7 +51,7 @@ See [`DROP ROLE`](../dcl_drop_role) for more details.
 
 - Drop a user.
 
-```sql
+```postgresql
 yugabyte=# DROP USER John;
 ```
 

--- a/docs/content/latest/api/ysql/commands/dcl_grant.md
+++ b/docs/content/latest/api/ysql/commands/dcl_grant.md
@@ -121,13 +121,13 @@ If `WITH ADMIN OPTION` is specified, the member can in turn grant membership in 
 
 - Grant SELECT privilege to all users on table 'stores'
 
-```sql
+```postgresql
 yugabyte=# GRANT SELECT ON stores TO PUBLIC;
 ```
 
 - Add user John to SysAdmins group.
 
-```sql
+```postgresql
 yugabyte=# GRANT SysAdmins TO John;
 ```
 

--- a/docs/content/latest/api/ysql/commands/dcl_reassign_owned.md
+++ b/docs/content/latest/api/ysql/commands/dcl_reassign_owned.md
@@ -50,7 +50,7 @@ showAsideToc: true
 
 - Reassign all objects owned by john to yugabyte.
 
-```sql
+```postgresql
 yugabyte=# reassign owned by john to yugabyte;
 ```
 

--- a/docs/content/latest/api/ysql/commands/dcl_revoke.md
+++ b/docs/content/latest/api/ysql/commands/dcl_revoke.md
@@ -61,13 +61,13 @@ When revoking privileges on a table, the corresponding column privileges (if any
 
 - Revoke SELECT privilege for PUBLIC on table 'stores'
 
-```sql
+```postgresql
 yugabyte=# REVOKE SELECT ON stores FROM PUBLIC;
 ```
 
 - Remove user John from SysAdmins group.
 
-```sql
+```postgresql
 yugabyte=# REVOKE SysAdmins FROM John;
 ```
 

--- a/docs/content/latest/api/ysql/commands/dcl_set_role.md
+++ b/docs/content/latest/api/ysql/commands/dcl_set_role.md
@@ -53,7 +53,7 @@ To reset the role back to current user, `RESET ROLE` or `SET ROLE NONE` can be u
 
 - Change to new role John.
 
-```sql
+```postgresql
 yugabyte=# select session_user, current_user;
  session_user | current_user
 --------------+--------------
@@ -70,7 +70,7 @@ yugabyte=# select session_user, current_user;
 
 - Changing to new role assumes the privileges available to that role.
 
-```sql
+```postgresql
 yugabyte=# select session_user, current_user;
  session_user | current_user
 --------------+--------------

--- a/docs/content/latest/api/ysql/commands/dcl_set_session_authorization.md
+++ b/docs/content/latest/api/ysql/commands/dcl_set_session_authorization.md
@@ -53,7 +53,7 @@ To reset the session user back to current authenticated user, `RESET SESSION AUT
 
 - Set session user to John.
 
-```sql
+```postgresql
 yugabyte=# select session_user, current_user;
  session_user | current_user
 --------------+--------------

--- a/docs/content/latest/api/ysql/commands/ddl_alter_domain.md
+++ b/docs/content/latest/api/ysql/commands/ddl_alter_domain.md
@@ -59,19 +59,19 @@ Specify the name of the domain. An error is raised if DOMAIN `name` does not exi
 
 ## Examples
 
-```sql
+```postgresql
 yugabyte=# CREATE DOMAIN idx DEFAULT 5 CHECK (VALUE > 0);
 ```
 
-```sql
+```postgresql
 yugabyte=# ALTER DOMAIN idx DROP DEFAULT;
 ```
 
-```sql
+```postgresql
 yugabyte=# ALTER DOMAIN idx RENAME TO idx_new;
 ```
 
-```sql
+```postgresql
 yugabyte=# DROP DOMAIN idx_new;
 ```
 

--- a/docs/content/latest/api/ysql/commands/ddl_alter_sequence.md
+++ b/docs/content/latest/api/ysql/commands/ddl_alter_sequence.md
@@ -89,7 +89,7 @@ It gives ownership of the sequence to the specified column (if any). This means 
 
 Create a simple sequence.
 
-```sql
+```postgresql
 yugabyte=# CREATE SEQUENCE s;
 ```
 
@@ -99,7 +99,7 @@ CEATE SEQUENCE
 
 Modify the increment value.
 
-```sql
+```postgresql
 yugabyte=# ALTER SEQUENCE s INCREMENT BY 5;
 ```
 
@@ -107,7 +107,7 @@ yugabyte=# ALTER SEQUENCE s INCREMENT BY 5;
 ALTER SEQUENCE
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT nextval('s');
 ```
 
@@ -118,7 +118,7 @@ yugabyte=# SELECT nextval('s');
 (1 row)
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT nextval('s');
 ```
 
@@ -131,7 +131,7 @@ yugabyte=# SELECT nextval('s');
 
 Modify the starting value.
 
-```sql
+```postgresql
 yugabyte=# ALTER SEQUENCE s RESTART WITH 2;
 ```
 
@@ -139,7 +139,7 @@ yugabyte=# ALTER SEQUENCE s RESTART WITH 2;
 ALTER SEQUENCE
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT nextval('s');
 ```
 
@@ -150,7 +150,7 @@ yugabyte=# SELECT nextval('s');
 (1 row)
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT nextval('s');
 ```
 

--- a/docs/content/latest/api/ysql/commands/ddl_create_aggregate.md
+++ b/docs/content/latest/api/ysql/commands/ddl_create_aggregate.md
@@ -55,7 +55,7 @@ See the semantics of each option in the [PostgreSQL docs][postgresql-docs-create
 
 Normal syntax example.
 
-```sql
+```postgresql
 yugabyte=# CREATE AGGREGATE sumdouble (float8) (
               STYPE = float8,
               SFUNC = float8pl,
@@ -75,7 +75,7 @@ yugabyte=# SELECT sumdouble(f), sumdouble(i) FROM normal_table;
 
 Order by syntax example.
 
-```sql
+```postgresql
 yugabyte=# CREATE AGGREGATE my_percentile_disc(float8 ORDER BY anyelement) (
              STYPE = internal,
              SFUNC = ordered_set_transition,
@@ -90,7 +90,7 @@ yugabyte=# SELECT my_percentile_disc(0.1), my_percentile_disc(0.9)
 
 Old syntax example.
 
-```sql
+```postgresql
 yugabyte=# CREATE AGGREGATE oldcnt(
              SFUNC = int8inc,
              BASETYPE = 'ANY',
@@ -102,7 +102,7 @@ yugabyte=# SELECT oldcnt(*) FROM pg_aggregate;
 
 Zero-argument aggregate example.
 
-```sql
+```postgresql
 yugabyte=# CREATE AGGREGATE newcnt(*) (
              SFUNC = int8inc,
              STYPE = int8,

--- a/docs/content/latest/api/ysql/commands/ddl_create_cast.md
+++ b/docs/content/latest/api/ysql/commands/ddl_create_cast.md
@@ -51,7 +51,7 @@ See the semantics of each option in the [PostgreSQL docs][postgresql-docs-create
 
 `WITH FUNCTION` example.
 
-```sql
+```postgresql
 yugabyte=# CREATE FUNCTION sql_to_date(integer) RETURNS date AS $$
              SELECT $1::text::date
              $$ LANGUAGE SQL IMMUTABLE STRICT;
@@ -61,7 +61,7 @@ yugabyte=# SELECT CAST (3 AS date);
 
 `WITHOUT FUNCTION` example.
 
-```sql
+```postgresql
 yugabyte=# CREATE TYPE myfloat4;
 yugabyte=# CREATE FUNCTION myfloat4_in(cstring) RETURNS myfloat4
              LANGUAGE internal IMMUTABLE STRICT PARALLEL SAFE AS 'float4in';
@@ -79,7 +79,7 @@ yugabyte=# SELECT CAST('3.14'::myfloat4 AS float4);
 
 `WITH INOUT` example.
 
-```sql
+```postgresql
 yugabyte=# CREATE TYPE myint4;
 yugabyte=# CREATE FUNCTION myint4_in(cstring) RETURNS myint4
              LANGUAGE internal IMMUTABLE STRICT PARALLEL SAFE AS 'int4in';

--- a/docs/content/latest/api/ysql/commands/ddl_create_domain.md
+++ b/docs/content/latest/api/ysql/commands/ddl_create_domain.md
@@ -81,11 +81,11 @@ The key word VALUE should be used to refer to the value being tested. Expression
 
 ## Examples
 
-```sql
+```postgresql
 yugabyte=# CREATE DOMAIN phone_number AS TEXT CHECK(VALUE ~ '^\d{3}-\d{3}-\d{4}$');
 ```
 
-```sql
+```postgresql
 yugabyte=# CREATE TABLE person(first_name TEXT, last_name TEXT, phone_number phone_number);
 ```
 

--- a/docs/content/latest/api/ysql/commands/ddl_create_function.md
+++ b/docs/content/latest/api/ysql/commands/ddl_create_function.md
@@ -63,7 +63,7 @@ Use the `CREATE FUNCTION` statement to define a new function in a database.
 
 ### Define a function using the SQL language.
 
-```sql
+```postgresql
 CREATE FUNCTION mul(integer, integer) RETURNS integer
     AS 'SELECT $1 * $2;'
     LANGUAGE SQL
@@ -82,7 +82,7 @@ SELECT mul(2,3), mul(10, 12);
 
 ### Define a function using the PL/pgSQL language.
 
-```sql
+```postgresql
 CREATE OR REPLACE FUNCTION inc(i integer) RETURNS integer AS $$
         BEGIN
                 RAISE NOTICE 'Incrementing %', i ;

--- a/docs/content/latest/api/ysql/commands/ddl_create_index.md
+++ b/docs/content/latest/api/ysql/commands/ddl_create_index.md
@@ -85,7 +85,7 @@ Specify one or more columns of the table and must be surrounded by parentheses.
 
 Create a unique index with hash ordered columns.
 
-```sql
+```postgresql
 yugabyte=# CREATE TABLE products(id int PRIMARY KEY,
                                  name text,
                                  code text);
@@ -106,7 +106,7 @@ Indexes:
 
 Create an index with ascending ordered key.
 
-```sql
+```postgresql
 yugabyte=# CREATE INDEX products_name ON products(name ASC);
 yugabyte=# \d products_name
    Index "public.products_name"
@@ -120,7 +120,7 @@ lsm, for table "public.products
 
 Create an index with ascending ordered key and include other columns as non-key columns
 
-```sql
+```postgresql
 yugabyte=# CREATE INDEX products_name_code ON products(name) INCLUDE (code);
 yugabyte=# \d products_name_code;
  Index "public.products_name_code"

--- a/docs/content/latest/api/ysql/commands/ddl_create_operator.md
+++ b/docs/content/latest/api/ysql/commands/ddl_create_operator.md
@@ -51,7 +51,7 @@ See the semantics of each option in the [PostgreSQL docs][postgresql-docs-create
 
 Basic example.
 
-```sql
+```postgresql
 yugabyte=# CREATE OPERATOR @#@ (
              rightarg = int8,
              procedure = numeric_fac

--- a/docs/content/latest/api/ysql/commands/ddl_create_operator_class.md
+++ b/docs/content/latest/api/ysql/commands/ddl_create_operator_class.md
@@ -53,7 +53,7 @@ docs][postgresql-docs-xindex].
 
 Basic example.
 
-```sql
+```postgresql
 yugabyte=# CREATE OPERATOR CLASS my_op_class
            FOR TYPE int4
            USING btree AS

--- a/docs/content/latest/api/ysql/commands/ddl_create_procedure.md
+++ b/docs/content/latest/api/ysql/commands/ddl_create_procedure.md
@@ -54,7 +54,7 @@ Use the `CREATE PROCEDURE` statement to define a new procedure in a database.
 ## Examples
 
 - Set up an accounts table.
-    ```sql
+    ```postgresql
     CREATE TABLE accounts (
       id integer PRIMARY KEY,
       name text NOT NULL,
@@ -76,7 +76,7 @@ Use the `CREATE PROCEDURE` statement to define a new procedure in a database.
     ```
 - Define a `transfer` procedure to transfer money from one account to another.
 
-    ```sql
+    ```postgresql
     CREATE OR REPLACE PROCEDURE transfer(integer, integer, decimal)
     LANGUAGE plpgsql
     AS $$
@@ -91,7 +91,7 @@ Use the `CREATE PROCEDURE` statement to define a new procedure in a database.
     ```
 
 - Transfer `$20.00` from Jane to John.
-```sql
+```postgresql
 CALL transfer(1, 2, 20.00);
 SELECT * from accounts;
 ```
@@ -105,7 +105,7 @@ SELECT * from accounts;
 ```
 
 - Errors will be thrown for unsupported argument values.
-```sql
+```postgresql
 CALL transfer(2, 2, 20.00);
 ```
 ```
@@ -113,7 +113,7 @@ ERROR:  Sender and receiver cannot be the same
 CONTEXT:  PL/pgSQL function transfer(integer,integer,numeric) line 4 at RAISE
 ```
 
-```sql
+```postgresql
 yugabyte=# CALL transfer(1, 2, -20.00);
 ```
 

--- a/docs/content/latest/api/ysql/commands/ddl_create_rule.md
+++ b/docs/content/latest/api/ysql/commands/ddl_create_rule.md
@@ -51,7 +51,7 @@ See the semantics of each option in the [PostgreSQL docs][postgresql-docs-create
 
 Basic example.
 
-```sql
+```postgresql
 yugabyte=# CREATE TABLE t1(a int4, b int4);
 yugabyte=# CREATE TABLE t2(a int4, b int4);
 yugabyte=# CREATE RULE t1_to_t2 AS ON INSERT TO t1 DO INSTEAD
@@ -66,7 +66,7 @@ yugabyte=# SELECT * FROM t1;
 (0 rows)
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM t2;
 ```
 

--- a/docs/content/latest/api/ysql/commands/ddl_create_schema.md
+++ b/docs/content/latest/api/ysql/commands/ddl_create_schema.md
@@ -59,26 +59,26 @@ Other kinds of objects may be created in separate commands after the schema is c
 
 - Create a new schema.
 
-```sql
+```postgresql
 yugabyte=# CREATE SCHEMA IF NOT EXIST branch;
 ```
 
 - Create a schema for a user.
 
-```sql
+```postgresql
 yugabyte=# CREATE ROLE John;
 yugabyte=# CREATE SCHEMA AUTHORIZATION john;
 ```
 
 - Create a schema that will be owned by another role.
 
-```sql
+```postgresql
 yugabyte=# CREATE SCHEMA branch AUTHORIZATION john;
 ```
 
 - Create a schema and an object within that schema.
 
-```sql
+```postgresql
 yugabyte=# CREATE SCHEMA branch
                CREATE TABLE dept(
                    dept_id INT NOT NULL,

--- a/docs/content/latest/api/ysql/commands/ddl_create_sequence.md
+++ b/docs/content/latest/api/ysql/commands/ddl_create_sequence.md
@@ -109,7 +109,7 @@ CREATE TABLE t(k integer NOT NULL DEFAULT nextval('t_k_seq'));
 
 Create a simple sequence that increments by 1 every time `nextval()` is called.
 
-```sql
+```postgresql
 yugabyte=# CREATE SEQUENCE s;
 ```
 
@@ -119,7 +119,7 @@ CREATE SEQUENCE
 
 Call `nextval()`.
 
-```sql
+```postgresql
 yugabyte=# SELECT nextval('s');
 ```
 
@@ -132,7 +132,7 @@ yugabyte=# SELECT nextval('s');
 
 Create a sequence with a cache of 10,000 values.
 
-```sql
+```postgresql
 yugabyte=# CREATE SEQUENCE s2 CACHE 10000;
 ```
 
@@ -142,7 +142,7 @@ CREATE SEQUENCE
 
 In the same session, select `nextval()`.
 
-```sql
+```postgresql
 SELECT nextval('s2');
 ```
 
@@ -155,7 +155,7 @@ SELECT nextval('s2');
 
 In a different session, select `nextval()`.
 
-```sql
+```postgresql
 SELECT nextval('s2');
 ```
 
@@ -168,7 +168,7 @@ nextval
 
 Create a sequence that starts at 0. MINVALUE also has to be changed from its default 1 to something less than or equal to 0.
 
-```sql
+```postgresql
 CREATE SEQUENCE s3 START 0 MINVALUE 0;
 ```
 
@@ -176,7 +176,7 @@ CREATE SEQUENCE s3 START 0 MINVALUE 0;
 CREATE SEQUENCE
 ```
 
-```sql
+```postgresql
 SELECT nextval('s3');
 ```
 

--- a/docs/content/latest/api/ysql/commands/ddl_create_table.md
+++ b/docs/content/latest/api/ysql/commands/ddl_create_table.md
@@ -91,7 +91,7 @@ This is ignored and only present for compatibility with Postgres.
 
 ### Table with primary key.
 
-```sql
+```postgresql
 yugabyte=# CREATE TABLE sample(k1 int,
                                k2 int,
                                v1 int,
@@ -114,7 +114,7 @@ Indexes:
 ```
 
 ### Table with range primary key.
-```sql
+```postgresql
 yugabyte=# CREATE TABLE range(k1 int,
                               k2 int,
                               v1 int,
@@ -124,7 +124,7 @@ yugabyte=# CREATE TABLE range(k1 int,
 
 ### Table with check constraint.
 
-```sql
+```postgresql
 yugabyte=# CREATE TABLE student_grade(student_id int,
                                       class_id int,
                                       term_id int,
@@ -134,7 +134,7 @@ yugabyte=# CREATE TABLE student_grade(student_id int,
 
 ### Table with default value.
 
-```sql
+```postgresql
 yugabyte=# CREATE TABLE cars(id int PRIMARY KEY,
                              brand text CHECK (brand in ('X', 'Y', 'Z')),
                              model text NOT NULL,
@@ -144,7 +144,7 @@ yugabyte=# CREATE TABLE cars(id int PRIMARY KEY,
 ### Table with foreign key constraint.
 
 Define two tables with a foreign keys constraint.
-```sql
+```postgresql
 yugabyte=# CREATE TABLE products(id int PRIMARY KEY,
                                  descr text);
 yugabyte=# CREATE TABLE orders(id int PRIMARY KEY,
@@ -154,7 +154,7 @@ yugabyte=# CREATE TABLE orders(id int PRIMARY KEY,
 ```
 
 Insert some rows.
-```sql
+```postgresql
 yugabyte=# SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 yugabyte=# INSERT INTO products VALUES (1, 'Phone X'), (2, 'Tablet Z');
 yugabyte=# INSERT INTO orders VALUES (1, 1, 3), (2, 1, 3), (3, 2, 2);
@@ -171,7 +171,7 @@ order_id | product_id |  descr   | amount
 ```
 
 Inserting a row referencing a non-existent product is not allowed.
-```sql
+```postgresql
 yugabyte=# INSERT INTO orders VALUES (1, 3, 3);
 ```
 ```
@@ -181,7 +181,7 @@ DETAIL:  Key (pid)=(3) is not present in table "products".
 
 Deleting a product will cascade to all orders (as defined in the `CREATE TABLE` statement above).
 
-```sql
+```postgresql
 yugabyte=# DELETE from products where id = 1;
 yugabyte=# SELECT o.id AS order_id, p.id as product_id, p.descr, o.amount FROM products p, orders o WHERE o.pid = p.id;
 ```
@@ -195,7 +195,7 @@ yugabyte=# SELECT o.id AS order_id, p.id as product_id, p.descr, o.amount FROM p
 
 ### Table with unique constraint.
 
-```sql
+```postgresql
 yugabyte=# CREATE TABLE translations(message_id int UNIQUE,
                                      message_txt text);
 ```

--- a/docs/content/latest/api/ysql/commands/ddl_create_table_as.md
+++ b/docs/content/latest/api/ysql/commands/ddl_create_table_as.md
@@ -67,19 +67,19 @@ Specify the name of a column in the new table. When not specified, column names 
 
 ## Examples
 
-```sql
+```postgresql
 CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1, k2));
 ```
 
-```sql
+```postgresql
 INSERT INTO sample VALUES (1, 2.0, 3, 'a'), (2, 3.0, 4, 'b'), (3, 4.0, 5, 'c');
 ```
 
-```sql
+```postgresql
 CREATE TABLE selective_sample SELECT * FROM sample WHERE k1 > 1;
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM selective_sample ORDER BY k1;
 ```
 

--- a/docs/content/latest/api/ysql/commands/ddl_create_trigger.md
+++ b/docs/content/latest/api/ysql/commands/ddl_create_trigger.md
@@ -52,7 +52,7 @@ Use the `CREATE TRIGGER` statement to define a new trigger.
 - Set up a table with triggers for tracking modification time and user (role).
     Use the pre-installed extensions `insert_username` and `moddatetime`.
 
-    ```sql
+    ```postgresql
     CREATE EXTENSION insert_username;
     CREATE EXTENSION moddatetime;
 
@@ -78,7 +78,7 @@ Use the `CREATE TRIGGER` statement to define a new trigger.
     For each insert, the triggers should set the current role as `username` and the current timestamp as `moddate`.
 
 
-    ```sql
+    ```postgresql
     SET ROLE yugabyte;
     INSERT INTO posts VALUES(1, 'desc1');
 
@@ -111,7 +111,7 @@ Use the `CREATE TRIGGER` statement to define a new trigger.
 - Update some rows.
     For each update the triggers should set both `username`  and `moddate` accordingly.
 
-    ```sql
+    ```postgresql
     UPDATE posts SET content = 'desc1_updated' WHERE id = 1;
     UPDATE posts SET content = 'desc3_updated' WHERE id = 3;
 

--- a/docs/content/latest/api/ysql/commands/ddl_create_type.md
+++ b/docs/content/latest/api/ysql/commands/ddl_create_type.md
@@ -107,28 +107,28 @@ The order of options in creating range types and base types does not matter.  Ev
 
 Composite type
 
-```sql
+```postgresql
 yugabyte=# CREATE TYPE feature_struct AS (id INTEGER, name TEXT);
 yugabyte=# CREATE TABLE feature_tab_struct (feature_col feature_struct);
 ```
 
 Enumerated type
 
-```sql
+```postgresql
 yugabyte=# CREATE TYPE feature_enum AS ENUM ('one', 'two', 'three');
 yugabyte=# CREATE TABLE feature_tab_enum (feature_col feature_enum);
 ```
 
 Range type
 
-```sql
+```postgresql
 yugabyte=# CREATE TYPE feature_range AS RANGE (subtype=INTEGER);
 yugabyte=# CREATE TABLE feature_tab_range (feature_col feature_range);
 ```
 
 Base type
 
-```sql
+```postgresql
 yugabyte=# CREATE TYPE int4_type;
 yugabyte=# CREATE FUNCTION int4_type_in(cstring) RETURNS int4_type
                LANGUAGE internal IMMUTABLE STRICT PARALLEL SAFE AS 'int4in';
@@ -144,7 +144,7 @@ yugabyte=# CREATE TABLE int4_table (t int4_type);
 
 Shell type
 
-```sql
+```postgresql
 yugabyte=# CREATE TYPE shell_type;
 ```
 

--- a/docs/content/latest/api/ysql/commands/ddl_create_view.md
+++ b/docs/content/latest/api/ysql/commands/ddl_create_view.md
@@ -67,25 +67,25 @@ Specify a `SELECT` or `VALUES` statement that will provide the columns and rows 
 
 Create a sample table.
 
-```sql
+```postgresql
 CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1, k2));
 ```
 
 Insert some rows.
 
-```sql
+```postgresql
 INSERT INTO sample(k1, k2, v1, v2) VALUES (1, 2.0, 3, 'a'), (2, 3.0, 4, 'b'), (3, 4.0, 5, 'c');
 ```
 
 Create a view on the `sample` table.
 
-```sql
+```postgresql
 CREATE VIEW sample_view AS SELECT * FROM sample WHERE v2 != 'b' ORDER BY k1 DESC;
 ```
 
 Select from the view.
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample_view;
 ```
 

--- a/docs/content/latest/api/ysql/commands/ddl_drop_aggregate.md
+++ b/docs/content/latest/api/ysql/commands/ddl_drop_aggregate.md
@@ -51,7 +51,7 @@ See the semantics of each option in the [PostgreSQL docs][postgresql-docs-drop-a
 
 Basic example.
 
-```sql
+```postgresql
 yugabyte=# CREATE AGGREGATE newcnt(*) (
              sfunc = int8inc,
              stype = int8,
@@ -63,7 +63,7 @@ yugabyte=# DROP AGGREGATE newcnt(*);
 
 `IF EXISTS` example.
 
-```sql
+```postgresql
 yugabyte=# DROP AGGREGATE IF EXISTS newcnt(*);
 yugabyte=# CREATE AGGREGATE newcnt(*) (
              sfunc = int8inc,
@@ -76,7 +76,7 @@ yugabyte=# DROP AGGREGATE IF EXISTS newcnt(*);
 
 `CASCADE` and `RESTRICT` example.
 
-```sql
+```postgresql
 yugabyte=# CREATE AGGREGATE newcnt(*) (
              sfunc = int8inc,
              stype = int8,

--- a/docs/content/latest/api/ysql/commands/ddl_drop_cast.md
+++ b/docs/content/latest/api/ysql/commands/ddl_drop_cast.md
@@ -51,7 +51,7 @@ See the semantics of each option in the [PostgreSQL docs][postgresql-docs-drop-c
 
 Basic example.
 
-```sql
+```postgresql
 yugabyte=# CREATE FUNCTION sql_to_date(integer) RETURNS date AS $$
              SELECT $1::text::date
              $$ LANGUAGE SQL IMMUTABLE STRICT;

--- a/docs/content/latest/api/ysql/commands/ddl_drop_domain.md
+++ b/docs/content/latest/api/ysql/commands/ddl_drop_domain.md
@@ -67,25 +67,25 @@ Refuse to drop the domain if objects depend on it (default).
 
 ### Example 1
 
-```sql
+```postgresql
 yugabyte=# CREATE DOMAIN idx DEFAULT 5 CHECK (VALUE > 0);
 ```
 
-```sql
+```postgresql
 yugabyte=# DROP DOMAIN idx;
 ```
 
 ### Example 2
 
-```sql
+```postgresql
 yugabyte=# CREATE DOMAIN idx DEFAULT 5 CHECK (VALUE > 0);
 ```
 
-```sql
+```postgresql
 yugabyte=# CREATE TABLE t (k idx primary key);
 ```
 
-```sql
+```postgresql
 yugabyte=# DROP DOMAIN idx CASCADE;
 ```
 

--- a/docs/content/latest/api/ysql/commands/ddl_drop_function.md
+++ b/docs/content/latest/api/ysql/commands/ddl_drop_function.md
@@ -53,7 +53,7 @@ Use the `DROP FUNCTION` statement to remove a function from a database.
 
 ## Examples
 
-```sql
+```postgresql
 DROP FUNCTION IF EXISTS inc(i integer), mul(integer, integer) CASCADE;
 ```
 

--- a/docs/content/latest/api/ysql/commands/ddl_drop_operator.md
+++ b/docs/content/latest/api/ysql/commands/ddl_drop_operator.md
@@ -51,7 +51,7 @@ See the semantics of each option in the [PostgreSQL docs][postgresql-docs-drop-o
 
 Basic example.
 
-```sql
+```postgresql
 yugabyte=# CREATE OPERATOR @#@ (
              rightarg = int8,
              procedure = numeric_fac

--- a/docs/content/latest/api/ysql/commands/ddl_drop_operator_class.md
+++ b/docs/content/latest/api/ysql/commands/ddl_drop_operator_class.md
@@ -51,7 +51,7 @@ See the semantics of each option in the [PostgreSQL docs][postgresql-docs-drop-o
 
 Basic example.
 
-```sql
+```postgresql
 yugabyte=# CREATE OPERATOR CLASS my_op_class
            FOR TYPE int4
            USING btree AS

--- a/docs/content/latest/api/ysql/commands/ddl_drop_procedure.md
+++ b/docs/content/latest/api/ysql/commands/ddl_drop_procedure.md
@@ -53,7 +53,7 @@ Use the `DROP PROCEDURE` statement to remove a procedure from a database.
 
 ## Examples
 
-```sql
+```postgresql
 DROP PROCEDURE IF EXISTS transfer(integer, integer, dec) CASCADE;
 ```
 

--- a/docs/content/latest/api/ysql/commands/ddl_drop_rule.md
+++ b/docs/content/latest/api/ysql/commands/ddl_drop_rule.md
@@ -51,7 +51,7 @@ See the semantics of each option in the [PostgreSQL docs][postgresql-docs-drop-r
 
 Basic example.
 
-```sql
+```postgresql
 yugabyte=# CREATE TABLE t1(a int4, b int4);
 yugabyte=# CREATE TABLE t2(a int4, b int4);
 yugabyte=# CREATE RULE t1_to_t2 AS ON INSERT TO t1 DO INSTEAD

--- a/docs/content/latest/api/ysql/commands/ddl_drop_sequence.md
+++ b/docs/content/latest/api/ysql/commands/ddl_drop_sequence.md
@@ -64,7 +64,7 @@ Do not remove this sequence if any object depends on it. This is the default beh
 
 Dropping a sequence that has an object depending on it, fails.
 
-```sql
+```postgresql
 yugabyte=# CREATE TABLE t(k SERIAL, v INT);
 ```
 
@@ -72,7 +72,7 @@ yugabyte=# CREATE TABLE t(k SERIAL, v INT);
 CREATE TABLE
 ```
 
-```sql
+```postgresql
 \d t
 ```
 
@@ -84,7 +84,7 @@ CREATE TABLE
  v      | integer |           |          |
 ```
 
-```sql
+```postgresql
 yugabyte=#  DROP SEQUENCE t_k_seq;
 ```
 
@@ -96,7 +96,7 @@ HINT:  Use DROP ... CASCADE to drop the dependent objects too.
 
 Dropping the sequence with the `CASCADE` option solves the problem and also deletes the default value in table `t`.
 
-```sql
+```postgresql
 yugabyte=# DROP SEQUENCE t_k_seq CASCADE;
 ```
 
@@ -105,7 +105,7 @@ NOTICE:  drop cascades to default for table t column k
 DROP SEQUENCE
 ```
 
-```sql
+```postgresql
 \d t
 ```
 

--- a/docs/content/latest/api/ysql/commands/ddl_drop_trigger.md
+++ b/docs/content/latest/api/ysql/commands/ddl_drop_trigger.md
@@ -49,7 +49,7 @@ Use the `DROP TRIGGER` statement to remove a trigger from the database.
 
 ## Examples
 
-```sql
+```postgresql
 DROP TRIGGER update_moddatetime ON posts;
 ```
 

--- a/docs/content/latest/api/ysql/commands/ddl_drop_type.md
+++ b/docs/content/latest/api/ysql/commands/ddl_drop_type.md
@@ -55,20 +55,20 @@ Specify the name of the user-defined type to drop.
 
 Simple example
 
-```sql
+```postgresql
 yugabyte=# CREATE TYPE feature_struct AS (id INTEGER, name TEXT);
 yugabyte=# DROP TYPE feature_struct;
 ```
 
 `IF EXISTS` example
 
-```sql
+```postgresql
 yugabyte=# DROP TYPE IF EXISTS feature_shell;
 ```
 
 `CASCADE` example
 
-```sql
+```postgresql
 yugabyte=# CREATE TYPE feature_enum AS ENUM ('one', 'two', 'three');
 yugabyte=# CREATE TABLE feature_tab_enum (feature_col feature_enum);
 yugabyte=# DROP TYPE feature_tab_enum CASCADE;
@@ -76,7 +76,7 @@ yugabyte=# DROP TYPE feature_tab_enum CASCADE;
 
 `RESTRICT` example
 
-```sql
+```postgresql
 yugabyte=# CREATE TYPE feature_range AS RANGE (subtype=INTEGER);
 yugabyte=# CREATE TABLE feature_tab_range (feature_col feature_range);
 yugabyte=# -- The following should error:

--- a/docs/content/latest/api/ysql/commands/ddl_truncate.md
+++ b/docs/content/latest/api/ysql/commands/ddl_truncate.md
@@ -58,15 +58,15 @@ Specify the name of the table to be truncated.
 
 ## Examples
 
-```sql
+```postgresql
 yugabyte=# CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1, k2));
 ```
 
-```sql
+```postgresql
 yugabyte=# INSERT INTO sample VALUES (1, 2.0, 3, 'a'), (2, 3.0, 4, 'b'), (3, 4.0, 5, 'c');
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample ORDER BY k1;
 ```
 
@@ -79,11 +79,11 @@ yugabyte=# SELECT * FROM sample ORDER BY k1;
 (3 rows)
 ```
 
-```sql
+```postgresql
 yugabyte=# TRUNCATE sample;
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample;
 ```
 

--- a/docs/content/latest/api/ysql/commands/dml_delete.md
+++ b/docs/content/latest/api/ysql/commands/dml_delete.md
@@ -77,15 +77,15 @@ Specify the value to be returned. When the _output_expression_ references a colu
 
 Create a sample table, insert a few rows, then delete one of the inserted row.
 
-```sql
+```postgresql
 CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1, k2));
 ```
 
-```sql
+```postgresql
 INSERT INTO sample VALUES (1, 2.0, 3, 'a'), (2, 3.0, 4, 'b'), (3, 4.0, 5, 'c');
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample ORDER BY k1;
 ```
 
@@ -98,11 +98,11 @@ yugabyte=# SELECT * FROM sample ORDER BY k1;
 (3 rows)
 ```
 
-```sql
+```postgresql
 DELETE FROM sample WHERE k1 = 2 AND k2 = 3;
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample ORDER BY k1;
 ```
 

--- a/docs/content/latest/api/ysql/commands/dml_insert.md
+++ b/docs/content/latest/api/ysql/commands/dml_insert.md
@@ -98,19 +98,19 @@ DO NOTHING | DO UPDATE SET *update_item* [ , ... ] [ WHERE *condition* ]
 
 First, the bare insert. Create a sample table.
 
-```sql
+```postgresql
 yugabyte=# CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1, k2));
 ```
 
 Insert some rows.
 
-```sql
+```postgresql
 yugabyte=# INSERT INTO sample VALUES (1, 2.0, 3, 'a'), (2, 3.0, 4, 'b'), (3, 4.0, 5, 'c');
 ```
 
 Check the inserted rows.
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample ORDER BY k1;
 ```
 
@@ -124,18 +124,18 @@ yugabyte=# SELECT * FROM sample ORDER BY k1;
 
 Next, a basic "upsert" example. Re-create and re-populate the sample table.
 
-```sql
+```postgresql
 yugabyte=# DROP TABLE IF EXISTS sample CASCADE;
 ```
 
-```sql
+```postgresql
 yugabyte=# CREATE TABLE sample(
   id int  CONSTRAINT sample_id_pk PRIMARY KEY,
   c1 text CONSTRAINT sample_c1_NN NOT NULL,
   c2 text CONSTRAINT sample_c2_NN NOT NULL);
 ```
 
-```sql
+```postgresql
 yugabyte=# INSERT INTO sample(id, c1, c2)
   VALUES (1, 'cat'    , 'sparrow'),
          (2, 'dog'    , 'blackbird'),
@@ -144,7 +144,7 @@ yugabyte=# INSERT INTO sample(id, c1, c2)
 
 Check the inserted rows.
 
-```sql
+```postgresql
 yugabyte=# SELECT id, c1, c2 FROM sample ORDER BY id;
 ```
 
@@ -158,7 +158,7 @@ yugabyte=# SELECT id, c1, c2 FROM sample ORDER BY id;
 
 Demonstrate "on conflict do nothing". In this case, we don't need to specify the conflict target.
 
-```sql
+```postgresql
 yugabyte=# INSERT INTO sample(id, c1, c2)
   VALUES (3, 'horse' , 'pigeon'),
          (4, 'cow'   , 'robin')
@@ -169,7 +169,7 @@ yugabyte=# INSERT INTO sample(id, c1, c2)
 Check the result.
 The non-conflicting row with id = 4 is inserted, but the conflicting row with id = 3 is NOT updated.
 
-```sql
+```postgresql
 yugabyte=# SELECT id, c1, c2 FROM sample ORDER BY id;
 ```
 
@@ -185,7 +185,7 @@ yugabyte=# SELECT id, c1, c2 FROM sample ORDER BY id;
 Demonstrate the real "upsert". In this case, we DO need to specify the conflict target. Notice the use of the
 EXCLUDED keyword to specify the conflicting rows in the to-be-upserted relation.
 
-```sql
+```postgresql
 yugabyte=# INSERT INTO sample(id, c1, c2)
   VALUES (3, 'horse' , 'pigeon'),
          (5, 'tiger' , 'starling')
@@ -197,7 +197,7 @@ yugabyte=# INSERT INTO sample(id, c1, c2)
 Check the result.
 The non-conflicting row with id = 5 is inserted, and the conflicting row with id = 3 is updated.
 
-```sql
+```postgresql
 yugabyte=# SELECT id, c1, c2 FROM sample ORDER BY id;
 ```
 
@@ -217,7 +217,7 @@ excluded rows. We illustrate this by attempting to insert two conflicting rows
 And we specify that the existing row with c1 = 'tiger' should not be updated
 with "WHERE sample.c1 <> 'tiger'".
 
-```sql
+```postgresql
 INSERT INTO sample(id, c1, c2)
   VALUES (4, 'deer'   , 'vulture'),
          (5, 'lion'   , 'hawk'),
@@ -232,7 +232,7 @@ Check the result.
 The non-conflicting row with id = 6 is inserted;  the conflicting row with id = 4 is updated;
 but the conflicting row with id = 5 (and c1 = 'tiger') is NOT updated;
 
-```sql
+```postgresql
 yugabyte=# SELECT id, c1, c2 FROM sample ORDER BY id;
 ```
 
@@ -256,18 +256,18 @@ WHERE EXCLUDED.c1 <> 'lion'
 Finally, a slightly more elaborate "upsert" example. Re-create and re-populate the sample table.
 Notice that id is a self-populating surrogate primary key and that c1 is a business unique key.
 
-```sql
+```postgresql
 yugabyte=# DROP TABLE IF EXISTS sample CASCADE;
 ```
 
-```sql
+```postgresql
 CREATE TABLE sample(
   id INTEGER GENERATED ALWAYS AS IDENTITY CONSTRAINT sample_id_pk PRIMARY KEY,
   c1 TEXT CONSTRAINT sample_c1_NN NOT NULL CONSTRAINT sample_c1_unq unique,
   c2 TEXT CONSTRAINT sample_c2_NN NOT NULL);
 ```
 
-```sql
+```postgresql
 INSERT INTO sample(c1, c2)
   VALUES ('cat'   , 'sparrow'),
          ('deer'  , 'thrush'),
@@ -277,7 +277,7 @@ INSERT INTO sample(c1, c2)
 
 Check the inserted rows.
 
-```sql
+```postgresql
 yugabyte=# SELECT id, c1, c2 FROM sample ORDER BY c1;
 ```
 
@@ -297,7 +297,7 @@ a VALUES clause. We also specify the conflict column(s)
 indirectly by mentioniing the name of the unique constrained
 that covers them.
 
-```sql
+```postgresql
 yugabyte=# WITH to_be_upserted AS (
   SELECT c1, c2 FROM (VALUES
     ('cat'   , 'chaffinch'),
@@ -314,7 +314,7 @@ yugabyte=# WITH to_be_upserted AS (
 
 Check the inserted rows.
 
-```sql
+```postgresql
 yugabyte=# SELECT id, c1, c2 FROM sample ORDER BY c1;
 ```
 

--- a/docs/content/latest/api/ysql/commands/dml_select.md
+++ b/docs/content/latest/api/ysql/commands/dml_select.md
@@ -60,27 +60,27 @@ For details on `from_item`, `grouping_element`, and `with_query` see [SELECT](ht
 
 Create two sample tables.
 
-```sql
+```postgresql
 yugabyte=# CREATE TABLE sample1(k1 bigint, k2 float, v text, PRIMARY KEY (k1, k2));
 ```
 
-```sql
+```postgresql
 yugabyte=# CREATE TABLE sample2(k1 bigint, k2 float, v text, PRIMARY KEY (k1, k2));
 ```
 
 Insert some rows.
 
-```sql
+```postgresql
 yugabyte=# INSERT INTO sample1(k1, k2, v) VALUES (1, 2.5, 'abc'), (1, 3.5, 'def'), (1, 4.5, 'xyz');
 ```
 
-```sql
+```postgresql
 yugabyte=# INSERT INTO sample2(k1, k2, v) VALUES (1, 2.5, 'foo'), (1, 4.5, 'bar');
 ```
 
 Select from both tables using join.
 
-```sql
+```postgresql
 yugabyte=# SELECT a.k1, a.k2, a.v as av, b.v as bv FROM sample1 a LEFT JOIN sample2 b ON (a.k1 = b.k1 and a.k2 = b.k2) WHERE a.k1 = 1 AND a.k2 IN (2.5, 3.5) ORDER BY a.k2 DESC;
 ```
 

--- a/docs/content/latest/api/ysql/commands/dml_update.md
+++ b/docs/content/latest/api/ysql/commands/dml_update.md
@@ -81,15 +81,15 @@ Specify the SELECT subquery statement. Its selected values will be assigned to t
 
 Create a sample table, insert a few rows, then update the inserted rows.
 
-```sql
+```postgresql
 yugabyte=# CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1, k2));
 ```
 
-```sql
+```postgresql
 yugabyte=# INSERT INTO sample VALUES (1, 2.0, 3, 'a'), (2, 3.0, 4, 'b'), (3, 4.0, 5, 'c');
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample ORDER BY k1;
 ```
 
@@ -102,7 +102,7 @@ yugabyte=# SELECT * FROM sample ORDER BY k1;
 (3 rows)
 ```
 
-```sql
+```postgresql
 yugabyte=# UPDATE sample SET v1 = v1 + 3, v2 = '7' WHERE k1 = 2 AND k2 = 3;
 ```
 
@@ -110,7 +110,7 @@ yugabyte=# UPDATE sample SET v1 = v1 + 3, v2 = '7' WHERE k1 = 2 AND k2 = 3;
 UPDATE 1
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample ORDER BY k1;
 ```
 

--- a/docs/content/latest/api/ysql/commands/perf_deallocate.md
+++ b/docs/content/latest/api/ysql/commands/perf_deallocate.md
@@ -57,16 +57,16 @@ Deallocate all prepared statements.
 
 Prepare and deallocate an insert statement.
 
-```sql
+```postgresql
 yugabyte=# CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1, k2));
 ```
 
-```sql
+```postgresql
 yugabyte=# PREPARE ins (bigint, double precision, int, text) AS 
                INSERT INTO sample(k1, k2, v1, v2) VALUES ($1, $2, $3, $4);
 ```
 
-```sql
+```postgresql
 yugabyte=# DEALLOCATE ins;
 ```
 

--- a/docs/content/latest/api/ysql/commands/perf_execute.md
+++ b/docs/content/latest/api/ysql/commands/perf_execute.md
@@ -57,30 +57,30 @@ Specify the expression. Each expression in `EXECUTE` must match with the corresp
 
 - Create a sample table.
 
-```sql
+```postgresql
 yugabyte=# CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1, k2));
 ```
 
 - Prepare a simple insert.
 
-```sql
+```postgresql
 yugabyte=# PREPARE ins (bigint, double precision, int, text) AS 
                INSERT INTO sample(k1, k2, v1, v2) VALUES ($1, $2, $3, $4);
 ```
 
 - Execute the insert twice (with different parameters).
 
-```sql
+```postgresql
 yugabyte=# EXECUTE ins(1, 2.0, 3, 'a');
 ```
 
-```sql
+```postgresql
 yugabyte=# EXECUTE ins(2, 3.0, 4, 'b');
 ```
 
 - Check the results.
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample ORDER BY k1;
 ```
 

--- a/docs/content/latest/api/ysql/commands/perf_explain.md
+++ b/docs/content/latest/api/ysql/commands/perf_explain.md
@@ -55,19 +55,19 @@ Execute the statement and show actual run times and other statistics.
 
 Create a sample table.
 
-```sql
+```postgresql
 yugabyte=# CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1, k2));
 ```
 
 Insert some rows.
 
-```sql
+```postgresql
 yugabyte=# INSERT INTO sample(k1, k2, v1, v2) VALUES (1, 2.0, 3, 'a'), (2, 3.0, 4, 'b'), (3, 4.0, 5, 'c');
 ```
 
 Check the execution plan for simple select (condition will get pushed down).
 
-```sql
+```postgresql
 yugabyte=# EXPLAIN SELECT * FROM sample WHERE k1 = 1;
 ```
 
@@ -80,7 +80,7 @@ yugabyte=# EXPLAIN SELECT * FROM sample WHERE k1 = 1;
 
 - Check the execution plan for select with complex condition (second condition requires filtering).
 
-```sql
+```postgresql
 yugabyte=# EXPLAIN SELECT * FROM sample WHERE k1 = 2 and floor(k2 + 1.5) = v1;
 ```
 
@@ -94,7 +94,7 @@ yugabyte=# EXPLAIN SELECT * FROM sample WHERE k1 = 2 and floor(k2 + 1.5) = v1;
 
 Check execution with `ANALYZE` option.
 
-```sql
+```postgresql
 yugabyte=# EXPLAIN ANALYZE SELECT * FROM sample WHERE k1 = 2 and floor(k2 + 1.5) = v1;
 ```
 

--- a/docs/content/latest/api/ysql/commands/perf_prepare.md
+++ b/docs/content/latest/api/ysql/commands/perf_prepare.md
@@ -52,30 +52,30 @@ Use the `PREPARE` command creates a handle to a prepared statement by parsing, a
 
 Create a sample table.
 
-```sql
+```postgresql
 yugabyte=# CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1, k2));
 ```
 
 Prepare a simple insert.
 
-```sql
+```postgresql
 yugabyte=# PREPARE ins (bigint, double precision, int, text) AS 
                INSERT INTO sample(k1, k2, v1, v2) VALUES ($1, $2, $3, $4);
 ```
 
 Execute the insert twice (with different parameters).
 
-```sql
+```postgresql
 yugabyte=# EXECUTE ins(1, 2.0, 3, 'a');
 ```
 
-```sql
+```postgresql
 yugabyte=# EXECUTE ins(2, 3.0, 4, 'b');
 ```
 
 Check the results.
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample ORDER BY k1;
 ```
 

--- a/docs/content/latest/api/ysql/commands/txn_abort.md
+++ b/docs/content/latest/api/ysql/commands/txn_abort.md
@@ -64,27 +64,27 @@ Add optional keyword — has no effect.
 
 Create a sample table.
 
-```sql
+```postgresql
 yugabyte=# CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1, k2));
 ```
 
 Begin a transaction and insert some rows.
 
-```sql
+```postgresql
 yugabyte=# BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
 ```
 
-```sql
+```postgresql
 yugabyte=# INSERT INTO sample(k1, k2, v1, v2) VALUES (1, 2.0, 3, 'a'), (1, 3.0, 4, 'b');
 ```
 
 Start a new shell  with `ysqlsh` and begin another transaction to insert some more rows.
 
-```sql
+```postgresql
 yugabyte=# BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
 ```
 
-```sql
+```postgresql
 yugabyte=# INSERT INTO sample(k1, k2, v1, v2) VALUES (2, 2.0, 3, 'a'), (2, 3.0, 4, 'b');
 ```
 
@@ -92,7 +92,7 @@ In each shell, check the only the rows from the current transaction are visible.
 
 1st shell.
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample; -- run in first shell
 ```
 
@@ -105,7 +105,7 @@ yugabyte=# SELECT * FROM sample; -- run in first shell
 ```
 2nd shell
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample; -- run in second shell
 ```
 
@@ -119,19 +119,19 @@ yugabyte=# SELECT * FROM sample; -- run in second shell
 
 Commit the first transaction and abort the second one.
 
-```sql
+```postgresql
 yugabyte=# COMMIT TRANSACTION; -- run in first shell.
 ```
 
 Abort the current transaction (from the first shell).
 
-```sql
+```postgresql
 yugabyte=# ABORT TRANSACTION; -- run second shell.
 ```
 
 In each shell check that only the rows from the committed transaction are visible.
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample; -- run in first shell.
 ```
 
@@ -143,7 +143,7 @@ yugabyte=# SELECT * FROM sample; -- run in first shell.
 (2 rows)
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample; -- run in second shell.
 ```
 

--- a/docs/content/latest/api/ysql/commands/txn_begin.md
+++ b/docs/content/latest/api/ysql/commands/txn_begin.md
@@ -47,7 +47,7 @@ Use the `BEGIN` statement to start a new transaction with the default (or given)
 
 ### *begin*
 
-```sql
+```postgresql
 BEGIN [ TRANSACTION | WORK ] [ transaction_mode [ ... ] ]
 ```
 
@@ -69,27 +69,27 @@ Note that the Serializable isolation level support was added in [v1.2.6](../../.
 
 Create a sample table.
 
-```sql
+```postgresql
 CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1, k2));
 ```
 
 Begin a transaction and insert some rows.
 
-```sql
+```postgresql
 BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
 ```
 
-```sql
+```postgresql
 INSERT INTO sample(k1, k2, v1, v2) VALUES (1, 2.0, 3, 'a'), (1, 3.0, 4, 'b');
 ```
 
 Start a new shell  with `ysqlsh` and begin another transaction to insert some more rows.
 
-```sql
+```postgresql
 BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
 ```
 
-```sql
+```postgresql
 INSERT INTO sample(k1, k2, v1, v2) VALUES (2, 2.0, 3, 'a'), (2, 3.0, 4, 'b');
 ```
 
@@ -97,7 +97,7 @@ In each shell, check the only the rows from the current transaction are visible.
 
 1st shell.
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample; -- run in first shell
 ```
 
@@ -111,7 +111,7 @@ yugabyte=# SELECT * FROM sample; -- run in first shell
 
 2nd shell
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample; -- run in second shell
 ```
 
@@ -125,19 +125,19 @@ yugabyte=# SELECT * FROM sample; -- run in second shell
 
 Commit the first transaction and abort the second one.
 
-```sql
+```postgresql
 COMMIT TRANSACTION; -- run in first shell.
 ```
 
 Abort the current transaction (from the first shell).
 
-```sql
+```postgresql
 ABORT TRANSACTION; -- run second shell.
 ```
 
 In each shell check that only the rows from the committed transaction are visible.
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample; -- run in first shell.
 ```
 
@@ -149,7 +149,7 @@ yugabyte=# SELECT * FROM sample; -- run in first shell.
 (2 rows)
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample; -- run in second shell.
 ```
 

--- a/docs/content/latest/api/ysql/commands/txn_commit.md
+++ b/docs/content/latest/api/ysql/commands/txn_commit.md
@@ -63,27 +63,27 @@ Add optional keyword — has no effect.
 
 Create a sample table.
 
-```sql
+```postgresql
 CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1, k2));
 ```
 
 Begin a transaction and insert some rows.
 
-```sql
+```postgresql
 BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
 ```
 
-```sql
+```postgresql
 INSERT INTO sample(k1, k2, v1, v2) VALUES (1, 2.0, 3, 'a'), (1, 3.0, 4, 'b');
 ```
 
 Start a new shell  with `ysqlsh` and begin another transaction to insert some more rows.
 
-```sql
+```postgresql
 yugabyte=# BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
 ```
 
-```sql
+```postgresql
 INSERT INTO sample(k1, k2, v1, v2) VALUES (2, 2.0, 3, 'a'), (2, 3.0, 4, 'b');
 ```
 
@@ -91,7 +91,7 @@ In each shell, check the only the rows from the current transaction are visible.
 
 1st shell.
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample; -- run in first shell
 ```
 
@@ -104,7 +104,7 @@ yugabyte=# SELECT * FROM sample; -- run in first shell
 ```
 2nd shell
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample; -- run in second shell
 ```
 
@@ -118,19 +118,19 @@ yugabyte=# SELECT * FROM sample; -- run in second shell
 
 Commit the first transaction and abort the second one.
 
-```sql
+```postgresql
 COMMIT TRANSACTION; -- run in first shell.
 ```
 
 Abort the current transaction (from the first shell).
 
-```sql
+```postgresql
 ABORT TRANSACTION; -- run second shell.
 ```
 
 In each shell check that only the rows from the committed transaction are visible.
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample; -- run in first shell.
 ```
 
@@ -142,7 +142,7 @@ yugabyte=# SELECT * FROM sample; -- run in first shell.
 (2 rows)
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample; -- run in second shell.
 ```
 

--- a/docs/content/latest/api/ysql/commands/txn_set.md
+++ b/docs/content/latest/api/ysql/commands/txn_set.md
@@ -118,27 +118,27 @@ Note that the Serializable isolation level support was added in [v1.2.6](../../.
 
 Create a sample table.
 
-```sql
+```postgresql
 yugabyte=# CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1, k2));
 ```
 
 Begin a transaction and insert some rows.
 
-```sql
+```postgresql
 yugabyte=# BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
 ```
 
-```sql
+```postgresql
 yugabyte=# INSERT INTO sample(k1, k2, v1, v2) VALUES (1, 2.0, 3, 'a'), (1, 3.0, 4, 'b');
 ```
 
 Start a new shell  with `ysqlsh` and begin another transaction to insert some more rows.
 
-```sql
+```postgresql
 yugabyte=# BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
 ```
 
-```sql
+```postgresql
 yugabyte=# INSERT INTO sample(k1, k2, v1, v2) VALUES (2, 2.0, 3, 'a'), (2, 3.0, 4, 'b');
 ```
 
@@ -146,7 +146,7 @@ In each shell, check the only the rows from the current transaction are visible.
 
 1st shell.
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample; -- run in first shell
 ```
 
@@ -160,7 +160,7 @@ yugabyte=# SELECT * FROM sample; -- run in first shell
 
 2nd shell
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample; -- run in second shell
 ```
 
@@ -174,19 +174,19 @@ yugabyte=# SELECT * FROM sample; -- run in second shell
 
 Commit the first transaction and abort the second one.
 
-```sql
+```postgresql
 yugabyte=# COMMIT TRANSACTION; -- run in first shell.
 ```
 
 Abort the current transaction (from the first shell).
 
-```sql
+```postgresql
 yugabyte=# ABORT TRANSACTION; -- run second shell.
 ```
 
 In each shell check that only the rows from the committed transaction are visible.
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample; -- run in first shell.
 ```
 
@@ -198,7 +198,7 @@ yugabyte=# SELECT * FROM sample; -- run in first shell.
 (2 rows)
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM sample; -- run in second shell.
 ```
 

--- a/docs/content/latest/api/ysql/exprs/func_currval.md
+++ b/docs/content/latest/api/ysql/exprs/func_currval.md
@@ -28,7 +28,7 @@ Specify the name of the sequence.
 
 ### Create a sequence
 
-```sql
+```postgresql
 yugabyte=# CREATE SEQUENCE s;
 ```
 
@@ -38,7 +38,7 @@ CREATE SEQUENCE
 
 Call `nextval()`.
 
-```sql
+```postgresql
 yugabyte=# SELECT nextval('s');
 ```
 
@@ -49,7 +49,7 @@ yugabyte=# SELECT nextval('s');
 (1 row)
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT currval('s');
 ```
 
@@ -62,7 +62,7 @@ yugabyte=# SELECT currval('s');
 
 Call `currval()` before `nextval()` is called.
 
-```sql
+```postgresql
 yugabyte=# CREATE SEQUENCE s2;
 ```
 
@@ -70,7 +70,7 @@ yugabyte=# CREATE SEQUENCE s2;
 CREATE SEQUENCE
 ```
 
-```sql
+```postgresql
 SELECT currval('s2');
 ```
 

--- a/docs/content/latest/api/ysql/exprs/func_lastval.md
+++ b/docs/content/latest/api/ysql/exprs/func_lastval.md
@@ -24,7 +24,7 @@ Use the `lastval()` function to return the value returned from the last call to 
 
 Create two sequences and call `nextval()` for each of them.
 
-```sql
+```postgresql
 yugabyte=# CREATE SEQUENCE s1;
 ```
 
@@ -32,7 +32,7 @@ yugabyte=# CREATE SEQUENCE s1;
 CREATE SEQUENCE
 ```
 
-```sql
+```postgresql
 yugabyte=# CREATE SEQUENCE s2 START -100 MINVALUE -100;
 ```
 
@@ -40,7 +40,7 @@ yugabyte=# CREATE SEQUENCE s2 START -100 MINVALUE -100;
 CREATE SEQUENCE
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT nextval('s1');
 ```
 
@@ -51,7 +51,7 @@ yugabyte=# SELECT nextval('s1');
 (1 row)
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT nextval('s2');
 ```
 
@@ -64,7 +64,7 @@ yugabyte=# SELECT nextval('s2');
 
 Call `lastval()`.
 
-```sql
+```postgresql
 yugabyte=# SELECT lastval()
 ```
 

--- a/docs/content/latest/api/ysql/exprs/func_nextval.md
+++ b/docs/content/latest/api/ysql/exprs/func_nextval.md
@@ -28,7 +28,7 @@ Specify the name of the sequence.
 
 ### Create a simple sequence that increments by 1 every time nextval() is called
 
-```sql
+```postgresql
 yugabyte=# CREATE SEQUENCE s;
 ```
 
@@ -38,7 +38,7 @@ CREATE SEQUENCE
 
 Call nextval() a couple of times.
 
-```sql
+```postgresql
 yugabyte=# SELECT nextval('s');
 ```
 
@@ -49,7 +49,7 @@ yugabyte=# SELECT nextval('s');
 (1 row)
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT nextval('s');
 ```
 
@@ -62,7 +62,7 @@ yugabyte=# SELECT nextval('s');
 
 ### Create a sequence with a cache of 3 values
 
-```sql
+```postgresql
 yugabyte=# CREATE SEQUENCE s2 CACHE 3;
 ```
 
@@ -72,7 +72,7 @@ CREATE SEQUENCE
 
 In the same session, call `nextval()`. The first time it's called, the session's cache will allocate numbers 1, 2, and 3. This means that the data for this sequence will have its `last_val` set to 3. This modification requires two RPC requests.
 
-```sql
+```postgresql
 SELECT nextval('s2');
 ```
 
@@ -85,7 +85,7 @@ SELECT nextval('s2');
 
 The next call of `nextval()` in the same session will not generate new numbers for the sequence, so it is much faster than the first `nextval()` call because it will just use the next value available from the cache.
 
-```sql
+```postgresql
 SELECT nextval('s2');
 ```
 

--- a/docs/content/latest/api/ysql/extensions.md
+++ b/docs/content/latest/api/ysql/extensions.md
@@ -28,7 +28,7 @@ The `pgcrypto` extension provides various cryptographic functions.
 -->
 <h4> Example </h4>
 
-```sql
+```postgresql
 CREATE EXTENSION pgcrypto;
 CREATE TABLE pgcrypto_example(id uuid PRIMARY KEY DEFAULT gen_random_uuid(), content text, digest text);
 INSERT INTO pgcrypto_example (content, digest) values ('abc', digest('abc', 'sha1'));
@@ -51,7 +51,7 @@ The `fuzzystrmatch` extension provides several functions to determine similariti
 
 <h4> Example </h4>
 
-```sql
+```postgresql
 CREATE EXTENSION fuzzystrmatch;
 SELECT levenshtein('Yugabyte', 'yugabyte'), metaphone('yugabyte', 8);
 ```
@@ -77,7 +77,7 @@ The specific extensions currently supported in YSQL are:
 
 1. Set up a table with triggers for tracking modification time and user (role).
     Connect with `ysqlsh` and run the commands below.
-    ```sql
+    ```postgresql
     CREATE EXTENSION insert_username;
     CREATE EXTENSION moddatetime;
 
@@ -102,7 +102,7 @@ The specific extensions currently supported in YSQL are:
 2. Insert some rows.
     Each insert should add the current role as `username` and the current timestamp as `moddate`.
 
-    ```sql
+    ```postgresql
     SET ROLE yugabyte;
     INSERT INTO spi_test VALUES(1, 'desc1');
 
@@ -135,7 +135,7 @@ The specific extensions currently supported in YSQL are:
 3. Update some rows.
     Should update both `username`  and `moddate` accordingly.
 
-    ```sql
+    ```postgresql
     UPDATE spi_test SET content = 'desc1_updated' WHERE id = 1;
     UPDATE spi_test SET content = 'desc3_updated' WHERE id = 3;
 
@@ -282,7 +282,7 @@ This might take a couple of minutes.
 5. Run some sample queries.
     Connect with `ysqlsh` and run:
 
-    ```sql
+    ```postgresql
     SELECT name, area_km2, ST_Area(geom), ST_Area(geom)/area_km2 AS area_ratio FROM "geo_export" LIMIT 10;
     ```
 
@@ -302,7 +302,7 @@ This might take a couple of minutes.
     (10 rows)
     ```
 
-    ```sql
+    ```postgresql
     SELECT a.name, b.name FROM "geo_export" AS a, "geo_export" AS b
     WHERE ST_Intersects(a.geom, b.geom) AND a.name LIKE 'University of Alberta';
     ```
@@ -344,7 +344,7 @@ $ cp -v "$(pg_config --pkglibdir)"/*uuid-ossp*.so "$(yb_pg_config --pkglibdir)" 
 
 Connect with `ysqlsh` and run:
 
-```sql
+```postgresql
 SELECT uuid_generate_v1(), uuid_generate_v4(), uuid_nil();
 ```
 

--- a/docs/content/latest/architecture/2dc-deployments.md
+++ b/docs/content/latest/architecture/2dc-deployments.md
@@ -80,7 +80,7 @@ Details about each of these life cycle phases follows.
 
 In order to set up a 2DC asynchronous replication, the user runs a command similar to the one here:
 
-```bash
+```sh
 yb-admin -master_addresses <consumer_universe_master_addresses>
 setup_universe_replication <producer_universe_uuid>
   <producer_universe_master_addresses>

--- a/docs/content/latest/deploy/cdc/cdc-to-kafka.md
+++ b/docs/content/latest/deploy/cdc/cdc-to-kafka.md
@@ -41,7 +41,7 @@ To get a local Confluent Platform (with Apache Kafka) up and running quickly, fo
 
 With your local YugabyteDB cluster running, create a table, called `users`, in the default database (`yugabyte`).
 
-```sql
+```postgresql
 CREATE TABLE users (name text, pass text, id int, primary key (id));
 ```
 
@@ -85,13 +85,13 @@ You can use the following two Avro schema examples that will work with the `user
 
 1. Create a Kafka topic.
 
-    ```bash
+    ```sh
     ./bin/kafka-topics --create --partitions 1 --topic users_topic --bootstrap-server localhost:9092 --replication-factor 1
     ```
 
 2. Start the Kafka consumer service.
 
-    ```bash
+    ```sh
     bin/kafka-avro-console-consumer --bootstrap-server localhost:9092 --topic users_topic --key-deserializer=io.confluent.kafka.serializers.KafkaAvroDeserializer     --value-deserializer=io.confluent.kafka.serializers.KafkaAvroDeserializer
     ```
 
@@ -103,7 +103,7 @@ Download the [Yugabyte CDC connector (JAR file)](https://github.com/yugabyte/yb-
 
 Run the following command to start logging an output stream of data changes from YugabyteDB to Apache Kafka.
 
-```bash
+```sh
 java -jar target/yb_cdc_connector.jar
 --table_name yugabyte.cdc
 --topic_name cdc-test

--- a/docs/content/latest/deploy/cdc/cdc-to-stdout.md
+++ b/docs/content/latest/deploy/cdc/cdc-to-stdout.md
@@ -29,7 +29,7 @@ A JRE (or JDK), for Java 8 or later, is installed. JDK and JRE installers for Li
 
 Start your local YugabyteDB cluster and add a table, named `users`, to the default `yugabyte` database.
 
-```sql
+```postgresql
 
 ```
 
@@ -41,7 +41,7 @@ Download the [Yugabyte CDC connector (JAR file)](https://github.com/yugabyte/yb-
 
 Run the command below to to start the YugabyteDB CDC connector and stream the output from the `cdc` table to `stdout`.
 
-```bash
+```sh
 java -jar yb_cdc_connector.jar
 --table_name yugabyte.users
 --log_only

--- a/docs/content/latest/deploy/cdc/use-cdc.md
+++ b/docs/content/latest/deploy/cdc/use-cdc.md
@@ -65,7 +65,7 @@ To use the Yugabyte CDC connector, run the `yb_cdc_connector` JAR file.
 
 ### Syntax for Apache Kafka
 
-```bash
+```sh
 java -jar target/yb_cdc_connector.jar
 --table_name <namespace>.<table>
 --master_addrs <yb-master-addresses>
@@ -79,7 +79,7 @@ java -jar target/yb_cdc_connector.jar
 
 ### Syntax for stdout
 
-```bash
+```sh
 java -jar yb_cdc_connector.jar
 --table_name <namespace>.<table>
 --master_addrs <yb-master-addresses>
@@ -135,7 +135,7 @@ To get the stream ID, run the YugabyteDB CDC connector and the first time you ca
 
 The following command will start the Yugabyte CDC connector and send an output stream from a 3-node YugabyteDB cluster to `stdout`.
 
-```bash
+```sh
 java -jar yb_cdc_connector.jar
 --master_addrs 127.0.0.1,127.0.0.2,127.0.0.3
 --table_name yugabyte.users
@@ -146,7 +146,7 @@ java -jar yb_cdc_connector.jar
 
 The following command will start the Yugabyte CDC connector and send an output stream from a 3-node YugabyteDB cluster to a Kafka topic.
 
-```bash
+```sh
 java -jar target/yb_cdc_connector.jar
 --table_name yugabyte.users
 --master_addrs 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100

--- a/docs/content/latest/deploy/kubernetes/rook-operator.md
+++ b/docs/content/latest/deploy/kubernetes/rook-operator.md
@@ -26,7 +26,7 @@ Verify that your Kubernetes cluster is ready for Rook by reviewing the [Kubernet
 
 Rook must be installed — see the [Rook GitHub Repository](https://github.com/rook/rook). You can install Rook by running the following command:
 
-```bash
+```sh
 git clone git@github.com:rook/rook.git
 ```
 
@@ -36,19 +36,19 @@ To deploy the YugabyteDB operator:
 
 1. Change your directory to the Rook directory containing the YugabyteDB example files.
 
-    ```bash
+    ```sh
     cd cluster/examples/kubernetes/yugabytedb
     ```
 
 2. Create the Rook YugabyteDB operator by running the following command:
 
-    ```bash
+    ```sh
     kubectl create -f operator.yaml
     ```
 
 3. Observe the Rook operator by running the following command:
 
-    ```bash
+    ```sh
     kubectl -n rook-yugabytedb-system get pods
     ```
 
@@ -58,7 +58,7 @@ When using the Rook YugabyteDB operator, your YugabyteDB clusters are controlled
 
 A sample Custom Resource Definition (CRD) file, called `cluster.yaml`, is located in the following Rook directory:
 
-```bash
+```sh
 cluster/examples/kubernetes/yugabytedb
 ```
 
@@ -68,19 +68,19 @@ Make a copy of the sample CRD file (`cluster.yaml`)  and modify it as needed. Fo
 
 1. Create your YugabyteDB cluster by running the following command:
 
-    ```bash
+    ```sh
     kubectl create -f cluster.yaml
     ```
 
 2. Verify that the custom resource object was created by using the following command:
 
-    ```bash
+    ```sh
     kubectl -n rook-yugabytedb get ybclusters.yugabytedb.rook.io
     ```
 
 3. Verify that the number of YB-Master and YB- TServer services that are running match the number you specified in the `cluster.yaml` file by running the following command:
 
-    ```bash
+    ```sh
     kubectl -n rook-yugabytedb get pods
     ```
 
@@ -116,7 +116,7 @@ Manually delete any Persistent Volumes that were created for this YugabyteDB clu
 
 If the cluster does not start,  run following command to take a look at operator logs.
 
-```bash
+```sh
 kubectl -n rook-yugabytedb-system logs -l app=rook-yugabytedb-operator
 ```
 
@@ -124,7 +124,7 @@ kubectl -n rook-yugabytedb-system logs -l app=rook-yugabytedb-operator
 
 If everything is OK in the operator logs, check the YugabyteDB logs for YB-Master and YB-TServer.
 
-```bash
+```sh
 kubectl -n rook-yugabytedb logs -l app=yb-master-rook-yugabytedb
 kubectl -n rook-yugabytedb logs -l app=yb-tserver-rook-yugabytedb
 ```

--- a/docs/content/latest/deploy/replicate-2dc.md
+++ b/docs/content/latest/deploy/replicate-2dc.md
@@ -47,7 +47,7 @@ After creating the required tables, you can now set up the replication behavior.
 
 2. Run the following `yb-admin` command.
 
-```bash
+```sh
 yb-admin -master_addresses <consumer_universe_master_addresses>
 setup_universe_replication <producer_universe_uuid>
   <producer_universe_master_addresses>
@@ -56,7 +56,7 @@ setup_universe_replication <producer_universe_uuid>
 
 ### Example
 
-```bash
+```sh
 yb-admin -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 setup_universe_replication e260b8b6-e89f-4505-bb8e-b31f74aa29f3 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 000030a5000030008000000000004000,000030a5000030008000000000004005,dfef757c415c4b2cacc9315b8acb539a
 ```
 
@@ -78,13 +78,13 @@ Note that this time, “yugabyte-producer” will be set up to consume data from
 
 #### YSQL example
 
-```bash
+```sh
 java -jar target/yb-sample-apps.jar --workload SqlSecondaryIndex  --nodes 127.0.0.1:5433
 ```
 
 #### YCQL example
 
-```bash
+```sh
 java -jar target/yb-sample-apps.jar --workload CassandraBatchKeyValue --nodes 127.0.0.1:9042
 ```
 

--- a/docs/content/latest/develop/ecosystem-integrations/metabase.md
+++ b/docs/content/latest/develop/ecosystem-integrations/metabase.md
@@ -62,15 +62,15 @@ yugabyte=#
 
 ### Create a database
 
-```sql
+```postgresql
 yugabyte=# CREATE DATABASE yb_demo;
 ```
 
-```sql
+```postgresql
 yugabyte=# GRANT ALL ON DATABASE yb_demo to postgres;
 ```
 
-```sql
+```postgresql
 yugabyte=# \c yb_demo;
 ```
 
@@ -78,25 +78,25 @@ yugabyte=# \c yb_demo;
 
 First create the 4 tables necessary to store the data.
 
-```sql
+```postgresql
 yugabyte=# \i 'schema.sql';
 ```
 
 Now load the data into the tables.
 
-```sql
+```postgresql
 yugabyte=# \i 'data/products.sql'
 ```
 
-```sql
+```postgresql
 yugabyte=# \i 'data/users.sql'
 ```
 
-```sql
+```postgresql
 yugabyte=# \i 'data/orders.sql'
 ```
 
-```sql
+```postgresql
 yugabyte=# \i 'data/reviews.sql'
 ```
 

--- a/docs/content/latest/develop/graphql/hasura.md
+++ b/docs/content/latest/develop/graphql/hasura.md
@@ -29,7 +29,7 @@ To use Hasura with YugabyteDB, the configuration should be similar to PostgreSQL
 
 For a local Mac setup, the configuration should be:
 
-```
+```sh
 docker run -d -p 8080:8080 \
        -e HASURA_GRAPHQL_DATABASE_URL=postgres://postgres:@host.docker.internal:5433/postgres \
        -e HASURA_GRAPHQL_ENABLE_CONSOLE=true \
@@ -47,7 +47,7 @@ Make sure that the release version specified for `hasura/graphql-engine` matches
 
 To start Hasura, run the following script:
 
-```bash
+```sh
 ./docker-run.sh
 ```
 
@@ -57,7 +57,7 @@ This initialization step may take a minute or more.
 
 To check the Docker logs, you can use the container ID returned by the command above:
 
-```bash
+```sh
 docker logs <container-id>
 ```
 
@@ -113,13 +113,13 @@ Click **Add**, and then click **Save**.
 
 1. On the command line, change your directory to the root `yugabyte` directory, and then open `ysqlsh` (the YSQL CLI) to connect to the YugabyteDB cluster:
 
-```bash
+```sh
 ./bin/ysqlsh
 ```
 
 2. Copy the commands below into the shell and press **Enter**.
 
-```sql
+```postgresql
 SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SERIALIZABLE
 INSERT INTO author(name) VALUES ('John Doe'), ('Jane Doe')
 INSERT INTO article(title, content, rating, author_id) 
@@ -144,7 +144,7 @@ Go back to the Hasura UI, click the **GRAPHQL** tab on top.
 
 Fetch a list of articles and sort each article’s author in descending order and by rating.
 
-```json
+```graphql
 {
   article(order_by: {rating: desc}) {
     id
@@ -163,7 +163,7 @@ Fetch a list of articles and sort each article’s author in descending order an
 
 Fetch a list of authors and a nested list of each author’s articles where the authors are ordered by descending by the average ratings of their articles, and their article lists are ordered by title.
 
- ```json
+ ```graphql
  {
    author(order_by: {articles_aggregate: {avg: {rating: desc}}}) {
      name
@@ -184,24 +184,24 @@ Now that you're done with this exploration, you can clean up the pieces for your
 
 1. Stop the YugabyteDB cluster by running the `yb-ctl stop` command.
 
-    ```bash
+    ```sh
     ./bin/yb-ctl stop
     ```
 
     Note: To completely remove all YugabyteDB data/cluster-state you can instead run:
 
-    ```bash
+    ```sh
     ./bin/yb-ctl destroy
     ```
 
 2. Stop The Hasura container,
 
-    ```bash
+    ```sh
     docker stop <container-id>
     ```
 
     You can list running containers using the following command:
 
-    ```bash
+    ```sh
     docker ps
     ```

--- a/docs/content/latest/develop/graphql/prisma.md
+++ b/docs/content/latest/develop/graphql/prisma.md
@@ -21,7 +21,7 @@ Explore how you can use Prisma, and its GraphQL support, to interact with Yugaby
 
 If YugabyteDB is installed, run the following `yb-ctl create` command to start a YugabyteDB 1-node cluster, setting the default transaction isolation level to `serializable`:
 
-```bash
+```sh
 ./bin/yb-ctl create --tserver_flags='ysql_pg_conf="default_transaction_isolation=serializable"'
 ```
 
@@ -52,7 +52,7 @@ For more information, see [Set up Prisma (for a new database)](https://www.prism
 
 To set up a Prisma project, named `prisma-yb`, run the following command.
 
-```bash
+```sh
 prisma init prisma-yb
 ```
 
@@ -81,7 +81,7 @@ When finished, the following three files have created in the project directory, 
 
 To start the Prisma server (in the Docker container) and launch the connected YugabyteDB database, go to the `prisma-yb` directory and then run the `docker-compose` command:
 
-```bash
+```sh
 cd prisma-yb
 docker-compose up -d
 ```
@@ -115,7 +115,7 @@ type User {
 
 To deploy the Prisma service, run the following command:
 
-```bash
+```sh
 prisma deploy
 ```
 
@@ -129,7 +129,7 @@ For details on writing data with the Prisma client, see [Writing Data (JavaScrip
 
 1. Create a user Jane with three postings
 
-```json
+```graphql
 mutation {
   createUser(data: {
     name: "Jane Doe"
@@ -160,7 +160,7 @@ mutation {
 
 2. Create a user John with two postings.
 
-```json
+```graphql
 mutation {
   createUser(data: {
     name: "John Doe"
@@ -193,7 +193,7 @@ For details on using the Prisma client to read data, see [Reading Data (JavaScri
 
 ### Get all users
 
-```json
+```graphqlå
 {
   users {
     id
@@ -208,7 +208,7 @@ For details on using the Prisma client to read data, see [Reading Data (JavaScri
 
 ### Get all posts
 
-```json
+```graphql
 {
   posts {
     id
@@ -223,7 +223,7 @@ For details on using the Prisma client to read data, see [Reading Data (JavaScri
 
 ### Get all users – ordered alphabetically
 
-```json
+```graphql
 {
   users(orderBy: name_ASC) {
     name
@@ -239,7 +239,7 @@ For details on using the Prisma client to read data, see [Reading Data (JavaScri
 
 ### Get all posts – ordered by popularity.
 
-```json
+```graphql
 {
   posts(orderBy: views_DESC) {
     text
@@ -260,7 +260,7 @@ In this subsection, you can take a quick look at the Prisma ORM functionality.
 
 Initialize an NPM project.
 
-```bash
+```sh
 npm init -y
 npm install --save prisma-client-lib
 ```
@@ -269,7 +269,7 @@ npm install --save prisma-client-lib
 
 1. Create a file
 
-```bash
+```sh
 touch index.js
 ```
 
@@ -306,7 +306,7 @@ The code above will create a new user `Alice` and a new post for that user. Fina
 
 3. Run the file:
 
-```bash
+```sh
 node index.js
 ```
 
@@ -318,13 +318,13 @@ Now that you're done with this exploration, you can clean up the pieces for your
 
 1. Stop the YugabyteDB cluster
 
-```bash
+```sh
 ./bin/yb-ctl stop
 ```
 
 To completely remove all YugabyteDB data/cluster-state you can instead run:
 
-```bash
+```sh
 ./bin/yb-ctl destroy
 2. Stop The Prisma container
 docker stop <container-id>
@@ -332,7 +332,7 @@ docker stop <container-id>
 
 To completely remove all Prisma data/tate you can additionally run:
 
-```bash
+```sh
 docker rm <container-id>
 ```
 

--- a/docs/content/latest/develop/realworld-apps/retail-analytics.md
+++ b/docs/content/latest/develop/realworld-apps/retail-analytics.md
@@ -60,15 +60,15 @@ yugabyte=#
 
 You can do this as shown below.
 
-```sql
+```postgresql
 yugabyte=# CREATE DATABASE yb_demo;
 ```
 
-```sql
+```postgresql
 yugabyte=# GRANT ALL ON DATABASE yb_demo to postgres;
 ```
 
-```sql
+```postgresql
 yugabyte=# \c yb_demo;
 ```
 
@@ -76,25 +76,25 @@ yugabyte=# \c yb_demo;
 
 First create the four tables necessary to store the data.
 
-```sql
+```postgresql
 yugabyte=# \i 'schema.sql';
 ```
 
 Now load the data into the tables.
 
-```sql
+```postgresql
 yugabyte=# \i 'data/products.sql'
 ```
 
-```sql
+```postgresql
 yugabyte=# \i 'data/users.sql'
 ```
 
-```sql
+```postgresql
 yugabyte=# \i 'data/orders.sql'
 ```
 
-```sql
+```postgresql
 yugabyte=# \i 'data/reviews.sql'
 ```
 
@@ -102,7 +102,7 @@ yugabyte=# \i 'data/reviews.sql'
 
 ### How are users signing up for my site?
 
-```sql
+```postgresql
 yb_demo=# SELECT DISTINCT(source) FROM users;
 ```
 
@@ -119,7 +119,7 @@ source
 
 ### What is the most effective channel for user signups?
 
-```sql
+```postgresql
 yb_demo=# SELECT source, count(*) AS num_user_signups
           FROM users
           GROUP BY source
@@ -139,7 +139,7 @@ source     | num_user_signups
 
 ### What are the most effective channels for product sales by revenue?
 
-```sql
+```postgresql
 yb_demo=# SELECT source, ROUND(SUM(orders.total)) AS total_sales
           FROM users, orders WHERE users.id=orders.user_id
           GROUP BY source
@@ -159,7 +159,7 @@ source     | total_sales
 
 ### What is the min, max and average price of products in the store?
 
-```sql
+```postgresql
 yb_demo=# SELECT MIN(price), MAX(price), AVG(price) FROM products;
 ```
 
@@ -174,7 +174,7 @@ min               |       max        |       avg
 
 You can do this as shown below.
 
-```sql
+```postgresql
 yb_demo=# CREATE VIEW channel AS
             (SELECT source, ROUND(SUM(orders.total)) AS total_sales
              FROM users, orders
@@ -185,7 +185,7 @@ yb_demo=# CREATE VIEW channel AS
 
 Now that the view is created, we can see it in our list of relations.
 
-```sql
+```postgresql
 yb_demo=# \d
 ```
 
@@ -201,7 +201,7 @@ List of relations
 (5 rows)
 ```
 
-```sql
+```postgresql
 yb_demo=# SELECT source, total_sales * 100.0 / (SELECT SUM(total_sales) FROM channel) AS percent_sales
           FROM channel WHERE source='Facebook';
 ```

--- a/docs/content/latest/quick-start/build-apps/go/ysql-gorm.md
+++ b/docs/content/latest/quick-start/build-apps/go/ysql-gorm.md
@@ -145,7 +145,7 @@ Type "help" for help.
 yugabyte=#
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT count(*) FROM users;
 ```
 
@@ -156,7 +156,7 @@ yugabyte=# SELECT count(*) FROM users;
 (1 row)
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT count(*) FROM products;
 ```
 
@@ -167,7 +167,7 @@ yugabyte=# SELECT count(*) FROM products;
 (1 row)
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT count(*) FROM orders;
 ```
 

--- a/docs/content/latest/quick-start/build-apps/java/ysql-spring-data.md
+++ b/docs/content/latest/quick-start/build-apps/java/ysql-spring-data.md
@@ -129,7 +129,7 @@ yugabyte=#
 ```
 
 List the tables created by the app.
-```sql
+```postgresql
 yugabyte=# \d
 ```
 ```
@@ -147,7 +147,7 @@ List of relations
 ```
 Note the 4 tables and 3 sequences in the list above.
 
-```sql
+```postgresql
 yugabyte=# SELECT count(*) FROM users;
 ```
 ```
@@ -157,7 +157,7 @@ yugabyte=# SELECT count(*) FROM users;
 (1 row)
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT count(*) FROM products;
 ```
 ```
@@ -167,7 +167,7 @@ yugabyte=# SELECT count(*) FROM products;
 (1 row)
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT count(*) FROM orders;
 ```
 ```
@@ -177,7 +177,7 @@ yugabyte=# SELECT count(*) FROM orders;
 (1 row)
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT * FROM orderline;
 ```
 ```

--- a/docs/content/latest/quick-start/build-apps/nodejs/ysql-sequelize.md
+++ b/docs/content/latest/quick-start/build-apps/nodejs/ysql-sequelize.md
@@ -130,7 +130,7 @@ Type "help" for help.
 yugabyte=#
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT count(*) FROM users;
 ```
 
@@ -141,7 +141,7 @@ yugabyte=# SELECT count(*) FROM users;
 (1 row)
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT count(*) FROM products;
 ```
 
@@ -152,7 +152,7 @@ yugabyte=# SELECT count(*) FROM products;
 (1 row)
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT count(*) FROM orders;
 ```
 

--- a/docs/content/latest/quick-start/build-apps/python/ysql-sqlalchemy.md
+++ b/docs/content/latest/quick-start/build-apps/python/ysql-sqlalchemy.md
@@ -129,7 +129,7 @@ Type "help" for help.
 
 yugabyte=#
 ```
-```sql
+```postgresql
 yugabyte=# SELECT count(*) FROM users;
 ```
 ```
@@ -139,7 +139,7 @@ yugabyte=# SELECT count(*) FROM users;
 (1 row)
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT count(*) FROM products;
 ```
 ```
@@ -149,7 +149,7 @@ yugabyte=# SELECT count(*) FROM products;
 (1 row)
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT count(*) FROM orders;
 ```
 ```

--- a/docs/content/latest/quick-start/build-apps/ruby/ysql-rails-activerecord.md
+++ b/docs/content/latest/quick-start/build-apps/ruby/ysql-rails-activerecord.md
@@ -125,7 +125,7 @@ Type "help" for help.
 yugabyte=#
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT count(*) FROM users;
 ```
 
@@ -136,7 +136,7 @@ yugabyte=# SELECT count(*) FROM users;
 (1 row)
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT count(*) FROM products;
 ```
 
@@ -147,7 +147,7 @@ yugabyte=# SELECT count(*) FROM products;
 (1 row)
 ```
 
-```sql
+```postgresql
 yugabyte=# SELECT count(*) FROM orders;
 ```
 

--- a/docs/content/latest/quick-start/explore-ysql.md
+++ b/docs/content/latest/quick-start/explore-ysql.md
@@ -101,7 +101,7 @@ Follow the steps to create a database and load sample data.
 
 1. Create a database named `yb_demo` by using the following `CREATE DATABASE` command.
 
-    ```sql
+    ```postgresql
     yugabyte=# CREATE DATABASE yb_demo;
     ```
 
@@ -167,7 +167,7 @@ Indexes:
 
 To see how many products there are in this table, you can run the following query.
 
-```sql
+```postgresql
 yb_demo=# SELECT count(*) FROM products;
 ```
 
@@ -182,7 +182,7 @@ You should see an output which looks like the following:
 
 Now let us run a query to select the `id`, `title`, `category` and `price` columns for the first five products.
 
-```sql
+```postgresql
 yb_demo=# SELECT id, title, category, price, rating
           FROM products
           LIMIT 5;
@@ -203,7 +203,7 @@ You should see an output like the following:
 
 To view the next 3 products, we simply add an `OFFSET 5` clause to start from the fifth product.
 
-```sql
+```postgresql
 yb_demo=# SELECT id, title, category, price, rating
           FROM products
           LIMIT 3 OFFSET 5;
@@ -226,7 +226,7 @@ A JOIN clause is used to combine rows from two or more tables, based on a relate
 
 From the `orders` table, we are going to select the `total` column that represents the total amount the user paid. For each of these orders, we are going to fetch the `id`, the `name` and the `email` from the `users` table of the corresponding users that placed those orders. The related column between the two tables is the user's id. This can be expressed as the following join query:
 
-```sql
+```postgresql
 yb_demo=# SELECT users.id, users.name, users.email, orders.id, orders.total
           FROM orders INNER JOIN users ON orders.user_id=users.id
           LIMIT 10;
@@ -257,7 +257,7 @@ Imagine the user with id `1` wants to order for `10` units of the product with i
 
 Before running the transaction, we can verify that we have `5000` units of product `2` in stock by running the following query:
 
-```sql
+```postgresql
 yb_demo=# SELECT id, category, price, quantity FROM products WHERE id=2;
 ```
 
@@ -271,7 +271,7 @@ SELECT id, category, price, quantity FROM products WHERE id=2;
 
 Now, to place the order, we can run the following transaction:
 
-```sql
+```postgresql
 yb_demo=# BEGIN TRANSACTION;
 
 /* First insert a new order into the orders table. */
@@ -297,11 +297,11 @@ COMMIT;
 
 We can verify that the order got inserted by running the following:
 
-```sql
+```postgresql
 yb_demo=# select * from orders where id = (select max(id) from orders);
 ```
 
-```sql
+```postgresql
 select * from orders where id = (select max(id) from orders);
   id   |        created_at         | user_id | product_id | discount | quantity |     subtotal     | tax |      total
 -------+---------------------------+---------+------------+----------+----------+------------------+-----+------------------
@@ -311,11 +311,11 @@ select * from orders where id = (select max(id) from orders);
 
 We can also verify that total quantity of product id `2` in the inventory is `4990` by running the following query.
 
-```sql
+```postgresql
 yb_demo=# SELECT id, category, price, quantity FROM products WHERE id=2;
 ```
 
-```sql
+```postgresql
 SELECT id, category, price, quantity FROM products WHERE id=2;
  id | category  |      price       | quantity
 ----+-----------+------------------+----------
@@ -331,7 +331,7 @@ YSQL supports a rich set of built-in functions. In this example, we will look at
 
 To answer this question, we should list the unique set of `source` channels present in the database. This can be achieved as follows:
 
-```sql
+```postgresql
 yb_demo=# SELECT DISTINCT(source) FROM users;
 ```
 
@@ -348,7 +348,7 @@ source
 
 - What is the min, max and average price of products in the store?
 
-```sql
+```postgresql
 yb_demo=# SELECT MIN(price), MAX(price), AVG(price) FROM products;
 ```
 
@@ -365,7 +365,7 @@ The `GROUP BY` clause is commonly used to perform aggregations. Below are a coup
 
 - What is the most effective channel for user signups?
 
-```sql
+```postgresql
 yb_demo=# SELECT source, count(*) AS num_user_signups
           FROM users
           GROUP BY source
@@ -385,7 +385,7 @@ source     | num_user_signups
 
 - What are the most effective channels for product sales by revenue?
 
-```sql
+```postgresql
 yb_demo=# SELECT source, ROUND(SUM(orders.total)) AS total_sales
           FROM users, orders WHERE users.id=orders.user_id
           GROUP BY source
@@ -409,7 +409,7 @@ Let us answer the questions below by creating a view.
 
 - What percentage of the total sales is from the Facebook channel?
 
-```sql
+```postgresql
 yb_demo=# CREATE VIEW channel AS
             (SELECT source, ROUND(SUM(orders.total)) AS total_sales
              FROM users, orders
@@ -420,7 +420,7 @@ yb_demo=# CREATE VIEW channel AS
 
 Now that the view is created, we can see it in our list of relations.
 
-```sql
+```postgresql
 yb_demo=# \d
 ```
 
@@ -440,7 +440,7 @@ yb_demo=# \d
 (9 rows)
 ```
 
-```sql
+```postgresql
 yb_demo=# SELECT source, 
             total_sales * 100.0 / (SELECT SUM(total_sales) FROM channel) AS percent_sales
           FROM channel

--- a/docs/content/latest/sample-data/chinook.md
+++ b/docs/content/latest/sample-data/chinook.md
@@ -61,7 +61,7 @@ yugabyte=#
 
 To create the `chinook` database, run the following command.
 
-```sql
+```postgresql
 CREATE DATABASE chinook;
 ```
 
@@ -111,7 +111,7 @@ chinook=# \i /Users/yugabyte/chinook_songs.sql
 
 Now verify that you have data by running a simple `SELECT` statement to pull some data from the `Track` table.
 
-```sql
+```postgresql
 chinook=# SELECT "Name", "Composer" FROM "Track" LIMIT 10;
 ```
 

--- a/docs/content/latest/sample-data/northwind.md
+++ b/docs/content/latest/sample-data/northwind.md
@@ -59,7 +59,7 @@ yugabyte=#
 
 To create the Northwind database, run the following CREATE DATABASE command.
 
-```sql
+```postgresql
 CREATE DATABASE northwind;
 ```
 

--- a/docs/content/latest/sample-data/pgexercises.md
+++ b/docs/content/latest/sample-data/pgexercises.md
@@ -57,7 +57,7 @@ yugabyte=#
 
 To create the `exercises` database, run the following SQL `CREATE DATABASE` command.
 
-```sql
+```postgresql
 CREATE DATABASE exercises;
 ```
 

--- a/docs/content/latest/sample-data/sportsdb.md
+++ b/docs/content/latest/sample-data/sportsdb.md
@@ -53,7 +53,7 @@ yugabyte=#
 
 To create the `sportsdb` database, run the following YSQL command
 
-```sql
+```postgresql
 CREATE DATABASE sportsdb;
 ```
 


### PR DESCRIPTION
For the Chroma syntax highlighting:
- For YSQL, replace `sql` with `postgresql`
- Replace `bash` with `sh`
- For GraphQL examples, use `graphql'