### PR TITLE
Add new YSQL flags and update configuration options/flags for CLI section.

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -43,4 +43,5 @@ blackfriday:
   fractions: true
   smartDashes: false
   plainIDAnchors: true
+  noIntraEmphasis: true
 ---

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -41,6 +41,6 @@ menu:
 blackfriday:
   smartypants: true
   fractions: true
-  smartDashes: true
+  smartDashes: false
   plainIDAnchors: true
 ---

--- a/docs/content/latest/admin/_index.html
+++ b/docs/content/latest/admin/_index.html
@@ -23,7 +23,7 @@ aliases:
         <div class="title">yb-ctl</div>
       </div>
       <div class="body">
-        Command line utility to easily manage Linux- and macOS-based local clusters.
+        Command line utility to easily create and manage local clusters on macOS or Linux.
       </div>
     </a>
   </div>
@@ -35,7 +35,7 @@ aliases:
         <div class="title">yb-docker-ctl</div>
       </div>
       <div class="body">
-        Command line utility to easily manage Docker-based local clusters.
+        Command line utility to easily create and manage Docker-based local clusters.
       </div>
     </a>
   </div>
@@ -47,7 +47,7 @@ aliases:
         <div class="title">docker-compose</div>
       </div>
       <div class="body">
-        Manage Docker-based local clusters using docker-compose.
+        Create and manage Docker-based local clusters using docker-compose.
       </div>
     </a>
   </div>
@@ -72,7 +72,7 @@ aliases:
         <div class="title">yb-master</div>
       </div>
       <div class="body">
-        Manages metadata of data stored in yb-tserver and coordinates cluster-wide operations.
+        Manage metadata of data stored in yb-tserver and coordinates cluster-wide operations.
       </div>
     </a>
   </div>
@@ -84,7 +84,7 @@ aliases:
         <div class="title">ysqlsh CLI for YSQL</div>
       </div>
       <div class="body">
-        Command line interface for connecting to YugabyteDB with YSQL.
+        Command line interface for interacting with YugabyteDB using YSQL.
       </div>
     </a>
   </div>
@@ -96,7 +96,7 @@ aliases:
         <div class="title">cqlsh CLI for YCQL</div>
       </div>
       <div class="body">
-        Command line interface for connecting to YugabyteDB with YCQL.
+        Command line interface for interacting with YugabyteDB using YCQL.
       </div>
     </a>
   </div>

--- a/docs/content/latest/admin/cqlsh.md
+++ b/docs/content/latest/admin/cqlsh.md
@@ -33,9 +33,11 @@ $ ./bin/cqlsh --execute "select cluster_name, data_center, rack from system.loca
  local cluster | datacenter1 | rack1
 ```
 
-## Command line options
+## Online help
 
-Run `cqlsh --help` to see all the supported command line options.
+Run `cqlsh --help` to display the online help.
+
+## Syntax
 
 ```sh
 cqlsh [options] [host [port]]

--- a/docs/content/latest/admin/cqlsh.md
+++ b/docs/content/latest/admin/cqlsh.md
@@ -17,11 +17,11 @@ showAsideToc: true
 
 ## Overview
 
-The `cqlsh` shell provides a command line interface (CLI) for interacting with YugabyteDB through [YCQL](../../api/ycql/).
+The YugabyteDB CQL shell (`cqlsh`) provides a command line interface (CLI) for interacting with YugabyteDB using [YCQL](../../api/ycql/).
 
 ## Download
 
-`cqlsh` is installed as part of YugabyteDB and is located in the `bin` directory of YugabyteDB home. It is also available for download and install from YugabyteDB's [GitHub repository](https://github.com/yugabyte/cqlsh/releases).
+The `cqlsh` shell is installed as part of YugabyteDB and is located in the `bin` directory of YugabyteDB home. It is also available for download and install from YugabyteDB's [GitHub repository](https://github.com/yugabyte/cqlsh/releases).
 
 ## Example
 
@@ -35,7 +35,7 @@ $ ./bin/cqlsh --execute "select cluster_name, data_center, rack from system.loca
 
 ## Command line options
 
-Use the **-\-help** option to see all the command line options supported.
+Run `cqlsh --help` to see all the supported command line options.
 
 ```sh
 cqlsh [options] [host [port]]

--- a/docs/content/latest/admin/yb-ctl.md
+++ b/docs/content/latest/admin/yb-ctl.md
@@ -136,7 +136,7 @@ Default: `yugabyte-home/bin/`
 
 Specifies the data directory for YugabyteDB.
 
-Default: `yugabyte-data/`
+Default: `$HOME/yugabyte-data/`
 
 ### --master_flags
 

--- a/docs/content/latest/admin/yb-ctl.md
+++ b/docs/content/latest/admin/yb-ctl.md
@@ -16,30 +16,35 @@ showAsideToc: true
 
 The `yb-ctl` utility, located in the bin directory of YugabyteDB home, provides a simple command line interface for administering local clusters used for development and learning. It invokes the [`yb-master`](../admin/yb-master/) and [`yb-tserver`](../admin/yb-tserver/) binaries to perform the necessary administration.
 
-Use the `--help` option to see all of the supported commands.
+## Online help
+
+Run `yb-ctl --help` to display the online help.
 
 ```sh
 $ ./bin/yb-ctl --help
 ```
 
+## Syntax
+
 ```sh
-usage: yb-ctl [-h] [--binary_dir BINARY_DIR] [--data_dir DATA_DIR]
-              [--replication_factor REPLICATION_FACTOR]
-              [--num_shards_per_tserver NUM_SHARDS_PER_TSERVER]
-              [--timeout TIMEOUT] [--verbose] [--install-if-needed]
-              {create,start,stop,destroy,restart,wipe_restart,add_node,remove_node,start_node,stop_node,restart_node,status,setup_redis}
-              ...
+yb-ctl [ command ] [ argument ]
 ```
 
-## Global options
-
-
+```
+yb-ctl 
+```
 
 ## Commands
 
 ### create
 
-Creates a cluster.
+Creates a local cluster.
+
+For more details and examples, see:
+
+- [Create a local cluster](#create-a-local-cluster)
+- [Create a cluster across multiple zones, regions, and clouds](#Create-a-cluster-across-multiple-zones-regions-and-clouds)
+- [Create a cluster with custom flags](#Create-a-cluster-with-custom-flags).
 
 ### start
 
@@ -53,25 +58,51 @@ Stops the cluster, if running.
 
 Destroys the current cluster.
 
+For details and examples, see:
+
+- [Destroy a local cluster](#destroy-a-local-cluster)
+
 ### status
 
 Display the current status of the cluster.
+
+For details and examples, see:
+
+- [Check cluster status](#check-cluster-status)
 
 ### restart
 
 Restarts the current cluster all at once.
 
+For details and examples, see:
+
+- [Restart a cluster](#restart-a-cluster)
+- [Restart with custom tags](#restart-with-custom-tags)
+
 ### wipe_restart
 
 Stops the current cluster, wipes all data files and starts the cluster as before (losing all flags).
+
+For details and examples, see:
+
+- [Wipe and restart with placement info flags](#wipe-and-restart-with-placement-info-flags)
 
 ### add_node
 
 Adds a new node to the current cluster.
 
+For details and examples, see:
+
+- [Add nodes](#add-nodes)
+- [Create a cluster across multiple zones, regions, and clouds](#create-a-cluster-across-multiple-zones-regions-and-clouds)
+
 ### remove_node
 
 Stops a particular node in the running cluster.
+
+For details and examples, see:
+
+- [Stop and remove nodes](#stop-and-remove-nodes)
 
 ### start_node
 
@@ -81,33 +112,67 @@ Starts a specified node in the running cluster.
 
 Stops the specified node in the running cluster.
 
+For details and examples, see:
+
+- [Stop and remove nodes](#stop-and-remove-nodes)
+
 ### restart_node
 
 Restarts the specified node in a running cluster.
+
+For details and examples, see:
+
+- [Restart node with placement information](#restart-node-with-placement-information)
 
 ### setup_redis
 
 Set up YugabyteDB to support the Redis-compatible YEDIS API.
 
-### Optional arguments
+For details and examples, see [Initialize the YEDIS API](#initialize-the-yedis-api)
 
-### `-h` | `--help`
+## Optional arguments
+
+### --help | -h
 
 Shows the help message and then exits.
 
-### `--binary_dir BINARY_DIR`
+### --binary_dir
 
 Specifies the directory in which to find the YugabyteDB `yb-master` and `yb-tserver` binary files.
 
 Default: `yugabyte-home/bin/`
 
-### `--data_dir DATA_DIR`
+### --data_dir
 
 Specifies the data directory for YugabyteDB.
 
-Default: `/yugabyte-data`
+Default: `yugabyte-data/`
 
-### `--replication_factor REPLICATION_FACTOR` | `--rf REPLICATION_FACTOR`
+### --master_flags
+
+Specifies a list of YB-Master flags, separated by commas.
+
+For details and examples, see [Create a cluster with custom flags](#create-a-cluster-with-custom-flags).
+
+### --tserver_flags
+
+Specifies a list of YB-TServer flags, separated by commas.
+
+For details and examples, see [Create a cluster with custom flags](#create-a-cluster-with-custom-flags).
+
+### --placement_info
+
+Specifies the cloud, region, and zone as `cloud.region.zone`, separated by commas.
+
+Default: `cloud1.datacenter1.rack1`
+
+For details and examples, see:
+
+- [Create a cluster across multiple zones, regions, and clouds](#create-a-cluster-across-multiple-zones-regions-and-clouds)
+- [Restart node with placement information](#restart-node-with-placement-information)
+- [Wipe and restart with placement info flags](#wipe-and-restart-with-placement-info-flags)
+
+### --replication_factor | -rf
 
 Specifies the number of replicas for each tablet. Should be an odd number (for example, `1`, `3`, or `5`) so that majority consensus can be established.
 
@@ -115,31 +180,35 @@ Replication factor for the cluster as well as default number of YB-Master servic
 
 Default: `1`
 
-### `--require_clock_sync`
+### --require_clock_sync
 
 Specifies whether YugabyteDB requires clock synchronization between the nodes in the cluster.
 
 Default: `false`
 
-### `--num_shards_per_tserver NUM_SHARDS_PER_TSERVER`
+### --num_shards_per_tserver
 
 Number of shards (tablets) to start per tablet server for each table.
 
 Default: `2`
 
-### --timeout TIMEOUT
+### --timeout-yb-admin-sec
 
-Timeout in seconds for operations that wait on the cluster.
+Timeout, in seconds, for operations that call `yb-admin` and wait on the cluster.
 
-### `--verbose`
+### --timeout-processes-running-sec
 
-If specified, will log internal debug messages to `stderr`.
+Timeout, in seconds, for operations that wait on the cluster.
+
+### --verbose
+
+Flag to log internal debug messages to `stderr`.
   
-### `--install-if-needed`
+### --install-if-needed
 
 With this option, if YugabyteDB is not yet installed on the system, the latest version will be downloaded and installed automatically.
 
-## Create a cluster
+## Create a local cluster
 
 To quickly create a local YugabyteDB cluster for development and learning, use the `yb-ctl create` command.
 
@@ -147,7 +216,7 @@ In order to ensure that all of the replicas for a given tablet can be placed on 
 
 Each of these initial nodes run a `yb-tserver` service and a `yb-master` service. Note that the number of YB-Master services in a cluster must equal the replication factor for the cluster to be considered operating normally.
 
-### Create a local cluster with RF=1
+### Create a local 1-node cluster with replication factor of 1
 
 ```sh
 $ ./bin/yb-ctl create
@@ -155,7 +224,7 @@ $ ./bin/yb-ctl create
 
 Note that the default replication factor is 1.
 
-### Create a 4-node cluster with RF=3
+### Create a 4-node cluster with replication factor of 3
 
 First create 3-node cluster with replication factor of `3`.
 
@@ -282,10 +351,9 @@ $ ./bin/yb-ctl stop_node 4
 
 At this point of time `remove_node` and `stop_node` do the same thing. So they can be used interchangeably.
 
-## Destroy a cluster
+## Destroy a local cluster
 
-You can use the `yb-ctl destroy` command to destroy a cluster. This command stops all the nodes and
-deletes the data directory of the cluster.
+You can use the `yb-ctl destroy` command to destroy a local cluster. This command stops all the nodes and deletes the data directory of the cluster.
 
 ```sh
 $ ./bin/yb-ctl destroy
@@ -349,7 +417,7 @@ $ ./bin/yb-ctl restart
 $ ./bin/yb-ctl restart --placement_info "cloud1.region1.zone1" 
 ```
 
-- Restart with custom flags
+### Restart with custom flags
 
 ```sh
 $ ./bin/yb-ctl restart --master_flags "log_cache_size_limit_mb=128,log_min_seconds_to_retain=20,master_backup_svc_queue_length=70" --tserver_flags "log_inject_latency=false,log_segment_size_mb=128,raft_heartbeat_interval_ms=1000"

--- a/docs/content/latest/admin/yb-ctl.md
+++ b/docs/content/latest/admin/yb-ctl.md
@@ -130,7 +130,7 @@ Shows the help message and then exits.
 
 Specifies the directory in which to find the YugabyteDB `yb-master` and `yb-tserver` binary files.
 
-Default: `yugabyte-home/bin/`
+Default: `<yugabyte-installation-dir>/bin/`
 
 ### --data_dir
 

--- a/docs/content/latest/admin/yb-ctl.md
+++ b/docs/content/latest/admin/yb-ctl.md
@@ -27,11 +27,7 @@ $ ./bin/yb-ctl --help
 ## Syntax
 
 ```sh
-yb-ctl [ command ] [ argument ]
-```
-
-```
-yb-ctl 
+yb-ctl [ command ] [ argument, argument2, ... ]
 ```
 
 ## Commands

--- a/docs/content/latest/admin/yb-ctl.md
+++ b/docs/content/latest/admin/yb-ctl.md
@@ -58,17 +58,13 @@ Stops the cluster, if running.
 
 Destroys the current cluster.
 
-For details and examples, see:
-
-- [Destroy a local cluster](#destroy-a-local-cluster)
+For details and examples, see [Destroy a local cluster](#destroy-a-local-cluster).
 
 ### status
 
 Display the current status of the cluster.
 
-For details and examples, see:
-
-- [Check cluster status](#check-cluster-status)
+For details and examples, see [Check cluster status](#check-cluster-status).
 
 ### restart
 
@@ -83,9 +79,7 @@ For details and examples, see:
 
 Stops the current cluster, wipes all data files and starts the cluster as before (losing all flags).
 
-For details and examples, see:
-
-- [Wipe and restart with placement info flags](#wipe-and-restart-with-placement-info-flags)
+For details and examples, see [Wipe and restart with placement info flags](#wipe-and-restart-with-placement-info-flags).
 
 ### add_node
 

--- a/docs/content/latest/admin/yb-ctl.md
+++ b/docs/content/latest/admin/yb-ctl.md
@@ -29,55 +29,115 @@ usage: yb-ctl [-h] [--binary_dir BINARY_DIR] [--data_dir DATA_DIR]
               [--timeout TIMEOUT] [--verbose] [--install-if-needed]
               {create,start,stop,destroy,restart,wipe_restart,add_node,remove_node,start_node,stop_node,restart_node,status,setup_redis}
               ...
-
-positional arguments:
-  {create,start,stop,destroy,restart,wipe_restart,add_node,remove_node,start_node,stop_node,restart_node,status,setup_redis}
-    create              Create a new cluster
-    start               Create a new cluster, or start existing cluster if it
-                        already exists.
-    stop                Stops the cluster
-    destroy             Destroy the current cluster
-    restart             Restart the current cluster all at once
-    wipe_restart        Stop the cluster, wipe all data files and start the
-                        cluster as before. Will lose all the flags though.
-    add_node            Add a new node to the current cluster
-    remove_node         Stop a particular node in the cluster.
-    start_node          Start a particular node with flags.
-    stop_node           Stop a particular node in the cluster
-    restart_node        Restart the node specified.
-    status              Get info on the current cluster processes
-    setup_redis         Setup YugabyteDB to support Redis API
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --binary_dir BINARY_DIR
-                        Specify a custom directory in which to find the
-                        yugabyte binaries.
-  --data_dir DATA_DIR   Specify a custom directory where to store data.
-  --replication_factor REPLICATION_FACTOR, --rf REPLICATION_FACTOR
-                        Replication factor for the cluster as well as default
-                        number of masters.
-  --num_shards_per_tserver NUM_SHARDS_PER_TSERVER
-                        Number of shards (tablets) to start per tablet server
-                        for each table.
-  --timeout TIMEOUT     Timeout in seconds for operations that wait on the
-                        cluster
-  --verbose             If specified, will log internal debug messages to
-                        stderr.
-  --install-if-needed   With this option, if YugabyteDB is not yet installed
-                        on the system, the latest version will be downloaded
-                        and installed automatically.
 ```
 
-Here are the default values for all the optional arguments.
+## Global options
 
-| Optional argument                | Default                               | Description                                                  |
-| -------------------------------- | ------------------------------------- | ------------------------------------------------------------ |
-| `--binary_dir`                   | Same directory as the `yb-ctl` binary | Location of the `yb-master` and the `yb-tserver` binaries    |
-| `--data_dir`                     | `/yugabyte-data`         | Location of the data directory for YugabyteDB           |
-| `--replication_factor` or `--rf` | `1`                                   | Number of replicas for each tablet, should be an odd number (e.g. `1`,`3`,`5`) so that majority consensus can be established |
-| `--require_clock_sync`           | `false`                               | Tells YugabyteDB whether to depend on clock synchronization between the nodes in the cluster |
-| `--num_shards_per_tserver`       | `2`                                   | Number of shards (tablets) per tablet server for each table  |
+
+
+## Commands
+
+### create
+
+Creates a cluster.
+
+### start
+
+Starts the existing cluster or, if not existing, creates and starts the cluster.
+
+### stop
+
+Stops the cluster, if running.
+
+### destroy
+
+Destroys the current cluster.
+
+### status
+
+Display the current status of the cluster.
+
+### restart
+
+Restarts the current cluster all at once.
+
+### wipe_restart
+
+Stops the current cluster, wipes all data files and starts the cluster as before (losing all flags).
+
+### add_node
+
+Adds a new node to the current cluster.
+
+### remove_node
+
+Stops a particular node in the running cluster.
+
+### start_node
+
+Starts a specified node in the running cluster.
+
+### stop_node
+
+Stops the specified node in the running cluster.
+
+### restart_node
+
+Restarts the specified node in a running cluster.
+
+### setup_redis
+
+Set up YugabyteDB to support the Redis-compatible YEDIS API.
+
+### Optional arguments
+
+### `-h` | `--help`
+
+Shows the help message and then exits.
+
+### `--binary_dir BINARY_DIR`
+
+Specifies the directory in which to find the YugabyteDB `yb-master` and `yb-tserver` binary files.
+
+Default: `yugabyte-home/bin/`
+
+### `--data_dir DATA_DIR`
+
+Specifies the data directory for YugabyteDB.
+
+Default: `/yugabyte-data`
+
+### `--replication_factor REPLICATION_FACTOR` | `--rf REPLICATION_FACTOR`
+
+Specifies the number of replicas for each tablet. Should be an odd number (for example, `1`, `3`, or `5`) so that majority consensus can be established.
+
+Replication factor for the cluster as well as default number of YB-Master services.
+
+Default: `1`
+
+### `--require_clock_sync`
+
+Specifies whether YugabyteDB requires clock synchronization between the nodes in the cluster.
+
+Default: `false`
+
+### `--num_shards_per_tserver NUM_SHARDS_PER_TSERVER`
+
+Number of shards (tablets) to start per tablet server for each table.
+
+Default: `2`
+
+### --timeout TIMEOUT
+
+Timeout in seconds for operations that wait on the cluster.
+
+### `--verbose`
+
+If specified, will log internal debug messages to `stderr`.
+  
+### `--install-if-needed`
+
+With this option, if YugabyteDB is not yet installed on the system, the latest version will be downloaded and installed automatically.
 
 ## Create a cluster
 
@@ -87,7 +147,7 @@ In order to ensure that all of the replicas for a given tablet can be placed on 
 
 Each of these initial nodes run a `yb-tserver` service and a `yb-master` service. Note that the number of YB-Master services in a cluster must equal the replication factor for the cluster to be considered operating normally.
 
-### Create a local cluster with replication factor of 1
+### Create a local cluster with RF=1
 
 ```sh
 $ ./bin/yb-ctl create
@@ -95,15 +155,15 @@ $ ./bin/yb-ctl create
 
 Note that the default replication factor is 1.
 
-### Create a 4-node cluster with replication factor of 3
+### Create a 4-node cluster with RF=3
 
-First create 3-node cluster with replication factor of 3.
+First create 3-node cluster with replication factor of `3`.
 
 ```sh
 $ ./bin/yb-ctl --rf 3 create
 ```
 
-Add a node to make it a 4-node cluster.
+Use `yb-ctl add_node` command to add a node and make it a 4-node cluster.
 
 ```sh
 $ ./bin/yb-ctl add_node
@@ -115,17 +175,21 @@ $ ./bin/yb-ctl add_node
 $ ./bin/yb-ctl --rf 5 create
 ```
 
-## Default cluster configuration
+## Default directories for clusters created by `yb-ctl`
+
+YugabyteDB clusters created with the `yb-ctl` utility are created locally on the same host and simulate a distributed multi-host cluster.
 
 ### Data directory
 
-Cluster data is installed in `$HOME/yugabyte-data/`.
+YugabyteDB cluster data is installed in `$HOME/yugabyte-data/`.
 
 #### Node directories
 
-`/yugabyte-data/node-#/` directory created for node #.
+For each simulated YugabyteDB node, a `yugabyte-data` subdirectory, named `node-#` (where # is the number of the node), is created.
 
-This directory contains the following.
+`/yugabyte-data/node-#/`
+
+Each `node-#` directory contains the following:
 
 ```sh
 yugabyte-data/node-#/disk-#/
@@ -135,9 +199,9 @@ cluster_config.json
 
 #### Disk directories
 
-`/yugabyte-data/node-#/disk-#/` directory created for each disk.
+For each simulated disk, a `disk-#` subdirectory is created in each "node" directory. `/yugabyte-data/node-#/disk-#/` .
 
-This directory contains the following.
+Each `disk-#` directory contains the following:
 
 ```sh
 yugabyte-data/node-#/disk-#/pg_data/
@@ -146,7 +210,7 @@ yugabyte-data/node-#/disk-#/yb-data/
 
 ### Logs
 
-yb-master logs are located at
+YB-Master logs are added in the following location:
 
 ```sh
 yugabyte-data/node-#/disk-#/yb-data/master.out
@@ -154,7 +218,7 @@ yugabyte-data/node-#/disk-#/yb-data/master/logs
 
 ```
 
-yb-tserver logs are located at
+YB-TServer logs are added in the following location:
 
 ```sh
 yugabyte-data/node-#/disk-#/yb-data/tserver.out
@@ -164,23 +228,22 @@ yugabyte-data/node-#/disk-#/yb-data/tserver/logs
 
 ## Start and stop an existing cluster
 
-Create a new cluster, or start an existing cluster if it already exists.
+Start the existing cluster, or create and start a cluster (if one doesn't exist) by running the `yb-ctl start` command.
 
 ```sh
 $ ./bin/yb-ctl start
 
 ```
 
-Stop a cluster so that you can start it later.
+Stop a cluster so that you can start it later by running the `yb-ctl stop` command.
 
 ```sh
 $ ./bin/yb-ctl stop
-
 ```
 
 ## Check cluster status
 
-You can get the status of the local cluster, including the URLs for the admin UIs for the YB-Master and YB-TServer, by using the `yb-ctl status` command.
+To get the status of your local cluster, including the Admin UI URLs for the YB-Master and YB-TServer, run the `yb-ctl status` command.
 
 ```sh
 $ ./bin/yb-ctl status
@@ -301,19 +364,19 @@ $ ./bin/yb-ctl restart_node 2
 
 ```
 
-- Restart node with placement information
+#### Restart node with placement information
 
 ```sh
 $ ./bin/yb-ctl restart_node 2 --placement_info "cloud1.region1.zone1"
 ```
 
-- Restart master node
+#### Restart master node
 
 ```sh
 $ ./bin/yb-ctl restart_node 2 --master
 ```
 
-- Restart node with flags
+#### Restart node with flags
 
 ```sh
 $ ./bin/yb-ctl restart_node 2 --master --master_flags "log_cache_size_limit_mb=128,log_min_seconds_to_retain=20"
@@ -321,21 +384,21 @@ $ ./bin/yb-ctl restart_node 2 --master --master_flags "log_cache_size_limit_mb=1
 
 ### Wipe and restart a cluster
 
-This command stops all the nodes, removes the underlying data directories, then starts back the same number of nodes that you had in your previous configuration.
+The `yb-ctl wipe_restart` command stops all the nodes, removes the underlying data directories, and then restarts with the same number of nodes that you had in your previous configuration.
 
-Just like the `yb-ctl restart` command the custom defined flags and placement information will be lost during `wipe_restart`, though you can pass placement information and custom flags in the same way as they are passed in the `yb-ctl create` command.
+Just like the `yb-ctl restart` command, the custom-defined flags and placement information will be lost during `wipe_restart`, though you can pass placement information and custom flags in the same way as they are passed in the `yb-ctl create` command.
 
 ```sh
 $ ./bin/yb-ctl wipe_restart
 ```
 
-- Wipe and restart with placement info flags
+#### Wipe and restart with placement info flags
 
 ```sh
 $ ./bin/yb-ctl wipe_restart --placement_info "cloud1.region1.zone1" 
 ```
 
-- Wipe and restart with custom flags
+#### Wipe and restart with custom flags
 
 ```sh
 $ ./bin/yb-ctl wipe_restart --master_flags "log_cache_size_limit_mb=128,log_min_seconds_to_retain=20,master_backup_svc_queue_length=70" --tserver_flags "log_inject_latency=false,log_segment_size_mb=128,raft_heartbeat_interval_ms=1000"

--- a/docs/content/latest/admin/yb-docker-ctl.md
+++ b/docs/content/latest/admin/yb-docker-ctl.md
@@ -26,65 +26,66 @@ $ mkdir ~/yugabyte && cd ~/yugabyte
 $ wget https://downloads.yugabyte.com/yb-docker-ctl && chmod +x yb-docker-ctl
 ```
 
-## Help command
+## Online help
 
-Run `yb-docker-ctl --help` to see the online help for supported commands.
+Run `yb-docker-ctl --help` to display the online help.
 
 ```sh
 $ ./yb-docker-ctl -h
 ```
 
-```
-usage: yb-docker-ctl [-h]
-                     {create,add_node,status,destroy,stop_node,start_node,stop,start,remove_node}
-                     ...
+## Syntax
+
+```sh
+yb-docker-ctl [ command ] [ arguments ]
+
 ```
 
 ## Commands
 
-### `create`
+### create
 
 Creates a local YugabyteDB cluster.
 
-### `add_node`
+### add_node
 
 Adds a new local YugabyteDB cluster node.
 
-### `status`
+### status
 
 Displays the current status of the local YugabyteDB cluster.
 
-### `destroy`
+### destroy
 
 Destroys the local YugabyteDB cluster.
 
-### `stop_node`
+### stop_node
 
 Stops the specified local YugabyteDB cluster node.
 
-### `start_node`
+### start_node
 
 Starts the specified local YugabyteDB cluster node.
 
-### `stop`
+### stop
 
 Stops the local YugabyteDB cluster so that it can be started later.
 
-### `start`
+### start
 
 Starts the local YugabyteDB cluster, if it already exists.
 
-### `remove_node`
+### remove_node
 
 Stops the specified local YugabyteDB cluster node.
 
 ## Optional arguments
 
-### `-h` | `--help`
+### --help | -h
 
 Displays the online help and then exits.
 
-### `--tag`
+### --tag
 
 Use with `create` and `add_node` commands to specify a specific Docker image tag (version). If not included, then latest Docker image is used.
 

--- a/docs/content/latest/admin/yb-docker-ctl.md
+++ b/docs/content/latest/admin/yb-docker-ctl.md
@@ -14,7 +14,7 @@ showAsideToc: true
 
 ---
 
-The `yb-docker-ctl` utility provides a simple command line interface (CLI), or shell, for administering local Docker-based clusters for development and learning. It manages the [YB-Master](../yb-master/) and [YB-TServer](../yb-tserver/) containers to perform the necessary administration.
+The YugabyteDB `yb-docker-ctl` utility provides a simple command line interface (CLI), or shell, for administering a local Docker-based cluster for development and learning. It manages the [YB-Master](../yb-master/) and [YB-TServer](../yb-tserver/) containers to perform the necessary administration.
 
 ## Download
 
@@ -28,7 +28,7 @@ $ wget https://downloads.yugabyte.com/yb-docker-ctl && chmod +x yb-docker-ctl
 
 ## Help command
 
-Use the `-\-help` option to see all of the supported commands.
+Run `yb-docker-ctl --help` to see the online help for supported commands.
 
 ```sh
 $ ./yb-docker-ctl -h
@@ -38,33 +38,61 @@ $ ./yb-docker-ctl -h
 usage: yb-docker-ctl [-h]
                      {create,add_node,status,destroy,stop_node,start_node,stop,start,remove_node}
                      ...
-
-YugabyteDB Docker Container Control
-
-positional arguments:
-  {create,add_node,status,destroy,stop_node,start_node,stop,start,remove_node}
-                        Commands
-    create              Create Yugabyte Cluster
-    add_node            Add a new Yugabyte Cluster Node
-    status              Check Yugabyte Cluster status
-    destroy             Destroy Yugabyte Cluster
-    stop_node           Stop a Yugabyte Cluster Node
-    start_node          Start a Yugabyte Cluster Node
-    stop                Stop Yugabyte Cluster so that it can be started later
-    start               Start Yugabyte Cluster if one already exists
-    remove_node         Stop a Yugabyte Cluster Node
-
-optional arguments:
-  -h, --help            Show the online help and exit
-  --tag                 Use with `create` and `add_node` commands to
-                          specify a specific Docker image tag (version). If not included, then latest Docker image is used.
 ```
+
+## Commands
+
+### `create`
+
+Creates a local YugabyteDB cluster.
+
+### `add_node`
+
+Adds a new local YugabyteDB cluster node.
+
+### `status`
+
+Displays the current status of the local YugabyteDB cluster.
+
+### `destroy`
+
+Destroys the local YugabyteDB cluster.
+
+### `stop_node`
+
+Stops the specified local YugabyteDB cluster node.
+
+### `start_node`
+
+Starts the specified local YugabyteDB cluster node.
+
+### `stop`
+
+Stops the local YugabyteDB cluster so that it can be started later.
+
+### `start`
+
+Starts the local YugabyteDB cluster, if it already exists.
+
+### `remove_node`
+
+Stops the specified local YugabyteDB cluster node.
+
+## Optional arguments
+
+### `-h` | `--help`
+
+Displays the online help and then exits.
+
+### `--tag`
+
+Use with `create` and `add_node` commands to specify a specific Docker image tag (version). If not included, then latest Docker image is used.
 
 ## Create a cluster
 
 Use the `yb-docker-ctl create` command to create a local Docker-based cluster for development and learning.
 
-The number of nodes created when you use the `yb-dockter-ctl create` command is always equal to the replication factor (RF), ensuring that all of the replicas for a given tablet can be placed on different nodes. With the [`add_node`](#add-a-node) and [`remove_node`](#remove-a-node) commands, the size of the cluster can thereafter be expanded or shrunk as needed.
+The number of nodes created when you use the `yb-docker-ctl create` command is always equal to the replication factor (RF), ensuring that all of the replicas for a given tablet can be placed on different nodes. With the [`add_node`](#add-a-node) and [`remove_node`](#remove-a-node) commands, the size of the cluster can thereafter be expanded or shrunk as needed.
 
 ### Specify a docker image tag
 
@@ -80,15 +108,15 @@ $yb-docker-ctl create --tag 1.3.2.1-b2
 
 To get the correct tag value, see the [Docker Hub listing of tags for `yugabytedb/yugabyte`](https://hub.docker.com/r/yugabytedb/yugabyte/tags).
 
-### Create a 1-node local cluster with RF of 1
+### Create a 1-node local cluster with RF=1
 
-To create a 1-node local cluster for development and learning YugabyteDB, run the default `yb-docker-ctl` command. By default, this creates a 1-node cluster with a replication factor (RF) of 1. Note that the `yb-docker-ctl create` command pulls the latest `yugabytedb/yugabyte` image at the outset, in case the image has not yet downloaded or is not the latest version.
+To create a 1-node local YugabyteDB cluster for development and learning, run the default `yb-docker-ctl` command. By default, this creates a 1-node cluster with a replication factor (RF) of 1. Note that the `yb-docker-ctl create` command pulls the latest `yugabytedb/yugabyte` image at the outset, in case the image has not yet downloaded or is not the latest version.
 
 ```sh
 $ ./yb-docker-ctl create
 ```
 
-### Create a 3-node local cluster with RF of 3
+### Create a 3-node local cluster with RF=3
 
 When you create a 3-node local Docker-based cluster using the `yb-docker-ctl create` command, each of the initial nodes run a `yb-tserver` process and a `yb-master` process. Note that the number of YB-Masters in a cluster has to equal to the replication factor (RF) for the cluster to be considered as operating normally and the number of YB-TServers is equal to be the number of nodes.
 

--- a/docs/content/latest/admin/yb-master.md
+++ b/docs/content/latest/admin/yb-master.md
@@ -49,11 +49,11 @@ Shows version and build info, then exits.
 
 #### --master_addresses
 
-Comma-separated list of all the RPC addresses for `yb-master` consensus-configuration. Mandatory.
+Specifies a comma-separated list of all the RPC addresses for `yb-master` consensus-configuration. Mandatory.
 
 #### --fs_data_dirs
 
-Comma-separated list of directories where the `yb-master` will place all it's `yb-data/master` data directory. Mandatory.
+Specifies a comma-separated list of directories where the `yb-master` will place all it's `yb-data/master` data directory. Mandatory.
 
 #### --fs_wal_dirs
 
@@ -63,13 +63,13 @@ Default: Same value as `--fs_data_dirs`
 
 #### --rpc_bind_addresses
 
-Comma-separated list of addresses to bind to for RPC connections. Mandatory.
+Speicies a comma-separated list of addresses to bind to for RPC connections. Mandatory.
 
 Default: `0.0.0.0:7100`
 
 #### --server_broadcast_addresses
 
-Public IP or DNS hostname of the server (along with an optional port).
+Specifies the public IP or DNS hostname of the server (along with an optional port).
 
 Default: `0.0.0.0:7100`
 
@@ -128,6 +128,8 @@ Number of replicas to store for each tablet in the universe.
 Default: `3`
 
 ### Placement options
+
+The placement options, or flags, provide 
 
 #### --placement_zone
 

--- a/docs/content/latest/admin/yb-master.md
+++ b/docs/content/latest/admin/yb-master.md
@@ -113,7 +113,7 @@ Switches to log to standard error (`stderr`).
 
 Specifies the number of shards per yb-tserver per table when a user table is created. Server automatically picks a valid default internally.
 
-Default: `-1`
+Default: Server automatically picks a valid default internally, typically 8.
 
 #### --max_clock_skew_usec
 

--- a/docs/content/latest/admin/yb-master.md
+++ b/docs/content/latest/admin/yb-master.md
@@ -27,35 +27,123 @@ $ ./bin/yb-master \
 
 ## Help
 
-Use the **-\-help** option to see all the commands supported.
+Use the `--help` option to see all the commands supported.
 
 ```sh
 $ ./bin/yb-master --help
 ```
 
-## Configuration flags
+## Configuration options (flags)
 
-Flag | Mandatory | Default | Description 
-----------------------|------|---------|------------------------
-`--master_addresses` | Y | N/A |Comma-separated list of all the RPC addresses for `yb-master` consensus-configuration. 
-`--fs_data_dirs` | Y | N/A | Comma-separated list of directories where the `yb-master` will place all it's `yb-data/master` data directory. 
-`--fs_wal_dirs`| N | Same value as `--fs_data_dirs` | The directory where the `yb-master` will place its write-ahead logs. May be the same as one of the directories listed in `--fs_data_dirs`, but not a sub-directory of a data directory. 
-`--log_dir`| N | Same value as `--fs_data_dirs`   | The directory to store `yb-master` log files.  
-`--max_clock_skew_usec` | N | 50000 (50ms) | The expected maximum clock skew between any two nodes in your deployment.
-`--rpc_bind_addresses`| Y |`0.0.0.0:7100` | Comma-separated list of addresses to bind to for RPC connections.
-`--server_broadcast_addresses`| N |`0.0.0.0:7100` | Public IP or DNS hostname of the server (along with an optional port).
-`--use_private_ip`| N |`never` | Determines when to use private IP addresses. Possible values are `never`,`zone`,`cloud` and `region`. Based on the values of the `placement_*` config flags listed in this table.
-`--webserver_interface`| N |`0.0.0.0` | Address to bind for server UI access.
-`--webserver_port`| N | `7000` | Monitoring web server port.
-`--webserver_doc_root`| N | The `www` directory in the YugabyteDB home directory | Monitoring web server home.
-`--replication_factor`| N |`3`  | Number of replicas to store for each tablet in the universe.
-`--placement_zone`| N |`rack1`  | Name of the availability zone or rack where this instance is deployed.
-`--placement_region`| N |`datacenter1`  | Name of the region or data center where this instance is deployed.
-`--placement_cloud`| N |`cloud1`  | Name of the cloud where this instance is deployed.
-`--logtostderr`| N | N/A  | Log to standard error.
-`--flagfile`| N | N/A  | Load flags from the specified file.
-`--version` | N | N/A | Show version and build info.
-`--yb_num_shards_per_tserver` | N | -1 | The number of shards per yb-tserver per table when a user table is created. Server automatically picks a valid default internally.
+### General
+
+#### `--version`
+
+Shows version and build info, then exits.
+
+#### `--master_addresses`
+
+Comma-separated list of all the RPC addresses for `yb-master` consensus-configuration. Mandatory.
+
+#### `--fs_data_dirs`
+
+Comma-separated list of directories where the `yb-master` will place all it's `yb-data/master` data directory. Mandatory.
+
+#### `--fs_wal_dirs`
+
+The directory where the `yb-master` will place its write-ahead logs. May be the same as one of the directories listed in `--fs_data_dirs`, but not a sub-directory of a data directory. 
+
+Default: Same value as `--fs_data_dirs`
+
+#### `--rpc_bind_addresses`
+
+Comma-separated list of addresses to bind to for RPC connections. Mandatory.
+
+Default: `0.0.0.0:7100`
+
+#### `--server_broadcast_addresses`| N |`0.0.0.0:7100` | 
+
+Public IP or DNS hostname of the server (along with an optional port).
+
+#### `--webserver_interface`
+
+Address to bind for server UI access.
+
+Default: `0.0.0.0`
+
+#### `--webserver_port`
+
+Monitoring web server port.
+
+Default: `7000`
+
+#### `--webserver_doc_root`
+
+Monitoring web server home.
+
+Default: The `www` directory in the YugabyteDB home directory
+
+#### `--flagfile`
+
+Specifies file to load flags from.
+
+### Logging
+
+#### `--log_dir`
+
+The directory to store `yb-master` log files.
+
+Default: Same value as `--fs_data_dirs`
+
+#### `--logtostderr`
+
+Switches to log to standard error (`stderr`).
+
+### Cluster
+
+#### `--yb_num_shards_per_tserver`
+
+Specifies the number of shards per yb-tserver per table when a user table is created. Server automatically picks a valid default internally.
+
+Default: `-1`
+
+#### `--max_clock_skew_usec`
+
+The expected maximum clock skew between any two nodes in your deployment.
+
+Default: `50000` (50ms)
+
+##### `--replication_factor`
+
+Number of replicas to store for each tablet in the universe.
+
+Default: `3`
+
+### Deployment
+
+#### `--placement_zone`
+
+Name of the availability zone or rack where this instance is deployed.
+
+Default: `rack1`
+
+#### `--placement_region`
+
+Name of the region or data center where this instance is deployed.
+
+Default: `datacenter1`
+
+#### `--placement_cloud`
+
+Name of the cloud where this instance is deployed.
+
+Default: `cloud1`
+
+#### `--use_private_ip`
+
+Determines when to use private IP addresses. Possible values are `never` (default),`zone`,`cloud` and `region`. Based on the values of the `placement_*` configuration options.
+
+Default: `never`
 
 ## Admin UI
 
@@ -63,7 +151,7 @@ The Admin UI for yb-master is available at http://localhost:7000.
 
 ### Home
 
-Home page of the yb-master that gives a high level overview of the cluster. Note all yb-masters in a cluster show exactly the same information.
+Home page of the YB-Master service that gives a high level overview of the cluster. Note all YB-Master services in a cluster show identical information.
 
 ![master-home](/images/admin/master-home-binary-with-tables.png)
 
@@ -75,7 +163,7 @@ List of tables present in the cluster.
 
 ### Tablet servers
 
-List of all nodes (aka yb-tservers) present in the cluster.
+List of all nodes (aka YB-TServer services) present in the cluster.
 
 ![master-tservers](/images/admin/master-tservers-list-binary-with-tablets.png)
 

--- a/docs/content/latest/admin/yb-master.md
+++ b/docs/content/latest/admin/yb-master.md
@@ -25,121 +25,129 @@ $ ./bin/yb-master \
 --replication_factor=3 &
 ```
 
-## Help
+## Online help
 
-Use the `--help` option to see all the commands supported.
+Run `yb-master --help` to display the online help.
 
 ```sh
 $ ./bin/yb-master --help
 ```
 
-## Configuration options (flags)
+## Syntax
 
-### General
+```sh
+yb-master [ option  ] | [ option ]
+```
 
-#### `--version`
+## Configuration options
+
+### General options
+
+#### --version
 
 Shows version and build info, then exits.
 
-#### `--master_addresses`
+#### --master_addresses
 
 Comma-separated list of all the RPC addresses for `yb-master` consensus-configuration. Mandatory.
 
-#### `--fs_data_dirs`
+#### --fs_data_dirs
 
 Comma-separated list of directories where the `yb-master` will place all it's `yb-data/master` data directory. Mandatory.
 
-#### `--fs_wal_dirs`
+#### --fs_wal_dirs
 
 The directory where the `yb-master` will place its write-ahead logs. May be the same as one of the directories listed in `--fs_data_dirs`, but not a sub-directory of a data directory. 
 
 Default: Same value as `--fs_data_dirs`
 
-#### `--rpc_bind_addresses`
+#### --rpc_bind_addresses
 
 Comma-separated list of addresses to bind to for RPC connections. Mandatory.
 
 Default: `0.0.0.0:7100`
 
-#### `--server_broadcast_addresses`| N |`0.0.0.0:7100` | 
+#### --server_broadcast_addresses
 
 Public IP or DNS hostname of the server (along with an optional port).
 
-#### `--webserver_interface`
+Default: `0.0.0.0:7100`
+
+#### --webserver_interface
 
 Address to bind for server UI access.
 
 Default: `0.0.0.0`
 
-#### `--webserver_port`
+#### --webserver_port
 
 Monitoring web server port.
 
 Default: `7000`
 
-#### `--webserver_doc_root`
+#### --webserver_doc_root
 
 Monitoring web server home.
 
 Default: The `www` directory in the YugabyteDB home directory
 
-#### `--flagfile`
+#### --flagfile
 
-Specifies file to load flags from.
+Specifies the file to load flags from.
 
-### Logging
+### Logging options
 
-#### `--log_dir`
+#### --log_dir
 
 The directory to store `yb-master` log files.
 
 Default: Same value as `--fs_data_dirs`
 
-#### `--logtostderr`
+#### --logtostderr
 
 Switches to log to standard error (`stderr`).
 
-### Cluster
+### Cluster options
 
-#### `--yb_num_shards_per_tserver`
+#### --yb_num_shards_per_tserver
 
 Specifies the number of shards per yb-tserver per table when a user table is created. Server automatically picks a valid default internally.
 
 Default: `-1`
 
-#### `--max_clock_skew_usec`
+#### --max_clock_skew_usec
 
 The expected maximum clock skew between any two nodes in your deployment.
 
 Default: `50000` (50ms)
 
-##### `--replication_factor`
+##### --replication_factor
 
 Number of replicas to store for each tablet in the universe.
 
 Default: `3`
 
-### Deployment
+### Placement options
 
-#### `--placement_zone`
+#### --placement_zone
 
 Name of the availability zone or rack where this instance is deployed.
 
 Default: `rack1`
 
-#### `--placement_region`
+#### --placement_region
 
 Name of the region or data center where this instance is deployed.
 
 Default: `datacenter1`
 
-#### `--placement_cloud`
+#### --placement_cloud
 
 Name of the cloud where this instance is deployed.
 
 Default: `cloud1`
 
-#### `--use_private_ip`
+#### --use_private_ip
 
 Determines when to use private IP addresses. Possible values are `never` (default),`zone`,`cloud` and `region`. Based on the values of the `placement_*` configuration options.
 

--- a/docs/content/latest/admin/yb-tserver.md
+++ b/docs/content/latest/admin/yb-tserver.md
@@ -203,7 +203,7 @@ Default: `""` — Uses the YSQL display format.
 
 Specifies the maximum number of concurrent YSQL connections.
 
-Default: `0`
+Default: `300`
 
 #### --ysql_default_transaction_isolation
 

--- a/docs/content/latest/admin/yb-tserver.md
+++ b/docs/content/latest/admin/yb-tserver.md
@@ -177,7 +177,7 @@ Default: `13000`
 
 #### --ysql_hba_conf
 
-Specify a comma-separated list of YugabyteDB setting assignments.
+Specifies a comma-separated list of PostgreSQL client authentication settings.
 
 Default: `""`
 

--- a/docs/content/latest/admin/yb-tserver.md
+++ b/docs/content/latest/admin/yb-tserver.md
@@ -33,7 +33,7 @@ Use the `--help` option to see all of the supported commands.
 $ ./bin/yb-tserver --help
 ```
 
-## Configuration flags
+## Configuration options (flags)
 
 ### General
 
@@ -47,7 +47,7 @@ Displays help on modules named by the specified flag value.
 
 #### `--flagfile`
 
-Specifies file to load flags from.
+Specifies the file to load flags from.
 
 #### `--version`
 

--- a/docs/content/latest/admin/yb-tserver.md
+++ b/docs/content/latest/admin/yb-tserver.md
@@ -201,7 +201,7 @@ Default: `""` — Uses the YSQL display format.
 
 #### --ysql_max_connections
 
-Specifies the maximum number of concurrent YSQL connections. 
+Specifies the maximum number of concurrent YSQL connections.
 
 Default: `0`
 
@@ -219,7 +219,7 @@ Default: `""`
 
 #### --ysql_log_min_messages
 
-Specifies the lowest YSQL message level to log. 
+Specifies the lowest YSQL message level to log.
 
 Default: `""`
 

--- a/docs/content/latest/admin/yb-tserver.md
+++ b/docs/content/latest/admin/yb-tserver.md
@@ -147,19 +147,25 @@ Specifies the name of the cloud where this instance is deployed.
 
 Default: `cloud1`
 
-### YSQL
+### YSQL options
 
-The following settings manage the Yugabyte Structured Query Language (YSQL).
+The following options, or flags, support the use of the [YSQL API](../../api/ysql/).
 
 #### --enable_ysql
 
-Specifies to enable YSQL API. Replaces the deprecated `--start_pgsql_proxy` option.
+Enables the YSQL API. Replaces the deprecated `--start_pgsql_proxy` option.
+
+Default: `false`
+
+#### --ysql_enable_auth
+
+Enables YSQL authentication.
 
 Default: `false`
 
 #### --pgsql_proxy_bind_address
 
-Specifies the bind address for YSQL API.
+Specifies the bind address for the YSQL API.
 
 Default: `0.0.0.0:5433`
 
@@ -169,12 +175,6 @@ Specifies the web server port for YSQL metrics monitoring.
 
 Default: `13000`
 
-#### --ysql_enable_auth
-
-Enable YSQL authentication.
-
-Default: `false`
-
 #### --ysql_hba_conf
 
 Specify a comma-separated list of YugabyteDB setting assignments.
@@ -183,7 +183,7 @@ Default: `""`
 
 #### --ysql_pg_conf
 
-Comma-separated list of PostgreSQL setting assignments. 
+Comma-separated list of PostgreSQL setting assignments.
 
 Default: `""`
 
@@ -223,9 +223,9 @@ Specifies the lowest YSQL message level to log.
 
 Default: `""`
 
-### YCQL
+### YCQL options
 
-The following options support the use of YCQL.
+The following options, or flags, support the use of the [YCQL API](../../api/ycql/).
 
 #### --use_cassandra_authentication
 
@@ -246,6 +246,8 @@ Specifies the port for monitoring YCQL metrics.
 Default: `12000`
 
 ### YEDIS options
+
+The following options, or flags, support the use of the YEDIS API.
 
 #### --redis_proxy_bind_address
 

--- a/docs/content/latest/admin/yb-tserver.md
+++ b/docs/content/latest/admin/yb-tserver.md
@@ -179,7 +179,7 @@ Default: `13000`
 
 Specifies a comma-separated list of PostgreSQL client authentication settings.
 
-Default: `""`
+Default: `"host all all 0.0.0.0/0 trust,host all all ::0/0 trust"`
 
 #### --ysql_pg_conf
 

--- a/docs/content/latest/admin/yb-tserver.md
+++ b/docs/content/latest/admin/yb-tserver.md
@@ -37,10 +37,23 @@ $ ./bin/yb-tserver --help
 
 Flag | Mandatory | Default | Description
 ----------------------|------|---------|------------------------
+
+### General
+
+`--help` | N | N/A | Show help on all flags.
+`--helpon` | N | N/A | Show help on modules named by the specified flag value.
+`--flagfile` | N | N/A  | Specify file to load flags from.
+`--version` | N | N/A | Specify to show version and build info, then exit.
+
+### Logging
+
+`--logtostderr` | N | N/A  | Log to standard error.
+`--log_dir` | N | Same value as `--fs_data_dirs` | The directory to store `yb-tserver` log files.
+
+
 `--tserver_master_addrs` | Y | N/A  |Comma-separated list of all the `yb-master` RPC addresses.
 `--fs_data_dirs` | Y | N/A | Comma-separated list of directories where the `yb-tserver` will place it's `yb-data/tserver` data directory.
 `--fs_wal_dirs` | N | Same value as `--fs_data_dirs` | The directory where the `yb-tserver` will place its write-ahead logs. May be the same as one of the directories listed in `--fs_data_dirs`, but not a sub-directory of a data directory.
-`--log_dir` | N | Same value as `--fs_data_dirs` | The directory to store `yb-tserver` log files.
 `--max_clock_skew_usec` | N | 50000 (50ms) | The expected maximum clock skew between any two nodes in your deployment.
 `--rpc_bind_addresses` | N |`0.0.0.0:9100` | Comma-separated list of addresses to bind to for RPC connections.
 `--server_broadcast_addresses` | N |`0.0.0.0:9100` | Public IP or DNS hostname of the server (along with an optional port).
@@ -49,25 +62,46 @@ Flag | Mandatory | Default | Description
 `--webserver_port` | N | `7000` | Monitoring web server port.
 `--webserver_doc_root` | N | The `www` directory in the YugabyteDB home directory | Monitoring web server home.
 `--cql_proxy_bind_address` | N | `0.0.0.0:9042` | YCQL API bind address.
-`--cql_proxy_webserver_port` | N | 12000 | YCQL metrics monitoring port
+`--cql_proxy_webserver_port` | N | `12000` | YCQL metrics monitoring port
 `--redis_proxy_bind_address` | N | `0.0.0.0:6379` | YEDIS API bind address.
 `--redis_proxy_webserver_port` | N | 11000 | YEDIS metrics monitoring port.
-`--start_pgsql_proxy` | N | N/A | Enable YSQL API.
-`--pgsql_proxy_bind_address` | N | `0.0.0.0:5433` | YSQL API bind address.
-`--pgsql_proxy_webserver_port` | N | 13000 | YSQL metrics monitoring port.
-`--placement_zone` | N |`rack1` | Name of the availability zone or rack where this instance is deployed.
-`--placement_region` | N |`datacenter1` | Name of the region or data center where this instance is deployed.
+
+### Deployment
+
+`--placement_zone` | N |`rack1` | Name of the availability zone, or rack, where this instance is deployed.
+`--placement_region` | N |`datacenter1` | Name of the region, or data center, where this instance is deployed.
 `--placement_cloud` | N |`cloud1` | Name of the cloud where this instance is deployed.
-`--logtostderr` | N | N/A  | Log to standard error.
-`--flagfile` | N | N/A  | Load flags from the specified file.
-`--version` | N | N/A | Show version and build info.
-`--use_cassandra_authentication` | N | false | If enabled, it will require YCQL client authentication (username/password), enable YCQL security statements (CREATE/DROP/GRANT/REVOKE ROLE and GRANT/REVOKE PERMISSION), and enforce permissions for YCQL statements.
-`--rocksdb_compact_flush_rate_limit_bytes_per_sec` | N | 256MB | Used to control rate of memstore flush and SSTable file compaction.
-`--remote_bootstrap_rate_limit_bytes_per_sec` | N | 256MB | Rate control across all tablets being remote bootstrapped from or to this process.
-`--yb_num_shards_per_tserver` | N | -1 | The number of shards per yb-tserver per table when a user table is created. Server automatically picks a valid default internally.
-`--durable_wal_write` | N | false | If set to `false`, the writes to the Raft log are synced to disk every `interval_durable_wal_write_ms` milliseconds or every `bytes_durable_wal_write_mb` MB, whichever comes first. This default setting is recommended only for multi-AZ or multi-region deployments where the zones/regions are independent failure domains and there isn't a risk of correlated power loss. For single AZ deployments, this flag should be set to `true`.
-`--interval_durable_wal_write_ms` | N | 1000ms | When `durable_wal_write` is false, writes to the Raft log are synced to disk every `interval_durable_wal_write_ms` milliseconds or `bytes_durable_wal_write_mb` MB whichever comes first.
-`--bytes_durable_wal_write_mb` | N | 1MB | When `durable_wal_write` is false, writes to the Raft log are synced to disk every `bytes_durable_wal_write_mb` MB or `interval_durable_wal_write_ms` milliseconds whichever comes first.
+
+### YSQL
+
+`--enable_ysql` | N | false | Specify to enable YSQL API. Default is `false`. Use instead of deprecated `--start_pgsql_proxy`.
+`--pgsql_proxy_bind_address` | N | `0.0.0.0:5433` | Specify the bind address for YSQL API. Default value is `0.0.0.0:5433`.
+`--pgsql_proxy_webserver_port` | N | `13000` | Webserver port for YSQL metrics monitoring.
+`--ysql_enable_auth` | N | `false` | Enable YSQL authentication. Default is `false`.
+`--ysql_hba_conf` | N | `""` | Specify a comma-separated list of YugabyteDB setting assignments. Default is `""`.
+`--ysql_pg_conf` | N | `""` | Comma-separated list of PostgreSQL setting assignments. Default is `""`. String.
+`--ysql_timezone` | N | `""` | Specify the time zone for displaying and interpreting timestamps. Default of `""` uses the YSQL time zone.
+`--ysql_datestyle` | N | `""` | Specify the display format for data and time values. Default of "" uses the YSQL display format.
+`--ysql_max_connections` |  | `0` | Specify the maximum number of concurrent YSQL connections. Default is `0`.
+`--ysql_default_transaction_isolation` |  | `""` | Specify the default transaction isolation level. Default is `""`.
+`--ysql_log_statement` | N | `""` | Specify the types of YSQL statements that should be logged. Default is `""`.
+`--ysql_log_min_messages` | N | `""` | Specify the lowest YSQL message level to log. Default is `""`.
+
+### YCQL
+
+`--use_cassandra_authentication` | N | `false` | Specify `true` to enable YCQL authentication (`username` and `password`), enable YCQL security statements (`CREATE ROLE`, `DROP ROLE`, `GRANT ROLE`, `REVOKE ROLE`, `GRANT PERMISSION`, and `REVOKE PERMISSION`), and enforce permissions for YCQL statements.
+
+### Performance
+
+`--rocksdb_compact_flush_rate_limit_bytes_per_sec` | N | `256MB` | Used to control rate of memstore flush and SSTable file compaction.
+`--remote_bootstrap_rate_limit_bytes_per_sec` | N | `256MB` | Rate control across all tablets being remote bootstrapped from or to this process.
+`--yb_num_shards_per_tserver` | N | `-1` | The number of shards per yb-tserver per table when a user table is created. Server automatically picks a valid default internally.
+
+### WAL
+
+`--durable_wal_write` | N | `false` | If set to `false`, the writes to the Raft log are synced to disk every `interval_durable_wal_write_ms` milliseconds or every `bytes_durable_wal_write_mb` MB, whichever comes first. This default setting is recommended only for multi-AZ or multi-region deployments where the zones/regions are independent failure domains and there isn't a risk of correlated power loss. For single AZ deployments, this flag should be set to `true`.
+`--interval_durable_wal_write_ms` | N | `1000ms` | When `durable_wal_write` is false, writes to the Raft log are synced to disk every `interval_durable_wal_write_ms` milliseconds or `bytes_durable_wal_write_mb` MB whichever comes first.
+`--bytes_durable_wal_write_mb` | N | `1MB` | When `durable_wal_write` is false, writes to the Raft log are synced to disk every `bytes_durable_wal_write_mb` MB or `interval_durable_wal_write_ms` milliseconds whichever comes first.
 
 ## Admin UI
 

--- a/docs/content/latest/admin/yb-tserver.md
+++ b/docs/content/latest/admin/yb-tserver.md
@@ -25,117 +25,123 @@ $ ./bin/yb-tserver \
 --fs_data_dirs "/home/centos/disk1,/home/centos/disk2" &
 ```
 
-## Help
+## Online help
 
-Use the `--help` option to see all of the supported commands.
+Run `yb-tserver --help` to display the online help.
 
 ```sh
 $ ./bin/yb-tserver --help
 ```
 
-## Configuration options (flags)
+## Syntax
 
-### General
+```sh
+yb-tserver [ options ]
+```
 
-#### `--help`
+## Configuration options
 
-Displays help on all flags.
+### General options
 
-#### `--helpon`
+#### --help
 
-Displays help on modules named by the specified flag value.
+Displays help on all options.
 
-#### `--flagfile`
+#### --helpon
 
-Specifies the file to load flags from.
+Displays help on modules named by the specified option (or flag) value.
 
-#### `--version`
+#### --flagfile
+
+Specifies the file to load options (or flags) from.
+
+#### --version
 
 Shows version and build info, then exits.
 
-#### `--tserver_master_addrs`
+#### --tserver_master_addrs
 
 Comma-separated list of all the `yb-master` RPC addresses. Mandatory.
 
-#### `--fs_data_dirs` 
+#### --fs_data_dirs
 
 Comma-separated list of directories where the `yb-tserver` will place it's `yb-data/tserver` data directory. Mandatory.
 
-#### `--fs_wal_dirs`
+#### --fs_wal_dirs
 
 Default: Same as `--fs_data_dirs`
 
 The directory where the `yb-tserver` will place its write-ahead logs. May be the same as one of the directories listed in `--fs_data_dirs`, but not a sub-directory of a data directory.
 
-#### `--max_clock_skew_usec`
+#### --max_clock_skew_usec
 
 Specifies the expected maximum clock skew between any two nodes in your deployment.
 
-Default: `50000` (50ms) 
+Default: `50000` (50ms)
 
-#### `--rpc_bind_addresses` 
+#### --rpc_bind_addresses
 
 Specifies the comma-separated list of addresses to bind to for RPC connections.
 
 Default: `0.0.0.0:9100`
 
-#### `--server_broadcast_addresses`
+#### --server_broadcast_addresses
 
 Public IP or DNS hostname of the server (along with an optional port).
 
 Default: `0.0.0.0:9100`
 
-#### `--use_private_ip`
+#### --use_private_ip
 
-Determines when to use private IP addresses. Possible values are `never` (default),`zone`,`cloud` and `region`. Based on the values of the `placement_*` config flags listed in this table. 
+Determines when to use private IP addresses. Possible values are `never` (default),`zone`,`cloud` and `region`. Based on the values of the [placement (`--placement_*`) configuration options](#placement-options).
 
 Default: `never`
 
-#### `--webserver_interface`
+#### --webserver_interface
 
 Address to bind for the web server user interface.
 
 Default: `0.0.0.0`
 
-#### `--webserver_port` 
+#### --webserver_port
 
 The port for monitoring the web server.
 
 Default: `7000`
 
-#### `--webserver_doc_root`
+#### --webserver_doc_root
 
 Monitoring web server home.
 
 Default: The `www` directory in the YugabyteDB home directory.
 
-### Logging
+### Logging options
 
-#### `--logtostderr`
+#### --logtostderr
 
-Log to standard error (`stderr`).
+Flag to log to standard error (`stderr`).
 
-#### `--log_dir`
+#### --log_dir
 
 Specifies the directory to store `yb-tserver` log files.
 
-Default: Same as `--fs_data_dirs`
+Default: Same as [`--fs_data_dirs`](#fs-data-dirs)
 
-### Deployment
+### Placement options
 
-#### `--placement_zone`
+#### --placement_zone
 
 Specifies the name of the availability zone, or rack, where this instance is deployed.
 
 Default: `rack1`
 
-#### `--placement_region`
+#### --placement_region
 
 Specifies the name of the region, or data center, where this instance is deployed.
 
 Default: `datacenter1`
 
-#### `--placement_cloud`
+#### --placement_cloud
 
 Specifies the name of the cloud where this instance is deployed.
 
@@ -143,142 +149,157 @@ Default: `cloud1`
 
 ### YSQL
 
-#### `--enable_ysql`
+The following settings manage the Yugabyte Structured Query Language (YSQL).
 
-Specifies to enable YSQL API. Default is `false`. Replaces the deprecated `--start_pgsql_proxy` option.
+#### --enable_ysql
+
+Specifies to enable YSQL API. Replaces the deprecated `--start_pgsql_proxy` option.
 
 Default: `false`
 
-#### `--pgsql_proxy_bind_address`
+#### --pgsql_proxy_bind_address
 
-Specifies the bind address for YSQL API. Default value is `0.0.0.0:5433`.
+Specifies the bind address for YSQL API.
 
 Default: `0.0.0.0:5433`
 
-#### `--pgsql_proxy_webserver_port`
+#### --pgsql_proxy_webserver_port
 
 Specifies the web server port for YSQL metrics monitoring.
 
 Default: `13000`
 
-#### `--ysql_enable_auth`
+#### --ysql_enable_auth
 
 Enable YSQL authentication.
 
 Default: `false`
 
-#### `--ysql_hba_conf`
+#### --ysql_hba_conf
 
-Specify a comma-separated list of YugabyteDB setting assignments. 
+Specify a comma-separated list of YugabyteDB setting assignments.
 
 Default: `""`
 
-#### `--ysql_pg_conf`
+#### --ysql_pg_conf
 
-Comma-separated list of PostgreSQL setting assignments. Default is `""`. 
+Comma-separated list of PostgreSQL setting assignments. 
 
-#### `--ysql_timezone`
+Default: `""`
+
+#### --ysql_timezone
 
 Specifies the time zone for displaying and interpreting timestamps.
 
-Default: `""` — uses the YSQL time zone.
+Default: `""` — Uses the YSQL time zone.
 
-#### `--ysql_datestyle`
+#### --ysql_datestyle
 
-Specifies the display format for data and time values. 
+Specifies the display format for data and time values.
 
-Default: `""` — uses the YSQL display format.
+Default: `""` — Uses the YSQL display format.
 
-#### `--ysql_max_connections`
+#### --ysql_max_connections
 
 Specifies the maximum number of concurrent YSQL connections. 
 
 Default: `0`
 
-`--ysql_default_transaction_isolation`
+#### --ysql_default_transaction_isolation
 
 Specifies the default transaction isolation level.
 
 Default: `""`
 
-#### `--ysql_log_statement`
+#### --ysql_log_statement
 
-Specifies the types of YSQL statements that should be logged. 
+Specifies the types of YSQL statements that should be logged.
 
 Default: `""`
 
-#### `--ysql_log_min_messages`
+#### --ysql_log_min_messages
 
-Specifies the lowest YSQL message level to log. Default is `""`.
+Specifies the lowest YSQL message level to log. 
+
+Default: `""`
 
 ### YCQL
 
-#### `--cql_proxy_bind_address`
+The following options support the use of YCQL.
 
-Specifies the bind address for the YCQL API.
-
-Default: `0.0.0.0:9042`
-
-#### `--cql_proxy_webserver_port`
-
-Specifies the port for monitoring YCQL metrics.
-
-Default: `12000`
-
-#### `--use_cassandra_authentication`
+#### --use_cassandra_authentication
 
 Specify `true` to enable YCQL authentication (`username` and `password`), enable YCQL security statements (`CREATE ROLE`, `DROP ROLE`, `GRANT ROLE`, `REVOKE ROLE`, `GRANT PERMISSION`, and `REVOKE PERMISSION`), and enforce permissions for YCQL statements.
 
 Default: `false`
 
-### YEDIS
+#### --cql_proxy_bind_address
 
-#### `--redis_proxy_bind_address`
+Specifies the bind address for the YCQL API.
+
+Default: `0.0.0.0:9042`
+
+#### --cql_proxy_webserver_port
+
+Specifies the port for monitoring YCQL metrics.
+
+Default: `12000`
+
+### YEDIS options
+
+#### --redis_proxy_bind_address
 
 Specifies the bind address for the YEDIS API.
 
 Default: `0.0.0.0:6379`
 
-#### `--redis_proxy_webserver_port`
+#### --redis_proxy_webserver_port
 
 Specifies the port for monitoring YEDIS metrics.
 
 Default: `11000`
 
-### Performance
+### Performance options
 
-#### `--rocksdb_compact_flush_rate_limit_bytes_per_sec` 
+#### --rocksdb_compact_flush_rate_limit_bytes_per_sec
 
 Used to control rate of memstore flush and SSTable file compaction.
 
 Default: `256MB`
 
-#### `--remote_bootstrap_rate_limit_bytes_per_sec` | N | `256MB` | 
+#### --remote_bootstrap_rate_limit_bytes_per_sec
 
 Rate control across all tablets being remote bootstrapped from or to this process.
 
-#### `--yb_num_shards_per_tserver` | N | `-1` | 
+Default: `256MB`
 
-The number of shards per yb-tserver per table when a user table is created. Server automatically picks a valid default internally.
+#### --yb_num_shards_per_tserver
 
-### Write Ahead Log (WAL)
+The number of shards per YB-TServer per table when a user table is created.
 
-#### `--durable_wal_write`
+Default: `-1` — Server automatically picks a valid default internally.
+
+### Write Ahead Log (WAL) options
+
+#### --durable_wal_write
 
 If set to `false`, the writes to the Raft log are synced to disk every `interval_durable_wal_write_ms` milliseconds or every `bytes_durable_wal_write_mb` MB, whichever comes first. This default setting is recommended only for multi-AZ or multi-region deployments where the zones/regions are independent failure domains and there isn't a risk of correlated power loss. For single AZ deployments, this flag should be set to `true`.
 
 Default: `false`
 
-#### `--interval_durable_wal_write_ms`
+#### --interval_durable_wal_write_ms
 
-When `durable_wal_write` is false, writes to the Raft log are synced to disk every `interval_durable_wal_write_ms` milliseconds or `bytes_durable_wal_write_mb` MB whichever comes first.
-`--bytes_durable_wal_write_mb` | N | `1MB` | When `durable_wal_write` is false, writes to the Raft log are synced to disk every `bytes_durable_wal_write_mb` MB or `interval_durable_wal_write_ms` milliseconds whichever comes first.
+When [`--durable_wal_write`](#durable-wal-write) is false, writes to the Raft log are synced to disk every `--interval_durable_wal_write_ms` or [`--bytes_durable_wal_write_mb`](#bytes-durable-wal-write-mb), whichever comes first.
 
-Default: `1000ms`
+#### --bytes_durable_wal_write_mb
+
+When `--durable_wal_write` is `false`, writes to the Raft log are synced to disk every `--bytes_durable_wal_write_mb` or `--interval_durable_wal_write_ms`, whichever comes first.
+
+Default: `1000ms` or `1MB`
 
 ## Admin UI
 
-The Admin UI for the YB-TServer is available at http://localhost:9000.
+The Admin UI for the YB-TServer is available at `http://localhost:9000`.
 
 ### Home
 

--- a/docs/content/latest/admin/yb-tserver.md
+++ b/docs/content/latest/admin/yb-tserver.md
@@ -35,73 +35,246 @@ $ ./bin/yb-tserver --help
 
 ## Configuration flags
 
-Flag | Mandatory | Default | Description
-----------------------|------|---------|------------------------
-
 ### General
 
-`--help` | N | N/A | Show help on all flags.
-`--helpon` | N | N/A | Show help on modules named by the specified flag value.
-`--flagfile` | N | N/A  | Specify file to load flags from.
-`--version` | N | N/A | Specify to show version and build info, then exit.
+#### `--help`
+
+Displays help on all flags.
+
+#### `--helpon`
+
+Displays help on modules named by the specified flag value.
+
+#### `--flagfile`
+
+Specifies file to load flags from.
+
+#### `--version`
+
+Shows version and build info, then exits.
+
+#### `--tserver_master_addrs`
+
+Comma-separated list of all the `yb-master` RPC addresses. Mandatory.
+
+#### `--fs_data_dirs` 
+
+Comma-separated list of directories where the `yb-tserver` will place it's `yb-data/tserver` data directory. Mandatory.
+
+#### `--fs_wal_dirs`
+
+Default: Same as `--fs_data_dirs`
+
+The directory where the `yb-tserver` will place its write-ahead logs. May be the same as one of the directories listed in `--fs_data_dirs`, but not a sub-directory of a data directory.
+
+#### `--max_clock_skew_usec`
+
+Specifies the expected maximum clock skew between any two nodes in your deployment.
+
+Default: `50000` (50ms) 
+
+#### `--rpc_bind_addresses` 
+
+Specifies the comma-separated list of addresses to bind to for RPC connections.
+
+Default: `0.0.0.0:9100`
+
+#### `--server_broadcast_addresses`
+
+Public IP or DNS hostname of the server (along with an optional port).
+
+Default: `0.0.0.0:9100`
+
+#### `--use_private_ip`
+
+Determines when to use private IP addresses. Possible values are `never` (default),`zone`,`cloud` and `region`. Based on the values of the `placement_*` config flags listed in this table. 
+
+Default: `never`
+
+#### `--webserver_interface`
+
+Address to bind for the web server user interface.
+
+Default: `0.0.0.0`
+
+#### `--webserver_port` 
+
+The port for monitoring the web server.
+
+Default: `7000`
+
+#### `--webserver_doc_root`
+
+Monitoring web server home.
+
+Default: The `www` directory in the YugabyteDB home directory.
 
 ### Logging
 
-`--logtostderr` | N | N/A  | Log to standard error.
-`--log_dir` | N | Same value as `--fs_data_dirs` | The directory to store `yb-tserver` log files.
+#### `--logtostderr`
 
+Log to standard error (`stderr`).
 
-`--tserver_master_addrs` | Y | N/A  |Comma-separated list of all the `yb-master` RPC addresses.
-`--fs_data_dirs` | Y | N/A | Comma-separated list of directories where the `yb-tserver` will place it's `yb-data/tserver` data directory.
-`--fs_wal_dirs` | N | Same value as `--fs_data_dirs` | The directory where the `yb-tserver` will place its write-ahead logs. May be the same as one of the directories listed in `--fs_data_dirs`, but not a sub-directory of a data directory.
-`--max_clock_skew_usec` | N | 50000 (50ms) | The expected maximum clock skew between any two nodes in your deployment.
-`--rpc_bind_addresses` | N |`0.0.0.0:9100` | Comma-separated list of addresses to bind to for RPC connections.
-`--server_broadcast_addresses` | N |`0.0.0.0:9100` | Public IP or DNS hostname of the server (along with an optional port).
-`--use_private_ip` | N |`never` | Determines when to use private IP addresses. Possible values are `never`,`zone`,`cloud` and `region`. Based on the values of the `placement_*` config flags listed in this table.
-`--webserver_interface` | N |`0.0.0.0` | Address to bind for server UI access.
-`--webserver_port` | N | `7000` | Monitoring web server port.
-`--webserver_doc_root` | N | The `www` directory in the YugabyteDB home directory | Monitoring web server home.
-`--cql_proxy_bind_address` | N | `0.0.0.0:9042` | YCQL API bind address.
-`--cql_proxy_webserver_port` | N | `12000` | YCQL metrics monitoring port
-`--redis_proxy_bind_address` | N | `0.0.0.0:6379` | YEDIS API bind address.
-`--redis_proxy_webserver_port` | N | 11000 | YEDIS metrics monitoring port.
+#### `--log_dir`
+
+Specifies the directory to store `yb-tserver` log files.
+
+Default: Same as `--fs_data_dirs`
 
 ### Deployment
 
-`--placement_zone` | N |`rack1` | Name of the availability zone, or rack, where this instance is deployed.
-`--placement_region` | N |`datacenter1` | Name of the region, or data center, where this instance is deployed.
-`--placement_cloud` | N |`cloud1` | Name of the cloud where this instance is deployed.
+#### `--placement_zone`
+
+Specifies the name of the availability zone, or rack, where this instance is deployed.
+
+Default: `rack1`
+
+#### `--placement_region`
+
+Specifies the name of the region, or data center, where this instance is deployed.
+
+Default: `datacenter1`
+
+#### `--placement_cloud`
+
+Specifies the name of the cloud where this instance is deployed.
+
+Default: `cloud1`
 
 ### YSQL
 
-`--enable_ysql` | N | false | Specify to enable YSQL API. Default is `false`. Use instead of deprecated `--start_pgsql_proxy`.
-`--pgsql_proxy_bind_address` | N | `0.0.0.0:5433` | Specify the bind address for YSQL API. Default value is `0.0.0.0:5433`.
-`--pgsql_proxy_webserver_port` | N | `13000` | Webserver port for YSQL metrics monitoring.
-`--ysql_enable_auth` | N | `false` | Enable YSQL authentication. Default is `false`.
-`--ysql_hba_conf` | N | `""` | Specify a comma-separated list of YugabyteDB setting assignments. Default is `""`.
-`--ysql_pg_conf` | N | `""` | Comma-separated list of PostgreSQL setting assignments. Default is `""`. String.
-`--ysql_timezone` | N | `""` | Specify the time zone for displaying and interpreting timestamps. Default of `""` uses the YSQL time zone.
-`--ysql_datestyle` | N | `""` | Specify the display format for data and time values. Default of "" uses the YSQL display format.
-`--ysql_max_connections` |  | `0` | Specify the maximum number of concurrent YSQL connections. Default is `0`.
-`--ysql_default_transaction_isolation` |  | `""` | Specify the default transaction isolation level. Default is `""`.
-`--ysql_log_statement` | N | `""` | Specify the types of YSQL statements that should be logged. Default is `""`.
-`--ysql_log_min_messages` | N | `""` | Specify the lowest YSQL message level to log. Default is `""`.
+#### `--enable_ysql`
+
+Specifies to enable YSQL API. Default is `false`. Replaces deprecated `--start_pgsql_proxy` option.
+
+Default: `false`
+
+#### `--pgsql_proxy_bind_address`
+
+Specifies the bind address for YSQL API. Default value is `0.0.0.0:5433`.
+
+Default: `0.0.0.0:5433`
+
+#### `--pgsql_proxy_webserver_port`
+
+Specifies the web server port for YSQL metrics monitoring.
+
+Default: `13000`
+
+#### `--ysql_enable_auth`
+
+Enable YSQL authentication.
+
+Default: `false`
+
+#### `--ysql_hba_conf`
+
+Specify a comma-separated list of YugabyteDB setting assignments. 
+
+Default: `""`
+
+#### `--ysql_pg_conf`
+
+Comma-separated list of PostgreSQL setting assignments. Default is `""`. 
+
+#### `--ysql_timezone`
+
+Specifies the time zone for displaying and interpreting timestamps.
+
+Default: `""` — uses the YSQL time zone.
+
+#### `--ysql_datestyle`
+
+Specifies the display format for data and time values. 
+
+Default: `""` — uses the YSQL display format.
+
+#### `--ysql_max_connections`
+
+Specifies the maximum number of concurrent YSQL connections. 
+
+Default: `0`
+
+`--ysql_default_transaction_isolation`
+
+Specifies the default transaction isolation level.
+
+Default: `""`
+
+#### `--ysql_log_statement`
+
+Specifies the types of YSQL statements that should be logged. 
+
+Default: `""`
+
+#### `--ysql_log_min_messages`
+
+Specifies the lowest YSQL message level to log. Default is `""`.
 
 ### YCQL
 
-`--use_cassandra_authentication` | N | `false` | Specify `true` to enable YCQL authentication (`username` and `password`), enable YCQL security statements (`CREATE ROLE`, `DROP ROLE`, `GRANT ROLE`, `REVOKE ROLE`, `GRANT PERMISSION`, and `REVOKE PERMISSION`), and enforce permissions for YCQL statements.
+#### `--cql_proxy_bind_address`
+
+Specifies the bind address for the YCQL API.
+
+Default: `0.0.0.0:9042`
+
+#### `--cql_proxy_webserver_port`
+
+Specifies the port for monitoring YCQL metrics.
+
+Default: `12000`
+
+#### `--use_cassandra_authentication`
+
+Specify `true` to enable YCQL authentication (`username` and `password`), enable YCQL security statements (`CREATE ROLE`, `DROP ROLE`, `GRANT ROLE`, `REVOKE ROLE`, `GRANT PERMISSION`, and `REVOKE PERMISSION`), and enforce permissions for YCQL statements.
+
+Default: `false`
+
+### YEDIS
+
+#### `--redis_proxy_bind_address`
+
+Specifies the bind address for the YEDIS API.
+
+Default: `0.0.0.0:6379`
+
+#### `--redis_proxy_webserver_port`
+
+Specifies the port for monitoring YEDIS metrics.
+
+Default: `11000`
 
 ### Performance
 
-`--rocksdb_compact_flush_rate_limit_bytes_per_sec` | N | `256MB` | Used to control rate of memstore flush and SSTable file compaction.
-`--remote_bootstrap_rate_limit_bytes_per_sec` | N | `256MB` | Rate control across all tablets being remote bootstrapped from or to this process.
-`--yb_num_shards_per_tserver` | N | `-1` | The number of shards per yb-tserver per table when a user table is created. Server automatically picks a valid default internally.
+#### `--rocksdb_compact_flush_rate_limit_bytes_per_sec` 
 
-### WAL
+Used to control rate of memstore flush and SSTable file compaction.
 
-`--durable_wal_write` | N | `false` | If set to `false`, the writes to the Raft log are synced to disk every `interval_durable_wal_write_ms` milliseconds or every `bytes_durable_wal_write_mb` MB, whichever comes first. This default setting is recommended only for multi-AZ or multi-region deployments where the zones/regions are independent failure domains and there isn't a risk of correlated power loss. For single AZ deployments, this flag should be set to `true`.
-`--interval_durable_wal_write_ms` | N | `1000ms` | When `durable_wal_write` is false, writes to the Raft log are synced to disk every `interval_durable_wal_write_ms` milliseconds or `bytes_durable_wal_write_mb` MB whichever comes first.
+Default: `256MB`
+
+#### `--remote_bootstrap_rate_limit_bytes_per_sec` | N | `256MB` | 
+
+Rate control across all tablets being remote bootstrapped from or to this process.
+
+#### `--yb_num_shards_per_tserver` | N | `-1` | 
+
+The number of shards per yb-tserver per table when a user table is created. Server automatically picks a valid default internally.
+
+### Write Ahead Log (WAL)
+
+#### `--durable_wal_write`
+
+If set to `false`, the writes to the Raft log are synced to disk every `interval_durable_wal_write_ms` milliseconds or every `bytes_durable_wal_write_mb` MB, whichever comes first. This default setting is recommended only for multi-AZ or multi-region deployments where the zones/regions are independent failure domains and there isn't a risk of correlated power loss. For single AZ deployments, this flag should be set to `true`.
+
+Default: `false`
+
+#### `--interval_durable_wal_write_ms`
+
+When `durable_wal_write` is false, writes to the Raft log are synced to disk every `interval_durable_wal_write_ms` milliseconds or `bytes_durable_wal_write_mb` MB whichever comes first.
 `--bytes_durable_wal_write_mb` | N | `1MB` | When `durable_wal_write` is false, writes to the Raft log are synced to disk every `bytes_durable_wal_write_mb` MB or `interval_durable_wal_write_ms` milliseconds whichever comes first.
+
+Default: `1000ms`
 
 ## Admin UI
 

--- a/docs/content/latest/admin/yb-tserver.md
+++ b/docs/content/latest/admin/yb-tserver.md
@@ -279,7 +279,7 @@ Default: `256MB`
 
 The number of shards per YB-TServer per table when a user table is created.
 
-Default: `-1` — Server automatically picks a valid default internally.
+Default: Server automatically picks a valid default internally, typically 8.
 
 ### Write Ahead Log (WAL) options
 

--- a/docs/content/latest/admin/yb-tserver.md
+++ b/docs/content/latest/admin/yb-tserver.md
@@ -145,7 +145,7 @@ Default: `cloud1`
 
 #### `--enable_ysql`
 
-Specifies to enable YSQL API. Default is `false`. Replaces deprecated `--start_pgsql_proxy` option.
+Specifies to enable YSQL API. Default is `false`. Replaces the deprecated `--start_pgsql_proxy` option.
 
 Default: `false`
 

--- a/docs/content/latest/admin/ysqlsh.md
+++ b/docs/content/latest/admin/ysqlsh.md
@@ -17,11 +17,11 @@ showAsideToc: true
 
 ## Overview
 
-`ysqlsh` is a command line interface (CLI), or shell, for interacting with YugabyteDB through [YSQL](../../api/ysql/). It is derived from [`psql`](https://www.postgresql.org/docs/11/app-psql.html), the PostgreSQL shell.
+`ysqlsh` is YugabyteDB command line interface (CLI), or shell, for using [YSQL](../../api/ysql/). The YSQL shell is derived from [`psql`](https://www.postgresql.org/docs/11/app-psql.html), the PostgreSQL shell.
 
 ## Download
 
-`ysqlsh` is installed as part of YugabyteDB and is located in the bin directory of YugabyteDB home.
+`ysqlsh` is installed as part of YugabyteDB and is located in the `bin` directory of YugabyteDB home.
 
 ## Example
 

--- a/docs/content/latest/admin/ysqlsh.md
+++ b/docs/content/latest/admin/ysqlsh.md
@@ -17,11 +17,11 @@ showAsideToc: true
 
 ## Overview
 
-`ysqlsh` is YugabyteDB command line interface (CLI), or shell, for using [YSQL](../../api/ysql/). The YSQL shell is derived from [`psql`](https://www.postgresql.org/docs/11/app-psql.html), the PostgreSQL shell.
+The YSQL shell (`ysqlsh`) is a YugabyteDB command line interface (CLI), or shell, for using [YSQL](../../api/ysql/). The YSQL shell is derived from [`psql`](https://www.postgresql.org/docs/11/app-psql.html), the PostgreSQL shell.
 
 ## Download
 
-`ysqlsh` is installed as part of YugabyteDB and is located in the `bin` directory of YugabyteDB home.
+The YSQL shell (`ysqlsh`) is installed with YugabyteDB and is located in the `bin` directory of YugabyteDB home.
 
 ## Example
 
@@ -36,12 +36,10 @@ Type "help" for help.
 yugabyte=#
 ```
 
-## Defaults
+## Default options (flags)
 
-`ysqlsh` defaults the following flags so that the user does not have to specify them.
+When you open `ysqlsh`, the following flags are set so that the user does not have to specify them.
 
-```
--h 127.0.0.1 
--p 5433 
--U postgres
-```
+- Host: `-h 127.0.0.1`
+- Port: `-p 5433`
+- User: `-U yugabyte`


### PR DESCRIPTION
Add new YSQL flags. Also, reformatted CLI pages for consistency, findability, and linkability of settings. Added missing flags to `yb-ctl` page and links to relevant examples.

Fixes first item of https://github.com/yugabyte/yugabyte-db/issues/2413 and required for completing the other two items.