### PR TITLE
Add default password to yugabyte user for ysqlsh.

### DIFF
--- a/docs/content/latest/admin/ysqlsh.md
+++ b/docs/content/latest/admin/ysqlsh.md
@@ -43,3 +43,9 @@ When you open `ysqlsh`, the following flags are set so that the user does not ha
 - Host: `-h 127.0.0.1`
 - Port: `-p 5433`
 - User: `-U yugabyte`
+
+{{< note title="Note" >}}
+
+Starting with YugabyteDB 2.0.1, you are prompted for a password for the `yugabyte` user — the default password is `yugabyte`. Prior to this release, no password was required.
+
+{{< /note >}}

--- a/docs/content/latest/deploy/public-clouds/gcp/gke.md
+++ b/docs/content/latest/deploy/public-clouds/gcp/gke.md
@@ -14,18 +14,17 @@ $ gcloud components install kubectl
 
 - Configure defaults for gcloud
 
-Set the project id as `yugabyte`. You can change this as per your need.
+Set the project ID as `yugabyte`. You can change this as per your need.
 
 ```sh
 $ gcloud config set project yugabyte
 ```
 
-Set the defaut compute zone as `us-west1-b`. You can change this as per your need.
+Set the default compute zone as `us-west1-b`. You can change this as per your need.
 
 ```sh
 $ gcloud config set compute/zone us-west1-b
 ```
-
 
 ## 1. Create a GKE cluster
 
@@ -34,7 +33,6 @@ Create a Kubernetes cluster if you have not already done so by running the follo
 ```sh
 $ gcloud container clusters create yugabyte
 ```
-
 
 ## 2. Create a YugabyteDB cluster
 

--- a/docs/content/latest/develop/graphql/hasura.md
+++ b/docs/content/latest/develop/graphql/hasura.md
@@ -117,7 +117,7 @@ Click **Add**, and then click **Save**.
 ./bin/ysqlsh
 ```
 
-2. Copy the commands below into the shell and press **Enter**.
+1. Copy the commands below into the shell and press **Enter**.
 
 ```postgresql
 SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SERIALIZABLE


### PR DESCRIPTION
Adds note to `ysqlsh` page that "Starting with YugabyteDB 2.0.1, the default `yugabyte` user for `ysqlsh` has a default password of `yugabyte`. Before this release, no password was required."
