### PR TITLE
[docs] Fix link to build section of RRDiagram

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -119,8 +119,8 @@ instructions just as a reference for YCQL._
    ```
 
    _Note: Alternatively, you can manually build the jar file as described in the [build
-   section](https://github.com/yugabyte/RRDiagram/README.md#build) of the `RRDiagram` repo (and
-   move/rename the resulting jar from the target folder)._
+   section](https://github.com/yugabyte/RRDiagram#build) of the `RRDiagram` repo (and move/rename
+   the resulting jar from the target folder)._
 
 1. Run the diagram generator using the following command:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -118,9 +118,8 @@ instructions just as a reference for YCQL._
           | grep browser_download_url | cut -d \" -f 4)
    ```
 
-   _Note: Alternatively, you can manually build the jar file as described in the [build
-   section](https://github.com/yugabyte/RRDiagram#build) of the `RRDiagram` repo (and move/rename
-   the resulting jar from the target folder)._
+   _Note: Alternatively, you can manually build the JAR file as described in the [build
+   section](https://github.com/yugabyte/RRDiagram#build) of the `RRDiagram` repository._
 
 1. Run the diagram generator using the following command:
 


### PR DESCRIPTION
In the docs README, there is a link to the build section of the README
of the RRDiagram repo.  However, that link is incorrectly formatted, so
it takes users to an unhelpful "Not Found" page.  Fix the link.