### PR TITLE
Set Timeout and elapsed time in same units

### DIFF
--- a/src/yb/rpc/outbound_call.cc
+++ b/src/yb/rpc/outbound_call.cc
@@ -537,7 +537,7 @@ bool OutboundCall::DumpPB(const DumpRunningRpcsRequestPB& req,
                           RpcCallInProgressPB* resp) {
   std::lock_guard<simple_spinlock> l(lock_);
   InitHeader(resp->mutable_header());
-  resp->set_micros_elapsed(MonoTime::Now().GetDeltaSince(start_).ToMicroseconds());
+  resp->set_elapsed_millis(MonoTime::Now().GetDeltaSince(start_).ToMilliseconds());
   resp->set_state(state());
   if (req.include_traces() && trace_) {
     resp->set_trace_buffer(trace_->DumpToString(true));

--- a/src/yb/rpc/rpc_introspection.proto
+++ b/src/yb/rpc/rpc_introspection.proto
@@ -69,7 +69,7 @@ enum RpcCallState {
 message RpcCallInProgressPB {
   required RequestHeader header = 1;
   optional string trace_buffer = 2;
-  optional uint64 micros_elapsed = 3;
+  optional uint64 elapsed_millis = 3;
   optional uint64 sending_bytes = 6;
   optional RpcCallState state = 7;
   oneof call_details {

--- a/src/yb/rpc/rpc_stub-test.cc
+++ b/src/yb/rpc/rpc_stub-test.cc
@@ -549,7 +549,7 @@ TEST_F(RpcStubTest, TestDumpCallsInFlight) {
   ASSERT_EQ(1, dump_resp.outbound_connections(0).calls_in_flight_size());
   ASSERT_EQ("Sleep", dump_resp.outbound_connections(0).calls_in_flight(0).
                         header().remote_method().method_name());
-  ASSERT_GT(dump_resp.outbound_connections(0).calls_in_flight(0).micros_elapsed(), 0);
+  ASSERT_GT(dump_resp.outbound_connections(0).calls_in_flight(0).elapsed_millis(), 0);
 
   // And the server messenger.
   // We have to loop this until we find a result since the actual call is sent
@@ -569,7 +569,7 @@ TEST_F(RpcStubTest, TestDumpCallsInFlight) {
   ASSERT_EQ(1, dump_resp.inbound_connections(0).calls_in_flight_size());
   ASSERT_EQ("Sleep", dump_resp.inbound_connections(0).calls_in_flight(0).
                         header().remote_method().method_name());
-  ASSERT_GT(dump_resp.inbound_connections(0).calls_in_flight(0).micros_elapsed(), 0);
+  ASSERT_GT(dump_resp.inbound_connections(0).calls_in_flight(0).elapsed_millis(), 0);
   ASSERT_STR_CONTAINS(dump_resp.inbound_connections(0).calls_in_flight(0).trace_buffer(),
                       "Inserting onto call queue");
   latch.Wait();

--- a/src/yb/rpc/yb_rpc.cc
+++ b/src/yb/rpc/yb_rpc.cc
@@ -342,8 +342,8 @@ bool YBInboundCall::DumpPB(const DumpRunningRpcsRequestPB& req,
   if (req.include_traces() && trace_) {
     resp->set_trace_buffer(trace_->DumpToString(true));
   }
-  resp->set_micros_elapsed(MonoTime::Now().GetDeltaSince(timing_.time_received)
-      .ToMicroseconds());
+  resp->set_elapsed_millis(MonoTime::Now().GetDeltaSince(timing_.time_received)
+      .ToMilliseconds());
   return true;
 }
 

--- a/src/yb/yql/cql/cqlserver/cql_rpc.cc
+++ b/src/yb/yql/cql/cqlserver/cql_rpc.cc
@@ -283,8 +283,8 @@ bool CQLInboundCall::DumpPB(const rpc::DumpRunningRpcsRequestPB& req,
   if (req.include_traces() && trace_) {
     resp->set_trace_buffer(trace_->DumpToString(true));
   }
-  resp->set_micros_elapsed(
-      MonoTime::Now().GetDeltaSince(timing_.time_received).ToMicroseconds());
+  resp->set_elapsed_millis(
+      MonoTime::Now().GetDeltaSince(timing_.time_received).ToMilliseconds());
   GetCallDetails(resp);
 
   return true;

--- a/src/yb/yql/redis/redisserver/redis_rpc.cc
+++ b/src/yb/yql/redis/redisserver/redis_rpc.cc
@@ -292,8 +292,8 @@ bool RedisInboundCall::DumpPB(const rpc::DumpRunningRpcsRequestPB& req,
   if (req.include_traces() && trace_) {
     resp->set_trace_buffer(trace_->DumpToString(true));
   }
-  resp->set_micros_elapsed(MonoTime::Now().GetDeltaSince(timing_.time_received)
-      .ToMicroseconds());
+  resp->set_elapsed_millis(MonoTime::Now().GetDeltaSince(timing_.time_received)
+      .ToMilliseconds());
 
   if (!parsed_.load(std::memory_order_acquire)) {
     return true;


### PR DESCRIPTION
The elasped time is in micros-seconds and
timeout is in milliseconds for endpoint /rpcz

Set elasped time to milliseconds.

Possible Fix to #2801 