### PR TITLE
[docs] Correct yb-admin syntax and add new "Geo-distributed options"

### DIFF
--- a/docs/content/latest/admin/yb-admin.md
+++ b/docs/content/latest/admin/yb-admin.md
@@ -76,7 +76,7 @@ Changes the configuration of a tablet.
 **Syntax**
 
 ```sh
-yb-admin change_config -master_addresses server1:port,server2:port,server3:port,...  <tablet_id> [ ADD_SERVER | REMOVE_SERVER ] <peer_uuid> [ PRE_VOTER | PRE_OBSERVER ]
+yb-admin -master_addresses <master-addresses> change_config <tablet_id> [ ADD_SERVER | REMOVE_SERVER ] <peer_uuid> [ PRE_VOTER | PRE_OBSERVER ]
 ```
 
 - master_addresses: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.
@@ -185,7 +185,7 @@ Prints a list of replica types and counts for the specified table.
 
 **Syntax**
 
-```
+```sh
 yb-admin -master_addresses <master-addresses> list_replica_type_counts <keyspace> <table_name>
 ```
 
@@ -223,7 +223,7 @@ Lists all tablets for the specified tablet server.
 
 **Syntax**
 
-```
+```sh
 yb-admin -master_addresses <master-addresses> list_tablets_for_tablet_server <ts_uuid>
 ```
 
@@ -487,7 +487,7 @@ Modifies the placement information (cloud, region, and zone) for a deployment.
 **Syntax**
 
 ```sh
-yb-admin -master_addresses <master-addresses> modify_placement_info <placement_info> <replication_factor> [ placement_id ]
+yb-admin -master_addresses <master-addresses> modify_placement_info <placement_info> <replication_factor> [ <placement_id> ]
 ```
 
 - *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.
@@ -615,7 +615,7 @@ Delete the read replica.
 **Syntax**
 
 ```sh
-yb-admin -master_addresses <master-addresses> delete_read_replica_placement_info <placement_id>
+yb-admin -master_addresses <master-addresses> delete_read_replica_placement_info [ <placement_id> ]
 ```
 
 - *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.

--- a/docs/content/latest/admin/yb-master.md
+++ b/docs/content/latest/admin/yb-master.md
@@ -46,7 +46,7 @@ $ ./bin/yb-master --help
 - [YSQL](#ysql-options)
 - [Logging](#logging-options)
 - [Cluster](#cluster-options)
-- [Placement](#placement-options)
+- [Geo-distribution](#geo-distribution-options)
 - [Security](#security-options)
 - [Change data capture (CDC)](#change-data-capture-cdc-options)
 
@@ -238,7 +238,17 @@ Default: `3`
 
 ---
 
-### Placement options
+### Geo-distribution options
+
+Settings related to managing geo-distributed clusters and Raft consensus.
+
+#### --leader_failure_max_missed_heartbeat_periods
+
+The maximum heartbeat periods that the leader can fail to heartbeat in before the leader is considered to be failed. The total failure timeout, in milliseconds, is [`--raft_heartbeat_interval_ms`](#raft-heartbeat-interval-ms) multiplied by `--leader_failure_max_missed_heartbeat_periods`.
+
+For read replica clusters, set the value to `10` on both YB-Master and YB-TServer nodes.  Because the the data is globally replicated, RPC latencies are higher. Use this flag to increase the failure detection interval in such a higher RPC latency deployment.
+
+Default: `6`
 
 #### --placement_zone
 
@@ -263,6 +273,12 @@ Default: `cloud1`
 Determines when to use private IP addresses. Possible values are `never` (default),`zone`,`cloud` and `region`. Based on the values of the `placement_*` configuration options.
 
 Default: `never`
+
+#### --raft_heartbeat_interval_ms
+
+The heartbeat interval, in milliseconds, for Raft replication. The leader produces heartbeats to followers at this interval. The followers expect a heartbeat at this interval and consider a leader to have failed if it misses several in a row.
+
+Default: `500`
 
 ---
 

--- a/docs/content/latest/admin/yb-tserver.md
+++ b/docs/content/latest/admin/yb-tserver.md
@@ -44,7 +44,7 @@ $ ./bin/yb-tserver --help
 - [Help](#help-options)
 - [General](#general-options)
 - [Logging](#logging-options)
-- [Cluster](#cluster-options)
+- [Geo-distribution](#geo-distribution-options)
 - [YSQL](#ysql-options)
 - [YCQL](#ycql-options)
 - [YEDIS](#yedis-options)
@@ -181,7 +181,17 @@ Default: `false`
 
 ---
 
-### Placement options
+### Geo-distribution options
+
+Settings related to managing geo-distributed clusters and Raft consensus.
+
+#### --leader_failure_max_missed_heartbeat_periods
+
+The maximum heartbeat periods that the leader can fail to heartbeat in before the leader is considered to be failed. The total failure timeout, in milliseconds (ms), is [`--raft_heartbeat_interval_ms`](#raft-heartbeat-interval-ms) multiplied by `--leader_failure_max_missed_heartbeat_periods`.
+
+For read replica clusters, set the value to `10` on both YB-Master and YB-TServer nodes.  Because the the data is globally replicated, RPC latencies are higher. Use this flag to increase the failure detection interval in such a higher RPC latency deployment.
+
+Default: `6`
 
 #### --placement_zone
 
@@ -200,6 +210,12 @@ Default: `datacenter1`
 Specifies the name of the cloud where this instance is deployed.
 
 Default: `cloud1`
+
+#### --raft_heartbeat_interval_ms
+
+The heartbeat interval, in milliseconds (ms), for Raft replication. The leader produces heartbeats to followers at this interval. The followers expect a heartbeat at this interval and consider a leader to have failed if it misses several in a row.
+
+Default: `500`
 
 ---
 

--- a/docs/content/latest/reference/default-ports.md
+++ b/docs/content/latest/reference/default-ports.md
@@ -15,7 +15,7 @@ menu:
 | Service    | Port | Configuration setting (default)                              |
 | ---------- | ---- | ------------------------------------------------------------ |
 | yb-master  | 7100 | yb-master: [`--rpc_bind_addresses 0.0.0.0:7100`](../../admin/yb-master/#rpc-bind-addresses) |
-| yb-tserver | 9100 | yb-tserver: [`--tserver_master_addrs 0.0.0.0:9100`](../../admin/yb-tserver/#tserver-master-addrs)<br/>yb-tserver: [`--server_broadcast_addresses=0.0.0.0:9100`](../yb-tserver/#server-broadcast-addresses) |
+| yb-tserver | 9100 | yb-tserver: [`--tserver_master_addrs 0.0.0.0:9100`](../../admin/yb-tserver/#tserver-master-addrs)<br/>yb-tserver: [`--server_broadcast_addresses=0.0.0.0:9100`](../../admin/yb-tserver/#server-broadcast-addresses) |
 
 ## Admin web server
 
@@ -31,6 +31,6 @@ menu:
 
 | API     | Port  | Configuration setting (default)           |
 | ------- | ----- | ----------------------------------------- |
-| ysql    | 5433  | yb-tserver: `--pgsql_proxy_bind_address 0.0.0.0:5433` |
-| ycql    | 9042  | yb-tserver: `--cql_proxy_bind_address 0.0.0.0:9042`   |
-| yedis   | 6379  | yb-tserver: `--redis_proxy_bind_address 0.0.0.0:6379` |
+| ysql    | 5433  | yb-tserver: [`--pgsql_proxy_bind_address 0.0.0.0:5433`](../../admin/yb-tserver/#pgsql-proxy-bind-address) |
+| ycql    | 9042  | yb-tserver: [`--cql_proxy_bind_address 0.0.0.0:9042`](../../admin/yb-tserver/#cql-proxy-bind-address)   |
+| yedis   | 6379  | yb-tserver: [`--redis_proxy_bind_address 0.0.0.0:6379`](../../admin/yb-tserver/#redis-proxy-bind-address) |


### PR DESCRIPTION
- Fixes a syntax error in yb-admin
- Replaces "Placement options" with "Geo-distribution options"
- Add hearbeat-related settings to yb-master and yb-tserver