### PR TITLE
[docs] Update use of "enable_ysql` in settings and examples

### DIFF
--- a/docs/content/latest/admin/yb-ctl.md
+++ b/docs/content/latest/admin/yb-ctl.md
@@ -107,8 +107,6 @@ For details and examples, see [Initialize the YEDIS API](#initialize-the-yedis-a
 
 ## Optional arguments
 
-
-
 ### --help | -h
 
 Shows the help message and then exits.

--- a/docs/content/latest/admin/yb-master.md
+++ b/docs/content/latest/admin/yb-master.md
@@ -28,8 +28,7 @@ $ ./bin/yb-master \
 --master_addresses 172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100 \
 --rpc_bind_addresses 172.151.17.130 \
 --fs_data_dirs "/home/centos/disk1,/home/centos/disk2" \
---replication_factor=3 &
---enable_ysql=true
+--replication_factor=3
 ```
 
 ### Online help
@@ -120,13 +119,7 @@ Default: The `www` directory in the YugabyteDB home directory.
 
 Enables the YSQL API when value is `true`. Replaces the deprecated `--start_pgsql_proxy` option.
 
-Default: `false`
-
-{{< note title="Note" >}}
-
-To enable YSQL, you must set `--enable_ysql=true` on all YB-Master and YB-TServer nodes.
-
-{{< /note >}}
+Default: `true`
 
 ---
 

--- a/docs/content/latest/admin/yb-tserver.md
+++ b/docs/content/latest/admin/yb-tserver.md
@@ -227,17 +227,11 @@ The following options, or flags, support the use of the [YSQL API](../../api/ysq
 
 Enables the YSQL API. Replaces the deprecated `--start_pgsql_proxy` option.
 
-Default: `false`
-
-{{< note title="Note" >}}
-
-To enable YSQL, you must set `--enable_ysql=true` on all YB-Master and YB-TServer nodes.
-
-{{< /note >}}
+Default: `true`
 
 #### --ysql_enable_auth
 
-Enables YSQL authentication. 
+Enables YSQL authentication.
 
 {{< note title="Note" >}}
 

--- a/docs/content/latest/deploy/docker/docker-compose.md
+++ b/docs/content/latest/deploy/docker/docker-compose.md
@@ -57,8 +57,7 @@ services:
       command: [ "/home/yugabyte/bin/yb-master",
                 "--fs_data_dirs=/mnt/disk0,/mnt/disk1",
                 "--master_addresses=yb-master-n1:7100",
-                "--replication_factor=1",
-                "--enable_ysql=true"]
+                "--replication_factor=1"]
       ports:
       - "7000:7000"
       environment:

--- a/docs/content/latest/deploy/docker/docker-swarm.md
+++ b/docs/content/latest/deploy/docker/docker-swarm.md
@@ -167,8 +167,7 @@ $ docker service create \
 yugabytedb/yugabyte:latest /home/yugabyte/bin/yb-master \
 --fs_data_dirs=/mnt/data0 \
 --master_addresses=yb-master1:7100,yb-master2:7100,yb-master3:7100 \
---replication_factor=3 \
---enable_ysql=true
+--replication_factor=3
 ```
 
 ```sh
@@ -180,8 +179,7 @@ $ docker service create \
 yugabytedb/yugabyte:latest /home/yugabyte/bin/yb-master \
 --fs_data_dirs=/mnt/data0 \
 --master_addresses=yb-master1:7100,yb-master2:7100,yb-master3:7100 \
---replication_factor=3 \
---enable_ysql=true
+--replication_factor=3
 ```
 
 ```sh
@@ -193,8 +191,7 @@ $ docker service create \
 yugabytedb/yugabyte:latest /home/yugabyte/bin/yb-master \
 --fs_data_dirs=/mnt/data0 \
 --master_addresses=yb-master1:7100,yb-master2:7100,yb-master3:7100 \
---replication_factor=3 \
---enable_ysql=true
+--replication_factor=3
 ```
 
 - Run the command below to see the services that are now live.

--- a/docs/content/latest/deploy/manual-deployment/start-masters.md
+++ b/docs/content/latest/deploy/manual-deployment/start-masters.md
@@ -41,7 +41,6 @@ For the full list of flags, see the [yb-master Reference](../../../admin/yb-mast
 $ ./bin/yb-master \
   --master_addresses 172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100 \
   --rpc_bind_addresses 172.151.17.130 \
-  --enable_ysql=true \
   --fs_data_dirs "/home/centos/disk1,/home/centos/disk2" \
   >& /home/centos/disk1/yb-master.out &
 ```
@@ -53,7 +52,6 @@ $ ./bin/yb-master \
 ```sh
 --master_addresses=172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100
 --rpc_bind_addresses=172.151.17.130
---enable_ysql=true
 --fs_data_dirs=/home/centos/disk1,/home/centos/disk2
 ```
 

--- a/docs/content/latest/deploy/public-clouds/aws/manual-deployment.md
+++ b/docs/content/latest/deploy/public-clouds/aws/manual-deployment.md
@@ -331,7 +331,6 @@ This step prepares the config files for the 3 masters. The config files need to,
     echo --placement_cloud=$CLOUD               >> $CONFIG_FILE
     echo --placement_region=$REGION             >> $CONFIG_FILE
     echo --placement_zone=$AZ                   >> $CONFIG_FILE
-    echo --enable_ysql                          >> $CONFIG_FILE
 "
 )
 ```
@@ -348,7 +347,6 @@ This step prepares the config files for the 3 masters. The config files need to,
     echo --placement_cloud=$CLOUD               >> $CONFIG_FILE
     echo --placement_region=$REGION             >> $CONFIG_FILE
     echo --placement_zone=$AZ                   >> $CONFIG_FILE
-    echo --enable_ysql                          >> $CONFIG_FILE
 "
 )
 ```
@@ -365,7 +363,6 @@ This step prepares the config files for the 3 masters. The config files need to,
     echo --placement_cloud=$CLOUD               >> $CONFIG_FILE
     echo --placement_region=$REGION             >> $CONFIG_FILE
     echo --placement_zone=$AZ                   >> $CONFIG_FILE
-    echo --enable_ysql                          >> $CONFIG_FILE
 "
 )
 ```
@@ -399,7 +396,6 @@ done
       echo --placement_cloud=$CLOUD                           >> $CONFIG_FILE
       echo --placement_region=$REGION                         >> $CONFIG_FILE
       echo --placement_zone=$AZ                               >> $CONFIG_FILE
-      echo --enable_ysql                                      >> $CONFIG_FILE
       echo --pgsql_proxy_bind_address=$ip:5433                >> $CONFIG_FILE
     "
  done
@@ -422,7 +418,6 @@ done
       echo --placement_cloud=$CLOUD                           >> $CONFIG_FILE
       echo --placement_region=$REGION                         >> $CONFIG_FILE
       echo --placement_zone=$AZ                               >> $CONFIG_FILE
-      echo --enable_ysql                                      >> $CONFIG_FILE
       echo --pgsql_proxy_bind_address=$ip:5433                >> $CONFIG_FILE
     "
  done
@@ -445,7 +440,6 @@ done
       echo --placement_cloud=$CLOUD                           >> $CONFIG_FILE
       echo --placement_region=$REGION                         >> $CONFIG_FILE
       echo --placement_zone=$AZ                               >> $CONFIG_FILE
-      echo --enable_ysql                                      >> $CONFIG_FILE
       echo --pgsql_proxy_bind_address=$ip:5433                >> $CONFIG_FILE
     "
  done

--- a/docs/content/latest/develop/kubernetes/run-sample-apps.md
+++ b/docs/content/latest/develop/kubernetes/run-sample-apps.md
@@ -8,12 +8,6 @@ Create a cluster.
 $ kubectl apply -f yugabyte-statefulset.yaml
 ```
 
-Initialize the YSQL API.
-
-```sh
-$ kubectl exec -it yb-master-0 bash --  -c "YB_ENABLED_IN_POSTGRES=1 FLAGS_pggate_master_addresses=yb-master-0.yb-masters.default.svc.cluster.local:7100,yb-master-1.yb-masters.default.svc.cluster.local:7100,yb-master-2.yb-masters.default.svc.cluster.local:7100 /home/yugabyte/postgres/bin/initdb -D /tmp/yb_pg_initdb_tmp_data_dir -U postgres"
-```
-
 Initialize the YEDIS API.
 
 ```sh

--- a/docs/content/latest/quick-start/kubernetes/create-local-cluster.md
+++ b/docs/content/latest/quick-start/kubernetes/create-local-cluster.md
@@ -30,8 +30,6 @@ yb-tserver-0   0/1       ContainerCreating   0          4s
 
 Eventually all the pods will have the `Running` state.
 
-Run the following command to initialize the YSQL API. Note that this step can take a few minutes depending on the resource utilization of your Kubernetes environment.
-
 ```sh
 $ kubectl get pods
 ```
@@ -42,15 +40,7 @@ yb-master-0    1/1       Running   0          13s
 yb-tserver-0   1/1       Running   0          12s
 ```
 
-## 3. Initialize the YSQL API
-
-```sh
-$ kubectl exec -it yb-master-0 bash --  -c "YB_ENABLED_IN_POSTGRES=1 FLAGS_pggate_master_addresses=yb-master-0.yb-masters.default.svc.cluster.local:7100 /home/yugabyte/postgres/bin/initdb -D /tmp/yb_pg_initdb_tmp_data_dir -U postgres"
-```
-
-Clients can now connect to this YugabyteDB universe using YSQL and YCQL APIs on the 5433 and 9042 ports respectively.
-
-## 4. Check cluster status via Kubernetes
+## 3. Check cluster status via Kubernetes
 
 You can see the status of the 3 services by simply running the following command.
 
@@ -66,7 +56,7 @@ yb-masters     ClusterIP      None            <none>        7000/TCP,7100/TCP   
 yb-tservers    ClusterIP      None            <none>        9000/TCP,9100/TCP,9042/TCP,6379/TCP,5433/TCP   11m
 ```
 
-## 5. Check cluster status with Admin UI
+## 4. Check cluster status with Admin UI
 
 In order to do this, we would need to access the UI on port 7000 exposed by any of the pods in the `yb-master` service. In order to do so, we find the URL for the yb-master-ui LoadBalancer service.
 
@@ -80,7 +70,7 @@ http://192.168.99.100:31283
 
 Now, you can view the [yb-master-0 Admin UI](../../admin/yb-master/#admin-ui) is available at the above URL.
 
-### 5.1 Overview and master status
+### 4.1 Overview and master status
 
 The yb-master-0 home page shows that we have a cluster (aka a Universe) with `Replication Factor` of 1 and `Num Nodes (TServers)` as 1. The `Num User Tables` is 0 since there are no user tables created yet. YugabyteDB version is also shown for your reference.
 
@@ -88,7 +78,7 @@ The yb-master-0 home page shows that we have a cluster (aka a Universe) with `Re
 
 The Masters section highlights the 1 yb-master along its corresponding cloud, region and zone placement information.
 
-### 5.2 TServer status
+### 4.2 TServer status
 
 Clicking on the `See all nodes` takes us to the Tablet Servers page where we can observe the 1 tserver along with the time since it last connected to this master via regular heartbeats. Additionally, we can see that the `Load (Num Tablets)` is balanced across all available tservers. These tablets are the shards of the user tables currently managed by the cluster (which in this case is the `system_redis.redis` table). As new tables get added, new tablets will get automatically created and distributed evenly across all the available tservers.
 

--- a/docs/content/latest/releases/v2.0.3.md
+++ b/docs/content/latest/releases/v2.0.3.md
@@ -37,16 +37,16 @@ docker pull yugabytedb/yugabyte:2.0.3.0-b7
 ```
 
 ## YSQL changes
+* [YSQL] Set `enable_ysql` to `true` by default for YB-Master and YB-TServer. [#2455](https://github.com/yugabyte/yugabyte-db/issues/2455)
 * [YSQL] Build YBTupleID value with respect to DocDB column order. [#2438](https://github.com/yugabyte/yugabyte-db/issues/2438)
 * [YSQL] Support TLS Server-Server Encryption through YSQL API. [#1845](https://github.com/yugabyte/yugabyte-db/issues/1845)
 * [YSQL] Check constraints when doing UPDATE. [#2361](https://github.com/yugabyte/yugabyte-db/issues/2361)
 * [YSQL] Add default password to yugabyte user for ysqlsh. [#2594](https://github.com/yugabyte/yugabyte-db/issues/2594)
 * [YSQL] authentication and authorization. [#2610](https://github.com/yugabyte/yugabyte-db/issues/2610)
 * [YSQL] client authentication update. [#2614](https://github.com/yugabyte/yugabyte-db/issues/2614)
-* [YSQL] Enable FOR SHARE and FOR KEY SHARE row locking in YSQL SELECT statements. [#1199](https://github.com/yugabyte/yugabyte-db/issues/1199)
-* [YSQL] Avoid namespace id resolving for import_namespace yb-admin command. [#2582](https://github.com/yugabyte/yugabyte-db/issues/2582)
+* [YSQL] Enable `FOR SHARE` and `FOR KEY SHARE` row locking in YSQL `SELECT` statements. [#1199](https://github.com/yugabyte/yugabyte-db/issues/1199)
+* [YSQL] Avoid namespace id resolving for `yb-admin` `import_namespace` command. [#2582](https://github.com/yugabyte/yugabyte-db/issues/2582)
 * [YSQL] SERIALIZABLE READ ONLY DEFERRABLE. [#2161](https://github.com/yugabyte/yugabyte-db/issues/2161)
-
 
 ## YCQL changes
 * [YCQL] Fix for SIGBUS TS crash on invalid statement. [#2476](https://github.com/yugabyte/yugabyte-db/issues/2476)


### PR DESCRIPTION
- Add #2455 (Set default for enable_ysql` to `true`) to 2.0.3 release notes
- Remove all `enable_ysql` settings where not needed.
- Changed `eanable_ysql` default values in yb-master and yb-tserver to `true`.
- Remove "Initialize the YSQL API" from Kubernetes quick start.