### PR TITLE
Add GitHub issue and link for users to track Python 3 support.

### DIFF
--- a/docs/content/latest/quick-start/binary/linux-install.md
+++ b/docs/content/latest/quick-start/binary/linux-install.md
@@ -6,7 +6,7 @@
 
     <i class="icon-ubuntu"></i> Ubuntu 16.04+
 
-2. Verify that you have Python 2 installed. Support for Python 3 is in the works.
+2. Verify that you have Python 2 installed. Support for Python 3 is in the works — to follow the status, see [Enhance yb-ctl and yb-docker-ctl to support Python3 #3025](https://github.com/yugabyte/yugabyte-db/issues/3025).
 
     ```sh
     $ python --version

--- a/docs/content/latest/quick-start/binary/macos-install.md
+++ b/docs/content/latest/quick-start/binary/macos-install.md
@@ -2,7 +2,7 @@
 
 1. <i class="fab fa-apple" aria-hidden="true"></i> macOS 10.12 or later.
 
-2. Verify that you have Python 2 installed. Support for Python 3 is in the works.
+2. Verify that you have Python 2 installed. Support for Python 3 is in the works — to follow the status, see [Enhance yb-ctl and yb-docker-ctl to support Python3 #3025](https://github.com/yugabyte/yugabyte-db/issues/3025).
 
     ```sh
     $ python --version

--- a/docs/content/latest/quick-start/docker/install.md
+++ b/docs/content/latest/quick-start/docker/install.md
@@ -15,7 +15,7 @@ a) You must have the Docker runtime installed on your localhost. Follow the link
 
 <i class="fab fa-windows" aria-hidden="true"></i> [Docker for Windows](https://store.docker.com/editions/community/docker-ce-desktop-windows)
 
-b) Verify that you have python2 installed. Support for python3 is in the works.
+b) Verify that you have python2 installed. Support for Python 3 is in the works — to follow the status, see [Enhance yb-ctl and yb-docker-ctl to support Python3 #3025](https://github.com/yugabyte/yugabyte-db/issues/3025).
 
 ```sh
 $ python --version


### PR DESCRIPTION
Add note to macOS, Linux, and Docker installation requirements in Quick Start.