### PR TITLE
Fix the mixed content warning in docs

### DIFF
--- a/docs/content/latest/deploy/public-clouds/azure/azure-arm.md
+++ b/docs/content/latest/deploy/public-clouds/azure/azure-arm.md
@@ -14,7 +14,7 @@
     ```
     $ az group deployment show -g <Your-Azure-Resource-Group> -n <YOur-Deployment-Name> --query properties.outputs
     ```
-    In the output, you will get the YugaByte DB admin URL, JDBC URL, YSQL, YCQL and YEDIS connection string. You can use YugaByte admin URL to access admin portal.
+    In the output, you will get the YugabyteDB admin URL, JDBC URL, YSQL, YCQL and YEDIS connection string. You can use YugaByte admin URL to access admin portal.
 
 ## Deploying From Azure Portal
 - Clone this repo locally.
@@ -29,4 +29,4 @@
 -  Click on the `Save` button at the bottom of the window.
 -  Now provide the required details.
 -  Once details are provided, then check the Terms and Condition checkbox and click on the `Purchase` button. 
--  Once deployments get compleated, you can access the YugaByte DB admin from URL you get in the deployment output section.
+-  Once deployments get compleated, you can access the YugabyteDB admin from URL you get in the deployment output section.

--- a/docs/content/latest/deploy/public-clouds/gcp/gcp-deployment-manager.md
+++ b/docs/content/latest/deploy/public-clouds/gcp/gcp-deployment-manager.md
@@ -15,4 +15,4 @@
     ```
     $ gcloud deployment-manager deployments describe <your-deployment-name>
     ```
-    In the output, you will get the YugaByte DB admin URL, JDBC URL, YSQL, YCQL and YEDIS connection string. You can use YugaByte admin URL to access admin portal. 
+    In the output, you will get the YugabyteDB admin URL, JDBC URL, YSQL, YCQL and YEDIS connection string. You can use YugaByte admin URL to access admin portal. 

--- a/docs/content/latest/deploy/public-clouds/gcp/gcp-deployment-manager.md
+++ b/docs/content/latest/deploy/public-clouds/gcp/gcp-deployment-manager.md
@@ -3,7 +3,7 @@
 * Clone git repo from [here](https://github.com/yugabyte/gcp-deployment-manager.git)
 
 # Usage
-[![Open in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FYugaByte%2Fgcp-deployment-manager.git)
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FYugaByte%2Fgcp-deployment-manager.git)
 
 * Change current directory to cloned git repo directory
 * Use gcloud command to create deployment-manager deployment <br/> 

--- a/docs/content/latest/explore/binary/two-data-centers.md
+++ b/docs/content/latest/explore/binary/two-data-centers.md
@@ -243,5 +243,5 @@ For more information, see the following in the Architecture section:
 
 For detailed design documents, see the following GitHub repository pages:
 
-- [Two Data Center Deployment Support with YugaByte DB](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/multi-region-2DC-deployment.md)
+- [Two Data Center Deployment Support with YugabyteDB](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/multi-region-2DC-deployment.md)
 - [Change Data Capture in YugabyteDB](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/docdb-change-data-capture.md)

--- a/docs/content/latest/manage/backup-restore/snapshots.md
+++ b/docs/content/latest/manage/backup-restore/snapshots.md
@@ -15,7 +15,7 @@ isTocNested: true
 showAsideToc: true
 ---
 
-This page covers backups for YugaByte DB using snapshots. Here are some points to keep in mind.
+This page covers backups for YugabyteDB using snapshots. Here are some points to keep in mind.
 
 - Distributed backups using snapshots
   - Massively parallel, efficient for very large data sets


### PR DESCRIPTION
There is a place in our docs which has a `http` endpoint and it keeps giving me warning messages on netlify deployments. fix that.
