### PR TITLE
[docs] Fix YSQL statement front matter and titles

### DIFF
--- a/docs/content/latest/api/ysql/commands/cmd_do.md
+++ b/docs/content/latest/api/ysql/commands/cmd_do.md
@@ -13,10 +13,9 @@ showAsideToc: true
 
 ## Synopsis
 
-`DO` executes an anonymous code block, or in other words a transient anonymous function in a procedural language.
+Use the `DO` statement to execute an anonymous code block, or in other words a transient anonymous function in a procedural language.
 The code block is treated as though it were the body of a function with no parameters, returning void. It is parsed and executed a single time.
-The optional LANGUAGE clause can be written either before or after the code block.
-
+The optional `LANGUAGE` clause can be written either before or after the code block.
 
 ## Syntax
 

--- a/docs/content/latest/api/ysql/commands/dcl_alter_default_privileges.md
+++ b/docs/content/latest/api/ysql/commands/dcl_alter_default_privileges.md
@@ -1,5 +1,6 @@
 ---
 title: ALTER DEFAULT PRIVILEGES
+linkTitle: ALTER DEFAULT PRIVILEGES
 description: ALTER DEFAULT PRIVILEGES
 summary: Roles (users and groups)
 menu:
@@ -14,7 +15,7 @@ showAsideToc: true
 
 ## Synopsis
 
-`ALTER DEFAULT PRIVILEGES` defines the default access privileges.
+Use the `ALTER DEFAULT PRIVILEGES` statement to define the default access privileges.
 
 ## Syntax
 

--- a/docs/content/latest/api/ysql/commands/dcl_alter_group.md
+++ b/docs/content/latest/api/ysql/commands/dcl_alter_group.md
@@ -1,6 +1,7 @@
 ---
 title: ALTER GROUP
-description: Groups and roles
+linkTitle: ALTER GROUP
+description: ALTER GROUP
 summary: Groups and roles
 menu:
   latest:

--- a/docs/content/latest/api/ysql/commands/dcl_alter_policy.md
+++ b/docs/content/latest/api/ysql/commands/dcl_alter_policy.md
@@ -1,5 +1,6 @@
 ---
 title: ALTER POLICY
+linkTitle: ALTER POLICY
 description: ALTER POLICY
 summary: Alter row level security policy
 menu:
@@ -14,7 +15,7 @@ showAsideToc: true
 
 ## Synopsis
 
-`ALTER POLICY` changes the definition of an existing row level security policy. It can be used to
+Use  the `ALTER POLICY` statement to change the definition of an existing row level security policy. It can be used to
 change the roles that the policy applies to and the `USING` and `CHECK` expressions of the policy.
 
 ## Syntax

--- a/docs/content/latest/api/ysql/commands/dcl_alter_role.md
+++ b/docs/content/latest/api/ysql/commands/dcl_alter_role.md
@@ -1,5 +1,6 @@
 ---
 title: ALTER ROLE
+linkTitle: ALTER ROLE
 description: ALTER ROLE
 summary: Roles (users and groups)
 menu:

--- a/docs/content/latest/api/ysql/commands/dcl_alter_user.md
+++ b/docs/content/latest/api/ysql/commands/dcl_alter_user.md
@@ -1,5 +1,6 @@
 ---
 title: ALTER USER
+linkTitle: ALTER USER
 description: Users and roles
 summary: Users and roles
 menu:
@@ -14,7 +15,7 @@ showAsideToc: true
 
 ## Synopsis
 
-`ALTER USER` is an alias for [`ALTER ROLE`](../dcl_alter_role) and is used to alter a role.
+Use the `ALTER USER` statementto alter a role. `ALTER USER` is an alias for [`ALTER ROLE`](../dcl_alter_role) and is used to alter a role.
 
 ## Syntax
 

--- a/docs/content/latest/api/ysql/commands/dcl_create_group.md
+++ b/docs/content/latest/api/ysql/commands/dcl_create_group.md
@@ -1,6 +1,7 @@
 ---
 title: CREATE GROUP
-description: Groups and roles
+linkTitle: CREATE GROUP
+description: CREATE GROUP
 summary: Groups and roles
 menu:
   latest:
@@ -14,7 +15,7 @@ showAsideToc: true
 
 ## Synopsis
 
-`CREATE GROUP` is an alias for [`CREATE ROLE`](../dcl_create_role) and is used to create a group role.
+Use the `CREATE GROUP` statement to create a group role. `CREATE GROUP` is an alias for [`CREATE ROLE`](../dcl_create_role) and is used to create a group role.
 
 ## Syntax
 

--- a/docs/content/latest/api/ysql/commands/dcl_create_policy.md
+++ b/docs/content/latest/api/ysql/commands/dcl_create_policy.md
@@ -1,5 +1,6 @@
 ---
 title: CREATE POLICY
+linkTitle: CREATE POLICY
 description: CREATE POLICY
 summary: Create row level security policy
 menu:
@@ -14,7 +15,7 @@ showAsideToc: true
 
 ## Synopsis
 
-`CREATE POLICY` creates a new row level security policy for a table.
+Use the `CREATE POLICY` statement to create a new row level security policy for a table.
 A policy grants the permission to select, insert, update, or delete rows that match the relevant policy expression.
 Row level security must be enabled on the table using [ALTER TABLE](../ddl_alter_table) for the
 policies to take effect.

--- a/docs/content/latest/api/ysql/commands/dcl_create_role.md
+++ b/docs/content/latest/api/ysql/commands/dcl_create_role.md
@@ -1,5 +1,6 @@
 ---
 title: CREATE ROLE
+linkTitle: CREATE ROLE
 description: CREATE ROLE
 summary: Roles (users and groups)
 menu:

--- a/docs/content/latest/api/ysql/commands/dcl_drop_group.md
+++ b/docs/content/latest/api/ysql/commands/dcl_drop_group.md
@@ -1,7 +1,7 @@
 ---
 title: DROP GROUP
 linkTitle: DROP GROUP
-description: Groups and roles
+description: DROP GROUP
 summary: DROP GROUP
 menu:
   latest:
@@ -15,7 +15,7 @@ showAsideToc: true
 
 ## Synopsis
 
-`DROP GROUP` is an alias for [`DROP ROLE`](../dcl_drop_role) and is used to drop a role.
+Use the `DROP GROUP` to drop a role. `DROP GROUP` is an alias for [`DROP ROLE`](../dcl_drop_role) and is used to drop a role.
 
 ## Syntax
 

--- a/docs/content/latest/api/ysql/commands/dcl_drop_owned.md
+++ b/docs/content/latest/api/ysql/commands/dcl_drop_owned.md
@@ -1,5 +1,6 @@
 ---
 title: DROP OWNED
+linkTitle: DROP OWNED
 description: DROP OWNED
 summary: Roles (users and groups)
 menu:

--- a/docs/content/latest/api/ysql/commands/dcl_drop_policy.md
+++ b/docs/content/latest/api/ysql/commands/dcl_drop_policy.md
@@ -1,5 +1,6 @@
 ---
 title: DROP POLICY
+linkTitle: DROP POLICY
 description: DROP POLICY
 summary: Drop row level security policy
 menu:

--- a/docs/content/latest/api/ysql/commands/dcl_drop_role.md
+++ b/docs/content/latest/api/ysql/commands/dcl_drop_role.md
@@ -1,5 +1,6 @@
 ---
 title: DROP ROLE
+linkTitle: DROP ROLE
 description: DROP ROLE
 summary: Roles (users and groups)
 menu:
@@ -14,7 +15,7 @@ showAsideToc: true
 
 ## Synopsis
 
-`DROP ROLE` removes the specified role(s).
+Use the `DROP ROLE` statement to remove the specified roles.
 
 ## Syntax
 

--- a/docs/content/latest/api/ysql/commands/dcl_drop_user.md
+++ b/docs/content/latest/api/ysql/commands/dcl_drop_user.md
@@ -1,7 +1,7 @@
 ---
 title: DROP USER
 linkTitle: DROP USER
-description: Users and roles
+description: DROP USER
 summary: DROP USER
 menu:
   latest:
@@ -15,7 +15,7 @@ showAsideToc: true
 
 ## Synopsis
 
-`DROP USER` is an alias for [`DROP ROLE`](../dcl_drop_role) and is used to drop a role.
+Use the `DROP USER` statement to drop a user or role. `DROP USER` is an alias for [`DROP ROLE`](../dcl_drop_role) and is used to drop a role.
 
 ## Syntax
 

--- a/docs/content/latest/api/ysql/commands/dcl_grant.md
+++ b/docs/content/latest/api/ysql/commands/dcl_grant.md
@@ -15,7 +15,7 @@ showAsideToc: true
 
 ## Synopsis
 
-The `GRANT` statement is used to grant access privileges on database objects as well as to assign membership in roles.
+Use the `GRANT` statement to grant access privileges on database objects as well as to assign membership in roles.
 
 ## Syntax
 

--- a/docs/content/latest/api/ysql/commands/dcl_reassign_owned.md
+++ b/docs/content/latest/api/ysql/commands/dcl_reassign_owned.md
@@ -1,5 +1,6 @@
 ---
 title: REASSIGN OWNED
+linkTitle: REASSIGN OWNED
 description: REASSIGN OWNED
 summary: Roles (users and groups)
 menu:
@@ -14,7 +15,7 @@ showAsideToc: true
 
 ## Synopsis
 
-`REASSIGN OWNED` changes the ownership of database objects owned by any of the old_roles to new_role.
+Use the `REASSIGN OWNED` statement to change the ownership of database objects owned by any of the `old_roles` to `new_role`.
 
 ## Syntax
 
@@ -44,7 +45,7 @@ showAsideToc: true
 
 ## Semantics
 
-`REASSIGN OWNED` is typically used to prepare for the removal of a role. It requires membership on both the source role(s) and target role.
+`REASSIGN OWNED` is typically used to prepare for the removal of a role. It requires membership on both the source roles and target role.
 
 ## Examples
 

--- a/docs/content/latest/api/ysql/commands/dcl_revoke.md
+++ b/docs/content/latest/api/ysql/commands/dcl_revoke.md
@@ -15,7 +15,7 @@ showAsideToc: true
 
 ## Synopsis
 
-The `REVOKE` statement is used to remove access privileges from one or more roles.
+Use the `REVOKE` statement to remove access privileges from one or more roles.
 
 ## Syntax
 

--- a/docs/content/latest/api/ysql/commands/dcl_set_role.md
+++ b/docs/content/latest/api/ysql/commands/dcl_set_role.md
@@ -1,5 +1,6 @@
 ---
 title: SET ROLE
+linkTitle: SET ROLE
 description: SET ROLE
 summary: Roles (users and groups)
 menu:
@@ -14,7 +15,7 @@ showAsideToc: true
 
 ## Synopsis
 
-`SET ROLE` sets the current user of the current session to be the specified user.
+Use the `SET ROLE` statement to set the current user of the current session to be the specified user.
 
 ## Syntax
 

--- a/docs/content/latest/api/ysql/commands/dcl_set_session_authorization.md
+++ b/docs/content/latest/api/ysql/commands/dcl_set_session_authorization.md
@@ -1,5 +1,6 @@
 ---
 title: SET SESSION AUTHORIZATION
+linkTitle: SET SESSION AUTHORIZATION
 description: SET SESSION AUTHORIZATION
 summary: Roles (users and groups)
 menu:
@@ -14,7 +15,7 @@ showAsideToc: true
 
 ## Synopsis
 
-`SET SESSION AUTHORIZATION` sets the current user and session user of the current session to be the specified user.
+Use the `SET SESSION AUTHORIZATION` statement to set the current user and session user of the current session to be the specified user.
 
 ## Syntax
 

--- a/docs/content/latest/api/ysql/commands/ddl_create_schema.md
+++ b/docs/content/latest/api/ysql/commands/ddl_create_schema.md
@@ -15,7 +15,7 @@ showAsideToc: true
 
 ## Synopsis
 
-`CREATE SCHEMA` creates a new schema in the current database.
+Use the `CREATE SCHEMA` statement to create a new schema in the current database.
 A schema is essentially a namespace: it contains named objects (tables, data types, functions, and operators) whose names can duplicate those of other objects existing in other schemas.
 Named objects in a schema can be accessed by using the schema name as prefix or by setting the schema name in the search path.
 

--- a/docs/content/latest/api/ysql/commands/ddl_create_table.md
+++ b/docs/content/latest/api/ysql/commands/ddl_create_table.md
@@ -88,6 +88,7 @@ Using this qualifier will create a temporary table. Temporary tables are only vi
 The `SPLIT INTO` clause specifies the number of tablets that will be created for the table. This is useful for two data center (2DC) deployments. See example below: [Create CDC table specifying number of tablets](#create-cdc-table-specifying-number-of-tablets).
 
 ### Storage parameters
+
 Storage parameters [as defined by PostgreSQL](https://www.postgresql.org/docs/11/sql-createtable.html#SQL-CREATETABLE-STORAGE-PARAMETERS) are ignored and only present for compatibility with PostgreSQL.
 
 ## Examples

--- a/docs/content/latest/api/ysql/commands/perf_prepare.md
+++ b/docs/content/latest/api/ysql/commands/perf_prepare.md
@@ -15,7 +15,7 @@ showAsideToc: true
 
 ## Synopsis
 
-Use the `PREPARE` command creates a handle to a prepared statement by parsing, analyzing and rewriting (but not executing) the target statement.
+Use the `PREPARE` statement to create a handle to a prepared statement by parsing, analyzing and rewriting (but not executing) the target statement.
 
 ## Syntax
 


### PR DESCRIPTION
- Add mising `linkTitle`to statements
- Replace "Users and groups" in about five statements to show statement names.