### PR TITLE
[Docs] Fix mobile responsive styling not sizing correctly and change fonts

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -25,7 +25,7 @@ params:
     primary: orange
     accent: amber
   font:
-    text: Open Sans
+    text: Inter
     code: Inconsolata
   algolia:
     index: docs

--- a/docs/layouts/partials/head.html
+++ b/docs/layouts/partials/head.html
@@ -83,10 +83,10 @@
     <link rel="stylesheet" href="/css/temporary.css">
     <link rel="stylesheet" href="{{ with .Site.Params.highlight_css }}{{ . | absURL }}{{ else }}{{ "/css/highlight/highlight.css" }}{{ end }}">
 
-    {{ $text := or .Site.Params.font.text "Open Sans" }}
+    {{ $text := or .Site.Params.font.text "Inter" }}
     {{ $code := or .Site.Params.font.code "Roboto Mono" }}
-    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,300i,500,500i,600,600i,700,700i,800,800i" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,700,700i,900,900i" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Rubik:300,400,500,600,700,800&amp;display=swap" rel="stylesheet">
+    <link href="https://rsms.me/inter/inter.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Inconsolata" rel="stylesheet">
     <style>
       body, input {

--- a/docs/styles/_buttons.scss
+++ b/docs/styles/_buttons.scss
@@ -1,6 +1,6 @@
 .btn, button {
   position: relative;
-  font-family: "Open Sans", sans-serif;
+  font-family: "Inter", sans-serif;
   font-weight: 400;
   transition: all 0.2s;
   line-height: 40px;
@@ -86,8 +86,8 @@
     a.nav-link {
       position: relative;
       top: 1px;
-      font-family: Montserrat, sans-serif;
-      font-weight: 600;
+      font-family: 'Rubik', sans-serif;
+      font-weight: 500;
       font-size: 20px;
       font-weight: 500 !important;
       border-radius: 0 !important;
@@ -183,7 +183,7 @@ button.small {
   width: auto;
   font-size: 12px;
   line-height: 16px;
-  font-weight: 600;
+  font-weight: 500;
   text-align: center;
   cursor: pointer;
   padding: 3px 12px;

--- a/docs/styles/_feedback.scss
+++ b/docs/styles/_feedback.scss
@@ -14,8 +14,8 @@
     margin-top: 0;
     padding-top: 0 !important;
     font-size: 28px;
-    font-weight: 600;
-    font-family: Montserrat, "Open Sans", sans-serif !important;
+    font-weight: 500;
+    font-family: 'Rubik', sans-serif !important;
     color: #202951 !important;
     letter-spacing: -.02em;
     line-height: 36px;
@@ -162,7 +162,7 @@
   .title, .submit-thank-you {
     color: #fff;
     text-align: center;
-    font-family: Montserrat, "Open Sans", sans-serif !important;
+    font-family: 'Rubik', sans-serif !important;
     letter-spacing: -.02em;
     margin: 40px 0 35px;
     font-size: 28px;

--- a/docs/styles/_footer.scss
+++ b/docs/styles/_footer.scss
@@ -29,9 +29,9 @@
   position: relative;
 
   h3 {
-    font-family: Montserrat, sans-serif;
+    font-family: 'Rubik', sans-serif;
     font-size: 20px;
-    font-weight: 600;
+    font-weight: 500;
     letter-spacing: -.04em;
     text-transform: uppercase;
     color: $YB_DARK_MILD;
@@ -42,7 +42,7 @@
   }
 
   h4 {
-    font-weight: 600;
+    font-weight: 500;
     color: $YB_DARK_MILD;
     letter-spacing: -.02em;
     font-size: 15px;
@@ -269,7 +269,7 @@
   }
 
   h3 {
-    font-family: Montserrat, sans-serif;
+    font-family: 'Rubik', sans-serif;
   }
 
   .headerlink {

--- a/docs/styles/_indexpage.scss
+++ b/docs/styles/_indexpage.scss
@@ -49,9 +49,9 @@
     }
 
     h1 {
-      font-family: Montserrat, sans-serif;
+      font-family: 'Rubik', sans-serif;
       font-size: 48px;
-      font-weight: 600;
+      font-weight: 500;
       color: $YB_DARK_MILD;
       margin-bottom: 10px;
       
@@ -145,8 +145,8 @@
 
   .contents-title {
     margin: 10px 0 10px;
-    font-family: Montserrat, sans-serif;
-    font-weight: 600;
+    font-family: 'Rubik', sans-serif;
+    font-weight: 500;
     color: #C0C3D3;
     font-size: 16px;
     letter-spacing: -.02em;
@@ -251,8 +251,8 @@
 
           .title {
             margin-left: 78px;
-            font-family: Montserrat, "Open Sans", sans-serif;
-            font-weight: 600;
+            font-family: 'Rubik', sans-serif;
+            font-weight: 500;
             font-size: 24px;
             line-height: 1.5;
             letter-spacing: -.02em;
@@ -309,6 +309,11 @@
       }
     }
   }
+}
+
+dd {
+  margin-inline-start: 40px;
+  margin-bottom: .5em;
 }
 
 .video-wrapper {

--- a/docs/styles/_navbar.scss
+++ b/docs/styles/_navbar.scss
@@ -291,7 +291,7 @@ body {
         margin: 35px 16px 5px;
         font-size: 16px;
         font-weight: 500;
-        font-family: Montserrat, sans-serif;
+        font-family: 'Rubik', sans-serif;
         color: $YB_VIOLET;
 
         a {
@@ -313,7 +313,7 @@ body {
       display: inline-block;
       padding: 6px 8px 8px;
       margin-bottom: -4px;
-      font-family: "Open Sans", sans-serif;
+      font-family: "Inter", sans-serif;
       font-weight: 300;
       font-size: 15px;
       color: #e4e8ec !important;
@@ -345,7 +345,7 @@ body {
       display: inline-block;
       padding: 0 8px;
       line-height: 75px;
-      font-family: "Open Sans", sans-serif;
+      font-family: "Inter", sans-serif;
       font-weight: 400;
       font-size: 15px;
       margin-bottom: 0;

--- a/docs/styles/_search.scss
+++ b/docs/styles/_search.scss
@@ -27,7 +27,7 @@
   }
 
   .search-title a {
-    font-family: Montserrat, "Open Sans", sans-serif !important;
+    font-family: 'Rubik', sans-serif !important;
     font-size: 18px;
     color: $YB_DARK_BLUE !important;
   }
@@ -87,7 +87,7 @@
   }
 
   .algolia-autocomplete {
-    font-family: Montserrat, sans-serif !important;
+    font-family: 'Rubik', sans-serif !important;
   }
 
   .algolia-autocomplete .aa-hint {

--- a/docs/styles/_toc.scss
+++ b/docs/styles/_toc.scss
@@ -16,11 +16,11 @@ h1 {
 }
 #TableOfContents:before {
   content: 'On this page';
-  font-family: Montserrat, sans-serif;
+  font-family: 'Rubik', sans-serif;
   margin-bottom: 7px;
   display: block;
   font-size: 20px;
-  font-weight: 600;
+  font-weight: 500;
   color: $YB_DARK_BLUE;
 }
 #TableOfContents > ul {
@@ -70,7 +70,7 @@ pre code.copy + textarea + button.copy, .copy pre code + textarea + button.copy,
   width: auto;
   font-size: 12px;
   line-height: inherit;
-  font-weight: 600;
+  font-weight: 500;
   text-align: center;
   padding: 3px 8px;
   border-radius: 3px;

--- a/docs/styles/_yuga_content.scss
+++ b/docs/styles/_yuga_content.scss
@@ -26,7 +26,7 @@
 
     .admonition-title, .title  {
       font-size: 26px;
-      font-weight: 600;
+      font-weight: 500;
       letter-spacing: -0.02em;
       margin-bottom: 25px;
       margin-bottom: 30px;

--- a/docs/styles/_yuga_overrides.scss
+++ b/docs/styles/_yuga_overrides.scss
@@ -36,7 +36,7 @@ a {
   color: $YB_DARK;
 
   h1, h2, h3, h4 {
-    font-family: Montserrat, "Open Sans", sans-serif !important;
+    font-family: 'Rubik', sans-serif !important;
     color: $YB_DARK_BLUE !important;
     letter-spacing: -.02em;
     line-height: 36px;
@@ -47,7 +47,7 @@ a {
     padding-top: 0 !important;
     margin: 26px 0 0;
     font-size: 40px;
-    font-weight: 600;
+    font-weight: 500;
     letter-spacing: -.02em;
     margin-bottom: 20px;
     @media only screen and (max-width: 767px) {
@@ -56,10 +56,8 @@ a {
   }
   h2 {
     z-index: 1005;
-    margin-top: 48px;
-    padding-top: 0;
     font-size: 28px;
-    font-weight: 600;
+    font-weight: 500;
     letter-spacing: -.02em;
     margin-top: -52px;
     padding-top: 100px !important;
@@ -73,22 +71,22 @@ a {
     margin-top: 36px;
     padding-top: 0;
     font-size: 22px;
-    font-weight: 600;
+    font-weight: 500;
     margin-top: -52px;
     padding-top: 100px !important;
     @media only screen and (max-width: 767px) {
-      font-size: 28px;
+      font-size: 17px;
     }
   }
   h4 {
     z-index: 1003;
     margin-top: 24px;
     font-size: 18px;
-    font-weight: 600;
+    font-weight: 500;
     margin-top: -52px;
     padding-top: 100px !important;
     @media only screen and (max-width: 767px) {
-      font-size: 22px;
+      font-size: 16px;
     }
   }
   h5 {
@@ -96,13 +94,13 @@ a {
     margin-top: 24px;
     font-size: 16px;
     line-height: 20px;
-    font-weight: 600;
+    font-weight: 500;
     font-style: normal;
     margin-top: -32px;
     padding-top: 60px !important;
 
     @media only screen and (max-width: 767px) {
-      font-size: 18px;
+      font-size: 15px;
     }
   }
   h6 {
@@ -110,7 +108,7 @@ a {
     margin-top: 24px;
     font-size: 14px;
     line-height: 20px;
-    font-weight: 600;
+    font-weight: 500;
     font-style: normal;
     margin-top: -32px;
     padding-top: 60px !important;
@@ -160,8 +158,8 @@ a {
     color: #F0F9FF;
     background-color: #35A3FF;
     border-radius: 4px;
-    font-family: 'Open Sans', sans-serif;
-    font-weight: 600;
+    font-family: 'Inter', sans-serif;
+    font-weight: 500;
     text-transform: uppercase;
     font-size: 14px;
     line-height: 30px;
@@ -466,9 +464,9 @@ h1, h2, h3, h4, h5, h6 {
     }
   }
   > ul > li > a {
-    font-family: Montserrat, sans-serif;
+    font-family: 'Rubik', sans-serif;
     font-size: 16px;
-    font-weight: 600;
+    font-weight: 500;
   }
   .node-toggle {
     position: relative;
@@ -545,7 +543,7 @@ h1, h2, h3, h4, h5, h6 {
       > a.node-toggle {
         text-transform: uppercase;
         font-size: 15px;
-        font-weight: 600;
+        font-weight: 500;
         line-height: 36px !important;
         display: block;
         margin-left: -35px;
@@ -608,9 +606,9 @@ h1, h2, h3, h4, h5, h6 {
       }
 
       > ul > li > a {
-        font-family: Montserrat, sans-serif;
+        font-family: 'Rubik', sans-serif;
         font-size: 15px;
-        font-weight: 400;
+        font-weight: 300;
       }
     }
   }
@@ -663,6 +661,7 @@ h1, h2, h3, h4, h5, h6 {
   display: block;
   width: 100% !important;
   line-height: 1.5;
+  
   border-radius: 7px;
   padding: 12px 20px;
   margin: 0;
@@ -696,8 +695,8 @@ h1, h2, h3, h4, h5, h6 {
     margin: 0px 0px 10px 0px;
     color: $YB_DARK_BLUE;
     padding: 0;
-    font-family: Montserrat, sans-serif;
-    font-weight: 600;
+    font-family: 'Rubik', sans-serif;
+    font-weight: 500;
     display: block;
     font-size: 20px;
   
@@ -867,10 +866,10 @@ h1, h2, h3, h4, h5, h6 {
 
             .title {
               display: block;
-              font-family: Montserrat, sans-serif;
+              font-family: 'Rubik', sans-serif;
               font-size: 24px;
               line-height: 30px;
-              font-weight: 600;
+              font-weight: 500;
               max-width: 100%;
               letter-spacing: -.02em;
               color: #2D365D !important;
@@ -969,10 +968,10 @@ h1, h2, h3, h4, h5, h6 {
           }
 
           .title {
-            font-family: Montserrat, sans-serif;
+            font-family: 'Rubik', sans-serif;
             font-size: 18px;
             display: block;
-            font-weight: 600;
+            font-weight: 500;
             color: $YB_DARK;
             letter-spacing: -0.03em;
             line-height: 20px;
@@ -1265,7 +1264,7 @@ h1, h2, h3, h4, h5, h6 {
   }
 
   .caption {
-    font-family: "Open Sans", sans-serif;
+    font-family: "Inter", sans-serif;
     font-size: 14px;
     color: $YB_DARK_BLUE;
   }
@@ -1305,8 +1304,8 @@ table code {
 
 .toc-container {
   font-size: 16px;
-  font-weight: 600;
-  font-family: Montserrat, sans-serif;
+  font-weight: 500;
+  font-family: 'Rubik', sans-serif;
   padding: 0 25px 25px 25px;
 
   & > ul {
@@ -1322,7 +1321,7 @@ table code {
     margin-top: 0 !important;
     font-size: 13px;
     font-weight: 400;
-    font-family: "Open Sans", sans-serif;
+    font-family: "Inter", sans-serif;
 
     li {
       margin-top: 12px !important;


### PR DESCRIPTION
- Fix h3 font-size being larger than h2 in mobile view.
- Fix definition list tags not having inline indents.
- Change fonts from Montserrat to Rubik and Open Sans to Inter.