### PR TITLE
[#2160][Docs] Fix Algolia search to filter by version of page

### DIFF
--- a/docs/layouts/partials/footer_js.html
+++ b/docs/layouts/partials/footer_js.html
@@ -272,9 +272,23 @@
         let queryStr = document.URL.split('?')[1];
         let urlParams = new URLSearchParams(window.location.search)
         if (urlParams.has('q')) {
+          // Get previous page version
+          let prevUrl = document.referrer;
+          const versionRegex = /https:\/\/docs\.yugabyte\.com\/(.*?)\//i;
+          const m = versionRegex.exec(prevUrl);
+          // If no match or version not found or no previous page,
+          // use 'latest' to filter version
+          let searchVersion = 'latest';
+          if (m && m[1] && prevUrl) {
+            searchVersion = m[1];
+          }
+
           let client = algoliasearch('{{ .algolia.appid }}', '{{ .algolia.apikey }}');
           let index = client.initIndex('{{ .algolia.index }}');
-          index.search(urlParams.get('q'), function(err, content) {
+          index.search({
+            query: urlParams.get('q'),
+            filters: `version:${searchVersion}`,
+          }, function(err, content) {
             let formattedHits = docsearch.formatHits(content.hits);
             let previousResult = null;
             let collatedResults = [];


### PR DESCRIPTION
As Steve mentioned, a search on the docs sometimes returns results from previous version BEFORE results from the latest version. This will cause confusion and led to outdated information.
The search takes place on a separate page so first check the window.referrer to find out the page from which the search from initialized and get the proper version if it exists. Now if the version is not present in the url we can assume 'latest' version, or if the user somehow lands on the url of the search page itself, then we can also assume 'latest'. Luckily we already track the version of the page through our fork of docsearch-scrapper so we only need to add that filter to the search parameter object in the JS.
Note that this change will remove all results that don't match the version of the page the user was searching from.