### PR TITLE
Update docs on installing the compatible version of bison (3.4.1).

### DIFF
--- a/docs/content/latest/contribute/core-database/build-from-src/macos.md
+++ b/docs/content/latest/contribute/core-database/build-from-src/macos.md
@@ -11,11 +11,19 @@ First install [Homebrew](https://brew.sh/) in case you do not already have it. W
 Install the following packages using Homebrew:
 
 ```sh
-brew install autoconf automake bash bison ccache cmake  \
-             coreutils flex gnu-tar icu4c libtool maven \
-             ninja pkg-config pstree wget zlib python@2
+brew install autoconf automake bash ccache cmake  \
+             coreutils flex gnu-tar icu4c libtool \
+             maven ninja pkg-config pstree wget \
+             zlib python@2
+```
+
+We need an older version of bison to correctly compile our code. The following command installs the 3.4.1 version of bison.
+
+```sh
+brew install \
+https://raw.githubusercontent.com/Homebrew/homebrew-core/ee89a1d59df03f495a85c15e253b60299082ab9d/Formula/bison.rb
 ```
 
 {{< note title="Note on bash" >}}
-YugabyteDB build scripts rely on Bash 4. Make sure that which bash outputs `/usr/local/bin/bash` before proceeding. You may need to put `/usr/local/bin` as the first directory on PATH in your `~/.bashrc` to achieve that.
+YugabyteDB build scripts rely on Bash 4. Make sure that `which bash` outputs `/usr/local/bin/bash` before proceeding. You may need to put `/usr/local/bin` as the first directory on PATH in your `~/.bashrc` to achieve that.
 {{< /note >}}


### PR DESCRIPTION
Summary:
The latest version of bison on Homebrew is 3.5 and it prevents the code
from compiling as described in issue: https://github.com/yugabyte/yugabyte-db/issues/3218
This issue is resolved using the older version of bison.
Hencei, we need to update the docs describing how to do the same.

Reviewers: Karthik, MBautin