### PR TITLE
Docs fix first header margin 

### DIFF
--- a/docs/layouts/_default/single.html
+++ b/docs/layouts/_default/single.html
@@ -28,7 +28,7 @@
 						{{ partial "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) }}
 
 						<h1>{{ .Description }} {{ if .IsDraft }} (Draft){{ end }}{{ if .Page.Params.beta }}<a class="tag-beta" href="{{ .Page.Params.beta }}">Beta</a>{{ end }}</h1>
-						
+
 						{{ $urlArray := split (urls.Parse .Permalink).Path "/" }}
 						{{ $latestUrl := path.Join "latest" (after 2 $urlArray) }}
 						{{ $latestUrl = add (add "/" $latestUrl) "/" }}
@@ -38,7 +38,6 @@
 							This page documents an earlier version. <a href="{{ $latestUrl }}">Go to the latest (v2.0)version.</a>
 						</div>
 						{{ end }}
-						<br />
 
 						{{if (.Params.showAsideToc) }}						
 						<div id="toc-static">{{ .TableOfContents }}</div>

--- a/docs/styles/_toc.scss
+++ b/docs/styles/_toc.scss
@@ -132,6 +132,9 @@ pre code.copy + textarea, .copy pre textarea {
   padding: 0 0 1px 1px;
   border: none;
 }
+.content-flex-container > h1 + div + h2, .content-flex-container > h1 + h2{
+  margin-top: -92px !important;
+}
 .content-flex-wrapper {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
This tries to fix 
![image](https://user-images.githubusercontent.com/1592898/72086424-2e222a00-3307-11ea-963e-f755b8d4b398.png)
