### PR TITLE
[Docs] Change padding below the article h1 to be 0 and fix formatting for h4,h5

### DIFF
--- a/docs/layouts/_default/single.html
+++ b/docs/layouts/_default/single.html
@@ -28,7 +28,7 @@
 						{{ partial "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) }}
 
 						<h1>{{ .Description }} {{ if .IsDraft }} (Draft){{ end }}{{ if .Page.Params.beta }}<a class="tag-beta" href="{{ .Page.Params.beta }}">Beta</a>{{ end }}</h1>
-						
+
 						{{ $urlArray := split (urls.Parse .Permalink).Path "/" }}
 						{{ $latestUrl := path.Join "latest" (after 2 $urlArray) }}
 						{{ $latestUrl = add (add "/" $latestUrl) "/" }}
@@ -38,7 +38,6 @@
 							This page documents an earlier version. <a href="{{ $latestUrl }}">Go to the latest (v2.0)version.</a>
 						</div>
 						{{ end }}
-						<br />
 
 						{{if (.Params.showAsideToc) }}						
 						<div id="toc-static">{{ .TableOfContents }}</div>

--- a/docs/styles/_toc.scss
+++ b/docs/styles/_toc.scss
@@ -178,7 +178,7 @@ pre code.copy + textarea, .copy pre textarea {
         ul, & > ul > li {
           margin: 0;
           font-size: 13px;
-          line-height: 13px;
+          line-height: 1.2;
         }
 
         li {

--- a/docs/styles/_yuga_overrides.scss
+++ b/docs/styles/_yuga_overrides.scss
@@ -49,11 +49,11 @@ dd {
   h1 {
     z-index: 1006;
     padding-top: 0 !important;
+    padding-bottom: 0 !important;
     margin: 26px 0 0;
     font-size: 40px;
     font-weight: 500;
     letter-spacing: -.02em;
-    margin-bottom: 20px;
     @media only screen and (max-width: 767px) {
       font-size: 28px;
     }
@@ -98,7 +98,7 @@ dd {
     margin-top: 24px;
     font-size: 16px;
     line-height: 20px;
-    font-weight: 500;
+    font-weight: 700;
     font-style: normal;
     margin-top: -32px;
     padding-top: 60px !important;


### PR DESCRIPTION
Improving Dorian's PR: https://github.com/yugabyte/yugabyte-db/pull/3301

Also, added styling fixes for h4, h5 as per @stevebang suggestion.