### PR TITLE
Hide drift widget on docs

### DIFF
--- a/docs/styles/_yuga_overrides.scss
+++ b/docs/styles/_yuga_overrides.scss
@@ -923,6 +923,11 @@ h1, h2, h3, h4, h5, h6 {
     }
   }
 }
+
+#drift-widget {
+  display: none !important;
+}
+
 .footer-links {
   overflow: visible;
   width: 100%;


### PR DESCRIPTION
Drift widget is injected via iframe by bigpicture, we don't want to show the widget on our docs page.

`npm start` 
and validated the widget was not displayed.