### PR TITLE
[Docs] Fix head content spacing between description title

### DIFF
--- a/docs/styles/_indexpage.scss
+++ b/docs/styles/_indexpage.scss
@@ -118,6 +118,7 @@
         }
         .head-content {
           margin-left: 185px;
+          margin-top: 25px;
         }
 
         @media only screen and (max-width: 767px) {


### PR DESCRIPTION
See page: https://docs.yugabyte.com/latest/comparisons/

Notice that the head content is spaced too close to the title.

Fix:
<img width="1110" alt="Screen Shot 2020-01-14 at 2 28 20 PM" src="https://user-images.githubusercontent.com/50115930/72388303-698f7080-36da-11ea-90bf-6c9f585fc8bb.png">
