### PR TITLE
[docs] Change WAL-related FAQ and add related gflags

### DIFF
--- a/docs/content/latest/deploy/public-clouds/aws/manual-deployment.md
+++ b/docs/content/latest/deploy/public-clouds/aws/manual-deployment.md
@@ -78,7 +78,7 @@ export TAR_FILE=yugabyte-${YB_VERSION}-linux.tar.gz
 
 ### Prepare data drives
 
-If your AMI already has the needed hooks for mounting the devices as directories in some well defined location OR if are just trying to use a vanilla directory as the data drive for a quick experiment and do not need mounting the additional devices on your AWS volume, you can just use an arbitrary directory (like `/home/$USER/` as your data directory), and YugabyteDB will create a `yb-data` sub-directory there (`/home/$USER/yb-data`) and use that. The steps below are are simply a guide to help use the additional volumes (install a filesystem on those volumes and mount them in some well defined location so that they can be used as data directories by YugabyteDB).
+If your AMI already has the needed hooks for mounting the devices as directories in some well defined location OR if are just trying to use a vanilla directory as the data drive for a quick experiment and do not need mounting the additional devices on your AWS volume, you can just use an arbitrary directory (like `/home/$USER/` as your data directory), and YugabyteDB will create a `yb-data` subdirectory there (`/home/$USER/yb-data`) and use that. The steps below are are simply a guide to help use the additional volumes (install a filesystem on those volumes and mount them in some well defined location so that they can be used as data directories by YugabyteDB).
 
 #### Locate drives
 

--- a/docs/content/latest/faq/general.md
+++ b/docs/content/latest/faq/general.md
@@ -1,12 +1,12 @@
 ---
-title: Product FAQ
-linkTitle: Product FAQ
-description: Product FAQ
+title: General FAQ
+linkTitle: General FAQ
+description: General FAQ
 aliases:
   - /faq/product/
 menu:
   latest:
-    identifier: product
+    identifier: general-faq
     parent: faq
     weight: 2710
 isTocNested: false

--- a/docs/content/latest/faq/operations-faq.md
+++ b/docs/content/latest/faq/operations-faq.md
@@ -23,7 +23,7 @@ For YCQL, YugabyteDB provides automatic load balancing.
 
 ## Can write ahead log (WAL) files be cleaned up or reduced in size? I'm running out of disk space.
 
-For most YugabyteDB deployments, you should not need to adjust the log file configuration options for the write ahead log (WAL). While your data size is small and growing, the WAL files may seem to be much larger, but over time, the WAL files should reach their steady state while the data size continues to grow and become larger than the WAL files.
+For most YugabyteDB deployments, you should not need to adjust the configuration options for the write ahead log (WAL). While your data size is small and growing, the WAL files may seem to be much larger, but over time, the WAL files should reach their steady state while the data size continues to grow and become larger than the WAL files.
 
 WAL files are per tablet and the retention policy is managed by the following two `yb-tserver` configuration options:
 

--- a/docs/content/latest/faq/operations-faq.md
+++ b/docs/content/latest/faq/operations-faq.md
@@ -16,7 +16,7 @@ showAsideToc: true
 For YSQL, an external load balancer is recommended, but note the following:
 
 - If you use the [YugabyteDB JDBC driver (beta)](../../reference/drivers/yugabytedb-jdbc-driver) with an application regularly opens and closes connections to clients, then the YugabyteDB JDBC driver effectively provides basic load balancing by randomly using connections to your nodes.
-- If you use the[Spring Data Yugabyte driver (beta)](../../reference/drivers/spring-data-yugabytedb) with your Spring application, then the underlying YugabyteDB JDBC driver provides basic load balancing.
+- If you use the [Spring Data Yugabyte driver (beta)](../../reference/drivers/spring-data-yugabytedb) with your Spring application, then the underlying YugabyteDB JDBC driver provides basic load balancing.
 - If you have an application that is not in the same Kubernetes cluster, then you should use an external load balancing system.
 
 For YCQL, YugabyteDB provides automatic load balancing.

--- a/docs/content/latest/faq/operations-faq.md
+++ b/docs/content/latest/faq/operations-faq.md
@@ -23,13 +23,13 @@ For YCQL, YugabyteDB provides automatic load balancing.
 
 ## Can write ahead log (WAL) files be cleaned up or reduced in size? I'm running out of disk space.
 
-For most YugabyteDB deployments, you shouldn't need to adjust these values. While your data size is small and growing, the WAL files may seem to be much larger, but over time, the WAL files should reach their steady state while the data size continues to grow and become larger than the WAL files.
+For most YugabyteDB deployments, you should not need to adjust the log file configuration options for the write ahead log (WAL). While your data size is small and growing, the WAL files may seem to be much larger, but over time, the WAL files should reach their steady state while the data size continues to grow and become larger than the WAL files.
 
 WAL files are per tablet and the retention policy is managed by the following two `yb-tserver` configuration options:
 
-- [`log_min_segments_to_retain`](../../reference/configuration/tserver/#log-min-segments-to-retain)
-- [`log_min_seconds_to_retain`](../../reference/configuration/tserver/#log-min-seconds-to-retain)
+- [`log_min_segments_to_retain`](../../reference/configuration/yb-tserver/#log-min-segments-to-retain)
+- [`log_min_seconds_to_retain`](../../reference/configuration/yb-tserver/#log-min-seconds-to-retain)
 
-Also, the following `yb-tserver` configuration option is a factor in the size of each WAL before it is rolled into a new one:
+Also, the following `yb-tserver` configuration option is a factor in the size of each WAL file before it is rolled into a new one:
 
-- [`log_segment_size_mb`](../../reference/configuration/tserver/#log-segment-size-mb)
+- [`log_segment_size_mb`](../../reference/configuration/yb-tserver/#log-segment-size-mb)

--- a/docs/content/latest/faq/operations-faq.md
+++ b/docs/content/latest/faq/operations-faq.md
@@ -21,15 +21,15 @@ For YSQL, an external load balancer is recommended, but note the following:
 
 For YCQL, YugabyteDB provides automatic load balancing.
 
-## Can write ahead log (WAL) files for YCQL be cleaned up or reduced in size? I'm running out of disk space.
-
-WAL files are per tablet and the retention policy is managed by the following two gflags:
-
-- `src/yb/consensus/log.cc:DEFINE_int32(log_min_segments_to_retain, 2,`
-- `src/yb/consensus/log.cc:DEFINE_int32(log_min_seconds_to_retain, 900,`
-
-Also, the following gflag is a factor in the size of each WAL before it is rolled into a new one:
-
-- `src/yb/consensus/log_util.cc:DEFINE_int32(log_segment_size_mb, 64,`
+## Can write ahead log (WAL) files be cleaned up or reduced in size? I'm running out of disk space.
 
 For most YugabyteDB deployments, you shouldn't need to adjust these values. While your data size is small and growing, the WAL files may seem to be much larger, but over time, the WAL files should reach their steady state while the data size continues to grow and become larger than the WAL files.
+
+WAL files are per tablet and the retention policy is managed by the following two `yb-tserver` configuration options:
+
+- [`log_min_segments_to_retain`](../../reference/configuration/tserver/#log-min-segments-to-retain)
+- [`log_min_seconds_to_retain`](../../reference/configuration/tserver/#log-min-seconds-to-retain)
+
+Also, the following `yb-tserver` configuration option is a factor in the size of each WAL before it is rolled into a new one:
+
+- [`log_segment_size_mb`](../../reference/configuration/tserver/#log-segment-size-mb)

--- a/docs/content/latest/faq/operations-faq.md
+++ b/docs/content/latest/faq/operations-faq.md
@@ -27,9 +27,9 @@ For most YugabyteDB deployments, you should not need to adjust the configuration
 
 WAL files are per tablet and the retention policy is managed by the following two `yb-tserver` configuration options:
 
-- [`log_min_segments_to_retain`](../../reference/configuration/yb-tserver/#log-min-segments-to-retain) – default is `2`.
-- [`log_min_seconds_to_retain`](../../reference/configuration/yb-tserver/#log-min-seconds-to-retain) – default is `900`.
+- [`--log_min_segments_to_retain`](../../reference/configuration/yb-tserver/#log-min-segments-to-retain) – default is `2`.
+- [`--log_min_seconds_to_retain`](../../reference/configuration/yb-tserver/#log-min-seconds-to-retain) – default is `900`.
 
 Also, the following `yb-tserver` configuration option is a factor in the size of each WAL file before it is rolled into a new one:
 
-- [`log_segment_size_mb`](../../reference/configuration/yb-tserver/#log-segment-size-mb) – default is `64`.
+- [`--log_segment_size_mb`](../../reference/configuration/yb-tserver/#log-segment-size-mb) – default is `64`.

--- a/docs/content/latest/faq/operations-faq.md
+++ b/docs/content/latest/faq/operations-faq.md
@@ -16,7 +16,7 @@ showAsideToc: true
 For YSQL, an external load balancer is recommended, but note the following:
 
 - If you use the [YugabyteDB JDBC driver (beta)](../../reference/drivers/yugabytedb-jdbc-driver) with an application regularly opens and closes connections to clients, then the YugabyteDB JDBC driver effectively provides basic load balancing by randomly using connections to your nodes.
-- If you use the [Spring Data Yugabyte driver (beta)](../../reference/drivers/spring-data-yugabytedb) with your Spring application, then the underlying YugabyteDB JDBC driver provides basic load balancing.
+- If you use the[Spring Data Yugabyte driver (beta)](../../reference/drivers/spring-data-yugabytedb) with your Spring application, then the underlying YugabyteDB JDBC driver provides basic load balancing.
 - If you have an application that is not in the same Kubernetes cluster, then you should use an external load balancing system.
 
 For YCQL, YugabyteDB provides automatic load balancing.
@@ -27,9 +27,9 @@ For most YugabyteDB deployments, you should not need to adjust the configuration
 
 WAL files are per tablet and the retention policy is managed by the following two `yb-tserver` configuration options:
 
-- [`log_min_segments_to_retain`](../../reference/configuration/yb-tserver/#log-min-segments-to-retain)
-- [`log_min_seconds_to_retain`](../../reference/configuration/yb-tserver/#log-min-seconds-to-retain)
+- [`log_min_segments_to_retain`](../../reference/configuration/yb-tserver/#log-min-segments-to-retain) – default is `2`.
+- [`log_min_seconds_to_retain`](../../reference/configuration/yb-tserver/#log-min-seconds-to-retain) – default is `900`.
 
 Also, the following `yb-tserver` configuration option is a factor in the size of each WAL file before it is rolled into a new one:
 
-- [`log_segment_size_mb`](../../reference/configuration/yb-tserver/#log-segment-size-mb)
+- [`log_segment_size_mb`](../../reference/configuration/yb-tserver/#log-segment-size-mb) – default is `64`.

--- a/docs/content/latest/faq/operations-faq.md
+++ b/docs/content/latest/faq/operations-faq.md
@@ -21,14 +21,14 @@ For YSQL, an external load balancer is recommended, but note the following:
 
 For YCQL, YugabyteDB provides automatic load balancing.
 
-## Can write ahead log (WAL) files be cleaned up or reduced in size? I'm running out of disk space.
+## Can write ahead log (WAL) files be cleaned up or reduced in size?
 
 For most YugabyteDB deployments, you should not need to adjust the configuration options for the write ahead log (WAL). While your data size is small and growing, the WAL files may seem to be much larger, but over time, the WAL files should reach their steady state while the data size continues to grow and become larger than the WAL files.
 
 WAL files are per tablet and the retention policy is managed by the following two `yb-tserver` configuration options:
 
-- [`--log_min_segments_to_retain`](../../reference/configuration/yb-tserver/#log-min-segments-to-retain) – default is `2`.
-- [`--log_min_seconds_to_retain`](../../reference/configuration/yb-tserver/#log-min-seconds-to-retain) – default is `900`.
+- [`--log_min_segments_to_retain`](../../reference/configuration/yb-tserver/#log-min-segments-to-retain)
+- [`--log_min_seconds_to_retain`](../../reference/configuration/yb-tserver/#log-min-seconds-to-retain)
 
 Also, the following `yb-tserver` configuration option is a factor in the size of each WAL file before it is rolled into a new one:
 

--- a/docs/content/latest/reference/configuration/yb-master.md
+++ b/docs/content/latest/reference/configuration/yb-master.md
@@ -221,59 +221,71 @@ Default: `2`
 
 ### Raft options
 
+{{< note title="Note" >}}
+
+Ensure that values used for Raft and the write ahead log (WAL) in `yb-master` configurations match the values in `yb-tserver` configurations.
+
+{{< /note >}}
+
 ##### --follower_unavailable_considered_failed_sec
 
-The duration, in seconds, after which a follower is considered to be failed because the leader is unable to heartbeat to it. The follower is then evicted from the configuration and the data is re-replicated somewhere else.
+The duration, in seconds, after which a follower is considered to be failed because the leader has not received a heartbeat. The follower is then evicted from the configuration and the data is rereplicated elsewhere.
 
 Default: `900` (15 minutes)
 
 {{< note title="Important" >}}
 
-The value should match the value for [`--log_min_seconds_to_retain`](#log-min-seconds-to-retain).
+The `--follower_unavailable_considered_failed_sec` value should match the value for [`--log_min_seconds_to_retain`](#log-min-seconds-to-retain).
 
 {{< /note >}}
 
-### Write ahead log (WAL) options
+#### Write ahead log (WAL) options
+
+{{< note title="Note" >}}
+
+Ensure that values used for the write ahead log (WAL) in `yb-master` configurations match the values in `yb-tserver` configurations.
+
+{{< /note >}}
 
 ##### --fs_wal_dirs
 
-The directory where the `yb-master` will place its write-ahead log files. May be the same as one of the directories listed in `--fs_data_dirs`, but not a sub-directory of a data directory.
+The directory where the `yb-tserver` retains WAL files. May be the same as one of the directories listed in [`--fs_data_dirs`](#fs-data-dirs), but not a subdirectory of a data directory.
 
 Default: Same as `--fs_data_dirs`
 
 ##### --durable_wal_write
 
-If set to `false`, the writes to the Raft log are synced to disk every `interval_durable_wal_write_ms` milliseconds or every `bytes_durable_wal_write_mb` MB, whichever comes first. This default setting is recommended only for multi-AZ or multi-region deployments where the availability zones (AZs) or regions are independent failure domains and there isn't a risk of correlated power loss. For single AZ deployments, this flag should be set to `true`.
+If set to `false`, the writes to the WAL are synced to disk every [`interval_durable_wal_write_ms`](#interval-durable-wal-write-mas) milliseconds (ms) or every [`bytes_durable_wal_write_mb`](#bytes-durable-wal-write-mb) megabyte (MB), whichever comes first. This default setting is recommended only for multi-AZ or multi-region deployments where the availability zones (AZs) or regions are independent failure domains and there is not a risk of correlated power loss. For single AZ deployments, this option should be set to `true`.
 
 Default: `false`
 
 ##### --interval_durable_wal_write_ms
 
-When [`--durable_wal_write`](#durable-wal-write) is false, writes to the Raft log are synced to disk every `--interval_durable_wal_write_ms` or [`--bytes_durable_wal_write_mb`](#bytes-durable-wal-write-mb), whichever comes first.
+When [`--durable_wal_write`](#durable-wal-write) is false, writes to the WAL are synced to disk every `--interval_durable_wal_write_ms` or [`--bytes_durable_wal_write_mb`](#bytes-durable-wal-write-mb), whichever comes first.
 
 Default: `1000`
 
 ##### --bytes_durable_wal_write_mb
 
-When `--durable_wal_write` is `false`, writes to the Raft log are synced to disk every `--bytes_durable_wal_write_mb` or `--interval_durable_wal_write_ms`, whichever comes first.
+When [`--durable_wal_write`](#durable-wal-write) is `false`, writes to the WAL are synced to disk every `--bytes_durable_wal_write_mb` or `--interval_durable_wal_write_ms`, whichever comes first.
 
 Default: `1`
 
 ##### --log_min_seconds_to_retain
 
-The minimum number of seconds for which to keep log segments to keep at all times, regardless of what is required for durability. Logs may be retained for a longer amount of time if they are necessary for correct restart. This should be set long enough such that a tablet server which has temporarily failed can be restarted within the given time period. 
+The minimum duration, in seconds, to retain WAL segments, regardless of durability requirements. WAL segments can be retained for a longer amount of time, if they are necessary for correct restart. This value should be set long enough such that a tablet server which has temporarily failed can be restarted within the given time period.
 
 Default: `900` (15 minutes)
 
 ##### --log_min_segments_to_retain
 
-The minimum number of past log segments to keep at all times, regardless of what is required for durability. The value must be at least `1`.
+The minimum number of WAL segments (files) to retain, regardless of durability requirements. The value must be at least `1`.
 
 Default: `2`
 
 ##### --log_segment_size_mb
 
-The default segment size, in megabytes (MB), for log rollovers.
+The size, in megabytes (MB), of a WAL segment (file). When the WAL segment reaches the specified size, then a log rollover occurs and a new WAL segment file is created.
 
 Default: `64`
 

--- a/docs/content/latest/reference/configuration/yb-master.md
+++ b/docs/content/latest/reference/configuration/yb-master.md
@@ -44,6 +44,8 @@ $ ./bin/yb-master --help
 - [General](#general-options)
 - [YSQL](#ysql-options)
 - [Logging](#logging-options)
+- [Raft](#raft-options)
+  - [Write ahead log (WAL)](write-ahead-log-wal-options)
 - [Cluster](#cluster-options)
 - [Geo-distribution](#geo-distribution-options)
 - [Security](#security-options)
@@ -92,12 +94,6 @@ Default: Same value as `--fs_data_dirs`
 Specifies a comma-separated list of addresses to bind to for RPC connections.
 
 Required.
-
-{{< note title="Note" >}}
-
-
-
-{{< /note >}}
 
 Default: `0.0.0.0:7100`
 
@@ -220,6 +216,66 @@ Default: `0` (INFO)
 Log messages at, or above, this level are copied to `stderr` in addition to log files.
 
 Default: `2`
+
+---
+
+### Raft options
+
+##### --follower_unavailable_considered_failed_sec
+
+The duration, in seconds, after which a follower is considered to be failed because the leader is unable to heartbeat to it. The follower is then evicted from the configuration and the data is re-replicated somewhere else.
+
+Default: `900` (15 minutes)
+
+{{< note title="Important" >}}
+
+The value should match the value for [`--log_min_seconds_to_retain`](#log-min-seconds-to-retain).
+
+{{< /note >}}
+
+### Write ahead log (WAL) options
+
+##### --fs_wal_dirs
+
+The directory where the `yb-master` will place its write-ahead log files. May be the same as one of the directories listed in `--fs_data_dirs`, but not a sub-directory of a data directory.
+
+Default: Same as `--fs_data_dirs`
+
+##### --durable_wal_write
+
+If set to `false`, the writes to the Raft log are synced to disk every `interval_durable_wal_write_ms` milliseconds or every `bytes_durable_wal_write_mb` MB, whichever comes first. This default setting is recommended only for multi-AZ or multi-region deployments where the availability zones (AZs) or regions are independent failure domains and there isn't a risk of correlated power loss. For single AZ deployments, this flag should be set to `true`.
+
+Default: `false`
+
+##### --interval_durable_wal_write_ms
+
+When [`--durable_wal_write`](#durable-wal-write) is false, writes to the Raft log are synced to disk every `--interval_durable_wal_write_ms` or [`--bytes_durable_wal_write_mb`](#bytes-durable-wal-write-mb), whichever comes first.
+
+Default: `1000`
+
+##### --bytes_durable_wal_write_mb
+
+When `--durable_wal_write` is `false`, writes to the Raft log are synced to disk every `--bytes_durable_wal_write_mb` or `--interval_durable_wal_write_ms`, whichever comes first.
+
+Default: `1`
+
+##### --log_min_seconds_to_retain
+
+The minimum number of seconds for which to keep log segments to keep at all times, regardless of what is required for durability. Logs may be retained for a longer amount of time if they are necessary for correct restart. This should be set long enough such that a tablet server which has temporarily failed can be restarted within the given time period. 
+
+Default: `900` (15 minutes)
+
+##### --log_min_segments_to_retain
+
+The minimum number of past log segments to keep at all times, regardless of what is required for durability. The value must be at least `1`.
+
+Default: `2`
+
+##### --log_segment_size_mb
+
+The default segment size, in megabytes (MB), for log rollovers.
+
+Default: `64`
 
 ---
 

--- a/docs/content/latest/reference/configuration/yb-tserver.md
+++ b/docs/content/latest/reference/configuration/yb-tserver.md
@@ -155,24 +155,6 @@ The directory to write `yb-tserver` log files.
 
 Default: Same as [`--fs_data_dirs`](#fs-data-dirs)
 
-##### --log_min_seconds_to_retain
-
-The minimum number of seconds for which to keep log segments to keep at all times, regardless of what is required for durability. Logs may be retained for a longer amount of time if they are necessary for correct restart. This should be set long enough such that a tablet server which has temporarily failed can be restarted within the given time period. If a server is down for longer than this amount of time, it is possible that its tablets will be re-replicated on other machines.
-
-Default: `900`
-
-##### --log_min_segments_to_retain
-
-The minimum number of past log segments to keep at all times, regardless of what is required for durability. The value must be at least 1.
-
-Default: `2`
-
-##### --log_segment_size_mb
-
-The default segment size, in megabytes (MB) for log rollovers.
-
-Default: `64`
-
 ##### --logemaillevel
 
 Email log messages logged at this level, or higher. Values: `0` (all), 1, 2, `3` (FATAL), `999` (none)
@@ -452,6 +434,24 @@ Default: `1000`
 When `--durable_wal_write` is `false`, writes to the Raft log are synced to disk every `--bytes_durable_wal_write_mb` or `--interval_durable_wal_write_ms`, whichever comes first.
 
 Default: `1`
+
+##### --log_min_seconds_to_retain
+
+The minimum number of seconds for which to keep log segments to keep at all times, regardless of what is required for durability. Logs may be retained for a longer amount of time if they are necessary for correct restart. This should be set long enough such that a tablet server which has temporarily failed can be restarted within the given time period. If a server is down for longer than this amount of time, it is possible that its tablets will be re-replicated on other machines.
+
+Default: `900`
+
+##### --log_min_segments_to_retain
+
+The minimum number of past log segments to keep at all times, regardless of what is required for durability. The value must be at least `1`.
+
+Default: `2`
+
+##### --log_segment_size_mb
+
+The default segment size, in megabytes (MB) for log rollovers.
+
+Default: `64`
 
 ---
 

--- a/docs/content/latest/reference/configuration/yb-tserver.md
+++ b/docs/content/latest/reference/configuration/yb-tserver.md
@@ -409,47 +409,73 @@ Default: Server automatically picks a valid default internally, typically `8`.
 
 ---
 
-### Write Ahead Log (WAL) options
+### Raft options
+
+{{< note title="Note" >}}
+
+Ensure that values used for Raft and the write ahead log (WAL) in `yb-tserver` configurations match the values in `yb-master` configurations.
+
+{{< /note >}}
+
+##### --follower_unavailable_considered_failed_sec
+
+The duration, in seconds, after which a follower is considered to be failed because the leader has not received a heartbeat. The follower is then evicted from the configuration and the data is rereplicated elsewhere.
+
+Default: `900` (15 minutes)
+
+{{< note title="Important" >}}
+
+The `--follower_unavailable_considered_failed_sec` value should match the value for [`--log_min_seconds_to_retain`](#log-min-seconds-to-retain).
+
+{{< /note >}}
+
+#### Write ahead log (WAL) options
+
+{{< note title="Note" >}}
+
+Ensure that values used for the write ahead log (WAL) in `yb-tserver` configurations match the values for `yb-master` configurations.
+
+{{< /note >}}
 
 ##### --fs_wal_dirs
 
-The directory where the `yb-tserver` will place its write-ahead logs. May be the same as one of the directories listed in `--fs_data_dirs`, but not a sub-directory of a data directory.
+The directory where the `yb-tserver` retains WAL files. May be the same as one of the directories listed in [`--fs_data_dirs`](#fs-data-dirs), but not a subdirectory of a data directory.
 
 Default: Same as `--fs_data_dirs`
 
 ##### --durable_wal_write
 
-If set to `false`, the writes to the Raft log are synced to disk every `interval_durable_wal_write_ms` milliseconds or every `bytes_durable_wal_write_mb` MB, whichever comes first. This default setting is recommended only for multi-AZ or multi-region deployments where the zones/regions are independent failure domains and there isn't a risk of correlated power loss. For single AZ deployments, this flag should be set to `true`.
+If set to `false`, the writes to the WAL are synced to disk every [`interval_durable_wal_write_ms`](#interval-durable-wal-write-mas) milliseconds (ms) or every [`bytes_durable_wal_write_mb`](#bytes-durable-wal-write-mb) megabyte (MB), whichever comes first. This default setting is recommended only for multi-AZ or multi-region deployments where the availability zones (AZs) or regions are independent failure domains and there is not a risk of correlated power loss. For single AZ deployments, this option should be set to `true`.
 
 Default: `false`
 
 ##### --interval_durable_wal_write_ms
 
-When [`--durable_wal_write`](#durable-wal-write) is false, writes to the Raft log are synced to disk every `--interval_durable_wal_write_ms` or [`--bytes_durable_wal_write_mb`](#bytes-durable-wal-write-mb), whichever comes first.
+When [`--durable_wal_write`](#durable-wal-write) is false, writes to the WAL are synced to disk every `--interval_durable_wal_write_ms` or [`--bytes_durable_wal_write_mb`](#bytes-durable-wal-write-mb), whichever comes first.
 
 Default: `1000`
 
 ##### --bytes_durable_wal_write_mb
 
-When `--durable_wal_write` is `false`, writes to the Raft log are synced to disk every `--bytes_durable_wal_write_mb` or `--interval_durable_wal_write_ms`, whichever comes first.
+When [`--durable_wal_write`](#durable-wal-write) is `false`, writes to the WAL are synced to disk every `--bytes_durable_wal_write_mb` or `--interval_durable_wal_write_ms`, whichever comes first.
 
 Default: `1`
 
 ##### --log_min_seconds_to_retain
 
-The minimum number of seconds for which to keep log segments to keep at all times, regardless of what is required for durability. Logs may be retained for a longer amount of time if they are necessary for correct restart. This should be set long enough such that a tablet server which has temporarily failed can be restarted within the given time period. If a server is down for longer than this amount of time, it is possible that its tablets will be re-replicated on other machines.
+The minimum duration, in seconds, to retain WAL segments, regardless of durability requirements. WAL segments can be retained for a longer amount of time, if they are necessary for correct restart. This value should be set long enough such that a tablet server which has temporarily failed can be restarted within the given time period.
 
-Default: `900`
+Default: `900` (15 minutes)
 
 ##### --log_min_segments_to_retain
 
-The minimum number of past log segments to keep at all times, regardless of what is required for durability. The value must be at least `1`.
+The minimum number of WAL segments (files) to retain, regardless of durability requirements. The value must be at least `1`.
 
 Default: `2`
 
 ##### --log_segment_size_mb
 
-The default segment size, in megabytes (MB) for log rollovers.
+The size, in megabytes (MB), of a WAL segment (file). When the WAL segment reaches the specified size, then a log rollover occurs and a new WAL segment file is created.
 
 Default: `64`
 

--- a/docs/content/latest/reference/configuration/yb-tserver.md
+++ b/docs/content/latest/reference/configuration/yb-tserver.md
@@ -44,12 +44,13 @@ $ ./bin/yb-tserver --help
 - [Help](#help-options)
 - [General](#general-options)
 - [Logging](#logging-options)
+- [Raft](#raft-options)
+  - [Write Ahead Log (WAL)](#write-ahead-log-wal-options)
 - [Geo-distribution](#geo-distribution-options)
 - [YSQL](#ysql-options)
 - [YCQL](#ycql-options)
 - [YEDIS](#yedis-options)
 - [Performance](#performance-options)
-- [Write Ahead Log (WAL)](#write-ahead-log-wal-options)
 - [Security](#security-options)
 - [Change data capture (CDC)](#change-data-capture-cdc-options)
 
@@ -196,6 +197,78 @@ Default: `2`
 Stop attempting to log to disk if the disk is full.
 
 Default: `false`
+
+---
+
+### Raft options
+
+{{< note title="Note" >}}
+
+Ensure that values used for Raft and the write ahead log (WAL) in `yb-tserver` configurations match the values in `yb-master` configurations.
+
+{{< /note >}}
+
+##### --follower_unavailable_considered_failed_sec
+
+The duration, in seconds, after which a follower is considered to be failed because the leader has not received a heartbeat. The follower is then evicted from the configuration and the data is rereplicated elsewhere.
+
+Default: `900` (15 minutes)
+
+{{< note title="Important" >}}
+
+The `--follower_unavailable_considered_failed_sec` value should match the value for [`--log_min_seconds_to_retain`](#log-min-seconds-to-retain).
+
+{{< /note >}}
+
+#### Write ahead log (WAL) options
+
+{{< note title="Note" >}}
+
+Ensure that values used for the write ahead log (WAL) in `yb-tserver` configurations match the values for `yb-master` configurations.
+
+{{< /note >}}
+
+##### --fs_wal_dirs
+
+The directory where the `yb-tserver` retains WAL files. May be the same as one of the directories listed in [`--fs_data_dirs`](#fs-data-dirs), but not a subdirectory of a data directory.
+
+Default: Same as `--fs_data_dirs`
+
+##### --durable_wal_write
+
+If set to `false`, the writes to the WAL are synced to disk every [`interval_durable_wal_write_ms`](#interval-durable-wal-write-mas) milliseconds (ms) or every [`bytes_durable_wal_write_mb`](#bytes-durable-wal-write-mb) megabyte (MB), whichever comes first. This default setting is recommended only for multi-AZ or multi-region deployments where the availability zones (AZs) or regions are independent failure domains and there is not a risk of correlated power loss. For single AZ deployments, this option should be set to `true`.
+
+Default: `false`
+
+##### --interval_durable_wal_write_ms
+
+When [`--durable_wal_write`](#durable-wal-write) is false, writes to the WAL are synced to disk every `--interval_durable_wal_write_ms` or [`--bytes_durable_wal_write_mb`](#bytes-durable-wal-write-mb), whichever comes first.
+
+Default: `1000`
+
+##### --bytes_durable_wal_write_mb
+
+When [`--durable_wal_write`](#durable-wal-write) is `false`, writes to the WAL are synced to disk every `--bytes_durable_wal_write_mb` or `--interval_durable_wal_write_ms`, whichever comes first.
+
+Default: `1`
+
+##### --log_min_seconds_to_retain
+
+The minimum duration, in seconds, to retain WAL segments, regardless of durability requirements. WAL segments can be retained for a longer amount of time, if they are necessary for correct restart. This value should be set long enough such that a tablet server which has temporarily failed can be restarted within the given time period.
+
+Default: `900` (15 minutes)
+
+##### --log_min_segments_to_retain
+
+The minimum number of WAL segments (files) to retain, regardless of durability requirements. The value must be at least `1`.
+
+Default: `2`
+
+##### --log_segment_size_mb
+
+The size, in megabytes (MB), of a WAL segment (file). When the WAL segment reaches the specified size, then a log rollover occurs and a new WAL segment file is created.
+
+Default: `64`
 
 ---
 
@@ -406,78 +479,6 @@ Default: `256MB`
 The number of shards per YB-TServer per table when a user table is created.
 
 Default: Server automatically picks a valid default internally, typically `8`.
-
----
-
-### Raft options
-
-{{< note title="Note" >}}
-
-Ensure that values used for Raft and the write ahead log (WAL) in `yb-tserver` configurations match the values in `yb-master` configurations.
-
-{{< /note >}}
-
-##### --follower_unavailable_considered_failed_sec
-
-The duration, in seconds, after which a follower is considered to be failed because the leader has not received a heartbeat. The follower is then evicted from the configuration and the data is rereplicated elsewhere.
-
-Default: `900` (15 minutes)
-
-{{< note title="Important" >}}
-
-The `--follower_unavailable_considered_failed_sec` value should match the value for [`--log_min_seconds_to_retain`](#log-min-seconds-to-retain).
-
-{{< /note >}}
-
-#### Write ahead log (WAL) options
-
-{{< note title="Note" >}}
-
-Ensure that values used for the write ahead log (WAL) in `yb-tserver` configurations match the values for `yb-master` configurations.
-
-{{< /note >}}
-
-##### --fs_wal_dirs
-
-The directory where the `yb-tserver` retains WAL files. May be the same as one of the directories listed in [`--fs_data_dirs`](#fs-data-dirs), but not a subdirectory of a data directory.
-
-Default: Same as `--fs_data_dirs`
-
-##### --durable_wal_write
-
-If set to `false`, the writes to the WAL are synced to disk every [`interval_durable_wal_write_ms`](#interval-durable-wal-write-mas) milliseconds (ms) or every [`bytes_durable_wal_write_mb`](#bytes-durable-wal-write-mb) megabyte (MB), whichever comes first. This default setting is recommended only for multi-AZ or multi-region deployments where the availability zones (AZs) or regions are independent failure domains and there is not a risk of correlated power loss. For single AZ deployments, this option should be set to `true`.
-
-Default: `false`
-
-##### --interval_durable_wal_write_ms
-
-When [`--durable_wal_write`](#durable-wal-write) is false, writes to the WAL are synced to disk every `--interval_durable_wal_write_ms` or [`--bytes_durable_wal_write_mb`](#bytes-durable-wal-write-mb), whichever comes first.
-
-Default: `1000`
-
-##### --bytes_durable_wal_write_mb
-
-When [`--durable_wal_write`](#durable-wal-write) is `false`, writes to the WAL are synced to disk every `--bytes_durable_wal_write_mb` or `--interval_durable_wal_write_ms`, whichever comes first.
-
-Default: `1`
-
-##### --log_min_seconds_to_retain
-
-The minimum duration, in seconds, to retain WAL segments, regardless of durability requirements. WAL segments can be retained for a longer amount of time, if they are necessary for correct restart. This value should be set long enough such that a tablet server which has temporarily failed can be restarted within the given time period.
-
-Default: `900` (15 minutes)
-
-##### --log_min_segments_to_retain
-
-The minimum number of WAL segments (files) to retain, regardless of durability requirements. The value must be at least `1`.
-
-Default: `2`
-
-##### --log_segment_size_mb
-
-The size, in megabytes (MB), of a WAL segment (file). When the WAL segment reaches the specified size, then a log rollover occurs and a new WAL segment file is created.
-
-Default: `64`
 
 ---
 

--- a/docs/content/latest/reference/configuration/yb-tserver.md
+++ b/docs/content/latest/reference/configuration/yb-tserver.md
@@ -155,6 +155,24 @@ The directory to write `yb-tserver` log files.
 
 Default: Same as [`--fs_data_dirs`](#fs-data-dirs)
 
+##### --log_min_seconds_to_retain
+
+The minimum number of seconds for which to keep log segments to keep at all times, regardless of what is required for durability. Logs may be retained for a longer amount of time if they are necessary for correct restart. This should be set long enough such that a tablet server which has temporarily failed can be restarted within the given time period. If a server is down for longer than this amount of time, it is possible that its tablets will be re-replicated on other machines.
+
+Default: `900`
+
+##### --log_min_segments_to_retain
+
+The minimum number of past log segments to keep at all times, regardless of what is required for durability. The value must be at least 1.
+
+Default: `2`
+
+##### --log_segment_size_mb
+
+The default segment size, in megabytes (MB) for log rollovers.
+
+Default: `64`
+
 ##### --logemaillevel
 
 Email log messages logged at this level, or higher. Values: `0` (all), 1, 2, `3` (FATAL), `999` (none)


### PR DESCRIPTION
- Change Karthik's code examples to use `yb-tserver` configuration options.
- Add the following three logging-related options (gflags) mentioned in the FAQ to the `yb-tserver` configuration page:

- `--log_min_segments_to_retain`
- `--log_min_seconds_to_retain`
- `--log_segment_size_mb`