### PR TITLE
#3229: Adding batching support for insertions into the table in ysql_bench.

### DIFF
--- a/src/postgres/src/bin/pgbench/pgbench.c
+++ b/src/postgres/src/bin/pgbench/pgbench.c
@@ -4376,12 +4376,6 @@ initGenerateData(PGconn *con)
 	ereport(ELEVEL_LOG_MAIN, (errmsg("generating data...\n")));
 
 	/*
-	 * we do all of this in one transaction to enable the backend's
-	 * data-loading optimizations
-	 */
-	executeStatement(con, "begin");
-
-	/*
 	 * truncate away any old data, in one command in case there are foreign
 	 * keys
 	 */
@@ -4413,9 +4407,12 @@ initGenerateData(PGconn *con)
 		executeStatement(con, sql);
 	}
 
-	/* We begin a new transaction for the insertion into ysql_bench_accounts. */
-	executeStatement(con, "commit");
+	/*
+	 * we do all of this in one transaction to enable the backend's
+	 * data-loading optimizations
+	 */
 	executeStatement(con, "begin");
+
 	/*
 	 * accounts is big enough to be worth using COPY and tracking runtime
 	 */


### PR DESCRIPTION
Summary:
Currently with large scale factors we are facing troubles inserting data
into the table. This is because all of the inserts happen in one large
transaction.

This change involves persisting the rows in much smaller transactions
with the size of the batch being configured using 'batch-size' argument.

The issue is described in: https://github.com/yugabyte/yugabyte-db/issues/3229

Reviewers: Kannan, Mihnea, Neha

Performance Comparisons with and without the batching:
We see that the performance difference is 1.4X between the two approaches.
Performance with a batch size of 1024:
```
ysql_bench_batch_sizing:postgres $ time bin/ysql_bench -h 127.0.0.1 -p 5433 -i -s 20 --batch-size 1024 yugabyte
dropping old tables...
NOTICE: table "ysql_bench_accounts" does not exist, skipping
NOTICE: table "ysql_bench_branches" does not exist, skipping
NOTICE: table "ysql_bench_history" does not exist, skipping
NOTICE: table "ysql_bench_tellers" does not exist, skipping
creating tables (with primary keys)...
generating data...
100000 of 2000000 tuples (5%) done (elapsed 5.76 s, remaining 109.45 s)
200000 of 2000000 tuples (10%) done (elapsed 12.46 s, remaining 112.16 s)
...
1800000 of 2000000 tuples (90%) done (elapsed 151.12 s, remaining 16.79 s)
1900000 of 2000000 tuples (95%) done (elapsed 161.92 s, remaining 8.52 s)
2000000 of 2000000 tuples (100%) done (elapsed 173.04 s, remaining 0.00 s)
done.

real 3m0.322s
user 0m1.435s
sys 0m0.290s
```

Performance with a batch size of 2048:
```
ysql_bench_batch_sizing:postgres $ time bin/ysql_bench -h 127.0.0.1 -p 5433 -i --batch-size 2048 -s 20 yugabyte
dropping old tables...
NOTICE:  table "ysql_bench_accounts" does not exist, skipping
NOTICE:  table "ysql_bench_branches" does not exist, skipping
NOTICE:  table "ysql_bench_tellers" does not exist, skipping
creating tables (with primary keys)...
generating data...
100000 of 2000000 tuples (5%) done (elapsed 4.69 s, remaining 89.11 s)
200000 of 2000000 tuples (10%) done (elapsed 9.56 s, remaining 86.04 s)
300000 of 2000000 tuples (15%) done (elapsed 14.44 s, remaining 81.81 s)
...
1900000 of 2000000 tuples (95%) done (elapsed 157.81 s, remaining 8.31 s)
2000000 of 2000000 tuples (100%) done (elapsed 168.87 s, remaining 0.00 s)
done.
real	2m58.371s
user	0m1.410s
sys	0m0.174s
```
and,
```
ysql_bench_batch_sizing:postgres $ time bin/ysql_bench -h 127.0.0.1 -p 5433 -i --batch-size 4000000 -s 20 yugabyte
dropping old tables...
creating tables (with primary keys)...
generating data...
100000 of 2000000 tuples (5%) done (elapsed 1.00 s, remaining 18.92 s)
200000 of 2000000 tuples (10%) done (elapsed 2.45 s, remaining 22.01 s)
...
1900000 of 2000000 tuples (95%) done (elapsed 25.92 s, remaining 1.36 s)
2000000 of 2000000 tuples (100%) done (elapsed 27.20 s, remaining 0.00 s)
done.

real	4m9.511s
user	0m0.768s
sys	0m0.050s

```