### PR TITLE
[docs] Reorganize Raft settings and search/replace terms

### DIFF
--- a/docs/content/latest/architecture/concepts/universe.md
+++ b/docs/content/latest/architecture/concepts/universe.md
@@ -84,4 +84,4 @@ Note that:
 - There is always one primary cluster in a universe.
 - There can be zero or more read replica clusters in that universe.
 
-For more information about read replica clusters, see [Read-only replicas](../../docdb/replication/#read-only-replicas).
+For more information about read replica clusters, see [read replicas](../../docdb/replication/#read-only-replicas).

--- a/docs/content/latest/architecture/docdb/replication.md
+++ b/docs/content/latest/architecture/docdb/replication.md
@@ -59,10 +59,10 @@ guarantees which is desired in some deployment models. All other tablet-peers ar
 and merely replicate data, and are available as hot standbys that can take over quickly in case the
 leader fails.
 
-## Read-only replicas
+## read replicas
 
 In addition to the core distributed consensus based replication, DocDB extends Raft to add
-read-only replicas (aks observer nodes) that do not participate in writes but get a timeline consistent
+read replicas (aks observer nodes) that do not participate in writes but get a timeline consistent
 copy of the data in an asynchronous manner. Nodes in remote data centers can thus be added in "read-only"
 mode. This is primarily for cases where latency of doing a distributed consensus-based write is not
 tolerable for some workloads. This read-only node (or timeline-consistent node) is still strictly better than

--- a/docs/content/latest/comparisons/amazon-aurora.md
+++ b/docs/content/latest/comparisons/amazon-aurora.md
@@ -16,7 +16,7 @@ Generally available since 2015, Amazon Aurora is built on a proprietary distribu
 
 ## Horizontal write scalability
 
-By default, Aurora runs in a single-master configuration where only a single node can process write requests and all other nodes are read-only replicas. If the writer node becomes unavailable, a failover mechanism promotes one of the read-only nodes to be the new writer. 
+By default, Aurora runs in a single-master configuration where only a single node can process write requests and all other nodes are read replicas. If the writer node becomes unavailable, a failover mechanism promotes one of the read-only nodes to be the new writer. 
 
 [Multi-master](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-multi-master.html) configuration is a recent addition to Aurora MySQL (not yet available on Aurora PostgreSQL) for scaling writes that involves a second writer node. However, since all of the data is now present in both the nodes, concurrent writes to the same data on the two nodes can lead to [write conflicts and deadlock errors](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-multi-master.html#aurora-multi-master-deadlocks) that the application has to handle. A long list of [limitations](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-multi-master.html#aurora-multi-master-limitations) include the inability to scale beyond the original two writer nodes as well as lack of geo-distributed writes across multiple regions.
 

--- a/docs/content/latest/faq/general.md
+++ b/docs/content/latest/faq/general.md
@@ -21,7 +21,7 @@ YugabyteDB is a good fit for fast-growing, cloud native applications that need t
 
 2. Hybrid Transactional/Analytical Processing (HTAP), also known as Translytical, applications needing real-time analytics on transactional data. E.g User personalization, fraud detection, machine learning.
 
-3. Streaming applications needing to efficiently ingest, analyze and store ever-growing data. E.g. IoT sensor analytics, time series metrics, real time monitoring.
+3. Streaming applications needing to efficiently ingest, analyze and store ever-growing data. E.g. IoT sensor analytics, time series metrics, real-time monitoring.
 
 A few such use cases are detailed [here](https://www.yugabyte.com/).
 

--- a/docs/content/latest/introduction.md
+++ b/docs/content/latest/introduction.md
@@ -45,7 +45,7 @@ YugabyteDB feature highlights are listed below.
 
 ### 2. High performance and massive scalability
 
-- Low latency for geo-distributed applications with multiple [read consistency levels](../architecture/concepts/docdb/replication/#tunable-read-consistency) and [read-only replicas](../architecture/concepts/docdb/replication/#read-only-replicas).
+- Low latency for geo-distributed applications with multiple [read consistency levels](../architecture/concepts/docdb/replication/#tunable-read-consistency) and [read replicas](../architecture/concepts/docdb/replication/#read-only-replicas).
 
 - Linearly scalable throughput for ingesting and serving ever-growing datasets.
 

--- a/docs/content/latest/reference/configuration/yb-master.md
+++ b/docs/content/latest/reference/configuration/yb-master.md
@@ -85,7 +85,7 @@ Required.
 
 ##### --fs_wal_dirs
 
-Specifies a comma-separated list of directories, where `yb-master` will store write-ahead (WAL) logs. This can be the same as one of the directories listed in `--fs_data_dirs`, but not a sub-directory of a data directory.
+Specifies a comma-separated list of directories, where `yb-master` will store write-ahead (WAL) logs. This can be the same as one of the directories listed in `--fs_data_dirs`, but not a subdirectory of a data directory.
 
 Default: Same value as `--fs_data_dirs`
 
@@ -239,6 +239,20 @@ The `--follower_unavailable_considered_failed_sec` value should match the value 
 
 {{< /note >}}
 
+##### -- leader_failure_max_missed_heartbeat_periods
+
+The maximum heartbeat periods that the leader can fail to heartbeat in before the leader is considered to be failed. The total failure timeout, in milliseconds, is [`--raft_heartbeat_interval_ms`](#raft-heartbeat-interval-ms) multiplied by `--leader_failure_max_missed_heartbeat_periods`.
+
+For read replica clusters, set the value to `10` in all `yb-tserver` and `yb-master` configurations.  Because the the data is globally replicated, RPC latencies are higher. Use this option to increase the failure detection interval in such a higher RPC latency deployment.
+
+Default: `6`
+
+##### -- raft_heartbeat_interval_ms
+
+The heartbeat interval, in milliseconds, for Raft replication. The leader produces heartbeats to followers at this interval. The followers expect a heartbeat at this interval and consider a leader to have failed if it misses several in a row.
+
+Default: `500`
+
 #### Write ahead log (WAL) options
 
 {{< note title="Note" >}}
@@ -315,15 +329,7 @@ Default: `3`
 
 ### Geo-distribution options
 
-Settings related to managing geo-distributed clusters and Raft consensus.
-
-##### -- leader_failure_max_missed_heartbeat_periods
-
-The maximum heartbeat periods that the leader can fail to heartbeat in before the leader is considered to be failed. The total failure timeout, in milliseconds, is [`--raft_heartbeat_interval_ms`](#raft-heartbeat-interval-ms) multiplied by `--leader_failure_max_missed_heartbeat_periods`.
-
-For read replica clusters, set the value to `10` on both YB-Master and YB-TServer servers.  Because the the data is globally replicated, RPC latencies are higher. Use this flag to increase the failure detection interval in such a higher RPC latency deployment.
-
-Default: `6`
+Settings related to managing geo-distributed clusters.
 
 ##### -- placement_zone
 
@@ -348,12 +354,6 @@ Default: `cloud1`
 Determines when to use private IP addresses. Possible values are `never` (default),`zone`,`cloud` and `region`. Based on the values of the `placement_*` configuration options.
 
 Default: `never`
-
-##### -- raft_heartbeat_interval_ms
-
-The heartbeat interval, in milliseconds, for Raft replication. The leader produces heartbeats to followers at this interval. The followers expect a heartbeat at this interval and consider a leader to have failed if it misses several in a row.
-
-Default: `500`
 
 ---
 

--- a/docs/content/latest/reference/configuration/yb-tserver.md
+++ b/docs/content/latest/reference/configuration/yb-tserver.md
@@ -100,7 +100,7 @@ Required.
 
 ##### --fs_wal_dirs
 
-Specifies a comma-separated list of directories, where `yb-tserver` will store write-ahead (WAL) logs. This can be the same as one of the directories listed in `--fs_data_dirs`, but not a sub-directory of a data directory.
+Specifies a comma-separated list of directories, where `yb-tserver` will store write-ahead (WAL) logs. This can be the same as one of the directories listed in `--fs_data_dirs`, but not a subdirectory of a data directory.
 
 Default: Same value as `--fs_data_dirs`
 
@@ -220,6 +220,20 @@ The `--follower_unavailable_considered_failed_sec` value should match the value 
 
 {{< /note >}}
 
+##### --leader_failure_max_missed_heartbeat_periods
+
+The maximum heartbeat periods that the leader can fail to heartbeat in before the leader is considered to be failed. The total failure timeout, in milliseconds (ms), is [`--raft_heartbeat_interval_ms`](#raft-heartbeat-interval-ms) multiplied by `--leader_failure_max_missed_heartbeat_periods`.
+
+For read replica clusters, set the value to `10` in all `yb-tserver` and `yb-master` configurations.  Because the the data is globally replicated, RPC latencies are higher. Use this option to increase the failure detection interval in such a higher RPC latency deployment.
+
+Default: `6`
+
+##### --raft_heartbeat_interval_ms
+
+The heartbeat interval, in milliseconds (ms), for Raft replication. The leader produces heartbeats to followers at this interval. The followers expect a heartbeat at this interval and consider a leader to have failed if it misses several in a row.
+
+Default: `500`
+
 #### Write ahead log (WAL) options
 
 {{< note title="Note" >}}
@@ -274,15 +288,7 @@ Default: `64`
 
 ### Geo-distribution options
 
-Settings related to managing geo-distributed clusters and Raft consensus.
-
-##### --leader_failure_max_missed_heartbeat_periods
-
-The maximum heartbeat periods that the leader can fail to heartbeat in before the leader is considered to be failed. The total failure timeout, in milliseconds (ms), is [`--raft_heartbeat_interval_ms`](#raft-heartbeat-interval-ms) multiplied by `--leader_failure_max_missed_heartbeat_periods`.
-
-For read replica clusters, set the value to `10` on both YB-Master and YB-TServer servers.  Because the the data is globally replicated, RPC latencies are higher. Use this flag to increase the failure detection interval in such a higher RPC latency deployment.
-
-Default: `6`
+Settings related to managing geo-distributed clusters.
 
 ##### --placement_zone
 
@@ -301,12 +307,6 @@ Default: `datacenter1`
 Specifies the name of the cloud where this instance is deployed.
 
 Default: `cloud1`
-
-##### --raft_heartbeat_interval_ms
-
-The heartbeat interval, in milliseconds (ms), for Raft replication. The leader produces heartbeats to followers at this interval. The followers expect a heartbeat at this interval and consider a leader to have failed if it misses several in a row.
-
-Default: `500`
 
 ---
 

--- a/docs/content/latest/troubleshoot/nodes/check-logs.md
+++ b/docs/content/latest/troubleshoot/nodes/check-logs.md
@@ -14,7 +14,7 @@ showAsideToc: true
 
 ## YugabyteDB base folder
 
-The logs for each node are written to a sub-directory of the YugabyteDB `yugabyte-data` directory and may vary depending on your deployment:
+The logs for each node are written to a subdirectory of the YugabyteDB `yugabyte-data` directory and may vary depending on your deployment:
 
 - When you use `yb-ctl` to create local YugabyteDB clusters on a single host (for example, your laptop), the default location for each node is `/yugabyte-data/node-<node_nr>/`. For a 3-node cluster, `yb-ctl` utility creates three directories: `node-1`, `node-2` and `node-3`.
 - For a multi-node cluster deployment to multiple hosts, the location where YugabyteDB disks are set up can vary (for example, `/home/centos/`, `/mnt/`, or another directory) on each node (host).

--- a/docs/content/v1.0/architecture/concepts/replication.md
+++ b/docs/content/v1.0/architecture/concepts/replication.md
@@ -54,10 +54,10 @@ guarantees which is desired in some deployment models. All other tablet-peers ar
 and merely replicate data, and are available as hot standbys that can take over quickly in case the
 leader fails.
 
-## Read-only replicas
+## read replicas
 
 In addition to the core distributed consensus based replication, YugabyteDB extends Raft to add
-read-only replicas (aks observer nodes) that do not participate in writes but get a timeline consistent
+read replicas (aks observer nodes) that do not participate in writes but get a timeline consistent
 copy of the data in an asynchronous manner. Nodes in remote  datacenters can thus be added in "read-only"
 mode. This is primarily for cases where latency of doing a distributed consensus based write is not
 tolerable for some workloads. This read-only node (or timeline-consistent node) is still strictly better than

--- a/docs/content/v1.0/introduction/overview.md
+++ b/docs/content/v1.0/introduction/overview.md
@@ -34,7 +34,7 @@ YugabyteDB is a single operational database that brings together 3 must-have nee
 
 ### 2. High Performance
 
-- Low latency for geo-distributed applications with multiple [read consistency levels](../../architecture/concepts/replication/#tunable-read-consistency) and [read-only replicas](../../architecture/concepts/replication/#read-only-replicas).
+- Low latency for geo-distributed applications with multiple [read consistency levels](../../architecture/concepts/replication/#tunable-read-consistency) and [read replicas](../../architecture/concepts/replication/#read-only-replicas).
 
 - High throughput for ingesting and serving ever-growing datasets.
 

--- a/docs/content/v1.1/architecture/concepts/docdb/replication.md
+++ b/docs/content/v1.1/architecture/concepts/docdb/replication.md
@@ -55,10 +55,10 @@ guarantees which is desired in some deployment models. All other tablet-peers ar
 and merely replicate data, and are available as hot standbys that can take over quickly in case the
 leader fails.
 
-## Read-only Replicas
+## read replicas
 
 In addition to the core distributed consensus based replication, DocDB extends Raft to add
-read-only replicas (aks observer nodes) that do not participate in writes but get a timeline consistent
+read replicas (aks observer nodes) that do not participate in writes but get a timeline consistent
 copy of the data in an asynchronous manner. Nodes in remote  datacenters can thus be added in "read-only"
 mode. This is primarily for cases where latency of doing a distributed consensus based write is not
 tolerable for some workloads. This read-only node (or timeline-consistent node) is still strictly better than

--- a/docs/content/v1.1/introduction.md
+++ b/docs/content/v1.1/introduction.md
@@ -40,7 +40,7 @@ YugabyteDB feature highlights are listed below.
 
 ### 2. High Performance
 
-- Low latency for geo-distributed applications with multiple [read consistency levels](../architecture/concepts/replication/#tunable-read-consistency) and [read-only replicas](../architecture/concepts/replication/#read-only-replicas).
+- Low latency for geo-distributed applications with multiple [read consistency levels](../architecture/concepts/replication/#tunable-read-consistency) and [read replicas](../architecture/concepts/replication/#read-only-replicas).
 
 - High throughput for ingesting and serving ever-growing datasets.
 

--- a/docs/content/v1.2/architecture/docdb/replication.md
+++ b/docs/content/v1.2/architecture/docdb/replication.md
@@ -55,10 +55,10 @@ guarantees which is desired in some deployment models. All other tablet-peers ar
 and merely replicate data, and are available as hot standbys that can take over quickly in case the
 leader fails.
 
-## Read-only Replicas
+## read replicas
 
 In addition to the core distributed consensus based replication, DocDB extends Raft to add
-read-only replicas (aks observer nodes) that do not participate in writes but get a timeline consistent
+read replicas (aks observer nodes) that do not participate in writes but get a timeline consistent
 copy of the data in an asynchronous manner. Nodes in remote  datacenters can thus be added in "read-only"
 mode. This is primarily for cases where latency of doing a distributed consensus based write is not
 tolerable for some workloads. This read-only node (or timeline-consistent node) is still strictly better than

--- a/docs/content/v1.2/introduction.md
+++ b/docs/content/v1.2/introduction.md
@@ -38,7 +38,7 @@ YugabyteDB feature highlights are listed below.
 
 ### 2. High performance and massive scalability
 
-- Low latency for geo-distributed applications with multiple [read consistency levels](../architecture/concepts/docdb/replication/#tunable-read-consistency) and [read-only replicas](../architecture/concepts/docdb/replication/#read-only-replicas).
+- Low latency for geo-distributed applications with multiple [read consistency levels](../architecture/concepts/docdb/replication/#tunable-read-consistency) and [read replicas](../architecture/concepts/docdb/replication/#read-only-replicas).
 
 - Linearly scalable throughput for ingesting and serving ever-growing datasets.
 

--- a/docs/content/v1.3/architecture/docdb/replication.md
+++ b/docs/content/v1.3/architecture/docdb/replication.md
@@ -55,10 +55,10 @@ guarantees which is desired in some deployment models. All other tablet-peers ar
 and merely replicate data, and are available as hot standbys that can take over quickly in case the
 leader fails.
 
-## Read-only replicas
+## read replicas
 
 In addition to the core distributed consensus based replication, DocDB extends Raft to add
-read-only replicas (aks observer nodes) that do not participate in writes but get a timeline consistent
+read replicas (aks observer nodes) that do not participate in writes but get a timeline consistent
 copy of the data in an asynchronous manner. Nodes in remote  datacenters can thus be added in "read-only"
 mode. This is primarily for cases where latency of doing a distributed consensus based write is not
 tolerable for some workloads. This read-only node (or timeline-consistent node) is still strictly better than

--- a/docs/content/v1.3/introduction.md
+++ b/docs/content/v1.3/introduction.md
@@ -38,7 +38,7 @@ YugabyteDB feature highlights are listed below.
 
 ### 2. High performance and massive scalability
 
-- Low latency for geo-distributed applications with multiple [read consistency levels](../architecture/concepts/docdb/replication/#tunable-read-consistency) and [read-only replicas](../architecture/concepts/docdb/replication/#read-only-replicas).
+- Low latency for geo-distributed applications with multiple [read consistency levels](../architecture/concepts/docdb/replication/#tunable-read-consistency) and [read replicas](../architecture/concepts/docdb/replication/#read-only-replicas).
 
 - Linearly scalable throughput for ingesting and serving ever-growing datasets.
 


### PR DESCRIPTION
- Move all Raft flags into "Raft options" sections of `yb-tserver` and `yb-master` configurations.
- Replace "read-only replica" with "read replica" for consistency and searching.