### PR TITLE
[YW][#3429] Add additional conditional before fetching Universe table…

### DIFF
--- a/managed/ui/src/components/config/OnPrem/OnPremConfiguration.scss
+++ b/managed/ui/src/components/config/OnPrem/OnPremConfiguration.scss
@@ -112,7 +112,6 @@
 }
 
 .provider-task-progress-container {
-  border: 1px solid #d3d3d3;
   padding: 6px 8px;
   width: 100%;
 }

--- a/managed/ui/src/components/universes/UniverseDetail/UniverseDetail.js
+++ b/managed/ui/src/components/universes/UniverseDetail/UniverseDetail.js
@@ -76,11 +76,11 @@ class UniverseDetail extends Component {
     }
   }
 
-  componentDidUpdate(prevProps, prevState, snapshot) {
-    const { universe: { currentUniverse }} = this.props;
+  componentDidUpdate(prevProps) {
+    const { universe: { currentUniverse }, universeTables } = this.props;
     if (getPromiseState(currentUniverse).isSuccess() &&
         !getPromiseState(prevProps.universe.currentUniverse).isSuccess()) {
-      if (hasLiveNodes(currentUniverse.data)) {
+      if (hasLiveNodes(currentUniverse.data) && !universeTables.length) {
         this.props.fetchUniverseTables(currentUniverse.data.universeUUID);
       }
     }

--- a/managed/ui/src/components/universes/UniverseDetail/UniverseDetailContainer.js
+++ b/managed/ui/src/components/universes/UniverseDetail/UniverseDetailContainer.js
@@ -126,6 +126,7 @@ function mapStateToProps(state, ownProps) {
     customer: state.customer,
     universe: state.universe,
     tasks: state.tasks,
+    universeTables: state.tables.universeTablesList,
     modal: state.modal,
     providers: state.cloud.providers,
     updateAvailable: isUpdateAvailable(state)


### PR DESCRIPTION
…s and remove border from TaskProgress

Summary:
Add additional check whether tables have been already fetched before calling API to fetch
tables. Remove border from TaskProgress because it was distracting and caused the spacing to look
strange.

Test Plan:
Create a backup (preferably one that takes a long time), and then navigate to the
universe-level Tasks tab and check what happens to the UI. Make sure that the stepbar does not do
any flickering.
*One symptom of the incorrect code was that a TON of network requests were being made and causing the UI to lag*

I recommend connecting local YW to customer's environment to repro. After tunneling, you can add the url to .env with `REACT_APP_YUGAWARE_API_URL=http://localhost:8080/api`

Example of fixed UI:
{F13140}

Reviewers: wesley, arnav, ram

Reviewed By: ram

Subscribers: kannan, rao, ui

Differential Revision: https://phabricator.dev.yugabyte.com/D7831