### PR TITLE
[docs] Revert yb-demo to yb_demo for non-Kubernetes content

### DIFF
--- a/docs/content/latest/deploy/kubernetes/oss/helm-chart.md
+++ b/docs/content/latest/deploy/kubernetes/oss/helm-chart.md
@@ -179,7 +179,7 @@ If you are running in a resource-constrained environment or a local environment,
 ```sh
 $ helm install yugabytedb/yugabyte \
 --set resource.master.requests.cpu=0.5,resource.master.requests.memory=0.5Gi,\
-resource.tserver.requests.cpu=0.5,resource.tserver.requests.memory=0.5Gi --namespace yb-demo --name yb-demo
+resource.tserver.requests.cpu=0.5,resource.tserver.requests.memory=0.5Gi --namespace yb_demo --name yb-demo
 ```
 
 **For Helm 3:**

--- a/docs/content/latest/develop/learn/date-and-time-ysql.md
+++ b/docs/content/latest/develop/learn/date-and-time-ysql.md
@@ -272,19 +272,19 @@ A detailed explanation of how time is obtained can be found at the blog post des
 A simpler explanation is that the time is determined by the 'Shard Leader' of the table and this is the time used by all followers of the leader. Therefore there could be differences to the UTC timestamp of the underlying server to the current timestamp that is used for a transaction on a particular table.
 {{< /note >}}
 
-Lets start working with dates and timestamps. The following assumes that you have installed the yb-demo database and its demo data.
+Lets start working with dates and timestamps. The following assumes that you have installed the yb_demo database and its demo data.
 
 ```
-yugabyte=# \c yb-demo
-You are now connected to database "yb-demo" as user "yugabyte".
+yugabyte=# \c yb_demo
+You are now connected to database "yb_demo" as user "yugabyte".
 
-yb-demo=# select to_char(max(orders.created_at), 'DD-MON-YYYY HH24:MI') AS "Last Order Date" from orders;
+yb_demo=# select to_char(max(orders.created_at), 'DD-MON-YYYY HH24:MI') AS "Last Order Date" from orders;
 
   Last Order Date  
 -------------------
  19-APR-2020 14:07
 
-yb-demo=# select extract(MONTH from o.created_at) AS "Mth Num", to_char(o.created_at, 'MON') AS "Month",
+yb_demo=# select extract(MONTH from o.created_at) AS "Mth Num", to_char(o.created_at, 'MON') AS "Month",
           extract(YEAR from o.created_at) AS "Year", count(*) AS "Orders"
           from orders o
           where o.created_at > current_timestamp(0)
@@ -305,7 +305,7 @@ yb-demo=# select extract(MONTH from o.created_at) AS "Mth Num", to_char(o.create
        7 | JUL   | 2019 |    421
 (10 rows)
 
-yb-demo=# select to_char(o.created_at, 'HH AM') AS "Popular Hours", count(*) AS "Orders"
+yb_demo=# select to_char(o.created_at, 'HH AM') AS "Popular Hours", count(*) AS "Orders"
           from orders o
           group by 1
           order by 2 DESC
@@ -319,12 +319,12 @@ yb-demo=# select to_char(o.created_at, 'HH AM') AS "Popular Hours", count(*) AS 
  08 PM         |    812
 (4 rows)
 
-yb-demo=# update orders
+yb_demo=# update orders
           set created_at = created_at + ((floor(random() * (25-2+2) + 2))::int * interval '1 day 14 hours');
 
 UPDATE 18760
 
-yb-demo=# select to_char(o.created_at, 'Day') AS "Top Day",
+yb_demo=# select to_char(o.created_at, 'Day') AS "Top Day",
           count(o.*) AS "SALES"
           from orders o
           group by 1
@@ -341,14 +341,14 @@ Top Day  | SALES
  Thursday  |    2621
 (7 rows)
 
-yb-demo=# create table order_deliveries (
+yb_demo=# create table order_deliveries (
           order_id bigint,
           creation_date date DEFAULT current_date,
           delivery_date timestamptz);
 
 CREATE TABLE
 
-yb-demo=# insert into order_deliveries
+yb_demo=# insert into order_deliveries
           (order_id, delivery_date)
           select o.id, o.created_at + ((floor(random() * (25-2+2) + 2))::int * interval '1 day 3 hours')
           from orders o
@@ -356,7 +356,7 @@ yb-demo=# insert into order_deliveries
 
 INSERT 0 12268
 
-yb-demo=# select * from order_deliveries limit 5;
+yb_demo=# select * from order_deliveries limit 5;
 
  order_id | creation_date |       delivery_date
 ----------+---------------+----------------------------
@@ -367,7 +367,7 @@ yb-demo=# select * from order_deliveries limit 5;
     13954 | 2019-07-09    | 2019-02-08 04:07:01.457+00
 (5 rows)
 
-yb-demo=# select d.order_id, to_char(o.created_at, 'DD-MON-YYYY HH AM') AS "Ordered",
+yb_demo=# select d.order_id, to_char(o.created_at, 'DD-MON-YYYY HH AM') AS "Ordered",
           to_char(d.delivery_date, 'DD-MON-YYYY HH AM') AS "Delivered",
           d.delivery_date - o.created_at AS "Delivery Days"
           from orders o, order_deliveries d
@@ -395,10 +395,10 @@ yb-demo=# select d.order_id, to_char(o.created_at, 'DD-MON-YYYY HH AM') AS "Orde
 Your data will be slightly different as we used a `RANDOM()` function for setting the 'delivery_date' in the new 'order_deliveries' table.
 {{< /note >}}
 
-You can use views of the YugabyteDB Data Catalogs to create data that is already prepared and formatted for your application code so that your SQL is simpler. Below is an example that is defined in the yb-demo database (has no dependency on yb-demo). This demonstration shows how you can nominate a shortlist of timezones that are formatted and ready to use for display purposes.
+You can use views of the YugabyteDB Data Catalogs to create data that is already prepared and formatted for your application code so that your SQL is simpler. Below is an example that is defined in the yb_demo database (has no dependency on yb_demo). This demonstration shows how you can nominate a shortlist of timezones that are formatted and ready to use for display purposes.
 
 ```
-yb-demo=# CREATE OR REPLACE VIEW TZ AS
+yb_demo=# CREATE OR REPLACE VIEW TZ AS
           select '* Current time' AS "tzone", '' AS "offset", to_char(current_timestamp AT TIME ZONE 'Australia/Sydney', 'Dy dd-Mon-yy hh:mi PM') AS "Local Time"
           UNION
           select x.name AS "tzone",
@@ -410,7 +410,7 @@ yb-demo=# CREATE OR REPLACE VIEW TZ AS
 
 CREATE VIEW
 
-yb-demo=# select * from tz;
+yb_demo=# select * from tz;
 
          tzone         | offset |       Local Time
 -----------------------+--------+------------------------
@@ -533,16 +533,16 @@ The `EXTRACT` command is the preferred command to `DATE_PART`.
 
 ## Manipulating using truncation
 
-Another useful command is `DATE_TRUNC` which is used to 'floor' the timestamp to a particular unit. For the following YSQL, we assume that you are in the 'yb-demo' database with the demo data loaded.
+Another useful command is `DATE_TRUNC` which is used to 'floor' the timestamp to a particular unit. For the following YSQL, we assume that you are in the 'yb_demo' database with the demo data loaded.
 
 ```
-yb-demo=# select date_trunc('hour', current_timestamp);
+yb_demo=# select date_trunc('hour', current_timestamp);
        date_trunc
 ------------------------
  2019-07-09 06:00:00+00
 (1 row)
 
-yb-demo=# select to_char((date_trunc('month', generate_series)::date)-1, 'DD-MON-YYYY') AS "Last Day of Month"
+yb_demo=# select to_char((date_trunc('month', generate_series)::date)-1, 'DD-MON-YYYY') AS "Last Day of Month"
           from generate_series(current_date-(365-1), current_date, '1 month');
 
  Last Day of Month
@@ -561,7 +561,7 @@ yb-demo=# select to_char((date_trunc('month', generate_series)::date)-1, 'DD-MON
  31-MAY-2019
 (12 rows)
 
-yb-demo=# select date_trunc('days', age(created_at)) AS "Product Age" from products order by 1 desc limit 10;
+yb_demo=# select date_trunc('days', age(created_at)) AS "Product Age" from products order by 1 desc limit 10;
 
       Product Age
 ------------------------

--- a/docs/content/latest/develop/learn/strings-and-text-ysql.md
+++ b/docs/content/latest/develop/learn/strings-and-text-ysql.md
@@ -127,15 +127,15 @@ In the last example above, the column 'hasindexes' is a `Boolean` data type and 
 
 There are a lot of functions that can be applied to text. Below the functions are classified into logical groupings - in many cases the capability of the functions overlap and personal choice will determine how you approach solving the problem.
 
-The focus here was to quickly show how each of the functions could be used, along with some examples. It is assumed that you have the [`yb-demo` database](/latest/quick-start/explore-ysql/#1-load-data) installed.
+The focus here was to quickly show how each of the functions could be used, along with some examples. It is assumed that you have the [`yb_demo` database](/latest/quick-start/explore-ysql/#1-load-data) installed.
 
 ### Altering the appearance of text
 
 ```sh
-yugabyte=# \c yb-demo  
-You are now connected to database "yb-demo" as user "yugabyte".
+yugabyte=# \c yb_demo  
+You are now connected to database "yb_demo" as user "yugabyte".
 
-yb-demo =# select lower('hELLO world') AS LOWER,
+yb_demo =# select lower('hELLO world') AS LOWER,
   upper('hELLO world') AS UPPER,
   initcap('hELLO world') AS INITCAP;
 
@@ -143,19 +143,19 @@ yb-demo =# select lower('hELLO world') AS LOWER,
 -------------+-------------+-------------
  hello world | HELLO WORLD | Hello World
 
-yb-demo =# select quote_ident('ok') AS EASY, quote_ident('I am OK') AS QUOTED, quote_ident('I''m not OK') AS DOUBLE_QUOTED, quote_ident('') AS EMPTY_STR, quote_ident(null) AS NULL_QUOTED;
+yb_demo =# select quote_ident('ok') AS EASY, quote_ident('I am OK') AS QUOTED, quote_ident('I''m not OK') AS DOUBLE_QUOTED, quote_ident('') AS EMPTY_STR, quote_ident(null) AS NULL_QUOTED;
 
  easy |  quoted   | double_quoted | empty_str | null_quoted
 ------+-----------+---------------+-----------+-------------
  ok   | "I am OK" | "I'm not OK"  | ""        |
 
-yb-demo =# select quote_literal('ok') AS EASY, quote_literal('I am OK') AS QUOTED, quote_literal('I''m not OK') AS DOUBLE_QUOTED, quote_literal('') AS EMPTY_STR, quote_literal(null) AS NULL_QUOTED;
+yb_demo =# select quote_literal('ok') AS EASY, quote_literal('I am OK') AS QUOTED, quote_literal('I''m not OK') AS DOUBLE_QUOTED, quote_literal('') AS EMPTY_STR, quote_literal(null) AS NULL_QUOTED;
 
  easy |  quoted   | double_quoted | empty_str | null_quoted
 ------+-----------+---------------+-----------+-------------
  'ok' | 'I am OK' | 'I''m not OK' | ''        |
 
-yb-demo =# select quote_nullable('ok') AS EASY, quote_nullable('I am OK') AS QUOTED, quote_nullable('I''m not OK') AS DOUBLE_QUOTED, quote_nullable('') AS EMPTY_STR, quote_nullable(null) AS NULL_QUOTED;
+yb_demo =# select quote_nullable('ok') AS EASY, quote_nullable('I am OK') AS QUOTED, quote_nullable('I''m not OK') AS DOUBLE_QUOTED, quote_nullable('') AS EMPTY_STR, quote_nullable(null) AS NULL_QUOTED;
 
 easy |  quoted   | double_quoted | empty_str | null_quoted
 ------+-----------+---------------+-----------+-------------
@@ -193,7 +193,7 @@ Some values need to be padded for formatting purposes, and `LPAD` and `RPAD` are
 The reverse of padding is trimming, which will remove spaces if found. Below are examples of using padding and trimming to achieve the results required.
 
 ```
-yb-demo=# select name, lpad(name, 10), rpad(name, 15) from users order by name limit 5;
+yb_demo=# select name, lpad(name, 10), rpad(name, 15) from users order by name limit 5;
 
        name        |    lpad    |      rpad
 -------------------+------------+-----------------
@@ -203,7 +203,7 @@ yb-demo=# select name, lpad(name, 10), rpad(name, 15) from users order by name l
  Abbie Ryan        | Abbie Ryan | Abbie Ryan
  Abby Larkin       | Abby Larki | Abby Larkin
 
-yb-demo=# select name, lpad(name, 20), rpad(name, 20) from users order by name limit 5;
+yb_demo=# select name, lpad(name, 20), rpad(name, 20) from users order by name limit 5;
 
        name        |         lpad         |         rpad
 -------------------+----------------------+----------------------
@@ -213,7 +213,7 @@ yb-demo=# select name, lpad(name, 20), rpad(name, 20) from users order by name l
  Abbie Ryan        |           Abbie Ryan | Abbie Ryan
  Abby Larkin       |          Abby Larkin | Abby Larkin
 
-yb-demo=# select name, lpad(name, 20, '. '), rpad(name, 20, '.') from users order by name limit 5;
+yb_demo=# select name, lpad(name, 20, '. '), rpad(name, 20, '.') from users order by name limit 5;
 
        name        |         lpad         |         rpad
 -------------------+----------------------+----------------------
@@ -223,7 +223,7 @@ yb-demo=# select name, lpad(name, 20, '. '), rpad(name, 20, '.') from users orde
  Abbie Ryan        | . . . . . Abbie Ryan | Abbie Ryan..........
  Abby Larkin       | . . . . .Abby Larkin | Abby Larkin.........
 
-yb-demo=# select repeat(' ', ((x.maxlen-length(u.name))/2)::int) || rpad(u.name, x.maxlen) AS "cname"
+yb_demo=# select repeat(' ', ((x.maxlen-length(u.name))/2)::int) || rpad(u.name, x.maxlen) AS "cname"
           from users u,
           (select max(length(a.name))::int AS maxlen from users a) AS x;
 
@@ -251,7 +251,7 @@ yb-demo=# select repeat(' ', ((x.maxlen-length(u.name))/2)::int) || rpad(u.name,
       Theresa Grant
  ...
 
-yb-demo=# select x.RawDay, length(x.RawDay) AS RawLen, x.TrimDay, length(x.TrimDay) AS TrimLen,
+yb_demo=# select x.RawDay, length(x.RawDay) AS RawLen, x.TrimDay, length(x.TrimDay) AS TrimLen,
           x.LTrimDay, length(x.LTrimDay) AS LTrimLen, x.RTrimDay, length(x.RTrimDay) AS RTrimLen
           from (select to_char(generate_series, 'Day') AS RawDay,
                 trim(to_char(generate_series, 'Day')) AS TrimDay,
@@ -300,51 +300,51 @@ YugabyteDB also has `DECODE` and `ENCODE` for decoding and encoding from, or to,
 You can concatenate strings of text in several different ways. For robustness, you should ensure that everything being passed is interpreted as text (by casting) so that unexpected results do not appear in edge cases. Here are some examples that show that YugabyteDB is leniant in passing in variables, but you should implement more robust casting for proper treatment of strings.
 
 ```sh
-yb-demo=# select 'one' || '-' || 2 || '-one' AS "121";
+yb_demo=# select 'one' || '-' || 2 || '-one' AS "121";
 
     121
 -----------
  one-2-one
 
-yb-demo=# select 2 || '-one-one' AS "211";
+yb_demo=# select 2 || '-one-one' AS "211";
 
     211
 -----------
  2-one-one
 
-yb-demo=# select 1 || '-one' || repeat('-two', 2) AS "1122";
+yb_demo=# select 1 || '-one' || repeat('-two', 2) AS "1122";
 
      1122
 ---------------
  1-one-two-two
 
-yb-demo=# select 1::text || 2::text || 3::text AS "123";
+yb_demo=# select 1::text || 2::text || 3::text AS "123";
 
  123
 -----
  123
 
-yb-demo=# select 1 || 2 || 3 AS "123";
+yb_demo=# select 1 || 2 || 3 AS "123";
 
 ERROR:  operator does not exist: integer || integer
 LINE 1: select 1 || 2 || 3 AS "123";
                  ^
 HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
 
-yb-demo=# select concat(1,2,3) AS "123";
+yb_demo=# select concat(1,2,3) AS "123";
 
  123
 -----
  123
 
-yb-demo=# select concat_ws(':', 1,2,3) AS "123 WS";
+yb_demo=# select concat_ws(':', 1,2,3) AS "123 WS";
 
  123 WS
 --------
  1:2:3
 (1 row)
 
-yb-demo =# select left(vendor,1) AS V, string_agg(distinct(category), ', ' ORDER BY category) AS CATEGORIES
+yb_demo =# select left(vendor,1) AS V, string_agg(distinct(category), ', ' ORDER BY category) AS CATEGORIES
   from products group by left(vendor,1) order by 1;
   
  v |            categories
@@ -380,7 +380,7 @@ In the example above, we explore the `LEFT` function, but the `string_agg` funct
 There is also the `REVERSE` function that reverses the contents of text in a simple manner as shown in the next example.
 
 ```sh
-yb-demo=# select reverse(to_char(current_date, 'DD-MON-YYYY'));
+yb_demo=# select reverse(to_char(current_date, 'DD-MON-YYYY'));
 
    reverse
 -------------
@@ -390,19 +390,19 @@ yb-demo=# select reverse(to_char(current_date, 'DD-MON-YYYY'));
 You can use the `FORMAT` function parse user input as parameters to a SQL statement in order to minimise the impact of unexpected data that is typical of a SQL injection attack. The most popular method is to use the `EXECUTE` command within a procedure as this is not available at the YSQL command prompt, only within the YSQL plpgsql environment. The `FORMAT` command is used to finalise the complete SQL statement and passed to `EXECUTE` to run. As we are not simulating YSQL plpgsql here, let's illustrate how to use the `FORMAT` function only.
 
 ```
-yb-demo=# select format('Hello %s, today''s date is %s', 'Jono', to_char(current_date, 'DD-MON-YYYY'), 'discarded');
+yb_demo=# select format('Hello %s, today''s date is %s', 'Jono', to_char(current_date, 'DD-MON-YYYY'), 'discarded');
 
                  format
 -----------------------------------------
  Hello Jono, today's date is 29-JUL-2019
 
-yb-demo=# select format('On this day, %2$s, %1$s was here', 'Jono', to_char(current_date, 'DD-MON-YYYY'));
+yb_demo=# select format('On this day, %2$s, %1$s was here', 'Jono', to_char(current_date, 'DD-MON-YYYY'));
 
                  format
 -----------------------------------------
  On this day, 29-JUL-2019, Jono was here
 
-yb-demo=# select format('SELECT %2$I, %3$I from %1$I where name = %4$L', 'users', 'birth_date', 'email', 'Brody O''Reilly');
+yb_demo=# select format('SELECT %2$I, %3$I from %1$I where name = %4$L', 'users', 'birth_date', 'email', 'Brody O''Reilly');
 
                                format
 --------------------------------------------------------------------
@@ -417,13 +417,13 @@ Substituting text with other text can be a complex task as you need to fully und
 The treatment of nulls in mathematical operations is often problematic, as is string joins as joining a null to a value results in a null. Coalescing the inputs will avoid these issues as shown in the examples below.
 
 ```
-yb-demo=# select trunc(avg(coalesce(discount,0))::numeric,3) AS "COALESCED", trunc(avg(discount)::numeric,3) AS "RAW" from orders;
+yb_demo=# select trunc(avg(coalesce(discount,0))::numeric,3) AS "COALESCED", trunc(avg(discount)::numeric,3) AS "RAW" from orders;
 
  COALESCED |  RAW  
 -----------+-------
      0.530 | 5.195
 
-yb-demo=# select 'Hello ' || null AS GREETING, 'Goodbye ' || coalesce(null, 'Valued Customer') AS GOODBYE;
+yb_demo=# select 'Hello ' || null AS GREETING, 'Goodbye ' || coalesce(null, 'Valued Customer') AS GOODBYE;
 
  greeting |         goodbye
 ----------+-------------------------
@@ -433,7 +433,7 @@ yb-demo=# select 'Hello ' || null AS GREETING, 'Goodbye ' || coalesce(null, 'Val
 The above shows how substituting when null can have a significant impact upon the results you achieve or even the behaviour of your application. Below concentrates on changing existing text with other text.
 
 ```
-yb-demo=# select overlay(password placing 'XXXXXXXXXXXXXXX' from 1 for length(password)) AS SCRAMBLED from users limit 5;
+yb_demo=# select overlay(password placing 'XXXXXXXXXXXXXXX' from 1 for length(password)) AS SCRAMBLED from users limit 5;
 
     scrambled
 -----------------
@@ -443,19 +443,19 @@ yb-demo=# select overlay(password placing 'XXXXXXXXXXXXXXX' from 1 for length(pa
  XXXXXXXXXXXXXXX
  XXXXXXXXXXXXXXX
 
-yb-demo=# select regexp_replace('Hi my number is +999 9996-1234','[[:alpha:]]','','g');
+yb_demo=# select regexp_replace('Hi my number is +999 9996-1234','[[:alpha:]]','','g');
 
    regexp_replace
 --------------------
      +999 9996-1234
 
-yb-demo=# select 'I think I can hear an ' || repeat('echo.. ', 3) AS CLICHE;
+yb_demo=# select 'I think I can hear an ' || repeat('echo.. ', 3) AS CLICHE;
 
                    cliche
 ---------------------------------------------
  I think I can hear an echo.. echo.. echo..
 
-yb-demo=# select replace('Gees I love Windows', 'Windows', 'Linux') AS OBVIOUS;
+yb_demo=# select replace('Gees I love Windows', 'Windows', 'Linux') AS OBVIOUS;
 
       obvious
 -------------------
@@ -469,43 +469,43 @@ The `REGEXP_REPLACE` function along with the other REGEX functions require an en
 There are several ways of extracting text from text, in some cases it might be part of 'cleaning' the text, note that removing leading or trailing spaces is covered by the trim functions shown above. The remaining functions here show how parts of text can be manipulated.
 
 ```
-yb-demo=# select left('123456', 3);
+yb_demo=# select left('123456', 3);
 
  left
 ------
  123
 
-yb-demo=# select right('123456', 3);
+yb_demo=# select right('123456', 3);
 
  right
 -------
  456
 
-yb-demo=# select substr('123456', 3);
+yb_demo=# select substr('123456', 3);
 
  substr
 --------
  3456
 
-yb-demo=# select substr('123456', 3, 2);
+yb_demo=# select substr('123456', 3, 2);
 
  substr
 --------
  34
 
-yb-demo=# select substr('123456', position('4' in '123456')+1, 2);
+yb_demo=# select substr('123456', position('4' in '123456')+1, 2);
 
  substr
 --------
  56
 
-yb-demo=# select substring('123456', position('4' in '123456')+1, 2);
+yb_demo=# select substring('123456', position('4' in '123456')+1, 2);
 
  substring
 -----------
  56
 
-yb-demo=# select replace(substr(email, position('@' in email)+1, (length(email)
+yb_demo=# select replace(substr(email, position('@' in email)+1, (length(email)
             -position('.' in substr(email, position('@' in email)+1)))), '.com', '') AS "Domain", count(*)
           from users
           group by 1;
@@ -525,7 +525,7 @@ The command ```SUBSTRING``` has overloaded equivalents that accept POSIX express
 As stated above for ```REGEXP_REPLACE```, the full explanation of regular expressions requires its own comprehensive documentation that is not covered here. Here is an example illustrating its use.
 
 ```
-yb-demo=# select name as Fullname, regexp_match(name, '(.*)(\s+)(.*)') AS "REGEXED Name",
+yb_demo=# select name as Fullname, regexp_match(name, '(.*)(\s+)(.*)') AS "REGEXED Name",
           (regexp_match(name, '(.*)(\s+)(.*)'))[1] AS "First Name",
           (regexp_match(name, '(.*)(\s+)(.*)'))[3] AS "Last Name"
           from users limit 5;
@@ -546,11 +546,11 @@ In the example abov, we are asking the 'name' column to be segmented by the exis
 Now, let's look at some manipulation and splitting of text so that you can process it in pieces. For this example, I will be using a sample extract from a bank file that is used for processing payments. This example could apply if the entire file was uploaded as a single text entry into a table and you select it and then process it.
 
 ```
-yb-demo=# create table bank_payments(bank_file text);
+yb_demo=# create table bank_payments(bank_file text);
 
 CREATE TABLE
 
-yb-demo=# insert into bank_payments values($$"CMGB","1.0","95012141352105","999999","30128193018492","20","","GBP","B","Beneficiary name18","Txt on senders acc","Txt for credit acc","","","","","","909170/1","AB"
+yb_demo=# insert into bank_payments values($$"CMGB","1.0","95012141352105","999999","30128193018492","20","","GBP","B","Beneficiary name18","Txt on senders acc","Txt for credit acc","","","","","","909170/1","AB"
 "CMGB","1.0","95012141352105","999999","95012113864863","10.00","","GBP","B","Beneficiary name18","Txt on senders acc","Txt for credit acc","","","","","Remitters name  18","Tech ref for automatic processing5","AT","/t.x",
 "CMGB","1.0","95012141352105","","30128193018492","21","","GBP","C","Beneficiary name18","Txt on senders acc","","Txt for credit acc","","","","","909175/0","AB"
 "CMGB","1.0","95012141352105","","30128193018492","22","","GBP","I","Beneficiary name18","Txt on senders acc","text","","","","","","909175/1","AB"
@@ -558,7 +558,7 @@ yb-demo=# insert into bank_payments values($$"CMGB","1.0","95012141352105","9999
 
 INSERT 0 1
 
-yb-demo=# select regexp_split_to_table(bank_file, chr(10)) from bank_payments;
+yb_demo=# select regexp_split_to_table(bank_file, chr(10)) from bank_payments;
 
                                                                                                      regexp_split_to_table
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -568,7 +568,7 @@ yb-demo=# select regexp_split_to_table(bank_file, chr(10)) from bank_payments;
  "CMGB","1.0","95012141352105","","30128193018492","22","","GBP","I","Beneficiary name18","Txt on senders acc","text","","","","","","909175/1","AB"
  "CMGB","1.0","95012141352105","","30128193018492","23","","GBP","F","Beneficiary name18","Txt on senders acc","Txt for credit acc","","","","","","909171/0","AB"
 
-yb-demo=# select split_part(f.line, ',' , 8) AS "currency",
+yb_demo=# select split_part(f.line, ',' , 8) AS "currency",
                  split_part(f.line, ',' , 5) AS "Account"
                  from (select regexp_split_to_table(bank_file, chr(10)) AS "line" from bank_payments) AS f;
 
@@ -584,7 +584,7 @@ yb-demo=# select split_part(f.line, ',' , 8) AS "currency",
 _Remember to drop the table 'bank_payments' if it is no longer required._
 
 ```
-yb-demo=# select reverse(translate(replace(lower(i.input), ' ', ''),
+yb_demo=# select reverse(translate(replace(lower(i.input), ' ', ''),
                          'abcdefghijklmnopqrstuvwxyz',
                          'A8Cd349h172!mN0pQr$TuVw*yZ')) AS "simplePWD"
           from (select 'type a word here' AS "input") AS i;
@@ -601,7 +601,7 @@ The `TRANSLATE` command above will replace multiple different characters in a si
 Rather than format or change the contents of text, you often might want to understand particular attributes of the text. Below are some examples of using commands to return information of the text.
 
 ```
-yb-demo=# select x.c AS CHAR, ascii(x.c) AS ASCII
+yb_demo=# select x.c AS CHAR, ascii(x.c) AS ASCII
           from (select regexp_split_to_table(i.input, '') AS "c"
                 from (select 'hello' AS input) AS i) AS x;
   
@@ -613,13 +613,13 @@ yb-demo=# select x.c AS CHAR, ascii(x.c) AS ASCII
  l    |   108
  o    |   111
 
-yb-demo=# select bit_length('hello'), char_length('hello'), octet_length('hello');
+yb_demo=# select bit_length('hello'), char_length('hello'), octet_length('hello');
 
  bit_length | char_length | octet_length
 ------------+-------------+--------------
          40 |           5 |            5
 
-yb-demo=# select array_agg(chr(ascii(x.c))) AS "CHAR"
+yb_demo=# select array_agg(chr(ascii(x.c))) AS "CHAR"
           from (select regexp_split_to_table(i.input, '') AS "c"
                 from (select 'hello' AS input) AS i) AS x;
   
@@ -627,13 +627,13 @@ yb-demo=# select array_agg(chr(ascii(x.c))) AS "CHAR"
 -------------
  {h,e,l,l,o}
 
-yb-demo=# select avg(length(name))::int AS AVG_LENGTH from users;
+yb_demo=# select avg(length(name))::int AS AVG_LENGTH from users;
 
  avg_length
 ------------
          14
 
-yb-demo=# select name from users
+yb_demo=# select name from users
           where position('T' in name) > 2
           and position('p' in name) = length(name)
           order by name;
@@ -657,7 +657,7 @@ yb-demo=# select name from users
  Porter Tromp
  Rebeka Tromp
 
-yb-demo=# select name, position('ar' in name) AS posn, strpos(name, 'ar') as strpos
+yb_demo=# select name, position('ar' in name) AS posn, strpos(name, 'ar') as strpos
           from users
           where strpos(name, 'ark') > 0
           order by name desc limit 10;
@@ -675,7 +675,7 @@ yb-demo=# select name, position('ar' in name) AS posn, strpos(name, 'ar') as str
  Markus Hirthe  |    2 |      2
  Mark Klein     |    2 |      2
 
-yb-demo=# select m.name
+yb_demo=# select m.name
           from (select to_char(generate_series, 'Month') AS name
                 from generate_series(current_date-364, current_date, '1 month')) AS m
           where starts_with(m.name, 'J');

--- a/docs/content/latest/develop/realworld-apps/retail-analytics.md
+++ b/docs/content/latest/develop/realworld-apps/retail-analytics.md
@@ -61,15 +61,15 @@ yugabyte=#
 You can do this as shown below.
 
 ```postgresql
-yugabyte=# CREATE DATABASE yb-demo;
+yugabyte=# CREATE DATABASE yb_demo;
 ```
 
 ```postgresql
-yugabyte=# GRANT ALL ON DATABASE yb-demo to yugabyte;
+yugabyte=# GRANT ALL ON DATABASE yb_demo to yugabyte;
 ```
 
 ```postgresql
-yugabyte=# \c yb-demo;
+yugabyte=# \c yb_demo;
 ```
 
 ### Load data
@@ -103,7 +103,7 @@ yugabyte=# \i 'data/reviews.sql'
 ### How are users signing up for my site?
 
 ```postgresql
-yb-demo=# SELECT DISTINCT(source) FROM users;
+yb_demo=# SELECT DISTINCT(source) FROM users;
 ```
 
 ```
@@ -120,7 +120,7 @@ source
 ### What is the most effective channel for user signups?
 
 ```postgresql
-yb-demo=# SELECT source, count(*) AS num_user_signups
+yb_demo=# SELECT source, count(*) AS num_user_signups
           FROM users
           GROUP BY source
           ORDER BY num_user_signups DESC;
@@ -140,7 +140,7 @@ source     | num_user_signups
 ### What are the most effective channels for product sales by revenue?
 
 ```postgresql
-yb-demo=# SELECT source, ROUND(SUM(orders.total)) AS total_sales
+yb_demo=# SELECT source, ROUND(SUM(orders.total)) AS total_sales
           FROM users, orders WHERE users.id=orders.user_id
           GROUP BY source
           ORDER BY total_sales DESC;
@@ -160,7 +160,7 @@ source     | total_sales
 ### What is the min, max and average price of products in the store?
 
 ```postgresql
-yb-demo=# SELECT MIN(price), MAX(price), AVG(price) FROM products;
+yb_demo=# SELECT MIN(price), MAX(price), AVG(price) FROM products;
 ```
 
 ```
@@ -175,7 +175,7 @@ min               |       max        |       avg
 You can do this as shown below.
 
 ```postgresql
-yb-demo=# CREATE VIEW channel AS
+yb_demo=# CREATE VIEW channel AS
             (SELECT source, ROUND(SUM(orders.total)) AS total_sales
              FROM users, orders
              WHERE users.id=orders.user_id
@@ -186,7 +186,7 @@ yb-demo=# CREATE VIEW channel AS
 Now that the view is created, we can see it in our list of relations.
 
 ```postgresql
-yb-demo=# \d
+yb_demo=# \d
 ```
 
 ```
@@ -202,7 +202,7 @@ List of relations
 ```
 
 ```postgresql
-yb-demo=# SELECT source, total_sales * 100.0 / (SELECT SUM(total_sales) FROM channel) AS percent_sales
+yb_demo=# SELECT source, total_sales * 100.0 / (SELECT SUM(total_sales) FROM channel) AS percent_sales
           FROM channel WHERE source='Facebook';
 ```
 

--- a/docs/content/latest/quick-start/build-apps/ysql/csharp.md
+++ b/docs/content/latest/quick-start/build-apps/ysql/csharp.md
@@ -33,7 +33,7 @@ namespace Yugabyte_CSharp_Demo
     {
         static void Main(string[] args)
         {
-            NpgsqlConnection conn = new NpgsqlConnection("host=localhost;port=5433;database=yb-demo;user id=yugabyte;password=");
+            NpgsqlConnection conn = new NpgsqlConnection("host=localhost;port=5433;database=yb_demo;user id=yugabyte;password=");
 
             try
             {

--- a/docs/content/latest/quick-start/explore-ysql/_index.md
+++ b/docs/content/latest/quick-start/explore-ysql/_index.md
@@ -88,40 +88,40 @@ Open the YSQL shell (`ysqlsh) by running the following command.
   </div>
 </div>
 
-1. Create a database (`yb-demo`) by using the following `CREATE DATABASE` command.
+1. Create a database (`yb_demo`) by using the following `CREATE DATABASE` command.
 
     ```postgresql
-    yugabyte=# CREATE DATABASE yb-demo;
+    yugabyte=# CREATE DATABASE yb_demo;
     ```
 
 2. Connect to the new database using the following YSQL shell `\c` meta command.
 
     ```postgresql
-    yugabyte=# \c yb-demo;
+    yugabyte=# \c yb_demo;
     ```
 
 3. Create the database schema, which includes four tables, by running the following `\i` meta command.
 
     ```postgresql
-    yb-demo=# \i share/schema.sql;
+    yb_demo=# \i share/schema.sql;
     ```
 
 4. Load the data into the tables by running the following four `\i` commands.
 
     ```postgresql
-    yb-demo=# \i share/products.sql
+    yb_demo=# \i share/products.sql
     ```
 
     ```postgresql
-    yb-demo=# \i share/users.sql
+    yb_demo=# \i share/users.sql
     ```
 
     ```postgresql
-    yb-demo=# \i share/orders.sql
+    yb_demo=# \i share/orders.sql
     ```
 
     ```postgresql
-    yb-demo=# \i share/reviews.sql
+    yb_demo=# \i share/reviews.sql
     ```
 
     You now have sample data and are ready to begin exploring YSQL in YugabyteDB.
@@ -131,7 +131,7 @@ Open the YSQL shell (`ysqlsh) by running the following command.
 Lets us look at the schema of the `products` table. You can do this as follows:
 
 ```postgresql
-yb-demo=# \d products
+yb_demo=# \d products
 ```
 
 You should see an output like the following:
@@ -156,7 +156,7 @@ Indexes:
 To see how many products there are in this table, you can run the following query.
 
 ```postgresql
-yb-demo=# SELECT count(*) FROM products;
+yb_demo=# SELECT count(*) FROM products;
 ```
 
 You should see an output which looks like the following:
@@ -171,7 +171,7 @@ You should see an output which looks like the following:
 Now let us run a query to select the `id`, `title`, `category` and `price` columns for the first five products.
 
 ```postgresql
-yb-demo=# SELECT id, title, category, price, rating
+yb_demo=# SELECT id, title, category, price, rating
           FROM products
           LIMIT 5;
 ```
@@ -192,7 +192,7 @@ You should see an output like the following:
 To view the next 3 products, we simply add an `OFFSET 5` clause to start from the fifth product.
 
 ```postgresql
-yb-demo=# SELECT id, title, category, price, rating
+yb_demo=# SELECT id, title, category, price, rating
           FROM products
           LIMIT 3 OFFSET 5;
 ```
@@ -215,7 +215,7 @@ A JOIN clause is used to combine rows from two or more tables, based on a relate
 From the `orders` table, we are going to select the `total` column that represents the total amount the user paid. For each of these orders, we are going to fetch the `id`, the `name` and the `email` from the `users` table of the corresponding users that placed those orders. The related column between the two tables is the user's id. This can be expressed as the following join query:
 
 ```postgresql
-yb-demo=# SELECT users.id, users.name, users.email, orders.id, orders.total
+yb_demo=# SELECT users.id, users.name, users.email, orders.id, orders.total
           FROM orders INNER JOIN users ON orders.user_id=users.id
           LIMIT 10;
 ```
@@ -247,7 +247,7 @@ Imagine the user with id `1` wants to order for `10` units of the product with i
 Before running the transaction, we can verify that we have `5000` units of product `2` in stock by running the following query:
 
 ```postgresql
-yb-demo=# SELECT id, category, price, quantity FROM products WHERE id=2;
+yb_demo=# SELECT id, category, price, quantity FROM products WHERE id=2;
 ```
 
 ```
@@ -261,7 +261,7 @@ SELECT id, category, price, quantity FROM products WHERE id=2;
 Now, to place the order, we can run the following transaction:
 
 ```postgresql
-yb-demo=# BEGIN TRANSACTION;
+yb_demo=# BEGIN TRANSACTION;
 
 /* First insert a new order into the orders table. */
 INSERT INTO orders
@@ -287,7 +287,7 @@ COMMIT;
 We can verify that the order got inserted by running the following:
 
 ```postgresql
-yb-demo=# select * from orders where id = (select max(id) from orders);
+yb_demo=# select * from orders where id = (select max(id) from orders);
 ```
 
 ```
@@ -300,7 +300,7 @@ yb-demo=# select * from orders where id = (select max(id) from orders);
 We can also verify that total quantity of product id `2` in the inventory is `4990` by running the following query.
 
 ```postgresql
-yb-demo=# SELECT id, category, price, quantity FROM products WHERE id=2;
+yb_demo=# SELECT id, category, price, quantity FROM products WHERE id=2;
 ```
 
 ```
@@ -319,7 +319,7 @@ YSQL supports a rich set of built-in functions. In this example, we will look at
 To answer this question, we should list the unique set of `source` channels present in the database. This can be achieved as follows:
 
 ```postgresql
-yb-demo=# SELECT DISTINCT(source) FROM users;
+yb_demo=# SELECT DISTINCT(source) FROM users;
 ```
 
 ```
@@ -336,7 +336,7 @@ source
 - What is the min, max and average price of products in the store?
 
 ```postgresql
-yb-demo=# SELECT MIN(price), MAX(price), AVG(price) FROM products;
+yb_demo=# SELECT MIN(price), MAX(price), AVG(price) FROM products;
 ```
 
 ```
@@ -353,7 +353,7 @@ The `GROUP BY` clause is commonly used to perform aggregations. Below are a coup
 - What is the most effective channel for user signups?
 
 ```postgresql
-yb-demo=# SELECT source, count(*) AS num_user_signups
+yb_demo=# SELECT source, count(*) AS num_user_signups
           FROM users
           GROUP BY source
           ORDER BY num_user_signups DESC;
@@ -373,7 +373,7 @@ source     | num_user_signups
 - What are the most effective channels for product sales by revenue?
 
 ```postgresql
-yb-demo=# SELECT source, ROUND(SUM(orders.total)) AS total_sales
+yb_demo=# SELECT source, ROUND(SUM(orders.total)) AS total_sales
           FROM users, orders WHERE users.id=orders.user_id
           GROUP BY source
           ORDER BY total_sales DESC;
@@ -397,7 +397,7 @@ Let us answer the questions below by creating a view.
 - What percentage of the total sales is from the Facebook channel?
 
 ```postgresql
-yb-demo=# CREATE VIEW channel AS
+yb_demo=# CREATE VIEW channel AS
             (SELECT source, ROUND(SUM(orders.total)) AS total_sales
              FROM users, orders
              WHERE users.id=orders.user_id
@@ -408,7 +408,7 @@ yb-demo=# CREATE VIEW channel AS
 Now that the view is created, we can see it in our list of relations.
 
 ```postgresql
-yb-demo=# \d
+yb_demo=# \d
 ```
 
 ```
@@ -428,7 +428,7 @@ yb-demo=# \d
 ```
 
 ```postgresql
-yb-demo=# SELECT source, 
+yb_demo=# SELECT source, 
             total_sales * 100.0 / (SELECT SUM(total_sales) FROM channel) AS percent_sales
           FROM channel
           WHERE source='Facebook';

--- a/docs/content/latest/quick-start/explore-ysql/kubernetes/explore-ysql.md
+++ b/docs/content/latest/quick-start/explore-ysql/kubernetes/explore-ysql.md
@@ -2,7 +2,7 @@
 To open the YSQL shell (`ysqlsh`), run the following.
 
 ```sh
-$ kubectl --namespace yb-demo exec -it yb-tserver-0 /home/yugabyte/bin/ysqlsh -- -h yb-tserver-0  --echo-queries
+$ kubectl --namespace yb_demo exec -it yb-tserver-0 /home/yugabyte/bin/ysqlsh -- -h yb-tserver-0  --echo-queries
 ```
 
 ```


### PR DESCRIPTION
Use of hyphen causes issues with `ysqlsh`. Also, apparently, Oracle and PostgreSQL don't allow hyphens in identifiers. Need to review why Kubernetes examples all use `yb-demo` in namespaces, etc.