### PR TITLE
Add support for current version of the internet protocol (IPv6). 

### DIFF
--- a/src/yb/integration-tests/external_mini_cluster.cc
+++ b/src/yb/integration-tests/external_mini_cluster.cc
@@ -932,7 +932,7 @@ string ExternalMiniCluster::GetTabletServerAddresses() const {
     if (!peer_addrs.empty()) {
       peer_addrs += ",";
     }
-    peer_addrs += Format("$0:$1", ts->bind_host(), ts->rpc_port());
+    peer_addrs += HostPortToString(ts->bind_host(), ts->rpc_port());
   }
   return peer_addrs;
 }

--- a/src/yb/master/master-path-handlers.cc
+++ b/src/yb/master/master-path-handlers.cc
@@ -180,10 +180,10 @@ void MasterPathHandlers::CallIfLeaderOrPrintRedirect(
       }
 
       if (master.role() == consensus::RaftPeerPB::LEADER) {
-        // URI already starts with a /, so none is needed between $1 and $2.
-        redirect = Substitute("http://$0:$1$2$3",
-                              master.registration().http_addresses(0).host(),
-                              master.registration().http_addresses(0).port(),
+        // URI already starts with a /, so none is needed between $0 and $1.
+        redirect = Substitute("http://$0$1$2",
+                              HostPortToString(master.registration().http_addresses(0).host(),
+                                               master.registration().http_addresses(0).port()),
                               req.redirect_uri,
                               req.query_string.empty() ? "?raw" : "?" + req.query_string + "&raw");
         break;
@@ -265,9 +265,8 @@ void MasterPathHandlers::TServerDisplay(const std::string& current_uuid,
     if (desc->placement_uuid() == current_uuid) {
       const string time_since_hb = StringPrintf("%.1fs", desc->TimeSinceHeartbeat().ToSeconds());
       TSRegistrationPB reg = desc->GetRegistration();
-      string host_port = Substitute("$0:$1",
-                                    reg.common().http_addresses(0).host(),
-                                    reg.common().http_addresses(0).port());
+      string host_port = HostPortToString(reg.common().http_addresses(0).host(),
+                                          reg.common().http_addresses(0).port());
       *output << "  <tr>\n";
       *output << "  <td>" << RegistrationToHtml(reg.common(), host_port) << "</br>";
       *output << "  " << desc->permanent_uuid() << "</td>";
@@ -507,9 +506,8 @@ void MasterPathHandlers::HandleGetTserverStatus(const Webserver::WebRequest& req
     for (auto desc : descs) {
       if (desc->placement_uuid() == cur_uuid) {
         TSRegistrationPB reg = desc->GetRegistration();
-        string host_port = Substitute("$0:$1",
-                                      reg.common().http_addresses(0).host(),
-                                      reg.common().http_addresses(0).port());
+        string host_port = HostPortToString(reg.common().http_addresses(0).host(),
+                                            reg.common().http_addresses(0).port());
         jw.String(host_port);
 
         jw.StartObject();
@@ -932,10 +930,10 @@ void MasterPathHandlers::RootHandler(const Webserver::WebRequest& req,
         }
 
         if (master.role() == consensus::RaftPeerPB::LEADER) {
-          // URI already starts with a /, so none is needed between $1 and $2.
-          redirect = Substitute("http://$0:$1$2$3",
-                                master.registration().http_addresses(0).host(),
-                                master.registration().http_addresses(0).port(),
+          // URI already starts with a /, so none is needed between $0 and $1.
+          redirect = Substitute("http://$0$1$2",
+                                HostPortToString(master.registration().http_addresses(0).host(),
+                                                 master.registration().http_addresses(0).port()),
                                 req.redirect_uri,
                                 req.query_string.empty() ? "?raw" :
                                                            "?" + req.query_string + "&raw");
@@ -1120,8 +1118,8 @@ void MasterPathHandlers::HandleMasters(const Webserver::WebRequest& req,
       continue;
     }
     auto reg = master.registration();
-    string host_port = Substitute("$0:$1",
-                                  reg.http_addresses(0).host(), reg.http_addresses(0).port());
+    string host_port = HostPortToString(reg.http_addresses(0).host(),
+                                        reg.http_addresses(0).port());
     string reg_text = RegistrationToHtml(reg, host_port);
     if (master.instance_id().permanent_uuid() == master_->instance_pb().permanent_uuid()) {
       reg_text = Substitute("<b>$0</b>", reg_text);
@@ -1267,7 +1265,7 @@ class JsonTabletDumper : public Visitor<PersistentTabletInfo>, public JsonDumper
 
         jw_->String("addr");
         const auto& host_port = peer.last_known_private_addr()[0];
-        jw_->String(Format("$0:$1", host_port.host(), host_port.port()));
+        jw_->String(HostPortToString(host_port.host(), host_port.port()));
 
         jw_->EndObject();
       }
@@ -1418,8 +1416,10 @@ string MasterPathHandlers::TSDescriptorToHtml(const TSDescriptor& desc,
 
   if (reg.common().http_addresses().size() > 0) {
     return Substitute(
-        "<a href=\"http://$0:$1/tablet?id=$2\">$3</a>", reg.common().http_addresses(0).host(),
-        reg.common().http_addresses(0).port(), EscapeForHtmlToString(tablet_id),
+        "<a href=\"http://$0/tablet?id=$1\">$2</a>",
+        HostPortToString(reg.common().http_addresses(0).host(),
+                         reg.common().http_addresses(0).port()),
+        EscapeForHtmlToString(tablet_id),
         EscapeForHtmlToString(reg.common().http_addresses(0).host()));
   } else {
     return EscapeForHtmlToString(desc.permanent_uuid());
@@ -1430,9 +1430,10 @@ string MasterPathHandlers::RegistrationToHtml(
     const ServerRegistrationPB& reg, const std::string& link_text) const {
   string link_html = EscapeForHtmlToString(link_text);
   if (reg.http_addresses().size() > 0) {
-    link_html = Substitute("<a href=\"http://$0:$1/\">$2</a>",
-                           reg.http_addresses(0).host(),
-                           reg.http_addresses(0).port(), link_html);
+    link_html = Substitute("<a href=\"http://$0/\">$1</a>",
+                           HostPortToString(reg.http_addresses(0).host(),
+                                            reg.http_addresses(0).port()),
+                           link_html);
   }
   return link_html;
 }

--- a/src/yb/master/master_main.cc
+++ b/src/yb/master/master_main.cc
@@ -66,7 +66,7 @@ namespace master {
 
 static int MasterMain(int argc, char** argv) {
   // Reset some default values before parsing gflags.
-  FLAGS_rpc_bind_addresses = strings::Substitute("0.0.0.0:$0", kMasterDefaultPort);
+  FLAGS_rpc_bind_addresses = strings::Substitute("[::]:$0", kMasterDefaultPort);
   FLAGS_webserver_port = kMasterDefaultWebPort;
   FLAGS_default_memory_limit_to_ram_ratio = 0.10;
   // For masters we always want to fsync the WAL files.

--- a/src/yb/server/rpc_server.cc
+++ b/src/yb/server/rpc_server.cc
@@ -57,7 +57,7 @@ using strings::Substitute;
 using std::unique_ptr;
 using std::make_unique;
 
-DEFINE_string(rpc_bind_addresses, "0.0.0.0",
+DEFINE_string(rpc_bind_addresses, "::",
               "Comma-separated list of addresses to bind to for RPC connections. "
               "Currently, ephemeral ports (i.e. port 0) are not allowed.");
 TAG_FLAG(rpc_bind_addresses, stable);

--- a/src/yb/server/server_base.cc
+++ b/src/yb/server/server_base.cc
@@ -107,7 +107,7 @@ using strings::Substitute;
 namespace yb {
 namespace server {
 
-static const string kWildCardHostAddress = "0.0.0.0";
+static const string kWildCardHostAddress = "::";
 
 namespace {
 
@@ -596,7 +596,7 @@ std::string TEST_RpcAddress(int index, Private priv) {
 }
 
 string TEST_RpcBindEndpoint(int index, uint16_t port) {
-  return Format("$0:$1", TEST_RpcAddress(index, Private::kTrue), port);
+  return HostPortToString(TEST_RpcAddress(index, Private::kTrue), port);
 }
 
 constexpr int kMaxServers = 20;

--- a/src/yb/server/webserver.cc
+++ b/src/yb/server/webserver.cc
@@ -98,7 +98,7 @@ Webserver::Webserver(const WebserverOptions& opts, const std::string& server_nam
   : opts_(opts),
     context_(nullptr),
     server_name_(server_name) {
-  string host = opts.bind_interface.empty() ? "0.0.0.0" : opts.bind_interface;
+  string host = opts.bind_interface.empty() ? "[::]" : opts.bind_interface;
   http_address_ = host + ":" + boost::lexical_cast<string>(opts.port);
 }
 

--- a/src/yb/tools/yb-admin_client.cc
+++ b/src/yb/tools/yb-admin_client.cc
@@ -106,7 +106,7 @@ static constexpr const char* kDBTypePrefixRedis = "yedis";
 
 
 string FormatHostPort(const HostPortPB& host_port) {
-  return Format("$0:$1", host_port.host(), host_port.port());
+  return HostPortToString(host_port.host(), host_port.port());
 }
 
 string FormatFirstHostPort(

--- a/src/yb/tserver/tablet_server.cc
+++ b/src/yb/tserver/tablet_server.cc
@@ -415,9 +415,8 @@ TabletServiceImpl* TabletServer::tablet_server_service() {
 
 string GetDynamicUrlTile(const string path, const string host, const int port) {
 
-  vector<std::string> parsed_hostname = strings::Split(host, ":");
-  std::string link = strings::Substitute("http://$0:$1$2",
-                                         parsed_hostname[0], yb::ToString(port), path);
+  std::string link = strings::Substitute("http://$0$1",
+                                         HostPortToString(host, port), path);
   return link;
 }
 

--- a/src/yb/util/net/dns_resolver.cc
+++ b/src/yb/util/net/dns_resolver.cc
@@ -136,12 +136,10 @@ Result<InetAddress> PickResolvedAddress(
   if (error) {
     return STATUS_FORMAT(NetworkError, "Resolve failed $0: $1", host, error.message());
   }
-  std::vector<InetAddress> addresses, addresses_v6;
+  std::vector<InetAddress> addresses;
   for (const auto& entry : entries) {
-    auto& dest = entry.endpoint().address().is_v4() ? addresses : addresses_v6;
-    dest.emplace_back(entry.endpoint().address());
+    addresses.emplace_back(entry.endpoint().address());
   }
-  addresses.insert(addresses.end(), addresses_v6.begin(), addresses_v6.end());
   if (addresses.empty()) {
     return STATUS_FORMAT(NetworkError, "No endpoints resolved for: $0", host);
   }

--- a/thirdparty/build_definitions/squeasel.py
+++ b/thirdparty/build_definitions/squeasel.py
@@ -27,7 +27,7 @@ class SqueaselDependency(Dependency):
 
     def build(self, builder):
         log_prefix = builder.log_prefix(self)
-        compile_command = [builder.get_c_compiler(), '-std=c99', '-O3', '-DNDEBUG', '-fPIC', '-c',
+        compile_command = [builder.get_c_compiler(), '-std=c99', '-O3', '-DNDEBUG', '-DUSE_IPV6', '-fPIC', '-c',
                            'squeasel.c']
         compile_command += builder.compiler_flags + builder.c_flags
         log_output(log_prefix, compile_command)


### PR DESCRIPTION
Also:
Fix incorrect preference for the legacy IP in resolver. 
Listen on IPv6 (and IPv4) by default.

Fixes #3644 
Possible shortcomings: 
1. Previously, the ParseString function accepted white space, not any more as I'm not sure that's the right place for it.
2. I'm not entirely familiar with the strings library and the use of Format vs Substitute and if they allocate memory. I've assumed they do the same thing and have standardized on where I've replaced calls.
3. ybmaster starts and works, but have not run the entire testsuite, nor extended the test suite with tests
