### PR TITLE
[#3454] Make OpenSSL usage thread-safe

### DIFF
--- a/src/yb/rpc/secure_stream.cc
+++ b/src/yb/rpc/secure_stream.cc
@@ -27,6 +27,7 @@
 #include "yb/util/logging.h"
 #include "yb/util/scope_exit.h"
 #include "yb/util/size_literals.h"
+#include "yb/util/encryption_util.h"
 
 using namespace std::literals;
 
@@ -39,18 +40,6 @@ namespace rpc {
 namespace {
 
 const unsigned char kContextId[] = { 'Y', 'u', 'g', 'a', 'B', 'y', 't', 'e' };
-
-std::vector<std::unique_ptr<std::mutex>> crypto_mutexes;
-
-__attribute__((unused)) void NO_THREAD_SAFETY_ANALYSIS LockingCallback(
-    int mode, int n, const char* /*file*/, int /*line*/) {
-  CHECK_LT(static_cast<size_t>(n), crypto_mutexes.size());
-  if (mode & CRYPTO_LOCK) {
-    crypto_mutexes[n]->lock();
-  } else {
-    crypto_mutexes[n]->unlock();
-  }
-}
 
 std::string SSLErrorMessage(int error) {
   auto message = ERR_reason_error_string(error);
@@ -204,35 +193,6 @@ Result<detail::X509Ptr> CreateCertificate(
   return std::move(cert);
 }
 
-class OpenSSLInitializer {
- public:
-  OpenSSLInitializer() {
-    SSL_library_init();
-    SSL_load_error_strings();
-    OpenSSL_add_all_algorithms();
-    OpenSSL_add_all_ciphers();
-
-    while (crypto_mutexes.size() != CRYPTO_num_locks()) {
-      crypto_mutexes.emplace_back(std::make_unique<std::mutex>());
-    }
-    CRYPTO_set_locking_callback(&LockingCallback);
-  }
-
-  ~OpenSSLInitializer() {
-    CRYPTO_set_locking_callback(nullptr);
-    ERR_free_strings();
-    EVP_cleanup();
-    CRYPTO_cleanup_all_ex_data();
-    ERR_remove_thread_state(nullptr);
-    SSL_COMP_free_compression_methods();
-  }
-};
-
-OpenSSLInitializer* InitOpenSSL() {
-  static std::unique_ptr<OpenSSLInitializer> initializer = std::make_unique<OpenSSLInitializer>();
-  return initializer.get();
-}
-
 } // namespace
 
 namespace detail {
@@ -246,7 +206,7 @@ YB_RPC_SSL_TYPE_DEFINE(X509)
 }
 
 SecureContext::SecureContext() {
-  InitOpenSSL();
+  yb::enterprise::InitOpenSSL();
 
   context_.reset(SSL_CTX_new(SSLv23_method()));
   DCHECK(context_);

--- a/src/yb/server/server_base.cc
+++ b/src/yb/server/server_base.cc
@@ -73,6 +73,7 @@
 #include "yb/util/spinlock_profiling.h"
 #include "yb/util/thread.h"
 #include "yb/util/version_info.h"
+#include "yb/util/encryption_util.h"
 #include "yb/gutil/sysinfo.h"
 
 DEFINE_int32(num_reactor_threads, -1,
@@ -440,6 +441,8 @@ void RpcAndWebServerBase::GenerateInstanceID() {
 }
 
 Status RpcAndWebServerBase::Init() {
+  yb::enterprise::InitOpenSSL();
+
   Status s = fs_manager_->Open();
   if (s.IsNotFound() || (!s.ok() && fs_manager_->HasAnyLockFiles())) {
     LOG(INFO) << "Could not load existing FS layout: " << s.ToString();

--- a/src/yb/util/CMakeLists.txt
+++ b/src/yb/util/CMakeLists.txt
@@ -276,6 +276,7 @@ set(UTIL_LIBS
   encryption_proto
   zlib
   ${OPENSSL_CRYPTO_LIBRARY}
+  ${OPENSSL_SSL_LIBRARY}
   ${UTIL_LIBS_EXTENSIONS})
 
 if (NOT APPLE AND NOT USING_LINUXBREW)
@@ -487,3 +488,6 @@ endif()
 
 ADD_YB_TEST(encrypted_env-test)
 target_link_libraries(encrypted_env-test encryption_test_util)
+
+ADD_YB_TEST(ctr_cipher_stream-test)
+target_link_libraries(ctr_cipher_stream-test encryption_test_util)

--- a/src/yb/util/ctr_cipher_stream-test.cc
+++ b/src/yb/util/ctr_cipher_stream-test.cc
@@ -1,0 +1,90 @@
+// Copyright (c) YugaByte, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include <sys/types.h>
+
+#include <string>
+
+#include "yb/rocksutil/rocksdb_encrypted_file_factory.h"
+
+#include "yb/util/status.h"
+#include "yb/util/test_util.h"
+#include "yb/util/header_manager.h"
+#include "yb/util/header_manager_mock_impl.h"
+#include "yb/util/encryption_test_util.h"
+#include "yb/util/cipher_stream.h"
+
+#include "yb/util/random_util.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+namespace yb {
+namespace enterprise {
+
+class TestCipherStream : public YBTest {};
+
+TEST_F(TestCipherStream, ConcurrentEncryption) {
+  InitOpenSSL();
+
+  constexpr int kBufSize = 10000;
+  constexpr int kNumRuns = 10000;
+  auto plaintext_bytes = RandomBytes(kBufSize);
+  uint8_t encrypted_bytes[kBufSize];
+  auto encryption_params = EncryptionParams::NewEncryptionParams();
+  auto cipher_stream  = ASSERT_RESULT(BlockAccessCipherStream::FromEncryptionParams(
+      std::move(encryption_params)));
+  ASSERT_OK(cipher_stream->Encrypt(0, Slice(plaintext_bytes.data(), kBufSize), encrypted_bytes));
+
+  std::function<void(bool)> f = [&](bool encrypt) {
+    uint8_t result[kBufSize];
+    int start = RandomUniformInt(0, kBufSize);
+    int size = RandomUniformInt(0, kBufSize - start);
+
+    uint8_t* start_data = encrypt ? plaintext_bytes.data() : encrypted_bytes;
+    uint8_t* verify_data = encrypt ? encrypted_bytes : plaintext_bytes.data();
+
+
+    ASSERT_OK(cipher_stream->Encrypt(start, Slice(start_data + start, size), result));
+    ASSERT_EQ(Slice(verify_data + start, size), Slice(result, result + size));
+  };
+
+  std::vector<std::thread> threads;
+  // Create 20 encrypt threads
+  for (int i = 0; i < 20; i++) {
+    threads.emplace_back([&]() {
+      for (int i = 0; i < kNumRuns; i++) {
+        // Do this to trigger use of openssl RAND_bytes
+        EncryptionParams::NewEncryptionParams();
+        ASSERT_NO_FATALS(f(true /* encrypt */));
+      }
+    });
+  }
+
+  // Create 20 decrypt threads
+  for (int i = 0; i < 20; i++) {
+    threads.emplace_back([&]() {
+      for (int i = 0; i < kNumRuns; i++) {
+        EncryptionParams::NewEncryptionParams();
+        ASSERT_NO_FATALS(f(false /* encrypt */));
+      }
+    });
+  }
+
+  for (int i = 0; i < threads.size(); i++) {
+    threads[i].join();
+  }
+}
+
+} // namespace enterprise
+} // namespace yb

--- a/src/yb/util/encryption_util.h
+++ b/src/yb/util/encryption_util.h
@@ -30,6 +30,7 @@ namespace enterprise {
 
 class HeaderManager;
 class BlockAccessCipherStream;
+class OpenSSLInitializer;
 
 // Struct generated for encryption status of existing files.
 struct FileEncryptionStatus {
@@ -178,6 +179,8 @@ Status CreateWritableFile(WritablePtr* result,
 }
 
 Result<uint32_t> GetHeaderSize(SequentialFile* file, HeaderManager* header_manager);
+
+OpenSSLInitializer& InitOpenSSL();
 
 } // namespace enterprise
 } // namespace yb


### PR DESCRIPTION
Summary:
https://www.openssl.org/docs/man1.0.2/man3/CRYPTO_set_locking_callback.html

Set a locking and thread id callback to enable thread-safe usage for openssl. Move the openssl init process to a once per-process initialization in RpcServerBase.

Test Plan: ybd --cxx-test ctr_cipher_stream-test --gtest_filter TestCipherStream.ConcurrentEncryption

Reviewers: mikhail, sergei

Reviewed By: sergei

Subscribers: ybase, bogdan

Differential Revision: https://phabricator.dev.yugabyte.com/D7862