### PR TITLE
Adding to contributor list

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -89,3 +89,4 @@ This is a list of people who have contributed code to the [YugabyteDB](https://g
 * [graffido](https://github.com/graffido)
 * [svanellewee](https://github.com/svanellewee)
 * [ghaskins](https://github.com/ghaskins)
+* [Klins](https://github.com/carlos-username)


### PR DESCRIPTION
Extending functionality for YugabyteDB in order to orchestrate it on aws via ansible.
[issue description] (https://github.com/yugabyte/yugabyte-db/issues/3677)