### PR TITLE
[docs] Add auto-generated, custom sitemap.xml to docs.yugabyte.com

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -7,6 +7,7 @@ canonifyurls: false
 googleAnalytics: UA-104956980-3
 pygmentsCodefences: true
 pygmentsStyle: "pygments"
+enableGitInfo: true
 
 
 params:

--- a/docs/layouts/_default/sitemap.xml
+++ b/docs/layouts/_default/sitemap.xml
@@ -1,0 +1,17 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" 
+    xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{ range .Data.Pages }}
+    {{ if not .Site.Menus.latest }}
+    <url>
+        <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+        <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+        <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
+        <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
+        <xhtml:link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .Permalink }}" />
+{{ end }}
+        <xhtml:link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .Permalink }}" />
+{{ end }}
+    </url>
+  {{ end }}
+</urlset>

--- a/docs/layouts/_default/sitemap.xml
+++ b/docs/layouts/_default/sitemap.xml
@@ -1,17 +1,15 @@
-{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" 
-    xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  {{ range .Data.Pages }}
-    {{ if not .Site.Menus.latest }}
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {{ range .Data.Pages }}{{ range where .Pages "Section" "latest" }}
     <url>
-        <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
-        <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
-        <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
-        <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
-        <xhtml:link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .Permalink }}" />
+<loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+<lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+<changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
+<priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
+<xhtml:link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}" />
 {{ end }}
-        <xhtml:link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .Permalink }}" />
+<xhtml:link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}" />
 {{ end }}
     </url>
-  {{ end }}
+  {{ end }}{{ end }}
 </urlset>

--- a/docs/layouts/_default/sitemap.xml
+++ b/docs/layouts/_default/sitemap.xml
@@ -4,9 +4,7 @@
   {{ range where .Pages "Section" "latest" }}
     <url>
 <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
-<lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
-<changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
-<priority>{{ .Sitemap.Priority }}</priority>{{ end }}
+<lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02" ) }}</lastmod>{{ end }}
     </url>
   {{ end }}{{ end }}
 </urlset>

--- a/docs/layouts/_default/sitemap.xml
+++ b/docs/layouts/_default/sitemap.xml
@@ -1,15 +1,12 @@
 {{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  {{ range .Data.Pages }}{{ range where .Pages "Section" "latest" }}
+  {{ range .Data.Pages }}
+  {{ range where .Pages "Section" "latest" }}
     <url>
 <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
-<lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+<lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
 <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
-<priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
-<xhtml:link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}" />
-{{ end }}
-<xhtml:link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}" />
-{{ end }}
+<priority>{{ .Sitemap.Priority }}</priority>{{ end }}
     </url>
   {{ end }}{{ end }}
 </urlset>


### PR DESCRIPTION
This PR adds an auto-generated, custom `sitemap.xml` file that only includes the `/latest/` URLs. 
- As the existing Google Search cached files expire, users will see only the latest docs in their search results.
- Users can continue to find docs for older versions using the DocSearch search on our site.

During testing, Hugo generated 3559 pages. The auto-generated sitemap includes only 1443 files.