### PR TITLE
[docs] fixup server-certificates.md code formatting

### DIFF
--- a/docs/content/latest/secure/tls-encryption/server-certificates.md
+++ b/docs/content/latest/secure/tls-encryption/server-certificates.md
@@ -211,7 +211,7 @@ Certificate:
          b4:9d:39:57:58:6c:b3:8e:25:e3:86:24:13:59:d6:a0:d2:f0:
          15:1e:8c:24:44:5b:3a:db:1c:ef:60:70:24:58:df:56:99:aa:
          22:78:12:d6
-         ```
+```
 
 ## Copy the root certificate to each node directory
 
@@ -259,7 +259,7 @@ distinguished_name = my_distinguished_name
 organizationName = Yugabyte
 # Required value for commonName, do not change.
 commonName = <node-ip-address>
-    ```
+```
 
 3. After pasting the content in step 2 and replacing `<node-ip-address>` with the node IP address, save and close the file by entering `Ctl+D`.
 


### PR DESCRIPTION
Fixes triple-hash-tick (?) indentation to properly render the document.

Keep in mind I have NOT ran the code to render this locally on my machine, only used the markdown editor on github, so it may be beneficial to double-check the rendering is 100% fixed first. I can definitely do that a bit later if desired. Sorry, don't mean to be lazy, but... I'm being a little lazy 🤷‍♂ 

Current rendering looks a little off:

<img width="893" alt="Screen Shot 2020-03-04 at 1 11 33 PM" src="https://user-images.githubusercontent.com/5619476/75914148-de993f80-5e19-11ea-8a6f-70c3e389c120.png">
