### PR TITLE
[docs] Update robots.txt to exclude .diagram and .grammar files from Google Search indexing

### DIFF
--- a/docs/content/latest/api/ysql/syntax_resources/commands/foo
+++ b/docs/content/latest/api/ysql/syntax_resources/commands/foo
@@ -1,1 +1,0 @@
-cp drop_owned,role_specification.diagram.md alter_default_privileges,abbr_gr_table,abbr_gr_seq,abbr_gr_func,abbr_gr_type,abbr_gr_schema,abbr_rev_table,abbr_rev_seq,abbr_rev_func,abbr_rev_type,abbr_rev_schema,gr_table_privileges,gr_seq_privileges,gr_role_spec.diagram.md

--- a/docs/static/robots.txt
+++ b/docs/static/robots.txt
@@ -1,4 +1,4 @@
 Sitemap: https://docs.yugabyte.com/sitemap.xml
 User-agent: *
-Disallow: /latest/api/ysql/syntax_resources/commands/*.diagram
-Disallow: /latest/api/ysql/syntax_resources/commands/*.grammar
+Disallow: /latest/api/ysql/syntax_resources/
+Allow: /latest/api/ysql/syntax_resources/grammar_diagrams/

--- a/docs/static/robots.txt
+++ b/docs/static/robots.txt
@@ -1,2 +1,4 @@
+Sitemap: https://docs.yugabyte.com/sitemap.xml
 User-agent: *
-Disallow: /v1.0/
+Disallow: /latest/api/ysql/syntax_resources/commands/*.diagram
+Disallow: /latest/api/ysql/syntax_resources/commands/*.grammar


### PR DESCRIPTION
Update `robots.txt` to:
- include link to `sitemap.xml`/latest/api/ysql/syntax_resources/commands/*.diagram
- disallow the following files:/latest/api/ysql/syntax_resources/commands/*.grammar

Based on discussion with @m-iancu 