### PR TITLE
[docs] Fix links and copy command 

### DIFF
--- a/docs/content/latest/secure/tls-encryption/_index.html
+++ b/docs/content/latest/secure/tls-encryption/_index.html
@@ -27,7 +27,7 @@ Follow the steps in this section to learn how to enable encryption using TLS for
 <div class="row">
 
   <div class="col-12 col-md-6 col-lg-12 col-xl-6">
-    <a class="section-link icon-offset" href="prepare-nodes/">
+    <a class="section-link icon-offset" href="server-certificates/">
       <div class="head">
         <img class="icon" src="/images/section_icons/secure/tls-encryption/prepare-nodes.png" aria-hidden="true" />
         <div class="title">Create server certificates</div>
@@ -39,7 +39,7 @@ Follow the steps in this section to learn how to enable encryption using TLS for
   </div>
 
   <div class="col-12 col-md-6 col-lg-12 col-xl-6">
-    <a class="section-link icon-offset" href="prepare-nodes/">
+    <a class="section-link icon-offset" href="client-certificates/">
       <div class="head">
         <img class="icon" src="/images/section_icons/secure/tls-encryption/prepare-nodes.png" aria-hidden="true" />
         <div class="title">Create client certificates</div>

--- a/docs/content/latest/secure/tls-encryption/client-certificates.md
+++ b/docs/content/latest/secure/tls-encryption/client-certificates.md
@@ -51,9 +51,9 @@ $ cat > client-certs-temp/yugabyte.conf
 Paste in the following node configuration file.
 
 ```
-################################
+#################################
 # Example node configuration file
-################################
+#################################
 
 [ req ]
 prompt=no
@@ -110,7 +110,7 @@ Now, copy the required certificate files to the `/tmp/yugabyte` directory.
 ```sh
 $ mkdir /tmp/yugabyte
 $ cp secure-data/ca.crt /tmp/yugabyte/
-$ cp client-certs-temp/ysql.* /tmp/yugabyte/
+$ cp client-certs-temp/yugabyte.* /tmp/yugabyte/
 ```
 
 ### Generate client private key and certificate
@@ -120,6 +120,7 @@ Next, generate the client private key (`yugabyte.key`) and client certificate (`
 ```sh
 $ openssl genrsa -out ~/.yugabytedb/yugabytedb.key
 ```
+
 You should see output similar to this:
 
 ```


### PR DESCRIPTION
Based on comments from @bmatican, two links are fixed. And a copy command prefix was fixed.