### PR TITLE
[Docs][#3882] Add new 'headerTitle' param field to allow 'Description' to be used in meta tag

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -19,7 +19,8 @@ All docs pages must start with a front matter as shown below.
 ---
 title: Browser-Title
 linkTitle: My-Left-Nav-Link
-description: Doc-Page-Title
+headerTitle: Doc-Page-Title (if different from Browser-Title)
+description: SEO-Meta-Description
 image: Icon-For-Page-Title
 headcontent: Brief-description
 menu:

--- a/docs/content/_index.html
+++ b/docs/content/_index.html
@@ -1,6 +1,6 @@
 ---
 title: YugabyteDB Docs
-description: YugabyteDB Docs
+description: Get started with YugabyteDB Docs to quickly install and integrate your application. Learn how to run queries and manage configurations with our articles.
 type: indexpage
 weight: 1
 ---

--- a/docs/content/latest/_index.html
+++ b/docs/content/latest/_index.html
@@ -1,6 +1,6 @@
 ---
 title: YugabyteDB documentation
-description: YugabyteDB documentation
+description: YugabyteDB documentation is the best way to learn the most in-depth information about YugabyteDB.
 headcontent: v2.1 — the latest stable version
 type: list
 image: /images/ybsymbol_original.png

--- a/docs/content/latest/admin/_index.html
+++ b/docs/content/latest/admin/_index.html
@@ -1,7 +1,7 @@
 ---
 title: CLIs
 linkTitle: CLIs
-description: CLIs
+description: Learn how to use CLIs to manage YugabyteDB.
 image: /images/section_icons/index/admin.png
 headcontent: Command line interfaces (CLIs) and tools reference.
 type: page

--- a/docs/content/latest/admin/cqlsh.md
+++ b/docs/content/latest/admin/cqlsh.md
@@ -1,7 +1,8 @@
 ---
 title: cqlsh
 linkTitle: cqlsh
-description: cqlsh shell for YCQL
+headerTitle: cqlsh shell for YCQL
+description: The YugabyteDB CQL shell cqlsh provides a CLI for interacting with YugabyteDB using YCQL
 aliases:
   - /develop/tools/cqlsh/
   - /latest/develop/tools/cqlsh/

--- a/docs/content/latest/admin/yb-admin.md
+++ b/docs/content/latest/admin/yb-admin.md
@@ -1,7 +1,7 @@
 ---
 title: yb-admin
 linkTitle: yb-admin
-description: yb-admin
+description: The yb-admin utility, located in the bin directory of YugabyteDB home, provides a commandl ine interface for adminstering clusters.
 menu:
   latest:
     identifier: yb-admin

--- a/docs/content/latest/admin/yb-ctl.md
+++ b/docs/content/latest/admin/yb-ctl.md
@@ -1,7 +1,7 @@
 ---
 title: yb-ctl
 linkTitle: yb-ctl
-description: yb-ctl
+description: The yb-ctl utility, located in the bin directory of YugabyteDB home, provides a simple command line interface for administering local clusters used for development and learning.
 menu:
   latest:
     identifier: yb-ctl

--- a/docs/content/latest/admin/ysqlsh.md
+++ b/docs/content/latest/admin/ysqlsh.md
@@ -1,7 +1,8 @@
 ---
 title: ysqlsh
 linkTitle: ysqlsh
-description: ysqlsh shell for YSQL
+headerTitle: ysqlsh shell for YSQL
+description: The YugabyteDB SQL shell provides a CLI for interacting with YugabyteDB using YSQL. It enables you to interactively enter SQL queries and see query results.
 aliases:
   - /develop/tools/ysqlsh/
   - /latest/develop/tools/ysqlsh/

--- a/docs/content/latest/api/ycql/_index.md
+++ b/docs/content/latest/api/ycql/_index.md
@@ -1,7 +1,8 @@
 ---
 title: YCQL
 linkTitle: YCQL
-description: Yugabyte Cloud Query Language (YCQL)
+headerTitle: Yugabyte Cloud Query Language (YCQL)
+description: YCQL is a SQL-based, flexible-schema API that is best fit for internet-scale OLTP application needing a semi-relational API.
 summary: Reference for the YCQL API
 image: /images/section_icons/api/ycql.png
 headcontent:

--- a/docs/content/latest/api/ycql/expr_fcall.md
+++ b/docs/content/latest/api/ycql/expr_fcall.md
@@ -1,7 +1,8 @@
 ---
 title: Function Call
 summary: Combination of one or more values.
-description: Built-in Function Call
+headerTitle: Built-in Function Call
+description: Function call expression applies the specified function to to given arguments between parentheses and return the result of the computation.
 menu:
   latest:
     parent: api-cassandra

--- a/docs/content/latest/api/ycql/expr_ocall.md
+++ b/docs/content/latest/api/ycql/expr_ocall.md
@@ -1,7 +1,8 @@
 ---
 title: Operator call
 summary: Compounding expression using operators.
-description: Built-in operator call
+headerTitle: Built-in operator call
+description: An expression with operators is a compound expression that combines multiple expressions using builtin operators.
 menu:
   latest:
     parent: api-cassandra

--- a/docs/content/latest/api/ycql/expr_subscript.md
+++ b/docs/content/latest/api/ycql/expr_subscript.md
@@ -1,7 +1,8 @@
 ---
 title: Subscript
 summary: Subscripted columns
-description: Subscripted expressions
+headerTitle: Subscripted expressions
+description: Subscripted expression allows access to an element in a multi-element value such as a map collection
 menu:
   latest:
     parent: api-cassandra

--- a/docs/content/latest/api/ycql/grammar_diagrams.md
+++ b/docs/content/latest/api/ycql/grammar_diagrams.md
@@ -1,5 +1,5 @@
 ---
-title: Grammar xiagrams
+title: Grammar diagrams
 summary: Diagrams of the grammar rules.
 ---
 

--- a/docs/content/latest/api/ycql/type_blob.md
+++ b/docs/content/latest/api/ycql/type_blob.md
@@ -1,7 +1,8 @@
 ---
 title: BLOB
 summary: Binary strings of variable length
-description: BLOB type
+headerTitle: BLOB type
+description: BLOB data type is used to represent arbitrary binary data of variable length.
 menu:
   latest:
     parent: api-cassandra

--- a/docs/content/latest/api/ycql/type_bool.md
+++ b/docs/content/latest/api/ycql/type_bool.md
@@ -1,7 +1,8 @@
 ---
 title: BOOLEAN
 summary: Boolean values of false or true
-description: BOOLEAN type
+headerTitle: BOOLEAN type
+description: BOOLEAN data type is used to specify values of either true or false.
 menu:
   latest:
     parent: api-cassandra

--- a/docs/content/latest/api/ycql/type_collection.md
+++ b/docs/content/latest/api/ycql/type_collection.md
@@ -1,7 +1,8 @@
 ---
 title: MAP, SET, LIST
 summary: MAP, SET and LIST types
-description: Collection Types
+headerTitle: Collection Types
+description: Collection data types are used to specify columns for data objects that can contain more than one value.
 menu:
   latest:
     parent: api-cassandra
@@ -15,7 +16,7 @@ showAsideToc: true
 
 ## Synopsis
 
-Collection data types are used to specify columns for data objects that can contains more than one value.
+Collection data types are used to specify columns for data objects that can contain more than one value.
 
 ### LIST
 
@@ -45,7 +46,7 @@ set_literal ::= '{' [ expression ...] '}'
 
 Where 
 
-- Columns of type `LIST`, 'MAP', or `SET` cannot be part of the `PRIMARY KEY`.
+- Columns of type `LIST`, `MAP`, or `SET` cannot be part of the `PRIMARY KEY`.
 - `type` must be a [non-parametric data type](../#data-types) or a [frozen](../type_frozen) data type.
 - `key_type` must be any data type that is allowed in a primary key (Currently `FROZEN` and all non-parametric data types except `BOOL`).
 - For `map_literal` the left-side `expression` represents the key and the right-side one represents the value.

--- a/docs/content/latest/api/ycql/type_datetime.md
+++ b/docs/content/latest/api/ycql/type_datetime.md
@@ -1,7 +1,7 @@
 ---
 title: Date & Time Types
 summary: DATE, TIME and TIMESTAMP
-description: Date & Time Types
+description: Datetime data types are used to specify data of date and time at a timezone.
 menu:
   latest:
     parent: api-cassandra

--- a/docs/content/latest/api/ycql/type_frozen.md
+++ b/docs/content/latest/api/ycql/type_frozen.md
@@ -1,7 +1,8 @@
 ---
 title: FROZEN
 summary: Binary format for complex data types.
-description: FROZEN data types
+headerTitle: FROZEN data types
+description: FROZEN data data type is used to specify columns of binary strings that result from serializing either collections, tuples, or user-defined types.
 menu:
   latest:
     parent: api-cassandra

--- a/docs/content/latest/api/ycql/type_inet.md
+++ b/docs/content/latest/api/ycql/type_inet.md
@@ -1,7 +1,8 @@
 ---
 title: INET
 summary: IP Address String
-description: INET type
+headerTitle: INET type
+description: INET data type is used to specify columns for data of IP addresses.
 menu:
   latest:
     parent: api-cassandra

--- a/docs/content/latest/api/ycql/type_int.md
+++ b/docs/content/latest/api/ycql/type_int.md
@@ -1,7 +1,7 @@
 ---
 title: Integer and counter types
 summary: Signed integers of different ranges
-description: Integer and counter types
+description: There are several different data types for integers of different value ranges. Integers can be set, inserted, incremented, and decremented
 menu:
   latest:
     parent: api-cassandra

--- a/docs/content/latest/api/ycql/type_jsonb.md
+++ b/docs/content/latest/api/ycql/type_jsonb.md
@@ -1,7 +1,7 @@
 ---
 title: JSONB
 summary: JSONB types
-description: JSONB
+description: JSONB data type is used to efficiently model json data. This data type makes it easy to model json data which does not have a set schema and might change often.
 menu:
   latest:
     parent: api-cassandra

--- a/docs/content/latest/api/ycql/type_number.md
+++ b/docs/content/latest/api/ycql/type_number.md
@@ -1,7 +1,8 @@
 ---
 title: Non-integer
 summary: FLOAT, DOUBLE, and DECIMAL
-description: Non-integer numbers
+headerTitle: Non-integer numbers
+description: Floating-point and fixed-point numbers are used to specify non-integer numbers. Different floating point data types represent different precision numbers.
 menu:
   latest:
     parent: api-cassandra

--- a/docs/content/latest/api/ycql/type_text.md
+++ b/docs/content/latest/api/ycql/type_text.md
@@ -1,7 +1,8 @@
 ---
 title: TEXT
 summary: String of Unicode characters
-description: TEXT type
+headerTitle: TEXT type
+description: TEXT data type is used to specify data of a string of unicode characters.
 menu:
   latest:
     parent: api-cassandra

--- a/docs/content/latest/api/ycql/type_uuid.md
+++ b/docs/content/latest/api/ycql/type_uuid.md
@@ -1,7 +1,7 @@
 ---
 title: UUID and TIMEUUID
 summary: UUID types
-description: UUID and TIMEUUID
+description: UUID data type is used to specify columns for data of universally unique ids. TIMEUUID is a universal unique identifier variant that includes time information.
 menu:
   latest:
     parent: api-cassandra

--- a/docs/content/latest/api/ysql/_index.md
+++ b/docs/content/latest/api/ysql/_index.md
@@ -1,7 +1,8 @@
 ---
 title: YSQL
 linkTitle: YSQL
-description: Yugabyte Structured Query Language (YSQL)
+headerTitle: Yugabyte Structured Query Language (YSQL)
+description: The Yugabyte Structured Query Language (YSQL) is the distributed SQL API for YugabyteDB and is compatible with the SQL dialect of PostgreSQL.
 summary: Reference for the YSQL API
 image: /images/section_icons/api/ysql.png
 menu:

--- a/docs/content/latest/api/ysql/commands/dcl_alter_role.md
+++ b/docs/content/latest/api/ysql/commands/dcl_alter_role.md
@@ -1,7 +1,7 @@
 ---
 title: ALTER ROLE
 linkTitle: ALTER ROLE
-description: ALTER ROLE
+description: ALTER ROLE changes the attributes of a role (user or group). Superusers can change the attributes of any role.
 summary: Roles (users and groups)
 menu:
   latest:

--- a/docs/content/latest/api/ysql/commands/dcl_alter_user.md
+++ b/docs/content/latest/api/ysql/commands/dcl_alter_user.md
@@ -1,7 +1,7 @@
 ---
 title: ALTER USER
 linkTitle: ALTER USER
-description: Users and roles
+description: Use the ALTER USER statement to alter a role. ALTER USER is an alias for ALTER ROLE and is used to alter a role.
 summary: Users and roles
 menu:
   latest:
@@ -15,7 +15,7 @@ showAsideToc: true
 
 ## Synopsis
 
-Use the `ALTER USER` statementto alter a role. `ALTER USER` is an alias for [`ALTER ROLE`](../dcl_alter_role) and is used to alter a role.
+Use the `ALTER USER` statement to alter a role. `ALTER USER` is an alias for [`ALTER ROLE`](../dcl_alter_role) and is used to alter a role.
 
 ## Syntax
 

--- a/docs/content/latest/api/ysql/commands/dcl_create_group.md
+++ b/docs/content/latest/api/ysql/commands/dcl_create_group.md
@@ -1,7 +1,7 @@
 ---
 title: CREATE GROUP
 linkTitle: CREATE GROUP
-description: CREATE GROUP
+description: Use the CREATE GROUP statement to create a group role. CREATE GROUP is an alias for CREATE ROLE and is used to create a group role.
 summary: Groups and roles
 menu:
   latest:

--- a/docs/content/latest/api/ysql/commands/dcl_create_policy.md
+++ b/docs/content/latest/api/ysql/commands/dcl_create_policy.md
@@ -1,7 +1,7 @@
 ---
 title: CREATE POLICY
 linkTitle: CREATE POLICY
-description: CREATE POLICY
+description: Use the CREATE POLICY statement to create a new row level security policy for a table to select, insert, update, or delete rows that match the relevant policy expression.
 summary: Create row level security policy
 menu:
   latest:

--- a/docs/content/latest/api/ysql/commands/dcl_create_role.md
+++ b/docs/content/latest/api/ysql/commands/dcl_create_role.md
@@ -1,7 +1,7 @@
 ---
 title: CREATE ROLE
 linkTitle: CREATE ROLE
-description: CREATE ROLE
+description: CREATE ROLE adds a new role to a YugabyteDB database cluster. A role is an entity that can own database objects and have database privileges.
 summary: Roles (users and groups)
 menu:
   latest:

--- a/docs/content/latest/api/ysql/commands/dcl_create_user.md
+++ b/docs/content/latest/api/ysql/commands/dcl_create_user.md
@@ -1,7 +1,7 @@
 ---
 title: CREATE USER
 linkTitle: CREATE USER
-description: CREATE USER
+description: Use the CREATE USER statement to create a user. The CREATE USER statement is an alias for CREATE ROLE, but creates a role that has LOGIN privileges by default.
 summary: CREATE USER
 menu:
   latest:

--- a/docs/content/latest/api/ysql/commands/dcl_drop_group.md
+++ b/docs/content/latest/api/ysql/commands/dcl_drop_group.md
@@ -1,7 +1,7 @@
 ---
 title: DROP GROUP
 linkTitle: DROP GROUP
-description: DROP GROUP
+description: Use the DROP GROUP to drop a role. DROP GROUP is an alias for DROP ROLE and is used to drop a role.
 summary: DROP GROUP
 menu:
   latest:

--- a/docs/content/latest/api/ysql/commands/dcl_drop_owned.md
+++ b/docs/content/latest/api/ysql/commands/dcl_drop_owned.md
@@ -1,7 +1,7 @@
 ---
 title: DROP OWNED
 linkTitle: DROP OWNED
-description: DROP OWNED
+description: Use the DROP OWNED statement to drop all database objects within the current database that are owned by one of the specified roles.
 summary: Roles (users and groups)
 menu:
   latest:

--- a/docs/content/latest/api/ysql/commands/ddl_comment.md
+++ b/docs/content/latest/api/ysql/commands/ddl_comment.md
@@ -1,3 +1,4 @@
+---
 title: COMMENT
 linkTitle: COMMENT
 summary: COMMENT

--- a/docs/content/latest/api/ysql/datatypes/type_character.md
+++ b/docs/content/latest/api/ysql/datatypes/type_character.md
@@ -1,7 +1,8 @@
 ---
 title: TEXT
 linkTitle: Character
-description: Character Types
+headerTitle: Character Types
+description: Character-based data types are used to specify data of a string of Unicode characters.
 summary: String of Unicode characters
 menu:
   latest:

--- a/docs/content/latest/api/ysql/datatypes/type_json/_index.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/_index.md
@@ -2,7 +2,8 @@
 title: JSON
 linkTitle: JSON
 summary: JSON and JSONB data types
-description: JSON data types and functionality
+headerTitle: JSON data types and functionality
+description: YSQL supports two data types for representing a JSON document in json and jsonb. Both data types reject any JSON document that does not conform to RFC 7159
 image: /images/section_icons/api/ysql.png
 menu:
   latest:

--- a/docs/content/latest/api/ysql/datatypes/type_json/create-indexes-check-constraints.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/create-indexes-check-constraints.md
@@ -2,6 +2,7 @@
 title: Indexes and check constraints
 linkTitle: Indexes and check constraints
 summary: Create indexes and check constraints on JSON columns
+headerTitle: Create indexes and check constraints on JSON columns
 description: Create indexes and check constraints on JSON columns
 menu:
   latest:

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/_index.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/_index.md
@@ -2,7 +2,8 @@
 title: Functions and operators
 linkTitle: Functions & operators
 summary: Functions and operators
-description: JSON functions and operators
+headerTitle: JSON functions and operators
+description: The JSON functions and operators available in YugabyteDB are categorized below by purpose, that is based upon the goals you want to accomplish.
 image: /images/section_icons/api/ysql.png
 menu:
   latest:

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/concatenation-operator.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/concatenation-operator.md
@@ -1,7 +1,8 @@
 ---
 title: Concatenation
 linkTitle: '|| (concatenation)'
-description:  '|| (concatenation)'
+headerTitle:  '|| (concatenation)'
+description:  'The concatenation operator takes two values. If both sides of the operator are primitive JSON values, then the result is an array of these values'
 menu:
   latest:
     identifier: concatentation-operator

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/containment-operators.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/containment-operators.md
@@ -2,7 +2,8 @@
 title: Containment
 linkTitle: '@> and <@ (containment)'
 summary: Containment (@> & <@)
-description: '@> and <@ (containment)'
+headerTitle: '@> and <@ (containment)'
+description: The @> operator tests if the left-hand JSON value contains the right-hand JSON value. And the <@ operator tests if the right-hand JSON value contains the left-hand JSON value. 
 menu:
   latest:
     identifier: containment-operators

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/equality-operator.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/equality-operator.md
@@ -2,7 +2,8 @@
 title: Equality
 linkTitle: '= (equality)'
 summary: Equality - the `=` operator
-description: = (equality)
+headerTitle: = (equality)
+description: The = operator checks for equality and requires that the inputs are presented as jsonb values.
 menu:
   latest:
     identifier: equality-operator

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/json-subvalue-operators.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/json-subvalue-operators.md
@@ -2,7 +2,8 @@
 title: JSON subvalue operators
 linkTitle: '->, ->>, #>, and #>> (JSON subvalues)'
 summary: JSON subvalue operators
-description: '->, ->>, #>, and #>> (JSON subvalues)'
+headerTitle: '->, ->>, #>, and #>> (JSON subvalues)'
+description: An arbitrarily deeply located JSON subvalue is identified by its path from the topmost JSON value.
 menu:
   latest:
     identifier: json-subvalue-operators

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-array-elements-text.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-array-elements-text.md
@@ -2,7 +2,8 @@
 title: jsonb_array_elements_text()
 linkTitle: jsonb_array_elements_text()
 summary: jsonb_array_elements_text() and json_array_elements_text()
-description: jsonb_array_elements_text() and json_array_elements_text()
+headerTitle: jsonb_array_elements_text() and json_array_elements_text()
+description: The function jsonb_array_elements_text() bears the same relationship to jsonb_array_elements() that the other *text() functions bear to their plain counterparts.
 menu:
   latest:
     identifier: jsonb-array-elements-text

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-array-elements.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-array-elements.md
@@ -2,7 +2,8 @@
 title: jsonb_array_elements()
 linkTitle: jsonb_array_elements()
 summary: jsonb_array_elements() and json_array_elements()
-description: jsonb_array_elements() and json_array_elements()
+headerTitle: jsonb_array_elements() and json_array_elements()
+description: The functions in this pair require that the supplied JSON value is an array, and transform the list into a table.
 menu:
   latest:
     identifier: jsonb-array-elements

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-array-length.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-array-length.md
@@ -2,7 +2,8 @@
 title: jsonb_array_length
 linkTitle: jsonb_array_length()
 summary: jsonb_array_length() and json_array_length()
-description: jsonb_array_length() and json_array_length()
+headerTitle: jsonb_array_length() and json_array_length()
+description: The functions in this pair require that the supplied JSON value and return the count of values in the array.
 menu:
   latest:
     identifier: jsonb-array-length

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-build-array.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-build-array.md
@@ -3,6 +3,7 @@ title: jsonb_build_array()
 linkTitle: jsonb_build_array()
 summary: jsonb_build_array() and json_build_array()
 description: jsonb_build_array() and json_build_array()
+description: These two functions take an arbitrary number of actual arguments of mixed SQL data types.
 menu:
   latest:
     identifier: jsonb-build-array

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-build-object.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-build-object.md
@@ -2,7 +2,8 @@
 title: jsonb_build_object() 
 linkTitle: jsonb_build_object() 
 summary: jsonb_build_object() and json_build_object() 
-description: jsonb_build_object() and json_build_object() 
+headerTitle: jsonb_build_object() and json_build_object() 
+description: The jsonb_build_object() variadic function is the obvious counterpart to jsonb_build_array().
 menu:
   latest:
     identifier: jsonb-build-object

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-each-text.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-each-text.md
@@ -2,7 +2,8 @@
 title: jsonb_each_text()
 linkTitle: jsonb_each_text()
 summary: jsonb_each_text() and json_each_text()
-description: jsonb_each_text() and json_each_text()
+headerTitle: jsonb_each_text() and json_each_text()
+description: The result of jsonb_each_text() bears the same relationship to the result of jsonb_each() as does the result of the ->> operator to that of the -> operator
 menu:
   latest:
     identifier: jsonb-each-text

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-each.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-each.md
@@ -2,7 +2,8 @@
 title: jsonb_each()
 linkTitle: jsonb_each()
 summary: jsonb_each() and json_each()
-description: jsonb_each()  and json_each()
+headerTitle: jsonb_each() and json_each()
+description: The functions in this pair require that the supplied JSON value is an object. They return a row set with columns "key" and "value"
 menu:
   latest:
     identifier: jsonb-each

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-extract-path-text.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-extract-path-text.md
@@ -2,7 +2,8 @@
 title: jsonb_extract_path_text()
 linkTitle: jsonb_extract_path_text() 
 summary: jsonb_extract_path_text() and json_extract_path_text()
-description: jsonb_extract_path_text()  and json_extract_path_text()
+headerTitle: jsonb_extract_path_text()  and json_extract_path_text()
+description: The result jsonb_extract_path_text() bears the same relationship to the result of its jsonb_extract_path() as does the \#>> operator to taht of the \#> operator.
 menu:
   latest:
     identifier: jsonb-extract-path-text

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-extract-path.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-extract-path.md
@@ -2,7 +2,8 @@
 title: jsonb_extract_path()
 linkTitle: jsonb_extract_path()
 summary: jsonb_extract_path() and json_extract_path()
-description: jsonb_extract_path() and json_extract_path()
+headerTitle: jsonb_extract_path() and json_extract_path()
+description: These are functionally identical to the \#> operator. The invocation of \#> can be mechanically transformed to use jsonb_extract_path() by these steps
 menu:
   latest:
     identifier: jsonb-extract-path

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-object-keys.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-object-keys.md
@@ -2,7 +2,8 @@
 title: jsonb_object_keys()
 linkTitle: jsonb_object_keys() 
 summary: jsonb_object_keys() and json_object_keys()
-description: jsonb_object_keys()  and json_object_keys() 
+headerTitle: jsonb_object_keys()  and json_object_keys()
+description: The functions in this pair require that the supplied JSON value is an object and transform the list of key names into a set of text values.
 menu:
   latest:
     identifier: jsonb-object-keys

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-object.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-object.md
@@ -2,6 +2,7 @@
 title: jsonb_object()
 linkTitle: jsonb_object() 
 summary: jsonb_object()  and json_object()
+headerTitle: jsonb_object() and json_object()
 description: jsonb_object() and json_object()
 menu:
   latest:

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-typeof.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-typeof.md
@@ -2,7 +2,8 @@
 title: jsonb_typeof()
 linkTitle: jsonb_typeof()
 summary: jsonb_typeof() and json_typeof()
-description: jsonb_typeof() and json_typeof()
+headerTitle: jsonb_typeof() and json_typeof()
+description: jsonb_typeof() and json_typeof() functions return the type of the JSON value as a SQL text value.
 menu:
   latest:
     identifier: jsonb-typeof

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/key-existence-operators.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/key-existence-operators.md
@@ -2,7 +2,8 @@
 title: Existence of keys
 linkTitle: '?, ?|, and ? (key existence)'
 summary: Existence of keys
-description: '?, ?|, and ? (key existence)'
+headerTitle: '?, ?|, and ? (key existence)'
+description: The ?, ?|, and ? (key existence) operators require that inputs are presented as jsonb value. They don't have overloads for json.
 menu:
   latest:
     identifier: key-existence-operators

--- a/docs/content/latest/api/ysql/datatypes/type_json/primitive-and-compound-data-types.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/primitive-and-compound-data-types.md
@@ -2,7 +2,8 @@
 title: Primitive and compound data types
 linkTitle: Primitive and compound data types
 summary: Primitive and compound data types
-description: Primitive and compound JSON data types
+headerTitle: Primitive and compound JSON data types
+description: JSON can represent (sub)values of four primitive data types and of two compound data types. The primitive data types are string, number, boolean, and null.
 menu:
   latest:
     identifier: primitive-and-compound-data-types

--- a/docs/content/latest/api/ysql/extensions.md
+++ b/docs/content/latest/api/ysql/extensions.md
@@ -1,7 +1,8 @@
 ---
 title: Extensions
 linkTitle: Extensions
-description: Install and use Extensions
+headerTitle: Install and use Extensions
+description: This page documents how to install and use PostgreSQL extensions that are tested to work with YSQL.
 summary: Reference for YSQL Extensions
 menu:
   latest:

--- a/docs/content/latest/api/ysql/keywords.md
+++ b/docs/content/latest/api/ysql/keywords.md
@@ -1,7 +1,8 @@
 ---
 title: Keywords
 linkTitle: Keywords
-description: List of YSQL keywords
+headerTitle: List of YSQL keywords
+description: The following list is a reference of all YSQL API keywords that work with YugabyteDB
 summary: Reference for YSQL API
 image: /images/section_icons/api/ysql.png
 menu:

--- a/docs/content/latest/api/ysql/reserved_names.md
+++ b/docs/content/latest/api/ysql/reserved_names.md
@@ -1,7 +1,8 @@
 ---
 title: Reserved names
 linkTitle: Reserved names
-description: List of reserved names
+headerTitle: List of reserved names
+description: YSQL reserves the following names for internal usage. Exception will be raised when these names are used even when they are double-quoted.
 summary: List of reserved names
 image: /images/section_icons/api/ysql.png
 menu:

--- a/docs/content/latest/architecture/query-layer/overview.md
+++ b/docs/content/latest/architecture/query-layer/overview.md
@@ -1,7 +1,8 @@
 ---
 title: Overview
 linkTitle: Overview
-description: Overview of Yugabyte Query Layer (YQL)
+headerTitle: Overview of Yugabyte Query Layer (YQL)
+description: The Yugabyte Query Layer (YQL) is the upper layer of YugabyteDB. Applications interact directly with YQL using client drivers.
 aliases:
   - /architecture/concepts/yql/
 menu:

--- a/docs/content/latest/architecture/transactions/distributed-txns.md
+++ b/docs/content/latest/architecture/transactions/distributed-txns.md
@@ -1,7 +1,8 @@
 ---
 title: Distributed transactions
 linkTitle: Distributed transactions
-description: Distributed ACID transactions
+headerTitle: Distributed ACID transactions
+description: Distributed ACID transactions are transactions that modify multiple rows in more than one shard. YugabyteDB supports distributed transactions, enabling strongly consistent secondary indexes and multi-table/row ACID operations
 menu:
   latest:
     identifier: architecture-distributed-acid-transactions

--- a/docs/content/latest/architecture/transactions/isolation-levels.md
+++ b/docs/content/latest/architecture/transactions/isolation-levels.md
@@ -1,7 +1,8 @@
 ---
 title: Isolation Levels
 linkTitle: Isolation Levels
-description: Transaction isolation Levels
+headerTitle: Transaction isolation Levels
+description: YugabyteDB supports two isolation levels. Snapshot isolation and Serializable isolation
 aliases:
   - /architecture/transactions/isolation-levels/
 menu:

--- a/docs/content/latest/architecture/transactions/single-row-transactions.md
+++ b/docs/content/latest/architecture/transactions/single-row-transactions.md
@@ -1,7 +1,8 @@
 ---
 title: Single row transactions
 linkTitle: Single row transactions
-description: Single row ACID transactions
+headerTitle: Single row ACID transactions
+description: YugabyteDB offers ACID semantics for mutations involving a single row or rows that fall within the same shard (partition, tablet).
 aliases:
   - /architecture/transactions/single-row-transactions/
 menu:

--- a/docs/content/latest/benchmark/_index.html
+++ b/docs/content/latest/benchmark/_index.html
@@ -1,7 +1,8 @@
 ---
 title: Benchmark
 linkTitle: Benchmark
-description: Benchmark YugabyteDB
+headerTitle: Benchmark YugabyteDB
+description: Benchmark YugabyteDB with YCSB or concurrent transaction with TPC-C
 image: /images/section_icons/explore/high_performance.png
 headcontent:
 section: USER GUIDES

--- a/docs/content/latest/comparisons/_index.md
+++ b/docs/content/latest/comparisons/_index.md
@@ -1,7 +1,8 @@
 ---
 title: Comparisons
 linkTitle: Comparisons
-description: Compare YugabyteDB to other databases
+headerTitle: Compare YugabyteDB to other databases
+description: See how YugabyteDB compares against other operational databases in the distributed SQL and NoSQL categories. Click the database name in the table header to see a more detailed comparison.
 image: /images/section_icons/index/comparisons.png
 headcontent: See how YugabyteDB compares against other operational databases in the distributed SQL and NoSQL categories. Click the database name in the table header to see a more detailed comparison.
 aliases:

--- a/docs/content/latest/deploy/_index.html
+++ b/docs/content/latest/deploy/_index.html
@@ -1,7 +1,8 @@
 ---
 title: Deploy
 linkTitle: Deploy
-description: Deploy YugabyteDB
+headerTitle: Deploy YugabyteDB
+description: Deploy to any public cloud or private data center of your choice using either YugabyteDB or the Yugabyte Platform.
 headcontent: Deploy to any public cloud or private data center of your choice using either YugabyteDB or the Yugabyte Platform.
 image: /images/section_icons/index/deploy.png
 aliases:

--- a/docs/content/latest/deploy/cdc/cdc-to-kafka.md
+++ b/docs/content/latest/deploy/cdc/cdc-to-kafka.md
@@ -1,7 +1,8 @@
 ---
 title: CDC to Kafka
 linkTitle: CDC to Kafka
-description: Change data capture (CDC) to Kafka
+headerTitle: Change data capture (CDC) to Kafka
+description: Learn how to use Change data capture (CDC) API to send data changes to Apache Kafka
 beta: /latest/faq/general/#what-is-the-definition-of-the-beta-feature-tag
 menu:
   latest:

--- a/docs/content/latest/deploy/kubernetes/_index.html
+++ b/docs/content/latest/deploy/kubernetes/_index.html
@@ -1,7 +1,8 @@
 ---
 title: Kubernetes
 linkTitle: Kubernetes
-description: Deploy on Kubernetes
+headerTitle: Deploy on Kubernetes
+description: Deploy YugabyteDB natively on Kubernetes with various providers
 headcontent: This section describes how to deploy YugabyteDB natively on Kubernetes.
 image: /images/section_icons/deploy/kubernetes.png
 aliases:

--- a/docs/content/latest/deploy/public-clouds/azure/azure-arm.md
+++ b/docs/content/latest/deploy/public-clouds/azure/azure-arm.md
@@ -1,3 +1,9 @@
+---
+title: Azure ARM
+linkTitle: Azure-ARM 
+description: Azure ARM
+---
+
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fyugabyte%2Fazure-resource-manager%2Fmaster%2Fyugabyte_deployment.json" target="_blank">
     <img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.png"/>
 </a>

--- a/docs/content/latest/develop/learn/acid-transactions-ycql.md
+++ b/docs/content/latest/develop/learn/acid-transactions-ycql.md
@@ -1,7 +1,8 @@
 ---
 title: 4. ACID transactions
 linkTitle: 4. ACID transactions
-description: ACID transactions
+headerTitle: ACID transactions
+description: ACID transaction is a sequence of operations performed as a single logical unit of work. Learn how ACID transactions work in YCQL.
 menu:
   latest:
     identifier: acid-transactions-1-ycql

--- a/docs/content/latest/develop/learn/acid-transactions-ysql.md
+++ b/docs/content/latest/develop/learn/acid-transactions-ysql.md
@@ -1,7 +1,8 @@
 ---
 title: 4. ACID transactions
 linkTitle: 4. ACID transactions
-description: ACID transactions
+headerTitle: ACID transactions
+description: ACID transaction is a sequence of operations performed as a single logical unit of work. Learn how ACID transactions work in YSQL.
 aliases:
   - /latest/explore/transactional/acid-transactions/
   - /latest/develop/learn/acid-transactions/

--- a/docs/content/latest/develop/learn/aggregations-ycql.md
+++ b/docs/content/latest/develop/learn/aggregations-ycql.md
@@ -1,7 +1,8 @@
 ---
 title: 5. Aggregations
 linkTitle: 5. Aggregations
-description: Aggregations
+headerTitle: Aggregations
+description: YugabyteDB YCQL supports a number of standard aggregation functions. Let us go through some of these using an example.
 menu:
   latest:
     identifier: aggregations-1-ycql

--- a/docs/content/latest/develop/learn/aggregations-ysql.md
+++ b/docs/content/latest/develop/learn/aggregations-ysql.md
@@ -1,7 +1,8 @@
 ---
 title: 5. Aggregations
 linkTitle: 5. Aggregations
-description: Aggregations
+headerTitle: Aggregations
+description: YugabyteDB YSQL supports a number of standard aggregation functions. Let us go through some of these using an example.
 aliases:
   - /develop/learn/aggregations/
   - /latest/develop/learn/aggregations/

--- a/docs/content/latest/develop/learn/batch-operations-ycql.md
+++ b/docs/content/latest/develop/learn/batch-operations-ycql.md
@@ -1,7 +1,8 @@
 ---
 title: 6. Batch operations
 linkTitle: 6. Batch operations
-description: Batch operations
+headerTitle: Batch operations
+description: Batch operations in YCQL is the ability to send a set of operations as one operation (RPC call) to the database instead of sending the operations one by one as individual RPC calls.
 menu:
   latest:
     identifier: batch-operations-1-ycql

--- a/docs/content/latest/develop/learn/batch-operations-ysql.md
+++ b/docs/content/latest/develop/learn/batch-operations-ysql.md
@@ -1,7 +1,8 @@
 ---
 title: 6. Batch operations
 linkTitle: 6. Batch operations
-description: Batch operations
+headerTitle: Batch operations
+description: Batch operations in YSQL is the ability to send a set of operations as one operation (RPC call) to the database instead of sending the operations one by one as individual RPC calls.
 aliases:
   - /latest/develop/learn/batch-operations/
 menu:

--- a/docs/content/latest/develop/learn/data-modeling-ycql.md
+++ b/docs/content/latest/develop/learn/data-modeling-ycql.md
@@ -1,7 +1,8 @@
 ---
 title: 2. Data modeling
 linkTitle: 2. Data modeling
-description: Data modeling
+headerTitle: Data modeling
+description: Data modeling in YCQL is a process that involves identifying the entities (items to be stored) and the relationships between entities.
 aliases:
   - /develop/learn/data-modeling/
   - /latest/explore/transactional/secondary-indexes/

--- a/docs/content/latest/develop/learn/data-modeling-ysql.md
+++ b/docs/content/latest/develop/learn/data-modeling-ysql.md
@@ -1,7 +1,8 @@
 ---
 title: 2. Data modeling
 linkTitle: 2. Data modeling
-description: Data modeling
+headerTitle: Data modeling
+description: Data modeling in YSQL is a process that involves identifying the entities (items to be stored) and the relationships between entities.
 menu:
   latest:
     identifier: data-modeling-2-ysql

--- a/docs/content/latest/develop/learn/data-types-ycql.md
+++ b/docs/content/latest/develop/learn/data-types-ycql.md
@@ -1,7 +1,8 @@
 ---
 title: 3. Data types
 linkTitle: 3. Data types
-description: Data types
+headerTitle: Data types
+description: There are various Data types in YCQL listed here
 menu:
   latest:
     identifier: data-types-1-ycql

--- a/docs/content/latest/develop/learn/data-types-ysql.md
+++ b/docs/content/latest/develop/learn/data-types-ysql.md
@@ -1,7 +1,8 @@
 ---
 title: 3. Data types
 linkTitle: 3. Data types
-description: Data types
+headerTitle: Data types
+description: There are various Data types in YSQL listed here
 aliases:
   - /latest/explore/transactional/json-documents/
   - /latest/develop/learn/data-types/

--- a/docs/content/latest/develop/learn/date-and-time-ycql.md
+++ b/docs/content/latest/develop/learn/date-and-time-ycql.md
@@ -1,7 +1,8 @@
 ---
 title: 7. Date and time
 linkTitle: 7. Date and time
-description: Date and time
+headerTitle: Date and time
+description: Date and time in YCQL
 menu:
   latest:
     parent: learn

--- a/docs/content/latest/develop/learn/date-and-time-ysql.md
+++ b/docs/content/latest/develop/learn/date-and-time-ysql.md
@@ -1,7 +1,8 @@
 ---
 title: 7. Date and time
 linkTitle: 7. Date and time
-description: Date and time
+headerTitle: Date and time
+description: Date and time in YSQL
 aliases:
   - /latest/explore/date-and-time/
   - /latest/develop/learn/date-and-time/

--- a/docs/content/latest/develop/learn/sql-nosql.md
+++ b/docs/content/latest/develop/learn/sql-nosql.md
@@ -1,7 +1,8 @@
 ---
 title: 1. SQL vs NoSQL
 linkTitle: 1. SQL vs NoSQL
-description: SQL vs NoSQL
+headerTitle: SQL vs NoSQL
+description: YugabyteDB brings the best of these YSQL and NoSQL together into one unified platform to simplify development of scalable cloud services.
 aliases:
   - /develop/learn/sql-nosql/
 menu:

--- a/docs/content/latest/develop/learn/strings-and-text-ycql.md
+++ b/docs/content/latest/develop/learn/strings-and-text-ycql.md
@@ -1,6 +1,7 @@
 ---
 title: 8. Strings and text
 linkTitle: 8. Strings and text
+headerTitle: String and text data types
 description: String and text data types
 menu:
   latest:

--- a/docs/content/latest/develop/learn/ttl-data-expiration-ycql.md
+++ b/docs/content/latest/develop/learn/ttl-data-expiration-ycql.md
@@ -1,6 +1,7 @@
 ---
 title: 9. TTL for data expiration
 linkTitle: 9. TTL for data expiration
+headerTitle: TTL for data expiration
 description: TTL for data expiration
 menu:
   latest:

--- a/docs/content/latest/develop/realworld-apps/iot-spark-kafka-ksql.md
+++ b/docs/content/latest/develop/realworld-apps/iot-spark-kafka-ksql.md
@@ -1,7 +1,8 @@
 ---
 title: IoT - Confluent Kafka, KSQL, Apache Spark 
 linkTitle: IoT Fleet Management
-description: IoT Fleet Management - Confluent Kafka, KSQL, Apache Spark
+headerTitle: IoT Fleet Management - Confluent Kafka, KSQL, Apache Spark
+description: This is a fleet management application with source code and installation instructions available on Github and built with Confluent Kafka, KSQL, Apache Spark
 aliases:
   - /develop/realworld-apps/iot-spark-kafka/
   - /latest/develop/realworld-apps/iot-spark-kafka/

--- a/docs/content/latest/explore/two-data-centers/linux.md
+++ b/docs/content/latest/explore/two-data-centers/linux.md
@@ -1,7 +1,8 @@
 ---
 title: Two data center (2DC)
 linkTitle: Two data center (2DC)
-description: Two data center (2DC) deployment
+headerTitle: Two data center (2DC) deployment
+description: This tutorial simulates a geo-distributed two data center (2DC) deployment using two local YugabyteDB clusters in Linux
 aliases:
   - /latest/explore/two-data-centers-linux/
 menu:

--- a/docs/content/latest/explore/two-data-centers/macos.md
+++ b/docs/content/latest/explore/two-data-centers/macos.md
@@ -1,7 +1,8 @@
 ---
 title: Two data center (2DC)
 linkTitle: Two data center (2DC)
-description: Two data center (2DC) deployment
+headerTitle: Two data center (2DC) deployment
+description: This tutorial simulates a geo-distributed two data center (2DC) deployment using two local YugabyteDB clusters in Linux
 aliases:
   - /latest/explore/two-data-centers/
   - /latest/explore/two-data-centers-macos/

--- a/docs/content/latest/secure/authorization/rbac-model-ycql.md
+++ b/docs/content/latest/secure/authorization/rbac-model-ycql.md
@@ -1,7 +1,8 @@
 ---
 title: RBAC model
 linkTitle: RBAC model
-description: Role-based access control (RBAC) model
+headerTitle: Role-based access control (RBAC) model
+description: The role-based access control (RBAC) model in YCQL is a collection of permissions on resources given to roles.
 headcontent: How role-based access control works
 image: /images/section_icons/secure/rbac-model.png
 menu:

--- a/docs/content/latest/secure/authorization/rbac-model.md
+++ b/docs/content/latest/secure/authorization/rbac-model.md
@@ -1,7 +1,8 @@
 ---
 title: RBAC model
 linkTitle: RBAC model
-description: Role-based access control (RBAC) model
+headerTitle: Role-based access control (RBAC) model
+description: The role-based access control (RBAC) model in YSQL is a collection of privileges on resources given to roles.
 headcontent: How role-based access control works
 image: /images/section_icons/secure/rbac-model.png
 menu:

--- a/docs/content/latest/troubleshoot/nodes/check-logs.md
+++ b/docs/content/latest/troubleshoot/nodes/check-logs.md
@@ -1,6 +1,7 @@
 ---
 title: Inspect logs
 linkTitle: Inspect logs
+headerTitle: Inspect YugabyteDB logs
 description: Inspect YugabyteDB logs
 aliases:
   - /troubleshoot/nodes/check-logs/

--- a/docs/content/latest/troubleshoot/nodes/check-processes.md
+++ b/docs/content/latest/troubleshoot/nodes/check-processes.md
@@ -1,7 +1,8 @@
 ---
 title: Check processes
 linkTitle: Check processes
-description: Check YugabyteDB processes
+headerTitle: Check YugabyteDB processes
+description: How to check if your YugabyteDB processes are running
 aliases:
   - /troubleshoot/nodes/check-processes/
 menu:

--- a/docs/content/latest/troubleshoot/nodes/check-stats.md
+++ b/docs/content/latest/troubleshoot/nodes/check-stats.md
@@ -1,7 +1,8 @@
 ---
 title: System statistics
 linkTitle: System statistics
-description: Check system statistics
+headerTitle: Check system statistics
+description: How to check system statistics on your YugabyteDB cluster
 aliases:
   - /troubleshoot/nodes/check-stats/
 menu:

--- a/docs/content/latest/troubleshoot/nodes/recover-disk.md
+++ b/docs/content/latest/troubleshoot/nodes/recover-disk.md
@@ -1,7 +1,8 @@
 ---
 title: Disk failure
 linkTitle: Disk failure
-description: Recover failing disk
+headerTitle: Recover failing disk
+description: Learn how to recover failing disk
 aliases:
   - /troubleshoot/nodes/disk-failure/
 menu:

--- a/docs/content/latest/troubleshoot/overview.md
+++ b/docs/content/latest/troubleshoot/overview.md
@@ -1,6 +1,7 @@
 ---
 title: Troubleshooting
 linkTitle: Troubleshooting
+headerTitle: Troubleshooting overview
 description: Troubleshooting overview
 aliases:
   - /troubleshoot/overview/

--- a/docs/content/latest/yedis/_index.md
+++ b/docs/content/latest/yedis/_index.md
@@ -1,7 +1,8 @@
 ---
 title: YEDIS
 linkTitle: YEDIS
-description: Yugabyte Dictionary Service (YEDIS) 
+headerTitle: Yugabyte Dictionary Service (YEDIS)
+description: The YEDIS API allows YugabyteDB to function as a clustered, auto-sharded, globally distributed and persistent key-value database that is compatible with the Redis commands library.
 headcontent: 
 image: /images/section_icons/api/yedis.png
 aliases:

--- a/docs/content/search.html
+++ b/docs/content/search.html
@@ -1,7 +1,7 @@
 ---
 title: Search results
 linkTitle: Search results
-description: Search results
+description: Search results powered with Algolia. Quickly find articles that you are looking for.
 type: search
 ---
 

--- a/docs/content/v1.0/deploy/kubernetes/multi-zone.md
+++ b/docs/content/v1.0/deploy/kubernetes/multi-zone.md
@@ -1,3 +1,7 @@
+---
+title: Multi-zone Kubernetes
+linkTitle: Multi-zone-Kubernetes
+---
 
 <ul class="nav nav-tabs nav-tabs-yb">
   <li >

--- a/docs/content/v2.0/deploy/public-clouds/azure/azure-arm.md
+++ b/docs/content/v2.0/deploy/public-clouds/azure/azure-arm.md
@@ -1,3 +1,9 @@
+---
+title: Azure ARM
+linkTitle: Azure-ARM 
+description: Azure ARM
+---
+
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fyugabyte%2Fazure-resource-manager%2Fmaster%2Fyugabyte_deployment.json" target="_blank">
     <img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.png"/>
 </a>

--- a/docs/layouts/_default/list.html
+++ b/docs/layouts/_default/list.html
@@ -23,11 +23,11 @@
 		<article class="article">
 			<div class="wrapper">
 				<div class="image">
-					<img alt="{{ .Description }}" title="{{ .Description }}" src="{{ .Page.Params.image }}" />
+					<img alt="{{ .Title }}" title="{{ .Title }}" src="{{ .Page.Params.image }}" />
 				</div>
 				{{ partial "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) }}	
 
-				<h1>{{ .Description }}  {{ if .Draft }} (Draft){{ end }}</h1>
+				<h1>{{ if .Page.Params.headerTitle }}{{ .Page.Params.headerTitle }}{{ else }}{{ .Page.Title }}{{ end }}  {{ if .Draft }} (Draft){{ end }}</h1>
 
 				<div class="head-content clearfix">{{ .Page.Params.headcontent }}</div>
 				

--- a/docs/layouts/_default/single.html
+++ b/docs/layouts/_default/single.html
@@ -27,7 +27,7 @@
 					<div class="content-flex-container">
 						{{ partial "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) }}
 
-						<h1>{{ .Description }} {{ if .Draft }} (Draft){{ end }}{{ if .Page.Params.beta }}<a class="tag-beta" href="{{ .Page.Params.beta }}">Beta</a>{{ end }}</h1>
+						<h1>{{ if .Page.Params.headerTitle }}{{ .Page.Params.headerTitle }}{{ else }}{{ .Page.Title }}{{ end }} {{ if .Draft }} (Draft){{ end }}{{ if .Page.Params.beta }}<a class="tag-beta" href="{{ .Page.Params.beta }}">Beta</a>{{ end }}</h1>
 
 						{{ $urlArray := split (urls.Parse .Permalink).Path "/" }}
 						{{ $latestUrl := path.Join "latest" (after 2 $urlArray) }}

--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -25,7 +25,7 @@
 
 				{{ partial "detect_version" . }}
 
-				<h1>{{ .Title }} {{ if .Draft }} (Draft){{ end }}</h1>
+				<h1>{{ if .Page.Params.headerTitle }}{{ .Page.Params.headerTitle }}{{ else }}{{ .Title }}{{ end }} {{ if .Draft }} (Draft){{ end }}</h1>
 
 				{{ .TableOfContents }}
 

--- a/docs/layouts/indexpage/single.html
+++ b/docs/layouts/indexpage/single.html
@@ -25,7 +25,7 @@
 				{{ partial "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) }}	
 
 				{{ range where .Site.Pages "Type" "index" }}
-					<h1>{{ .Title }} {{ if .Draft }} (Draft){{ end }}</h1>
+					<h1>{{ if .Page.Params.headerTitle }}{{ .Page.Params.headerTitle }}{{ else }}{{ .Page.Title }}{{ end }} {{ if .Draft }} (Draft){{ end }}</h1>
 
 					{{ .TableOfContents }}
 

--- a/docs/layouts/partials/head.html
+++ b/docs/layouts/partials/head.html
@@ -12,9 +12,7 @@
     <title>{{ .Title }}{{ if not .IsHome }} | {{ .Site.Title }}{{ end }}</title>
     {{ hugo.Generator }}
 
-    {{ with .Site.Params.description }}
-    <meta name="description" content="{{ . }}">
-    {{ end }}
+    <meta name="description" content="{{ if .Description }}{{ .Description }}{{ else if .Site.Params.Description }}{{ .Site.Params.Description }}{{ else }}YugabyteDB is a transactional, high-performance database.{{ end }}">
     <link rel="canonical" href="{{ .Permalink }}">
     {{ with .Site.Params.author }}
     <meta name="author" content="{{ . }}">

--- a/docs/layouts/partials/pagination.html
+++ b/docs/layouts/partials/pagination.html
@@ -30,7 +30,11 @@
                 {{ end }}
               </div>
               <div class="title">
-                {{ $PrevLink.Page.Description }}
+                {{ if $PrevLink.Page.Params.headerTitle }}
+                  {{ $PrevLink.Page.Params.headerTitle }}
+                {{ else }}
+                  {{ $PrevLink.Page.Title }}
+                {{ end }}
               </div>
             </div>
           </div>
@@ -53,7 +57,11 @@
                 {{ end }}
               </div>
               <div class="title">
-                {{ $NextLink.Page.Description }}
+                {{ if $NextLink.Page.Params.headerTitle }}
+                  {{ $NextLink.Page.Params.headerTitle }}
+                {{ else }}
+                  {{ $NextLink.Page.Title }}
+                {{ end }}
               </div>
             </div>
             <div class="button button-next" role="button" aria-label="Next">

--- a/docs/layouts/search/single.html
+++ b/docs/layouts/search/single.html
@@ -25,7 +25,7 @@
 			<div class="wrapper">
 				{{ partial "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) }}	
 
-				<h1>{{ .Description }} {{ if .Draft }} (Draft){{ end }}</h1>
+				<h1>{{ if .Page.Params.headerTitle }}{{ .Page.Params.headerTitle }}{{ else }}{{ .Page.Title }}{{ end }} {{ if .Draft }} (Draft){{ end }}</h1>
 
 				{{ .TableOfContents }}
 				{{ .Content }}


### PR DESCRIPTION
- Fix H1’s in HTML files to use front matter `headerTitle` if available, otherwise default to page `Title` which, for the most part, is the same. 
- Change section image in header to default to Title, which is accurate
- Change header to use page’s description if available, otherwise use Site param description, and if that fails, use a hardcoded string
- Change pagination link title to use `headerTitle` front matter if available, otherwise use the `Title` param
- Fix some cloud pages that we causing errors due to parser interpreting as html instead of markdown
- Update CONTRIBUTING.md to mention headerTitle as an override