### PR TITLE
[Docs][#3895] Change pagination links to be set when page weight changes

### DIFF
--- a/docs/layouts/partials/pagination_url_search.html
+++ b/docs/layouts/partials/pagination_url_search.html
@@ -6,11 +6,15 @@
   {{ $context := $.context }}
   {{ $iterator := print "neededLinkCurrentIndex" $level }}
   {{ .Scratch.Set $iterator false }}
+  {{ $currentVersion := index (split .File.Dir "/") 0 }}
+  {{ $currentWeight := index .Params "menu" (string $currentVersion) "weight" }}
 
   {{ range $index,$elem := $.menu }}
+    {{ $version := $elem.Menu }}
+    {{ $weight := (index $elem.Page.Params.menu $version).weight }}
     <!-- previous link search -->
       <!-- set next as needed -->
-      {{ if and (not ($context.Scratch.Get "neededNextLink")) ($context.Scratch.Get $iterator) }}
+      {{ if and (not ($context.Scratch.Get "neededNextLink")) ($context.Scratch.Get $iterator) (gt $weight $currentWeight)}}
         {{ $context.Scratch.Set "neededNextLink" $elem }}
       {{ end }}
       <!-- check if current -->
@@ -27,7 +31,7 @@
         {{ end }}
       {{ else }}
         <!-- if not current set as buffer for prev -->
-        {{ if (not ($context.Scratch.Get $iterator)) }}
+        {{ if and (not ($context.Scratch.Get $iterator)) (lt $weight $currentWeight) }}
           {{ $context.Scratch.Set "neededPrevLinkBuffer" $elem }}
         {{ end }}
       {{ end }}


### PR DESCRIPTION
Add check that new page weight is greater than current page weight when going to next page, and less than current page weight when going to previous page.