### PR TITLE
JSON technical changes

### DIFF
--- a/docs/content/latest/api/ysql/datatypes/type_json/create-indexes-check-constraints.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/create-indexes-check-constraints.md
@@ -13,69 +13,74 @@ isTocNested: true
 showAsideToc: true
 ---
 
-Often, when JSON documents are inserted into a table, the table will have just the columns `k` (as a self-populating surrogate primary key) and `v` of data type `jsonb`. This choice allows the use of a broader range of operators and functions, and allows these to execute more efficiently, then when a `json` column is used.
+Often, when  JSON documents are inserted into a table, the table will have just a self-populating surrogate primary key column and a value column, like `v`, of datatype `jsonb`. Choosing `jsonb` allows the use of a broader range of operators and functions, and allows these to execute more efficiently, than does choosing `json`.
 
-It's most likely that each document will be a JSON _object_ and that all will conform to the same structure definition. In other words, each _object_ will have the same set of possible key names (but some might be missing) and the same JSON data type for the value for each key. And when a data type is compound, the same notion of common structure definition will apply, extending the notion recursively to arbitrary depth. Here is an example. To reduce clutter, primary key is not defined to be self-populating.
+It's most likely that each document will be a JSON _object_ and that all will conform to the same structure definition. In other words, each _object_ will have the same set of possible key names (but some might be missing) and the same JSON datatype for the value for each key. And when a datatype is compound, the same notion of common structure definition will apply, extending the notion recursively to arbitrary depth. Here is an example. To reduce clutter, the primary key is not defined to be self-populating. 
 
 ```postgresql
 create table books(k int primary key, json_doc jsonb not null);
 
 insert into books(k, json_doc) values
   (1,
-  '{ "ISBN"   " 1234567890123",
-     "title"  : "Macbeth", 
-     "author" : {"given_name": "William", "family_name": "Shakespeare"},
-     "year"   : 1623}'),
+  '{ "ISBN"    : 4582546494267,
+     "title"   : "Macbeth", 
+     "author"  : {"given_name": "William", "family_name": "Shakespeare"},
+     "year"    : 1623}'),
 
   (2,
-  '{ "title"  : "Hamlet",
-     "author" : {"given_name": "William", "family_name": "Shakespeare"},
-     "year"   : 1603,
-     "editors": ["Lysa", "Elizabeth"] }'),
+  '{ "ISBN"    : 8760835734528,
+     "title"   : "Hamlet",
+     "author"  : {"given_name": "William", "family_name": "Shakespeare"},
+     "year"    : 1603,
+     "editors" : ["Lysa", "Elizabeth"] }'),
 
   (3,
-  '{ "title"  : "Oliver Twist",
-     "author" : {"given_name": "Charles", "family_name": "Dickens"},
-     "year"   : 1838,
-     "genre"  : "novel",
-     "editors": ["Mark", "Tony", "Britney"] }'),
+  '{ "ISBN"    : 7658956876542,
+     "title"   : "Oliver Twist",
+     "author"  : {"given_name": "Charles", "family_name": "Dickens"},
+     "year"    : 1838,
+     "genre"   : "novel",
+     "editors" : ["Mark", "Tony", "Britney"] }'),
   (4,
-  '{ "title"  : "Great Expectations",
-     "author" : {"family_name": "Dickens"},
-     "year"   : 1950,
-     "genre"  : "novel",
-     "editors": ["Robert", "John", "Melisa", "Elizabeth"] }'),
+  '{ "ISBN"    : 9874563896457,
+     "title"   : "Great Expectations",
+     "author"  : {"family_name": "Dickens"},
+     "year"    : 1950,
+     "genre"   : "novel",
+     "editors" : ["Robert", "John", "Melisa", "Elizabeth"] }'),
 
   (5,
-  '{ "title"  : "A Brief History of Time",
-     "author" : {"given_name": "Stephen", "family_name": "Hawking"},
-     "year"   : 1988,
-     "genre"  : "science",
-     "editors": ["Melisa", "Mark", "John", "Fred", "Jane"] }'),
+  '{ "ISBN"    : 8647295405123,
+     "title"   : "A Brief History of Time",
+     "author"  : {"given_name": "Stephen", "family_name": "Hawking"},
+     "year"    : 1988,
+     "genre"   : "science",
+     "editors" : ["Melisa", "Mark", "John", "Fred", "Jane"] }'),
 
   (6,
   '{
-    "year": 1989,
-    "genre": "novel",
-    "title": "Joy Luck Club",
-    "author": {"given_name": "Amy", "family_name": "Tan"},
-    "editors": ["Ruilin", "Jueyin"]}');
+    "ISBN"     : 6563973589123,
+    "year"     : 1989,
+    "genre"    : "novel",
+    "title"    : "Joy Luck Club",
+    "author"   : {"given_name": "Amy", "family_name": "Tan"},
+    "editors"  : ["Ruilin", "Aiping"]}');
 ```
 
 Some of the rows have some of the keys missing. But the row with `k = 6` has every key.
 
-You will probably want at least to know if your corpus contains a nonconformant document and, in some cases, that you will want to disallow nonconformant documents.
+You will probably want at least to know if your corpus contains a non-conformant document and, in some cases, you will want to disallow non-conformant documents. You might want to insist that the ISBN is always defined and is a positive 13-digit number.
 
 You will almost certainly want to retrieve documents, not simply by providing the key, but rather by using predicates on their content—the primitive values that they contain. You will probably want, also, to project out values of interest.
 
-For example, a probable query will be "Show me the books whose hire publication year is between  and whose phone number list includes a _US_ number with area code _415_.
+For example, you might want to see the title and author of books whose publication year is later than 1850.
 
-Of course, then, you will want these queries to be supported by indexes. (The alternative – a table scan over a huge corpus where each document is analyzed on the fly to evaluate the selection predicates is simply unworkabåle.)
+Of course, then, you will want these queries to be supported by indexes. (The alternative – a table scan over a huge corpus where each document is analyzed on the fly to evaluate the selection predicates is simply unworkable.)
 
-## Indexes on _jsonb_ columns
+### Check constraints on _jsonb_ columns
 
 Coming soon.
 
-## Check constraints  on _jsonb_ columns
+### Indexes on _jsonb_ columns
 
 Coming soon.

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/_index.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/_index.md
@@ -23,13 +23,13 @@ The JSON functions and operators available in YugabyteDB are categorized below b
 - [**Convert a JSON value to a SQL value**](#convert-a-json-value-to-a-sql-value)
 - [**Get a property of a JSON value**](#get-a-property-of-a-json-value)
 
-**Note:** For an alphabetical listing of the JSON functions and operators, see the listing in the navigation bar.
+**Notes:** for an alphabetical listing of the JSON functions and operators, see the listing in the navigation bar.
 
 There are two trivial typecast operators for converting between a `text` value that conforms to [RFC 7159](https://tools.ietf.org/html/rfc7159) and a `jsonb` or `json` value, the ordinarily overloaded `=` operator, 12 dedicated JSON operators, and 23 dedicated JSON functions.
 
 Most of the operators are overloaded so that they can be used on both `json` and `jsonb` values. When such an operator reads a subvalue as a genuine JSON value, then the result has the same data type as the input. When such an operator reads a subvalue as a SQL `text` value that represents the JSON value, then the result is the same for a `json` input as for a `jsonb` input.
 
-Some of the functions have just a `jsonb` variant and a couple have just a `json` variant. Function names reflect this by starting with `jsonb_` or ending with `_jsonb` (and, correspondingly, for the `json` variants). This naming scheme might seem to reflect a strange design choice by the implementers of PostgreSQL. A trivial test shows that an overload pair _can_ be distinguished by the difference in formal parameter data type between `jsonb` and `json`. However, PostgreSQL doesn't allow an overload function pair to be distinguished by the difference in return data type. It seems, then, that the PostgreSQL implementers decided to use a single consistent naming convention — a `b` variant and a plain variant — both when the pair differ in the data type of the _input_ JSON value and when they differ in the data type of the _output_ JSON value. Because YSQL is PostgreSQL-compatible, it follows the PostgreSQL convention.
+Some of the functions have just a `jsonb` variant and a couple have just a `json` variant. Function names reflect this by starting with `jsonb_` or ending with `_jsonb` (and, correspondingly, for the `json` variants). The reason that this naming convention is used, rather than ordinary overloading, is that YSQL can distinguish between same-named functions when the specification of their formal parameters differ but not when their return types differ. Some of the JSON builtin functions for a specific purpose differ only by returning a `json` value or a `jsonb` value. This is why a single consistent naming convention — a `b` variant and a plain variant — is used throughout.
 
 When an operator or function has both a JSON value input and a JSON value output, the `jsonb` variant takes a `jsonb` input and produces a `jsonb` output; and, correspondingly, the `json` variant takes a `json` input and produces a `json` output. You can use the `ysqlsh` [`\df`](../../../../../admin/ysqlsh/#df-antws-pattern) metacommand to show the signature (that is, the data types of the formal parameters and the return value) of any of the JSON functions; but you cannot do this for the operators.
 
@@ -41,52 +41,52 @@ To avoid clutter in the tables, only the `jsonb` variants of the function names 
 
 | Function or operator | Description |
 | ---- | ---- |
-| [`::jsonb`](./typecast-operators/#) | Typecasts SQL `text` value that conforms to RFC 7159 to a `jsonb` value. |
-| [`to_jsonb()`](./to-jsonb/) | Converts a single SQL value into a semantically equivalent JSON value. The SQL value can be an arbitrary tree. The intermediate nodes are either `record` (which corresponds to a JSON _object_) or `array` (which corresponds to a JSON _array_). And the terminal nodes a primitive `text`, `numeric`, `boolean`, or `null` (which correspond, respectively, to JSON _string_, _number_, _boolean_, and _null_). In the general case, the result is a JSON _object_ or JSON _array_. In the degenerate case (where the input is a primitive SQL value) the result is the corresponding primitive JSON value. |
-| [`row_to_json()`](./row-to-json/) | A special case of `to_json` that requires that the input is a SQL `record`. The result is a JSON _object_. It has no practical advantage over `to_jsonb()`. |
-| [`array_to_json()`](./array-to-json/) | A special case of `to_json` that requires that the input is a SQL `array`. The result is a JSON _object_. It has no practical advantage over `to_jsonb()`. |
-| [`jsonb_build_array()`](./jsonb-build-array/) | Variadic function that takes an arbitrary number of actual arguments of mixed SQL data types and produce a JSON _array_. Valuable because the values in a JSON _array_  can each have a different data type from the others, but the values in a SQL `array` must all have the same data type. |
-| [`jsonb_build_object()`](./jsonb-build-object/) | Variadic function that is the obvious counterpart to `jsonb_build_array`. The keys and values can be specified in a few different ways, for example in an alternating list of keys (as `text` values) and their values (as values of any of `text`, `numeric`, `boolean` — or `null`. |
-| [`jsonb_object()`](./jsonb-object/)  | Non-variadic function that achieves roughly the same effect as `jsonb_build_object()` with simpler syntax by presenting the key-value pairs using an array of data type `::text`. However, the functionality is severely limited because all the SQL `text` values are mapped to JSON _string_ values. |
+| [`::jsonb`](./typecast-operators/#) | `::jsonb` typecasts a SQL `text` value that conforms to RFC 7159 to a `jsonb` value. Use the appropriate one of  `::jsonb`, `::json`, or `::text` to typecast between any pair out of `text`, `json`, and `jsonb`, in the direction that you need. |
+| [`to_jsonb()`](./to-jsonb/) | Convert a single SQL value of any primitive or compound data type, that allows a JSON representation, to a sematically equivaent `jsonb`, or `json`, value. |
+| [`row_to_json()`](./row-to-json/) | Create a JSON _object_ from a SQL _record_. It has no practical advantage over `to_jsonb()`. |
+| [`array_to_json()`](./array-to-json/) | Create a JSON _array_ from a SQL _array_. It has no practical advantage over `to_jsonb()`. |
+| [`jsonb_build_array()`](./jsonb-build-array/) | Create a JSON _array_ from a variadic list of _array_ values of arbirary SQL data type. |
+| [`jsonb_build_object()`](./jsonb-build-object/) | Create a JSON _object_ from a variadic list that specifies keys with values of arbitrary SQL data type. |
+| [`jsonb_object()`](./jsonb-object/)  | create a JSON _object_ from SQL _array_(s) that specifiy keys with their values of SQL data type `text`. |
 
 ## Convert a JSON value to another JSON value
 
 | Function or operator | Description |
 | ---- | ---- |
-| [`->`](./jsonb-subvalue-operators/) | Reads a subvalue at a specified JSON _object_ key or JSON _array_ index as a JSON value.   |
-| [`#>`](./jsonb-subvalue-operators/) | Like `->` except that the to-be-read JSON subvalue is specified by the path to it from the enclosing JSON value. |
-| [&#124;&#124;](./concatenation-operator/) | Concatenates two JSON values to produce a new JSON value. |
-| [`-`](./remove-operators/) | Creates a new JSON value from the input JSON value: _either_ by removing a key-value pair with the specified key from a JSON _object_; _or_ by removing a JSON value at the specified index in a JSON _array_. Error if the input is not a JSON _object_ or JSON _array_. |
-| [`#-`](./remove-operators) | Like `-` except that the to-be-removed key-value pair (from a JSON _object_) or JSON value (from a JSON _array_) is specified by a path from the enclosing JSON value. The path is specified in the same way as for the `#>` operator. |
-| [`jsonb_extract_path()`](./jsonb-extract-path/) | Functionally equivalent to the `#>` operator. The path is presented as a variadic list of steps that must all be `text` values. Its invocation more verbose than that of the `#>` operator and there seems to be no reason to prefer the function form to the operator form. |
-| [`jsonb_strip_nulls()`](./jsonb-strip-nulls/) | Finds all key-value pairs at any depth in the hierarchy of the supplied JSON compound value (such a pair can occur only as an element of an _object_) and return a JSON value where each pair whose value is _null_. has been removed. By definition, they leave _null_ values within _arrays_ untouched. |
-| [`jsonb_set()` and `jsonb_insert()`](./jsonb-set-jsonb-insert/) | These functions return a new JSON value modified from the input value in the specified way using the so-called replacement JSON value. Because the effect of `jsonb_set` is identical to that of `jsonb_insert` in some cases, they are grouped together here. However, in other cases, there are critical differences. They target a specific JSON value at a specified path. When the target is a key-value pair in a JSON _object_, they set it to the specified value when the key already exists and create it when it doesn't. When the target is a JSON value at a specified index in a JSON _array_, and the index already exists, they either set it or insert a new value after or before it. And when the index is before the _array_'s first value or after its last value, they insert it. |
+| [`->`](./subvalue-operators/) | Read the value specified by a one-step path returning it as a `json` or `jsonb` value.  |
+| [`#>`](./subvalue-operators/) | Read the value specified by a multi-step path returning it as a `json` or `jsonb` value. |
+| [&#124;&#124;](./concatenation-operator/) | Concatenate two `jsonb` values. The rule for deriving the output value depends upon the JSON data types of the operands. |
+| [`-`](./remove-operators/) | Remove key-value pair(s) from an _object_ or a single value from an _array_. |
+| [`#-`](./remove-operators) | Remove a single key-value pair from an _object_ or a single value from an _array_ at the specified path. |
+| [`jsonb_extract_path()`](./jsonb-extract-path/) | Provide the identical functionality to the `#>` operator. The path is presented as a variadic list of steps that must all be `text` values. Its invocation more verbose than that of the `#>` operator and there is no reason to prefer the function form to the operator form. |
+| [`jsonb_strip_nulls()`](./jsonb-strip-nulls/) | Find all key-value pairs at any depth in the hierarchy of the supplied JSON compound value (such a pair can occur only as an element of an _object_) and return a JSON value where each pair whose value is _null_ has been removed. |
+| [`jsonb_set()` and `jsonb_insert()`](./jsonb-set-jsonb-insert/) | Use `jsonb_set()` to change an existing JSON value, i.e. the value of an existing key-value pair in a JSON _object_ or the value at an existing index in a JSON array. Use `jsonb_insert()` to insert a new value, either as the value for a key that doesn't yet exist in a JSON _object_ or beyond the end or before the start of the index range for a JSON _array_. |
 
 ## Convert a JSON value to a SQL value
 
 | Function or operator | Description |
 | ---- | ---- |
-| [`::text`](./typecast-operators/) | Typecasts a `jsonb`  value to a SQL `text` value that conforms to RFC 7159. Single spaces (but not newlines) are inserted in conventioanally defined places. |
-| [`->>`](./json-subvalue-operators/) | Like `->` except that the targeted value is returned as a SQL `text` value: _either_ the `::text` typecast of a compound JSON value; _or_ a typecastable `text` value holding the actual value that a primitive JSON value represents. |
-| [`#>>`](./json-subvalue-operators/) | Like `->>` except that the to-be-read JSON subvalue is specified by the path to it from the enclosing JSON value. |
-| [`jsonb_extract_path_text()`](./jsonb-extract-path-text/) | Functionally equivalent to the `#>>` operator. Parameterized in the same way as `jsonb_extract_path` and `json_extract_path`. There seems to be no reason to prefer the function form to the operator form. |
-| [`jsonb_populate_record()`](./jsonb-populate-record/) | This function requires that the supplied JSON value is an _object_. It translates the JSON _object_ into the equivalent SQL record whose type name is supplied to the functions (using the strange locution `null::type_identifier`). |
-| [`jsonb_populate_recordset()`](./jsonb-populate-recordset/) | A natural extension of the functionality of `jsonb_populate_record`. Requires that the supplied JSON value is an _array_, each of whose subvalues is an _object_ which is compatible with the specified SQL record data type, defined as a `type` whose name is passed using the locution `null:type_identifier`. |
-| [`jsonb_to_record()`](./jsonb-to-record/) | Syntax variant of the same functionality that  `jsonb_populate_record` provides. It has some quirky limitations when the input JSON value has JSON key-value pairs whose JSON values that are compound. It seems, therefore, to bring no practical advantage over its less restricted equivalent. |
-| [`jsonb_to_recordset()`](./jsonb-to-recordset/) | Bears the same relationship to `jsonb_to_record()` as  `json_populate_recordset()` bears to `json_populate_record()`. Again, it seems, therefore, to bring no practical advantage over their its restricted equivalent. |
-| [`jsonb_array_elements()`](./jsonb-array-elements/) | Require that the supplied JSON value is an _array_ whose elements are primitive JSON values, and transform the list into a table whose single column has data type `text` and whose values are the `::text` typecasts of the primitive JSON values. It is the counterpart, for an _array_ of primitive JSON values, to `jsonb_populate_recordset()` for JSON _objects_. |
-| [`jsonb_array_elements_text()`](./jsonb-array-elements-text/) | Bears the same relationship to `jsonb_array_elements` that the other `*text` functions bear to their plain counterparts: it's the same relationship that the `->>` and `#>>` operators bear, respectively to `->` and `#>`. |
-| [`jsonb_each()`](./jsonb-each/) | Requires that the supplied JSON value is an _object_. They return a row set with columns _"key"_ (as a SQL `text`) and _"value"_ (as a SQL `jsonb`). |
-| [`jsonb_each_text()`](./jsonb-each-text/) | Bears the same relationship to the result of `jsonb_each()` as does the result of the `->>` operator to that of the `->` operator. For that reason, `jsonb_each_text()` is useful when the results are primitive values. |
-| [`jsonb_pretty()`](./jsonb-pretty/) | Formats the text representation of the input JSON value  using whitespace to make it maximally easily human readable. |
+| [`::text`](./typecast-operators/) | Typecast a `jsonb`  value to a SQL `text` value that conforms to RFC 7159. Whitesace is conventioanally defined for a `jsonb` operand. Whitespace, in general, is unpredicatable for a `json` operand. |
+| [`->>`](./subvalue-operators/) | Like `->` except that the targeted value is returned as a SQL `text` value: _either_ the `::text` typecast of a compound JSON value; _or_ a typecastable `text` value holding the actual value that a primitive JSON value represents. |
+| [`#>>`](./subvalue-operators/) | Like `->>` except that the to-be-read JSON subvalue is specified by the path to it from the enclosing JSON value. |
+| [`jsonb_extract_path_text()`](./jsonb-extract-path-text/) | Provide the identical functionality to the `#>>` operator. There is no reason to prefer the function form to the operator form. |
+| [`jsonb_populate_record()`](./jsonb-populate-record/) | Convert a JSON _object_ into the equivalent SQL `record`. |
+| [`jsonb_populate_recordset()`](./jsonb-populate-recordset/) | Convert a homogeneous JSON _array_ of JSON _objects_ into the equivalent set of SQL _records_. |
+| [`jsonb_to_record()`](./jsonb-to-record/) | Convert a JSON _object_ into the equivalent SQL `record`. Syntax variant of the functionality that  `jsonb_populate_record()` provides. It has some restrictions and brings no practical advantage over its less restricted equivalent. |
+| [`jsonb_to_recordset()`](./jsonb-to-recordset/) | Bears the same relationship to `jsonb_to_record()` as  `jsonb_populate_recordset()` bears to `jsonb_populate_record()`. Therefore, it brings no practical advantage over its restricted equivalent. |
+| [`jsonb_array_elements()`](./jsonb-array-elements/) | Transform the JSON values of JSON _array_ into a SQL table of (i.e. `setof`) `jsonb` values. |
+| [`jsonb_array_elements_text()`](./jsonb-array-elements-text/) | Transform the JSON values of JSON _array_ into a SQL table of (i.e. `setof`) `text` values. |
+| [`jsonb_each()`](./jsonb-each/) | Create a row set with columns _"key"_ (as a SQL `text`) and _"value"_ (as a SQL `jsonb`) from a JSON _object_. |
+| [`jsonb_each_text()`](./jsonb-each-text/) | Create a row set with columns _"key"_ (as a SQL `text`) and _"value"_ (as a SQL `text`) from a JSON _object_. |
+| [`jsonb_pretty()`](./jsonb-pretty/) | Format the text representation of the JSON value that the input `jsonb` actual argument represents, using whitespace, to make it maximally easily human readable. |
 
 ## Get a property of a JSON value
 
 | Function or operator | Description |
 | ---- | ---- |
-| [`=`](./equality-operator/) | The `=` operator is overloaded for all the SQL data types including `jsonb`. By a strange oversight, there is _no overload_ for plain `json`. |
-| [`@>` and `<@`](./containment-operators/) | `@>` tests if the left-hand JSON value contains the right-hand JSON value. And `<@` tests if the right-hand JSON value contains the left-hand JSON value. Returns a SQL `boolean`. |
+| [`=`](./equality-operator/) | Test if two `jsonb` values are equal. There is no `json` overload.|
+| [`@>` and `<@`](./containment-operators/) | The `@>` operator tests if the left-hand JSON value contains the right-hand JSON value. The `<@` operator tests if the right-hand JSON value contains the left-hand JSON value. |
 | [?, ?&#124;, and ?&](./key-existence-operators/) | Test for existence of keys.  Returns a SQL `boolean`. |
-| [`jsonb_array_length()`](./jsonb-array-length/) | The input must be a JSON _array_. Returns the number of JSON values in the _array_ as a SQL `int`. |
-| [`jsonb_typeof()`](./jsonb-typeof/) | Takes a single JSON value of arbitrary data type (_string_, _number_, _boolean_, _null_,  _object_, and _array_) and returns the data type name as a SQL `text` value. |
-| [`jsonb_object_keys()`](./jsonb-object-keys/) | Require that the supplied JSON value is an _object_. It transforms the list of key names into a set (i.e. table) of SQL `text` values. |
+| [`jsonb_array_length()`](./jsonb-array-length/) | Return the count of values (primitive or compound) in the array. You can use this to iterate over the elements of a JSON _array_ using the  `->` operator. |
+| [`jsonb_typeof()`](./jsonb-typeof/) | Return the data type of the JSON value as a SQL `text` value. |
+| [`jsonb_object_keys()`](./jsonb-object-keys/) | Transform the list of key names int the supplied JSON _object_ into a set (i.e. table) of `text` values. |

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/array-to-json.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/array-to-json.md
@@ -12,15 +12,17 @@ isTocNested: true
 showAsideToc: true
 ---
 
-This has one variant that returns a `json` value. Here is the signature:
+**Purpose:** create a JSON _array_ from a SQL _array_.
+
+**Signature:**
 
 ```
-input value        anyarray
-pretty             boolean
-return value       json
+input value:       anyarray
+pretty:            boolean (optional)
+return value:      json
 ```
 
-The first (mandatory) formal parameter is any SQL `array` whose elements might be compound values. The second formal parameter is optional. When it is _true_, line feeds are added between dimension-1 elements.
+**Notes:** this has only the `json` variant. The first (mandatory) formal parameter is any SQL `array` whose elements might be compound values. The second formal parameter is optional. When it is _true_, line feeds are added between dimension-1 elements.
 
 ```postgresql
 do $body$

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/code-example-conventions.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/code-example-conventions.md
@@ -50,9 +50,9 @@ For these reasons, each code example is presented as a `DO` block with this patt
 - The expected output is declared as a value of the same data type.
 - An `assert` is used to show that the produced value is equal to the expected value, using an `is null` comparison where appropriate.
 
-## Note about SQL array manifest constants
+## Note about SQL _array_ manifest constants
 
-RFC 7159 defines the syntax for a JSON _array_ as a comma-separated list of items surrounded by `[]` and  the syntax for a JSON _object_ as a comma-separated list of key-value pairs surrounded by `{}`. SQL defines one form for an array manifest constant as a `text` value with an inner syntax: the value starts with `{` and ends with `}` and contains a comma-separated list whose items are not themselves quoted but are all taken to be values of the array's data type. So this SQL manifest constant:
+RFC 7159 defines the syntax for a JSON _array_ as a comma-separated list of items surrounded by `[]` and  the syntax for a JSON _object_ as a comma-separated list of key-value pairs surrounded by `{}`. SQL defines one form for an _array_ manifest constant as a `text` value with an inner syntax: the value starts with `{` and ends with `}` and contains a comma-separated list whose items are not themselves quoted but are all taken to be values of the _array_'s data type. So this SQL manifest constant:
 
 ```
 array['a', 'b', 'c']::text[]
@@ -64,6 +64,6 @@ can also be written thus:
 '{a, b, c}'::text[]
 ```
 
-This dramatic context-sensitive difference in meaning of `'{...}'` might confuse the reader. Therefore, in the major section _"JSON data types and functionality"_,  the `array[...]` form will be used for a SQL array manifest constant — and the `'{...}'`form will be avoided.
+This dramatic context-sensitive difference in meaning of `'{...}'` might confuse the reader. Therefore, in the major section _"JSON data types and functionality"_,  the `array[...]` form will be used for a SQL _array_ manifest constant — and the `'{...}'`form will be avoided.
 
-The fact that a JSON array can have subvalues of mixed data type but a SQL array can have only elements of the same data type means that special steps have to be taken when the goal is to construct a JSON array mixed subvalue data type from SQL values.
+The fact that a JSON _array_ can have subvalues of mixed data type but a SQL _array_ can have only elements of the same data type means that special steps have to be taken when the goal is to construct a JSON _array_ mixed subvalue data type from SQL values.

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/concatenation-operator.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/concatenation-operator.md
@@ -12,6 +12,16 @@ isTocNested: true
 showAsideToc: true
 ---
 
+**Purpose:** concatenate two `jsonb` values. The rule for deriving the output value depends upon the JSON data types of the operands. 
+
+**Signature:**
+```
+input values:       jsonb || jsonb
+return value:       jsonb
+```
+
+**Notes:** this operator doesn't have an overload for `json`.
+
 If both sides of the operator are primitive JSON values, then the result is an _array_ of these values:
 
 ```postgresql
@@ -23,7 +33,7 @@ declare
 begin
   assert
     j_left || j_right = j_expected,
- 'assert failed';
+ 'unexpected';
 end;
 $body$;
 ```
@@ -39,7 +49,7 @@ declare
 begin
   assert
     j_left || j_right = j_expected,
- 'assert failed';
+ 'unexpected';
 end;
 $body$;
 ```
@@ -55,7 +65,7 @@ declare
 begin
   assert
     j_left || j_right = j_expected,
- 'assert failed';
+ 'unexpected';
 end;
 $body$;
 ```
@@ -71,7 +81,7 @@ declare
 begin
   assert
     j_left || j_right = j_expected,
- 'assert failed';
+ 'unexpected';
 end;
 $body$;
 ```
@@ -87,7 +97,7 @@ declare
 begin
   assert
     j_left || j_right = j_expected,
- 'assert failed';
+ 'unexpected';
 end;
 $body$;
 ```

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/containment-operators.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/containment-operators.md
@@ -13,7 +13,21 @@ isTocNested: true
 showAsideToc: true
 ---
 
-The `@>` operator tests if the left-hand JSON value contains the right-hand JSON value. And the `<@` operator tests if the right-hand JSON value contains the left-hand JSON value. These operators require that the inputs are presented as `jsonb` values. They don't have overloads for `json`.
+**Purpose:** the `@>` operator tests if the left-hand JSON value contains the right-hand JSON value. The `<@` operator tests if the right-hand JSON value contains the left-hand JSON value.
+
+**Signatures:**
+
+```
+input values:       jsonb @> jsonb
+return value:       boolean
+```
+and:
+```
+input values:       jsonb <@ jsonb
+return value:       boolean
+```
+
+**Notes:** these operators require that the inputs are presented as `jsonb` values. They don't have overloads for `json`.
 
 ```postgresql
 do $body$
@@ -24,7 +38,7 @@ begin
   assert
     (j_left @> j_right) and
     (j_right <@ j_left),
- 'assert failed';
+ 'unexpected';
 end;
 $body$;
 ```

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/equality-operator.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/equality-operator.md
@@ -13,8 +13,19 @@ isTocNested: true
 showAsideToc: true
 ---
 
-This operator requires that the inputs are presented as `jsonb` values. It doesn't have an overload for `json`.
+**Purpose:** test if two `jsonb` values are equal.
 
+**Signature:**
+```
+input values:       jsonb = jsonb
+return value:       boolean
+```
+
+**Notes:** it doesn't have an overload for `json`.. If you want to test that two `json` values are equal, express the predicate thus:
+```
+lhs_json_value::text = rhs_json_value::text
+```
+Example:
 ```postgresql
 do $body$
 declare
@@ -25,24 +36,29 @@ declare
     ]';
 begin
   assert
-    j1::text = j2::text,
+    j1 = j2,
   'unexpected';
 end;
 $body$;
 ```
 
-Notice that the text forms of the to-be-compared JSON values may differ in whitespace. Because `jsonb` holds a fully parsed representation of the value, whitespace (exception within primitive JSON _string_ values) has no meaning.
+Notice that the text definitions of the to-be-compared JSON values may differ in whitespace. Because `jsonb` holds a fully parsed representation of the value, whitespace (except within primitive JSON _string_ values and key names) has no meaning.
 
 If you need to test two `json` values for equality, then you must `::text` typecast each.
+
+See the account of the `::text` operator when the input is a `json` value. The `json` representation preserves semantically insignificant whitespace and repeats occurrents of the same keys in an _object_. This implies that the equality comparison ow two `json` values will in general be unpredicatble and therefore meaningless. This is another reason to prefer consistently to choose to use `jsonb`.
 
 ```postgresql 
 do $body$
 declare
   j1 constant json := '["a","b","c"]';
   j2 constant json := '["a","b","c"]';
+  j3 constant json := '["a","b", "c"]';
+
 begin
   assert
-    j1::text = j2::text,
+    (j1::text = j2::text) and
+    not (j1::text = j3::text),
   'unexpected';
 end;
 $body$;

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-array-elements-text.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-array-elements-text.md
@@ -13,14 +13,20 @@ isTocNested: true
 showAsideToc: true
 ---
 
-Here is the signature for the `jsonb` variant:
+**Purpose:** transform the JSON values of JSON _array_ into a SQL table of (i.e. `setof`) `text` values.
+
+**Signature:** for the `jsonb` variant:
 
 ```
-input value        jsonb
-return value       SETOF text
+input value:       jsonb
+return value:      SETOF text
 ```
 
-The function `jsonb_array_elements_text()` bears the same relationship to `jsonb_array_elements()` that the other `*text()` functions bear to their plain counterparts: it's the same relationship that the `->>` and `#>>` operators bear, respectively to `->` and `#>`. This example uses the same JSON _array_ input that was used to illustrate `jsonb_array_elements()` .
+**Notes:** The function `jsonb_array_elements_text()` bears the same relationship to `jsonb_array_elements()` that the other `*text()` functions bear to their plain counterparts: it's the same relationship that the `->>` and `#>>` operators bear, respectively to `->` and `#>`. (Compound values become the RFC 7159 text of the value; primitive values become the `::text` representation of the SQL value that the JSON primitive value corresponds to.)
+
+This example uses the same JSON _array_ input that was used to illustrate `jsonb_array_elements()`.
+
+Notice that the JSON value _null_ becomes a genuine SQL `null` and so needs the dedicated `is null` test.
 
 ```postgresql
 do $body$

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-array-elements.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-array-elements.md
@@ -12,20 +12,21 @@ menu:
 isTocNested: true
 showAsideToc: true
 ---
+**Purpose:** transform the JSON values of JSON _array_ into a SQL table of (i.e. `setof`) `jsonb` values.
 
-Here is the signature for the `jsonb` variant:
+**Signature:** for the `jsonb` variant:
 
 ```
-input value        jsonb
-return value       SETOF jsonb
+input value:       jsonb
+return value:      SETOF jsonb
 ```
 
-The functions in this pair require that the supplied JSON value is an _array_, and transform the list into a table. They are the counterparts, for an _array_ of primitive JSON values, to `jsonb_populate_recordset()` for JSON _objects_.
+**Notes:** the functions in this pair require that the supplied JSON value is an _array_, They are the counterparts, for an _array_, to `jsonb_populate_recordset()` for a JSON _object_.
 
 ```postgresql
 do $body$
 declare
-  j_array constant jsonb := '["cat", "dog house", 42, true, null, {"x": 17}]';
+  j_array constant jsonb := '["cat", "dog house", 42, true, {"x": 17}, null]';
   j jsonb;
 
   elements jsonb[];
@@ -35,8 +36,8 @@ declare
       '"dog house"'::jsonb,
       '42'::jsonb,
       'true'::jsonb,
-      'null'::jsonb,
-      '{"x": 17}'::jsonb
+      '{"x": 17}'::jsonb,
+      'null'::jsonb
     ];
 
   n int := 0;

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-array-length.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-array-length.md
@@ -13,15 +13,16 @@ isTocNested: true
 showAsideToc: true
 ---
 
+**Purpose:** return the count of values (primitive or compound) in the array. You can use this to iterate over the elements of a JSON _array_ using the  `->` operator.
 
-The functions in this pair require that the supplied JSON value is an _array_. Here is the signature for the `jsonb` variant:
+**Signature** for the `jsonb` variant:
 
 ```
-input value        jsonb
-return value       integer
+input value:       jsonb
+return value:      integer
 ```
 
-The functions return the count of values (primitive or compound) in the array. You can use this to iterate over the elements of a JSON _array_ using the  `->` operator.
+**Notes:** The functions in this pair require that the supplied JSON value is an _array_.
 
 ```postgresql
 do $body$
@@ -31,10 +32,8 @@ declare
 
   expected_typeof constant text[] :=
     array['string', 'number', 'boolean', 'null'];
-
-  n int := 0;
 begin
-  for n in 1..last_idx loop
+  for n in 0..last_idx loop
     assert
       jsonb_typeof(j -> n) = expected_typeof[n + 1],
     'unexpected';

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-build-array.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-build-array.md
@@ -13,14 +13,18 @@ isTocNested: true
 showAsideToc: true
 ---
 
-Here is the signature for the `jsonb` variant:
+**Purpose:** create a JSON _array_ from a variadic list of _array_ values of arbirary SQL data type.
+
+**Signature** for the `jsonb` variant:
 
 ```
-input value        VARIADIC "any"
-return value       jsonb
+input value:       VARIADIC "any"
+return value:      jsonb
 ```
 
-These two functions take an arbitrary number of actual arguments of mixed SQL data types. (The PostgreSQL documentation uses the term _"[variadic](https://en.wikipedia.org/wiki/Variadic_function)"_ to characterize this.) The data type of each argument must have a direct JSON equivalent or allow implicit conversion to such an equivalent. Use this _ysqlsh_ script to create the required type `t` and then to execute the `assert`.
+**Notes:** these two functions take an arbitrary number of actual arguments of mixed SQL data types. The data type of each argument must have a direct JSON equivalent or allow implicit conversion to such an equivalent.
+
+Use this _ysqlsh_ script to create the required type `t` and then to execute the `assert`.
 
 ```postgresql
 create type t as (a int, b text);
@@ -61,6 +65,7 @@ begin
 end;
 $body$;
 
+-- Relies on "type t as (a int, b text)" created above.
 do $body$
 declare
   v_17 constant int := 17;
@@ -68,8 +73,8 @@ declare
   v_true constant boolean := true;
   v_t constant t := (17::int, 'cat'::text);
 
-  j constant jsonb := jsonb_build_array(v_17, v_dog, v_true, v_t);
-  expected_j constant jsonb := f(
+  expected_j constant jsonb := jsonb_build_array(v_17, v_dog, v_true, v_t);
+  j constant jsonb := f(
     $$
       17::integer,
       'dog'::text,

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-each-text.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-each-text.md
@@ -13,14 +13,18 @@ isTocNested: true
 showAsideToc: true
 ---
 
-Here is the signature for the `jsonb` variant:
+**Purpose:** create a row set with columns _"key"_ (as a SQL `text`) and _"value"_ (as a SQL `text`) from a JSON _object_.
+
+**Signature** for the `jsonb` variant:
 
 ```
-input value        jsonb
-return value       SETOF (text, text)
+input value:       jsonb
+return value:      SETOF (text, text)
 ```
 
-The result of `jsonb_each_text()` bears the same relationship to the result of `jsonb_each()` as does the result of the `->>` operator to that of the `->` operator. For that reason, `jsonb_each_text()` is useful when the results are primitive values. Use this _ysqlsh_ script to create the required type `t` and then to execute the `assert`.
+**Notes:** the result of `jsonb_each_text()` bears the same relationship to the result of `jsonb_each()` as does the result of the `->>` operator to that of the `->` operator. For that reason, `jsonb_each_text()` is useful when the results are primitive values.
+
+Use this _ysqlsh_ script to create the required type `t` and then to execute the `assert`.
 
 ```postgresql
 create type t as (k text, v text);

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-each.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-each.md
@@ -13,14 +13,16 @@ isTocNested: true
 showAsideToc: true
 ---
 
-Here is the signature for the `jsonb` variant:
+**Purpose:** create a row set with columns _"key"_ (as a SQL `text`) and _"value"_ (as a SQL `jsonb`) from a JSON _object_.
+
+**Signature** for the `jsonb` variant:
 
 ```
-input value        jsonb
-return value       SETOF (text, jsonb)
+input value:       jsonb
+return value:      SETOF (text, jsonb)
 ```
 
-The functions in this pair require that the supplied JSON value is an _object_. They return a row set with columns _"key"_ (as a SQL `text`) and _"value"_ (as a SQL `jsonb`). Use this _ysqlsh_ script to create the required type `t` and then to execute the `assert`.
+Use this _ysqlsh_ script to create the required type `t` and then to execute the `assert`.
 
 ```postgresql
 create type t as (k text, v jsonb);

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-extract-path-text.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-extract-path-text.md
@@ -13,11 +13,13 @@ isTocNested: true
 showAsideToc: true
 ---
 
-Here is the signature for the `jsonb` variant:
+**Purpose:** provide the identical functionality to the `#>>` operator.
+
+**Signature** for the `jsonb` variant:
 
 ```
-input value        jsonb, VARIADIC text
-return value       text
+input value:       jsonb, VARIADIC text
+return value:      text
 ```
 
-The result `jsonb_extract_path_text()` bears the same relationship to the result of its `jsonb_extract_path()`as does the result of the `#>>` operator to that of the `#>` operator. For the same reasons that there is no reason to prefer`jsonb_extract_path()` over `#>`, there is no reason to prefer `jsonb_extract_path_text()` over `#>>`.
+**Notes:** the result of `jsonb_extract_path_text()` bears the same relationship to the result of its `jsonb_extract_path()` counterpart as does the result of the `#>>` operator to that of its `#>` counterpart. For the same reason that there is no reason to prefer`jsonb_extract_path()` over `#>`, there is no reason to prefer `jsonb_extract_path_text()` over `#>>`.

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-extract-path.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-extract-path.md
@@ -13,14 +13,16 @@ isTocNested: true
 showAsideToc: true
 ---
 
-Here is the signature for the `jsonb` variant:
+**Purpose:** provide the identical functionality to the `#>` operator.
+
+**Signature** for the `jsonb` variant:
 
 ```
-input value        jsonb, VARIADIC text
-return value       jsonb
+input value:       jsonb, VARIADIC text
+return value:      jsonb
 ```
 
-These are functionally identical to the `#>` operator. The invocation of `#>` can be mechanically transformed to use `jsonb_extract_path()` by these steps:
+The invocation of `#>` can be mechanically transformed to use `jsonb_extract_path()` by these steps:
 
 - Add the function invocation with its required parentheses.
 - Replace `#>` with a comma.
@@ -47,6 +49,6 @@ end;
 $body$;
 ```
 
-Strangely, even though `jsonb_extract_path()`is variadic, each step that defines the path must be presented as a convertible SQL `text`, even when its meaning is a properly expressed by a SQL `integer`.
+Notice that even though `jsonb_extract_path()`is variadic, each step that defines the path must be presented as a convertible SQL `text`, even when its meaning is a properly expressed by a SQL `integer`.
 
-The function form is more verbose than the operator form. Moreover, the fact that the function is variadic makes it impossible to invoke it statically (in PL/pgSQL code) when the path length isn't known until run time. There seems, therefore, to be no reason to prefer the function form to the operator form.
+The function form is more verbose than the operator form. Moreover, the fact that the function is variadic makes it impossible to invoke it statically (in PL/pgSQL code) when the path length isn't known until run time. There is, therefore, no reason to prefer the function form to the operator form.

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-object-keys.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-object-keys.md
@@ -13,14 +13,16 @@ isTocNested: true
 showAsideToc: true
 ---
 
-Here is the signature for the `jsonb` variant:
+**Purpose:** transform the list of key names int the supplied JSON _object_ into a set (i.e. table) of `text` values.
+
+**Signature** for the `jsonb` variant:
 
 ```
-input value        jsonb
-return value       SETOF text
+input value:       jsonb
+return value:      SETOF text
 ```
 
-The functions in this pair require that the supplied JSON value is an _object_. They transform the list of key names into a set (i.e. table) of `text` values. Notice that the returned keys are ordered alphabetically.
+**Notes:** The functions in this pair require that the supplied JSON value is an _object_. The returned keys are ordered alphabetically.
 
 ```
 do $body$

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-object.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-object.md
@@ -13,18 +13,18 @@ isTocNested: true
 showAsideToc: true
 ---
 
-Here is the signature for the `jsonb` variant:
+**Purpose:** create a JSON _object_ from SQL _array_(s) that specifiy keys with their values of SQL data type `text`.
+
+**Signature** for the `jsonb` variant:
 
 ```
-input value        text[]  OR text[][]  OR  text[], text[]
-return value       jsonb
+input value:       [ text[] ]  |  [ text[][] ]  |  [ text[], text[] ]
+return value:      jsonb
 ```
 
-The `jsonb_object()` function achieves a similar effect to `jsonb_build_object()` but with significantly less verbose syntax.
+**Notes**: the `jsonb_object()` function achieves a similar effect to `jsonb_build_object()` but with significantly less verbose syntax.
 
-Precisely because you present a single `text` actual, you can avoid the fuss of dynamic invocation and of dealing with interior single quotes that this brings in its train.
-
-However, it has the limitation that the primitive values in the resulting JSON value can only be _string_. It has three overloads.
+Precisely because you present a single `text` actual, you can avoid the fuss of dynamic invocation and of dealing with interior single quotes that this brings in its train. However, it has the limitation that the primitive values in the resulting JSON value can only be _string_. It has three overloads.
 
 The first overload has a single `text[]` formal whose actual text expresses the variadic intention conventionally: the alternating _comma_ separated items are the respectively the key and the value of a key-value pair.
 
@@ -47,7 +47,7 @@ $body$;
 
 Compare this result with the result from supplying the same primitive SQL values to the `jsonb_build_object()` function. There, the data types of the SQL values are properly honored: The _numeric_ `17` and the _boolean_ `true` are represented by the proper JSON primitive types. But with `jsonb_object()` there is simply no way to express that `17` should be taken as a JSON _number_ value and `true` should be taken as a JSON _boolean_ value.
 
-The potential loss of data type fidelity brought by `jsonb_object()` seems to be a high price to pay for the reduction in verbosity. On the other hand, `jsonb_object()` has the distinct advantage over `jsonb_build_object()` that you don't need to know statically how many key-value pairs the target JSON _object_ is to have.
+The potential loss of data type fidelity brought by `jsonb_object()` is a high price to pay for the reduction in verbosity. On the other hand, `jsonb_object()` has the distinct advantage over `jsonb_build_object()` that you don't need to know statically how many key-value pairs the target JSON _object_ is to have.
 
 If you think that it improves the clarity, you can use the second overload. This has a single `text[][]` formal—in other words an array of arrays.
 

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-populate-record.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-populate-record.md
@@ -12,14 +12,18 @@ isTocNested: true
 showAsideToc: true
 ---
 
-Here is the signature for the `jsonb` variant:
+**Purpose:** convert a JSON _object_ into the equivalent SQL `record`.
+
+**Signature** for the `jsonb` variant:
 
 ```
-input value        anyelement, jsonb
-return value       anyelement
+input value:       anyelement, jsonb
+return value:      anyelement
 ```
 
-The functions in this pair require that the supplied JSON value is an _object_. They translate the JSON _object_ into the equivalent SQL` record`. The data type of the `record` must be defined as a schema-level `type` whose name is passed via the function's first formal parameter using the locution `null:type_identifier`. The JSON value is passed via the second formal parameter. Use this _ysqlsh_ script to create the required types `t1` and `t2`, and then to execute the `assert`.
+**Notes:** require that the supplied JSON value is an _object_. The data type of the `record` must be defined as a schema-level `type` whose name is passed via the function's first formal parameter using the locution `null:type_identifier`. The JSON value is passed via the second formal parameter.
+
+Use this _ysqlsh_ script to create the required types `t1` and `t2`, and then to execute the `assert`.
 
 ```
 create type t1 as ( d int, e text);

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-populate-recordset.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-populate-recordset.md
@@ -12,14 +12,17 @@ isTocNested: true
 showAsideToc: true
 ---
 
-Here is the signature for the `jsonb` variant:
+**Purpose:** convert a homogeneous JSON _array_ of JSON _objects_ into the equivalent set of SQL _records_.
+
+
+**Signature** for the `jsonb` variant:
 
 ```
-input value        anyelement, jsonb
-return value       SETOF anyelement
+input value:       anyelement, jsonb
+return value:      SETOF anyelement
 ```
 
-The functions in this pair and are a natural extension of the functionality of `jsonb_populate_record()`.
+**Notes:** the functions in this pair and are a natural extension of the functionality of `jsonb_populate_record()`.
 
 Each requires that the supplied JSON value is an _array_, each of whose values is an _object_ which is compatible with the specified SQL `record` which is defined as a `type` whose name is passed via the function's first formal parameter using the locution `null:type_identifier`. The JSON value is passed via the second formal parameter. The result is a set (i.e. a table) of `record`s of the specified type.
 

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-pretty.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-pretty.md
@@ -12,18 +12,18 @@ isTocNested: true
 showAsideToc: true
 ---
 
-This function formats the text representation of the JSON value that the input `jsonb` actual argument represents, using whitespace to make it maximally easily human readable.
+**Purpose:** format the text representation of the JSON value that the input `jsonb` actual argument represents, using whitespace, to make it maximally easily human readable.
 
-Here is its signature:
+**Signature:**
 
 ```
-input value        jsonb
-return value       text
+input value:       jsonb
+return value:      text
 ```
+
+**Notes:** `jsonb_pretty()` has no variant for a plain `json` value. However, you can trivially typecast a `json` value to a `jsonb` value.
 
 Because, in the main, JSON is mechanically generated and mechanically consumed, it's unlikely that you'll use `jsonb_pretty()` in final production code. However, because JSON isn't self-describing, and because external documentation of a corpus's data-representation intent isn't always available, developers often need to study a representative set of extant JSON values and deduce the intended rules of composition. This task is made hugely easier when JSON values are formatted in a standard, well designed, way.
-
-Notice that `jsonb_pretty()` has no variant for a plain `json` value. However, you can trivially typecast a `json` value to a `jsonb` value.
 
 The pretty format makes conventional, and liberal, use of newlines and spaces, thus:
 
@@ -52,7 +52,7 @@ declare
 begin
   assert
     pretty_text = expected_pretty_text,
- 'assert failed';
+ 'unexpected';
 end;
 $body$;
 ```

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-set-jsonb-insert.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-set-jsonb-insert.md
@@ -1,8 +1,8 @@
 ---
-title: jsonb_set()
-linkTitle: jsonb_set()
-summary: jsonb_set()  and jsonb_insert()
-description: jsonb_set()  and jsonb_insert()
+title: jsonb_set(), jsonb_insert()
+linkTitle: jsonb_set(), jsonb_insert()
+summary: jsonb_set() and jsonb_insert()
+description: jsonb_set() and jsonb_insert()
 menu:
   latest:
     identifier: jsonb-set-jsonb-insert
@@ -12,36 +12,214 @@ isTocNested: true
 showAsideToc: true
 ---
 
-These two functions require a `jsonb` input. There are no variants for plain `json`.
+**Purpose**: use `jsonb_set()` to change an existing JSON value, i.e. the value of an existing key-value pair in a JSON _object_ or the value at an existing index in a JSON array. Use `jsonb_insert()` to insert a new value, either as the value for a key that doesn't yet exist in a JSON _object_ or beyond the end or before the start of the index range for a JSON _array_.
 
-- Use `jsonb_set()` to change an existing JSON value, i.e. the value of an existing key-value pair in a JSON _object_ or the value at an existing index in a JSON array.
-
-- Use `jsonb_insert()` to insert a new value, either as the value for a key that doesn't yet exist in a JSON _object_ or beyond the end or before the start of the index range for a JSON _array_.
-
-It turns out that the effect of the two functions is the same in some cases. This brings useful "upsert" functionality when the target is a JSON _array_. Here are their signatures:
+**Signature:** For `jsonb_set()`:
 
 ```
-jsonb_set()
------------
-  jsonb_in           jsonb
-  path               text[]
-  replacement        jsonb
-  create_if_missing  boolean default true
-  return value       jsonb
+jsonb_in:           jsonb
+path:               text[]
+replacement:        jsonb
+create_if_missing:  boolean default true
+return value:       jsonb
 ```
 
-and:
+**Signature:** For `jsonb_insert()`:
 
 ```
-jsonb_insert()
---------------
-  jsonb_in           jsonb
-  path               text[]
-  replacement        jsonb
-  insert_after       boolean default false
-  return value       jsonb
+jsonb_in:           jsonb
+path:               text[]
+replacement:        jsonb
+insert_after:       boolean default false
+return value:       jsonb
+```
+**Notes:**
+
+- These two functions require a `jsonb` input. There are no variants for plain `json`.
+
+- It turns out that the effect of the two functions is the same in some cases. This brings useful "upsert" functionality when the target is a JSON _array_.
+
+- The meaning of the defaulted `boolean` formal parameter is context dependent.
+
+- The input JSON value must be either an _object_ or an _array_ — in other words, it must have elements that can be addressed by a path.
+
+#### Semantics when _jsonb&#95;in_ is an _object_
+
+An _object_ is a set of key-value pairs where each key is unique and the order is undefined and insignificant. (As explained earlier, when a JSON manifest constant is parsed, or when two JSON values are concatenated, and if a key is repeated, then the last-mentioned in left-to-right order wins.) The functionality is sufficiently illustrated by a `json_in` value that has just primitive values. The result of each function invocation is the same.
+
+```postgresql
+do $body$
+declare
+  j constant jsonb := '{"a": 1, "b": 2, "c": 3}';
+  path constant text[] := array['d'];
+  new_number constant jsonb := '4';
+
+  j_set constant jsonb := jsonb_set(
+    jsonb_in          => j,
+    path              => path,
+    replacement       => new_number,
+    create_if_missing => true);
+
+  j_insert constant jsonb := jsonb_insert(
+    jsonb_in          => j,
+    path              => path,
+    replacement       => new_number,
+    insert_after      => false);
+
+  expected_j constant jsonb := '{"a": 1, "b": 2, "c": 3, "d": 4}';
+
+begin
+  assert
+    j_set = expected_j and
+    j_insert = expected_j,
+  'unexpected';
+end;
+$body$;
 ```
 
-The meaning of the defaulted boolean formal parameter is context dependent.
+Notice that the specified `path`, the key `"d"` doesn't yet exist. Each function call asks to produce the result that the key `"d"` should exist with  the value `4`. So, as we see, the effect of each, as written above, is the same.
 
-The input JSON value must be either an _object_ or an _array_ — in other words, it must have elements that can be addressed by a path.
+If `jsonb_set()` is invoked with `create_if_missing=>false`, then its result is the same as the input. But if `jsonb_insert()` is invoked with `insert_after=>true`, then its output is the same as when it's invoked with `insert_after=>false`. This reflects the fact that the order of key-value pairs in an _object_ is insignificant.
+
+What if `path` specifies a key that does already exist? Now `jsonb_insert()` causes this error when it's invoked both with `insert_after=>true` and with `insert_after=>false`:
+```
+cannot replace existing key
+Try using the function jsonb_set to replace key value.
+```
+
+And this `DO` block quitely succeeds, both when it's invoked with `create_if_missing=>false` and when it's invoked with `create_if_missing=>true`.
+
+```postgresql
+do $body$
+declare
+  j constant jsonb := '{"a": 1, "b": 2, "c": 3}';
+  path constant text[] := array['c'];
+  new_number constant jsonb := '4';
+
+  j_set constant jsonb := jsonb_set(
+    jsonb_in          => j,
+    path              => path,
+    replacement       => new_number,
+    create_if_missing => true);
+
+  expected_j constant jsonb := '{"a": 1, "b": 2, "c": 4}';
+
+begin
+  assert
+    j_set = expected_j,
+  'unexpected';
+end;
+$body$;
+```
+#### Semantics when _jsonb&#95;in_ is an _array_
+
+An _array_ is a list of index-addressable values — in other words, the order is undefined and insignificant. Again, the functionality is sufficiently illustrated by a `json_in` value that has just primitive values. Now the result of `jsonb_set()` differs from that of `jsonb_insert()`. 
+
+```postgresql
+do $body$
+declare
+  j constant jsonb := '["a", "b", "c", "d"]';
+  path constant text[] := array['3'];
+  new_string constant jsonb := '"x"';
+
+  j_set constant jsonb := jsonb_set(
+    jsonb_in          => j,
+    path              => path,
+    replacement       => new_string,
+    create_if_missing => true);
+
+  j_insert constant jsonb := jsonb_insert(
+    jsonb_in     => j,
+    path         => path,
+    replacement  => new_string,
+    insert_after => true);
+
+  expected_j_set    constant jsonb := '["a", "b", "c", "x"]';
+  expected_j_insert constant jsonb := '["a", "b", "c", "d", "x"]';
+
+begin
+  assert
+    (j_set = expected_j_set) and
+    (j_insert = expected_j_insert),
+  'unexpected';
+end;
+$body$;
+```
+
+Notice that the path denotes the fourth value and that this already exists.
+
+Here, `jsonb_set()` located the fourth value and set it to `"x"` while `jsonb_insert()` located the fourth value and, as requested by `insert_after=>true`, inserted `"x"` after it. Of course, with `insert_after=>false`, `"x"` is inserted before `"d"`. And (of course, again) the choice for `create_if_missing` has no effect on the result of `jsonb_set()`.
+
+What if the path denotes a value beyond the end of the array?
+
+```postgresql
+do $body$
+declare
+  j constant jsonb := '["a", "b", "c", "d"]';
+  path constant text[] := array['42'];
+  new_string constant jsonb := '"x"';
+
+  j_set constant jsonb := jsonb_set(
+    jsonb_in          => j,
+    path              => path,
+    replacement       => new_string,
+    create_if_missing => true);
+
+  j_insert constant jsonb := jsonb_insert(
+    jsonb_in          => j,
+    path              => path,
+    replacement       => new_string,
+    insert_after      => true);
+
+  expected_j constant jsonb := '["a", "b", "c", "d", "x"]';
+
+begin
+  assert
+    j_set = expected_j and
+    j_insert = expected_j,
+  'unexpected';
+end;
+$body$;
+```
+
+Here, each function had the same effect.
+
+The path, for `jsonb_set()`, is taken to mean the as yet nonexistent fifth value. So, with `create_if_missing=>false`, `jsonb_set()` has no effect.
+
+The path, for `jsonb_insert()`, is also taken to mean the as yet nonexistent fifth value. But now, the choice of `true` or `false` for `insert_after` makes no difference because before, or after, a nonexistent element is simply taken to mean insert it.
+
+Notice that even if the path is specified as `-42` (i.e. an impossible _array_ index) the result is the complementary. So this:
+
+```postgresql
+do $body$
+declare
+  j constant jsonb := '["a", "b", "c", "d"]';
+  path constant text[] := array['-42'];
+  new_string constant jsonb := '"x"';
+
+  j_set constant jsonb := jsonb_set(
+    jsonb_in          => j,
+    path              => path,
+    replacement       => new_string,
+    create_if_missing => true);
+
+  j_insert constant jsonb := jsonb_insert(
+    jsonb_in          => j,
+    path              => path,
+    replacement       => new_string,
+    insert_after      => true);
+
+  expected_j constant jsonb := '["x", "a", "b", "c", "d"]';
+
+begin
+  assert
+    j_set = expected_j and
+    j_insert = expected_j,
+  'unexpected';
+end;
+$body$;
+```
+
+The path, for `jsonb_set()`, is taken to mean a new first value (implying that the existing values all move along one place). So, again, with `create_if_missing=>false`, `jsonb_set()` has no effect. 
+
+The path, for `jsonb_insert()`, is also taken to mean a new first value. So again, the choice of `true` or `false` for `insert_after` makes no difference because before or after, a nonexsistent element is simply taken to mean insert it.

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-strip-nulls.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-strip-nulls.md
@@ -12,14 +12,16 @@ isTocNested: true
 showAsideToc: true
 ---
 
-Here is the signature for the `jsonb` variant:
+**Purpose:** find all key-value pairs at any depth in the hierarchy of the supplied JSON compound value (such a pair can occur only as an element of an _object_) and return a JSON value where each pair whose value is _null_ has been removed.
+
+**Signature** for the `jsonb` variant:
 
 ```
-input value        jsonb
-return value       jsonb
+input value:       jsonb
+return value:      jsonb
 ```
 
-Each function returns a value of the same data type as that of the actual with which it is invoked. They find all key-value pairs at any depth in the hierarchy of the supplied JSON compound value (such a pair can occur only as an element of an _object_) and return a JSON value where each pair whose value is _null_. has been removed. By definition, they leave _null_ values within _arrays_ untouched.
+**Notes:** by definition, these functions leave _null_ values within _arrays_ untouched.
 
 ```postgresql
 do $body$

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-to-record.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-to-record.md
@@ -12,14 +12,18 @@ isTocNested: true
 showAsideToc: true
 ---
 
-Here is the signature for the `jsonb` variant:
+**Purpose:** convert a JSON _object_ into the equivalent SQL `record`.
+
+**Signature** for the `jsonb` variant:
 
 ```
-input value        jsonb
-return value       record
+input value:       jsonb
+return value:      record
 ```
 
-The `jsonb_to_record()` function is a syntax variant of the same functionality that  `jsonb_populate_record()` provides. It doesn't need a schema-level type but, rather, uses the special SQL locution `select... as on_the_fly(<record definition>)`. Notice that `on_the_fly` is a nonce name, made up for this example. Anything will suffice. Use this _ysqlsh_ script to create the  type `t` that just `jsonb_populate_record()` requires, to convert the input `jsonb` into a SQL `record` using each of  `jsonb_populate_record()` and `jsonb_to_record`, and then to execute the `assert`.
+**Notes:** the `jsonb_to_record()` function is a syntax variant of the same functionality that [`jsonb_populate_record`](./jsonb-populate-record/) provides. It doesn't need a schema-level type but, rather, uses the special SQL locution `select... as on_the_fly(<record definition>)`.
+
+Use this _ysqlsh_ script to create the  type `t` that just `jsonb_populate_record()` requires, to convert the input `jsonb` into a SQL `record` using each of  `jsonb_populate_record()` and `jsonb_to_record`, and then to execute the `assert`. Notice that `on_the_fly` is a nonce name, made up for this example. Anything will suffice.
 
 ```postgresql
 create type t as (a int, b text);
@@ -82,4 +86,4 @@ It does show that `jsonb_populate_record()` and `jsonb_to_record()` both produce
 
 So the outer type `t2` can be defined on the fly in the `as` clause but it references the inner schema-level type `t1`. It isn't possible to absorb `t1`'s definition into the `as` clause. Moreover, the fact that `jsonb_to_record()` cannot be used in an ordinary assignment but requires a SQL `select ... into` statement is a serious drawback.
 
-It would seem, therefore, that the `jsonb_to_record()` variant has no practical advantage over the `jsonb_populate_record()` variant.
+The `jsonb_to_record()` syntax variant therefore has no practical advantage over the `jsonb_populate_record()` variant.

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-to-recordset.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-to-recordset.md
@@ -12,14 +12,18 @@ isTocNested: true
 showAsideToc: true
 ---
 
-Here is the signature for the `jsonb` variant:
+**Purpose:** convert a homogeneous JSON _array_ of JSON _objects_ into the equivalent set of SQL _records_.
+
+**Signature** for the `jsonb` variant:
 
 ```
-input value        jsonb
-return value       SETOF record
+input value:       jsonb
+return value:      SETOF record
 ```
 
-The function `jsonb_to_recordset()` bears the same relationship to `jsonb_to_record()` as  `json_populate_recordset()` bears to `json_populate_record()`. Therefore the `DO` block that demonstrated `json_populate_recordset()`'s functionality can be easily extended to demonstrate `jsonb_to_recordset()`'s functionality as well and to show that their results are identical. The `DO` block needs the same type `t` and function `same_as()` that the _ysqlsh_ script for `json_populate_recordset()`defined.
+**Notes:** the function `jsonb_to_recordset()` bears the same relationship to `jsonb_to_record()` as  `jsonb_populate_recordset()` bears to `jsonb_populate_record()`.
+
+Therefore the `DO` block that demonstrated `jsonb_populate_recordset()`'s functionality can be easily extended to demonstrate `jsonb_to_recordset()`'s functionality as well and to show that their results are identical. The `DO` block needs the same type `t` and function `same_as()` that the _ysqlsh_ script for `jsonb_populate_recordset()`defined.
 
 ```postgresql
 do $body$
@@ -73,4 +77,4 @@ end;
 $body$;
 ```
 
-The same considerations apply if the target `record` data type has a non-primitive field. It would seem, therefore, that the `jsonb_to_recordset()` variant has no practical advantage over the `jsonb_populate_recordset()` variant.
+The same considerations apply here as do for `to jsonb_to_record()` if the target `record` data type has a non-primitive field. The `jsonb_to_recordset()` syntax variant therefore has no practical advantage over the `jsonb_populate_recordset()` variant.

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-typeof.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-typeof.md
@@ -13,14 +13,17 @@ isTocNested: true
 showAsideToc: true
 ---
 
-These functions return the type of the JSON value as a SQL `text` value. Here is the signature for the `jsonb` variant:
+**Purpose:** return the data type of the JSON value as a SQL `text` value.
+
+
+**Signature** for the `jsonb` variant:
 
 ```
-input value        jsonb
-return value       text
+input value:       jsonb
+return value:      text
 ```
 
-Possible types are _string_, _number_, _boolean_, _null_,  _object_, and _array_ — as follows.
+**Notes:** possible return values are _string_, _number_, _boolean_, _null_,  _object_, and _array_ — as follows.
 
 ```postgresql
 do $body$
@@ -39,7 +42,7 @@ begin
     jsonb_typeof(j_null)     = 'null'    and
     jsonb_typeof(j_object)   = 'object'  and
     jsonb_typeof(j_array)    = 'array',
- 'assert failed';
+ 'unexpected';
 end;
 $body$;
 ```

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/key-existence-operators.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/key-existence-operators.md
@@ -13,11 +13,21 @@ isTocNested: true
 showAsideToc: true
 ---
 
-These operators require that inputs are presented as `jsonb` value. They don't have overloads for `json`. The first variant allows a single `text` value to be provided. The second and third variants allow a list of `text` values to be provided. The second is the _or_ (any) flavor and the third is the _and_ (all) flavor.
+**Purpose:** test if the left-hand JSON value is an _object_ with a key-value pair whose _key_ whose name(s) are  given by the right-hand expression.
+
+**Notes:** these operators require that inputs are presented as `jsonb` value. They don't have overloads for `json`. The first variant allows a single `text` value to be provided. The second and third variants allow a list of `text` values to be provided. The second is the _or_ (any) flavor and the third is the _and_ (all) flavor.
 
 ### Existence of the provided `text` value as _key_ of key-value pair: `?`
 
-Is the left-hand JSON value an _object_ with a key-value pair whose _key_ whose name is given by the right-hand  scalar `text` value? The existence expression evaluates to `true` so the  `assert` succeeds:
+**Purpose:** test if the left-hand JSON value is an _object_ with a key-value pair whose _key_ whose name is given by the right-hand  scalar `text` value.
+
+**Signature:**
+```
+input values:       jsonb ? text
+return value:       boolean
+```
+
+Here, the existence expression evaluates to `true` so the  `assert` succeeds:
 
 ```postgresql
 do $body$
@@ -27,12 +37,12 @@ declare
 begin
   assert
     j ? key,
- 'assert failed';
+ 'unexpected';
 end;
 $body$;
 ```
 
-The existence expression for this counter-example evaluates to `false` because the left-hand JSON value has `x` as a _value_ and not as a _key_.
+Here, the existence expression for this counter-example evaluates to `false` because the left-hand JSON value has `x` as a _value_ and not as a _key_.
 
 ````postgresql
 do $body$
@@ -42,12 +52,12 @@ declare
 begin
   assert
     not (j ? key),
- 'assert failed';
+ 'unexpected';
 end;
 $body$;
 ````
 
-The existence expression for this counter-example evaluates to `false` because the left-hand JSON value has the _object_ not at top-level but as the second subvalue in a top-level _array_:
+Here, the existence expression for this counter-example evaluates to `false` because the left-hand JSON value has the _object_ not at top-level but as the second subvalue in a top-level _array_:
 
 ````postgresql
 do $body$
@@ -57,15 +67,21 @@ declare
 begin
   assert
     not (j ? key),
- 'assert failed';
+ 'unexpected';
 end;
 $body$;
 ````
 
-#### Existence of at least one provided `text` value as  the key of key-value pair: `?|`
+### Existence of at least one provided `text` value as  the key of key-value pair: `?|`
 
-Is the left-hand JSON value an _object_ with at least one key-value pair where its key is present in the right-hand list of scalar `text` values?
+**Purpose:** test if the left-hand JSON value an _object_ with _at least one_ key-value pair where its key is present in the right-hand list of scalar `text` values.
 
+**Signature:**
+```
+input values:       jsonb ?| text[]
+return value:       boolean
+```
+Here, existence expression evalueates to `true`.
 ```postgresql
 do $body$
 declare
@@ -74,12 +90,12 @@ declare
 begin
   assert
     j ?| key_list,
- 'assert failed';
+ 'unexpected';
 end;
 $body$;
 ```
 
-The existence expression for this counter-example evaluates to `false` because none of the `text` values in the right-hand array exists as the key of a key-value pair.
+Here, the existence expression for this counter-example evaluates to `false` because none of the `text` values in the right-hand array exists as the key of a key-value pair.
 
 ```postgresql
 do $body$
@@ -89,7 +105,7 @@ declare
 begin
   assert
     not (j ?| key_list),
- 'assert failed';
+ 'unexpected';
 end;
 $body$;
 ```
@@ -98,7 +114,15 @@ $body$;
 
 ### Existence of all the provided `text` values as keys of key-value pairs: `?&`
 
-Is the left-hand JSON value an _object_ where every value in the right-hand list of ordinary scalar `text`(or ordinary `text`) values present as the key of a key-value pair?   This shows _true_:
+**Purpose:** test if the left-hand JSON value an _object_ where _every_ value in the right-hand list of ordinary scalar `text`(or ordinary `text`) values present as the key of a key-value pair.
+
+**Signature:**
+```
+input values:       jsonb ?& text[]
+return value:       boolean
+```
+
+Here, existence expression ecaluates to _true_:
 
 ```postgresql
 do $body$
@@ -108,12 +132,12 @@ declare
 begin
   assert
     j ?& key_list,
- 'assert failed';
+ 'unexpected';
 end;
 $body$;
 ```
 
-The existence expression for this counter-example evaluates to `false` because `'z'` in the right-hand key list exists as the value of a key-value pair, but not as the key of such a pair.
+Here, the existence expression for this counter-example evaluates to `false` because `'z'` in the right-hand key list exists as the value of a key-value pair, but not as the key of such a pair.
 
 ```postgresql
 do $body$
@@ -123,7 +147,7 @@ declare
 begin
   assert
     not(j ?& key_list),
- 'assert failed';
+ 'unexpected';
 end;
 $body$;
 ```

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/remove-operators.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/remove-operators.md
@@ -12,11 +12,20 @@ isTocNested: true
 showAsideToc: true
 ---
 
-## Remove single key-value pair from an _object_ or a single value from an _array_: the `-` operator
+**Purpose:** remove key-value pair(s) from an _object_ or a single value from an _array_. The plain `-` variant takes the specified object itself. The `#-` variant takes the path from the specified object.
 
-Notice that, for all the operators whose behavior is described by using the term "remove", this is a convenient shorthand. The actual effect of these operators is to create a _new_ `jsonb` value from the `jsonb` value on the left of the operator according to the rule that the operator implements, parameterized by the SQL value on the right of the operator.
+**Notes:** describing the behavior by using the term "remove" is a convenient shorthand. The actual effect of these operators is to create a _new_ `jsonb` value from the specified `jsonb` value according to the rule that the operator implements, parameterized by the SQL value on the right of the operator.
 
-### Remove key-value pairs from an _object_
+### The `-` operator
+
+**Purpose:** remove key-value pair(s) from an _object_ or a single value from an _array_.
+
+**Signature:**
+```
+input values:       jsonb - [int | text]
+return value:       jsonb
+```
+**Notes:** there is no `json` overload.
 
 To remove a single key-value pair:
 
@@ -29,7 +38,7 @@ declare
 begin
   assert
     j_left - key = j_expected,
- 'assert failed';
+ 'unexpected';
 end;
 $body$;
 ```
@@ -45,14 +54,12 @@ declare
 begin
   assert
     j_left - key_list = j_expected,
- 'assert failed';
+ 'unexpected';
 end;
 $body$;
 ```
 
-### Remove single value from an _array_
-
-Thus:
+To remove a single value from an _array_:
 
 ```postgresql
 do $body$
@@ -63,18 +70,18 @@ declare
 begin
   assert
     j_left - idx = j_expected,
- 'assert failed';
+ 'unexpected';
 end;
 $body$;
 ```
 
-There seems not to be a way to remove several values from an _array_ at a list of indexes analogous to the ability to remove several key-value pairs from an _object_ with a list of pair keys. The obvious attempt fails with this error:
+There is no direct way to remove several values from an _array_ at a list of indexes, analogous to the ability to remove several key-value pairs from an _object_ with a list of pair keys. The obvious attempt fails with this error:
 
 ```
 operator does not exist: jsonb - integer[]
 ```
 
-Obviously, you can achieve the result at the cost of verbosity thus:
+You can achieve the result thus:
 
 ```postgresql
 do $body$
@@ -85,14 +92,23 @@ declare
 begin
   assert
     ((j_left - idx) - idx) - idx = j_expected,
- 'assert failed';
+ 'unexpected';
 end;
 $body$;
 ```
 
-## Remove a single key-value pair from an _object_ or a single value from an _array_ at the specified path: `#-`
+### The `#-` operator
 
-Thus:
+**Purpose:** remove a single key-value pair from an _object_ or a single value from an _array_ at the specified path.
+
+**Signature:**
+```
+input values:       jsonb - text[]
+return value:       jsonb
+```
+
+**Notes:** there is no `json` overload.
+
 
 ```postgresql
 do $body$

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/row-to-json.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/row-to-json.md
@@ -12,15 +12,18 @@ isTocNested: true
 showAsideToc: true
 ---
 
-This has one variant that returns a `json` value. Here is the signature:
+**Purpose:** create a JSON _object_ from a SQL _record_.
+
+
+**Signature:**
 
 ```
-input value        record
-pretty             boolean
-return value       json
+input value:       record
+pretty:            boolean (optional)
+return value:      json
 ```
 
-The first (mandatory) formal parameter is any SQL `record` whose fields might be compound values. The second formal parameter is optional. When it is _true_, line feeds are added between fields. Use this _ysqlsh_ script to create the required type `t` and then to execute the `assert`.
+**Notes:** this has only the `json` variant. The first (mandatory) formal parameter is any SQL `record` whose fields might be compound values. The second formal parameter is optional. When it is _true_, line feeds are added between fields. Use this _ysqlsh_ script to create the required type `t` and then to execute the `assert`.
 
 ```postgresql
 create type t as (a int, b text);

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/subvalue-operators.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/subvalue-operators.md
@@ -6,14 +6,73 @@ headerTitle: '->, ->>, #>, and #>> (JSON subvalues)'
 description: An arbitrarily deeply located JSON subvalue is identified by its path from the topmost JSON value.
 menu:
   latest:
-    identifier: json-subvalue-operators
+    identifier: subvalue-operators
     parent: functions-operators
     weight: 12
 isTocNested: true
 showAsideToc: true
 ---
 
-An arbitrarily deeply located JSON subvalue is identified by its path from the topmost JSON value. In general, a path is specified by a mixture of keys for _object_ subvalues and index values for _array_ subvalues. Consider this JSON value:
+**Purpose:** read a JSON value at a specified path. The `>` variants return a `json` or `jsonb` value, according to the data type of the input. And the `>>` variants reurn a `text` value. The `#>` and `#>>` variants differ from `->` and `->>` variants in how the path is specified.
+
+### The `->` operator
+
+**Purpose:** read the value specified by a one-step path returning it as a `json` or `jsonb` value.
+
+**Signature** for the `jsonb` overload:
+```
+input values:       jsonb -> [int | text] [ -> [int | text] ]*
+return value:       jsonb
+```
+
+**Notes:** `->` requires that the JSON value is an _object_ or an _array_. _Key_ is a SQL value. When _key_ is a SQL `text` value, it reads the JSON value of the key-value pair with that key from an _object_. When _key_ is a SQL `integer` value, it reads the JSON value at that index key from an _array_. If the input JSON value is `json`, then the output JSON value is `json`, and correspondingly if the input JSON value is `jsonb`.
+
+Reading a key value:
+
+```postgresql
+do $body$
+declare
+  j  constant jsonb := '{"a": 1, "b": {"x": 1, "y": 19}, "c": true}';
+  jsub constant jsonb := j  -> 'b';
+  expected_jsub constant jsonb := '{"x": 1, "y": 19}';
+begin
+  assert
+    jsub = expected_jsub,
+  'unexpected';
+end;
+$body$;
+```
+
+Reading an _array_ value. (The first value in an _array_ has the index `0`.)
+
+```postgresql
+do $body$
+declare
+  j  constant jsonb := '["a", "b", "c", "d"]';
+  j_first constant jsonb := j -> 0;
+  expected_first constant jsonb := '"a"';
+begin
+  assert
+    j_first = expected_first,
+  'unexpected';
+end;
+$body$;
+```
+
+### The `#>` operator
+
+**Purpose:** read the value specified by a multi-step path returning it as a `json` or `jsonb` value.
+
+**Signature** for the `jsonb` overload:
+
+```
+input value:        jsonb #> text[]
+return value:       jsonb
+```
+
+**Notes:** An arbitrarily deeply located JSON subvalue is identified by its path from the topmost JSON value. In general, a path is specified by a mixture of keys for _object_ subvalues and index values for _array_ subvalues.
+
+Consider this JSON value:
 
 ```json
 [
@@ -33,11 +92,11 @@ An arbitrarily deeply located JSON subvalue is identified by its path from the t
 
 - At the topmost level of decomposition, it's an _array_ of three subvalues.
 
-- At the second level of decomposition, the second _array_ subvalue is an _object_ with two key-value pairs called `"x"` and `"y"`.
+- At the second level of decomposition, the second _array_ subvalue (i.e. the value with the index of `1`) is an _object_ with two key-value pairs called `"x"` and `"y"`.
 
 - At the third level of decomposition, the subvalue for the key `"x"` is an _array_ of subvalues.
 
-- At the fourth level of decomposition, the third _array_ subvalue is an _object_ with two key-value pairs called `"a"` and `"b"`.
+- At the fourth level of decomposition, the third _array_ subvalue  (i.e. the value with the index of `2`) is an _object_ with two key-value pairs called `"a"` and `"b"`.
 
 - And at the fifth level of decomposition, the subvalue for key `"b"` is the primitive _string_ value `"dog"`.
 
@@ -55,7 +114,7 @@ The `#>` operator is a convenient syntax sugar shorthand for specifying a long p
 #> array['1', 'x', '2', 'b']::text[]
 ```
 
-Notice that with the `->` operator, integers must be presented as such (so that `'1'` rather than `1` would, surprisingly, read out `null`. However, with the `#>` operator, integers must be presented as convertible `text` values because all the values in a SQL array must have the same data type.
+Notice that with the `->` operator, integers must be presented as such (so that `'1'` rather than `1` would, surprisingly, silently read out `null`. However, with the `#>` operator, integers must be presented as convertible `text` values because all the values in a SQL array must have the same data type.
 
 The PL/pgSQL `assert` confirms that both the `->` path specification and the `#>` path specification produce the same result, thus:
 
@@ -101,15 +160,29 @@ The paths are written using PL/pgSQL variables so that, as a pedagogic device, t
 
 ### The `->>` and `#>>` operators
 
-The `->` operator returns a JSON object. When the targeted value is compound, the `->>` operator returns the `::text` typecast of the value. But when the targeted value is primitive, the `->>` operator returns the value itself, as a `text` value. In particular; a JSON _number_ value is returned as the `::text` typecast of that value (for example `'4.2'`), allowing it to be trivially `::numeric` typecasted back to what it actually is; a JSON _boolean_ value is returned as the `::text` typecast of that value (`'true'` or `'false'`), allowing it to be trivially `::boolean` typecasted back to what it actually is; a JSON _string_ value is return as is as a `text` value; and a JSON _null_ value is returned as a genuine SQL `null` so that the `is null` test is `true`.
+**Purpose:** read the specified JSON value as a `text` value.
+
+**Signatures** for the `jsonb` overloads:
+```
+input values:       jsonb ->> [int | text] [ -> [int | text] ]*
+return value:       text
+```
+and:
+```
+input value:        jsonb #>> text[]
+return value:       text
+```
+
+**Notes:** the `->` operator returns a JSON object. When the targeted value is compound, the `->>` operator returns the `::text` typecast of the value. But when the targeted value is primitive, the `->>` operator returns the value itself, as a `text` value. In particular; a JSON _number_ value is returned as the `::text` typecast of that value (for example `'4.2'`), allowing it to be trivially `::numeric` typecasted back to what it actually is; a JSON _boolean_ value is returned as the `::text` typecast of that value (`'true'` or `'false'`), allowing it to be trivially `::boolean` typecasted back to what it actually is; a JSON _string_ value is return as is as a `text` value; and a JSON _null_ value is returned as a genuine SQL `null` so that the `is null` test is `true`.
 
 The difference in semantics between the `->` operator and the `->>` operator is vividly illustrated (as promised above) by targeting this primitive JSON _string_ subvalue:
 
-```postgresql
+```
 "\"First line\"\n\"second line\""
 ```
 from the JSON value in which it is embedded. For example, here it is the value of the key `"a"` in a JSON _object_:
-```
+
+```postgresql
 do $body$
 declare
   j constant jsonb := '{"a": "\"First line\"\n\"second line\""}'::jsonb;
@@ -171,7 +244,7 @@ begin
     (j3 ->  'q')             = j2 and
     (j3 ->> 'q')             = t2
     ,
-    'assert failed';
+    'unexpected';
 end;
 $body$;
 ```

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/to-jsonb.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/to-jsonb.md
@@ -11,11 +11,13 @@ isTocNested: true
 showAsideToc: true
 ---
 
-Each takes a single value of any single SQL primitive or compound data type that allows a JSON representation. Here is the signature for the `jsonb` variant:
+**Purpose:** convert a single SQL value of any primitive or compound data type, that allows a JSON representation, to a sematically equivaent `jsonb` value..
+
+**Signature** for the `jsonb` variant:
 
 ```
-input value        anyelement
-return value       jsonb
+input value:       anyelement
+return value:      jsonb
 ```
 
 Use this _ysqlsh_ script to create types `t1` and `t2` and then to execute the `do` block that asserts that the behavior is as expected. For an arbitrary nest of SQL `record` and SQL `array` values, readability is improved by building the compound value from the bottom up.
@@ -51,12 +53,13 @@ declare
       "y": true,
       "z": [{"a": 17, "b": "dog"}, {"a": 42, "b": "cat"}]}';
 begin
-  assert
-    j1_dog   = j2_dog  and
-    j1_42    = j2_42   and
-    j1_true  = j2_true and
-    j1_array = j2_array,
- 'assert failed';
+assert
+    j1_dog    = j2_dog   and
+    j1_42     = j2_42    and
+    j1_true   = j2_true  and
+    j1_array  = j2_array and
+    j1_object = j2_object,
+  'unexpected';
 end;
 $body$;
 ```

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/typecast-operators.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/typecast-operators.md
@@ -12,6 +12,18 @@ isTocNested: true
 showAsideToc: true
 ---
 
+**Purpose:** typecast between any pair out of `text`, `json`, and `jsonb` in both directions.
+
+**Signature for the `jsonb` overload of `::text`:**
+
+```
+input value:       jsonb
+return value:      text
+```
+
+**Notes:** you can use the `::text` operator on both a `jsonb` value and a `json` value;
+you can use the `::jsonb` operator on both a `text` value and a `json` value; and
+you can use the `::json` operator on both a `jsonb` value and a `text` value.
 
 Consider this round trip:
 
@@ -39,7 +51,7 @@ declare
 begin
   assert
     new_rfc_7159_text = expected_new_rfc_7159_text,
- 'assert failed';
+ 'unexpected';
 end;
 $body$;
 ```
@@ -68,7 +80,58 @@ declare
 begin
   assert
     new_rfc_7159_text = orig_rfc_7159_text,
- 'assert failed';
+ 'unexpected';
 end;
 $body$;
 ```
+This example illustrates the point dramatically:
+
+```postgresql
+do $body$
+declare
+  orig_rfc_7159_text constant text := '{"a": 42, "b": 17, "a": 99}';
+
+  j_json  constant json  := orig_rfc_7159_text::json;
+  j_jsonb constant jsonb := orig_rfc_7159_text::jsonb;
+
+  text_from_json  constant text := j_json::text;
+  text_from_jsonb constant text := j_jsonb::text;
+
+  expected_text_from_jsonb constant text := '{"a": 99, "b": 17}';
+begin
+  assert
+    (text_from_json = orig_rfc_7159_text) and
+    (text_from_jsonb = expected_text_from_jsonb),
+  'unexpected';
+end;
+$body$;
+```
+The `jsonb` representation is semantics-aware, and so it applies the "rightmost mention wins" rule to overwrite the first value establishment for the key `"a"` (the JSON _number 42_) with the second value establishment for that key (the JSON _number 92_). But the `json` representation is _not_ semantics-aware; it merely applies a syntax-check before accepting the content.
+
+This last example shows that the round trip:
+```
+new_json_value := (json_value::jsonb)::json;
+```
+is lossy because the `json` representation stores the text definition of the JSON value.
+
+```postgresql
+do $body$
+declare
+  orig_json constant json := '
+    {
+      "a": 1,
+      "b": {"x": 1, "y": 19},
+      "c": true
+    }'::json;
+
+  jsonb_from_json constant jsonb := orig_json::jsonb;
+  json_from_jsonb constant json := jsonb_from_json::json;
+begin
+  assert
+    not (json_from_jsonb::text = orig_json::text),
+  'unexpected';
+end;
+$body$;
+```
+
+The predicate for the assert has to use `::text` operator on both sides of the `=` operator because this has a `jsonb` overload but not a `json` overload.

--- a/docs/content/latest/api/ysql/datatypes/type_json/primitive-and-compound-data-types.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/primitive-and-compound-data-types.md
@@ -15,7 +15,11 @@ showAsideToc: true
 
 JSON can represent (sub)values of four primitive data types and of two compound data types.
 
-The primitive data types are _string_, _number_, _boolean_, and _null_. There is no way to declare the datatype of a JSON value; rather, it simply emerges from the syntax of the representation. It is for this reason that, in the JSON type system, _null_ is defined as a datatype rather than as a "value" (strictly, the absence of information about the value) of one of the other data types. Notice that JSON cannot represent date-time values except as a conventionally formatted _string_ value. 
+The primitive data types are _string_, _number_, _boolean_, and _null_. There is no way to declare the data type of a JSON value; rather, it simply emerges from the syntax of the representation.
+
+Compare this with SQL and PL/pgSQL. SQL establishes the data type of a value from the metadata for the column in the table, or the field in the record, into which it is written or from which it is read. It also has the typecast notation, like `::text` or `::boolean` to establish the data type of a manifest constant. PL/pgSQL also supports the typecast notation and establishes the data type of a variable or a formal parameter by declaration. In this way, JSON is better compared with Python, which also implements an emergent data type paradigm. It is for this reason that, in the JSON type system, _null_ is defined as a data type rather than as a "value" (strictly, the absence of information about the value) of one of the other data types.
+
+Notice that JSON cannot represent a date-time value except as a conventionally formatted _string_ value.
 
 The two compound data types are _object_, and _array_.
 
@@ -75,9 +79,9 @@ and:
 
 Notice that JSON makes no distinction between integers and real numbers.
 
-## _Boolean_ and _null_
+## _Boolean_
 
-Here are some examples, shown as SQL manifest constants:
+Here are the two allowed values, shown as SQL manifest constants:
 
 ```
 'true'::jsonb
@@ -89,7 +93,9 @@ and:
 'false'::jsonb
 ```
 
-and:
+## _Null_
+
+As explained above, _null_ is special in JSON in that it is its own datatype that allows exactly one "value", thus:
 
 ```
 'null'::jsonb
@@ -109,7 +115,7 @@ An _object_ is a set of key-value pairs separated by _commas_ and surrounded by 
 }'::jsonb
 ```
 
-Keys are case-sensitive and whitespace within such keys is significant. They can even contain characters that must be escaped. However, if a key does include spaces and special characters, the syntax that you need to read its value becomes rather complex. It would seem to be sensible, therefore, to avoid exploiting this freedom.
+Keys are case-sensitive and whitespace within such keys is significant. They can even contain characters that must be escaped. However, if a key does include spaces and special characters, the syntax that you need to read its value can become rather complex. It is sensible, therefore, to avoid exploiting this freedom.
 
 An object can include more than one key-value pair with the same key. This is not recommended, but the outcome is well-defined: the last-mentioned key-value pair, in left-to-right order, in the set of key-value pairs with the same key "wins". You can test this by reading the value for a specified key with an operator like `->`.
 


### PR DESCRIPTION
The diffs in this PR are entirely “technical”. In other words, no substantive changes in the prose of the doc. Rather, only this was done:

- Correct minor typos in the prose and in the code examples.

- Make each "leaf" file that describes the operators and functions start with "Purpose", "Signature" and, when appropriate, "Notes".

- Use the same text in the four tables on the "JSON functions and operators" page (docs/content/latest/api/ysql/datatypes/type_json/_index.md) as for the "purpose" account for each function/operator, except where a little further explanation helped.

Initially nominating only stevebang as reviewer. Steve, please ask me to add others if appropriate.