### PR TITLE
[docs] Add support for special characters in meta descriptions and titles

### DIFF
--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/key-existence-operators.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/key-existence-operators.md
@@ -1,9 +1,9 @@
 ---
-title: Existence of keys
-linkTitle: '?, ?|, and ? (key existence)'
+title: ?, ?|, and ?& (key existence)
+linkTitle: ?, ?|, and ?& (key existence)
 summary: Existence of keys
-headerTitle: '?, ?|, and ? (key existence)'
-description: The ?, ?|, and ? (key existence) operators require that inputs are presented as jsonb value. They don't have overloads for json.
+headerTitle: ?, ?|, and ?& (key existence)
+description: The ?, ?|, and ?* (key existence) operators require that inputs are presented as jsonb value. They don't have overloads for json.
 menu:
   latest:
     identifier: key-existence-operators

--- a/docs/layouts/_default/list.html
+++ b/docs/layouts/_default/list.html
@@ -27,7 +27,7 @@
 				</div>
 				{{ partial "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) }}	
 
-				<h1>{{ if .Page.Params.headerTitle }}{{ .Page.Params.headerTitle }}{{ else }}{{ .Page.Title }}{{ end }}  {{ if .Draft }} (Draft){{ end }}</h1>
+				<h1>{{ if .Page.Params.headerTitle }}{{ .Page.Params.headerTitle | safeHTML }}{{ else }}{{ .Page.Title | safeHTML }}{{ end }}  {{ if .Draft }} (Draft){{ end }}</h1>
 
 				<div class="head-content clearfix">{{ .Page.Params.headcontent }}</div>
 				

--- a/docs/layouts/_default/single.html
+++ b/docs/layouts/_default/single.html
@@ -27,7 +27,7 @@
 					<div class="content-flex-container">
 						{{ partial "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) }}
 
-						<h1>{{ if .Page.Params.headerTitle }}{{ .Page.Params.headerTitle }}{{ else }}{{ .Page.Title }}{{ end }} {{ if .Draft }} (Draft){{ end }}{{ if .Page.Params.beta }}<a class="tag-beta" href="{{ .Page.Params.beta }}">Beta</a>{{ end }}</h1>
+						<h1>{{ if .Page.Params.headerTitle }}{{ .Page.Params.headerTitle | safeHTML }}{{ else }}{{ .Page.Title | safeHTML }}{{ end }} {{ if .Draft }} (Draft){{ end }}{{ if .Page.Params.beta }}<a class="tag-beta" href="{{ .Page.Params.beta }}">Beta</a>{{ end }}</h1>
 
 						{{ $urlArray := split (urls.Parse .Permalink).Path "/" }}
 						{{ $latestUrl := path.Join "latest" (after 2 $urlArray) }}

--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -25,7 +25,7 @@
 
 				{{ partial "detect_version" . }}
 
-				<h1>{{ if .Page.Params.headerTitle }}{{ .Page.Params.headerTitle }}{{ else }}{{ .Title }}{{ end }} {{ if .Draft }} (Draft){{ end }}</h1>
+				<h1>{{ if .Page.Params.headerTitle }}{{ .Page.Params.headerTitle | safeHTML }}{{ else }}{{ .Title | safeHTML }}{{ end }} {{ if .Draft }} (Draft){{ end }}</h1>
 
 				{{ .TableOfContents }}
 

--- a/docs/layouts/indexpage/single.html
+++ b/docs/layouts/indexpage/single.html
@@ -25,7 +25,7 @@
 				{{ partial "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) }}	
 
 				{{ range where .Site.Pages "Type" "index" }}
-					<h1>{{ if .Page.Params.headerTitle }}{{ .Page.Params.headerTitle }}{{ else }}{{ .Page.Title }}{{ end }} {{ if .Draft }} (Draft){{ end }}</h1>
+					<h1>{{ if .Page.Params.headerTitle }}{{ .Page.Params.headerTitle | safeHTML }}{{ else }}{{ .Page.Title | safeHTML }}{{ end }} {{ if .Draft }} (Draft){{ end }}</h1>
 
 					{{ .TableOfContents }}
 

--- a/docs/layouts/partials/head.html
+++ b/docs/layouts/partials/head.html
@@ -9,7 +9,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,user-scalable=no,initial-scale=1,maximum-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=10" />
-    <title>{{ .Title }}{{ if not .IsHome }} | {{ .Site.Title }}{{ end }}</title>
+    <title>{{ .Title | safeHTML }}{{ if not .IsHome }} | {{ .Site.Title | }}{{ end }}</title>
     {{ hugo.Generator }}
 
     <meta name="description" content="{{ if .Description }}{{ .Description }}{{ else if .Site.Params.Description }}{{ .Site.Params.Description }}{{ else }}YugabyteDB is a transactional, high-performance database.{{ end }}">

--- a/docs/layouts/search/single.html
+++ b/docs/layouts/search/single.html
@@ -25,7 +25,7 @@
 			<div class="wrapper">
 				{{ partial "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) }}	
 
-				<h1>{{ if .Page.Params.headerTitle }}{{ .Page.Params.headerTitle }}{{ else }}{{ .Page.Title }}{{ end }} {{ if .Draft }} (Draft){{ end }}</h1>
+				<h1>{{ if .Page.Params.headerTitle }}{{ .Page.Params.headerTitle | safeHTML }}{{ else }}{{ .Page.Title | safeHTML }}{{ end }} {{ if .Draft }} (Draft){{ end }}</h1>
 
 				{{ .TableOfContents }}
 				{{ .Content }}


### PR DESCRIPTION
- Add fixes to Hugo to support special characters (for example, ampersand (`&`), `@`, and others)
 