### PR TITLE
[Docs] Fix missing HTML snippets in index.html in latest Hugo

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -45,4 +45,8 @@ blackfriday:
   smartDashes: false
   plainIDAnchors: true
   noIntraEmphasis: true
+markup:
+  goldmark:
+    renderer:
+      unsafe: true
 ---


### PR DESCRIPTION
As described in release notes due to change in the Markdown renderer Hugo uses: https://gohugo.io/news/0.60.0-relnotes/