### PR TITLE
[Docs] Fix strange formatting of ToC under latest version of Hugo

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -39,14 +39,12 @@ menu:
   main:
     - name: Introduction
       identifier: intro
-blackfriday:
-  smartypants: true
-  fractions: true
-  smartDashes: false
-  plainIDAnchors: true
-  noIntraEmphasis: true
 markup:
   goldmark:
     renderer:
       unsafe: true
+  tableOfContents:
+    startLevel: 2
+    endLevel: 3
+    ordered: false
 ---

--- a/docs/layouts/partials/footer_js.html
+++ b/docs/layouts/partials/footer_js.html
@@ -38,8 +38,6 @@
             headers.on("click", function() {
               window.location.hash = this.id
             }).addClass("clickable-header");
-            // double unwrap .TableOfContents because of ul>li wrapper for h1 headers
-            $(this).find('nav > ul > li > ul').eq(0).unwrap().unwrap();
             // remove submenus if TOC is not nested
             if (!settings.isTocNested) {
               $(this).find('nav > ul > li > ul').remove();

--- a/docs/styles/_toc.scss
+++ b/docs/styles/_toc.scss
@@ -200,6 +200,7 @@ pre code.copy + textarea, .copy pre textarea {
 }
 
 #toc-static {
+  margin-top: 30px;
   @media only screen and (min-width: 1200px) {
     display: none;
   }


### PR DESCRIPTION
Turns out we were previously removing dom elements inside the Table of Contents. Reverting this JQuery command will fix the strange formatting on various pages.

I also added a margin-top to fix the header being too close to the ToC
Current
![Screen Shot 2020-03-23 at 5 34 11 PM](https://user-images.githubusercontent.com/50115930/77377750-4b289f80-6d31-11ea-8be5-089bdd5d5adb.png)
