### PR TITLE
[Docs] Fix empty table of contents from being shown underneath header

### DIFF
--- a/docs/content/latest/deploy/public-clouds/aws/manual-deployment.md
+++ b/docs/content/latest/deploy/public-clouds/aws/manual-deployment.md
@@ -91,9 +91,9 @@ export ADMIN_USER=centos
 # masters.)
 #
 # You don’t need to CHANGE these unless you want to customize.
-export MASTER1=`echo $AZ1_NODES | cut -f1 -d" "`
-export MASTER2=`echo $AZ2_NODES | cut -f1 -d" "`
-export MASTER3=`echo $AZ3_NODES | cut -f1 -d" "`
+export MASTER1=\`echo $AZ1_NODES | cut -f1 -d" "\`
+export MASTER2=\`echo $AZ2_NODES | cut -f1 -d" "\`
+export MASTER3=\`echo $AZ3_NODES | cut -f1 -d" "\`
 
 
 # Other Environment vars that are simply derived from above ones.

--- a/docs/layouts/_default/single.html
+++ b/docs/layouts/_default/single.html
@@ -39,15 +39,14 @@
 						</div>
 						{{ end }}
 
-						{{if (.Params.showAsideToc) }}						
-						<div id="toc-static">{{ .TableOfContents }}</div>
-						{{ else }}
-						{{ .TableOfContents }}
+						{{if (.Params.showAsideToc) }}
+							<div id="toc-static">{{ .TableOfContents }}</div>
+						{{ else if (and (ge (len .TableOfContents) 50) (ne .Params.toc "false")) }}
+							{{ .TableOfContents }}
 						{{ end }}
 						{{ .Content }}
-					</div>		
-					
-					{{if (and (.Params.showAsideToc) (ne (print .TableOfContents) "")) }}
+					</div>
+					{{if (and (.Params.showAsideToc) (and (ge (len .TableOfContents) 50) (ne .Params.toc "false"))) }}
 					<div class="menu-flex-container">
 						<div class="toc-container" id="toc-aside">{{ .TableOfContents }}</div>
 					</div>


### PR DESCRIPTION
Also escape backticks used in code fence.