### PR TITLE
[Docs] Fix top navbar from overflowing when viewing on Pixel 3a

### DIFF
--- a/docs/styles/_navbar.scss
+++ b/docs/styles/_navbar.scss
@@ -169,7 +169,7 @@ body {
   }
 
   .navbar-search-small {
-    width: auto;
+    width: 60%;
     flex-grow: 1;
     margin: 0 23px 0 20px;
 


### PR DESCRIPTION
Example of current docs homepage on phone
![Screenshot_20200327-120411](https://user-images.githubusercontent.com/50115930/77791498-f7b19c80-7023-11ea-9ddc-0d36b8c7f741.png)
