### PR TITLE
[docs] Disable typographer extension

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -41,6 +41,8 @@ menu:
       identifier: intro
 markup:
   goldmark:
+    extensions:
+      typographer: false
     renderer:
       unsafe: true
   tableOfContents:


### PR DESCRIPTION
Disables the conversion of double hyphens (`--`) used for flags into en dashes.

Affects all documentation use of flags (`--`). 
Disabling the "typographer" extension is similar to the previous "smartyPants = false" blackFriday setting.