### PR TITLE
[docs] Open external links in new tab and show external link icon

### DIFF
--- a/docs/layouts/_default/_markup/render-link.html
+++ b/docs/layouts/_default/_markup/render-link.html
@@ -1,0 +1,2 @@
+<a href="{{ .Destination | safeURL }}" {{ if strings.HasPrefix .Destination "http" }} target="_blank"
+    {{ end }}>{{ .Text }}</a>

--- a/docs/layouts/_default/_markup/render-link.html
+++ b/docs/layouts/_default/_markup/render-link.html
@@ -1,2 +1,2 @@
 <a href="{{ .Destination | safeURL }}" {{ if strings.HasPrefix .Destination "http" }} target="_blank"
-    {{ end }}>{{ .Text }}</a>
+    {{ end }}>{{ .Text }} {{ if strings.HasPrefix .Destination "http"}}<i class="fas fa-external-link-alt"></i>{{ end }}</a>


### PR DESCRIPTION
Adds new `render-link.html` to layouts > _markup > render-link.html that includes Render Hooks Templates (https://gohugo.io/getting-started/configuration-markup/#render-hook-templates) to open Markdown links that start with `http` to:
- open external link in a new tab
- display an "external link" icon
