### PR TITLE
#2603: Display the equivalent of "ulimit -a" in the log on master/tserver st…

### DIFF
--- a/src/yb/master/master_main.cc
+++ b/src/yb/master/master_main.cc
@@ -42,6 +42,7 @@
 #include "yb/util/init.h"
 #include "yb/util/logging.h"
 #include "yb/util/main_util.h"
+#include "yb/util/ulimit_info.h"
 #include "yb/gutil/sysinfo.h"
 #include "yb/server/total_mem_watcher.h"
 
@@ -115,6 +116,7 @@ static int MasterMain(int argc, char** argv) {
   LOG_AND_RETURN_FROM_MAIN_NOT_OK(server.Init());
 
   LOG(INFO) << "Starting Master server...";
+  LOG(INFO) << "ulimit cur(max)..." << UlimitInfo::GetUlimitInfo();
   LOG_AND_RETURN_FROM_MAIN_NOT_OK(server.Start());
 
   LOG(INFO) << "Master server successfully started.";

--- a/src/yb/tserver/tablet_server_main.cc
+++ b/src/yb/tserver/tablet_server_main.cc
@@ -58,6 +58,7 @@
 #include "yb/util/init.h"
 #include "yb/util/logging.h"
 #include "yb/util/main_util.h"
+#include "yb/util/ulimit_info.h"
 #include "yb/util/size_literals.h"
 
 using namespace std::placeholders;
@@ -192,6 +193,7 @@ int TabletServerMain(int argc, char** argv) {
   LOG(INFO) << "Initializing tablet server...";
   LOG_AND_RETURN_FROM_MAIN_NOT_OK(server->Init());
   LOG(INFO) << "Starting tablet server...";
+  LOG(INFO) << "ulimit cur(max)..." << UlimitInfo::GetUlimitInfo();
   LOG_AND_RETURN_FROM_MAIN_NOT_OK(server->Start());
   LOG(INFO) << "Tablet server successfully started.";
 

--- a/src/yb/util/CMakeLists.txt
+++ b/src/yb/util/CMakeLists.txt
@@ -247,6 +247,7 @@ set(UTIL_SRCS
   timestamp.cc
   trace.cc
   trilean.cc
+  ulimit_info.cc
   universe_key_manager.cc
   url-coding.cc
   user.cc

--- a/src/yb/util/env.h
+++ b/src/yb/util/env.h
@@ -462,6 +462,9 @@ class Env {
 
   // Get free space available on the path's filesystem.
   virtual Result<uint64_t> GetFreeSpaceBytes(const std::string& path) = 0;
+
+  // Get ulimit
+  virtual CHECKED_STATUS GetUlimit(int resource, int64_t* soft_limit, int64_t* hard_limit) = 0;
  private:
   // No copying allowed
   Env(const Env&);
@@ -787,6 +790,9 @@ class EnvWrapper : public Env {
   }
   Result<uint64_t> GetFreeSpaceBytes(const std::string& path) override {
     return target_->GetFreeSpaceBytes(path);
+  }
+  CHECKED_STATUS GetUlimit(int resource, int64_t* soft_limit, int64_t* hard_limit) override {
+    return target_->GetUlimit(resource, soft_limit, hard_limit);
   }
  private:
   Env* target_;

--- a/src/yb/util/ulimit_info.cc
+++ b/src/yb/util/ulimit_info.cc
@@ -1,0 +1,94 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// The following only applies to changes made to this file as part of YugaByte development.
+//
+// Portions Copyright (c) YugaByte, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/util/ulimit_info.h"
+
+#include <sys/resource.h>
+#include <string>
+#include <sstream>
+
+#include "yb/util/env.h"
+
+using std::string;
+using std::stringstream;
+
+namespace yb {
+
+static stringstream& getLimit(
+    stringstream& ss, const char* pfx, const char* sfx, int resource, int rightshift) {
+  ss << "ulimit: " << pfx << " ";
+  int64_t cur, max;
+  Status status = Env::Default()->GetUlimit(resource, &cur, &max);
+  if (status.ok()) {
+    if (cur == RLIM_INFINITY) {
+      ss << "unlimited";
+    }
+    else {
+      ss << (cur >> rightshift);
+    }
+    ss << "(";
+    if (max == RLIM_INFINITY) {
+      ss << "unlimited";
+    }
+    else {
+      ss << (max >> rightshift);
+    }
+    ss << ")";
+  } else {
+    ss << "-1";
+  }
+  ss << (sfx[0] ? " " : "") << sfx << "\n";
+
+  return ss;
+}
+
+string UlimitInfo::GetUlimitInfo() {
+  stringstream ss;
+  ss << "\n";
+  getLimit(ss, "core file size", "blks", RLIMIT_CORE, 0);
+  getLimit(ss, "data seg size", "kb", RLIMIT_DATA, 10);
+  getLimit(ss, "open files", "", RLIMIT_NOFILE, 0);
+  getLimit(ss, "file size", "blks", RLIMIT_FSIZE, 0);
+#if !defined(__APPLE__)
+  getLimit(ss, "pending signals", "", RLIMIT_SIGPENDING, 0);
+  getLimit(ss, "file locks", "", RLIMIT_LOCKS, 0);
+#endif
+  getLimit(ss, "max locked memory", "kb", RLIMIT_MEMLOCK, 10);
+  getLimit(ss, "max memory size", "kb", RLIMIT_AS, 10);
+  getLimit(ss, "stack size", "kb", RLIMIT_STACK, 10);
+  getLimit(ss, "cpu time", "secs", RLIMIT_CPU, 0);
+  getLimit(ss, "max user processes", "", RLIMIT_NPROC, 0);
+
+  return ss.str();
+}
+
+}  // namespace yb

--- a/src/yb/util/ulimit_info.h
+++ b/src/yb/util/ulimit_info.h
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// The following only applies to changes made to this file as part of YugaByte development.
+//
+// Portions Copyright (c) YugaByte, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+#ifndef YB_UTIL_ULIMIT_INFO_H
+#define YB_UTIL_ULIMIT_INFO_H
+
+#include <string>
+
+namespace yb {
+
+// Static functions related to fetching information about the current build.
+class UlimitInfo {
+ public:
+  static std::string GetUlimitInfo();
+};
+
+} // namespace yb
+#endif /* YB_UTIL_ULIMIT_INFO_H */


### PR DESCRIPTION
Please review

Sample output:

I0330 12:15:12.678930 22581 master_main.cc:118] Starting Master server...
I0330 12:15:12.678956 22581 master_main.cc:119] ulimit cur(max)...
ulimit: core file size 0(unlimited) blks
ulimit: data seg size unlimited(unlimited) kb
ulimit: open files 1024(1048576)
ulimit: file size unlimited(unlimited) blks
ulimit: pending signals 63712(63712)
ulimit: max locked memory 65536(65536) kb
ulimit: max memory size unlimited(unlimited) kb
ulimit: stack size 8192(unlimited) kb
ulimit: cpu time unlimited(unlimited) secs
ulimit: max user processes 63712(63712)
ulimit: file locks unlimited(unlimited)
I0330 12:15:12.687182 22581 service_pool.cc:148] yb.master.MasterBackupService: yb::rpc::ServicePoolImpl created at 0x5636cc97f8c0
----------------------------------------------------------------------------------------------
I0419 20:46:37.202193  6857 server_base.cc:245] Auto setting FLAGS_num_reactor_threads to 3
I0419 20:46:37.209270  6857 master_main.cc:118] Starting Master server...
I0419 20:46:37.209293  6857 master_main.cc:119] ulimit cur(max)...
ulimit: core file size 0(unlimited) blks
ulimit: data seg size unlimited(unlimited) kb
ulimit: open files 1024(1048576)
ulimit: file size unlimited(unlimited) blks
ulimit: pending signals 63710(63710)
ulimit: max locked memory 65536(65536) kb
ulimit: max memory size unlimited(unlimited) kb
ulimit: stack size 8192(unlimited) kb
ulimit: cpu time unlimited(unlimited) secs
ulimit: max user processes 63710(63710)
ulimit: file locks unlimited(unlimited)
I0419 20:46:37.209379  6875 async_initializer.cc:73] Starting to init ybclient
----------------------------------------------------------------------------------------------
I0419 20:55:11.392761  9191 tablet_server_main.cc:196] ulimit cur(max)...
ulimit: core file size 0(unlimited) blks
ulimit: data seg size unlimited(unlimited) kb
ulimit: open files 1024(1048576)
ulimit: file size unlimited(unlimited) blks
ulimit: pending signals 63710(63710)
ulimit: max locked memory 65536(65536) kb
ulimit: max memory size unlimited(unlimited) kb
ulimit: stack size 8192(unlimited) kb
ulimit: cpu time unlimited(unlimited) secs
ulimit: max user processes 63710(63710)
ulimit: file locks unlimited(unlimited)
I0419 20:55:11.392786  9191 tablet_server.cc:272] Auto setting FLAGS_tablet_server_svc_num_threads to 96
