### PR TITLE
[docs] Change goldmark autoHeadingIDType to blackfriday

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -43,6 +43,8 @@ markup:
   goldmark:
     extensions:
       typographer: false
+    parser:
+      autoHeadingIDType: blackfriday
     renderer:
       unsafe: true
   tableOfContents:


### PR DESCRIPTION
Previous blackFriday Markdown render engine handled header link IDs differently. The newer goldmark, by default, uses GFM (github) to auto-create IDs. That's likely better, but too many links would need to be updated to use the `github` behavior. This change preserves the old ID behavior for now, until we can update the links and teach everyone the differences.

For details, see https://gohugo.io/getting-started/configuration-markup#goldmark
