### PR TITLE
Add python-devel to list of packages

### DIFF
--- a/docs/content/latest/contribute/core-database/build-from-src-centos.md
+++ b/docs/content/latest/contribute/core-database/build-from-src-centos.md
@@ -53,7 +53,7 @@ Update packages on your system, install development tools and additional package
 ```sh
 sudo yum update
 sudo yum groupinstall -y 'Development Tools'
-sudo yum install -y ruby perl-Digest epel-release ccache git python2-pip python-devel
+sudo yum install -y ruby perl-Digest epel-release ccache git python2-pip python-devel python3 python3-pip python3-devel
 sudo yum install -y cmake3 ctest3
 ```
 

--- a/docs/content/latest/contribute/core-database/build-from-src-centos.md
+++ b/docs/content/latest/contribute/core-database/build-from-src-centos.md
@@ -53,7 +53,7 @@ Update packages on your system, install development tools and additional package
 ```sh
 sudo yum update
 sudo yum groupinstall -y 'Development Tools'
-sudo yum install -y ruby perl-Digest epel-release ccache git python2-pip
+sudo yum install -y ruby perl-Digest epel-release ccache git python2-pip python-devel
 sudo yum install -y cmake3 ctest3
 ```
 


### PR DESCRIPTION
Needed for Python.h

Repros on vanilla CentOS 7 machine from GCP.