### PR TITLE
[Docs][#4365] Make the default option for clickable queryHeaders to be h2 thru h6

### DIFF
--- a/docs/layouts/partials/footer_js.html
+++ b/docs/layouts/partials/footer_js.html
@@ -31,7 +31,7 @@
               }
               queryHeaders = queryHeaders.slice(0, -1);
             } else {
-              queryHeaders = "h2:visible,h3:visible";
+              queryHeaders = "h2:visible,h3:visible,h4:visible,h5:visible,h6:visible";
             }
             settings.headers = settings.isTocNested ? queryHeaders : "h2:visible";
             let headers = $(settings.headers);


### PR DESCRIPTION
This code does not generate a permalink icon but does make the headers clickable as long as `isTocNested` is true but not a number.