### PR TITLE
[docs] Update isTocNested and add h4 to h6 to queryHeaders

### DIFF
--- a/docs/content/latest/admin/yb-admin.md
+++ b/docs/content/latest/admin/yb-admin.md
@@ -8,7 +8,7 @@ menu:
     identifier: yb-admin
     parent: admin
     weight: 2465
-isTocNested: 4
+isTocNested: true
 showAsideToc: true
 ---
 

--- a/docs/content/latest/admin/yb-ts-cli.md
+++ b/docs/content/latest/admin/yb-ts-cli.md
@@ -8,7 +8,7 @@ menu:
     identifier: yb-ts-cli
     parent: admin
     weight: 2466
-isTocNested: 3
+isTocNested: true
 showAsideToc: true
 ---
 

--- a/docs/content/latest/admin/ysql-dump.md
+++ b/docs/content/latest/admin/ysql-dump.md
@@ -9,7 +9,7 @@ menu:
     identifier: ysql-dump
     parent: admin
     weight: 2467
-isTocNested: 3
+isTocNested: true
 showAsideToc: true
 ---
 

--- a/docs/content/latest/admin/ysql-dumpall.md
+++ b/docs/content/latest/admin/ysql-dumpall.md
@@ -9,7 +9,7 @@ menu:
     identifier: ysql-dumpall
     parent: admin
     weight: 2468
-isTocNested: 3
+isTocNested: true
 showAsideToc: true
 ---
 

--- a/docs/content/latest/admin/ysqlsh.md
+++ b/docs/content/latest/admin/ysqlsh.md
@@ -11,7 +11,7 @@ menu:
     identifier: ysqlsh
     parent: admin
     weight: 2459
-isTocNested: 5
+isTocNested: true
 showAsideToc: true
 ---
 

--- a/docs/content/latest/reference/configuration/default-ports.md
+++ b/docs/content/latest/reference/configuration/default-ports.md
@@ -11,7 +11,7 @@ menu:
     weight: 2740
 aliases:
   - /latest/reference/default-ports
-isTocNested: 3
+isTocNested: true
 showAsideToc: true
 ---
 

--- a/docs/content/latest/reference/configuration/yb-master.md
+++ b/docs/content/latest/reference/configuration/yb-master.md
@@ -10,7 +10,7 @@ menu:
     weight: 2450
 aliases:
   - /latest/admin/yb-master
-isTocNested: 3
+isTocNested: true
 showAsideToc: true
 ---
 

--- a/docs/content/latest/reference/configuration/yb-tserver.md
+++ b/docs/content/latest/reference/configuration/yb-tserver.md
@@ -10,7 +10,7 @@ menu:
     weight: 2440
 aliases:
   - /latest/admin/yb-tserver
-isTocNested: 3
+isTocNested: true
 showAsideToc: true
 ---
 

--- a/docs/content/latest/reference/connectors/kafka-connect-yugabytedb.md
+++ b/docs/content/latest/reference/connectors/kafka-connect-yugabytedb.md
@@ -9,7 +9,7 @@ menu:
     identifier: kafka-connect-yugabytedb
     parent: connectors
     weight: 2930
-isTocNested: 3
+isTocNested: true
 showAsideToc: true
 ---
 

--- a/docs/content/latest/reference/drivers/postgresql-jdbc-driver.md
+++ b/docs/content/latest/reference/drivers/postgresql-jdbc-driver.md
@@ -11,7 +11,7 @@ menu:
     weight: 2910
 aliases:
   - /latest/reference/connectors/postgresql-jdbc-driver
-isTocNested: 3
+isTocNested: true
 showAsideToc: true
 ---
 

--- a/docs/content/latest/reference/drivers/spring-data-yugabytedb.md
+++ b/docs/content/latest/reference/drivers/spring-data-yugabytedb.md
@@ -12,7 +12,7 @@ menu:
     weight: 2940
 aliases:
   - /latest/reference/connectors/spring-data-yugabytedb
-isTocNested: 3
+isTocNested: true
 showAsideToc: true
 ---
 

--- a/docs/content/latest/reference/drivers/yugabytedb-jdbc-driver.md
+++ b/docs/content/latest/reference/drivers/yugabytedb-jdbc-driver.md
@@ -12,7 +12,7 @@ menu:
     weight: 2920
 aliases:
   - /latest/reference/connectors/yugabytedb-jdbc-driver
-isTocNested: 3
+isTocNested: true
 showAsideToc: true
 ---
 

--- a/docs/layouts/partials/footer_js.html
+++ b/docs/layouts/partials/footer_js.html
@@ -94,7 +94,7 @@
                 queryHeaders.push(`h${i}`);
               }
             } else {
-              queryHeaders = ['h2', 'h3'];
+              queryHeaders = ['h2', 'h3', 'h4', 'h5', 'h6'];
             }
 
           {{ "/* Add permanent link next to the headers */" | safeJS }}


### PR DESCRIPTION
- Changes all `isTocNested` to use true instead of level numbers.
- Changes `footer_js.html` to show header-link icon. Adds to change in #4366.
