### PR TITLE
Brand new "Array" doc under "APIs > YSQL > Data types"

### DIFF
--- a/docs/content/latest/api/ysql/datatypes/type_array/_index.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/_index.md
@@ -1,0 +1,364 @@
+---
+title: YSQL array
+linkTitle: Array
+headerTitle: Array data types and functionality
+description: YSQL lets you construct an array data type, of any dimensionality, of any built-in or user-defined data type. You can use this constructed data type for a table column and for a variable or formal parameter in a PL/pgSQL procedure.
+image: /images/section_icons/api/ysql.png
+menu:
+  latest:
+    identifier: api-ysql-datatypes-array
+    parent: api-ysql-datatypes
+aliases:
+  - /latest/api/ysql/datatypes/type_array
+isTocNested: false
+showAsideToc: false
+---
+**On this page**<br>
+&#160;&#160;&#160;&#160;[Synopsis](./#synopsis)<br>
+&#160;&#160;&#160;&#160;[Atomically null vs having all values null](./#atomically-null-vs-having-all-values-null)<br>
+&#160;&#160;&#160;&#160;[Type construction](./#type-construction)<br>
+&#160;&#160;&#160;&#160;[Informal sketch of array functionality](./#informal-sketch-of-array-functionality)<br>
+&#160;&#160;&#160;&#160;[Uses of arrays](./#uses-of-arrays)<br>
+&#160;&#160;&#160;&#160;[Example use case: GPS trip data](./#example-use-case-gps-trip-data)<br>
+&#160;&#160;&#160;&#160;[Organization of the remaining array functionality content](./#organization-of-the-remaining-array-functionality-content)
+
+## Synopsis
+
+A multidimensional array lets you store a large composite value in a single field (row-column intersection) in a table; and it lets you assign such a value to a PL/pgSQL variable, or pass it via a procedure's, or a function's, formal parameter. 
+
+You can see from the declarations below that every value in an array is non-negotiably of the same data type—either a primitive data type like `text` or `numeric`, or a user-defined scalar or composite data type (like a _"row"_ type).
+
+An array is, by definition, a rectilinear N-dimensional set of "cells". You can picture a one-dimensional array as a line of cells, a two-dimensional array as a rectangle of cells, and a three-dimensional array as a cuboid of cells. The terms "line", "rectangle", and "cuboid" are the only specific ones. The generic term "N-dimensional array" includes these and all others. The meaning of "rectilinear" is sometimes captured by saying that the shape as no ragged edges or surfaces. If you try to create an array value that is not rectilinear, then you get an error whose detail says _"Multidimensional arrays must have sub-arrays with matching dimensions"_. The number of dimensions that an array has is called its _dimensionality_.
+
+> **Note:** Sometimes, a ragged structure is useful. Here's an example:
+>
+> - a one-dimensional array of "payload" one-dimensional arrays, each of which might have a different length
+>
+> This structure is crucially different from a rectilinear two-dimensional array. It's easily created by using a `DOMAIN`. This lets you give the payload array data type a name. The [Using an array of `DOMAIN`s](./array-of-domains/) section shows how to do this.
+
+A value within an array is specified by a tuple of _index_ values, like this (for a four-dimensional array):
+```
+arr[13][7][5][17]
+```
+The index is the cell number along the dimension in question. The index values along each dimension are consecutive—in other words, you cannot delete a cell within an existing array. This reflects the fact that an array is rectilinear. However, a value in a cell can, of course, be `null`.
+
+The leftmost value (`13` in the example) is the index along the first dimension; the rightmost value (`17` in this example) is the index along the Nth dimension—that is, the fourth dimension in this example. The value of the index of the first cell along a particular dimension is known as the _lower bound_ for that dimension. If you take no special steps when you create an array value, then the lower bound of each dimension is `1`. But, if you find it useful, you can specify any positive or negative integer, or zero, as the lower bound of the specified dimension. The lower bounds of an array are fixed at creation time, and so is its dimensionality.
+
+Correspondingly, each dimension has an upper bound. This, too, is fixed at array creation time. The index values along each dimension are consecutive. The fact that each dimension has a single value for its upper and lower bound reflects the fact that an array is rectilinear.
+
+If you read a within-array value with a tuple of index values that put it outside of the array bounds, then you silently get `null`. But if you attempt to set such an out-of-bounds value, then, because this is an implicit attempt to change the array's bounds, you get the _"array subscript out of range"_ error.
+
+Notice that you can create a new array, using a single assignment, as a so-called "slice" of an existing array, by specifying desired lower and upper index values along each axis of the source array. The new array cannot have a different dimensionality than its source. You should specify the lower and upper index values for the slice, along each dimension of the source array, to lie within (or, maximally, coincide with) the bounds of that dimension. If you specify the slice with a lower bound less than the corresponding lower bound of the source array, then the new lower bound is simply, and silently, interpreted as the extant corresponding source lower bound. The same is true for the upper bounds. The syntax of this simple method means that the lower bounds of the new array inevitably all start at `1`. Here is an example (in PL/pgSQL syntax) using a two-dimensional source array:
+
+```
+new_arr := source_arr[3:4][7:9];
+```
+**Note:** A one-dimensional array is a special case because, uniquely among N-dimensional shapes, it is tautologically rectilinear. You can increase the length of such an array implicitly, simply by setting a value in a cell that has a lower index value than the present lower bound or a higher index value than the present upper bound. Once you've done this, there is no way to reduce the length because there is no explicit operation for this and no "unset" operation for a specified cell. You can, however, create a slice so that the new array has the source array's original size.
+
+The following properties determine the shape of an array. Each can be observed using the listed dedicated function. The first formal parameter (with data type `anyarray`) is the array of interest . When appropriate, there's a second formal parameter (with data type `int`) that specifies the dimension of interest. The return is an `int` value, except in one case where it's a `text` value, as detailed below.
+
+- [`array_ndims()`](functions-operators/properties/#array-ndims) returns the dimensionality of the specified array.
+
+- [`array_lower()`](functions-operators/properties/#array-lower) returns the lower bound of the specified array on the specified dimension.
+
+- [`array_upper()`](functions-operators/properties/#array-upper) returns the upper bound of the specified array on the specified dimension.
+
+- [`array_length()`](functions-operators/properties/#array-length) returns the length of the specified array on the specified dimension. The length, the upper bound, and the lower bound, for a particular dimension, are mutually related, thus:
+```
+ "length" = "upper bound" - "lower bound" + 1
+```
+
+- [`cardinality()`](functions-operators/properties/#cardinality) returns the total number of cells (and therefore values) in the specified array. The cardinality and length along each dimension are mutually related, thus:
+```
+ "cardinality" = "length 1" * "length 2" * ... * "length N"
+```
+
+- [`array_dims()`](functions-operators/properties/#array-dims) returns a text representation of the same information as `array_lower()` and `array_length()` return, for all dimension in a single `text` value, showing the upper and lower bounds like this: `[3:4][7:9][2:5]` for a three-dimensional array. Use this for human consumption. Use `array_lower()` and `array_length()` for programmatic consumption.
+
+Arrays are special because (unlike is the case for, for example, numeric data types like `decimal` and `int`, or character data types like `text` and `varchar`) there are no ready-made array data types. Rather, you construct the array data type that you need using an array _type constructor_. Here's a simple example:
+
+```postgresql
+create table t1(k int primary key, arr text array[4]);
+```
+This syntax conforms to the SQL Standard. Notice that `array` is a reserved word. (You cannot, for example, create a table with that name.) It appears to let you specify just a one-dimensional array and to specify how many values it holds. But both of these apparent declarations of intent are ignored and act, therefore, only as potentially misleading documentation.
+
+The following illustrates PostgreSQL's extension to the Standard that YSQL, therefore, inherits.:
+
+```postgresql
+create table t2(
+  k int primary key,
+  one_dimensional_array int[],
+  two_dimensional_array int[10][10]);
+```
+Notice that it appears, optionally, to let you specify how many values each dimension holds. (The Standard syntax allows the specification of the length of just one dimension.) However, these apparent declarations of intent, too, are simply ignored. Moreover, even the _dimensionality_ is ignored. The value, in a particular row, in a table column with an array data type (or its cousin, a variable in a PL/pgSQL program) can hold an array value of _any_ dimensionality. This is demonstrated by example in the section [The literal for an array of primitive values](./literals/array-of-primitive-values/). This means that declaring an array using the reserved word `array`, which apparently lets you define only a one-dimensional array, and declaring an array using `[]`, which apparently lets you define array of any dimensionality, where one, some, or all of the dimensions are nominally constrained, are entirely equivalent.
+
+Notice that different rows in the same table column can hold array values of different dimensionality. This is explained by picturing the implementation. Array values are held, in an opaque internal representation, as a linear "ribbon" of suitably delimited values of the array's data type. The array's actual dimensionality, and the upper and lower bound of the index along each dimension, is suitably represented in a header. This information is used, in a trivial arithmetic formula, to translate an address specification like `arr[13][7][5][17]` into the position of the value, as a single integer, along the ribbon of values. Understanding this explains why, except for the special case of a one-dimensional array, the dimensionality and the bounds of an array value are fixed at creation time. It also explains why a few of the array functions are supported only for one-dimensional arrays.
+
+Yugabyte recommends that, for uniformity, you choose to declare arrays only with this syntax:
+
+```
+create table t2(
+  k int primary key,
+  one_dimensional_array int[],
+  two_dimensional_array int[]);
+```
+
+The `array_ndims()` function lets you define a table constraint to insist that the array dimensionality is fixed for every row in a table column with such a data type. The `array_length()` function lets you insist that each dimension of a multidimensional array has a specified length for every row, or that its length doesn't exceed a specified limit for any row.
+
+## Atomically null vs having all values null
+
+Here is a minimal example:
+```postgresql
+create table t(k int primary key, v int[]);
+insert into t(k) values(1);
+insert into t(k, v) values (2, '{null}'::int[]);
+\pset null '<is null>'
+select k, v, array_dims(v) as dims from t order by k;
+```
+It shows this:
+
+```
+ k |     v     |   dims    
+---+-----------+-----------
+ 1 | <is null> | <is null>
+ 2 | {NULL}    | [1:1]
+```
+
+Because `v` has no constraint, it can be `null`, just like when its data type is scalar. This is the case for the row with `k = 1`. Here, `v` is said to be _atomically null_. (This term is usually used only when the data type is composite to distinguish the outcome from what is seen for the row with `k = 2`where `v` is not atomically null. The array properties of the first row's `v`, like its dimensionality, are all `null`. But for the second row, they have meaningful, `not null`, values. Now try this:
+```postgresql
+update t set v = v||'{null}'::int[] where k = 2;
+select k, v, array_dims(v) as dims from t where k = 2;
+```
+The `||` operator is explained in the section [Array concatenation functions and operators](./functions-operators/concatenation/#the-operator). The query shows this:
+
+```
+ k |      v      | dims  
+---+-------------+-------
+ 2 | {NULL,NULL} | [1:2]
+```
+Here, `v` for the second row, while not atomically null, has all of its values `null`. Its dimensionality cannot be changed, but because it is a one dimensional array, its length can be extended, as was explained above. This is allowed:
+```postgresql
+update t set v[0] = 17 where k = 2;
+select k, v, array_dims(v) as dims from t where k = 2;
+```
+It shows this:
+```
+ k |             v             | dims  
+---+---------------------------+-------
+ 2 | [0:3]={17,NULL,NULL,NULL} | [0:3]
+```
+ This, too, is allowed:
+```postgresql
+update t set v[1] = 42 where k = 1;
+select k, v, array_dims(v) as dims from t where k = 1;
+```
+It shows this:
+```
+ k |  v   | dims  
+---+------+-------
+ 1 | {42} | [1:1]
+```
+
+The dimensionality of `v` for this first row has now been irrevocably established.
+
+
+## Type construction
+
+Arrays are not YSQL's only example of type construction. So, also, are _"row"_ types:
+
+```postgresql
+create type rec_t as(f1 int, f2 text);
+create table t3(k int primary key, rec rec_t);
+```
+
+Notice that you must define a _"row"_ type as a schema object. But you define the data type of an array "in place" when you create a table or write PL/pgSQL code, as was illustrated above. To put this another way, you _cannot_ name a constructed array type. Rather, you can use it only "on the fly" to define the data type of a column, a PL/pgSQL variable, or a PL/pgSQL formal parameter. The consequence of this is that while you _can_ define, for example, the data type of a named field in a _"row"_ type as an array of a specified data type, you _cannot_ define an array of a specified array data type. (If you try to write such a declaration, you'll see, as you type it, that you have no way to express what you're trying to say.)
+
+## Informal sketch of array functionality
+
+This sections within this "Array data types and functionality" major section carefully describe what is sketched here.
+
+_First_, create a table with an `int[]` column and populate it with a two-dimensional array by using an array literal.
+```postgresql
+create table t(
+  k int primary key, v int[]);
+
+insert into t(k, v) values(1,
+   '{
+      {11, 12, 13},
+      {21, 22, 23}
+    }
+  '::int[]);
+```
+_Next_, look at a direct `::text` typecast of the value that was inserted:
+
+```postgresql
+select v::text from t where k = 1;
+```
+It shows this:
+```
+            v            
+-------------------------
+ {{11,12,13},{21,22,23}}
+```
+Notice that, apart from the fact that it has no whitespace, this representation is identical to the literal that defined the inserted array. It can therefore be used in this way.
+
+_Next_ check that the inserted array value has the expected properties:
+```postgresql
+select
+  array_ndims(v),
+  array_length(v, 1),
+  array_length(v, 2),
+  array_dims(v)
+from t where k = 1;
+```
+It shows this:
+```
+  array_ndims | array_length | array_length | array_dims 
+-------------+--------------+--------------+------------
+           2 |            2 |            3 | [1:2][1:3]
+```
+
+The `array_ndims()` function reports the dimensionality of the array; `array_length()` reports the length of the specified dimension (that is, the number of values that this dimension has); and `array_dims()` presents the same information, as a single `text` value, as using `array_length()` in turn for each dimension does. Notice that `array_length()` returns a _single_ `int` value for the specified dimension. Its design rests upon a rule, exemplified by saying that a two-dimensional array must be a rectangle (it cannot have a ragged edge). In the same way, a three-dimensional array must be a cuboid (it cannot have an uneven surface). This notion, though its harder to visualise, continues to apply as the number of dimensions increases.
+
+Here's an example that violates the rule:
+```postgresql
+insert into t(k, v) values(2,
+   '{
+      {11, 12, 13},
+      {21, 22, 23, 24}
+    }
+  '::int[]);
+```
+
+The formatting emphasizes that its edge is ragged. It causes a _"22P02: malformed array literal"_ error whose detail says _"Multidimensional arrays must have sub-arrays with matching dimensions"_.
+
+Finally, in this sketch, this `DO` block shows how you can visualise the values in a two-dimensional array as a rectangular grid.
+
+```postgresql
+do $body$
+declare
+  arr constant int[] not null:= '{
+      {11, 12, 13, 14},
+      {21, 22, 23, 24},
+      {31, 32, 33, 34}
+    }'::int[];
+
+  ndims constant int not null := array_ndims(arr);
+  line text;
+begin
+  if array_ndims(arr) <> 2 then
+    raise exception 'This code handles only a two-dimensional array.';
+  end if;
+
+  declare
+    len1 constant int not null := array_length(arr, 1);
+    len2 constant int not null := array_length(arr, 2);
+  begin
+    for row in 1..len1 loop
+      line := ' ';
+      for col in 1..len2 loop
+        line := line||lpad(arr[row][col]::text, 5);
+      end loop;
+      raise info '%', line;
+    end loop;
+  end;
+end;
+$body$;
+```
+It produces this result (after manually stripping the repeating _"INFO:"_ prompts):
+```
+   11   12   13   14
+   21   22   23   24
+   31   32   33   34
+```
+This approach isn't practical for an array with higher dimensionality or for a two-dimensional array whose second dimension is large. Rather, this code is included here to show how you can address individual elements. The names of the implicitly declared _"for loop"_ variables `row` and `col` correspond intuitively to how the values are laid out in the literal that defines the array value. The nested loops are designed to visit the values in so-called row-major order (the last subscript varies most rapidly). When, for example, the values of same-dimensioned multidimensional arrays are compared, they are visited in this order and compared pairwise in just the same way that scalar values are compared.
+
+**Note:** The term "_row-major order"_ is explained in the [Joint semantics](./functions-operators/properties/#joint-semantics)) section within the _"Functions for reporting the geometric properties of an array"_ section. it contains a an example PL/pgSQL procedure that shows how to traverse an arbitrary two-dimensional array's values, where the lower bounds and lengths along each dimension are unknown beforehand, in this order.
+
+Notice that, in the example above, the first value in each dimension has index value 1. This is the case when an array value is created using a literal and you say nothing about the index values. The next example shows how you can control where the index values for each dimension start and end.
+```postgresql
+\pset null '<is null>'
+with v as (
+  select '[2:4][5:8]=
+    {
+      {25, 26, 27, 28},
+      {35, 36, 37, 38},
+      {45, 46, 47, 48}
+    }'::int[] as arr)
+select
+  arr[0][0] as "[0][0]",
+  arr[2][5] as "[2][5]",
+  arr[2][8] as "[2][8]",
+  arr[4][5] as "[4][5]",
+  arr[4][8] as "[4][8]",
+  arr[9][9] as "[9][9]"
+from v;
+```
+In this syntax, `[2:4]` says that the index runs from 2 through 4 on the first dimension; and `[5:8]` says that runs from 5 through 8 on the second dimension. The values have been chosen to illustrate this. Of course, you must provide the right number of values for each dimension. The query produces this result:
+```
+  [0][0]   | [2][5] | [2][8] | [4][5] | [4][8] |  [9][9]   
+-----------+--------+--------+--------+--------+-----------
+ <is null> |     25 |     28 |     45 |     48 | <is null>
+```
+Notice that if you access an element whose index values put it outside the ranges of the defined values, then, as mentioned, you silently get `null`.
+
+The values in an array are stored simply by laying out their internal representations consecutively in row-major order. This term is explained in the [Joint semantics](./functions-operators/properties/#joint-semantics)) section within the _"Functions for reporting the geometric properties of an array"_ section. Because every value has the same data type, this means that a value of interest can be addressed quickly, without index support, simply by calculating its offset. The value itself knows its dimensions. This explains how arrays of different dimensionality can be stored in a single table column. Even when the representations are of variable length (as is the case with `text` values), each knows its length, allowing the value boundaries easily to be calculated.
+
+## Uses of arrays
+
+You can use a one-dimensional array to store a graph, like temperature readings as a function of time. But the time axis is implicit: it's defined by each successive value's index. The application decides how to translate the integral index value to a time value.
+
+You can use a two-dimensional array to store a surface. For example you could decide to interpret the first index as an increment in latitude, and the second index as an increment in longitude. You might, then, use the array values to represent, say, the average temperature, over some period, at a location measured at points on a rectangular grid.
+
+A trained machine learning model is likely to be either a single array with maybe five or six dimensions and with fixed size. Or might be a collection of such arrays. It's useful, for various practical reasons, to store several of such models, corresponding to different stages of training or to different detailed use areas. The large physics applications at the Lawrence Livermore National Laboratory represent, and store, observations as multi-dimensional arrays.
+
+In these uses, your requirement is to persist the data and then to retrieve it (possibly retrieving just a slice) for programmatic analysis of the kind for which SQL is at best cumbersome or at worst inappropriate. For example, a one-dimensional array might be used to represent a path on a horizontal surface, where the value is a row representing the _(x, y)_ coordinate pair, and you might want to fit a curve through the data points to smooth out measurement inaccuracies. The [GPS trip data](./#example-use-case-gps-trip-data) use case, described below, typifies this use of arrays.
+
+## Example use case: GPS trip data
+Amateur cyclists like to record their trips using a GPS device and then to upload the recorded data to one of no end of Internet sites, dedicated to that purpose, so that they can review their trips, and those of others, whenever they want to into the indefinite future. It's easy to imagine that such a site will use a SQL database to store all these trips.
+
+The GPS device lets the cyclist split the trip into successive intervals, usually called laps, so that they can later focus their review attention on particular laps of interest like, for example, a notorious steep hill. So each trip has one or many laps. A lap is typically no more than about 100 km—and often more like 5-10 km. But it could be as large as, say, 300 km. The resolution of modern devices is typically just a few paces under good conditions—say 3m. So a lap could have as many as 100,000 GPS data points, each of which records the timestamp, position, and no end of other associated instantaneous values of facts like, for example, heart rate.
+
+This sounds like a classic three table design, with foreign key constraints to capture the notion that a GPS data point belongs to a lap and that a lap belongs to a trip. The array data type allows all of the GPS data points that belong to a lap to be recorded in a single row in the _"laps"_ table—in other words as a multivalued field, thus: 
+
+```postgresql
+create type gps_data_point_t as (
+  ts          timestamp,
+  lat         numeric,
+  long        numeric,
+  alt         numeric,
+  cadence     int,
+  heart_rate  int
+  ...
+  );
+
+create table laps(
+  lap_start_ts     timestamp,
+  trip_start_ts    timestamp,
+  userid           uuid,
+  gps_data_points  gps_data_point_t[],
+
+  constraint laps_pk primary key (lap_start_ts, trip_start_ts, userid),
+
+  constraint laps_fk foreign key (trip_start_ts, userid)
+    references trips(trip_start_ts, userid)
+    match full on delete cascade on update restrict);
+```
+**Note:** In PostgreSQL, the maximum number of values that an array of any dimensionality can hold is `(2^27 - 1)` (about 137 million). If you exceed this limit, then you get a clear _"54000: array size exceeds the maximum allowed (134217727)"_ error. This maps to the PL/pgSQL exception `program_limit_exceeded`. In PostgreSQL, array values are stored out of line. However, in YugabyteDB's YSQL subsystem, they are stored in line, just like, for example, a `json` or `jsonb` value. As a consequence, the maximum number of values that a YSQL array can accommodate is smaller than PostgreSQL's limit. Moreover, the actual YSQL limit depends on circumstances—and when it's exceeded you get a "time out" error. Experiment shows that the limit is about 30 million values. You can easily test this for yourself using [`array_fill()`](./functions-operators/array-fill/)) function.
+
+With about 100,000 GPS data points, a 300 km trip is very easily accommodated.
+
+The design that stores the GPS points in an array certainly breaks one of the time-honored rules of relational design: that column data types should be scalars. It does, however, bring definite advantages without the correctness risk and loss of functionality that it might in other use cases.
+
+For example, in the classic _"orders"_ and _"order_lines"_ design, an order line is for a quantity of a particular item from the vendor's catalog. And order lines for many different users will doubtless refer to the same catalog item. The catalog item has lots of fields; and some of them (especially the price) sometimes must be updated. Moreover, the overall business context implies queries like this: _find the total number of a specified catalog item that was ordered, by any user, during a specified time period_. Clearly a fully normal Codd-and-Date design is called for here.
+
+It's different with GPS data. The resolution of modern devices is so fine (typically just a few paces, as mentioned) that it's hugely unlikely that two different GPS data points would have the same position. It's even less likely that different point would share the same heart rate and all the other facts that are recorded at each position. In other words it's inconceivable that a query like the example given for the *"orders"* use case (_find the trips, by any user, that all share a common GPS data point_) would be useful. Moreover, all typical uses require fetching a trip and all its GPS data in a single query. One obvious example is to plot the transit of a lap on a map. Another example is to compute the generous containing envelope for a lap so that the set of coinciding lap envelopes can be discovered and analyzed to generate leader board reports and the like. SQL is not up to this kind of computation. Rather, you need procedural code—either in a stored procedure or in a client-side program.
+
+## Organization of the remaining array functionality content
+
+The following sections explain the details about array data types and functionality:
+
+- [The `array[]` value constructor](./array-constructor/)
+- [Creating an array value using a literal](./literals/)
+- [Built-in SQL functions and operators for arrays](./functions-operators/)
+- [Using an array of DOMAINs](./array-of-domains)

--- a/docs/content/latest/api/ysql/datatypes/type_array/array-constructor.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/array-constructor.md
@@ -1,0 +1,192 @@
+---
+title: The array[] value constructor
+linkTitle: array[] constructor
+headerTitle: The array[] value constructor
+description: The array[] value constructor
+menu:
+  latest:
+    identifier: array-constructor
+    parent: api-ysql-datatypes-array
+    weight: 10
+isTocNested: false
+showAsideToc: false
+---
+
+The `array[]` value constructor is a special variadic function. Uniquely among all the functions described in this _"Array data types and functionality"_ major section, it uses square brackets (`[]`) to surround its list of actual arguments.
+
+## Purpose and signature
+
+**Purpose:** Create an array value from scratch using an expression for each of the array's values. Such an expression can itself use the `array[]` constructor or an [array literal](../literals/). 
+
+**Signature** 
+```
+input value:       [anyarray | [ anyelement, [anyelement]* ]
+return value:      anyarray
+```
+**Note:** You can meet the goal of creating an array from directly specified values, instead, by using an [array literal](../literals/).
+
+These thee ordinary functions also create an array value from scratch:
+
+- The [`array_fill()`](../functions-operators/array-fill/) function creates a "blank canvas" array of the specified shape with all values set the same to what you want.
+- The [`array_agg()`](../functions-operators/array-agg-unnest/#array-agg) function creates an array (of, in general, an implied _"row"_ type) from a SQL subquery.
+- The [`text_to_array()`](../functions-operators/string-to-array/) function creates a `text[]`array from a single `text` value that uses a a specifiable delimiter to beak it into individual values.
+
+**Example:**
+```postgresql
+create type rt as (f1 int, f2 text);
+select array[(1, 'a')::rt, (2, 'b')::rt, (3, 'dog \ house')::rt]::rt[] as arr;
+```
+This is the result:
+```
+                    arr                     
+--------------------------------------------
+ {"(1,a)","(2,b)","(3,\"dog \\\\ house\")"}
+```
+Whenever an array value is shown in `ysqlsh`, it is implicitly `::text` typecasted. And this `text` value can be used immediately, simply by enquoting it and typecasting it to the appropriate array data type, to recreate the starting value. The YSQL documentation refers to this form of the literal as its _canonical form_. It is characterized by its complete lack of whitespace except within `text` scalar values and within date-time scalar values. This term is defined formally in [Defining the canonical form of a literal](../literals/text-typecasting-and-literals/#defining-the-canonical-form-of-a-literal).
+
+To learn why you see four consecutive backslashes, see [Statement of the rules](../literals/array-of-rows/#statement-of-the-rules).
+
+Users who are familiar with the rules that are described in that section often find it expedient, for example when prototyping code that builds an array literal, simply to create an example value first, _ad hoc_, using the `array[]` constructor, like the code above does, to see an example of the syntax that their code must create programmatically.
+
+## Using the array[] constructor in PL/pgSQL code
+
+The example below attempts to make many teaching points in one piece of code.
+
+- The actual syntax, when the expressions that the `array[]` constructor uses are all literals, is far simpler than the syntax that governs how to construct an array literal.
+- You can use all of YSQL's array functionality in PL/pgSQL code, just as you can in SQL statements. The code creates and invokes a table function, and not just a `DO` block, to emphasize this interoperability point.
+- Array-like functionality is essential in any programming language.
+- The `array[]` constructor is most valuable when the expressions that it uses are composed using declared variables, and especially formal parameters, that are used to build whatever values are intended. In this example, the values have the user-defined data type `rt`. In other words, the `array[]` constructor is particularly valuable when you build an array programmatically from scalar values that you know first at run time.
+- It vividly demonstrates the semantic effect of the `array[]` constructor like this:
+```
+declare
+  r     rt[];
+  two_d rt[];
+begin
+  ...
+  assert (array_dims(r) = '[1:3]'), 'assert failed';
+  one_d_1 := array[r[1], r[2], r[3]];
+  assert (one_d_1 = r), 'assert failed';
+```
+The [`array_dims()`](../functions-operators/properties/#array-dims) function is documented in the _"Functions for reporting the geometric properties of an array"_ section.
+
+Run this to create the required user-defined _"row"_ type and the table function and then to invoke it.
+
+```postgresql
+-- Don't create "type rt" if it's still there following the previous example.
+create type rt as (f1 int, f2 text);
+
+create function some_arrays()
+  returns table(arr text)
+  language plpgsql
+as $body$
+declare
+  i1 constant int := 1;
+  t1 constant text := 'a';
+  r1 constant rt := (i1, t1);
+
+  i2 constant int := 2;
+  t2 constant text := 'b';
+  r2 constant rt := (i2, t2);
+
+  i3 constant int := 3;
+  t3 constant text := 'dog \ house';
+  r3 constant rt := (i3, t3);
+
+  a1 constant rt[] := array[r1, r2, r3];
+begin
+  arr := a1::text;
+  return next;
+
+  declare
+    r rt[];
+    one_d_1 rt[];
+    one_d_2 rt[];
+    one_d_3 rt[];
+    two_d   rt[];
+    n int not null := 0;
+  begin
+    ----------------------------------------------
+    -- Show how arrays are useful, in the classic
+    -- sense, as what EVERY programming language
+    -- needs to handle a number of items when the
+    -- number isn't known until run time.
+    for j in 1..3 loop
+      n := j + 100;
+      r[j] := (n, chr(n));
+    end loop;
+
+    -- This further demonstrates the semantics
+    -- of the array[] constructor.
+    assert (array_dims(r) = '[1:3]'), 'assert failed';
+    one_d_1 := array[r[1], r[2], r[3]];
+    assert (one_d_1 = r), 'assert failed';
+    ----------------------------------------------
+
+    one_d_2 := array[(104, chr(104)), (105, chr(105)), (106, chr(106))];
+    one_d_3 := array[(107, chr(107)), (108, chr(108)), (109, chr(109))];
+
+    -- Show how the expressions that define the outcome
+    -- of the array[] constructor can themselves be arrays.
+    two_d := array[one_d_1, one_d_2, one_d_3];
+    arr := two_d::text;
+    return next;
+  end;
+  
+end;
+$body$;
+
+select arr from some_arrays();
+```
+It produces two rows. This is the first:
+
+```
+                    arr                     
+--------------------------------------------
+ {"(1,a)","(2,b)","(3,\"dog \\\\ house\")"}
+```
+
+And this is the second row. The readability was improved by adding some whitespace manually:
+
+```
+{
+  {"(101,e)","(102,f)","(103,g)"},
+  {"(104,h)","(105,i)","(106,j)"},
+  {"(107,k)","(108,l)","(109,m)"}
+}
+```
+
+## Using the array[] constructor in a prepared statement
+
+This example emphasizes the value of using the `array[]` constructor over using an array literal because it lets you use expressions like `chr()` within it.
+```postgresql
+-- Don't create "type rt" if it's still there followng the previous examples.
+create type rt as (f1 int, f2 text);
+create table t(k serial primary key, arr rt[]);
+
+prepare stmt(rt[]) as insert into t(arr) values($1);
+
+-- It's essential to typecast the individual "rt" values.
+execute stmt(array[(104, chr(104))::rt, (105, chr(105))::rt, (106, chr(106))::rt]);
+```
+This execution of the prepared statement, using an array literal as the actual argument, is semantically equivalent:
+```postgresql
+execute stmt('{"(104,h)","(105,i)","(106,j)"}');
+```
+But here, of course, you just have to know in advance that `chr(104)` is `h`, and so on. Prove that the results of the two executions of the prepared statement are identical thus:
+
+```postgresql
+select
+  (
+    (select arr from t where k = 1)
+    =
+    (select arr from t where k = 2)
+  )::text as result;
+```
+
+It shows this:
+
+```
+ result 
+--------
+ true
+```

--- a/docs/content/latest/api/ysql/datatypes/type_array/array-of-domains.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/array-of-domains.md
@@ -1,0 +1,17 @@
+---
+title: Using an array of DOMAINs
+linkTitle: array of DOMAINs
+headerTitle: Using an array of DOMAINs
+description: Using an array of DOMAINs
+menu:
+  latest:
+    identifier: array-of-domains
+    parent: api-ysql-datatypes-array
+    weight: 10
+isTocNested: false
+showAsideToc: false
+---
+
+An array of `DOMAIN`s lets you create, for example, a one-dimensional array whose values are one-dimensional arrays of _different_ lengths. In other words, it lets you overcome that restriction that an array must normally be rectilinear.
+
+**Coming soon**

--- a/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/_index.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/_index.md
@@ -1,0 +1,99 @@
+---
+title: SQL functions and operators for arrays
+linkTitle: Functions and operators
+headerTitle: Built-in SQL functions and operators for arrays
+description: Built-in SQL functions and operators for arrays
+image: /images/section_icons/api/ysql.png
+menu:
+  latest:
+    identifier: array-functions-operators
+    parent: api-ysql-datatypes-array
+    weight: 30
+isTocNested: false
+showAsideToc: false
+---
+Most of the functions and operators listed here can use an array of any dimensionality, but four of the functions accept, or produce, only a one-dimensional array. This property is called out by the second column _"1-d only?"_ in the tables that follow. The restricted status is indicated by _"1-d"_ in that function's row. When the field is blank, there is no dimensionality restriction.
+
+## Functions for creating arrays from scratch 
+
+The `array[]` constructor, and the three functions, create an array from scratch.
+
+| Function or operator | 1-d only? | Description |
+| ---- | ---- | ---- |
+| [array[]](./../array-constructor/) | | The array[] value constructor is a special variadic function that creates an array value from scratch using an expression for each of the array's values. Such an expression can itself use the `array[]` constructor or an _[array literal](../literals/)_. |
+| [array_fill()](./array-fill/) | | Returns a new "blank canvas" array of the specified shape with all cells set to the same specified value. |
+| [array_agg()](./array-agg-unnest/#array-agg) | | Returns an array (of an implied _"row"_ type) from a SQL subquery. |
+| [string_to_array()](./string-to-array/) | 1-d | Returns a one-dimensional `text[]` array by splitting the input `text` value into subvalues using the specified `text` value as the delimiter. Optionally, allows a specified `text` value to be interpreted as `null`. |
+
+## Functions for reporting the geometric properties of an array
+
+| Function | 1-d only? | Description |
+| ---- | ---- | ---- |
+| [array_ndims()](./properties/#array-ndims) | | Returns the dimensionality of the specified array. |
+| [array_lower()](./properties/#array-lower) | | Returns the lower bound of the specified array along the specified dimension. |
+| [array_upper()](./properties/#array-upper) | | Returns the upper bound of the specified array along the specified dimension. |
+| [array_length()](./properties/#array-length) | | Returns the length of the specified array along the specified dimension. |
+| [cardinality()](./properties/#cardinality) | | Returns the total number of values in the specified array. |
+| [array_dims()](./properties/#array-dims) | | Returns a text representation of the same information as “array_lower()" and “array_length()" return, for all dimension in a single text value. |
+| [array_dims()](./properties/#array-dims) | | Returns a text representation of the same information as `array_lower()` and `array_length()` return, for all dimensions, in a single text value. |
+
+## Functions to find a value in an array
+
+| Function | 1-d only? | Description |
+| ---- | ---- | ---- |
+| [array_position()](./array-position/#array-position) | 1-d | Returns the index, in the supplied array, of the specified value. Optionally starts searching at the specified index. |
+| [array_positions()](./array-position/#array-positions) | 1-d | Returns the indexes, in the supplied array, of all occurrences the specified value. |
+
+## Operators for comparing two arrays
+
+These operators require that the [LHS and RHS](https://en.wikipedia.org/wiki/Sides_of_an_equation) arrays have the same data type.
+
+| Operator | 1-d only? | Description |
+| ---- | ---- | ---- |
+| [=](./comparison/#the-and-operator) | | Returns `true` if the LHS and RHS arrays are equal. |
+| [<>](./comparison/#the-and-operator) | | Returns `true` if the LHS and RHS arrays are not equal. |
+| [>](./comparison/#the-and-and-and-and-operators) | | Returns `true` if the LHS array is greater than the RHS array. |
+| [>=](./comparison/#the-and-and-and-and-operators) | | Returns `true` if the LHS array is greater than or equal to the RHS array. |
+| [<=](./comparison/#the-and-and-and-and-operators) | | Returns `true` if the LHS array is less than or equal to the RHS array. |
+| [<](./comparison/#the-and-and-and-and-operators) | | Returns `true` if the LHS array is less than the RHS array. |
+| [@>](./comparison/#the-and-operators) | | Returns `true` if the LHS array contains the RHS array—that is, if every distinct value in the RHS array is found among the LHS array's distinct values. |
+| [<@](./comparison/#the-and-operators) | | Returns `true` if the LHS array is contained by the RHS array—that is, if every distinct value in the LHS array is found among the RHS array's distinct values. |
+| [&&](./comparison/#the-operator) | | Returns `true` if the LHS and RHS arrays overlap—that is, if they have at least one value in common. |
+
+
+## The slice operator
+
+| Operator | 1-d only? | Description |
+| ---- | ---- | ---- |
+|[[lb1:ub1]...[lbN:ubN]](./slice-operator/) | | Returns a new array whose length is defined by specifying the slice's lower and upper bound along each dimension. These specified slicing bounds must not exceed the source array's bounds. The new array has the same dimensionality as the source array and its lower bound is `1` on each axis. |
+
+## Functions and operators for concatenating an array with an array or an element
+
+These functions require that the two arrays have the same data type and compatible dimensionality.
+
+| Function or operator | 1-d only? | Description |
+| ---- | ---- | ---- |
+| [&#124;&#124;](./concatenation/#the-operator) | | Returns the concatenation of any number of compatible `anyarray` and `anyelement` values. |
+| [array_cat()](./concatenation/#array-cat) | | Returns the concatenation of two compatible `anyarray` values. |
+| [array_append()](./concatenation/#array-append) | | Returns an array that results from appending a scalar value to (that is, _after_) an array value. |
+| [array_prepend()](./concatenation/#array-prepend) | | Returns an array that results from prepending a scalar value to (that is, _before_) an array value. |
+
+## Functions and operators to change values in an existing array
+
+| Function or operator | 1-d only? | Description |
+| ---- | ---- | ---- |
+| [array_replace()](./replace-a-value/#array-replace) | | Returns a new array where every occurrence of the specified value in the input array has been replaced by the specified new value. |
+| [arr[idx_1]...[idx_N] := val](./replace-a-value/#setting-an-array-value-explicitly-and-in-place) | | Update a value in an existing array "in place". |
+| [array_remove()](./array-remove) | 1-d | Returns a new array where _every_ occurrence of the specified value has been removed from the specified input array. |
+
+## Function to convert an array to a text value
+
+| Function | 1-d only? | Description |
+| ---- | ---- | ---- |
+| [array_to_string()](./array-to-string) | | Returns a `text` value computed by representing each array value, traversing these in row-major order, by its `::text` typecast, using the supplied delimiter between each such representation. (The result, therefore, loses all information about the arrays geometric properties.) Optionally, represent `null` by the supplied `text` value. |
+
+## Table function to transform an array into a `SETOF anyelement`
+
+| Function | 1-d only? | Description |
+| ---- | ---- | ---- |
+| [unnest()](./array-agg-unnest/#unnest) | | Use in the `FROM` clause of a `SELECT` statement. The simple overload accepts a single `anyarray` value and returns a `SETOF anyelement`. The exotic overload accepts a variadic list of `anyarray` values and returns a `SETOF` with many columns where each, in turn, has the output of the corresponding simple overload. |

--- a/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/array-agg-unnest.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/array-agg-unnest.md
@@ -1,0 +1,520 @@
+---
+title: array_agg() and unnest()
+linkTitle: array_agg() / unnest()
+headerTitle: array_agg() and unnest()
+description: array_agg() and unnest()
+menu:
+  latest:
+    identifier: array-agg-unnest
+    parent: array-functions-operators
+isTocNested: false
+showAsideToc: false
+---
+
+For one-dimensional arrays, but _only for these_ (see [Multidimensional `array_agg()` and `unnest()`](./#multidimensional-array-and-and-unnest)), these two functions have mutually complementary effects in the following sense. After this sequence (the notation is informal):
+```
+array_agg of "SETOF tuples #1" => "result array"
+unnest of "result array" => "SETOF tuples #3"
+```
+The `SETOF tuples #3` has identical shape and content to that of `SETOF tuples #1`. And the data type of `result array` is an array of the data type of the tuples.
+
+For this reason, the two functions, `array_agg()` and `unnest()`, are described in the same section.
+
+## array_agg()
+
+In normal use, `array_agg()` is applied to the _select list_ from a physical table, or maybe from a view that encapsulates the query. This is shown in the _"[Realistic use case](./#realistic-use-case)"_ example below. But first, you can demonstrate the functionality without creating and populating a table by using, instead, the `values` statement. Try this:
+
+```postgresql
+values
+  (1::int, 'dog'::text),
+  (2::int, 'cat'::text),
+  (3::int, 'ant'::text);
+```
+
+It produces this result:
+```
+ column1 | column2 
+---------+---------
+       1 | dog
+       2 | cat
+       3 | ant
+```
+Notice that YSQL has named the _select list_ items `column1` and `column2`. The result is a so-called `SETOF`. It means a set of rows, just as is produced by a `SELECT` statement. (You'll see this word if you describe the `generate_series()` built-in table function with the `\df` metacommand.) To use the rows that the `values` statement produces as the input for `array_agg()`, you need to use a named `type`, thus:
+```postgresql
+create type rt as (k int, v text);
+
+with tab as (
+  values
+    (1::int, 'dog'::text),
+    (2::int, 'cat'::text),
+    (3::int, 'ant'::text))
+select array_agg((column1, column2)::rt order by column1) as array_literal
+from tab;
+```
+It produces this result:
+```
+          array_literal          
+---------------------------------
+ {"(1,dog)","(2,cat)","(3,ant)"}
+```
+You recognize this as the text of the literal that represents an array of tuples that are shape-compatible with type rt. Recall from the [`array[]` constructor](../../array-constructor/) section that this value doesn't encode the type name. In fact, you could typecast it to any shape compatible type.
+
+You can understand the effect of `array_agg()` thus:
+
+- Treat each row as a `rt[]` array with a single-value.
+- Concatenate (see the [`||` operator](../concatenation/#the-operator)) the values from all the rows in the specified order into a new `rt[]` array.
+
+This code illustrates this point:
+```postgresql
+-- Eqivalent to this:
+with tab as (
+  values
+    ((1, 'dog')::rt),
+    ((2, 'cat')::rt),
+    ((3, 'ant')::rt)
+  )
+select array_agg(column1 order by column1) as array_literal
+from tab;
+
+-- Can be seen as this:
+with tab as (
+  values
+    ((1, 'dog')::rt),
+    ((2, 'cat')::rt),
+    ((3, 'ant')::rt)
+  )
+select
+  array[(1, 'dog')::rt] ||
+  array[(2, 'cat')::rt] ||
+  array[(3, 'ant')::rt]
+as arr;
+```
+To prepare for the demonstration of `unnest()`, save this single-valued result into a `ysqlsh` variable by using the `\gset` metacommand. This takes a single argument, conventionally spelled with a trailing underscore (for example, `result_`) and re-runs the `SELECT` statement that, as the last submitted `ysqlsh` command, is still in the command buffer. (If the `SELECT` doesn't return a single row, then you get a clear error.) In general, when the _select list_ has _N_ members, called `c1` through `cN`, each of these values is stored in automatically-created variables called `result_c1` through `result_cN`.
+
+if you aren't already familiar with the `\gset` metacommand, you can read a brief account of how it works in the section [Meta-commands](../../../../../../admin/ysqlsh/#meta-commands) within the major section on `ysqlsh`.
+
+Immediately after running the `with... select array_agg(...) as array_literal...` query above, do this:
+
+```postgresql
+\gset result_
+\echo :result_array_literal
+```
+The `\gset` metacommand is silent. The `\echo` metacommand shows this:
+```
+{"(1,dog)","(2,cat)","(3,ant)"}
+```
+The text of the literal is now available for re-use, as was intended.
+## unnest()
+
+As the sketch at the start of this page indicated, the input to unnest is an array. To use what the code example in the account of `array_agg()` set in the `ysqlsh` variable `result_array_literal` in a SQL statement, you must quote it and typecast it to `rt[]`. This is easily done with the `\set` metacommand, thus:
+
+```postgresql
+\set unnest_arg '\'':result_array_literal'\'::rt[]'
+\echo :unnest_arg
+```
+
+The `\set` metacommand uses the backslash character to escape the single quote character that it also uses to surround the string that it assigns to the target `ysqlsh` variable. The `\echo` metacommand shows this:
+```
+'{"(1,dog)","(2,cat)","(3,ant)"}'::rt[]
+```
+Now use it as the actual argument for `unnest()` thus:
+```postgresql
+with
+  rows as (
+    select unnest(:unnest_arg) as rec)
+select
+  (rec).k,
+  (rec).v
+from rows
+order by 1;
+```
+The parentheses around the column alias `rec` are required to remove what the SQL compiler would otherwise see as an ambiguity, and would report as a _"42P01 undefined_table"_ error. This is the result:
+
+```
+ k |  v  
+---+-----
+ 1 | dog
+ 2 | cat
+ 3 | ant
+```
+
+As promised, the original `SETOF` tuples has been recovered.
+
+## Multidimensional array_agg() and unnest()
+
+Start by aggregating three `int[]` array instances and by preparing the result as an `int[]` literal for the next step using the same `\gset` technique that was used above:
+```postgresql
+with tab as (
+  values
+    ('{1, 2, 3}'::int[]),
+    ('{4, 5, 6}'::int[]),
+    ('{7, 8, 9}'::int[]))
+select array_agg(column1 order by column1) as array_literal
+from tab
+
+\gset result_
+\set unnest_arg '\'':result_array_literal'\'::int[]'
+\echo :unnest_arg
+```
+Notice that the SQL statement, this time, is _not_ terminated with a semicolon. Rather, the `\gset` metacommand acts as the terminator. This simply makes the `ysqlsh` output less noisy. This is the result:
+
+```
+'{{1,2,3},{4,5,6},{7,8,9}}'::int[]
+```
+You recognize this as the literal for a two-dimensional array. Now use this as the actual argument for `unnest()`:
+```postgresql
+select unnest(:unnest_arg) as val 
+order by 1;
+```
+It produces this result:
+```
+ val 
+-----
+   1
+   2
+   3
+   4
+   5
+   6
+   7
+   8
+   9
+```
+This `SETOF` result lists all of the input array's "leaf" values in row-major order. This term is explained in the [Joint semantics](./functions-operators/properties/#joint-semantics)) section within the _"Functions for reporting the geometric properties of an array"_ section.
+
+Notice that, for the multidimensional case, the original input to `array_agg()` was _not_, therefore, regained. This point is emphasized by aggregating the result:
+
+```postgresql
+with v as
+  (select unnest(:unnest_arg) as val)
+select array_agg(val order by val) from v;
+```
+It produces this result:
+```
+      array_agg      
+---------------------
+ {1,2,3,4,5,6,7,8,9}
+```
+You started with a two-dimensional array. But now you have a one-dimensional array with the same values as the input array in the same row-major order.
+
+This result has the same semantic content that the `array_to_string()` function produces:
+
+```postgresql
+select array_to_string(:unnest_arg, ',');
+```
+It produces this result:
+```
+  array_to_string  
+-------------------
+ 1,2,3,4,5,6,7,8,9
+```
+
+## Realistic use case
+
+The basic illustration of the functionality of `array_agg()` showed how it can convert the entire contents of a table (or, by extension, the `SETOF` rows defined by a `SELECT` execution) into a single array value. This can be useful to return a large `SELECT` result in its entirety (in other words, in a single round trip) to a client program.
+
+Another use is to populate a single newly-created _"masters_with_details"_ table from the fully projected and unrestricted _inner join_ of a classic _"masters"_ and _"details"_ pair of tables. The new table has all the columns that the source _"masters"_ table has and all of its rows. And it has an additional _"details"_ column that holds, for each _"masters"_ row, a _"details_t[]"_ array that represents all of the child rows that it has in the source _"details"_ table. The type _"details_t"_ has all of the columns of the _"details"_ table except the _"details.masters_pk"_ foreign key column. This column vanishes because, as the _join_ column, it vanishes in the _"inner join"_. The _"details"_ table's "payload" is now held in place in a single multivalued field in the new _"masters_with_details"_ table.
+
+Start by creating and populating the _"masters"_ and _"details"_ tables:
+```postgresql
+create table masters(
+  master_pk int primary key,
+  master_name text not null);
+
+insert into masters(master_pk, master_name)
+values
+  (1, 'John'),
+  (2, 'Mary'),
+  (3, 'Joze');
+
+create table details(
+  master_pk int not null,
+  seq int not null,
+  detail_name text not null,
+
+  constraint details_pk primary key(master_pk, seq),
+
+  constraint master_pk_fk foreign key(master_pk)
+    references masters(master_pk)
+    match full
+    on delete cascade
+    on update restrict);
+
+insert into details(master_pk, seq, detail_name)
+values
+  (1, 1, 'cat'),    (1, 2, 'dog'),
+  (2, 1, 'rabbit'), (2, 2, 'hare'), (2, 3, 'squirrel'), (2, 4, 'horse'),
+  (3, 1, 'swan'),   (3, 2, 'duck'), (3, 3, 'turkey');
+```
+Next, create a view that encodes the fully projected, unrestricted _inner join_ of the original data, and inspect the result set that it represents:
+```postgresql
+create view original_data as
+select
+  master_pk,
+  m.master_name,
+  d.seq,
+  d.detail_name
+from masters m inner join details d using (master_pk);
+
+select
+  master_pk,
+  master_name,
+  seq,
+  detail_name
+from original_data
+order by
+master_pk, seq;
+```
+This is the result:
+```
+ master_pk | master_name | seq | detail_name 
+-----------+-------------+-----+-------------
+         1 | John        |   1 | cat
+         1 | John        |   2 | dog
+         2 | Mary        |   1 | rabbit
+         2 | Mary        |   2 | hare
+         2 | Mary        |   3 | squirrel
+         2 | Mary        |   4 | horse
+         3 | Joze        |   1 | swan
+         3 | Joze        |   2 | duck
+         3 | Joze        |   3 | turkey
+```
+Next, create the type `details_t` and the new table:
+
+```postgresql
+create type details_t as (seq int, detail_name text);
+
+create table masters_with_details (
+  master_pk int primary key,
+  master_name text not null,
+  details details_t[] not null);
+```
+Notice that you made the _"details"_ column `not null`. This was a choice. It adds semantics that are very hard to capture in the original two table design without tricky, and therefore error-prone, programming of triggers and the like. You have implemented the so-called _"mandatory one-to-many"_ rule. In the present example, the rule says (in the domain of the entity-relationship model that specifies the requirements) that an occurrence of a _"Master"_ entity type cannot exist unless it has at least one, but possibly many, child occurrences of a _"Detail"_ entity type.
+
+Next, populate the new table and inspect its contents:
+```postgresql
+insert into masters_with_details
+select
+  master_pk,
+  master_name,
+  array_agg((seq, detail_name)::details_t order by seq) as agg
+from original_data
+group by master_pk, master_name;
+
+select master_pk, master_name, details
+from masters_with_details
+order by 1;
+```
+This is the result:
+```
+ master_pk | master_name |                       details                        
+-----------+-------------+------------------------------------------------------
+         1 | John        | {"(1,cat)","(2,dog)"}
+         2 | Mary        | {"(1,rabbit)","(2,hare)","(3,squirrel)","(4,horse)"}
+         3 | Joze        | {"(1,swan)","(2,duck)","(3,turkey)"}
+```
+Here's a helper function to show the primitive values that the `details_t[]` array encodes without the clutter of the array literal syntax:
+
+```postgresql
+create function pretty_details(arr in details_t[])
+  returns text
+  immutable
+  language plpgsql
+as $body$
+declare
+  arr_type constant text := pg_typeof(arr);
+  ndims constant int := array_ndims(arr);
+  lb constant int := array_lower(arr, 1);
+  ub constant int := array_upper(arr, 1);
+begin
+  assert arr_type = 'details_t[]', 'assert failed: ndims = %', arr_type;
+  assert ndims = 1, 'assert failed: ndims = %', ndims;
+  declare
+    line text not null :=
+      rpad(arr[lb].seq::text||': '||arr[lb].detail_name::text, 12)||
+      ' | ';
+  begin
+    for j in (lb + 1)..ub loop
+      line := line||
+      rpad(arr[j].seq::text||': '||arr[j].detail_name::text, 12)||
+      ' | ';
+    end loop;
+    return line;
+  end;
+end;
+$body$;
+```
+Notice that this is not a general purpose function. Rather, it expects that the input is a `details_t` array. So it first checks that this pre-condition is met. It then discovers the lower and upper bounds of the array so that it can loop over its values. It uses these functions for reporting the geometric properties of the input array: [`array_ndims()`](../../functions-operators/properties/#array-ndims); [`array_lower()`](../../functions-operators/properties/#array-lower); and [`array_upper()`](../../functions-operators/properties/#array-upper).
+
+Invoke it like this:
+
+```postgresql
+select master_pk, master_name, pretty_details(details)
+from masters_with_details
+order by 1;
+```
+It produces this result:
+```
+ master_pk | master_name |                        pretty_details                        
+-----------+-------------+--------------------------------------------------------------
+         1 | John        | 1: cat       | 2: dog       | 
+         2 | Mary        | 1: rabbit    | 2: hare      | 3: squirrel  | 4: horse     | 
+         3 | Joze        | 1: swan      | 2: duck      | 3: turkey    |
+```
+Next, create a view that uses `unnest()` to re-create the effect of the fully projected, unrestricted _inner join_ of the original data, and inspect the result set that it represents:
+```postgresql
+create view new_data as
+with v as (
+  select
+    master_pk,
+    master_name,
+    unnest(details) as details
+  from masters_with_details)
+select
+  master_pk,
+  master_name,
+  (details).seq,
+  (details).detail_name
+from v;
+
+select
+  master_pk,
+  master_name,
+  seq,
+  detail_name
+from new_data
+order by
+master_pk, seq;
+```
+The result is identical to what the _"original_data"_ view represents. But rather than relying on visual inspection, can check that the _"new_data"_ view and the the _"original_data"_ view represent the identical result by using SQL thus:
+```postgresql
+with
+  original_except_new as (
+    select master_pk, master_name, seq, detail_name 
+    from original_data
+    except
+    select master_pk, master_name, seq, detail_name
+    from new_data),
+
+  new_except_original as (
+    select master_pk, master_name, seq, detail_name
+    from new_data
+    except
+    select master_pk, master_name, seq, detail_name
+    from original_data),
+
+  original_except_new_union_new_except_original as (
+    select master_pk, master_name, seq, detail_name
+    from original_except_new
+    union
+    select master_pk, master_name, seq, detail_name
+    from new_except_original)
+
+select
+  case count(*)
+    when 0 then '"new_data" is identical to "original_data."'
+    else        '"new_data" differs from "original_data".'
+  end as result
+from original_except_new_union_new_except_original;
+```
+This is the result:
+```
+                   result                    
+---------------------------------------------
+ "new_data" is identical to "original_data."
+```
+Notice that if you choose the _"masters_with_details"_ approach (either as a migration from a two-table approach in an extant application, or as an initial choice in a new application) you must appreciate the trade-offs.
+
+**Prerequisite:**
+
+- You must be confident that the _"details"_ rows are genuinely private each to its own master and do not implement a many-to-many relationship in the way that the _"order_items"_ table does between the _"customers"_ table and the _"items"_ table in the classic sales order entry model that is frequently used to teach table design according to the relational model.
+
+**Pros:**
+
+- You can enforce the mandatory one-to-many requirement declaratively and effortlessly.
+- Changing and querying the data will be faster because you use single table, single-row access rather than two-table, multi-row access.
+- You can trivially recapture the query functionality of the two-table approach by implementing a _"new_data"_ unnesting view as has been shown. So you can still find, for example, rows in the _"masters_with_details"_ table where the "details" array has the specified values like this:
+```postgresql
+with v as (
+  select master_pk, master_name, seq, detail_name
+  from new_data
+  where detail_name in ('rabbit', 'horse', 'duck', 'turkey'))
+select
+  master_pk,
+  master_name,
+  array_agg((seq, detail_name)::details_t order by seq) as agg
+from v
+group by master_pk, master_name
+order by 1;
+```
+&#160;&#160;&#160;&#160;This is the result:
+```
+ master_pk | master_name |            agg             
+-----------+-------------+----------------------------
+         2 | Mary        | {"(1,rabbit)","(4,horse)"}
+         3 | Joze        | {"(2,duck)","(3,turkey)"}
+```
+**Cons:**
+- Changing the data in the "details" array is rather difficult. Try this (in the two-table regime):
+```postgresql
+update details
+set detail_name = 'bobcat'
+where master_pk = 2
+and detail_name = 'squirrel';
+
+select
+  master_pk,
+  master_name,
+  seq,
+  detail_name
+from original_data
+where master_pk = 2
+order by
+master_pk, seq;
+```
+&#160;&#160;&#160;&#160;This is the result:
+```
+ master_pk | master_name | seq | detail_name 
+-----------+-------------+-----+-------------
+         2 | Mary        |   1 | rabbit
+         2 | Mary        |   2 | hare
+         2 | Mary        |   3 | bobcat
+         2 | Mary        |   4 | horse
+```
+- Here's how you achieve the same effect, and check that it worked as intended, in the new regime. Notice that you need to know the value of _"seq"_ for the _"rt"_ object that has the _"detail_name"_ value of interest. This is easy to do by implementing a dedicated PL/pgSQL function that encapsulates `array_replace()` or that replaces a value directly by addressing it using its index. But it's hard to do without that. (These methods are described in [`array_replace()` and setting an array value explicitly](../../functions-operators/replace-a-value/).)
+
+```postgresql
+with v as (
+  select array_replace(details, '(3,squirrel)', '(3,bobcat)')
+  as new_arr from masters_with_details where master_pk = 2)
+update masters_with_details
+set details = (select new_arr from v)
+where master_pk = 2;
+
+select
+  master_pk,
+  master_name,
+  seq,
+  detail_name
+from new_data
+where master_pk = 2
+order by
+master_pk, seq;
+```
+&#160;&#160;&#160;&#160;The result is identical to the result shown for querying _"original_data"_ above.
+
+**Note:** The `UPDATE` statement, using as it does a subquery from a view defined in a `WITH` clause as the actual argument for `array_replace()`, seems to be unnecessarily complex. You might expect to use this:
+
+```
+update masters_with_details
+set details = array_replace(details, '(3,squirrel)', '(3,bobcat)')
+where master_pk = 2;
+```
+
+The more complex, but semantically equivalent, locution is used as a workaround for [GitHub Issue #4296](https://github.com/yugabyte/yugabyte-db/issues/4296). For more information, see [`array_replace()`](../replace-a-value/#array-replace). The code above will be updated when that issue is fixed.
+
+- Implementing the requirement that the values of _"detail_name"_ must be unique for a given _"masters"_ row is trivial in the old regime:
+```postgresql
+create unique index on details(master_pk, detail_name);
+```
+To achieve the effect in the new regime, you'd need to write a PL/pgSQL function, with return type `boolean` that scans the values in the _"details"_ array and returns `true` when there are no duplicates among the values of the _"detail_name"_ field and that otherwise returns `false`. Then you'd use this function as the basis for a check constraint in the definition of the _"details_with_masters"_ table. This is a straightforward programming task, but it does take more effort than the simple declarative implementation of the business rule that the two-table regime allows.

--- a/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/array-fill.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/array-fill.md
@@ -1,0 +1,123 @@
+---
+title: array_fill()
+linkTitle: array_fill()
+headerTitle: array_fill()
+description: array_fill()
+menu:
+  latest:
+    identifier: array-fill
+    parent: array-functions-operators
+isTocNested: false
+showAsideToc: false
+---
+**Signature:**
+```
+input value:       anyelement, int[] [, int[]]
+return value:      anyarray
+```
+**Purpose:** Return a new "blank canvas" array of the specified shape with all cells set to the same specified value.
+
+- The first parameter determines the value and data type for every cell, and therefore the data type of the new array as a whole. It can be a value of a primitive data type, or, for example, a _"row"_ type value. It can also be written `null::some_type` if this suits your purpose. You would presumably set a `not null` value if, for example, you wanted to insert the array into a table column on which you have created a constraint, based upon a PL/pgSQL function, that explicitly tests the array's geometric properties and the `not null` status of each of its values. Try this:
+```postgresql
+select pg_typeof(array_fill(null::text, '{1}')) as "type of the new array";
+```
+&#160;&#160;&#160;&#160;This is the result:
+```
+ type of the new array 
+-----------------------
+ text[]
+```
+- The second parameter is an `int[]` array. Each of its values specifies the value that `array_length(new_arr, n)` returns—where `n` is the dimension number, starting with the major dimension. So the cardinality of the array that you supply here specifies the value returned by `array_ndims(new_arr)`.
+- The third parameter is optional. When supplied, it must be an `int[]` array with the same cardinality as the second parameter. Each of its values specifies the value that `array_lower(new_arr, n)` returns.
+
+The shape of the new array is, therefore, fully specified by the second and third parameters.
+
+**Note:** Why does `array_fill()` exist? In other words, why not simply set the values that you want by directly indexing each cell and assigning the value you want to it? Recall that, as described in [Synopsis](../../#synopsis), an array value is rectilinear. This means that its shape, when its number of dimensions exceeds one, is non-negotiably fixed at creation time. This `DO` block emphasizes the point.
+
+```postgresql
+do $body$
+declare
+  a int[];
+  b int[] := array_fill(null::int, '{3, 4}');
+begin
+  a[1][1] := 42;
+  begin
+    -- Causes ERROR: array subscript out of range
+    a[2][2] := 17;
+  exception
+    when array_subscript_error then null;
+  end;
+  raise info
+    'cardinality(a), cardinality(b): %, %', cardinality(a), cardinality(b);
+end;
+$body$;
+```
+
+It shows this (after manually stripping the _"INFO:"_ prompt:
+
+```
+cardinality(a), cardinality(b): 1, 12
+```
+
+So the array `a` is stuck as a possibly not very useful singleton cell.
+
+**Example:**
+
+Run this:
+```postgresql
+create table t(k int primary key, arr text[]);
+
+insert into t(k, arr)
+values(1, array_fill('-----'::text, '{3, 4}', '{2, 7}')::text[]);
+
+select
+  array_length(arr, 1)  as len_1,
+  array_length(arr, 2)  as len_2,
+  array_lower(arr,  1)  as lb_1,
+  array_lower(arr,  2)  as lb_2,
+  array_ndims(arr)      as ndims,
+  cardinality(arr)      as cardinality
+from t
+where k = 1;
+```
+It shows this:
+```
+ len_1 | len_2 | lb_1 | lb_2 | ndims | cardinality 
+-------+-------+------+------+-------+-------------
+     3 |     4 |    2 |    7 |     2 |          12
+```
+
+Now run this:
+```postgresql
+update t
+set
+  arr[2][ 7] = '2---7',
+  arr[2][10] = '2--10',
+  arr[4][ 7] = '4---7',
+  arr[4][10] = '4--10'
+where k = 1;
+
+select arr::text from t where k = 1;
+```
+It shows this (after some manual white-space formatting for readability):
+```
+[2:4][7:10]=
+  {
+    {2---7,-----,-----,2--10},
+    {-----,-----,-----,-----},
+    {4---7,-----,-----,4--10}
+  }
+```
+
+Finally, run this:
+```postgresql
+\set VERBOSITY verbose
+update t
+set
+  arr[1][17] = 'Hmm...'
+where k = 1;
+```
+It reports this error, as expected:
+```
+2202E: array subscript out of range
+```

--- a/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/array-position.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/array-position.md
@@ -1,0 +1,83 @@
+---
+title: array_position() and array_positions()
+linkTitle: array_position(), array_positions()
+headerTitle: array_position() and array_positions()
+description: array_position() and array_positions()
+menu:
+  latest:
+    identifier: array-position
+    parent: array-functions-operators
+isTocNested: false
+showAsideToc: false
+---
+These functions require that the to-be-searched array is one-dimensional. They return the index values of the specified to-be-searched-for value in the specified to-be-searched array.
+
+Create `view v` now. The examples below use it.
+```postgresql
+create view v as
+select array[
+    'sun', -- 1
+    'mon', -- 2
+    'tue', -- 3
+    'wed', -- 4
+    'thu', -- 5
+    'fri', -- 6
+    'sat', -- 7
+    'mon'  -- 9
+  ]::text
+as arr;
+```
+## array_position()
+
+**Purpose:** Return the index, in the supplied array, of the specified value. Optionally, starts searching at the specified index.
+
+**Signature:**
+```
+input value:       anyarray, anyelement [, int]
+return value:      int
+```
+**Note:** The optional third parameter specifies the _inclusive_ index value at which to start the search.
+
+**Example:**
+```postgresql
+select array_position(
+  (select arr from v)::text[],  -- #1. The to-be-searched array.
+
+  'mon'::text,                  -- #2. The to-be-searched-for value.
+
+  3::int                        -- #3. The (inclusive) position at which to start searching. [optional]
+) as position;
+```
+This is the result:
+
+```
+ position 
+----------
+        8
+```
+
+## array_positions()
+
+**Purpose:** Return the indexes, in the supplied array, of all occurrences of the specified value.
+
+**Signature:**
+
+```
+input value:       anyarray, anyelement
+return value:      integer[] 
+```
+**Example:**
+```postgresql
+select array_positions(
+  (select arr from v)::text[],  -- #1. The to-be-searched array.
+
+  'mon'::text                   -- #2. The to-be-searched-for value.
+) as positions;
+```
+This is the result:
+
+```
+ positions 
+-----------
+ {2,8}
+```

--- a/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/array-remove.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/array-remove.md
@@ -1,0 +1,58 @@
+---
+title: array_remove()
+linkTitle: array_remove()
+headerTitle: array_remove()
+description: array_remove()
+menu:
+  latest:
+    identifier: array-remove
+    parent: array-functions-operators
+isTocNested: false
+showAsideToc: false
+---
+
+**Purpose:** Return a new array where _every_ occurrence of the specified value has been removed from the specified input array.
+
+**Signature:**
+```
+input value:       anyarray, anyelement
+return value:      anyarray
+```
+**Note:** This function requires the array from which values are to be removed is one-dimensional. This restriction is easily understood in light of the fact that arrays are rectilinear—in other words, the geometry of an array whose dimensionality is two or more is fixed at creation time. For examples illustrating this rule, see [`array_fill()`](.././array-fill).
+
+**Example:**
+```postgresql
+create table t(k int primary key, arr int[]);
+insert into t(k, arr)
+values (1, '{1, 2, 2, 2, 5, 6}'::int[]);
+
+select arr as "old value of arr" from t where k = 1;
+
+update t
+set arr = array_remove(arr, 2)
+where k = 1;
+
+select arr as "new value of arr" from t where k = 1;
+```
+This is the result of the two queries:
+```
+ old value of arr 
+------------------
+ {1,2,2,2,5,6}
+
+ new value of arr 
+------------------
+ {1,5,6}
+```
+
+The example suffers from the problem that [GitHub Issue #4296](https://github.com/yugabyte/yugabyte-db/issues/4296) tracks. (This same issue also affects the concatenation operator and the `array_replace()` function.) If you run this example as presented, then the `UPDATE` statement causes an error that causes the client session to terminate. But, when you restart it, an attempt to execute the _"new value of arr"_ query causes an error.
+
+This section will be updated when the issue is fixed. You can sidestep the problem, for demonstration purposes, simply by creating `table t` without a primary key constraint. But this violates proper practice. Here is a viable workaround. Simply use this `UPDATE` statement instead of the one shown above:
+
+```postgresql
+with v as (
+  select array_remove(arr, 2) as new_arr from t where k = 1)
+update t
+set arr = (select new_arr from v)
+where k = 1;
+```

--- a/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/array-to-string.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/array-to-string.md
@@ -1,0 +1,78 @@
+---
+title: array_to_string()
+linkTitle: array_to_string()
+headerTitle: array_to_string()
+description: array_to_string()
+menu:
+  latest:
+    identifier: array-to-string
+    parent: array-functions-operators
+isTocNested: false
+showAsideToc: false
+---
+
+**Purpose:** Return a `text` value computed by representing each array value, traversing these in row-major order, by its `::text` typecast, using the supplied delimiter between each such representation. (The result, therefore, loses all information about the arrays geometric properties.) Optionally, represent `null` by the supplied `text` value. The term _"row-major order"_ is explained in the [Joint semantics](./functions-operators/properties/#joint-semantics)) section within the _"Functions for reporting the geometric properties of an array"_ section.
+
+**Signature:**
+```
+input value:       anyarray, text [, text]
+return value:      text
+```
+
+**Example:**
+```postgresql
+create type rt as (f1 int, f2 text);
+create table t(k int primary key, arr rt[]);
+insert into t(k, arr) values(1,
+  array[
+    array[
+      array[(1, 'a')::rt, (2, null)::rt, null, (3, 'c')::rt]
+    ]
+  ]::rt[]
+);
+
+select arr::text from t where k = 1;
+```
+It shows this:
+```
+                arr                
+-----------------------------------
+ {{{"(1,a)","(2,)",NULL,"(3,c)"}}}
+```
+To understand the syntax of the text of this literal, especially when a field is `null`, see  [The literal for a _"row"_ type value](../../literals/row/).
+
+Now do this:
+```postgresql
+select
+  array_to_string(
+    arr,     -- the input array
+    ' | ')   -- the delimiter
+from t
+where k = 1;
+```
+It shows this:
+```
+   array_to_string    
+----------------------
+ (1,a) | (2,) | (3,c)
+```
+Notice that the third, `null`, array value is simply not represented.
+
+Now do this;
+```postgresql
+select
+  array_to_string(
+    arr,     -- the input array
+    ' | ',   -- the delimiter
+    '?')     -- the null indicator
+from t
+where k = 1;
+```
+It shows this:
+```
+     array_to_string      
+--------------------------
+ (1,a) | (2,) | ? | (3,c)
+```
+
+The third array value is now represented by `?`. But the fact that `f2 is null` within the second array value is _not_ represented by `?`. In other words, this technique for visualizing `null` is applied only at the granularity of top-level array values and not within such values when they are composite.

--- a/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/comparison.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/comparison.md
@@ -1,0 +1,454 @@
+---
+title: Array comparison
+linkTitle: Array comparison
+headerTitle: Operators for comparing two arrays
+description: Operators for comparing two arrays
+menu:
+  latest:
+    identifier: array-comparison
+    parent: array-functions-operators
+isTocNested: false
+showAsideToc: false
+---
+
+## Comparison operators overview
+
+**Purpose:** Each of the comparison operators returns `true` or `false` according to the outcome of the particular comparison test between the input [LHS and RHS](https://en.wikipedia.org/wiki/Sides_of_an_equation) arrays.
+
+**Signature**
+
+These operators all have the same signature, thus:
+
+```
+input value:       anyarray, anyarray
+return value:      boolean
+```
+**Note:** These operators require that the LHS and RHS arrays have the same data type. (It's the same rule for the comparison of scalars.) However, they do _not_ require that the arrays have identical geometric properties. Rules are defined so that a difference between one or more of these properties does not mean that they are necessarily simply unequal. Rather, the LHS array might be deemed to be less than, or greater than, the RHS array. It's essential, therefore, to understand the comparison algorithm.
+
+### Comparison criteria
+
+These are the unique characteristics of an array with respect to the algorithm that compares two array values:
+
+- the actual values, compared pairwise in row-major order
+- the cardinality
+- the number of dimensions
+- the lower bound on each dimension.
+
+The term "row-major order"_ is explained in the [Joint semantics](./functions-operators/properties/#joint-semantics)) section within the _"Functions for reporting the geometric properties of an array"_ section.
+
+The other geometric properties (the length and upper bound along each dimension) can be derived from the properties that the bullets list..
+
+There is, of course, a well-defined priority among the comparisons. Briefly, value comparison is done first. Then, but only if no difference is detected, are the geometric properties compared.
+
+
+### Pairwise comparison of values
+
+The first comparison test scans the values in each of the LHS and RHS arrays in row-major order (see [Joint semantics](../functions-operators/properties/#joint-semantics)) and does a pairwise comparison. Notably, the comparison rule non-negotiably uses `is not distinct from` semantics. Moreover, when a `not null` array value is pairwise compared with a `null` value, the `not null` value is deemed to be _less than_ the `null` value.
+
+Notice the contrast with the `=` operator comparison rule for free-standing scalar values. This comparison uses `null` semantics but, of course, lets you use `is not distinct from` comparison if this better suits your purpose. 
+
+Otherwise, the comparison rules are the same as those for scalar values and, by extension, with those for, for example, _"row"_ type values.
+
+If a pairwise comparison results in inequality, then the LHS and RHS arrays are immediately deemed to be unequal with no regard to the geometric properties. The outcome of the _first_ pairwise comparison, when these values differ, determines the outcome of the array comparison. Remaining pairwise comparisons are not considered.
+
+Notice that the two arrays might not have the same cardinality. If all possible pairwise comparisons result in equality, then the array with the greater cardinality is deemed to be greater than the other array, and the other geometric properties are not considered.
+
+### The priority of differences among the geometric properties
+
+The previous section stated the rule that the cardinality comparison has the highest priority among the geometric property comparisons. And that this rule kicks in only of all possible value comparisons result in equality.
+
+When _both_ all possible value comparisons _and_ the cardinality comparison result in equality, then the comparison between the number of dimensions has a higher priority than the comparison between the lower bound on each dimension. Of course, the array with the greater number of dimensions is deemed to be the greater array.
+
+This means that the lower bounds are significant when two arrays are compared _only_ when they are identical in pairwise value comparison, cardinality, and the number of dimensions. Then the array with the greater lower bound, in dimension order, is deemed to be the greater array.
+
+The [Equality and inequality semantics](./#equality-and-inequality-semantics) section demonstrates each of the rules that this _"Comparison operators overview"_  section has stated.
+
+## Containment and overlap operators overview
+
+These three operators are insensitive to the geometric properties of the two to-be-compared arrays.
+- The two containment operators test if the distinct set of values in one array contains, or is contained by, the distinct set of values in the other array.
+- The overlap operator tests if the distinct set of values in one array and the distinct set of values in the other array have at least one value in common.
+
+The [Containment and overlap operators semantics](./#containment-and-overlap-operators-semantics) section below demonstrates each of the rules that this section has stated.
+
+## Examples for each operator
+
+### The `=` and `<>` operator
+
+- The `=` operator returns `true` if the LHS and RHS arrays are equal.
+- The `<>` operator is the natural complement: it returns `true` if the LHS and RHS arrays are not equal.
+
+```postgresql
+with
+  v as (
+    select
+      (select array['a', 'b', null, 'd']::text[]) as a1,
+      (select      '{a,   b,  null,  d}'::text[]) as a2
+  )
+select (a1 = a2)::text as "EQUALITY comparison result"
+from v;
+```
+This is the result:
+```
+ EQUALITY comparison result 
+----------------------------
+ true
+```
+
+```postgresql
+with
+  v as (
+    select
+      (select array['a', 'b', 'c',  'd']::text[]) as a1,
+      (select      '{a,   b,  null,  d}'::text[]) as a2
+  )
+select (a1 <> a2)::text as "INEQUALITY comparison result"
+from v;
+```
+This is the result:
+```
+ INEQUALITY comparison result
+------------------------------
+ true
+```
+
+### The `>` and `>=` and `<=` and `<` and `<>` operators
+
+These four operators implement the familiar inequality comparisons.
+- The `>` operator returns `true` if the LHS array is greater than the RHS array.
+- The `>=` operator returns `true` if the LHS array is greater than or equal to the RHS array.
+- The `<=` operator returns `true` if the LHS array is less than or equal to the RHS array.
+- The `<` operator returns `true` if the LHS array is less than the RHS array.
+
+It's sufficient, therefore, to provide a simple example for just the `<` operator.
+```postgresql
+with
+  v as (
+    select
+      (select array['a', 'b', 'c',  'd']::text[]) as a1,
+      (select array['a', 'b', 'e',  'd']::text[]) as a2,
+      (select      '{a,   b,  null,  d}'::text[]) as a3
+  )
+select
+  (a1 < a2)::text as "'LESS THAN' comparison result 1",
+  (a1 < a3)::text as "'LESS THAN' comparison result 2"
+from v;
+```
+This is the result:
+```
+ 'LESS THAN' comparison result 1 | 'LESS THAN' comparison result 2 
+---------------------------------+---------------------------------
+ true                            | true
+```
+
+### The `@>` and `<@` operators
+
+- The `@>` operator returns `true` if the LHS array contains the RHS array—that is, if every distinct value in the RHS array is found among the LHS array's distinct values.
+- The `<@` operator is the natural complement: it returns `true` if every distinct value in the LHS array is found among the RHS array's distinct values.
+
+```postgresql
+with
+  v as (
+    select
+      (select array['a', 'b', 'c',  'd']::text[]) as a1,
+      (select array['a',      'c'      ]::text[]) as a2
+  )
+select
+  (a1 @> a2)::text as "CONTAINS comparison result",
+  (a2 <@ a1)::text as "'IS CONTAINED BY' comparison result"
+from v;
+```
+This is the result:
+```
+ CONTAINS comparison result | 'IS CONTAINED BY' comparison result 
+----------------------------+-------------------------------------
+ true                       | true
+```
+
+### The `&&` operator
+
+The `&&` operator returns `true` if the LHS and RHS arrays overlap—that is, if they have at least one value in common. The definition of this operator makes it insensitive to which of the two to-be-compared is used on the LHS and which is used on the RHS.
+
+```postgresql
+with
+  v as (
+    select
+      (select array['a', 'b', 'c',  'd']::text[]) as a1,
+      (select array['d', 'e', 'f',  'g']::text[]) as a2
+  )
+select
+  (a1 && a2)::text as "'a1 OVERLAPS a2' comparison result",
+  (a2 && a1)::text as "'a2 OVERLAPS a1' comparison result"
+from v;
+```
+This is the result:
+```
+ 'a1 OVERLAPS a2' comparison result | 'a2 OVERLAPS a1' comparison result 
+------------------------------------+------------------------------------
+ true                               | true
+```
+
+## Equality and inequality semantics
+
+This section demonstrates each of the rules that the [Comparison operators overview](./#comparison-operators-overview) section above stated.
+
+```postgresql
+-- Any two arrays can be compared without error if they have the same data type.
+do $body$
+begin
+  ------------------------------------------------------------------------------
+  -- Illustrate "IS NOT DISTINCT FROM" semantics.
+  declare
+    v1 constant int := 1;
+    v2 constant int := 1;
+    n1 constant int := null;
+    n2 constant int := null;
+  begin
+    assert
+      (v1 = v2)                    and
+      (v1 is not distinct from v2) and
+
+      ((n1 = n2) is null)          and
+      (n1 is not distinct from n2),
+    'unexpected';
+  end;
+
+  ------------------------------------------------------------------------------
+  -- Basic demonstration of equaliy when the geom. properties of
+  -- the two arrays are identical.
+  -- Shows that pairwise comparison uses ""IS NOT DISTINCT FROM" semantics and NOT
+  -- the conventional NULL semantics used when scalars are compared.
+  declare
+    a constant int[] := '{10, null, 30}';
+    b constant int[] := '{10, null, 30}'; -- Identical to a.
+  begin
+    assert
+      (a = b),
+    '"a = b" assert failed';
+
+    -- Because of this, there's no need ever to write this.
+    assert
+      (a is not distinct from b),
+    '"a is not distinct from b" assert failed';
+  end;
+
+  ------------------------------------------------------------------------------
+  -- Basic demonstration of inequality when the geometric properties of
+  -- the two arrays are identical.
+  -- When the first difference is encountered in row-major order, the comparison
+  -- is made. Other differences are irrelevant.
+  declare
+    a constant int[] := '{10, 20, 30}';
+    b constant int[] := '{10, 19, 31}'; 
+  begin
+    assert
+      (a <> b) and
+      (a >  b) and
+      (a >= b) and
+      (b <= a) and
+      (b <  a) ,
+    '"a > b" assert failed';
+  end;
+
+  ------------------------------------------------------------------------------
+  -- Demonstration of inequality when the geometric properties of
+  -- the two arrays are identical.
+  -- Here, the first pairwise difference is NOT NULL versus NULL.
+  declare
+    a constant int[] := '{10, 20,   30}';
+    b constant int[] := '{10, null, 29}';
+  begin
+    -- Bizarrely, a NOT NULL value counts as LESS THAN a NULL value in the
+    -- pairwise comparison.
+    assert
+      (a <> b) and
+      (a <  b),
+    '"a < b" assert failed';
+
+    -- Again, because of this, there's no need ever to write this.
+    assert
+      (a is distinct from b) ,
+    '"a is distinct from b" assert failed';
+  end;
+
+  ------------------------------------------------------------------------------
+  -- Extreme demonstration of priority.
+  -- c has just a single value and d has several.
+  -- c has one dimension and d has two.
+  -- c's first lower bound is less than d's first lower.
+  -- d's second lower bound is greater than one, but is presumably irrelevant.
+  -- But c's first value is GREATER THAN d's first value,
+  -- scanning in row-major order.
+  --
+  -- Pairwise value comparison has the hoghest priority.
+  -- therefore c is deemed to be GREATER THAN d.
+  
+  declare
+    c constant int[] := '{2}';
+
+    -- Notice that d's first value is at [2][3].
+    d constant int[] := '[2:3][3:4]={{1, 2}, {3, 3}}';
+
+  begin
+    assert
+      cardinality(c) < cardinality(d),
+    '"cardinality(c) < cardinality(d)" assert failed';
+
+    assert
+      array_ndims(c) < array_ndims(d),
+    '"ndims(c) < ndims(d)" assert failed';
+    assert
+      array_lower(c, 1) < array_lower(d, 1),
+    '"lower(c, 1) < lower(d, 1)" assert failed';
+
+    assert
+      c[1] > d[2][3],
+    '"c[1] > d[2][3]" assert failed';
+
+   assert
+     c > d,
+   '"c > d" assert failed';
+  end;
+
+  ------------------------------------------------------------------------------
+  -- Pairwise comparison is equal are far as it is feasible.
+  -- e's ndims < f's.
+  -- e's lb-1 < f's.
+  -- BUT e's cardinality > f's.
+  -- Cardinality has highest priority among the geom. propoerties,
+  -- so e is deemed to be GREATER THAN f.
+  declare
+    e constant int[] := '{10, 20, 30, 40, 50, 60, 70}';
+    f constant int[] := '[2:3][3:5]={{10, 20, 30}, {40, 50, 60}}'; 
+  begin
+    assert
+      e[1] = f[2][3] and
+      e[2] = f[2][4] and
+      e[3] = f[2][5] and
+      e[4] = f[3][3] and
+      e[5] = f[3][4] and
+      e[6] = f[3][5] ,
+    '"e-to-f eqality test, as far as feasible, assert failed';
+
+    assert
+      array_ndims(e) < array_ndims(f),
+    '"ndims(e) < ndims(f)" assert failed';
+
+    assert
+      array_lower(e, 1) < array_lower(f, 1),
+    '"lower(e, 1) < lower(f, 1)" assert failed';
+
+    assert
+      cardinality(e) > cardinality(f),
+    '"cardinality(e) > cardinality(f)" assert failed';
+
+    assert
+      (e > f) ,
+    'e > f assert failed';
+  end;
+
+  ------------------------------------------------------------------------------
+  -- g's cardinality = h's.
+  -- So pairwise comparison is feasible for all values, and is equal.
+  -- g's ndims > h's.
+  -- g's lb-1 < h's.
+  -- Ndims has higher priority among ndims and lower bounds,
+  -- so g is deemed to be GREATER THAN h.
+  declare
+    g constant int[] := '{{10, 20, 30}, {40, 50, 60}}'; 
+    h constant int[] := '[2:7]={10, 20, 30, 40, 50, 60}';
+  begin
+    assert
+      cardinality(g) = cardinality(h),
+    '"cardinality(g) = cardinality(h)" assert failed';
+
+    assert
+      g[1][1] = h[2] and
+      g[1][2] = h[3] and
+      g[1][3] = h[4] and
+      g[2][1] = h[5] and
+      g[2][2] = h[6] and
+      g[2][3] = h[7] ,
+    '"g-to-h eqality test assert failed';
+
+    assert
+      array_ndims(g) > array_ndims(h),
+    '"ndims(g) > ndims(h)" assert failed';
+
+    assert
+      array_lower(g, 1) < array_lower(h, 1),
+    '"lower(g, 1) < lower(h, 1)" assert failed';
+
+    assert
+      (g > h) ,
+    'g > h assert failed';
+  end;
+
+  ------------------------------------------------------------------------------
+  declare
+    i constant int[] := '[5:6][4:6]={{10, 20, 30}, {40, 50, 60}}'; 
+    j constant int[] := '[3:4][6:8]={{10, 20, 30}, {40, 50, 60}}';
+  begin
+    assert
+      cardinality(i) = cardinality(j),
+    '"cardinality(i) = cardinality(j)" assert failed';
+
+    assert
+      i[5][4] = j[3][6] and
+      i[5][5] = j[3][7] and
+      i[5][6] = j[3][8] and
+      i[6][4] = j[4][6] and
+      i[6][5] = j[4][7] and
+      i[6][6] = j[4][8] ,
+    '"i-to-j eqality test assert failed';
+
+    assert
+      array_ndims(i) = array_ndims(j),
+    '"ndims(i) = ndims(j)" assert failed';
+
+    assert
+      array_lower(i, 1) > array_lower(j, 1),
+    '"lower(i, 1) > lower(j, 1)" assert failed';
+
+    assert
+      (i > j) ,
+    'i > j assert failed';
+  end;
+
+  ------------------------------------------------------------------------------
+end;
+$body$;
+```
+
+
+
+## Containment and overlap operators semantics
+
+This section demonstrates each of the rules that the [Containment and overlap operators overview](./#containment-and-overlap-operators-overview) section stated.
+
+```postgresql
+-- Any two arrays can be compared without error if they have the same data type.
+-- Insensitive to the geom. properties.
+do $body$
+declare
+  a constant int[] := '[2:3][4:5]={{10, 20}, {30, 40}}';
+  b constant int[] := '[5:6]={20, 30}';
+  c constant int[] := '[6:9]={40, 50, 70, 70}';
+  d constant int[] := '[2:4]={50, 60, 70}';
+begin
+  assert
+    -- Containment
+    (b @> b) and
+    (b <@ a) and
+
+    -- Overlap.
+    -- The definition of the semantics makes the LHS, RHS order immaterial.
+    (a && c) and
+    (c && a) and
+
+    -- a and d have NO values in common.
+    not (a && d),
+  'unexpected';
+end;
+$body$;
+```

--- a/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/concatenation.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/concatenation.md
@@ -1,0 +1,240 @@
+---
+title: Array concatenation functions and operators
+linkTitle: Array concatenation
+headerTitle: Array concatenation functions and operators
+description: Array concatenation functions and operators
+menu:
+  latest:
+    identifier: array-concatenation
+    parent: array-functions-operators
+isTocNested: false
+showAsideToc: false
+---
+
+The `||` operator implements, by itself, all of the functionality that each of the `array_cat()`, `array_append()`, and `array_prepend()` functions individually implement. Yugabyte recommends that you use the `||` operator and avoid the functions. They are documented here for completeness—especially in case you find them in inherited code.
+
+## The `||` operator
+
+**Purpose:** Return the concatenation of any number of compatible `anyarray` and `anyelement` values.
+
+**Signature**
+
+```
+LHS and RHS input value:  [anyarray | anyelement] [anyarray | anyelement]*
+return value:             anyarray`
+```
+**Note:** "_Compatible"_ is used here to denote two requirements:
+
+- The values within the array, or the value of the scalar, must be of the same data type, for example, an `int[]` array and an `int` scalar.
+- The LHS and the RHS must be _dimensionally_ compatible. For example, you can produce a one-dimensional array: _either_ by concatenating two scalars; _or_ by concatenating a scalar and a one-dimensional array; _or_ by concatenating two one-dimensional arrays. This notion extends to multidimensional arrays. The next bullet gives the rules.
+- When you concatenate two N-dimensional arrays, the lengths along the major (that is, the first dimension) may be different but the lengths along the other dimensions must be identical. And when (as the analogy of concatenating a one-dimensional array and a scalar) you concatenate an N-dimensional and an (N-1)-dimensional array, the lengths along the dimensions of the (N-1)-dimensional array must all be identical to the corresponding lengths along the dimensions that follow the major dimension in the N-dimensional array.
+
+These rules follow directly from the fact that arrays are rectilinear. For examples, see [|| operator semantics](./#operator-semantics) below.
+
+**Example:**
+
+```postgresql
+create table t(k int primary key, arr int[]);
+insert into t(k, arr)
+values (1, '{3, 4, 5}'::int[]);
+
+select arr as "old value of arr" from t where k = 1;
+
+update t
+set arr = '{1, 2}'::int[]||arr||6::int
+where k = 1;
+
+select arr as "new value of arr" from t where k = 1;
+```
+It shows this:
+```
+ old value of arr 
+------------------
+ {3,4,5}
+```
+and then this:
+```
+ new value of arr 
+------------------
+ {1,2,3,4,5,6}
+```
+The example suffers from the problem that [GitHub Issue #4296](https://github.com/yugabyte/yugabyte-db/issues/4296) tracks. (This same issue also affects the `array_remove()` and the `array_replace()` functions.) If you run this example as presented, then the `UPDATE` statement causes a timeout error of such a severity that in order to continue, you must restart the crashed tserver.
+
+This section will be updated when the issue is fixed. You can sidestep the problem, for demonstration purposes, simply by creating `table t` without a primary key constraint. But this violates proper practice. Here is a viable workaround. Simply use this `UPDATE` statement instead of the one shown above:
+```postgresql
+with v as (
+  select '{1, 2}'::int[]||arr||6::int as new_arr from t where k = 1)
+update t
+set arr = (select new_arr from v)
+where k = 1;
+```
+## array_cat()
+
+**Purpose:** Return the concatenation of two compatible `anyarray` values.
+
+**Signature**
+```
+input value:              anyarray, anyarray
+return value:             anyarray`
+```
+**Note:** The `DO` block shows that the `||` operator is able to implement the full functionality of the `array_cat()` function.
+
+```postgresql
+do $body$
+declare
+  arr_1 constant int[] := '{1, 2, 3}'::int[];
+  arr_2 constant int[] := '{4, 5, 6}'::int[];
+  val constant int := 5;
+  workaround constant int[] := array[val];
+begin
+  assert
+    array_cat(arr_1, arr_2)      = arr_1||arr_2 and
+    array_cat(arr_1, workaround) = arr_1||val   ,
+  'unexpected';
+end;
+$body$;
+```
+## array_append()
+**Purpose:** Return an array that results from appending a scalar value to (that is, _after_) an array value.
+
+**Signature**
+```
+input value:              anyarray, anyelement
+return value:             anyarray`
+```
+**Note:** The `DO` block shows that the `||` operator is able to implement the full functionality of the `array_append()` function. The values must be compatible.
+
+```postgresql
+do $body$
+declare
+  arr constant int[] := '{1, 2, 3, 4}'::int[];
+  val constant int := 5;
+  workaround constant int[] := array[val];
+begin
+  assert
+    array_append(arr, val) = arr||val                   and
+    array_append(arr, val) = array_cat(arr, workaround) ,
+  'unexpected';
+end;
+$body$;
+```
+## array_prepend()
+**Purpose:** Return an array that results from prepending a scalar value to (that is, _before_) an array value.
+
+**Signature**
+```
+input value:              anyelement, anyarray
+return value:             anyarray`
+```
+**Note:** The `DO` block shows that the `||` operator is able to implement the full functionality of the `array_prepend()` function. The values must be compatible.
+
+```postgresql
+do $body$
+declare
+  arr constant int[] := '{1, 2, 3, 4}'::int[];
+  val constant int := 5;
+  workaround constant int[] := array[val];
+begin
+  assert
+    array_prepend(val, arr) = val||arr                   and
+    array_prepend(val, arr) = array_cat(workaround, arr) ,
+  'unexpected';
+end;
+$body$;
+```
+## Concatenation semantics
+
+**Semantics for one-arrays**
+
+```postgresql
+create type rt as (f1 int, f2 text);
+
+do $body$
+declare
+  arr constant rt[] := array[(3, 'c')::rt, (4, 'd')::rt, (5, 'e')::rt];
+
+  prepend_row  constant rt := (0, 'z')::rt;
+  prepend_arr  constant rt[] := array[(1, 'a')::rt, (2, 'b')::rt];
+  append_row   constant rt := (6, 'f')::rt;
+
+  cat_result   constant rt[] := prepend_row||prepend_arr||arr||append_row;
+
+  expected_result constant rt[] :=
+    array[(0, 'z')::rt, (1, 'a')::rt, (2, 'b')::rt, (3, 'c')::rt, 
+         (4, 'd')::rt, (5, 'e')::rt, (6, 'f')::rt];
+
+begin
+  assert
+    (cat_result   = expected_result),
+  'unexpected';
+end;
+$body$;
+```
+
+**Semantics for multidimensional arrays**
+
+```postgresql
+do $body$
+declare
+  -- arr_1 and arr_2 are demensionally compatible.
+  -- Its's OK for array_length(*, 1) to differ.
+  -- But array_length(*, 1) must be the same.
+  arr_1 constant int[] :=
+    array[
+       array[11, 12, 13],
+       array[21, 22, 23]
+    ];
+
+  arr_2 constant int[] :=
+    array[
+       array[31, 32, 33],
+       array[41, 42, 43],
+       array[51, 52, 53]
+    ];
+
+  -- Notice that this is a 1-d array.
+  -- Its lenth is the same as as that of arr_1
+  -- along arr_1's SECOND dimension.
+  arr_3 constant int[] := array[31, 32, 33];
+
+  -- Notice that bad_arr is dimensionally INCOMPATIBLE with arr_1:
+  -- they have different lengths along their SECOND major dimension.
+  bad_arr constant int[] :=
+    array[
+       array[61, 62, 63, 64],
+       array[71, 72, 73, 74],
+       array[81, 82, 83, 84]
+    ];
+
+  expected_cat_1 constant int[] :=
+    array[
+       array[11, 12, 13],
+       array[21, 22, 23],
+       array[31, 32, 33],
+       array[41, 42, 43],
+       array[51, 52, 53]
+    ];
+
+  expected_cat_2 constant int[] :=
+    array[
+       array[11, 12, 13],
+       array[21, 22, 23],
+       array[31, 32, 33]
+    ];
+begin
+  assert
+    arr_1||arr_2 = expected_cat_1 and
+    arr_1||arr_3 = expected_cat_2,
+  'unexpected';
+
+  declare
+    a int[];
+  begin
+    -- ERROR: cannot concatenate incompatible arrays.
+    a := arr_1||bad_arr;
+  exception
+    when array_subscript_error then null;
+  end;
+end;
+$body$;
+```

--- a/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/properties.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/properties.md
@@ -1,0 +1,416 @@
+---
+title: Array properties
+linkTitle: Array properties
+headerTitle: Functions for reporting the geometric properties of an array
+description: Functions for reporting the geometric properties of an array
+menu:
+  latest:
+    identifier: array-properties
+    parent: array-functions-operators
+isTocNested: false
+showAsideToc: false
+---
+
+These functions return the various dimensional properties that jointly characterize an array. These three together completely specify the shape and size:
+
+- its dimensionality (`int`)
+- the lower bound along each dimension (`int`)
+- the upper bound along each dimension (`int`).
+
+There are functions for returning two other properties: the length along each dimension (`int`); and its cardinality (`int`). But each of these can be derived from set set of the lower and upper bounds for all the dimensions. There is also a function that returns the values for the lower and upper bounds for all the dimensions as a single `text` value.
+
+## Overview
+
+The behavior of each of the functions for reporting the geometric properties of an array is illustrated by supplying the same two arrays as the first actual argument to two invocations of the function. The return value, in all cases, is insensitive to the array's data type and the values within the array.
+
+Create and populate `table t` thus:
+
+```postgresql
+create table t(k int primary key, arr_1 text[], arr_2 text[]);
+insert into t(k, arr_1, arr_2) values(1,
+      '[3:10]={ 1, 2, 3, 4,   5, 6, 7, 8}',
+  '[2:3][4:7]={{1, 2, 3, 4}, {5, 6, 7, 8}}'
+  );
+```
+
+You will use it in the example for each of the functions. (The optional syntax items `[3:10]` and `[2:3][2:5]` specify the lower and upper bounds along the one dimension of the first array and along both dimensions of the second array. This syntax is explained in [Multidimensional array of numeric values](../../literals/array-of-primitive-values/#multidimensional-array-of-numeric-values).
+
+Run the `SELECT` statement for each function to illustrate what produces for the same pair of input arrays.
+
+### array_ndims()
+
+**Purpose:** Return the number of dimensions (that is, the _dimensionality_) of the specified array.
+
+**Signature:**
+```
+input value:       anyarray
+return value:      int
+```
+**Example:**
+
+```postgresql
+select
+  array_ndims(arr_1) as ndims_1,
+  array_ndims(arr_2) as ndims_2
+from t where k = 1;
+```
+It produces this result:
+```
+  ndims_1 | ndims_2 
+---------+---------
+       1 |       2
+```
+### array_lower()
+
+**Purpose:** Return the lower bound of the specified array along the specified dimension.
+
+**Signature:**
+```
+input value:       anyarray, int
+return value:      int
+```
+**Example:**
+
+```postgresql
+select
+  array_lower(arr_1, 1) as arr_1_lb,
+  array_lower(arr_2, 1) as arr_2_lb_1,
+  array_lower(arr_2, 2) as arr_2_lb_2
+from t where k = 1;
+```
+It produces this result:
+```
+ arr_1_lb | arr_2_lb_1 | arr_2_lb_2 
+----------+------------+------------
+        3 |          2 |          4
+```
+### array_upper()
+
+**Purpose:** Return the upper bound of the specified array along the specified dimension.
+
+**Signature:**
+```
+input value:       anyarray, int
+return value:      int
+```
+**Example:**
+The use of `array_upper()` is exactly symmetrical with the use of `array_lower()`.
+```postgresql
+select
+  array_upper(arr_1, 1) as arr_1_ub,
+  array_upper(arr_2, 1) as arr_2_ub_1,
+  array_upper(arr_2, 2) as arr_2_ub_2
+from t where k = 1;
+```
+It produces this result:
+```
+ arr_1_ub | arr_2_ub_1 | arr_2_ub_2 
+----------+------------+------------
+       10 |          3 |          7
+```
+### array_length()
+
+**Purpose:** Return the length of the specified array along the specified dimension. Notice that, among `array_lower()` and `array_upper()` and `array_length()`, the result of any two of them determines the result of the third. You could therefore decide, for example, only to use `array_lower()` and `array_upper()` and to determine the length, when you need it, by subtraction. But, for code clarity and brevity, you may as well use exactly the one that matches your present purpose.
+
+**Signature:**
+```
+input value:       anyarray, int
+return value:      int
+```
+**Example:**
+The use of `array_length()` is exactly symmetrical with the use of `array_lower()` and `array_upper()`.
+
+```postgresql
+select
+  array_length(arr_1, 1) as arr_1_len,
+  array_length(arr_2, 1) as arr_2_len_1,
+  array_length(arr_2, 2) as arr_2_len_2
+from t where k = 1;
+```
+It produces this result:
+```
+ arr_1_len | arr_2_len_1 | arr_2_len_2 
+-----------+-------------+-------------
+         8 |           2 |           4
+```
+### cardinality()
+
+**Purpose:** Return the total number of values in the specified array. Notice that the value that this function returns can be computed as the product of values returned by the `array_length()` function along each direction.
+
+**Signature:**
+```
+input value:       anyarray
+return value:      int
+```
+**Example:**
+
+```postgresql
+select
+  cardinality(arr_1) as card_1,
+  cardinality(arr_2) as card_2
+from t where k = 1;
+```
+It produces this result:
+```
+ card_1 | card_2 
+--------+--------
+      8 |      8
+```
+### array_dims()
+
+**Purpose:** Return a text representation of the same information as `array_lower()` and `array_length()` return, for all dimensions, in a single text value.
+
+**Signature:**
+```
+input value:       anyarray
+return value:      text
+```
+**Example:**
+The `array_dims()` function is useful to produce a result that is easily humanly readable. If you want to use the information that it returns programmatically, then you should use `array_lower()`, `array_upper()`, or `array_length()`.
+
+```postgresql
+select
+  array_dims(arr_1) as arr_1_dims,
+  array_dims(arr_2) as arr_2_dims
+from t where k = 1;
+```
+It produces this result:
+```
+ arr_1_dims | arr_2_dims 
+------------+------------
+ [3:10]     | [2:3][4:7]
+```
+
+## Joint semantics
+
+Create the procedure `assert_semantics_and_traverse_values()` and then invoke it for each of the three provided data sets. You supply it with a one-dimensional array and a two dimensional array and, for each, your humanly determined estimates of these values:
+
+- what `array_ndims()` returns
+- what `array_lower()` returns for each dimension
+- what `array_upper()` returns for each dimension.
+
+The procedure obtains the actual values, programmatically, for all of the values that you supply and asserts that they agree.
+
+Notice that the cardinality and the length along each dimension are omitted, by design, from this list. The procedure also obtains these values, programmatically, and checks that these agree with the values that are computed from, respectively, the length along each dimension and the upper and lower bounds along each dimension.
+
+Notice, too, that the value that `array_dims()` returns can be computed from the upper and lower bounds along each dimension. So the procedure does this too and checks that the value returned by `array_dims()` is consistent with the values returned by `array_lower()` and `array_upper()`.
+
+The procedure has some particular requirements:
+
+- The cardinality of each of the two supplied arrays must be the same.
+- The actual array values, in row-major order, must be the same, pairwise.
+
+These requirements might seem to be arbitrary. They are implemented so that the procedure can deliver two bonus benefits. It demonstrates how to traverse array values in row-major order using the values returned by the functions that this section describes. In this way, it shows you what the term "row-major order" means. And it compares the values, pairwise, for equality. This comparison rule is the basis of the semantics of the comparison operations described in [Operators for comparing two arrays](../comparison).
+
+**Note:** There are no built-in functions for computing, for example, the product of two matrixes or the product of a vector and a matrix. (A vector is a one-dimensional array, and a matrix is a two-dimensional array.) But, as long as you know how to traverse the values in a matrix in row-major order, it's easy to implement the missing vector and matrix multiplication functionality for yourself.
+
+```postgresql
+create procedure assert_semantics_and_traverse_values(
+  a in int[], b in int[],
+
+  a_ndims in int, a_lb   in int, a_ub   in int,
+
+  b_ndims in int, b_lb_1 in int, b_ub_1 in int,
+                  b_lb_2 in int, b_ub_2 in int)
+  language plpgsql
+as $body$
+declare
+  -- Get the facts that are implied by the user-supplied facts.
+  a_len   constant int := array_length(a, 1);
+  b_len_1 constant int := array_length(b, 1);
+  b_len_2 constant int := array_length(b, 2);
+
+  a_dims constant text := '['||a_lb::text||':'||a_ub::text||']';
+  b_dims constant text := '['||b_lb_1::text||':'||b_ub_1::text||']'||
+                          '['||b_lb_2::text||':'||b_ub_2::text||']';
+begin
+  -- Confirm that the supplied arrays meet the basic
+  -- dimensionalities requirement.
+  assert
+    a_ndims = 1 and b_ndims = 2,
+  'ndims assert failed';
+
+  -- Confirm the user-supplied facts about the shape and size of "a".
+  assert
+    array_ndims(a) = a_ndims           and
+    array_lower(a, 1) = a_lb           and
+    array_upper(a, 1) = a_ub           ,
+  '"a" dimensions assert failed';
+
+  -- Confirm the user-supplied facts about the shape and size of "b".
+  assert
+    array_ndims(b) = b_ndims           and
+    array_lower(b, 1) = b_lb_1         and
+    array_upper(b, 1) = b_ub_1         and
+    array_lower(b, 2) = b_lb_2         and
+    array_upper(b, 2) = b_ub_2         ,
+  '"b" dimensions assert failed';
+
+  -- Confirm the length overspecification rule.
+  assert
+    (a_ub   - a_lb + 1  ) = a_len and
+    (b_ub_1 - b_lb_1 + 1) = b_len_1 and
+    (b_ub_2 - b_lb_2 + 1) = b_len_2 ,
+  'Length overspecification rule assert failed.';
+
+  -- Confirm the cardinality overspecification rule.
+  assert
+    cardinality(a) = a_len             and
+    cardinality(b) = b_len_1 * b_len_2 ,
+  'Cardinality overspecification rule assert failed.';
+
+  -- Confirm the "dims" overspecification rule.
+  assert
+    array_dims(a) = a_dims             and
+    array_dims(b) = b_dims             ,
+  '"dims" overspecification rule assert failed.';
+
+  -- Do the row-major order traversal and
+  -- check that the values are pairwise-identical. 
+  for j in 0..(a_len - 1) loop
+    declare
+      -- Traversing a 1-d array is trivial.
+      a_idx   constant int := j + a_lb;
+
+      -- Traversing a 2-d array is need a bit more thought.
+      b_idx_1 constant int := floor(j/b_len_2)          + b_lb_1;
+      b_idx_2 constant int := ((j + b_len_2) % b_len_2) + b_lb_2;
+
+      a_txt   constant text := lpad(a_idx::text,    2);
+      b_txt_1 constant text := lpad(b_idx_1::text,  2);
+      b_txt_2 constant text := lpad(b_idx_2::text,  2);
+      val     constant text := lpad(a[a_idx]::text, 2);
+
+      line constant text := 
+        'a['||a_txt||'] = '||
+        'b['||b_txt_1||']['||b_txt_2||'] = '||
+        val;
+    begin
+      assert
+        a[a_idx] = b[b_idx_1][b_idx_2],
+      'Row-major order pairwise equality assert failed';
+      raise info '%', line;
+    end;
+  end loop;
+end;
+$body$;
+```
+
+Try it on the first data set:
+```postgresql
+do $body$
+declare
+  a constant int[] :=            '{ 1, 2,   3,  4,   5,  6}';
+  b constant int[] :=            '{{1, 2}, {3,  4}, {5,  6}}';
+
+  a_ndims constant int  := 1;
+  a_lb    constant int  := 1;
+  a_ub    constant int  := 6;
+
+  b_ndims constant int  := 2;
+  b_lb_1  constant int  := 1;
+  b_ub_1  constant int  := 3;
+  b_lb_2  constant int  := 1;
+  b_ub_2  constant int  := 2;
+begin
+  call assert_semantics_and_traverse_values(
+    a, b,
+    a_ndims, a_lb,   a_ub,
+    b_ndims, b_lb_1, b_ub_1,
+             b_lb_2, b_ub_2);
+end;
+$body$;
+```
+It produces this result (after manually stripping the _"INFO:"_ prompts):
+```
+a[ 1] = b[ 1][ 1] =  1
+a[ 2] = b[ 1][ 2] =  2
+a[ 3] = b[ 2][ 1] =  3
+a[ 4] = b[ 2][ 2] =  4
+a[ 5] = b[ 3][ 1] =  5
+a[ 6] = b[ 3][ 2] =  6
+```
+Try it on the second data set:
+```postgresql
+do $body$
+declare
+  a constant int[] :=     '[3:14]={ 1, 2, 3,   4, 5, 6,   7, 8, 9,   10, 11, 12}';
+  b constant int[] := '[3:6][6:8]={{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}}';
+
+  a_ndims constant int  := 1;
+  a_lb    constant int  := 3;
+  a_ub    constant int  := 14;
+
+  b_ndims constant int  := 2;
+  b_lb_1  constant int  := 3;
+  b_ub_1  constant int  := 6;
+  b_lb_2  constant int  := 6;
+  b_ub_2  constant int  := 8;
+begin
+  call assert_semantics_and_traverse_values(
+    a, b,
+    a_ndims, a_lb,   a_ub,
+    b_ndims, b_lb_1, b_ub_1,
+             b_lb_2, b_ub_2);
+end;
+$body$;
+```
+It produces this result:
+```
+a[ 3] = b[ 3][ 6] =  1
+a[ 4] = b[ 3][ 7] =  2
+a[ 5] = b[ 3][ 8] =  3
+a[ 6] = b[ 4][ 6] =  4
+a[ 7] = b[ 4][ 7] =  5
+a[ 8] = b[ 4][ 8] =  6
+a[ 9] = b[ 5][ 6] =  7
+a[10] = b[ 5][ 7] =  8
+a[11] = b[ 5][ 8] =  9
+a[12] = b[ 6][ 6] = 10
+a[13] = b[ 6][ 7] = 11
+a[14] = b[ 6][ 8] = 12
+```
+Try it on the third data set:
+```postgresql
+do $body$
+declare
+  a constant int[] :=     '[3:18]={ 1, 2, 3, 4,   5, 6, 7, 8,   9, 10, 11, 12,   13, 14, 15, 16}';
+  b constant int[] := '[3:6][2:5]={{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}, {13, 14, 15, 16}}';
+
+  a_ndims constant int  := 1;
+  a_lb    constant int  := 3;
+  a_ub    constant int  := 18;
+
+  b_ndims constant int  := 2;
+  b_lb_1  constant int  := 3;
+  b_ub_1  constant int  := 6;
+  b_lb_2  constant int  := 2;
+  b_ub_2  constant int  := 5;
+begin
+  call assert_semantics_and_traverse_values(
+    a, b,
+    a_ndims, a_lb,   a_ub,
+    b_ndims, b_lb_1, b_ub_1,
+             b_lb_2, b_ub_2);
+end;
+$body$;
+```
+It produces this result:
+```
+a[ 3] = b[ 3][ 2] =  1
+a[ 4] = b[ 3][ 3] =  2
+a[ 5] = b[ 3][ 4] =  3
+a[ 6] = b[ 3][ 5] =  4
+a[ 7] = b[ 4][ 2] =  5
+a[ 8] = b[ 4][ 3] =  6
+a[ 9] = b[ 4][ 4] =  7
+a[10] = b[ 4][ 5] =  8
+a[11] = b[ 5][ 2] =  9
+a[12] = b[ 5][ 3] = 10
+a[13] = b[ 5][ 4] = 11
+a[14] = b[ 5][ 5] = 12
+a[15] = b[ 6][ 2] = 13
+a[16] = b[ 6][ 3] = 14
+a[17] = b[ 6][ 4] = 15
+a[18] = b[ 6][ 5] = 16
+```

--- a/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/replace-a-value.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/replace-a-value.md
@@ -1,0 +1,331 @@
+---
+title: array_replace()
+linkTitle: array_replace() / set value
+headerTitle: array_replace() and setting an array value explicitly
+description: array_replace() and setting an array value explicitly
+menu:
+  latest:
+    identifier: array-replace-a-value
+    parent: array-functions-operators
+isTocNested: false
+showAsideToc: false
+---
+Each of the approaches described in this section, using the `array_replace()` function and setting an addressed array value explicitly and in place, can be used to change values in an array. But the two approaches differ importantly:
+
+- `array_replace()` changes all values that match the specified value to the same new value, insensitively to their address in the array.
+
+- Setting an addressed array value changes that one value insensitively to its present value.
+
+## array_replace()
+
+**Purpose:** Return a new array that is derived from the input array by replacing _every_ array value that is equal to the specified existing value with the specified new value.
+
+**Signature** 
+
+```
+input value:       anyarray, anyelement, anyelement
+return value:      anyarray
+```
+**Example:**
+
+```postgresql
+create type rt as (f1 int, f2 text);
+create table t(k int primary key, arr rt[]);
+insert into t(k, arr)
+values (1, '{"(1,rabbit)","(2,hare)","(3,squirrel)","(4,horse)"}'::rt[]);
+
+select arr as "old value of arr" from t where k = 1;
+
+update t
+set arr = array_replace(arr, '(3,squirrel)', '(3,bobcat)')
+where k = 1;
+
+select arr as "new value of arr" from t where k = 1;
+```
+This is the result of the two queries:
+```
+                   old value of arr                   
+------------------------------------------------------
+ {"(1,rabbit)","(2,hare)","(3,squirrel)","(4,horse)"}
+
+                  new value of arr                  
+----------------------------------------------------
+ {"(1,rabbit)","(2,hare)","(3,bobcat)","(4,horse)"}
+```
+The example suffers from the problem that [GitHub Issue #4296](https://github.com/yugabyte/yugabyte-db/issues/4296) tracks. (This same issue also affects the concatenation operator and the `array_remove()` function.) If you run this example as presented, then the `UPDATE` statement causes a timeout error of a severity that means that, to continue, you must restart the crashed tserver..
+
+This section will be updated when the issue is fixed. You can sidestep the problem, for demonstration purposes, simply by creating `table t` without a primary key constraint. But this violates proper practice. Here is a viable workaround. Simply use this `UPDATE` statement instead of the one shown above:
+
+```postgresql
+with v as (
+  select array_replace(arr, '(3,squirrel)', '(3,bobcat)')
+  as new_arr from t where k = 1)
+update t
+set arr = (select new_arr from v)
+where k = 1;
+```
+
+**Semantics:**
+
+_One-dimensional array of primitive scalar values_.
+
+```postgresql
+do $body$
+declare
+  old_val constant int := 42;
+  new_val constant int := 17;
+
+  arr constant int[] :=
+    array[1, old_val, 3, 4, 5, old_val, 6, 7];
+
+  expected_modified_arr constant int[] :=
+    array[1, new_val, 3, 4, 5, new_val, 6, 7];
+begin
+  assert
+    array_replace(arr, old_val, new_val) = expected_modified_arr,
+  'unexpected';
+end;
+$body$;
+```
+
+_One-dimensional array of _"row"_ type values_.
+
+The definition of `rt` used here is the same as the example above used. Don't create again if it already exists.
+
+```postgresql
+create type rt as (f1 int, f2 text);
+
+do $body$
+declare
+  old_val constant rt := (42, 'x');
+  new_val constant rt := (17, 'y');
+
+  arr constant rt[] :=
+    array[(1, 'a')::rt, old_val, (1, 'a')::rt, (2, 'b')::rt, (3, 'c')::rt, 
+                        old_val, (4, 'd')::rt, (5, 'e')::rt];
+
+  expected_modified_arr constant rt[] :=
+    array[(1, 'a')::rt, new_val, (1, 'a')::rt, (2, 'b')::rt, (3, 'c')::rt, 
+                        new_val, (4, 'd')::rt, (5, 'e')::rt];
+begin
+  assert
+    array_replace(arr, old_val, new_val) = expected_modified_arr,
+  'unexpected';
+end;
+$body$;
+```
+
+_Two-dimensional array of primitive scalar values_. This is sufficient to illustrate the semantics of the general multidimensional case. The function's signature (at the start of this section) shows that the to-be-replaced value and the replacement value are instances of `anyelement`. There is no overload where these two parameters accept instances of `anyarray`. This restriction is easily understood by picturing the internal representation as a linear ribbon of values, as was explained in the [Synopsis](../../#synopsis) section. The replacement works by scanning along the ribbon, finding each occurrence in turn of the to-be-replaced value, and replacing it.
+
+Here is a postive illustration:
+```postgresql
+do $body$
+declare
+  old_val constant int := 22;
+  new_val constant int := 97;
+
+  arr int[] :=
+    array[
+       array[11, 12],
+       array[11, old_val],
+       array[32, 33]
+    ];
+
+  expected_modified_arr constant int[] :=
+    array[
+       array[11, 12],
+       array[11, new_val],
+       array[32, 33]
+    ];
+begin
+  arr := array_replace(arr, old_val, new_val);
+
+  assert
+    arr = expected_modified_arr,
+  'unexpected';
+end;
+$body$;
+```
+And here is a negative illustration:
+```postgresql
+do $body$
+declare
+  old_val constant int[] := array[22, 23];
+  new_val constant int[] := array[87, 97];
+
+  arr int[] :=
+    array[
+       array[11, 12],
+       old_val,
+       array[32, 33]
+    ];
+  expected_modified_arr constant int[] :=
+    array[
+       array[11, 12],
+       new_val,
+       array[32, 33]
+    ];
+begin
+  begin
+    -- Causes: 42883: function array_replace(integer[], integer[], integer[]) does not exist.
+    arr := array_replace(arr, old_val, new_val);
+  exception
+    when undefined_function then null;
+  end;
+
+  -- The goal is met by replacing the scalar values one by one.
+  arr := array_replace(arr, old_val[1], new_val[1]);
+  arr := array_replace(arr, old_val[2], new_val[2]);
+
+  assert
+    arr = expected_modified_arr,
+  'unexpected';
+end;
+$body$;
+```
+
+## Setting an array value explicitly and in place
+
+**Purpose:** Change an array in place by changing an explicitly addressed value.
+
+**Signature** 
+
+```
+-- Uses the notation
+--   arr[idx_1][idx_2]...[idx_N]
+-- for an N-dimensional array.
+
+input/output value: anyarray, "vector of index values"
+```
+**Example:**
+```postgresql
+create table t(k int primary key, arr int[]);
+
+insert into t(k, arr) values (1,
+  '{1, 2, 3, 4}');
+
+update t set arr[2] = 42 where k = 1;
+
+select arr from t where k = 1;
+```
+This is the result:
+```
+    arr     
+------------
+ {1,42,3,4}
+```
+**Semantics:**
+
+_Array of primitive scalar values_. Notice that the starting value is "snapshotted" as `old_arr` and that this is marked `constant`. Notice too that `expected_modified_arr` is marked `constant`. This proves that the modification was done in place within the only array value that is _not_ marked `constant`.
+
+```postgresql
+do $body$
+declare
+  old_val constant int := 42;
+  new_val constant int := 17;
+
+  arr int[] :=                            array[1, 2, old_val, 4];
+  expected_modified_arr constant int[] := array[1, 2, new_val, 4];
+  old_arr constant int[] := arr;
+begin
+  arr[3] := new_val;
+  assert
+    old_arr =               '{1, 2, 42, 4}' and
+    expected_modified_arr = '{1, 2, 17, 4}' and
+    arr = expected_modified_arr,
+  'unexpected';
+end;
+$body$;
+```
+_Array of "record" type values_.
+
+The definition of `rt` used here is the same as the example above used. Don't create again if it already exists.
+```postgresql
+create type rt as (f1 int, f2 text);
+
+do $body$
+declare
+  old_val constant rt := (42, 'x');
+  new_val constant rt := (17, 'y');
+
+  arr rt[] :=
+    array[(1, 'a')::rt, old_val, (1, 'a')::rt, (2, 'b')::rt, (3, 'c')::rt, 
+                        old_val, (4, 'd')::rt, (5, 'e')::rt];
+
+  expected_modified_arr constant rt[] :=
+    array[(1, 'a')::rt, new_val, (1, 'a')::rt, (2, 'b')::rt, (3, 'c')::rt, 
+                        new_val, (4, 'd')::rt, (5, 'e')::rt];
+
+  old_arr constant rt[] := arr;
+begin
+  arr[2] := new_val;
+  arr[6] := new_val;
+
+  assert
+    old_arr =
+      '{"(1,a)","(42,x)","(1,a)","(2,b)","(3,c)","(42,x)","(4,d)","(5,e)"}' and
+    expected_modified_arr =
+      '{"(1,a)","(17,y)","(1,a)","(2,b)","(3,c)","(17,y)","(4,d)","(5,e)"}' and
+    arr = expected_modified_arr,
+  'unexpected';
+end;
+$body$;
+```
+_Two-dimensional array of primitive scalar values_. This is sufficient to illustrate the semantics of the general multidimensional case. The approach is just the same as when `array_replace()` is used to meet the same goal. You have no choice but to target the values explicitly.
+
+```postgresql
+do $body$
+declare
+  old_val constant int[] := array[21, 22, 23, 24];
+  new_val constant int[] := array[81, 82, 83, 84];
+
+  arr int[] :=
+    array[
+       array[11, 12, 13, 14],
+       old_val,
+       array[31, 32, 33, 34]
+    ];
+
+  expected_modified_arr constant int[] :=
+    array[
+       array[11, 12, 13, 14],
+       new_val,
+       array[31, 32, 33, 34]
+    ];
+
+  len_1 constant int := array_length(arr, 1);
+  len_2 constant int := array_length(arr, 2);
+begin
+  assert
+    (len_1 = 3) and (len_2 = 4),
+  'unexpected';
+  
+  -- OK to extract a slice. But, even though it's tempting to picture this as one row,
+  -- it is nevertheless a 2-d array with "array_length(arr, 1)" equal to 1.
+  assert
+    arr[2:2][1:4] = array[old_val],
+  'unexpected';
+
+  -- You cannot use the slice notation to specify the target of an assignment.
+  -- So this 
+  --   arr[2:2][1:4] = array[new_val];
+  -- causes a compilation error.
+
+  -- Similarly, this is meaningless. (But it doesn't cause a compilation error.)
+  -- Because it's a 2-d array, its values (individual values or slices) must be
+  -- addressed using two indexes or two slice ranges.
+  assert
+    arr[2] is null,
+  'unexpected';
+
+  -- Change the individual, addressable, values one by one.
+  for j in array_lower(arr, 2)..array_upper(arr, 2) loop
+    arr[2][j] := new_val[j];
+  end loop; 
+
+  assert
+    arr = expected_modified_arr,
+  'unexpected';
+end;
+$body$;
+```

--- a/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/slice-operator.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/slice-operator.md
@@ -1,0 +1,99 @@
+---
+title: The array slice operator
+linkTitle: Array slice operator 
+headerTitle: The array slice operator
+description: The array slice operator
+menu:
+  latest:
+    identifier: array-slice-operator
+    parent: array-functions-operators
+isTocNested: false
+showAsideToc: false
+---
+
+**Purpose:** Return a new array whose length is defined by specifying the slice's lower and upper bound along each dimension.
+
+**Signature:**
+```
+input value:       [lb-1:ub-1] ... [lb-N:ub-N]anyarray
+return value:      anyarray
+```
+**Note:**
+- You must specify the lower and upper slicing bounds, as `int` values for each of the input array's N dimensions.
+- The specified slicing bounds must not exceed the source array's bounds.
+- The new array has the same dimensionality as the source array and its lower bound is `1` on each axis.
+
+**Example:**
+```postgresql
+create table t(k int primary key, arr text[]);
+
+insert into t(k, arr)
+values (1, '
+  [2:4][3:6][4:5]=
+  {
+    {
+      {a,b}, {c,d}, {e,f}, {g,h}
+    },
+    {
+      {i,j}, {k,l}, {m,n}, {o,p}
+    },
+    {
+      {q,r}, {s,t}, {u,v}, {w,x}
+    }
+  }
+  '::text[]);
+
+select arr as "old value of arr" from t where k = 1;
+
+select
+  array_lower(arr, 1) as "lb-1",
+  array_upper(arr, 1) as "ub-1",
+  array_lower(arr, 2) as "lb-2",
+  array_upper(arr, 2) as "ub-2",
+  array_lower(arr, 3) as "lb-3",
+  array_upper(arr, 3) as "ub-3"
+from t where k = 1;
+```
+It produces these results:
+```
+                                        old value of arr                                         
+-------------------------------------------------------------------------------------------------
+ [2:4][3:6][4:5]={{{a,b},{c,d},{e,f},{g,h}},{{i,j},{k,l},{m,n},{o,p}},{{q,r},{s,t},{u,v},{w,x}}}
+```
+and:
+```
+ lb-1 | ub-1 | lb-2 | ub-2 | lb-3 | ub-3 
+------+------+------+------+------+------
+    2 |    4 |    3 |    6 |    4 |    5
+```
+Now do the slicing:
+```postgresql
+update t
+set arr = arr[2:3][4:5][3:4]
+where k = 1;
+
+select arr as "new value of arr" from t where k = 1;
+
+select
+  array_lower(arr, 1) as "lb-1",
+  array_upper(arr, 1) as "ub-1",
+  array_lower(arr, 2) as "lb-2",
+  array_upper(arr, 2) as "ub-2",
+  array_lower(arr, 3) as "lb-3",
+  array_upper(arr, 3) as "ub-3"
+from t where k = 1;
+```
+It produces these results:
+```
+   new value of arr    
+-----------------------
+ {{{c},{e}},{{k},{m}}}
+```
+and:
+```
+ lb-1 | ub-1 | lb-2 | ub-2 | lb-3 | ub-3 
+------+------+------+------+------+------
+    1 |    2 |    1 |    2 |    1 |    1
+```
+
+Notice, that as promised, all the lower bounds are equal to `1`.

--- a/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/string-to-array.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/string-to-array.md
@@ -1,0 +1,117 @@
+---
+title: string_to_array()
+linkTitle: string_to_array()
+headerTitle: string_to_array()
+description: string_to_array()
+menu:
+  latest:
+    identifier: string-to-array
+    parent: array-functions-operators
+isTocNested: false
+showAsideToc: false
+---
+**Purpose:** Return a one-dimensional `text[]` array by splitting the input `text` value into subvalues using the specified `text` value as the delimiter. Optionally, allows a specified `text` value to be interpreted as `null`.
+
+**Signature:** 
+
+```
+input value:       text, text [, text]
+return value:      text[]
+```
+**Example:**
+
+```postgresql
+select string_to_array(
+  'a|b|?|c', -- the to-be-split string
+  '|',       -- the character(s) to be taken as the delimiter
+  '?'        -- the character(s) to be taken to denote NULL
+) as "string_to_array result";
+```
+
+It produces thus result:
+
+```
+ string_to_array result 
+------------------------
+ {a,b,NULL,c}
+```
+
+**Semantics:**
+
+The interpretation of the delimiter `text` value and the null indicator `text` uses this priority rule:
+
+- _First_, the delimiter `text` value is consumed
+
+- _and only then_ is the null indicator `text` value consumed.
+
+However, this rule matters only when these two critical values are defined by more than one character and when one starts with a sequence that the other ends with.
+
+Yugabyte recommends, therefore, that when you can choose the `text` values for the delimiter and for the null indicator, you simply choose two different single characters. This is what the simple example, above, does. Of course, you must be sure that neither occurs in any of the `text` values that you want to convert into `text[]` arrays. (There is no escaping mechanism.)
+
+Predicting the outcome, when unfortunate choices for these two values were made, will require some mental effort. The `DO` block below demonstrates an example of this:
+
+- The delimiter is `' !'::text`.
+
+- The null indicator is `'~ '::text`.
+
+And the input contains this sequence:
+
+&#160;&#160;&#160; &#60;tilda&#62;&#60;space&#62;&#60;exclamationPoint&#62;
+
+The troublesome sequence is shown in typewriter font here:
+
+&#160;&#160;&#160; dog house !~  !x! `~ !` cat flap !  !
+
+These considerations, together with the fact that it can produce only a `text[]` output, mean that the `string_to_array()` function has limited usefulness.
+
+```postgresql
+do $body$
+declare
+  delim_text  constant text := ' !';
+  null_text   constant text := '~ ';
+
+  input_text  constant text := 'dog house !~  !x! ~ ! cat flap !  !';
+
+  result constant text[] :=
+    string_to_array(input_text, delim_text, null_text);
+
+  good_delim_text constant text := '|';
+  good_null_text  constant text := '?';
+
+  delim_first_text constant text :=
+    replace(replace(
+      input_text,
+      delim_text, good_delim_text),
+      null_text,  good_null_text);
+
+  null_first_text constant text := 
+    replace(replace(
+      input_text,
+      null_text,  good_null_text),
+      delim_text, good_delim_text);
+
+  delim_first_result constant text[] :=
+    string_to_array(delim_first_text, good_delim_text, good_null_text);
+
+  null_first_result constant text[] :=
+    string_to_array(null_first_text, good_delim_text, good_null_text);
+
+  -- Notice that one of the special characters, "!", remains in
+  -- both expected_result and unexpected_result.
+  -- If 
+  expected_result constant text[] :=
+    '{"dog house",NULL,"x! ~"," cat flap"," ",""}';
+  unexpected_result constant text[] :=
+    '{"dog house",NULL,"x! ?! cat flap"," ",""}';
+
+begin
+  assert
+  (result             =  expected_result)    and
+  (delim_first_result =  expected_result)    and
+  (null_first_result  <> delim_first_result) and
+  (null_first_result  =  unexpected_result)  and
+    true,
+  'unexpected';
+end;
+$body$;
+```

--- a/docs/content/latest/api/ysql/datatypes/type_array/literals/_index.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/literals/_index.md
@@ -1,0 +1,90 @@
+---
+title: Creating an array value using a literal
+linkTitle: Literals
+headerTitle: Creating an array value using a literal
+description: Creating an array value using a literal
+image: /images/section_icons/api/ysql.png
+menu:
+  latest:
+    identifier: array-literals
+    parent: api-ysql-datatypes-array
+    weight: 20
+isTocNested: false
+showAsideToc: false
+---
+
+This section introduces array literals informally with a few examples. Its subsections, listed below, explain formally how you construct syntactically correct array literals that establish the values that you intend.
+
+An array literal starts with a left curly brace. This is followed by some number of comma-separated literal representations for the array's values. Sometimes, the value representations need not be double-quoted—but _may_ be. And sometimes the value representations must be double-quoted. The array literal then ends with a right curly brace. Depending on the array's data type, its values might be scalar, or they might be composite. For example, they might be _"row"_ type values; or they might be arrays. The literal for a multidimensional array is written as an array of arrays of arrays... and so on. They might even be values of a user-defined `DOMAIN` which is based on an array data type. This somewhat exotic, but potentially very useful, notion is discussed in the dedicated [Using an array of `DOMAIN`s](../array-of-domains/) section.
+
+To use such a literal in SQL or in PL/pgSQL it must be enquoted in the same way as is an ordinary `text` literal. You can enquote an array literal using dollar quotes, if this suits your purpose, just as you can for a `text` literal. You sometimes need to follow the closing quote with a suitable typecast operator for the array data type that you intend. And sometimes the context of use uniquely determines the literal's data type. It's never wrong to write the typecast explicitly—and it's a good practice always to do this.
+
+Here, in use in a SQL `SELECT` statement, is the literal for a one-dimensional array of primitive `int` values:
+```postgresql
+\t on
+select '{1, 2, 3}'::int[];
+```
+The `\t on` metacommand suppresses column headers and the rule-off under these. Unless the headers are important for understanding, query output from `ysqlsh` will be shown, throughout the present "arrays" major section, without these.
+
+This is the output that the first example produces:
+
+```
+ {1,2,3}
+```
+The second example surrounds the values that the array literal defines with double quotes:
+```postgresql
+select '{"1", "2", "3"}'::int[];
+```
+It produces the identical output to the first example, where no double quotes were used.
+
+The third example defines a two-dimensional array of `int` values:
+
+```postgresql
+select '
+   {
+      {11, 12, 13},
+      {21, 22, 23}
+    }
+  '::int[];
+```
+
+It produces this result:
+
+```
+ {{11,12,13},{21,22,23}}
+```
+
+The fourth example defines an array whose values are instances of a _"row"_ type:
+
+```postgresql
+create type rt as (a int, b text);
+
+select '
+  {
+    "(1,a1 a2)",
+    "(2,b1 b2)",
+    "(3,c1 v2)"
+  }
+'::rt[];
+```
+It produces this output:
+```
+ {"(1,\"a1 a2\")","(2,\"b1 b2\")","(3,\"c1 v2\")"}
+```
+All whitespace (except, of course, within the text values) has been removed. The double quotes around the representation of each _"row"_ type value are retained. This suggests that they are significant. (Test this by removing them. It causes the _"22P02: malformed row literal"_ error.) Most noticeably, there are clearly rules at work in connection with the representation of each `text` value within the representation of each _"row"_ type value.
+
+The following sections present the rules carefully and, when the rules allow some freedom, give recommendations.
+
+[The text typecast of a value, the literal for that value, and how they are related](./text-typecasting-and-literals/) establishes the important notions that allow you to distinguish between a _literal_ and the _text of the literal_. It's the _text_ of an array literal that, by following specific grammar rules for this class of literal, actually defines the intended value. The literal, as a whole, enquotes this bare text and typecasts it to the desired target array data type.
+
+[The literal for an array of primitive values](./array-of-primitive-values/) gives the rules for array literals whose values are scalars (for example, are of primitive data types).
+
+[The literal for a _"row"_ type value](./row/) gives the rules for the literal for a value of a _"row"_ type. These rules are essential to the understanding of the next section.
+
+[The literal for an array of _"row"_ type values](./array-of-rows/) gives the rules for array literals whose values are composite (that is, a _"row"_ type).
+
+These rules are covered in the following sections of the PostgreSQL documentation:
+
+- [8.15. Arrays](https://www.postgresql.org/docs/11/arrays.html)
+
+- [8.16. Composite Types](https://www.postgresql.org/docs/11/rowtypes.html)

--- a/docs/content/latest/api/ysql/datatypes/type_array/literals/array-of-primitive-values.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/literals/array-of-primitive-values.md
@@ -1,0 +1,385 @@
+---
+title: The literal for an array of primitive values
+linkTitle: Array of primitive values
+headerTitle: The literal for an array of primitive values
+description: The literal for an array of primitive values
+menu:
+  latest:
+    identifier: array-of-primitive-values
+    parent: array-literals
+    weight: 10
+isTocNested: false
+showAsideToc: false
+---
+
+This section states a sufficient subset of the rules that allow you to write a syntactically correct array literal that expresses any set of values, for arrays of any scalar data type, that you could want to create. The full set of rules allows more flexibility than do just those that are stated here. But because these are sufficient, the full, and rather complex, set is not documented here. The explanations in this section will certainly allow you to interpret the `::text` typecast of any array value that you might see, for example in `ysqlsh`.
+
+Then Yugabyte's recommendation in this space is stated. And then the rules are illustrate with examples.
+
+## Statement of the rules
+
+The statement of these rules depends on understanding the notion of the canonical form of a literal. The [Defining the "canonical form of a literal](../text-typecasting-and-literals/#defining-the-canonical-form-of-a-literal) section explained that the `::text` typecast of any kind of array shows you that this form of the literal (more carefully stated, the _text_ of this literal) can be used to recreate the value.
+
+In fact, this definition, and the property that the canonical form of the literal is sufficient to recreate the value, hold for values of _all_ data types.
+
+Recall that every value within an array necessarily has the same data type. If you follow the rules that are stated here, and illustrated in the demonstrations below, you will always produce a syntactically valid literal which expresses the semantics that you intend. It turns out that very many other variants, especially for `text[]` arrays, are legal and can produce the values that you intend. However, the rules that govern these exotic uses will not documented because it is always sufficient to create your literals in canonical form.
+
+Here is the sufficient set of rules.
+
+- The commas that delimit successive values, the curly braces that enclose the entire literal, and the inner curly braces that are used in the literals for multidimensional arrays, can be surrounded by arbitrary amounts of whitespace. If you want strictly to adhere to canonical form, then you ought not to do this. But doing so can improve the readability of _ad hoc_ manually typed literals. It can also make it easier to read trace output in a program that constructs array literals programmatically.
+- In numeric and `boolean` array literals, do _not_ surround the individual values with double quotes.
+- In the literal for a `timestamp[]` array, _do_ surround the individual values with double quotes—even though this is not strictly necessary.
+- In the literal for a `text[]` array, _do_ surround every individual value with double quotes, even though this is not always necessary. It _is_ necessary for any value that itself contains, as ordinary text, any whitespace or any of the characters that have syntactic significance within the outermost curly brace pair. This is the list:
+```
+   <space>   {   }   ,   "   \
+```
+- It's sufficient simply to write the curly braces and the comma ordinarily within the enclosing double quotes. But each of the double quote character and the backslash character must be escaped with an immediately preceding single backslash.
+
+
+## Always write array literals in canonical form
+
+Bear in mind that you will very rarely manually type literals in the way that this section does to demonstrate the rules. You'll do this only when teaching yourself, when prototyping new code, or when debugging. Rather, you'll typically create the literals programmatically—often in a client-side program that parses out the data values from, for example, an XML text file or, these days, probably a JSON text file. In these scenarios, the target array is likely to have the data type `some_user_defined_row_type[]`. And when you create literals programmatically, you want to use the simplest rules that work and you have no need at all to omit arguably unnecessary double quote characters.
+
+**Yugabyte recommends that the array literals that you generate programmatically are always spelled using the canonical representations**
+
+You can relax this recommendation, to make tracing or debugging your code easier (as mentioned above), by using a newline between each successive encoded value in the array—at least when the values themselves use a lot of characters, as they might for _"row"_ type values.
+
+**Note:** You can hope that the client side programming language that you use, together with the driver that you use to issue SQL to YugabyteDB and to retrieve results, will allow the direct use of data types that your language defines that map directly to YSQL's array and _"row"_ type, just as they have scalar data types that map to `int`, `text`, `timestamp`, and `boolean`. For example Python has _"list"_ that maps to array and _"tuple"_ that maps to _"row"_ type. And the _"psycopg2"_ driver that you use for YugabyteDB can map values of these data types to, for example, a `prepare` statement like the one shown below.
+
+**Note**: YSQL has support for converting a JSON array (and this includes a JSON array of JSON objects) directly into the corresponding YSQL array values.
+
+The rules for constructing literals for arrays of _"row"_ type values are described in the [literal for an array of "row" type values](../array-of-rows/) dedicated section.
+
+Your program will parse the input and create the required literals as ordinary text strings that you'll then provide as the actual argument to a `prepare` statement execution, leaving the typecast of the `text` actual argument, to the appropriate array data type, to the prepared `INSERT` or `UPDATE` statement like this:
+```
+prepare stmt(text) as insert into t(rs) values($1::rt[]);
+```
+Assume that in, this example, `rt` is some particular user-define _"row"_ type.
+## Examples to illustrate the rules
+
+Here are some examples of kinds array of primitive values:
+
+- array of numeric values (like `int` and `numeric`)
+- array of stringy values (like `text`, `varchar`, and `char`)
+- array of date-time values (like `timestamp`)
+- array of `boolean` values.
+
+In order to illustrate the rules that govern the construction of an array literal, it is sufficient to consider only these.
+
+You'll use the `array[]` constructor to create representative values of each kind and inspect its `::text` typecast.
+
+### One-dimensional array of `int` values
+
+This example demonstrates the principle:
+
+```postgresql
+create table t(k serial primary key, v1 int[], v2 int[]);
+insert into t(v1) values (array[1, 2, 3]);
+select v1::text as text_typecast from t where k = 1
+\gset result_
+\echo :result_text_typecast
+```
+The `\gset` metacommand was used first in this _"Array data types and functionality"_ major section in the section [`array_agg()` and `unnest()`](../../functions-operators/array-agg-unnest). 
+
+Notice that, in this example, the `SELECT` statement is terminated by the `\gset` metacommand on the next line rather than by the usual semicolon. The `\gset` metacommand is silent. The `\echo` metacommand shows this:
+
+```
+{1,2,3}
+```
+You can see the general form already:
+
+- The (_text_ of) an array literal starts with the left curly brace and ends with the right curly brace.
+
+- The items within the braces are delimited by commas, and there is no space between one item, the comma, and the next item. Nor is there any space between the left curly brace and the first item or between the last item and the right curly brace.
+
+The [One-dimensional array of `text` values](./#one-dimensional-array-of-text-values) section shows that more needs to be said. But the two rules that you've already noticed always hold.
+
+To use the literal that you produced to create a value, you must enquote it and typecast it. Do this with the `\set` metacommand:
+
+```postgresql
+\set canonical_literal '\'':result_text_typecast'\'::int[]'
+\echo :canonical_literal
+```
+. The `\echo` metacommand now shows this:
+```
+'{1,2,3}'::int[]
+```
+Next, use the canonical literal that was have produced to update `t.v2` to confirm that the value that the row constructor created was recreated:
+```postgresql
+update t set v2 = :canonical_literal where k = 1;
+select (v1 = v2)::text as "v1 = v2" from t where k = 1;
+```
+It shows this:
+```
+ v1 = v2 
+---------
+ true
+```
+As promised, the canonical form of the array literal does indeed recreate the identical value that the `array[]` constructor created.
+
+**Note:**
+
+Try this:
+```postgresql
+select 12512454.872::text;
+```
+The result is the canonical form, `12512454.872`. So this (though you rarely see it):
+```postgresql
+select 12512454.872::numeric;
+```
+runs without error. Now try this:
+
+```postgresql
+select to_number('12,512,454.872', '999G999G999D999999')::text;
+```
+This, too, runs without error because it uses the `to_number()` built-in function. The result here, too, is the canonical form, `12512454.872`—with no commas. Now try this:
+
+```postgresql
+select '12,512,454.872'::numeric;
+```
+This causes the _"22P02: invalid input syntax for type numeric"_ error. In other words, _only_ a `numeric` value in canonical form can be directly typecast using `::numeric`.
+
+Here, using an array literal, is an informal first look at what follows. For now, take its syntax to mean what you'd intuitively expect. You must spell the representations for the values in a `numeric[]` array in canonical form. Try this:
+
+```postgresql
+select ('{123.456, -456.789}'::numeric[])::text;
+```
+It shows this:
+
+```
+ {123.456,-456.789}
+```
+
+Now try this:
+```postgresql
+select ('{9,123.456, -8,456.789}'::numeric[])::text;
+```
+It silently produces this presumably unintended result (an array of _four_ numeric values) because the commas are taken as delimiters and not as part of the representation of a single `numeric` value:
+```
+ {9,123.456,-8,456.789}
+```
+In an array literal (or in a _"row"_ type value literal), there is simply no way to accommodate forms that cannot be directly typecast. (The same holds for `timestamp` values as for `numeric` values.) YSQL inherits this limitation from PostgreSQL. It is the user's responsibility to work around this when preparing the literal because, of course, functions like _"to_number()"_ cannot be used within literals. Functions can, however, be used in a value constructor as the [`array[]` value constructor](../../array-constructor/) section shows.
+
+### One-dimensional array of `text` values
+
+Use the [One-dimensional array of `int` values](./#one-dimensional-array-of-int-values) example as a template for this and the subsequent sections. The example sets array values each of which, apart from the single character `a`, needs some discussion. These are the characters (or, in one case, character sequence), listed here "bare" and with ten spaces between each:
+
+```
+     a          a b          ()          ,          '          "          \
+```
+
+```postgresql
+create table t(k serial primary key, v1 text[], v2 text[]);
+insert into t(v1) values (array['a', 'a b', '()', ',', '{}', $$'$$, '"', '\']);
+select v1::text as text_typecast from t where k = 1
+\gset result_
+\echo :result_text_typecast
+```
+For ordinary reasons, something special is needed to establish the single quote within the surrounding array literal which itself must be enquoted for using in SQL. Dollar quotes are a convenient choice. The `\echo` metacommand shows this:
+
+```
+{a,"a b",(),",","{}",',"\"","\\"}
+```
+This is rather hard (for the human) to parse. To make the rules easier to see, this list doesn't show the left and right curly braces. And the syntactically significant commas are surrounded with four spaces on each side:
+```
+     a    ,    "a b"    ,    ()    ,    ","    ,    "{}"    '    ,    "\""    ,    "\\"
+```
+In addition to the first two rules, notice the following.
+
+- Double quotes are used to surround a value that includes any spaces. (Though the example doesn't show it, this applies to leading and trailing spaces too.)
+- The left and right parentheses are _not_ surrounded with double quotes. Though these have syntactic significance in other parsing contexts, they are insignificant within the curly braces of an array literal.
+- The comma _has_ been surrounded by double quotes. This is because it _does_ have syntactic significance, as the value delimiter, within the curly braces of an array literal.
+- The curly braces _have_ been surrounded by double quotes. This is because interior curly braces _do_ have syntactic significance, as you'll see below, in the array literal for a multidimensional array.
+- The single quote is _not_ surrounded with double quotes. Though it has syntactic significance in other parsing contexts, it is insignificant within the curly braces of an array literal. This holds, also, for all sorts of other punctuation characters like `;` and `:` and `[` and `]` and so on.
+- The double quote has been escaped with a single backslash and this has been then surrounded with double quotes. This is because it _does_ have syntactic significance, as the (one and only) quoting mechanism, within the curly braces of an array literal.
+- The backslash has also been escaped with another single backslash and this has been then surrounded with double quotes. This is because it _does_ have syntactic significance, as the escape character, within the curly braces of an array literal.
+
+There's another rule that the present example does not show. Though not every comma-separated value was surrounded by double quotes, it's _never harmful_ to do this. You can confirm this easily with your own test, Yugabyte recommends that, for consistency, you always surround every `text` value within the curly braces for a `text[]` array literal with double quotes.
+
+To use the text of the literal that was produced above to recreate the value, you must enquote it and typecast it. Do this, as you did for the `int[]` example above, with the `\set` metacommand. But you must use dollar quotes because the literal itself has an interior single quote.
+
+```postgresql
+\set canonical_literal '$$':result_text_typecast'$$'::text[]
+\echo :canonical_literal
+```
+The `\echo` metacommand now shows this:
+```
+$${a,"a b",(),",",',"\"","\\"}$$::text[]
+```
+Next, use the canonical literal to update `t.v2` to confirm that the value that the row constructor created was recreated:
+```postgresql
+update t set v2 = :canonical_literal where k = 1;
+select (v1 = v2)::text as "v1 = v2" from t where k = 1;
+```
+Again, it shows this:
+```
+ v1 = v2 
+---------
+ true
+```
+So, again as promised, the canonical form of the array literal does indeed recreate the identical value that the `array[]` constructor created.
+
+### One-dimensional array of `timestamp` values
+
+This example demonstrates the principle:
+
+```postgresql
+create table t(k serial primary key, v1 timestamp[], v2 timestamp[]);
+insert into t(v1) values (array[
+    '2019-01-27 11:48:33'::timestamp,
+    '2020-03-30 14:19:21'::timestamp
+  ]);
+select v1::text as text_typecast from t where k = 1
+\gset result_
+\echo :result_text_typecast
+```
+The `\echo` metacommand shows this:
+
+```
+{"2019-01-27 11:48:33","2020-03-30 14:19:21"}
+```
+You learn one further rule from this:
+
+- The `::timestamp` typecastable strings within the curly braces are tightly surrounded with double quotes.
+
+To use the text of the literal that was produced to create a value, you must enquote it and typecast it. Do this with the `\set` metacommand:
+
+```postgresql
+\set canonical_literal '\'':result_text_typecast'\'::timestamp[]'
+\echo :canonical_literal
+```
+. The `\echo` metacommand now shows this:
+```
+'{"2019-01-27 11:48:33","2020-03-30 14:19:21"}'::timestamp[]
+```
+Next, use the canonical literal to update `t.v2` to confirm that the value that the row constructor created was recreated:
+```postgresql
+update t set v2 = :canonical_literal where k = 1;
+select (v1 = v2)::text as "v1 = v2" from t where k = 1;
+```
+It shows this:
+```
+ v1 = v2 
+---------
+ true
+```
+Once again, as promised, the canonical form of the array literal does indeed recreate the identical value that the `array[]` constructor created.
+
+### One-dimensional array of `boolean` values (and `null` in general)
+
+This example demonstrates the principle:
+
+```postgresql
+create table t(k serial primary key, v1 boolean[], v2 boolean[]);
+insert into t(v1) values (array[
+    true,
+    false,
+    null
+  ]);
+select v1::text as text_typecast from t where k = 1
+\gset result_
+\echo :result_text_typecast
+```
+The `\echo` metacommand shows this:
+
+```
+{t,f,NULL}
+```
+You learn two further rules from this:
+
+- The canonical representations of `true` and `false` within the curly braces for a `boolean[]` array are `t` and `f`. They are not surrounded by double quotes.
+- To specify `null`, the canonical form uses upper case `NULL` and does not surround this with double quotes.
+
+Though the example doesn't show this, `NULL` is not case-sensitive. But to compose a literal that adheres to canonical form, you ought to spell it using upper case. And this is how you specify `null` within the array literal for _any_ data type. (A different rule applies for fields within the literal for _"row"_ type value).
+
+**Note:** If you surrounded `NULL` within a literal for a `text[]` array, then it would be silently interpreted as an ordinary `text` value that just happens to be spelled that way.
+
+To use the literal that that was produced to create a value, you must enquote it and typecast it. Do this with the `\set` metacommand:
+
+```postgresql
+\set canonical_literal '\'':result_text_typecast'\'::boolean[]'
+\echo :canonical_literal
+```
+. The `\echo` metacommand now shows this:
+```
+'{t,f,NULL}'::boolean[]
+```
+Next use the canonical literal to update `t.v2` to can confirm that the value that the row constructor created has been recreated :
+```postgresql
+update t set v2 = :canonical_literal where k = 1;
+select (v1 = v2)::text as "v1 = v2" from t where k = 1;
+```
+It shows this:
+```
+ v1 = v2 
+---------
+ true
+```
+Yet again, as promised, the canonical form of the array literal does indeed recreate the identical value that the `array[]` constructor created.
+
+### Multidimensional array of `int` values
+
+```postgresql
+create table t(k serial primary key, v int[]);
+
+-- Insert a 1-dimensional int[] value.
+insert into t(v) values('
+    {1,  2}
+  '::int[]);
+
+-- Insert a 2-dimensional int[] value.
+insert into t(v) values('
+    {
+      {1,  2},
+      {3,  4}
+    }
+  '::int[]);
+
+-- Insert a 3-dimensional int[] value.
+insert into t(v) values('
+    {
+      {
+        {1,  2}, {3,  4}
+      },
+      {
+        {5,  6}, {7,  8}
+      }
+    }
+  '::int[]);
+
+-- Insert a 3-dimensional int[] value, specifying
+-- the lower and upper bounds along each dimension.
+insert into t(v) values('
+    [3:4][5:6][7:8]=
+    {
+      {
+        {1,  2}, {3,  4}
+      },
+      {
+        {5,  6}, {7,  8}
+      }
+    }
+  '::int[]);
+
+select k, v::text from t order by k;
+```
+Notice that the three different `INSERT` statements define arrays with different dimensionality, as the comments state. This illustrates what was explained in the [Synopsis](../#synopsis) section: the column `t.v` can hold array values of _any_ dimensionality.
+
+Here is the `SELECT` result:
+
+```
+ 1 | {1,2}
+ 2 | {{1,2},{3,4}}
+ 3 | {{{1,2},{3,4}},{{5,6},{7,8}}}
+ 4 | [3:4][5:6][7:8]={{{1,2},{3,4}},{{5,6},{7,8}}}
+```
+Again, whitespace in the inserted literals for numeric values is insignificant, and the `text` typecasts use whitespace (actually, the lack thereof) conventionally.
+
+Notice the spelling of the array literal for the row with `k = 4`. The optional syntax `[3:4][5:6][7:8]` specifies the lower and upper bounds, respectively, for the first, the second, and the third dimension. This is the same syntax that you use to specify a slice of an existing array. (The [array slice operator](../../functions-operators/slice-operator)) is described in its own section.) When the freedom to specify the bounds is not exercised, then they are assumed all to start at `1`, and then the canonical form of the literal does not show the bounds.
+
+When the freedom is exercised, the bounds for _every_ dimension must be specified. Specifying the bounds gives you, of course, an opportunity for error. If the length along each axis that you (implicitly) specify doesn't agree with the lengths that emerge from the actual values listed between the surrounding outer `{}` pair, then you get the _"22P02 invalid_text_representation"_ error with this prose explanation:
+
+```
+malformed array literal...
+Specified array dimensions do not match array contents.
+```

--- a/docs/content/latest/api/ysql/datatypes/type_array/literals/array-of-rows.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/literals/array-of-rows.md
@@ -1,0 +1,241 @@
+---
+title: The literal for an array of rows
+linkTitle: Array of rows
+headerTitle: The literal for an array of "row" type values
+description: The literal for an array of "row" type values
+menu:
+  latest:
+    identifier: array-of-rows
+    parent: array-literals
+    weight: 40
+isTocNested: false
+showAsideToc: false
+---
+
+You now combine the understanding of how to write the literal for an array of primitive values with that of how to write the literal for a _"row"_ type value.
+
+This section uses the same approach as these sections: [The literal for an array of primitive values](../array-of-primitive-values/) and [The literal for a _"row"_ type value](../row/). First, it states the rules, and then it illustrates these with examples.
+
+## Statement of the rules
+
+Just as in the [Statement of the rules](../array-of-primitive-values/#statement-of-the-rules) section that stated the rules for literals for an array of primitive values, the statement of these rules depends on understanding the notion of the canonical form of a literal.
+
+If you follow the rules that are stated here and illustrated in the demonstration below, then you will always produce a syntactically valid literal which expresses the semantics that you intend. There are many other legal variants—especially because of the freedoms for `text[]` values. This can also produce the result that you intend. However, these rules will not be documented because it is always sufficient to create your literals in canonical form.
+
+The sufficient set of rules can be stated tersely:
+
+- Start off with the opening left curly brace.
+
+- First, prepare the literal for each _"row"_ type value according to the rules set out in the [The literal for a _"row"_ type value](../row/) section.
+
+- Then, understand that when these are used within the literal for _"row"_ type value within the literal for an array, the _"row"_ must itself be surrounded with double quotes, just like is the rule for, say, `timestamp` values or `text` values that include spaces or other troublesome characters.
+
+- Then understand that this implies that any occurrences of double quotes and backslashes within the surrounding parentheses of the _"row"_ type literal must be escaped a second time: _double-quote_ becomes _backslash-double-quote_; and _backslash_ becomes _backslash-backslash_.
+
+- Therefore, to avoid wrongly escaping the double quotes that will surround the parentheses,
+
+  -  *first*, do the inner escaping
+  - and only then, surround the complete representation for the _"row"_ type value with unescaped double quotes.
+
+- Finish off with the closing right curly brace.
+
+These rules are presented in the [Pseudocode for generating the literal for a one-dimensional array of "row" type values](./#pseudocode-for-generating-the-literal-for-a-one-dimensional-array-of-row-type-values) section.
+
+## Example to illustrate the rules
+
+The example uses a _"row"_ type with four fields: an `int` field; a `text` field; a `timestamp` field; and a `boolean` field. This is enough to illustrate all of the rules. These "challenging" characters need particular care:
+```
+     <space>     ,     (     )     "     \
+```
+First, create the _"row"_ type:
+```postgresql
+create type rt as (n int, s text, t timestamp, b boolean);
+```
+Next, you create a table with a column with data type `rt` so that you can populate it with six rows that jointly, in their `text` fields, use all of the "challenging" characters listed above:
+```postgresql
+create table t1(k int primary key, v rt);
+```
+Finally, you populate the table by building the _"row"_ type values bottom-up using appropriately typed PL/pgSQL variables in a `DO` block and inspect the result. This technique allows the actual primitive values that were chosen for this demonstration so be seen individually as the ordinary SQL literals that each data type requires. This makes the code more readable and more understandable than any other approach. In other words, it shows that, for humanly written code, the usability of a value constructor for any composite value is much greater than that of the literal that produces the same value. Of course, this benefit is of no consequence for a programmatically constructed literal.
+```postgresql
+do $body$
+declare
+  n1 constant int := 1;
+  s1 constant text := ' ';
+  t1 constant timestamp := '2091-01-20 12:10:05';
+  b1 constant boolean := true;
+
+  n2 constant int := 2;
+  s2 constant text := ',';
+  t2 constant timestamp := '2002-01-20 12:10:05';
+  b2 constant boolean := false;
+
+  n3 constant int := 3;
+  s3 constant text := '(';
+  t3 constant timestamp := '2003-01-20 12:10:05';
+  b3 constant boolean := null;
+
+  n4 constant int:= 4;
+  s4 constant text := ')';
+  t4 constant timestamp := '2004-01-20 12:10:05';
+  b4 constant boolean := true;
+
+  n5 constant int:= 5;
+  s5 constant text := '"';
+  t5 constant timestamp := '2005-01-20 12:10:05';
+  b5 constant boolean := false;
+
+  n6 constant int:= 6;
+  s6 constant text := '\';
+  t6 constant timestamp := '2006-01-20 12:10:05';
+  b6 constant boolean := null;
+begin
+  insert into t1(k, v) values
+    (1, (n1, s1, t1, b1)),
+    (2, (n2, s2, t2, b2)),
+    (3, (n3, s3, t3, b3)),
+    (4, (n4, s4, t4, b4)),
+    (5, (n5, s5, t5, b5)),
+    (6, (n6, s6, t6, b6));
+end;
+$body$;
+
+select v::text as lit from t1 order by k;
+```
+
+This is the result:
+```
+               lit                
+----------------------------------
+ (1," ","2091-01-20 12:10:05",t)
+ (2,",","2002-01-20 12:10:05",f)
+ (3,"(","2003-01-20 12:10:05",)
+ (4,")","2004-01-20 12:10:05",t)
+ (5,"""","2005-01-20 12:10:05",f)
+ (6,"\\","2006-01-20 12:10:05",)
+```
+
+The `int` field and the `timestamp` field are unremarkable given only that you understand that the representation of the `timestamp` values, in order to meet the canonical form requirement, must be double-quoted. The `boolean` fields are unremarkable, too, as long as you remember that `null` is represented by leaving no space between the delimiters that surround that field. This leaves just the `text` fields for consideration. Here are the field representations themselves, without the clutter of the delimiters:
+```
+     " "     ","     "("     ")"     """"     "\\"
+```
+
+The first four are unremarkable, as long as you remember that each of these four single characters, as shown at the start, must be ordinarily surrounded by double quotes. That leaves just the last two:
+
+- The single double quote occurrence, in the source data, must be doubled up and then surrounded by double quotes.
+- The single backslash occurrence, in the source data, must be doubled up and then surrounded by double quotes.
+
+Next, you concatenate these six _"row"_ type values into an array value by using the `array_agg()` function (described in [`array_agg()`](../../functions-operators/array-agg-unnest/#array-agg)), like this:
+```postgresql
+select array_agg(v order by k) from t1;
+```
+
+The demonstration is best served by inserting this value into a new table, like this:
+```postgresql
+create table t2(k int primary key, v1 rt[], v1_text_typecast text, v2 rt[]);
+insert into t2(k, v1)
+select 1, array_agg(v order by k) from t1;
+```
+
+The `\get` technique that you used in the earlier sections is not viable here because there's an upper limit on its size. So, instead insert the literal that you produce by `text` typecasting `t2.v1` into the companion `v1_text_typecast` field in the same table, like this:
+
+
+```postgresql
+update t2 set v1_text_typecast =
+(select v1::text from t2 where k = 1);
+```
+Finally, use this array literal to recreate the original value and check that it's identical to what you started with, thus:
+```postgresql
+update t2 set v2 = 
+(select v1_text_typecast from t2 where k = 1)::rt[];
+
+select (v1 = v2)::text as "v1 = v2" from t2 where k = 1;
+```
+As promised, the canonical form of the array literal does indeed recreate the identical value that the `array_agg()` function created:
+
+```
+ v1 = v2 
+---------
+ true
+```
+
+You haven't yet looked at the literal for the array of _"row"_ type values. Now is the moment to do so, thus:
+```postgresql
+select v1_text_typecast from t2 where k = 1;
+```
+The result that's produced is too hard to read without some manual introduction of whitespace. But this is allowed around the commas that delimit successive values within an array literal, thus:
+
+```
+{
+  "(1,\"a \",\"2091-01-20 12:10:05\",t)",
+  "(2,\", \",\"2002-01-20 12:10:05\",f)",
+  "(3,\"( \",\"2003-01-20 12:10:05\",)",
+  "(4,\" )\",\"2004-01-20 12:10:05\",t)",
+  "(5,\"\"\"\",\"2005-01-20 12:10:05\",f)",
+  "(6,\"\\\\\",\"2006-01-20 12:10:05\",)"
+}
+```
+
+With some effort, you'll see that this is indeed the properly formed canonical representation for the literal for an array of _"row"_ type values that the rules set out above specify.
+
+## Multidimensional array of _"row"_ type values
+
+You can work out the rules for a multidimensional array of _"row"_ type values, should you need these, by straightforward induction from what has already been explained this enclosing [Create an array value using a literal](../../literals/) section.
+
+## Pseudocode for generating the literal for a one-dimensional array of _"row"_ type values
+
+This pseudocode shows how to create an array literal of _"row"_ type values that have the same shape as `type rt` in the example above. The input is a succession of an arbitrary number of `(n, s, t, b)` tuples. The text below was derived by straightforward manual massage from actual working, and tested, Python code. The code was written simply an an exercise to verify the correctness of the algorithm.
+
+The pseudocode does retain Python locutions, but don't be distracted by this. The meaning is clear enough to allow the algorithm r=to be described. The various special characters were all set up as manifest constants with self-describing names.
+
+Notice that the algorithm inserts a newline after the opening curly brace, between the pairs of representations of each _"row"_ type value, and before the closing curly brace. While, strictly speaking, this means that the literal it produces is not in canonical form, this has no effect (as has been shown many times by example throughout this _"Array data types and functionality"_ major section.
+
+```
+"Start a new array literal":
+  wip_literal = lft_crly_brace + nl
+
+"For each next (n, s, t, b) tuple that defines a "row" type value":
+  curr_rec = dbl_quote + lft_parens
+
+  # Field "n" maps to a SQL numeric
+  if n is None:
+    curr_rec += comma
+  else:
+    curr_rec += (str(n) + comma)
+
+  # Field "s" maps to a SQL text.
+  if s is None:
+    curr_rec += comma
+  else:
+    # First, do the escaping needed for any stringy value
+    # as field in record literal value.
+    s = s.replace(bk_slash, two_bk_slashes)
+    s = s.replace(dbl_quote, two_dbl_quotes)
+    s = dbl_quote + s + dbl_quote
+
+    # Next, do the escaping to fix the bare record representation
+    # for use as a array element.
+    s = s.replace(bk_slash, two_bk_slashes)
+    s = s.replace(dbl_quote, bk_slash_dbl_quote)
+    curr_rec += (s + comma)
+
+    # Field "t" maps to a SQL timestamp.
+    if t is None:
+      curr_rec += comma
+    else:
+      curr_rec += (bk_slash_dbl_quote + t + bk_slash_dbl_quote + comma)
+
+    # Field "b" maps to a SQL boolean.
+    # It's the last field, do nothing if it's neither "t" nor "f"
+    if (b == "t" or b == "f"):
+      curr_rec += b
+
+  # Now there are no more inout tuples.
+  curr_rec = curr_rec + rgt_parens + dbl_quote
+  wip_literal = wip_literal + curr_rec + comma + nl
+
+# Now there are no more input tuples.
+"Finish off":
+  # Remove the final (comma + nl), put the nl back,
+  # and add the closing curly brace.
+  wip_literal = wip_literal[:-2] + nl + rgt_crly_brace
+```

--- a/docs/content/latest/api/ysql/datatypes/type_array/literals/row.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/literals/row.md
@@ -1,0 +1,300 @@
+---
+title: The literal for a row
+linkTitle: Row
+headerTitle: The literal for a "row" type value
+description: The literal for a "row" type value
+menu:
+  latest:
+    identifier: row
+    parent: array-literals
+    weight: 30
+isTocNested: false
+showAsideToc: false
+---
+
+The word "row" has two different uses; but these uses are really different sides of the same coin. A row in a schema-level table is actually an occurrence of a _"row"_ type—in other words, a _"row"_ type value. In this case, the schema-level _"row"_ type is created automatically as a side effect of executing the `CREATE TABLE` statement. It has the same name as the table. (This is allowed because tables and types are in different namespaces.) Further, a column in a schema-level table can have a user-defined _"row"_ type as its data type, and in this case the _"row"_ type need not be partnered with a table.
+
+You might see the term _"record"_ when you use the `\df` metacommand to show the signature of a function. Briefly, it's an anonymous _"row"_ type. You produce a record instance when you use a literal that has the correct form of a _"row"_ type but when you omit the typecast operator. If you adhere to recommended practice, and always explicitly typecast such literals, then you needn't try to understand what a record is.
+
+You can read more about these notions in the PostgreSQL documentation here:
+
+- section [43.3.4. Row Types](https://www.postgresql.org/docs/11/plpgsql-declarations.html#PLPGSQL-DECLARATION-ROWTYPES)
+
+- Section [43.3.5. Record Types](https://www.postgresql.org/docs/11/plpgsql-declarations.html#PLPGSQL-DECLARATION-RECORDS)
+
+You need first to understand how to write a literal for a _"row"_ type value before you can understand, as the [The literal for an array of "row" type values](../array-of-rows/) section explains, how to write the literal for an array of such values.
+
+This section uses the same approach as the [The literal for an array of primitive values](../array-of-primitive-values/) section: first it states the rules; and then it illustrates these with examples.
+
+## Statement of the rules
+
+Just as in the [Statement of the rules](../array-of-primitive-values/#statement-of-the-rules) subsection in the _"The literal for an array of primitive values"_ section, the statement of these rules depends on understanding the notion of the canonical form of a literal.
+
+If you follow the rules that are stated here, and illustrated in the demonstrations below, then you will always produce a syntactically valid literal which expresses the semantics that you intend. It turns out that very many other variants, especially for `text[]` values, are legal and can produce the result that you intend. However, the rules that govern these exotic uses will not be documented because it is always sufficient to create your literals in canonical form.
+
+Here is the sufficient set of rules.
+
+- The commas that delimit successive values, and opening and closing parentheses, must not be surrounded by whitespace.
+- Do _not_ surround the individual representations of numeric and `boolean` primitive values with double quotes.
+- _Do_ surround the individual representations of `timestamp` values with double quotes, even though this is not strictly necessary.
+- _Do_ surround every individual representation of a `text` value with double quotes, even though this is not always necessary. It _is_ necessary for any value that itself contains, as ordinary text, any whitespace or any of the characters that have syntactic significance within the outermost curly brace pair. This is the list:
+
+```
+   <space>   (   )   ,   "   \
+```
+
+- It's sufficient then simply to write all special characters ordinarily within the enclosing double quotes except for each of the double quote character itself and the backslash character. These must be escaped. The double quote character is escaped by doubling it up. And the backslash character is escaped with an immediately preceding single backslash.
+- To specify that the value for a field is `null` , you must leave no whitespace between the pair of delimiters (Left parenthesis, comma, or right parenthesis) that surround its position. (This is the only choice.)
+
+## Always write array literals in canonical form
+
+Exactly the same considerations apply here as were explained in [Always write array literals in canonical form](../array-of-primitive-values/#always-write-array-literals-in-canonical-form) in the section that explained the rules for literals for an array of primitive values.
+
+## Examples to illustrate the rules
+
+It will be sufficient to consider _"row"_ types with fields of just these data types: 
+
+- numeric data types (like `int` and `numeric`)
+- stringy data types (like `text`, `varchar`, and `char`)
+- date-time data types (like `timestamp`)
+- the `boolean` data type.
+
+Use the _"row"_ type constructor to create representative values of each kind and inspect its `::text` typecast.
+
+### _"Row"_ type with `int` fields
+
+This example demonstrates the principle:
+
+```postgresql
+create type row_t as (f1 int, f2 int, f3 int);
+create table t(k serial primary key, v1 row_t, v2 row_t);
+insert into t(v1) values (row(1, 2, 3)::row_t);
+select v1::text as text_typecast from t where k = 1
+\gset result_
+\echo :result_text_typecast
+```
+The keyword `row` names the _"row"_ type constructor function. It is optional, but is used here for emphasis.
+
+The `\gset` metacommand was used first in this _"Array data types and functionality"_ major section in the section [`array_agg()` and `unnest()`](../../functions-operators/array-agg-unnest). 
+
+Notice that, in this example, the `SELECT` statement is terminated by the `\gset` metacommand on the next line rather than by the usual semicolon. The `\gset` metacommand is silent. The `\echo` metacommand shows this:
+
+```
+(1,2,3)
+```
+In this case, the value of the `::text` typecast has the identical form to that of the _"row"_ type constructor. But, as is seen below, this is not generally the case.
+
+You can see the general form already:
+
+- The (_text_ of) a _"row"_ type literal starts with the left parenthesis and ends with the right parenthesis.
+
+- The items within the parentheses are delimited by commas, and there is no space between one item, the comma, and the next item. Nor is there any space between the left parenthesis and the first item or between the last item and the right parenthesis.
+
+The next section, [_"Row"_ type with `text` fields](./#row-type-with-text-fields), shows that more needs to be said. But the two rules that you have already noticed always hold.
+
+To use the text of the literal that was produced to create a value, you must enquote it and typecast it. Do this with the `\set` metacommand:
+```postgresql
+\set canonical_literal '\'':result_text_typecast'\''::row_t
+\echo :canonical_literal
+```
+. The `\echo` metacommand now shows this:
+```
+'(1,2,3)'::row_t
+```
+Next, use the canonical literal that you produced to update `t.v2` to confirm that the value that the row constructor created was recreated:
+```postgresql
+update t set v2 = :canonical_literal where k = 1;
+select (v1 = v2)::text as "v1 = v2" from t where k = 1;
+```
+It shows this:
+```
+ v1 = v2 
+---------
+ true
+```
+As promised, the canonical form of the _"row"_ type literal does indeed recreate the identical value that the _"row"_ type constructor created.
+
+### _"Row"_ type with `text` fields
+
+Use the [_"Row"_ type with `int` fields](./#row-type-with-text-fields) example as a template for this and the subsequent sections. The example sets array values each of which, apart from the single character `a`, needs some discussion. These are the characters (or, in one case, character sequence), listed here "bare" and with ten spaces between each:
+```
+     a       '       a b       ()       ,       "       \       null
+```
+
+```postgresql
+create type row_t as (f1 text, f2 text, f3 text, f4 text, f5 text, f6 text, f7 text, f8 text);
+create table t(k serial primary key, v1 row_t, v2 row_t);
+insert into t(v1) values (
+  ('a', $$'$$, 'a b', '()', ',', '"', '\', null)::row_t);
+
+select v1::text as text_typecast from t where k = 1
+\gset result_
+\echo :result_text_typecast
+```
+Here, the `row` keyword in the _"row"_ type constructor function is omitted to emphasize its optional status.
+
+The `\echo` metacommand shows this:
+```
+(a,',"a b","()",",","""","\\",)
+```
+This is rather hard (for the human) to parse. To make the rules easier to see, the syntactically significant commas are surrounded with three spaces on each side:
+```
+(   a   ,   '   ,   "a b"   ,   "()"   ,   ","   ,   """"   ,   "\\"   ,   )
+```
+**Note:** The introduction of spaces here, to help readability, is done _only_ for that purpose. Unlike is the case for an array literal, doing this actually affects the value that the literal produces. You will demonstrate this at the end of this section.
+
+In addition to the first two rules, you notice the following.
+
+- Double quotes are used to surround a value that includes any spaces. (Though the example doesn't show it, this applies to leading and trailing spaces too.)
+- The comma _has_ been surrounded by double quotes. This is because it _does_ have syntactic significance, as the value delimiter, within the parentheses of a _"row"_ type literal.
+- The parentheses _have_ been surrounded by double quotes. This is because these _do_ have syntactic significance.
+- The single quote is _not_ surrounded with double quotes. Though it has syntactic significance in other parsing contexts, it is insignificant within the parentheses of a _"row"_ type literal. This holds, also, for all sorts of other punctuation characters like `;` and `:` and `[` and `]` and so on.
+- The double quote has been escaped by doubling it up and this has been then surrounded with double quotes. This is because it _does_ have syntactic significance, as the (one and only) quoting mechanism, within the parentheses of a _"row"_ type literal.
+- The backslash has also been escaped with another single backslash and this has been then surrounded with double quotes. This is because it _does_ have syntactic significance, as the escape character, within the parentheses of a _"row"_ type literal.
+- `null` is represented in a _"row"_ type literal simply by the absence of any characters between two successive delimiters: between the left parenthesis and the first comma, between two successive commas, or between the last comma and the right parenthesis.
+
+There's another rule that the present example does not show. Though not every comma-separated value was surrounded by double quotes, it's _never harmful_ to do this. You can confirm this easily with your own test, Yugabyte recommends that, for consistency, you always surround every `text` value within the parentheses of a _"row"_ type literal with double quotes.
+
+To use the text of the literal that was produced to create a value, you must enquote it and typecast it. Do this, as you did for the `int` example above, with the `\set` metacommand. But you must use dollar quotes because the literal itself has an interior single quote.
+```postgresql
+\set canonical_literal '$$':result_text_typecast'$$'::row_t
+\echo :canonical_literal
+```
+The `\echo` metacommand now shows this:
+```
+$$(a,',"a b","()",",","""","\\",)$$::row_t
+```
+Next, use the canonical literal that you produced to update `t.v2` to confirm that the value that the row constructor created was recreated:
+```postgresql
+update t set v2 = :canonical_literal where k = 1;
+select (v1 = v2)::text as "v1 = v2" from t where k = 1;
+```
+It shows this:
+```
+ v1 = v2 
+---------
+ true
+```
+So, again as promised, the canonical form of the array literal does indeed recreate the identical value that the _"row"_ type constructor created.
+
+Finally in this section, consider the meaning-changing effect of surrounding the comma delimiters with whitespace. Try this:
+```postgresql
+create type row_t as (f1 text, f2 text, f3 text);
+select '(   a   ,   "(a b)"   ,   c   )'::row_t;;
+```
+It shows this:
+```
+ ("   a   ","   (a b)   ","   c   ")
+```
+You understand this by realizing that the entire run of characters between a pair of delimiters is taken as the value. And double quotes act as an _interior_ escaping mechanism. This model holds when, _but only when_, the value between a pair of delimiters is interpreted as a `text` value (because this is the data type of the declared _"row"_ type field at this position).
+
+This rule is different from the rule for an array literal. It's also different from the rules for JSON documents. In these cases, the value is entirely _within_ the double quotes, and whitespace around punctuation characters outside of the double-quoted values is insignificant.
+
+**Note:** There is absolutely no need to take advantage of this understanding. Yugabyte recommends that you simply always use the "almost-canonical" form of the literal—in other words, you surround every single `text` value with double quotes, even when these are not needed, and you allow no whitespace between these double-quoted values and the delimiter at the start an end of each such value.
+
+### _"Row"_ type with `timestamp` fields
+
+This example demonstrates the principle:
+
+```postgresql
+create type row_t as (f1 timestamp, f2 timestamp);
+create table t(k serial primary key, v1 row_t, v2 row_t);
+insert into t(v1) values (('2019-01-27 11:48:33', '2020-03-30 14:19:21')::row_t);
+select v1::text as text_typecast from t where k = 1
+\gset result_
+\echo :result_text_typecast
+```
+The `\echo` metacommand shows this:
+
+```
+("2019-01-27 11:48:33","2020-03-30 14:19:21")
+```
+To use the text of the literal that was produced to create a value, you must enquote it and typecast it. Do this with the `\set` metacommand:
+```postgresql
+\set canonical_literal '\'':result_text_typecast'\''::row_t
+\echo :canonical_literal
+```
+. The `\echo` metacommand now shows this:
+```
+'("2019-01-27 11:48:33","2020-03-30 14:19:21")'::row_t
+```
+Next, use the canonical literal that you produced to update `t.v2` to confirm that you have recreated the value that the row constructor created:
+```postgresql
+update t set v2 = :canonical_literal where k = 1;
+select (v1 = v2)::text as "v1 = v2" from t where k = 1;
+```
+It shows this:
+```
+ v1 = v2 
+---------
+ true
+```
+Once again, as promised, the canonical form of the array literal does indeed recreate the identical value that the _"row"_ type constructor created.
+
+### _"Row"_ type with `boolean` fields
+
+This example demonstrates the principle:
+
+```postgresql
+create type row_t as (f1 boolean, f2 boolean, f3 boolean);
+create table t(k serial primary key, v1 row_t, v2 row_t);
+insert into t(v1) values ((true, false, null)::row_t);
+select v1::text as text_typecast from t where k = 1
+\gset result_
+\echo :result_text_typecast
+```
+The `\echo` metacommand shows this:
+```
+ (t,f,)
+```
+To use the text of the literal that was produced to create a value, you must enquote it and typecast it. Do this with the `\set` metacommand:
+```postgresql
+\set canonical_literal '\'':result_text_typecast'\''::row_t
+\echo :canonical_literal
+```
+. The `\echo` metacommand now shows this:
+```
+'(t,f,)'::row_t
+```
+Next, use the canonical literal that you produced to update `t.v2` to confirm that the value that the row constructor created was recreated:
+```postgresql
+update t set v2 = :canonical_literal where k = 1;
+select (v1 = v2)::text as "v1 = v2" from t where k = 1;
+```
+It shows this:
+```
+ v1 = v2 
+---------
+ true
+```
+Yet again, as promised, the canonical form of the array literal does indeed recreate the identical value that the _"row"_ type constructor created.
+
+## Further examples
+
+There are other cases of interest like this:
+
+- a _"row"_ type whose definition include one or more fields whose data types are other user-defined _"row"_ types.
+
+The rules for such cases can be determined by induction from the rules that this section has stated and illustrated.
+
+## _"Row"_ type literal versus _"row"_ type constructor
+
+The two notions, _type constructor_ and _literal_, are functionally critically different. It's easy to demonstrate the difference using a `DO` block, because this lets you use a declared variable. It's harder to do this using a SQL statement because you'd have to use a scalar subquery in place of the PL/pgSQL variable. The `row` keyword is deliberately omitted here to emphasize its optional status.
+
+```postgresql
+create type rt as (n numeric, s text, t timestamp, b boolean);
+
+do $body$
+declare
+  n constant numeric := 42.17;
+  s constant text := 'dog house';
+  t constant timestamp := '2020-04-01 23:44:13';
+  b constant boolean := true;
+  r1 constant rt := (n, s, t, b)::rt;
+  r2 constant rt := '(42.17,"dog house","2020-04-01 23:44:13",t)'::rt;
+begin
+  assert r1 = r2, 'unexpected';
+end;
+$body$;
+```
+You can use the _"row"_ type constructor as an expression in the [`array[]` value constructor](../../array-constructor)). But, of course, you can use only the literal for a _"row"_ type value within the the _literal_ for an array. The section [The literal for an array of _"row"_ type values](../array-of-rows/) explains this.

--- a/docs/content/latest/api/ysql/datatypes/type_array/literals/text-typecasting-and-literals.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/literals/text-typecasting-and-literals.md
@@ -1,0 +1,242 @@
+---
+title: text typecast of a value, literal for that value, and how they are related
+linkTitle: Text typecasting and literals
+headerTitle: The text typecast of a value, the literal for that value, and how they are related
+description: The text typecast of a value, the literal for that value, and how they are related
+menu:
+  latest:
+    identifier: text-typecasting-and-literals
+    parent: array-literals
+    weight: 5
+isTocNested: false
+showAsideToc: false
+---
+
+This section establishes some basic notions that have a much broader scope of applicability than just arrays. But, because using array literals very much rests on these notions, they  are summarized here.
+
+## The non-lossy round trip: value to text typecast and back to value.
+
+Consider this pattern:
+```
+do $body$
+declare
+  original   constant <some data type>  not null := <some value>;
+  text_cast  constant text              not null := original::text;
+  recreated  constant <some data type>  not null := text_cast::<some data type>;
+begin
+  assert
+    (recreated = original),
+  'assert failed';
+end;
+$body$;
+```
+
+It demonstrates a universal rule that YSQL inherits from PostgreSQL:
+
+- Any value of any data type, primitive or composite, can be `::text` typecasted. Similarly, there always exists a `text` value that, when properly spelled, can be typecasted to a value of any desired data type, primitive or composite.
+- If you `::text` typecast a value of any data type and then typecast that `text` value to the original value's data type, then the value that you get is identical to the original value.
+
+The following `DO` block applies the pattern using a representative range of both primitive and composite data types. (The data type `text`, as the degenerate case, is not included.) It also displays the value of the `::text` typecast for each data type.
+```postgresql
+create type rt as (n numeric, s text, t timestamp, b boolean);
+
+do $body$
+begin
+  -- numeric
+  declare
+    original   constant numeric  not null := 42.1763;
+    text_cast  constant text     not null := original::text;
+    recreated  constant numeric  not null := text_cast::numeric;
+  begin
+    assert
+      (recreated = original),
+    'assert failed';
+    raise info 'numeric:              %', text_cast;
+  end;
+
+  -- timestamp
+  declare
+    original   constant timestamp  not null := now()::timestamp;
+    text_cast  constant text       not null := original::text;
+    recreated  constant timestamp  not null := text_cast::timestamp;
+  begin
+    assert
+      (recreated = original),
+    'assert failed';
+    raise info 'timestamp:            %', text_cast;
+  end;
+
+  -- timestamp with timezone
+  declare
+    original   constant timestamptz  not null := now()::timestamptz;
+    text_cast  constant text         not null := original::text;
+    recreated  constant timestamptz  not null := text_cast::timestamp;
+  begin
+    assert
+      (recreated = original),
+    'assert failed';
+    raise info 'timestamptz:          %', text_cast;
+  end;
+
+  -- boolean
+  declare
+    original   constant boolean  not null := true;
+    text_cast  constant text     not null := original::text;
+    recreated  constant boolean  not null := text_cast::boolean;
+  begin
+    assert
+      (recreated = original),
+    'assert failed';
+    raise info 'boolean:              %', text_cast;
+  end;
+
+  -- "row" type
+  declare
+    original   constant rt   not null := row(42.1763, 'dog house', now(), true);
+    text_cast  constant text not null := original::text;
+    recreated  constant rt   not null := text_cast::rt;
+  begin
+    assert
+      (recreated = original),
+    'assert failed';
+    raise info '"row" type:           %', text_cast;
+  end;
+
+  -- 2-d array
+  declare
+    original   constant int[]   not null := array[array[1, 2], array[3, 4]];
+    text_cast  constant text not null := original::text;
+    recreated  constant int[]   not null := text_cast::int[];
+  begin
+    assert
+      (recreated = original),
+    'assert failed';
+    raise info '2-d array             %', text_cast;
+  end;
+
+  -- 1-d array of "row" type values
+  declare
+    original   constant rt[]   not null :=
+      array[
+        row(42.1763, 'dog house', now(),                    true),
+        row(19.8651, 'cat flap',  now() + interval '1' day, false)
+      ];
+    text_cast  constant text   not null := original::text;
+    recreated  constant rt[]   not null := text_cast::rt[];
+  begin
+    assert
+      (recreated = original),
+    'assert failed';
+    raise info 'array of "row" type:  %', text_cast;
+  end;
+end;
+$body$;
+```
+It produces this result (after manually removing the `INFO:` prompt on each output line.
+```
+numeric:              42.1763
+timestamp:            2020-05-03 22:25:42.932771
+timestamptz:          2020-05-03 22:25:42.932771-07
+boolean:              true
+"row" type:           (42.1763,"dog house","2020-05-03 22:25:42.932771",t)
+2-d array             {{1,2},{3,4}}
+array of "row" type:  {"(42.1763,\"dog house\",\"2020-05-03 22:25:42.932771\",t)","(19.8651,\"cat flap\",\"2020-05-04 22:25:42.932771\",f)"}
+```
+The remaining sections in [Creating an array value using a literal](../../literals/) explain the syntax of the last three `text` values.
+
+## boolean values show special text forms in `ysqlsh`
+
+Try this:
+```postgresql
+select true as "bare true", true::text as "true::text";
+```
+This is the result:
+```
+ bare true | true::text 
+-----------+------------
+ t         | true
+```
+For all but `boolean` values, the string of characters that `ysqlsh` uses to display any value is the `::text` typecast of that value. (After all, the only feasible means of display is strings of characters.) But uniquely for the two `boolean` values `true` and `false` it uses the single characters `t` and `f` rather than their `::text` typecasts—unless you explicitly write the typecast. 
+
+This behavior is inherited from `psql`.
+
+You saw above that even when you explicitly `::text` typecast a composite value, `true` and `false` are represented as `t` and `f`. You can't influence this outcome because it has to do with the rules for deriving the `text` of the typecast and _not_ with the convention that `ysqlsh` uses. This asymmetry was established many years ago, and it will not change.
+
+## The relationship between the text typecast of a value and the literal that creates that value
+
+Try this in `ysqlsh`:
+```postgresql
+select
+  42.932771::numeric          as n,
+  'cat'::text                 as t1,
+  $$dog's breakfast$$::text   as t2,
+  array[1, 2, 3]::int[]       as "int array";
+```
+It shows the result:
+```
+     n     | t1  |       t2        | int array 
+-----------+-----+-----------------+-----------
+ 42.932771 | cat | dog's breakfast | {1,2,3}}
+```
+ You won't be surprised by this. But you need to establish the proper terms of art that allow you to describe what's going on precisely and correctly. The remaining sections in [Creating an array value using a literal](../../literals/) rely on this.
+
+Consider this first:
+
+```
+42.932771::numeric
+```
+
+This is the literal that the SQL language (at least in the YSQL and PostgreSQL dialects) uses to establish the corresponding strongly-typed `numeric` value. (PL/pgSQL uses the same form for the same purpose.) But, to state the obvious, a SQL statement and a PL/pgSQL source are nothing but strings of characters. That means that, in the present context, this:
+
+```
+42.932771
+```
+
+is the _text_ of the literal.
+
+Now consider these two:
+
+```
+'cat'::text          $$dog's breakfast$$::text
+```
+
+The parsing rules of both SQL and PL/pgSQL (or more properly stated, the definitions of the grammars of these two languages) require that `text` literals are enquoted. Moreover, there are two syntactic mechanisms for doing this: the ordinary single quote; and so-called dollar quotes, where `$$` is a special case of the more general `$anything_you_want$`. You might think that the `::text` typecast is redundant here. But don't forget that the text of these literals might be used to establish `varchar` or `char` values.
+
+You see already, then, that the rules for composing a `numeric` literal and a `text` literal are different:
+
+- You compose a `numeric` literal by following the bare text that specifies the intended value with the `::numeric` typecast operator.
+
+- You compose a `text` literal by enquoting the bare text that specifies the intended value (however you choose to do the quoting) and by then following this with the `::text` typecast operator.
+
+(If you did enquote the bare text in a `numeric` literal, then you would _not_ see an error. Rather, you would get implicit but undesirable behavior: first, a genuine `text` value would be generated internally, and then, this, in turn, would be typecasted to the `numeric` value.)
+
+You've already seen, informally, some examples of array literals. Here is the rule:
+
+- You compose the bare text that specifies the intended value by writing an utterance in a dedicated grammar that starts with the left curly brace and ends with the right curly brace. (This grammar is the focus of the remainder of the [Creating an array value using a literal](../../literals/) section.) Then you enquote this bare text (however you choose to do the quoting) and then typecast it to the desired target array data type.
+
+These are three special cases of a more general rule. In some cases (for example in the literal for a _"row"_ type value) the enquoting mechanism might be optional (depending on the intended value) and, when written uses _double quote_ as the enquoting character. But here, too, the general rule is the same. The bare text that specifies the intended value can always be correctly written as the `::text` typecast of that value.
+
+## Stating the general rule
+
+Here is the general rule.
+
+- The literal for a value of any data type is the possibly enquoted bare text that specifies the intended value, followed by the typecast operator to the desired target data type.
+- This rule is applied recursively, for the literal for a composite value, but with different actual rules at different levels of nesting. For example, the literal for an array value as a whole must be typecasted. But, because the data type of every value in the array is already determined, the bare text that specifies these values is _not_ typecasted.
+- The `::text` typecast of any value can always be used as the bare text of the literal that will recreate that value.
+
+A simple way to see examples of the bare text that specifies an array value, when used as a component in the literal, is to create the value using the constructor and then to inspect its `::text` typecast. But the safe way to create the text of a literal for an intended value is to understand the syntax and semantics that govern its composition.
+
+When this difference is important, the _"Array data types and functionality"_ major section distinguishes between:
+
+- (1) the _literal_ for the intended value (that is, the whole thing with the enquoting and the typecast, when one or both of these are needed);
+- and (2) the _text of the literal_ for the intended value (that is, the bare text that specifies this value).
+
+**Note:** Often, the data type of the assignment target (for example, a field in a column in a schema-level table or a variable in a PL/pgSQL program) is sufficient implicitly to specify the intended typecast without writing the operator. But it's never harmful to write it. Moreover, in some cases, omitting the explicit typecast can bring performance costs. For this reason, Yugabyte recommends that you always write the explicit typecast unless you are certain beyond all doubt that omitting it brings no penalty.
+
+## Defining the "canonical form of a literal"
+
+The term _"canonical form"_ applies specifically to the _text of a literal_ rather than to the _literal as a whole_. But when the text of a literal is in canonical form, the literal as a whole, too, is in canonical form.
+
+The canonical form of the text of a literal that produces a specific value, of any data type, is simply the `::text` typecast of that value.
+
+Many of the examples in this _"Array data types and functionality"_ major section show that many spellings of the text of an array literal, in addition to the canonical form, will produce a particular intended target value. The differences are due to how whitespace, punctuation, and escape characters are used.


### PR DESCRIPTION
This PR is for @bllewell's brand new `type_array` tree under:

> `.../docs/content/latest/api/ysql/datatypes`

There are no changes to existing files. All changes are additions within the brand-new directory tree. In all, it's twenty `.md` files.

All the content has been carefully reviewed by @m-iancu and @stevebang. All their feedback has been acted upon.

**Note:** One small piece remains to be done. But it's entirely self-contained and its absence doesn't detract in any way from the value of the content that this PR covers. You'll see this as _"Coming soon"_ in the file `array-of-domains.md`. There's a reference to this in `.../type_array/_index.md`. Look for _"Sometimes, a ragged structure is useful"_. I didn't want to delay publishing my work to date. I'll create a new PR very soon for this missing piece and at the same time I'll include the addition of the presently missing JSON functions (tracked by Issue #4319).