### PR TITLE
[docdb] Add flag for yb-admin list_snapshots to not show fully RESTORED entries #4351

### DIFF
--- a/ent/src/yb/tools/yb-admin_cli_ent.cc
+++ b/ent/src/yb/tools/yb-admin_cli_ent.cc
@@ -40,7 +40,7 @@ void ClusterAdminCli::RegisterCommandHandlers(ClusterAdminClientClass* client) {
       "list_snapshots", " [SHOW_DETAILS] [NOT_SHOW_RESTORED]",
       [client](const CLIArguments& args) -> Status {
         bool show_details = false;
-        bool not_show_restored=false;
+        bool not_show_restored = false;
         if (args.size() > 4) {
           return ClusterAdminCli::kInvalidArguments;
         }
@@ -57,7 +57,7 @@ void ClusterAdminCli::RegisterCommandHandlers(ClusterAdminClientClass* client) {
           }
         }
 
-        RETURN_NOT_OK_PREPEND(client->ListSnapshots(show_details,not_show_restored),
+        RETURN_NOT_OK_PREPEND(client->ListSnapshots(show_details, not_show_restored),
                               "Unable to list snapshots");
         return Status::OK();
       });

--- a/ent/src/yb/tools/yb-admin_cli_ent.cc
+++ b/ent/src/yb/tools/yb-admin_cli_ent.cc
@@ -40,24 +40,25 @@ void ClusterAdminCli::RegisterCommandHandlers(ClusterAdminClientClass* client) {
       "list_snapshots", " [SHOW_DETAILS] [NOT_SHOW_RESTORED]",
       [client](const CLIArguments& args) -> Status {
         bool show_details = false;
-        bool not_show_restored = false;
+        bool show_restored = true;
+
         if (args.size() > 4) {
           return ClusterAdminCli::kInvalidArguments;
         }
-        for (int i=2; i<args.size(); ++i) {
+        for (int i = 2; i < args.size(); ++i) {
           string uppercase_flag;
           ToUpperCase(args[i], &uppercase_flag);
 
           if (uppercase_flag == "SHOW_DETAILS") {
             show_details = true;
           } else if (uppercase_flag == "NOT_SHOW_RESTORED") {
-            not_show_restored= true;
+            show_restored = false;
           } else {
             return ClusterAdminCli::kInvalidArguments;
           }
         }
 
-        RETURN_NOT_OK_PREPEND(client->ListSnapshots(show_details, not_show_restored),
+        RETURN_NOT_OK_PREPEND(client->ListSnapshots(show_details, show_restored),
                               "Unable to list snapshots");
         return Status::OK();
       });

--- a/ent/src/yb/tools/yb-admin_cli_ent.cc
+++ b/ent/src/yb/tools/yb-admin_cli_ent.cc
@@ -36,23 +36,28 @@ using strings::Substitute;
 void ClusterAdminCli::RegisterCommandHandlers(ClusterAdminClientClass* client) {
   super::RegisterCommandHandlers(client);
 
-  Register(
-      "list_snapshots", " [SHOW_DETAILS]",
+    Register(
+      "list_snapshots", " [SHOW_DETAILS] [NOT_SHOW_RESTORED]",
       [client](const CLIArguments& args) -> Status {
         bool show_details = false;
-
-        if (args.size() >= 3) {
+        bool not_show_restored=false;
+        if (args.size() > 4) {
+          return ClusterAdminCli::kInvalidArguments;
+        }
+        for (int i=2; i<args.size(); ++i) {
           string uppercase_flag;
-          ToUpperCase(args[2], &uppercase_flag);
+          ToUpperCase(args[i], &uppercase_flag);
 
           if (uppercase_flag == "SHOW_DETAILS") {
             show_details = true;
+          } else if (uppercase_flag == "NOT_SHOW_RESTORED") {
+            not_show_restored= true;
           } else {
             return ClusterAdminCli::kInvalidArguments;
           }
         }
 
-        RETURN_NOT_OK_PREPEND(client->ListSnapshots(show_details),
+        RETURN_NOT_OK_PREPEND(client->ListSnapshots(show_details,not_show_restored),
                               "Unable to list snapshots");
         return Status::OK();
       });

--- a/ent/src/yb/tools/yb-admin_client.h
+++ b/ent/src/yb/tools/yb-admin_client.h
@@ -35,7 +35,7 @@ class ClusterAdminClient : public yb::tools::ClusterAdminClient {
       : super(init_master_addrs, timeout_millis) {}
 
   // Snapshot operations.
-  CHECKED_STATUS ListSnapshots(bool show_details);
+  CHECKED_STATUS ListSnapshots(bool show_details, bool not_show_restored);
   CHECKED_STATUS CreateSnapshot(const std::vector<client::YBTableName>& tables);
   CHECKED_STATUS RestoreSnapshot(const std::string& snapshot_id);
   CHECKED_STATUS DeleteSnapshot(const std::string& snapshot_id);

--- a/ent/src/yb/tools/yb-admin_client.h
+++ b/ent/src/yb/tools/yb-admin_client.h
@@ -35,7 +35,7 @@ class ClusterAdminClient : public yb::tools::ClusterAdminClient {
       : super(init_master_addrs, timeout_millis) {}
 
   // Snapshot operations.
-  CHECKED_STATUS ListSnapshots(bool show_details, bool not_show_restored);
+  CHECKED_STATUS ListSnapshots(bool show_details, bool show_restored);
   CHECKED_STATUS CreateSnapshot(const std::vector<client::YBTableName>& tables);
   CHECKED_STATUS RestoreSnapshot(const std::string& snapshot_id);
   CHECKED_STATUS DeleteSnapshot(const std::string& snapshot_id);

--- a/ent/src/yb/tools/yb-admin_client_ent.cc
+++ b/ent/src/yb/tools/yb-admin_client_ent.cc
@@ -143,14 +143,14 @@ Status ClusterAdminClient::ListSnapshots(bool show_details, bool not_show_restor
   ListSnapshotRestorationsResponsePB rest_resp;
   RETURN_NOT_OK(master_backup_proxy_->ListSnapshotRestorations(rest_req, &rest_resp, &rpc));
 
+  if (not_show_restored) {
+    cout<< "Not show fully RESTORED entries." << endl;
+  }
+
   if (rest_resp.restorations_size()) {
     cout << RightPadToUuidWidth("Restoration UUID") << kColumnSep << "State" << endl;
   } else {
     cout << "No snapshot restorations" << endl;
-  }
-
-  if (not_show_restored) {
-    cout<< "Not show fully RESTORED entries." << endl;
   }
 
   for (const SnapshotInfoPB& snapshot : rest_resp.restorations()) {

--- a/ent/src/yb/tools/yb-admin_client_ent.cc
+++ b/ent/src/yb/tools/yb-admin_client_ent.cc
@@ -144,7 +144,7 @@ Status ClusterAdminClient::ListSnapshots(bool show_details, bool show_restored) 
   ListSnapshotRestorationsResponsePB rest_resp;
   RETURN_NOT_OK(master_backup_proxy_->ListSnapshotRestorations(rest_req, &rest_resp, &rpc));
 
-  if (!rest_resp.restorations_size()) {
+  if (rest_resp.restorations_size() == 0) {
     cout << "No snapshot restorations" << endl;
   } else if (!show_restored) {
     cout << "Not show fully RESTORED entries" << endl;

--- a/ent/src/yb/tools/yb-admin_client_ent.cc
+++ b/ent/src/yb/tools/yb-admin_client_ent.cc
@@ -154,7 +154,7 @@ Status ClusterAdminClient::ListSnapshots(bool show_details, bool not_show_restor
   }
 
   for (const SnapshotInfoPB& snapshot : rest_resp.restorations()) {
-    if (!not_show_restored || snapshot.entry().state != "RESTORED") {
+    if (!not_show_restored || snapshot.entry().state() != "RESTORED") {
       cout << SnapshotIdToString(snapshot.id()) << kColumnSep << snapshot.entry().state() << endl;
     }
   }

--- a/ent/src/yb/tools/yb-admin_client_ent.cc
+++ b/ent/src/yb/tools/yb-admin_client_ent.cc
@@ -82,7 +82,7 @@ using master::SysTablesEntryPB;
 
 PB_ENUM_FORMATTERS(yb::master::SysSnapshotEntryPB::State);
 
-Status ClusterAdminClient::ListSnapshots(bool show_details) {
+Status ClusterAdminClient::ListSnapshots(bool show_details, bool not_show_restored) {
   RpcController rpc;
   rpc.set_timeout(timeout_);
   ListSnapshotsRequestPB req;
@@ -149,8 +149,14 @@ Status ClusterAdminClient::ListSnapshots(bool show_details) {
     cout << "No snapshot restorations" << endl;
   }
 
+  if (not_show_restored) {
+    cout<< "Not show fully RESTORED entries." << endl;
+  }
+
   for (const SnapshotInfoPB& snapshot : rest_resp.restorations()) {
-    cout << SnapshotIdToString(snapshot.id()) << kColumnSep << snapshot.entry().state() << endl;
+    if (!not_show_restored || snapshot.entry().state != "RESTORED") {
+      cout << SnapshotIdToString(snapshot.id()) << kColumnSep << snapshot.entry().state() << endl;
+    }
   }
 
   return Status::OK();

--- a/ent/src/yb/tools/yb-admin_client_ent.cc
+++ b/ent/src/yb/tools/yb-admin_client_ent.cc
@@ -154,7 +154,8 @@ Status ClusterAdminClient::ListSnapshots(bool show_details, bool not_show_restor
   }
 
   for (const SnapshotInfoPB& snapshot : rest_resp.restorations()) {
-    if (!not_show_restored || snapshot.entry().state() != "RESTORED") {
+    if (!not_show_restored ||
+        snapshot.entry().state() != master::SysSnapshotEntryPB_State_RESTORED) {
       cout << SnapshotIdToString(snapshot.id()) << kColumnSep << snapshot.entry().state() << endl;
     }
   }


### PR DESCRIPTION
Solved issue #4351 
The test output is attached at bottom.

<img width="846" alt="snapshot" src="https://user-images.githubusercontent.com/37463658/82005410-ec91ea80-962a-11ea-8268-a831d89f55a2.png">
