### PR TITLE
replace 'brew install python@2' in Mac OS build

### DIFF
--- a/docs/content/latest/contribute/core-database/build-from-src-macos.md
+++ b/docs/content/latest/contribute/core-database/build-from-src-macos.md
@@ -63,12 +63,7 @@ Install the following packages using Homebrew:
 brew install autoconf automake bash ccache cmake  \
              coreutils flex gnu-tar icu4c libtool \
              maven ninja pkg-config pstree wget \
-             zlib
-```
-If `pip2` does not exist locally, you will need to install:
-```sh
-curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-sudo python2 get-pip.py
+             zlib python@3
 ```
 
 An older version of `bison` is required to correctly compile the code. The following command installs the required `3.4.1` version of bison.

--- a/docs/content/latest/contribute/core-database/build-from-src-macos.md
+++ b/docs/content/latest/contribute/core-database/build-from-src-macos.md
@@ -63,7 +63,7 @@ Install the following packages using Homebrew:
 brew install autoconf automake bash ccache cmake  \
              coreutils flex gnu-tar icu4c libtool \
              maven ninja pkg-config pstree wget \
-             zlib python@3
+             zlib python3
 ```
 
 An older version of `bison` is required to correctly compile the code. The following command installs the required `3.4.1` version of bison.

--- a/docs/content/latest/contribute/core-database/build-from-src-macos.md
+++ b/docs/content/latest/contribute/core-database/build-from-src-macos.md
@@ -63,7 +63,12 @@ Install the following packages using Homebrew:
 brew install autoconf automake bash ccache cmake  \
              coreutils flex gnu-tar icu4c libtool \
              maven ninja pkg-config pstree wget \
-             zlib python@2
+             zlib
+```
+If `pip2` does not exist locally, you will need to install:
+```sh
+curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+sudo python2 get-pip.py
 ```
 
 An older version of `bison` is required to correctly compile the code. The following command installs the required `3.4.1` version of bison.

--- a/docs/content/latest/contribute/core-database/build-from-src-macos.md
+++ b/docs/content/latest/contribute/core-database/build-from-src-macos.md
@@ -63,7 +63,7 @@ Install the following packages using Homebrew:
 brew install autoconf automake bash ccache cmake  \
              coreutils flex gnu-tar icu4c libtool \
              maven ninja pkg-config pstree wget \
-             zlib python3
+             zlib python
 ```
 
 An older version of `bison` is required to correctly compile the code. The following command installs the required `3.4.1` version of bison.


### PR DESCRIPTION
These docs may need to be modified slightly since 'brew install python@2' has reached EOL and been removed (https://github.com/Homebrew/homebrew-core/pull/49796). 

Maybe better solution to replace pip2 here: https://github.com/yugabyte/yugabyte-db/blob/master/build-support/common-build-env.sh ?