### PR TITLE
[docs] Add note about matching rpc_bind_addresses_ values on yb-master and yb-tserver

### DIFF
--- a/docs/content/latest/reference/configuration/yb-master.md
+++ b/docs/content/latest/reference/configuration/yb-master.md
@@ -92,7 +92,11 @@ Default: Same value as `--fs_data_dirs`
 
 ##### --rpc_bind_addresses
 
-Specifies the comma-separated list of the network interface addresses to bind to for RPC connections. Typically, the value is set to the private IP address of the host on which the server is running. When using the default, or explicitly setting the value to `0.0.0.0:7100`, the server will listen on all available network interfaces.
+Specifies the comma-separated list of the network interface addresses to bind to for RPC connections
+
+- Typically, the value is set to the private IP address of the host on which the server is running. When using the default, or explicitly setting the value to `0.0.0.0:7100`, the server will listen on all available network interfaces.
+
+- The values used must match on all `yb-master` and [`yb-tserver`](../yb-tserver/#rpc-bind-addresses) configurations.
 
 Default: `0.0.0.0:7100`
 

--- a/docs/content/latest/reference/configuration/yb-tserver.md
+++ b/docs/content/latest/reference/configuration/yb-tserver.md
@@ -114,7 +114,11 @@ Default: `50000` (50,000 µs = 50ms)
 
 ##### --rpc_bind_addresses
 
-Specifies the comma-separated list of the network interface addresses to bind to for RPC connections. Typically, the value is set to the private IP address of the host on which the server is running. When using the default, or explicitly setting the value to `0.0.0.0:9100`, the server will listen on all available network interfaces.
+Specifies the comma-separated list of the network interface addresses to bind to for RPC connections.
+
+- Typically, the value is set to the private IP address of the host on which the server is running. When using the default, or explicitly setting the value to `0.0.0.0:9100`, the server will listen on all available network interfaces.
+
+- The values must match on all [`yb-master`](../yb-master/#rpc-bind-addresses) and `yb-tserver` configurations.
 
 Default: `0.0.0.0:9100`
 


### PR DESCRIPTION
Discussed with @iSignal -- users need to make sure to use the same values on all `yb-master` and `yb-tserver` configurations.