### PR TITLE
[#4775] Fix build on Ubuntu 20.04 (gcc 9.3.0)

### DIFF
--- a/src/postgres/CMakeLists.txt
+++ b/src/postgres/CMakeLists.txt
@@ -16,7 +16,8 @@ get_property(yb_cmake_include_dirs DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         PROPERTY INCLUDE_DIRECTORIES)
 foreach(include_dir ${yb_cmake_include_dirs})
   set(POSTGRES_EXTRA_C_CXX_FLAGS "${POSTGRES_EXTRA_C_CXX_FLAGS} -I${include_dir}")
-  if("${COMPILER_FAMILY}" STREQUAL "gcc8")
+  if( ("${COMPILER_FAMILY}" STREQUAL "gcc8") OR
+      ("${COMPILER_FAMILY}" STREQUAL "gcc" AND "${COMPILER_VERSION}" VERSION_GREATER "9.0"))
     set(POSTGRES_EXTRA_C_CXX_FLAGS "${POSTGRES_EXTRA_C_CXX_FLAGS} -Wno-format-truncation -Wno-maybe-uninitialized -Wno-stringop-truncation")
   endif()
 endforeach(include_dir)


### PR DESCRIPTION
    Summary:
    postgres build fails on Ubuntu 20.04 (gcc version 9.3.0), due to
    "-Werror=format-truncation" & "-Werror=stringop-truncation" warnings
    being generated.
    
    When $COMPILER_FAMILY is 'gcc8', these warnings are ignored. 'gcc8'
    compiler family is only for gcc with version 8.*
    
    Since Ubuntu 20.04, has gcc version 9.3.0, the $COMPILER_FAMILY is
    'gcc' and these warnings are not ignored and hence they are treated
    as errors and the build fails.
    
    Fix is to add the check to postgres/CMakeLists.txt for gcc versions
    9 & above.
    
    Test Plan: `./yb_build.sh release` on Ubuntu 20.04
    
    Reviewers:
    
    Reviewed By:
    
    Subcribers:
    
    Differential Revision:
