### PR TITLE
Add link for start local cluster page in contribution checklist

### DIFF
--- a/docs/content/latest/contribute/core-database/checklist.md
+++ b/docs/content/latest/contribute/core-database/checklist.md
@@ -23,7 +23,7 @@ showAsideToc: true
 
 ## Step 2. Start a local cluster
 
-Having built the source, you can start a local cluster.
+Having built the source, you can [start a local cluster](../../quick-start/create-local-cluster).
 
 ## Step 3. Make the change
 


### PR DESCRIPTION
Just adding a link to make it easier for new folks to navigate documentation.