### PR TITLE
[docs] update kubectl exec commands to use binary names directly

### DIFF
--- a/docs/content/latest/api/ycql/quick-start/kubernetes/explore-ycql.md
+++ b/docs/content/latest/api/ycql/quick-start/kubernetes/explore-ycql.md
@@ -1,8 +1,9 @@
 
-* Run cqlsh to connect to the service.
+To connect to the service, open the YCQL shell (`ycqlsh`) by running the following command:
+`
 
 ```sh
-$ kubectl exec -it yb-tserver-0 /home/yugabyte/bin/ycqlsh yb-tserver-0
+$ kubectl exec -it yb-tserver-0 -- ycqlsh yb-tserver-0
 ```
 
 ```

--- a/docs/content/latest/deploy/kubernetes/multi-cluster/gke/helm-chart.md
+++ b/docs/content/latest/deploy/kubernetes/multi-cluster/gke/helm-chart.md
@@ -475,11 +475,11 @@ Default replica placement policy treats every yb-tserver as equal irrespective o
 Run the following command to make the replica placement region/cluster-aware so that one replica is placed on each region/cluster.
 
 ```sh
-kubectl exec -it -n yb-demo-us-west1-b --context gke_yugabyte_us-west1-b_yugabytedb1 yb-master-0 bash \
--- -c "/home/yugabyte/master/bin/yb-admin --master_addresses yb-master-0.yb-masters.yb-demo-us-west1-b.svc.cluster.local:7100,yb-master-0.yb-masters.yb-demo-us-central1-b.svc.cluster.local:7100,yb-master-0.yb-masters.yb-demo-us-east1-b.svc.cluster.local:7100 modify_placement_info gke.us-west1.us-west1-b,gke.us-central1.us-central1-b,gke.us-east1.us-east1-b 3"
+kubectl exec -it -n yb-demo-us-west1-b --context gke_yugabyte_us-west1-b_yugabytedb1 yb-master-0 -- bash \
+-c "/home/yugabyte/master/bin/yb-admin --master_addresses yb-master-0.yb-masters.yb-demo-us-west1-b.svc.cluster.local:7100,yb-master-0.yb-masters.yb-demo-us-central1-b.svc.cluster.local:7100,yb-master-0.yb-masters.yb-demo-us-east1-b.svc.cluster.local:7100 modify_placement_info gke.us-west1.us-west1-b,gke.us-central1.us-central1-b,gke.us-east1.us-east1-b 3"
 ```
 
-Go to `http://<external-ip>:7000/cluster-config` to see the new configuration.
+To see the new configuration, go to `http://<external-ip>:7000/cluster-config`.
 
 ![after-regionaware](/images/deploy/kubernetes/gke-multicluster-after-regionaware.png)
 
@@ -489,14 +489,14 @@ To connect and use the YSQL Shell (`ysqlsh`), run the following command.
 
 ```sh
 $ kubectl exec -n yb-demo-us-west1-b --context gke_yugabyte_us-west1-b_yugabytedb1 \
- -it yb-tserver-0 -- /home/yugabyte/bin/ysqlsh -h yb-tserver-0.yb-tservers.yb-demo-us-west1-b
+ -it yb-tserver-0 -- ysqlsh -h yb-tserver-0.yb-tservers.yb-demo-us-west1-b
 ```
 
 To connect and use the YCQL Shell (`ycqlsh`), run the following command.
 
 ```sh
 $ kubectl exec -n yb-demo-us-west1-b --context gke_yugabyte_us-west1-b_yugabytedb1 \
--it yb-tserver-0 /home/yugabyte/bin/ycqlsh yb-tserver-0.yb-tservers.yb-demo-us-west1-b
+-it yb-tserver-0 -- ycqlsh yb-tserver-0.yb-tservers.yb-demo-us-west1-b
 ```
 
 You can follow the [Explore YSQL](../../../../../quick-start/explore-ysql) tutorial and then go to the `http://<external-ip>:7000/tablet-servers` page of the yb-master Admin UI to confirm that tablet peers and their leaders are placed evenly across all three zones for both user data and system data.

--- a/docs/content/latest/deploy/kubernetes/multi-zone/eks/helm-chart.md
+++ b/docs/content/latest/deploy/kubernetes/multi-zone/eks/helm-chart.md
@@ -337,14 +337,14 @@ Default replica placement policy treats every yb-tserver as equal irrespective o
 
 ![before-zoneaware](/images/deploy/kubernetes/gke-aws-multizone-before-zoneaware.png)
 
-Run the following command to make the replica placement zone aware so that one replica is placed on each zone.
+To make the replica placement zone-aware, so that one replica is placed in each zone, run the following command:
 
 ```sh
-kubectl exec -it -n yb-demo-us-east-1a yb-master-0 bash \
--- -c "/home/yugabyte/master/bin/yb-admin --master_addresses yb-master-0.yb-masters.yb-demo-us-east-1a.svc.cluster.local:7100,yb-master-0.yb-masters.yb-demo-us-east-1b.svc.cluster.local:7100,yb-master-0.yb-masters.yb-demo-us-east-1c.svc.cluster.local:7100 modify_placement_info aws.us-east-1.us-east-1a,aws.us-east-1.us-east-1b,aws.us-east-1.us-east-1c 3"
+kubectl exec -it -n yb-demo-us-east-1a yb-master-0 -- bash \
+-c "/home/yugabyte/master/bin/yb-admin --master_addresses yb-master-0.yb-masters.yb-demo-us-east-1a.svc.cluster.local:7100,yb-master-0.yb-masters.yb-demo-us-east-1b.svc.cluster.local:7100,yb-master-0.yb-masters.yb-demo-us-east-1c.svc.cluster.local:7100 modify_placement_info aws.us-east-1.us-east-1a,aws.us-east-1.us-east-1b,aws.us-east-1.us-east-1c 3"
 ```
 
-Go to `http://<external-ip>:7000/cluster-config` to see the new configuration.
+To see the new configuration, go to `http://<external-ip>:7000/cluster-config`.
 
 ![after-zoneaware](/images/deploy/kubernetes/aws-multizone-after-zoneaware.png)
 
@@ -355,14 +355,14 @@ To connect and use the YSQL Shell (`ysqlsh`), run the following command.
 us-east-1a,us-east-1b,us-east-1c \
 
 ```sh
-$ kubectl exec -n yb-demo-us-east-1a -it yb-tserver-0 -- /home/yugabyte/bin/ysqlsh \
+$ kubectl exec -n yb-demo-us-east-1a -it yb-tserver-0 -- ysqlsh \
   -h yb-tserver-0.yb-tservers.yb-demo-us-east-1a
 ```
 
-To connect and use the YCQL Shell (`ycqlsh`), run the following command.
+To connect and use the YCQL Shell (`ycqlsh`), run the following command:
 
 ```sh
-$ kubectl exec -n yb-demo-us-east-1a -it yb-tserver-0 /home/yugabyte/bin/ycqlsh \
+$ kubectl exec -n yb-demo-us-east-1a -it yb-tserver-0 -- ycqlsh \
 yb-tserver-0.yb-tservers.yb-demo-us-east-1a
 ```
 

--- a/docs/content/latest/deploy/kubernetes/multi-zone/gke/helm-chart.md
+++ b/docs/content/latest/deploy/kubernetes/multi-zone/gke/helm-chart.md
@@ -347,14 +347,14 @@ Default replica placement policy treats every yb-tserver as equal irrespective o
 
 ![before-zoneaware](/images/deploy/kubernetes/gke-aws-multizone-before-zoneaware.png)
 
-Run the following command to make the replica placement zone-aware so that one replica is placed on each zone.
+To make the replica placement zone-aware, so that one replica is placed in each zone, run the following command:
 
 ```sh
-kubectl exec -it -n yb-demo-us-central1-a yb-master-0 bash \
--- -c "/home/yugabyte/master/bin/yb-admin --master_addresses yb-master-0.yb-masters.yb-demo-us-central1-a.svc.cluster.local:7100,yb-master-0.yb-masters.yb-demo-us-central1-b.svc.cluster.local:7100,yb-master-0.yb-masters.yb-demo-us-central1-c.svc.cluster.local:7100 modify_placement_info gke.us-central1.us-central1-a,gke.us-central1.us-central1-b,gke.us-central1.us-central1-c 3"
+kubectl exec -it -n yb-demo-us-central1-a yb-master-0 -- bash \
+-c "/home/yugabyte/master/bin/yb-admin --master_addresses yb-master-0.yb-masters.yb-demo-us-central1-a.svc.cluster.local:7100,yb-master-0.yb-masters.yb-demo-us-central1-b.svc.cluster.local:7100,yb-master-0.yb-masters.yb-demo-us-central1-c.svc.cluster.local:7100 modify_placement_info gke.us-central1.us-central1-a,gke.us-central1.us-central1-b,gke.us-central1.us-central1-c 3"
 ```
 
-Go to `http://<external-ip>:7000/cluster-config` to see the new configuration.
+To see the new configuration, go to `http://<external-ip>:7000/cluster-config` to see the new configuration.
 
 ![after-zoneaware](/images/deploy/kubernetes/gke-multizone-after-zoneaware.png)
 
@@ -363,14 +363,14 @@ Go to `http://<external-ip>:7000/cluster-config` to see the new configuration.
 To connect and use the YSQL Shell (`ysqlsh`), run the following command.
 
 ```sh
-$ kubectl exec -n yb-demo-us-central1-a -it yb-tserver-0 -- /home/yugabyte/bin/ysqlsh \
+$ kubectl exec -n yb-demo-us-central1-a -it yb-tserver-0 -- ysqlsh \
   -h yb-tserver-0.yb-tservers.yb-demo-us-central1-a
 ```
 
-To connect and use the YCQL Shell (`ycqlsh`), run the following command.
+To open the YCQL Shell (`ycqlsh`), run the following command:
 
 ```sh
-$ kubectl exec -n yb-demo-us-central1-a -it yb-tserver-0 /home/yugabyte/bin/ycqlsh \
+$ kubectl exec -n yb-demo-us-central1-a -it yb-tserver-0 -- ycqlsh \
 yb-tserver-0.yb-tservers.yb-demo-us-central1-a
 ```
 

--- a/docs/content/latest/deploy/kubernetes/single-zone/aks/statefulset-yaml.md
+++ b/docs/content/latest/deploy/kubernetes/single-zone/aks/statefulset-yaml.md
@@ -152,10 +152,10 @@ yb-tservers   ClusterIP   None         <none>        9000/TCP,9100/TCP,9042/TCP,
 
 ## 4. Connect to the cluster
 
-You can connect to the YCQL API by running the following.
+To open the YCQL shell (`ycqlsh`), run the following command:
 
 ```sh
-$ kubectl exec -it yb-tserver-0 bin/ycqlsh
+$ kubectl exec -it yb-tserver-0 -- ycqlsh yb-tserver-0
 ```
 
 ```

--- a/docs/content/latest/deploy/kubernetes/single-zone/gke/helm-chart.md
+++ b/docs/content/latest/deploy/kubernetes/single-zone/gke/helm-chart.md
@@ -170,10 +170,10 @@ NOTES:
   kubectl get svc --namespace yb-demo
 
 4. Connect to one of the tablet server:
-  kubectl exec --namespace yb-demo -it yb-tserver-0 bash
+  kubectl exec --namespace yb-demo -it yb-tserver-0 -- bash
 
 5. Run YSQL shell from inside of a tablet server:
-  kubectl exec --namespace yb-demo -it yb-tserver-0 -- /home/yugabyte/bin/ysqlsh -h yb-tserver-0.yb-tservers.yb-demo
+  kubectl exec --namespace yb-demo -it yb-tserver-0 -- ysqlsh -h yb-tserver-0.yb-tservers.yb-demo
 
 6. Cleanup YugabyteDB Pods
   helm delete yb-demo --purge
@@ -230,13 +230,13 @@ REVISION  UPDATED                   STATUS    CHART           APP VERSION DESCRI
 To connect and use the YSQL Shell `ysqlsh`, run the following command.
 
 ```sh
-$ kubectl exec -n yb-demo -it yb-tserver-0 -- /home/yugabyte/bin/ysqlsh -h yb-tserver-0.yb-tservers.yb-demo
+$ kubectl exec -n yb-demo -it yb-tserver-0 -- ysqlsh -h yb-tserver-0.yb-tservers.yb-demo
 ```
 
 To connect and use the YCQL Shell `ycqlsh`, run the following command.
 
 ```sh
-$ kubectl exec -n yb-demo -it yb-tserver-0 /home/yugabyte/bin/ycqlsh yb-tserver-0.yb-tservers.yb-demo
+$ kubectl exec -n yb-demo -it yb-tserver-0 -- ycqlsh yb-tserver-0.yb-tservers.yb-demo
 ```
 
 ## Connect using external clients

--- a/docs/content/latest/deploy/kubernetes/single-zone/gke/statefulset-yaml-local-ssd.md
+++ b/docs/content/latest/deploy/kubernetes/single-zone/gke/statefulset-yaml-local-ssd.md
@@ -250,7 +250,7 @@ Note the `yb-master-ui` service above. It is a load balancer service, which expo
 You can connect to one of the tserver pods and verify that the local disk is mounted into the pods.
 
 ```sh
-$ kubectl exec -it yb-tserver-0 bash
+$ kubectl exec -it yb-tserver-0 -- bash
 ```
 
 You can observe the local disks by running the following command.
@@ -267,7 +267,7 @@ Filesystem      Size  Used Avail Use% Mounted on
 You can connect to the `ycqlsh` shell on this universe by running the following command.
 
 ```sh
-$ kubectl exec -it yb-tserver-0 bin/ycqlsh
+$ kubectl exec -it yb-tserver-0 -- ycqlsh yb-tserver-0
 ```
 
 ```sh

--- a/docs/content/latest/deploy/kubernetes/single-zone/gke/statefulset-yaml.md
+++ b/docs/content/latest/deploy/kubernetes/single-zone/gke/statefulset-yaml.md
@@ -140,7 +140,7 @@ yb-tservers   ClusterIP   None         <none>        9000/TCP,9100/TCP,9042/TCP,
 You can connect to the YCQL API by running the following.
 
 ```sh
-$ kubectl exec -it yb-tserver-0 bin/ycqlsh
+$ kubectl exec -it yb-tserver-0 -- ycqlsh yb-tserver-0
 ```
 
 ```

--- a/docs/content/latest/deploy/kubernetes/single-zone/oss/helm-chart.md
+++ b/docs/content/latest/deploy/kubernetes/single-zone/oss/helm-chart.md
@@ -171,10 +171,10 @@ NOTES:
   kubectl get svc --namespace yb-demo
 
 4. Connect to one of the tablet server:
-  kubectl exec --namespace yb-demo -it yb-tserver-0 bash
+  kubectl exec --namespace yb-demo -it yb-tserver-0 -- bash
 
 5. Run YSQL shell from inside of a tablet server:
-  kubectl exec --namespace yb-demo -it yb-tserver-0 -- /home/yugabyte/bin/ysqlsh  -h yb-tserver-0.yb-tservers.yb-demo
+  kubectl exec --namespace yb-demo -it yb-tserver-0 -- ysqlsh  -h yb-tserver-0.yb-tservers.yb-demo
 
 6. Cleanup YugabyteDB Pods
   helm delete yb-demo --purge
@@ -231,13 +231,13 @@ REVISION  UPDATED                   STATUS    CHART           APP VERSION   DESC
 To connect and use the YSQL Shell (`ysqlsh`), run the following command.
 
 ```sh
-$ kubectl exec -n yb-demo -it yb-tserver-0 -- /home/yugabyte/bin/ysqlsh -h yb-tserver-0.yb-tservers.yb-demo
+$ kubectl exec -n yb-demo -it yb-tserver-0 -- ysqlsh -h yb-tserver-0.yb-tservers.yb-demo
 ```
 
 To connect and use the YCQL Shell (`ycqlsh`), run the following command.
 
 ```sh
-$ kubectl exec -n yb-demo -it yb-tserver-0 /home/yugabyte/bin/ycqlsh yb-tserver-0.yb-tservers.yb-demo
+$ kubectl exec -n yb-demo -it yb-tserver-0 -- ycqlsh yb-tserver-0.yb-tservers.yb-demo
 ```
 
 ## Connect using external clients

--- a/docs/content/latest/deploy/kubernetes/single-zone/oss/operator-hub.md
+++ b/docs/content/latest/deploy/kubernetes/single-zone/oss/operator-hub.md
@@ -107,7 +107,7 @@ For configuration flags, see [Configuration flags](../yugabyte-operator/#configu
 When all of the pods in YugabyteDB cluster are running, you can use the YSQL shell (`ysqlsh`) to access the YSQL API, which is PostgreSQL-compliant.
 
 ```sh
-$ kubectl exec -it -n yb-operator yb-tserver-0 -- /home/yugabyte/bin/ysqlsh -h yb-tserver-0  --echo-queries
+$ kubectl exec -it -n yb-operator yb-tserver-0 -- ysqlsh -h yb-tserver-0  --echo-queries
 ```
 
 For details on the YSQL API, see:

--- a/docs/content/latest/deploy/kubernetes/single-zone/oss/rook-operator.md
+++ b/docs/content/latest/deploy/kubernetes/single-zone/oss/rook-operator.md
@@ -120,7 +120,7 @@ Make a copy of the sample CRD file (`cluster.yaml`)  and modify it as needed. Fo
 When all of the pods in YugabyteDB cluster are running, you can use the YSQL shell to access the YSQL API, which is PostgreSQL-compliant.
 
 ```console
-kubectl exec -it yb-tserver-rook-yugabytedb-0 -- /home/yugabyte/bin/ysqlsh  -h yb-tserver-rook-yugabytedb-0  --echo-queries
+kubectl exec -it yb-tserver-rook-yugabytedb-0 -- ysqlsh  -h yb-tserver-rook-yugabytedb-0  --echo-queries
 ```
 
 For details on the YSQL API, see:

--- a/docs/content/latest/deploy/kubernetes/single-zone/oss/yugabyte-operator.md
+++ b/docs/content/latest/deploy/kubernetes/single-zone/oss/yugabyte-operator.md
@@ -87,13 +87,13 @@ kubectl get po,sts,svc
 Once the cluster is up and running, you may start the YSQL API and start executing relational queries.
 
 ```sh
-kubectl exec -it yb-tserver-0 -- /home/yugabyte/bin/ysqlsh -h yb-tserver-0 --echo-queries
+kubectl exec -it yb-tserver-0 -- ysqlsh -h yb-tserver-0 --echo-queries
 ```
 
 You can also connect to the YCQL API as shown below.
 
 ```sh
-kubectl exec -it yb-tserver-0 /home/yugabyte/bin/ycqlsh yb-tserver-0
+kubectl exec -it yb-tserver-0 -- ycqlsh yb-tserver-0
 ```
 
 ## Configuration flags

--- a/docs/content/latest/develop/kubernetes/run-sample-apps.md
+++ b/docs/content/latest/develop/kubernetes/run-sample-apps.md
@@ -11,10 +11,10 @@ $ kubectl apply -f yugabyte-statefulset.yaml
 Initialize the YEDIS API.
 
 ```sh
-$ kubectl exec -it yb-master-0 /home/yugabyte/bin/yb-admin -- --master_addresses yb-master-0.yb-masters.default.svc.cluster.local:7100,yb-master-1.yb-masters.default.svc.cluster.local:7100,yb-master-2.yb-masters.default.svc.cluster.local:7100 setup_redis_table
+$ kubectl exec -it yb-master-0 -- /home/yugabyte/bin/yb-admin --master_addresses yb-master-0.yb-masters.default.svc.cluster.local:7100,yb-master-1.yb-masters.default.svc.cluster.local:7100,yb-master-2.yb-masters.default.svc.cluster.local:7100 setup_redis_table
 ```
 
-Clients can now connect to the YSQL, YCQL and YEDIS APIs of the cluster at 5433, 9042 and 6379 ports respectively.
+Clients can now connect to the YSQL, YCQL, and YEDIS APIs of the cluster at the following ports: `5433`, `9042`, and `6379`, respectively.
 
 ## 2. Install Yugastore
 
@@ -65,7 +65,7 @@ Now you can see the Yugastore app at http://localhost:3001.
 You can do this as shown below.
 
 ```sh
-$ kubectl exec -it yugastore-55d7c6965-ql95t node /usr/local/yugastore/test/sample-user.js
+$ kubectl exec -it yugastore-55d7c6965-ql95t -- node /usr/local/yugastore/test/sample-user.js
 ```
 
 ## 4. Observe effects of load on YugabyteDB Admin UI

--- a/docs/content/latest/manage/enterprise-edition/migrate-to-helm3.md
+++ b/docs/content/latest/manage/enterprise-edition/migrate-to-helm3.md
@@ -131,9 +131,9 @@ NOTES:
 3. Get information about the load balancer services:
   kubectl get svc --namespace yb-test
 4. Connect to one of the tablet server:
-  kubectl exec --namespace yb-test -it yb-tserver-0 bash
+  kubectl exec --namespace yb-test -it yb-tserver-0 -- bash
 5. Run YSQL shell from inside of a tablet server:
-  kubectl exec --namespace yb-test -it yb-tserver-0 /home/yugabyte/bin/ysqlsh -- -h yb-tserver-0.yb-tservers.yb-test
+  kubectl exec --namespace yb-test -it yb-tserver-0 -- ysqlsh -h yb-tserver-0.yb-tservers.yb-test
 6. Cleanup YugabyteDB Pods
   For helm 2:
   helm delete yb-test --purge

--- a/docs/content/latest/yedis/quick-start/kubernetes/test-yedis.md
+++ b/docs/content/latest/yedis/quick-start/kubernetes/test-yedis.md
@@ -3,7 +3,7 @@
 * Initialize YEDIS API in the YugabyteDB universe you just set up by running the following `yb-admin` command.
 
 ```sh
-$ kubectl exec -it yb-master-0 /home/yugabyte/bin/yb-admin -- --master_addresses yb-master-0.yb-masters.default.svc.cluster.local:7100 setup_redis_table
+$ kubectl exec -it yb-master-0 -- /home/yugabyte/bin/yb-admin --master_addresses yb-master-0.yb-masters.default.svc.cluster.local:7100 setup_redis_table
 ```
 
 ```
@@ -17,7 +17,7 @@ Run `redis-cli` to connect to the service.
 You can do this as shown below.
 
 ```sh
-$ kubectl exec -it yb-tserver-0 /home/yugabyte/bin/redis-cli
+$ kubectl exec -it yb-tserver-0 -- /home/yugabyte/bin/redis-cli
 ```
 
 ```


### PR DESCRIPTION
- Changes `/home/yugabyte/bin/ycqlsh` to `ycqlsh` and `/home/yugabyte/bin/ysqlsh` to `ysqlsh` as both are in `PATH`
- Similar to https://github.com/yugabyte/yugabyte-db/pull/4267 updates all the commands to use `--` at correct place
- Updates all the commands to use absolute paths, ref: https://github.com/yugabyte/charts/pull/9

### Scenarios tested
- Executed each type of command at least once