### PR TITLE
[YSQL] Use default db as yugabyte irrespective of user name #2484

### DIFF
--- a/src/postgres/src/interfaces/libpq/fe-connect.c
+++ b/src/postgres/src/interfaces/libpq/fe-connect.c
@@ -1132,7 +1132,7 @@ connectOptions2(PGconn *conn)
 	{
 		if (conn->dbName)
 			free(conn->dbName);
-		conn->dbName = strdup(conn->pguser);
+		conn->dbName = strdup("yugabyte");
 		if (!conn->dbName)
 			goto oom_error;
 	}


### PR DESCRIPTION
## Scenarios tested
- Before changes: 
```
./bin/ysqlsh -U xxx
WARNING: password file "/Users/xxx/.pgpass" is not a plain file
ysqlsh: FATAL:  database "xxx" does not exis
```

- After changes:
```
./bin/ysqlsh -U xxx
WARNING: password file "/Users/xxx/.pgpass" is not a plain file
ysqlsh (11.2-YB-2.1.8.0-b0)
Type "help" for help.

yugabyte=>
```