### PR TITLE
[YSQL] Use default db as yugabyte irrespective of user name 

### DIFF
--- a/src/postgres/src/interfaces/libpq/fe-connect.c
+++ b/src/postgres/src/interfaces/libpq/fe-connect.c
@@ -1132,7 +1132,7 @@ connectOptions2(PGconn *conn)
 	{
 		if (conn->dbName)
 			free(conn->dbName);
-		conn->dbName = strdup(conn->pguser);
+		conn->dbName = strdup("yugabyte");
 		if (!conn->dbName)
 			goto oom_error;
 	}

--- a/src/postgres/src/interfaces/libpq/fe-connect.c
+++ b/src/postgres/src/interfaces/libpq/fe-connect.c
@@ -5382,6 +5382,16 @@ conninfo_add_defaults(PQconninfoOption *options, PQExpBuffer errorMessage)
 			option->val = strdup("yugabyte");
 			continue;
 		}
+
+		/*
+		 * Special handling for "dbname" option.		 
+		 */
+		if (strcmp(option->keyword, "dbname") == 0)
+		{
+		  /* YugaByte default dbname to "yugabyte" */
+			option->val = strdup("yugabyte");
+			continue;
+		}
 	}
 
 	return true;


### PR DESCRIPTION
Fixes #2484

## Scenarios tested
- Before changes: 
```
./bin/ysqlsh -U xxx
ysqlsh: FATAL:  database "xxx" does not exis
```

- After changes:
```
./bin/ysqlsh -U xxx
ysqlsh (11.2-YB-2.1.8.0-b0)
Type "help" for help.

yugabyte=>
```