### PR TITLE
[docs] Add new YCQL client drivers section to Drivers in Reference.

### DIFF
--- a/docs/content/latest/quick-start/build-apps/cpp/ycql.md
+++ b/docs/content/latest/quick-start/build-apps/cpp/ycql.md
@@ -58,9 +58,9 @@ The YugabyteDB C++ Driver for YCQL depends on the following:
 
 For details on installing the dependencies, see [Installing dependencies](https://docs.datastax.com/en/developer/cpp-driver/2.9/topics/building/#installing-dependencies).
 
-### Install the Yugabyte
+### Install the Yugabyte C++ Driver for YCQL
 
-To build and install the driver:
+To build and install the driver, run the following commands:
 
 ```sh
 $ mkdir build
@@ -72,7 +72,7 @@ $ make install
 
 ## Create a working C++ sample application
 
-### Write the C++ application
+### Write the sample application
 
 Create a file `ybcql_hello_world.c` and copy the contents below:
 
@@ -221,7 +221,7 @@ int main() {
 }
 ```
 
-### Run the C++ application
+### Run the application
 
 You can compile the file using `gcc` or `clang`.
 

--- a/docs/content/latest/quick-start/build-apps/cpp/ycql.md
+++ b/docs/content/latest/quick-start/build-apps/cpp/ycql.md
@@ -35,7 +35,7 @@ showAsideToc: true
 The tutorial assumes that you have:
 
 - installed YugabyteDB, created a universe, and are able to interact with it using the YCQL shell (`ycqlsh`). If
-  not, follow the steps in [YCQL quick start](../../../../api/ycql/quick-start/).
+  not, follow the steps in [Quick start YCQL](../../../../api/ycql/quick-start/).
 - have a 32-bit (x86) or 64-bit (x64) architecture machine.
 - have gcc 4.1.2 or later.
 - have Clang 3.4 or later.

--- a/docs/content/latest/quick-start/build-apps/cpp/ycql.md
+++ b/docs/content/latest/quick-start/build-apps/cpp/ycql.md
@@ -1,8 +1,8 @@
 ---
-title: Build a C++ application using YCQL
+title: Build a C++ sample application that uses YCQL
 headerTitle: Build a C++ application
 linkTitle: C++
-description: Build a C++ application that uses the YCQL API.
+description: Build a sample C++ application with the Yugabyte C++ Driver for YCQL.
 menu:
   latest:
     identifier: build-apps-cpp-2-ycql
@@ -35,13 +35,14 @@ showAsideToc: true
 The tutorial assumes that you have:
 
 - installed YugabyteDB, created a universe, and are able to interact with it using the YCQL shell (`ycqlsh`). If
-  not, please follow the steps in the [Quick Start guide](../../../../api/ycql/quick-start/).
+  not, follow the steps in [YCQL quick start](../../../../api/ycql/quick-start/).
 - have a 32-bit (x86) or 64-bit (x64) architecture machine.
-- have gcc 4.1.2 or later, Clang 3.4 or later installed.
+- have gcc 4.1.2 or later.
+- have Clang 3.4 or later.
 
-## Install the C/C++ driver
+## Install the YugabyteDB C++ Driver for YCQL
 
-To get the C/C++ driver, run:
+To get the [YugabyteDB C++ Driver for YCQL](https://github.com/yugabyte/cassandra-cpp-driver), clone the repository:
 
 ```sh
 $ git clone https://github.com/yugabyte/cassandra-cpp-driver.git
@@ -49,16 +50,15 @@ $ git clone https://github.com/yugabyte/cassandra-cpp-driver.git
 
 ### Dependencies
 
-The C/C++ driver depends on the following:
+The YugabyteDB C++ Driver for YCQL depends on the following:
 
-- CMake v2.6.4+
+- CMake v2.6.4 or later
 - libuv 1.x
 - OpenSSL v1.0.x or v1.1.x
 
-More detailed instructions for installing the dependencies are 
-given [here](https://docs.datastax.com/en/developer/cpp-driver/2.9/topics/building/#dependencies).
+For details on installing the dependencies, see [Installing dependencies](https://docs.datastax.com/en/developer/cpp-driver/2.9/topics/building/#installing-dependencies).
 
-### Build and install
+### Install the Yugabyte
 
 To build and install the driver:
 
@@ -70,9 +70,9 @@ $ make
 $ make install
 ```
 
-## Working example
+## Create a working C++ sample application
 
-### Write an application
+### Write the C++ application
 
 Create a file `ybcql_hello_world.c` and copy the contents below:
 
@@ -221,10 +221,11 @@ int main() {
 }
 ```
 
-### Run the application
+### Run the C++ application
 
-You can compile the file using gcc or clang. 
-For clang, you can use:
+You can compile the file using `gcc` or `clang`.
+
+For `clang`, run the following command:
 
 ```sh
 $ clang ybcql_hello_world.c -lcassandra -Iinclude -o yb_cql_hello_world

--- a/docs/content/latest/quick-start/build-apps/csharp/ycql.md
+++ b/docs/content/latest/quick-start/build-apps/csharp/ycql.md
@@ -43,9 +43,9 @@ In your Visual Studio, create a new **Project** and choose **Console Application
 
 ### Install the YugaByte C# Driver for YCQL
 
-The [Yugabyte C# Driver for YCQL](https://github.com/yugabyte/cassandra-csharp-driver) is based on a fork of the Apache Cassandra C# Driver, but adds features unique to YCQL, including [JSONB support](../../api/ycql/type_jsonb/) and a different routing policy.
+The [Yugabyte C# Driver for YCQL](https://github.com/yugabyte/cassandra-csharp-driver) is based on a fork of the Apache Cassandra C# Driver, but adds features unique to YCQL, including [JSONB support](../../../api/ycql/type_jsonb/) and a different routing policy.
 
-To install the [YugbyteDB C# Driver for YCQL](https://www.nuget.org/packages/YugaByteCassandraCSharpDriver/) in your Visual Studio project, follow the instructions in the [README](https://github.com/yugabyte/cassandra-csharp-driver).
+To install the [Yugbyte C# Driver for YCQL](https://www.nuget.org/packages/YugaByteCassandraCSharpDriver/) in your Visual Studio project, follow the instructions in the [README](https://github.com/yugabyte/cassandra-csharp-driver).
 
 ### Copy the contents below to your `Program.cs` file
 
@@ -107,8 +107,9 @@ namespace Yugabyte_CSharp_Demo
 }
 ```
 
-### Running the C# app
-Run the C# app from menu select `Run -> Start Without Debugging`
+### Run the application
+
+To run the C# application from the Visual Studio menu, select `Run > Start Without Debugging`.
 
 You should see the following as the output.
 

--- a/docs/content/latest/quick-start/build-apps/csharp/ycql.md
+++ b/docs/content/latest/quick-start/build-apps/csharp/ycql.md
@@ -34,7 +34,7 @@ showAsideToc: true
 
 This tutorial assumes that you have:
 
-- installed YugabyteDB, created a universe and are able to interact with it using the YCQL shell. If not, follow the steps in [Quick start YCQL](../../../../quick-start/test-cassandra/).
+- installed YugabyteDB, created a universe and are able to interact with it using the YCQL shell. If not, follow the steps in [Quick start YCQL](../../../../api/ycql/quick-start/).
 - installed Visual Studio.
 
 ## Write the HelloWorld C# application

--- a/docs/content/latest/quick-start/build-apps/csharp/ycql.md
+++ b/docs/content/latest/quick-start/build-apps/csharp/ycql.md
@@ -2,7 +2,7 @@
 title: Build a C# application that uses YCQL
 headerTitle: Build a C# application
 linkTitle: C#
-description: Build a C# application that uses YCQL.
+description: Build a sample C# application with the Yugabyte C# Driver for YCQL.
 menu:
   latest:
     identifier: build-apps-csharp-2-ycql
@@ -34,20 +34,20 @@ showAsideToc: true
 
 This tutorial assumes that you have:
 
-- installed YugabyteDB, created a universe and are able to interact with it using the YCQL shell. If not, please follow these steps in the [Quick start YCQL](../../../../quick-start/test-cassandra/).
-- installed Visual Studio
+- installed YugabyteDB, created a universe and are able to interact with it using the YCQL shell. If not, follow the steps in [Quick start YCQL](../../../../quick-start/test-cassandra/).
+- installed Visual Studio.
 
-## Writing a HelloWorld C# app
+## Write the HelloWorld C# application
 
-In your Visual Studio create a new Project and choose Console Application as template. Follow the instructions to save the project.
+In your Visual Studio, create a new **Project** and choose **Console Application** as template. Follow the instructions to save the project.
 
-### Install YugaByteCassandraCSharpDriver C# driver
+### Install the YugaByte C# Driver for YCQL
 
-YugabyteDB has forked the Cassandra driver to add more features like JSONB and change the routing policy.
-[Install the C# driver](https://www.nuget.org/packages/YugaByteCassandraCSharpDriver/) in your Visual Studio project by
-following instructions on the page.
+The [Yugabyte C# Driver for YCQL](https://github.com/yugabyte/cassandra-csharp-driver) is based on a fork of the Apache Cassandra C# Driver, but adds features unique to YCQL, including [JSONB support](../../api/ycql/type_jsonb/) and a different routing policy.
 
-### Copy the contents below to your `Program.cs` file.
+To install the [YugbyteDB C# Driver for YCQL](https://www.nuget.org/packages/YugaByteCassandraCSharpDriver/) in your Visual Studio project, follow the instructions in the [README](https://github.com/yugabyte/cassandra-csharp-driver).
+
+### Copy the contents below to your `Program.cs` file
 
 ```cs
 using System;

--- a/docs/content/latest/quick-start/build-apps/go/ycql.md
+++ b/docs/content/latest/quick-start/build-apps/go/ycql.md
@@ -41,7 +41,7 @@ showAsideToc: true
 
 This tutorial assumes that you have:
 
-- installed YugabyteDB, created a universe, and are able to interact with it using the YCQL shell. If not, follow the steps in [Quick start YCQL](../../../../api/ycql/quick-start/).
+- installed YugabyteDB, created a universe, and are able to interact with it using the YCQL shell. If not, follow the steps in [YCQL quick start](../../../../api/ycql/quick-start/).
 - installed Go version 1.13 or later.
 
 ## Install the Yugabyte Go Driver for YCQL
@@ -121,7 +121,7 @@ func main() {
 }
 ```
 
-## Run the Go application
+## Run the application
 
 To use the application, run the following command:
 

--- a/docs/content/latest/quick-start/build-apps/go/ycql.md
+++ b/docs/content/latest/quick-start/build-apps/go/ycql.md
@@ -2,7 +2,7 @@
 title: Build a Go application that uses YCQL
 headerTitle: Build a Go application
 linkTitle: Go
-description: Build a Go application that uses YCQL.
+description: Build a sample Go application with the Yugabyte Go Driver for YCQL.
 aliases:
   - /latest/develop/client-drivers/cassandra/go/
 menu:
@@ -41,18 +41,18 @@ showAsideToc: true
 
 This tutorial assumes that you have:
 
-- installed YugabyteDB, created a universe and are able to interact with it using the YCQL shell. If not, please follow these steps in the [Quick start](../../../../api/ycql/quick-start/).
+- installed YugabyteDB, created a universe, and are able to interact with it using the YCQL shell. If not, follow the steps in [Quick start YCQL](../../../../api/ycql/quick-start/).
 - installed Go version 1.13 or later.
 
-## Install the Go Cassandra driver
+## Install the Yugabyte Go Driver for YCQL
 
-To install the driver locally, run:
+To install the [Yugabyte Go Driver for YCQL](https://github.com/yugabyte/gocql) locally, run the following command:
 
 ```sh
 $ go get github.com/yugabyte/gocql
 ```
 
-## Writing a HelloWorld YCQL app
+## Write the YCQL sample application
 
 Create a file `ybcql_hello_world.go` and copy the contents below.
 
@@ -121,9 +121,9 @@ func main() {
 }
 ```
 
-## Running the application
+## Run the Go application
 
-To execute the file, run the following command:
+To use the application, run the following command:
 
 ```sh
 $ go run ybcql_hello_world.go

--- a/docs/content/latest/quick-start/build-apps/go/ycql.md
+++ b/docs/content/latest/quick-start/build-apps/go/ycql.md
@@ -41,7 +41,7 @@ showAsideToc: true
 
 This tutorial assumes that you have:
 
-- installed YugabyteDB, created a universe, and are able to interact with it using the YCQL shell. If not, follow the steps in [YCQL quick start](../../../../api/ycql/quick-start/).
+- installed YugabyteDB, created a universe, and are able to interact with it using the YCQL shell. If not, follow the steps in [Quick start YCQL](../../../../api/ycql/quick-start/).
 - installed Go version 1.13 or later.
 
 ## Install the Yugabyte Go Driver for YCQL

--- a/docs/content/latest/quick-start/build-apps/java/ycql.md
+++ b/docs/content/latest/quick-start/build-apps/java/ycql.md
@@ -53,7 +53,7 @@ To build a sample Java application with the [Yugabyte Java Driver for YCQL](http
 
 This tutorial assumes that you have:
 
-- installed YugabyteDB, created a universe, and are able to interact with it using the YCQL shell. If not, follow the steps in [YCQL quick start](../../../../api/ycql/quick-start/).
+- installed YugabyteDB, created a universe, and are able to interact with it using the YCQL shell. If not, follow the steps in [Quick start YCQL](../../../../api/ycql/quick-start/).
 - installed JDK version 1.8 or later.
 - installed Maven 3.3 or later.
 

--- a/docs/content/latest/quick-start/build-apps/java/ycql.md
+++ b/docs/content/latest/quick-start/build-apps/java/ycql.md
@@ -2,7 +2,7 @@
 title: Build a Java application that uses YCQL
 headerTitle: Build a Java application
 linkTitle: Java
-description: Build a Java application that uses YCQL.
+description: Build a sample Java application with the Yugabyte Java Driver for YCQL.
 menu:
   latest:
     parent: build-apps
@@ -37,7 +37,7 @@ showAsideToc: true
 
 ## Maven
 
-To build your Java application using the YugabyteDB Cassandra driver, add the following Maven dependency to your application:
+To build a sample Java application with the [Yugabyte Java Driver for YCQL](https://github.com/yugabyte/cassandra-java-driver), add the following Maven dependency to your application:
 
 ```mvn
 <dependency>
@@ -47,14 +47,15 @@ To build your Java application using the YugabyteDB Cassandra driver, add the fo
 </dependency>
 ```
 
-## Working Example
+## Create a Java sample application
 
 ### Prerequisites
 
 This tutorial assumes that you have:
 
-- installed YugabyteDB, created a universe and are able to interact with it using the YCQL shell. If not, please follow these steps in the [quick start guide](../../../../api/ycql/quick-start/).
-- installed JDK version 1.8+ and maven 3.3+
+- installed YugabyteDB, created a universe, and are able to interact with it using the YCQL shell. If not, follow the steps in [YCQL quick start](../../../../api/ycql/quick-start/).
+- installed JDK version 1.8 or later.
+- installed Maven 3.3 or later.
 
 ### Create the Maven build file
 
@@ -108,7 +109,7 @@ Create a maven build file `pom.xml` and add the following content into it.
 </project>
 ```
 
-### Write a sample application
+### Write a sample Java application
 
 Create the appropriate directory structure as expected by Maven.
 

--- a/docs/content/latest/quick-start/build-apps/java/ycql.md
+++ b/docs/content/latest/quick-start/build-apps/java/ycql.md
@@ -59,7 +59,7 @@ This tutorial assumes that you have:
 
 ### Create the Maven build file
 
-Create a maven build file `pom.xml` and add the following content into it.
+Create a Maven build file, named `pom.xml`, and add the following content into it.
 
 ```mvn
 <?xml version="1.0"?>

--- a/docs/content/latest/quick-start/build-apps/nodejs/ycql.md
+++ b/docs/content/latest/quick-start/build-apps/nodejs/ycql.md
@@ -49,7 +49,7 @@ $ npm install yb-ycql-driver
 
 This tutorial assumes that you have:
 
-- installed YugabyteDB, created a universe, and are able to interact with it using the YCQL shell. If not, follow these steps in [YCQL quick start guide](../../../../api/ycql/quick-start/).
+- installed YugabyteDB, created a universe, and are able to interact with it using the YCQL shell. If not, follow these steps in [Quick start YCQL guide](../../../../api/ycql/quick-start/).
 - installed a recent version of [Node.js](https://nodejs.org/en/download/).
 - installed the JavaScript [async](https://github.com/caolan/async) utility to work with asynchronous Javascript. To install `async`, run the following command:
 

--- a/docs/content/latest/quick-start/build-apps/nodejs/ycql.md
+++ b/docs/content/latest/quick-start/build-apps/nodejs/ycql.md
@@ -35,30 +35,29 @@ showAsideToc: true
   </li>
 </ul>
 
-## Install the NodeJS driver
+## Install the Yugabyte Node.js driver for YCQL
 
-Install the YugabyteDB NodeJS driver for YCQL using the following command. You can find the source for the driver [here](https://github.com/yugabyte/cassandra-nodejs-driver).
+To install the [YugabyteDB Node.js driver for YCQL](https://github.com/yugabyte/cassandra-nodejs-driver), run the following `npm install` command:
 
 ```sh
 $ npm install yb-ycql-driver
 ```
 
-## Working example
+## Create a Node.js sample application
 
 ### Prerequisites
 
 This tutorial assumes that you have:
 
-- installed YugabyteDB, created a universe and are able to interact with it using the YCQL shell. If not, please follow these steps in the [quick start guide](../../../../api/ycql/quick-start/).
-- installed a recent version of `node`. If not, you can find install instructions [here](https://nodejs.org/en/download/).
-
-We will be using the [async](https://github.com/caolan/async) JS utility to work with asynchronous Javascript. Install this by running the following command:
+- installed YugabyteDB, created a universe, and are able to interact with it using the YCQL shell. If not, follow these steps in [YCQL quick start guide](../../../../api/ycql/quick-start/).
+- installed a recent version of [Node.js](https://nodejs.org/en/download/).
+- installed the JavaScript [async](https://github.com/caolan/async) utility to work with asynchronous Javascript. To install `async`, run the following command:
 
 ```sh
 $ npm install --save async
 ```
 
-### Write the JavaScript code
+### Write the Node.js sample application
 
 Create a file `yb-cql-helloworld.js` and add the following content to it.
 
@@ -122,9 +121,9 @@ async.series([
 });
 ```
 
-### Run the application
+### Run the Node.js application
 
-To run the application, type the following:
+To use the application, run the following command:
 
 ```sh
 $ node yb-cql-helloworld.js

--- a/docs/content/latest/quick-start/build-apps/nodejs/ycql.md
+++ b/docs/content/latest/quick-start/build-apps/nodejs/ycql.md
@@ -1,8 +1,8 @@
 ---
-title: Build a NodeJS application that uses YCQL
-headerTitle: Build a NodeJS application
+title: Build a Node.js application that uses YCQL
+headerTitle: Build a Node.js application
 linkTitle: NodeJS
-description: Build a NodeJS application that uses YCQL
+description: Build a Node.js application with the Yugabyte Node.js driver for YCQL.
 menu:
   latest:
     parent: build-apps
@@ -57,7 +57,7 @@ This tutorial assumes that you have:
 $ npm install --save async
 ```
 
-### Write the Node.js sample application
+### Write the application
 
 Create a file `yb-cql-helloworld.js` and add the following content to it.
 
@@ -121,7 +121,7 @@ async.series([
 });
 ```
 
-### Run the Node.js application
+### Run the application
 
 To use the application, run the following command:
 

--- a/docs/content/latest/quick-start/build-apps/python/ycql.md
+++ b/docs/content/latest/quick-start/build-apps/python/ycql.md
@@ -2,7 +2,7 @@
 title: Build a Python application that uses YCQL
 headerTitle: Build a Python application
 linkTitle: Python
-description: Build a Python application that uses YCQL.
+description: Build a Python application with the Yugabyte Python Driver for YCQL.
 menu:
   latest:
     parent: build-apps
@@ -51,7 +51,7 @@ This tutorial assumes that you have:
 
 - installed YugabyteDB, created a universe, and are able to interact with it using the YCQL shell. If not, follow the steps in [YCQL quick start](../../../../api/ycql/quick-start/).
 
-### Write the Python sample application
+### Write the application
 
 Create a file `yb-cql-helloworld.py` and add the following content to it.
 
@@ -93,7 +93,7 @@ for row in rows:
 cluster.shutdown()
 ```
 
-### Run the Python application
+### Run the application
 
 To use the application, run the following command:
 

--- a/docs/content/latest/quick-start/build-apps/python/ycql.md
+++ b/docs/content/latest/quick-start/build-apps/python/ycql.md
@@ -37,7 +37,7 @@ showAsideToc: true
 
 ## Install the Yugabyte Python Driver for YCQL
 
-To install the [Yugabyte Python Driver for YCQL](https://github.com/yugabyte/yb-cassandra--driver), run the following command:
+To install the [Yugabyte Python Driver for YCQL](https://github.com/yugabyte/cassandra-python-driver), run the following command:
 
 ```sh
 $ pip install yb-cassandra-driver
@@ -49,7 +49,7 @@ $ pip install yb-cassandra-driver
 
 This tutorial assumes that you have:
 
-- installed YugabyteDB, created a universe, and are able to interact with it using the YCQL shell. If not, follow the steps in [YCQL quick start](../../../../api/ycql/quick-start/).
+- installed YugabyteDB, created a universe, and are able to interact with it using the YCQL shell. If not, follow the steps in [Quick start YCQL](../../../../api/ycql/quick-start/).
 
 ### Write the application
 

--- a/docs/content/latest/quick-start/build-apps/python/ycql.md
+++ b/docs/content/latest/quick-start/build-apps/python/ycql.md
@@ -35,25 +35,23 @@ showAsideToc: true
   </li>
 </ul>
 
+## Install the Yugabyte Python Driver for YCQL
 
-## Installation
-
-Install the python driver using the following command.
+To install the [Yugabyte Python Driver for YCQL](https://github.com/yugabyte/yb-cassandra--driver), run the following command:
 
 ```sh
 $ pip install yb-cassandra-driver
 ```
 
-## Working Example
+## Create a sample Python application
 
 ### Prerequisites
 
 This tutorial assumes that you have:
 
-- installed YugabyteDB, created a universe and are able to interact with it using the YCQL shell. If not, please follow these steps in the [quick start guide](../../../../api/ycql/quick-start/).
+- installed YugabyteDB, created a universe, and are able to interact with it using the YCQL shell. If not, follow the steps in [YCQL quick start](../../../../api/ycql/quick-start/).
 
-
-### Writing the python code
+### Write the Python sample application
 
 Create a file `yb-cql-helloworld.py` and add the following content to it.
 
@@ -95,9 +93,9 @@ for row in rows:
 cluster.shutdown()
 ```
 
-### Running the application
+### Run the Python application
 
-To run the application, type the following:
+To use the application, run the following command:
 
 ```sh
 $ python yb-cql-helloworld.py

--- a/docs/content/latest/quick-start/build-apps/ruby/ycql.md
+++ b/docs/content/latest/quick-start/build-apps/ruby/ycql.md
@@ -2,7 +2,7 @@
 title: Build a Ruby application that uses YCQL
 headerTitle: Build a Ruby application
 linkTitle: Ruby
-description: Build a Ruby application that uses YCQL.
+description: Build a Ruby application with the Yugabyte Ruby Driver for YCQL.
 menu:
   latest:
     parent: build-apps
@@ -37,7 +37,7 @@ showAsideToc: true
 
 ## Install the Yugabyte Ruby Driver for YCQL
 
-Install the [Yugabyte Ruby Driver for YCQL](https://github.com/yugabyte/cassandra-ruby-driver) using the following command:
+Install the [Yugabyte Ruby Driver for YCQL](https://github.com/yugabyte/cassandra-ruby-driver) by running the following command:
 
 ```sh
 $ gem install yugabyte-ycql-driver
@@ -51,7 +51,7 @@ This tutorial assumes that you have:
 
 - installed YugabyteDB, created a universe, and are able to interact with it using the YCQL shell. If not, follow the steps in [Quick start YCQL](../../../../api/ycql/quick-start/).
 
-### Write the Ruby sample HelloWorld application
+### Write the application
 
 Create a file `yb-ycql-helloworld.rb` and add the following content to it.
 

--- a/docs/content/latest/quick-start/build-apps/ruby/ycql.md
+++ b/docs/content/latest/quick-start/build-apps/ruby/ycql.md
@@ -35,23 +35,23 @@ showAsideToc: true
   </li>
 </ul>
 
-## Installation
+## Install the Yugabyte Ruby Driver for YCQL
 
-Install the Ruby YCQL driver using the following command. You can get further details for the driver [here](https://github.com/yugabyte/cassandra-ruby-driver).
+Install the [Yugabyte Ruby Driver for YCQL](https://github.com/yugabyte/cassandra-ruby-driver) using the following command:
 
 ```sh
 $ gem install yugabyte-ycql-driver
 ```
 
-## Working example
+## Create a sample Ruby application
 
 ### Prerequisites
 
 This tutorial assumes that you have:
 
-- installed YugabyteDB, created a universe and are able to interact with it using the YCQL shell. If not, please follow these steps in the [quick start guide](../../../../api/ycql/quick-start/).
+- installed YugabyteDB, created a universe, and are able to interact with it using the YCQL shell. If not, follow the steps in [Quick start YCQL](../../../../api/ycql/quick-start/).
 
-### Writing the Ruby code
+### Write the Ruby sample HelloWorld application
 
 Create a file `yb-ycql-helloworld.rb` and add the following content to it.
 
@@ -94,9 +94,9 @@ end
 cluster.close()
 ```
 
-### Running the application
+### Run the application
 
-To run the application, type the following:
+To use the application, run the following command:
 
 ```sh
 $ ruby yb-cql-helloworld.rb

--- a/docs/content/latest/quick-start/build-apps/scala/ycql.md
+++ b/docs/content/latest/quick-start/build-apps/scala/ycql.md
@@ -27,25 +27,25 @@ showAsideToc: true
 
 ## sbt
 
-To build your Java application using the Yugabyte Java Driver for YCQL, add the following `sbt` (Scala build tool) dependency to your application:
+To build a Scala application using the [Yugabyte Java Driver for YCQL](), you must add the following `sbt` (Scala build tool) dependency to your application:
 
 ```sbt
 libraryDependencies += "com.yugabyte" % "cassandra-driver-core" % "3.8.0-yb-5"
 ```
 
-## Working example
+## Create a sample Scala application
 
 ### Prerequisites
 
 This tutorial assumes that you have:
 
-- installed YugabyteDB, created a universe and are able to interact with it using the YCQL shell. If not, follow the steps in [YCQL Quick start](../../../../api/ycql/quick-start/).
+- installed YugabyteDB, created a universe, and are able to interact with it using the YCQL shell. If not, follow the steps in [YCQL Quick start](../../../../api/ycql/quick-start/).
 - installed Scala version 2.12 or later.
 - installed `sbt` (Scala build tool) 1.3.8 or later.
 
-### Create the sbt build file
+### Create a `sbt` build file
 
-Create a sbt build file `build.sbt` and add the following content into it.
+Create a `sbt` build file, named `build.sbt`, and add the following content into it.
 
 ```sbt
 name := "YBCqlHelloWorld"
@@ -57,7 +57,7 @@ scalacOptions := Seq("-unchecked", "-deprecation")
 libraryDependencies += "com.yugabyte" % "cassandra-driver-core" % "3.2.0-yb-19"
 ```
 
-### Write a sample application
+### Write the Scala sample application
 
 Copy the following contents into the file `YBCqlHelloWorld.scala`.
 
@@ -158,4 +158,3 @@ Created table employee
 Inserted data: INSERT INTO ybdemo.employee (id, name, age, language) VALUES (1, 'John', 35, 'Scala');
 Query returned 1 row: name=John, age=35, language=Scala
 ```
-

--- a/docs/content/latest/quick-start/build-apps/scala/ycql.md
+++ b/docs/content/latest/quick-start/build-apps/scala/ycql.md
@@ -2,7 +2,7 @@
 title: Build a Scala application that uses YCQL
 headerTitle: Build a Scala application
 linkTitle: Scala
-description: Build a Scala application that uses YCQL.
+description: Build a Scala application with the Yugabyte Java Driver for YCQL and sbt dependency.
 menu:
   latest:
     parent: build-apps
@@ -27,7 +27,7 @@ showAsideToc: true
 
 ## sbt
 
-To build a Scala application using the [Yugabyte Java Driver for YCQL](), you must add the following `sbt` (Scala build tool) dependency to your application:
+To build a Scala application using the [Yugabyte Java Driver for YCQL](https://github.com/yugabyte/cassandra-java-driver), you must add the following `sbt` (Scala build tool) dependency to your application:
 
 ```sbt
 libraryDependencies += "com.yugabyte" % "cassandra-driver-core" % "3.8.0-yb-5"
@@ -39,7 +39,7 @@ libraryDependencies += "com.yugabyte" % "cassandra-driver-core" % "3.8.0-yb-5"
 
 This tutorial assumes that you have:
 
-- installed YugabyteDB, created a universe, and are able to interact with it using the YCQL shell. If not, follow the steps in [YCQL Quick start](../../../../api/ycql/quick-start/).
+- installed YugabyteDB, created a universe, and are able to interact with it using the YCQL shell. If not, follow the steps in [YCQL quick start](../../../../api/ycql/quick-start/).
 - installed Scala version 2.12 or later.
 - installed `sbt` (Scala build tool) 1.3.8 or later.
 

--- a/docs/content/latest/quick-start/build-apps/scala/ycql.md
+++ b/docs/content/latest/quick-start/build-apps/scala/ycql.md
@@ -25,24 +25,23 @@ showAsideToc: true
   </li>
 </ul>
 
-
-
 ## sbt
 
-To build your Java application using the YugabyteDB Java driver for YCQL, add the following sbt dependency to your application:
+To build your Java application using the Yugabyte Java Driver for YCQL, add the following `sbt` (Scala build tool) dependency to your application:
 
 ```sbt
-libraryDependencies += "com.yugabyte" % "cassandra-driver-core" % "3.2.0-yb-19"
+libraryDependencies += "com.yugabyte" % "cassandra-driver-core" % "3.8.0-yb-5"
 ```
 
-## Working Example
+## Working example
 
 ### Prerequisites
 
 This tutorial assumes that you have:
 
-- installed YugabyteDB, created a universe and are able to interact with it using the YCQL shell. If not, please follow these steps in the [quick start guide](../../../../api/ycql/quick-start/).
-- installed Scala version 2.12+ and sbt 1.3.8+
+- installed YugabyteDB, created a universe and are able to interact with it using the YCQL shell. If not, follow the steps in [YCQL Quick start](../../../../api/ycql/quick-start/).
+- installed Scala version 2.12 or later.
+- installed `sbt` (Scala build tool) 1.3.8 or later.
 
 ### Create the sbt build file
 
@@ -58,7 +57,7 @@ scalacOptions := Seq("-unchecked", "-deprecation")
 libraryDependencies += "com.yugabyte" % "cassandra-driver-core" % "3.2.0-yb-19"
 ```
 
-### Writing a sample app
+### Write a sample application
 
 Copy the following contents into the file `YBCqlHelloWorld.scala`.
 
@@ -137,16 +136,15 @@ object YBCqlHelloWorld {
 } // object YBCqlHelloWorld
 ```
 
-
 ### Build and run the application
 
-To build the application, just run the following command.
+To build the application, run the following command:
 
 ```sh
 $ sbt compile
 ```
 
-To run the program, run the following command.
+To run the program, run the following command:
 
 ```sh
 $ sbt run

--- a/docs/content/latest/quick-start/build-apps/scala/ycql.md
+++ b/docs/content/latest/quick-start/build-apps/scala/ycql.md
@@ -39,7 +39,7 @@ libraryDependencies += "com.yugabyte" % "cassandra-driver-core" % "3.8.0-yb-5"
 
 This tutorial assumes that you have:
 
-- installed YugabyteDB, created a universe, and are able to interact with it using the YCQL shell. If not, follow the steps in [YCQL quick start](../../../../api/ycql/quick-start/).
+- installed YugabyteDB, created a universe, and are able to interact with it using the YCQL shell. If not, follow the steps in [Quick start YCQL](../../../../api/ycql/quick-start/).
 - installed Scala version 2.12 or later.
 - installed `sbt` (Scala build tool) 1.3.8 or later.
 

--- a/docs/content/latest/reference/drivers/_index.md
+++ b/docs/content/latest/reference/drivers/_index.md
@@ -51,13 +51,13 @@ menu:
   </div>
 
   <div class="col-12 col-md-6 col-lg-12 col-xl-6">
-   <a class="section-link icon-offset" href="../../quick-start/build-apps">
+   <a class="section-link icon-offset" href="ycql-client-libraries">
      <div class="head">
        <img class="icon" src="/images/section_icons/index/api.png" aria-hidden="true" />
-       <div class="title">Other Drivers</div>
+       <div class="title">API client drivers for YCQL</div>
      </div>
      <div class="body">
-       Build your applications using other YSQL & YCQL drivers and ORMs.
+       Build your applications using these supported YCQL drivers.
      </div>
    </a>
   </div>

--- a/docs/content/latest/reference/drivers/ycql-client-libraries
+++ b/docs/content/latest/reference/drivers/ycql-client-libraries
@@ -24,7 +24,7 @@ For tutorials on building a sample application with the following API client dri
 
 The [Yugabyte C++ Driver for YCQL](https://github.com/yugabyte/cassandra-cpp-driver) is based on the [DataStax C++ Driver for Apache Cassandra](https://github.com/datastax/cpp-driver).
 
-For details, see the [README](https://github.com/yugabyte/cassandra-cpp-driver) in our `yugabyte/cassandra-cpp-driver` GitHub repository.
+For details, see the [README](https://github.com/yugabyte/cassandra-cpp-driver) in our GitHub repository.
 
 For a tutorial on building a sample C++ application with this driver, see [Build a C++ application](https://docs.yugabyte.com/latest/quick-start/build-apps/cpp/ycql/).
 
@@ -34,7 +34,7 @@ For a tutorial on building a sample C++ application with this driver, see [Build
 
 The [Yugabyte C# Driver for YCQL](https://github.com/yugabyte/cassandra-csharp-driver) is based on a fork of the [DataStax C# Driver for Apache Cassandra](https://github.com/datastax/csharp-driver). 
 
-For details, see the [README](https://github.com/yugabyte/cassandra-csharp-driver) in our `yugabyte/cassandra-csharp-driver` GitHub repository.
+For details, see the [README](https://github.com/yugabyte/cassandra-csharp-driver) in our GitHub repository.
 
 For a tutorial on building a sample C# application with this driver, see [Build a C# application](https://docs.yugabyte.com/latest/quick-start/build-apps/csharp/ycql/).
 
@@ -54,7 +54,7 @@ For a tutorial on building a sample Go application with this driver, see [Build 
 
 The [Yugabyte Java Driver for YCQL](https://github.com/yugabyte/cassandra-java-driver) is based on the [DataStax Java Driver for Apache Cassandra](https://github.com/datastax/java-driver) and requires the Maven dependency shown below. 
 
-For details, see the [README](https://github.com/yugabyte/cassandra-java-driver/blob/3.8.0-yb-x/README.md) in our `yugabyte/cassandra-java-driver` GitHub repository.
+For details, see the [README](https://github.com/yugabyte/cassandra-java-driver/blob/3.8.0-yb-x/README.md) in our GitHub repository.
 
 To build Java applications with this driver, you must add the following Maven dependency to your application:
 
@@ -82,9 +82,9 @@ For a tutorial on building a sample Node.js application with this driver, see [B
 
 ### Yugabyte Python Driver for YCQL
 
-The [Yugabyte Python Driver for YCQL](https://github.com/yugabyte/yb-cassandra--driver) is based on a fork of the [DataStax Python Driver for Apache Cassandra](https://github.com/datastax/yb-cassandra-driver).
+The [Yugabyte Python Driver for YCQL](https://github.com/yugabyte/cassandra-python-driver) is based on a fork of the [DataStax Python Driver for Apache Cassandra](https://github.com/datastax/python-driver).
 
-For details, see the [README](https://github.com/yugabyte/cassandra-ruby-driver/blob/v3.2.3.x-yb/README.md) in the `yugabyte/cassandra-ruby-driver` GitHub repository.
+For details, see the [README](https://github.com/yugabyte/cassandra-python-driver) in our GitHub repository.
 
 For a tutorial on building a sample Python application with this driver, see [Build a Python application](https://docs.yugabyte.com/latest/quick-start/build-apps/python/ycql/).
 
@@ -94,7 +94,7 @@ For a tutorial on building a sample Python application with this driver, see [Bu
 
 The [Yugabyte Ruby Driver for YCQL](https://github.com/yugabyte/cassandra-ruby-driver) is based on a fork of the [DataStax Ruby Driver for Apache Cassandra](https://github.com/datastax/ruby-driver).
 
-For details, see the [README](https://github.com/yugabyte/cassandra-ruby-driver/blob/v3.2.3.x-yb/README.md) in the `yugabyte/cassandra-ruby-driver` GitHub repository.
+For details, see the [README](https://github.com/yugabyte/cassandra-ruby-driver/blob/v3.2.3.x-yb/README.md) in our GitHub repository.
 
 For a tutorial on building a sample Ruby application with this driver, see [Build a Ruby application](https://docs.yugabyte.com/latest/quick-start/build-apps/ruby/ycql/).
 
@@ -104,7 +104,7 @@ For a tutorial on building a sample Ruby application with this driver, see [Buil
 
 The [Yugabyte Java Driver for YCQL](https://github.com/yugabyte/cassandra-java-driver) is based on a fork of the [DataStax Java Driver for Apache Cassandra](https://github.com/datastax/java-driver) and can be used to build Scala applications when you add the [`sbt` (Scala build tool)](https://www.scala-sbt.org/1.x/docs/index.html) dependency shown below to your application.
 
-For details, see the [README](https://github.com/yugabyte/cassandra-java-driver/blob/3.8.0-yb-x/README.md) in our `yugabyte/cassandra-java-driver` GitHub repository.
+For details, see the [README](https://github.com/yugabyte/cassandra-java-driver/blob/3.8.0-yb-x/README.md) in our GitHub repository.
 
 To build a Scala application with the Yugabyte Java Driver for YCQL, you must add the following `sbt` dependency to your application:
 

--- a/docs/content/latest/reference/drivers/ycql-client-libraries
+++ b/docs/content/latest/reference/drivers/ycql-client-libraries
@@ -55,3 +55,22 @@ The [Yugabyte Ruby Driver for YCQL](https://github.com/yugabyte/cassandra-ruby-d
 For details, see the [README](https://github.com/yugabyte/cassandra-ruby-driver/blob/v3.2.3.x-yb/README.md) in the `yugabyte/cassandra-ruby-driver` GitHub repository.
 
 To build a sample application using this driver, follow the tutorial in [Build a Ruby application](https://docs.yugabyte.com/latest/quick-start/build-apps/ruby/ycql/).
+
+## Scala
+
+### Yugabyte Java Driver for YCQL
+
+The [Yugabyte Java Driver for YCQL](https://github.com/yugabyte/cassandra-java-driver) is based on the [DataStax Java Driver for Apache Cassandra](https://github.com/datastax/java-driver) and can be used to build Scala applications.
+
+For details, see the [README](https://github.com/yugabyte/cassandra-java-driver/blob/3.8.0-yb-x/README.md) in our `yugabyte/cassandra-java-driver` GitHub repository.
+
+Note
+
+To build a Scala application using the Yugabyte Java Driver for YCQL, you must add the following [`sbt` (Scala Build Tool)](https://www.scala-sbt.org/1.x/docs/index.html) dependency to your application:
+
+```
+libraryDependencies += "com.yugabyte" % "cassandra-driver-core" % "3.8.0-yb-5"
+
+```
+
+To build a sample Scala application using this driver, follow the tutorial in [Build a Scala application](https://docs.yugabyte.com/latest/quick-start/build-apps/scala/ycql/).

--- a/docs/content/latest/reference/drivers/ycql-client-libraries
+++ b/docs/content/latest/reference/drivers/ycql-client-libraries
@@ -1,8 +1,8 @@
 ---
-title: API client libraries for YCQL
-headerTitle: API client libraries for YCQL
-linkTitle: API client libraries for YCQL
-description: Lists the API client libraries that you can use to build and access YCQL applications. 
+title: API client drivers for YCQL
+headerTitle: API client drivers for YCQL
+linkTitle: API client drivers for YCQL
+description: Lists the API client library drivers that you can use to build and access YCQL applications. 
 menu:
   latest:
     identifier: ycql-client-libraries
@@ -14,20 +14,28 @@ isTocNested: true
 showAsideToc: true
 ---
 
-YugabyteDB Cassandra driver
-: 
 
-## NodeJS (`yugabyte/cassandra-nodejs-driver`)
+## C/C++ 
 
-### [YugabyteDB NodeJS driver for YCQL](https://github.com/yugabyte/cassandra-nodejs-driver)
-
-The YugabyteDB NodeJS driver for YCQL is available as a fork of the Cassandra NodeJS driver. For details, see the [README](https://github.com/datastax/cpp-driver/blob/master/README.md) in our GitHub repository. 
-
-## C++ (`yugabyte/cassandra-cpp-driver`)
-
-### [YugabyteDB C++ Driver for YCQL](https://github.com/yugabyte/cassandra-cpp-driver)
+### [YugabyteDB C++ Driver for YCQL](https://github.com/yugabyte/cassandra-cpp-driver) (`yugabyte/cassandra-cpp-driver`)
 
 Based on the [DataStax C/C++ driver](https://github.com/datastax/cpp-driver).
+
+The [Yugabyte C++ Driver for YCQL](https://github.com/yugabyte/cassandra-cpp-driver) is based on the [DataStax C++ Driver for Apache Cassandra](https://github.com/datastax/cpp-driver). 
+
+For details, see the [README](https://github.com/yugabyte/cassandra-csharp-driver/blob/3.8.0-yb-x/README.md) in our `yugabyte/cassandra-csharp-driver` GitHub repository.
+
+For a tutorial on building a sample C++ application using this driver, see [Build a C++ application](https://docs.yugabyte.com/latest/quick-start/build-apps/cplusplus/ycql/).
+
+## C# 
+
+### [YugabyteDB C# Driver for YCQL](https://github.com/yugabyte/cassandra-cpp-driver) (`yugabyte/cassandra-cpp-driver`)
+
+The [Yugabyte C# Driver for YCQL](https://github.com/yugabyte/cassandra-csharp-driver) is based on the [DataStax C# Driver for Apache Cassandra](https://github.com/datastax/csharp-driver). 
+
+For details, see the [README](https://github.com/yugabyte/cassandra-csharp-driver/blob/3.8.0-yb-x/README.md) in our `yugabyte/cassandra-csharp-driver` GitHub repository.
+
+For a tutorial on building a sample C# application using this driver, see [Build a C# application](https://docs.yugabyte.com/latest/quick-start/build-apps/csharp/ycql/).
 
 ## Go
 
@@ -35,16 +43,28 @@ Based on the [DataStax C/C++ driver](https://github.com/datastax/cpp-driver).
 
 The [Yugabyte Go Driver for YCQL](https://github.com/yugabyte/gocql) is based on [GoCQL (`gocql/gocql`)](http://gocql.github.io/). For more information, see the [README](https://github.com/yugabyte/gocql/blob/master/README.md) in the `yugabyte/gocql` GitHub repository.
 
+For a tutorial on building a sample Go application using this driver, see [Build a Go application](https://docs.yugabyte.com/latest/quick-start/build-apps/go/ycql/).
+
+## NodeJS 
+
+### [YugabyteDB NodeJS driver for YCQL](https://github.com/yugabyte/cassandra-nodejs-driver) (`yugabyte/cassandra-nodejs-driver`)
+
+The YugabyteDB NodeJS driver for YCQL is available as a fork of the Cassandra NodeJS driver. For details, see the [README](https://github.com/datastax/cpp-driver/blob/master/README.md) in our GitHub repository. 
+
+For a tutorial on building a sample NodeJS application using this driver, see [Build a NodeJS application](https://docs.yugabyte.com/latest/quick-start/build-apps/nodejs/ycql/).
+
 
 ## Java
 
-### Yugabyte Java Driver for YCQL
+### Yugabyte Java Driver for YCQL (`yugabyte/cassandra-java-driver`)
 
 The [Yugabyte Java Driver for YCQL](https://github.com/yugabyte/cassandra-java-driver) is based on the [DataStax Java Driver for Apache Cassandra](https://github.com/datastax/java-driver). 
 
 For details, see the [README](https://github.com/yugabyte/cassandra-java-driver/blob/3.8.0-yb-x/README.md) in our `yugabyte/cassandra-java-driver` GitHub repository.
 
-To build a sample application using this driver, follow the tutorial in [Build a Java application](https://docs.yugabyte.com/latest/quick-start/build-apps/java/ycql/).
+To build a sample Java application using this driver, follow the tutorial in [Build a Java application](https://docs.yugabyte.com/latest/quick-start/build-apps/java/ycql/).
+
+For a tutorial on building a sample Java application using this driver, see [Build a Java application](https://docs.yugabyte.com/latest/quick-start/build-apps/java/ycql/).
 
 ## Ruby
 
@@ -54,7 +74,7 @@ The [Yugabyte Ruby Driver for YCQL](https://github.com/yugabyte/cassandra-ruby-d
 
 For details, see the [README](https://github.com/yugabyte/cassandra-ruby-driver/blob/v3.2.3.x-yb/README.md) in the `yugabyte/cassandra-ruby-driver` GitHub repository.
 
-To build a sample application using this driver, follow the tutorial in [Build a Ruby application](https://docs.yugabyte.com/latest/quick-start/build-apps/ruby/ycql/).
+For a tutorial on building a sample Ruby application using this driver, see [Build a Ruby application](https://docs.yugabyte.com/latest/quick-start/build-apps/ruby/ycql/).
 
 ## Scala
 
@@ -64,8 +84,6 @@ The [Yugabyte Java Driver for YCQL](https://github.com/yugabyte/cassandra-java-d
 
 For details, see the [README](https://github.com/yugabyte/cassandra-java-driver/blob/3.8.0-yb-x/README.md) in our `yugabyte/cassandra-java-driver` GitHub repository.
 
-Note
-
 To build a Scala application using the Yugabyte Java Driver for YCQL, you must add the following [`sbt` (Scala Build Tool)](https://www.scala-sbt.org/1.x/docs/index.html) dependency to your application:
 
 ```
@@ -73,4 +91,4 @@ libraryDependencies += "com.yugabyte" % "cassandra-driver-core" % "3.8.0-yb-5"
 
 ```
 
-To build a sample Scala application using this driver, follow the tutorial in [Build a Scala application](https://docs.yugabyte.com/latest/quick-start/build-apps/scala/ycql/).
+For a tutorial on building a sample Scala application using this driver, see [Build a Scala application](https://docs.yugabyte.com/latest/quick-start/build-apps/scala/ycql/).

--- a/docs/content/latest/reference/drivers/ycql-client-libraries
+++ b/docs/content/latest/reference/drivers/ycql-client-libraries
@@ -1,0 +1,57 @@
+---
+title: API client libraries for YCQL
+headerTitle: API client libraries for YCQL
+linkTitle: API client libraries for YCQL
+description: Lists the API client libraries that you can use to build and access YCQL applications. 
+menu:
+  latest:
+    identifier: ycql-client-libraries
+    parent: drivers
+    weight: 2921
+aliases:
+  - /latest/reference/connectors/yugabytedb-jdbc-driver
+isTocNested: true
+showAsideToc: true
+---
+
+YugabyteDB Cassandra driver
+: 
+
+## NodeJS (`yugabyte/cassandra-nodejs-driver`)
+
+### [YugabyteDB NodeJS driver for YCQL](https://github.com/yugabyte/cassandra-nodejs-driver)
+
+The YugabyteDB NodeJS driver for YCQL is available as a fork of the Cassandra NodeJS driver. For details, see the [README](https://github.com/datastax/cpp-driver/blob/master/README.md) in our GitHub repository. 
+
+## C++ (`yugabyte/cassandra-cpp-driver`)
+
+### [YugabyteDB C++ Driver for YCQL](https://github.com/yugabyte/cassandra-cpp-driver)
+
+Based on the [DataStax C/C++ driver](https://github.com/datastax/cpp-driver).
+
+## Go
+
+## Yugabyte Go Driver for YCQL (`yugabyte/gocql`)
+
+The [Yugabyte Go Driver for YCQL](https://github.com/yugabyte/gocql) is based on [GoCQL (`gocql/gocql`)](http://gocql.github.io/). For more information, see the [README](https://github.com/yugabyte/gocql/blob/master/README.md) in the `yugabyte/gocql` GitHub repository.
+
+
+## Java
+
+### Yugabyte Java Driver for YCQL
+
+The [Yugabyte Java Driver for YCQL](https://github.com/yugabyte/cassandra-java-driver) is based on the [DataStax Java Driver for Apache Cassandra](https://github.com/datastax/java-driver). 
+
+For details, see the [README](https://github.com/yugabyte/cassandra-java-driver/blob/3.8.0-yb-x/README.md) in our `yugabyte/cassandra-java-driver` GitHub repository.
+
+To build a sample application using this driver, follow the tutorial in [Build a Java application](https://docs.yugabyte.com/latest/quick-start/build-apps/java/ycql/).
+
+## Ruby
+
+### Yugabyte Ruby Driver for YCQL (`yugabyte/cassandra-ruby-driver`)
+
+The [Yugabyte Ruby Driver for YCQL](https://github.com/yugabyte/cassandra-ruby-driver) is based on the DataStax Ruby Driver for Apache Cassandra.
+
+For details, see the [README](https://github.com/yugabyte/cassandra-ruby-driver/blob/v3.2.3.x-yb/README.md) in the `yugabyte/cassandra-ruby-driver` GitHub repository.
+
+To build a sample application using this driver, follow the tutorial in [Build a Ruby application](https://docs.yugabyte.com/latest/quick-start/build-apps/ruby/ycql/).

--- a/docs/content/latest/reference/drivers/ycql-client-libraries
+++ b/docs/content/latest/reference/drivers/ycql-client-libraries
@@ -7,88 +7,109 @@ menu:
   latest:
     identifier: ycql-client-libraries
     parent: drivers
-    weight: 2921
+    weight: 2941
 aliases:
   - /latest/reference/connectors/yugabytedb-jdbc-driver
 isTocNested: true
 showAsideToc: true
 ---
 
+The following API client library drivers are supported for use with the [Yugabyte Cloud Query Language (YCQL) API](../../../api/ycql/), a SQL-based, semi-relational API, with roots in the Apache Cassandra Query Language (CQL).
+
+For tutorials on building a sample application with the following API client drivers, click the relevant link included below for each driver.
 
 ## C/C++ 
 
-### [YugabyteDB C++ Driver for YCQL](https://github.com/yugabyte/cassandra-cpp-driver) (`yugabyte/cassandra-cpp-driver`)
+### YugabyteDB C/C++ Driver for YCQL
 
-Based on the [DataStax C/C++ driver](https://github.com/datastax/cpp-driver).
+The [Yugabyte C++ Driver for YCQL](https://github.com/yugabyte/cassandra-cpp-driver) is based on the [DataStax C++ Driver for Apache Cassandra](https://github.com/datastax/cpp-driver).
 
-The [Yugabyte C++ Driver for YCQL](https://github.com/yugabyte/cassandra-cpp-driver) is based on the [DataStax C++ Driver for Apache Cassandra](https://github.com/datastax/cpp-driver). 
+For details, see the [README](https://github.com/yugabyte/cassandra-cpp-driver) in our `yugabyte/cassandra-cpp-driver` GitHub repository.
 
-For details, see the [README](https://github.com/yugabyte/cassandra-csharp-driver/blob/3.8.0-yb-x/README.md) in our `yugabyte/cassandra-csharp-driver` GitHub repository.
-
-For a tutorial on building a sample C++ application using this driver, see [Build a C++ application](https://docs.yugabyte.com/latest/quick-start/build-apps/cplusplus/ycql/).
+For a tutorial on building a sample C++ application with this driver, see [Build a C++ application](https://docs.yugabyte.com/latest/quick-start/build-apps/cpp/ycql/).
 
 ## C# 
 
-### [YugabyteDB C# Driver for YCQL](https://github.com/yugabyte/cassandra-cpp-driver) (`yugabyte/cassandra-cpp-driver`)
+### YugabyteDB C# Driver for YCQL
 
-The [Yugabyte C# Driver for YCQL](https://github.com/yugabyte/cassandra-csharp-driver) is based on the [DataStax C# Driver for Apache Cassandra](https://github.com/datastax/csharp-driver). 
+The [Yugabyte C# Driver for YCQL](https://github.com/yugabyte/cassandra-csharp-driver) is based on a fork of the [DataStax C# Driver for Apache Cassandra](https://github.com/datastax/csharp-driver). 
 
-For details, see the [README](https://github.com/yugabyte/cassandra-csharp-driver/blob/3.8.0-yb-x/README.md) in our `yugabyte/cassandra-csharp-driver` GitHub repository.
+For details, see the [README](https://github.com/yugabyte/cassandra-csharp-driver) in our `yugabyte/cassandra-csharp-driver` GitHub repository.
 
-For a tutorial on building a sample C# application using this driver, see [Build a C# application](https://docs.yugabyte.com/latest/quick-start/build-apps/csharp/ycql/).
+For a tutorial on building a sample C# application with this driver, see [Build a C# application](https://docs.yugabyte.com/latest/quick-start/build-apps/csharp/ycql/).
 
 ## Go
 
-## Yugabyte Go Driver for YCQL (`yugabyte/gocql`)
+## Yugabyte Go Driver for YCQL
 
-The [Yugabyte Go Driver for YCQL](https://github.com/yugabyte/gocql) is based on [GoCQL (`gocql/gocql`)](http://gocql.github.io/). For more information, see the [README](https://github.com/yugabyte/gocql/blob/master/README.md) in the `yugabyte/gocql` GitHub repository.
+The [Yugabyte Go Driver for YCQL](https://github.com/yugabyte/gocql) is based on a fork of [GoCQL](http://gocql.github.io/). 
 
-For a tutorial on building a sample Go application using this driver, see [Build a Go application](https://docs.yugabyte.com/latest/quick-start/build-apps/go/ycql/).
+For details, see the [README](https://github.com/yugabyte/gocql/blob/master/README.md) in our GitHub repository.
 
-## NodeJS 
-
-### [YugabyteDB NodeJS driver for YCQL](https://github.com/yugabyte/cassandra-nodejs-driver) (`yugabyte/cassandra-nodejs-driver`)
-
-The YugabyteDB NodeJS driver for YCQL is available as a fork of the Cassandra NodeJS driver. For details, see the [README](https://github.com/datastax/cpp-driver/blob/master/README.md) in our GitHub repository. 
-
-For a tutorial on building a sample NodeJS application using this driver, see [Build a NodeJS application](https://docs.yugabyte.com/latest/quick-start/build-apps/nodejs/ycql/).
-
+For a tutorial on building a sample Go application with this driver, see [Build a Go application](https://docs.yugabyte.com/latest/quick-start/build-apps/go/ycql/).
 
 ## Java
 
-### Yugabyte Java Driver for YCQL (`yugabyte/cassandra-java-driver`)
+### Yugabyte Java Driver for YCQL
 
-The [Yugabyte Java Driver for YCQL](https://github.com/yugabyte/cassandra-java-driver) is based on the [DataStax Java Driver for Apache Cassandra](https://github.com/datastax/java-driver). 
+The [Yugabyte Java Driver for YCQL](https://github.com/yugabyte/cassandra-java-driver) is based on the [DataStax Java Driver for Apache Cassandra](https://github.com/datastax/java-driver) and requires the Maven dependency shown below. 
 
 For details, see the [README](https://github.com/yugabyte/cassandra-java-driver/blob/3.8.0-yb-x/README.md) in our `yugabyte/cassandra-java-driver` GitHub repository.
 
-To build a sample Java application using this driver, follow the tutorial in [Build a Java application](https://docs.yugabyte.com/latest/quick-start/build-apps/java/ycql/).
+To build Java applications with this driver, you must add the following Maven dependency to your application:
 
-For a tutorial on building a sample Java application using this driver, see [Build a Java application](https://docs.yugabyte.com/latest/quick-start/build-apps/java/ycql/).
+```mvn
+<dependency>
+  <groupId>com.yugabyte</groupId>
+  <artifactId>cassandra-driver-core</artifactId>
+  <version>3.2.0-yb-18</version>
+</dependency>
+```
 
-## Ruby
+For a tutorial on building a sample Java application with this driver, see [Build a Java application](https://docs.yugabyte.com/latest/quick-start/build-apps/java/ycql/).
 
-### Yugabyte Ruby Driver for YCQL (`yugabyte/cassandra-ruby-driver`)
+## NodeJS 
 
-The [Yugabyte Ruby Driver for YCQL](https://github.com/yugabyte/cassandra-ruby-driver) is based on the DataStax Ruby Driver for Apache Cassandra.
+### YugabyteDB Node.js driver for YCQL
+
+The [YugabyteDB Node.js driver for YCQL](https://github.com/yugabyte/cassandra-nodejs-driver) is based on a fork of the [DataStax Node.js Driver for Apache Cassandra](https://github.com/datastax/nodejs-driver). 
+
+For details, see the [README](https://github.com/datastax/cpp-driver/blob/master/README.md) in our GitHub repository. 
+
+For a tutorial on building a sample Node.js application with this driver, see [Build a NodeJS application](https://docs.yugabyte.com/latest/quick-start/build-apps/nodejs/ycql/).
+
+## Python
+
+### Yugabyte Python Driver for YCQL
+
+The [Yugabyte Python Driver for YCQL](https://github.com/yugabyte/yb-cassandra--driver) is based on a fork of the [DataStax Python Driver for Apache Cassandra](https://github.com/datastax/yb-cassandra-driver).
 
 For details, see the [README](https://github.com/yugabyte/cassandra-ruby-driver/blob/v3.2.3.x-yb/README.md) in the `yugabyte/cassandra-ruby-driver` GitHub repository.
 
-For a tutorial on building a sample Ruby application using this driver, see [Build a Ruby application](https://docs.yugabyte.com/latest/quick-start/build-apps/ruby/ycql/).
+For a tutorial on building a sample Python application with this driver, see [Build a Python application](https://docs.yugabyte.com/latest/quick-start/build-apps/python/ycql/).
+
+## Ruby
+
+### Yugabyte Ruby Driver for YCQL
+
+The [Yugabyte Ruby Driver for YCQL](https://github.com/yugabyte/cassandra-ruby-driver) is based on a fork of the [DataStax Ruby Driver for Apache Cassandra](https://github.com/datastax/ruby-driver).
+
+For details, see the [README](https://github.com/yugabyte/cassandra-ruby-driver/blob/v3.2.3.x-yb/README.md) in the `yugabyte/cassandra-ruby-driver` GitHub repository.
+
+For a tutorial on building a sample Ruby application with this driver, see [Build a Ruby application](https://docs.yugabyte.com/latest/quick-start/build-apps/ruby/ycql/).
 
 ## Scala
 
 ### Yugabyte Java Driver for YCQL
 
-The [Yugabyte Java Driver for YCQL](https://github.com/yugabyte/cassandra-java-driver) is based on the [DataStax Java Driver for Apache Cassandra](https://github.com/datastax/java-driver) and can be used to build Scala applications.
+The [Yugabyte Java Driver for YCQL](https://github.com/yugabyte/cassandra-java-driver) is based on a fork of the [DataStax Java Driver for Apache Cassandra](https://github.com/datastax/java-driver) and can be used to build Scala applications when you add the [`sbt` (Scala build tool)](https://www.scala-sbt.org/1.x/docs/index.html) dependency shown below to your application.
 
 For details, see the [README](https://github.com/yugabyte/cassandra-java-driver/blob/3.8.0-yb-x/README.md) in our `yugabyte/cassandra-java-driver` GitHub repository.
 
-To build a Scala application using the Yugabyte Java Driver for YCQL, you must add the following [`sbt` (Scala Build Tool)](https://www.scala-sbt.org/1.x/docs/index.html) dependency to your application:
+To build a Scala application with the Yugabyte Java Driver for YCQL, you must add the following `sbt` dependency to your application:
 
 ```
 libraryDependencies += "com.yugabyte" % "cassandra-driver-core" % "3.8.0-yb-5"
-
 ```
 
-For a tutorial on building a sample Scala application using this driver, see [Build a Scala application](https://docs.yugabyte.com/latest/quick-start/build-apps/scala/ycql/).
+For a tutorial on building a sample Scala application with this driver, see [Build a Scala application](https://docs.yugabyte.com/latest/quick-start/build-apps/scala/ycql/).

--- a/docs/content/latest/reference/drivers/ycql-client-libraries.md
+++ b/docs/content/latest/reference/drivers/ycql-client-libraries.md
@@ -18,9 +18,9 @@ The following API client library drivers are supported for use with the [Yugabyt
 
 For tutorials on building a sample application with the following API client drivers, click the relevant link included below for each driver.
 
-## C/C++ 
+## C/C++
 
-### YugabyteDB C/C++ Driver for YCQL
+### Yugabyte C/C++ Driver for YCQL
 
 The [Yugabyte C++ Driver for YCQL](https://github.com/yugabyte/cassandra-cpp-driver) is based on the [DataStax C++ Driver for Apache Cassandra](https://github.com/datastax/cpp-driver).
 
@@ -28,11 +28,11 @@ For details, see the [README](https://github.com/yugabyte/cassandra-cpp-driver) 
 
 For a tutorial on building a sample C++ application with this driver, see [Build a C++ application](https://docs.yugabyte.com/latest/quick-start/build-apps/cpp/ycql/).
 
-## C# 
+## C\#
 
-### YugabyteDB C# Driver for YCQL
+### Yugabyte C# Driver for YCQL
 
-The [Yugabyte C# Driver for YCQL](https://github.com/yugabyte/cassandra-csharp-driver) is based on a fork of the [DataStax C# Driver for Apache Cassandra](https://github.com/datastax/csharp-driver). 
+The [Yugabyte C# Driver for YCQL](https://github.com/yugabyte/cassandra-csharp-driver) is based on a fork of the [DataStax C# Driver for Apache Cassandra](https://github.com/datastax/csharp-driver).
 
 For details, see the [README](https://github.com/yugabyte/cassandra-csharp-driver) in our GitHub repository.
 
@@ -42,7 +42,7 @@ For a tutorial on building a sample C# application with this driver, see [Build 
 
 ## Yugabyte Go Driver for YCQL
 
-The [Yugabyte Go Driver for YCQL](https://github.com/yugabyte/gocql) is based on a fork of [GoCQL](http://gocql.github.io/). 
+The [Yugabyte Go Driver for YCQL](https://github.com/yugabyte/gocql) is based on a fork of [GoCQL](http://gocql.github.io/).
 
 For details, see the [README](https://github.com/yugabyte/gocql/blob/master/README.md) in our GitHub repository.
 
@@ -52,7 +52,7 @@ For a tutorial on building a sample Go application with this driver, see [Build 
 
 ### Yugabyte Java Driver for YCQL
 
-The [Yugabyte Java Driver for YCQL](https://github.com/yugabyte/cassandra-java-driver) is based on the [DataStax Java Driver for Apache Cassandra](https://github.com/datastax/java-driver) and requires the Maven dependency shown below. 
+The [Yugabyte Java Driver for YCQL](https://github.com/yugabyte/cassandra-java-driver) is based on the [DataStax Java Driver for Apache Cassandra](https://github.com/datastax/java-driver) and requires the Maven dependency shown below.
 
 For details, see the [README](https://github.com/yugabyte/cassandra-java-driver/blob/3.8.0-yb-x/README.md) in our GitHub repository.
 
@@ -68,13 +68,13 @@ To build Java applications with this driver, you must add the following Maven de
 
 For a tutorial on building a sample Java application with this driver, see [Build a Java application](https://docs.yugabyte.com/latest/quick-start/build-apps/java/ycql/).
 
-## NodeJS 
+## NodeJS
 
-### YugabyteDB Node.js driver for YCQL
+### Yugabyte Node.js driver for YCQL
 
-The [YugabyteDB Node.js driver for YCQL](https://github.com/yugabyte/cassandra-nodejs-driver) is based on a fork of the [DataStax Node.js Driver for Apache Cassandra](https://github.com/datastax/nodejs-driver). 
+The [YugabyteDB Node.js driver for YCQL](https://github.com/yugabyte/cassandra-nodejs-driver) is based on a fork of the [DataStax Node.js Driver for Apache Cassandra](https://github.com/datastax/nodejs-driver).
 
-For details, see the [README](https://github.com/datastax/cpp-driver/blob/master/README.md) in our GitHub repository. 
+For details, see the [README](https://github.com/datastax/cpp-driver/blob/master/README.md) in our GitHub repository.
 
 For a tutorial on building a sample Node.js application with this driver, see [Build a NodeJS application](https://docs.yugabyte.com/latest/quick-start/build-apps/nodejs/ycql/).
 


### PR DESCRIPTION
This adds a new page in Reference > Drivers for "API client drivers for YCQL".
- Fixes inconsistent naming between names in "Build an application" section and driver titles.
- @sid We need to decide on consistent names for the drivers, either "YugabyteDB Java Driver for YCQL" or "Yugabyte Java Driver for YCQL". And, also update the names on the driver repositories.

Fixes #4902 