### PR TITLE
[Docs][#4927] Fix sidebar toggle element from wrapping on longer article titles

### DIFF
--- a/docs/styles/_yuga_overrides.scss
+++ b/docs/styles/_yuga_overrides.scss
@@ -385,7 +385,7 @@ dd {
     float: none;
     margin-bottom: 0;
     padding: 0;
-    width: 265px;
+    width: 275px;
     margin-left: -40px;
     flex-basis: auto;
   }
@@ -394,7 +394,7 @@ dd {
 .drawer {
   position: relative !important;
   nav {
-    width: 265px;
+    width: 275px;
     .scrollable {
       padding-left: 40px;
     }
@@ -583,7 +583,6 @@ h1, h2, h3, h4, h5, h6 {
 
           a.node-toggle {
             color: $YB_LIGHT_BLUE;
-
             > i {
               font-size: 12px;
             }
@@ -595,8 +594,9 @@ h1, h2, h3, h4, h5, h6 {
         margin-left: 10px;
         border-left: none;
 
-        a {
+        a:not(.node-toggle) {
           padding-left: 0px;
+          max-width: 85%;
         }
       }
 
@@ -604,8 +604,12 @@ h1, h2, h3, h4, h5, h6 {
         margin-left: 0;
         border-left: 1px solid $YB_ORANGE;
 
-        a {
+        > li {
           padding-left: 15px;
+        }
+
+        ul {
+          margin-left: 10px;
         }
       }
 


### PR DESCRIPTION
Also increase the sidebar width slightly.
Wide screen example of fix:
![Screen Shot 2020-06-30 at 12 40 59 PM](https://user-images.githubusercontent.com/50115930/86170810-8f65d180-bad0-11ea-895e-0b1d74233f52.png)
Wide screen another example of fix:
![Screen Shot 2020-06-30 at 12 41 15 PM](https://user-images.githubusercontent.com/50115930/86170847-9e4c8400-bad0-11ea-9d90-c6f5227af9ed.png)
Mobile view example of fix:
![Screen Shot 2020-06-30 at 12 41 41 PM](https://user-images.githubusercontent.com/50115930/86170900-ae646380-bad0-11ea-9f26-bca28b8590ef.png)
Mobile view another example of fix:
![Screen Shot 2020-06-30 at 12 41 28 PM](https://user-images.githubusercontent.com/50115930/86170916-b4f2db00-bad0-11ea-9946-0356fcc99849.png)
