### PR TITLE
[#4859] Change default value of flag metric_node_name to hostname:port

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -99,4 +99,4 @@ This is a list of people who have contributed code to the [YugabyteDB](https://g
 * [mirageyjd](https://github.com/mirageyjd)
 * [Abdallah](https://github.com/AbdallahKhaled93)
 * [Adm28](https://github.com/Adm28)
-
+* [vikramrajsitpal](https://github.com/vikramrajsitpal)

--- a/src/yb/master/master_main.cc
+++ b/src/yb/master/master_main.cc
@@ -72,13 +72,11 @@ static int MasterMain(int argc, char** argv) {
   FLAGS_rpc_bind_addresses = strings::Substitute("0.0.0.0:$0", kMasterDefaultPort);
   FLAGS_webserver_port = kMasterDefaultWebPort;
 
-
-  auto host_name = GetHostname();
-  if (host_name.ok()) {
-    FLAGS_metric_node_name = (*host_name) + ":" + std::to_string(FLAGS_webserver_port);
-  }
-  else {
-      LOG(INFO) << "Failed to get current host name, keeping default metric_node_name: " << host_name.status();
+  string host_name;
+  if (GetHostname(&host_name).ok()) {
+    FLAGS_metric_node_name = (host_name) + ":" + std::to_string(kMasterDefaultWebPort);
+  } else {
+      LOG(INFO) << "Failed to get master's host name, keeping default metric_node_name";
   }
 
   FLAGS_default_memory_limit_to_ram_ratio = 0.10;

--- a/src/yb/master/master_main.cc
+++ b/src/yb/master/master_main.cc
@@ -76,7 +76,7 @@ static int MasterMain(int argc, char** argv) {
   if (GetHostname(&host_name).ok()) {
     FLAGS_metric_node_name = strings::Substitute("$0:$1", host_name, kMasterDefaultWebPort);
   } else {
-      LOG(INFO) << "Failed to get master's host name, keeping default metric_node_name";
+    LOG(INFO) << "Failed to get master's host name, keeping default metric_node_name";
   }
 
   FLAGS_default_memory_limit_to_ram_ratio = 0.10;

--- a/src/yb/master/master_main.cc
+++ b/src/yb/master/master_main.cc
@@ -74,7 +74,7 @@ static int MasterMain(int argc, char** argv) {
 
   string host_name;
   if (GetHostname(&host_name).ok()) {
-    FLAGS_metric_node_name = (host_name) + ":" + std::to_string(kMasterDefaultWebPort);
+    FLAGS_metric_node_name = strings::Substitute("$0:$1", host_name, kMasterDefaultWebPort);
   } else {
       LOG(INFO) << "Failed to get master's host name, keeping default metric_node_name";
   }

--- a/src/yb/tserver/tablet_server_main.cc
+++ b/src/yb/tserver/tablet_server_main.cc
@@ -146,7 +146,7 @@ int TabletServerMain(int argc, char** argv) {
 
   string host_name;
   if (GetHostname(&host_name).ok()) {
-    FLAGS_metric_node_name = (host_name) + ":" + std::to_string(TabletServer::kDefaultWebPort);
+    FLAGS_metric_node_name = strings::Substitute("$0:$1", host_name, TabletServer::kDefaultWebPort);
   } else {
       LOG(INFO) << "Failed to get tablet's host name, keeping default metric_node_name";
   }

--- a/src/yb/tserver/tablet_server_main.cc
+++ b/src/yb/tserver/tablet_server_main.cc
@@ -148,7 +148,7 @@ int TabletServerMain(int argc, char** argv) {
   if (GetHostname(&host_name).ok()) {
     FLAGS_metric_node_name = strings::Substitute("$0:$1", host_name, TabletServer::kDefaultWebPort);
   } else {
-      LOG(INFO) << "Failed to get tablet's host name, keeping default metric_node_name";
+    LOG(INFO) << "Failed to get tablet's host name, keeping default metric_node_name";
   }
   // Do not sync GLOG to disk for INFO, WARNING.
   // ERRORs, and FATALs will still cause a sync to disk.

--- a/src/yb/tserver/tablet_server_main.cc
+++ b/src/yb/tserver/tablet_server_main.cc
@@ -60,6 +60,7 @@
 #include "yb/util/main_util.h"
 #include "yb/util/ulimit_info.h"
 #include "yb/util/size_literals.h"
+#include "yb/util/net/net_util.h"
 
 using namespace std::placeholders;
 
@@ -108,6 +109,7 @@ DECLARE_string(certs_dir);
 DECLARE_string(certs_for_client_dir);
 DECLARE_string(ysql_hba_conf);
 DECLARE_string(ysql_pg_conf);
+DECLARE_string(metric_node_name);
 
 // Deprecated because it's misspelled.  But if set, this flag takes precedence over
 // remote_bootstrap_rate_limit_bytes_per_sec for compatibility.
@@ -141,6 +143,13 @@ int TabletServerMain(int argc, char** argv) {
   FLAGS_webserver_port = TabletServer::kDefaultWebPort;
   FLAGS_redis_proxy_webserver_port = RedisServer::kDefaultWebPort;
   FLAGS_cql_proxy_webserver_port = CQLServer::kDefaultWebPort;
+
+  string host_name;
+  if (GetHostname(&host_name).ok()) {
+    FLAGS_metric_node_name = (host_name) + ":" + std::to_string(TabletServer::kDefaultWebPort);
+  } else {
+      LOG(INFO) << "Failed to get tablet's host name, keeping default metric_node_name";
+  }
   // Do not sync GLOG to disk for INFO, WARNING.
   // ERRORs, and FATALs will still cause a sync to disk.
   FLAGS_logbuflevel = google::GLOG_WARNING;


### PR DESCRIPTION
prometheus-metrics: change default metric_node_name to hostname:port

Default value for GFLAG metric_node_name was "DEFAULT_NODE_NAME". Changed this to hostname:web_server_port.
<target>/prometheus-metrics now show new default value.

Summary:
Test (on localhost):
Command: `./bin/yb-ctl start --rf 1 `
On opening http://127.0.0.1:7000/prometheus-metrics, the `exported_instance` field shows hostname:webserverPort

Command with custom `metric_node_name`: `./bin/yb-ctl start --rf 1 --master_flags "metric_node_name=alpha:1"`
On opening http://127.0.0.1:7000/prometheus-metrics, the `exported_instance` field shows `alpha:1`