### PR TITLE
Added document to use TLS Secured YugabyteDB Cluster by Helm Charts

### DIFF
--- a/docs/content/latest/deploy/kubernetes/clients.md
+++ b/docs/content/latest/deploy/kubernetes/clients.md
@@ -148,20 +148,14 @@ Here is an example of a client that uses the `YSQL shell` ([`ysqlsh`](../../../a
 Use the following command to verify the connection.
 
 ```sh
-$ kubectl exec -n yb-demo -it yb-client -- ysqlsh -h yb-tservers.yb-demo.svc.cluster.local "sslmode=require" -c \\conninfo
-You are connected to database "yugabyte" as user "yugabyte" on host "yb-tservers.yb-demo.svc.cluster.local" at port "5433".
-SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 256, compression: off)
-```
-
-Use the following command to use YugabyteDB cluster.
-
-```sh
 $ kubectl exec -n yb-demo -it yb-client -- ysqlsh -h yb-tservers.yb-demo.svc.cluster.local "sslmode=require"
 ysqlsh (11.2-YB-2.1.5.0-b0)
 SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 256, compression: off)
 Type "help" for help.
 
-yugabyte=#
+yugabyte=# \conninfo
+You are connected to database "yugabyte" as user "yugabyte" on host "yb-tservers.yb-demo.svc.cluster.local" at port "5433".
+SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 256, compression: off)
 ```
 
 Here is an example of a client that uses the `YCQL shell` ([`ycqlsh`](../../../admin/cqlsh)) to connect.
@@ -169,18 +163,12 @@ Here is an example of a client that uses the `YCQL shell` ([`ycqlsh`](../../../a
 Use the following command to verify the connection.
 
 ```sh
-$ kubectl exec -n yb-demo -it yb-client -- ycqlsh yb-tservers.yb-demo.svc.cluster.local 9042 --ssl --execute 'SHOW HOST'
-Connected to local cluster at yb-tservers.yb-demo.svc.cluster.local:9042.
-```
-
-Use the following command to use YugabyteDB cluster.
-
-```sh
 $ kubectl exec -n yb-demo -it yb-client -- ycqlsh yb-tservers.yb-demo.svc.cluster.local 9042 --ssl
 Connected to local cluster at yb-tservers.yb-demo.svc.cluster.local:9042.
 [cqlsh 5.0.1 | Cassandra 3.9-SNAPSHOT | CQL spec 3.4.2 | Native protocol v4]
 Use HELP for help.
-cqlsh>
+cqlsh> SHOW HOST
+Connected to local cluster at yb-tservers.yb-demo.svc.cluster.local:9042.
 ```
 
 (Optional) After the operations are complete, remove the client pod. 
@@ -191,10 +179,6 @@ pod "yb-client" deleted
 ```
 
 ### Connecting externally
-
-Prerequisites:
-1. Client Certificates
-2. External Cluster IP
 
 To connect externally to a TLS-enabled YugabyteDB helm cluster, first download the client certificates locally from the Kubernetes cluster's secrets.
 
@@ -210,20 +194,14 @@ Here is an example of a client that uses the `YSQL shell` ([`ysqlsh`](../../../a
 Use the following command to verify the connection.
 
 ```sh
-$ docker run -it --rm -v $(pwd)/certs/:/root/.yugabytedb/:ro yugabytedb/yugabyte-client:latest ysqlsh -h <External_Cluster_IP> "sslmode=require" -c \\conninfo
-You are connected to database "yugabyte" as user "yugabyte" on host "35.200.205.208" at port "5433".
-SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 256, compression: off)
-```
-
-Use the following command to use YugabyteDB cluster.
-
-```sh
 $ docker run -it --rm -v $(pwd)/certs/:/root/.yugabytedb/:ro yugabytedb/yugabyte-client:latest ysqlsh -h <External_Cluster_IP> "sslmode=require"
 ysqlsh (11.2-YB-2.1.5.0-b0)
 SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 256, compression: off)
 Type "help" for help.
 
-yugabyte=#
+yugabyte=# \conninfo
+You are connected to database "yugabyte" as user "yugabyte" on host "35.200.205.208" at port "5433".
+SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 256, compression: off)
 ```
 
 Here is an example of a client that uses the `YCQL shell` ([`ycqlsh`](../../../admin/cqlsh)) to connect.
@@ -232,18 +210,11 @@ Use the following docker command to verify the connection.
 
 ```sh
 $ docker run -it --rm -v $(pwd)/certs/:/root/.yugabytedb/:ro \
---env SSL_CERTFILE=/root/.yugabytedb/root.crt yugabytedb/yugabyte-client:latest ycqlsh <External_Cluster_IP> 9042 --ssl --execute 'SHOW HOST'
-Connected to local cluster at 35.200.205.208:9042.
-```
-
-Use the following docker command to use YugabyteDB cluster.
-
-```sh
-$ docker run -it --rm -v $(pwd)/certs/:/root/.yugabytedb/:ro \
 --env SSL_CERTFILE=/root/.yugabytedb/root.crt yugabytedb/yugabyte-client:latest ycqlsh <External_Cluster_IP> 9042 --ssl
 ysqlsh (11.2-YB-2.1.5.0-b0)
 Connected to local cluster at 35.200.205.208:9042.
 [cqlsh 5.0.1 | Cassandra 3.9-SNAPSHOT | CQL spec 3.4.2 | Native protocol v4]
 Use HELP for help.
-cqlsh>
+cqlsh> SHOW HOST
+Connected to local cluster at 35.200.205.208:9042.
 ```

--- a/docs/content/latest/deploy/kubernetes/clients.md
+++ b/docs/content/latest/deploy/kubernetes/clients.md
@@ -118,7 +118,7 @@ For example, `helm install yugabyte --namespace yb-demo --name yb-demo --set=tls
 
 ### Connect from within the Kubernetes cluster
 
-Copy the following `yb-client.yaml` and use this `kubectl create -f yb-client.yaml` command to create a pod with auto-mounted client certificates.
+Copy the following `yb-client.yaml` and use the `kubectl create -f yb-client.yaml` command to create a pod with auto-mounted client certificates.
 
 ```yaml
 apiVersion: v1

--- a/docs/content/latest/deploy/kubernetes/clients.md
+++ b/docs/content/latest/deploy/kubernetes/clients.md
@@ -80,7 +80,7 @@ ycqlsh> use demo;
 ycqlsh:demo> CREATE TABLE t_demo(id INT PRIMARY KEY);
 ```
 
-## Master UI dashboard
+## YB-Master Admin UI
 
 The master UI dashboard is available at the external IP address exposed by the `yb-master-ui` LoadBalancer service - in this case at `http://98.138.219.231:7000/`.
 

--- a/docs/content/latest/deploy/kubernetes/clients.md
+++ b/docs/content/latest/deploy/kubernetes/clients.md
@@ -112,7 +112,9 @@ Status:
 
 ## Connecting TLS Secured YugabyteDB cluster deployed by Helm Charts
 
-Follow the following [documentation link](https://docs.yugabyte.com/latest/deploy/kubernetes/single-zone/gke/helm-chart/) for the deployment of YugabyteDB cluster using Helm Chart and to bring up the cluster with encryption in transit (TLS) enabled, set the flag `tls.enabled=true` in the helm command-line.
+To bring up a YugabyteDB cluster with encryption in transit (TLS) enabled, follow the [instructions here](https://docs.yugabyte.com/latest/deploy/kubernetes/single-zone/gke/helm-chart/) and set the flag `tls.enabled=true` in the helm command-line.
+
+For example, `helm install yugabyte --namespace yb-demo --name yb-demo --set=tls.enabled=true`.
 
 ### Within Kubernetes cluster
 

--- a/docs/content/latest/deploy/kubernetes/clients.md
+++ b/docs/content/latest/deploy/kubernetes/clients.md
@@ -82,7 +82,7 @@ ycqlsh:demo> CREATE TABLE t_demo(id INT PRIMARY KEY);
 
 ## YB-Master Admin UI
 
-The master UI dashboard is available at the external IP address exposed by the `yb-master-ui` LoadBalancer service - in this case at `http://98.138.219.231:7000/`.
+The YB-Master Admin UI is available at the IP address exposed by the `yb-master-ui` LoadBalancer service – at `https://98.138.219.231:7000/`.
 
 Another option that does not require an external LoadBalancer is to create a tunnel from the local host to the master web server port on the master pod using [kubectl port-forward](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/).
 

--- a/docs/content/latest/deploy/kubernetes/clients.md
+++ b/docs/content/latest/deploy/kubernetes/clients.md
@@ -206,7 +206,7 @@ SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 25
 
 Here is an example of a client that uses the `YCQL shell` ([`ycqlsh`](../../../admin/cqlsh)) to connect.
 
-Use the following docker command to verify the connection.
+To verify the connection, use the following `docker run` command.
 
 ```sh
 $ docker run -it --rm -v $(pwd)/certs/:/root/.yugabytedb/:ro \

--- a/docs/content/latest/deploy/kubernetes/clients.md
+++ b/docs/content/latest/deploy/kubernetes/clients.md
@@ -178,7 +178,7 @@ $ kubectl delete pod yb-client -n yb-demo
 pod "yb-client" deleted
 ```
 
-### Connecting externally
+### Connect externally
 
 To connect externally to a TLS-enabled YugabyteDB helm cluster, first download the client certificates locally from the Kubernetes cluster's secrets.
 

--- a/docs/content/latest/deploy/kubernetes/clients.md
+++ b/docs/content/latest/deploy/kubernetes/clients.md
@@ -116,7 +116,7 @@ To bring up a YugabyteDB cluster with encryption in transit (TLS) enabled, follo
 
 For example, `helm install yugabyte --namespace yb-demo --name yb-demo --set=tls.enabled=true`.
 
-### Within Kubernetes cluster
+### Connecting from within the Kubernetes cluster
 
 Copy the following `yb-client.yaml` and use this `kubectl create -f yb-client.yaml` command to create a pod with auto-mounted client certificates.
 

--- a/docs/content/latest/deploy/kubernetes/clients.md
+++ b/docs/content/latest/deploy/kubernetes/clients.md
@@ -112,6 +112,8 @@ Status:
 
 ## Connecting TLS Secured YugabyteDB cluster deployed by Helm Charts
 
+Follow the following [documentation link](https://docs.yugabyte.com/latest/deploy/kubernetes/single-zone/gke/helm-chart/) for the deployment of YugabyteDB cluster using Helm Chart and to bring up the cluster with encryption in transit (TLS) enabled, set the flag `tls.enabled=true` in the helm command-line.
+
 ### Within Kubernetes cluster
 
 Copy the following `yb-client.yaml` and use this `kubectl create -f yb-client.yaml` command to create a pod with auto-mounted client certificates.
@@ -186,7 +188,7 @@ $ kubectl delete po yb-client -n yb-demo
 pod "yb-client" deleted
 ```
 
-### Connecting Remote Cluster
+### Connecting externally
 
 Prerequisites:
 1. Client Certificates

--- a/docs/content/latest/deploy/kubernetes/clients.md
+++ b/docs/content/latest/deploy/kubernetes/clients.md
@@ -112,7 +112,7 @@ Status:
 
 ## Connecting TLS Secured YugabyteDB cluster deployed by Helm Charts
 
-To bring up a YugabyteDB cluster with encryption in transit (TLS) enabled, follow the [instructions here](https://docs.yugabyte.com/latest/deploy/kubernetes/single-zone/gke/helm-chart/) and set the flag `tls.enabled=true` in the helm command-line.
+To start a YugabyteDB cluster with encryption in transit (TLS) enabled, follow the steps at [Google Kubernetes Service (GKE) - Helm Chart](https://docs.yugabyte.com/latest/deploy/kubernetes/single-zone/gke/helm-chart/) and set the flag `tls.enabled=true` in the helm command-line.
 
 For example, `helm install yugabyte --namespace yb-demo --name yb-demo --set=tls.enabled=true`.
 

--- a/docs/content/latest/deploy/kubernetes/clients.md
+++ b/docs/content/latest/deploy/kubernetes/clients.md
@@ -183,7 +183,7 @@ Use HELP for help.
 cqlsh>
 ```
 
-(Optional) Use the below-mentioned command to remove the `yb-client` pod.
+(Optional) After the operations are complete, remove the client pod. 
 
 ```sh
 $ kubectl delete pod yb-client -n yb-demo

--- a/docs/content/latest/deploy/kubernetes/clients.md
+++ b/docs/content/latest/deploy/kubernetes/clients.md
@@ -116,7 +116,7 @@ To bring up a YugabyteDB cluster with encryption in transit (TLS) enabled, follo
 
 For example, `helm install yugabyte --namespace yb-demo --name yb-demo --set=tls.enabled=true`.
 
-### Connecting from within the Kubernetes cluster
+### Connect from within the Kubernetes cluster
 
 Copy the following `yb-client.yaml` and use this `kubectl create -f yb-client.yaml` command to create a pod with auto-mounted client certificates.
 

--- a/docs/content/latest/deploy/kubernetes/clients.md
+++ b/docs/content/latest/deploy/kubernetes/clients.md
@@ -189,7 +189,7 @@ $ kubectl get secret yugabyte-tls-client-cert  -n yb-demo -o jsonpath='{.data.yu
 $ kubectl get secret yugabyte-tls-client-cert  -n yb-demo -o jsonpath='{.data.yugabytedb\.key}' | base64 --decode > $(pwd)/certs/yugabytedb.key
 ```
 
-Here is an example of a client that uses the `YSQL shell` ([`ysqlsh`](../../../admin/ysqlsh)) to connect. The command specifies the external LoadBalancer IP of the `yb-tserver-service` as shown in [the docs here](../single-zone/oss/helm-chart/#connect-using-external-clients). 
+Here is an example of a client that uses the `YSQL shell` ([`ysqlsh`](../../../admin/ysqlsh)) to connect. The command specifies the external LoadBalancer IP of the `yb-tserver-service` as described in [Connect using external clients](../single-zone/oss/helm-chart/#connect-using-external-clients). 
 
 Use the following command to verify the connection.
 

--- a/docs/content/latest/deploy/kubernetes/clients.md
+++ b/docs/content/latest/deploy/kubernetes/clients.md
@@ -186,7 +186,7 @@ cqlsh>
 (Optional) Use the below-mentioned command to remove the `yb-client` pod.
 
 ```sh
-$ kubectl delete po yb-client -n yb-demo
+$ kubectl delete pod yb-client -n yb-demo
 pod "yb-client" deleted
 ```
 

--- a/docs/content/latest/deploy/kubernetes/clients.md
+++ b/docs/content/latest/deploy/kubernetes/clients.md
@@ -205,7 +205,7 @@ $ kubectl get secret yugabyte-tls-client-cert  -n yb-demo -o jsonpath='{.data.yu
 $ kubectl get secret yugabyte-tls-client-cert  -n yb-demo -o jsonpath='{.data.yugabytedb\.key}' | base64 --decode > $(pwd)/certs/yugabytedb.key
 ```
 
-Here is an example of a client that uses the `YSQL shell` ([`ysqlsh`](../../../admin/ysqlsh)) to connect.
+Here is an example of a client that uses the `YSQL shell` ([`ysqlsh`](../../../admin/ysqlsh)) to connect. The command specifies the external LoadBalancer IP of the `yb-tserver-service` as shown in [the docs here](../single-zone/oss/helm-chart/#connect-using-external-clients). 
 
 Use the following command to verify the connection.
 

--- a/docs/content/latest/deploy/kubernetes/clients.md
+++ b/docs/content/latest/deploy/kubernetes/clients.md
@@ -196,7 +196,7 @@ Prerequisites:
 1. Client Certificates
 2. External Cluster IP
 
-Use the following commands to get the client certificates from Kubernetes cluster's Secrets.
+To connect externally to a TLS-enabled YugabyteDB helm cluster, first download the client certificates locally from the Kubernetes cluster's secrets.
 
 ```sh
 $ mkdir $(pwd)/certs


### PR DESCRIPTION
Added document to use TLS Secured YugabyteDB Cluster by Helm Charts

**Added two approaches to connect the TLS Secured YugabyteDB cluster -** 

1. Within Kubernetes Cluster.
2. Remotely.


Fixes: https://github.com/yugabyte/yugabyte-db/issues/4726