### PR TITLE
[Docs] Fix slow query on quick-start page aggregations/view sections

### DIFF
--- a/docs/content/latest/quick-start/explore/ysql.md
+++ b/docs/content/latest/quick-start/explore/ysql.md
@@ -392,7 +392,7 @@ source     | num_user_signups
 
 ```postgresql
 yb_demo=# SELECT source, ROUND(SUM(orders.total)) AS total_sales
-          FROM users, orders WHERE users.id=orders.user_id
+          FROM users LEFT JOIN orders ON users.id=orders.user_id
           GROUP BY source
           ORDER BY total_sales DESC;
 ```
@@ -417,8 +417,7 @@ Let us answer the questions below by creating a view.
 ```postgresql
 yb_demo=# CREATE VIEW channel AS
             (SELECT source, ROUND(SUM(orders.total)) AS total_sales
-             FROM users, orders
-             WHERE users.id=orders.user_id
+             FROM users LEFT JOIN orders ON users.id=orders.user_id
              GROUP BY source
              ORDER BY total_sales DESC);
 ```


### PR DESCRIPTION
Hi YugaBytes team,

The sample query for a group by aggregation on `source` and summarizing `totoal_sales` is too slow for this size of rows.
I change the query and use Joins to speed up the query response time.

Best Regards 