### PR TITLE
Modify docker quick start cmd line and clarify default value for server_broadcast_addresses in docs

### DIFF
--- a/docs/content/latest/quick-start/create-local-cluster/docker.md
+++ b/docs/content/latest/quick-start/create-local-cluster/docker.md
@@ -62,16 +62,16 @@ To create a 1-node cluster with a replication factor (RF) of 1, run the command 
 ```sh
 $ docker run -d --name yugabyte  -p7000:7000 -p9000:9000 -p5433:5433 -p9042:9042\
  yugabytedb/yugabyte:latest bin/yugabyted start\
- --daemon=false --ui=false
+ --daemon=false
 ```
 
 As per the above docker run command, the data stored in YugabyteDB is not persistent across container restarts. If you want to make YugabyteDB persist data across restarts then you have to add the volume mount option to the docker run command as shown below.
 
 ```sh
 docker run -d --name yugabyte  -p7000:7000 -p9000:9000 -p5433:5433 -p9042:9042\
- -v yb_data:/home/yugabyte/var\
+ -v ~/yb_data:/home/yugabyte/var\
  yugabytedb/yugabyte:latest bin/yugabyted start\
- --daemon=false --ui=false
+ --daemon=false 
 ```
 
 Clients can now connect to the YSQL and YCQL APIs at `localhost:5433` and `localhost:9042` respectively.

--- a/docs/content/latest/reference/configuration/yb-master.md
+++ b/docs/content/latest/reference/configuration/yb-master.md
@@ -110,7 +110,7 @@ In cases where `rpc_bind_addresses` is set to `0.0.0.0` (or not explicitly set, 
 
 Specifies the public IP or DNS hostname of the server (with an optional port). This value is used by servers to communicate with one another, depending on the connection policy parameter.
 
-Default: `0.0.0.0:7100`
+Default: `""`
 
 ##### --use_private_ip
 

--- a/docs/content/latest/reference/configuration/yb-tserver.md
+++ b/docs/content/latest/reference/configuration/yb-tserver.md
@@ -132,7 +132,7 @@ In cases where `rpc_bind_addresses` is set to `0.0.0.0` (or not explicitly set, 
 
 Specifies the public IP or DNS hostname of the server (with an optional port). This value is used by servers to communicate with one another, depending on the connection policy parameter.
 
-Default: `0.0.0.0:9100`
+Default: `""`
 
 ##### --use_private_ip
 


### PR DESCRIPTION
1. The default value for --server_broadcast_addresses in the code is an empty string.
@daniel-yb noticed the docs were incorrect.

2. The docker cmd line was changed to (a) remove --ui=false which is not necessary and (b) specify the volume by an explicit path "~/yb_data" instead of a volume name. (b) will help us locate the yugabyte log files for debugging in a more easy way. With the older volume specification, it is much harder to find the actual files on MacOS - see https://www.freshblurbs.com/blog/2017/04/16/inspect-docker-volumes-on-mac.html