### PR TITLE
Created Metric to track whether tablet is leader

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -98,4 +98,5 @@ This is a list of people who have contributed code to the [YugabyteDB](https://g
 * [baba230896](https://github.com/baba230896)
 * [mirageyjd](https://github.com/mirageyjd)
 * [Abdallah](https://github.com/AbdallahKhaled93)
+* [Adm28](https://github.com/Adm28)
 

--- a/src/yb/consensus/raft_consensus.cc
+++ b/src/yb/consensus/raft_consensus.cc
@@ -155,11 +155,11 @@ METRIC_DEFINE_lag(tablet, follower_lag_ms,
                   "The amount of time since the last UpdateConsensus request from the "
                   "leader.");
 
-METRIC_DEFINE_gauge_int32(tablet, is_leader,
-                          "Is tablet leader",
+METRIC_DEFINE_gauge_int64(tablet, is_raft_leader,
+                          "Is tablet raft leader",
                           yb::MetricUnit::kUnits,
-                          "Keeps track whether tablet is leader"
-                          "1 indicates that the tablet is leader");
+                          "Keeps track whether tablet is raft leader"
+                          "1 indicates that the tablet is raft leader");
 
 METRIC_DEFINE_histogram(
   tablet, dns_resolve_latency_during_update_raft_config,
@@ -341,7 +341,7 @@ RaftConsensus::RaftConsensus(
                                                     cmeta->current_term())),
       follower_last_update_time_ms_metric_(
           metric_entity->FindOrCreateAtomicMillisLag(&METRIC_follower_lag_ms)),
-      is_leader_metric_(metric_entity->FindOrCreateGauge(&METRIC_is_leader, static_cast<int32_t>(0))),
+      is_raft_leader_metric_(metric_entity->FindOrCreateGauge(&METRIC_is_raft_leader, static_cast<int64_t>(0))),
       parent_mem_tracker_(std::move(parent_mem_tracker)),
       table_type_(table_type),
       update_raft_config_dns_latency_(
@@ -951,7 +951,7 @@ Status RaftConsensus::BecomeLeaderUnlocked() {
 
   peer_manager_->SignalRequest(RequestTriggerMode::kNonEmptyOnly);
 
-  is_leader_metric_->set_value(1);
+  is_raft_leader_metric_->set_value(1);
 
   return Status::OK();
 }
@@ -984,7 +984,7 @@ Status RaftConsensus::BecomeReplicaUnlocked(
 
   peer_manager_->Close();
 
-  is_leader_metric_->set_value(0);
+  is_raft_leader_metric_->set_value(0);
 
   return Status::OK();
 }

--- a/src/yb/consensus/raft_consensus.cc
+++ b/src/yb/consensus/raft_consensus.cc
@@ -341,7 +341,8 @@ RaftConsensus::RaftConsensus(
                                                     cmeta->current_term())),
       follower_last_update_time_ms_metric_(
           metric_entity->FindOrCreateAtomicMillisLag(&METRIC_follower_lag_ms)),
-      is_raft_leader_metric_(metric_entity->FindOrCreateGauge(&METRIC_is_raft_leader, static_cast<int64_t>(0))),
+      is_raft_leader_metric_(metric_entity->FindOrCreateGauge(&METRIC_is_raft_leader,
+                                                              static_cast<int64_t>(0))),
       parent_mem_tracker_(std::move(parent_mem_tracker)),
       table_type_(table_type),
       update_raft_config_dns_latency_(

--- a/src/yb/consensus/raft_consensus.h
+++ b/src/yb/consensus/raft_consensus.h
@@ -663,7 +663,7 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   scoped_refptr<Counter> follower_memory_pressure_rejections_;
   scoped_refptr<AtomicGauge<int64_t>> term_metric_;
   scoped_refptr<AtomicMillisLag> follower_last_update_time_ms_metric_;
-  scoped_refptr<AtomicGauge<int32_t>> is_leader_metric_;
+  scoped_refptr<AtomicGauge<int64_t>> is_raft_leader_metric_;
   std::shared_ptr<MemTracker> parent_mem_tracker_;
 
   TableType table_type_;

--- a/src/yb/consensus/raft_consensus.h
+++ b/src/yb/consensus/raft_consensus.h
@@ -663,7 +663,7 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   scoped_refptr<Counter> follower_memory_pressure_rejections_;
   scoped_refptr<AtomicGauge<int64_t>> term_metric_;
   scoped_refptr<AtomicMillisLag> follower_last_update_time_ms_metric_;
-
+  scoped_refptr<AtomicGauge<int32_t>> is_leader_metric_;
   std::shared_ptr<MemTracker> parent_mem_tracker_;
 
   TableType table_type_;

--- a/src/yb/integration-tests/create-table-itest.cc
+++ b/src/yb/integration-tests/create-table-itest.cc
@@ -431,16 +431,18 @@ TEST_F(CreateTableITest, TestIsRaftLeaderMetric) {
                 .num_tablets(kNumTablets)
                 .Create());
 
-  // Count the total Number of Raft Leaders in the cluster. Go through each tablet of every tablet-server and sum up the leaders.
+  // Count the total Number of Raft Leaders in the cluster. Go through each tablet of every
+  // tablet-server and sum up the leaders.
   int64_t kNumRaftLeaders = 0;
-  for(int i=0 ; i< kNumReplicas ;i++) {
-    auto tabletIds = ASSERT_RESULT(cluster_->GetTabletIds(cluster_->tablet_server(i)));
-    for(int ti = 0;ti < inspect_->ListTabletsOnTS(i).size();ti++) {
-      const char *tabletId = tabletIds[ti].c_str();
-      kNumRaftLeaders += ASSERT_RESULT(cluster_->tablet_server(i)->GetInt64Metric(&METRIC_ENTITY_tablet,tabletId,&METRIC_is_raft_leader,"value"));
+  for (int i = 0 ; i < kNumReplicas; i++) {
+    auto tablet_ids = ASSERT_RESULT(cluster_->GetTabletIds(cluster_->tablet_server(i)));
+    for(int ti = 0; ti < inspect_->ListTabletsOnTS(i).size(); ti++) {
+      const char *tabletId = tablet_ids[ti].c_str();
+      kNumRaftLeaders += ASSERT_RESULT(cluster_->tablet_server(i)->GetInt64Metric(
+          &METRIC_ENTITY_tablet, tabletId, &METRIC_is_raft_leader, "value"));
     }
   }
-  ASSERT_EQ(kNumRaftLeaders,kExpectedRaftLeaders);
+  ASSERT_EQ(kNumRaftLeaders, kExpectedRaftLeaders);
 }
 
 }  // namespace yb


### PR DESCRIPTION
#3688 
Created Metric `is_leader` which tracks whether a tablet is leader/follower.
Plugged in the Metric into `raft_consensus.cc` to determine when the leader becomes leader and steps down from leader. 
The metric does so in the following way 

- Set the metric to 1 at the end of  func `RaftConsensus::BecomeLeaderUnlocked()` (Becomes a leader)
- Set the metric to 0 at the end of func `RaftConsensus::BecomeReplicaUnlocked()`(Steps down)