### PR TITLE
[Docs][#5074] Fix link rendering element to remove extra space when no external icon

### DIFF
--- a/docs/layouts/_default/_markup/render-link.html
+++ b/docs/layouts/_default/_markup/render-link.html
@@ -1,2 +1,2 @@
 <a href="{{ .Destination | safeURL }}" {{ if strings.HasPrefix .Destination "http" }} target="_blank"
-    {{ end }}>{{ .Text | safeHTML }} {{ if strings.HasPrefix .Destination "http"}}<i class="fas fa-external-link-alt"></i>{{ end }}</a>
+    {{ end }}>{{ .Text | safeHTML }}{{ if strings.HasPrefix .Destination "http"}}&nbsp;<i class="fas fa-external-link-alt"></i>{{ end }}</a>


### PR DESCRIPTION
Example of link with additional space on `/latest/api/ycql/dml_select`
![Screen Shot 2020-07-15 at 1 52 19 PM](https://user-images.githubusercontent.com/50115930/87594834-6c2b4c80-c6a2-11ea-8d3f-92d6e2f85f26.png)

Example of link with fixed formatting
![Screen Shot 2020-07-15 at 1 49 08 PM](https://user-images.githubusercontent.com/50115930/87594861-7b11ff00-c6a2-11ea-9460-b4f6d8e87672.png)
