### PR TITLE
Global replace of triple-backtick 'postgresql' lexer syntaxwith 'plpg…

### DIFF
--- a/docs/content/latest/api/ysql/datatypes/type_array/array-constructor.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/array-constructor.md
@@ -32,7 +32,7 @@ These thee ordinary functions also create an array value from scratch:
 - [`text_to_array()`](../functions-operators/string-to-array/) creates a `text[]`array from a single `text` value that uses a a specifiable delimiter to beak it into individual values.
 
 **Example:**
-```postgresql
+```plpgsql
 create type rt as (f1 int, f2 text);
 select array[(1, 'a')::rt, (2, 'b')::rt, (3, 'dog \ house')::rt]::rt[] as arr;
 ```
@@ -71,7 +71,7 @@ begin
 
 Run this to create the required user-defined _"row"_ type and the table function and then to invoke it.
 
-```postgresql
+```plpgsql
 -- Don't create "type rt" if it's still there following the previous example.
 create type rt as (f1 int, f2 text);
 
@@ -158,7 +158,7 @@ And this is the second row. The readability was improved by adding some whitespa
 ## Using the array[] constructor in a prepared statement
 
 This example emphasizes the value of using the `array[]` constructor over using an array literal because it lets you use expressions like `chr()` within it.
-```postgresql
+```plpgsql
 -- Don't create "type rt" if it's still there followng the previous examples.
 create type rt as (f1 int, f2 text);
 create table t(k serial primary key, arr rt[]);
@@ -169,12 +169,12 @@ prepare stmt(rt[]) as insert into t(arr) values($1);
 execute stmt(array[(104, chr(104))::rt, (105, chr(105))::rt, (106, chr(106))::rt]);
 ```
 This execution of the prepared statement, using an array literal as the actual argument, is semantically equivalent:
-```postgresql
+```plpgsql
 execute stmt('{"(104,h)","(105,i)","(106,j)"}');
 ```
 But here, of course, you just have to know in advance that `chr(104)` is `h`, and so on. Prove that the results of the two executions of the prepared statement are identical thus:
 
-```postgresql
+```plpgsql
 select
   (
     (select arr from t where k = 1)

--- a/docs/content/latest/api/ysql/datatypes/type_array/array-of-domains.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/array-of-domains.md
@@ -78,7 +78,7 @@ But this causes a compilation error. The paradox is exactly that `int[]` is anon
 
 The `DOMAIN` brings the functionality that overcomes the apparent restriction. First, do this:
 
-```postgresql
+```plpgsql
 create domain int_arr_t as int[];
 create table t(k serial primary key, v1 int_arr_t[], typecast text, v2 int_arr_t[]);
 ```
@@ -86,7 +86,7 @@ Notice that the use of the `CREATE DOMAIN` statement is an example of _type cons
 
 The columns _"v1"_ and _"v2"_ are now ready to store ragged arrays of arrays. Prove it like this:
 
-```postgresql
+```plpgsql
 do $body$
 declare
   arr_1      constant int_arr_t := array[1, 2];
@@ -100,7 +100,7 @@ $body$;
 By using a `DO` block to set the value of _"ragged_arr"_ by building it bottom-up, you emphasize the fact that it really is a one-dimensional array of one-dimensional arrays of different lengths. It is, then, clearly _not_ a rectilinear two-dimensional array.
 
 Now use the technique that [The non-lossy round trip: value to text typecast and back to value](../literals/text-typecasting-and-literals/#the-non-lossy-round-trip-value-to-text-typecast-and-back-to-value) explained to inspect the `::text` typecast of the ragged array and then to show that, by typecasting this back to a value of the original data type, it can serve as the literal for the original value. First, do this:
-```postgresql
+```plpgsql
 update t
 set typecast = v1::text
 where k = 1;
@@ -121,7 +121,7 @@ This sentence is copied from [The non-lossy round trip: value to text typecast a
 
 Now do this:
 
-```postgresql
+```plpgsql
 update t
 set v2 = typecast::int_arr_t[]
 where k = 1;
@@ -140,7 +140,7 @@ The original value has been recreated.
 ### Addressing values in a ragged array of arrays
 
 First, consider this counter example:
-```postgresql
+```plpgsql
 \pset null '<IS NULL'>
 with v as (
   select  '{{1,2},{3,4}}'::int[] as two_d_arr)
@@ -167,7 +167,7 @@ And it reminds you that you must supply exactly as many index values as the arra
 - How do you address, for example, the _first_ value in the array that is itself the _second_ array in the ragged array of arrays?
 
 You know before typing it that this can't be right:
-```postgresql
+```plpgsql
 select v1[2][1] as "v1[2][1]" from t where k = 1;
 ```
 Sure enough, it shows this:
@@ -177,7 +177,7 @@ Sure enough, it shows this:
  <IS NULL>
 ```
 You don't get an error. But neither do you get what you want. Try this instead:
-```postgresql
+```plpgsql
 select v1[2] as "v1[2]" from t where k = 1;
 ```
 This is the result:
@@ -187,7 +187,7 @@ This is the result:
  {3,4,5}
 ```
 This is the clue. You have identified the leaf array, in the array of arrays, that you want to. Now you have to identify the desired value in _that_ array. Try this:
-```postgresql
+```plpgsql
 select (v1[2])[1] as "(v1[2])[1]" from t where k = 1;
 ```
 This is the result:
@@ -197,7 +197,7 @@ This is the result:
           3
 ```
 In the same way, you can inspect the geometric properties of the leaf array like this:
-```postgresql
+```plpgsql
 select
   array_lower(v1[1], 1) as v1_lb,
   array_upper(v1[1], 1) as v1_ub,
@@ -213,7 +213,7 @@ This is the result:
 ```
 Finally, try this counter example:
 
-```postgresql
+```plpgsql
 with v as (
   select  '{{1,2},{3,4}}'::int[] as two_d_arr)
 select
@@ -246,7 +246,7 @@ First, define the data type for the "payload" matrix. To make it interesting, as
 - Each of the matrix's values must be `NOT NULL`.
 
 The motivating requirement for the `DOMAIN` type constructor is that it must allow arbitrary constraints to be defined on values of the constructed type, like this:
-```postgresql
+```plpgsql
 create domain matrix_t as text[]
 check (
   (value is not null)         and
@@ -275,7 +275,7 @@ Next, define the block matrix as a matrix of _"matrix_t"_. Assume that similar f
 - Each of the matrix's values must be `NOT NULL`.
 
 The `CREATE DOMAIN` statement for _"block_matrix_t"_ is therefore similar to that for _"matrix_t"_:
-```postgresql
+```plpgsql
 create domain block_matrix_t as matrix_t[]
 check (
   (value is not null)         and
@@ -296,7 +296,7 @@ These two `CREATE DOMAIN` statements are uncomfortably verbose and repetitive. B
 
 Next, create a block matrix value, insert it, and its `::text` typecast, into a table, and inspect the typecast's value.
 
-```postgresql
+```plpgsql
 create table block_matrices_1(k int primary key, v block_matrix_t, text_typecast text);
 
 do $body$
@@ -374,7 +374,7 @@ Finally, check that even this exotic structure conforms to the universal rule, c
 > - Any value of any data type, primitive or composite, can be `::text` typecasted. Similarly, there always exists a `text` value that, when properly spelled, can be typecasted to a value of any desired data type, primitive or composite.
 > - If you `::text` typecast a value of any data type and then typecast that `text` value to the original value's data type, then the value that you get is identical to the original value.
 
-```postgresql
+```plpgsql
 create table block_matrices_2(k int primary key, v block_matrix_t);
 
 insert into block_matrices_2(k, v)
@@ -404,7 +404,7 @@ The rule holds.
 
 ### Using unnest() on an array of arrays
 First, produce the list of _"matrix_t"_ values, in row-major order:
-```postgresql
+```plpgsql
 with matrices as (
   select unnest(v) as m
   from block_matrices_1
@@ -429,7 +429,7 @@ This is the result:
  4 | {{28,29,30},{31,32,33},{34,35,36}}
 ```
 Now unnest a _"matrix_t"_ value of interest:
-```postgresql
+```plpgsql
 select unnest(v[2][1]) as val
 from block_matrices_1
 where k = 1
@@ -446,7 +446,7 @@ This is the result:
  27
 ```
 Use this query if you want to see _all_ of the leaf values in row-major order:
-```postgresql
+```plpgsql
 with
   matrixes as (
     select unnest(v) as m

--- a/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/_index.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/_index.md
@@ -65,8 +65,8 @@ the [RHS](https://en.wikipedia.org/wiki/Sides_of_an_equation) is an array of tha
 
 | Operator | 1-d only? | Description |
 | ---- | ---- | ---- |
-| [`=ANY`](./any-all/#the-any-operator) | | Returns `TRUE` if the LHS is among RHS's values. |
-| [`=ALL`](./any-all/#the-all-operator) | | Returns `TRUE` if the LHS is equal to every one of the RHS's values. |
+| [`ANY`](./any-all/) | | Returns `TRUE` if _at least one_ of the specified inequality tests between the LHS element and each of the RHS array's elements evaluates to `TRUE`. |
+| [`ALL`](./any-all/) | | Returns `TRUE` if every one_ of the specified inequality tests between the LHS element and each of the RHS array's elements evaluates to `TRUE`. |
 
 ## Operators for comparing two arrays
 

--- a/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/array-fill.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/array-fill.md
@@ -18,7 +18,7 @@ return value:      anyarray
 **Purpose:** Return a new "blank canvas" array of the specified shape with all cells set to the same specified value.
 
 - The first parameter determines the value and data type for every cell, and therefore the data type of the new array as a whole. It can be a value of a primitive data type, or, for example, a _"row"_ type value. It can also be written `NULL::some_type` if this suits your purpose. You would presumably set a `NOT NULL` value if, for example, you wanted to insert the array into a table column on which you have created a constraint, based upon a PL/pgSQL function, that explicitly tests the array's geometric properties and the `NOT NULL` status of each of its values. Try this:
-  ```postgresql
+  ```plpgsql
   select pg_typeof(array_fill(null::text, '{1}')) as "type of the new array";
   ```
 &#160;&#160;&#160;&#160;This is the result:
@@ -34,7 +34,7 @@ The shape of the new array is, therefore, fully specified by the second and thir
 
 **Note:** Why does `array_fill()` exist? In other words, why not just set the values that you want by directly indexing each cell and assigning the value you want to it? Recall that, as described in [Synopsis](../../#synopsis), an array value is rectilinear. This means that its shape, when its number of dimensions exceeds one, is non-negotiably fixed at creation time. This `DO` block emphasizes the point.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   a int[];
@@ -64,7 +64,7 @@ So the array _"a"_ is stuck as one dimensional, one-by-one value.
 **Example:**
 
 Run this:
-```postgresql
+```plpgsql
 create table t(k int primary key, arr text[]);
 
 insert into t(k, arr)
@@ -88,7 +88,7 @@ It shows this:
 ```
 
 Now run this:
-```postgresql
+```plpgsql
 update t
 set
   arr[2][ 7] = '2---7',
@@ -110,7 +110,7 @@ It shows this (after some manual white-space formatting for readability):
 ```
 
 Finally, run this:
-```postgresql
+```plpgsql
 \set VERBOSITY verbose
 update t
 set

--- a/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/array-position.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/array-position.md
@@ -13,7 +13,7 @@ showAsideToc: true
 These functions require that the to-be-searched array is one-dimensional. They return the index values of the specified to-be-searched-for value in the specified to-be-searched array.
 
 Create _"view v"_ now. The examples below use it.
-```postgresql
+```plpgsql
 create view v as
 select array[
     'sun', -- 1
@@ -40,7 +40,7 @@ return value:      int
 **Note:** The optional third parameter specifies the _inclusive_ index value at which to start the search.
 
 **Example:**
-```postgresql
+```plpgsql
 select array_position(
   (select arr from v)::text[],  -- #1. The to-be-searched array.
 
@@ -68,7 +68,7 @@ input value:       anyarray, anyelement
 return value:      integer[] 
 ```
 **Example:**
-```postgresql
+```plpgsql
 select array_positions(
   (select arr from v)::text[],  -- #1. The to-be-searched array.
 

--- a/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/array-remove.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/array-remove.md
@@ -21,7 +21,7 @@ return value:      anyarray
 **Note:** This function requires the array from which values are to be removed is one-dimensional. This restriction is understood in light of the fact that arrays are rectilinear—in other words, the geometry of an array whose dimensionality is two or more is fixed at creation time. For examples illustrating this rule, see [`array_fill()`](.././array-fill).
 
 **Example:**
-```postgresql
+```plpgsql
 create table t(k int primary key, arr int[]);
 insert into t(k, arr)
 values (1, '{1, 2, 2, 2, 5, 6}'::int[]);

--- a/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/array-to-string.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/array-to-string.md
@@ -20,7 +20,7 @@ return value:      text
 ```
 
 **Example:**
-```postgresql
+```plpgsql
 create type rt as (f1 int, f2 text);
 create table t(k int primary key, arr rt[]);
 insert into t(k, arr) values(1,
@@ -42,7 +42,7 @@ It shows this:
 To understand the syntax of the text of this literal, especially when a field is `NULL`, see  [The literal for a _"row"_ type value](../../literals/row/).
 
 Now do this:
-```postgresql
+```plpgsql
 select
   array_to_string(
     arr,     -- the input array
@@ -59,7 +59,7 @@ It shows this:
 Notice that the third, `NULL`, array value is not represented. Rather, this implied by the _absence_ of any characters between the comma and the right parenthesis delimiters.
 
 Now do this;
-```postgresql
+```plpgsql
 select
   array_to_string(
     arr,     -- the input array

--- a/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/comparison.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/comparison.md
@@ -79,7 +79,7 @@ These three operators are insensitive to the geometric properties of the two to-
 - The `=` operator returns `TRUE` if the LHS and RHS arrays are equal.
 - The `<>` operator is the natural complement: it returns `TRUE` if the LHS and RHS arrays are not equal.
 
-```postgresql
+```plpgsql
 with
   v as (
     select
@@ -96,7 +96,7 @@ This is the result:
  true
 ```
 
-```postgresql
+```plpgsql
 with
   v as (
     select
@@ -122,7 +122,7 @@ These four operators implement the familiar inequality comparisons.
 - The `<` operator returns `TRUE` if the LHS array is less than the RHS array.
 
 It's sufficient, therefore, to provide an example for just the `<` operator.
-```postgresql
+```plpgsql
 with
   v as (
     select
@@ -147,7 +147,7 @@ This is the result:
 - The `@>` operator returns `TRUE` if the LHS array contains the RHS array—that is, if every distinct value in the RHS array is found among the LHS array's distinct values.
 - The `<@` operator is the natural complement: it returns `TRUE` if every distinct value in the LHS array is found among the RHS array's distinct values.
 
-```postgresql
+```plpgsql
 with
   v as (
     select
@@ -170,7 +170,7 @@ This is the result:
 
 The `&&` operator returns `TRUE` if the LHS and RHS arrays overlap—that is, if they have at least one value in common. The definition of this operator makes it insensitive to which of the two to-be-compared is used on the LHS and which is used on the RHS.
 
-```postgresql
+```plpgsql
 with
   v as (
     select
@@ -193,7 +193,7 @@ This is the result:
 
 This section demonstrates each of the rules that [Comparison operators overview](./#comparison-operators-overview) above stated.
 
-```postgresql
+```plpgsql
 -- Any two arrays can be compared without error if they have the same data type.
 do $body$
 begin
@@ -425,7 +425,7 @@ $body$;
 
 This section demonstrates each of the rules that [Containment and overlap operators overview](./#containment-and-overlap-operators-overview) stated.
 
-```postgresql
+```plpgsql
 -- Any two arrays can be compared without error if they have the same data type.
 -- Insensitive to the geometric properties.
 do $body$

--- a/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/concatenation.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/concatenation.md
@@ -34,7 +34,7 @@ These rules follow directly from the fact that arrays are rectilinear. For examp
 
 **Example:**
 
-```postgresql
+```plpgsql
 create table t(k int primary key, arr int[]);
 insert into t(k, arr)
 values (1, '{3, 4, 5}'::int[]);
@@ -71,7 +71,7 @@ return value:             anyarray
 ```
 **Note:** The `DO` block shows that the `||` operator is able to implement the full functionality of the `array_cat()` function.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   arr_1 constant int[] := '{1, 2, 3}'::int[];
@@ -96,7 +96,7 @@ return value:             anyarray
 ```
 **Note:** The `DO` block shows that the `||` operator is able to implement the full functionality of the `array_append()` function. The values must be compatible.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   arr constant int[] := '{1, 2, 3, 4}'::int[];
@@ -120,7 +120,7 @@ return value:             anyarray
 ```
 **Note:** The `DO` block shows that the `||` operator is able to implement the full functionality of the `array_prepend()` function. The values must be compatible.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   arr constant int[] := '{1, 2, 3, 4}'::int[];
@@ -138,7 +138,7 @@ $body$;
 
 **Semantics for one-arrays**
 
-```postgresql
+```plpgsql
 create type rt as (f1 int, f2 text);
 
 do $body$
@@ -165,7 +165,7 @@ $body$;
 
 **Semantics for multidimensional arrays**
 
-```postgresql
+```plpgsql
 do $body$
 declare
   -- arr_1 and arr_2 are demensionally compatible.

--- a/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/properties.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/properties.md
@@ -25,7 +25,7 @@ The behavior of each of the functions for reporting the geometric properties of 
 
 Create and populate _"table t"_ thus:
 
-```postgresql
+```plpgsql
 create table t(k int primary key, arr_1 text[], arr_2 text[]);
 insert into t(k, arr_1, arr_2) values(1,
       '[3:10]={ 1, 2, 3, 4,   5, 6, 7, 8}',
@@ -48,7 +48,7 @@ return value:      int
 ```
 **Example:**
 
-```postgresql
+```plpgsql
 select
   array_ndims(arr_1) as ndims_1,
   array_ndims(arr_2) as ndims_2
@@ -71,7 +71,7 @@ return value:      int
 ```
 **Example:**
 
-```postgresql
+```plpgsql
 select
   array_lower(arr_1, 1) as arr_1_lb,
   array_lower(arr_2, 1) as arr_2_lb_1,
@@ -95,7 +95,7 @@ return value:      int
 ```
 **Example:**
 The use of `array_upper()` is exactly symmetrical with the use of `array_lower()`.
-```postgresql
+```plpgsql
 select
   array_upper(arr_1, 1) as arr_1_ub,
   array_upper(arr_2, 1) as arr_2_ub_1,
@@ -120,7 +120,7 @@ return value:      int
 **Example:**
 The use of `array_length()` is exactly symmetrical with the use of `array_lower()` and `array_upper()`.
 
-```postgresql
+```plpgsql
 select
   array_length(arr_1, 1) as arr_1_len,
   array_length(arr_2, 1) as arr_2_len_1,
@@ -144,7 +144,7 @@ return value:      int
 ```
 **Example:**
 
-```postgresql
+```plpgsql
 select
   cardinality(arr_1) as card_1,
   cardinality(arr_2) as card_2
@@ -168,7 +168,7 @@ return value:      text
 **Example:**
 The `array_dims()` function is useful to produce a result that is easily humanly readable. If you want to use the information that it returns programmatically, then you should use `array_lower()`, `array_upper()`, or `array_length()`.
 
-```postgresql
+```plpgsql
 select
   array_dims(arr_1) as arr_1_dims,
   array_dims(arr_2) as arr_2_dims
@@ -206,7 +206,7 @@ Meeting these requirements are allows the procedure to deliver two bonus benefit
 
 **Note:** There are no built-in functions for computing, for example, the product of two matrices or the product of a vector and a matrix. (A vector is a one-dimensional array, and a matrix is a two-dimensional array.) But, as long as you know how to traverse the values in a matrix in row-major order, you can implement the missing vector and matrix multiplication functionality for yourself.
 
-```postgresql
+```plpgsql
 create procedure assert_semantics_and_traverse_values(
   a in int[], b in int[],
 
@@ -299,7 +299,7 @@ $body$;
 ```
 
 Try it on the first data set:
-```postgresql
+```plpgsql
 do $body$
 declare
   a constant int[] :=            '{ 1, 2,   3,  4,   5,  6}';
@@ -333,7 +333,7 @@ a[ 5] = b[ 3][ 1] =  5
 a[ 6] = b[ 3][ 2] =  6
 ```
 Try it on the second data set:
-```postgresql
+```plpgsql
 do $body$
 declare
   a constant int[] :=     '[3:14]={ 1, 2, 3,   4, 5, 6,   7, 8, 9,   10, 11, 12}';
@@ -373,7 +373,7 @@ a[13] = b[ 6][ 7] = 11
 a[14] = b[ 6][ 8] = 12
 ```
 Try it on the third data set:
-```postgresql
+```plpgsql
 do $body$
 declare
   a constant int[] :=     '[3:18]={ 1, 2, 3, 4,   5, 6, 7, 8,   9, 10, 11, 12,   13, 14, 15, 16}';

--- a/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/replace-a-value.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/replace-a-value.md
@@ -28,7 +28,7 @@ return value:      anyarray
 ```
 **Example:**
 
-```postgresql
+```plpgsql
 create type rt as (f1 int, f2 text);
 create table t(k int primary key, arr rt[]);
 insert into t(k, arr)
@@ -57,7 +57,7 @@ This is the result of the two queries:
 
 _One-dimensional array of primitive scalar values_.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   old_val constant int := 42;
@@ -80,7 +80,7 @@ _One-dimensional array of _"row"_ type values_.
 
 The definition of _"rt"_ used here is the same as the example above used. Don't create again if it already exists.
 
-```postgresql
+```plpgsql
 create type rt as (f1 int, f2 text);
 
 do $body$
@@ -106,7 +106,7 @@ $body$;
 _Two-dimensional array of primitive scalar values_. This is sufficient to illustrate the semantics of the general multidimensional case. The function's signature (at the start of this section) shows that the to-be-replaced value and the replacement value are instances of `anyelement`. There is no overload where these two parameters accept instances of `anyarray`. This restriction is understood by picturing the internal representation as a linear ribbon of values, as was explained in [Synopsis](../../#synopsis). The replacement works by scanning along the ribbon, finding each occurrence in turn of the to-be-replaced value, and replacing it.
 
 Here is a postive illustration:
-```postgresql
+```plpgsql
 do $body$
 declare
   old_val constant int := 22;
@@ -135,7 +135,7 @@ end;
 $body$;
 ```
 And here is a negative illustration:
-```postgresql
+```plpgsql
 do $body$
 declare
   old_val constant int[] := array[22, 23];
@@ -186,7 +186,7 @@ $body$;
 input/output value: anyarray, "vector of index values"
 ```
 **Example:**
-```postgresql
+```plpgsql
 create table t(k int primary key, arr int[]);
 
 insert into t(k, arr) values (1,
@@ -206,7 +206,7 @@ This is the result:
 
 _Array of primitive scalar values_. Notice that the starting value is "snapshotted" as `old_arr` and that this is marked `constant`. Notice too that _"expected_modified_arr"_ is marked `constant`. This proves that the modification was done in place within the only array value that is _not_ marked `constant`.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   old_val constant int := 42;
@@ -228,7 +228,7 @@ $body$;
 _Array of "record" type values_.
 
 The definition of _"rt"_ used here is the same as the example above used. Don't create again if it already exists.
-```postgresql
+```plpgsql
 create type rt as (f1 int, f2 text);
 
 do $body$
@@ -261,7 +261,7 @@ $body$;
 ```
 _Two-dimensional array of primitive scalar values_. This is sufficient to illustrate the semantics of the general multidimensional case. The approach is just the same as when `array_replace()` is used to meet the same goal. You have no choice but to target the values explicitly.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   old_val constant int[] := array[21, 22, 23, 24];

--- a/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/slice-operator.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/slice-operator.md
@@ -25,7 +25,7 @@ return value:      anyarray
 - The new array has the same dimensionality as the source array and its lower bound is `1` on each axis.
 
 **Example:**
-```postgresql
+```plpgsql
 create table t(k int primary key, arr text[]);
 
 insert into t(k, arr)
@@ -68,7 +68,7 @@ and:
     2 |    4 |    3 |    6 |    4 |    5
 ```
 Now do the slicing:
-```postgresql
+```plpgsql
 update t
 set arr = arr[2:3][4:5][3:4]
 where k = 1;

--- a/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/string-to-array.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/string-to-array.md
@@ -20,7 +20,7 @@ return value:      text[]
 ```
 **Example:**
 
-```postgresql
+```plpgsql
 select string_to_array(
   'a|b|?|c', -- the to-be-split string
   '|',       -- the character(s) to be taken as the delimiter
@@ -64,7 +64,7 @@ The troublesome sequence is shown in typewriter font here:
 
 These considerations, together with the fact that it can produce only a `text[]` output, mean that the `string_to_array()` function has limited usefulness.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   delim_text  constant text := ' !';

--- a/docs/content/latest/api/ysql/datatypes/type_array/literals/_index.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/literals/_index.md
@@ -20,7 +20,7 @@ An array literal starts with a left curly brace. This is followed by some number
 To use such a literal in SQL or in PL/pgSQL it must be enquoted in the same way as is an ordinary `text` literal. You can enquote an array literal using dollar quotes, if this suits your purpose, just as you can for a `text` literal. You sometimes need to follow the closing quote with a suitable typecast operator for the array data type that you intend. And sometimes the context of use uniquely determines the literal's data type. It's never wrong to write the typecast explicitly—and it's a good practice always to do this.
 
 Here, in use in a SQL `SELECT` statement, is the literal for a one-dimensional array of primitive `int` values:
-```postgresql
+```plpgsql
 \t on
 select '{1, 2, 3}'::int[];
 ```
@@ -32,14 +32,14 @@ This is the output that the first example produces:
  {1,2,3}
 ```
 The second example surrounds the values that the array literal defines with double quotes:
-```postgresql
+```plpgsql
 select '{"1", "2", "3"}'::int[];
 ```
 It produces the identical output to the first example, where no double quotes were used.
 
 The third example defines a two-dimensional array of `int` values:
 
-```postgresql
+```plpgsql
 select '
    {
       {11, 12, 13},
@@ -56,7 +56,7 @@ It produces this result:
 
 The fourth example defines an array whose values are instances of a _"row"_ type:
 
-```postgresql
+```plpgsql
 create type rt as (f1 int, f2 text);
 
 select '

--- a/docs/content/latest/api/ysql/datatypes/type_array/literals/array-of-primitive-values.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/literals/array-of-primitive-values.md
@@ -73,7 +73,7 @@ You'll use the `array[]` constructor to create representative values of each kin
 
 This example demonstrates the principle:
 
-```postgresql
+```plpgsql
 create table t(k serial primary key, v1 int[], v2 int[]);
 insert into t(v1) values (array[1, 2, 3]);
 select v1::text as text_typecast from t where k = 1
@@ -97,7 +97,7 @@ You can see the general form already:
 
 To use the literal that you produced to create a value, you must enquote it and typecast it. Do this with the `\set` metacommand:
 
-```postgresql
+```plpgsql
 \set canonical_literal '\'':result_text_typecast'\'::int[]'
 \echo :canonical_literal
 ```
@@ -106,7 +106,7 @@ To use the literal that you produced to create a value, you must enquote it and 
 '{1,2,3}'::int[]
 ```
 Next, use the canonical literal that was have produced to update _"t.v2"_ to confirm that the value that the row constructor created was recreated:
-```postgresql
+```plpgsql
 update t set v2 = :canonical_literal where k = 1;
 select (v1 = v2)::text as "v1 = v2" from t where k = 1;
 ```
@@ -121,28 +121,28 @@ As promised, the canonical form of the array literal does indeed recreate the id
 **Note:**
 
 Try this:
-```postgresql
+```plpgsql
 select 12512454.872::text;
 ```
 The result is the canonical form, `12512454.872`. So this (though you rarely see it):
-```postgresql
+```plpgsql
 select 12512454.872::numeric;
 ```
 runs without error. Now try this:
 
-```postgresql
+```plpgsql
 select to_number('12,512,454.872', '999G999G999D999999')::text;
 ```
 This, too, runs without error because it uses the `to_number()` built-in function. The result here, too, is the canonical form, `12512454.872`—with no commas. Now try this:
 
-```postgresql
+```plpgsql
 select '12,512,454.872'::numeric;
 ```
 This causes the _"22P02: invalid input syntax for type numeric"_ error. In other words, _only_ a `numeric` value in canonical form can be directly typecast using `::numeric`.
 
 Here, using an array literal, is an informal first look at what follows. For now, take its syntax to mean what you'd intuitively expect. You must spell the representations for the values in a `numeric[]` array in canonical form. Try this:
 
-```postgresql
+```plpgsql
 select ('{123.456, -456.789}'::numeric[])::text;
 ```
 It shows this:
@@ -152,7 +152,7 @@ It shows this:
 ```
 
 Now try this:
-```postgresql
+```plpgsql
 select ('{9,123.456, -8,456.789}'::numeric[])::text;
 ```
 It silently produces this presumably unintended result (an array of _four_ numeric values) because the commas are taken as delimiters and not as part of the representation of a single `numeric` value:
@@ -169,7 +169,7 @@ Use [One-dimensional array of `int` values](./#one-dimensional-array-of-int-valu
      a          a b          ()          ,          '          "          \
 ```
 
-```postgresql
+```plpgsql
 create table t(k serial primary key, v1 text[], v2 text[]);
 insert into t(v1) values (array['a', 'a b', '()', ',', '{}', $$'$$, '"', '\']);
 select v1::text as text_typecast from t where k = 1
@@ -199,7 +199,7 @@ There's another rule that the present example does not show. Though not every co
 
 To use the text of the literal that was produced above to recreate the value, you must enquote it and typecast it. Do this, as you did for the `int[]` example above, with the `\set` metacommand. But you must use dollar quotes because the literal itself has an interior single quote.
 
-```postgresql
+```plpgsql
 \set canonical_literal '$$':result_text_typecast'$$'::text[]
 \echo :canonical_literal
 ```
@@ -208,7 +208,7 @@ The `\echo` metacommand now shows this:
 $${a,"a b",(),",",',"\"","\\"}$$::text[]
 ```
 Next, use the canonical literal to update _"t.v2"_ to confirm that the value that the row constructor created was recreated:
-```postgresql
+```plpgsql
 update t set v2 = :canonical_literal where k = 1;
 select (v1 = v2)::text as "v1 = v2" from t where k = 1;
 ```
@@ -224,7 +224,7 @@ So, again as promised, the canonical form of the array literal does indeed recre
 
 This example demonstrates the principle:
 
-```postgresql
+```plpgsql
 create table t(k serial primary key, v1 timestamp[], v2 timestamp[]);
 insert into t(v1) values (array[
     '2019-01-27 11:48:33'::timestamp,
@@ -245,7 +245,7 @@ You learn one further rule from this:
 
 To use the text of the literal that was produced to create a value, you must enquote it and typecast it. Do this with the `\set` metacommand:
 
-```postgresql
+```plpgsql
 \set canonical_literal '\'':result_text_typecast'\'::timestamp[]'
 \echo :canonical_literal
 ```
@@ -254,7 +254,7 @@ To use the text of the literal that was produced to create a value, you must enq
 '{"2019-01-27 11:48:33","2020-03-30 14:19:21"}'::timestamp[]
 ```
 Next, use the canonical literal to update _"t.v2"_ to confirm that the value that the row constructor created was recreated:
-```postgresql
+```plpgsql
 update t set v2 = :canonical_literal where k = 1;
 select (v1 = v2)::text as "v1 = v2" from t where k = 1;
 ```
@@ -270,7 +270,7 @@ Once again, as promised, the canonical form of the array literal does indeed rec
 
 This example demonstrates the principle:
 
-```postgresql
+```plpgsql
 create table t(k serial primary key, v1 boolean[], v2 boolean[]);
 insert into t(v1) values (array[
     true,
@@ -297,7 +297,7 @@ Though the example doesn't show this, `NULL` is not case-sensitive. But to compo
 
 To use the literal that that was produced to create a value, you must enquote it and typecast it. Do this with the `\set` metacommand:
 
-```postgresql
+```plpgsql
 \set canonical_literal '\'':result_text_typecast'\'::boolean[]'
 \echo :canonical_literal
 ```
@@ -306,7 +306,7 @@ To use the literal that that was produced to create a value, you must enquote it
 '{t,f,NULL}'::boolean[]
 ```
 Next use the canonical literal to update _"t.v2"_ to can confirm that the value that the row constructor created has been recreated :
-```postgresql
+```plpgsql
 update t set v2 = :canonical_literal where k = 1;
 select (v1 = v2)::text as "v1 = v2" from t where k = 1;
 ```
@@ -320,7 +320,7 @@ Yet again, as promised, the canonical form of the array literal does indeed recr
 
 ### Multidimensional array of int values
 
-```postgresql
+```plpgsql
 create table t(k serial primary key, v int[]);
 
 -- Insert a 1-dimensional int[] value.

--- a/docs/content/latest/api/ysql/datatypes/type_array/literals/array-of-rows.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/literals/array-of-rows.md
@@ -49,15 +49,15 @@ The example uses a _"row"_ type with four fields: an `int` field; a `text` field
      <space>     ,     (     )     "     \
 ```
 First, create the _"row"_ type:
-```postgresql
+```plpgsql
 create type rt as (n int, s text, t timestamp, b boolean);
 ```
 Next, you create a table with a column with data type _"rt"_ so that you can populate it with six rows that jointly, in their `text` fields, use all of the "challenging" characters listed above:
-```postgresql
+```plpgsql
 create table t1(k int primary key, v rt);
 ```
 Finally, you populate the table by building the _"row"_ type values bottom-up using appropriately typed PL/pgSQL variables in a `DO` block and inspect the result. This technique allows the actual primitive values that were chosen for this demonstration so be seen individually as the ordinary SQL literals that each data type requires. This makes the code more readable and more understandable than any other approach. In other words, it shows that, for humanly written code, the usability of a value constructor for any composite value is much greater than that of the literal that produces the same value. Of course, this benefit is of no consequence for a programmatically constructed literal.
-```postgresql
+```plpgsql
 do $body$
 declare
   n1 constant int := 1;
@@ -126,12 +126,12 @@ The first four are unremarkable, as long as you remember that each of these four
 - The single backslash occurrence, in the source data, must be doubled up and then surrounded by double quotes.
 
 Next, you concatenate these six _"row"_ type values into an array value by using the `array_agg()` function (described in [`array_agg()`](../../functions-operators/array-agg-unnest/#array-agg)), like this:
-```postgresql
+```plpgsql
 select array_agg(v order by k) from t1;
 ```
 
 The demonstration is best served by inserting this value into a new table, like this:
-```postgresql
+```plpgsql
 create table t2(k int primary key, v1 rt[], v1_text_typecast text, v2 rt[]);
 insert into t2(k, v1)
 select 1, array_agg(v order by k) from t1;
@@ -140,12 +140,12 @@ select 1, array_agg(v order by k) from t1;
 The `\get` technique that you used in the earlier sections is not viable here because there's an upper limit on its size. So, instead insert the literal that you produce by `text` typecasting _"t2.v1"_ into the companion _"v1&#95;text&#95;typecast"_ field in the same table, like this:
 
 
-```postgresql
+```plpgsql
 update t2 set v1_text_typecast =
 (select v1::text from t2 where k = 1);
 ```
 Finally, use this array literal to recreate the original value and check that it's identical to what you started with, thus:
-```postgresql
+```plpgsql
 update t2 set v2 = 
 (select v1_text_typecast from t2 where k = 1)::rt[];
 
@@ -160,7 +160,7 @@ As promised, the canonical form of the array literal does indeed recreate the id
 ```
 
 You haven't yet looked at the literal for the array of _"row"_ type values. Now is the moment to do so, thus:
-```postgresql
+```plpgsql
 select v1_text_typecast from t2 where k = 1;
 ```
 The result that's produced is too hard to read without some manual introduction of whitespace. But this is allowed around the commas that delimit successive values within an array literal, thus:

--- a/docs/content/latest/api/ysql/datatypes/type_array/literals/row.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/literals/row.md
@@ -66,7 +66,7 @@ Use the _"row"_ type constructor to create representative values of each kind an
 
 This example demonstrates the principle:
 
-```postgresql
+```plpgsql
 create type row_t as (f1 int, f2 int, f3 int);
 create table t(k serial primary key, v1 row_t, v2 row_t);
 insert into t(v1) values (row(1, 2, 3)::row_t);
@@ -94,7 +94,7 @@ You can see the general form already:
 The next section, [_"Row"_ type with `text` fields](./#row-type-with-text-fields), shows that more needs to be said. But the two rules that you have already noticed always hold.
 
 To use the text of the literal that was produced to create a value, you must enquote it and typecast it. Do this with the `\set` metacommand:
-```postgresql
+```plpgsql
 \set canonical_literal '\'':result_text_typecast'\''::row_t
 \echo :canonical_literal
 ```
@@ -103,7 +103,7 @@ To use the text of the literal that was produced to create a value, you must enq
 '(1,2,3)'::row_t
 ```
 Next, use the canonical literal that you produced to update _"t.v2"_ to confirm that the value that the row constructor created was recreated:
-```postgresql
+```plpgsql
 update t set v2 = :canonical_literal where k = 1;
 select (v1 = v2)::text as "v1 = v2" from t where k = 1;
 ```
@@ -122,7 +122,7 @@ Use [_"Row"_ type with `int` fields](./#row-type-with-text-fields) as a template
      a       '       a b       ()       ,       "       \       null
 ```
 
-```postgresql
+```plpgsql
 create type row_t as (f1 text, f2 text, f3 text, f4 text, f5 text, f6 text, f7 text, f8 text);
 create table t(k serial primary key, v1 row_t, v2 row_t);
 insert into t(v1) values (
@@ -157,7 +157,7 @@ In addition to the first two rules, you notice the following.
 There's another rule that the present example does not show. Though not every comma-separated value was surrounded by double quotes, it's _never harmful_ to do this. You can confirm this with your own test, Yugabyte recommends that, for consistency, you always surround every `text` value within the parentheses of a _"row"_ type literal with double quotes.
 
 To use the text of the literal that was produced to create a value, you must enquote it and typecast it. Do this, as you did for the `int` example above, with the `\set` metacommand. But you must use dollar quotes because the literal itself has an interior single quote.
-```postgresql
+```plpgsql
 \set canonical_literal '$$':result_text_typecast'$$'::row_t
 \echo :canonical_literal
 ```
@@ -166,7 +166,7 @@ The `\echo` metacommand now shows this:
 $$(a,',"a b","()",",","""","\\",)$$::row_t
 ```
 Next, use the canonical literal that you produced to update _"t.v2"_ to confirm that the value that the row constructor created was recreated:
-```postgresql
+```plpgsql
 update t set v2 = :canonical_literal where k = 1;
 select (v1 = v2)::text as "v1 = v2" from t where k = 1;
 ```
@@ -179,7 +179,7 @@ It shows this:
 So, again as promised, the canonical form of the array literal does indeed recreate the identical value that the _"row"_ type constructor created.
 
 Finally in this section, consider the meaning-changing effect of surrounding the comma delimiters with whitespace. Try this:
-```postgresql
+```plpgsql
 create type row_t as (f1 text, f2 text, f3 text);
 select '(   a   ,   "(a b)"   ,   c   )'::row_t;;
 ```
@@ -197,7 +197,7 @@ This rule is different from the rule for an array literal. It's also different f
 
 This example demonstrates the principle:
 
-```postgresql
+```plpgsql
 create type row_t as (f1 timestamp, f2 timestamp);
 create table t(k serial primary key, v1 row_t, v2 row_t);
 insert into t(v1) values (('2019-01-27 11:48:33', '2020-03-30 14:19:21')::row_t);
@@ -211,7 +211,7 @@ The `\echo` metacommand shows this:
 ("2019-01-27 11:48:33","2020-03-30 14:19:21")
 ```
 To use the text of the literal that was produced to create a value, you must enquote it and typecast it. Do this with the `\set` metacommand:
-```postgresql
+```plpgsql
 \set canonical_literal '\'':result_text_typecast'\''::row_t
 \echo :canonical_literal
 ```
@@ -220,7 +220,7 @@ To use the text of the literal that was produced to create a value, you must enq
 '("2019-01-27 11:48:33","2020-03-30 14:19:21")'::row_t
 ```
 Next, use the canonical literal that you produced to update _"t.v2"_ to confirm that you have recreated the value that the row constructor created:
-```postgresql
+```plpgsql
 update t set v2 = :canonical_literal where k = 1;
 select (v1 = v2)::text as "v1 = v2" from t where k = 1;
 ```
@@ -236,7 +236,7 @@ Once again, as promised, the canonical form of the array literal does indeed rec
 
 This example demonstrates the principle:
 
-```postgresql
+```plpgsql
 create type row_t as (f1 boolean, f2 boolean, f3 boolean);
 create table t(k serial primary key, v1 row_t, v2 row_t);
 insert into t(v1) values ((true, false, null)::row_t);
@@ -249,7 +249,7 @@ The `\echo` metacommand shows this:
  (t,f,)
 ```
 To use the text of the literal that was produced to create a value, you must enquote it and typecast it. Do this with the `\set` metacommand:
-```postgresql
+```plpgsql
 \set canonical_literal '\'':result_text_typecast'\''::row_t
 \echo :canonical_literal
 ```
@@ -258,7 +258,7 @@ To use the text of the literal that was produced to create a value, you must enq
 '(t,f,)'::row_t
 ```
 Next, use the canonical literal that you produced to update _"t.v2"_ to confirm that the value that the row constructor created was recreated:
-```postgresql
+```plpgsql
 update t set v2 = :canonical_literal where k = 1;
 select (v1 = v2)::text as "v1 = v2" from t where k = 1;
 ```
@@ -282,7 +282,7 @@ The rules for such cases can be determined by induction from the rules that this
 
 The two notions, _type constructor_ and _literal_, are functionally critically different. You can demonstrate the difference using a `DO` block, because this lets you use a declared variable. It's more effort to do this using a SQL statement because you'd have to use a scalar subquery in place of the PL/pgSQL variable. The `ROW` keyword is deliberately omitted here to emphasize its optional status.
 
-```postgresql
+```plpgsql
 create type rt as (n numeric, s text, t timestamp, b boolean);
 
 do $body$

--- a/docs/content/latest/api/ysql/datatypes/type_array/literals/text-typecasting-and-literals.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/literals/text-typecasting-and-literals.md
@@ -40,7 +40,7 @@ The following `DO` block applies the pattern using a representative range of bot
 
 Notice that the last test uses an array whose data type is the user-created `DOMAIN` _"int_arr_t"_. [Using an array of `DOMAIN` values](../../array-of-domains/) explains this notion. This is a real stress-tests of the rule.
 
-```postgresql
+```plpgsql
 -- Needed by the '1-d array of "row" type values' test.
 create type rt as (n numeric, s text, t timestamp, b boolean);
 
@@ -175,7 +175,7 @@ Notice how the syntax for the _array of arrays_ `text` value compares with the s
 ## boolean values show special text forms in ysqlsh
 
 Try this:
-```postgresql
+```plpgsql
 select true as "bare true", true::text as "true::text";
 ```
 This is the result:
@@ -193,7 +193,7 @@ You saw above that even when you explicitly `::text` typecast a composite value,
 ## The relationship between the text typecast of a value and the literal that creates that value
 
 Try this in `ysqlsh`:
-```postgresql
+```plpgsql
 select
   42.932771::numeric          as n,
   'cat'::text                 as t1,

--- a/docs/content/latest/api/ysql/datatypes/type_array/looping-through-arrays.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/looping-through-arrays.md
@@ -90,7 +90,7 @@ END LOOP [ label ];
 
 This loop is functionally identical to the `FOR var IN` loop. However, in the `FOR` loop, YSQL automatically defines `var` with the type `int` so that its scope is limited to the loop; but in the `FOREACH` loop, `var` must be explicitly declared, as noted  in the _"Syntax and semantics"_ section above.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   arr1 int[] := array[1, 2];
@@ -123,7 +123,7 @@ The next loop shows these things of note:
 - The syntax spot where _"var"_ is used above need not be occupied by a single variable. Rather, _"f1"_ and _"f2"_ are used, to correspond to the fields in _"rt"_.
 - The `FOREACH` loop is followed by a _"cursor"_ loop whose `SELECT` statement uses `unnest()`.
 - The `FOREACH` loop is more terse than the _"cursor"_ loop. In particular, you can use the pair of declared variables _"f1"_ and _"f2"_ without any fuss (just as you could have used a single variable _"r"_ of type _"rt"_ without any fuss) as the iterator. YSQL looks after the proper assignment in both cases. But when you use `unnest()`, you have to look after this yourself.
-```postgresql
+```plpgsql
 create type rt as (f1 int, f2 text);
 
 do $body$
@@ -172,7 +172,7 @@ This shows that this use of the `FOREACH` loop (with an implied `0` as the `SLIC
 
 First, store a three-dimensional two-by-two-by-two array in a `::text[]` field in a single-row table. Each of the subsequent `DO` blocks uses it.
 
-```postgresql
+```plpgsql
 create table t(k int primary key, arr text[] not null);
 insert into t(k, arr) values(1, '
   {
@@ -187,7 +187,7 @@ insert into t(k, arr) values(1, '
   }'::text[]);
 ```
 Next, show the outcome when a bad value is used for the `SLICE` operand:
-```postgresql
+```plpgsql
 do $body$
 declare
   arr constant text[] not null := (select arr from t where k = 1);
@@ -210,7 +210,7 @@ This test confirms that the value of the `SLICE` operand must not exceed the ite
 
 As has been seen, `SLICE 0` (or equivalently omitting the `SLICE` clause) scans the array values in row-major order. The next test, with `SLICE 3`, demonstrates the meaning when the `SLICE` operand is equal to the iterand array's dimensionality.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   arr constant text[] not null := (select arr from t where k = 1);
@@ -239,7 +239,7 @@ The `FOREACH` loop generates just a single iterator slice. And, as the `assert` 
 
 The next test uses `SLICE 2`:
 
-```postgresql
+```plpgsql
 do $body$
 declare
   arr constant text[] not null := (select arr from t where k = 1);
@@ -266,7 +266,7 @@ As the `assert` shows, the operand of the `SLICE` operator determines the dimens
 
 The next test uses `SLICE 1`: 
 
-```postgresql
+```plpgsql
 do $body$
 declare
   arr constant text[] not null := (select arr from t where k = 1);
@@ -295,7 +295,7 @@ Once again, the `assert` shows that the operand of the `SLICE` operator determin
 
 The last `FOREACH` test uses `SLICE 0`. Notice that, now, the iterator is declared as the scalar `text` variable  _"var"_:
 
-```postgresql
+```plpgsql
 do $body$
 declare
   arr constant text[] not null := (select arr from t where k = 1);
@@ -324,7 +324,7 @@ FOREACH SLICE 0
 8 | 008
 ```
 This is functionally equivalent to `unnest()` as the final test shows:
-```postgresql
+```plpgsql
 do $body$
 <<b>>declare
   arr constant text[] not null := (select arr from t where k = 1);
@@ -383,7 +383,7 @@ Here is the basic encapsulation. It's hard-coded to handle values for the `SLICE
 
 Recall that the iterator for `SLICE 0` is a scalar and that the iterators for other values of the `SLICE` operand are arrays. And recall that a pair of functions with the same definitions of the input formal parameters cannot be overload-distinguished by the data type of their return values. For this reason, the encapsulation of the `FOREACH` loop for `SLICE 0` is a dedicated function with just one input formal parameter: the iterand array. And the encapsulation of the `FOREACH` loop for other values of the  `SLICE` operand is a second function with two input formal parameters: the iterand array and the value of the  `SLICE` operand. Here they are:
 
-```postgresql
+```plpgsql
 -- First overload
 create function array_slices(arr in anyarray)
   returns table(ret anyelement)
@@ -407,7 +407,7 @@ end;
 $body$;
 ```
 And:
-```postgresql
+```plpgsql
 -- Second overload
 create function array_slices(arr in anyarray, slice_operand in int)
   returns table(ret anyarray)
@@ -496,7 +496,7 @@ You can see that each leg of the `CASE` is "generated" formulaically—albeit ma
 2202E: slice dimension % is out of the valid range 0..%
 ```
 Here is the test harness. Both this procedure and the function that generates the to-be-tested iterand array are hard-coding for a dimensionality of `4`.
-```postgresql
+```plpgsql
 -- Exercise each of the meaningful calls to array_slices().
 --
 -- You cannot declare local variables as "anyelement" or "anyarray".
@@ -576,7 +576,7 @@ end;
 $body$;
 ```
 Here is a function to generate a four-dimensional array. Notice that the actual argument for  the _"lengths"_ formal parameter must be a one-dimensional `int[]` array with four values. These specify the lengths along each of the output array's dimensions.
-```postgresql
+```plpgsql
 create function four_d_array(lengths in int[])
   returns text[]
   immutable
@@ -636,7 +636,7 @@ end;
 $body$;
 ```
 And here is one example test invocation:
-```postgresql
+```plpgsql
 do $body$
 declare
   arr constant text[] not null := four_d_array('{2, 2, 2, 2}'::int[]);

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/array-to-json.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/array-to-json.md
@@ -25,7 +25,7 @@ return value:      json
 
 **Notes:** This has only a `json` variant. The first (mandatory) formal parameter is any SQL array whose elements might be compound values. The second formal parameter is optional. When it is _true_, line feeds are added between dimension-1 elements.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   sql_array constant text[] := array['a', 'b', 'c'];

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/concatenation-operator.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/concatenation-operator.md
@@ -25,7 +25,7 @@ return value:       jsonb
 
 If both sides of the operator are primitive JSON values, then the result is an _array_ of these values:
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j_left constant jsonb := '17';
@@ -41,7 +41,7 @@ $body$;
 
 If one side is a primitive JSON value and the other is an  _array_ , then the result is an _array_:
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j_left constant jsonb := '17';
@@ -57,7 +57,7 @@ $body$;
 
 If each side is an _object_, then the results is an _object_ with all the key-value pairs present:
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j_left constant jsonb := '{"a": 1, "b": 2}';
@@ -73,7 +73,7 @@ $body$;
 
 If the keys of key-value pairs collide, then the last-mentioned one wins, just as when the keys of such pairs collide in a single _object_:
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j_left constant jsonb := '{"a": 1, "b": 2}';
@@ -89,7 +89,7 @@ $body$;
 
 If one side is an _object_ and the other is an _array_, then the _object_ is absorbed as a value in the _array_:
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j_left constant jsonb := '{"a": 1, "b": 2}';

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/containment-operators.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/containment-operators.md
@@ -28,7 +28,7 @@ return value:       boolean
 
 **Notes:** Each of these operators requires that the inputs are presented as `jsonb` values. There are no `json` overloads.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j_left  constant jsonb := '{"a": 1, "b": 2}';

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/equality-operator.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/equality-operator.md
@@ -29,7 +29,7 @@ lhs_json_value::text = rhs_json_value::text
 
 Example:
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j1 constant jsonb := '["a","b","c"]';
@@ -51,7 +51,7 @@ If you need to test two `json` values for equality, then you must `::text` typec
 
 See the account of the `::text` operator when the input is a `json` value. The `json` representation preserves semantically insignificant whitespace and repeats occurrences of the same keys in an _object_. This implies that the equality comparison of two `json` values would in general be unpredictable and therefore meaningless. This is why the `=` operator doesn't have a `json` overload and is is another reason to prefer consistently to choose to use `jsonb`.
 
-```postgresql 
+```plpgsql 
 do $body$
 declare
   j1 constant json := '["a","b","c"]';

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-agg.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-agg.md
@@ -23,7 +23,7 @@ return value:      jsonb
 
 **Notes:** The syntax _"order by column1 nulls first"_ within the parentheses of the aggregate function is not specific to `jsonb_agg()`. Rather, it is a generic feature of aggregate functions. The same syntax is used with the [array_agg()`](../../../type_array/functions-operators/array-agg-unnest/#array-agg) function for SQL arrays.
 
-```postgresql
+```plpgsql
 create type rt as (key1 int, key2 text);
 
 do $body$
@@ -55,7 +55,7 @@ end;
 $body$;
 ```
 You can also aggregate SQL arrays into a ragged JSON _array_ of JSON _arrays_ like this:
-```postgresql
+```plpgsql
 do $body$
 declare
   agg jsonb not null := '"?"';

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-array-elements-text.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-array-elements-text.md
@@ -27,7 +27,7 @@ This example uses the same JSON _array_ input that was used to illustrate `jsonb
 
 Notice that the JSON value _null_ becomes a genuine SQL `NULL`. However, SQL array comparison uses `IS NOT DISTINCT FROM` semantics, and not the semantics that the comparison of scalars uses. So the simple `ASSERT` that `elements = expected_elements` is `TRUE` is sufficient. See the section [Operators for comparing two arrays](../../..//type_array/functions-operators/comparison/).
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j_array constant jsonb := '["cat", "dog house", 42, true, {"x": 17}, null]';
@@ -64,7 +64,7 @@ This example emphasizes the impedance mismatch between a JSON _array_ and a SQL 
 
 If you have prior knowledge of the convention to which the input JSON document adheres, you can cast the output of `jsonb_array_elements_text()` to, say, `integer` or `boolean`. For example, this:
 
-```postgresql
+```plpgsql
 create domain length as numeric
   not null
   check (value > 0);
@@ -82,7 +82,7 @@ value for domain length violates check constraint "length_check"
 ```
 
 And if you set one of the input elements to the JSON _null_, like this:
-```postgresql
+```plpgsql
 select value::length
 from jsonb_array_elements_text(
   '[17, null, 42, 47, 53]'::jsonb
@@ -96,7 +96,7 @@ domain length does not allow NULL values
 
 Here's the same idea for `boolean` values:
 
-```postgresql
+```plpgsql
 create domain truth as boolean
   not null;
 

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-array-elements.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-array-elements.md
@@ -24,7 +24,7 @@ return value:      SETOF jsonb
 
 Notice that the JSON value _null_ becomes a genuine SQL `NULL`. However, SQL array comparison and `record` comparison use `IS NOT DISTINCT FROM` semantics, and not the semantics that the comparison of scalars uses. So the simple `ASSERT` that `elements = expected_elements` is `TRUE` is sufficient. See the section [Operators for comparing two arrays](../../..//type_array/functions-operators/comparison/).
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j_array constant jsonb := '["cat", "dog house", 42, true, {"x": 17}, null]';

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-array-length.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-array-length.md
@@ -23,7 +23,7 @@ return value:      integer
 
 **Notes:** Each function in this pair requires that the supplied JSON value is an _array_.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j constant jsonb := '["a", 42, true, null]';

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-build-array.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-build-array.md
@@ -26,7 +26,7 @@ return value:      jsonb
 
 Use this `ysqlsh` script to create the required type _"t"_ and then to execute the `ASSERT`.
 
-```postgresql
+```plpgsql
 create type t as (a int, b text);
 
 do $body$
@@ -50,7 +50,7 @@ Using `jsonb_build_array()` is straightforward when you know the structure of yo
 
 The following `ysqlsh` script shows a feasible general workaround for this use case. The helper function _"f()"_ generates the variadic argument list as the text representation of a comma-separated list of SQL literals of various data types. Then it invokes `jsonb_build_array()` dynamically. Obviously this brings a performance cost. But you might not have an alternative.
 
-```postgresql
+```plpgsql
 create function f(variadic_array_elements in text) returns jsonb
   immutable
   language plpgsql

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-build-object.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-build-object.md
@@ -36,7 +36,7 @@ keyN::text, valueN::the_data_typeN
 
 Use this `ysqlsh` script to create the required type _"t"_ and then to execute the `ASSERT`.
 
-```postgresql
+```plpgsql
 create type t as (a int, b text);
 
 do $body$
@@ -65,7 +65,7 @@ Just as with [`jsonb_build_array()`](../jsonb-build-array), using `jsonb_build_o
 
 The following `ysqlsh` script shows a feasible general workaround for this use case. The helper function _"f()"_ generates the variadic argument list as the text representation of a comma-separated list of SQL literals of various data types. Then it invokes `jsonb_build_object()` dynamically. Obviously this brings a performance cost. But you might not have an alternative.
 
-```postgresql
+```plpgsql
 create function f(variadic_array_elements in text) returns jsonb
   immutable
   language plpgsql

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-each-text.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-each-text.md
@@ -25,7 +25,7 @@ return value:      SETOF (text, text)
 
 Use this `ysqlsh` script to create the required type _"t"_ and then to execute the `ASSERT`.
 
-```postgresql
+```plpgsql
 create type t as (k text, v text);
 
 do $body$

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-each.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-each.md
@@ -23,7 +23,7 @@ return value:      SETOF (text, jsonb)
 
 Use this `ysqlsh` script to create the required type _"t"_ and then to execute the `ASSERT`.
 
-```postgresql
+```plpgsql
 create type t as (k text, v jsonb);
 
 do $body$

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-object-agg.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-object-agg.md
@@ -22,7 +22,7 @@ return value:      jsonb
 ```
 
 **Notes:** The syntax _"order by... nulls first"_ within the parentheses of the aggregate function (a generic feature of aggregate functions) isn't useful here because the order of the _key-value_ pairs of a JSON _object_ has no semantic significance. (The `::text` typecast of a `jsonb` _object_ uses the convention of ordering the pairs alphabetically by the key_.
-```postgresql
+```plpgsql
 do $body$
 declare
   object_agg jsonb not null := '"?"';
@@ -46,7 +46,7 @@ $body$;
 ```
 
 An _object_ is a set of key-value pairs where each key is unique and the order is undefined and insignificant. (As explained earlier, when a JSON literal is This example emphasizes the property of a JSON _object_ that _keys_ are unique. (See the accounts of the [`jsonb_set()` and `jsonb_insert()`](../jsonb-set-jsonb-insert) functions.) This means that if a _key-value_ pair is specified more than once, then the one that is most recently specified wins. You see the same rule at work here:
-```postgresql
+```plpgsql
 select ('{"f2": 42, "f7": 7, "f2": null}'::jsonb)::text;
 ```
 It shows this:
@@ -56,7 +56,7 @@ It shows this:
  {"f2": null, "f7": 7}
 ```
 The `DO` block specifies both the value for _key "f2_" and the value for _key "f7_" twice:
-```postgresql
+```plpgsql
 do $body$
 declare
   object_agg jsonb not null := '"?"';

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-object-keys.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-object-keys.md
@@ -23,7 +23,7 @@ return value:      SETOF text
 
 **Notes:** Each function in this pair requires that the supplied JSON value is an _object_. The returned keys are ordered alphabetically.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   object constant jsonb :=

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-object.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-object.md
@@ -27,7 +27,7 @@ Precisely because you present a single `text` actual, you can avoid the fuss of 
 
 The first overload has a single `text[]` formal whose actual text expresses the variadic intention conventionally: the alternating _comma_ separated items are the respectively the key and the value of a key-value pair.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   array_values constant text[] :=
@@ -50,7 +50,7 @@ The potential loss of data type fidelity brought by `jsonb_object()` is a high p
 
 If you think that it improves the clarity, you can use the second overload. This has a single `text[][]` formal—in other words an array of arrays.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   array_values constant text[][] :=
@@ -75,7 +75,7 @@ This produces the identical result to that produced by the example for the first
 
 Again, if you think that it improves the clarity, you can use the third overload. This has a two `text[]` formals. The first expresses the list keys of the key-values pairs. And the second expresses the list values of the key-values pairs. The items must correspond pairwise, and clearly each array must have the same number of items. For example:
 
-```postgresql
+```plpgsql
 do $body$
 declare
   array_keys constant text[] :=

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-populate-recordset.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-populate-recordset.md
@@ -31,7 +31,7 @@ Use this `ysqlsh` script to create the  type _"t"_, and then to execute the `ASS
 Notice the because the result is a table, it must be materialized in a `cursor for loop`. Each selected row is accumulated in an array of type `t[]`. The expected result is also established in an array of type `t[]`. The input JSON _array_ has been contrived, by sometimes not having a key `"a"` or a key `"b"` so that the resulting records sometimes have `NULL` fields. Record comparison, and array comparison, both use `IS NOT DISTINCT FROM` semantics—unlike is the case for scalar comparison. This means that the `ASSERT` can use a simple equality test to compare _"rows"_ and _"expected_rows"_. See the section [Operators for comparing two arrays](../../..//type_array/functions-operators/comparison/).
 {{< /note >}}
 
-```postgresql
+```plpgsql
 create type t as (a int, b int);
 
 do $body$

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-pretty.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-pretty.md
@@ -27,7 +27,7 @@ Because, in the main, JSON is mechanically generated and mechanically consumed, 
 
 The pretty format makes conventional, and liberal, use of newlines and spaces, thus:
 
-```postgresql
+```plpgsql
 do $body$
 declare
   orig_text constant text := '

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-set-jsonb-insert.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-set-jsonb-insert.md
@@ -46,7 +46,7 @@ return value:       jsonb
 ## Semantics when "jsonb&#95;in" is a JSON object
 parsed, or when two JSON values are concatenated, and if a key is repeated, then the last-mentioned in left-to-right order wins.) The functionality is sufficiently illustrated by a _"json_in"_ value that has just primitive values. The result of each function invocation is the same.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j constant jsonb := '{"a": 1, "b": 2, "c": 3}';
@@ -88,7 +88,7 @@ Try using the function jsonb_set to replace key value.
 
 And this `DO` block quietly succeeds, both when it's invoked with _"create_if_missing"_ set to `FALSE` and when it's invoked with _"create_if_missing"_ set to `TRUE`.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j constant jsonb := '{"a": 1, "b": 2, "c": 3}';
@@ -114,7 +114,7 @@ $body$;
 
 A JSON _array_ is a list of index-addressable values—in other words, the order is defined and significant. Again, the functionality is sufficiently illustrated by a `json_in` value that has just primitive values. Now the result of `jsonb_set()` differs from that of `jsonb_insert()`. 
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j constant jsonb := '["a", "b", "c", "d"]';
@@ -151,7 +151,7 @@ Here, `jsonb_set()` located the fourth value and set it to _"x"_ while `jsonb_in
 
 What if the path denotes a value beyond the end of the array?
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j constant jsonb := '["a", "b", "c", "d"]';
@@ -189,7 +189,7 @@ The path, for `jsonb_insert()`, is also taken to mean the as yet nonexistent fif
 
 Notice that if the path is specified as `-42` (i.e. an impossible _array_ index) the result is to establish the specified new value at the _start_ of the _array_. `jsonb_set` and `jsonb_insert` produce the same result, this:
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j constant jsonb := '["a", "b", "c", "d"]';

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-strip-nulls.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-strip-nulls.md
@@ -23,7 +23,7 @@ return value:      jsonb
 
 **Notes:** By definition, these functions leave _null_ values within _arrays_ untouched.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j constant jsonb :=

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-to-record.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-to-record.md
@@ -27,7 +27,7 @@ select... as on_the_fly(<record definition>)
 ```
 Use this `ysqlsh` script to create the type _"t"_ that just `jsonb_populate_record()` requires, to convert the input `jsonb` into a SQL `record` using each of  `jsonb_populate_record()` and `jsonb_to_record`, and then to execute the `ASSERT`. Notice that _"on_the_fly"_ is a nonce name, made up for this example. Anything will suffice.
 
-```postgresql
+```plpgsql
 create type t as (a int, b text);
 
 do $body$
@@ -54,7 +54,7 @@ $body$;
 
 The nominal advantage of `jsonb_to_record()`, that it doesn't need a schema-level type, is lost when the input JSON _object_ has another _object_ as the value of one of its keys. Consider this `ysqlsh` script:
 
-```postgresql
+```plpgsql
 create type t1 as ( d int, e text);
 create type t2 as (a int, b text[], c t1);
 

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-to-recordset.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-to-recordset.md
@@ -25,7 +25,7 @@ return value:      SETOF record
 
 Therefore, the `DO` block that demonstrated the functionality of [`jsonb_populate_recordset()`](../jsonb-populate-recordset/) can be extended to demonstrate the functionality of `jsonb_to_recordset()` as well and to show that their results are identical. See the _"Record and array comparison"_ note in the account of `jsonb_populate_recordset()`.
 
-```postgresql
+```plpgsql
 create type t as (a int, b int);
 
 do $body$

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-typeof.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-typeof.md
@@ -23,7 +23,7 @@ return value:      text
 
 **Notes:** Possible return values are _string_, _number_, _boolean_, _null_,  _object_, and _array_, as follows.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j_string   constant jsonb := '"dog"';

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/key-or-value-existence-operators.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/key-or-value-existence-operators.md
@@ -31,7 +31,7 @@ return value:       boolean
 
 Here, the existence expression evaluates to `TRUE` so the  `ASSERT` succeeds:
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j constant jsonb := '{"a": "x", "b": "y"}';
@@ -46,7 +46,7 @@ $body$;
 
 Here, the existence expression for this counter-example evaluates to `FALSE` because the left-hand JSON value has _"x"_ as a _value_ and not as a _key_.
 
-````postgresql
+````plpgsql
 do $body$
 declare
   j constant jsonb := '{"a": "x", "b": "y"}';
@@ -61,7 +61,7 @@ $body$;
 
 Here, the existence expression for this counter-example evaluates to `FALSE` because the left-hand JSON value has the _object_ not at top-level but as the second subvalue in a top-level _array_:
 
-````postgresql
+````plpgsql
 do $body$
 declare
   j constant jsonb := '[1, {"a": "x", "b": "y"}]';
@@ -76,7 +76,7 @@ $body$;
 
 **Input is an _array_:** 
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j_str_arr constant jsonb := '["cat", "dog", "from"]';
@@ -92,7 +92,7 @@ $body$;
 **Further clarification of semantics:**
 
 The only possible (and useful) match for the right-hand scalar SQL `text` value is a _key_ name in an _object_ or a _string_ value in an _array_. Here are the counter-examples for the other primitive and compound JSON values:
-```postgresql
+```plpgsql
 do $body$
 declare
   -- Positive test
@@ -143,7 +143,7 @@ return value:       boolean
 **Input is an _object_:**
 
 Here, the existence expression evaluates to `TRUE`.
-```postgresql
+```plpgsql
 do $body$
 declare
   j constant jsonb := '{"a": "x", "b": "y", "c": "z"}';
@@ -158,7 +158,7 @@ $body$;
 
 Here, the existence expression for this counter-example evaluates to `FALSE` because none of the `text` values in the right-hand array exists as the key of a key-value pair.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j constant jsonb := '{"a": "x", "b": "y", "c": "z"}';
@@ -177,7 +177,7 @@ $body$;
 
 Here, the existence expression evaluates to `TRUE`.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j constant jsonb := '["a", "b", "c"]';
@@ -205,7 +205,7 @@ return value:       boolean
 
 Here, the existence expression evaluates to _true_:
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j constant jsonb := '{"a": "w", "b": "x", "c": "y", "d": "z"}';
@@ -220,7 +220,7 @@ $body$;
 
 Here, the existence expression for this counter-example evaluates to `FALSE` because _'z'_ in the right-hand key list exists as the value of a key-value pair, but not as the key of such a pair.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j constant jsonb := '{"a": "x", "b": "y", "c": "z"}';
@@ -236,7 +236,7 @@ $body$;
 
 Here, existence expression evaluates to _true_:
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j constant jsonb := '["a", "b", "c", "d"]';

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/remove-operators.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/remove-operators.md
@@ -31,7 +31,7 @@ return value:       jsonb
 
 To remove a single key-value pair:
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j_left constant jsonb := '{"a": "x", "b": "y"}';
@@ -47,7 +47,7 @@ $body$;
 
 To remove several key-value pairs:
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j_left constant jsonb := '{"a": "p", "b": "q", "c": "r"}';
@@ -63,7 +63,7 @@ $body$;
 
 To remove a single value from an _array_:
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j_left constant jsonb := '[1, 2, 3, 4]';
@@ -85,7 +85,7 @@ operator does not exist: jsonb - integer[]
 
 You can achieve the result thus:
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j_left constant jsonb := '[1, 2, 3, 4, 5, 7]';
@@ -112,7 +112,7 @@ return value:       jsonb
 
 **Notes:** There is no `json` overload.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j_left constant jsonb := '["a", {"b":17, "c": ["dog", "cat"]}]';

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/row-to-json.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/row-to-json.md
@@ -24,7 +24,7 @@ return value:      json
 
 **Notes:** This has only the `json` variant. The first (mandatory) formal parameter is any SQL `record` whose fields might be compound values. The second formal parameter is optional. When it is _true_, line feeds are added between fields. Use this `ysqlsh` script to create the required type _"t"_ and then to execute the `ASSERT`.
 
-```postgresql
+```plpgsql
 create type t as (a int, b text);
 
 do $body$

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/subvalue-operators.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/subvalue-operators.md
@@ -29,7 +29,7 @@ return value:       jsonb
 
 Reading a key value:
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j  constant jsonb := '{"a": 1, "b": {"x": 1, "y": 19}, "c": true}';
@@ -45,7 +45,7 @@ $body$;
 
 Reading an _array_ value. (The first value in an _array_ has the index `0`.)
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j  constant jsonb := '["a", "b", "c", "d"]';
@@ -118,7 +118,7 @@ Notice that with the `->` operator, integers must be presented as such (so that 
 
 The PL/pgSQL `ASSERT` confirms that both the `->` path specification and the `#>` path specification produce the same result, thus:
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j constant jsonb := '
@@ -183,7 +183,7 @@ The difference in semantics between the `->` operator and the `->>` operator is 
 ```
 from the JSON value in which it is embedded. For example, here it is the value of the key _"a"_ in a JSON _object_:
 
-```postgresql
+```plpgsql
 do $body$
 declare
   j constant jsonb := '{"a": "\"First line\"\n\"second line\""}'::jsonb;
@@ -218,7 +218,7 @@ The `>>` variant (both for `->` _vs_ `->>` and for `#>` _vs_ `#>>`) is interesti
 
 The following `ASSERT` tests all these rules:
 
-```postgresql
+```plpgsql
 do $body$
 declare
   ta constant text     := 'a';

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/to-jsonb.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/to-jsonb.md
@@ -22,7 +22,7 @@ return value:      jsonb
 
 Use this `ysqlsh` script to create types _"t1"_ and _"t2"_ and then to execute the `DO` block that asserts that the behavior is as expected. For an arbitrary nest of SQL `record` and SQL array values, readability is improved by building the compound value from the bottom up.
 
-```postgresql
+```plpgsql
 create type t1 as(a int, b text);
 create type t2 as(x text, y boolean, z t1[]);
 

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/typecast-operators.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/typecast-operators.md
@@ -33,7 +33,7 @@ new_rfc_7159_text := (orig_rfc_7159_text::jsonb)::text
 
 The round trip is, in general, literally, but not semantically, lossy because _"orig_rfc_7159_text"_ can contain arbitrary occurrences of whitespace characters but _"new_rfc_7159_text"_ has conventionally defined whitespace use: there are no newlines; and single spaces are used according to a rule.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   orig_rfc_7159_text constant text := '
@@ -64,7 +64,7 @@ new_rfc_7159_text := (orig_rfc_7159_text::json)::text
 
 is literally non-lossy because `json` stores the actual Unicode text, as is, that defines the JSON value.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   orig_rfc_7159_text constant text := '
@@ -87,7 +87,7 @@ $body$;
 
 This example illustrates the point dramatically:
 
-```postgresql
+```plpgsql
 do $body$
 declare
   orig_rfc_7159_text constant text := '{"a": 42, "b": 17, "a": 99}';
@@ -118,7 +118,7 @@ new_json_value := (json_value::jsonb)::json;
 
 is lossy because the `json` representation stores the text definition of the JSON value.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   orig_json constant json := '

--- a/docs/content/latest/api/ysql/datatypes/type_json/json-literals.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/json-literals.md
@@ -17,7 +17,7 @@ The mutual relationship between a JSON value and its `::text` typecast is an ins
 
 This `DO` block follows, for `jsonb`,  the same pattern that is used in that section for a variety of different data types. See also the section [::jsonb and ::json and ::text (typecast)](../functions-operators/typecast-operators/).
 
-```postgresql
+```plpgsql
 create type t as (f1 int, f2 text, f3 boolean, f4 text[]);
 
 do $body$
@@ -52,7 +52,7 @@ And it shows that the `::text` typecast of a `jsonb` value that has been constru
 
 The next block follows the same pattern for `json`. However, the `ASSERT` must be written differently because the [`=` operator](../functions-operators/equality-operator/) has no overload for `json`.
 
-```postgresql
+```plpgsql
 do $body$
 declare
   v1 constant int     := 42;

--- a/docs/content/latest/api/ysql/exprs/func_currval.md
+++ b/docs/content/latest/api/ysql/exprs/func_currval.md
@@ -29,7 +29,7 @@ Specify the name of the sequence.
 
 ### Create a sequence
 
-```postgresql
+```plpgsql
 yugabyte=# CREATE SEQUENCE s;
 ```
 
@@ -39,7 +39,7 @@ CREATE SEQUENCE
 
 Call `nextval()`.
 
-```postgresql
+```plpgsql
 yugabyte=# SELECT nextval('s');
 ```
 
@@ -50,7 +50,7 @@ yugabyte=# SELECT nextval('s');
 (1 row)
 ```
 
-```postgresql
+```plpgsql
 yugabyte=# SELECT currval('s');
 ```
 
@@ -63,7 +63,7 @@ yugabyte=# SELECT currval('s');
 
 Call `currval()` before `nextval()` is called.
 
-```postgresql
+```plpgsql
 yugabyte=# CREATE SEQUENCE s2;
 ```
 
@@ -71,7 +71,7 @@ yugabyte=# CREATE SEQUENCE s2;
 CREATE SEQUENCE
 ```
 
-```postgresql
+```plpgsql
 SELECT currval('s2');
 ```
 

--- a/docs/content/latest/api/ysql/exprs/func_lastval.md
+++ b/docs/content/latest/api/ysql/exprs/func_lastval.md
@@ -25,7 +25,7 @@ Use the `lastval()` function to return the value returned from the last call to 
 
 Create two sequences and call `nextval()` for each of them.
 
-```postgresql
+```plpgsql
 yugabyte=# CREATE SEQUENCE s1;
 ```
 
@@ -33,7 +33,7 @@ yugabyte=# CREATE SEQUENCE s1;
 CREATE SEQUENCE
 ```
 
-```postgresql
+```plpgsql
 yugabyte=# CREATE SEQUENCE s2 START -100 MINVALUE -100;
 ```
 
@@ -41,7 +41,7 @@ yugabyte=# CREATE SEQUENCE s2 START -100 MINVALUE -100;
 CREATE SEQUENCE
 ```
 
-```postgresql
+```plpgsql
 yugabyte=# SELECT nextval('s1');
 ```
 
@@ -52,7 +52,7 @@ yugabyte=# SELECT nextval('s1');
 (1 row)
 ```
 
-```postgresql
+```plpgsql
 yugabyte=# SELECT nextval('s2');
 ```
 
@@ -65,7 +65,7 @@ yugabyte=# SELECT nextval('s2');
 
 Call `lastval()`.
 
-```postgresql
+```plpgsql
 yugabyte=# SELECT lastval()
 ```
 

--- a/docs/content/latest/api/ysql/exprs/func_nextval.md
+++ b/docs/content/latest/api/ysql/exprs/func_nextval.md
@@ -29,7 +29,7 @@ Specify the name of the sequence.
 
 ### Create a simple sequence that increments by 1 every time nextval() is called
 
-```postgresql
+```plpgsql
 yugabyte=# CREATE SEQUENCE s;
 ```
 
@@ -39,7 +39,7 @@ CREATE SEQUENCE
 
 Call nextval() a couple of times.
 
-```postgresql
+```plpgsql
 yugabyte=# SELECT nextval('s');
 ```
 
@@ -50,7 +50,7 @@ yugabyte=# SELECT nextval('s');
 (1 row)
 ```
 
-```postgresql
+```plpgsql
 yugabyte=# SELECT nextval('s');
 ```
 
@@ -63,7 +63,7 @@ yugabyte=# SELECT nextval('s');
 
 ### Create a sequence with a cache of 3 values
 
-```postgresql
+```plpgsql
 yugabyte=# CREATE SEQUENCE s2 CACHE 3;
 ```
 
@@ -73,7 +73,7 @@ CREATE SEQUENCE
 
 In the same session, call `nextval()`. The first time it's called, the session's cache will allocate numbers 1, 2, and 3. This means that the data for this sequence will have its `last_val` set to 3. This modification requires two RPC requests.
 
-```postgresql
+```plpgsql
 SELECT nextval('s2');
 ```
 
@@ -86,7 +86,7 @@ SELECT nextval('s2');
 
 The next call of `nextval()` in the same session will not generate new numbers for the sequence, so it is much faster than the first `nextval()` call because it will just use the next value available from the cache.
 
-```postgresql
+```plpgsql
 SELECT nextval('s2');
 ```
 

--- a/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/_index.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/_index.md
@@ -94,7 +94,7 @@ Drop and re-create the results tables using [`do_clean_start.sql`](./do-clean-st
 ### Step ONE
 
 To confirm that the outcome is sensible, first create the table function `show_t4()` with [this script](./cr-show-t4/). It reports some useful overall measures of _"t4"_.  Then execute it like this:
-```postgresql
+```plpgsql
 select t as "Some useful overall measures of t4."
 from show_t4();
 ```
@@ -114,7 +114,7 @@ Now get a sense of how similar the values returned by [`percent_rank()`](../func
 
 Run the function with five different values for _"delta_threshold"_ like this:
 
-```postgresql
+```plpgsql
 select * from pr_cd_equality_report(0.50);
 select * from pr_cd_equality_report(0.10);
 select * from pr_cd_equality_report(0.05);
@@ -178,7 +178,7 @@ as $body$
 to encapsulate the identical SQL text. But it has the advantage that it can be done once when the application's database artifacts are installed rather than at the start of every session by each session that needs it. It also as the additional benefit that you can use  named formal parameters to make the SQL more readable.
 
 Now generate the histogram like this:
-```postgresql
+```plpgsql
 select * from histogram(50, 100);
 ```
 You can see typical results here: [Output from running `histogram()` on _"t4.dp_score"_](./reports/histogram-report/).

--- a/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/bucket-allocation.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/bucket-allocation.md
@@ -51,7 +51,7 @@ then the buckets are defined as these _closed-open_ intervals:
 Any value that is less than _0_ is allocated to the lower overflow bucket _0_. And any value that is greater than or equal to the value _100_ is allocated to the upper overflow bucket _11_.
 Here is an example:
 
-```postgresql
+```plpgsql
 do $body$
 declare
   lb     constant double precision := 0;

--- a/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/cr-bucket-dedicated-code.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/cr-bucket-dedicated-code.md
@@ -12,7 +12,7 @@ isTocNested: true
 showAsideToc: true
 ---
 Save this script as `cr_bucket_dedicated_code.sql`.
-```postgresql
+```plpgsql
 -- This approach implements the required "open-closed" interval
 -- bucket semantics directly. See the test
 --

--- a/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/cr-bucket-using-width-bucket.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/cr-bucket-using-width-bucket.md
@@ -12,7 +12,7 @@ isTocNested: true
 showAsideToc: true
 ---
 Save this script as `cr_bucket_using_width_bucket.sql`.
-```postgresql
+```plpgsql
 -- This approach subtracts a tiny value, epsilon, from the input value
 -- to change "width_bucket()"'s "closed-open" interval bucket semantics to
 -- the required "open-closed" interval bucket semantics.

--- a/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/cr-do-cume-dist.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/cr-do-cume-dist.md
@@ -12,7 +12,7 @@ isTocNested: true
 showAsideToc: true
 ---
 Save this script as `cr_do_cume_dist.sql`.
-```postgresql
+```plpgsql
 create or replace procedure do_cume_dist(no_of_buckets in int)
   language sql
 as $body$

--- a/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/cr-do-ntile.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/cr-do-ntile.md
@@ -12,7 +12,7 @@ isTocNested: true
 showAsideToc: true
 ---
 Save this script as `cr_do_ntile.sql`.
-```postgresql
+```plpgsql
 create or replace procedure do_ntile(no_of_buckets in int)
   language sql
 as $body$

--- a/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/cr-do-percent-rank.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/cr-do-percent-rank.md
@@ -12,7 +12,7 @@ isTocNested: true
 showAsideToc: true
 ---
 Save this script as `cr_do_percent_rank.sql`.
-```postgresql
+```plpgsql
 create or replace procedure do_percent_rank(no_of_buckets in int)
   language sql
 as $body$

--- a/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/cr-dp-views.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/cr-dp-views.md
@@ -12,7 +12,7 @@ isTocNested: true
 showAsideToc: true
 ---
 Save this script as `cr_dp_views.sql`.
-```postgresql
+```plpgsql
 -- Suppress the spurious warning that is raised
 -- when the to-be-deleted view doesn't yet exist.
 set client_min_messages = warning;

--- a/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/cr-histogram.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/cr-histogram.md
@@ -12,7 +12,7 @@ isTocNested: true
 showAsideToc: true
 ---
 Save this script as `cr_histogram.sql`.
-```postgresql
+```plpgsql
 -- "scale_factor" controls the histogram height.
 -- Use 10 for 10,000 rows, 100 for 100,000 rows.
 

--- a/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/cr-int-views.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/cr-int-views.md
@@ -12,7 +12,7 @@ isTocNested: true
 showAsideToc: true
 ---
 Save this script as `cr_int_views.sql`.
-```postgresql
+```plpgsql
 -- Suppress the spurious warning that is raised
 -- when the to-be-deleted view doesn't yet exist.
 set client_min_messages = warning;

--- a/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/cr-pr-cd-equality-report.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/cr-pr-cd-equality-report.md
@@ -12,7 +12,7 @@ isTocNested: true
 showAsideToc: true
 ---
 Save this script as `cr_pr_cd_equality_report.sql`.
-```postgresql
+```plpgsql
 set client_min_messages = warning;
 drop type if exists pr_cd_equality_report_t cascade;
 create type pr_cd_equality_report_t as("count(*)" int, max_score text, max_ratio text);

--- a/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/cr-show-t4.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/cr-show-t4.md
@@ -12,7 +12,7 @@ isTocNested: true
 showAsideToc: true
 ---
 Save this script as `cr_show_t4.sql`.
-```postgresql
+```plpgsql
 -- Function to report on some useful overall measures of t4.
 create or replace function show_t4()
   returns table(t varchar)

--- a/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/do-assert-bucket-ok.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/do-assert-bucket-ok.md
@@ -12,7 +12,7 @@ isTocNested: true
 showAsideToc: true
 ---
 Save this script as `do_assert_bucket_ok.sql`.
-```postgresql
+```plpgsql
 -- Test it over the full range.
 -- Pay special attention to the bucket boundaries.
 do $body$

--- a/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/do-clean-start.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/do-clean-start.md
@@ -12,7 +12,7 @@ isTocNested: true
 showAsideToc: true
 ---
 Save this script as `do_clean_start.sql`.
-```postgresql
+```plpgsql
 -- Get a clean start.
 -- These tables will store some query results so that, with
 -- all these in a single table, it is easy to use

--- a/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/do-compare-dp-results.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/do-compare-dp-results.md
@@ -12,7 +12,7 @@ isTocNested: true
 showAsideToc: true
 ---
 Save this script as `do_compare_dp_results.sql`.
-```postgresql
+```plpgsql
 with
   nt_results as (
     select

--- a/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/do-demo.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/do-demo.md
@@ -12,7 +12,7 @@ isTocNested: true
 showAsideToc: true
 ---
 Save this script as `do_demo.sql`.
-```postgresql
+```plpgsql
 -- Uses table t4.
 -- Once you've created it, you can run this script time and again using
 -- for example, a different number of histogran buckets or a

--- a/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/do-populate-results.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/do-populate-results.md
@@ -12,7 +12,7 @@ isTocNested: true
 showAsideToc: true
 ---
 Save this script as `do_populate_results.sql`.
-```postgresql
+```plpgsql
 do $body$
 declare
   nof_buckets constant int not null := 20;

--- a/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/do-report-results.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/analyzing-a-normal-distribution/do-report-results.md
@@ -12,7 +12,7 @@ isTocNested: true
 showAsideToc: true
 ---
 Save this script as `do_report_results.sql`.
-```postgresql
+```plpgsql
 \t on
 select 'Using ntile().';
 \t off

--- a/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/_index.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/_index.md
@@ -70,7 +70,7 @@ The names of the other window functions that the second table lists, `first_valu
 
 See the section [Window function invocation—SQL syntax and semantics](../sql-syntax-semantics). But the default does _not_ specify the entire [_window_](../sql-syntax-semantics/#the-window-definition-rule). To do this, use this variant:
 
-```postgresql
+```plpgsql
 -- You must specify this explicitly unless you are sure
 -- that you want a different specification.
 range between unbounded preceding and unbounded following

--- a/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/data-sets/_index.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/data-sets/_index.md
@@ -24,7 +24,7 @@ contain scripts to create and populate tables with data sets that are useful for
 
 Each table uses a surrogate `uuid` primary key whose values are provided by the function `gen_random_uuid()`, brought by the `pgcrypto` extension. The procedure to populate table _"t4"_ also uses the function `normal_rand()`, brought by the `tablefunc` extension. These extensions are described in the sections [pgcrypto](../../../../extensions/#pgcrypto) and [tablefunc](../../../../extensions/#tablefunc) in the section [Install and use extensions](../../../../extensions/). Each is a pre-bundled extension. This means that the installation for each will work without any preparatory steps, as long as you install them as a `superuser` like this:
 
-```postgresql
+```plpgsql
 create extension pgcrypto;
 create extension tablefunc;
 ```
@@ -79,7 +79,7 @@ and save each of the scripts that these present onto the same directory where yo
 
 Save this script as, for example, `install_all_tables.sql`:
 
-```postgresql
+```plpgsql
 -- You can run this script time and again. It will always finish silently.
 
 \i t1.sql
@@ -97,7 +97,7 @@ Save this script as, for example, `install_all_tables.sql`:
 ```
 Then you can simply do this whenever you need to re-establish the state that the code examples rely on:
 
-```postgresql
+```plpgsql
 \i install_all_tables.sql
 ```
 

--- a/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/data-sets/table-t1.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/data-sets/table-t1.md
@@ -25,7 +25,7 @@ It is also used in the section [Informal overview of function invocation using t
 
 This `ysqlsh` script creates and populates able _"t1"_. Save it as `t1.sql`.
 
-```postgresql
+```plpgsql
 -- Suppress the spurious warning that is raised
 -- when the to-be-deleted table doesn't yet exist.
 set client_min_messages = warning;
@@ -72,7 +72,7 @@ Now inspect its contents. Notice that the first SELECT to display the content ha
 
 The second `SELECT` orders the rows usefully and, of course, produces a deterministically reliable result.
 
-```postgresql
+```plpgsql
 \pset null '??'
 
 -- Notice the absence of "ORDER BY".
@@ -120,7 +120,7 @@ Here is the result of the second `SELECT`. To make it easier to see the pattern,
 
 Do the following to demonstrate that the result set produced by invoking a window function with an `OVER` clause whose [**window_definition**](../../../../../syntax_resources/grammar_diagrams/#window-definition) doesn't include a window `ORDER BY` clause is unreliable. Be sure to re-run the table creation and population script each time before you run this query:
 
-```postgresql
+```plpgsql
 select
   class,
   k,

--- a/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/data-sets/table-t2.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/data-sets/table-t2.md
@@ -32,7 +32,7 @@ For maximum pedagogic effect, it uses the same technique that [table t1](../tabl
 
 This `ysqlsh` script creates and populates able _"t2"_. Save it as `t2.sql`.
 
-```postgresql
+```plpgsql
 -- Suppress the spurious warning that is raised
 -- when the to-be-deleted table doesn't yet exist.
 set client_min_messages = warning;
@@ -88,7 +88,7 @@ order by r;
 ```
 Now inspect its contents:
 
-```postgresql
+```plpgsql
 -- Notice the absence of "ORDER BY".
 select class, k, score
 from t2;

--- a/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/data-sets/table-t3.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/data-sets/table-t3.md
@@ -20,7 +20,7 @@ The rows in table  _"t3"_ are inserted in random order. It has twenty-five rows 
 
 This `ysqlsh` script creates and populates able _"t3"_. Save it as `t3.sql`.
 
-```postgresql
+```plpgsql
 -- Suppress the spurious warning that is raised
 -- when the to-be-deleted table doesn't yet exist.
 set client_min_messages = warning;
@@ -76,7 +76,7 @@ order by r;
 
 Now inspect its contents:
 
-```postgresql
+```plpgsql
 -- Notice the absence of "ORDER BY".
 select
   to_char(day, 'Dy DD-Mon-YYYY') as "Day",

--- a/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/data-sets/table-t4.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/data-sets/table-t4.md
@@ -33,7 +33,7 @@ A large value like 100,000 gives the best compromise between the time to populat
 This `ysqlsh` script creates the table _"t4"_ and creates the procedure to populate the table.
 Save it as `t4_1.sql`.
 
-```postgresql
+```plpgsql
 -- Suppress the spurious warning that is raised
 -- when the to-be-deleted table doesn't yet exist.
 set client_min_messages = warning;
@@ -89,7 +89,7 @@ $body$;
 
 This script executes the procedure and then creates a unique index on the _"dp_score"_ column. Save it as `t4_2.sql`.
 
-```postgresql
+```plpgsql
 -- You can run this script time and again. It will always finish silently.
 
 set client_min_messages = warning;

--- a/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/first-value-nth-value-last-value.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/first-value-nth-value-last-value.md
@@ -56,7 +56,7 @@ If you haven't yet installed the tables that the code examples use, then go to t
 This example uses table _"t1"_. Notice that it has been contrived so that the last _"v"_ (ordered by _"k"_) for each value of _"class"_ is `NULL`. 
 
 Use the technique shown in the section [Using `nth_value()` and `last_value()` to return the whole row](../#using-nth-value-and-last-value-to-return-the-whole-row) so that each of the three window functions produces all of the fields in each row:
-```postgresql
+```plpgsql
 drop type if exists rt cascade;
 create type rt as (class int, k int, v int);
 
@@ -107,7 +107,7 @@ Here is the result. To make it easier to see the pattern, a break has been manua
      5 | 25 | (5,21,21) | (5,23,23) | (5,25,)
 ```
 Notice that the `::text` typecast of a _"row"_ type value renders `NULL` simply as an absence. This explains why you see, for example, _"(1,5,)"_ for each value produced by `last_value()` in the [_window_](../../sql-syntax-semantics/#the-window-definition-rule) where _"k=1"_. This basic example certainly demonstrates the meaning of _"first"_, _"Nth"_ (for _"N=3"_), and _"last"_. But it isn't very useful because, just as these names suggest, the output is the same for each row in a particular [_window_](../../sql-syntax-semantics/#the-window-definition-rule). The following query adds a conventional `GROUP BY` clause. It also extracts the interesting fields from the _"row"_ type value that each window function produces as individual values.
-```postgresql
+```plpgsql
 drop type if exists rt cascade;
 create type rt as (class int, k int, v int);
 \pset null '??'

--- a/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/lag-lead.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/lag-lead.md
@@ -22,7 +22,7 @@ If you haven't yet installed the tables that the code examples use, then go to t
 
 Try this basic demonstration. The actual argument, _2_, for each of `lag()` and `lead()` means, respectively, look back by two rows and look forward by two rows.
 
-```postgresql
+```plpgsql
 \pset null '<null>'
 select
   to_char(day, 'Dy DD-Mon') as "Day",
@@ -65,7 +65,7 @@ This is the result:
 ```
 Notice that _"last_but_one_price"_ is `NULL` for the first two rows. This is, of course, because looking back by two rows for each of these takes you to before the start of the window and so the result of _"lag(price, 2)"_ cannot be determined. In the same way,  _"next_but_one_price"_ is `NULL` for the last two rows. It's easier to check, visually, that the results are as promised by focusing on one particular row, say Wed 01-Oct, the previous-but-one row, Mon 29-Sep, and the next-but-one row, Fri 03-Oct, thus:
 
-```postgresql
+```plpgsql
 with v as (
   select
     day,
@@ -125,7 +125,7 @@ Use the optional last parameter to specify the value to be returned, instead of 
 ## Example of returning a row
 
 Here is the minimal demonstration of this technique. Notice that the syntax requires that the actual argument to `lag()` must used to construct a record or a _"row"_ type value. Usually, you want to access the individual column values, but, it can be tricky to work with records because they are anonymous data types. This means that you don't know what the fields are called. The better, therefore, is given by a user-defined _"row"_ type. Do this to demonstrate the technique:
-```postgresql
+```plpgsql
 drop type if exists rt cascade;
 create type rt as(day date, price money);
 \pset null '<null>'
@@ -152,7 +152,7 @@ This is the result. (Some rows have been manually elided.)
 
 Now, the fields of the _"row"_ type values can be accessed, thus:
 
-```postgresql
+```plpgsql
 drop type if exists rt cascade;
 create type rt as(day date, price money);
 \pset null '<null>'
@@ -201,7 +201,7 @@ This is the result. (Again, some rows have been manually elided.)
 ## Realistic use case
 
 The first example lists the daily change in stock price for the available data, deliberately excluding the case where `lag()` would look before the start of the window:
-```postgresql
+```plpgsql
 with
   v1 as (
   select
@@ -248,7 +248,7 @@ This is the result:
  Fri 17-Oct | $17.02 |     $16.99 |    0.2
 ```
 The second example uses conventional techniques to show the row that saw the biggest daily price change:
-```postgresql
+```plpgsql
 with
   v1 as (
   select

--- a/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/percent-rank-cume-dist-ntile.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/percent-rank-cume-dist-ntile.md
@@ -122,7 +122,7 @@ Create a data set using the `ysqlsh` script that [table t2](../data-sets/table-t
 
 Now do this:
 
-```postgresql
+```plpgsql
 with
   v1 as (
     select

--- a/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/row-number-rank-dense-rank.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/row-number-rank-dense-rank.md
@@ -51,7 +51,7 @@ If you haven't yet installed the tables that the code examples use, then go to t
 {{< /note >}}
 
 This example highlights the semantic difference between `row_number()`, `rank()`, and `dense_rank()`. Create a data set using the `ysqlsh` script that [table t2](../data-sets/table-t2/) presents. Then do this:
-```postgresql
+```plpgsql
 select
   class,
   k,

--- a/docs/content/latest/api/ysql/exprs/window_functions/functionality-overview.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/functionality-overview.md
@@ -30,7 +30,7 @@ If you haven't yet installed the tables that the code examples use, then go to t
 
 The [`row_number()`](../function-syntax-semantics/row-number-rank-dense-rank/#row-number) window function is the simplest among the set of eleven such functions that YSQL supports. Briefly, this function assigns an ordinal number, starting at _1_, to the rows within the specified [_window_](../sql-syntax-semantics/#the-window-definition-rule) according to the specified ordering rule. Here is the most basic example.
 
-```postgresql
+```plpgsql
 select
   k,
   row_number() over(order by k desc) as r
@@ -61,7 +61,7 @@ Because the `OVER` clause doesn't specify a `PARTITION BY` clause, the so-called
 
 The next example emphasizes the point that a window function is often used in a subquery which, like any other subquery, is used to define a `WITH` clause view to allow further logic to be applied—in this case, a `WHERE` cause restriction on the values returned by [`row_number()`](../function-syntax-semantics/row-number-rank-dense-rank/#row-number) (and, of course, a final query-level `ORDER BY` rule).
 
-```postgresql
+```plpgsql
 with v as (
   select
     k,
@@ -150,7 +150,7 @@ Sometimes, you'll see that, by chance, not a single output row is marked _"true"
 ### Using row_number() with "PARTITION BY"
 
 This example adds a `PARTITION BY` clause to the window `ORDER BY` clause in the [**window_definition**](../../../syntax_resources/grammar_diagrams/#window-definition) . It selects and orders by _"v"_ rather than _"k"_ because this has `NULL`s and demonstrates the within-[_window_](../sql-syntax-semantics/#the-window-definition-rule) effect of `NULLS FIRST`. The [**window_definition**](../../../syntax_resources/grammar_diagrams/#window-definition) is moved to a dedicated `WINDOW` clause that names it so that the `OVER` clause can simply reference the definition that it needs. This might seem only to add verbosity in this example. But using a dedicated `WINDOW` clause reduces verbosity when invocations of several different window functions in the same subquery use the same [**window_definition**](../../../syntax_resources/grammar_diagrams/#window-definition) .
-```postgresql
+```plpgsql
 \pset null '??'
 
 with a as (
@@ -187,7 +187,7 @@ This is the result:
 
 If you want the output value for any of `first_value()`, `last_value()`, `nth_value()`, `lag()`, or `lead()` to include more than one column, then you must list them in a _"row"_ type constructor. This example uses [`nth_value()`](../function-syntax-semantics/first-value-nth-value-last-value/#nth-value). This accesses the _Nth_ row within the ordered set that each [_window_](../sql-syntax-semantics/#the-window-definition-rule) defines. It picks out the third row. The restriction _"class in (3, 5)"_ cuts down the result set to make it easier to read.
 
-```postgresql
+```plpgsql
 drop type if exists rt cascade;
 create type rt as (class int, k int, v int);
 
@@ -219,7 +219,7 @@ It produces this result:
      5 | (5,23,23)
 ```
 Each of `first_value()`, `last_value()`, and `nth_value()`, as their names suggest, produces the same output for each row of a [_window_](../sql-syntax-semantics/#the-window-definition-rule). It would be natural, therefore, to use the query above in a `WITH` clause whose final `SELECT ` picks out the individual columns from the record and adds a `GROUP BY` clause, thus:
-```postgresql
+```plpgsql
 drop type if exists rt cascade;
 create type rt as (class int, k int, v int);
 
@@ -260,7 +260,7 @@ The query is specifically written to meet the exact requirements. It would need 
 
 The statement of requirement implies that the computation is not feasible for the first two and the last two days in the window. Under these circumstances, `lag()` and `lead()`, return `NULL`—or, it you prefer, a default value that you supply using an optional third parameter. See the dedicated section on [`lag()` and `lead()`](../function-syntax-semantics/lag-lead/) for details.
 
-```postgresql
+```plpgsql
 with v as (
   select
     day,
@@ -312,7 +312,7 @@ order by day groups between $1 preceding and $1 following
 Here, the statement is first prepared and then executed to emphasize the fact that a single formulation of the statement text works for any arbitrary range of days around the current row. The section [Window function invocation—SQL syntax and semantics](../sql-syntax-semantics/) explains the full power of expression brought by the `OVER` clause.
 
 Notice that this approach uses the value returned by [`row_number()`](../function-syntax-semantics/row-number-rank-dense-rank/#row-number), using an `OVER` clause that does no more than order the rows, to exclude the meaningless first _N_ and last _N_ averages, where _N_ is the same parameterized value that _"groups between N preceding and N following"_ uses. These rows, if not excluded, would simply show the averages over the rows that allow access. You probably don't want to see those answers.
-```postgresql
+```plpgsql
 prepare stmt(int) as
 with v as (
   select
@@ -339,7 +339,7 @@ range between unbounded preceding and current row
 ```
 so that the average includes, for each row, the row itself and only the rows that precede it in the sort order.
 
-```postgresql
+```plpgsql
 with v as (
   select
     class,

--- a/docs/content/latest/api/ysql/exprs/window_functions/sql-syntax-semantics.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/sql-syntax-semantics.md
@@ -132,7 +132,7 @@ In summary, the [**window_definition**](../../../syntax_resources/grammar_diagra
 
 The `FILTER` clause's `WHERE` clause has the same syntax and semantics as it does at the regular `WHERE` clause syntax spot immediately after a subquery's `FROM` list. Notice that the `FILTER` clause is legal only for the invocation of an aggregate function. Here is an example:
 
-```postgresql
+```plpgsql
 select
   class,
   k,


### PR DESCRIPTION
**Global replace of triple-backtick 'postgresql' lexer syntaxwith 'plpgsql' in JSON, Arrays, and Window functions**

292 replacements made in 83 files.