### PR TITLE
Small change in Arrays section (FOREACH over array of DOMAINs)

### DIFF
--- a/docs/content/latest/api/ysql/datatypes/type_array/array-of-domains.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/array-of-domains.md
@@ -79,6 +79,8 @@ But this causes a compilation error. The paradox is exactly that `int[]` is anon
 The `DOMAIN` brings the functionality that overcomes the apparent restriction. First, do this:
 
 ```plpgsql
+set client_min_messages = warning;
+drop domain if exists int_arr_t cascade;
 create domain int_arr_t as int[];
 create table t(k serial primary key, v1 int_arr_t[], typecast text, v2 int_arr_t[]);
 ```
@@ -221,6 +223,187 @@ select
 from v;
 ```
 It causes a SQL compilation error. You must know whether the value at hand, within which you want to address a value,  is a rectilinear multidimensional array or a ragged array of arrays.
+
+### Using FOREACH with an array of DOMAINs
+
+This example demonstrates the problem.
+
+```plpgsql
+set client_min_messages = warning;
+drop domain if exists array_t cascade;
+drop domain if exists arrays_t cascade;
+
+create domain array_t  as int[];
+create domain arrays_t as array_t[];
+
+\set VERBOSITY verbose
+do $body$
+declare
+  arrays arrays_t := array[
+    array[1, 2]::array_t, array[3, 4, 5]::array_t];
+
+  runner array_t not null := '{}';
+begin
+  -- Error 42804 here.
+  foreach runner in array arrays loop
+    raise info '%', runner::text;
+  end loop;
+end;
+$body$;
+```
+It causes this syntax error:
+
+```
+42804: FOREACH expression must yield an array, not type arrays_t
+```
+The error text might confuse you. It really means that the argument of the `ARRAY` keyword in the loop header must, literally, be an explicit array—and _not_ a domain that names such an array.
+
+A simple workaround is to declare _"arrays"_ explicitly as
+_"array_t[]"_ rather that use _"arrays_t"_ as a shorthand for this.
+
+```plpgsql
+\set VERBOSITY default
+do $body$
+declare
+  arrays array_t[] := array[
+    array[1, 2]::array_t, array[3, 4, 5]::array_t];
+
+  runner array_t not null := '{}';
+begin
+  foreach runner in array arrays loop
+    raise info '%', runner::text;
+  end loop;
+end;
+$body$;
+```
+
+It shows this:
+
+```
+INFO:  {1,2}
+INFO:  {3,4,5}
+```
+
+What if you really _do_ need to use a `DOMAIN`? For example, you might want to define a constraint like this:
+
+```plpgsql
+set client_min_messages = warning;
+drop domain if exists arrays_t cascade;
+create domain arrays_t as array_t[]
+check ((cardinality(value) = 2));
+```
+
+The workaround is to typecast the argument of the `ARRAY` keyword _in situ_ to an array of the appropriate element data type.
+
+```plpgsql
+do $body$
+declare
+  arrays arrays_t := array[
+    array[1, 2]::array_t, array[3, 4, 5]::array_t];
+
+  runner array_t not null := '{}';
+begin
+  foreach runner in array arrays::array_t[] loop
+    raise info '%', runner::text;
+  end loop;
+end;
+$body$;
+```
+Once again, it shows this:
+
+```
+INFO:  {1,2}
+INFO:  {3,4,5}
+```
+
+### Using array_agg() to produce an array of DOMAIN values
+
+See [array_agg()](../functions-operators/array-agg-unnest/#array-agg-first-overload). It turns out that directly aggregating `DOMAIN` values that represent a ragged array is not supported. But a simple PL/pgSQL function provides the workaround. This sets up to demonstrate the problem:
+
+```plpgsql
+set client_min_messages = warning;
+drop table if exists t cascade;
+drop domain if exists array_t cascade;
+drop domain if exists arrays_t cascade;
+
+create domain array_t  as int[];
+create domain arrays_t as array_t[];
+
+create table t(k serial primary key, v array_t);
+
+insert into t(v) values
+  ('{2,6}'),
+  ('{1,4,5,6}'),
+  ('{4,5}'),
+  ('{2,3}'),
+  ('{4,5}'),
+  ('{3,5,7}');
+
+select v from t order by k;
+```
+It shows the raggedness thus:
+
+```
+     v     
+-----------
+ {2,6}
+ {1,4,5,6}
+ {4,5}
+ {2,3}
+ {4,5}
+ {3,5,7}
+```
+
+And this demonstrates the problem:
+
+```plpgsql
+\set VERBOSITY verbose
+select
+  array_agg(v order by k)
+from t;
+```
+
+It causes this error:
+
+```
+2202E: cannot accumulate arrays of different dimensionality
+```
+
+Typecasting cannot come to the rescue here. But this function produces the required result:
+
+```plpgsql
+\set VERBOSITY default
+create or replace function array_agg_v()
+  returns arrays_t
+  immutable
+  language plpgsql
+as $body$
+<<b>>declare
+  v  array_t    not null := '{}';
+  n  int        not null := 0;
+  r  array_t[]  not null := '{}';
+begin
+  for b.v in (select t.v from t order by k) loop
+    n := n + 1;
+    r[n] := b.v;
+  end loop;
+  return r;
+end b;
+$body$;
+```
+Do this:
+
+```plpgsql
+select array_agg_v();
+```
+
+This is the result:
+
+```
+                       array_agg_v                       
+---------------------------------------------------------
+ {"{2,6}","{1,4,5,6}","{4,5}","{2,3}","{4,5}","{3,5,7}"}
+```
 
 ## Creating a matrix of matrices
 

--- a/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/_index.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/functions-operators/_index.md
@@ -66,7 +66,7 @@ the [RHS](https://en.wikipedia.org/wiki/Sides_of_an_equation) is an array of tha
 | Operator | 1-d only? | Description |
 | ---- | ---- | ---- |
 | [`ANY`](./any-all/) | | Returns `TRUE` if _at least one_ of the specified inequality tests between the LHS element and each of the RHS array's elements evaluates to `TRUE`. |
-| [`ALL`](./any-all/) | | Returns `TRUE` if every one_ of the specified inequality tests between the LHS element and each of the RHS array's elements evaluates to `TRUE`. |
+| [`ALL`](./any-all/) | | Returns `TRUE` if _every one_ of the specified inequality tests between the LHS element and each of the RHS array's elements evaluates to `TRUE`. |
 
 ## Operators for comparing two arrays
 

--- a/docs/content/latest/api/ysql/datatypes/type_array/looping-through-arrays.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/looping-through-arrays.md
@@ -367,7 +367,7 @@ unnest()
 
 You need to be aware of some special considerations to implement this scenario. [Using FOREACH with an array of DOMAINs](../array-of-domains/#using-foreach-with-an-array-of-domains), within the dedicated section [Using an array of DOMAIN values](../array-of-domains/) explains what you need to know. 
 
-## Using a wrapper PL/pgSQL table function to expose the SLICE operand as a formal parameter.
+## Using a wrapper PL/pgSQL table function to expose the SLICE operand as a formal parameter
 
 The fact that the `SLICE` operand must be a literal means that there are only two ways two parameterize this—and neither is satisfactory for real application code. Each uses a table function whose input is the iterand array and the value for the `SLICE` operand, and whose output is a `SETOF` iterator array values.
 

--- a/docs/content/latest/api/ysql/datatypes/type_array/looping-through-arrays.md
+++ b/docs/content/latest/api/ysql/datatypes/type_array/looping-through-arrays.md
@@ -362,6 +362,11 @@ unnest()
 8 | 007
 9 | 008
 ```
+
+## Using FOREACH to iterate over the elements in an array of DOMAIN values
+
+You need to be aware of some special considerations to implement this scenario. [Using FOREACH with an array of DOMAINs](../array-of-domains/#using-foreach-with-an-array-of-domains), within the dedicated section [Using an array of DOMAIN values](../array-of-domains/) explains what you need to know. 
+
 ## Using a wrapper PL/pgSQL table function to expose the SLICE operand as a formal parameter.
 
 The fact that the `SLICE` operand must be a literal means that there are only two ways two parameterize this—and neither is satisfactory for real application code. Each uses a table function whose input is the iterand array and the value for the `SLICE` operand, and whose output is a `SETOF` iterator array values.

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/_index.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/_index.md
@@ -7,7 +7,7 @@ description: Learn about JSON functions and operators categorized by the goal yo
 image: /images/section_icons/api/ysql.png
 menu:
   latest:
-    identifier: functions-operators
+    identifier: json-functions-operators
     parent: api-ysql-datatypes-json
     weight: 50
 isTocNested: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/array-to-json.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/array-to-json.md
@@ -7,7 +7,7 @@ description: Create a JSON array from a SQL array using the array_to_json() func
 menu:
   latest:
     identifier: array-to-json
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 53
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/concatenation-operator.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/concatenation-operator.md
@@ -6,7 +6,7 @@ description: Concatenate two jsonb values using the JSON concatenation operator 
 menu:
   latest:
     identifier: concatenation-operator
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 14
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/containment-operators.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/containment-operators.md
@@ -6,7 +6,7 @@ description:  Test whether one jsonb value contains another jsonb value using th
 menu:
   latest:
     identifier: containment-operators
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 16
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/equality-operator.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/equality-operator.md
@@ -6,7 +6,7 @@ description: Test if two jsonb values are equal using the JSON equality operator
 menu:
   latest:
     identifier: equality-operator
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 15
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-agg.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-agg.md
@@ -6,7 +6,7 @@ description: Aggregate a SETOF values into a JSON array.
 menu:
   latest:
     identifier: jsonb-agg
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 57
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-array-elements-text.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-array-elements-text.md
@@ -6,7 +6,7 @@ description: Transform JSON values of an JSON array into a SQL table of text val
 menu:
   latest:
     identifier: jsonb-array-elements-text
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 70
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-array-elements.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-array-elements.md
@@ -6,7 +6,7 @@ description: Transform JSON values of a JSON array into a SQL table of jsonb val
 menu:
   latest:
     identifier: jsonb-array-elements
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 60
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-array-length.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-array-length.md
@@ -6,7 +6,7 @@ description: Return the count of values in an array using jsonb_array_length() a
 menu:
   latest:
     identifier: jsonb-array-length
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 80
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-build-array.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-build-array.md
@@ -6,7 +6,7 @@ description: Build a JSON array from a variadic list of array values of arbitrar
 menu:
   latest:
     identifier: jsonb_build_array-each
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 110
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-build-object.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-build-object.md
@@ -6,7 +6,7 @@ description: Build a JSON object from a variadic list that specifies keys with v
 menu:
   latest:
     identifier: jsonb-build-object
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 100
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-each-text.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-each-text.md
@@ -6,7 +6,7 @@ description: Create a row set with columns "key" (as a SQL text) and "value" (as
 menu:
   latest:
     identifier: jsonb-each-text
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 120
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-each.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-each.md
@@ -6,7 +6,7 @@ description: Create a row set with columns "key" (as a SQL text) and "value" (as
 menu:
   latest:
     identifier: jsonb-each
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 110
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-extract-path-text.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-extract-path-text.md
@@ -6,7 +6,7 @@ description: Provide identical functionality to the "#>>" operator.
 menu:
   latest:
     identifier: jsonb-extract-path-text
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 140
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-extract-path.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-extract-path.md
@@ -6,7 +6,7 @@ description: Provide identical functionality to the "#>" operator.
 menu:
   latest:
     identifier: jsonb-extract-path
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 130
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-object-agg.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-object-agg.md
@@ -6,7 +6,7 @@ description: Aggregate a SETOF values into a JSON object.
 menu:
   latest:
     identifier: jsonb-object-agg
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 155
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-object-keys.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-object-keys.md
@@ -6,7 +6,7 @@ description: Transform the list of key names in the supplied JSON object into a 
 menu:
   latest:
     identifier: jsonb-object-keys
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 160
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-object.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-object.md
@@ -6,7 +6,7 @@ description: Create a JSON object from SQL arrays that specify keys with their v
 menu:
   latest:
     identifier: jsonb-object
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 150
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-populate-record.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-populate-record.md
@@ -6,7 +6,7 @@ description: Convert a JSON object into the equivalent SQL record.
 menu:
   latest:
     identifier: jsonb-populate-record
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 180
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-populate-recordset.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-populate-recordset.md
@@ -6,7 +6,7 @@ description: Convert a homogeneous JSON array of JSON objects into the equivalen
 menu:
   latest:
     identifier: jsonb-populate-recordset
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 190
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-pretty.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-pretty.md
@@ -6,7 +6,7 @@ description: Format the text representation of the JSON value that the input jso
 menu:
   latest:
     identifier: jsonb-pretty
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 200
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-set-jsonb-insert.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-set-jsonb-insert.md
@@ -6,7 +6,7 @@ description: Change an existing JSON value using jsonb_set() and insert a new va
 menu:
   latest:
     identifier: jsonb-set-jsonb-insert
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 210
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-strip-nulls.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-strip-nulls.md
@@ -6,7 +6,7 @@ description: Find all key-value pairs in the hierarchy of the supplied JSON comp
 menu:
   latest:
     identifier: jsonb-strip-nulls
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 220
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-to-record.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-to-record.md
@@ -6,7 +6,7 @@ description: Convert a JSON object into the equivalent SQL record. Offers no pra
 menu:
   latest:
     identifier: jsonb-to-record
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 230
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-to-recordset.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-to-recordset.md
@@ -6,7 +6,7 @@ description: Convert a homogeneous JSON array of JSON objects into the equivalen
 menu:
   latest:
     identifier: jsonb-to-recordset
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 240
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-typeof.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/jsonb-typeof.md
@@ -6,7 +6,7 @@ description: Return the data type of the JSON value as a SQL text value.
 menu:
   latest:
     identifier: jsonb-typeof
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 250
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/key-or-value-existence-operators.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/key-or-value-existence-operators.md
@@ -6,7 +6,7 @@ description: Test if JSONB values exist as keys in an object or as string value(
 menu:
   latest:
     identifier: key-or-value-existence-operators
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 17
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/remove-operators.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/remove-operators.md
@@ -6,7 +6,7 @@ description: Remove key-value pairs from an object or remove a single value from
 menu:
   latest:
     identifier: remove-operators
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 13
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/row-to-json.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/row-to-json.md
@@ -6,7 +6,7 @@ description: Create a JSON object from a SQL record.
 menu:
   latest:
     identifier: row-to-json
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 270
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/subvalue-operators.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/subvalue-operators.md
@@ -6,7 +6,7 @@ description: Read a JSON value at a specified path.
 menu:
   latest:
     identifier: subvalue-operators
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 12
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/to-jsonb.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/to-jsonb.md
@@ -6,7 +6,7 @@ description: Convert a single SQL value of any primitive or compound data type, 
 menu:
   latest:
     identifier: to-jsonb
-    parent: functions-operators
+    parent: json-functions-operators
 isTocNested: true
 showAsideToc: true
 ---

--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/typecast-operators.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/typecast-operators.md
@@ -6,7 +6,7 @@ description: Typecast between any pair of text, json, and jsonb values.
 menu:
   latest:
     identifier: typecast-operators
-    parent: functions-operators
+    parent: json-functions-operators
     weight: 10
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/_index.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/_index.md
@@ -6,7 +6,7 @@ description: This section summarizes the signature and purpose of each of YSQL's
 image: /images/section_icons/api/ysql.png
 menu:
   latest:
-    identifier: function-syntax-semantics
+    identifier: window-function-syntax-semantics
     parent: window-functions
     weight: 30
 aliases:

--- a/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/data-sets/_index.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/data-sets/_index.md
@@ -7,7 +7,7 @@ image: /images/section_icons/api/ysql.png
 menu:
   latest:
     identifier: data-sets
-    parent: function-syntax-semantics
+    parent: window-function-syntax-semantics
     weight: 50
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/first-value-nth-value-last-value.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/first-value-nth-value-last-value.md
@@ -6,7 +6,7 @@ description: Describes the functionality of the YSQL window functions first_valu
 menu:
   latest:
     identifier: first-value-nth-value-last-value
-    parent: function-syntax-semantics
+    parent: window-function-syntax-semantics
     weight: 30
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/lag-lead.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/lag-lead.md
@@ -6,7 +6,7 @@ description: Describes the functionality of the YSQL window functions lag(), lea
 menu:
   latest:
     identifier: lag-lead
-    parent: function-syntax-semantics
+    parent: window-function-syntax-semantics
     weight: 40
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/percent-rank-cume-dist-ntile.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/percent-rank-cume-dist-ntile.md
@@ -6,7 +6,7 @@ description: Describes the functionality of the YSQL window functions percent_ra
 menu:
   latest:
     identifier: percent-rank-cume-dist-ntile
-    parent: function-syntax-semantics
+    parent: window-function-syntax-semantics
     weight: 20
 isTocNested: true
 showAsideToc: true

--- a/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/row-number-rank-dense-rank.md
+++ b/docs/content/latest/api/ysql/exprs/window_functions/function-syntax-semantics/row-number-rank-dense-rank.md
@@ -6,7 +6,7 @@ description: Describes the functionality of the YSQL window functions row_number
 menu:
   latest:
     identifier: row-number-rank-dense-rank
-    parent: function-syntax-semantics
+    parent: window-function-syntax-semantics
     weight: 10
 isTocNested: true
 showAsideToc: true


### PR DESCRIPTION
Added these sections in `.../ysql/datatypes/type_array/array-of-domains/`:

— Using FOREACH with an array of DOMAINs
— Using array_agg() to produce an array of DOMAIN values

Globally changed identifier to `json-functions-operators` in `.../ysql/datatypes/type_json/functions-operators/_index.md` and its children.

Globally changed identifier to `window-function-syntax-semantics` in `.../ysql/exprs/window_functions/function-syntax-semantics/_index.md` and its children.

