### PR TITLE
issue-5098: Added repository dispatch event for yugabyte-db-action

### DIFF
--- a/.github/workflows/create-repository-dispatch.yml
+++ b/.github/workflows/create-repository-dispatch.yml
@@ -68,4 +68,12 @@ jobs:
           curl -XPOST -u "${{ secrets.PAT_USERNAME}}:${{secrets.PAT_TOKEN}}" \
           -H "Accept: application/vnd.github.everest-preview+json" \
           -H "Content-Type: application/json" https://api.github.com/repos/yugabyte/charts/dispatches \
-          --data '{"event_type": "update-on-release",  "client_payload": {"prerelease": "${{ github.event.release.prerelease }}", "release": "${{github.event.release.tag_name}}"  }}'  
+          --data '{"event_type": "update-on-release",  "client_payload": {"prerelease": "${{ github.event.release.prerelease }}", "release": "${{github.event.release.tag_name}}"  }}'
+
+      - name: "Trigger Repository Dispatch - yugabyte/yugabyte-db-action"
+        run: |
+          curl -XPOST -u "${{ secrets.PAT_USERNAME}}:${{secrets.PAT_TOKEN}}" \
+          -H "Accept: application/vnd.github.everest-preview+json" \
+          -H "Content-Type: application/json" https://api.github.com/repos/yugabyte/yugabyte-db-action/dispatches \
+          --data '{"event_type": "on-release"}'
+


### PR DESCRIPTION
### Summary
Added repository dispatch event for the `yugbyte-db-action` repo on release event.

Whenever the `yugabyte-db` repo gets the new release, it triggers the test job on the `yugbyte-db-action` repo to test the new YugabyteDB docker image.

Related PR: https://github.com/yugabyte/yugabyte-db-action/pull/1/files

Fixes: https://github.com/yugabyte/yugabyte-db/issues/5098