### PR TITLE
Added env variables functionality in yugabyted

### DIFF
--- a/bin/yugabyted
+++ b/bin/yugabyted
@@ -94,8 +94,6 @@ Please set 'PGPASSWORD' in environment variables to use 'bin/ysqlsh'."
 DEFAULT_YCQL_USER = "cassandra"
 DEFAULT_YCQL_PASSWORD = "cassandra"
 DEFAULT_YCQL_KEYSPACE = None
-DEFAULT_YSQL_AUTH = False
-DEFAULT_YCQL_AUTH = False
 VERSION_METADATA_PATH = os.path.join(YUGABYTE_DIR, "version_metadata.json")
 YUGABYTE_API_CLIENT_PROGRAMS = {
     "ysql": "ysqlsh",
@@ -133,7 +131,7 @@ class ControlScript(object):
         self.stop_callhome = False
         self.alerts = []
         self.script = None
-        self.setup_env_init = SetupEnvBasedCredentials()
+        self.setup_env_init = EnvBasedCredentials()
 
     # Starts YugabyteDB node.
     def start(self):
@@ -248,8 +246,7 @@ class ControlScript(object):
             Output.log_error_and_exit(
                 "{} is not running. Cannot connect to YCQL.".format(SCRIPT_NAME))
         ycql_proxy = YcqlProxy(ip=self.advertise_ip(),
-                        port=self.configs.saved_data.get("ycql_port"),
-                        enforced_auth=self.configs.saved_data.get("ycql_auth"))
+                        port=self.configs.saved_data.get("ycql_port"))
         ycql_proxy.connect()
 
     # Creates demo database and starts an interactive shell into it. Destroys the sample database
@@ -295,18 +292,14 @@ class ControlScript(object):
             "Initializing {} demo database. This may take up to a minute...".format(demo_db))
         # Create demo database.
         Output.log("Creating database {}...".format(db_name))
-        _, err = ysql_proxy.create_db(db_name)
-        if err:
-            Output.log_error_and_exit("Failed to create {} database: {}".format(demo_db, err))
+        ysql_proxy.create_db(db_name)
 
         # Populate demo database.
         Output.log("Populating {} with sample data...".format(db_name))
         files = []
         for name in Configs.get_demo_info()[demo_db]["files"]:
             files.append(os.path.join(YUGABYTE_DIR, "share", name))
-        _, err = ysql_proxy.load_files(files, db=db_name)
-        if err:
-            Output.log_error_and_exit("Failed to populate data to {}: {}".format(demo_db, err))
+        ysql_proxy.load_files(files, db=db_name)
 
         msg = "Successfully loaded sample database!"
         Output.print_and_log(msg)
@@ -344,9 +337,7 @@ class ControlScript(object):
         db_name = DEMO_DB_PREFIX + demo_db
         ysql_proxy = YsqlProxy(self.advertise_ip(), self.configs.saved_data.get("ysql_port"))
         if ysql_proxy.db_exists(db_name):
-            _, err = ysql_proxy.drop_db(db_name)
-            if err:
-                Output.log_error_and_exit("Failed to drop database {}: {}".format(demo_db, err))
+            ysql_proxy.drop_db(db_name)
         msg = "Deleted demo database {}.".format(demo_db)
         Output.print_and_log(msg)
 
@@ -474,14 +465,6 @@ class ControlScript(object):
                 "--start_redis_proxy=false",
             ]
 
-        # Add ysql_enable_auth flag to enforce authentication for YSQL
-        if self.configs.saved_data.get("ysql_auth"):
-            yb_tserver_cmd.extend(["--ysql_enable_auth=true"])
-
-        # Add use_cassandra_authentication flag to enforce authentication for YCQL
-        if self.configs.saved_data.get("ycql_auth"):
-            yb_tserver_cmd.extend(["--use_cassandra_authentication=true"])
-
         if self.configs.saved_data.get("tserver_flags"):
             yb_tserver_cmd.extend(
                 ["--{}".format(flag) for flag in \
@@ -546,19 +529,14 @@ class ControlScript(object):
             # Add enforced authentication flags on first installation
             # Add ysql_enable_auth, if YSQL_PASSWORD env variable exists
             # Add use_cassandra_authentication, if YCQL_USER or YCQL_PASSWORD env variables exists
-            if is_first_install:
-                # Add ysql_enable_auth flag to enforce authentication for YSQL
-                if self.setup_env_init.is_exists('YSQL_PASSWORD'):
-                    yb_tserver_cmd.extend(["--ysql_enable_auth=true"])
-                    self.configs.saved_data["ysql_auth"] = True
-                    self.configs.save_configs()
+            # Add ysql_enable_auth flag to enforce authentication for YSQL
+            if self.setup_env_init.is_exists('YSQL_PASSWORD'):
+                yb_tserver_cmd.extend(["--ysql_enable_auth=true"])
 
-                # Add use_cassandra_authentication flag to enforce authentication for YCQL
-                if self.setup_env_init.is_exists('YCQL_USER') or \
-                        self.setup_env_init.is_exists('YCQL_PASSWORD'):
-                    yb_tserver_cmd.extend(["--use_cassandra_authentication=true"])
-                    self.configs.saved_data["ycql_auth"] = True
-                    self.configs.save_configs()
+            # Add use_cassandra_authentication flag to enforce authentication for YCQL
+            if self.setup_env_init.is_exists('YCQL_USER') or \
+                    self.setup_env_init.is_exists('YCQL_PASSWORD'):
+                yb_tserver_cmd.extend(["--use_cassandra_authentication=true"])
 
             # Start or initialize yb-master and yb-tserver.
             if is_first_run:
@@ -1037,8 +1015,8 @@ class ControlScript(object):
 
         ysql_flags = " {} {} -U {} -d {}".format(ysql_hostname_param, ysql_port_param,
                         ysql_username, ysql_db)
-        ycql_flags = " {} {} -u {} -p {}".format(cql_hostname_param, cql_port_param,
-                        ycql_username, ycql_password)
+        ycql_flags = " {} {} -u {}".format(cql_hostname_param, cql_port_param,
+                        ycql_username)
         if ycql_keyspace is not None:
             ycql_flags = ycql_flags + " -k {}".format(ycql_keyspace)
 
@@ -1365,8 +1343,7 @@ class ControlScript(object):
                 self.setup_env_init.is_exists('YCQL_KEYSPACE'):
             ycql_proxy = YcqlProxy(ip=self.advertise_ip(),
                             port=self.configs.saved_data.get("ycql_port"),
-                            get_default_credentials=True,
-                            enforced_auth=self.configs.saved_data.get("ycql_auth"))
+                            get_default_credentials=True)
             if retry_op(ycql_proxy.is_ycql_up):
                 Output.log("Setting up custom credentials for YCQL...")
                 self.setup_env_init.setup_ycql_credentials(ycql_proxy)
@@ -1393,8 +1370,6 @@ class Configs(object):
             "master_flags": "",
             "tserver_flags": "",
             "join": "",
-            "ysql_auth": DEFAULT_YSQL_AUTH,
-            "ycql_auth": DEFAULT_YCQL_AUTH,
         }
         # Used to store data specific to certain functions that we don't want to save.
         self.temp_data = {
@@ -1846,7 +1821,7 @@ class YsqlProxy(object):
     def __init__(self, ip, port, path=os.path.join(BIN_DIR, YUGABYTE_API_CLIENT_PROGRAMS["ysql"]),
                     get_default_credentials=False):
         self.cmd = [path, "-h", str(ip), "-p", str(port)]
-        self.setup_env_init = SetupEnvBasedCredentials()
+        self.setup_env_init = EnvBasedCredentials()
         self.username, self.password, self.db = self.setup_env_init.get_ysql_credentials(
                                                     get_default_credentials)
         self.env = {"PGUSER": self.username, "PGPASSWORD": self.password, "PGDATABASE": self.db}
@@ -1864,20 +1839,17 @@ class YsqlProxy(object):
     def db_exists(self, db):
         cmd = self.cmd + ["-q", "-c", "\\t", "-c",
             "select datname from pg_catalog.pg_database where datname='{}'".format(db)]
-        out, err, _ = run_process(cmd=cmd, env_vars=self.env)
-        return out.strip() == db
+        return run_process_checked(cmd=cmd, env_vars=self.env).strip() == db
 
     # Creates specified db.
     def create_db(self, db):
         cmd = self.cmd + ["-c", "create database {}".format(db)]
-        out, err, _ = run_process(cmd=cmd, env_vars=self.env)
-        return out, err
+        run_process_checked(cmd=cmd, env_vars=self.env)
 
     # Deletes specified db.
     def drop_db(self, db):
         cmd = self.cmd + ["-c", "drop database {}".format(db)]
-        out, err, _ = run_process(cmd=cmd, env_vars=self.env)
-        return out, err
+        run_process_checked(cmd=cmd, env_vars=self.env)
 
     # Runs ysqlsh with specified files.
     def load_files(self, filepaths, db=None):
@@ -1887,23 +1859,20 @@ class YsqlProxy(object):
             env['PGDATABASE'] = db
         for path in filepaths:
             cmd.extend(["-f", path])
-        out, err, _ = run_process(cmd=cmd, env_vars=env)
-        return out, err
+        run_process(cmd=cmd, log_cmd=False, env_vars=env)
 
     # Check user exists
     # Note that this will return false if ysqlsh can't connect, even if user exists.
     def user_exists(self, ysql_username):
         cmd = self.cmd + ["-c", "select rolname from pg_catalog.pg_roles where rolname='{}'".
                 format(ysql_username)]
-        out, err, _ = run_process(cmd=cmd, env_vars=self.env)
-        return out.strip() == ysql_username
+        run_process_checked(cmd=cmd, env_vars=self.env).strip() == ysql_username
 
     # Create specified superuser
     def create_user(self, ysql_username, ysql_password):
         cmd = self.cmd + ["-c", "create role {} with LOGIN SUPERUSER password '{}';".
                 format(ysql_username, ysql_password)]
-        out, err, _ = run_process(cmd=cmd, env_vars=self.env)
-        return out, err
+        run_process_checked(cmd=cmd, log_cmd=False, env_vars=self.env)
 
     # Delete specified user
     def delete_user(self, username, password, user_to_delete=DEFAULT_YSQL_USER):
@@ -1911,25 +1880,22 @@ class YsqlProxy(object):
         env = self.env
         env['PGUSER'] = username
         env['PGPASSWORD'] = password
-        out, err, _ = run_process(cmd=cmd, env_vars=env)
-        return out, err 
+        run_process_checked(cmd=cmd, env_vars=env)
     
     # Update specified user's password
     def update_password(self, new_password, user_to_update=DEFAULT_YSQL_USER):
         cmd = self.cmd + ["-c", "alter role {} password '{}';".format(user_to_update, new_password)]
-        out, err, _ = run_process(cmd=cmd, env_vars=self.env)
-        return out, err
+        run_process_checked(cmd=cmd, log_cmd=False, env_vars=self.env)
 
     # Change specified DB's owner
     def db_owner(self, db, new_owner):
         cmd = self.cmd + ["-c", "alter database {} owner to {};".format(db, new_owner)]
-        out, err, _ = run_process(cmd=cmd, env_vars=self.env)
-        return out, err
+        run_process_checked(cmd=cmd, env_vars=self.env)
 
     # Check YSQL is UP
     def is_ysql_up(self):
         cmd = self.cmd + ["-c", "\\conninfo"]
-        out, err, _ = run_process(cmd=cmd, env_vars=self.env)
+        out, err, _ = run_process(cmd=cmd, log_cmd=True, env_vars=self.env)
         if err:
             Output.log("Unable to connect using YSQL. Error: {}".format(err))
             raise RetryableError()
@@ -1940,17 +1906,17 @@ class YsqlProxy(object):
 # Proxy for ycqlsh commands.
 class YcqlProxy(object):
     def __init__(self, ip, port, path=os.path.join(BIN_DIR, YUGABYTE_API_CLIENT_PROGRAMS["ycql"]),
-                    get_default_credentials=False, enforced_auth=False):
+                    get_default_credentials=False):
         self.cmd = [path, str(ip), str(port)]
-        self.setup_env_init = SetupEnvBasedCredentials()
-        self.enforced_auth = enforced_auth
+        self.setup_env_init = EnvBasedCredentials()
         self.username, self.password, self.keyspace = self.setup_env_init.get_ycql_credentials(
                                                         get_default_credentials)
 
     # Starts interactive YCQL shell.
     def connect(self):
         cmd = self.cmd
-        if self.enforced_auth:
+        if self.setup_env_init.is_exists('YCQL_USER') or \
+                    self.setup_env_init.is_exists('YCQL_PASSWORD'):
             cmd.extend(["-u", self.username])
         if self.keyspace is not None:
             cmd.extend(["-k", self.keyspace])
@@ -1962,30 +1928,26 @@ class YcqlProxy(object):
     def user_exists(self, ycql_username):
         cmd = self.cmd + ["-u", self.username, "-p", self.password, "-e",
             "SELECT role FROM system_auth.roles WHERE role='{}';".format(ycql_username)]
-        out, err, _ = run_process(cmd)
-        return out.strip() == ycql_username
+        return run_process_checked(cmd).strip() == ycql_username
 
     # Create specified superuser
     def create_user(self, ycql_username, ycql_password):
         cmd = self.cmd + ["-u", self.username, "-p", self.password, "-e",
                 "CREATE ROLE {} WITH PASSWORD = '{}' AND LOGIN = true AND SUPERUSER = true;".
                 format(ycql_username, ycql_password)]
-        out, err, _ = run_process(cmd)
-        return out, err
+        run_process_checked(cmd, log_cmd=False)
 
     # Delete specified user
     def delete_user(self, username, password, user_to_delete=DEFAULT_YCQL_USER):
         cmd = self.cmd + ["-u", username, "-p", password, "-e",
                 "DROP ROLE IF EXISTS {};".format(user_to_delete)]
-        out, err, _ = run_process(cmd)
-        return out, err 
+        run_process_checked(cmd)
     
     # Update specified user's password
     def update_password(self, new_password, user_to_update=DEFAULT_YCQL_USER):
         cmd = self.cmd + ["-u", self.username, "-p", self.password, "-e",
                 "ALTER ROLE {} WITH PASSWORD = '{}';".format(user_to_update, new_password)]
-        out, err, _ = run_process(cmd)
-        return out, err
+        run_process_checked(cmd, log_cmd=False)
 
     # Check keyspace exists
     # Note that this will return false if ycqlsh can't connect, even if keyspace exists.
@@ -1993,20 +1955,18 @@ class YcqlProxy(object):
         cmd = self.cmd + ["-u", self.username, "-p", self.password, "-e",
             "SELECT keyspace_name FROM system_schema.keyspaces WHERE keyspace_name='{}';".
             format(keyspace)]
-        out, err, _ = run_process(cmd)
-        return out.strip() == keyspace
+        return run_process_checked(cmd).strip() == keyspace
 
     # Create specified keyspace
     def create_keyspace(self, keyspace):
         cmd = self.cmd + ["-u", self.username, "-p", self.password, "-e",
                 "CREATE KEYSPACE {};".format(keyspace)]
-        out, err, _ = run_process(cmd)
-        return out, err
+        run_process_checked(cmd)
 
     # Check YCQL is UP
     def is_ycql_up(self):
         cmd = self.cmd + ["-u", self.username, "-p", self.password, "-e", "SHOW HOST"]
-        out, err, _ = run_process(cmd)
+        out, err, _ = run_process(cmd, log_cmd=True)
         if err:
             Output.log("Unable to connect using YCQL. Error: {}".format(err))
             raise RetryableError()
@@ -2447,6 +2407,12 @@ def run_process(cmd, timeout=None, log_cmd=False, env_vars=None):
             retcode, ret_out, ret_err))
     return (ret_out, ret_err, retcode)
 
+def run_process_checked(cmd, timeout=None, log_cmd=True, env_vars=None):
+    out, err, retcode = run_process(cmd=cmd, timeout=timeout, log_cmd=log_cmd, env_vars=env_vars)
+    if retcode:
+        Output.log_error_and_exit("Error: {}".format(err))
+    return out
+
 def rmcontents(dirname, exclude_names=[]):
     for f in os.listdir(dirname):
         if f in exclude_names:
@@ -2482,7 +2448,7 @@ def retry_op(func, timeout=180):
         now - start_time))
 
 
-class SetupEnvBasedCredentials(object):
+class EnvBasedCredentials(object):
     def __init__(self):
         self.ysql_user = os.environ.get('YSQL_USER')
         self.ysql_password = os.environ.get('YSQL_PASSWORD')
@@ -2491,30 +2457,23 @@ class SetupEnvBasedCredentials(object):
         self.ycql_password = os.environ.get('YCQL_PASSWORD')
         self.ycql_keyspace = os.environ.get('YCQL_KEYSPACE')
 
-    def is_valid(self, var_name):
-        return True if var_name is not None and var_name else False
-
     def get_ysql_user(self):
-        return self.ysql_user if self.is_valid(self.ysql_user) else DEFAULT_YSQL_USER
+        return self.ysql_user or DEFAULT_YSQL_USER
 
     def get_ysql_password(self):
-        return self.ysql_password if self.is_valid(self.ysql_password) else (self.ysql_user if (
-                    self.is_valid(self.ysql_user)) else DEFAULT_YSQL_PASSWORD)
+        return self.ysql_password or (self.ysql_user or DEFAULT_YSQL_PASSWORD)
 
     def get_ysql_db(self):
-        return self.ysql_db if self.is_valid(self.ysql_db) else (self.ysql_user if (
-                    self.is_valid(self.ysql_user)) else DEFAULT_YSQL_DB)
+        return self.ysql_db or (self.ysql_user or DEFAULT_YSQL_DB)
 
     def get_ycql_user(self):
-        return self.ycql_user if self.is_valid(self.ycql_user) else DEFAULT_YCQL_USER
+        return self.ycql_user or DEFAULT_YCQL_USER
 
     def get_ycql_password(self):
-        return self.ycql_password if self.is_valid(self.ycql_password) else (self.ycql_user if (
-                    self.is_valid(self.ycql_user)) else DEFAULT_YCQL_PASSWORD)
+        return self.ycql_password or (self.ycql_user or DEFAULT_YCQL_PASSWORD)
 
     def get_ycql_keyspace(self):
-        return self.ycql_keyspace if self.is_valid(self.ycql_keyspace) else (self.ycql_user if (
-                    self.is_valid(self.ycql_user)) else DEFAULT_YCQL_KEYSPACE)
+        return self.ycql_keyspace or (self.ycql_user or DEFAULT_YCQL_KEYSPACE)
 
     def get_ysql_credentials(self, get_default_credentials=False):
         if get_default_credentials:
@@ -2529,91 +2488,44 @@ class SetupEnvBasedCredentials(object):
             return self.get_ycql_user(), self.get_ycql_password(), self.get_ycql_keyspace()
 
     def is_exists(self, var_to_check):
-        return self.is_valid(os.environ.get(var_to_check))
+        return True if var_to_check in os.environ and os.environ.get(var_to_check) else False
 
     def setup_ysql_credentials(self, proxy_class):
 
         # Create DB
         if self.get_ysql_db() != DEFAULT_YSQL_DB and not proxy_class.db_exists(self.get_ysql_db()):
-            Output.log("Creating {} database".format(self.get_ysql_db()))
-            _, err = proxy_class.create_db(self.get_ysql_db())
-            if err:
-                Output.log_error_and_exit("Failed to create {} database: \
-                    {}".format(self.get_ysql_db(), err))
-
-            Output.log("{} database created successfully".format(self.get_ysql_db()))
+            proxy_class.create_db(self.get_ysql_db())
 
         # Update password for default user
         if self.get_ysql_user() == DEFAULT_YSQL_USER:
-            _, err = proxy_class.update_password(self.get_ysql_password())
-            if err:
-                Output.log_error_and_exit("class: {} Failed to update password for default user {}".
-                    format(proxy_class, err))
-
-            Output.log("class: {} Password has updated for default user successfully".
-                format(proxy_class))
+            proxy_class.update_password(self.get_ysql_password())
 
         # Create User
         if self.get_ysql_user() != DEFAULT_YSQL_USER and not proxy_class.user_exists(self.get_ysql_user()):
-            Output.log("Creating {} user".format(self.get_ysql_user()))
-            _, err = proxy_class.create_user(self.get_ysql_user(), self.get_ysql_password())
-            if err:
-                Output.log_error_and_exit("Failed to create {} user: {}".
-                    format(self.get_ysql_user(), err))
+            proxy_class.create_user(self.get_ysql_user(), self.get_ysql_password())
 
             if self.get_ysql_db() != DEFAULT_YSQL_DB:
-                _, err = proxy_class.db_owner(self.get_ysql_db(), self.get_ysql_user())
-                if err:
-                    Output.log_error_and_exit("Failed to change owner on {} database: {}".
-                        format(self.get_ysql_db(), err))
+                proxy_class.db_owner(self.get_ysql_db(), self.get_ysql_user())
 
             # Note: Following lines will be commented till we can decide on default user deletion.
-            #_, err = proxy_class.delete_user(self.get_ysql_user(), self.get_ysql_password())
-            #if err:
-            #   Output.log_error_and_exit("Failed to delete default user: {}".format(err))
-
-            Output.log("{} user created successfully".format(self.get_ysql_user()))
-
-        Output.log("Custom credentials configured successfully for YSQL")
+            #proxy_class.delete_user(self.get_ysql_user(), self.get_ysql_password())
 
     def setup_ycql_credentials(self, proxy_class):
 
         # Create YCQL Keyspace
         if self.get_ycql_keyspace() and not proxy_class.keyspace_exists(self.get_ycql_keyspace()):
-            Output.log("Creating {} keyspace".format(self.get_ycql_keyspace()))
-            _, err = proxy_class.create_keyspace(self.get_ycql_keyspace())
-            if err:
-                Output.log_error_and_exit("Failed to create {} keyspace: {}".
-                    format(self.get_ycql_keyspace(), err))
-
-            Output.log("{} keyspace created successfully".format(self.get_ycql_keyspace()))
+            proxy_class.create_keyspace(self.get_ycql_keyspace())
 
         # Update password for default user
         if self.get_ycql_user() == DEFAULT_YCQL_USER:
-            _, err = proxy_class.update_password(self.get_ycql_password())
-            if err:
-                Output.log_error_and_exit("class: {} Failed to update password for default user {}".
-                    format(proxy_class, err))
-
-            Output.log("class: {} Password has updated for default user successfully".
-                format(proxy_class))
+            proxy_class.update_password(self.get_ycql_password())
 
         # Create user
         if self.get_ycql_user() != DEFAULT_YCQL_USER and not proxy_class.user_exists(self.get_ycql_user()):
-            Output.log("Creating {} user".format(self.get_ycql_user()))
-            _, err = proxy_class.create_user(self.get_ycql_user(), self.get_ycql_password())
-            if err:
-                Output.log_error_and_exit("Failed to create {} user: {}".
-                    format(self.get_ycql_user(), err))
+            proxy_class.create_user(self.get_ycql_user(), self.get_ycql_password())
 
             # Note: Following lines will be commented till we can decide on default user deletion.
-            #_, err = proxy_class.delete_user(self.get_ycql_user(), self.get_ycql_password())
-            #if err:
-            #   Output.log_error_and_exit("Failed to delete default user: {}".format(err))
-
-            Output.log("{} user created successfully".format(self.get_ycql_user()))
-
-        Output.log("Custom credentials configured successfully for YCQL")
+            #proxy_class.delete_user(self.get_ycql_user(), self.get_ycql_password())
 
 
 if __name__ == '__main__':

--- a/bin/yugabyted
+++ b/bin/yugabyted
@@ -86,6 +86,16 @@ DEFAULT_YSQL_PORT = 5433
 DEFAULT_YCQL_PORT = 9042
 DEFAULT_WEBSERVER_PORT = 7200
 DEFAULT_CALLHOME = True
+DEFAULT_YSQL_USER = "yugabyte"
+DEFAULT_YSQL_PASSWORD = "yugabyte"
+DEFAULT_YSQL_DB = "yugabyte"
+YSQL_PASSWORD_LENGTH_WARNING = "Warning: Your 'YSQL_PASSWORD' length is greater than 99 characters.\
+Please set 'PGPASSWORD' in environment variables to use 'bin/ysqlsh'."
+DEFAULT_YCQL_USER = "cassandra"
+DEFAULT_YCQL_PASSWORD = "cassandra"
+DEFAULT_YCQL_KEYSPACE = None
+DEFAULT_YSQL_AUTH = False
+DEFAULT_YCQL_AUTH = False
 VERSION_METADATA_PATH = os.path.join(YUGABYTE_DIR, "version_metadata.json")
 YUGABYTE_API_CLIENT_PROGRAMS = {
     "ysql": "ysqlsh",
@@ -123,6 +133,7 @@ class ControlScript(object):
         self.stop_callhome = False
         self.alerts = []
         self.script = None
+        self.setup_env_init = SetupEnvBasedCredentials()
 
     # Starts YugabyteDB node.
     def start(self):
@@ -228,7 +239,7 @@ class ControlScript(object):
         if self.get_failed_node_processes():
             Output.log_error_and_exit(
                 "{} is not running. Cannot connect to YSQL.".format(SCRIPT_NAME))
-        ysql_proxy = YsqlProxy(self.configs.saved_data.get("ysql_port"))
+        ysql_proxy = YsqlProxy(self.advertise_ip(), self.configs.saved_data.get("ysql_port"))
         ysql_proxy.connect()
 
     # Starts an interactive YCQL shell.
@@ -236,12 +247,10 @@ class ControlScript(object):
         if self.get_failed_node_processes():
             Output.log_error_and_exit(
                 "{} is not running. Cannot connect to YCQL.".format(SCRIPT_NAME))
-        path = os.path.join(BIN_DIR, YUGABYTE_API_CLIENT_PROGRAMS["ycql"])
-        cmd = [
-            path, self.advertise_ip(),
-            str(self.configs.saved_data.get("ycql_port"))
-        ]
-        os.execv(path, cmd)
+        ycql_proxy = YcqlProxy(ip=self.advertise_ip(),
+                        port=self.configs.saved_data.get("ycql_port"),
+                        enforced_auth=self.configs.saved_data.get("ycql_auth"))
+        ycql_proxy.connect()
 
     # Creates demo database and starts an interactive shell into it. Destroys the sample database
     # after shell quits.
@@ -252,7 +261,7 @@ class ControlScript(object):
                     SCRIPT_NAME))
 
         db_name = DEMO_DB_PREFIX + self.configs.temp_data.get("demo_db")
-        ysql_proxy = YsqlProxy(self.configs.saved_data.get("ysql_port"))
+        ysql_proxy = YsqlProxy(self.advertise_ip(), self.configs.saved_data.get("ysql_port"))
         if ysql_proxy.db_exists(db_name):
             Output.log_error_and_exit(
                 "Demo is already running. Concurrent demos are currently unsupported.")
@@ -277,7 +286,7 @@ class ControlScript(object):
 
         demo_db = self.configs.temp_data.get("demo_db")
         db_name = DEMO_DB_PREFIX + demo_db
-        ysql_proxy = YsqlProxy(self.configs.saved_data.get("ysql_port"))
+        ysql_proxy = YsqlProxy(self.advertise_ip(), self.configs.saved_data.get("ysql_port"))
         if ysql_proxy.db_exists(db_name):
             Output.print_out("Demo database {} already exists.".format(demo_db))
             return
@@ -311,7 +320,7 @@ class ControlScript(object):
 
         demo_db = self.configs.temp_data.get("demo_db")
         db_name = DEMO_DB_PREFIX + demo_db
-        ysql_proxy = YsqlProxy(self.configs.saved_data.get("ysql_port"))
+        ysql_proxy = YsqlProxy(self.advertise_ip(), self.configs.saved_data.get("ysql_port"))
         if not ysql_proxy.db_exists(db_name):
             self.create_demo()
 
@@ -333,7 +342,7 @@ class ControlScript(object):
 
         demo_db = self.configs.temp_data.get("demo_db")
         db_name = DEMO_DB_PREFIX + demo_db
-        ysql_proxy = YsqlProxy(self.configs.saved_data.get("ysql_port"))
+        ysql_proxy = YsqlProxy(self.advertise_ip(), self.configs.saved_data.get("ysql_port"))
         if ysql_proxy.db_exists(db_name):
             _, err = ysql_proxy.drop_db(db_name)
             if err:
@@ -465,6 +474,14 @@ class ControlScript(object):
                 "--start_redis_proxy=false",
             ]
 
+        # Add ysql_enable_auth flag to enforce authentication for YSQL
+        if self.configs.saved_data.get("ysql_auth"):
+            yb_tserver_cmd.extend(["--ysql_enable_auth=true"])
+
+        # Add use_cassandra_authentication flag to enforce authentication for YCQL
+        if self.configs.saved_data.get("ycql_auth"):
+            yb_tserver_cmd.extend(["--use_cassandra_authentication=true"])
+
         if self.configs.saved_data.get("tserver_flags"):
             yb_tserver_cmd.extend(
                 ["--{}".format(flag) for flag in \
@@ -526,6 +543,23 @@ class ControlScript(object):
                     " Removing...").format(data_dir_files, data_dir))
                 rmcontents(data_dir, exclude_names=[pid_file_name])
 
+            # Add enforced authentication flags on first installation
+            # Add ysql_enable_auth, if YSQL_PASSWORD env variable exists
+            # Add use_cassandra_authentication, if YCQL_USER or YCQL_PASSWORD env variables exists
+            if is_first_install:
+                # Add ysql_enable_auth flag to enforce authentication for YSQL
+                if self.setup_env_init.is_exists('YSQL_PASSWORD'):
+                    yb_tserver_cmd.extend(["--ysql_enable_auth=true"])
+                    self.configs.saved_data["ysql_auth"] = True
+                    self.configs.save_configs()
+
+                # Add use_cassandra_authentication flag to enforce authentication for YCQL
+                if self.setup_env_init.is_exists('YCQL_USER') or \
+                        self.setup_env_init.is_exists('YCQL_PASSWORD'):
+                    yb_tserver_cmd.extend(["--use_cassandra_authentication=true"])
+                    self.configs.saved_data["ycql_auth"] = True
+                    self.configs.save_configs()
+
             # Start or initialize yb-master and yb-tserver.
             if is_first_run:
                 Output.init_animation("Running system checks...")
@@ -566,6 +600,9 @@ class ControlScript(object):
                 (_, was_started) = self.maybe_start_yw(is_first_run, is_first_install)
                 should_callhome = should_callhome or was_started
 
+            if is_first_install and not join_ip:
+                self.first_install_init()
+
             if is_first_run:
                 status = self.get_status_string() + \
                     "{} {} started successfully! To load a sample dataset, " \
@@ -575,6 +612,10 @@ class ControlScript(object):
                         Output.ROCKET, SCRIPT_NAME, SCRIPT_NAME, Output.PARTY,
                         Output.make_underline(SLACK_LINK), Output.SHIRT,
                         Output.make_underline(COMMUNITY_REWARDS_LINK))
+
+                if len(self.setup_env_init.get_ysql_password()) > 99:
+                    status = status + Output.make_red(YSQL_PASSWORD_LENGTH_WARNING)
+
                 Output.print_out(status)
 
                 if self.configs.temp_data.get("daemon"):
@@ -976,10 +1017,12 @@ class ControlScript(object):
         if advertise_ip != IP_LOCALHOST or ycql_port != DEFAULT_YCQL_PORT:
             cql_hostname_param =  advertise_ip
             cql_port_param = str(ycql_port)
+        ycql_username, ycql_password, ycql_keyspace = self.setup_env_init.get_ycql_credentials()
 
         ysql_hostname_param = "-h {}".format(advertise_ip) if advertise_ip != IP_LOCALHOST else ""
         ysql_port = self.configs.saved_data.get("ysql_port")
         ysql_port_param = "-p {}".format(ysql_port) if ysql_port != DEFAULT_YSQL_PORT else ""
+        ysql_username, ysql_password, ysql_db = self.setup_env_init.get_ysql_credentials()
 
         # Make sure ascii escape characters for color encoding do not count towards char limit.
         if self.get_failed_node_processes():
@@ -992,8 +1035,12 @@ class ControlScript(object):
             status = "Running"
 
 
-        ysql_flags = " {} {}".format(ysql_hostname_param, ysql_port_param)
-        ycql_flags = " {} {}".format(cql_hostname_param, cql_port_param)
+        ysql_flags = " {} {} -U {} -d {}".format(ysql_hostname_param, ysql_port_param,
+                        ysql_username, ysql_db)
+        ycql_flags = " {} {} -u {} -p {}".format(cql_hostname_param, cql_port_param,
+                        ycql_username, ycql_password)
+        if ycql_keyspace is not None:
+            ycql_flags = ycql_flags + " -k {}".format(ycql_keyspace)
 
         # TODO: Check if YW is disabled. This could be from saving --ui flag, checking PID,
         # or some other method. The first is not preferred because it would deviate from how the
@@ -1014,9 +1061,8 @@ class ControlScript(object):
             status_info += [ (Output.make_yellow(console_desc), yb_master_status), ]
 
         status_info += [
-            (Output.make_yellow("JDBC"),
-               "jdbc:postgresql://{}:{}/yugabyte?user=yugabyte&password=yugabyte".format(
-                advertise_ip, ysql_port)),
+            (Output.make_yellow("JDBC"), "jdbc:postgresql://{}:{}/{}?user={}&password={}".
+                format(advertise_ip, ysql_port, ysql_db, ysql_username, ysql_password)),
             (Output.make_yellow("YSQL"), "bin/ysqlsh{}".format(ysql_flags)),
             (Output.make_yellow("YCQL"), "bin/ycqlsh{}".format(ycql_flags)),
             (Output.make_yellow("Data Dir"), self.configs.saved_data.get("data_dir")),
@@ -1299,6 +1345,32 @@ class ControlScript(object):
     def master_port(self):
        self.configs.saved_data.get("master_rpc_port")
 
+    def first_install_init(self):
+        if self.get_failed_node_processes():
+            Output.log_error_and_exit(
+                "{} is not running.".format(SCRIPT_NAME))
+
+        if self.setup_env_init.is_exists('YSQL_USER') or \
+                self.setup_env_init.is_exists('YSQL_PASSWORD') or \
+                self.setup_env_init.is_exists('YSQL_DB'):
+            ysql_proxy = YsqlProxy(ip=self.advertise_ip(),
+                            port=self.configs.saved_data.get("ysql_port"),
+                            get_default_credentials=True)
+            if retry_op(ysql_proxy.is_ysql_up):
+                Output.log("Setting up custom credentials for YSQL...")
+                self.setup_env_init.setup_ysql_credentials(ysql_proxy)
+
+        if self.setup_env_init.is_exists('YCQL_USER') or \
+                self.setup_env_init.is_exists('YCQL_PASSWORD') or \
+                self.setup_env_init.is_exists('YCQL_KEYSPACE'):
+            ycql_proxy = YcqlProxy(ip=self.advertise_ip(),
+                            port=self.configs.saved_data.get("ycql_port"),
+                            get_default_credentials=True,
+                            enforced_auth=self.configs.saved_data.get("ycql_auth"))
+            if retry_op(ycql_proxy.is_ycql_up):
+                Output.log("Setting up custom credentials for YCQL...")
+                self.setup_env_init.setup_ycql_credentials(ycql_proxy)
+
 class Configs(object):
     def __init__(self, config_file, base_dir):
         self.saved_data = {
@@ -1321,6 +1393,8 @@ class Configs(object):
             "master_flags": "",
             "tserver_flags": "",
             "join": "",
+            "ysql_auth": DEFAULT_YSQL_AUTH,
+            "ycql_auth": DEFAULT_YCQL_AUTH,
         }
         # Used to store data specific to certain functions that we don't want to save.
         self.temp_data = {
@@ -1769,52 +1843,176 @@ class YBAdminProxy(object):
 
 # Proxy for ysqlsh commands.
 class YsqlProxy(object):
-    def __init__(self, port, path=os.path.join(BIN_DIR, YUGABYTE_API_CLIENT_PROGRAMS["ysql"])):
-        self.port = str(port)
-        self.path = path
+    def __init__(self, ip, port, path=os.path.join(BIN_DIR, YUGABYTE_API_CLIENT_PROGRAMS["ysql"]),
+                    get_default_credentials=False):
+        self.cmd = [path, "-h", str(ip), "-p", str(port)]
+        self.setup_env_init = SetupEnvBasedCredentials()
+        self.username, self.password, self.db = self.setup_env_init.get_ysql_credentials(
+                                                    get_default_credentials)
+        self.env = {"PGUSER": self.username, "PGPASSWORD": self.password, "PGDATABASE": self.db}
 
     # Starts interactive YSQL shell.
     def connect(self, db=None):
-        cmd = [self.path, "-p", self.port]
-        if db:
-            cmd.extend(["-d", db])
-        shell = subprocess.Popen(cmd)
+        if db is None:
+            db = self.db
+        cmd = self.cmd + ["-d", db]
+        shell = subprocess.Popen(cmd, env={"PGUSER": self.username})
         shell.communicate()
 
     # Checks if db exists.
     # Note that this will return false if ysqlsh can't connect, even if db exists.
     def db_exists(self, db):
-        cmd = [self.path, "-p", self.port, "-q", "-c", "\\t", "-c",
+        cmd = self.cmd + ["-q", "-c", "\\t", "-c",
             "select datname from pg_catalog.pg_database where datname='{}'".format(db)]
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        out, err = p.communicate()
+        out, err, _ = run_process(cmd=cmd, env_vars=self.env)
         return out.strip() == db
 
     # Creates specified db.
     def create_db(self, db):
-        cmd = [self.path, "-p", self.port, "-c", "create database {}".format(db)]
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        out, err = p.communicate()
+        cmd = self.cmd + ["-c", "create database {}".format(db)]
+        out, err, _ = run_process(cmd=cmd, env_vars=self.env)
         return out, err
 
     # Deletes specified db.
     def drop_db(self, db):
-        cmd = [self.path, "-p", self.port, "-c", "drop database {}".format(db)]
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        out, err = p.communicate()
+        cmd = self.cmd + ["-c", "drop database {}".format(db)]
+        out, err, _ = run_process(cmd=cmd, env_vars=self.env)
         return out, err
 
     # Runs ysqlsh with specified files.
     def load_files(self, filepaths, db=None):
-        cmd = [self.path, "-p", self.port]
+        cmd = self.cmd
+        env = self.env
         if db:
-            cmd.extend(["-d", db])
+            env['PGDATABASE'] = db
         for path in filepaths:
             cmd.extend(["-f", path])
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        out, err = p.communicate()
+        out, err, _ = run_process(cmd=cmd, env_vars=env)
         return out, err
 
+    # Check user exists
+    # Note that this will return false if ysqlsh can't connect, even if user exists.
+    def user_exists(self, ysql_username):
+        cmd = self.cmd + ["-c", "select rolname from pg_catalog.pg_roles where rolname='{}'".
+                format(ysql_username)]
+        out, err, _ = run_process(cmd=cmd, env_vars=self.env)
+        return out.strip() == ysql_username
+
+    # Create specified superuser
+    def create_user(self, ysql_username, ysql_password):
+        cmd = self.cmd + ["-c", "create role {} with LOGIN SUPERUSER password '{}';".
+                format(ysql_username, ysql_password)]
+        out, err, _ = run_process(cmd=cmd, env_vars=self.env)
+        return out, err
+
+    # Delete specified user
+    def delete_user(self, username, password, user_to_delete=DEFAULT_YSQL_USER):
+        cmd = self.cmd + ["-c", "drop role {};".format(user_to_delete)]
+        env = self.env
+        env['PGUSER'] = username
+        env['PGPASSWORD'] = password
+        out, err, _ = run_process(cmd=cmd, env_vars=env)
+        return out, err 
+    
+    # Update specified user's password
+    def update_password(self, new_password, user_to_update=DEFAULT_YSQL_USER):
+        cmd = self.cmd + ["-c", "alter role {} password '{}';".format(user_to_update, new_password)]
+        out, err, _ = run_process(cmd=cmd, env_vars=self.env)
+        return out, err
+
+    # Change specified DB's owner
+    def db_owner(self, db, new_owner):
+        cmd = self.cmd + ["-c", "alter database {} owner to {};".format(db, new_owner)]
+        out, err, _ = run_process(cmd=cmd, env_vars=self.env)
+        return out, err
+
+    # Check YSQL is UP
+    def is_ysql_up(self):
+        cmd = self.cmd + ["-c", "\\conninfo"]
+        out, err, _ = run_process(cmd=cmd, env_vars=self.env)
+        if err:
+            Output.log("Unable to connect using YSQL. Error: {}".format(err))
+            raise RetryableError()
+        else:
+            Output.log("YSQL Connection Info - {}".format(out))
+            return True
+
+# Proxy for ycqlsh commands.
+class YcqlProxy(object):
+    def __init__(self, ip, port, path=os.path.join(BIN_DIR, YUGABYTE_API_CLIENT_PROGRAMS["ycql"]),
+                    get_default_credentials=False, enforced_auth=False):
+        self.cmd = [path, str(ip), str(port)]
+        self.setup_env_init = SetupEnvBasedCredentials()
+        self.enforced_auth = enforced_auth
+        self.username, self.password, self.keyspace = self.setup_env_init.get_ycql_credentials(
+                                                        get_default_credentials)
+
+    # Starts interactive YCQL shell.
+    def connect(self):
+        cmd = self.cmd
+        if self.enforced_auth:
+            cmd.extend(["-u", self.username])
+        if self.keyspace is not None:
+            cmd.extend(["-k", self.keyspace])
+        shell = subprocess.Popen(cmd)
+        shell.communicate()
+
+    # Check user exists
+    # Note that this will return false if ycqlsh can't connect, even if user exists.
+    def user_exists(self, ycql_username):
+        cmd = self.cmd + ["-u", self.username, "-p", self.password, "-e",
+            "SELECT role FROM system_auth.roles WHERE role='{}';".format(ycql_username)]
+        out, err, _ = run_process(cmd)
+        return out.strip() == ycql_username
+
+    # Create specified superuser
+    def create_user(self, ycql_username, ycql_password):
+        cmd = self.cmd + ["-u", self.username, "-p", self.password, "-e",
+                "CREATE ROLE {} WITH PASSWORD = '{}' AND LOGIN = true AND SUPERUSER = true;".
+                format(ycql_username, ycql_password)]
+        out, err, _ = run_process(cmd)
+        return out, err
+
+    # Delete specified user
+    def delete_user(self, username, password, user_to_delete=DEFAULT_YCQL_USER):
+        cmd = self.cmd + ["-u", username, "-p", password, "-e",
+                "DROP ROLE IF EXISTS {};".format(user_to_delete)]
+        out, err, _ = run_process(cmd)
+        return out, err 
+    
+    # Update specified user's password
+    def update_password(self, new_password, user_to_update=DEFAULT_YCQL_USER):
+        cmd = self.cmd + ["-u", self.username, "-p", self.password, "-e",
+                "ALTER ROLE {} WITH PASSWORD = '{}';".format(user_to_update, new_password)]
+        out, err, _ = run_process(cmd)
+        return out, err
+
+    # Check keyspace exists
+    # Note that this will return false if ycqlsh can't connect, even if keyspace exists.
+    def keyspace_exists(self, keyspace):
+        cmd = self.cmd + ["-u", self.username, "-p", self.password, "-e",
+            "SELECT keyspace_name FROM system_schema.keyspaces WHERE keyspace_name='{}';".
+            format(keyspace)]
+        out, err, _ = run_process(cmd)
+        return out.strip() == keyspace
+
+    # Create specified keyspace
+    def create_keyspace(self, keyspace):
+        cmd = self.cmd + ["-u", self.username, "-p", self.password, "-e",
+                "CREATE KEYSPACE {};".format(keyspace)]
+        out, err, _ = run_process(cmd)
+        return out, err
+
+    # Check YCQL is UP
+    def is_ycql_up(self):
+        cmd = self.cmd + ["-u", self.username, "-p", self.password, "-e", "SHOW HOST"]
+        out, err, _ = run_process(cmd)
+        if err:
+            Output.log("Unable to connect using YCQL. Error: {}".format(err))
+            raise RetryableError()
+        else:
+            Output.log("YCQL Connection Info - {}".format(out))
+            return True
 
 # Currently unused. Useful for getting diagnostics that are available only through logs.
 class LogAnalyzer(object):
@@ -2231,10 +2429,10 @@ def get_kv(map):
     else:
         return map.items()
 
-def run_process(cmd, timeout=None, log_cmd=False):
+def run_process(cmd, timeout=None, log_cmd=False, env_vars=None):
     if log_cmd:
         Output.log("run_process: cmd: {}".format(str(cmd)))
-    proc = subprocess.Popen(cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+    proc = subprocess.Popen(cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE, env=env_vars)
     if PY_VERSION >= 3:
         try:
             out, err = proc.communicate(timeout=timeout)
@@ -2282,6 +2480,141 @@ def retry_op(func, timeout=180):
 
     raise RuntimeError("Failed after retrying operation for {} secs.".format(
         now - start_time))
+
+
+class SetupEnvBasedCredentials(object):
+    def __init__(self):
+        self.ysql_user = os.environ.get('YSQL_USER')
+        self.ysql_password = os.environ.get('YSQL_PASSWORD')
+        self.ysql_db = os.environ.get('YSQL_DB')
+        self.ycql_user = os.environ.get('YCQL_USER')
+        self.ycql_password = os.environ.get('YCQL_PASSWORD')
+        self.ycql_keyspace = os.environ.get('YCQL_KEYSPACE')
+
+    def is_valid(self, var_name):
+        return True if var_name is not None and var_name else False
+
+    def get_ysql_user(self):
+        return self.ysql_user if self.is_valid(self.ysql_user) else DEFAULT_YSQL_USER
+
+    def get_ysql_password(self):
+        return self.ysql_password if self.is_valid(self.ysql_password) else (self.ysql_user if (
+                    self.is_valid(self.ysql_user)) else DEFAULT_YSQL_PASSWORD)
+
+    def get_ysql_db(self):
+        return self.ysql_db if self.is_valid(self.ysql_db) else (self.ysql_user if (
+                    self.is_valid(self.ysql_user)) else DEFAULT_YSQL_DB)
+
+    def get_ycql_user(self):
+        return self.ycql_user if self.is_valid(self.ycql_user) else DEFAULT_YCQL_USER
+
+    def get_ycql_password(self):
+        return self.ycql_password if self.is_valid(self.ycql_password) else (self.ycql_user if (
+                    self.is_valid(self.ycql_user)) else DEFAULT_YCQL_PASSWORD)
+
+    def get_ycql_keyspace(self):
+        return self.ycql_keyspace if self.is_valid(self.ycql_keyspace) else (self.ycql_user if (
+                    self.is_valid(self.ycql_user)) else DEFAULT_YCQL_KEYSPACE)
+
+    def get_ysql_credentials(self, get_default_credentials=False):
+        if get_default_credentials:
+            return DEFAULT_YSQL_USER, DEFAULT_YSQL_PASSWORD, DEFAULT_YSQL_DB
+        else:
+            return self.get_ysql_user(), self.get_ysql_password(), self.get_ysql_db()
+
+    def get_ycql_credentials(self, get_default_credentials=False):
+        if get_default_credentials:
+            return DEFAULT_YCQL_USER, DEFAULT_YCQL_PASSWORD, DEFAULT_YCQL_KEYSPACE
+        else:
+            return self.get_ycql_user(), self.get_ycql_password(), self.get_ycql_keyspace()
+
+    def is_exists(self, var_to_check):
+        return self.is_valid(os.environ.get(var_to_check))
+
+    def setup_ysql_credentials(self, proxy_class):
+
+        # Create DB
+        if self.get_ysql_db() != DEFAULT_YSQL_DB and not proxy_class.db_exists(self.get_ysql_db()):
+            Output.log("Creating {} database".format(self.get_ysql_db()))
+            _, err = proxy_class.create_db(self.get_ysql_db())
+            if err:
+                Output.log_error_and_exit("Failed to create {} database: \
+                    {}".format(self.get_ysql_db(), err))
+
+            Output.log("{} database created successfully".format(self.get_ysql_db()))
+
+        # Update password for default user
+        if self.get_ysql_user() == DEFAULT_YSQL_USER:
+            _, err = proxy_class.update_password(self.get_ysql_password())
+            if err:
+                Output.log_error_and_exit("class: {} Failed to update password for default user {}".
+                    format(proxy_class, err))
+
+            Output.log("class: {} Password has updated for default user successfully".
+                format(proxy_class))
+
+        # Create User
+        if self.get_ysql_user() != DEFAULT_YSQL_USER and not proxy_class.user_exists(self.get_ysql_user()):
+            Output.log("Creating {} user".format(self.get_ysql_user()))
+            _, err = proxy_class.create_user(self.get_ysql_user(), self.get_ysql_password())
+            if err:
+                Output.log_error_and_exit("Failed to create {} user: {}".
+                    format(self.get_ysql_user(), err))
+
+            if self.get_ysql_db() != DEFAULT_YSQL_DB:
+                _, err = proxy_class.db_owner(self.get_ysql_db(), self.get_ysql_user())
+                if err:
+                    Output.log_error_and_exit("Failed to change owner on {} database: {}".
+                        format(self.get_ysql_db(), err))
+
+            # Note: Following lines will be commented till we can decide on default user deletion.
+            #_, err = proxy_class.delete_user(self.get_ysql_user(), self.get_ysql_password())
+            #if err:
+            #   Output.log_error_and_exit("Failed to delete default user: {}".format(err))
+
+            Output.log("{} user created successfully".format(self.get_ysql_user()))
+
+        Output.log("Custom credentials configured successfully for YSQL")
+
+    def setup_ycql_credentials(self, proxy_class):
+
+        # Create YCQL Keyspace
+        if self.get_ycql_keyspace() and not proxy_class.keyspace_exists(self.get_ycql_keyspace()):
+            Output.log("Creating {} keyspace".format(self.get_ycql_keyspace()))
+            _, err = proxy_class.create_keyspace(self.get_ycql_keyspace())
+            if err:
+                Output.log_error_and_exit("Failed to create {} keyspace: {}".
+                    format(self.get_ycql_keyspace(), err))
+
+            Output.log("{} keyspace created successfully".format(self.get_ycql_keyspace()))
+
+        # Update password for default user
+        if self.get_ycql_user() == DEFAULT_YCQL_USER:
+            _, err = proxy_class.update_password(self.get_ycql_password())
+            if err:
+                Output.log_error_and_exit("class: {} Failed to update password for default user {}".
+                    format(proxy_class, err))
+
+            Output.log("class: {} Password has updated for default user successfully".
+                format(proxy_class))
+
+        # Create user
+        if self.get_ycql_user() != DEFAULT_YCQL_USER and not proxy_class.user_exists(self.get_ycql_user()):
+            Output.log("Creating {} user".format(self.get_ycql_user()))
+            _, err = proxy_class.create_user(self.get_ycql_user(), self.get_ycql_password())
+            if err:
+                Output.log_error_and_exit("Failed to create {} user: {}".
+                    format(self.get_ycql_user(), err))
+
+            # Note: Following lines will be commented till we can decide on default user deletion.
+            #_, err = proxy_class.delete_user(self.get_ycql_user(), self.get_ycql_password())
+            #if err:
+            #   Output.log_error_and_exit("Failed to delete default user: {}".format(err))
+
+            Output.log("{} user created successfully".format(self.get_ycql_user()))
+
+        Output.log("Custom credentials configured successfully for YCQL")
+
 
 if __name__ == '__main__':
     ControlScript().run()

--- a/docs/content/latest/reference/configuration/yugabyted.md
+++ b/docs/content/latest/reference/configuration/yugabyted.md
@@ -354,6 +354,81 @@ Deletes the `yb_demo_northwind` northwind database.
 
 -----
 
+## Environment Variables
+
+### For YSQL:  `YSQL_USER` `YSQL_PASSWORD` `YSQL_DB`
+
+Set `YSQL_PASSWORD` to use the cluster in enforced authentication mode.
+
+Combinations of environment variables and their uses. 
+
+- `YSQL_PASSWORD`
+   
+  Update the default yugabyte user's password.
+
+- `YSQL_PASSWORD, YSQL_DB`
+
+  Update the default yugabyte user's password and create `YSQL_DB` named DB.
+
+- `YSQL_PASSWORD, YSQL_USER`
+
+  Create `YSQL_USER` named user and DB with password `YSQL_PASSWORD`.
+
+- `YSQL_USER`
+
+  Create `YSQL_USER` named user and DB with password `YSQL_USER`.
+
+- `YSQL_USER, YSQL_DB`
+
+  Create `YSQL_USER` named user with password `YSQL_USER` and `YSQL_DB` named DB.
+
+- `YSQL_DB`
+
+  Create `YSQL_DB` named DB.
+
+- `YSQL_USER, YSQL_PASSWORD, YSQL_DB`
+  
+  Create `YSQL_USER` named user with password `YSQL_PASSWORD` and `YSQL_DB` named DB.
+
+### For YCQL:  `YCQL_USER` `YCQL_PASSWORD` `YCQL_KEYSPACE`
+
+Set `YCQL_USER` or `YCQL_PASSWORD` to use the cluster in enforced authentication mode.
+
+Combinations of environment variables and their uses.
+
+- `YCQL_PASSWORD`
+   
+  Update the default cassandra user's password.
+
+- `YCQL_PASSWORD, YCQL_KEYSPACE`
+
+  Update the default cassandra user's password and create `YCQL_KEYSPACE` named keyspace.
+
+- `YCQL_PASSWORD, YCQL_USER`
+
+  Create `YCQL_USER` named user and DB with password `YCQL_PASSWORD`.
+
+- `YCQL_USER`
+
+  Create `YCQL_USER` named user and DB with password `YCQL_USER`.
+
+- `YCQL_USER, YCQL_KEYSPACE`
+
+  Create `YCQL_USER` named user with password `YCQL_USER` and `YCQL_USER` named keyspace.
+
+- `YCQL_KEYSPACE`
+
+  Create `YCQL_KEYSPACE` named keyspace.
+
+- `YCQL_USER, YCQL_PASSWORD, YCQL_KEYSPACE`
+  
+  Create `YCQL_USER` named user with password `YCQL_PASSWORD` and `YCQL_KEYSPACE` named keyspace.
+
+**Note**
+- In the case of multi-node deployment, all nodes should have similar environment variables. 
+
+-----
+
 ## Examples
 
 ### Create a single-node cluster


### PR DESCRIPTION
### Summary:

Added env variables functionality in `yugabyted`

- Added env variables for YSQL: `YSQL_USER, YSQL_PASSWORD, YSQL_DB`
- Added env variables for YCQL: `YCQL_USER, YCQL_PASSWORD, YCQL_KEYSPACE`
-  Added docs to use environment variables

**Edited:**
-----

- Environment variables should exist with every execution to maintain idempotency. Authentication flags will be added to the tserver on the existence of environment variables.
- `yugabyted` won't execute environment variables based configuration snippet on `follower nodes`.

**Note:** 

- `bin/yugabyted status` command output will change with the existence of environment variables.
- For now, the default credentials haven't been removed.

**Test Plan:**

1. A single node cluster with and without environment variables.
2. Multinode cluster with and without environment variables.
3. Multiple combinations of environment variables as suggested in the docs.
4. Tested with the latest docker image.
5. Tested with Python v2.7.5 and v3.5.2


Fixes: https://github.com/yugabyte/yugabyte-db/issues/3956