### PR TITLE
[docs] Add releases updates

### DIFF
--- a/docs/content/latest/_index.html
+++ b/docs/content/latest/_index.html
@@ -7,6 +7,13 @@ image: /images/ybsymbol_original.png
 weight: 1
 ---
 
+{{< note title="New release versioning" >}}
+
+Starting with v2.2.0, Yugabyte release versions follow a [new release versioning convention](/latest/releases/versioning). The latest release series, denoted by `MAJOR.ODD`, incrementally introduces new features and changes and is intended for development and testing only. Patch releases, denoted by `MAJOR.ODD.PATCH` versioning, can include new features and changes that might break backwards compatibility. For more information, see [Supported and planned releases](/latest/releases/releases-overview).
+
+{{< /note >}}
+
+
 <div class="row">
   <div class="col-12 col-md-6">
     <a class="section-link icon-offset" href="quick-start/">

--- a/docs/content/latest/releases/earlier-releases/_index.md
+++ b/docs/content/latest/releases/earlier-releases/_index.md
@@ -8,7 +8,7 @@ section: RELEASES
 menu:
   latest:
     identifier: earlier-releases
-    weight: 2586 
+    weight: 2589
 ---
 
 Download earlier YugabyteDB releases from the listing below. Information on the latest release is available

--- a/docs/content/latest/releases/releases-overview.md
+++ b/docs/content/latest/releases/releases-overview.md
@@ -41,11 +41,11 @@ The following release series include:
 
 ## Planned releases
 
-Listed below are tentative release dates for upcoming planned releases, subject to change. For information on what's being worked on, see [Current roadmap](https://github.com/yugabyte/yugabyte-db#current-roadmap).
+Listed below are tentative release dates for upcoming planned release series, subject to change. For get insights into the new features planned for these upcoming releases, visit the [Current roadmap](https://github.com/yugabyte/yugabyte-db#current-roadmap).
 
-| Version | Planned release |
-| :------ | --------------- |
-| 2.4     | Jan 2021        |
-| 2.5     | Nov 2020        |
-| 2.6     | Apr 2021        |
-| 2.7     | Feb 2021        |
+| Release series | Planned release |
+| :------------- | --------------- |
+| 2.4            | Jan 2021        |
+| 2.5            | Nov 2020        |
+| 2.6            | Apr 2021        |
+| 2.7            | Feb 2021        |

--- a/docs/content/latest/releases/releases-overview.md
+++ b/docs/content/latest/releases/releases-overview.md
@@ -7,7 +7,7 @@ section: RELEASES
 menu:
   latest:
     identifier: releases-overview
-    weight: 2588 
+    weight: 2585
 isTocNested: true
 showAsideToc: true
 ---
@@ -29,19 +29,21 @@ The following release series include:
 
 [Planned releases](#planned-releases), in a section below, includes timelines for upcoming stable and latest release series.
 
-| Release series                    | Released     | Maintenance support ends | EOL          | Status                              |
-| :-------------------------------- | :----------- | :----------------------- | :----------- | :----------------------------------- |
-| [2.3](../whats-new)               | Sep 08, 2020 | ---                      | ---          | Latest (development and testing)
-| [2.2](../earlier-releases/v2.2.0) | Jul 15, 2020 | Jul 15, 2021             | Jan 15, 2022 | Stable (recommended for production)
-| [2.1](../earlier-releases/v2.1.0) | Feb 25, 2020 | Feb 25, 2021             | Aug 08, 2021 | Stable
-| [2.0](../earlier-releases/v2.0.0) | Sep 17, 2019 | Sep 17, 2020             | Mar 03, 2021 | Stable
-| [1.3](../earlier-releases/v1.3.0) | Jul 15, 2019 | Jul 15, 2020             | Jan 15, 2021 | Stable
+| Release series                      | Released     | Maintenance support ends | EOL          | Status                              |
+| :---------------------------------- | :----------- | :----------------------- | :----------- | :----------------------------------- |
+| [2.3](../whats-new/latest-releases) | Sep 08, 2020 | ---                      | ---          | Latest (development and testing)
+| [2.2](../whats-new/stable-releases) | Jul 15, 2020 | Jul 15, 2021             | Jan 15, 2022 | Stable (recommended for production)
+| [2.1](../earlier-releases/v2.1.0)   | Feb 25, 2020 | Feb 25, 2021             | Aug 08, 2021 | Stable
+| [2.0](../earlier-releases/v2.0.0)   | Sep 17, 2019 | Sep 17, 2020             | Mar 03, 2021 | Stable
+| [1.3](../earlier-releases/v1.3.0)   | Jul 15, 2019 | Jul 15, 2020             | Jan 15, 2021 | Stable
 
-**Note:** The stable release series include `2.1`, `2.0`, and `1.3`, released prior to the new [release versioning](../) convention.
+**Note:** The stable release series includes `2.1`, `2.0`, and `1.3`, released prior to the new [release versioning](../release-versioning) convention.
 
 ## Planned releases
 
-Listed below are tentative release dates for upcoming planned release series, subject to change. For get insights into the new features planned for these upcoming releases, visit the [Current roadmap](https://github.com/yugabyte/yugabyte-db#current-roadmap).
+Listed below are tentative release dates for upcoming planned release series, subject to change. 
+
+To help you plan, visit [Current roadmap](https://github.com/yugabyte/yugabyte-db#current-roadmap) for insights into key features planned for the upcoming releases.
 
 | Release series | Planned release |
 | :------------- | --------------- |

--- a/docs/content/latest/releases/versioning.md
+++ b/docs/content/latest/releases/versioning.md
@@ -7,7 +7,7 @@ section: RELEASES
 menu:
   latest:
     identifier: versioning
-    weight: 2589
+    weight: 2586
 isTocNested: true
 showAsideToc: true
 ---
@@ -22,13 +22,15 @@ Yugabyte follows the [semantic versioning (semver)](https://semver.org) conventi
 - `MINOR` — Incremented when new features and changes are introduced.
   - `EVEN` — Stable minor release, intended for production deployments.
   - `ODD` — Latest minor release, intended for development and testing.
-- `PATCH` — bug fixes and revisions that do not break backwards compatibility.
+- `PATCH` — Patches in a stable release (`MAJOR.EVEN.PATCH) include bug fixes and revisions that do not break backward compatibility. For patches in the latest release series (`MAJOR.ODD.PATCH`), new features and changes are introduced that might break backward compatibility.
 
 Examples follow in the relevant sections below.
 
 ## Stable releases
 
-Stable release series, denoted by `MAJOR.EVEN` numbers, introduce fully tested new features and changes added since the last stable release. The current `2.2` stable release series will be followed by the next `2.4` stable release series.
+Releases within stable release series, denoted by `MAJOR.EVEN` versioning, introduce fully tested new features and changes added since the last stable release. The `2.2` stable release series will be followed by the next `2.4` stable release series.
+
+Patch releases in a stable release series (`MAJOR.EVEN.PATCH`) include bug fixes and revisions that do not break backward compatibility.
 
 {{< note title="Important" >}}
 
@@ -38,4 +40,6 @@ Yugabyte supports *production deployments* based on stable releases and can only
 
 ## Latest releases
 
-The latest release series, denoted by a `MAJOR.ODD` number, is the current work-in-progress release series that incrementally introduces new features and changes. The `2.3` latest release series will become the basis for the next `2.4` stable release series. And the next latest release series available will then be `2.5`. These `MAJOR.ODD` releases are not supported for production deployments.
+Releases within the latest release series, denoted by `MAJOR.ODD` versioning, incrementally introduces new features and changes and are intended for development and testing. The latest releases are not supported for production deployments. The `2.3` latest release series will become the basis for the next `2.4` stable release series. And the next latest release series available will then be `2.5`.
+
+Patches released in the latest release series (`MAJOR.ODD.PATCH`) can introduce new features and changes that might break backward compatibility. 

--- a/docs/content/latest/releases/versioning.md
+++ b/docs/content/latest/releases/versioning.md
@@ -2,7 +2,7 @@
 title: Release versioning
 headerTitle: Release versioning
 linkTitle: Release versioning
-description: Explains the new release versioning approach for latest and stable releases.
+description: Explains the new release versioning convention for latest and stable releases.
 section: RELEASES
 menu:
   latest:
@@ -28,7 +28,7 @@ Examples follow in the relevant sections below.
 
 ## Stable releases
 
-Stable release series, denoted by `MAJOR.EVEN` numbers, introduce fully tested new features and changes added since the last stable release. The current stable `2.2` release series will be followed by the next stable `2.4` release series.
+Stable release series, denoted by `MAJOR.EVEN` numbers, introduce fully tested new features and changes added since the last stable release. The current `2.2` stable release series will be followed by the next `2.4` stable release series.
 
 {{< note title="Important" >}}
 
@@ -38,4 +38,4 @@ Yugabyte supports *production deployments* based on stable releases and can only
 
 ## Latest releases
 
-The latest release series, denoted by a `MAJOR.ODD` number, is the current work-in-progress release series that incrementally introduces new features and changes. The latest `2.3` release series will become the next stable `2.4` release series. And the next latest release series will be `2.5`. These `MAJOR.ODD` releases are not supported for production deployments.
+The latest release series, denoted by a `MAJOR.ODD` number, is the current work-in-progress release series that incrementally introduces new features and changes. The `2.3` latest release series will become the basis for the next `2.4` stable release series. And the next latest release series available will then be `2.5`. These `MAJOR.ODD` releases are not supported for production deployments.

--- a/docs/content/latest/releases/whats-new/_index.md
+++ b/docs/content/latest/releases/whats-new/_index.md
@@ -14,16 +14,14 @@ menu:
     weight: 2585 
 ---
 
-This page includes the what's new and release notes for all releases in the `2.3` latest release series. You can now compare updates within the same `2.3` release series without changing pages.
-
-The `2.3` latest release series include the following releases:
+Included here are the release notes for all releases in the `2.3` latest release series. The `2.3` latest release series include the following releases:
 
 - [v2.3.1.0 (Released Sep 15, 2020)](#v2-3-1-0-2020-09-15)
 - [v2.3.0.0 (Released Sep 08, 2020)](#v2-3-0-0-2020-09-08)
 
 {{< note title="Important" >}}
 
-Starting with v2.2.0, Yugabyte release versions are numbered based on an even/odd release versioning. For more details, see the following:
+Starting with v2.2.0, Yugabyte release versions are numbered based on an a new release versioning convention. For more details, see the following:
 
 - [Release versioning](../../versioning) – Includes details on stable and latest versioning.
 - [Supported and planned releases](../../releases-overview) – Information on supported and latest releases.

--- a/docs/content/latest/releases/whats-new/_index.md
+++ b/docs/content/latest/releases/whats-new/_index.md
@@ -1,9 +1,9 @@
 ---
-title: What's new in 2.3
-headerTitle: What's new in 2.3
-linkTitle: What's new in 2.3
-description: Enhancements, changes, and resolved issues in the latest release series.
-headcontent: Features, enhancements, and resolved issues in the latest release series.
+title: What's new
+headerTitle: What's new
+linkTitle: What's new
+description: Enhancements, changes, and resolved issues in the latest and stable release series.
+headcontent: Features, enhancements, and resolved issues in the latest and stable release series.
 image: /images/section_icons/quick_start/install.png
 aliases:
   - /latest/releases/
@@ -11,250 +11,33 @@ section: RELEASES
 menu:
   latest:
     identifier: whats-new
-    weight: 2585 
+    weight: 2588 
 ---
 
-Included here are the release notes for all releases in the `2.3` latest release series. The `2.3` latest release series include the following releases:
+<div class="row">
 
-- [v2.3.1.0 (Released Sep 15, 2020)](#v2-3-1-0-2020-09-15)
-- [v2.3.0.0 (Released Sep 08, 2020)](#v2-3-0-0-2020-09-08)
+  <div class="col-12 col-md-6 col-lg-12 col-xl-6">
+      <a class="section-link icon-offset" href="latest-releases/">
+          <div class="head">
+              <img class="icon" src="/images/section_icons/quick_start/install.png" aria-hidden="true" />
+              <div class="title">What's new in 2.3 (latest)</div>
+          </div>
+          <div class="body">
+              Features, enhancements, and fixes in the latest release series `2.3` (Updated September 15, 2020).
+          </div>
+      </a>
+  </div>
+  
+  <div class="col-12 col-md-6 col-lg-12 col-xl-6">
+      <a class="section-link icon-offset" href="stable-releases/">
+          <div class="head">
+              <img class="icon" src="/images/section_icons/quick_start/install.png" aria-hidden="true" />
+              <div class="title">What's new in 2.2 (stable)</div>
+          </div>
+          <div class="body">
+              Features, enhancements, and fixes in the recommended stable release series `2.2` (Updated August 19, 2020).
+          </div>
+      </a>
+  </div>
 
-{{< note title="Important" >}}
-
-Starting with v2.2.0, Yugabyte release versions are numbered based on an a new release versioning convention. For more details, see the following:
-
-- [Release versioning](../../versioning) – Includes details on stable and latest versioning.
-- [Supported and planned releases](../../releases-overview) – Information on supported and latest releases.
-
-{{< /note >}}  
-
-## v2.3.1.0 [2020-09-15]
-
-**Released:** September 15, 2020 (2.3.1.0-b15).
-
-### Downloads
-
-#### Binaries
-
-<a class="download-binary-link" href="https://downloads.yugabyte.com/yugabyte-2.3.1.0-darwin.tar.gz">
-  <button>
-    <i class="fab fa-apple"></i><span class="download-text">macOS</span>
-  </button>
-</a>
-&nbsp; &nbsp; &nbsp;
-<a class="download-binary-link" href="https://downloads.yugabyte.com/yugabyte-2.3.1.0-linux.tar.gz">
-  <button>
-    <i class="fab fa-linux"></i><span class="download-text">Linux</span>
-  </button>
-</a>
-<br />
-
-#### Docker
-
-```sh
-docker pull yugabytedb/yugabyte:2.3.1.0-b15
-```
-
-### Features and changes
-
-#### YSQL
-
-- Fixes OOM when using `COPY <table> FROM <file>` to load data from a large file to a table. [#5453](https://github.com/yugabyte/yugabyte-db/issues/5453)
-- Enable 2DC replication bootstrap for YSQL tables. This allows the producer to know where to start replicating from. [#5601](https://github.com/yugabyte/yugabyte-db/issues/5601)
-- Fix `CREATE TABLE` is 4-5x slower using Docker on Mac than not using Docker. Speeds up table creation by buffering writes to postgres system tables, caching pinned objects, and significantly reducing write RPC calls. [#3503](https://github.com/yugabyte/yugabyte-db/issues/3503)
-- Roll back the catalog version made in commit `46f3701` so that 2.3 upgrades can proceed. [#5408](ttps://github.com/yugabyte/yugabyte-db/issues/5408)
-
-#### Core database
-
-- Quickly evict known unresponsive tablet servers from the tablet location cache. Applies only to follower reads. For example, when tablet servers are not replying to RPC calls or dead — not sending heartbeats to the master for 5 minutes. This could also happen after decommissioning nodes. [#1052](https://github.com/yugabyte/yugabyte-db/issues/1052)
-
-#### Yugabyte Platform
-
-- Add search input and data sorting to the on-premises instances table list. Click arrows next to column titles to sort. Use the Search form to search multiple columns. [#4757](https://github.com/yugabyte/yugabyte-db/issues/4757)
-- Add the ability to change the user role (`Admin`, `ReadOnly`, or `BackupAdmin`) from the UI by an admin. Also, fix stale users list after creation or deletion of a user and disable **Save** buttons at Customer Profile tabs for `ReadOnly` users. [#5311](https://github.com/yugabyte/yugabyte-db/issues/5311)
-- Before deleting a universe, stop the master/tserver processes and release the instance so that if started again, the processes are not still running. [#4953](https://github.com/yugabyte/yugabyte-db/issues/4953)
-
-{{< note title="Note" >}}
-
-Prior to version 2.0, YSQL was still in beta. As a result, the 2.0 release included a backward-incompatible file format change for YSQL. If you have an existing cluster running releases earlier than 2.0 with YSQL enabled, then you will not be able to upgrade to version 2.0+. Export from your existing cluster and then import into a new cluster (v2.0 or later) to use existing data.
-
-{{< /note >}}
-
-## v2.3.0.0 [2020-09-08]
-
-**Released:** September 8, 2020 (2.3.0.0-b176).
-
-### Downloads
-
-#### Binaries
-
-<a class="download-binary-link" href="https://downloads.yugabyte.com/yugabyte-2.3.0.0-darwin.tar.gz">
-  <button>
-    <i class="fab fa-apple"></i><span class="download-text">macOS</span>
-  </button>
-</a>
-&nbsp; &nbsp; &nbsp;
-<a class="download-binary-link" href="https://downloads.yugabyte.com/yugabyte-2.3.0.0-linux.tar.gz">
-  <button>
-    <i class="fab fa-linux"></i><span class="download-text">Linux</span>
-  </button>
-</a>
-<br />
-
-#### Docker
-
-```sh
-docker pull yugabytedb/yugabyte:2.3.0.0-b176
-```
-
-### Features and changes
-
-#### YSQL
-
-- Fix OOM when running large `COPY TO` statements by creating new memory context for the loop over retrieved rows and resetting it after processing each row. [#5205](https://github.com/yugabyte/yugabyte-db/issues/5205)
-- Support transactional batch size for [`COPY FROM` command](../../api/ysql/commands/cmd_copy) with OOM fix. Batch sizes can be passed in with `ROWS_PER_TRANSACTION` in the `COPY OPTION` syntax. For an example, see [Import a large table using smaller transactions](../../api/ysql/commands/cmd_copy/#import-a-large-table-using-smaller-transactions) [#2855](https://github.com/yugabyte/yugabyte-db/issues/2855) [#5453](https://github.com/yugabyte/yugabyte-db/issues/5453)
-- For index backfill flags, use better default values. Set `index_backfill_rpc_timeout_ms` default from `60000` to `30000` and change `backfill_index_timeout_grace_margin_ms` default from `50` to `500`. [#5494](https://github.com/yugabyte/yugabyte-db/issues/5494)
-- Remove spurious error message "0A000: Alter table is not yet supported" from `CREATE OR REPLACE VIEW`. [#5071](https://github.com/yugabyte/yugabyte-db/issues/5071)
-- Prevent consistency violations when a partitioned table has foreign key constraints due to erroneous classification as a single-row transaction. [#5387](https://github.com/yugabyte/yugabyte-db/issues/5387)
-- Fix restore from a distributed backup fails for tables using `SPLIT INTO` without a primary key. [#4993](https://github.com/yugabyte/yugabyte-db/issues/4993)
-- Fix wrong result by avoiding pushdown of `UPDATE` statement with the `RETURNING` clause. [#5366](https://github.com/yugabyte/yugabyte-db/issues/5366)
-- Improve error message when `UPDATE` changes partition so its clear what went wrong, fixed `yb_pg_foreign_key` `pg_regress` test for semantic merge conflict when updating primary keys and row-level partitioning. [#659](https://github.com/yugabyte/yugabyte-db/issues/659) [#5179](https://github.com/yugabyte/yugabyte-db/issues/5179) [#5310](https://github.com/yugabyte/yugabyte-db/issues/5310)
-- Allow `UPDATE` statement to change primary key columns. [#659](https://github.com/yugabyte/yugabyte-db/issues/659)
-- Support row-level partitioning. [#5179](https://github.com/yugabyte/yugabyte-db/issues/5179)
-- Block usage of `TABLEGROUP` with the `SPLIT` clause. For `CREATE TABLE`, usage is blocked in the grammar. For `CREATE INDEX`, if `NO TABLEGROUP` was provided, then presplitting for the index is allowed; otherwise, an error is issued. [#5352](https://github.com/yugabyte/yugabyte-db/issues/5352)
-- Buffered operations may share single RPC with read operation. Reducing the number of RPC calls speeds up `CREATE TABLE` statement. For example, the total number of RPC calls is dropped from 66 to 58 for a simple table like `CREATE TABLE t(k INT PRIMARY KEY)`. [#5177](https://github.com/yugabyte/yugabyte-db/issues/5177)
-- Add new `ysqlsh` describe metacommands for tablegroups: `\dgr[+] [grpname]` to describe tablegroups, `\dgrt[+] [grpname]` lists all tables/indexes within the specified tablegroup (or within all tablegroups if `grpname` is not specified), and `\d <table_name>` is modified to include tablegroup information in the footer, if any. [#5088](https://github.com/yugabyte/yugabyte-db/issues/3118)
-- Add `ALTER TABLEGROUP` statements to support `ALTER TABLEGROUP tablegroup_name RENAME TO ...` and `ALTER TABLEGROUP tablegroup_name OWNER TO ...`. Also changes `pg_tablegroup` entry corresponding to `tablegroup_name` to properly reflect new `grpname` and `grpowner` (if the user has proper permissions or ownership to issue the `ALTER TABLEGROUP` statement. [#5249](https://github.com/yugabyte/yugabyte-db/issues/5249)
-- Add support for indexes to opt out of tablegroups (`NO TABLEGROUPS`) or select their own tablegroup (`TABLEGROUP group_name`). [#5293](https://github.com/yugabyte/yugabyte-db/issues/5293)
-- For [`ysql_dump`](../../admin/ysql-dump), enable `serializable-deferrable` mode by default. Add new [`--no-serializable-deferrable`](../../admin/ysql-dump/#no-serializable-deferrable) flag to disable the default mode. [#5128](https://github.com/yugabyte/yugabyte-db/issues/5128)
-- Support `ALTER COLUMN type` for variants that don't require on-disk changes. Specifically only allowing `ALTER COLUMN type` for `varch(n)` and `varbit(n)`. For example, changing column type from `varchar(50)` to `varchar(255)`. [#4424](https://github.com/yugabyte/yugabyte-db/issues/4424)
-- Enable `USING` clause in `DELETE` statement and `FROM` clause in `UPDATE` statement. [#738](https://github.com/yugabyte/yugabyte-db/issues/738) [#5262](https://github.com/yugabyte/yugabyte-db/issues/5262)
-- Support GRANT/REVOKE/ALTER DEFAULT PRIVILEGES for tablegroups. [#5087](https://github.com/yugabyte/yugabyte-db/issues/5087) [#5160](https://github.com/yugabyte/yugabyte-db/issues/5160)
-- Implement tablegroup query layer changes. [#4525](https://github.com/yugabyte/yugabyte-db/issues/4525)
-- Replace "Foreign Scan" with "Seq Scan" for `EXPLAIN` statement. [#2076](https://github.com/yugabyte/yugabyte-db/issues/2076)
-- Fix `initdb` when index backfill is enabled. [#5027](https://github.com/yugabyte/yugabyte-db/issues/5027)
-- Properly handle empty delete with backfill by sending appropriate messages to the client, including setting it `skipped` and `rows_affected_count` to `0`. [#5015](https://github.com/yugabyte/yugabyte-db/issues/5015)
-- `DROP INDEX` statement invalidates table cache entry for the index table, but should invalidate the table cache entry for the indexed table. [#4974](https://github.com/yugabyte/yugabyte-db/issues/4974)
-- `yb-admin create_database_snapshot` command should not require `ysql.` prefix for database name. [#4991](https://github.com/yugabyte/yugabyte-db/issues/4991)
-- For non-prepared statements, optimize `pg_statistic` system table lookups and update debugging utilities. [#5051](https://github.com/yugabyte/yugabyte-db/issues/5051)
-- Correctly show beta feature warnings by default. [#5322](https://github.com/yugabyte/yugabyte-db/issues/5322)
-
-#### YCQL
-
-- For `WHERE` clause in the `CREATE INDEX` statement, return a `Not supported` error. [#5363](https://github.com/yugabyte/yugabyte-db/issues/5363)
-- Fix TSAN issue in partition-aware policy for C++ driver 2.9.0-yb-8 (yugabyte/cassandra-cpp-driver). [#1837](https://github.com/yugabyte/yugabyte-db/issues/1837)
-- Support YCQL backup for indexes based on JSON-attribute. [#5198](https://github.com/yugabyte/yugabyte-db/issues/5198)
-- Correctly set `release_version` for `system.peers` queries. [#5407](https://github.com/yugabyte/yugabyte-db/issues/5407)
-- Reject `TRUNCATE` operations when [`ycql_require_drop_privs_for_truncate`](../../reference/configuration/yb-tserver/#ycql-require-drop-privs-for-truncate) flag is enabled. When enabled, `DROP TABLE` permission is required to truncate a table. Default is `false`. [#5443](https://github.com/yugabyte/yugabyte-db/issues/5443)
-- Fix missing return statement in error case of the `SetPagingState` method in `statement_params.cc`. [#5441](https://github.com/yugabyte/yugabyte-db/issues/5441)
-- Enable backfilling of transactional tables by default. [#4708](https://github.com/yugabyte/yugabyte-db/issues/4708)
-- Fix `ycqlsh` should return a failure when known that the create (unique) index has failed. [#5161](https://github.com/yugabyte/yugabyte-db/issues/5161)
-
-#### Core database
-
-- Fix core dump related to DNS resolution from cache for Kubernetes universes. [#5561](https://github.com/yugabyte/yugabyte-db/issues/5561)
-- Fix yb-master fails to restart after errors on first run. [#5276](https://github.com/yugabyte/yugabyte-db/issues/5276)
-- Show better error message when using `yugabyted` and yb-master fails to start. [#5304](https://github.com/yugabyte/yugabyte-db/issues/5304)
-- Disable ignoring deleted tablets on load by default. [#5122](https://github.com/yugabyte/yugabyte-db/issues/5122)
-- [CDC] Improve CDC idle throttling logic to reduce high CPU utilization in clusters without workloads running. [#5472](https://github.com/yugabyte/yugabyte-db/issues/5472)
-- For the `server_broadcast_addresses` flag, provide default port if not specified. [#2540](https://github.com/yugabyte/yugabyte-db/issues/2540)
-- [CDC] Fix CDC TSAN destructor warning. [#4258](https://github.com/yugabyte/yugabyte-db/issues/4258)
-- Add an API endpoint to download root certificate file. [#4957](https://github.com/yugabyte/yugabyte-db/issues/4957)
-- Do not load deleted tables and tablets into memory on startup. [#5122](https://github.com/yugabyte/yugabyte-db/issues/5122)
-- Set the follower lag for leaders to `0` by resetting timestamp to the maximum value when a peer becomes a leader and when the peer loses leadership. [#5502](https://github.com/yugabyte/yugabyte-db/issues/5502)
-- Flow keyspace information from yb-master to yb-tserver. [#3020](https://github.com/yugabyte/yugabyte-db/issues/3020)
-- Implement meta cache lookups throttling to reduce unnecessary thrashing. [#5434](https://github.com/yugabyte/yugabyte-db/issues/5434)
-- Fix `rpcz/statements` links in `yb-tserver` Web UI when `pgsql_proxy_bind_address` and `cql_proxy_bind_address` are `0.0.0.0`. [#4963](https://github.com/yugabyte/yugabyte-db/issues/4963)
-- `DumpReplayStateToStrings` should handle too many WAL entries scenario. Also, log lines only display fields critical for debugging and do not show customer-sensitive information. [#5345](https://github.com/yugabyte/yugabyte-db/issues/5345)
-- Find the difference between the replica map and consensus state more quickly using a map lookup. [#5435](https://github.com/yugabyte/yugabyte-db/issues/5435)
-- Improve failover to a new master leader in the case of a network partition or a dead tserver by registering tablet servers present in Raft quorums if they don't register themselves. Also, mark replicas that are in `BOOTSTRAPPING`/`NOT_STARTED` state with its true consensus information instead of marking it as a `NON_PARTICIPANT`. [#4691](https://github.com/yugabyte/yugabyte-db/issues/4691)
-- Add YB-Master UI changes to support tablegroups and colocation. [#5086](https://github.com/yugabyte/yugabyte-db/issues/5086)
-  - Adds a column to the user and index tables to display the YSQL OID information about the colocation parent table (if any).
-  - For tablegroups, it displays the OID of the table's tablegroup (same as the OID present in `pg_tablegroup` as well as the `reltablegroup` column of `pg_class` for that relation).
-  - For colocated databases, it displays the OID of the database.
-  - Also, creates a table to display information about the parent tables. Wrap the names and uuid of the parent tables. Display YSQL OIDs as explained above.
-- Fix `MetaCache::TAbleData::stale` is not getting reset back to `false`. [#5245](https://github.com/yugabyte/yugabyte-db/issues/5245)
-- Do not crash yb-tserver when the `op_id` of the last WAL file is less than the committed `op_id`. [#1560](https://github.com/yugabyte/yugabyte-db/issues/1560)
-- Add `CREATE TABLEGROUP` and `DROP TABLEGROUP` flow. [#4525](https://github.com/yugabyte/yugabyte-db/issues/4525)
-- Add [`yb-admin list_snapshots`](../../admin/yb-admin/#list_snapshots) `SHOW_DELETED` flag to show deleted snapshots that are still retained in memory. [#5332](https://github.com/yugabyte/yugabyte-db/issues/5332)
-- Move read path functions to a separate file. [#4944](https://github.com/yugabyte/yugabyte-db/issues/4944)
-- Wait for `yb_client_admin_operation_timeout_sec` for table creation in `yb-admin import_snapshot` task. [#5295](https://github.com/yugabyte/yugabyte-db/issues/5295)
-- Create a cache for system-wide queries. [#5043](https://github.com/yugabyte/yugabyte-db/issues/5043)
-- Annotate access to `enable_collect_cdc_metrics` flag and prevent TSAN warnings. [#5303](https://github.com/yugabyte/yugabyte-db/issues/5303)
-- Raise yb-master and yb-tserver process ulimits to hard limits when appropriate. [#4943](https://github.com/yugabyte/yugabyte-db/issues/4943)
-- Add a pre-flush step, triggered by yb-master, to snapshot operations to minimize the amount of data being flushed in sync. [#4718](https://github.com/yugabyte/yugabyte-db/issues/4718)
-- Use Strand to remove intents and avoid wasting threads. [#5265](https://github.com/yugabyte/yugabyte-db/issues/5265)
-- Add metric severity level [PORT] and sever-side level-based filtering for metrics and prometheus-metrics. [#4686](https://github.com/yugabyte/yugabyte-db/issues/5265)
-- Decrease logging frequency for no local transaction status tablet from on every warning to once per second. [#5035](https://github.com/yugabyte/yugabyte-db/issues/5035)
-- Fix MonoTime subtraction implementation to return `result` of the operation instead of `lhs`. [#5020](https://github.com/yugabyte/yugabyte-db/issues/5020)
-- When dropping tables, delete snapshot directories for deleted tables. [#4756](https://github.com/yugabyte/yugabyte-db/issues/4756)
-- Set up a global leader balance threshold while allowing progress across tables. Add [`load_balancer_max_concurrent_moves_per_table`](../../reference/configuration/yb-master/#load-balancer-max-concurrent-moves-per-table) and [`load_balancer_max_concurrent_moves`](../../reference/configuration/yb-master/#load-balancer-max-concurrent-moves) to improve performance of leader moves. And properly update state for leader stepdowns to prevent check failures. [#5021](https://github.com/yugabyte/yugabyte-db/issues/5021) [#5181](https://github.com/yugabyte/yugabyte-db/issues/5181)
-- Reduce default value of [`load_balancer_max_concurrent_moves`](../../reference/configuration/yb-master/#load-balancer-max-concurrent-moves) from `10` to `2`. [#5461](https://github.com/yugabyte/yugabyte-db/issues/5461)
-- Improve bootstrap logic for resolving transaction statuses. [#5215](https://github.com/yugabyte/yugabyte-db/issues/5215)
-- Avoid duplicate DNS lookup requests while handling `system.partitions` table requests. [#5225](https://github.com/yugabyte/yugabyte-db/issues/5225)
-- Handle write operation failures during tablet bootstrap. [#5224](https://github.com/yugabyte/yugabyte-db/issues/5224)
-- Ensure `strict_capacity_limit` is set when SetCapacity is called to prevent ASAN failures. [#5222](https://github.com/yugabyte/yugabyte-db/issues/5222)
-- Drop index upon failed backfill. For YCQL, generate error to CREATE INDEX call if index backfill fails before the call is completed. [#5144](https://github.com/yugabyte/yugabyte-db/issues/5144) [#5161](https://github.com/yugabyte/yugabyte-db/issues/5161)
-- Allow overflow of single-touch cache if multi-touch cache is not consuming space. [#4495](https://github.com/yugabyte/yugabyte-db/issues/4495)
-- Don't flush RocksDB before restoration. [#5184](https://github.com/yugabyte/yugabyte-db/issues/5184)
-- Fix `yugabyted` fails to start UI due to class binding failure. [#5069](https://github.com/yugabyte/yugabyte-db/issues/5069)
-- On `yb-tserver` restart, prioritize bootstrapping transaction status tablets. [#4926](https://github.com/yugabyte/yugabyte-db/issues/4926)
-- For `yb-admin` commands, clarify syntax for namespace. [#5482](https://github.com/yugabyte/yugabyte-db/issues/5482)
-- Improve for-loops to avoid unnecessary copies and remove range-loop-analysis warnings. [#5458](https://github.com/yugabyte/yugabyte-db/issues/5458)
-- Apply large transaction in a separate thread if the transaction will not fit into the limit of key-value pairs. The running transaction is removed from memory after all its intents are applied and removed. [#1923](https://github.com/yugabyte/yugabyte-db/issues/1923)
-- Fix `SEGV` in Master UI when registering YB-TServer from Raft. [#5501](https://github.com/yugabyte/yugabyte-db/issues/5501)
-- Heartbeats process only new consensus information unless `master_ignore_stale_cstate` flag is disabled. [#5301](https://github.com/yugabyte/yugabyte-db/issues/5301)
-- Remove KernelStackWatchdog and use LongOperationTracker to waste less resources per thread. [#5226](https://github.com/yugabyte/yugabyte-db/issues/5226)
-- Change the default value of `metric_node_name` flag from `DEFAULT_NODE_NAME` to `hostname:port`. [#4859](https://github.com/yugabyte/yugabyte-db/issues/4859)
-
-#### Yugabyte Platform
-
-- For S3 backups, install `s3cmd` required for encrypted backup and restore flows. [#5593](https://github.com/yugabyte/yugabyte-db/issues/5593)
-- When creating on-premises provider, remove `YB_HOME_DIR` if not set. [#5592](https://github.com/yugabyte/yugabyte-db/issues/5592)
-- Update to use templatized values for setting TLS flags in Helm Charts. [#5424](https://github.com/yugabyte/yugabyte-db/issues/5424)
-- For YCQL client connectivity, allow downloading root certificate and key from **Certificates** menu. [#4957](https://github.com/yugabyte/yugabyte-db/issues/4957)
-- Bypass CSRF checks when registering and logging in due to bug with CSRF token not being set. [#5533](https://github.com/yugabyte/yugabyte-db/issues/5533)
-- Set node certificate field to subject of CA instead of issuer of CA. [#5377](https://github.com/yugabyte/yugabyte-db/issues/5377)
-- Add option in universe creation form to control whether node_exporter is installed on provisioned nodes (including creating prometheus user + group). [#5421](https://github.com/yugabyte/yugabyte-db/issues/5421)
-- Add Microsoft Azure provider UI and related changes to **Create Universe** form. [#5378](https://github.com/yugabyte/yugabyte-db/issues/5378)
-- Create default network resources for multi-region deployments in Microsoft Azure if they don't exist and store for use during universe creation. [#5388](https://github.com/yugabyte/yugabyte-db/issues/5388)
-- For Microsoft Azure, use preexisting network resources. [#5389](https://github.com/yugabyte/yugabyte-db/issues/5389)
-- Set **Assign Public IP** correctly using the UI. [#5463](https://github.com/yugabyte/yugabyte-db/issues/5463)
-- Fix `AreLeadersOnPreferredOnly` times out when setting preferred zones in **Edit Universe**. [#5406](https://github.com/yugabyte/yugabyte-db/issues/5406)
-- Fix `yb_backup.py` script to remove `sudo` requirement and correctly change user. [#5440](https://github.com/yugabyte/yugabyte-db/issues/5440)
-- Add CSRF tokens to forms. [#5419](https://github.com/yugabyte/yugabyte-db/issues/5419)
-- Allow configuration of OIDC scope (for SSO use) as well as email attribute field. [#5465](https://github.com/yugabyte/yugabyte-db/issues/5465)
-- If **Username** and **Password** are left empty in the **Custom SMTP Configuration**, remove `smtpUsername` and `smtpPassword` from the payload. [#5439](https://github.com/yugabyte/yugabyte-db/issues/5439)
-- Add the **UTC** label to indicate `cron` expression must be relative to UTC. Also, add help text indicating when next scheduled job will run. [#4709](https://github.com/yugabyte/yugabyte-db/issues/4709)
-- Move the source of truth for communication ports to the universe level. [#5353](https://github.com/yugabyte/yugabyte-db/issues/5353)
-- Use appropriate range for time period (over entire step window rather than last minute) when querying Prometheus for metrics. [#4203](https://github.com/yugabyte/yugabyte-db/issues/4203)
-- Support backing up encrypted at rest universes. [#3118](https://github.com/yugabyte/yugabyte-db/issues/3118)
-- Only display "Rolling Upgrade Delay" if upgrade type is "Rolling". [#5362](https://github.com/yugabyte/yugabyte-db/issues/5362)
-- Add guarding against never-ending loop when running the `yb_backup.py` script and yb-server doesn't have any data directories. [#5358](https://github.com/yugabyte/yugabyte-db/issues/5358)
-- Fix metric panel displaying incorrect time interval when reloading after changing graph filter. [#5294](https://github.com/yugabyte/yugabyte-db/issues/5294)
-- Fix logging on health check script failure. [#5340](https://github.com/yugabyte/yugabyte-db/issues/5294)
-- Rename the label for enabling server-side encryption in S3 backups to **Encrypt Backup** for both backups and scheduled backup modals. [#5273](https://github.com/yugabyte/yugabyte-db/issues/5273)
-- Add a VM backup script that includes Prometheus backups. [#5120](https://github.com/yugabyte/yugabyte-db/issues/5120)
-- Add `BackupAdmin` role to authorize users to create backup and restore tasks on universes, but not given other administration privileges. [#4694](https://github.com/yugabyte/yugabyte-db/issues/4694)
-- Modify the `yb_backup.py` script to add "round-robin" behavior to thread allocations to better spread loads across nodes in parallel during snapshot upload or download. [#4987](https://github.com/yugabyte/yugabyte-db/issues/4987)
-- Fix the invalid `yb_backup.py` script behavior if `--keyspace` flag is not specified. [#5199](https://github.com/yugabyte/yugabyte-db/issues/5199)
-- Add subtasks to check number of pods deployed during upgrades. [#5174](https://github.com/yugabyte/yugabyte-db/issues/5174)
-- Make use of parallelism argument for `yb_backup.py` script. Explicitly pass the number of threads to concurrently run backup script through UI. The form defaults to the backup script default value of 8 threads if no value is provided. [#5283](https://github.com/yugabyte/yugabyte-db/issues/5283)
-- The **Remove Node** action should be available if the **Add Node** action fails. [#5123](https://github.com/yugabyte/yugabyte-db/issues/5123)
-- Add ability for user to specify the S3 backup target host that their bucket is located on. [#3684](https://github.com/yugabyte/yugabyte-db/issues/3684)
-- Check if on-premise node instance has a universe that is using it and make a link to the Universe Overview page. [#4758](https://github.com/yugabyte/yugabyte-db/issues/4758)
-- Fix `Cannot read property 'displayName' of undefined` error. [#5267](https://github.com/yugabyte/yugabyte-db/issues/5267)
-- **Use Host Names** setting is not displaying correctly in **Provider Configuration** page. [#5252](https://github.com/yugabyte/yugabyte-db/issues/5252)
-- Disable glob before running the cleanup of old log files. [#5169](https://github.com/yugabyte/yugabyte-db/issues/5169)
-- Schedule job for `setUniverseKey` should handle errors on per-customer basis. [#3142](https://github.com/yugabyte/yugabyte-db/issues/3142)
-- After Yugabyte Platform (Yugaware) restart, any in-progress tasks should be cancelled and marked as failed. [#5045](https://github.com/yugabyte/yugabyte-db/issues/5045)
-- Redirect from login back to index if session is already validated. Logout should redirect to login endpoint. [#5019](https://github.com/yugabyte/yugabyte-db/issues/5019)
-- Fix updating of **Universes** list after creating new universe. [#4784](https://github.com/yugabyte/yugabyte-db/issues/4784)
-- Fix restore payload when renaming table to include keyspace. And check for keyspace if tableName is defined and return invalid request code when keyspace is missing. [#5178](https://github.com/yugabyte/yugabyte-db/issues/5178)
-- Add the ability to override communication port default values during universe creation. [#5354](https://github.com/yugabyte/yugabyte-db/issues/5354)
-
-{{< note title="Note" >}}
-
-Prior to version 2.0, YSQL was still in beta. As a result, the 2.0 release included a backward-incompatible file format change for YSQL. If you have an existing cluster running releases earlier than 2.0 with YSQL enabled, then you will not be able to upgrade to version 2.0+. Export from your existing cluster and then import into a new cluster (v2.0 or later) to use existing data.
-
-{{< /note >}}
+</div>

--- a/docs/content/latest/releases/whats-new/latest-releases.md
+++ b/docs/content/latest/releases/whats-new/latest-releases.md
@@ -10,7 +10,8 @@ aliases:
 section: RELEASES
 menu:
   latest:
-    identifier: whats-new
+    parent: whats-new
+    identifier: latest-release
     weight: 2585 
 ---
 
@@ -28,9 +29,9 @@ Starting with v2.2.0, Yugabyte release versions are numbered based on an a new r
 
 {{< /note >}}  
 
-## v2.3.1.0 [2020-09-15]
+## v2.3.1.0 [September 15, 2020]
 
-**Released:** September 15, 2020 (2.3.1.0-b15).
+### **Build:** 2.3.1.0-b15
 
 ### Downloads
 
@@ -80,9 +81,9 @@ Prior to version 2.0, YSQL was still in beta. As a result, the 2.0 release inclu
 
 {{< /note >}}
 
-## v2.3.0.0 [2020-09-08]
+## v2.3.0.0 [September 8, 2020]
 
-**Released:** September 8, 2020 (2.3.0.0-b176).
+### **Build:** 2.3.0.0-b176
 
 ### Downloads
 

--- a/docs/content/latest/releases/whats-new/latest-releases.md
+++ b/docs/content/latest/releases/whats-new/latest-releases.md
@@ -31,6 +31,87 @@ Prior to version 2.0, YSQL was still in beta. Upon release of 2.0, a backward-in
 
 {{< /note >}}
 
+## Notable features and changes
+
+Content will be added as new notable features and changes are added during the latest release series. 
+
+### YSQL
+
+#### Support for large transaction batches and better batch loading [#5241](https://github.com/yugabyte/yugabyte-db/issues/5241)
+
+- Load data from a large file to a table using the improved `COPY <table> FROM <file>` statement. For details, see [`COPY`](../../../api/ysql/#). Improved memory management should prevent out-of-memory (OOM) issues.
+
+- Optionally, you can specify smaller transaction sizes using the `COPY OPTION` `ROWS_PER_TRANSACTION`. For an example, see [Import a large table using smaller transactions](../../../api/ysql/commands/cmd_copy/#import-a-large-table-using-smaller-transactions)
+
+#### Backfilling of secondary indexes [#448](https://github.com/yugabyte/yugabyte-db/issues/448)
+
+- When a secondary index is created on a preexisting table with some data, support the backfilling the index for the existing data in the table.
+- Supported for backfilling non-unique indexes, including expression and partial indexes. [#2301](https://github.com/yugabyte/yugabyte-db/issues/2301)
+- Ability to view background index backfill tasks. [#3668](https://github.com/yugabyte/yugabyte-db/issues/3668)
+- Expose backfill metrics (writes/sec being performed on index table, rows/sec being processed from primary table, size of index table, etc.)
+- Ability to throttle the rate of backfill.
+- Design document: [Online index backfill](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/online-index-backfill.md)
+
+#### Geo-partitioned tables [#1958](https://github.com/yugabyte/yugabyte-db/issues/1958)
+
+##### Phase 1 - Table partitions (completed) [#3619](https://github.com/yugabyte/yugabyte-db/pull/3619)
+
+Design doc: [YSQL Table Partitioning](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/ysql-row-level-partitioning.md)
+
+[x] Support creating LIST partitions and basic operations (INSERT, UPDATE, SELECT, DELETE)
+
+[x] Support `RANGE` and `HASH` partitions (note these are different from range and hash shards)
+
+[x] Other operations and options on partitions (attach and detach partitions, sub-partitions)
+
+##### Phase 2 - Geo-partitioning support
+
+[ ] Ability to override placement policy at per-partition (per-table) level in DocDB.
+
+[ ] YSQL syntax to query and specify placement information for a table.
+
+[ ] Support colocation of geo-partitioned tables.
+
+#### LDAP integration [#2393](https://github.com/yugabyte/yugabyte-db/issues/2393)
+
+- Goal: Support LDAP authorization and authentication.
+- Not tested, but should be enabled already. [#2393#issuecomment-535057031](https://github.com/yugabyte/yugabyte-db/issues/2393#issuecomment-535057031)
+
+#### Support for json_path_query [#5408](https://github.com/yugabyte/yugabyte-db/issues/5408)
+
+Goal: Simplify complex JSON queries.
+
+#### Enable pg_stat_statements by default [#5478](https://github.com/yugabyte/yugabyte-db/issues/5478)
+
+- Execution statistics of all SQL statements executed by a server can be tracked. Statistics gathered by the module are made available in a system view, named `pg_stat_statements`. This view contains one row for each distinct database ID, user ID, and query ID (up to the maximum number of distinct statements that the module can track).
+
+
+### YCQL
+
+#### Backfilling of secondary indexes [#448](https://github.com/yugabyte/yugabyte-db/issues/448)
+
+- When a secondary index is created on a preexisting table with some data, support the backfilling the index for the existing data in the table.
+- Supported for both unique and non-unique indexes.
+- Ability to view background index backfill tasks. [#3668](https://github.com/yugabyte/yugabyte-db/issues/3668)
+- Expose backfill metrics (writes/sec being performed on index table, rows/sec being processed from primary table, size of index table, etc.)
+- Ability to throttle the rate of backfill.
+- Design document: [Online index backfill](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/online-index-backfill.md)
+
+### Core database
+
+### Yugabyte Platform
+
+#### Add Microsoft Azure integration [#5281](https://github.com/yugabyte/yugabyte-db/issues/5281)
+
+Goal: Fully support Microsoft Azure as a first class cloud provider in Yugabyte Platform.
+
+- Use existing network resources [#5389]
+- Create default network resources [#5388]
+- Add UI for Azure provider [#5378]
+
+#### LDAP integration [#4421](https://github.com/yugabyte/yugabyte-db/issues/4421)
+
+
 
 ## Release notes
 
@@ -55,7 +136,7 @@ Prior to version 2.0, YSQL was still in beta. Upon release of 2.0, a backward-in
 
 #### Core database
 
-- Quickly evict known unresponsive tablet servers from the tablet location cache. Applies only to follower reads. For example, when tablet servers are not replying to RPC calls or dead — not sending heartbeats to the master for 5 minutes. This could also happen after decommissioning nodes. [#1052](https://github.com/yugabyte/yugabyte-db/issues/1052)
+- Quickly evict known unresponsive tablet servers from the tablet location cache. Applies only to follower reads. For example, when tablet servers are nonresponsive or dead — not sending heartbeats to the master for 5 minutes. This could also happen after decommissioning nodes. [#1052](https://github.com/yugabyte/yugabyte-db/issues/1052)
 
 #### Yugabyte Platform
 
@@ -69,9 +150,16 @@ Prior to version 2.0, YSQL was still in beta. Upon release of 2.0, a backward-in
 
 #### Downloads (binaries)
 
+##### Precompiled 64-bit binaries
+
 - [macOS](https://downloads.yugabyte.com/yugabyte-2.3.0.0-darwin.tar.gz)
 - [Linux](https://downloads.yugabyte.com/yugabyte-2.3.0.0-linux.tar.gz)
 - Docker: `docker pull yugabytedb/yugabyte:2.3.0.0-b176`
+
+##### Source code
+
+- [Source code (zip)](https://github.com/yugabyte/yugabyte-db/archive/v2.3.1.0.zip)
+- [Source code (tar.gz)](https://github.com/yugabyte/yugabyte-db/archive/v2.3.1.0.tar.gz)
 
 #### Features and changes
 
@@ -218,4 +306,3 @@ Prior to version 2.0, YSQL was still in beta. Upon release of 2.0, a backward-in
 - Fix updating of **Universes** list after creating new universe. [#4784](https://github.com/yugabyte/yugabyte-db/issues/4784)
 - Fix restore payload when renaming table to include keyspace. And check for keyspace if tableName is defined and return invalid request code when keyspace is missing. [#5178](https://github.com/yugabyte/yugabyte-db/issues/5178)
 - Add the ability to override communication port default values during universe creation. [#5354](https://github.com/yugabyte/yugabyte-db/issues/5354)
-

--- a/docs/content/latest/releases/whats-new/latest-releases.md
+++ b/docs/content/latest/releases/whats-new/latest-releases.md
@@ -33,85 +33,21 @@ Prior to version 2.0, YSQL was still in beta. Upon release of 2.0, a backward-in
 
 ## Notable features and changes
 
-Content will be added as new notable features and changes are added during the latest release series. 
+Note: Content will be added as new notable features and changes are available in the patch releases of the latest release series.
 
 ### YSQL
 
-#### Support for large transaction batches and better batch loading [#5241](https://github.com/yugabyte/yugabyte-db/issues/5241)
-
 - Load data from a large file to a table using the improved `COPY <table> FROM <file>` statement. For details, see [`COPY`](../../../api/ysql/#). Improved memory management should prevent out-of-memory (OOM) issues.
 
-- Optionally, you can specify smaller transaction sizes using the `COPY OPTION` `ROWS_PER_TRANSACTION`. For an example, see [Import a large table using smaller transactions](../../../api/ysql/commands/cmd_copy/#import-a-large-table-using-smaller-transactions)
-
-#### Backfilling of secondary indexes [#448](https://github.com/yugabyte/yugabyte-db/issues/448)
-
-- When a secondary index is created on a preexisting table with some data, support the backfilling the index for the existing data in the table.
-- Supported for backfilling non-unique indexes, including expression and partial indexes. [#2301](https://github.com/yugabyte/yugabyte-db/issues/2301)
-- Ability to view background index backfill tasks. [#3668](https://github.com/yugabyte/yugabyte-db/issues/3668)
-- Expose backfill metrics (writes/sec being performed on index table, rows/sec being processed from primary table, size of index table, etc.)
-- Ability to throttle the rate of backfill.
-- Design document: [Online index backfill](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/online-index-backfill.md)
-
-#### Geo-partitioned tables [#1958](https://github.com/yugabyte/yugabyte-db/issues/1958)
-
-##### Phase 1 - Table partitions (completed) [#3619](https://github.com/yugabyte/yugabyte-db/pull/3619)
-
-Design doc: [YSQL Table Partitioning](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/ysql-row-level-partitioning.md)
-
-[x] Support creating LIST partitions and basic operations (INSERT, UPDATE, SELECT, DELETE)
-
-[x] Support `RANGE` and `HASH` partitions (note these are different from range and hash shards)
-
-[x] Other operations and options on partitions (attach and detach partitions, sub-partitions)
-
-##### Phase 2 - Geo-partitioning support
-
-[ ] Ability to override placement policy at per-partition (per-table) level in DocDB.
-
-[ ] YSQL syntax to query and specify placement information for a table.
-
-[ ] Support colocation of geo-partitioned tables.
-
-#### LDAP integration [#2393](https://github.com/yugabyte/yugabyte-db/issues/2393)
-
-- Goal: Support LDAP authorization and authentication.
-- Not tested, but should be enabled already. [#2393#issuecomment-535057031](https://github.com/yugabyte/yugabyte-db/issues/2393#issuecomment-535057031)
-
-#### Support for json_path_query [#5408](https://github.com/yugabyte/yugabyte-db/issues/5408)
-
-Goal: Simplify complex JSON queries.
-
-#### Enable pg_stat_statements by default [#5478](https://github.com/yugabyte/yugabyte-db/issues/5478)
-
-- Execution statistics of all SQL statements executed by a server can be tracked. Statistics gathered by the module are made available in a system view, named `pg_stat_statements`. This view contains one row for each distinct database ID, user ID, and query ID (up to the maximum number of distinct statements that the module can track).
-
-
-### YCQL
-
-#### Backfilling of secondary indexes [#448](https://github.com/yugabyte/yugabyte-db/issues/448)
-
-- When a secondary index is created on a preexisting table with some data, support the backfilling the index for the existing data in the table.
-- Supported for both unique and non-unique indexes.
-- Ability to view background index backfill tasks. [#3668](https://github.com/yugabyte/yugabyte-db/issues/3668)
-- Expose backfill metrics (writes/sec being performed on index table, rows/sec being processed from primary table, size of index table, etc.)
-- Ability to throttle the rate of backfill.
-- Design document: [Online index backfill](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/online-index-backfill.md)
-
-### Core database
+- Specify smaller transaction sizes using the `COPY OPTION` `ROWS_PER_TRANSACTION`. For an example, see [Import a large table using smaller transactions](../../../api/ysql/commands/cmd_copy/#import-a-large-table-using-smaller-transactions)
 
 ### Yugabyte Platform
 
-#### Add Microsoft Azure integration [#5281](https://github.com/yugabyte/yugabyte-db/issues/5281)
-
-Goal: Fully support Microsoft Azure as a first class cloud provider in Yugabyte Platform.
+#### Add Microsoft Azure integration
 
 - Use existing network resources [#5389]
 - Create default network resources [#5388]
 - Add UI for Azure provider [#5378]
-
-#### LDAP integration [#4421](https://github.com/yugabyte/yugabyte-db/issues/4421)
-
-
 
 ## Release notes
 

--- a/docs/content/latest/releases/whats-new/latest-releases.md
+++ b/docs/content/latest/releases/whats-new/latest-releases.md
@@ -37,7 +37,7 @@ Note: Content will be added as new notable features and changes are available in
 
 ### YSQL
 
-- Load data from a large file to a table using the improved `COPY <table> FROM <file>` statement. For details, see [`COPY`](../../../api/ysql/#). Improved memory management should prevent out-of-memory (OOM) issues.
+- Load data from a large file to a table using the improved `COPY <table> FROM <file>` statement. For details, see [`COPY`](../../../api/ysql/commands/). Improved memory management should prevent out-of-memory (OOM) issues.
 
 - Specify smaller transaction sizes using the `COPY OPTION` `ROWS_PER_TRANSACTION`. For an example, see [Import a large table using smaller transactions](../../../api/ysql/commands/cmd_copy/#import-a-large-table-using-smaller-transactions)
 
@@ -102,7 +102,7 @@ Note: Content will be added as new notable features and changes are available in
 #### YSQL
 
 - Fix OOM when running large `COPY TO` statements by creating new memory context for the loop over retrieved rows and resetting it after processing each row. [#5205](https://github.com/yugabyte/yugabyte-db/issues/5205)
-- Support transactional batch size for [`COPY FROM` command](../../api/ysql/commands/cmd_copy) with OOM fix. Batch sizes can be passed in with `ROWS_PER_TRANSACTION` in the `COPY OPTION` syntax. For an example, see [Import a large table using smaller transactions](../../api/ysql/commands/cmd_copy/#import-a-large-table-using-smaller-transactions) [#2855](https://github.com/yugabyte/yugabyte-db/issues/2855) [#5453](https://github.com/yugabyte/yugabyte-db/issues/5453)
+- Support transactional batch size for [`COPY FROM` command](../../../api/ysql/commands/cmd_copy) with OOM fix. Batch sizes can be passed in with `ROWS_PER_TRANSACTION` in the `COPY OPTION` syntax. For an example, see [Import a large table using smaller transactions](../../../api/ysql/commands/cmd_copy/#import-a-large-table-using-smaller-transactions) [#2855](https://github.com/yugabyte/yugabyte-db/issues/2855) [#5453](https://github.com/yugabyte/yugabyte-db/issues/5453)
 - For index backfill flags, use better default values. Set `index_backfill_rpc_timeout_ms` default from `60000` to `30000` and change `backfill_index_timeout_grace_margin_ms` default from `50` to `500`. [#5494](https://github.com/yugabyte/yugabyte-db/issues/5494)
 - Remove spurious error message "0A000: Alter table is not yet supported" from `CREATE OR REPLACE VIEW`. [#5071](https://github.com/yugabyte/yugabyte-db/issues/5071)
 - Prevent consistency violations when a partitioned table has foreign key constraints due to erroneous classification as a single-row transaction. [#5387](https://github.com/yugabyte/yugabyte-db/issues/5387)
@@ -116,7 +116,7 @@ Note: Content will be added as new notable features and changes are available in
 - Add new `ysqlsh` describe metacommands for tablegroups: `\dgr[+] [grpname]` to describe tablegroups, `\dgrt[+] [grpname]` lists all tables/indexes within the specified tablegroup (or within all tablegroups if `grpname` is not specified), and `\d <table_name>` is modified to include tablegroup information in the footer, if any. [#5088](https://github.com/yugabyte/yugabyte-db/issues/3118)
 - Add `ALTER TABLEGROUP` statements to support `ALTER TABLEGROUP tablegroup_name RENAME TO ...` and `ALTER TABLEGROUP tablegroup_name OWNER TO ...`. Also changes `pg_tablegroup` entry corresponding to `tablegroup_name` to properly reflect new `grpname` and `grpowner` (if the user has proper permissions or ownership to issue the `ALTER TABLEGROUP` statement. [#5249](https://github.com/yugabyte/yugabyte-db/issues/5249)
 - Add support for indexes to opt out of tablegroups (`NO TABLEGROUPS`) or select their own tablegroup (`TABLEGROUP group_name`). [#5293](https://github.com/yugabyte/yugabyte-db/issues/5293)
-- For [`ysql_dump`](../../admin/ysql-dump), enable `serializable-deferrable` mode by default. Add new [`--no-serializable-deferrable`](../../admin/ysql-dump/#no-serializable-deferrable) flag to disable the default mode. [#5128](https://github.com/yugabyte/yugabyte-db/issues/5128)
+- For [`ysql_dump`](../../admin/ysql-dump), enable `serializable-deferrable` mode by default. Add new [`--no-serializable-deferrable`](../../../admin/ysql-dump/#no-serializable-deferrable) flag to disable the default mode. [#5128](https://github.com/yugabyte/yugabyte-db/issues/5128)
 - Support `ALTER COLUMN type` for variants that don't require on-disk changes. Specifically only allowing `ALTER COLUMN type` for `varch(n)` and `varbit(n)`. For example, changing column type from `varchar(50)` to `varchar(255)`. [#4424](https://github.com/yugabyte/yugabyte-db/issues/4424)
 - Enable `USING` clause in `DELETE` statement and `FROM` clause in `UPDATE` statement. [#738](https://github.com/yugabyte/yugabyte-db/issues/738) [#5262](https://github.com/yugabyte/yugabyte-db/issues/5262)
 - Support GRANT/REVOKE/ALTER DEFAULT PRIVILEGES for tablegroups. [#5087](https://github.com/yugabyte/yugabyte-db/issues/5087) [#5160](https://github.com/yugabyte/yugabyte-db/issues/5160)
@@ -135,7 +135,7 @@ Note: Content will be added as new notable features and changes are available in
 - Fix TSAN issue in partition-aware policy for C++ driver 2.9.0-yb-8 (yugabyte/cassandra-cpp-driver). [#1837](https://github.com/yugabyte/yugabyte-db/issues/1837)
 - Support YCQL backup for indexes based on JSON-attribute. [#5198](https://github.com/yugabyte/yugabyte-db/issues/5198)
 - Correctly set `release_version` for `system.peers` queries. [#5407](https://github.com/yugabyte/yugabyte-db/issues/5407)
-- Reject `TRUNCATE` operations when [`ycql_require_drop_privs_for_truncate`](../../reference/configuration/yb-tserver/#ycql-require-drop-privs-for-truncate) flag is enabled. When enabled, `DROP TABLE` permission is required to truncate a table. Default is `false`. [#5443](https://github.com/yugabyte/yugabyte-db/issues/5443)
+- Reject `TRUNCATE` operations when [`ycql_require_drop_privs_for_truncate`](../../../reference/configuration/yb-tserver/#ycql-require-drop-privs-for-truncate) flag is enabled. When enabled, `DROP TABLE` permission is required to truncate a table. Default is `false`. [#5443](https://github.com/yugabyte/yugabyte-db/issues/5443)
 - Fix missing return statement in error case of the `SetPagingState` method in `statement_params.cc`. [#5441](https://github.com/yugabyte/yugabyte-db/issues/5441)
 - Enable backfilling of transactional tables by default. [#4708](https://github.com/yugabyte/yugabyte-db/issues/4708)
 - Fix `ycqlsh` should return a failure when known that the create (unique) index has failed. [#5161](https://github.com/yugabyte/yugabyte-db/issues/5161)
@@ -166,7 +166,7 @@ Note: Content will be added as new notable features and changes are available in
 - Fix `MetaCache::TAbleData::stale` is not getting reset back to `false`. [#5245](https://github.com/yugabyte/yugabyte-db/issues/5245)
 - Do not crash yb-tserver when the `op_id` of the last WAL file is less than the committed `op_id`. [#1560](https://github.com/yugabyte/yugabyte-db/issues/1560)
 - Add `CREATE TABLEGROUP` and `DROP TABLEGROUP` flow. [#4525](https://github.com/yugabyte/yugabyte-db/issues/4525)
-- Add [`yb-admin list_snapshots`](../../admin/yb-admin/#list_snapshots) `SHOW_DELETED` flag to show deleted snapshots that are still retained in memory. [#5332](https://github.com/yugabyte/yugabyte-db/issues/5332)
+- Add [`yb-admin list_snapshots`](../../../admin/yb-admin/#list_snapshots) `SHOW_DELETED` flag to show deleted snapshots that are still retained in memory. [#5332](https://github.com/yugabyte/yugabyte-db/issues/5332)
 - Move read path functions to a separate file. [#4944](https://github.com/yugabyte/yugabyte-db/issues/4944)
 - Wait for `yb_client_admin_operation_timeout_sec` for table creation in `yb-admin import_snapshot` task. [#5295](https://github.com/yugabyte/yugabyte-db/issues/5295)
 - Create a cache for system-wide queries. [#5043](https://github.com/yugabyte/yugabyte-db/issues/5043)
@@ -179,7 +179,7 @@ Note: Content will be added as new notable features and changes are available in
 - Fix MonoTime subtraction implementation to return `result` of the operation instead of `lhs`. [#5020](https://github.com/yugabyte/yugabyte-db/issues/5020)
 - When dropping tables, delete snapshot directories for deleted tables. [#4756](https://github.com/yugabyte/yugabyte-db/issues/4756)
 - Set up a global leader balance threshold while allowing progress across tables. Add [`load_balancer_max_concurrent_moves_per_table`](../../reference/configuration/yb-master/#load-balancer-max-concurrent-moves-per-table) and [`load_balancer_max_concurrent_moves`](../../reference/configuration/yb-master/#load-balancer-max-concurrent-moves) to improve performance of leader moves. And properly update state for leader stepdowns to prevent check failures. [#5021](https://github.com/yugabyte/yugabyte-db/issues/5021) [#5181](https://github.com/yugabyte/yugabyte-db/issues/5181)
-- Reduce default value of [`load_balancer_max_concurrent_moves`](../../reference/configuration/yb-master/#load-balancer-max-concurrent-moves) from `10` to `2`. [#5461](https://github.com/yugabyte/yugabyte-db/issues/5461)
+- Reduce default value of [`load_balancer_max_concurrent_moves`](../../../reference/configuration/yb-master/#load-balancer-max-concurrent-moves) from `10` to `2`. [#5461](https://github.com/yugabyte/yugabyte-db/issues/5461)
 - Improve bootstrap logic for resolving transaction statuses. [#5215](https://github.com/yugabyte/yugabyte-db/issues/5215)
 - Avoid duplicate DNS lookup requests while handling `system.partitions` table requests. [#5225](https://github.com/yugabyte/yugabyte-db/issues/5225)
 - Handle write operation failures during tablet bootstrap. [#5224](https://github.com/yugabyte/yugabyte-db/issues/5224)

--- a/docs/content/latest/releases/whats-new/latest-releases.md
+++ b/docs/content/latest/releases/whats-new/latest-releases.md
@@ -1,7 +1,7 @@
 ---
-title: What's new in 2.3
-headerTitle: What's new in 2.3
-linkTitle: What's new in 2.3
+title: What's new in 2.3 (latest)
+headerTitle: What's new in the 2.3 latest release series
+linkTitle: 2.3 (latest)
 description: Enhancements, changes, and resolved issues in the latest release series.
 headcontent: Features, enhancements, and resolved issues in the latest release series.
 image: /images/section_icons/quick_start/install.png
@@ -12,53 +12,41 @@ menu:
   latest:
     parent: whats-new
     identifier: latest-release
-    weight: 2585 
+    weight: 2585
+isTocNested: true
+showAsideToc: true 
 ---
 
-Included here are the release notes for all releases in the `2.3` latest release series. The `2.3` latest release series include the following releases:
+Included here are the release notes for all releases in the `2.3` latest release series.
 
-- [v2.3.1.0 (Released Sep 15, 2020)](#v2-3-1-0-2020-09-15)
-- [v2.3.0.0 (Released Sep 08, 2020)](#v2-3-0-0-2020-09-08)
+{{< note title="New release versioning" >}}
 
-{{< note title="Important" >}}
+Starting with v2.2.0, Yugabyte release versions follow a [new release versioning convention](../../versioning). The latest release series, denoted by `MAJOR.ODD`, incrementally introduces new features and changes and is intended for development and testing only. Patch releases, denoted by `MAJOR.ODD.PATCH` versioning, can include new features and changes that might break backwards compatibility. For more information, see [Supported and planned releases](../../releases-overview).
 
-Starting with v2.2.0, Yugabyte release versions are numbered based on an a new release versioning convention. For more details, see the following:
+{{< /note >}}
 
-- [Release versioning](../../versioning) – Includes details on stable and latest versioning.
-- [Supported and planned releases](../../releases-overview) – Information on supported and latest releases.
+{{< note title="Upgrading from 1.3" >}}
 
-{{< /note >}}  
+Prior to version 2.0, YSQL was still in beta. Upon release of 2.0, a backward-incompatible file format change was made for YSQL. For existing clusters running pre-2.0 release with YSQL enabled, you cannot upgrade to version 2.0 or later. Instead, export your data from existing clusters and then import the data into a new cluster (v2.0 or later).
 
-## v2.3.1.0 [September 15, 2020]
+{{< /note >}}
 
-### **Build:** 2.3.1.0-b15
 
-### Downloads
+## Release notes
 
-#### Binaries
+### v2.3.1 – September 15, 2020
 
-<a class="download-binary-link" href="https://downloads.yugabyte.com/yugabyte-2.3.1.0-darwin.tar.gz">
-  <button>
-    <i class="fab fa-apple"></i><span class="download-text">macOS</span>
-  </button>
-</a>
-&nbsp; &nbsp; &nbsp;
-<a class="download-binary-link" href="https://downloads.yugabyte.com/yugabyte-2.3.1.0-linux.tar.gz">
-  <button>
-    <i class="fab fa-linux"></i><span class="download-text">Linux</span>
-  </button>
-</a>
-<br />
+**Build:** `2.3.1.0-b15`
 
-#### Docker
+#### Downloads (binaries)
 
-```sh
-docker pull yugabytedb/yugabyte:2.3.1.0-b15
-```
+- [macOS](https://downloads.yugabyte.com/yugabyte-2.3.1.0-darwin.tar.gz)
+- [Linux](https://downloads.yugabyte.com/yugabyte-2.3.1.0-linux.tar.gz)
+- Docker: `docker pull yugabytedb/yugabyte:2.3.1.0-b15`
 
-### Features and changes
+#### Features and changes
 
-#### YSQL
+##### YSQL
 
 - Fixes OOM when using `COPY <table> FROM <file>` to load data from a large file to a table. [#5453](https://github.com/yugabyte/yugabyte-db/issues/5453)
 - Enable 2DC replication bootstrap for YSQL tables. This allows the producer to know where to start replicating from. [#5601](https://github.com/yugabyte/yugabyte-db/issues/5601)
@@ -75,40 +63,17 @@ docker pull yugabytedb/yugabyte:2.3.1.0-b15
 - Add the ability to change the user role (`Admin`, `ReadOnly`, or `BackupAdmin`) from the UI by an admin. Also, fix stale users list after creation or deletion of a user and disable **Save** buttons at Customer Profile tabs for `ReadOnly` users. [#5311](https://github.com/yugabyte/yugabyte-db/issues/5311)
 - Before deleting a universe, stop the master/tserver processes and release the instance so that if started again, the processes are not still running. [#4953](https://github.com/yugabyte/yugabyte-db/issues/4953)
 
-{{< note title="Note" >}}
+### v2.3.0 – September 8, 2020
 
-Prior to version 2.0, YSQL was still in beta. As a result, the 2.0 release included a backward-incompatible file format change for YSQL. If you have an existing cluster running releases earlier than 2.0 with YSQL enabled, then you will not be able to upgrade to version 2.0+. Export from your existing cluster and then import into a new cluster (v2.0 or later) to use existing data.
+**Build:** `2.3.0.0-b176`
 
-{{< /note >}}
+#### Downloads (binaries)
 
-## v2.3.0.0 [September 8, 2020]
+- [macOS](https://downloads.yugabyte.com/yugabyte-2.3.0.0-darwin.tar.gz)
+- [Linux](https://downloads.yugabyte.com/yugabyte-2.3.0.0-linux.tar.gz)
+- Docker: `docker pull yugabytedb/yugabyte:2.3.0.0-b176`
 
-### **Build:** 2.3.0.0-b176
-
-### Downloads
-
-#### Binaries
-
-<a class="download-binary-link" href="https://downloads.yugabyte.com/yugabyte-2.3.0.0-darwin.tar.gz">
-  <button>
-    <i class="fab fa-apple"></i><span class="download-text">macOS</span>
-  </button>
-</a>
-&nbsp; &nbsp; &nbsp;
-<a class="download-binary-link" href="https://downloads.yugabyte.com/yugabyte-2.3.0.0-linux.tar.gz">
-  <button>
-    <i class="fab fa-linux"></i><span class="download-text">Linux</span>
-  </button>
-</a>
-<br />
-
-#### Docker
-
-```sh
-docker pull yugabytedb/yugabyte:2.3.0.0-b176
-```
-
-### Features and changes
+#### Features and changes
 
 #### YSQL
 
@@ -254,8 +219,3 @@ docker pull yugabytedb/yugabyte:2.3.0.0-b176
 - Fix restore payload when renaming table to include keyspace. And check for keyspace if tableName is defined and return invalid request code when keyspace is missing. [#5178](https://github.com/yugabyte/yugabyte-db/issues/5178)
 - Add the ability to override communication port default values during universe creation. [#5354](https://github.com/yugabyte/yugabyte-db/issues/5354)
 
-{{< note title="Note" >}}
-
-Prior to version 2.0, YSQL was still in beta. As a result, the 2.0 release included a backward-incompatible file format change for YSQL. If you have an existing cluster running releases earlier than 2.0 with YSQL enabled, then you will not be able to upgrade to version 2.0+. Export from your existing cluster and then import into a new cluster (v2.0 or later) to use existing data.
-
-{{< /note >}}

--- a/docs/content/latest/releases/whats-new/stable-releases.md
+++ b/docs/content/latest/releases/whats-new/stable-releases.md
@@ -1,0 +1,476 @@
+---
+title: What's new in 2.2
+headerTitle: What's new in 2.2
+linkTitle: What's new in 2.2
+description: Enhancements, changes, and resolved issues in the recommended stable release series.
+headcontent: Features, enhancements, and resolved issues in the recommended stable release series.
+image: /images/section_icons/quick_start/install.png
+aliases:
+  - /latest/releases/
+section: RELEASES
+menu:
+  latest:
+    parent: whats-new
+    identifier: stable-releases
+    weight: 2585 
+---
+
+Included here are the release notes for all releases in the `2.3` latest release series. The `2.3` latest release series include the following releases:
+
+- [v2.2.2.0 (Released Sep 15, 2020)](#v2-3-1-0-2020-09-15)
+- [v2.2.0.0 (Released Sep 08, 2020)](#v2-3-0-0-2020-09-08)
+
+{{< note title="Important" >}}
+
+Starting with v2.2.0, Yugabyte release versions are numbered based on an a new release versioning convention. For more details, see the following:
+
+- [Release versioning](../../versioning) – Includes details on stable and latest versioning.
+- [Supported and planned releases](../../releases-overview) – Information on supported and latest releases.
+
+{{< /note >}}
+
+---
+
+## v2.2.2 [August 19, 2020]
+
+### Build: 2.2.2.0-b15
+
+{{< note title="Important" >}}
+
+Starting with v2.2.0, Yugabyte release versions are numbered based on an even/odd release versioning. For more details, see the following:
+
+- [Release versioning](../../versioning) – Includes details on stable and latest versioning.
+- [Supported and planned releases](../../releases-overview) – Information on supported and latest releases.
+
+{{< /note >}}  
+
+### Downloads
+
+#### Binaries
+
+<a class="download-binary-link" href="https://downloads.yugabyte.com/yugabyte-2.2.2.0-darwin.tar.gz">
+  <button>
+    <i class="fab fa-apple"></i><span class="download-text">macOS</span>
+  </button>
+</a>
+&nbsp; &nbsp; &nbsp;
+<a class="download-binary-link" href="https://downloads.yugabyte.com/yugabyte-2.2.2.0-linux.tar.gz">
+  <button>
+    <i class="fab fa-linux"></i><span class="download-text">Linux</span>
+  </button>
+</a>
+<br />
+
+#### Docker
+
+```sh
+docker pull yugabytedb/yugabyte:2.2.2.0-b15
+```
+
+### YSQL
+
+- Fix failed backup if restored table was deleted before restoration. [#5274](https://github.com/yugabyte/yugabyte-db/issues/5274)
+- Newly elected YB-Master leader should pause before initiating load balancing. [#5221](https://github.com/yugabyte/yugabyte-db/issues/5221)
+- Fix backfilling to better handle large indexed table tablets. [#5031](https://github.com/yugabyte/yugabyte-db/issues/5031)
+- Fix `DROP DATABASE` statement should work with databases deleted on YB-Master. [#4710](https://github.com/yugabyte/yugabyte-db/issues/4710)
+- For non-prepared statements, optimize `pg_statistic` system table lookups. [#5051](https://github.com/yugabyte/yugabyte-db/issues/5051)
+- [CDC] Avoid periodic querying of the `cdc_state` table for xDC metrics if there are no replication streams enabled. [#5173](https://github.com/yugabyte/yugabyte-db/issues/5173)
+
+### YCQL
+
+- Implement DNS cache to significantly reduce CPU loads due to a large number of DNS resolution requests (especially for YCQL connections). Adds [`dns_cache_expiration_ms`](../../reference/configuration/yb-master/#dns-cache-expiration-ms) flag (default is 1 minute). [#5201](https://github.com/yugabyte/yugabyte-db/issues/5201)
+- Fixed incorrect names de-mangling in index creation from `CatalogManager::ImportSnapshot()`. [#5157](https://github.com/yugabyte/yugabyte-db/issues/5157)
+- Fixed crashes when inserting literals containing newline characters. [#5270](https://github.com/yugabyte/yugabyte-db/issues/5270)
+- Reuse CQL parser between processors to improve memory usage. Add new `cql_processors_limit` flag to control processor allocation. [#5057](https://github.com/yugabyte/yugabyte-db/issues/5057)
+
+### Core database
+
+- Fix `yugabyted` fails to start UI due to class binding failure. [#5069](https://github.com/yugabyte/yugabyte-db/issues/5069)
+- Show hostnames in YB-Master and YB-TServer Admin UI when hostnames are specified in `--webserver_interface`, `rpc_bind_addresses`, and `server_broadcast_addresses` flags. [#5002](https://github.com/yugabyte/yugabyte-db/issues/5002)
+- Skip tablets without intents during commits, for example, the case of an update of a non-existing row. [#5321](https://github.com/yugabyte/yugabyte-db/issues/5321)
+- Fix log spew when applying unknown transaction and release a mutex as soon as possible when transaction is not found. [#5315](https://github.com/yugabyte/yugabyte-db/issues/5315)
+- Fix snapshots cleanup when snapshots removed before restart. [#5337](https://github.com/yugabyte/yugabyte-db/issues/5337)
+- Replace `SCHECK` with `LOG(DFATAL)` when checking for restart-safe timestamps in WAL entries. [#5314](https://github.com/yugabyte/yugabyte-db/issues/5314)
+- Replace all CHECK in the load balancer code with `SCHECK` or `RETURN_NOT_OK`. [#5182](https://github.com/yugabyte/yugabyte-db/issues/5182)
+- Implement DNS cache to significantly reduce CPU loads due to a large number of DNS resolution requests (especially for YCQL connections). Adds YB-Master [`dns_cache_expiration_ms`](../../reference/configuration/yb-master/#dns-cache-expiration-ms) flag (default is 1 minute). [#5201](https://github.com/yugabyte/yugabyte-db/issues/5201)
+- Avoid duplicate DNS requests when handling `system.partitions` table requests. [#5225](https://github.com/yugabyte/yugabyte-db/issues/5225)
+- Fix leader load balancing can cause `CHECK` failures if stepdown task is pending on next run. Sets global leader balance threshold while allowing progress to be made across tables. Adds new YB-Master [`load_balancer_max_concurrent_moves_per_table`](../../reference/configuration/yb-master/#load-balancer-max-concurrent-moves-per-table) flag to limit number of leader moves per table. [#5181](https://github.com/yugabyte/yugabyte-db/issues/5181) and [#5021](https://github.com/yugabyte/yugabyte-db/issues/5021)
+- Set the async `YBClient` initialization future in `TabletPeer` constructor to ensure tablet bootstrap logic can resolve transaction statuses. [#5215](https://github.com/yugabyte/yugabyte-db/issues/5215)
+- Handle write operation failures during tablet bootstrap. [#5224](https://github.com/yugabyte/yugabyte-db/issues/5224)
+- Drop index upon failed backfill. [#5144](https://github.com/yugabyte/yugabyte-db/issues/5144)  [#5161](https://github.com/yugabyte/yugabyte-db/issues/5161)
+- Fix WAL overwriting by new leader and replay of incorrect entries on tablet bootstrap. [#5003](https://github.com/yugabyte/yugabyte-db/issues/5003) [#3759](https://github.com/yugabyte/yugabyte-db/issues/3759) [#4983](https://github.com/yugabyte/yugabyte-db/issues/4983)
+- Avoid taking unique lock when starting lookup request. [#5059](https://github.com/yugabyte/yugabyte-db/issues/5059)
+- Set 2DC lag metrics to `0` if not the leader and if the replication is deleted. [#5113](https://github.com/yugabyte/yugabyte-db/issues/5113)
+- Set the table to ALTERING state when `fully_*` is populated. [#5139](https://github.com/yugabyte/yugabyte-db/issues/5139)
+- `Not the leader` errors should not cause a replica to be marked as failed. [#5072](https://github.com/yugabyte/yugabyte-db/issues/5072)
+- Use difference between follower's hybrid time and its safe time as a measure of staleness. [#4868](https://github.com/yugabyte/yugabyte-db/issues/4868)
+
+### Yugabyte Platform
+
+- Add **Master** section below **Tablet Server** section in **Metrics** page. [#5233](https://github.com/yugabyte/yugabyte-db/issues/5233)
+- Add `rpc_connections_alive` metrics for YSQL and YCQL APIs. [#5223](https://github.com/yugabyte/yugabyte-db/issues/5223)
+- Fix restore payload when renaming table to include keyspace. Disable keyspace field when restoring universe backup. [#5178](https://github.com/yugabyte/yugabyte-db/issues/5178)
+- Pass in `ssh_user` to air-gap provision script and add to on-premise template. [#5132](https://github.com/yugabyte/yugabyte-db/issues/5132)
+- Add the `--recursive` flag to AZCopy for multi-table restore. [#5163](https://github.com/yugabyte/yugabyte-db/issues/5163)
+- Fix transactional backup with specified tables list by including keyspace in payload. [#5149](https://github.com/yugabyte/yugabyte-db/issues/5149)
+- Fix undefine object property error when Prometheus is unavailable and navigating to the **Replication** tab. [#5146](https://github.com/yugabyte/yugabyte-db/issues/5146)
+- Backups should take provider-level environment variables, including home directory. [#5064](https://github.com/yugabyte/yugabyte-db/issues/5064)
+- Add hostname and display in the Nodes page along with node name and IP address. [#4760](https://github.com/yugabyte/yugabyte-db/issues/4760)
+- Support option of DNS names instead of IP addresses for nodes. Add option in Admin UI to choose between using hostnames or IP addresses for on-premises provider. [#4951](https://github.com/yugabyte/yugabyte-db/issues/4951) [#4950](https://github.com/yugabyte/yugabyte-db/issues/4950)
+- Disable glob before running cleanup of old log files using `zip_purge_yb_logs.sh`. Fixes issue on Red Hat. [#5169](https://github.com/yugabyte/yugabyte-db/issues/5169)
+- Fix Replication graph units and missing graph in **Replication** tab when metrics exist. [#5423](https://github.com/yugabyte/yugabyte-db/issues/5423)
+
+{{< note title="Note" >}}
+
+Prior to version 2.0, YSQL was still in beta. As a result, the 2.0 release included a backward-incompatible file format change for YSQL. If you have an existing cluster running releases earlier than 2.0 with YSQL enabled, then you will not be able to upgrade to version 2.0+. Export from your existing cluster and then import into a new cluster (v2.0 or later) to use existing data.
+
+{{< /note >}}
+
+## v2.2.0 [July 15, 2020]
+
+### Build: 2.2.0.0-b80
+
+{{< note title="Important" >}}
+
+Starting with v2.2.0, Yugabyte release versions are numbered based on an even/odd release versioning. For more details, see the following:
+
+- [Release versioning](../../versioning) – Includes details on stable and latest versioning.
+- [Supported and planned releases](../../releases-overview) – Information on supported and latest releases.
+
+{{< /note >}}  
+
+### Downloads
+
+#### Binaries
+
+<a class="download-binary-link" href="https://downloads.yugabyte.com/yugabyte-2.2.0.0-darwin.tar.gz">
+  <button>
+    <i class="fab fa-apple"></i><span class="download-text">macOS</span>
+  </button>
+</a>
+&nbsp; &nbsp; &nbsp;
+<a class="download-binary-link" href="https://downloads.yugabyte.com/yugabyte-2.2.0.0-linux.tar.gz">
+  <button>
+    <i class="fab fa-linux"></i><span class="download-text">Linux</span>
+  </button>
+</a>
+<br />
+
+#### Docker
+
+```sh
+docker pull yugabytedb/yugabyte:2.2.0.0-b80
+```
+
+## Notable new features and enhancements
+
+### YSQL
+
+#### Transactional distributed backups
+
+YugabyteDB now supports [distributed backup and restore of YSQL databases](../../manage/backup-restore/snapshot-ysql/), including backup of all tables in a database. [#1139](https://github.com/yugabyte/yugabyte-db/issues/1139) and [#3849](https://github.com/yugabyte/yugabyte-db/issues/3849)
+
+#### Online index backfills
+
+- YugabyteDB can now build indexes on non-empty tables while online, without failing other concurrent writes. When you add a new index to a table that is already populated with data, you can now use the YSQL [`CREATE INDEX`](../../api/ysql/commands/ddl_create_index/#semantics) statement to enable building these indexes in an online manner, without requiring downtime. For details how online backfill of indexes works, see the [Online Index Backfill](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/online-index-backfill.md) design document.
+- Backfilling an index while online is disable by default. To enable online index backfilling, set the `yb-tserver` [`--ysql_disable_index_backfill`](../../reference/configuration/yb-tserver/#ysql-disable-index-backfill) flag to `false` when starting YB-TServers. Note: Do not use this flag in a production cluster yet. For details on how this works, see [Online Index Backfill](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/online-index-backfill.md)
+
+#### Colocated tables
+
+Database-level colocation for YSQL, which started as a beta feature in the 2.1 release, is **now generally available** in the 2.2 release. Traditional RDBMS modeling of parent-child relationships as foreign key constraints can lead to high-latency `JOIN` queries in a geo-distributed SQL database. This is because the tablets (or shards) containing the child rows might be hosted in nodes, availability zones, and regions different from the tablets containing the parent rows. By using [colocated tables](../../architecture/docdb-sharding/colocated-tables), you can let a single tablet be shared across all tables. Colocation can also be at the overall database level, where all tables of a single database are located in the same tablet and managed by the same Raft group.  Note that tables that you do not want to reside in the overall database’s tablet because of the expectation of large data volume can override the feature at table creation time and hence get independent tablets for themselves.
+
+What happens when the “colocation” tablet containing all the tables of a database becomes too large and starts impacting performance? Check out [automatic tablet splitting [BETA]](#automatic-tablet-splitting-beta).
+
+#### Deferred constraints on foreign keys
+
+Foreign keys in YSQL now support the [DEFERRABLE INITIALLY IMMEDIATE](../../api/ysql/commands/ddl_create_table/#foreign-key) and [DEFERRABLE INITIALLY DEFERRED](../../api/ysql/commands/ddl_create_table/#foreign-key) clauses. Work on deferring additional constraints, including those for primary keys, is in progress.
+
+Application developers often declare constraints that their data must obey, leaving it to relational databases to enforce the rules. The end result is simpler application logic, lower error probability, and higher developer productivity. Automatic constraint enforcement is a powerful feature that should be leveraged whenever possible. There are times, however, when you need to temporarily defer enforcement. An example is during the data load of a relational schema where there are cyclic foreign key dependencies. Data migration tools usually defer the enforcement of foreign key dependencies to the end of a transaction by which data for all foreign keys would ideally be present.  This should also allow YSQL to power Django apps.
+
+#### yugabyted for single-node clusters
+
+The `yugabyted` server is now out of beta for single-node deployments. New users can start using YugabyteDB without needing to understand the underlying architectures acts as a parent server, reducing the need to understand data management by YB-TServers and metadata management by YB-Masters.
+
+See it in action by following the updated [Quick start](../../quick-start). For details, see [`yugabyted`](../../reference/configuration/yugabyted) in the Reference section.
+
+#### Automatic tablet splitting [BETA]
+
+- YugabyteDB now supports automatic tablet splitting, resharding your data by changing the number of tablets at runtime. For details, see [Tablet splitting](../../architecture/docdb-sharding/tablet-splitting) and [Automatic Resharding of Data with Tablet Splitting](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/docdb-automatic-tablet-splitting.md). [#1004](https://github.com/yugabyte/yugabyte-db/issues/1004), [#1461](https://github.com/yugabyte/yugabyte-db/issues/1461), and [#1462](https://github.com/yugabyte/yugabyte-db/issues/1462)
+- To enable automatic tablet splitting, use the new `yb-master` [`--tablet_split_size_threshold_bytes`](../../reference/configuration/yb-master/#tablet-split-size-threshold-bytes) flag to specify the size when tablets should split.
+
+#### TPC-C benchmarking
+
+New results are now available for benchmarking the performance of the YSQL API using the TPC-C suite. For the new TPC-C results and details on performing your own benchmark tests to evaluate YugabyteDB, see [TPC-C](../../benchmark/tpcc-ysql/).
+
+#### Other changes
+
+- Support presplitting using [CREATE INDEX...SPLIT INTO](../../api/ysql/commands/ddl_create_index/#split-into) for range-partitioned table indexes. For details, see [Presplitting](../../architecture/docdb-sharding/tablet-splitting/#presplitting) [#4235](https://github.com/yugabyte/yugabyte-db/issues/4235)
+- Fix crash for nested `SELECT` statements that involve null pushdown on system tables. [#4685](https://github.com/yugabyte/yugabyte-db/issues/4685)
+- Fix wrong sorting order in presplit tables. [#4651](https://github.com/yugabyte/yugabyte-db/issues/4651)
+- To help track down unoptimized (or "slow") queries, use the new `yb-tserver` [`--ysql_log_min_duration_statement`](../../reference/configuration/yb-tserver/#ysql-log-min-duration-statement). [#4817](https://github.com/yugabyte/yugabyte-db/issues/4817)
+- Enhance the [`yb-admin list_tables`](../../admin/yb-admin/#list-tables) command with optional flags for listing tables with database type (`include_db_type`), table ID (`include_table_id`), and table type (`include_table_type`). This command replaces the deprecated `yb-admin list_tables_with_db_types` command. [#4546](https://github.com/yugabyte/yugabyte-db/issues/4546)
+- Add support for [`ALTER TABLE`](../../api/ysql/commands/ddl_alter_table/#) on colocated tables. [#4293](https://github.com/yugabyte/yugabyte-db/issues/4293)
+- Improve logic for index delete permissions. [#4980](https://github.com/yugabyte/yugabyte-db/issues/4980)
+- Add fast path option for index backfill when certain statements can create indexes without unnecessary overhead from online schema migration (for example, `CREATE TABLE` with unique column constraint). Skip index backfill for unsupported statements, including `DROP INDEX`, "CREATE UNIQUE INDEX ON`, and index create in postgres nested DDL). [#4918]
+- Suppress `incomplete startup packet` messages in YSQL logs. [#4813](https://github.com/yugabyte/yugabyte-db/issues/4813)
+- Improve YSQL create namespace failure handling. [#3979](https://github.com/yugabyte/yugabyte-db/issues/3979)
+- Add error messages to table schema version mismatch errors so they are more understandable. [#4810]
+- Increase the default DDL operations timeout to 120 seconds to allow for multi-region deployments, where a CREATE DATABASE statement can take longer than one minute. [#4762](https://github.com/yugabyte/yugabyte-db/issues/4762)
+
+### YCQL
+
+#### Transactional distributed backups
+
+YugabyteDB supports [distributed backup and restore of YCQL databases and tables](../../manage/backup-restore/snapshot-ysql/). [#1139](https://github.com/yugabyte/yugabyte-db/issues/1139) and [#3849](https://github.com/yugabyte/yugabyte-db/issues/3849)
+
+#### Online index backfills
+
+- YugabyteDB can now build indexes on non-empty tables while online, without failing other concurrent writes. When you add a new index to a table that is already populated with data, you can now use the YCQL [CREATE INDEX](../../api/ycql/ddl_create_index/#synopsis) statement to enable building these indexes in an online manner, without requiring downtime. For details how online backfill of indexes works, see the [Online Index Backfill](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/online-index-backfill.md) design document.
+- In YCQL, backfilling an index while online is enabled by default. To disable, set the `yb-tserver` [`--ycql_disable_index_backfill`](../../reference/configuration/yb-tserver/#ycql-disable-index-backfill) flag to `false` when starting YB-TServers. For details on how online index backfill works, see [Online Index Backfill](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/online-index-backfill.md). [#2301](https://github.com/yugabyte/yugabyte-db/issues/2301) and [#4708](https://github.com/yugabyte/yugabyte-db/issues/4708)
+
+#### Online schema changes for YCQL [BETA]
+
+Most applications have a need to frequently evolve the database schema, while simultaneously ensuring zero downtime during those schema change operations. Therefore, there is a need for schema migrations (which involve DDL operations) to be safely run in a concurrent and online manner alongside foreground client operations. In case of a failure, the schema change should be rolled back and not leave the database in a partially modified state. With the 2.2 release, not only the overall DocDB framework for supporting such schema changes in an online and safe manner has been introduced but also this feature is now available in beta in the context of YCQL using the [`ALTER TABLE`](../../api/ycql/ddl_alter_table/) statement.
+
+#### Automatic tablet splitting [BETA]
+
+- YugabyteDB now supports automatic tablet splitting at runtime by changing the number of tablets based on size thresholds. For details, see [Tablet splitting](../../architecture/docdb-sharding/tablet-splitting) and [Automatic Resharding of Data with Tablet Splitting](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/docdb-automatic-tablet-splitting.md). [#1004](https://github.com/yugabyte/yugabyte-db/issues/1004), [#1461](https://github.com/yugabyte/yugabyte-db/issues/1461), and [#1462](https://github.com/yugabyte/yugabyte-db/issues/1462)
+- To enable automatic tablet splitting, use the new `yb-master` [`--tablet_split_size_threshold_bytes`](../../reference/configuration/yb-master/#tablet-split-size-threshold-bytes) flag to specify the size when tablets should split.
+
+#### Other changes
+
+- Throttle YCQL calls when soft memory limit is reached. Two new flags, `throttle_cql_calls_on_soft_memory_limit` and `throttle_cql_calls_policy` can be used to control it. [#4973](https://github.com/yugabyte/yugabyte-db/issues/4973)
+- Implements a password cache to allow connections to be created more quickly from recently used accounts. Helps reduce high CPU usage when using YCQL authorization. [#4596](https://github.com/yugabyte/yugabyte-db/issues/4596)
+- Fix `column doesn't exist` error when an index is created on a column which is a prefix of another column. [#4881](https://github.com/yugabyte/yugabyte-db/issues/4881)
+- Fix crashes when using ORDER BY for non-existent column with index scan. [#4908](https://github.com/yugabyte/yugabyte-db/issues/4908)
+
+### Core database
+
+- Add HTTP endpoints for determining master leadership and returning information on masters. [#2606](https://github.com/yugabyte/yugabyte-db/issues/2606)
+  - `<web>/api/v1/masters`: Returns all master statuses.
+  - `<web>/api/v1/is-leader`: Returns `200 OK` response status code when the master is a leader and `503 Service Unavailable` when the master is not a leader.
+- Add HTTP endpoint `/api/v1/cluster-config` for YB-Master to return the current cluster configuration in JSON format. [#4748](https://github.com/yugabyte/yugabyte-db/issues/4748)
+  - Thanks, [AbdallahKhaled93](https://github.com/AbdallahKhaled93), for your contribution!
+- Output of `yb-admin get_universe_config` command is now in JSON format for easier parsing. [#4589]([#1462](https://github.com/yugabyte/yugabyte-db/issues/4589)
+- Add `yugabyted destroy` command. [#3872]([#3849](https://github.com/yugabyte/yugabyte-db/issues/3872)
+- Change logic used to determine if the load balancer is idle. [#4707](https://github.com/yugabyte/yugabyte-db/issues/4707)
+- Default to IPv4 addresses for DNS resolution and local addresses. [#4851](https://github.com/yugabyte/yugabyte-db/issues/4293)
+- Add a Grafana dashboard for YugabyteDB. [#4725](https://github.com/yugabyte/yugabyte-db/issues/4725)
+- [CDC] Check for table properties equivalence when comparing schemas in 2DC setups and ignore properties that don't need to be the same. [#4233](https://github.com/yugabyte/yugabyte-db/issues/4233)
+- [DocDB] Allow multiple indexes to backfill or delete simultaneously. [#2784](https://github.com/yugabyte/yugabyte-db/issues/2784)
+- [DocDB] Transition to new leader gracefully during a leader stepdown. When a leader stepdown happens with no new leader candidate specified in the stepdown request, the peer simply steps down leaving the group with no leader until regular heartbeat timeouts are triggered. This change makes it so that the leader attempts to transition to the most up-to-date peer, if possible. [#4298](https://github.com/yugabyte/yugabyte-db/issues/4298)
+- Update [`yb-admin list_snapshots`](../../admin/yb-admin/#list-snapshots) command to use `not_show_restored` option to exclude fully RESTORED entries. [#4351](ttps://github.com/yugabyte/yugabyte-db/issues/4351)
+- [DocDB] Clean up leftover snapshot files from failed snapshots that resulted in remote bootstrap getting stuck in a failure loop. [#4745](https://github.com/yugabyte/yugabyte-db/issues/4745)
+- [DocDB] Clean up metadata in memory after deleting snapshots. [#4887](https://github.com/yugabyte/yugabyte-db/issues/4877)
+- [DocDB] Fix snapshots getting stuck in retry loop with deleted table. [#4610](https://github.com/yugabyte/yugabyte-db/issues/4877) and [#4302](https://github.com/yugabyte/yugabyte-db/issues/4302)
+- [DocDB] When using [`yb-admin master_leader_stepdown`](../../admin/yb-admin/#master-leader-stepdown), specifying a new leader is now optional. [#4722](https://github.com/yugabyte/yugabyte-db/issues/4722)
+- [DocDB] Add breakdown of disk space on TServer dashboard. [#4767](https://github.com/yugabyte/yugabyte-db/issues/4767)
+- [DocDB] Suppress `yb-admin` from logging harmless "Failed to schedule invoking callback on response" warning. [#4131](https://github.com/yugabyte/yugabyte-db/issues/4131)
+- [DocDB] Allow specifying IPv6 addresses in bind addresses. [#3644](https://github.com/yugabyte/yugabyte-db/issues/3644)
+- [DocDB] Fix TS Heartbeater can get stuck if master network connectivity breaks. [#4838](https://github.com/yugabyte/yugabyte-db/issues/4838)
+- [DocDB] Improve protection against hitting hard memory limit when follower tablet peers are lagging behind leaders on a node. (for example, node downtime because of yb-tserver restart). [#2563](https://github.com/yugabyte/yugabyte-db/issues/2563)
+- `yugabyted` `--bind_ip` flag renamed to `--listen`. [#4960](https://github.com/yugabyte/yugabyte-db/issues/4960)
+- Fix malformed URL for ycql rpcz when clicking **YCQL Live Ops** link in the YB-TServer utilities page. [#4886](https://github.com/yugabyte/yugabyte-db/issues/4866)
+- Fix export name for YCQL metrics. [#4955](https://github.com/yugabyte/yugabyte-db/issues/4955)
+- Fix YB-Master UI to show correct number of tablets for colocated tables. [#4699](https://github.com/yugabyte/yugabyte-db/issues/4699)
+
+### Yugabyte Platform
+
+- Add option to [back up and restore YSQL databases](../../) and universe-level transactional backups. [#3849](https://github.com/yugabyte/yugabyte-db/issues/3849)
+- On the **Universes** page, the **Replication** tab displays by default and adds default state when replication lag metric query returns no data.
+- Add **Replication** tab to Universe overview tab list if enabled and query for replication lag metrics. [#]
+- Add replication lag metrics `async_replication_sent_lag_micros` (last applied time on producer - last polled for record) and `async_replication_committed_lag_micros` (last applied time on producer - last applied time on consumer) for 2DC replication and export to Prometheus. [#2154](https://github.com/yugabyte/yugabyte-db/issues/2154)
+- Retrieve IAM Instance Profile Credentials for backups. This retrieves the `AccessKeyId` and `SecretAccessKey` and set these in the configuration so that data nodes inherit the required IAM permissions to access S3. [#3451](https://github.com/yugabyte/yugabyte-db/issues/3451) and [#4900](https://github.com/yugabyte/yugabyte-db/issues/4900)
+- Add option to create a backup of multiple YCQL transactional tables. [#4540](https://github.com/yugabyte/yugabyte-db/issues/4540)
+- Add support for c5d instance types. [#4914](https://github.com/yugabyte/yugabyte-db/issues/4914)
+- Add support for installing epel-release in Amazon Linux. [#4561](https://github.com/yugabyte/yugabyte-db/issues/4561)
+- Fixed requested TLS client certificate generated with expired date and ysqlsh fails to connect. [#4732](https://github.com/yugabyte/yugabyte-db/issues/4732)
+- Fixed universe fails to create if user-supplied certificate is selected. [#4733](https://github.com/yugabyte/yugabyte-db/issues/4733)
+- Implement OAuth2/SSO authentication for Yugabyte Platform sign-in. [#4633](https://github.com/yugabyte/yugabyte-db/issues/4644) and [#4420](https://github.com/yugabyte/yugabyte-db/issues/4420)
+- Add backup and restore options for YSQL tables and universe-level transactional backups. [#3849](https://github.com/yugabyte/yugabyte-db/issues/3849)
+- Retrieve IAM Instance Profile Credentials for backups. This retrieves the `AccessKeyId` and `SecretAccessKey` and set these in the configuration so that data nodes inherit the required IAM permissions to access S3. [#4900](https://github.com/yugabyte/yugabyte-db/issues/4900)
+- In the **Health and Alerting** tab of the Admin Console, the Username and Password fields in **Custom SMTP Configuration** are now optional. [#4952](https://github.com/yugabyte/yugabyte-db/issues/4952)
+- Fix password reset in customer profile page. [#4666](https://github.com/yugabyte/yugabyte-db/issues/4666) and [#3909](https://github.com/yugabyte/yugabyte-db/issues/3909)
+- Fix **Backups** page not loading when there is a pending task. [#4754](https://github.com/yugabyte/yugabyte-db/issues/4754)
+- Change UI text displaying "GFlag" to "Flag" in the Admin Console. [#4659](https://github.com/yugabyte/yugabyte-db/issues/4659)
+
+{{< note title="Note" >}}
+
+Prior to version 2.0, YSQL was still in beta. As a result, the 2.0 release included a backward-incompatible file format change for YSQL. If you have an existing cluster running releases earlier than 2.0 with YSQL enabled, then you will not be able to upgrade to version 2.0+. Export from your existing cluster and then import into a new cluster (v2.0 or later) to use existing data.
+
+{{< /note >}}
+
+## v2.2.0 []
+
+
+**Released:** July 15, 2020 (2.2.0.0-b80).
+
+{{< note title="Important" >}}
+
+Starting with v2.2.0, Yugabyte release versions are numbered based on an even/odd release versioning. For more details, see the following:
+
+- [Release versioning](../../versioning) – Includes details on stable and latest versioning.
+- [Supported and planned releases](../../releases-overview) – Information on supported and latest releases.
+
+{{< /note >}}  
+
+## Downloads
+
+### Binaries
+
+<a class="download-binary-link" href="https://downloads.yugabyte.com/yugabyte-2.2.0.0-darwin.tar.gz">
+  <button>
+    <i class="fab fa-apple"></i><span class="download-text">macOS</span>
+  </button>
+</a>
+&nbsp; &nbsp; &nbsp;
+<a class="download-binary-link" href="https://downloads.yugabyte.com/yugabyte-2.2.0.0-linux.tar.gz">
+  <button>
+    <i class="fab fa-linux"></i><span class="download-text">Linux</span>
+  </button>
+</a>
+<br />
+
+### Docker
+
+```sh
+docker pull yugabytedb/yugabyte:2.2.0.0-b80
+```
+
+## Notable new features and enhancements
+
+## YSQL
+
+### Transactional distributed backups
+
+YugabyteDB now supports [distributed backup and restore of YSQL databases](../../manage/backup-restore/snapshot-ysql/), including backup of all tables in a database. [#1139](https://github.com/yugabyte/yugabyte-db/issues/1139) and [#3849](https://github.com/yugabyte/yugabyte-db/issues/3849)
+
+### Online index backfills
+
+- YugabyteDB can now build indexes on non-empty tables while online, without failing other concurrent writes. When you add a new index to a table that is already populated with data, you can now use the YSQL [`CREATE INDEX`](../../api/ysql/commands/ddl_create_index/#semantics) statement to enable building these indexes in an online manner, without requiring downtime. For details how online backfill of indexes works, see the [Online Index Backfill](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/online-index-backfill.md) design document.
+- Backfilling an index while online is disable by default. To enable online index backfilling, set the `yb-tserver` [`--ysql_disable_index_backfill`](../../reference/configuration/yb-tserver/#ysql-disable-index-backfill) flag to `false` when starting YB-TServers. Note: Do not use this flag in a production cluster yet. For details on how this works, see [Online Index Backfill](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/online-index-backfill.md)
+
+### Colocated tables
+
+Database-level colocation for YSQL, which started as a beta feature in the 2.1 release, is **now generally available** in the 2.2 release. Traditional RDBMS modeling of parent-child relationships as foreign key constraints can lead to high-latency `JOIN` queries in a geo-distributed SQL database. This is because the tablets (or shards) containing the child rows might be hosted in nodes, availability zones, and regions different from the tablets containing the parent rows. By using [colocated tables](../../architecture/docdb-sharding/colocated-tables), you can let a single tablet be shared across all tables. Colocation can also be at the overall database level, where all tables of a single database are located in the same tablet and managed by the same Raft group.  Note that tables that you do not want to reside in the overall database’s tablet because of the expectation of large data volume can override the feature at table creation time and hence get independent tablets for themselves.
+
+What happens when the “colocation” tablet containing all the tables of a database becomes too large and starts impacting performance? Check out [automatic tablet splitting [BETA]](#automatic-tablet-splitting-beta).
+
+### Deferred constraints on foreign keys
+
+Foreign keys in YSQL now support the [DEFERRABLE INITIALLY IMMEDIATE](../../api/ysql/commands/ddl_create_table/#foreign-key) and [DEFERRABLE INITIALLY DEFERRED](../../api/ysql/commands/ddl_create_table/#foreign-key) clauses. Work on deferring additional constraints, including those for primary keys, is in progress. 
+
+Application developers often declare constraints that their data must obey, leaving it to relational databases to enforce the rules. The end result is simpler application logic, lower error probability, and higher developer productivity. Automatic constraint enforcement is a powerful feature that should be leveraged whenever possible. There are times, however, when you need to temporarily defer enforcement. An example is during the data load of a relational schema where there are cyclic foreign key dependencies. Data migration tools usually defer the enforcement of foreign key dependencies to the end of a transaction by which data for all foreign keys would ideally be present.  This should also allow YSQL to power Django apps.
+
+### yugabyted for single-node clusters
+
+The `yugabyted` server is now out of beta for single-node deployments. New users can start using YugabyteDB without needing to understand the underlying architectures acts as a parent server, reducing the need to understand data management by YB-TServers and metadata management by YB-Masters.
+
+See it in action by following the updated [Quick start](../../quick-start). For details, see [`yugabyted`](../../reference/configuration/yugabyted) in the Reference section.
+
+### Automatic tablet splitting [BETA]
+
+- YugabyteDB now supports automatic tablet splitting, resharding your data by changing the number of tablets at runtime. For details, see [Tablet splitting](../../architecture/docdb-sharding/tablet-splitting) and [Automatic Resharding of Data with Tablet Splitting](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/docdb-automatic-tablet-splitting.md). [#1004](https://github.com/yugabyte/yugabyte-db/issues/1004), [#1461](https://github.com/yugabyte/yugabyte-db/issues/1461), and [#1462](https://github.com/yugabyte/yugabyte-db/issues/1462)
+- To enable automatic tablet splitting, use the new `yb-master` [`--tablet_split_size_threshold_bytes`](../../reference/configuration/yb-master/#tablet-split-size-threshold-bytes) flag to specify the size when tablets should split.
+
+### TPC-C benchmarking
+
+New results are now available for benchmarking the performance of the YSQL API using the TPC-C suite. For the new TPC-C results and details on performing your own benchmark tests to evaluate YugabyteDB, see [TPC-C](../../benchmark/tpcc-ysql/).
+
+### Other notable changes
+
+- Support presplitting using [CREATE INDEX...SPLIT INTO](../../api/ysql/commands/ddl_create_index/#split-into) for range-partitioned table indexes. For details, see [Presplitting](../../architecture/docdb-sharding/tablet-splitting/#presplitting) [#4235](https://github.com/yugabyte/yugabyte-db/issues/4235)
+- Fix crash for nested `SELECT` statements that involve null pushdown on system tables. [#4685](https://github.com/yugabyte/yugabyte-db/issues/4685)
+- Fix wrong sorting order in presplit tables. [#4651](https://github.com/yugabyte/yugabyte-db/issues/4651)
+- To help track down unoptimized (or "slow") queries, use the new `yb-tserver` [`--ysql_log_min_duration_statement`](../../reference/configuration/yb-tserver/#ysql-log-min-duration-statement). [#4817](https://github.com/yugabyte/yugabyte-db/issues/4817)
+- Enhance the [`yb-admin list_tables`](../../admin/yb-admin/#list-tables) command with optional flags for listing tables with database type (`include_db_type`), table ID (`include_table_id`), and table type (`include_table_type`). This command replaces the deprecated `yb-admin list_tables_with_db_types` command. [#4546](https://github.com/yugabyte/yugabyte-db/issues/4546)
+- Add support for [`ALTER TABLE`](../../api/ysql/commands/ddl_alter_table/#) on colocated tables. [#4293](https://github.com/yugabyte/yugabyte-db/issues/4293)
+- Improve logic for index delete permissions. [#4980](https://github.com/yugabyte/yugabyte-db/issues/4980)
+- Add fast path option for index backfill when certain statements can create indexes without unnecessary overhead from online schema migration (for example, `CREATE TABLE` with unique column constraint). Skip index backfill for unsupported statements, including `DROP INDEX`, "CREATE UNIQUE INDEX ON`, and index create in postgres nested DDL). [#4918]
+- Suppress `incomplete startup packet` messages in YSQL logs. [#4813](https://github.com/yugabyte/yugabyte-db/issues/4813)
+- Improve YSQL create namespace failure handling. [#3979](https://github.com/yugabyte/yugabyte-db/issues/3979)
+- Add error messages to table schema version mismatch errors so they are more understandable. [#4810]
+- Increase the default DDL operations timeout to 120 seconds to allow for multi-region deployments, where a CREATE DATABASE statement can take longer than one minute. [#4762](https://github.com/yugabyte/yugabyte-db/issues/4762)
+
+## YCQL
+
+### Transactional distributed backups
+
+YugabyteDB supports [distributed backup and restore of YCQL databases and tables](../../manage/backup-restore/snapshot-ysql/). [#1139](https://github.com/yugabyte/yugabyte-db/issues/1139) and [#3849](https://github.com/yugabyte/yugabyte-db/issues/3849)
+
+### Online index backfills
+
+- YugabyteDB can now build indexes on non-empty tables while online, without failing other concurrent writes. When you add a new index to a table that is already populated with data, you can now use the YCQL [CREATE INDEX](../../api/ycql/ddl_create_index/#synopsis) statement to enable building these indexes in an online manner, without requiring downtime. For details how online backfill of indexes works, see the [Online Index Backfill](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/online-index-backfill.md) design document.
+- In YCQL, backfilling an index while online is enabled by default. To disable, set the `yb-tserver` [`--ycql_disable_index_backfill`](../../reference/configuration/yb-tserver/#ycql-disable-index-backfill) flag to `false` when starting YB-TServers. For details on how online index backfill works, see [Online Index Backfill](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/online-index-backfill.md). [#2301](https://github.com/yugabyte/yugabyte-db/issues/2301) and [#4708](https://github.com/yugabyte/yugabyte-db/issues/4708)
+
+### Online schema changes for YCQL [BETA]
+
+Most applications have a need to frequently evolve the database schema, while simultaneously ensuring zero downtime during those schema change operations. Therefore, there is a need for schema migrations (which involve DDL operations) to be safely run in a concurrent and online manner alongside foreground client operations. In case of a failure, the schema change should be rolled back and not leave the database in a partially modified state. With the 2.2 release, not only the overall DocDB framework for supporting such schema changes in an online and safe manner has been introduced but also this feature is now available in beta in the context of YCQL using the [`ALTER TABLE`](../../api/ycql/ddl_alter_table/) statement.
+
+### Automatic tablet splitting [BETA]
+
+- YugabyteDB now supports automatic tablet splitting at runtime by changing the number of tablets based on size thresholds. For details, see [Tablet splitting](../../architecture/docdb-sharding/tablet-splitting) and [Automatic Resharding of Data with Tablet Splitting](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/docdb-automatic-tablet-splitting.md). [#1004](https://github.com/yugabyte/yugabyte-db/issues/1004), [#1461](https://github.com/yugabyte/yugabyte-db/issues/1461), and [#1462](https://github.com/yugabyte/yugabyte-db/issues/1462)
+- To enable automatic tablet splitting, use the new `yb-master` [`--tablet_split_size_threshold_bytes`](../../reference/configuration/yb-master/#tablet-split-size-threshold-bytes) flag to specify the size when tablets should split.
+
+### Other notable changes
+
+- Throttle YCQL calls when soft memory limit is reached. Two new flags, `throttle_cql_calls_on_soft_memory_limit` and `throttle_cql_calls_policy` can be used to control it. [#4973](https://github.com/yugabyte/yugabyte-db/issues/4973)
+- Implements a password cache to allow connections to be created more quickly from recently used accounts. Helps reduce high CPU usage when using YCQL authorization. [#4596](https://github.com/yugabyte/yugabyte-db/issues/4596)
+- Fix `column doesn't exist` error when an index is created on a column which is a prefix of another column. [#4881](https://github.com/yugabyte/yugabyte-db/issues/4881)
+- Fix crashes when using ORDER BY for non-existent column with index scan. [#4908](https://github.com/yugabyte/yugabyte-db/issues/4908)
+
+## System improvements
+
+- Add HTTP endpoints for determining master leadership and returning information on masters. [#2606](https://github.com/yugabyte/yugabyte-db/issues/2606)
+  - `<web>/api/v1/masters`: Returns all master statuses.
+  - `<web>/api/v1/is-leader`: Returns `200 OK` response status code when the master is a leader and `503 Service Unavailable` when the master is not a leader.
+- Add HTTP endpoint `/api/v1/cluster-config` for YB-Master to return the current cluster configuration in JSON format. [#4748](https://github.com/yugabyte/yugabyte-db/issues/4748)
+  - Thanks, [AbdallahKhaled93](https://github.com/AbdallahKhaled93), for your contribution!
+- Output of `yb-admin get_universe_config` command is now in JSON format for easier parsing. [#4589]([#1462](https://github.com/yugabyte/yugabyte-db/issues/4589)
+- Add `yugabyted destroy` command. [#3872]([#3849](https://github.com/yugabyte/yugabyte-db/issues/3872)
+- Change logic used to determine if the load balancer is idle. [#4707](https://github.com/yugabyte/yugabyte-db/issues/4707)
+- Default to IPv4 addresses for DNS resolution and local addresses. [#4851](https://github.com/yugabyte/yugabyte-db/issues/4293)
+- Add a Grafana dashboard for YugabyteDB. [#4725](https://github.com/yugabyte/yugabyte-db/issues/4725)
+- [CDC] Check for table properties equivalence when comparing schemas in 2DC setups and ignore properties that don't need to be the same. [#4233](https://github.com/yugabyte/yugabyte-db/issues/4233)
+- [DocDB] Allow multiple indexes to backfill or delete simultaneously. [#2784](https://github.com/yugabyte/yugabyte-db/issues/2784)
+- [DocDB] Transition to new leader gracefully during a leader stepdown. When a leader stepdown happens with no new leader candidate specified in the stepdown request, the peer simply steps down leaving the group with no leader until regular heartbeat timeouts are triggered. This change makes it so that the leader attempts to transition to the most up-to-date peer, if possible. [#4298](https://github.com/yugabyte/yugabyte-db/issues/4298)
+- Update [`yb-admin list_snapshots`](../../admin/yb-admin/#list-snapshots) command to use `not_show_restored` option to exclude fully RESTORED entries. [#4351](ttps://github.com/yugabyte/yugabyte-db/issues/4351)
+- [DocDB] Clean up leftover snapshot files from failed snapshots that resulted in remote bootstrap getting stuck in a failure loop. [#4745](https://github.com/yugabyte/yugabyte-db/issues/4745)
+- [DocDB] Clean up metadata in memory after deleting snapshots. [#4887](https://github.com/yugabyte/yugabyte-db/issues/4877)
+- [DocDB] Fix snapshots getting stuck in retry loop with deleted table. [#4610](https://github.com/yugabyte/yugabyte-db/issues/4877) and [#4302](https://github.com/yugabyte/yugabyte-db/issues/4302)
+- [DocDB] When using [`yb-admin master_leader_stepdown`](../../admin/yb-admin/#master-leader-stepdown), specifying a new leader is now optional. [#4722](https://github.com/yugabyte/yugabyte-db/issues/4722)
+- [DocDB] Add breakdown of disk space on TServer dashboard. [#4767](https://github.com/yugabyte/yugabyte-db/issues/4767)
+- [DocDB] Suppress `yb-admin` from logging harmless "Failed to schedule invoking callback on response" warning. [#4131](https://github.com/yugabyte/yugabyte-db/issues/4131)
+- [DocDB] Allow specifying IPv6 addresses in bind addresses. [#3644](https://github.com/yugabyte/yugabyte-db/issues/3644)
+- [DocDB] Fix TS Heartbeater can get stuck if master network connectivity breaks. [#4838](https://github.com/yugabyte/yugabyte-db/issues/4838)
+- [DocDB] Improve protection against hitting hard memory limit when follower tablet peers are lagging behind leaders on a node. (for example, node downtime because of yb-tserver restart). [#2563](https://github.com/yugabyte/yugabyte-db/issues/2563)
+- `yugabyted` `--bind_ip` flag renamed to `--listen`. [#4960](https://github.com/yugabyte/yugabyte-db/issues/4960)
+- Fix malformed URL for ycql rpcz when clicking **YCQL Live Ops** link in the YB-TServer utilities page. [#4886](https://github.com/yugabyte/yugabyte-db/issues/4866)
+- Fix export name for YCQL metrics. [#4955](https://github.com/yugabyte/yugabyte-db/issues/4955)
+- Fix YB-Master UI to show correct number of tablets for colocated tables. [#4699](https://github.com/yugabyte/yugabyte-db/issues/4699)
+
+## Yugabyte Platform
+
+- Add option to [back up and restore YSQL databases](../../) and universe-level transactional backups. [#3849](https://github.com/yugabyte/yugabyte-db/issues/3849)
+- On the **Universes** page, the **Replication** tab displays by default and adds default state when replication lag metric query returns no data.
+- Add **Replication** tab to Universe overview tab list if enabled and query for replication lag metrics. [#]
+- Add replication lag metrics `async_replication_sent_lag_micros` (last applied time on producer - last polled for record) and `async_replication_committed_lag_micros` (last applied time on producer - last applied time on consumer) for 2DC replication and export to Prometheus. [#2154](https://github.com/yugabyte/yugabyte-db/issues/2154)
+- Retrieve IAM Instance Profile Credentials for backups. This retrieves the `AccessKeyId` and `SecretAccessKey` and set these in the configuration so that data nodes inherit the required IAM permissions to access S3. [#3451](https://github.com/yugabyte/yugabyte-db/issues/3451) and [#4900](https://github.com/yugabyte/yugabyte-db/issues/4900)
+- Add option to create a backup of multiple YCQL transactional tables. [#4540](https://github.com/yugabyte/yugabyte-db/issues/4540)
+- Add support for c5d instance types. [#4914](https://github.com/yugabyte/yugabyte-db/issues/4914)
+- Add support for installing epel-release in Amazon Linux. [#4561](https://github.com/yugabyte/yugabyte-db/issues/4561)
+- Fixed requested TLS client certificate generated with expired date and ysqlsh fails to connect. [#4732](https://github.com/yugabyte/yugabyte-db/issues/4732)
+- Fixed universe fails to create if user-supplied certificate is selected. [#4733](https://github.com/yugabyte/yugabyte-db/issues/4733)
+- Implement OAuth2/SSO authentication for Yugabyte Platform sign-in. [#4633](https://github.com/yugabyte/yugabyte-db/issues/4644) and [#4420](https://github.com/yugabyte/yugabyte-db/issues/4420)
+- Add backup and restore options for YSQL tables and universe-level transactional backups. [#3849](https://github.com/yugabyte/yugabyte-db/issues/3849)
+- Retrieve IAM Instance Profile Credentials for backups. This retrieves the `AccessKeyId` and `SecretAccessKey` and set these in the configuration so that data nodes inherit the required IAM permissions to access S3. [#4900](https://github.com/yugabyte/yugabyte-db/issues/4900)
+- In the **Health and Alerting** tab of the Admin Console, the Username and Password fields in **Custom SMTP Configuration** are now optional. [#4952](https://github.com/yugabyte/yugabyte-db/issues/4952)
+- Fix password reset in customer profile page. [#4666](https://github.com/yugabyte/yugabyte-db/issues/4666) and [#3909](https://github.com/yugabyte/yugabyte-db/issues/3909)
+- Fix **Backups** page not loading when there is a pending task. [#4754](https://github.com/yugabyte/yugabyte-db/issues/4754)
+- Change UI text displaying "GFlag" to "Flag" in the Admin Console. [#4659](https://github.com/yugabyte/yugabyte-db/issues/4659)
+
+{{< note title="Note" >}}
+
+Prior to version 2.0, YSQL was still in beta. As a result, the 2.0 release included a backward-incompatible file format change for YSQL. If you have an existing cluster running releases earlier than 2.0 with YSQL enabled, then you will not be able to upgrade to version 2.0+. Export from your existing cluster and then import into a new cluster (v2.0 or later) to use existing data.
+
+{{< /note >}}

--- a/docs/content/latest/releases/whats-new/stable-releases.md
+++ b/docs/content/latest/releases/whats-new/stable-releases.md
@@ -1,7 +1,7 @@
 ---
 title: What's new in 2.2 (stable)
-headerTitle: What's new in 2.2 (stable)
-linkTitle: What's new in 2.2 (stable)
+headerTitle: What's new in the 2.2 stable release series
+linkTitle: 2.2 (stable)
 description: Enhancements, changes, and resolved issues in the recommended stable release series.
 headcontent: Features, enhancements, and resolved issues in the recommended stable release series.
 image: /images/section_icons/quick_start/install.png
@@ -13,156 +13,29 @@ menu:
     parent: whats-new
     identifier: stable-releases
     weight: 2586 
+isTocNested: true
+showAsideToc: true
 ---
 
-Included here are the release notes for all releases in the `2.3` latest release series. The `2.3` latest release series include the following releases:
+Included here are the notable new features and enhancements and the release notes for all releases in the `2.3` latest release series.
 
-- [v2.2.2 (August 19, 2020)](#v2-2-2-august-19-2020)
-- [v2.2.0 (July 15, 2020)](#v2-2-0-july-15-2020)
+{{< note title="New release versioning" >}}
 
-{{< note title="Important" >}}
+Starting with v2.2.0, Yugabyte release versions follow a [new release versioning convention](../../versioning). Stable release series are denoted by `MAJOR.EVEN`, introduce new features and changes added since the previous stable release series and are supported for production deployments. Patch releases, denoted by `MAJOR.EVEN.PATCH`, include bug fixes and revisions that do not break backwards compatibility.
+For more information, see [Supported and planned releases](../../releases-overview).
 
-Starting with v2.2.0, Yugabyte release versions are numbered based on an a new release versioning convention. For more details, see the following:
+{{< /note >}}
 
-- [Release versioning](../../versioning) – Includes details on stable and latest versioning.
-- [Supported and planned releases](../../releases-overview) – Information on supported and latest releases.
+{{< note title="Upgrading from 1.3" >}}
+
+Prior to version 2.0, YSQL was still in beta. Upon release of 2.0, a backward-incompatible file format change was made for YSQL. For existing clusters running pre-2.0 release with YSQL enabled, you cannot upgrade to version 2.0 or later. Instead, export your data from existing clusters and then import the data into a new cluster (v2.0 or later).
 
 {{< /note >}}
 
 ---
+## Notable features and enhancements
 
-## v2.2.2 [August 19, 2020]
-
-### Build: 2.2.2.0-b15
-
-{{< note title="Important" >}}
-
-Starting with v2.2.0, Yugabyte release versions are numbered based on an even/odd release versioning. For more details, see the following:
-
-- [Release versioning](../../versioning) – Includes details on stable and latest versioning.
-- [Supported and planned releases](../../releases-overview) – Information on supported and latest releases.
-
-{{< /note >}}  
-
-### Downloads
-
-#### Binaries
-
-<a class="download-binary-link" href="https://downloads.yugabyte.com/yugabyte-2.2.2.0-darwin.tar.gz">
-  <button>
-    <i class="fab fa-apple"></i><span class="download-text">macOS</span>
-  </button>
-</a>
-&nbsp; &nbsp; &nbsp;
-<a class="download-binary-link" href="https://downloads.yugabyte.com/yugabyte-2.2.2.0-linux.tar.gz">
-  <button>
-    <i class="fab fa-linux"></i><span class="download-text">Linux</span>
-  </button>
-</a>
-<br />
-
-#### Docker
-
-```sh
-docker pull yugabytedb/yugabyte:2.2.2.0-b15
-```
-
-### YSQL
-
-- Fix failed backup if restored table was deleted before restoration. [#5274](https://github.com/yugabyte/yugabyte-db/issues/5274)
-- Newly elected YB-Master leader should pause before initiating load balancing. [#5221](https://github.com/yugabyte/yugabyte-db/issues/5221)
-- Fix backfilling to better handle large indexed table tablets. [#5031](https://github.com/yugabyte/yugabyte-db/issues/5031)
-- Fix `DROP DATABASE` statement should work with databases deleted on YB-Master. [#4710](https://github.com/yugabyte/yugabyte-db/issues/4710)
-- For non-prepared statements, optimize `pg_statistic` system table lookups. [#5051](https://github.com/yugabyte/yugabyte-db/issues/5051)
-- [CDC] Avoid periodic querying of the `cdc_state` table for xDC metrics if there are no replication streams enabled. [#5173](https://github.com/yugabyte/yugabyte-db/issues/5173)
-
-### YCQL
-
-- Implement DNS cache to significantly reduce CPU loads due to a large number of DNS resolution requests (especially for YCQL connections). Adds [`dns_cache_expiration_ms`](../../reference/configuration/yb-master/#dns-cache-expiration-ms) flag (default is 1 minute). [#5201](https://github.com/yugabyte/yugabyte-db/issues/5201)
-- Fixed incorrect names de-mangling in index creation from `CatalogManager::ImportSnapshot()`. [#5157](https://github.com/yugabyte/yugabyte-db/issues/5157)
-- Fixed crashes when inserting literals containing newline characters. [#5270](https://github.com/yugabyte/yugabyte-db/issues/5270)
-- Reuse CQL parser between processors to improve memory usage. Add new `cql_processors_limit` flag to control processor allocation. [#5057](https://github.com/yugabyte/yugabyte-db/issues/5057)
-
-### Core database
-
-- Fix `yugabyted` fails to start UI due to class binding failure. [#5069](https://github.com/yugabyte/yugabyte-db/issues/5069)
-- Show hostnames in YB-Master and YB-TServer Admin UI when hostnames are specified in `--webserver_interface`, `rpc_bind_addresses`, and `server_broadcast_addresses` flags. [#5002](https://github.com/yugabyte/yugabyte-db/issues/5002)
-- Skip tablets without intents during commits, for example, the case of an update of a non-existing row. [#5321](https://github.com/yugabyte/yugabyte-db/issues/5321)
-- Fix log spew when applying unknown transaction and release a mutex as soon as possible when transaction is not found. [#5315](https://github.com/yugabyte/yugabyte-db/issues/5315)
-- Fix snapshots cleanup when snapshots removed before restart. [#5337](https://github.com/yugabyte/yugabyte-db/issues/5337)
-- Replace `SCHECK` with `LOG(DFATAL)` when checking for restart-safe timestamps in WAL entries. [#5314](https://github.com/yugabyte/yugabyte-db/issues/5314)
-- Replace all CHECK in the load balancer code with `SCHECK` or `RETURN_NOT_OK`. [#5182](https://github.com/yugabyte/yugabyte-db/issues/5182)
-- Implement DNS cache to significantly reduce CPU loads due to a large number of DNS resolution requests (especially for YCQL connections). Adds YB-Master [`dns_cache_expiration_ms`](../../reference/configuration/yb-master/#dns-cache-expiration-ms) flag (default is 1 minute). [#5201](https://github.com/yugabyte/yugabyte-db/issues/5201)
-- Avoid duplicate DNS requests when handling `system.partitions` table requests. [#5225](https://github.com/yugabyte/yugabyte-db/issues/5225)
-- Fix leader load balancing can cause `CHECK` failures if stepdown task is pending on next run. Sets global leader balance threshold while allowing progress to be made across tables. Adds new YB-Master [`load_balancer_max_concurrent_moves_per_table`](../../reference/configuration/yb-master/#load-balancer-max-concurrent-moves-per-table) flag to limit number of leader moves per table. [#5181](https://github.com/yugabyte/yugabyte-db/issues/5181) and [#5021](https://github.com/yugabyte/yugabyte-db/issues/5021)
-- Set the async `YBClient` initialization future in `TabletPeer` constructor to ensure tablet bootstrap logic can resolve transaction statuses. [#5215](https://github.com/yugabyte/yugabyte-db/issues/5215)
-- Handle write operation failures during tablet bootstrap. [#5224](https://github.com/yugabyte/yugabyte-db/issues/5224)
-- Drop index upon failed backfill. [#5144](https://github.com/yugabyte/yugabyte-db/issues/5144)  [#5161](https://github.com/yugabyte/yugabyte-db/issues/5161)
-- Fix WAL overwriting by new leader and replay of incorrect entries on tablet bootstrap. [#5003](https://github.com/yugabyte/yugabyte-db/issues/5003) [#3759](https://github.com/yugabyte/yugabyte-db/issues/3759) [#4983](https://github.com/yugabyte/yugabyte-db/issues/4983)
-- Avoid taking unique lock when starting lookup request. [#5059](https://github.com/yugabyte/yugabyte-db/issues/5059)
-- Set 2DC lag metrics to `0` if not the leader and if the replication is deleted. [#5113](https://github.com/yugabyte/yugabyte-db/issues/5113)
-- Set the table to ALTERING state when `fully_*` is populated. [#5139](https://github.com/yugabyte/yugabyte-db/issues/5139)
-- `Not the leader` errors should not cause a replica to be marked as failed. [#5072](https://github.com/yugabyte/yugabyte-db/issues/5072)
-- Use difference between follower's hybrid time and its safe time as a measure of staleness. [#4868](https://github.com/yugabyte/yugabyte-db/issues/4868)
-
-### Yugabyte Platform
-
-- Add **Master** section below **Tablet Server** section in **Metrics** page. [#5233](https://github.com/yugabyte/yugabyte-db/issues/5233)
-- Add `rpc_connections_alive` metrics for YSQL and YCQL APIs. [#5223](https://github.com/yugabyte/yugabyte-db/issues/5223)
-- Fix restore payload when renaming table to include keyspace. Disable keyspace field when restoring universe backup. [#5178](https://github.com/yugabyte/yugabyte-db/issues/5178)
-- Pass in `ssh_user` to air-gap provision script and add to on-premise template. [#5132](https://github.com/yugabyte/yugabyte-db/issues/5132)
-- Add the `--recursive` flag to AZCopy for multi-table restore. [#5163](https://github.com/yugabyte/yugabyte-db/issues/5163)
-- Fix transactional backup with specified tables list by including keyspace in payload. [#5149](https://github.com/yugabyte/yugabyte-db/issues/5149)
-- Fix undefine object property error when Prometheus is unavailable and navigating to the **Replication** tab. [#5146](https://github.com/yugabyte/yugabyte-db/issues/5146)
-- Backups should take provider-level environment variables, including home directory. [#5064](https://github.com/yugabyte/yugabyte-db/issues/5064)
-- Add hostname and display in the Nodes page along with node name and IP address. [#4760](https://github.com/yugabyte/yugabyte-db/issues/4760)
-- Support option of DNS names instead of IP addresses for nodes. Add option in Admin UI to choose between using hostnames or IP addresses for on-premises provider. [#4951](https://github.com/yugabyte/yugabyte-db/issues/4951) [#4950](https://github.com/yugabyte/yugabyte-db/issues/4950)
-- Disable glob before running cleanup of old log files using `zip_purge_yb_logs.sh`. Fixes issue on Red Hat. [#5169](https://github.com/yugabyte/yugabyte-db/issues/5169)
-- Fix Replication graph units and missing graph in **Replication** tab when metrics exist. [#5423](https://github.com/yugabyte/yugabyte-db/issues/5423)
-
-{{< note title="Note" >}}
-
-Prior to version 2.0, YSQL was still in beta. As a result, the 2.0 release included a backward-incompatible file format change for YSQL. If you have an existing cluster running releases earlier than 2.0 with YSQL enabled, then you will not be able to upgrade to version 2.0+. Export from your existing cluster and then import into a new cluster (v2.0 or later) to use existing data.
-
-{{< /note >}}
-
-## v2.2.0 [July 15, 2020]
-
-### Build: 2.2.0.0-b80
-
-{{< note title="Important" >}}
-
-Starting with v2.2.0, Yugabyte release versions are numbered based on an even/odd release versioning. For more details, see the following:
-
-- [Release versioning](../../versioning) – Includes details on stable and latest versioning.
-- [Supported and planned releases](../../releases-overview) – Information on supported and latest releases.
-
-{{< /note >}}  
-
-### Downloads
-
-#### Binaries
-
-<a class="download-binary-link" href="https://downloads.yugabyte.com/yugabyte-2.2.0.0-darwin.tar.gz">
-  <button>
-    <i class="fab fa-apple"></i><span class="download-text">macOS</span>
-  </button>
-</a>
-&nbsp; &nbsp; &nbsp;
-<a class="download-binary-link" href="https://downloads.yugabyte.com/yugabyte-2.2.0.0-linux.tar.gz">
-  <button>
-    <i class="fab fa-linux"></i><span class="download-text">Linux</span>
-  </button>
-</a>
-<br />
-
-#### Docker
-
-```sh
-docker pull yugabytedb/yugabyte:2.2.0.0-b80
-```
-
-## Notable new features and enhancements
+Here is an overview of all notable features and enhancements added to the `2.2` stable release series. For features added in specific releases, see [Release notes](#release-notes) below.
 
 ### YSQL
 
@@ -202,21 +75,6 @@ See it in action by following the updated [Quick start](../../quick-start). For 
 
 New results are now available for benchmarking the performance of the YSQL API using the TPC-C suite. For the new TPC-C results and details on performing your own benchmark tests to evaluate YugabyteDB, see [TPC-C](../../benchmark/tpcc-ysql/).
 
-#### Other changes
-
-- Support presplitting using [CREATE INDEX...SPLIT INTO](../../api/ysql/commands/ddl_create_index/#split-into) for range-partitioned table indexes. For details, see [Presplitting](../../architecture/docdb-sharding/tablet-splitting/#presplitting) [#4235](https://github.com/yugabyte/yugabyte-db/issues/4235)
-- Fix crash for nested `SELECT` statements that involve null pushdown on system tables. [#4685](https://github.com/yugabyte/yugabyte-db/issues/4685)
-- Fix wrong sorting order in presplit tables. [#4651](https://github.com/yugabyte/yugabyte-db/issues/4651)
-- To help track down unoptimized (or "slow") queries, use the new `yb-tserver` [`--ysql_log_min_duration_statement`](../../reference/configuration/yb-tserver/#ysql-log-min-duration-statement). [#4817](https://github.com/yugabyte/yugabyte-db/issues/4817)
-- Enhance the [`yb-admin list_tables`](../../admin/yb-admin/#list-tables) command with optional flags for listing tables with database type (`include_db_type`), table ID (`include_table_id`), and table type (`include_table_type`). This command replaces the deprecated `yb-admin list_tables_with_db_types` command. [#4546](https://github.com/yugabyte/yugabyte-db/issues/4546)
-- Add support for [`ALTER TABLE`](../../api/ysql/commands/ddl_alter_table/#) on colocated tables. [#4293](https://github.com/yugabyte/yugabyte-db/issues/4293)
-- Improve logic for index delete permissions. [#4980](https://github.com/yugabyte/yugabyte-db/issues/4980)
-- Add fast path option for index backfill when certain statements can create indexes without unnecessary overhead from online schema migration (for example, `CREATE TABLE` with unique column constraint). Skip index backfill for unsupported statements, including `DROP INDEX`, "CREATE UNIQUE INDEX ON`, and index create in postgres nested DDL). [#4918]
-- Suppress `incomplete startup packet` messages in YSQL logs. [#4813](https://github.com/yugabyte/yugabyte-db/issues/4813)
-- Improve YSQL create namespace failure handling. [#3979](https://github.com/yugabyte/yugabyte-db/issues/3979)
-- Add error messages to table schema version mismatch errors so they are more understandable. [#4810]
-- Increase the default DDL operations timeout to 120 seconds to allow for multi-region deployments, where a CREATE DATABASE statement can take longer than one minute. [#4762](https://github.com/yugabyte/yugabyte-db/issues/4762)
-
 ### YCQL
 
 #### Transactional distributed backups
@@ -237,147 +95,84 @@ Most applications have a need to frequently evolve the database schema, while si
 - YugabyteDB now supports automatic tablet splitting at runtime by changing the number of tablets based on size thresholds. For details, see [Tablet splitting](../../architecture/docdb-sharding/tablet-splitting) and [Automatic Resharding of Data with Tablet Splitting](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/docdb-automatic-tablet-splitting.md). [#1004](https://github.com/yugabyte/yugabyte-db/issues/1004), [#1461](https://github.com/yugabyte/yugabyte-db/issues/1461), and [#1462](https://github.com/yugabyte/yugabyte-db/issues/1462)
 - To enable automatic tablet splitting, use the new `yb-master` [`--tablet_split_size_threshold_bytes`](../../reference/configuration/yb-master/#tablet-split-size-threshold-bytes) flag to specify the size when tablets should split.
 
-#### Other changes
+----
 
-- Throttle YCQL calls when soft memory limit is reached. Two new flags, `throttle_cql_calls_on_soft_memory_limit` and `throttle_cql_calls_policy` can be used to control it. [#4973](https://github.com/yugabyte/yugabyte-db/issues/4973)
-- Implements a password cache to allow connections to be created more quickly from recently used accounts. Helps reduce high CPU usage when using YCQL authorization. [#4596](https://github.com/yugabyte/yugabyte-db/issues/4596)
-- Fix `column doesn't exist` error when an index is created on a column which is a prefix of another column. [#4881](https://github.com/yugabyte/yugabyte-db/issues/4881)
-- Fix crashes when using ORDER BY for non-existent column with index scan. [#4908](https://github.com/yugabyte/yugabyte-db/issues/4908)
+## Release notes
 
-### Core database
+### v2.2.2 - August 19, 2020
 
-- Add HTTP endpoints for determining master leadership and returning information on masters. [#2606](https://github.com/yugabyte/yugabyte-db/issues/2606)
-  - `<web>/api/v1/masters`: Returns all master statuses.
-  - `<web>/api/v1/is-leader`: Returns `200 OK` response status code when the master is a leader and `503 Service Unavailable` when the master is not a leader.
-- Add HTTP endpoint `/api/v1/cluster-config` for YB-Master to return the current cluster configuration in JSON format. [#4748](https://github.com/yugabyte/yugabyte-db/issues/4748)
-  - Thanks, [AbdallahKhaled93](https://github.com/AbdallahKhaled93), for your contribution!
-- Output of `yb-admin get_universe_config` command is now in JSON format for easier parsing. [#4589]([#1462](https://github.com/yugabyte/yugabyte-db/issues/4589)
-- Add `yugabyted destroy` command. [#3872]([#3849](https://github.com/yugabyte/yugabyte-db/issues/3872)
-- Change logic used to determine if the load balancer is idle. [#4707](https://github.com/yugabyte/yugabyte-db/issues/4707)
-- Default to IPv4 addresses for DNS resolution and local addresses. [#4851](https://github.com/yugabyte/yugabyte-db/issues/4293)
-- Add a Grafana dashboard for YugabyteDB. [#4725](https://github.com/yugabyte/yugabyte-db/issues/4725)
-- [CDC] Check for table properties equivalence when comparing schemas in 2DC setups and ignore properties that don't need to be the same. [#4233](https://github.com/yugabyte/yugabyte-db/issues/4233)
-- [DocDB] Allow multiple indexes to backfill or delete simultaneously. [#2784](https://github.com/yugabyte/yugabyte-db/issues/2784)
-- [DocDB] Transition to new leader gracefully during a leader stepdown. When a leader stepdown happens with no new leader candidate specified in the stepdown request, the peer simply steps down leaving the group with no leader until regular heartbeat timeouts are triggered. This change makes it so that the leader attempts to transition to the most up-to-date peer, if possible. [#4298](https://github.com/yugabyte/yugabyte-db/issues/4298)
-- Update [`yb-admin list_snapshots`](../../admin/yb-admin/#list-snapshots) command to use `not_show_restored` option to exclude fully RESTORED entries. [#4351](ttps://github.com/yugabyte/yugabyte-db/issues/4351)
-- [DocDB] Clean up leftover snapshot files from failed snapshots that resulted in remote bootstrap getting stuck in a failure loop. [#4745](https://github.com/yugabyte/yugabyte-db/issues/4745)
-- [DocDB] Clean up metadata in memory after deleting snapshots. [#4887](https://github.com/yugabyte/yugabyte-db/issues/4877)
-- [DocDB] Fix snapshots getting stuck in retry loop with deleted table. [#4610](https://github.com/yugabyte/yugabyte-db/issues/4877) and [#4302](https://github.com/yugabyte/yugabyte-db/issues/4302)
-- [DocDB] When using [`yb-admin master_leader_stepdown`](../../admin/yb-admin/#master-leader-stepdown), specifying a new leader is now optional. [#4722](https://github.com/yugabyte/yugabyte-db/issues/4722)
-- [DocDB] Add breakdown of disk space on TServer dashboard. [#4767](https://github.com/yugabyte/yugabyte-db/issues/4767)
-- [DocDB] Suppress `yb-admin` from logging harmless "Failed to schedule invoking callback on response" warning. [#4131](https://github.com/yugabyte/yugabyte-db/issues/4131)
-- [DocDB] Allow specifying IPv6 addresses in bind addresses. [#3644](https://github.com/yugabyte/yugabyte-db/issues/3644)
-- [DocDB] Fix TS Heartbeater can get stuck if master network connectivity breaks. [#4838](https://github.com/yugabyte/yugabyte-db/issues/4838)
-- [DocDB] Improve protection against hitting hard memory limit when follower tablet peers are lagging behind leaders on a node. (for example, node downtime because of yb-tserver restart). [#2563](https://github.com/yugabyte/yugabyte-db/issues/2563)
-- `yugabyted` `--bind_ip` flag renamed to `--listen`. [#4960](https://github.com/yugabyte/yugabyte-db/issues/4960)
-- Fix malformed URL for ycql rpcz when clicking **YCQL Live Ops** link in the YB-TServer utilities page. [#4886](https://github.com/yugabyte/yugabyte-db/issues/4866)
-- Fix export name for YCQL metrics. [#4955](https://github.com/yugabyte/yugabyte-db/issues/4955)
-- Fix YB-Master UI to show correct number of tablets for colocated tables. [#4699](https://github.com/yugabyte/yugabyte-db/issues/4699)
+**Build:** `2.2.2.0-b15`
 
-### Yugabyte Platform
+#### Downloads (binaries)
 
-- Add option to [back up and restore YSQL databases](../../) and universe-level transactional backups. [#3849](https://github.com/yugabyte/yugabyte-db/issues/3849)
-- On the **Universes** page, the **Replication** tab displays by default and adds default state when replication lag metric query returns no data.
-- Add **Replication** tab to Universe overview tab list if enabled and query for replication lag metrics. [#]
-- Add replication lag metrics `async_replication_sent_lag_micros` (last applied time on producer - last polled for record) and `async_replication_committed_lag_micros` (last applied time on producer - last applied time on consumer) for 2DC replication and export to Prometheus. [#2154](https://github.com/yugabyte/yugabyte-db/issues/2154)
-- Retrieve IAM Instance Profile Credentials for backups. This retrieves the `AccessKeyId` and `SecretAccessKey` and set these in the configuration so that data nodes inherit the required IAM permissions to access S3. [#3451](https://github.com/yugabyte/yugabyte-db/issues/3451) and [#4900](https://github.com/yugabyte/yugabyte-db/issues/4900)
-- Add option to create a backup of multiple YCQL transactional tables. [#4540](https://github.com/yugabyte/yugabyte-db/issues/4540)
-- Add support for c5d instance types. [#4914](https://github.com/yugabyte/yugabyte-db/issues/4914)
-- Add support for installing epel-release in Amazon Linux. [#4561](https://github.com/yugabyte/yugabyte-db/issues/4561)
-- Fixed requested TLS client certificate generated with expired date and ysqlsh fails to connect. [#4732](https://github.com/yugabyte/yugabyte-db/issues/4732)
-- Fixed universe fails to create if user-supplied certificate is selected. [#4733](https://github.com/yugabyte/yugabyte-db/issues/4733)
-- Implement OAuth2/SSO authentication for Yugabyte Platform sign-in. [#4633](https://github.com/yugabyte/yugabyte-db/issues/4644) and [#4420](https://github.com/yugabyte/yugabyte-db/issues/4420)
-- Add backup and restore options for YSQL tables and universe-level transactional backups. [#3849](https://github.com/yugabyte/yugabyte-db/issues/3849)
-- Retrieve IAM Instance Profile Credentials for backups. This retrieves the `AccessKeyId` and `SecretAccessKey` and set these in the configuration so that data nodes inherit the required IAM permissions to access S3. [#4900](https://github.com/yugabyte/yugabyte-db/issues/4900)
-- In the **Health and Alerting** tab of the Admin Console, the Username and Password fields in **Custom SMTP Configuration** are now optional. [#4952](https://github.com/yugabyte/yugabyte-db/issues/4952)
-- Fix password reset in customer profile page. [#4666](https://github.com/yugabyte/yugabyte-db/issues/4666) and [#3909](https://github.com/yugabyte/yugabyte-db/issues/3909)
-- Fix **Backups** page not loading when there is a pending task. [#4754](https://github.com/yugabyte/yugabyte-db/issues/4754)
-- Change UI text displaying "GFlag" to "Flag" in the Admin Console. [#4659](https://github.com/yugabyte/yugabyte-db/issues/4659)
+- [macOS](https://downloads.yugabyte.com/yugabyte-2.2.2.0-darwin.tar.gz)
+- [Linux](https://downloads.yugabyte.com/yugabyte-2.2.2.0-linux.tar.gz)
+- Docker: `docker pull yugabytedb/yugabyte:2.2.2.0-b15`
 
-{{< note title="Note" >}}
+#### YSQL
 
-Prior to version 2.0, YSQL was still in beta. As a result, the 2.0 release included a backward-incompatible file format change for YSQL. If you have an existing cluster running releases earlier than 2.0 with YSQL enabled, then you will not be able to upgrade to version 2.0+. Export from your existing cluster and then import into a new cluster (v2.0 or later) to use existing data.
+- Fix failed backup if restored table was deleted before restoration. [#5274](https://github.com/yugabyte/yugabyte-db/issues/5274)
+- Newly elected YB-Master leader should pause before initiating load balancing. [#5221](https://github.com/yugabyte/yugabyte-db/issues/5221)
+- Fix backfilling to better handle large indexed table tablets. [#5031](https://github.com/yugabyte/yugabyte-db/issues/5031)
+- Fix `DROP DATABASE` statement should work with databases deleted on YB-Master. [#4710](https://github.com/yugabyte/yugabyte-db/issues/4710)
+- For non-prepared statements, optimize `pg_statistic` system table lookups. [#5051](https://github.com/yugabyte/yugabyte-db/issues/5051)
+- [CDC] Avoid periodic querying of the `cdc_state` table for xDC metrics if there are no replication streams enabled. [#5173](https://github.com/yugabyte/yugabyte-db/issues/5173)
 
-{{< /note >}}
+#### YCQL
 
-## v2.2.0 []
+- Implement DNS cache to significantly reduce CPU loads due to a large number of DNS resolution requests (especially for YCQL connections). Adds [`dns_cache_expiration_ms`](../../reference/configuration/yb-master/#dns-cache-expiration-ms) flag (default is 1 minute). [#5201](https://github.com/yugabyte/yugabyte-db/issues/5201)
+- Fixed incorrect names de-mangling in index creation from `CatalogManager::ImportSnapshot()`. [#5157](https://github.com/yugabyte/yugabyte-db/issues/5157)
+- Fixed crashes when inserting literals containing newline characters. [#5270](https://github.com/yugabyte/yugabyte-db/issues/5270)
+- Reuse CQL parser between processors to improve memory usage. Add new `cql_processors_limit` flag to control processor allocation. [#5057](https://github.com/yugabyte/yugabyte-db/issues/5057)
 
+#### Core database
 
-**Released:** July 15, 2020 (2.2.0.0-b80).
+- Fix `yugabyted` fails to start UI due to class binding failure. [#5069](https://github.com/yugabyte/yugabyte-db/issues/5069)
+- Show hostnames in YB-Master and YB-TServer Admin UI when hostnames are specified in `--webserver_interface`, `rpc_bind_addresses`, and `server_broadcast_addresses` flags. [#5002](https://github.com/yugabyte/yugabyte-db/issues/5002)
+- Skip tablets without intents during commits, for example, the case of an update of a non-existing row. [#5321](https://github.com/yugabyte/yugabyte-db/issues/5321)
+- Fix log spew when applying unknown transaction and release a mutex as soon as possible when transaction is not found. [#5315](https://github.com/yugabyte/yugabyte-db/issues/5315)
+- Fix snapshots cleanup when snapshots removed before restart. [#5337](https://github.com/yugabyte/yugabyte-db/issues/5337)
+- Replace `SCHECK` with `LOG(DFATAL)` when checking for restart-safe timestamps in WAL entries. [#5314](https://github.com/yugabyte/yugabyte-db/issues/5314)
+- Replace all CHECK in the load balancer code with `SCHECK` or `RETURN_NOT_OK`. [#5182](https://github.com/yugabyte/yugabyte-db/issues/5182)
+- Implement DNS cache to significantly reduce CPU loads due to a large number of DNS resolution requests (especially for YCQL connections). Adds YB-Master [`dns_cache_expiration_ms`](../../reference/configuration/yb-master/#dns-cache-expiration-ms) flag (default is 1 minute). [#5201](https://github.com/yugabyte/yugabyte-db/issues/5201)
+- Avoid duplicate DNS requests when handling `system.partitions` table requests. [#5225](https://github.com/yugabyte/yugabyte-db/issues/5225)
+- Fix leader load balancing can cause `CHECK` failures if stepdown task is pending on next run. Sets global leader balance threshold while allowing progress to be made across tables. Adds new YB-Master [`load_balancer_max_concurrent_moves_per_table`](../../reference/configuration/yb-master/#load-balancer-max-concurrent-moves-per-table) flag to limit number of leader moves per table. [#5181](https://github.com/yugabyte/yugabyte-db/issues/5181) and [#5021](https://github.com/yugabyte/yugabyte-db/issues/5021)
+- Set the async `YBClient` initialization future in `TabletPeer` constructor to ensure tablet bootstrap logic can resolve transaction statuses. [#5215](https://github.com/yugabyte/yugabyte-db/issues/5215)
+- Handle write operation failures during tablet bootstrap. [#5224](https://github.com/yugabyte/yugabyte-db/issues/5224)
+- Drop index upon failed backfill. [#5144](https://github.com/yugabyte/yugabyte-db/issues/5144)  [#5161](https://github.com/yugabyte/yugabyte-db/issues/5161)
+- Fix WAL overwriting by new leader and replay of incorrect entries on tablet bootstrap. [#5003](https://github.com/yugabyte/yugabyte-db/issues/5003) [#3759](https://github.com/yugabyte/yugabyte-db/issues/3759) [#4983](https://github.com/yugabyte/yugabyte-db/issues/4983)
+- Avoid taking unique lock when starting lookup request. [#5059](https://github.com/yugabyte/yugabyte-db/issues/5059)
+- Set 2DC lag metrics to `0` if not the leader and if the replication is deleted. [#5113](https://github.com/yugabyte/yugabyte-db/issues/5113)
+- Set the table to ALTERING state when `fully_*` is populated. [#5139](https://github.com/yugabyte/yugabyte-db/issues/5139)
+- `Not the leader` errors should not cause a replica to be marked as failed. [#5072](https://github.com/yugabyte/yugabyte-db/issues/5072)
+- Use difference between follower's hybrid time and its safe time as a measure of staleness. [#4868](https://github.com/yugabyte/yugabyte-db/issues/4868)
 
-{{< note title="Important" >}}
+#### Yugabyte Platform
 
-Starting with v2.2.0, Yugabyte release versions are numbered based on an even/odd release versioning. For more details, see the following:
+- Add **Master** section below **Tablet Server** section in **Metrics** page. [#5233](https://github.com/yugabyte/yugabyte-db/issues/5233)
+- Add `rpc_connections_alive` metrics for YSQL and YCQL APIs. [#5223](https://github.com/yugabyte/yugabyte-db/issues/5223)
+- Fix restore payload when renaming table to include keyspace. Disable keyspace field when restoring universe backup. [#5178](https://github.com/yugabyte/yugabyte-db/issues/5178)
+- Pass in `ssh_user` to air-gap provision script and add to on-premise template. [#5132](https://github.com/yugabyte/yugabyte-db/issues/5132)
+- Add the `--recursive` flag to AZCopy for multi-table restore. [#5163](https://github.com/yugabyte/yugabyte-db/issues/5163)
+- Fix transactional backup with specified tables list by including keyspace in payload. [#5149](https://github.com/yugabyte/yugabyte-db/issues/5149)
+- Fix undefine object property error when Prometheus is unavailable and navigating to the **Replication** tab. [#5146](https://github.com/yugabyte/yugabyte-db/issues/5146)
+- Backups should take provider-level environment variables, including home directory. [#5064](https://github.com/yugabyte/yugabyte-db/issues/5064)
+- Add hostname and display in the Nodes page along with node name and IP address. [#4760](https://github.com/yugabyte/yugabyte-db/issues/4760)
+- Support option of DNS names instead of IP addresses for nodes. Add option in Admin UI to choose between using hostnames or IP addresses for on-premises provider. [#4951](https://github.com/yugabyte/yugabyte-db/issues/4951) [#4950](https://github.com/yugabyte/yugabyte-db/issues/4950)
+- Disable glob before running cleanup of old log files using `zip_purge_yb_logs.sh`. Fixes issue on Red Hat. [#5169](https://github.com/yugabyte/yugabyte-db/issues/5169)
+- Fix Replication graph units and missing graph in **Replication** tab when metrics exist. [#5423](https://github.com/yugabyte/yugabyte-db/issues/5423)
 
-- [Release versioning](../../versioning) – Includes details on stable and latest versioning.
-- [Supported and planned releases](../../releases-overview) – Information on supported and latest releases.
+### v2.2.0 - July 15, 2020
 
-{{< /note >}}  
+**Build:** `2.2.0.0-b80`
 
-## Downloads
+#### Downloads - binaries
 
-### Binaries
+- [macOS](https://downloads.yugabyte.com/yugabyte-2.2.0.0-darwin.tar.gz)
+- [Linux](https://downloads.yugabyte.com/yugabyte-2.2.0.0-linux.tar.gz)
+- Docker: `docker pull yugabytedb/yugabyte:2.2.0.0-b80`
 
-<a class="download-binary-link" href="https://downloads.yugabyte.com/yugabyte-2.2.0.0-darwin.tar.gz">
-  <button>
-    <i class="fab fa-apple"></i><span class="download-text">macOS</span>
-  </button>
-</a>
-&nbsp; &nbsp; &nbsp;
-<a class="download-binary-link" href="https://downloads.yugabyte.com/yugabyte-2.2.0.0-linux.tar.gz">
-  <button>
-    <i class="fab fa-linux"></i><span class="download-text">Linux</span>
-  </button>
-</a>
-<br />
-
-### Docker
-
-```sh
-docker pull yugabytedb/yugabyte:2.2.0.0-b80
-```
-
-## Notable new features and enhancements
-
-## YSQL
-
-### Transactional distributed backups
-
-YugabyteDB now supports [distributed backup and restore of YSQL databases](../../manage/backup-restore/snapshot-ysql/), including backup of all tables in a database. [#1139](https://github.com/yugabyte/yugabyte-db/issues/1139) and [#3849](https://github.com/yugabyte/yugabyte-db/issues/3849)
-
-### Online index backfills
-
-- YugabyteDB can now build indexes on non-empty tables while online, without failing other concurrent writes. When you add a new index to a table that is already populated with data, you can now use the YSQL [`CREATE INDEX`](../../api/ysql/commands/ddl_create_index/#semantics) statement to enable building these indexes in an online manner, without requiring downtime. For details how online backfill of indexes works, see the [Online Index Backfill](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/online-index-backfill.md) design document.
-- Backfilling an index while online is disable by default. To enable online index backfilling, set the `yb-tserver` [`--ysql_disable_index_backfill`](../../reference/configuration/yb-tserver/#ysql-disable-index-backfill) flag to `false` when starting YB-TServers. Note: Do not use this flag in a production cluster yet. For details on how this works, see [Online Index Backfill](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/online-index-backfill.md)
-
-### Colocated tables
-
-Database-level colocation for YSQL, which started as a beta feature in the 2.1 release, is **now generally available** in the 2.2 release. Traditional RDBMS modeling of parent-child relationships as foreign key constraints can lead to high-latency `JOIN` queries in a geo-distributed SQL database. This is because the tablets (or shards) containing the child rows might be hosted in nodes, availability zones, and regions different from the tablets containing the parent rows. By using [colocated tables](../../architecture/docdb-sharding/colocated-tables), you can let a single tablet be shared across all tables. Colocation can also be at the overall database level, where all tables of a single database are located in the same tablet and managed by the same Raft group.  Note that tables that you do not want to reside in the overall database’s tablet because of the expectation of large data volume can override the feature at table creation time and hence get independent tablets for themselves.
-
-What happens when the “colocation” tablet containing all the tables of a database becomes too large and starts impacting performance? Check out [automatic tablet splitting [BETA]](#automatic-tablet-splitting-beta).
-
-### Deferred constraints on foreign keys
-
-Foreign keys in YSQL now support the [DEFERRABLE INITIALLY IMMEDIATE](../../api/ysql/commands/ddl_create_table/#foreign-key) and [DEFERRABLE INITIALLY DEFERRED](../../api/ysql/commands/ddl_create_table/#foreign-key) clauses. Work on deferring additional constraints, including those for primary keys, is in progress. 
-
-Application developers often declare constraints that their data must obey, leaving it to relational databases to enforce the rules. The end result is simpler application logic, lower error probability, and higher developer productivity. Automatic constraint enforcement is a powerful feature that should be leveraged whenever possible. There are times, however, when you need to temporarily defer enforcement. An example is during the data load of a relational schema where there are cyclic foreign key dependencies. Data migration tools usually defer the enforcement of foreign key dependencies to the end of a transaction by which data for all foreign keys would ideally be present.  This should also allow YSQL to power Django apps.
-
-### yugabyted for single-node clusters
-
-The `yugabyted` server is now out of beta for single-node deployments. New users can start using YugabyteDB without needing to understand the underlying architectures acts as a parent server, reducing the need to understand data management by YB-TServers and metadata management by YB-Masters.
-
-See it in action by following the updated [Quick start](../../quick-start). For details, see [`yugabyted`](../../reference/configuration/yugabyted) in the Reference section.
-
-### Automatic tablet splitting [BETA]
-
-- YugabyteDB now supports automatic tablet splitting, resharding your data by changing the number of tablets at runtime. For details, see [Tablet splitting](../../architecture/docdb-sharding/tablet-splitting) and [Automatic Resharding of Data with Tablet Splitting](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/docdb-automatic-tablet-splitting.md). [#1004](https://github.com/yugabyte/yugabyte-db/issues/1004), [#1461](https://github.com/yugabyte/yugabyte-db/issues/1461), and [#1462](https://github.com/yugabyte/yugabyte-db/issues/1462)
-- To enable automatic tablet splitting, use the new `yb-master` [`--tablet_split_size_threshold_bytes`](../../reference/configuration/yb-master/#tablet-split-size-threshold-bytes) flag to specify the size when tablets should split.
-
-### TPC-C benchmarking
-
-New results are now available for benchmarking the performance of the YSQL API using the TPC-C suite. For the new TPC-C results and details on performing your own benchmark tests to evaluate YugabyteDB, see [TPC-C](../../benchmark/tpcc-ysql/).
-
-### Other notable changes
+#### YSQL
 
 - Support presplitting using [CREATE INDEX...SPLIT INTO](../../api/ysql/commands/ddl_create_index/#split-into) for range-partitioned table indexes. For details, see [Presplitting](../../architecture/docdb-sharding/tablet-splitting/#presplitting) [#4235](https://github.com/yugabyte/yugabyte-db/issues/4235)
 - Fix crash for nested `SELECT` statements that involve null pushdown on system tables. [#4685](https://github.com/yugabyte/yugabyte-db/issues/4685)
@@ -392,34 +187,14 @@ New results are now available for benchmarking the performance of the YSQL API u
 - Add error messages to table schema version mismatch errors so they are more understandable. [#4810]
 - Increase the default DDL operations timeout to 120 seconds to allow for multi-region deployments, where a CREATE DATABASE statement can take longer than one minute. [#4762](https://github.com/yugabyte/yugabyte-db/issues/4762)
 
-## YCQL
-
-### Transactional distributed backups
-
-YugabyteDB supports [distributed backup and restore of YCQL databases and tables](../../manage/backup-restore/snapshot-ysql/). [#1139](https://github.com/yugabyte/yugabyte-db/issues/1139) and [#3849](https://github.com/yugabyte/yugabyte-db/issues/3849)
-
-### Online index backfills
-
-- YugabyteDB can now build indexes on non-empty tables while online, without failing other concurrent writes. When you add a new index to a table that is already populated with data, you can now use the YCQL [CREATE INDEX](../../api/ycql/ddl_create_index/#synopsis) statement to enable building these indexes in an online manner, without requiring downtime. For details how online backfill of indexes works, see the [Online Index Backfill](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/online-index-backfill.md) design document.
-- In YCQL, backfilling an index while online is enabled by default. To disable, set the `yb-tserver` [`--ycql_disable_index_backfill`](../../reference/configuration/yb-tserver/#ycql-disable-index-backfill) flag to `false` when starting YB-TServers. For details on how online index backfill works, see [Online Index Backfill](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/online-index-backfill.md). [#2301](https://github.com/yugabyte/yugabyte-db/issues/2301) and [#4708](https://github.com/yugabyte/yugabyte-db/issues/4708)
-
-### Online schema changes for YCQL [BETA]
-
-Most applications have a need to frequently evolve the database schema, while simultaneously ensuring zero downtime during those schema change operations. Therefore, there is a need for schema migrations (which involve DDL operations) to be safely run in a concurrent and online manner alongside foreground client operations. In case of a failure, the schema change should be rolled back and not leave the database in a partially modified state. With the 2.2 release, not only the overall DocDB framework for supporting such schema changes in an online and safe manner has been introduced but also this feature is now available in beta in the context of YCQL using the [`ALTER TABLE`](../../api/ycql/ddl_alter_table/) statement.
-
-### Automatic tablet splitting [BETA]
-
-- YugabyteDB now supports automatic tablet splitting at runtime by changing the number of tablets based on size thresholds. For details, see [Tablet splitting](../../architecture/docdb-sharding/tablet-splitting) and [Automatic Resharding of Data with Tablet Splitting](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/docdb-automatic-tablet-splitting.md). [#1004](https://github.com/yugabyte/yugabyte-db/issues/1004), [#1461](https://github.com/yugabyte/yugabyte-db/issues/1461), and [#1462](https://github.com/yugabyte/yugabyte-db/issues/1462)
-- To enable automatic tablet splitting, use the new `yb-master` [`--tablet_split_size_threshold_bytes`](../../reference/configuration/yb-master/#tablet-split-size-threshold-bytes) flag to specify the size when tablets should split.
-
-### Other notable changes
+#### YCQL
 
 - Throttle YCQL calls when soft memory limit is reached. Two new flags, `throttle_cql_calls_on_soft_memory_limit` and `throttle_cql_calls_policy` can be used to control it. [#4973](https://github.com/yugabyte/yugabyte-db/issues/4973)
 - Implements a password cache to allow connections to be created more quickly from recently used accounts. Helps reduce high CPU usage when using YCQL authorization. [#4596](https://github.com/yugabyte/yugabyte-db/issues/4596)
 - Fix `column doesn't exist` error when an index is created on a column which is a prefix of another column. [#4881](https://github.com/yugabyte/yugabyte-db/issues/4881)
 - Fix crashes when using ORDER BY for non-existent column with index scan. [#4908](https://github.com/yugabyte/yugabyte-db/issues/4908)
 
-## System improvements
+#### Core database
 
 - Add HTTP endpoints for determining master leadership and returning information on masters. [#2606](https://github.com/yugabyte/yugabyte-db/issues/2606)
   - `<web>/api/v1/masters`: Returns all master statuses.
@@ -449,7 +224,7 @@ Most applications have a need to frequently evolve the database schema, while si
 - Fix export name for YCQL metrics. [#4955](https://github.com/yugabyte/yugabyte-db/issues/4955)
 - Fix YB-Master UI to show correct number of tablets for colocated tables. [#4699](https://github.com/yugabyte/yugabyte-db/issues/4699)
 
-## Yugabyte Platform
+#### Yugabyte Platform
 
 - Add option to [back up and restore YSQL databases](../../) and universe-level transactional backups. [#3849](https://github.com/yugabyte/yugabyte-db/issues/3849)
 - On the **Universes** page, the **Replication** tab displays by default and adds default state when replication lag metric query returns no data.
@@ -468,9 +243,3 @@ Most applications have a need to frequently evolve the database schema, while si
 - Fix password reset in customer profile page. [#4666](https://github.com/yugabyte/yugabyte-db/issues/4666) and [#3909](https://github.com/yugabyte/yugabyte-db/issues/3909)
 - Fix **Backups** page not loading when there is a pending task. [#4754](https://github.com/yugabyte/yugabyte-db/issues/4754)
 - Change UI text displaying "GFlag" to "Flag" in the Admin Console. [#4659](https://github.com/yugabyte/yugabyte-db/issues/4659)
-
-{{< note title="Note" >}}
-
-Prior to version 2.0, YSQL was still in beta. As a result, the 2.0 release included a backward-incompatible file format change for YSQL. If you have an existing cluster running releases earlier than 2.0 with YSQL enabled, then you will not be able to upgrade to version 2.0+. Export from your existing cluster and then import into a new cluster (v2.0 or later) to use existing data.
-
-{{< /note >}}

--- a/docs/content/latest/releases/whats-new/stable-releases.md
+++ b/docs/content/latest/releases/whats-new/stable-releases.md
@@ -1,7 +1,7 @@
 ---
-title: What's new in 2.2
-headerTitle: What's new in 2.2
-linkTitle: What's new in 2.2
+title: What's new in 2.2 (stable)
+headerTitle: What's new in 2.2 (stable)
+linkTitle: What's new in 2.2 (stable)
 description: Enhancements, changes, and resolved issues in the recommended stable release series.
 headcontent: Features, enhancements, and resolved issues in the recommended stable release series.
 image: /images/section_icons/quick_start/install.png
@@ -12,13 +12,13 @@ menu:
   latest:
     parent: whats-new
     identifier: stable-releases
-    weight: 2585 
+    weight: 2586 
 ---
 
 Included here are the release notes for all releases in the `2.3` latest release series. The `2.3` latest release series include the following releases:
 
-- [v2.2.2.0 (Released Sep 15, 2020)](#v2-3-1-0-2020-09-15)
-- [v2.2.0.0 (Released Sep 08, 2020)](#v2-3-0-0-2020-09-08)
+- [v2.2.2 (August 19, 2020)](#v2-2-2-august-19-2020)
+- [v2.2.0 (July 15, 2020)](#v2-2-0-july-15-2020)
 
 {{< note title="Important" >}}
 

--- a/docs/content/stable/_index.html
+++ b/docs/content/stable/_index.html
@@ -1,12 +1,18 @@
 ---
 title: YugabyteDB documentation
 description: YugabyteDB documentation is the best source to learn the most in-depth information about YugabyteDB.
-headcontent: v2.2 — the stable version
+headcontent: v2.2 — the recommended stable release series
 type: list
 image: /images/ybsymbol_original.png
 weight: 1
 block_indexing: true
 ---
+
+{{< note title="New release versioning" >}}
+
+Starting with v2.2.0, Yugabyte release versions follow a [new release versioning convention](../latest/releases/versioning). The latest release series, denoted by `MAJOR.ODD`, incrementally introduces new features and changes and is intended for development and testing only. Patch releases, denoted by `MAJOR.ODD.PATCH` versioning, can include new features and changes that might break backwards compatibility. For more information, see [Supported and planned releases](../latest/releases/releases-overview).
+
+{{< /note >}}
 
 <div class="row">
   <div class="col-12 col-md-6">


### PR DESCRIPTION
Adds changes to the Releases section:
- Updates content of the pages: "Release versioning" and Supported and planned releases"
- Reorganizes the What's new to be a section with two pages:
  - "What's new in the 2.3 latest release series"
     - includes sections for "Notable features and changes" and "Release notes"
  - "What's new in the 2.2 stable release series"
    - includes sections for "Notable features and changes" and "Release notes"
- Notes added to top of default documentation pages for v2.2 and v2.3.
