### PR TITLE
[Docs][#5736] Fix version listed when on page that is not the latest

### DIFF
--- a/docs/layouts/_default/list.html
+++ b/docs/layouts/_default/list.html
@@ -37,7 +37,7 @@
 				{{ if ne (index $urlArray 1) "latest" }}
 				<div class="admonition warning">
 					<p class="admonition-title">Attention</p>
-					This page documents an earlier version. <a href="{{ $latestUrl }}">Go to the latest (v2.2) version.</a>
+					This page documents an earlier version. <a href="{{ $latestUrl }}">Go to the latest (v2.3) version.</a>
 				</div>
 				{{ end }}
 

--- a/docs/layouts/_default/single.html
+++ b/docs/layouts/_default/single.html
@@ -35,7 +35,7 @@
 						{{ if ne (index $urlArray 1) "latest" }}
 						<div class="admonition warning">
 							<p class="admonition-title">Attention</p>
-							This page documents an earlier version. <a href="{{ $latestUrl }}">Go to the latest (v2.2)version.</a>
+							This page documents an earlier version. <a href="{{ $latestUrl }}">Go to the latest (v2.3) version.</a>
 						</div>
 						{{ end }}
 


### PR DESCRIPTION
The version listed should be "Go to the latest version (2.3)" instead of 2.2