### PR TITLE
Added relative path support for base_dir in yugabyted

### DIFF
--- a/bin/yugabyted
+++ b/bin/yugabyted
@@ -1117,7 +1117,7 @@ class ControlScript(object):
 
         default_base_dir = os.path.join(YUGABYTE_DIR, "var")
         default_conf_path = os.path.join(default_base_dir, "conf", "{}.conf".format(SCRIPT_NAME))
-        base_dir = args.base_dir or default_base_dir
+        base_dir = os.path.abspath(args.base_dir) if args.base_dir else default_base_dir
         base_dir_conf = ''
         if args.base_dir:
             base_dir_conf = os.path.join(base_dir, "conf", "{}.conf".format(SCRIPT_NAME))


### PR DESCRIPTION
### Summary:

- Added relative path support for `--base_dir` flag in `yugabyted`.

### Test Plan:

1. With `--base_dir`
```sh
ubuntu@ip-172-31-12-205:~/yugabyte-2.3.1.0$ bin/yugabyted start --daemon=true --ui=false --base_dir=../base_db/ 
Starting yugabyted...
✅ System checks           

+--------------------------------------------------------------------------------------------------+
|                                            yugabyted                                             |
+--------------------------------------------------------------------------------------------------+
| Status              : Running                                                                    |
| Web console         : http://127.0.0.1:7000                                                      |
| JDBC                : jdbc:postgresql://127.0.0.1:5433/yugabyte?user=yugabyte&password=yugabyte  |
| YSQL                : bin/ysqlsh   -U yugabyte -d yugabyte                                       |
| YCQL                : bin/ycqlsh   -u cassandra                                                  |
| Data Dir            : /home/ubuntu/base_db/data                                                  |
| Log Dir             : /home/ubuntu/base_db/logs                                                  |
| Universe UUID       : 0c4b0775-bd93-469c-b9a5-dcaf078fde7f                                       |
+--------------------------------------------------------------------------------------------------+
🚀 yugabyted started successfully! To load a sample dataset, try 'yugabyted demo'.
🎉 Join us on Slack at https://www.yugabyte.com/slack
👕 Claim your free t-shirt at https://www.yugabyte.com/community-rewards/

ubuntu@ip-172-31-12-205:~/yugabyte-2.3.1.0$ cat ../base_db/conf/yugabyted.conf 
{
    "tserver_webserver_port": 9000, 
    "master_rpc_port": 7100, 
    "data_dir": "/home/ubuntu/base_db/data", 
    "callhome": true, 
    "master_uuid": "79b40e0f485e4136b1976be3d79467f9", 
    "universe_uuid": "0c4b0775-bd93-469c-b9a5-dcaf078fde7f", 
    "webserver_port": 7200, 
    "ysql_port": 5433, 
    "tserver_flags": "", 
    "master_webserver_port": 7000, 
    "node_uuid": "8dd56759-40cf-4384-acaf-9229634a78ba", 
    "log_dir": "/home/ubuntu/base_db/logs", 
    "master_flags": "", 
    "polling_interval": "5", 
    "join": "", 
    "ycql_port": 9042, 
    "listen": "0.0.0.0", 
    "tserver_uuid": "156adfd8c21d487d8b03690c04641be8", 
    "tserver_rpc_port": 9100
}ubuntu@ip-172-31-12-205:~/yugabyte-2.3.1.0$
```
2. Without `--base_dir`
`ubuntu@ip-172-31-12-205:~/yugabyte-2.3.1.0$ bin/yugabyted start --daemon=true --ui=false`

### Fixes:
https://github.com/yugabyte/yugabyte-db/issues/5063