### PR TITLE
docs: update operator related pages according to file name changes

### DIFF
--- a/docs/content/latest/deploy/kubernetes/single-zone/oss/operator-hub.md
+++ b/docs/content/latest/deploy/kubernetes/single-zone/oss/operator-hub.md
@@ -81,7 +81,7 @@ yugabyte-operator.v0.0.1   Yugabyte Operator   0.0.1                Succeeded
 3. Create YugabyteDB Custom Resource to create YugabyteDB cluster using operator deployed above
 
 ```sh
-$ kubectl create namespace yb-operator && kubectl create -f https://raw.githubusercontent.com/yugabyte/yugabyte-operator/master/deploy/crds/yugabyte_v1alpha1_ybcluster_cr.yaml
+$ kubectl create namespace yb-operator && kubectl create -f https://raw.githubusercontent.com/yugabyte/yugabyte-operator/master/deploy/crds/yugabyte.com_v1alpha1_ybcluster_cr.yaml
 ```
 
 Watch your YugabyteDB cluster pods come up.
@@ -122,7 +122,7 @@ To remove the YugabyteDB cluster and operator resources, run the following comma
 **NOTE:** This will destroy your database and delete all of its data.
 
 ```console
-kubectl delete -f https://raw.githubusercontent.com/yugabyte/yugabyte-operator/master/deploy/crds/yugabyte_v1alpha1_ybcluster_cr.yaml
+kubectl delete -f https://raw.githubusercontent.com/yugabyte/yugabyte-operator/master/deploy/crds/yugabyte.com_v1alpha1_ybcluster_cr.yaml
 kubectl delete namespace yb-operator
 kubectl delete -f https://operatorhub.io/install/yugabyte-operator.yaml
 ```

--- a/docs/content/latest/deploy/kubernetes/single-zone/oss/yugabyte-operator.md
+++ b/docs/content/latest/deploy/kubernetes/single-zone/oss/yugabyte-operator.md
@@ -45,18 +45,18 @@ showAsideToc: true
   </li>
 </ul>
 
-Create and manage a YugabyteDB cluster with a Kubernetes native custom resource `ybcluster.yugabyte.com`. The custom resource definition and other necessary specifications can be found in [YugabyteDB k8s operator repository](https://github.com/yugabyte/yugabyte-k8s-operator/). This operator currently provides more configuration flags as compared to the Rook operator. The Rook operator, in near future, will get these flags too. See full list of configuration flags [here](#configuration-flags).
+Create and manage a YugabyteDB cluster with a Kubernetes native custom resource `ybcluster.yugabyte.com`. The custom resource definition and other necessary specifications can be found in [YugabyteDB operator repository](https://github.com/yugabyte/yugabyte-operator/). This operator currently provides more configuration flags as compared to the Rook operator. The Rook operator, in near future, will get these flags too. See full list of configuration flags [here](#configuration-flags).
 
 ## Prerequisites
 
-Clone the [yugabyte-k8s-operator](https://github.com/yugaByte/yugabyte-k8s-operator/) repository on your local computer. Change into the cloned directory and follow instructions below.
+Clone the [yugabyte-operator](https://github.com/yugabyte/yugabyte-operator) repository on your local computer. Change into the cloned directory and follow instructions below.
 
 ## Deploy a YugabyteDB cluster with this operator
 
 To create a YugabyteDB cluster, first you need to register the custom resource that would represent YugabyteDB cluster: `ybclusters.yugabyte.com`.
 
 ```sh
-kubectl create -f deploy/crds/yugabyte_v1alpha1_ybcluster_crd.yaml
+kubectl create -f deploy/crds/yugabyte.com_ybclusters_crd.yaml
 ```
 
 Setup RBAC for operator and create the operator itself. Run the following command, from root of the repository, to do the same.
@@ -74,7 +74,7 @@ kubectl -n yb-operator get po,deployment
 Finally create an instance of the custom resource with which the operator would create a YugabyteDB cluster.
 
 ```sh
-kubectl create -f deploy/crds/yugabyte_v1alpha1_ybcluster_cr.yaml
+kubectl create -f deploy/crds/yugabyte.com_v1alpha1_ybcluster_cr.yaml
 ```
 
 Verify that the cluster is up and running with the following command. You should see 3 pods each for YB-Master and YB-TServer services.


### PR DESCRIPTION
- The following file names are changed as part of the SDK update (https://github.com/yugabyte/yugabyte-operator/pull/17), this
  commit updates the related documentation pages.
- yugabyte_v1alpha1_ybcluster_crd.yaml =>
  yugabyte.com_ybclusters_crd.yaml
- yugabyte_v1alpha1_ybcluster_cr.yaml =>
  yugabyte.com_v1alpha1_ybcluster_cr.yaml
- yugabyte_v1alpha1_ybcluster_full_cr.yaml =>
  yugabyte.com_v1alpha1_ybcluster_full_cr.yaml

Ref: #5987 