### PR TITLE
[Docs] Sysbench: correct the argument for the number of tables.

### DIFF
--- a/docs/content/latest/benchmark/sysbench-ysql.md
+++ b/docs/content/latest/benchmark/sysbench-ysql.md
@@ -75,7 +75,7 @@ This section outlines instructions in case you need to run workloads individuall
 
 ```sh
 $ sysbench oltp_point_select        \
-      --num-tables=10               \
+      --tables=10                   \
       --table-size=100000           \
       --range_key_partitioning=true \
       --db-driver=pgsql             \
@@ -90,7 +90,7 @@ Then you can run the workload as follows
 
 ```sh
 $ sysbench oltp_point_select        \
-      --num-tables=10               \
+      --tables=10                   \
       --table-size=100000           \
       --range_key_partitioning=true \
       --db-driver=pgsql             \


### PR DESCRIPTION
Summary:
Right now the docs erroneously indicate that controlling the number of
tables is done using `num_tables` instead of `tables`. Correct it.

Reviewers:
Kannan