### PR TITLE
Change github workflow to handle promoted pre-releases.

### DIFF
--- a/.github/workflows/create-repository-dispatch.yml
+++ b/.github/workflows/create-repository-dispatch.yml
@@ -2,7 +2,7 @@ name: Create Repository Dispatch
 on:
   release:
     types:
-      published
+      released
 jobs:
   createRepositoryDispatch:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We want to capture the case when a pre-release is changed to release.
https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#release