### PR TITLE
Update messenger.cc[#5720]

### DIFF
--- a/src/yb/rpc/messenger.cc
+++ b/src/yb/rpc/messenger.cc
@@ -663,6 +663,7 @@ ScheduledTaskId Messenger::ScheduleOnReactor(
   for (const auto& r : reactors_) {
     if (r->IsCurrentThread()) {
       chosen = r.get();
+      break;
     }
   }
   if (chosen == nullptr) {


### PR DESCRIPTION
There has a small flaw.
Since only one reactor is required, it should be quit immediately to save time.