### PR TITLE
[docs] Disable previous and next buttons

### DIFF
--- a/docs/content/latest/architecture/design-goals.md
+++ b/docs/content/latest/architecture/design-goals.md
@@ -12,7 +12,6 @@ menu:
     weight: 1105
 isTocNested: true
 showAsideToc: true
-hidePagination: true
 ---
 
 This page outlines the design goals with which YugabyteDB has been built.

--- a/docs/content/stable/architecture/design-goals.md
+++ b/docs/content/stable/architecture/design-goals.md
@@ -13,7 +13,6 @@ menu:
     weight: 1105
 isTocNested: true
 showAsideToc: true
-hidePagination: true
 ---
 
 This page outlines the design goals with which YugabyteDB has been built.

--- a/docs/content/v1.3/architecture/design-goals.md
+++ b/docs/content/v1.3/architecture/design-goals.md
@@ -10,7 +10,6 @@ menu:
     weight: 1105
 isTocNested: true
 showAsideToc: true
-hidePagination: true
 ---
 
 This page outlines the design goals with which YugabyteDB has been built.

--- a/docs/content/v2.0/architecture/design-goals.md
+++ b/docs/content/v2.0/architecture/design-goals.md
@@ -10,7 +10,6 @@ menu:
     weight: 1105
 isTocNested: true
 showAsideToc: true
-hidePagination: true
 ---
 
 This page outlines the design goals with which YugabyteDB has been built.

--- a/docs/content/v2.1/architecture/design-goals.md
+++ b/docs/content/v2.1/architecture/design-goals.md
@@ -11,7 +11,6 @@ menu:
     weight: 1105
 isTocNested: true
 showAsideToc: true
-hidePagination: true
 ---
 
 This page outlines the design goals with which YugabyteDB has been built.

--- a/docs/layouts/_default/single.html
+++ b/docs/layouts/_default/single.html
@@ -53,11 +53,11 @@
 					{{ end }}	
 				</div>	
 			</div>	
-
+<!--
 				{{if not (.Params.hidePagination) }}
 					{{ partial "pagination" . }}
 				{{ end }}
-
+-->
 				{{ partial "footer_links" . }}
 				<!--{{ partial "feedback" . }}-->
 		</article>

--- a/docs/layouts/indexpage/single.html
+++ b/docs/layouts/indexpage/single.html
@@ -31,9 +31,11 @@
 
 					{{ .Content }}
 				{{ end }}
+<!--
 				{{if not (.Params.hidePagination) }}
 					{{ partial "pagination" . }}
 				{{ end }}
+-->
 			</div>
 		</article>
 


### PR DESCRIPTION
This PR comments out the following code in `layouts/_default/single.html` and `layouts/indexpage/singlthml`  turns off the "previous" and "next" buttons because none of the pages have `hidePagination: true` (removed that from the only page in all branches that had that setting). 

```
<!--
				{{if not (.Params.hidePagination) }}
					{{ partial "pagination" . }}
				{{ end }}
-->
```

Original commit that added this conditional logic is: https://github.com/yugabyte/yugabyte-db/commit/f379afc167d5ba5d6546d0ee333db7b3d155760f

Closes #5676.
Closes #4333.