### PR TITLE
[yb-docker-ctl] wait_for_cluster: set minloglevel to 0 for yb-admin

### DIFF
--- a/bin/yb-docker-ctl
+++ b/bin/yb-docker-ctl
@@ -434,7 +434,7 @@ class YBDockerControl():
                                   ",".join(self.master_addrs),
                                   '--yb_num_shards_per_tserver={}'.format(
                                       self.args.num_shards_per_tserver),
-                                  'setup_redis_table']
+                                  'setup_redis_table', '--minloglevel', '0']
                     result = get_subprocess_result_as_str(docker_cmd)
                     if "created." not in result:
                         continue


### PR DESCRIPTION
In b689b91587176212f0496832570a99eadaab2e19 the value of -minloglevel flag was set to 2 for yb-admin. The function wait_for_cluster runs `yb-admin … setup_redis_table` command and expects the output to have string 'created.'. This change modifies the minloglevel for that particular invocation of yb-admin so that the INFO level log statement expected by wait_for_cluster is printed.

### Scenarios tested

The check is executed when creating a cluster. Tried creating a new cluster, works as expected.