### PR TITLE
[docdb] Added tablet ID in the /tablet-consensus-status UI page

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -105,3 +105,4 @@ This is a list of people who have contributed code to the [YugabyteDB](https://g
 * [hitesh](https://github.com/jainhitesh9998)
 * [robertsami](https://github.com/robertsami)
 * [tedyu](https://github.com/tedyu)
+* [idnaninitesh](https://github.com/idnaninitesh)

--- a/src/yb/tserver/tablet_server-test.cc
+++ b/src/yb/tserver/tablet_server-test.cc
@@ -202,6 +202,10 @@ TEST_F(TabletServerTest, TestSetFlagsAndCheckWebPages) {
   ASSERT_STR_CONTAINS(buf.ToString(), "<th>key</th>");
   ASSERT_STR_CONTAINS(buf.ToString(), "<td>string NULLABLE NOT A PARTITION KEY</td>");
 
+  ASSERT_OK(c.FetchURL(Substitute("http://$0/tablet-consensus-status?id=$1",
+                       addr, kTabletId), &buf));
+  ASSERT_STR_CONTAINS(buf.ToString(), kTabletId);
+
   // Test fetching metrics.
   // Fetching metrics has the side effect of retiring metrics, but not in a single pass.
   // So, we check a couple of times in a loop -- thus, if we had a bug where one of these

--- a/src/yb/tserver/tserver-path-handlers.cc
+++ b/src/yb/tserver/tserver-path-handlers.cc
@@ -254,6 +254,8 @@ void HandleConsensusStatusPage(
     *output << "Tablet " << EscapeForHtmlToString(tablet_id) << " not running";
     return;
   }
+
+  *output << "<h1>Tablet " << EscapeForHtmlToString(tablet_id) << "</h1>\n";
   consensus->DumpStatusHtml(*output);
 }
 


### PR DESCRIPTION
Summary:
Added tablet ID in the tablet-consensus-status UI page
Added test in tserver_tablet_server-test to verify the same
Reviewers:
Rob

Screenshot:
![VirtualBox_CentOS 7_09_10_2020_18_15_47](https://user-images.githubusercontent.com/8759930/95941953-daada280-0d96-11eb-8d82-f379461d653f.png)
