### PR TITLE
[yugabyted] don't update the password if it's same as default password

### DIFF
--- a/bin/yugabyted
+++ b/bin/yugabyted
@@ -2576,7 +2576,7 @@ class EnvBasedCredentials(object):
             proxy_class.create_db(self.get_ysql_db())
 
         # Update password for default user
-        if self.get_ysql_user() == DEFAULT_YSQL_USER:
+        if self.get_ysql_user() == DEFAULT_YSQL_USER and self.get_ysql_password() != DEFAULT_YSQL_PASSWORD:
             proxy_class.update_password(self.get_ysql_password())
 
         # Create User
@@ -2596,7 +2596,7 @@ class EnvBasedCredentials(object):
             proxy_class.create_keyspace(self.get_ycql_keyspace())
 
         # Update password for default user
-        if self.get_ycql_user() == DEFAULT_YCQL_USER:
+        if self.get_ycql_user() == DEFAULT_YCQL_USER and self.get_ycql_password() != DEFAULT_YCQL_PASSWORD:
             proxy_class.update_password(self.get_ycql_password())
 
         # Create user


### PR DESCRIPTION
## Summary

The verification check is to resolve the below-mentioned issues:

- Update the password for the default user only if the password is different from the default.
- Without this check, the workflow will break for YCQL when someone sets only `YCQL_KEYSPACE` in env vars because yugabyted tries to update the password even if `YCQL_PASSWORD` doesn't exist.

## Test Plan
Set `YCQL_KEYSPACE` in environment and executed the below command. It's working as expected.
```sh
export YCQL_KEYSPACE=testks
bin/yugabyted start --daemon=true --ui=false
```