### PR TITLE
[docs] explore-ysql: start ysqlsh from correct directory

### DIFF
--- a/docs/content/latest/explore/fault-tolerance/kubernetes.md
+++ b/docs/content/latest/explore/fault-tolerance/kubernetes.md
@@ -89,7 +89,7 @@ Now, you can view the [yb-master-0 Admin UI](../../../reference/configuration/yb
 Connect to `ycqlsh` on node `1`.
 
 ```sh
-$ kubectl -n yb-demo exec -it yb-tserver-0 /home/yugabyte/bin/ycqlsh yb-tserver-0
+$ kubectl -n yb-demo exec -it yb-tserver-0 -- ycqlsh yb-tserver-0
 ```
 
 ```
@@ -150,7 +150,7 @@ ycqlsh> SELECT email, profile FROM users.profile;
 Let us now query the data from node `3`.
 
 ```sh
-$ kubectl -n yb-demo exec -it yb-tserver-2 /home/yugabyte/bin/ycqlsh yb-tserver-2
+$ kubectl -n yb-demo exec -it yb-tserver-2 -- ycqlsh yb-tserver-2
 ```
 
 ```sql
@@ -197,7 +197,7 @@ yb-tserver-2   1/1       Terminating   0          33m
 Now connect to node `2`.
 
 ```sh
-$ kubectl -n yb-demo exec -it yb-tserver-1 /home/yugabyte/bin/ycqlsh yb-tserver-1
+$ kubectl -n yb-demo exec -it yb-tserver-1 -- ycqlsh yb-tserver-1
 ```
 
 Let us insert some data to ensure that the loss of a node hasn't impacted the ability of the universe to take writes.

--- a/docs/content/latest/quick-start/explore/kubernetes/explore-ysql.md
+++ b/docs/content/latest/quick-start/explore/kubernetes/explore-ysql.md
@@ -2,7 +2,7 @@
 To open the YSQL shell (`ysqlsh`), run the following.
 
 ```sh
-$ kubectl --namespace yb-demo exec -it yb-tserver-0 -- /home/yugabyte/bin/ysqlsh -h yb-tserver-0  --echo-queries
+$ kubectl --namespace yb-demo exec -it yb-tserver-0 -- sh -c "cd /home/yugabyte && ysqlsh -h yb-tserver-0 --echo-queries"
 ```
 
 ```


### PR DESCRIPTION
-   Changes the directory to `/home/yugabyte` before starting ysqlsh in the Kubernetes pod, this makes sure the instructions like `\i share/*.sql` work as expected.
-   Ref: <https://github.com/yugabyte/charts/pull/9> (current directory is different if Helm chart is being used.)
-   Update remaining kubectl exec commands according to <https://github.com/yugabyte/yugabyte-db/pull/4818>

### Scenarios Tested

-   Tried executing the modified commands to make sure they work as expected.