### PR TITLE
[Doc][YSQL][#6041] Adding documentation related to TServer flag "ysql_sequence_cache_minval"

### DIFF
--- a/docs/content/latest/api/ysql/the-sql-language/statements/ddl_alter_sequence.md
+++ b/docs/content/latest/api/ysql/the-sql-language/statements/ddl_alter_sequence.md
@@ -81,6 +81,8 @@ Change the current value of the sequence. If no value is specified, the current 
 
 Specify how many numbers from the sequence to cache in the client. Default is `1`.
 
+When YB-TServer [ysql_sequence_cache_minval](../../../../../latest/reference/configuration/yb-tserver/#ysql-sequence-cache-minval) configuration flag is not explicitly turned off (set to `0`), the maximum value of the flag and the cache clause will be used.
+
 #### OWNED BY *table_name.table_column* | NONE
 
 It gives ownership of the sequence to the specified column (if any). This means that if the column (or the table to which it belongs to) is dropped, the sequence will be automatically dropped. If `NONE` is specified, any previous ownership will be deleted.

--- a/docs/content/latest/api/ysql/the-sql-language/statements/ddl_create_sequence.md
+++ b/docs/content/latest/api/ysql/the-sql-language/statements/ddl_create_sequence.md
@@ -75,9 +75,11 @@ Specify the first value in the sequence. `start` cannot be less than `minvalue`.
 
 Specify how many numbers from the sequence to cache in the client. Default is `1`.
 
+When YB-TServer [ysql_sequence_cache_minval](../../../../../reference/configuration/yb-tserver/#ysql-sequence-cache-minval) configuration flag is not explicitly turned off (set to `0`), the maximum value of the flag and the cache clause will be used.
+
 #### [ NO ] CYCLE
 
-If `CYCLE` is spefified, the sequence will wrap around once it has reached `minvalue` or `maxvalue`. If `maxvalue` was reached, `minvalue` will be the next number in the sequence. If `minvalue` was reached (for a descending sequence), `maxvalue` will be the next number in a sequence. `NO CYCLE` is the default.
+If `CYCLE` is specified, the sequence will wrap around once it has reached `minvalue` or `maxvalue`. If `maxvalue` was reached, `minvalue` will be the next number in the sequence. If `minvalue` was reached (for a descending sequence), `maxvalue` will be the next number in a sequence. `NO CYCLE` is the default.
 
 ## Cache
 

--- a/docs/content/latest/reference/configuration/yb-tserver.md
+++ b/docs/content/latest/reference/configuration/yb-tserver.md
@@ -485,6 +485,16 @@ For details on how online index backfill works, see the [Online Index Backfill](
 
 Default: `true`
 
+##### --ysql_sequence_cache_minval
+
+Specify the minimum number of sequence values to cache in the client for every sequence object.
+
+To turn off the default size of cache flag, set the flag to `0`.
+
+For details on the expected behaviour when used with the sequence cache clause, see the semantics under [CREATE SEQUENCE](../../../api/ysql/the-sql-language/statements/ddl_create_sequence/#cache-cache) and [ALTER SEQUENCE](../../../api/ysql/the-sql-language/statements/ddl_alter_sequence/#cache-cache) pages.
+
+Default: `100`
+
 ##### --ysql_log_statement
 
 Specifies the types of YSQL statements that should be logged. 


### PR DESCRIPTION
The documentation is related to this Github issue: #6041.
The new tserver flag sets the cache size of sequence objects in YSQL.
This change is not included in v2.2.

3 pages have been updated:

1. Path: /latest/reference/configuration/yb-tserver/#ysql-sequence-cache-minval
New section is added for --ysql_sequence_cache_minval under YSQL yb-tserver flag page.

2. Path: /latest/api/ysql/the-sql-language/statements/ddl_create_sequence/#cache-cache
Added more description under create sequence cache clause section.

3. Path: /latest/api/ysql/the-sql-language/statements/ddl_alter_sequence/#cache-cache
Added more description under alter sequence cache clause section.

<img width="1918" alt="flag" src="https://user-images.githubusercontent.com/66644511/97376016-a952cd80-1892-11eb-9cd1-8c0d15ca3b7d.png">
<img width="1920" alt="create seq" src="https://user-images.githubusercontent.com/66644511/97376012-a6f07380-1892-11eb-8890-be57bb59269f.png">
<img width="1913" alt="alter seq" src="https://user-images.githubusercontent.com/66644511/97376008-a35cec80-1892-11eb-896e-49d94f2ed91f.png">
