### PR TITLE
[WIP PATCH]

### DIFF
--- a/ent/src/yb/master/cluster_balance.cc
+++ b/ent/src/yb/master/cluster_balance.cc
@@ -97,10 +97,10 @@ Result<bool> ClusterLoadBalancer::HandleLeaderLoadIfNonAffinitized(TabletId* mov
 void ClusterLoadBalancer::PopulatePlacementInfo(TabletInfo* tablet, PlacementInfoPB* pb) {
   auto l = tablet->table()->LockForRead();
   const Options* options_ent = GetEntState()->GetEntOptions();
-  if (options_ent->type == LIVE &&
-      l->data().pb.has_replication_info() &&
-      l->data().pb.replication_info().has_live_replicas()) {
-    pb->CopyFrom(l->data().pb.replication_info().live_replicas());
+  if (options_ent->type == LIVE) {
+    ReplicationInfoPB replication_info = CHECK_RESULT(catalog_manager_->ResolveReplicationInfo(
+      l->data().pb.replication_info(), l->data().pb.tablespace_id()));
+    pb->CopyFrom(replication_info.live_replicas());
   } else if (options_ent->type == READ_ONLY &&
       l->data().pb.has_replication_info() &&
       !l->data().pb.replication_info().read_replicas().empty()) {

--- a/java/yb-pgsql/src/test/java/org/yb/pgsql/TestTablespaceProperties.java
+++ b/java/yb-pgsql/src/test/java/org/yb/pgsql/TestTablespaceProperties.java
@@ -1,0 +1,152 @@
+// Copyright (c) YugaByte, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+package org.yb.pgsql;
+
+import org.yb.minicluster.MiniYBDaemon;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yb.client.LocatedTablet.Replica;
+import org.yb.client.LocatedTablet;
+import org.yb.client.YBClient;
+import org.yb.client.YBTable;
+import org.yb.master.Master;
+import org.yb.util.YBTestRunnerNonTsanOnly;
+
+import java.util.*;
+import java.sql.Statement;
+
+import static org.yb.AssertionWrappers.assertEquals;
+import static org.yb.AssertionWrappers.assertFalse;
+import static org.yb.AssertionWrappers.assertGreaterThanOrEqualTo;
+import static org.yb.AssertionWrappers.assertTrue;
+
+@RunWith(value=YBTestRunnerNonTsanOnly.class)
+public class TestTablespaceProperties extends BasePgSQLTest {
+  private static final Logger LOG = LoggerFactory.getLogger(MiniYBDaemon.class);
+
+  private static final String TABLE = "test";
+
+  @Override
+  public int getTestMethodTimeoutSec() {
+    return 300;
+  }
+
+  @Test
+  public void testTablespaces() throws Exception {
+    // Destroy the cluster so we can create a new one.
+    destroyMiniCluster();
+
+    List<String> zone1Placement = Arrays.asList(
+            "--placement_cloud=cloud1", "--placement_region=region1",
+            "--placement_zone=zone1");
+
+    List<String> zone2Placement = Arrays.asList(
+            "--placement_cloud=cloud2", "--placement_region=region2",
+            "--placement_zone=zone2");
+
+    List<String> zone3Placement = Arrays.asList(
+            "--placement_cloud=cloud3", "--placement_region=region3",
+            "--placement_zone=zone3");
+
+    List<List<String>> tserverArgs = new ArrayList<List<String>>();
+    tserverArgs.add(zone1Placement);
+    tserverArgs.add(zone2Placement);
+    tserverArgs.add(zone3Placement);
+
+    createMiniCluster(3, tserverArgs);
+    pgInitialized = false;
+    initPostgresBefore();
+
+    // Create a tablespace with replication info.
+    // TODO: Add negative test cases.
+    try (Statement setupStatement = connection.createStatement()) {
+      setupStatement.execute(
+          " CREATE TABLESPACE testTablespace " +
+          "  WITH (replication_factor=2," +
+          "    placement='cloud1.region1.zone1=1,cloud2.region2.zone2=1'" +
+          " );");
+      setupStatement.execute(
+          "CREATE TABLE " + TABLE + "(a int) TABLESPACE testTablespace;");
+      setupStatement.execute(
+          "INSERT INTO " + TABLE + " values(5);");
+    }
+
+    // Verify that the table was created and its tablets were placed
+    // according to the tablespace replication info.
+    verifyPlacement();
+
+    // Add 2 tservers, one in zone 2 and the other in zone 3.
+    int expectedTServers = miniCluster.getTabletServers().size() + 2;
+    miniCluster.startTServer(zone2Placement);
+    miniCluster.startTServer(zone3Placement);
+    miniCluster.waitForTabletServers(expectedTServers);
+
+    // Wait for loadbalancer to run.
+    boolean isBalanced = miniCluster.getClient().waitForLoadBalance(Long.MAX_VALUE, 0);
+    assertTrue(isBalanced);
+
+    // Verify that the loadbalancer also placed the tablets of the table based on the
+    // tablespace replication info.
+    verifyPlacement();
+
+    /* More tests:
+     * Drop tablespace with and without tables mapped to it.
+     * Test tablespace with user specified if appropriate.
+     * Perform sanity crud on table associated with tablespace.
+     * Associate table with tablespace with no options and it should
+     * be placed according to cluster level config.
+     * Fix any pg tests that now fail due to supporting tablespace
+     * features.
+     * Remove tserver and see everything works as expected.
+     * Add negative tests for wrong formats of placement options, invalid
+     * replication factor inputs, min_replication_factor per block being
+     * higher than total replication factor etc.
+     * Some of the above should be Pg tests?
+     */
+  }
+
+  // Verify that 'TABLE' has been placed only in zone 1 and zone 2.
+  void verifyPlacement() throws Exception {
+    // Open table.
+    final YBClient client = miniCluster.getClient();
+    List<Master.ListTablesResponsePB.TableInfo> tables =
+      client.getTablesList(TABLE).getTableInfoList();
+    assertEquals(1, tables.size());
+    final YBTable ybtable = client.openTableByUUID(
+      tables.get(0).getId().toStringUtf8());
+
+    // Get tablets for table.
+    for (LocatedTablet tablet : ybtable.getTabletsLocations(30000)) {
+      List<LocatedTablet.Replica> replicas = tablet.getReplicas();
+      // Replication factor should be 2.
+      assertEquals(2, replicas.size());
+
+      // Verify that both tablets either belong to zone1 or zone2.
+      for (LocatedTablet.Replica replica : replicas) {
+        org.yb.Common.CloudInfoPB cloudInfo = replica.getCloudInfo();
+        if (cloudInfo.getPlacementCloud().equals("cloud1")) {
+          assertTrue(cloudInfo.getPlacementRegion().equals("region1"));
+          assertTrue(cloudInfo.getPlacementZone().equals("zone1"));
+          continue;
+        }
+        assertTrue(cloudInfo.getPlacementCloud().equals("cloud2"));
+        assertTrue(cloudInfo.getPlacementRegion().equals("region2"));
+        assertTrue(cloudInfo.getPlacementZone().equals("zone2"));
+      }
+    }
+  }
+}

--- a/src/postgres/src/backend/access/common/reloptions.c
+++ b/src/postgres/src/backend/access/common/reloptions.c
@@ -379,6 +379,15 @@ static relopt_int intRelOpts[] =
 		},
 		-1, FirstNormalObjectId, INT_MAX
 	},
+	{
+		{
+			"replication_factor",
+			"Number of replicas for the data stored in this object",
+			RELOPT_KIND_YB_TABLESPACE,
+			AccessExclusiveLock
+		},
+		3, 1, INT_MAX
+	},
 	/* list terminator */
 	{{NULL}}
 };
@@ -478,6 +487,18 @@ static relopt_string stringRelOpts[] =
 		validateWithCheckOption,
 		NULL
 	},
+  {
+    {
+      "placement",
+      "Comma separated list of the form <cloud.region.zone=minreplicas>",
+      RELOPT_KIND_YB_TABLESPACE,
+      AccessExclusiveLock
+    },
+    0,
+    false,
+    validatePlacementConfiguration,
+    NULL
+  },
 	/* list terminator */
 	{{NULL}}
 };
@@ -1616,6 +1637,37 @@ tablespace_reloptions(Datum reloptions, bool validate)
 
 	return (bytea *) tsopts;
 }
+
+/*
+ * Option parser for yugabyte tablespace reloptions
+ */
+bytea *
+yb_tablespace_reloptions(Datum reloptions, bool validate)
+{
+  relopt_value *options;
+  YBTableSpaceOpts *tsopts;
+  int     numoptions;
+  static const relopt_parse_elt yb_tab[] = {
+    {"replication_factor", RELOPT_TYPE_INT, offsetof(YBTableSpaceOpts, replication_factor)},
+    {"placement", RELOPT_TYPE_STRING, offsetof(YBTableSpaceOpts, placement)}
+  };
+
+  options = parseRelOptions(reloptions, validate, RELOPT_KIND_YB_TABLESPACE, &numoptions);
+
+  /* if none set, we're done */
+  if (numoptions == 0)
+    return NULL;
+
+  tsopts = allocateReloptStruct(sizeof(YBTableSpaceOpts), options, numoptions);
+
+  fillRelOptions((void *) tsopts, sizeof(YBTableSpaceOpts), options, numoptions,
+           validate, yb_tab, lengthof(yb_tab));
+
+  pfree(options);
+
+  return (bytea *) tsopts;
+}
+
 
 /*
  * Determine the required LOCKMODE from an option list.

--- a/src/postgres/src/backend/bootstrap/ybcbootstrap.c
+++ b/src/postgres/src/backend/bootstrap/ybcbootstrap.c
@@ -137,9 +137,10 @@ void YBCCreateSysCatalogTable(const char *table_name,
 	                                   table_oid,
 	                                   is_shared_relation,
 	                                   false, /* if_not_exists */
-									   								 pkey_idx == NULL, /* add_primary_key */
-									   								 true, /* colocated */
-									   								 InvalidOid /*tablegroup oid*/,
+                                     pkey_idx == NULL, /* add_primary_key */
+                                     true, /* colocated */
+                                     InvalidOid /* tablegroup oid */,
+                                     InvalidOid /* tablespaceOid */,
 	                                   &yb_stmt));
 
 	/* Add all key columns first, then the regular columns */

--- a/src/postgres/src/backend/catalog/index.c
+++ b/src/postgres/src/backend/catalog/index.c
@@ -987,7 +987,8 @@ index_create(Relation heapRelation,
 					   heapRelation,
 					   split_options,
 					   skip_index_backfill,
-					   tablegroupId);
+					   tablegroupId,
+					   tableSpaceId);
 	}
 
 	/*

--- a/src/postgres/src/backend/commands/tablecmds.c
+++ b/src/postgres/src/backend/commands/tablecmds.c
@@ -862,7 +862,7 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 	if (IsYugaByteEnabled())
 	{
 		CheckIsYBSupportedRelationByKind(relkind);
-		YBCCreateTable(stmt, relkind, descriptor, relationId, namespaceId, tablegroupId);
+		YBCCreateTable(stmt, relkind, descriptor, relationId, namespaceId, tablegroupId, tablespaceId);
 	}
 
 	/*

--- a/src/postgres/src/backend/commands/ybccmds.c
+++ b/src/postgres/src/backend/commands/ybccmds.c
@@ -399,7 +399,7 @@ static void CreateTableHandleSplitOptions(YBCPgStatement handle,
 
 void
 YBCCreateTable(CreateStmt *stmt, char relkind, TupleDesc desc,
-							 Oid relationId, Oid namespaceId, Oid tablegroupId)
+							 Oid relationId, Oid namespaceId, Oid tablegroupId, Oid tablespaceId)
 {
 	if (relkind != RELKIND_RELATION && relkind != RELKIND_PARTITIONED_TABLE)
 	{
@@ -479,6 +479,7 @@ YBCCreateTable(CreateStmt *stmt, char relkind, TupleDesc desc,
 									   primary_key == NULL /* add_primary_key */,
 									   colocated,
 									   tablegroupId,
+									   tablespaceId,
 									   &handle));
 
 	CreateTableAddColumns(handle, desc, primary_key, colocated, tablegroupId);
@@ -686,7 +687,8 @@ YBCCreateIndex(const char *indexName,
 			   Relation rel,
 			   OptSplit *split_options,
 			   const bool skip_index_backfill,
-			   Oid tablegroupId)
+			   Oid tablegroupId,
+			   Oid tablespaceId)
 {
 	char *db_name	  = get_database_name(MyDatabaseId);
 	char *schema_name = get_namespace_name(RelationGetNamespace(rel));
@@ -710,6 +712,7 @@ YBCCreateIndex(const char *indexName,
 									   skip_index_backfill,
 									   false, /* if_not_exists */
 									   tablegroupId,
+									   tablespaceId,
 									   &handle));
 
 	for (int i = 0; i < indexTupleDesc->natts; i++)

--- a/src/postgres/src/backend/exports.txt
+++ b/src/postgres/src/backend/exports.txt
@@ -13,3 +13,4 @@ YbgGetTypeTable
 YbgExprContextCreate
 YbgExprContextAddColValue
 YbgEvalExpr
+YbgDecodeTextArrayToCString

--- a/src/postgres/src/include/access/reloptions.h
+++ b/src/postgres/src/include/access/reloptions.h
@@ -49,8 +49,9 @@ typedef enum relopt_kind
 	RELOPT_KIND_VIEW = (1 << 9),
 	RELOPT_KIND_BRIN = (1 << 10),
 	RELOPT_KIND_PARTITIONED = (1 << 11),
+	RELOPT_KIND_YB_TABLESPACE = (1 << 12),
 	/* if you add a new kind, make sure you update "last_default" too */
-	RELOPT_KIND_LAST_DEFAULT = RELOPT_KIND_PARTITIONED,
+	RELOPT_KIND_LAST_DEFAULT = RELOPT_KIND_YB_TABLESPACE,
 	RELOPT_KIND_INDEX = RELOPT_KIND_BTREE | RELOPT_KIND_HASH | RELOPT_KIND_GIN | RELOPT_KIND_SPGIST,
 	/* some compilers treat enums as signed ints, so we can't use 1 << 31 */
 	RELOPT_KIND_MAX = (1 << 30)
@@ -280,6 +281,7 @@ extern bytea *index_reloptions(amoptions_function amoptions, Datum reloptions,
 extern bytea *index_generic_reloptions(Datum reloptions, bool validate);
 extern bytea *attribute_reloptions(Datum reloptions, bool validate);
 extern bytea *tablespace_reloptions(Datum reloptions, bool validate);
+extern bytea *yb_tablespace_reloptions(Datum reloptions, bool validate);
 extern LOCKMODE AlterTableGetRelOptionsLockLevel(List *defList);
 
 #endif							/* RELOPTIONS_H */

--- a/src/postgres/src/include/commands/tablespace.h
+++ b/src/postgres/src/include/commands/tablespace.h
@@ -42,6 +42,16 @@ typedef struct TableSpaceOpts
 	int			effective_io_concurrency;
 } TableSpaceOpts;
 
+typedef struct YBTableSpaceOpts
+{
+	int32   vl_len_;    /* varlena header (do not touch directly!) */
+	int     replication_factor;
+	char    placement[FLEXIBLE_ARRAY_MEMBER]; /* null-terminated string */
+} YBTableSpaceOpts;
+
+extern void validatePlacementConfiguration(const char *value);
+extern void validatePlacement(char *value);
+extern void validatePlacementBlock(char *value);
 extern Oid	CreateTableSpace(CreateTableSpaceStmt *stmt);
 extern void DropTableSpace(DropTableSpaceStmt *stmt);
 extern ObjectAddress RenameTableSpace(const char *oldname, const char *newname);

--- a/src/postgres/src/include/commands/ybccmds.h
+++ b/src/postgres/src/include/commands/ybccmds.h
@@ -55,7 +55,8 @@ extern void YBCCreateTable(CreateStmt *stmt,
 						   TupleDesc desc,
 						   Oid relationId,
 						   Oid namespaceId,
-						   Oid tablegroupId);
+						   Oid tablegroupId,
+						   Oid tablespaceId);
 
 extern void YBCDropTable(Oid relationId);
 
@@ -70,7 +71,8 @@ extern void YBCCreateIndex(const char *indexName,
 						   Relation rel,
 						   OptSplit *split_options,
 						   const bool skip_index_backfill,
-						   Oid tablegroupId);
+						   Oid tablegroupId,
+						   Oid tablespaceId);
 
 extern void YBCDropIndex(Oid relationId);
 

--- a/src/postgres/src/include/ybgate/ybgate_api.h
+++ b/src/postgres/src/include/ybgate/ybgate_api.h
@@ -129,6 +129,8 @@ YbgStatus YbgExprContextAddColValue(YbgExprContext expr_ctx, int32_t attno, uint
  */
 YbgStatus YbgEvalExpr(char* expr_cstring, YbgExprContext expr_ctx, uint64_t *datum, bool *is_null);
 
+int YbgDecodeTextArrayToCString(uint64_t datum, char ***cstringp);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/yb/client/table_creator.cc
+++ b/src/yb/client/table_creator.cc
@@ -95,6 +95,11 @@ YBTableCreator& YBTableCreator::tablegroup_id(const std::string& tablegroup_id) 
   return *this;
 }
 
+YBTableCreator& YBTableCreator::tablespace_id(const std::string& tablespace_id) {
+  tablespace_id_ = tablespace_id;
+  return *this;
+}
+
 YBTableCreator& YBTableCreator::schema(const YBSchema* schema) {
   schema_ = schema;
   return *this;
@@ -225,6 +230,10 @@ Status YBTableCreator::Create() {
 
   if (!tablegroup_id_.empty()) {
     req.set_tablegroup_id(tablegroup_id_);
+  }
+
+  if (!tablespace_id_.empty()) {
+    req.set_tablespace_id(tablespace_id_);
   }
 
   // Note that the check that the sum of min_num_replicas for each placement block being less or

--- a/src/yb/client/table_creator.h
+++ b/src/yb/client/table_creator.h
@@ -54,6 +54,9 @@ class YBTableCreator {
   // Tablegroup ID - will be ignored by catalog manager if the table is not in a tablegroup.
   YBTableCreator& tablegroup_id(const std::string& tablegroup_id);
 
+  // Tablespace ID.
+  YBTableCreator& tablespace_id(const std::string& tablespace_id);
+
   // Sets the schema with which to create the table. Must remain valid for
   // the lifetime of the builder. Required.
   YBTableCreator& schema(const YBSchema* schema);
@@ -183,6 +186,9 @@ class YBTableCreator {
 
   // The tablegroup id to assign (if a table is in a tablegroup).
   std::string tablegroup_id_;
+
+  // The id of the tablespace to which this table is to be associated with.
+  std::string tablespace_id_;
 
   DISALLOW_COPY_AND_ASSIGN(YBTableCreator);
 };

--- a/src/yb/common/entity_ids.cc
+++ b/src/yb/common/entity_ids.cc
@@ -30,10 +30,16 @@ const uint32_t kPgProcTableOid = 1255;  // Hardcoded for pg_proc. (in pg_proc.h)
 // This should match the value for pg_yb_catalog_version hardcoded in pg_yb_catalog_version.h.
 const uint32_t kPgYbCatalogVersionTableOid = 8010;
 
+// This should match the value for pg_tablespace hardcoded in pg_tablespace.h
+const uint32_t kPgTablespaceTableOid = 1213;
+
 // Static initialization is OK because this won't be used in another static initialization.
 const TableId kPgProcTableId = GetPgsqlTableId(kTemplate1Oid, kPgProcTableOid);
 const TableId kPgYbCatalogVersionTableId =
     GetPgsqlTableId(kTemplate1Oid, kPgYbCatalogVersionTableOid);
+const TableId kPgTablespaceTableId =
+    GetPgsqlTableId(kTemplate1Oid, kPgTablespaceTableOid);
+
 
 
 //-------------------------------------------------------------------------------------------------
@@ -93,6 +99,14 @@ TableId GetPgsqlTableId(const uint32_t database_oid, const uint32_t table_oid) {
 
 TablegroupId GetPgsqlTablegroupId(const uint32_t database_oid, const uint32_t tablegroup_oid) {
   return GetPgsqlTableId(database_oid, tablegroup_oid);
+}
+
+TablespaceId GetPgsqlTablespaceId(const uint32_t tablespace_oid) {
+  uuid id = boost::uuids::nil_uuid();
+  // Tablespace is an entity across databases so this is better than UuidSetTableIds.
+  // TODO: Explore if this should be better?
+  UuidSetDatabaseId(tablespace_oid, &id);
+  return UuidToString(&id);
 }
 
 bool IsPgsqlId(const string& id) {
@@ -182,5 +196,23 @@ Result<uint32_t> GetPgsqlDatabaseOidByTableId(const TableId& table_id) {
 
   return STATUS(InvalidArgument, "Invalid PostgreSQL table id", table_id);
 }
+
+Result<uint32_t> GetPgsqlTablespaceOid(const TablespaceId& tablespace_id) {
+  // TODO: If we are sticking with this format for tablespaceid, see if you can
+  // refactor with namespace id. Same for tablegroup_id and table_id above.
+  DCHECK(IsPgsqlId(tablespace_id));
+  try {
+    size_t pos = 0;
+    const uint32_t oid = stoul(tablespace_id.substr(0, sizeof(uint32_t) * 2), &pos, 16);
+    if (pos == sizeof(uint32_t) * 2) {
+      return oid;
+    }
+  } catch(const std::invalid_argument&) {
+  } catch(const std::out_of_range&) {
+  }
+
+  return STATUS(InvalidArgument, "Invalid PostgreSQL tablespace id", tablespace_id);
+}
+
 
 }  // namespace yb

--- a/src/yb/common/entity_ids.h
+++ b/src/yb/common/entity_ids.h
@@ -40,6 +40,7 @@ using SnapshotId = std::string;
 using TabletServerId = PeerId;
 using TabletId = std::string;
 using TablegroupId = std::string;
+using TablespaceId = std::string;
 
 YB_STRONGLY_TYPED_STRING(KvStoreId);
 
@@ -59,6 +60,7 @@ static const uint32_t kPgIndexTableOid = 2610;  // Hardcoded for pg_index. (in p
 
 extern const TableId kPgProcTableId;
 extern const TableId kPgYbCatalogVersionTableId;
+extern const TableId kPgTablespaceTableId;
 
 // Get YB namespace id for a Postgres database.
 NamespaceId GetPgsqlNamespaceId(uint32_t database_oid);
@@ -69,6 +71,9 @@ TableId GetPgsqlTableId(uint32_t database_oid, uint32_t table_oid);
 // Get YB tablegroup id for a Postgres tablegroup.
 TablegroupId GetPgsqlTablegroupId(uint32_t database_oid, uint32_t tablegroup_oid);
 
+// Get YB tablespace id for a Postgres tablespace.
+TablespaceId GetPgsqlTablespaceId(uint32_t tablespace_oid);
+
 // Is the namespace/table id a Postgres database or table id?
 bool IsPgsqlId(const string& id);
 
@@ -78,6 +83,7 @@ Result<uint32_t> GetPgsqlTableOid(const TableId& table_id);
 Result<uint32_t> GetPgsqlTablegroupOid(const TablegroupId& tablegroup_id);
 Result<uint32_t> GetPgsqlTablegroupOidByTableId(const TableId& table_id);
 Result<uint32_t> GetPgsqlDatabaseOidByTableId(const TableId& table_id);
+Result<uint32_t> GetPgsqlTablespaceOid(const TablespaceId& tablespace_id);
 
 }  // namespace yb
 

--- a/src/yb/docdb/docdb_pgapi.h
+++ b/src/yb/docdb/docdb_pgapi.h
@@ -58,6 +58,9 @@ Status DocPgEvalExpr(const std::string& expr_str,
                      const Schema *schema,
                      QLValue* result);
 
+Status ExtractTextArrayFromQLBinaryValue(const QLValuePB& input,
+                                         std::vector<string> *options);
+
 } // namespace docdb
 } // namespace yb
 

--- a/src/yb/master/CMakeLists.txt
+++ b/src/yb/master/CMakeLists.txt
@@ -56,6 +56,12 @@ set(MASTER_PROTO_LIBS
   master_proto
   ${MASTER_PROTO_LIBS_EXTENSIONS})
 
+include_directories(${YB_BUILD_ROOT}/postgres/include/server)
+
+# TODO: find a way to add this only to the top-level CMakeLists.txt file.
+# See https://github.com/yugabyte/yugabyte-db/issues/5853 for more details.
+allow_using_postgres_libraries()
+
 set(MASTER_SRCS
   async_flush_tablets_task.cc
   async_rpc_tasks.cc
@@ -124,7 +130,9 @@ target_link_libraries(master
   rpc_header_proto
   master_util
   version_info_proto
-  yb_pggate_flags)
+  yb_pggate_flags
+  yb_pggate
+)
 
 set(MASTER_RPC_SRCS
   master_rpc.cc)

--- a/src/yb/master/master.proto
+++ b/src/yb/master/master.proto
@@ -398,6 +398,9 @@ message SysTablesEntryPB {
 
   optional bool colocated = 25 [ default = false ]; // Is this a colocated table?
 
+  // Denotes the tablespace to which this table belongs.
+  optional bytes tablespace_id = 31;
+
   // For index backfill/schema related changes.
   // When a schema change is going on, we want to make sure that the master returns the "older"
   // fully applied version until all the tablets have moved on to the newer version.
@@ -904,6 +907,9 @@ message CreateTableRequestPB {
 
   // This is only applicable for tablegroups. Eventually colocated will be deprecated.
   optional bytes tablegroup_id = 19;
+
+  // For YSQL tables, this denotes the tablespace that this table is associated with.
+  optional bytes tablespace_id = 20;
 }
 
 message CreateTableResponsePB {

--- a/src/yb/master/sys_catalog.h
+++ b/src/yb/master/sys_catalog.h
@@ -157,10 +157,19 @@ class SysCatalogTable {
 
   CHECKED_STATUS Visit(VisitorBase* visitor);
 
-  // Read the ysql catalog version info from the pg_yb_catalog_verison catalog table.
+  // Read the ysql catalog version info from the pg_yb_catalog_version catalog table.
   Status ReadYsqlCatalogVersion(TableId ysql_catalog_table_id,
                                 uint64_t *catalog_version,
                                 uint64_t *last_breaking_version);
+
+  // Read the pg_tablespace catalog table and populate 'tablespace_map' with
+  // placement information pertaining to the tablespace.
+  Status ReadYsqlTablespaceInfo(
+    TableId ysql_tablespace_table_id,
+    unordered_map<TablespaceId, boost::optional<ReplicationInfoPB>> *tablespace_map);
+
+  // Parse the binary value present in ql_value into ReplicationInfoPB.
+  Result<boost::optional<ReplicationInfoPB>> ParseReplicationInfo(const QLValuePB& ql_value);
 
   // Copy the content of co-located tables in sys catalog as a batch.
   CHECKED_STATUS CopyPgsqlTables(const std::vector<TableId>& source_table_ids,

--- a/src/yb/yql/pggate/pg_ddl.cc
+++ b/src/yb/yql/pggate/pg_ddl.cc
@@ -170,7 +170,8 @@ PgCreateTable::PgCreateTable(PgSession::ScopedRefPtr pg_session,
                              bool if_not_exist,
                              bool add_primary_key,
                              const bool colocated,
-                             const PgObjectId& tablegroup_oid)
+                             const PgObjectId& tablegroup_oid,
+			     const PgObjectId& tablespace_oid)
     : PgDdl(pg_session),
       table_name_(YQL_DATABASE_PGSQL,
                   GetPgsqlNamespaceId(table_id.database_oid),
@@ -183,7 +184,8 @@ PgCreateTable::PgCreateTable(PgSession::ScopedRefPtr pg_session,
       is_shared_table_(is_shared_table),
       if_not_exist_(if_not_exist),
       colocated_(colocated),
-      tablegroup_oid_(tablegroup_oid) {
+      tablegroup_oid_(tablegroup_oid),
+      tablespace_oid_(tablespace_oid) {
   // Add internal primary key column to a Postgres table without a user-specified primary key.
   if (add_primary_key) {
     // For regular user table, ybrowid should be a hash key because ybrowid is a random uuid.
@@ -330,6 +332,10 @@ Status PgCreateTable::Exec() {
     table_creator->tablegroup_id(tablegroup_oid_.GetYBTablegroupId());
   }
 
+  if (tablespace_oid_.IsValid()) {
+    table_creator->tablespace_id(tablespace_oid_.GetYBTablespaceId());
+  }
+
   // For index, set indexed (base) table id.
   if (indexed_table_id()) {
     table_creator->indexed_table_id(indexed_table_id()->GetYBTableId());
@@ -419,10 +425,12 @@ PgCreateIndex::PgCreateIndex(PgSession::ScopedRefPtr pg_session,
                              bool is_unique_index,
                              const bool skip_index_backfill,
                              bool if_not_exist,
-                             const PgObjectId& tablegroup_oid)
+                             const PgObjectId& tablegroup_oid,
+			     const PgObjectId& tablespace_oid)
     : PgCreateTable(pg_session, database_name, schema_name, index_name, index_id,
                     is_shared_index, if_not_exist, false /* add_primary_key */,
-                    tablegroup_oid.IsValid() ? false : true /* colocated */, tablegroup_oid),
+                    tablegroup_oid.IsValid() ? false : true /* colocated */, tablegroup_oid,
+                    tablespace_oid),
       base_table_id_(base_table_id),
       is_unique_index_(is_unique_index),
       skip_index_backfill_(skip_index_backfill) {

--- a/src/yb/yql/pggate/pg_ddl.h
+++ b/src/yb/yql/pggate/pg_ddl.h
@@ -145,7 +145,8 @@ class PgCreateTable : public PgDdl {
                 bool if_not_exist,
                 bool add_primary_key,
                 const bool colocated,
-                const PgObjectId& tablegroup_oid);
+                const PgObjectId& tablegroup_oid,
+                const PgObjectId& tablespace_oid);
 
   StmtOp stmt_op() const override { return StmtOp::STMT_CREATE_TABLE; }
 
@@ -204,6 +205,7 @@ class PgCreateTable : public PgDdl {
   bool if_not_exist_;
   bool colocated_ = true;
   const PgObjectId tablegroup_oid_;
+  const PgObjectId tablespace_oid_;
   boost::optional<YBHashSchema> hash_schema_;
   std::vector<std::string> range_columns_;
   std::vector<std::vector<QLValuePB>> split_rows_; // Split rows for range tables
@@ -255,7 +257,8 @@ class PgCreateIndex : public PgCreateTable {
                 bool is_unique_index,
                 const bool skip_index_backfill,
                 bool if_not_exist,
-                const PgObjectId& tablegroup_oid);
+                const PgObjectId& tablegroup_oid,
+                const PgObjectId& tablespace_oid);
 
   StmtOp stmt_op() const override { return StmtOp::STMT_CREATE_INDEX; }
 

--- a/src/yb/yql/pggate/pg_env.h
+++ b/src/yb/yql/pggate/pg_env.h
@@ -72,6 +72,10 @@ struct PgObjectId {
     return GetPgsqlTablegroupId(database_oid, object_oid);
   }
 
+  TablespaceId GetYBTablespaceId() const {
+    return GetPgsqlTablespaceId(object_oid);
+  }
+
   std::string ToString() const {
     return Format("{$0, $1}", database_oid, object_oid);
   }

--- a/src/yb/yql/pggate/pggate.cc
+++ b/src/yb/yql/pggate/pggate.cc
@@ -501,10 +501,12 @@ Status PgApiImpl::NewCreateTable(const char *database_name,
                                  bool add_primary_key,
                                  const bool colocated,
                                  const PgObjectId& tablegroup_oid,
+                                 const PgObjectId& tablespace_oid,
                                  PgStatement **handle) {
   auto stmt = std::make_unique<PgCreateTable>(
       pg_session_, database_name, schema_name, table_name,
-      table_id, is_shared_table, if_not_exist, add_primary_key, colocated, tablegroup_oid);
+      table_id, is_shared_table, if_not_exist, add_primary_key, colocated, tablegroup_oid,
+      tablespace_oid);
   RETURN_NOT_OK(AddToCurrentPgMemctx(std::move(stmt), handle));
   return Status::OK();
 }
@@ -724,10 +726,12 @@ Status PgApiImpl::NewCreateIndex(const char *database_name,
                                  const bool skip_index_backfill,
                                  bool if_not_exist,
                                  const PgObjectId& tablegroup_oid,
+				 const PgObjectId& tablespace_oid,
                                  PgStatement **handle) {
   auto stmt = std::make_unique<PgCreateIndex>(
       pg_session_, database_name, schema_name, index_name, index_id, base_table_id,
-      is_shared_index, is_unique_index, skip_index_backfill, if_not_exist, tablegroup_oid);
+      is_shared_index, is_unique_index, skip_index_backfill, if_not_exist, tablegroup_oid,
+      tablespace_oid);
   RETURN_NOT_OK(AddToCurrentPgMemctx(std::move(stmt), handle));
   return Status::OK();
 }

--- a/src/yb/yql/pggate/pggate.h
+++ b/src/yb/yql/pggate/pggate.h
@@ -214,6 +214,7 @@ class PgApiImpl {
                                 bool add_primary_key,
                                 const bool colocated,
                                 const PgObjectId& tablegroup_oid,
+                                const PgObjectId& tablespace_oid,
                                 PgStatement **handle);
 
   CHECKED_STATUS CreateTableAddColumn(PgStatement *handle, const char *attr_name, int attr_num,
@@ -277,6 +278,7 @@ class PgApiImpl {
                                 const bool skip_index_backfill,
                                 bool if_not_exist,
                                 const PgObjectId& tablegroup_oid,
+                                const PgObjectId& tablespace_oid,
                                 PgStatement **handle);
 
   CHECKED_STATUS CreateIndexAddColumn(PgStatement *handle, const char *attr_name, int attr_num,

--- a/src/yb/yql/pggate/test/pggate_test_catalog.cc
+++ b/src/yb/yql/pggate/test/pggate_test_catalog.cc
@@ -39,7 +39,9 @@ TEST_F(PggateTestCatalog, TestDml) {
                                        kDefaultDatabaseOid, tab_oid,
                                        false /* is_shared_table */, true /* if_not_exist */,
                                        false /* add_primary_key */, true /* colocated */,
-                                       kInvalidOid /*tablegroup_id*/, &pg_stmt));
+                                       kInvalidOid /* tablegroup_id */,
+                                       kInvalidOid /* tablespace_id */,
+                                       &pg_stmt));
   CHECK_YBC_STATUS(YBCTestCreateTableAddColumn(pg_stmt, "company_id", ++col_count,
                                              DataType::INT64, false, true));
   CHECK_YBC_STATUS(YBCTestCreateTableAddColumn(pg_stmt, "empid", ++col_count,
@@ -378,7 +380,9 @@ TEST_F(PggateTestCatalog, TestCopydb) {
                                        kDefaultDatabaseOid, tab_oid,
                                        false /* is_shared_table */, true /* if_not_exist */,
                                        false /* add_primary_key */, true /* colocated */,
-                                       kInvalidOid /*tablegroup_id*/, &pg_stmt));
+                                       kInvalidOid /* tablegroup_id */,
+                                       kInvalidOid /* tablespace_id */,
+                                       &pg_stmt));
   CHECK_YBC_STATUS(YBCTestCreateTableAddColumn(pg_stmt, "key", 1, DataType::INT32, false, true));
   CHECK_YBC_STATUS(YBCTestCreateTableAddColumn(pg_stmt, "value", 2, DataType::INT32, false, false));
   CHECK_YBC_STATUS(YBCPgExecCreateTable(pg_stmt));

--- a/src/yb/yql/pggate/test/pggate_test_delete.cc
+++ b/src/yb/yql/pggate/test/pggate_test_delete.cc
@@ -35,7 +35,9 @@ TEST_F(PggateTestDelete, TestDelete) {
                                        kDefaultDatabaseOid, tab_oid,
                                        false /* is_shared_table */, true /* if_not_exist */,
                                        false /* add_primary_key */, true /* colocated */,
-                                       kInvalidOid /*tablegroup_id*/, &pg_stmt));
+                                       kInvalidOid /* tablegroup_id */,
+                                       kInvalidOid /* tablespace_id */,
+                                       &pg_stmt));
   CHECK_YBC_STATUS(YBCTestCreateTableAddColumn(pg_stmt, "hash_key", ++col_count,
                                              DataType::INT64, true, true));
   CHECK_YBC_STATUS(YBCTestCreateTableAddColumn(pg_stmt, "id", ++col_count,

--- a/src/yb/yql/pggate/test/pggate_test_select.cc
+++ b/src/yb/yql/pggate/test/pggate_test_select.cc
@@ -35,7 +35,8 @@ TEST_F(PggateTestSelect, TestSelectOneTablet) {
                                        kDefaultDatabaseOid, tab_oid,
                                        false /* is_shared_table */, true /* if_not_exist */,
                                        false /* add_primary_key */, true /* colocated */,
-                                       kInvalidOid /*tablegroup_id*/, &pg_stmt));
+                                       kInvalidOid /* tablegroup_id */,
+                                       kInvalidOid /* tablespace_id */, &pg_stmt));
   CHECK_YBC_STATUS(YBCTestCreateTableAddColumn(pg_stmt, "hash_key", ++col_count,
                                                DataType::INT64, true, true));
   CHECK_YBC_STATUS(YBCTestCreateTableAddColumn(pg_stmt, "id", ++col_count,

--- a/src/yb/yql/pggate/test/pggate_test_select_inequality.cc
+++ b/src/yb/yql/pggate/test/pggate_test_select_inequality.cc
@@ -35,7 +35,9 @@ TEST_F(PggateTestSelectInequality, TestSelectInequality) {
                                        kDefaultDatabaseOid, tab_oid,
                                        false /* is_shared_table */, true /* if_not_exist */,
                                        false /* add_primary_key */, true /* colocated */,
-                                       kInvalidOid /*tablegroup_id*/, &pg_stmt));
+                                       kInvalidOid /* tablegroup_id */,
+                                       kInvalidOid /* tablespace_id */,
+                                       &pg_stmt));
   CHECK_YBC_STATUS(YBCTestCreateTableAddColumn(pg_stmt, "h", ++col_count,
                                                DataType::STRING, true, false));
   CHECK_YBC_STATUS(YBCTestCreateTableAddColumn(pg_stmt, "r1", ++col_count,

--- a/src/yb/yql/pggate/test/pggate_test_select_multi_tablets.cc
+++ b/src/yb/yql/pggate/test/pggate_test_select_multi_tablets.cc
@@ -35,7 +35,9 @@ TEST_F(PggateTestSelectMultiTablets, TestSelectMultiTablets) {
                                        kDefaultDatabaseOid, tab_oid,
                                        false /* is_shared_table */, true /* if_not_exist */,
                                        false /* add_primary_key */, true /* colocated */,
-                                       kInvalidOid /*tablegroup_id*/, &pg_stmt));
+                                       kInvalidOid /*tablegroup_id*/,
+                                       kInvalidOid /*tablespace_id*/,
+                                       &pg_stmt));
   CHECK_YBC_STATUS(YBCTestCreateTableAddColumn(pg_stmt, "hash_key", ++col_count,
                                              DataType::INT64, true, true));
   CHECK_YBC_STATUS(YBCTestCreateTableAddColumn(pg_stmt, "id", ++col_count,

--- a/src/yb/yql/pggate/test/pggate_test_update.cc
+++ b/src/yb/yql/pggate/test/pggate_test_update.cc
@@ -35,7 +35,9 @@ TEST_F(PggateTestDelete, TestDelete) {
                                        kDefaultDatabaseOid, tab_oid,
                                        false /* is_shared_table */, true /* if_not_exist */,
                                        false /* add_primary_key */, true /* colocated */,
-                                       kInvalidOid /*tablegroup_id*/, &pg_stmt));
+                                       kInvalidOid /* tablegroup_id */,
+                                       kInvalidOid /* tablespace_id */,
+                                       &pg_stmt));
   CHECK_YBC_STATUS(YBCTestCreateTableAddColumn(pg_stmt, "hash_key", ++col_count,
                                                DataType::INT64, true, true));
   CHECK_YBC_STATUS(YBCTestCreateTableAddColumn(pg_stmt, "id", ++col_count,

--- a/src/yb/yql/pggate/ybc_pggate.cc
+++ b/src/yb/yql/pggate/ybc_pggate.cc
@@ -322,12 +322,14 @@ YBCStatus YBCPgNewCreateTable(const char *database_name,
                               bool add_primary_key,
                               const bool colocated,
                               const YBCPgOid tablegroup_oid,
+                              const YBCPgOid tablespace_oid,
                               YBCPgStatement *handle) {
   const PgObjectId table_id(database_oid, table_oid);
   const PgObjectId tablegroup_id(database_oid, tablegroup_oid);
+  const PgObjectId tablespace_id(database_oid, tablespace_oid);
   return ToYBCStatus(pgapi->NewCreateTable(
       database_name, schema_name, table_name, table_id, is_shared_table,
-      if_not_exist, add_primary_key, colocated, tablegroup_id, handle));
+      if_not_exist, add_primary_key, colocated, tablegroup_id, tablespace_id, handle));
 }
 
 YBCStatus YBCPgCreateTableAddColumn(YBCPgStatement handle, const char *attr_name, int attr_num,
@@ -477,14 +479,16 @@ YBCStatus YBCPgNewCreateIndex(const char *database_name,
                               const bool skip_index_backfill,
                               bool if_not_exist,
                               const YBCPgOid tablegroup_oid,
+                              const YBCPgOid tablespace_oid,
                               YBCPgStatement *handle) {
   const PgObjectId index_id(database_oid, index_oid);
   const PgObjectId table_id(database_oid, table_oid);
   const PgObjectId tablegroup_id(database_oid, tablegroup_oid);
+  const PgObjectId tablespace_id(database_oid, tablespace_oid);
   return ToYBCStatus(pgapi->NewCreateIndex(database_name, schema_name, index_name, index_id,
                                            table_id, is_shared_index, is_unique_index,
                                            skip_index_backfill, if_not_exist, tablegroup_id,
-                                           handle));
+                                           tablespace_id, handle));
 }
 
 YBCStatus YBCPgCreateIndexAddColumn(YBCPgStatement handle, const char *attr_name, int attr_num,

--- a/src/yb/yql/pggate/ybc_pggate.h
+++ b/src/yb/yql/pggate/ybc_pggate.h
@@ -174,6 +174,7 @@ YBCStatus YBCPgNewCreateTable(const char *database_name,
                               bool add_primary_key,
                               const bool colocated,
                               YBCPgOid tablegroup_oid,
+                              YBCPgOid tablespace_oid,
                               YBCPgStatement *handle);
 
 YBCStatus YBCPgCreateTableAddColumn(YBCPgStatement handle, const char *attr_name, int attr_num,
@@ -255,6 +256,7 @@ YBCStatus YBCPgNewCreateIndex(const char *database_name,
                               const bool skip_index_backfill,
                               bool if_not_exist,
                               YBCPgOid tablegroup_oid,
+                              YBCPgOid tablespace_oid,
                               YBCPgStatement *handle);
 
 YBCStatus YBCPgCreateIndexAddColumn(YBCPgStatement handle, const char *attr_name, int attr_num,


### PR DESCRIPTION
This patch explores exposing the YSQL API to create Tablespaces.
The user will specify placement options as part of this API.

These placement options will be stored in the pg_tablespace catalog
table and will be parsed by the YB Master to decide how to place
the tablets of this table.

If the table itself has placement information, then that will be used.
Otherwise placement info associated with its tablespace will be used.
If neither are present we will use cluster level placement policy.

There are sanity tests (that do pass) in this patch, but this is
still very much WIP and is being used to evaluate any better
design/code flows.