### PR TITLE
[docdb] master UI make hash_split more readable

### DIFF
--- a/src/yb/common/partition.cc
+++ b/src/yb/common/partition.cc
@@ -733,8 +733,8 @@ string PartitionSchema::PartitionDebugString(const Partition& partition,
         const string& pstart = partition.partition_key_start();
         const string& pend = partition.partition_key_end();
         uint16_t hash_start = !pstart.empty() ? DecodeMultiColumnHashValue(pstart) : 0;
-        uint16_t hash_end = !pend.empty() ? DecodeMultiColumnHashValue(pend) : 65535;
-        s.append(Substitute("hash_split: [0x$0, 0x$1]", 
+        uint16_t hash_end = !pend.empty() ? DecodeMultiColumnHashValue(pend) : UINT16_MAX;
+        s.append(Substitute("hash_split: [0x$0,0x$1)", 
                             Uint16ToHexString(hash_start), Uint16ToHexString(hash_end)));
         return s;
       }

--- a/src/yb/common/partition.cc
+++ b/src/yb/common/partition.cc
@@ -734,7 +734,7 @@ string PartitionSchema::PartitionDebugString(const Partition& partition,
         const string& pend = partition.partition_key_end();
         uint16_t hash_start = !pstart.empty() ? DecodeMultiColumnHashValue(pstart) : 0;
         uint16_t hash_end = !pend.empty() ? DecodeMultiColumnHashValue(pend) : UINT16_MAX;
-        s.append(Substitute("hash_split: [0x$0,0x$1)", 
+        s.append(Substitute("hash_split: [0x$0, 0x$1)", 
                             Uint16ToHexString(hash_start), Uint16ToHexString(hash_end)));
         return s;
       }

--- a/src/yb/common/partition.cc
+++ b/src/yb/common/partition.cc
@@ -731,26 +731,11 @@ string PartitionSchema::PartitionDebugString(const Partition& partition,
       case YBHashSchema::kRedisHash: FALLTHROUGH_INTENDED;
       case YBHashSchema::kMultiColumnHash: {
         const string& pstart = partition.partition_key_start();
-        uint16_t hash_start = !pstart.empty() ? DecodeMultiColumnHashValue(pstart) : 0;
         const string& pend = partition.partition_key_end();
-        if (!pend.empty()) {
-          uint16 hash_end = DecodeMultiColumnHashValue(pend);
-          if (pstart.empty()) {
-            s.append(Substitute("hash_split: [0x0000, $0)",
-                                Uint16ToHexString(hash_end)));
-          } else {
-            s.append(Substitute("hash_split: [$0, $1)",
-                                Uint16ToHexString(hash_start),
-                                Uint16ToHexString(hash_end)));
-          }
-        } else {
-          if (pstart.empty()) {
-            s.append(Substitute("hash_split: [0x0000, 0x0000)"));
-          } else {
-            s.append(Substitute("hash_split: [$0, 0xFFFF)",
-                                Uint16ToHexString(hash_start)));
-          }
-        }
+        uint16_t hash_start = !pstart.empty() ? DecodeMultiColumnHashValue(pstart) : 0;
+        uint16_t hash_end = !pend.empty() ? DecodeMultiColumnHashValue(pend) : 65535;
+        s.append(Substitute("hash_split: [0x$0, 0x$1]", 
+                            Uint16ToHexString(hash_start), Uint16ToHexString(hash_end)));
         return s;
       }
       case YBHashSchema::kPgsqlHash:

--- a/src/yb/common/partition.cc
+++ b/src/yb/common/partition.cc
@@ -734,7 +734,7 @@ string PartitionSchema::PartitionDebugString(const Partition& partition,
         const string& pend = partition.partition_key_end();
         uint16_t hash_start = !pstart.empty() ? DecodeMultiColumnHashValue(pstart) : 0;
         uint16_t hash_end = !pend.empty() ? DecodeMultiColumnHashValue(pend) : UINT16_MAX;
-        s.append(Substitute("hash_split: [0x$0, 0x$1)", 
+        s.append(Substitute("hash_split: [0x$0, 0x$1)",
                             Uint16ToHexString(hash_start), Uint16ToHexString(hash_end)));
         return s;
       }

--- a/src/yb/common/partition.cc
+++ b/src/yb/common/partition.cc
@@ -736,15 +736,19 @@ string PartitionSchema::PartitionDebugString(const Partition& partition,
         if (!pend.empty()) {
           uint16 hash_end = DecodeMultiColumnHashValue(pend);
           if (pstart.empty()) {
-            s.append(Substitute("hash_split: [<start>, $1)", hash_start, hash_end));
+            s.append(Substitute("hash_split: [0x0000, $0)",
+                                Uint16ToHexString(hash_end)));
           } else {
-            s.append(Substitute("hash_split: [$0, $1)", hash_start, hash_end));
+            s.append(Substitute("hash_split: [$0, $1)",
+                                Uint16ToHexString(hash_start),
+                                Uint16ToHexString(hash_end)));
           }
         } else {
           if (pstart.empty()) {
-            s.append(Substitute("hash_split: [<start>, <end>)"));
+            s.append(Substitute("hash_split: [0x0000, 0x0000)"));
           } else {
-            s.append(Substitute("hash_split: [$0, <end>)", hash_start));
+            s.append(Substitute("hash_split: [$0, 0xFFFF)",
+                                Uint16ToHexString(hash_start)));
           }
         }
         return s;

--- a/src/yb/gutil/strings/numbers.cc
+++ b/src/yb/gutil/strings/numbers.cc
@@ -526,7 +526,7 @@ string Uint128ToHexString(uint128 ui128) {
 
 string Uint16ToHexString(uint16_t ui16) {
   char buf[5];
-  sprintf(buf, "%04X", ui16);
+  snprintf(buf, "%04X", ui16);
   return string(buf);
 }
 

--- a/src/yb/gutil/strings/numbers.cc
+++ b/src/yb/gutil/strings/numbers.cc
@@ -526,7 +526,7 @@ string Uint128ToHexString(uint128 ui128) {
 
 string Uint16ToHexString(uint16_t ui16) {
   char buf[5];
-  snprintf(buf, "%04X", ui16);
+  snprintf(buf,sizeof(buf), "%04X", ui16);
   return string(buf);
 }
 

--- a/src/yb/gutil/strings/numbers.cc
+++ b/src/yb/gutil/strings/numbers.cc
@@ -526,7 +526,7 @@ string Uint128ToHexString(uint128 ui128) {
 
 string Uint16ToHexString(uint16_t ui16) {
   char buf[5];
-  snprintf(buf,sizeof(buf), "%04X", ui16);
+  snprintf(buf, sizeof(buf), "%04X", ui16);
   return string(buf);
 }
 

--- a/src/yb/gutil/strings/numbers.cc
+++ b/src/yb/gutil/strings/numbers.cc
@@ -524,10 +524,9 @@ string Uint128ToHexString(uint128 ui128) {
   return string(buf);
 }
 
-// Default arguments
 string Uint16ToHexString(uint16_t ui16) {
-  char buf[20];
-  sprintf(buf, "0x%X", ui16);
+  char buf[5];
+  sprintf(buf, "%04X", ui16);
   return string(buf);
 }
 

--- a/src/yb/gutil/strings/numbers.cc
+++ b/src/yb/gutil/strings/numbers.cc
@@ -524,6 +524,13 @@ string Uint128ToHexString(uint128 ui128) {
   return string(buf);
 }
 
+// Default arguments
+string Uint16ToHexString(uint16_t ui16) {
+  char buf[20];
+  sprintf(buf, "0x%X", ui16);
+  return string(buf);
+}
+
 namespace {
 
 // Represents integer values of digits.

--- a/src/yb/gutil/strings/numbers.h
+++ b/src/yb/gutil/strings/numbers.h
@@ -52,7 +52,7 @@ string FpToString(Fprint fp);
 string Uint128ToHexString(uint128 ui128);
 
 // Formats a uint16 as a 4-digit hex string.
-string Uint16ToHexString(uint16_t v);
+string Uint16ToHexString(uint16_t ui16);
 
 // Convert strings to numeric values, with strict error checking.
 // Leading and trailing spaces are allowed.

--- a/src/yb/gutil/strings/numbers.h
+++ b/src/yb/gutil/strings/numbers.h
@@ -51,6 +51,9 @@ string FpToString(Fprint fp);
 // Formats a uint128 as a 32-digit hex string.
 string Uint128ToHexString(uint128 ui128);
 
+// Formats a uint16 as a 4-digit hex string.
+string Uint16ToHexString(uint16_t v);
+
 // Convert strings to numeric values, with strict error checking.
 // Leading and trailing spaces are allowed.
 // Negative inputs are not allowed for unsigned ints (unlike strtoul).


### PR DESCRIPTION
Summary:
Master UI make hash_split more readable

Fix: #4811

Screenshot:
![image](https://user-images.githubusercontent.com/17941719/97725062-4e261280-1b00-11eb-83b8-c356414bd592.png)
