### PR TITLE
[#6116] Removed user and index tables from the master home page

### DIFF
--- a/src/yb/master/master-path-handlers.cc
+++ b/src/yb/master/master-path-handlers.cc
@@ -1344,11 +1344,6 @@ void MasterPathHandlers::RootHandler(const Webserver::WebRequest& req,
   (*output) << "<div class='col-xs-12 col-md-8 col-lg-6'>\n";
   HandleMasters(req, resp);
   (*output) << "</div> <!-- col-xs-12 col-md-8 col-lg-6 -->\n";
-
-  // Display the user tables if any.
-  (*output) << "<div class='col-md-12 col-lg-12'>\n";
-  HandleCatalogManager(req, resp, true /* only_user_tables */);
-  (*output) << "</div> <!-- col-md-12 col-lg-12 -->\n";
 }
 
 void MasterPathHandlers::HandleMasters(const Webserver::WebRequest& req,


### PR DESCRIPTION
Summary:
Removed the user and index tables section from the home-page
Modified this only for the master server
Reviewers:
Rob

Screenshot
<img width="1280" alt="Screen Shot 2020-11-01 at 1 25 56 AM" src="https://user-images.githubusercontent.com/8759930/97799180-45593d80-1be1-11eb-91f6-369b0a202e49.png">