### PR TITLE
Disable CircleCI builds on master branch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+jobs:
+  no-build:
+    docker:
+      - image: circleci/node:latest
+    steps:
+      - run: echo "Not running builds at this time."
+
+workflows:
+  version: 2
+
+  no-build:
+    jobs:
+      - no-build:
+          name: no-automatic-build
+          filters:
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
Defines a minimal build, and then ignores it for all branches.