### PR TITLE
Direct Platform license requests to website form.

### DIFF
--- a/docs/content/latest/faq/yugabyte-platform.md
+++ b/docs/content/latest/faq/yugabyte-platform.md
@@ -52,7 +52,7 @@ For airgapped hosts, a supported version of docker-engine (currently 1.7.1 to 17
 
 - Following ports should be open on the YugaWare host: `8800` (replicated ui), `80` (http for YugabyteDB Admin Console), `22` (ssh)
 - Attached disk storage (such as persistent EBS volumes on AWS): 100 GB minimum
-- A Yugabyte Platform license file (attached to your welcome email from Yugabyte Support)
+- A Yugabyte Platform license file from [Yugabyte](https://www.yugabyte.com/platform/#request-trial-form)
 - Ability to connect from the Yugabyte Platform host to all YugabyteDB data nodes. If this is not set up, [setup passwordless ssh](#step-5-troubleshoot-yugaware).
 
 ## What are the OS requirements and permissions to run the YugabyteDB data nodes?

--- a/docs/content/latest/yugabyte-platform/install-yugabyte-platform/install-software/airgapped.md
+++ b/docs/content/latest/yugabyte-platform/install-yugabyte-platform/install-software/airgapped.md
@@ -117,7 +117,7 @@ The simplest option is use a self-signed cert for now and add the custom SSL cer
 
 ## Upload license file
 
-Now, upload the Yugabyte license file received from Yugabyte Support.
+Now, upload the Yugabyte license file received from [Yugabyte](https://www.yugabyte.com/platform/#request-trial-form).
 
 ![Replicated License Upload](/images/replicated/replicated-license-upload.png)
 

--- a/docs/content/latest/yugabyte-platform/install-yugabyte-platform/install-software/default.md
+++ b/docs/content/latest/yugabyte-platform/install-yugabyte-platform/install-software/default.md
@@ -83,7 +83,7 @@ The simplest option is use a self-signed certificate for now and add the custom 
 
 ## Upload the license file
 
-Now, upload the Yugabyte license file that you received from Yugabyte Support.
+Now, upload the Yugabyte license file that you received from [Yugabyte](https://www.yugabyte.com/platform/#request-trial-form).
 
 ![Replicated License Upload](/images/replicated/replicated-license-upload.png)
 

--- a/docs/content/latest/yugabyte-platform/install-yugabyte-platform/install-software/kubernetes.md
+++ b/docs/content/latest/yugabyte-platform/install-yugabyte-platform/install-software/kubernetes.md
@@ -96,7 +96,7 @@ The following output should appear:
     kubectl create namespace yb-platform
     ```
 
-2. Apply the Yugabyte Platform secret (obtained from [Yugabyte Support](mailto:support@yugabyte.com) by running the following `kubectl create` command:
+2. Apply the Yugabyte Platform secret (obtained from [Yugabyte](https://www.yugabyte.com/platform/#request-trial-form) by running the following `kubectl create` command:
 
     ```sh
     $ kubectl create -f yugabyte-k8s-secret.yml -n yb-platform

--- a/docs/content/latest/yugabyte-platform/install-yugabyte-platform/prepare-environment/kubernetes.md
+++ b/docs/content/latest/yugabyte-platform/install-yugabyte-platform/prepare-environment/kubernetes.md
@@ -64,7 +64,7 @@ Before installing the YugbyteDB Admin Console, verify you have the following:
 
 - A Kubernetes cluster configured with [Helm](https://helm.sh/).
 - A Kubernetes node with minimum 4 CPU core and 15 GB RAM can be allocated to Yugabyte Platform.
-- A Kubernetes secret obtained from Yugabyte Support.
+- A Kubernetes secret obtained from [Yugabyte](https://www.yugabyte.com/platform/#request-trial-form).
 
 To confirm that `helm` is configured correctly, run the following command:
 

--- a/docs/content/latest/yugabyte-platform/install-yugabyte-platform/prerequisites.md
+++ b/docs/content/latest/yugabyte-platform/install-yugabyte-platform/prerequisites.md
@@ -65,5 +65,5 @@ To install Yugabyte Platform on Airgapped hosts, without access to any Internet 
   - `22` – SSH
 - Attached disk storage (such as persistent EBS volumes on AWS): 100 GB minimum
 - The Yugabyte Platform airgapped install package (contact Yugabyte support)
-- A Yugabyte Platform license file (contact Yugabyte Support)
+- A Yugabyte Platform license file from [Yugabyte](https://www.yugabyte.com/platform/#request-trial-form)
 - Ability to connect from the Yugabyte Platform host to all YugabyteDB data nodes. If this is not set up, set up passwordless SSH.

--- a/docs/content/stable/faq/yugabyte-platform.md
+++ b/docs/content/stable/faq/yugabyte-platform.md
@@ -53,7 +53,7 @@ For airgapped hosts, a supported version of docker-engine (currently 1.7.1 to 17
 
 - Following ports should be open on the YugaWare host: `8800` (replicated ui), `80` (http for YugabyteDB Admin Console), `22` (ssh)
 - Attached disk storage (such as persistent EBS volumes on AWS): 100 GB minimum
-- A Yugabyte Platform license file (attached to your welcome email from Yugabyte Support)
+- A Yugabyte Platform license file from [Yugabyte](https://www.yugabyte.com/platform/#request-trial-form)
 - Ability to connect from the Yugabyte Platform host to all YugabyteDB data nodes. If this is not set up, [setup passwordless ssh](#step-5-troubleshoot-yugaware).
 
 ## What are the OS requirements and permissions to run the YugabyteDB data nodes?

--- a/docs/content/stable/yugabyte-platform/install-yugabyte-platform/install-software/airgapped.md
+++ b/docs/content/stable/yugabyte-platform/install-yugabyte-platform/install-software/airgapped.md
@@ -117,7 +117,7 @@ The simplest option is use a self-signed cert for now and add the custom SSL cer
 
 ## Upload license file
 
-Now, upload the Yugabyte license file received from Yugabyte Support.
+Now, upload the Yugabyte license file received from [Yugabyte](https://www.yugabyte.com/platform/#request-trial-form).
 
 ![Replicated License Upload](/images/replicated/replicated-license-upload.png)
 

--- a/docs/content/stable/yugabyte-platform/install-yugabyte-platform/install-software/default.md
+++ b/docs/content/stable/yugabyte-platform/install-yugabyte-platform/install-software/default.md
@@ -83,7 +83,7 @@ The simplest option is use a self-signed certificate for now and add the custom 
 
 ## Upload the license file
 
-Now, upload the Yugabyte license file that you received from Yugabyte Support.
+Now, upload the Yugabyte license file that you received from [Yugabyte](https://www.yugabyte.com/platform/#request-trial-form).
 
 ![Replicated License Upload](/images/replicated/replicated-license-upload.png)
 

--- a/docs/content/stable/yugabyte-platform/install-yugabyte-platform/install-software/kubernetes.md
+++ b/docs/content/stable/yugabyte-platform/install-yugabyte-platform/install-software/kubernetes.md
@@ -96,7 +96,7 @@ The following output should appear:
     kubectl create namespace yb-platform
     ```
 
-2. Apply the Yugabyte Platform secret (obtained from [Yugabyte Support](mailto:support@yugabyte.com) by running the following `kubectl create` command:
+2. Apply the Yugabyte Platform secret (obtained from [Yugabyte](https://www.yugabyte.com/platform/#request-trial-form) by running the following `kubectl create` command:
 
     ```sh
     $ kubectl create -f yugabyte-k8s-secret.yml -n yb-platform

--- a/docs/content/stable/yugabyte-platform/install-yugabyte-platform/prepare-environment/kubernetes.md
+++ b/docs/content/stable/yugabyte-platform/install-yugabyte-platform/prepare-environment/kubernetes.md
@@ -67,7 +67,7 @@ Before installing the YugbyteDB Admin Console, verify you have the following:
 
 - A Kubernetes cluster configured with [Helm](https://helm.sh/).
 - A Kubernetes node with minimum 4 CPU core and 15 GB RAM can be allocated to Yugabyte Platform.
-- A Kubernetes secret obtained from Yugabyte Support.
+- A Kubernetes secret obtained from [Yugabyte](https://www.yugabyte.com/platform/#request-trial-form).
 
 To confirm that `helm` is configured correctly, run the following command:
 

--- a/docs/content/stable/yugabyte-platform/install-yugabyte-platform/prerequisites.md
+++ b/docs/content/stable/yugabyte-platform/install-yugabyte-platform/prerequisites.md
@@ -65,5 +65,5 @@ To install Yugabyte Platform on Airgapped hosts, without access to any Internet 
   - `22` – SSH
 - Attached disk storage (such as persistent EBS volumes on AWS): 100 GB minimum
 - The Yugabyte Platform airgapped install package (contact Yugabyte support)
-- A Yugabyte Platform license file (contact Yugabyte Support)
+- A Yugabyte Platform license file from [Yugabyte](https://www.yugabyte.com/platform/#request-trial-form)
 - Ability to connect from the Yugabyte Platform host to all YugabyteDB data nodes. If this is not set up, set up passwordless SSH.

--- a/docs/content/v1.3/deploy/enterprise-edition/install-admin-console/airgapped.md
+++ b/docs/content/v1.3/deploy/enterprise-edition/install-admin-console/airgapped.md
@@ -97,7 +97,7 @@ The simplest option is use a self-signed cert for now and add the custom SSL cer
 
 ### Upload license file
 
-Now upload the Yugabyte license file received from Yugabyte Support.
+Now upload the Yugabyte license file received from [Yugabyte](https://www.yugabyte.com/platform/#request-trial-form).
 
 ![Replicated License Upload](/images/replicated/replicated-license-upload.png)
 

--- a/docs/content/v1.3/deploy/enterprise-edition/install-admin-console/default.md
+++ b/docs/content/v1.3/deploy/enterprise-edition/install-admin-console/default.md
@@ -49,7 +49,7 @@ The simplest option is use a self-signed cert for now and add the custom SSL cer
 
 ### Upload license file
 
-Now upload the Yugabyte license file received from Yugabyte Support.
+Now upload the Yugabyte license file received from [Yugabyte](https://www.yugabyte.com/platform/#request-trial-form).
 
 ![Replicated License Upload](/images/replicated/replicated-license-upload.png)
 

--- a/docs/content/v1.3/faq/enterprise-edition.md
+++ b/docs/content/v1.3/faq/enterprise-edition.md
@@ -50,7 +50,7 @@ For airgapped hosts a supported version of docker-engine (currently 1.7.1 to 17.
 
 - Following ports should be open on the YugaWare host: 8800 (replicated ui), 80 (http for yugaware ui), 22 (ssh)
 - Attached disk storage (such as persistent EBS volumes on AWS): 100 GB minimum
-- A Yugabyte license file (attached to your welcome email from Yugabyte Support)
+- A Yugabyte license file from [Yugabyte](https://www.yugabyte.com/platform/#request-trial-form)
 - Ability to connect from the YugaWare host to all the YugabyteDB data nodes. If this is not setup, [setup passwordless ssh](#step-5-troubleshoot-yugaware).
 
 

--- a/docs/content/v2.0/deploy/enterprise-edition/install-admin-console/airgapped.md
+++ b/docs/content/v2.0/deploy/enterprise-edition/install-admin-console/airgapped.md
@@ -97,7 +97,7 @@ The simplest option is use a self-signed cert for now and add the custom SSL cer
 
 ### Upload license file
 
-Now upload the Yugabyte license file received from Yugabyte Support.
+Now upload the Yugabyte license file received from [Yugabyte](https://www.yugabyte.com/platform/#request-trial-form).
 
 ![Replicated License Upload](/images/replicated/replicated-license-upload.png)
 

--- a/docs/content/v2.0/deploy/enterprise-edition/install-admin-console/default.md
+++ b/docs/content/v2.0/deploy/enterprise-edition/install-admin-console/default.md
@@ -49,7 +49,7 @@ The simplest option is use a self-signed cert for now and add the custom SSL cer
 
 ### Upload license file
 
-Now upload the Yugabyte license file received from Yugabyte Support.
+Now upload the Yugabyte license file received from [Yugabyte](https://www.yugabyte.com/platform/#request-trial-form).
 
 ![Replicated License Upload](/images/replicated/replicated-license-upload.png)
 

--- a/docs/content/v2.0/faq/yugabyte-platform.md
+++ b/docs/content/v2.0/faq/yugabyte-platform.md
@@ -50,7 +50,7 @@ For airgapped hosts a supported version of docker-engine (currently 1.7.1 to 17.
 
 - Following ports should be open on the YugaWare host: 8800 (replicated ui), 80 (http for yugaware ui), 22 (ssh)
 - Attached disk storage (such as persistent EBS volumes on AWS): 100 GB minimum
-- A Yugabyte license file (attached to your welcome email from Yugabyte Support)
+- A Yugabyte license file from [Yugabyte](https://www.yugabyte.com/platform/#request-trial-form)
 - Ability to connect from the YugaWare host to all the YugabyteDB data nodes. If this is not setup, [setup passwordless ssh](#step-5-troubleshoot-yugaware).
 
 ## What are the OS requirements and permissions to run the YugabyteDB data nodes?

--- a/docs/content/v2.1/deploy/enterprise-edition/install-admin-console/airgapped.md
+++ b/docs/content/v2.1/deploy/enterprise-edition/install-admin-console/airgapped.md
@@ -133,7 +133,7 @@ The simplest option is use a self-signed cert for now and add the custom SSL cer
 
 ### Upload license file
 
-Now, upload the Yugabyte license file received from Yugabyte Support.
+Now, upload the Yugabyte license file received from [Yugabyte](https://www.yugabyte.com/platform/#request-trial-form).
 
 ![Replicated License Upload](/images/replicated/replicated-license-upload.png)
 

--- a/docs/content/v2.1/deploy/enterprise-edition/install-admin-console/default.md
+++ b/docs/content/v2.1/deploy/enterprise-edition/install-admin-console/default.md
@@ -85,7 +85,7 @@ The simplest option is use a self-signed cert for now and add the custom SSL cer
 
 ### Upload license file
 
-Now upload the Yugabyte license file received from Yugabyte Support.
+Now upload the Yugabyte license file received from [Yugabyte](https://www.yugabyte.com/platform/#request-trial-form).
 
 ![Replicated License Upload](/images/replicated/replicated-license-upload.png)
 

--- a/docs/content/v2.1/deploy/enterprise-edition/install-admin-console/kubernetes.md
+++ b/docs/content/v2.1/deploy/enterprise-edition/install-admin-console/kubernetes.md
@@ -67,7 +67,7 @@ $ kubectl create namespace yw-test
 namespace/yw-test created
 ```
 
-2. Run the following `kubectl apply` command to apply the secret. To get the secret, contact Yugabyte Support.
+2. Run the following `kubectl apply` command to apply the secret. To get the secret, contact [Yugabyte](https://www.yugabyte.com/platform/#request-trial-form).
 
 ```sh
 $ kubectl apply -f ~/Desktop/K8s/yugabyte-k8s-secret.yml -n yw-test

--- a/docs/content/v2.1/faq/yugabyte-platform.md
+++ b/docs/content/v2.1/faq/yugabyte-platform.md
@@ -51,7 +51,7 @@ For airgapped hosts, a supported version of docker-engine (currently 1.7.1 to 17
 
 - Following ports should be open on the YugaWare host: `8800` (replicated ui), `80` (http for YugabyteDB Admin Console), `22` (ssh)
 - Attached disk storage (such as persistent EBS volumes on AWS): 100 GB minimum
-- A Yugabyte Platform license file (attached to your welcome email from Yugabyte Support)
+- A Yugabyte Platform license file from [Yugabyte](https://www.yugabyte.com/platform/)
 - Ability to connect from the Yugabyte Platform host to all YugabyteDB data nodes. If this is not set up, [setup passwordless ssh](#step-5-troubleshoot-yugaware).
 
 ## What are the OS requirements and permissions to run the YugabyteDB data nodes?


### PR DESCRIPTION
Yugabyte support does not currently control the license issuing process,
so direct folks following along in the documentation to the form that
leads them down the right path.