### PR TITLE
[yugabyted] Added --stdout to collect_logs for docker

### DIFF
--- a/bin/yugabyted
+++ b/bin/yugabyted
@@ -350,7 +350,17 @@ class ControlScript(object):
         tarpath = os.path.join(os.path.expanduser('~'), tmpprefix)
         with tarfile.open(name=tarpath, mode='w:gz', dereference=True) as archive:
             archive.add(logpath)
-        Output.print_and_log("Logs are packaged into {}".format(tarpath))
+
+        if self.configs.temp_data.get("collect_logs_stdout"):
+            Output.log("Logs are packaged into {}".format(tarpath))
+            if tarfile.is_tarfile(tarpath):
+                with open(tarpath, 'rb') as tar_fd:
+                    if sys.version_info[0] == 3:
+                        sys.stdout.buffer.write(tar_fd.read())
+                    else:
+                        sys.stdout.write(tar_fd.read())
+        else:
+            Output.print_and_log("Logs are packaged into {}".format(tarpath))
 
     # Checks yb-master and yb-tserver are running. Returns failed processes.
     # TODO: Check postmaster.pid.
@@ -1134,6 +1144,9 @@ class ControlScript(object):
             if path:
                 setattr(args, path_args, os.path.abspath(os.path.realpath(path)))
 
+        if args.parser == "collect_logs":
+            self.configs.temp_data["collect_logs_stdout"] = args.stdout
+
         if args.parser == "start":
             if args.data_dir is not None:
                 config_data_dir = self.configs.saved_data.get("data_dir")
@@ -1265,6 +1278,14 @@ class ControlScript(object):
             func = getattr(self, parser_name, None)
             subparser.set_defaults(func=func)
             all_parsers[parser_name] = subparser
+
+        # Docker: Redirect the logs.tar.gz to stdout
+        for cmd in ("collect_logs",):
+            cur_parser = all_parsers[cmd]
+            cur_parser.add_argument(
+                "--stdout", help="Redirect the logs.tar.gz file's content to stdout. Ex: \
+                docker exec <container-id> bin/yugabyted collect_logs --stdout > yugabyted.tar.gz",
+                action="store_true", default=False)
 
         # Commands that can alter configuration file.
         for cmd in ("start",):
@@ -1440,6 +1461,7 @@ class Configs(object):
             "daemon": True,
             "ui": False,
             "initial_scripts_dir": "",
+            "collect_logs_stdout": False,
         }
         self.config_file = config_file
 


### PR DESCRIPTION
### Summary:

- Added `--stdout` functionality to `collect_logs` command of `yugabyted`
- Mentioning `--stdout` like this `bin/yugabyted collect_logs --stdout` will publish the `logs.tar.gz` on stdout. We can use the redirection operator to capture the output. So the final command will be like this to capture the logs from yugabyted in docker. `docker exec <container-id> bin/yugabyted collect_logs --stdout > yugabyted-logs.tar.gz`.

### Test plan:

- Tested with Python v2 and v3.
- Working as expected in the local environment.
- Created the docker image and execute the above-mentioned command to get logs outside from the docker container.

```bash
ubuntu@ip-172-31-12-205:~/test-yugabyted/test$ docker run -d baba230896/yugabyte-db:6145 bin/yugabyted start --daemon=false
b5805457a3d653685f45a0768f9fcac2e5db782dc9c8542a3a6fb9ca7d69304c
ubuntu@ip-172-31-12-205:~/test-yugabyted/test$ docker ps
CONTAINER ID        IMAGE                         COMMAND                  CREATED             STATUS              PORTS                                                                                                             NAMES
b5805457a3d6        baba230896/yugabyte-db:6145   "bin/yugabyted start…"   47 seconds ago      Up 46 seconds       5433/tcp, 6379/tcp, 7000/tcp, 7100/tcp, 7200/tcp, 9000/tcp, 9042/tcp, 9100/tcp, 10100/tcp, 11000/tcp, 12000/tcp   stupefied_noyce
ubuntu@ip-172-31-12-205:~/test-yugabyted/test$ docker exec -it b5805457a3d6 bin/ysqlsh
ysqlsh (11.2-YB-2.5.0.0-b0)
Type "help" for help.

yugabyte=# CREATE DATABASE demo;
CREATE DATABASE
yugabyte=# exit
ubuntu@ip-172-31-12-205:~/test-yugabyted/test$ docker exec  b5805457a3d6 bin/yugabyted collect_logs
Logs are packaged into /root/yugabyted-2020-11-24-17:08:15.280498.tar.gz
ubuntu@ip-172-31-12-205:~/test-yugabyted/test$ docker exec  b5805457a3d6 bin/yugabyted collect_logs --stdout > yugabyted-logs.tar.gz
ubuntu@ip-172-31-12-205:~/test-yugabyted/test$ ll
total 184
drwxrwxr-x 2 ubuntu ubuntu   4096 Nov 24 17:08 ./
drwxrwxr-x 4 ubuntu ubuntu   4096 Nov 24 04:48 ../
-rw-rw-r-- 1 ubuntu ubuntu  61353 Nov 24 17:08 yugabyted-logs.tar.gz
ubuntu@ip-172-31-12-205:~/test-yugabyted/test$ tar -xzf yugabyted-logs.tar.gz 
ubuntu@ip-172-31-12-205:~/test-yugabyted/test$ ll home/yugabyte/var/logs/
master/        master.err     master.out     tserver/       tserver.err    tserver.out    yugabyted.log
```

### Fixes:
https://github.com/yugabyte/yugabyte-db/issues/6145