### PR TITLE
Additional default firewall ports

### DIFF
--- a/docs/content/latest/reference/configuration/default-ports.md
+++ b/docs/content/latest/reference/configuration/default-ports.md
@@ -64,7 +64,7 @@ YugabyteDB servers expose time-series performance metrics in the [Prometheus exp
 <target>/prometheus-metrics
 ```
 
-You can access the Prometheus server on port `9090`, and you can see the list of targets at the `http://<yugaware-ip>:9090/targets`. In particular, note port `93000` for node level metrics.
+You can access the Prometheus server on port `9090` of the Platform node, and you can see the list of targets at the `http://<yugaware-ip>:9090/targets`. In particular, note port `93000` for node level metrics.
 
 ### Servers
 

--- a/docs/content/latest/reference/configuration/default-ports.md
+++ b/docs/content/latest/reference/configuration/default-ports.md
@@ -45,6 +45,17 @@ Admin web server UI can be viewed at these addresses.
 | yb-master  | 7000  |  [`--webserver_interface 0.0.0.0`](../yb-master/#webserver-interface)<br>[`--webserver_port 7000`](../yb-master/#webserver-port) |
 | yb-tserver | 9000  |  [`--webserver_interface 0.0.0.0`](../yb-master/#webserver-interface)<br>[`--webserver_port 9000`](../yb-master/#webserver-port) |
 
+## Firewall Rules
+Along with the above, include the following common ports in firewall rules. 
+
+| Service     | Port
+| ------- | ------------------------- |
+| SSH    | `tcp:22` |
+| HTTP   | `tcp:80` |
+| HTTPS   | `tcp:443` |
+| HTTP (alternate)   | `tcp:8080` |
+| HTTP (Replicated)    | `tcp:8800` |
+
 ## Prometheus monitoring
 
 YugabyteDB servers expose time-series performance metrics in the [Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format) on multiple HTTP endpoints. These endpoints have the following structure.
@@ -73,5 +84,6 @@ Use the following `yb-tserver` targets for the various API metrics.
 | ysql    | `<yb-tserver-address>:13000` |
 | ycql    | `<yb-tserver-address>:12000` |
 | yedis   | `<yb-tserver-address>:11000` |
+
 
 For a quick tutorial on using Prometheus with YugabyteDB, see [Observability with Prometheus](../../../explore/observability).

--- a/docs/content/latest/reference/configuration/default-ports.md
+++ b/docs/content/latest/reference/configuration/default-ports.md
@@ -50,11 +50,11 @@ Along with the above, include the following common ports in firewall rules.
 
 | Service     | Port
 | ------- | ------------------------- |
-| SSH    | `tcp:22` |
-| HTTP   | `tcp:80` |
-| HTTPS   | `tcp:443` |
-| HTTP (alternate)   | `tcp:8080` |
-| HTTP (Replicated)    | `tcp:8800` |
+| SSH    | 22 |
+| HTTP for Platform  | 80 |
+| HTTP for Platform (alternate) | 8080 |
+| HTTPS for Platform  | 443 |
+| HTTP for Replicated | 8800 |
 
 ## Prometheus monitoring
 
@@ -64,7 +64,7 @@ YugabyteDB servers expose time-series performance metrics in the [Prometheus exp
 <target>/prometheus-metrics
 ```
 
-Following is the list of targets available.
+You can access the Prometheus server on port `9090`, and you can see the list of targets at the `http://<yugaware-ip>:9090/targets`. In particular, note port `93000` for node level metrics.
 
 ### Servers
 

--- a/docs/content/stable/reference/configuration/default-ports.md
+++ b/docs/content/stable/reference/configuration/default-ports.md
@@ -43,6 +43,17 @@ Admin web server UI can be viewed at these addresses.
 | yb-master  | 7000  |  [`--webserver_interface 0.0.0.0`](../yb-master/#webserver-interface)<br>[`--webserver_port 7000`](../yb-master/#webserver-port) |
 | yb-tserver | 9000  |  [`--webserver_interface 0.0.0.0`](../yb-master/#webserver-interface)<br>[`--webserver_port 9000`](../yb-master/#webserver-port) |
 
+## Firewall Rules
+Along with the above, include the following common ports in firewall rules. 
+
+| Service     | Port
+| ------- | ------------------------- |
+| SSH    | `tcp:22` |
+| HTTP   | `tcp:80` |
+| HTTPS   | `tcp:443` |
+| HTTP (alternate)   | `tcp:8080` |
+| HTTP (Replicated)    | `tcp:8800` |
+
 ## Prometheus monitoring
 
 YugabyteDB servers expose time-series performance metrics in the [Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format) on multiple HTTP endpoints. These endpoints have the following structure.

--- a/docs/content/stable/reference/configuration/default-ports.md
+++ b/docs/content/stable/reference/configuration/default-ports.md
@@ -48,21 +48,24 @@ Along with the above, include the following common ports in firewall rules.
 
 | Service     | Port
 | ------- | ------------------------- |
-| SSH    | `tcp:22` |
-| HTTP   | `tcp:80` |
-| HTTPS   | `tcp:443` |
-| HTTP (alternate)   | `tcp:8080` |
-| HTTP (Replicated)    | `tcp:8800` |
+| SSH    | 22 |
+| HTTP for Platform  | 80 |
+| HTTP for Platform (alternate) | 8080 |
+| HTTPS for Platform  | 443 |
+| HTTP for Replicated | 8800 |
 
-## Prometheus monitoring
+## Monitoring with Prometheus
 
-YugabyteDB servers expose time-series performance metrics in the [Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format) on multiple HTTP endpoints. These endpoints have the following structure.
+Use the following targets to configure [Prometheus](https://prometheus.io/) to scrape available metrics (in [Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format)) from the YugabyteDB HTTP endpoint:
 
 ```
 <target>/prometheus-metrics
 ```
 
-Following is the list of targets available.
+You can access the Prometheus server on port `9090` of the Platform node, and you can see the list of targets at the `http://<yugaware-ip>:9090/targets`. In particular, note port `93000` for node level metrics.
+
+For a quick tutorial on using Prometheus with YugabyteDB, see [Observability with Prometheus](../../../explore/observability).
+
 
 ### Servers
 
@@ -83,4 +86,3 @@ Use the following `yb-tserver` targets for the various API metrics.
 | ycql    | `<yb-tserver-address>:12000` |
 | yedis   | `<yb-tserver-address>:11000` |
 
-For a quick tutorial on using Prometheus with YugabyteDB, see [Observability with Prometheus](../../../explore/observability).

--- a/docs/content/v2.0/reference/configuration/default-ports.md
+++ b/docs/content/v2.0/reference/configuration/default-ports.md
@@ -28,8 +28,10 @@ Application clients connect to these addresses.
 Use the following targets to configure [Prometheus](https://prometheus.io/) to scrape available metrics (in [Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format)) from the YugabyteDB HTTP endpoint:
 
 ```
-/prometheus-metrics
+<target>/prometheus-metrics
 ```
+
+You can access the Prometheus server on port `9090` of the Platform node, and you can see the list of targets at the `http://<yugaware-ip>:9090/targets`. In particular, note port `93000` for node level metrics.
 
 For a quick tutorial on using Prometheus with YugabyteDB, see [Observability with Prometheus](../../../explore/observability).
 
@@ -75,8 +77,8 @@ Along with the above, include the following common ports in firewall rules.
 
 | Service     | Port
 | ------- | ------------------------- |
-| SSH    | `tcp:22` |
-| HTTP   | `tcp:80` |
-| HTTPS   | `tcp:443` |
-| HTTP (alternate)   | `tcp:8080` |
-| HTTP (Replicated)    | `tcp:8800` |
+| SSH    | 22 |
+| HTTP for Platform  | 80 |
+| HTTP for Platform (alternate) | 8080 |
+| HTTPS for Platform  | 443 |
+| HTTP for Replicated | 8800 |

--- a/docs/content/v2.0/reference/configuration/default-ports.md
+++ b/docs/content/v2.0/reference/configuration/default-ports.md
@@ -70,4 +70,13 @@ Admin web server UI can be viewed at these addresses.
 | yb-master  | 7000  |  [`--webserver_interface 0.0.0.0`](../yb-master/#webserver-interface)<br >[`--webserver_port 7000`](../yb-master/#webserver-port) |
 | yb-tserver | 9000  |  [`--webserver_interface 0.0.0.0`](../yb-master/#webserver-interface)<br >[`--webserver_port 9000`](../yb-master/#webserver-port) |
 
+### Firewall Rules
+Along with the above, include the following common ports in firewall rules. 
 
+| Service     | Port
+| ------- | ------------------------- |
+| SSH    | `tcp:22` |
+| HTTP   | `tcp:80` |
+| HTTPS   | `tcp:443` |
+| HTTP (alternate)   | `tcp:8080` |
+| HTTP (Replicated)    | `tcp:8800` |

--- a/docs/content/v2.1/reference/configuration/default-ports.md
+++ b/docs/content/v2.1/reference/configuration/default-ports.md
@@ -49,21 +49,24 @@ Along with the above, include the following common ports in firewall rules.
 
 | Service     | Port
 | ------- | ------------------------- |
-| SSH    | `tcp:22` |
-| HTTP   | `tcp:80` |
-| HTTPS   | `tcp:443` |
-| HTTP (alternate)   | `tcp:8080` |
-| HTTP (Replicated)    | `tcp:8800` |
+| SSH    | 22 |
+| HTTP for Platform  | 80 |
+| HTTP for Platform (alternate) | 8080 |
+| HTTPS for Platform  | 443 |
+| HTTP for Replicated | 8800 |
 
-## Prometheus monitoring
+## Monitoring with Prometheus
 
-YugabyteDB servers expose time-series performance metrics in the [Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format) on multiple HTTP endpoints. These endpoints have the following structure.
+Use the following targets to configure [Prometheus](https://prometheus.io/) to scrape available metrics (in [Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format)) from the YugabyteDB HTTP endpoint:
 
 ```
 <target>/prometheus-metrics
 ```
 
-Following is the list of targets available.
+You can access the Prometheus server on port `9090` of the Platform node, and you can see the list of targets at the `http://<yugaware-ip>:9090/targets`. In particular, note port `93000` for node level metrics.
+
+For a quick tutorial on using Prometheus with YugabyteDB, see [Observability with Prometheus](../../../explore/observability).
+
 
 ### Servers
 
@@ -84,4 +87,3 @@ Use the following `yb-tserver` targets for the various API metrics.
 | ycql    | `<yb-tserver-address>:12000` |
 | yedis   | `<yb-tserver-address>:11000` |
 
-For a quick tutorial on using Prometheus with YugabyteDB, see [Observability with Prometheus](../../../explore/observability).

--- a/docs/content/v2.1/reference/configuration/default-ports.md
+++ b/docs/content/v2.1/reference/configuration/default-ports.md
@@ -44,6 +44,17 @@ Admin web server UI can be viewed at these addresses.
 | yb-master  | 7000  |  [`--webserver_interface 0.0.0.0`](../yb-master/#webserver-interface)<br>[`--webserver_port 7000`](../yb-master/#webserver-port) |
 | yb-tserver | 9000  |  [`--webserver_interface 0.0.0.0`](../yb-master/#webserver-interface)<br>[`--webserver_port 9000`](../yb-master/#webserver-port) |
 
+## Firewall Rules
+Along with the above, include the following common ports in firewall rules. 
+
+| Service     | Port
+| ------- | ------------------------- |
+| SSH    | `tcp:22` |
+| HTTP   | `tcp:80` |
+| HTTPS   | `tcp:443` |
+| HTTP (alternate)   | `tcp:8080` |
+| HTTP (Replicated)    | `tcp:8800` |
+
 ## Prometheus monitoring
 
 YugabyteDB servers expose time-series performance metrics in the [Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format) on multiple HTTP endpoints. These endpoints have the following structure.


### PR DESCRIPTION
Adds additional default ports needed for firewall rules when setting up a cluster managed by YB Platform.