### PR TITLE
docs: fix client-to-server.md style

### DIFF
--- a/docs/content/latest/secure/tls-encryption/client-to-server.md
+++ b/docs/content/latest/secure/tls-encryption/client-to-server.md
@@ -35,7 +35,7 @@ Configuration flag                   | Process    | Description                 
 To enable access control, follow these steps, start the `yb-tserver` services with the following flag (described above):
   
 ```
---use_client_to_server_encryption=true`
+--use_client_to_server_encryption=true
 ```
 
 This flag enables both encrypted and unencrypted clients to connect to the cluster.
@@ -43,7 +43,7 @@ This flag enables both encrypted and unencrypted clients to connect to the clust
 To prevent clients without the appropriate encryption from connecting, you must add the following flag:
 
 ```
---allow_insecure_connections=false`
+--allow_insecure_connections=false
 ```
 
 Your command should look similar to this:

--- a/docs/content/latest/secure/tls-encryption/client-to-server.md
+++ b/docs/content/latest/secure/tls-encryption/client-to-server.md
@@ -16,7 +16,7 @@ isTocNested: true
 showAsideToc: true
 ---
 
-YugabyteDB clusters can be configured to use client-to-server encryption to protect data in transit between YugabyteDB servers and clients, tools, and APIs. When enabled,  [Transport Layer Security (TLS)](https://en.wikipedia.org/wiki/Transport_Layer_Security), the successor to the deprecated Secure Sockets Layer (SSL), is used to ensure data protection for YSQL and YCQL only. Note that there is no planned support for YEDIS.
+YugabyteDB clusters can be configured to use client-to-server encryption to protect data in transit between YugabyteDB servers and clients, tools, and APIs. When enabled, [Transport Layer Security (TLS)](https://en.wikipedia.org/wiki/Transport_Layer_Security), the successor to the deprecated Secure Sockets Layer (SSL), is used to ensure data protection for YSQL and YCQL only. Note that there is no planned support for YEDIS.
 
 ## Prerequisites
 
@@ -28,12 +28,12 @@ To enable client-to-server encryption for YSQL and YCQL, start your YB-TServer s
 
 Configuration flag                   | Process    | Description                  |
 -------------------------------------|------------|------------------------------|
-[`--use_client_to_server_encryption`](../../../admin/yb-tserver/#use-client-to-server-encryption)  | YB-TServer | Set to `true` to enable encryption between the various YugabyteDB clients and the database cluster. Default value is `false`. |
-[`--allow_insecure_connections`](../../../admin/yb-tserver/#allow-insecure-connections)         | YB-TServer | Set to `false` to disallow any client with unencrypted communication from joining this cluster. Default value is `true`. Note that this flag requires `--use_client_to_server_encryption` to be enabled. |
-[`--certs_for_client_dir`](../../../admin/yb-tserver/#certs-for-client-dir)               | YB-TServer | Optional. Defaults to the same directory as the server-to-server encryption. This directory should contain the configuration for the client to perform TLS communication with the cluster. Default value for YB-TServer is `<data drive>/yb-data/tserver/data/certs`  |
+[`--use_client_to_server_encryption`](../../../admin/yb-tserver/#use-client-to-server-encryption) | YB-TServer | Set to `true` to enable encryption between the various YugabyteDB clients and the database cluster. Default value is `false`. |
+[`--allow_insecure_connections`](../../../admin/yb-tserver/#allow-insecure-connections) | YB-TServer | Set to `false` to disallow any client with unencrypted communication from joining this cluster. Default value is `true`. Note that this flag requires `--use_client_to_server_encryption` to be enabled. |
+[`--certs_for_client_dir`](../../../admin/yb-tserver/#certs-for-client-dir) | YB-TServer | Optional. Defaults to the same directory as the server-to-server encryption. This directory should contain the configuration for the client to perform TLS communication with the cluster. Default value for YB-TServer is `<data drive>/yb-data/tserver/data/certs` |
 
 To enable access control, follow these steps, start the `yb-tserver` services with the following flag (described above):
-  
+
 ```
 --use_client_to_server_encryption=true
 ```


### PR DESCRIPTION
- fix: rm trailing backtick in fenced codeblocks
- style: rm useless whitespace