### PR TITLE
[Docs] Fix section image in exploring Transactions page. Add correct page link

### DIFF
--- a/docs/content/latest/explore/transactions/_index.md
+++ b/docs/content/latest/explore/transactions/_index.md
@@ -4,6 +4,7 @@ headerTitle: Transactions
 linkTitle: Transactions
 description: Transactions in YugabyteDB.
 headcontent: Transactions in YugabyteDB.
+image: /images/section_icons/explore/transactional.png
 menu:
   latest:
     identifier: explore-transactions

--- a/docs/content/latest/yugabyte-platform/_index.md
+++ b/docs/content/latest/yugabyte-platform/_index.md
@@ -86,13 +86,13 @@ menu:
   </div>
   
   <div class="col-12 col-md-6 col-lg-12 col-xl-6">
-    <a class="section-link icon-offset" href="alerts-monitoring/">
+    <a class="section-link icon-offset" href="create-deployments/">
       <div class="head">
         <img class="icon" src="/images/section_icons/deploy/enterprise/console.png" aria-hidden="true" />
-        <div class="title">Alerts and monitoring</div>
+        <div class="title">Create deployments</div>
       </div>
       <div class="body">
-        Create alerts and monitor dashboards using Yugabyte Platform.
+        Create YugabyteDB universe deployments
       </div>
     </a>
   </div>


### PR DESCRIPTION
Transactions section image
<img width="1055" alt="Screen Shot 2020-12-14 at 9 53 35 PM" src="https://user-images.githubusercontent.com/50115930/102177144-bd10be00-3e57-11eb-8ba4-bf096e6aaee4.png">
Page link of duplicated card: https://docs.yugabyte.com/latest/yugabyte-platform/
Fixed link
<img width="1038" alt="Screen Shot 2020-12-14 at 10 01 07 PM" src="https://user-images.githubusercontent.com/50115930/102177211-e5002180-3e57-11eb-8202-fd400cdd938a.png">
