### PR TITLE
[Platform] Use appConfig to get value of log.override.path

### DIFF
--- a/managed/src/main/java/com/yugabyte/yw/controllers/SessionController.java
+++ b/managed/src/main/java/com/yugabyte/yw/controllers/SessionController.java
@@ -362,7 +362,7 @@ public class SessionController extends Controller {
   @With(TokenAuthenticator.class)
   public Result getLogs(Integer maxLines) {
     String appHomeDir = appConfig.getString("application.home", ".");
-    String logDir = System.getProperty("log.override.path", String.format("%s/logs", appHomeDir));
+    String logDir = appConfig.getString("log.override.path", String.format("%s/logs", appHomeDir));
     File file = new File(String.format("%s/application.log", logDir));
     // TODO(bogdan): This is not really pagination friendly as it re-reads everything all the time.
     // TODO(bogdan): Need to figure out if there's a rotation-friendly log-reader..


### PR DESCRIPTION
This change makes it possible to configure the value of log.override.path via application conf file.

The application.conf should have following entries to configure this.

```
play.logger.includeConfigProperties=true
log.override.path=/opt/platform-logs
```

The existing way to change the value continues to work i.e specifying flag `-Dlog.override.path=/opt/platform-logs`.

### Scenarios tested
- Started platform with following snippet in the application.conf file.
  ```
  play.logger.includeConfigProperties=true
  log.override.path=/opt/yugaware_data/logs
  ```
  The logs were created in that directory and the `/logs` endpoint was showing the logs.
- Started platform with `-Dlog.override.path=/opt/yugaware_data/logs`
  The logs were created in the given directory and the `/logs` endpoint was showing the logs.