### PR TITLE
allow OPTIONS in CQL protocol prior to AUTHENTICATE

### DIFF
--- a/src/yb/yql/cql/cqlserver/cql_processor.cc
+++ b/src/yb/yql/cql/cqlserver/cql_processor.cc
@@ -246,6 +246,8 @@ bool CQLProcessor::CheckAuthentication(const CQLRequest& req) const {
   return call_->ql_session()->is_user_authenticated() ||
       // CQL requests which do not need authorization.
       req.opcode() == CQLMessage::Opcode::STARTUP ||
+      // Some drivers issue OPTIONS prior to AUTHENTICATE
+      req.opcode() == CQLMessage::Opcode::OPTIONS ||
       req.opcode() == CQLMessage::Opcode::AUTH_RESPONSE;
 }
 


### PR DESCRIPTION
for backwards compatibility with DataStax PHP driver (and possibly their cpp driver, which PHP driver relies on).
