### PR TITLE
[#5594] Platform:Handle invalid certs/keys correctly.

### DIFF
--- a/managed/src/main/java/com/yugabyte/yw/controllers/CertificateController.java
+++ b/managed/src/main/java/com/yugabyte/yw/controllers/CertificateController.java
@@ -74,7 +74,7 @@ public class CertificateController extends AuthenticatedController {
       return ApiResponse.success(certUUID);
     } catch (Exception e) {
       LOG.error("Could not upload certs for customer {}", customerUUID, e);
-      return ApiResponse.error(BAD_REQUEST, "Couldn't upload certfiles");
+      return ApiResponse.error(BAD_REQUEST, e.getMessage());
     }
   }
 

--- a/managed/src/test/java/com/yugabyte/yw/common/CertificateHelperTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/common/CertificateHelperTest.java
@@ -36,11 +36,12 @@ import java.security.cert.X509Certificate;
 import java.util.UUID;
 import java.util.Calendar;
 import java.util.Date;
+
 import static org.junit.Assert.*;
 
 
 @RunWith(MockitoJUnitRunner.class)
-public class CertificateHelperTest extends FakeDBApplication{
+public class CertificateHelperTest extends FakeDBApplication {
 
   private Customer c;
 
@@ -68,7 +69,7 @@ public class CertificateHelperTest extends FakeDBApplication{
       CertificateFactory factory = CertificateFactory.getInstance("X.509");
       X509Certificate cert = (X509Certificate) factory.generateCertificate(in);
       assertEquals(cert.getIssuerDN(), cert.getSubjectDN());
-    } catch (Exception e){
+    } catch (Exception e) {
       fail(e.getMessage());
     }
   }
@@ -79,8 +80,8 @@ public class CertificateHelperTest extends FakeDBApplication{
     taskParams.nodePrefix = "test-universe";
     UUID rootCA = CertificateHelper.createRootCA(taskParams.nodePrefix, c.uuid, "/tmp");
     CertificateHelper.createClientCertificate(rootCA, String.format(certPath + "/%s",
-                                                                    rootCA),
-                                              "yugabyte", null, null);
+      rootCA),
+      "yugabyte", null, null);
     assertNotNull(CertificateInfo.get(rootCA));
     try {
       InputStream in = new FileInputStream(certPath + String.format("/%s/ca.root.crt", rootCA));
@@ -88,17 +89,17 @@ public class CertificateHelperTest extends FakeDBApplication{
       X509Certificate cert = (X509Certificate) factory.generateCertificate(in);
       assertEquals(cert.getIssuerDN(), cert.getSubjectDN());
       FileInputStream is = new FileInputStream(new File(certPath +
-          String.format("/%s/yugabytedb.crt", rootCA)));
+        String.format("/%s/yugabytedb.crt", rootCA)));
       X509Certificate clientCer = (X509Certificate) factory.generateCertificate(is);
       clientCer.verify(cert.getPublicKey(), "BC");
-    } catch (Exception e){
+    } catch (Exception e) {
       fail(e.getMessage());
     }
   }
 
   @Test
   public void testCreateCustomerCertToString() throws CertificateException,
-    NoSuchAlgorithmException,InvalidKeyException, NoSuchProviderException,
+    NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException,
     SignatureException, IOException {
     UniverseDefinitionTaskParams taskParams = new UniverseDefinitionTaskParams();
     taskParams.nodePrefix = "test-universe";
@@ -115,7 +116,7 @@ public class CertificateHelperTest extends FakeDBApplication{
     cal.add(Calendar.YEAR, 1);
     Date certExpiry = cal.getTime();
     JsonNode result = CertificateHelper.createClientCertificate(rootCA, null, "postgres",
-                                                                certStart, certExpiry);
+      certStart, certExpiry);
     String clientCert = result.get("yugabytedb.crt").asText();
     assertNotNull(clientCert);
     ByteArrayInputStream bytes = new ByteArrayInputStream(clientCert.getBytes());
@@ -142,7 +143,7 @@ public class CertificateHelperTest extends FakeDBApplication{
     cal.add(Calendar.YEAR, 1);
     Date certExpiry = cal.getTime();
     JsonNode result = CertificateHelper.createClientCertificate(rootCA,
-        String.format("/tmp", rootCA), "postgres", certStart, certExpiry);
+      String.format("/tmp", rootCA), "postgres", certStart, certExpiry);
 
     is = new FileInputStream(new File(String.format("/tmp/yugabytedb.crt", rootCA)));
     X509Certificate clientCer = (X509Certificate) fact.generateCertificate(is);
@@ -157,14 +158,50 @@ public class CertificateHelperTest extends FakeDBApplication{
     cal.add(Calendar.YEAR, 1);
     Date certExpiry = cal.getTime();
     UUID rootCA = null;
-    CertificateInfo.Type type = CertificateInfo.Type.SelfSigned;
+    CertificateInfo.Type type = CertificateInfo.Type.CustomCertHostPath;
+    String cert_content = "-----BEGIN CERTIFICATE-----\n" +
+      "MIIDDjCCAfagAwIBAgIGAXVXb5y/MA0GCSqGSIb3DQEBCwUAMDQxHDAaBgNVBAMM\n" +
+      "E3liLWFkbWluLXRlc3QtYXJuYXYxFDASBgNVBAoMC2V4YW1wbGUuY29tMB4XDTIw\n" +
+      "MTAyMzIxNDg1M1oXDTIxMTAyMzIxNDg1M1owNDEcMBoGA1UEAwwTeWItYWRtaW4t\n" +
+      "dGVzdC1hcm5hdjEUMBIGA1UECgwLZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEB\n" +
+      "AQUAA4IBDwAwggEKAoIBAQCVWSZiQhr9e+L2MkSXP38dwXwF7RlZGhrYKrL7pp6l\n" +
+      "aHkLZ0lsFgxI6h0Yyn5S+Hhi/jGWbBso6kXw7frUwVY5kX2Q6iv+E+rKqbYQgNV3\n" +
+      "0vpCtOmNNolhNN3x4SKAIXyKOB5dXMGesjvba/qD6AstKS8bvRCUZcYDPjIUQGPu\n" +
+      "cYLmywV/EdXgB+7WLhUOOY2eBRWBrnGxk60pcHJZeW44g1vas9cfiw81OWVp5/V5\n" +
+      "apA631bE0MTgg283OCyYz+CV/YtnytUTg/+PUEqzM2cWsWdvpEz7TkKYXinRdN4d\n" +
+      "SwgOQEIvb7A/GYYmVf3yk4moUxEh4NLoV9CBDljEBUjZAgMBAAGjJjAkMBIGA1Ud\n" +
+      "EwEB/wQIMAYBAf8CAQEwDgYDVR0PAQH/BAQDAgLkMA0GCSqGSIb3DQEBCwUAA4IB\n" +
+      "AQAFR0m7r1I3FyoatuLBIG+alaeGHqsgNqseAJTDGlEyajGDz4MT0c76ZIQkTSGM\n" +
+      "vsM49Ad2D04sJR44/WlI2AVijubzHBr6Sj8ZdB909nPvGtB+Z8OnvKxJ0LUKyG1K\n" +
+      "VUbcCnN3qSoVeY5PaPeFMmWF0Qv4S8lRTZqAvCnk34bckwkWoHkuuNGO49CsNb40\n" +
+      "Z2NBy9Ckp0KkfeDpGcv9lHuUrl13iakCY09irvYRbfi0lVGF3+wXZtefV8ZAxfnN\n" +
+      "Vt4faawkJ79oahlXDYs6WCKEd3zVM3mR3STnzwxvtB6WacjhqgP4ozXdt6PUbTfZ\n" +
+      "jZPSP3OuL0IXk96wFHScay8S\n" +
+      "-----END CERTIFICATE-----\n";
+
     try {
-      rootCA = CertificateHelper.uploadRootCA("test", c.uuid, "/tmp", "test_cert", "test_key",
-          certStart, certExpiry, type, null);
+      rootCA = CertificateHelper.uploadRootCA("test", c.uuid, "/tmp", cert_content, null,
+        certStart, certExpiry, type, null);
     } catch (Exception e) {
+      //assertEquals("Invalid certificate.", e.getMessage());
       fail(e.getMessage());
     }
     assertNotNull(CertificateInfo.get(rootCA));
   }
 
+  @Test
+  public void testSelfSignedCertUploadRootCA() {
+    Calendar cal = Calendar.getInstance();
+    Date certStart = cal.getTime();
+    cal.add(Calendar.YEAR, 1);
+    Date certExpiry = cal.getTime();
+    UUID rootCA = null;
+    CertificateInfo.Type type = CertificateInfo.Type.SelfSigned;
+    try {
+      rootCA = CertificateHelper.uploadRootCA("test", c.uuid, "/tmp", "test_cert", "test_key",
+        certStart, certExpiry, type, null);
+    } catch (Exception e) {
+      assertEquals("Invalid certificate.", e.getMessage());
+    }
+  }
 }

--- a/managed/src/test/java/com/yugabyte/yw/controllers/CertificateControllerTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/controllers/CertificateControllerTest.java
@@ -145,13 +145,8 @@ public class CertificateControllerTest extends FakeDBApplication {
     bodyJson.put("certType", "SelfSigned");
     Result result = uploadCertificate(customer.uuid, bodyJson);
     JsonNode json = Json.parse(contentAsString(result));
-    assertEquals(OK, result.status());
-    UUID certUUID = UUID.fromString(json.asText());
-    CertificateInfo ci = CertificateInfo.get(certUUID);
-    assertEquals(ci.label, "test");
-    assertEquals(ci.certType, CertificateInfo.Type.SelfSigned);
-    assertTrue(ci.certificate.contains("/tmp"));
-    assertAuditEntry(1, customer.uuid);
+    assertEquals(BAD_REQUEST, result.status());
+    assertAuditEntry(0, customer.uuid);
   }
 
   @Test
@@ -170,9 +165,28 @@ public class CertificateControllerTest extends FakeDBApplication {
 
   @Test
   public void testUploadCustomCertificate() {
+    String cert_content = "-----BEGIN CERTIFICATE-----\n" +
+      "MIIDDjCCAfagAwIBAgIGAXVXb5y/MA0GCSqGSIb3DQEBCwUAMDQxHDAaBgNVBAMM\n" +
+      "E3liLWFkbWluLXRlc3QtYXJuYXYxFDASBgNVBAoMC2V4YW1wbGUuY29tMB4XDTIw\n" +
+      "MTAyMzIxNDg1M1oXDTIxMTAyMzIxNDg1M1owNDEcMBoGA1UEAwwTeWItYWRtaW4t\n" +
+      "dGVzdC1hcm5hdjEUMBIGA1UECgwLZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEB\n" +
+      "AQUAA4IBDwAwggEKAoIBAQCVWSZiQhr9e+L2MkSXP38dwXwF7RlZGhrYKrL7pp6l\n" +
+      "aHkLZ0lsFgxI6h0Yyn5S+Hhi/jGWbBso6kXw7frUwVY5kX2Q6iv+E+rKqbYQgNV3\n" +
+      "0vpCtOmNNolhNN3x4SKAIXyKOB5dXMGesjvba/qD6AstKS8bvRCUZcYDPjIUQGPu\n" +
+      "cYLmywV/EdXgB+7WLhUOOY2eBRWBrnGxk60pcHJZeW44g1vas9cfiw81OWVp5/V5\n" +
+      "apA631bE0MTgg283OCyYz+CV/YtnytUTg/+PUEqzM2cWsWdvpEz7TkKYXinRdN4d\n" +
+      "SwgOQEIvb7A/GYYmVf3yk4moUxEh4NLoV9CBDljEBUjZAgMBAAGjJjAkMBIGA1Ud\n" +
+      "EwEB/wQIMAYBAf8CAQEwDgYDVR0PAQH/BAQDAgLkMA0GCSqGSIb3DQEBCwUAA4IB\n" +
+      "AQAFR0m7r1I3FyoatuLBIG+alaeGHqsgNqseAJTDGlEyajGDz4MT0c76ZIQkTSGM\n" +
+      "vsM49Ad2D04sJR44/WlI2AVijubzHBr6Sj8ZdB909nPvGtB+Z8OnvKxJ0LUKyG1K\n" +
+      "VUbcCnN3qSoVeY5PaPeFMmWF0Qv4S8lRTZqAvCnk34bckwkWoHkuuNGO49CsNb40\n" +
+      "Z2NBy9Ckp0KkfeDpGcv9lHuUrl13iakCY09irvYRbfi0lVGF3+wXZtefV8ZAxfnN\n" +
+      "Vt4faawkJ79oahlXDYs6WCKEd3zVM3mR3STnzwxvtB6WacjhqgP4ozXdt6PUbTfZ\n" +
+      "jZPSP3OuL0IXk96wFHScay8S\n" +
+      "-----END CERTIFICATE-----\n";
     ObjectNode bodyJson = Json.newObject();
     bodyJson.put("label", "test");
-    bodyJson.put("certContent", "cert_test");
+    bodyJson.put("certContent", cert_content);
     Date date = new Date();
     bodyJson.put("certStart", date.getTime());
     bodyJson.put("certExpiry", date.getTime());


### PR DESCRIPTION
**Heading:**
[5594][Platform] Handle invalid certs/keys correctly
**Description:**
We wanted to verify the cert at upload time itself.
**Testing:**
When we try to upload selfSigned cert, we were able to upload any
garbage files. Now with this fix, we have handled this scenrio. User
won't be able to upload garbage file. Incase of self signed cert upload
workflow, We are matching the modulus of
cert RSA Public key with the modulus of its private key if its matched
then it means certs are valid otheriwse Invalid.
For CA Cert, we are just validating the Cert format.
Added the unit Tests as well.