### PR TITLE
[Platform] [Kubernetes] Allow specifying namespace in the AZ config

### DIFF
--- a/managed/devops/bin/cluster_health.py
+++ b/managed/devops/bin/cluster_health.py
@@ -168,6 +168,11 @@ class KubernetesDetails():
         self.pod_name = node_fqdn.split('.')[0]
         # The pod names are yb-master-n/yb-tserver-n where n is the pod number
         # and yb-master/yb-tserver are the container names.
+
+        # TODO(bhavin192): need to change in case of multiple releases
+        # in one namespace. Something like find the word 'master' in
+        # the name.
+
         self.container = self.pod_name.rsplit('-', 1)[0]
         self.config = config_map[self.namespace]
 

--- a/managed/devops/bin/yb_backup.py
+++ b/managed/devops/bin/yb_backup.py
@@ -516,6 +516,11 @@ class KubernetesDetails():
         self.pod_name = server_fqdn.split('.')[0]
         # The pod names are yb-master-n/yb-tserver-n where n is the pod number
         # and yb-master/yb-tserver are the container names.
+
+        # TODO(bhavin192): need to change in case of multiple releases
+        # in one namespace. Something like find the word 'master' in
+        # the name.
+
         self.container = self.pod_name.rsplit('-', 1)[0]
         self.env_config = os.environ.copy()
         self.env_config["KUBECONFIG"] = config_map[self.namespace]

--- a/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/subtasks/KubernetesCheckNumPod.java
+++ b/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/subtasks/KubernetesCheckNumPod.java
@@ -66,6 +66,7 @@ public class KubernetesCheckNumPod extends AbstractTaskBase {
     // We use the nodePrefix as Helm Chart's release name,
     // so we would need that for any sort helm operations.
     public String nodePrefix;
+    public String namespace;
     public int podNum = 0;
     public Map<String, String> config = null;
   }
@@ -106,7 +107,7 @@ public class KubernetesCheckNumPod extends AbstractTaskBase {
     if (taskParams().config == null) {
       config = Provider.get(taskParams().providerUUID).getConfig();
     }
-    ShellResponse podResponse = kubernetesManager.getPodInfos(config, taskParams().nodePrefix);
+    ShellResponse podResponse = kubernetesManager.getPodInfos(config, taskParams().nodePrefix, taskParams().namespace);
     JsonNode podInfos = parseShellResponseAsJson(podResponse);
     if (podInfos.path("items").size() == taskParams().podNum) {
       return true;

--- a/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/subtasks/KubernetesWaitForPod.java
+++ b/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/subtasks/KubernetesWaitForPod.java
@@ -75,9 +75,14 @@ public class KubernetesWaitForPod extends AbstractTaskBase {
     public UUID providerUUID;
     public CommandType commandType;
     public UUID universeUUID;
+    // TODO(bhavin192): nodePrefix can be removed as we are not doing
+    // any sort of Helm operation here. Or we might want to use it for
+    // some sort of label based selection.
+
     // We use the nodePrefix as Helm Chart's release name,
     // so we would need that for any sort helm operations.
     public String nodePrefix;
+    public String namespace;
     public String podName = null;
     public Map<String, String> config = null;
   }
@@ -118,7 +123,7 @@ public class KubernetesWaitForPod extends AbstractTaskBase {
     if (taskParams().config == null) {
       config = Provider.get(taskParams().providerUUID).getConfig();
     }
-    ShellResponse podResponse = kubernetesManager.getPodStatus(config, taskParams().nodePrefix,
+    ShellResponse podResponse = kubernetesManager.getPodStatus(config, taskParams().namespace,
         taskParams().podName);
     JsonNode podInfo = parseShellResponseAsJson(podResponse);
     JsonNode statusNode = podInfo.path("status");

--- a/managed/src/main/java/com/yugabyte/yw/controllers/MetaMasterController.java
+++ b/managed/src/main/java/com/yugabyte/yw/controllers/MetaMasterController.java
@@ -148,9 +148,8 @@ public class MetaMasterController extends Controller {
 
         Map<String, String> config = entry.getValue();
 
-        String namespace = isMultiAz ?
-            String.format("%s-%s", universeDetails.nodePrefix, azName) :
-            universeDetails.nodePrefix;
+        String namespace = PlacementInfoUtil.getKubernetesNamespace(
+            isMultiAz, universeDetails.nodePrefix, azName, config);
 
         ShellResponse r = kubernetesManager.getServiceIPs(
             config, namespace, type == ServerType.MASTER);

--- a/managed/src/test/java/com/yugabyte/yw/commissioner/tasks/CreateKubernetesUniverseTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/commissioner/tasks/CreateKubernetesUniverseTest.java
@@ -50,6 +50,7 @@ import static com.yugabyte.yw.models.TaskInfo.State.Failure;
 import static com.yugabyte.yw.models.TaskInfo.State.Success;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Mockito.mock;
@@ -69,14 +70,20 @@ public class CreateKubernetesUniverseTest extends CommissionerBaseTest {
   YBClient mockClient;
 
   String nodePrefix = "demo-universe";
+  String nodePrefix1, nodePrefix2, nodePrefix3;
+  String ns, ns1, ns2, ns3;
 
   Map<String, String> config= new HashMap<String, String>();
+  Map<String, String> config1 = new HashMap<String, String>();
+  Map<String, String> config2 = new HashMap<String, String>();
+  Map<String, String> config3 = new HashMap<String, String>();
 
-  private void setupUniverseMultiAZ(boolean setMasters, boolean enabledYEDIS) {
+  private void setupUniverseMultiAZ(boolean setMasters, boolean enabledYEDIS,
+                                    boolean setNamespace) {
     Region r = Region.create(defaultProvider, "region-1", "PlacementRegion-1", "default-image");
-    AvailabilityZone.create(r, "az-1", "PlacementAZ-1", "subnet-1");
-    AvailabilityZone.create(r, "az-2", "PlacementAZ-2", "subnet-2");
-    AvailabilityZone.create(r, "az-3", "PlacementAZ-3", "subnet-3");
+    AvailabilityZone az1 = AvailabilityZone.create(r, "az-1", "PlacementAZ-1", "subnet-1");
+    AvailabilityZone az2 = AvailabilityZone.create(r, "az-2", "PlacementAZ-2", "subnet-2");
+    AvailabilityZone az3 = AvailabilityZone.create(r, "az-3", "PlacementAZ-3", "subnet-3");
     InstanceType i = InstanceType.upsert(defaultProvider.code, "c3.xlarge",
         10, 5.5, new InstanceType.InstanceTypeDetails());
     UniverseDefinitionTaskParams.UserIntent userIntent = getTestUserIntent(r, defaultProvider, i, 3);
@@ -92,11 +99,59 @@ public class CreateKubernetesUniverseTest extends CommissionerBaseTest {
     defaultUniverse = Universe.get(defaultUniverse.universeUUID);
     defaultUniverse.setConfig(ImmutableMap.of(Universe.HELM2_LEGACY,
                                               Universe.HelmLegacy.V3.toString()));
+    nodePrefix1 = String.format("%s-%s", nodePrefix, az1.code);
+    nodePrefix2 = String.format("%s-%s", nodePrefix, az2.code);
+    nodePrefix3 = String.format("%s-%s", nodePrefix, az3.code);
+    ns1 = nodePrefix1;
+    ns2 = nodePrefix2;
+    ns3 = nodePrefix3;
+
+    if (setNamespace) {
+      ns1 = "demo-ns-1";
+      ns2 = "demons2";
+
+      config1.put("KUBECONFIG", "test-kc-" + 1);
+      config2.put("KUBECONFIG", "test-kc-" + 2);
+      config3.put("KUBECONFIG", "test-kc-" + 3);
+
+      config1.put("KUBENAMESPACE", ns1);
+      config2.put("KUBENAMESPACE", ns2);
+
+      az1.setConfig(config1);
+      az2.setConfig(config2);
+      az3.setConfig(config3);
+    } else {
+      config.put("KUBECONFIG", "test");
+      defaultProvider.setConfig(config);
+      defaultProvider.save();
+
+      // Copying provider config
+      config1.putAll(config);
+      config2.putAll(config);
+      config3.putAll(config);
+    }
+
+    String podInfosMessage =
+        "{\"items\": [{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\"," +
+            " \"podIP\": \"123.456.78.90\"}, \"spec\": {\"hostname\": \"yb-master-0\"}," +
+            " \"metadata\": {\"namespace\": \"%1$s\"}}," +
+        "{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
+            "\"podIP\": \"123.456.78.91\"}, \"spec\": {\"hostname\": \"yb-tserver-0\"}," +
+            " \"metadata\": {\"namespace\": \"%1$s\"}}]}";
+    ShellResponse shellResponse1 =
+        ShellResponse.create(0, String.format(podInfosMessage, ns1));
+    when(mockKubernetesManager.getPodInfos(any(), eq(nodePrefix1), eq(ns1))).thenReturn(shellResponse1);
+    ShellResponse shellResponse2 =
+        ShellResponse.create(0, String.format(podInfosMessage, ns2));
+    when(mockKubernetesManager.getPodInfos(any(), eq(nodePrefix2), eq(ns2))).thenReturn(shellResponse2);
+    ShellResponse shellResponse3 =
+        ShellResponse.create(0, String.format(podInfosMessage, ns3));
+    when(mockKubernetesManager.getPodInfos(any(), eq(nodePrefix3), eq(ns3))).thenReturn(shellResponse3);
   }
 
-  private void setupUniverse(boolean setMasters, boolean enabledYEDIS) {
+  private void setupUniverse(boolean setMasters, boolean enabledYEDIS, boolean setNamespace) {
     Region r = Region.create(defaultProvider, "region-1", "PlacementRegion-1", "default-image");
-    AvailabilityZone.create(r, "az-1", "PlacementAZ-1", "subnet-1");
+    AvailabilityZone az = AvailabilityZone.create(r, "az-1", "PlacementAZ-1", "subnet-1");
     InstanceType i = InstanceType.upsert(defaultProvider.code, "c3.xlarge",
         10, 5.5, new InstanceType.InstanceTypeDetails());
     UniverseDefinitionTaskParams.UserIntent userIntent = getTestUserIntent(r, defaultProvider, i, 3);
@@ -112,15 +167,46 @@ public class CreateKubernetesUniverseTest extends CommissionerBaseTest {
     defaultUniverse = Universe.get(defaultUniverse.universeUUID);
     defaultUniverse.setConfig(ImmutableMap.of(Universe.HELM2_LEGACY,
                                               Universe.HelmLegacy.V3.toString()));
+
+    ns = nodePrefix;
+    if (setNamespace) {
+      ns = "demo-ns";
+      config.put("KUBECONFIG", "test-kc");
+      config.put("KUBENAMESPACE", ns);
+      az.setConfig(config);
+    } else {
+      config.put("KUBECONFIG", "test");
+      defaultProvider.setConfig(config);
+      defaultProvider.save();
+    }
+
+    ShellResponse response = new ShellResponse();
+    response.message =
+        "{\"items\": [{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
+            "\"podIP\": \"1.2.3.1\"}, \"spec\": {\"hostname\": \"yb-master-0\"}," +
+            " \"metadata\": {\"namespace\": \"" + ns + "\"}}," +
+            "{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
+            "\"podIP\": \"1.2.3.2\"}, \"spec\": {\"hostname\": \"yb-tserver-0\"}," +
+            " \"metadata\": {\"namespace\": \"" + ns + "\"}}," +
+            "{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
+            "\"podIP\": \"1.2.3.3\"}, \"spec\": {\"hostname\": \"yb-master-1\"}," +
+            " \"metadata\": {\"namespace\": \"" + ns + "\"}}," +
+            "{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
+            "\"podIP\": \"1.2.3.4\"}, \"spec\": {\"hostname\": \"yb-tserver-1\"}," +
+            " \"metadata\": {\"namespace\": \"" + ns + "\"}}," +
+            "{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
+            "\"podIP\": \"1.2.3.5\"}, \"spec\": {\"hostname\": \"yb-master-2\"}," +
+            " \"metadata\": {\"namespace\": \"" + ns + "\"}}," +
+            "{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
+            "\"podIP\": \"1.2.3.6\"}, \"spec\": {\"hostname\": \"yb-tserver-2\"}," +
+            " \"metadata\": {\"namespace\": \"" + ns + "\"}}]}";
+    when(mockKubernetesManager.getPodInfos(any(), any(), any())).thenReturn(response);
   }
 
   private void setupCommon() {
-    config.put("KUBECONFIG", "test");
-    defaultProvider.setConfig(config);
-    defaultProvider.save();
     ShellResponse response = new ShellResponse();
     when(mockKubernetesManager.createNamespace(anyMap(), any())).thenReturn(response);
-    when(mockKubernetesManager.helmInstall(anyMap(), any(), any(), any())).thenReturn(response);
+    when(mockKubernetesManager.helmInstall(anyMap(), any(), any(), any(), any())).thenReturn(response);
     // Table RPCs.
     mockClient = mock(YBClient.class);
     // WaitForTServerHeartBeats mock.
@@ -176,35 +262,53 @@ public class CreateKubernetesUniverseTest extends CommissionerBaseTest {
     );
   }
 
-  private void assertTaskSequence(Map<Integer, List<TaskInfo>> subTasksByPosition, int numTasks) {
-    assertTaskSequence(subTasksByPosition, numTasks, KUBERNETES_CREATE_UNIVERSE_TASKS,
-        getExpectedCreateUniverseTaskResults());
+  List<Integer> getTaskPositionsToSkip(boolean skipNamespace) {
+    // 3 is WAIT_FOR_PODS of type KubernetesCheckNumPod task.
+    // 0 is CREATE_NAMESPACE of type KubernetesCommandExecutor
+    return skipNamespace ? ImmutableList.of(0, 3) : ImmutableList.of(3);
   }
 
-  private void assertTaskSequence(Map<Integer, List<TaskInfo>> subTasksByPosition, int numTasks,
-      List<TaskType> expectedTasks, List<JsonNode> expectedTasksResult) {
+  List<Integer> getTaskCountPerPosition(int namespaceTasks, int parallelTasks) {
+    return ImmutableList.of(
+      namespaceTasks,
+      parallelTasks,
+      parallelTasks,
+      0,
+      1,
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1);
+  }
+
+  private void assertTaskSequence(Map<Integer, List<TaskInfo>> subTasksByPosition, int numTasks) {
+    assertTaskSequence(subTasksByPosition,
+                       KUBERNETES_CREATE_UNIVERSE_TASKS, getExpectedCreateUniverseTaskResults(),
+                       getTaskPositionsToSkip(/* skip namespace task */ false),
+                       getTaskCountPerPosition(numTasks, numTasks));
+  }
+
+  private void assertTaskSequence(Map<Integer, List<TaskInfo>> subTasksByPosition,
+                                  List<TaskType> expectedTasks, List<JsonNode> expectedTasksResult,
+                                  List<Integer> taskPositionsToSkip,
+                                  List<Integer> taskCountPerPosition) {
     int position = 0;
     for (TaskType taskType: expectedTasks) {
-      List<TaskInfo> tasks = subTasksByPosition.get(position);
-      if (taskType == TaskType.KubernetesCheckNumPod) {
+      if (taskPositionsToSkip.contains(position)) {
         position++;
         continue;
       }
+
+      List<TaskInfo> tasks = subTasksByPosition.get(position);
       JsonNode expectedResults = expectedTasksResult.get(position);
       List<JsonNode> taskDetails = tasks.stream()
           .map(t -> t.getTaskDetails())
           .collect(Collectors.toList());
-      List<JsonNode> parallelTasks = ImmutableList.of(
-        Json.toJson(ImmutableMap.of("commandType", CREATE_NAMESPACE.name())),
-        Json.toJson(ImmutableMap.of("commandType", APPLY_SECRET.name())),
-        Json.toJson(ImmutableMap.of("commandType", HELM_INSTALL.name())));
-      if (parallelTasks.contains(expectedResults)) {
-        assertEquals(numTasks, tasks.size());
-      } else if (taskType == TaskType.WaitForServer) {
-        assertEquals(3, tasks.size());
-      } else {
-        assertEquals(1, tasks.size());
-      }
+      int expectedSize = taskCountPerPosition.get(position);
+      assertEquals(expectedSize, tasks.size());
       assertEquals(taskType, tasks.get(0).getTaskType());
       assertJsonEqual(expectedResults, taskDetails.get(0));
       position++;
@@ -230,113 +334,106 @@ public class CreateKubernetesUniverseTest extends CommissionerBaseTest {
 
   @Test
   public void testCreateKubernetesUniverseSuccessMultiAZ() {
-    setupUniverseMultiAZ(/* Create Masters */ false, /* YEDIS/REDIS enabled */ true);
-    setupCommon();
-    ShellResponse response = new ShellResponse();
-    response.message =
-        "{\"items\": [{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
-            "\"podIP\": \"1.2.3.1\"}, \"spec\": {\"hostname\": \"yb-master-0\"}}," +
-            "{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
-            "\"podIP\": \"1.2.3.2\"}, \"spec\": {\"hostname\": \"yb-tserver-0\"}}]}";
-    when(mockKubernetesManager.getPodInfos(any(), any())).thenReturn(response);
+    testCreateKubernetesUniverseSuccessMultiAZBase(false);
+  }
 
-    ArgumentCaptor<UUID> expectedUniverseUUID = ArgumentCaptor.forClass(UUID.class);
-    ArgumentCaptor<String> expectedNodePrefix = ArgumentCaptor.forClass(String.class);
+  @Test
+  public void testCreateKubernetesUniverseSuccessMultiAZWithNamespace() {
+    testCreateKubernetesUniverseSuccessMultiAZBase(true);
+  }
+
+  private void testCreateKubernetesUniverseSuccessMultiAZBase(boolean setNamespace) {
+    setupUniverseMultiAZ(/* Create Masters */ false, /* YEDIS/REDIS enabled */ true, setNamespace);
+    setupCommon();
+
     ArgumentCaptor<String> expectedOverrideFile = ArgumentCaptor.forClass(String.class);
-    ArgumentCaptor<String> expectedPullSecretFile = ArgumentCaptor.forClass(String.class);
-    ArgumentCaptor<HashMap> expectedConfig = ArgumentCaptor.forClass(HashMap.class);
     UniverseDefinitionTaskParams taskParams = new UniverseDefinitionTaskParams();
     TaskInfo taskInfo = submitTask(taskParams);
 
-    verify(mockKubernetesManager, times(3)).createNamespace(expectedConfig.capture(),
-        String.format("%s-%s", expectedNodePrefix.capture(), "az-1"));
-    verify(mockKubernetesManager, times(3)).createNamespace(expectedConfig.capture(),
-        String.format("%s-%s", expectedNodePrefix.capture(), "az-2"));
-    verify(mockKubernetesManager, times(3)).createNamespace(expectedConfig.capture(),
-        String.format("%s-%s", expectedNodePrefix.capture(), "az-3"));
+    if (setNamespace) {
+      verify(mockKubernetesManager, times(0)).createNamespace(config1, ns1);
+      verify(mockKubernetesManager, times(0)).createNamespace(config2, ns2);
+    } else {
+      verify(mockKubernetesManager, times(1)).createNamespace(config1, ns1);
+      verify(mockKubernetesManager, times(1)).createNamespace(config2, ns2);
+    }
 
-    verify(mockKubernetesManager, times(3)).helmInstall(expectedConfig.capture(), expectedUniverseUUID.capture(),
-        String.format("%s-%s", expectedNodePrefix.capture(), "az-1"), expectedOverrideFile.capture());
-    verify(mockKubernetesManager, times(3)).helmInstall(expectedConfig.capture(), expectedUniverseUUID.capture(),
-        String.format("%s-%s", expectedNodePrefix.capture(), "az-2"), expectedOverrideFile.capture());
-    verify(mockKubernetesManager, times(3)).helmInstall(expectedConfig.capture(), expectedUniverseUUID.capture(),
-        String.format("%s-%s", expectedNodePrefix.capture(), "az-3"), expectedOverrideFile.capture());
+    verify(mockKubernetesManager, times(1)).createNamespace(config3, ns3);
 
-    assertEquals(defaultProvider.uuid, expectedUniverseUUID.getValue());
-    assertTrue(expectedNodePrefix.getValue().contains(nodePrefix));
+    verify(mockKubernetesManager, times(1)).helmInstall(eq(config1), eq(defaultProvider.uuid),
+        eq(nodePrefix1), eq(ns1), expectedOverrideFile.capture());
+    verify(mockKubernetesManager, times(1)).helmInstall(eq(config2), eq(defaultProvider.uuid),
+        eq(nodePrefix2), eq(ns2), expectedOverrideFile.capture());
+    verify(mockKubernetesManager, times(1)).helmInstall(eq(config3), eq(defaultProvider.uuid),
+        eq(nodePrefix3), eq(ns3), expectedOverrideFile.capture());
+
     String overrideFileRegex = "(.*)" + defaultUniverse.universeUUID + "(.*).yml";
     assertThat(expectedOverrideFile.getValue(), RegexMatcher.matchesRegex(overrideFileRegex));
 
-    verify(mockKubernetesManager, times(3)).getPodInfos(expectedConfig.capture(),
-        String.format("%s-%s", expectedNodePrefix.capture(), "az-1"));
-    verify(mockKubernetesManager, times(3)).getPodInfos(expectedConfig.capture(),
-        String.format("%s-%s", expectedNodePrefix.capture(), "az-2"));
-    verify(mockKubernetesManager, times(3)).getPodInfos(expectedConfig.capture(),
-        String.format("%s-%s", expectedNodePrefix.capture(), "az-3"));
+    verify(mockKubernetesManager, times(1)).getPodInfos(config1, nodePrefix1, ns1);
+    verify(mockKubernetesManager, times(1)).getPodInfos(config2, nodePrefix2, ns2);
+    verify(mockKubernetesManager, times(1)).getPodInfos(config3, nodePrefix3, ns3);
     verify(mockSwamperHelper, times(1)).writeUniverseTargetJson(defaultUniverse.universeUUID);
 
     List<TaskInfo> subTasks = taskInfo.getSubTasks();
     Map<Integer, List<TaskInfo>> subTasksByPosition =
         subTasks.stream().collect(Collectors.groupingBy(w -> w.getPosition()));
-    assertTaskSequence(subTasksByPosition, 3);
+    int numNamespaces = setNamespace ? 1 : 3;
+    assertTaskSequence(subTasksByPosition,
+                       KUBERNETES_CREATE_UNIVERSE_TASKS, getExpectedCreateUniverseTaskResults(),
+                       getTaskPositionsToSkip(/* skip namespace task */ false),
+                       getTaskCountPerPosition(numNamespaces, 3));
     assertEquals(Success, taskInfo.getTaskState());
   }
 
   @Test
   public void testCreateKubernetesUniverseSuccessSingleAZ() {
-    setupUniverse(/* Create Masters */ false, /* YEDIS/REDIS enabled */ true);
+    testCreateKubernetesUniverseSuccessSingleAZBase(false);
+  }
+
+  @Test
+  public void testCreateKubernetesUniverseSuccessSingleAZWithNamespace() {
+    testCreateKubernetesUniverseSuccessSingleAZBase(true);
+  }
+
+  private void testCreateKubernetesUniverseSuccessSingleAZBase(boolean setNamespace) {
+    setupUniverse(/* Create Masters */ false, /* YEDIS/REDIS enabled */ true, setNamespace);
     setupCommon();
-    ShellResponse response = new ShellResponse();
-    response.message =
-        "{\"items\": [{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
-            "\"podIP\": \"1.2.3.1\"}, \"spec\": {\"hostname\": \"yb-master-0\"}}," +
-            "{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
-            "\"podIP\": \"1.2.3.2\"}, \"spec\": {\"hostname\": \"yb-tserver-0\"}}," +
-            "{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
-            "\"podIP\": \"1.2.3.3\"}, \"spec\": {\"hostname\": \"yb-master-1\"}}," +
-            "{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
-            "\"podIP\": \"1.2.3.4\"}, \"spec\": {\"hostname\": \"yb-tserver-1\"}}," +
-            "{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
-            "\"podIP\": \"1.2.3.5\"}, \"spec\": {\"hostname\": \"yb-master-2\"}}," +
-            "{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
-            "\"podIP\": \"1.2.3.6\"}, \"spec\": {\"hostname\": \"yb-tserver-2\"}}]}";
-    when(mockKubernetesManager.getPodInfos(any(), any())).thenReturn(response);
-
-    ArgumentCaptor<UUID> expectedUniverseUUID = ArgumentCaptor.forClass(UUID.class);
-    ArgumentCaptor<String> expectedNodePrefix = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> expectedOverrideFile = ArgumentCaptor.forClass(String.class);
-    ArgumentCaptor<String> expectedPullSecretFile = ArgumentCaptor.forClass(String.class);
-    ArgumentCaptor<HashMap> expectedConfig = ArgumentCaptor.forClass(HashMap.class);
-
     UniverseDefinitionTaskParams taskParams = new UniverseDefinitionTaskParams();
     TaskInfo taskInfo = submitTask(taskParams);
 
-    verify(mockKubernetesManager, times(1)).createNamespace(expectedConfig.capture(),
-        expectedNodePrefix.capture());
+    if (setNamespace) {
+      verify(mockKubernetesManager, times(0)).createNamespace(config, ns);
+    } else {
+      verify(mockKubernetesManager, times(1)).createNamespace(config, ns);
+    }
 
-    verify(mockKubernetesManager, times(1)).helmInstall(expectedConfig.capture(),
-        expectedUniverseUUID.capture(),
-        expectedNodePrefix.capture(), expectedOverrideFile.capture());
+    verify(mockKubernetesManager, times(1)).helmInstall(eq(config), eq(defaultProvider.uuid),
+                                                        eq(nodePrefix), eq(ns),
+                                                        expectedOverrideFile.capture());
 
-    assertEquals(defaultProvider.uuid, expectedUniverseUUID.getValue());
-    assertEquals(expectedNodePrefix.getValue(), nodePrefix);
     String overrideFileRegex = "(.*)" + defaultUniverse.universeUUID + "(.*).yml";
     assertThat(expectedOverrideFile.getValue(), RegexMatcher.matchesRegex(overrideFileRegex));
 
-    verify(mockKubernetesManager, times(1)).getPodInfos(expectedConfig.capture(),
-        expectedNodePrefix.capture());
+    verify(mockKubernetesManager, times(1)).getPodInfos(config, nodePrefix, ns);
     verify(mockSwamperHelper, times(1)).writeUniverseTargetJson(defaultUniverse.universeUUID);
 
     List<TaskInfo> subTasks = taskInfo.getSubTasks();
     Map<Integer, List<TaskInfo>> subTasksByPosition =
         subTasks.stream().collect(Collectors.groupingBy(w -> w.getPosition()));
-    assertTaskSequence(subTasksByPosition, 1);
+    int numNamespaces = setNamespace ? 0 : 1;
+    assertTaskSequence(subTasksByPosition,
+                       KUBERNETES_CREATE_UNIVERSE_TASKS, getExpectedCreateUniverseTaskResults(),
+                       getTaskPositionsToSkip(/* skip namespace task */ setNamespace),
+                       getTaskCountPerPosition(numNamespaces, 1));
     assertEquals(Success, taskInfo.getTaskState());
   }
 
   @Test
   public void testCreateKubernetesUniverseFailure() {
-    setupUniverse(/* Create Masters */ true, /* YEDIS/REDIS enabled */ true);
+    setupUniverse(/* Create Masters */ true, /* YEDIS/REDIS enabled */ true,
+                  /* set namespace */ false);
     UniverseDefinitionTaskParams taskParams = new UniverseDefinitionTaskParams();
     TaskInfo taskInfo = submitTask(taskParams);
     assertEquals(Failure, taskInfo.getTaskState());
@@ -344,37 +441,15 @@ public class CreateKubernetesUniverseTest extends CommissionerBaseTest {
 
   @Test
   public void testCreateKubernetesUniverseMultiAZWithoutYedis() {
-    setupUniverseMultiAZ(/* Create Masters */ false, /* YEDIS/REDIS disabled */ false);
-    ShellResponse response = new ShellResponse();
-    response.message =
-        "{\"items\": [{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
-            "\"podIP\": \"1.2.3.1\"}, \"spec\": {\"hostname\": \"yb-master-0\"}}," +
-            "{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
-            "\"podIP\": \"1.2.3.2\"}, \"spec\": {\"hostname\": \"yb-tserver-0\"}}]}";
-    when(mockKubernetesManager.getPodInfos(any(), any())).thenReturn(response);
-
+    setupUniverseMultiAZ(/* Create Masters */ false, /* YEDIS/REDIS disabled */ false,
+                         /* set namespace */ false);
     testCreateKubernetesUniverseSubtasksWithoutYedis(3);
   }
 
   @Test
   public void testCreateKubernetesUniverseSingleAZWithoutYedis() {
-    setupUniverse(/* Create Masters */ false, /* YEDIS/REDIS disabled */ false);
-    ShellResponse response = new ShellResponse();
-    response.message =
-        "{\"items\": [{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
-            "\"podIP\": \"1.2.3.1\"}, \"spec\": {\"hostname\": \"yb-master-0\"}}," +
-            "{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
-            "\"podIP\": \"1.2.3.2\"}, \"spec\": {\"hostname\": \"yb-tserver-0\"}}," +
-            "{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
-            "\"podIP\": \"1.2.3.3\"}, \"spec\": {\"hostname\": \"yb-master-1\"}}," +
-            "{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
-            "\"podIP\": \"1.2.3.4\"}, \"spec\": {\"hostname\": \"yb-tserver-1\"}}," +
-            "{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
-            "\"podIP\": \"1.2.3.5\"}, \"spec\": {\"hostname\": \"yb-master-2\"}}," +
-            "{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
-            "\"podIP\": \"1.2.3.6\"}, \"spec\": {\"hostname\": \"yb-tserver-2\"}}]}";
-    when(mockKubernetesManager.getPodInfos(any(), any())).thenReturn(response);
-
+    setupUniverse(/* Create Masters */ false, /* YEDIS/REDIS disabled */ false,
+                  /* set namespace */ false);
     testCreateKubernetesUniverseSubtasksWithoutYedis(1);
   }
 
@@ -383,15 +458,23 @@ public class CreateKubernetesUniverseTest extends CommissionerBaseTest {
     TaskInfo taskInfo = submitTask(new UniverseDefinitionTaskParams());
 
     List<TaskType> createUniverseTasks = new ArrayList<>(KUBERNETES_CREATE_UNIVERSE_TASKS);
+    int createTableTaskIndex = createUniverseTasks.indexOf(TaskType.CreateTable);
     createUniverseTasks.remove(TaskType.CreateTable);
 
     List<JsonNode> expectedResults = new ArrayList<>(getExpectedCreateUniverseTaskResults());
     expectedResults.remove(Json.toJson(EXPECTED_RESULT_FOR_CREATE_TABLE_TASK));
 
+    List<Integer> taskCountPerPosition =
+        new ArrayList<>(getTaskCountPerPosition(tasksNum, tasksNum));
+    taskCountPerPosition.remove(createTableTaskIndex);
+
     List<TaskInfo> subTasks = taskInfo.getSubTasks();
     Map<Integer, List<TaskInfo>> subTasksByPosition =
         subTasks.stream().collect(Collectors.groupingBy(w -> w.getPosition()));
-    assertTaskSequence(subTasksByPosition, tasksNum, createUniverseTasks, expectedResults);
+    assertTaskSequence(subTasksByPosition,
+                       createUniverseTasks, expectedResults,
+                       getTaskPositionsToSkip(/* skip namespace task */ false),
+                       taskCountPerPosition);
     assertEquals(Success, taskInfo.getTaskState());
   }
 }

--- a/managed/src/test/java/com/yugabyte/yw/commissioner/tasks/subtasks/KubernetesCommandExecutorTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/commissioner/tasks/subtasks/KubernetesCommandExecutorTest.java
@@ -52,6 +52,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -76,6 +77,7 @@ public class KubernetesCommandExecutorTest extends SubTaskBaseTest {
   InstanceType instanceType;
   String ybSoftwareVersion = "1.0.0";
   int numNodes = 3;
+  String namespace = "demo-ns";
   Map<String, String> config= new HashMap<String, String>();
 
   protected CallbackController mockCallbackController;
@@ -97,12 +99,12 @@ public class KubernetesCommandExecutorTest extends SubTaskBaseTest {
   @Before
   public void setUp() {
     super.setUp();
+    // TODO(bhavin192): shouldn't this be a Kubernetes provider?
     defaultProvider = ModelFactory.awsProvider(defaultCustomer);
-    config.put("KUBECONFIG", "test");
-    defaultProvider.setConfig(config);
-    defaultProvider.save();
     defaultRegion = Region.create(defaultProvider, "region-1", "PlacementRegion 1", "default-image");
     defaultAZ = AvailabilityZone.create(defaultRegion, "az-1", "PlacementAZ 1", "subnet-1");
+    config.put("KUBECONFIG", "test");
+    defaultAZ.setConfig(config);
     defaultUniverse = ModelFactory.createUniverse(defaultCustomer.getCustomerId());
     defaultUniverse = updateUniverseDetails("small");
     defaultCert = CertificateInfo.get(CertificateHelper.createRootCA(
@@ -134,7 +136,8 @@ public class KubernetesCommandExecutorTest extends SubTaskBaseTest {
     return u;
   }
 
-  private KubernetesCommandExecutor createExecutor(KubernetesCommandExecutor.CommandType commandType) {
+  private KubernetesCommandExecutor createExecutor(KubernetesCommandExecutor.CommandType commandType,
+                                                   boolean setNamespace) {
     KubernetesCommandExecutor kubernetesCommandExecutor = new KubernetesCommandExecutor();
     KubernetesCommandExecutor.Params params = new KubernetesCommandExecutor.Params();
     params.providerUUID = defaultProvider.uuid;
@@ -142,6 +145,9 @@ public class KubernetesCommandExecutorTest extends SubTaskBaseTest {
     params.config = config;
     params.nodePrefix = defaultUniverse.getUniverseDetails().nodePrefix;
     params.universeUUID = defaultUniverse.universeUUID;
+    if (setNamespace) {
+      params.namespace = namespace;
+    }
     kubernetesCommandExecutor.initialize(params);
     return kubernetesCommandExecutor;
   }
@@ -307,21 +313,23 @@ public class KubernetesCommandExecutorTest extends SubTaskBaseTest {
   public void testHelmInstall() throws IOException {
     assertEquals(hackPlacementUUID, defaultUniverse.getUniverseDetails().getPrimaryCluster().uuid);
     KubernetesCommandExecutor kubernetesCommandExecutor =
-        createExecutor(KubernetesCommandExecutor.CommandType.HELM_INSTALL);
+        createExecutor(KubernetesCommandExecutor.CommandType.HELM_INSTALL, /* set namespace */ true);
     kubernetesCommandExecutor.run();
     assertEquals(hackPlacementUUID, defaultUniverse.getUniverseDetails().getPrimaryCluster().uuid);
 
     ArgumentCaptor<UUID> expectedProviderUUID = ArgumentCaptor.forClass(UUID.class);
     ArgumentCaptor<String> expectedNodePrefix = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> expectedNamespace = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> expectedOverrideFile = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<HashMap> expectedConfig = ArgumentCaptor.forClass(HashMap.class);
     verify(kubernetesManager, times(1))
         .helmInstall(expectedConfig.capture(), expectedProviderUUID.capture(), expectedNodePrefix.capture(),
-            expectedOverrideFile.capture());
+            expectedNamespace.capture(), expectedOverrideFile.capture());
     assertEquals(config, expectedConfig.getValue());
     assertEquals(hackPlacementUUID, defaultUniverse.getUniverseDetails().getPrimaryCluster().uuid);
     assertEquals(defaultProvider.uuid, expectedProviderUUID.getValue());
     assertEquals(defaultUniverse.getUniverseDetails().nodePrefix, expectedNodePrefix.getValue());
+    assertEquals(namespace, expectedNamespace.getValue());
     String overrideFileRegex = "(.*)" + defaultUniverse.universeUUID + "(.*).yml";
     assertThat(expectedOverrideFile.getValue(), RegexMatcher.matchesRegex(overrideFileRegex));
     Yaml yaml = new Yaml();
@@ -333,7 +341,7 @@ public class KubernetesCommandExecutorTest extends SubTaskBaseTest {
     assertEquals(getExpectedOverrides(true), overrides);
   }
 
-    @Test
+  @Test
   public void testHelmInstallIPV6() throws IOException {
     defaultUserIntent.enableIPV6 = true;
     Universe u = Universe.saveDetails(defaultUniverse.universeUUID,
@@ -341,19 +349,22 @@ public class KubernetesCommandExecutorTest extends SubTaskBaseTest {
     hackPlacementUUID = u.getUniverseDetails().getPrimaryCluster().uuid;
 
     KubernetesCommandExecutor kubernetesCommandExecutor =
-        createExecutor(KubernetesCommandExecutor.CommandType.HELM_INSTALL);
+        createExecutor(KubernetesCommandExecutor.CommandType.HELM_INSTALL, /* set namespace */ true);
     kubernetesCommandExecutor.run();
 
     ArgumentCaptor<UUID> expectedProviderUUID = ArgumentCaptor.forClass(UUID.class);
     ArgumentCaptor<String> expectedNodePrefix = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> expectedNamespace = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> expectedOverrideFile = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<HashMap> expectedConfig = ArgumentCaptor.forClass(HashMap.class);
     verify(kubernetesManager, times(1))
-        .helmInstall(expectedConfig.capture(), expectedProviderUUID.capture(),
-                     expectedNodePrefix.capture(), expectedOverrideFile.capture());
+        .helmInstall(expectedConfig.capture(), expectedProviderUUID.capture(), expectedNodePrefix.capture(),
+            expectedNamespace.capture(), expectedOverrideFile.capture());
     assertEquals(config, expectedConfig.getValue());
     assertEquals(defaultProvider.uuid, expectedProviderUUID.getValue());
     assertEquals(defaultUniverse.getUniverseDetails().nodePrefix, expectedNodePrefix.getValue());
+    assertEquals(namespace, expectedNamespace.getValue());
+
     String overrideFileRegex = "(.*)" + defaultUniverse.universeUUID + "(.*).yml";
     assertThat(expectedOverrideFile.getValue(), RegexMatcher.matchesRegex(overrideFileRegex));
     Yaml yaml = new Yaml();
@@ -373,19 +384,22 @@ public class KubernetesCommandExecutorTest extends SubTaskBaseTest {
     hackPlacementUUID = u.getUniverseDetails().getPrimaryCluster().uuid;
 
     KubernetesCommandExecutor kubernetesCommandExecutor =
-        createExecutor(KubernetesCommandExecutor.CommandType.HELM_INSTALL);
+        createExecutor(KubernetesCommandExecutor.CommandType.HELM_INSTALL, /* set namespace */ true);
     kubernetesCommandExecutor.run();
 
     ArgumentCaptor<UUID> expectedProviderUUID = ArgumentCaptor.forClass(UUID.class);
     ArgumentCaptor<String> expectedNodePrefix = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> expectedNamespace = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> expectedOverrideFile = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<HashMap> expectedConfig = ArgumentCaptor.forClass(HashMap.class);
     verify(kubernetesManager, times(1))
         .helmInstall(expectedConfig.capture(), expectedProviderUUID.capture(), expectedNodePrefix.capture(),
-            expectedOverrideFile.capture());
+            expectedNamespace.capture(), expectedOverrideFile.capture());
     assertEquals(defaultProvider.uuid, expectedProviderUUID.getValue());
     assertEquals(config, expectedConfig.getValue());
     assertEquals(defaultUniverse.getUniverseDetails().nodePrefix, expectedNodePrefix.getValue());
+    assertEquals(namespace, expectedNamespace.getValue());
+
     String overrideFileRegex = "(.*)" + defaultUniverse.universeUUID + "(.*).yml";
     assertThat(expectedOverrideFile.getValue(), RegexMatcher.matchesRegex(overrideFileRegex));
     Yaml yaml = new Yaml();
@@ -407,20 +421,23 @@ public class KubernetesCommandExecutorTest extends SubTaskBaseTest {
       ApiUtils.mockUniverseUpdater(defaultUserIntent, "host", true));
     hackPlacementUUID = u.getUniverseDetails().getPrimaryCluster().uuid;
     KubernetesCommandExecutor kubernetesCommandExecutor =
-      createExecutor(KubernetesCommandExecutor.CommandType.HELM_INSTALL);
+      createExecutor(KubernetesCommandExecutor.CommandType.HELM_INSTALL, /* set namespace */ true);
       kubernetesCommandExecutor.taskParams().rootCA = defaultCert.uuid;
       kubernetesCommandExecutor.run();
 
     ArgumentCaptor<UUID> expectedProviderUUID = ArgumentCaptor.forClass(UUID.class);
     ArgumentCaptor<String> expectedNodePrefix = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> expectedNamespace = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> expectedOverrideFile = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<HashMap> expectedConfig = ArgumentCaptor.forClass(HashMap.class);
     verify(kubernetesManager, times(1))
         .helmInstall(expectedConfig.capture(), expectedProviderUUID.capture(), expectedNodePrefix.capture(),
-            expectedOverrideFile.capture());
+            expectedNamespace.capture(), expectedOverrideFile.capture());
     assertEquals(defaultProvider.uuid, expectedProviderUUID.getValue());
     assertEquals(config, expectedConfig.getValue());
     assertEquals(defaultUniverse.getUniverseDetails().nodePrefix, expectedNodePrefix.getValue());
+    assertEquals(namespace, expectedNamespace.getValue());
+
     String overrideFileRegex = "(.*)" + defaultUniverse.universeUUID + "(.*).yml";
     assertThat(expectedOverrideFile.getValue(), RegexMatcher.matchesRegex(overrideFileRegex));
     Yaml yaml = new Yaml();
@@ -434,19 +451,22 @@ public class KubernetesCommandExecutorTest extends SubTaskBaseTest {
   private void testHelmInstallForInstanceType(String instanceType) throws IOException {
     defaultUniverse = updateUniverseDetails(instanceType);
     KubernetesCommandExecutor kubernetesCommandExecutor =
-        createExecutor(KubernetesCommandExecutor.CommandType.HELM_INSTALL);
+        createExecutor(KubernetesCommandExecutor.CommandType.HELM_INSTALL, /* set namespace */ true);
     kubernetesCommandExecutor.run();
 
     ArgumentCaptor<UUID> expectedProviderUUID = ArgumentCaptor.forClass(UUID.class);
     ArgumentCaptor<String> expectedNodePrefix = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> expectedNamespace = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> expectedOverrideFile = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<HashMap> expectedConfig = ArgumentCaptor.forClass(HashMap.class);
     verify(kubernetesManager, times(1))
         .helmInstall(expectedConfig.capture(), expectedProviderUUID.capture(), expectedNodePrefix.capture(),
-            expectedOverrideFile.capture());
+            expectedNamespace.capture(), expectedOverrideFile.capture());
     assertEquals(defaultProvider.uuid, expectedProviderUUID.getValue());
     assertEquals(config, expectedConfig.getValue());
     assertEquals(defaultUniverse.getUniverseDetails().nodePrefix, expectedNodePrefix.getValue());
+    assertEquals(namespace, expectedNamespace.getValue());
+
     String overrideFileRegex = "(.*)" + defaultUniverse.universeUUID + "(.*).yml";
     assertThat(expectedOverrideFile.getValue(), RegexMatcher.matchesRegex(overrideFileRegex));
     Yaml yaml = new Yaml();
@@ -479,19 +499,22 @@ public class KubernetesCommandExecutorTest extends SubTaskBaseTest {
     defaultAnnotations.put("OVERRIDES", "serviceEndpoints:\n  - name: yb-master-service\n    type: LoadBalancer\n    app: yb-master\n    annotations:\n      annotation-1: foo\n    ports:\n      ui: 7000\n\n  - name: yb-tserver-service\n    type: LoadBalancer\n    app: yb-tserver\n    ports:\n      ycql-port: 9042\n      yedis-port: 6379");
     defaultProvider.setConfig(defaultAnnotations);
     KubernetesCommandExecutor kubernetesCommandExecutor =
-        createExecutor(KubernetesCommandExecutor.CommandType.HELM_INSTALL);
+        createExecutor(KubernetesCommandExecutor.CommandType.HELM_INSTALL, /* set namespace */ true);
     kubernetesCommandExecutor.run();
 
     ArgumentCaptor<UUID> expectedProviderUUID = ArgumentCaptor.forClass(UUID.class);
     ArgumentCaptor<String> expectedNodePrefix = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> expectedNamespace = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> expectedOverrideFile = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<HashMap> expectedConfig = ArgumentCaptor.forClass(HashMap.class);
     verify(kubernetesManager, times(1))
         .helmInstall(expectedConfig.capture(), expectedProviderUUID.capture(), expectedNodePrefix.capture(),
-            expectedOverrideFile.capture());
+            expectedNamespace.capture(), expectedOverrideFile.capture());
     assertEquals(config, expectedConfig.getValue());
     assertEquals(defaultProvider.uuid, expectedProviderUUID.getValue());
     assertEquals(defaultUniverse.getUniverseDetails().nodePrefix, expectedNodePrefix.getValue());
+    assertEquals(namespace, expectedNamespace.getValue());
+
     String overrideFileRegex = "(.*)" + defaultUniverse.universeUUID + "(.*).yml";
     assertThat(expectedOverrideFile.getValue(), RegexMatcher.matchesRegex(overrideFileRegex));
     Yaml yaml = new Yaml();
@@ -508,19 +531,22 @@ public class KubernetesCommandExecutorTest extends SubTaskBaseTest {
     defaultAnnotations.put("OVERRIDES", "serviceEndpoints:\n  - name: yb-master-service\n    type: LoadBalancer\n    app: yb-master\n    annotations:\n      annotation-1: bar\n    ports:\n      ui: 7000\n\n  - name: yb-tserver-service\n    type: LoadBalancer\n    app: yb-tserver\n    ports:\n      ycql-port: 9042\n      yedis-port: 6379");
     defaultRegion.setConfig(defaultAnnotations);
     KubernetesCommandExecutor kubernetesCommandExecutor =
-        createExecutor(KubernetesCommandExecutor.CommandType.HELM_INSTALL);
+        createExecutor(KubernetesCommandExecutor.CommandType.HELM_INSTALL, /* set namespace */ true);
     kubernetesCommandExecutor.run();
 
     ArgumentCaptor<UUID> expectedProviderUUID = ArgumentCaptor.forClass(UUID.class);
     ArgumentCaptor<String> expectedNodePrefix = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> expectedNamespace = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> expectedOverrideFile = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<HashMap> expectedConfig = ArgumentCaptor.forClass(HashMap.class);
     verify(kubernetesManager, times(1))
         .helmInstall(expectedConfig.capture(), expectedProviderUUID.capture(), expectedNodePrefix.capture(),
-            expectedOverrideFile.capture());
+            expectedNamespace.capture(), expectedOverrideFile.capture());
     assertEquals(config, expectedConfig.getValue());
     assertEquals(defaultProvider.uuid, expectedProviderUUID.getValue());
     assertEquals(defaultUniverse.getUniverseDetails().nodePrefix, expectedNodePrefix.getValue());
+    assertEquals(namespace, expectedNamespace.getValue());
+
     String overrideFileRegex = "(.*)" + defaultUniverse.universeUUID + "(.*).yml";
     assertThat(expectedOverrideFile.getValue(), RegexMatcher.matchesRegex(overrideFileRegex));
     Yaml yaml = new Yaml();
@@ -537,19 +563,22 @@ public class KubernetesCommandExecutorTest extends SubTaskBaseTest {
     defaultAnnotations.put("OVERRIDES", "serviceEndpoints:\n  - name: yb-master-service\n    type: LoadBalancer\n    app: yb-master\n    annotations:\n      annotation-1: bar\n    ports:\n      ui: 7000\n\n  - name: yb-tserver-service\n    type: LoadBalancer\n    app: yb-tserver\n    ports:\n      ycql-port: 9042\n      yedis-port: 6379");
     defaultAZ.setConfig(defaultAnnotations);
     KubernetesCommandExecutor kubernetesCommandExecutor =
-        createExecutor(KubernetesCommandExecutor.CommandType.HELM_INSTALL);
+        createExecutor(KubernetesCommandExecutor.CommandType.HELM_INSTALL, /* set namespace */ true);
     kubernetesCommandExecutor.run();
 
     ArgumentCaptor<UUID> expectedProviderUUID = ArgumentCaptor.forClass(UUID.class);
     ArgumentCaptor<String> expectedNodePrefix = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> expectedNamespace = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> expectedOverrideFile = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<HashMap> expectedConfig = ArgumentCaptor.forClass(HashMap.class);
     verify(kubernetesManager, times(1))
         .helmInstall(expectedConfig.capture(), expectedProviderUUID.capture(), expectedNodePrefix.capture(),
-            expectedOverrideFile.capture());
+            expectedNamespace.capture(), expectedOverrideFile.capture());
     assertEquals(config, expectedConfig.getValue());
     assertEquals(defaultProvider.uuid, expectedProviderUUID.getValue());
     assertEquals(defaultUniverse.getUniverseDetails().nodePrefix, expectedNodePrefix.getValue());
+    assertEquals(namespace, expectedNamespace.getValue());
+
     String overrideFileRegex = "(.*)" + defaultUniverse.universeUUID + "(.*).yml";
     assertThat(expectedOverrideFile.getValue(), RegexMatcher.matchesRegex(overrideFileRegex));
     Yaml yaml = new Yaml();
@@ -569,19 +598,22 @@ public class KubernetesCommandExecutorTest extends SubTaskBaseTest {
     defaultAZ.setConfig(defaultAnnotations);
 
     KubernetesCommandExecutor kubernetesCommandExecutor =
-        createExecutor(KubernetesCommandExecutor.CommandType.HELM_INSTALL);
+        createExecutor(KubernetesCommandExecutor.CommandType.HELM_INSTALL, /* set namespace */ true);
     kubernetesCommandExecutor.run();
 
     ArgumentCaptor<UUID> expectedProviderUUID = ArgumentCaptor.forClass(UUID.class);
     ArgumentCaptor<String> expectedNodePrefix = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> expectedNamespace = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> expectedOverrideFile = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<HashMap> expectedConfig = ArgumentCaptor.forClass(HashMap.class);
     verify(kubernetesManager, times(1))
         .helmInstall(expectedConfig.capture(), expectedProviderUUID.capture(), expectedNodePrefix.capture(),
-            expectedOverrideFile.capture());
+            expectedNamespace.capture(), expectedOverrideFile.capture());
     assertEquals(config, expectedConfig.getValue());
     assertEquals(defaultProvider.uuid, expectedProviderUUID.getValue());
     assertEquals(defaultUniverse.getUniverseDetails().nodePrefix, expectedNodePrefix.getValue());
+    assertEquals(namespace, expectedNamespace.getValue());
+
     String overrideFileRegex = "(.*)" + defaultUniverse.universeUUID + "(.*).yml";
     assertThat(expectedOverrideFile.getValue(), RegexMatcher.matchesRegex(overrideFileRegex));
     Yaml yaml = new Yaml();
@@ -601,19 +633,22 @@ public class KubernetesCommandExecutorTest extends SubTaskBaseTest {
         ApiUtils.mockUniverseUpdater(defaultUserIntent, "host", true));
     hackPlacementUUID = u.getUniverseDetails().getPrimaryCluster().uuid;
     KubernetesCommandExecutor kubernetesCommandExecutor =
-        createExecutor(KubernetesCommandExecutor.CommandType.HELM_INSTALL);
+        createExecutor(KubernetesCommandExecutor.CommandType.HELM_INSTALL, /* set namespace */ true);
     kubernetesCommandExecutor.run();
 
     ArgumentCaptor<UUID> expectedProviderUUID = ArgumentCaptor.forClass(UUID.class);
     ArgumentCaptor<String> expectedNodePrefix = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> expectedNamespace = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> expectedOverrideFile = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<HashMap> expectedConfig = ArgumentCaptor.forClass(HashMap.class);
     verify(kubernetesManager, times(1))
         .helmInstall(expectedConfig.capture(), expectedProviderUUID.capture(), expectedNodePrefix.capture(),
-            expectedOverrideFile.capture());
+            expectedNamespace.capture(), expectedOverrideFile.capture());
     assertEquals(defaultProvider.uuid, expectedProviderUUID.getValue());
     assertEquals(config, expectedConfig.getValue());
     assertEquals(defaultUniverse.getUniverseDetails().nodePrefix, expectedNodePrefix.getValue());
+    assertEquals(namespace, expectedNamespace.getValue());
+
     String overrideFileRegex = "(.*)" + defaultUniverse.universeUUID + "(.*).yml";
     assertThat(expectedOverrideFile.getValue(), RegexMatcher.matchesRegex(overrideFileRegex));
     Yaml yaml = new Yaml();
@@ -627,54 +662,83 @@ public class KubernetesCommandExecutorTest extends SubTaskBaseTest {
   @Test
   public void testHelmDelete() {
     KubernetesCommandExecutor kubernetesCommandExecutor =
-        createExecutor(KubernetesCommandExecutor.CommandType.HELM_DELETE);
+        createExecutor(KubernetesCommandExecutor.CommandType.HELM_DELETE,
+                       /* set namespace */ true);
     kubernetesCommandExecutor.run();
     verify(kubernetesManager, times(1))
-        .helmDelete(config, defaultUniverse.getUniverseDetails().nodePrefix);
+        .helmDelete(config, defaultUniverse.getUniverseDetails().nodePrefix, namespace);
   }
 
   @Test
   public void testVolumeDelete() {
     KubernetesCommandExecutor kubernetesCommandExecutor =
-        createExecutor(KubernetesCommandExecutor.CommandType.VOLUME_DELETE);
+        createExecutor(KubernetesCommandExecutor.CommandType.VOLUME_DELETE,
+                       /* set namespace */ true);
     kubernetesCommandExecutor.run();
     verify(kubernetesManager, times(1))
-        .deleteStorage(config, defaultUniverse.getUniverseDetails().nodePrefix);
+      .deleteStorage(config, defaultUniverse.getUniverseDetails().nodePrefix, namespace);
   }
 
   @Test
   public void testNamespaceDelete() {
     KubernetesCommandExecutor kubernetesCommandExecutor =
-        createExecutor(KubernetesCommandExecutor.CommandType.NAMESPACE_DELETE);
+        createExecutor(KubernetesCommandExecutor.CommandType.NAMESPACE_DELETE,
+                       /* set namespace */ true);
     kubernetesCommandExecutor.run();
     verify(kubernetesManager, times(1))
-        .deleteNamespace(config, defaultUniverse.getUniverseDetails().nodePrefix);
+        .deleteNamespace(config, namespace);
   }
 
   @Test
   public void testPodInfo() {
+    testPodInfoBase(false);
+  }
+
+  @Test
+  public void testPodInfoWithNamespace() {
+    testPodInfoBase(true);
+  }
+
+  private void testPodInfoBase(boolean setNamespace) {
+    String nodePrefix = defaultUniverse.getUniverseDetails().nodePrefix;
+    String namespace = nodePrefix;
+    Map<String, String> azConfig = new HashMap();
+    azConfig.putAll(config);
+
+    if (setNamespace) {
+      namespace = "test-ns";
+      azConfig.put("KUBECONFIG", "test-kc");
+      azConfig.put("KUBENAMESPACE", namespace);
+    }
+    defaultAZ.setConfig(azConfig);
+
     ShellResponse shellResponse = new ShellResponse();
     shellResponse.message =
         "{\"items\": [{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\"," +
-            " \"podIP\": \"123.456.78.90\"}, \"spec\": {\"hostname\": \"yb-master-0\"}}," +
+            " \"podIP\": \"123.456.78.90\"}, \"spec\": {\"hostname\": \"yb-master-0\"}," +
+            " \"metadata\": {\"namespace\": \"" + namespace + "\"}}," +
         "{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
-            "\"podIP\": \"123.456.78.91\"}, \"spec\": {\"hostname\": \"yb-tserver-0\"}}," +
+            "\"podIP\": \"123.456.78.91\"}, \"spec\": {\"hostname\": \"yb-tserver-0\"}," +
+            " \"metadata\": {\"namespace\": \"" + namespace + "\"}}," +
         "{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
-            "\"podIP\": \"123.456.78.92\"}, \"spec\": {\"hostname\": \"yb-master-1\"}}," +
+            "\"podIP\": \"123.456.78.92\"}, \"spec\": {\"hostname\": \"yb-master-1\"}," +
+            " \"metadata\": {\"namespace\": \"" + namespace + "\"}}," +
         "{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\"," +
-            " \"podIP\": \"123.456.78.93\"}, \"spec\": {\"hostname\": \"yb-tserver-1\"}}," +
+            " \"podIP\": \"123.456.78.93\"}, \"spec\": {\"hostname\": \"yb-tserver-1\"}," +
+            " \"metadata\": {\"namespace\": \"" + namespace + "\"}}," +
         "{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
-            "\"podIP\": \"123.456.78.94\"}, \"spec\": {\"hostname\": \"yb-master-2\"}}," +
+            "\"podIP\": \"123.456.78.94\"}, \"spec\": {\"hostname\": \"yb-master-2\"}," +
+            " \"metadata\": {\"namespace\": \"" + namespace + "\"}}," +
         "{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
-            "\"podIP\": \"123.456.78.95\"}, \"spec\": {\"hostname\": \"yb-tserver-2\"}}]}";
-    when(kubernetesManager.getPodInfos(any(), any())).thenReturn(shellResponse);
+            "\"podIP\": \"123.456.78.95\"}, \"spec\": {\"hostname\": \"yb-tserver-2\"}," +
+            " \"metadata\": {\"namespace\": \"" + namespace + "\"}}]}";
+    when(kubernetesManager.getPodInfos(any(), any(), any())).thenReturn(shellResponse);
     KubernetesCommandExecutor kubernetesCommandExecutor =
         createExecutor(KubernetesCommandExecutor.CommandType.POD_INFO,
-        defaultUniverse.getUniverseDetails().getPrimaryCluster().placementInfo);
+                       defaultUniverse.getUniverseDetails().getPrimaryCluster().placementInfo);
     assertEquals(3, defaultUniverse.getNodes().size());
     kubernetesCommandExecutor.run();
-    verify(kubernetesManager, times(1))
-        .getPodInfos(config, defaultUniverse.getUniverseDetails().nodePrefix);
+    verify(kubernetesManager, times(1)).getPodInfos(azConfig, nodePrefix, namespace);
     defaultUniverse = Universe.get(defaultUniverse.universeUUID);
     ImmutableList<String> pods = ImmutableList.of(
         "yb-master-0",
@@ -690,21 +754,21 @@ public class KubernetesCommandExecutorTest extends SubTaskBaseTest {
       String serviceName = podName.contains("master") ? "yb-masters" : "yb-tservers";
       assertTrue(podName.contains("master") ? node.isMaster: node.isTserver);
       assertEquals(node.cloudInfo.private_ip, String.format("%s.%s.%s.%s", podName,
-          serviceName, defaultUniverse.getUniverseDetails().nodePrefix, "svc.cluster.local"));
+          serviceName, namespace, "svc.cluster.local"));
     }
   }
 
   @Test
   public void testPodInfoMultiAZ() {
+    testPodInfoMultiAZBase(false);
+  }
 
-    ShellResponse shellResponse = new ShellResponse();
-    shellResponse.message =
-        "{\"items\": [{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\"," +
-            " \"podIP\": \"123.456.78.90\"}, \"spec\": {\"hostname\": \"yb-master-0\"}}," +
-        "{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
-            "\"podIP\": \"123.456.78.91\"}, \"spec\": {\"hostname\": \"yb-tserver-0\"}}]}";
-    when(kubernetesManager.getPodInfos(any(), any())).thenReturn(shellResponse);
+  @Test
+  public void testPodInfoMultiAZWithNamespace() {
+    testPodInfoMultiAZBase(true);
+  }
 
+  private void testPodInfoMultiAZBase(boolean setNamespace) {
     Region r1 = Region.create(defaultProvider, "region-1", "region-1", "yb-image-1");
     Region r2 = Region.create(defaultProvider, "region-2", "region-2", "yb-image-1");
     AvailabilityZone az1 = AvailabilityZone.create(r1, "az-" + 1, "az-" + 1, "subnet-" + 1);
@@ -715,30 +779,78 @@ public class KubernetesCommandExecutorTest extends SubTaskBaseTest {
     PlacementInfoUtil.addPlacementZone(az2.uuid, pi);
     PlacementInfoUtil.addPlacementZone(az3.uuid, pi);
 
+    String nodePrefix1 = String.format("%s-%s", defaultUniverse.getUniverseDetails().nodePrefix,
+                                       "az-1");
+    String nodePrefix2 = String.format("%s-%s", defaultUniverse.getUniverseDetails().nodePrefix,
+                                       "az-2");
+    String nodePrefix3 = String.format("%s-%s", defaultUniverse.getUniverseDetails().nodePrefix,
+                                       "az-3");
+
+    String ns1 = nodePrefix1;
+    String ns2 = nodePrefix2;
+    String ns3 = nodePrefix3;
+
+    Map<String, String> config1 = new HashMap();
+    Map<String, String> config2 = new HashMap();
+    Map<String, String> config3 = new HashMap();
+    config1.put("KUBECONFIG", "test-kc-" + 1);
+    config2.put("KUBECONFIG", "test-kc-" + 2);
+    config3.put("KUBECONFIG", "test-kc-" + 3);
+
+    if (setNamespace) {
+      ns1 = "demo-ns-1";
+      ns2 = "demons2";
+
+      config1.put("KUBENAMESPACE", ns1);
+      config2.put("KUBENAMESPACE", ns2);
+    }
+
+    az1.setConfig(config1);
+    az2.setConfig(config2);
+    az3.setConfig(config3);
+
+    String podInfosMessage =
+        "{\"items\": [{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\"," +
+            " \"podIP\": \"123.456.78.90\"}, \"spec\": {\"hostname\": \"yb-master-0\"}," +
+            " \"metadata\": {\"namespace\": \"%1$s\"}}," +
+        "{\"status\": {\"startTime\": \"1234\", \"phase\": \"Running\", " +
+            "\"podIP\": \"123.456.78.91\"}, \"spec\": {\"hostname\": \"yb-tserver-0\"}," +
+            " \"metadata\": {\"namespace\": \"%1$s\"}}]}";
+    ShellResponse shellResponse1 =
+        ShellResponse.create(0, String.format(podInfosMessage, ns1));
+    when(kubernetesManager.getPodInfos(any(), eq(nodePrefix1), eq(ns1))).thenReturn(shellResponse1);
+    ShellResponse shellResponse2 =
+        ShellResponse.create(0, String.format(podInfosMessage, ns2));
+    when(kubernetesManager.getPodInfos(any(), eq(nodePrefix2), eq(ns2))).thenReturn(shellResponse2);
+    ShellResponse shellResponse3 =
+        ShellResponse.create(0, String.format(podInfosMessage, ns3));
+    when(kubernetesManager.getPodInfos(any(), eq(nodePrefix3), eq(ns3))).thenReturn(shellResponse3);
+
     KubernetesCommandExecutor kubernetesCommandExecutor =
         createExecutor(KubernetesCommandExecutor.CommandType.POD_INFO, pi);
     kubernetesCommandExecutor.run();
 
-    verify(kubernetesManager, times(1)).getPodInfos(config,
-        String.format("%s-%s", defaultUniverse.getUniverseDetails().nodePrefix, "az-1"));
-    verify(kubernetesManager, times(1)).getPodInfos(config,
-        String.format("%s-%s", defaultUniverse.getUniverseDetails().nodePrefix, "az-2"));
-    verify(kubernetesManager, times(1)).getPodInfos(config,
-        String.format("%s-%s", defaultUniverse.getUniverseDetails().nodePrefix, "az-3"));
+    verify(kubernetesManager, times(1)).getPodInfos(config1, nodePrefix1, ns1);
+    verify(kubernetesManager, times(1)).getPodInfos(config2, nodePrefix2, ns2);
+    verify(kubernetesManager, times(1)).getPodInfos(config3, nodePrefix3, ns3);
     defaultUniverse = Universe.get(defaultUniverse.universeUUID);
-    ImmutableList<String> pods = ImmutableList.of(
-        "yb-master-0_az-1",
-        "yb-master-0_az-2",
-        "yb-master-0_az-3",
-        "yb-tserver-0_az-1",
-        "yb-tserver-0_az-2",
-        "yb-tserver-0_az-3"
-    );
+
+    Map<String, String> podToNamespace = new HashMap();
+    podToNamespace.put("yb-master-0_az-1", ns1);
+    podToNamespace.put("yb-master-0_az-2", ns2);
+    podToNamespace.put("yb-master-0_az-3", ns3);
+    podToNamespace.put("yb-tserver-0_az-1", ns1);
+    podToNamespace.put("yb-tserver-0_az-2", ns2);
+    podToNamespace.put("yb-tserver-0_az-3", ns3);
+
     Map<String, String> azToRegion = new HashMap();
     azToRegion.put("az-1", "region-1");
     azToRegion.put("az-2", "region-1");
     azToRegion.put("az-3", "region-2");
-    for (String podName : pods) {
+
+    for (Map.Entry<String, String> entry : podToNamespace.entrySet()) {
+      String podName = entry.getKey();
+      String namespace = entry.getValue();
       NodeDetails node = defaultUniverse.getNode(podName);
       assertNotNull(node);
       String serviceName = podName.contains("master") ? "yb-masters" : "yb-tservers";
@@ -748,12 +860,12 @@ public class KubernetesCommandExecutorTest extends SubTaskBaseTest {
       String az = podName.split("_")[1];
       String podK8sName = podName.split("_")[0];
       assertEquals(node.cloudInfo.private_ip, String.format("%s.%s.%s.%s", podK8sName, serviceName,
-          String.format("%s-%s", defaultUniverse.getUniverseDetails().nodePrefix, az),
-          "svc.cluster.local"));
+          namespace, "svc.cluster.local"));
       assertEquals(node.cloudInfo.az, az);
       assertEquals(node.cloudInfo.region, azToRegion.get(az));
     }
   }
+
 
   @Test
   public void testHelmInstallLegacy() throws IOException {
@@ -761,30 +873,35 @@ public class KubernetesCommandExecutorTest extends SubTaskBaseTest {
     shellResponse.message =
         "{\"items\": [{\"metadata\": {\"name\": \"test\"}, \"spec\": {\"clusterIP\": \"None\"," +
         "\"type\":\"clusterIP\"}}]}";
-    when(kubernetesManager.getServices(any(), any())).thenReturn(shellResponse);
+    when(kubernetesManager.getServices(any(), any(), any())).thenReturn(shellResponse);
     defaultUniverse.setConfig(ImmutableMap.of(Universe.HELM2_LEGACY,
                                               Universe.HelmLegacy.V2TO3.toString()));
     assertEquals(hackPlacementUUID, defaultUniverse.getUniverseDetails().getPrimaryCluster().uuid);
     KubernetesCommandExecutor kubernetesCommandExecutor =
         createExecutor(KubernetesCommandExecutor.CommandType.HELM_INSTALL,
                        defaultUniverse.getUniverseDetails().getPrimaryCluster().placementInfo);
+    kubernetesCommandExecutor.taskParams().namespace = namespace;
     kubernetesCommandExecutor.run();
     assertEquals(hackPlacementUUID, defaultUniverse.getUniverseDetails().getPrimaryCluster().uuid);
 
     ArgumentCaptor<UUID> expectedProviderUUID = ArgumentCaptor.forClass(UUID.class);
     ArgumentCaptor<String> expectedNodePrefix = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> expectedNamespace = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> expectedOverrideFile = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<HashMap> expectedConfig = ArgumentCaptor.forClass(HashMap.class);
     verify(kubernetesManager, times(1)).helmInstall(expectedConfig.capture(),
                                                     expectedProviderUUID.capture(),
                                                     expectedNodePrefix.capture(),
+                                                    expectedNamespace.capture(),
                                                     expectedOverrideFile.capture());
     verify(kubernetesManager, times(1)).getServices(expectedConfig.capture(),
-                                                    expectedNodePrefix.capture());
+                                                    expectedNodePrefix.capture(),
+                                                    expectedNamespace.capture());
     assertEquals(config, expectedConfig.getValue());
     assertEquals(hackPlacementUUID, defaultUniverse.getUniverseDetails().getPrimaryCluster().uuid);
     assertEquals(defaultProvider.uuid, expectedProviderUUID.getValue());
     assertEquals(defaultUniverse.getUniverseDetails().nodePrefix, expectedNodePrefix.getValue());
+    assertEquals(namespace, expectedNamespace.getValue());
     String overrideFileRegex = "(.*)" + defaultUniverse.universeUUID + "(.*).yml";
     assertThat(expectedOverrideFile.getValue(), RegexMatcher.matchesRegex(overrideFileRegex));
     Yaml yaml = new Yaml();
@@ -794,5 +911,17 @@ public class KubernetesCommandExecutorTest extends SubTaskBaseTest {
     // TODO implement exposeAll false case
     assertEquals(hackPlacementUUID, defaultUniverse.getUniverseDetails().getPrimaryCluster().uuid);
     assertEquals(getExpectedOverrides(true), overrides);
+  }
+
+  @Test
+  public void testNullNamespaceParameter() {
+    KubernetesCommandExecutor kubernetesCommandExecutor =
+        createExecutor(KubernetesCommandExecutor.CommandType.HELM_DELETE,
+                       /* set namespace */ false);
+    try {
+      kubernetesCommandExecutor.run();
+    } catch (IllegalArgumentException e) {
+      assertEquals("namespace can be null only in case of POD_INFO", e.getMessage());
+    }
   }
 }

--- a/managed/ui/src/components/config/PublicCloud/Kubernetes/AddRegionList.js
+++ b/managed/ui/src/components/config/PublicCloud/Kubernetes/AddRegionList.js
@@ -36,6 +36,7 @@ class AddRegionList extends Component {
         {
           zoneLabel: '',
           storageClasses: '',
+          namespace: '',
           zoneKubeConfig: formik.values.kubeConfig,
           zoneOverrides: ''
         }
@@ -117,6 +118,7 @@ class AddRegionList extends Component {
               zoneArrayHelpers.replace(rowIdx, {
                 zoneLabel: '',
                 storageClasses: '',
+                namespace: '',
                 zoneKubeConfig: vals.kubeConfig,
                 zoneOverrides: ''
               });
@@ -137,6 +139,7 @@ class AddRegionList extends Component {
     arrayPush({
       zoneLabel: '',
       storageClasses: '',
+      namespace: '',
       zoneKubeConfig: formik.values.kubeConfig,
       zoneOverrides: ''
     });
@@ -263,6 +266,13 @@ class AddRegionList extends Component {
                                     STORAGE CLASS
                                   </TableHeaderColumn>
                                   <TableHeaderColumn
+                                    dataField="namespace"
+                                    columnClassName="no-border name-column"
+                                    className="no-border"
+                                  >
+                                    NAMESPACE
+                                  </TableHeaderColumn>
+                                  <TableHeaderColumn
                                     dataField="zoneKubeConfig.name"
                                     dataFormat={this.zoneConfigFormatter}
                                     columnClassName="no-border name-column"
@@ -318,6 +328,27 @@ class AddRegionList extends Component {
                                         title="Storage Classes"
                                         content={
                                           "Default is 'standard'. This field is accepts comma-delimited values."
+                                        }
+                                      />
+                                    </Col>
+                                  </Row>
+                                  <Row className="config-provider-row">
+                                    <Col lg={3}>
+                                      <div className="form-item-custom-label">Namespace</div>
+                                    </Col>
+                                    <Col lg={7}>
+                                      <Field
+                                        name={`regionList[${regionIndex}].zoneList[${zoneIndex}].namespace`}
+                                        placeholder="Namespace for this Zone"
+                                        component={YBFormInput}
+                                        className={'kube-provider-input-field'}
+                                      />
+                                    </Col>
+                                    <Col lg={1} className="config-zone-tooltip">
+                                      <YBInfoTip
+                                        title="Namespace"
+                                        content={
+                                          "An existing namespace into which pods in this zone will be deployed."
                                         }
                                       />
                                     </Col>

--- a/managed/ui/src/components/config/PublicCloud/Kubernetes/CreateKubernetesConfiguration.js
+++ b/managed/ui/src/components/config/PublicCloud/Kubernetes/CreateKubernetesConfiguration.js
@@ -64,6 +64,7 @@ class CreateKubernetesConfiguration extends Component {
           name: zone.zoneLabel,
           config: {
             STORAGE_CLASS: zone.storageClasses || 'standard',
+            KUBENAMESPACE: zone.namespace || undefined,
             OVERRIDES: zone.zoneOverrides,
             KUBECONFIG_NAME: (zone.zoneKubeConfig && zone.zoneKubeConfig.name) || undefined
           }


### PR DESCRIPTION
These set of changes introduces a new key KUBENAMESPACE in the AZ config. Useful for the situations where the platform software does not have access to create, list or delete namespaces in the cluster.

When KUBENAMESPACE is present in the AZ config, the deployment in that AZ in done in that namespace only. Platform does not try to create namespace when creating the universe. It does not delete the namespace when destroying the universe.

Makes changes to the kubectl, helm commands from KubernetesManager.java to use namespace as well as nodePrefix. The value of nodePrefix and namespace can be same if the AZ does not have KUBENAMESPACE.

DestroyKubernetesUniverse now always deletes the volumes before deleting the namespace and uses release label selector to make sure the volumes being deleted are of the universe being destroyed. Deleting a failed universe was deleting volumes of an existing one.

Use kubectl apply for the pull secret. This makes sure that we don't fail if the namespace already has a pull secret in it. This will just update the existing pull secret.

[Platform UI] Add option to specify namespace in the AZ modal

Test plan:

The following tests have been done on OpenShift, where the Kubernetes ServiceAccount does not have access to create namespaces.

-   Created a single AZ provider with KUBENAMESPACE set.
-   Created a universe with it, tried GFlags update, database backup, universe edit operations, these pass as expected.
-   Destroyed the same universe.
-   Performed same set of operations with a multi AZ provider and a universe.

Fixes #6551, fixes #6702

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yugabyte/yugabyte-db/6807)
<!-- Reviewable:end -->
