### PR TITLE
[#6164] Manual backup of ysql task is not showing up in the universe tasks page

### DIFF
--- a/managed/ui/src/components/universes/UniverseDetail/UniverseDetail.js
+++ b/managed/ui/src/components/universes/UniverseDetail/UniverseDetail.js
@@ -258,6 +258,7 @@ class UniverseDetail extends Component {
         editTLSAvailability = 'disabled';
       }
     }
+
     const defaultTab = isNotHidden(currentCustomer.data.features, 'universes.details.overview')
       ? 'overview'
       : 'overview';

--- a/managed/ui/src/components/universes/UniverseDetail/UniverseDetail.js
+++ b/managed/ui/src/components/universes/UniverseDetail/UniverseDetail.js
@@ -258,7 +258,6 @@ class UniverseDetail extends Component {
         editTLSAvailability = 'disabled';
       }
     }
-
     const defaultTab = isNotHidden(currentCustomer.data.features, 'universes.details.overview')
       ? 'overview'
       : 'overview';
@@ -371,6 +370,7 @@ class UniverseDetail extends Component {
               universe={universe}
               tasks={tasks}
               isCommunityEdition={!!customer.INSECURE_apiToken}
+              fetchCustomerTasks={this.props.fetchCustomerTasks}
             />
           </Tab.Pane>
         )

--- a/managed/ui/src/components/universes/UniverseDetail/UniverseDetailContainer.js
+++ b/managed/ui/src/components/universes/UniverseDetail/UniverseDetailContainer.js
@@ -10,6 +10,11 @@ import {
   getHealthCheck,
   getHealthCheckResponse
 } from '../../../actions/universe';
+import {
+  fetchCustomerTasks,
+  fetchCustomerTasksSuccess,
+  fetchCustomerTasksFailure
+} from '../../../actions/tasks';
 
 import { getAlerts, getAlertsSuccess, getAlertsFailure } from '../../../actions/customers';
 
@@ -78,6 +83,16 @@ const mapDispatchToProps = (dispatch) => {
     getHealthCheck: (uuid) => {
       dispatch(getHealthCheck(uuid)).then((response) => {
         dispatch(getHealthCheckResponse(response.payload));
+      });
+    },
+    
+    fetchCustomerTasks: () => {
+      return dispatch(fetchCustomerTasks()).then((response) => {
+        if (!response.error) {
+          return dispatch(fetchCustomerTasksSuccess(response.payload));
+        } else {
+          return dispatch(fetchCustomerTasksFailure(response.payload));
+        }
       });
     },
     getAlertsList: () => {

--- a/managed/ui/src/components/universes/UniverseDetail/compounds/UniverseTaskList.jsx
+++ b/managed/ui/src/components/universes/UniverseDetail/compounds/UniverseTaskList.jsx
@@ -5,6 +5,10 @@ import { TaskListTable, TaskProgressContainer } from '../../../tasks';
 import { TASK_SHORT_TIMEOUT } from '../../../tasks/constants';
 
 export class UniverseTaskList extends Component {
+  componentDidMount() {
+    this.props.fetchCustomerTasks();
+  }
+
   tasksForUniverse = () => {
     const {
       universe: {


### PR DESCRIPTION
Universe task was not showing if the user clicks on the task tab after creating a manual backup.
The issue happens because we are not fetching latest task. Added API call when the user clicks on universe task tab.