### PR TITLE
stable release notes: remove tablet splitting

### DIFF
--- a/docs/content/latest/releases/whats-new/stable-releases.md
+++ b/docs/content/latest/releases/whats-new/stable-releases.md
@@ -43,7 +43,6 @@ showAsideToc: false
 
 ##### Core Database
 
-- General availability of [Automatic Tablet splitting](/latest/architecture/docdb-sharding/tablet-splitting/), which enables resharding of data in a cluster automatically while online, and transparently to users, when a specified size threshold has been reached ([#1004](https://github.com/yugabyte/yugabyte-db/issues/1004))
 - Introducing support for audit logging in YCQL and YSQL API ([#1331](https://github.com/yugabyte/yugabyte-db/issues/1331),[ #5887](https://github.com/yugabyte/yugabyte-db/issues/5887), [#6199](https://github.com/yugabyte/yugabyte-db/issues/6199))
 - Ability to log slow running queries in YSQL ([#4817](https://github.com/YugaByte/yugabyte-db/issues/4817))
 - Introducing support for LDAP integration in YSQL API ([#6088](https://github.com/yugabyte/yugabyte-db/issues/6088))

--- a/docs/content/stable/releases/whats-new/stable-releases.md
+++ b/docs/content/stable/releases/whats-new/stable-releases.md
@@ -41,7 +41,6 @@ showAsideToc: false
 
 ##### Core Database
 
-- General availability of [Automatic Tablet splitting](/latest/architecture/docdb-sharding/tablet-splitting/), which enables resharding of data in a cluster automatically while online, and transparently to users, when a specified size threshold has been reached ([#1004](https://github.com/yugabyte/yugabyte-db/issues/1004))
 - Introducing support for audit logging in YCQL and YSQL API ([#1331](https://github.com/yugabyte/yugabyte-db/issues/1331),[ #5887](https://github.com/yugabyte/yugabyte-db/issues/5887), [#6199](https://github.com/yugabyte/yugabyte-db/issues/6199))
 - Ability to log slow running queries in YSQL ([#4817](https://github.com/YugaByte/yugabyte-db/issues/4817))
 - Introducing support for LDAP integration in YSQL API ([#6088](https://github.com/yugabyte/yugabyte-db/issues/6088))


### PR DESCRIPTION
Removing this entry from the stable (2.4) release notes at @ameyb's request.