### PR TITLE
netlify update: redirect release notes to latest

### DIFF
--- a/docs/.markdownlint.json
+++ b/docs/.markdownlint.json
@@ -1,0 +1,11 @@
+{
+  "default": true,
+  "MD007": {"indent": 4},
+  "MD009": false,
+  "MD013": false,
+  "MD014": false,
+  "MD024": {"siblings_only": true},
+  "MD033": false,
+  "MD036": false,
+  "MD041": {"front_matter_title": "^\\s*title\\s*[:=]"}
+}

--- a/docs/content/latest/quick-start/build-apps/_index.html
+++ b/docs/content/latest/quick-start/build-apps/_index.html
@@ -16,9 +16,9 @@ menu:
     weight: 150
 ---
 
-Applications connect to and interact with YugabyteDB using API client libraries, also known as a client drivers. Here is a list, by programming language, of tutorials for building sample applications using available drivers and ORMs. Because YugabyteDB YSQL API is PostgreSQL-compatible and YCQL API has roots in the Apache Cassandra CQL, many of the tutorials use third party drivers.
+<p>Applications connect to and interact with YugabyteDB using API client libraries, also known as a client drivers. Here is a list, by programming language, of tutorials for building sample applications using available drivers and ORMs. Because YugabyteDB YSQL API is PostgreSQL-compatible and YCQL API has roots in the Apache Cassandra CQL, many of the tutorials use third-party drivers.</p>
 
-For details about supported API client drivers (by programming language), see [Drivers](../../reference/drivers).
+<p>For details about supported API client drivers (by programming language), see <a href="../../reference/drivers">Drivers</a>.</p>
 
 <div class="row">
 

--- a/docs/content/stable/quick-start/build-apps/_index.html
+++ b/docs/content/stable/quick-start/build-apps/_index.html
@@ -12,9 +12,9 @@ menu:
     weight: 150
 ---
 
-Applications connect to and interact with YugabyteDB using API client libraries, also known as a client drivers. Here is a list, by programming language, of tutorials for building sample applications using available drivers and ORMs. Because YugabyteDB YSQL API is PostgreSQL-compatible and YCQL API has roots in the Apache Cassandra CQL, many of the tutorials use third party drivers.
+<p>Applications connect to and interact with YugabyteDB using API client libraries, also known as a client drivers. Here is a list, by programming language, of tutorials for building sample applications using available drivers and ORMs. Because YugabyteDB YSQL API is PostgreSQL-compatible and YCQL API has roots in the Apache Cassandra CQL, many of the tutorials use third-party drivers.</p>
 
-For details about supported API client drivers (by programming language), see [Drivers](../../reference/drivers).
+<p>For details about supported API client drivers (by programming language), see <a href="../../reference/drivers">Drivers</a>.</p>
 
 <div class="row">
 

--- a/docs/content/v2.2/quick-start/build-apps/_index.html
+++ b/docs/content/v2.2/quick-start/build-apps/_index.html
@@ -13,9 +13,9 @@ menu:
     weight: 150
 ---
 
-Applications connect to and interact with YugabyteDB using API client libraries, also known as a client drivers. Here is a list, by programming language, of tutorials for building sample applications using available drivers and ORMs. Because YugabyteDB YSQL API is PostgreSQL-compatible and YCQL API has roots in the Apache Cassandra CQL, many of the tutorials use third party drivers.
+<p>Applications connect to and interact with YugabyteDB using API client libraries, also known as a client drivers. Here is a list, by programming language, of tutorials for building sample applications using available drivers and ORMs. Because YugabyteDB YSQL API is PostgreSQL-compatible and YCQL API has roots in the Apache Cassandra CQL, many of the tutorials use third-party drivers.</p>
 
-For details about supported API client drivers (by programming language), see [Drivers](../../reference/drivers).
+<p>For details about supported API client drivers (by programming language), see <a href="../../reference/drivers">Drivers</a>.</p>
 
 <div class="row">
 

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -34,6 +34,12 @@
   to = "/latest/faq/:splat"
   force = true
 
+# Point all release notes to latest
+
+[[redirects]]
+  from="/:version/releases/*"
+  to="/latest/releases/:splat"
+
 # Docs prior to v1.3 are not online
 
 [[redirects]]

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -40,10 +40,20 @@
   from="/:version/releases/*"
   to="/latest/releases/:splat"
 
-# Stable quick-start needs to point to macOS by default
+# Stable quick-starts need defaults,
+# since archiving from /latest removes aliases
+
 [[redirects]]
   from="/stable/quick-start/install/"
   to="/stable/quick-start/install/macos/"
+
+[[redirects]]
+  from="/stable/quick-start/create-local-cluster/"
+  to="/stable/quick-start/create-local-cluster/macos/"
+
+[[redirects]]
+  from="/stable/quick-start/explore/"
+  to="/stable/quick-start/explore/ysql/"
 
 # Docs prior to v1.3 are not online
 

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -40,6 +40,11 @@
   from="/:version/releases/*"
   to="/latest/releases/:splat"
 
+# Stable quick-start needs to point to macOS by default
+[[redirects]]
+  from="/stable/quick-start/install/"
+  to="/stable/quick-start/install/macos/"
+
 # Docs prior to v1.3 are not online
 
 [[redirects]]


### PR DESCRIPTION
Adding a redirect so all /version/releases/* point to /latest/releases/*

More of these to come, as we identify more redundant content that should be version-independent...

(Also a couple of small random fixes)