### PR TITLE
docs: fix another version number and redirect

### DIFF
--- a/docs/content/latest/releases/releases-overview.md
+++ b/docs/content/latest/releases/releases-overview.md
@@ -66,10 +66,10 @@ For information on key features planned for the upcoming releases, visit [Curren
 
 | Release series | Planned release   |
 | :------------- | :---------------- |
-| v2.4 (stable)   | Jan 2021          |
-| v2.5            | Nov 2020          |
-| v2.6 (stable)   | Apr 2021          |
-| v2.7            | Feb 2021          |
+| v2.4 (stable)  | Jan 2021          |
+| v2.5           | Nov 2020          |
+| v2.6 (stable)  | Apr 2021          |
+| v2.7           | Feb 2021          |
 
 ## Recommended release series for projects
 
@@ -77,7 +77,7 @@ To ensure that your production go-live uses the most up-to-date stable release, 
 
 | Production go-live  | Recommended release series |
 | :------------------ | :------------------------- |
-| < 3 months          | v2.2 (current stable)      |
+| < 3 months          | v2.4 (current stable)      |
 | > 3 months          | v2.5 (latest)              |
 
 If your production go-live is more than three months from now, start your development and testing with the latest release series. By the time your production is ready to go live, the current stable release series, based on the latest release series you used for development and testing, will be available. By following this guideline, you ensure that your application is developed with the latest available features, enhancements, and fixes.

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -22,7 +22,8 @@
 #
 # validator: https://play.netlify.com/redirects
 
-# Legal and FAQ pages should always point to the latest
+# Legal, FAQ, and release notes should always point to the latest,
+# even if we have content in the older version's folder.
 
 [[redirects]]
   from = "/:version/legal/*"
@@ -34,11 +35,10 @@
   to = "/latest/faq/:splat"
   force = true
 
-# Point all release notes to latest
-
 [[redirects]]
-  from="/:version/releases/*"
-  to="/latest/releases/:splat"
+  from = "/:version/releases/*"
+  to = "/latest/releases/:splat"
+  force = true
 
 # Stable quick-starts need defaults,
 # since archiving from /latest removes aliases


### PR DESCRIPTION
Missed one occurrence of 2.2 as stable. At the same time, I realized the release-notes redirect wasn't working. This fixes both of those issues.