### PR TITLE
[Platform][Kubernetes] Merge the Helm overrides YAML recursively

### DIFF
--- a/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/subtasks/KubernetesCommandExecutor.java
+++ b/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/subtasks/KubernetesCommandExecutor.java
@@ -685,7 +685,7 @@ public class KubernetesCommandExecutor extends UniverseTaskBase {
     if (overridesYAML != null) {
       annotations =(HashMap<String, Object>) yaml.load(overridesYAML);
       if (annotations != null ) {
-        overrides.putAll(annotations);
+        mergeYaml(overrides, annotations);
       }
     }
 
@@ -716,6 +716,24 @@ public class KubernetesCommandExecutor extends UniverseTaskBase {
     } catch (IOException e) {
       LOG.error(e.getMessage());
       throw new RuntimeException("Error writing Helm Override file!");
+    }
+  }
+
+  // Recursively traverses the override map and updates or adds the
+  // keys to source map.
+  private void mergeYaml(Map<String, Object> source, Map<String, Object> override) {
+    for (Entry<String, Object> entry : override.entrySet()) {
+      String key = entry.getKey();
+      if (!source.containsKey(key)) {
+        source.put(key, override.get(key));
+        continue;
+      }
+      if (!(override.get(key) instanceof Map) || !(source.get(key) instanceof Map)) {
+        source.put(key, override.get(key));
+        continue;
+      }
+      mergeYaml((Map<String, Object>) source.get(key),
+                (Map<String, Object>) override.get(key));
     }
   }
 }


### PR DESCRIPTION
The generated Helm overrides are recursively merged with the Helm overrides provided at the zone/region/provider level. Consider following blocks,

generated YAML:
```
resource:
  master:
    requests:
      cpu: 2
      memory: 2Gi
    limits:
      cpu: 2
      memory: 2Gi
```

Zone level override:
```
resource:
  master:
    requests:
      cpu: 650m
```

final merged YAML:
```
resource:
  master:
    requests:
      cpu: 650m
      memory: 2Gi
    limits:
      cpu: 2
      memory: 2Gi
```

Arrays/lists are not merged, and are replaced directly. For Helm, if one has to change something from a list, they have to provide the whole list in their overrides YAML. We are following the same mechanism.

Fixes https://github.com/yugabyte/yugabyte-db/issues/5930

Scenarios tested:

Set the 'Zone level override' block in the provider and tried creating a universe with instance type 'small'. The resulting values are as follows (only the CPU requests of master is changed).

```
$ kubectl get pods yb-master-0 -n yb-dev-o1 -ojson | jq '.spec.containers[0].resources'
{
  "limits": {
    "cpu": "2400m",
    "memory": "4Gi"
  },
  "requests": {
    "cpu": "650m",
    "memory": "4Gi"
  }
}
```