### PR TITLE
[#5594] Platform:Handle invalid certs/keys correctly.

### DIFF
--- a/managed/src/main/java/com/yugabyte/yw/common/CertificateHelper.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/CertificateHelper.java
@@ -87,7 +87,7 @@ public class CertificateHelper {
 
   public static UUID createRootCA(String nodePrefix, UUID customerUUID, String storagePath) {
     try {
-      KeyPair clientKeyPair = getKeyPairObject();
+      KeyPair keyPair = getKeyPairObject();
 
       UUID rootCA_UUID = UUID.randomUUID();
       Calendar cal = Calendar.getInstance();
@@ -425,15 +425,16 @@ public class CertificateHelper {
   }
 
   public static KeyPair getKeyPairObject() {
+    KeyPairGenerator keypairGen = null;
     try {
       // Add the security provider in case it was never called.
       Security.addProvider(new BouncyCastleProvider());
-      KeyPairGenerator keypairGen = KeyPairGenerator.getInstance("RSA");
+      keypairGen = KeyPairGenerator.getInstance("RSA");
       keypairGen.initialize(2048);
-      return keypairGen.generateKeyPair();
     } catch (Exception e) {
       LOG.error(e.getMessage());
     }
+    return keypairGen.generateKeyPair();
   }
 
   private static boolean verifySignature(X509Certificate cert, String key) {

--- a/managed/src/main/java/com/yugabyte/yw/common/CertificateHelper.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/CertificateHelper.java
@@ -36,12 +36,15 @@ import org.slf4j.LoggerFactory;
 
 import play.libs.Json;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.StringWriter;
+import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.math.BigInteger;
@@ -52,6 +55,8 @@ import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
 import java.security.Security;
 import java.security.SignatureException;
 import java.security.cert.CertificateException;
@@ -59,6 +64,7 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Calendar;
 import java.util.Date;
@@ -80,88 +86,77 @@ public class CertificateHelper {
   public static final String ROOT_CERT = "root.crt";
 
   public static UUID createRootCA(String nodePrefix, UUID customerUUID, String storagePath) {
-      try {
-        Security.addProvider(new BouncyCastleProvider());
-        KeyPairGenerator keypairGen = KeyPairGenerator.getInstance("RSA");
-        keypairGen.initialize(2048);
-        UUID rootCA_UUID = UUID.randomUUID();
-        KeyPair keyPair = keypairGen.generateKeyPair();
-        Calendar cal = Calendar.getInstance();
-        Date certStart = cal.getTime();
-        cal.add(Calendar.YEAR, 1);
-        Date certExpiry = cal.getTime();
-        X500Name subject = new X500NameBuilder(BCStyle.INSTANCE)
-          .addRDN(BCStyle.CN, nodePrefix)
-          .addRDN(BCStyle.O, "example.com")
-          .build();
-        BigInteger serial = BigInteger.valueOf(System.currentTimeMillis());
-        X509v3CertificateBuilder certGen = new JcaX509v3CertificateBuilder(
-          subject,
-          serial,
-          certStart,
-          certExpiry,
-          subject,
-          keyPair.getPublic());
-        BasicConstraints basicConstraints = new BasicConstraints(1);
-        KeyUsage keyUsage = new KeyUsage(KeyUsage.digitalSignature | KeyUsage.nonRepudiation |
-                                         KeyUsage.keyEncipherment | KeyUsage.keyCertSign);
-        certGen.addExtension(
-          Extension.basicConstraints,
-          true,
-          basicConstraints.toASN1Primitive());
-        certGen.addExtension(
-          Extension.keyUsage,
-          true,
-          keyUsage.toASN1Primitive());
-        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
-          .build(keyPair.getPrivate());
-        X509CertificateHolder holder = certGen.build(signer);
-        JcaX509CertificateConverter converter = new JcaX509CertificateConverter();
-        converter.setProvider(new BouncyCastleProvider());
-        X509Certificate x509 = converter.getCertificate(holder);
-        String certPath = String.format(CERT_PATH + "/ca.%s", storagePath,
-            customerUUID.toString(), rootCA_UUID.toString(), ROOT_CERT);
-        String keyPath = String.format(CERT_PATH + "/ca.key.pem", storagePath,
-            customerUUID.toString(), rootCA_UUID.toString());
-        File certfile = new File(certPath);
-        certfile.getParentFile().mkdirs();
-        File keyfile = new File(keyPath);
-        JcaPEMWriter certWriter = new JcaPEMWriter(new FileWriter(certfile));
-        JcaPEMWriter keyWriter = new JcaPEMWriter(new FileWriter(keyfile));
-        certWriter.writeObject(x509);
-        certWriter.flush();
-        keyWriter.writeObject(keyPair.getPrivate());
-        keyWriter.flush();
-        CertificateInfo.Type certType = CertificateInfo.Type.SelfSigned;
-        LOG.info(
-          "Generated self signed cert label {} uuid {} of type {} for customer {} at paths {}, {}",
-          nodePrefix, rootCA_UUID, certType, customerUUID,
-          certPath, keyPath
-        );
+    try {
+      KeyPair clientKeyPair = getKeyPairObject();
 
-        CertificateInfo cert = CertificateInfo.create(
-          rootCA_UUID, customerUUID, nodePrefix,
-          certStart, certExpiry, keyPath, certPath, certType
-        );
+      UUID rootCA_UUID = UUID.randomUUID();
+      Calendar cal = Calendar.getInstance();
+      Date certStart = cal.getTime();
+      cal.add(Calendar.YEAR, 1);
+      Date certExpiry = cal.getTime();
+      X500Name subject = new X500NameBuilder(BCStyle.INSTANCE)
+        .addRDN(BCStyle.CN, nodePrefix)
+        .addRDN(BCStyle.O, "example.com")
+        .build();
+      BigInteger serial = BigInteger.valueOf(System.currentTimeMillis());
+      X509v3CertificateBuilder certGen = new JcaX509v3CertificateBuilder(
+        subject,
+        serial,
+        certStart,
+        certExpiry,
+        subject,
+        keyPair.getPublic());
+      BasicConstraints basicConstraints = new BasicConstraints(1);
+      KeyUsage keyUsage = new KeyUsage(KeyUsage.digitalSignature | KeyUsage.nonRepudiation |
+        KeyUsage.keyEncipherment | KeyUsage.keyCertSign);
+      certGen.addExtension(
+        Extension.basicConstraints,
+        true,
+        basicConstraints.toASN1Primitive());
+      certGen.addExtension(
+        Extension.keyUsage,
+        true,
+        keyUsage.toASN1Primitive());
+      ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
+        .build(keyPair.getPrivate());
+      X509CertificateHolder holder = certGen.build(signer);
+      JcaX509CertificateConverter converter = new JcaX509CertificateConverter();
+      converter.setProvider(new BouncyCastleProvider());
+      X509Certificate x509 = converter.getCertificate(holder);
+      String certPath = String.format(CERT_PATH + "/ca.%s", storagePath,
+        customerUUID.toString(), rootCA_UUID.toString(), ROOT_CERT);
+      saveCertContent(x509, certPath);
+      String keyPath = String.format(CERT_PATH + "/ca.key.pem", storagePath,
+        customerUUID.toString(), rootCA_UUID.toString());
+      writeKeyFileContentToKeyPath(keyPair.getPrivate(), keyPath);
+      CertificateInfo.Type certType = CertificateInfo.Type.SelfSigned;
+      LOG.info(
+        "Generated self signed cert label {} uuid {} of type {} for customer {} at paths {}, {}",
+        nodePrefix, rootCA_UUID, certType, customerUUID,
+        certPath, keyPath
+      );
 
-        LOG.info("Created Root CA for {}.", nodePrefix);
-        return cert.uuid;
-      } catch (NoSuchAlgorithmException | IOException | OperatorCreationException |
-               CertificateException e) {
-        LOG.error("Unable to create RootCA for universe " + nodePrefix, e);
-        return null;
-      }
+      CertificateInfo cert = CertificateInfo.create(
+        rootCA_UUID, customerUUID, nodePrefix,
+        certStart, certExpiry, keyPath, certPath, certType
+      );
+
+      LOG.info("Created Root CA for {}.", nodePrefix);
+      return cert.uuid;
+    } catch (NoSuchAlgorithmException | IOException | OperatorCreationException |
+      CertificateException e) {
+      LOG.error("Unable to create RootCA for universe " + nodePrefix, e);
+      return null;
+    }
   }
 
   public static JsonNode createClientCertificate(UUID rootCA, String storagePath, String username,
                                                  Date certStart, Date certExpiry) {
     LOG.info("Creating client certificate signed by root CA {} and user {} at path {}",
-            rootCA, username, storagePath);
+      rootCA, username, storagePath);
     try {
-      // Add the security provider in case createRootCA was never called.
-      Security.addProvider(new BouncyCastleProvider());
-      KeyPairGenerator keypairGen = KeyPairGenerator.getInstance("RSA");
-      keypairGen.initialize(2048);
+      // Add the security provider in case createClientCertificate was never called.
+      KeyPair clientKeyPair = getKeyPairObject();
 
       Calendar cal = Calendar.getInstance();
       if (certStart == null) {
@@ -176,54 +171,44 @@ public class CertificateHelper {
       if (cert.privateKey == null) {
         throw new RuntimeException("Keyfile cannot be null!");
       }
-
-      FileInputStream is = new FileInputStream(new File(cert.certificate));
-      CertificateFactory fact = CertificateFactory.getInstance("X.509");
-      X509Certificate cer = (X509Certificate) fact.generateCertificate(is);
+      X509Certificate cer = getX509CertificateCertObject(FileUtils.readFileToString
+          (new File(cert.certificate)));
       X500Name subject = new JcaX509CertificateHolder(cer).getSubject();
-      PemReader pemReader = new PemReader(new FileReader(cert.privateKey));
-      PemObject pemObject = pemReader.readPemObject();
-      byte[] bytes = pemObject.getContent();
-      pemReader.close();
-      PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(bytes);
-      KeyFactory kf = null;
       PrivateKey pk = null;
       try {
-        kf = KeyFactory.getInstance("RSA");
-        pk = kf.generatePrivate(spec);
-      } catch (InvalidKeySpecException e) {
+        pk = getPrivateKey(FileUtils.readFileToString(new File(cert.privateKey)));
+      } catch (Exception e) {
         LOG.error("Unable to create client CA for username {} using root CA {}",
-                  username, rootCA, e);
+          username, rootCA, e);
         throw new RuntimeException("Could not create client cert.");
       }
 
-      X500Name clientCertSubject = new X500Name(String.format("CN=%s",username));
+      X500Name clientCertSubject = new X500Name(String.format("CN=%s", username));
       BigInteger clientSerial = BigInteger.valueOf(System.currentTimeMillis());
-      KeyPair clientKeyPair = keypairGen.generateKeyPair();
       PKCS10CertificationRequestBuilder p10Builder = new JcaPKCS10CertificationRequestBuilder(
         clientCertSubject,
         clientKeyPair.getPublic());
       ContentSigner csrContentSigner = new JcaContentSignerBuilder("SHA256withRSA")
-          .build(pk);
+        .build(pk);
       PKCS10CertificationRequest csr = p10Builder.build(csrContentSigner);
 
       KeyUsage keyUsage = new KeyUsage(KeyUsage.digitalSignature | KeyUsage.nonRepudiation |
-                                           KeyUsage.keyEncipherment | KeyUsage.keyCertSign);
+        KeyUsage.keyEncipherment | KeyUsage.keyCertSign);
 
       X509v3CertificateBuilder clientCertBuilder = new X509v3CertificateBuilder(
         subject, clientSerial, certStart, certExpiry,
         csr.getSubject(), csr.getSubjectPublicKeyInfo());
       JcaX509ExtensionUtils clientCertExtUtils = new JcaX509ExtensionUtils();
       clientCertBuilder.addExtension(Extension.basicConstraints, true,
-                                     new BasicConstraints(false).toASN1Primitive());
+        new BasicConstraints(false).toASN1Primitive());
       clientCertBuilder.addExtension(Extension.authorityKeyIdentifier, false,
-                                     clientCertExtUtils.createAuthorityKeyIdentifier(cer));
+        clientCertExtUtils.createAuthorityKeyIdentifier(cer));
       clientCertBuilder.addExtension(Extension.subjectKeyIdentifier, false,
-          clientCertExtUtils.createSubjectKeyIdentifier(csr.getSubjectPublicKeyInfo()));
+        clientCertExtUtils.createSubjectKeyIdentifier(csr.getSubjectPublicKeyInfo()));
       clientCertBuilder.addExtension(Extension.keyUsage, false, keyUsage.toASN1Primitive());
 
       X509CertificateHolder clientCertHolder = clientCertBuilder.build(csrContentSigner);
-      X509Certificate clientCert  = new JcaX509CertificateConverter()
+      X509Certificate clientCert = new JcaX509CertificateConverter()
         .setProvider(new BouncyCastleProvider())
         .getCertificate(clientCertHolder);
 
@@ -257,8 +242,8 @@ public class CertificateHelper {
       return bodyJson;
 
     } catch (NoSuchAlgorithmException | IOException | OperatorCreationException |
-             CertificateException | InvalidKeyException | NoSuchProviderException |
-             SignatureException e) {
+      CertificateException | InvalidKeyException | NoSuchProviderException |
+      SignatureException e) {
       LOG.error("Unable to create client CA for username {} using root CA {}", username, rootCA, e);
       throw new RuntimeException("Could not create client cert.");
     }
@@ -275,21 +260,21 @@ public class CertificateHelper {
     }
     UUID rootCA_UUID = UUID.randomUUID();
     String keyPath = null;
+    X509Certificate x509Certificate = getX509CertificateCertObject(certContent);
     if (certType == CertificateInfo.Type.SelfSigned) {
+      if (!verifySignature(x509Certificate, keyContent))
+        throw new RuntimeException("Invalid certificate.");
       keyPath = String.format("%s/certs/%s/%s/ca.key.pem", storagePath,
-                                   customerUUID.toString(), rootCA_UUID.toString());
+        customerUUID.toString(), rootCA_UUID.toString());
+    } else {
+      if (!isValidCACert(x509Certificate))
+        throw new RuntimeException("Invalid CA certificate.");
     }
     String certPath = String.format("%s/certs/%s/%s/ca.%s", storagePath,
-                                    customerUUID.toString(), rootCA_UUID.toString(), ROOT_CERT);
+      customerUUID.toString(), rootCA_UUID.toString(), ROOT_CERT);
 
-    File certfile = new File(certPath);
-    // Create directory to store the keys.
-    certfile.getParentFile().mkdirs();
-    Files.write(certfile.toPath(), certContent.getBytes());
-    if (certType == CertificateInfo.Type.SelfSigned) {
-      File keyfile = new File(keyPath);
-      Files.write(keyfile.toPath(), keyContent.getBytes());
-    }
+
+    saveCertContent(getX509CertificateCertObject(certContent), certPath);
     LOG.info(
       "Uploaded cert label {} (uuid {}) of type {} at paths {}, {}",
       label, rootCA_UUID, certType,
@@ -298,6 +283,7 @@ public class CertificateHelper {
     CertificateInfo cert;
     try {
       if (certType == CertificateInfo.Type.SelfSigned) {
+        writeKeyFileContentToKeyPath(getPrivateKey(keyContent), keyPath);
         cert = CertificateInfo.create(rootCA_UUID, customerUUID, label, certStart,
           certExpiry, keyPath, certPath, certType);
       } else {
@@ -317,25 +303,25 @@ public class CertificateHelper {
     return certPEM;
   }
 
-  public static String getCertPEM(UUID rootCA){
+  public static String getCertPEM(UUID rootCA) {
     String certPEM = getCertPEMFileContents(rootCA);
     certPEM = Base64.getEncoder().encodeToString(certPEM.getBytes());
     return certPEM;
   }
 
-  public static String getCertPEM(CertificateInfo cert){
+  public static String getCertPEM(CertificateInfo cert) {
     String certPEM = FileUtils.readFileToString(new File(cert.certificate));
     certPEM = Base64.getEncoder().encodeToString(certPEM.getBytes());
     return certPEM;
   }
 
-  public static String getKeyPEM(CertificateInfo cert){
+  public static String getKeyPEM(CertificateInfo cert) {
     String privateKeyPEM = FileUtils.readFileToString(new File(cert.privateKey));
     privateKeyPEM = Base64.getEncoder().encodeToString(privateKeyPEM.getBytes());
     return privateKeyPEM;
   }
 
-  public static String getKeyPEM(UUID rootCA){
+  public static String getKeyPEM(UUID rootCA) {
     CertificateInfo cert = CertificateInfo.get(rootCA);
     String privateKeyPEM = FileUtils.readFileToString(new File(cert.privateKey));
     privateKeyPEM = Base64.getEncoder().encodeToString(privateKeyPEM.getBytes());
@@ -376,7 +362,7 @@ public class CertificateHelper {
     CertificateInfo cer1 = CertificateInfo.get(cert1);
     CertificateInfo cer2 = CertificateInfo.get(cert2);
     return (cer1.getCustomCertInfo().nodeCertPath.equals(cer2.getCustomCertInfo().nodeCertPath) ||
-            cer1.getCustomCertInfo().nodeKeyPath.equals(cer2.getCustomCertInfo().nodeKeyPath));
+      cer1.getCustomCertInfo().nodeKeyPath.equals(cer2.getCustomCertInfo().nodeKeyPath));
   }
 
   public static void createChecksums() {
@@ -388,6 +374,89 @@ public class CertificateHelper {
         // Log error, but don't cause it to error out.
         LOG.error("Could not generate checksum for cert: {}", cert.certificate);
       }
+    }
+  }
+
+  public static X509Certificate getX509CertificateCertObject(String certContent) {
+    try {
+      InputStream in = null;
+      byte[] certEntryBytes = certContent.getBytes();
+      in = new ByteArrayInputStream(certEntryBytes);
+      CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
+      return (X509Certificate) certFactory.generateCertificate(in);
+    } catch (CertificateException e) {
+      LOG.error(e.getMessage());
+      throw new RuntimeException("Unable to get cert Object");
+    }
+  }
+
+  public static PrivateKey getPrivateKey(String keyContent) {
+    try (PemReader pemReader = new PemReader(new StringReader(new String(keyContent)))) {
+      PemObject pemObject = pemReader.readPemObject();
+      byte[] bytes = pemObject.getContent();
+      PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(bytes);
+      KeyFactory kf = KeyFactory.getInstance("RSA");
+      return kf.generatePrivate(spec);
+    } catch (Exception e) {
+      LOG.error(e.getMessage());
+      throw new RuntimeException("Unable to get Private Key");
+    }
+  }
+
+  public static void writeKeyFileContentToKeyPath(PrivateKey keyContent, String keyPath) {
+    File keyFile = new File(keyPath);
+    try (JcaPEMWriter keyWriter = new JcaPEMWriter(new FileWriter(keyFile))) {
+      keyWriter.writeObject(keyContent);
+    } catch (Exception e) {
+      LOG.error(e.getMessage());
+      throw new RuntimeException("Save privateKey failed.");
+    }
+  }
+
+  public static void saveCertContent(X509Certificate cert, String certPath) {
+    File certfile = new File(certPath);
+    // Create directory to store the certFile.
+    certfile.getParentFile().mkdirs();
+    try (JcaPEMWriter certWriter = new JcaPEMWriter(new FileWriter(certfile))) {
+      certWriter.writeObject(cert);
+    } catch (Exception e) {
+      LOG.error(e.getMessage());
+      throw new RuntimeException("Save certContent failed.");
+    }
+  }
+
+  public static KeyPair getKeyPairObject() {
+    try {
+      // Add the security provider in case it was never called.
+      Security.addProvider(new BouncyCastleProvider());
+      KeyPairGenerator keypairGen = KeyPairGenerator.getInstance("RSA");
+      keypairGen.initialize(2048);
+      return keypairGen.generateKeyPair();
+    } catch (Exception e) {
+      LOG.error(e.getMessage());
+    }
+  }
+
+  private static boolean verifySignature(X509Certificate cert, String key) {
+    try {
+      // Add the security provider in case verifySignature was never called.
+      getKeyPairObject();
+      RSAPrivateKey privKey = (RSAPrivateKey) getPrivateKey(key);
+      RSAPublicKey publicKey = (RSAPublicKey) cert.getPublicKey();
+      return privKey.getModulus().toString().equals(publicKey.getModulus().toString());
+    } catch (Exception e) {
+      LOG.error("Cert or key is invalid." + e.getMessage());
+    }
+    return false;
+  }
+
+  private static boolean isValidCACert(X509Certificate cert) {
+    try {
+      cert.verify(cert.getPublicKey());
+      return true;
+    } catch (Exception exp) {
+      LOG.error(exp.getMessage());
+      return false;
     }
   }
 }

--- a/managed/src/main/java/com/yugabyte/yw/common/CertificateHelper.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/CertificateHelper.java
@@ -125,7 +125,7 @@ public class CertificateHelper {
       X509Certificate x509 = converter.getCertificate(holder);
       String certPath = String.format(CERT_PATH + "/ca.%s", storagePath,
         customerUUID.toString(), rootCA_UUID.toString(), ROOT_CERT);
-      saveCertContent(x509, certPath);
+      writeCertContentToCertPath(x509, certPath);
       String keyPath = String.format(CERT_PATH + "/ca.key.pem", storagePath,
         customerUUID.toString(), rootCA_UUID.toString());
       writeKeyFileContentToKeyPath(keyPair.getPrivate(), keyPath);
@@ -273,8 +273,7 @@ public class CertificateHelper {
     String certPath = String.format("%s/certs/%s/%s/ca.%s", storagePath,
       customerUUID.toString(), rootCA_UUID.toString(), ROOT_CERT);
 
-
-    saveCertContent(getX509CertificateCertObject(certContent), certPath);
+    writeCertContentToCertPath(getX509CertificateCertObject(certContent), certPath);
     LOG.info(
       "Uploaded cert label {} (uuid {}) of type {} at paths {}, {}",
       label, rootCA_UUID, certType,
@@ -413,7 +412,7 @@ public class CertificateHelper {
     }
   }
 
-  public static void saveCertContent(X509Certificate cert, String certPath) {
+  public static void writeCertContentToCertPath(X509Certificate cert, String certPath) {
     File certfile = new File(certPath);
     // Create directory to store the certFile.
     certfile.getParentFile().mkdirs();

--- a/managed/src/main/java/com/yugabyte/yw/controllers/CertificateController.java
+++ b/managed/src/main/java/com/yugabyte/yw/controllers/CertificateController.java
@@ -74,7 +74,7 @@ public class CertificateController extends AuthenticatedController {
       return ApiResponse.success(certUUID);
     } catch (Exception e) {
       LOG.error("Could not upload certs for customer {}", customerUUID, e);
-      return ApiResponse.error(BAD_REQUEST, "Couldn't upload certfiles");
+      return ApiResponse.error(BAD_REQUEST, e.getMessage());
     }
   }
 

--- a/managed/src/test/java/com/yugabyte/yw/common/CertificateHelperTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/common/CertificateHelperTest.java
@@ -150,6 +150,28 @@ public class CertificateHelperTest extends FakeDBApplication{
     clientCer.verify(cer.getPublicKey(), "BC");
   }
 
+  private String getCertContent() {
+    return "-----BEGIN CERTIFICATE-----\n" +
+      "MIIDDjCCAfagAwIBAgIGAXVXb5y/MA0GCSqGSIb3DQEBCwUAMDQxHDAaBgNVBAMM\n" +
+      "E3liLWFkbWluLXRlc3QtYXJuYXYxFDASBgNVBAoMC2V4YW1wbGUuY29tMB4XDTIw\n" +
+      "MTAyMzIxNDg1M1oXDTIxMTAyMzIxNDg1M1owNDEcMBoGA1UEAwwTeWItYWRtaW4t\n" +
+      "dGVzdC1hcm5hdjEUMBIGA1UECgwLZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEB\n" +
+      "AQUAA4IBDwAwggEKAoIBAQCVWSZiQhr9e+L2MkSXP38dwXwF7RlZGhrYKrL7pp6l\n" +
+      "aHkLZ0lsFgxI6h0Yyn5S+Hhi/jGWbBso6kXw7frUwVY5kX2Q6iv+E+rKqbYQgNV3\n" +
+      "0vpCtOmNNolhNN3x4SKAIXyKOB5dXMGesjvba/qD6AstKS8bvRCUZcYDPjIUQGPu\n" +
+      "cYLmywV/EdXgB+7WLhUOOY2eBRWBrnGxk60pcHJZeW44g1vas9cfiw81OWVp5/V5\n" +
+      "apA631bE0MTgg283OCyYz+CV/YtnytUTg/+PUEqzM2cWsWdvpEz7TkKYXinRdN4d\n" +
+      "SwgOQEIvb7A/GYYmVf3yk4moUxEh4NLoV9CBDljEBUjZAgMBAAGjJjAkMBIGA1Ud\n" +
+      "EwEB/wQIMAYBAf8CAQEwDgYDVR0PAQH/BAQDAgLkMA0GCSqGSIb3DQEBCwUAA4IB\n" +
+      "AQAFR0m7r1I3FyoatuLBIG+alaeGHqsgNqseAJTDGlEyajGDz4MT0c76ZIQkTSGM\n" +
+      "vsM49Ad2D04sJR44/WlI2AVijubzHBr6Sj8ZdB909nPvGtB+Z8OnvKxJ0LUKyG1K\n" +
+      "VUbcCnN3qSoVeY5PaPeFMmWF0Qv4S8lRTZqAvCnk34bckwkWoHkuuNGO49CsNb40\n" +
+      "Z2NBy9Ckp0KkfeDpGcv9lHuUrl13iakCY09irvYRbfi0lVGF3+wXZtefV8ZAxfnN\n" +
+      "Vt4faawkJ79oahlXDYs6WCKEd3zVM3mR3STnzwxvtB6WacjhqgP4ozXdt6PUbTfZ\n" +
+      "jZPSP3OuL0IXk96wFHScay8S\n" +
+      "-----END CERTIFICATE-----\n";
+  }
+
   @Test
   public void testUploadRootCA() {
     Calendar cal = Calendar.getInstance();
@@ -157,9 +179,11 @@ public class CertificateHelperTest extends FakeDBApplication{
     cal.add(Calendar.YEAR, 1);
     Date certExpiry = cal.getTime();
     UUID rootCA = null;
-    CertificateInfo.Type type = CertificateInfo.Type.SelfSigned;
+    CertificateInfo.Type type = CertificateInfo.Type.CustomCertHostPath;
+    String cert_content = getCertContent();
+
     try {
-      rootCA = CertificateHelper.uploadRootCA("test", c.uuid, "/tmp", "test_cert", "test_key",
+      rootCA = CertificateHelper.uploadRootCA("test", c.uuid, "/tmp", cert_content, null,
           certStart, certExpiry, type, null);
     } catch (Exception e) {
       fail(e.getMessage());
@@ -167,4 +191,20 @@ public class CertificateHelperTest extends FakeDBApplication{
     assertNotNull(CertificateInfo.get(rootCA));
   }
 
+  @Test
+  public void testSelfSignedCertUploadRootCA() {
+    Calendar cal = Calendar.getInstance();
+    Date certStart = cal.getTime();
+    cal.add(Calendar.YEAR, 1);
+    Date certExpiry = cal.getTime();
+    UUID rootCA = null;
+    CertificateInfo.Type type = CertificateInfo.Type.SelfSigned;
+    String cert_content = getCertContent();
+    try {
+      rootCA = CertificateHelper.uploadRootCA("test", c.uuid, "/tmp", cert_content, "test_key",
+        certStart, certExpiry, type, null);
+    } catch (Exception e) {
+      assertEquals("Invalid certificate.", e.getMessage());
+    }
+  }
 }

--- a/managed/src/test/java/com/yugabyte/yw/controllers/CertificateControllerTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/controllers/CertificateControllerTest.java
@@ -138,9 +138,28 @@ public class CertificateControllerTest extends FakeDBApplication {
 
   @Test
   public void testUploadCertificate() {
+    String cert_content = "-----BEGIN CERTIFICATE-----\n" +
+      "MIIDDjCCAfagAwIBAgIGAXVXb5y/MA0GCSqGSIb3DQEBCwUAMDQxHDAaBgNVBAMM\n" +
+      "E3liLWFkbWluLXRlc3QtYXJuYXYxFDASBgNVBAoMC2V4YW1wbGUuY29tMB4XDTIw\n" +
+      "MTAyMzIxNDg1M1oXDTIxMTAyMzIxNDg1M1owNDEcMBoGA1UEAwwTeWItYWRtaW4t\n" +
+      "dGVzdC1hcm5hdjEUMBIGA1UECgwLZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEB\n" +
+      "AQUAA4IBDwAwggEKAoIBAQCVWSZiQhr9e+L2MkSXP38dwXwF7RlZGhrYKrL7pp6l\n" +
+      "aHkLZ0lsFgxI6h0Yyn5S+Hhi/jGWbBso6kXw7frUwVY5kX2Q6iv+E+rKqbYQgNV3\n" +
+      "0vpCtOmNNolhNN3x4SKAIXyKOB5dXMGesjvba/qD6AstKS8bvRCUZcYDPjIUQGPu\n" +
+      "cYLmywV/EdXgB+7WLhUOOY2eBRWBrnGxk60pcHJZeW44g1vas9cfiw81OWVp5/V5\n" +
+      "apA631bE0MTgg283OCyYz+CV/YtnytUTg/+PUEqzM2cWsWdvpEz7TkKYXinRdN4d\n" +
+      "SwgOQEIvb7A/GYYmVf3yk4moUxEh4NLoV9CBDljEBUjZAgMBAAGjJjAkMBIGA1Ud\n" +
+      "EwEB/wQIMAYBAf8CAQEwDgYDVR0PAQH/BAQDAgLkMA0GCSqGSIb3DQEBCwUAA4IB\n" +
+      "AQAFR0m7r1I3FyoatuLBIG+alaeGHqsgNqseAJTDGlEyajGDz4MT0c76ZIQkTSGM\n" +
+      "vsM49Ad2D04sJR44/WlI2AVijubzHBr6Sj8ZdB909nPvGtB+Z8OnvKxJ0LUKyG1K\n" +
+      "VUbcCnN3qSoVeY5PaPeFMmWF0Qv4S8lRTZqAvCnk34bckwkWoHkuuNGO49CsNb40\n" +
+      "Z2NBy9Ckp0KkfeDpGcv9lHuUrl13iakCY09irvYRbfi0lVGF3+wXZtefV8ZAxfnN\n" +
+      "Vt4faawkJ79oahlXDYs6WCKEd3zVM3mR3STnzwxvtB6WacjhqgP4ozXdt6PUbTfZ\n" +
+      "jZPSP3OuL0IXk96wFHScay8S\n" +
+      "-----END CERTIFICATE-----\n";
     ObjectNode bodyJson = Json.newObject();
     bodyJson.put("label", "test");
-    bodyJson.put("certContent", "cert_test");
+    bodyJson.put("certContent", cert_content);
     bodyJson.put("keyContent", "key_test");
     Date date = new Date();
     bodyJson.put("certStart", date.getTime());
@@ -148,13 +167,8 @@ public class CertificateControllerTest extends FakeDBApplication {
     bodyJson.put("certType", "SelfSigned");
     Result result = uploadCertificate(customer.uuid, bodyJson);
     JsonNode json = Json.parse(contentAsString(result));
-    assertEquals(OK, result.status());
-    UUID certUUID = UUID.fromString(json.asText());
-    CertificateInfo ci = CertificateInfo.get(certUUID);
-    assertEquals(ci.label, "test");
-    assertEquals(ci.certType, CertificateInfo.Type.SelfSigned);
-    assertTrue(ci.certificate.contains("/tmp"));
-    assertAuditEntry(1, customer.uuid);
+    assertEquals(BAD_REQUEST, result.status());
+    assertAuditEntry(0, customer.uuid);
   }
 
   @Test
@@ -173,9 +187,28 @@ public class CertificateControllerTest extends FakeDBApplication {
 
   @Test
   public void testUploadCustomCertificate() {
+    String cert_content = "-----BEGIN CERTIFICATE-----\n" +
+      "MIIDDjCCAfagAwIBAgIGAXVXb5y/MA0GCSqGSIb3DQEBCwUAMDQxHDAaBgNVBAMM\n" +
+      "E3liLWFkbWluLXRlc3QtYXJuYXYxFDASBgNVBAoMC2V4YW1wbGUuY29tMB4XDTIw\n" +
+      "MTAyMzIxNDg1M1oXDTIxMTAyMzIxNDg1M1owNDEcMBoGA1UEAwwTeWItYWRtaW4t\n" +
+      "dGVzdC1hcm5hdjEUMBIGA1UECgwLZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEB\n" +
+      "AQUAA4IBDwAwggEKAoIBAQCVWSZiQhr9e+L2MkSXP38dwXwF7RlZGhrYKrL7pp6l\n" +
+      "aHkLZ0lsFgxI6h0Yyn5S+Hhi/jGWbBso6kXw7frUwVY5kX2Q6iv+E+rKqbYQgNV3\n" +
+      "0vpCtOmNNolhNN3x4SKAIXyKOB5dXMGesjvba/qD6AstKS8bvRCUZcYDPjIUQGPu\n" +
+      "cYLmywV/EdXgB+7WLhUOOY2eBRWBrnGxk60pcHJZeW44g1vas9cfiw81OWVp5/V5\n" +
+      "apA631bE0MTgg283OCyYz+CV/YtnytUTg/+PUEqzM2cWsWdvpEz7TkKYXinRdN4d\n" +
+      "SwgOQEIvb7A/GYYmVf3yk4moUxEh4NLoV9CBDljEBUjZAgMBAAGjJjAkMBIGA1Ud\n" +
+      "EwEB/wQIMAYBAf8CAQEwDgYDVR0PAQH/BAQDAgLkMA0GCSqGSIb3DQEBCwUAA4IB\n" +
+      "AQAFR0m7r1I3FyoatuLBIG+alaeGHqsgNqseAJTDGlEyajGDz4MT0c76ZIQkTSGM\n" +
+      "vsM49Ad2D04sJR44/WlI2AVijubzHBr6Sj8ZdB909nPvGtB+Z8OnvKxJ0LUKyG1K\n" +
+      "VUbcCnN3qSoVeY5PaPeFMmWF0Qv4S8lRTZqAvCnk34bckwkWoHkuuNGO49CsNb40\n" +
+      "Z2NBy9Ckp0KkfeDpGcv9lHuUrl13iakCY09irvYRbfi0lVGF3+wXZtefV8ZAxfnN\n" +
+      "Vt4faawkJ79oahlXDYs6WCKEd3zVM3mR3STnzwxvtB6WacjhqgP4ozXdt6PUbTfZ\n" +
+      "jZPSP3OuL0IXk96wFHScay8S\n" +
+      "-----END CERTIFICATE-----\n";
     ObjectNode bodyJson = Json.newObject();
     bodyJson.put("label", "test");
-    bodyJson.put("certContent", "cert_test");
+    bodyJson.put("certContent", cert_content);
     Date date = new Date();
     bodyJson.put("certStart", date.getTime());
     bodyJson.put("certExpiry", date.getTime());
@@ -256,11 +289,31 @@ public class CertificateControllerTest extends FakeDBApplication {
 
   @Test
   public void testCreateClientCertificate() {
+    String cert_content = "-----BEGIN CERTIFICATE-----\n" +
+      "MIIDDjCCAfagAwIBAgIGAXVXb5y/MA0GCSqGSIb3DQEBCwUAMDQxHDAaBgNVBAMM\n" +
+      "E3liLWFkbWluLXRlc3QtYXJuYXYxFDASBgNVBAoMC2V4YW1wbGUuY29tMB4XDTIw\n" +
+      "MTAyMzIxNDg1M1oXDTIxMTAyMzIxNDg1M1owNDEcMBoGA1UEAwwTeWItYWRtaW4t\n" +
+      "dGVzdC1hcm5hdjEUMBIGA1UECgwLZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEB\n" +
+      "AQUAA4IBDwAwggEKAoIBAQCVWSZiQhr9e+L2MkSXP38dwXwF7RlZGhrYKrL7pp6l\n" +
+      "aHkLZ0lsFgxI6h0Yyn5S+Hhi/jGWbBso6kXw7frUwVY5kX2Q6iv+E+rKqbYQgNV3\n" +
+      "0vpCtOmNNolhNN3x4SKAIXyKOB5dXMGesjvba/qD6AstKS8bvRCUZcYDPjIUQGPu\n" +
+      "cYLmywV/EdXgB+7WLhUOOY2eBRWBrnGxk60pcHJZeW44g1vas9cfiw81OWVp5/V5\n" +
+      "apA631bE0MTgg283OCyYz+CV/YtnytUTg/+PUEqzM2cWsWdvpEz7TkKYXinRdN4d\n" +
+      "SwgOQEIvb7A/GYYmVf3yk4moUxEh4NLoV9CBDljEBUjZAgMBAAGjJjAkMBIGA1Ud\n" +
+      "EwEB/wQIMAYBAf8CAQEwDgYDVR0PAQH/BAQDAgLkMA0GCSqGSIb3DQEBCwUAA4IB\n" +
+      "AQAFR0m7r1I3FyoatuLBIG+alaeGHqsgNqseAJTDGlEyajGDz4MT0c76ZIQkTSGM\n" +
+      "vsM49Ad2D04sJR44/WlI2AVijubzHBr6Sj8ZdB909nPvGtB+Z8OnvKxJ0LUKyG1K\n" +
+      "VUbcCnN3qSoVeY5PaPeFMmWF0Qv4S8lRTZqAvCnk34bckwkWoHkuuNGO49CsNb40\n" +
+      "Z2NBy9Ckp0KkfeDpGcv9lHuUrl13iakCY09irvYRbfi0lVGF3+wXZtefV8ZAxfnN\n" +
+      "Vt4faawkJ79oahlXDYs6WCKEd3zVM3mR3STnzwxvtB6WacjhqgP4ozXdt6PUbTfZ\n" +
+      "jZPSP3OuL0IXk96wFHScay8S\n" +
+      "-----END CERTIFICATE-----\n";
     ObjectNode bodyJson = Json.newObject();
     Date date = new Date();
     bodyJson.put("username", "test");
     bodyJson.put("certStart", date.getTime());
     bodyJson.put("certExpiry", date.getTime());
+    bodyJson.put("certContent", cert_content);
     UUID rootCA = CertificateHelper.createRootCA("test-universe", customer.uuid,
                                                  "/tmp");
     Result result = createClientCertificate(customer.uuid, rootCA, bodyJson);


### PR DESCRIPTION
[5594][Platform] Handle invalid certs/keys correctly
**Description:**
We wanted to verify the cert at upload time itself.
**Testing:**
When we try to upload selfSigned cert, we were able to upload any
garbage files. Now with this fix, we have handled this scenrio. User
won't be able to upload garbage file. Incase of self signed cert upload
workflow, We are matching the modulus of
cert RSA Public key with the modulus of its private key if its matched
then it means certs are valid otheriwse Invalid.
For CA Cert, we are just validating the Cert format.
Added the unit Tests as well.