### PR TITLE
#7199 track and display heartbeat roundtrip time from each yb-tserver in yb-master UI

### DIFF
--- a/src/yb/master/master-path-handlers.cc
+++ b/src/yb/master/master-path-handlers.cc
@@ -225,7 +225,8 @@ inline void MasterPathHandlers::TServerTable(std::stringstream* output,
 
   if (viewType == TServersViewType::kTServersClocksView) {
     *output << "      <th>Physical Time (UTC)</th>\n"
-            << "      <th>Hybrid Time (UTC)</th>\n";
+            << "      <th>Hybrid Time (UTC)</th>\n"
+            << "      <th>Heartbeat RTT</th>\n";
   } else {
     DCHECK_EQ(viewType, TServersViewType::kTServersDefaultView);
     *output << "      <th>User Tablet-Peers / Leaders</th>\n"
@@ -369,6 +370,9 @@ void MasterPathHandlers::TServerDisplay(const std::string& current_uuid,
           *output << " / Logical: " << ht.GetLogicalValue();
         }
         *output << "</td>";
+        // Render the roundtrip time of previous heartbeat.
+        double rtt_ms = desc->heartbeat_rtt().ToMicroseconds()/1000.0;
+        *output << "    <td>" <<  StringPrintf("%.2fms", rtt_ms) << "</td>";
       } else {
         DCHECK_EQ(viewType, TServersViewType::kTServersDefaultView);
         *output << "    <td>" << (no_tablets ? 0

--- a/src/yb/master/master.proto
+++ b/src/yb/master/master.proto
@@ -755,6 +755,9 @@ message TSHeartbeatRequestPB {
 
   // Hybrid time on tablet server
   optional fixed64 ts_hybrid_time = 11;
+
+  // Roundtrip time for previous heartbeat in microseconds.
+  optional int64 rtt_us = 12;
 }
 
 message TSHeartbeatResponsePB {

--- a/src/yb/master/master_service.cc
+++ b/src/yb/master/master_service.cc
@@ -187,6 +187,7 @@ void MasterServiceImpl::TSHeartbeat(const TSHeartbeatRequestPB* req,
   ts_desc->set_leader_count(req->leader_count());
   ts_desc->set_physical_time(req->ts_physical_time());
   ts_desc->set_hybrid_time(HybridTime::FromPB(req->ts_hybrid_time()));
+  ts_desc->set_heartbeat_rtt(MonoDelta::FromMicroseconds(req->rtt_us()));
 
   // Adjust the table report limit per heartbeat so this can be dynamically changed.
   if (ts_desc->HasCapability(CAPABILITY_TabletReportLimit)) {

--- a/src/yb/master/ts_descriptor.h
+++ b/src/yb/master/ts_descriptor.h
@@ -194,7 +194,7 @@ class TSDescriptor {
     hybrid_time_ = hybrid_time;
   }
 
- HybridTime hybrid_time() const {
+  HybridTime hybrid_time() const {
     SharedLock<decltype(lock_)> l(lock_);
     return hybrid_time_;
   }

--- a/src/yb/master/ts_descriptor.h
+++ b/src/yb/master/ts_descriptor.h
@@ -194,9 +194,19 @@ class TSDescriptor {
     hybrid_time_ = hybrid_time;
   }
 
-  HybridTime hybrid_time() const {
+ HybridTime hybrid_time() const {
     SharedLock<decltype(lock_)> l(lock_);
     return hybrid_time_;
+  }
+
+  void set_heartbeat_rtt(MonoDelta heartbeat_rtt) {
+    std::lock_guard<decltype(lock_)> l(lock_);
+    heartbeat_rtt_ = heartbeat_rtt;
+  }
+
+  MonoDelta heartbeat_rtt() const {
+    SharedLock<decltype(lock_)> l(lock_);
+    return heartbeat_rtt_;
   }
 
   void set_total_memory_usage(uint64_t total_memory_usage) {
@@ -362,6 +372,9 @@ class TSDescriptor {
   // The physical and hybrid times on this node at the time of heartbeat
   MicrosTime physical_time_;
   HybridTime hybrid_time_;
+
+  // Roundtrip time of previous heartbeat.
+  MonoDelta heartbeat_rtt_;
 
   // Set to true once this instance has reported all of its tablets.
   bool has_tablet_report_;

--- a/src/yb/tserver/heartbeater.cc
+++ b/src/yb/tserver/heartbeater.cc
@@ -153,6 +153,9 @@ class Heartbeater::Thread {
   // The server for which we are heartbeating.
   TabletServer* const server_;
 
+  // Roundtrip time of previous heartbeat to yb-master.
+  MonoDelta heartbeat_rtt_ = MonoDelta::kZero;
+
   // The actual running thread (NULL before it is started)
   scoped_refptr<yb::Thread> thread_;
 
@@ -381,6 +384,7 @@ Status Heartbeater::Thread::TryHeartbeat() {
 
   req.set_config_index(server_->GetCurrentMasterIndex());
   req.set_cluster_config_version(server_->cluster_config_version());
+  req.set_rtt_us(heartbeat_rtt_.ToMicroseconds());
 
   // Include the hybrid time of this tablet server in the heartbeat.
   auto* hybrid_clock = dynamic_cast<server::HybridClock*>(server_->Clock());
@@ -401,9 +405,12 @@ Status Heartbeater::Thread::TryHeartbeat() {
 
   {
     VLOG_WITH_PREFIX(2) << "Sending heartbeat:\n" << req.DebugString();
+    heartbeat_rtt_ = MonoDelta::kZero;
+    MonoTime start_time = MonoTime::Now();
     master::TSHeartbeatResponsePB resp;
     RETURN_NOT_OK_PREPEND(proxy_->TSHeartbeat(req, &resp, &rpc),
                           "Failed to send heartbeat");
+    MonoTime end_time = MonoTime::Now();
     if (resp.has_error()) {
       if (resp.error().code() != master::MasterErrorPB::NOT_THE_LEADER) {
         return StatusFromPB(resp.error().status());
@@ -458,6 +465,7 @@ Status Heartbeater::Thread::TryHeartbeat() {
     // the last heartbeat response. This invalidates resp so we should use last_hb_response_ instead
     // below (hence using the nested scope for resp until here).
     last_hb_response_.Swap(&resp);
+    heartbeat_rtt_ = end_time.GetDeltaSince(start_time);
   }
 
   if (last_hb_response_.has_cluster_uuid() && !last_hb_response_.cluster_uuid().empty()) {

--- a/src/yb/tserver/heartbeater.h
+++ b/src/yb/tserver/heartbeater.h
@@ -66,8 +66,6 @@ class HeartbeatDataProvider {
 
  private:
   TabletServer& server_;
-  // Roundtrip time of previous heartbeat to yb-master.
-  MonoDelta heartbeat_rtt_ = MonoDelta::kZero;
 };
 
 // Component of the Tablet Server which is responsible for heartbeating to the

--- a/src/yb/tserver/heartbeater.h
+++ b/src/yb/tserver/heartbeater.h
@@ -66,6 +66,8 @@ class HeartbeatDataProvider {
 
  private:
   TabletServer& server_;
+  // Roundtrip time of previous heartbeat to yb-master.
+  MonoDelta heartbeat_rtt_ = MonoDelta::kZero;
 };
 
 // Component of the Tablet Server which is responsible for heartbeating to the


### PR DESCRIPTION
In the tablet server, this change tracks the roundtrip time of a heartbeat to the yb-master leader. This information is sent on the subsequent heartbeat and displayed in the http://yb-master:7000/tablet-server-clocks view.

<img width="1440" alt="Screen Shot 2021-02-11 at 3 59 49 PM" src="https://user-images.githubusercontent.com/60417098/107714475-31ae8000-6c82-11eb-871f-6bff4eaea0d3.png">