### PR TITLE
[#7223][Platform]: Show the associated universes for a certificate.

### DIFF
--- a/managed/src/main/java/com/yugabyte/yw/models/CertificateInfo.java
+++ b/managed/src/main/java/com/yugabyte/yw/models/CertificateInfo.java
@@ -4,6 +4,7 @@ package com.yugabyte.yw.models;
 
 import com.yugabyte.yw.common.Util;
 import com.yugabyte.yw.forms.CertificateParams;
+import com.yugabyte.yw.forms.UniverseDefinitionTaskParams;
 
 import io.ebean.*;
 import io.ebean.annotation.*;
@@ -22,9 +23,12 @@ import javax.persistence.Id;
 
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Entity
 public class CertificateInfo extends Model {
@@ -169,5 +173,15 @@ public class CertificateInfo extends Model {
   // Returns if there is an in use reference to the object.
   public boolean getInUse() {
     return Universe.existsCertificate(this.uuid, this.customerUUID);
+  }
+
+  public List<UniverseDefinitionTaskParams> getUniverseDetails() {
+    List<Universe> universeDetails = Universe.universeDetailsIfCertsExists(this.uuid,
+        this.customerUUID);
+    List<UniverseDefinitionTaskParams> universeDefinitionTaskParamsList = new ArrayList<>();
+    for (Universe universe: universeDetails) {
+      universeDefinitionTaskParamsList.add(universe.getUniverseDetails());
+    }
+    return universeDefinitionTaskParamsList;
   }
 }

--- a/managed/src/main/java/com/yugabyte/yw/models/Universe.java
+++ b/managed/src/main/java/com/yugabyte/yw/models/Universe.java
@@ -829,12 +829,14 @@ public class Universe extends Model {
     Universe.saveDetails(universeUUID, updater);
   }
 
+  public static List<Universe> universeDetailsIfCertsExists(UUID certUUID, UUID customerUUID) {
+    return Customer.get(customerUUID).getUniverses().stream()
+      .filter(s -> s.getUniverseDetails().rootCA != null
+        && !s.getUniverseDetails().rootCA.equals(certUUID))
+      .collect(Collectors.toList());
+  }
+
   public static boolean existsCertificate(UUID certUUID, UUID customerUUID) {
-    Set<Universe> universeList = Customer.get(customerUUID).getUniverses();
-    universeList = universeList.stream()
-        .filter(s -> s.getUniverseDetails().rootCA != null
-             && s.getUniverseDetails().rootCA.equals(certUUID))
-                .collect(Collectors.toSet());
-    return universeList.size() != 0;
+    return universeDetailsIfCertsExists(certUUID, customerUUID).size() != 0;
   }
 }


### PR DESCRIPTION
**Summary:**
Currently, there is no way for the user to know the list of universes for a certificate
this fix ensures to show the all the universe details associated with a
perticular certificate.

**Testing:**
1. Select a certificate in the UI and click on actions
   (Config->security->Encryption in transit-> Actions)
2. Click on show universes under Actions dropdown
3. We should be able to see all the universe associated with that
selected certificate.

**TODO:** UI changes are pending.

**O/p of SBT Test:**

Caused by: java.sql.SQLException: HikariDataSource HikariDataSource (HikariPool-1099) has been closed.
	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:96)
	at play.db.ebean.DefaultEbeanConfig$EbeanConfigParser$WrappingDatasource.getConnection(DefaultEbeanConfig.java:153)
	at io.ebeaninternal.server.transaction.TransactionFactoryBasic.createQueryTransaction(TransactionFactoryBasic.java:28)
	... 15 common frames omitted
2021-02-18 19:46:03.778 ERROR Scheduler.java:193 [application-akka.actor.default-dispatcher-7] Error Running scheduler threadjavax.persistence.PersistenceException: java.sql.SQLException: HikariDataSource HikariDataSource (HikariPool-1099) has been closed.
**[error] Failed: Total 1214, Failed 1, Errors 0, Passed 1209, Skipped 4**
[error] Failed tests:
[error] 	com.yugabyte.yw.controllers.ApiDiscoveryControllerTest
[error] (test:test) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 839 s, completed 18 Feb, 2021 7:46:46 PM


