### PR TITLE
[Platform] Exit health check with non zero code on invalid arguments

### DIFF
--- a/managed/devops/bin/cluster_health.py
+++ b/managed/devops/bin/cluster_health.py
@@ -622,6 +622,7 @@ def main():
         print(report)
     else:
         logging.error("Invalid argument combination")
+        sys.exit(1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When the argument cluster_payload is missing, the health check script
exits with 0 exit code (i.e. it silently fails). This happened with an
older version of this script where there was a mismatch with the
platform code and devops tar). As the platform code was new and it was
passing only one argument but the script was expecting two, it was
failing silently.

This change makes sure that this condition result in a non-zero return
code.

Scenarios tested:
- Created a universe and checked if the health checks work as expected.
- When the health checks fail with non-zero code, the errors are shown
  in the Alerts tab. (tried by commenting the Java code which adds
  --cluster_payload argument to the script).
