### PR TITLE
[#7228, #7225][Platform UI] Enable the OpenShift tab

### DIFF
--- a/managed/ui/src/components/config/ConfigProvider/DataCenterConfiguration.js
+++ b/managed/ui/src/components/config/ConfigProvider/DataCenterConfiguration.js
@@ -122,9 +122,7 @@ class DataCenterConfiguration extends Component {
                   <KubernetesProviderConfigurationContainer type="tanzu" params={params} />
                 </Tab>
                 <Tab eventKey="openshift" title={openshiftTabContent} key="openshift-tab" unmountOnExit={true}>
-                  <div className="h4">
-                    Coming Soon! Stay tuned for Red Hat OpenShift integration!
-                  </div>
+                  <KubernetesProviderConfigurationContainer type="openshift" params={params} />
                 </Tab>
                 <Tab eventKey="k8s" title={k8sTabContent} key="k8s-tab" unmountOnExit={true}>
                   <KubernetesProviderConfigurationContainer type="k8s" params={params} />

--- a/managed/ui/src/components/config/ConfigProvider/providerConfig.scss
+++ b/managed/ui/src/components/config/ConfigProvider/providerConfig.scss
@@ -382,17 +382,22 @@
   display: none !important;
 }
 
-#cloud-config-tab-panel-tab-azure:before {
+#cloud-config-tab-panel-tab-azure:before,
+#cloud-config-tab-panel-tab-openshift:before {
   content: 'BETA';
   position: absolute;
-  padding: 3px 7px;
+  padding: 2px 6px;
   top: 0;
   right: 0;
   background-color: $YB_ORANGE;
   border-radius: 4px;
   color: $YB_BACKGROUND;
   font-weight: 700;
-  font-size: 14px;
+  font-size: 10px;
+}
+
+#cloud-config-tab-panel-tab-openshift:before {
+  content: 'ALPHA';
 }
 
 .action-bar {

--- a/managed/ui/src/components/config/PublicCloud/Kubernetes/CreateKubernetesConfiguration.js
+++ b/managed/ui/src/components/config/PublicCloud/Kubernetes/CreateKubernetesConfiguration.js
@@ -17,6 +17,8 @@ import { KUBERNETES_PROVIDERS, REGION_DICT } from '../../../../config';
 import AddRegionList from './AddRegionList';
 
 const convertStrToCode = (s) => s.trim().toLowerCase().replace(/\s/g, '-');
+const quayImageRegistry = 'quay.io/yugabyte/yugabyte';
+const redhatImageRegistry = 'registry.connect.redhat.com/yugabytedb/yugabyte';
 
 class CreateKubernetesConfiguration extends Component {
   createProviderConfig = (vals, setSubmitting) => {
@@ -82,12 +84,11 @@ class CreateKubernetesConfiguration extends Component {
               ? providerTypeMetadata.code
               : 'gke',
           KUBECONFIG_SERVICE_ACCOUNT: vals.serviceAccount,
-          KUBECONFIG_IMAGE_REGISTRY: vals.imageRegistry || 'quay.io/yugabyte/yugabyte'
+          KUBECONFIG_IMAGE_REGISTRY: vals.imageRegistry || quayImageRegistry
         };
 
         if (!vals.imageRegistry && providerConfig['KUBECONFIG_PROVIDER'] === 'openshift') {
-          providerConfig['KUBECONFIG_IMAGE_REGISTRY'] =
-            'registry.connect.redhat.com/yugabytedb/yugabyte';
+          providerConfig['KUBECONFIG_IMAGE_REGISTRY'] = redhatImageRegistry;
         }
 
         configIndexRecord.forEach(([regionIdx, zoneIdx], i) => {
@@ -277,7 +278,7 @@ class CreateKubernetesConfiguration extends Component {
                           <Field
                             name="imageRegistry"
                             placeholder={ providerTypeOptions.length === 1 && providerTypeOptions[0].value === 'openshift'
-                                          ? "registry.connect.redhat.com/yugabytedb/yugabyte" : "quay.io/yugabyte/yugabyte" }
+                                          ? redhatImageRegistry : quayImageRegistry }
                             component={YBFormInput}
                             className={'kube-provider-input-field'}
                           />

--- a/managed/ui/src/components/config/PublicCloud/Kubernetes/CreateKubernetesConfiguration.js
+++ b/managed/ui/src/components/config/PublicCloud/Kubernetes/CreateKubernetesConfiguration.js
@@ -85,6 +85,11 @@ class CreateKubernetesConfiguration extends Component {
           KUBECONFIG_IMAGE_REGISTRY: vals.imageRegistry || 'quay.io/yugabyte/yugabyte'
         };
 
+        if (!vals.imageRegistry && providerConfig['KUBECONFIG_PROVIDER'] === 'openshift') {
+          providerConfig['KUBECONFIG_IMAGE_REGISTRY'] =
+            'registry.connect.redhat.com/yugabytedb/yugabyte';
+        }
+
         configIndexRecord.forEach(([regionIdx, zoneIdx], i) => {
           const currentZone = regionsLocInfo[regionIdx].zoneList[zoneIdx];
           currentZone.config.KUBECONFIG_CONTENT = configs[1 + i];
@@ -127,7 +132,8 @@ class CreateKubernetesConfiguration extends Component {
     } else {
       providerTypeOptions = KUBERNETES_PROVIDERS
         // skip providers with dedicated tab
-        .filter((provider) => provider.code !== 'tanzu' && provider.code !== 'pks')
+        .filter((provider) => provider.code !== 'tanzu' && provider.code !== 'pks'
+                && provider.code !== 'openshift')
         .map((provider) => ({ value: provider.code, label: provider.name }));
     }
 
@@ -270,7 +276,8 @@ class CreateKubernetesConfiguration extends Component {
                         <Col lg={7}>
                           <Field
                             name="imageRegistry"
-                            placeholder="quay.io/yugabyte/yugabyte"
+                            placeholder={ providerTypeOptions.length === 1 && providerTypeOptions[0].value === 'openshift'
+                                          ? "registry.connect.redhat.com/yugabytedb/yugabyte" : "quay.io/yugabyte/yugabyte" }
                             component={YBFormInput}
                             className={'kube-provider-input-field'}
                           />

--- a/managed/ui/src/components/config/PublicCloud/Kubernetes/KubernetesProviderConfiguration.js
+++ b/managed/ui/src/components/config/PublicCloud/Kubernetes/KubernetesProviderConfiguration.js
@@ -50,7 +50,7 @@ class KubernetesProviderConfiguration extends Component {
 
         // If the type has a dedicated tab, we don't want to include
         // other k8s configs and vice versa.
-        let dedicatedK8sTabs = ['tanzu', 'openshift']
+        const dedicatedK8sTabs = ['tanzu', 'openshift'];
         if (
           !isDefinedNotNull(providerData) ||
           (dedicatedK8sTabs.includes(type) && providerData.config['KUBECONFIG_PROVIDER'] !== type) ||

--- a/managed/ui/src/components/config/PublicCloud/Kubernetes/KubernetesProviderConfiguration.js
+++ b/managed/ui/src/components/config/PublicCloud/Kubernetes/KubernetesProviderConfiguration.js
@@ -48,11 +48,13 @@ class KubernetesProviderConfiguration extends Component {
       .map((region) => {
         const providerData = providers.data.find((p) => p.uuid === region.provider.uuid);
 
-        // If the type is Tanzu we don't want to include other k8s configs and vice versa.
+        // If the type has a dedicated tab, we don't want to include
+        // other k8s configs and vice versa.
+        let dedicatedK8sTabs = ['tanzu', 'openshift']
         if (
           !isDefinedNotNull(providerData) ||
-          (type === 'tanzu' && providerData.config['KUBECONFIG_PROVIDER'] !== type) ||
-          (type === 'k8s' && providerData.config['KUBECONFIG_PROVIDER'] === 'tanzu')
+          (dedicatedK8sTabs.includes(type) && providerData.config['KUBECONFIG_PROVIDER'] !== type) ||
+          (type === 'k8s' && dedicatedK8sTabs.includes(providerData.config['KUBECONFIG_PROVIDER']))
         ) {
           return null;
         }

--- a/managed/ui/src/config.js
+++ b/managed/ui/src/config.js
@@ -56,6 +56,7 @@ export const KUBERNETES_PROVIDERS = [
   // keep deprecated PKS to properly show existing PKS providers in the list, if any
   { code: "pks", name: "Pivotal Container Service" },
   { code: "tanzu", name: "VMware Tanzu" },
+  { code: "openshift", name: "Red Hat OpenShift" },
   { code: "gke", name: "Google Container Engine" },
   { code: "aks", name: "Azure Container Service" },
   { code: "eks", name: "Elastic Container Service" },


### PR DESCRIPTION
This enables the Red Hat OpenShift tab in the Configs section. The
image registry for this provider is set to
registry.connect.redhat.com/yugabytedb/yugabyte.

**_Marking the provider as alpha._**
This is how it looks without any provider:
![image](https://user-images.githubusercontent.com/5154532/109113345-1eabad80-7762-11eb-8bbb-458b1be6f421.png)

With one provider:
![image](https://user-images.githubusercontent.com/5154532/109113268-ff148500-7761-11eb-9b1a-1f35bd912616.png)


Fixes #7228, fixes #7225

Scenarios tested:
- Created OpenShift, Tanzu, Kubernetes providers as follows
  - Without specifying any registry.
  - With a custom container registry.
- All these providers had correct default registries.
- These 6 providers were listed correctly under their own tabs.