### PR TITLE
[#7392][Platform] Fix the cqlsh healthcheck failures happening because of warnings in the output

### DIFF
--- a/managed/devops/bin/cluster_health.py
+++ b/managed/devops/bin/cluster_health.py
@@ -441,7 +441,7 @@ class NodeChecker():
 
         errors = []
         output = self._remote_check_output(remote_cmd).strip()
-        if not ('You are connected to database "{}"'.format(user) in output or
+        if not (output.startswith('You are connected to database "{}"'.format(user)) or
                 "Password for user {}:".format(user) in output):
             errors = [output]
         return e.fill_and_return_entry(errors, len(errors) > 0)

--- a/managed/devops/bin/cluster_health.py
+++ b/managed/devops/bin/cluster_health.py
@@ -405,8 +405,8 @@ class NodeChecker():
         output = self._remote_check_output(remote_cmd).strip()
 
         errors = []
-        if not (output.startswith('Connected to local cluster at {}:{}'
-                                  .format(self.node, self.ycql_port)) or
+        if not ('Connected to local cluster at {}:{}'
+                                .format(self.node, self.ycql_port) in output or
                 "AuthenticationFailed('Remote end requires authentication.'" in output):
             errors = [output]
         return e.fill_and_return_entry(errors, len(errors) > 0)
@@ -432,17 +432,17 @@ class NodeChecker():
         ysqlsh = '{}/bin/ysqlsh'.format(YB_TSERVER_DIR)
         if not self.enable_tls_client:
             user = "postgres"
-            remote_cmd = r'echo "\conninfo" | {} -h {} -p {} -U {}'.format(
+            remote_cmd = "{} -h {} -p {} -U {} -c \"\conninfo\"".format(
                 ysqlsh, self.node, self.ysql_port, user)
         else:
             user = "yugabyte"
-            remote_cmd = r'echo "\conninfo" | {} -h {} -p {} -U {} {}'.format(
+            remote_cmd = "{} -h {} -p {} -U {} {} -c \"\conninfo\"".format(
                 ysqlsh, self.node, self.ysql_port, user, '"sslmode=require"')
 
         errors = []
         output = self._remote_check_output(remote_cmd).strip()
-        if not (output.startswith('You are connected to database "{}"'.format(user)) or
-                "Password for user {}:".format(user)):
+        if not ('You are connected to database "{}"'.format(user) in output or
+                "Password for user {}:".format(user) in output):
             errors = [output]
         return e.fill_and_return_entry(errors, len(errors) > 0)
 


### PR DESCRIPTION
### Summary

- Previously the health-check verify the status using starting characters of output, but now it checks for the successful status string in the output of the command.

**Explaination**
In OpenShift, `ycqlsh` gives a warning `Cannot create directory at `/.cassandra`. Command history will not be saved` (https://github.com/yugabyte/yugabyte-db/issues/6522). The health check verifies the output using Python's `startswith` & expects the string `Connected to local cluster at …`, but in reality, we get a warning & then successful status message like shown below. As a result, it fails the health check.

```
Warning: Cannot create directory at `/.cassandra`. Command history will not be saved.

Connected to local cluster at yb-tserver-0.yb-tservers.yb-us-east4-a.svc:9042.
```

### Test Plan

- Able to get health related data in health tab of YW UI.
- Can see the data on health check card of YW UI's overview tab.

fixes: https://github.com/yugabyte/yugabyte-db/issues/7392