### PR TITLE
[#7448 ][docs] Additional step for macOS Catalina to ensure "npm ci" does not fail

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,13 @@ Follow these steps if this is the first time you are setting up to work on the d
 >
 > Only now do `git` commands start to work normally. Now, too (but not before) `npm ci` works properly.
 
+Note:
+For Catalina, an additional step maybe necessary to make sure xcode-select is pointing to the Xcode Developer directory using a command like this:
+
+```
+xcode-select -s /Applications/Xcode.app/Contents/Developer
+```
+
 Then:
 
 Fork the yugabyte-db GitHub repository and create a local clone of your fork with a command like this:

--- a/docs/README.md
+++ b/docs/README.md
@@ -75,10 +75,10 @@ Follow these steps if this is the first time you are setting up to work on the d
 > Only now do `git` commands start to work normally. Now, too (but not before) `npm ci` works properly.
 
 Note:
-For Catalina, an additional step maybe necessary to make sure xcode-select is pointing to the Xcode Developer directory using a command like this:
+In some cases, an additional step may be necessary to make sure `xcode-select` is pointing to the correct Xcode or Command-Line Tools installation. For example:
 
-```
-xcode-select -s /Applications/Xcode.app/Contents/Developer
+```sh
+sudo xcode-select --switch /Applications/Xcode.app
 ```
 
 Then:


### PR DESCRIPTION
resolves #7448 
This PR includes a command to ensure "xcode-select" is pointing to the right directory for Catalina.