### PR TITLE
[docs] stop redirecting /images

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -22,6 +22,13 @@
 #
 # validator: https://play.netlify.com/redirects
 
+# Make sure we're not redirecting anything under /images
+
+[[redirects]]
+  from = "/images/*"
+  to = "/images/:splat"
+  status = 200
+
 # Legal, FAQ, and release notes should always point to the latest,
 # even if we have content in the older version's folder.
 


### PR DESCRIPTION
Yes, it's technically a no-op, butit works to catch the images the `/:version` redirects are breaking!

(Netlify redirects are first-match-wins, so this stops the problem of the broken images on /latest/releases/releases-overview/ as well as others.)

<img width="278" alt="image" src="https://user-images.githubusercontent.com/538384/110050953-c8aeab00-7d09-11eb-8d54-3dce3b2e52c2.png">
