### PR TITLE
[#7472] Platform: Hide upgrade action on Pause Universe

### DIFF
--- a/managed/ui/src/components/universes/UniverseOverview/UniverseOverviewNew.js
+++ b/managed/ui/src/components/universes/UniverseOverview/UniverseOverviewNew.js
@@ -698,15 +698,20 @@ export default class UniverseOverviewNew extends Component {
 
   getDatabaseWidget = (universeInfo, tasks) => {
     const lastUpdateDate = this.getLastUpdateDate();
-    const { updateAvailable, currentCustomer } = this.props;
+    const {
+      universe: { currentUniverse },
+      updateAvailable, 
+      currentCustomer
+    } = this.props;
     const showUpdate =
       updateAvailable && !isDisabled(currentCustomer.data.features, 'universes.actions');
+    const universePaused = currentUniverse?.data?.universeDetails?.universePaused;
 
     const infoWidget = (
       <YBWidget
         headerLeft={'Info'}
         headerRight={
-          showUpdate ? (
+          showUpdate && !universePaused ? (
             <a onClick={(e) => {
               this.props.showSoftwareUpgradesModal(e);
               e.preventDefault();


### PR DESCRIPTION
When the new upgrade is available then for Pause universe the upgrade button is available which is not supposed to be the case.
If Universe is in a Pause state then no action supposed to be available apart from the Resume and Delete universe.