### PR TITLE
[Platform] Mark the OpenShift provider tab as beta

### DIFF
--- a/managed/ui/src/components/config/ConfigProvider/providerConfig.scss
+++ b/managed/ui/src/components/config/ConfigProvider/providerConfig.scss
@@ -396,10 +396,6 @@
   font-size: 10px;
 }
 
-#cloud-config-tab-panel-tab-openshift:before {
-  content: 'ALPHA';
-}
-
 .action-bar {
   display: flex;
   justify-content: flex-end;


### PR DESCRIPTION
Scenarios tested:
- The UI shows the tab as beta instead of alpha.

![image](https://user-images.githubusercontent.com/5154532/110119741-39c19180-7de2-11eb-866b-0dc66aa2846e.png)
