### PR TITLE
[#6889]Platform: Email alerts formatting and missing details

### DIFF
--- a/managed/src/main/java/com/yugabyte/yw/commissioner/HealthChecker.java
+++ b/managed/src/main/java/com/yugabyte/yw/commissioner/HealthChecker.java
@@ -211,7 +211,7 @@ public class HealthChecker {
       SmtpData smtpData = emailHelper.getSmtpData(c.uuid);
       if (!StringUtils.isEmpty(emailDestinations) && (smtpData != null)
           && (sendMailAlways || hasErrors)) {
-        String subject = String.format("%s - <%s> %s", hasErrors ? "ERROR" : "OK", c.getTag(),
+        String subject = String.format("%s %s - <%s> %s", "Yugabyte Platform Alert " , hasErrors ? "ERROR" : "OK", c.getTag(),
             u.name);
         String mailError = sendEmailReport(u, c, smtpData, emailDestinations, subject, healthJSON,
             reportOnlyErrors);

--- a/managed/src/main/java/com/yugabyte/yw/common/AlertManager.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/AlertManager.java
@@ -15,6 +15,8 @@ import com.yugabyte.yw.models.*;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.mail.MessagingException;
@@ -29,6 +31,9 @@ public class AlertManager {
   private EmailHelper emailHelper;
 
   public static final Logger LOG = LoggerFactory.getLogger(AlertManager.class);
+  // @formatter:off
+  private static final String STYLE_FONT =
+    "font-family: SF Pro Display, SF Pro, Helvetica Neue, Helvetica, sans-serif;";
 
   /**
    * Sends email notification with information about the alert. Doesn't send email
@@ -63,18 +68,19 @@ public class AlertManager {
       return;
     }
 
-    String subject = String.format("Yugabyte Platform Alert - <%s>", customer.getTag());
     AlertDefinition definition = alert.definitionUUID == null ? null
         : AlertDefinition.get(alert.definitionUUID);
     String content;
+    Universe universe;
+    String subject;
     if (definition != null) {
       // The universe should exist (otherwise the definition should not exist as
       // well).
-      Universe universe = Universe.get(definition.universeUUID);
+      universe = Universe.get(definition.universeUUID);
       content = String.format("%s for %s is %s.", definition.name /* alert_name */, universe.name,
           state);
     } else {
-      Universe universe = alert.targetType == Alert.TargetType.UniverseType
+      universe = alert.targetType == Alert.TargetType.UniverseType
           ? Universe.find.byId(alert.targetUUID)
           : null;
       if (universe != null) {
@@ -87,10 +93,41 @@ public class AlertManager {
             customer.name, state, alert.message);
       }
     }
+    subject = String.format("Yugabyte Platform Alert ERROR- <%s> %s", customer.getTag(),
+      universe.name);
+    String style = String
+      .format("%s font-size: 14px;background-color:#f7f7f7;padding:25px 30px 5px;", STYLE_FONT);
+    String hostname = "";
+    String ip = "";
+    try {
+      hostname = InetAddress.getLocalHost().getHostName();
+      ip = InetAddress.getLocalHost().getHostAddress().toString();
+    } catch (UnknownHostException e) {
+      LOG.error("Could not determine the hostname", e);
+    }
+
+    String header = String.format(
+      "<table width=\"100%%\">\n" +
+        "    <tr>\n" +
+        "        <td style=\"text-align:left\">%s</td>\n" +
+        "        <td style=\"text-align:left\">%s</td>\n" +
+        "    </tr>\n" +
+        "    <tr>\n" +
+        "        <td style=\"text-align:left\">%s</td>\n" +
+        "        <td style=\"text-align:left\">%s</td>\n" +
+        "    </tr>\n" +
+        "</table>\n",
+      makeHeaderLeft("Universe name", universe.name),
+      makeHeaderLeft("Universe version", (universe.version+"")),
+      makeHeaderLeft("YW host name", hostname),
+      makeHeaderLeft("YW host IP", ip));
+
+    content = String.format("<html><body><pre style=\"%s\">%s\n%s</pre></body></html>", style,
+      header, content.toString());
 
     try {
       emailHelper.sendEmail(customer, subject, String.join(",", destinations), smtpData,
-          Collections.singletonMap("text/plain; charset=\"us-ascii\"", content));
+          Collections.singletonMap("text/html; charset=\"us-ascii\"", content));
     } catch (MessagingException e) {
       LOG.error("Error sending email for alert {} in state '{}'", alert.uuid, state, e);
     }
@@ -127,5 +164,16 @@ public class AlertManager {
     }
 
     return alert;
+  }
+
+  private static String makeHeaderLeft(String title, String content) {
+    return String.format(
+      "%s<h1 style=\"%sline-height:1em;color:#202951;font-weight:700;font-size:1.85em;\n" +
+        "padding-bottom:15px;margin:0;\">%s</h1>",
+      makeSubtitle(title), STYLE_FONT, content);
+  }
+
+  private static String makeSubtitle(String content) {
+    return String.format("<span style=\"color:#8D8F9D;font-weight:400;\">%s:</span>\n", content);
   }
 }


### PR DESCRIPTION
**Heading:**
[#6889]Platform: Email alerts formatting and missing details
Description:
We need to ensure email alert formatting should be same for all the
alerts. Mail subject and body should be in the same format
Each email should include yugaware hostname and port

Testing:
 1. Check whether each email alerts are in the same format or not
     a. Back up failure email alert
     b. Health check email alert
     c. Alert report with various checks for different nodes

TODO: Unable to test backup email alert - not getting email looking into
this, once testing is done, will Add UTs - This is not final PR