### PR TITLE
[#7603] rocksdb: Calling memset on atomic variable generates warning

### DIFF
--- a/src/yb/rocksdb/util/histogram.cc
+++ b/src/yb/rocksdb/util/histogram.cc
@@ -96,7 +96,9 @@ void HistogramImpl::Clear() {
   num_ = 0;
   sum_ = 0;
   sum_squares_ = 0;
-  memset(buckets_, 0, sizeof buckets_);
+  for (int i = 0; i < kHistogramNumBuckets; ++i) {
+    set_bucket(i, 0);
+  }
 }
 
 bool HistogramImpl::Empty() { return num_ == 0; }


### PR DESCRIPTION
Summary:
rocksdb::HistogramImpl::Clear() does a memset() on
HistogramImpl::buckets_, which is std::atomic<uint64_t>, generates the
following warning,

‘void* memset(void*, int, size_t)’ clearing an object of type ‘struct std::atomic<long unsigned int>’,
 with no trivial copy-assignment; use value-initialization instead [-Werror=class-memaccess]

Make use of the set_bucket() to set all values to zero.

Test Plan:
`ybd --cxx-test rocksdb_histogram_test`

Reviewers:

Reviewed By: