### PR TITLE
[Docs] change default: ysql_disable_index_backfill

### DIFF
--- a/docs/content/latest/reference/configuration/yb-tserver.md
+++ b/docs/content/latest/reference/configuration/yb-tserver.md
@@ -515,7 +515,7 @@ Set this flag to `false` to enable online index backfill. When set to `false`, o
 
 For details on how online index backfill works, see the [Online Index Backfill](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/online-index-backfill.md) design document.
 
-Default: `true`
+Default: `false`
 
 ##### --ysql_sequence_cache_minval
 

--- a/docs/content/stable/reference/configuration/yb-tserver.md
+++ b/docs/content/stable/reference/configuration/yb-tserver.md
@@ -508,7 +508,7 @@ Set this flag to `false` to enable online index backfill. When set to `false`, o
 
 For details on how online index backfill works, see the [Online Index Backfill](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/online-index-backfill.md) design document.
 
-Default: `true`
+Default: `false`
 
 ##### --ysql_sequence_cache_minval
 


### PR DESCRIPTION
The default value for `ysql_disable_index_backfill` changed in YB 2.4 from `true` to `false`. Updating the docs to match.