### PR TITLE
[docs] Correct prometheus port from 93000 to 9300

### DIFF
--- a/docs/content/latest/reference/configuration/default-ports.md
+++ b/docs/content/latest/reference/configuration/default-ports.md
@@ -64,7 +64,7 @@ YugabyteDB servers expose time-series performance metrics in the [Prometheus exp
 <target>/prometheus-metrics
 ```
 
-You can access the Prometheus server on port `9090` of the Platform node, and you can see the list of targets at the `http://<yugaware-ip>:9090/targets`. In particular, note port `93000` for node level metrics.
+You can access the Prometheus server on port `9090` of the Platform node, and you can see the list of targets at the `http://<yugaware-ip>:9090/targets`. In particular, note port `9300` for node level metrics.
 
 ### Servers
 

--- a/docs/content/latest/reference/configuration/default-ports.md
+++ b/docs/content/latest/reference/configuration/default-ports.md
@@ -46,6 +46,7 @@ Admin web server UI can be viewed at these addresses.
 | yb-tserver | 9000  |  [`--webserver_interface 0.0.0.0`](../yb-master/#webserver-interface)<br>[`--webserver_port 9000`](../yb-master/#webserver-port) |
 
 ## Firewall Rules
+
 Along with the above, include the following common ports in firewall rules. 
 
 | Service     | Port
@@ -84,6 +85,5 @@ Use the following `yb-tserver` targets for the various API metrics.
 | ysql    | `<yb-tserver-address>:13000` |
 | ycql    | `<yb-tserver-address>:12000` |
 | yedis   | `<yb-tserver-address>:11000` |
-
 
 For a quick tutorial on using Prometheus with YugabyteDB, see [Observability with Prometheus](../../../explore/observability).

--- a/docs/content/stable/reference/configuration/default-ports.md
+++ b/docs/content/stable/reference/configuration/default-ports.md
@@ -44,6 +44,7 @@ Admin web server UI can be viewed at these addresses.
 | yb-tserver | 9000  |  [`--webserver_interface 0.0.0.0`](../yb-master/#webserver-interface)<br>[`--webserver_port 9000`](../yb-master/#webserver-port) |
 
 ## Firewall Rules
+
 Along with the above, include the following common ports in firewall rules. 
 
 | Service     | Port
@@ -66,7 +67,6 @@ You can access the Prometheus server on port `9090` of the Platform node, and yo
 
 For a quick tutorial on using Prometheus with YugabyteDB, see [Observability with Prometheus](../../../explore/observability).
 
-
 ### Servers
 
 Use the following targets to monitor `yb-tserver` and `yb-master` server metrics.
@@ -85,4 +85,3 @@ Use the following `yb-tserver` targets for the various API metrics.
 | ysql    | `<yb-tserver-address>:13000` |
 | ycql    | `<yb-tserver-address>:12000` |
 | yedis   | `<yb-tserver-address>:11000` |
-

--- a/docs/content/stable/reference/configuration/default-ports.md
+++ b/docs/content/stable/reference/configuration/default-ports.md
@@ -62,7 +62,7 @@ Use the following targets to configure [Prometheus](https://prometheus.io/) to s
 <target>/prometheus-metrics
 ```
 
-You can access the Prometheus server on port `9090` of the Platform node, and you can see the list of targets at the `http://<yugaware-ip>:9090/targets`. In particular, note port `93000` for node level metrics.
+You can access the Prometheus server on port `9090` of the Platform node, and you can see the list of targets at the `http://<yugaware-ip>:9090/targets`. In particular, note port `9300` for node level metrics.
 
 For a quick tutorial on using Prometheus with YugabyteDB, see [Observability with Prometheus](../../../explore/observability).
 

--- a/docs/content/v2.0/reference/configuration/default-ports.md
+++ b/docs/content/v2.0/reference/configuration/default-ports.md
@@ -31,7 +31,7 @@ Use the following targets to configure [Prometheus](https://prometheus.io/) to s
 <target>/prometheus-metrics
 ```
 
-You can access the Prometheus server on port `9090` of the Platform node, and you can see the list of targets at the `http://<yugaware-ip>:9090/targets`. In particular, note port `93000` for node level metrics.
+You can access the Prometheus server on port `9090` of the Platform node, and you can see the list of targets at the `http://<yugaware-ip>:9090/targets`. In particular, note port `9300` for node level metrics.
 
 For a quick tutorial on using Prometheus with YugabyteDB, see [Observability with Prometheus](../../../explore/observability).
 

--- a/docs/content/v2.0/reference/configuration/default-ports.md
+++ b/docs/content/v2.0/reference/configuration/default-ports.md
@@ -73,6 +73,7 @@ Admin web server UI can be viewed at these addresses.
 | yb-tserver | 9000  |  [`--webserver_interface 0.0.0.0`](../yb-master/#webserver-interface)<br >[`--webserver_port 9000`](../yb-master/#webserver-port) |
 
 ### Firewall Rules
+
 Along with the above, include the following common ports in firewall rules. 
 
 | Service     | Port

--- a/docs/content/v2.1/reference/configuration/default-ports.md
+++ b/docs/content/v2.1/reference/configuration/default-ports.md
@@ -45,6 +45,7 @@ Admin web server UI can be viewed at these addresses.
 | yb-tserver | 9000  |  [`--webserver_interface 0.0.0.0`](../yb-master/#webserver-interface)<br>[`--webserver_port 9000`](../yb-master/#webserver-port) |
 
 ## Firewall Rules
+
 Along with the above, include the following common ports in firewall rules. 
 
 | Service     | Port
@@ -67,7 +68,6 @@ You can access the Prometheus server on port `9090` of the Platform node, and yo
 
 For a quick tutorial on using Prometheus with YugabyteDB, see [Observability with Prometheus](../../../explore/observability).
 
-
 ### Servers
 
 Use the following targets to monitor `yb-tserver` and `yb-master` server metrics.
@@ -86,4 +86,3 @@ Use the following `yb-tserver` targets for the various API metrics.
 | ysql    | `<yb-tserver-address>:13000` |
 | ycql    | `<yb-tserver-address>:12000` |
 | yedis   | `<yb-tserver-address>:11000` |
-

--- a/docs/content/v2.1/reference/configuration/default-ports.md
+++ b/docs/content/v2.1/reference/configuration/default-ports.md
@@ -63,7 +63,7 @@ Use the following targets to configure [Prometheus](https://prometheus.io/) to s
 <target>/prometheus-metrics
 ```
 
-You can access the Prometheus server on port `9090` of the Platform node, and you can see the list of targets at the `http://<yugaware-ip>:9090/targets`. In particular, note port `93000` for node level metrics.
+You can access the Prometheus server on port `9090` of the Platform node, and you can see the list of targets at the `http://<yugaware-ip>:9090/targets`. In particular, note port `9300` for node level metrics.
 
 For a quick tutorial on using Prometheus with YugabyteDB, see [Observability with Prometheus](../../../explore/observability).
 

--- a/docs/content/v2.2/reference/configuration/default-ports.md
+++ b/docs/content/v2.2/reference/configuration/default-ports.md
@@ -52,7 +52,7 @@ YugabyteDB servers expose time-series performance metrics in the [Prometheus exp
 <target>/prometheus-metrics
 ```
 
-Following is the list of targets available.
+You can access the Prometheus server on port `9090` of the Platform node, and you can see the list of targets at the `http://<yugaware-ip>:9090/targets`. In particular, note port `9300` for node level metrics.
 
 ### Servers
 


### PR DESCRIPTION
Commit 2cc084f introduced some extra ports, and the 93000 had a extra zero on it. This corrects that.