### PR TITLE
[#6460]Platform: Follow up change to fix blocker issue which was caused by https://github.com/yugabyte/yugabyte-db/pull/6948)

### DIFF
--- a/managed/src/main/java/com/yugabyte/yw/controllers/CloudProviderController.java
+++ b/managed/src/main/java/com/yugabyte/yw/controllers/CloudProviderController.java
@@ -202,7 +202,6 @@ public class CloudProviderController extends AuthenticatedController {
               provider.delete();
               return ApiResponse.error(BAD_REQUEST, "Invalid AWS Credentials.");
             }
-            String hostedZoneId = provider.getAwsHostedZoneId();
             if (hostedZoneId != null) {
               return validateHostedZoneUpdate(provider, hostedZoneId);
             }

--- a/managed/src/test/java/com/yugabyte/yw/controllers/CloudProviderControllerTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/controllers/CloudProviderControllerTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
 import static play.test.Helpers.contentAsString;
 
 import java.io.File;


### PR DESCRIPTION
Heading:
[#6460]Platform: Follow up change to fix blocker issue which was caused by https://github.com/yugabyte/yugabyte-db/pull/6948)
Description:
**mock** import was missing in the test file and same variable was declared twice in the file which lead to compile error during sbt  run.

RCA: This might be introduced when tried to resolve merge conflict on the github.
**Testing:**

**All the  sbt tests are getting passed except these two:**
Test com.yugabyte.yw.controllers.ApiDiscoveryControllerTest.testApiIndexWithAuthBadRoute failed: java.lang.AssertionError: expected:<404> but was:<200>,
error] Test com.yugabyte.yw.ConfigTest.singleKey(application.test.conf, test.expected.conf, envTest) [4] failed: junit.framework.AssertionFailedError: 

**sbt test o/p:**
[info] Test com.yugabyte.yw.commissioner.TaskGarbageCollectorTest.testPurge_invalidData started
[info] Test run finished: 0 failed, 0 ignored, 7 total, 0.184s
[error] Failed: Total 1248, Failed 2, Errors 0, Passed 1242, Skipped 4
[error] Failed tests:
[error] 	com.yugabyte.yw.controllers.ApiDiscoveryControllerTest
[error] 	com.yugabyte.yw.ConfigTest
[error] (test:test) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 2668 s, completed 15 Mar, 2021 1:34:42 PM

