### PR TITLE
[#7486][docs]  Commands to fix the YSQL and YCQL pages for Asynchronous replication.

### DIFF
--- a/docs/content/latest/explore/multi-region-deployments/asynchronous-replication-ycql.md
+++ b/docs/content/latest/explore/multi-region-deployments/asynchronous-replication-ycql.md
@@ -95,13 +95,30 @@ Waiting for cluster to be ready.
 
 In the default `yugabyte` database, create the database table `users` on the "Data Center - East" cluster.
 
-Open `ysqlsh` specifying the host IP address of `127.0.0.1`.
+Open `ycqlsh` specifying the host IP address of `127.0.0.1`.
 
 ```sh
-$ ./bin/ysqlsh -h 127.0.0.1
+$ ./bin/ycqlsh -h 127.0.0.1
+```
+Create a keyspace by running the following statement.
+
+```sql
+ycqlsh> CREATE KEYSPACE example;
+```
+
+```sql
+ycqlsh> USE example;
 ```
 
 Run the following `CREATE TABLE` statement.
+
+``` sql
+ycqlsh:example> CREATE TABLE users (
+                    email varchar(35) PRIMARY KEY,
+                    username varchar(20)
+                    );
+
+```
 
 ```plpgsql
 CREATE TABLE users (
@@ -112,10 +129,10 @@ CREATE TABLE users (
 
 Now create the identical database table on cluster B.
 
-Open `ysqlsh` for "Data Center - West" by specifying the host IP address of `127.0.0.2`.
+Open `ycqlsh` for "Data Center - West" by specifying the host IP address of `127.0.0.2`.
 
 ```sh
-$ ./bin/ysqlsh -h 127.0.0.2
+$ ./bin/ycqlsh -h 127.0.0.2
 ```
 
 Run the following `CREATE TABLE` statement.
@@ -164,20 +181,20 @@ Replication setup successfully
 
 Now that you've configured unidirectional replication, you can now add data to the `users` table on the "Data Center - East" cluster and see the data appear in the `users` table on "Data Center - West" cluster.
 
-To add data to the "Data Center - East" cluster, open `ysqlsh` by running the following command, making sure you are pointing to the new producer host.
+To add data to the "Data Center - East" cluster, open `ycqlsh` by running the following command, making sure you are pointing to the new producer host.
 
 ```sh
-$ ./bin/ysqlsh -host 127.0.0.1
+$ ./bin/ycqlsh -host 127.0.0.1
 ```
 
 ```plpgsql
 yugabyte=# INSERT INTO users(email, username) VALUES ('hector@example.com', 'hector'), ('steve@example.com', 'steve');
 ```
 
-On the consumer "Data Center - West" cluster, open `ysqlsh` and run the following to quickly see that data has been replicated between clusters.
+On the consumer "Data Center - West" cluster, open `ycqlsh` and run the following to quickly see that data has been replicated between clusters.
 
 ```sh
-$ ./bin/ysqlsh -host 127.0.0.2
+$ ./bin/ycqlsh -host 127.0.0.2
 ```
 
 ```plpgsql
@@ -220,20 +237,20 @@ Replication setup successfully
 
 Now that you've configured bidirectional replication, you can now add data to the `users` table on the "Data Center - West" cluster and see the data appear in the `users` table on "Data Center - East" cluster.
 
-To add data to the "Data Center - West" cluster, open`ysqlsh` by running the following command, making sure you are pointing to the new producer host.
+To add data to the "Data Center - West" cluster, open`ycqlsh` by running the following command, making sure you are pointing to the new producer host.
 
 ```sh
-$ ./bin/ysqlsh -host 127.0.0.2
+$ ./bin/ycqlsh -host 127.0.0.2
 ```
 
 ```plpgsql
 yugabyte=# INSERT INTO users(email, username) VALUES ('neha@example.com', 'neha'), ('mikhail@example.com', 'mikhail');
 ```
 
-On the new "consumer" cluster, open `ysqlsh` and run the following to quickly see that data has been replicated between clusters.
+On the new "consumer" cluster, open `ycqlsh` and run the following to quickly see that data has been replicated between clusters.
 
 ```sh
-$ ./bin/ysqlsh -host 127.0.0.1
+$ ./bin/ycqlsh -host 127.0.0.1
 ```
 
 ```plpgsql

--- a/docs/content/latest/explore/multi-region-deployments/asynchronous-replication-ycql.md
+++ b/docs/content/latest/explore/multi-region-deployments/asynchronous-replication-ycql.md
@@ -114,7 +114,6 @@ Run the following `CREATE TABLE` statement.
 
 ``` sql
 CREATE TABLE users ( email varchar PRIMARY KEY, username varchar );
-
 ```
 
 Now create the identical database table on the second cluster.

--- a/docs/content/latest/explore/multi-region-deployments/asynchronous-replication-ycql.md
+++ b/docs/content/latest/explore/multi-region-deployments/asynchronous-replication-ycql.md
@@ -117,7 +117,7 @@ CREATE TABLE users ( email varchar PRIMARY KEY, username varchar );
 
 ```
 
-Now create the identical database table on cluster B.
+Now create the identical database table on the second cluster.
 
 Open `ycqlsh` for "Data Center - West" by specifying the host IP address of `127.0.0.2`.
 
@@ -135,7 +135,7 @@ ycqlsh> USE customers;
 ```
 Run the following `CREATE TABLE` statement.
 
-```plpgsql
+```sql
 CREATE TABLE users ( email varchar PRIMARY KEY, username varchar );
 ```
 
@@ -182,7 +182,7 @@ To add data to the "Data Center - East" cluster, open `ycqlsh` by running the fo
 $ ./bin/ycqlsh 127.0.0.1
 ```
 
-```plpgsql
+```sql
 ycqlsh:customers> INSERT INTO users(email, username) VALUES ('hector@example.com', 'hector');
 ycqlsh:customers> INSERT INTO users(email, username) VALUES ('steve@example.com', 'steve');
 ```
@@ -193,7 +193,7 @@ On the consumer "Data Center - West" cluster, open `ycqlsh` and run the followin
 $ ./bin/ycqlsh 127.0.0.2
 ```
 
-```plpgsql
+```sql
 yugabyte=# SELECT * FROM users;
 ```
 

--- a/docs/content/latest/explore/multi-region-deployments/asynchronous-replication-ycql.md
+++ b/docs/content/latest/explore/multi-region-deployments/asynchronous-replication-ycql.md
@@ -98,33 +98,23 @@ In the default `yugabyte` database, create the database table `users` on the "Da
 Open `ycqlsh` specifying the host IP address of `127.0.0.1`.
 
 ```sh
-$ ./bin/ycqlsh -h 127.0.0.1
+$ ./bin/ycqlsh 127.0.0.1
 ```
 Create a keyspace by running the following statement.
 
 ```sql
-ycqlsh> CREATE KEYSPACE example;
+ycqlsh> CREATE KEYSPACE customers;
 ```
 
 ```sql
-ycqlsh> USE example;
+ycqlsh> USE customers;
 ```
 
 Run the following `CREATE TABLE` statement.
 
 ``` sql
-ycqlsh:example> CREATE TABLE users (
-                    email varchar(35) PRIMARY KEY,
-                    username varchar(20)
-                    );
+CREATE TABLE users ( email varchar PRIMARY KEY, username varchar );
 
-```
-
-```plpgsql
-CREATE TABLE users (
-    email varchar(35) PRIMARY KEY,
-    username varchar(20)
-    );
 ```
 
 Now create the identical database table on cluster B.
@@ -132,16 +122,21 @@ Now create the identical database table on cluster B.
 Open `ycqlsh` for "Data Center - West" by specifying the host IP address of `127.0.0.2`.
 
 ```sh
-$ ./bin/ycqlsh -h 127.0.0.2
+$ ./bin/ycqlsh 127.0.0.2
+```
+Create a keyspace by running the following statement.
+
+```sql
+ycqlsh> CREATE KEYSPACE customers;
 ```
 
+```sql
+ycqlsh> USE customers;
+```
 Run the following `CREATE TABLE` statement.
 
 ```plpgsql
-CREATE TABLE users (
-    email varchar(35) PRIMARY KEY,
-    username varchar(20)
-    );
+CREATE TABLE users ( email varchar PRIMARY KEY, username varchar );
 ```
 
 You now have the identical database table on each of your clusters and can now set up 2DC asynchronous replication.
@@ -184,17 +179,18 @@ Now that you've configured unidirectional replication, you can now add data to t
 To add data to the "Data Center - East" cluster, open `ycqlsh` by running the following command, making sure you are pointing to the new producer host.
 
 ```sh
-$ ./bin/ycqlsh -host 127.0.0.1
+$ ./bin/ycqlsh 127.0.0.1
 ```
 
 ```plpgsql
-yugabyte=# INSERT INTO users(email, username) VALUES ('hector@example.com', 'hector'), ('steve@example.com', 'steve');
+ycqlsh:customers> INSERT INTO users(email, username) VALUES ('hector@example.com', 'hector');
+ycqlsh:customers> INSERT INTO users(email, username) VALUES ('steve@example.com', 'steve');
 ```
 
 On the consumer "Data Center - West" cluster, open `ycqlsh` and run the following to quickly see that data has been replicated between clusters.
 
 ```sh
-$ ./bin/ycqlsh -host 127.0.0.2
+$ ./bin/ycqlsh 127.0.0.2
 ```
 
 ```plpgsql
@@ -240,17 +236,18 @@ Now that you've configured bidirectional replication, you can now add data to th
 To add data to the "Data Center - West" cluster, open`ycqlsh` by running the following command, making sure you are pointing to the new producer host.
 
 ```sh
-$ ./bin/ycqlsh -host 127.0.0.2
+$ ./bin/ycqlsh 127.0.0.2
 ```
 
 ```plpgsql
-yugabyte=# INSERT INTO users(email, username) VALUES ('neha@example.com', 'neha'), ('mikhail@example.com', 'mikhail');
+ycqlsh:customers> INSERT INTO users(email, username) VALUES ('neha@example.com', 'neha');
+ycqlsh:customers> INSERT INTO users(email, username) VALUES ('mikhail@example.com', 'mikhail');
 ```
 
 On the new "consumer" cluster, open `ycqlsh` and run the following to quickly see that data has been replicated between clusters.
 
 ```sh
-$ ./bin/ycqlsh -host 127.0.0.1
+$ ./bin/ycqlsh 127.0.0.1
 ```
 
 ```plpgsql

--- a/docs/content/latest/explore/multi-region-deployments/asynchronous-replication-ycql.md
+++ b/docs/content/latest/explore/multi-region-deployments/asynchronous-replication-ycql.md
@@ -250,8 +250,8 @@ On the new "consumer" cluster, open `ycqlsh` and run the following to quickly se
 $ ./bin/ycqlsh 127.0.0.1
 ```
 
-```plpgsql
-yugabyte=# SELECT * FROM users;
+```sql
+ycqlsh:customers> SELECT * FROM users;
 ```
 
 You should see the following in the results.

--- a/docs/content/latest/explore/multi-region-deployments/asynchronous-replication-ycql.md
+++ b/docs/content/latest/explore/multi-region-deployments/asynchronous-replication-ycql.md
@@ -194,7 +194,7 @@ $ ./bin/ycqlsh 127.0.0.2
 ```
 
 ```sql
-ycqlsh:customers>SELECT * FROM users;
+ycqlsh:customers> SELECT * FROM users;
 ```
 
 You should see the following in the results.

--- a/docs/content/latest/explore/multi-region-deployments/asynchronous-replication-ycql.md
+++ b/docs/content/latest/explore/multi-region-deployments/asynchronous-replication-ycql.md
@@ -194,7 +194,7 @@ $ ./bin/ycqlsh 127.0.0.2
 ```
 
 ```sql
-yugabyte=# SELECT * FROM users;
+ycqlsh:customers>SELECT * FROM users;
 ```
 
 You should see the following in the results.

--- a/docs/content/latest/explore/multi-region-deployments/asynchronous-replication-ysql.md
+++ b/docs/content/latest/explore/multi-region-deployments/asynchronous-replication-ysql.md
@@ -95,10 +95,10 @@ Waiting for cluster to be ready.
 
 In the default `yugabyte` database, create the database table `users` on the "Data Center - East" cluster.
 
-Open `ycqlsh` specifying the host IP address of `127.0.0.1`.
+Open `ysqlsh` specifying the host IP address of `127.0.0.1`.
 
 ```sh
-$ ./bin/ycqlsh 127.0.0.1
+$ ./bin/ysqlsh 127.0.0.1
 ```
 
 Run the following `CREATE TABLE` statement.
@@ -112,10 +112,10 @@ CREATE TABLE users (
 
 Now create the identical database table on cluster B.
 
-Open `ycqlsh` for "Data Center - West" by specifying the host IP address of `127.0.0.2`.
+Open `ysqlsh` for "Data Center - West" by specifying the host IP address of `127.0.0.2`.
 
 ```sh
-$ ./bin/ycqlsh 127.0.0.2
+$ ./bin/ysqlsh 127.0.0.2
 ```
 
 Run the following `CREATE TABLE` statement.
@@ -167,17 +167,17 @@ Now that you've configured unidirectional replication, you can now add data to t
 To add data to the "Data Center - East" cluster, open `ycqlsh` by running the following command, making sure you are pointing to the new producer host.
 
 ```sh
-$ ./bin/ycqlsh 127.0.0.1
+$ ./bin/ysqlsh 127.0.0.1
 ```
 
 ```plpgsql
 yugabyte=# INSERT INTO users(email, username) VALUES ('hector@example.com', 'hector'), ('steve@example.com', 'steve');
 ```
 
-On the consumer "Data Center - West" cluster, open `ycqlsh` and run the following to quickly see that data has been replicated between clusters.
+On the consumer "Data Center - West" cluster, open `ysqlsh` and run the following to quickly see that data has been replicated between clusters.
 
 ```sh
-$ ./bin/ycqlsh 127.0.0.2
+$ ./bin/ysqlsh 127.0.0.2
 ```
 
 ```plpgsql
@@ -223,17 +223,17 @@ Now that you've configured bidirectional replication, you can now add data to th
 To add data to the "Data Center - West" cluster, open`ysqlsh` by running the following command, making sure you are pointing to the new producer host.
 
 ```sh
-$ ./bin/ycqlsh 127.0.0.2
+$ ./bin/ysqlsh 127.0.0.2
 ```
 
 ```plpgsql
 yugabyte=# INSERT INTO users(email, username) VALUES ('neha@example.com', 'neha'), ('mikhail@example.com', 'mikhail');
 ```
 
-On the new "consumer" cluster, open `ycqlsh` and run the following to quickly see that data has been replicated between clusters.
+On the new "consumer" cluster, open `ysqlsh` and run the following to quickly see that data has been replicated between clusters.
 
 ```sh
-$ ./bin/ycqlsh 127.0.0.1
+$ ./bin/ysqlsh 127.0.0.1
 ```
 
 ```plpgsql

--- a/docs/content/latest/explore/multi-region-deployments/asynchronous-replication-ysql.md
+++ b/docs/content/latest/explore/multi-region-deployments/asynchronous-replication-ysql.md
@@ -98,7 +98,7 @@ In the default `yugabyte` database, create the database table `users` on the "Da
 Open `ysqlsh` specifying the host IP address of `127.0.0.1`.
 
 ```sh
-$ ./bin/ysqlsh 127.0.0.1
+$ ./bin/ysqlsh -h 127.0.0.1
 ```
 
 Run the following `CREATE TABLE` statement.
@@ -115,7 +115,7 @@ Now create the identical database table on cluster B.
 Open `ysqlsh` for "Data Center - West" by specifying the host IP address of `127.0.0.2`.
 
 ```sh
-$ ./bin/ysqlsh 127.0.0.2
+$ ./bin/ysqlsh -h 127.0.0.2
 ```
 
 Run the following `CREATE TABLE` statement.
@@ -167,7 +167,7 @@ Now that you've configured unidirectional replication, you can now add data to t
 To add data to the "Data Center - East" cluster, open `ycqlsh` by running the following command, making sure you are pointing to the new producer host.
 
 ```sh
-$ ./bin/ysqlsh 127.0.0.1
+$ ./bin/ysqlsh -h 127.0.0.1
 ```
 
 ```plpgsql
@@ -177,7 +177,7 @@ yugabyte=# INSERT INTO users(email, username) VALUES ('hector@example.com', 'hec
 On the consumer "Data Center - West" cluster, open `ysqlsh` and run the following to quickly see that data has been replicated between clusters.
 
 ```sh
-$ ./bin/ysqlsh 127.0.0.2
+$ ./bin/ysqlsh -h 127.0.0.2
 ```
 
 ```plpgsql
@@ -223,7 +223,7 @@ Now that you've configured bidirectional replication, you can now add data to th
 To add data to the "Data Center - West" cluster, open`ysqlsh` by running the following command, making sure you are pointing to the new producer host.
 
 ```sh
-$ ./bin/ysqlsh 127.0.0.2
+$ ./bin/ysqlsh -h 127.0.0.2
 ```
 
 ```plpgsql
@@ -233,7 +233,7 @@ yugabyte=# INSERT INTO users(email, username) VALUES ('neha@example.com', 'neha'
 On the new "consumer" cluster, open `ysqlsh` and run the following to quickly see that data has been replicated between clusters.
 
 ```sh
-$ ./bin/ysqlsh 127.0.0.1
+$ ./bin/ysqlsh -h 127.0.0.1
 ```
 
 ```plpgsql


### PR DESCRIPTION
Resolves #7486 
This PR includes the correct commands required for Asynchronous replication in YSQL and YCQL. 
In specific, it addresses the interchanged commands for the same.

PREVIEW BUILD IS [HERE (YCQL)](https://deploy-preview-7692--infallible-bardeen-164bc9.netlify.app/latest/explore/multi-region-deployments/asynchronous-replication-ycql) and [HERE (YSQL)](https://deploy-preview-7692--infallible-bardeen-164bc9.netlify.app/latest/explore/multi-region-deployments/asynchronous-replication-ysql)