### PR TITLE
[#6447]Platform: Remove cloud accessKey after cloud provider is deleted

### DIFF
--- a/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/subtasks/cloud/CloudAccessKeySetup.java
+++ b/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/subtasks/cloud/CloudAccessKeySetup.java
@@ -54,7 +54,8 @@ public class CloudAccessKeySetup extends CloudTaskBase {
         taskParams().sshUser == null || taskParams().sshUser.isEmpty()) {
       String sanitizedProviderName = getProvider().name.replaceAll("\\s+", "-").toLowerCase();
       String accessKeyCode = String.format(
-          "yb-%s-%s-key", Customer.get(getProvider().customerUUID).code, sanitizedProviderName);
+          "yb-%s-%s_%s-key", Customer.get(getProvider().customerUUID).code, sanitizedProviderName,
+          taskParams().providerUUID);
       accessManager.addKey(
           region.uuid, accessKeyCode, null, taskParams().sshUser, sshPort, airGapInstall, false);
     } else {

--- a/managed/src/test/java/com/yugabyte/yw/commissioner/tasks/CloudBootstrapTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/commissioner/tasks/CloudBootstrapTest.java
@@ -127,7 +127,7 @@ public class CloudBootstrapTest extends CommissionerBaseTest {
             eq(taskParams.sshPort), eq(taskParams.airGapInstall), eq(false));
       } else {
         String expectedAccessKeyCode = String.format(
-            "yb-%s-%s-key", defaultCustomer.code, provider.name.toLowerCase());
+            "yb-%s-%s_%s-key", defaultCustomer.code, provider.name.toLowerCase(), taskParams.providerUUID);
         verify(mockAccessManager, times(1)).addKey(eq(r.uuid), eq(expectedAccessKeyCode),
                any(),eq(taskParams.sshUser), eq(taskParams.sshPort), eq(taskParams.airGapInstall),
                eq(false));


### PR DESCRIPTION
**Heading:[**
#6447]Platform: Remove cloud accessKey after cloud provider is deleted
**Description:**
After deleting the cloud provider we don't clean up the platform generated ssh
accessKey which can lead to universe creation failures for the new cloud provider.

**Runtime error: KeyPair already exists yb-dev-aws-cloud-key**

Now, we are making sure unique ssh key gets generated while creating the
provider
**Testing:**
1. Try to create AWS cloud provider by giving any name
2. SSH key should include providerUUID
eg:  i.e yb-admin-aws87db5f86-b61a-42a7-9eee-9d600c18bb04-key