### PR TITLE
[Docs] Fix `masterAddress` lists in example Helm overrides

### DIFF
--- a/docs/content/latest/deploy/kubernetes/multi-cluster/gke/helm-chart.md
+++ b/docs/content/latest/deploy/kubernetes/multi-cluster/gke/helm-chart.md
@@ -305,7 +305,7 @@ isMultiAz: True
 
 AZ: us-west1-b
 
-masterAddresses: "yb-master-0.yb-masters.yb-demo-us-west1-b.svc.cluster.local:7100, yb-master-0.yb-masters.yb-demo-us-central1-b.svc.cluster.local:7100, yb-master-0.yb-masters.yb-demo-us-east1-b.svc.cluster.local:7100"
+masterAddresses: "yb-master-0.yb-masters.yb-demo-us-west1-b.svc.cluster.local:7100,yb-master-0.yb-masters.yb-demo-us-central1-b.svc.cluster.local:7100,yb-master-0.yb-masters.yb-demo-us-east1-b.svc.cluster.local:7100"
 
 storage:
   master:
@@ -338,7 +338,7 @@ isMultiAz: True
 
 AZ: us-central1-b
 
-masterAddresses: "yb-master-0.yb-masters.yb-demo-us-west1-b.svc.cluster.local:7100, yb-master-0.yb-masters.yb-demo-us-central1-b.svc.cluster.local:7100, yb-master-0.yb-masters.yb-demo-us-east1-b.svc.cluster.local:7100"
+masterAddresses: "yb-master-0.yb-masters.yb-demo-us-west1-b.svc.cluster.local:7100,yb-master-0.yb-masters.yb-demo-us-central1-b.svc.cluster.local:7100,yb-master-0.yb-masters.yb-demo-us-east1-b.svc.cluster.local:7100"
 
 storage:
   master:
@@ -371,7 +371,7 @@ isMultiAz: True
 
 AZ: us-east1-b
 
-masterAddresses: "yb-master-0.yb-masters.yb-demo-us-west1-b.svc.cluster.local:7100, yb-master-0.yb-masters.yb-demo-us-central1-b.svc.cluster.local:7100, yb-master-0.yb-masters.yb-demo-us-east1-b.svc.cluster.local:7100"
+masterAddresses: "yb-master-0.yb-masters.yb-demo-us-west1-b.svc.cluster.local:7100,yb-master-0.yb-masters.yb-demo-us-central1-b.svc.cluster.local:7100,yb-master-0.yb-masters.yb-demo-us-east1-b.svc.cluster.local:7100"
 
 storage:
   master:


### PR DESCRIPTION
The extra spaces break the helm chart.