### PR TITLE
Three small bug fixes

### DIFF
--- a/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/concatenation-operator.md
+++ b/docs/content/latest/api/ysql/datatypes/type_json/functions-operators/concatenation-operator.md
@@ -55,14 +55,14 @@ end;
 $body$;
 ```
 
-If each side is an _object_, then the results is an _object_ with all the key-value pairs present:
+If each side is an _object_, and no key-value pair in the RHS _object_ has the same key as any key-value pair in the LHS  _object_ then the result is an _object_ with all of the key-value pairs present:
 
 ```plpgsql
 do $body$
 declare
   j_left constant jsonb := '{"a": 1, "b": 2}';
-  j_right constant jsonb := '{"p":17, "a": 19}';
-  j_expected constant jsonb := '{"a": 19, "b": 2, "p": 17}';
+  j_right constant jsonb := '{"p":17, "q": 19}';
+  j_expected constant jsonb := '{"a": 1, "b": 2, "p": 17, "q": 19}';
 begin
   assert
     j_left || j_right = j_expected,
@@ -71,7 +71,7 @@ end;
 $body$;
 ```
 
-If the keys of key-value pairs collide, then the last-mentioned one wins, just as when the keys of such pairs collide in a single _object_:
+If the key of any key-value pair in the RHS _object_ collides with a key of a key-value pair in the LHS _object_, then the key-value pair from the RHS _object_ wins, just as when the keys of such pairs collide in a single _object_:
 
 ```plpgsql
 do $body$

--- a/docs/content/latest/api/ysql/datatypes/type_range.md
+++ b/docs/content/latest/api/ysql/datatypes/type_range.md
@@ -16,7 +16,7 @@ YSQL supports six built-in range data types. Each defines a range of values of a
 ## Synopsis
 
 Range data type | Underlying data type |
-----------|-------------|-------------
+----------|-------------|
 `int4range` | `integer` (a.k.a. `int`) |
 `int8range` | `bigint` |
 `numrange` | `numeric` |

--- a/docs/content/latest/api/ysql/the-sql-language/statements/dml_values.md
+++ b/docs/content/latest/api/ysql/the-sql-language/statements/dml_values.md
@@ -80,7 +80,7 @@ Each successive parenthesized expression list must specify the same number of ex
 ```plpgsql
 values
   (1::int, '2019-06-25 12:05:30'::timestamp, 'dog'::text),
-  (2::int, '2020-07-30 13:10:45'::timestamp, 'cat'::text);
+  (2::int, '2020-07-30 13:10:45'::timestamp, 'cat'::text, 42::int);
 ```
 
 It causes this error:


### PR DESCRIPTION
```
.../ysql/the-sql-language/statements/dml_values.md
.../ysql/datatypes/type_range.md
.../ysql/datatypes/type_json/functions-operators/concatenation-operator.md
```

`VALUES` statement: Fixed typo in "counter-example".

`range` data type: fixed typo in table formatting.

The array concatenation operator: fixed typo in code sample that shows priority rule when LHS and RHS _objects_ have colliding key-value pairs (i.e. same key for pairs).