### PR TITLE
[docs] tweak prompt-removal logic for code blocks

### DIFF
--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -151,16 +151,21 @@ $(document).ready(() => {
       let regExpCopy = /a^/;
       if (languageDescriptor) {
         // Then apply copy button
-        if (['postgresql', 'sql', 'postgres'].includes(languageDescriptor)) {
+        // Strip the prompt from SQL languages
+        if (['pgsql', 'plpgsql', 'postgres', 'postgresql', 'sql'].includes(languageDescriptor)) {
           if (element.textContent.match(/^[0-9a-z_.:@=^]{1,30}[>|#]\s/gm)) {
             regExpCopy = /^[0-9a-z_.:@=^]{1,30}[>|#]\s/gm;
           }
-        } else if (['sh', 'bash', 'shell'].includes(languageDescriptor)) {
+        // Strip the $ shell prompt
+        } else if (['bash', 'sh', 'shell', 'terminal', 'zsh'].includes(languageDescriptor)) {
           if (element.textContent.match(/^\$\s/gm)) {
             regExpCopy = /^\$\s/gm;
           } else if (element.textContent.match(/^[0-9a-z_.:@=^]{1,30}[>|#]\s/gm)) {
             regExpCopy = /^[0-9a-z_.:@=^]{1,30}[>|#]\s/gm;
           }
+        // Don't add a copy button to blocks labeled "output"
+        } else if (['output'].includes(languageDescriptor)) {
+          return;
         }
         const button = document.createElement('button');
         button.className = 'copy unclicked';


### PR DESCRIPTION
Fixes #7685

* add a couple more labels for SQL languages
* add a couple more common labels for shell prompts
* add a new label called "output" that doesn't get a copy button