### PR TITLE
[#7724] docs: switch to GUC var yb_index_state_flags_update_delay

### DIFF
--- a/docs/content/latest/api/ysql/the-sql-language/statements/ddl_create_index.md
+++ b/docs/content/latest/api/ysql/the-sql-language/statements/ddl_create_index.md
@@ -205,7 +205,7 @@ If it still doesn't work, here are some troubleshooting steps:
 - **Did you get a "duplicate key value" error?**
   Then, you have a unique constraint violation.
 
-**To prioritize keeping other transactions alive** during the index backfill, bump up
+**To prioritize keeping other transactions alive** during the index backfill, bump up the following:
 
 - master flag `index_backfill_wait_for_old_txns_ms`
 - YSQL GUC variable `yb_index_state_flags_update_delay`

--- a/docs/content/latest/api/ysql/the-sql-language/statements/ddl_create_index.md
+++ b/docs/content/latest/api/ysql/the-sql-language/statements/ddl_create_index.md
@@ -210,4 +210,4 @@ If it still doesn't work, here are some troubleshooting steps:
 - master flag `index_backfill_wait_for_old_txns_ms`
 - YSQL GUC variable `yb_index_state_flags_update_delay`
 
-**To speed up index creation** by a few seconds when you know there will be no online writes, set YSQL GUC variable `yb_index_state_flags_update_delay` to zero.
+**To speed up index creation** by a few seconds when you know there will be no online writes, set the YSQL GUC variable `yb_index_state_flags_update_delay` to zero.

--- a/docs/content/latest/api/ysql/the-sql-language/statements/ddl_create_index.md
+++ b/docs/content/latest/api/ysql/the-sql-language/statements/ddl_create_index.md
@@ -205,9 +205,9 @@ If it still doesn't work, here are some troubleshooting steps:
 - **Did you get a "duplicate key value" error?**
   Then, you have a unique constraint violation.
 
-**To prioritize keeping other transactions alive** during the index backfill, bump up the following flags:
+**To prioritize keeping other transactions alive** during the index backfill, bump up
 
-- master `index_backfill_wait_for_old_txns_ms`
-- tserver `ysql_index_state_flags_update_delay_ms`
+- master flag `index_backfill_wait_for_old_txns_ms`
+- YSQL GUC variable `yb_index_state_flags_update_delay`
 
-**To speed up index creation** by a few seconds when you know there will be no online writes, set tserver flag `ysql_index_state_flags_update_delay_ms=0`.
+**To speed up index creation** by a few seconds when you know there will be no online writes, set YSQL GUC variable `yb_index_state_flags_update_delay` to zero.


### PR DESCRIPTION
Replace mentions of flag `ysql_index_state_flags_update_delay_ms`
(actually supposed to be `TEST_ysql_index_state_flags_update_delay_ms`)
with GUC variable `yb_index_state_flags_update_delay`.