### PR TITLE
[#7959] Platform: Fixed Universe Failure when node-to-node TLS is disabled. 

### DIFF
--- a/managed/ui/src/components/universes/UniverseForm/ClusterFields.js
+++ b/managed/ui/src/components/universes/UniverseForm/ClusterFields.js
@@ -777,6 +777,12 @@ export default class ClusterFields extends Component {
     if (clusterType === 'primary') {
       updateFormField('primary.enableNodeToNodeEncrypt', event.target.checked);
       updateFormField('async.NodeToNodeEncrypt', event.target.checked);
+      
+      // If NodeToNodeEncrypt is false update ClientToNodeEncrypt field to false.
+      if (!event.target.checked) {
+        updateFormField('primary.enableClientToNodeEncrypt', event.target.checked);
+        updateFormField('async.enableClientToNodeEncrypt', event.target.checked);
+      }
       this.setState({
         enableNodeToNodeEncrypt: event.target.checked,
         enableClientToNodeEncrypt: this.state.enableClientToNodeEncrypt && event.target.checked


### PR DESCRIPTION
Description: Disabling node-to-node TLS sets the client-to-node TLS to be disabled, but this field was not updating payload form value, it was just done for UI.

Scenario: After this fix, I tried creating Universe for the following scenario.
1. Keeping node-to-node and client-to-node set to true (**Default**)
2. Keeping node-to-node enabled and client-to-node to be disabled.
3. Keeping node-to-node and client-to-node set to false.