### PR TITLE
[docs] break ecosystem snippets into in+out

### DIFF
--- a/docs/content/latest/develop/ecosystem-integrations/_index.html
+++ b/docs/content/latest/develop/ecosystem-integrations/_index.html
@@ -6,7 +6,6 @@ description: Integrate YugabyteDB with Apache Kafka, Apache Spark, JanusGraph, K
 headcontent: YugabyteDB is driver-compatible with PostgreSQL, Apache Cassandra, and Redis clients. Here are a few of the ecosystem of projects built around the YSQL and YCQL APIs.
 image: /images/section_icons/develop/ecosystem-integrations.png
 aliases:
-  - /develop/ecosystem-integrations/
 menu:
   latest:
     identifier: ecosystem-integrations

--- a/docs/content/latest/develop/ecosystem-integrations/apache-kafka.md
+++ b/docs/content/latest/develop/ecosystem-integrations/apache-kafka.md
@@ -3,7 +3,6 @@ title: Apache Kafka
 linkTitle: Apache Kafka
 description: Apache Kafka
 aliases:
-  - /develop/ecosystem-integrations/apache-kafka/
 menu:
   latest:
     identifier: apache-kafka
@@ -23,7 +22,7 @@ Start a YugabyteDB cluster on your [local machine](../../../quick-start/install/
 $ ./bin/ycqlsh localhost
 ```
 
-```
+```output
 Connected to local cluster at 127.0.0.1:9042.
 [ycqlsh 5.0.1 | Cassandra 3.9-SNAPSHOT | CQL spec 3.4.2 | Native protocol v4]
 Use HELP for help.
@@ -116,7 +115,7 @@ $ ./bin/connect-standalone.sh \
 
 The `yugabyte.sink.properties` file used above (and shown below) has the configuration necessary for this sink to work correctly. You will have to change this file to the Kafka topic and YugabyteDB table necessary for your application.
 
-```
+```cfg
 # Sample yugabyte sink properties.
 
 name=yugabyte-sink
@@ -140,7 +139,7 @@ $ ~/yb-kafka/kafka_2.12-2.5.0/bin/kafka-console-producer.sh
 
 Enter the following.
 
-```
+```json
 {"key" : "A", "value" : 1, "ts" : 1541559411000}
 {"key" : "B", "value" : 2, "ts" : 1541559412000}
 {"key" : "C", "value" : 3, "ts" : 1541559413000}
@@ -154,7 +153,7 @@ The events above should now show up as rows in the YugabyteDB table.
 ycqlsh> SELECT * FROM demo.test_table;
 ```
 
-```
+```output
 key | value | ts
 ----+-------+---------------------------------
   A |     1 | 2018-11-07 02:56:51.000000+0000

--- a/docs/content/latest/develop/ecosystem-integrations/apache-spark/scala.md
+++ b/docs/content/latest/develop/ecosystem-integrations/apache-spark/scala.md
@@ -4,7 +4,6 @@ headerTitle: Apache Spark
 linkTitle: Apache Spark
 description: Build a Scala application using Apache Spark and YugabyteDB
 aliases:
-  - /develop/ecosystem-integrations/apache-spark/
   - /latest/develop/ecosystem-integrations/apache-spark/
 menu:
   latest:
@@ -46,7 +45,7 @@ isTocNested: true
 
 To build your Scala application using the YugabyteDB Spark Connector for YCQL, add the following sbt dependency to your application:
 
-```
+```scala
 libraryDependencies += "com.yugabyte.spark" %% "spark-cassandra-connector" % "2.4-yb-3"
 ```
 
@@ -60,7 +59,7 @@ This tutorial assumes that you have:
 
 - installed the [`sbt-assembly`](https://github.com/sbt/sbt-assembly) plugin in your sbt project as shown below.
 
-```sh
+```scala
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
 ```
 
@@ -68,7 +67,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
 
 Create an sbt build file (`build.sbt`) and add the following content into it.
 
-```sbt
+```scala
 name := "CassandraSparkWordCount"
 version := "1.0"
 scalaVersion := "2.11.12"
@@ -305,7 +304,7 @@ $ spark-submit --class com.yugabyte.sample.apps.CassandraSparkWordCount \
 
 You should see a table similar to the following as the output.
 
-```
+```output
 +-----+-----+
 | word|count|
 +-----+-----+

--- a/docs/content/latest/develop/ecosystem-integrations/janusgraph.md
+++ b/docs/content/latest/develop/ecosystem-integrations/janusgraph.md
@@ -3,7 +3,6 @@ title: JanusGraph
 linkTitle: JanusGraph
 description: JanusGraph
 aliases:
-  - /develop/ecosystem-integrations/janusgraph/
 menu:
   latest:
     identifier: janusgraph

--- a/docs/content/latest/develop/ecosystem-integrations/janusgraph.md
+++ b/docs/content/latest/develop/ecosystem-integrations/janusgraph.md
@@ -23,7 +23,7 @@ Start a cluster on your [local machine](../../../quick-start/install/). Check th
 $ ycqlsh
 ```
 
-```
+```output
 Connected to local cluster at 127.0.0.1:9042.
 [ycqlsh 5.0.1 | Cassandra 3.9-SNAPSHOT | CQL spec 3.4.2 | Native protocol v4]
 Use HELP for help.
@@ -50,6 +50,9 @@ $ cd janusgraph-0.2.0-hadoop2
 
 ```sh
 $ ./bin/gremlin.sh
+```
+
+```output
          \,,,/
          (o o)
 -----oOOo-(3)-oOOo-----
@@ -66,6 +69,9 @@ gremlin>
 
 ```sql
 gremlin> graph = JanusGraphFactory.open('conf/janusgraph-cql.properties')
+```
+
+```output
 ==>standardjanusgraph[cql:[127.0.0.1]]
 ```
 
@@ -79,8 +85,17 @@ We are going to load the sample data that JanusGraph ships with - the Graph of t
 
 ```sh
 gremlin> GraphOfTheGodsFactory.loadWithoutMixedIndex(graph,true)
+```
+
+```output
 ==>null
+```
+
+```sql
 gremlin> g = graph.traversal()
+```
+
+```output
 ==>graphtraversalsource[standardjanusgraph[cql:[127.0.0.1]], standard]
 ```
 
@@ -94,6 +109,9 @@ For reference, here is the graph data loaded by the Graph of the Gods. You can f
 
 ```sh
 gremlin> saturn = g.V().has('name', 'saturn').next()
+```
+
+```output
 ==>v[4168]
 ```
 
@@ -101,6 +119,9 @@ gremlin> saturn = g.V().has('name', 'saturn').next()
 
 ```sh
 gremlin> g.V(saturn).in('father').in('father').values('name')
+```
+
+```output
 ==>hercules
 ```
 
@@ -108,26 +129,49 @@ gremlin> g.V(saturn).in('father').in('father').values('name')
 
 ```sh
 gremlin> hercules = g.V(saturn).repeat(__.in('father')).times(2).next()
-==>v[4120]
+```
 
+```output
+==>v[4120]
+```
+
+```sql
 // Who were the parents of Hercules?
 gremlin> g.V(hercules).out('father', 'mother').values('name')
+```
+
+```output
 ==>jupiter
 ==>alcmene
+```
 
+```sql
 // Were the parents of Hercules gods or humans?
 gremlin> g.V(hercules).out('father', 'mother').label()
+```
+
+```output
 ==>god
 ==>human
+```
 
+```sql
 // Who did Hercules battle?
 gremlin> g.V(hercules).out('battled').valueMap()
+```
+
+```output
 ==>[name:[hydra]]
 ==>[name:[nemean]]
 ==>[name:[cerberus]]
+```
 
+```sql
 // Who did Hercules battle after time 1?
 gremlin> g.V(hercules).outE('battled').has('time', gt(1)).inV().values('name')
+```
+
+```output
 ==>cerberus
 ==>hydra
 ```
@@ -136,38 +180,69 @@ gremlin> g.V(hercules).outE('battled').has('time', gt(1)).inV().values('name')
 
 - Who are Pluto's cohabitants?
 
-```sh
+```sql
 gremlin> pluto = g.V().has('name', 'pluto').next()
-==>v[8416]
+```
 
+```output
+==>v[8416]
+```
+
+```sql
 // who are pluto's cohabitants?
 gremlin> g.V(pluto).out('lives').in('lives').values('name')
+```
+
+```output
 ==>pluto
 ==>cerberus
+```
 
+```sql
 // pluto can't be his own cohabitant
 gremlin> g.V(pluto).out('lives').in('lives').where(is(neq(pluto))).values('name')
+```
+
+```output
 ==>cerberus
+```
+
+```sql
 gremlin> g.V(pluto).as('x').out('lives').in('lives').where(neq('x')).values('name')
+```
+
+```output
 ==>cerberus
-gremlin>
 ```
 
 - Queries about Pluto’s Brothers.
 
-```sh
+```sql
 // where do pluto's brothers live?
 gremlin> g.V(pluto).out('brother').out('lives').values('name')
+```
+
+```output
 ==>sea
 ==>sky
+```
 
+```sql
 // which brother lives in which place?
 gremlin> g.V(pluto).out('brother').as('god').out('lives').as('place').select('god', 'place')
+```
+
+```output
 ==>[god:v[4248],place:v[4320]]
 ==>[god:v[8240],place:v[4144]]
+```
 
+```sql
 // what is the name of the brother and the name of the place?
 gremlin> g.V(pluto).out('brother').as('god').out('lives').as('place').select('god', 'place').by('name')
+```
+
+```output
 ==>[god:neptune,place:sea]
 ==>[god:jupiter,place:sky]
 ```
@@ -176,14 +251,22 @@ gremlin> g.V(pluto).out('brother').as('god').out('lives').as('place').select('go
 
 Geo-spatial indexes - events that have happened within 50 kilometers of Athens (latitude:37.97 and long:23.72).
 
-```sh
+```sql
 // Show all events that happened within 50 kilometers of Athens (latitude:37.97 and long:23.72).
 gremlin> g.E().has('place', geoWithin(Geoshape.circle(37.97, 23.72, 50)))
+```
+
+```output
 ==>e[4cj-36g-7x1-6c8][4120-battled->8216]
 ==>e[3yb-36g-7x1-9io][4120-battled->12336]
+```
 
+```sql
 // For these events that happened within 50 kilometers of Athens, show who battled whom.
 gremlin> g.E().has('place', geoWithin(Geoshape.circle(37.97, 23.72, 50))).as('source').inV().as('god2').select('source').outV().as('god1').select('god1', 'god2').by('name')
+```
+
+```output
 ==>[god1:hercules,god2:hydra]
 ==>[god1:hercules,god2:nemean]
 ```

--- a/docs/content/latest/develop/ecosystem-integrations/kairosdb.md
+++ b/docs/content/latest/develop/ecosystem-integrations/kairosdb.md
@@ -3,7 +3,6 @@ title: KairosDB
 linkTitle: KairosDB
 description: KairosDB
 aliases:
-  - /develop/ecosystem-integrations/kairosdb/
 menu:
   latest:
     identifier: kairosdb
@@ -31,13 +30,13 @@ $ cd kairosdb/
 
 You can follow the [Getting started](http://kairosdb.github.io/docs/build/html/GettingStarted.html) to see how to configure KairosDB in general. For the purpose of integrating with the local YugabyteDB cluster running at `localhost:9042`, simply open `conf/kairosdb.properties` and comment out the default in-memory datastore as below.
 
-```
+```cfg
 #kairosdb.service.datastore=org.kairosdb.datastore.h2.H2Module
 ```
 
 Uncomment the following line to make Cassandra the datastore.
 
-```
+```cfg
 kairosdb.service.datastore=org.kairosdb.datastore.cassandra.CassandraModule
 ```
 
@@ -49,7 +48,7 @@ $ ./bin/kairosdb.sh run
 
 You should see the following lines if KairosDB starts up successfully.
 
-```
+```output
 18:34:01.094 [main] INFO  [AbstractConnector.java:338] - Started SelectChannelConnector@0.0.0.0:8080
 18:34:01.098 [main] INFO  [Main.java:522] - Starting service class org.kairosdb.core.telnet.TelnetServer
 18:34:01.144 [main] INFO  [Main.java:378] - ------------------------------------------
@@ -67,7 +66,7 @@ Assuming you are using the macOS or Linux binary
 $ ./bin/ycqlsh localhost
 ```
 
-```
+```output
 Connected to local cluster at 127.0.0.1:9042.
 [ycqlsh 5.0.1 | Cassandra 3.9-SNAPSHOT | CQL spec 3.4.2 | Native protocol v4]
 Use HELP for help.
@@ -80,7 +79,7 @@ ycqlsh>
 ycqlsh> describe keyspaces;
 ```
 
-```
+```output
 kairosdb  system_schema  system_auth  system
 ```
 
@@ -89,7 +88,7 @@ ycqlsh> use kairosdb;
 ycqlsh:kairosdb> describe tables;
 ```
 
-```
+```output
 row_keys       data_points    string_index
 row_key_index  service_index  row_key_time_index
 ```

--- a/docs/content/latest/develop/ecosystem-integrations/metabase.md
+++ b/docs/content/latest/develop/ecosystem-integrations/metabase.md
@@ -3,7 +3,6 @@ title: Metabase
 linkTitle: Metabase
 description: Metabase
 aliases:
-  - /develop/ecosystem-integrations/metabase/
 menu:
   latest:
     identifier: metabase
@@ -41,8 +40,8 @@ $ tar zxvf sample-data.tgz
 $ ls data/
 ```
 
-```
-orders.sql	products.sql	reviews.sql	users.sql
+```output
+orders.sql  products.sql  reviews.sql  users.sql
 ```
 
 ### Connect to YugabyteDB using ysqlsh
@@ -53,7 +52,7 @@ You can do this as shown below.
 $ ./bin/ysqlsh
 ```
 
-```
+```output
 ysqlsh (11.2)
 Type "help" for help.
 
@@ -62,15 +61,9 @@ yugabyte=#
 
 ### Create a database
 
-```plpgsql
+```sql
 yugabyte=# CREATE DATABASE yb-demo;
-```
-
-```plpgsql
 yugabyte=# GRANT ALL ON DATABASE yb-demo to yugabyte;
-```
-
-```plpgsql
 yugabyte=# \c yb-demo;
 ```
 
@@ -78,31 +71,22 @@ yugabyte=# \c yb-demo;
 
 First create the 4 tables necessary to store the data.
 
-```plpgsql
+```sql
 yugabyte=# \i 'schema.sql';
 ```
 
 Now load the data into the tables.
 
-```plpgsql
+```sql
 yugabyte=# \i 'data/products.sql'
-```
-
-```plpgsql
 yugabyte=# \i 'data/users.sql'
-```
-
-```plpgsql
 yugabyte=# \i 'data/orders.sql'
-```
-
-```plpgsql
 yugabyte=# \i 'data/reviews.sql'
 ```
 
 ## 3. Download and configure Metabase
 
-Detailed steps for setting up Metabase are available [here](https://www.metabase.com/docs/latest/setting-up-metabase.html). The following are the minimal setup steps for getting started.
+Detailed steps for setting up Metabase are available in the [Metabase documentation](https://www.metabase.com/docs/latest/setting-up-metabase.html). The following are the minimal setup steps for getting started.
 
 ```sh
 $ wget http://downloads.metabase.com/v0.30.4/metabase.jar
@@ -112,15 +96,15 @@ $ wget http://downloads.metabase.com/v0.30.4/metabase.jar
 $ java -jar metabase.jar
 ```
 
-Go to http://localhost:3000 to configure your Metabase server and point it to the YSQL API endpoint at `localhost:5433`.
+Go to <http://localhost:3000> to configure your Metabase server and point it to the YSQL API endpoint at `localhost:5433`.
 
 ## 4. Run complex queries with Metabase
 
-Detailed steps on how to use Metabase are available [here](https://www.metabase.com/docs/latest/getting-started.html). For this doc, you will specifically focus on asking questions that require RDBMS capabilities.
+Detailed steps on how to use Metabase are available in the [Metabase documentation](https://www.metabase.com/docs/latest/getting-started.html). For this doc, you will specifically focus on asking questions that require RDBMS capabilities.
 
 - Filter data using WHERE clauses
 - Join data between tables
 - Perform data aggregation using GROUP BY
 - Use built-in functions such as SUM, MIN, MAX, etc.
 
-You can click on Ask a Question -> Custom Query. Choose the database you just setup, and enter the SQL queries noted in the [Retail Analytics](../../realworld-apps/retail-analytics/) section.
+Click Ask a Question > Custom Query. Choose the database you just set up, and enter the SQL queries noted in the [Retail Analytics](../../realworld-apps/retail-analytics/) section.

--- a/docs/content/latest/develop/ecosystem-integrations/presto.md
+++ b/docs/content/latest/develop/ecosystem-integrations/presto.md
@@ -3,7 +3,6 @@ title: Presto
 linkTitle: Presto
 description: Presto
 aliases:
-  - /develop/ecosystem-integrations/presto/
 menu:
   latest:
     identifier: presto
@@ -14,11 +13,12 @@ showAsideToc: true
 ---
 
 [Presto](https://prestosql.io/) is a distributed SQL query engine optimized for ad-hoc analysis at interactive speed. It supports standard ANSI SQL, including complex queries, aggregations, joins, and window functions. It has a connector architecture to query data from many data sources.
-This page shows how Presto can be setup to query YugabyteDB's YCQL tables.
+
+This page shows how to set up Presto to query YugabyteDB's YCQL tables.
 
 ## 1. Start local cluster
 
-Follow [Quick start](../../../quick-start/) instructions to run a local YugabyteDB cluster. Test YugabyteDB's Cassandra compatible API as [documented](../../../quick-start/test-cassandra/) so that you can confirm that you have a Cassandra compatible service running on `localhost:9042`. We assume you have created the keyspace and table, and inserted sample data as described there.
+Follow [Quick start](../../../quick-start/) instructions to run a local YugabyteDB cluster. Test YugabyteDB's Cassandra compatible API as [documented](../../../quick-start/explore/ycql/) so that you can confirm that you have a Cassandra compatible service running on `localhost:9042`. We assume you have created the keyspace and table, and inserted sample data as described there.
 
 ## 2. Download and configure Presto
 
@@ -57,11 +57,13 @@ $ mkdir data
 $ cat > etc/node.properties
 ```
 
-```
+```cfg
 node.environment=test
 node.id=ffffffff-ffff-ffff-ffff-ffffffffffff
 node.data-dir=/Users/<username>/presto-server-309/data
 ```
+
+Press Ctrl-D after you've pasted the file contents.
 
 ### Create jvm.config file
 
@@ -69,7 +71,7 @@ node.data-dir=/Users/<username>/presto-server-309/data
 $ cat > etc/jvm.config
 ```
 
-```
+```cfg
 -server
 -Xmx6G
 -XX:+UseG1GC
@@ -80,13 +82,15 @@ $ cat > etc/jvm.config
 -XX:+ExitOnOutOfMemoryError
 ```
 
+Press Ctrl-D after you've pasted the file contents.
+
 ### Create config.properties file
 
 ```sh
 $ cat > etc/config.properties
 ```
 
-```
+```cfg
 coordinator=true
 node-scheduler.include-coordinator=true
 http-server.http.port=8080
@@ -96,15 +100,19 @@ discovery-server.enabled=true
 discovery.uri=http://localhost:8080
 ```
 
+Press Ctrl-D after you've pasted the file contents.
+
 ### Create log.properties file
 
 ```sh
 $ cat > etc/log.properties
 ```
 
-```
+```cfg
 io.prestosql=INFO
 ```
+
+Press Ctrl-D after you've pasted the file contents.
 
 ### Configure Cassandra connector to YugabyteDB
 
@@ -115,10 +123,12 @@ Detailed instructions are [here](https://prestosql.io/docs/current/connector/cas
 $ cat > etc/catalog/cassandra.properties
 ```
 
-```
+```cfg
 connector.name=cassandra
 cassandra.contact-points=127.0.0.1
 ```
+
+Press Ctrl-D after you've pasted the file contents.
 
 ## 3. Download Presto CLI
 
@@ -130,7 +140,7 @@ $ cd ~/presto-server-309/bin
 $ wget https://repo1.maven.org/maven2/io/prestosql/presto-cli/309/presto-cli-309-executable.jar
 ```
 
-Rename jar to ‘presto’. It is meant to be a self-running binary.
+Rename the JAR file to `presto`. It is meant to be a self-running binary.
 
 ```sh
 $ mv presto-cli-309-executable.jar presto && chmod +x presto
@@ -139,19 +149,19 @@ $ mv presto-cli-309-executable.jar presto && chmod +x presto
 ## 4. Launch Presto server
 
 ```sh
-$ cd presto-server-309
+$ cd ~/presto-server-309
 ```
 
 To run in foreground mode.
 
 ```sh
-$ ./bin/launcher run       
+$ ./bin/launcher run
 ```
 
 To run in background mode.
 
 ```sh
-$ ./bin/launcher start  
+$ ./bin/launcher start
 ```
 
 ## 5. Test Presto queries
@@ -168,7 +178,7 @@ Start using `myapp`.
 presto:default> use myapp;
 ```
 
-```sh
+```output
 USE
 ```
 
@@ -178,7 +188,7 @@ Show the tables available.
 presto:myapp> show tables;
 ```
 
-```
+```output
  Table
 -------
  stock_market
@@ -191,7 +201,7 @@ Describe a particular table.
 presto:myapp> describe stock_market;
 ```
 
-```
+```output
     Column     |  Type   | Extra | Comment 
 ---------------+---------+-------+---------
  stock_symbol  | varchar |       |         
@@ -206,7 +216,7 @@ presto:myapp> describe stock_market;
 presto:myapp> select * from stock_market where stock_symbol = 'AAPL';
 ```
 
-```
+```output
  stock_symbol |         ts          | current_price 
 --------------+---------------------+---------------
  AAPL         | 2017-10-26 09:00:00 |        157.41 
@@ -220,7 +230,7 @@ presto:myapp> select * from stock_market where stock_symbol = 'AAPL';
 presto:myapp> select stock_symbol, avg(current_price) from stock_market group by stock_symbol;
 ```
 
-```
+```output
  stock_symbol |  _col1  
 --------------+---------
  GOOG         | 972.235 

--- a/docs/content/latest/develop/ecosystem-integrations/spring.md
+++ b/docs/content/latest/develop/ecosystem-integrations/spring.md
@@ -3,7 +3,6 @@ title: Spring Support for YugabyteDB
 linkTitle: Spring Framework
 description: Spring Support for YugabyteDB
 aliases:
-  - /develop/ecosystem-integrations/spring/
 menu:
   latest:
     identifier: spring
@@ -21,7 +20,7 @@ YCQL provides Cassandra wire-compatible query language for client applications t
 
 The following is a non-exhaustive list of supported features:
 
-- Yugabyte Java driver for YCQL 3.n and 4.n drivers.
+- Yugabyte Java driver for YCQL 3.x and 4.x drivers.
 - Automatic implementation of Repository interfaces including support for custom query methods.
 - Build repositories based on common Spring Data interfaces.
 - Synchronous, reactive, and asynchronous YCQL operations.
@@ -30,7 +29,7 @@ The following is a non-exhaustive list of supported features:
 
 Spring Data Cassandra projects are bundled with the Apache Cassandra Java driver. To enhance performance, it is recommended to replace this driver with the Yugabyte Java driver for YCQL.
 
-**Yugabyte Java Driver YCQL 3.n**
+**Yugabyte Java Driver YCQL 3.x**
 
 ```xml
 <dependency>
@@ -55,7 +54,7 @@ Spring Data Cassandra projects are bundled with the Apache Cassandra Java driver
 
 The following shows how to exclude and add dependencies via Gradle:
 
-```javascript
+```gradle
 dependencies {
   compile('org.springframework.data:spring-data-cassandra:2.2.12.RELEASE') { 
   exclude group: "com.datastax.cassandra", name: "cassandra-driver-core" 
@@ -64,7 +63,7 @@ dependencies {
 }
 ```
 
-**Yugabyte Java Driver YCQL 4.n**
+**Yugabyte Java Driver YCQL 4.x**
 
 ```xml
 <dependency>
@@ -89,7 +88,7 @@ dependencies {
 
 The following shows how to exclude and add dependencies via Gradle:
 
-```javascript
+```gradle
 dependencies {
   compile('org.springframework.data:spring-data-cassandra:3.0.6.RELEASE') { 
   exclude group: "com.datastax.oss", name: "java-driver-core" 
@@ -102,42 +101,42 @@ Yugabyte Java driver for YCQL provides support for single hop fetch which enable
 
 ### Sample Spring Boot Project
 
-A sample Spring boot project is available at https://github.com/yugabyte/spring-ycql-demo. The following steps show how to incrementally build a Spring boot application using Spring Data Cassandra and YCQL.
+A sample Spring boot project is available at <https://github.com/yugabyte/spring-ycql-demo>. The following steps show how to incrementally build a Spring boot application using Spring Data Cassandra and YCQL.
 
 #### Use Spring Initializer
 
-1. Navigate to [https://start.spring.io](https://start.spring.io/) to creating a new Spring boot project and select the following dependencies for implementing the Spring boot application:
-   - Spring Boot Data Cassandra
-   - Java 8
+1. Navigate to [https://start.spring.io](https://start.spring.io/) to create a new Spring boot project. Select the following dependencies for implementing the Spring boot application:
+    - Spring Boot Data Cassandra
+    - Java 8
 
-2. Update the Maven dependencies to use Yugabyte Java driver for YCQL, as follows:
+1. Update the Maven dependencies to use Yugabyte Java driver for YCQL, as follows:
 
-```xml
-   <dependency>
-     <groupId>org.springframework.boot</groupId>
-     <artifactId>spring-boot-starter-data-cassandra</artifactId>
-     <exclusions>
-   ​   <exclusion>
-   ​     <groupId>com.datastax.oss</groupId>
-   ​     <artifactId>java-driver-core</artifactId>
-   ​   </exclusion>
-     </exclusions>
-   </dependency>
-   <dependency>
-    <groupId>com.yugabyte</groupId>
-    <artifactId>java-driver-core</artifactId>
-    <version>4.6.0-yb-6</version>
-   </dependency>
-```
+    ```xml
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-data-cassandra</artifactId>
+        <exclusions>
+      ​   <exclusion>
+      ​     <groupId>com.datastax.oss</groupId>
+      ​     <artifactId>java-driver-core</artifactId>
+      ​   </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.yugabyte</groupId>
+        <artifactId>java-driver-core</artifactId>
+        <version>4.6.0-yb-6</version>
+      </dependency>
+    ```
 
-3. Configure the Spring boot application to connect to YugabyteDB cluster using following properties in `application.properties` file:
+1. Configure the Spring boot application to connect to YugabyteDB cluster using the following properties in the `application.properties` file:
 
-| Property                                | Description                                                  |
-| --------------------------------------- | ------------------------------------------------------------ |
-| spring.data.cassandra.keyspace-name=    | YCQL keyspace                                                |
-| spring.data.cassandra.contact-points=   | YugabyteDB T-servers. Comma separated list of ip-addresses or DNS |
-| spring.data.cassandra.port=             | YCQL port                                                    |
-| spring.data.cassandra.local-datacenter= | Datacenter that is considered "local". Contact points should be from this datacenter. |
+    | Property | Description |
+    | :------- | :---------- |
+    | spring.data.cassandra.keyspace-name | YCQL keyspace |
+    | spring.data.cassandra.contact-points | YugabyteDB T-servers. Comma-separated list of IP addresses or DNS |
+    | spring.data.cassandra.port | YCQL port |
+    | spring.data.cassandra.local-datacenter | Datacenter that is considered "local". Contact points should be from this datacenter. |
 
 #### Set Up Domain Objects and Repositories for YCQL Tables
 
@@ -248,7 +247,7 @@ public class YcqlDataAccesssApplication implements CommandLineRunner {
 }
 ```
 
-The `CustomerRespository` type is autowired in `YcqlDataAccesssApplication` which allows the insert of new records into the `customer` table using the `customerRepository.save()` method.
+The `CustomerRepository` type is autowired in `YcqlDataAccesssApplication` which allows the insert of new records into the `customer` table using the `customerRepository.save()` method.
 
 You can retrieve the data using the `customerRepository.findByFirstName()` method which returns records based on the `firstName` column. The implementation of the method is supplied by Spring at runtime.
 
@@ -274,7 +273,7 @@ java -jar target/ycqldataaccess-1.0.0.jar
 
 Expect the following output:
 
-```shell
+```output
 INFO 28010 --- [main] c.y.e.y.YcqlDataAccesssApplication    : Started YcqlDataAccesssApplication in 1.7 seconds (JVM running for 2.139)
 
 INFO 28010 --- [main] c.y.e.y.YcqlDataAccesssApplication    : Creating Keyspace
@@ -325,42 +324,43 @@ Spring Data Reactive Cassandra projects are bundled with the Apache Cassandra Ja
 
 ### Sample Spring Boot Project for Reactive
 
-A sample Spring boot project is available at https://github.com/yugabyte/spring-reactive-ycql-client. The following steps show how to incrementally build a Spring boot application using Spring Data Cassandra and YCQL.
+A sample Spring boot project is available at <https://github.com/yugabyte/spring-reactive-ycql-client>. The following steps show how to incrementally build a Spring boot application using Spring Data Cassandra and YCQL.
 
 #### Use Spring Initializer
 
-1. Navigate to [https://start.spring.io](https://start.spring.io/) to creating a new Spring boot project and select the following dependencies for implementing the Spring boot application:
-   - Spring Boot Data Cassandra Reactive
-   - Java 8
-2. Update the Maven dependencies to use Yugabyte Java driver for YCQL, as follows:
+1. Navigate to [https://start.spring.io](https://start.spring.io/) to create a new Spring boot project. Select the following dependencies for implementing the Spring boot application:
+    - Spring Boot Data Cassandra Reactive
+    - Java 8
 
-```xml
-<dependency>
-  <groupId>org.springframework.boot</groupId>
-  <artifactId>spring-boot-starter-data-cassandra-reactive</artifactId>
-  <exclusions>
-    <exclusion>
-      <groupId>com.datastax.oss</groupId>
+1. Update the Maven dependencies to use the Yugabyte Java driver for YCQL, as follows:
+
+    ```xml
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-cassandra-reactive</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.datastax.oss</groupId>
+          <artifactId>java-driver-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>com.yugabyte</groupId>
       <artifactId>java-driver-core</artifactId>
-    </exclusion>
-  </exclusions>
-</dependency>
+      <version>4.6.0-yb-6</version>
+    </dependency>
+    ```
 
-<dependency>
-  <groupId>com.yugabyte</groupId>
-  <artifactId>java-driver-core</artifactId>
-  <version>4.6.0-yb-6</version>
-</dependency>
-```
+1. Configure the Spring boot application to connect to YugabyteDB cluster using the following properties in the `application.properties` file:
 
-3. Configure the Spring boot application to connect to YugabyteDB cluster using following properties in `application.properties` file:
-
-| Property                                | Description                                                  |
-| --------------------------------------- | ------------------------------------------------------------ |
-| spring.data.cassandra.keyspace-name=    | YCQL keyspace                                                |
-| spring.data.cassandra.contact-points=   | YugabyteDB T-servers. Comma separated list of ip-addresses or DNS |
-| spring.data.cassandra.port=             | YCQL port                                                    |
-| spring.data.cassandra.local-datacenter= | Datacenter that is considered "local". Contact points should be from this datacenter. |
+    | Property | Description |
+    | :------- | :---------- |
+    | spring.data.cassandra.keyspace-name | YCQL keyspace |
+    | spring.data.cassandra.contact-points | YugabyteDB T-servers. Comma-separated list of IP addresses or DNS |
+    | spring.data.cassandra.port | YCQL port |
+    | spring.data.cassandra.local-datacenter | Datacenter that is considered "local". Contact points should be from this datacenter. |
 
 #### Set Up Domain Objects and Repositories for YugabyteDB Tables
 
@@ -478,8 +478,7 @@ public class YcqlReactiveDataAccessApplication implements CommandLineRunner {
 
 ## Compatibility Matrix
 
-| **YugabyteDB Java Driver** | **Spring Data Cassandra** |
-| -------------------------- | ------------------------- |
-| 3.8.0-yb-6                 | 2.2.12.RELEASE and latest |
-| 4.6.0-yb-6                 | 3.0.6.RELEASE and latest  |
-
+| YugabyteDB Java Driver | Spring Data Cassandra |
+| :--------------------- | :-------------------- |
+| 3.8.0-yb-6 | 2.2.12.RELEASE and later |
+| 4.6.0-yb-6 | 3.0.6.RELEASE and later |


### PR DESCRIPTION
Having inputs and outputs in the same code block renders the copy button useless.

It'll take a fair while to address this across the docs, but this is a start for the ecosystem integrations section.

Using Janusgraph as a first target...

**Deploy preview**: https://deploy-preview-7981--infallible-bardeen-164bc9.netlify.app/latest/develop/ecosystem-integrations/janusgraph/