### PR TITLE
[docs] fix broken links to "configure the cloud provider"

### DIFF
--- a/docs/content/latest/reference/configuration/yugabyted.md
+++ b/docs/content/latest/reference/configuration/yugabyted.md
@@ -20,7 +20,7 @@ The `yugabyted` executable file is located in the YugabyteDB home's `bin` direct
 
 - yugabyted currently supports both single-node and multi-node clusters (using the `join` option in the `start` command). However, ability to create multi-node clusters is currently under BETA.
 
-- yugabytedb is not recommended for production deployments at this time. For production deployments with fully-distributed multi-node clusters, use [`yb-tserver`](../yb-tserver) and [`yb-master`](../yb-master) directly using the [Deploy](../../../deploy) docs.
+- yugabyted is not recommended for production deployments at this time. For production deployments with fully-distributed multi-node clusters, use [`yb-tserver`](../yb-tserver) and [`yb-master`](../yb-master) directly using the [Deploy](../../../deploy) docs.
 
 {{< /note >}}
 

--- a/docs/content/latest/yugabyte-platform/configure-yugabyte-platform/_index.md
+++ b/docs/content/latest/yugabyte-platform/configure-yugabyte-platform/_index.md
@@ -27,7 +27,7 @@ menu:
   </div>
 
   <div class="col-12 col-md-6 col-lg-12 col-xl-6">
-    <a class="section-link icon-offset" href="set-up-cloud-provider/">
+    <a class="section-link icon-offset" href="set-up-cloud-provider/aws/">
       <div class="head">
         <img class="icon" src="/images/section_icons/manage/enterprise/edit_flags.png" aria-hidden="true" />
         <div class="title">Configure the cloud provider</div>

--- a/docs/content/stable/reference/configuration/yugabyted.md
+++ b/docs/content/stable/reference/configuration/yugabyted.md
@@ -20,7 +20,7 @@ The `yugabyted` executable file is located in the YugabyteDB home's `bin` direct
 
 - yugabyted currently supports both single-node and multi-node clusters (using the `join` option in the `start` command). However, ability to create multi-node clusters is currently under BETA.
 
-- yugabytedb is not recommended for production deployments at this time. For production deployments with fully-distributed multi-node clusters, use [`yb-tserver`](../yb-tserver) and [`yb-master`](../yb-master) directly using the [Deploy](../../../deploy) docs.
+- yugabyted is not recommended for production deployments at this time. For production deployments with fully-distributed multi-node clusters, use [`yb-tserver`](../yb-tserver) and [`yb-master`](../yb-master) directly using the [Deploy](../../../deploy) docs.
 
 {{< /note >}}
 

--- a/docs/content/stable/yugabyte-platform/configure-yugabyte-platform/_index.md
+++ b/docs/content/stable/yugabyte-platform/configure-yugabyte-platform/_index.md
@@ -27,7 +27,7 @@ menu:
   </div>
 
   <div class="col-12 col-md-6 col-lg-12 col-xl-6">
-    <a class="section-link icon-offset" href="set-up-cloud-provider/">
+    <a class="section-link icon-offset" href="set-up-cloud-provider/aws/">
       <div class="head">
         <img class="icon" src="/images/section_icons/manage/enterprise/edit_flags.png" aria-hidden="true" />
         <div class="title">Configure the cloud provider</div>

--- a/docs/content/v2.2/reference/configuration/yugabyted.md
+++ b/docs/content/v2.2/reference/configuration/yugabyted.md
@@ -21,7 +21,7 @@ The `yugabyted` executable file is located in the YugabyteDB home's `bin` direct
 
 - yugabyted currently supports both single-node and multi-node clusters (using the `join` option in the `start` command). However, ability to create multi-node clusters is currently under BETA.
 
-- yugabytedb is not recommended for production deployments at this time. For production deployments with fully-distributed multi-node clusters, use [`yb-tserver`](../yb-tserver) and [`yb-master`](../yb-master) directly using the [Deploy](../../../deploy) docs.
+- yugabyted is not recommended for production deployments at this time. For production deployments with fully-distributed multi-node clusters, use [`yb-tserver`](../yb-tserver) and [`yb-master`](../yb-master) directly using the [Deploy](../../../deploy) docs.
 
 {{< /note >}}
 


### PR DESCRIPTION
One broken link in stable, and one link that _will_ break in latest when we make a new stable... This fixes both.

Click the "Configure the Cloud Provider" boxes for each of these in the preview build, and make sure they go to the right place (AWS config).

[/**stable**/yugabyte-platform/configure-yugabyte-platform/](http://deploy-preview-8008--infallible-bardeen-164bc9.netlify.app/stable/yugabyte-platform/configure-yugabyte-platform/)
[/**latest**/yugabyte-platform/configure-yugabyte-platform/](http://deploy-preview-8008--infallible-bardeen-164bc9.netlify.app/latest/yugabyte-platform/configure-yugabyte-platform/)