### PR TITLE
[docdb] master UI hash_split of last partition should be inclusive

### DIFF
--- a/src/yb/common/partition.cc
+++ b/src/yb/common/partition.cc
@@ -849,7 +849,7 @@ string PartitionSchema::PartitionDebugString(const Partition& partition,
         const string& pend = partition.partition_key_end();
         uint16_t hash_start = !pstart.empty() ? DecodeMultiColumnHashValue(pstart) : 0;
         uint16_t hash_end = !pend.empty() ? DecodeMultiColumnHashValue(pend) : UINT16_MAX;
-        s.append(Substitute("hash_split: [0x$0, 0x$1)",
+        s.append(Substitute("hash_split: [0x$0, 0x$1]",
                             Uint16ToHexString(hash_start), Uint16ToHexString(hash_end)));
         return s;
       }


### PR DESCRIPTION
- Fixes master UI hash_split of the last partition by making it inclusive.
- Changing that last partition to be all-inclusive so that it looks like `[foo, 0xffff]`

Fixes #6299 