### PR TITLE
[docs][OpenShift] Use different word than IP address and add clarification about admin user

### DIFF
--- a/docs/content/latest/yugabyte-platform/install-yugabyte-platform/install-software/openshift.md
+++ b/docs/content/latest/yugabyte-platform/install-yugabyte-platform/install-software/openshift.md
@@ -413,31 +413,32 @@ To configure the OpenShift command-line interface (CLI) tool oc, you start by lo
 
 Once you have created and deployed Yugabyte Platform, you can access its web UI and create an account.
 
-### How to Find the IP Address to Access the Web UI
+### How to Find the Location to Access the Web UI
 
-To find the IP address, you can use the OpenShift web console or the command line.
+To find the location (IP address or hostname), you can use the OpenShift web console or the command line.
 
 #### Using the OpenShift Web Console
 
-You can locate the IP address using the OpenShift web console as follows:
+You can obtain the location using the OpenShift web console as follows:
 
 - Use the OCP web console to navigate to **Networking > Services** and select **ybplatform-sample-yugaware-ui** from the list. Ensure that the **yb-platform** project is selected.
-- In the **Service Routing** section of the **Details** tab, locate **External Load Balancer** and copy the IP address, as shown in the following illustration:
+- In the **Service Routing** section of the **Details** tab, locate **External Load Balancer** and copy the value, as shown in the following illustration:
 
 ![Service Details](/images/ee/openshift-service-details.png)
 
-- Open the copied IP in a new instance of your web browser.
+- Open the copied location in a new instance of your web browser.
 
 #### Using the Command Line
 
-Alternatively, you can obtain the information about the IP address via the command line. 
+Alternatively, you can obtain the information about the location via the command line.
 
 In case of the Operator-based installation of Yugabyte Platform, execute the following command: 
 
 ```shell
 oc get services \
   ybplatform-sample-yugaware-ui \
-  -ojsonpath='{.status.loadBalancer.ingress[0].ip}{"\n"}'
+  -ojsonpath='{.status.loadBalancer.ingress[0].ip}{"\n"}
+              {.status.loadBalancer.ingress[0].hostname}{"\n"}'
 ```
 
 ```
@@ -450,7 +451,8 @@ In case of the Helm-based installation, execute the following command:
 ```shell
 oc get services \
    yw-test-yugaware-ui \
-  -ojsonpath='{.status.loadBalancer.ingress[0].ip}{"\n"}'
+  -ojsonpath='{.status.loadBalancer.ingress[0].ip}{"\n"}
+              {.status.loadBalancer.ingress[0].hostname}{"\n"}'
 ```
 
 ```

--- a/docs/content/latest/yugabyte-platform/install-yugabyte-platform/install-software/openshift.md
+++ b/docs/content/latest/yugabyte-platform/install-yugabyte-platform/install-software/openshift.md
@@ -382,8 +382,6 @@ You start by logging in the OCP's web console as admin user, and then performing
 
   ![Create Machines](/images/ee/openshift-yp-create-machine.png)
 
-- Log out of the admin account and login with your user account.
-
 ### How to Use the Command Line
 
 Alternatively, you can find the availability zone codes via the command line.

--- a/docs/content/latest/yugabyte-platform/install-yugabyte-platform/install-software/openshift.md
+++ b/docs/content/latest/yugabyte-platform/install-yugabyte-platform/install-software/openshift.md
@@ -47,6 +47,8 @@ To install Yugabyte Platform on an OpenShift cluster, you can use Yugabyte Platf
 
 Before you install Yugabyte Platform on an OpenShift cluster, you need to prepare the environment, as described in [Prepare the OpenShift Environment](../../../install-yugabyte-platform/prepare-environment/openshift/).
 
+Unless otherwise specified, you can use a user account for executing the steps described in this document. Using admin account for all the steps should work as well.
+
 ## Operator-Based Installation
 
 Installing Yugabyte Platform on an OpenShift cluster using the Yugabyte Platform Operator involves the following:
@@ -129,7 +131,7 @@ You start by creating an instance of Yugabyte Platform in a new project (namespa
 
 #### How to Use the OpenShift Web Console
 
-You can create an instance of Yugabyte Platform via he OpenShift web console as follows:
+You can create an instance of Yugabyte Platform via the OpenShift web console as follows:
 
 - Open the OCP web console and navigate to **Home > Projects > Create Project**.
 - Enter the name yb-platform and click **Create**.


### PR DESCRIPTION
- Remove note about logging out of admin account
  - The note was there because the whole section of finding Availability Zones was at some other place.
- Use different word than IP address
  - There are setups where you don't have an IP address for a LoadBalancer service, instead you get a hostname. Changing the word IP address with location for now, I wasn't able to find anything better than that. URI can be used but it will add some confusion.
-  Add a note about admin and normal user accounts