### PR TITLE
[docs] fix broken dbeaver page link

### DIFF
--- a/docs/content/latest/tools/dbeaver-ysql.md
+++ b/docs/content/latest/tools/dbeaver-ysql.md
@@ -3,6 +3,8 @@ title: Using DBeaver with YugabyteDB YSQL
 headerTitle: Using DBeaver with YSQL
 linkTitle: DBeaver
 description: Use the DBeaver multi-platform database tool to explore and query YugabyteDB.
+aliases:
+- /latest/tools/dbeaver
 menu:
   latest:
     identifier: dbeaver-ysql

--- a/docs/content/latest/yugabyte-cloud/connect-to-clusters.md
+++ b/docs/content/latest/yugabyte-cloud/connect-to-clusters.md
@@ -147,7 +147,7 @@ To see the host, port, username, and password required to connect:
 For detailed steps for configuring popular third party tools, see [Third party tools](../../tools/). In that section, configuration steps
 are included for the following tools:
 
-- [DBeaver](../../tools/dbeaver)
+- [DBeaver](../../tools/dbeaver-ysql)
 - [DbSchema](../../tools/dbschema)
 - [pgAdmin](../../tools/pgadmin)
 - [SQL Workbench/J](../../tools/sql-workbench)


### PR DESCRIPTION
Broken link popped up in SEO audit.

This is a result of splitting the DBeaver page into two, but not adding an alias to the original name. The alias _should_ be redundant now, but I've added it in case old blog posts etc might be linking to it.