### PR TITLE
[#6758][Platform] Unable to reuse On-premise instance incase previouse universe failed / deleted

### DIFF
--- a/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/UniverseTaskBase.java
+++ b/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/UniverseTaskBase.java
@@ -324,8 +324,20 @@ public abstract class UniverseTaskBase extends AbstractTaskBase {
       // Check if the private ip for the node is set. If not, that means we don't have
       // a clean state to delete the node. Log it and skip the node.
       if (node.cloudInfo.private_ip == null) {
+      // a clean state to delete the node. Log it, free up the onprem node
+      // so that the client can use the node instance to create another universe.
+      if (node.cloudInfo.private_ip == null){
         LOG.warn(String.format("Node %s doesn't have a private IP. Skipping node delete.",
                                node.nodeName));
+        if (node.cloudInfo.cloud.equals(
+            com.yugabyte.yw.commissioner.Common.CloudType.onprem.name())) {
+          try {
+            NodeInstance providerNode = NodeInstance.getByName(node.nodeName);
+            providerNode.clearNodeDetails();
+          } catch (Exception ex) {
+            LOG.warn("On-prem node {} doesn't have a linked instance ", node.nodeName);
+          }
+        }
         continue;
       }
       AnsibleDestroyServer.Params params = new AnsibleDestroyServer.Params();

--- a/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/UniverseTaskBase.java
+++ b/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/UniverseTaskBase.java
@@ -322,8 +322,6 @@ public abstract class UniverseTaskBase extends AbstractTaskBase {
     SubTaskGroup subTaskGroup = new SubTaskGroup("AnsibleDestroyServers", executor);
     for (NodeDetails node : nodes) {
       // Check if the private ip for the node is set. If not, that means we don't have
-      // a clean state to delete the node. Log it and skip the node.
-      if (node.cloudInfo.private_ip == null) {
       // a clean state to delete the node. Log it, free up the onprem node
       // so that the client can use the node instance to create another universe.
       if (node.cloudInfo.private_ip == null){

--- a/managed/src/test/java/com/yugabyte/yw/commissioner/tasks/UniverseTaskBaseTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/commissioner/tasks/UniverseTaskBaseTest.java
@@ -1,0 +1,107 @@
+// Copyright (c) YugaByte, Inc.
+
+package com.yugabyte.yw.commissioner.tasks;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.yugabyte.yw.commissioner.SubTaskGroupQueue;
+import com.yugabyte.yw.commissioner.Common.CloudType;
+import com.yugabyte.yw.common.FakeDBApplication;
+import com.yugabyte.yw.forms.NodeInstanceFormData.NodeInstanceData;
+import com.yugabyte.yw.forms.UniverseTaskParams;
+import com.yugabyte.yw.models.NodeInstance;
+import com.yugabyte.yw.models.helpers.CloudSpecificInfo;
+import com.yugabyte.yw.models.helpers.NodeDetails;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.converters.Nullable;
+
+@RunWith(JUnitParamsRunner.class)
+public class UniverseTaskBaseTest extends FakeDBApplication {
+
+    private static final int NUM_NODES = 3;
+    private TestUniverseTaskBase universeTaskBase = new TestUniverseTaskBase();
+
+    private List<NodeDetails> setupNodeDetails(CloudType cloudType, String privateIp) {
+        List<NodeDetails> nodes = new ArrayList<>();
+        for (int i = 0; i < NUM_NODES; i++) {
+            NodeDetails node = new NodeDetails();
+            node.nodeUuid = UUID.randomUUID();
+            node.azUuid = UUID.randomUUID();
+            node.nodeName = "node_" + String.valueOf(i);
+            node.cloudInfo = new CloudSpecificInfo();
+            node.cloudInfo.cloud = cloudType.name();
+            node.cloudInfo.private_ip = privateIp;
+
+            NodeInstance nodeInstance = new NodeInstance();
+            NodeInstanceData details = new NodeInstanceData();
+            details.instanceName = node.nodeName + "_instance";
+            details.ip = "ip";
+            details.nodeName = node.nodeName;
+            details.instanceType = "type";
+            details.zone = "zone";
+            nodeInstance.setDetails(details);
+            nodeInstance.setNodeName(node.nodeName);
+            nodeInstance.nodeUuid = node.nodeUuid;
+            nodeInstance.instanceName = details.instanceName;
+            nodeInstance.zoneUuid = node.azUuid;
+            nodeInstance.inUse = true;
+            nodeInstance.instanceTypeCode = details.instanceType;
+
+            nodeInstance.save();
+            nodes.add(node);
+        }
+        return nodes;
+    }
+
+    @Test
+    // @formatter:off
+    @Parameters({
+                 "aws, 1.1.1.1, false",    // aws with private IP
+                 "aws, null, false",       // aws without private IP
+                 "onprem, 1.1.1.1, false", // onprem with private IP
+                 "onprem, null, true"      // onprem without private IP
+                })
+    // @formatter:on
+    public void testCreateDestroyServerTasks(
+        CloudType cloudType, @Nullable String privateIp,boolean detailsCleanExpected) {
+
+        List<NodeDetails> nodes = setupNodeDetails(cloudType, privateIp);
+        universeTaskBase.createDestroyServerTasks(nodes, false, false);
+        for (int i = 0; i < NUM_NODES; i++) {
+            // Node should not be in use.
+            NodeInstance ni = NodeInstance.get(nodes.get(i).nodeUuid);
+            assertEquals(detailsCleanExpected, !ni.inUse);
+            // If the instance details are cleared then it is not possible to find it by node name
+            try {
+                NodeInstance nodeInstance =  NodeInstance.getByName(nodes.get(i).nodeName);
+                assertFalse(detailsCleanExpected);
+                assertTrue(nodeInstance.inUse);
+            } catch (Exception e) {
+                assertTrue(detailsCleanExpected);
+            }
+        }
+    }
+
+    private static class TestUniverseTaskBase extends UniverseTaskBase {
+
+        public TestUniverseTaskBase() {
+            super();
+            subTaskGroupQueue = new SubTaskGroupQueue(UUID.randomUUID());
+            taskParams = new UniverseTaskParams();
+        }
+
+        @Override
+        public void run() {}
+    }
+}


### PR DESCRIPTION
**Description:** Once we delete the onpremis universe, we have to clear the node instance so that we can use the node to create another universe.

**Testing: :**

1. Add instance under onpremis
2. Created the universe with the instance (should get failed)
3. Delete the universe.
4. Used the same instance to create another universe.
5. The change should not affect anything else.


**Note**: Have not tested in local for 2.4 as the changes are working in master.

**sbt test**

```[info] Passed: Total 1127, Failed 0, Errors 0, Passed 1123, Skipped 4```


**sbt compile**
```[info] Passed: Total 1127, Failed 0, Errors 0, Passed 1123, Skipped 4
mahendra@mahendra-HP-ZBook-14u-G5:~/yugabyte-main/yugabyte-db/managed$ sbt compile
[info] Loading project definition from /home/mahendra/yugabyte-main/yugabyte-db/managed/project
Installing the s3:// URLStreamHandler via java.net.URL.setURLStreamHandlerFactory
Creating a new Ivy URLHandlerDispatcher to handle s3:// URLs
[info] Set current project to yugaware (in build file:/home/mahendra/yugabyte-main/yugabyte-db/managed/)
[info] Executing in batch mode. For better performance use sbt's shell
[success] Total time: 1 s, completed 3 May, 2021 1:56:18 PM```
