### PR TITLE
[#6460] Platform: Preflight checks for AWS cloud provider configuration

### DIFF
--- a/managed/src/main/java/com/yugabyte/yw/cloud/CloudAPI.java
+++ b/managed/src/main/java/com/yugabyte/yw/cloud/CloudAPI.java
@@ -44,4 +44,12 @@ public interface CloudAPI {
     Provider provider,
     Map<Region, Set<String>> azByRegionMap,
     Set<String> instanceTypesFilter);
+
+  /**
+   * Check whether cloud provider's credentials are valid or not.
+   *
+   * @param config The credentials info.
+   * @return true if credentials are valid otherwise return false.
+   */
+  boolean isValidCreds(Map<String, String> config, String region);
 }

--- a/managed/src/main/java/com/yugabyte/yw/cloud/aws/AWSCloudImpl.java
+++ b/managed/src/main/java/com/yugabyte/yw/cloud/aws/AWSCloudImpl.java
@@ -2,8 +2,10 @@ package com.yugabyte.yw.cloud.aws;
 
 import com.amazonaws.auth.*;
 import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.AmazonEC2Client;
 import com.amazonaws.services.ec2.AmazonEC2ClientBuilder;
 import com.amazonaws.services.ec2.model.*;
+import com.amazonaws.regions.Regions;
 import com.google.common.base.Strings;
 import com.yugabyte.yw.cloud.CloudAPI;
 import com.yugabyte.yw.models.Provider;
@@ -13,21 +15,27 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static java.util.stream.Collectors.*;
 
 //TODO - Better handling of UnauthorizedOperation. Ideally we should trigger alert so that
 // site admin knows about it
 class AWSCloudImpl implements CloudAPI {
+  public static final Logger LOG = LoggerFactory.getLogger(AWSCloudImpl.class);
 
   // TODO use aws sdk 2.x and switch to async
   public AmazonEC2 getEcC2Client(Provider provider, Region r) {
-    Map<String, String> config = provider.getConfig();
+    return getEC2ClientInternal(provider.getConfig(), r.code);
+  }
+
+  private AmazonEC2 getEC2ClientInternal(Map<String, String> config, String regionCode) {
     AWSCredentialsProvider credentialsProvider = getCredsOrFallbackToDefault(
       config.get("AWS_ACCESS_KEY_ID"),
       config.get("AWS_SECRET_ACCESS_KEY"));
     return AmazonEC2ClientBuilder.standard()
-      .withRegion(r.code)
+      .withRegion(regionCode)
       .withCredentials(credentialsProvider)
       .build();
   }
@@ -80,5 +88,22 @@ class AWSCloudImpl implements CloudAPI {
     return results.stream().flatMap(result -> result.getInstanceTypeOfferings().stream())
       .collect(groupingBy(InstanceTypeOffering::getInstanceType,
         mapping(InstanceTypeOffering::getLocation, toSet())));
+  }
+
+  @Override
+  public boolean isValidCreds(Map<String, String> config, String region) {
+    try {
+      AmazonEC2 ec2Client = getEC2ClientInternal(config, region);
+      DryRunResult<DescribeInstancesRequest> dryRunResult = ec2Client
+        .dryRun(new DescribeInstancesRequest());
+      if(!dryRunResult.isSuccessful()) {
+        LOG.error(dryRunResult.getDryRunResponse().getMessage());
+        return false;
+      }
+      return dryRunResult.isSuccessful();
+    } catch (Exception e) {
+      LOG.error(e.getMessage());
+      return false;
+    }
   }
 }

--- a/managed/src/main/java/com/yugabyte/yw/forms/CloudProviderFormData.java
+++ b/managed/src/main/java/com/yugabyte/yw/forms/CloudProviderFormData.java
@@ -24,4 +24,6 @@ public class CloudProviderFormData {
     // We would store credentials and other environment
     // settings specific to the provider as a key-value map.
     public Map<String, String> config;
+
+    public String region = null;
 }

--- a/managed/src/test/java/com/yugabyte/yw/controllers/CloudProviderControllerTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/controllers/CloudProviderControllerTest.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.yugabyte.yw.cloud.CloudAPI;
 import com.typesafe.config.Config;
 import com.yugabyte.yw.commissioner.Common;
 import com.yugabyte.yw.commissioner.tasks.CloudBootstrap;
@@ -585,6 +586,24 @@ public class CloudProviderControllerTest extends FakeDBApplication {
     assertEquals("1234", provider.getConfig().get("HOSTED_ZONE_ID"));
     assertEquals("test", provider.getConfig().get("HOSTED_ZONE_NAME"));
     assertAuditEntry(1, customer.uuid);
+  }
+
+  @Test
+  public void testCreateAwsProviderWithInValidAWSCredentials() {
+    ObjectNode bodyJson = Json.newObject();
+    bodyJson.put("code", "aws");
+    bodyJson.put("name", "aws-Provider");
+    bodyJson.put("region", "ap-south-1");
+    ObjectNode configJson = Json.newObject();
+    configJson.put("AWS_ACCESS_KEY_ID", "test");
+    configJson.put("AWS_SECRET_ACCESS_KEY", "secret");
+    configJson.put("AWS_HOSTED_ZONE_ID", "1234");
+    bodyJson.set("config", configJson);
+    CloudAPI mockCloudAPI = mock(CloudAPI.class);
+    when(mockCloudAPIFactory.get(any())).thenReturn(mockCloudAPI);
+    Result result = createProvider(bodyJson);
+    assertBadRequest(result, "Invalid AWS Credentials.");
+    assertAuditEntry(0, customer.uuid);
   }
 
   @Test

--- a/managed/ui/src/actions/cloud.js
+++ b/managed/ui/src/actions/cloud.js
@@ -216,8 +216,8 @@ export function createProvider(type, name, config, regionFormVals = null) {
     config: config,
   };
   if (regionFormVals) {
-      const region = Object.keys(regionFormVals?.perRegionMetadata)[0] || '';
-      formValues['region'] = region;
+    const region = Object.keys(regionFormVals.perRegionMetadata)[0] || '';
+    formValues['region'] = region;
   }
   const request = axios.post(`${ROOT_URL}/customers/${customerUUID}/providers`, formValues);
   return {

--- a/managed/ui/src/actions/cloud.js
+++ b/managed/ui/src/actions/cloud.js
@@ -207,7 +207,7 @@ export function resetProviderList() {
   };
 }
 
-export function createProvider(type, name, config) {
+export function createProvider(type, name, config, regionFormVals = null) {
   const customerUUID = localStorage.getItem('customerId');
   const provider = PROVIDER_TYPES.find((providerType) => providerType.code === type);
   const formValues = {
@@ -215,6 +215,10 @@ export function createProvider(type, name, config) {
     name: name,
     config: config,
   };
+  if (regionFormVals) {
+      const region = Object.keys(regionFormVals?.perRegionMetadata)[0] || '';
+      formValues['region'] = region;
+  }
   const request = axios.post(`${ROOT_URL}/customers/${customerUUID}/providers`, formValues);
   return {
     type: CREATE_PROVIDER,

--- a/managed/ui/src/components/config/PublicCloud/ProviderConfigurationContainer.js
+++ b/managed/ui/src/components/config/PublicCloud/ProviderConfigurationContainer.js
@@ -57,8 +57,8 @@ const mapDispatchToProps = (dispatch) => {
             dispatch(bootstrapProviderResponse(boostrapResponse.payload));
           });
         } else {
-                  const errorMessage = response.payload?.response?.data?.error || response.payload.message;
-                  toast.error(errorMessage);
+          const errorMessage = response.payload?.response?.data?.error || response.payload.message;
+          toast.error(errorMessage);
         }
       });
     },

--- a/managed/ui/src/components/config/PublicCloud/ProviderConfigurationContainer.js
+++ b/managed/ui/src/components/config/PublicCloud/ProviderConfigurationContainer.js
@@ -47,14 +47,18 @@ const mapDispatchToProps = (dispatch) => {
         if (typeof regionFormVals[key] === 'string' || regionFormVals[key] instanceof String)
           regionFormVals[key] = regionFormVals[key].trim();
       });
-      dispatch(createProvider('aws', name.trim(), config)).then((response) => {
+      dispatch(createProvider('aws', name.trim(), config, regionFormVals)).then((response) => {
         dispatch(createProviderResponse(response.payload));
         if (response.payload.status === 200) {
           dispatch(fetchCloudMetadata());
           const providerUUID = response.payload.data.uuid;
           dispatch(bootstrapProvider(providerUUID, regionFormVals)).then((boostrapResponse) => {
+            toast.success('Successfully created AWS Provider!');
             dispatch(bootstrapProviderResponse(boostrapResponse.payload));
           });
+        } else {
+                  const errorMessage = response.payload?.response?.data?.error || response.payload.message;
+                  toast.error(errorMessage);
         }
       });
     },


### PR DESCRIPTION
**Heading:**
[#6460]Platform: Preflight checks for cloud provider configuration
**Description:**
We need to validate the AWS credentials at the time of cloud provider configuration
**Summary**
This change had already been merged into the master but due to itest change failure, we had to revert it back
Already merged PR: https://github.com/yugabyte/yugabyte-db/pull/6948/
Reverted PR: https://github.com/yugabyte/yugabyte-db/pull/7712/

Now we have incorporated the changes required in itest script so we should be good now.
i-test changes PR:  https://phabricator.dev.yugabyte.com/D11540

**Test Plan:**
 We can test this by passing invalid aws access key or secret key while configuring AWS cloud provider.

**SBT Test results:**
Caused by: java.sql.SQLException: HikariDataSource HikariDataSource (HikariPool-1187) has been closed.
	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:96)
	at play.db.ebean.DefaultEbeanConfig$EbeanConfigParser$WrappingDatasource.getConnection(DefaultEbeanConfig.java:153)
	at io.ebeaninternal.server.transaction.TransactionFactoryBasic.createQueryTransaction(TransactionFactoryBasic.java:28)
	... 18 common frames omitted
[info] Passed: Total 1304, Failed 0, Errors 0, Passed 1300, Skipped 4
[success] Total time: 1051 s (17:31), completed 11 May, 2021 6:47:57 PM


For now, we have handled only for AWS provider.