### PR TITLE
[Platform UI] Fixed connect button for K8s-based universes.

### DIFF
--- a/managed/ui/src/components/universes/NodeDetails/NodeConnectModal.js
+++ b/managed/ui/src/components/universes/NodeDetails/NodeConnectModal.js
@@ -42,7 +42,8 @@ class NodeConnectModal extends Component {
 
     if (
       (isEmptyObject(nodeIPs) || currentRow.cloudInfo.cloud !== 'kubernetes') &&
-      !getPromiseState(accessKeys).isSuccess()) {
+      !getPromiseState(accessKeys).isSuccess()
+    ) {
       return <MenuItem>{label}</MenuItem>;
     }
 
@@ -54,7 +55,7 @@ class NodeConnectModal extends Component {
     if (currentRow.cloudInfo.cloud === 'kubernetes') {
       accessTitle = 'Access your pod';
       const podNamespace = currentRow.privateIP.split(".")[2];
-      accessCommand = `kubectl exec -it -n ${podNamespace} ${currentRow.name.split("_")[0]} -- sh`;
+      accessCommand = `kubectl exec -it -n ${podNamespace} ${currentRow.name.split('_')[0]} -- sh`;
     } else {
       accessTitle = 'Access your node';
       const accessKey = accessKeys.data.filter((key) => key.idKey.providerUUID === providerUUID)[0];

--- a/managed/ui/src/components/universes/NodeDetails/NodeConnectModal.js
+++ b/managed/ui/src/components/universes/NodeDetails/NodeConnectModal.js
@@ -40,7 +40,9 @@ class NodeConnectModal extends Component {
     let accessCommand = null;
     let accessTitle = null;
 
-    if (isEmptyObject(nodeIPs) || !getPromiseState(accessKeys).isSuccess()) {
+    if (
+      (isEmptyObject(nodeIPs) || currentRow.cloudInfo.cloud !== 'kubernetes') &&
+      !getPromiseState(accessKeys).isSuccess()) {
       return <MenuItem>{label}</MenuItem>;
     }
 

--- a/managed/ui/src/components/universes/NodeDetails/NodeConnectModal.js
+++ b/managed/ui/src/components/universes/NodeDetails/NodeConnectModal.js
@@ -54,7 +54,7 @@ class NodeConnectModal extends Component {
     if (currentRow.cloudInfo.cloud === 'kubernetes') {
       accessTitle = 'Access your pod';
       const podNamespace = currentRow.privateIP.split(".")[2];
-      accessCommand = `kubectl exec -it -n ${podNamespace} ${currentRow.name} -- sh`;
+      accessCommand = `kubectl exec -it -n ${podNamespace} ${currentRow.name.split("_")[0]} -- sh`;
     } else {
       accessTitle = 'Access your node';
       const accessKey = accessKeys.data.filter((key) => key.idKey.providerUUID === providerUUID)[0];


### PR DESCRIPTION
### Summary

**Issues:** 
- The Connect button wasn't working for the Kubernetes-based universe due to the unavailability of access keys. It works fine if the YW has one k8s based universe & a VM-based cloud-config provider (GCP, AWS). The condition checks for the following parameters - access keys & node IPs.
- YW appends the zone name with pod name in multi-zone deployment so the kubectl command created that has appended name. If the user copies it & runs then it won't work.

**Fix:** 
- Conditional check has been updated & now it has one more condition to check the universe type.
- Extract pod name from the appended nodeName.

### Test Plan

- Spin up the YW UI locally & connected the local UI to the YW container deployed on the GKE cluster.
![image](https://user-images.githubusercontent.com/13635843/117938087-47385200-b324-11eb-87db-d73638d6898a.png)


fixes: https://github.com/yugabyte/yugabyte-db/issues/6681