### PR TITLE
[yugabyte#5781] Don't require checking "force delete" when deleting a universe with a released node

### DIFF
--- a/managed/src/main/java/com/yugabyte/yw/controllers/UniverseController.java
+++ b/managed/src/main/java/com/yugabyte/yw/controllers/UniverseController.java
@@ -942,6 +942,14 @@ public class UniverseController extends AuthenticatedController {
 
   }
 
+  private boolean hasAnyNodeStopped(Universe universe) {
+    for (NodeDetails node : universe.getNodes()) {
+      if (node.state == NodeDetails.NodeState.Stopped) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   public Result destroy(UUID customerUUID, UUID universeUUID) {
     Customer customer = Customer.getOrBadRequest(customerUUID);
@@ -950,6 +958,9 @@ public class UniverseController extends AuthenticatedController {
     boolean isForceDelete = false;
     if (request().getQueryString("isForceDelete") != null) {
       isForceDelete = Boolean.parseBoolean(request().getQueryString("isForceDelete"));
+    }
+    if (hasAnyNodeStopped(universe)) {
+      isForceDelete = true;
     }
     boolean isDeleteBackups = false;
     if (request().getQueryString("isDeleteBackups") != null) {


### PR DESCRIPTION
Automatically sets force delete in the handler function when there is a released node
Fix #5781 
