### PR TITLE
Add format check for Java code under managed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
       - README.md
       - 'docs/**'
       - 'architecture/**'
+      - 'managed/**'
 
   pull_request:
     branches:
@@ -18,6 +19,7 @@ on:
       - README.md
       - 'docs/**'
       - 'architecture/**'
+      - 'managed/**'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/managed-java-checks.yaml
+++ b/.github/workflows/managed-java-checks.yaml
@@ -1,0 +1,38 @@
+name: Lint java code under managed
+
+on:
+  push:
+    branches:
+      - master
+      - '2.6'
+    paths:
+      - .github/workflows/managed-java-checks.yaml
+      - managed/**/*.java
+
+  pull_request:
+    branches:
+      - master
+      - '2.6'
+    paths:
+      - .github/workflows/managed-java-checks.yaml
+      - managed/**/*.java
+
+
+jobs:
+  lint-checks:
+    name: Lint checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 8
+
+      - name: Check formatting
+        run: sbt javafmtCheckAll
+        working-directory: managed/
+


### PR DESCRIPTION
Run an `sbt javafmtCheck` on PRs and pushes.

Also disable the C++ build for managed sub directory.

Test Plan: https://github.com/iSignal/yugabyte-db/actions/runs/875999659