### PR TITLE
[#6945] [Platform] [Backport-2.6] Add limit to customer task API.

### DIFF
--- a/managed/src/main/java/com/yugabyte/yw/common/kms/util/AwsEARServiceUtil.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/kms/util/AwsEARServiceUtil.java
@@ -141,6 +141,7 @@ public class AwsEARServiceUtil {
     } catch (Exception e) {
       String errMsg = "Error occurred retrieving default cmk policy base";
       LOG.error(errMsg, e);
+    }
     return policy;
   }
 

--- a/managed/src/main/java/com/yugabyte/yw/controllers/CustomerTaskController.java
+++ b/managed/src/main/java/com/yugabyte/yw/controllers/CustomerTaskController.java
@@ -2,21 +2,10 @@
 
 package com.yugabyte.yw.controllers;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.Map;
-import java.util.HashMap;
-
-import io.ebean.Ebean;
 import io.ebean.Query;
-import io.ebean.RawSql;
-import io.ebean.RawSqlBuilder;
 
 import com.yugabyte.yw.forms.SubTaskFormData;
 import com.yugabyte.yw.forms.UniverseDefinitionTaskParams;
-import com.yugabyte.yw.models.Audit;
 import com.yugabyte.yw.models.TaskInfo;
 import com.yugabyte.yw.models.Universe;
 import com.yugabyte.yw.models.helpers.TaskType;
@@ -24,7 +13,6 @@ import com.yugabyte.yw.models.helpers.TaskType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.typesafe.config.Config;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.inject.Inject;
@@ -32,14 +20,8 @@ import com.yugabyte.yw.commissioner.Commissioner;
 import com.yugabyte.yw.common.ApiResponse;
 import com.yugabyte.yw.common.config.RuntimeConfigFactory;
 import com.yugabyte.yw.forms.CustomerTaskFormData;
-import com.yugabyte.yw.forms.SubTaskFormData;
-import com.yugabyte.yw.forms.UniverseDefinitionTaskParams;
 import com.yugabyte.yw.forms.UniverseResp;
 import com.yugabyte.yw.models.*;
-import com.yugabyte.yw.models.helpers.TaskType;
-import io.ebean.Query;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import play.libs.Json;
 import play.mvc.Result;
 

--- a/managed/src/main/java/com/yugabyte/yw/controllers/CustomerTaskController.java
+++ b/managed/src/main/java/com/yugabyte/yw/controllers/CustomerTaskController.java
@@ -31,8 +31,7 @@ public class CustomerTaskController extends AuthenticatedController {
 
   @Inject Commissioner commissioner;
 
-  @Inject
-  private RuntimeConfigFactory runtimeConfigFactory;
+  @Inject private RuntimeConfigFactory runtimeConfigFactory;
 
   static final String CUSTOMER_TASK_DB_QUERY_LIMIT = "yb.customer_task_db_query_limit";
 
@@ -65,19 +64,24 @@ public class CustomerTaskController extends AuthenticatedController {
   private Map<UUID, List<CustomerTaskFormData>> fetchTasks(UUID customerUUID, UUID targetUUID) {
     List<CustomerTask> customerTaskList;
 
-    Query<CustomerTask> customerTaskQuery = CustomerTask.find.query().where()
-      .eq("customer_uuid", customerUUID)
-      .orderBy("create_time desc");
+    Query<CustomerTask> customerTaskQuery =
+        CustomerTask.find
+            .query()
+            .where()
+            .eq("customer_uuid", customerUUID)
+            .orderBy("create_time desc");
 
     if (targetUUID != null) {
-      customerTaskQuery.where().eq("target_uuid", targetUUID); 
+      customerTaskQuery.where().eq("target_uuid", targetUUID);
     }
-    
-    customerTaskList = customerTaskQuery.setMaxRows(
-          runtimeConfigFactory.globalRuntimeConf().getInt(CUSTOMER_TASK_DB_QUERY_LIMIT))
-      .orderBy("create_time desc")
-      .findPagedList()
-      .getList();
+
+    customerTaskList =
+        customerTaskQuery
+            .setMaxRows(
+                runtimeConfigFactory.globalRuntimeConf().getInt(CUSTOMER_TASK_DB_QUERY_LIMIT))
+            .orderBy("create_time desc")
+            .findPagedList()
+            .getList();
 
     Map<UUID, List<CustomerTaskFormData>> taskListMap = new HashMap<>();
 

--- a/managed/src/main/java/com/yugabyte/yw/controllers/CustomerTaskController.java
+++ b/managed/src/main/java/com/yugabyte/yw/controllers/CustomerTaskController.java
@@ -79,7 +79,6 @@ public class CustomerTaskController extends AuthenticatedController {
         customerTaskQuery
             .setMaxRows(
                 runtimeConfigFactory.globalRuntimeConf().getInt(CUSTOMER_TASK_DB_QUERY_LIMIT))
-            .orderBy("create_time desc")
             .findPagedList()
             .getList();
 

--- a/managed/src/main/java/com/yugabyte/yw/controllers/CustomerTaskController.java
+++ b/managed/src/main/java/com/yugabyte/yw/controllers/CustomerTaskController.java
@@ -2,12 +2,35 @@
 
 package com.yugabyte.yw.controllers;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.Map;
+import java.util.HashMap;
+
+import io.ebean.Ebean;
+import io.ebean.Query;
+import io.ebean.RawSql;
+import io.ebean.RawSqlBuilder;
+
+import com.yugabyte.yw.forms.SubTaskFormData;
+import com.yugabyte.yw.forms.UniverseDefinitionTaskParams;
+import com.yugabyte.yw.models.Audit;
+import com.yugabyte.yw.models.TaskInfo;
+import com.yugabyte.yw.models.Universe;
+import com.yugabyte.yw.models.helpers.TaskType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.typesafe.config.Config;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.inject.Inject;
 import com.yugabyte.yw.commissioner.Commissioner;
 import com.yugabyte.yw.common.ApiResponse;
+import com.yugabyte.yw.common.config.RuntimeConfigFactory;
 import com.yugabyte.yw.forms.CustomerTaskFormData;
 import com.yugabyte.yw.forms.SubTaskFormData;
 import com.yugabyte.yw.forms.UniverseDefinitionTaskParams;
@@ -25,6 +48,11 @@ import java.util.*;
 public class CustomerTaskController extends AuthenticatedController {
 
   @Inject Commissioner commissioner;
+
+  @Inject
+  private RuntimeConfigFactory runtimeConfigFactory;
+
+  static final String CUSTOMER_TASK_DB_QUERY_LIMIT = "yb.customer_task_db_query_limit";
 
   protected static final int TASK_HISTORY_LIMIT = 6;
   public static final Logger LOG = LoggerFactory.getLogger(CustomerTaskController.class);
@@ -53,22 +81,25 @@ public class CustomerTaskController extends AuthenticatedController {
   }
 
   private Map<UUID, List<CustomerTaskFormData>> fetchTasks(UUID customerUUID, UUID targetUUID) {
-    Query<CustomerTask> customerTaskQuery =
-        CustomerTask.find
-            .query()
-            .where()
-            .eq("customer_uuid", customerUUID)
-            .orderBy("create_time desc");
+    List<CustomerTask> customerTaskList;
+
+    Query<CustomerTask> customerTaskQuery = CustomerTask.find.query().where()
+      .eq("customer_uuid", customerUUID)
+      .orderBy("create_time desc");
 
     if (targetUUID != null) {
-      customerTaskQuery.where().eq("target_uuid", targetUUID);
+      customerTaskQuery.where().eq("target_uuid", targetUUID); 
     }
-
-    Set<CustomerTask> pendingTasks = customerTaskQuery.findSet();
+    
+    customerTaskList = customerTaskQuery.setMaxRows(
+          runtimeConfigFactory.globalRuntimeConf().getInt(CUSTOMER_TASK_DB_QUERY_LIMIT))
+      .orderBy("create_time desc")
+      .findPagedList()
+      .getList();
 
     Map<UUID, List<CustomerTaskFormData>> taskListMap = new HashMap<>();
 
-    for (CustomerTask task : pendingTasks) {
+    for (CustomerTask task : customerTaskList) {
       try {
         CustomerTaskFormData taskData = new CustomerTaskFormData();
 

--- a/managed/src/main/resources/reference.conf
+++ b/managed/src/main/resources/reference.conf
@@ -110,6 +110,8 @@ yb {
     use_oauth = false
     oidcEmailAttribute = ""
   }
+
+  customer_task_db_query_limit = 2000
 }
 
 runtime_config {
@@ -118,6 +120,7 @@ runtime_config {
       "yb.taskGC."
       "yb.alert.max_clock_skew_ms"
       "yb.proxy_endpoint_timeout"
+      "yb.customer_task_db_query_limit"
   ]
   excluded_paths = [
   ]

--- a/managed/src/test/java/com/yugabyte/yw/controllers/CustomerTaskControllerTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/controllers/CustomerTaskControllerTest.java
@@ -10,6 +10,8 @@ import com.yugabyte.yw.commissioner.UserTaskDetails;
 import com.yugabyte.yw.common.FakeApiHelper;
 import com.yugabyte.yw.common.FakeDBApplication;
 import com.yugabyte.yw.common.ModelFactory;
+import com.yugabyte.yw.common.config.impl.RuntimeConfig;
+import com.yugabyte.yw.common.config.impl.SettableRuntimeConfigFactory;
 import com.yugabyte.yw.models.Customer;
 import com.yugabyte.yw.models.CustomerTask;
 
@@ -19,6 +21,9 @@ import com.yugabyte.yw.models.Users;
 import com.yugabyte.yw.models.helpers.TaskType;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
+
+import io.ebean.Model;
 import play.Application;
 import play.inject.guice.GuiceApplicationBuilder;
 import play.libs.Json;
@@ -27,6 +32,7 @@ import play.test.WithApplication;
 import play.test.Helpers;
 
 import java.util.Calendar;
+import java.util.stream.IntStream;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -50,17 +56,31 @@ import static play.mvc.Http.Status.FORBIDDEN;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.fakeRequest;
 import static play.test.Helpers.route;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.InjectMocks;
 
+@RunWith(MockitoJUnitRunner.class)
 public class CustomerTaskControllerTest extends FakeDBApplication {
   private Customer customer;
   private Users user;
   private Universe universe;
+
+  @Mock
+  private RuntimeConfig<Model> config;
+
+  @Mock
+  SettableRuntimeConfigFactory mockRuntimeConfigFactory;
+
+  @InjectMocks
+  private CustomerTaskController controller;
 
   @Before
   public void setUp() {
     customer = ModelFactory.testCustomer();
     user = ModelFactory.testUser(customer);
     universe = createUniverse(customer.getCustomerId());
+    when(mockRuntimeConfigFactory.globalRuntimeConf()).thenReturn(config);
   }
 
   @Test
@@ -304,6 +324,24 @@ public class CustomerTaskControllerTest extends FakeDBApplication {
     assertTrue(universeTasks.isArray());
     assertEquals(1, universeTasks.size());
     assertValues(universeTasks, "id", ImmutableList.of(taskUUID1.toString()));
+    assertAuditEntry(0, customer.uuid);
+  }
+
+  @Test
+  public void testTaskHistoryLimit() {
+    String authToken = user.createAuthToken();
+    Universe universe1 = createUniverse("Universe 2", customer.getCustomerId());
+    when(config.getInt(CustomerTaskController.CUSTOMER_TASK_DB_QUERY_LIMIT))
+      .thenReturn(25);
+    IntStream.range(0, 100).forEach(i -> createTaskWithStatus(
+        universe.universeUUID, CustomerTask.TargetType.Universe, Create, "Foo", "Running", 50.0));
+    Result result = controller.list(customer.uuid);
+    assertEquals(OK, result.status());
+    JsonNode json = Json.parse(contentAsString(result));
+    assertTrue(json.isObject());
+    JsonNode universeTasks = json.get(universe.universeUUID.toString());
+    assertTrue(universeTasks.isArray());
+    assertEquals(25, universeTasks.size());
     assertAuditEntry(0, customer.uuid);
   }
 

--- a/managed/src/test/java/com/yugabyte/yw/controllers/CustomerTaskControllerTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/controllers/CustomerTaskControllerTest.java
@@ -66,14 +66,11 @@ public class CustomerTaskControllerTest extends FakeDBApplication {
   private Users user;
   private Universe universe;
 
-  @Mock
-  private RuntimeConfig<Model> config;
+  @Mock private RuntimeConfig<Model> config;
 
-  @Mock
-  SettableRuntimeConfigFactory mockRuntimeConfigFactory;
+  @Mock SettableRuntimeConfigFactory mockRuntimeConfigFactory;
 
-  @InjectMocks
-  private CustomerTaskController controller;
+  @InjectMocks private CustomerTaskController controller;
 
   @Before
   public void setUp() {
@@ -331,10 +328,17 @@ public class CustomerTaskControllerTest extends FakeDBApplication {
   public void testTaskHistoryLimit() {
     String authToken = user.createAuthToken();
     Universe universe1 = createUniverse("Universe 2", customer.getCustomerId());
-    when(config.getInt(CustomerTaskController.CUSTOMER_TASK_DB_QUERY_LIMIT))
-      .thenReturn(25);
-    IntStream.range(0, 100).forEach(i -> createTaskWithStatus(
-        universe.universeUUID, CustomerTask.TargetType.Universe, Create, "Foo", "Running", 50.0));
+    when(config.getInt(CustomerTaskController.CUSTOMER_TASK_DB_QUERY_LIMIT)).thenReturn(25);
+    IntStream.range(0, 100)
+        .forEach(
+            i ->
+                createTaskWithStatus(
+                    universe.universeUUID,
+                    CustomerTask.TargetType.Universe,
+                    Create,
+                    "Foo",
+                    "Running",
+                    50.0));
     Result result = controller.list(customer.uuid);
     assertEquals(OK, result.status());
     JsonNode json = Json.parse(contentAsString(result));

--- a/managed/src/test/java/com/yugabyte/yw/controllers/CustomerTaskControllerTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/controllers/CustomerTaskControllerTest.java
@@ -10,8 +10,8 @@ import com.yugabyte.yw.commissioner.UserTaskDetails;
 import com.yugabyte.yw.common.FakeApiHelper;
 import com.yugabyte.yw.common.FakeDBApplication;
 import com.yugabyte.yw.common.ModelFactory;
+import com.yugabyte.yw.common.config.RuntimeConfigFactory;
 import com.yugabyte.yw.common.config.impl.RuntimeConfig;
-import com.yugabyte.yw.common.config.impl.SettableRuntimeConfigFactory;
 import com.yugabyte.yw.models.Customer;
 import com.yugabyte.yw.models.CustomerTask;
 
@@ -68,7 +68,7 @@ public class CustomerTaskControllerTest extends FakeDBApplication {
 
   @Mock private RuntimeConfig<Model> config;
 
-  @Mock SettableRuntimeConfigFactory mockRuntimeConfigFactory;
+  @Mock RuntimeConfigFactory mockRuntimeConfigFactory;
 
   @InjectMocks private CustomerTaskController controller;
 


### PR DESCRIPTION
Description:
We could make the tasks UI more functional by adding a LIMIT 2000 to our tasks DB query, so we don't end up with a spinning task UI for Platform instances that accumulate many tasks over time.
Currently it is set to 2000 in reference.conf.

Original Commit: [https://github.com/yugabyte/yugabyte-db/pull/7477] (57d835e9c13c92cf2feaaa716d5f08e6cdef9442)

Test Plan:

Updated reference.conf to 20.
Verified whether the API returning only 20 entries or not.
Also verified the working endpoint of a particular task.
Verified by creating 10 + tasks and verified pagination in UI too.


sbt test

```	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:96)
	at play.db.ebean.DefaultEbeanConfig$EbeanConfigParser$WrappingDatasource.getConnection(DefaultEbeanConfig.java:153)
	at io.ebeaninternal.server.transaction.TransactionFactoryBasic.createQueryTransaction(TransactionFactoryBasic.java:28)
	... 18 common frames omitted
[info] Passed: Total 1305, Failed 0, Errors 0, Passed 1301, Skipped 4
[success] Total time: 919 s (15:19), completed 26 May, 2021 4:44:34 PM
mahendra@mahendra-HP-ZBook-14u-G5:~/yugabyte/yugabyte-db/managed$ git branch
  6373-Pause-Universe
  6373-Pause-Universe-backup
  6373_PauseUniverse
  6540-Remove-Certificate
  6555-manual-backup-retention
  6756-Invalid-Date-V2
  6758-Reuse-Onpremis
  6758-Reuse-Onpremis-V2
* 6945-Limit-TAsk-Queries-2.6
  6945-Limit-Task-Queries
```