### PR TITLE
[#8620] [Platform] [Backport-2.4] Reset the values on cancel.

### DIFF
--- a/managed/ui/src/components/config/Storage/AwsStorageConfiguration.js
+++ b/managed/ui/src/components/config/Storage/AwsStorageConfiguration.js
@@ -11,14 +11,6 @@ import YBInfoTip from '../../common/descriptors/YBInfoTip';
 const required = (value) => value ? undefined : 'This field is required.';
 
 class AwsStorageConfiguration extends Component {
-  state = {
-    iamRoleEnabled: false
-  };
-
-  iamInstanceToggle = (event) => {
-    this.setState({ iamRoleEnabled: event.target.checked });
-  };
-
   disabledInputFields = (config, isEdited, iamRoleEnabled = false) => {
     if (
       ((!isEmptyObject(config) && isEdited) || (isEmptyObject(config) && !isEdited)) &&
@@ -49,9 +41,10 @@ class AwsStorageConfiguration extends Component {
       deleteStorageConfig,
       showDeleteStorageConfig,
       enableEdit,
-      onEditConfig
+      onEditConfig,
+      iamInstanceToggle,
+      iamRoleEnabled
     } = this.props;
-    const { iamRoleEnabled } = this.state;
     const s3Config = customerConfigs.data.find((config) => config.name === 'S3');
     const config = s3Config ? s3Config.data : {};
 
@@ -66,7 +59,7 @@ class AwsStorageConfiguration extends Component {
               <Field
                 name="IAM_INSTANCE_PROFILE"
                 component={YBToggle}
-                onToggle={this.iamInstanceToggle}
+                onToggle={iamInstanceToggle}
                 isReadOnly={this.disabledInputFields(s3Config, enableEdit)}
                 subLabel="Whether to use instance's IAM role for S3 backup."
               />

--- a/managed/ui/src/components/config/Storage/AwsStorageConfiguration.js
+++ b/managed/ui/src/components/config/Storage/AwsStorageConfiguration.js
@@ -196,7 +196,7 @@ class AwsStorageConfiguration extends Component {
               <YBButton
                 btnText="Edit Configuration"
                 btnClass="btn btn-orange"
-                onClick={onEditConfig}
+                onClick={() => onEditConfig(config)}
               />
               {isDefinedNotNull(config) && (
                 <YBConfirmModal

--- a/managed/ui/src/components/config/Storage/StorageConfiguration.js
+++ b/managed/ui/src/components/config/Storage/StorageConfiguration.js
@@ -92,12 +92,18 @@ class StorageConfiguration extends Component {
     super(props);
 
     this.state = {
-      enableEdit: false
+      enableEdit: false,
+      iamRoleEnabled: false
     };
   }
 
+  iamInstanceToggle = (event) => {
+    console.log(event.target.checked, '****** iam toogle');
+    this.setState({ iamRoleEnabled: event.target.checked });
+  };
+
   getConfigByType = (name, customerConfigs) => {
-    return customerConfigs.data.find((config) => config.name.toLowerCase() === name);
+    return customerConfigs?.data?.find((config) => config.name.toLowerCase() === name);
   };
 
   wrapFields = (configFields, configName, configControls) => {
@@ -205,6 +211,11 @@ class StorageConfiguration extends Component {
   };
 
   deleteStorageConfig = (configUUID) => {
+    this.setState({
+      enableEdit: false,
+      iamRoleEnabled: !this.state.iamRoleEnabled
+    });
+
     this.props.deleteCustomerConfig(configUUID).then(() => {
       this.props.reset(); // reset form to initial values
       this.props.fetchCustomerConfigs();
@@ -231,7 +242,11 @@ class StorageConfiguration extends Component {
    * This method will disable the edit input fields.
    */
   disableEditFields = () => {
-    this.setState({ enableEdit: false });
+    this.props.reset();
+    this.setState({
+      enableEdit: false,
+      iamRoleEnabled: !this.state.iamRoleEnabled
+    });
   };
 
   /**
@@ -324,7 +339,7 @@ class StorageConfiguration extends Component {
       customerConfigs,
       initialValues
     } = this.props;
-    const { enableEdit } = this.state;
+    const { enableEdit, iamRoleEnabled } = this.state;
     const activeTab = this.props.activeTab || Object.keys(storageConfigTypes)[0].toLowerCase();
     const config = this.getConfigByType(activeTab, customerConfigs);
 
@@ -347,6 +362,8 @@ class StorageConfiguration extends Component {
           <AwsStorageConfiguration
             {...this.props}
             deleteStorageConfig={this.deleteStorageConfig}
+            iamRoleEnabled={iamRoleEnabled}
+            iamInstanceToggle={this.iamInstanceToggle}
             enableEdit={enableEdit}
             onEditConfig={this.onEditConfig}
           />

--- a/managed/ui/src/components/config/Storage/StorageConfiguration.js
+++ b/managed/ui/src/components/config/Storage/StorageConfiguration.js
@@ -234,8 +234,11 @@ class StorageConfiguration extends Component {
    * This method will enable edit options for respective
    * backup config.
    */
-  onEditConfig = () => {
-    this.setState({ enableEdit: true });
+  onEditConfig = (config) => {
+    this.setState({
+      enableEdit: true,
+      iamRoleEnabled: config?.IAM_INSTANCE_PROFILE || this.state.iamRoleEnabled
+    });
   };
 
   /**
@@ -365,7 +368,7 @@ class StorageConfiguration extends Component {
             iamRoleEnabled={iamRoleEnabled}
             iamInstanceToggle={this.iamInstanceToggle}
             enableEdit={enableEdit}
-            onEditConfig={this.onEditConfig}
+            onEditConfig={(config) => this.onEditConfig(config)}
           />
         </Tab>
       ];


### PR DESCRIPTION
**Description:**
Backup -> Edit configuration. I edited something in the AWS key but I clicked cancel, though the value is not saved, the values I edited are still showing up. Once I reload the page, the edited values are gone and original (saved) values are shown, which is correct. It's good to reload the original values if cancel clicked rather than showing the edited values.

**Test Plan:**

1. Click on config from the side nav.
2. Go to Backup-> AWS.
3. Create a new Backup config.
4. Hit the Edit configuration button.
5. Change some values and hit the Cancel button.

Check if it's restoring the original values or not.