### PR TITLE
[#8611] [Platform] [Backport-2.4] Enable edit backup configuration for the active tab only. 

### DIFF
--- a/managed/ui/src/components/config/Storage/AwsStorageConfiguration.js
+++ b/managed/ui/src/components/config/Storage/AwsStorageConfiguration.js
@@ -11,9 +11,9 @@ import YBInfoTip from '../../common/descriptors/YBInfoTip';
 const required = (value) => value ? undefined : 'This field is required.';
 
 class AwsStorageConfiguration extends Component {
-  disabledInputFields = (config, isEdited, iamRoleEnabled = false) => {
+  disabledInputFields = (config, editingTab, iamRoleEnabled = false) => {
     if (
-      ((!isEmptyObject(config) && isEdited) || (isEmptyObject(config) && !isEdited)) &&
+      ((!isEmptyObject(config) && editingTab === 's3') || (isEmptyObject(config) && editingTab !== 's3')) &&
       !iamRoleEnabled
     ) {
       return false;
@@ -40,7 +40,7 @@ class AwsStorageConfiguration extends Component {
       addConfig: { loading },
       deleteStorageConfig,
       showDeleteStorageConfig,
-      enableEdit,
+      editingTab,
       onEditConfig,
       iamInstanceToggle,
       iamRoleEnabled
@@ -60,7 +60,7 @@ class AwsStorageConfiguration extends Component {
                 name="IAM_INSTANCE_PROFILE"
                 component={YBToggle}
                 onToggle={iamInstanceToggle}
-                isReadOnly={this.disabledInputFields(s3Config, enableEdit)}
+                isReadOnly={this.disabledInputFields(s3Config, editingTab)}
                 subLabel="Whether to use instance's IAM role for S3 backup."
               />
             </Col>
@@ -75,7 +75,7 @@ class AwsStorageConfiguration extends Component {
                   name="AWS_ACCESS_KEY_ID"
                   placeHolder="AWS Access Key"
                   component={YBTextInputWithLabel}
-                  isReadOnly={this.disabledInputFields(s3Config, enableEdit, iamRoleEnabled)}
+                  isReadOnly={this.disabledInputFields(s3Config, editingTab, iamRoleEnabled)}
                 />
               ) : (
                 <Field
@@ -83,7 +83,7 @@ class AwsStorageConfiguration extends Component {
                   placeHolder="AWS Access Key"
                   component={YBTextInputWithLabel}
                   validate={required}
-                  isReadOnly={this.disabledInputFields(s3Config, enableEdit, iamRoleEnabled)}
+                  isReadOnly={this.disabledInputFields(s3Config, editingTab, iamRoleEnabled)}
                 />
               )}
             </Col>
@@ -98,7 +98,7 @@ class AwsStorageConfiguration extends Component {
                   name="AWS_SECRET_ACCESS_KEY"
                   placeHolder="AWS Access Secret"
                   component={YBTextInputWithLabel}
-                  isReadOnly={this.disabledInputFields(s3Config, enableEdit, iamRoleEnabled)}
+                  isReadOnly={this.disabledInputFields(s3Config, editingTab, iamRoleEnabled)}
                 />
               ) : (
                 <Field
@@ -106,7 +106,7 @@ class AwsStorageConfiguration extends Component {
                   placeHolder="AWS Access Secret"
                   component={YBTextInputWithLabel}
                   validate={required}
-                  isReadOnly={this.disabledInputFields(s3Config, enableEdit, iamRoleEnabled)}
+                  isReadOnly={this.disabledInputFields(s3Config, editingTab, iamRoleEnabled)}
                 />
               )}
             </Col>
@@ -185,7 +185,7 @@ class AwsStorageConfiguration extends Component {
               )}
               <YBButton
                 btnText={'Delete Configuration'}
-                disabled={s3Config.inUse || submitting || loading || enableEdit}
+                disabled={s3Config.inUse || submitting || loading || editingTab === 's3'}
                 btnClass={'btn btn-default'}
                 onClick={
                   !isEmptyObject(s3Config)
@@ -203,7 +203,7 @@ class AwsStorageConfiguration extends Component {
                   name="delete-storage-config"
                   title={'Confirm Delete'}
                   type="reset"
-                  onConfirm={() => deleteStorageConfig(s3Config.configUUID, 's3')}
+                  onConfirm={() => deleteStorageConfig(s3Config.configUUID)}
                   currentModal={'delete' + s3Config.name + 'StorageConfig'}
                   visibleModal={this.props.visibleModal}
                   hideConfirmModal={this.props.hideDeleteStorageConfig}

--- a/managed/ui/src/components/config/Storage/AwsStorageConfiguration.js
+++ b/managed/ui/src/components/config/Storage/AwsStorageConfiguration.js
@@ -196,14 +196,14 @@ class AwsStorageConfiguration extends Component {
               <YBButton
                 btnText="Edit Configuration"
                 btnClass="btn btn-orange"
-                onClick={() => onEditConfig(config)}
+                onClick={() => onEditConfig(config, 's3')}
               />
               {isDefinedNotNull(config) && (
                 <YBConfirmModal
                   name="delete-storage-config"
                   title={'Confirm Delete'}
                   type="reset"
-                  onConfirm={() => deleteStorageConfig(s3Config.configUUID)}
+                  onConfirm={() => deleteStorageConfig(s3Config.configUUID, 's3')}
                   currentModal={'delete' + s3Config.name + 'StorageConfig'}
                   visibleModal={this.props.visibleModal}
                   hideConfirmModal={this.props.hideDeleteStorageConfig}

--- a/managed/ui/src/components/config/Storage/StorageConfiguration.js
+++ b/managed/ui/src/components/config/Storage/StorageConfiguration.js
@@ -92,12 +92,7 @@ class StorageConfiguration extends Component {
     super(props);
 
     this.state = {
-      enableEdit: {
-        s3: false,
-        nfs: false,
-        gcs: false,
-        az: false
-      },
+      editingTab: '',
       iamRoleEnabled: false
     };
   }
@@ -175,12 +170,7 @@ class StorageConfiguration extends Component {
     }
 
     if (values.type === 'update') {
-      this.setState({
-        enableEdit: {
-          ...this.state.enableEdit,
-          [props.activeTab]: false
-        }
-      });
+      this.setState({ editingTab: false });
       return this.props
         .updateCustomerConfig({
           type: 'STORAGE',
@@ -199,12 +189,7 @@ class StorageConfiguration extends Component {
           }
         });
     } else {
-      this.setState({
-        enableEdit: {
-          ...this.state.enableEdit,
-          [props.activeTab]: false
-        }
-      });
+      this.setState({ editingTab: false });
       return this.props
         .addCustomerConfig({
           type: 'STORAGE',
@@ -224,12 +209,9 @@ class StorageConfiguration extends Component {
     }
   };
 
-  deleteStorageConfig = (configUUID, activeTab) => {
+  deleteStorageConfig = (configUUID) => {
     this.setState({
-      enableEdit: {
-        ...this.state.enableEdit,
-        [activeTab]: false
-      },
+      editingTab: false,
       iamRoleEnabled: false
     });
 
@@ -253,10 +235,7 @@ class StorageConfiguration extends Component {
    */
   onEditConfig = (config, activeTab) => {
     this.setState({
-      enableEdit: {
-        ...this.state.enableEdit,
-        [activeTab]: true
-      },
+      editingTab: activeTab,
       iamRoleEnabled: config?.IAM_INSTANCE_PROFILE || this.state.iamRoleEnabled
     });
   };
@@ -264,13 +243,10 @@ class StorageConfiguration extends Component {
   /**
    * This method will disable the edit input fields.
    */
-  disableEditFields = (activeTab) => {
+  disableEditFields = () => {
     this.props.reset();
     this.setState({
-      enableEdit: {
-        ...this.state.enableEdit,
-        [activeTab]: false
-      },
+      editingTab: false,
       iamRoleEnabled: !this.state.iamRoleEnabled
     });
   };
@@ -282,9 +258,9 @@ class StorageConfiguration extends Component {
    * @param {string} fieldKey Input Field Id.
    * @returns Boolean.
    */
-  disableInputFields = (fieldKey, enableEdit, activeTab) => {
+  disableInputFields = (fieldKey, activeTab, editingTab) => {
     const tab = activeTab.toUpperCase();
-    return !enableEdit || fieldKey === `${tab}_BACKUP_LOCATION` ? true : false;
+    return editingTab !== activeTab || fieldKey === `${tab}_BACKUP_LOCATION` ? true : false;
   };
 
   /**
@@ -366,8 +342,8 @@ class StorageConfiguration extends Component {
       initialValues
     } = this.props;
     const {
-      enableEdit,
-      iamRoleEnabled
+      iamRoleEnabled,
+      editingTab
     } = this.state;
     const activeTab = this.props.activeTab || Object.keys(storageConfigTypes)[0].toLowerCase();
     const config = this.getConfigByType(activeTab, customerConfigs);
@@ -393,7 +369,7 @@ class StorageConfiguration extends Component {
             deleteStorageConfig={this.deleteStorageConfig}
             iamRoleEnabled={iamRoleEnabled}
             iamInstanceToggle={this.iamInstanceToggle}
-            enableEdit={enableEdit[activeTab]}
+            editingTab={editingTab}
             onEditConfig={this.onEditConfig}
           />
         </Tab>
@@ -427,7 +403,7 @@ class StorageConfiguration extends Component {
                     name={field.id}
                     placeHolder={field.placeHolder}
                     component={YBTextInputWithLabel}
-                    isReadOnly={this.disableInputFields(field.id, enableEdit[activeTab], activeTab)}
+                    isReadOnly={this.disableInputFields(field.id, activeTab, editingTab)}
                   />
                 </Col>
               </Row>
@@ -456,7 +432,7 @@ class StorageConfiguration extends Component {
                   submitting ||
                   loading ||
                   isEmptyObject(config) ||
-                  (enableEdit[activeTab] && activeTab !== 'nfs')
+                  (editingTab === activeTab && activeTab !== 'nfs')
                 }
                 btnClass={'btn btn-default'}
                 onClick={
@@ -476,7 +452,7 @@ class StorageConfiguration extends Component {
                 <YBConfirmModal
                   name="delete-storage-config"
                   title={'Confirm Delete'}
-                  onConfirm={handleSubmit(this.deleteStorageConfig.bind(this, config.configUUID, activeTab))}
+                  onConfirm={handleSubmit(this.deleteStorageConfig.bind(this, config.configUUID))}
                   currentModal={'delete' + config.name + 'StorageConfig'}
                   visibleModal={this.props.visibleModal}
                   hideConfirmModal={this.props.hideDeleteStorageConfig}
@@ -536,14 +512,14 @@ class StorageConfiguration extends Component {
                   />
                 ) : (
                   <>
-                    {enableEdit[activeTab] && activeTab !== 'nfs' && (
+                    {editingTab === activeTab && activeTab !== 'nfs' && (
                       <YBButton btnText="Update" btnClass={'btn btn-orange'} btnType="submit" />
                     )}
-                    {enableEdit[activeTab] && activeTab !== 'nfs' && (
+                    {editingTab === activeTab && activeTab !== 'nfs' && (
                       <YBButton
                         btnText="Cancel"
                         btnClass={'btn btn-default'}
-                        onClick={() => this.disableEditFields(activeTab)}
+                        onClick={this.disableEditFields}
                       />
                     )}
                   </>

--- a/managed/ui/src/components/config/Storage/StorageConfiguration.js
+++ b/managed/ui/src/components/config/Storage/StorageConfiguration.js
@@ -92,7 +92,12 @@ class StorageConfiguration extends Component {
     super(props);
 
     this.state = {
-      enableEdit: false,
+      enableEdit: {
+        s3: false,
+        nfs: false,
+        gcs: false,
+        az: false
+      },
       iamRoleEnabled: false
     };
   }
@@ -170,7 +175,12 @@ class StorageConfiguration extends Component {
     }
 
     if (values.type === 'update') {
-      this.setState({ enableEdit: false });
+      this.setState({
+        enableEdit: {
+          ...this.state.enableEdit,
+          [props.activeTab]: false
+        }
+      });
       return this.props
         .updateCustomerConfig({
           type: 'STORAGE',
@@ -189,7 +199,12 @@ class StorageConfiguration extends Component {
           }
         });
     } else {
-      this.setState({ enableEdit: false });
+      this.setState({
+        enableEdit: {
+          ...this.state.enableEdit,
+          [props.activeTab]: false
+        }
+      });
       return this.props
         .addCustomerConfig({
           type: 'STORAGE',
@@ -209,10 +224,13 @@ class StorageConfiguration extends Component {
     }
   };
 
-  deleteStorageConfig = (configUUID) => {
+  deleteStorageConfig = (configUUID, activeTab) => {
     this.setState({
-      enableEdit: false,
-      iamRoleEnabled: !this.state.iamRoleEnabled
+      enableEdit: {
+        ...this.state.enableEdit,
+        [activeTab]: false
+      },
+      iamRoleEnabled: false
     });
 
     this.props.deleteCustomerConfig(configUUID).then(() => {
@@ -233,9 +251,12 @@ class StorageConfiguration extends Component {
    * This method will enable edit options for respective
    * backup config.
    */
-  onEditConfig = (config) => {
+  onEditConfig = (config, activeTab) => {
     this.setState({
-      enableEdit: true,
+      enableEdit: {
+        ...this.state.enableEdit,
+        [activeTab]: true
+      },
       iamRoleEnabled: config?.IAM_INSTANCE_PROFILE || this.state.iamRoleEnabled
     });
   };
@@ -243,10 +264,13 @@ class StorageConfiguration extends Component {
   /**
    * This method will disable the edit input fields.
    */
-  disableEditFields = () => {
+  disableEditFields = (activeTab) => {
     this.props.reset();
     this.setState({
-      enableEdit: false,
+      enableEdit: {
+        ...this.state.enableEdit,
+        [activeTab]: false
+      },
       iamRoleEnabled: !this.state.iamRoleEnabled
     });
   };
@@ -341,7 +365,10 @@ class StorageConfiguration extends Component {
       customerConfigs,
       initialValues
     } = this.props;
-    const { enableEdit, iamRoleEnabled } = this.state;
+    const {
+      enableEdit,
+      iamRoleEnabled
+    } = this.state;
     const activeTab = this.props.activeTab || Object.keys(storageConfigTypes)[0].toLowerCase();
     const config = this.getConfigByType(activeTab, customerConfigs);
 
@@ -366,8 +393,8 @@ class StorageConfiguration extends Component {
             deleteStorageConfig={this.deleteStorageConfig}
             iamRoleEnabled={iamRoleEnabled}
             iamInstanceToggle={this.iamInstanceToggle}
-            enableEdit={enableEdit}
-            onEditConfig={(config) => this.onEditConfig(config)}
+            enableEdit={enableEdit[activeTab]}
+            onEditConfig={this.onEditConfig}
           />
         </Tab>
       ];
@@ -400,7 +427,7 @@ class StorageConfiguration extends Component {
                     name={field.id}
                     placeHolder={field.placeHolder}
                     component={YBTextInputWithLabel}
-                    isReadOnly={this.disableInputFields(field.id, enableEdit, activeTab)}
+                    isReadOnly={this.disableInputFields(field.id, enableEdit[activeTab], activeTab)}
                   />
                 </Col>
               </Row>
@@ -429,7 +456,7 @@ class StorageConfiguration extends Component {
                   submitting ||
                   loading ||
                   isEmptyObject(config) ||
-                  (enableEdit && activeTab !== 'nfs')
+                  (enableEdit[activeTab] && activeTab !== 'nfs')
                 }
                 btnClass={'btn btn-default'}
                 onClick={
@@ -442,14 +469,14 @@ class StorageConfiguration extends Component {
                 <YBButton
                   btnText="Edit Configuration"
                   btnClass="btn btn-orange"
-                  onClick={this.onEditConfig}
+                  onClick={() => this.onEditConfig('', activeTab)}
                 />
               )}
               {isDefinedNotNull(config) && (
                 <YBConfirmModal
                   name="delete-storage-config"
                   title={'Confirm Delete'}
-                  onConfirm={handleSubmit(this.deleteStorageConfig.bind(this, config.configUUID))}
+                  onConfirm={handleSubmit(this.deleteStorageConfig.bind(this, config.configUUID, activeTab))}
                   currentModal={'delete' + config.name + 'StorageConfig'}
                   visibleModal={this.props.visibleModal}
                   hideConfirmModal={this.props.hideDeleteStorageConfig}
@@ -509,14 +536,14 @@ class StorageConfiguration extends Component {
                   />
                 ) : (
                   <>
-                    {enableEdit && activeTab !== 'nfs' && (
+                    {enableEdit[activeTab] && activeTab !== 'nfs' && (
                       <YBButton btnText="Update" btnClass={'btn btn-orange'} btnType="submit" />
                     )}
-                    {enableEdit && activeTab !== 'nfs' && (
+                    {enableEdit[activeTab] && activeTab !== 'nfs' && (
                       <YBButton
                         btnText="Cancel"
                         btnClass={'btn btn-default'}
-                        onClick={this.disableEditFields}
+                        onClick={() => this.disableEditFields(activeTab)}
                       />
                     )}
                   </>


### PR DESCRIPTION
**Description:**
When the users will hit the Edit configuration button from a particular backup config then the other tabs also enables the editing even though you clicked it or not. So it shouldn't happen. Edit config will only allow editing the backup config of the respective tab.

**Test Plan:**

1. Click config from the side nav.
2. Hit the backup tab and create backup configs for the respective tabs.
3. Then go to one of the tabs and hit the edit-config button.
4. Without saving it or cancelling it go to another tab and see if edit-config is available or not. If yes then it's a bug otherwise we're good to go.