### PR TITLE
Initial support for clang build on ubuntu

### DIFF
--- a/build-support/common-build-env.sh
+++ b/build-support/common-build-env.sh
@@ -966,6 +966,7 @@ find_compiler_by_type() {
           # the transition to Linuxbrew (https://phabricator.dev.yugabyte.com/D982). This can be
           # removed when the transition is complete.
           "$YB_THIRDPARTY_DIR/installed/common/bin/clang"
+          "/usr/bin/clang"
         )
         for clang_path in "${clang_paths_to_try[@]}"; do
           if [[ -f $clang_path ]]; then
@@ -2318,6 +2319,10 @@ set_prebuilt_thirdparty_url() {
     if [[ ${YB_COMPILER_TYPE} =~ ^.*[0-9]+$ ]]; then
       # For compiler types like gcc9 or clang11, append the compiler type to the file path.
       thirdparty_url_file+="_${YB_COMPILER_TYPE}"
+    fi
+    if [[ $YB_COMPILER_TYPE == "clang" ]]
+    then
+      thirdparty_url_file+="_clang11"
     fi
     if [[ $YB_COMPILER_TYPE == "clang" && ( $build_type == "asan" || $build_type == "tsan" ) ]]
     then

--- a/build-support/thirdparty_url_ubuntu_clang11.txt
+++ b/build-support/thirdparty_url_ubuntu_clang11.txt
@@ -1,0 +1,1 @@
+https://github.com/yugabyte/yugabyte-db-thirdparty/releases/download/v20210520175442-8aebe87f79-ubuntu2004-clang11/yugabyte-db-thirdparty-v20210520175442-8aebe87f79-ubuntu2004-clang11.tar.gz


### PR DESCRIPTION
Fixes #7735 

With this change I'm able to build with clang on ubuntu 20.04, at least the unversioned package installation using `apt install clang`.

Tested with successful debug and release builds with (for example) the command `./yb_build.sh --clean --clean-thirdparty release --clang`

Note that this may not address other configurations such as clang10, clang11 on other versions of ubuntu because I am unable to test at this time.
