### PR TITLE
[#8619] Log index table name instead of index id

### DIFF
--- a/src/yb/master/backfill_index.cc
+++ b/src/yb/master/backfill_index.cc
@@ -635,7 +635,8 @@ std::unordered_set<TableId> IndexIdsFromInfos(const std::vector<IndexInfoPB>& in
   return idx_ids;
 }
 
-std::string RetrieveIndexNames(CatalogManager* mgr, const std::unordered_set<std::string>& index_ids) {
+std::string RetrieveIndexNames(CatalogManager* mgr,
+                               const std::unordered_set<std::string>& index_ids) {
   std::ostringstream out;
   out << "{ ";
   bool first = true;

--- a/src/yb/master/backfill_index.cc
+++ b/src/yb/master/backfill_index.cc
@@ -635,6 +635,27 @@ std::unordered_set<TableId> IndexIdsFromInfos(const std::vector<IndexInfoPB>& in
   return idx_ids;
 }
 
+std::string RetrieveIndexNames(CatalogManager* mgr, const std::unordered_set<std::string>& index_ids) {
+  std::ostringstream out;
+  out << "{ ";
+  bool first = true;
+  for (const auto& index_id : index_ids) {
+    const auto table_info = mgr->GetTableInfo(index_id);
+    if (!table_info) {
+      LOG(WARNING) << "No table info can be found with index table id " << index_id;
+      continue;
+    }
+    if (!first) {
+      out << ", ";
+    }
+    first = false;
+
+    out << table_info->name();
+  }
+  out << " }";
+  return out.str();
+}
+
 }  // namespace
 
 BackfillTable::BackfillTable(
@@ -645,20 +666,8 @@ BackfillTable::BackfillTable(
       indexed_table_(indexed_table),
       index_infos_(indexes),
       requested_index_ids_(IndexIdsFromInfos(indexes)),
+      requested_index_names_(RetrieveIndexNames(master->catalog_manager(), requested_index_ids_)),
       ns_info_(ns_info) {
-  std::ostringstream out;
-  out << "{ ";
-  bool first = true;
-  for (const auto& index_id : requested_index_ids_) {
-    if (!first) {
-      out << ", ";
-    }
-    out << master_->catalog_manager()->GetTableInfo(index_id)->name();
-    first = false;
-  }
-  out << " }";
-  requested_index_names_ = out.str();
-
   auto l = indexed_table_->LockForRead();
   schema_version_ = indexed_table_->metadata().state().pb.version();
   leader_term_ = master_->catalog_manager()->leader_ready_term();
@@ -1243,6 +1252,21 @@ void GetSafeTimeForTablet::UnregisterAsyncTaskCallback() {
   }
   WARN_NOT_OK(backfill_table_->UpdateSafeTime(status, safe_time),
     "Could not UpdateSafeTime");
+}
+
+BackfillChunk::BackfillChunk(std::shared_ptr<BackfillTablet> backfill_tablet,
+                             const std::string& start_key) : 
+                             RetryingTSRpcTask(backfill_tablet->master(),
+                                              backfill_tablet->threadpool(),
+                                              gscoped_ptr<TSPicker>(new PickLeaderReplica(
+                                              backfill_tablet->tablet())),
+                            backfill_tablet->tablet()->table().get()),
+                            indexes_being_backfilled_(backfill_tablet->indexes_to_build()),
+                            backfill_tablet_(backfill_tablet),
+                            start_key_(start_key), 
+                            requested_index_names_(RetrieveIndexNames(backfill_tablet->master()->catalog_manager(),
+                                                                      indexes_being_backfilled_)) {
+  deadline_ = MonoTime::Max(); // Never time out.
 }
 
 // -----------------------------------------------------------------------------------------------

--- a/src/yb/master/backfill_index.cc
+++ b/src/yb/master/backfill_index.cc
@@ -1255,17 +1255,16 @@ void GetSafeTimeForTablet::UnregisterAsyncTaskCallback() {
 }
 
 BackfillChunk::BackfillChunk(std::shared_ptr<BackfillTablet> backfill_tablet,
-                             const std::string& start_key) : 
-                             RetryingTSRpcTask(backfill_tablet->master(),
-                                              backfill_tablet->threadpool(),
-                                              gscoped_ptr<TSPicker>(new PickLeaderReplica(
-                                              backfill_tablet->tablet())),
-                            backfill_tablet->tablet()->table().get()),
-                            indexes_being_backfilled_(backfill_tablet->indexes_to_build()),
-                            backfill_tablet_(backfill_tablet),
-                            start_key_(start_key), 
-                            requested_index_names_(RetrieveIndexNames(backfill_tablet->master()->catalog_manager(),
-                                                                      indexes_being_backfilled_)) {
+                             const std::string& start_key)
+    : RetryingTSRpcTask(backfill_tablet->master(),
+                        backfill_tablet->threadpool(),
+                        gscoped_ptr<TSPicker>(new PickLeaderReplica(backfill_tablet->tablet())),
+                        backfill_tablet->tablet()->table().get()),
+      indexes_being_backfilled_(backfill_tablet->indexes_to_build()),
+      backfill_tablet_(backfill_tablet),
+      start_key_(start_key),
+      requested_index_names_(RetrieveIndexNames(backfill_tablet->master()->catalog_manager(),
+                                                indexes_being_backfilled_)) {
   deadline_ = MonoTime::Max(); // Never time out.
 }
 


### PR DESCRIPTION
I went over the changes, and I observed that their might've been some inconsistencies with my approach. I added a helper method instead which would retrieve the index table names instead (as the field ```requested_index_names_``` might not necessarily contain only the indexes we are currently backfilling).