### PR TITLE
[#6945] [Platform] [Backport-2.4] Add limit to customer task API.

### DIFF
--- a/managed/src/main/java/com/yugabyte/yw/controllers/CustomerTaskController.java
+++ b/managed/src/main/java/com/yugabyte/yw/controllers/CustomerTaskController.java
@@ -35,8 +35,7 @@ public class CustomerTaskController extends AuthenticatedController {
 
   @Inject Commissioner commissioner;
 
-  @Inject
-  private RuntimeConfigFactory runtimeConfigFactory;
+  @Inject private RuntimeConfigFactory configFactory;
 
   static final String CUSTOMER_TASK_DB_QUERY_LIMIT = "yb.customer_task_db_query_limit";
 
@@ -78,7 +77,7 @@ public class CustomerTaskController extends AuthenticatedController {
     }
     
     customerTaskList = customerTaskQuery.setMaxRows(
-          runtimeConfigFactory.globalRuntimeConf().getInt(CUSTOMER_TASK_DB_QUERY_LIMIT))
+      configFactory.globalRuntimeConf().getInt(CUSTOMER_TASK_DB_QUERY_LIMIT))
       .orderBy("create_time desc")
       .findPagedList()
       .getList();

--- a/managed/src/main/java/com/yugabyte/yw/controllers/CustomerTaskController.java
+++ b/managed/src/main/java/com/yugabyte/yw/controllers/CustomerTaskController.java
@@ -68,19 +68,23 @@ public class CustomerTaskController extends AuthenticatedController {
   private Map<UUID, List<CustomerTaskFormData>> fetchTasks(UUID customerUUID, UUID targetUUID) {
     List<CustomerTask> customerTaskList;
 
-    Query<CustomerTask> customerTaskQuery = CustomerTask.find.query().where()
-      .eq("customer_uuid", customerUUID)
-      .orderBy("create_time desc");
+    Query<CustomerTask> customerTaskQuery =
+        CustomerTask.find
+            .query()
+            .where()
+            .eq("customer_uuid", customerUUID)
+            .orderBy("create_time desc");
 
     if (targetUUID != null) {
-      customerTaskQuery.where().eq("target_uuid", targetUUID); 
+      customerTaskQuery.where().eq("target_uuid", targetUUID);
     }
-    
-    customerTaskList = customerTaskQuery.setMaxRows(
-      configFactory.globalRuntimeConf().getInt(CUSTOMER_TASK_DB_QUERY_LIMIT))
-      .orderBy("create_time desc")
-      .findPagedList()
-      .getList();
+
+    customerTaskList =
+        customerTaskQuery
+            .setMaxRows(configFactory.globalRuntimeConf().getInt(CUSTOMER_TASK_DB_QUERY_LIMIT))
+            .orderBy("create_time desc")
+            .findPagedList()
+            .getList();
 
     Map<UUID, List<CustomerTaskFormData>> taskListMap = new HashMap<>();
 

--- a/managed/src/main/java/com/yugabyte/yw/controllers/CustomerTaskController.java
+++ b/managed/src/main/java/com/yugabyte/yw/controllers/CustomerTaskController.java
@@ -2,14 +2,11 @@
 
 package com.yugabyte.yw.controllers;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.Map;
-import java.util.HashMap;
+import java.util.*;
 
 import io.ebean.Query;
+import io.ebean.Ebean;
+
 import com.yugabyte.yw.forms.SubTaskFormData;
 import com.yugabyte.yw.forms.UniverseDefinitionTaskParams;
 import com.yugabyte.yw.models.Audit;
@@ -20,11 +17,13 @@ import com.yugabyte.yw.models.helpers.TaskType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.typesafe.config.Config;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.inject.Inject;
 import com.yugabyte.yw.commissioner.Commissioner;
 import com.yugabyte.yw.common.ApiResponse;
+import com.yugabyte.yw.common.config.RuntimeConfigFactory;
 import com.yugabyte.yw.forms.CustomerTaskFormData;
 import com.yugabyte.yw.models.Customer;
 import com.yugabyte.yw.models.CustomerTask;
@@ -35,6 +34,11 @@ import play.mvc.Result;
 public class CustomerTaskController extends AuthenticatedController {
 
   @Inject Commissioner commissioner;
+
+  @Inject
+  private RuntimeConfigFactory runtimeConfigFactory;
+
+  static final String CUSTOMER_TASK_DB_QUERY_LIMIT = "yb.customer_task_db_query_limit";
 
   protected static final int TASK_HISTORY_LIMIT = 6;
   public static final Logger LOG = LoggerFactory.getLogger(CustomerTaskController.class);
@@ -63,22 +67,25 @@ public class CustomerTaskController extends AuthenticatedController {
   }
 
   private Map<UUID, List<CustomerTaskFormData>> fetchTasks(UUID customerUUID, UUID targetUUID) {
-    Query<CustomerTask> customerTaskQuery =
-        CustomerTask.find
-            .query()
-            .where()
-            .eq("customer_uuid", customerUUID)
-            .orderBy("create_time desc");
+    List<CustomerTask> customerTaskList;
+
+    Query<CustomerTask> customerTaskQuery = CustomerTask.find.query().where()
+      .eq("customer_uuid", customerUUID)
+      .orderBy("create_time desc");
 
     if (targetUUID != null) {
-      customerTaskQuery.where().eq("target_uuid", targetUUID);
+      customerTaskQuery.where().eq("target_uuid", targetUUID); 
     }
-
-    Set<CustomerTask> pendingTasks = customerTaskQuery.findSet();
+    
+    customerTaskList = customerTaskQuery.setMaxRows(
+          runtimeConfigFactory.globalRuntimeConf().getInt(CUSTOMER_TASK_DB_QUERY_LIMIT))
+      .orderBy("create_time desc")
+      .findPagedList()
+      .getList();
 
     Map<UUID, List<CustomerTaskFormData>> taskListMap = new HashMap<>();
 
-    for (CustomerTask task : pendingTasks) {
+    for (CustomerTask task : customerTaskList) {
       try {
         CustomerTaskFormData taskData = new CustomerTaskFormData();
 

--- a/managed/src/main/resources/application.test.conf
+++ b/managed/src/main/resources/application.test.conf
@@ -10,6 +10,7 @@ db {
 
 yb {
   storage.path="/tmp"
+  customer_task_db_query_limit = 5
 }
 
 ebean {

--- a/managed/src/main/resources/reference.conf
+++ b/managed/src/main/resources/reference.conf
@@ -29,4 +29,15 @@ yb {
     default_smtp_port_ssl = 465
     debug_email = false
   }
+
+  customer_task_db_query_limit = 2000
+}
+
+runtime_config {
+  included_paths = [
+      #  We can set this to "yb." if/when there are more includedPaths than excludedPaths
+      "yb.customer_task_db_query_limit"
+  ]
+  excluded_paths = [
+  ]
 }

--- a/managed/src/main/resources/reference.conf
+++ b/managed/src/main/resources/reference.conf
@@ -32,12 +32,3 @@ yb {
 
   customer_task_db_query_limit = 2000
 }
-
-runtime_config {
-  included_paths = [
-      #  We can set this to "yb." if/when there are more includedPaths than excludedPaths
-      "yb.customer_task_db_query_limit"
-  ]
-  excluded_paths = [
-  ]
-}

--- a/managed/src/test/java/com/yugabyte/yw/controllers/CustomerTaskControllerTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/controllers/CustomerTaskControllerTest.java
@@ -10,6 +10,8 @@ import com.yugabyte.yw.commissioner.UserTaskDetails;
 import com.yugabyte.yw.common.FakeApiHelper;
 import com.yugabyte.yw.common.FakeDBApplication;
 import com.yugabyte.yw.common.ModelFactory;
+import com.yugabyte.yw.common.config.impl.RuntimeConfig;
+import com.yugabyte.yw.common.config.impl.SettableRuntimeConfigFactory;
 import com.yugabyte.yw.models.Customer;
 import com.yugabyte.yw.models.CustomerTask;
 
@@ -19,6 +21,9 @@ import com.yugabyte.yw.models.Users;
 import com.yugabyte.yw.models.helpers.TaskType;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
+
+import io.ebean.Model;
 import play.Application;
 import play.inject.guice.GuiceApplicationBuilder;
 import play.libs.Json;
@@ -27,6 +32,7 @@ import play.test.WithApplication;
 import play.test.Helpers;
 
 import java.util.Calendar;
+import java.util.stream.IntStream;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -50,17 +56,31 @@ import static play.mvc.Http.Status.FORBIDDEN;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.fakeRequest;
 import static play.test.Helpers.route;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.InjectMocks;
 
+@RunWith(MockitoJUnitRunner.class)
 public class CustomerTaskControllerTest extends FakeDBApplication {
   private Customer customer;
   private Users user;
   private Universe universe;
+
+  @Mock
+  private RuntimeConfig<Model> config;
+
+  @Mock
+  SettableRuntimeConfigFactory mockRuntimeConfigFactory;
+
+  @InjectMocks
+  private CustomerTaskController controller;
 
   @Before
   public void setUp() {
     customer = ModelFactory.testCustomer();
     user = ModelFactory.testUser(customer);
     universe = createUniverse(customer.getCustomerId());
+    when(mockRuntimeConfigFactory.globalRuntimeConf()).thenReturn(config);
   }
 
   @Test
@@ -304,6 +324,24 @@ public class CustomerTaskControllerTest extends FakeDBApplication {
     assertTrue(universeTasks.isArray());
     assertEquals(1, universeTasks.size());
     assertValues(universeTasks, "id", ImmutableList.of(taskUUID1.toString()));
+    assertAuditEntry(0, customer.uuid);
+  }
+
+  @Test
+  public void testTaskHistoryLimit() {
+    String authToken = user.createAuthToken();
+    Universe universe1 = createUniverse("Universe 2", customer.getCustomerId());
+    when(config.getInt(CustomerTaskController.CUSTOMER_TASK_DB_QUERY_LIMIT))
+      .thenReturn(25);
+    IntStream.range(0, 100).forEach(i -> createTaskWithStatus(
+        universe.universeUUID, CustomerTask.TargetType.Universe, Create, "Foo", "Running", 50.0));
+    Result result = controller.list(customer.uuid);
+    assertEquals(OK, result.status());
+    JsonNode json = Json.parse(contentAsString(result));
+    assertTrue(json.isObject());
+    JsonNode universeTasks = json.get(universe.universeUUID.toString());
+    assertTrue(universeTasks.isArray());
+    assertEquals(25, universeTasks.size());
     assertAuditEntry(0, customer.uuid);
   }
 

--- a/managed/src/test/java/com/yugabyte/yw/controllers/CustomerTaskControllerTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/controllers/CustomerTaskControllerTest.java
@@ -64,8 +64,6 @@ public class CustomerTaskControllerTest extends FakeDBApplication {
   private Users user;
   private Universe universe;
 
-  @InjectMocks private CustomerTaskController controller;
-
   @Before
   public void setUp() {
     customer = ModelFactory.testCustomer();

--- a/managed/src/test/java/com/yugabyte/yw/controllers/CustomerTaskControllerTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/controllers/CustomerTaskControllerTest.java
@@ -69,8 +69,7 @@ public class CustomerTaskControllerTest extends FakeDBApplication {
   @Mock private Config config;
   @Mock private RuntimeConfigFactory configFactory;
 
-  @InjectMocks
-  private CustomerTaskController controller;
+  @InjectMocks private CustomerTaskController controller;
 
   @Before
   public void setUp() {
@@ -328,10 +327,17 @@ public class CustomerTaskControllerTest extends FakeDBApplication {
   public void testTaskHistoryLimit() {
     String authToken = user.createAuthToken();
     Universe universe1 = createUniverse("Universe 2", customer.getCustomerId());
-    when(config.getInt(CustomerTaskController.CUSTOMER_TASK_DB_QUERY_LIMIT))
-      .thenReturn(5);
-    IntStream.range(0, 100).forEach(i -> createTaskWithStatus(
-        universe.universeUUID, CustomerTask.TargetType.Universe, Create, "Foo", "Running", 50.0));
+    when(config.getInt(CustomerTaskController.CUSTOMER_TASK_DB_QUERY_LIMIT)).thenReturn(5);
+    IntStream.range(0, 100)
+        .forEach(
+            i ->
+                createTaskWithStatus(
+                    universe.universeUUID,
+                    CustomerTask.TargetType.Universe,
+                    Create,
+                    "Foo",
+                    "Running",
+                    50.0));
     Result result = controller.list(customer.uuid);
     assertEquals(OK, result.status());
     JsonNode json = Json.parse(contentAsString(result));

--- a/managed/src/test/java/com/yugabyte/yw/controllers/CustomerTaskControllerTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/controllers/CustomerTaskControllerTest.java
@@ -66,7 +66,8 @@ public class CustomerTaskControllerTest extends FakeDBApplication {
   private Users user;
   private Universe universe;
 
-  @Mock private play.Configuration mockConfig;
+  @Mock private Config config;
+  @Mock private RuntimeConfigFactory configFactory;
 
   @InjectMocks
   private CustomerTaskController controller;
@@ -76,7 +77,7 @@ public class CustomerTaskControllerTest extends FakeDBApplication {
     customer = ModelFactory.testCustomer();
     user = ModelFactory.testUser(customer);
     universe = createUniverse(customer.getCustomerId());
-    // when(config.globalRuntimeConf()).thenReturn(runtimeConfig);
+    when(configFactory.globalRuntimeConf()).thenReturn(config);
   }
 
   @Test
@@ -327,8 +328,8 @@ public class CustomerTaskControllerTest extends FakeDBApplication {
   public void testTaskHistoryLimit() {
     String authToken = user.createAuthToken();
     Universe universe1 = createUniverse("Universe 2", customer.getCustomerId());
-    when(mockConfig.getInt(CustomerTaskController.CUSTOMER_TASK_DB_QUERY_LIMIT))
-      .thenReturn(25);
+    when(config.getInt(CustomerTaskController.CUSTOMER_TASK_DB_QUERY_LIMIT))
+      .thenReturn(5);
     IntStream.range(0, 100).forEach(i -> createTaskWithStatus(
         universe.universeUUID, CustomerTask.TargetType.Universe, Create, "Foo", "Running", 50.0));
     Result result = controller.list(customer.uuid);

--- a/managed/src/test/java/com/yugabyte/yw/controllers/CustomerTaskControllerTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/controllers/CustomerTaskControllerTest.java
@@ -5,13 +5,13 @@ package com.yugabyte.yw.controllers;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
+import com.typesafe.config.Config;
 import com.yugabyte.yw.commissioner.Commissioner;
 import com.yugabyte.yw.commissioner.UserTaskDetails;
 import com.yugabyte.yw.common.FakeApiHelper;
 import com.yugabyte.yw.common.FakeDBApplication;
 import com.yugabyte.yw.common.ModelFactory;
-import com.yugabyte.yw.common.config.impl.RuntimeConfig;
-import com.yugabyte.yw.common.config.impl.SettableRuntimeConfigFactory;
+import com.yugabyte.yw.common.config.RuntimeConfigFactory;
 import com.yugabyte.yw.models.Customer;
 import com.yugabyte.yw.models.CustomerTask;
 
@@ -66,11 +66,7 @@ public class CustomerTaskControllerTest extends FakeDBApplication {
   private Users user;
   private Universe universe;
 
-  @Mock
-  private RuntimeConfig<Model> config;
-
-  @Mock
-  SettableRuntimeConfigFactory mockRuntimeConfigFactory;
+  @Mock private play.Configuration mockConfig;
 
   @InjectMocks
   private CustomerTaskController controller;
@@ -80,7 +76,7 @@ public class CustomerTaskControllerTest extends FakeDBApplication {
     customer = ModelFactory.testCustomer();
     user = ModelFactory.testUser(customer);
     universe = createUniverse(customer.getCustomerId());
-    when(mockRuntimeConfigFactory.globalRuntimeConf()).thenReturn(config);
+    // when(config.globalRuntimeConf()).thenReturn(runtimeConfig);
   }
 
   @Test
@@ -331,7 +327,7 @@ public class CustomerTaskControllerTest extends FakeDBApplication {
   public void testTaskHistoryLimit() {
     String authToken = user.createAuthToken();
     Universe universe1 = createUniverse("Universe 2", customer.getCustomerId());
-    when(config.getInt(CustomerTaskController.CUSTOMER_TASK_DB_QUERY_LIMIT))
+    when(mockConfig.getInt(CustomerTaskController.CUSTOMER_TASK_DB_QUERY_LIMIT))
       .thenReturn(25);
     IntStream.range(0, 100).forEach(i -> createTaskWithStatus(
         universe.universeUUID, CustomerTask.TargetType.Universe, Create, "Foo", "Running", 50.0));


### PR DESCRIPTION
Description:
We could make the tasks UI more functional by adding a LIMIT 2000 to our tasks DB query, so we don't end up with a spinning task UI for Platform instances that accumulate many tasks over time.
Currently it is set to 2000 in reference.conf.

Original Commit: [https://github.com/yugabyte/yugabyte-db/pull/7477] (57d835e9c13c92cf2feaaa716d5f08e6cdef9442)

Test Plan:

Updated reference.conf to 20.
Verified whether the API returning only 20 entries or not.
Also verified the working endpoint of a particular task.
Verified by creating 10 + tasks and verified pagination in UI too.


sbt test:

```info] Test com.yugabyte.yw.cloud.UniverseResourceDetailsTest.testAddPriceWithRemovingOneNode started
[info] Test run finished: 0 failed, 0 ignored, 7 total, 1.009s
[info] Passed: Total 1131, Failed 0, Errors 0, Passed 1127, Skipped 4
[success] Total time: 439 s, completed 1 Jun, 2021 10:45:19 PM```