### PR TITLE
issue-8709: fix yb-ctl start_node to not fail when other nodes are down

### DIFF
--- a/docs/content/latest/quick-start/build-apps/java/ycql-4.6.md
+++ b/docs/content/latest/quick-start/build-apps/java/ycql-4.6.md
@@ -79,12 +79,18 @@ Create a file, named `pom.xml`, and then copy the following content into it. The
   <artifactId>hello-world</artifactId>
   <version>1.0</version>
   <packaging>jar</packaging>
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
 
- <dependency>
-   <groupId>com.yugabyte</groupId>
-   <artifactId>java-driver-core</artifactId>
-   <version>4.6.0-yb-6</version>
- </dependency>
+  <dependencies>
+    <dependency>
+      <groupId>com.yugabyte</groupId>
+      <artifactId>java-driver-core</artifactId>
+      <version>4.6.0-yb-6</version>
+    </dependency>
+  </dependencies>
 
   <build>
     <plugins>

--- a/docs/content/latest/quick-start/build-apps/java/ysql-jdbc.md
+++ b/docs/content/latest/quick-start/build-apps/java/ysql-jdbc.md
@@ -172,7 +172,7 @@ This tutorial assumes that:
 1. Run your new program.
 
     ```sh
-    $ mvn -q exec:java -Dexec.mainClass=com.yugabyte.HelloSqlApp
+    $ mvn -q package exec:java -Dexec.mainClass=com.yugabyte.HelloSqlApp
     ```
 
     You should see the following as the output:

--- a/docs/content/latest/quick-start/build-apps/java/ysql-spring-data.md
+++ b/docs/content/latest/quick-start/build-apps/java/ysql-spring-data.md
@@ -68,7 +68,7 @@ There are a number of options that can be customized in the properties file loca
 ## Build the application
 
 ```sh
-$ cd ./java/spring
+$ cd orm-examples/java/spring
 ```
 
 ```sh


### PR DESCRIPTION
This PR fixes an issue with yb-ctl start_node. Instead of waiting for the entire cluster to be ready, it just waits for what we just started to be ready.