### PR TITLE
github workflow: Revert github workflow error.

### DIFF
--- a/.github/workflows/yugabyted-test.yml
+++ b/.github/workflows/yugabyted-test.yml
@@ -6,16 +6,12 @@ on:
       - master
     paths:
       - '**/yugabyted*'
-    paths-ignore:
-        - 'docs/**'
 
   pull_request:
     branches:
       - master
     paths:
       - '**/yugabyted*'
-    paths-ignore:
-        - 'docs/**'
 
 jobs:
   yugabyted-test:


### PR DESCRIPTION
Prior change (b10270234f10e55a8fa012ea924e9db5beb1101d) added file
exemptions to the workflow that are not allowed to be mixed with paths
statements.