### PR TITLE
[#7349]Change ToString to TextVlue for json node

### DIFF
--- a/managed/src/main/java/com/yugabyte/yw/models/Backup.java
+++ b/managed/src/main/java/com/yugabyte/yw/models/Backup.java
@@ -300,7 +300,7 @@ public class Backup extends Model {
                             .asText()
                             .equals(configUUID.toString())
                         && universeUUIDs.add(
-                            UUID.fromString(s.getTaskParams().path("universeUUID").textValue())))
+                            UUID.fromString(s.getTaskParams().get("universeUUID").asText())))
             .collect(Collectors.toList());
     Set<Universe> universes = new HashSet<>();
     for (UUID universeUUID : universeUUIDs) {

--- a/managed/src/main/java/com/yugabyte/yw/models/Backup.java
+++ b/managed/src/main/java/com/yugabyte/yw/models/Backup.java
@@ -300,7 +300,7 @@ public class Backup extends Model {
                             .asText()
                             .equals(configUUID.toString())
                         && universeUUIDs.add(
-                            UUID.fromString(s.getTaskParams().path("universeUUID").toString())))
+                            UUID.fromString(s.getTaskParams().path("universeUUID").textValue())))
             .collect(Collectors.toList());
     Set<Universe> universes = new HashSet<>();
     for (UUID universeUUID : universeUUIDs) {


### PR DESCRIPTION
Whenever we create any scheduled backup, config API starts getting failed.
Scenario:- 
1. Configure Storage
2. Add sample data
3. Create a scheduled backup
4. Try to access the universe backup page/ Config page.

Both pages started getting failed. 

Debug and got to know very minor issue. One place we had used toString() for jsonNode.
tested and working fine.
Testcase report:- 
[info] Test run finished: 0 failed, 0 ignored, 7 total, 0.134s
[info] Passed: Total 1359, Failed 0, Errors 0, Passed 1355, Skipped 4
[success] Total time: 2087 s (34:47), completed 7 Jun, 2021 3:22:24 PM