### PR TITLE
[Platform] Remove commons-collections4 and use guava instead

### DIFF
--- a/managed/build.sbt
+++ b/managed/build.sbt
@@ -169,8 +169,7 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.core" % "jackson-core" % "2.10.5",
   "com.jayway.jsonpath" % "json-path" % "2.4.0",
   "commons-io" % "commons-io" % "2.8.0",
-  "commons-codec" % "commons-codec" % "1.15",
-  "org.apache.commons" % "commons-collections4" % "4.4"
+  "commons-codec" % "commons-codec" % "1.15"
 )
 // Clear default resolvers.
 appResolvers := None


### PR DESCRIPTION
This is a follow up change from https://github.com/yugabyte/yugabyte-db/pull/8371

Scenarios tested:
- Ran platform inside Kubernetes, curl the API, it returns the expected JSON.