### PR TITLE
[#8905] Replaced gscoped_ptr with std::unique_ptr

### DIFF
--- a/src/yb/tablet/tablet.h
+++ b/src/yb/tablet/tablet.h
@@ -776,7 +776,7 @@ class Tablet : public AbstractTablet, public TransactionIntentApplier {
 
   MetricEntityPtr tablet_metrics_entity_;
   MetricEntityPtr table_metrics_entity_;
-  gscoped_ptr<TabletMetrics> metrics_;
+  std::unique_ptr<TabletMetrics> metrics_;
   FunctionGaugeDetacher metric_detacher_;
 
   // A pointer to the server's clock.


### PR DESCRIPTION
Replaced gscoped_ptr to std::unique_ptr in src/yb/tablet/tablet.h