### PR TITLE
[doc] Fixed typos and formatting issues in Configure Audit Logging in YSQL 

### DIFF
--- a/docs/content/latest/secure/audit-logging/audit-logging-ysql.md
+++ b/docs/content/latest/secure/audit-logging/audit-logging-ysql.md
@@ -45,7 +45,7 @@ This can be done in one of the following ways:
 
 ##### Option A: Using `--ysql_pg_conf` TServer flag
 
-Database administrators can leverage `ysql_pg_conf` to set appropriate values for pgAudit configuration.
+Database administrators can leverage `ysql_pg_conf` to set appropriate values for `pgAudit` configuration.
 
 For example, `ysql_pg_conf="pgaudit.log='DDL',pgaudit.log_level=notice"`
 
@@ -63,7 +63,7 @@ For example, `SET pgaudit.log='DDL'`
 
 ### Step 2. Load the `pgAudit` extension
 
-Enable audit logging in YugabyteDB clusters by creating the `pgaudit` extension. Executing the following statement in a YSQL shell enables Audit logging:
+Enable audit logging in YugabyteDB clusters by creating the `pgAudit` extension. Executing the following statement in a YSQL shell enables Audit logging:
 
 ```sql
 CREATE EXTENSION IF NOT EXISTS pgaudit;
@@ -72,7 +72,7 @@ CREATE EXTENSION IF NOT EXISTS pgaudit;
 
 ## Customizing Audit Logging
 
-YSQL audit logging can be further customized by configuring the pgAudit flags as per the following table.
+YSQL audit logging can be further customized by configuring the `pgAudit` flags as per the following table.
 
 <table>
   <tr>
@@ -174,14 +174,14 @@ There is no default.
   </tr>
 </table>
 
-## Example
+## Examples
 
 Use these steps to configure audit logging in a YugabyteDB cluster with bare minimum configurations.
 
 
 ### 1. Enable audit logging
 
-Start the YugabyteDB Cluster with the following Audit logging Configuration:
+Start the YugabyteDB Cluster with the following Audit logging configuration:
 
 ```shell
 --ysql_pg_conf="pgaudit.log='DDL',pgaudit.log_level=notice,pgaudit.log_client=ON"
@@ -215,7 +215,7 @@ You should be able to login and see an output similar to the following:
     
     yugabyte=#
 
-To enable the `pgaudit` extension on the YugabyteDB cluster, connect to the database by using the following:
+To enable the `pgAudit` extension on the YugabyteDB cluster, connect to the database by using the following:
 
 ```shell
 yugabyte=> \c yugabyte yugabyte;

--- a/docs/content/latest/secure/audit-logging/audit-logging-ysql.md
+++ b/docs/content/latest/secure/audit-logging/audit-logging-ysql.md
@@ -41,35 +41,38 @@ The goal of the YSQL audit logging is to provide YugabyteDB users with capabilit
 
 ### Step 1. Enable audit logging on YB-TServer
 
-This can be done in one of the following ways.
+This can be done in one of the following ways:
 
 ##### Option A: Using `--ysql_pg_conf` TServer flag
 
-1. Database administrators can leverage `ysql_pg_conf` to set appropriate values for pgAudit configuration.
-2. Eg. `ysql_pg_conf="pgaudit.log='DDL',pgaudit.log_level=notice"`
-3. These configuration values are set when the YugabyteDB cluster is created and hence are picked up for all users and for every session.
+Database administrators can leverage `ysql_pg_conf` to set appropriate values for pgAudit configuration.
+
+For example, `ysql_pg_conf="pgaudit.log='DDL',pgaudit.log_level=notice"`
+
+These configuration values are set when the YugabyteDB cluster is created and hence are picked up for all users and for every session.
 
 
 ##### Option B: Using YugabyteDB `SET` command
 
-1. An alternative suggestion is to use the YB `SET` command, which essentially changes the run-time configuration parameters.
-2. Eg. `SET pgaudit.log='DDL'`
-3. `SET` only affects the value used by the current session. A detailed description of the set command is illustrated in this [webpage](https://www.postgresql.org/docs/8.3/sql-set.html). 
+An alternative suggestion is to use the YB `SET` command, which essentially changes the run-time configuration parameters.
+
+For example, `SET pgaudit.log='DDL'`
+
+`SET` only affects the value used by the current session. For more information, see the [PostgreSQL documentation](https://www.postgresql.org/docs/11/sql-set.html). 
 
 
 ### Step 2. Load the `pgAudit` extension
 
-Enable Audit logging in YugabyteDB clusters by creating the `pgaudit` extension. Executing the below statement in a YSQL shell will enable Audit logging.
+Enable audit logging in YugabyteDB clusters by creating the `pgaudit` extension. Executing the following statement in a YSQL shell enables Audit logging:
 
-```
-yugabyte=# CREATE EXTENSION IF NOT EXISTS pgaudit;
-CREATE EXTENSION
+```sql
+CREATE EXTENSION IF NOT EXISTS pgaudit;
 ```
 
 
 ## Customizing Audit Logging
 
-YSQL Audit logging can be further customized by configuring the pgAudit flags as described below.
+YSQL audit logging can be further customized by configuring the pgAudit flags as per the following table.
 
 <table>
   <tr>
@@ -81,8 +84,9 @@ YSQL Audit logging can be further customized by configuring the pgAudit flags as
   <tr>
    <td><code>pgaudit.log</code>
    </td>
-   <td>Specifies which classes of statements will be logged by <strong>session audit logging</strong>.
+   <td>Specifies which classes of statements are to be logged by <strong>session audit logging</strong>.
 <ul>
+
 
 <li><strong><code>READ</code></strong>: <code>SELECT</code> and <code>COPY</code> when the source is a relation or a query.
 
@@ -94,13 +98,13 @@ YSQL Audit logging can be further customized by configuring the pgAudit flags as
 
 <li><strong><code>DDL</code></strong>: All <code>DDL</code> that is not included in the <code>ROLE</code> class.
 
-<li><strong><code>MISC</code></strong>: Miscellaneous commands, e.g. <code>DISCARD, FETCH, CHECKPOINT, VACUUM, SET</code>.
+<li><strong><code>MISC</code></strong>: Miscellaneous commands, such as <code>DISCARD, FETCH, CHECKPOINT, VACUUM, SET</code>.
 
-<li><strong><code>MISC_SET</code></strong>: Miscellaneous <code>SET</code> commands, e.g. <code>SET ROLE</code>.
+<li><strong><code>MISC_SET</code></strong>: Miscellaneous <code>SET</code> commands, such as <code>SET ROLE</code>.
 
-<li><strong><code>ALL</code></strong>: Include all of the above.
+<li><strong><code>ALL</code></strong>: Include all of the preceding options.
 
-Multiple classes can be provided using a comma-separated list and classes can be subtracted by prefacing the class with a - sign.
+Multiple classes can be provided using a comma-separated list and classes can be subtracted by prefacing the class with a `-` (minus) sign.
 
 </li>
 </ul>
@@ -112,16 +116,16 @@ The default is none.
    <td><code>pgaudit.log_catalog</code>
    </td>
    <td><strong><code>ON</code></strong>: <strong>Session logging</strong> would be enabled in the case for all relations in a statement that are in pg_catalog.
-<strong><code>OFF</code></strong>: Vice Versa!  Disabling this setting will reduce noise in the log from tools.<p>
+<strong><code>OFF</code></strong>: Disabling this setting will reduce noise in the log from tools.<p>
 The default is <strong><code>ON</code></strong>.
    </td>
   </tr>
   <tr>
    <td><code>pgaudit.log_client</code>
    </td>
-   <td><strong><code>ON</code></strong>: Log messages will be visible to a client process such as psql. Useful for debugging.
-<strong><code>OFF</code></strong>: Vice Versa!
-Note that pgaudit.log_level is only enabled when pgaudit.log_client is <strong><code>ON</code></strong>.<p>
+   <td><strong><code>ON</code></strong>: Log messages are to be visible to a client process such as psql. Useful for debugging.
+<strong><code>OFF</code></strong>: Reverse.
+Note that `pgaudit.log_level` is only enabled when pgaudit.log_client is <strong><code>ON</code></strong>.<p>
 The default is <strong><code>OFF</code></strong>.
    </td>
   </tr>
@@ -129,7 +133,7 @@ The default is <strong><code>OFF</code></strong>.
    <td><code>pgaudit.log_level</code>
    </td>
    <td>Values: <strong><code>DEBUG1 .. DEBUG5, INFO, NOTICE, WARNING, LOG</code></strong>. 
-Log level that will be used for log entries (<code>ERROR</code>, <code>FATAL</code>, and <code>PANIC</code> are not allowed). This setting is used for testing.
+Log level to be used for log entries (<code>ERROR</code>, <code>FATAL</code>, and <code>PANIC</code> are not allowed). This setting is used for testing.
 
 <p>
 Note that <code>pgaudit.log_level</code> is only enabled when pgaudit.log_client is <strong><code>ON</code></strong>; otherwise the default will be used.<br><br>
@@ -177,69 +181,70 @@ Use these steps to configure audit logging in a YugabyteDB cluster with bare min
 
 ### 1. Enable audit logging
 
-Start the YugabyteDB Cluster with the following Audit logging Configuration.
+Start the YugabyteDB Cluster with the following Audit logging Configuration:
 
-    ```
-    --ysql_pg_conf="pgaudit.log='DDL',pgaudit.log_level=notice,pgaudit.log_client=ON"
-    ```
+```shell
+--ysql_pg_conf="pgaudit.log='DDL',pgaudit.log_level=notice,pgaudit.log_client=ON"
+```
 
-    Alternatively, go to a YSQL shell and execute the following commands.
+Alternatively, open the YSQL shell and execute the following commands:
 
 
-    ```
-    SET pgaudit.log='DDL'; 
-    SET pgaudit.log_client=ON;
-    SET pgaudit.log_level=notice;
-    ```
+```shell
+SET pgaudit.log='DDL'; 
+SET pgaudit.log_client=ON;
+SET pgaudit.log_level=notice;
+```
 
 
 ### 2. Load `pgAudit` extension
 
-Open the YSQL shell (ysqlsh), specifying the `yugabyte` user and prompting for the password.
+Open the YSQL shell (ysqlsh), specifying the `yugabyte` user and prompting for the password, as follows:
 
-    ```
-    $ ./ysqlsh -U yugabyte -W
-    ```
+```shell
+$ ./ysqlsh -U yugabyte -W
+```
 
-    When prompted for the password, enter the yugabyte password. You should be able to login and see a response like below.
+When prompted for the password, enter the yugabyte password. 
+
+You should be able to login and see an output similar to the following:
 
 
-    ```
     ysqlsh (11.2-YB-2.5.0.0-b0)
     Type "help" for help.
     
     yugabyte=#
-    ```
+
+To enable the `pgaudit` extension on the YugabyteDB cluster, connect to the database by using the following:
+
+```shell
+yugabyte=> \c yugabyte yugabyte;
+```
+
+You are now connected to database called yugabyte as user yugabyte.
+
+Finally, create the `pgAudit` extension as follows:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pgaudit;
+```
+
+### 3. Create a table and verify log 
+
+Since `pgaudit.log='DDL'` is configured, `CREATE TABLE` YSQL statements are logged and the corresponding log is shown in the YSQL client:
 
 
-Enable `pgaudit` extension on the YugabyteDB cluster.
-
-    Connect to the database using the following: `yugabyte=> \c yugabyte yugabyte;`
-    
-    Create the `pgAudit` extension.
-    ```
-    You are now connected to database "yugabyte" as user "yugabyte".
-    
-    yugabyte=# CREATE EXTENSION IF NOT EXISTS pgaudit;
-    CREATE EXTENSION
-    
-    ```
-
-### 3. Create a table, verify log 
-
-Since `pgaudit.log='DDL'` is configured, `CREATE TABLE` YSQL statements will be logged and the corresponding log will be shown in the ysql client. 
-
+```sql
+CREATE TABLE employees (empno int, ename text, address text, 
+  salary int, account_number text);
+```
 
 ```
-yugabyte=# create table employees ( empno int, ename text, address text, 
-  salary int, account_number text );
 NOTICE:  AUDIT: SESSION,2,1,DDL,CREATE TABLE,TABLE,public.employees,
 "create table employees ( empno int, ename text, address text, salary int, 
 account_number text );",<not logged>
 CREATE TABLE
-
 ```
 
-
-Notice that audit logs get generated for DDL statements.
+Notice that audit logs are generated for DDL statements.
 

--- a/docs/content/latest/secure/audit-logging/audit-logging-ysql.md
+++ b/docs/content/latest/secure/audit-logging/audit-logging-ysql.md
@@ -101,17 +101,18 @@ YSQL Audit logging can be further customized by configuring the pgAudit flags as
 <li><strong><code>ALL</code></strong>: Include all of the above.
 
 Multiple classes can be provided using a comma-separated list and classes can be subtracted by prefacing the class with a - sign.
-<p>
-The default is none.
+
 </li>
 </ul>
+
+The default is none.
    </td>
   </tr>
   <tr>
    <td><code>pgaudit.log_catalog</code>
    </td>
    <td><strong><code>ON</code></strong>: <strong>Session logging</strong> would be enabled in the case for all relations in a statement that are in pg_catalog.
-<strong><code>OFF</code></strong>: Vice Versa!  Disabling this setting will reduce noise in the log from tools.
+<strong><code>OFF</code></strong>: Vice Versa!  Disabling this setting will reduce noise in the log from tools.<p>
 The default is <strong><code>ON</code></strong>.
    </td>
   </tr>
@@ -120,42 +121,43 @@ The default is <strong><code>ON</code></strong>.
    </td>
    <td><strong><code>ON</code></strong>: Log messages will be visible to a client process such as psql. Useful for debugging.
 <strong><code>OFF</code></strong>: Vice Versa!
-Note that pgaudit.log_level is only enabled when pgaudit.log_client is <strong><code>ON</code></strong>.
+Note that pgaudit.log_level is only enabled when pgaudit.log_client is <strong><code>ON</code></strong>.<p>
 The default is <strong><code>OFF</code></strong>.
    </td>
   </tr>
   <tr>
-   <td><code>pgaudit.log_leve</code>l
+   <td><code>pgaudit.log_level</code>
    </td>
    <td>Values: <strong><code>DEBUG1 .. DEBUG5, INFO, NOTICE, WARNING, LOG</code></strong>. 
 Log level that will be used for log entries (<code>ERROR</code>, <code>FATAL</code>, and <code>PANIC</code> are not allowed). This setting is used for testing.
+
 <p>
-Note that <code>pgaudit.log_leve</code>l is only enabled when pgaudit.log_client is <strong><code>ON</code></strong>; otherwise the default will be used.
-The default is <code>LOG</code>.
+Note that <code>pgaudit.log_level</code> is only enabled when pgaudit.log_client is <strong><code>ON</code></strong>; otherwise the default will be used.<br><br>
+The default is <strong><code>LOG</code></strong>.
    </td>
   </tr>
   <tr>
    <td><code>pgaudit.log_parameter</code>
    </td>
-   <td><code>ON</code>: Audit logging includes the parameters that were passed with the statement. When parameters are present they will be included in CSV format after the statement text.
+   <td><strong><code>ON</code></strong>: Audit logging includes the parameters that were passed with the statement. When parameters are present they will be included in CSV format after the statement text.
 <p>
-The default is <code>OFF</code>.
+The default is <strong><code>OFF</code></strong>.
    </td>
   </tr>
   <tr>
    <td><code>pgaudit.log_relation</code>
    </td>
-   <td><code>ON</code>: Session audit logging creates separate log entries for each relation (<code>TABLE</code>, <code>VIEW</code>, etc.) referenced in a <code>SELECT</code> or <code>DML</code> statement. This is a useful shortcut for exhaustive logging without using <strong>object audit logging</strong>.
+   <td><strong><code>ON</code></strong>: Session audit logging creates separate log entries for each relation (<code>TABLE</code>, <code>VIEW</code>, etc.) referenced in a <code>SELECT</code> or <code>DML</code> statement. This is a useful shortcut for exhaustive logging without using <strong>object audit logging</strong>.
 <p>
-The default is <code>OFF</code>.
+The default is <strong><code>OFF</code></strong>.
    </td>
   </tr>
   <tr>
    <td><code>pgaudit.log_statement_once</code>
    </td>
-   <td><code>ON</code>: Specifies whether logging will include the statement text and parameters with the first log entry for a statement/substatement combination or with every entry. Disabling this setting will result in less verbose logging but may make it more difficult to determine the statement that generated a log entry.
+   <td><strong><code>ON</code></strong>: Specifies whether logging will include the statement text and parameters with the first log entry for a statement/substatement combination or with every entry. Disabling this setting will result in less verbose logging but may make it more difficult to determine the statement that generated a log entry.
 <p>
-The default is <code>OFF</code>.
+The default is <strong><code>OFF</code></strong>.
    </td>
   </tr>
   <tr>
@@ -167,7 +169,6 @@ There is no default.
    </td>
   </tr>
 </table>
-
 
 ## Example
 
@@ -181,8 +182,6 @@ Start the YugabyteDB Cluster with the following Audit logging Configuration.
     ```
     --ysql_pg_conf="pgaudit.log='DDL',pgaudit.log_level=notice,pgaudit.log_client=ON"
     ```
-
-
 
     Alternatively, go to a YSQL shell and execute the following commands.
 
@@ -202,35 +201,29 @@ Open the YSQL shell (ysqlsh), specifying the `yugabyte` user and prompting for t
     $ ./ysqlsh -U yugabyte -W
     ```
 
-
-
     When prompted for the password, enter the yugabyte password. You should be able to login and see a response like below.
 
 
     ```
     ysqlsh (11.2-YB-2.5.0.0-b0)
     Type "help" for help.
-
+    
     yugabyte=#
     ```
 
 
 Enable `pgaudit` extension on the YugabyteDB cluster.
 
-  
-
     Connect to the database using the following: `yugabyte=> \c yugabyte yugabyte;`
-
+    
     Create the `pgAudit` extension.
     ```
     You are now connected to database "yugabyte" as user "yugabyte".
-
+    
     yugabyte=# CREATE EXTENSION IF NOT EXISTS pgaudit;
     CREATE EXTENSION
-
+    
     ```
-
-
 
 ### 3. Create a table, verify log 
 


### PR DESCRIPTION
Some typos and formatting issues (per Kannan, via slack). 
Also the whole file is kind of messed up.

Doc build preview: https://deploy-preview-8946--infallible-bardeen-164bc9.netlify.app/latest/secure/audit-logging/audit-logging-ysql/