### PR TITLE
[docs] add missing alias to async-replication

### DIFF
--- a/docs/content/latest/architecture/docdb-replication/async-replication.md
+++ b/docs/content/latest/architecture/docdb-replication/async-replication.md
@@ -21,7 +21,7 @@ xCluster replication enables asynchronous replication between independent Yugaby
 
 YugabyteDB provides synchronous replication of data in clusters dispersed across multiple (three or more) data centers by leveraging the Raft consensus algorithm to achieve enhanced high availability and performance. However, many use cases do not require synchronous replication or justify the additional complexity and operation costs associated with managing three or more data centers. For these needs, YugabyteDB supports two data center (2DC) deployments that use asynchronous replication built on top of [change data capture (CDC)](../change-data-capture) in DocDB.
 
-For details about configuring a 2DC deployment, see [Replicate between two data centers](../../../deploy/multi-dc/2dc-deployment).
+For details about configuring a 2DC deployment, see [Replicate between two data centers](../../../deploy/multi-dc/async-replication).
 
 {{< note title="Note" >}}
 

--- a/docs/content/latest/architecture/docdb-replication/change-data-capture.md
+++ b/docs/content/latest/architecture/docdb-replication/change-data-capture.md
@@ -38,7 +38,7 @@ Maintaining multiple data centers enables enterprises to provide:
 - High availability (HA) — Redundant systems help ensure that your operations virtually never fail.
 - Geo-redundancy — Geographically dispersed servers provide resiliency against catastrophic events and natural disasters.
 
-Two data center (2DC), or dual data center, deployments are a common use of CDC that allows efficient management of two YugabyteDB universes that are geographically separated. For more information, see [Two data center (2DC) deployments](../async-replication) and [Replicate between two data centers](../../../deploy/multi-dc/2dc-deployment)
+Two data center (2DC), or dual data center, deployments are a common use of CDC that allows efficient management of two YugabyteDB universes that are geographically separated. For more information, see [Two data center (2DC) deployments](../async-replication) and [Replicate between two data centers](../../../deploy/multi-dc/async-replication)
 
 ### Compliance and auditing
 

--- a/docs/content/latest/deploy/multi-dc/async-replication.md
+++ b/docs/content/latest/deploy/multi-dc/async-replication.md
@@ -3,6 +3,8 @@ title: Deploy to two universes with asynchronous replication
 headerTitle: Asynchronous Replication
 linkTitle: Asynchronous Replication
 description: Enable deployment using unidirectional (master-follower) or bidirectional (multi-master) replication between universes
+aliases:
+- /latest/deploy/multi-dc/2dc-deployment
 menu:
   latest:
     parent: multi-dc


### PR DESCRIPTION
Add a missing alias since we changed the name of the file. Also catch any remaining links to the old name.

http://deploy-preview-8966--infallible-bardeen-164bc9.netlify.app/latest/deploy/multi-dc/async-replication
http://deploy-preview-8966--infallible-bardeen-164bc9.netlify.app/latest/deploy/multi-dc/2dc-deployment (make sure this redirects to async-replication)