### PR TITLE
[#8809] [Platfrom] [Backport-2.4] Editing fields is only available alternatively when we click 'Edit Configuration'.

### DIFF
--- a/managed/ui/src/components/config/Storage/StorageConfiguration.js
+++ b/managed/ui/src/components/config/Storage/StorageConfiguration.js
@@ -236,7 +236,7 @@ class StorageConfiguration extends Component {
   onEditConfig = (config, activeTab) => {
     this.setState({
       editingTab: activeTab,
-      iamRoleEnabled: config?.IAM_INSTANCE_PROFILE || this.state.iamRoleEnabled
+      iamRoleEnabled: config?.IAM_INSTANCE_PROFILE || false
     });
   };
 
@@ -246,8 +246,7 @@ class StorageConfiguration extends Component {
   disableEditFields = () => {
     this.props.reset();
     this.setState({
-      editingTab: false,
-      iamRoleEnabled: !this.state.iamRoleEnabled
+      editingTab: false
     });
   };
 


### PR DESCRIPTION
On the 2.4 portal, the edit configuration button under cloud provider config makes editing available alternatively.

Test Plan:

1. login 2.4 portal
2. Go to Configs -> Backup -> Amazon S3
3. Click on edit Configuration
4. Click on Cancel without making any changes
5. Click on Edit configuration again
6. The fields are editable. If yes then we're good to go.