### PR TITLE
[docs] Fix the indentation of ClusterRoleBinding from OpenShift Helm

### DIFF
--- a/docs/content/latest/yugabyte-platform/install-yugabyte-platform/install-software/openshift.md
+++ b/docs/content/latest/yugabyte-platform/install-yugabyte-platform/install-software/openshift.md
@@ -349,14 +349,14 @@ To create a Yugabyte Platform instance, perform the following:
     name: yw-test-cluster-monitoring-view
     labels:
       app: yugaware
-    subjects:
-    - kind: ServiceAccount
-      name: yw-test
-      namespace: yb-platform
-    roleRef:
-      kind: ClusterRole
-      name: cluster-monitoring-view
-      apiGroup: rbac.authorization.k8s.io
+  subjects:
+  - kind: ServiceAccount
+    name: yw-test
+    namespace: yb-platform
+  roleRef:
+    kind: ClusterRole
+    name: cluster-monitoring-view
+    apiGroup: rbac.authorization.k8s.io
   EOF
   ```
 


### PR DESCRIPTION
Scenarios tested:
- Ran the command and created one universe. Was able to see the
  metrics on the overview page.

Fixes https://github.com/yugabyte/yugabyte-db/issues/8976