### PR TITLE
[docs] add aliases to old PITR pages

### DIFF
--- a/docs/content/latest/manage/backup-restore/point-in-time-recovery.md
+++ b/docs/content/latest/manage/backup-restore/point-in-time-recovery.md
@@ -6,6 +6,8 @@ description: Restore data from a specific point in time in YugabyteDB for YSQL
 beta: /latest/faq/general/#what-is-the-definition-of-the-beta-feature-tag
 aliases:
 - /latest/manage/backup-restore/point-in-time-restore
+- /latest/manage/backup-restore/point-in-time-restore-ysql
+- /latest/manage/backup-restore/point-in-time-restore-ycql
 menu:
   latest:
     identifier: point-in-time-recovery


### PR DESCRIPTION
Google is still indexing the old addresses of the PITR pages under /latest/manage. This will avoid 404s. Try the deploy preview link (`point-in-time-restore-ysql`) to verify that you get redirected to `point-in-time-recovery`.

@netlify /latest/manage/backup-restore/point-in-time-restore-ysql/