### PR TITLE
Split off .../type_datetime/intro.md from ~/_index.md.

### DIFF
--- a/docs/content/latest/api/ysql/_index.md
+++ b/docs/content/latest/api/ysql/_index.md
@@ -27,7 +27,7 @@ The main components of YSQL include the data definition language (DDL), the data
 
 {{< note title="Note" >}}
 
-If you don't find what you're looking for in the YSQL documentation, you might find answers in the relevant [PostgreSQL documentation](https://www.postgresql.org/docs/11/index.html). Successive YugabyteDB releases honor PostgreSQL syntax and semantics, although some features (for example those that are specific to the PostgreSQL monolithic SQL database architecture) might not be supported for distributed SQL. The YSQL documentation specifies the supported syntax and extensions.
+If you don't find what you're looking for in the YSQL documentation, you might find answers in the relevant <a href="https://www.postgresql.org/docs/11/index.html" target="_blank">PostgreSQL documentation <i class="fas fa-external-link-alt"></i></a>. Successive YugabyteDB releases honor PostgreSQL syntax and semantics, although some features (for example those that are specific to the PostgreSQL monolithic SQL database architecture) might not be supported for distributed SQL. The YSQL documentation specifies the supported syntax and extensions.
 
 To find the version of the PostgreSQL processing layer used in YugabyteDB, you can use the `version()` function. The following YSQL query displays only the first part of the returned value:
 

--- a/docs/content/latest/api/ysql/datatypes/type_datetime/conceptual-background.md
+++ b/docs/content/latest/api/ysql/datatypes/type_datetime/conceptual-background.md
@@ -12,7 +12,7 @@ isTocNested: true
 showAsideToc: true
 ---
 
-The following subsections provide the conceptual background for the accounts of the _date-time_ data types that the table shown in the [Synopsis](../../type_datetime/#synopsis) lists and for the operations that the _date-time_ operators and built-in SQL functions perform.
+The following subsections provide the conceptual background for the accounts of the _date-time_ data types that the table shown in the [Synopsis](../intro/#synopsis) lists and for the operations that the _date-time_ operators and built-in SQL functions perform.
 
 - [Absolute time and the UTC Time Standard](#absolute-time-and-the-utc-time-standard)
 - [Wall-clock-time and local time](#wall-clock-time-and-local-time)
@@ -31,9 +31,9 @@ Ignoring what Einstein had to say, the absolute time is identical at all spots o
 
 These days, it's easy to find a visual image for the notion of absolute time. Imagine a dedicated TV channel, available everywhere on the planet, that simply broadcasts what a camera sees that's pointing at a clock located in Greenwich UK. The clock is set to what a sundial, standing on the exact zero degree meridian, will read—i.e. it will read 12:00:00 noon when the sundial casts its shortest shadow.
 
-Absolute time can now be measured with very high precision and accuracy with an atomic clock. Seconds, minutes, hours, and days, can all be defined as specific multiples of the caesium standard unit.
+Absolute time can now be measured with very high precision and accuracy with an atomic clock. Seconds, minutes, and hours can all be defined as specific multiples of the caesium standard unit.
 
-Of course, there is a standard for absolute time: the _UTC Time Standard_.
+Of course, there is a standard for absolute time: the _[UTC Time Standard](https://en.wikipedia.org/wiki/Coordinated_Universal_Time)_.
 
 Naturally, this "TV channel" (continuing with this metaphor) is available as a web service—for example, the [World Time API](http://worldtimeapi.org). Try this URL
 
@@ -47,7 +47,7 @@ It returns a JSON document that includes the current absolute time in this [ISO 
 2021-05-16T22:58:53.122521+00:00
 ```
 
-This is usable, as is, as a SQL literal—exploiting the full precision that the plain _timestamp_ and _timestamptz_ data types support.
+This is usable, "as is", as a SQL literal—exploiting the full precision that the plain _timestamp_ and _timestamptz_ data types support.
 
 ```plpgsql
 select ('2021-05-16T22:58:53.122521+00:00'::timestamptz) at time zone 'UTC' as "absolute time";
@@ -72,23 +72,23 @@ It quietly succeeds and produces the obvious result. (The _::text_ typecast of a
  4713-01-01 00:00:00 BC | 294276-01-01 00:00:00
 ```
 
-The values, _4713 BC_ and _294276_ AD, are given in the table at the start of the enclosing [Date and time data types](../../type_datetime/) major section.
+The values, _4713 BC_ and _294276_ AD, are given in the [table](../intro/#synopsis) in the _"Introduction"_ section to the present _date-time_ data types major section.
 
 ## Wall-clock-time and local time
 
-The history of human culture has established the tradition that no matter at what longitude people live, they want to organize their day around the coming and going of daylight (even in places that at some times of the year never experience daylight). "Noon" is a universal notion, and all languages have a word for it—just as they do for "mother" and "father". Wall-clock-time, according to  purist definition, is what you read off a sundial, wherever you happen to be.
+The history of human culture has established the tradition that no matter at what longitude people live, they want to organize their day around the coming and going of daylight (even in places that at some times of the year never experience daylight). "Noon" is a universal notion, and all languages have a word for it—just as they do for "mother" and "father". Wall-clock-time, according to the purist definition, is what you read off a sundial, wherever you happen to be.
 
 People came to understand a long time ago, when reliable mechanical clocks were first invented, that the absolute time at which noon occurs as you circumnavigate along any line of latitude (i.e. as you pass through all longitude values) is not a constant. Rather, it varies continuously.
 
-A local time represents a _conventionalized_ wall-clock-time. You cannot map between these two kinds of values unless you know in which timezone (see below) the "sundial" is located. Moreover, the conversion is non-trivial. All sorts of social factors, like conventions about Daylight Savings Time, matter. But there is no need to rehearse that story here. Modern IT systems, including SQL database systems, have encoded all of the relevant rules. Local time, in a particular timezone quantizes sundial time so that it _typically_ changes in one hour steps when you cross the boundary between adjacent timezones. Some timezones, however, specify offsets from the _UTC Time Standard_ with half-hour, or even quarter-hour, granularity. For example, _Asia/Kabul_ specifies an offset of _04:30:00_; and _Asia/Kathmandu_ specifies an offset of _05:45:00_. (Neither _Asia/Kabul_ nor _Asia/Kathmandu_ observes Daylight Savings Time.)
+A local time represents a _conventionalized_ wall-clock-time. You cannot map between these two kinds of values unless you know in which timezone (see below) the "sundial" is located. Moreover, the conversion is non-trivial. All sorts of social factors, like conventions about Daylight Savings Time, matter. But there is no need to rehearse that story here. Modern IT systems, including SQL database systems, have encoded all of the relevant rules. Local time, in a particular timezone quantizes sundial time so that it _typically_ changes in one hour steps when you cross the boundary between adjacent timezones. Some timezones, however, specify offsets from the _UTC Time Standard_ with half-hour, or even quarter-hour, granularity. For example, _Asia/Kabul_ specifies an offset of _04:30_; and _Asia/Kathmandu_ specifies an offset of _05:45_. (Neither _Asia/Kabul_ nor _Asia/Kathmandu_ observes Daylight Savings Time.)
 
 ## Timezones and the offset from the UTC Time Standard
 
 People around the world prefer a convention that says that noon occurs at 12:00 local time. You need to drive only about 100&nbsp;km to the west (depending on your latitude, to see that sundial noon occurs five minutes later at your journey's destination than at its start. Clearly, not everybody can be happy. This leads to the timezone notion. Loosely, a clock set to local time (like the one on your smartphone) will show something between 11:30 and 12:30 at sundial noon wherever you are on the planet according to the timezone you're in—"loosely", of course, because of two things: _firstly_, because some timezones, like, _Asia/Shanghai_ (this is the canonical name for the timezone that covers the whole of the PRC) cover a much bigger latitude span than corresponds to just a one hour change in the absolute time at which noon occurs); and _secondly_, because of Daylight Savings Time.
 
-- Look at the table shown in [Real timezones that observe Daylight Savings Time](canonical-real-country-with-dst/). (_Real_ means that these canonically-named timezones, unlike _UTC_, are associated with specified geographic regions.) It lists 114 timezones.
+- Look at the table shown in [Real timezones that observe Daylight Savings Time](../timezones/extended-timezone-names/canonical-real-country-with-dst/). (_Real_ means that these canonically-named timezones, unlike _UTC_, are associated with specified geographic regions.) It lists 114 timezones.
 
-- Now look at the table shown in [Real timezones that do not observe Daylight Savings Time](canonical-real-country-no-dst/). It lists 68 timezones.
+- Now look at the table shown in [Real timezones that do not observe Daylight Savings Time](../timezones/extended-timezone-names/canonical-real-country-no-dst/). It lists 68 timezones.
 
 A _real_ timezone, according to a purist definition of this term of art, denotes a region, or maybe a set of regions, where, _by an agreed convention_, all correctly set wall-clocks show the same date and time. These days, the notion of a correctly set wall-clock is immediately understood as what a smartphone shows when the option is selected to set the date and the time automatically. Your smartphone knows where it is and, from this, it knows what timezone it's in. It has access to the _UTC_ time (the absolute date-and-time). And it has access to various facts that characterize its present timezone—in particular, the _current_ offset in hours and minutes from _UTC_. (The qualifier _current_ is important because, in general, the offset from _UTC_ depends on the date according to whether or not the timezone observes Daylight Savings Time.)
 
@@ -157,7 +157,7 @@ This is the result:
 
 Look these up in the [List of tz&nbsp;database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). They do not have a country code, latitude and longitude, or specification of the region covered. In this sense, they are like _UTC_. They are simply canonical names for time standards with particular offsets from _UTC_. All of the offsets are an integral number of hours. Such timezones will be referred to as pseudotimezones in the overall [Date and time data types](../../type_datetime/) section.
 
-The section [Specifying the timezone](../http://localhost:1313/latest/api/ysql/datatypes/type_datetime/). explains how to define the view _extended_pg_timezone_names_. This joins the native catalog view with extra facts from the [List of tz&nbsp;database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+The section [The extended_timezone_names view](../timezones/extended-timezone-names/) explains how to define this view. It joins the native catalog view with extra facts from the [List of tz&nbsp;database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 
 ## The strange history of timezones
 
@@ -261,7 +261,7 @@ You get results like these:
  Pacific/Chatham       |     12:45
 ```
 
-This output was massaged by hand for readability: it retains only those zones that, in the [List of tz&nbsp;database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), have the status _Canonical_; and the seconds field of the display of the offset has been removed because it's always zero. The section [The extended_pg_timezone_names view](../specify-timezone/extended-pg_timezone_names/) explains how to create a view and write a query that produces the output as shown without massage.
+This output was massaged by hand for readability: it retains only those zones that, in the [List of tz&nbsp;database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), have the status _Canonical_; and the seconds field of the display of the offset has been elided because it's always zero. The section [The _extended_pg_timezone_names_ view](../timezones/extended-timezone-names/) explains how to create a view and write a query that produces the output as shown without massage.
 
 ## Two ways of conceiving of time: calendar-time and clock-time
 
@@ -269,7 +269,7 @@ For obvious reasons, most known ancient human cultures, from time immemorial, se
 
 As the ability to count developed, a (lunar) month was seen to be a roughly constant number of days, and a year was seen to be a roughly constant number of (lunar) months.
 
-It was only relatively recently in the history of human culture that clocks were invented: first sundials, then mechanical clocks, and eventually atomic clocks and in particular [the caesium standard](https://en.wikipedia.org/wiki/Caesium_standard). The adoption of hours, minutes, and seconds (as successive subdivisions of the length of a  day) came hand in hand with the invention of clocks. An increase in the accuracy and precision of clocks, and an improvement in observation and thinking in astronomy, brought the realization that one year is not exactly equal to 365 days—as nor need it be. There's no reason to expect that the time it takes for the earth to orbit the sun (one year) should be an integral multiple of the time between successive noons (one day)—nor even any reason to expect that the length of one year or one day should remain constant.
+It was only relatively recently in the history of human culture that clocks were invented: first sundials, then mechanical clocks, and eventually atomic clocks and in particular [the caesium standard](https://en.wikipedia.org/wiki/Caesium_standard). The adoption of hours, minutes, and seconds (as successive subdivisions of the length of a  day) came hand in hand with the invention of clocks. An increase in the accuracy and precision of clocks, and an improvement in observation and thinking in astronomy, brought the realization that one year is not exactly equal to 365 days—as nor need it be. There's no reason to expect that the time it takes for the earth to orbit the sun (one year) should be an integral multiple of the time between successive noons (one day).
 
 It was eventually decided that an atomic clock should define the ultimate standard unit of time and that the _second_ should be defined  as a multiple of the caesium standard unit. One second is defined to be 9,192,631,770 caesium units. See the Wikipedia article [Second](https://en.wikipedia.org/wiki/Second). One minute is defined as exactly 60 seconds. And one hour is defined as exactly 60 minutes. You might be tempted to extend this by saying that one day is exactly 24 hours. But this is complicated by the business of Daylight Savings Time. See [Calendar-time](#calendar-time) below.
 
@@ -298,7 +298,7 @@ Using _calendar-time-semantics_:
 
 The fact that the _clock-time-semantics_ duration of identically specified _calendar-time-semantics_ durations is not constant is defined to be unimportant. You cannot convert deterministically, in either direction, between a _calendar-time-semantics_ duration (years, months, and days) and a _clock-time-semantics_ duration (hours, minutes and seconds) except by asserting an arbitrary rule of thumb.
 
-The calendar encodes all of the relevant special rules—with the critical exception of the facts about Daylights Savings Time periods in all timezones for for all years that the calendar spans.
+The calendar encodes all of the relevant special rules—with the critical exception of the facts about Daylights Savings Time periods in all timezones for all years that the calendar spans. (This information is encoded separately as a mapping from timezone to transition dates.)
 
 Treating one day as exactly 24 hours, one month as 30 days, and one year as 12 months (or alternatively as 365 days) brings inaccuracies and mutual contradictions. Twelve months (30*60 days) is just 360 days—and not 365 (or 366) days. None of this matters at all when _calendar-time-semantics_ durations are needed, or given, only approximately. When you ask a child how old she is, and she answers "seven and three-quarters", this denotes a necessarily approximate _calendar-time-semantics_ duration. And the precision implied by how the duration is stated ("seven and three-quarters" rather then "eight") swamps any concerns about the exact durations of the days, months, and years that the child's lifetime spans.
 
@@ -320,7 +320,7 @@ Of course, you might prefer to use larger units so that you can quote smaller nu
 
 ### Practical examples
 
-The section [Interval arithmetic](../../type_datetime/date-time-data-types-semantics/type-interval/#interval-arithmetic), within the enclosing section [The _interval_ data type and its variants](../../type_datetime/date-time-data-types-semantics/type-interval/), explains the semantics of computing an _interval_ value by subtracting one _timestamp(tz)_ value from another or adding an _interval_ value to, for example, a _timestamp(tz)_ value. Briefly, _calendar-time_semantics_ is always used for the years, months, and days fields. And _clock-time-semantics_ is always used for the hours, minutes, and seconds fields. _Clock-time-semantics_ is used to compute the days field when one _timestamp(tz)_ value is subtracted from another (using the rule of thumb that one day  is _always_ exactly twenty-four hours). And _calendar-time-semantics_ is used when a days field is added to a _timestamp(tz)_ value. This asymmetry might surprise you.
+The section [Interval arithmetic](../../type_datetime/date-time-data-types-semantics/type-interval/#interval-arithmetic), within the enclosing section [The _interval_ data type and its variants](../../type_datetime/date-time-data-types-semantics/type-interval/), explains the semantics of computing an _interval_ value by subtracting one _timestamp(tz)_ value from another or adding an _interval_ value to, for example, a _timestamp(tz)_ value. Briefly, _calendar-time_semantics_ is always used for the years, months, and days fields. And _clock-time-semantics_ is always used for the hours, minutes, and seconds fields. _Clock-time-semantics_ is used to compute the days field when one _timestamp(tz)_ value is subtracted from another (using the rule of thumb that one day is _always_ exactly twenty-four hours). And _calendar-time-semantics_ is used when a days field is added to a _timestamp(tz)_ value. This asymmetry might surprise you.
 
 {{< note title="Interval arithmetic across the moment that the US adopted Standard Time." >}}
 See the section [The strange history of timezones](#the-strange-history-of-timezones) above. Try this:
@@ -374,4 +374,3 @@ The result _"t0 + 1 day"_ is a consequence of _calendar-time-semantics_ (calenda
 
 - one day after 08:00 on some day is just 08:00 on the next day—no matter what conventional adjustment is made to what your clock reads during that interval.
 {{< /note >}}
-

--- a/docs/content/latest/api/ysql/datatypes/type_datetime/date-time-data-types-semantics/type-interval/_index.md
+++ b/docs/content/latest/api/ysql/datatypes/type_datetime/date-time-data-types-semantics/type-interval/_index.md
@@ -14,7 +14,7 @@ showAsideToc: true
 ---
 
 {{< tip title="Install the user-defined interval utility functions now." >}}
-The code is included in a larger set of useful re-useable _date-time_ code. See [Download the '.zip' file to create the reusable code that this overall major section describes](../../#download).
+The code is included in a larger set of useful re-useable _date-time_ code. See [Download the _.zip_ file to create the reusable code that this overall major section describes](../../#download).
 {{< /tip >}}
 
 ## Why does the interval data type exist?

--- a/docs/content/latest/api/ysql/datatypes/type_datetime/date-time-data-types-semantics/type-interval/custom-interval-domains.md
+++ b/docs/content/latest/api/ysql/datatypes/type_datetime/date-time-data-types-semantics/type-interval/custom-interval-domains.md
@@ -13,7 +13,7 @@ showAsideToc: true
 ---
 
 {{< tip title="Download the kit to create the custom interval domains." >}}
-The code that this page presents is included in a larger set of useful re-useable _date-time_ code. In particular, it also installs [User-defined _interval_ utility functions](../interval-utilities/). The custom interval domains code depends on some of these utilities. See [Download the '.zip' file to create the reusable code that this overall major section describes](../../../#download).
+The code that this page presents is included in a larger set of useful re-useable _date-time_ code. In particular, it also installs [User-defined _interval_ utility functions](../interval-utilities/). The custom interval domains code depends on some of these utilities. See [Download the _.zip_ file to create the reusable code that this overall major section describes](../../../#download).
 {{< /tip >}}
 
 Each of the sections [The moment-moment overloads of the "-" operator](../interval-arithmetic/moment-moment-overloads-of-minus/) and [The moment-_interval overloads_ of the "+" and "-" operators](../interval-arithmetic/moment-interval-overloads-of-plus-and-minus/) makes the point that hybrid _interval_ arithmetic is dangerous and recommends that you should ensure that you create and use only _"pure months"_,  _"pure seconds"_, or  _"pure days"_ _interval_ values. And they recommend the adoption of the approach that this section describes so that your good practice will be ensured by using it's APIs rather than the native _interval_ functionality.

--- a/docs/content/latest/api/ysql/datatypes/type_datetime/date-time-data-types-semantics/type-interval/interval-utilities.md
+++ b/docs/content/latest/api/ysql/datatypes/type_datetime/date-time-data-types-semantics/type-interval/interval-utilities.md
@@ -13,7 +13,7 @@ showAsideToc: true
 ---
 
 {{< tip title="Download the kit to create all of the code that this section describes." >}}
-The code is included in a larger set of useful re-useable _date-time_ code. See [Download the '.zip' file to create the reusable code that this overall major section describes](../../../#download).
+The code is included in a larger set of useful re-useable _date-time_ code. See [Download the _.zip_ file to create the reusable code that this overall major section describes](../../../#download).
 {{< /tip >}}
 
 The code presented on this page was designed to support the pedagogy of the code examples in the other sections in the enclosing section [The _interval_ data type and its variants](../../type-interval/). You can install it all, in the order presented here, at any time. It depends only on built-in SQL functions and operators and, for some of the functions, on code that was created previously in the installation order that this page shows.

--- a/docs/content/latest/api/ysql/datatypes/type_datetime/intro.md
+++ b/docs/content/latest/api/ysql/datatypes/type_datetime/intro.md
@@ -1,0 +1,72 @@
+---
+title: Date and time data types—introduction[YSQL]
+headerTitle: Date and time data types—introduction
+linkTitle: introduction
+description: YSQL supports the date, time, timestamp, and interval data types together with interval arithmetic.
+menu:
+  latest:
+    identifier: intro
+    parent: api-ysql-datatypes-datetime
+    weight: 5
+isTocNested: true
+showAsideToc: true
+---
+<p id="download">&nbsp;</p>
+
+{{< tip title="Download the _.zip_ file to create the reusable code that this overall major section describes." >}}
+
+Each of these five sections describes re-useable code that you might find useful:
+
+- [User-defined interval utility functions](../date-time-data-types-semantics/type-interval/interval-utilities/)
+- [Defining and using custom domain types to specialize the native interval functionality](../date-time-data-types-semantics/type-interval/custom-interval-domains/)
+- [The _extended_timezone_names view_](../timezones/extended-timezone-names/)
+- [Recommended practice for specifying the _UTC offset_](../timezones/recommendation/)
+- [Rules for resolving a string that's intended to identify a UTC offset](../timezones/ways-to-spec-offset/name-res-rules/)
+
+Moreover, some of the code examples depend on some of this code. Yugabyte recommends therefore that you download and install the entire kit into the database that you use to support your study of the _date-time_ data types. With this code installed, all the code examples on every page listed in the [Table of contents](../../type_datetime/) will run without error provided only that, in the general case, you run them in the order in which a particular page presents them.
+
+[Download date-and-time-utilities.zip](https://raw.githubusercontent.com/yugabyte/yugabyte-db/master/sample/date-and-time-utilities/date-and-time-utilities.zip) to any convenient directory and unzip it. It creates a small directory hierarchy.
+
+You'll find _README.pdf_ at the top level. It describes the rest of the content and tells you simply to start the master script _0.sql_ at the _ysqlsh_ prompt (or at the _psql_ prompt). You can run it time and again. It will always finish silently.
+{{< /tip >}}
+
+## Synopsis
+
+YSQL supports the following data types for values that represent a date, a time, a _date-time_ pair, or a duration:
+
+| Data type                                                                               | Alias             | Description                            | Min                        | Max                     |
+| --------------------------------------------------------------------------------------- | ----------------- | -------------------------------------- | -------------------------- | ----------------------- |
+| [date](../date-time-data-types-semantics/type-date/)                                     |                   | date (4-bytes)                         | 4713 BC                    | 5874897 AD              |
+| [time](../date-time-data-types-semantics/type-time/) [(p)] [without time zone]           | time [(p)]        | time of day (8-bytes)                  | 00:00:00                   | 24:00:00                |
+| time [(p) with time zone                                                                | timetz [(p)]      | time of day (12-bytes)                 | 00:00:00+14:59             | 24:00:00-14:59          |
+| [timestamp](../date-time-data-types-semantics/type-timestamp/) [(p)] [without time zone] | timestamp [(p)]   | date and time (8-bytes)                | 4713 BC                    | 294276 AD               |
+| [timestamp](../date-time-data-types-semantics/type-timestamp/) [(p)] with time zone      | timestamptz [(p)] | date and time (8-bytes)                | 4713 BC                    | 294276 AD               |
+| [interval](../date-time-data-types-semantics/type-interval/) [fields] [(p)]              |                   | duration (16-bytes 3-field struct)     | -178000000 years (approx) | 178000000 years (approx) |
+
+A value of one of the _date_, _time_, or _timestamp_ data types each represents a _point in time_ (a.k.a. a _moment_). In contrast, a value of the _interval_ data type represents a _duration_. These six data types will be referred to jointly as the _date-time_ data types.
+
+**Note:** The [PostgreSQL documentation](https://www.postgresql.org/docs/11/datatype-datetime.html#DATATYPE-DATETIME-TABLE) recommends against using the _time with time zone_ (a.k.a. _timetz_) data type
+
+> The type _time with time zone_ is defined by the SQL standard, but the definition exhibits properties which lead to questionable usefulness. In most cases, a combination of _date_, _time_, _timestamp without time zone_, and _timestamp with time zone_ should provide a complete range of _date-time_ functionality required by any application.
+
+The thinking is that a notion that expresses only what a clock might read in a particular timezone gives only part of the picture. For example when a clock reads 20:00 in _UTC_, it reads 03:00 in China Standard Time. But 20:00 _UTC_ is the evening of one day and 03:00 is in the small hours of the morning of the _next day_ in China Standard Time. (Neither _UTC_ nor China Standard Time adjusts its clocks for Daylight Savings.) The data type _timestamptz_ represents both the time of day and the date and so it handles the present use case naturally. No further reference will be made to _timetz_.
+
+**Note:** Because of their brevity, the aliases (plain) _timestamp_ and _timestamptz_ will be preferred in the present _date-time_ data types main section to the respective verbose forms _timestamp without time zone_ and _timestamp with time zone_.
+
+**Note:** You might discover that you can define an earlier _timestamp_ value than _4713-01-01 00:00:00 BC_, or a later one than  _294276-01-01 00:00:00_, without error. But you should not rely on this. Rather, you should accept that the values in the "Min" and "Max" columns in the table above specify the _supported_ range.
+
+{{< note title="Notice the 'approx' qualifier by the minimum and maximum interval values." >}}
+You need to understand how an _interval_ value is represented internally as a three-field _[mm, dd, ss]_ tuple to appreciate that the limits must be expressed individually in terms of these fields. The section [Understanding and discovering the upper and lower limits for _interval_ values](../date-time-data-types-semantics/type-interval/interval-limits/) explains all this.
+{{< /note >}}
+
+<p id="table-of-five"> If you follow the advice (above) and avoid <i>timetz</i>, then these _date-time_ data types remain:</p>
+
+| Data type                                                             | Comment                                                                                                          |
+| --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| [_date_](../date-time-data-types-semantics/type-date/)                 | wall-clock-time (local date) moment                                                                              |
+| [plain _time_](../date-time-data-types-semantics/type-time/)           | wall-clock-time (local time) moment                                                                              |
+| [plain _timestamp_](../date-time-data-types-semantics/type-timestamp/) | wall-clock-time (local _date-time_) moment                                                                       |
+| [_timestamptz_](../date-time-data-types-semantics/type-timestamp/)     | absolute _date-time_ moment                                                                                      |
+| [_interval_](../date-time-data-types-semantics/type-interval/)         | duration between EITHER two plain _time_ moments, OR two plain _timestamp_ moments, OR two _timestamptz_ moments |
+
+Modern applications almost always are designed for global deployment. This means that they must accommodate timezones—and that it will be the norm to use the _timestamptz_ data type and not _date_, plain _time_, or plain _timestamp_. Application code will therefore need to be aware of, and to set, the timezone. It's not uncommon to expose the ability to set the timezone to the user so that _date-time_ moments can be shown differently according to the user's present purpose.

--- a/docs/content/latest/api/ysql/datatypes/type_datetime/timezones/extended-timezone-names/_index.md
+++ b/docs/content/latest/api/ysql/datatypes/type_datetime/timezones/extended-timezone-names/_index.md
@@ -1,8 +1,8 @@
 ---
 title: The extended_timezone_names view [YSQL]
-headerTitle: The 'extended_timezone_names' view
+headerTitle: The extended_timezone_names view
 linkTitle: extended_timezone_names
-description: The 'extended_timezone_names' extends the 'pg_timezone_names' view with extra columns from the 'tz database'. [YSQL]
+description: The extended_timezone_names extends the pg_timezone_names view with extra columns from the tz database. [YSQL]
 image: /images/section_icons/api/subsection.png
 menu:
   latest:
@@ -32,8 +32,8 @@ It's useful, therefore, to join these two projections as the _extended_timezone_
 
 ## Create the 'extended_timezone_names' view
 
-{{< tip title="Download a zip of the data and code to create the 'extended_timezone_names' view." >}}
-See [Download the '.zip' file to create the reusable code that the overall _date-time_ major section describes](../../#download). This includes the code and data that creates the _extended_timezone_names_ view. For example, it creates the  user-defined function _[jan_and_jul_tz_abbrevs_and_offsets()](../catalog-views/#the-jan-and-jul-tz-abbrevs-and-offsets-table-function)_ that the _extended_timezone_names_ view depends upon. It also creates the views that are used to produce the tables that this page's child pages show.
+{{< tip title="Download the data and code to create the extended_timezone_names view." >}}
+See [Download the _.zip_ file to create the reusable code that the overall _date-time_ major section describes](../../#download). This includes the code and data that creates the _extended_timezone_names_ view. For example, it creates the  user-defined function _[jan_and_jul_tz_abbrevs_and_offsets()](../catalog-views/#the-jan-and-jul-tz-abbrevs-and-offsets-table-function)_ that the _extended_timezone_names_ view depends upon. It also creates the views that are used to produce the tables that this page's child pages show.
 {{< /tip >}}
 
 {{< note title="Note." >}}

--- a/docs/content/latest/api/ysql/datatypes/type_datetime/timezones/extended-timezone-names/canonical-no-country-no-dst.md
+++ b/docs/content/latest/api/ysql/datatypes/type_datetime/timezones/extended-timezone-names/canonical-no-country-no-dst.md
@@ -14,7 +14,6 @@ showAsideToc: true
 
 This table shows canonically-named timezones that are not associated with a specific country or region—in other words, they are _synthetic_ timezones, a.k.a. _time standards_. _UTC_ is the primary time standard. The remaining rows map all the offsets found among the real timezones that are multiples of one hour. (There are no synthetic timezones that correspond to real timezones with offsets that are non-integral multiples of one hour.) Do this to list the unusual timezones:
 
-
 ```plpgsql
 select
   name,

--- a/docs/content/latest/api/ysql/datatypes/type_datetime/timezones/extended-timezone-names/unrestricted-full-projection.md
+++ b/docs/content/latest/api/ysql/datatypes/type_datetime/timezones/extended-timezone-names/unrestricted-full-projection.md
@@ -1,6 +1,6 @@
 ---
-title: extended_timezone_names — unrestricted full, projection [YSQL]
-headerTitle: extended_timezone_names — unrestricted, full projection
+title: extended_timezone_names — unrestricted full projection [YSQL]
+headerTitle: extended_timezone_names — unrestricted full projection
 linkTitle: unrestricted full projection
 description: Table. [YSQL]
 menu:

--- a/docs/content/latest/api/ysql/datatypes/type_datetime/timezones/recommendation.md
+++ b/docs/content/latest/api/ysql/datatypes/type_datetime/timezones/recommendation.md
@@ -26,7 +26,7 @@ Yugabyte recommends that you create two user-defined function overload sets, thu
 
 Following these recommendations protects you from the many opportunities to go wrong brought by using the native functionality with no constraints; and yet doing so still allows you all the functionality that you could need.
 
-The code that this page presents is included in a larger set of useful re-useable _date-time_ code. See [Download the '.zip' file to create the reusable code that this overall major section describes](../../#download). The code on this page depends on the [custom _interval_ domains](../../date-time-data-types-semantics/type-interval/custom-interval-domains/) code. And this, in turn, depends on the [user-defined utilities](../../date-time-data-types-semantics/type-interval/interval-utilities/).
+The code that this page presents is included in a larger set of useful re-useable _date-time_ code. See [Download the _.zip_ file to create the reusable code that this overall major section describes](../../#download). The code on this page depends on the [custom _interval_ domains](../../date-time-data-types-semantics/type-interval/custom-interval-domains/) code. And this, in turn, depends on the [user-defined utilities](../../date-time-data-types-semantics/type-interval/interval-utilities/).
 {{< /tip >}}
 
 ## The approved_timezone_names view

--- a/docs/content/latest/api/ysql/datatypes/type_datetime/timezones/ways-to-spec-offset/name-res-rules/helper-functions.md
+++ b/docs/content/latest/api/ysql/datatypes/type_datetime/timezones/ways-to-spec-offset/name-res-rules/helper-functions.md
@@ -5,7 +5,7 @@ linkTitle: helper functions
 description: Code to create helper functions for substantiating rules 2, 3, and 4 for specifying the UTC offset. [YSQL]
 menu:
   latest:
-    identifier: helpers
+    identifier: helper-functions
     parent: name-res-rules
     weight: 50
 isTocNested: true

--- a/docs/content/latest/api/ysql/datatypes/type_datetime/timezones/ways-to-spec-offset/name-res-rules/rule-1.md
+++ b/docs/content/latest/api/ysql/datatypes/type_datetime/timezones/ways-to-spec-offset/name-res-rules/rule-1.md
@@ -13,7 +13,7 @@ showAsideToc: true
 ---
 
 {{< tip title="" >}}
-A string that's intended to identify a _UTC offset_ is resolved case-insensitively.
+A string that's intended to identify a _UTC offset_ is resolved case-insensitively. (This excludes, of course, using an explicit select statement from one of the _pg_timezone_names_ or _pg_timezone_abbrevs catalog_ views).
 {{< /tip >}}
 
 The anonymous PL/pgSQL block below looks up the name _America/Costa_Rica_, spelled exactly with that mix of case, in _pg_timezone_names_ and returns its abbreviation. Because an ordinary query with a case-sensitive predicate is used, this confirms the canonical status of the spelling.

--- a/docs/content/latest/api/ysql/datatypes/type_datetime/timezones/ways-to-spec-offset/name-res-rules/rule-2.md
+++ b/docs/content/latest/api/ysql/datatypes/type_datetime/timezones/ways-to-spec-offset/name-res-rules/rule-2.md
@@ -16,7 +16,7 @@ showAsideToc: true
 A string that's intended to identify a _UTC offset_ is never resolved in _pg_timezone_names.abbrev_.
 {{< /tip >}}
 
-You can discover, with _ad hoc_ queries. that the string _WEST_ occurs uniquely in _pg_timezone_names.abbrev_. Use the function [_occurrences()_](../helpers/#function-occurrences-string-in-text) to confirm it thus:
+You can discover, with _ad hoc_ queries. that the string _WEST_ occurs uniquely in _pg_timezone_names.abbrev_. Use the function [_occurrences()_](../helper-functions/#function-occurrences-string-in-text) to confirm it thus:
 
 ```plpgsql
 with c as (select occurrences('WEST') as r)
@@ -35,7 +35,7 @@ This is the result:
  false       | true          | false
 ```
 
-This means that the string _WEST_ can be used as a probe, using the function [_legal_scopes_for_syntax_context()_](../helpers/#function-legal-scopes-for-syntax-context-string-in-text)_:
+This means that the string _WEST_ can be used as a probe, using the function [_legal_scopes_for_syntax_context()_](../helper-functions/#function-legal-scopes-for-syntax-context-string-in-text)_:
 
 ```plpgsql
 select x from legal_scopes_for_syntax_context('WEST');

--- a/docs/content/latest/api/ysql/datatypes/type_datetime/timezones/ways-to-spec-offset/name-res-rules/rule-3.md
+++ b/docs/content/latest/api/ysql/datatypes/type_datetime/timezones/ways-to-spec-offset/name-res-rules/rule-3.md
@@ -16,7 +16,7 @@ showAsideToc: true
 A string that's intended to identify a _UTC offset_ is never resolved in _pg_timezone_abbrevs.abbrev_ as the argument of _set timezone_ but is resolved there as the argument of _at time zone_ (and, equivalently, in _timezone()_) and as the argument of _make_timestamptz()_ (and equivalently within a _text_ literal for a _timestamptz_ value).
 {{< /tip >}}
 
-You can discover, with _ad hoc_ queries. that the string _AZOT_ occurs uniquely in _pg_timezone_names.abbrev_. Use the function [_occurrences()_](../helpers/#function-occurrences-string-in-text) to confirm it thus:
+You can discover, with _ad hoc_ queries. that the string _AZOT_ occurs uniquely in _pg_timezone_names.abbrev_. Use the function [_occurrences()_](../helper-functions/#function-occurrences-string-in-text) to confirm it thus:
 
 ```plpgsql
 with c as (select occurrences('AZOT') as r)
@@ -35,7 +35,7 @@ This is the result:
  false       | false         | true
 ```
 
-This means that the string _AZOT_ can be used as a probe, using the function [_legal_scopes_for_syntax_context()_](../helpers/#function-legal-scopes-for-syntax-context-string-in-text)_:
+This means that the string _AZOT_ can be used as a probe, using the function [_legal_scopes_for_syntax_context()_](../helper-functions/#function-legal-scopes-for-syntax-context-string-in-text)_:
 
 ```plpgsql
 select x from legal_scopes_for_syntax_context('AZOT');

--- a/docs/content/latest/api/ysql/datatypes/type_datetime/timezones/ways-to-spec-offset/name-res-rules/rule-4.md
+++ b/docs/content/latest/api/ysql/datatypes/type_datetime/timezones/ways-to-spec-offset/name-res-rules/rule-4.md
@@ -2,7 +2,7 @@
 title: Rule 4 (for string intended to specify the UTC offset) [YSQL]
 headerTitle: Rule 4
 linkTitle: 4 ~abbrevs.abbrev before ~names.name
-description: ZZZ [YSQL].
+description: Substantiates the rule that a string that's intended to identify a UTC offset is resolved first in pg_timezone_abbrevs.abbrev and, only if this fails, then in pg_timezone_names.name. [YSQL]
 menu:
   latest:
     identifier: rule-4
@@ -22,7 +22,7 @@ The page for [Rule 3](../rule-3) tested with a string that's found uniquely in _
 
 ## Test with a string that's found uniquely in 'pg_timezone_names.name'
 
-You can discover, with _ad hoc_ queries. that the string _Europe/Amsterdam_ occurs only in _pg_timezone_names.name_. Use the function [_occurrences()_](../helpers/#function-occurrences-string-in-text) to confirm it thus
+You can discover, with _ad hoc_ queries. that the string _Europe/Amsterdam_ occurs only in _pg_timezone_names.name_. Use the function [_occurrences()_](../helper-functions/#function-occurrences-string-in-text) to confirm it thus
 
 ```plpgsql
 with c as (select occurrences('Europe/Amsterdam') as r)
@@ -41,7 +41,7 @@ This is the result:
  true        | false         | false
 ```
 
-This means that the string _Europe/Amsterdam_ can be used as a probe, using the function [_legal_scopes_for_syntax_context()_](../helpers/#function-legal-scopes-for-syntax-context-string-in-text)_:
+This means that the string _Europe/Amsterdam_ can be used as a probe, using the function [_legal_scopes_for_syntax_context()_](../helper-functions/#function-legal-scopes-for-syntax-context-string-in-text)_:
 
 ```plpgsql
 select x from legal_scopes_for_syntax_context('Europe/Amsterdam');
@@ -62,7 +62,7 @@ So _pg_timezone_names.name_ is searched in each of the three syntax contexts.
 
 The outcomes of the test that substantiated [Rule-3](../rule-3) and of the test [above](#test-with-a-string-that-s-found-uniquely-in-pg-timezone-names-names) raise the question of priority: what if the string that's intended to specify the _UTC offset_ occurs in _both_ columns?
 
-You can discover, with _ad hoc_ queries. that the string _MET_ occurs both in _pg_timezone_names.name_ and in _pg_timezone_abbrevs.abbrev_. Use the function [_occurrences()_](../helpers/#function-occurrences-string-in-text) to confirm it thus
+You can discover, with _ad hoc_ queries. that the string _MET_ occurs both in _pg_timezone_names.name_ and in _pg_timezone_abbrevs.abbrev_. Use the function [_occurrences()_](../helper-functions/#function-occurrences-string-in-text) to confirm it thus
 
 ```plpgsql
 with c as (select occurrences('MET') as r)
@@ -81,7 +81,7 @@ This is the result:
  true        | false         | true
 ```
 
-This means that the string _MET_ can be used as a probe, using the function [_legal_scopes_for_syntax_context()_](../helpers/#function-legal-scopes-for-syntax-context-string-in-text)_:
+This means that the string _MET_ can be used as a probe, using the function [_legal_scopes_for_syntax_context()_](../helper-functions/#function-legal-scopes-for-syntax-context-string-in-text)_:
 
 ```plpgsql
 select x from legal_scopes_for_syntax_context('MET');


### PR DESCRIPTION
 _index is now just the table of contents. Fixed some broken links.