### PR TITLE
[Platform][Issue #9103] Update "preflight_checks.sh" from ping to tcp check.

### DIFF
--- a/managed/devops/opscli/ybops/data/preflight_checks.sh
+++ b/managed/devops/opscli/ybops/data/preflight_checks.sh
@@ -31,7 +31,7 @@ preflight_provision_check() {
     PORT=443
 
     for i in 1 2 3; do
-      timeout 3 bash -c "cat < /dev/null > /dev/tcp/$HOST/$PORT" --preserve-status && break
+      timeout 3 bash -c "cat < /dev/null > /dev/tcp/${HOST}/${PORT}" --preserve-status && break
     done
     update_result_json_with_rc "Internet Connection" "$?"
   fi

--- a/managed/devops/opscli/ybops/data/preflight_checks.sh
+++ b/managed/devops/opscli/ybops/data/preflight_checks.sh
@@ -25,10 +25,13 @@ preflight_provision_check() {
 
   # Check for internet access.
   if [[ "$airgap" = false ]]; then
-    # Send 3 packets with 3 second timeout and return success if any succeed. Do not send
-    # multiple packets at once since ping will return an error if any packet fails.
+    # Attempt to run "/dev/tcp" 3 times with a 3 second timeout and return success if any succeed.
+    # --preserve-status flag will maintain the exit code of the "/dev/tcp" command.
+    HOST="yugabyte.com"
+    PORT=443
+
     for i in 1 2 3; do
-      ping -c 1 -W 3 www.yugabyte.com && break
+      timeout 3 bash -c "cat < /dev/null > /dev/tcp/$HOST/$PORT" --preserve-status && break
     done
     update_result_json_with_rc "Internet Connection" "$?"
   fi


### PR DESCRIPTION
- The existing check for internet connectivity runs a "ping" check to "yugabyte.com".

- This can be problematic since enterprise customers often block icmp, even when there is internet access.

- The new check uses "/dev/tcp" to try to reach "yugabyte.com" on port 443. This was chosen in favor of netcat since there's no assurance that netcat will be present on the system.