### PR TITLE
exclude docs/** from yugabyted-test github action

### DIFF
--- a/.github/workflows/yugabyted-test.yml
+++ b/.github/workflows/yugabyted-test.yml
@@ -6,12 +6,14 @@ on:
       - master
     paths:
       - '**/yugabyted*'
+      - '!docs/**'
 
   pull_request:
     branches:
       - master
     paths:
       - '**/yugabyted*'
+      - '!docs/**'
 
 jobs:
   yugabyted-test:


### PR DESCRIPTION
Add a path exclusion to yugabyted-test.yaml so changes in the docs tree don't trigger this long job.