### PR TITLE
[docs] explain logs location when using `docker` & `yugabyted` cli

### DIFF
--- a/docs/content/latest/troubleshoot/nodes/check-logs.md
+++ b/docs/content/latest/troubleshoot/nodes/check-logs.md
@@ -22,6 +22,8 @@ For a 3-node cluster, the `yb-ctl` utility creates three directories: `node-1`, 
 - For a multi-node cluster deployment to multiple hosts, the location where YugabyteDB disks are set up can vary (for example, `/home/centos/`, `/mnt/`, or another directory) on each node (host).
 - When using the `--fs_data_dirs` flag with multiple directories, logs will be saved in the first directory in the list.
 - When using Yugabyte Platform, logs are located in `/home/yugabyte/{master,tserver}/logs`. This is a symlink to the first directory in `--fs_data_dirs` list.
+- When using the docker container, logs are located in `/root/var/logs` inside the container.
+- When using the `yugabyted` cli to create the local YugabyteDB cluster, logs are located in `~/var/logs`.
 
 In the sections below, the YugabyteDB `yugabyte-data` directory is represented by `<yugabyte-data-directory>`.
 


### PR DESCRIPTION
Pretty small addition.