### PR TITLE
[Platform] Changes to allow multiple Helm releases in one namespace 

### DIFF
--- a/managed/devops/bin/cluster_health.py
+++ b/managed/devops/bin/cluster_health.py
@@ -180,14 +180,10 @@ class KubernetesDetails():
     def __init__(self, node_fqdn, config_map):
         self.namespace = node_fqdn.split('.')[2]
         self.pod_name = node_fqdn.split('.')[0]
-        # The pod names are yb-master-n/yb-tserver-n where n is the pod number
-        # and yb-master/yb-tserver are the container names.
-
-        # TODO(bhavin192): need to change in case of multiple releases
-        # in one namespace. Something like find the word 'master' in
-        # the name.
-
-        self.container = self.pod_name.rsplit('-', 1)[0]
+        # The pod names are <helm fullname>yb-<master|tserver>-n where
+        # n is the pod number. <helm fullname> can be blank. And
+        # yb-master/yb-tserver are the container names.
+        self.container = "yb-master" if self.pod_name.find("master") > 0 else "yb-tserver"
         self.config = config_map[self.namespace]
 
 

--- a/managed/devops/bin/yb_backup.py
+++ b/managed/devops/bin/yb_backup.py
@@ -549,14 +549,10 @@ class KubernetesDetails():
     def __init__(self, server_fqdn, config_map):
         self.namespace = server_fqdn.split('.')[2]
         self.pod_name = server_fqdn.split('.')[0]
-        # The pod names are yb-master-n/yb-tserver-n where n is the pod number
-        # and yb-master/yb-tserver are the container names.
-
-        # TODO(bhavin192): need to change in case of multiple releases
-        # in one namespace. Something like find the word 'master' in
-        # the name.
-
-        self.container = self.pod_name.rsplit('-', 1)[0]
+        # The pod names are <helm fullname>yb-<master|tserver>-n where
+        # n is the pod number. <helm fullname> can be blank. And
+        # yb-master/yb-tserver are the container names.
+        self.container = "yb-master" if self.pod_name.find("master") > 0 else "yb-tserver"
         self.env_config = os.environ.copy()
         self.env_config["KUBECONFIG"] = config_map[self.namespace]
 

--- a/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/CreateKubernetesUniverse.java
+++ b/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/CreateKubernetesUniverse.java
@@ -62,7 +62,8 @@ public class CreateKubernetesUniverse extends KubernetesTaskBase {
 
       KubernetesPlacement placement = new KubernetesPlacement(pi);
 
-      // TODO(bhavin192): FIX ME: should this be a taskParam?
+      // TODO(bhavin192): REVIEW: should this be a taskParam? I
+      // personally don't think so.
       boolean newNamingStyle = universe.usesHelmNewNamingStyle();
 
       String masterAddresses =

--- a/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/CreateKubernetesUniverse.java
+++ b/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/CreateKubernetesUniverse.java
@@ -62,13 +62,17 @@ public class CreateKubernetesUniverse extends KubernetesTaskBase {
 
       KubernetesPlacement placement = new KubernetesPlacement(pi);
 
+      // TODO(bhavin192): FIX ME: should this be a taskParam?
+      boolean newNamingStyle = universe.usesHelmNewNamingStyle();
+
       String masterAddresses =
           PlacementInfoUtil.computeMasterAddresses(
               pi,
               placement.masters,
               taskParams().nodePrefix,
               provider,
-              taskParams().communicationPorts.masterRpcPort);
+              taskParams().communicationPorts.masterRpcPort,
+              newNamingStyle);
 
       boolean isMultiAz = PlacementInfoUtil.isMultiAZ(provider);
 
@@ -77,7 +81,13 @@ public class CreateKubernetesUniverse extends KubernetesTaskBase {
       createSingleKubernetesExecutorTask(KubernetesCommandExecutor.CommandType.POD_INFO, pi);
 
       Set<NodeDetails> tserversAdded =
-          getPodsToAdd(placement.tservers, null, ServerType.TSERVER, isMultiAz);
+          getPodsToAdd(
+              placement.tservers,
+              null,
+              ServerType.TSERVER,
+              taskParams().nodePrefix,
+              isMultiAz,
+              newNamingStyle);
 
       // Wait for new tablet servers to be responsive.
       createWaitForServersTasks(tserversAdded, ServerType.TSERVER)

--- a/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/EditKubernetesUniverse.java
+++ b/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/EditKubernetesUniverse.java
@@ -89,7 +89,8 @@ public class EditKubernetesUniverse extends KubernetesTaskBase {
 
       currPlacement = new KubernetesPlacement(currPI);
 
-      // TODO(bhavin192): FIX ME: should this be a taskParam?
+      // TODO(bhavin192): REVIEW: should this be a taskParam? I
+      // personally don't think so.
       boolean newNamingStyle = universe.usesHelmNewNamingStyle();
 
       String nodePrefix = taskParams().nodePrefix;

--- a/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/UpgradeKubernetesUniverse.java
+++ b/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/UpgradeKubernetesUniverse.java
@@ -71,7 +71,8 @@ public class UpgradeKubernetesUniverse extends KubernetesTaskBase {
         }
       }
 
-      // TODO(bhavin192): FIX ME: should this be a taskParam?
+      // TODO(bhavin192): REVIEW: should this be a taskParam? I
+      // personally don't think so.
       newNamingStyle = universe.usesHelmNewNamingStyle();
 
       switch (taskParams().taskType) {

--- a/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/UpgradeKubernetesUniverse.java
+++ b/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/UpgradeKubernetesUniverse.java
@@ -37,6 +37,8 @@ public class UpgradeKubernetesUniverse extends KubernetesTaskBase {
 
   public static class Params extends UpgradeParams {}
 
+  boolean newNamingStyle = false;
+
   @Override
   protected UpgradeParams taskParams() {
     return (UpgradeParams) taskParams;
@@ -68,6 +70,9 @@ public class UpgradeKubernetesUniverse extends KubernetesTaskBase {
               "Cluster is already on yugabyte software version: " + taskParams().ybSoftwareVersion);
         }
       }
+
+      // TODO(bhavin192): FIX ME: should this be a taskParam?
+      newNamingStyle = universe.usesHelmNewNamingStyle();
 
       switch (taskParams().taskType) {
         case Software:
@@ -156,7 +161,8 @@ public class UpgradeKubernetesUniverse extends KubernetesTaskBase {
             placement.masters,
             taskParams().nodePrefix,
             provider,
-            universeDetails.communicationPorts.masterRpcPort);
+            universeDetails.communicationPorts.masterRpcPort,
+            newNamingStyle);
 
     if (masterChanged) {
       userIntent.masterGFlags = taskParams().masterGFlags;
@@ -168,7 +174,8 @@ public class UpgradeKubernetesUniverse extends KubernetesTaskBase {
           version,
           taskParams().sleepAfterMasterRestartMillis,
           masterChanged,
-          tserverChanged);
+          tserverChanged,
+          newNamingStyle);
     }
     if (tserverChanged) {
       createLoadBalancerStateChangeTask(false /*enable*/)
@@ -183,7 +190,8 @@ public class UpgradeKubernetesUniverse extends KubernetesTaskBase {
           version,
           taskParams().sleepAfterTServerRestartMillis,
           false /* master change is false since it has already been upgraded.*/,
-          tserverChanged);
+          tserverChanged,
+          newNamingStyle);
 
       createLoadBalancerStateChangeTask(true /*enable*/).setSubTaskGroupType(getTaskSubGroupType());
     }

--- a/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/subtasks/KubernetesCommandExecutor.java
+++ b/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/subtasks/KubernetesCommandExecutor.java
@@ -745,7 +745,7 @@ public class KubernetesCommandExecutor extends UniverseTaskBase {
       overrides.put("oldNamingStyle", false);
     }
 
-    // TODO(bhavin192): FIX ME: do we want to have fullnameOverride
+    // TODO(bhavin192): REVIEW: do we want to have fullnameOverride
     // for Helm?  That way we can avoid the -yugabyte from name. For
     // example, currently the resource names i.e. pods, services etc
     // are generated as yb-dev-my-universe-yugabyte-yb-master-0, we

--- a/managed/src/main/java/com/yugabyte/yw/common/KubernetesManager.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/KubernetesManager.java
@@ -43,8 +43,18 @@ public class KubernetesManager {
   // https://github.com/yugabyte/yugabyte-db/issues/7012
   public ShellResponse applySecret(
       Map<String, String> config, String namespace, String pullSecret) {
+    // TODO(bhavin192): FIX ME: update the kubectl binary to 1.16.x?
+    // --server-side flag ensures that there is no race condition when
+    // --multiple kubectl apply try to apply same secret
     List<String> commandList =
-        ImmutableList.of("kubectl", "apply", "-f", pullSecret, "--namespace", namespace);
+        ImmutableList.of(
+            "kubectl",
+            "apply",
+            "-f",
+            pullSecret,
+            "--namespace",
+            namespace,
+            "--experimental-server-side");
     return execCommand(config, commandList);
   }
 

--- a/managed/src/main/java/com/yugabyte/yw/common/KubernetesManager.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/KubernetesManager.java
@@ -43,9 +43,9 @@ public class KubernetesManager {
   // https://github.com/yugabyte/yugabyte-db/issues/7012
   public ShellResponse applySecret(
       Map<String, String> config, String namespace, String pullSecret) {
-    // TODO(bhavin192): FIX ME: update the kubectl binary to 1.16.x?
+    // TODO(bhavin192): REVIEW: update the kubectl binary to 1.16.x?
     // --server-side flag ensures that there is no race condition when
-    // --multiple kubectl apply try to apply same secret
+    // multiple kubectl apply try to apply same secret.
     List<String> commandList =
         ImmutableList.of(
             "kubectl",

--- a/managed/src/main/java/com/yugabyte/yw/common/Util.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/Util.java
@@ -358,6 +358,9 @@ public class Util {
     return details;
   }
 
+  // Compare v1 and v2 Strings. Returns 0 if the versions are equal, a
+  // positive integer if v1 is newer than v2, a negative integer if v1
+  // is older than v2.
   public static int compareYbVersions(String v1, String v2) {
     Pattern versionPattern = Pattern.compile("^(\\d+.\\d+.\\d+.\\d+)(-(b(\\d+)|(\\w+)))?$");
     Matcher v1Matcher = versionPattern.matcher(v1);

--- a/managed/src/main/java/com/yugabyte/yw/controllers/handlers/UniverseCRUDHandler.java
+++ b/managed/src/main/java/com/yugabyte/yw/controllers/handlers/UniverseCRUDHandler.java
@@ -192,12 +192,13 @@ public class UniverseCRUDHandler {
         taskType = TaskType.CreateKubernetesUniverse;
         universe.updateConfig(
             ImmutableMap.of(Universe.HELM2_LEGACY, Universe.HelmLegacy.V3.toString()));
-        // TODO(bhavin192): FIX ME: new naming style is enabled by
+        // TODO(bhavin192): REVIEW: new naming style is enabled by
         // default for all new versions for now.
 
-        // TODO(bhavin192): FIX ME: set the version to latest release
-        // of 2.7.x.?
-        // https://github.com/yugabyte/charts/commit/5d164cb
+        // TODO(bhavin192): REVIEW: set the version to latest release
+        // of 2.7.x.?  The change
+        // https://github.com/yugabyte/charts/commit/5d164cb seems to
+        // be available in b113.
         if (Util.compareYbVersions(primaryIntent.ybSoftwareVersion, "2.7.2.0-b113") >= 0) {
           universe.updateConfig(
               ImmutableMap.of(Universe.HELM_NAMING_STYLE, Universe.HelmNamingStyle.NEW.toString()));

--- a/managed/src/main/java/com/yugabyte/yw/controllers/handlers/UniverseCRUDHandler.java
+++ b/managed/src/main/java/com/yugabyte/yw/controllers/handlers/UniverseCRUDHandler.java
@@ -192,6 +192,19 @@ public class UniverseCRUDHandler {
         taskType = TaskType.CreateKubernetesUniverse;
         universe.updateConfig(
             ImmutableMap.of(Universe.HELM2_LEGACY, Universe.HelmLegacy.V3.toString()));
+        // TODO(bhavin192): FIX ME: new naming style is enabled by
+        // default for all new versions for now.
+
+        // TODO(bhavin192): FIX ME: set the version to latest release
+        // of 2.7.x.?
+        // https://github.com/yugabyte/charts/commit/5d164cb
+        if (Util.compareYbVersions(primaryIntent.ybSoftwareVersion, "2.7.2.0-b113") >= 0) {
+          universe.updateConfig(
+              ImmutableMap.of(Universe.HELM_NAMING_STYLE, Universe.HelmNamingStyle.NEW.toString()));
+        } else {
+          universe.updateConfig(
+              ImmutableMap.of(Universe.HELM_NAMING_STYLE, Universe.HelmNamingStyle.OLD.toString()));
+        }
       } else {
         if (primaryCluster.userIntent.enableIPV6) {
           throw new YWServiceException(
@@ -883,6 +896,10 @@ public class UniverseCRUDHandler {
                 + " as it is not helm 3 compatible. "
                 + "Manually migrate the deployment to helm3 "
                 + "and then mark the universe as helm 3 compatible.");
+      }
+      if (!universeConfig.containsKey(Universe.HELM_NAMING_STYLE)) {
+        universe.updateConfig(
+            ImmutableMap.of(Universe.HELM_NAMING_STYLE, Universe.HelmNamingStyle.OLD.toString()));
       }
     }
 

--- a/managed/src/main/java/com/yugabyte/yw/models/Universe.java
+++ b/managed/src/main/java/com/yugabyte/yw/models/Universe.java
@@ -38,6 +38,7 @@ public class Universe extends Model {
   public static final String DISABLE_ALERTS_UNTIL = "disableAlertsUntilSecs";
   public static final String TAKE_BACKUPS = "takeBackups";
   public static final String HELM2_LEGACY = "helm2Legacy";
+  public static final String HELM_NAMING_STYLE = "helmNamingStyle";
 
   private static void checkUniverseInCustomer(UUID universeUUID, Customer customer) {
     if (!customer.getUniverseUUIDs().contains(universeUUID)) {
@@ -58,6 +59,11 @@ public class Universe extends Model {
   public enum HelmLegacy {
     V3,
     V2TO3
+  }
+
+  public enum HelmNamingStyle {
+    NEW,
+    OLD
   }
 
   // The universe UUID.
@@ -825,5 +831,21 @@ public class Universe extends Model {
           Json.fromJson(detailsJson.get("placementInfo"), PlacementInfo.class);
       universe.universeDetails.upsertPrimaryCluster(userIntent, placementInfo);
     }
+  }
+
+  /**
+   * Check if the universe uses NEW {@link HelmNamingStyle}. This configuration key is used by
+   * Kubernetes based universes.
+   *
+   * @return true only if the HELM_NAMING_STYLE is present in the configuration and is set to NEW,
+   *     otherwise false.
+   */
+  public boolean usesHelmNewNamingStyle() {
+    String helmNamingStyle =
+        getConfig().getOrDefault(HELM_NAMING_STYLE, HelmNamingStyle.OLD.toString());
+    if (helmNamingStyle.equals(HelmNamingStyle.NEW.toString())) {
+      return true;
+    }
+    return false;
   }
 }


### PR DESCRIPTION
Adds a new universe configuration key HELM_NAMING_STYLE, the new naming style is enabled for all the YugabyteDB installations which are newer than 2.7.2.0-b113, as this version has Helm chart related changes required for this naming to work.

Make changes to Create, Update, Edit flows, backup and healthchecks scripts, metrics accordingly.

When we try to create multiple Helm releases in one namespace, we try to apply the same pull secret in same namespace in parallel. There is a race condition with `kubectl apply` on the client side (kubectl side), it fails with an error saying the secret already exist. This is fixed by using server side apply, the flag is experimental in 1.15 but from Kubernetes 1.16 the feature is marked as beta and hence available everywhere.

I will update the commit message, add test scenarios, once an initial review is done. 

Comments marked with `TODO(bhavin192): REVIEW:` are the ones where I would like to have opinion or comment from reviewer.

Fixes https://github.com/yugabyte/yugabyte-db/issues/8565