### PR TITLE
(YUGA-9261) - Disable "Pause Universe" operation for Read-Only users in YB-PLATFORM

### DIFF
--- a/managed/src/main/resources/cloudFeatureConfig.json
+++ b/managed/src/main/resources/cloudFeatureConfig.json
@@ -24,7 +24,7 @@
         "editUniverse": "hidden",
         "manageEncryption": "hidden",
         "restartUniverse": "hidden",
-        "pausedUniverse": "enabled",
+        "pausedUniverse": "hidden",
         "deleteUniverse": "hidden",
         "costs": "hidden"
       },

--- a/managed/src/main/resources/cloudFeatureConfig.json
+++ b/managed/src/main/resources/cloudFeatureConfig.json
@@ -24,6 +24,7 @@
         "editUniverse": "hidden",
         "manageEncryption": "hidden",
         "restartUniverse": "hidden",
+        "pausedUniverse": "enabled",
         "deleteUniverse": "hidden",
         "costs": "hidden"
       },

--- a/managed/src/main/resources/ossFeatureConfig.json
+++ b/managed/src/main/resources/ossFeatureConfig.json
@@ -40,6 +40,7 @@
         "restartUniverse": "disabled",
         "metricsInterval": 15000,
         "editUniverse": "hidden",
+        "pausedUniverse": "enabled",
         "deleteUniverse": "disabled"
       }
     },

--- a/managed/src/main/resources/ossFeatureConfig.json
+++ b/managed/src/main/resources/ossFeatureConfig.json
@@ -40,7 +40,7 @@
         "restartUniverse": "disabled",
         "metricsInterval": 15000,
         "editUniverse": "hidden",
-        "pausedUniverse": "enabled",
+        "pausedUniverse": "hidden",
         "deleteUniverse": "disabled"
       }
     },

--- a/managed/src/main/resources/readOnlyFeatureConfig.json
+++ b/managed/src/main/resources/readOnlyFeatureConfig.json
@@ -20,6 +20,7 @@
         "readReplica": "hidden",
         "manageEncryption": "hidden",
         "restartUniverse": "hidden",
+        "pausedUniverse": "disabled",
         "deleteUniverse": "hidden",
         "costs": "hidden"
       }

--- a/managed/ui/src/components/universes/UniverseDetail/UniverseDetail.js
+++ b/managed/ui/src/components/universes/UniverseDetail/UniverseDetail.js
@@ -665,11 +665,22 @@ class UniverseDetail extends Component {
                       2. One more condition needs to be added which specifies the
                       current status of the universe. */}
 
+                      {/*
+                      Read-only users should not be given the rights to "Pause Universe"
+                      */
+                      }
+
                       {isAWSUniverse(currentUniverse?.data) &&
                         !isEphemeralAwsStorage &&
                         (featureFlags.test['pausedUniverse'] ||
                           featureFlags.released['pausedUniverse']) && (
-                          <YBMenuItem onClick={showToggleUniverseStateModal}>
+                          <YBMenuItem 
+                            onClick={showToggleUniverseStateModal}
+                            availability={getFeatureState(
+                              currentCustomer.data.features,
+                              'universes.details.overview.pausedUniverse'
+                            )}
+                          >
                             <YBLabelWithIcon icon="fa fa-pause-circle-o">
                               {!universePaused ? 'Pause Universe' : 'Resume Universe'}
                             </YBLabelWithIcon>


### PR DESCRIPTION
Description
--
Disable "Pause Universe" operation for Read-Only users in YB-PLATFORM

Changes
--
On a high level
1. Since the READONLY user should have the `Pause Universe` disabled, ensure to have the `Available` property for the element
2. Ensure in the `readOnlyConfig.json`, set "pausedUniverse" to disabled and in other configs set it to "enabled", this is to ensure only readOnly users should have it disabled and not other users
