### PR TITLE
[#9430] Added success message for all tablets and single tablet compaction

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -139,3 +139,4 @@ This is a list of people who have contributed code to the [YugabyteDB](https://g
 * [jackstenglein](https://github.com/jackstenglein)
 * [BozhiYou](https://github.com/bozhiyou)
 * [pkj415](https://github.com/pkj415)
+* [leeleeian](https://github.com/leeleeian)

--- a/src/yb/tools/ts-cli.cc
+++ b/src/yb/tools/ts-cli.cc
@@ -469,6 +469,9 @@ Status TsAdminClient::FlushTablets(const std::string& tablet_id, bool is_compact
     return STATUS(IOError, "Failed to flush tablet: ",
                            resp.error().ShortDebugString());
   }
+  std::cout << "Successfully " << (is_compaction ? "compacted " : "flushed ")
+            << (tablet_id.empty() ? "all tablets" : "tablet <" + tablet_id + ">")
+            << std::endl;
   return Status::OK();
 }
 


### PR DESCRIPTION
There was no notification for completion of all tablets compaction previously. 
This PR adds 2 print statements following the completion of compaction for single tablet and all tablets.