### PR TITLE
[docs] adjust copy button behaviour on code blocks

### DIFF
--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -151,8 +151,8 @@ $(document).ready(() => {
       let regExpCopy = /a^/;
       if (languageDescriptor) {
         // Then apply copy button
-        // Strip the prompt from SQL languages
-        if (['pgsql', 'plpgsql', 'postgres', 'postgresql', 'sql'].includes(languageDescriptor)) {
+        // Strip the prompt from CQL/SQL languages
+        if (['cassandra', 'cql', 'pgsql', 'plpgsql', 'postgres', 'postgresql', 'sql'].includes(languageDescriptor)) {
           if (element.textContent.match(/^[0-9a-z_.:@=^]{1,30}[>|#]\s/gm)) {
             regExpCopy = /^[0-9a-z_.:@=^]{1,30}[>|#]\s/gm;
           }
@@ -163,8 +163,11 @@ $(document).ready(() => {
           } else if (element.textContent.match(/^[0-9a-z_.:@=^]{1,30}[>|#]\s/gm)) {
             regExpCopy = /^[0-9a-z_.:@=^]{1,30}[>|#]\s/gm;
           }
-        // Don't add a copy button to blocks labeled "output"
-        } else if (['output'].includes(languageDescriptor)) {
+        // Don't add a copy button to language names that include "output" or "nocopy".
+        // For example, `output.xml` or `nocopy.java`.
+        } else if (languageDescriptor.includes('output')) {
+          return;
+        } else if (languageDescriptor.includes('nocopy')) {
           return;
         }
         const button = document.createElement('button');


### PR DESCRIPTION
A couple of code-block handling changes.

1. Strip prompts from `cassandra` and `cql` blocks. (Yes, these are valid source-highlighter languages, and distinct from the sql ones...)

2. Adjust how the `output` language works, and add a `nocopy` one. Specify either one alone and they both work as output did before. Or, append a language name to have the code block highlighted but _without_ a copy button.

    \
    All of these are valid: `output`, `nocopy`, `nocopy.java`, and `output.json`. (The language name needs to come last!)

**Discussion**

First thing, you can keep on going with blocks tagged as `output` just like you could before. This change adds options, but doesn't change that base behaviour.

We could drop the "output" and just go with "nocopy", but:

- there's a lot of output already tagged in the docs
- `output` makes sense, semantically, as a (non-)highlight language for _output_
- as does `nocopy`, for other stuff the reader shouldn't need to copy :)

**One potential downside**: you need a bit more complex search pattern to find all code blocks of a given type. Instead of a simple search for this:

````markdown
```xml
````

you'd need to do a regular-expression search along the lines of this, instead:

````markdown
```.*xml
````
