### PR TITLE
[docs] CloudFormation and docker compose fixes

### DIFF
--- a/docs/content/latest/deploy/docker/docker-compose.md
+++ b/docs/content/latest/deploy/docker/docker-compose.md
@@ -32,7 +32,7 @@ showAsideToc: true
   </li>
 </ul>
 
-Use [docker-compose](https://docs.docker.com/compose/overview/) utility to create and manage YugabyteDB local clusters. Note that this approach is not recommended for multi-node clusters used for performance testing and production environments.
+Use [docker-compose](https://docs.docker.com/compose/overview/) utility to create and manage YugabyteDB local clusters. Note that this approach is not recommended for multi-node clusters used for performance testing and production environments. Refer to the [deployment checklist](../../../deploy/checklist/) to understand the configuration to create clusters.
 
 ## Prerequisites
 

--- a/docs/content/latest/deploy/public-clouds/aws/cloudformation.md
+++ b/docs/content/latest/deploy/public-clouds/aws/cloudformation.md
@@ -77,8 +77,7 @@ $ aws cloudformation describe-stacks \
 
 From this output, you will be able to get the VPC id and YugabyteDB admin URL.
 
-Because the stack creates a security group that restricts access to the database, you might need to update the security group inbound rules if you have trouble connecting to it. 
-if you have trouble connecting to the DB.
+Because the stack creates a security group that restricts access to the database, you might need to update the security group inbound rules if you have trouble connecting to the DB.
 
 ## AWS Console
 


### PR DESCRIPTION
- Cloud Formation page need a fix in this line : "Because the stack creates a security group that restricts access to the database, you might need to update the security group inbound rules if you have trouble connecting to it. if you have trouble connecting to the DB."
Build preview: https://deploy-preview-9830--infallible-bardeen-164bc9.netlify.app/latest/deploy/public-clouds/aws/cloudformation/

- Added the link to the Deployment checklist before creating clusters on the Docker compose page. This could help with understanding replication and other necessary configs.
Build preview: https://deploy-preview-9830--infallible-bardeen-164bc9.netlify.app/latest/deploy/docker/docker-compose/