### PR TITLE
[docs] yb-ctl explain how to quote flags

### DIFF
--- a/docs/content/latest/admin/yb-ctl.md
+++ b/docs/content/latest/admin/yb-ctl.md
@@ -470,6 +470,12 @@ To add a node with custom YB-Master flags:
 $ ./bin/yb-ctl add_node --master_flags "log_cache_size_limit_mb=128,log_min_seconds_to_retain=20"
 ```
 
+To handle flags whose value contains commas or equals, quote the whole key-value pair with double-quotes:
+
+```sh
+$ ./bin/yb-ctl create --tserver_flags 'ysql_enable_auth=false,"vmodule=tablet_service=1,pg_doc_op=1",ysql_prefetch_limit=1000'
+```
+
 ### Restart a cluster
 
 The `yb-ctl restart` command can be used to restart a cluster. Please note that if you restart the cluster, all custom defined flags and placement information will be lost. Nevertheless, you can pass the placement information and custom flags in the same way as they are passed in the `yb-ctl create` command.

--- a/scripts/installation/bin/yb-ctl
+++ b/scripts/installation/bin/yb-ctl
@@ -25,12 +25,13 @@ Creating a cluster with replication factor 5
   yb-ctl --rf 5 start
 
 Creating a cluster with placement_info
-  yb-ctl start
-  --placement_info 'cloud1.region1.zone1,cloud2.region2.zone2,cloud3.region3.zone3'
+  yb-ctl start \\
+    --placement_info 'cloud1.region1.zone1,cloud2.region2.zone2,cloud3.region3.zone3'
 
 Creating a cluster with custom flags
-  yb-ctl start --master_flags 'flag1=value,flag2=value,flag3=value'
-  --tserver_flags 'flag1=value,flag2=value,flag3=value'
+  yb-ctl start \\
+    --master_flags 'flag1=value,flag2=value,flag3=value' \\
+    --tserver_flags 'flag1=value,flag2=value,flag3=value'
 
 Destroying a cluster
   yb-ctl destroy

--- a/scripts/installation/bin/yb-ctl
+++ b/scripts/installation/bin/yb-ctl
@@ -28,7 +28,7 @@ Creating a cluster with placement_info
   yb-ctl start
   --placement_info "cloud1.region1.zone1,cloud2.region2.zone2,cloud3.region3.zone3"
 
-Creating a cluster with custom_flags
+Creating a cluster with custom flags
   yb-ctl start --master_flags "flag1=value,flag2=value,flag3=value"
   --tserver_flags "flag1=value,flag2=value,flag3=value"
 

--- a/scripts/installation/bin/yb-ctl
+++ b/scripts/installation/bin/yb-ctl
@@ -31,7 +31,7 @@ Creating a cluster with placement_info
 Creating a cluster with custom flags
   yb-ctl start \\
     --master_flags 'flag1=value,flag2=value,flag3=value' \\
-    --tserver_flags 'flag1=value,flag2=value,flag3=value'
+    --tserver_flags 'flag1=value,"flag2=complex=,=,=,value",flag3=value'
 
 Destroying a cluster
   yb-ctl destroy

--- a/scripts/installation/bin/yb-ctl
+++ b/scripts/installation/bin/yb-ctl
@@ -25,8 +25,7 @@ Creating a cluster with replication factor 5
   yb-ctl --rf 5 start
 
 Creating a cluster with placement_info
-  yb-ctl start \\
-    --placement_info 'cloud1.region1.zone1,cloud2.region2.zone2,cloud3.region3.zone3'
+  yb-ctl start --placement_info 'cloud1.region1.zone1,cloud2.region2.zone2,cloud3.region3.zone3'
 
 Creating a cluster with custom flags
   yb-ctl start \\

--- a/scripts/installation/bin/yb-ctl
+++ b/scripts/installation/bin/yb-ctl
@@ -25,7 +25,7 @@ Creating a cluster with replication factor 5
   yb-ctl --rf 5 start
 
 Creating a cluster with placement_info
-  yb-ctl start --placement_info 'cloud1.region1.zone1,cloud2.region2.zone2,cloud3.region3.zone3'
+  yb-ctl start --placement_info "cloud1.region1.zone1,cloud2.region2.zone2,cloud3.region3.zone3"
 
 Creating a cluster with custom flags
   yb-ctl start \\

--- a/scripts/installation/bin/yb-ctl
+++ b/scripts/installation/bin/yb-ctl
@@ -26,11 +26,11 @@ Creating a cluster with replication factor 5
 
 Creating a cluster with placement_info
   yb-ctl start
-  --placement_info "cloud1.region1.zone1,cloud2.region2.zone2,cloud3.region3.zone3"
+  --placement_info 'cloud1.region1.zone1,cloud2.region2.zone2,cloud3.region3.zone3'
 
 Creating a cluster with custom flags
-  yb-ctl start --master_flags "flag1=value,flag2=value,flag3=value"
-  --tserver_flags "flag1=value,flag2=value,flag3=value"
+  yb-ctl start --master_flags 'flag1=value,flag2=value,flag3=value'
+  --tserver_flags 'flag1=value,flag2=value,flag3=value'
 
 Destroying a cluster
   yb-ctl destroy


### PR DESCRIPTION
yb-ctl --master_flags and --tserver_flags each take a comma-separated
list of key-value pairs.  It gets tricky when the value has commas or
equals.  Explain how to deal with that in the docs and script docstring.