### PR TITLE
[#9850][Platform] - Fix suggested Paths for Node Cert Path and Key

### DIFF
--- a/managed/ui/src/components/config/Security/certificates/AddCertificateForm.js
+++ b/managed/ui/src/components/config/Security/certificates/AddCertificateForm.js
@@ -56,8 +56,8 @@ export default class AddCertificateForm extends Component {
 
   placeholderObject = {
     rootCACert: '/opt/yugabyte/keys/cert1/ca.crt',
-    nodeCertPath: '/opt/yugabyte/keys/cert1/node.key',
-    nodeCertPrivate: '/opt/yugabyte/keys/cert1/node.crt',
+    nodeCertPath: '/opt/yugabyte/keys/cert1/node.crt',
+    nodeCertPrivate: '/opt/yugabyte/keys/cert1/node.key',
     clientCertPath: '/opt/yugabyte/yugaware/data/cert1/client.crt',
     clientKeyPath: '/opt/yugabyte/yugaware/data/cert1/client.key'
   };


### PR DESCRIPTION
Current Behavior:
When creating a new CA signed certificate, the suggested paths for Node Cert and Node Key are reversed. Currently, for Database Node Certificate Path, the suggested path is /opt/yugabyte/keys/cert1/node.key but it should be /opt/yugabyte/keys/cert1/node.crt. And, for Database Node Certificate Private Key, the suggested path is /opt/yugabyte/keys/cert1/node.crt but it should be /opt/yugabyte/keys/cert1/node.key.

Please refer to https://github.com/yugabyte/yugabyte-db/issues/9850