### PR TITLE
[docs] redirect deleted spring page to integrations

### DIFF
--- a/docs/content/latest/integrations/spring-framework/_index.md
+++ b/docs/content/latest/integrations/spring-framework/_index.md
@@ -5,6 +5,7 @@ linkTitle: Spring Framework
 description: Using Spring Framework with YugabyteDB
 headcontent: Using Spring Framework with YugabyteDB
 aliases:
+- /latest/reference/drivers/spring-data-yugabytedb
 image: /images/section_icons/develop/ecosystem/spring.png
 menu:
   latest:


### PR DESCRIPTION
**NOTE** click the PR preview link once the Netlify bot has added it, and make sure you get redirected to `/latest/integrations/spring-framework/`

@netlify /latest/reference/drivers/spring-data-yugabytedb