### PR TITLE
[docs] improve docs build and hugo caching

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -34,6 +34,9 @@ params:
     apiKey: 12bc78d612b87db0163597f245889f18
   bigpicture:
     projectId: 1064
+  ui:
+    # https://github.com/gohugoio/hugo/issues/8918#issuecomment-903314696
+    sidebar_cache_limit: 1
 social: {}
 menu:
   main:

--- a/docs/layouts/_default/list.html
+++ b/docs/layouts/_default/list.html
@@ -25,7 +25,7 @@
 				<div class="image">
 					<img alt="{{ .Title }}" title="{{ .Title }}" src="{{ .Page.Params.image }}" />
 				</div>
-				{{ partialCached "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) .Section }}
+				{{ partial "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) }}
 
 				<h1>{{ if .Page.Params.headerTitle }}{{ .Page.Params.headerTitle }}{{ else }}{{ .Page.Title }}{{ end }}  {{ if .Draft }} (Draft){{ end }}</h1>
 

--- a/docs/layouts/_default/list.html
+++ b/docs/layouts/_default/list.html
@@ -13,7 +13,7 @@
 <input class="toggle" type="checkbox" id="toggle-search">
 <label class="toggle-button overlay" for="toggle-drawer"></label>
 
-{{ partial "header" . }}
+{{ partialCached "header" . }}
 
 <div class="container-fluid listpage">
 	<main class="main">
@@ -25,7 +25,7 @@
 				<div class="image">
 					<img alt="{{ .Title }}" title="{{ .Title }}" src="{{ .Page.Params.image }}" />
 				</div>
-				{{ partial "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) }}	
+				{{ partialCached "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) .Section }}
 
 				<h1>{{ if .Page.Params.headerTitle }}{{ .Page.Params.headerTitle }}{{ else }}{{ .Page.Title }}{{ end }}  {{ if .Draft }} (Draft){{ end }}</h1>
 
@@ -52,7 +52,7 @@
 
 				</div>
 				
-				{{ partial "footer_links" . }}
+				{{ partialCached "footer_links" . }}
 
 			</article>
 
@@ -67,5 +67,5 @@
 	</main>
 </div>
 
-{{ partial "footer" . }}
-{{ partial "footer_js" . }}
+{{ partialCached "footer" . }}
+{{ partialCached "footer_js" . }}

--- a/docs/layouts/_default/single.html
+++ b/docs/layouts/_default/single.html
@@ -25,7 +25,7 @@
 			<div class="wrapper">
 				<div class="content-flex-wrapper">
 					<div class="content-flex-container">
-						{{ partialCached "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) .Section }}
+						{{ partialCached "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) .CurrentSection }}
 
 						<h1>{{ if .Page.Params.headerTitle }}{{ .Page.Params.headerTitle }}{{ else }}{{ .Page.Title }}{{ end }} {{ if .Draft }} (Draft){{ end }}{{ if .Page.Params.beta }}<a class="tag-beta" href="{{ .Page.Params.beta }}">Beta</a>{{ end }}</h1>
 

--- a/docs/layouts/_default/single.html
+++ b/docs/layouts/_default/single.html
@@ -13,7 +13,7 @@
 <input class="toggle" type="checkbox" id="toggle-search">
 <label class="toggle-button overlay" for="toggle-drawer"></label>
 
-{{ partial "header" . }}
+{{ partialCached "header" . }}
 
 <div class="container-fluid">
 	<main class="main">
@@ -25,7 +25,7 @@
 			<div class="wrapper">
 				<div class="content-flex-wrapper">
 					<div class="content-flex-container">
-						{{ partial "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) }}
+						{{ partialCached "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) .Section }}
 
 						<h1>{{ if .Page.Params.headerTitle }}{{ .Page.Params.headerTitle }}{{ else }}{{ .Page.Title }}{{ end }} {{ if .Draft }} (Draft){{ end }}{{ if .Page.Params.beta }}<a class="tag-beta" href="{{ .Page.Params.beta }}">Beta</a>{{ end }}</h1>
 
@@ -64,8 +64,8 @@
 					{{ partial "pagination" . }}
 				{{ end }}
 -->
-				{{ partial "footer_links" . }}
-				<!--{{ partial "feedback" . }}-->
+				{{ partialCached "footer_links" . }}
+				<!--{{ partialCached "feedback" . }}-->
 		</article>
 		<div class="modal fade" id="imageModal" tabindex="-1" role="dialog" aria-labelledby="imageModal" aria-hidden="true">
 			<div class="modal-dialog" role="document">
@@ -87,8 +87,8 @@
 	</main>
 </div>
 
-{{ partial "footer_content" . }}
-{{ partial "footer_js" . }}
+{{ partialCached "footer_content" . }}
+{{ partialCached "footer_js" . }}
 
 <script>
 	const pageConfig = {

--- a/docs/layouts/_default/term.html
+++ b/docs/layouts/_default/term.html
@@ -18,7 +18,7 @@
   <input class="toggle" type="checkbox" id="toggle-search">
   <label class="toggle-button overlay" for="toggle-drawer"></label>
 
-  {{ partial "header" . }}
+  {{ partialCached "header" . }}
 
   <main class="main">
     <div class="drawer">
@@ -27,7 +27,7 @@
 
     <article class="article">
       <div class="wrapper">
-				{{ partial "breadcrumbs" (dict "context" . "menu" (.Site.Menus.latest)) }}	
+				{{ partialCached "breadcrumbs" (dict "context" . "menu" (.Site.Menus.latest)) .Section }}	
 
 
         {{ range $key, $value := ($.Scratch.Get "terms") }}
@@ -50,5 +50,5 @@
     </div>
   </main>
 
-  {{ partial "footer" . }}
-  {{ partial "footer_js" . }}
+  {{ partialCached "footer" . }}
+  {{ partialCached "footer_js" . }}

--- a/docs/layouts/_default/term.html
+++ b/docs/layouts/_default/term.html
@@ -27,7 +27,7 @@
 
     <article class="article">
       <div class="wrapper">
-				{{ partialCached "breadcrumbs" (dict "context" . "menu" (.Site.Menus.latest)) .Section }}	
+				{{ partial "breadcrumbs" (dict "context" . "menu" (.Site.Menus.latest)) }}	
 
 
         {{ range $key, $value := ($.Scratch.Get "terms") }}

--- a/docs/layouts/home.html
+++ b/docs/layouts/home.html
@@ -13,7 +13,7 @@
 <input class="toggle" type="checkbox" id="toggle-search">
 <label class="toggle-button overlay" for="toggle-drawer"></label>
 
-{{ partial "header" . }}
+{{ partialCached "header" . }}
 
 <div class="container">
 <main class="main">
@@ -55,5 +55,5 @@
 	</div>
 </main>
 
-{{ partial "footer" . }}
-{{ partial "footer_js" . }}
+{{ partialCached "footer" . }}
+{{ partialCached "footer_js" . }}

--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -13,7 +13,7 @@
 <input class="toggle" type="checkbox" id="toggle-search">
 <label class="toggle-button overlay" for="toggle-drawer"></label>
 
-{{ partial "header" . }}
+{{ partialCached "header" . }}
 
 <div class="container">
 <main class="main">
@@ -45,5 +45,5 @@
 	</div>
 </main>
 
-{{ partial "footer" . }}
-{{ partial "footer_js" . }}
+{{ partialCached "footer" . }}
+{{ partialCached "footer_js" . }}

--- a/docs/layouts/indexpage/list.html
+++ b/docs/layouts/indexpage/list.html
@@ -13,7 +13,7 @@
 <input class="toggle" type="checkbox" id="toggle-search">
 <label class="toggle-button overlay" for="toggle-drawer"></label>
 
-{{ partial "header" . }}
+{{ partialCached "header" . }}
 
 <div class="container indexpage">
 		<div id="particles-js"></div>
@@ -28,6 +28,6 @@
 		</div>
 </div>
 
-{{ partial "footer" . }}
+{{ partialCached "footer" . }}
 {{ partial "indexpage_js" . }}
-{{ partial "footer_js" . }}
+{{ partialCached "footer_js" . }}

--- a/docs/layouts/indexpage/single.html
+++ b/docs/layouts/indexpage/single.html
@@ -13,7 +13,7 @@
 <input class="toggle" type="checkbox" id="toggle-search">
 <label class="toggle-button overlay" for="toggle-drawer"></label>
 
-{{ partial "header" . }}
+{{ partialCached "header" . }}
 
 <div class="container">
 	<main class="main">
@@ -22,7 +22,7 @@
 		</div> 
 		<article class="article">
 			<div class="wrapper">
-				{{ partial "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) }}	
+				{{ partialCached "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) .Section }}	
 
 				{{ range where .Site.Pages "Type" "index" }}
 					<h1>{{ if .Page.Params.headerTitle }}{{ .Page.Params.headerTitle }}{{ else }}{{ .Page.Title }}{{ end }} {{ if .Draft }} (Draft){{ end }}</h1>
@@ -50,5 +50,5 @@
 	</main>
 </div>
 
-{{ partial "footer" . }}
-{{ partial "footer_js" . }}
+{{ partialCached "footer" . }}
+{{ partialCached "footer_js" . }}

--- a/docs/layouts/indexpage/single.html
+++ b/docs/layouts/indexpage/single.html
@@ -22,7 +22,7 @@
 		</div> 
 		<article class="article">
 			<div class="wrapper">
-				{{ partialCached "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) .Section }}	
+				{{ partial "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) }}	
 
 				{{ range where .Site.Pages "Type" "index" }}
 					<h1>{{ if .Page.Params.headerTitle }}{{ .Page.Params.headerTitle }}{{ else }}{{ .Page.Title }}{{ end }} {{ if .Draft }} (Draft){{ end }}</h1>

--- a/docs/layouts/partials/drawer.html
+++ b/docs/layouts/partials/drawer.html
@@ -23,7 +23,7 @@
       <div class="toc">
 
         {{ partial "detect_version" . }}
-        {{ partial "version_switcher" . }}
+        {{ partialCached "version_switcher" . }}
 
         {{ if $.menu }}
           {{ partial "nav" (dict "context" . "menu" $.menu) }}

--- a/docs/layouts/partials/feedback.html
+++ b/docs/layouts/partials/feedback.html
@@ -12,7 +12,7 @@
     </div>
     
   <div class="widget-wrapper">
-    {{ partial "feedback_widget" . }}
+    {{ partialCached "feedback_widget" . }}
   </div>
 </div>
 

--- a/docs/layouts/partials/footer.html
+++ b/docs/layouts/partials/footer.html
@@ -37,7 +37,7 @@
               <a href="/privacy/">Privacy Policy</a> -->
             </div>
             <p class="copyright">
-              Copyright &copy; 2017-2021 Yugabyte, Inc. <nobr>All rights reserved.</nobr>
+              Copyright &copy; 2017-2021 Yugabyte, Inc. <span style="white-space: nowrap">All rights reserved.</span>
             </p>
           </div>
           <div>

--- a/docs/layouts/partials/footer.html
+++ b/docs/layouts/partials/footer.html
@@ -32,7 +32,7 @@
         <div class="flexy">
           <div>
             <div class="menu">
-              <a href="https://www.yugabyte.com/contact-us/">Contact us</a>
+              <a href="https://www.yugabyte.com/contact/">Contact us</a>
               <!-- <a href="/terms/">Terms of Use</a>
               <a href="/privacy/">Privacy Policy</a> -->
             </div>

--- a/docs/layouts/partials/footer_content.html
+++ b/docs/layouts/partials/footer_content.html
@@ -9,7 +9,7 @@
       </a>
     </div>
     <div class="copyright">
-      Copyright &copy; 2017-2021 Yugabyte, Inc. <nobr>All rights reserved.</nobr>
+      Copyright &copy; 2017-2021 Yugabyte, Inc. <span style="white-space: nowrap">All rights reserved.</span>
     </div>
   </div>
 </footer>

--- a/docs/layouts/partials/footer_content.html
+++ b/docs/layouts/partials/footer_content.html
@@ -4,7 +4,7 @@
       <img alt="Yugabyte" src="/images/ybdocs-white.png" class="nav-logo not-scrolled"/>
     </div>
     <div class="footer-menu">
-      <a href="https://www.yugabyte.com/contact-us/">
+      <a href="https://www.yugabyte.com/contact/">
         Contact Us
       </a>
     </div>

--- a/docs/layouts/partials/header.html
+++ b/docs/layouts/partials/header.html
@@ -7,7 +7,7 @@
       </a>
 
       <div class="navbar-search-small">
-        {{ partial "search" . }}
+        {{ partialCached "search" . }}
       </div>
       <button type="button" class="navbar-toggler collapsed" data-toggle="collapse" data-target=".navbar-collapse">
         
@@ -21,7 +21,7 @@
       <div class="navbar-collapse collapse">
         <div class="flex-spacer"></div>
         <div class="navbar-text navbar-search-main">
-            {{ partial "search" . }}
+            {{ partialCached "search" . }}
         </div>
         <div class="navbar-misc">
           <a href="https://www.yugabyte.com/slack" target="_blank" class="navbar-link-btn">

--- a/docs/layouts/search/single.html
+++ b/docs/layouts/search/single.html
@@ -13,7 +13,7 @@
 <input class="toggle" type="checkbox" id="toggle-search">
 <label class="toggle-button overlay" for="toggle-drawer"></label>
 
-{{ partial "header" . }}
+{{ partialCached "header" . }}
 
 <div class="container-fluid">
 	<main class="main">
@@ -23,7 +23,7 @@
 
 		<article class="article">
 			<div class="wrapper">
-				{{ partial "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) }}	
+				{{ partialCached "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) .Section }}	
 
 				<h1>{{ if .Page.Params.headerTitle }}{{ .Page.Params.headerTitle }}{{ else }}{{ .Page.Title }}{{ end }} {{ if .Draft }} (Draft){{ end }}</h1>
 
@@ -32,7 +32,7 @@
 				
 			</div>
 
-			<!-- {{ partial "feedback" . }} -->
+			<!-- {{ partialCached "feedback" . }} -->
 		</article>
 
 		<div class="results" role="status" aria-live="polite">
@@ -46,8 +46,8 @@
 	</main>
 </div>
 
-{{ partial "footer" . }}
-{{ partial "footer_js" . }}
+{{ partialCached "footer" . }}
+{{ partialCached "footer_js" . }}
 
 <script>
 	const pageConfig = {

--- a/docs/layouts/search/single.html
+++ b/docs/layouts/search/single.html
@@ -23,7 +23,7 @@
 
 		<article class="article">
 			<div class="wrapper">
-				{{ partialCached "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) .Section }}	
+				{{ partial "breadcrumbs" (dict "context" . "menu" (.Scratch.Get "currentVersionMenu")) }}	
 
 				<h1>{{ if .Page.Params.headerTitle }}{{ .Page.Params.headerTitle }}{{ else }}{{ .Page.Title }}{{ end }} {{ if .Draft }} (Draft){{ end }}</h1>
 

--- a/docs/layouts/versionlist/list.html
+++ b/docs/layouts/versionlist/list.html
@@ -13,7 +13,7 @@
 <input class="toggle" type="checkbox" id="toggle-search">
 <label class="toggle-button overlay" for="toggle-drawer"></label>
 
-{{ partial "header" . }}
+{{ partialCached "header" . }}
 
 <main class="main">
 		<div class="wrapper">	
@@ -45,5 +45,5 @@
 	</div>
 </main>
 
-{{ partial "footer" . }}
-{{ partial "footer_js" . }}
+{{ partialCached "footer" . }}
+{{ partialCached "footer_js" . }}

--- a/docs/layouts/versionlist/single.html
+++ b/docs/layouts/versionlist/single.html
@@ -13,13 +13,13 @@
 <input class="toggle" type="checkbox" id="toggle-search">
 <label class="toggle-button overlay" for="toggle-drawer"></label>
 
-{{ partial "header" . }}
+{{ partialCached "header" . }}
 
 <main class="main">
 		<div class="wrapper">
 
 			<br/><br/><br/><br/>
-			{{ partial "version_list" . }}
+			{{ partialCached "version_list" . }}
 
 			<!--<aside class="copyright" role="note">
 				{{ with .Site.Params.copyright }}
@@ -44,5 +44,5 @@
 	</div>
 </main>
 
-{{ partial "footer" . }}
-{{ partial "footer_js" . }}
+{{ partialCached "footer" . }}
+{{ partialCached "footer_js" . }}

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -39,6 +39,11 @@
 # even if we have content in the older version's folder.
 
 [[redirects]]
+  from = "/"
+  to = "/latest/"
+  force = true
+
+[[redirects]]
   from = "/:version/comparisons/*"
   to = "/latest/comparisons/:splat"
   force = true

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -5,12 +5,12 @@
 # https://docs.netlify.com/configure-builds/file-based-configuration/#deploy-contexts
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.84.4"
+  HUGO_VERSION = "0.87.0"
   NODE_VERSION = "16"
   CXXFLAGS = "-std=c++17"
 
 [context.branch-deploy.environment]
-  HUGO_VERSION = "0.84.4"
+  HUGO_VERSION = "0.87.0"
   NODE_VERSION = "16"
   CXXFLAGS = "-std=c++17"
 

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -15,7 +15,7 @@
   CXXFLAGS = "-std=c++17"
 
 [context.production.environment]
-  HUGO_VERSION = "0.84.4"
+  HUGO_VERSION = "0.87.0"
   NODE_VERSION = "16"
   CXXFLAGS = "-std=c++17"
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "start": "run-p webpack-watch sass-watch hugo-server",
     "build": "rm -rf public && npm ci && run-s webpack-build sass-build hugo-build",
+    "debug-build": "rm -rf public && npm ci && run-s webpack-build sass-build hugo-build-with-metrics",
     "hugo-build": "hugo -b https://docs.yugabyte.com",
+    "hugo-build-with-metrics": "hugo --templateMetrics --templateMetricsHints -b https://docs.yugabyte.com",
     "hugo-server": "hugo server --bind 0.0.0.0 --baseURL ${YB_HUGO_BASE:-localhost}",
     "sass-build": "node_modules/node-sass/bin/node-sass --output-style compressed styles/site.scss > static/css/site.css",
     "sass-watch": "npm run sass-build; node_modules/node-sass/bin/node-sass --watch --output static/css --output-style compressed styles/site.scss",


### PR DESCRIPTION
In addition to a Netlify change (turning off form detection), I'm trying a few more optimizations to bring down our docs build and deploy times:

* set a sidebar cache limit (may not have an impact)
* call a number of partials as `partialCached`
* bump hugo to current version
* add `debug-build` and `hugo-build-with-metrics` scripts to package.json to get hugo to output some useful metrics
* redirect / to /latest so we bypass the landing page with no left nav

**To verify things are working as they should:**

- [x] Check the netlify deploy preview logs to see how long things took (hoping for 12-15 minutes)
- [x] Browse around to some pages in different sections, and make sure the breadcrumbs are correct

@netlify /latest/quick-start/install/macos/