### PR TITLE
[docs] WIP: playing with a proxy redirect

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -28,6 +28,17 @@
 #
 # validator: https://play.netlify.com/redirects
 
+### ALEX TESTING
+# This style of redirect will pull content from the remote URL
+# without actually redirecting the browser.
+# Hopefully, this is a way to split the docs up into microsites
+# and speed up build times!
+
+[[redirects]]
+  from = "/platform-api-docs/*"
+  to = "https://api-docs.yugabyte.com/docs/yugabyte-platform/:splat"
+  status = 200
+
 # Make sure we're not redirecting anything under /images
 
 [[redirects]]


### PR DESCRIPTION
Playing around with a Netlify feature that could allow us to break the docs up into a few microsites and hopefully get our build times down to just a few minutes.

The build preview should point to "List availability zones".

@netlify /platform-api-docs/b3A6MTg5NDc2ODQ-list-availability-zones