### PR TITLE
[docs] update explore data-types: typo+linting

### DIFF
--- a/docs/content/latest/explore/ysql-language-features/data-types.md
+++ b/docs/content/latest/explore/ysql-language-features/data-types.md
@@ -378,7 +378,7 @@ CREATE TABLE on_hand (
 
 ### 3. Insert a row
 
-To insert a row, use the `RUN` keyword, as follows:
+To insert a row, use the `ROW` keyword, as follows:
 
 ```sql
 INSERT INTO on_hand VALUES (ROW('fuzzy dice', 42, 1.99), 1000);

--- a/docs/content/latest/explore/ysql-language-features/data-types.md
+++ b/docs/content/latest/explore/ysql-language-features/data-types.md
@@ -100,7 +100,6 @@ YSQL supports the following pseudotypes:
 * `SERIAL`:  4 bytes (1 to 2,147,483,647)
 * `BIGSERIAL`: 8 bytes (1 to 9,223,372,036,854,775,807)
 
-
 ## Date and Time
 
 Temporal data types allow us to store date and time data. The following date and time types are supported in PostgreSQL and YugabyteDB:
@@ -124,6 +123,7 @@ CREATE TABLE temporal_types (
 ```
 
 The following example inserts a row into the table:
+
 ```sql
 INSERT INTO temporal_types (
   date_type, time_type, timestamp_type, timestampz_type, interval_type)
@@ -136,8 +136,11 @@ VALUES
 
 The following shows the inserted data:
 
-```
+```sql
 yugabyte=# select * from temporal_types;
+```
+
+```output
  date_type  | time_type |   timestamp_type    |    timestampz_type     |     interval_type
 ------------+-----------+---------------------+------------------------+------------------------
  2010-06-28 | 12:32:12  | 2016-06-22 19:10:25 | 2016-06-22 19:10:25-07 | 10 years 3 mons 5 days
@@ -181,8 +184,10 @@ INSERT INTO rock_band VALUES (
 ```sql
 SELECT * FROM rock_band;
 ```
+
 Expect the following output:
-```
+
+```output
      name     |          members
 --------------+---------------------------
  Pink Floyd   | {Barrett,Gilmour}
@@ -195,8 +200,10 @@ You can access array values using subscripts, as follows:
 ```sql
 SELECT name FROM rock_band WHERE members[2] = 'Plant';
 ```
+
 Expect the following output:
-```
+
+```output
      name
 --------------
  Led Zeppelin
@@ -208,8 +215,10 @@ You can also access array values using slices, as follows:
 ```sql
 SELECT members[1:2] FROM rock_band;
 ```
+
 Expect the following output:
-```
+
+```output
       members
 -------------------
  {Barrett,Gilmour}
@@ -221,10 +230,12 @@ Expect the following output:
 
 ```sql
 UPDATE rock_band SET members[2] = 'Waters' WHERE name = 'Pink Floyd';
+select * from rock_band where name = 'Pink Floyd';
 ```
+
 Expect the following output:
-```
-yugabyte=# select * from rock_band where name = 'Pink Floyd';
+
+```output
     name    |     members
 ------------+------------------
  Pink Floyd | {Barrett,Waters}
@@ -235,11 +246,13 @@ yugabyte=# select * from rock_band where name = 'Pink Floyd';
 
 ```sql
 UPDATE rock_band SET members = '{"Mason", "Wright", "Gilmour"}' 
-WHERE name = 'Pink Floyd';
+       WHERE name = 'Pink Floyd';
+select * from rock_band where name = 'Pink Floyd';
 ```
+
 Expect the following output:
-```
-yugabyte=# select * from rock_band where name = 'Pink Floyd';
+
+```output
     name    |        members
 ------------+------------------------
  Pink Floyd | {Mason,Wright,Gilmour}
@@ -249,23 +262,26 @@ yugabyte=# select * from rock_band where name = 'Pink Floyd';
 ### 6. Search in arrays
 
 Use the `ANY` keyword to search for a particular value in an array, as follows:
+
 ```sql
 SELECT name FROM rock_band WHERE 'Mason' = ANY(members);
 ```
+
 Expect the following output:
-```
+
+```output
     name
 ------------
  Pink Floyd
 (1 row)
 ```
 
-
 ## Enumerations - `ENUM` Type
 
 YugabyteDB supports the `ENUM` type in PostgreSQL. The following examples are adapted from [Enums](http://postgresguide.com/sexy/enums.html):
 
 ### 1. Create `ENUM`
+
 ```sql
 CREATE TYPE e_contact_method AS ENUM (
   'Email', 
@@ -276,13 +292,16 @@ CREATE TYPE e_contact_method AS ENUM (
 ### 2. View the `ENUM`
 
 To view the list of values across all `ENUM` types, execute the following:
+
 ```sql
 SELECT t.typname, e.enumlabel 
   FROM pg_type t, pg_enum e 
   WHERE t.oid = e.enumtypid;
 ```
+
 The output should be as follows:
-```
+
+```output
      typname      | enumlabel
 ------------------+-----------
  e_contact_method | Email
@@ -309,8 +328,12 @@ INSERT INTO contact_method_info VALUES ('Jeff', 'Email', 'jeff@mail.com')
 ```
 
 Execute the following to verify:
-```
+
+```sql
 yugabyte=# select * from contact_method_info;
+```
+
+```output
  contact_name | contact_method |     value
 --------------+----------------+---------------
  Jeff         | Email          | jeff@mail.com
@@ -322,8 +345,10 @@ Inserting an invalid `ENUM` value would fail, as shown in the following example:
 ```sql
 yugabyte=# INSERT INTO contact_method_info VALUES ('Jeff', 'Fax', '4563456');
 ```
+
 You should see the following error (which is compatible with that of PostgreSQL):
-```
+
+```output
 ERROR:  22P02: invalid input value for enum e_contact_method: "Fax"
 LINE 1: INSERT INTO contact_method_info VALUES ('Jeff', 'Fax', '4563...
 ```
@@ -354,6 +379,7 @@ CREATE TABLE on_hand (
 ### 3. Insert a row
 
 To insert a row, use the `RUN` keyword, as follows:
+
 ```sql
 INSERT INTO on_hand VALUES (ROW('fuzzy dice', 42, 1.99), 1000);
 ```
@@ -361,16 +387,20 @@ INSERT INTO on_hand VALUES (ROW('fuzzy dice', 42, 1.99), 1000);
 ### 4. Select data
 
 To select some subfields from the `on_hand` example table, execute the following:
+
 ```sql
 SELECT (item).name FROM on_hand WHERE (item).price > 0.99;
 ```
+
 You can also use the table names, as follows:
+
 ```sql
 SELECT (on_hand.item).name FROM on_hand WHERE (on_hand.item).price > 0.99;
 ```
+
 Expect the following output:
-```
-yugabyte=# SELECT (item).name FROM on_hand WHERE (item).price > 0.99;
+
+```output
     name
 ------------
  fuzzy dice
@@ -383,13 +413,13 @@ Range data types represent a range of values of an element type. Range types are
 
 YSQL supports the following range types:
 
-- `tsrange`, which corresponds to a range of `timestamp without time zone`.
-- `tstzrange`, which corresponds to a range of `timestamp with time zone`.
-- `daterange`, which corresponds to a range of `date`.
-- `int4range`, which corresponds to a range of `integer`.
-- `int8range`, which corresponds to a range of `biginteger`.
-- `numrange`, which corresponds to a range of `numeric`.
-- User-defined types.
+* `tsrange`, which corresponds to a range of `timestamp without time zone`.
+* `tstzrange`, which corresponds to a range of `timestamp with time zone`.
+* `daterange`, which corresponds to a range of `date`.
+* `int4range`, which corresponds to a range of `integer`.
+* `int8range`, which corresponds to a range of `biginteger`.
+* `numrange`, which corresponds to a range of `numeric`.
+* User-defined types.
 
 The following example shows how to provide a range of time for an employee's vacation:
 
@@ -406,7 +436,7 @@ A non-empty range has a lower bound and an upper bound, with everything between 
 
 The following is a syntax of an input for a range value, where *empty* is a representation of a range that does not contain anything:
 
-```sql
+```nocopy.sql
 (lowerbound, upperbound)
 
 (lowerbound, upperbound]
@@ -438,4 +468,3 @@ SELECT '( " a " " a ", " z " " z " )'::textrange;
 ```
 
 For more information on range types, see [Range Data Types](/latest/api/ysql/datatypes/type_range/). 
-


### PR DESCRIPTION
Fix a typo in "To insert a row, use the RUN keyword" (should be ROW, and now is). While I was at it, I fixed all the markdownlint warnings and cleaned up the code snippet tagging.

@netlify /latest/explore/ysql-language-features/data-types