### PR TITLE
[Docs] LDAP authentication for YCQL

### DIFF
--- a/docs/content/latest/secure/authentication/ldap-authentication-ycql.md
+++ b/docs/content/latest/secure/authentication/ldap-authentication-ycql.md
@@ -5,7 +5,7 @@ linkTitle: LDAP Authentication
 description: Configuring YugabyteDB to use an external LDAP authentication service.
 menu:
   latest:
-    identifier: ldap-authentication-ycql
+    identifier: ldap-authentication-2-ycql
     parent: authentication
     weight: 732
 isTocNested: false
@@ -14,13 +14,13 @@ showAsideToc: true
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/latest/secure/authentication/ldap-authentication-ysql" class="nav-link">
+    <a href="../ldap-authentication-ysql/" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
   <li >
-    <a href="/latest/secure/authentication/ldap-authentication-ycql" class="nav-link active">
+    <a href="../ldap-authentication-ycql/" class="nav-link active">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>
@@ -31,53 +31,17 @@ The LDAP authentication method is similar to the password method, except that it
 
 LDAP Authentication for YCQL can be enabled in the YugabyteDB cluster by setting the LDAP configuration with a set of tserver gflags. YugabyteDB supports two modes for LDAP authentication for YCQL (described in detail below):
 
-* <strong>simple-bind</strong> mode
-* <strong>search+bind</strong> mode
+* **simple-bind** mode
+* **search+bind** mode
 
 A prerequisite to using LDAP for YCQL is that the `use_cassandra_authentication` flag should be set to true. A set of configuration gflags common to both modes are -
 
-<table>
-  <tr>
-   <td><strong>Tserver gflag name</strong>
-   </td>
-   <td><strong>Description</strong>
-   </td>
-   <td><strong>Default value</strong>
-   </td>
-  </tr>
-  <tr>
-   <td>ycql_use_ldap
-   </td>
-   <td>Flag to enable LDAP for YCQL.
-   </td>
-   <td><code>false</code>
-   </td>
-  </tr>
-  <tr>
-   <td>ycql_ldap_users_to_skip_csv 
-   </td>
-   <td>Users that are authenticated via the local password mechanism even if ycql_use_ldap=true. This is a comma separated list.
-   </td>
-   <td><code>''</code>
-   </td>
-  </tr>
-  <tr>
-   <td>ycql_ldap_server
-   </td>
-   <td>LDAP server endpoint of the form scheme://ip:port. Scheme can be ldap (or) ldaps.
-   </td>
-   <td><code>''</code>
-   </td>
-  </tr>
-  <tr>
-   <td>ycql_ldap_tls (Not supported yet)
-   </td>
-   <td>Connect to LDAP server using TLS encryption
-   </td>
-   <td><code>false</code>
-   </td>
-  </tr>
-</table>
+| T-Server Gflag name | Default value | Description |
+| :------------------ | :------------ | :---------- |
+| `ycql_use_ldap` | false | Enable LDAP for YCQL |
+| `ycql_ldap_users_to_skip_csv` | (empty) | Comma-separated list of users that are authenticated via the local password mechanism even if `ycql_use_ldap` is true. |
+| `ycql_ldap_server` | (empty) | LDAP server endpoint of the form _scheme_://_ip_:_port_. Scheme can be `ldap` (or) `ldaps`. |
+| `ycql_ldap_tls` | false | (Not yet supported) Connect to LDAP server using TLS encryption |
 
 ## Simple Bind Mode
 
@@ -91,36 +55,14 @@ In **simple-bind** mode, YB-TServer will bind to the Distinguished Name (â€œDNâ€
 
 The configuration specific to simple bind mode.
 
-<table>
-  <tr>
-   <td><strong>Tserver gflag name</strong>
-   </td>
-   <td><strong>Description</strong>
-   </td>
-   <td><strong>Default value</strong>
-   </td>
-  </tr>
-  <tr>
-   <td>ycql_ldap_user_prefix
-   </td>
-   <td>String used for prepending the user name when forming the DN for binding to the LDAP server
-   </td>
-   <td><code>''</code>
-   </td>
-  </tr>
-  <tr>
-   <td>ycql_ldap_user_suffix
-   </td>
-   <td>String used for appending the user name when forming the DN for binding to the LDAP Server
-   </td>
-   <td><code>''</code>
-   </td>
-  </tr>
-</table>
+| T-Server Gflag name | Default value | Description |
+| :------------------ | :------------ | :---------- |
+| `ycql_ldap_user_prefix` | (empty) | String to prepend to the user name when forming the DN for binding to the LDAP server |
+| `ycql_ldap_user_suffix` | (empty) | String to append to the user name when forming the DN for binding to the LDAP server |
 
 ## Search + Bind Mode
 
-In `Search + Bind` mode, YB-Tserver will bind to the LDAP directory with a fixed username and password, specified with `ycql_ldap_bind_dn` and `ycql_ldap_bind_passwd`, and performs a search for the user trying to log in to the database. This mode is commonly used by LDAP authentication schemes in other softwares.
+In `Search + Bind` mode, YB-Tserver will bind to the LDAP directory with a fixed username and password, specified with `ycql_ldap_bind_dn` and `ycql_ldap_bind_passwd`, and performs a search for the user trying to log in to the database. This mode is commonly used by LDAP authentication schemes in other software.
 
 For Searching the LDAP directory if no fixed username and password is configured at YB-TServer, an anonymous bind will be attempted to the directory. The search will be performed over the subtree at `ycql_ldap_base_dn`, and will try to do an exact match of the attribute specified in `ycql_ldap_search_attribute`. Once the user has been found in this search, the server disconnects and re-binds to the directory as this user, using the password specified by the client, to verify that the login is correct.
 
@@ -134,56 +76,13 @@ Here is an example for search + bind mode:
 
 The configurations supported for search + bind mode.
 
-<table>
-  <tr>
-   <td><strong>Tserver gflag name</strong>
-   </td>
-   <td><strong>Description</strong>
-   </td>
-   <td><strong>Default value</strong>
-   </td>
-  </tr>
-  <tr>
-   <td>ycql_ldap_base_dn
-   </td>
-   <td>Specifies the base directory to begin the user name search
-   </td>
-   <td><code>''</code>
-   </td>
-  </tr>
-  <tr>
-   <td>ycql_ldap_bind_dn
-   </td>
-   <td>Specifies the username to perform the initial search when doing search + bind authentication
-   </td>
-   <td><code>''</code>
-   </td>
-  </tr>
-  <tr>
-   <td>ycql_ldap_bind_passwd
-   </td>
-   <td>Password for username being used to perform the initial search when doing search + bind authentication
-   </td>
-   <td><code>''</code>
-   </td>
-  </tr>
-  <tr>
-   <td>ycql_ldap_search_attribute
-   </td>
-   <td>Attribute to match against the username in the search when doing search + bind authentication. If no attribute is specified, the uid attribute is used
-   </td>
-   <td><code>''</code>
-   </td>
-  </tr>
-  <tr>
-   <td>ycql_ldap_search_filter (not supported yet)
-   </td>
-   <td>The search filter to use when doing search + bind authentication
-   </td>
-   <td><code>''</code>
-   </td>
-  </tr>
-</table>
+| T-Server Gflag name | Default value | Description |
+| :------------------ | :------------ | :---------- |
+| `ycql_ldap_base_dn` | (empty) | Base directory to begin the user name search |
+| `ycql_ldap_bind_dn` | (empty) | Username to perform the initial search when doing search + bind authentication |
+| `ycql_ldap_bind_passwd` | (empty) | Password for the username being used to perform the initial search when doing search + bind authentication |
+| `ycql_ldap_search_attribute` | `uid` attribute | Attribute to match against the username in the search when doing search + bind authentication. If no attribute is specified, the `uid` attribute is used. |
+| `ycql_ldap_search_filter` | (empty) | Search filter to use when doing search + bind authentication |
 
 ## Example
 
@@ -209,7 +108,7 @@ In the above sample configuration, we are using an [online LDAP test server](htt
     $ ./ycqlsh -u cassandra
     ```
 
-    When prompted for the password, enter `cassandra` (default password of `cassandra` user). You should be able to login and see a response like below.
+    When prompted for the password, enter `cassandra` (default password of `cassandra` user). You should be able to log in and see a response like below.
 
     ```output
     Connected to local cluster at 127.0.0.1:9042.

--- a/docs/content/latest/secure/authentication/ldap-authentication-ysql.md
+++ b/docs/content/latest/secure/authentication/ldap-authentication-ysql.md
@@ -7,7 +7,7 @@ aliases:
 - /latest/secure/authentication/ldap-authentication
 menu:
   latest:
-    identifier: ldap-authentication-ysql
+    identifier: ldap-authentication-1-ysql
     parent: authentication
     weight: 732
 isTocNested: false
@@ -16,13 +16,13 @@ showAsideToc: true
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/latest/secure/authentication/ldap-authentication-ysql" class="nav-link active">
+    <a href="../ldap-authentication-ysql/" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
   <li >
-    <a href="/latest/secure/authentication/ldap-authentication-ycql" class="nav-link">
+    <a href="../ldap-authentication-ycql/" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>
@@ -33,8 +33,8 @@ The LDAP authentication method is similar to the password method, except that it
 
 LDAP Authentication can be enabled in the YugabyteDB cluster by setting the LDAP configuration with the <code>[--ysql_hba_conf_csv](../../../reference/configuration/yb-tserver/#ysql-hba-conf-csv)</code> flag. YugabyteDB supports two modes for LDAP authentication: 
 
-* <strong>simple-bind</strong> mode
-* <strong>search+bind</strong> mode
+* **simple-bind** mode
+* **search+bind** mode
 
 These are described below.
 
@@ -50,48 +50,18 @@ In **simple-bind** mode, YB-TServer will bind to the Distinguished Name (â€œDNâ€
 
 The configurations supported for simple bind mode.
 
-<table>
-  <tr>
-   <td><strong>ldapserver</strong>
-   </td>
-   <td>Names or IP addresses of LDAP servers to connect to. Multiple servers may be specified, separated by spaces.
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldapport</strong> 
-   </td>
-   <td>Port number on LDAP server to connect to. If no port is specified, LDAP default port 389 will be used.
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldapscheme</strong>
-   </td>
-   <td>Set to ldaps to use LDAPS. This is a non-standard way of using LDAP over SSL, supported by some LDAP server implementations. See also the ldaptls option for an alternative.
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldaptls</strong>
-   </td>
-   <td>Set to 1 to make the connection between PostgreSQL and the LDAP server use TLS encryption. 
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldapprefix</strong>
-   </td>
-   <td>String used for prepending the user name when forming the DN for binding to the LDAP server.
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldapsuffix</strong>
-   </td>
-   <td>String used for appending the user name when forming the DN for binding to the LDAP Server.
-   </td>
-  </tr>
-</table>
+| T-Server Gflag name | Default value | Description |
+| :------------------ | :------------ | :---------- |
+| `ldapserver` | (empty) | Names or IP addresses of LDAP servers to connect to. Separate servers with spaces. |
+| `ldapport` | 389 | Port number on LDAP server to connect to. |
+| `ldapscheme` | (empty) | Set to `ldaps` to use LDAPS. This is a non-standard way of using LDAP over SSL, supported by some LDAP server implementations. See also the `ldaptls` option for an alternative. |
+| `ldaptls` | 0 | Set to 1 to make the connection between PostgreSQL and the LDAP server use TLS encryption. |
+| `ldapprefix` | (empty) | String to be prepended to the user name when forming the DN for binding to the LDAP server. |
+| `ldapsuffix` | (empty) | String to be appended to the user name when forming the DN for binding to the LDAP Server. |
 
 ## Search + Bind Mode
 
-In `Search + Bind` mode, YB-Tserver will bind to the LDAP directory with a fixed username and password, specified with `ldapbinddn` and `ldapbindpasswd`, and performs a search for the user trying to log in to the database. This mode is commonly used by LDAP authentication schemes in other softwares.
+In `Search + Bind` mode, YB-Tserver will bind to the LDAP directory with a fixed username and password, specified with `ldapbinddn` and `ldapbindpasswd`, and performs a search for the user trying to log into the database. This mode is commonly used by LDAP authentication schemes in other software.
 
 For Searching the LDAP directory if no fixed username and password is configured at YB-TServer, an anonymous bind will be attempted to the directory. The search will be performed over the subtree at `ldapbasedn`, and will try to do an exact match of the attribute specified in `ldapsearchattribute`. Once the user has been found in this search, the server disconnects and re-binds to the directory as this user, using the password specified by the client, to verify that the login is correct.
 
@@ -105,68 +75,18 @@ Here is an example for search + bind mode:
 
 The configurations supported for search + bind mode.
 
-<table>
-  <tr>
-   <td><strong>ldapserver</strong>
-   </td>
-   <td>Names or IP addresses of LDAP servers to connect to. Multiple servers may be specified, separated by spaces.
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldapport</strong> 
-   </td>
-   <td>Port number on LDAP server to connect to. If no port is specified, LDAP default port 389 will be used.
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldapscheme</strong>
-   </td>
-   <td>Set to ldaps to use LDAPS. This is a non-standard way of using LDAP over SSL, supported by some LDAP server implementations. See also the ldaptls option for an alternative.
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldaptls</strong>
-   </td>
-   <td>Set to 1 to make the connection between PostgreSQL and the LDAP server use TLS encryption. 
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldapbasedn</strong>
-   </td>
-   <td>Specifies the base directory to begin the user name search 
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldapbinddn</strong>
-   </td>
-   <td>Specifies the username to perform the initial search when doing search + bind authentication
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldapbindpasswd</strong>
-   </td>
-   <td>Password for username being used to perform the initial search when doing search + bind authentication
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldapsearchattribute</strong>
-   </td>
-   <td>Attribute to match against the username in the search when doing search + bind authentication. If no attribute is specified, the <strong>uid </strong>attribute is used.
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldapsearchfilter</strong>
-   </td>
-   <td>The search filter to use when doing search + bind authentication.
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldapurl</strong>
-   </td>
-   <td>An RFC 4516 LDAP URL. This is an alternative way to write LDAP options in a more compact and standard form.
-   </td>
-  </tr>
-</table>
+| T-Server Gflag name | Default value | Description |
+| :------------------ | :------------ | :---------- |
+| `ldapserver` | (empty) | Names or IP addresses of LDAP servers to connect to. Separate servers with spaces. |
+| `ldapport` | 389 | Port number on LDAP server to connect to. |
+| `ldapscheme` | (empty) | Set to `ldaps` to use LDAPS. This is a non-standard way of using LDAP over SSL, supported by some LDAP server implementations. See also the `ldaptls` option for an alternative. |
+| `ldaptls` | 0 | Set to 1 to make the connection between PostgreSQL and the LDAP server use TLS encryption. |
+| `ldapbasedn` | (empty) | Specifies the base directory to begin the user name search |
+| `ldapbinddn` | (empty) | Specifies the username to perform the initial search when doing search + bind authentication |
+| `ldapbindpasswd` | (empty) | Password for username being used to perform the initial search when doing search + bind authentication |
+| `ldapsearchattribute` | `uid` | Attribute to match against the username in the search when doing search + bind authentication. If no attribute is specified, the **uid** attribute is used. |
+| `ldapsearchfilter` | (empty) | The search filter to use when doing search + bind authentication. |
+| `ldapurl` | (empty) | An RFC 4516 LDAP URL. This is an alternative way to write LDAP options in a more compact and standard form. |
 
 ## Example
 
@@ -195,7 +115,7 @@ In the above sample configuration, we are using an [online LDAP test server](htt
     $ ./ysqlsh -U yugabyte -W
     ```
 
-    When prompted for the password, enter the yugabyte password (default is `yugabyte`). You should be able to login and see a response like below.
+    When prompted for the password, enter the yugabyte password (default is `yugabyte`). You should be able to log in and see a response like below.
 
     ```output
     ysqlsh (11.2-YB-2.3.3.0-b0)

--- a/docs/content/stable/secure/authentication/_index.md
+++ b/docs/content/stable/secure/authentication/_index.md
@@ -36,7 +36,7 @@ The various methods for authenticating users supported by YugabyteDB are listed 
   </div>
 
   <div class="col-12 col-md-6 col-lg-12 col-xl-6">
-    <a class="section-link icon-offset" href="ldap-authentication/">
+    <a class="section-link icon-offset" href="ldap-authentication-ysql/">
       <div class="head">
         <img class="icon" src="/images/section_icons/secure/authentication.png" aria-hidden="true" />
         <div class="title">LDAP Authentication</div>

--- a/docs/content/stable/secure/authentication/ldap-authentication-ycql.md
+++ b/docs/content/stable/secure/authentication/ldap-authentication-ycql.md
@@ -1,0 +1,241 @@
+---
+title: LDAP Authentication in YCQL
+headerTitle: LDAP Authentication in YCQL
+linkTitle: LDAP Authentication
+description: Configuring YugabyteDB to use an external LDAP authentication service.
+menu:
+  stable:
+    identifier: ldap-authentication-ycql
+    parent: authentication
+    weight: 732
+isTocNested: false
+showAsideToc: true
+---
+
+<ul class="nav nav-tabs-alt nav-tabs-yb">
+  <li >
+    <a href="/stable/secure/authentication/ldap-authentication-ysql" class="nav-link">
+      <i class="icon-postgres" aria-hidden="true"></i>
+      YSQL
+    </a>
+  </li>
+  <li >
+    <a href="/stable/secure/authentication/ldap-authentication-ycql" class="nav-link active">
+      <i class="icon-cassandra" aria-hidden="true"></i>
+      YCQL
+    </a>
+  </li>
+</ul>
+
+The LDAP authentication method is similar to the password method, except that it uses LDAP to verify the password. Therefore, before LDAP can be used for authentication, the user must already exist in the database (and have appropriate permissions). 
+
+LDAP Authentication for YCQL can be enabled in the YugabyteDB cluster by setting the LDAP configuration with a set of tserver gflags. YugabyteDB supports two modes for LDAP authentication for YCQL (described in detail below):
+
+* <strong>simple-bind</strong> mode
+* <strong>search+bind</strong> mode
+
+A prerequisite to using LDAP for YCQL is that the `use_cassandra_authentication` flag should be set to true. A set of configuration gflags common to both modes are -
+
+<table>
+  <tr>
+   <td><strong>Tserver gflag name</strong>
+   </td>
+   <td><strong>Description</strong>
+   </td>
+   <td><strong>Default value</strong>
+   </td>
+  </tr>
+  <tr>
+   <td>ycql_use_ldap
+   </td>
+   <td>Flag to enable LDAP for YCQL.
+   </td>
+   <td><code>false</code>
+   </td>
+  </tr>
+  <tr>
+   <td>ycql_ldap_users_to_skip_csv 
+   </td>
+   <td>Users that are authenticated via the local password mechanism even if ycql_use_ldap=true. This is a comma separated list.
+   </td>
+   <td><code>''</code>
+   </td>
+  </tr>
+  <tr>
+   <td>ycql_ldap_server
+   </td>
+   <td>LDAP server endpoint of the form scheme://ip:port. Scheme can be ldap (or) ldaps.
+   </td>
+   <td><code>''</code>
+   </td>
+  </tr>
+  <tr>
+   <td>ycql_ldap_tls (Not supported yet)
+   </td>
+   <td>Connect to LDAP server using TLS encryption
+   </td>
+   <td><code>false</code>
+   </td>
+  </tr>
+</table>
+
+## Simple Bind Mode
+
+In **simple-bind** mode, YB-TServer will bind to the Distinguished Name (“DN”) constructed with “prefix username suffix” format. Here is an example for Simple bind mode:
+
+```sh
+--use_cassandra_authentication=true --ycql_use_ldap=true --ycql_ldap_server=ldap://ldap.yugabyte.com:389 --ycql_ldap_user_prefix=uid= --ycql_ldap_user_suffix=, ou=DBAs, dc=example, dc=com --ycql_ldap_users_to_skip_csv=cassandra
+```
+
+### Configurations
+
+The configuration specific to simple bind mode.
+
+<table>
+  <tr>
+   <td><strong>Tserver gflag name</strong>
+   </td>
+   <td><strong>Description</strong>
+   </td>
+   <td><strong>Default value</strong>
+   </td>
+  </tr>
+  <tr>
+   <td>ycql_ldap_user_prefix
+   </td>
+   <td>String used for prepending the user name when forming the DN for binding to the LDAP server
+   </td>
+   <td><code>''</code>
+   </td>
+  </tr>
+  <tr>
+   <td>ycql_ldap_user_suffix
+   </td>
+   <td>String used for appending the user name when forming the DN for binding to the LDAP Server
+   </td>
+   <td><code>''</code>
+   </td>
+  </tr>
+</table>
+
+## Search + Bind Mode
+
+In `Search + Bind` mode, YB-Tserver will bind to the LDAP directory with a fixed username and password, specified with `ycql_ldap_bind_dn` and `ycql_ldap_bind_passwd`, and performs a search for the user trying to log in to the database. This mode is commonly used by LDAP authentication schemes in other softwares.
+
+For Searching the LDAP directory if no fixed username and password is configured at YB-TServer, an anonymous bind will be attempted to the directory. The search will be performed over the subtree at `ycql_ldap_base_dn`, and will try to do an exact match of the attribute specified in `ycql_ldap_search_attribute`. Once the user has been found in this search, the server disconnects and re-binds to the directory as this user, using the password specified by the client, to verify that the login is correct.
+
+Here is an example for search + bind mode:
+
+```sh
+--use_cassandra_authentication=true --ycql_use_ldap=true --ycql_ldap_server=ldap://ldap.yugabyte.com:389 --ycql_ldap_base_dn="dc=yugabyte, dc=com" --ycql_ldap_bind_dn="cn=admin,dc=example,dc=org" --ycql_ldap_bind_passwd=admin --ycql_ldap_search_attribute=uid
+```
+
+### Configurations
+
+The configurations supported for search + bind mode.
+
+<table>
+  <tr>
+   <td><strong>Tserver gflag name</strong>
+   </td>
+   <td><strong>Description</strong>
+   </td>
+   <td><strong>Default value</strong>
+   </td>
+  </tr>
+  <tr>
+   <td>ycql_ldap_base_dn
+   </td>
+   <td>Specifies the base directory to begin the user name search
+   </td>
+   <td><code>''</code>
+   </td>
+  </tr>
+  <tr>
+   <td>ycql_ldap_bind_dn
+   </td>
+   <td>Specifies the username to perform the initial search when doing search + bind authentication
+   </td>
+   <td><code>''</code>
+   </td>
+  </tr>
+  <tr>
+   <td>ycql_ldap_bind_passwd
+   </td>
+   <td>Password for username being used to perform the initial search when doing search + bind authentication
+   </td>
+   <td><code>''</code>
+   </td>
+  </tr>
+  <tr>
+   <td>ycql_ldap_search_attribute
+   </td>
+   <td>Attribute to match against the username in the search when doing search + bind authentication. If no attribute is specified, the uid attribute is used
+   </td>
+   <td><code>''</code>
+   </td>
+  </tr>
+  <tr>
+   <td>ycql_ldap_search_filter (not supported yet)
+   </td>
+   <td>The search filter to use when doing search + bind authentication
+   </td>
+   <td><code>''</code>
+   </td>
+  </tr>
+</table>
+
+## Example
+
+To use LDAP password authentication on a new YugabyteDB cluster, follow these steps:
+
+1. Use tserver gflags to enable LDAP authentication on YB-TServer in simple bind mode. Use the below configuration to start a YugabyteDB cluster.
+
+    ```sh
+    --use_cassandra_authentication=true --ycql_use_ldap=true --ycql_ldap_server=ldap://ldap.forumsys.com:389 --ycql_ldap_user_prefix=uid= --ycql_ldap_user_suffix=, dc=example, dc=com --ycql_ldap_users_to_skip_csv=cassandra
+    ```
+
+    {{< note title="Note" >}}
+In the above sample configuration, we are using an [online LDAP test server](https://www.forumsys.com/tutorials/integration-how-to/ldap/online-ldap-test-server/) for setting up the LDAP authentication with YugabyteDB.
+    {{< /note >}}
+
+    The `--ycql_ldap_users_to_skip_csv=cassandra` gflag allows access to the user `cassandra` with password authentication. This allows the administrator to log in for setting up the roles (and permissions) for the LDAP users.
+
+1. Start the YugabyteDB cluster.
+
+1. Open the YCQL shell (ycqlsh), specifying the `cassandra` user and prompting for the password.
+
+    ```sh
+    $ ./ycqlsh -u cassandra
+    ```
+
+    When prompted for the password, enter `cassandra` (default password of `cassandra` user). You should be able to login and see a response like below.
+
+    ```output
+    Connected to local cluster at 127.0.0.1:9042.
+    [ycqlsh 5.0.1 | Cassandra 3.9-SNAPSHOT | CQL spec 3.4.2 | Native protocol v4]
+    Use HELP for help.
+    cassandra@ycqlsh>
+    ```
+
+1. Configure database role(s) for the LDAP user(s).
+
+    We are creating a `ROLE` for username riemann supported by the test LDAP server.
+
+    ```sql
+    cassandra@ycqlsh> create role riemann with login=true;
+    ```
+
+1. Connect using LDAP authentication.
+
+    Connect ycqlsh using the `riemann` LDAP user and password specified in the [Online LDAP Test Server](https://www.forumsys.com/tutorials/integration-how-to/ldap/online-ldap-test-server/) page. 
+
+    ```sh
+    $ ./ycqlsh -u riemann
+    ```
+
+    ```output
+    Connected to local cluster at 127.0.0.1:9042.
+    [ycqlsh 5.0.1 | Cassandra 3.9-SNAPSHOT | CQL spec 3.4.2 | Native protocol v4]
+    Use HELP for help.
+    riemann@ycqlsh>```

--- a/docs/content/stable/secure/authentication/ldap-authentication-ycql.md
+++ b/docs/content/stable/secure/authentication/ldap-authentication-ycql.md
@@ -14,13 +14,13 @@ showAsideToc: true
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/stable/secure/authentication/ldap-authentication-ysql" class="nav-link">
+    <a href="../ldap-authentication-ysql" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
   <li >
-    <a href="/stable/secure/authentication/ldap-authentication-ycql" class="nav-link active">
+    <a href="../ldap-authentication-ycql" class="nav-link active">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>
@@ -31,53 +31,17 @@ The LDAP authentication method is similar to the password method, except that it
 
 LDAP Authentication for YCQL can be enabled in the YugabyteDB cluster by setting the LDAP configuration with a set of tserver gflags. YugabyteDB supports two modes for LDAP authentication for YCQL (described in detail below):
 
-* <strong>simple-bind</strong> mode
-* <strong>search+bind</strong> mode
+* **simple-bind** mode
+* **search+bind** mode
 
 A prerequisite to using LDAP for YCQL is that the `use_cassandra_authentication` flag should be set to true. A set of configuration gflags common to both modes are -
 
-<table>
-  <tr>
-   <td><strong>Tserver gflag name</strong>
-   </td>
-   <td><strong>Description</strong>
-   </td>
-   <td><strong>Default value</strong>
-   </td>
-  </tr>
-  <tr>
-   <td>ycql_use_ldap
-   </td>
-   <td>Flag to enable LDAP for YCQL.
-   </td>
-   <td><code>false</code>
-   </td>
-  </tr>
-  <tr>
-   <td>ycql_ldap_users_to_skip_csv 
-   </td>
-   <td>Users that are authenticated via the local password mechanism even if ycql_use_ldap=true. This is a comma separated list.
-   </td>
-   <td><code>''</code>
-   </td>
-  </tr>
-  <tr>
-   <td>ycql_ldap_server
-   </td>
-   <td>LDAP server endpoint of the form scheme://ip:port. Scheme can be ldap (or) ldaps.
-   </td>
-   <td><code>''</code>
-   </td>
-  </tr>
-  <tr>
-   <td>ycql_ldap_tls (Not supported yet)
-   </td>
-   <td>Connect to LDAP server using TLS encryption
-   </td>
-   <td><code>false</code>
-   </td>
-  </tr>
-</table>
+| T-Server Gflag name | Default value | Description |
+| :------------------ | :------------ | :---------- |
+| `ycql_use_ldap` | false | Enable LDAP for YCQL |
+| `ycql_ldap_users_to_skip_csv` | (empty) | Comma-separated list of users that are authenticated via the local password mechanism even if `ycql_use_ldap` is true. |
+| `ycql_ldap_server` | (empty) | LDAP server endpoint of the form _scheme_://_ip_:_port_. Scheme can be `ldap` (or) `ldaps`. |
+| `ycql_ldap_tls` | false | (Not yet supported) Connect to LDAP server using TLS encryption |
 
 ## Simple Bind Mode
 
@@ -91,32 +55,10 @@ In **simple-bind** mode, YB-TServer will bind to the Distinguished Name (â€œDNâ€
 
 The configuration specific to simple bind mode.
 
-<table>
-  <tr>
-   <td><strong>Tserver gflag name</strong>
-   </td>
-   <td><strong>Description</strong>
-   </td>
-   <td><strong>Default value</strong>
-   </td>
-  </tr>
-  <tr>
-   <td>ycql_ldap_user_prefix
-   </td>
-   <td>String used for prepending the user name when forming the DN for binding to the LDAP server
-   </td>
-   <td><code>''</code>
-   </td>
-  </tr>
-  <tr>
-   <td>ycql_ldap_user_suffix
-   </td>
-   <td>String used for appending the user name when forming the DN for binding to the LDAP Server
-   </td>
-   <td><code>''</code>
-   </td>
-  </tr>
-</table>
+| T-Server Gflag name | Default value | Description |
+| :------------------ | :------------ | :---------- |
+| `ycql_ldap_user_prefix` | (empty) | String to prepend to the user name when forming the DN for binding to the LDAP server |
+| `ycql_ldap_user_suffix` | (empty) | String to append to the user name when forming the DN for binding to the LDAP server |
 
 ## Search + Bind Mode
 
@@ -134,56 +76,13 @@ Here is an example for search + bind mode:
 
 The configurations supported for search + bind mode.
 
-<table>
-  <tr>
-   <td><strong>Tserver gflag name</strong>
-   </td>
-   <td><strong>Description</strong>
-   </td>
-   <td><strong>Default value</strong>
-   </td>
-  </tr>
-  <tr>
-   <td>ycql_ldap_base_dn
-   </td>
-   <td>Specifies the base directory to begin the user name search
-   </td>
-   <td><code>''</code>
-   </td>
-  </tr>
-  <tr>
-   <td>ycql_ldap_bind_dn
-   </td>
-   <td>Specifies the username to perform the initial search when doing search + bind authentication
-   </td>
-   <td><code>''</code>
-   </td>
-  </tr>
-  <tr>
-   <td>ycql_ldap_bind_passwd
-   </td>
-   <td>Password for username being used to perform the initial search when doing search + bind authentication
-   </td>
-   <td><code>''</code>
-   </td>
-  </tr>
-  <tr>
-   <td>ycql_ldap_search_attribute
-   </td>
-   <td>Attribute to match against the username in the search when doing search + bind authentication. If no attribute is specified, the uid attribute is used
-   </td>
-   <td><code>''</code>
-   </td>
-  </tr>
-  <tr>
-   <td>ycql_ldap_search_filter (not supported yet)
-   </td>
-   <td>The search filter to use when doing search + bind authentication
-   </td>
-   <td><code>''</code>
-   </td>
-  </tr>
-</table>
+| T-Server Gflag name | Default value | Description |
+| :------------------ | :------------ | :---------- |
+| `ycql_ldap_base_dn` | (empty) | Base directory to begin the user name search |
+| `ycql_ldap_bind_dn` | (empty) | Username to perform the initial search when doing search + bind authentication |
+| `ycql_ldap_bind_passwd` | (empty) | Password for the username being used to perform the initial search when doing search + bind authentication |
+| `ycql_ldap_search_attribute` | `uid` attribute | Attribute to match against the username in the search when doing search + bind authentication. If no attribute is specified, the `uid` attribute is used. |
+| `ycql_ldap_search_filter` | (empty) | Search filter to use when doing search + bind authentication |
 
 ## Example
 

--- a/docs/content/stable/secure/authentication/ldap-authentication-ycql.md
+++ b/docs/content/stable/secure/authentication/ldap-authentication-ycql.md
@@ -5,7 +5,7 @@ linkTitle: LDAP Authentication
 description: Configuring YugabyteDB to use an external LDAP authentication service.
 menu:
   stable:
-    identifier: ldap-authentication-ycql
+    identifier: ldap-authentication-2-ycql
     parent: authentication
     weight: 732
 isTocNested: false
@@ -14,13 +14,13 @@ showAsideToc: true
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="../ldap-authentication-ysql" class="nav-link">
+    <a href="../ldap-authentication-ysql/" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
   <li >
-    <a href="../ldap-authentication-ycql" class="nav-link active">
+    <a href="../ldap-authentication-ycql/" class="nav-link active">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>
@@ -62,7 +62,7 @@ The configuration specific to simple bind mode.
 
 ## Search + Bind Mode
 
-In `Search + Bind` mode, YB-Tserver will bind to the LDAP directory with a fixed username and password, specified with `ycql_ldap_bind_dn` and `ycql_ldap_bind_passwd`, and performs a search for the user trying to log in to the database. This mode is commonly used by LDAP authentication schemes in other softwares.
+In `Search + Bind` mode, YB-Tserver will bind to the LDAP directory with a fixed username and password, specified with `ycql_ldap_bind_dn` and `ycql_ldap_bind_passwd`, and performs a search for the user trying to log in to the database. This mode is commonly used by LDAP authentication schemes in other software.
 
 For Searching the LDAP directory if no fixed username and password is configured at YB-TServer, an anonymous bind will be attempted to the directory. The search will be performed over the subtree at `ycql_ldap_base_dn`, and will try to do an exact match of the attribute specified in `ycql_ldap_search_attribute`. Once the user has been found in this search, the server disconnects and re-binds to the directory as this user, using the password specified by the client, to verify that the login is correct.
 
@@ -108,7 +108,7 @@ In the above sample configuration, we are using an [online LDAP test server](htt
     $ ./ycqlsh -u cassandra
     ```
 
-    When prompted for the password, enter `cassandra` (default password of `cassandra` user). You should be able to login and see a response like below.
+    When prompted for the password, enter `cassandra` (default password of `cassandra` user). You should be able to log in and see a response like below.
 
     ```output
     Connected to local cluster at 127.0.0.1:9042.

--- a/docs/content/stable/secure/authentication/ldap-authentication-ysql.md
+++ b/docs/content/stable/secure/authentication/ldap-authentication-ysql.md
@@ -3,8 +3,6 @@ title: LDAP Authentication in YSQL
 headerTitle: LDAP Authentication in YSQL
 linkTitle: LDAP Authentication
 description: Configuring YugabyteDB to use an external LDAP authentication service.
-aliases:
-- /stable/secure/authentication/ldap-authentication
 menu:
   stable:
     identifier: ldap-authentication-ysql
@@ -16,13 +14,13 @@ showAsideToc: true
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/stable/secure/authentication/ldap-authentication-ysql" class="nav-link active">
+    <a href="../ldap-authentication-ysql" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
   <li >
-    <a href="/stable/secure/authentication/ldap-authentication-ycql" class="nav-link">
+    <a href="../ldap-authentication-ycql" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/stable/secure/authentication/ldap-authentication-ysql.md
+++ b/docs/content/stable/secure/authentication/ldap-authentication-ysql.md
@@ -5,7 +5,7 @@ linkTitle: LDAP Authentication
 description: Configuring YugabyteDB to use an external LDAP authentication service.
 menu:
   stable:
-    identifier: ldap-authentication-ysql
+    identifier: ldap-authentication-1-ysql
     parent: authentication
     weight: 732
 isTocNested: false
@@ -14,13 +14,13 @@ showAsideToc: true
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="../ldap-authentication-ysql" class="nav-link active">
+    <a href="../ldap-authentication-ysql/" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
   <li >
-    <a href="../ldap-authentication-ycql" class="nav-link">
+    <a href="../ldap-authentication-ycql/" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>
@@ -31,8 +31,8 @@ The LDAP authentication method is similar to the password method, except that it
 
 LDAP Authentication can be enabled in the YugabyteDB cluster by setting the LDAP configuration with the <code>[--ysql_hba_conf_csv](../../../reference/configuration/yb-tserver/#ysql-hba-conf-csv)</code> flag. YugabyteDB supports two modes for LDAP authentication: 
 
-* <strong>simple-bind</strong> mode
-* <strong>search+bind</strong> mode
+* **simple-bind** mode
+* **search+bind** mode
 
 These are described below.
 
@@ -48,48 +48,18 @@ In **simple-bind** mode, YB-TServer will bind to the Distinguished Name (â€œDNâ€
 
 The configurations supported for simple bind mode.
 
-<table>
-  <tr>
-   <td><strong>ldapserver</strong>
-   </td>
-   <td>Names or IP addresses of LDAP servers to connect to. Multiple servers may be specified, separated by spaces.
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldapport</strong> 
-   </td>
-   <td>Port number on LDAP server to connect to. If no port is specified, LDAP default port 389 will be used.
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldapscheme</strong>
-   </td>
-   <td>Set to ldaps to use LDAPS. This is a non-standard way of using LDAP over SSL, supported by some LDAP server implementations. See also the ldaptls option for an alternative.
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldaptls</strong>
-   </td>
-   <td>Set to 1 to make the connection between PostgreSQL and the LDAP server use TLS encryption. 
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldapprefix</strong>
-   </td>
-   <td>String used for prepending the user name when forming the DN for binding to the LDAP server.
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldapsuffix</strong>
-   </td>
-   <td>String used for appending the user name when forming the DN for binding to the LDAP Server.
-   </td>
-  </tr>
-</table>
+| T-Server Gflag name | Default value | Description |
+| :------------------ | :------------ | :---------- |
+| `ldapserver` | (empty) | Names or IP addresses of LDAP servers to connect to. Separate servers with spaces. |
+| `ldapport` | 389 | Port number on LDAP server to connect to. |
+| `ldapscheme` | (empty) | Set to `ldaps` to use LDAPS. This is a non-standard way of using LDAP over SSL, supported by some LDAP server implementations. See also the `ldaptls` option for an alternative. |
+| `ldaptls` | 0 | Set to 1 to make the connection between PostgreSQL and the LDAP server use TLS encryption. |
+| `ldapprefix` | (empty) | String to be prepended to the user name when forming the DN for binding to the LDAP server. |
+| `ldapsuffix` | (empty) | String to be appended to the user name when forming the DN for binding to the LDAP Server. |
 
 ## Search + Bind Mode
 
-In `Search + Bind` mode, YB-Tserver will bind to the LDAP directory with a fixed username and password, specified with `ldapbinddn` and `ldapbindpasswd`, and performs a search for the user trying to log in to the database. This mode is commonly used by LDAP authentication schemes in other softwares.
+In `Search + Bind` mode, YB-Tserver will bind to the LDAP directory with a fixed username and password, specified with `ldapbinddn` and `ldapbindpasswd`, and performs a search for the user trying to log into the database. This mode is commonly used by LDAP authentication schemes in other software.
 
 For Searching the LDAP directory if no fixed username and password is configured at YB-TServer, an anonymous bind will be attempted to the directory. The search will be performed over the subtree at `ldapbasedn`, and will try to do an exact match of the attribute specified in `ldapsearchattribute`. Once the user has been found in this search, the server disconnects and re-binds to the directory as this user, using the password specified by the client, to verify that the login is correct.
 
@@ -103,68 +73,18 @@ Here is an example for search + bind mode:
 
 The configurations supported for search + bind mode.
 
-<table>
-  <tr>
-   <td><strong>ldapserver</strong>
-   </td>
-   <td>Names or IP addresses of LDAP servers to connect to. Multiple servers may be specified, separated by spaces.
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldapport</strong> 
-   </td>
-   <td>Port number on LDAP server to connect to. If no port is specified, LDAP default port 389 will be used.
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldapscheme</strong>
-   </td>
-   <td>Set to ldaps to use LDAPS. This is a non-standard way of using LDAP over SSL, supported by some LDAP server implementations. See also the ldaptls option for an alternative.
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldaptls</strong>
-   </td>
-   <td>Set to 1 to make the connection between PostgreSQL and the LDAP server use TLS encryption. 
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldapbasedn</strong>
-   </td>
-   <td>Specifies the base directory to begin the user name search 
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldapbinddn</strong>
-   </td>
-   <td>Specifies the username to perform the initial search when doing search + bind authentication
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldapbindpasswd</strong>
-   </td>
-   <td>Password for username being used to perform the initial search when doing search + bind authentication
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldapsearchattribute</strong>
-   </td>
-   <td>Attribute to match against the username in the search when doing search + bind authentication. If no attribute is specified, the <strong>uid </strong>attribute is used.
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldapsearchfilter</strong>
-   </td>
-   <td>The search filter to use when doing search + bind authentication.
-   </td>
-  </tr>
-  <tr>
-   <td><strong>ldapurl</strong>
-   </td>
-   <td>An RFC 4516 LDAP URL. This is an alternative way to write LDAP options in a more compact and standard form.
-   </td>
-  </tr>
-</table>
+| T-Server Gflag name | Default value | Description |
+| :------------------ | :------------ | :---------- |
+| `ldapserver` | (empty) | Names or IP addresses of LDAP servers to connect to. Separate servers with spaces. |
+| `ldapport` | 389 | Port number on LDAP server to connect to. |
+| `ldapscheme` | (empty) | Set to `ldaps` to use LDAPS. This is a non-standard way of using LDAP over SSL, supported by some LDAP server implementations. See also the `ldaptls` option for an alternative. |
+| `ldaptls` | 0 | Set to 1 to make the connection between PostgreSQL and the LDAP server use TLS encryption. |
+| `ldapbasedn` | (empty) | Specifies the base directory to begin the user name search |
+| `ldapbinddn` | (empty) | Specifies the username to perform the initial search when doing search + bind authentication |
+| `ldapbindpasswd` | (empty) | Password for username being used to perform the initial search when doing search + bind authentication |
+| `ldapsearchattribute` | `uid` | Attribute to match against the username in the search when doing search + bind authentication. If no attribute is specified, the **uid** attribute is used. |
+| `ldapsearchfilter` | (empty) | The search filter to use when doing search + bind authentication. |
+| `ldapurl` | (empty) | An RFC 4516 LDAP URL. This is an alternative way to write LDAP options in a more compact and standard form. |
 
 ## Example
 
@@ -193,7 +113,7 @@ In the above sample configuration, we are using an [online LDAP test server](htt
     $ ./ysqlsh -U yugabyte -W
     ```
 
-    When prompted for the password, enter the yugabyte password (default is `yugabyte`). You should be able to login and see a response like below.
+    When prompted for the password, enter the yugabyte password (default is `yugabyte`). You should be able to log in and see a response like below.
 
     ```output
     ysqlsh (11.2-YB-2.3.3.0-b0)

--- a/docs/content/stable/secure/authentication/ldap-authentication-ysql.md
+++ b/docs/content/stable/secure/authentication/ldap-authentication-ysql.md
@@ -1,11 +1,13 @@
 ---
-title: LDAP Authentication
-headerTitle: LDAP Authentication
+title: LDAP Authentication in YSQL
+headerTitle: LDAP Authentication in YSQL
 linkTitle: LDAP Authentication
 description: Configuring YugabyteDB to use an external LDAP authentication service.
+aliases:
+- /stable/secure/authentication/ldap-authentication
 menu:
   stable:
-    identifier: ldap-authentication
+    identifier: ldap-authentication-ysql
     parent: authentication
     weight: 732
 isTocNested: false
@@ -14,9 +16,15 @@ showAsideToc: true
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/latest/secure/authentication/ldap-authentication" class="nav-link active">
+    <a href="/stable/secure/authentication/ldap-authentication-ysql" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
+    </a>
+  </li>
+  <li >
+    <a href="/stable/secure/authentication/ldap-authentication-ycql" class="nav-link">
+      <i class="icon-cassandra" aria-hidden="true"></i>
+      YCQL
     </a>
   </li>
 </ul>


### PR DESCRIPTION
[Alex note: this is new for 2.6, and already in 2.9, but the files are the same. Edited in /stable, then copied the content into /latest]