### PR TITLE
[docs] fix incorrect link in design-goals

### DIFF
--- a/docs/content/latest/architecture/design-goals.md
+++ b/docs/content/latest/architecture/design-goals.md
@@ -51,7 +51,7 @@ Refer to the [table of isolation levels](/latest/explore/transactions/isolation-
 - Achieving [consistency with Raft consensus](../docdb-replication/replication/).
 - How [fault tolerance and high availability](../core-functions/high-availability/) are achieved.
 - [Single-row linearizable transactions](../transactions/single-row-transactions/) in YugabyteDB.
-- The architecture of [distributed transactions](../transactions/single-row-transactions/).
+- The architecture of [distributed transactions](../transactions/distributed-txns/).
 
 {{< /tip >}}
 


### PR DESCRIPTION
Fixing an incorrect link in the design goals section of architecture.

Thanks to Kripa Sreenivasan for catching this!

@netlify /latest/architecture/design-goals/