### PR TITLE
Correcting DDL statements for YSQL Table Partitioning document.

### DIFF
--- a/architecture/design/ysql-row-level-partitioning.md
+++ b/architecture/design/ysql-row-level-partitioning.md
@@ -30,7 +30,7 @@ Example: partitioning by date ranges, an example of partitioning by month is sho
 1. Create the table with the `PARTITION BY` clause as shown below:
 ```sql
 CREATE TABLE measurement (
-    city_id         int not null PRIMARY KEY,
+    city_id         int not null,
     logdate         date not null,
     peaktemp        int,
     unitsales       int
@@ -57,7 +57,7 @@ Example: partitioning a table containing information about people by region.
 1. Table creation:
 ```sql
 CREATE TABLE person (
-    person_id         int not null PRIMARY KEY,
+    person_id         int not null,
     country           text
 ) PARTITION BY LIST (country);
 ```


### PR DESCRIPTION
Executing Range and Hash partitioning DDL statement with primary key constraints won't allow creating a table. We should remove the primary key constraints from the Range and Hash partitioning 'CREATE TABLE' statements as the primary key has to be a part of partition keys.