### PR TITLE
[docs] remove remaining CDC content

### DIFF
--- a/docs/content/latest/reference/connectors/kafka-connect-yugabytedb.md
+++ b/docs/content/latest/reference/connectors/kafka-connect-yugabytedb.md
@@ -21,8 +21,6 @@ There are two approaches of integrating [YugabyteDB](https://github.com/yugabyte
 
 The Kafka Connect YugabyteDB source connector streams table updates in YugabyteDB to Kafka topics. It is based on YugabyteDB's Change Data Capture (CDC) feature. CDC allows the connector to simply subscribe to these table changes and then publish the changes to selected Kafka topics.
 
-For an example of the source connector in action, see [CDC to Kafka](../../../integrations/change-data-capture/cdc-kafka/) page.
-
 ## Kafka Connect YugabyteDB Sink Connector
 
 The Kafka Connect YugabyteDB Sink Connector delivers data from Kafka topics into YugabyteDB tables. The connector subscribes to specific topics in Kafka and then writes to specific tables in YugabyteDB as soon as new messages are received in the selected topics.

--- a/docs/content/stable/integrations/_index.html
+++ b/docs/content/stable/integrations/_index.html
@@ -131,7 +131,7 @@ menu:
       </div>
     </a>
   </div>
-
+<!--
   <div class="col-12 col-md-6 col-lg-12 col-xl-6">
     <a class="section-link icon-offset" href="change-data-capture/cdc-generic/">
       <div class="head">
@@ -143,7 +143,7 @@ menu:
       </div>
     </a>
   </div>
-
+-->
   <div class="col-12 col-md-6 col-lg-12 col-xl-6">
     <a class="section-link icon-offset" href="smart-driver/">
       <div class="head">

--- a/docs/content/stable/integrations/change-data-capture/cdc-generic.md
+++ b/docs/content/stable/integrations/change-data-capture/cdc-generic.md
@@ -1,3 +1,4 @@
+<!--
 ---
 title: Change Data Capture
 headerTitle: Change Data Capture
@@ -12,6 +13,7 @@ menu:
 isTocNested: true
 showAsideToc: true
 ---
+-->
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >

--- a/docs/content/stable/integrations/change-data-capture/cdc-kafka.md
+++ b/docs/content/stable/integrations/change-data-capture/cdc-kafka.md
@@ -1,3 +1,4 @@
+<!--
 ---
 title: Change data capture to Kafka
 headerTitle: Change data capture to Kafka
@@ -12,6 +13,7 @@ menu:
 isTocNested: true
 showAsideToc: true
 ---
+-->
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >

--- a/docs/content/stable/reference/connectors/kafka-connect-yugabytedb.md
+++ b/docs/content/stable/reference/connectors/kafka-connect-yugabytedb.md
@@ -21,8 +21,6 @@ There are two approaches of integrating [YugabyteDB](https://github.com/yugabyte
 
 The Kafka Connect YugabyteDB source connector streams table updates in YugabyteDB to Kafka topics. It is based on YugabyteDB's Change Data Capture (CDC) feature. CDC allows the connector to simply subscribe to these table changes and then publish the changes to selected Kafka topics.
 
-For an example of the source connector in action, see [CDC to Kafka](../../../integrations/change-data-capture/cdc-kafka/) page.
-
 ## Kafka Connect YugabyteDB Sink Connector
 
 The Kafka Connect YugabyteDB Sink Connector delivers data from Kafka topics into YugabyteDB tables. The connector subscribes to specific topics in Kafka and then writes to specific tables in YugabyteDB as soon as new messages are received in the selected topics.


### PR DESCRIPTION
Removing references to the (alpha) CDC content.

@netlify /latest/reference/connectors/kafka-connect-yugabytedb/