### PR TITLE
[docs] validate the issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/docDB.yml
+++ b/.github/ISSUE_TEMPLATE/docDB.yml
@@ -1,7 +1,7 @@
 name: Core-DocDB
 description: Create a DocDB issue.
 title: "[DocDB] Title"
-labels: "area/docdb"
+labels: ["area/docdb"]
 body:
 - type: textarea
   id: docDB

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,7 +1,7 @@
 name: Docs
 description: Create a documentation issue.
 title: "[Docs] Title"
-labels: "area/documentation"
+labels: ["area/documentation"]
 body:
 - type: textarea
   id: documentation
@@ -11,4 +11,3 @@ body:
       **Provide a detailed description of the information you want to update/include in the YugabyteDB docs.**
   validations:
     required: true 
-    

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature request
 description: Suggest an idea for this project.
 title: "[New Feature] Title"
-labels: "kind/new-feature"
+labels: ["kind/new-feature"]
 body:
 - type: textarea
   attributes:

--- a/.github/ISSUE_TEMPLATE/platform.yml
+++ b/.github/ISSUE_TEMPLATE/platform.yml
@@ -1,7 +1,7 @@
 name: Platform
 description: Create a Platform issue.
 title: "[Platform] Title"
-labels: "area/platform"
+labels: ["area/platform"]
 body:
 - type: textarea
   id: platform

--- a/.github/ISSUE_TEMPLATE/ui.yml
+++ b/.github/ISSUE_TEMPLATE/ui.yml
@@ -1,7 +1,7 @@
 name: Yugabyte UI
 description: Create a UI issue.
 title: "[UI] Title"
-labels: "area/ui"
+labels: ["area/ui"]
 body:
 - type: textarea
   id: ui

--- a/.github/ISSUE_TEMPLATE/ycql.yml
+++ b/.github/ISSUE_TEMPLATE/ycql.yml
@@ -1,7 +1,7 @@
 name: Core-YCQL
 description: Create a YCQL issue.
 title: "[YCQL] Title"
-labels: "area/ycql"
+labels: ["area/ycql"]
 body:
 - type: textarea
   id: ycql
@@ -13,4 +13,3 @@ body:
       **Include steps to reproduce the issue.**
   validations:
     required: true 
-    

--- a/.github/ISSUE_TEMPLATE/ysql.yml
+++ b/.github/ISSUE_TEMPLATE/ysql.yml
@@ -1,7 +1,7 @@
 name: Core-YSQL
 description: Create a YSQL issue.
 title: "[YSQL] Title"
-labels: "area/ysql"
+labels: ["area/ysql"]
 body:
 - type: textarea
   id: ysql
@@ -13,4 +13,3 @@ body:
       **Include steps to reproduce the issue.**
   validations:
     required: true
-    


### PR DESCRIPTION
Minor changes so the forms validate against github's [issue form schema](https://json.schemastore.org/github-issue-forms.json).