### PR TITLE
Added else clause in run_yb_admin function to accomodate non-TLS cases.

### DIFF
--- a/managed/devops/bin/yb_backup.py
+++ b/managed/devops/bin/yb_backup.py
@@ -994,7 +994,6 @@ class YBBackup:
             ipv6_flag = ["--net_address_filter", "ipv6_all"]
             cmd_line_args = ipv6_flag + cmd_line_args
 
-
         return self.run_tool(self.args.local_yb_admin_binary, self.args.remote_yb_admin_binary,
                              ['--master_addresses', self.args.masters],
                              cmd_line_args, run_ip=run_ip)


### PR DESCRIPTION
The function in question, run_yb_admin, should be called since it is the one which gets the master addresses. In current code, it is called only when TLS is enabled. In cases where TLS is not enabled, it is not called. So added an else clause which calls the command in case TLS is disabled.