### PR TITLE
[Docs] need to modify the command to run the Java application

### DIFF
--- a/docs/content/latest/quick-start/build-apps/java/ysql-jdbc-ssl.md
+++ b/docs/content/latest/quick-start/build-apps/java/ysql-jdbc-ssl.md
@@ -213,7 +213,7 @@ To build a Java application that connects to YugabyteDB over an SSL connection, 
 1. Run your new program.
 
     ```sh
-    $ java -Djavax.net.ssl.trustStore=ybtruststore -Djavax.net.ssl.trustStorePassword=yugabyte -cp "target/MySample-1.0-SNAPSHOT.jar:target/lib/*" -jar target/MySample-1.0-SNAPSHOT.jar
+    $ mvn -q package exec:java -DskipTests -Djavax.net.ssl.trustStore=ybtruststore -Djavax.net.ssl.trustStorePassword=yugabyte -Dexec.mainClass=com.yugabyte.HelloSqlSslApp
     ```
 
     You should see the following output:


### PR DESCRIPTION
Change the command to run the application with `mvn` command, otherwise, the original `java` cmd will return error as `no main manifest attribute`. 
If still using `java`, 
- it can be resolved with adding the main class `com.yugabyte.HelloSqlSslApp` as follows the sample code.
- Also, the postgres driver will not found with the classpath, the external library will be found in `$HOME/.m2/ directory` if no additional configurations are there in maven. so may need to add the classpath to that, or configure maven to copy the dependencies to `target/lib`