### PR TITLE
[UI] [docs] Fix re-rendering of docs page version dropdown

### DIFF
--- a/docs/layouts/partials/drawer.html
+++ b/docs/layouts/partials/drawer.html
@@ -23,7 +23,7 @@
       <div class="toc">
 
         {{ partial "detect_version" . }}
-        {{ partialCached "version_switcher" . }}
+        {{ partial "version_switcher" . }}
 
         {{ if $.menu }}
           {{ partial "nav" (dict "context" . "menu" $.menu) }}


### PR DESCRIPTION
Issue: https://github.com/yugabyte/yugabyte-db/issues/10480

Description
--
The issue currently today is that when a user goes to Yugabyte document page when they change the version of docs on the left side menu, the dropdown value always sticks to the first index instead of reacting to the dropDownValue change

Fix
--
This happens because the `version_switcher.html` component is cached and is not allowed to re-render in `drawer.html`.
