### PR TITLE
[docs] redirect updates

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -15,3 +15,5 @@ static/js/site.js
 .session.vim*
 
 *.sw?
+
+.hugo_build.lock

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -5,17 +5,17 @@
 # https://docs.netlify.com/configure-builds/file-based-configuration/#deploy-contexts
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.89.0"
+  HUGO_VERSION = "0.89.1"
   NODE_VERSION = "16"
   CXXFLAGS = "-std=c++17"
 
 [context.branch-deploy.environment]
-  HUGO_VERSION = "0.89.0"
+  HUGO_VERSION = "0.89.1"
   NODE_VERSION = "16"
   CXXFLAGS = "-std=c++17"
 
 [context.production.environment]
-  HUGO_VERSION = "0.88.1"
+  HUGO_VERSION = "0.89.1"
   NODE_VERSION = "16"
   CXXFLAGS = "-std=c++17"
 

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -5,12 +5,12 @@
 # https://docs.netlify.com/configure-builds/file-based-configuration/#deploy-contexts
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.88.1"
+  HUGO_VERSION = "0.89.0"
   NODE_VERSION = "16"
   CXXFLAGS = "-std=c++17"
 
 [context.branch-deploy.environment]
-  HUGO_VERSION = "0.88.1"
+  HUGO_VERSION = "0.89.0"
   NODE_VERSION = "16"
   CXXFLAGS = "-std=c++17"
 
@@ -73,6 +73,25 @@
 [[redirects]]
   from = "/:version/troubleshoot/*"
   to = "/latest/troubleshoot/:splat"
+  force = true
+
+# Cloud should point to latest
+
+[[redirects]]
+  from = "/:version/yugabyte-cloud/*"
+  to = "/latest/yugabyte-cloud/:splat"
+  force = true
+
+# Integrations should point to latest
+
+[[redirects]]
+  from = "/:version/integrations/*"
+  to = "/latest/integrations/:splat"
+  force = true
+
+[[redirects]]
+  from = "/:version/develop/ecosystem-integrations/*"
+  to = "/latest/integrations/:splat"
   force = true
 
 # Stable quick-starts need defaults,

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -79,19 +79,19 @@
 
 [[redirects]]
   from = "/:version/yugabyte-cloud/*"
-  to = "/latest/yugabyte-cloud/:splat"
+  to = "/latest/yugabyte-cloud/"
   force = true
 
 # Integrations should point to latest
 
 [[redirects]]
   from = "/:version/integrations/*"
-  to = "/latest/integrations/:splat"
+  to = "/latest/integrations/"
   force = true
 
 [[redirects]]
   from = "/:version/develop/ecosystem-integrations/*"
-  to = "/latest/integrations/:splat"
+  to = "/latest/integrations/"
   force = true
 
 # Stable quick-starts need defaults,


### PR DESCRIPTION
Redirects:

* all older versions of /_version_/yugabyte-cloud point to /latest/yugabyte-cloud
* all older versions of /_version_/integrations and /_version_/develop/ecosystem-integrations point to /latest/integrations

Also bumping Hugo to [current 89.1](https://github.com/gohugoio/hugo/releases) from 88.1. (This required adding the build lock to .gitignore.)