### PR TITLE
[docs] bump hugo version

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -5,17 +5,17 @@
 # https://docs.netlify.com/configure-builds/file-based-configuration/#deploy-contexts
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.89.1"
+  HUGO_VERSION = "0.89.2"
   NODE_VERSION = "16"
   CXXFLAGS = "-std=c++17"
 
 [context.branch-deploy.environment]
-  HUGO_VERSION = "0.89.1"
+  HUGO_VERSION = "0.89.2"
   NODE_VERSION = "16"
   CXXFLAGS = "-std=c++17"
 
 [context.production.environment]
-  HUGO_VERSION = "0.89.1"
+  HUGO_VERSION = "0.89.2"
   NODE_VERSION = "16"
   CXXFLAGS = "-std=c++17"
 


### PR DESCRIPTION
Hugo 89.2 addresses a rendering bug for indented code blocks. If the code snippets in the numbered steps render correctly, we're good to go.

@netlify /latest/explore/cluster-management/point-in-time-recovery-ycql/