### PR TITLE
[docs] update hugo config to provide dates in RSS

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -10,6 +10,11 @@ pygmentsStyle: "pygments"
 enableGitInfo: true
 resourceDir: docs/resources
 
+frontmatter:
+  date:
+    - :git
+    - :default
+
 params:
   author: Team Yugabyte
   description: 'YugabyteDB, the transactional, high-performance database for building internet-scale, globally-distributed apps.'


### PR DESCRIPTION
This change tells Hugo to pull each file's last-committed date from Git to populate the `<pubDate>` elements in the RSS.

The feed we most care about currently is `/latest/releases/whats-new/index.xml` — verify that the two pages in that file actually have non-zero pub dates!

Compare the new output to the old output...

```sh
# new output:
$ curl https://deploy-preview-10568--infallible-bardeen-164bc9.netlify.app/latest/releases/whats-new/index.xml

# old output:
$ curl https://docs.yugabyte.com/latest/releases/whats-new/index.xml

# or, for less noise in the output:

$ curl https://deploy-preview-10568--infallible-bardeen-164bc9.netlify.app/latest/releases/whats-new/index.xml | grep pubDate
$ curl https://docs.yugabyte.com/latest/releases/whats-new/index.xml | grep pubDate
```