### PR TITLE
[docs] alias to redirect to the new jdbc page

### DIFF
--- a/docs/content/latest/integrations/jdbc-driver.md
+++ b/docs/content/latest/integrations/jdbc-driver.md
@@ -3,6 +3,7 @@ title: Yugabyte JDBC Driver
 linkTitle: Yugabyte JDBC Driver
 description: Yugabyte JDBC Driver for YSQL
 aliases:
+  - /latest/integrations/smart-driver/
 menu:
   latest:
     identifier: jdbc-driver


### PR DESCRIPTION
Added an alias to redirect the smart driver to the new JDBC page.

@netlify /latest/integrations/jdbc-driver/