### PR TITLE
[docs] 2.6.6.0 release notes

### DIFF
--- a/docs/content/latest/releases/earlier-releases/_index.md
+++ b/docs/content/latest/releases/earlier-releases/_index.md
@@ -18,6 +18,7 @@ Note that, starting with 2.3, download links for all releases in a given release
 | Release | Date | Binary | Docker Image Tag |
 | :------ | :--- | :----- | :--------------- |
 | [v2.7](./v2.7/) | May 5, 2021 and later | in release notes | in release notes |
+| [v2.6](./v2.6/) | July 7, 2021 and later | in release notes | in release notes |
 | [v2.5](./v2.5/) | Nov 12, 2020 and later | in release notes | in release notes |
 | [v2.4](./v2.4/) | Jan 22, 2021 and later | in release notes | in release notes |
 | [v2.2.7](./v2.2.0#v2-2-7-feb-19-2021) | Feb 19, 20201 | <a href="https://downloads.yugabyte.com/yugabyte-2.2.7.0-darwin.tar.gz"><i class="fab fa-apple"></i><span class="release-os">macOS</span></a>, <a href="https://downloads.yugabyte.com/yugabyte-2.2.7.0-linux.tar.gz"><i class="fab fa-linux"></i><span class="release-os">Linux</span></a> | 2.2.7.0-b5 |

--- a/docs/content/latest/releases/earlier-releases/v2.4.md
+++ b/docs/content/latest/releases/earlier-releases/v2.4.md
@@ -3,12 +3,11 @@ title: What's new in the v2.4 release series
 headerTitle: What's new in the v2.4 release series
 linkTitle: v2.4 series
 description: Enhancements, changes, and resolved issues in the v2.4 release series.
-headcontent: Enhancements, changes, and resolved issues in the v2.4 release series.
 menu:
   latest:
     parent: earlier-releases
     identifier: v2.4
-    weight: 2549
+    weight: 2548
 isTocNested: true
 showAsideToc: true
 ---

--- a/docs/content/latest/releases/earlier-releases/v2.5.md
+++ b/docs/content/latest/releases/earlier-releases/v2.5.md
@@ -3,13 +3,12 @@ title: What's new in the v2.5 release series
 headerTitle: What's new in the v2.5 release series
 linkTitle: v2.5 series
 description: Enhancements, changes, and resolved issues in the v2.5 release series.
-headcontent: Features, enhancements, and resolved issues in the v2.5 release series.
 image: /images/section_icons/quick_start/install.png
 menu:
   latest:
     parent: earlier-releases
     identifier: v2.5
-    weight: 2549
+    weight: 2547
 isTocNested: true
 showAsideToc: true 
 ---

--- a/docs/content/latest/releases/earlier-releases/v2.6.md
+++ b/docs/content/latest/releases/earlier-releases/v2.6.md
@@ -55,7 +55,7 @@ docker pull yugabytedb/yugabyte:2.6.6.0-b10
 
 #### Database
 
-[#10428] [DocDB] Improve logging for SST file expiration
+* [[10428](https://github.com/yugabyte/yugabyte-db/issues/10428)] [DocDB] Improve logging for SST file expiration
 
 ### Bug fixes
 
@@ -68,12 +68,12 @@ docker pull yugabytedb/yugabyte:2.6.6.0-b10
 
 #### Database
 
-[#8229] [Backup] Repartition table if needed on YSQL restore
-[#8251] [#9825] Add Transaction Cleanup to CREATE INDEX
-[#10304] [DocDB] Fix deadlock in ProcessTabletReportBatch
-[#10430] [YSQL] Limit to IPv4 for sys catalog initialization
-[#10503] [DocDB] Add GFlag to trust value-level TTL metadata during file expiration.
-[#10504] [DocDB] Move value TTL metadata collection to DocWriteBatch
+* [[8229](https://github.com/yugabyte/yugabyte-db/issues/8229)] [Backup] Repartition table if needed on YSQL restore
+* [[8251](https://github.com/yugabyte/yugabyte-db/issues/8251)] [[9825](https://github.com/yugabyte/yugabyte-db/issues/9825)] Add Transaction Cleanup to CREATE INDEX
+* [[10304](https://github.com/yugabyte/yugabyte-db/issues/10304)] [DocDB] Fix deadlock in ProcessTabletReportBatch
+* [[10430](https://github.com/yugabyte/yugabyte-db/issues/10430)] [YSQL] Limit to IPv4 for sys catalog initialization
+* [[10503](https://github.com/yugabyte/yugabyte-db/issues/10503)] [DocDB] Add GFlag to trust value-level TTL metadata during file expiration.
+* [[10504](https://github.com/yugabyte/yugabyte-db/issues/10504)] [DocDB] Move value TTL metadata collection to DocWriteBatch
 
 ### Known issues
 

--- a/docs/content/latest/releases/earlier-releases/v2.6.md
+++ b/docs/content/latest/releases/earlier-releases/v2.6.md
@@ -1,14 +1,13 @@
 ---
 title: What's new in the v2.6 release series
 headerTitle: What's new in the v2.6 release series
-linkTitle: v2.6
+linkTitle: v2.6 series
 description: Enhancements, changes, and resolved issues in the v2.6 release series.
-headcontent: Features, enhancements, and resolved issues in the v2.6 release series.
 menu:
   latest:
     parent: earlier-releases
     identifier: v2.6
-    weight: 2549
+    weight: 2546
 isTocNested: true
 showAsideToc: true
 ---
@@ -20,6 +19,71 @@ Release v2.6.1.0 contains an authentication vulnerability in YCQL LDAP. _YSQL is
 
 If you're using YCQL LDAP with v2.6.1.0 and can't upgrade immediately, see the note in the [Version 2.6.1.0 section](#v2-6-1-0-sept-3-2021) for mitigation instructions.
 {{< /warning >}}
+
+## v2.6.6.0 - Nov 16, 2021
+
+**Build:** `2.6.6.0-b10`
+
+### Downloads
+
+<a class="download-binary-link" href="https://downloads.yugabyte.com/yugabyte-2.6.6.0-darwin.tar.gz">
+  <button>
+    <i class="fab fa-apple"></i><span class="download-text">macOS</span>
+  </button>
+</a>
+&nbsp; &nbsp; &nbsp;
+<a class="download-binary-link" href="https://downloads.yugabyte.com/yugabyte-2.6.6.0-linux.tar.gz">
+  <button>
+    <i class="fab fa-linux"></i><span class="download-text">Linux</span>
+  </button>
+</a>
+<br />
+
+### Docker
+
+```sh
+docker pull yugabytedb/yugabyte:2.6.6.0-b10
+```
+
+### Improvements
+
+#### Yugabyte Platform
+
+* [PLAT-490] Display timezone with timestamp
+* [PLAT-1962] Add optional AWS KMS Endpoint field while creating KMS config.
+* [PLAT-2144] Prometheus K8s metrics storage settings
+
+#### Database
+
+[#10428] [DocDB] Improve logging for SST file expiration
+
+### Bug fixes
+
+#### Yugabyte Platform
+
+* [PLAT-2109] Skip hostname validation in certificate
+* [PLAT-2167] Fix 3000 seconds timeout for IAM profile retrieval operation
+* [PLAT-2189] Fix universe creation on airgap install
+* [Platform] [UI] Add an optional field AWS KMS Endpoint while creating KMS config
+
+#### Database
+
+[#8229] [Backup] Repartition table if needed on YSQL restore
+[#8251] [#9825] Add Transaction Cleanup to CREATE INDEX
+[#10304] [DocDB] Fix deadlock in ProcessTabletReportBatch
+[#10430] [YSQL] Limit to IPv4 for sys catalog initialization
+[#10503] [DocDB] Add GFlag to trust value-level TTL metadata during file expiration.
+[#10504] [DocDB] Move value TTL metadata collection to DocWriteBatch
+
+### Known issues
+
+#### Yugabyte Platform
+
+N/A
+
+#### Database
+
+N/A
 
 ## v2.6.5.0 - Oct 29, 2021
 
@@ -69,7 +133,7 @@ N/A
 * [PLAT-1634] Backup page is not loading because of empty config column
 * [PLAT-1934] Adding UI to set KUBE_DOMAIN
 * [PLAT-2113] [PLAT-2116] Fix HA failing with entity_too_large
-* [PLAT-2020] [PLAT-2041] Fix HA on IPv6-enabled K8s setup 
+* [PLAT-2020] [PLAT-2041] Fix HA on IPv6-enabled K8s setup
 * [YB] Replaced the Busybox image with a YB image, as some environments are unable to access Busybox
 
 ### Known issues

--- a/docs/content/latest/releases/earlier-releases/v2.7.md
+++ b/docs/content/latest/releases/earlier-releases/v2.7.md
@@ -3,13 +3,12 @@ title: What's new in the v2.7 release series
 headerTitle: What's new in the v2.7 release series
 linkTitle: v2.7 series
 description: Enhancements, changes, and resolved issues in the v2.7 release series.
-headcontent: Features, enhancements, and resolved issues in the v2.7 release series.
 image: /images/section_icons/quick_start/install.png
 menu:
   latest:
     parent: earlier-releases
     identifier: v2.7
-    weight: 2549
+    weight: 2545
 isTocNested: true
 showAsideToc: true 
 ---

--- a/docs/content/latest/releases/whats-new/latest-release.md
+++ b/docs/content/latest/releases/whats-new/latest-release.md
@@ -3,7 +3,6 @@ title: What's new in the v2.9 latest release series
 headerTitle: What's new in the v2.9 latest release series
 linkTitle: v2.9 (latest)
 description: Enhancements, changes, and resolved issues in the latest release series.
-headcontent: Features, enhancements, and resolved issues in the latest release series.
 image: /images/section_icons/quick_start/install.png
 aliases:
   - /latest/releases/

--- a/docs/content/latest/releases/whats-new/stable-release.md
+++ b/docs/content/latest/releases/whats-new/stable-release.md
@@ -3,7 +3,6 @@ title: What's new in the v2.8 stable release series
 headerTitle: What's new in the v2.8 stable release series
 linkTitle: v2.8 (stable)
 description: Enhancements, changes, and resolved issues in the current stable release series recommended for production deployments.
-headcontent: Features, enhancements, and resolved issues in the current stable release series recommended for production deployments.
 aliases:
   - /latest/releases/whats-new/stable-releases/
 menu:
@@ -19,7 +18,7 @@ Included here are the release notes for all releases in the v2.8 stable release 
 
 For an RSS feed of the release notes for the latest and stable releases, point your feed reader to [https://docs.yugabyte.com/latest/releases/whats-new/index.xml](../index.xml).
 
-## v2.8.0.0 - November 8, 2021
+## v2.8.0.0 - November 16, 2021
 
 **Build:** `2.8.0.0-b37`
 

--- a/docs/content/v2.6/quick-start/install/docker.md
+++ b/docs/content/v2.6/quick-start/install/docker.md
@@ -71,7 +71,7 @@ You must have the Docker runtime installed on your localhost. Follow the links b
 Pull the YugabyteDB container.
 
 ```sh
-$ docker pull yugabytedb/yugabyte:2.6.5.0-b4
+$ docker pull yugabytedb/yugabyte:2.6.6.0-b10
 ```
 
 {{<tip title="Next step" >}}

--- a/docs/content/v2.6/quick-start/install/linux.md
+++ b/docs/content/v2.6/quick-start/install/linux.md
@@ -100,7 +100,7 @@ Starting from Ubuntu 20.04, `python` isn't available anymore. An easy fix is to 
 1. Extract the package and then change directories to the YugabyteDB home.
 
     ```sh
-    $ tar xvfz yugabyte-2.6.6.0-linux.tar.gz && cd yugabyte-2.6.4.0/
+    $ tar xvfz yugabyte-2.6.6.0-linux.tar.gz && cd yugabyte-2.6.6.0/
     ```
 
 ## Configure YugabyteDB

--- a/docs/content/v2.6/quick-start/install/linux.md
+++ b/docs/content/v2.6/quick-start/install/linux.md
@@ -69,7 +69,7 @@ showAsideToc: true
 By default, CentOS 8 doesn't have an unversioned system-wide `python` command to avoid locking users to a specific version of Python.
 One way to fix this is to set `python3` the alternative for `python` by running: `sudo alternatives --set python /usr/bin/python3`.
 
-Starting from Ubuntu 20.04, `python` isn't available anymore. An easy fix is to install `sudo apt install python-is-python3`. 
+Starting from Ubuntu 20.04, `python` isn't available anymore. An easy fix is to install `sudo apt install python-is-python3`.
 
     {{< /note >}}
 
@@ -94,13 +94,13 @@ Starting from Ubuntu 20.04, `python` isn't available anymore. An easy fix is to 
 1. Download the YugabyteDB package using the following `wget` command.
 
     ```sh
-    $ wget https://downloads.yugabyte.com/yugabyte-2.6.5.0-linux.tar.gz
+    $ wget https://downloads.yugabyte.com/yugabyte-2.6.6.0-linux.tar.gz
     ```
 
 1. Extract the package and then change directories to the YugabyteDB home.
 
     ```sh
-    $ tar xvfz yugabyte-2.6.5.0-linux.tar.gz && cd yugabyte-2.6.4.0/
+    $ tar xvfz yugabyte-2.6.6.0-linux.tar.gz && cd yugabyte-2.6.4.0/
     ```
 
 ## Configure YugabyteDB

--- a/docs/content/v2.6/quick-start/install/macos.md
+++ b/docs/content/v2.6/quick-start/install/macos.md
@@ -50,7 +50,7 @@ showAsideToc: true
 
 1. macOS 10.12 or later.
 
-1. Verify that you have Python 2 or 3 installed. 
+1. Verify that you have Python 2 or 3 installed.
 
     ```sh
     $ python --version
@@ -125,13 +125,13 @@ showAsideToc: true
 1. Download the YugabyteDB `tar.gz` file using the following `wget` command.
 
     ```sh
-    $ wget https://downloads.yugabyte.com/yugabyte-2.6.5.0-darwin.tar.gz
+    $ wget https://downloads.yugabyte.com/yugabyte-2.6.6.0-darwin.tar.gz
     ```
 
 1. Extract the package and then change directories to the YugabyteDB home.
 
     ```sh
-    $ tar xvfz yugabyte-2.6.5.0-darwin.tar.gz && cd yugabyte-2.6.4.0/
+    $ tar xvfz yugabyte-2.6.6.0-darwin.tar.gz && cd yugabyte-2.6.4.0/
     ```
 
 ## Configure

--- a/docs/content/v2.6/quick-start/install/macos.md
+++ b/docs/content/v2.6/quick-start/install/macos.md
@@ -131,7 +131,7 @@ showAsideToc: true
 1. Extract the package and then change directories to the YugabyteDB home.
 
     ```sh
-    $ tar xvfz yugabyte-2.6.6.0-darwin.tar.gz && cd yugabyte-2.6.4.0/
+    $ tar xvfz yugabyte-2.6.6.0-darwin.tar.gz && cd yugabyte-2.6.6.0/
     ```
 
 ## Configure

--- a/docs/layouts/partials/head.html
+++ b/docs/layouts/partials/head.html
@@ -100,9 +100,9 @@
     {{ end }}
     <script src="/js/modernizr.js"></script>
 
-    {{ with .RSSLink }}
-    <link href="{{ . }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
-    <link href="{{ . }}" rel="feed" type="application/rss+xml" title="{{ $.Site.Title }}" />
+    {{ with .OutputFormats.Get "RSS" }}
+    <link href="{{ .Permalink }}" rel="alternate" type="application/rss+xml" title="{{ $.Page.Title }}" />
+    <link href="{{ .Permalink }}" rel="feed" type="application/rss+xml" title="{{ $.Page.Title }}" />
     {{ end }}
 
   </head>


### PR DESCRIPTION
And some other minor changes:
- add 2.6 to table of earlier releases
- left-nav ordering of earlier releases
- fix the RSS template to correct a hugo warning
- remove "headcontent" from non-index files

@netlify /latest/releases/earlier-releases/v2.6/