### PR TITLE
[docs] Fix for row-level-geo-partitioning page.

### DIFF
--- a/docs/content/latest/explore/multi-region-deployments/row-level-geo-partitioning.md
+++ b/docs/content/latest/explore/multi-region-deployments/row-level-geo-partitioning.md
@@ -109,7 +109,7 @@ First, we create the parent table that contains a `geo_partition` column which i
           (user_id, account_id, geo_partition, account_type,
           amount, txn_type, created_at,
           PRIMARY KEY (user_id HASH, account_id, geo_partition))
-        FOR VALUES IN ('EU') TABLESPACE eu_central_1_tablespace;;
+        FOR VALUES IN ('EU') TABLESPACE eu_central_1_tablespace;
 
     CREATE TABLE transactions_india
         PARTITION OF transactions

--- a/docs/content/stable/explore/multi-region-deployments/row-level-geo-partitioning.md
+++ b/docs/content/stable/explore/multi-region-deployments/row-level-geo-partitioning.md
@@ -109,7 +109,7 @@ First, we create the parent table that contains a `geo_partition` column which i
           (user_id, account_id, geo_partition, account_type,
           amount, txn_type, created_at,
           PRIMARY KEY (user_id HASH, account_id, geo_partition))
-        FOR VALUES IN ('EU') TABLESPACE eu_central_1_tablespace;;
+        FOR VALUES IN ('EU') TABLESPACE eu_central_1_tablespace;
 
     CREATE TABLE transactions_india
         PARTITION OF transactions

--- a/docs/content/v2.6/explore/multi-region-deployments/row-level-geo-partitioning.md
+++ b/docs/content/v2.6/explore/multi-region-deployments/row-level-geo-partitioning.md
@@ -109,7 +109,7 @@ First, we create the parent table that contains a `geo_partition` column which i
           (user_id, account_id, geo_partition, account_type,
           amount, txn_type, created_at,
           PRIMARY KEY (user_id HASH, account_id, geo_partition))
-        FOR VALUES IN ('EU') TABLESPACE eu_central_1_tablespace;;
+        FOR VALUES IN ('EU') TABLESPACE eu_central_1_tablespace;
 
     CREATE TABLE transactions_india
         PARTITION OF transactions


### PR DESCRIPTION
 Remove an extra semicolon for one of the commands for latest, stable, and v2.6.
@netlify /latest/explore/multi-region-deployments/row-level-geo-partitioning/