### PR TITLE
[docs] Fixed 'timestampz' typo to 'timestamptz' in 'latest' and 'stable'

### DIFF
--- a/docs/content/latest/api/ysql/datatypes/_index.md
+++ b/docs/content/latest/api/ysql/datatypes/_index.md
@@ -63,7 +63,7 @@ The following table lists the primitive and compound data types in YSQL.
 | [`time [ (p) ] [ without time zone ]`](type_datetime) | | Time of day (no time zone) |
 | [`time [ (p) ] with time zone`](type_datetime) | [`timetz`](type_datetime) | Time of day, including time zone |
 | [`timestamp [ (p) ] [ without time zone ]`](type_datetime) | | Date and time (no time zone) |
-| [`timestamp [ (p) ] with time zone`](type_datetime) | [`timestampz`](type_datetime) | Date and time, including time zone |
+| [`timestamp [ (p) ] with time zone`](type_datetime) | [`timestamptz`](type_datetime) | Date and time, including time zone |
 | `tsquery` <sup>1</sup> | | Text search query |
 | `tsvector` <sup>1</sup> | | Text search document |
 | `txid_snapshot` <sup>1</sup> | | Transaction ID snapshot |

--- a/docs/content/stable/api/ysql/datatypes/_index.md
+++ b/docs/content/stable/api/ysql/datatypes/_index.md
@@ -61,7 +61,7 @@ The following table lists the primitive and compound data types in YSQL.
 | [`time [ (p) ] [ without time zone ]`](type_datetime) | | Time of day (no time zone) |
 | [`time [ (p) ] with time zone`](type_datetime) | [`timetz`](type_datetime) | Time of day, including time zone |
 | [`timestamp [ (p) ] [ without time zone ]`](type_datetime) | | Date and time (no time zone) |
-| [`timestamp [ (p) ] with time zone`](type_datetime) | [`timestampz`](type_datetime) | Date and time, including time zone |
+| [`timestamp [ (p) ] with time zone`](type_datetime) | [`timestamptz`](type_datetime) | Date and time, including time zone |
 | `tsquery` <sup>1</sup> | | Text search query |
 | `tsvector` <sup>1</sup> | | Text search document |
 | `txid_snapshot` <sup>1</sup> | | Transaction ID snapshot |


### PR DESCRIPTION
Only two occurrences found:

```
docs/content/latest/api/ysql/datatypes/_index.md
docs/content/stable/api/ysql/datatypes/_index.md
```