### PR TITLE
[docs] PR Add links to the blog post about alerts (Doc-BlogLinkInAlertsDocs)

### DIFF
--- a/docs/content/latest/yugabyte-platform/alerts-monitoring/alert.md
+++ b/docs/content/latest/yugabyte-platform/alerts-monitoring/alert.md
@@ -21,5 +21,5 @@ You can access detailed information about a specific alert by clicking on its na
 
 The alert status can be active, acknowledged, or resolved. You can change the status by taking an appropriate action, such as, for example, **Acknowledge** for an active alert. Note that if you are using a read-only account for Yugabyte Platform, you cannot perform actions.
 
-
+For additional information, see [Alerts and Notifications in Yugabyte Platform](https://blog.yugabyte.com/yugabytedb-2-8-alerts-and-notifications/).
 

--- a/docs/content/latest/yugabyte-platform/configure-yugabyte-platform/set-up-alerts-health-check.md
+++ b/docs/content/latest/yugabyte-platform/configure-yugabyte-platform/set-up-alerts-health-check.md
@@ -14,6 +14,12 @@ showAsideToc: true
 
 Yugabyte Platform can check universes for issues that may affect deployment. Should problems arise, Yugabyte Platform can automatically issue alert notifications.
 
+For additional information, see the following: 
+
+- [Alerts](../../alerts-monitoring/alert/)
+- [Metrics](../../troubleshoot/universe-issues/#use-metrics/)
+- [Alerts and Notifications in Yugabyte Platform](https://blog.yugabyte.com/yugabytedb-2-8-alerts-and-notifications/)
+
 You can access Yugabyte Platform health monitor and configure alerts by navigating to **Admin > Alert Configurations**, as per the following illustration:
 
 ![Configure alerts](/images/yp/config-alerts1.png)


### PR DESCRIPTION
Docs on alerts should benefit from a link to a new blog post on the topic.
Added the link to two files.