### PR TITLE
[docs] update markdownlint configuration

### DIFF
--- a/docs/.markdownlint.json
+++ b/docs/.markdownlint.json
@@ -1,11 +1,13 @@
 {
   "default": true,
   "MD007": {"indent": 2},
-  "MD009": false,
+  "MD009": {"list_item_empty_lines": false, "strict": true},
   "MD013": false,
   "MD014": false,
   "MD024": {"siblings_only": true},
   "MD033": false,
   "MD036": false,
-  "MD041": {"front_matter_title": "^\\s*title\\s*[:=]"}
+  "MD041": {"front_matter_title": "^\\s*title\\s*[:=]"},
+  "MD046": {"style": "fenced"},
+  "MD048": {"style": "backtick"}
 }

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "docs",
       "version": "1.1.0",
       "license": "UNLICENSED",
       "dependencies": {


### PR DESCRIPTION
Removing a couple of redundant entries, and adding some more specificity to a couple of rules.

(Also a tiny update to docs package-lock)