### PR TITLE
[docs] remove conflicting redirects from /develop

### DIFF
--- a/docs/content/latest/develop/_index.md
+++ b/docs/content/latest/develop/_index.md
@@ -5,8 +5,6 @@ linkTitle: Develop
 description: Build YugabyteDB application that use ecosystem integrations and GraphQL.
 headcontent: Get started building applications based on YugabyteDB.
 image: /images/section_icons/index/develop.png
-aliases:
-  - /develop/
 section: YUGABYTEDB CORE
 menu:
   latest:

--- a/docs/content/latest/yedis/develop/_index.md
+++ b/docs/content/latest/yedis/develop/_index.md
@@ -2,10 +2,8 @@
 title: Develop
 linkTitle: Develop
 description: Develop applications on YEDIS
-headcontent: 
+headcontent:
 image: /images/section_icons/index/develop.png
-aliases:
-  - /develop/
 menu:
   latest:
     identifier: develop-yedis


### PR DESCRIPTION
Removing a pair of conflicting (and very old) aliases. The deploy preview should be a 404.

@netlify /develop