### PR TITLE
[docs] add reference and link to support site

### DIFF
--- a/docs/content/latest/troubleshoot/overview.md
+++ b/docs/content/latest/troubleshoot/overview.md
@@ -30,10 +30,9 @@ Next, check the list of [cluster issues](../cluster) and the respective fixes fo
 
 Inspect the YugabyteDB logs for more details on your issue. For more details on where to find and how to understand the YugabyteDB log files, see [Inspect logs](../nodes/check-logs).
 
-## 4. Explore Support KB's 
+## 4. Explore knowledge base articles
 
-Additional troubleshooting resources, and information on errata can be found on our [Support page](https://support.yugabyte.com).
-
+You can find additional troubleshooting resources, and information on errata, on our [Support page](https://support.yugabyte.com).
 
 ## 5. File an issue
 

--- a/docs/content/latest/troubleshoot/overview.md
+++ b/docs/content/latest/troubleshoot/overview.md
@@ -30,6 +30,11 @@ Next, check the list of [cluster issues](../cluster) and the respective fixes fo
 
 Inspect the YugabyteDB logs for more details on your issue. For more details on where to find and how to understand the YugabyteDB log files, see [Inspect logs](../nodes/check-logs).
 
-## 4. File an issue
+## 4. Explore Support KB's 
+
+Additional troubleshooting resources, and information on errata can be found on our [Support page](https://support.yugabyte.com).
+
+
+## 5. File an issue
 
 If you could not find a solution to your problem in these docs, please file a [GitHub issue](https://github.com/yugabyte/yugabyte-db/issues) describing your specific problem.


### PR DESCRIPTION
Support KB's often have the most recent information for Bugs affecting customers, they also have a wealth of information not available in the current troubleshooting section of the docs. This will allow customers reading the docs to have a link to explore support articles. 