### PR TITLE
[docs] [#10890] Platform: Remove HA Beta tag

### DIFF
--- a/docs/content/latest/yugabyte-platform/manage-deployments/high-availability.md
+++ b/docs/content/latest/yugabyte-platform/manage-deployments/high-availability.md
@@ -13,7 +13,7 @@ isTocNested: true
 showAsideToc: true
 ---
 
-Yugabyte’s distributed architecture enables your database clusters (called universes) to have extremely high availability. And as the central source of database orchestration, monitoring, alerting, and more, Yugabyte Platform brings its own distributed architecture to the table in the form of the High Availability feature (beta).
+Yugabyte’s distributed architecture enables your database clusters (called universes) to have extremely high availability. And as the central source of database orchestration, monitoring, alerting, and more, Yugabyte Platform brings its own distributed architecture to the table in the form of the High Availability feature.
 
 Platform's high availability feature is an active-standby model for multiple platforms in a cluster with asynchronous replication. Your platform data is replicated across multiple VMs, ensuring that you can recover smoothly and quickly from a VM failure and continue to manage and monitor your universes, with your configuration and metrics data intact.
 

--- a/docs/content/stable/yugabyte-platform/manage-deployments/high-availability.md
+++ b/docs/content/stable/yugabyte-platform/manage-deployments/high-availability.md
@@ -12,7 +12,7 @@ isTocNested: true
 showAsideToc: true
 ---
 
-Yugabyte’s distributed architecture enables your database clusters (called universes) to have extremely high availability. And as the central source of database orchestration, monitoring, alerting, and more, Yugabyte Platform brings its own distributed architecture to the table in the form of the High Availability feature (beta).
+Yugabyte’s distributed architecture enables your database clusters (called universes) to have extremely high availability. And as the central source of database orchestration, monitoring, alerting, and more, Yugabyte Platform brings its own distributed architecture to the table in the form of the High Availability feature.
 
 Platform's high availability feature is an active-standby model for multiple platforms in a cluster with asynchronous replication. Your platform data is replicated across multiple VMs, ensuring that you can recover smoothly and quickly from a VM failure and continue to manage and monitor your universes, with your configuration and metrics data intact.
 

--- a/docs/content/v2.6/yugabyte-platform/manage-deployments/high-availability.md
+++ b/docs/content/v2.6/yugabyte-platform/manage-deployments/high-availability.md
@@ -12,7 +12,7 @@ isTocNested: true
 showAsideToc: true
 ---
 
-Yugabyte’s distributed architecture enables your database clusters (called universes) to have extremely high availability. And as the central source of database orchestration, monitoring, alerting, and more, Yugabyte Platform brings its own distributed architecture to the table in the form of the High Availability feature (beta).
+Yugabyte’s distributed architecture enables your database clusters (called universes) to have extremely high availability. And as the central source of database orchestration, monitoring, alerting, and more, Yugabyte Platform brings its own distributed architecture to the table in the form of the High Availability feature.
 
 Platform's high availability feature is an active-standby model for multiple platforms in a cluster with asynchronous replication. Your platform data is replicated across multiple VMs, ensuring that you can recover smoothly and quickly from a VM failure and continue to manage and monitor your universes, with your configuration and metrics data intact.
 


### PR DESCRIPTION
Platform HA was Beta in v2.5.3.1, and went GA in v2.6:

https://docs.yugabyte.com/latest/releases/earlier-releases/v2.6/

Announcing YugabyteDB 2.6 > Yugabyte Platform High Availability (HA)

> HA mode of Yugabyte Platform, first announced in YugabyteDB 2.7, is now
generally available.