### PR TITLE
[Platform][Kubernetes] Use az.updateConfig for incluster credentials

### DIFF
--- a/managed/src/main/java/com/yugabyte/yw/controllers/handlers/CloudProviderHandler.java
+++ b/managed/src/main/java/com/yugabyte/yw/controllers/handlers/CloudProviderHandler.java
@@ -219,7 +219,7 @@ public class CloudProviderHandler {
         boolean isConfigInZone = updateKubeConfigForZone(provider, region, az, zoneConfig, false);
         if (!(isConfigInProvider || isConfigInRegion || isConfigInZone)) {
           // Use in-cluster ServiceAccount credentials
-          az.setConfig(ImmutableMap.of("KUBECONFIG", ""));
+          az.updateConfig(ImmutableMap.of("KUBECONFIG", ""));
           az.save();
         }
       }
@@ -287,7 +287,7 @@ public class CloudProviderHandler {
         boolean isConfigInZone = updateKubeConfigForZone(provider, region, az, zoneConfig, false);
         if (!(isConfigInProvider || isConfigInRegion || isConfigInZone)) {
           // Use in-cluster ServiceAccount credentials
-          az.setConfig(ImmutableMap.of("KUBECONFIG", ""));
+          az.updateConfig(ImmutableMap.of("KUBECONFIG", ""));
           az.save();
         }
       }


### PR DESCRIPTION
c0b9786ec2eec41d5773eef07f88d87ed77d189e changed the behavior of az.setConfig and added az.updateConfig. This change uses the correct method to add `{"KUBECONFIG": ""}` to the existing configuration instead of overwriting the whole AZ configuration.

This was missed when I rebased https://github.com/yugabyte/yugabyte-db/pull/8371 against latest changes.

Fixes https://github.com/yugabyte/yugabyte-db/issues/10860