### PR TITLE
[docs] [Quick start] Updated python driver install commands for ycql

### DIFF
--- a/docs/content/latest/quick-start/build-apps/python/ycql.md
+++ b/docs/content/latest/quick-start/build-apps/python/ycql.md
@@ -46,8 +46,12 @@ showAsideToc: true
 To install the [Yugabyte Python Driver for YCQL](https://github.com/yugabyte/cassandra-python-driver), run the following command:
 
 ```sh
-$ pip install yb-cassandra-driver
+$ pip3 install yb-cassandra-driver --install-option="--no-cython"
 ```
+
+{{< note title="Note">}}
+The flag `--no-cython` is necessary on MacOS Catalina and further MacOS releases to avoid a failure while building the `yb-cassandra-driver`.
+{{< /note >}}
 
 ## Create a sample Python application
 
@@ -104,7 +108,7 @@ cluster.shutdown()
 To run the application, type the following:
 
 ```sh
-$ python yb-cql-helloworld.py
+$ python3 yb-cql-helloworld.py
 ```
 
 You should see the following output.

--- a/docs/content/stable/quick-start/build-apps/python/ycql.md
+++ b/docs/content/stable/quick-start/build-apps/python/ycql.md
@@ -46,8 +46,12 @@ showAsideToc: true
 To install the [Yugabyte Python Driver for YCQL](https://github.com/yugabyte/cassandra-python-driver), run the following command:
 
 ```sh
-$ pip install yb-cassandra-driver
+$ pip3 install yb-cassandra-driver --install-option="--no-cython"
 ```
+
+{{< note title="Note">}}
+The flag `--no-cython` is necessary on MacOS Catalina and further MacOS releases to avoid a failure while building the `yb-cassandra-driver`.
+{{< /note >}}
 
 ## Create a sample Python application
 
@@ -104,7 +108,7 @@ cluster.shutdown()
 To run the application, type the following:
 
 ```sh
-$ python yb-cql-helloworld.py
+$ python3 yb-cql-helloworld.py
 ```
 
 You should see the following output.

--- a/docs/content/v2.2/quick-start/build-apps/python/ycql.md
+++ b/docs/content/v2.2/quick-start/build-apps/python/ycql.md
@@ -47,8 +47,12 @@ showAsideToc: true
 To install the [Yugabyte Python Driver for YCQL](https://github.com/yugabyte/cassandra-python-driver), run the following command:
 
 ```sh
-$ pip install yb-cassandra-driver
+$ pip3 install yb-cassandra-driver --install-option="--no-cython"
 ```
+
+{{< note title="Note">}}
+The flag `--no-cython` is necessary on MacOS Catalina and further MacOS releases to avoid a failure while building the `yb-cassandra-driver`.
+{{< /note >}}
 
 ## Create a sample Python application
 
@@ -105,12 +109,12 @@ cluster.shutdown()
 To run the application, type the following:
 
 ```sh
-$ python yb-cql-helloworld.py
+$ python3 yb-cql-helloworld.py
 ```
 
 You should see the following output.
 
-```
+```output
 Created keyspace ybdemo
 Created table employee
 Inserted (id, name, age, language) = (1, 'John', 35, 'Python')

--- a/docs/content/v2.4/quick-start/build-apps/python/ycql.md
+++ b/docs/content/v2.4/quick-start/build-apps/python/ycql.md
@@ -46,8 +46,12 @@ showAsideToc: true
 To install the [Yugabyte Python Driver for YCQL](https://github.com/yugabyte/cassandra-python-driver), run the following command:
 
 ```sh
-$ pip install yb-cassandra-driver
+$ pip3 install yb-cassandra-driver --install-option="--no-cython"
 ```
+
+{{< note title="Note">}}
+The flag `--no-cython` is necessary on MacOS Catalina and further MacOS releases to avoid a failure while building the `yb-cassandra-driver`.
+{{< /note >}}
 
 ## Create a sample Python application
 
@@ -104,12 +108,12 @@ cluster.shutdown()
 To run the application, type the following:
 
 ```sh
-$ python yb-cql-helloworld.py
+$ python3 yb-cql-helloworld.py
 ```
 
 You should see the following output.
 
-```
+```output
 Created keyspace ybdemo
 Created table employee
 Inserted (id, name, age, language) = (1, 'John', 35, 'Python')

--- a/docs/content/v2.6/quick-start/build-apps/python/ycql.md
+++ b/docs/content/v2.6/quick-start/build-apps/python/ycql.md
@@ -46,8 +46,12 @@ showAsideToc: true
 To install the [Yugabyte Python Driver for YCQL](https://github.com/yugabyte/cassandra-python-driver), run the following command:
 
 ```sh
-$ pip install yb-cassandra-driver
+$ pip3 install yb-cassandra-driver --install-option="--no-cython"
 ```
+
+{{< note title="Note">}}
+The flag `--no-cython` is necessary on MacOS Catalina and further MacOS releases to avoid a failure while building the `yb-cassandra-driver`.
+{{< /note >}}
 
 ## Create a sample Python application
 
@@ -104,7 +108,7 @@ cluster.shutdown()
 To run the application, type the following:
 
 ```sh
-$ python yb-cql-helloworld.py
+$ python3 yb-cql-helloworld.py
 ```
 
 You should see the following output.


### PR DESCRIPTION
Resolves #5684 

- Updated the commands as per the ticket instructions.
- Also updated the command to run the application from python2 to python3. 
- Changes in latest,stable ,2.6, 2.4,and 2.2.

@netlify /latest/quick-start/build-apps/python/ycql/