### PR TITLE
[Docs] Make headers actual links, but no visual change

### DIFF
--- a/docs/layouts/partials/footer_js.html
+++ b/docs/layouts/partials/footer_js.html
@@ -35,8 +35,13 @@
             }
             settings.headers = settings.isTocNested ? queryHeaders : "h2:visible";
             let headers = $(settings.headers);
-            headers.on("click", function() {
-              window.location.hash = this.id
+            $.each(headers, function (i, value) {
+              let a = document.createElement("a");
+              a.setAttribute("href", "#" + value.id);
+              a.className = "header-link";
+              a.innerHTML = headers[i].innerHTML;
+              headers[i].innerHTML = "";
+              headers[i].appendChild(a);
             }).addClass("clickable-header");
             // remove submenus if TOC is not nested
             if (!settings.isTocNested) {

--- a/docs/styles/_yuga_overrides.scss
+++ b/docs/styles/_yuga_overrides.scss
@@ -30,6 +30,10 @@ dd {
   margin-inline-start: 40px;
 }
 
+.links {
+  display: inline;
+}
+
 .article {
   flex: 1;
   min-width: 0;
@@ -1390,4 +1394,11 @@ table code {
       }
     }
   }
+}
+
+.header-link {
+  text-decoration: inherit !important;
+  border-bottom: inherit !important;
+  color: inherit !important;
+  font-weight: inherit !important;
 }


### PR DESCRIPTION
Resolves #11041

Verified locally that documentation looks fine with `npm start` and
behavior is as expected.