### PR TITLE
[docs] [infra] remove deprecated hugo functions

### DIFF
--- a/docs/layouts/partials/feedback.html
+++ b/docs/layouts/partials/feedback.html
@@ -5,12 +5,12 @@
       <form class="buttons" id="feedbackPositiveForm">
         <input type="hidden" id="action_type" name="action_type" value="docs-feedback-positive">
         <input type="hidden" id="action_payload_from" name="action_payload[from]" value='footer'>
-        <input type="hidden" id="action_payload_feedback_url" name="action_payload[feedback_url]" value='{{ .URL }}'>
+        <input type="hidden" id="action_payload_feedback_url" name="action_payload[feedback_url]" value='{{ .Permalink }}'>
         <button type="submit" class="button_yes small">Yes</button>
         <button class="button_no small">No</button>
       </form>
     </div>
-    
+
   <div class="widget-wrapper">
     {{ partialCached "feedback_widget" . }}
   </div>
@@ -19,13 +19,13 @@
 <script>
     document.addEventListener("DOMContentLoaded", function() {
       "use strict";
-      
+
       const widget = $('.feedback_widget');
       const caption = $('#feedback .survey .caption');
       const buttons = $('#feedback .survey .buttons');
       const widgetwrapper = $('#feedback .widget-wrapper');
       const survey = $('#feedback .survey');
-      
+
 
       $(document).on('feedback:reset', function(e) {
         widgetwrapper.removeClass('active');
@@ -39,13 +39,13 @@
               caption.html('Thanks for your feedback!');
               buttons.fadeOut(300);
               break;
-          
+
             case 'no':
               $(document).trigger('feedback:reset');
               widget.addClass('active');
               widgetwrapper.addClass('active');
               break;
-          
+
             default:
               break;
           }
@@ -55,5 +55,5 @@
         setupRegistrationForm('#feedbackPositiveForm', false);
       }
     });
-  
+
 </script>

--- a/docs/layouts/partials/feedback_widget.html
+++ b/docs/layouts/partials/feedback_widget.html
@@ -1,5 +1,5 @@
 <div class="feedback_widget">
-  
+
   <a class="btn-close"><i class="fas fa-close"></i></a>
   <div class="submit-replace">
     <div class="title">Help us improve our docs</div>
@@ -9,7 +9,7 @@
           <label for="exampleInputEmail1">Email address</label>
           <input type="hidden" id="action_type" name="action_type" value="docs-feedback">
           <input type="hidden" id="action_payload_from" name="action_payload[from]" value='footer'>
-          <input type="hidden" id="action_payload_feedback_url" name="action_payload[feedback_url]" value='{{ .URL }}'>
+          <input type="hidden" id="action_payload_feedback_url" name="action_payload[feedback_url]" value='{{ .Permalink }}'>
           <select class="form-control" id="feedback_subject" name="action_payload[feedback_subject]">
             <option value="Incorrect info">Incorrect info</option>
             <option value="Unclear info">Unclear info</option>
@@ -73,7 +73,7 @@
             case 6:
               textarea.attr("placeholder","I just want to share with you that...");
               break;
-          
+
             default:
               break;
           }
@@ -87,7 +87,7 @@
         if ($('#feedbackForm').length) {
           setupRegistrationForm('#feedbackForm', 'Thanks for your feedback!');
         }
-        
+
       });
-    
+
   </script>

--- a/docs/layouts/partials/nav_version_menu.html
+++ b/docs/layouts/partials/nav_version_menu.html
@@ -5,7 +5,7 @@
     {{ range .menu }}
     {{$.level}} {{.HasChildren}}
         {{ $.context.Scratch.Set "currentMenuEntry" . }}
-        {{ $absoluteLinkUrl := .URL | absURL | printf "%s" }}
+        {{ $absoluteLinkUrl := .Permalink | absURL | printf "%s" }}
         {{ $hasOrIsCurrent := eq $absoluteLinkUrl (substr $.context.Permalink 0 (len $absoluteLinkUrl)) }}
         <li {{ if $hasOrIsCurrent }}class="open"{{ end }}>
           {{ partial "nav_link" $.context }}

--- a/docs/layouts/partials/pagination_url_search.html
+++ b/docs/layouts/partials/pagination_url_search.html
@@ -1,8 +1,8 @@
 {{ with $.context}}
   {{ .Scratch.Set "neededPrevLinkBuffer" false }}
-  {{ $url := .URL }}
+  {{ $url := .Permalink }}
   {{ $level := (cond (isset $ "level") $.level 1) }}
-  {{ $urlLevel := len (split (trim .URL "/") "/") }}
+  {{ $urlLevel := len (split (trim .Permalink "/") "/") }}
   {{ $context := $.context }}
   {{ $iterator := print "neededLinkCurrentIndex" $level }}
   {{ .Scratch.Set $iterator false }}

--- a/docs/layouts/shortcodes/includeMarkdown.html
+++ b/docs/layouts/shortcodes/includeMarkdown.html
@@ -1,3 +1,3 @@
-{{ $includePath := (print .Page.Dir (.Get 0)) | printf "./content/%s" }}
+{{ $includePath := (print .Page.File.Dir (.Get 0)) | printf "./content/%s" }}
 {{ readFile $includePath | markdownify }}
 {{ .Inner | markdownify }}


### PR DESCRIPTION
Hugo 0.92 _completely removes_ two functions we depend on ([release notes](https://github.com/gohugoio/hugo/releases/tag/v0.92.0)). This PR replaces them with supported functions.

1. Verify that `includeMarkdown` is working properly: make sure the PR preview landing page (dcl_alter_role) has its grammar and syntax diagram tabs populated.
2. Verify that the left nav still works (top-level items, and lower-level items).
3. Verify that the version menu still works (remember: it's _supposed_ to dump you at the top level right now; that fix hasn't landed yet!).
4. (Feedback and pagination, we're not using, but theoretically they do work...)

**Note...** We're not actually using the current version of Hugo right now, but I worry that these will trip up people running the build locally. And I'll bump us up to 0.92.1 once that comes out in the next couple of weeks.

@netlify /latest/api/ysql/the-sql-language/statements/dcl_alter_role/