### PR TITLE
[docs] minor duplicate fix on TPC-C benchmark page

### DIFF
--- a/docs/content/latest/benchmark/tpcc-ysql/_index.md
+++ b/docs/content/latest/benchmark/tpcc-ysql/_index.md
@@ -18,9 +18,11 @@ isTocNested: true
 ---
 
 ## Overview
-Follow the steps below to run the [TPC-C workload](https://github.com/yugabyte/tpcc) against YugabyteDB YSQL. [TPC-C](http://www.tpc.org/tpcc/) is a popular online transaction processing benchmark that provides metrics you can use to evaluate the performance of YugabyteDB for concurrent transactions of different types and complexity that are either either executed online or queued for deferred execution.
+
+Follow the steps below to run the [TPC-C workload](https://github.com/yugabyte/tpcc) against YugabyteDB YSQL. [TPC-C](http://www.tpc.org/tpcc/) is a popular online transaction processing benchmark that provides metrics you can use to evaluate the performance of YugabyteDB for concurrent transactions of different types and complexity that are either executed online or queued for deferred execution.
 
 ### Results at a glance (Amazon Web Services)
+
 | Warehouses| TPMC | Efficiency (approx) | Cluster Details
 -------------|-----------|------------|------------|
 10    | 127      | 98.75%   | 3 nodes of type `c5d.large` (2 vCPUs)
@@ -61,7 +63,6 @@ Start your YugabyteDB cluster by following the steps [here](../../deploy/manual-
 {{< tip title="Tip" >}}
 You will need the IP addresses of the nodes in the cluster for the next step.
 {{< /tip>}}
-
 
 ## 2. Configure DB connection params (optional)
 
@@ -121,4 +122,3 @@ Other options like username, password, port, etc. can be changed using the confi
     {{% includeMarkdown "10000-wh/tpcc-ysql.md" /%}}
   </div>
 </div>
-

--- a/docs/content/stable/benchmark/tpcc-ysql/_index.md
+++ b/docs/content/stable/benchmark/tpcc-ysql/_index.md
@@ -15,9 +15,11 @@ isTocNested: true
 ---
 
 ## Overview
-Follow the steps below to run the [TPC-C workload](https://github.com/yugabyte/tpcc) against YugabyteDB YSQL. [TPC-C](http://www.tpc.org/tpcc/) is a popular online transaction processing benchmark that provides metrics you can use to evaluate the performance of YugabyteDB for concurrent transactions of different types and complexity that are either either executed online or queued for deferred execution.
+
+Follow the steps below to run the [TPC-C workload](https://github.com/yugabyte/tpcc) against YugabyteDB YSQL. [TPC-C](http://www.tpc.org/tpcc/) is a popular online transaction processing benchmark that provides metrics you can use to evaluate the performance of YugabyteDB for concurrent transactions of different types and complexity that are either executed online or queued for deferred execution.
 
 ### Results at a glance (Amazon Web Services)
+
 | Warehouses| TPMC | Efficiency (approx) | Cluster Details
 -------------|-----------|------------|------------|
 10    | 127      | 98.75%   | 3 nodes of type `c5d.large` (2 vCPUs)
@@ -58,7 +60,6 @@ Start your YugabyteDB cluster by following the steps [here](../../deploy/manual-
 {{< tip title="Tip" >}}
 You will need the IP addresses of the nodes in the cluster for the next step.
 {{< /tip>}}
-
 
 ## 2. Configure DB connection params (optional)
 
@@ -118,4 +119,3 @@ Other options like username, password, port, etc. can be changed using the confi
     {{% includeMarkdown "10000-wh/tpcc-ysql.md" /%}}
   </div>
 </div>
-

--- a/docs/content/v2.2/benchmark/tpcc-ysql/_index.md
+++ b/docs/content/v2.2/benchmark/tpcc-ysql/_index.md
@@ -16,9 +16,11 @@ isTocNested: true
 ---
 
 ## Overview
-Follow the steps below to run the [TPC-C workload](https://github.com/yugabyte/tpcc) against YugabyteDB YSQL. [TPC-C](http://www.tpc.org/tpcc/) is a popular online transaction processing benchmark that provides metrics you can use to evaluate the performance of YugabyteDB for concurrent transactions of different types and complexity that are either either executed online or queued for deferred execution.
+
+Follow the steps below to run the [TPC-C workload](https://github.com/yugabyte/tpcc) against YugabyteDB YSQL. [TPC-C](http://www.tpc.org/tpcc/) is a popular online transaction processing benchmark that provides metrics you can use to evaluate the performance of YugabyteDB for concurrent transactions of different types and complexity that are either executed online or queued for deferred execution.
 
 ### Results at a glance
+
 | Warehouses| TPMC | Efficiency (approx) | Cluster Details
 -------------|-----------|------------|------------|
 10    | 127      | 98.75%   | 3 nodes of type `c5d.large` (2 vCPUs)
@@ -48,7 +50,6 @@ Start your YugabyteDB cluster by following the steps [here](../../deploy/manual-
 {{< tip title="Tip" >}}
 You will need the IP addresses of the nodes in the cluster for the next step.
 {{< /tip>}}
-
 
 ## 2. Configure DB connection params (optional)
 
@@ -100,4 +101,3 @@ Other options like username, password, port, etc. can be changed using the confi
     {{% includeMarkdown "10000-wh/tpcc-ysql.md" /%}}
   </div>
 </div>
-

--- a/docs/content/v2.4/benchmark/tpcc-ysql/_index.md
+++ b/docs/content/v2.4/benchmark/tpcc-ysql/_index.md
@@ -15,9 +15,11 @@ isTocNested: true
 ---
 
 ## Overview
-Follow the steps below to run the [TPC-C workload](https://github.com/yugabyte/tpcc) against YugabyteDB YSQL. [TPC-C](http://www.tpc.org/tpcc/) is a popular online transaction processing benchmark that provides metrics you can use to evaluate the performance of YugabyteDB for concurrent transactions of different types and complexity that are either either executed online or queued for deferred execution.
+
+Follow the steps below to run the [TPC-C workload](https://github.com/yugabyte/tpcc) against YugabyteDB YSQL. [TPC-C](http://www.tpc.org/tpcc/) is a popular online transaction processing benchmark that provides metrics you can use to evaluate the performance of YugabyteDB for concurrent transactions of different types and complexity that are either executed online or queued for deferred execution.
 
 ### Results at a glance
+
 | Warehouses| TPMC | Efficiency (approx) | Cluster Details
 -------------|-----------|------------|------------|
 10    | 127      | 98.75%   | 3 nodes of type `c5d.large` (2 vCPUs)
@@ -47,7 +49,6 @@ Start your YugabyteDB cluster by following the steps [here](../../deploy/manual-
 {{< tip title="Tip" >}}
 You will need the IP addresses of the nodes in the cluster for the next step.
 {{< /tip>}}
-
 
 ## 2. Configure DB connection params (optional)
 
@@ -99,4 +100,3 @@ Other options like username, password, port, etc. can be changed using the confi
     {{% includeMarkdown "10000-wh/tpcc-ysql.md" /%}}
   </div>
 </div>
-

--- a/docs/content/v2.6/benchmark/tpcc-ysql/_index.md
+++ b/docs/content/v2.6/benchmark/tpcc-ysql/_index.md
@@ -15,9 +15,11 @@ isTocNested: true
 ---
 
 ## Overview
-Follow the steps below to run the [TPC-C workload](https://github.com/yugabyte/tpcc) against YugabyteDB YSQL. [TPC-C](http://www.tpc.org/tpcc/) is a popular online transaction processing benchmark that provides metrics you can use to evaluate the performance of YugabyteDB for concurrent transactions of different types and complexity that are either either executed online or queued for deferred execution.
+
+Follow the steps below to run the [TPC-C workload](https://github.com/yugabyte/tpcc) against YugabyteDB YSQL. [TPC-C](http://www.tpc.org/tpcc/) is a popular online transaction processing benchmark that provides metrics you can use to evaluate the performance of YugabyteDB for concurrent transactions of different types and complexity that are either executed online or queued for deferred execution.
 
 ### Results at a glance
+
 | Warehouses| TPMC | Efficiency (approx) | Cluster Details
 -------------|-----------|------------|------------|
 10    | 127      | 98.75%   | 3 nodes of type `c5d.large` (2 vCPUs)
@@ -47,7 +49,6 @@ Start your YugabyteDB cluster by following the steps [here](../../deploy/manual-
 {{< tip title="Tip" >}}
 You will need the IP addresses of the nodes in the cluster for the next step.
 {{< /tip>}}
-
 
 ## 2. Configure DB connection params (optional)
 
@@ -99,4 +100,3 @@ Other options like username, password, port, etc. can be changed using the confi
     {{% includeMarkdown "10000-wh/tpcc-ysql.md" /%}}
   </div>
 </div>
-


### PR DESCRIPTION
Fixed the duplicate occurrence of 'either' on the TPC-C page for latest, stable, and couple other versions.

@netlify : /latest/benchmark/tpcc-ysql/