### PR TITLE
[docs][cloud]Add overview page for links from cloud UI

### DIFF
--- a/docs/content/latest/yugabyte-cloud/cloud-overview.md
+++ b/docs/content/latest/yugabyte-cloud/cloud-overview.md
@@ -1,0 +1,67 @@
+---
+title: Overview
+linkTitle: Overview
+description: Yugabyte Cloud overview.
+headcontent:
+image: /images/section_icons/index/quick_start.png
+type: page
+section: YUGABYTE CLOUD
+aliases:
+  - /latest/yugabyte-cloud/
+menu:
+  latest:
+    identifier: cloud-overview
+    weight: 14
+isTocNested: true
+showAsideToc: true
+---
+
+Yugabyte Cloud is a fully managed YugabyteDB-as-a-Service that allows you to run YugabyteDB clusters on <a href="https://cloud.google.com/">Google Cloud Platform (GCP)</a> and <a href="https://aws.amazon.com/">Amazon Web Services (AWS)</a> (as of September 2021; Azure coming soon, for information contact [Yugabyte Support](https://support.yugabyte.com/hc/en-us/requests/new?ticket_form_id=360003113431)).
+
+To begin using Yugabyte Cloud, go to [Quick start](cloud-quickstart).
+
+## Cluster basics
+
+Learn about the basics of using YugabyteDB clusters in Yugabyte Cloud.
+
+[Deploy](../cloud-basics/)
+: Create single region clusters that can be deployed across multiple and single availability zones. (To deploy multi-region clusters, contact [Yugabyte Support](https://support.yugabyte.com/hc/en-us/requests/new?ticket_form_id=360003113431).)
+
+[Secure](../cloud-secure-clusters)
+: Manage the security features of your clusters, including network authorization, database authorization, encryption, and auditing.
+: Use IP allow lists to manage access to clusters.
+: Create virtual private cloud (VPC) networks to peer clusters with application VPCs.
+
+[Connect](../cloud-connect)
+: Connect to clusters from a browser using the cloud shell, from your desktop using a shell, and from applications.
+
+[Alerts and monitoring](../cloud-monitor)
+: Monitor cluster performance and get notified of potential problems.
+
+[Manage](../cloud-clusters)
+: Scale vertically and horizontally to match your performance requirements.
+: Back up and restore clusters.
+
+## Cloud basics
+
+Learn about managing your Yugabyte Cloud account.
+
+[Add cloud users](../cloud-admin/manage-access)
+: Invite team members to your cloud.
+
+[Manage billing](../cloud-admin/cloud-billing-profile)
+: Create your billing profile, manage your payment methods, and review invoices.
+
+## Reference
+
+[What's new](../release-notes)
+: See what's new in Yugabyte Cloud, what regions are supported, and known issues.
+
+[Troubleshooting](../cloud-troubleshoot)
+: Get solutions to common problems.
+
+[FAQ](../cloud-faq)
+: Get answers to frequently asked questions.
+
+[Security architecture](../cloud-security)
+: Review Yugabyte Cloud's security architecture and shared responsibility model.

--- a/docs/content/latest/yugabyte-cloud/cloud-quickstart/_index.md
+++ b/docs/content/latest/yugabyte-cloud/cloud-quickstart/_index.md
@@ -7,8 +7,6 @@ image: /images/section_icons/index/quick_start.png
 headcontent: Test YugabyteDB's APIs and core features by creating a free cluster on Yugabyte Cloud.
 type: page
 section: YUGABYTE CLOUD
-aliases:
-  - /latest/yugabyte-cloud/
 menu:
   latest:
     identifier: cloud-quickstart


### PR DESCRIPTION
Reorganization of Docs left nav meant some links to separate topics from the cloud UI were pointing at the same topic (quick start)

@netlify /latest/yugabyte-cloud/cloud-overview/