### PR TITLE
ycql: add RPC metadata to cql protocol

### DIFF
--- a/src/yb/rpc/inbound_call.cc
+++ b/src/yb/rpc/inbound_call.cc
@@ -153,11 +153,13 @@ MonoDelta InboundCall::GetTimeInQueue() const {
   return timing_.time_handled.GetDeltaSince(timing_.time_received);
 }
 
-ThreadPoolTask* InboundCall::BindTask(InboundCallHandler* handler) {
+ThreadPoolTask* InboundCall::BindTask(InboundCallHandler* handler, int64_t rpc_queue_limit) {
   auto shared_this = shared_from(this);
-  if (!handler->CallQueued()) {
+  boost::optional<int64_t> rpc_queue_position = handler->CallQueued(rpc_queue_limit);
+  if (!rpc_queue_position) {
     return nullptr;
   }
+  rpc_queue_position_ = *rpc_queue_position;
   tracker_ = handler;
   task_.Bind(handler, shared_this);
   return &task_;

--- a/src/yb/rpc/service_pool.cc
+++ b/src/yb/rpc/service_pool.cc
@@ -42,6 +42,7 @@
 #include <vector>
 
 #include <boost/asio/strand.hpp>
+#include <boost/optional/optional.hpp>
 #include <cds/container/basket_queue.h>
 #include <cds/gc/dhp.h>
 #include <glog/logging.h>
@@ -386,19 +387,20 @@ class ServicePoolImpl final : public InboundCallHandler {
     return log_prefix_;
   }
 
-  bool CallQueued() override {
+  boost::optional<int64_t> CallQueued(int64_t rpc_queue_limit) override {
     auto queued_calls = queued_calls_.fetch_add(1, std::memory_order_acq_rel);
     if (queued_calls < 0) {
       YB_LOG_EVERY_N_SECS(DFATAL, 5) << "Negative number of queued calls: " << queued_calls;
     }
 
-    if (implicit_cast<size_t>(queued_calls) >= max_queued_calls_) {
+    size_t max_queued_calls = std::min(max_queued_calls_, implicit_cast<size_t>(rpc_queue_limit));
+    if (implicit_cast<size_t>(queued_calls) >= max_queued_calls) {
       queued_calls_.fetch_sub(1, std::memory_order_relaxed);
-      return false;
+      return boost::none;
     }
 
     rpcs_in_queue_->Increment();
-    return true;
+    return queued_calls;
   }
 
   void CallDequeued() override {

--- a/src/yb/yql/cql/cqlserver/cql_processor.cc
+++ b/src/yb/yql/cql/cqlserver/cql_processor.cc
@@ -268,6 +268,7 @@ void CQLProcessor::PrepareAndSendResponse(const unique_ptr<CQLResponse>& respons
     const CQLConnectionContext& context =
         static_cast<const CQLConnectionContext&>(call_->connection()->context());
     response->set_registered_events(context.registered_events());
+    response->set_rpc_queue_position(call_->GetRpcQueuePosition());
     SendResponse(*response);
   }
 }

--- a/src/yb/yql/cql/cqlserver/cql_rpc.cc
+++ b/src/yb/yql/cql/cqlserver/cql_rpc.cc
@@ -359,5 +359,10 @@ CoarseTimePoint CQLInboundCall::GetClientDeadline() const {
   return deadline_;
 }
 
+rpc::ThreadPoolTask* CQLInboundCall::BindTask(rpc::InboundCallHandler* handler) {
+  int64_t rpc_queue_limit = CQLRequest::ParseRpcQueueLimit(serialized_request_);
+  return rpc::InboundCall::BindTask(handler, rpc_queue_limit);
+}
+
 } // namespace cqlserver
 } // namespace yb

--- a/src/yb/yql/cql/cqlserver/cql_rpc.h
+++ b/src/yb/yql/cql/cqlserver/cql_rpc.h
@@ -160,6 +160,8 @@ class CQLInboundCall : public rpc::InboundCall {
     return DynamicMemoryUsageOf(response_msg_buf_);
   }
 
+  rpc::ThreadPoolTask* BindTask(rpc::InboundCallHandler* handler) override;
+
  private:
   RefCntBuffer response_msg_buf_;
   const ql::QLSession::SharedPtr ql_session_;

--- a/src/yb/yql/cql/ql/util/cql_message.h
+++ b/src/yb/yql/cql/ql/util/cql_message.h
@@ -43,6 +43,7 @@
 
 #include "yb/gutil/callback.h"
 #include "yb/gutil/callback_internal.h"
+#include "yb/gutil/casts.h"
 #include "yb/gutil/template_util.h"
 
 #include "yb/rpc/server_event.h"
@@ -96,6 +97,8 @@ class CQLMessage {
   static constexpr Flags kTracingFlag       = 0x02;
   static constexpr Flags kCustomPayloadFlag = 0x04; // Since V4
   static constexpr Flags kWarningFlag       = 0x08; // Since V4
+  // Not specified by CQL protocol - YB custom flag
+  static constexpr Flags kMetadataFlag      = 0x80;
 
   using StreamId = uint16_t;
   static constexpr StreamId kEventStreamId = 0xffff; // Special stream id for events.
@@ -130,6 +133,32 @@ class CQLMessage {
     Header(const Version version, const StreamId stream_id, const Opcode opcode)
        : version(version), flags(0), stream_id(stream_id), opcode(opcode) { }
   };
+
+  // The CQL metadata consists of the first 8 bytes of the request body.
+  // The format of the request metadata is
+  //   0        16        32        48        64
+  //   +---------+---------+---------+---------+
+  //   |           unused            | Q limit |
+  //   +---------+---------+---------+---------+
+  // The format of the response metadata is
+  //   0        16        32        48        64
+  //   +---------+---------+---------+---------+
+  //   |           unused            |  Q pos  |
+  //   +---------+---------+---------+---------+
+  //
+  // The RPC queue limit ("Q limit") is a unsigned 16-bit integer indicating
+  // whether the request should be dropped. If the queue position of the
+  // incoming RPC is greater than the queue limit, then the request gets
+  // dropped immediately and an ERROR_SERVER_TOO_BUSY response is sent back
+  // to the client. If the queue limit is 0, then the request is not dropped
+  // based on the queue position.
+  //
+  // The RPC queue position ("Q pos") is a signed 16-bit integer indicating
+  // the queue position of the corresponding inbound RPC. If for some reason
+  // the queue position could not be determined, then a value of -1 is returned.
+  static constexpr size_t kMetadataSize = 8;
+  static constexpr size_t kMetadataQueueLimitOffset = 6;
+  static constexpr size_t kMetadataQueuePosOffset = 6;
 
   // STARTUP options.
   static constexpr char kCQLVersionOption[] = "CQL_VERSION";
@@ -285,6 +314,8 @@ class CQLRequest : public CQLMessage {
   size_t body_size() const {
     return body_.size();
   }
+
+  static int64_t ParseRpcQueueLimit(const Slice& mesg);
 
   virtual ~CQLRequest();
 
@@ -498,6 +529,10 @@ class CQLResponse : public CQLMessage {
   Events registered_events() const { return registered_events_; }
   void set_registered_events(Events events) { registered_events_ = events; }
 
+  void set_rpc_queue_position(int64_t rpc_queue_position) {
+    rpc_queue_position_ = trim_cast<int16_t>(rpc_queue_position);
+  }
+
  protected:
   CQLResponse(const CQLRequest& request, Opcode opcode);
   CQLResponse(StreamId stream_id, Opcode opcode);
@@ -508,6 +543,7 @@ class CQLResponse : public CQLMessage {
 
  private:
   Events registered_events_ = kNoEvents;
+  int16_t rpc_queue_position_ = -1;
 };
 
 // ------------------------------ Individual CQL responses -----------------------------------


### PR DESCRIPTION
In this phab, we modify the CQL protocol with the metadata flag. If the flag
is set, then the first 8 bytes of the request body are reserved for RPC-related
metadata. Currently, the request will have 2 bytes set to the RPC queue limit,
which is used for load-shedding on the server. Also, the response will have 2
bytes set to the RPC queue position of the request, which is used for adaptive
throttling on the client.