### PR TITLE
[docs] [integrations] fixed link on Janusgraph integrations page

### DIFF
--- a/docs/content/latest/integrations/janusgraph.md
+++ b/docs/content/latest/integrations/janusgraph.md
@@ -113,7 +113,7 @@ gremlin> g = graph.traversal()
 
 ## 5. Graph traversal examples
 
-For reference, here is the graph data loaded by the Graph of the Gods. You can find a lot more useful information about this in the [JanusGraph getting started page](http://docs.janusgraph.org/latest/getting-started.html).
+For reference, here is the graph data loaded by the Graph of the Gods. You can find a lot more useful information about this in the [JanusGraph getting started page](https://docs.janusgraph.org/getting-started/basic-usage/).
 
 ![Graph of the Gods](/images/develop/ecosystem-integrations/janusgraph/graph-of-the-gods-2.png)
 


### PR DESCRIPTION
resolves #11108 
The graph traversal step now points to the right link. 

@netlify /latest/integrations/janusgraph/