### PR TITLE
[docs] [infra] Add spelling exceptions for shell names

### DIFF
--- a/.github/vale-styles/Yugabyte/spelling-exceptions.txt
+++ b/.github/vale-styles/Yugabyte/spelling-exceptions.txt
@@ -469,6 +469,7 @@ proxying
 pseudocode
 pseudonymized
 pseudonymizer
+psql
 Puma
 pytest
 Python
@@ -824,6 +825,8 @@ Worldline
 Xcode
 Xeon
 YouTrack
+ycqlsh
+ysqlsh
 ytt
 Yubico
 Yugabyte


### PR DESCRIPTION
spelling-exceptions.txt additions ysqlsh ycqlsh psql