### PR TITLE
[docs] [#9160] Describe the process for using xCluster replication with TLS

### DIFF
--- a/docs/content/latest/deploy/multi-dc/async-replication.md
+++ b/docs/content/latest/deploy/multi-dc/async-replication.md
@@ -130,19 +130,19 @@ When both universes use different certificates, you need to store the certificat
 
 1. Copy this file to each node on the target. It needs to be copied to a directory named: `<certs_for_cdc_dir>/<source_universe_uuid>`.
 
-  For example, if you previously set `certs_for_cdc_dir=/home/yugabyte/yugabyte_producer_certs`, and the source universe's ID is `00000000-1111-2222-3333-444444444444`, then you would need to copy the cert file to `/home/yugabyte/yugabyte_producer_certs/00000000-1111-2222-3333-444444444444/ca.crt`.
+    For example, if you previously set `certs_for_cdc_dir=/home/yugabyte/yugabyte_producer_certs`, and the source universe's ID is `00000000-1111-2222-3333-444444444444`, then you would need to copy the cert file to `/home/yugabyte/yugabyte_producer_certs/00000000-1111-2222-3333-444444444444/ca.crt`.
 
 1. Finally, set up replication using `yb-admin setup_universe_replication`, making sure to also set the `-certs_dir_name` flag to the directory with the *target universe's* certificates (this should be different from the directory used in the previous steps).
 
-  For example, if you have the target's certificates in `/home/yugabyte/yugabyte-tls-config`, then you would run:
+    For example, if you have the target's certificates in `/home/yugabyte/yugabyte-tls-config`, then you would run:
 
-  ```sh
-  ./bin/yb-admin -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
-    -certs_dir_name /home/yugabyte/yugabyte-tls-config \
-    setup_universe_replication 00000000-1111-2222-3333-444444444444 \
-    127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
-    000030a5000030008000000000004000,000030a5000030008000000000004005,dfef757c415c4b2cacc9315b8acb539a
-  ```
+    ```sh
+    ./bin/yb-admin -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+      -certs_dir_name /home/yugabyte/yugabyte-tls-config \
+      setup_universe_replication 00000000-1111-2222-3333-444444444444 \
+      127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+      000030a5000030008000000000004000,000030a5000030008000000000004005,dfef757c415c4b2cacc9315b8acb539a
+    ```
 
 ## Verifying Replication
 

--- a/docs/content/latest/deploy/multi-dc/async-replication.md
+++ b/docs/content/latest/deploy/multi-dc/async-replication.md
@@ -106,18 +106,43 @@ When completed, proceed to [Verifying Replication](#verifying-replication).
 
 ### Source and Target Universes have the Same Certificates
 
-If both universes use the same certificates, run the same `yb-admin` [`setup_universe_replication`](../../../admin/yb-admin/#setup-universe-replication) command as above, but also include the [`-certs_dir_name`](../../../admin/yb-admin#syntax) flag. Setting that to the target universe's certificate directory will make replication use those certificates for connecting to both universes.
+If both universes use the same certificates, run `yb-admin setup_universe_replication` and include the [`-certs_dir_name`](../../../admin/yb-admin#syntax) flag. Setting that to the target universe's certificate directory will make replication use those certificates for connecting to both universes.
+
+For example:
+
+```sh
+./bin/yb-admin -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+  -certs_dir_name /home/yugabyte/yugabyte-tls-config \
+  setup_universe_replication e260b8b6-e89f-4505-bb8e-b31f74aa29f3 \
+  127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+  000030a5000030008000000000004000,000030a5000030008000000000004005,dfef757c415c4b2cacc9315b8acb539a
+```
 
 ### Source and Target Universes have Different Certificates
 
-When both universes use different certificates, we need to store the certificates for the producer universe on the target universe. Each node on the target universe will have a parent directory (determined by the `certs_for_cdc_dir` gflag), under which there will be sub-directories for each source universe, which each contain their respective source universe's certificates.
+When both universes use different certificates, you need to store the certificates for the producer universe on the target universe:
 
-1. Ensure that `use_node_to_node_encryption` is set to `true` on all nodes (source and target).
-2. For each master and tserver on the target universe, set the gflag `certs_for_cdc_dir` to the parent directory where you will store all the producer certs for replication.
-3. Fetch all of the certificates that the source universe uses.
-4. Copy these certificates to each node on the target. They need to be copied to a directory named: `<certs_for_cdc_dir>/<producer_cluster_id>`.
-  - For example, if we previously set `certs_for_cdc_dir=/home/yugabyte/yugabyte_producer_certs`, and the source universe's id is `00000000-1111-2222-3333-444444444444`, then we would need to save all the source universe's certificates to `/home/yugabyte/yugabyte_producer_certs/00000000-1111-2222-3333-444444444444/*`.
-5. Finally, setup replication using `yb-admin setup_universe_replication`, making sure to also set the `-certs_dir_name` flag to the directory with the *target universe's* certificates (this should be different from the directory used in the previous steps).
+1. Ensure that `use_node_to_node_encryption` is set to `true` on all [masters](../../reference/configuration/yb-master/#use-node-to-node-encryption) and [tservers](../../reference/configuration/yb-tserver/#use-node-to-node-encryption) on both the source and target.
+
+1. For each master and tserver on the target universe, set the gflag `certs_for_cdc_dir` to the parent directory where you will store all the source universe's certs for replication.
+
+1. Find the certificate authority file used by the source universe (`ca.crt`). This should be stored within the [`--certs_dir`](https://docs.yugabyte.com/latest/reference/configuration/yb-master/#certs-dir).
+
+1. Copy this file to each node on the target. It needs to be copied to a directory named: `<certs_for_cdc_dir>/<source_universe_uuid>`.
+
+  For example, if you previously set `certs_for_cdc_dir=/home/yugabyte/yugabyte_producer_certs`, and the source universe's ID is `00000000-1111-2222-3333-444444444444`, then you would need to copy the cert file to `/home/yugabyte/yugabyte_producer_certs/00000000-1111-2222-3333-444444444444/ca.crt`.
+
+1. Finally, set up replication using `yb-admin setup_universe_replication`, making sure to also set the `-certs_dir_name` flag to the directory with the *target universe's* certificates (this should be different from the directory used in the previous steps).
+
+  For example, if you have the target's certificates in `/home/yugabyte/yugabyte-tls-config`, then you would run:
+
+  ```sh
+  ./bin/yb-admin -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    -certs_dir_name /home/yugabyte/yugabyte-tls-config \
+    setup_universe_replication 00000000-1111-2222-3333-444444444444 \
+    127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+    000030a5000030008000000000004000,000030a5000030008000000000004005,dfef757c415c4b2cacc9315b8acb539a
+  ```
 
 ## Verifying Replication
 


### PR DESCRIPTION
Adding section to the xcluster setup docs for how to create xCluster replications setups with TLS (where both universes have either the same certs or different certs)

[Alex edit to add: you can set the entry point for the PR preview by tagging the Netlify bot. It only reads these tags at initial PR creation time and again after any subsequent commits.]

@netlify /latest/deploy/multi-dc/async-replication/