### PR TITLE
[Platform] Updated the azcopy and node-exporter version

### DIFF
--- a/docs/content/latest/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises.md
+++ b/docs/content/latest/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises.md
@@ -373,10 +373,10 @@ Physical nodes (or cloud instances) are installed with a standard Centos 7 serve
 
 ##### Install Prometheus node exporter
 
-For Yugabyte Platform versions 2.8 and later, download the 1.2.2 version of the Prometheus node exporter, as follows:
+For Yugabyte Platform versions 2.8 and later, download the 1.3.1 version of the Prometheus node exporter, as follows:
 
 ```sh
-wget https://github.com/prometheus/node_exporter/releases/download/v1.2.2/node_exporter-1.2.2.linux-amd64.tar.gz
+wget https://github.com/prometheus/node_exporter/releases/download/v1.3.1/node_exporter-1.3.1.linux-amd64.tar.gz
 ```
 
 For Yugabyte Platform versions prior to 2.8, download the 0.13.0 version of the exporter, as follows:
@@ -387,7 +387,7 @@ $ wget https://github.com/prometheus/node_exporter/releases/download/v0.13.0/nod
 
 If you are doing an airgapped installation, download the node exporter using a computer connected to the internet and copy it over to the database nodes.
 
-Note that the instructions are for the 0.13.0 version. The same instructions are applicable to the 1.2.2 version, but you need to use the correct file name.
+Note that the instructions are for the 0.13.0 version. The same instructions are applicable to the 1.3.1 version, but you need to use the correct file name.
 
 On each node, perform the following as a user with sudo access:
 
@@ -487,17 +487,17 @@ Yugabyte Platform supports backing up YugabyteDB to AWS S3, Azure Storage, Googl
 
 **Azure Storage** - Install azcopy using one of the following options:
 
-* Download `azcopy_linux_amd64_10.4.0.tar.gz` using the following command:
+* Download `azcopy_linux_amd64_10.13.0.tar.gz` using the following command:
 
     ```sh
-    $ wget https://azcopyvnext.azureedge.net/release20200410/azcopy_linux_amd64_10.4.0.tar.gz
+    $ wget https://azcopyvnext.azureedge.net/release20200410/azcopy_linux_amd64_10.13.0.tar.gz
     ```
 
-* For airgapped installations, copy `/opt/third-party/azcopy_linux_amd64_10.4.0.tar.gz` from the Yugabyte Platform node, as follows:
+* For airgapped installations, copy `/opt/third-party/azcopy_linux_amd64_10.13.0.tar.gz` from the Yugabyte Platform node, as follows:
 
     ```sh
     $ cd /usr/local
-    $ sudo tar xfz path-to-azcopy_linux_amd64_10.4.0.tar.gz -C /usr/local/bin azcopy_linux_amd64_10.4.0/azcopy --strip-components 1
+    $ sudo tar xfz path-to-azcopy_linux_amd64_10.13.0.tar.gz -C /usr/local/bin azcopy_linux_amd64_10.13.0/azcopy --strip-components 1
     ```
 
 **Google Cloud Storage** - Install gsutil using one of the following options:

--- a/managed/devops/roles/install_backup_util/defaults/main.yml
+++ b/managed/devops/roles/install_backup_util/defaults/main.yml
@@ -10,7 +10,7 @@
 bin_path: "/usr/local/bin"
 
 # azcopy variables
-azcopy_package: "azcopy_linux_amd64_10.4.0.tar.gz"
+azcopy_package: "azcopy_linux_amd64_10.13.0.tar.gz"
 
 # gsutil variables
 gsutil_package_name: "gsutil"

--- a/managed/devops/roles/swamper/meta/main.yml
+++ b/managed/devops/roles/swamper/meta/main.yml
@@ -17,7 +17,7 @@ dependencies:
     become_method: sudo
     prometheus_go_version: 1.7
     prometheus_use_service: true
-    prometheus_node_exporter_version: 1.2.2
+    prometheus_node_exporter_version: 1.3.1
     prometheus_node_exporter_opts: "--web.listen-address=:{{ node_exporter_port }} \
                                     --collector.textfile.directory=/tmp/yugabyte/metrics"
     prometheus_node_exporter_use_systemd: true


### PR DESCRIPTION
### Summary

- Updated the azcopy (10.4.0 to 10.13.0), and node-exporter (1.2.2 to 1.3.1) to newer versions. 

**Note -**
- Changes completed the itest successfully, and there are no breaking changes in these updated versions.

Fixes https://github.com/yugabyte/yugabyte-db/issues/11004