### PR TITLE
[Backport 2.6][Platform] Update azcopy version

### DIFF
--- a/managed/devops/roles/install_backup_util/defaults/main.yml
+++ b/managed/devops/roles/install_backup_util/defaults/main.yml
@@ -10,7 +10,7 @@
 bin_path: "/usr/local/bin"
 
 # azcopy variables
-azcopy_package: "azcopy_linux_amd64_10.4.0.tar.gz"
+azcopy_package: "azcopy_linux_amd64_10.13.0.tar.gz"
 
 # gcloud variables
 gcloud_package_name: "google-cloud-sdk"


### PR DESCRIPTION
Updated the azcopy (10.4.0 to 10.13.0) to newer versions.

The updated versions don't have any breaking changes.

Issue - https://github.com/yugabyte/yugabyte-db/issues/11004