### PR TITLE
[Backport 2.12][Platform] Updated the azcopy and node-exporter version

### DIFF
--- a/managed/devops/roles/install_backup_util/defaults/main.yml
+++ b/managed/devops/roles/install_backup_util/defaults/main.yml
@@ -10,7 +10,7 @@
 bin_path: "/usr/local/bin"
 
 # azcopy variables
-azcopy_package: "azcopy_linux_amd64_10.4.0.tar.gz"
+azcopy_package: "azcopy_linux_amd64_10.13.0.tar.gz"
 
 # gsutil variables
 gsutil_package_name: "gsutil"

--- a/managed/devops/roles/swamper/meta/main.yml
+++ b/managed/devops/roles/swamper/meta/main.yml
@@ -16,7 +16,7 @@ dependencies:
     become_method: sudo
     prometheus_go_version: 1.7
     prometheus_use_service: true
-    prometheus_node_exporter_version: 1.2.2
+    prometheus_node_exporter_version: 1.3.1
     prometheus_node_exporter_opts: "--web.listen-address=:{{ node_exporter_port }} \
                                     --collector.textfile.directory=/tmp/yugabyte/metrics"
     prometheus_node_exporter_use_systemd: true


### PR DESCRIPTION
Updated the azcopy (10.4.0 to 10.13.0), and node-exporter (1.2.2 to 1.3.1) to newer versions.

The updated versions don't have any breaking changes.

Issue - yugabyte#11004