### PR TITLE
[#11541] Add missing xcluster commands to yb-admin reference

### DIFF
--- a/docs/content/latest/admin/yb-admin.md
+++ b/docs/content/latest/admin/yb-admin.md
@@ -1221,6 +1221,10 @@ yb-admin \
 * *comma_separated_list_of_table_ids*: Comma-separated list of table identifiers (`table_id`).
 * *comma_separated_list_of_producer_bootstrap_ids*: Comma-separated list of bootstrap identifiers (`bootstrap_id`). These are obtained from using [`bootstrap_cdc_producer`](#bootstrap-cdc-producer).
 
+{{< note title="Note" >}}
+It is important that the bootstrap_ids are in the same order as their corresponding table_ids!
+{{< /note >}}
+
 {{< note title="Tip" >}}
 
 To display a list of tables and their UUID (`table_id`) values, open the **YB-Master UI** (`<master_host>:7000/`) and click **Tables** in the navigation bar.

--- a/docs/content/latest/admin/yb-admin.md
+++ b/docs/content/latest/admin/yb-admin.md
@@ -1211,13 +1211,15 @@ yb-admin \
     setup_universe_replication \
     <source_universe_uuid> \
     <source_master_addresses> \
-    <comma_separated_list_of_table_ids>
+    <comma_separated_list_of_table_ids> \
+    [comma_separated_list_of_producer_bootstrap_ids]
 ```
 
 * _master-addresses_: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.
 * *source_universe_uuid*: The UUID of the source universe.
 * *source_master_addresses*: Comma-separated list of the source master addresses.
 * *comma_separated_list_of_table_ids*: Comma-separated list of table identifiers (`table_id`).
+* *comma_separated_list_of_producer_bootstrap_ids*: Comma-separated list of bootstrap identifiers (`bootstrap_id`). These are obtained from using [`bootstrap_cdc_producer`](#bootstrap-cdc-producer).
 
 {{< note title="Tip" >}}
 
@@ -1256,26 +1258,40 @@ yb-admin -master_addresses <master-addresses> \
     set_master_addresses <source_master_addresses>
 ```
 
+* _master-addresses_: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.
+* *source_universe_uuid*: The UUID of the source universe.
+* *source_master_addresses*: Comma-separated list of the source master addresses.
+
 Use the `add_table` subcommand to add one or more tables to the existing list:
 
 ```sh
 yb-admin -master_addresses <master-addresses> \
     alter_universe_replication <source_universe_uuid> \
-    add_table <table_id>[, <table_id>...]
+    add_table [comma_separated_list_of_table_ids] \
+    [comma_separated_list_of_producer_bootstrap_ids]
 ```
+
+* _master-addresses_: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.
+* *source_universe_uuid*: The UUID of the source universe.
+* *comma_separated_list_of_table_ids*: Comma-separated list of table identifiers (`table_id`).
+* *comma_separated_list_of_producer_bootstrap_ids*: Comma-separated list of bootstrap identifiers (`bootstrap_id`). These are obtained from using [`bootstrap_cdc_producer`](#bootstrap-cdc-producer).
+
+{{< note title="Note" >}}
+It is important that the bootstrap_ids are in the same order as their corresponding table_ids!
+{{< /note >}}
+
 
 Use the `remove_table` subcommand to remove one or more tables from the existing list:
 
 ```sh
 yb-admin -master_addresses <master-addresses> \
     alter_universe_replication <source_universe_uuid> \
-    remove_table <table_id>[, <table_id>...]
+    remove_table [comma_separated_list_of_table_ids]
 ```
 
 * _master-addresses_: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.
 * _source_universe_uuid_: The UUID of the source universe.
-* _source_master_addresses_: Comma-separated list of the new source master addresses.
-* _table_id_: The identifier (ID) of the table.
+* *comma_separated_list_of_table_ids*: Comma-separated list of table identifiers (`table_id`).
 
 #### delete_universe_replication <source_universe_uuid>
 
@@ -1455,7 +1471,7 @@ The new key ID (`<key_id_2>`) should be different from the previous one (`<key_i
 **Example**
 
 ```sh
-$ ./bin/yb-admin \
+./bin/yb-admin \
     -master_addresses ip1:7100,ip2:7100,ip3:7100 \
     is_encryption_enabled
 ```
@@ -1531,6 +1547,11 @@ yb-admin \
 * *stream_id*: The ID of the CDC stream.
 * `force_delete`: (Optional) Force the delete operation.
 
+{{< note title="Note" >}}
+This command should only be needed for advanced operations, such as doing manual cleanup of old bootstrapped streams that were never fully initialized, or otherwise failed replication streams.
+For normal xcluster replication cleanup, please use [`delete_universe_replication`](#delete-universe-replication).
+{{< /note >}}
+
 #### bootstrap_cdc_producer <comma_separated_list_of_table_ids>
 
 Mark a set of tables in preparation for setting up universe level replication.
@@ -1546,6 +1567,20 @@ yb-admin \
 * _master-addresses_: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.
 * *comma_separated_list_of_table_ids*: Comma-separated list of table identifiers (`table_id`).
 
+**Example**
+```sh
+./bin/yb-admin \
+    -master_addresses 172.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    bootstrap_cdc_producer 000030ad000030008000000000004000
+```
+
+```output
+table id: 000030ad000030008000000000004000, CDC bootstrap id: dd5ea73b5d384b2c9ebd6c7b6d05972c
+```
+
+{{< note title="Note" >}}
+The CDC bootstrap ids are the ones that should be used with [`setup_universe_replication`](#setup-universe-replication) and [`alter_universe_replication`](#alter-universe-replication).
+{{< /note >}}
 
 ---
 

--- a/docs/content/latest/admin/yb-admin.md
+++ b/docs/content/latest/admin/yb-admin.md
@@ -1515,6 +1515,38 @@ yb-admin \
     list_cdc_streams
 ```
 
+#### delete_cdc_stream <stream_id> [force_delete]
+
+Deletes underlying CDC stream for the specified YB-Master servers.
+
+**Syntax**
+
+```sh
+yb-admin \
+    -master_addresses <master-addresses> \
+    delete_cdc_stream <stream_id [force_delete]>
+```
+
+* _master-addresses_: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.
+* *stream_id*: The ID of the CDC stream.
+* `force_delete`: (Optional) Force the delete operation.
+
+#### bootstrap_cdc_producer <comma_separated_list_of_table_ids>
+
+Mark a set of tables in preparation for setting up universe level replication.
+
+**Syntax**
+
+```sh
+yb-admin \
+    -master_addresses <master-addresses> \
+    bootstrap_cdc_producer <comma_separated_list_of_table_ids>
+```
+
+* _master-addresses_: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.
+* *comma_separated_list_of_table_ids*: Comma-separated list of table identifiers (`table_id`).
+
+
 ---
 
 ### Decommissioning commands

--- a/docs/content/latest/architecture/docdb-replication/async-replication.md
+++ b/docs/content/latest/architecture/docdb-replication/async-replication.md
@@ -33,7 +33,7 @@ Asynchronous replication of data works across all the APIs (YSQL, YCQL), since t
 
 ### Active-Passive
 
-The replication could be unidirectional from a source cluster (aka the producer cluster) to one or more sink clusters (aka consumer clusters). The sink clusters are typically located in data centers or regions that are different from the source cluster. They are passive because they do not take writes from the higher layer services. Such deployments are typically used for serving low latency reads from the sink clusters as well as for disaster recovery purposes.
+The replication could be unidirectional from a source cluster (aka the producer cluster) to one sink cluster (aka consumer cluster). The sink clusters are typically located in data centers or regions that are different from the source cluster. They are passive because they do not take writes from the higher layer services. Such deployments are typically used for serving low latency reads from the sink clusters as well as for disaster recovery purposes.
 
 The source-sink deployment architecture is shown in the diagram below:
 


### PR DESCRIPTION
Adding yb-admin references for
- delete_cdc_stream
- bootstrap_cdc_producer