### PR TITLE
[PLAT-3171, PLAT-3169] Use provider KUBECONFIG in NodeUniverseManager

### DIFF
--- a/managed/devops/bin/run_node_action.py
+++ b/managed/devops/bin/run_node_action.py
@@ -13,6 +13,7 @@ ActionHandler = namedtuple('ActionHandler', ['handler', 'parser'])
 def add_k8s_subparser(subparsers, command, parent):
     k8s_parser = subparsers.add_parser(command, help='is k8s universe', parents=[parent])
     k8s_parser.add_argument('--namespace', type=str, help='k8s namespace', required=True)
+    k8s_parser.add_argument('--kubeconfig', type=str, help='k8s kubeconfig', required=True)
     return k8s_parser
 
 

--- a/managed/src/main/java/com/yugabyte/yw/common/NodeUniverseManager.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/NodeUniverseManager.java
@@ -181,10 +181,21 @@ public class NodeUniverseManager extends DevopsBase {
               universe.getUniverseDetails().nodePrefix,
               isMultiAz ? AvailabilityZone.getOrBadRequest(node.azUuid).name : null,
               AvailabilityZone.get(node.azUuid).getUnmaskedConfig());
+      // TODO(bhavin192): this might need an updated when we have
+      // multiple releases in one namespace.
+      String kubeconfig =
+          PlacementInfoUtil.getConfigPerNamespace(
+                  cluster.placementInfo, universe.getUniverseDetails().nodePrefix, provider)
+              .get(namespace);
+      if (kubeconfig == null) {
+        throw new RuntimeException("kubeconfig cannot be null");
+      }
 
       commandArgs.add("k8s");
       commandArgs.add("--namespace");
       commandArgs.add(namespace);
+      commandArgs.add("--kubeconfig");
+      commandArgs.add(kubeconfig);
     } else if (!getNodeDeploymentMode(node, universe).equals(Common.CloudType.unknown)) {
       AccessKey accessKey =
           AccessKey.getOrBadRequest(providerUUID, cluster.userIntent.accessKeyCode);


### PR DESCRIPTION
Currently we don't use kubeconfig given by user at the time of provider creation, this in-turn means that any kubectl commands run by NodeUniverseManager uses in-cluster ServiceAccount credentials. In case of OpenShift the platform pod's ServiceAccount doesn't have permissions to run `kubectl exec` and hence operations like software upgrade fail.

- Changes the run_node_action.py to accept a new kubeconfig flag.
- Addresses the scenario where node_name is pod-hostname_azname (multiaz universes): this fixes issues with operations like software upgrade, download logs etc.

Scenarios tested:

- Created one multi AZ Kubernetes universe, then ran universe upgrade. It worked as expected.
- Download logs works as expected as well.
- Ran same steps on OpenShift where platform's ServiceAccount doesn't have permission to run `kubectl exec`