### PR TITLE
[Backport 2.12][PLAT-3171, PLAT-3169] Use provider KUBECONFIG in NodeUniverseManager

### DIFF
--- a/managed/devops/bin/node_client_utils.py
+++ b/managed/devops/bin/node_client_utils.py
@@ -1,3 +1,4 @@
+import os
 import paramiko
 import subprocess
 
@@ -7,8 +8,11 @@ YB_USERNAME = 'yugabyte'
 class KubernetesClient:
     def __init__(self, args):
         self.namespace = args.namespace
-        self.node_name = args.node_name
+        # MultiAZ deployments have hostname_az in their name.
+        self.node_name = args.node_name.split('_')[0]
         self.is_master = args.is_master
+        self.env_config = os.environ.copy()
+        self.env_config["KUBECONFIG"] = args.kubeconfig
 
     def wrap_command(self, cmd):
         if isinstance(cmd, str):
@@ -18,11 +22,11 @@ class KubernetesClient:
 
     def get_command_output(self, cmd, stdout=None):
         cmd = self.wrap_command(cmd)
-        return subprocess.call(cmd, stdout=stdout)
+        return subprocess.call(cmd, stdout=stdout, env=self.env_config)
 
     def exec_command(self, cmd):
         cmd = self.wrap_command(cmd)
-        return subprocess.check_output(cmd).decode()
+        return subprocess.check_output(cmd, env=self.env_config).decode()
 
 
 class SshParamikoClient:

--- a/managed/devops/bin/run_node_action.py
+++ b/managed/devops/bin/run_node_action.py
@@ -11,6 +11,7 @@ ActionHandler = namedtuple('ActionHandler', ['handler', 'parser'])
 def add_k8s_subparser(subparsers, command, parent):
     k8s_parser = subparsers.add_parser(command, help='is k8s universe', parents=[parent])
     k8s_parser.add_argument('--namespace', type=str, help='k8s namespace', required=True)
+    k8s_parser.add_argument('--kubeconfig', type=str, help='k8s kubeconfig', required=True)
     return k8s_parser
 
 

--- a/managed/src/main/java/com/yugabyte/yw/common/NodeUniverseManager.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/NodeUniverseManager.java
@@ -164,10 +164,21 @@ public class NodeUniverseManager extends DevopsBase {
               universe.getUniverseDetails().nodePrefix,
               isMultiAz ? AvailabilityZone.getOrBadRequest(node.azUuid).name : null,
               AvailabilityZone.get(node.azUuid).getUnmaskedConfig());
+      // TODO(bhavin192): this might need an updated when we have
+      // multiple releases in one namespace.
+      String kubeconfig =
+          PlacementInfoUtil.getConfigPerNamespace(
+                  cluster.placementInfo, universe.getUniverseDetails().nodePrefix, provider)
+              .get(namespace);
+      if (kubeconfig == null) {
+        throw new RuntimeException("kubeconfig cannot be null");
+      }
 
       commandArgs.add("k8s");
       commandArgs.add("--namespace");
       commandArgs.add(namespace);
+      commandArgs.add("--kubeconfig");
+      commandArgs.add(kubeconfig);
     } else if (!getNodeDeploymentMode(node, universe).equals(Common.CloudType.unknown)) {
       AccessKey accessKey =
           AccessKey.getOrBadRequest(providerUUID, cluster.userIntent.accessKeyCode);


### PR DESCRIPTION
Original commit: 0a3c893cf25ef19544d84b2c21d5b156554d342e

Currently we don't use kubeconfig given by user at the time of
provider creation, this in-turn means that any kubectl commands run by
NodeUniverseManager uses in-cluster ServiceAccount credentials. In
case of OpenShift the platform pod's ServiceAccount doesn't have
permissions to run `kubectl exec` and hence operations like software
upgrade fail.

- Changes the run_node_action.py to accept a new kubeconfig flag.
- Addresses the scenario where node_name is
  pod-hostname_azname (multiaz universes): this fixes issues with
  operations like software upgrade, download logs etc.

Scenarios tested:

- Created OpenShift universe where platform's ServiceAccount doesn't
  have permission to run `kubectl exec`
- Then ran universe upgrade. It worked as expected.
- Download logs works as expected as well.
