### PR TITLE
prevent text in tables from overflowing #7839

### DIFF
--- a/www/yb.css
+++ b/www/yb.css
@@ -158,6 +158,13 @@ body {
 
 .table > tbody > tr > td {
   padding: 26px;
+  overflow:hidden;
+  text-overflow:ellipsis;
+}
+
+.table > tbody > tr > th {
+  overflow:hidden;
+  text-overflow:ellipsis;
 }
 
 .yb-dashboard-icon {


### PR DESCRIPTION
This pull request solves issue #7839. It adds css to handle overflow and text-overflow in tableheader and tabledata fields.