### PR TITLE
[Platform][Docs] Bump the azcopy and node-exporter version

### DIFF
--- a/docs/content/v2.8/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises.md
+++ b/docs/content/v2.8/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises.md
@@ -378,10 +378,10 @@ Physical nodes (or cloud instances) are installed with a standard Centos 7 serve
 
 ##### Install Prometheus node exporter
 
-For Yugabyte Platform versions 2.8 and later, download the 1.2.2 version of the Prometheus node exporter:
+For Yugabyte Platform versions 2.8 and later, download the 1.3.1 version of the Prometheus node exporter:
 
 ```sh
-wget https://github.com/prometheus/node_exporter/releases/download/v1.2.2/node_exporter-1.2.2.linux-amd64.tar.gz
+wget https://github.com/prometheus/node_exporter/releases/download/v1.3.1/node_exporter-1.3.1.linux-amd64.tar.gz
 ```
 
 For Yugabyte Platform versions prior to 2.8, download the 0.13.0 version of the exporter:
@@ -392,7 +392,7 @@ $ wget https://github.com/prometheus/node_exporter/releases/download/v0.13.0/nod
 
 If you’re doing an airgapped installation, download the node exporter using a computer connected to the internet and copy it over to the database nodes.
 
-Note that the instructions here are for the 0.13.0 version. The same instructions work with the 1.2.2 version, but make sure to use the right filename.
+Note that the instructions here are for the 0.13.0 version. The same instructions work with the 1.3.1 version, but make sure to use the right filename.
 
 **On each node**, do the following as a user with sudo access:
 
@@ -493,17 +493,17 @@ Platform supports backing up YugabyteDB to AWS S3, Azure Storage, Google Cloud S
 
 **Azure Storage**: Install azcopy. You have two options:
 
-* Download azcopy_linux_amd64_10.4.0.tar.gz using this command:
+* Download azcopy_linux_amd64_10.13.0.tar.gz using this command:
 
     ```sh
-    $ wget https://azcopyvnext.azureedge.net/release20200410/azcopy_linux_amd64_10.4.0.tar.gz
+    $ wget https://azcopyvnext.azureedge.net/release20200410/azcopy_linux_amd64_10.13.0.tar.gz
     ```
 
-* For airgapped installs, copy `/opt/third-party/azcopy_linux_amd64_10.4.0.tar.gz` from the Platform node.
+* For airgapped installs, copy `/opt/third-party/azcopy_linux_amd64_10.13.0.tar.gz` from the Platform node.
 
     ```sh
     $ cd /usr/local
-    $ sudo tar xfz path-to-azcopy_linux_amd64_10.4.0.tar.gz -C /usr/local/bin azcopy_linux_amd64_10.4.0/azcopy --strip-components 1
+    $ sudo tar xfz path-to-azcopy_linux_amd64_10.13.0.tar.gz -C /usr/local/bin azcopy_linux_amd64_10.13.0/azcopy --strip-components 1
     ```
 
 **Google Cloud Storage**: Install gsutil. You have two options:


### PR DESCRIPTION
### Summary

- We have updated the azcopy and node-exporter versions in the docker image, so it'll have new versions whenever we have a new 2.8 release.
- We can merge this PR once the new 2.8 release is available. 

https://github.com/yugabyte/yugabyte-db/issues/11004