### PR TITLE
[docs][OpenShift] Use correct container registry with Helm

### DIFF
--- a/docs/content/latest/yugabyte-platform/install-yugabyte-platform/install-software/openshift.md
+++ b/docs/content/latest/yugabyte-platform/install-yugabyte-platform/install-software/openshift.md
@@ -318,7 +318,7 @@ To create a Yugabyte Platform instance, perform the following:
 
   ```shell
   helm install yw-test yugabytedb/yugaware -n yb-platform \
-     --set image.tag=latest-ubi \
+     --set image.repository=quay.io/yugabyte/yugaware-ubi \
      --set ocpCompatibility.enabled=true --set rbac.create=false --wait
   ```
 

--- a/docs/content/stable/yugabyte-platform/install-yugabyte-platform/install-software/openshift.md
+++ b/docs/content/stable/yugabyte-platform/install-yugabyte-platform/install-software/openshift.md
@@ -318,7 +318,7 @@ To create a Yugabyte Platform instance, perform the following:
 
   ```shell
   helm install yw-test yugabytedb/yugaware -n yb-platform \
-     --set image.tag=latest-ubi \
+     --set image.repository=quay.io/yugabyte/yugaware-ubi \
      --set ocpCompatibility.enabled=true --set rbac.create=false --wait
   ```
 

--- a/docs/content/v2.6/yugabyte-platform/install-yugabyte-platform/install-software/openshift.md
+++ b/docs/content/v2.6/yugabyte-platform/install-yugabyte-platform/install-software/openshift.md
@@ -316,7 +316,7 @@ To create a Yugabyte Platform instance, perform the following:
 
   ```shell
   helm install yw-test yugabytedb/yugaware -n yb-platform \
-     --set image.tag=latest-ubi \
+     --set image.repository=quay.io/yugabyte/yugaware-ubi \
      --set ocpCompatibility.enabled=true --set rbac.create=false --wait
   ```
 

--- a/docs/content/v2.8/yugabyte-platform/install-yugabyte-platform/install-software/openshift.md
+++ b/docs/content/v2.8/yugabyte-platform/install-yugabyte-platform/install-software/openshift.md
@@ -318,7 +318,7 @@ To create a Yugabyte Platform instance, perform the following:
 
   ```shell
   helm install yw-test yugabytedb/yugaware -n yb-platform \
-     --set image.tag=latest-ubi \
+     --set image.repository=quay.io/yugabyte/yugaware-ubi \
      --set ocpCompatibility.enabled=true --set rbac.create=false --wait
   ```
 


### PR DESCRIPTION
All the platform images which are UBI based have been in a separate
container registry since 2.6+, with same tags as of the main yugaware
registry.

Scenarios tested:
- Have been using this command to install platform on OpenShift