### PR TITLE
[Docs] PR for AWS Security group is missing ports

### DIFF
--- a/docs/content/latest/reference/configuration/default-ports.md
+++ b/docs/content/latest/reference/configuration/default-ports.md
@@ -73,7 +73,7 @@ Use the following targets to monitor `yb-tserver` and `yb-master` server metrics
 
 | Server     | Target                      |
 | ---------- | --------------------------- |
-| yb-master  | `<yb-master-address>:7000`  |  
+| yb-master  | `<yb-master-address>:7000`  |
 | yb-tserver | `<yb-tserver-address>:9000` |
 
 ### APIs

--- a/docs/content/latest/reference/configuration/default-ports.md
+++ b/docs/content/latest/reference/configuration/default-ports.md
@@ -36,8 +36,6 @@ Internode (server-to-server or node-to-node) communication is managed using RPC 
 
 To enable login to the machines running these servers, the SSH port 22 should be opened.
 
-If you are installing Yugabyte Platform, you also need to make port 54422 available because the Yugabyte Platform installer reconfigures nodes to use this port as a default SSH port.
-
 ## Admin web server
 
 Admin web server UI can be viewed at the following addresses:
@@ -58,6 +56,9 @@ The following common ports are required for firewall rules:
 | HTTP for Platform (alternate) | 8080 |
 | HTTPS for Platform  | 443 |
 | HTTP for Replicated | 8800 |
+| SSH  **   | 54422 |
+
+** 54422 is a custom SSH port for universe nodes.
 
 ## Prometheus monitoring
 

--- a/docs/content/latest/reference/configuration/default-ports.md
+++ b/docs/content/latest/reference/configuration/default-ports.md
@@ -17,7 +17,7 @@ showAsideToc: true
 
 ## Client APIs
 
-Application clients connect to these addresses.
+Application clients connect to the following addresses:
 
 | API     | Port  | Server | Flag (default)           |
 | ------- | ----- | ------- |------------------------------------------|
@@ -27,18 +27,20 @@ Application clients connect to these addresses.
 
 ## Internode RPC communication
 
-Internode (server-to-server or node-to-node) communication is managed using RPC calls on these addresses.
+Internode (server-to-server or node-to-node) communication is managed using RPC calls on the following addresses:
 
 | Server    | Port | Flag (default)                              |
 | ---------- | ---- | ------------------------------------------------------------ |
 | yb-master  | 7100 |  [`--rpc_bind_addresses 0.0.0.0:7100`](../yb-master/#rpc-bind-addresses) |
 | yb-tserver | 9100 |  [`--rpc_bind_addresses 0.0.0.0:9100`](../yb-tserver/#rpc-bind-addresses)<br/>[`--tserver_master_addrs 0.0.0.0:7100`](../yb-tserver/#tserver-master-addrs)<br/>[`--server_broadcast_addresses 0.0.0.0:9100`](../yb-tserver/#server-broadcast-addresses) |
 
-If you want to log into the machines running these servers, then the ssh port `22` should be opened as well.
+To enable login to the machines running these servers, the SSH port 22 should be opened.
+
+If you are installing Yugabyte Platform, you also need to make port 54422 available because the Yugabyte Platform installer reconfigures nodes to use this port as a default SSH port.
 
 ## Admin web server
 
-Admin web server UI can be viewed at these addresses.
+Admin web server UI can be viewed at the following addresses:
 
 | Server    | Port  | Flag (default)                             |
 | ---------- | ----- | ------------------------------------------------------------ |
@@ -47,7 +49,7 @@ Admin web server UI can be viewed at these addresses.
 
 ## Firewall Rules
 
-Along with the above, include the following common ports in firewall rules. 
+The following common ports are required for firewall rules:
 
 | Service     | Port
 | ------- | ------------------------- |

--- a/docs/content/latest/yugabyte-platform/install-yugabyte-platform/prepare-environment/aws.md
+++ b/docs/content/latest/yugabyte-platform/install-yugabyte-platform/prepare-environment/aws.md
@@ -66,7 +66,7 @@ In order to access Yugabyte Platform from outside the AWS environment, you would
 - Check, manage, and upgrade Yugabyte Platform (port `tcp:8800`).
 - View the Yugabyte Platform UI (port `tcp:80`).
 
-If you are using your own Virtual Private Cloud (VPC) as a self-managed configuration, the following additional TCP ports must be accessible: 7000, 7100, 9000, 9100, 11000, 12000, 13000, 9300, 9042, 5433, 6379. For more information on ports used by YugabyteDB, refer to [Default ports](../../../../reference/configuration/default-ports).
+If you are using your own Virtual Private Cloud (VPC) as a self-managed configuration, the following additional TCP ports must be accessible: 7000, 7100, 9000, 9100, 11000, 12000, 13000, 9300, 9042, 5433, 6379, 54422. For more information on ports used by YugabyteDB, refer to [Default ports](../../../../reference/configuration/default-ports).
 
 To create a security group that enables these, use the Amazon console to navigate to **EC2 > Security Groups**, click **Create Security Group**, and then add the following values:
 
@@ -78,7 +78,7 @@ To create a security group that enables these, use the Amazon console to navigat
 
 - Add the ports 22, 8800, and 80 to the **Port Range** field. The **Protocol** selected must be TCP.
 
-  For a self-managed configuration, also add the 7000, 7100, 9000, 9100, 11000, 12000, 13000, 9300, 9042, 5433, and 6379 TCP ports.
+  For a self-managed configuration, also add the previously listed TCP ports.
 
 You should see a configuration similar to the one shown in the following illustration:
 

--- a/docs/content/latest/yugabyte-platform/install-yugabyte-platform/prepare-environment/gcp.md
+++ b/docs/content/latest/yugabyte-platform/install-yugabyte-platform/prepare-environment/gcp.md
@@ -102,7 +102,7 @@ In order to access Yugabyte Platform from outside the GCP environment, you have 
 - Check, manage, and upgrade Yugabyte Platform (port `tcp:8800`).
 - View the Yugabyte Platform UI (port `tcp:80`).
 
-If you are using your own Virtual Private Cloud (VPC) as a self-managed configuration, the following additional TCP ports must be accessible: 7000, 7100, 9000, 9100, 11000, 12000, 13000, 9300, 9042, 5433, 6379. For more information, see [Default ports](../../../../reference/configuration/default-ports).
+If you are using your own Virtual Private Cloud (VPC) as a self-managed configuration, the following additional TCP ports must be accessible: 7000, 7100, 9000, 9100, 11000, 12000, 13000, 9300, 9042, 5433, 6379, 54422. For more information, see [Default ports](../../../../reference/configuration/default-ports).
 
 Next, you need to create a firewall entry, as follows: 
 

--- a/docs/content/latest/yugabyte-platform/install-yugabyte-platform/prepare-on-prem-nodes.md
+++ b/docs/content/latest/yugabyte-platform/install-yugabyte-platform/prepare-on-prem-nodes.md
@@ -29,14 +29,13 @@ The following ports must be exposed for intra-cluster communication, and you sho
 * 11000 - YEDIS API
 * 12000 - YCQL API
 * 13000 - YSQL API
+* 54422 - Custom SSH
 
 The following ports must be exposed for intra-node communication and be available to your application or any user attempting to connect to the YugabyteDB:
 
 * 5433 - YSQL server
 * 9042 - YCQL server
 * 6379 - YEDIS server
-
-In addition, port 54422 must be available because the Yugabyte Platform installer reconfigures nodes to use this port as a default SSH port. If it is not included in the security group, the installation will fail due to nodes being unreachable.
 
 For more information on ports used by YugabyteDB, refer to [Default ports](../../../reference/configuration/default-ports).
 

--- a/docs/content/latest/yugabyte-platform/install-yugabyte-platform/prepare-on-prem-nodes.md
+++ b/docs/content/latest/yugabyte-platform/install-yugabyte-platform/prepare-on-prem-nodes.md
@@ -1,7 +1,7 @@
 ---
-title: Prepare nodes (on-prem)
+title: Prepare nodes (on-premises)
 headerTitle: Prepare nodes for on-premises deployment
-linkTitle: Prepare nodes (on-prem)
+linkTitle: Prepare nodes (on-premises)
 description: Prepare YugabyteDB nodes for on-premises deployments.
 menu:
   latest:
@@ -12,7 +12,7 @@ isTocNested: false
 showAsideToc: true
 ---
 
-For on-premises deployments of Yugabyte universes, you need to import nodes that can be managed by Yugabyte Platform. This page outlines the steps required to prepare these YugabyteDB nodes for on-premises deployments.
+For on-premises deployments of Yugabyte universes, you need to import nodes that can be managed by Yugabyte Platform.
 
 ## Ports
 
@@ -38,14 +38,14 @@ The following nodes must be available to your application or any user attempting
 
 For more information on ports used by YugabyteDB, refer to [Default ports](../../../reference/configuration/default-ports).
 
-## Preparing nodes
+## Prepare nodes
 
 To prepare nodes for on premises deployment:
 
 1. Ensure that the YugabyteDB nodes conform to the requirements outlined in the [deployment checklist](/latest/deploy/checklist/). This checklist also gives an idea of [recommended instance types across public clouds](/latest/deploy/checklist/#running-on-public-clouds). 
-1. Install the prerequisites and verify the system resource limits as described in [system configuration](/latest/deploy/manual-deployment/system-config).
-1. Ensure you have `ssh` access to the machine and root access (or the ability to run `sudo`; the sudo user can require a password but having passwordless access is desirable for simplicity and ease of use).
-1. Verify that you can `ssh` into this node (from your local machine if the node has a public address).
+1. Install the prerequisites and verify the system resource limits, as described in [system configuration](/latest/deploy/manual-deployment/system-config).
+1. Ensure you have `ssh` access to the server and root access (or the ability to run `sudo`; the sudo user can require a password but having passwordless access is desirable for simplicity and ease of use).
+1. Execute the following command to verify that you can `ssh` into this node (from your local machine if the node has a public address):
 
     ```sh
     $ ssh -i your_private_key.pem ssh_user@node_ip
@@ -53,24 +53,24 @@ To prepare nodes for on premises deployment:
 
 The following actions are performed with sudo access:
 
-* Create the `yugabyte:yugabyte` user + group.
-* Set the home directory to /home/yugabyte.
-* Create the `prometheus:prometheus` user + group.
+* Create the `yugabyte:yugabyte` user and group.
+* Set the home directory to `/home/yugabyte`.
+* Create the `prometheus:prometheus` user and group.
 
   {{< tip title="Tip" >}}
-If you're using the LDAP directory for managing system users, you can pre-provision Yugabyte and Prometheus users: 
+If you are using the LDAP directory for managing system users, you can preprovision Yugabyte and Prometheus users, as follows: 
 
-* The `yugabyte` user should belong to the `yugabyte` group.
+* Ensure that the `yugabyte` user belongs to the `yugabyte` group.
 
-* Set the home directory for the `yugabyte` user (default /home/yugabyte) and ensure the directory is owned by `yugabyte:yugabyte`. The home directory is used during cloud provider configuration.
-    
-* The Prometheus username and the group can be user-defined. You enter the custom user during cloud provider configuration.
+* Set the home directory for the `yugabyte` user (default `/home/yugabyte`) and ensure that the directory is owned by `yugabyte:yugabyte`. The home directory is used during cloud provider configuration.
+  
+* The Prometheus username and the group can be user-defined. You enter the custom user during the cloud provider configuration.
   {{< /tip >}}
 
-* Ensure you can schedule Cron jobs with Crontab. Cron jobs are used for health monitoring, log file rotation, and cleanup of system core files.
+* Ensure that you can schedule Cron jobs with Crontab. Cron jobs are used for health monitoring, log file rotation, and cleanup of system core files.
 
   {{< tip title="Tip" >}}
-For any 3rd party cron scheduling tools, you can disable Crontab and add these cron entries: 
+For any third-party Cron scheduling tools, you can disable Crontab and add the following Cron entries: 
 
 ```sh
 # Ansible: cleanup core files hourly
@@ -83,21 +83,21 @@ For any 3rd party cron scheduling tools, you can disable Crontab and add these c
 */1 * * * * /home/yugabyte/bin/yb-server-ctl.sh tserver cron-check || /home/yugabyte/bin/yb-server-ctl.sh tserver start
 ```
 
-Disabling Crontab creates alerts after the universe is created, but they can be ignored. But you need to ensure cron jobs are set appropriately for the platform to work as expected.
+<br>Disabling Crontab creates alerts after the universe is created, but they can be ignored. You need to ensure Cron jobs are set appropriately for Yugabyte Platform to function as expected.
   {{< /tip >}}
 
 * Verify that Python 2.7 is installed.
-* Enable core dumps and set ulimits.
+* Enable core dumps and set ulimits, as follows:
 
     ```sh
     *       hard        core        unlimited
     *       soft        core        unlimited
     ```
 
-* Configure SSH as follows:
+* Configure SSH, as follows:
 
   * Disable `sshguard`.
-  * Set `UseDNS no` in `/etc/ssh/sshd_config` (disables reverse lookup, which is used for auth; DNS is still useable).
+  * Set `UseDNS no` in `/etc/ssh/sshd_config` (disables reverse lookup, which is used for authentication; DNS is still useable).
 
 * Set `vm.swappiness` to 0.
 * Set `mount` path permissions to 0755.

--- a/docs/content/latest/yugabyte-platform/install-yugabyte-platform/prepare-on-prem-nodes.md
+++ b/docs/content/latest/yugabyte-platform/install-yugabyte-platform/prepare-on-prem-nodes.md
@@ -16,12 +16,12 @@ For on-premises deployments of Yugabyte universes, you need to import nodes that
 
 ## Ports
 
-The following ports must be opened for intra-cluster communication (they do not need to be exposed to your application, only to other nodes in the cluster and the platform node):
+The following ports must be opened for intra-cluster communication (they do not need to be exposed to your application, only to other nodes in the cluster and the Yugabyte Platform node):
 
 * 7100 - Master RPC
 * 9100 - TServer RPC
 
-The following ports must be exposed for intra-cluster communication, and you should additionally expose these ports to administrators or users monitoring the system, as these ports provide valuable diagnostic troubleshooting and metrics:
+The following ports must be exposed for intra-cluster communication, and you should expose these ports to administrators or users monitoring the system, as these ports provide diagnostic troubleshooting and metrics:
 
 * 9300 - Prometheus metrics
 * 7000 - Master HTTP endpoint
@@ -30,11 +30,13 @@ The following ports must be exposed for intra-cluster communication, and you sho
 * 12000 - YCQL API
 * 13000 - YSQL API
 
-The following nodes must be available to your application or any user attempting to connect to the YugabyteDB, in addition to intra-node communication:
+The following ports must be exposed for intra-node communication and be available to your application or any user attempting to connect to the YugabyteDB:
 
 * 5433 - YSQL server
 * 9042 - YCQL server
 * 6379 - YEDIS server
+
+In addition, port 54422 must be available because the Yugabyte Platform installer reconfigures nodes to use this port as a default SSH port. If it is not included in the security group, the installation will fail due to nodes being unreachable.
 
 For more information on ports used by YugabyteDB, refer to [Default ports](../../../reference/configuration/default-ports).
 


### PR DESCRIPTION
@nzaporozhets 

- Could you, please, let me know under which category I should add 54422 in https://docs.yugabyte.com/latest/reference/configuration/default-ports/ and https://docs.yugabyte.com/latest/yugabyte-platform/install-yugabyte-platform/prepare-on-prem-nodes/#ports ?

- Should the firewall rules section for GCP also have port 54422 added? https://docs.yugabyte.com/latest/yugabyte-platform/install-yugabyte-platform/prepare-environment/gcp/#create-a-firewall-rule

