### PR TITLE
Adding a Codemap to our README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,60 +117,6 @@ Here is a list of some of the key features being worked on for the upcoming rele
 
 Review detailed architecture in our [Docs](https://docs.yugabyte.com/latest/architecture/).
 
-# Codemap
-
-The YugabyteDB code is split into two top-level sections:
-
-* [`postgres`](src/postgres/) is our modified fork of the Postgresql code. This is mostly C code.
-
-* [`yb`](src/yb/) is the core of the YugabyteDB storage engine. This is mostly C++ code.
-
-**The core storage engine is split into the following C++ components**:
-
-* [`bfpg`](src/yb/bfpg/) TODO
-
-* [`bfql`](src/yb/bfql/) TODO
-
-* [`cdc`](src/yb/cdc/) is the main code for the Xcluster Replication feature and the CDCSDK, generalized Change Data Capture feature.
-
-* [`client`](src/yb/client/) is the underlying client component used for RPC communication between servers.
-
-* [`common`](src/yb/common/) is code shared across server, client and query components.
-
-* [`consensus`](src/yb/consensus/) is the core Raft consensus implementation.
-
-* [`docdb`](src/yb/docdb/) is the DocDB encoding implementation
-
-* [`encryption`](src/yb/encryption/) is a set of utilities for encryption related work, such as TLS and Encryption at Rest.
-
-* [`fs`](src/yb/fs/) covers the abstractions for manipulating the underlying file systems.
-
-* [`gen_yrpc`](src/yb/gen_yrpc/) covers the abstraction on top of our protobuf usage, for generating server side code.
-
-* [`gutil`](src/yb/gutil/) is for utilities to augment the standard library, from the upstream Chromium project.
-
-* [`integration-tests`](src/yb/integration-tests/) is strictly used for tests which depend on several components in the code.
-
-* [`master`](src/yb/master/) is the control path server side of the database. This is responsible for DDLs, Cluster balancing, health checking, etc.
-
-* [`rocksdb`](src/yb/rocksdb/) is our heavily modified fork of the RocksDB single-node storage library.
-
-* [`rocksutil`](src/yb/rocksutil/) covers utilities for working with RocksDB.
-
-* [`rpc`](src/yb/rpc/) is the underlying RPC layer implementation.
-
-* [`server`](src/yb/server/) cover abstract classes used by both master and tserver processes.
-
-* [`tablet`](src/yb/tablet/) is the main data path IO logic, both for single shard and multi shard transactions.
-
-* [`tools`](src/yb/tools/) contains command line utilities to help debug, inspect or modify state on a live running cluster.
-
-* [`tserver`](src/yb/tserver/) is the data path server side of the database. Responsible internally for managing tablets and externally for communication with master and the Postgres clients.
-
-* [`util`](src/yb/util/) covers utilities used across the entire code base. These range from low level atomic abstractions or memory management primitives, to higher level thread pools, metrics and gflag handling.
-
-* [`yql`](src/yb/yql/) covers query layer abstractions. This contains both server side code for YCQL and YEDIS, as well as the C to C++ transition for our YSQL layer.
-
 # Need Help?
 
 * You can ask questions, find answers, and help others on our Community [Slack](https://communityinviter.com/apps/yugabyte-db/register), [Forum](https://forum.yugabyte.com), [Stack Overflow](https://stackoverflow.com/questions/tagged/yugabyte-db), as well as Twitter [@Yugabyte](https://twitter.com/yugabyte)

--- a/README.md
+++ b/README.md
@@ -117,6 +117,60 @@ Here is a list of some of the key features being worked on for the upcoming rele
 
 Review detailed architecture in our [Docs](https://docs.yugabyte.com/latest/architecture/).
 
+# Codemap
+
+The YugabyteDB code is split into two top-level section:
+* [`postgres`](src/postgres/)
+<br /> Our modified fork of the Postgresql code. This is mostly C code.
+* [`yb`](src/yb/)
+<br /> The core of the YugabyteDB storage engine. This is mostly C++ code.
+
+The core storage engine is then further split into the following C++ components:
+* [`bfpg`](src/yb/bfpg/)
+<br /> TODO
+* [`bfql`](src/yb/bfql/)
+<br /> TODO
+* [`cdc`](src/yb/cdc/)
+<br /> Main code for our Xcluster Replication product and CDCSDK (generalized Change Data Capture product).
+* [`client`](src/yb/client/)
+<br /> Underlying client component used for RPC communication between servers.
+* [`common`](src/yb/common/)
+<br /> Code that is shared across server, client and query components.
+* [`consensus`](src/yb/consensus/)
+<br /> Raft consensus implementation.
+* [`docdb`](src/yb/docdb/)
+<br /> DocDB encoding implementation.
+* [`encryption`](src/yb/encryption/)
+<br /> Utilities for encryption related work, such as TLS and Encryption at Rest.
+* [`fs`](src/yb/fs/)
+<br /> Abstractions for manipulating the underlying file systems.
+* [`gen_yrpc`](src/yb/gen_yrpc/)
+<br /> Abstraction on top of our protobuf usage, for generating server side code.
+* [`gutil`](src/yb/gutil/)
+<br /> Utilities to augment the standard library, from the upstream Chromium project.
+* [`integration-tests`](src/yb/integration-tests/)
+<br /> Strictly used for tests which depend on several components in the code.
+* [`master`](src/yb/master/)
+<br /> Control path server side of the database. This is responsible for DDLs, Cluster balancing, health checking, etc.
+* [`rocksdb`](src/yb/rocksdb/)
+<br /> Heavily modified fork of the RocksDB single-node storage library.
+* [`rocksutil`](src/yb/rocksutil/)
+<br /> Utilities for working with RocksDB.
+* [`rpc`](src/yb/rpc/)
+<br /> Underlying RPC layer implementation.
+* [`server`](src/yb/server/)
+<br /> Abstract classes used by both master and tserver processes.
+* [`tablet`](src/yb/tablet/)
+<br /> Main data path IO logic, both for single shard and multi shard transactions.
+* [`tools`](src/yb/tools/)
+<br /> Command line utilities to help debug, inspect or modify state on a live running cluster.
+* [`tserver`](src/yb/tserver/)
+<br /> Data path server side of the database. Responsible internally for managing tablets and externally for communication with master and the Postgres clients.
+* [`util`](src/yb/util/)
+<br /> Utilities used across the entire code base. These range from low level atomic abstractions or memory management primitives, to higher level thread pools, metrics and gflag handling.
+* [`yql`](src/yb/yql/)
+<br /> Query layer abstractions. This contains both server side code for YCQL and YEDIS, as well as the C to C++ transition for our YSQL layer.
+
 # Need Help?
 
 * You can ask questions, find answers, and help others on our Community [Slack](https://communityinviter.com/apps/yugabyte-db/register), [Forum](https://forum.yugabyte.com), [Stack Overflow](https://stackoverflow.com/questions/tagged/yugabyte-db), as well as Twitter [@Yugabyte](https://twitter.com/yugabyte)

--- a/README.md
+++ b/README.md
@@ -119,57 +119,57 @@ Review detailed architecture in our [Docs](https://docs.yugabyte.com/latest/arch
 
 # Codemap
 
-The YugabyteDB code is split into two top-level section:
-* [`postgres`](src/postgres/)
-<br /> Our modified fork of the Postgresql code. This is mostly C code.
-* [`yb`](src/yb/)
-<br /> The core of the YugabyteDB storage engine. This is mostly C++ code.
+The YugabyteDB code is split into two top-level sections:
 
-The core storage engine is then further split into the following C++ components:
-* [`bfpg`](src/yb/bfpg/)
-<br /> TODO
-* [`bfql`](src/yb/bfql/)
-<br /> TODO
-* [`cdc`](src/yb/cdc/)
-<br /> Main code for our Xcluster Replication product and CDCSDK (generalized Change Data Capture product).
-* [`client`](src/yb/client/)
-<br /> Underlying client component used for RPC communication between servers.
-* [`common`](src/yb/common/)
-<br /> Code that is shared across server, client and query components.
-* [`consensus`](src/yb/consensus/)
-<br /> Raft consensus implementation.
-* [`docdb`](src/yb/docdb/)
-<br /> DocDB encoding implementation.
-* [`encryption`](src/yb/encryption/)
-<br /> Utilities for encryption related work, such as TLS and Encryption at Rest.
-* [`fs`](src/yb/fs/)
-<br /> Abstractions for manipulating the underlying file systems.
-* [`gen_yrpc`](src/yb/gen_yrpc/)
-<br /> Abstraction on top of our protobuf usage, for generating server side code.
-* [`gutil`](src/yb/gutil/)
-<br /> Utilities to augment the standard library, from the upstream Chromium project.
-* [`integration-tests`](src/yb/integration-tests/)
-<br /> Strictly used for tests which depend on several components in the code.
-* [`master`](src/yb/master/)
-<br /> Control path server side of the database. This is responsible for DDLs, Cluster balancing, health checking, etc.
-* [`rocksdb`](src/yb/rocksdb/)
-<br /> Heavily modified fork of the RocksDB single-node storage library.
-* [`rocksutil`](src/yb/rocksutil/)
-<br /> Utilities for working with RocksDB.
-* [`rpc`](src/yb/rpc/)
-<br /> Underlying RPC layer implementation.
-* [`server`](src/yb/server/)
-<br /> Abstract classes used by both master and tserver processes.
-* [`tablet`](src/yb/tablet/)
-<br /> Main data path IO logic, both for single shard and multi shard transactions.
-* [`tools`](src/yb/tools/)
-<br /> Command line utilities to help debug, inspect or modify state on a live running cluster.
-* [`tserver`](src/yb/tserver/)
-<br /> Data path server side of the database. Responsible internally for managing tablets and externally for communication with master and the Postgres clients.
-* [`util`](src/yb/util/)
-<br /> Utilities used across the entire code base. These range from low level atomic abstractions or memory management primitives, to higher level thread pools, metrics and gflag handling.
-* [`yql`](src/yb/yql/)
-<br /> Query layer abstractions. This contains both server side code for YCQL and YEDIS, as well as the C to C++ transition for our YSQL layer.
+* [`postgres`](src/postgres/) is our modified fork of the Postgresql code. This is mostly C code.
+
+* [`yb`](src/yb/) is the core of the YugabyteDB storage engine. This is mostly C++ code.
+
+**The core storage engine is split into the following C++ components**:
+
+* [`bfpg`](src/yb/bfpg/) TODO
+
+* [`bfql`](src/yb/bfql/) TODO
+
+* [`cdc`](src/yb/cdc/) is the main code for the Xcluster Replication feature and the CDCSDK, generalized Change Data Capture feature.
+
+* [`client`](src/yb/client/) is the underlying client component used for RPC communication between servers.
+
+* [`common`](src/yb/common/) is code shared across server, client and query components.
+
+* [`consensus`](src/yb/consensus/) is the core Raft consensus implementation.
+
+* [`docdb`](src/yb/docdb/) is the DocDB encoding implementation
+
+* [`encryption`](src/yb/encryption/) is a set of utilities for encryption related work, such as TLS and Encryption at Rest.
+
+* [`fs`](src/yb/fs/) covers the abstractions for manipulating the underlying file systems.
+
+* [`gen_yrpc`](src/yb/gen_yrpc/) covers the abstraction on top of our protobuf usage, for generating server side code.
+
+* [`gutil`](src/yb/gutil/) is for utilities to augment the standard library, from the upstream Chromium project.
+
+* [`integration-tests`](src/yb/integration-tests/) is strictly used for tests which depend on several components in the code.
+
+* [`master`](src/yb/master/) is the control path server side of the database. This is responsible for DDLs, Cluster balancing, health checking, etc.
+
+* [`rocksdb`](src/yb/rocksdb/) is our heavily modified fork of the RocksDB single-node storage library.
+
+* [`rocksutil`](src/yb/rocksutil/) covers utilities for working with RocksDB.
+
+* [`rpc`](src/yb/rpc/) is the underlying RPC layer implementation.
+
+* [`server`](src/yb/server/) cover abstract classes used by both master and tserver processes.
+
+* [`tablet`](src/yb/tablet/) is the main data path IO logic, both for single shard and multi shard transactions.
+
+* [`tools`](src/yb/tools/) contains command line utilities to help debug, inspect or modify state on a live running cluster.
+
+* [`tserver`](src/yb/tserver/) is the data path server side of the database. Responsible internally for managing tablets and externally for communication with master and the Postgres clients.
+
+* [`util`](src/yb/util/) covers utilities used across the entire code base. These range from low level atomic abstractions or memory management primitives, to higher level thread pools, metrics and gflag handling.
+
+* [`yql`](src/yb/yql/) covers query layer abstractions. This contains both server side code for YCQL and YEDIS, as well as the C to C++ transition for our YSQL layer.
 
 # Need Help?
 

--- a/src/README.md
+++ b/src/README.md
@@ -8,9 +8,9 @@ The YugabyteDB code is split into two top-level sections:
 
 **The core storage engine is split into the following C++ components**:
 
-* [`bfpg`](yb/bfpg/) TODO
+* [`bfpg`](yb/bfpg/) covers Builtin Functions for Postgres. This directory is now DEPRECATED, in favor of the respective code in [`postgres`](postgres/).
 
-* [`bfql`](yb/bfql/) TODO
+* [`bfql`](yb/bfql/) covers Builtin Functions for YCQL.
 
 * [`cdc`](yb/cdc/) is the main code for the Xcluster Replication feature and the CDCSDK, generalized Change Data Capture feature.
 
@@ -20,7 +20,7 @@ The YugabyteDB code is split into two top-level sections:
 
 * [`consensus`](yb/consensus/) is the core Raft consensus implementation.
 
-* [`docdb`](yb/docdb/) is the DocDB encoding implementation
+* [`docdb`](yb/docdb/) is the DocDB encoding implementation.
 
 * [`encryption`](yb/encryption/) is a set of utilities for encryption related work, such as TLS and Encryption at Rest.
 

--- a/src/README.md
+++ b/src/README.md
@@ -2,52 +2,52 @@
 
 The YugabyteDB code is split into two top-level sections:
 
-* [`postgres`](src/postgres/) is our modified fork of the Postgresql code. This is mostly C code.
+* [`postgres`](postgres/) is our modified fork of the Postgresql code. This is mostly C code.
 
-* [`yb`](src/yb/) is the core of the YugabyteDB storage engine. This is mostly C++ code.
+* [`yb`](yb/) is the core of the YugabyteDB storage engine. This is mostly C++ code.
 
 **The core storage engine is split into the following C++ components**:
 
-* [`bfpg`](src/yb/bfpg/) TODO
+* [`yql`](yb/bfpg/) TODO
 
-* [`bfql`](src/yb/bfql/) TODO
+* [`bfql`](yb/bfql/) TODO
 
-* [`cdc`](src/yb/cdc/) is the main code for the Xcluster Replication feature and the CDCSDK, generalized Change Data Capture feature.
+* [`cdc`](yb/cdc/) is the main code for the Xcluster Replication feature and the CDCSDK, generalized Change Data Capture feature.
 
-* [`client`](src/yb/client/) is the underlying client component used for RPC communication between servers.
+* [`client`](yb/client/) is the underlying client component used for RPC communication between servers.
 
-* [`common`](src/yb/common/) is code shared across server, client and query components.
+* [`common`](yb/common/) is code shared across server, client and query components.
 
-* [`consensus`](src/yb/consensus/) is the core Raft consensus implementation.
+* [`consensus`](yb/consensus/) is the core Raft consensus implementation.
 
-* [`docdb`](src/yb/docdb/) is the DocDB encoding implementation
+* [`docdb`](yb/docdb/) is the DocDB encoding implementation
 
-* [`encryption`](src/yb/encryption/) is a set of utilities for encryption related work, such as TLS and Encryption at Rest.
+* [`encryption`](yb/encryption/) is a set of utilities for encryption related work, such as TLS and Encryption at Rest.
 
-* [`fs`](src/yb/fs/) covers the abstractions for manipulating the underlying file systems.
+* [`fs`](yb/fs/) covers the abstractions for manipulating the underlying file systems.
 
-* [`gen_yrpc`](src/yb/gen_yrpc/) covers the abstraction on top of our protobuf usage, for generating server side code.
+* [`gen_yrpc`](yb/gen_yrpc/) covers the abstraction on top of our protobuf usage, for generating server side code.
 
-* [`gutil`](src/yb/gutil/) is for utilities to augment the standard library, from the upstream Chromium project.
+* [`gutil`](yb/gutil/) is for utilities to augment the standard library, from the upstream Chromium project.
 
-* [`integration-tests`](src/yb/integration-tests/) is strictly used for tests which depend on several components in the code.
+* [`integration-tests`](yb/integration-tests/) is strictly used for tests which depend on several components in the code.
 
-* [`master`](src/yb/master/) is the control path server side of the database. This is responsible for DDLs, Cluster balancing, health checking, etc.
+* [`master`](yb/master/) is the control path server side of the database. This is responsible for DDLs, Cluster balancing, health checking, etc.
 
-* [`rocksdb`](src/yb/rocksdb/) is our heavily modified fork of the RocksDB single-node storage library.
+* [`rocksdb`](yb/rocksdb/) is our heavily modified fork of the RocksDB single-node storage library.
 
-* [`rocksutil`](src/yb/rocksutil/) covers utilities for working with RocksDB.
+* [`rocksutil`](yb/rocksutil/) covers utilities for working with RocksDB.
 
-* [`rpc`](src/yb/rpc/) is the underlying RPC layer implementation.
+* [`rpc`](yb/rpc/) is the underlying RPC layer implementation.
 
-* [`server`](src/yb/server/) cover abstract classes used by both master and tserver processes.
+* [`server`](yb/server/) cover abstract classes used by both master and tserver processes.
 
-* [`tablet`](src/yb/tablet/) is the main data path IO logic, both for single shard and multi shard transactions.
+* [`tablet`](yb/tablet/) is the main data path IO logic, both for single shard and multi shard transactions.
 
-* [`tools`](src/yb/tools/) contains command line utilities to help debug, inspect or modify state on a live running cluster.
+* [`tools`](yb/tools/) contains command line utilities to help debug, inspect or modify state on a live running cluster.
 
-* [`tserver`](src/yb/tserver/) is the data path server side of the database. Responsible internally for managing tablets and externally for communication with master and the Postgres clients.
+* [`tserver`](yb/tserver/) is the data path server side of the database. Responsible internally for managing tablets and externally for communication with master and the Postgres clients.
 
-* [`util`](src/yb/util/) covers utilities used across the entire code base. These range from low level atomic abstractions or memory management primitives, to higher level thread pools, metrics and gflag handling.
+* [`util`](yb/util/) covers utilities used across the entire code base. These range from low level atomic abstractions or memory management primitives, to higher level thread pools, metrics and gflag handling.
 
-* [`yql`](src/yb/yql/) covers query layer abstractions. This contains both server side code for YCQL and YEDIS, as well as the C to C++ transition for our YSQL layer.
+* [`yql`](yb/yql/) covers query layer abstractions. This contains both server side code for YCQL and YEDIS, as well as the C to C++ transition for our YSQL layer.

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,53 @@
+# Codemap
+
+The YugabyteDB code is split into two top-level sections:
+
+* [`postgres`](src/postgres/) is our modified fork of the Postgresql code. This is mostly C code.
+
+* [`yb`](src/yb/) is the core of the YugabyteDB storage engine. This is mostly C++ code.
+
+**The core storage engine is split into the following C++ components**:
+
+* [`bfpg`](src/yb/bfpg/) TODO
+
+* [`bfql`](src/yb/bfql/) TODO
+
+* [`cdc`](src/yb/cdc/) is the main code for the Xcluster Replication feature and the CDCSDK, generalized Change Data Capture feature.
+
+* [`client`](src/yb/client/) is the underlying client component used for RPC communication between servers.
+
+* [`common`](src/yb/common/) is code shared across server, client and query components.
+
+* [`consensus`](src/yb/consensus/) is the core Raft consensus implementation.
+
+* [`docdb`](src/yb/docdb/) is the DocDB encoding implementation
+
+* [`encryption`](src/yb/encryption/) is a set of utilities for encryption related work, such as TLS and Encryption at Rest.
+
+* [`fs`](src/yb/fs/) covers the abstractions for manipulating the underlying file systems.
+
+* [`gen_yrpc`](src/yb/gen_yrpc/) covers the abstraction on top of our protobuf usage, for generating server side code.
+
+* [`gutil`](src/yb/gutil/) is for utilities to augment the standard library, from the upstream Chromium project.
+
+* [`integration-tests`](src/yb/integration-tests/) is strictly used for tests which depend on several components in the code.
+
+* [`master`](src/yb/master/) is the control path server side of the database. This is responsible for DDLs, Cluster balancing, health checking, etc.
+
+* [`rocksdb`](src/yb/rocksdb/) is our heavily modified fork of the RocksDB single-node storage library.
+
+* [`rocksutil`](src/yb/rocksutil/) covers utilities for working with RocksDB.
+
+* [`rpc`](src/yb/rpc/) is the underlying RPC layer implementation.
+
+* [`server`](src/yb/server/) cover abstract classes used by both master and tserver processes.
+
+* [`tablet`](src/yb/tablet/) is the main data path IO logic, both for single shard and multi shard transactions.
+
+* [`tools`](src/yb/tools/) contains command line utilities to help debug, inspect or modify state on a live running cluster.
+
+* [`tserver`](src/yb/tserver/) is the data path server side of the database. Responsible internally for managing tablets and externally for communication with master and the Postgres clients.
+
+* [`util`](src/yb/util/) covers utilities used across the entire code base. These range from low level atomic abstractions or memory management primitives, to higher level thread pools, metrics and gflag handling.
+
+* [`yql`](src/yb/yql/) covers query layer abstractions. This contains both server side code for YCQL and YEDIS, as well as the C to C++ transition for our YSQL layer.

--- a/src/README.md
+++ b/src/README.md
@@ -8,7 +8,7 @@ The YugabyteDB code is split into two top-level sections:
 
 **The core storage engine is split into the following C++ components**:
 
-* [`yql`](yb/bfpg/) TODO
+* [`bfpg`](yb/bfpg/) TODO
 
 * [`bfql`](yb/bfql/) TODO
 


### PR DESCRIPTION
Adding a Codemap section to describe the top-level source code directories better for onboarding new engineers.