### PR TITLE
[docs] update some server-side redirects

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -47,6 +47,7 @@
 [[redirects]]
   from = "/latest/*"
   to = "/preview/:splat"
+  force = true
 
 # Redirect old cloud docs to root of current
 

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -42,7 +42,21 @@
   to = "/preview/"
   force = true
 
+# Catch-all for old links to /latest (now called /preview)
+
+[[redirects]]
+  from = "/latest/*"
+  to = "/preview/:splat"
+
+# Redirect old cloud docs to root of current
+
+[[redirects]]
+  from = "/:version/yugabyte-cloud/*"
+  to = "/preview/yugabyte-cloud/"
+  force = true
+
 # Redirect EOL docs to the archive site
+# (And note that v1.0-1.2 don't exist)
 
 [[redirects]]
   from = "/v1.0/*"
@@ -61,22 +75,22 @@
 
 [[redirects]]
   from = "/v1.3/*"
-  to = "https://docs-archive.yugabyte.com/"
+  to = "https://docs-archive.yugabyte.com/v1.3/"
   force = true
 
 [[redirects]]
   from = "/v2.0/*"
-  to = "https://docs-archive.yugabyte.com/"
+  to = "https://docs-archive.yugabyte.com/v2.0/"
   force = true
 
 [[redirects]]
   from = "/v2.1/*"
-  to = "https://docs-archive.yugabyte.com/"
+  to = "https://docs-archive.yugabyte.com/v2.1/"
   force = true
 
 [[redirects]]
   from = "/v2.2/*"
-  to = "https://docs-archive.yugabyte.com/"
+  to = "https://docs-archive.yugabyte.com/v2.2/"
   force = true
 
 # Redirect older versions of specific sections
@@ -132,11 +146,6 @@
   to = "/preview/yedis/"
   force = true
 
-[[redirects]]
-  from = "/:version/yugabyte-cloud/*"
-  to = "/preview/yugabyte-cloud/"
-  force = true
-
 # Stable quick-starts need defaults,
 # since archiving from /preview removes aliases
 
@@ -161,12 +170,6 @@
   from = "/preview/api/ysql/extensions/"
   to = "/preview/explore/ysql-language-features/pg-extensions/"
   force = true
-
-# Catch-all for old links to /latest (now called /preview)
-
-[[redirects]]
-  from = "/latest/*"
-  to = "/preview/:splat"
 
 # Hugo resource caching plugin configuration
 # https://github.com/cdeleeuwe/netlify-plugin-hugo-cache-resources#readme


### PR DESCRIPTION
Adjusting some redirects...

The PR preview link should land you on the same page under /preview by way of two redirects. Verify with `curl -I` to see what the chain is...

@netlify /latest/yugabyte-cloud/cloud-secure-clusters/add-connections/
