### PR TITLE
WaitForServer.java error message

### DIFF
--- a/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/subtasks/WaitForServer.java
+++ b/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/subtasks/WaitForServer.java
@@ -55,7 +55,7 @@ public class WaitForServer extends ServerSubTaskBase {
       closeClient(client);
     }
     if (!ret) {
-      throw new RuntimeException(getName() + " did not respond to pings in the set time.");
+      throw new RuntimeException(getName() + " did not respond in the set time.");
     }
     log.info(
         "Server {} responded to RPC calls in {} ms",


### PR DESCRIPTION
#9133 changed the connectivity test from icmp to /dev/tcp, but the error message still refers to ping.  Removing the ping reference avoids the erroneous debugging step of enabling icmp when another protocol is actually required.