### PR TITLE
[docs] Add documentation for yb-ts-cli reload_certificates

### DIFF
--- a/docs/content/preview/admin/yb-ts-cli.md
+++ b/docs/content/preview/admin/yb-ts-cli.md
@@ -49,6 +49,7 @@ The following commands are available:
 * [flush_all_tablets](#flush-all-tablets)
 * [flush_tablet](#flush-tablet)
 * [list_tablets](#list-tablets)
+* [reload_certificates](#reload-certificates)
 * [set_flag](#set-flag)
 * [status](#status)
 
@@ -189,6 +190,18 @@ yb-ts-cli [ --server_address=<host>:<port> ] list_tablets
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
+
+##### reload_certificates
+
+Trigger a reload of TLS certificates and private keys from disk on the specified (master or tablet) server.
+
+**Syntax**
+
+```sh
+yb-ts-cli [ --server_address=<host>:<port> ] reload_certificates
+```
+
+* *host*:*port*: The *host* and *port* of the master or tablet server. Default is `localhost:9100`.
 
 ##### set_flag
 


### PR DESCRIPTION
Added documentation for the yb-ts-cli reload_certificates command added in https://github.com/yugabyte/yugabyte-db/commit/73a3ca42ed0dfe7fa71de6f86777e18f5b4d7ab7 (https://github.com/yugabyte/yugabyte-db/issues/11531).

Resolves #12334.