### PR TITLE
Add note to cloud shell quickstart page about case sensitivity

### DIFF
--- a/docs/content/preview/secure/authorization/create-roles-ycql.md
+++ b/docs/content/preview/secure/authorization/create-roles-ycql.md
@@ -36,6 +36,12 @@ Roles in YCQL can represent individual users or a group of users. Users are a ro
 
 You manage roles and users using the CREATE ROLE, GRANT ROLE, REVOKE ROLE, and DROP ROLE statements.
 
+{{< note title="YCQL and case sensitivity" >}}
+
+Like SQL, YCQL is case-insensitive by default. When specifying an identifier, such as the name of a table or role, YCQL automatically converts the identifier to lowercase. For example, `CREATE ROLE Alice` creates the role "alice". To use a case-sensitive name for an identifier, enclose the name in quotes. For example, to create the role "Alice", use `CREATE ROLE "Alice"`.
+
+{{< /note >}}
+
 ## Create roles
 
 You can create roles with the [CREATE ROLE](../../../api/ycql/ddl_create_role/) command.

--- a/docs/content/preview/secure/authorization/create-roles-ycql.md
+++ b/docs/content/preview/secure/authorization/create-roles-ycql.md
@@ -38,7 +38,7 @@ You manage roles and users using the CREATE ROLE, GRANT ROLE, REVOKE ROLE, and D
 
 {{< note title="YCQL and case sensitivity" >}}
 
-Like SQL, YCQL is case-insensitive by default. When specifying an identifier, such as the name of a table or role, YCQL automatically converts the identifier to lowercase. For example, `CREATE ROLE Alice` creates the role "alice". To use a case-sensitive name for an identifier, enclose the name in quotes. For example, to create the role "Alice", use `CREATE ROLE "Alice"`.
+Like CQL, YCQL is case-insensitive by default. When specifying an identifier, such as the name of a table or role, YCQL automatically converts the identifier to lowercase. For example, `CREATE ROLE Alice` creates the role "alice". To use a case-sensitive name for an identifier, enclose the name in quotes. For example, to create the role "Alice", use `CREATE ROLE "Alice"`.
 
 {{< /note >}}
 

--- a/docs/content/preview/secure/authorization/create-roles.md
+++ b/docs/content/preview/secure/authorization/create-roles.md
@@ -35,6 +35,12 @@ Roles in YSQL can represent individual users or a group of users. Users are a ro
 
 You manage roles and users using the CREATE ROLE, GRANT, REVOKE, and DROP ROLE statements.
 
+{{< note title="YSQL and case sensitivity" >}}
+
+Like SQL, YSQL is case-insensitive by default. When specifying an identifier, such as the name of a table or role, YSQL automatically converts the identifier to lowercase. For example, `CREATE ROLE Alice` creates the role "alice". To use a case-sensitive name for an identifier, enclose the name in quotes. For example, to create the role "Alice", use `CREATE ROLE "Alice"`.
+
+{{< /note >}}
+
 ## Create roles
 
 You can create roles with the [CREATE ROLE](../../../api/ysql/the-sql-language/statements/dcl_create_role/) statement.

--- a/docs/content/preview/yugabyte-cloud/cloud-secure-clusters/add-users.md
+++ b/docs/content/preview/yugabyte-cloud/cloud-secure-clusters/add-users.md
@@ -46,6 +46,12 @@ Add database users as follows:
 1. Authorize their network so that they can access the cluster. Refer to [Assign IP allow lists](../../cloud-secure-clusters/add-connections/).
 1. Send them the credentials.
 
+{{< note title="Database users and case sensitivity" >}}
+
+Like SQL, both YSQL and YCQL are case-insensitive by default. When specifying an identifier, such as the name of a table or role, YSQL/YCQL automatically converts the identifier to lowercase. For example, `CREATE ROLE Alice` creates the role "alice". To use a case-sensitive name for an identifier, enclose the name in quotes. For example, to create the role "Alice", use `CREATE ROLE "Alice"`.
+
+{{< /note >}}
+
 #### YSQL
 
 To add a database user in YSQL, use the CREATE ROLE statement as follows:

--- a/docs/content/preview/yugabyte-cloud/cloud-secure-clusters/add-users.md
+++ b/docs/content/preview/yugabyte-cloud/cloud-secure-clusters/add-users.md
@@ -48,7 +48,7 @@ Add database users as follows:
 
 {{< note title="Database users and case sensitivity" >}}
 
-Like SQL, both YSQL and YCQL are case-insensitive by default. When specifying an identifier, such as the name of a table or role, YSQL/YCQL automatically converts the identifier to lowercase. For example, `CREATE ROLE Alice` creates the role "alice". To use a case-sensitive name for an identifier, enclose the name in quotes. For example, to create the role "Alice", use `CREATE ROLE "Alice"`.
+Like SQL and CQL, both YSQL and YCQL are case-insensitive by default. When specifying an identifier, such as the name of a table or role, YSQL and YCQL automatically convert the identifier to lowercase. For example, `CREATE ROLE Alice` creates the role "alice". To use a case-sensitive name for an identifier, enclose the name in quotes. For example, to create the role "Alice", use `CREATE ROLE "Alice"`.
 
 {{< /note >}}
 


### PR DESCRIPTION
Internal testers have noted that SQL's standard practice of converting to lower case was surprising and might trip up users. This change adds a note in the quickstart page about this potential pitfall.

What are your thoughts on moving this `Note` into the YSQL reference page? https://docs.yugabyte.com/preview/api/ysql/the-sql-language/statements/dcl_create_role/