### PR TITLE
[Docs] Removed documentation for hidden/unsafe email logging gflags

### DIFF
--- a/docs/content/preview/reference/configuration/yb-master.md
+++ b/docs/content/preview/reference/configuration/yb-master.md
@@ -176,12 +176,6 @@ Default: `true`
 
 ### Logging flags
 
-##### --alsologtoemail
-
-Sends log messages to these email addresses in addition to logfiles.
-
-Default: `""`
-
 ##### --colorlogtostderr
 
 Color messages logged to `stderr` (if supported by terminal).
@@ -201,20 +195,6 @@ Default: `0`
 Buffer log messages for at most this many seconds.
 
 Default: `30`
-
-##### --logemaillevel
-
-Email log messages logged at this level, or higher.
-
-Values: `0` (all); `1` (WARN), `2` (ERROR), `3` (FATAL), `999` (none)
-
-Default: `999`
-
-##### --logmailer
-
-The mailer used to send logging email messages.
-
-Default: `"/bin/mail"
 
 ##### --logtostderr
 

--- a/docs/content/preview/reference/configuration/yb-tserver.md
+++ b/docs/content/preview/reference/configuration/yb-tserver.md
@@ -187,18 +187,6 @@ The directory to write `yb-tserver` log files.
 
 Default: Same as [`--fs_data_dirs`](#fs-data-dirs)
 
-##### --logemaillevel
-
-Email log messages logged at this level, or higher. Values: `0` (all), 1, 2, `3` (FATAL), `999` (none)
-
-Default: `999`
-
-##### --logmailer
-
-The mailer used to send logging email messages.
-
-Default: `"/bin/mail"`
-
 ##### --logtostderr
 
 Write log messages to `stderr` instead of `logfiles`.

--- a/docs/content/stable/reference/configuration/yb-master.md
+++ b/docs/content/stable/reference/configuration/yb-master.md
@@ -167,12 +167,6 @@ Default: `true`
 
 ### Logging flags
 
-##### --alsologtoemail
-
-Sends log messages to these email addresses in addition to logfiles.
-
-Default: `""`
-
 ##### --colorlogtostderr
 
 Color messages logged to `stderr` (if supported by terminal).
@@ -192,20 +186,6 @@ Default: `0`
 Buffer log messages for at most this many seconds.
 
 Default: `30`
-
-##### --logemaillevel
-
-Email log messages logged at this level, or higher.
-
-Values: `0` (all); `1` (WARN), `2` (ERROR), `3` (FATAL), `999` (none)
-
-Default: `999`
-
-##### --logmailer
-
-The mailer used to send logging email messages.
-
-Default: `"/bin/mail"
 
 ##### --logtostderr
 

--- a/docs/content/stable/reference/configuration/yb-tserver.md
+++ b/docs/content/stable/reference/configuration/yb-tserver.md
@@ -184,18 +184,6 @@ The directory to write `yb-tserver` log files.
 
 Default: Same as [`--fs_data_dirs`](#fs-data-dirs)
 
-##### --logemaillevel
-
-Email log messages logged at this level, or higher. Values: `0` (all), 1, 2, `3` (FATAL), `999` (none)
-
-Default: `999`
-
-##### --logmailer
-
-The mailer used to send logging email messages.
-
-Default: `"/bin/mail"`
-
 ##### --logtostderr
 
 Write log messages to `stderr` instead of `logfiles`.

--- a/docs/content/v2.4/reference/configuration/yb-master.md
+++ b/docs/content/v2.4/reference/configuration/yb-master.md
@@ -167,12 +167,6 @@ Default: `true`
 
 ### Logging flags
 
-##### --alsologtoemail
-
-Sends log messages to these email addresses in addition to logfiles.
-
-Default: `""`
-
 ##### --colorlogtostderr
 
 Color messages logged to `stderr` (if supported by terminal).
@@ -192,20 +186,6 @@ Default: `0`
 Buffer log messages for at most this many seconds.
 
 Default: `30`
-
-##### --logemaillevel
-
-Email log messages logged at this level, or higher. 
-
-Values: `0` (all); `1` (WARN), `2` (ERROR), `3` (FATAL), `999` (none)
-
-Default: `999`
-
-##### --logmailer
-
-The mailer used to send logging email messages.
-
-Default: `"/bin/mail"
 
 ##### --logtostderr
 

--- a/docs/content/v2.4/reference/configuration/yb-tserver.md
+++ b/docs/content/v2.4/reference/configuration/yb-tserver.md
@@ -184,18 +184,6 @@ The directory to write `yb-tserver` log files.
 
 Default: Same as [`--fs_data_dirs`](#fs-data-dirs)
 
-##### --logemaillevel
-
-Email log messages logged at this level, or higher. Values: `0` (all), 1, 2, `3` (FATAL), `999` (none)
-
-Default: `999`
-
-##### --logmailer
-
-The mailer used to send logging email messages.
-
-Default: `"/bin/mail"`
-
 ##### --logtostderr
 
 Write log messages to `stderr` instead of `logfiles`.

--- a/docs/content/v2.6/reference/configuration/yb-master.md
+++ b/docs/content/v2.6/reference/configuration/yb-master.md
@@ -167,12 +167,6 @@ Default: `true`
 
 ### Logging flags
 
-##### --alsologtoemail
-
-Sends log messages to these email addresses in addition to logfiles.
-
-Default: `""`
-
 ##### --colorlogtostderr
 
 Color messages logged to `stderr` (if supported by terminal).
@@ -192,20 +186,6 @@ Default: `0`
 Buffer log messages for at most this many seconds.
 
 Default: `30`
-
-##### --logemaillevel
-
-Email log messages logged at this level, or higher.
-
-Values: `0` (all); `1` (WARN), `2` (ERROR), `3` (FATAL), `999` (none)
-
-Default: `999`
-
-##### --logmailer
-
-The mailer used to send logging email messages.
-
-Default: `"/bin/mail"
 
 ##### --logtostderr
 

--- a/docs/content/v2.6/reference/configuration/yb-tserver.md
+++ b/docs/content/v2.6/reference/configuration/yb-tserver.md
@@ -184,18 +184,6 @@ The directory to write `yb-tserver` log files.
 
 Default: Same as [`--fs_data_dirs`](#fs-data-dirs)
 
-##### --logemaillevel
-
-Email log messages logged at this level, or higher. Values: `0` (all), 1, 2, `3` (FATAL), `999` (none)
-
-Default: `999`
-
-##### --logmailer
-
-The mailer used to send logging email messages.
-
-Default: `"/bin/mail"`
-
 ##### --logtostderr
 
 Write log messages to `stderr` instead of `logfiles`.

--- a/docs/content/v2.8/reference/configuration/yb-master.md
+++ b/docs/content/v2.8/reference/configuration/yb-master.md
@@ -167,12 +167,6 @@ Default: `true`
 
 ### Logging flags
 
-##### --alsologtoemail
-
-Sends log messages to these email addresses in addition to logfiles.
-
-Default: `""`
-
 ##### --colorlogtostderr
 
 Color messages logged to `stderr` (if supported by terminal).
@@ -192,20 +186,6 @@ Default: `0`
 Buffer log messages for at most this many seconds.
 
 Default: `30`
-
-##### --logemaillevel
-
-Email log messages logged at this level, or higher.
-
-Values: `0` (all); `1` (WARN), `2` (ERROR), `3` (FATAL), `999` (none)
-
-Default: `999`
-
-##### --logmailer
-
-The mailer used to send logging email messages.
-
-Default: `"/bin/mail"
 
 ##### --logtostderr
 

--- a/docs/content/v2.8/reference/configuration/yb-tserver.md
+++ b/docs/content/v2.8/reference/configuration/yb-tserver.md
@@ -184,18 +184,6 @@ The directory to write `yb-tserver` log files.
 
 Default: Same as [`--fs_data_dirs`](#fs-data-dirs)
 
-##### --logemaillevel
-
-Email log messages logged at this level, or higher. Values: `0` (all), 1, 2, `3` (FATAL), `999` (none)
-
-Default: `999`
-
-##### --logmailer
-
-The mailer used to send logging email messages.
-
-Default: `"/bin/mail"`
-
 ##### --logtostderr
 
 Write log messages to `stderr` instead of `logfiles`.


### PR DESCRIPTION
Context: #11930 

Removing documentation for three gflags: logemaillevel, alsologtoemail, logmailer.

All three of these gflags have always been marked as "hidden" and logemail/alsologtoemail have always also been marked as "unsafe" - indicating that these gflags are meant for internal use only and should have always been excluded from user-facing documentation. These markings have been present since even before the v1.2 release.