### PR TITLE
[docs] Fix logo link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://www.yugabyte.com/wp-content/uploads/2021/05/yb_horizontal_alt_color_RGB.png" align="center" alt="YugabyteDB" width="50%"/>
+<img src="https://www.yugabyte.com/wp-content/themes/yugabyte/assets/images/yugabyteDB-site-logo-new-blue.svg" align="center" alt="YugabyteDB" width="50%"/>
 
 ---------------------------------------
 


### PR DESCRIPTION
Link to logo in top README.md has been broken since at least May 17.
Point to a new, working link mentioned by Alex Ball.  This new image is
an SVG, so it has better quality compared to the previous raster image.