### PR TITLE
[docs][cloud] yb_db_admin role

### DIFF
--- a/docs/content/preview/secure/authorization/rbac-model.md
+++ b/docs/content/preview/secure/authorization/rbac-model.md
@@ -67,7 +67,7 @@ The following table describes the default YSQL roles and users in YugabyteDB clu
 | :--- | :---------- |
 | postgres | Superuser role created during database creation. |
 | yb_extension | Role that allows non-superuser users to create PostgreSQL extensions. |
-| yb_fdw | Role that allows non-superuser users to [CREATE](https://www.postgresql.org/docs/11/sql-createforeigndatawrapper.html), [ALTER](https://www.postgresql.org/docs/11/sql-alterforeigndatawrapper.html), and [DROP](https://www.postgresql.org/docs/11/sql-dropforeigndatawrapper.html) the [Foreign data wrapper](https://www.postgresql.org/docs/12/ddl-foreign-data.html)(beta feature). |
+| yb_fdw | Role that allows non-superuser users to [CREATE](../../../api/ysql/the-sql-language/statements/ddl_create_foreign_data_wrapper/), [ALTER](../../../api/ysql/the-sql-language/statements/ddl_alter_foreign_data_wrapper/), and [DROP](../../../api/ysql/the-sql-language/statements/ddl_drop_foreign_data_wrapper/) [foreign data wrappers](../../../explore/ysql-language-features/foreign-data-wrappers/). |
 | yugabyte | Superuser role used during database creation, by Yugabyte support to perform maintenance operations, and for backups (using ysql_dump). |
 
 ### yb_extension

--- a/docs/content/preview/yugabyte-cloud/cloud-secure-clusters/cloud-users.md
+++ b/docs/content/preview/yugabyte-cloud/cloud-secure-clusters/cloud-users.md
@@ -44,10 +44,11 @@ The following table describes the default YSQL roles and users in YugabyteDB Man
 
 | Role | Description |
 | --- | --- |
-| [admin](#admin-and-yb-superuser) | The default user for your cluster. If you added your own credentials during cluster creation, the user name will be the one you entered. Although not a superuser, this role is a member of yb_superuser, and you can use it to perform database operations, create other yb_superuser users, create extensions, and manage your cluster. |
+| [admin](#admin-and-yb-superuser) | The default user for your cluster. If you added your own credentials during cluster creation, the user name will be the one you provided. Although not a superuser, this role is a member of yb_superuser, and you can use it to perform database operations, create other yb_superuser users, create extensions, and manage your cluster. |
 | postgres | Superuser role created during database creation. Not available to YugabyteDB Managed users. |
 | [yb_db_admin](#yb-db-admin) | Role that allows non-superuser users to create tablespaces and perform other privileged operations. |
 | [yb_extension](#yb-extension) | Role that allows non-superuser users to create PostgreSQL extensions. |
+| yb_fdw | Role that allows non-superuser users to [CREATE](../../../api/ysql/the-sql-language/statements/ddl_create_foreign_data_wrapper/), [ALTER](../../../api/ysql/the-sql-language/statements/ddl_alter_foreign_data_wrapper/), and [DROP](../../../api/ysql/the-sql-language/statements/ddl_drop_foreign_data_wrapper/) [foreign data wrappers](../../../explore/ysql-language-features/foreign-data-wrappers/). |
 | [yb_superuser](#admin-and-yb-superuser) | YugabyteDB Managed only role. This role is assigned to the default cluster user (that is, admin) to perform all the required operations on the database, including creating other yb_superuser users. For security reasons, yb_superuser doesn't have YugabyteDB superuser privileges. |
 | yugabyte | Superuser role used during database creation, by Yugabyte support to perform maintenance operations, and for backups (ysql_dumps). Not available to YugabyteDB Managed users. |
 

--- a/docs/content/preview/yugabyte-cloud/cloud-secure-clusters/cloud-users.md
+++ b/docs/content/preview/yugabyte-cloud/cloud-secure-clusters/cloud-users.md
@@ -46,7 +46,7 @@ The following table describes the default YSQL roles and users in YugabyteDB Man
 | --- | --- |
 | [admin](#admin-and-yb-superuser) | The default user for your cluster. If you added your own credentials during cluster creation, the user name will be the one you entered. Although not a superuser, this role is a member of yb_superuser, and you can use it to perform database operations, create other yb_superuser users, create extensions, and manage your cluster. |
 | postgres | Superuser role created during database creation. Not available to YugabyteDB Managed users. |
-| yb_db_admin | Role that allows non-superuser users to create tablespaces and perform other privileged operations. |
+| [yb_db_admin](#yb-db-admin) | Role that allows non-superuser users to create tablespaces and perform other privileged operations. |
 | [yb_extension](#yb-extension) | Role that allows non-superuser users to create PostgreSQL extensions. |
 | [yb_superuser](#admin-and-yb-superuser) | YugabyteDB Managed only role. This role is assigned to the default cluster user (that is, admin) to perform all the required operations on the database, including creating other yb_superuser users. For security reasons, yb_superuser doesn't have YugabyteDB superuser privileges. |
 | yugabyte | Superuser role used during database creation, by Yugabyte support to perform maintenance operations, and for backups (ysql_dumps). Not available to YugabyteDB Managed users. |

--- a/docs/content/preview/yugabyte-cloud/cloud-secure-clusters/cloud-users.md
+++ b/docs/content/preview/yugabyte-cloud/cloud-secure-clusters/cloud-users.md
@@ -66,7 +66,7 @@ Although not a superuser, `yb_superuser` includes sufficient privileges to perfo
 
 ### yb_db_admin
 
-The `yb_db_admin` role is specific to YugabyteDB Managed clusters and allows non-superuser roles to perform a number of privileged operations in a manner similar to a superuser, such as performing operations on objects it does not own. A user granted this role can only alter the BYPASSRLS attribute of a role.
+The `yb_db_admin` role is specific to YugabyteDB Managed clusters and allows non-superuser roles to perform a number of privileged operations in a manner similar to a superuser, such as performing operations on objects it does not own.
 
 `yb_superuser` and, by extension, the default admin user, is a member of `yb_db_admin`.
 

--- a/docs/content/preview/yugabyte-cloud/cloud-secure-clusters/cloud-users.md
+++ b/docs/content/preview/yugabyte-cloud/cloud-secure-clusters/cloud-users.md
@@ -63,6 +63,18 @@ Although not a superuser, `yb_superuser` includes sufficient privileges to perfo
 
 `yb_superuser` is the highest privileged role you have access to in YugabyteDB Managed. You can't delete, change the passwords, or login using the `postgres` or `yugabyte` superuser roles.
 
+### yb_db_admin
+
+The `yb_db_admin` role is specific to YugabyteDB Managed clusters and allows non-superuser roles to perform a number of privileged operations. A user granted this role can do the following:
+
+- alter and drop schemas it does not own
+- alter and drop tables it does not own
+- alter and drop indexes it does not own
+- create tablespaces on tables and indexes it does not own, and drop tablespaces it does not own
+- alter roles it does not own
+
+`yb_superuser` and, by extension, the default admin user, is a member of `yb_db_admin`.
+
 ### yb_extension
 
 The `yb_extension` role allows non-superuser roles to [create extensions](../../cloud-clusters/add-extensions/). A user granted this role can create all the extensions that are bundled in YugabyteDB. `yb_superuser` and, by extension, the default admin user, is a member of `yb_extension`.

--- a/docs/content/preview/yugabyte-cloud/cloud-secure-clusters/cloud-users.md
+++ b/docs/content/preview/yugabyte-cloud/cloud-secure-clusters/cloud-users.md
@@ -66,13 +66,7 @@ Although not a superuser, `yb_superuser` includes sufficient privileges to perfo
 
 ### yb_db_admin
 
-The `yb_db_admin` role is specific to YugabyteDB Managed clusters and allows non-superuser roles to perform a number of privileged operations. A user granted this role can do the following:
-
-- alter and drop schemas it does not own
-- alter and drop tables it does not own
-- alter and drop indexes it does not own
-- create tablespaces on tables and indexes it does not own, and drop tablespaces it does not own
-- alter roles it does not own
+The `yb_db_admin` role is specific to YugabyteDB Managed clusters and allows non-superuser roles to perform a number of privileged operations in a manner similar to a superuser, such as performing operations on objects it does not own. A user granted this role can only alter the BYPASSRLS attribute of a role.
 
 `yb_superuser` and, by extension, the default admin user, is a member of `yb_db_admin`.
 

--- a/docs/content/preview/yugabyte-cloud/cloud-secure-clusters/cloud-users.md
+++ b/docs/content/preview/yugabyte-cloud/cloud-secure-clusters/cloud-users.md
@@ -28,11 +28,13 @@ yugabyte=> \du
 ```output
                                                          List of roles
   Role name   |                         Attributes                         |                     Member of
---------------+------------------------------------------------------------+----------------------------------------------------
+--------------+------------------------------------------------------------+---------------------------------------------------------------
  admin        | Create role, Create DB, Bypass RLS                         | {yb_superuser}
  postgres     | Superuser, Create role, Create DB, Replication, Bypass RLS | {}
+ yb_db_admin  | No inheritance, Cannot login                               | {}
  yb_extension | Cannot login                                               | {}
- yb_superuser | Create role, Create DB, Cannot login, Bypass RLS           | {pg_read_all_stats,pg_signal_backend,yb_extension}
+ yb_fdw       | Cannot login                                               | {}
+ yb_superuser | Create role, Create DB, Cannot login, Bypass RLS           | {pg_read_all_stats,pg_signal_backend,yb_extension,yb_db_admin}
  yugabyte     | Superuser, Create role, Create DB, Replication, Bypass RLS | {}
 ```
 
@@ -44,6 +46,7 @@ The following table describes the default YSQL roles and users in YugabyteDB Man
 | --- | --- |
 | [admin](#admin-and-yb-superuser) | The default user for your cluster. If you added your own credentials during cluster creation, the user name will be the one you entered. Although not a superuser, this role is a member of yb_superuser, and you can use it to perform database operations, create other yb_superuser users, create extensions, and manage your cluster. |
 | postgres | Superuser role created during database creation. Not available to YugabyteDB Managed users. |
+| yb_db_admin | Role that allows non-superuser users to create tablespaces and perform other privileged operations. |
 | [yb_extension](#yb-extension) | Role that allows non-superuser users to create PostgreSQL extensions. |
 | [yb_superuser](#admin-and-yb-superuser) | YugabyteDB Managed only role. This role is assigned to the default cluster user (that is, admin) to perform all the required operations on the database, including creating other yb_superuser users. For security reasons, yb_superuser doesn't have YugabyteDB superuser privileges. |
 | yugabyte | Superuser role used during database creation, by Yugabyte support to perform maintenance operations, and for backups (ysql_dumps). Not available to YugabyteDB Managed users. |
@@ -56,7 +59,7 @@ Although not a superuser, `yb_superuser` includes sufficient privileges to perfo
 
 - Has the following role options: `INHERIT`, `CREATEROLE`, `CREATEDB`, and `BYPASSRLS`.
 
-- Member of the following roles: `pg_read_all_stats`, `pg_signal_backend`, and [yb_extension](#yb-extension).
+- Member of the following roles: `pg_read_all_stats`, `pg_signal_backend`, `yb_db_admin`, and [yb_extension](#yb-extension).
 
 `yb_superuser` is the highest privileged role you have access to in YugabyteDB Managed. You can't delete, change the passwords, or login using the `postgres` or `yugabyte` superuser roles.
 


### PR DESCRIPTION
Details on the yb_db_admin role used to grant yb_superusers aome superuser abilities

@netlify /preview/yugabyte-cloud/cloud-secure-clusters/cloud-users/#yb-db-admin