### PR TITLE
[Docs] remove reference to docker swarm which is practically not used anymore - from preview and stable

### DIFF
--- a/docs/content/preview/deploy/docker/docker-compose.md
+++ b/docs/content/preview/deploy/docker/docker-compose.md
@@ -24,12 +24,6 @@ showAsideToc: true
       Docker Compose
     </a>
   </li>
-  <li >
-    <a href="{{< relref "./docker-swarm.md" >}}" class="nav-link">
-      <i class="fas fa-layer-group"></i>
-      Docker Swarm
-    </a>
-  </li>
 </ul>
 
 Use [docker-compose](https://docs.docker.com/compose/overview/) utility to create and manage YugabyteDB local clusters. Note that this approach is not recommended for multi-node clusters used for performance testing and production environments. Refer to the [deployment checklist](../../../deploy/checklist/) to understand the configuration to create clusters.

--- a/docs/content/stable/deploy/docker/docker-compose.md
+++ b/docs/content/stable/deploy/docker/docker-compose.md
@@ -21,12 +21,6 @@ showAsideToc: true
       Docker Compose
     </a>
   </li>
-  <li >
-    <a href="{{< relref "./docker-swarm.md" >}}" class="nav-link">
-      <i class="fas fa-layer-group"></i>
-      Docker Swarm
-    </a>
-  </li>
 </ul>
 
 Use [docker-compose](https://docs.docker.com/compose/overview/) utility to create and manage YugabyteDB local clusters. Note that this approach is not recommended for multi-node clusters used for performance testing and production environments. Refer to the [deployment checklist](../../../deploy/checklist/) to understand the configuration to create clusters.


### PR DESCRIPTION
Files changed both under stable and latest versions - just to remove the reference of docker swarm as an option to install .