### PR TITLE
[docs] fix broken shortcode end tags

### DIFF
--- a/docs/content/preview/api/ysql/exprs/aggregate_functions/invocation-syntax-semantics.md
+++ b/docs/content/preview/api/ysql/exprs/aggregate_functions/invocation-syntax-semantics.md
@@ -35,10 +35,10 @@ The following six diagrams, [`select_start`](../../../syntax_resources/grammar_d
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.diagram.md" %}}
   </div>
 </div>
 These rules govern the invocation of aggregate functions as `SELECT` list items.
@@ -66,10 +66,10 @@ When aggregate functions are invoked using the syntax specified by either the `o
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.diagram.md" %}}
   </div>
 </div>
 
@@ -92,10 +92,10 @@ The result set may be restricted by the `HAVING` clause:
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/exprs/aggregate_functions/invocation-syntax-semantics.md
+++ b/docs/content/preview/api/ysql/exprs/aggregate_functions/invocation-syntax-semantics.md
@@ -35,10 +35,10 @@ The following six diagrams, [`select_start`](../../../syntax_resources/grammar_d
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.diagram.md" %}}
   </div>
 </div>
 These rules govern the invocation of aggregate functions as `SELECT` list items.
@@ -66,10 +66,10 @@ When aggregate functions are invoked using the syntax specified by either the `o
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.diagram.md" %}}
   </div>
 </div>
 
@@ -92,10 +92,10 @@ The result set may be restricted by the `HAVING` clause:
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/exprs/window_functions/invocation-syntax-semantics.md
+++ b/docs/content/preview/api/ysql/exprs/window_functions/invocation-syntax-semantics.md
@@ -52,10 +52,10 @@ The following three diagrams, [`select_start`](../../../syntax_resources/grammar
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.diagram.md" %}}
   </div>
 </div>
 
@@ -82,10 +82,10 @@ A [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-defin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.diagram.md" %}}
   </div>
 </div>
 
@@ -108,10 +108,10 @@ A [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-defin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/exprs/window_functions/invocation-syntax-semantics.md
+++ b/docs/content/preview/api/ysql/exprs/window_functions/invocation-syntax-semantics.md
@@ -52,10 +52,10 @@ The following three diagrams, [`select_start`](../../../syntax_resources/grammar
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.diagram.md" %}}
   </div>
 </div>
 
@@ -82,10 +82,10 @@ A [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-defin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.diagram.md" %}}
   </div>
 </div>
 
@@ -108,10 +108,10 @@ A [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-defin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/cmd_analyze.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/cmd_analyze.md
@@ -46,10 +46,10 @@ To collect or update statistics, run the ANALYZE command manually.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/analyze,table_and_columns.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/analyze,table_and_columns.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/analyze,table_and_columns.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/analyze,table_and_columns.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/cmd_analyze.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/cmd_analyze.md
@@ -46,10 +46,10 @@ To collect or update statistics, run the ANALYZE command manually.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/analyze,table_and_columns.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/analyze,table_and_columns.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/analyze,table_and_columns.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/analyze,table_and_columns.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/cmd_call.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/cmd_call.md
@@ -34,10 +34,10 @@ Use the `CALL` statement to execute a stored procedure.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.diagram.md" %}}
   </div>
 </div>
 **Note:** The syntax and semantics of the `procedure_argument` (for example how to use the named parameter invocation style to avoid providing actual arguments for defaulted parameters) is the same for invoking a user-defined`FUNCTION`. A function cannot be invoked with the `CALL` statement. Rather, it's invoked as (part of) an expression in DML statements like `SELECT`.

--- a/docs/content/preview/api/ysql/the-sql-language/statements/cmd_call.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/cmd_call.md
@@ -34,10 +34,10 @@ Use the `CALL` statement to execute a stored procedure.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.diagram.md" %}}
   </div>
 </div>
 **Note:** The syntax and semantics of the `procedure_argument` (for example how to use the named parameter invocation style to avoid providing actual arguments for defaulted parameters) is the same for invoking a user-defined`FUNCTION`. A function cannot be invoked with the `CALL` statement. Rather, it's invoked as (part of) an expression in DML statements like `SELECT`.

--- a/docs/content/preview/api/ysql/the-sql-language/statements/cmd_copy.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/cmd_copy.md
@@ -36,10 +36,10 @@ Use the `COPY` statement to transfer data between tables and files. `COPY TO` co
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/cmd_copy.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/cmd_copy.md
@@ -36,10 +36,10 @@ Use the `COPY` statement to transfer data between tables and files. `COPY TO` co
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/cmd_do.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/cmd_do.md
@@ -38,10 +38,10 @@ The optional `LANGUAGE` clause can be written either before or after the code bl
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/cmd_do.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/cmd_do.md
@@ -38,10 +38,10 @@ The optional `LANGUAGE` clause can be written either before or after the code bl
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/cmd_reset.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/cmd_reset.md
@@ -36,10 +36,10 @@ Use the `RESET` statement to restore the value of a run-time parameter to the de
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/cmd_reset.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/cmd_reset.md
@@ -36,10 +36,10 @@ Use the `RESET` statement to restore the value of a run-time parameter to the de
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/cmd_set.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/cmd_set.md
@@ -36,10 +36,10 @@ Use the `SET` statement to update a run-time control parameter.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/cmd_set.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/cmd_set.md
@@ -36,10 +36,10 @@ Use the `SET` statement to update a run-time control parameter.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/cmd_show.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/cmd_show.md
@@ -36,10 +36,10 @@ Use the `SHOW` statement to display the value of a run-time parameter.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/cmd_show.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/cmd_show.md
@@ -36,10 +36,10 @@ Use the `SHOW` statement to display the value of a run-time parameter.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_alter_default_privileges.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_alter_default_privileges.md
@@ -36,10 +36,10 @@ Use the `ALTER DEFAULT PRIVILEGES` statement to define the default access privil
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_alter_default_privileges.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_alter_default_privileges.md
@@ -36,10 +36,10 @@ Use the `ALTER DEFAULT PRIVILEGES` statement to define the default access privil
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_alter_group.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_alter_group.md
@@ -37,10 +37,10 @@ This is added for compatibility with Postgres. Its usage is discouraged. [`ALTER
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_alter_group.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_alter_group.md
@@ -37,10 +37,10 @@ This is added for compatibility with Postgres. Its usage is discouraged. [`ALTER
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_alter_policy.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_alter_policy.md
@@ -37,10 +37,10 @@ change the roles that the policy applies to and the `USING` and `CHECK` expressi
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_alter_policy.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_alter_policy.md
@@ -37,10 +37,10 @@ change the roles that the policy applies to and the `USING` and `CHECK` expressi
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_alter_role.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_alter_role.md
@@ -39,10 +39,10 @@ Other roles can only change their own password.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_alter_role.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_alter_role.md
@@ -39,10 +39,10 @@ Other roles can only change their own password.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_alter_user.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_alter_user.md
@@ -36,10 +36,10 @@ Use the `ALTER USER` statement to alter a role. `ALTER USER` is an alias for [`A
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_alter_user.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_alter_user.md
@@ -36,10 +36,10 @@ Use the `ALTER USER` statement to alter a role. `ALTER USER` is an alias for [`A
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_create_group.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_create_group.md
@@ -36,10 +36,10 @@ Use the `CREATE GROUP` statement to create a group role. `CREATE GROUP` is an al
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_create_group.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_create_group.md
@@ -36,10 +36,10 @@ Use the `CREATE GROUP` statement to create a group role. `CREATE GROUP` is an al
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_create_policy.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_create_policy.md
@@ -39,10 +39,10 @@ policies to take effect.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_create_policy.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_create_policy.md
@@ -39,10 +39,10 @@ policies to take effect.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_create_role.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_create_role.md
@@ -42,10 +42,10 @@ You can use `GRANT`/`REVOKE` commands to set/remove permissions for roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_create_role.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_create_role.md
@@ -42,10 +42,10 @@ You can use `GRANT`/`REVOKE` commands to set/remove permissions for roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_create_user.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_create_user.md
@@ -36,10 +36,10 @@ Use the `CREATE USER` statement to create a user. The `CREATE USER` statement is
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_create_user.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_create_user.md
@@ -36,10 +36,10 @@ Use the `CREATE USER` statement to create a user. The `CREATE USER` statement is
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_drop_group.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_drop_group.md
@@ -35,10 +35,10 @@ Use the `DROP GROUP` statement to drop a role. `DROP GROUP` is an alias for [`DR
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_drop_group.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_drop_group.md
@@ -35,10 +35,10 @@ Use the `DROP GROUP` statement to drop a role. `DROP GROUP` is an alias for [`DR
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_drop_owned.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_drop_owned.md
@@ -37,10 +37,10 @@ Any privileges granted to the given roles on objects in the current database or 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_drop_owned.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_drop_owned.md
@@ -37,10 +37,10 @@ Any privileges granted to the given roles on objects in the current database or 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_drop_policy.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_drop_policy.md
@@ -38,10 +38,10 @@ deny all policy will be applied for the table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_drop_policy.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_drop_policy.md
@@ -38,10 +38,10 @@ deny all policy will be applied for the table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_drop_role.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_drop_role.md
@@ -36,10 +36,10 @@ Use the `DROP ROLE` statement to remove the specified roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_drop_role.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_drop_role.md
@@ -36,10 +36,10 @@ Use the `DROP ROLE` statement to remove the specified roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_drop_user.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_drop_user.md
@@ -36,10 +36,10 @@ Use the `DROP USER` statement to drop a user or role. `DROP USER` is an alias fo
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_drop_user.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_drop_user.md
@@ -36,10 +36,10 @@ Use the `DROP USER` statement to drop a user or role. `DROP USER` is an alias fo
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_grant.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_grant.md
@@ -36,10 +36,10 @@ Use the `GRANT` statement to grant access privileges on database objects as well
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_grant.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_grant.md
@@ -36,10 +36,10 @@ Use the `GRANT` statement to grant access privileges on database objects as well
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_reassign_owned.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_reassign_owned.md
@@ -36,10 +36,10 @@ Use the `REASSIGN OWNED` statement to change the ownership of database objects o
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_reassign_owned.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_reassign_owned.md
@@ -36,10 +36,10 @@ Use the `REASSIGN OWNED` statement to change the ownership of database objects o
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_revoke.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_revoke.md
@@ -36,10 +36,10 @@ Use the `REVOKE` statement to remove access privileges from one or more roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_revoke.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_revoke.md
@@ -36,10 +36,10 @@ Use the `REVOKE` statement to remove access privileges from one or more roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_set_role.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_set_role.md
@@ -36,10 +36,10 @@ Use the `SET ROLE` statement to set the current user of the current session to b
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_set_role.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_set_role.md
@@ -36,10 +36,10 @@ Use the `SET ROLE` statement to set the current user of the current session to b
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_set_session_authorization.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_set_session_authorization.md
@@ -36,10 +36,10 @@ Use the `SET SESSION AUTHORIZATION` statement to set the current user and sessio
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dcl_set_session_authorization.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dcl_set_session_authorization.md
@@ -36,10 +36,10 @@ Use the `SET SESSION AUTHORIZATION` statement to set the current user and sessio
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_db.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_db.md
@@ -36,10 +36,10 @@ Use the `ALTER DATABASE` statement to redefine the attributes of a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_db.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_db.md
@@ -36,10 +36,10 @@ Use the `ALTER DATABASE` statement to redefine the attributes of a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_domain.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_domain.md
@@ -36,10 +36,10 @@ Use the `ALTER DOMAIN` statement to change the definition of a domain.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_domain.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_domain.md
@@ -36,10 +36,10 @@ Use the `ALTER DOMAIN` statement to change the definition of a domain.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_foreign_data_wrapper.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_foreign_data_wrapper.md
@@ -34,10 +34,10 @@ Use the `ALTER FOREIGN DATA WRAPPER` command to alter the definition of the fore
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_foreign_data_wrapper.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_foreign_data_wrapper.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_foreign_data_wrapper.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_foreign_data_wrapper.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_foreign_data_wrapper.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_foreign_data_wrapper.md
@@ -34,10 +34,10 @@ Use the `ALTER FOREIGN DATA WRAPPER` command to alter the definition of the fore
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_foreign_data_wrapper.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_foreign_data_wrapper.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_foreign_data_wrapper.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_foreign_data_wrapper.diagram.md" %}}
   </div>
 </div>
 
@@ -47,7 +47,7 @@ Alter the foreign-data wrapper named **fdw_name**.
 
 ### Handler:
 The `HANDLER` clause can be used to specify the handler function.
-The `NO HANDLER` clause can be used to specify that the foreign-data wrapper has no handler function. 
+The `NO HANDLER` clause can be used to specify that the foreign-data wrapper has no handler function.
 
 ### Validator
 The `VALIDATOR` clause can be used to specify the validator function.

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_foreign_table.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_foreign_table.md
@@ -13,7 +13,7 @@ showAsideToc: true
 
 ## Synopsis
 
-Use the `ALTER FOREIGN TABLE` command to alter a foreign table. 
+Use the `ALTER FOREIGN TABLE` command to alter a foreign table.
 
 ## Syntax
 
@@ -34,16 +34,16 @@ Use the `ALTER FOREIGN TABLE` command to alter a foreign table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_foreign_table.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_foreign_table.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_foreign_table.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_foreign_table.diagram.md" %}}
   </div>
 </div>
 
 ## Semantics
 
-Alter the foreign table named *table_name*. 
+Alter the foreign table named *table_name*.
 
 ### Add a column
 The `ADD COLUMN` clause can be used to add a new column to the foreign table. There's no effect on the underlying storage: the `ADD COLUMN` action just indicates that the newly added column can be accessed through the foreign table.

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_foreign_table.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_foreign_table.md
@@ -34,10 +34,10 @@ Use the `ALTER FOREIGN TABLE` command to alter a foreign table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_foreign_table.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_foreign_table.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_foreign_table.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_foreign_table.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_sequence.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_sequence.md
@@ -36,10 +36,10 @@ Use the `ALTER SEQUENCE` statement to change the definition of a sequence in the
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_sequence.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_sequence.md
@@ -36,10 +36,10 @@ Use the `ALTER SEQUENCE` statement to change the definition of a sequence in the
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_server.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_server.md
@@ -34,10 +34,10 @@ Use the `ALTER SERVER` command to alter the definition of a foreign server. The 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_server.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_server.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_server.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_server.diagram.md" %}}
   </div>
 </div>
 
@@ -46,7 +46,7 @@ Use the `ALTER SERVER` command to alter the definition of a foreign server. The 
 Alter the foreign server named **server_name**.
 
 ### Version
-The `VERSION` clause can be used to specify the updated version of the server. 
+The `VERSION` clause can be used to specify the updated version of the server.
 
 ### Options
 The `OPTIONS` clause can be used to specify the new options of the foreign server. `ADD`, `SET`, and `DROP` specify the action to be performed. `ADD` is assumed if no operation is explicitly specified.

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_server.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_server.md
@@ -34,10 +34,10 @@ Use the `ALTER SERVER` command to alter the definition of a foreign server. The 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_server.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_server.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_server.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_server.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_table.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_table.md
@@ -36,10 +36,10 @@ Use the `ALTER TABLE` statement to change the definition of a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint,table_expr.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint,table_expr.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint,table_expr.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint,table_expr.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_table.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_table.md
@@ -36,10 +36,10 @@ Use the `ALTER TABLE` statement to change the definition of a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint,table_expr.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint,table_expr.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint,table_expr.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint,table_expr.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_comment.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_comment.md
@@ -36,10 +36,10 @@ Use the `COMMENT` statement to set, update, or remove a comment on a database ob
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_comment.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_comment.md
@@ -36,10 +36,10 @@ Use the `COMMENT` statement to set, update, or remove a comment on a database ob
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_aggregate.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_aggregate.md
@@ -37,10 +37,10 @@ create aggregates.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_aggregate.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_aggregate.md
@@ -37,10 +37,10 @@ create aggregates.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_cast.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_cast.md
@@ -36,10 +36,10 @@ Use the `CREATE CAST` statement to create a cast.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_cast.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_cast.md
@@ -36,10 +36,10 @@ Use the `CREATE CAST` statement to create a cast.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_database.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_database.md
@@ -36,10 +36,10 @@ Use the `CREATE DATABASE` statement to create a database that functions as a gro
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_database.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_database.md
@@ -36,10 +36,10 @@ Use the `CREATE DATABASE` statement to create a database that functions as a gro
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.grammar.md" %}}
+{{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.diagram.md" %}}
+{{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_domain.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_domain.md
@@ -36,10 +36,10 @@ Use the `CREATE DOMAIN` statement to create a user-defined data type with option
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_domain.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_domain.md
@@ -36,10 +36,10 @@ Use the `CREATE DOMAIN` statement to create a user-defined data type with option
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_extension.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_extension.md
@@ -37,10 +37,10 @@ Use the `CREATE EXTENSION` statement to load an extension into a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_extension.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_extension.md
@@ -37,10 +37,10 @@ Use the `CREATE EXTENSION` statement to load an extension into a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_foreign_data_wrapper.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_foreign_data_wrapper.md
@@ -36,10 +36,10 @@ Only superusers or users with the yb_fdw role can create foreign data wrappers.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_foreign_data_wrapper.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_foreign_data_wrapper.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_foreign_data_wrapper.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_foreign_data_wrapper.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_foreign_data_wrapper.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_foreign_data_wrapper.md
@@ -13,7 +13,7 @@ showAsideToc: true
 
 ## Synopsis
 
-Use the `CREATE FOREIGN DATA WRAPPER` statement to create a foreign data wrapper. 
+Use the `CREATE FOREIGN DATA WRAPPER` statement to create a foreign data wrapper.
 Only superusers or users with the yb_fdw role can create foreign data wrappers.
 
 
@@ -36,10 +36,10 @@ Only superusers or users with the yb_fdw role can create foreign data wrappers.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_foreign_data_wrapper.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_foreign_data_wrapper.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_foreign_data_wrapper.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_foreign_data_wrapper.diagram.md" %}}
   </div>
 </div>
 
@@ -48,18 +48,18 @@ Only superusers or users with the yb_fdw role can create foreign data wrappers.
 Create a FDW named *fdw_name*.
 
 ### Handler function
-The *handler_function* will be called to retrieve the execution functions for foreign tables. These functions are required by the planner and executor. 
+The *handler_function* will be called to retrieve the execution functions for foreign tables. These functions are required by the planner and executor.
 The handler function takes no arguments and its return type should be `fdw_handler`.
-If no handler function is provided, foreign tables that use the wrapper can only be declared (and not accessed). 
+If no handler function is provided, foreign tables that use the wrapper can only be declared (and not accessed).
 
 ### Validator function
 
-The *validator_function* is used to validate the options given to the foreign-data wrapper, and the foreign servers, user mappings and foreign tables that use the foreign-data wrapper. 
-The validator function takes two arguments: a text array (type text[]) that contains the options to be validated, and an OID of the system catalog that the object associated with the options is stored in. 
-If no validator function is provided (or `NO VALIDATOR` is specified), the options will not be checked at the time of creation. 
+The *validator_function* is used to validate the options given to the foreign-data wrapper, and the foreign servers, user mappings and foreign tables that use the foreign-data wrapper.
+The validator function takes two arguments: a text array (type text[]) that contains the options to be validated, and an OID of the system catalog that the object associated with the options is stored in.
+If no validator function is provided (or `NO VALIDATOR` is specified), the options will not be checked at the time of creation.
 
 ### Options:
-The `OPTIONS` clause specifies options for the foreign-data wrapper. The permitted option names and values are specific to each foreign data wrapper. The options are validated using the FDW’s validator function. 
+The `OPTIONS` clause specifies options for the foreign-data wrapper. The permitted option names and values are specific to each foreign data wrapper. The options are validated using the FDW’s validator function.
 
 ## Examples
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_foreign_table.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_foreign_table.md
@@ -13,7 +13,7 @@ showAsideToc: true
 
 ## Synopsis
 
-Use the `CREATE FOREIGN TABLE` command to create a foreign table. 
+Use the `CREATE FOREIGN TABLE` command to create a foreign table.
 
 ## Syntax
 
@@ -34,10 +34,10 @@ Use the `CREATE FOREIGN TABLE` command to create a foreign table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_foreign_table.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_foreign_table.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_foreign_table.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_foreign_table.diagram.md" %}}
   </div>
 </div>
 
@@ -53,7 +53,7 @@ The `COLLATE` clause can be used to specify a collation for the column.
 The `SERVER` clause can be used to specify the name of the foreign server to use.
 
 ### Options:
-The `OPTIONS` clause specifies options for the foreign table. The permitted option names and values are specific to each foreign data wrapper. The options are validated using the FDW’s validator function. 
+The `OPTIONS` clause specifies options for the foreign table. The permitted option names and values are specific to each foreign data wrapper. The options are validated using the FDW’s validator function.
 
 ## Examples
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_foreign_table.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_foreign_table.md
@@ -34,10 +34,10 @@ Use the `CREATE FOREIGN TABLE` command to create a foreign table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_foreign_table.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_foreign_table.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_foreign_table.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_foreign_table.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_function.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_function.md
@@ -36,10 +36,10 @@ Use the `CREATE FUNCTION` statement to create a function in a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl,function_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl,function_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl,function_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl,function_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_function.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_function.md
@@ -36,10 +36,10 @@ Use the `CREATE FUNCTION` statement to create a function in a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl,function_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl,function_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl,function_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl,function_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_index.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_index.md
@@ -36,10 +36,10 @@ Use the `CREATE INDEX` statement to create an index on the specified columns of 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_index.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_index.md
@@ -36,10 +36,10 @@ Use the `CREATE INDEX` statement to create an index on the specified columns of 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_matview.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_matview.md
@@ -36,10 +36,10 @@ Use the `CREATE MATERIALIZED VIEW` statement to create a materialized view.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_matview.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_matview.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_matview.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_matview.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_matview.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_matview.md
@@ -36,10 +36,10 @@ Use the `CREATE MATERIALIZED VIEW` statement to create a materialized view.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_matview.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_matview.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_matview.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_matview.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_operator.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_operator.md
@@ -36,10 +36,10 @@ Use the `CREATE OPERATOR` statement to create an operator.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_operator.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_operator.md
@@ -36,10 +36,10 @@ Use the `CREATE OPERATOR` statement to create an operator.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_operator_class.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_operator_class.md
@@ -36,10 +36,10 @@ Use the `CREATE OPERATOR CLASS` statement to create an operator class.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_operator_class.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_operator_class.md
@@ -36,10 +36,10 @@ Use the `CREATE OPERATOR CLASS` statement to create an operator class.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_procedure.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_procedure.md
@@ -36,10 +36,10 @@ Use the `CREATE PROCEDURE` statement to create a procedure in a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl,procedure_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl,procedure_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl,procedure_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl,procedure_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_procedure.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_procedure.md
@@ -36,10 +36,10 @@ Use the `CREATE PROCEDURE` statement to create a procedure in a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl,procedure_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl,procedure_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl,procedure_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl,procedure_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_rule.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_rule.md
@@ -36,10 +36,10 @@ Use the `CREATE RULE` statement to create a rule.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_rule.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_rule.md
@@ -36,10 +36,10 @@ Use the `CREATE RULE` statement to create a rule.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_schema.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_schema.md
@@ -38,10 +38,10 @@ Named objects in a schema can be accessed by using the schema name as prefix or 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_schema.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_schema.md
@@ -38,10 +38,10 @@ Named objects in a schema can be accessed by using the schema name as prefix or 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_sequence.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_sequence.md
@@ -36,10 +36,10 @@ Use the `CREATE SEQUENCE` statement to create a sequence in the current schema.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_sequence.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_sequence.md
@@ -36,10 +36,10 @@ Use the `CREATE SEQUENCE` statement to create a sequence in the current schema.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_server.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_server.md
@@ -34,10 +34,10 @@ Use the `CREATE SERVER` command to create a foreign table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_server.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_server.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_server.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_server.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_server.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_server.md
@@ -13,7 +13,7 @@ showAsideToc: true
 
 ## Synopsis
 
-Use the `CREATE SERVER` command to create a foreign table. 
+Use the `CREATE SERVER` command to create a foreign table.
 
 ## Syntax
 
@@ -34,10 +34,10 @@ Use the `CREATE SERVER` command to create a foreign table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_server.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_server.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_server.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_server.diagram.md" %}}
   </div>
 </div>
 
@@ -56,7 +56,7 @@ The `VERSION` clause can be optionally used to specify the server version.
 The `FOREIGN DATA WRAPPER` clause can be used to specify the name of the foreign-data wrapper.
 
 ### Options:
-The `OPTIONS` clause specifies options for the foreign server. They typically define the connection details of the server, but the actual permitted option names and values are specific to the server’s foreign data wrapper. 
+The `OPTIONS` clause specifies options for the foreign server. They typically define the connection details of the server, but the actual permitted option names and values are specific to the server’s foreign data wrapper.
 
 ## Examples
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_table.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_table.md
@@ -36,10 +36,10 @@ Use the `CREATE TABLE` statement to create a table in a database. It defines the
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_table.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_table.md
@@ -36,10 +36,10 @@ Use the `CREATE TABLE` statement to create a table in a database. It defines the
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_table_as.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_table_as.md
@@ -36,10 +36,10 @@ Use the `CREATE TABLE AS` statement to create a table using the output of a subq
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_table_as.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_table_as.md
@@ -36,10 +36,10 @@ Use the `CREATE TABLE AS` statement to create a table using the output of a subq
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_trigger.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_trigger.md
@@ -36,10 +36,10 @@ Use the `CREATE TRIGGER` statement to create a trigger.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_trigger.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_trigger.md
@@ -36,10 +36,10 @@ Use the `CREATE TRIGGER` statement to create a trigger.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_type.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_type.md
@@ -36,10 +36,10 @@ Use the `CREATE TYPE` statement to create a user-defined type in a database.  Th
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_type.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_type.md
@@ -36,10 +36,10 @@ Use the `CREATE TYPE` statement to create a user-defined type in a database.  Th
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_user_mapping.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_user_mapping.md
@@ -15,7 +15,7 @@ showAsideToc: true
 
 Use the `CREATE USER MAPPING` command to define the mapping of a specific user to authorization credentials in the foreign server. The foreign-data wrapper uses the information provided by the foreign server and the user mapping to connect to the external data source.
 
-The owner of a foreign server can create user mappings for the server for any user. Moreover, a user can create user mapping for themself if they have `USAGE` privilege on the server. 
+The owner of a foreign server can create user mappings for the server for any user. Moreover, a user can create user mapping for themself if they have `USAGE` privilege on the server.
 
 ## Syntax
 
@@ -36,10 +36,10 @@ The owner of a foreign server can create user mappings for the server for any us
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user_mapping.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user_mapping.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user_mapping.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user_mapping.diagram.md" %}}
   </div>
 </div>
 
@@ -48,7 +48,7 @@ The owner of a foreign server can create user mappings for the server for any us
 Create a user mapping for the user *user_name* for the server *server_name*. If a mapping between the user and the foreign server already exists, an error will be raised unless the `IF NOT EXISTS` clause is used.
 
 ### Options:
-The `OPTIONS` clause specifies options for the foreign-data server. They typically define the mapped username and password to be used on the external data source, but the actual permitted option names and values are specific to the server’s foreign data wrapper. 
+The `OPTIONS` clause specifies options for the foreign-data server. They typically define the mapped username and password to be used on the external data source, but the actual permitted option names and values are specific to the server’s foreign data wrapper.
 
 
 ## Examples

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_user_mapping.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_user_mapping.md
@@ -36,10 +36,10 @@ The owner of a foreign server can create user mappings for the server for any us
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user_mapping.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user_mapping.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user_mapping.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user_mapping.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_view.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_view.md
@@ -36,10 +36,10 @@ Use the `CREATE VIEW` statement to create a view in a database. It defines the v
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_view.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_view.md
@@ -36,10 +36,10 @@ Use the `CREATE VIEW` statement to create a view in a database. It defines the v
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_aggregate.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_aggregate.md
@@ -36,10 +36,10 @@ Use the `DROP AGGREGATE` statement to remove an aggregate.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_aggregate.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_aggregate.md
@@ -36,10 +36,10 @@ Use the `DROP AGGREGATE` statement to remove an aggregate.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_cast.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_cast.md
@@ -36,10 +36,10 @@ Use the `DROP CAST` statement to remove a cast.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_cast.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_cast.md
@@ -36,10 +36,10 @@ Use the `DROP CAST` statement to remove a cast.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_database.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_database.md
@@ -36,10 +36,10 @@ Use the `DROP DATABASE` statement to remove a database and all of its associated
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_database.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_database.md
@@ -36,10 +36,10 @@ Use the `DROP DATABASE` statement to remove a database and all of its associated
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_domain.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_domain.md
@@ -36,10 +36,10 @@ Use the `DROP DOMAIN` statement to remove a domain from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_domain.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_domain.md
@@ -36,10 +36,10 @@ Use the `DROP DOMAIN` statement to remove a domain from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_extension.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_extension.md
@@ -37,10 +37,10 @@ Use the `DROP EXTENSION` statement to remove an extension from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_extension.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_extension.md
@@ -37,10 +37,10 @@ Use the `DROP EXTENSION` statement to remove an extension from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_foreign_data_wrapper.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_foreign_data_wrapper.md
@@ -34,10 +34,10 @@ Use the `DROP FOREIGN DATA WRAPPER` command to remove a foreign-data wrapper. Th
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_foreign_data_wrapper.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_foreign_data_wrapper.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_foreign_data_wrapper.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_foreign_data_wrapper.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_foreign_data_wrapper.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_foreign_data_wrapper.md
@@ -34,10 +34,10 @@ Use the `DROP FOREIGN DATA WRAPPER` command to remove a foreign-data wrapper. Th
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_foreign_data_wrapper.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_foreign_data_wrapper.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_foreign_data_wrapper.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_foreign_data_wrapper.diagram.md" %}}
   </div>
 </div>
 
@@ -46,7 +46,7 @@ Use the `DROP FOREIGN DATA WRAPPER` command to remove a foreign-data wrapper. Th
 Drop a foreign-data wrapper named **fdw_name**. If it doesn’t exist in the database, an error will be thrown unless the `IF EXISTS` clause is used.
 
 ### RESTRICT/CASCADE:
-`RESTRICT` is the default and it will not drop the foreign-data wrapper if any objects depend on it. 
+`RESTRICT` is the default and it will not drop the foreign-data wrapper if any objects depend on it.
 `CASCADE` will drop the foreign-data wrapper and any objects that transitively depend on it.
 
 ## Examples

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_foreign_table.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_foreign_table.md
@@ -34,10 +34,10 @@ Use the `DROP FOREIGN TABLE` command to remove a foreign table. The user who exe
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_foreign_table.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_foreign_table.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_foreign_table.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_foreign_table.diagram.md" %}}
   </div>
 </div>
 
@@ -46,7 +46,7 @@ Use the `DROP FOREIGN TABLE` command to remove a foreign table. The user who exe
 Drop a foreign table named **table_name**. If it doesn’t exist in the database, an error will be thrown unless the `IF EXISTS` clause is used.
 
 ### RESTRICT/CASCADE:
-`RESTRICT` is the default and it will not drop the foreign table if any objects depend on it. 
+`RESTRICT` is the default and it will not drop the foreign table if any objects depend on it.
 `CASCADE` will drop the foreign table and any objects that transitively depend on it.
 
 ## Examples

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_foreign_table.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_foreign_table.md
@@ -34,10 +34,10 @@ Use the `DROP FOREIGN TABLE` command to remove a foreign table. The user who exe
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_foreign_table.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_foreign_table.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_foreign_table.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_foreign_table.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_function.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_function.md
@@ -36,10 +36,10 @@ Use the `DROP FUNCTION` statement to remove a function from a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_function.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_function.md
@@ -36,10 +36,10 @@ Use the `DROP FUNCTION` statement to remove a function from a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_matview.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_matview.md
@@ -36,10 +36,10 @@ Use the `DROP MATERIALIZED VIEW` statement to drop a materialized view.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_matview.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_matview.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_matview.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_matview.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_matview.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_matview.md
@@ -36,10 +36,10 @@ Use the `DROP MATERIALIZED VIEW` statement to drop a materialized view.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_matview.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_matview.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_matview.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_matview.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_operator.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_operator.md
@@ -36,10 +36,10 @@ Use the `DROP OPERATOR` statement to remove an operator.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_operator.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_operator.md
@@ -36,10 +36,10 @@ Use the `DROP OPERATOR` statement to remove an operator.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_operator_class.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_operator_class.md
@@ -36,10 +36,10 @@ Use the `DROP OPERATOR CLASS` statement to remove an operator class.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_operator_class.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_operator_class.md
@@ -36,10 +36,10 @@ Use the `DROP OPERATOR CLASS` statement to remove an operator class.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_procedure.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_procedure.md
@@ -36,10 +36,10 @@ Use the `DROP PROCEDURE` statement to remove a procedure from a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_procedure.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_procedure.md
@@ -36,10 +36,10 @@ Use the `DROP PROCEDURE` statement to remove a procedure from a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_rule.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_rule.md
@@ -36,10 +36,10 @@ Use the `DROP RULE` statement to remove a rule.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_rule.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_rule.md
@@ -36,10 +36,10 @@ Use the `DROP RULE` statement to remove a rule.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_sequence.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_sequence.md
@@ -36,10 +36,10 @@ Use the `DROP SEQUENCE` statement to delete a sequence in the current schema.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.diagram.md" %}}
   </div>
 </div>
 
@@ -126,4 +126,4 @@ DROP SEQUENCE
 - [`lastval()`](../../../exprs/func_lastval)
 - [`nextval()`](../../../exprs/func_nextval)
 - [`setval()`](../../../exprs/func_setval)
-- 
+-

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_sequence.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_sequence.md
@@ -36,10 +36,10 @@ Use the `DROP SEQUENCE` statement to delete a sequence in the current schema.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_server.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_server.md
@@ -34,10 +34,10 @@ Use the `DROP SERVER` command to remove a foreign server. The user who executes 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_server.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_server.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_server.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_server.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_server.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_server.md
@@ -34,10 +34,10 @@ Use the `DROP SERVER` command to remove a foreign server. The user who executes 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_server.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_server.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_server.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_server.diagram.md" %}}
   </div>
 </div>
 
@@ -46,7 +46,7 @@ Use the `DROP SERVER` command to remove a foreign server. The user who executes 
 Drop a foreign server named **server_name**. If it doesn’t exist in the database, an error will be thrown unless the `IF EXISTS` clause is used.
 
 ### RESTRICT/CASCADE:
-`RESTRICT` is the default and it will not drop the foreign server if any objects depend on it. 
+`RESTRICT` is the default and it will not drop the foreign server if any objects depend on it.
 `CASCADE` will drop the foreign server and any objects that transitively depend on it.
 
 ## Examples

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_table.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_table.md
@@ -36,10 +36,10 @@ Use the `DROP TABLE` statement to remove one or more tables (with all of their d
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_table.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_table.md
@@ -36,10 +36,10 @@ Use the `DROP TABLE` statement to remove one or more tables (with all of their d
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_trigger.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_trigger.md
@@ -36,10 +36,10 @@ Use the `DROP TRIGGER` statement to remove a trigger from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_trigger.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_trigger.md
@@ -36,10 +36,10 @@ Use the `DROP TRIGGER` statement to remove a trigger from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_type.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_type.md
@@ -36,10 +36,10 @@ Use the `DROP TYPE` statement to remove a user-defined type from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_type.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_drop_type.md
@@ -36,10 +36,10 @@ Use the `DROP TYPE` statement to remove a user-defined type from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_import_foreign_schema.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_import_foreign_schema.md
@@ -36,10 +36,10 @@ To use this command, the user must have `USAGE` privileges on the foreign server
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/import_foreign_schema.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/import_foreign_schema.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/import_foreign_schema.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/import_foreign_schema.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_import_foreign_schema.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_import_foreign_schema.md
@@ -13,8 +13,8 @@ showAsideToc: true
 
 ## Synopsis
 
-Use the `IMPORT FOREIGN SCHEMA`  command to create foreign tables that represent tables in a foreign schema on a foreign server. The newly created foreign tables are owned by the user who issued the command. 
-By default, all the tables in the foreign schema are imported. However, the user can specify which tables to import using the `LIMIT TO` and `EXCEPT` clauses. 
+Use the `IMPORT FOREIGN SCHEMA`  command to create foreign tables that represent tables in a foreign schema on a foreign server. The newly created foreign tables are owned by the user who issued the command.
+By default, all the tables in the foreign schema are imported. However, the user can specify which tables to import using the `LIMIT TO` and `EXCEPT` clauses.
 To use this command, the user must have `USAGE` privileges on the foreign server, and `CREATE` privileges on the target schema.
 
 ## Syntax
@@ -36,16 +36,16 @@ To use this command, the user must have `USAGE` privileges on the foreign server
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/import_foreign_schema.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/import_foreign_schema.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/import_foreign_schema.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/import_foreign_schema.diagram.md" %}}
   </div>
 </div>
 
 ## Semantics
 
-Create foreign tables (in *local_schema*) that represent tables in a foreign schema named *remote_schema* located on a foreign server named *server_name*. 
+Create foreign tables (in *local_schema*) that represent tables in a foreign schema named *remote_schema* located on a foreign server named *server_name*.
 
 ### LIMIT TO
 The `LIMIT TO` clause can be optionally used to specify which tables to import. All other tables will be ignored.

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_refresh_matview.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_refresh_matview.md
@@ -36,10 +36,10 @@ Use the `REFRESH MATERIALIZED VIEW` statement to replace the contents of a mater
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/refresh_matview.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/refresh_matview.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/refresh_matview.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/refresh_matview.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_refresh_matview.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_refresh_matview.md
@@ -36,10 +36,10 @@ Use the `REFRESH MATERIALIZED VIEW` statement to replace the contents of a mater
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/refresh_matview.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/refresh_matview.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/refresh_matview.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/refresh_matview.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_truncate.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_truncate.md
@@ -38,10 +38,10 @@ Applying `TRUNCATE` to a set of tables produces the same ultimate outcome as doe
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_truncate.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_truncate.md
@@ -38,10 +38,10 @@ Applying `TRUNCATE` to a set of tables produces the same ultimate outcome as doe
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dml_delete.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dml_delete.md
@@ -36,10 +36,10 @@ Use the `DELETE` statement to remove rows that meet certain conditions, and when
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dml_delete.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dml_delete.md
@@ -36,10 +36,10 @@ Use the `DELETE` statement to remove rows that meet certain conditions, and when
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dml_insert.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dml_insert.md
@@ -36,10 +36,10 @@ Use the `INSERT` statement to add one or more rows to the specified table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dml_insert.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dml_insert.md
@@ -36,10 +36,10 @@ Use the `INSERT` statement to add one or more rows to the specified table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dml_select.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dml_select.md
@@ -38,10 +38,10 @@ The same syntax rules govern a subquery, wherever you might use one—like, for 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dml_select.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dml_select.md
@@ -38,10 +38,10 @@ The same syntax rules govern a subquery, wherever you might use one—like, for 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dml_update.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dml_update.md
@@ -36,10 +36,10 @@ Use the `UPDATE` statement to modify the values of specified columns in all rows
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dml_update.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dml_update.md
@@ -36,10 +36,10 @@ Use the `UPDATE` statement to modify the values of specified columns in all rows
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dml_values.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dml_values.md
@@ -34,10 +34,10 @@ Use the `VALUES` statement to generate a row set specified as an explicitly writ
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/dml_values.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/dml_values.md
@@ -34,10 +34,10 @@ Use the `VALUES` statement to generate a row set specified as an explicitly writ
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/perf_deallocate.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/perf_deallocate.md
@@ -36,10 +36,10 @@ Use the `DEALLOCATE` statement to deallocate a previously prepared SQL statement
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/perf_deallocate.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/perf_deallocate.md
@@ -36,10 +36,10 @@ Use the `DEALLOCATE` statement to deallocate a previously prepared SQL statement
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/perf_execute.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/perf_execute.md
@@ -36,10 +36,10 @@ Use the `EXECUTE` statement to execute a previously prepared statement. This sep
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/perf_execute.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/perf_execute.md
@@ -36,10 +36,10 @@ Use the `EXECUTE` statement to execute a previously prepared statement. This sep
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/perf_explain.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/perf_explain.md
@@ -36,10 +36,10 @@ Use the `EXPLAIN` statement to show the execution plan for an statement. If the 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/perf_explain.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/perf_explain.md
@@ -36,10 +36,10 @@ Use the `EXPLAIN` statement to show the execution plan for an statement. If the 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/perf_prepare.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/perf_prepare.md
@@ -36,10 +36,10 @@ Use the `PREPARE` statement to create a handle to a prepared statement by parsin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/perf_prepare.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/perf_prepare.md
@@ -36,10 +36,10 @@ Use the `PREPARE` statement to create a handle to a prepared statement by parsin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/savepoint_create.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/savepoint_create.md
@@ -36,10 +36,10 @@ Use the `SAVEPOINT` statement to define a new savepoint within the current trans
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_create.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_create.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_create.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_create.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/savepoint_create.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/savepoint_create.md
@@ -36,10 +36,10 @@ Use the `SAVEPOINT` statement to define a new savepoint within the current trans
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_create.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_create.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_create.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_create.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/savepoint_release.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/savepoint_release.md
@@ -36,10 +36,10 @@ Use the `RELEASE SAVEPOINT` statement to release the server-side state associate
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_release.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_release.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_release.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_release.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/savepoint_release.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/savepoint_release.md
@@ -36,10 +36,10 @@ Use the `RELEASE SAVEPOINT` statement to release the server-side state associate
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_release.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_release.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_release.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_release.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/savepoint_rollback.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/savepoint_rollback.md
@@ -36,10 +36,10 @@ Use the `ROLLBACK TO SAVEPOINT` statement to revert the state of the transaction
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_rollback.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_rollback.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_rollback.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_rollback.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/savepoint_rollback.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/savepoint_rollback.md
@@ -36,10 +36,10 @@ Use the `ROLLBACK TO SAVEPOINT` statement to revert the state of the transaction
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_rollback.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_rollback.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_rollback.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_rollback.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/txn_abort.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/txn_abort.md
@@ -36,10 +36,10 @@ Use the `ABORT` statement to roll back the current transaction and discards all 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/txn_abort.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/txn_abort.md
@@ -36,10 +36,10 @@ Use the `ABORT` statement to roll back the current transaction and discards all 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/txn_begin.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/txn_begin.md
@@ -36,10 +36,10 @@ Use the `BEGIN` statement to start a transaction with the default (or given) iso
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/txn_begin.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/txn_begin.md
@@ -36,10 +36,10 @@ Use the `BEGIN` statement to start a transaction with the default (or given) iso
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/txn_commit.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/txn_commit.md
@@ -36,10 +36,10 @@ Use the `COMMIT` statement to commit the current transaction. All changes made b
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/txn_commit.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/txn_commit.md
@@ -36,10 +36,10 @@ Use the `COMMIT` statement to commit the current transaction. All changes made b
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/txn_end.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/txn_end.md
@@ -36,10 +36,10 @@ Use the `END` statement to commit the current transaction. All changes made by t
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/txn_end.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/txn_end.md
@@ -36,10 +36,10 @@ Use the `END` statement to commit the current transaction. All changes made by t
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/txn_lock.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/txn_lock.md
@@ -36,10 +36,10 @@ Use the `LOCK` statement to lock a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/txn_lock.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/txn_lock.md
@@ -36,10 +36,10 @@ Use the `LOCK` statement to lock a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/txn_rollback.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/txn_rollback.md
@@ -36,10 +36,10 @@ Use the `ROLLBACK` statement to roll back the current transactions. All changes 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/txn_rollback.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/txn_rollback.md
@@ -36,10 +36,10 @@ Use the `ROLLBACK` statement to roll back the current transactions. All changes 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/txn_set.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/txn_set.md
@@ -37,10 +37,10 @@ Use the `SET TRANSACTION` statement to set the current transaction isolation lev
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/txn_set.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/txn_set.md
@@ -37,10 +37,10 @@ Use the `SET TRANSACTION` statement to set the current transaction isolation lev
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/txn_set_constraints.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/txn_set_constraints.md
@@ -37,10 +37,10 @@ Use the `SET CONSTRAINTS` statement to set the timing of constraint checking wit
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/txn_set_constraints.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/txn_set_constraints.md
@@ -37,10 +37,10 @@ Use the `SET CONSTRAINTS` statement to set the timing of constraint checking wit
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/txn_show.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/txn_show.md
@@ -37,10 +37,10 @@ Use the `SHOW TRANSACTION` statement to show the current transaction isolation l
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/txn_show.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/txn_show.md
@@ -37,10 +37,10 @@ Use the `SHOW TRANSACTION` statement to show the current transaction isolation l
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/with-clause/recursive-cte.md
+++ b/docs/content/preview/api/ysql/the-sql-language/with-clause/recursive-cte.md
@@ -95,10 +95,10 @@ The `WITH` clause syntax (see the section [WITH clause—SQL syntax and semantic
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/with-clause/recursive-cte.md
+++ b/docs/content/preview/api/ysql/the-sql-language/with-clause/recursive-cte.md
@@ -95,10 +95,10 @@ The `WITH` clause syntax (see the section [WITH clause—SQL syntax and semantic
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/with-clause/with-clause-syntax-semantics.md
+++ b/docs/content/preview/api/ysql/the-sql-language/with-clause/with-clause-syntax-semantics.md
@@ -33,10 +33,10 @@ The [with_clause](../../../syntax_resources/grammar_diagrams/#with-clause)  and 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/api/ysql/the-sql-language/with-clause/with-clause-syntax-semantics.md
+++ b/docs/content/preview/api/ysql/the-sql-language/with-clause/with-clause-syntax-semantics.md
@@ -33,10 +33,10 @@ The [with_clause](../../../syntax_resources/grammar_diagrams/#with-clause)  and 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/benchmark/tpcc-ysql/_index.md
+++ b/docs/content/preview/benchmark/tpcc-ysql/_index.md
@@ -108,16 +108,16 @@ Other options like username, password, port, etc. can be changed using the confi
 
 <div class="tab-content">
   <div id="10-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="10-wh-tab">
-    {{% includeMarkdown "10-wh/tpcc-ysql.md" /%}}
+    {{% includeMarkdown "10-wh/tpcc-ysql.md" %}}
   </div>
   <div id="100-wh" class="tab-pane fade show active" role="tabpanel" aria-labelledby="100-wh-tab">
-    {{% includeMarkdown "100-wh/tpcc-ysql.md" /%}}
+    {{% includeMarkdown "100-wh/tpcc-ysql.md" %}}
   </div>
   <div id="1000-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="1000-wh-tab">
-    {{% includeMarkdown "1000-wh/tpcc-ysql.md" /%}}
+    {{% includeMarkdown "1000-wh/tpcc-ysql.md" %}}
   </div>
   <div id="10000-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="10000-wh-tab">
-    {{% includeMarkdown "10000-wh/tpcc-ysql.md" /%}}
+    {{% includeMarkdown "10000-wh/tpcc-ysql.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/benchmark/tpcc-ysql/_index.md
+++ b/docs/content/preview/benchmark/tpcc-ysql/_index.md
@@ -108,16 +108,16 @@ Other options like username, password, port, etc. can be changed using the confi
 
 <div class="tab-content">
   <div id="10-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="10-wh-tab">
-    {{% includeMarkdown "10-wh/tpcc-ysql.md" %}}
+  {{% includeMarkdown "10-wh/tpcc-ysql.md" %}}
   </div>
   <div id="100-wh" class="tab-pane fade show active" role="tabpanel" aria-labelledby="100-wh-tab">
-    {{% includeMarkdown "100-wh/tpcc-ysql.md" %}}
+  {{% includeMarkdown "100-wh/tpcc-ysql.md" %}}
   </div>
   <div id="1000-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="1000-wh-tab">
-    {{% includeMarkdown "1000-wh/tpcc-ysql.md" %}}
+  {{% includeMarkdown "1000-wh/tpcc-ysql.md" %}}
   </div>
   <div id="10000-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="10000-wh-tab">
-    {{% includeMarkdown "10000-wh/tpcc-ysql.md" %}}
+  {{% includeMarkdown "10000-wh/tpcc-ysql.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/contribute/docs/syntax-diagrams.md
+++ b/docs/content/preview/contribute/docs/syntax-diagrams.md
@@ -308,10 +308,10 @@ You must include this boilerplate text in `wants-to-include.md` at the location 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{%/* includeMarkdown "../../../syntax_resources/dir_1/dir_2/dir_3/<rule set X>.grammar.md" /*/%}}
+  {{%/* includeMarkdown "../../../syntax_resources/dir_1/dir_2/dir_3/<rule set X>.grammar.md" */%}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{%/* includeMarkdown "../../../syntax_resources/dir_1/dir_2/dir_3/<rule set X>.diagram.md" /*/%}}
+  {{%/* includeMarkdown "../../../syntax_resources/dir_1/dir_2/dir_3/<rule set X>.diagram.md" */%}}
   </div>
 </div>
 ```

--- a/docs/content/preview/contribute/docs/widgets-and-shortcodes.md
+++ b/docs/content/preview/contribute/docs/widgets-and-shortcodes.md
@@ -106,16 +106,16 @@ The corresponding code for this widget is shown below. Note that the actual cont
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{%/* includeMarkdown "binary/explore-ysql.md" /*/%}}
+  {{%/* includeMarkdown "binary/explore-ysql.md" */%}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{%/* includeMarkdown "binary/explore-ysql.md" /*/%}}
+  {{%/* includeMarkdown "binary/explore-ysql.md" */%}}
   </div>
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{%/* includeMarkdown "docker/explore-ysql.md" /*/%}}
+  {{%/* includeMarkdown "docker/explore-ysql.md" */%}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{%/* includeMarkdown "kubernetes/explore-ysql.md" /*/%}}
+  {{%/* includeMarkdown "kubernetes/explore-ysql.md" */%}}
   </div>
 </div>
 ```

--- a/docs/content/preview/develop/explore-sample-apps.md
+++ b/docs/content/preview/develop/explore-sample-apps.md
@@ -49,15 +49,15 @@ After running Yugastore, Yugabyte recommend running the [IoT Fleet Management](.
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/run-sample-apps.md" %}}
+  {{% includeMarkdown "binary/run-sample-apps.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/run-sample-apps.md" %}}
+  {{% includeMarkdown "binary/run-sample-apps.md" %}}
   </div>
    <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/run-sample-apps.md" %}}
+  {{% includeMarkdown "docker/run-sample-apps.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/run-sample-apps.md" %}}
+  {{% includeMarkdown "kubernetes/run-sample-apps.md" %}}
   </div>
 </div>

--- a/docs/content/preview/develop/explore-sample-apps.md
+++ b/docs/content/preview/develop/explore-sample-apps.md
@@ -49,15 +49,15 @@ After running Yugastore, Yugabyte recommend running the [IoT Fleet Management](.
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/run-sample-apps.md" /%}}
+    {{% includeMarkdown "binary/run-sample-apps.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/run-sample-apps.md" /%}}
+    {{% includeMarkdown "binary/run-sample-apps.md" %}}
   </div>
    <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/run-sample-apps.md" /%}}
+    {{% includeMarkdown "docker/run-sample-apps.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/run-sample-apps.md" /%}}
+    {{% includeMarkdown "kubernetes/run-sample-apps.md" %}}
   </div>
 </div>

--- a/docs/content/preview/explore/ysql-language-features/going-beyond-sql/tablespaces.md
+++ b/docs/content/preview/explore/ysql-language-features/going-beyond-sql/tablespaces.md
@@ -71,10 +71,10 @@ The differences between single-zone, multi-zone and multi-region configuration b
 
 <div class="tab-content">
   <div id="yugabyted" class="tab-pane fade show active" role="tabpanel" aria-labelledby="yugabyted-tab">
-    {{% includeMarkdown "./tablespaces-yugabyted.md" /%}}
+    {{% includeMarkdown "./tablespaces-yugabyted.md" %}}
   </div>
   <div id="platform" class="tab-pane fade show active" role="tabpanel" aria-labelledby="platform-tab">
-    {{% includeMarkdown "./tablespaces-platform.md" /%}}
+    {{% includeMarkdown "./tablespaces-platform.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/explore/ysql-language-features/going-beyond-sql/tablespaces.md
+++ b/docs/content/preview/explore/ysql-language-features/going-beyond-sql/tablespaces.md
@@ -71,10 +71,10 @@ The differences between single-zone, multi-zone and multi-region configuration b
 
 <div class="tab-content">
   <div id="yugabyted" class="tab-pane fade show active" role="tabpanel" aria-labelledby="yugabyted-tab">
-    {{% includeMarkdown "./tablespaces-yugabyted.md" %}}
+  {{% includeMarkdown "./tablespaces-yugabyted.md" %}}
   </div>
   <div id="platform" class="tab-pane fade show active" role="tabpanel" aria-labelledby="platform-tab">
-    {{% includeMarkdown "./tablespaces-platform.md" %}}
+  {{% includeMarkdown "./tablespaces-platform.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/quick-start/explore/ycql.md
+++ b/docs/content/preview/quick-start/explore/ycql.md
@@ -73,16 +73,16 @@ After [creating a local cluster](../../create-local-cluster/macos/), follow the 
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/explore-ycql.md" /%}}
+    {{% includeMarkdown "binary/explore-ycql.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/explore-ycql.md" /%}}
+    {{% includeMarkdown "binary/explore-ycql.md" %}}
   </div>
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/explore-ycql.md" /%}}
+    {{% includeMarkdown "docker/explore-ycql.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/explore-ycql.md" /%}}
+    {{% includeMarkdown "kubernetes/explore-ycql.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/quick-start/explore/ycql.md
+++ b/docs/content/preview/quick-start/explore/ycql.md
@@ -73,16 +73,16 @@ After [creating a local cluster](../../create-local-cluster/macos/), follow the 
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/explore-ycql.md" %}}
+  {{% includeMarkdown "binary/explore-ycql.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/explore-ycql.md" %}}
+  {{% includeMarkdown "binary/explore-ycql.md" %}}
   </div>
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/explore-ycql.md" %}}
+  {{% includeMarkdown "docker/explore-ycql.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/explore-ycql.md" %}}
+  {{% includeMarkdown "kubernetes/explore-ycql.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/quick-start/explore/ysql.md
+++ b/docs/content/preview/quick-start/explore/ysql.md
@@ -82,16 +82,16 @@ Using the YugabyteDB SQL shell, [ysqlsh](../../../admin/ysqlsh/), you can connec
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/explore-ysql.md" %}}
+  {{% includeMarkdown "binary/explore-ysql.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/explore-ysql.md" %}}
+  {{% includeMarkdown "binary/explore-ysql.md" %}}
   </div>
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/explore-ysql.md" %}}
+  {{% includeMarkdown "docker/explore-ysql.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/explore-ysql.md" %}}
+  {{% includeMarkdown "kubernetes/explore-ysql.md" %}}
   </div>
 </div>
 
@@ -234,7 +234,7 @@ UPDATE emp SET sal=sal+100
 ```
 
 ```output
- ename  | new_salary 
+ ename  | new_salary
 --------+------------
  SMITH  |        900
  ADAMS  |       1200
@@ -547,15 +547,15 @@ To send the e-mails to all employees in different batches, split them into three
 ```sql
 WITH groups AS (
     SELECT ntile(3) OVER (ORDER BY empno) group_num
-    ,* 
+    ,*
     FROM emp
 )
-SELECT string_agg(format('<%s> %s',ename,email),', ') 
+SELECT string_agg(format('<%s> %s',ename,email),', ')
 FROM groups GROUP BY group_num;
 ```
 
 ```output
-                                                          string_agg                                                           
+                                                          string_agg
 -------------------------------------------------------------------------------------------------------------------------------
  <ADAMS> ADAMS@acme.org, <JAMES> JAMES@acme.org, <FORD> FORD@acme.com, <MILLER> MILLER@acme.com
  <BLAKE> BLAKE@hotmail.com, <CLARK> CLARK@acme.com, <SCOTT> SCOTT@acme.com, <KING> KING@aol.com, <TURNER> TURNER@acme.com
@@ -833,7 +833,7 @@ To get fast on-demand reports, create a [materialized view](../../../explore/ysq
     ```
 
     ```output
-    deptno |   dname    | sal_per_dept | num_of_employees |       distinct_jobs       
+    deptno |   dname    | sal_per_dept | num_of_employees |       distinct_jobs
     --------+------------+--------------+------------------+---------------------------
         10 | ACCOUNTING |         8750 |                3 | CLERK, MANAGER, PRESIDENT
         30 | SALES      |         9400 |                6 | CLERK, MANAGER, SALESMAN
@@ -851,7 +851,7 @@ To get fast on-demand reports, create a [materialized view](../../../explore/ysq
     ```
 
     ```output
-                                                                        QUERY PLAN                                                                       
+                                                                        QUERY PLAN
     --------------------------------------------------------------------------------------------------------------------------------------------------------
     Index Scan Backward using report_sal_per_dept_sal on report_sal_per_dept  (cost=0.00..5.33 rows=10 width=84) (actual time=1.814..1.821 rows=2 loops=1)
     Index Cond: (sal_per_dept <= 10000)

--- a/docs/content/preview/quick-start/explore/ysql.md
+++ b/docs/content/preview/quick-start/explore/ysql.md
@@ -82,16 +82,16 @@ Using the YugabyteDB SQL shell, [ysqlsh](../../../admin/ysqlsh/), you can connec
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/explore-ysql.md" /%}}
+    {{% includeMarkdown "binary/explore-ysql.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/explore-ysql.md" /%}}
+    {{% includeMarkdown "binary/explore-ysql.md" %}}
   </div>
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/explore-ysql.md" /%}}
+    {{% includeMarkdown "docker/explore-ysql.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/explore-ysql.md" /%}}
+    {{% includeMarkdown "kubernetes/explore-ysql.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/yedis/quick-start/_index.md
+++ b/docs/content/preview/yedis/quick-start/_index.md
@@ -52,16 +52,16 @@ After [creating a local cluster](../../quick-start/create-local-cluster/), follo
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/test-yedis.md" /%}}
+    {{% includeMarkdown "binary/test-yedis.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/test-yedis.md" /%}}
+    {{% includeMarkdown "binary/test-yedis.md" %}}
   </div>
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/test-yedis.md" /%}}
+    {{% includeMarkdown "docker/test-yedis.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/test-yedis.md" /%}}
+    {{% includeMarkdown "kubernetes/test-yedis.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/yedis/quick-start/_index.md
+++ b/docs/content/preview/yedis/quick-start/_index.md
@@ -52,16 +52,16 @@ After [creating a local cluster](../../quick-start/create-local-cluster/), follo
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/test-yedis.md" %}}
+  {{% includeMarkdown "binary/test-yedis.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/test-yedis.md" %}}
+  {{% includeMarkdown "binary/test-yedis.md" %}}
   </div>
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/test-yedis.md" %}}
+  {{% includeMarkdown "docker/test-yedis.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/test-yedis.md" %}}
+  {{% includeMarkdown "kubernetes/test-yedis.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/yugabyte-cloud/cloud-connect/connect-client-shell.md
+++ b/docs/content/preview/yugabyte-cloud/cloud-connect/connect-client-shell.md
@@ -48,10 +48,10 @@ Use the ysqlsh and ycqlsh shells to connect to and interact with YuagbyteDB usin
 
 <div class="tab-content">
   <div id="ysqlsh" class="tab-pane fade show active" role="tabpanel" aria-labelledby="ysqlsh-tab">
-    {{% includeMarkdown "connect/ysql.md" %}}
+  {{% includeMarkdown "connect/ysql.md" %}}
   </div>
   <div id="ycqlsh" class="tab-pane fade" role="tabpanel" aria-labelledby="ycqlsh-tab">
-    {{% includeMarkdown "connect/ycql.md" %}}
+  {{% includeMarkdown "connect/ycql.md" %}}
   </div>
 </div>
 

--- a/docs/content/preview/yugabyte-cloud/cloud-connect/connect-client-shell.md
+++ b/docs/content/preview/yugabyte-cloud/cloud-connect/connect-client-shell.md
@@ -48,10 +48,10 @@ Use the ysqlsh and ycqlsh shells to connect to and interact with YuagbyteDB usin
 
 <div class="tab-content">
   <div id="ysqlsh" class="tab-pane fade show active" role="tabpanel" aria-labelledby="ysqlsh-tab">
-    {{% includeMarkdown "connect/ysql.md" /%}}
+    {{% includeMarkdown "connect/ysql.md" %}}
   </div>
   <div id="ycqlsh" class="tab-pane fade" role="tabpanel" aria-labelledby="ycqlsh-tab">
-    {{% includeMarkdown "connect/ycql.md" /%}}
+    {{% includeMarkdown "connect/ycql.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/exprs/aggregate_functions/invocation-syntax-semantics.md
+++ b/docs/content/stable/api/ysql/exprs/aggregate_functions/invocation-syntax-semantics.md
@@ -35,10 +35,10 @@ The following six diagrams, [`select_start`](../../../syntax_resources/grammar_d
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.diagram.md" %}}
   </div>
 </div>
 These rules govern the invocation of aggregate functions as `SELECT` list items.
@@ -66,10 +66,10 @@ When aggregate functions are invoked using the syntax specified by either the `o
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.diagram.md" %}}
   </div>
 </div>
 
@@ -92,10 +92,10 @@ The result set may be restricted by the `HAVING` clause:
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/exprs/aggregate_functions/invocation-syntax-semantics.md
+++ b/docs/content/stable/api/ysql/exprs/aggregate_functions/invocation-syntax-semantics.md
@@ -35,10 +35,10 @@ The following six diagrams, [`select_start`](../../../syntax_resources/grammar_d
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.diagram.md" %}}
   </div>
 </div>
 These rules govern the invocation of aggregate functions as `SELECT` list items.
@@ -66,10 +66,10 @@ When aggregate functions are invoked using the syntax specified by either the `o
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.diagram.md" %}}
   </div>
 </div>
 
@@ -92,10 +92,10 @@ The result set may be restricted by the `HAVING` clause:
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/exprs/window_functions/invocation-syntax-semantics.md
+++ b/docs/content/stable/api/ysql/exprs/window_functions/invocation-syntax-semantics.md
@@ -52,10 +52,10 @@ The following three diagrams, [`select_start`](../../../syntax_resources/grammar
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.diagram.md" %}}
   </div>
 </div>
 
@@ -82,10 +82,10 @@ A [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-defin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.diagram.md" %}}
   </div>
 </div>
 
@@ -108,10 +108,10 @@ A [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-defin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/exprs/window_functions/invocation-syntax-semantics.md
+++ b/docs/content/stable/api/ysql/exprs/window_functions/invocation-syntax-semantics.md
@@ -23,7 +23,7 @@ Notice these three different orthography styles:
 
 - `OVER` is a keyword that names a clause. You write such a keyword in a SQL statement.
 
-- [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-definition) is the name of a rule within the overall SQL grammar. You never type such a name in a SQL statement. It is written in bold lower case with underscores, as appropriate, between the English words. Because such a rule is always shown as a link, you can jump directly to the rule in the [Grammar Diagrams](../../../syntax_resources/grammar_diagrams/#abort) page. This page shows every single one of the SQL rules. It so happens that the [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-definition) rule starts with the keyword `WINDOW` and might therefore, according to the context of use, be referred to alternatively as the `WINDOW` clause. 
+- [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-definition) is the name of a rule within the overall SQL grammar. You never type such a name in a SQL statement. It is written in bold lower case with underscores, as appropriate, between the English words. Because such a rule is always shown as a link, you can jump directly to the rule in the [Grammar Diagrams](../../../syntax_resources/grammar_diagrams/#abort) page. This page shows every single one of the SQL rules. It so happens that the [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-definition) rule starts with the keyword `WINDOW` and might therefore, according to the context of use, be referred to alternatively as the `WINDOW` clause.
 
 - [_window frame_](./#frame-clause-semantics-for-window-functions) is a pure term of art. It is written in italic lower case with spaces, as appropriate, between the English words. You neither write it in a SQL statement nor use it to look up anything in the [Grammar Diagrams](../../../syntax_resources/grammar_diagrams/#abort) page. Because such a term of art is always shown as a link, you can jump directly to its definition within this _"Window function invocation—SQL syntax and semantics"_ page.
 
@@ -52,10 +52,10 @@ The following three diagrams, [`select_start`](../../../syntax_resources/grammar
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.diagram.md" %}}
   </div>
 </div>
 
@@ -82,10 +82,10 @@ A [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-defin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.diagram.md" %}}
   </div>
 </div>
 
@@ -108,10 +108,10 @@ A [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-defin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.diagram.md" %}}
   </div>
 </div>
 
@@ -182,7 +182,7 @@ The [`frame_clause`](../../../syntax_resources/grammar_diagrams/#frame-clause) s
 - The functions in the first group, [Window functions that return an "int" or "double precision" value as a "classifier" of the rank of the row within its window](../function-syntax-semantics/#window-functions-that-return-an-int-or-double-precision-value-as-a-classifier-of-the-rank-of-the-row-within-its-window), are not sensitive to what the [`frame_clause`](../../../syntax_resources/grammar_diagrams/#frame-clause) specifies and always use all of the rows in the current [_window_](./#the-window-definition-rule). Yugabyte recommends that you therefore omit the [`frame_clause`](../../../syntax_resources/grammar_diagrams/#frame-clause) in the `OVER` clause that you use to invoke these functions.
 
 - The functions in the second group, [Window functions that return columns of another row within the window](../function-syntax-semantics/#window-functions-that-return-column-s-of-another-row-within-the-window), make obvious sense when the scope within which the specified row is found is the entire [_window_](./#the-window-definition-rule). If you have one of the very rare use cases where the output that you want is produced by a different [`frame_clause`](../../../syntax_resources/grammar_diagrams/#frame-clause), then specify what you want explicitly. Otherwise, because it isn't the default, you must specify that the [_window frame_](./#frame-clause-semantics-for-window-functions) includes the entire current [_window_](./#the-window-definition-rule) like this:
-  
+
   ```
   range between unbounded preceding and unbounded following
   ```

--- a/docs/content/stable/api/ysql/the-sql-language/statements/cmd_analyze.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/cmd_analyze.md
@@ -46,10 +46,10 @@ To collect or update statistics, run the ANALYZE command manually.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/analyze,table_and_columns.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/analyze,table_and_columns.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/analyze,table_and_columns.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/analyze,table_and_columns.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/cmd_analyze.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/cmd_analyze.md
@@ -46,10 +46,10 @@ To collect or update statistics, run the ANALYZE command manually.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/analyze,table_and_columns.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/analyze,table_and_columns.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/analyze,table_and_columns.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/analyze,table_and_columns.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/cmd_call.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/cmd_call.md
@@ -34,10 +34,10 @@ Use the `CALL` statement to execute a stored procedure.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.diagram.md" %}}
   </div>
 </div>
 **Note:** The syntax and semantics of the `procedure_argument` (for example how to use the named parameter invocation style to avoid providing actual arguments for defaulted parameters) is the same for invoking a user-defined`FUNCTION`. A function cannot be invoked with the `CALL` statement. Rather, it's invoked as (part of) an expression in DML statements like `SELECT`.

--- a/docs/content/stable/api/ysql/the-sql-language/statements/cmd_call.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/cmd_call.md
@@ -34,10 +34,10 @@ Use the `CALL` statement to execute a stored procedure.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.diagram.md" %}}
   </div>
 </div>
 **Note:** The syntax and semantics of the `procedure_argument` (for example how to use the named parameter invocation style to avoid providing actual arguments for defaulted parameters) is the same for invoking a user-defined`FUNCTION`. A function cannot be invoked with the `CALL` statement. Rather, it's invoked as (part of) an expression in DML statements like `SELECT`.

--- a/docs/content/stable/api/ysql/the-sql-language/statements/cmd_copy.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/cmd_copy.md
@@ -34,10 +34,10 @@ Use the `COPY` statement to transfer data between tables and files. `COPY TO` co
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.diagram.md" %}}
   </div>
 </div>
 
@@ -59,7 +59,7 @@ Specify a `SELECT`, `VALUES`, `INSERT`, `UPDATE`, or `DELETE` statement whose re
 
 Specify the path of the file to be copied. An input file name can be an absolute or relative path, but an output file name must be an absolute path. Critically, the file must be located _server-side_ on the local filesystem of the YB-TServer that you connect to.
 
-To work with files that reside on the client, nominate `stdin` as the argument for `FROM` or `stdout` as the argument for `TO`.  
+To work with files that reside on the client, nominate `stdin` as the argument for `FROM` or `stdout` as the argument for `TO`.
 
 Alternatively, you can use the `\copy` metacommand in [`ysqlsh`](../../../../../admin/ysqlsh#copy-table-column-list-query-from-to-filename-program-command-stdin-stdout-pstdin-pstdout-with-option).
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/cmd_copy.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/cmd_copy.md
@@ -34,10 +34,10 @@ Use the `COPY` statement to transfer data between tables and files. `COPY TO` co
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/cmd_do.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/cmd_do.md
@@ -36,10 +36,10 @@ The optional `LANGUAGE` clause can be written either before or after the code bl
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/cmd_do.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/cmd_do.md
@@ -36,10 +36,10 @@ The optional `LANGUAGE` clause can be written either before or after the code bl
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/cmd_reset.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/cmd_reset.md
@@ -34,10 +34,10 @@ Use the `RESET` statement to restore the value of a run-time parameter to the de
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/cmd_reset.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/cmd_reset.md
@@ -34,10 +34,10 @@ Use the `RESET` statement to restore the value of a run-time parameter to the de
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/cmd_set.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/cmd_set.md
@@ -1,7 +1,7 @@
 ---
 title: SET statement [YSQL]
 headerTitle: SET
-linkTitle: SET 
+linkTitle: SET
 description: Use the SET statement to update a run-time control parameter.
 menu:
   stable:
@@ -34,10 +34,10 @@ Use the `SET` statement to update a run-time control parameter.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/cmd_set.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/cmd_set.md
@@ -34,10 +34,10 @@ Use the `SET` statement to update a run-time control parameter.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/cmd_show.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/cmd_show.md
@@ -34,10 +34,10 @@ Use the `SHOW` statement to display the value of a run-time parameter.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/cmd_show.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/cmd_show.md
@@ -34,10 +34,10 @@ Use the `SHOW` statement to display the value of a run-time parameter.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_alter_default_privileges.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_alter_default_privileges.md
@@ -34,10 +34,10 @@ Use the `ALTER DEFAULT PRIVILEGES` statement to define the default access privil
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_alter_default_privileges.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_alter_default_privileges.md
@@ -34,10 +34,10 @@ Use the `ALTER DEFAULT PRIVILEGES` statement to define the default access privil
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_alter_group.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_alter_group.md
@@ -35,10 +35,10 @@ This is added for compatibility with Postgres. Its usage is discouraged. [`ALTER
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_alter_group.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_alter_group.md
@@ -35,10 +35,10 @@ This is added for compatibility with Postgres. Its usage is discouraged. [`ALTER
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_alter_policy.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_alter_policy.md
@@ -35,10 +35,10 @@ change the roles that the policy applies to and the `USING` and `CHECK` expressi
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.diagram.md" %}}
   </div>
 </div>
 
@@ -49,11 +49,11 @@ Where
 - `new_name` is the new name of the policy.
 - `role_name` is the role(s) to which the policy applies. Use `PUBLIC` if the policy should be
   applied to all roles.
-- `using_expression` is a SQL conditional expression. Only rows for which the condition returns to   
-  true will be visible in a `SELECT` and available for modification in an `UPDATE` or `DELETE`.      
-- `check_expression` is a SQL conditional expression that is used only for `INSERT` and `UPDATE`     
-  queries. Only rows for which the expression evaluates to true will be allowed in an `INSERT` or    
-  `UPDATE`. Note that unlike `using_expression`, this is evaluated against the proposed new contents 
+- `using_expression` is a SQL conditional expression. Only rows for which the condition returns to
+  true will be visible in a `SELECT` and available for modification in an `UPDATE` or `DELETE`.
+- `check_expression` is a SQL conditional expression that is used only for `INSERT` and `UPDATE`
+  queries. Only rows for which the expression evaluates to true will be allowed in an `INSERT` or
+  `UPDATE`. Note that unlike `using_expression`, this is evaluated against the proposed new contents
   of the row.
 
 ## Examples

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_alter_policy.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_alter_policy.md
@@ -35,10 +35,10 @@ change the roles that the policy applies to and the `USING` and `CHECK` expressi
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_alter_role.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_alter_role.md
@@ -37,10 +37,10 @@ Other roles can only change their own password.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_alter_role.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_alter_role.md
@@ -37,10 +37,10 @@ Other roles can only change their own password.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_alter_user.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_alter_user.md
@@ -34,10 +34,10 @@ Use the `ALTER USER` statement to alter a role. `ALTER USER` is an alias for [`A
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_alter_user.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_alter_user.md
@@ -34,10 +34,10 @@ Use the `ALTER USER` statement to alter a role. `ALTER USER` is an alias for [`A
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_create_group.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_create_group.md
@@ -34,10 +34,10 @@ Use the `CREATE GROUP` statement to create a group role. `CREATE GROUP` is an al
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_create_group.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_create_group.md
@@ -34,10 +34,10 @@ Use the `CREATE GROUP` statement to create a group role. `CREATE GROUP` is an al
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_create_policy.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_create_policy.md
@@ -37,10 +37,10 @@ policies to take effect.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.diagram.md" %}}
   </div>
 </div>
 
@@ -51,7 +51,7 @@ Where
 - `table_name` is the name of the table that the policy applies to.
 - `PERMISSIVE` / `RESTRICTIVE` specifies that the policy is permissive or restrictive.
 While applying policies to a table, permissive policies are combined together using a logical OR operator,
-while restrictive policies are combined using logical AND operator. Restrictive policies are used to 
+while restrictive policies are combined using logical AND operator. Restrictive policies are used to
 reduce the number of records that can be accessed. Default is permissive.
 - `role_name` is the role(s) to which the policy is applied. Default is `PUBLIC` which applies the
   policy to all roles.

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_create_policy.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_create_policy.md
@@ -37,10 +37,10 @@ policies to take effect.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_create_role.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_create_role.md
@@ -40,10 +40,10 @@ You can use `GRANT`/`REVOKE` commands to set/remove permissions for roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_create_role.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_create_role.md
@@ -40,10 +40,10 @@ You can use `GRANT`/`REVOKE` commands to set/remove permissions for roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_create_user.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_create_user.md
@@ -34,10 +34,10 @@ Use the `CREATE USER` statement to create a user. The `CREATE USER` statement is
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_create_user.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_create_user.md
@@ -34,10 +34,10 @@ Use the `CREATE USER` statement to create a user. The `CREATE USER` statement is
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_drop_group.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_drop_group.md
@@ -33,10 +33,10 @@ Use the `DROP GROUP` statement to drop a role. `DROP GROUP` is an alias for [`DR
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_drop_group.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_drop_group.md
@@ -33,10 +33,10 @@ Use the `DROP GROUP` statement to drop a role. `DROP GROUP` is an alias for [`DR
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_drop_owned.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_drop_owned.md
@@ -35,10 +35,10 @@ Any privileges granted to the given roles on objects in the current database or 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_drop_owned.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_drop_owned.md
@@ -35,10 +35,10 @@ Any privileges granted to the given roles on objects in the current database or 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_drop_policy.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_drop_policy.md
@@ -36,10 +36,10 @@ deny all policy will be applied for the table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_drop_policy.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_drop_policy.md
@@ -36,10 +36,10 @@ deny all policy will be applied for the table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_drop_role.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_drop_role.md
@@ -34,10 +34,10 @@ Use the `DROP ROLE` statement to remove the specified roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_drop_role.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_drop_role.md
@@ -34,10 +34,10 @@ Use the `DROP ROLE` statement to remove the specified roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_drop_user.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_drop_user.md
@@ -34,10 +34,10 @@ Use the `DROP USER` statement to drop a user or role. `DROP USER` is an alias fo
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_drop_user.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_drop_user.md
@@ -34,10 +34,10 @@ Use the `DROP USER` statement to drop a user or role. `DROP USER` is an alias fo
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_grant.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_grant.md
@@ -34,10 +34,10 @@ Use the `GRANT` statement to grant access privileges on database objects as well
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_grant.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_grant.md
@@ -34,10 +34,10 @@ Use the `GRANT` statement to grant access privileges on database objects as well
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_reassign_owned.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_reassign_owned.md
@@ -34,10 +34,10 @@ Use the `REASSIGN OWNED` statement to change the ownership of database objects o
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_reassign_owned.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_reassign_owned.md
@@ -34,10 +34,10 @@ Use the `REASSIGN OWNED` statement to change the ownership of database objects o
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_revoke.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_revoke.md
@@ -34,10 +34,10 @@ Use the `REVOKE` statement to remove access privileges from one or more roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_revoke.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_revoke.md
@@ -34,10 +34,10 @@ Use the `REVOKE` statement to remove access privileges from one or more roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_set_role.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_set_role.md
@@ -34,10 +34,10 @@ Use the `SET ROLE` statement to set the current user of the current session to b
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_set_role.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_set_role.md
@@ -34,10 +34,10 @@ Use the `SET ROLE` statement to set the current user of the current session to b
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_set_session_authorization.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_set_session_authorization.md
@@ -34,10 +34,10 @@ Use the `SET SESSION AUTHORIZATION` statement to set the current user and sessio
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dcl_set_session_authorization.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dcl_set_session_authorization.md
@@ -34,10 +34,10 @@ Use the `SET SESSION AUTHORIZATION` statement to set the current user and sessio
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_alter_db.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_alter_db.md
@@ -34,10 +34,10 @@ Use the `ALTER DATABASE` statement to redefine the attributes of a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_alter_db.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_alter_db.md
@@ -34,10 +34,10 @@ Use the `ALTER DATABASE` statement to redefine the attributes of a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_alter_domain.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_alter_domain.md
@@ -34,10 +34,10 @@ Use the `ALTER DOMAIN` statement to change the definition of a domain.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_alter_domain.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_alter_domain.md
@@ -34,10 +34,10 @@ Use the `ALTER DOMAIN` statement to change the definition of a domain.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_alter_sequence.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_alter_sequence.md
@@ -34,10 +34,10 @@ Use the `ALTER SEQUENCE` statement to change the definition of a sequence in the
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_alter_sequence.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_alter_sequence.md
@@ -34,10 +34,10 @@ Use the `ALTER SEQUENCE` statement to change the definition of a sequence in the
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_alter_table.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_alter_table.md
@@ -34,10 +34,10 @@ Use the `ALTER TABLE` statement to change the definition of a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint,table_expr.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint,table_expr.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint,table_expr.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint,table_expr.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_alter_table.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_alter_table.md
@@ -34,10 +34,10 @@ Use the `ALTER TABLE` statement to change the definition of a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint,table_expr.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint,table_expr.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint,table_expr.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint,table_expr.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_comment.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_comment.md
@@ -34,10 +34,10 @@ Use the `COMMENT` statement to set, update, or remove a comment on a database ob
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_comment.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_comment.md
@@ -34,10 +34,10 @@ Use the `COMMENT` statement to set, update, or remove a comment on a database ob
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_aggregate.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_aggregate.md
@@ -35,10 +35,10 @@ create aggregates.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_aggregate.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_aggregate.md
@@ -35,10 +35,10 @@ create aggregates.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_cast.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_cast.md
@@ -34,10 +34,10 @@ Use the `CREATE CAST` statement to create a cast.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_cast.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_cast.md
@@ -34,10 +34,10 @@ Use the `CREATE CAST` statement to create a cast.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_database.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_database.md
@@ -34,10 +34,10 @@ Use the `CREATE DATABASE` statement to create a database that functions as a gro
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_database.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_database.md
@@ -34,10 +34,10 @@ Use the `CREATE DATABASE` statement to create a database that functions as a gro
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_domain.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_domain.md
@@ -34,10 +34,10 @@ Use the `CREATE DOMAIN` statement to create a user-defined data type with option
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_domain.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_domain.md
@@ -34,10 +34,10 @@ Use the `CREATE DOMAIN` statement to create a user-defined data type with option
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_extension.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_extension.md
@@ -35,10 +35,10 @@ Use the `CREATE EXTENSION` statement to load an extension into a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_extension.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_extension.md
@@ -35,10 +35,10 @@ Use the `CREATE EXTENSION` statement to load an extension into a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_function.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_function.md
@@ -34,10 +34,10 @@ Use the `CREATE FUNCTION` statement to create a function in a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl,function_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl,function_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl,function_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl,function_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_function.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_function.md
@@ -34,10 +34,10 @@ Use the `CREATE FUNCTION` statement to create a function in a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl,function_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl,function_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl,function_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl,function_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.diagram.md" %}}
   </div>
 </div>
 
@@ -47,14 +47,14 @@ Use the `CREATE FUNCTION` statement to create a function in a database.
 
 - The languages supported by default are `sql`, `plpgsql` and `C`.
 
-- `VOLATILE`, `STABLE` and `IMMUTABLE` inform the query optimizer about the behavior the function. 
+- `VOLATILE`, `STABLE` and `IMMUTABLE` inform the query optimizer about the behavior the function.
     - `VOLATILE` is the default and indicates that the function result could be different for every call. For instance `random()` or `now()`.
     - `STABLE` indicates that the function cannot modify the database so that within a single scan it will return the same result given the same arguments.
     - `IMMUTABLE` indicates that the function cannot modify the database _and_ always returns the same results given the same arguments.
 
 - `CALLED ON NULL INPUT`, `RETURNS NULL ON NULL INPUT` and `STRICT` define the function's behavior with respect to 'null's.
     - `CALLED ON NULL INPUT` indicates that input arguments may be `null`.
-    - `RETURNS NULL ON NULL INPUT` or `STRICT` indicate that the function always returns `null` if any of its arguments are `null`. 
+    - `RETURNS NULL ON NULL INPUT` or `STRICT` indicate that the function always returns `null` if any of its arguments are `null`.
 
 ## Examples
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_index.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_index.md
@@ -34,10 +34,10 @@ Use the `CREATE INDEX` statement to create an index on the specified columns of 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_index.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_index.md
@@ -34,10 +34,10 @@ Use the `CREATE INDEX` statement to create an index on the specified columns of 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_matview.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_matview.md
@@ -34,10 +34,10 @@ Use the `CREATE MATERIALIZED VIEW` statement to create a materialized view.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_matview.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_matview.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_matview.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_matview.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_matview.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_matview.md
@@ -34,10 +34,10 @@ Use the `CREATE MATERIALIZED VIEW` statement to create a materialized view.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_matview.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_matview.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_matview.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_matview.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_operator.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_operator.md
@@ -34,10 +34,10 @@ Use the `CREATE OPERATOR` statement to create an operator.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_operator.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_operator.md
@@ -34,10 +34,10 @@ Use the `CREATE OPERATOR` statement to create an operator.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_operator_class.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_operator_class.md
@@ -34,10 +34,10 @@ Use the `CREATE OPERATOR CLASS` statement to create an operator class.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_operator_class.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_operator_class.md
@@ -34,10 +34,10 @@ Use the `CREATE OPERATOR CLASS` statement to create an operator class.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_procedure.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_procedure.md
@@ -34,10 +34,10 @@ Use the `CREATE PROCEDURE` statement to create a procedure in a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl,procedure_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl,procedure_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl,procedure_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl,procedure_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_procedure.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_procedure.md
@@ -34,10 +34,10 @@ Use the `CREATE PROCEDURE` statement to create a procedure in a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl,procedure_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl,procedure_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl,procedure_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl,procedure_attribute,security_kind,lang_name,implementation_definition,sql_stmt_list.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_rule.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_rule.md
@@ -34,10 +34,10 @@ Use the `CREATE RULE` statement to create a rule.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_rule.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_rule.md
@@ -34,10 +34,10 @@ Use the `CREATE RULE` statement to create a rule.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_schema.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_schema.md
@@ -36,10 +36,10 @@ Named objects in a schema can be accessed by using the schema name as prefix or 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_schema.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_schema.md
@@ -36,10 +36,10 @@ Named objects in a schema can be accessed by using the schema name as prefix or 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_sequence.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_sequence.md
@@ -34,10 +34,10 @@ Use the `CREATE SEQUENCE` statement to create a sequence in the current schema.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_sequence.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_sequence.md
@@ -34,10 +34,10 @@ Use the `CREATE SEQUENCE` statement to create a sequence in the current schema.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.diagram.md" %}}
   </div>
 </div>
 
@@ -55,7 +55,7 @@ The sequence name must be distinct from any other sequences, tables, indexes, vi
 
 #### INCREMENT BY *increment*
 
-Specify the *increment* value to add to the current sequence value to create a new value. The default value is `1`. A positive number 
+Specify the *increment* value to add to the current sequence value to create a new value. The default value is `1`. A positive number
 
 #### MINVALUE *minvalue* | NO MINVALUE
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_table.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_table.md
@@ -34,10 +34,10 @@ Use the `CREATE TABLE` statement to create a table in a database. It defines the
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_table.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_table.md
@@ -34,10 +34,10 @@ Use the `CREATE TABLE` statement to create a table in a database. It defines the
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_table_as.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_table_as.md
@@ -34,10 +34,10 @@ Use the `CREATE TABLE AS` statement to create a table using the output of a subq
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_table_as.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_table_as.md
@@ -34,10 +34,10 @@ Use the `CREATE TABLE AS` statement to create a table using the output of a subq
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_trigger.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_trigger.md
@@ -34,16 +34,16 @@ Use the `CREATE TRIGGER` statement to create a trigger.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.diagram.md" %}}
   </div>
 </div>
 
 ## Semantics
 
-- the `WHEN` condition can be used to specify whether the trigger should be fired. For low-level triggers it can reference the old and/or new values of the row's columns. 
+- the `WHEN` condition can be used to specify whether the trigger should be fired. For low-level triggers it can reference the old and/or new values of the row's columns.
 - multiple triggers can be defined for the same event. In that case, they will be fired in alphabetical order by name.
 
 ## Examples

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_trigger.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_trigger.md
@@ -34,10 +34,10 @@ Use the `CREATE TRIGGER` statement to create a trigger.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_type.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_type.md
@@ -34,10 +34,10 @@ Use the `CREATE TYPE` statement to create a user-defined type in a database.  Th
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_type.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_type.md
@@ -34,10 +34,10 @@ Use the `CREATE TYPE` statement to create a user-defined type in a database.  Th
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_view.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_view.md
@@ -34,10 +34,10 @@ Use the `CREATE VIEW` statement to create a view in a database. It defines the v
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_view.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_view.md
@@ -2,7 +2,7 @@
 title: CREATE VIEW statement [YSQL]
 headerTitle: CREATE VIEW
 linkTitle: CREATE VIEW
-description: Use the CREATE VIEW statement to create a view in a database. 
+description: Use the CREATE VIEW statement to create a view in a database.
 menu:
   stable:
     identifier: ddl_create_view
@@ -13,7 +13,7 @@ showAsideToc: true
 
 ## Synopsis
 
-Use the `CREATE VIEW` statement to create a view in a database. It defines the view name and the (select) statement defining it.  
+Use the `CREATE VIEW` statement to create a view in a database. It defines the view name and the (select) statement defining it.
 
 ## Syntax
 
@@ -34,10 +34,10 @@ Use the `CREATE VIEW` statement to create a view in a database. It defines the v
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_aggregate.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_aggregate.md
@@ -34,10 +34,10 @@ Use the `DROP AGGREGATE` statement to remove an aggregate.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_aggregate.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_aggregate.md
@@ -34,10 +34,10 @@ Use the `DROP AGGREGATE` statement to remove an aggregate.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_cast.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_cast.md
@@ -34,10 +34,10 @@ Use the `DROP CAST` statement to remove a cast.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_cast.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_cast.md
@@ -34,10 +34,10 @@ Use the `DROP CAST` statement to remove a cast.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_database.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_database.md
@@ -34,10 +34,10 @@ Use the `DROP DATABASE` statement to remove a database and all of its associated
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_database.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_database.md
@@ -2,7 +2,7 @@
 title: DROP DATABASE statement [YSQL]
 headerTitle: DROP DATABASE
 linkTitle: DROP DATABASE
-description: Use the DROP DATABASE statement to remove a database and all of its associated objects from the system. 
+description: Use the DROP DATABASE statement to remove a database and all of its associated objects from the system.
 menu:
   stable:
     identifier: ddl_drop_database
@@ -34,10 +34,10 @@ Use the `DROP DATABASE` statement to remove a database and all of its associated
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_domain.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_domain.md
@@ -34,10 +34,10 @@ Use the `DROP DOMAIN` statement to remove a domain from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_domain.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_domain.md
@@ -34,10 +34,10 @@ Use the `DROP DOMAIN` statement to remove a domain from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_extension.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_extension.md
@@ -35,10 +35,10 @@ Use the `DROP EXTENSION` statement to remove an extension from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_extension.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_extension.md
@@ -35,10 +35,10 @@ Use the `DROP EXTENSION` statement to remove an extension from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_function.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_function.md
@@ -34,10 +34,10 @@ Use the `DROP FUNCTION` statement to remove a function from a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_function.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_function.md
@@ -34,10 +34,10 @@ Use the `DROP FUNCTION` statement to remove a function from a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_matview.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_matview.md
@@ -34,10 +34,10 @@ Use the `DROP MATERIALIZED VIEW` statement to drop a materialized view.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_matview.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_matview.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_matview.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_matview.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_matview.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_matview.md
@@ -34,10 +34,10 @@ Use the `DROP MATERIALIZED VIEW` statement to drop a materialized view.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_matview.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_matview.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_matview.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_matview.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_operator.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_operator.md
@@ -34,10 +34,10 @@ Use the `DROP OPERATOR` statement to remove an operator.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_operator.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_operator.md
@@ -34,10 +34,10 @@ Use the `DROP OPERATOR` statement to remove an operator.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_operator_class.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_operator_class.md
@@ -34,10 +34,10 @@ Use the `DROP OPERATOR CLASS` statement to remove an operator class.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_operator_class.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_operator_class.md
@@ -34,10 +34,10 @@ Use the `DROP OPERATOR CLASS` statement to remove an operator class.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_procedure.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_procedure.md
@@ -34,10 +34,10 @@ Use the `DROP PROCEDURE` statement to remove a procedure from a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_procedure.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_procedure.md
@@ -34,10 +34,10 @@ Use the `DROP PROCEDURE` statement to remove a procedure from a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_rule.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_rule.md
@@ -34,10 +34,10 @@ Use the `DROP RULE` statement to remove a rule.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_rule.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_rule.md
@@ -34,10 +34,10 @@ Use the `DROP RULE` statement to remove a rule.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_sequence.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_sequence.md
@@ -34,10 +34,10 @@ Use the `DROP SEQUENCE` statement to delete a sequence in the current schema.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_sequence.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_sequence.md
@@ -34,10 +34,10 @@ Use the `DROP SEQUENCE` statement to delete a sequence in the current schema.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_table.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_table.md
@@ -34,10 +34,10 @@ Use the `DROP TABLE` statement to remove one or more tables (with all of their d
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_table.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_table.md
@@ -34,10 +34,10 @@ Use the `DROP TABLE` statement to remove one or more tables (with all of their d
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_trigger.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_trigger.md
@@ -34,10 +34,10 @@ Use the `DROP TRIGGER` statement to remove a trigger from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_trigger.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_trigger.md
@@ -34,10 +34,10 @@ Use the `DROP TRIGGER` statement to remove a trigger from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_type.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_type.md
@@ -34,10 +34,10 @@ Use the `DROP TYPE` statement to remove a user-defined type from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_type.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_type.md
@@ -34,10 +34,10 @@ Use the `DROP TYPE` statement to remove a user-defined type from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_refresh_matview.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_refresh_matview.md
@@ -34,10 +34,10 @@ Use the `REFRESH MATERIALIZED VIEW` statement to replace the contents of a mater
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/refresh_matview.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/refresh_matview.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/refresh_matview.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/refresh_matview.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_refresh_matview.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_refresh_matview.md
@@ -34,16 +34,16 @@ Use the `REFRESH MATERIALIZED VIEW` statement to replace the contents of a mater
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/refresh_matview.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/refresh_matview.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/refresh_matview.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/refresh_matview.diagram.md" %}}
   </div>
 </div>
 
 ## Semantics
 
-Replace the contents of a materialized view named *matview_name*. 
+Replace the contents of a materialized view named *matview_name*.
 
 ### WITH DATA
 If `WITH DATA` (default) is specified, the view's query is executed to obtain the new data and the materialized view's contents are updated.
@@ -52,7 +52,7 @@ If `WITH DATA` (default) is specified, the view's query is executed to obtain th
 If `WITH NO DATA` is specified, the old contents of the materialized view are discarded and the materialized view is left in an unscannable state.
 
 ### CONCURRENTLY
-This option may be faster in the cases where a small number of rows require updates. Without this option, a refresh that updates a large number of rows will tend to use fewer resources and complete quicker. 
+This option may be faster in the cases where a small number of rows require updates. Without this option, a refresh that updates a large number of rows will tend to use fewer resources and complete quicker.
 This option is only permitted when there is at least one UNIQUE index on the materialized view, and when the materialized view is populated.
 `CONCURRENTLY` AND `WITH NO DATA` cannot be used together. Moreover, the `CONCURRENTLY` option can also not be used when there are rows where _all_ the columns are null. In both scenarios, refreshing the materialized view will raise an error.
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_truncate.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_truncate.md
@@ -36,10 +36,10 @@ Applying `TRUNCATE` to a set of tables produces the same ultimate outcome as doe
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_truncate.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_truncate.md
@@ -36,10 +36,10 @@ Applying `TRUNCATE` to a set of tables produces the same ultimate outcome as doe
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.diagram.md" %}}
   </div>
 </div>
 
@@ -100,7 +100,7 @@ order by p.k, c.k;
 This is the result:
 
 ```output
- parents.v |  children.v  
+ parents.v |  children.v
 -----------+--------------
  dog       | dog-child-a
  dog       | dog-child-b
@@ -159,7 +159,7 @@ select
 The `truncate` statement now finishes without error. This is the result:
 
 ```
- parents count | children count 
+ parents count | children count
 ---------------+----------------
              0 |              0
 ```

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dml_delete.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dml_delete.md
@@ -34,10 +34,10 @@ Use the `DELETE` statement to remove rows that meet certain conditions, and when
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dml_delete.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dml_delete.md
@@ -34,10 +34,10 @@ Use the `DELETE` statement to remove rows that meet certain conditions, and when
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.diagram.md" %}}
   </div>
 </div>
 
@@ -53,7 +53,7 @@ See the section [The WITH clause and common table expressions](../../with-clause
 
 - While the `WHERE` clause allows a wide range of operators, the exact conditions used in the `WHERE` clause have significant performance considerations (especially for large datasets). For the best performance, use a `WHERE` clause that provides values for all columns in `PRIMARY KEY` or `INDEX KEY`.
 
-### *delete* 
+### *delete*
 
 #### WITH [ RECURSIVE ] *with_query* [ , ... ] DELETE FROM [ ONLY ] *table_name* [ * ] [ [ AS ] *alias* ] [ WHERE *condition* | WHERE CURRENT OF *cursor_name* ] [ [*returning_clause*] (#returning-clause) ]
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dml_insert.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dml_insert.md
@@ -34,10 +34,10 @@ Use the `INSERT` statement to add one or more rows to the specified table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.diagram.md" %}}
   </div>
 </div>
 
@@ -45,7 +45,7 @@ See the section [The WITH clause and common table expressions](../../with-clause
 
 ## Semantics
 
-Constraints must be satisfied.  
+Constraints must be satisfied.
 
 ### *insert*
 
@@ -236,7 +236,7 @@ yugabyte=# SELECT id, c1, c2 FROM sample ORDER BY id;
 ```
 
 ```
- id |   c1   |    c2     
+ id |   c1   |    c2
 ----+--------+-----------
   1 | cat    | sparrow
   2 | dog    | blackbird

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dml_insert.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dml_insert.md
@@ -34,10 +34,10 @@ Use the `INSERT` statement to add one or more rows to the specified table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dml_select.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dml_select.md
@@ -36,10 +36,10 @@ The same syntax rules govern a subquery, wherever you might use one—like, for 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dml_select.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dml_select.md
@@ -36,10 +36,10 @@ The same syntax rules govern a subquery, wherever you might use one—like, for 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dml_update.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dml_update.md
@@ -34,10 +34,10 @@ Use the `UPDATE` statement to modify the values of specified columns in all rows
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dml_update.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dml_update.md
@@ -34,10 +34,10 @@ Use the `UPDATE` statement to modify the values of specified columns in all rows
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dml_values.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dml_values.md
@@ -34,10 +34,10 @@ Use the `VALUES` statement to generate a row set specified as an explicitly writ
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.diagram.md" %}}
   </div>
 </div>
 
@@ -53,7 +53,7 @@ values ('dog'::text);
 This is the result:
 
 ```
- column1 
+ column1
 ---------
  dog
 ```
@@ -68,7 +68,7 @@ values
 This is the result:
 
 ```
- column1 |       column2       | column3 
+ column1 |       column2       | column3
 ---------+---------------------+---------
        1 | 2019-06-25 12:05:30 | dog
        2 | 2020-07-30 13:10:45 | cat
@@ -117,7 +117,7 @@ select chr(v) as c from (
 This is the result:
 
 ```
- c 
+ c
 ---
  a
  b
@@ -137,7 +137,7 @@ select chr(v) as c from (
 This is the result:
 
 ```
- c 
+ c
 ---
  d
  o

--- a/docs/content/stable/api/ysql/the-sql-language/statements/dml_values.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dml_values.md
@@ -34,10 +34,10 @@ Use the `VALUES` statement to generate a row set specified as an explicitly writ
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/perf_deallocate.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/perf_deallocate.md
@@ -34,10 +34,10 @@ Use the `DEALLOCATE` statement to deallocate a previously prepared SQL statement
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.diagram.md" %}}
   </div>
 </div>
 
@@ -60,7 +60,7 @@ yugabyte=# CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1,
 ```
 
 ```plpgsql
-yugabyte=# PREPARE ins (bigint, double precision, int, text) AS 
+yugabyte=# PREPARE ins (bigint, double precision, int, text) AS
                INSERT INTO sample(k1, k2, v1, v2) VALUES ($1, $2, $3, $4);
 ```
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/perf_deallocate.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/perf_deallocate.md
@@ -34,10 +34,10 @@ Use the `DEALLOCATE` statement to deallocate a previously prepared SQL statement
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/perf_execute.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/perf_execute.md
@@ -34,10 +34,10 @@ Use the `EXECUTE` statement to execute a previously prepared statement. This sep
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/perf_execute.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/perf_execute.md
@@ -2,7 +2,7 @@
 title: EXECUTE statement [YSQL]
 headerTitle: EXECUTE
 linkTitle: EXECUTE
-description: Use the EXECUTE statement to execute a previously prepared statement. 
+description: Use the EXECUTE statement to execute a previously prepared statement.
 menu:
   stable:
     identifier: perf_execute
@@ -34,10 +34,10 @@ Use the `EXECUTE` statement to execute a previously prepared statement. This sep
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.diagram.md" %}}
   </div>
 </div>
 
@@ -62,7 +62,7 @@ yugabyte=# CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1,
 - Prepare a simple insert.
 
 ```plpgsql
-yugabyte=# PREPARE ins (bigint, double precision, int, text) AS 
+yugabyte=# PREPARE ins (bigint, double precision, int, text) AS
                INSERT INTO sample(k1, k2, v1, v2) VALUES ($1, $2, $3, $4);
 ```
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/perf_explain.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/perf_explain.md
@@ -34,10 +34,10 @@ Use the `EXPLAIN` statement to show the execution plan for an statement. If the 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/perf_explain.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/perf_explain.md
@@ -34,10 +34,10 @@ Use the `EXPLAIN` statement to show the execution plan for an statement. If the 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/perf_prepare.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/perf_prepare.md
@@ -34,10 +34,10 @@ Use the `PREPARE` statement to create a handle to a prepared statement by parsin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.diagram.md" %}}
   </div>
 </div>
 
@@ -57,7 +57,7 @@ yugabyte=# CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1,
 Prepare a simple insert.
 
 ```plpgsql
-yugabyte=# PREPARE ins (bigint, double precision, int, text) AS 
+yugabyte=# PREPARE ins (bigint, double precision, int, text) AS
                INSERT INTO sample(k1, k2, v1, v2) VALUES ($1, $2, $3, $4);
 ```
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/perf_prepare.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/perf_prepare.md
@@ -34,10 +34,10 @@ Use the `PREPARE` statement to create a handle to a prepared statement by parsin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/savepoint_create.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/savepoint_create.md
@@ -34,10 +34,10 @@ Use the `SAVEPOINT` statement to define a new savepoint within the current trans
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_create.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_create.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_create.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_create.diagram.md" %}}
   </div>
 </div>
 
@@ -77,7 +77,7 @@ SELECT * FROM sample;
 ```
 
 ```output
- k  | v  
+ k  | v
 ----+----
   1 |  2
   3 |  4
@@ -92,7 +92,7 @@ SELECT * FROM sample;
 ```
 
 ```output
- k  | v  
+ k  | v
 ----+----
   1 |  2
 (1 row)
@@ -107,7 +107,7 @@ SELECT * FROM SAMPLE;
 ```
 
 ```output
- k  | v  
+ k  | v
 ----+----
   1 |  2
   5 |  6

--- a/docs/content/stable/api/ysql/the-sql-language/statements/savepoint_create.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/savepoint_create.md
@@ -34,10 +34,10 @@ Use the `SAVEPOINT` statement to define a new savepoint within the current trans
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_create.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_create.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_create.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_create.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/savepoint_release.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/savepoint_release.md
@@ -34,10 +34,10 @@ Use the `RELEASE SAVEPOINT` statement to release the server-side state associate
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_release.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_release.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_release.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_release.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/savepoint_release.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/savepoint_release.md
@@ -34,10 +34,10 @@ Use the `RELEASE SAVEPOINT` statement to release the server-side state associate
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_release.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_release.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_release.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_release.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/savepoint_rollback.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/savepoint_rollback.md
@@ -34,10 +34,10 @@ Use the `ROLLBACK TO SAVEPOINT` statement to revert the state of the transaction
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_rollback.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_rollback.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_rollback.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_rollback.diagram.md" %}}
   </div>
 </div>
 
@@ -107,7 +107,7 @@ SELECT * FROM sample;
 ```
 
 ```output
- k  | v  
+ k  | v
 ----+----
   1 |  2
   3 |  4

--- a/docs/content/stable/api/ysql/the-sql-language/statements/savepoint_rollback.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/savepoint_rollback.md
@@ -34,10 +34,10 @@ Use the `ROLLBACK TO SAVEPOINT` statement to revert the state of the transaction
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_rollback.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_rollback.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_rollback.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_rollback.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/txn_abort.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/txn_abort.md
@@ -34,10 +34,10 @@ Use the `ABORT` statement to roll back the current transaction and discards all 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/txn_abort.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/txn_abort.md
@@ -34,10 +34,10 @@ Use the `ABORT` statement to roll back the current transaction and discards all 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.diagram.md" %}}
   </div>
 </div>
 
@@ -66,7 +66,7 @@ yugabyte=# CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1,
 Begin a transaction and insert some rows.
 
 ```plpgsql
-yugabyte=# BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
+yugabyte=# BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 ```
 
 ```plpgsql

--- a/docs/content/stable/api/ysql/the-sql-language/statements/txn_begin.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/txn_begin.md
@@ -34,10 +34,10 @@ Use the `BEGIN` statement to start a transaction with the default (or given) iso
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.diagram.md" %}}
   </div>
 </div>
 
@@ -74,7 +74,7 @@ CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1, k2));
 Begin a transaction and insert some rows.
 
 ```plpgsql
-BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
+BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 ```
 
 ```plpgsql
@@ -84,7 +84,7 @@ INSERT INTO sample(k1, k2, v1, v2) VALUES (1, 2.0, 3, 'a'), (1, 3.0, 4, 'b');
 Start a new shell  with `ysqlsh` and begin another transaction to insert some more rows.
 
 ```plpgsql
-BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
+BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 ```
 
 ```plpgsql

--- a/docs/content/stable/api/ysql/the-sql-language/statements/txn_begin.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/txn_begin.md
@@ -34,10 +34,10 @@ Use the `BEGIN` statement to start a transaction with the default (or given) iso
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/txn_commit.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/txn_commit.md
@@ -34,10 +34,10 @@ Use the `COMMIT` statement to commit the current transaction. All changes made b
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.diagram.md" %}}
   </div>
 </div>
 
@@ -68,7 +68,7 @@ CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1, k2));
 Begin a transaction and insert some rows.
 
 ```plpgsql
-BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
+BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 ```
 
 ```plpgsql
@@ -78,7 +78,7 @@ INSERT INTO sample(k1, k2, v1, v2) VALUES (1, 2.0, 3, 'a'), (1, 3.0, 4, 'b');
 Start a new shell  with `ysqlsh` and begin another transaction to insert some more rows.
 
 ```plpgsql
-yugabyte=# BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
+yugabyte=# BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 ```
 
 ```plpgsql

--- a/docs/content/stable/api/ysql/the-sql-language/statements/txn_commit.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/txn_commit.md
@@ -34,10 +34,10 @@ Use the `COMMIT` statement to commit the current transaction. All changes made b
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/txn_end.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/txn_end.md
@@ -34,10 +34,10 @@ Use the `END` statement to commit the current transaction. All changes made by t
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/txn_end.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/txn_end.md
@@ -34,10 +34,10 @@ Use the `END` statement to commit the current transaction. All changes made by t
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/txn_lock.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/txn_lock.md
@@ -34,10 +34,10 @@ Use the `LOCK` statement to lock a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/txn_lock.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/txn_lock.md
@@ -34,10 +34,10 @@ Use the `LOCK` statement to lock a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/txn_rollback.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/txn_rollback.md
@@ -34,10 +34,10 @@ Use the `ROLLBACK` statement to roll back the current transactions. All changes 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/txn_rollback.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/txn_rollback.md
@@ -34,10 +34,10 @@ Use the `ROLLBACK` statement to roll back the current transactions. All changes 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/txn_set.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/txn_set.md
@@ -35,10 +35,10 @@ Use the `SET TRANSACTION` statement to set the current transaction isolation lev
 
 <div class="tab-content"> 
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/txn_set.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/txn_set.md
@@ -33,12 +33,12 @@ Use the `SET TRANSACTION` statement to set the current transaction isolation lev
   </li>
 </ul>
 
-<div class="tab-content"> 
+<div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/txn_set_constraints.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/txn_set_constraints.md
@@ -35,10 +35,10 @@ Use the `SET CONSTRAINTS` statement to set the timing of constraint checking wit
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/txn_set_constraints.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/txn_set_constraints.md
@@ -35,10 +35,10 @@ Use the `SET CONSTRAINTS` statement to set the timing of constraint checking wit
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/txn_show.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/txn_show.md
@@ -35,10 +35,10 @@ Use the `SHOW TRANSACTION` statement to show the current transaction isolation l
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/txn_show.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/txn_show.md
@@ -35,10 +35,10 @@ Use the `SHOW TRANSACTION` statement to show the current transaction isolation l
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/with-clause/recursive-cte.md
+++ b/docs/content/stable/api/ysql/the-sql-language/with-clause/recursive-cte.md
@@ -63,7 +63,7 @@ Notice that the parentheses that surround the _non-recursive term_ and the _recu
 This is the result:
 
 ```
- n 
+ n
 ---
  1
  2
@@ -95,10 +95,10 @@ The `WITH` clause syntax (see the section [WITH clause—SQL syntax and semantic
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.diagram.md" %}}
   </div>
 </div>
 
@@ -142,7 +142,7 @@ order by n desc;
 This is the result:
 
 ```
- n  
+ n
 ----
  99
  42
@@ -193,7 +193,7 @@ a1(n) as (
 then the statement executes without error to produce this result:
 
 ```
- n  
+ n
 ----
  99
   5
@@ -234,7 +234,7 @@ select n from r order by n;
 Notice that this is simply a _syntax_ example. Using `WITH` clauses within the recursive and non-recursive terms brings no value. The statement executes without error and produces this result:
 
 ```
- n 
+ n
 ---
  1
  2
@@ -306,7 +306,7 @@ select n from r order by n;
 This is the results:
 
 ```
- n 
+ n
 ---
  1
  2
@@ -339,15 +339,15 @@ A compact, and exact, formulation is given by using pseudocode. The _final_resul
 > - **while the _previous_results_ table is not empty loop**
 >
 >   - **Purge the _temp_results_ table.**
->   
+>
 >   - **Evaluate the recursive term using the current contents of the _previous_results_ table for the recursive self-reference, inserting the resulting rows into the _temp_results_ table.**
->   
+>
 >   - **Purge the _previous_results_ table and insert the contents of the _temp_results_ table.**
->   
+>
 >   - **Append the contents of the _temp_results_ table into the _final_results_ table.**
->   
+>
 >- **end loop**
-> 
+>
 >- **Deliver the present contents of the _final_results_ table so that whatever follows the recursive CTE can use them.**
 
 ### PL/pgSQL procedure implementation of the pseudocode : example 1
@@ -436,24 +436,24 @@ select c1, c2 from r order by c1, c2;
 This is the result:
 
 ```
- c1 | c2 
+ c1 | c2
 ----+----
   0 |  1
   0 |  2
   0 |  3
-  
+
   1 |  2
   1 |  3
   1 |  4
-  
+
   2 |  3
   2 |  4
   2 |  5
-  
+
   3 |  4
   3 |  5
   3 |  6
-  
+
   4 |  5
   4 |  6
   4 |  7

--- a/docs/content/stable/api/ysql/the-sql-language/with-clause/recursive-cte.md
+++ b/docs/content/stable/api/ysql/the-sql-language/with-clause/recursive-cte.md
@@ -95,10 +95,10 @@ The `WITH` clause syntax (see the section [WITH clause—SQL syntax and semantic
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/api/ysql/the-sql-language/with-clause/with-clause-syntax-semantics.md
+++ b/docs/content/stable/api/ysql/the-sql-language/with-clause/with-clause-syntax-semantics.md
@@ -33,10 +33,10 @@ The [with_clause](../../../syntax_resources/grammar_diagrams/#with-clause)  and 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.diagram.md" %}}
   </div>
 </div>
 
@@ -92,7 +92,7 @@ order by 1, 2;
 This is the result:
 
 ```
- name | k | v  
+ name | k | v
 ------+---+----
  t1   | 1 |  2
  t1   | 2 |  4
@@ -108,16 +108,16 @@ This is the result:
 Now execute the example query. Notice that the `WITH` clause defines an `INSERT` CTE, an `UPDATE` CTE, a `DELETE` CTE, and a `SELECT` CTE. Each of the data-changing CTEs has a `RETURNING` clause; and the `SELECT` CTE accesses the unions returned by each of these.
 
 ```plpgsql
-with 
+with
   i as (
     insert into t1(k, v) values (21, 17), (31, 42) returning k, v),
-    
+
   u as (
     update t2 set v = 99 where k in (4, 5) returning k, v),
-    
+
   d as (
     delete from t3 where k in (8, 9) returning k, v),
-    
+
   s as (
     select 'inserted into t1'::text as action, k, v from i
     union all
@@ -131,7 +131,7 @@ select action, k, v from s order by k;
 This is the result:
 
 ```
-      action      | k  | v  
+      action      | k  | v
 ------------------+----+----
  udated in t2     |  4 | 99
  udated in t2     |  5 | 99
@@ -155,7 +155,7 @@ order by 1, 2;
 This is the result:
 
 ```
- name | k  | v  
+ name | k  | v
 ------+----+----
  t1   |  1 |  2
  t1   |  2 |  4
@@ -198,7 +198,7 @@ select k, v from t1 order by k;
 This is the result:
 
 ```
- k  | v  
+ k  | v
 ----+----
   1 |  2
   2 |  4
@@ -241,7 +241,7 @@ from colliding;
 This is the result:
 
 ```
-      colliding      
+      colliding
 ---------------------
  goodbye—Hello world
 ```

--- a/docs/content/stable/api/ysql/the-sql-language/with-clause/with-clause-syntax-semantics.md
+++ b/docs/content/stable/api/ysql/the-sql-language/with-clause/with-clause-syntax-semantics.md
@@ -33,10 +33,10 @@ The [with_clause](../../../syntax_resources/grammar_diagrams/#with-clause)  and 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/benchmark/tpcc-ysql/_index.md
+++ b/docs/content/stable/benchmark/tpcc-ysql/_index.md
@@ -105,16 +105,16 @@ Other options like username, password, port, etc. can be changed using the confi
 
 <div class="tab-content">
   <div id="10-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="10-wh-tab">
-    {{% includeMarkdown "10-wh/tpcc-ysql.md" /%}}
+    {{% includeMarkdown "10-wh/tpcc-ysql.md" %}}
   </div>
   <div id="100-wh" class="tab-pane fade show active" role="tabpanel" aria-labelledby="100-wh-tab">
-    {{% includeMarkdown "100-wh/tpcc-ysql.md" /%}}
+    {{% includeMarkdown "100-wh/tpcc-ysql.md" %}}
   </div>
   <div id="1000-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="1000-wh-tab">
-    {{% includeMarkdown "1000-wh/tpcc-ysql.md" /%}}
+    {{% includeMarkdown "1000-wh/tpcc-ysql.md" %}}
   </div>
   <div id="10000-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="10000-wh-tab">
-    {{% includeMarkdown "10000-wh/tpcc-ysql.md" /%}}
+    {{% includeMarkdown "10000-wh/tpcc-ysql.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/benchmark/tpcc-ysql/_index.md
+++ b/docs/content/stable/benchmark/tpcc-ysql/_index.md
@@ -105,16 +105,16 @@ Other options like username, password, port, etc. can be changed using the confi
 
 <div class="tab-content">
   <div id="10-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="10-wh-tab">
-    {{% includeMarkdown "10-wh/tpcc-ysql.md" %}}
+  {{% includeMarkdown "10-wh/tpcc-ysql.md" %}}
   </div>
   <div id="100-wh" class="tab-pane fade show active" role="tabpanel" aria-labelledby="100-wh-tab">
-    {{% includeMarkdown "100-wh/tpcc-ysql.md" %}}
+  {{% includeMarkdown "100-wh/tpcc-ysql.md" %}}
   </div>
   <div id="1000-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="1000-wh-tab">
-    {{% includeMarkdown "1000-wh/tpcc-ysql.md" %}}
+  {{% includeMarkdown "1000-wh/tpcc-ysql.md" %}}
   </div>
   <div id="10000-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="10000-wh-tab">
-    {{% includeMarkdown "10000-wh/tpcc-ysql.md" %}}
+  {{% includeMarkdown "10000-wh/tpcc-ysql.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/develop/explore-sample-apps.md
+++ b/docs/content/stable/develop/explore-sample-apps.md
@@ -46,15 +46,15 @@ After running Yugastore, Yugabyte recommend running the [IoT Fleet Management](.
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/run-sample-apps.md" /%}}
+    {{% includeMarkdown "binary/run-sample-apps.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/run-sample-apps.md" /%}}
+    {{% includeMarkdown "binary/run-sample-apps.md" %}}
   </div>
    <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/run-sample-apps.md" /%}}
+    {{% includeMarkdown "docker/run-sample-apps.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/run-sample-apps.md" /%}}
+    {{% includeMarkdown "kubernetes/run-sample-apps.md" %}}
   </div>
 </div>

--- a/docs/content/stable/develop/explore-sample-apps.md
+++ b/docs/content/stable/develop/explore-sample-apps.md
@@ -46,15 +46,15 @@ After running Yugastore, Yugabyte recommend running the [IoT Fleet Management](.
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/run-sample-apps.md" %}}
+  {{% includeMarkdown "binary/run-sample-apps.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/run-sample-apps.md" %}}
+  {{% includeMarkdown "binary/run-sample-apps.md" %}}
   </div>
    <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/run-sample-apps.md" %}}
+  {{% includeMarkdown "docker/run-sample-apps.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/run-sample-apps.md" %}}
+  {{% includeMarkdown "kubernetes/run-sample-apps.md" %}}
   </div>
 </div>

--- a/docs/content/stable/explore/ysql-language-features/going-beyond-sql/tablespaces.md
+++ b/docs/content/stable/explore/ysql-language-features/going-beyond-sql/tablespaces.md
@@ -69,10 +69,10 @@ The differences between single-zone, multi-zone and multi-region configuration b
 
 <div class="tab-content">
   <div id="yugabyted" class="tab-pane fade show active" role="tabpanel" aria-labelledby="yugabyted-tab">
-    {{% includeMarkdown "./tablespaces-yugabyted.md" /%}}
+    {{% includeMarkdown "./tablespaces-yugabyted.md" %}}
   </div>
   <div id="platform" class="tab-pane fade show active" role="tabpanel" aria-labelledby="platform-tab">
-    {{% includeMarkdown "./tablespaces-platform.md" /%}}
+    {{% includeMarkdown "./tablespaces-platform.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/explore/ysql-language-features/going-beyond-sql/tablespaces.md
+++ b/docs/content/stable/explore/ysql-language-features/going-beyond-sql/tablespaces.md
@@ -69,10 +69,10 @@ The differences between single-zone, multi-zone and multi-region configuration b
 
 <div class="tab-content">
   <div id="yugabyted" class="tab-pane fade show active" role="tabpanel" aria-labelledby="yugabyted-tab">
-    {{% includeMarkdown "./tablespaces-yugabyted.md" %}}
+  {{% includeMarkdown "./tablespaces-yugabyted.md" %}}
   </div>
   <div id="platform" class="tab-pane fade show active" role="tabpanel" aria-labelledby="platform-tab">
-    {{% includeMarkdown "./tablespaces-platform.md" %}}
+  {{% includeMarkdown "./tablespaces-platform.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/quick-start/explore/ycql.md
+++ b/docs/content/stable/quick-start/explore/ycql.md
@@ -68,16 +68,16 @@ After [creating a local cluster](../../create-local-cluster/macos/), follow the 
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/explore-ycql.md" /%}}
+    {{% includeMarkdown "binary/explore-ycql.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/explore-ycql.md" /%}}
+    {{% includeMarkdown "binary/explore-ycql.md" %}}
   </div> 
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/explore-ycql.md" /%}}
+    {{% includeMarkdown "docker/explore-ycql.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/explore-ycql.md" /%}}
+    {{% includeMarkdown "kubernetes/explore-ycql.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/quick-start/explore/ycql.md
+++ b/docs/content/stable/quick-start/explore/ycql.md
@@ -30,7 +30,7 @@ showAsideToc: true
       YCQL
     </a>
   </li>
-  
+
 </ul>
 
 After [creating a local cluster](../../create-local-cluster/macos/), follow the instructions below to explore YugabyteDB's semi-relational [Yugabyte Cloud QL](../../../api/ycql/) API.
@@ -68,16 +68,16 @@ After [creating a local cluster](../../create-local-cluster/macos/), follow the 
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/explore-ycql.md" %}}
+  {{% includeMarkdown "binary/explore-ycql.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/explore-ycql.md" %}}
-  </div> 
+  {{% includeMarkdown "binary/explore-ycql.md" %}}
+  </div>
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/explore-ycql.md" %}}
+  {{% includeMarkdown "docker/explore-ycql.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/explore-ycql.md" %}}
+  {{% includeMarkdown "kubernetes/explore-ycql.md" %}}
   </div>
 </div>
 

--- a/docs/content/stable/quick-start/explore/ysql.md
+++ b/docs/content/stable/quick-start/explore/ysql.md
@@ -1,6 +1,6 @@
 ---
 title: Explore YSQL, the Yugabyte SQL API
-headerTitle: 3. Explore Yugabyte SQL 
+headerTitle: 3. Explore Yugabyte SQL
 linkTitle: 3. Explore distributed SQL APIs
 description: Explore Yugabyte SQL (YSQL), a PostgreSQL-compatible fully-relational distributed SQL API
 image: /images/section_icons/quick_start/explore_ysql.png
@@ -30,7 +30,7 @@ showAsideToc: true
       YCQL
     </a>
   </li>
-  
+
 </ul>
 
 After [creating a local cluster](../../create-local-cluster/macos/), you can start exploring YugabyteDB's PostgreSQL-compatible, fully-relational [Yugabyte SQL API](../../../api/ysql/).
@@ -78,16 +78,16 @@ The following files are used:
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/explore-ysql.md" %}}
+  {{% includeMarkdown "binary/explore-ysql.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/explore-ysql.md" %}}
+  {{% includeMarkdown "binary/explore-ysql.md" %}}
   </div>
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/explore-ysql.md" %}}
+  {{% includeMarkdown "docker/explore-ysql.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/explore-ysql.md" %}}
+  {{% includeMarkdown "kubernetes/explore-ysql.md" %}}
   </div>
 </div>
 
@@ -132,17 +132,17 @@ You should see an output like the following:
 
 ```output
                                         Table "public.products"
-   Column   |            Type             | Collation | Nullable |               Default                
+   Column   |            Type             | Collation | Nullable |               Default
 ------------+-----------------------------+-----------+----------+--------------------------------------
  id         | bigint                      |           | not null | nextval('products_id_seq'::regclass)
- created_at | timestamp without time zone |           |          | 
- category   | text                        |           |          | 
- ean        | text                        |           |          | 
- price      | double precision            |           |          | 
+ created_at | timestamp without time zone |           |          |
+ category   | text                        |           |          |
+ ean        | text                        |           |          |
+ price      | double precision            |           |          |
  quantity   | integer                     |           |          | 5000
- rating     | double precision            |           |          | 
- title      | text                        |           |          | 
- vendor     | text                        |           |          | 
+ rating     | double precision            |           |          |
+ title      | text                        |           |          |
+ vendor     | text                        |           |          |
 Indexes:
     "products_pkey" PRIMARY KEY, lsm (id HASH)
 ```
@@ -173,7 +173,7 @@ yb_demo=# SELECT id, title, category, price, rating
 You should see output like the following:
 
 ```output
- id  |           title            | category |      price       | rating 
+ id  |           title            | category |      price       | rating
 -----+----------------------------+----------+------------------+--------
   22 | Enormous Marble Shoes      | Gizmo    | 21.4245199604423 |    4.2
   38 | Lightweight Leather Gloves | Gadget   | 44.0462485589292 |    3.8
@@ -194,7 +194,7 @@ yb_demo=# SELECT id, title, category, price, rating
 You should see an output which looks like the following:
 
 ```output
- id  |           title           | category  |      price       | rating 
+ id  |           title           | category  |      price       | rating
 -----+---------------------------+-----------+------------------+--------
  152 | Enormous Aluminum Clock   | Widget    | 32.5971248660044 |    3.6
    3 | Synergistic Granite Chair | Doohickey | 35.3887448815391 |      4
@@ -264,7 +264,7 @@ VALUES (
   (SELECT max(id)+1 FROM orders)                 /* id */,
   now()                                          /* created_at */,
   1                                              /* user_id */,
-  2                                              /* product_id */, 
+  2                                              /* product_id */,
   0                                              /* discount */,
   10                                             /* quantity */,
   (10 * (SELECT price FROM products WHERE id=2)) /* subtotal */,
@@ -285,7 +285,7 @@ yb_demo=# select * from orders where id = (select max(id) from orders);
 ```
 
 ```output
-  id   |         created_at         | user_id | product_id | discount | quantity |     subtotal     | tax |      total       
+  id   |         created_at         | user_id | product_id | discount | quantity |     subtotal     | tax |      total
 -------+----------------------------+---------+------------+----------+----------+------------------+-----+------------------
  18761 | 2020-01-30 09:24:29.784078 |       1 |          2 |        0 |       10 | 700.798961307176 |   0 | 700.798961307176
 (1 row)
@@ -421,7 +421,7 @@ yb_demo=# \d
 ```
 
 ```plpgsql
-yb_demo=# SELECT source, 
+yb_demo=# SELECT source,
             total_sales * 100.0 / (SELECT SUM(total_sales) FROM channel) AS percent_sales
           FROM channel
           WHERE source='Facebook';

--- a/docs/content/stable/quick-start/explore/ysql.md
+++ b/docs/content/stable/quick-start/explore/ysql.md
@@ -78,16 +78,16 @@ The following files are used:
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/explore-ysql.md" /%}}
+    {{% includeMarkdown "binary/explore-ysql.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/explore-ysql.md" /%}}
+    {{% includeMarkdown "binary/explore-ysql.md" %}}
   </div>
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/explore-ysql.md" /%}}
+    {{% includeMarkdown "docker/explore-ysql.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/explore-ysql.md" /%}}
+    {{% includeMarkdown "kubernetes/explore-ysql.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/exprs/aggregate_functions/invocation-syntax-semantics.md
+++ b/docs/content/v2.4/api/ysql/exprs/aggregate_functions/invocation-syntax-semantics.md
@@ -35,10 +35,10 @@ The following six diagrams, [`select_start`](../../../syntax_resources/grammar_d
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.diagram.md" %}}
   </div>
 </div>
 These rules govern the invocation of aggregate functions as `SELECT` list items.
@@ -66,10 +66,10 @@ When aggregate functions are invoked using the syntax specified by either the `o
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.diagram.md" %}}
   </div>
 </div>
 
@@ -92,10 +92,10 @@ The result set may be restricted by the `HAVING` clause:
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/exprs/aggregate_functions/invocation-syntax-semantics.md
+++ b/docs/content/v2.4/api/ysql/exprs/aggregate_functions/invocation-syntax-semantics.md
@@ -35,10 +35,10 @@ The following six diagrams, [`select_start`](../../../syntax_resources/grammar_d
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.diagram.md" %}}
   </div>
 </div>
 These rules govern the invocation of aggregate functions as `SELECT` list items.
@@ -66,10 +66,10 @@ When aggregate functions are invoked using the syntax specified by either the `o
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.diagram.md" %}}
   </div>
 </div>
 
@@ -92,10 +92,10 @@ The result set may be restricted by the `HAVING` clause:
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.diagram.md" %}}
   </div>
 </div>
 
@@ -135,7 +135,7 @@ order by class;
 It produces this result:
 
 ```
- class | array_agg(v) | string_agg(v) |    jsonb_agg    |  jsonb_object_agg(v, k)  
+ class | array_agg(v) | string_agg(v) |    jsonb_agg    |  jsonb_object_agg(v, k)
 -------+--------------+---------------+-----------------+--------------------------
      1 | {c,b,a}      | c ~ b ~ a     | ["c", "b", "a"] | {"a": 1, "b": 2, "c": 3}
      2 | {f,e,d}      | f ~ e ~ d     | ["f", "e", "d"] | {"d": 4, "e": 5, "f": 6}
@@ -158,7 +158,7 @@ from t;
 This is the result:
 
 ```
- string_agg(v) without f | string_agg(v) without a 
+ string_agg(v) without f | string_agg(v) without a
 -------------------------+-------------------------
  a ~ b ~ c ~ d ~ e       | f ~ e ~ d ~ c ~ b
 ```
@@ -197,7 +197,7 @@ select k, class, v from t order by class, v nulls last, k;
 This is the result:
 
 ```
- k  | class |   v    
+ k  | class |   v
 ----+-------+--------
   1 |     1 | a
   2 |     1 | b
@@ -231,7 +231,7 @@ order by class;
 This is the result:
 
 ```
- class | k mode | v mode 
+ class | k mode | v mode
 -------+--------+--------
      1 |     11 | e
      2 |     15 | f
@@ -253,7 +253,7 @@ from t;
 This is the result:
 
 ```
- expr-1 mode | expr-2 mode 
+ expr-1 mode | expr-2 mode
 -------------+-------------
  ex          | <null>
 ```
@@ -297,7 +297,7 @@ as a;
 This is the result:
 
 ```
- number of resulting rows 
+ number of resulting rows
 --------------------------
                      1536
 ```
@@ -370,7 +370,7 @@ select k, class, v from t order by k;
 This is the result:
 
 ```
- k  | class |   v    
+ k  | class |   v
 ----+-------+--------
   1 |     1 |    100
   2 |     1 |    101
@@ -411,7 +411,7 @@ order by class;
 This is the result:
 
 ```
- class | count 
+ class | count
 -------+-------
      2 |     5
 ```
@@ -453,7 +453,7 @@ with a as (
   group by class)
 select class, count
 from a
-where count > 4  
+where count > 4
 order by class;
 ```
 

--- a/docs/content/v2.4/api/ysql/exprs/window_functions/invocation-syntax-semantics.md
+++ b/docs/content/v2.4/api/ysql/exprs/window_functions/invocation-syntax-semantics.md
@@ -52,10 +52,10 @@ The following three diagrams, [`select_start`](../../../syntax_resources/grammar
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.diagram.md" %}}
   </div>
 </div>
 
@@ -82,10 +82,10 @@ A [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-defin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.diagram.md" %}}
   </div>
 </div>
 
@@ -108,10 +108,10 @@ A [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-defin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/exprs/window_functions/invocation-syntax-semantics.md
+++ b/docs/content/v2.4/api/ysql/exprs/window_functions/invocation-syntax-semantics.md
@@ -23,7 +23,7 @@ Notice these three different orthography styles:
 
 - `OVER` is a keyword that names a clause. You write such a keyword in a SQL statement.
 
-- [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-definition) is the name of a rule within the overall SQL grammar. You never type such a name in a SQL statement. It is written in bold lower case with underscores, as appropriate, between the English words. Because such a rule is always shown as a link, you can jump directly to the rule in the [Grammar Diagrams](../../../syntax_resources/grammar_diagrams/#abort) page. This page shows every single one of the SQL rules. It so happens that the [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-definition) rule starts with the keyword `WINDOW` and might therefore, according to the context of use, be referred to alternatively as the `WINDOW` clause. 
+- [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-definition) is the name of a rule within the overall SQL grammar. You never type such a name in a SQL statement. It is written in bold lower case with underscores, as appropriate, between the English words. Because such a rule is always shown as a link, you can jump directly to the rule in the [Grammar Diagrams](../../../syntax_resources/grammar_diagrams/#abort) page. This page shows every single one of the SQL rules. It so happens that the [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-definition) rule starts with the keyword `WINDOW` and might therefore, according to the context of use, be referred to alternatively as the `WINDOW` clause.
 
 - [_window frame_](./#frame-clause-semantics-for-window-functions) is a pure term of art. It is written in italic lower case with spaces, as appropriate, between the English words. You neither write it in a SQL statement nor use it to look up anything in the [Grammar Diagrams](../../../syntax_resources/grammar_diagrams/#abort) page. Because such a term of art is always shown as a link, you can jump directly to its definition within this _"Window function invocation—SQL syntax and semantics"_ page.
 
@@ -52,10 +52,10 @@ The following three diagrams, [`select_start`](../../../syntax_resources/grammar
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.diagram.md" %}}
   </div>
 </div>
 
@@ -82,10 +82,10 @@ A [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-defin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.diagram.md" %}}
   </div>
 </div>
 
@@ -108,10 +108,10 @@ A [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-defin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.diagram.md" %}}
   </div>
 </div>
 
@@ -182,7 +182,7 @@ The [`frame_clause`](../../../syntax_resources/grammar_diagrams/#frame-clause) s
 - The functions in the first group, [Window functions that return an "int" or "double precision" value as a "classifier" of the rank of the row within its window](../function-syntax-semantics/#window-functions-that-return-an-int-or-double-precision-value-as-a-classifier-of-the-rank-of-the-row-within-its-window), are not sensitive to what the [`frame_clause`](../../../syntax_resources/grammar_diagrams/#frame-clause) specifies and always use all of the rows in the current [_window_](./#the-window-definition-rule). Yugabyte recommends that you therefore omit the [`frame_clause`](../../../syntax_resources/grammar_diagrams/#frame-clause) in the `OVER` clause that you use to invoke these functions.
 
 - The functions in the second group, [Window functions that return columns of another row within the window](../function-syntax-semantics/#window-functions-that-return-column-s-of-another-row-within-the-window), make obvious sense when the scope within which the specified row is found is the entire [_window_](./#the-window-definition-rule). If you have one of the very rare use cases where the output that you want is produced by a different [`frame_clause`](../../../syntax_resources/grammar_diagrams/#frame-clause), then specify what you want explicitly. Otherwise, because it isn't the default, you must specify that the [_window frame_](./#frame-clause-semantics-for-window-functions) includes the entire current [_window_](./#the-window-definition-rule) like this:
-  
+
   ```
   range between unbounded preceding and unbounded following
   ```

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/cmd_call.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/cmd_call.md
@@ -34,10 +34,10 @@ Use the `CALL` statement to execute a stored procedure.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.diagram.md" %}}
   </div>
 </div>
 **Note:** The syntax and semantics of the `procedure_argument` (for example how to use the named parameter invocation style to avoid providing actual arguments for defaulted parameters) is the same for invoking a user-defined`FUNCTION`. A function cannot be invoked with the `CALL` statement. Rather, it's invoked as (part of) an expression in DML statements like `SELECT`.

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/cmd_call.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/cmd_call.md
@@ -34,10 +34,10 @@ Use the `CALL` statement to execute a stored procedure.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.diagram.md" %}}
   </div>
 </div>
 **Note:** The syntax and semantics of the `procedure_argument` (for example how to use the named parameter invocation style to avoid providing actual arguments for defaulted parameters) is the same for invoking a user-defined`FUNCTION`. A function cannot be invoked with the `CALL` statement. Rather, it's invoked as (part of) an expression in DML statements like `SELECT`.
@@ -194,7 +194,7 @@ call x(10, 20, 30, 40, 50);
 This is the result:
 
 ```
- a  | b  | c  | d  | e  
+ a  | b  | c  | d  | e
 ----+----+----+----+----
  11 | 22 | 33 | 44 | 55
 ```

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/cmd_copy.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/cmd_copy.md
@@ -34,10 +34,10 @@ Use the `COPY` statement to transfer data between tables and files. `COPY TO` co
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.diagram.md" %}}
   </div>
 </div>
 
@@ -59,7 +59,7 @@ Specify a `SELECT`, `VALUES`, `INSERT`, `UPDATE`, or `DELETE` statement whose re
 
 Specify the path of the file to be copied. An input file name can be an absolute or relative path, but an output file name must be an absolute path. Critically, the file must be located _server-side_ on the local filesystem of the YB-TServer that you connect to.
 
-To work with files that reside on the client, nominate `stdin` as the argument for `FROM` or `stdout` as the argument for `TO`.  
+To work with files that reside on the client, nominate `stdin` as the argument for `FROM` or `stdout` as the argument for `TO`.
 
 Alternatively, you can use the `\copy` metacommand in [`ysqlsh`](../../../../../admin/ysqlsh#copy-table-column-list-query-from-to-filename-program-command-stdin-stdout-pstdin-pstdout-with-option).
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/cmd_copy.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/cmd_copy.md
@@ -34,10 +34,10 @@ Use the `COPY` statement to transfer data between tables and files. `COPY TO` co
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/cmd_do.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/cmd_do.md
@@ -36,10 +36,10 @@ The optional `LANGUAGE` clause can be written either before or after the code bl
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/cmd_do.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/cmd_do.md
@@ -36,10 +36,10 @@ The optional `LANGUAGE` clause can be written either before or after the code bl
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/cmd_reset.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/cmd_reset.md
@@ -34,10 +34,10 @@ Use the `RESET` statement to restore the value of a run-time parameter to the de
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/cmd_reset.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/cmd_reset.md
@@ -34,10 +34,10 @@ Use the `RESET` statement to restore the value of a run-time parameter to the de
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/cmd_set.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/cmd_set.md
@@ -1,7 +1,7 @@
 ---
 title: SET statement [YSQL]
 headerTitle: SET
-linkTitle: SET 
+linkTitle: SET
 description: Use the SET statement to update a run-time control parameter.
 menu:
   v2.4:
@@ -34,10 +34,10 @@ Use the `SET` statement to update a run-time control parameter.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/cmd_set.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/cmd_set.md
@@ -34,10 +34,10 @@ Use the `SET` statement to update a run-time control parameter.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/cmd_show.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/cmd_show.md
@@ -34,10 +34,10 @@ Use the `SHOW` statement to display the value of a run-time parameter.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/cmd_show.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/cmd_show.md
@@ -34,10 +34,10 @@ Use the `SHOW` statement to display the value of a run-time parameter.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_alter_default_privileges.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_alter_default_privileges.md
@@ -34,10 +34,10 @@ Use the `ALTER DEFAULT PRIVILEGES` statement to define the default access privil
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_alter_default_privileges.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_alter_default_privileges.md
@@ -34,10 +34,10 @@ Use the `ALTER DEFAULT PRIVILEGES` statement to define the default access privil
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_alter_group.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_alter_group.md
@@ -35,10 +35,10 @@ This is added for compatibility with Postgres. Its usage is discouraged. [`ALTER
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_alter_group.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_alter_group.md
@@ -35,10 +35,10 @@ This is added for compatibility with Postgres. Its usage is discouraged. [`ALTER
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_alter_policy.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_alter_policy.md
@@ -35,10 +35,10 @@ change the roles that the policy applies to and the `USING` and `CHECK` expressi
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.diagram.md" %}}
   </div>
 </div>
 
@@ -49,11 +49,11 @@ Where
 - `new_name` is the new name of the policy.
 - `role_name` is the role(s) to which the policy applies. Use `PUBLIC` if the policy should be
   applied to all roles.
-- `using_expression` is a SQL conditional expression. Only rows for which the condition returns to   
-  true will be visible in a `SELECT` and available for modification in an `UPDATE` or `DELETE`.      
-- `check_expression` is a SQL conditional expression that is used only for `INSERT` and `UPDATE`     
-  queries. Only rows for which the expression evaluates to true will be allowed in an `INSERT` or    
-  `UPDATE`. Note that unlike `using_expression`, this is evaluated against the proposed new contents 
+- `using_expression` is a SQL conditional expression. Only rows for which the condition returns to
+  true will be visible in a `SELECT` and available for modification in an `UPDATE` or `DELETE`.
+- `check_expression` is a SQL conditional expression that is used only for `INSERT` and `UPDATE`
+  queries. Only rows for which the expression evaluates to true will be allowed in an `INSERT` or
+  `UPDATE`. Note that unlike `using_expression`, this is evaluated against the proposed new contents
   of the row.
 
 ## Examples

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_alter_policy.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_alter_policy.md
@@ -35,10 +35,10 @@ change the roles that the policy applies to and the `USING` and `CHECK` expressi
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_alter_role.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_alter_role.md
@@ -37,10 +37,10 @@ Other roles can only change their own password.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_alter_role.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_alter_role.md
@@ -37,10 +37,10 @@ Other roles can only change their own password.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_alter_user.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_alter_user.md
@@ -34,10 +34,10 @@ Use the `ALTER USER` statement to alter a role. `ALTER USER` is an alias for [`A
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_alter_user.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_alter_user.md
@@ -34,10 +34,10 @@ Use the `ALTER USER` statement to alter a role. `ALTER USER` is an alias for [`A
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_create_group.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_create_group.md
@@ -34,10 +34,10 @@ Use the `CREATE GROUP` statement to create a group role. `CREATE GROUP` is an al
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_create_group.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_create_group.md
@@ -34,10 +34,10 @@ Use the `CREATE GROUP` statement to create a group role. `CREATE GROUP` is an al
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_create_policy.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_create_policy.md
@@ -37,10 +37,10 @@ policies to take effect.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.diagram.md" %}}
   </div>
 </div>
 
@@ -51,7 +51,7 @@ Where
 - `table_name` is the name of the table that the policy applies to.
 - `PERMISSIVE` / `RESTRICTIVE` specifies that the policy is permissive or restrictive.
 While applying policies to a table, permissive policies are combined together using a logical OR operator,
-while restrictive policies are combined using logical AND operator. Restrictive policies are used to 
+while restrictive policies are combined using logical AND operator. Restrictive policies are used to
 reduce the number of records that can be accessed. Default is permissive.
 - `role_name` is the role(s) to which the policy is applied. Default is `PUBLIC` which applies the
   policy to all roles.

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_create_policy.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_create_policy.md
@@ -37,10 +37,10 @@ policies to take effect.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_create_role.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_create_role.md
@@ -40,10 +40,10 @@ You can use `GRANT`/`REVOKE` commands to set/remove permissions for roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_create_role.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_create_role.md
@@ -40,10 +40,10 @@ You can use `GRANT`/`REVOKE` commands to set/remove permissions for roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_create_user.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_create_user.md
@@ -34,10 +34,10 @@ Use the `CREATE USER` statement to create a user. The `CREATE USER` statement is
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_create_user.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_create_user.md
@@ -34,10 +34,10 @@ Use the `CREATE USER` statement to create a user. The `CREATE USER` statement is
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_drop_group.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_drop_group.md
@@ -33,10 +33,10 @@ Use the `DROP GROUP` statement to drop a role. `DROP GROUP` is an alias for [`DR
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_drop_group.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_drop_group.md
@@ -33,10 +33,10 @@ Use the `DROP GROUP` statement to drop a role. `DROP GROUP` is an alias for [`DR
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_drop_owned.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_drop_owned.md
@@ -35,10 +35,10 @@ Any privileges granted to the given roles on objects in the current database or 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_drop_owned.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_drop_owned.md
@@ -35,10 +35,10 @@ Any privileges granted to the given roles on objects in the current database or 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_drop_policy.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_drop_policy.md
@@ -36,10 +36,10 @@ deny all policy will be applied for the table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_drop_policy.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_drop_policy.md
@@ -36,10 +36,10 @@ deny all policy will be applied for the table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_drop_role.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_drop_role.md
@@ -34,10 +34,10 @@ Use the `DROP ROLE` statement to remove the specified roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_drop_role.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_drop_role.md
@@ -34,10 +34,10 @@ Use the `DROP ROLE` statement to remove the specified roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_drop_user.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_drop_user.md
@@ -34,10 +34,10 @@ Use the `DROP USER` statement to drop a user or role. `DROP USER` is an alias fo
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_drop_user.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_drop_user.md
@@ -34,10 +34,10 @@ Use the `DROP USER` statement to drop a user or role. `DROP USER` is an alias fo
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_grant.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_grant.md
@@ -34,10 +34,10 @@ Use the `GRANT` statement to grant access privileges on database objects as well
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_grant.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_grant.md
@@ -34,10 +34,10 @@ Use the `GRANT` statement to grant access privileges on database objects as well
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_reassign_owned.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_reassign_owned.md
@@ -34,10 +34,10 @@ Use the `REASSIGN OWNED` statement to change the ownership of database objects o
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_reassign_owned.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_reassign_owned.md
@@ -34,10 +34,10 @@ Use the `REASSIGN OWNED` statement to change the ownership of database objects o
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_revoke.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_revoke.md
@@ -34,10 +34,10 @@ Use the `REVOKE` statement to remove access privileges from one or more roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_revoke.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_revoke.md
@@ -34,10 +34,10 @@ Use the `REVOKE` statement to remove access privileges from one or more roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_set_role.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_set_role.md
@@ -34,10 +34,10 @@ Use the `SET ROLE` statement to set the current user of the current session to b
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_set_role.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_set_role.md
@@ -34,10 +34,10 @@ Use the `SET ROLE` statement to set the current user of the current session to b
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_set_session_authorization.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_set_session_authorization.md
@@ -34,10 +34,10 @@ Use the `SET SESSION AUTHORIZATION` statement to set the current user and sessio
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_set_session_authorization.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dcl_set_session_authorization.md
@@ -34,10 +34,10 @@ Use the `SET SESSION AUTHORIZATION` statement to set the current user and sessio
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_alter_db.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_alter_db.md
@@ -34,10 +34,10 @@ Use the `ALTER DATABASE` statement to redefine the attributes of a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_alter_db.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_alter_db.md
@@ -34,10 +34,10 @@ Use the `ALTER DATABASE` statement to redefine the attributes of a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_alter_domain.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_alter_domain.md
@@ -34,10 +34,10 @@ Use the `ALTER DOMAIN` statement to change the definition of a domain.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_alter_domain.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_alter_domain.md
@@ -34,10 +34,10 @@ Use the `ALTER DOMAIN` statement to change the definition of a domain.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_alter_sequence.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_alter_sequence.md
@@ -34,10 +34,10 @@ Use the `ALTER SEQUENCE` statement to change the definition of a sequence in the
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_alter_sequence.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_alter_sequence.md
@@ -34,10 +34,10 @@ Use the `ALTER SEQUENCE` statement to change the definition of a sequence in the
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_alter_table.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_alter_table.md
@@ -34,10 +34,10 @@ Use the `ALTER TABLE` statement to change the definition of a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_alter_table.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_alter_table.md
@@ -34,10 +34,10 @@ Use the `ALTER TABLE` statement to change the definition of a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint.diagram.md" %}}
   </div>
 </div>
 
@@ -72,7 +72,7 @@ Renaming a table is a non blocking metadata change operation.
 
 #### DROP [ COLUMN ] *column_name* [ RESTRICT | CASCADE ]
 
-Drop the named column from the table. 
+Drop the named column from the table.
 
 - `RESTRICT` — Remove only the specified
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_comment.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_comment.md
@@ -34,10 +34,10 @@ Use the `COMMENT` statement to set, update, or remove a comment on a database ob
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_comment.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_comment.md
@@ -34,10 +34,10 @@ Use the `COMMENT` statement to set, update, or remove a comment on a database ob
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_aggregate.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_aggregate.md
@@ -35,10 +35,10 @@ create aggregates.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_aggregate.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_aggregate.md
@@ -35,10 +35,10 @@ create aggregates.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_cast.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_cast.md
@@ -34,10 +34,10 @@ Use the `CREATE CAST` statement to create a cast.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_cast.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_cast.md
@@ -34,10 +34,10 @@ Use the `CREATE CAST` statement to create a cast.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_database.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_database.md
@@ -34,10 +34,10 @@ Use the `CREATE DATABASE` statement to create a database that functions as a gro
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_database.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_database.md
@@ -34,10 +34,10 @@ Use the `CREATE DATABASE` statement to create a database that functions as a gro
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_domain.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_domain.md
@@ -34,10 +34,10 @@ Use the `CREATE DOMAIN` statement to create a user-defined data type with option
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_domain.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_domain.md
@@ -34,10 +34,10 @@ Use the `CREATE DOMAIN` statement to create a user-defined data type with option
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_extension.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_extension.md
@@ -35,10 +35,10 @@ Use the `CREATE EXTENSION` statement to load an extension into a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_extension.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_extension.md
@@ -35,10 +35,10 @@ Use the `CREATE EXTENSION` statement to load an extension into a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_function.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_function.md
@@ -34,10 +34,10 @@ Use the `CREATE FUNCTION` statement to create a function in a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_function.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_function.md
@@ -34,10 +34,10 @@ Use the `CREATE FUNCTION` statement to create a function in a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl.diagram.md" %}}
   </div>
 </div>
 
@@ -47,14 +47,14 @@ Use the `CREATE FUNCTION` statement to create a function in a database.
 
 - The languages supported by default are `sql`, `plpgsql` and `C`.
 
-- `VOLATILE`, `STABLE` and `IMMUTABLE` inform the query optimizer about the behavior the function. 
+- `VOLATILE`, `STABLE` and `IMMUTABLE` inform the query optimizer about the behavior the function.
     - `VOLATILE` is the default and indicates that the function result could be different for every call. For instance `random()` or `now()`.
     - `STABLE` indicates that the function cannot modify the database so that within a single scan it will return the same result given the same arguments.
     - `IMMUTABLE` indicates that the function cannot modify the database _and_ always returns the same results given the same arguments.
 
 - `CALLED ON NULL INPUT`, `RETURNS NULL ON NULL INPUT` and `STRICT` define the function's behavior with respect to 'null's.
     - `CALLED ON NULL INPUT` indicates that input arguments may be `null`.
-    - `RETURNS NULL ON NULL INPUT` or `STRICT` indicate that the function always returns `null` if any of its arguments are `null`. 
+    - `RETURNS NULL ON NULL INPUT` or `STRICT` indicate that the function always returns `null` if any of its arguments are `null`.
 
 ## Examples
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_index.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_index.md
@@ -34,10 +34,10 @@ Use the `CREATE INDEX` statement to create an index on the specified columns of 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_index.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_index.md
@@ -34,10 +34,10 @@ Use the `CREATE INDEX` statement to create an index on the specified columns of 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.diagram.md" %}}
   </div>
 </div>
 
@@ -61,9 +61,9 @@ Specify a list of columns which will be included in the index as non-key columns
 
 ### WHERE clause
 
-A [partial index](#partial-indexes) is an index that is built on a subset of a table and includes only rows that satisfy the condition specified in the `WHERE` clause. 
+A [partial index](#partial-indexes) is an index that is built on a subset of a table and includes only rows that satisfy the condition specified in the `WHERE` clause.
 It can be used to exclude NULL or common values from the index, or include just the rows of interest.
-This will speed up any writes to the table since rows containing the common column values don't need to be indexed. 
+This will speed up any writes to the table since rows containing the common column values don't need to be indexed.
 It will also reduce the size of the index, thereby improving the speed for read queries that use the index.
 
 #### *name*

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_operator.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_operator.md
@@ -34,10 +34,10 @@ Use the `CREATE OPERATOR` statement to create an operator.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_operator.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_operator.md
@@ -34,10 +34,10 @@ Use the `CREATE OPERATOR` statement to create an operator.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_operator_class.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_operator_class.md
@@ -34,10 +34,10 @@ Use the `CREATE OPERATOR CLASS` statement to create an operator class.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_operator_class.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_operator_class.md
@@ -34,10 +34,10 @@ Use the `CREATE OPERATOR CLASS` statement to create an operator class.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_procedure.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_procedure.md
@@ -34,10 +34,10 @@ Use the `CREATE PROCEDURE` statement to to create a procedure in a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_procedure.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_procedure.md
@@ -34,10 +34,10 @@ Use the `CREATE PROCEDURE` statement to to create a procedure in a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_rule.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_rule.md
@@ -34,10 +34,10 @@ Use the `CREATE RULE` statement to create a rule.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_rule.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_rule.md
@@ -34,10 +34,10 @@ Use the `CREATE RULE` statement to create a rule.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_schema.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_schema.md
@@ -36,10 +36,10 @@ Named objects in a schema can be accessed by using the schema name as prefix or 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_schema.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_schema.md
@@ -36,10 +36,10 @@ Named objects in a schema can be accessed by using the schema name as prefix or 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_sequence.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_sequence.md
@@ -34,10 +34,10 @@ Use the `CREATE SEQUENCE` statement to create a sequence in the current schema.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_sequence.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_sequence.md
@@ -34,10 +34,10 @@ Use the `CREATE SEQUENCE` statement to create a sequence in the current schema.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.diagram.md" %}}
   </div>
 </div>
 
@@ -55,7 +55,7 @@ The sequence name must be distinct from any other sequences, tables, indexes, vi
 
 #### INCREMENT BY *increment*
 
-Specify the *increment* value to add to the current sequence value to create a new value. The default value is `1`. A positive number 
+Specify the *increment* value to add to the current sequence value to create a new value. The default value is `1`. A positive number
 
 #### MINVALUE *minvalue* | NO MINVALUE
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_table.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_table.md
@@ -34,10 +34,10 @@ Use the `CREATE TABLE` statement to create a table in a database. It defines the
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_table.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_table.md
@@ -34,10 +34,10 @@ Use the `CREATE TABLE` statement to create a table in a database. It defines the
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_table_as.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_table_as.md
@@ -34,10 +34,10 @@ Use the `CREATE TABLE AS` statement to create a table using the output of a subq
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_table_as.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_table_as.md
@@ -34,10 +34,10 @@ Use the `CREATE TABLE AS` statement to create a table using the output of a subq
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_trigger.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_trigger.md
@@ -34,16 +34,16 @@ Use the `CREATE TRIGGER` statement to create a trigger.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.diagram.md" %}}
   </div>
 </div>
 
 ## Semantics
 
-- the `WHEN` condition can be used to specify whether the trigger should be fired. For low-level triggers it can reference the old and/or new values of the row's columns. 
+- the `WHEN` condition can be used to specify whether the trigger should be fired. For low-level triggers it can reference the old and/or new values of the row's columns.
 - multiple triggers can be defined for the same event. In that case, they will be fired in alphabetical order by name.
 
 ## Examples

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_trigger.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_trigger.md
@@ -34,10 +34,10 @@ Use the `CREATE TRIGGER` statement to create a trigger.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_type.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_type.md
@@ -34,10 +34,10 @@ Use the `CREATE TYPE` statement to create a user-defined type in a database.  Th
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_type.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_type.md
@@ -34,10 +34,10 @@ Use the `CREATE TYPE` statement to create a user-defined type in a database.  Th
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_view.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_view.md
@@ -34,10 +34,10 @@ Use the `CREATE VIEW` statement to create a view in a database. It defines the v
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_view.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_create_view.md
@@ -2,7 +2,7 @@
 title: CREATE VIEW statement [YSQL]
 headerTitle: CREATE VIEW
 linkTitle: CREATE VIEW
-description: Use the CREATE VIEW statement to create a view in a database. 
+description: Use the CREATE VIEW statement to create a view in a database.
 menu:
   v2.4:
     identifier: ddl_create_view
@@ -13,7 +13,7 @@ showAsideToc: true
 
 ## Synopsis
 
-Use the `CREATE VIEW` statement to create a view in a database. It defines the view name and the (select) statement defining it.  
+Use the `CREATE VIEW` statement to create a view in a database. It defines the view name and the (select) statement defining it.
 
 ## Syntax
 
@@ -34,10 +34,10 @@ Use the `CREATE VIEW` statement to create a view in a database. It defines the v
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_aggregate.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_aggregate.md
@@ -34,10 +34,10 @@ Use the `DROP AGGREGATE` statement to remove an aggregate.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_aggregate.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_aggregate.md
@@ -34,10 +34,10 @@ Use the `DROP AGGREGATE` statement to remove an aggregate.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_cast.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_cast.md
@@ -34,10 +34,10 @@ Use the `DROP CAST` statement to remove a cast.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_cast.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_cast.md
@@ -34,10 +34,10 @@ Use the `DROP CAST` statement to remove a cast.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_database.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_database.md
@@ -2,7 +2,7 @@
 title: DROP DATABASE statement [YSQL]
 headerTitle: DROP DATABASE
 linkTitle: DROP DATABASE
-description: Use the DROP DATABASE statement to remove a database and all of its associated objects from the system. 
+description: Use the DROP DATABASE statement to remove a database and all of its associated objects from the system.
 menu:
   v2.4:
     identifier: ddl_drop_database
@@ -34,10 +34,10 @@ Use the `DROP DATABASE` statement to remove a database and all of its associated
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_database.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_database.md
@@ -34,10 +34,10 @@ Use the `DROP DATABASE` statement to remove a database and all of its associated
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_domain.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_domain.md
@@ -34,10 +34,10 @@ Use the `DROP DOMAIN` statement to remove a domain from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_domain.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_domain.md
@@ -34,10 +34,10 @@ Use the `DROP DOMAIN` statement to remove a domain from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_extension.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_extension.md
@@ -35,10 +35,10 @@ Use the `DROP EXTENSION` statement to remove an extension from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_extension.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_extension.md
@@ -35,10 +35,10 @@ Use the `DROP EXTENSION` statement to remove an extension from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_function.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_function.md
@@ -34,10 +34,10 @@ Use the `DROP FUNCTION` statement to remove a function from a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_function.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_function.md
@@ -34,10 +34,10 @@ Use the `DROP FUNCTION` statement to remove a function from a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_operator.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_operator.md
@@ -34,10 +34,10 @@ Use the `DROP OPERATOR` statement to remove an operator.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_operator.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_operator.md
@@ -34,10 +34,10 @@ Use the `DROP OPERATOR` statement to remove an operator.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_operator_class.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_operator_class.md
@@ -34,10 +34,10 @@ Use the `DROP OPERATOR CLASS` statement to remove an operator class.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_operator_class.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_operator_class.md
@@ -34,10 +34,10 @@ Use the `DROP OPERATOR CLASS` statement to remove an operator class.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_procedure.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_procedure.md
@@ -34,10 +34,10 @@ Use the `DROP PROCEDURE` statement to remove a procedure from a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_procedure.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_procedure.md
@@ -34,10 +34,10 @@ Use the `DROP PROCEDURE` statement to remove a procedure from a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_rule.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_rule.md
@@ -34,10 +34,10 @@ Use the `DROP RULE` statement to remove a rule.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_rule.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_rule.md
@@ -34,10 +34,10 @@ Use the `DROP RULE` statement to remove a rule.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_sequence.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_sequence.md
@@ -34,10 +34,10 @@ Use the `DROP SEQUENCE` statement to delete a sequence in the current schema.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_sequence.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_sequence.md
@@ -34,10 +34,10 @@ Use the `DROP SEQUENCE` statement to delete a sequence in the current schema.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_table.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_table.md
@@ -34,10 +34,10 @@ Use the `DROP TABLE` statement to remove one or more tables (with all of their d
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_table.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_table.md
@@ -34,10 +34,10 @@ Use the `DROP TABLE` statement to remove one or more tables (with all of their d
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_trigger.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_trigger.md
@@ -34,10 +34,10 @@ Use the `DROP TRIGGER` statement to remove a trigger from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_trigger.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_trigger.md
@@ -34,10 +34,10 @@ Use the `DROP TRIGGER` statement to remove a trigger from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_type.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_type.md
@@ -34,10 +34,10 @@ Use the `DROP TYPE` statement to remove a user-defined type from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_type.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_drop_type.md
@@ -34,10 +34,10 @@ Use the `DROP TYPE` statement to remove a user-defined type from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_truncate.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_truncate.md
@@ -34,10 +34,10 @@ Use the `TRUNCATE` statement to clear all rows in a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_truncate.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/ddl_truncate.md
@@ -34,10 +34,10 @@ Use the `TRUNCATE` statement to clear all rows in a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dml_delete.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dml_delete.md
@@ -34,10 +34,10 @@ Use the `DELETE` statement to remove rows that meet certain conditions, and when
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dml_delete.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dml_delete.md
@@ -34,10 +34,10 @@ Use the `DELETE` statement to remove rows that meet certain conditions, and when
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.diagram.md" %}}
   </div>
 </div>
 
@@ -49,7 +49,7 @@ See the section [The WITH clause and common table expressions](../../with-clause
 
 - While the `WHERE` clause allows a wide range of operators, the exact conditions used in the `WHERE` clause have significant performance considerations (especially for large datasets). For the best performance, use a `WHERE` clause that provides values for all columns in `PRIMARY KEY` or `INDEX KEY`.
 
-### *delete* 
+### *delete*
 
 #### WITH [ RECURSIVE ] *with_query* [ , ... ] DELETE FROM [ ONLY ] *table_name* [ * ] [ [ AS ] *alias* ] [ WHERE *condition* | WHERE CURRENT OF *cursor_name* ] [ [*returning_clause*] (#returning-clause) ]
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dml_insert.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dml_insert.md
@@ -34,10 +34,10 @@ Use the `INSERT` statement to add one or more rows to the specified table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.diagram.md" %}}
   </div>
 </div>
 
@@ -45,7 +45,7 @@ See the section [The WITH clause and common table expressions](../../with-clause
 
 ## Semantics
 
-Constraints must be satisfied.  
+Constraints must be satisfied.
 
 ### *insert*
 
@@ -236,7 +236,7 @@ yugabyte=# SELECT id, c1, c2 FROM sample ORDER BY id;
 ```
 
 ```
- id |   c1   |    c2     
+ id |   c1   |    c2
 ----+--------+-----------
   1 | cat    | sparrow
   2 | dog    | blackbird

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dml_insert.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dml_insert.md
@@ -34,10 +34,10 @@ Use the `INSERT` statement to add one or more rows to the specified table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dml_select.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dml_select.md
@@ -36,10 +36,10 @@ The same syntax rules govern a subquery, wherever you might use one—like, for 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.diagram.md" %}}
   </div>
 </div>
 
@@ -100,7 +100,7 @@ When you understand the story of the invocation of these two kinds of functions 
   42809: WITHIN GROUP is required for ordered-set aggregate mode
   ```
 
-**Note:** The documentation in the [Aggregate functions](../../../exprs/aggregate_functions/) major section usually refers to the syntax that the `ordinary_aggregate_fn_invocation` rule and the `within_group_aggregate_fn_invocation` rule jointly govern as the [`GROUP BY` syntax](../../../exprs/aggregate_functions/function-syntax-semantics/avg-count-max-min-sum/#group-by-syntax) because it's these two syntax variants (and _only_ these two) can be used together with the `GROUP BY` clause (and therefore the `HAVING` clause). And it usually refers to the syntax that the `fn_over_window` rule governs as the [`OVER` syntax](../../../exprs/aggregate_functions/function-syntax-semantics/avg-count-max-min-sum/#over-syntax) because this syntax variant _requires_ the use of the `OVER` clause. Moreover, the use of the `GROUP BY` clause (and therefore the `HAVING` clause) is illegal with this syntax variant. 
+**Note:** The documentation in the [Aggregate functions](../../../exprs/aggregate_functions/) major section usually refers to the syntax that the `ordinary_aggregate_fn_invocation` rule and the `within_group_aggregate_fn_invocation` rule jointly govern as the [`GROUP BY` syntax](../../../exprs/aggregate_functions/function-syntax-semantics/avg-count-max-min-sum/#group-by-syntax) because it's these two syntax variants (and _only_ these two) can be used together with the `GROUP BY` clause (and therefore the `HAVING` clause). And it usually refers to the syntax that the `fn_over_window` rule governs as the [`OVER` syntax](../../../exprs/aggregate_functions/function-syntax-semantics/avg-count-max-min-sum/#over-syntax) because this syntax variant _requires_ the use of the `OVER` clause. Moreover, the use of the `GROUP BY` clause (and therefore the `HAVING` clause) is illegal with this syntax variant.
 
 ## Examples
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dml_select.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dml_select.md
@@ -36,10 +36,10 @@ The same syntax rules govern a subquery, wherever you might use one—like, for 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dml_update.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dml_update.md
@@ -34,10 +34,10 @@ Use the `UPDATE` statement to modify the values of specified columns in all rows
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dml_update.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dml_update.md
@@ -34,10 +34,10 @@ Use the `UPDATE` statement to modify the values of specified columns in all rows
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dml_values.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dml_values.md
@@ -34,10 +34,10 @@ Use the `VALUES` statement to generate a row set specified as an explicitly writ
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.diagram.md" %}}
   </div>
 </div>
 
@@ -53,7 +53,7 @@ values ('dog'::text);
 This is the result:
 
 ```
- column1 
+ column1
 ---------
  dog
 ```
@@ -68,7 +68,7 @@ values
 This is the result:
 
 ```
- column1 |       column2       | column3 
+ column1 |       column2       | column3
 ---------+---------------------+---------
        1 | 2019-06-25 12:05:30 | dog
        2 | 2020-07-30 13:10:45 | cat
@@ -117,7 +117,7 @@ select chr(v) as c from (
 This is the result:
 
 ```
- c 
+ c
 ---
  a
  b
@@ -137,7 +137,7 @@ select chr(v) as c from (
 This is the result:
 
 ```
- c 
+ c
 ---
  d
  o

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/dml_values.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/dml_values.md
@@ -34,10 +34,10 @@ Use the `VALUES` statement to generate a row set specified as an explicitly writ
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/perf_deallocate.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/perf_deallocate.md
@@ -34,10 +34,10 @@ Use the `DEALLOCATE` statement to deallocate a previously prepared SQL statement
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.diagram.md" %}}
   </div>
 </div>
 
@@ -60,7 +60,7 @@ yugabyte=# CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1,
 ```
 
 ```plpgsql
-yugabyte=# PREPARE ins (bigint, double precision, int, text) AS 
+yugabyte=# PREPARE ins (bigint, double precision, int, text) AS
                INSERT INTO sample(k1, k2, v1, v2) VALUES ($1, $2, $3, $4);
 ```
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/perf_deallocate.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/perf_deallocate.md
@@ -34,10 +34,10 @@ Use the `DEALLOCATE` statement to deallocate a previously prepared SQL statement
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/perf_execute.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/perf_execute.md
@@ -34,10 +34,10 @@ Use the `EXECUTE` statement to execute a previously prepared statement. This sep
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/perf_execute.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/perf_execute.md
@@ -2,7 +2,7 @@
 title: EXECUTE statement [YSQL]
 headerTitle: EXECUTE
 linkTitle: EXECUTE
-description: Use the EXECUTE statement to execute a previously prepared statement. 
+description: Use the EXECUTE statement to execute a previously prepared statement.
 menu:
   v2.4:
     identifier: perf_execute
@@ -34,10 +34,10 @@ Use the `EXECUTE` statement to execute a previously prepared statement. This sep
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.diagram.md" %}}
   </div>
 </div>
 
@@ -62,7 +62,7 @@ yugabyte=# CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1,
 - Prepare a simple insert.
 
 ```plpgsql
-yugabyte=# PREPARE ins (bigint, double precision, int, text) AS 
+yugabyte=# PREPARE ins (bigint, double precision, int, text) AS
                INSERT INTO sample(k1, k2, v1, v2) VALUES ($1, $2, $3, $4);
 ```
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/perf_explain.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/perf_explain.md
@@ -34,10 +34,10 @@ Use the `EXPLAIN` statement to show the execution plan for an statement. If the 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/perf_explain.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/perf_explain.md
@@ -34,10 +34,10 @@ Use the `EXPLAIN` statement to show the execution plan for an statement. If the 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/perf_prepare.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/perf_prepare.md
@@ -34,10 +34,10 @@ Use the `PREPARE` statement to create a handle to a prepared statement by parsin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.diagram.md" %}}
   </div>
 </div>
 
@@ -57,7 +57,7 @@ yugabyte=# CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1,
 Prepare a simple insert.
 
 ```plpgsql
-yugabyte=# PREPARE ins (bigint, double precision, int, text) AS 
+yugabyte=# PREPARE ins (bigint, double precision, int, text) AS
                INSERT INTO sample(k1, k2, v1, v2) VALUES ($1, $2, $3, $4);
 ```
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/perf_prepare.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/perf_prepare.md
@@ -34,10 +34,10 @@ Use the `PREPARE` statement to create a handle to a prepared statement by parsin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_abort.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_abort.md
@@ -34,10 +34,10 @@ Use the `ABORT` statement to roll back the current transaction and discards all 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_abort.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_abort.md
@@ -34,10 +34,10 @@ Use the `ABORT` statement to roll back the current transaction and discards all 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.diagram.md" %}}
   </div>
 </div>
 
@@ -66,7 +66,7 @@ yugabyte=# CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1,
 Begin a transaction and insert some rows.
 
 ```plpgsql
-yugabyte=# BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
+yugabyte=# BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 ```
 
 ```plpgsql

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_begin.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_begin.md
@@ -34,10 +34,10 @@ Use the `BEGIN` statement to start a transaction with the default (or given) iso
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.diagram.md" %}}
   </div>
 </div>
 
@@ -72,7 +72,7 @@ CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1, k2));
 Begin a transaction and insert some rows.
 
 ```plpgsql
-BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
+BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 ```
 
 ```plpgsql
@@ -82,7 +82,7 @@ INSERT INTO sample(k1, k2, v1, v2) VALUES (1, 2.0, 3, 'a'), (1, 3.0, 4, 'b');
 Start a new shell  with `ysqlsh` and begin another transaction to insert some more rows.
 
 ```plpgsql
-BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
+BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 ```
 
 ```plpgsql

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_begin.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_begin.md
@@ -34,10 +34,10 @@ Use the `BEGIN` statement to start a transaction with the default (or given) iso
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_commit.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_commit.md
@@ -34,10 +34,10 @@ Use the `COMMIT` statement to commit the current transaction. All changes made b
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.diagram.md" %}}
   </div>
 </div>
 
@@ -68,7 +68,7 @@ CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1, k2));
 Begin a transaction and insert some rows.
 
 ```plpgsql
-BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
+BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 ```
 
 ```plpgsql
@@ -78,7 +78,7 @@ INSERT INTO sample(k1, k2, v1, v2) VALUES (1, 2.0, 3, 'a'), (1, 3.0, 4, 'b');
 Start a new shell  with `ysqlsh` and begin another transaction to insert some more rows.
 
 ```plpgsql
-yugabyte=# BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
+yugabyte=# BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 ```
 
 ```plpgsql

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_commit.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_commit.md
@@ -34,10 +34,10 @@ Use the `COMMIT` statement to commit the current transaction. All changes made b
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_end.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_end.md
@@ -34,10 +34,10 @@ Use the `END` statement to commit the current transaction. All changes made by t
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_end.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_end.md
@@ -34,10 +34,10 @@ Use the `END` statement to commit the current transaction. All changes made by t
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_lock.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_lock.md
@@ -34,10 +34,10 @@ Use the `LOCK` statement to lock a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_lock.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_lock.md
@@ -34,10 +34,10 @@ Use the `LOCK` statement to lock a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_rollback.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_rollback.md
@@ -34,10 +34,10 @@ Use the `ROLLBACK` statement to roll back the current transactions. All changes 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_rollback.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_rollback.md
@@ -34,10 +34,10 @@ Use the `ROLLBACK` statement to roll back the current transactions. All changes 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_set.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_set.md
@@ -35,10 +35,10 @@ Use the `SET TRANSACTION` statement to set the current transaction isolation lev
 
 <div class="tab-content"> 
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_set.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_set.md
@@ -33,12 +33,12 @@ Use the `SET TRANSACTION` statement to set the current transaction isolation lev
   </li>
 </ul>
 
-<div class="tab-content"> 
+<div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_set_constraints.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_set_constraints.md
@@ -35,10 +35,10 @@ Use the `SET CONSTRAINTS` statement to set the timing of constraint checking wit
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_set_constraints.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_set_constraints.md
@@ -35,10 +35,10 @@ Use the `SET CONSTRAINTS` statement to set the timing of constraint checking wit
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_show.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_show.md
@@ -35,10 +35,10 @@ Use the `SHOW TRANSACTION` statement to show the current transaction isolation l
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_show.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/statements/txn_show.md
@@ -35,10 +35,10 @@ Use the `SHOW TRANSACTION` statement to show the current transaction isolation l
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/with-clause/recursive-cte.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/with-clause/recursive-cte.md
@@ -63,7 +63,7 @@ Notice that the parentheses that surround the _non-recursive term_ and the _recu
 This is the result:
 
 ```
- n 
+ n
 ---
  1
  2
@@ -95,10 +95,10 @@ The `WITH` clause syntax (see the section [WITH clause—SQL syntax and semantic
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.diagram.md" %}}
   </div>
 </div>
 
@@ -142,7 +142,7 @@ order by n desc;
 This is the result:
 
 ```
- n  
+ n
 ----
  99
  42
@@ -193,7 +193,7 @@ a1(n) as (
 then the statement executes without error to produce this result:
 
 ```
- n  
+ n
 ----
  99
   5
@@ -234,7 +234,7 @@ select n from r order by n;
 Notice that this is simply a _syntax_ example. Using `WITH` clauses within the recursive and non-recursive terms brings no value. The statement executes without error and produces this result:
 
 ```
- n 
+ n
 ---
  1
  2
@@ -306,7 +306,7 @@ select n from r order by n;
 This is the results:
 
 ```
- n 
+ n
 ---
  1
  2
@@ -339,15 +339,15 @@ A compact, and exact, formulation is given by using pseudocode. The _"RECURSIVE_
 > - **while the WORKING_RESULTS table is not empty loop**
 >
 >   - **Purge the TEMP_RESULTS table.**
->   
+>
 >   - **Evaluate the recursive term using the current contents of the WORKING_RESULTS table for the recursive self-reference, inserting the resulting rows into the TEMP_RESULTS table.**
->   
+>
 >   - **Purge the WORKING_RESULTS table and insert the contents of the TEMP_RESULTS table.**
->   
+>
 >   - **Append the contents of the TEMP_RESULTS table into the RECURSIVE_WITH_RESULTS table.**
->   
+>
 >- **end loop**
-> 
+>
 >- **Deliver the present contents of the RECURSIVE_WITH_RESULTS table as the final result.**
 
 ### PL/pgSQL procedure implementation of the pseudocode : example 1
@@ -436,24 +436,24 @@ select c1, c2 from r order by c1, c2;
 This is the result:
 
 ```
- c1 | c2 
+ c1 | c2
 ----+----
   0 |  1
   0 |  2
   0 |  3
-  
+
   1 |  2
   1 |  3
   1 |  4
-  
+
   2 |  3
   2 |  4
   2 |  5
-  
+
   3 |  4
   3 |  5
   3 |  6
-  
+
   4 |  5
   4 |  6
   4 |  7

--- a/docs/content/v2.4/api/ysql/the-sql-language/with-clause/recursive-cte.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/with-clause/recursive-cte.md
@@ -95,10 +95,10 @@ The `WITH` clause syntax (see the section [WITH clause—SQL syntax and semantic
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/api/ysql/the-sql-language/with-clause/with-clause-syntax-semantics.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/with-clause/with-clause-syntax-semantics.md
@@ -33,10 +33,10 @@ The [with_clause](../../../syntax_resources/grammar_diagrams/#with-clause)  and 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.diagram.md" %}}
   </div>
 </div>
 
@@ -92,7 +92,7 @@ order by 1, 2;
 This is the result:
 
 ```
- name | k | v  
+ name | k | v
 ------+---+----
  t1   | 1 |  2
  t1   | 2 |  4
@@ -108,16 +108,16 @@ This is the result:
 Now execute the example query. Notice that the `WITH` clause defines an `INSERT` CTE, an `UPDATE` CTE, a `DELETE` CTE, and a `SELECT` CTE. Each of the data-changing CTEs has a `RETURNING` clause; and the `SELECT` CTE accesses the unions returned by each of these.
 
 ```plpgsql
-with 
+with
   i as (
     insert into t1(k, v) values (21, 17), (31, 42) returning k, v),
-    
+
   u as (
     update t2 set v = 99 where k in (4, 5) returning k, v),
-    
+
   d as (
     delete from t3 where k in (8, 9) returning k, v),
-    
+
   s as (
     select 'inserted into t1'::text as action, k, v from i
     union all
@@ -131,7 +131,7 @@ select action, k, v from s order by k;
 This is the result:
 
 ```
-      action      | k  | v  
+      action      | k  | v
 ------------------+----+----
  udated in t2     |  4 | 99
  udated in t2     |  5 | 99
@@ -155,7 +155,7 @@ order by 1, 2;
 This is the result:
 
 ```
- name | k  | v  
+ name | k  | v
 ------+----+----
  t1   |  1 |  2
  t1   |  2 |  4
@@ -198,7 +198,7 @@ select k, v from t1 order by k;
 This is the result:
 
 ```
- k  | v  
+ k  | v
 ----+----
   1 |  2
   2 |  4
@@ -241,7 +241,7 @@ from colliding;
 This is the result:
 
 ```
-      colliding      
+      colliding
 ---------------------
  goodbye—Hello world
 ```

--- a/docs/content/v2.4/api/ysql/the-sql-language/with-clause/with-clause-syntax-semantics.md
+++ b/docs/content/v2.4/api/ysql/the-sql-language/with-clause/with-clause-syntax-semantics.md
@@ -33,10 +33,10 @@ The [with_clause](../../../syntax_resources/grammar_diagrams/#with-clause)  and 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/benchmark/tpcc-ysql/_index.md
+++ b/docs/content/v2.4/benchmark/tpcc-ysql/_index.md
@@ -87,16 +87,16 @@ Other options like username, password, port, etc. can be changed using the confi
 
 <div class="tab-content">
   <div id="10-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="10-wh-tab">
-    {{% includeMarkdown "10-wh/tpcc-ysql.md" /%}}
+    {{% includeMarkdown "10-wh/tpcc-ysql.md" %}}
   </div>
   <div id="100-wh" class="tab-pane fade show active" role="tabpanel" aria-labelledby="100-wh-tab">
-    {{% includeMarkdown "100-wh/tpcc-ysql.md" /%}}
+    {{% includeMarkdown "100-wh/tpcc-ysql.md" %}}
   </div>
   <div id="1000-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="1000-wh-tab">
-    {{% includeMarkdown "1000-wh/tpcc-ysql.md" /%}}
+    {{% includeMarkdown "1000-wh/tpcc-ysql.md" %}}
   </div>
   <div id="10000-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="10000-wh-tab">
-    {{% includeMarkdown "10000-wh/tpcc-ysql.md" /%}}
+    {{% includeMarkdown "10000-wh/tpcc-ysql.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/benchmark/tpcc-ysql/_index.md
+++ b/docs/content/v2.4/benchmark/tpcc-ysql/_index.md
@@ -87,16 +87,16 @@ Other options like username, password, port, etc. can be changed using the confi
 
 <div class="tab-content">
   <div id="10-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="10-wh-tab">
-    {{% includeMarkdown "10-wh/tpcc-ysql.md" %}}
+  {{% includeMarkdown "10-wh/tpcc-ysql.md" %}}
   </div>
   <div id="100-wh" class="tab-pane fade show active" role="tabpanel" aria-labelledby="100-wh-tab">
-    {{% includeMarkdown "100-wh/tpcc-ysql.md" %}}
+  {{% includeMarkdown "100-wh/tpcc-ysql.md" %}}
   </div>
   <div id="1000-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="1000-wh-tab">
-    {{% includeMarkdown "1000-wh/tpcc-ysql.md" %}}
+  {{% includeMarkdown "1000-wh/tpcc-ysql.md" %}}
   </div>
   <div id="10000-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="10000-wh-tab">
-    {{% includeMarkdown "10000-wh/tpcc-ysql.md" %}}
+  {{% includeMarkdown "10000-wh/tpcc-ysql.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/develop/explore-sample-apps.md
+++ b/docs/content/v2.4/develop/explore-sample-apps.md
@@ -45,15 +45,15 @@ After running Yugastore, Yugabyte recommend running the [IoT Fleet Management](.
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/run-sample-apps.md" /%}}
+    {{% includeMarkdown "binary/run-sample-apps.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/run-sample-apps.md" /%}}
+    {{% includeMarkdown "binary/run-sample-apps.md" %}}
   </div>
    <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/run-sample-apps.md" /%}}
+    {{% includeMarkdown "docker/run-sample-apps.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/run-sample-apps.md" /%}}
+    {{% includeMarkdown "kubernetes/run-sample-apps.md" %}}
   </div>
 </div>

--- a/docs/content/v2.4/develop/explore-sample-apps.md
+++ b/docs/content/v2.4/develop/explore-sample-apps.md
@@ -3,7 +3,7 @@ title: Explore YugabyteDB sample applications
 headerTitle: Explore sample applications
 linkTitle: Explore sample apps
 description: Explore sample applications running on YugabyteDB.
-headcontent: 
+headcontent:
 image: /images/section_icons/index/develop.png
 menu:
   v2.4:
@@ -45,15 +45,15 @@ After running Yugastore, Yugabyte recommend running the [IoT Fleet Management](.
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/run-sample-apps.md" %}}
+  {{% includeMarkdown "binary/run-sample-apps.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/run-sample-apps.md" %}}
+  {{% includeMarkdown "binary/run-sample-apps.md" %}}
   </div>
    <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/run-sample-apps.md" %}}
+  {{% includeMarkdown "docker/run-sample-apps.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/run-sample-apps.md" %}}
+  {{% includeMarkdown "kubernetes/run-sample-apps.md" %}}
   </div>
 </div>

--- a/docs/content/v2.4/quick-start/explore/ycql.md
+++ b/docs/content/v2.4/quick-start/explore/ycql.md
@@ -68,16 +68,16 @@ After [creating a local cluster](../../create-local-cluster/), follow the instru
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/explore-ycql.md" %}}
+  {{% includeMarkdown "binary/explore-ycql.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/explore-ycql.md" %}}
+  {{% includeMarkdown "binary/explore-ycql.md" %}}
   </div>
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/explore-ycql.md" %}}
+  {{% includeMarkdown "docker/explore-ycql.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/explore-ycql.md" %}}
+  {{% includeMarkdown "kubernetes/explore-ycql.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/quick-start/explore/ycql.md
+++ b/docs/content/v2.4/quick-start/explore/ycql.md
@@ -68,16 +68,16 @@ After [creating a local cluster](../../create-local-cluster/), follow the instru
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/explore-ycql.md" /%}}
+    {{% includeMarkdown "binary/explore-ycql.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/explore-ycql.md" /%}}
+    {{% includeMarkdown "binary/explore-ycql.md" %}}
   </div>
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/explore-ycql.md" /%}}
+    {{% includeMarkdown "docker/explore-ycql.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/explore-ycql.md" /%}}
+    {{% includeMarkdown "kubernetes/explore-ycql.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/quick-start/explore/ysql.md
+++ b/docs/content/v2.4/quick-start/explore/ysql.md
@@ -82,16 +82,16 @@ The `share` directory includes sample dataset files available for creating datab
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/explore-ysql.md" %}}
+  {{% includeMarkdown "binary/explore-ysql.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/explore-ysql.md" %}}
+  {{% includeMarkdown "binary/explore-ysql.md" %}}
   </div>
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/explore-ysql.md" %}}
+  {{% includeMarkdown "docker/explore-ysql.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/explore-ysql.md" %}}
+  {{% includeMarkdown "kubernetes/explore-ysql.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/quick-start/explore/ysql.md
+++ b/docs/content/v2.4/quick-start/explore/ysql.md
@@ -82,16 +82,16 @@ The `share` directory includes sample dataset files available for creating datab
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/explore-ysql.md" /%}}
+    {{% includeMarkdown "binary/explore-ysql.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/explore-ysql.md" /%}}
+    {{% includeMarkdown "binary/explore-ysql.md" %}}
   </div>
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/explore-ysql.md" /%}}
+    {{% includeMarkdown "docker/explore-ysql.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/explore-ysql.md" /%}}
+    {{% includeMarkdown "kubernetes/explore-ysql.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/yedis/quick-start/_index.md
+++ b/docs/content/v2.4/yedis/quick-start/_index.md
@@ -46,16 +46,16 @@ After [creating a local cluster](../../quick-start/create-local-cluster/), follo
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/test-yedis.md" %}}
+  {{% includeMarkdown "binary/test-yedis.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/test-yedis.md" %}}
+  {{% includeMarkdown "binary/test-yedis.md" %}}
   </div>
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/test-yedis.md" %}}
+  {{% includeMarkdown "docker/test-yedis.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/test-yedis.md" %}}
+  {{% includeMarkdown "kubernetes/test-yedis.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.4/yedis/quick-start/_index.md
+++ b/docs/content/v2.4/yedis/quick-start/_index.md
@@ -46,16 +46,16 @@ After [creating a local cluster](../../quick-start/create-local-cluster/), follo
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/test-yedis.md" /%}}
+    {{% includeMarkdown "binary/test-yedis.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/test-yedis.md" /%}}
+    {{% includeMarkdown "binary/test-yedis.md" %}}
   </div>
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/test-yedis.md" /%}}
+    {{% includeMarkdown "docker/test-yedis.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/test-yedis.md" /%}}
+    {{% includeMarkdown "kubernetes/test-yedis.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/exprs/aggregate_functions/invocation-syntax-semantics.md
+++ b/docs/content/v2.6/api/ysql/exprs/aggregate_functions/invocation-syntax-semantics.md
@@ -35,10 +35,10 @@ The following six diagrams, [`select_start`](../../../syntax_resources/grammar_d
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.diagram.md" %}}
   </div>
 </div>
 These rules govern the invocation of aggregate functions as `SELECT` list items.
@@ -66,10 +66,10 @@ When aggregate functions are invoked using the syntax specified by either the `o
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.diagram.md" %}}
   </div>
 </div>
 
@@ -92,10 +92,10 @@ The result set may be restricted by the `HAVING` clause:
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/exprs/aggregate_functions/invocation-syntax-semantics.md
+++ b/docs/content/v2.6/api/ysql/exprs/aggregate_functions/invocation-syntax-semantics.md
@@ -35,10 +35,10 @@ The following six diagrams, [`select_start`](../../../syntax_resources/grammar_d
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.diagram.md" %}}
   </div>
 </div>
 These rules govern the invocation of aggregate functions as `SELECT` list items.
@@ -66,10 +66,10 @@ When aggregate functions are invoked using the syntax specified by either the `o
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.diagram.md" %}}
   </div>
 </div>
 
@@ -92,10 +92,10 @@ The result set may be restricted by the `HAVING` clause:
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/exprs/window_functions/invocation-syntax-semantics.md
+++ b/docs/content/v2.6/api/ysql/exprs/window_functions/invocation-syntax-semantics.md
@@ -52,10 +52,10 @@ The following three diagrams, [`select_start`](../../../syntax_resources/grammar
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.diagram.md" %}}
   </div>
 </div>
 
@@ -82,10 +82,10 @@ A [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-defin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.diagram.md" %}}
   </div>
 </div>
 
@@ -108,10 +108,10 @@ A [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-defin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/exprs/window_functions/invocation-syntax-semantics.md
+++ b/docs/content/v2.6/api/ysql/exprs/window_functions/invocation-syntax-semantics.md
@@ -23,7 +23,7 @@ Notice these three different orthography styles:
 
 - `OVER` is a keyword that names a clause. You write such a keyword in a SQL statement.
 
-- [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-definition) is the name of a rule within the overall SQL grammar. You never type such a name in a SQL statement. It is written in bold lower case with underscores, as appropriate, between the English words. Because such a rule is always shown as a link, you can jump directly to the rule in the [Grammar Diagrams](../../../syntax_resources/grammar_diagrams/#abort) page. This page shows every single one of the SQL rules. It so happens that the [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-definition) rule starts with the keyword `WINDOW` and might therefore, according to the context of use, be referred to alternatively as the `WINDOW` clause. 
+- [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-definition) is the name of a rule within the overall SQL grammar. You never type such a name in a SQL statement. It is written in bold lower case with underscores, as appropriate, between the English words. Because such a rule is always shown as a link, you can jump directly to the rule in the [Grammar Diagrams](../../../syntax_resources/grammar_diagrams/#abort) page. This page shows every single one of the SQL rules. It so happens that the [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-definition) rule starts with the keyword `WINDOW` and might therefore, according to the context of use, be referred to alternatively as the `WINDOW` clause.
 
 - [_window frame_](./#frame-clause-semantics-for-window-functions) is a pure term of art. It is written in italic lower case with spaces, as appropriate, between the English words. You neither write it in a SQL statement nor use it to look up anything in the [Grammar Diagrams](../../../syntax_resources/grammar_diagrams/#abort) page. Because such a term of art is always shown as a link, you can jump directly to its definition within this _"Window function invocation—SQL syntax and semantics"_ page.
 
@@ -52,10 +52,10 @@ The following three diagrams, [`select_start`](../../../syntax_resources/grammar
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.diagram.md" %}}
   </div>
 </div>
 
@@ -82,10 +82,10 @@ A [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-defin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.diagram.md" %}}
   </div>
 </div>
 
@@ -108,10 +108,10 @@ A [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-defin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.diagram.md" %}}
   </div>
 </div>
 
@@ -182,7 +182,7 @@ The [`frame_clause`](../../../syntax_resources/grammar_diagrams/#frame-clause) s
 - The functions in the first group, [Window functions that return an "int" or "double precision" value as a "classifier" of the rank of the row within its window](../function-syntax-semantics/#window-functions-that-return-an-int-or-double-precision-value-as-a-classifier-of-the-rank-of-the-row-within-its-window), are not sensitive to what the [`frame_clause`](../../../syntax_resources/grammar_diagrams/#frame-clause) specifies and always use all of the rows in the current [_window_](./#the-window-definition-rule). Yugabyte recommends that you therefore omit the [`frame_clause`](../../../syntax_resources/grammar_diagrams/#frame-clause) in the `OVER` clause that you use to invoke these functions.
 
 - The functions in the second group, [Window functions that return columns of another row within the window](../function-syntax-semantics/#window-functions-that-return-column-s-of-another-row-within-the-window), make obvious sense when the scope within which the specified row is found is the entire [_window_](./#the-window-definition-rule). If you have one of the very rare use cases where the output that you want is produced by a different [`frame_clause`](../../../syntax_resources/grammar_diagrams/#frame-clause), then specify what you want explicitly. Otherwise, because it isn't the default, you must specify that the [_window frame_](./#frame-clause-semantics-for-window-functions) includes the entire current [_window_](./#the-window-definition-rule) like this:
-  
+
   ```
   range between unbounded preceding and unbounded following
   ```

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/cmd_call.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/cmd_call.md
@@ -34,10 +34,10 @@ Use the `CALL` statement to execute a stored procedure.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.diagram.md" %}}
   </div>
 </div>
 **Note:** The syntax and semantics of the `procedure_argument` (for example how to use the named parameter invocation style to avoid providing actual arguments for defaulted parameters) is the same for invoking a user-defined`FUNCTION`. A function cannot be invoked with the `CALL` statement. Rather, it's invoked as (part of) an expression in DML statements like `SELECT`.

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/cmd_call.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/cmd_call.md
@@ -34,10 +34,10 @@ Use the `CALL` statement to execute a stored procedure.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.diagram.md" %}}
   </div>
 </div>
 **Note:** The syntax and semantics of the `procedure_argument` (for example how to use the named parameter invocation style to avoid providing actual arguments for defaulted parameters) is the same for invoking a user-defined`FUNCTION`. A function cannot be invoked with the `CALL` statement. Rather, it's invoked as (part of) an expression in DML statements like `SELECT`.

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/cmd_copy.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/cmd_copy.md
@@ -34,10 +34,10 @@ Use the `COPY` statement to transfer data between tables and files. `COPY TO` co
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.diagram.md" %}}
   </div>
 </div>
 
@@ -59,7 +59,7 @@ Specify a `SELECT`, `VALUES`, `INSERT`, `UPDATE`, or `DELETE` statement whose re
 
 Specify the path of the file to be copied. An input file name can be an absolute or relative path, but an output file name must be an absolute path. Critically, the file must be located _server-side_ on the local filesystem of the YB-TServer that you connect to.
 
-To work with files that reside on the client, nominate `stdin` as the argument for `FROM` or `stdout` as the argument for `TO`.  
+To work with files that reside on the client, nominate `stdin` as the argument for `FROM` or `stdout` as the argument for `TO`.
 
 Alternatively, you can use the `\copy` metacommand in [`ysqlsh`](../../../../../admin/ysqlsh#copy-table-column-list-query-from-to-filename-program-command-stdin-stdout-pstdin-pstdout-with-option).
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/cmd_copy.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/cmd_copy.md
@@ -34,10 +34,10 @@ Use the `COPY` statement to transfer data between tables and files. `COPY TO` co
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/cmd_do.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/cmd_do.md
@@ -36,10 +36,10 @@ The optional `LANGUAGE` clause can be written either before or after the code bl
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/cmd_do.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/cmd_do.md
@@ -36,10 +36,10 @@ The optional `LANGUAGE` clause can be written either before or after the code bl
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/cmd_reset.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/cmd_reset.md
@@ -34,10 +34,10 @@ Use the `RESET` statement to restore the value of a run-time parameter to the de
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/cmd_reset.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/cmd_reset.md
@@ -34,10 +34,10 @@ Use the `RESET` statement to restore the value of a run-time parameter to the de
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/cmd_set.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/cmd_set.md
@@ -1,7 +1,7 @@
 ---
 title: SET statement [YSQL]
 headerTitle: SET
-linkTitle: SET 
+linkTitle: SET
 description: Use the SET statement to update a run-time control parameter.
 menu:
   v2.6:
@@ -34,10 +34,10 @@ Use the `SET` statement to update a run-time control parameter.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/cmd_set.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/cmd_set.md
@@ -34,10 +34,10 @@ Use the `SET` statement to update a run-time control parameter.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/cmd_show.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/cmd_show.md
@@ -34,10 +34,10 @@ Use the `SHOW` statement to display the value of a run-time parameter.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/cmd_show.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/cmd_show.md
@@ -34,10 +34,10 @@ Use the `SHOW` statement to display the value of a run-time parameter.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_alter_default_privileges.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_alter_default_privileges.md
@@ -34,10 +34,10 @@ Use the `ALTER DEFAULT PRIVILEGES` statement to define the default access privil
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_alter_default_privileges.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_alter_default_privileges.md
@@ -34,10 +34,10 @@ Use the `ALTER DEFAULT PRIVILEGES` statement to define the default access privil
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_alter_group.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_alter_group.md
@@ -35,10 +35,10 @@ This is added for compatibility with Postgres. Its usage is discouraged. [`ALTER
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_alter_group.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_alter_group.md
@@ -35,10 +35,10 @@ This is added for compatibility with Postgres. Its usage is discouraged. [`ALTER
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_alter_policy.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_alter_policy.md
@@ -35,10 +35,10 @@ change the roles that the policy applies to and the `USING` and `CHECK` expressi
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.diagram.md" %}}
   </div>
 </div>
 
@@ -49,11 +49,11 @@ Where
 - `new_name` is the new name of the policy.
 - `role_name` is the role(s) to which the policy applies. Use `PUBLIC` if the policy should be
   applied to all roles.
-- `using_expression` is a SQL conditional expression. Only rows for which the condition returns to   
-  true will be visible in a `SELECT` and available for modification in an `UPDATE` or `DELETE`.      
-- `check_expression` is a SQL conditional expression that is used only for `INSERT` and `UPDATE`     
-  queries. Only rows for which the expression evaluates to true will be allowed in an `INSERT` or    
-  `UPDATE`. Note that unlike `using_expression`, this is evaluated against the proposed new contents 
+- `using_expression` is a SQL conditional expression. Only rows for which the condition returns to
+  true will be visible in a `SELECT` and available for modification in an `UPDATE` or `DELETE`.
+- `check_expression` is a SQL conditional expression that is used only for `INSERT` and `UPDATE`
+  queries. Only rows for which the expression evaluates to true will be allowed in an `INSERT` or
+  `UPDATE`. Note that unlike `using_expression`, this is evaluated against the proposed new contents
   of the row.
 
 ## Examples

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_alter_policy.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_alter_policy.md
@@ -35,10 +35,10 @@ change the roles that the policy applies to and the `USING` and `CHECK` expressi
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_alter_role.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_alter_role.md
@@ -37,10 +37,10 @@ Other roles can only change their own password.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_alter_role.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_alter_role.md
@@ -37,10 +37,10 @@ Other roles can only change their own password.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_alter_user.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_alter_user.md
@@ -34,10 +34,10 @@ Use the `ALTER USER` statement to alter a role. `ALTER USER` is an alias for [`A
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_alter_user.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_alter_user.md
@@ -34,10 +34,10 @@ Use the `ALTER USER` statement to alter a role. `ALTER USER` is an alias for [`A
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_create_group.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_create_group.md
@@ -34,10 +34,10 @@ Use the `CREATE GROUP` statement to create a group role. `CREATE GROUP` is an al
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_create_group.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_create_group.md
@@ -34,10 +34,10 @@ Use the `CREATE GROUP` statement to create a group role. `CREATE GROUP` is an al
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_create_policy.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_create_policy.md
@@ -37,10 +37,10 @@ policies to take effect.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.diagram.md" %}}
   </div>
 </div>
 
@@ -51,7 +51,7 @@ Where
 - `table_name` is the name of the table that the policy applies to.
 - `PERMISSIVE` / `RESTRICTIVE` specifies that the policy is permissive or restrictive.
 While applying policies to a table, permissive policies are combined together using a logical OR operator,
-while restrictive policies are combined using logical AND operator. Restrictive policies are used to 
+while restrictive policies are combined using logical AND operator. Restrictive policies are used to
 reduce the number of records that can be accessed. Default is permissive.
 - `role_name` is the role(s) to which the policy is applied. Default is `PUBLIC` which applies the
   policy to all roles.

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_create_policy.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_create_policy.md
@@ -37,10 +37,10 @@ policies to take effect.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_create_role.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_create_role.md
@@ -40,10 +40,10 @@ You can use `GRANT`/`REVOKE` commands to set/remove permissions for roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_create_role.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_create_role.md
@@ -40,10 +40,10 @@ You can use `GRANT`/`REVOKE` commands to set/remove permissions for roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_create_user.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_create_user.md
@@ -34,10 +34,10 @@ Use the `CREATE USER` statement to create a user. The `CREATE USER` statement is
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_create_user.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_create_user.md
@@ -34,10 +34,10 @@ Use the `CREATE USER` statement to create a user. The `CREATE USER` statement is
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_drop_group.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_drop_group.md
@@ -33,10 +33,10 @@ Use the `DROP GROUP` statement to drop a role. `DROP GROUP` is an alias for [`DR
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_drop_group.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_drop_group.md
@@ -33,10 +33,10 @@ Use the `DROP GROUP` statement to drop a role. `DROP GROUP` is an alias for [`DR
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_drop_owned.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_drop_owned.md
@@ -35,10 +35,10 @@ Any privileges granted to the given roles on objects in the current database or 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_drop_owned.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_drop_owned.md
@@ -35,10 +35,10 @@ Any privileges granted to the given roles on objects in the current database or 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_drop_policy.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_drop_policy.md
@@ -36,10 +36,10 @@ deny all policy will be applied for the table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_drop_policy.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_drop_policy.md
@@ -36,10 +36,10 @@ deny all policy will be applied for the table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_drop_role.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_drop_role.md
@@ -34,10 +34,10 @@ Use the `DROP ROLE` statement to remove the specified roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_drop_role.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_drop_role.md
@@ -34,10 +34,10 @@ Use the `DROP ROLE` statement to remove the specified roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_drop_user.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_drop_user.md
@@ -34,10 +34,10 @@ Use the `DROP USER` statement to drop a user or role. `DROP USER` is an alias fo
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_drop_user.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_drop_user.md
@@ -34,10 +34,10 @@ Use the `DROP USER` statement to drop a user or role. `DROP USER` is an alias fo
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_grant.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_grant.md
@@ -34,10 +34,10 @@ Use the `GRANT` statement to grant access privileges on database objects as well
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_grant.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_grant.md
@@ -34,10 +34,10 @@ Use the `GRANT` statement to grant access privileges on database objects as well
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_reassign_owned.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_reassign_owned.md
@@ -34,10 +34,10 @@ Use the `REASSIGN OWNED` statement to change the ownership of database objects o
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_reassign_owned.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_reassign_owned.md
@@ -34,10 +34,10 @@ Use the `REASSIGN OWNED` statement to change the ownership of database objects o
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_revoke.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_revoke.md
@@ -34,10 +34,10 @@ Use the `REVOKE` statement to remove access privileges from one or more roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_revoke.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_revoke.md
@@ -34,10 +34,10 @@ Use the `REVOKE` statement to remove access privileges from one or more roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_set_role.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_set_role.md
@@ -34,10 +34,10 @@ Use the `SET ROLE` statement to set the current user of the current session to b
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_set_role.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_set_role.md
@@ -34,10 +34,10 @@ Use the `SET ROLE` statement to set the current user of the current session to b
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_set_session_authorization.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_set_session_authorization.md
@@ -34,10 +34,10 @@ Use the `SET SESSION AUTHORIZATION` statement to set the current user and sessio
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_set_session_authorization.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dcl_set_session_authorization.md
@@ -34,10 +34,10 @@ Use the `SET SESSION AUTHORIZATION` statement to set the current user and sessio
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_alter_db.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_alter_db.md
@@ -34,10 +34,10 @@ Use the `ALTER DATABASE` statement to redefine the attributes of a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_alter_db.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_alter_db.md
@@ -34,10 +34,10 @@ Use the `ALTER DATABASE` statement to redefine the attributes of a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_alter_domain.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_alter_domain.md
@@ -34,10 +34,10 @@ Use the `ALTER DOMAIN` statement to change the definition of a domain.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_alter_domain.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_alter_domain.md
@@ -34,10 +34,10 @@ Use the `ALTER DOMAIN` statement to change the definition of a domain.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_alter_sequence.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_alter_sequence.md
@@ -34,10 +34,10 @@ Use the `ALTER SEQUENCE` statement to change the definition of a sequence in the
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_alter_sequence.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_alter_sequence.md
@@ -34,10 +34,10 @@ Use the `ALTER SEQUENCE` statement to change the definition of a sequence in the
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_alter_table.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_alter_table.md
@@ -34,10 +34,10 @@ Use the `ALTER TABLE` statement to change the definition of a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_alter_table.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_alter_table.md
@@ -34,10 +34,10 @@ Use the `ALTER TABLE` statement to change the definition of a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint.diagram.md" %}}
   </div>
 </div>
 
@@ -72,7 +72,7 @@ Renaming a table is a non blocking metadata change operation.
 
 #### DROP [ COLUMN ] *column_name* [ RESTRICT | CASCADE ]
 
-Drop the named column from the table. 
+Drop the named column from the table.
 
 - `RESTRICT` — Remove only the specified
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_comment.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_comment.md
@@ -34,10 +34,10 @@ Use the `COMMENT` statement to set, update, or remove a comment on a database ob
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_comment.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_comment.md
@@ -34,10 +34,10 @@ Use the `COMMENT` statement to set, update, or remove a comment on a database ob
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_aggregate.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_aggregate.md
@@ -35,10 +35,10 @@ create aggregates.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_aggregate.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_aggregate.md
@@ -35,10 +35,10 @@ create aggregates.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_cast.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_cast.md
@@ -34,10 +34,10 @@ Use the `CREATE CAST` statement to create a cast.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_cast.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_cast.md
@@ -34,10 +34,10 @@ Use the `CREATE CAST` statement to create a cast.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_database.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_database.md
@@ -34,10 +34,10 @@ Use the `CREATE DATABASE` statement to create a database that functions as a gro
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_database.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_database.md
@@ -34,10 +34,10 @@ Use the `CREATE DATABASE` statement to create a database that functions as a gro
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_domain.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_domain.md
@@ -34,10 +34,10 @@ Use the `CREATE DOMAIN` statement to create a user-defined data type with option
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_domain.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_domain.md
@@ -34,10 +34,10 @@ Use the `CREATE DOMAIN` statement to create a user-defined data type with option
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_extension.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_extension.md
@@ -35,10 +35,10 @@ Use the `CREATE EXTENSION` statement to load an extension into a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_extension.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_extension.md
@@ -35,10 +35,10 @@ Use the `CREATE EXTENSION` statement to load an extension into a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_function.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_function.md
@@ -34,10 +34,10 @@ Use the `CREATE FUNCTION` statement to create a function in a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_function.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_function.md
@@ -34,10 +34,10 @@ Use the `CREATE FUNCTION` statement to create a function in a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl.diagram.md" %}}
   </div>
 </div>
 
@@ -47,14 +47,14 @@ Use the `CREATE FUNCTION` statement to create a function in a database.
 
 - The languages supported by default are `sql`, `plpgsql` and `C`.
 
-- `VOLATILE`, `STABLE` and `IMMUTABLE` inform the query optimizer about the behavior the function. 
+- `VOLATILE`, `STABLE` and `IMMUTABLE` inform the query optimizer about the behavior the function.
     - `VOLATILE` is the default and indicates that the function result could be different for every call. For instance `random()` or `now()`.
     - `STABLE` indicates that the function cannot modify the database so that within a single scan it will return the same result given the same arguments.
     - `IMMUTABLE` indicates that the function cannot modify the database _and_ always returns the same results given the same arguments.
 
 - `CALLED ON NULL INPUT`, `RETURNS NULL ON NULL INPUT` and `STRICT` define the function's behavior with respect to 'null's.
     - `CALLED ON NULL INPUT` indicates that input arguments may be `null`.
-    - `RETURNS NULL ON NULL INPUT` or `STRICT` indicate that the function always returns `null` if any of its arguments are `null`. 
+    - `RETURNS NULL ON NULL INPUT` or `STRICT` indicate that the function always returns `null` if any of its arguments are `null`.
 
 ## Examples
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_index.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_index.md
@@ -34,10 +34,10 @@ Use the `CREATE INDEX` statement to create an index on the specified columns of 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_index.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_index.md
@@ -34,10 +34,10 @@ Use the `CREATE INDEX` statement to create an index on the specified columns of 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_operator.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_operator.md
@@ -34,10 +34,10 @@ Use the `CREATE OPERATOR` statement to create an operator.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_operator.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_operator.md
@@ -34,10 +34,10 @@ Use the `CREATE OPERATOR` statement to create an operator.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_operator_class.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_operator_class.md
@@ -34,10 +34,10 @@ Use the `CREATE OPERATOR CLASS` statement to create an operator class.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_operator_class.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_operator_class.md
@@ -34,10 +34,10 @@ Use the `CREATE OPERATOR CLASS` statement to create an operator class.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_procedure.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_procedure.md
@@ -34,10 +34,10 @@ Use the `CREATE PROCEDURE` statement to create a procedure in a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_procedure.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_procedure.md
@@ -34,10 +34,10 @@ Use the `CREATE PROCEDURE` statement to create a procedure in a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_rule.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_rule.md
@@ -34,10 +34,10 @@ Use the `CREATE RULE` statement to create a rule.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_rule.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_rule.md
@@ -34,10 +34,10 @@ Use the `CREATE RULE` statement to create a rule.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_schema.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_schema.md
@@ -36,10 +36,10 @@ Named objects in a schema can be accessed by using the schema name as prefix or 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_schema.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_schema.md
@@ -36,10 +36,10 @@ Named objects in a schema can be accessed by using the schema name as prefix or 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_sequence.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_sequence.md
@@ -34,10 +34,10 @@ Use the `CREATE SEQUENCE` statement to create a sequence in the current schema.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_sequence.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_sequence.md
@@ -34,10 +34,10 @@ Use the `CREATE SEQUENCE` statement to create a sequence in the current schema.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.diagram.md" %}}
   </div>
 </div>
 
@@ -55,7 +55,7 @@ The sequence name must be distinct from any other sequences, tables, indexes, vi
 
 #### INCREMENT BY *increment*
 
-Specify the *increment* value to add to the current sequence value to create a new value. The default value is `1`. A positive number 
+Specify the *increment* value to add to the current sequence value to create a new value. The default value is `1`. A positive number
 
 #### MINVALUE *minvalue* | NO MINVALUE
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_table.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_table.md
@@ -34,10 +34,10 @@ Use the `CREATE TABLE` statement to create a table in a database. It defines the
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_table.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_table.md
@@ -34,10 +34,10 @@ Use the `CREATE TABLE` statement to create a table in a database. It defines the
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_table_as.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_table_as.md
@@ -34,10 +34,10 @@ Use the `CREATE TABLE AS` statement to create a table using the output of a subq
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_table_as.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_table_as.md
@@ -34,10 +34,10 @@ Use the `CREATE TABLE AS` statement to create a table using the output of a subq
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_trigger.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_trigger.md
@@ -34,16 +34,16 @@ Use the `CREATE TRIGGER` statement to create a trigger.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.diagram.md" %}}
   </div>
 </div>
 
 ## Semantics
 
-- the `WHEN` condition can be used to specify whether the trigger should be fired. For low-level triggers it can reference the old and/or new values of the row's columns. 
+- the `WHEN` condition can be used to specify whether the trigger should be fired. For low-level triggers it can reference the old and/or new values of the row's columns.
 - multiple triggers can be defined for the same event. In that case, they will be fired in alphabetical order by name.
 
 ## Examples

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_trigger.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_trigger.md
@@ -34,10 +34,10 @@ Use the `CREATE TRIGGER` statement to create a trigger.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_type.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_type.md
@@ -34,10 +34,10 @@ Use the `CREATE TYPE` statement to create a user-defined type in a database.  Th
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_type.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_type.md
@@ -34,10 +34,10 @@ Use the `CREATE TYPE` statement to create a user-defined type in a database.  Th
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_view.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_view.md
@@ -34,10 +34,10 @@ Use the `CREATE VIEW` statement to create a view in a database. It defines the v
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_view.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_create_view.md
@@ -2,7 +2,7 @@
 title: CREATE VIEW statement [YSQL]
 headerTitle: CREATE VIEW
 linkTitle: CREATE VIEW
-description: Use the CREATE VIEW statement to create a view in a database. 
+description: Use the CREATE VIEW statement to create a view in a database.
 menu:
   v2.6:
     identifier: ddl_create_view
@@ -13,7 +13,7 @@ showAsideToc: true
 
 ## Synopsis
 
-Use the `CREATE VIEW` statement to create a view in a database. It defines the view name and the (select) statement defining it.  
+Use the `CREATE VIEW` statement to create a view in a database. It defines the view name and the (select) statement defining it.
 
 ## Syntax
 
@@ -34,10 +34,10 @@ Use the `CREATE VIEW` statement to create a view in a database. It defines the v
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_aggregate.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_aggregate.md
@@ -34,10 +34,10 @@ Use the `DROP AGGREGATE` statement to remove an aggregate.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_aggregate.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_aggregate.md
@@ -34,10 +34,10 @@ Use the `DROP AGGREGATE` statement to remove an aggregate.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_cast.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_cast.md
@@ -34,10 +34,10 @@ Use the `DROP CAST` statement to remove a cast.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_cast.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_cast.md
@@ -34,10 +34,10 @@ Use the `DROP CAST` statement to remove a cast.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_database.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_database.md
@@ -34,10 +34,10 @@ Use the `DROP DATABASE` statement to remove a database and all of its associated
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_database.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_database.md
@@ -2,7 +2,7 @@
 title: DROP DATABASE statement [YSQL]
 headerTitle: DROP DATABASE
 linkTitle: DROP DATABASE
-description: Use the DROP DATABASE statement to remove a database and all of its associated objects from the system. 
+description: Use the DROP DATABASE statement to remove a database and all of its associated objects from the system.
 menu:
   v2.6:
     identifier: ddl_drop_database
@@ -34,10 +34,10 @@ Use the `DROP DATABASE` statement to remove a database and all of its associated
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_domain.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_domain.md
@@ -34,10 +34,10 @@ Use the `DROP DOMAIN` statement to remove a domain from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_domain.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_domain.md
@@ -34,10 +34,10 @@ Use the `DROP DOMAIN` statement to remove a domain from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_extension.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_extension.md
@@ -35,10 +35,10 @@ Use the `DROP EXTENSION` statement to remove an extension from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_extension.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_extension.md
@@ -35,10 +35,10 @@ Use the `DROP EXTENSION` statement to remove an extension from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_function.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_function.md
@@ -34,10 +34,10 @@ Use the `DROP FUNCTION` statement to remove a function from a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_function.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_function.md
@@ -34,10 +34,10 @@ Use the `DROP FUNCTION` statement to remove a function from a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_operator.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_operator.md
@@ -34,10 +34,10 @@ Use the `DROP OPERATOR` statement to remove an operator.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_operator.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_operator.md
@@ -34,10 +34,10 @@ Use the `DROP OPERATOR` statement to remove an operator.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_operator_class.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_operator_class.md
@@ -34,10 +34,10 @@ Use the `DROP OPERATOR CLASS` statement to remove an operator class.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_operator_class.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_operator_class.md
@@ -34,10 +34,10 @@ Use the `DROP OPERATOR CLASS` statement to remove an operator class.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_procedure.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_procedure.md
@@ -34,10 +34,10 @@ Use the `DROP PROCEDURE` statement to remove a procedure from a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_procedure.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_procedure.md
@@ -34,10 +34,10 @@ Use the `DROP PROCEDURE` statement to remove a procedure from a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_rule.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_rule.md
@@ -34,10 +34,10 @@ Use the `DROP RULE` statement to remove a rule.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_rule.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_rule.md
@@ -34,10 +34,10 @@ Use the `DROP RULE` statement to remove a rule.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_sequence.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_sequence.md
@@ -34,10 +34,10 @@ Use the `DROP SEQUENCE` statement to delete a sequence in the current schema.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_sequence.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_sequence.md
@@ -34,10 +34,10 @@ Use the `DROP SEQUENCE` statement to delete a sequence in the current schema.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_table.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_table.md
@@ -34,10 +34,10 @@ Use the `DROP TABLE` statement to remove one or more tables (with all of their d
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_table.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_table.md
@@ -34,10 +34,10 @@ Use the `DROP TABLE` statement to remove one or more tables (with all of their d
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_trigger.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_trigger.md
@@ -34,10 +34,10 @@ Use the `DROP TRIGGER` statement to remove a trigger from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_trigger.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_trigger.md
@@ -34,10 +34,10 @@ Use the `DROP TRIGGER` statement to remove a trigger from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_type.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_type.md
@@ -34,10 +34,10 @@ Use the `DROP TYPE` statement to remove a user-defined type from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_type.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_drop_type.md
@@ -34,10 +34,10 @@ Use the `DROP TYPE` statement to remove a user-defined type from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_truncate.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_truncate.md
@@ -34,10 +34,10 @@ Use the `TRUNCATE` statement to clear all rows in a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_truncate.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/ddl_truncate.md
@@ -34,10 +34,10 @@ Use the `TRUNCATE` statement to clear all rows in a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dml_delete.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dml_delete.md
@@ -34,10 +34,10 @@ Use the `DELETE` statement to remove rows that meet certain conditions, and when
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dml_delete.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dml_delete.md
@@ -34,10 +34,10 @@ Use the `DELETE` statement to remove rows that meet certain conditions, and when
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.diagram.md" %}}
   </div>
 </div>
 
@@ -49,7 +49,7 @@ See the section [The WITH clause and common table expressions](../../with-clause
 
 - While the `WHERE` clause allows a wide range of operators, the exact conditions used in the `WHERE` clause have significant performance considerations (especially for large datasets). For the best performance, use a `WHERE` clause that provides values for all columns in `PRIMARY KEY` or `INDEX KEY`.
 
-### *delete* 
+### *delete*
 
 #### WITH [ RECURSIVE ] *with_query* [ , ... ] DELETE FROM [ ONLY ] *table_name* [ * ] [ [ AS ] *alias* ] [ WHERE *condition* | WHERE CURRENT OF *cursor_name* ] [ [*returning_clause*] (#returning-clause) ]
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dml_insert.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dml_insert.md
@@ -34,10 +34,10 @@ Use the `INSERT` statement to add one or more rows to the specified table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.diagram.md" %}}
   </div>
 </div>
 
@@ -45,7 +45,7 @@ See the section [The WITH clause and common table expressions](../../with-clause
 
 ## Semantics
 
-Constraints must be satisfied.  
+Constraints must be satisfied.
 
 ### *insert*
 
@@ -236,7 +236,7 @@ yugabyte=# SELECT id, c1, c2 FROM sample ORDER BY id;
 ```
 
 ```
- id |   c1   |    c2     
+ id |   c1   |    c2
 ----+--------+-----------
   1 | cat    | sparrow
   2 | dog    | blackbird

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dml_insert.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dml_insert.md
@@ -34,10 +34,10 @@ Use the `INSERT` statement to add one or more rows to the specified table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dml_select.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dml_select.md
@@ -36,10 +36,10 @@ The same syntax rules govern a subquery, wherever you might use one—like, for 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dml_select.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dml_select.md
@@ -36,10 +36,10 @@ The same syntax rules govern a subquery, wherever you might use one—like, for 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dml_update.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dml_update.md
@@ -34,10 +34,10 @@ Use the `UPDATE` statement to modify the values of specified columns in all rows
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dml_update.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dml_update.md
@@ -34,10 +34,10 @@ Use the `UPDATE` statement to modify the values of specified columns in all rows
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dml_values.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dml_values.md
@@ -34,10 +34,10 @@ Use the `VALUES` statement to generate a row set specified as an explicitly writ
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.diagram.md" %}}
   </div>
 </div>
 
@@ -53,7 +53,7 @@ values ('dog'::text);
 This is the result:
 
 ```
- column1 
+ column1
 ---------
  dog
 ```
@@ -68,7 +68,7 @@ values
 This is the result:
 
 ```
- column1 |       column2       | column3 
+ column1 |       column2       | column3
 ---------+---------------------+---------
        1 | 2019-06-25 12:05:30 | dog
        2 | 2020-07-30 13:10:45 | cat
@@ -117,7 +117,7 @@ select chr(v) as c from (
 This is the result:
 
 ```
- c 
+ c
 ---
  a
  b
@@ -137,7 +137,7 @@ select chr(v) as c from (
 This is the result:
 
 ```
- c 
+ c
 ---
  d
  o

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/dml_values.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/dml_values.md
@@ -34,10 +34,10 @@ Use the `VALUES` statement to generate a row set specified as an explicitly writ
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/perf_deallocate.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/perf_deallocate.md
@@ -34,10 +34,10 @@ Use the `DEALLOCATE` statement to deallocate a previously prepared SQL statement
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.diagram.md" %}}
   </div>
 </div>
 
@@ -60,7 +60,7 @@ yugabyte=# CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1,
 ```
 
 ```plpgsql
-yugabyte=# PREPARE ins (bigint, double precision, int, text) AS 
+yugabyte=# PREPARE ins (bigint, double precision, int, text) AS
                INSERT INTO sample(k1, k2, v1, v2) VALUES ($1, $2, $3, $4);
 ```
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/perf_deallocate.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/perf_deallocate.md
@@ -34,10 +34,10 @@ Use the `DEALLOCATE` statement to deallocate a previously prepared SQL statement
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/perf_execute.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/perf_execute.md
@@ -34,10 +34,10 @@ Use the `EXECUTE` statement to execute a previously prepared statement. This sep
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/perf_execute.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/perf_execute.md
@@ -2,7 +2,7 @@
 title: EXECUTE statement [YSQL]
 headerTitle: EXECUTE
 linkTitle: EXECUTE
-description: Use the EXECUTE statement to execute a previously prepared statement. 
+description: Use the EXECUTE statement to execute a previously prepared statement.
 menu:
   v2.6:
     identifier: perf_execute
@@ -34,10 +34,10 @@ Use the `EXECUTE` statement to execute a previously prepared statement. This sep
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.diagram.md" %}}
   </div>
 </div>
 
@@ -62,7 +62,7 @@ yugabyte=# CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1,
 - Prepare a simple insert.
 
 ```plpgsql
-yugabyte=# PREPARE ins (bigint, double precision, int, text) AS 
+yugabyte=# PREPARE ins (bigint, double precision, int, text) AS
                INSERT INTO sample(k1, k2, v1, v2) VALUES ($1, $2, $3, $4);
 ```
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/perf_explain.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/perf_explain.md
@@ -34,10 +34,10 @@ Use the `EXPLAIN` statement to show the execution plan for an statement. If the 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/perf_explain.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/perf_explain.md
@@ -34,10 +34,10 @@ Use the `EXPLAIN` statement to show the execution plan for an statement. If the 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/perf_prepare.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/perf_prepare.md
@@ -34,10 +34,10 @@ Use the `PREPARE` statement to create a handle to a prepared statement by parsin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.diagram.md" %}}
   </div>
 </div>
 
@@ -57,7 +57,7 @@ yugabyte=# CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1,
 Prepare a simple insert.
 
 ```plpgsql
-yugabyte=# PREPARE ins (bigint, double precision, int, text) AS 
+yugabyte=# PREPARE ins (bigint, double precision, int, text) AS
                INSERT INTO sample(k1, k2, v1, v2) VALUES ($1, $2, $3, $4);
 ```
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/perf_prepare.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/perf_prepare.md
@@ -34,10 +34,10 @@ Use the `PREPARE` statement to create a handle to a prepared statement by parsin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_abort.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_abort.md
@@ -34,10 +34,10 @@ Use the `ABORT` statement to roll back the current transaction and discards all 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_abort.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_abort.md
@@ -34,10 +34,10 @@ Use the `ABORT` statement to roll back the current transaction and discards all 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.diagram.md" %}}
   </div>
 </div>
 
@@ -66,7 +66,7 @@ yugabyte=# CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1,
 Begin a transaction and insert some rows.
 
 ```plpgsql
-yugabyte=# BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
+yugabyte=# BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 ```
 
 ```plpgsql

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_begin.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_begin.md
@@ -34,10 +34,10 @@ Use the `BEGIN` statement to start a transaction with the default (or given) iso
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.diagram.md" %}}
   </div>
 </div>
 
@@ -72,7 +72,7 @@ CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1, k2));
 Begin a transaction and insert some rows.
 
 ```plpgsql
-BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
+BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 ```
 
 ```plpgsql
@@ -82,7 +82,7 @@ INSERT INTO sample(k1, k2, v1, v2) VALUES (1, 2.0, 3, 'a'), (1, 3.0, 4, 'b');
 Start a new shell  with `ysqlsh` and begin another transaction to insert some more rows.
 
 ```plpgsql
-BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
+BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 ```
 
 ```plpgsql

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_begin.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_begin.md
@@ -34,10 +34,10 @@ Use the `BEGIN` statement to start a transaction with the default (or given) iso
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_commit.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_commit.md
@@ -34,10 +34,10 @@ Use the `COMMIT` statement to commit the current transaction. All changes made b
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.diagram.md" %}}
   </div>
 </div>
 
@@ -68,7 +68,7 @@ CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1, k2));
 Begin a transaction and insert some rows.
 
 ```plpgsql
-BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
+BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 ```
 
 ```plpgsql
@@ -78,7 +78,7 @@ INSERT INTO sample(k1, k2, v1, v2) VALUES (1, 2.0, 3, 'a'), (1, 3.0, 4, 'b');
 Start a new shell  with `ysqlsh` and begin another transaction to insert some more rows.
 
 ```plpgsql
-yugabyte=# BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
+yugabyte=# BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 ```
 
 ```plpgsql

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_commit.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_commit.md
@@ -34,10 +34,10 @@ Use the `COMMIT` statement to commit the current transaction. All changes made b
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_end.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_end.md
@@ -34,10 +34,10 @@ Use the `END` statement to commit the current transaction. All changes made by t
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_end.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_end.md
@@ -34,10 +34,10 @@ Use the `END` statement to commit the current transaction. All changes made by t
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_lock.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_lock.md
@@ -34,10 +34,10 @@ Use the `LOCK` statement to lock a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_lock.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_lock.md
@@ -34,10 +34,10 @@ Use the `LOCK` statement to lock a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_rollback.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_rollback.md
@@ -34,10 +34,10 @@ Use the `ROLLBACK` statement to roll back the current transactions. All changes 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_rollback.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_rollback.md
@@ -34,10 +34,10 @@ Use the `ROLLBACK` statement to roll back the current transactions. All changes 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_set.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_set.md
@@ -35,10 +35,10 @@ Use the `SET TRANSACTION` statement to set the current transaction isolation lev
 
 <div class="tab-content"> 
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_set.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_set.md
@@ -33,12 +33,12 @@ Use the `SET TRANSACTION` statement to set the current transaction isolation lev
   </li>
 </ul>
 
-<div class="tab-content"> 
+<div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_set_constraints.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_set_constraints.md
@@ -35,10 +35,10 @@ Use the `SET CONSTRAINTS` statement to set the timing of constraint checking wit
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_set_constraints.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_set_constraints.md
@@ -35,10 +35,10 @@ Use the `SET CONSTRAINTS` statement to set the timing of constraint checking wit
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_show.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_show.md
@@ -35,10 +35,10 @@ Use the `SHOW TRANSACTION` statement to show the current transaction isolation l
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_show.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/statements/txn_show.md
@@ -35,10 +35,10 @@ Use the `SHOW TRANSACTION` statement to show the current transaction isolation l
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/with-clause/recursive-cte.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/with-clause/recursive-cte.md
@@ -63,7 +63,7 @@ Notice that the parentheses that surround the _non-recursive term_ and the _recu
 This is the result:
 
 ```
- n 
+ n
 ---
  1
  2
@@ -95,10 +95,10 @@ The `WITH` clause syntax (see the section [WITH clause—SQL syntax and semantic
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.diagram.md" %}}
   </div>
 </div>
 
@@ -142,7 +142,7 @@ order by n desc;
 This is the result:
 
 ```
- n  
+ n
 ----
  99
  42
@@ -193,7 +193,7 @@ a1(n) as (
 then the statement executes without error to produce this result:
 
 ```
- n  
+ n
 ----
  99
   5
@@ -234,7 +234,7 @@ select n from r order by n;
 Notice that this is simply a _syntax_ example. Using `WITH` clauses within the recursive and non-recursive terms brings no value. The statement executes without error and produces this result:
 
 ```
- n 
+ n
 ---
  1
  2
@@ -306,7 +306,7 @@ select n from r order by n;
 This is the results:
 
 ```
- n 
+ n
 ---
  1
  2
@@ -339,15 +339,15 @@ A compact, and exact, formulation is given by using pseudocode. The _"RECURSIVE_
 > - **while the WORKING_RESULTS table is not empty loop**
 >
 >   - **Purge the TEMP_RESULTS table.**
->   
+>
 >   - **Evaluate the recursive term using the current contents of the WORKING_RESULTS table for the recursive self-reference, inserting the resulting rows into the TEMP_RESULTS table.**
->   
+>
 >   - **Purge the WORKING_RESULTS table and insert the contents of the TEMP_RESULTS table.**
->   
+>
 >   - **Append the contents of the TEMP_RESULTS table into the RECURSIVE_CTE_RESULTS table.**
->   
+>
 >- **end loop**
-> 
+>
 >- **Deliver the present contents of the RECURSIVE_CTE_RESULTS table as the final result.**
 
 ### PL/pgSQL procedure implementation of the pseudocode : example 1
@@ -436,24 +436,24 @@ select c1, c2 from r order by c1, c2;
 This is the result:
 
 ```
- c1 | c2 
+ c1 | c2
 ----+----
   0 |  1
   0 |  2
   0 |  3
-  
+
   1 |  2
   1 |  3
   1 |  4
-  
+
   2 |  3
   2 |  4
   2 |  5
-  
+
   3 |  4
   3 |  5
   3 |  6
-  
+
   4 |  5
   4 |  6
   4 |  7

--- a/docs/content/v2.6/api/ysql/the-sql-language/with-clause/recursive-cte.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/with-clause/recursive-cte.md
@@ -95,10 +95,10 @@ The `WITH` clause syntax (see the section [WITH clause—SQL syntax and semantic
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/api/ysql/the-sql-language/with-clause/with-clause-syntax-semantics.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/with-clause/with-clause-syntax-semantics.md
@@ -33,10 +33,10 @@ The [with_clause](../../../syntax_resources/grammar_diagrams/#with-clause)  and 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.diagram.md" %}}
   </div>
 </div>
 
@@ -92,7 +92,7 @@ order by 1, 2;
 This is the result:
 
 ```
- name | k | v  
+ name | k | v
 ------+---+----
  t1   | 1 |  2
  t1   | 2 |  4
@@ -108,16 +108,16 @@ This is the result:
 Now execute the example query. Notice that the `WITH` clause defines an `INSERT` CTE, an `UPDATE` CTE, a `DELETE` CTE, and a `SELECT` CTE. Each of the data-changing CTEs has a `RETURNING` clause; and the `SELECT` CTE accesses the unions returned by each of these.
 
 ```plpgsql
-with 
+with
   i as (
     insert into t1(k, v) values (21, 17), (31, 42) returning k, v),
-    
+
   u as (
     update t2 set v = 99 where k in (4, 5) returning k, v),
-    
+
   d as (
     delete from t3 where k in (8, 9) returning k, v),
-    
+
   s as (
     select 'inserted into t1'::text as action, k, v from i
     union all
@@ -131,7 +131,7 @@ select action, k, v from s order by k;
 This is the result:
 
 ```
-      action      | k  | v  
+      action      | k  | v
 ------------------+----+----
  udated in t2     |  4 | 99
  udated in t2     |  5 | 99
@@ -155,7 +155,7 @@ order by 1, 2;
 This is the result:
 
 ```
- name | k  | v  
+ name | k  | v
 ------+----+----
  t1   |  1 |  2
  t1   |  2 |  4
@@ -198,7 +198,7 @@ select k, v from t1 order by k;
 This is the result:
 
 ```
- k  | v  
+ k  | v
 ----+----
   1 |  2
   2 |  4
@@ -241,7 +241,7 @@ from colliding;
 This is the result:
 
 ```
-      colliding      
+      colliding
 ---------------------
  goodbye—Hello world
 ```

--- a/docs/content/v2.6/api/ysql/the-sql-language/with-clause/with-clause-syntax-semantics.md
+++ b/docs/content/v2.6/api/ysql/the-sql-language/with-clause/with-clause-syntax-semantics.md
@@ -33,10 +33,10 @@ The [with_clause](../../../syntax_resources/grammar_diagrams/#with-clause)  and 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/benchmark/tpcc-ysql/_index.md
+++ b/docs/content/v2.6/benchmark/tpcc-ysql/_index.md
@@ -87,16 +87,16 @@ Other options like username, password, port, etc. can be changed using the confi
 
 <div class="tab-content">
   <div id="10-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="10-wh-tab">
-    {{% includeMarkdown "10-wh/tpcc-ysql.md" /%}}
+    {{% includeMarkdown "10-wh/tpcc-ysql.md" %}}
   </div>
   <div id="100-wh" class="tab-pane fade show active" role="tabpanel" aria-labelledby="100-wh-tab">
-    {{% includeMarkdown "100-wh/tpcc-ysql.md" /%}}
+    {{% includeMarkdown "100-wh/tpcc-ysql.md" %}}
   </div>
   <div id="1000-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="1000-wh-tab">
-    {{% includeMarkdown "1000-wh/tpcc-ysql.md" /%}}
+    {{% includeMarkdown "1000-wh/tpcc-ysql.md" %}}
   </div>
   <div id="10000-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="10000-wh-tab">
-    {{% includeMarkdown "10000-wh/tpcc-ysql.md" /%}}
+    {{% includeMarkdown "10000-wh/tpcc-ysql.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/benchmark/tpcc-ysql/_index.md
+++ b/docs/content/v2.6/benchmark/tpcc-ysql/_index.md
@@ -87,16 +87,16 @@ Other options like username, password, port, etc. can be changed using the confi
 
 <div class="tab-content">
   <div id="10-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="10-wh-tab">
-    {{% includeMarkdown "10-wh/tpcc-ysql.md" %}}
+  {{% includeMarkdown "10-wh/tpcc-ysql.md" %}}
   </div>
   <div id="100-wh" class="tab-pane fade show active" role="tabpanel" aria-labelledby="100-wh-tab">
-    {{% includeMarkdown "100-wh/tpcc-ysql.md" %}}
+  {{% includeMarkdown "100-wh/tpcc-ysql.md" %}}
   </div>
   <div id="1000-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="1000-wh-tab">
-    {{% includeMarkdown "1000-wh/tpcc-ysql.md" %}}
+  {{% includeMarkdown "1000-wh/tpcc-ysql.md" %}}
   </div>
   <div id="10000-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="10000-wh-tab">
-    {{% includeMarkdown "10000-wh/tpcc-ysql.md" %}}
+  {{% includeMarkdown "10000-wh/tpcc-ysql.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/develop/explore-sample-apps.md
+++ b/docs/content/v2.6/develop/explore-sample-apps.md
@@ -45,15 +45,15 @@ After running Yugastore, Yugabyte recommend running the [IoT Fleet Management](.
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/run-sample-apps.md" /%}}
+    {{% includeMarkdown "binary/run-sample-apps.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/run-sample-apps.md" /%}}
+    {{% includeMarkdown "binary/run-sample-apps.md" %}}
   </div>
    <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/run-sample-apps.md" /%}}
+    {{% includeMarkdown "docker/run-sample-apps.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/run-sample-apps.md" /%}}
+    {{% includeMarkdown "kubernetes/run-sample-apps.md" %}}
   </div>
 </div>

--- a/docs/content/v2.6/develop/explore-sample-apps.md
+++ b/docs/content/v2.6/develop/explore-sample-apps.md
@@ -3,7 +3,7 @@ title: Explore YugabyteDB sample applications
 headerTitle: Explore sample applications
 linkTitle: Explore sample apps
 description: Explore sample applications running on YugabyteDB.
-headcontent: 
+headcontent:
 image: /images/section_icons/index/develop.png
 menu:
   v2.6:
@@ -45,15 +45,15 @@ After running Yugastore, Yugabyte recommend running the [IoT Fleet Management](.
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/run-sample-apps.md" %}}
+  {{% includeMarkdown "binary/run-sample-apps.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/run-sample-apps.md" %}}
+  {{% includeMarkdown "binary/run-sample-apps.md" %}}
   </div>
    <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/run-sample-apps.md" %}}
+  {{% includeMarkdown "docker/run-sample-apps.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/run-sample-apps.md" %}}
+  {{% includeMarkdown "kubernetes/run-sample-apps.md" %}}
   </div>
 </div>

--- a/docs/content/v2.6/explore/ysql-language-features/tablespaces.md
+++ b/docs/content/v2.6/explore/ysql-language-features/tablespaces.md
@@ -69,10 +69,10 @@ The differences between single-zone, multi-zone and multi-region configuration b
 
 <div class="tab-content">
   <div id="yugabyted" class="tab-pane fade show active" role="tabpanel" aria-labelledby="yugabyted-tab">
-    {{% includeMarkdown "./tablespaces-yugabyted.md" /%}}
+    {{% includeMarkdown "./tablespaces-yugabyted.md" %}}
   </div>
   <div id="platform" class="tab-pane fade show active" role="tabpanel" aria-labelledby="platform-tab">
-    {{% includeMarkdown "./tablespaces-platform.md" /%}}
+    {{% includeMarkdown "./tablespaces-platform.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/explore/ysql-language-features/tablespaces.md
+++ b/docs/content/v2.6/explore/ysql-language-features/tablespaces.md
@@ -69,10 +69,10 @@ The differences between single-zone, multi-zone and multi-region configuration b
 
 <div class="tab-content">
   <div id="yugabyted" class="tab-pane fade show active" role="tabpanel" aria-labelledby="yugabyted-tab">
-    {{% includeMarkdown "./tablespaces-yugabyted.md" %}}
+  {{% includeMarkdown "./tablespaces-yugabyted.md" %}}
   </div>
   <div id="platform" class="tab-pane fade show active" role="tabpanel" aria-labelledby="platform-tab">
-    {{% includeMarkdown "./tablespaces-platform.md" %}}
+  {{% includeMarkdown "./tablespaces-platform.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/quick-start/explore/ycql.md
+++ b/docs/content/v2.6/quick-start/explore/ycql.md
@@ -68,16 +68,16 @@ After [creating a local cluster](../../create-local-cluster/macos/), follow the 
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/explore-ycql.md" /%}}
+    {{% includeMarkdown "binary/explore-ycql.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/explore-ycql.md" /%}}
+    {{% includeMarkdown "binary/explore-ycql.md" %}}
   </div> 
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/explore-ycql.md" /%}}
+    {{% includeMarkdown "docker/explore-ycql.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/explore-ycql.md" /%}}
+    {{% includeMarkdown "kubernetes/explore-ycql.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/quick-start/explore/ycql.md
+++ b/docs/content/v2.6/quick-start/explore/ycql.md
@@ -30,7 +30,7 @@ showAsideToc: true
       YCQL
     </a>
   </li>
-  
+
 </ul>
 
 After [creating a local cluster](../../create-local-cluster/macos/), follow the instructions below to explore YugabyteDB's semi-relational [Yugabyte Cloud QL](../../../api/ycql/) API.
@@ -68,16 +68,16 @@ After [creating a local cluster](../../create-local-cluster/macos/), follow the 
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/explore-ycql.md" %}}
+  {{% includeMarkdown "binary/explore-ycql.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/explore-ycql.md" %}}
-  </div> 
+  {{% includeMarkdown "binary/explore-ycql.md" %}}
+  </div>
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/explore-ycql.md" %}}
+  {{% includeMarkdown "docker/explore-ycql.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/explore-ycql.md" %}}
+  {{% includeMarkdown "kubernetes/explore-ycql.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/quick-start/explore/ysql.md
+++ b/docs/content/v2.6/quick-start/explore/ysql.md
@@ -1,6 +1,6 @@
 ---
 title: Explore YSQL, the Yugabyte SQL API
-headerTitle: 3. Explore Yugabyte SQL 
+headerTitle: 3. Explore Yugabyte SQL
 linkTitle: 3. Explore distributed SQL APIs
 description: Explore Yugabyte SQL (YSQL), a PostgreSQL-compatible fully-relational distributed SQL API
 image: /images/section_icons/quick_start/explore_ysql.png
@@ -30,7 +30,7 @@ showAsideToc: true
       YCQL
     </a>
   </li>
-  
+
 </ul>
 
 After [creating a local cluster](../../create-local-cluster/macos/), you can start exploring YugabyteDB's PostgreSQL-compatible, fully-relational [Yugabyte SQL API](../../../api/ysql/).
@@ -82,16 +82,16 @@ The `share` directory includes sample dataset files available for creating datab
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/explore-ysql.md" %}}
+  {{% includeMarkdown "binary/explore-ysql.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/explore-ysql.md" %}}
+  {{% includeMarkdown "binary/explore-ysql.md" %}}
   </div>
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/explore-ysql.md" %}}
+  {{% includeMarkdown "docker/explore-ysql.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/explore-ysql.md" %}}
+  {{% includeMarkdown "kubernetes/explore-ysql.md" %}}
   </div>
 </div>
 
@@ -145,17 +145,17 @@ You should see an output like the following:
 
 ```output
                                         Table "public.products"
-   Column   |            Type             | Collation | Nullable |               Default                
+   Column   |            Type             | Collation | Nullable |               Default
 ------------+-----------------------------+-----------+----------+--------------------------------------
  id         | bigint                      |           | not null | nextval('products_id_seq'::regclass)
- created_at | timestamp without time zone |           |          | 
- category   | text                        |           |          | 
- ean        | text                        |           |          | 
- price      | double precision            |           |          | 
+ created_at | timestamp without time zone |           |          |
+ category   | text                        |           |          |
+ ean        | text                        |           |          |
+ price      | double precision            |           |          |
  quantity   | integer                     |           |          | 5000
- rating     | double precision            |           |          | 
- title      | text                        |           |          | 
- vendor     | text                        |           |          | 
+ rating     | double precision            |           |          |
+ title      | text                        |           |          |
+ vendor     | text                        |           |          |
 Indexes:
     "products_pkey" PRIMARY KEY, lsm (id HASH)
 ```
@@ -186,7 +186,7 @@ yb_demo=# SELECT id, title, category, price, rating
 You should see an output like the following:
 
 ```output
- id  |           title            | category |      price       | rating 
+ id  |           title            | category |      price       | rating
 -----+----------------------------+----------+------------------+--------
   22 | Enormous Marble Shoes      | Gizmo    | 21.4245199604423 |    4.2
   38 | Lightweight Leather Gloves | Gadget   | 44.0462485589292 |    3.8
@@ -207,7 +207,7 @@ yb_demo=# SELECT id, title, category, price, rating
 You should see an output which looks like the following:
 
 ```output
- id  |           title           | category  |      price       | rating 
+ id  |           title           | category  |      price       | rating
 -----+---------------------------+-----------+------------------+--------
  152 | Enormous Aluminum Clock   | Widget    | 32.5971248660044 |    3.6
    3 | Synergistic Granite Chair | Doohickey | 35.3887448815391 |      4
@@ -277,7 +277,7 @@ VALUES (
   (SELECT max(id)+1 FROM orders)                 /* id */,
   now()                                          /* created_at */,
   1                                              /* user_id */,
-  2                                              /* product_id */, 
+  2                                              /* product_id */,
   0                                              /* discount */,
   10                                             /* quantity */,
   (10 * (SELECT price FROM products WHERE id=2)) /* subtotal */,
@@ -298,7 +298,7 @@ yb_demo=# select * from orders where id = (select max(id) from orders);
 ```
 
 ```output
-  id   |         created_at         | user_id | product_id | discount | quantity |     subtotal     | tax |      total       
+  id   |         created_at         | user_id | product_id | discount | quantity |     subtotal     | tax |      total
 -------+----------------------------+---------+------------+----------+----------+------------------+-----+------------------
  18761 | 2020-01-30 09:24:29.784078 |       1 |          2 |        0 |       10 | 700.798961307176 |   0 | 700.798961307176
 (1 row)
@@ -434,7 +434,7 @@ yb_demo=# \d
 ```
 
 ```plpgsql
-yb_demo=# SELECT source, 
+yb_demo=# SELECT source,
             total_sales * 100.0 / (SELECT SUM(total_sales) FROM channel) AS percent_sales
           FROM channel
           WHERE source='Facebook';

--- a/docs/content/v2.6/quick-start/explore/ysql.md
+++ b/docs/content/v2.6/quick-start/explore/ysql.md
@@ -82,16 +82,16 @@ The `share` directory includes sample dataset files available for creating datab
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/explore-ysql.md" /%}}
+    {{% includeMarkdown "binary/explore-ysql.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/explore-ysql.md" /%}}
+    {{% includeMarkdown "binary/explore-ysql.md" %}}
   </div>
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/explore-ysql.md" /%}}
+    {{% includeMarkdown "docker/explore-ysql.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/explore-ysql.md" /%}}
+    {{% includeMarkdown "kubernetes/explore-ysql.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/yedis/quick-start/_index.md
+++ b/docs/content/v2.6/yedis/quick-start/_index.md
@@ -46,16 +46,16 @@ After [creating a local cluster](../../quick-start/create-local-cluster/), follo
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/test-yedis.md" %}}
+  {{% includeMarkdown "binary/test-yedis.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/test-yedis.md" %}}
+  {{% includeMarkdown "binary/test-yedis.md" %}}
   </div>
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/test-yedis.md" %}}
+  {{% includeMarkdown "docker/test-yedis.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/test-yedis.md" %}}
+  {{% includeMarkdown "kubernetes/test-yedis.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.6/yedis/quick-start/_index.md
+++ b/docs/content/v2.6/yedis/quick-start/_index.md
@@ -46,16 +46,16 @@ After [creating a local cluster](../../quick-start/create-local-cluster/), follo
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/test-yedis.md" /%}}
+    {{% includeMarkdown "binary/test-yedis.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/test-yedis.md" /%}}
+    {{% includeMarkdown "binary/test-yedis.md" %}}
   </div>
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/test-yedis.md" /%}}
+    {{% includeMarkdown "docker/test-yedis.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/test-yedis.md" /%}}
+    {{% includeMarkdown "kubernetes/test-yedis.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/exprs/aggregate_functions/invocation-syntax-semantics.md
+++ b/docs/content/v2.8/api/ysql/exprs/aggregate_functions/invocation-syntax-semantics.md
@@ -35,10 +35,10 @@ The following six diagrams, [`select_start`](../../../syntax_resources/grammar_d
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.diagram.md" %}}
   </div>
 </div>
 These rules govern the invocation of aggregate functions as `SELECT` list items.
@@ -66,10 +66,10 @@ When aggregate functions are invoked using the syntax specified by either the `o
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.diagram.md" %}}
   </div>
 </div>
 
@@ -92,10 +92,10 @@ The result set may be restricted by the `HAVING` clause:
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/exprs/aggregate_functions/invocation-syntax-semantics.md
+++ b/docs/content/v2.8/api/ysql/exprs/aggregate_functions/invocation-syntax-semantics.md
@@ -35,10 +35,10 @@ The following six diagrams, [`select_start`](../../../syntax_resources/grammar_d
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/select_start,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation.diagram.md" %}}
   </div>
 </div>
 These rules govern the invocation of aggregate functions as `SELECT` list items.
@@ -66,10 +66,10 @@ When aggregate functions are invoked using the syntax specified by either the `o
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/group_by_clause,grouping_element.diagram.md" %}}
   </div>
 </div>
 
@@ -92,10 +92,10 @@ The result set may be restricted by the `HAVING` clause:
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/aggregate_functions/having_clause.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/exprs/window_functions/invocation-syntax-semantics.md
+++ b/docs/content/v2.8/api/ysql/exprs/window_functions/invocation-syntax-semantics.md
@@ -52,10 +52,10 @@ The following three diagrams, [`select_start`](../../../syntax_resources/grammar
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.diagram.md" %}}
   </div>
 </div>
 
@@ -82,10 +82,10 @@ A [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-defin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.diagram.md" %}}
   </div>
 </div>
 
@@ -108,10 +108,10 @@ A [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-defin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/exprs/window_functions/invocation-syntax-semantics.md
+++ b/docs/content/v2.8/api/ysql/exprs/window_functions/invocation-syntax-semantics.md
@@ -23,7 +23,7 @@ Notice these three different orthography styles:
 
 - `OVER` is a keyword that names a clause. You write such a keyword in a SQL statement.
 
-- [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-definition) is the name of a rule within the overall SQL grammar. You never type such a name in a SQL statement. It is written in bold lower case with underscores, as appropriate, between the English words. Because such a rule is always shown as a link, you can jump directly to the rule in the [Grammar Diagrams](../../../syntax_resources/grammar_diagrams/#abort) page. This page shows every single one of the SQL rules. It so happens that the [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-definition) rule starts with the keyword `WINDOW` and might therefore, according to the context of use, be referred to alternatively as the `WINDOW` clause. 
+- [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-definition) is the name of a rule within the overall SQL grammar. You never type such a name in a SQL statement. It is written in bold lower case with underscores, as appropriate, between the English words. Because such a rule is always shown as a link, you can jump directly to the rule in the [Grammar Diagrams](../../../syntax_resources/grammar_diagrams/#abort) page. This page shows every single one of the SQL rules. It so happens that the [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-definition) rule starts with the keyword `WINDOW` and might therefore, according to the context of use, be referred to alternatively as the `WINDOW` clause.
 
 - [_window frame_](./#frame-clause-semantics-for-window-functions) is a pure term of art. It is written in italic lower case with spaces, as appropriate, between the English words. You neither write it in a SQL statement nor use it to look up anything in the [Grammar Diagrams](../../../syntax_resources/grammar_diagrams/#abort) page. Because such a term of art is always shown as a link, you can jump directly to its definition within this _"Window function invocation—SQL syntax and semantics"_ page.
 
@@ -52,10 +52,10 @@ The following three diagrams, [`select_start`](../../../syntax_resources/grammar
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/select_start,window_clause,fn_over_window.diagram.md" %}}
   </div>
 </div>
 
@@ -82,10 +82,10 @@ A [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-defin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/window_definition.diagram.md" %}}
   </div>
 </div>
 
@@ -108,10 +108,10 @@ A [`window_definition`](../../../syntax_resources/grammar_diagrams/#window-defin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/exprs/window_functions/frame_clause,frame_bounds,frame_start,frame_end,frame_bound,frame_exclusion.diagram.md" %}}
   </div>
 </div>
 
@@ -182,7 +182,7 @@ The [`frame_clause`](../../../syntax_resources/grammar_diagrams/#frame-clause) s
 - The functions in the first group, [Window functions that return an "int" or "double precision" value as a "classifier" of the rank of the row within its window](../function-syntax-semantics/#window-functions-that-return-an-int-or-double-precision-value-as-a-classifier-of-the-rank-of-the-row-within-its-window), are not sensitive to what the [`frame_clause`](../../../syntax_resources/grammar_diagrams/#frame-clause) specifies and always use all of the rows in the current [_window_](./#the-window-definition-rule). Yugabyte recommends that you therefore omit the [`frame_clause`](../../../syntax_resources/grammar_diagrams/#frame-clause) in the `OVER` clause that you use to invoke these functions.
 
 - The functions in the second group, [Window functions that return columns of another row within the window](../function-syntax-semantics/#window-functions-that-return-column-s-of-another-row-within-the-window), make obvious sense when the scope within which the specified row is found is the entire [_window_](./#the-window-definition-rule). If you have one of the very rare use cases where the output that you want is produced by a different [`frame_clause`](../../../syntax_resources/grammar_diagrams/#frame-clause), then specify what you want explicitly. Otherwise, because it isn't the default, you must specify that the [_window frame_](./#frame-clause-semantics-for-window-functions) includes the entire current [_window_](./#the-window-definition-rule) like this:
-  
+
   ```
   range between unbounded preceding and unbounded following
   ```

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_analyze.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_analyze.md
@@ -46,10 +46,10 @@ To collect or update statistics, run the ANALYZE command manually.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/analyze,table_and_columns.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/analyze,table_and_columns.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/analyze,table_and_columns.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/analyze,table_and_columns.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_analyze.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_analyze.md
@@ -46,10 +46,10 @@ To collect or update statistics, run the ANALYZE command manually.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/analyze,table_and_columns.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/analyze,table_and_columns.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/analyze,table_and_columns.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/analyze,table_and_columns.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_call.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_call.md
@@ -34,10 +34,10 @@ Use the `CALL` statement to execute a stored procedure.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.diagram.md" %}}
   </div>
 </div>
 **Note:** The syntax and semantics of the `procedure_argument` (for example how to use the named parameter invocation style to avoid providing actual arguments for defaulted parameters) is the same for invoking a user-defined`FUNCTION`. A function cannot be invoked with the `CALL` statement. Rather, it's invoked as (part of) an expression in DML statements like `SELECT`.

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_call.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_call.md
@@ -34,10 +34,10 @@ Use the `CALL` statement to execute a stored procedure.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/call_procedure,procedure_argument,argument_name.diagram.md" %}}
   </div>
 </div>
 **Note:** The syntax and semantics of the `procedure_argument` (for example how to use the named parameter invocation style to avoid providing actual arguments for defaulted parameters) is the same for invoking a user-defined`FUNCTION`. A function cannot be invoked with the `CALL` statement. Rather, it's invoked as (part of) an expression in DML statements like `SELECT`.

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_copy.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_copy.md
@@ -34,10 +34,10 @@ Use the `COPY` statement to transfer data between tables and files. `COPY TO` co
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.diagram.md" %}}
   </div>
 </div>
 
@@ -59,7 +59,7 @@ Specify a `SELECT`, `VALUES`, `INSERT`, `UPDATE`, or `DELETE` statement whose re
 
 Specify the path of the file to be copied. An input file name can be an absolute or relative path, but an output file name must be an absolute path. Critically, the file must be located _server-side_ on the local filesystem of the YB-TServer that you connect to.
 
-To work with files that reside on the client, nominate `stdin` as the argument for `FROM` or `stdout` as the argument for `TO`.  
+To work with files that reside on the client, nominate `stdin` as the argument for `FROM` or `stdout` as the argument for `TO`.
 
 Alternatively, you can use the `\copy` metacommand in [`ysqlsh`](../../../../../admin/ysqlsh#copy-table-column-list-query-from-to-filename-program-command-stdin-stdout-pstdin-pstdout-with-option).
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_copy.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_copy.md
@@ -34,10 +34,10 @@ Use the `COPY` statement to transfer data between tables and files. `COPY TO` co
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/copy_from,copy_to,copy_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_do.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_do.md
@@ -36,10 +36,10 @@ The optional `LANGUAGE` clause can be written either before or after the code bl
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_do.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_do.md
@@ -36,10 +36,10 @@ The optional `LANGUAGE` clause can be written either before or after the code bl
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/do.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_reset.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_reset.md
@@ -34,10 +34,10 @@ Use the `RESET` statement to restore the value of a run-time parameter to the de
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_reset.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_reset.md
@@ -34,10 +34,10 @@ Use the `RESET` statement to restore the value of a run-time parameter to the de
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reset_stmt.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_set.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_set.md
@@ -1,7 +1,7 @@
 ---
 title: SET statement [YSQL]
 headerTitle: SET
-linkTitle: SET 
+linkTitle: SET
 description: Use the SET statement to update a run-time control parameter.
 menu:
   v2.8:
@@ -34,10 +34,10 @@ Use the `SET` statement to update a run-time control parameter.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_set.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_set.md
@@ -34,10 +34,10 @@ Use the `SET` statement to update a run-time control parameter.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_show.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_show.md
@@ -34,10 +34,10 @@ Use the `SHOW` statement to display the value of a run-time parameter.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_show.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/cmd_show.md
@@ -34,10 +34,10 @@ Use the `SHOW` statement to display the value of a run-time parameter.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_stmt.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_alter_default_privileges.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_alter_default_privileges.md
@@ -34,10 +34,10 @@ Use the `ALTER DEFAULT PRIVILEGES` statement to define the default access privil
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_alter_default_privileges.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_alter_default_privileges.md
@@ -34,10 +34,10 @@ Use the `ALTER DEFAULT PRIVILEGES` statement to define the default access privil
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_default_priv,abbr_grant_or_revoke,a_grant_table,a_grant_seq,a_grant_func,a_grant_type,a_grant_schema,a_revoke_table,a_revoke_seq,a_revoke_func,a_revoke_type,a_revoke_schema,grant_table_priv,grant_seq_priv,grant_role_spec.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_alter_group.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_alter_group.md
@@ -35,10 +35,10 @@ This is added for compatibility with Postgres. Its usage is discouraged. [`ALTER
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_alter_group.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_alter_group.md
@@ -35,10 +35,10 @@ This is added for compatibility with Postgres. Its usage is discouraged. [`ALTER
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_group,role_specification,alter_group_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_alter_policy.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_alter_policy.md
@@ -35,10 +35,10 @@ change the roles that the policy applies to and the `USING` and `CHECK` expressi
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.diagram.md" %}}
   </div>
 </div>
 
@@ -49,11 +49,11 @@ Where
 - `new_name` is the new name of the policy.
 - `role_name` is the role(s) to which the policy applies. Use `PUBLIC` if the policy should be
   applied to all roles.
-- `using_expression` is a SQL conditional expression. Only rows for which the condition returns to   
-  true will be visible in a `SELECT` and available for modification in an `UPDATE` or `DELETE`.      
-- `check_expression` is a SQL conditional expression that is used only for `INSERT` and `UPDATE`     
-  queries. Only rows for which the expression evaluates to true will be allowed in an `INSERT` or    
-  `UPDATE`. Note that unlike `using_expression`, this is evaluated against the proposed new contents 
+- `using_expression` is a SQL conditional expression. Only rows for which the condition returns to
+  true will be visible in a `SELECT` and available for modification in an `UPDATE` or `DELETE`.
+- `check_expression` is a SQL conditional expression that is used only for `INSERT` and `UPDATE`
+  queries. Only rows for which the expression evaluates to true will be allowed in an `INSERT` or
+  `UPDATE`. Note that unlike `using_expression`, this is evaluated against the proposed new contents
   of the row.
 
 ## Examples

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_alter_policy.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_alter_policy.md
@@ -35,10 +35,10 @@ change the roles that the policy applies to and the `USING` and `CHECK` expressi
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_policy,alter_policy_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_alter_role.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_alter_role.md
@@ -37,10 +37,10 @@ Other roles can only change their own password.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_alter_role.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_alter_role.md
@@ -37,10 +37,10 @@ Other roles can only change their own password.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_role,alter_role_option,role_specification,alter_role_rename,alter_role_config,config_setting.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_alter_user.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_alter_user.md
@@ -34,10 +34,10 @@ Use the `ALTER USER` statement to alter a role. `ALTER USER` is an alias for [`A
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_alter_user.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_alter_user.md
@@ -34,10 +34,10 @@ Use the `ALTER USER` statement to alter a role. `ALTER USER` is an alias for [`A
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_user,alter_role_option,role_specification,alter_user_rename,alter_user_config,config_setting.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_create_group.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_create_group.md
@@ -34,10 +34,10 @@ Use the `CREATE GROUP` statement to create a group role. `CREATE GROUP` is an al
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_create_group.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_create_group.md
@@ -34,10 +34,10 @@ Use the `CREATE GROUP` statement to create a group role. `CREATE GROUP` is an al
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_group,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_create_policy.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_create_policy.md
@@ -37,10 +37,10 @@ policies to take effect.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.diagram.md" %}}
   </div>
 </div>
 
@@ -51,7 +51,7 @@ Where
 - `table_name` is the name of the table that the policy applies to.
 - `PERMISSIVE` / `RESTRICTIVE` specifies that the policy is permissive or restrictive.
 While applying policies to a table, permissive policies are combined together using a logical OR operator,
-while restrictive policies are combined using logical AND operator. Restrictive policies are used to 
+while restrictive policies are combined using logical AND operator. Restrictive policies are used to
 reduce the number of records that can be accessed. Default is permissive.
 - `role_name` is the role(s) to which the policy is applied. Default is `PUBLIC` which applies the
   policy to all roles.

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_create_policy.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_create_policy.md
@@ -37,10 +37,10 @@ policies to take effect.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_policy.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_create_role.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_create_role.md
@@ -40,10 +40,10 @@ You can use `GRANT`/`REVOKE` commands to set/remove permissions for roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_create_role.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_create_role.md
@@ -40,10 +40,10 @@ You can use `GRANT`/`REVOKE` commands to set/remove permissions for roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_role,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_create_user.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_create_user.md
@@ -34,10 +34,10 @@ Use the `CREATE USER` statement to create a user. The `CREATE USER` statement is
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_create_user.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_create_user.md
@@ -34,10 +34,10 @@ Use the `CREATE USER` statement to create a user. The `CREATE USER` statement is
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_user,role_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_drop_group.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_drop_group.md
@@ -33,10 +33,10 @@ Use the `DROP GROUP` statement to drop a role. `DROP GROUP` is an alias for [`DR
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_drop_group.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_drop_group.md
@@ -33,10 +33,10 @@ Use the `DROP GROUP` statement to drop a role. `DROP GROUP` is an alias for [`DR
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_group.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_drop_owned.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_drop_owned.md
@@ -35,10 +35,10 @@ Any privileges granted to the given roles on objects in the current database or 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_drop_owned.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_drop_owned.md
@@ -35,10 +35,10 @@ Any privileges granted to the given roles on objects in the current database or 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_owned,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_drop_policy.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_drop_policy.md
@@ -36,10 +36,10 @@ deny all policy will be applied for the table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_drop_policy.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_drop_policy.md
@@ -36,10 +36,10 @@ deny all policy will be applied for the table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_policy.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_drop_role.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_drop_role.md
@@ -34,10 +34,10 @@ Use the `DROP ROLE` statement to remove the specified roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_drop_role.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_drop_role.md
@@ -34,10 +34,10 @@ Use the `DROP ROLE` statement to remove the specified roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_drop_user.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_drop_user.md
@@ -34,10 +34,10 @@ Use the `DROP USER` statement to drop a user or role. `DROP USER` is an alias fo
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_drop_user.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_drop_user.md
@@ -34,10 +34,10 @@ Use the `DROP USER` statement to drop a user or role. `DROP USER` is an alias fo
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_user.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_grant.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_grant.md
@@ -34,10 +34,10 @@ Use the `GRANT` statement to grant access privileges on database objects as well
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_grant.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_grant.md
@@ -34,10 +34,10 @@ Use the `GRANT` statement to grant access privileges on database objects as well
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/grant_table,grant_table_col,grant_seq,grant_db,grant_domain,grant_schema,grant_type,grant_role,grant_role_spec.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_reassign_owned.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_reassign_owned.md
@@ -34,10 +34,10 @@ Use the `REASSIGN OWNED` statement to change the ownership of database objects o
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_reassign_owned.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_reassign_owned.md
@@ -34,10 +34,10 @@ Use the `REASSIGN OWNED` statement to change the ownership of database objects o
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/reassign_owned,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_revoke.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_revoke.md
@@ -34,10 +34,10 @@ Use the `REVOKE` statement to remove access privileges from one or more roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_revoke.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_revoke.md
@@ -34,10 +34,10 @@ Use the `REVOKE` statement to remove access privileges from one or more roles.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/revoke_table,revoke_table_col,revoke_seq,revoke_db,revoke_domain,revoke_schema,revoke_type,revoke_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_set_role.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_set_role.md
@@ -34,10 +34,10 @@ Use the `SET ROLE` statement to set the current user of the current session to b
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_set_role.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_set_role.md
@@ -34,10 +34,10 @@ Use the `SET ROLE` statement to set the current user of the current session to b
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_role,reset_role.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_set_session_authorization.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_set_session_authorization.md
@@ -34,10 +34,10 @@ Use the `SET SESSION AUTHORIZATION` statement to set the current user and sessio
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_set_session_authorization.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dcl_set_session_authorization.md
@@ -34,10 +34,10 @@ Use the `SET SESSION AUTHORIZATION` statement to set the current user and sessio
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_session_authorization,reset_session_authorization.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_alter_db.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_alter_db.md
@@ -34,10 +34,10 @@ Use the `ALTER DATABASE` statement to redefine the attributes of a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_alter_db.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_alter_db.md
@@ -34,10 +34,10 @@ Use the `ALTER DATABASE` statement to redefine the attributes of a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_database,alter_database_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_alter_domain.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_alter_domain.md
@@ -34,10 +34,10 @@ Use the `ALTER DOMAIN` statement to change the definition of a domain.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_alter_domain.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_alter_domain.md
@@ -34,10 +34,10 @@ Use the `ALTER DOMAIN` statement to change the definition of a domain.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_domain_default,alter_domain_rename.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_alter_sequence.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_alter_sequence.md
@@ -34,10 +34,10 @@ Use the `ALTER SEQUENCE` statement to change the definition of a sequence in the
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_alter_sequence.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_alter_sequence.md
@@ -34,10 +34,10 @@ Use the `ALTER SEQUENCE` statement to change the definition of a sequence in the
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_sequence,name,alter_sequence_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_alter_table.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_alter_table.md
@@ -34,10 +34,10 @@ Use the `ALTER TABLE` statement to change the definition of a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_alter_table.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_alter_table.md
@@ -34,10 +34,10 @@ Use the `ALTER TABLE` statement to change the definition of a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/alter_table,alter_table_action,alter_table_constraint,alter_column_constraint.diagram.md" %}}
   </div>
 </div>
 
@@ -72,7 +72,7 @@ Renaming a table is a non blocking metadata change operation.
 
 #### DROP [ COLUMN ] *column_name* [ RESTRICT | CASCADE ]
 
-Drop the named column from the table. 
+Drop the named column from the table.
 
 - `RESTRICT` — Remove only the specified
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_comment.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_comment.md
@@ -34,10 +34,10 @@ Use the `COMMENT` statement to set, update, or remove a comment on a database ob
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_comment.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_comment.md
@@ -34,10 +34,10 @@ Use the `COMMENT` statement to set, update, or remove a comment on a database ob
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/comment_on.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_aggregate.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_aggregate.md
@@ -35,10 +35,10 @@ create aggregates.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_aggregate.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_aggregate.md
@@ -35,10 +35,10 @@ create aggregates.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_aggregate,create_aggregate_normal,create_aggregate_order_by,create_aggregate_old,aggregate_arg,aggregate_normal_option,aggregate_order_by_option,aggregate_old_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_cast.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_cast.md
@@ -34,10 +34,10 @@ Use the `CREATE CAST` statement to create a cast.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_cast.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_cast.md
@@ -34,10 +34,10 @@ Use the `CREATE CAST` statement to create a cast.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_cast,create_cast_with_function,create_cast_without_function,create_cast_with_inout,cast_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_database.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_database.md
@@ -34,10 +34,10 @@ Use the `CREATE DATABASE` statement to create a database that functions as a gro
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_database.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_database.md
@@ -34,10 +34,10 @@ Use the `CREATE DATABASE` statement to create a database that functions as a gro
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_database,create_database_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_domain.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_domain.md
@@ -34,10 +34,10 @@ Use the `CREATE DOMAIN` statement to create a user-defined data type with option
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_domain.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_domain.md
@@ -34,10 +34,10 @@ Use the `CREATE DOMAIN` statement to create a user-defined data type with option
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_domain,domain_constraint.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_extension.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_extension.md
@@ -35,10 +35,10 @@ Use the `CREATE EXTENSION` statement to load an extension into a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_extension.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_extension.md
@@ -35,10 +35,10 @@ Use the `CREATE EXTENSION` statement to load an extension into a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_extension.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_function.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_function.md
@@ -34,10 +34,10 @@ Use the `CREATE FUNCTION` statement to create a function in a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_function.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_function.md
@@ -34,10 +34,10 @@ Use the `CREATE FUNCTION` statement to create a function in a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_function,arg_decl.diagram.md" %}}
   </div>
 </div>
 
@@ -47,14 +47,14 @@ Use the `CREATE FUNCTION` statement to create a function in a database.
 
 - The languages supported by default are `sql`, `plpgsql` and `C`.
 
-- `VOLATILE`, `STABLE` and `IMMUTABLE` inform the query optimizer about the behavior the function. 
+- `VOLATILE`, `STABLE` and `IMMUTABLE` inform the query optimizer about the behavior the function.
     - `VOLATILE` is the default and indicates that the function result could be different for every call. For instance `random()` or `now()`.
     - `STABLE` indicates that the function cannot modify the database so that within a single scan it will return the same result given the same arguments.
     - `IMMUTABLE` indicates that the function cannot modify the database _and_ always returns the same results given the same arguments.
 
 - `CALLED ON NULL INPUT`, `RETURNS NULL ON NULL INPUT` and `STRICT` define the function's behavior with respect to 'null's.
     - `CALLED ON NULL INPUT` indicates that input arguments may be `null`.
-    - `RETURNS NULL ON NULL INPUT` or `STRICT` indicate that the function always returns `null` if any of its arguments are `null`. 
+    - `RETURNS NULL ON NULL INPUT` or `STRICT` indicate that the function always returns `null` if any of its arguments are `null`.
 
 ## Examples
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_index.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_index.md
@@ -34,10 +34,10 @@ Use the `CREATE INDEX` statement to create an index on the specified columns of 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_index.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_index.md
@@ -34,10 +34,10 @@ Use the `CREATE INDEX` statement to create an index on the specified columns of 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_index,index_elem.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_operator.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_operator.md
@@ -34,10 +34,10 @@ Use the `CREATE OPERATOR` statement to create an operator.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_operator.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_operator.md
@@ -34,10 +34,10 @@ Use the `CREATE OPERATOR` statement to create an operator.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator,operator_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_operator_class.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_operator_class.md
@@ -34,10 +34,10 @@ Use the `CREATE OPERATOR CLASS` statement to create an operator class.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_operator_class.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_operator_class.md
@@ -34,10 +34,10 @@ Use the `CREATE OPERATOR CLASS` statement to create an operator class.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_operator_class,operator_class_as.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_procedure.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_procedure.md
@@ -34,10 +34,10 @@ Use the `CREATE PROCEDURE` statement to create a procedure in a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_procedure.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_procedure.md
@@ -34,10 +34,10 @@ Use the `CREATE PROCEDURE` statement to create a procedure in a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_procedure,arg_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_rule.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_rule.md
@@ -34,10 +34,10 @@ Use the `CREATE RULE` statement to create a rule.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_rule.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_rule.md
@@ -34,10 +34,10 @@ Use the `CREATE RULE` statement to create a rule.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_rule,rule_event,command.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_schema.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_schema.md
@@ -36,10 +36,10 @@ Named objects in a schema can be accessed by using the schema name as prefix or 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_schema.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_schema.md
@@ -36,10 +36,10 @@ Named objects in a schema can be accessed by using the schema name as prefix or 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_schema_name,create_schema_role,schema_element,role_specification.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_sequence.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_sequence.md
@@ -34,10 +34,10 @@ Use the `CREATE SEQUENCE` statement to create a sequence in the current schema.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_sequence.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_sequence.md
@@ -34,10 +34,10 @@ Use the `CREATE SEQUENCE` statement to create a sequence in the current schema.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_sequence,sequence_name,sequence_options.diagram.md" %}}
   </div>
 </div>
 
@@ -55,7 +55,7 @@ The sequence name must be distinct from any other sequences, tables, indexes, vi
 
 #### INCREMENT BY *increment*
 
-Specify the *increment* value to add to the current sequence value to create a new value. The default value is `1`. A positive number 
+Specify the *increment* value to add to the current sequence value to create a new value. The default value is `1`. A positive number
 
 #### MINVALUE *minvalue* | NO MINVALUE
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_table.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_table.md
@@ -34,10 +34,10 @@ Use the `CREATE TABLE` statement to create a table in a database. It defines the
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_table.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_table.md
@@ -34,10 +34,10 @@ Use the `CREATE TABLE` statement to create a table in a database. It defines the
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table,table_elem,column_constraint,table_constraint,key_columns,hash_columns,range_columns,storage_parameters,storage_parameter,index_parameters,references_clause,split_row.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_table_as.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_table_as.md
@@ -34,10 +34,10 @@ Use the `CREATE TABLE AS` statement to create a table using the output of a subq
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_table_as.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_table_as.md
@@ -34,10 +34,10 @@ Use the `CREATE TABLE AS` statement to create a table using the output of a subq
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_table_as.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_trigger.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_trigger.md
@@ -34,16 +34,16 @@ Use the `CREATE TRIGGER` statement to create a trigger.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.diagram.md" %}}
   </div>
 </div>
 
 ## Semantics
 
-- the `WHEN` condition can be used to specify whether the trigger should be fired. For low-level triggers it can reference the old and/or new values of the row's columns. 
+- the `WHEN` condition can be used to specify whether the trigger should be fired. For low-level triggers it can reference the old and/or new values of the row's columns.
 - multiple triggers can be defined for the same event. In that case, they will be fired in alphabetical order by name.
 
 ## Examples

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_trigger.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_trigger.md
@@ -34,10 +34,10 @@ Use the `CREATE TRIGGER` statement to create a trigger.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_trigger,event.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_type.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_type.md
@@ -34,10 +34,10 @@ Use the `CREATE TYPE` statement to create a user-defined type in a database.  Th
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_type.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_type.md
@@ -34,10 +34,10 @@ Use the `CREATE TYPE` statement to create a user-defined type in a database.  Th
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_composite_type,create_enum_type,create_range_type,create_base_type,create_shell_type,composite_type_elem,range_type_option,base_type_option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_view.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_view.md
@@ -2,7 +2,7 @@
 title: CREATE VIEW statement [YSQL]
 headerTitle: CREATE VIEW
 linkTitle: CREATE VIEW
-description: Use the CREATE VIEW statement to create a view in a database. 
+description: Use the CREATE VIEW statement to create a view in a database.
 menu:
   v2.8:
     identifier: ddl_create_view
@@ -13,7 +13,7 @@ showAsideToc: true
 
 ## Synopsis
 
-Use the `CREATE VIEW` statement to create a view in a database. It defines the view name and the (select) statement defining it.  
+Use the `CREATE VIEW` statement to create a view in a database. It defines the view name and the (select) statement defining it.
 
 ## Syntax
 
@@ -34,10 +34,10 @@ Use the `CREATE VIEW` statement to create a view in a database. It defines the v
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_view.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_create_view.md
@@ -34,10 +34,10 @@ Use the `CREATE VIEW` statement to create a view in a database. It defines the v
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/create_view.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_aggregate.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_aggregate.md
@@ -34,10 +34,10 @@ Use the `DROP AGGREGATE` statement to remove an aggregate.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_aggregate.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_aggregate.md
@@ -34,10 +34,10 @@ Use the `DROP AGGREGATE` statement to remove an aggregate.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_aggregate,aggregate_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_cast.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_cast.md
@@ -34,10 +34,10 @@ Use the `DROP CAST` statement to remove a cast.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_cast.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_cast.md
@@ -34,10 +34,10 @@ Use the `DROP CAST` statement to remove a cast.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_cast.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_database.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_database.md
@@ -2,7 +2,7 @@
 title: DROP DATABASE statement [YSQL]
 headerTitle: DROP DATABASE
 linkTitle: DROP DATABASE
-description: Use the DROP DATABASE statement to remove a database and all of its associated objects from the system. 
+description: Use the DROP DATABASE statement to remove a database and all of its associated objects from the system.
 menu:
   v2.8:
     identifier: ddl_drop_database
@@ -34,10 +34,10 @@ Use the `DROP DATABASE` statement to remove a database and all of its associated
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_database.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_database.md
@@ -34,10 +34,10 @@ Use the `DROP DATABASE` statement to remove a database and all of its associated
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_database.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_domain.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_domain.md
@@ -34,10 +34,10 @@ Use the `DROP DOMAIN` statement to remove a domain from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_domain.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_domain.md
@@ -34,10 +34,10 @@ Use the `DROP DOMAIN` statement to remove a domain from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_domain.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_extension.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_extension.md
@@ -35,10 +35,10 @@ Use the `DROP EXTENSION` statement to remove an extension from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_extension.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_extension.md
@@ -35,10 +35,10 @@ Use the `DROP EXTENSION` statement to remove an extension from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_extension.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_function.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_function.md
@@ -34,10 +34,10 @@ Use the `DROP FUNCTION` statement to remove a function from a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_function.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_function.md
@@ -34,10 +34,10 @@ Use the `DROP FUNCTION` statement to remove a function from a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_function,argtype_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_operator.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_operator.md
@@ -34,10 +34,10 @@ Use the `DROP OPERATOR` statement to remove an operator.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_operator.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_operator.md
@@ -34,10 +34,10 @@ Use the `DROP OPERATOR` statement to remove an operator.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator,operator_signature.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_operator_class.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_operator_class.md
@@ -34,10 +34,10 @@ Use the `DROP OPERATOR CLASS` statement to remove an operator class.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_operator_class.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_operator_class.md
@@ -34,10 +34,10 @@ Use the `DROP OPERATOR CLASS` statement to remove an operator class.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_operator_class.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_procedure.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_procedure.md
@@ -34,10 +34,10 @@ Use the `DROP PROCEDURE` statement to remove a procedure from a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_procedure.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_procedure.md
@@ -34,10 +34,10 @@ Use the `DROP PROCEDURE` statement to remove a procedure from a database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_procedure,argtype_decl.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_rule.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_rule.md
@@ -34,10 +34,10 @@ Use the `DROP RULE` statement to remove a rule.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_rule.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_rule.md
@@ -34,10 +34,10 @@ Use the `DROP RULE` statement to remove a rule.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_rule.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_sequence.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_sequence.md
@@ -34,10 +34,10 @@ Use the `DROP SEQUENCE` statement to delete a sequence in the current schema.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_sequence.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_sequence.md
@@ -34,10 +34,10 @@ Use the `DROP SEQUENCE` statement to delete a sequence in the current schema.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_sequence.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_table.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_table.md
@@ -34,10 +34,10 @@ Use the `DROP TABLE` statement to remove one or more tables (with all of their d
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_table.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_table.md
@@ -34,10 +34,10 @@ Use the `DROP TABLE` statement to remove one or more tables (with all of their d
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_table.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_trigger.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_trigger.md
@@ -34,10 +34,10 @@ Use the `DROP TRIGGER` statement to remove a trigger from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_trigger.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_trigger.md
@@ -34,10 +34,10 @@ Use the `DROP TRIGGER` statement to remove a trigger from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_trigger.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_type.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_type.md
@@ -34,10 +34,10 @@ Use the `DROP TYPE` statement to remove a user-defined type from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_type.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_drop_type.md
@@ -34,10 +34,10 @@ Use the `DROP TYPE` statement to remove a user-defined type from the database.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/drop_type.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_truncate.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_truncate.md
@@ -34,10 +34,10 @@ Use the `TRUNCATE` statement to clear all rows in a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_truncate.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/ddl_truncate.md
@@ -34,10 +34,10 @@ Use the `TRUNCATE` statement to clear all rows in a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/truncate.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dml_delete.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dml_delete.md
@@ -34,10 +34,10 @@ Use the `DELETE` statement to remove rows that meet certain conditions, and when
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dml_delete.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dml_delete.md
@@ -34,10 +34,10 @@ Use the `DELETE` statement to remove rows that meet certain conditions, and when
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/delete,returning_clause.diagram.md" %}}
   </div>
 </div>
 
@@ -49,7 +49,7 @@ See the section [The WITH clause and common table expressions](../../with-clause
 
 - While the `WHERE` clause allows a wide range of operators, the exact conditions used in the `WHERE` clause have significant performance considerations (especially for large datasets). For the best performance, use a `WHERE` clause that provides values for all columns in `PRIMARY KEY` or `INDEX KEY`.
 
-### *delete* 
+### *delete*
 
 #### WITH [ RECURSIVE ] *with_query* [ , ... ] DELETE FROM [ ONLY ] *table_name* [ * ] [ [ AS ] *alias* ] [ WHERE *condition* | WHERE CURRENT OF *cursor_name* ] [ [*returning_clause*] (#returning-clause) ]
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dml_insert.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dml_insert.md
@@ -34,10 +34,10 @@ Use the `INSERT` statement to add one or more rows to the specified table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.diagram.md" %}}
   </div>
 </div>
 
@@ -45,7 +45,7 @@ See the section [The WITH clause and common table expressions](../../with-clause
 
 ## Semantics
 
-Constraints must be satisfied.  
+Constraints must be satisfied.
 
 ### *insert*
 
@@ -236,7 +236,7 @@ yugabyte=# SELECT id, c1, c2 FROM sample ORDER BY id;
 ```
 
 ```
- id |   c1   |    c2     
+ id |   c1   |    c2
 ----+--------+-----------
   1 | cat    | sparrow
   2 | dog    | blackbird

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dml_insert.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dml_insert.md
@@ -34,10 +34,10 @@ Use the `INSERT` statement to add one or more rows to the specified table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/insert,returning_clause,column_values,conflict_target,conflict_action.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dml_select.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dml_select.md
@@ -36,10 +36,10 @@ The same syntax rules govern a subquery, wherever you might use one—like, for 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dml_select.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dml_select.md
@@ -36,10 +36,10 @@ The same syntax rules govern a subquery, wherever you might use one—like, for 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/select,common_table_expression,fn_over_window,ordinary_aggregate_fn_invocation,within_group_aggregate_fn_invocation,grouping_element,order_expr.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dml_update.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dml_update.md
@@ -34,10 +34,10 @@ Use the `UPDATE` statement to modify the values of specified columns in all rows
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dml_update.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dml_update.md
@@ -34,10 +34,10 @@ Use the `UPDATE` statement to modify the values of specified columns in all rows
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/update,returning_clause,update_item,column_values,column_names.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dml_values.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dml_values.md
@@ -34,10 +34,10 @@ Use the `VALUES` statement to generate a row set specified as an explicitly writ
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.diagram.md" %}}
   </div>
 </div>
 
@@ -53,7 +53,7 @@ values ('dog'::text);
 This is the result:
 
 ```
- column1 
+ column1
 ---------
  dog
 ```
@@ -68,7 +68,7 @@ values
 This is the result:
 
 ```
- column1 |       column2       | column3 
+ column1 |       column2       | column3
 ---------+---------------------+---------
        1 | 2019-06-25 12:05:30 | dog
        2 | 2020-07-30 13:10:45 | cat
@@ -117,7 +117,7 @@ select chr(v) as c from (
 This is the result:
 
 ```
- c 
+ c
 ---
  a
  b
@@ -137,7 +137,7 @@ select chr(v) as c from (
 This is the result:
 
 ```
- c 
+ c
 ---
  d
  o

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/dml_values.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/dml_values.md
@@ -34,10 +34,10 @@ Use the `VALUES` statement to generate a row set specified as an explicitly writ
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/values,expression_list.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/perf_deallocate.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/perf_deallocate.md
@@ -34,10 +34,10 @@ Use the `DEALLOCATE` statement to deallocate a previously prepared SQL statement
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.diagram.md" %}}
   </div>
 </div>
 
@@ -60,7 +60,7 @@ yugabyte=# CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1,
 ```
 
 ```plpgsql
-yugabyte=# PREPARE ins (bigint, double precision, int, text) AS 
+yugabyte=# PREPARE ins (bigint, double precision, int, text) AS
                INSERT INTO sample(k1, k2, v1, v2) VALUES ($1, $2, $3, $4);
 ```
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/perf_deallocate.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/perf_deallocate.md
@@ -34,10 +34,10 @@ Use the `DEALLOCATE` statement to deallocate a previously prepared SQL statement
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/deallocate.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/perf_execute.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/perf_execute.md
@@ -34,10 +34,10 @@ Use the `EXECUTE` statement to execute a previously prepared statement. This sep
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/perf_execute.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/perf_execute.md
@@ -2,7 +2,7 @@
 title: EXECUTE statement [YSQL]
 headerTitle: EXECUTE
 linkTitle: EXECUTE
-description: Use the EXECUTE statement to execute a previously prepared statement. 
+description: Use the EXECUTE statement to execute a previously prepared statement.
 menu:
   v2.8:
     identifier: perf_execute
@@ -34,10 +34,10 @@ Use the `EXECUTE` statement to execute a previously prepared statement. This sep
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/execute_statement.diagram.md" %}}
   </div>
 </div>
 
@@ -62,7 +62,7 @@ yugabyte=# CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1,
 - Prepare a simple insert.
 
 ```plpgsql
-yugabyte=# PREPARE ins (bigint, double precision, int, text) AS 
+yugabyte=# PREPARE ins (bigint, double precision, int, text) AS
                INSERT INTO sample(k1, k2, v1, v2) VALUES ($1, $2, $3, $4);
 ```
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/perf_explain.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/perf_explain.md
@@ -34,10 +34,10 @@ Use the `EXPLAIN` statement to show the execution plan for an statement. If the 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/perf_explain.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/perf_explain.md
@@ -34,10 +34,10 @@ Use the `EXPLAIN` statement to show the execution plan for an statement. If the 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/explain,option.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/perf_prepare.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/perf_prepare.md
@@ -34,10 +34,10 @@ Use the `PREPARE` statement to create a handle to a prepared statement by parsin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.diagram.md" %}}
   </div>
 </div>
 
@@ -57,7 +57,7 @@ yugabyte=# CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1,
 Prepare a simple insert.
 
 ```plpgsql
-yugabyte=# PREPARE ins (bigint, double precision, int, text) AS 
+yugabyte=# PREPARE ins (bigint, double precision, int, text) AS
                INSERT INTO sample(k1, k2, v1, v2) VALUES ($1, $2, $3, $4);
 ```
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/perf_prepare.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/perf_prepare.md
@@ -34,10 +34,10 @@ Use the `PREPARE` statement to create a handle to a prepared statement by parsin
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/prepare_statement.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/savepoint_create.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/savepoint_create.md
@@ -34,10 +34,10 @@ Use the `SAVEPOINT` statement to define a new savepoint within the current trans
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_create.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_create.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_create.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_create.diagram.md" %}}
   </div>
 </div>
 
@@ -77,7 +77,7 @@ SELECT * FROM sample;
 ```
 
 ```output
- k  | v  
+ k  | v
 ----+----
   1 |  2
   3 |  4
@@ -92,7 +92,7 @@ SELECT * FROM sample;
 ```
 
 ```output
- k  | v  
+ k  | v
 ----+----
   1 |  2
 (1 row)
@@ -107,7 +107,7 @@ SELECT * FROM SAMPLE;
 ```
 
 ```output
- k  | v  
+ k  | v
 ----+----
   1 |  2
   5 |  6

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/savepoint_create.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/savepoint_create.md
@@ -34,10 +34,10 @@ Use the `SAVEPOINT` statement to define a new savepoint within the current trans
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_create.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_create.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_create.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_create.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/savepoint_release.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/savepoint_release.md
@@ -34,10 +34,10 @@ Use the `RELEASE SAVEPOINT` statement to release the server-side state associate
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_release.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_release.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_release.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_release.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/savepoint_release.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/savepoint_release.md
@@ -34,10 +34,10 @@ Use the `RELEASE SAVEPOINT` statement to release the server-side state associate
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_release.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_release.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_release.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_release.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/savepoint_rollback.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/savepoint_rollback.md
@@ -34,10 +34,10 @@ Use the `ROLLBACK TO SAVEPOINT` statement to revert the state of the transaction
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_rollback.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_rollback.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_rollback.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_rollback.diagram.md" %}}
   </div>
 </div>
 
@@ -107,7 +107,7 @@ SELECT * FROM sample;
 ```
 
 ```output
- k  | v  
+ k  | v
 ----+----
   1 |  2
   3 |  4

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/savepoint_rollback.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/savepoint_rollback.md
@@ -34,10 +34,10 @@ Use the `ROLLBACK TO SAVEPOINT` statement to revert the state of the transaction
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_rollback.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_rollback.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_rollback.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/savepoint_rollback.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_abort.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_abort.md
@@ -34,10 +34,10 @@ Use the `ABORT` statement to roll back the current transaction and discards all 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_abort.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_abort.md
@@ -34,10 +34,10 @@ Use the `ABORT` statement to roll back the current transaction and discards all 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/abort.diagram.md" %}}
   </div>
 </div>
 
@@ -66,7 +66,7 @@ yugabyte=# CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1,
 Begin a transaction and insert some rows.
 
 ```plpgsql
-yugabyte=# BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
+yugabyte=# BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 ```
 
 ```plpgsql

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_begin.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_begin.md
@@ -34,10 +34,10 @@ Use the `BEGIN` statement to start a transaction with the default (or given) iso
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.diagram.md" %}}
   </div>
 </div>
 
@@ -72,7 +72,7 @@ CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1, k2));
 Begin a transaction and insert some rows.
 
 ```plpgsql
-BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
+BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 ```
 
 ```plpgsql
@@ -82,7 +82,7 @@ INSERT INTO sample(k1, k2, v1, v2) VALUES (1, 2.0, 3, 'a'), (1, 3.0, 4, 'b');
 Start a new shell  with `ysqlsh` and begin another transaction to insert some more rows.
 
 ```plpgsql
-BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
+BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 ```
 
 ```plpgsql

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_begin.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_begin.md
@@ -34,10 +34,10 @@ Use the `BEGIN` statement to start a transaction with the default (or given) iso
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/begin.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_commit.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_commit.md
@@ -34,10 +34,10 @@ Use the `COMMIT` statement to commit the current transaction. All changes made b
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.diagram.md" %}}
   </div>
 </div>
 
@@ -68,7 +68,7 @@ CREATE TABLE sample(k1 int, k2 int, v1 int, v2 text, PRIMARY KEY (k1, k2));
 Begin a transaction and insert some rows.
 
 ```plpgsql
-BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
+BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 ```
 
 ```plpgsql
@@ -78,7 +78,7 @@ INSERT INTO sample(k1, k2, v1, v2) VALUES (1, 2.0, 3, 'a'), (1, 3.0, 4, 'b');
 Start a new shell  with `ysqlsh` and begin another transaction to insert some more rows.
 
 ```plpgsql
-yugabyte=# BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; 
+yugabyte=# BEGIN TRANSACTION; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 ```
 
 ```plpgsql

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_commit.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_commit.md
@@ -34,10 +34,10 @@ Use the `COMMIT` statement to commit the current transaction. All changes made b
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/commit.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_end.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_end.md
@@ -34,10 +34,10 @@ Use the `END` statement to commit the current transaction. All changes made by t
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_end.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_end.md
@@ -34,10 +34,10 @@ Use the `END` statement to commit the current transaction. All changes made by t
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/end.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_lock.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_lock.md
@@ -34,10 +34,10 @@ Use the `LOCK` statement to lock a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_lock.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_lock.md
@@ -34,10 +34,10 @@ Use the `LOCK` statement to lock a table.
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/lock_table,lockmode.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_rollback.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_rollback.md
@@ -34,10 +34,10 @@ Use the `ROLLBACK` statement to roll back the current transactions. All changes 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_rollback.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_rollback.md
@@ -34,10 +34,10 @@ Use the `ROLLBACK` statement to roll back the current transactions. All changes 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/rollback.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_set.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_set.md
@@ -35,10 +35,10 @@ Use the `SET TRANSACTION` statement to set the current transaction isolation lev
 
 <div class="tab-content"> 
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_set.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_set.md
@@ -33,12 +33,12 @@ Use the `SET TRANSACTION` statement to set the current transaction isolation lev
   </li>
 </ul>
 
-<div class="tab-content"> 
+<div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_transaction,transaction_mode,isolation_level,read_write_mode,deferrable_mode.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_set_constraints.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_set_constraints.md
@@ -35,10 +35,10 @@ Use the `SET CONSTRAINTS` statement to set the timing of constraint checking wit
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_set_constraints.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_set_constraints.md
@@ -35,10 +35,10 @@ Use the `SET CONSTRAINTS` statement to set the timing of constraint checking wit
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/set_constraints.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_show.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_show.md
@@ -35,10 +35,10 @@ Use the `SHOW TRANSACTION` statement to show the current transaction isolation l
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_show.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/statements/txn_show.md
@@ -35,10 +35,10 @@ Use the `SHOW TRANSACTION` statement to show the current transaction isolation l
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/statements/show_transaction.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/with-clause/recursive-cte.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/with-clause/recursive-cte.md
@@ -63,7 +63,7 @@ Notice that the parentheses that surround the _non-recursive term_ and the _recu
 This is the result:
 
 ```
- n 
+ n
 ---
  1
  2
@@ -95,10 +95,10 @@ The `WITH` clause syntax (see the section [WITH clause—SQL syntax and semantic
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.diagram.md" %}}
   </div>
 </div>
 
@@ -142,7 +142,7 @@ order by n desc;
 This is the result:
 
 ```
- n  
+ n
 ----
  99
  42
@@ -193,7 +193,7 @@ a1(n) as (
 then the statement executes without error to produce this result:
 
 ```
- n  
+ n
 ----
  99
   5
@@ -234,7 +234,7 @@ select n from r order by n;
 Notice that this is simply a _syntax_ example. Using `WITH` clauses within the recursive and non-recursive terms brings no value. The statement executes without error and produces this result:
 
 ```
- n 
+ n
 ---
  1
  2
@@ -306,7 +306,7 @@ select n from r order by n;
 This is the results:
 
 ```
- n 
+ n
 ---
  1
  2
@@ -339,15 +339,15 @@ A compact, and exact, formulation is given by using pseudocode. The _final_resul
 > - **while the _previous_results_ table is not empty loop**
 >
 >   - **Purge the _temp_results_ table.**
->   
+>
 >   - **Evaluate the recursive term using the current contents of the _previous_results_ table for the recursive self-reference, inserting the resulting rows into the _temp_results_ table.**
->   
+>
 >   - **Purge the _previous_results_ table and insert the contents of the _temp_results_ table.**
->   
+>
 >   - **Append the contents of the _temp_results_ table into the _final_results_ table.**
->   
+>
 >- **end loop**
-> 
+>
 >- **Deliver the present contents of the _final_results_ table so that whatever follows the recursive CTE can use them.**
 
 ### PL/pgSQL procedure implementation of the pseudocode : example 1
@@ -436,24 +436,24 @@ select c1, c2 from r order by c1, c2;
 This is the result:
 
 ```
- c1 | c2 
+ c1 | c2
 ----+----
   0 |  1
   0 |  2
   0 |  3
-  
+
   1 |  2
   1 |  3
   1 |  4
-  
+
   2 |  3
   2 |  4
   2 |  5
-  
+
   3 |  4
   3 |  5
   3 |  6
-  
+
   4 |  5
   4 |  6
   4 |  7

--- a/docs/content/v2.8/api/ysql/the-sql-language/with-clause/recursive-cte.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/with-clause/recursive-cte.md
@@ -95,10 +95,10 @@ The `WITH` clause syntax (see the section [WITH clause—SQL syntax and semantic
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/api/ysql/the-sql-language/with-clause/with-clause-syntax-semantics.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/with-clause/with-clause-syntax-semantics.md
@@ -33,10 +33,10 @@ The [with_clause](../../../syntax_resources/grammar_diagrams/#with-clause)  and 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.grammar.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.diagram.md" %}}
+  {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.diagram.md" %}}
   </div>
 </div>
 
@@ -92,7 +92,7 @@ order by 1, 2;
 This is the result:
 
 ```
- name | k | v  
+ name | k | v
 ------+---+----
  t1   | 1 |  2
  t1   | 2 |  4
@@ -108,16 +108,16 @@ This is the result:
 Now execute the example query. Notice that the `WITH` clause defines an `INSERT` CTE, an `UPDATE` CTE, a `DELETE` CTE, and a `SELECT` CTE. Each of the data-changing CTEs has a `RETURNING` clause; and the `SELECT` CTE accesses the unions returned by each of these.
 
 ```plpgsql
-with 
+with
   i as (
     insert into t1(k, v) values (21, 17), (31, 42) returning k, v),
-    
+
   u as (
     update t2 set v = 99 where k in (4, 5) returning k, v),
-    
+
   d as (
     delete from t3 where k in (8, 9) returning k, v),
-    
+
   s as (
     select 'inserted into t1'::text as action, k, v from i
     union all
@@ -131,7 +131,7 @@ select action, k, v from s order by k;
 This is the result:
 
 ```
-      action      | k  | v  
+      action      | k  | v
 ------------------+----+----
  udated in t2     |  4 | 99
  udated in t2     |  5 | 99
@@ -155,7 +155,7 @@ order by 1, 2;
 This is the result:
 
 ```
- name | k  | v  
+ name | k  | v
 ------+----+----
  t1   |  1 |  2
  t1   |  2 |  4
@@ -198,7 +198,7 @@ select k, v from t1 order by k;
 This is the result:
 
 ```
- k  | v  
+ k  | v
 ----+----
   1 |  2
   2 |  4
@@ -241,7 +241,7 @@ from colliding;
 This is the result:
 
 ```
-      colliding      
+      colliding
 ---------------------
  goodbye—Hello world
 ```

--- a/docs/content/v2.8/api/ysql/the-sql-language/with-clause/with-clause-syntax-semantics.md
+++ b/docs/content/v2.8/api/ysql/the-sql-language/with-clause/with-clause-syntax-semantics.md
@@ -33,10 +33,10 @@ The [with_clause](../../../syntax_resources/grammar_diagrams/#with-clause)  and 
 
 <div class="tab-content">
   <div id="grammar" class="tab-pane fade show active" role="tabpanel" aria-labelledby="grammar-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.grammar.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.grammar.md" %}}
   </div>
   <div id="diagram" class="tab-pane fade" role="tabpanel" aria-labelledby="diagram-tab">
-    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.diagram.md" /%}}
+    {{% includeMarkdown "../../syntax_resources/the-sql-language/with-clause/with_clause,common_table_expression.diagram.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/benchmark/tpcc-ysql/_index.md
+++ b/docs/content/v2.8/benchmark/tpcc-ysql/_index.md
@@ -106,16 +106,16 @@ Other options like username, password, port, etc. can be changed using the confi
 
 <div class="tab-content">
   <div id="10-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="10-wh-tab">
-    {{% includeMarkdown "10-wh/tpcc-ysql.md" %}}
+  {{% includeMarkdown "10-wh/tpcc-ysql.md" %}}
   </div>
   <div id="100-wh" class="tab-pane fade show active" role="tabpanel" aria-labelledby="100-wh-tab">
-    {{% includeMarkdown "100-wh/tpcc-ysql.md" %}}
+  {{% includeMarkdown "100-wh/tpcc-ysql.md" %}}
   </div>
   <div id="1000-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="1000-wh-tab">
-    {{% includeMarkdown "1000-wh/tpcc-ysql.md" %}}
+  {{% includeMarkdown "1000-wh/tpcc-ysql.md" %}}
   </div>
   <div id="10000-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="10000-wh-tab">
-    {{% includeMarkdown "10000-wh/tpcc-ysql.md" %}}
+  {{% includeMarkdown "10000-wh/tpcc-ysql.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/benchmark/tpcc-ysql/_index.md
+++ b/docs/content/v2.8/benchmark/tpcc-ysql/_index.md
@@ -106,16 +106,16 @@ Other options like username, password, port, etc. can be changed using the confi
 
 <div class="tab-content">
   <div id="10-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="10-wh-tab">
-    {{% includeMarkdown "10-wh/tpcc-ysql.md" /%}}
+    {{% includeMarkdown "10-wh/tpcc-ysql.md" %}}
   </div>
   <div id="100-wh" class="tab-pane fade show active" role="tabpanel" aria-labelledby="100-wh-tab">
-    {{% includeMarkdown "100-wh/tpcc-ysql.md" /%}}
+    {{% includeMarkdown "100-wh/tpcc-ysql.md" %}}
   </div>
   <div id="1000-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="1000-wh-tab">
-    {{% includeMarkdown "1000-wh/tpcc-ysql.md" /%}}
+    {{% includeMarkdown "1000-wh/tpcc-ysql.md" %}}
   </div>
   <div id="10000-wh" class="tab-pane fade" role="tabpanel" aria-labelledby="10000-wh-tab">
-    {{% includeMarkdown "10000-wh/tpcc-ysql.md" /%}}
+    {{% includeMarkdown "10000-wh/tpcc-ysql.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/develop/explore-sample-apps.md
+++ b/docs/content/v2.8/develop/explore-sample-apps.md
@@ -45,15 +45,15 @@ After running Yugastore, Yugabyte recommend running the [IoT Fleet Management](.
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/run-sample-apps.md" /%}}
+    {{% includeMarkdown "binary/run-sample-apps.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/run-sample-apps.md" /%}}
+    {{% includeMarkdown "binary/run-sample-apps.md" %}}
   </div>
    <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/run-sample-apps.md" /%}}
+    {{% includeMarkdown "docker/run-sample-apps.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/run-sample-apps.md" /%}}
+    {{% includeMarkdown "kubernetes/run-sample-apps.md" %}}
   </div>
 </div>

--- a/docs/content/v2.8/develop/explore-sample-apps.md
+++ b/docs/content/v2.8/develop/explore-sample-apps.md
@@ -3,7 +3,7 @@ title: Explore YugabyteDB sample applications
 headerTitle: Explore sample applications
 linkTitle: Explore sample apps
 description: Explore sample applications running on YugabyteDB.
-headcontent: 
+headcontent:
 image: /images/section_icons/index/develop.png
 menu:
   v2.8:
@@ -45,15 +45,15 @@ After running Yugastore, Yugabyte recommend running the [IoT Fleet Management](.
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/run-sample-apps.md" %}}
+  {{% includeMarkdown "binary/run-sample-apps.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/run-sample-apps.md" %}}
+  {{% includeMarkdown "binary/run-sample-apps.md" %}}
   </div>
    <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/run-sample-apps.md" %}}
+  {{% includeMarkdown "docker/run-sample-apps.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/run-sample-apps.md" %}}
+  {{% includeMarkdown "kubernetes/run-sample-apps.md" %}}
   </div>
 </div>

--- a/docs/content/v2.8/explore/ysql-language-features/tablespaces.md
+++ b/docs/content/v2.8/explore/ysql-language-features/tablespaces.md
@@ -69,10 +69,10 @@ The differences between single-zone, multi-zone and multi-region configuration b
 
 <div class="tab-content">
   <div id="yugabyted" class="tab-pane fade show active" role="tabpanel" aria-labelledby="yugabyted-tab">
-    {{% includeMarkdown "./tablespaces-yugabyted.md" /%}}
+    {{% includeMarkdown "./tablespaces-yugabyted.md" %}}
   </div>
   <div id="platform" class="tab-pane fade show active" role="tabpanel" aria-labelledby="platform-tab">
-    {{% includeMarkdown "./tablespaces-platform.md" /%}}
+    {{% includeMarkdown "./tablespaces-platform.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/explore/ysql-language-features/tablespaces.md
+++ b/docs/content/v2.8/explore/ysql-language-features/tablespaces.md
@@ -69,10 +69,10 @@ The differences between single-zone, multi-zone and multi-region configuration b
 
 <div class="tab-content">
   <div id="yugabyted" class="tab-pane fade show active" role="tabpanel" aria-labelledby="yugabyted-tab">
-    {{% includeMarkdown "./tablespaces-yugabyted.md" %}}
+  {{% includeMarkdown "./tablespaces-yugabyted.md" %}}
   </div>
   <div id="platform" class="tab-pane fade show active" role="tabpanel" aria-labelledby="platform-tab">
-    {{% includeMarkdown "./tablespaces-platform.md" %}}
+  {{% includeMarkdown "./tablespaces-platform.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/quick-start/explore/ycql.md
+++ b/docs/content/v2.8/quick-start/explore/ycql.md
@@ -68,16 +68,16 @@ After [creating a local cluster](../../create-local-cluster/macos/), follow the 
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/explore-ycql.md" /%}}
+    {{% includeMarkdown "binary/explore-ycql.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/explore-ycql.md" /%}}
+    {{% includeMarkdown "binary/explore-ycql.md" %}}
   </div> 
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/explore-ycql.md" /%}}
+    {{% includeMarkdown "docker/explore-ycql.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/explore-ycql.md" /%}}
+    {{% includeMarkdown "kubernetes/explore-ycql.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/quick-start/explore/ycql.md
+++ b/docs/content/v2.8/quick-start/explore/ycql.md
@@ -30,7 +30,7 @@ showAsideToc: true
       YCQL
     </a>
   </li>
-  
+
 </ul>
 
 After [creating a local cluster](../../create-local-cluster/macos/), follow the instructions below to explore YugabyteDB's semi-relational [Yugabyte Cloud QL](../../../api/ycql/) API.
@@ -68,16 +68,16 @@ After [creating a local cluster](../../create-local-cluster/macos/), follow the 
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/explore-ycql.md" %}}
+  {{% includeMarkdown "binary/explore-ycql.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/explore-ycql.md" %}}
-  </div> 
+  {{% includeMarkdown "binary/explore-ycql.md" %}}
+  </div>
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/explore-ycql.md" %}}
+  {{% includeMarkdown "docker/explore-ycql.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/explore-ycql.md" %}}
+  {{% includeMarkdown "kubernetes/explore-ycql.md" %}}
   </div>
 </div>
 

--- a/docs/content/v2.8/quick-start/explore/ysql.md
+++ b/docs/content/v2.8/quick-start/explore/ysql.md
@@ -1,6 +1,6 @@
 ---
 title: Explore YSQL, the Yugabyte SQL API
-headerTitle: 3. Explore Yugabyte SQL 
+headerTitle: 3. Explore Yugabyte SQL
 linkTitle: 3. Explore distributed SQL APIs
 description: Explore Yugabyte SQL (YSQL), a PostgreSQL-compatible fully-relational distributed SQL API
 image: /images/section_icons/quick_start/explore_ysql.png
@@ -30,7 +30,7 @@ showAsideToc: true
       YCQL
     </a>
   </li>
-  
+
 </ul>
 
 After [creating a local cluster](../../create-local-cluster/macos/), you can start exploring YugabyteDB's PostgreSQL-compatible, fully-relational [Yugabyte SQL API](../../../api/ysql/).
@@ -78,16 +78,16 @@ The following files are used:
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/explore-ysql.md" %}}
+  {{% includeMarkdown "binary/explore-ysql.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/explore-ysql.md" %}}
+  {{% includeMarkdown "binary/explore-ysql.md" %}}
   </div>
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/explore-ysql.md" %}}
+  {{% includeMarkdown "docker/explore-ysql.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/explore-ysql.md" %}}
+  {{% includeMarkdown "kubernetes/explore-ysql.md" %}}
   </div>
 </div>
 
@@ -132,17 +132,17 @@ You should see an output like the following:
 
 ```output
                                         Table "public.products"
-   Column   |            Type             | Collation | Nullable |               Default                
+   Column   |            Type             | Collation | Nullable |               Default
 ------------+-----------------------------+-----------+----------+--------------------------------------
  id         | bigint                      |           | not null | nextval('products_id_seq'::regclass)
- created_at | timestamp without time zone |           |          | 
- category   | text                        |           |          | 
- ean        | text                        |           |          | 
- price      | double precision            |           |          | 
+ created_at | timestamp without time zone |           |          |
+ category   | text                        |           |          |
+ ean        | text                        |           |          |
+ price      | double precision            |           |          |
  quantity   | integer                     |           |          | 5000
- rating     | double precision            |           |          | 
- title      | text                        |           |          | 
- vendor     | text                        |           |          | 
+ rating     | double precision            |           |          |
+ title      | text                        |           |          |
+ vendor     | text                        |           |          |
 Indexes:
     "products_pkey" PRIMARY KEY, lsm (id HASH)
 ```
@@ -173,7 +173,7 @@ yb_demo=# SELECT id, title, category, price, rating
 You should see output like the following:
 
 ```output
- id  |           title            | category |      price       | rating 
+ id  |           title            | category |      price       | rating
 -----+----------------------------+----------+------------------+--------
   22 | Enormous Marble Shoes      | Gizmo    | 21.4245199604423 |    4.2
   38 | Lightweight Leather Gloves | Gadget   | 44.0462485589292 |    3.8
@@ -194,7 +194,7 @@ yb_demo=# SELECT id, title, category, price, rating
 You should see an output which looks like the following:
 
 ```output
- id  |           title           | category  |      price       | rating 
+ id  |           title           | category  |      price       | rating
 -----+---------------------------+-----------+------------------+--------
  152 | Enormous Aluminum Clock   | Widget    | 32.5971248660044 |    3.6
    3 | Synergistic Granite Chair | Doohickey | 35.3887448815391 |      4
@@ -264,7 +264,7 @@ VALUES (
   (SELECT max(id)+1 FROM orders)                 /* id */,
   now()                                          /* created_at */,
   1                                              /* user_id */,
-  2                                              /* product_id */, 
+  2                                              /* product_id */,
   0                                              /* discount */,
   10                                             /* quantity */,
   (10 * (SELECT price FROM products WHERE id=2)) /* subtotal */,
@@ -285,7 +285,7 @@ yb_demo=# select * from orders where id = (select max(id) from orders);
 ```
 
 ```output
-  id   |         created_at         | user_id | product_id | discount | quantity |     subtotal     | tax |      total       
+  id   |         created_at         | user_id | product_id | discount | quantity |     subtotal     | tax |      total
 -------+----------------------------+---------+------------+----------+----------+------------------+-----+------------------
  18761 | 2020-01-30 09:24:29.784078 |       1 |          2 |        0 |       10 | 700.798961307176 |   0 | 700.798961307176
 (1 row)
@@ -421,7 +421,7 @@ yb_demo=# \d
 ```
 
 ```plpgsql
-yb_demo=# SELECT source, 
+yb_demo=# SELECT source,
             total_sales * 100.0 / (SELECT SUM(total_sales) FROM channel) AS percent_sales
           FROM channel
           WHERE source='Facebook';

--- a/docs/content/v2.8/quick-start/explore/ysql.md
+++ b/docs/content/v2.8/quick-start/explore/ysql.md
@@ -78,16 +78,16 @@ The following files are used:
 
 <div class="tab-content">
   <div id="macos" class="tab-pane fade show active" role="tabpanel" aria-labelledby="macos-tab">
-    {{% includeMarkdown "binary/explore-ysql.md" /%}}
+    {{% includeMarkdown "binary/explore-ysql.md" %}}
   </div>
   <div id="linux" class="tab-pane fade" role="tabpanel" aria-labelledby="linux-tab">
-    {{% includeMarkdown "binary/explore-ysql.md" /%}}
+    {{% includeMarkdown "binary/explore-ysql.md" %}}
   </div>
   <div id="docker" class="tab-pane fade" role="tabpanel" aria-labelledby="docker-tab">
-    {{% includeMarkdown "docker/explore-ysql.md" /%}}
+    {{% includeMarkdown "docker/explore-ysql.md" %}}
   </div>
   <div id="kubernetes" class="tab-pane fade" role="tabpanel" aria-labelledby="kubernetes-tab">
-    {{% includeMarkdown "kubernetes/explore-ysql.md" /%}}
+    {{% includeMarkdown "kubernetes/explore-ysql.md" %}}
   </div>
 </div>
 

--- a/docs/layouts/shortcodes/includeMarkdown.html
+++ b/docs/layouts/shortcodes/includeMarkdown.html
@@ -1,3 +1,2 @@
 {{ $includePath := (print .Page.File.Dir (.Get 0)) | printf "./content/%s" }}
 {{ readFile $includePath | safeHTML }}
-{{ .Inner }}

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -15,7 +15,7 @@
   CXXFLAGS = "-std=c++17"
 
 [context.production.environment]
-  HUGO_VERSION = "0.96.0"
+  HUGO_VERSION = "0.100.2"
   NODE_VERSION = "16"
   CXXFLAGS = "-std=c++17"
 

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -5,12 +5,12 @@
 # https://docs.netlify.com/configure-builds/file-based-configuration/#deploy-contexts
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.96.0"
+  HUGO_VERSION = "0.100.2"
   NODE_VERSION = "16"
   CXXFLAGS = "-std=c++17"
 
 [context.branch-deploy.environment]
-  HUGO_VERSION = "0.96.0"
+  HUGO_VERSION = "0.100.2"
   NODE_VERSION = "16"
   CXXFLAGS = "-std=c++17"
 


### PR DESCRIPTION
**Problem**: A recent Hugo update showed that we've been incorrectly closing a lot of shortcode tags. Tags should be of the form `{{% ... %}}`, but we had a bunch (all for includeMarkdown) with a slash in the closing, like this: `{{% ... /%}}`.

Older versions of Hugo just ignored the bad slash, but recent ones don't. This meant that over 1000 of our EBNF grammar and syntax diagrams displayed the markdown source, instead of syntax-highlighted EBNF or a rendered SVG diagram.

**Command** run to fix:

```bash
cd docs/content
find . -type f -exec perl -pi -e 's#(\{\{% .+ )(\/%\}\})#$1%\}\}#g' {} +
```

**Testing** is in two parts:

1. Verify that the PR preview correctly shows syntax-highlighted EBNF and syntax diagrams. Netlify is currently configured to use Hugo 0.96.0.
2. Update Hugo to 0.100.2, and re-verify.

@netlify /preview/api/ysql/the-sql-language/statements/ddl_create_database/#grammar