### PR TITLE
[Docs] Add docs on gflags for webserver SSL/authentication

### DIFF
--- a/docs/content/preview/reference/configuration/yb-master.md
+++ b/docs/content/preview/reference/configuration/yb-master.md
@@ -160,22 +160,19 @@ Default: The `www` directory in the YugabyteDB home directory.
 
 ##### --webserver_certificate_file
 
-Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is
-not enabled for the web server.
+Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is not enabled for the web server.
 
 Default: `""`
 
 ##### --webserver_authentication_domain
 
-Domain used for .htpasswd authentication. This should be used in conjunction with
-[`--webserver_password_file`](#webserver-password-file).
+Domain used for .htpasswd authentication. This should be used in conjunction with [`--webserver_password_file`](#webserver-password-file).
 
 Default: `""`
 
 ##### --webserver_password_file
 
-Location of .htpasswd file containing usernames and hashed passwords, for authentication to the
-web server.
+Location of .htpasswd file containing usernames and hashed passwords, for authentication to the web server.
 
 Default: `""`
 

--- a/docs/content/preview/reference/configuration/yb-master.md
+++ b/docs/content/preview/reference/configuration/yb-master.md
@@ -158,6 +158,27 @@ Monitoring web server home.
 
 Default: The `www` directory in the YugabyteDB home directory.
 
+##### --webserver_certificate_file
+
+Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is
+not enabled for the web server.
+
+Default: `""`
+
+##### --webserver_authentication_domain
+
+Domain used for .htpasswd authentication. This should be used in conjunction with
+[`--webserver_password_file`](#webserver-password-file).
+
+Default: `""`
+
+##### --webserver_password_file
+
+Location of .htpasswd file containing usernames and hashed passwords, for authentication to the
+web server.
+
+Default: `""`
+
 ---
 
 ### YSQL flags

--- a/docs/content/preview/reference/configuration/yb-tserver.md
+++ b/docs/content/preview/reference/configuration/yb-tserver.md
@@ -179,6 +179,27 @@ The monitoring web server home directory..
 
 Default: The `www` directory in the YugabyteDB home directory.
 
+##### --webserver_certificate_file
+
+Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is
+not enabled for the web server.
+
+Default: `""`
+
+##### --webserver_authentication_domain
+
+Domain used for .htpasswd authentication. This should be used in conjunction with
+[`--webserver_password_file`](#webserver-password-file).
+
+Default: `""`
+
+##### --webserver_password_file
+
+Location of .htpasswd file containing usernames and hashed passwords, for authentication to the
+web server.
+
+Default: `""`
+
 ---
 
 ### Logging flags

--- a/docs/content/preview/reference/configuration/yb-tserver.md
+++ b/docs/content/preview/reference/configuration/yb-tserver.md
@@ -181,22 +181,19 @@ Default: The `www` directory in the YugabyteDB home directory.
 
 ##### --webserver_certificate_file
 
-Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is
-not enabled for the web server.
+Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is not enabled for the web server.
 
 Default: `""`
 
 ##### --webserver_authentication_domain
 
-Domain used for .htpasswd authentication. This should be used in conjunction with
-[`--webserver_password_file`](#webserver-password-file).
+Domain used for .htpasswd authentication. This should be used in conjunction with [`--webserver_password_file`](#webserver-password-file).
 
 Default: `""`
 
 ##### --webserver_password_file
 
-Location of .htpasswd file containing usernames and hashed passwords, for authentication to the
-web server.
+Location of .htpasswd file containing usernames and hashed passwords, for authentication to the web server.
 
 Default: `""`
 

--- a/docs/content/stable/reference/configuration/yb-master.md
+++ b/docs/content/stable/reference/configuration/yb-master.md
@@ -153,6 +153,27 @@ Monitoring web server home.
 
 Default: The `www` directory in the YugabyteDB home directory.
 
+##### --webserver_certificate_file
+
+Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is
+not enabled for the web server.
+
+Default: `""`
+
+##### --webserver_authentication_domain
+
+Domain used for .htpasswd authentication. This should be used in conjunction with
+[`--webserver_password_file`](#webserver-password-file).
+
+Default: `""`
+
+##### --webserver_password_file
+
+Location of .htpasswd file containing usernames and hashed passwords, for authentication to the
+web server.
+
+Default: `""`
+
 ---
 
 ### YSQL flags

--- a/docs/content/stable/reference/configuration/yb-master.md
+++ b/docs/content/stable/reference/configuration/yb-master.md
@@ -155,22 +155,19 @@ Default: The `www` directory in the YugabyteDB home directory.
 
 ##### --webserver_certificate_file
 
-Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is
-not enabled for the web server.
+Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is not enabled for the web server.
 
 Default: `""`
 
 ##### --webserver_authentication_domain
 
-Domain used for .htpasswd authentication. This should be used in conjunction with
-[`--webserver_password_file`](#webserver-password-file).
+Domain used for .htpasswd authentication. This should be used in conjunction with [`--webserver_password_file`](#webserver-password-file).
 
 Default: `""`
 
 ##### --webserver_password_file
 
-Location of .htpasswd file containing usernames and hashed passwords, for authentication to the
-web server.
+Location of .htpasswd file containing usernames and hashed passwords, for authentication to the web server.
 
 Default: `""`
 

--- a/docs/content/stable/reference/configuration/yb-tserver.md
+++ b/docs/content/stable/reference/configuration/yb-tserver.md
@@ -176,22 +176,19 @@ Default: The `www` directory in the YugabyteDB home directory.
 
 ##### --webserver_certificate_file
 
-Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is
-not enabled for the web server.
+Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is not enabled for the web server.
 
 Default: `""`
 
 ##### --webserver_authentication_domain
 
-Domain used for .htpasswd authentication. This should be used in conjunction with
-[`--webserver_password_file`](#webserver-password-file).
+Domain used for .htpasswd authentication. This should be used in conjunction with [`--webserver_password_file`](#webserver-password-file).
 
 Default: `""`
 
 ##### --webserver_password_file
 
-Location of .htpasswd file containing usernames and hashed passwords, for authentication to the
-web server.
+Location of .htpasswd file containing usernames and hashed passwords, for authentication to the web server.
 
 Default: `""`
 

--- a/docs/content/stable/reference/configuration/yb-tserver.md
+++ b/docs/content/stable/reference/configuration/yb-tserver.md
@@ -174,6 +174,27 @@ The monitoring web server home directory..
 
 Default: The `www` directory in the YugabyteDB home directory.
 
+##### --webserver_certificate_file
+
+Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is
+not enabled for the web server.
+
+Default: `""`
+
+##### --webserver_authentication_domain
+
+Domain used for .htpasswd authentication. This should be used in conjunction with
+[`--webserver_password_file`](#webserver-password-file).
+
+Default: `""`
+
+##### --webserver_password_file
+
+Location of .htpasswd file containing usernames and hashed passwords, for authentication to the
+web server.
+
+Default: `""`
+
 ---
 
 ### Logging flags

--- a/docs/content/v2.4/reference/configuration/yb-master.md
+++ b/docs/content/v2.4/reference/configuration/yb-master.md
@@ -153,6 +153,27 @@ Monitoring web server home.
 
 Default: The `www` directory in the YugabyteDB home directory.
 
+##### --webserver_certificate_file
+
+Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is
+not enabled for the web server.
+
+Default: `""`
+
+##### --webserver_authentication_domain
+
+Domain used for .htpasswd authentication. This should be used in conjunction with
+[`--webserver_password_file`](#webserver-password-file).
+
+Default: `""`
+
+##### --webserver_password_file
+
+Location of .htpasswd file containing usernames and hashed passwords, for authentication to the
+web server.
+
+Default: `""`
+
 ---
 
 ### YSQL flags

--- a/docs/content/v2.4/reference/configuration/yb-master.md
+++ b/docs/content/v2.4/reference/configuration/yb-master.md
@@ -155,22 +155,19 @@ Default: The `www` directory in the YugabyteDB home directory.
 
 ##### --webserver_certificate_file
 
-Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is
-not enabled for the web server.
+Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is not enabled for the web server.
 
 Default: `""`
 
 ##### --webserver_authentication_domain
 
-Domain used for .htpasswd authentication. This should be used in conjunction with
-[`--webserver_password_file`](#webserver-password-file).
+Domain used for .htpasswd authentication. This should be used in conjunction with [`--webserver_password_file`](#webserver-password-file).
 
 Default: `""`
 
 ##### --webserver_password_file
 
-Location of .htpasswd file containing usernames and hashed passwords, for authentication to the
-web server.
+Location of .htpasswd file containing usernames and hashed passwords, for authentication to the web server.
 
 Default: `""`
 

--- a/docs/content/v2.4/reference/configuration/yb-tserver.md
+++ b/docs/content/v2.4/reference/configuration/yb-tserver.md
@@ -176,22 +176,19 @@ Default: The `www` directory in the YugabyteDB home directory.
 
 ##### --webserver_certificate_file
 
-Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is
-not enabled for the web server.
+Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is not enabled for the web server.
 
 Default: `""`
 
 ##### --webserver_authentication_domain
 
-Domain used for .htpasswd authentication. This should be used in conjunction with
-[`--webserver_password_file`](#webserver-password-file).
+Domain used for .htpasswd authentication. This should be used in conjunction with [`--webserver_password_file`](#webserver-password-file).
 
 Default: `""`
 
 ##### --webserver_password_file
 
-Location of .htpasswd file containing usernames and hashed passwords, for authentication to the
-web server.
+Location of .htpasswd file containing usernames and hashed passwords, for authentication to the web server.
 
 Default: `""`
 

--- a/docs/content/v2.4/reference/configuration/yb-tserver.md
+++ b/docs/content/v2.4/reference/configuration/yb-tserver.md
@@ -174,6 +174,27 @@ The monitoring web server home directory..
 
 Default: The `www` directory in the YugabyteDB home directory.
 
+##### --webserver_certificate_file
+
+Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is
+not enabled for the web server.
+
+Default: `""`
+
+##### --webserver_authentication_domain
+
+Domain used for .htpasswd authentication. This should be used in conjunction with
+[`--webserver_password_file`](#webserver-password-file).
+
+Default: `""`
+
+##### --webserver_password_file
+
+Location of .htpasswd file containing usernames and hashed passwords, for authentication to the
+web server.
+
+Default: `""`
+
 ---
 
 ### Logging flags

--- a/docs/content/v2.6/reference/configuration/yb-master.md
+++ b/docs/content/v2.6/reference/configuration/yb-master.md
@@ -153,6 +153,27 @@ Monitoring web server home.
 
 Default: The `www` directory in the YugabyteDB home directory.
 
+##### --webserver_certificate_file
+
+Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is
+not enabled for the web server.
+
+Default: `""`
+
+##### --webserver_authentication_domain
+
+Domain used for .htpasswd authentication. This should be used in conjunction with
+[`--webserver_password_file`](#webserver-password-file).
+
+Default: `""`
+
+##### --webserver_password_file
+
+Location of .htpasswd file containing usernames and hashed passwords, for authentication to the
+web server.
+
+Default: `""`
+
 ---
 
 ### YSQL flags

--- a/docs/content/v2.6/reference/configuration/yb-master.md
+++ b/docs/content/v2.6/reference/configuration/yb-master.md
@@ -155,22 +155,19 @@ Default: The `www` directory in the YugabyteDB home directory.
 
 ##### --webserver_certificate_file
 
-Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is
-not enabled for the web server.
+Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is not enabled for the web server.
 
 Default: `""`
 
 ##### --webserver_authentication_domain
 
-Domain used for .htpasswd authentication. This should be used in conjunction with
-[`--webserver_password_file`](#webserver-password-file).
+Domain used for .htpasswd authentication. This should be used in conjunction with [`--webserver_password_file`](#webserver-password-file).
 
 Default: `""`
 
 ##### --webserver_password_file
 
-Location of .htpasswd file containing usernames and hashed passwords, for authentication to the
-web server.
+Location of .htpasswd file containing usernames and hashed passwords, for authentication to the web server.
 
 Default: `""`
 

--- a/docs/content/v2.6/reference/configuration/yb-tserver.md
+++ b/docs/content/v2.6/reference/configuration/yb-tserver.md
@@ -176,22 +176,19 @@ Default: The `www` directory in the YugabyteDB home directory.
 
 ##### --webserver_certificate_file
 
-Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is
-not enabled for the web server.
+Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is not enabled for the web server.
 
 Default: `""`
 
 ##### --webserver_authentication_domain
 
-Domain used for .htpasswd authentication. This should be used in conjunction with
-[`--webserver_password_file`](#webserver-password-file).
+Domain used for .htpasswd authentication. This should be used in conjunction with [`--webserver_password_file`](#webserver-password-file).
 
 Default: `""`
 
 ##### --webserver_password_file
 
-Location of .htpasswd file containing usernames and hashed passwords, for authentication to the
-web server.
+Location of .htpasswd file containing usernames and hashed passwords, for authentication to the web server.
 
 Default: `""`
 

--- a/docs/content/v2.6/reference/configuration/yb-tserver.md
+++ b/docs/content/v2.6/reference/configuration/yb-tserver.md
@@ -174,6 +174,27 @@ The monitoring web server home directory..
 
 Default: The `www` directory in the YugabyteDB home directory.
 
+##### --webserver_certificate_file
+
+Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is
+not enabled for the web server.
+
+Default: `""`
+
+##### --webserver_authentication_domain
+
+Domain used for .htpasswd authentication. This should be used in conjunction with
+[`--webserver_password_file`](#webserver-password-file).
+
+Default: `""`
+
+##### --webserver_password_file
+
+Location of .htpasswd file containing usernames and hashed passwords, for authentication to the
+web server.
+
+Default: `""`
+
 ---
 
 ### Logging flags

--- a/docs/content/v2.8/reference/configuration/yb-master.md
+++ b/docs/content/v2.8/reference/configuration/yb-master.md
@@ -153,6 +153,27 @@ Monitoring web server home.
 
 Default: The `www` directory in the YugabyteDB home directory.
 
+##### --webserver_certificate_file
+
+Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is
+not enabled for the web server.
+
+Default: `""`
+
+##### --webserver_authentication_domain
+
+Domain used for .htpasswd authentication. This should be used in conjunction with
+[`--webserver_password_file`](#webserver-password-file).
+
+Default: `""`
+
+##### --webserver_password_file
+
+Location of .htpasswd file containing usernames and hashed passwords, for authentication to the
+web server.
+
+Default: `""`
+
 ---
 
 ### YSQL flags

--- a/docs/content/v2.8/reference/configuration/yb-master.md
+++ b/docs/content/v2.8/reference/configuration/yb-master.md
@@ -155,22 +155,19 @@ Default: The `www` directory in the YugabyteDB home directory.
 
 ##### --webserver_certificate_file
 
-Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is
-not enabled for the web server.
+Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is not enabled for the web server.
 
 Default: `""`
 
 ##### --webserver_authentication_domain
 
-Domain used for .htpasswd authentication. This should be used in conjunction with
-[`--webserver_password_file`](#webserver-password-file).
+Domain used for .htpasswd authentication. This should be used in conjunction with [`--webserver_password_file`](#webserver-password-file).
 
 Default: `""`
 
 ##### --webserver_password_file
 
-Location of .htpasswd file containing usernames and hashed passwords, for authentication to the
-web server.
+Location of .htpasswd file containing usernames and hashed passwords, for authentication to the web server.
 
 Default: `""`
 

--- a/docs/content/v2.8/reference/configuration/yb-tserver.md
+++ b/docs/content/v2.8/reference/configuration/yb-tserver.md
@@ -176,22 +176,19 @@ Default: The `www` directory in the YugabyteDB home directory.
 
 ##### --webserver_certificate_file
 
-Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is
-not enabled for the web server.
+Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is not enabled for the web server.
 
 Default: `""`
 
 ##### --webserver_authentication_domain
 
-Domain used for .htpasswd authentication. This should be used in conjunction with
-[`--webserver_password_file`](#webserver-password-file).
+Domain used for .htpasswd authentication. This should be used in conjunction with [`--webserver_password_file`](#webserver-password-file).
 
 Default: `""`
 
 ##### --webserver_password_file
 
-Location of .htpasswd file containing usernames and hashed passwords, for authentication to the
-web server.
+Location of .htpasswd file containing usernames and hashed passwords, for authentication to the web server.
 
 Default: `""`
 

--- a/docs/content/v2.8/reference/configuration/yb-tserver.md
+++ b/docs/content/v2.8/reference/configuration/yb-tserver.md
@@ -174,6 +174,27 @@ The monitoring web server home directory..
 
 Default: The `www` directory in the YugabyteDB home directory.
 
+##### --webserver_certificate_file
+
+Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is
+not enabled for the web server.
+
+Default: `""`
+
+##### --webserver_authentication_domain
+
+Domain used for .htpasswd authentication. This should be used in conjunction with
+[`--webserver_password_file`](#webserver-password-file).
+
+Default: `""`
+
+##### --webserver_password_file
+
+Location of .htpasswd file containing usernames and hashed passwords, for authentication to the
+web server.
+
+Default: `""`
+
 ---
 
 ### Logging flags


### PR DESCRIPTION
Added documentation for the `webserver_certificate_file`, `webserver_authentication_domain`, and `webserver_password_file` gflags that were present in all past releases but not documented.

Context: #12861