### PR TITLE
[docs] adjust support shortcodes

### DIFF
--- a/docs/layouts/partials/support-anywhere.html
+++ b/docs/layouts/partials/support-anywhere.html
@@ -1,0 +1,1 @@
+https://support.yugabyte.com/hc/en-us/requests/new?ticket_form_id=360001955891

--- a/docs/layouts/partials/support-general.html
+++ b/docs/layouts/partials/support-general.html
@@ -1,0 +1,1 @@
+https://support.yugabyte.com/

--- a/docs/layouts/partials/support-managed.html
+++ b/docs/layouts/partials/support-managed.html
@@ -1,0 +1,1 @@
+https://support.yugabyte.com/hc/en-us/requests/new?ticket_form_id=360003113431

--- a/docs/layouts/shortcodes/support-cloud.html
+++ b/docs/layouts/shortcodes/support-cloud.html
@@ -1,1 +1,1 @@
-{{ "[Yugabyte Support](https://support.yugabyte.com/hc/en-us/requests/new?ticket_form_id=360003113431)" | .Page.RenderString }}
+[Yugabyte Support]({{ partialCached "support-managed" . }})

--- a/docs/layouts/shortcodes/support-general.html
+++ b/docs/layouts/shortcodes/support-general.html
@@ -1,1 +1,1 @@
-{{ "[Yugabyte Support](https://support.yugabyte.com/)" | .Page.RenderString }}
+[Yugabyte Support]({{ partialCached "support-general" . }})

--- a/docs/layouts/shortcodes/support-platform.html
+++ b/docs/layouts/shortcodes/support-platform.html
@@ -1,1 +1,1 @@
-{{ "[Yugabyte Support](https://support.yugabyte.com/hc/en-us/requests/new?ticket_form_id=360001955891)" | .Page.RenderString }}
+[Yugabyte Support]({{ partialCached "support-anywhere" . }})


### PR DESCRIPTION
Change the support shortcodes so they render correctly when nested in other shortcodes (such as notes). This is, incidentally, already how the `slack-link` shortcode works.