### PR TITLE
[docs] [reference] fixed maven repo link for yugabyte java driver for ycql. 

### DIFF
--- a/docs/content/preview/reference/drivers/ycql-client-drivers.md
+++ b/docs/content/preview/reference/drivers/ycql-client-drivers.md
@@ -63,11 +63,11 @@ To build Java applications with this driver, you must add the following Maven de
 <dependency>
   <groupId>com.yugabyte</groupId>
   <artifactId>java-driver-core</artifactId>
-  <version>4.6.0-yb-6</version>
+  <version>4.6.0-yb-11</version>
 </dependency>
 ```
 
-For details, see the [Maven repository contents](https://mvnrepository.com/artifact/com.yugabyte/cassandra-driver-core/4.6.0-yb-6).
+For details, see the [Maven repository contents](https://mvnrepository.com/artifact/com.yugabyte/java-driver-core/4.6.0-yb-11).
 
 ### Yugabyte Java Driver for YCQL 3.10
 


### PR DESCRIPTION
@netlify /preview/reference/drivers/ycql-client-drivers/

Verify the maven repository link : https://deploy-preview-13088--infallible-bardeen-164bc9.netlify.app/preview/reference/drivers/ycql-client-drivers/#yugabyte-java-driver-for-ycql-4-6 