### PR TITLE
[Docs] Update git repository URL of sample/demo apps 

### DIFF
--- a/docs/content/preview/develop/binary/run-sample-apps.md
+++ b/docs/content/preview/develop/binary/run-sample-apps.md
@@ -6,14 +6,14 @@ Create a cluster.
 
 ```sh
 $ ./bin/yb-ctl create
-``` 
+```
 Clients can now connect to the YSQL API at `localhost:5433` and YCQL API at `localhost:9042`.
 
 ## 2. Install Yugastore
 
 Clone the repo.
 ```sh
-$ git clone https://github.com/yugabyte/yugastore-java.git
+$ git clone https://github.com/YugabyteDB-Samples/yugastore-java.git
 ```
 ```sh
 $ cd yugastore-java
@@ -93,7 +93,7 @@ yugabyte=# select * from shopping_cart;
 ```
 
 ```
- cart_key     | user_id |    asin    |       time_added        | quantity 
+ cart_key     | user_id |    asin    |       time_added        | quantity
 ------------------+---------+------------+-------------------------+----------
  u1001-0001048236 | u1001   | 0001048236 | 2019-05-29T13:46:54.046 |        1
  u1001-0001048775 | u1001   | 0001048775 | 2019-05-29T13:46:56.055 |        1
@@ -102,7 +102,7 @@ yugabyte=# select * from shopping_cart;
 
 ## 5. Verify the completed order
 
-Now complete the checkout and observe the order number generated. 
+Now complete the checkout and observe the order number generated.
 
 ![yugastore-java order confirmation](/images/quick_start/binary-yugastore-java-orderconfirmation.png)
 
@@ -130,7 +130,7 @@ yugabyte=# select * from shopping_cart;
 ```
 
 ```
-cart_key | user_id | asin | time_added | quantity 
+cart_key | user_id | asin | time_added | quantity
 ----------+---------+------+------------+----------
 (0 rows)
 ```

--- a/docs/content/preview/develop/explore-sample-apps.md
+++ b/docs/content/preview/develop/explore-sample-apps.md
@@ -30,7 +30,7 @@ After [creating a local cluster](../../quick-start/), follow the instructions on
   1. Clone the repo.
 
       ```sh
-      $ git clone https://github.com/yugabyte/yugastore-java.git
+      $ git clone https://github.com/YugabyteDB-Samples/yugastore-java.git
       ```
 
       ```sh
@@ -70,7 +70,7 @@ After [creating a local cluster](../../quick-start/), follow the instructions on
   1. Clone the repo.
 
       ```sh
-      $ git clone https://github.com/yugabyte/yugastore-java.git
+      $ git clone https://github.com/YugabyteDB-Samples/yugastore-java.git
       ```
 
       ```sh

--- a/docs/content/preview/quick-start-yugabytedb-managed/_index.md
+++ b/docs/content/preview/quick-start-yugabytedb-managed/_index.md
@@ -137,7 +137,7 @@ This tutorial requires the following.
 Clone the sample application to your computer:
 
 ```sh
-git clone https://github.com/yugabyte/yugabyte-simple-java-app.git && cd yugabyte-simple-java-app
+git clone https://github.com/YugabyteDB-Samples/yugabyte-simple-java-app.git && cd yugabyte-simple-java-app
 ```
 
 ### Provide connection parameters

--- a/docs/content/preview/quick-start/build-apps/csharp/ysql-entity-framework.md
+++ b/docs/content/preview/quick-start/build-apps/csharp/ysql-entity-framework.md
@@ -53,7 +53,7 @@ The tutorial assumes that you have:
 ## Clone the "orm-examples" repository
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git && cd orm-examples/csharp/entityframework
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git && cd orm-examples/csharp/entityframework
 ```
 
 ## Database configuration

--- a/docs/content/preview/quick-start/build-apps/go/ysql-gorm.md
+++ b/docs/content/preview/quick-start/build-apps/go/ysql-gorm.md
@@ -90,7 +90,7 @@ go get github.com/lib/pq/hstore
 Clone the Yugabyte [`orm-examples` repository](https://github.com/yugabyte/orm-examples) by running the following command.
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 Run the following `export` command to specify the `GOPATH` environment variable.

--- a/docs/content/preview/quick-start/build-apps/java/ysql-ebeans.md
+++ b/docs/content/preview/quick-start/build-apps/java/ysql-ebeans.md
@@ -90,7 +90,7 @@ This tutorial assumes that you have:
 ## Clone the "orm-examples" repository
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git && cd orm-examples/java/ebeans
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git && cd orm-examples/java/ebeans
 ```
 
 ## Database configuration

--- a/docs/content/preview/quick-start/build-apps/java/ysql-hibernate.md
+++ b/docs/content/preview/quick-start/build-apps/java/ysql-hibernate.md
@@ -81,7 +81,7 @@ This tutorial assumes that:
 ## Clone the "orm-examples" repository
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 The [Using ORMs with YugabyteDB `orm-examples` repository](https://github.com/yugabyte/orm-examples) has a [Hibernate ORM](https://hibernate.org/orm/) example that implements a simple REST API server. The scenario is that of an e-commerce application. Database access in this application is managed through Hibernate ORM. It consists of the following:

--- a/docs/content/preview/quick-start/build-apps/java/ysql-spring-data.md
+++ b/docs/content/preview/quick-start/build-apps/java/ysql-spring-data.md
@@ -80,7 +80,7 @@ This tutorial assumes that you have:
 ## Clone the "orm-examples" repository
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 The [Using ORMs with YugabyteDB `orm-examples` repository](https://github.com/yugabyte/orm-examples) has a [Spring Boot](https://spring.io/projects/spring-boot) example that implements a simple REST API server. The scenario is that of an e-commerce application. Database access in this application is managed through [Spring Data JPA](https://spring.io/projects/spring-data-jpa), which internally uses Hibernate as the JPA provider. It consists of the following:

--- a/docs/content/preview/quick-start/build-apps/nodejs/ysql-prisma.md
+++ b/docs/content/preview/quick-start/build-apps/nodejs/ysql-prisma.md
@@ -51,7 +51,7 @@ This tutorial assumes that you have installed YugabyteDB and created a cluster. 
 ## Clone the orm-examples repository
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 This repository has a Node.js example that implements a REST API server. The scenario is that of an e-commerce application. Database access in this application is managed through the [Prisma](https://prisma.io). It consists of the following:

--- a/docs/content/preview/quick-start/build-apps/nodejs/ysql-sequelize.md
+++ b/docs/content/preview/quick-start/build-apps/nodejs/ysql-sequelize.md
@@ -41,13 +41,13 @@ type: docs
 ## Prerequisites
 
 This tutorial assumes that you have installed:
-- YugabyteDB and created a cluster. Refer to [Quick Start](../../../../quick-start/). 
+- YugabyteDB and created a cluster. Refer to [Quick Start](../../../../quick-start/).
 - [node.js](https://nodejs.org/en/) version 16 or later.
 
 ## Clone the orm-examples repository
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 This repository has a Node.js example that implements a REST API server. The scenario is that of an e-commerce application. Database access in this application is managed through the Sequelize ORM. It consists of the following:

--- a/docs/content/preview/quick-start/build-apps/python/ysql-django.md
+++ b/docs/content/preview/quick-start/build-apps/python/ysql-django.md
@@ -66,7 +66,7 @@ YugabyteDB is up and running. If you are new to YugabyteDB, you can have Yugabyt
 ## Clone the orm-examples repository
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 This repository has a Django ORM example that implements a simple REST API server. Database access in this application is managed through the Django ORM. The e-commerce database `ysql_django` includes the following tables:

--- a/docs/content/preview/quick-start/build-apps/python/ysql-sqlalchemy.md
+++ b/docs/content/preview/quick-start/build-apps/python/ysql-sqlalchemy.md
@@ -85,7 +85,7 @@ $ pip3 install psycopg2-binary sqlalchemy jsonpickle
 Clone the Yugabyte [`orm-examples` repository](https://github.com/yugabyte/orm-examples) by running the following command.
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 Update the database settings in the `src/config.py` file to match the following. If YSQL authentication is enabled, add the password (default for the `yugabyte` user is `yugabyte`).

--- a/docs/content/preview/quick-start/build-apps/ruby/ysql-rails-activerecord.md
+++ b/docs/content/preview/quick-start/build-apps/ruby/ysql-rails-activerecord.md
@@ -42,7 +42,7 @@ This tutorial assumes that you have:
 ## Clone the orm-examples repository
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 ```sh

--- a/docs/content/preview/quick-start/build-apps/rust/ysql-diesel.md
+++ b/docs/content/preview/quick-start/build-apps/rust/ysql-diesel.md
@@ -42,7 +42,7 @@ This tutorial assumes that you have:
 ## Clone the "orm-examples" repository
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git && cd orm-examples/rust/diesel
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git && cd orm-examples/rust/diesel
 ```
 
 Build the REST API server (written using Diesel and Rocket) as follows:

--- a/docs/content/preview/yugabyte-cloud/cloud-examples/connect-application.md
+++ b/docs/content/preview/yugabyte-cloud/cloud-examples/connect-application.md
@@ -38,7 +38,7 @@ In this walkthrough, you will:
 1. On your computer, clone the Spring PetClinic sample application built with Spring Data YugabyteDB:
 
     ```sh
-    $ git clone https://github.com/yugabyte/petclinic-spring-data-yugabytedb.git
+    $ git clone https://github.com/YugabyteDB-Samples/petclinic-spring-data-yugabytedb.git
     ```
 
     ```output

--- a/docs/content/preview/yugabyte-cloud/cloud-examples/hasura-sample-app.md
+++ b/docs/content/preview/yugabyte-cloud/cloud-examples/hasura-sample-app.md
@@ -43,7 +43,7 @@ $ hasura update-cli --version v2.0.0-beta.2
 The Realtime Poll application is available from the Yugabyte GraphQL Apps repo.
 
 ```sh
-$ git clone https://github.com/yugabyte/yugabyte-graphql-apps
+$ git clone https://github.com/YugabyteDB-Samples/yugabyte-graphql-apps.git
 $ cd yugabyte-graphql-apps/realtime-poll
 ```
 

--- a/docs/content/preview/yugabyte-cloud/cloud-quickstart/cloud-build-apps/cloud-ysql-c.md
+++ b/docs/content/preview/yugabyte-cloud/cloud-quickstart/cloud-build-apps/cloud-ysql-c.md
@@ -30,7 +30,7 @@ The following tutorial shows a small [C application](https://github.com/yugabyte
 Clone the sample application to your computer:
 
 ```sh
-git clone https://github.com/yugabyte/yugabyte-simple-c-app && cd yugabyte-simple-c-app
+git clone https://github.com/YugabyteDB-Samples/yugabyte-simple-c-app.git && cd yugabyte-simple-c-app
 ```
 
 ## Provide connection parameters

--- a/docs/content/preview/yugabyte-cloud/cloud-quickstart/cloud-build-apps/cloud-ysql-cpp.md
+++ b/docs/content/preview/yugabyte-cloud/cloud-quickstart/cloud-build-apps/cloud-ysql-cpp.md
@@ -31,7 +31,7 @@ The following tutorial shows a small [C++ application](https://github.com/yugaby
 Clone the sample application to your computer:
 
 ```sh
-git clone https://github.com/yugabyte/yugabyte-simple-cpp-app && cd yugabyte-simple-cpp-app
+git clone https://github.com/YugabyteDB-Samples/yugabyte-simple-cpp-app.git && cd yugabyte-simple-cpp-app
 ```
 
 ## Provide connection parameters

--- a/docs/content/preview/yugabyte-cloud/cloud-quickstart/cloud-build-apps/cloud-ysql-csharp.md
+++ b/docs/content/preview/yugabyte-cloud/cloud-quickstart/cloud-build-apps/cloud-ysql-csharp.md
@@ -27,7 +27,7 @@ The following tutorial shows a small [C# application](https://github.com/yugabyt
 Clone the sample application to your computer:
 
 ```sh
-git clone https://github.com/yugabyte/yugabyte-simple-csharp-app && cd yugabyte-simple-csharp-app
+git clone https://github.com/YugabyteDB-Samples/yugabyte-simple-csharp-app.git && cd yugabyte-simple-csharp-app
 ```
 
 The `yugabyte-simple-csharp-app.csproj` file includes the following package reference to include the driver:

--- a/docs/content/preview/yugabyte-cloud/cloud-quickstart/cloud-build-apps/cloud-ysql-go.md
+++ b/docs/content/preview/yugabyte-cloud/cloud-quickstart/cloud-build-apps/cloud-ysql-go.md
@@ -28,7 +28,7 @@ In addition to [Go (tested with version 1.17.6)](https://go.dev/dl/), this tutor
 Clone the sample application to your computer:
 
 ```sh
-git clone https://github.com/yugabyte/yugabyte-simple-go-app.git && cd yugabyte-simple-go-app
+git clone https://github.com/YugabyteDB-Samples/yugabyte-simple-go-app.git && cd yugabyte-simple-go-app
 ```
 
 ## Provide connection parameters

--- a/docs/content/preview/yugabyte-cloud/cloud-quickstart/cloud-build-apps/cloud-ysql-node.md
+++ b/docs/content/preview/yugabyte-cloud/cloud-quickstart/cloud-build-apps/cloud-ysql-node.md
@@ -27,7 +27,7 @@ In addition to the latest version of [Node.js](https://nodejs.org/en/download/),
 Clone the sample application to your computer:
 
 ```sh
-git clone https://github.com/yugabyte/yugabyte-simple-node-app && cd yugabyte-simple-node-app
+git clone https://github.com/YugabyteDB-Samples/yugabyte-simple-node-app.git && cd yugabyte-simple-node-app
 ```
 
 ## Provide connection parameters

--- a/docs/content/preview/yugabyte-cloud/cloud-quickstart/cloud-build-apps/cloud-ysql-php.md
+++ b/docs/content/preview/yugabyte-cloud/cloud-quickstart/cloud-build-apps/cloud-ysql-php.md
@@ -31,7 +31,7 @@ The following tutorial shows a small [PHP application](https://github.com/yugaby
 Clone the sample application to your computer:
 
 ```sh
-git clone https://github.com/yugabyte/yugabyte-simple-php-app && cd yugabyte-simple-php-app
+git clone https://github.com/YugabyteDB-Samples/yugabyte-simple-php-app.git && cd yugabyte-simple-php-app
 ```
 
 ## Provide connection parameters

--- a/docs/content/preview/yugabyte-cloud/cloud-quickstart/cloud-build-apps/cloud-ysql-python.md
+++ b/docs/content/preview/yugabyte-cloud/cloud-quickstart/cloud-build-apps/cloud-ysql-python.md
@@ -28,7 +28,7 @@ The following tutorial shows a small [Python application](https://github.com/yug
 Clone the sample application to your computer:
 
 ```sh
-git clone https://github.com/yugabyte/yugabyte-simple-python-app.git && cd yugabyte-simple-python-app
+git clone https://github.com/YugabyteDB-Samples/yugabyte-simple-python-app.git && cd yugabyte-simple-python-app
 ```
 
 ## Provide connection parameters

--- a/docs/content/preview/yugabyte-cloud/cloud-quickstart/cloud-build-apps/cloud-ysql-ruby.md
+++ b/docs/content/preview/yugabyte-cloud/cloud-quickstart/cloud-build-apps/cloud-ysql-ruby.md
@@ -36,7 +36,7 @@ The following tutorial shows a small [Ruby application](https://github.com/yugab
 Clone the sample application to your computer:
 
 ```sh
-git clone https://github.com/yugabyte/yugabyte-simple-ruby-app && cd yugabyte-simple-ruby-app
+git clone https://github.com/YugabyteDB-Samples/yugabyte-simple-ruby-app.git && cd yugabyte-simple-ruby-app
 ```
 
 ## Provide connection parameters

--- a/docs/content/preview/yugabyte-cloud/cloud-quickstart/cloud-build-apps/cloud-ysql-rust.md
+++ b/docs/content/preview/yugabyte-cloud/cloud-quickstart/cloud-build-apps/cloud-ysql-rust.md
@@ -27,7 +27,7 @@ The following tutorial shows a small [Rust application](https://github.com/yugab
 Clone the sample application to your computer:
 
 ```sh
-git clone https://github.com/yugabyte/yugabyte-simple-rust-app && cd yugabyte-simple-rust-app
+git clone https://github.com/YugabyteDB-Samples/yugabyte-simple-rust-app.git && cd yugabyte-simple-rust-app
 ```
 
 ## Provide connection parameters

--- a/docs/content/preview/yugabyte-cloud/cloud-quickstart/cloud-build-apps/cloud-ysql-yb-jdbc.md
+++ b/docs/content/preview/yugabyte-cloud/cloud-quickstart/cloud-build-apps/cloud-ysql-yb-jdbc.md
@@ -33,7 +33,7 @@ This tutorial requires the following.
 Clone the sample application to your computer:
 
 ```sh
-git clone https://github.com/yugabyte/yugabyte-simple-java-app.git && cd yugabyte-simple-java-app
+git clone https://github.com/YugabyteDB-Samples/yugabyte-simple-java-app.git && cd yugabyte-simple-java-app
 ```
 
 ## Provide connection parameters

--- a/docs/content/stable/develop/binary/run-sample-apps.md
+++ b/docs/content/stable/develop/binary/run-sample-apps.md
@@ -6,14 +6,14 @@ Create a cluster.
 
 ```sh
 $ ./bin/yb-ctl create
-``` 
+```
 Clients can now connect to the YSQL API at `localhost:5433` and YCQL API at `localhost:9042`.
 
 ## 2. Install Yugastore
 
 Clone the repo.
 ```sh
-$ git clone https://github.com/yugabyte/yugastore-java.git
+$ git clone https://github.com/YugabyteDB-Samples/yugastore-java.git
 ```
 ```sh
 $ cd yugastore-java
@@ -93,7 +93,7 @@ yugabyte=# select * from shopping_cart;
 ```
 
 ```
- cart_key     | user_id |    asin    |       time_added        | quantity 
+ cart_key     | user_id |    asin    |       time_added        | quantity
 ------------------+---------+------------+-------------------------+----------
  u1001-0001048236 | u1001   | 0001048236 | 2019-05-29T13:46:54.046 |        1
  u1001-0001048775 | u1001   | 0001048775 | 2019-05-29T13:46:56.055 |        1
@@ -102,7 +102,7 @@ yugabyte=# select * from shopping_cart;
 
 ## 5. Verify the completed order
 
-Now complete the checkout and observe the order number generated. 
+Now complete the checkout and observe the order number generated.
 
 ![yugastore-java order confirmation](/images/quick_start/binary-yugastore-java-orderconfirmation.png)
 
@@ -130,7 +130,7 @@ yugabyte=# select * from shopping_cart;
 ```
 
 ```
-cart_key | user_id | asin | time_added | quantity 
+cart_key | user_id | asin | time_added | quantity
 ----------+---------+------+------------+----------
 (0 rows)
 ```

--- a/docs/content/stable/quick-start/build-apps/csharp/ysql-entity-framework.md
+++ b/docs/content/stable/quick-start/build-apps/csharp/ysql-entity-framework.md
@@ -53,7 +53,7 @@ The tutorial assumes that you have:
 ## Clone the "orm-examples" repository
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git && cd orm-examples/csharp/entityframework
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git && cd orm-examples/csharp/entityframework
 ```
 
 ## Database configuration

--- a/docs/content/stable/quick-start/build-apps/go/ysql-gorm.md
+++ b/docs/content/stable/quick-start/build-apps/go/ysql-gorm.md
@@ -84,7 +84,7 @@ go get github.com/lib/pq/hstore
 Clone the Yugabyte [`orm-examples` repository](https://github.com/yugabyte/orm-examples) by running the following command.
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 Run the following `export` command to specify the `GOPATH` environment variable.

--- a/docs/content/stable/quick-start/build-apps/java/ysql-ebeans.md
+++ b/docs/content/stable/quick-start/build-apps/java/ysql-ebeans.md
@@ -78,7 +78,7 @@ This tutorial assumes that you have:
 ## Clone the "orm-examples" repository
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git && cd orm-examples/java/ebeans
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git && cd orm-examples/java/ebeans
 ```
 
 ## Database configuration

--- a/docs/content/stable/quick-start/build-apps/java/ysql-spring-data.md
+++ b/docs/content/stable/quick-start/build-apps/java/ysql-spring-data.md
@@ -68,7 +68,7 @@ This tutorial assumes that you have:
 ## Clone the "orm-examples" repository
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 The [Using ORMs with YugabyteDB `orm-examples` repository](https://github.com/yugabyte/orm-examples) has a [Spring Boot](https://spring.io/projects/spring-boot) example that implements a simple REST API server. The scenario is that of an e-commerce application. Database access in this application is managed through [Spring Data JPA](https://spring.io/projects/spring-data-jpa), which internally uses Hibernate as the JPA provider. It consists of the following:

--- a/docs/content/stable/quick-start/build-apps/nodejs/ysql-sequelize.md
+++ b/docs/content/stable/quick-start/build-apps/nodejs/ysql-sequelize.md
@@ -39,7 +39,7 @@ This tutorial assumes that you have installed YugabyteDB and created a cluster. 
 ## Clone the orm-examples repository
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 This repository has a Node.js example that implements a REST API server. The scenario is that of an e-commerce application. Database access in this application is managed through the Sequelize ORM. It consists of the following:

--- a/docs/content/stable/quick-start/build-apps/python/ysql-django.md
+++ b/docs/content/stable/quick-start/build-apps/python/ysql-django.md
@@ -66,7 +66,7 @@ YugabyteDB is up and running. If you are new to YugabyteDB, you can have Yugabyt
 ## Clone the orm-examples repository
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 This repository has a Django ORM example that implements a simple REST API server. Database access in this application is managed through the Django ORM. The e-commerce database `ysql_django` includes the following tables:

--- a/docs/content/stable/quick-start/build-apps/python/ysql-sqlalchemy.md
+++ b/docs/content/stable/quick-start/build-apps/python/ysql-sqlalchemy.md
@@ -85,7 +85,7 @@ $ pip3 install psycopg2-binary sqlalchemy jsonpickle
 Clone the Yugabyte [`orm-examples` repository](https://github.com/yugabyte/orm-examples) by running the following command.
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 Update the database settings in the `src/config.py` file to match the following. If YSQL authentication is enabled, add the password (default for the `yugabyte` user is `yugabyte`).

--- a/docs/content/stable/quick-start/build-apps/ruby/ysql-rails-activerecord.md
+++ b/docs/content/stable/quick-start/build-apps/ruby/ysql-rails-activerecord.md
@@ -42,7 +42,7 @@ This tutorial assumes that you have:
 ## Clone the orm-examples repository
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 ```sh

--- a/docs/content/v2.4/develop/binary/run-sample-apps.md
+++ b/docs/content/v2.4/develop/binary/run-sample-apps.md
@@ -6,14 +6,14 @@ Create a cluster.
 
 ```sh
 $ ./bin/yb-ctl create
-``` 
+```
 Clients can now connect to the YSQL API at `localhost:5433` and YCQL API at `localhost:9042`.
 
 ## 2. Install Yugastore
 
 Clone the repo.
 ```sh
-$ git clone https://github.com/yugabyte/yugastore-java.git
+$ git clone https://github.com/YugabyteDB-Samples/yugastore-java.git
 ```
 ```sh
 $ cd yugastore-java
@@ -93,7 +93,7 @@ yugabyte=# select * from shopping_cart;
 ```
 
 ```
- cart_key     | user_id |    asin    |       time_added        | quantity 
+ cart_key     | user_id |    asin    |       time_added        | quantity
 ------------------+---------+------------+-------------------------+----------
  u1001-0001048236 | u1001   | 0001048236 | 2019-05-29T13:46:54.046 |        1
  u1001-0001048775 | u1001   | 0001048775 | 2019-05-29T13:46:56.055 |        1
@@ -102,7 +102,7 @@ yugabyte=# select * from shopping_cart;
 
 ## 5. Verify the completed order
 
-Now complete the checkout and observe the order number generated. 
+Now complete the checkout and observe the order number generated.
 
 ![yugastore-java order confirmation](/images/quick_start/binary-yugastore-java-orderconfirmation.png)
 
@@ -130,7 +130,7 @@ yugabyte=# select * from shopping_cart;
 ```
 
 ```
-cart_key | user_id | asin | time_added | quantity 
+cart_key | user_id | asin | time_added | quantity
 ----------+---------+------+------------+----------
 (0 rows)
 ```

--- a/docs/content/v2.4/quick-start/build-apps/go/ysql-gorm.md
+++ b/docs/content/v2.4/quick-start/build-apps/go/ysql-gorm.md
@@ -72,7 +72,7 @@ go get github.com/lib/pq/hstore
 Clone the Yugabyte [`orm-examples` repository](https://github.com/yugabyte/orm-examples) by running the following command.
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 Run the following `export` command to specify the `GOPATH` environment variable.

--- a/docs/content/v2.4/quick-start/build-apps/java/ysql-spring-data.md
+++ b/docs/content/v2.4/quick-start/build-apps/java/ysql-spring-data.md
@@ -50,7 +50,7 @@ This tutorial assumes that you have:
 ## Clone the "orm-examples" repository
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 The [Using ORMs with YugabyteDB `orm-examples` repository](https://github.com/yugabyte/orm-examples) has a [Spring Boot](https://spring.io/projects/spring-boot) example that implements a simple REST API server. The scenario is that of an e-commerce application. Database access in this application is managed through [Spring Data JPA](https://spring.io/projects/spring-data-jpa), which internally uses Hibernate as the JPA provider. It consists of the following:

--- a/docs/content/v2.4/quick-start/build-apps/nodejs/ysql-sequelize.md
+++ b/docs/content/v2.4/quick-start/build-apps/nodejs/ysql-sequelize.md
@@ -44,7 +44,7 @@ This tutorial assumes that you have:
 ## Clone the orm-examples repo
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 This repository has a node.js example that implements a simple REST API server. The scenario is that of an e-commerce application. Database access in this application is managed through the Sequelize ORM. It consists of the following.

--- a/docs/content/v2.4/quick-start/build-apps/python/ysql-sqlalchemy.md
+++ b/docs/content/v2.4/quick-start/build-apps/python/ysql-sqlalchemy.md
@@ -79,7 +79,7 @@ $ pip3 install psycopg2-binary sqlalchemy jsonpickle
 Clone the Yugabyte [`orm-examples` repository](https://github.com/yugabyte/orm-examples) by running the following command.
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 Update the database settings in the `src/config.py` file to match the following. If YSQL authentication is enabled, add the password (default for the `yugabyte` user is `yugabyte`).

--- a/docs/content/v2.4/quick-start/build-apps/ruby/ysql-rails-activerecord.md
+++ b/docs/content/v2.4/quick-start/build-apps/ruby/ysql-rails-activerecord.md
@@ -42,7 +42,7 @@ This tutorial assumes that you have:
 ## Clone the orm-examples repository
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 ```sh

--- a/docs/content/v2.6/develop/binary/run-sample-apps.md
+++ b/docs/content/v2.6/develop/binary/run-sample-apps.md
@@ -6,14 +6,14 @@ Create a cluster.
 
 ```sh
 $ ./bin/yb-ctl create
-``` 
+```
 Clients can now connect to the YSQL API at `localhost:5433` and YCQL API at `localhost:9042`.
 
 ## 2. Install Yugastore
 
 Clone the repo.
 ```sh
-$ git clone https://github.com/yugabyte/yugastore-java.git
+$ git clone https://github.com/YugabyteDB-Samples/yugastore-java.git
 ```
 ```sh
 $ cd yugastore-java
@@ -93,7 +93,7 @@ yugabyte=# select * from shopping_cart;
 ```
 
 ```
- cart_key     | user_id |    asin    |       time_added        | quantity 
+ cart_key     | user_id |    asin    |       time_added        | quantity
 ------------------+---------+------------+-------------------------+----------
  u1001-0001048236 | u1001   | 0001048236 | 2019-05-29T13:46:54.046 |        1
  u1001-0001048775 | u1001   | 0001048775 | 2019-05-29T13:46:56.055 |        1
@@ -102,7 +102,7 @@ yugabyte=# select * from shopping_cart;
 
 ## 5. Verify the completed order
 
-Now complete the checkout and observe the order number generated. 
+Now complete the checkout and observe the order number generated.
 
 ![yugastore-java order confirmation](/images/quick_start/binary-yugastore-java-orderconfirmation.png)
 
@@ -130,7 +130,7 @@ yugabyte=# select * from shopping_cart;
 ```
 
 ```
-cart_key | user_id | asin | time_added | quantity 
+cart_key | user_id | asin | time_added | quantity
 ----------+---------+------+------------+----------
 (0 rows)
 ```

--- a/docs/content/v2.6/quick-start/build-apps/go/ysql-gorm.md
+++ b/docs/content/v2.6/quick-start/build-apps/go/ysql-gorm.md
@@ -72,7 +72,7 @@ go get github.com/lib/pq/hstore
 Clone the Yugabyte [`orm-examples` repository](https://github.com/yugabyte/orm-examples) by running the following command.
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 Run the following `export` command to specify the `GOPATH` environment variable.

--- a/docs/content/v2.6/quick-start/build-apps/java/ysql-spring-data.md
+++ b/docs/content/v2.6/quick-start/build-apps/java/ysql-spring-data.md
@@ -56,7 +56,7 @@ This tutorial assumes that you have:
 ## Clone the "orm-examples" repository
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 The [Using ORMs with YugabyteDB `orm-examples` repository](https://github.com/yugabyte/orm-examples) has a [Spring Boot](https://spring.io/projects/spring-boot) example that implements a simple REST API server. The scenario is that of an e-commerce application. Database access in this application is managed through [Spring Data JPA](https://spring.io/projects/spring-data-jpa), which internally uses Hibernate as the JPA provider. It consists of the following:

--- a/docs/content/v2.6/quick-start/build-apps/nodejs/ysql-sequelize.md
+++ b/docs/content/v2.6/quick-start/build-apps/nodejs/ysql-sequelize.md
@@ -43,7 +43,7 @@ This tutorial assumes that you have:
 ## Clone the orm-examples repo
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 This repository has a node.js example that implements a simple REST API server. The scenario is that of an e-commerce application. Database access in this application is managed through the Sequelize ORM. It consists of the following.

--- a/docs/content/v2.6/quick-start/build-apps/python/ysql-sqlalchemy.md
+++ b/docs/content/v2.6/quick-start/build-apps/python/ysql-sqlalchemy.md
@@ -79,7 +79,7 @@ $ pip3 install psycopg2-binary sqlalchemy jsonpickle
 Clone the Yugabyte [`orm-examples` repository](https://github.com/yugabyte/orm-examples) by running the following command.
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 Update the database settings in the `src/config.py` file to match the following. If YSQL authentication is enabled, add the password (default for the `yugabyte` user is `yugabyte`).

--- a/docs/content/v2.6/quick-start/build-apps/ruby/ysql-rails-activerecord.md
+++ b/docs/content/v2.6/quick-start/build-apps/ruby/ysql-rails-activerecord.md
@@ -42,7 +42,7 @@ This tutorial assumes that you have:
 ## Clone the orm-examples repository
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 ```sh

--- a/docs/content/v2.6/yugabyte-cloud/develop/hasura-sample-app.md
+++ b/docs/content/v2.6/yugabyte-cloud/develop/hasura-sample-app.md
@@ -41,7 +41,7 @@ $ hasura update-cli --version v2.0.0-beta.2
 The Realtime Poll application is available from the Yugabyte GraphQL Apps repo.
 
 ```sh
-$ git clone https://github.com/yugabyte/yugabyte-graphql-apps
+$ git clone https://github.com/YugabyteDB-Samples/yugabyte-graphql-apps.git
 $ cd yugabyte-graphql-apps/realtime-poll
 ```
 

--- a/docs/content/v2.8/develop/binary/run-sample-apps.md
+++ b/docs/content/v2.8/develop/binary/run-sample-apps.md
@@ -6,14 +6,14 @@ Create a cluster.
 
 ```sh
 $ ./bin/yb-ctl create
-``` 
+```
 Clients can now connect to the YSQL API at `localhost:5433` and YCQL API at `localhost:9042`.
 
 ## 2. Install Yugastore
 
 Clone the repo.
 ```sh
-$ git clone https://github.com/yugabyte/yugastore-java.git
+$ git clone https://github.com/YugabyteDB-Samples/yugastore-java.git
 ```
 ```sh
 $ cd yugastore-java
@@ -93,7 +93,7 @@ yugabyte=# select * from shopping_cart;
 ```
 
 ```
- cart_key     | user_id |    asin    |       time_added        | quantity 
+ cart_key     | user_id |    asin    |       time_added        | quantity
 ------------------+---------+------------+-------------------------+----------
  u1001-0001048236 | u1001   | 0001048236 | 2019-05-29T13:46:54.046 |        1
  u1001-0001048775 | u1001   | 0001048775 | 2019-05-29T13:46:56.055 |        1
@@ -102,7 +102,7 @@ yugabyte=# select * from shopping_cart;
 
 ## 5. Verify the completed order
 
-Now complete the checkout and observe the order number generated. 
+Now complete the checkout and observe the order number generated.
 
 ![yugastore-java order confirmation](/images/quick_start/binary-yugastore-java-orderconfirmation.png)
 
@@ -130,7 +130,7 @@ yugabyte=# select * from shopping_cart;
 ```
 
 ```
-cart_key | user_id | asin | time_added | quantity 
+cart_key | user_id | asin | time_added | quantity
 ----------+---------+------+------------+----------
 (0 rows)
 ```

--- a/docs/content/v2.8/quick-start/build-apps/go/ysql-gorm.md
+++ b/docs/content/v2.8/quick-start/build-apps/go/ysql-gorm.md
@@ -84,7 +84,7 @@ go get github.com/lib/pq/hstore
 Clone the Yugabyte [`orm-examples` repository](https://github.com/yugabyte/orm-examples) by running the following command.
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 Run the following `export` command to specify the `GOPATH` environment variable.

--- a/docs/content/v2.8/quick-start/build-apps/java/ysql-spring-data.md
+++ b/docs/content/v2.8/quick-start/build-apps/java/ysql-spring-data.md
@@ -62,7 +62,7 @@ This tutorial assumes that you have:
 ## Clone the "orm-examples" repository
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 The [Using ORMs with YugabyteDB `orm-examples` repository](https://github.com/yugabyte/orm-examples) has a [Spring Boot](https://spring.io/projects/spring-boot) example that implements a simple REST API server. The scenario is that of an e-commerce application. Database access in this application is managed through [Spring Data JPA](https://spring.io/projects/spring-data-jpa), which internally uses Hibernate as the JPA provider. It consists of the following:

--- a/docs/content/v2.8/quick-start/build-apps/nodejs/ysql-sequelize.md
+++ b/docs/content/v2.8/quick-start/build-apps/nodejs/ysql-sequelize.md
@@ -42,7 +42,7 @@ This tutorial assumes that you have:
 ## Clone the orm-examples repository
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 This repository has a node.js example that implements a simple REST API server. The scenario is that of an e-commerce application. Database access in this application is managed through the Sequelize ORM. It consists of the following.

--- a/docs/content/v2.8/quick-start/build-apps/python/ysql-django.md
+++ b/docs/content/v2.8/quick-start/build-apps/python/ysql-django.md
@@ -66,7 +66,7 @@ YugabyteDB is up and running. If you are new to YugabyteDB, you can have Yugabyt
 ## Clone the orm-examples repository
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 This repository has a Django ORM example that implements a simple REST API server. Database access in this application is managed through the Django ORM. The e-commerce database `ysql_django` includes the following tables:

--- a/docs/content/v2.8/quick-start/build-apps/python/ysql-sqlalchemy.md
+++ b/docs/content/v2.8/quick-start/build-apps/python/ysql-sqlalchemy.md
@@ -85,7 +85,7 @@ $ pip3 install psycopg2-binary sqlalchemy jsonpickle
 Clone the Yugabyte [`orm-examples` repository](https://github.com/yugabyte/orm-examples) by running the following command.
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 Update the database settings in the `src/config.py` file to match the following. If YSQL authentication is enabled, add the password (default for the `yugabyte` user is `yugabyte`).

--- a/docs/content/v2.8/quick-start/build-apps/ruby/ysql-rails-activerecord.md
+++ b/docs/content/v2.8/quick-start/build-apps/ruby/ysql-rails-activerecord.md
@@ -42,7 +42,7 @@ This tutorial assumes that you have:
 ## Clone the orm-examples repository
 
 ```sh
-$ git clone https://github.com/yugabyte/orm-examples.git
+$ git clone https://github.com/YugabyteDB-Samples/orm-examples.git
 ```
 
 ```sh


### PR DESCRIPTION
## Description

- This is a medium change.
- **Context:**  We have moved all the sample apps (including the ones in technical documentation) to [YugabyteDB-Samples](https://github.com/YugabyteDB-Samples/) GitHub org for an improved developer experience in the community.
- This PR  updates all the git repository URLs for the code samples in the documentation that are migrated to [YugabyteDB-Samples](https://github.com/YugabyteDB-Samples/)
- **Note:** Only URLs for `git clone` commands has been updated. GitHub by default supports the redirection of repo URLs if it has been migrated from one org to another, read more [here](https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository), so other URLs are not updated as it will be redirected to the new location automatically.


## Checklist
- [x] Set an informative, carefully chosen **title**
- [x] Applied *labels* to the PR

@netlify /preview/quick-start/