### PR TITLE
[Doc]: Fix the code formatting of Python SQLAlchemy ORM example page

### DIFF
--- a/docs/content/preview/drivers-orms/python/sqlalchemy.md
+++ b/docs/content/preview/drivers-orms/python/sqlalchemy.md
@@ -42,8 +42,8 @@ The following sections demonstrate how to perform common tasks required for Pyth
 To download and install SQLAlchemy to your project, use the following command.
 
 ```shell
-  pip3 install sqlalchemy
-  ```
+pip3 install sqlalchemy
+```
 
 You can verify the installation as follows:
 
@@ -111,33 +111,31 @@ To start with SQLAlchemy, in your project directory, create 4 Python files - `co
    from model import Employee
    from base import Base
    from sqlalchemy import Table, Column, Integer, String, DateTime, ForeignKey
-   ```
 
-# create connection
-engine = create_engine('postgresql://{0}:{1}@{2}:{3}/{4}'.format(cfg.db_user, cfg.db_password, cfg.db_host, cfg.db_port, cfg.database))
+    # create connection
+    engine = create_engine('postgresql://{0}:{1}@{2}:{3}/{4}'.format(cfg.db_user, cfg.db_password, cfg.db_host, cfg.db_port, cfg.database))
 
-# create metadata
-Base.metadata.create_all(engine)
+    # create metadata
+    Base.metadata.create_all(engine)
 
-# create session
-Session = sessionmaker(bind=engine)
-session = Session()
+    # create session
+    Session = sessionmaker(bind=engine)
+    session = Session()
 
-# insert data
-tag_1 = Employee(name='Bob', age=21, language='Python')
-tag_2 = Employee(name='John', age=35, language='Java')
-tag_3 = Employee(name='Ivy', age=27, language='C++')
+    # insert data
+    tag_1 = Employee(name='Bob', age=21, language='Python')
+    tag_2 = Employee(name='John', age=35, language='Java')
+    tag_3 = Employee(name='Ivy', age=27, language='C++')
 
-session.add_all([tag_1, tag_2, tag_3])
+    session.add_all([tag_1, tag_2, tag_3])
 
-# Read the inserted data
+    # Read the inserted data
 
-print('Query returned:')
-for instance in session.query(Employee):
-    print("Name: %s Age: %s Language: %s"%(instance.name, instance.age, instance.language))
-session.commit()
+    print('Query returned:')
+    for instance in session.query(Employee):
+        print("Name: %s Age: %s Language: %s"%(instance.name, instance.age, instance.language))
+    session.commit()
 
-```
 
 When you run the `main.py` file, you should get the output similar to the following.
 

--- a/docs/content/preview/drivers-orms/python/sqlalchemy.md
+++ b/docs/content/preview/drivers-orms/python/sqlalchemy.md
@@ -69,29 +69,29 @@ To start with SQLAlchemy, in your project directory, create 4 Python files - `co
 
 1. `config.py` contains the credentials to connect to your database. Copy the following sample code to the `config.py` file.
 
-   ```python
-    db_user = 'yugabyte'
-    db_password = 'yugabyte'
-    database = 'yugabyte'
-    db_host = 'localhost'
-    db_port = 5433
-   ```
+    ```python
+     db_user = 'yugabyte'
+     db_password = 'yugabyte'
+     database = 'yugabyte'
+     db_host = 'localhost'
+     db_port = 5433
+    ```
 
 1. Next, declare a mapping. When using the ORM, the configuration process begins with describing the database tables you'll use, and then defining the classes which map to those tables. In modern SQLAlchemy, these two tasks are usually performed together, using a system known as **Declarative Extensions**. Classes mapped using the Declarative system are defined in terms of a base class which maintains a catalog of classes and tables relative to that base - this is known as the declarative base class. You create the base class using the `declarative_base()` function. Add the following code to the `base.py` file.
 
-   ```python
-   from sqlalchemy.ext.declarative import declarative_base
-   Base = declarative_base()
-   ```
+    ```python
+    from sqlalchemy.ext.declarative import declarative_base
+    Base = declarative_base()
+    ```
 
 1. Now that you have a _base_, you can define any number of mapped classes in terms of it. Start with a single table called `employees`, to store records for the end-users using your application. A new class called `Employee` maps to this table. In the class, you define details about the table to which you're mapping; primarily the table name, and names and datatypes of the columns. Add the following to the `model.py` file:
 
-   ```python
-   from sqlalchemy.ext.declarative import declarative_base
-   from sqlalchemy import Table, Column, Integer, String, DateTime, ForeignKey
-   from base import Base
+    ```python
+    from sqlalchemy.ext.declarative import declarative_base
+    from sqlalchemy import Table, Column, Integer, String, DateTime, ForeignKey
+    from base import Base
 
-   class Employee(Base):
+    class Employee(Base):
 
       __tablename__ = 'employees'
 
@@ -99,18 +99,18 @@ To start with SQLAlchemy, in your project directory, create 4 Python files - `co
       name = Column(String(255), unique=True, nullable=False)
       age = Column(Integer)
       language = Column(String(255))
-   ```
+    ```
 
-1. After the setup is done, you can connect to the database and create a new session. In the `main.py` file, add the following.
+1. After the setup is done, you can connect to the database and create a new session. In the `main.py` file, add the following:
 
-   ```python
-   import config as cfg
-   from sqlalchemy.orm import sessionmaker, relationship
-   from sqlalchemy import create_engine
-   from sqlalchemy import MetaData
-   from model import Employee
-   from base import Base
-   from sqlalchemy import Table, Column, Integer, String, DateTime, ForeignKey
+    ```python
+    import config as cfg
+    from sqlalchemy.orm import sessionmaker, relationship
+    from sqlalchemy import create_engine
+    from sqlalchemy import MetaData
+    from model import Employee
+    from base import Base
+    from sqlalchemy import Table, Column, Integer, String, DateTime, ForeignKey
 
     # create connection
     engine = create_engine('postgresql://{0}:{1}@{2}:{3}/{4}'.format(cfg.db_user, cfg.db_password, cfg.db_host, cfg.db_port, cfg.database))
@@ -135,9 +135,9 @@ To start with SQLAlchemy, in your project directory, create 4 Python files - `co
     for instance in session.query(Employee):
         print("Name: %s Age: %s Language: %s"%(instance.name, instance.age, instance.language))
     session.commit()
+    ```
 
-
-When you run the `main.py` file, you should get the output similar to the following.
+When you run the `main.py` file, you should get the output similar to the following:
 
 ```text
 Query returned:


### PR DESCRIPTION
## Description:

- This is a 🐁 small change.
- This PR  fixes the code formatting issue on the [Python SQLAlchemy ORM example](https://docs.yugabyte.com/preview/drivers-orms/python/sqlalchemy/) page.

 ## Screenshots:

**- Before the fix:**

<img width="1260" alt="sqlalchemy_orm_code_format_before_fix png" src="https://user-images.githubusercontent.com/38150419/178775308-edf78e6a-536d-4cf7-894d-76911b58f9c0.png">


**- After the fix:**

<img width="1125" alt="sqlalchemy_orm_code_format_after_fix" src="https://user-images.githubusercontent.com/38150419/178775417-8a34b697-cc4a-41b6-9c9f-ed3fd71d9df0.png">




## Checklist
- [x] Set an informative, carefully chosen **title**
- [x] Applied *labels* to the PR

@netlify /preview/drivers-orms/python/sqlalchemy