### PR TITLE
[Docs] Adds multi-clustering-column for IN operator

### DIFF
--- a/docs/content/preview/api/ycql/dml_select.md
+++ b/docs/content/preview/api/ycql/dml_select.md
@@ -72,6 +72,7 @@ Where
 
   - Only `=`, `!=`, `IN` and `NOT IN` operators can be used for conditions on partition columns.
   - Only operators `=`, `!=`, `<`, `<=`, `>`, `>=`, `IN` and `NOT IN` can be used for conditions on clustering and regular columns.
+  - Only `IN` operator can be used for conditions on tuples of clustering columns.
 
 ### `IF` clause
 


### PR DESCRIPTION
With https://github.com/yugabyte/yugabyte-db/commit/c1a46aa8034486371ca929b9b9ac25bb4b655c41, we introduced support for multi clustering column for `IN` operator. This PR updates the docs for the same.