### PR TITLE
[docs] added a netlify redirect and aliases

### DIFF
--- a/docs/content/preview/develop/build-apps/java/ysql-ebean.md
+++ b/docs/content/preview/develop/build-apps/java/ysql-ebean.md
@@ -3,6 +3,8 @@ title: Build a Java application that uses Ebean and YSQL
 headerTitle: Build a Java application
 linkTitle: More examples
 description: Build a sample Java application that uses Ebean and YSQL API to connect to and interact with YugabyteDB.
+aliases:
+  - /preview/quick-start/build-apps/java/ysql-ebean/
 menu:
   preview:
     parent: cloud-java

--- a/docs/content/preview/develop/build-apps/java/ysql-hibernate.md
+++ b/docs/content/preview/develop/build-apps/java/ysql-hibernate.md
@@ -3,6 +3,8 @@ title: Build a Java application that uses YSQL
 headerTitle: Build a Java application
 linkTitle: More examples
 description: Build a sample Java application with Hibernate ORM and use the YSQL API to connect to and interact with YugabyteDB.
+aliases:
+  - /preview/quick-start/build-apps/java/ysql-hibernate/
 menu:
   preview:
     parent: cloud-java

--- a/docs/content/preview/develop/build-apps/java/ysql-jdbc-ssl.md
+++ b/docs/content/preview/develop/build-apps/java/ysql-jdbc-ssl.md
@@ -3,6 +3,8 @@ title: Build a Java application that uses YSQL over SSL
 headerTitle: Build a Java application
 linkTitle: More examples
 description: Build a sample Java application with the PostgreSQL JDBC Driver and use the YSQL API to connect to and interact with YugabyteDB via SSL/TLS.
+aliases:
+  - /preview/quick-start/build-apps/java/ysql-jdbc-ssl/
 menu:
   preview:
     parent: cloud-java

--- a/docs/content/preview/develop/build-apps/java/ysql-jdbc.md
+++ b/docs/content/preview/develop/build-apps/java/ysql-jdbc.md
@@ -3,6 +3,8 @@ title: Build a Java application that uses YSQL
 headerTitle: Build a Java application
 linkTitle: More examples
 description: Build a sample Java application with the PostgreSQL JDBC Driver and use the YSQL API to connect to and interact with YugabyteDB.
+aliases:
+  - /preview/quick-start/build-apps/java/ysql-jdbc/
 menu:
   preview:
     parent: cloud-java

--- a/docs/content/preview/develop/build-apps/java/ysql-sdyb.md
+++ b/docs/content/preview/develop/build-apps/java/ysql-sdyb.md
@@ -3,6 +3,8 @@ title: Build a Java application that uses YSQL
 headerTitle: Build a Java application
 linkTitle: More examples
 description: Build a sample Java application with Spring Data YugabyteDB and use the YSQL API to connect to and interact with YugabyteDB.
+aliases:
+  - /preview/quick-start/build-apps/java/ysql-sdyb/
 menu:
   preview:
     parent: cloud-java

--- a/docs/content/preview/develop/build-apps/java/ysql-spring-data.md
+++ b/docs/content/preview/develop/build-apps/java/ysql-spring-data.md
@@ -3,6 +3,8 @@ title: Build a Java application that uses Spring Boot and YSQL
 headerTitle: Build a Java application
 linkTitle: More examples
 description: Build a simple Java e-commerce application that uses Spring Boot and YSQL.
+aliases:
+  - /preview/quick-start/build-apps/java/ysql-spring-data/
 menu:
   preview:
     parent: cloud-java

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -157,6 +157,10 @@
   from="/preview/yugabyte-cloud/cloud-quickstart/cloud-build-apps/cloud-ysql-rust/*"
   to = "/preview/develop/build-apps/rust/cloud-ysql-rust/"
   force = true
+[[redirects]]
+  from="/preview/yugabyte-cloud/cloud-quickstart/cloud-build-apps/cloud-add-ip/"
+  to = "/preview/develop/build-apps/cloud-add-ip/"
+  force = true
 
 # Redirect older versions of specific sections
 


### PR DESCRIPTION
Two files from the search results for "Certificates" on the docs page are returning 404s.
https://docs.yugabyte.com/preview/yugabyte-cloud/cloud-quickstart/cloud-build-apps/cloud-add-ip/#download-your-cluster-certificate
https://docs.yugabyte.com/preview/quick-start/build-apps/java/ysql-jdbc-ssl/#ssl-certificates-for-a-cluster-in-kubernetes-optional

-Added a redirect for one - [Before you begin](https://docs.yugabyte.com/preview/develop/build-apps/cloud-add-ip/). 
-Added aliases to rest of the java files under quick start. (not sure about this) 