### PR TITLE
[#12860] Display TLS details on console

### DIFF
--- a/ent/src/yb/integration-tests/secure_connection_test.cc
+++ b/ent/src/yb/integration-tests/secure_connection_test.cc
@@ -131,6 +131,19 @@ TEST_F(SecureConnectionTest, Simple) {
   TestSimpleOps();
 }
 
+TEST_F(SecureConnectionTest, CertificateDetails) {
+  TestSimpleOps();
+
+  auto certDetails = secure_context_->GetCertificateDetails();
+  ASSERT_STR_CONTAINS(certDetails, "Client certificate");
+  ASSERT_STR_CONTAINS(certDetails, "Issuer");
+  ASSERT_STR_CONTAINS(certDetails, "Serial Number");
+  ASSERT_STR_CONTAINS(certDetails, "Validity");
+  ASSERT_STR_CONTAINS(certDetails, "Not Before");
+  ASSERT_STR_CONTAINS(certDetails, "Not After");
+  ASSERT_STR_CONTAINS(certDetails, "Subject");
+}
+
 class SecureConnectionTLS12Test : public SecureConnectionTest {
   void SetUp() override {
     FLAGS_ssl_protocols = "tls12";

--- a/ent/src/yb/master/master.h
+++ b/ent/src/yb/master/master.h
@@ -45,6 +45,7 @@ class Master : public yb::master::Master {
   void operator=(const Master&) = delete;
 
   Status ReloadKeysAndCertificates() override;
+  std::string GetCertificateDetails() override;
 
  protected:
   Status RegisterServices() override;

--- a/ent/src/yb/master/master_ent.cc
+++ b/ent/src/yb/master/master_ent.cc
@@ -84,6 +84,12 @@ Status Master::ReloadKeysAndCertificates() {
         options_.HostsString());
 }
 
+std::string Master::GetCertificateDetails() {
+  if(!secure_context_) return "";
+
+  return secure_context_.get()->GetCertificateDetails();
+}
+
 } // namespace enterprise
 } // namespace master
 } // namespace yb

--- a/ent/src/yb/server/secure.cc
+++ b/ent/src/yb/server/secure.cc
@@ -80,6 +80,14 @@ string CertsDir(const std::string& root_dir, SecureContextType type) {
 
 } // namespace
 
+bool IsNodeToNodeEncryptionEnabled() {
+  return FLAGS_use_node_to_node_encryption;
+}
+
+bool IsClientToServerEncryptionEnabled() {
+  return FLAGS_use_client_to_server_encryption;
+}
+
 string DefaultCertsDir(const FsManager& fs_manager) {
   return fs_manager.GetCertsDir(fs_manager.GetDefaultRootDir());
 }

--- a/ent/src/yb/server/secure.h
+++ b/ent/src/yb/server/secure.h
@@ -71,6 +71,10 @@ Status ReloadSecureContextKeysAndCertificates(
 
 void ApplySecureContext(const rpc::SecureContext* context, rpc::MessengerBuilder* builder);
 
+bool IsNodeToNodeEncryptionEnabled();
+
+bool IsClientToServerEncryptionEnabled();
+
 } // namespace server
 } // namespace yb
 

--- a/ent/src/yb/tserver/tablet_server.h
+++ b/ent/src/yb/tserver/tablet_server.h
@@ -52,6 +52,7 @@ class TabletServer : public yb::tserver::TabletServer {
   CDCConsumer* GetCDCConsumer();
 
   Status ReloadKeysAndCertificates() override;
+  std::string GetCertificateDetails() override;
 
   void RegisterCertificateReloader(CertificateReloader reloader) override;
 

--- a/ent/src/yb/tserver/tablet_server_ent.cc
+++ b/ent/src/yb/tserver/tablet_server_ent.cc
@@ -186,6 +186,12 @@ Status TabletServer::ReloadKeysAndCertificates() {
   return Status::OK();
 }
 
+std::string TabletServer::GetCertificateDetails() {
+  if(!secure_context_) return "";
+
+  return secure_context_.get()->GetCertificateDetails();
+}
+
 void TabletServer::RegisterCertificateReloader(CertificateReloader reloader) {
   certificate_reloaders_.push_back(std::move(reloader));
 }

--- a/src/yb/rpc/secure_stream.cc
+++ b/src/yb/rpc/secure_stream.cc
@@ -275,6 +275,130 @@ YB_STRONGLY_TYPED_BOOL(UseCertificateKeyPair);
 
 } // namespace
 
+namespace {
+
+// Matches pattern from RFC 2818:
+// Names may contain the wildcard character * which is considered to match any single domain name
+// component or component fragment. E.g., *.a.com matches foo.a.com but not bar.foo.a.com.
+// f*.com matches foo.com but not bar.com.
+bool MatchPattern(Slice pattern, Slice host) {
+  const char* p = pattern.cdata();
+  const char* p_end = pattern.cend();
+  const char* h = host.cdata();
+  const char* h_end = host.cend();
+
+  while (p != p_end && h != h_end) {
+    if (*p == '*') {
+      ++p;
+      while (h != h_end && *h != '.') {
+        if (MatchPattern(Slice(p, p_end), Slice(h, h_end))) {
+          return true;
+        }
+        ++h;
+      }
+    } else if (std::tolower(*p) == std::tolower(*h)) {
+      ++p;
+      ++h;
+    } else {
+      return false;
+    }
+  }
+
+  return p == p_end && h == h_end;
+}
+
+Slice GetEntryByNid(X509* cert, int nid) {
+  X509_NAME* name = X509_get_subject_name(cert);
+  int last_i = -1;
+  for (int i = -1; (i = X509_NAME_get_index_by_NID(name, nid, i)) >= 0; ) {
+    last_i = i;
+  }
+  if (last_i == -1) {
+    return Slice();
+  }
+  auto* name_entry = X509_NAME_get_entry(name, last_i);
+  if (!name_entry) {
+    LOG(DFATAL) << "No name entry in certificate at index: " << last_i;
+    return Slice();
+  }
+  auto* common_name = X509_NAME_ENTRY_get_data(name_entry);
+
+  if (common_name && common_name->data && common_name->length) {
+    return Slice(common_name->data, common_name->length);
+  }
+
+  return Slice();
+}
+
+Slice GetCommonName(X509* cert) {
+  return GetEntryByNid(cert, NID_commonName);
+}
+
+std::string X509CertToString(X509* cert) {
+#define BUF_LENGTH 1024
+
+  char buffer[BUF_LENGTH+1];
+  X509_NAME_oneline(X509_get_issuer_name(cert), buffer, BUF_LENGTH);
+  string result = "Issuer: ";
+  result.append(buffer);
+
+  result.append("\nSerial Number: ");
+  result.append(std::to_string(ASN1_INTEGER_get(X509_get_serialNumber(cert))));
+
+  // Validity - notBefore
+  auto appendTime = [&](const ASN1_TIME* time) {
+    BIO *bmem = BIO_new(BIO_s_mem());
+
+    if (ASN1_TIME_print(bmem, time)) {
+        BUF_MEM * bptr;
+
+        BIO_get_mem_ptr(bmem, &bptr);
+        result.append(std::string(bptr->data, bptr->length));
+    }
+    else { // Log error
+      result.append("<error>");
+    }
+    BIO_free_all(bmem);
+  };
+
+  // notBefore
+  result.append("\nValidity:\n  Not Before: ");
+  appendTime(X509_get_notBefore(cert));
+  result.append("\n  Not After: ");
+  appendTime(X509_get_notAfter(cert));
+
+  X509_NAME_oneline(X509_get_subject_name(cert), buffer, BUF_LENGTH);
+  result.append("\nSubject: ");
+  result.append(buffer);
+
+  return result;
+}
+
+} // namespace
+
+
+bool AllowInsecureConnections() {
+  return FLAGS_allow_insecure_connections;
+}
+
+std::string GetSSLProtocols() {
+  const std::string& ssl_protocols = FLAGS_ssl_protocols;
+  if (ssl_protocols.empty()) { return "default - TLS only"; }
+  return ssl_protocols;
+}
+
+std::string GetCipherList() {
+  auto cipher_list = FLAGS_cipher_list;
+  if (cipher_list.empty()) { return "default"; }
+  return cipher_list;
+}
+
+std::string GetCipherSuites() {
+  auto ciphersuites = FLAGS_ciphersuites;
+  if (ciphersuites.empty()) { return "default"; }
+  return ciphersuites;
+}
+
 void InitOpenSSL() {
   static OpenSSLInitializer initializer;
 }
@@ -294,6 +418,8 @@ class SecureContext::Impl {
   Status UseCertificates(
       const std::string& ca_cert_file, const Slice& certificate_data,
       const Slice& pkey_data) EXCLUDES(mutex_);
+
+  std::string GetCertificateDetails();
 
   // Generates and uses temporary keys, should be used only during testing.
   Status TEST_GenerateKeys(int bits, const std::string& common_name,
@@ -465,6 +591,23 @@ Status SecureContext::Impl::UseCertificates(
   return Status::OK();
 }
 
+std::string SecureContext::Impl::GetCertificateDetails() {
+  UNIQUE_LOCK(lock, mutex_);
+
+  std::string result;
+  if(certificate_) {
+    result = "Client certificate: \n";
+    result.append(X509CertToString(certificate_.get()));
+  }
+
+  if(require_client_certificate()) {
+    // TODO: extend tabletserver to use certificate reloader callback like mechanism to capture server validation certificate. 
+    result.append("\n\nNote: Server validation certificate is not added to tracing yet.");
+  }
+
+  return result;
+}
+
 Status SecureContext::Impl::TEST_GenerateKeys(int bits, const std::string& common_name,
                                               MatchingCertKeyPair matching_cert_key_pair) {
   auto ca_key = VERIFY_RESULT(GeneratePrivateKey(bits));
@@ -498,6 +641,10 @@ Status SecureContext::AddCertificateAuthorityFile(const std::string& file) {
 Status SecureContext::UseCertificates(
     const std::string& ca_cert_file, const Slice& certificate_data, const Slice& pkey_data) {
   return impl_->UseCertificates(ca_cert_file, certificate_data, pkey_data);
+}
+
+std::string SecureContext::GetCertificateDetails() {
+  return impl_->GetCertificateDetails();
 }
 
 Status SecureContext::TEST_GenerateKeys(int bits, const std::string& common_name,
@@ -789,67 +936,6 @@ int SecureRefiner::VerifyCallback(int preverified, X509_STORE_CTX* store_context
   refiner->verification_status_ = status;
   return 0;
 }
-
-namespace {
-
-// Matches pattern from RFC 2818:
-// Names may contain the wildcard character * which is considered to match any single domain name
-// component or component fragment. E.g., *.a.com matches foo.a.com but not bar.foo.a.com.
-// f*.com matches foo.com but not bar.com.
-bool MatchPattern(Slice pattern, Slice host) {
-  const char* p = pattern.cdata();
-  const char* p_end = pattern.cend();
-  const char* h = host.cdata();
-  const char* h_end = host.cend();
-
-  while (p != p_end && h != h_end) {
-    if (*p == '*') {
-      ++p;
-      while (h != h_end && *h != '.') {
-        if (MatchPattern(Slice(p, p_end), Slice(h, h_end))) {
-          return true;
-        }
-        ++h;
-      }
-    } else if (std::tolower(*p) == std::tolower(*h)) {
-      ++p;
-      ++h;
-    } else {
-      return false;
-    }
-  }
-
-  return p == p_end && h == h_end;
-}
-
-Slice GetEntryByNid(X509* cert, int nid) {
-  X509_NAME* name = X509_get_subject_name(cert);
-  int last_i = -1;
-  for (int i = -1; (i = X509_NAME_get_index_by_NID(name, nid, i)) >= 0; ) {
-    last_i = i;
-  }
-  if (last_i == -1) {
-    return Slice();
-  }
-  auto* name_entry = X509_NAME_get_entry(name, last_i);
-  if (!name_entry) {
-    LOG(DFATAL) << "No name entry in certificate at index: " << last_i;
-    return Slice();
-  }
-  auto* common_name = X509_NAME_ENTRY_get_data(name_entry);
-
-  if (common_name && common_name->data && common_name->length) {
-    return Slice(common_name->data, common_name->length);
-  }
-
-  return Slice();
-}
-
-Slice GetCommonName(X509* cert) {
-  return GetEntryByNid(cert, NID_commonName);
-}
-
-} // namespace
 
 bool SecureRefiner::MatchEndpoint(X509* cert, GENERAL_NAMES* gens) {
   auto address = stream_->Remote().address();

--- a/src/yb/rpc/secure_stream.h
+++ b/src/yb/rpc/secure_stream.h
@@ -40,6 +40,8 @@ class SecureContext {
   Status UseCertificates(
       const std::string& ca_cert_file, const Slice& certificate_data, const Slice& pkey_data);
 
+  std::string GetCertificateDetails();
+
   // Generates and uses temporary keys, should be used only during testing.
   Status TEST_GenerateKeys(int bits, const std::string& common_name,
                                    MatchingCertKeyPair matching_cert_key_pair);
@@ -57,6 +59,12 @@ StreamFactoryPtr SecureStreamFactory(
     const SecureContext* context);
 
 void InitOpenSSL();
+
+bool AllowInsecureConnections();
+
+std::string GetSSLProtocols();
+std::string GetCipherList();
+std::string GetCipherSuites();
 
 } // namespace rpc
 } // namespace yb

--- a/src/yb/server/default-path-handlers.cc
+++ b/src/yb/server/default-path-handlers.cc
@@ -65,7 +65,10 @@
 #include "yb/gutil/strings/human_readable.h"
 #include "yb/gutil/strings/split.h"
 #include "yb/gutil/strings/substitute.h"
+#include "yb/rpc/secure_stream.h"
 #include "yb/server/pprof-path-handlers.h"
+#include "yb/server/server_base.h"
+#include "yb/server/secure.h"
 #include "yb/server/webserver.h"
 #include "yb/util/flag_tags.h"
 #include "yb/util/format.h"
@@ -443,6 +446,47 @@ static void PathUsageHandler(FsManager* fsmanager,
 void RegisterPathUsageHandler(Webserver* webserver, FsManager* fsmanager) {
   Webserver::PathHandlerCallback callback = std::bind(PathUsageHandler, fsmanager, _1, _2);
   webserver->RegisterPathHandler("/drives", "Drives", callback, true, false);
+}
+
+// Registered to handle "/tls", and prints out certificate details
+// Registered to handle "/drives", and prints out paths usage
+static void CertificateHandler(server::RpcServerBase* server,
+                             const Webserver::WebRequest& req,
+                             Webserver::WebResponse* resp) {
+  std::stringstream *output = &resp->output;
+  bool as_text = (req.parsed_args.find("raw") != req.parsed_args.end());
+  Tags tags(as_text);
+  (*output) << tags.header <<"TLS Settings" << tags.end_header << endl;
+
+  (*output) << tags.pre_tag;
+
+  (*output) << "Node to node encryption enabled: " << (yb::server::IsNodeToNodeEncryptionEnabled() ? "true" : "false");
+
+  (*output) << tags.line_break <<"Client to server encryption enabled: " << (yb::server::IsClientToServerEncryptionEnabled() ? "true" : "false");
+
+  (*output) << tags.line_break <<"Allow insecure connections: " << (yb::rpc::AllowInsecureConnections() ? "on" : "off");
+
+  (*output) << tags.line_break <<"SSL Protocols: " << yb::rpc::GetSSLProtocols().c_str();
+
+  (*output) << tags.line_break <<"Cipher list: " << yb::rpc::GetCipherList().c_str();
+
+  (*output) << tags.line_break <<"Ciphersuites: " << yb::rpc::GetCipherSuites().c_str();
+
+  (*output) << tags.end_pre_tag;
+
+  auto details = server->GetCertificateDetails();
+
+  if(!details.empty()) {
+    (*output) << tags.header <<"Certificate details" << tags.end_header << endl;
+
+    (*output) << tags.pre_tag << details.c_str() << tags.end_pre_tag << endl;
+  }
+}
+
+void RegisterTlsHandler(Webserver* webserver, server::RpcServerBase* server)
+{
+  Webserver::PathHandlerCallback callback = std::bind(CertificateHandler, server, _1, _2);
+  webserver->RegisterPathHandler("/tls", "TLS", callback, true /*is_styled*/, false /*is_on_nav_bar*/);
 }
 
 } // namespace yb

--- a/src/yb/server/default-path-handlers.h
+++ b/src/yb/server/default-path-handlers.h
@@ -44,12 +44,15 @@
 #ifndef YB_SERVER_DEFAULT_PATH_HANDLERS_H
 #define YB_SERVER_DEFAULT_PATH_HANDLERS_H
 
-
 namespace yb {
 
 class MetricRegistry;
 class Webserver;
 class FsManager;
+
+namespace server {
+    class RpcServerBase;
+}
 
 // Adds a set of default path handlers to the webserver to display
 // logs and configuration flags.
@@ -60,6 +63,8 @@ void RegisterMetricsJsonHandler(Webserver* webserver, const MetricRegistry* cons
 
 // Adds an endpoint to display path usage.
 void RegisterPathUsageHandler(Webserver* webserver, FsManager* fsmanager);
+
+void RegisterTlsHandler(Webserver* webserver, server::RpcServerBase* server);
 
 } // namespace yb
 

--- a/src/yb/server/server_base.cc
+++ b/src/yb/server/server_base.cc
@@ -611,6 +611,8 @@ void RpcAndWebServerBase::DisplayGeneralInfoIcons(std::stringstream* output) {
   DisplayIconTile(output, "fa-microchip", "Threads", "/threadz");
   // Drives.
   DisplayIconTile(output, "fa-hdd-o", "Drives", "/drives");
+  // TLS.
+  DisplayIconTile(output, "fa-lock", "TLS", "/tls");
 }
 
 Status RpcAndWebServerBase::DisplayRpcIcons(std::stringstream* output) {
@@ -642,6 +644,7 @@ Status RpcAndWebServerBase::Start() {
   AddRpczPathHandlers(messenger_.get(), web_server_.get());
   RegisterMetricsJsonHandler(web_server_.get(), metric_registry_.get());
   RegisterPathUsageHandler(web_server_.get(), fs_manager_.get());
+  RegisterTlsHandler(web_server_.get(), (RpcServerBase*)this);
   TracingPathHandlers::RegisterHandlers(web_server_.get());
   web_server_->RegisterPathHandler("/utilz", "Utilities",
                                    std::bind(&RpcAndWebServerBase::HandleDebugPage, this, _1, _2),

--- a/src/yb/server/server_base.h
+++ b/src/yb/server/server_base.h
@@ -107,6 +107,7 @@ class RpcServerBase {
   const std::string get_hostname() const;
 
   virtual Status ReloadKeysAndCertificates() { return Status::OK(); }
+  virtual std::string GetCertificateDetails() { return ""; }
 
  protected:
   RpcServerBase(std::string name,


### PR DESCRIPTION
Summary: Added TLS webpage under Utilities to provide node level TLS settings and display the certificates used as well.

Note: currently we only display the client certificate used for node to node communication.