### PR TITLE
[docs] remove very deprecated "start_pgsql_proxy"

### DIFF
--- a/docs/content/preview/deploy/docker/docker-compose.md
+++ b/docs/content/preview/deploy/docker/docker-compose.md
@@ -74,7 +74,7 @@ services:
       - yb-tserver-data-1:/mnt/tserver
       command: [ "/home/yugabyte/bin/yb-tserver",
                 "--fs_data_dirs=/mnt/tserver",
-                "--start_pgsql_proxy",
+                "--enable_ysql",
                 "--rpc_bind_addresses=yb-tserver-n1:9100",
                 "--tserver_master_addrs=yb-master-n1:7100"]
       ports:
@@ -181,7 +181,7 @@ services:
       - yb-tserver-data-1:/mnt/tserver
       command: [ "/home/yugabyte/bin/yb-tserver",
                 "--fs_data_dirs=/mnt/tserver",
-                "--start_pgsql_proxy",
+                "--enable_ysql",
                 "--rpc_bind_addresses=yb-tserver-n1:9100",
                 "--tserver_master_addrs=yb-master-n1:7100"
                 ]

--- a/docs/content/preview/deploy/manual-deployment/start-tservers.md
+++ b/docs/content/preview/deploy/manual-deployment/start-tservers.md
@@ -36,7 +36,7 @@ Run the `yb-tserver` server on each of the six nodes as shown below. Note that a
 $ ./bin/yb-tserver \
   --tserver_master_addrs 172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100 \
   --rpc_bind_addresses 172.151.17.130:9100 \
-  --start_pgsql_proxy \
+  --enable_ysql \
   --pgsql_proxy_bind_address 172.151.17.130:5433 \
   --cql_proxy_bind_address 172.151.17.130:9042 \
   --fs_data_dirs "/home/centos/disk1,/home/centos/disk2" \
@@ -61,7 +61,7 @@ Alternatively, you can also create a `tserver.conf` file with the following flag
 ```sh
 --tserver_master_addrs=172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100
 --rpc_bind_addresses=172.151.17.130:9100
---start_pgsql_proxy
+--enable_ysql
 --pgsql_proxy_bind_address=172.151.17.130:5433
 --cql_proxy_bind_address=172.151.17.130:9042
 --fs_data_dirs=/home/centos/disk1,/home/centos/disk2

--- a/docs/content/preview/deploy/multi-dc/3dc-deployment.md
+++ b/docs/content/preview/deploy/multi-dc/3dc-deployment.md
@@ -64,7 +64,7 @@ Run the [yb-tserver](../../../reference/configuration/yb-tserver/) server on eac
 $ ./bin/yb-tserver \
   --tserver_master_addrs 172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100 \
   --rpc_bind_addresses 172.151.17.130 \
-  --start_pgsql_proxy \
+  --enable_ysql \
   --pgsql_proxy_bind_address 172.151.17.130:5433 \
   --cql_proxy_bind_address 172.151.17.130:9042 \
   --fs_data_dirs "/home/centos/disk1,/home/centos/disk2" \

--- a/docs/content/preview/reference/configuration/yb-master.md
+++ b/docs/content/preview/reference/configuration/yb-master.md
@@ -183,7 +183,7 @@ Default: `""`
 
 {{< note title="Note" >}}
 
-Ensure that `enable_ysql` in `yb-master` configurations match the values in `yb-tserver` configurations.
+Ensure that `enable_ysql` values in `yb-master` configurations match the values in `yb-tserver` configurations.
 
 {{< /note >}}
 

--- a/docs/content/preview/reference/configuration/yb-master.md
+++ b/docs/content/preview/reference/configuration/yb-master.md
@@ -187,7 +187,7 @@ Ensure that `enable_ysql` in `yb-master` configurations match the values in `yb-
 
 {{< /note >}}
 
-Enables the YSQL API when value is `true`. Replaces the deprecated `--start_pgsql_proxy` flag.
+Enables the YSQL API when value is `true`.
 
 Default: `true`
 

--- a/docs/content/preview/reference/configuration/yb-tserver.md
+++ b/docs/content/preview/reference/configuration/yb-tserver.md
@@ -28,7 +28,7 @@ yb-tserver [ flags ]
 $ ./bin/yb-tserver \
 --tserver_master_addrs 172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100 \
 --rpc_bind_addresses 172.151.17.130 \
---start_pgsql_proxy \
+--enable_ysql \
 --fs_data_dirs "/home/centos/disk1,/home/centos/disk2" &
 ```
 
@@ -433,11 +433,11 @@ The following flags support the use of the [YSQL API](../../../api/ysql/).
 
 {{< note title="Note" >}}
 
-Ensure that `enable_ysql` in `yb-tserver` configurations match the values in `yb-master` configurations.
+Ensure that `enable_ysql` values in `yb-tserver` configurations match the values in `yb-master` configurations.
 
 {{< /note >}}
 
-Enables the YSQL API. Replaces the deprecated `--start_pgsql_proxy` flag.
+Enables the YSQL API.
 
 Default: `true`
 

--- a/docs/content/stable/deploy/docker/docker-compose.md
+++ b/docs/content/stable/deploy/docker/docker-compose.md
@@ -71,7 +71,7 @@ services:
       - yb-tserver-data-1:/mnt/tserver
       command: [ "/home/yugabyte/bin/yb-tserver",
                 "--fs_data_dirs=/mnt/tserver",
-                "--start_pgsql_proxy",
+                "--enable_ysql",
                 "--rpc_bind_addresses=yb-tserver-n1:9100",
                 "--tserver_master_addrs=yb-master-n1:7100"]
       ports:
@@ -178,7 +178,7 @@ services:
       - yb-tserver-data-1:/mnt/tserver
       command: [ "/home/yugabyte/bin/yb-tserver",
                 "--fs_data_dirs=/mnt/tserver",
-                "--start_pgsql_proxy",
+                "--enable_ysql",
                 "--rpc_bind_addresses=yb-tserver-n1:9100",
                 "--tserver_master_addrs=yb-master-n1:7100"
                 ]

--- a/docs/content/stable/deploy/manual-deployment/start-tservers.md
+++ b/docs/content/stable/deploy/manual-deployment/start-tservers.md
@@ -36,7 +36,7 @@ Run the `yb-tserver` server on each of the six nodes as shown below. Note that a
 $ ./bin/yb-tserver \
   --tserver_master_addrs 172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100 \
   --rpc_bind_addresses 172.151.17.130:9100 \
-  --start_pgsql_proxy \
+  --enable_ysql \
   --pgsql_proxy_bind_address 172.151.17.130:5433 \
   --cql_proxy_bind_address 172.151.17.130:9042 \
   --fs_data_dirs "/home/centos/disk1,/home/centos/disk2" \
@@ -61,7 +61,7 @@ Alternatively, you can also create a `tserver.conf` file with the following flag
 ```sh
 --tserver_master_addrs=172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100
 --rpc_bind_addresses=172.151.17.130:9100
---start_pgsql_proxy
+--enable_ysql
 --pgsql_proxy_bind_address=172.151.17.130:5433
 --cql_proxy_bind_address=172.151.17.130:9042
 --fs_data_dirs=/home/centos/disk1,/home/centos/disk2

--- a/docs/content/stable/deploy/multi-dc/3dc-deployment.md
+++ b/docs/content/stable/deploy/multi-dc/3dc-deployment.md
@@ -64,7 +64,7 @@ Run the [yb-tserver](../../../reference/configuration/yb-tserver/) server on eac
 $ ./bin/yb-tserver \
   --tserver_master_addrs 172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100 \
   --rpc_bind_addresses 172.151.17.130 \
-  --start_pgsql_proxy \
+  --enable_ysql \
   --pgsql_proxy_bind_address 172.151.17.130:5433 \
   --cql_proxy_bind_address 172.151.17.130:9042 \
   --fs_data_dirs "/home/centos/disk1,/home/centos/disk2" \

--- a/docs/content/stable/reference/configuration/yb-master.md
+++ b/docs/content/stable/reference/configuration/yb-master.md
@@ -184,7 +184,7 @@ Ensure that `enable_ysql` in `yb-master` configurations match the values in `yb-
 
 {{< /note >}}
 
-Enables the YSQL API when value is `true`. Replaces the deprecated `--start_pgsql_proxy` flag.
+Enables the YSQL API when value is `true`.
 
 Default: `true`
 

--- a/docs/content/stable/reference/configuration/yb-master.md
+++ b/docs/content/stable/reference/configuration/yb-master.md
@@ -180,7 +180,7 @@ Default: `""`
 
 {{< note title="Note" >}}
 
-Ensure that `enable_ysql` in `yb-master` configurations match the values in `yb-tserver` configurations.
+Ensure that `enable_ysql` values in `yb-master` configurations match the values in `yb-tserver` configurations.
 
 {{< /note >}}
 

--- a/docs/content/stable/reference/configuration/yb-tserver.md
+++ b/docs/content/stable/reference/configuration/yb-tserver.md
@@ -25,7 +25,7 @@ yb-tserver [ flags ]
 $ ./bin/yb-tserver \
 --tserver_master_addrs 172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100 \
 --rpc_bind_addresses 172.151.17.130 \
---start_pgsql_proxy \
+--enable_ysql \
 --fs_data_dirs "/home/centos/disk1,/home/centos/disk2" &
 ```
 
@@ -430,11 +430,11 @@ The following flags support the use of the [YSQL API](../../../api/ysql/).
 
 {{< note title="Note" >}}
 
-Ensure that `enable_ysql` in `yb-tserver` configurations match the values in `yb-master` configurations.
+Ensure that `enable_ysql` values in `yb-tserver` configurations match the values in `yb-master` configurations.
 
 {{< /note >}}
 
-Enables the YSQL API. Replaces the deprecated `--start_pgsql_proxy` flag.
+Enables the YSQL API.
 
 Default: `true`
 

--- a/docs/content/v2.12/deploy/docker/docker-compose.md
+++ b/docs/content/v2.12/deploy/docker/docker-compose.md
@@ -71,7 +71,7 @@ services:
       - yb-tserver-data-1:/mnt/tserver
       command: [ "/home/yugabyte/bin/yb-tserver",
                 "--fs_data_dirs=/mnt/tserver",
-                "--start_pgsql_proxy",
+                "--enable_ysql",
                 "--rpc_bind_addresses=yb-tserver-n1:9100",
                 "--tserver_master_addrs=yb-master-n1:7100"]
       ports:
@@ -178,7 +178,7 @@ services:
       - yb-tserver-data-1:/mnt/tserver
       command: [ "/home/yugabyte/bin/yb-tserver",
                 "--fs_data_dirs=/mnt/tserver",
-                "--start_pgsql_proxy",
+                "--enable_ysql",
                 "--rpc_bind_addresses=yb-tserver-n1:9100",
                 "--tserver_master_addrs=yb-master-n1:7100"
                 ]

--- a/docs/content/v2.12/deploy/manual-deployment/start-tservers.md
+++ b/docs/content/v2.12/deploy/manual-deployment/start-tservers.md
@@ -36,7 +36,7 @@ Run the `yb-tserver` server on each of the six nodes as shown below. Note that a
 $ ./bin/yb-tserver \
   --tserver_master_addrs 172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100 \
   --rpc_bind_addresses 172.151.17.130:9100 \
-  --start_pgsql_proxy \
+  --enable_ysql \
   --pgsql_proxy_bind_address 172.151.17.130:5433 \
   --cql_proxy_bind_address 172.151.17.130:9042 \
   --fs_data_dirs "/home/centos/disk1,/home/centos/disk2" \
@@ -61,7 +61,7 @@ Alternatively, you can also create a `tserver.conf` file with the following flag
 ```sh
 --tserver_master_addrs=172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100
 --rpc_bind_addresses=172.151.17.130:9100
---start_pgsql_proxy
+--enable_ysql
 --pgsql_proxy_bind_address=172.151.17.130:5433
 --cql_proxy_bind_address=172.151.17.130:9042
 --fs_data_dirs=/home/centos/disk1,/home/centos/disk2

--- a/docs/content/v2.12/deploy/multi-dc/3dc-deployment.md
+++ b/docs/content/v2.12/deploy/multi-dc/3dc-deployment.md
@@ -64,7 +64,7 @@ Run the [yb-tserver](../../../reference/configuration/yb-tserver/) server on eac
 $ ./bin/yb-tserver \
   --tserver_master_addrs 172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100 \
   --rpc_bind_addresses 172.151.17.130 \
-  --start_pgsql_proxy \
+  --enable_ysql \
   --pgsql_proxy_bind_address 172.151.17.130:5433 \
   --cql_proxy_bind_address 172.151.17.130:9042 \
   --fs_data_dirs "/home/centos/disk1,/home/centos/disk2" \

--- a/docs/content/v2.12/reference/configuration/yb-master.md
+++ b/docs/content/v2.12/reference/configuration/yb-master.md
@@ -176,7 +176,7 @@ Default: `""`
 
 ##### --enable_ysql
 
-Enables the YSQL API when value is `true`. Replaces the deprecated `--start_pgsql_proxy` flag.
+Enables the YSQL API when value is `true`.
 
 Default: `true`
 

--- a/docs/content/v2.12/reference/configuration/yb-tserver.md
+++ b/docs/content/v2.12/reference/configuration/yb-tserver.md
@@ -25,7 +25,7 @@ yb-tserver [ flags ]
 $ ./bin/yb-tserver \
 --tserver_master_addrs 172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100 \
 --rpc_bind_addresses 172.151.17.130 \
---start_pgsql_proxy \
+--enable_ysql \
 --fs_data_dirs "/home/centos/disk1,/home/centos/disk2" &
 ```
 
@@ -414,7 +414,7 @@ The following flags support the use of the [YSQL API](../../../api/ysql/).
 
 ##### --enable_ysql
 
-Enables the YSQL API. Replaces the deprecated `--start_pgsql_proxy` flag.
+Enables the YSQL API.
 
 Default: `true`
 

--- a/docs/content/v2.4/deploy/docker/docker-compose.md
+++ b/docs/content/v2.4/deploy/docker/docker-compose.md
@@ -73,7 +73,7 @@ services:
       - yb-tserver-data-1:/mnt/tserver
       command: [ "/home/yugabyte/bin/yb-tserver",
                 "--fs_data_dirs=/mnt/tserver",
-                "--start_pgsql_proxy",
+                "--enable_ysql",
                 "--rpc_bind_addresses=yb-tserver-n1:9100",
                 "--tserver_master_addrs=yb-master-n1:7100"]
       ports:
@@ -180,7 +180,7 @@ services:
       - yb-tserver-data-1:/mnt/tserver
       command: [ "/home/yugabyte/bin/yb-tserver",
                 "--fs_data_dirs=/mnt/tserver",
-                "--start_pgsql_proxy",
+                "--enable_ysql",
                 "--rpc_bind_addresses=yb-tserver-n1:9100",
                 "--tserver_master_addrs=yb-master-n1:7100"
                 ]

--- a/docs/content/v2.4/deploy/manual-deployment/start-tservers.md
+++ b/docs/content/v2.4/deploy/manual-deployment/start-tservers.md
@@ -36,7 +36,7 @@ Run the `yb-tserver` server on each of the six nodes as shown below. Note that a
 $ ./bin/yb-tserver \
   --tserver_master_addrs 172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100 \
   --rpc_bind_addresses 172.151.17.130:9100 \
-  --start_pgsql_proxy \
+  --enable_ysql \
   --pgsql_proxy_bind_address 172.151.17.130:5433 \
   --cql_proxy_bind_address 172.151.17.130:9042 \
   --fs_data_dirs "/home/centos/disk1,/home/centos/disk2" \
@@ -61,7 +61,7 @@ Alternatively, you can also create a `tserver.conf` file with the following flag
 ```sh
 --tserver_master_addrs=172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100
 --rpc_bind_addresses=172.151.17.130:9100
---start_pgsql_proxy
+--enable_ysql
 --pgsql_proxy_bind_address=172.151.17.130:5433
 --cql_proxy_bind_address=172.151.17.130:9042
 --fs_data_dirs=/home/centos/disk1,/home/centos/disk2

--- a/docs/content/v2.4/deploy/multi-dc/3dc-deployment.md
+++ b/docs/content/v2.4/deploy/multi-dc/3dc-deployment.md
@@ -64,7 +64,7 @@ Run the [yb-tserver](../../../reference/configuration/yb-tserver/) server on eac
 $ ./bin/yb-tserver \
   --tserver_master_addrs 172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100 \
   --rpc_bind_addresses 172.151.17.130 \
-  --start_pgsql_proxy \
+  --enable_ysql \
   --pgsql_proxy_bind_address 172.151.17.130:5433 \
   --cql_proxy_bind_address 172.151.17.130:9042 \
   --fs_data_dirs "/home/centos/disk1,/home/centos/disk2" \

--- a/docs/content/v2.4/reference/configuration/yb-master.md
+++ b/docs/content/v2.4/reference/configuration/yb-master.md
@@ -176,7 +176,7 @@ Default: `""`
 
 ##### --enable_ysql
 
-Enables the YSQL API when value is `true`. Replaces the deprecated `--start_pgsql_proxy` flag.
+Enables the YSQL API when value is `true`.
 
 Default: `true`
 

--- a/docs/content/v2.4/reference/configuration/yb-tserver.md
+++ b/docs/content/v2.4/reference/configuration/yb-tserver.md
@@ -25,7 +25,7 @@ yb-tserver [ flags ]
 $ ./bin/yb-tserver \
 --tserver_master_addrs 172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100 \
 --rpc_bind_addresses 172.151.17.130 \
---start_pgsql_proxy \
+--enable_ysql \
 --fs_data_dirs "/home/centos/disk1,/home/centos/disk2" &
 ```
 
@@ -402,7 +402,7 @@ The following flags support the use of the [YSQL API](../../../api/ysql/).
 
 ##### --enable_ysql
 
-Enables the YSQL API. Replaces the deprecated `--start_pgsql_proxy` flag.
+Enables the YSQL API.
 
 Default: `true`
 

--- a/docs/content/v2.6/deploy/docker/docker-compose.md
+++ b/docs/content/v2.6/deploy/docker/docker-compose.md
@@ -73,7 +73,7 @@ services:
       - yb-tserver-data-1:/mnt/tserver
       command: [ "/home/yugabyte/bin/yb-tserver",
                 "--fs_data_dirs=/mnt/tserver",
-                "--start_pgsql_proxy",
+                "--enable_ysql",
                 "--rpc_bind_addresses=yb-tserver-n1:9100",
                 "--tserver_master_addrs=yb-master-n1:7100"]
       ports:
@@ -180,7 +180,7 @@ services:
       - yb-tserver-data-1:/mnt/tserver
       command: [ "/home/yugabyte/bin/yb-tserver",
                 "--fs_data_dirs=/mnt/tserver",
-                "--start_pgsql_proxy",
+                "--enable_ysql",
                 "--rpc_bind_addresses=yb-tserver-n1:9100",
                 "--tserver_master_addrs=yb-master-n1:7100"
                 ]

--- a/docs/content/v2.6/deploy/manual-deployment/start-tservers.md
+++ b/docs/content/v2.6/deploy/manual-deployment/start-tservers.md
@@ -36,7 +36,7 @@ Run the `yb-tserver` server on each of the six nodes as shown below. Note that a
 $ ./bin/yb-tserver \
   --tserver_master_addrs 172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100 \
   --rpc_bind_addresses 172.151.17.130:9100 \
-  --start_pgsql_proxy \
+  --enable_ysql \
   --pgsql_proxy_bind_address 172.151.17.130:5433 \
   --cql_proxy_bind_address 172.151.17.130:9042 \
   --fs_data_dirs "/home/centos/disk1,/home/centos/disk2" \
@@ -61,7 +61,7 @@ Alternatively, you can also create a `tserver.conf` file with the following flag
 ```sh
 --tserver_master_addrs=172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100
 --rpc_bind_addresses=172.151.17.130:9100
---start_pgsql_proxy
+--enable_ysql
 --pgsql_proxy_bind_address=172.151.17.130:5433
 --cql_proxy_bind_address=172.151.17.130:9042
 --fs_data_dirs=/home/centos/disk1,/home/centos/disk2

--- a/docs/content/v2.6/deploy/multi-dc/3dc-deployment.md
+++ b/docs/content/v2.6/deploy/multi-dc/3dc-deployment.md
@@ -64,7 +64,7 @@ Run the [yb-tserver](../../../reference/configuration/yb-tserver/) server on eac
 $ ./bin/yb-tserver \
   --tserver_master_addrs 172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100 \
   --rpc_bind_addresses 172.151.17.130 \
-  --start_pgsql_proxy \
+  --enable_ysql \
   --pgsql_proxy_bind_address 172.151.17.130:5433 \
   --cql_proxy_bind_address 172.151.17.130:9042 \
   --fs_data_dirs "/home/centos/disk1,/home/centos/disk2" \

--- a/docs/content/v2.6/reference/configuration/yb-master.md
+++ b/docs/content/v2.6/reference/configuration/yb-master.md
@@ -176,7 +176,7 @@ Default: `""`
 
 ##### --enable_ysql
 
-Enables the YSQL API when value is `true`. Replaces the deprecated `--start_pgsql_proxy` flag.
+Enables the YSQL API when value is `true`.
 
 Default: `true`
 

--- a/docs/content/v2.6/reference/configuration/yb-tserver.md
+++ b/docs/content/v2.6/reference/configuration/yb-tserver.md
@@ -25,7 +25,7 @@ yb-tserver [ flags ]
 $ ./bin/yb-tserver \
 --tserver_master_addrs 172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100 \
 --rpc_bind_addresses 172.151.17.130 \
---start_pgsql_proxy \
+--enable_ysql \
 --fs_data_dirs "/home/centos/disk1,/home/centos/disk2" &
 ```
 
@@ -402,7 +402,7 @@ The following flags support the use of the [YSQL API](../../../api/ysql/).
 
 ##### --enable_ysql
 
-Enables the YSQL API. Replaces the deprecated `--start_pgsql_proxy` flag.
+Enables the YSQL API.
 
 Default: `true`
 

--- a/docs/content/v2.8/deploy/docker/docker-compose.md
+++ b/docs/content/v2.8/deploy/docker/docker-compose.md
@@ -77,7 +77,7 @@ services:
       - yb-tserver-data-1:/mnt/tserver
       command: [ "/home/yugabyte/bin/yb-tserver",
                 "--fs_data_dirs=/mnt/tserver",
-                "--start_pgsql_proxy",
+                "--enable_ysql",
                 "--rpc_bind_addresses=yb-tserver-n1:9100",
                 "--tserver_master_addrs=yb-master-n1:7100"]
       ports:
@@ -184,7 +184,7 @@ services:
       - yb-tserver-data-1:/mnt/tserver
       command: [ "/home/yugabyte/bin/yb-tserver",
                 "--fs_data_dirs=/mnt/tserver",
-                "--start_pgsql_proxy",
+                "--enable_ysql",
                 "--rpc_bind_addresses=yb-tserver-n1:9100",
                 "--tserver_master_addrs=yb-master-n1:7100"
                 ]

--- a/docs/content/v2.8/deploy/manual-deployment/start-tservers.md
+++ b/docs/content/v2.8/deploy/manual-deployment/start-tservers.md
@@ -36,7 +36,7 @@ Run the `yb-tserver` server on each of the six nodes as shown below. Note that a
 $ ./bin/yb-tserver \
   --tserver_master_addrs 172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100 \
   --rpc_bind_addresses 172.151.17.130:9100 \
-  --start_pgsql_proxy \
+  --enable_ysql \
   --pgsql_proxy_bind_address 172.151.17.130:5433 \
   --cql_proxy_bind_address 172.151.17.130:9042 \
   --fs_data_dirs "/home/centos/disk1,/home/centos/disk2" \
@@ -61,7 +61,7 @@ Alternatively, you can also create a `tserver.conf` file with the following flag
 ```sh
 --tserver_master_addrs=172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100
 --rpc_bind_addresses=172.151.17.130:9100
---start_pgsql_proxy
+--enable_ysql
 --pgsql_proxy_bind_address=172.151.17.130:5433
 --cql_proxy_bind_address=172.151.17.130:9042
 --fs_data_dirs=/home/centos/disk1,/home/centos/disk2

--- a/docs/content/v2.8/deploy/multi-dc/3dc-deployment.md
+++ b/docs/content/v2.8/deploy/multi-dc/3dc-deployment.md
@@ -64,7 +64,7 @@ Run the [yb-tserver](../../../reference/configuration/yb-tserver/) server on eac
 $ ./bin/yb-tserver \
   --tserver_master_addrs 172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100 \
   --rpc_bind_addresses 172.151.17.130 \
-  --start_pgsql_proxy \
+  --enable_ysql \
   --pgsql_proxy_bind_address 172.151.17.130:5433 \
   --cql_proxy_bind_address 172.151.17.130:9042 \
   --fs_data_dirs "/home/centos/disk1,/home/centos/disk2" \

--- a/docs/content/v2.8/reference/configuration/yb-master.md
+++ b/docs/content/v2.8/reference/configuration/yb-master.md
@@ -176,7 +176,7 @@ Default: `""`
 
 ##### --enable_ysql
 
-Enables the YSQL API when value is `true`. Replaces the deprecated `--start_pgsql_proxy` flag.
+Enables the YSQL API when value is `true`.
 
 Default: `true`
 

--- a/docs/content/v2.8/reference/configuration/yb-tserver.md
+++ b/docs/content/v2.8/reference/configuration/yb-tserver.md
@@ -25,7 +25,7 @@ yb-tserver [ flags ]
 $ ./bin/yb-tserver \
 --tserver_master_addrs 172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100 \
 --rpc_bind_addresses 172.151.17.130 \
---start_pgsql_proxy \
+--enable_ysql \
 --fs_data_dirs "/home/centos/disk1,/home/centos/disk2" &
 ```
 
@@ -402,7 +402,7 @@ The following flags support the use of the [YSQL API](../../../api/ysql/).
 
 ##### --enable_ysql
 
-Enables the YSQL API. Replaces the deprecated `--start_pgsql_proxy` flag.
+Enables the YSQL API.
 
 Default: `true`
 


### PR DESCRIPTION
We deprecated the `--start_pgsql_proxy` flag in v2.2, but never replaced it everywhere in the docs with `--enable_ysql`. This fixes that in all YugabyteDB versions (well, all the versions on the main docs site: 2.4 and up).

@netlify /preview/reference/configuration/yb-tserver/#example