### PR TITLE
[docs] Added docs for vertx pg client for Java

### DIFF
--- a/docs/content/preview/develop/build-apps/java/ycql-4.6.md
+++ b/docs/content/preview/develop/build-apps/java/ycql-4.6.md
@@ -25,6 +25,12 @@ type: docs
     </a>
   </li>
   <li >
+    <a href="../ysql-vertx-pg-client/" class="nav-link ">
+      <i class="icon-postgres" aria-hidden="true"></i>
+      YSQL - Vertx PG Client
+    </a>
+  </li>
+  <li >
     <a href="../ysql-jdbc-ssl/" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL - JDBC SSL/TLS

--- a/docs/content/preview/develop/build-apps/java/ycql.md
+++ b/docs/content/preview/develop/build-apps/java/ycql.md
@@ -25,6 +25,12 @@ type: docs
     </a>
   </li>
   <li >
+    <a href="../ysql-vertx-pg-client/" class="nav-link ">
+      <i class="icon-postgres" aria-hidden="true"></i>
+      YSQL - Vertx PG Client
+    </a>
+  </li>
+  <li >
     <a href="../ysql-jdbc-ssl/" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL - JDBC SSL/TLS

--- a/docs/content/preview/develop/build-apps/java/ysql-ebean.md
+++ b/docs/content/preview/develop/build-apps/java/ysql-ebean.md
@@ -26,6 +26,12 @@ type: docs
     </a>
   </li>
   <li >
+    <a href="../ysql-vertx-pg-client/" class="nav-link ">
+      <i class="icon-postgres" aria-hidden="true"></i>
+      YSQL - Vertx PG Client
+    </a>
+  </li>
+  <li >
     <a href="../ysql-jdbc-ssl/" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL - JDBC SSL/TLS

--- a/docs/content/preview/develop/build-apps/java/ysql-hibernate.md
+++ b/docs/content/preview/develop/build-apps/java/ysql-hibernate.md
@@ -26,6 +26,12 @@ type: docs
     </a>
   </li>
   <li >
+    <a href="../ysql-vertx-pg-client/" class="nav-link ">
+      <i class="icon-postgres" aria-hidden="true"></i>
+      YSQL - Vertx PG Client
+    </a>
+  </li>
+  <li >
     <a href="../ysql-jdbc-ssl/" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL - JDBC SSL/TLS

--- a/docs/content/preview/develop/build-apps/java/ysql-jdbc-ssl.md
+++ b/docs/content/preview/develop/build-apps/java/ysql-jdbc-ssl.md
@@ -25,6 +25,12 @@ type: docs
     </a>
   </li>
   <li >
+    <a href="../ysql-vertx-pg-client/" class="nav-link ">
+      <i class="icon-postgres" aria-hidden="true"></i>
+      YSQL - Vertx PG Client
+    </a>
+  </li>
+  <li >
     <a href="../ysql-jdbc-ssl/" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL - JDBC SSL/TLS

--- a/docs/content/preview/develop/build-apps/java/ysql-jdbc.md
+++ b/docs/content/preview/develop/build-apps/java/ysql-jdbc.md
@@ -25,6 +25,12 @@ type: docs
     </a>
   </li>
   <li >
+    <a href="../ysql-vertx-pg-client/" class="nav-link ">
+      <i class="icon-postgres" aria-hidden="true"></i>
+      YSQL - Vertx PG Client
+    </a>
+  </li>
+  <li >
     <a href="../ysql-jdbc-ssl/" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL - JDBC SSL/TLS

--- a/docs/content/preview/develop/build-apps/java/ysql-sdyb.md
+++ b/docs/content/preview/develop/build-apps/java/ysql-sdyb.md
@@ -26,6 +26,12 @@ type: docs
     </a>
   </li>
   <li >
+    <a href="../ysql-vertx-pg-client/" class="nav-link ">
+      <i class="icon-postgres" aria-hidden="true"></i>
+      YSQL - Vertx PG Client
+    </a>
+  </li>
+  <li >
     <a href="../ysql-jdbc-ssl/" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL - JDBC SSL/TLS

--- a/docs/content/preview/develop/build-apps/java/ysql-spring-data.md
+++ b/docs/content/preview/develop/build-apps/java/ysql-spring-data.md
@@ -25,6 +25,12 @@ type: docs
     </a>
   </li>
   <li >
+    <a href="../ysql-vertx-pg-client/" class="nav-link ">
+      <i class="icon-postgres" aria-hidden="true"></i>
+      YSQL - Vertx PG Client
+    </a>
+  </li>
+  <li >
     <a href="../ysql-jdbc-ssl/" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL - JDBC SSL/TLS

--- a/docs/content/preview/develop/build-apps/java/ysql-vertx-pg-client.md
+++ b/docs/content/preview/develop/build-apps/java/ysql-vertx-pg-client.md
@@ -141,7 +141,7 @@ This tutorial assumes that:
             PgConnectOptions options = new PgConnectOptions()
                 .setPort(5433)
                 .setHost("127.0.0.1")
-                .setDatabase("vertx_pg_test")
+                .setDatabase("yugabyte")
                 .setUser("yugabyte")
                 .setPassword("yugabyte");
 

--- a/docs/content/preview/develop/build-apps/java/ysql-vertx-pg-client.md
+++ b/docs/content/preview/develop/build-apps/java/ysql-vertx-pg-client.md
@@ -1,0 +1,214 @@
+---
+title: Build a Java application that uses YSQL
+headerTitle: Build a Java application
+linkTitle: Java
+description: Build a sample Java application with the Vertx PG Client and use the YSQL API to connect to and interact with YugabyteDB.
+menu:
+  preview:
+    parent: build-apps
+    name: Java
+    identifier: java-10
+    weight: 550
+type: page
+isTocNested: true
+showAsideToc: true
+---
+
+<ul class="nav nav-tabs-alt nav-tabs-yb">
+  <li >
+    <a href="../ysql-yb-jdbc/" class="nav-link">
+      <i class="icon-postgres" aria-hidden="true"></i>
+      YSQL - YB - JDBC
+    </a>
+  </li>
+  <li >
+    <a href="../ysql-jdbc/" class="nav-link">
+      <i class="icon-postgres" aria-hidden="true"></i>
+      YSQL - JDBC
+    </a>
+  </li>
+  <li >
+    <a href="../ysql-vertx-pg-client/" class="nav-link active">
+      <i class="icon-postgres" aria-hidden="true"></i>
+      YSQL - Vertx PG Client
+    </a>
+  </li>
+  <li >
+    <a href="../ysql-jdbc-ssl/" class="nav-link">
+      <i class="icon-postgres" aria-hidden="true"></i>
+      YSQL - JDBC SSL/TLS
+    </a>
+  </li>
+  <li >
+    <a href="../ysql-hibernate/" class="nav-link">
+      <i class="icon-postgres" aria-hidden="true"></i>
+      YSQL - Hibernate
+    </a>
+  </li>
+  <li >
+    <a href="../ysql-sdyb/" class="nav-link">
+      <i class="icon-postgres" aria-hidden="true"></i>
+      YSQL - Spring Data YugabyteDB
+    </a>
+  </li>
+  <li >
+    <a href="../ysql-spring-data/" class="nav-link">
+      <i class="icon-postgres" aria-hidden="true"></i>
+      YSQL - Spring Data JPA
+    </a>
+  </li>
+  <li>
+    <a href="../ysql-ebean/" class="nav-link">
+      <i class="icon-postgres" aria-hidden="true"></i>
+      YSQL - Ebean
+    </a>
+  </li>
+  <li>
+    <a href="../ycql/" class="nav-link">
+      <i class="icon-cassandra" aria-hidden="true"></i>
+      YCQL
+    </a>
+  </li>
+  <li>
+    <a href="../ycql-4.6/" class="nav-link">
+      <i class="icon-cassandra" aria-hidden="true"></i>
+      YCQL (4.6)
+    </a>
+  </li>
+</ul>
+
+[Vertx PG client](https://vertx.io/docs/vertx-pg-client/java/) is the client for PostgreSQL with the simple APIs for communicating with the Database. It is reactive and non-blocking client for handling the database connections with single threaded API.
+
+As this client is for PostgreSQL and YugabyteDB is wire compatible with PostgreSQL, it is also supported by YugabyteDB with one [limitation](#limitation).
+
+## Prerequisites
+
+This tutorial assumes that:
+
+- YugabyteDB is up and running. If you are new to YugabyteDB, you can download, install, and have YugabyteDB up and running within five minutes by following the steps in [Quick start](../../../../quick-start/).
+- Java Development Kit (JDK) 1.8, or later, is installed. 
+- [Apache Maven](https://maven.apache.org/index.html) 3.3 or later, is installed.
+
+## Create and configure the Java project
+
+1. Create a project called "MySample".
+
+    ```sh
+    $ mvn archetype:generate \
+        -DgroupId=com.yugabyte \
+        -DartifactId=vertx-pg-example \
+        -DarchetypeArtifactId=maven-archetype-quickstart \
+        -DinteractiveMode=false
+
+    $ cd vertx-pg-example
+    ```
+
+1. Add the following dependency for the vertx pg client within the `<dependencies>` element in the `pom.xml` file.
+
+    ```xml
+    <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-pg-client</artifactId>
+        <version>4.3.2</version>
+    </dependency>
+    ```
+
+1. Install the added dependency.
+
+    ```sh
+    $ mvn install
+    ```
+
+## Create the sample Java application
+
+1. Copy the following Java code to a new file named `src/main/java/com/yugabyte/vertxPgExample.java`:
+
+    ```java
+    package com.yugabyte;
+
+    import io.vertx.core.Promise;
+    import io.vertx.core.Vertx;
+    import io.vertx.pgclient.PgConnectOptions;
+    import io.vertx.pgclient.PgPool;
+    import io.vertx.sqlclient.PoolOptions;
+    import io.vertx.sqlclient.Tuple;
+    import io.vertx.sqlclient.Row;
+    import io.vertx.sqlclient.RowStream;
+
+    public class vertxPgExample {
+        public static void main(String[] args) {
+
+            PgConnectOptions options = new PgConnectOptions()
+                .setPort(5433)
+                .setHost("127.0.0.1")
+                .setDatabase("vertx_pg_test")
+                .setUser("yugabyte")
+                .setPassword("yugabyte");
+
+            Vertx vertx = Vertx.vertx();
+            // creating the PgPool with configuration as option and maxsize 10.
+            PgPool pool = PgPool.pool(vertx, options, new PoolOptions().setMaxSize(10));
+
+            //getting a connection from the pool and running the example on that
+            pool.getConnection().compose(connection -> {
+                Promise<Void> promise = Promise.promise();
+                // create a test table
+                connection.query("create table test(id int primary key, name text)").execute()
+                        .compose(v -> {
+                            // insert some test data
+                            return connection.query("insert into test values (1, 'Hello'), (2, 'World'), (3,'Example'), (4, 'Vertx'), (5, 'Yugabyte')").execute();
+                        })
+                        .compose(v -> {
+                            // prepare the query
+                            return connection.prepare("select * from test order by id");
+                        })
+                        .map(preparedStatement -> {
+                            // create a stream for the prepared statement
+                            return preparedStatement.createStream(50, Tuple.tuple());
+                        })
+                        .onComplete(ar -> {
+                            if (ar.succeeded()) {
+                                RowStream<Row> stream = ar.result();
+                                stream
+                                        .exceptionHandler(promise::fail)
+                                        .endHandler(promise::complete)
+                                        .handler(row -> System.out.println(row.toJson())); // Printing each row as JSON
+                            } else {
+                                promise.fail(ar.cause());
+                            }
+                        });
+                return promise.future().onComplete(v -> {
+                    // close the connection
+                    connection.close();
+                });
+            }).onComplete(ar -> {
+                if (ar.succeeded()) {
+                    System.out.println("Example ran successfully!");
+                } else {
+                    ar.cause().printStackTrace();
+                }
+            });
+
+        }
+    }
+    ```
+
+1. Run your new program.
+
+    ```sh
+    $ mvn -q package exec:java -DskipTests -Dexec.mainClass=com.yugabyte.vertxPgExample
+    ```
+
+    You should see the following as the output:
+
+    ```output
+    {"id":1,"name":"Hello"}
+    {"id":2,"name":"World"}
+    {"id":3,"name":"Example"}
+    {"id":4,"name":"Vertx"}
+    {"id":5,"name":"Yugabyte"}
+    Example ran successfully!
+    ```
+## Limitation
+
+[PubSub](https://vertx.io/docs/vertx-pg-client/java/#_pubsub) feature of Vertx PG client is currently not supported with YugabyteDB.

--- a/docs/content/preview/develop/build-apps/java/ysql-vertx-pg-client.md
+++ b/docs/content/preview/develop/build-apps/java/ysql-vertx-pg-client.md
@@ -211,4 +211,4 @@ This tutorial assumes that:
     ```
 ## Limitation
 
-[PubSub](https://vertx.io/docs/vertx-pg-client/java/#_pubsub) feature of Vertx PG client is currently not supported with YugabyteDB.
+[Pub/sub](https://vertx.io/docs/vertx-pg-client/java/#_pubsub) feature of Vertx PG client is currently not supported with YugabyteDB.

--- a/docs/content/preview/develop/build-apps/java/ysql-vertx-pg-client.md
+++ b/docs/content/preview/develop/build-apps/java/ysql-vertx-pg-client.md
@@ -103,7 +103,7 @@ This tutorial assumes that:
     $ cd vertx-pg-example
     ```
 
-1. Add the following dependency for the vertx pg client within the `<dependencies>` element in the `pom.xml` file.
+1. Add the following dependency for the Vertx PG Client within the `<dependencies>` element in the `pom.xml` file.
 
     ```xml
     <dependency>

--- a/docs/content/preview/develop/build-apps/java/ysql-vertx-pg-client.md
+++ b/docs/content/preview/develop/build-apps/java/ysql-vertx-pg-client.md
@@ -85,7 +85,7 @@ As this client is for PostgreSQL and YugabyteDB is wire compatible with PostgreS
 
 This tutorial assumes that:
 
-- YugabyteDB is up and running. If you are new to YugabyteDB, you can download, install, and have YugabyteDB up and running within five minutes by following the steps in [Quick start](../../../../quick-start/).
+- YugabyteDB up and running. Download and install YugabyteDB by following the steps in [Quick start](../../../../quick-start/).
 - Java Development Kit (JDK) 1.8, or later, is installed. 
 - [Apache Maven](https://maven.apache.org/index.html) 3.3 or later, is installed.
 

--- a/docs/content/preview/develop/build-apps/java/ysql-vertx-pg-client.md
+++ b/docs/content/preview/develop/build-apps/java/ysql-vertx-pg-client.md
@@ -79,7 +79,7 @@ showAsideToc: true
 
 [Vertx PG Client](https://vertx.io/docs/vertx-pg-client/java/) is the client for PostgreSQL with simple APIs to communicate with the database. It is a reactive and non-blocking client for handling the database connections with a single threaded API.
 
-As this client is for PostgreSQL and YugabyteDB is wire compatible with PostgreSQL, it is also supported by YugabyteDB with one [limitation](#limitation).
+Because Vertx is a PostgreSQL client and YugabyteDB is PostgreSQL compatible, it is supported by YugabyteDB with a [limitation](#limitation).
 
 ## Prerequisites
 
@@ -101,6 +101,14 @@ This tutorial assumes that:
         -DinteractiveMode=false
 
     $ cd vertx-pg-example
+    ```
+1. Add the following below the `<url>` element.
+
+    ```xml
+    <properties>
+      <maven.compiler.source>1.8</maven.compiler.source>
+      <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
     ```
 
 1. Add the following dependency for the Vertx PG Client within the `<dependencies>` element in the `pom.xml` file.
@@ -211,4 +219,5 @@ This tutorial assumes that:
     ```
 ## Limitation
 
-[Pub/sub](https://vertx.io/docs/vertx-pg-client/java/#_pubsub) feature of Vertx PG client is currently not supported with YugabyteDB.
+[PubSub](https://vertx.io/docs/vertx-pg-client/java/#_pubsub) feature of Vertx PG client is currently not supported with YugabyteDB. This limitation will be lifted when `LISTEN`/`NOTIFY` support is added to YugabyteDB. Tracking issue: [#1872](https://github.com/yugabyte/yugabyte-db/issues/1872).
+

--- a/docs/content/preview/develop/build-apps/java/ysql-vertx-pg-client.md
+++ b/docs/content/preview/develop/build-apps/java/ysql-vertx-pg-client.md
@@ -76,7 +76,7 @@ type: docs
 
 [Vertx PG Client](https://vertx.io/docs/vertx-pg-client/java/) is the client for PostgreSQL with simple APIs to communicate with the database. It is a reactive and non-blocking client for handling the database connections with a single threaded API.
 
-Because Vertx is a PostgreSQL client and YugabyteDB is PostgreSQL compatible, it is supported by YugabyteDB with a [limitation](#limitation).
+Since YugabyteDB is wire compatible with PostgreSQL, Vertx PG Client works with YugabyteDB as well.
 
 ## Prerequisites
 

--- a/docs/content/preview/develop/build-apps/java/ysql-vertx-pg-client.md
+++ b/docs/content/preview/develop/build-apps/java/ysql-vertx-pg-client.md
@@ -193,7 +193,7 @@ This tutorial assumes that:
     }
     ```
 
-1. Run your new program.
+1. Run the program.
 
     ```sh
     $ mvn -q package exec:java -DskipTests -Dexec.mainClass=com.yugabyte.vertxPgExample

--- a/docs/content/preview/develop/build-apps/java/ysql-vertx-pg-client.md
+++ b/docs/content/preview/develop/build-apps/java/ysql-vertx-pg-client.md
@@ -121,7 +121,7 @@ This tutorial assumes that:
 
 ## Create the sample Java application
 
-1. Copy the following Java code to a new file named `src/main/java/com/yugabyte/vertxPgExample.java`:
+1. Copy the following Java code to a new file `src/main/java/com/yugabyte/vertxPgExample.java`:
 
     ```java
     package com.yugabyte;

--- a/docs/content/preview/develop/build-apps/java/ysql-vertx-pg-client.md
+++ b/docs/content/preview/develop/build-apps/java/ysql-vertx-pg-client.md
@@ -77,7 +77,7 @@ showAsideToc: true
   </li>
 </ul>
 
-[Vertx PG client](https://vertx.io/docs/vertx-pg-client/java/) is the client for PostgreSQL with the simple APIs for communicating with the Database. It is reactive and non-blocking client for handling the database connections with single threaded API.
+[Vertx PG Client](https://vertx.io/docs/vertx-pg-client/java/) is the client for PostgreSQL with simple APIs to communicate with the database. It is a reactive and non-blocking client for handling the database connections with a single threaded API.
 
 As this client is for PostgreSQL and YugabyteDB is wire compatible with PostgreSQL, it is also supported by YugabyteDB with one [limitation](#limitation).
 

--- a/docs/content/preview/develop/build-apps/java/ysql-vertx-pg-client.md
+++ b/docs/content/preview/develop/build-apps/java/ysql-vertx-pg-client.md
@@ -1,17 +1,14 @@
 ---
 title: Build a Java application that uses YSQL
 headerTitle: Build a Java application
-linkTitle: Java
+linkTitle: More examples
 description: Build a sample Java application with the Vertx PG Client and use the YSQL API to connect to and interact with YugabyteDB.
 menu:
   preview:
-    parent: build-apps
-    name: Java
+    parent: cloud-java
     identifier: java-10
     weight: 550
-type: page
-isTocNested: true
-showAsideToc: true
+type: docs
 ---
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
@@ -85,13 +82,16 @@ Because Vertx is a PostgreSQL client and YugabyteDB is PostgreSQL compatible, it
 
 This tutorial assumes that:
 
-- YugabyteDB up and running. Download and install YugabyteDB by following the steps in [Quick start](../../../../quick-start/).
+- YugabyteDB up and running. Download and install the latest version of YugabyteDB by following the steps in [Quick start](../../../../quick-start/).
+{{< note title="Note" >}}
+The `executeBatch()` API of the Vertx PG Client is supported in the YugabyteDB version - `2.15.2.0-b0` onwards. 
+{{< /note >}}
 - Java Development Kit (JDK) 1.8, or later, is installed. 
 - [Apache Maven](https://maven.apache.org/index.html) 3.3 or later, is installed.
 
 ## Create and configure the Java project
 
-1. Create a project called "MySample".
+1. Create a project called "vertx-pg-example".
 
     ```sh
     $ mvn archetype:generate \
@@ -102,7 +102,7 @@ This tutorial assumes that:
 
     $ cd vertx-pg-example
     ```
-1. Add the following below the `<url>` element.
+1. Add the following properties in the `pom.xml` file within the `<project>` element.
 
     ```xml
     <properties>
@@ -219,5 +219,5 @@ This tutorial assumes that:
     ```
 ## Limitation
 
-[PubSub](https://vertx.io/docs/vertx-pg-client/java/#_pubsub) feature of Vertx PG client is currently not supported with YugabyteDB. This limitation will be lifted when `LISTEN`/`NOTIFY` support is added to YugabyteDB. Tracking issue: [#1872](https://github.com/yugabyte/yugabyte-db/issues/1872).
+[Pub/sub](https://vertx.io/docs/vertx-pg-client/java/#_pubsub) feature of Vertx PG client is currently not supported with YugabyteDB. This limitation will go away when `LISTEN`/`NOTIFY` support is added to YugabyteDB. See [GitHub issue](https://github.com/yugabyte/yugabyte-db/issues/1872).
 

--- a/docs/content/preview/develop/build-apps/java/ysql-yb-jdbc.md
+++ b/docs/content/preview/develop/build-apps/java/ysql-yb-jdbc.md
@@ -31,6 +31,12 @@ type: docs
     </a>
   </li>
   <li >
+    <a href="../ysql-vertx-pg-client/" class="nav-link ">
+      <i class="icon-postgres" aria-hidden="true"></i>
+      YSQL - Vertx PG Client
+    </a>
+  </li>
+  <li >
     <a href="../ysql-jdbc-ssl/" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL - JDBC SSL/TLS

--- a/docs/content/preview/reference/drivers/ysql-client-drivers.md
+++ b/docs/content/preview/reference/drivers/ysql-client-drivers.md
@@ -152,7 +152,7 @@ To get the latest versions for projects using [Apache Maven](https://maven.apach
 
 ### Vertx PG Client 
 
-[Vertx PG client](https://vertx.io/docs/vertx-pg-client/java/) is the client for PostgreSQL with the simple APIs for communicating with the Database. It is reactive and non-blocking client for handling the database connections with single threaded API.
+[Vertx PG Client](https://vertx.io/docs/vertx-pg-client/java/) is the client for PostgreSQL with simple APIs to communicate with the database. It is a reactive and non-blocking client for handling the database connections with a single threaded API.
 
 For a tutorial on building a sample Java application with the Vertx PG Client, see [Build a Java application](../../../develop/build-apps/java/ysql-vertx-pg-client/).
 

--- a/docs/content/preview/reference/drivers/ysql-client-drivers.md
+++ b/docs/content/preview/reference/drivers/ysql-client-drivers.md
@@ -150,6 +150,14 @@ To download binary JAR files, go to [PostgreSQL JDBC driver – Downloads](https
 
 To get the latest versions for projects using [Apache Maven](https://maven.apache.org), see [Maven Central Repository Search](https://search.maven.org/artifact/org.postgresql/postgresql/42.2.14.jre7/jar).
 
+### Vertx PG Client 
+
+[Vertx PG client](https://vertx.io/docs/vertx-pg-client/java/) is the client for PostgreSQL with the simple APIs for communicating with the Database. It is reactive and non-blocking client for handling the database connections with single threaded API.
+
+For a tutorial on building a sample Java application with the Vertx PG Client, see [Build a Java application](../../../develop/build-apps/java/ysql-vertx-pg-client/).
+
+To get the latest versions for projects using [Apache Maven](https://maven.apache.org), see [Maven Central Repository of Vertx PG Client](https://mvnrepository.com/artifact/io.vertx/vertx-pg-client).
+
 ## Node.JS
 
 ### node-postgres


### PR DESCRIPTION
This PR adds the docs for Vertx PG Client in [build-app](https://docs.yugabyte.com/preview/develop/build-apps/java/ysql-yb-jdbc/) for Java and mentions as supported client drivers in [reference](https://docs.yugabyte.com/preview/reference/drivers/ysql-client-drivers/).