### PR TITLE
[docs] [Anywhere] Added information about converting certs when using JDBC driver with YugabyteDB Anywhere

### DIFF
--- a/docs/content/preview/yugabyte-platform/security/enable-encryption-in-transit.md
+++ b/docs/content/preview/yugabyte-platform/security/enable-encryption-in-transit.md
@@ -137,7 +137,7 @@ In addition, verify the following:
 
    ![add-cert](/images/yp/encryption-in-transit/add-cert.png)<br><br>
 
-1. Upload the custom CA root certificate as the root certificate. 
+1. Upload the custom CA root certificate as the root certificate.
 
    If you do not have the root certificate but instead have an intermediate certificate, you need to create a bundle by executing the `cat intermediate-ca.crt root-ca.crt > bundle.crt` command, and then using this bundle as the root certificate.
 
@@ -406,6 +406,8 @@ If you created your universe with the Client-to-Node TLS option enabled, then yo
 
 To use TLS from a different client, consult the client-specific documentation. For example, if you are using a PostgreSQL JDBC driver to connect to YugabyteDB, see [Configuring the client](https://jdbc.postgresql.org/documentation/head/ssl-client.html) for more details.
 
+If you are using PostgreSQL/YugabyteDB JDBC driver with SSL, you need to convert the certificates to DER format. To do this, you need to perform only steps 6 and 7 from [Set up SSL certificates for Java applications](../../../develop/build-apps/java/ysql-jdbc-ssl/#set-up-ssl-certificates-for-java-applications) section after downloading the certificates.
+
 ### Connect to a YCQL endpoint with TLS
 
 If you created your universe with the Client-to-Node TLS option enabled, then you must download client certificates to your client computer to establish connection to your database, as follows:
@@ -482,7 +484,7 @@ To enforce the minimum TLS version of 1.2, you need to specify all available sub
 ssl_protocols = tls12,tls13
 ```
 
-In addition, since the `ssl_protocols` setting does not propagate to PostgreSQL, it is recommended that you specify the minimum TLS version ( `ssl_min_protocol_version` ) for PostgreSQL by setting the following T-Server gflag:
+In addition, as the `ssl_protocols` setting does not propagate to PostgreSQL, it is recommended that you specify the minimum TLS version ( `ssl_min_protocol_version` ) for PostgreSQL by setting the following T-Server gflag:
 
 ```shell
 --ysql_pg_conf_csv="ssl_min_protocol_version=TLSv1.2"

--- a/docs/content/stable/yugabyte-platform/security/enable-encryption-in-transit.md
+++ b/docs/content/stable/yugabyte-platform/security/enable-encryption-in-transit.md
@@ -484,7 +484,7 @@ To enforce the minimum TLS version of 1.2, you need to specify all available sub
 ssl_protocols = tls12,tls13
 ```
 
-In addition, since the `ssl_protocols` setting does not propagate to PostgreSQL, it is recommended that you specify the minimum TLS version ( `ssl_min_protocol_version` ) for PostgreSQL by setting the following T-Server gflag:
+In addition, as the `ssl_protocols` setting does not propagate to PostgreSQL, it is recommended that you specify the minimum TLS version ( `ssl_min_protocol_version` ) for PostgreSQL by setting the following T-Server gflag:
 
 ```shell
 --ysql_pg_conf_csv="ssl_min_protocol_version=TLSv1.2"

--- a/docs/content/stable/yugabyte-platform/security/enable-encryption-in-transit.md
+++ b/docs/content/stable/yugabyte-platform/security/enable-encryption-in-transit.md
@@ -406,6 +406,8 @@ If you created your universe with the Client-to-Node TLS option enabled, then yo
 
 To use TLS from a different client, consult the client-specific documentation. For example, if you are using a PostgreSQL JDBC driver to connect to YugabyteDB, see [Configuring the client](https://jdbc.postgresql.org/documentation/head/ssl-client.html) for more details.
 
+If you are using PostgreSQL/YugabyteDB JDBC driver with SSL, you need to convert the certificates to DER format. To do this, you need to perform only steps 6 and 7 from [Set up SSL certificates for Java applications](/preview/develop/build-apps/java/ysql-jdbc-ssl/#set-up-ssl-certificates-for-java-applications) section after downloading the certificates.
+
 ### Connect to a YCQL endpoint with TLS
 
 If you created your universe with the Client-to-Node TLS option enabled, then you must download client certificates to your client computer to establish connection to your database, as follows:


### PR DESCRIPTION
Notes from slack thread -
so ssl keys can be downloaded from portal directly, but the only documentation we have is this page
https://docs.yugabyte.com/preview/develop/build-apps/java/ysql-jdbc-ssl/#set-up-ssl-certificates-for-java-applications
but it’s not about yugaware case.
basically we need only these lines to convert keys:
```
openssl x509 -outform der -in /home/centos/nm/puppy-food-arm-1.crt -out /home/centos/nm/puppy-food-arm-1.crt.der

openssl pkcs8 -topk8 -inform PEM -in /home/centos/nm/puppy-food-arm-1.key -outform DER -nocrypt -out /home/centos/nm/puppy-food-arm-1.key.pk8
```
@qvad , here's the deploy preview. Please take a look if this note is sufficient. https://deploy-preview-13607--infallible-bardeen-164bc9.netlify.app/preview/yugabyte-platform/security/enable-encryption-in-transit/#connect-to-a-ysql-endpoint-with-tls
@netlify /preview/yugabyte-platform/security/enable-encryption-in-transit/