### PR TITLE
[PLAT-4688] Raise default nginx timeout for Platform API requests

### DIFF
--- a/managed/devops/replicated.yml
+++ b/managed/devops/replicated.yml
@@ -489,6 +489,11 @@ components:
                   proxy_set_header X-Forwarded-Proto $scheme;
                   proxy_set_header Host $host;
 
+                  #Changing default timeout values
+
+                  proxy_read_timeout 600;
+                  proxy_send_timeout 600;
+
                 location / {
                   proxy_pass http://{{repl HostPrivateIpAddress "app" "yugabyte/yugaware" }}:{{repl ContainerExposedPort "app" "yugabyte/yugaware" "9000" }};
                 }


### PR DESCRIPTION
Summary:
Raise default nginx timeout (read, connect, send) for Platform API requests
Applied changes to replicated.yml

Test Plan: Doesn't include tests

Reviewers: sanketh, arnav, sneelakantan

Reviewed By: sneelakantan

Subscribers: jenkins-bot, yugaware

Differential Revision: https://phabricator.dev.yugabyte.com/D18549