### PR TITLE
[Docs] Removed references to ROWS_PER_TRANSACTION

### DIFF
--- a/docs/content/preview/api/ysql/the-sql-language/statements/cmd_copy.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/cmd_copy.md
@@ -136,23 +136,10 @@ In the following example, the data exported in the previous examples are importe
 yugabyte=# COPY users FROM '/home/yuga/Desktop/users.txt.sql' DELIMITER ',' CSV HEADER;
 ```
 
-
 ### Performance tips for large tables
 
-When importing a very large table, Yugabyte recommends using many smaller transactions (rather than one large transaction).
-This can be achieved natively by using the `ROWS_PER_TRANSACTION` option.
+The following copy options may help to speed up copying, or allow for faster recovery from a partial state:
 
-```plpgsql
-yugabyte=# COPY large_table FROM '/home/yuga/Desktop/large_table.csv'
-               WITH (FORMAT CSV, HEADER, ROWS_PER_TRANSACTION 1000);
-```
-
-
-- If the table does not exist, errors are raised.
-- `COPY TO` can only be used with regular tables.
-- `COPY FROM` can be used with tables, foreign tables, and views.
-
-Additionally, the following copy options may help to speed up copying, or allow for faster recovery from a partial state:
 * `DISABLE_FK_CHECK` skips the foreign key check when copying new rows to the table.
 * `REPLACE` replaces the existing row in the table if the new row's primary/unique key conflicts with that of the existing row.
 * `SKIP n` skips the first `n` rows of the file. `n` must be a nonnegative integer.

--- a/docs/content/preview/migrate/manual-import/import-data.md
+++ b/docs/content/preview/migrate/manual-import/import-data.md
@@ -24,12 +24,12 @@ To import data that was previously exported into CSV files, use the COPY FROM co
 ```sql
 COPY <table_name>
     FROM '<table_name>.csv'
-    WITH (FORMAT CSV DELIMITER ',', HEADER, ROWS_PER_TRANSACTION 1000, DISABLE_FK_CHECK);
+    WITH (FORMAT CSV DELIMITER ',', HEADER, DISABLE_FK_CHECK);
 ```
 
-In the command above, the `ROWS_PER_TRANSACTION` parameter splits the load into smaller transactions (1000 rows each in this example), instead of running a single transaction spawning across all the data in the file. Additionally, the `DISABLE_FK_CHECK` parameter skips the foreign key checks for the duration of the import process.
+In the command above, the `DISABLE_FK_CHECK` parameter skips the foreign key checks for the duration of the import process. Providing `DISABLE_FK_CHECK` parameter is recommended for the initial import of the data, especially for large tables, because it reduces the total time required to import the data.
 
-Both `ROWS_PER_TRANSACTION` and `DISABLE_FK_CHECK` parameters are recommended for the initial import of the data, especially for large tables, because they significantly reduce the total time required to import the data. You can import multiple files in a single COPY command to further speed up the process. Following is a sample example:
+To further speed up the process, you can import multiple files in a single COPY command. Following is a sample example:
 
 ```sql
 yugabyte=# \! ls t*.txt
@@ -67,7 +67,7 @@ yugabyte=# SELECT * FROM t;
 ```
 
 ```sql
-yugabyte=# COPY t FROM PROGRAM 'cat /home/yugabyte/t*.txt' WITH (FORMAT CSV, DELIMITER ',', ROWS_PER_TRANSACTION 1000, DISABLE_FK_CHECK);
+yugabyte=# COPY t FROM PROGRAM 'cat /home/yugabyte/t*.txt' WITH (FORMAT CSV, DELIMITER ',', DISABLE_FK_CHECK);
 COPY 3
 ```
 
@@ -95,7 +95,7 @@ For example, to skip the first 5000 rows in a file, run the command as follows:
 ```sql
 COPY <table_name>
     FROM '<table_name>.csv'
-    WITH (FORMAT CSV DELIMITER ',', HEADER, ROWS_PER_TRANSACTION 1000, DISABLE_FK_CHECK, SKIP 5000);
+    WITH (FORMAT CSV DELIMITER ',', HEADER, DISABLE_FK_CHECK, SKIP 5000);
 ```
 
 ## Import data from SQL script

--- a/docs/content/stable/api/ysql/the-sql-language/statements/cmd_copy.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/cmd_copy.md
@@ -134,23 +134,10 @@ In the following example, the data exported in the previous examples are importe
 yugabyte=# COPY users FROM '/home/yuga/Desktop/users.txt.sql' DELIMITER ',' CSV HEADER;
 ```
 
-
 ### Performance tips for large tables
 
-When importing a very large table, Yugabyte recommends using many smaller transactions (rather than one large transaction).
-This can be achieved natively by using the `ROWS_PER_TRANSACTION` option.
+The following copy options may help to speed up copying, or allow for faster recovery from a partial state:
 
-```plpgsql
-yugabyte=# COPY large_table FROM '/home/yuga/Desktop/large_table.csv'
-               WITH (FORMAT CSV, HEADER, ROWS_PER_TRANSACTION 1000);
-```
-
-
-- If the table does not exist, errors are raised.
-- `COPY TO` can only be used with regular tables.
-- `COPY FROM` can be used with tables, foreign tables, and views.
-
-Additionally, the following copy options may help to speed up copying, or allow for faster recovery from a partial state:
 * `DISABLE_FK_CHECK` skips the foreign key check when copying new rows to the table.
 * `REPLACE` replaces the existing row in the table if the new row's primary/unique key conflicts with that of the existing row.
 * `SKIP n` skips the first `n` rows of the file. `n` must be a nonnegative integer.

--- a/docs/content/stable/migrate/manual-import/import-data.md
+++ b/docs/content/stable/migrate/manual-import/import-data.md
@@ -22,12 +22,12 @@ To import data that was previously exported into CSV files, use the COPY FROM co
 ```sql
 COPY <table_name>
     FROM '<table_name>.csv'
-    WITH (FORMAT CSV DELIMITER ',', HEADER, ROWS_PER_TRANSACTION 1000, DISABLE_FK_CHECK);
+    WITH (FORMAT CSV DELIMITER ',', HEADER, DISABLE_FK_CHECK);
 ```
 
-In the command above, the `ROWS_PER_TRANSACTION` parameter splits the load into smaller transactions (1000 rows each in this example), instead of running a single transaction spawning across all the data in the file. Additionally, the `DISABLE_FK_CHECK` parameter skips the foreign key checks for the duration of the import process.
+In the command above, the `DISABLE_FK_CHECK` parameter skips the foreign key checks for the duration of the import process. Providing `DISABLE_FK_CHECK` parameter is recommended for the initial import of the data, especially for large tables, because it reduces the total time required to import the data.
 
-Both `ROWS_PER_TRANSACTION` and `DISABLE_FK_CHECK` parameters are recommended for the initial import of the data, especially for large tables, because they significantly reduce the total time required to import the data. You can import multiple files in a single COPY command to further speed up the process. Following is a sample example:
+To further speed up the process, you can import multiple files in a single COPY command. Following is a sample example:
 
 ```sql
 yugabyte=# \! ls t*.txt
@@ -65,7 +65,7 @@ yugabyte=# SELECT * FROM t;
 ```
 
 ```sql
-yugabyte=# COPY t FROM PROGRAM 'cat /home/yugabyte/t*.txt' WITH (FORMAT CSV, DELIMITER ',', ROWS_PER_TRANSACTION 1000, DISABLE_FK_CHECK);
+yugabyte=# COPY t FROM PROGRAM 'cat /home/yugabyte/t*.txt' WITH (FORMAT CSV, DELIMITER ',', DISABLE_FK_CHECK);
 COPY 3
 ```
 
@@ -93,7 +93,7 @@ For example, to skip the first 5000 rows in a file, run the command as follows:
 ```sql
 COPY <table_name>
     FROM '<table_name>.csv'
-    WITH (FORMAT CSV DELIMITER ',', HEADER, ROWS_PER_TRANSACTION 1000, DISABLE_FK_CHECK, SKIP 5000);
+    WITH (FORMAT CSV DELIMITER ',', HEADER, DISABLE_FK_CHECK, SKIP 5000);
 ```
 
 ## Import data from SQL script


### PR DESCRIPTION
The default value for the ROWS_PER_TRANSACTION parameter is currently set to 10000, which is sufficient for most cases. Therefore, there is no reason to mention it in examples for COPY FROM command.

@netlify /preview/migrate/manual-import/import-data/