### PR TITLE
[docs] fix the yb-version shortcode

### DIFF
--- a/docs/content/preview/yugabyte-platform/install-yugabyte-platform/install-software/airgapped.md
+++ b/docs/content/preview/yugabyte-platform/install-yugabyte-platform/install-software/airgapped.md
@@ -65,7 +65,7 @@ On a computer connected to the Internet, perform the following steps:
 - Download the `yugaware` binary and change the following number, as required:
 
   ```sh
-  wget https://downloads.yugabyte.com/releases/{{< yb-version version="preview">}}/yugaware-{{< yb-version version="preview" format="build">}}-linux-x86_64.airgap
+  wget https://downloads.yugabyte.com/releases/{{<yb-version version="preview">}}/yugaware-{{<yb-version version="preview" format="build">}}-linux-x86_64.airgap
   ```
 
 - Switch to the following directory:

--- a/docs/content/stable/yugabyte-platform/install-yugabyte-platform/install-software/airgapped.md
+++ b/docs/content/stable/yugabyte-platform/install-yugabyte-platform/install-software/airgapped.md
@@ -65,7 +65,7 @@ On a computer connected to the Internet, perform the following steps:
 - Download the `yugaware` binary and change the following number, as required:
 
   ```sh
-  wget https://downloads.yugabyte.com/releases/{{< yb-version version="stable">}}/yugaware-{{< yb-version version="stable" format="build">}}-linux-x86_64.airgap
+  wget https://downloads.yugabyte.com/releases/{{<yb-version version="stable">}}/yugaware-{{<yb-version version="stable" format="build">}}-linux-x86_64.airgap
   ```
 
 - Switch to the following directory:

--- a/docs/content/v2.12/quick-start/_index.md
+++ b/docs/content/v2.12/quick-start/_index.md
@@ -168,13 +168,13 @@ type: docs
 1. Download the YugabyteDB `tar.gz` file using the following `wget` command.
 
     ```sh
-    $ wget https://downloads.yugabyte.com/releases/{{< yb-version version="stable">}}/yugabyte-{{< yb-version version="stable" format="build">}}-darwin-x86_64.tar.gz
+    $ wget https://downloads.yugabyte.com/releases/{{< yb-version version="v2.12">}}/yugabyte-{{< yb-version version="v2.12" format="build">}}-darwin-x86_64.tar.gz
     ```
 
 1. Extract the package and then change directories to the YugabyteDB home.
 
     ```sh
-    $ tar xvfz yugabyte-{{< yb-version version="stable" format="build">}}-darwin-x86_64.tar.gz && cd yugabyte-{{< yb-version version="stable">}}/
+    $ tar xvfz yugabyte-{{< yb-version version="v2.12" format="build">}}-darwin-x86_64.tar.gz && cd yugabyte-{{< yb-version version="v2.12">}}/
     ```
 
 ## Create a local cluster

--- a/docs/content/v2.12/quick-start/_index.md
+++ b/docs/content/v2.12/quick-start/_index.md
@@ -168,13 +168,13 @@ type: docs
 1. Download the YugabyteDB `tar.gz` file using the following `wget` command.
 
     ```sh
-    $ wget https://downloads.yugabyte.com/releases/{{< yb-version version="v2.12">}}/yugabyte-{{< yb-version version="v2.12" format="build">}}-darwin-x86_64.tar.gz
+    $ wget https://downloads.yugabyte.com/releases/{{<yb-version version="v2.12">}}/yugabyte-{{<yb-version version="v2.12" format="build">}}-darwin-x86_64.tar.gz
     ```
 
 1. Extract the package and then change directories to the YugabyteDB home.
 
     ```sh
-    $ tar xvfz yugabyte-{{< yb-version version="v2.12" format="build">}}-darwin-x86_64.tar.gz && cd yugabyte-{{< yb-version version="v2.12">}}/
+    $ tar xvfz yugabyte-{{<yb-version version="v2.12" format="build">}}-darwin-x86_64.tar.gz && cd yugabyte-{{<yb-version version="v2.12">}}/
     ```
 
 ## Create a local cluster

--- a/docs/content/v2.12/quick-start/docker.md
+++ b/docs/content/v2.12/quick-start/docker.md
@@ -77,7 +77,7 @@ You must have the Docker runtime installed on your localhost. Follow the links b
 Pull the YugabyteDB container.
 
 ```sh
-$ docker pull yugabytedb/yugabyte:{{< yb-version version="v2.12" format="build">}}
+$ docker pull yugabytedb/yugabyte:{{<yb-version version="v2.12" format="build">}}
 ```
 
 ## Create a local cluster

--- a/docs/content/v2.12/quick-start/docker.md
+++ b/docs/content/v2.12/quick-start/docker.md
@@ -77,7 +77,7 @@ You must have the Docker runtime installed on your localhost. Follow the links b
 Pull the YugabyteDB container.
 
 ```sh
-$ docker pull yugabytedb/yugabyte:{{< yb-version version="stable" format="build">}}
+$ docker pull yugabytedb/yugabyte:{{< yb-version version="v2.12" format="build">}}
 ```
 
 ## Create a local cluster

--- a/docs/content/v2.12/quick-start/linux.md
+++ b/docs/content/v2.12/quick-start/linux.md
@@ -100,27 +100,27 @@ Starting from Ubuntu 20.04, `python` isn't available anymore. An easy fix is to 
 1. Download the YugabyteDB package using the following `wget` command.
 
     ```sh
-    $ wget https://downloads.yugabyte.com/releases/{{< yb-version version="v2.12">}}/yugabyte-{{< yb-version version="v2.12" format="build">}}-linux-x86_64.tar.gz
+    $ wget https://downloads.yugabyte.com/releases/{{<yb-version version="v2.12">}}/yugabyte-{{<yb-version version="v2.12" format="build">}}-linux-x86_64.tar.gz
     ```
 
     \
     OR:
 
     ```sh
-    $ wget https://downloads.yugabyte.com/releases/{{< yb-version version="v2.12">}}/yugabyte-{{< yb-version version="v2.12" format="build">}}-el8-aarch64.tar.gz
+    $ wget https://downloads.yugabyte.com/releases/{{<yb-version version="v2.12">}}/yugabyte-{{<yb-version version="v2.12" format="build">}}-el8-aarch64.tar.gz
     ```
 
 1. Extract the package and then change directories to the YugabyteDB home.
 
     ```sh
-    $ tar xvfz yugabyte-{{< yb-version version="v2.12" format="build">}}-linux-x86_64.tar.gz && cd yugabyte-{{< yb-version version="v2.12">}}/
+    $ tar xvfz yugabyte-{{<yb-version version="v2.12" format="build">}}-linux-x86_64.tar.gz && cd yugabyte-{{<yb-version version="v2.12">}}/
     ```
 
     \
     OR:
 
     ```sh
-    $ tar xvfz yugabyte-{{< yb-version version="v2.12" format="build">}}-el8-aarch64.tar.gz && cd yugabyte-{{< yb-version version="v2.12">}}/
+    $ tar xvfz yugabyte-{{<yb-version version="v2.12" format="build">}}-el8-aarch64.tar.gz && cd yugabyte-{{<yb-version version="v2.12">}}/
     ```
 
 ### Configure YugabyteDB

--- a/docs/content/v2.12/quick-start/linux.md
+++ b/docs/content/v2.12/quick-start/linux.md
@@ -100,27 +100,27 @@ Starting from Ubuntu 20.04, `python` isn't available anymore. An easy fix is to 
 1. Download the YugabyteDB package using the following `wget` command.
 
     ```sh
-    $ wget https://downloads.yugabyte.com/releases/{{< yb-version version="stable">}}/yugabyte-{{< yb-version version="stable" format="build">}}-linux-x86_64.tar.gz
+    $ wget https://downloads.yugabyte.com/releases/{{< yb-version version="v2.12">}}/yugabyte-{{< yb-version version="v2.12" format="build">}}-linux-x86_64.tar.gz
     ```
 
     \
     OR:
 
     ```sh
-    $ wget https://downloads.yugabyte.com/releases/{{< yb-version version="stable">}}/yugabyte-{{< yb-version version="stable" format="build">}}-el8-aarch64.tar.gz
+    $ wget https://downloads.yugabyte.com/releases/{{< yb-version version="v2.12">}}/yugabyte-{{< yb-version version="v2.12" format="build">}}-el8-aarch64.tar.gz
     ```
 
 1. Extract the package and then change directories to the YugabyteDB home.
 
     ```sh
-    $ tar xvfz yugabyte-{{< yb-version version="stable" format="build">}}-linux-x86_64.tar.gz && cd yugabyte-{{< yb-version version="stable">}}/
+    $ tar xvfz yugabyte-{{< yb-version version="v2.12" format="build">}}-linux-x86_64.tar.gz && cd yugabyte-{{< yb-version version="v2.12">}}/
     ```
 
     \
     OR:
 
     ```sh
-    $ tar xvfz yugabyte-{{< yb-version version="stable" format="build">}}-el8-aarch64.tar.gz && cd yugabyte-{{< yb-version version="stable">}}/
+    $ tar xvfz yugabyte-{{< yb-version version="v2.12" format="build">}}-el8-aarch64.tar.gz && cd yugabyte-{{< yb-version version="v2.12">}}/
     ```
 
 ### Configure YugabyteDB

--- a/docs/content/v2.12/yugabyte-platform/install-yugabyte-platform/install-software/airgapped.md
+++ b/docs/content/v2.12/yugabyte-platform/install-yugabyte-platform/install-software/airgapped.md
@@ -65,7 +65,7 @@ $ wget --trust-server-names https://get.replicated.com/airgap
 Download the `yugaware` binary and change the following number, as required:
 
 ```sh
-$ wget https://downloads.yugabyte.com/releases/{{< yb-version version="stable">}}/yugaware-{{< yb-version version="stable" format="build">}}-linux-x86_64.airgap
+$ wget https://downloads.yugabyte.com/releases/{{<yb-version version="v2.12">}}/yugaware-{{<yb-version version="v2.12" format="build">}}-linux-x86_64.airgap
 ```
 
 Switch to the following directory:

--- a/docs/content/v2.6/yugabyte-platform/install-yugabyte-platform/install-software/airgapped.md
+++ b/docs/content/v2.6/yugabyte-platform/install-yugabyte-platform/install-software/airgapped.md
@@ -65,7 +65,7 @@ $ wget --trust-server-names https://get.replicated.com/airgap
 Download the `yugaware` binary and change the following number, as required:
 
 ```sh
-$ wget https://downloads.yugabyte.com/releases/2.6.18.0/yugabyte-2.6.18.0-b3-linux-x86_64.airgap
+$ wget https://downloads.yugabyte.com/releases/{{<yb-version version="v2.6">}}/yugaware-{{<yb-version version="v2.6" format="build">}}-linux-x86_64.airgap
 ```
 
 Switch to the following directory:

--- a/docs/layouts/shortcodes/yb-version.html
+++ b/docs/layouts/shortcodes/yb-version.html
@@ -52,7 +52,7 @@ Formats:
     {{- end -}}
 
   {{- else -}}
-    {{- if eq .name $version -}}
+    {{- if eq $version .series -}}
       {{- if eq $format "build" -}}
         {{ .appVersion }}
       {{- else if eq $format "short" -}}
@@ -63,7 +63,7 @@ Formats:
         {{ .display }}
       {{- else -}}
         {{ .version }}
-      {{ end }}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 


### PR DESCRIPTION
The shortcode logic wasn't quite correct for numbered versions. This fixes that, and updates a few incorrect invocations while we're at it.

@netlify /v2.8/yugabyte-platform/install-yugabyte-platform/install-software/airgapped/#install-replicated