### PR TITLE
Explain `ROWS_PER_TRANSACTION` is 20K by default and show an example …

### DIFF
--- a/docs/content/preview/api/ysql/the-sql-language/statements/cmd_copy.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/cmd_copy.md
@@ -143,3 +143,11 @@ The following copy options may help to speed up copying, or allow for faster rec
 * `DISABLE_FK_CHECK` skips the foreign key check when copying new rows to the table.
 * `REPLACE` replaces the existing row in the table if the new row's primary/unique key conflicts with that of the existing row.
 * `SKIP n` skips the first `n` rows of the file. `n` must be a nonnegative integer.
+* `ROWS_PER_TRANSACTION n` split the copy process into many smaller transactions (rather than one large transaction) (default 20000). 
+
+Example using the `users` table as previously in the doc:
+
+```plpgsql
+yugabyte=# COPY users FROM '/home/yuga/Desktop/users.txt.sql' WITH (FORMAT CSV,
+HEADER, DELIMITER ',', ROWS_PER_TRANSACTION 20000, DISABLE_FK_CHECK, REPLACE, SKIP 1);
+```


### PR DESCRIPTION
…using `DISABLE_FK_CHECK`, `REPLACE`, `SKIP n`, `ROWS_PER_TRANSACTION n`

Fixes #13674