### PR TITLE
Fix formatting in a `CREATE TABLE` example, fix formatting in `ENUM` data type examples

### DIFF
--- a/docs/content/preview/explore/ysql-language-features/data-manipulation.md
+++ b/docs/content/preview/explore/ysql-language-features/data-manipulation.md
@@ -285,7 +285,9 @@ DELETE FROM employees WHERE department = 'Sales' RETURNING *;
 
 Using a special kind of database object called a sequence, you can generate unique identifiers by auto-incrementing the numeric identifier of each preceding row. In most cases, you would use sequences to auto-generate primary keys.
 
+```sql
 CREATE TABLE employees2 (employee_no serial, name text, department text);
+```
 
 Typically, you add sequences using the `serial` pseudotype that creates a new sequence object and sets the default value for the column to the next value produced by the sequence.
 

--- a/docs/content/preview/explore/ysql-language-features/data-types.md
+++ b/docs/content/preview/explore/ysql-language-features/data-types.md
@@ -307,7 +307,7 @@ The output should be as follows:
  e_contact_method | Phone
 ```
 
-### 2. Create a table with an ENUM column
+### 3. Create a table with an ENUM column
 
 ```sql
 CREATE TABLE contact_method_info (
@@ -317,18 +317,18 @@ CREATE TABLE contact_method_info (
 );
 ```
 
-### 3. Insert a row with ENUM
+### 4. Insert a row with ENUM
 
 The `ENUM` should have a valid value, as follows:
 
 ```sql
-INSERT INTO contact_method_info VALUES ('Jeff', 'Email', 'jeff@mail.com')
+INSERT INTO contact_method_info VALUES ('Jeff', 'Email', 'jeff@mail.com');
 ```
 
 Execute the following to verify:
 
 ```sql
-yugabyte=# select * from contact_method_info;
+select * from contact_method_info;
 ```
 
 ```output
@@ -341,7 +341,7 @@ yugabyte=# select * from contact_method_info;
 Inserting an invalid `ENUM` value would fail, as shown in the following example:
 
 ```sql
-yugabyte=# INSERT INTO contact_method_info VALUES ('Jeff', 'Fax', '4563456');
+INSERT INTO contact_method_info VALUES ('Jeff', 'Fax', '4563456');
 ```
 
 You should see the following error (which is compatible with that of PostgreSQL):

--- a/docs/content/stable/explore/ysql-language-features/data-manipulation.md
+++ b/docs/content/stable/explore/ysql-language-features/data-manipulation.md
@@ -284,7 +284,9 @@ DELETE FROM employees WHERE department = 'Sales' RETURNING *;
 
 Using a special kind of database object called sequence, you can generate unique identifiers by auto-incrementing the numeric identifier of each preceding row. In most cases, you would use sequences to auto-generate primary keys.
 
+```sql
 CREATE TABLE employees2 (employee_no serial, name text, department text);
+```
 
 Typically, you add sequences using the `serial` pseudotype that creates a new sequence object and sets the default value for the column to the next value produced by the sequence.
 

--- a/docs/content/stable/explore/ysql-language-features/data-types.md
+++ b/docs/content/stable/explore/ysql-language-features/data-types.md
@@ -307,7 +307,7 @@ The output should be as follows:
  e_contact_method | Phone
 ```
 
-### 2. Create a table with an `ENUM` column
+### 3. Create a table with an `ENUM` column
 
 ```sql
 CREATE TABLE contact_method_info (
@@ -317,18 +317,18 @@ CREATE TABLE contact_method_info (
 );
 ```
 
-### 3. Insert a row with `ENUM`
+### 4. Insert a row with `ENUM`
 
 The `ENUM` should have a valid value, as follows:
 
 ```sql
-INSERT INTO contact_method_info VALUES ('Jeff', 'Email', 'jeff@mail.com')
+INSERT INTO contact_method_info VALUES ('Jeff', 'Email', 'jeff@mail.com');
 ```
 
 Execute the following to verify:
 
 ```sql
-yugabyte=# select * from contact_method_info;
+select * from contact_method_info;
 ```
 
 ```output
@@ -341,7 +341,7 @@ yugabyte=# select * from contact_method_info;
 Inserting an invalid `ENUM` value would fail, as shown in the following example:
 
 ```sql
-yugabyte=# INSERT INTO contact_method_info VALUES ('Jeff', 'Fax', '4563456');
+INSERT INTO contact_method_info VALUES ('Jeff', 'Fax', '4563456');
 ```
 
 You should see the following error (which is compatible with that of PostgreSQL):

--- a/docs/content/v2.12/explore/ysql-language-features/data-manipulation.md
+++ b/docs/content/v2.12/explore/ysql-language-features/data-manipulation.md
@@ -283,8 +283,9 @@ DELETE FROM employees WHERE department = 'Sales' RETURNING *;
 ## Auto-Incrementing Column Values
 
 Using a special kind of database object called sequence, you can generate unique identifiers by auto-incrementing the numeric identifier of each preceding row. In most cases, you would use sequences to auto-generate primary keys.
-
+```sql
 CREATE TABLE employees2 (employee_no serial, name text, department text);
+```
 
 Typically, you add sequences using the `serial` pseudotype that creates a new sequence object and sets the default value for the column to the next value produced by the sequence.
 

--- a/docs/content/v2.12/explore/ysql-language-features/data-types.md
+++ b/docs/content/v2.12/explore/ysql-language-features/data-types.md
@@ -307,7 +307,7 @@ The output should be as follows:
  e_contact_method | Phone
 ```
 
-### 2. Create a table with an `ENUM` column
+### 3. Create a table with an `ENUM` column
 
 ```sql
 CREATE TABLE contact_method_info (
@@ -317,18 +317,18 @@ CREATE TABLE contact_method_info (
 );
 ```
 
-### 3. Insert a row with `ENUM`
+### 4. Insert a row with `ENUM`
 
 The `ENUM` should have a valid value, as follows:
 
 ```sql
-INSERT INTO contact_method_info VALUES ('Jeff', 'Email', 'jeff@mail.com')
+INSERT INTO contact_method_info VALUES ('Jeff', 'Email', 'jeff@mail.com');
 ```
 
 Execute the following to verify:
 
 ```sql
-yugabyte=# select * from contact_method_info;
+select * from contact_method_info;
 ```
 
 ```output
@@ -341,7 +341,7 @@ yugabyte=# select * from contact_method_info;
 Inserting an invalid `ENUM` value would fail, as shown in the following example:
 
 ```sql
-yugabyte=# INSERT INTO contact_method_info VALUES ('Jeff', 'Fax', '4563456');
+INSERT INTO contact_method_info VALUES ('Jeff', 'Fax', '4563456');
 ```
 
 You should see the following error (which is compatible with that of PostgreSQL):

--- a/docs/content/v2.6/explore/ysql-language-features/data-manipulation.md
+++ b/docs/content/v2.6/explore/ysql-language-features/data-manipulation.md
@@ -285,7 +285,9 @@ DELETE FROM employees WHERE department = 'Sales' RETURNING *;
 
 Using a special kind of database object called sequence, you can generate unique identifiers by auto-incrementing the numeric identifier of each preceding row. In most cases, you would use sequences to auto-generate primary keys.
 
+```sql
 CREATE TABLE employees2 (employee_no serial, name text, department text);
+```
 
 Typically, you add sequences using the `serial` pseudotype that creates a new sequence object and sets the default value for the column to the next value produced by the sequence.
 

--- a/docs/content/v2.6/explore/ysql-language-features/data-types.md
+++ b/docs/content/v2.6/explore/ysql-language-features/data-types.md
@@ -289,7 +289,7 @@ The output should be as follows:
  e_contact_method | Phone
 ```
 
-### 2. Create a table with an `ENUM` column
+### 3. Create a table with an `ENUM` column
 
 ```sql
 CREATE TABLE contact_method_info (
@@ -299,17 +299,20 @@ CREATE TABLE contact_method_info (
 );
 ```
 
-### 3. Insert a row with `ENUM`
+### 4. Insert a row with `ENUM`
 
 The `ENUM` should have a valid value, as follows:
 
 ```sql
-INSERT INTO contact_method_info VALUES ('Jeff', 'Email', 'jeff@mail.com')
+INSERT INTO contact_method_info VALUES ('Jeff', 'Email', 'jeff@mail.com');
 ```
 
 Execute the following to verify:
+```sql
+select * from contact_method_info;
 ```
-yugabyte=# select * from contact_method_info;
+
+```output
  contact_name | contact_method |     value
 --------------+----------------+---------------
  Jeff         | Email          | jeff@mail.com
@@ -319,10 +322,10 @@ yugabyte=# select * from contact_method_info;
 Inserting an invalid `ENUM` value would fail, as shown in the following example:
 
 ```sql
-yugabyte=# INSERT INTO contact_method_info VALUES ('Jeff', 'Fax', '4563456');
+INSERT INTO contact_method_info VALUES ('Jeff', 'Fax', '4563456');
 ```
 You should see the following error (which is compatible with that of PostgreSQL):
-```
+```output
 ERROR:  22P02: invalid input value for enum e_contact_method: "Fax"
 LINE 1: INSERT INTO contact_method_info VALUES ('Jeff', 'Fax', '4563...
 ```

--- a/docs/content/v2.8/explore/ysql-language-features/data-manipulation.md
+++ b/docs/content/v2.8/explore/ysql-language-features/data-manipulation.md
@@ -285,7 +285,9 @@ DELETE FROM employees WHERE department = 'Sales' RETURNING *;
 
 Using a special kind of database object called sequence, you can generate unique identifiers by auto-incrementing the numeric identifier of each preceding row. In most cases, you would use sequences to auto-generate primary keys.
 
+```sql
 CREATE TABLE employees2 (employee_no serial, name text, department text);
+```
 
 Typically, you add sequences using the `serial` pseudotype that creates a new sequence object and sets the default value for the column to the next value produced by the sequence.
 

--- a/docs/content/v2.8/explore/ysql-language-features/data-types.md
+++ b/docs/content/v2.8/explore/ysql-language-features/data-types.md
@@ -308,7 +308,7 @@ The output should be as follows:
  e_contact_method | Phone
 ```
 
-### 2. Create a table with an `ENUM` column
+### 3. Create a table with an `ENUM` column
 
 ```sql
 CREATE TABLE contact_method_info (
@@ -318,18 +318,18 @@ CREATE TABLE contact_method_info (
 );
 ```
 
-### 3. Insert a row with `ENUM`
+### 4. Insert a row with `ENUM`
 
 The `ENUM` should have a valid value, as follows:
 
 ```sql
-INSERT INTO contact_method_info VALUES ('Jeff', 'Email', 'jeff@mail.com')
+INSERT INTO contact_method_info VALUES ('Jeff', 'Email', 'jeff@mail.com');
 ```
 
 Execute the following to verify:
 
 ```sql
-yugabyte=# select * from contact_method_info;
+select * from contact_method_info;
 ```
 
 ```output
@@ -342,7 +342,7 @@ yugabyte=# select * from contact_method_info;
 Inserting an invalid `ENUM` value would fail, as shown in the following example:
 
 ```sql
-yugabyte=# INSERT INTO contact_method_info VALUES ('Jeff', 'Fax', '4563456');
+INSERT INTO contact_method_info VALUES ('Jeff', 'Fax', '4563456');
 ```
 
 You should see the following error (which is compatible with that of PostgreSQL):


### PR DESCRIPTION
Fixes #12455