### PR TITLE
[docs] [explore] added an exception note about pessimistic locking

### DIFF
--- a/docs/content/preview/explore/ysql-language-features/postgresql-compatibility.md
+++ b/docs/content/preview/explore/ysql-language-features/postgresql-compatibility.md
@@ -20,7 +20,7 @@ Because YugabyteDB is a distributed database, supporting all PostgreSQL features
 
 The following PostgreSQL features are not supported in YugabyteDB:
 
-- Pessimistic locking
+- Pessimistic locking (Except Read Committed which is in beta _supports_ [pessimistic locking](../../../architecture/transactions/read-committed/#cross-feature-interaction))
 - Table locks
 - [Inheritance](https://www.postgresql.org/docs/11/tutorial-inheritance.html)
 - Exclusion Constraints

--- a/docs/content/stable/explore/ysql-language-features/postgresql-compatibility.md
+++ b/docs/content/stable/explore/ysql-language-features/postgresql-compatibility.md
@@ -12,13 +12,15 @@ type: docs
 ---
 YugabyteDB is a PostgreSQL compatible distributed database that supports the majority of PostgreSQL syntax. This means that existing applications built on PostgreSQL can often be migrated to YugabyteDB without changing application code.
 
-Since YugabyteDB is PostgreSQL compatible, it works with the majority of PostgreSQL database tools such as various language drivers, ORM tools, schema migration tools, and many more third-party database tools.
+Because YugabyteDB is PostgreSQL compatible, it works with the majority of PostgreSQL database tools such as various language drivers, ORM tools, schema migration tools, and many more third-party database tools.
 
-Since YugabyteDB is a distributed database, supporting all PostgreSQL features easily in a distributed system is not always feasible. This page documents the known list of differences between PostgreSQL and YugabyteDB. You need to consider these differences while porting an existing application to YugabyteDB.
+Because YugabyteDB is a distributed database, supporting all PostgreSQL features easily in a distributed system is not always feasible. This page documents the known list of differences between PostgreSQL and YugabyteDB. You need to consider these differences while porting an existing application to YugabyteDB.
 
 ## Unsupported PostgreSQL features
+
 The following PostgreSQL features are not supported in YugabyteDB:
-- Pessimistic locking
+
+- Pessimistic locking (Except Read Committed which is in beta _supports_ [pessimistic locking](../../../architecture/transactions/read-committed/#cross-feature-interaction))
 - Table locks
 - [Inheritance](https://www.postgresql.org/docs/11/tutorial-inheritance.html)
 - Exclusion Constraints


### PR DESCRIPTION
@dmagda , here's the Deploy preview for adding the exception note on Pessimistic locking:
https://deploy-preview-13752--infallible-bardeen-164bc9.netlify.app/preview/explore/ysql-language-features/postgresql-compatibility/#unsupported-postgresql-features


@netlify /preview/explore/ysql-language-features/postgresql-compatibility/