### PR TITLE
[docs] Add note about YCQL requiring Yugabyte-specific client drivers

### DIFF
--- a/docs/content/preview/reference/drivers/ycql-client-drivers.md
+++ b/docs/content/preview/reference/drivers/ycql-client-drivers.md
@@ -16,6 +16,8 @@ The following client drivers are supported for use with the [Yugabyte Cloud Quer
 
 For tutorials on building a sample application with the following client drivers, click the relevant link included below for each driver.
 
+Note that for YCQL you have to use the Yugabyte-specific client drivers, otherwise you can run into `NotSupportedError: Unknown data type code 0x0080. Have to skip entire result set.` errors.
+
 ## C/C++
 
 ### Yugabyte C/C++ Driver for YCQL

--- a/docs/content/preview/reference/drivers/ycql-client-drivers.md
+++ b/docs/content/preview/reference/drivers/ycql-client-drivers.md
@@ -16,7 +16,9 @@ The following client drivers are supported for use with the [Yugabyte Cloud Quer
 
 For tutorials on building a sample application with the following client drivers, click the relevant link included below for each driver.
 
-Note that for YCQL you have to use the Yugabyte-specific client drivers, otherwise you can run into `NotSupportedError: Unknown data type code 0x0080. Have to skip entire result set.` errors.
+{{< note title="Use YugabyteDB client drivers" >}}
+You should always use the YugabyteDB YCQL client drivers. Using generic Cassandra drivers can lead to errors and performance issues.
+{{< /note >}}
 
 ## C/C++
 


### PR DESCRIPTION
Was recently noticed two times in QA, and there are existing bugs about this: https://github.com/yugabyte/yugabyte-db/issues/520
So there seems to be some confusion on this topic, best to clear that up in documentation.