### PR TITLE
[docs] [integrations] Removed duplicate left navigation entry for Apache Spark 

### DIFF
--- a/docs/content/preview/integrations/apache-spark/java-ycql.md
+++ b/docs/content/preview/integrations/apache-spark/java-ycql.md
@@ -8,7 +8,7 @@ menu:
   preview:
     identifier: apache-spark-2-java-ycql
     parent: apache-spark
-    weight: 580
+    weight: 574
 type: docs
 ---
 

--- a/docs/content/preview/integrations/apache-spark/java-ysql.md
+++ b/docs/content/preview/integrations/apache-spark/java-ysql.md
@@ -6,7 +6,7 @@ menu:
   preview:
     identifier: apache-spark-2-java-ysql
     parent: apache-spark
-    weight: 575
+    weight: 573
 type: docs
 ---
 

--- a/docs/content/preview/integrations/apache-spark/python-ycql.md
+++ b/docs/content/preview/integrations/apache-spark/python-ycql.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   preview:
     identifier: apache-spark-3-python-ycql
-    parent: integrations
-    weight: 572
+    parent: apache-spark
+    weight: 576
 type: docs
 ---
 

--- a/docs/content/preview/integrations/apache-spark/python-ysql.md
+++ b/docs/content/preview/integrations/apache-spark/python-ysql.md
@@ -5,8 +5,8 @@ description: Build a Python application using Apache Spark and YugabyteDB
 menu:
   preview:
     identifier: apache-spark-3-python-ysql
-    parent: integrations
-    weight: 572
+    parent: apache-spark
+    weight: 575
 type: docs
 ---
 

--- a/docs/content/preview/integrations/apache-spark/scala-ycql.md
+++ b/docs/content/preview/integrations/apache-spark/scala-ycql.md
@@ -7,8 +7,8 @@ aliases:
 menu:
   preview:
     identifier: apache-spark-1-scala-ycql
-    parent: integrations
-    weight: 572
+    parent: apache-spark
+    weight: 578
 type: docs
 ---
 

--- a/docs/content/preview/integrations/apache-spark/scala-ysql.md
+++ b/docs/content/preview/integrations/apache-spark/scala-ysql.md
@@ -6,8 +6,8 @@ aliases:
 menu:
   preview:
     identifier: apache-spark-1-scala-ysql
-    parent: integrations
-    weight: 572
+    parent: apache-spark
+    weight: 577
 type: docs
 ---
 

--- a/docs/content/preview/integrations/apache-spark/spark-sql.md
+++ b/docs/content/preview/integrations/apache-spark/spark-sql.md
@@ -6,8 +6,8 @@ aliases:
 menu:
   preview:
     identifier: apache-spark-4-sql
-    parent: integrations
-    weight: 572
+    parent: apache-spark
+    weight: 579
 type: docs
 ---
 


### PR DESCRIPTION
@netlify /preview/integrations/apache-spark/

Currently, there are two extra entries under integrations left nav titled YSQL and YCQL which are pages from Apache Spark. 
This PR removes the duplicates.