### PR TITLE
Fix missing `\` in docs of `yb-boyager import schema`

### DIFF
--- a/docs/content/preview/migrate/yb-voyager/migrate-steps.md
+++ b/docs/content/preview/migrate/yb-voyager/migrate-steps.md
@@ -293,7 +293,7 @@ yb-voyager import schema --export-dir ${EXPORT_DIR} \
         --target-db-host ${TARGET_DB_HOST} \
         --target-db-user ${TARGET_DB_USER} \
         --target-db-password ${TARGET_DB_PASSWORD} \
-        --target-db-name ${TARGET_DB_NAME}
+        --target-db-name ${TARGET_DB_NAME} \
         --target-db-user ${TARGET_DB_USER}
 ```
 
@@ -314,7 +314,7 @@ yb-voyager import data --export-dir ${EXPORT_DIR} \
         --target-db-host ${TARGET_DB_HOST} \
         --target-db-user ${TARGET_DB_USER} \
         --target-db-password ${TARGET_DB_PASSWORD} \
-        --target-db-name ${TARGET_DB_NAME}
+        --target-db-name ${TARGET_DB_NAME} \
         --target-db-schema ${TARGET_DB_SCHEMA}
 ```
 
@@ -376,7 +376,7 @@ yb-voyager import data file --export-dir ${EXPORT_DIR} \
         --target-db-host ${TARGET_DB_HOST} \
         --target-db-user ${TARGET_DB_USER} \
         --target-db-password ${TARGET_DB_PASSWORD} \
-        --target-db-name ${TARGET_DB_NAME}
+        --target-db-name ${TARGET_DB_NAME} \
         –-data-dir "/path/to/files/dir/" \
         --file-table-map "filename1:table1,filename2:table2" \
         --delimiter "|" \

--- a/docs/content/stable/migrate/yb-voyager/migrate-steps.md
+++ b/docs/content/stable/migrate/yb-voyager/migrate-steps.md
@@ -293,7 +293,7 @@ yb-voyager import schema --export-dir ${EXPORT_DIR} \
         --target-db-host ${TARGET_DB_HOST} \
         --target-db-user ${TARGET_DB_USER} \
         --target-db-password ${TARGET_DB_PASSWORD} \
-        --target-db-name ${TARGET_DB_NAME}
+        --target-db-name ${TARGET_DB_NAME} \
         --target-db-user ${TARGET_DB_USER}
 ```
 
@@ -314,7 +314,7 @@ yb-voyager import data --export-dir ${EXPORT_DIR} \
         --target-db-host ${TARGET_DB_HOST} \
         --target-db-user ${TARGET_DB_USER} \
         --target-db-password ${TARGET_DB_PASSWORD} \
-        --target-db-name ${TARGET_DB_NAME}
+        --target-db-name ${TARGET_DB_NAME} \
         --target-db-schema ${TARGET_DB_SCHEMA}
 ```
 
@@ -376,7 +376,7 @@ yb-voyager import data file --export-dir ${EXPORT_DIR} \
         --target-db-host ${TARGET_DB_HOST} \
         --target-db-user ${TARGET_DB_USER} \
         --target-db-password ${TARGET_DB_PASSWORD} \
-        --target-db-name ${TARGET_DB_NAME}
+        --target-db-name ${TARGET_DB_NAME} \
         –-data-dir "/path/to/files/dir/" \
         --file-table-map "filename1:table1,filename2:table2" \
         --delimiter "|" \


### PR DESCRIPTION
Fixes #13439