### PR TITLE
[doc] PR for rpc_bind_addresses param for yb-master and yb-tserver is not set to 0.0.0.0 

### DIFF
--- a/docs/content/preview/reference/configuration/yb-master.md
+++ b/docs/content/preview/reference/configuration/yb-master.md
@@ -95,19 +95,21 @@ Default: Same value as `--fs_data_dirs`
 
 ##### --rpc_bind_addresses
 
-Specifies the comma-separated list of the network interface addresses to bind to for RPC connections
+Specifies the comma-separated list of the network interface addresses to which to bind for RPC connections:
 
-- Typically, the value is set to the private IP address of the host on which the server is running. When using the default, or explicitly setting the value to `0.0.0.0:7100`, the server will listen on all available network interfaces.
+The values used must match on all `yb-master` and [`yb-tserver`](../yb-tserver/#rpc-bind-addresses) configurations.
 
-- The values used must match on all `yb-master` and [`yb-tserver`](../yb-tserver/#rpc-bind-addresses) configurations.
+Default: Private IP address of the host on which the server is running, as defined in `/home/yugabyte/master/conf/server.conf`. For example:
 
-Default: `0.0.0.0:7100`
+```sh
+egrep -i rpc /home/yugabyte/master/conf/server.conf 
+--rpc_bind_addresses=172.161.x.x:7100
+```
 
-{{< note title="Note" >}}
+Make sure that the [`server_broadcast_addresses`](#server-broadcast-addresses) flag is set correctly if the following applies:
 
-In cases where `rpc_bind_addresses` is set to `0.0.0.0` (or not explicitly set, and uses the default) or in cases involving public IP addresses, make sure that [`server_broadcast_addresses`](#server-broadcast-addresses) is correctly set.
-
-{{< /note >}}
+- `rpc_bind_addresses` is set to `0.0.0.0`
+- `rpc_bind_addresses` involves public IP addresses such as, for example, `0.0.0.0:7100`, which instructs the server to listen on all available network interfaces.
 
 ##### --server_broadcast_addresses
 

--- a/docs/content/preview/reference/configuration/yb-master.md
+++ b/docs/content/preview/reference/configuration/yb-master.md
@@ -25,7 +25,7 @@ yb-master [ flag  ] | [ flag ]
 ### Example
 
 ```sh
-$ ./bin/yb-master \
+./bin/yb-master \
 --master_addresses 172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100 \
 --rpc_bind_addresses 172.151.17.130 \
 --fs_data_dirs "/home/centos/disk1,/home/centos/disk2" \
@@ -34,28 +34,13 @@ $ ./bin/yb-master \
 
 ### Online help
 
-To display the online help, run `yb-master --help` from the YugabyteDB home directory.
+To display the online help, run `yb-master --help` from the YugabyteDB home directory:
 
 ```sh
-$ ./bin/yb-master --help
+./bin/yb-master --help
 ```
 
-## Configuration flags
-
-- [General](#general-flags)
-- [YSQL](#ysql-flags)
-- [Logging](#logging-flags)
-- [Raft](#raft-flags)
-  - [Write ahead log (WAL)](#write-ahead-log-wal-flags)
-- [Sharding](#sharding-flags)
-- [Load balancing](#load-balancing-flags)
-- [Geo-distribution](#geo-distribution-flags)
-- [Security](#security-flags)
-- [Change data capture (CDC)](#change-data-capture-cdc-flags)
-
----
-
-### General flags
+## General flags
 
 ##### --version
 
@@ -95,7 +80,7 @@ Default: Same value as `--fs_data_dirs`
 
 ##### --rpc_bind_addresses
 
-Specifies the comma-separated list of the network interface addresses to which to bind for RPC connections:
+Specifies the comma-separated list of the network interface addresses to which to bind for RPC connections.
 
 The values used must match on all `yb-master` and [`yb-tserver`](../yb-tserver/#rpc-bind-addresses) configurations.
 
@@ -131,7 +116,7 @@ If this value is changed from the default, make sure to add the same value to al
 
 ##### --use_private_ip
 
-Specifies the policy that determines when to use private IP addresses for inter-node communication. Possible values are `never` (default),`zone`,`cloud` and `region`. Based on the values of the [placement (`--placement_*`) configuration flags](#placement-flags).
+Specifies the policy that determines when to use private IP addresses for inter-node communication. Possible values are `never`, `zone`, `cloud`, and `region`. Based on the values of the [geo-distribution flags](#geo-distribution-flags).
 
 Valid values for the policy are:
 
@@ -177,9 +162,7 @@ Location of .htpasswd file containing usernames and hashed passwords, for authen
 
 Default: `""`
 
----
-
-### YSQL flags
+## YSQL flags
 
 ##### --enable_ysql
 
@@ -193,9 +176,7 @@ Enables the YSQL API when value is `true`.
 
 Default: `true`
 
----
-
-### Logging flags
+## Logging flags
 
 ##### --colorlogtostderr
 
@@ -259,15 +240,9 @@ Log messages at, or above, this level are copied to `stderr` in addition to log 
 
 Default: `2`
 
----
-
-### Raft flags
-
-{{< note title="Note" >}}
+## Raft flags
 
 Ensure that values used for Raft and the write ahead log (WAL) in `yb-master` configurations match the values in `yb-tserver` configurations.
-
-{{< /note >}}
 
 ##### --follower_unavailable_considered_failed_sec
 
@@ -275,11 +250,7 @@ The duration, in seconds, after which a follower is considered to be failed beca
 
 Default: `900` (15 minutes)
 
-{{< note title="Important" >}}
-
 The `--follower_unavailable_considered_failed_sec` value should match the value for [`--log_min_seconds_to_retain`](#log-min-seconds-to-retain).
-
-{{< /note >}}
 
 ##### --leader_failure_max_missed_heartbeat_periods
 
@@ -295,13 +266,9 @@ The heartbeat interval, in milliseconds, for Raft replication. The leader produc
 
 Default: `500`
 
-#### Write ahead log (WAL) flags
-
-{{< note title="Note" >}}
+### Write ahead log (WAL) flags
 
 Ensure that values used for the write ahead log (WAL) in `yb-master` configurations match the values in `yb-tserver` configurations.
-
-{{< /note >}}
 
 ##### --fs_wal_dirs
 
@@ -311,7 +278,7 @@ Default: Same as `--fs_data_dirs`
 
 ##### --durable_wal_write
 
-If set to `false`, the writes to the WAL are synced to disk every [`interval_durable_wal_write_ms`](#interval-durable-wal-write-mas) milliseconds (ms) or every [`bytes_durable_wal_write_mb`](#bytes-durable-wal-write-mb) megabyte (MB), whichever comes first. This default setting is recommended only for multi-AZ or multi-region deployments where the availability zones (AZs) or regions are independent failure domains and there is not a risk of correlated power loss. For single AZ deployments, this flag should be set to `true`.
+If set to `false`, the writes to the WAL are synced to disk every [`interval_durable_wal_write_ms`](#interval-durable-wal-write-ms) milliseconds (ms) or every [`bytes_durable_wal_write_mb`](#bytes-durable-wal-write-mb) megabyte (MB), whichever comes first. This default setting is recommended only for multi-AZ or multi-region deployments where the availability zones (AZs) or regions are independent failure domains and there is not a risk of correlated power loss. For single AZ deployments, this flag should be set to `true`.
 
 Default: `false`
 
@@ -345,9 +312,7 @@ The size, in megabytes (MB), of a WAL segment (file). When the WAL segment reach
 
 Default: `64`
 
----
-
-### Load balancing flags
+## Load balancing flags
 
 For information on YB-Master load balancing, see [Data placement and load balancing](../../../architecture/concepts/yb-master/#data-placement-and-load-balancing).
 
@@ -405,7 +370,7 @@ Default: `10`
 
 ##### --load_balancer_max_concurrent_tablet_remote_bootstraps_per_table
 
- Maximum number of tablets being remote bootstrapped for any table. The maximum number of remote bootstraps across the cluster is still limited by the flag `load_balancer_max_concurrent_tablet_remote_bootstraps`. This flag is meant to prevent a single table use all the available remote bootstrap sessions and starving other tables.
+Maximum number of tablets being remote bootstrapped for any table. The maximum number of remote bootstraps across the cluster is still limited by the flag `load_balancer_max_concurrent_tablet_remote_bootstraps`. This flag is meant to prevent a single table use all the available remote bootstrap sessions and starving other tables.
 
 Default: `2`
 
@@ -427,9 +392,7 @@ Should the LB skip a leader as a possible remove candidate.
 
 Default: `false`
 
----
-
-### Sharding flags
+## Sharding flags
 
 ##### --max_clock_skew_usec
 
@@ -449,23 +412,11 @@ The number of shards per YB-TServer for each YCQL table when a user table is cre
 
 Default: `-1` (server internally sets default value). For servers with up to two CPU cores, the default value is `4`. For three or more CPU cores, the default value is `8`. Local cluster installations, created with `yb-ctl` and `yb-docker-ctl`, use a value of `2` for this flag. Clusters created with `yugabyted` use a default value of `1`.
 
-{{< note title="Important" >}}
-
 This value must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
-
-{{< /note >}}
-
-{{< note title="Note" >}}
 
 On a per-table basis, the [`CREATE TABLE ... WITH TABLETS = <num>`](../../../api/ycql/ddl_create_table/#create-a-table-specifying-the-number-of-tablets) clause can be used to override the `yb_num_shards_per_tserver` value.
 
-{{< /note >}}
-
-{{< note title="Note" >}}
-
 If `enable_automatic_tablet_splitting` is `true`, this value will be overridden and tables will begin with 1 tablet per node.
-
-{{< /note >}}
 
 ##### --ysql_num_shards_per_tserver
 
@@ -473,19 +424,11 @@ The number of shards per YB-TServer for each YSQL table when a user table is cre
 
 Default: `-1` (server internally sets default value). For servers with up to two CPU cores, the default value is `2`. For servers with three or four CPU cores, the default value is `4`. Beyond four cores, the default value is `8`. Local cluster installations, created with `yb-ctl` and `yb-docker-ctl`, use a value of `2` for this flag. Clusters created with `yugabyted` use a default value of `1`.
 
-{{< note title="Note" >}}
-
 On a per-table basis, the [`CREATE TABLE ...SPLIT INTO`](../../../api/ysql/the-sql-language/statements/ddl_create_table/#split-into) clause can be used to override the `ysql_num_shards_per_tserver` value.
-
-{{< /note >}}
-
-{{< note title="Note" >}}
 
 If `enable_automatic_tablet_splitting` is `true`, this value will be overridden and tables will begin with 1 tablet per node.
 
-{{< /note >}}
-
-### Tablet splitting flags
+## Tablet splitting flags
 
 ##### --enable_automatic_tablet_splitting
 
@@ -571,11 +514,7 @@ Enables automatic tablet splitting for tables that are part of an xCluster repli
 
 Default: `false`
 
-{{< note title="Note" >}}
-
 To enable tablet splitting on cross cluster replicated tables, this flag should be set to `true` on both the producer and consumer clusters, as they will perform splits independently of each other. Both the producer and consumer clusters must be running v2.14.0+ to enable the feature (relevant in case of cluster upgrades).
-
-{{< /note >}}
 
 ##### --prevent_split_for_ttl_tables_for_seconds
 
@@ -595,7 +534,7 @@ Determines whether to sort automatic split candidates from largest to smallest (
 
 Default: `true`
 
-**Syntax**
+Syntax:
 
 ```sh
 yb-admin --master_addresses <master-addresses> --tablet_force_split_size_threshold_bytes <bytes>
@@ -604,14 +543,12 @@ yb-admin --master_addresses <master-addresses> --tablet_force_split_size_thresho
 - *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.
 - *bytes*: The threshold size, in bytes, after which tablets should be split. Default value of `0` disables automatic tablet splitting.
 
-For details on automatic tablet splitting, see:
+For details on automatic tablet splitting, see the following:
 
-- [Automatic tablet splitting](../../../architecture/docdb-sharding/tablet-splitting) — Architecture overview
+- [Automatic tablet splitting](../../../architecture/docdb-sharding/tablet-splitting) — Architecture overview.
 - [Automatic Re-sharding of Data with Tablet Splitting](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/docdb-automatic-tablet-splitting.md) — Architecture design document in the GitHub repository.
 
----
-
-### Geo-distribution flags
+## Geo-distribution flags
 
 Settings related to managing geo-distributed clusters.
 
@@ -651,9 +588,7 @@ If true, transaction tables will be automatically created for any YSQL tablespac
 
 Default: `true`
 
----
-
-### Security flags
+## Security flags
 
 For details on enabling server-to-server encryption, see [Server-server encryption](../../../secure/tls-encryption/server-to-server/).
 
@@ -661,7 +596,7 @@ For details on enabling server-to-server encryption, see [Server-server encrypti
 
 Directory that contains certificate authority, private key, and certificates for this server.
 
-Default: `""` (Uses `<data drive>/yb-data/master/data/certs`.)
+Default: `""` (uses `<data drive>/yb-data/master/data/certs`.)
 
 ##### --allow_insecure_connections
 
@@ -683,7 +618,7 @@ Default: `false`
 
 ##### --cipher_list
 
-Specify cipher lists for TLS 1.2 and below. (For TLS 1.3, use [--ciphersuite](#ciphersuite).) Use a colon (":") separated list of TLSv1.2 cipher names in order of preference. Use an exclamation mark ("!") to exclude ciphers. For example:
+Specify cipher lists for TLS 1.2 and earlier versions. (For TLS 1.3, use [--ciphersuite](#ciphersuite).) Use a colon-separated list of TLS 1.2 cipher names in order of preference. Use an exclamation mark ( `!` ) to exclude ciphers. For example:
 
 ```sh
 --cipher_list DEFAULTS:!DES:!IDEA:!3DES:!RC2
@@ -699,9 +634,9 @@ For more information, refer to [SSL_CTX_set_cipher_list](https://www.openssl.org
 
 ##### --ciphersuite
 
-Specify cipher lists for TLS 1.3. (For TLS 1.2 and below, use [--cipher_list](#cipher-list).)
+Specify cipher lists for TLS 1.3. For TLS 1.2 and earlier, use [--cipher_list](#cipher-list).
 
-Use a colon (":") separated list of TLSv1.3 ciphersuite names in order of preference. Use an exclamation mark ("!") to exclude ciphers. For example:
+Use a colon-separated list of TLS 1.3 ciphersuite names in order of preference. Use an exclamation mark ( ! ) to exclude ciphers. For example:
 
 ```sh
 --ciphersuite DEFAULTS:!CHACHA20
@@ -715,13 +650,11 @@ Default: `DEFAULTS`
 
 For more information, refer to [SSL_CTX_set_cipher_list](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_cipher_list.html) in the OpenSSL documentation.
 
----
+## Change data capture (CDC) flags
 
-### Change data capture (CDC) flags
+To learn about CDC, see [Change data capture (CDC)](../../../architecture/docdb-replication/change-data-capture/).
 
-To learn more about CDC, see [Change data capture (CDC)](../../../architecture/docdb-replication/change-data-capture/).
-
-For other CDC configuration flags, see [YB-TServer's CDC flags](../yb-tserver/#change-data-capture-cdc-flags).
+For information on other CDC configuration flags, see [YB-TServer's CDC flags](../yb-tserver/#change-data-capture-cdc-flags).
 
 ##### --cdc_state_table_num_tablets
 
@@ -731,17 +664,17 @@ Default: `0` (Use the same default number of tablets as for regular tables.)
 
 ##### --cdc_wal_retention_time_secs
 
-WAL retention time, in seconds, to be used for tables for which a CDC stream was created. If you change the value, make sure that the [`yb-tserver --cdc_wal_retention_time_secs`](../yb-tserver/#cdc-wal-retention-time-secs) flag is also updated with the same value.
+WAL retention time, in seconds, to be used for tables for which a CDC stream was created. If you change the value, make sure that the corresponding flag is updated with the same value on YB-TServer.
 
 Default: `14400` (4 hours)
 
 ## Admin UI
 
-The Admin UI for yb-master is available at <http://localhost:7000>.
+The Admin UI for YB-Master is available at <http://localhost:7000>.
 
 ### Home
 
-Home page of the YB-Master server that gives a high level overview of the cluster. Note all YB-Master servers in a cluster show identical information.
+Home page of the YB-Master server that gives a high level overview of the cluster. Not all YB-Master servers in a cluster show identical information.
 
 ![master-home](/images/admin/master-home-binary-with-tables.png)
 

--- a/docs/content/preview/reference/configuration/yb-tserver.md
+++ b/docs/content/preview/reference/configuration/yb-tserver.md
@@ -34,13 +34,13 @@ yb-tserver [ flags ]
 
 ### Online help
 
-To display the online help, run `yb-tserver --help` from the YugabyteDB home directory.
+To display the online help, run `yb-tserver --help` from the YugabyteDB home directory:
 
 ```sh
 ./bin/yb-tserver --help
 ```
 
-### Help flags
+## Help flags
 
 - ##### --help
 
@@ -51,7 +51,7 @@ To display the online help, run `yb-tserver --help` from the YugabyteDB home dir
   Displays help on modules named by the specified flag value.
 
 
-### General flags
+## General flags
 
 - ##### --flagfile
 
@@ -93,7 +93,7 @@ To display the online help, run `yb-tserver --help` from the YugabyteDB home dir
 
 - ##### --rpc_bind_addresses
 
-  Specifies the comma-separated list of the network interface addresses to which to bind for RPC connections:
+  Specifies the comma-separated list of the network interface addresses to which to bind for RPC connections.
 
   The values must match on all [`yb-master`](../yb-master/#rpc-bind-addresses) and `yb-tserver` configurations.
 
@@ -125,12 +125,12 @@ To display the online help, run `yb-tserver --help` from the YugabyteDB home dir
 
 - ##### --use_private_ip
 
-  Specifies the policy that determines when to use private IP addresses for inter-node communication. Possible values are `never` (default),`zone`,`cloud` and `region`. Based on the values of the [placement (`--placement_*`) configuration flags](#placement-flags).
+  Specifies the policy that determines when to use private IP addresses for inter-node communication. Possible values are `never`, `zone`, `cloud`, and `region`. Based on the values of the [geo-distribution flags](#geo-distribution-flags).
 
   Valid values for the policy are:
 
-  - never` — Always use the [`--server_broadcast_addresses`](#server-broadcast-addresses).
-  - `zone` — Use the private IP inside a zone; use the [`--server_broadcast_addresses`](#server-broadcast-addresses) outside the zone.
+  - `never` — Always use [`--server_broadcast_addresses`](#server-broadcast-addresses).
+  - `zone` — Use the private IP inside a zone; use [`--server_broadcast_addresses`](#server-broadcast-addresses) outside the zone.
   - `region` — Use the private IP address across all zone in a region; use [`--server_broadcast_addresses`](#server-broadcast-addresses) outside the region.
 
   Default: `never`
@@ -257,7 +257,7 @@ Ensure that values used for the write ahead log (WAL) in `yb-tserver` configurat
 
 - ##### --durable_wal_write
 
-  If set to `false`, the writes to the WAL are synced to disk every [`interval_durable_wal_write_ms`](#interval-durable-wal-write-mas) milliseconds (ms) or every [`bytes_durable_wal_write_mb`](#bytes-durable-wal-write-mb) megabyte (MB), whichever comes first. This default setting is recommended only for multi-AZ or multi-region deployments where the availability zones (AZs) or regions are independent failure domains and there is not a risk of correlated power loss. For single AZ deployments, this flag should be set to `true`.
+  If set to `false`, the writes to the WAL are synchronized to disk every [`interval_durable_wal_write_ms`](#interval-durable-wal-write-ms) milliseconds (ms) or every [`bytes_durable_wal_write_mb`](#bytes-durable-wal-write-mb) megabyte (MB), whichever comes first. This default setting is recommended only for multi-AZ or multi-region deployments where the availability zones (AZs) or regions are independent failure domains and there is not a risk of correlated power loss. For single AZ deployments, this flag should be set to `true`.
 
   Default: `false`
 

--- a/docs/content/preview/reference/configuration/yb-tserver.md
+++ b/docs/content/preview/reference/configuration/yb-tserver.md
@@ -25,7 +25,7 @@ yb-tserver [ flags ]
 ### Example
 
 ```sh
-$ ./bin/yb-tserver \
+./bin/yb-tserver \
 --tserver_master_addrs 172.151.17.130:7100,172.151.17.220:7100,172.151.17.140:7100 \
 --rpc_bind_addresses 172.151.17.130 \
 --enable_ysql \
@@ -37,947 +37,886 @@ $ ./bin/yb-tserver \
 To display the online help, run `yb-tserver --help` from the YugabyteDB home directory.
 
 ```sh
-$ ./bin/yb-tserver --help
+./bin/yb-tserver --help
 ```
-
----
 
 ### Help flags
 
-##### --help
+- ##### --help
 
-Displays help on all flags.
+  Displays help on all flags.
 
-##### --helpon
+- ##### --helpon
 
-Displays help on modules named by the specified flag value.
+  Displays help on modules named by the specified flag value.
 
----
 
 ### General flags
 
-##### --flagfile
+- ##### --flagfile
 
-Specifies the file to load the configuration flags from. The configuration flags must be in the same format as supported by the command line flags.
+  Specifies the file to load the configuration flags from. The configuration flags must be in the same format as supported by the command line flags.
 
-##### --version
+- ##### --version
 
-Shows version and build info, then exits.
+  Shows version and build info, then exits.
 
-##### --tserver_master_addrs
+- ##### --tserver_master_addrs
 
-Specifies a comma-separated list of all the `yb-master` RPC addresses.
+  Specifies a comma-separated list of all the `yb-master` RPC addresses.
 
-Required.
+  Required.
 
-Default: `127.0.0.1:7100`
+  Default: `127.0.0.1:7100`
 
-{{< note title="Note" >}}
+  The number of comma-separated values should match the total number of YB-Master servers (or the replication factor).
 
-The number of comma-separated values should match the total number of YB-Master servers (or the replication factor).
+- ##### --fs_data_dirs
 
-{{< /note >}}
+  Specifies a comma-separated list of mount directories, where `yb-tserver` will add a `yb-data/tserver` data directory, `tserver.err`, `tserver.out`, and `pg_data` directory.
 
-##### --fs_data_dirs
+  Required.
 
-Specifies a comma-separated list of mount directories, where `yb-tserver` will add a `yb-data/tserver` data directory, `tserver.err`, `tserver.out`, and `pg_data` directory.
+  Changing the value of this flag after the cluster has already been created is not supported.
 
-Required.
+- ##### --fs_wal_dirs
 
-Changing the value of this flag after the cluster has already been created is not supported.
+  Specifies a comma-separated list of directories, where `yb-tserver` will store write-ahead (WAL) logs. This can be the same as one of the directories listed in `--fs_data_dirs`, but not a subdirectory of a data directory.
 
-##### --fs_wal_dirs
+  Default: The same value as `--fs_data_dirs`
 
-Specifies a comma-separated list of directories, where `yb-tserver` will store write-ahead (WAL) logs. This can be the same as one of the directories listed in `--fs_data_dirs`, but not a subdirectory of a data directory.
+- ##### --max_clock_skew_usec
 
-Default: Same value as `--fs_data_dirs`
+  Specifies the expected maximum clock skew, in microseconds (µs), between any two nodes in your deployment.
 
-##### --max_clock_skew_usec
+  Default: `500000` (500,000 µs = 500ms)
 
-Specifies the expected maximum clock skew, in microseconds (µs), between any two nodes in your deployment.
+- ##### --rpc_bind_addresses
 
-Default: `500000` (500,000 µs = 500ms)
+  Specifies the comma-separated list of the network interface addresses to which to bind for RPC connections:
 
-##### --rpc_bind_addresses
+  The values must match on all [`yb-master`](../yb-master/#rpc-bind-addresses) and `yb-tserver` configurations.
 
-Specifies the comma-separated list of the network interface addresses to bind to for RPC connections:
+  Default: Private IP address of the host on which the server is running, as defined in `/home/yugabyte/tserver/conf/server.conf`. For example:
 
-- Typically, the value is set to the private IP address of the host on which the server is running. When using the default, or explicitly setting the value to `0.0.0.0:9100`, the server will listen on all available network interfaces.
+  ```sh
+  egrep -i rpc /home/yugabyte/tserver/conf/server.conf 
+  --rpc_bind_addresses=172.161.x.x:9100
+  ```
 
-- The values must match on all [`yb-master`](../yb-master/#rpc-bind-addresses) and `yb-tserver` configurations.
+  Make sure that the [`server_broadcast_addresses`](#server-broadcast-addresses) flag is set correctly if the following applies:
 
-Default: `0.0.0.0:9100`
+  - `rpc_bind_addresses` is set to `0.0.0.0`
+  - `rpc_bind_addresses` involves public IP addresses such as, for example, `0.0.0.0:9100`, which instructs the server to listen on all available network interfaces.
 
-{{< note title="Note" >}}
+- ##### --server_broadcast_addresses
 
-In cases where `rpc_bind_addresses` is set to `0.0.0.0` (or not explicitly set, and uses the default) or in cases involving public IP addresses, make sure that [`server_broadcast_addresses`](#server-broadcast-addresses) is correctly set.
+  Specifies the public IP or DNS hostname of the server (with an optional port). This value is used by servers to communicate with one another, depending on the connection policy parameter.
 
-{{< /note >}}
+  Default: `""`
 
-##### --server_broadcast_addresses
+- ##### --dns_cache_expiration_ms
 
-Specifies the public IP or DNS hostname of the server (with an optional port). This value is used by servers to communicate with one another, depending on the connection policy parameter.
+  Specifies the duration, in milliseconds, until a cached DNS resolution expires. When hostnames are used instead of IP addresses, a DNS resolver must be queried to match hostnames to IP addresses. By using a local DNS cache to temporarily store DNS lookups, DNS queries can be resolved quicker and additional queries can be avoided, thereby reducing latency, improving load times, and reducing bandwidth and CPU consumption.
 
-Default: `""`
+  Default: `60000` (1 minute)
 
-##### --dns_cache_expiration_ms
+  If you change this value from the default, be sure to add the identical value to all YB-Master and YB-TServer configurations.
 
-Specifies the duration, in milliseconds, until a cached DNS resolution expires. When hostnames are used instead of IP addresses, a DNS resolver must be queried to match hostnames to IP addresses. By using a local DNS cache to temporarily store DNS lookups, DNS queries can be resolved quicker and additional queries can be avoided, thereby reducing latency, improving load times, and reducing bandwidth and CPU consumption.
+- ##### --use_private_ip
 
-Default: `60000` (1 minute)
+  Specifies the policy that determines when to use private IP addresses for inter-node communication. Possible values are `never` (default),`zone`,`cloud` and `region`. Based on the values of the [placement (`--placement_*`) configuration flags](#placement-flags).
 
-{{< note title="Note" >}}
+  Valid values for the policy are:
 
-If you change this value from the default, be sure to add the identical value to all YB-Master and YB-TServer configurations.
+  - never` — Always use the [`--server_broadcast_addresses`](#server-broadcast-addresses).
+  - `zone` — Use the private IP inside a zone; use the [`--server_broadcast_addresses`](#server-broadcast-addresses) outside the zone.
+  - `region` — Use the private IP address across all zone in a region; use [`--server_broadcast_addresses`](#server-broadcast-addresses) outside the region.
 
-{{< /note >}}
+  Default: `never`
 
-##### --use_private_ip
+- ##### --webserver_interface
 
-Specifies the policy that determines when to use private IP addresses for inter-node communication. Possible values are `never` (default),`zone`,`cloud` and `region`. Based on the values of the [placement (`--placement_*`) configuration flags](#placement-flags).
+  The address to bind for the web server user interface.
 
-Valid values for the policy are:
+  Default: `0.0.0.0` (`127.0.0.1`)
 
-- `never` — Always use the [`--server_broadcast_addresses`](#server-broadcast-addresses).
-- `zone` — Use the private IP inside a zone; use the [`--server_broadcast_addresses`](#server-broadcast-addresses) outside the zone.
-- `region` — Use the private IP address across all zone in a region; use [`--server_broadcast_addresses`](#server-broadcast-addresses) outside the region.
+- ##### --webserver_port
 
-Default: `never`
+  The port for monitoring the web server.
 
-##### --webserver_interface
+  Default: `9000`
 
-The address to bind for the web server user interface.
+- ##### --webserver_doc_root
 
-Default: `0.0.0.0` (`127.0.0.1`)
+  The monitoring web server home directory..
 
-##### --webserver_port
+  Default: The `www` directory in the YugabyteDB home directory.
 
-The port for monitoring the web server.
+- ##### --webserver_certificate_file
 
-Default: `9000`
+  Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is not enabled for the web server.
 
-##### --webserver_doc_root
+  Default: `""`
 
-The monitoring web server home directory..
+- ##### --webserver_authentication_domain
 
-Default: The `www` directory in the YugabyteDB home directory.
+  Domain used for `.htpasswd` authentication. This should be used in conjunction with [`--webserver_password_file`](#webserver-password-file).
 
-##### --webserver_certificate_file
+  Default: `""`
 
-Location of the SSL certificate file (in .pem format) to use for the web server. If empty, SSL is not enabled for the web server.
+- ##### --webserver_password_file
 
-Default: `""`
+  Location of the `.htpasswd` file containing usernames and hashed passwords, for authentication to the web server.
 
-##### --webserver_authentication_domain
+  Default: `""`
 
-Domain used for .htpasswd authentication. This should be used in conjunction with [`--webserver_password_file`](#webserver-password-file).
-
-Default: `""`
-
-##### --webserver_password_file
-
-Location of .htpasswd file containing usernames and hashed passwords, for authentication to the web server.
-
-Default: `""`
-
----
 
 ### Logging flags
 
-##### --log_dir
+- 
+  ##### --log_dir
 
-The directory to write `yb-tserver` log files.
+  The directory to write `yb-tserver` log files.
 
-Default: Same as [`--fs_data_dirs`](#fs-data-dirs)
+  Default: The same as [`--fs_data_dirs`](#fs-data-dirs)
 
-##### --logtostderr
+- ##### --logtostderr
 
-Write log messages to `stderr` instead of `logfiles`.
+  Write log messages to `stderr` instead of `logfiles`.
 
-Default: `false`
+  Default: `false`
 
-##### --max_log_size
+- ##### --max_log_size
 
-The maximum log size, in megabytes (MB). A value of `0` will be silently overridden to `1`.
+  The maximum log size, in megabytes (MB). A value of `0` will be silently overridden to `1`.
 
-Default: `1800` (1.8 GB)
+  Default: `1800` (1.8 GB)
 
-##### --minloglevel
+- ##### --minloglevel
 
-The minimum level to log messages. Values are: `0` (INFO), `1`, `2`, `3` (FATAL).
+  The minimum level to log messages. Values are: `0` (INFO), `1`, `2`, `3` (FATAL).
 
-Default: `0` (INFO)
+  Default: `0` (INFO)
 
-##### --stderrthreshold
+- ##### --stderrthreshold
 
-Log messages at, or above, this level are copied to `stderr` in addition to log files.
+  Log messages at, or above, this level are copied to `stderr` in addition to log files.
 
-Default: `2`
+  Default: `2`
 
-##### --stop_logging_if_full_disk
+- ##### --stop_logging_if_full_disk
 
-Stop attempting to log to disk if the disk is full.
+  Stop attempting to log to disk if the disk is full.
 
-Default: `false`
-
----
+  Default: `false`
 
 ### Raft flags
 
-{{< note title="Note" >}}
-
 Ensure that values used for Raft and the write ahead log (WAL) in `yb-tserver` configurations match the values in `yb-master` configurations.
 
-{{< /note >}}
+- ##### --follower_unavailable_considered_failed_sec
 
-##### --follower_unavailable_considered_failed_sec
+  The duration, in seconds, after which a follower is considered to be failed because the leader has not received a heartbeat. The follower is then evicted from the configuration and the data is re-replicated elsewhere.
 
-The duration, in seconds, after which a follower is considered to be failed because the leader has not received a heartbeat. The follower is then evicted from the configuration and the data is re-replicated elsewhere.
+  Default: `900` (15 minutes)
 
-Default: `900` (15 minutes)
+  The `--follower_unavailable_considered_failed_sec` value should match the value for [`--log_min_seconds_to_retain`](#log-min-seconds-to-retain).
 
-{{< note title="Important" >}}
+- ##### --leader_failure_max_missed_heartbeat_periods
 
-The `--follower_unavailable_considered_failed_sec` value should match the value for [`--log_min_seconds_to_retain`](#log-min-seconds-to-retain).
+  The maximum heartbeat periods that the leader can fail to heartbeat in before the leader is considered to be failed. The total failure timeout, in milliseconds (ms), is [`--raft_heartbeat_interval_ms`](#raft-heartbeat-interval-ms) multiplied by `--leader_failure_max_missed_heartbeat_periods`.
 
-{{< /note >}}
+  For read replica clusters, set the value to `10` in all `yb-tserver` and `yb-master` configurations.  Because the data is globally replicated, RPC latencies are higher. Use this flag to increase the failure detection interval in such a higher RPC latency deployment.
 
-##### --leader_failure_max_missed_heartbeat_periods
+  Default: `6`
 
-The maximum heartbeat periods that the leader can fail to heartbeat in before the leader is considered to be failed. The total failure timeout, in milliseconds (ms), is [`--raft_heartbeat_interval_ms`](#raft-heartbeat-interval-ms) multiplied by `--leader_failure_max_missed_heartbeat_periods`.
+- ##### --max_stale_read_bound_time_ms
 
-For read replica clusters, set the value to `10` in all `yb-tserver` and `yb-master` configurations.  Because the data is globally replicated, RPC latencies are higher. Use this flag to increase the failure detection interval in such a higher RPC latency deployment.
+  Specifies the maximum bounded staleness (duration), in milliseconds, before a follower forwards a read request to the leader.
+  In a geo-distributed cluster, with followers located a long distance from the tablet leader, you can use this setting to increase the maximum bounded staleness.
 
-Default: `6`
+  Default: `10000` (10 seconds)
 
-##### --max_stale_read_bound_time_ms
+- ##### --raft_heartbeat_interval_ms
 
-Specifies the maximum bounded staleness (duration), in milliseconds, before a follower forwards a read request to the leader.
-In a geo-distributed cluster, with followers located a long distance from the tablet leader, you can use this setting to increase the maximum bounded staleness.
+  The heartbeat interval, in milliseconds (ms), for Raft replication. The leader produces heartbeats to followers at this interval. The followers expect a heartbeat at this interval and consider a leader to have failed if it misses several in a row.
 
-Default: `10000` (10 seconds)
+  Default: `500`
 
-##### --raft_heartbeat_interval_ms
-
-The heartbeat interval, in milliseconds (ms), for Raft replication. The leader produces heartbeats to followers at this interval. The followers expect a heartbeat at this interval and consider a leader to have failed if it misses several in a row.
-
-Default: `500`
 
 #### Write ahead log (WAL) flags
 
-{{< note title="Note" >}}
-
 Ensure that values used for the write ahead log (WAL) in `yb-tserver` configurations match the values for `yb-master` configurations.
 
-{{< /note >}}
+- ##### --fs_wal_dirs
 
-##### --fs_wal_dirs
+  The directory where the `yb-tserver` retains WAL files. May be the same as one of the directories listed in [`--fs_data_dirs`](#fs-data-dirs), but not a subdirectory of a data directory.
 
-The directory where the `yb-tserver` retains WAL files. May be the same as one of the directories listed in [`--fs_data_dirs`](#fs-data-dirs), but not a subdirectory of a data directory.
+  Default: The same as `--fs_data_dirs`
 
-Default: Same as `--fs_data_dirs`
+- ##### --durable_wal_write
 
-##### --durable_wal_write
+  If set to `false`, the writes to the WAL are synced to disk every [`interval_durable_wal_write_ms`](#interval-durable-wal-write-mas) milliseconds (ms) or every [`bytes_durable_wal_write_mb`](#bytes-durable-wal-write-mb) megabyte (MB), whichever comes first. This default setting is recommended only for multi-AZ or multi-region deployments where the availability zones (AZs) or regions are independent failure domains and there is not a risk of correlated power loss. For single AZ deployments, this flag should be set to `true`.
 
-If set to `false`, the writes to the WAL are synced to disk every [`interval_durable_wal_write_ms`](#interval-durable-wal-write-mas) milliseconds (ms) or every [`bytes_durable_wal_write_mb`](#bytes-durable-wal-write-mb) megabyte (MB), whichever comes first. This default setting is recommended only for multi-AZ or multi-region deployments where the availability zones (AZs) or regions are independent failure domains and there is not a risk of correlated power loss. For single AZ deployments, this flag should be set to `true`.
+  Default: `false`
 
-Default: `false`
+- ##### --interval_durable_wal_write_ms
 
-##### --interval_durable_wal_write_ms
+  When [`--durable_wal_write`](#durable-wal-write) is false, writes to the WAL are synced to disk every `--interval_durable_wal_write_ms` or [`--bytes_durable_wal_write_mb`](#bytes-durable-wal-write-mb), whichever comes first.
 
-When [`--durable_wal_write`](#durable-wal-write) is false, writes to the WAL are synced to disk every `--interval_durable_wal_write_ms` or [`--bytes_durable_wal_write_mb`](#bytes-durable-wal-write-mb), whichever comes first.
+  Default: `1000`
 
-Default: `1000`
+- ##### --bytes_durable_wal_write_mb
 
-##### --bytes_durable_wal_write_mb
+  When [`--durable_wal_write`](#durable-wal-write) is `false`, writes to the WAL are synced to disk every `--bytes_durable_wal_write_mb` or `--interval_durable_wal_write_ms`, whichever comes first.
 
-When [`--durable_wal_write`](#durable-wal-write) is `false`, writes to the WAL are synced to disk every `--bytes_durable_wal_write_mb` or `--interval_durable_wal_write_ms`, whichever comes first.
+  Default: `1`
 
-Default: `1`
+- ##### --log_min_seconds_to_retain
 
-##### --log_min_seconds_to_retain
+  The minimum duration, in seconds, to retain WAL segments, regardless of durability requirements. WAL segments can be retained for a longer amount of time, if they are necessary for correct restart. This value should be set long enough such that a tablet server which has temporarily failed can be restarted in the given time period.
 
-The minimum duration, in seconds, to retain WAL segments, regardless of durability requirements. WAL segments can be retained for a longer amount of time, if they are necessary for correct restart. This value should be set long enough such that a tablet server which has temporarily failed can be restarted in the given time period.
+  Default: `900` (15 minutes)
 
-Default: `900` (15 minutes)
+- ##### --log_min_segments_to_retain
 
-##### --log_min_segments_to_retain
+  The minimum number of WAL segments (files) to retain, regardless of durability requirements. The value must be at least `1`.
 
-The minimum number of WAL segments (files) to retain, regardless of durability requirements. The value must be at least `1`.
+  Default: `2`
 
-Default: `2`
+- ##### --log_segment_size_mb
 
-##### --log_segment_size_mb
+  The size, in megabytes (MB), of a WAL segment (file). When the WAL segment reaches the specified size, then a log rollover occurs and a new WAL segment file is created.
 
-The size, in megabytes (MB), of a WAL segment (file). When the WAL segment reaches the specified size, then a log rollover occurs and a new WAL segment file is created.
+  Default: `64`
 
-Default: `64`
-
----
 
 ### Sharding flags
 
-##### --yb_num_shards_per_tserver
+- ##### --yb_num_shards_per_tserver
 
-The number of shards per YB-TServer for each YCQL table when a user table is created.
+  The number of shards per YB-TServer for each YCQL table when a user table is created.
 
-Default: `-1` (server internally sets default value). For servers with up to two CPU cores, the default value is `4`. For three or more CPU cores, the default value is `8`. Local cluster installations, created with `yb-ctl` and `yb-docker-ctl`, use a value of `2` for this flag. Clusters created with `yugabyted` use a default value of `1`.
+  Default: `-1` (server internally sets default value). For servers with up to two CPU cores, the default value is `4`. For three or more CPU cores, the default value is `8`. Local cluster installations, created with `yb-ctl` and `yb-docker-ctl`, use a value of `2` for this flag. Clusters created with `yugabyted` use a default value of `1`.
 
-{{< note title="Important" >}}
+  This value must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
 
-This value must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
+  On a per-table basis, the [`CREATE TABLE ... WITH TABLETS = <num>`](../../../api/ycql/ddl_create_table/#create-a-table-specifying-the-number-of-tablets) clause can be used to override the `yb_num_shards_per_tserver` value.
 
-{{< /note >}}
+- ##### --ysql_num_shards_per_tserver
 
-{{< note title="Note" >}}
+  The number of shards per YB-TServer for each YSQL table when a user table is created.
 
-On a per-table basis, the [`CREATE TABLE ... WITH TABLETS = <num>`](../../../api/ycql/ddl_create_table/#create-a-table-specifying-the-number-of-tablets) clause can be used to override the `yb_num_shards_per_tserver` value.
+  Default: `-1` (server internally sets default value). For servers with up to two CPU cores, the default value is `2`. For servers with three or four CPU cores, the default value is `4`. Beyond four cores, the default value is `8`. Local cluster installations, created with `yb-ctl` and `yb-docker-ctl`, use a value of `2` for this flag. Clusters created with `yugabyted` use a default value of `1`.
 
-{{< /note >}}
+  This value must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
 
-##### --ysql_num_shards_per_tserver
+  On a per-table basis, the [`CREATE TABLE ...SPLIT INTO`](../../../api/ysql/the-sql-language/statements/ddl_create_table/#split-into) clause can be used to override the `ysql_num_shards_per_tserver` value.
 
-The number of shards per YB-TServer for each YSQL table when a user table is created.
+- ##### --cleanup_split_tablets_interval_sec
 
-Default: `-1` (server internally sets default value). For servers with up to two CPU cores, the default value is `2`. For servers with three or four CPU cores, the default value is `4`. Beyond four cores, the default value is `8`. Local cluster installations, created with `yb-ctl` and `yb-docker-ctl`, use a value of `2` for this flag. Clusters created with `yugabyted` use a default value of `1`.
+  Interval at which the tablet manager tries to cleanup split tablets that are no longer needed. Setting this to 0 disables cleanup of split tablets.
 
-{{< note title="Important" >}}
+  Default: `60`
 
-This value must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
+- ##### --post_split_trigger_compaction_pool_max_threads
 
-{{< /note >}}
+  The maximum number of threads allowed for post-split compactions (i.e. compactions that remove irrelevant data from new tablets after splits).
 
-{{< note title="Note" >}}
+  Default: `1`
 
-On a per-table basis, the [`CREATE TABLE ...SPLIT INTO`](../../../api/ysql/the-sql-language/statements/ddl_create_table/#split-into) clause can be used to override the `ysql_num_shards_per_tserver` value.
+- ##### --post_split_trigger_compaction_pool_max_queue_size
 
-{{< /note >}}
+  The maximum number of post-split compaction tasks that can be queued simultaneously (compactions that remove irrelevant data from new tablets after splits).
 
-##### --cleanup_split_tablets_interval_sec
+  Default: `16`
 
-Interval at which the tablet manager tries to cleanup split tablets that are no longer needed. Setting this to 0 disables cleanup of split tablets.
+- ##### --automatic_compaction_extra_priority
 
-Default: `60`
+  Assigns an extra priority to automatic (minor) compactions when automatic tablet splitting is enabled. This deprioritizes post-split compactions and ensures that smaller compactions are not starved. Suggested values are between 0 and 50.
 
-##### --post_split_trigger_compaction_pool_max_threads
+  Default: `50`
 
-The maximum number of threads allowed for post-split compactions (i.e. compactions that remove irrelevant data from new tablets after splits).
-
-Default: `1`
-
-##### --post_split_trigger_compaction_pool_max_queue_size
-
-The maximum number of post-split compaction tasks that can be queued simultaneously (compactions that remove irrelevant data from new tablets after splits).
-
-Default: `16`
-
-##### --automatic_compaction_extra_priority
-
-Assigns an extra priority to automatic (minor) compactions when automatic tablet splitting is enabled. This deprioritizes post-split compactions and ensures that smaller compactions are not starved. Suggested values are between 0 and 50.
-
-Default: `50`
-
----
 
 ### Geo-distribution flags
 
-Settings related to managing geo-distributed clusters.
+Settings related to managing geo-distributed clusters:
 
-##### --placement_zone
+- ##### --placement_zone
 
-The name of the availability zone, or rack, where this instance is deployed.
+  The name of the availability zone, or rack, where this instance is deployed.
 
-Default: `rack1`
+  Default: `rack1`
 
-##### --placement_region
+- ##### --placement_region
 
-Specifies the name of the region, or data center, where this instance is deployed.
+  Specifies the name of the region, or data center, where this instance is deployed.
 
-Default: `datacenter1`
+  Default: `datacenter1`
 
-##### --placement_cloud
+- ##### --placement_cloud
 
-Specifies the name of the cloud where this instance is deployed.
+  Specifies the name of the cloud where this instance is deployed.
 
-Default: `cloud1`
+  Default: `cloud1`
 
-##### --placement_uuid
+- ##### --placement_uuid
 
-The unique identifier for the cluster.
+  The unique identifier for the cluster.
 
-Default: `""`
+  Default: `""`
 
-##### --force_global_transactions
+- ##### --force_global_transactions
 
-If true, forces all transactions through this instance to always be global transactions that use the `system.transactions` transaction status table. This is equivalent to always setting the session variable `force_global_transaction = TRUE`.
+  If true, forces all transactions through this instance to always be global transactions that use the `system.transactions` transaction status table. This is equivalent to always setting the session variable `force_global_transaction = TRUE`.
 
-{{< note title="Global transaction latency" >}}
+  {{< note title="Global transaction latency" >}}
 
-Avoid setting this flag when possible. All distributed transactions _can_ run without issue as global transactions, but you may have significantly higher latency when committing transactions, because YugabyteDB must achieve consensus across multiple regions to write to `system.transactions`. When necessary, it is preferable to selectively set the session variable `force_global_transaction = TRUE` rather than setting this flag.
+  Avoid setting this flag when possible. All distributed transactions _can_ run without issue as global transactions, but you may have significantly higher latency when committing transactions, because YugabyteDB must achieve consensus across multiple regions to write to `system.transactions`. When necessary, it is preferable to selectively set the session variable `force_global_transaction = TRUE` rather than setting this flag.
 
-{{< /note >}}
+  {{< /note >}}
 
-Default: `false`
+  Default: `false`
 
-##### --auto-create-local-transaction-tables
+- ##### --auto-create-local-transaction-tables
 
-If true, transaction status tables will be created under each YSQL tablespace that has a placement set and contains at least one other table.
+  If true, transaction status tables will be created under each YSQL tablespace that has a placement set and contains at least one other table.
 
-Default: `true`
+  Default: `true`
 
-##### --auto-promote-nonlocal-transactions-to-global
+- ##### --auto-promote-nonlocal-transactions-to-global
 
-If true, local transactions using transaction status tables other than `system.transactions` will be automatically promoted to global transactions using the `system.transactions` transaction status table upon accessing data outside of the local region.
+  If true, local transactions using transaction status tables other than `system.transactions` will be automatically promoted to global transactions using the `system.transactions` transaction status table upon accessing data outside of the local region.
 
-Default: `true`
+  Default: `true`
 
----
 
 ### YSQL flags
 
-The following flags support the use of the [YSQL API](../../../api/ysql/).
+The following flags support the use of the [YSQL API](../../../api/ysql/):
 
-##### --enable_ysql
+- ##### --enable_ysql
 
-{{< note title="Note" >}}
+  Enables the YSQL API.
 
-Ensure that `enable_ysql` values in `yb-tserver` configurations match the values in `yb-master` configurations.
+  Default: `true`
 
-{{< /note >}}
+  Ensure that `enable_ysql` values in `yb-tserver` configurations match the values in `yb-master` configurations.
 
-Enables the YSQL API.
+- ##### --ysql_enable_auth
 
-Default: `true`
+  Enables YSQL authentication.
 
-##### --ysql_enable_auth
+  When YSQL authentication is enabled, you can sign into `ysqlsh` using the default `yugabyte` user that has a default password of `yugabyte`.
 
-Enables YSQL authentication.
+  Default: `false`
 
-When YSQL authentication is enabled, you can sign into `ysqlsh` using the default `yugabyte` user that has a default password of `yugabyte`.
+- ##### --pgsql_proxy_bind_address
 
-Default: `false`
+  Specifies the TCP/IP bind addresses for the YSQL API. The default value of `0.0.0.0:5433` allows listening for all IPv4 addresses access to localhost on port `5433`. The `--pgsql_proxy_bind_address` value overwrites `listen_addresses` (default value of `127.0.0.1:5433`) that controls which interfaces accept connection attempts.
 
-##### --pgsql_proxy_bind_address
+  To specify fine-grained access control over who can access the server, use [`--ysql_hba_conf`](#ysql-hba-conf).
 
-Specifies the TCP/IP bind addresses for the YSQL API. The default value of `0.0.0.0:5433` allows listening for all IPv4 addresses access to localhost on port `5433`. The `--pgsql_proxy_bind_address` value overwrites `listen_addresses` (default value of `127.0.0.1:5433`) that controls which interfaces accept connection attempts.
+  Default: `0.0.0.0:5433`
 
-To specify fine-grained access control over who can access the server, use [`--ysql_hba_conf`](#ysql-hba-conf).
+- ##### --pgsql_proxy_webserver_port
 
-Default: `0.0.0.0:5433`
+  Specifies the web server port for YSQL metrics monitoring.
 
-##### --pgsql_proxy_webserver_port
+  Default: `13000`
 
-Specifies the web server port for YSQL metrics monitoring.
+- ##### --ysql_hba_conf
 
-Default: `13000`
+  Deprecated. Use `--ysql_hba_conf_csv` instead.
 
-##### --ysql_hba_conf
+- ##### --ysql_hba_conf_csv
 
-Deprecated. Use `--ysql_hba_conf_csv` instead.
+  Specifies a comma-separated list of PostgreSQL client authentication settings that is written to the `ysql_hba.conf` file. To see the current values in the `ysql_hba.conf` file, run the `SHOW hba_file;` statement and then view the file. Because the file is autogenerated, direct edits are overwritten by the autogenerated content.
 
-##### --ysql_hba_conf_csv
+  For details on using `--ysql_hba_conf_csv` to specify client authentication, refer to [Host-based authentication](../../../secure/authentication/host-based-authentication/).
 
-Specifies a comma-separated list of PostgreSQL client authentication settings that is written to the `ysql_hba.conf` file. To see the current values in the `ysql_hba.conf` file, run the `SHOW hba_file;` statement and then view the file. Because the file is autogenerated, direct edits are overwritten by the autogenerated content.
+  If a setting includes a comma (`,`) or double quotes (`"`), the setting should be enclosed in double quotes. In addition, double quotes inside the quoted text should be doubled (`""`).
 
-For details on using `--ysql_hba_conf_csv` to specify client authentication, refer to [Host-based authentication](../../../secure/authentication/host-based-authentication/).
+  Suppose you have two fields: `host all all 127.0.0.1/0 password` and `host all all 0.0.0.0/0 ldap ldapserver=***** ldapsearchattribute=cn ldapport=3268 ldapbinddn=***** ldapbindpasswd="*****"`.
 
-If a setting includes a comma (`,`) or double quotes (`"`), the setting should be enclosed in double quotes. In addition, double quotes inside the quoted text should be doubled (`""`).
+  Because the second field includes double quotes (`"`) around one of the settings, you need to double the quotes and enclose the entire field in quotes, as follows:
 
-Suppose you have two fields: `host all all 127.0.0.1/0 password` and `host all all 0.0.0.0/0 ldap ldapserver=***** ldapsearchattribute=cn ldapport=3268 ldapbinddn=***** ldapbindpasswd="*****"`.
+  ```sh
+  "host all all 0.0.0.0/0 ldap ldapserver=***** ldapsearchattribute=cn ldapport=3268 ldapbinddn=***** ldapbindpasswd=""*****"""
+  ```
 
-Because the second field includes double quotes (`"`) around one of the settings, you need to double the quotes and enclose the entire field in quotes, as follows:
+  To set the flag, join the fields using a comma (`,`) and enclose the final flag value in single quotes (`'`):
 
-```sh
-"host all all 0.0.0.0/0 ldap ldapserver=***** ldapsearchattribute=cn ldapport=3268 ldapbinddn=***** ldapbindpasswd=""*****"""
-```
+  ```sh
+  --ysql_hba_conf_csv='host all all 127.0.0.1/0 password,"host all all 0.0.0.0/0 ldap ldapserver=***** ldapsearchattribute=cn ldapport=3268 ldapbinddn=***** ldapbindpasswd=""*****"""'
+  ```
 
-To set the flag, join the fields using a comma (`,`) and enclose the final flag value in single quotes (`'`):
+  Default: `"host all all 0.0.0.0/0 trust,host all all ::0/0 trust"`
 
-```sh
---ysql_hba_conf_csv='host all all 127.0.0.1/0 password,"host all all 0.0.0.0/0 ldap ldapserver=***** ldapsearchattribute=cn ldapport=3268 ldapbinddn=***** ldapbindpasswd=""*****"""'
-```
+- ##### --ysql_pg_conf_csv
 
-Default: `"host all all 0.0.0.0/0 trust,host all all ::0/0 trust"`
+  Comma-separated list of PostgreSQL server configuration parameters that is appended to the `postgresql.conf` file.
 
-##### --ysql_pg_conf_csv
+  For example:
 
-Comma-separated list of PostgreSQL server configuration parameters that is appended to the `postgresql.conf` file.
+  ```sh
+  --ysql_pg_conf_csv="suppress_nonpg_logs=true,log_connections=on"
+  ```
 
-For example:
+  For information on available PostgreSQL server configuration parameters, refer to [Server Configuration](https://www.postgresql.org/docs/11/runtime-config.html) in the PostgreSQL documentation.
+  
+  The server configuration parameters for YugabyteDB are the same as for PostgreSQL, with the exception of some logging options. Refer to [PostgreSQL logging options](#postgresql-logging-options).
+  
+- ##### --ysql_timezone
 
-```sh
---ysql_pg_conf_csv="suppress_nonpg_logs=true,log_connections=on"
-```
+  Specifies the time zone for displaying and interpreting timestamps.
 
-For information on available PostgreSQL server configuration parameters, refer to [Server Configuration](https://www.postgresql.org/docs/11/runtime-config.html) in the PostgreSQL documentation.
+  Default: Uses the YSQL time zone.
 
-The server configuration parameters for YugabyteDB are the same as for PostgreSQL, with the exception of some logging options. Refer to [PostgreSQL logging options](#postgresql-logging-options).
+- ##### --ysql_datestyle
 
-##### --ysql_timezone
+  Specifies the display format for data and time values.
 
-Specifies the time zone for displaying and interpreting timestamps.
+  Default: Uses the YSQL display format.
 
-Default: Uses the YSQL time zone.
+- ##### --ysql_max_connections
 
-##### --ysql_datestyle
+  Specifies the maximum number of concurrent YSQL connections.
 
-Specifies the display format for data and time values.
+  Default: 300 for superusers. Non-superuser roles see only the connections available for use, while superusers see all connections, including those reserved for superusers.
 
-Default: Uses the YSQL display format.
+- ##### --ysql_default_transaction_isolation
 
-##### --ysql_max_connections
+  Specifies the default transaction isolation level.
 
-Specifies the maximum number of concurrent YSQL connections.
+  Valid values: `SERIALIZABLE`, `REPEATABLE READ`, `READ COMMITTED`, and `READ UNCOMMITTED`.
 
-Default: 300 for superusers. Non-superuser roles see only the connections available for use, while superusers see all connections, including those reserved for superusers.
+- Default: `READ COMMITTED`<sup>$</sup>
 
-##### --ysql_default_transaction_isolation
+  <sup>$</sup> Read Committed Isolation is supported only if the tserver gflag `yb_enable_read_committed_isolation` is set to `true`. By default this gflag is `false` and in this case the Read Committed isolation level of Yugabyte's transactional layer falls back to the stricter Snapshot Isolation (in which case `READ COMMITTED` and `READ UNCOMMITTED` of YSQL also in turn use Snapshot Isolation). Read Committed support is currently in [Beta](/preview/faq/general/#what-is-the-definition-of-the-beta-feature-tag).
 
-Specifies the default transaction isolation level.
+- ##### --ysql_disable_index_backfill
 
-Valid values: `SERIALIZABLE`, `REPEATABLE READ`, `READ COMMITTED`, and `READ UNCOMMITTED`.
+  Set this flag to `false` to enable online index backfill. When set to `false`, online index builds run while online, without failing other concurrent writes and traffic.
 
-Default: `READ COMMITTED`<sup>$</sup>
+  For details on how online index backfill works, see the [Online Index Backfill](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/online-index-backfill.md) design document.
 
-<sup>$</sup> Read Committed Isolation is supported only if the tserver gflag `yb_enable_read_committed_isolation` is set to `true`. By default this gflag is `false` and in this case the Read Committed isolation level of Yugabyte's transactional layer falls back to the stricter Snapshot Isolation (in which case `READ COMMITTED` and `READ UNCOMMITTED` of YSQL also in turn use Snapshot Isolation). Read Committed support is currently in [Beta](/preview/faq/general/#what-is-the-definition-of-the-beta-feature-tag).
+  Default: `false`
 
-##### --ysql_disable_index_backfill
+- ##### --ysql_sequence_cache_minval
 
-Set this flag to `false` to enable online index backfill. When set to `false`, online index builds run while online, without failing other concurrent writes and traffic.
+  Specify the minimum number of sequence values to cache in the client for every sequence object.
 
-For details on how online index backfill works, see the [Online Index Backfill](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/online-index-backfill.md) design document.
+  To turn off the default size of cache flag, set the flag to `0`.
 
-Default: `false`
+  For details on the expected behaviour when used with the sequence cache clause, see the semantics under [CREATE SEQUENCE](../../../api/ysql/the-sql-language/statements/ddl_create_sequence/#cache-cache) and [ALTER SEQUENCE](../../../api/ysql/the-sql-language/statements/ddl_alter_sequence/#cache-cache) pages.
 
-##### --ysql_sequence_cache_minval
+  Default: `100`
 
-Specify the minimum number of sequence values to cache in the client for every sequence object.
+- ##### --ysql_log_statement
 
-To turn off the default size of cache flag, set the flag to `0`.
+  Specifies the types of YSQL statements that should be logged.
 
-For details on the expected behaviour when used with the sequence cache clause, see the semantics under [CREATE SEQUENCE](../../../api/ysql/the-sql-language/statements/ddl_create_sequence/#cache-cache) and [ALTER SEQUENCE](../../../api/ysql/the-sql-language/statements/ddl_alter_sequence/#cache-cache) pages.
+  Valid values: `none` (off), `ddl` (only data definition queries, such as create/alter/drop), `mod` (all modifying/write statements, includes DDLs plus insert/update/delete/trunctate, etc), and `all` (all statements).
 
-Default: `100`
+  Default: `none`
 
-##### --ysql_log_statement
+- ##### --ysql_log_min_duration_statement
 
-Specifies the types of YSQL statements that should be logged.
+  Logs the duration of each completed SQL statement that runs the specified duration (in milliseconds) or longer. Setting the value to `0` prints all statement durations. You can use this flag to help track down unoptimized (or "slow") queries.
 
-Valid values: `none` (off), `ddl` (only data definition queries, such as create/alter/drop), `mod` (all modifying/write statements, includes DDLs plus insert/update/delete/trunctate, etc), and `all` (all statements).
+  Default: `-1` (disables logging statement durations)
 
-Default: `none`
+- ##### --ysql_log_min_messages
 
-##### --ysql_log_min_duration_statement
+  Specifies the lowest YSQL message level to log.
 
-Logs the duration of each completed SQL statement that runs the specified duration (in milliseconds) or longer. Setting the value to `0` prints all statement durations. You can use this flag to help track down unoptimized (or "slow") queries.
+- ##### --temp_file_limit
 
-Default: `-1` (disables logging statement durations)
+  Specifies the amount of disk space used for temp files for each YSQL connection, such as sort and hash temporary files, or the storage file for a held cursor.
 
-##### --ysql_log_min_messages
+  Any query whose disk space usage exceeds `temp_file_limit` will terminate with the error `ERROR:  temporary file size exceeds temp_file_limit`. Note that temporary tables do not count against this limit.
 
-Specifies the lowest YSQL message level to log.
+  You can remove the limit (set the size to unlimited) using `SET temp_file_limit=-1`.
 
-##### --temp_file_limit
+  Valid values are `-1` (unlimited), `integer` (in kilobytes), `xMB` (in megabytes), and `xGB` (in gigabytes).
 
- Specifies the amount of disk space used for temp files for each YSQL connection, such as sort and hash temporary files, or the storage file for a held cursor.
+  Default: `1GB`
 
- Any query whose disk space usage exceeds `temp_file_limit` will terminate with the error `ERROR:  temporary file size exceeds temp_file_limit`. Note that temporary tables do not count against this limit.
 
- You can remove the limit (set the size to unlimited) using `SET temp_file_limit=-1`.
-
- Valid values are `-1` (unlimited), `integer` (in kilobytes), `xMB` (in megabytes), and `xGB` (in gigabytes).
-
- Default: `1GB`
-
----
 
 ### YCQL flags
 
-The following flags support the use of the [YCQL API](../../../api/ycql/).
+The following flags support the use of the [YCQL API](../../../api/ycql/):
 
-##### --use_cassandra_authentication
+- ##### --use_cassandra_authentication
 
-Specify `true` to enable YCQL authentication (`username` and `password`), enable YCQL security statements (`CREATE ROLE`, `DROP ROLE`, `GRANT ROLE`, `REVOKE ROLE`, `GRANT PERMISSION`, and `REVOKE PERMISSION`), and enforce permissions for YCQL statements.
+  Specify `true` to enable YCQL authentication (`username` and `password`), enable YCQL security statements (`CREATE ROLE`, `DROP ROLE`, `GRANT ROLE`, `REVOKE ROLE`, `GRANT PERMISSION`, and `REVOKE PERMISSION`), and enforce permissions for YCQL statements.
 
-Default: `false`
+  Default: `false`
 
-##### --cql_proxy_bind_address
+- ##### --cql_proxy_bind_address
 
-Specifies the bind address for the YCQL API.
+  Specifies the bind address for the YCQL API.
 
-Default: `0.0.0.0:9042` (`127.0.0.1:9042`)
+  Default: `0.0.0.0:9042` (`127.0.0.1:9042`)
 
-##### --cql_proxy_webserver_port
+- ##### --cql_proxy_webserver_port
 
-Specifies the port for monitoring YCQL metrics.
+  Specifies the port for monitoring YCQL metrics.
 
-Default: `12000`
+  Default: `12000`
 
-##### --cql_table_is_transactional_by_default
+- ##### --cql_table_is_transactional_by_default
 
-Specifies if YCQL tables are created with transactions enabled by default.
+  Specifies if YCQL tables are created with transactions enabled by default.
 
-Default: `false`
+  Default: `false`
 
-##### --ycql_disable_index_backfill
+- ##### --ycql_disable_index_backfill
 
-Set this flag to `false` to enable online index backfill. When set to `false`, online index builds run while online, without failing other concurrent writes and traffic.
+  Set this flag to `false` to enable online index backfill. When set to `false`, online index builds run while online, without failing other concurrent writes and traffic.
 
-For details on how online index backfill works, see the [Online Index Backfill](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/online-index-backfill.md) design document.
+  For details on how online index backfill works, see the [Online Index Backfill](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/online-index-backfill.md) design document.
 
-Default: `true`
+  Default: `true`
 
-##### --ycql_require_drop_privs_for_truncate
+- ##### --ycql_require_drop_privs_for_truncate
 
-Set this flag to `true` to reject [`TRUNCATE`](../../../api/ycql/dml_truncate) statements unless allowed by [`DROP TABLE`](../../../api/ycql/ddl_drop_table) privileges.
+  Set this flag to `true` to reject [`TRUNCATE`](../../../api/ycql/dml_truncate) statements unless allowed by [`DROP TABLE`](../../../api/ycql/ddl_drop_table) privileges.
 
-Default: `false`
+  Default: `false`
 
-##### --ycql_enable_audit_log
+- ##### --ycql_enable_audit_log
 
-Set this flag to `true` to enable audit logging for the universe.
+  Set this flag to `true` to enable audit logging for the universe.
 
-For details, see [Audit logging for the YCQL API](../../../secure/audit-logging/audit-logging-ycql).
+  For details, see [Audit logging for the YCQL API](../../../secure/audit-logging/audit-logging-ycql).
 
----
 
 ### YEDIS flags
 
-The following flags support the use of the YEDIS API.
+The following flags support the use of the YEDIS API:
 
-##### --redis_proxy_bind_address
+- ##### --redis_proxy_bind_address
 
-Specifies the bind address for the YEDIS API.
+  Specifies the bind address for the YEDIS API.
 
-Default: `0.0.0.0:6379`
+  Default: `0.0.0.0:6379`
 
-##### --redis_proxy_webserver_port
+- ##### --redis_proxy_webserver_port
 
-Specifies the port for monitoring YEDIS metrics.
+  Specifies the port for monitoring YEDIS metrics.
 
-Default: `11000`
+  Default: `11000`
 
----
 
 ### Performance flags
 
-Use the following two flags to select the SSTable compression type.
+Use the following two flags to select the SSTable compression type:
 
-##### --enable_ondisk_compression
+- ##### --enable_ondisk_compression
 
-Enable SSTable compression at the cluster level.
+  Enable SSTable compression at the cluster level.
 
-Default: `true`
+  Default: `true`
 
-##### --compression_type
+- ##### --compression_type
 
-Change the SSTable compression type. The valid compression types are `Snappy`, `Zlib`, `LZ4`, and `NoCompression`.
+  Change the SSTable compression type. The valid compression types are `Snappy`, `Zlib`, `LZ4`, and `NoCompression`.
 
-Default: `Snappy`
+  Default: `Snappy`
 
-{{< note title="Note" >}}
+  If you select an invalid option, the cluster will not come up.
 
-If you select an invalid option, the cluster will not come up.
+  If you change this flag, the change takes effect after you restart the cluster nodes.
 
-If you change this flag, the change takes effect after you restart the cluster nodes.
+  Changing this flag on an existing database is supported; a tablet can validly have SSTs with different compression types. Eventually, compaction will remove the old compression type files.
 
-{{< /note >}}
+- ##### --regular_tablets_data_block_key_value_encoding
 
-Changing this flag on an existing database is supported; a tablet can validly have SSTs with different compression types. Eventually, compaction will remove the old compression type files.
+  Key-value encoding to use for regular data blocks in RocksDB. Possible options: `shared_prefix`, `three_shared_parts`.
 
-##### --regular_tablets_data_block_key_value_encoding
+  Default: `shared_prefix`
 
-Key-value encoding to use for regular data blocks in RocksDB. Possible options: `shared_prefix`, `three_shared_parts`.
+  Only change this flag to `three_shared_parts` after you migrate the whole cluster to the YugabyteDB version that supports it.
 
-Default: `shared_prefix`
+- ##### --rocksdb_compact_flush_rate_limit_bytes_per_sec
 
-{{< note title="Note" >}}
+  Used to control rate of memstore flush and SSTable file compaction.
 
-Only change this flag to `three_shared_parts` after you migrate the whole cluster to the YugabyteDB version that supports it.
+  Default: `256MB` (256 MB/second)
 
-{{< /note >}}
+- ##### --rocksdb_universal_compaction_min_merge_width
 
-##### --rocksdb_compact_flush_rate_limit_bytes_per_sec
+  Compactions run only if there are at least `rocksdb_universal_compaction_min_merge_width` eligible files and their running total (summation of size of files considered so far) is within `rocksdb_universal_compaction_size_ratio` of the next file in consideration to be included into the same compaction.
 
-Used to control rate of memstore flush and SSTable file compaction.
+  Default: `4`
 
-Default: `256MB` (256 MB/second)
+- ##### --rocksdb_universal_compaction_size_ratio
 
-##### --rocksdb_universal_compaction_min_merge_width
+  Compactions run only if there are at least `rocksdb_universal_compaction_min_merge_width` eligible files and their running total (summation of size of files considered so far) is within `rocksdb_universal_compaction_size_ratio` of the next file in consideration to be included into the same compaction.
 
-Compactions run only if there are at least `rocksdb_universal_compaction_min_merge_width` eligible files and their running total (summation of size of files considered so far) is within `rocksdb_universal_compaction_size_ratio` of the next file in consideration to be included into the same compaction.
+  Default: `20`
 
-Default: `4`
+- ##### --timestamp_history_retention_interval_sec
 
-##### --rocksdb_universal_compaction_size_ratio
+  The time interval, in seconds, to retain history/older versions of data. Point-in-time reads at a hybrid time prior to this interval might not be allowed after a compaction and return a `Snapshot too old` error. Set this to be greater than the expected maximum duration of any single transaction in your application.
 
-Compactions run only if there are at least `rocksdb_universal_compaction_min_merge_width` eligible files and their running total (summation of size of files considered so far) is within `rocksdb_universal_compaction_size_ratio` of the next file in consideration to be included into the same compaction.
+  Default: `900` (15 minutes)
 
-Default: `20`
+- ##### --remote_bootstrap_rate_limit_bytes_per_sec
 
-##### --timestamp_history_retention_interval_sec
+  Rate control across all tablets being remote bootstrapped from or to this process.
 
-The time interval, in seconds, to retain history/older versions of data. Point-in-time reads at a hybrid time prior to this interval might not be allowed after a compaction and return a `Snapshot too old` error. Set this to be greater than the expected maximum duration of any single transaction in your application.
+  Default: `256MB` (256 MB/second)
 
-Default: `900` (15 minutes)
-
-##### --remote_bootstrap_rate_limit_bytes_per_sec
-
-Rate control across all tablets being remote bootstrapped from or to this process.
-
-Default: `256MB` (256 MB/second)
-
----
 
 ### Network compression
 
-Use the following two gflags to configure RPC compression.
+Use the following two gflags to configure RPC compression:
 
-##### --enable_stream_compression
+- ##### --enable_stream_compression
 
-Controls whether YugabyteDB uses RPC compression.
+  Controls whether YugabyteDB uses RPC compression.
 
-Default: `true`
+  Default: `true`
 
-##### --stream_compression_algo
+- ##### --stream_compression_algo
 
-Specifies which RPC compression algorithm to use. Requires `enable_stream_compression` to be set to true. Valid values are:
+  Specifies which RPC compression algorithm to use. Requires `enable_stream_compression` to be set to true. Valid values are:
 
-- 0: No compression (default value)
-- 1: Gzip
-- 2: Snappy
-- 3: LZ4
+  0: No compression (default value)
 
-In most cases, LZ4 (`--stream_compression_algo=3`) offers the best compromise of compression performance versus CPU overhead.
+  1: Gzip
 
-{{< note title="Upgrade notes" >}}
+  2: Snappy
 
-To upgrade from an older version that doesn't support RPC compression (such as 2.4), to a newer version that does (such as 2.6), you need to do the following:
+  3: LZ4
 
-1. Rolling restart to upgrade YugabyteDB to a version that supports compression.
+  In most cases, LZ4 (`--stream_compression_algo=3`) offers the best compromise of compression performance versus CPU overhead.
 
-1. Rolling restart to enable compression, on both master and tserver, by setting `enable_stream_compression=true`.
+  To upgrade from an older version that doesn't support RPC compression (such as 2.4), to a newer version that does (such as 2.6), you need to do the following:
 
-    \
-    **Note** You can omit this step if the version you're upgrading to already has compression enabled by default. For the stable release series, versions from 2.6.3.0 and above (including all 2.8 releases) have `enable_stream_compression` set to true by default. For the preview release series, this is all releases beyond 2.9.0.
+  - Rolling restart to upgrade YugabyteDB to a version that supports compression.
 
-1. Rolling restart to set the compression algorithm to use, on both master and tserver, such as by setting `stream_compression_algo=3`.
+  - Rolling restart to enable compression, on both master and tserver, by setting `enable_stream_compression=true`.
+    Note that you can omit this step if the YugabyteDB version you are upgrading to already has compression enabled by default. For the stable release series, versions from 2.6.3.0 and later (including all 2.8 releases) have `enable_stream_compression` set to true by default. For the preview release series, this is all releases beyond 2.9.0.
 
-{{< /note >}}
+  - Rolling restart to set the compression algorithm to use, on both YB-Master and YB-TServer, such as by setting `stream_compression_algo=3`.
 
 ### Security flags
 
 For details on enabling client-server encryption, see [Client-server encryption](../../../secure/tls-encryption/client-to-server/).
 
-##### --certs_dir
+- ##### --certs_dir
 
-Directory that contains certificate authority, private key, and certificates for this server.
+  Directory that contains certificate authority, private key, and certificates for this server.
 
-Default: `""` (Uses `<data drive>/yb-data/tserver/data/certs`.)
+  Default: `""` (Uses `<data drive>/yb-data/tserver/data/certs`.)
 
-##### --allow_insecure_connections
+- ##### --allow_insecure_connections
 
-Allow insecure connections. Set to `false` to prevent any process with unencrypted communication from joining a cluster. Note that this flag requires the [`use_node_to_node_encryption`](#use-node-to-node-encryption) to be enabled and [`use_client_to_server_encryption`](#use-client-to-server-encryption) to be enabled.
+  Allow insecure connections. Set to `false` to prevent any process with unencrypted communication from joining a cluster. Note that this flag requires the [`use_node_to_node_encryption`](#use-node-to-node-encryption) to be enabled and [`use_client_to_server_encryption`](#use-client-to-server-encryption) to be enabled.
 
-Default: `true`
+  Default: `true`
 
-##### --certs_for_client_dir
+- ##### --certs_for_client_dir
 
-The directory that contains certificate authority, private key, and certificates for this server that should be used for client-to-server communications.
+  The directory that contains certificate authority, private key, and certificates for this server that should be used for client-to-server communications.
 
-Default: `""` (Use the same directory as for server-to-server communications.)
+  Default: `""` (Use the same directory as for server-to-server communications.)
 
-##### --dump_certificate_entries
+- ##### --dump_certificate_entries
 
-Adds certificate entries, including IP addresses and hostnames, to log for handshake error messages. Enable this flag to debug certificate issues.
+  Adds certificate entries, including IP addresses and hostnames, to log for handshake error messages. Enable this flag to debug certificate issues.
 
-Default: `false`
+  Default: `false`
 
-##### --use_client_to_server_encryption
+- ##### --use_client_to_server_encryption
 
-Use client-to-server, or client-server, encryption with YCQL.
+  Use client-to-server, or client-server, encryption with YCQL.
 
-Default: `false`
+  Default: `false`
 
-##### --use_node_to_node_encryption
+- ##### --use_node_to_node_encryption
 
-Enable server-server or node-to-node encryption between YugabyteDB YB-Master and YB-TServer servers in a cluster or universe. To work properly, all YB-Master servers must also have their [`--use_node_to_node_encryption`](../yb-master/#use-node-to-node-encryption) setting enabled. When enabled, then [`--allow_insecure_connections`](#allow-insecure-connections) must be disabled.
+  Enable server-server or node-to-node encryption between YugabyteDB YB-Master and YB-TServer servers in a cluster or universe. To work properly, all YB-Master servers must also have their [`--use_node_to_node_encryption`](../yb-master/#use-node-to-node-encryption) setting enabled. When enabled, then [`--allow_insecure_connections`](#allow-insecure-connections) must be disabled.
 
-Default: `false`
+  Default: `false`
 
-##### --cipher_list
+- ##### --cipher_list
 
-Specify cipher lists for TLS 1.2 and below. (For TLS 1.3, use [--ciphersuite](#ciphersuite).) Use a colon (":") separated list of TLSv1.2 cipher names in order of preference. Use an exclamation mark ("!") to exclude ciphers. For example:
+  Specify cipher lists for TLS 1.2 and below. (For TLS 1.3, use [--ciphersuite](#ciphersuite).) Use a colon (":") separated list of TLSv1.2 cipher names in order of preference. Use an exclamation mark ("!") to exclude ciphers. For example:
 
-```sh
---cipher_list DEFAULTS:!DES:!IDEA:!3DES:!RC2
-```
+  ```sh
+  --cipher_list DEFAULTS:!DES:!IDEA:!3DES:!RC2
+  ```
 
-This allows all ciphers for TLS 1.2 to be accepted, except those matching the category of ciphers omitted.
+  This allows all ciphers for TLS 1.2 to be accepted, except those matching the category of ciphers omitted.
 
-This flag requires a restart or rolling restart.
+  This flag requires a restart or rolling restart.
 
-Default: `DEFAULTS`
+  Default: `DEFAULTS`
 
-For more information, refer to [SSL_CTX_set_cipher_list](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_cipher_list.html) in the OpenSSL documentation.
+  For more information, refer to [SSL_CTX_set_cipher_list](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_cipher_list.html) in the OpenSSL documentation.
 
-##### --ciphersuite
+- ##### --ciphersuite
 
-Specify cipher lists for TLS 1.3. (For TLS 1.2 and below, use [--cipher_list](#cipher-list).)
+  Specify cipher lists for TLS 1.3. (For TLS 1.2 and below, use [--cipher_list](#cipher-list).)
 
-Use a colon (":") separated list of TLSv1.3 ciphersuite names in order of preference. Use an exclamation mark ("!") to exclude ciphers. For example:
+  Use a colon (":") separated list of TLSv1.3 ciphersuite names in order of preference. Use an exclamation mark ("!") to exclude ciphers. For example:
 
-```sh
---ciphersuite DEFAULTS:!CHACHA20
-```
+  ```sh
+  --ciphersuite DEFAULTS:!CHACHA20
+  ```
 
-This allows all ciphersuites for TLS 1.3 to be accepted, except CHACHA20 ciphers.
+  This allows all ciphersuites for TLS 1.3 to be accepted, except CHACHA20 ciphers.
 
-This flag requires a restart or rolling restart.
+  This flag requires a restart or rolling restart.
 
-Default: `DEFAULTS`
+  Default: `DEFAULTS`
 
-For more information, refer to [SSL_CTX_set_cipher_list](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_cipher_list.html) in the OpenSSL documentation.
-
----
+  For more information, refer to [SSL_CTX_set_cipher_list](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_cipher_list.html) in the OpenSSL documentation.
 
 ### Change data capture (CDC) flags
 
 To learn about CDC, see [Change data capture (CDC)](../../../architecture/docdb-replication/change-data-capture/).
 
-##### --cdc_state_checkpoint_update_interval_ms
+- ##### --cdc_state_checkpoint_update_interval_ms
 
-The rate at which CDC state's checkpoint is updated.
+  The rate at which CDC state's checkpoint is updated.
 
-Default: `15000`
+  Default: `15000`
 
-##### --cdc_ybclient_reactor_threads
+- ##### --cdc_ybclient_reactor_threads
 
-The number of reactor threads to be used for processing `ybclient` requests for CDC. Increase to improve throughput on large tablet setups.
+  The number of reactor threads to be used for processing `ybclient` requests for CDC. Increase to improve throughput on large tablet setups.
 
-Default: `50`
+  Default: `50`
 
-##### --cdc_max_stream_intent_records
+- ##### --cdc_max_stream_intent_records
 
-Maximum number of intent records allowed in a single CDC batch.
+  Maximum number of intent records allowed in a single CDC batch.
 
-Default: `1000`
+  Default: `1000`
 
-##### --cdc_snapshot_batch_size
+- ##### --cdc_snapshot_batch_size
 
-Number of records fetched in a single batch of snapshot operation of CDC.
+  Number of records fetched in a single batch of snapshot operation of CDC.
 
-Default: `250`
+  Default: `250`
 
-##### --cdc_min_replicated_index_considered_stale_seconds
+- ##### --cdc_min_replicated_index_considered_stale_seconds
 
-If `cdc_min_replicated_index` hasn't been replicated in this amount of time, we reset its value to max int64 to avoid retaining any logs.
+  If `cdc_min_replicated_index` hasn't been replicated in this amount of time, we reset its value to max int64 to avoid retaining any logs.
 
-Default: `900` (15 minutes)
+  Default: `900` (15 minutes)
 
-##### --timestamp_history_retention_interval_sec
+- ##### --timestamp_history_retention_interval_sec
 
-Time interval (in seconds) to retain history or older versions of data.
+  Time interval (in seconds) to retain history or older versions of data.
 
-Default: `900` (15 minutes)
+  Default: `900` (15 minutes)
 
-##### --update_min_cdc_indices_interval_secs
+- ##### --update_min_cdc_indices_interval_secs
 
-How often to read the `cdc_state` table to get the minimum applied index for each tablet across all streams. This information is used to correctly keep log files that contain unapplied entries. This is also the rate at which a tablet's minimum replicated index across all streams is sent to the other peers in the configuration. If flag `enable_log_retention_by_op_idx` (default: `true`) is disabled, this flag has no effect.
+  How often to read the `cdc_state` table to get the minimum applied index for each tablet across all streams. This information is used to correctly keep log files that contain unapplied entries. This is also the rate at which a tablet's minimum replicated index across all streams is sent to the other peers in the configuration. If flag `enable_log_retention_by_op_idx` (default: `true`) is disabled, this flag has no effect.
 
-Default: `60`
+  Default: `60`
 
-##### --cdc_checkpoint_opid_interval_ms
+- ##### --cdc_checkpoint_opid_interval_ms
 
-The number of seconds for which the client can go down and the intents will be retained. This means that if a client has not updated the checkpoint for this interval, the intents would be garbage collected.
+  The number of seconds for which the client can go down and the intents will be retained. This means that if a client has not updated the checkpoint for this interval, the intents would be garbage collected.
 
-Default: `60000`
+  Default: `60000`
 
-{{< warning title="Warning" >}}
+  {{< warning title="Warning" >}}
 
-If you are using multiple streams, it is advised that you set this flag to `1800000` (30 minutes).
+  If you are using multiple streams, it is advised that you set this flag to `1800000` (30 minutes).
 
-{{< /warning >}}
+  {{< /warning >}}
 
-##### --log_max_seconds_to_retain
+- ##### --log_max_seconds_to_retain
 
-Number of seconds to retain log files. Log files older than this value will be deleted even if they contain unreplicated CDC entries. If 0, this flag will be ignored. This flag is ignored if a log segment contains entries that haven't been flushed to RocksDB.
+  Number of seconds to retain log files. Log files older than this value will be deleted even if they contain unreplicated CDC entries. If 0, this flag will be ignored. This flag is ignored if a log segment contains entries that haven't been flushed to RocksDB.
 
-Default: `86400`
+  Default: `86400`
 
-##### --log_stop_retaining_min_disk_mb
+- ##### --log_stop_retaining_min_disk_mb
 
-Stop retaining logs if the space available for the logs falls below this limit, specified in megabytes. As with `log_max_seconds_to_retain`, this flag is ignored if a log segment contains unflushed entries.
+  Stop retaining logs if the space available for the logs falls below this limit, specified in megabytes. As with `log_max_seconds_to_retain`, this flag is ignored if a log segment contains unflushed entries.
 
-Default: `102400`
+  Default: `102400`
 
-##### --stream_truncate_record
+- ##### --stream_truncate_record
 
-Enable streaming of TRUNCATE record for a table on which CDC is active.
+  Enable streaming of TRUNCATE record for a table on which CDC is active.
 
-Default: `false`
+  Default: `false`
 
-##### --cdc_intent_retention_ms
+- ##### --cdc_intent_retention_ms
 
-The time period, in milliseconds, after which the intents will be cleaned up if there is no client polling for the change records.
+  The time period, in milliseconds, after which the intents will be cleaned up if there is no client polling for the change records.
 
-Default: `14400000` (4 hours)
+  Default: `14400000` (4 hours)
 
-##### --enable_update_local_peer_min_index
+- ##### --enable_update_local_peer_min_index
 
-Enable each local peer to update its own log checkpoint instead of the leader updating all peers.
+  Enable each local peer to update its own log checkpoint instead of the leader updating all peers.
 
-Default: `false`
+  Default: `false`
 
----
 
 ### File expiration based on TTL flags
 
-##### --tablet_enable_ttl_file_filter
+- ##### --tablet_enable_ttl_file_filter
 
-Turn on the file expiration for TTL feature.
+  Turn on the file expiration for TTL feature.
 
-Default: `false`
+  Default: `false`
 
-##### --rocksdb_max_file_size_for_compaction
+- ##### --rocksdb_max_file_size_for_compaction
 
-For tables with a `default_time_to_live` table property, sets a size threshold at which files will no longer be considered for compaction. Files over this threshold will still be considered for expiration. Disabled if value is `0`.
+  For tables with a `default_time_to_live` table property, sets a size threshold at which files will no longer be considered for compaction. Files over this threshold will still be considered for expiration. Disabled if value is `0`.
 
-Ideally, `rocksdb_max_file_size_for_compaction` should strike a balance between expiring data at a reasonable frequency and not creating too many SST files (which can impact read performance). For instance, if 90 days worth of data is stored, consider setting this flag to roughly the size of one day's worth of data.
+  Ideally, `rocksdb_max_file_size_for_compaction` should strike a balance between expiring data at a reasonable frequency and not creating too many SST files (which can impact read performance). For instance, if 90 days worth of data is stored, consider setting this flag to roughly the size of one day's worth of data.
 
-Default: `0`
+  Default: `0`
 
-##### --sst_files_soft_limit
+- ##### --sst_files_soft_limit
 
-Threshold for number of SST files per tablet. When exceeded, writes to a tablet will be throttled until the number of files is reduced.
+  Threshold for number of SST files per tablet. When exceeded, writes to a tablet will be throttled until the number of files is reduced.
 
-Default: `24`
+  Default: `24`
 
-##### --sst_files_hard_limit
+- ##### --sst_files_hard_limit
 
-Threshold for number of SST files per tablet. When exceeded, writes to a tablet will no longer be allowed until the number of files is reduced.
+  Threshold for number of SST files per tablet. When exceeded, writes to a tablet will no longer be allowed until the number of files is reduced.
 
-Default: `48`
+  Default: `48`
 
-##### --file_expiration_ignore_value_ttl
+- ##### --file_expiration_ignore_value_ttl
 
-When set to true, ignores any value-level TTL metadata when determining file expiration. Useful in situations where some SST files are missing the necessary value-level metadata (in case of upgrade, for instance).
+  When set to true, ignores any value-level TTL metadata when determining file expiration. Useful in situations where some SST files are missing the necessary value-level metadata (in case of upgrade, for instance).
 
-{{< warning title="Warning">}}
-Use of this flag can potentially result in expiration of live data - use at your discretion.
-{{< /warning >}}
+  Default: `false`
+  
+  {{< warning title="Warning">}}
+Use of this flag can potentially result in expiration of live data. Use at your discretion.
+  {{< /warning >}}
 
-Default: `false`
+- ##### --file_expiration_value_ttl_overrides_table_ttl
 
-##### --file_expiration_value_ttl_overrides_table_ttl
+  When set to true, allows files to expire purely based on their value-level TTL expiration time (even if it is lower than the table TTL). This is useful for times where a file needs to expire earlier than its table-level TTL would allow. If no value-level TTL metadata is available, then table-level TTL will still be used.
 
-When set to true, allows files to expire purely based on their value-level TTL expiration time (even if it is lower than the table TTL). This is useful for times where a file needs to expire earlier than its table-level TTL would allow. If no value-level TTL metadata is available, then table-level TTL will still be used.
+  Default: `false`
+  
+  {{< warning title="Warning">}}
+Use of this flag can potentially result in expiration of live data. Use at your discretion.
+  {{< /warning >}}
 
-{{< warning title="Warning">}}
-Use of this flag can potentially result in expiration of live data - use at your discretion.
-{{< /warning >}}
-
-Default: `false`
 
 ## PostgreSQL logging options
 


### PR DESCRIPTION
Made changes in /reference/configuration/yb-tserver/ and /reference/configuration/yb-master/ files.

https://docs.yugabyte.com/preview/deploy/manual-deployment/start-tservers/#run-yb-tserver-with-command-line-flags and https://docs.yugabyte.com/preview/deploy/manual-deployment/start-masters/#run-yb-master-servers-with-command-line-flags reference the --rpc_bind_addresses flag with updated description.