### PR TITLE
Crash while accessing NoneType corrected

### DIFF
--- a/bin/yb-docker-ctl
+++ b/bin/yb-docker-ctl
@@ -384,7 +384,7 @@ class YBDockerControl():
             node_type_first = node_types[0] if isinstance(node_types, list) else next(node_types)
             ui_port = self.YB_MASTER_UI_PORT if \
                 node_type_first == "master" else self.YB_TSERVER_UI_PORT
-            node_ui_host = "http://{}:{}".format(ip, ui_port) if status == 'running' else None
+            node_ui_host = "http://{}:{}".format(ip, ui_port) if status == 'running' else '' 
             state = 'Running' if 'running' in status else 'Stopped'
             print ("{:<15}{:<10} {:<10} {:<20} {:<25} {:<15} {:<20}".format(
                 cid[:12], pid, node_type_first, name, node_ui_host, state, started_at))


### PR DESCRIPTION
**Change Description:**
Issue while printing NoneType corrected.

How to reproduce the issue:
```
 ./yb-docker-ctl create --rf 1
./yb-docker-ctl remove_node 1
./yb-docker-ctl status
```

OutPut without fix:
```
ID             PID        Type       Node                 URL                       Status          Started At          
Traceback (most recent call last):
  File "./yb-docker-ctl", line 545, in <module>
    YBDockerControl().run()
  File "./yb-docker-ctl", line 528, in run
    self.cluster_status()
  File "./yb-docker-ctl", line 390, in cluster_status
    cid[:12], pid, node_type_first, name, node_ui_host, state, started_at))
TypeError: unsupported format string passed to NoneType.__format__

```
Output with fix:
```
ID             PID        Type       Node                 URL                       Status          Started At          
a8abee93e33f   0          tserver    yb-tserver-n1                                  Stopped         2022-09-02T18:04:50.493571382Z
1b7b81d949ae   26238      master     yb-master-n1         http://172.26.0.2:7000    Running         2022-09-02T18:04:49.948076198Z
```
