### PR TITLE
[docs] Add Monterey note for Docker Quick Start

### DIFF
--- a/docs/content/preview/quick-start/_index.md
+++ b/docs/content/preview/quick-start/_index.md
@@ -197,21 +197,15 @@ To create a single-node local cluster with a replication factor (RF) of 1, run t
 ./bin/yugabyted start
 ```
 
-{{<note title="Note for macOS Monterey" >}}
-
-macOS Monterey enables AirPlay receiving by default, which listens on port 7000. This conflicts with YugabyteDB and causes `yugabyted start` to fail. To resolve the issue, you can disable AirPlay receiving, then start YugabyteDB, and then, optionally, re-enable AirPlay receiving. Alternatively, you can change the default port number using the `--master_webserver_port` flag when you start the cluster as follows:
+If you are running macOS Monterey, run the following command:
 
 ```sh
 ./bin/yugabyted start --master_webserver_port=9999
 ```
 
-{{< /note >}}
+macOS Monterey enables AirPlay receiving by default, which listens on port 7000. This conflicts with YugabyteDB and causes `yugabyted start` to fail. Using the [--master_webserver_port flag](../reference/configuration/yugabyted/#advanced-flags) when you start the cluster changes the default port number. Alternatively, you can disable AirPlay receiving, then start YugabyteDB normally, and then, optionally, re-enable AirPlay receiving.
 
-After the cluster has been created, clients can connect to the YSQL and YCQL APIs at `http://localhost:5433` and `http://localhost:9042` respectively. You can also check `~/var/data` to see the data directory and `~/var/logs` to see the logs directory.
-
-If you have previously installed YugabyteDB version 2.8 or later and created a cluster on the same computer, you may need to [upgrade the YSQL system catalog](../manage/upgrade-deployment/#upgrade-the-ysql-system-catalog) to run the latest features.
-
-### Check cluster status
+### Check the cluster status
 
 Execute the following command to check the cluster status:
 
@@ -237,7 +231,11 @@ Expect an output similar to the following:
 +--------------------------------------------------------------------------------------------------+
 ```
 
-### Check cluster status with Admin UI
+After the cluster has been created, clients can [connect to the YSQL and YCQL APIs](#connect-to-the-database) at `http://localhost:5433` and `http://localhost:9042` respectively. You can also check `~/var/data` to see the data directory and `~/var/logs` to see the logs directory.
+
+If you have previously installed YugabyteDB version 2.8 or later and created a cluster on the same computer, you may need to [upgrade the YSQL system catalog](../manage/upgrade-deployment/#upgrade-the-ysql-system-catalog) to run the latest features.
+
+### Use the Admin UI
 
 The cluster you have created consists of two processes: [YB-Master](../architecture/concepts/yb-master/) which keeps track of various metadata (list of tables, users, roles, permissions, and so on) and [YB-TServer](../architecture/concepts/yb-tserver/) which is responsible for the actual end-user requests for data updates and queries.
 

--- a/docs/content/preview/quick-start/docker.md
+++ b/docs/content/preview/quick-start/docker.md
@@ -93,6 +93,23 @@ docker run -d --name yugabyte  -p7000:7000 -p9000:9000 -p5433:5433 -p9042:9042\
  --daemon=false
 ```
 
+If you are running macOS Monterey, replace `-p7000:7000` with `-p7001:7000`. This is necessary because Monterey enables AirPlay receiving by default, which listens on port 7000. This conflicts with YugabyteDB and causes `yugabyted start` to fail unless you forward the port as shown. Alternatively, you can disable AirPlay receiving, then start YugabyteDB normally, and then, optionally, re-enable AirPlay receiving.
+
+Run the following command to check the cluster status:
+
+```sh
+docker ps
+```
+
+```output
+CONTAINER ID        IMAGE                 COMMAND                  CREATED             STATUS              PORTS                                                                                                                                                                     NAMES
+5088ca718f70        yugabytedb/yugabyte   "bin/yugabyted start…"   46 seconds ago      Up 44 seconds       0.0.0.0:5433->5433/tcp, 6379/tcp, 7100/tcp, 0.0.0.0:7000->7000/tcp, 0.0.0.0:9000->9000/tcp, 7200/tcp, 9100/tcp, 10100/tcp, 11000/tcp, 0.0.0.0:9042->9042/tcp, 12000/tcp   yugabyte
+```
+
+Clients can now [connect to the YSQL and YCQL APIs](#connect-to-the-database) at `http://localhost:5433` and `http://localhost:9042` respectively.
+
+### Run Docker in a persistent volume
+
 In the preceding `docker run` command, the data stored in YugabyteDB does not persist across container restarts. To make YugabyteDB persist data across restarts, you can add a volume mount option to the docker run command, as follows:
 
 - Create a `~/yb_data` directory by executing the following command:
@@ -111,28 +128,15 @@ In the preceding `docker run` command, the data stored in YugabyteDB does not pe
            --base_dir=/home/yugabyte/yb_data --daemon=false
   ```
 
-Clients can now connect to the YSQL and YCQL APIs at `http://localhost:5433` and `http://localhost:9042` respectively.
+  If running macOS Monterey, replace `-p7000:7000` with `-p7001:7000`.
 
-### Check cluster status
-
-Run the following command to check the cluster status:
-
-```sh
-docker ps
-```
-
-```output
-CONTAINER ID        IMAGE                 COMMAND                  CREATED             STATUS              PORTS                                                                                                                                                                     NAMES
-5088ca718f70        yugabytedb/yugabyte   "bin/yugabyted start…"   46 seconds ago      Up 44 seconds       0.0.0.0:5433->5433/tcp, 6379/tcp, 7100/tcp, 0.0.0.0:7000->7000/tcp, 0.0.0.0:9000->9000/tcp, 7200/tcp, 9100/tcp, 10100/tcp, 11000/tcp, 0.0.0.0:9042->9042/tcp, 12000/tcp   yugabyte
-```
-
-### Check cluster status with Admin UI
+## Use the Admin UI
 
 The cluster you have created consists of two processes: [YB-Master](../../architecture/concepts/yb-master/) which keeps track of various metadata (list of tables, users, roles, permissions, and so on) and [YB-TServer](../../architecture/concepts/yb-tserver/) which is responsible for the actual end user requests for data updates and queries.
 
 Each of the processes exposes its own Admin UI that can be used to check the status of the corresponding process, as well as perform certain administrative operations. The [yb-master Admin UI](../../reference/configuration/yb-master/#admin-ui) is available at <http://localhost:7000> and the [yb-tserver Admin UI](../../reference/configuration/yb-tserver/#admin-ui) is available at <http://localhost:9000>. To avoid port conflicts, you should make sure other processes on your machine do not have these ports mapped to `localhost`.
 
-#### Overview and YB-Master status
+### Overview and YB-Master status
 
 The following illustration shows the YB-Master home page with a cluster with a replication factor of 1, a single node, and no tables. The YugabyteDB version is also displayed.
 
@@ -140,7 +144,7 @@ The following illustration shows the YB-Master home page with a cluster with a r
 
 The **Masters** section shows the 1 YB-Master along with its corresponding cloud, region, and zone placement.
 
-#### YB-TServer status
+### YB-TServer status
 
 Click **See all nodes** to open the **Tablet Servers** page that lists the YB-TServer along with the time since it last connected to the YB-Master using regular heartbeats, as per the following illustration:
 

--- a/docs/content/preview/quick-start/linux.md
+++ b/docs/content/preview/quick-start/linux.md
@@ -176,7 +176,7 @@ Expect an output similar to the following:
 +--------------------------------------------------------------------------------------------------+
 ```
 
-### Check cluster status with Admin UI
+### Use the Admin UI
 
 The cluster you have created consists of two processes: [YB-Master](../../architecture/concepts/yb-master/) which keeps track of various metadata (list of tables, users, roles, permissions, and so on) and [YB-TServer](../../architecture/concepts/yb-tserver/) which is responsible for the actual end-user requests for data updates and queries.
 

--- a/docs/content/preview/quick-start/linux.md
+++ b/docs/content/preview/quick-start/linux.md
@@ -151,7 +151,7 @@ After the cluster has been created, clients can connect to the YSQL and YCQL API
 
 If you have previously installed YugabyteDB 2.8 or later and created a cluster on the same computer, you may need to [upgrade the YSQL system catalog](../../manage/upgrade-deployment/#upgrade-the-ysql-system-catalog) to run the latest features.
 
-### Check cluster status
+### Check the cluster status
 
 Execute the following command to check the cluster status:
 

--- a/docs/content/preview/yugabyte-cloud/cloud-basics/cloud-vpcs/cloud-add-vpc-aws.md
+++ b/docs/content/preview/yugabyte-cloud/cloud-basics/cloud-vpcs/cloud-add-vpc-aws.md
@@ -137,7 +137,7 @@ To set DNS settings:
 
 To accept the peering request, do the following:
 
-1. On the AWS [Peering Connections](https://console.aws.amazon.com/vpc/home?#PeeringConnections) page, select the VPC in the list; its status is Pending request.
+1. On the AWS [Peering Connections](https://console.aws.amazon.com/vpc/home?#PeeringConnections) page, select the VPC in the list; its status is Pending acceptance.
 1. Click **Actions** and choose **Accept request** to display the **Accept VPC peering connection request** window.
     ![Accept peering in AWS](/images/yb-cloud/cloud-peer-aws-accept.png)
 1. Click **Accept request**.


### PR DESCRIPTION
Add port forward instruction for running Docker on macOS Monterey

@netlify /preview/quick-start/docker/#create-a-local-cluster