### PR TITLE
Update tablet splitting limitations.

### DIFF
--- a/docs/content/preview/architecture/docdb-sharding/tablet-splitting.md
+++ b/docs/content/preview/architecture/docdb-sharding/tablet-splitting.md
@@ -306,8 +306,7 @@ In the following example, a three-node cluster is created and uses a YCSB worklo
 The following known limitations are planned to be resolved in upcoming releases:
 
 * Colocated tables cannot be split. For details, see [#4463](https://github.com/yugabyte/yugabyte-db/issues/4463).
-* In v2.14.0, tablet splitting should be disabled during an index backfill. This is expected to be fixed in 2.14.1. For details, see [#13127](https://github.com/yugabyte/yugabyte-db/issues/13127).
-* When tablet splitting is used with Point In Time Recovery (PITR), restoring to arbitrary times in the past when a tablet is in the process of splitting is not supported. For details, see [#13022](https://github.com/yugabyte/yugabyte-db/issues/13022).
+* In 2.14.0, when tablet splitting is used with Point In Time Recovery (PITR), restoring to arbitrary times in the past when a tablet is in the process of splitting is not supported. This is fixed in 2.14.1.
 * Tablet splitting is currently disabled by default for tables with cross cluster replication. It can be enabled using the [`enable_tablet_split_of_xcluster_replicated_tables`](../../../reference/configuration/yb-master/#enable-tablet-split-of-xcluster-replicated-tables) flag on master on both the producer and consumer clusters (as they will perform splits independently of one another). If using this feature after upgrade, the producer and consumer clusters should both be upgraded to 2.14.0+ before enabling the feature.
 * Tablet splitting is currently disabled during bootstrap for tables with cross cluster replication. For details, see [#13170](https://github.com/yugabyte/yugabyte-db/issues/13170).
 * Tablet splitting is currently disabled for tables that are using the [TTL file expiration](../../develop/learn/ttl-data-expiration-ycql/#efficient-data-expiration-for-ttl) feature.

--- a/docs/content/stable/architecture/docdb-sharding/tablet-splitting.md
+++ b/docs/content/stable/architecture/docdb-sharding/tablet-splitting.md
@@ -300,8 +300,7 @@ In the following example, a three-node cluster is created and uses a YCSB worklo
 The following known limitations are planned to be resolved in upcoming releases:
 
 * Colocated tables cannot be split. For details, see [#4463](https://github.com/yugabyte/yugabyte-db/issues/4463).
-* In v2.14.0, tablet splitting should be disabled during an index backfill. This is expected to be fixed in 2.14.1. For details, see [#13127](https://github.com/yugabyte/yugabyte-db/issues/13127).
-* When tablet splitting is used with Point In Time Recovery (PITR), restoring to arbitrary times in the past when a tablet is in the process of splitting is not supported. For details, see [#13022](https://github.com/yugabyte/yugabyte-db/issues/13022).
+* In 2.14.0, when tablet splitting is used with Point In Time Recovery (PITR), restoring to arbitrary times in the past when a tablet is in the process of splitting is not supported. This is fixed in 2.14.1.
 * Tablet splitting is currently disabled by default for tables with cross cluster replication. It can be enabled using the [`enable_tablet_split_of_xcluster_replicated_tables`](../../../reference/configuration/yb-master/#enable-tablet-split-of-xcluster-replicated-tables) flag on master on both the producer and consumer clusters (as they will perform splits independently of one another). If using this feature after upgrade, the producer and consumer clusters should both be upgraded to 2.14.0+ before enabling the feature.
 * Tablet splitting is currently disabled during bootstrap for tables with cross cluster replication. For details, see [#13170](https://github.com/yugabyte/yugabyte-db/issues/13170).
 * Tablet splitting is currently disabled for tables that are using the [TTL file expiration](../../develop/learn/ttl-data-expiration-ycql/#efficient-data-expiration-for-ttl) feature.


### PR DESCRIPTION
`tablet splitting should be disabled during an index backfill` -> This is now fixed and in 2.14.0.
Restoring to arbitrary times for PITR is fixed in 2.14.1.