### PR TITLE
[docs] Remove need for storage class per zone

### DIFF
--- a/docs/content/preview/deploy/kubernetes/multi-zone/eks/helm-chart.md
+++ b/docs/content/preview/deploy/kubernetes/multi-zone/eks/helm-chart.md
@@ -95,7 +95,7 @@ As stated in the Prerequisites section, the default configuration in the Yugabyt
 
 ### Create a storage class
 
-We need to ensure that the storage classes used by the pods in a given zone are always pinned to that zone only.
+We need to make sure to specify `WaitForFirstConsumer` mode for the volumeBindingMode so that volumes will be provisioned according to pods' zone affinities. 
 
 Copy the contents below to a file named `storage.yaml`.
 

--- a/docs/content/preview/deploy/kubernetes/multi-zone/eks/helm-chart.md
+++ b/docs/content/preview/deploy/kubernetes/multi-zone/eks/helm-chart.md
@@ -95,7 +95,7 @@ As stated in the Prerequisites section, the default configuration in the Yugabyt
 
 ### Create a storage class
 
-We need to make sure to specify `WaitForFirstConsumer` mode for the volumeBindingMode so that volumes will be provisioned according to pods' zone affinities. 
+We need to specify `WaitForFirstConsumer` mode for the volumeBindingMode so that volumes will be provisioned according to pods' zone affinities. 
 
 Copy the contents below to a file named `storage.yaml`.
 

--- a/docs/content/preview/deploy/kubernetes/multi-zone/eks/helm-chart.md
+++ b/docs/content/preview/deploy/kubernetes/multi-zone/eks/helm-chart.md
@@ -93,7 +93,7 @@ $ eksctl create cluster \
 
 As stated in the Prerequisites section, the default configuration in the YugabyteDB Helm Chart requires Kubernetes nodes to have a total of 12 CPU cores and 45 GB RAM allocated to YugabyteDB. This can be three nodes with 4 CPU cores and 15 GB RAM allocated to YugabyteDB. The smallest AWS instance type that meets this requirement is `m5.2xlarge` which has 8 CPU cores and 32 GB RAM.
 
-### Create a storage class per zone
+### Create a storage class
 
 We need to ensure that the storage classes used by the pods in a given zone are always pinned to that zone only.
 
@@ -101,31 +101,15 @@ Copy the contents below to a file named `storage.yaml`.
 
 ```yaml
 kind: StorageClass
-apiVersion: storage.k8s.io/v1
 metadata:
-  name: standard-us-east-1a
+  name: yb-storage
+apiVersion: storage.k8s.io/v1
+allowVolumeExpansion: true
 provisioner: kubernetes.io/aws-ebs
+volumeBindingMode: WaitForFirstConsumer
 parameters:
   type: gp2
-  zone: us-east-1a
----
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: standard-us-east-1b
-provisioner: kubernetes.io/aws-ebs
-parameters:
-  type: gp2
-  zone: us-east-1b
----
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: standard-us-east-1c
-provisioner: kubernetes.io/aws-ebs
-parameters:
-  type: gp2
-  zone: us-east-1c
+  fsType: xfs
 ```
 
 Apply the above configuration to your cluster.
@@ -174,9 +158,9 @@ masterAddresses: "yb-master-0.yb-masters.yb-demo-us-east-1a.svc.cluster.local:71
 
 storage:
   master:
-    storageClass: "standard-us-east-1a"
+    storageClass: "yb-storage"
   tserver:
-    storageClass: "standard-us-east-1a"
+    storageClass: "yb-storage"
 
 replicas:
   master: 1
@@ -205,9 +189,9 @@ masterAddresses: "yb-master-0.yb-masters.yb-demo-us-east-1a.svc.cluster.local:71
 
 storage:
   master:
-    storageClass: "standard-us-east-1b"
+    storageClass: "yb-storage"
   tserver:
-    storageClass: "standard-us-east-1b"
+    storageClass: "yb-storage"
 
 replicas:
   master: 1
@@ -236,9 +220,9 @@ masterAddresses: "yb-master-0.yb-masters.yb-demo-us-east-1a.svc.cluster.local:71
 
 storage:
   master:
-    storageClass: "standard-us-east-1c"
+    storageClass: "yb-storage"
   tserver:
-    storageClass: "standard-us-east-1c"
+    storageClass: "yb-storage"
 
 replicas:
   master: 1

--- a/docs/content/preview/deploy/kubernetes/multi-zone/gke/helm-chart.md
+++ b/docs/content/preview/deploy/kubernetes/multi-zone/gke/helm-chart.md
@@ -92,9 +92,9 @@ my-regional-cluster  us-central1  1.14.10-gke.17  35.226.36.261  n1-standard-8  
 
 As stated in the Prerequisites section, the default configuration in the YugabyteDB Helm Chart requires Kubernetes nodes to have a total of 12 CPU cores and 45 GB RAM allocated to YugabyteDB. This can be three nodes with 4 CPU cores and 15 GB RAM allocated to YugabyteDB. The smallest Google Cloud machine type that meets this requirement is `n1-standard-8` which has 8 CPU cores and 30 GB RAM.
 
-### Create a storage class per zone
+### Create a storage class
 
-We need to ensure that the storage classes used by the pods in a given zone are always pinned to that zone only.
+We need to make sure to specify `WaitForFirstConsumer` mode for the volumeBindingMode so that volumes will be provisioned according to pods' zone affinities.
 
 Copy the contents below to a file named `storage.yaml`.
 
@@ -102,33 +102,13 @@ Copy the contents below to a file named `storage.yaml`.
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: standard-us-central1-a
+  name: yb-storage
 provisioner: kubernetes.io/gce-pd
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
 parameters:
-  type: pd-standard
-  replication-type: none
-  zone: us-central1-a
----
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: standard-us-central1-b
-provisioner: kubernetes.io/gce-pd
-parameters:
-  type: pd-standard
-  replication-type: none
-  zone: us-central1-b
----
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: standard-us-central1-c
-provisioner: kubernetes.io/gce-pd
-parameters:
-  type: pd-standard
-  replication-type: none
-  zone: us-central1-c
-
+  type: pd-ssd
+  fsType: xfs
 ```
 
 Apply the above configuration to your cluster.
@@ -177,9 +157,9 @@ masterAddresses: "yb-master-0.yb-masters.yb-demo-us-central1-a.svc.cluster.local
 
 storage:
   master:
-    storageClass: "standard-us-central1-a"
+    storageClass: "yb-storage"
   tserver:
-    storageClass: "standard-us-central1-a"
+    storageClass: "yb-storage"
 
 replicas:
   master: 1
@@ -208,9 +188,9 @@ masterAddresses: "yb-master-0.yb-masters.yb-demo-us-central1-a.svc.cluster.local
 
 storage:
   master:
-    storageClass: "standard-us-central1-b"
+    storageClass: "yb-storage"
   tserver:
-    storageClass: "standard-us-central1-b"
+    storageClass: "yb-storage"
 
 replicas:
   master: 1
@@ -239,9 +219,9 @@ masterAddresses: "yb-master-0.yb-masters.yb-demo-us-central1-a.svc.cluster.local
 
 storage:
   master:
-    storageClass: "standard-us-central1-c"
+    storageClass: "yb-storage"
   tserver:
-    storageClass: "standard-us-central1-c"
+    storageClass: "yb-storage"
 
 replicas:
   master: 1

--- a/docs/content/preview/deploy/kubernetes/multi-zone/gke/helm-chart.md
+++ b/docs/content/preview/deploy/kubernetes/multi-zone/gke/helm-chart.md
@@ -94,7 +94,7 @@ As stated in the Prerequisites section, the default configuration in the Yugabyt
 
 ### Create a storage class
 
-We need to make sure to specify `WaitForFirstConsumer` mode for the volumeBindingMode so that volumes will be provisioned according to pods' zone affinities.
+We need to specify `WaitForFirstConsumer` mode for the volumeBindingMode so that volumes will be provisioned according to pods' zone affinities.
 
 Copy the contents below to a file named `storage.yaml`.
 

--- a/docs/content/stable/deploy/kubernetes/multi-zone/eks/helm-chart.md
+++ b/docs/content/stable/deploy/kubernetes/multi-zone/eks/helm-chart.md
@@ -91,39 +91,23 @@ $ eksctl create cluster \
 
 As stated in the Prerequisites section, the default configuration in the YugabyteDB Helm Chart requires Kubernetes nodes to have a total of 12 CPU cores and 45 GB RAM allocated to YugabyteDB. This can be three nodes with 4 CPU cores and 15 GB RAM allocated to YugabyteDB. The smallest AWS instance type that meets this requirement is `m5.2xlarge` which has 8 CPU cores and 32 GB RAM.
 
-### Create a storage class per zone
+### Create a storage class
 
-We need to ensure that the storage classes used by the pods in a given zone are always pinned to that zone only.
+We need to make sure to specify `WaitForFirstConsumer` mode for the volumeBindingMode so that volumes will be provisioned according to pods' zone affinities. 
 
 Copy the contents below to a file named `storage.yaml`.
 
 ```yaml
 kind: StorageClass
-apiVersion: storage.k8s.io/v1
 metadata:
-  name: standard-us-east-1a
+  name: yb-storage
+apiVersion: storage.k8s.io/v1
+allowVolumeExpansion: true
 provisioner: kubernetes.io/aws-ebs
+volumeBindingMode: WaitForFirstConsumer
 parameters:
   type: gp2
-  zone: us-east-1a
----
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: standard-us-east-1b
-provisioner: kubernetes.io/aws-ebs
-parameters:
-  type: gp2
-  zone: us-east-1b
----
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: standard-us-east-1c
-provisioner: kubernetes.io/aws-ebs
-parameters:
-  type: gp2
-  zone: us-east-1c
+  fsType: xfs
 ```
 
 Apply the above configuration to your cluster.
@@ -172,9 +156,9 @@ masterAddresses: "yb-master-0.yb-masters.yb-demo-us-east-1a.svc.cluster.local:71
 
 storage:
   master:
-    storageClass: "standard-us-east-1a"
+    storageClass: "yb-storage"
   tserver:
-    storageClass: "standard-us-east-1a"
+    storageClass: "yb-storage"
 
 replicas:
   master: 1
@@ -203,9 +187,9 @@ masterAddresses: "yb-master-0.yb-masters.yb-demo-us-east-1a.svc.cluster.local:71
 
 storage:
   master:
-    storageClass: "standard-us-east-1b"
+    storageClass: "yb-storage"
   tserver:
-    storageClass: "standard-us-east-1b"
+    storageClass: "yb-storage"
 
 replicas:
   master: 1
@@ -234,9 +218,9 @@ masterAddresses: "yb-master-0.yb-masters.yb-demo-us-east-1a.svc.cluster.local:71
 
 storage:
   master:
-    storageClass: "standard-us-east-1c"
+    storageClass: "yb-storage"
   tserver:
-    storageClass: "standard-us-east-1c"
+    storageClass: "yb-storage"
 
 replicas:
   master: 1

--- a/docs/content/stable/deploy/kubernetes/multi-zone/eks/helm-chart.md
+++ b/docs/content/stable/deploy/kubernetes/multi-zone/eks/helm-chart.md
@@ -93,7 +93,7 @@ As stated in the Prerequisites section, the default configuration in the Yugabyt
 
 ### Create a storage class
 
-We need to make sure to specify `WaitForFirstConsumer` mode for the volumeBindingMode so that volumes will be provisioned according to pods' zone affinities. 
+We need to specify `WaitForFirstConsumer` mode for the volumeBindingMode so that volumes will be provisioned according to pods' zone affinities. 
 
 Copy the contents below to a file named `storage.yaml`.
 

--- a/docs/content/stable/deploy/kubernetes/multi-zone/gke/helm-chart.md
+++ b/docs/content/stable/deploy/kubernetes/multi-zone/gke/helm-chart.md
@@ -90,9 +90,9 @@ my-regional-cluster  us-central1  1.14.10-gke.17  35.226.36.261  n1-standard-8  
 
 As stated in the Prerequisites section, the default configuration in the YugabyteDB Helm Chart requires Kubernetes nodes to have a total of 12 CPU cores and 45 GB RAM allocated to YugabyteDB. This can be three nodes with 4 CPU cores and 15 GB RAM allocated to YugabyteDB. The smallest Google Cloud machine type that meets this requirement is `n1-standard-8` which has 8 CPU cores and 30 GB RAM.
 
-### Create a storage class per zone
+### Create a storage class
 
-We need to ensure that the storage classes used by the pods in a given zone are always pinned to that zone only.
+We need to make sure to specify `WaitForFirstConsumer` mode for the volumeBindingMode so that volumes will be provisioned according to pods' zone affinities.
 
 Copy the contents below to a file named `storage.yaml`.
 
@@ -100,33 +100,13 @@ Copy the contents below to a file named `storage.yaml`.
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: standard-us-central1-a
+  name: yb-storage
 provisioner: kubernetes.io/gce-pd
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
 parameters:
-  type: pd-standard
-  replication-type: none
-  zone: us-central1-a
----
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: standard-us-central1-b
-provisioner: kubernetes.io/gce-pd
-parameters:
-  type: pd-standard
-  replication-type: none
-  zone: us-central1-b
----
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: standard-us-central1-c
-provisioner: kubernetes.io/gce-pd
-parameters:
-  type: pd-standard
-  replication-type: none
-  zone: us-central1-c
-
+  type: pd-ssd
+  fsType: xfs
 ```
 
 Apply the above configuration to your cluster.
@@ -175,9 +155,9 @@ masterAddresses: "yb-master-0.yb-masters.yb-demo-us-central1-a.svc.cluster.local
 
 storage:
   master:
-    storageClass: "standard-us-central1-a"
+    storageClass: "yb-storage"
   tserver:
-    storageClass: "standard-us-central1-a"
+    storageClass: "yb-storage"
 
 replicas:
   master: 1
@@ -206,9 +186,9 @@ masterAddresses: "yb-master-0.yb-masters.yb-demo-us-central1-a.svc.cluster.local
 
 storage:
   master:
-    storageClass: "standard-us-central1-b"
+    storageClass: "yb-storage"
   tserver:
-    storageClass: "standard-us-central1-b"
+    storageClass: "yb-storage"
 
 replicas:
   master: 1
@@ -237,9 +217,9 @@ masterAddresses: "yb-master-0.yb-masters.yb-demo-us-central1-a.svc.cluster.local
 
 storage:
   master:
-    storageClass: "standard-us-central1-c"
+    storageClass: "yb-storage"
   tserver:
-    storageClass: "standard-us-central1-c"
+    storageClass: "yb-storage"
 
 replicas:
   master: 1

--- a/docs/content/stable/deploy/kubernetes/multi-zone/gke/helm-chart.md
+++ b/docs/content/stable/deploy/kubernetes/multi-zone/gke/helm-chart.md
@@ -92,7 +92,7 @@ As stated in the Prerequisites section, the default configuration in the Yugabyt
 
 ### Create a storage class
 
-We need to make sure to specify `WaitForFirstConsumer` mode for the volumeBindingMode so that volumes will be provisioned according to pods' zone affinities.
+We need to specify `WaitForFirstConsumer` mode for the volumeBindingMode so that volumes will be provisioned according to pods' zone affinities.
 
 Copy the contents below to a file named `storage.yaml`.
 


### PR DESCRIPTION
By using WaitForFirstConsumer, we can simplify these docs and avoid the need for a storage class per zone.