### PR TITLE
Add documentation for yb-ts-cli remote_bootstrap

### DIFF
--- a/docs/content/preview/admin/yb-ts-cli.md
+++ b/docs/content/preview/admin/yb-ts-cli.md
@@ -49,6 +49,7 @@ The following commands are available:
 * [flush_tablet](#flush-tablet)
 * [list_tablets](#list-tablets)
 * [reload_certificates](#reload-certificates)
+* [remote_bootstrap](#remote-bootstrap)
 * [set_flag](#set-flag)
 * [status](#status)
 
@@ -201,6 +202,22 @@ yb-ts-cli [ --server_address=<host>:<port> ] reload_certificates
 ```
 
 * *host*:*port*: The *host* and *port* of the master or tablet server. Default is `localhost:9100`.
+
+##### remote_bootstrap
+
+Trigger a remote bootstrap of a tablet from another tablet server to the specified tablet server.
+
+**Syntax**
+
+```sh
+yb-ts-cli [ --server_address=<host>:<port> ] remote_bootstrap <source_host> <tablet_id>
+```
+
+* *host*:*port*: The *host* and *port* of the tablet server running the remote bootstrap. Default is `localhost:9100`.
+* *source_host*: The *host* or *host* and *port* of the tablet server to bootstrap from.
+* *tablet_id*: The identifier of the tablet to trigger a remote bootstrap for.
+
+See [Manual remote bootstrap of failed peer](../../troubleshoot/cluster/replace_failed_peers/) for example usage.
 
 ##### set_flag
 

--- a/docs/content/preview/troubleshoot/cluster/replace_failed_peers.md
+++ b/docs/content/preview/troubleshoot/cluster/replace_failed_peers.md
@@ -22,22 +22,22 @@ Assume you have a cluster where the following applies:
 
 These are the steps to follow:
 
-- Delete the tablet from tablet data from the broken peers if necessary, by running:
+- Delete the tablet from the broken peers if necessary, by running:
 
-```
-yb-ts-cli --server_address=NODE_BAD1 delete_tablet TABLET1
-yb-ts-cli --server_address=NODE_BAD2 delete_tablet TABLET1
-```
+    ```
+    yb-ts-cli --server_address=NODE_BAD1 delete_tablet TABLET1
+    yb-ts-cli --server_address=NODE_BAD2 delete_tablet TABLET1
+    ```
 
-- Trigger a remote bootstrap of `TABLET1` from `NODE_GOOD` to `NODE_BAD`.
+- Trigger a remote bootstrap of `TABLET1` from `NODE_GOOD` to `NODE_BAD1`.
 
-```
-yb-ts-cli --server_address=NODE_BAD1 remote_bootstrap NODE_GOOD TABLET1
-```
+    ```
+    yb-ts-cli --server_address=NODE_BAD1 remote_bootstrap NODE_GOOD TABLET1
+    ```
 
-Once the remote bootstrap finishes, `NODE_BAD2` should be automatically fixed and removed from its quorum, as it has gotten a majority of healthy peers.
+Once the remote bootstrap finishes, `NODE_BAD2` should be automatically removed from the quorum and `TABLET1` fixed, as it has gotten a majority of healthy peers.
 
-In case you are unable to follow the above steps, the following steps can be followed instead to manually execute the equivalent of a remote bootstrap:
+If you can't perform the preceding steps, you can do the following to manually execute the equivalent of a remote bootstrap:
 
 - On `NODE_GOOD`, create an archive of the WALS (Raft data), RocksDB (regular) directories, intents (transactions data), and snapshots directories for `TABLET1`.
 
@@ -53,7 +53,7 @@ In case you are unable to follow the above steps, the following steps can be fol
 
 - Restart `NODE_GOOD` so it can properly observe the changed state and data on `NODE_BAD1`.
 
-At this point, `NODE_BAD2` should be automatically fixed and removed from its quorum, as it has gotten a majority of healthy peers.
+At this point, `NODE_BAD2` should be automatically removed from the quorum and `TABLET1` fixed, as it has gotten a majority of healthy peers.
 
 Note that typically, when you try to find tablet data, you would use a `find` command across the `--fs_data_dir` paths.
 

--- a/docs/content/stable/admin/yb-ts-cli.md
+++ b/docs/content/stable/admin/yb-ts-cli.md
@@ -49,6 +49,7 @@ The following commands are available:
 * [flush_tablet](#flush-tablet)
 * [list_tablets](#list-tablets)
 * [reload_certificates](#reload-certificates)
+* [remote_bootstrap](#remote-bootstrap)
 * [set_flag](#set-flag)
 * [status](#status)
 
@@ -201,6 +202,22 @@ yb-ts-cli [ --server_address=<host>:<port> ] reload_certificates
 ```
 
 * *host*:*port*: The *host* and *port* of the master or tablet server. Default is `localhost:9100`.
+
+##### remote_bootstrap
+
+Trigger a remote bootstrap of a tablet from another tablet server to the specified tablet server.
+
+**Syntax**
+
+```sh
+yb-ts-cli [ --server_address=<host>:<port> ] remote_bootstrap <source_host> <tablet_id>
+```
+
+* *host*:*port*: The *host* and *port* of the tablet server running the remote bootstrap. Default is `localhost:9100`.
+* *source_host*: The *host* or *host* and *port* of the tablet server to bootstrap from.
+* *tablet_id*: The identifier of the tablet to trigger a remote bootstrap for.
+
+See [Manual remote bootstrap of failed peer](../../troubleshoot/cluster/replace_failed_peers/) for example usage.
 
 ##### set_flag
 

--- a/docs/content/v2.12/admin/yb-ts-cli.md
+++ b/docs/content/v2.12/admin/yb-ts-cli.md
@@ -48,6 +48,7 @@ The following commands are available:
 * [flush_all_tablets](#flush-all-tablets)
 * [flush_tablet](#flush-tablet)
 * [list_tablets](#list-tablets)
+* [remote_bootstrap](#remote-bootstrap)
 * [set_flag](#set-flag)
 * [status](#status)
 
@@ -188,6 +189,22 @@ yb-ts-cli [ --server_address=<host>:<port> ] list_tablets
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
+
+##### remote_bootstrap
+
+Trigger a remote bootstrap of a tablet from another tablet server to the specified tablet server.
+
+**Syntax**
+
+```sh
+yb-ts-cli [ --server_address=<host>:<port> ] remote_bootstrap <source_host> <tablet_id>
+```
+
+* *host*:*port*: The *host* and *port* of the tablet server running the remote bootstrap. Default is `localhost:9100`.
+* *source_host*: The *host* or *host* and *port* of the tablet server to bootstrap from.
+* *tablet_id*: The identifier of the tablet to trigger a remote bootstrap for.
+
+See [Manual remote bootstrap of failed peer](../../troubleshoot/cluster/replace_failed_peers/) for example usage.
 
 ##### set_flag
 

--- a/docs/content/v2.8/admin/yb-ts-cli.md
+++ b/docs/content/v2.8/admin/yb-ts-cli.md
@@ -48,6 +48,7 @@ The following commands are available:
 * [flush_all_tablets](#flush-all-tablets)
 * [flush_tablet](#flush-tablet)
 * [list_tablets](#list-tablets)
+* [remote_bootstrap](#remote-bootstrap)
 * [set_flag](#set-flag)
 * [status](#status)
 
@@ -188,6 +189,22 @@ yb-ts-cli [ --server_address=<host>:<port> ] list_tablets
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
+
+##### remote_bootstrap
+
+Trigger a remote bootstrap of a tablet from another tablet server to the specified tablet server.
+
+**Syntax**
+
+```sh
+yb-ts-cli [ --server_address=<host>:<port> ] remote_bootstrap <source_host> <tablet_id>
+```
+
+* *host*:*port*: The *host* and *port* of the tablet server running the remote bootstrap. Default is `localhost:9100`.
+* *source_host*: The *host* or *host* and *port* of the tablet server to bootstrap from.
+* *tablet_id*: The identifier of the tablet to trigger a remote bootstrap for.
+
+See [Manual remote bootstrap of failed peer](../../troubleshoot/cluster/replace_failed_peers/) for example usage.
 
 ##### set_flag
 


### PR DESCRIPTION
This PR adds documentation for the `yb-ts-cli remote_bootstrap` command added in dec0805927f6b77f0e6b8918ef69b6efa5a9ba30 and backported to 2.8, 2.12, and 2.14.

Resolves #14053