### PR TITLE
Added pgsql_read_latency because it needed tracking for Docdb. Then co…

### DIFF
--- a/src/yb/tablet/tablet.cc
+++ b/src/yb/tablet/tablet.cc
@@ -1407,7 +1407,8 @@ Status Tablet::HandleRedisReadRequest(CoarseTimePoint deadline,
   auto scoped_read_operation = CreateNonAbortableScopedRWOperation(deadline);
   RETURN_NOT_OK(scoped_read_operation);
 
-  ScopedTabletMetricsTracker metrics_tracker(metrics_->redis_read_latency);
+  ScopedTabletMetricsTracker metrics_tracker(metrics_->ql_read_latency);/*changed to redis_read_latency  to ql_read_latency 
+Since  ql_read_latency, redis_read_latency,  pgsql_read_latency as  only one  of them can be non-zero for Table type */
 
   docdb::RedisReadOperation doc_op(redis_read_request, doc_db(), deadline, read_time);
   RETURN_NOT_OK(doc_op.Execute());
@@ -1535,8 +1536,8 @@ Status Tablet::HandlePgsqlReadRequest(
   auto scoped_read_operation = CreateNonAbortableScopedRWOperation(deadline);
   RETURN_NOT_OK(scoped_read_operation);
   // TODO(neil) Work on metrics for PGSQL.
-  // ScopedTabletMetricsTracker metrics_tracker(metrics_->pgsql_read_latency);
-
+  ScopedTabletMetricsTracker metrics_tracker(metrics_->ql_read_latency);
+//Added pgsql_read_latency so it would  be in sync with other  latencies 
   const shared_ptr<tablet::TableInfo> table_info =
       VERIFY_RESULT(metadata_->GetTableInfo(pgsql_read_request.table_id()));
   Result<TransactionOperationContext> txn_op_ctx =


### PR DESCRIPTION
Added pgsql_read_latency because it needed tracking for Docdb. Then converted pgsql/redis/ql all to ql_read_latency as only one of them can be non-zero.



<img width="623" alt="Screen Shot 2022-10-02 at 2 14 31 PM" src="https://user-images.githubusercontent.com/70077608/193469563-aafc7218-ba33-4f0a-942a-d4d608d26221.png">
<img width="946" alt="Screen Shot 2022-10-02 at 2 13 59 PM" src="https://user-images.githubusercontent.com/70077608/193469567-b94ba679-0d35-4976-a9a5-912d1b808308.png">

