### PR TITLE
[doc] Fix cdc_wal_retention_time_secs gflag description

### DIFF
--- a/docs/content/preview/reference/configuration/yb-master.md
+++ b/docs/content/preview/reference/configuration/yb-master.md
@@ -666,13 +666,13 @@ For information on other CDC configuration flags, see [YB-TServer's CDC flags](.
 
 ##### --cdc_state_table_num_tablets
 
-The number of tablets to use when creating the CDC state table.
+The number of tablets to use when creating the CDC state table. Used in both xCluster and CDCSDK.
 
 Default: `0` (Use the same default number of tablets as for regular tables.)
 
 ##### --cdc_wal_retention_time_secs
 
-WAL retention time, in seconds, to be used for tables for which a CDC stream was created. If you change the value, make sure that the corresponding flag is updated with the same value on YB-TServer.
+WAL retention time, in seconds, to be used for tables for which a CDC stream was created. Used in both xCluster and CDCSDK.
 
 Default: `14400` (4 hours)
 

--- a/docs/content/stable/reference/configuration/yb-master.md
+++ b/docs/content/stable/reference/configuration/yb-master.md
@@ -724,13 +724,13 @@ For other CDC configuration flags, see [YB-TServer's CDC flags](../yb-tserver/#c
 
 ##### --cdc_state_table_num_tablets
 
-The number of tablets to use when creating the CDC state table.
+The number of tablets to use when creating the CDC state table. Used in both xCluster and CDCSDK.
 
 Default: `0` (Use the same default number of tablets as for regular tables.)
 
 ##### --cdc_wal_retention_time_secs
 
-WAL retention time, in seconds, to be used for tables for which a CDC stream was created. If you change the value, make sure that the [`yb-tserver --cdc_wal_retention_time_secs`](../yb-tserver/#cdc-wal-retention-time-secs) flag is also updated with the same value.
+WAL retention time, in seconds, to be used for tables for which a CDC stream was created. Used in both xCluster and CDCSDK.
 
 Default: `14400` (4 hours)
 


### PR DESCRIPTION
Removing comment about updating the flag on tservers as this is a master only flag.