### PR TITLE
[docs] [#14484] Fix Ubuntu build instructions

### DIFF
--- a/docs/content/preview/contribute/core-database/build-from-src-centos.md
+++ b/docs/content/preview/contribute/core-database/build-from-src-centos.md
@@ -72,7 +72,7 @@ We also use [Linuxbrew](https://github.com/linuxbrew/brew) to provide some of th
 Linuxbrew allows us to create a portable package that contains its own copy of glibc and can be installed on most Linux distributions.
 However, we are transitioning away from using Linuxbrew and towards native toolchains on various platforms.
 
-Our build scripts may automatically install Linuxbrew in a directory such as `/opt/yb-build/brew/linuxbrew-<version>` or `~/.linuxbrew-yb-build/linuxbrew-<version>`.
+Our build scripts may automatically install Linuxbrew in a directory such as `/opt/yb-build/brew/linuxbrew-<version>`.
 There is no need to add any of those directories to PATH.
 
 {{< /note >}}

--- a/docs/content/preview/contribute/core-database/build-from-src-ubuntu.md
+++ b/docs/content/preview/contribute/core-database/build-from-src-ubuntu.md
@@ -50,8 +50,26 @@ Update packages on your system, install development tools and additional package
 
 ```sh
 sudo apt-get update
-sudo apt-get install -y autoconf cmake curl git libtool maven ninja-build pkg-config python3-pip \
-                        python3-venv rsync zip pkg-config git libtool locales pkg-config git
+packages=(
+  autoconf
+  cmake
+  curl
+  git
+  git
+  git
+  libtool
+  libtool
+  locales
+  maven
+  ninja-build
+  patchelf
+  pkg-config
+  python3-pip
+  python3-venv
+  rsync
+  zip
+)
+sudo apt-get install -y "${packages[@]}"
 sudo locale-gen en_US.UTF-8
 ```
 
@@ -60,11 +78,6 @@ Assuming this repository is checked out in `~/code/yugabyte-db`, do the followin
 ```sh
 cd ~/code/yugabyte-db
 ./yb_build.sh release --no-linuxbrew
-```
-
-To create a release archive suitable for deployment on a cluster node:
-```
-./yb_release --build_args="--no-linuxbrew"
 ```
 
 {{< note title="Note" >}}

--- a/docs/content/preview/contribute/core-database/build-from-src-ubuntu.md
+++ b/docs/content/preview/contribute/core-database/build-from-src-ubuntu.md
@@ -50,42 +50,31 @@ Update packages on your system, install development tools and additional package
 
 ```sh
 sudo apt-get update
-sudo apt-get install uuid-dev libbz2-dev libreadline-dev maven ninja-build \
-                     cmake curl rsync python3-pip python3-venv zip autoconf libtool \
-                     pkg-config libssl1.0-dev libicu-dev bison flex \
-                     libncurses5-dev
+sudo apt-get install -y autoconf cmake curl git libtool maven ninja-build pkg-config python3-pip \
+                        python3-venv rsync zip pkg-config git libtool locales pkg-config git
+sudo locale-gen en_US.UTF-8
 ```
 
 Assuming this repository is checked out in `~/code/yugabyte-db`, do the following:
 
 ```sh
 cd ~/code/yugabyte-db
-./yb_build.sh release
+./yb_build.sh release --no-linuxbrew
+```
+
+To create a release archive suitable for deployment on a cluster node:
+```
+./yb_release --build_args="--no-linuxbrew"
 ```
 
 {{< note title="Note" >}}
 
-If you see errors, such as `g++: internal compiler error: Killed`, the system has probably run out of memory.
+If you see errors, such as `internal compiler error: Killed`, the system has probably run out of memory.
 Try again by running the build script with less concurrency, for example, `-j1`.
 
 {{< /note >}}
 
 The command above will build the release configuration, add the C++ binaries into the `build/release-gcc-dynamic-ninja` directory, and create a `build/latest` symlink to that directory.
-
-
-{{< note title="Note" >}}
-If you are getting errors in the form of:
-```
-uild/release-gcc-dynamic-ninja/postgres_build/src/backend/libpq/be-secure-openssl.o: In function `my_sock_read':
-src/postgres/src/backend/libpq/be-secure-openssl.c:665: undefined reference to `BIO_get_data'
-build/release-gcc-dynamic-ninja/postgres_build/src/backend/libpq/be-secure-openssl.o: In function `my_sock_write':
-src/postgres/src/backend/libpq/be-secure-openssl.c:685: undefined reference to `BIO_get_data'
-```
-The code is probably not finding the right path for libssl1.0. Try a clean build `./yb_build.sh --clean release`.
-If that doesn't work, look into your $PATH if some other openssl version path is being used.
-{{< /note >}}
-
-
 
 {{< tip title="Tip" >}}
 


### PR DESCRIPTION
Remove some unneeded packages and do not mention an outdated version of OpenSSL. Add --no-linuxbrew until we make sure we automatically disable the use of Linuxbrew on Ubuntu.