### PR TITLE
[docs] fix broken links

### DIFF
--- a/docs/content/preview/reference/drivers/nodejs/postgres-pg-reference.md
+++ b/docs/content/preview/reference/drivers/nodejs/postgres-pg-reference.md
@@ -138,7 +138,7 @@ client
 
 To build a Node.js application that communicates securely over SSL, get the root certificate (`ca.crt`) of the YugabyteDB Cluster. If certificates are not generated yet, follow the instructions in [Create server certificates](../../../../secure/tls-encryption/server-certificates/).
 
-Because a YugabyteDB Managed cluster is always configured with SSL/TLS, you don't have to generate any certificate but only set the client-side SSL configuration. To fetch your root certificate, refer to [CA certificate](../../../../yugabyte-cloud/cloud-secure-clusters/cloud-authentication/#download-your-cluster-certificate).
+Because a YugabyteDB Managed cluster is always configured with SSL/TLS, you don't have to generate any certificate but only set the client-side SSL configuration. To fetch your root certificate, refer to [Download your cluster certificate](../../../../yugabyte-cloud/cloud-secure-clusters/cloud-authentication/#download-your-cluster-certificate).
 
 The node-postgres driver allows you to avoid including the parameters like `sslcert`, `sslkey`, `sslrootcert`, or `sslmode` in the connection string. You can pass the object which includes `connectionString` and `ssl` object which has various fields including the following:
 

--- a/docs/content/preview/reference/drivers/nodejs/postgres-pg-reference.md
+++ b/docs/content/preview/reference/drivers/nodejs/postgres-pg-reference.md
@@ -138,7 +138,7 @@ client
 
 To build a Node.js application that communicates securely over SSL, get the root certificate (`ca.crt`) of the YugabyteDB Cluster. If certificates are not generated yet, follow the instructions in [Create server certificates](../../../../secure/tls-encryption/server-certificates/).
 
-Because a YugabyteDB Managed cluster is always configured with SSL/TLS, you don't have to generate any certificate but only set the client-side SSL configuration. To fetch your root certificate, refer to [CA certificate](../../../yugabyte-cloud/cloud-connect/connect-applications/).
+Because a YugabyteDB Managed cluster is always configured with SSL/TLS, you don't have to generate any certificate but only set the client-side SSL configuration. To fetch your root certificate, refer to [CA certificate](../../../../yugabyte-cloud/cloud-connect/connect-applications/#cluster-certificate).
 
 The node-postgres driver allows you to avoid including the parameters like `sslcert`, `sslkey`, `sslrootcert`, or `sslmode` in the connection string. You can pass the object which includes `connectionString` and `ssl` object which has various fields including the following:
 

--- a/docs/content/preview/reference/drivers/nodejs/postgres-pg-reference.md
+++ b/docs/content/preview/reference/drivers/nodejs/postgres-pg-reference.md
@@ -138,7 +138,7 @@ client
 
 To build a Node.js application that communicates securely over SSL, get the root certificate (`ca.crt`) of the YugabyteDB Cluster. If certificates are not generated yet, follow the instructions in [Create server certificates](../../../../secure/tls-encryption/server-certificates/).
 
-Because a YugabyteDB Managed cluster is always configured with SSL/TLS, you don't have to generate any certificate but only set the client-side SSL configuration. To fetch your root certificate, refer to [CA certificate](../../../../yugabyte-cloud/cloud-connect/connect-applications/#cluster-certificate).
+Because a YugabyteDB Managed cluster is always configured with SSL/TLS, you don't have to generate any certificate but only set the client-side SSL configuration. To fetch your root certificate, refer to [CA certificate](../../../../yugabyte-cloud/cloud-secure-clusters/cloud-authentication/#download-your-cluster-certificate).
 
 The node-postgres driver allows you to avoid including the parameters like `sslcert`, `sslkey`, `sslrootcert`, or `sslmode` in the connection string. You can pass the object which includes `connectionString` and `ssl` object which has various fields including the following:
 

--- a/docs/content/preview/yugabyte-platform/security/enable-encryption-in-transit.md
+++ b/docs/content/preview/yugabyte-platform/security/enable-encryption-in-transit.md
@@ -406,7 +406,7 @@ If you created your universe with the Client-to-Node TLS option enabled, then yo
 
 To use TLS from a different client, consult the client-specific documentation. For example, if you are using a PostgreSQL JDBC driver to connect to YugabyteDB, see [Configuring the client](https://jdbc.postgresql.org/documentation/head/ssl-client.html) for more details.
 
-If you are using PostgreSQL/YugabyteDB JDBC driver with SSL, you need to convert the certificates to DER format. To do this, you need to perform only steps 6 and 7 from [Set up SSL certificates for Java applications](../../../develop/build-apps/java/ysql-jdbc-ssl/#set-up-ssl-certificates-for-java-applications) section after downloading the certificates.
+If you are using PostgreSQL/YugabyteDB JDBC driver with SSL, you need to convert the certificates to DER format. To do this, you need to perform only steps 6 and 7 from [Set up SSL certificates for Java applications](../../../reference/drivers/java/postgres-jdbc-reference/#set-up-ssl-certificates-for-java-applications) section after downloading the certificates.
 
 ### Connect to a YCQL endpoint with TLS
 


### PR DESCRIPTION
- Set up SSL for java applications : https://deploy-preview-14807--infallible-bardeen-164bc9.netlify.app/preview/yugabyte-platform/security/enable-encryption-in-transit/#connect-to-a-ysql-endpoint-with-tls
- cluster certificate link for Managed : https://deploy-preview-14807--infallible-bardeen-164bc9.netlify.app/preview/reference/drivers/nodejs/postgres-pg-reference/#configure-ssl-tls