### PR TITLE
[docs][PLAT-5834] Use env vars in K8s service account creation steps

### DIFF
--- a/docs/content/preview/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/kubernetes.md
+++ b/docs/content/preview/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/kubernetes.md
@@ -79,15 +79,19 @@ Before you install YugabyteDB on a Kubernetes cluster, perform the following:
 
 The secret of a service account can be used to generate a `kubeconfig` file. This account should not be deleted once it is in use by YugabyteDB Anywhere. 
 
-Set the `YBA_NAMESPACE` environment variable to the namespace where you have installed YugabyteDB Anywhere. This variable will used by the rest of the commands from this document.
+Set the `YBA_NAMESPACE` environment variable to the namespace where your YugabyteDB Anywhere is installed, as follows:
 
 ```sh
 export YBA_NAMESPACE="yb-platform"
 ```
 
+Note that the `YBA_NAMESPACE` variable is used in the commands throughout this document.
+
 Run the following `kubectl` command to apply the YAML file:
 
 ```sh
+export YBA_NAMESPACE="yb-platform"
+
 kubectl apply -f https://raw.githubusercontent.com/yugabyte/charts/master/rbac/yugabyte-platform-universe-management-sa.yaml -n ${YBA_NAMESPACE}
 ```
 
@@ -106,6 +110,8 @@ The tasks you can perform depend on your access level.
 **Global Admin** can grant broad cluster level admin access by executing the following command:
 
 ```sh
+export YBA_NAMESPACE="yb-platform"
+
 curl -s https://raw.githubusercontent.com/yugabyte/charts/master/rbac/platform-global-admin.yaml \
   | sed "s/namespace: <SA_NAMESPACE>/namespace: ${YBA_NAMESPACE}"/g \
   | kubectl apply -n ${YBA_NAMESPACE} -f -
@@ -114,6 +120,8 @@ curl -s https://raw.githubusercontent.com/yugabyte/charts/master/rbac/platform-g
 **Global Restricted** can grant access to only the specific cluster roles to create and manage YugabyteDB universes across all the namespaces in a cluster using the following command:
 
 ```sh
+export YBA_NAMESPACE="yb-platform"
+
 curl -s https://raw.githubusercontent.com/yugabyte/charts/master/rbac/platform-global.yaml \
   | sed "s/namespace: <SA_NAMESPACE>/namespace: ${YBA_NAMESPACE}"/g \
   | kubectl apply -n ${YBA_NAMESPACE} -f -
@@ -124,6 +132,8 @@ This contains ClusterRoles and ClusterRoleBindings for the required set of permi
 **Namespace Admin** can grant namespace-level admin access by using the following command:
 
 ```sh
+export YBA_NAMESPACE="yb-platform"
+
 curl -s https://raw.githubusercontent.com/yugabyte/charts/master/rbac/platform-namespaced-admin.yaml \
   | sed "s/namespace: <SA_NAMESPACE>/namespace: ${YBA_NAMESPACE}"/g \
   | kubectl apply -n ${YBA_NAMESPACE} -f -
@@ -136,6 +146,8 @@ If you have multiple target namespaces, then you have to apply the YAML in all o
 For example, if your goal is to allow YugabyteDB Anywhere to manage YugabyteDB universes in the namespaces `yb-db-demo` and `yb-db-us-east4-a` (the target namespaces), then you need to apply in both the target namespaces, as follows:
 
 ```sh
+export YBA_NAMESPACE="yb-platform"
+
 curl -s https://raw.githubusercontent.com/yugabyte/charts/master/rbac/platform-namespaced.yaml \
   | sed "s/namespace: <SA_NAMESPACE>/namespace: ${YBA_NAMESPACE}"/g \
   | kubectl apply -n ${YBA_NAMESPACE} -f -
@@ -154,6 +166,8 @@ You can create a `kubeconfig` file for the previously created `yugabyte-platform
 2. Run the following command to generate the `kubeconfig` file:
 
     ```sh
+    export YBA_NAMESPACE="yb-platform"
+
     python generate_kubeconfig.py -s yugabyte-platform-universe-management -n ${YBA_NAMESPACE}
     ```
 

--- a/docs/content/preview/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/kubernetes.md
+++ b/docs/content/preview/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/kubernetes.md
@@ -77,7 +77,7 @@ Before you install YugabyteDB on a Kubernetes cluster, perform the following:
 
 ### Service account
 
-The secret of a service account can be used to generate a `kubeconfig` file. This account should not be deleted once it is in use by YugabyteDB Anywhere. 
+The secret of a service account can be used to generate a `kubeconfig` file. This account should not be deleted once it is in use by YugabyteDB Anywhere.
 
 Set the `YBA_NAMESPACE` environment variable to the namespace where your YugabyteDB Anywhere is installed, as follows:
 

--- a/docs/content/preview/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/kubernetes.md
+++ b/docs/content/preview/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/kubernetes.md
@@ -77,12 +77,18 @@ Before you install YugabyteDB on a Kubernetes cluster, perform the following:
 
 ### Service account
 
-The secret of a service account can be used to generate a `kubeconfig` file. This account should not be deleted once it is in use by YugabyteDB Anywhere. *namespace* in the service account creation command can be replaced with the desired namespace in which to install YugabyteDB.
+The secret of a service account can be used to generate a `kubeconfig` file. This account should not be deleted once it is in use by YugabyteDB Anywhere. 
+
+Set the `YBA_NAMESPACE` environment variable to the namespace where you have installed YugabyteDB Anywhere. This variable will used by the rest of the commands from this document.
+
+```sh
+export YBA_NAMESPACE="yb-platform"
+```
 
 Run the following `kubectl` command to apply the YAML file:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/yugabyte/charts/master/rbac/yugabyte-platform-universe-management-sa.yaml -n <namespace>
+kubectl apply -f https://raw.githubusercontent.com/yugabyte/charts/master/rbac/yugabyte-platform-universe-management-sa.yaml -n ${YBA_NAMESPACE}
 ```
 
 Expect the following output:
@@ -101,47 +107,29 @@ The tasks you can perform depend on your access level.
 
 ```sh
 curl -s https://raw.githubusercontent.com/yugabyte/charts/master/rbac/platform-global-admin.yaml \
-  | sed "s/namespace: <SA_NAMESPACE>/namespace: <namespace>"/g \
-  | kubectl apply -n <namespace> -f -
+  | sed "s/namespace: <SA_NAMESPACE>/namespace: ${YBA_NAMESPACE}"/g \
+  | kubectl apply -n ${YBA_NAMESPACE} -f -
 ```
 
 **Global Restricted** can grant access to only the specific cluster roles to create and manage YugabyteDB universes across all the namespaces in a cluster using the following command:
 
 ```sh
 curl -s https://raw.githubusercontent.com/yugabyte/charts/master/rbac/platform-global.yaml \
-  | sed "s/namespace: <SA_NAMESPACE>/namespace: <namespace>"/g \
-  | kubectl apply -n <namespace> -f -
+  | sed "s/namespace: <SA_NAMESPACE>/namespace: ${YBA_NAMESPACE}"/g \
+  | kubectl apply -n ${YBA_NAMESPACE} -f -
 ```
 
 This contains ClusterRoles and ClusterRoleBindings for the required set of permissions.
-
-The following command can be used to validate the service account:
-
-```sh
-kubectl auth can-i \
---as system:serviceaccount:<namespace>:yugabyte-platform-universe-management \
-{get|create|delete|list} \
-{namespaces|poddisruptionbudgets|services|statefulsets|secrets|pods|pvc}
-```
 
 **Namespace Admin** can grant namespace-level admin access by using the following command:
 
 ```sh
 curl -s https://raw.githubusercontent.com/yugabyte/charts/master/rbac/platform-namespaced-admin.yaml \
-  | sed "s/namespace: <SA_NAMESPACE>/namespace: <namespace>"/g \
-  | kubectl apply -n <namespace> -f -
+  | sed "s/namespace: <SA_NAMESPACE>/namespace: ${YBA_NAMESPACE}"/g \
+  | kubectl apply -n ${YBA_NAMESPACE} -f -
 ```
 
 If you have multiple target namespaces, then you have to apply the YAML in all of them.
-
-The following command can be used to validate the service account:
-
-```sh
-kubectl auth can-i \
---as system:serviceaccount:<namespace>:yugabyte-platform-universe-management \
-{get|create|delete|list|patch} \
-{namespaces|poddisruptionbudgets|services|statefulsets|secrets|pods|pvc}
-```
 
 **Namespace Restricted** can grant access to only the specific roles required to create and manage YugabyteDB universes in a particular namespace. Contains Roles and RoleBindings for the required set of permissions.
 
@@ -149,18 +137,8 @@ For example, if your goal is to allow YugabyteDB Anywhere to manage YugabyteDB u
 
 ```sh
 curl -s https://raw.githubusercontent.com/yugabyte/charts/master/rbac/platform-namespaced.yaml \
-  | sed "s/namespace: <SA_NAMESPACE>/namespace: <namespace>"/g \
-  | kubectl apply -n <namespace> -f -
-```
-
-The following command can be used to validate the service account:
-
-```sh
-kubectl auth can-i \
---as system:serviceaccount:<namespace>:yugabyte-platform-universe-management \
---namespace {namespace} \
-{get|delete|list} \
-{namespaces|poddisruptionbudgets|services|statefulsets|secrets|pods|pvc}
+  | sed "s/namespace: <SA_NAMESPACE>/namespace: ${YBA_NAMESPACE}"/g \
+  | kubectl apply -n ${YBA_NAMESPACE} -f -
 ```
 
 ### kubeconfig file
@@ -176,7 +154,7 @@ You can create a `kubeconfig` file for the previously created `yugabyte-platform
 2. Run the following command to generate the `kubeconfig` file:
 
     ```sh
-    python generate_kubeconfig.py -s yugabyte-platform-universe-management -n <namespace>
+    python generate_kubeconfig.py -s yugabyte-platform-universe-management -n ${YBA_NAMESPACE}
     ```
 
     Expect the following output:

--- a/docs/content/stable/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/kubernetes.md
+++ b/docs/content/stable/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/kubernetes.md
@@ -75,12 +75,22 @@ Before you install YugabyteDB on a Kubernetes cluster, perform the following:
 
 ### Service account
 
-The secret of a service account can be used to generate a `kubeconfig` file. This account should not be deleted once it is in use by YugabyteDB Anywhere. *namespace* in the service account creation command can be replaced with the desired namespace in which to install YugabyteDB.
+The secret of a service account can be used to generate a `kubeconfig` file. This account should not be deleted once it is in use by YugabyteDB Anywhere.
+
+Set the `YBA_NAMESPACE` environment variable to the namespace where your YugabyteDB Anywhere is installed, as follows:
+
+```sh
+export YBA_NAMESPACE="yb-platform"
+```
+
+Note that the `YBA_NAMESPACE` variable is used in the commands throughout this document.
 
 Run the following `kubectl` command to apply the YAML file:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/yugabyte/charts/master/rbac/yugabyte-platform-universe-management-sa.yaml -n <namespace>
+export YBA_NAMESPACE="yb-platform"
+
+kubectl apply -f https://raw.githubusercontent.com/yugabyte/charts/master/rbac/yugabyte-platform-universe-management-sa.yaml -n ${YBA_NAMESPACE}
 ```
 
 Expect the following output:
@@ -98,67 +108,47 @@ The tasks you can perform depend on your access level.
 **Global Admin** can grant broad cluster level admin access by executing the following command:
 
 ```sh
+export YBA_NAMESPACE="yb-platform"
+
 curl -s https://raw.githubusercontent.com/yugabyte/charts/master/rbac/platform-global-admin.yaml \
-  | sed "s/namespace: <SA_NAMESPACE>/namespace: <namespace>"/g \
-  | kubectl apply -n <namespace> -f -
+  | sed "s/namespace: <SA_NAMESPACE>/namespace: ${YBA_NAMESPACE}"/g \
+  | kubectl apply -n ${YBA_NAMESPACE} -f -
 ```
 
 **Global Restricted** can grant access to only the specific cluster roles to create and manage YugabyteDB universes across all the namespaces in a cluster using the following command:
 
 ```sh
+export YBA_NAMESPACE="yb-platform"
+
 curl -s https://raw.githubusercontent.com/yugabyte/charts/master/rbac/platform-global.yaml \
-  | sed "s/namespace: <SA_NAMESPACE>/namespace: <namespace>"/g \
-  | kubectl apply -n <namespace> -f -
+  | sed "s/namespace: <SA_NAMESPACE>/namespace: ${YBA_NAMESPACE}"/g \
+  | kubectl apply -n ${YBA_NAMESPACE} -f -
 ```
 
 This contains ClusterRoles and ClusterRoleBindings for the required set of permissions.
 
-The following command can be used to validate the service account:
-
-```sh
-kubectl auth can-i \
---as system:serviceaccount:<namespace>:yugabyte-platform-universe-management \
-{get|create|delete|list} \
-{namespaces|poddisruptionbudgets|services|statefulsets|secrets|pods|pvc}
-```
-
 **Namespace Admin** can grant namespace-level admin access by using the following command:
 
 ```sh
+export YBA_NAMESPACE="yb-platform"
+
 curl -s https://raw.githubusercontent.com/yugabyte/charts/master/rbac/platform-namespaced-admin.yaml \
-  | sed "s/namespace: <SA_NAMESPACE>/namespace: <namespace>"/g \
-  | kubectl apply -n <namespace> -f -
+  | sed "s/namespace: <SA_NAMESPACE>/namespace: ${YBA_NAMESPACE}"/g \
+  | kubectl apply -n ${YBA_NAMESPACE} -f -
 ```
 
 If you have multiple target namespaces, then you have to apply the YAML in all of them.
-
-The following command can be used to validate the service account:
-
-```sh
-kubectl auth can-i \
---as system:serviceaccount:<namespace>:yugabyte-platform-universe-management \
-{get|create|delete|list|patch} \
-{namespaces|poddisruptionbudgets|services|statefulsets|secrets|pods|pvc}
-```
 
 **Namespace Restricted** can grant access to only the specific roles required to create and manage YugabyteDB universes in a particular namespace. Contains Roles and RoleBindings for the required set of permissions.
 
 For example, if your goal is to allow YugabyteDB Anywhere to manage YugabyteDB universes in the namespaces `yb-db-demo` and `yb-db-us-east4-a` (the target namespaces), then you need to apply in both the target namespaces, as follows:
 
 ```sh
+export YBA_NAMESPACE="yb-platform"
+
 curl -s https://raw.githubusercontent.com/yugabyte/charts/master/rbac/platform-namespaced.yaml \
-  | sed "s/namespace: <SA_NAMESPACE>/namespace: <namespace>"/g \
-  | kubectl apply -n <namespace> -f -
-```
-
-The following command can be used to validate the service account:
-
-```sh
-kubectl auth can-i \
---as system:serviceaccount:<namespace>:yugabyte-platform-universe-management \
---namespace {namespace} \
-{get|delete|list} \
-{namespaces|poddisruptionbudgets|services|statefulsets|secrets|pods|pvc}
+  | sed "s/namespace: <SA_NAMESPACE>/namespace: ${YBA_NAMESPACE}"/g \
+  | kubectl apply -n ${YBA_NAMESPACE} -f -
 ```
 
 ### `kubeconfig` file
@@ -174,7 +164,9 @@ You can create a `kubeconfig` file for the previously created `yugabyte-platform
 2. Run the following command to generate the `kubeconfig` file:
 
     ```sh
-    python generate_kubeconfig.py -s yugabyte-platform-universe-management -n <namespace>
+    export YBA_NAMESPACE="yb-platform"
+
+    python generate_kubeconfig.py -s yugabyte-platform-universe-management -n ${YBA_NAMESPACE}
     ```
 
     <br>Expect the following output:


### PR DESCRIPTION
Summary:
The <namespace> placeholder and the <SA_NAMESPACE> from the RBAC YAML were creating confusion on which one to replace while running the commands.

With this change we set an environment variable and use it across all the commands, so that users can just set one variable and easily execute all the commands.

Fixes https://github.com/yugabyte/yugabyte-db/issues/11475

Test Plan:
- Tried all the commands from this page with the variable value set and without it.