### PR TITLE
[docs][ybmaster] Fix default for 2 flags

### DIFF
--- a/docs/content/preview/reference/configuration/yb-master.md
+++ b/docs/content/preview/reference/configuration/yb-master.md
@@ -248,7 +248,7 @@ For a typical deployment, values used for Raft and the write ahead log (WAL) fla
 
 The duration, in seconds, after which a follower is considered to be failed because the leader has not received a heartbeat. The follower is then evicted from the configuration and the data is re-replicated elsewhere.
 
-Default: `900` (15 minutes)
+Default: `7200` (2 hours)
 
 The `--follower_unavailable_considered_failed_sec` value should match the value for [`--log_min_seconds_to_retain`](#log-min-seconds-to-retain).
 
@@ -308,7 +308,9 @@ Default: `1`
 
 The minimum duration, in seconds, to retain WAL segments, regardless of durability requirements. WAL segments can be retained for a longer amount of time, if they are necessary for correct restart. This value should be set long enough such that a tablet server which has temporarily failed can be restarted in the given time period.
 
-Default: `900` (15 minutes)
+Default: `7200` (2 hours)
+
+The `--log_min_seconds_to_retain` value should match the value for [`--follower_unavailable_considered_failed_sec`](#follower-unavailable-considered-failed-sec).
 
 ##### --log_min_segments_to_retain
 


### PR DESCRIPTION
Update default for follower_unavailable_considered_failed_sec and log_min_seconds_to_retain flags

@netlify /preview/reference/configuration/yb-master/#follower-unavailable-considered-failed-sec