### PR TITLE
[Docs][#15105] Updating the documentation for referance page of yugabyted CLI

### DIFF
--- a/docs/content/preview/reference/configuration/insecure-yugabyted-examples.md
+++ b/docs/content/preview/reference/configuration/insecure-yugabyted-examples.md
@@ -8,11 +8,11 @@ rightNav:
   hideH4: true
 ---
 
-YugabyteDB uses a 2-server architecture with YB-TServers managing the data and YB-Masters managing the metadata. However, this can introduce a burden on new users who want to get started right away. To manage YugabyteDB for testing and learning purposes, you can use `yugabyted`, which is a database server that acts as a parent server across the [`yb-tserver`](../yb-tserver/) and [`yb-master`](../yb-master/) servers. yugabyted also provides a UI similar to the YugabyteDB Anywhere UI, with a data placement map and metrics dashboard.
+YugabyteDB uses a two-server architecture, with YB-TServers managing the data and YB-Masters managing the metadata. However, this can introduce a burden on new users who want to get started right away. To manage YugabyteDB for testing and learning purposes, you can use `yugabyted`, which is a database server that acts as a parent server across the [`yb-tserver`](../yb-tserver/) and [`yb-master`](../yb-master/) servers. yugabyted also provides a UI similar to the YugabyteDB Anywhere UI, with a data placement map and metrics dashboard.
 
 The `yugabyted` executable file is located in the YugabyteDB home's `bin` directory.
 
-Using yugabyted, you can create single-node clusters, and, using the `--join` flag in the `start` command, multi-node clusters.
+Using yugabyted, you can create single-node clusters. To create multi-node clusters, you would need to use the `--join` flag in the `start` command.
 
 Note that yugabyted is not recommended for production deployments. For production deployments with fully-distributed multi-node clusters, use [`yb-tserver`](../yb-tserver/) and [`yb-master`](../yb-master/) directly. Refer to [Deploy YugabyteDB](../../../deploy).
 
@@ -33,7 +33,7 @@ $ ./bin/yugabyted start
 
 ### Online help
 
-You can access the overview command line help for `yugabyted` by running one of the following examples from the YugabyteDB home.
+You can access command-line help for `yugabyted` by running one of the following examples from the YugabyteDB home:
 
 ```sh
 $ ./bin/yugabyted -h
@@ -43,7 +43,7 @@ $ ./bin/yugabyted -h
 $ ./bin/yugabyted -help
 ```
 
-For help with specific `yugabyted` commands, run 'yugabyted [ command ] -h'. For example, you can print the command line help for the `yugabyted start` command by running the following:
+For help with specific `yugabyted` commands, run 'yugabyted [ command ] -h'. For example, you can print the command-line help for the `yugabyted start` command by running the following:
 
 ```sh
 $ ./bin/yugabyted start -h
@@ -68,7 +68,7 @@ The following commands are available:
 
 ### start
 
-Use the `yugabyted start` command to start a one-node YugabyteDB cluster in your local environment. This allows you to quickly get started with a YugabyteDB cluster for running [YSQL](../../../architecture/layered-architecture/#yugabyte-sql-ysql) and [YCQL](../../../architecture/layered-architecture/#yugabyte-cloud-ql-ycql) workloads.
+Use the `yugabyted start` command to start a one-node YugabyteDB cluster for running [YSQL](../../../architecture/layered-architecture/#yugabyte-sql-ysql) and [YCQL](../../../architecture/layered-architecture/#yugabyte-cloud-ql-ycql) workloads in your local environment.
 
 #### Syntax
 
@@ -93,7 +93,7 @@ Examples:
 #### Flags
 
 -h, --help
-: Print the command line help and exit.
+: Print the command-line help and exit.
 
 --advertise_address *bind-ip*
 : IP address or local hostname on which yugabyted will listen.
@@ -117,10 +117,10 @@ Examples:
 : Enable or disable running yugabyted in the background as a daemon. Does not persist on restart. Default: `true`
 
 --cloud_location *cloud-location*
-: Cloud location of the Yugabyted node in the format `cloudprovider.region.zone`. This information is used for multi-zone, multi-region, and multi-cloud deployments of YugabyteDB clusters.
+: Cloud location of the yugabyted node in the format `cloudprovider.region.zone`. This information is used for multi-zone, multi-region, and multi-cloud deployments of YugabyteDB clusters.
 
 --fault_tolerance *fault_tolerance*
-: Determines the fault tolerance constraint to be applied on the data placement policy of the YugabyteDB cluster. This flag can accept the following values - none, zone, region, and cloud.
+: Determines the fault tolerance constraint to be applied on the data placement policy of the YugabyteDB cluster. This flag can accept the following values: none, zone, region, cloud.
 
 --ui *bool*
 : Enable or disable the webserver UI. Default: `false`
@@ -160,13 +160,13 @@ Advanced flags can be set by using the configuration file in the `--config` flag
 : Specify extra [tserver flags](../../../reference/configuration/yb-tserver#configuration-flags) as a set of key value pairs. Format (key=value,key=value).
 
 --ysql_enable_auth *bool*
-: Enable or disable YSQL Authentication. Default: `false`.
-: If the `YSQL_PASSWORD` [environment variable](#environment-variables) exists, then authentication mode is automatically set to true.
+: Enable or disable YSQL authentication. Default: `false`.
+: If the `YSQL_PASSWORD` [environment variable](#environment-variables) exists, then authentication mode is automatically set to `true`.
 
 --use_cassandra_authentication *bool*
-: Enable or disable YCQL Authentication. Default: `false`.
-: If the `YCQL_USER` or `YCQL_PASSWORD` [environment variables](#environment-variables) exist, then authentication mode is automatically set to true.
-: **Note**: The corresponding environment variables have higher priority than the command-line flags.
+: Enable or disable YCQL authentication. Default: `false`.
+: If the `YCQL_USER` or `YCQL_PASSWORD` [environment variables](#environment-variables) exist, then authentication mode is automatically set to `true`.
+Note that the corresponding environment variables have higher priority than the command-line flags.
 
 --initial_scripts_dir *initial-scripts-dir*
 : The directory from where yugabyted reads initialization scripts.
@@ -222,13 +222,13 @@ yugabyted configure data_placement --fault_tolerance=zone
 #### Flags
 
 -h | --help
-: Print the command line help and exit.
+: Print the command-line help and exit.
 
 --fault_tolerance *fault-tolerance*
-: Specify the fault tolerance for the cluster. This flag can accept one of these values - zone, region, or cloud. For example, when the flag is set to zone (`--fault_tolerance=zone`), yugabyted applies zone fault tolerance to the cluster, placing the nodes in 3 different zones, if available.
+: Specify the fault tolerance for the cluster. This flag can accept one of the following values: zone, region, cloud. For example, when the flag is set to zone (`--fault_tolerance=zone`), yugabyted applies zone fault tolerance to the cluster, placing the nodes in three different zones, if available.
 
 --constraint_value *data-placement-constraint-value*
-: Specify the data placement for the YugabyteDB cluster. This is an optional flag. The flag takes comma-seperated values in the format `cloud.region.zone`.
+: Specify the data placement for the YugabyteDB cluster. This is an optional flag. The flag takes comma-separated values in the format `cloud.region.zone`.
 
 --rf *replication-factor*
 : Specify the replication factor for the cluster. This is an optional flag which takes a value of `3` or `5`.
@@ -272,13 +272,13 @@ Examples:
 #### Flags
 
 -h | --help
-: Print the command line help and exit.
+: Print the command-line help and exit.
 
 --disable *disable*
-: Disable encryption at rest for the cluster. No need to set a value for the flag. Use --enable or --disable flag to toggle encryption features on a YugabyteDB cluster.
+: Disable encryption at rest for the cluster. There is no need to set a value for the flag. Use `--enable` or `--disable` flag to toggle encryption features on a YugabyteDB cluster.
 
 --enable *enable*
-: Enable encryption at rest for the cluster. No need to set a value for the flag. Use --enable or --disable flag to toggle encryption features on a YugabyteDB cluster.
+: Enable encryption at rest for the cluster. There is no need to set a value for the flag. Use `--enable` or `--disable` flag to toggle encryption features on a YugabyteDB cluster.
 
 --config *config-file*
 : The path to the configuration file of the yugabyted server.
@@ -328,7 +328,7 @@ Usage: yugabyted cert generate_server_certs --hostnames=127.0.0.1,127.0.0.2,127.
 #### Flags
 
 -h | --help
-: Print the command line help and exit.
+: Print the command-line help and exit.
 
 --hostnames *hostnames*
 : Hostnames of the nodes to be added in the cluster. Mandatory flag.
@@ -360,7 +360,7 @@ Usage: yugabyted stop [flags]
 #### Flags
 
 -h | --help
-: Print the command line help and exit.
+: Print the command-line help and exit.
 
 --config *config-file*
 : The path to the configuration file of the yugabyted server that needs to be stopped.
@@ -389,7 +389,7 @@ Usage: yugabyted destroy [flags]
 #### Flags
 
 -h, --help
-: Print the command line help and exit.
+: Print the command-line help and exit.
 
 --config *config-file*
 : The path to the configuration file of the yugabyted server that needs to be destroyed.
@@ -418,7 +418,7 @@ Usage: yugabyted status [flags]
 #### Flags
 
 -h | --help
-: Print the command line help and exit.
+: Print the command-line help and exit.
 
 --config *config-file*
 : The path to the configuration file of the yugabyted server whose status is desired.
@@ -447,7 +447,7 @@ Usage: yugabyted version [flags]
 #### Flags
 
 -h | --help
-: Print the command line help and exit.
+: Print the command-line help and exit.
 
 --config *config-file*
 : The path to the configuration file of the yugabyted server whose version is desired.
@@ -476,7 +476,7 @@ Usage: yugabyted collect_logs [flags]
 #### Flags
 
 -h | --help
-: Print the command line help and exit.
+: Print the command-line help and exit.
 
 --stdout *stdout*
 : Redirect the `logs.tar.gz` file's content to stdout. For example, `docker exec \<container-id\> bin/yugabyted collect_logs --stdout > yugabyted.tar.gz`
@@ -525,7 +525,7 @@ Usage: yugabyted connect ysql [flags]
 #### Flags
 
 -h | --help
-: Print the command line help and exit.
+: Print the command-line help and exit.
 
 --config *config-file*
 : The path to the configuration file of the yugabyted server whose logs are desired.
@@ -552,7 +552,7 @@ Usage: yugabyted connect ycql [flags]
 #### Flags
 
 -h | --help
-: Print the command line help and exit.
+: Print the command-line help and exit.
 
 --config *config-file*
 : The path to the configuration file of the yugabyted server whose logs are desired.
@@ -651,7 +651,7 @@ Changing the values of the environment variables after the first run has no effe
 
 Set `YSQL_PASSWORD` to use the cluster in enforced authentication mode.
 
-Combinations of environment variables and their uses.
+The following are combinations of environment variables and their uses:
 
 - `YSQL_PASSWORD`
 
@@ -685,7 +685,7 @@ Combinations of environment variables and their uses.
 
 Set `YCQL_USER` or `YCQL_PASSWORD` to use the cluster in enforced authentication mode.
 
-Combinations of environment variables and their uses.
+The following are combinations of environment variables and their uses:
 
 - `YCQL_PASSWORD`
 
@@ -723,7 +723,7 @@ Combinations of environment variables and their uses.
   <li>
     <a href="../yugabyted/#examples" class="nav-link">
       <!-- <i class="fa-brands fa-apple" aria-hidden="true"></i> -->
-    Secure Cluster
+    Secure cluster
     </a>
   </li>
   <li class="active">
@@ -734,11 +734,7 @@ Combinations of environment variables and their uses.
   </li>
 </ul>
 
-{{< note title="Note" >}}
-
-For using encryption at rest, `openssl` must be installed in the machine.
-
-{{< /note >}}
+For using encryption at rest, `openssl` must be installed on the machine.
 
 ### Create a single-node cluster
 
@@ -756,14 +752,14 @@ Run the following command:
 ./bin/yugabyted start --advertise_address=127.0.0.1 --base_dir=$HOME/yugabyte-{{< yb-version version="preview" >}}/node1 --cloud_location=aws.us-east.us-east-1a
 ```
 
-On MacOS and Linux, the additional nodes need loopback addresses configured:
+On MacOS and Linux, the additional nodes need loopback addresses configured as follows:
 
 ```sh
 sudo ifconfig lo0 alias 127.0.0.2
 sudo ifconfig lo0 alias 127.0.0.3
 ```
 
-Add two more nodes to the cluster using the `join` option.
+Add two more nodes to the cluster using the `join` option, as follows:
 
 ```sh
 ./bin/yugabyted start --advertise_address=127.0.0.2 --join=127.0.0.1 --base_dir=$HOME/yugabyte-{{< yb-version version="preview" >}}/node2 --cloud_location=aws.us-east.us-east-2a
@@ -803,7 +799,7 @@ After starting the yugabyted processes on all the nodes, configure the data plac
 ./bin/yugabyted configure data_placement --fault_tolerance=zone
 ```
 
-This command automatically determines the data placement constraint based on the `--cloud_location` of each node in the cluster. If there are 3 or more zones available in the cluster, the configure command configures the cluster to survive at least 1 availability zone failure. Otherwise, it outputs a warning message.
+The preceding command automatically determines the data placement constraint based on the `--cloud_location` of each node in the cluster. If there are three or more zones available in the cluster, the `configure` command configures the cluster to survive at least one availability zone failure. Otherwise, it outputs a warning message.
 
 The replication factor of the cluster defaults to 3.
 
@@ -842,7 +838,7 @@ After starting the yugabyted processes on all the nodes, configure the data plac
 ./bin/yugabyted configure data_placement --fault_tolerance=region
 ```
 
-This command determines the data placement constraint based on the `--cloud_location` of each node in the cluster. If there are 3 or more regions available in the cluster, the command configures the cluster to survive at least 1 region failure. Otherwise, it outputs a warning message.
+The preceding command determines the data placement constraint based on the `--cloud_location` of each node in the cluster. If there are three or more regions available in the cluster, the command configures the cluster to survive at least one region failure. Otherwise, it outputs a warning message.
 
 The replication factor of the cluster defaults to 3.
 
@@ -858,7 +854,7 @@ You can set the replication factor of the cluster manually using the `--rf` flag
 ./bin/yugabyted configure data_placement --fault_tolerance=region --constraint_value=aws.us-east.us-east-1a,aws.us-west.us-west-1a,aws.us-central.us-central-1a --rf=3
 ```
 
-### Enabling and Disabling encryption at rest
+### Enable and disable encryption at rest
 
 Create a cluster using the desired deployment example.
 
@@ -877,14 +873,14 @@ To disable encryption at rest in a local cluster with encryption at rest enabled
 ./bin/yugabyted configure encrypt_at_rest --disable --base_dir=$HOME/yugabyte-{{< yb-version version="preview" >}}/node1
 ```
 
-To disbale encryption-at-rest in a multi-zone or multi-region cluster with encryption-at-rest enabled, run the following command from any VM:
+To disable encryption at rest in a multi-zone or multi-region cluster with this type of encryption enabled, run the following command from any VM:
 ```sh
 ./bin/yugabyted configure encrypt_at_rest --disable
 ```
 
 ### Pass additional flags to YB-TServer
 
-Create a single-node cluster and set additional flags for the YB-TServer process.
+Create a single-node cluster and set additional flags for the YB-TServer process:
 
 ```sh
 ./bin/yugabyted start --tserver_flags="pg_yb_session_timeout_ms=1200000,ysql_max_connections=400"
@@ -892,7 +888,7 @@ Create a single-node cluster and set additional flags for the YB-TServer process
 
 ## Upgrade a YugabyteDB cluster
 
-To use the latest features of the database and apply the latest security fixes, it's prudent to upgrade your YugabyteDB cluster to the [latest release](https://download.yugabyte.com/).
+To use the latest YugabyteDB features and apply the latest security updates, it is recommended to upgrade your YugabyteDB cluster to the [latest release](https://download.yugabyte.com/).
 
 Upgrading an existing YugabyteDB cluster that was deployed using yugabyted includes the following steps:
 
@@ -903,12 +899,6 @@ Upgrading an existing YugabyteDB cluster that was deployed using yugabyted inclu
 Repeat the steps on all the nodes of the cluster, one node at a time.
 
 ### Upgrade a cluster from single to multi zone
-
-{{< note title="Note" >}}
-
-Multi-zone, multi-region deployment using yugabyted is supported in YugabyteDB 2.15.0.0 and later.
-
-{{< /note >}}
 
 The following steps assume that you have a running YugabyteDB cluster deployed using `yugabyted`, and have [downloaded the update](https://download.yugabyte.com/).
 

--- a/docs/content/preview/reference/configuration/yugabyted.md
+++ b/docs/content/preview/reference/configuration/yugabyted.md
@@ -13,11 +13,11 @@ rightNav:
   hideH4: true
 ---
 
-YugabyteDB uses a 2-server architecture with YB-TServers managing the data and YB-Masters managing the metadata. However, this can introduce a burden on new users who want to get started right away. To manage YugabyteDB for testing and learning purposes, you can use `yugabyted`, which is a database server that acts as a parent server across the [`yb-tserver`](../yb-tserver/) and [`yb-master`](../yb-master/) servers. yugabyted also provides a UI similar to the YugabyteDB Anywhere UI, with a data placement map and metrics dashboard.
+YugabyteDB uses a two-server architecture, with YB-TServers managing the data and YB-Masters managing the metadata. However, this can introduce a burden on new users who want to get started right away. To manage YugabyteDB for testing and learning purposes, you can use `yugabyted`, which is a database server that acts as a parent server across the [`yb-tserver`](../yb-tserver/) and [`yb-master`](../yb-master/) servers. yugabyted also provides a UI similar to the YugabyteDB Anywhere UI, with a data placement map and metrics dashboard.
 
 The `yugabyted` executable file is located in the YugabyteDB home's `bin` directory.
 
-Using yugabyted, you can create single-node clusters, and, using the `--join` flag in the `start` command, multi-node clusters.
+Using yugabyted, you can create single-node clusters. To create multi-node clusters, you would need to use the `--join` flag in the `start` command.
 
 Note that yugabyted is not recommended for production deployments. For production deployments with fully-distributed multi-node clusters, use [`yb-tserver`](../yb-tserver/) and [`yb-master`](../yb-master/) directly. Refer to [Deploy YugabyteDB](../../../deploy).
 
@@ -38,7 +38,7 @@ $ ./bin/yugabyted start
 
 ### Online help
 
-You can access the overview command line help for `yugabyted` by running one of the following examples from the YugabyteDB home.
+You can access command-line help for `yugabyted` by running one of the following examples from the YugabyteDB home:
 
 ```sh
 $ ./bin/yugabyted -h
@@ -48,7 +48,7 @@ $ ./bin/yugabyted -h
 $ ./bin/yugabyted -help
 ```
 
-For help with specific `yugabyted` commands, run 'yugabyted [ command ] -h'. For example, you can print the command line help for the `yugabyted start` command by running the following:
+For help with specific `yugabyted` commands, run 'yugabyted [ command ] -h'. For example, you can print the command-line help for the `yugabyted start` command by running the following:
 
 ```sh
 $ ./bin/yugabyted start -h
@@ -73,7 +73,7 @@ The following commands are available:
 
 ### start
 
-Use the `yugabyted start` command to start a one-node YugabyteDB cluster in your local environment. This allows you to quickly get started with a YugabyteDB cluster for running [YSQL](../../../architecture/layered-architecture/#yugabyte-sql-ysql) and [YCQL](../../../architecture/layered-architecture/#yugabyte-cloud-ql-ycql) workloads.
+Use the `yugabyted start` command to start a one-node YugabyteDB cluster for running [YSQL](../../../architecture/layered-architecture/#yugabyte-sql-ysql) and [YCQL](../../../architecture/layered-architecture/#yugabyte-cloud-ql-ycql) workloads in your local environment.
 
 #### Syntax
 
@@ -98,7 +98,7 @@ Examples:
 #### Flags
 
 -h, --help
-: Print the command line help and exit.
+: Print the command-line help and exit.
 
 --advertise_address *bind-ip*
 : IP address or local hostname on which yugabyted will listen.
@@ -122,10 +122,10 @@ Examples:
 : Enable or disable running yugabyted in the background as a daemon. Does not persist on restart. Default: `true`
 
 --cloud_location *cloud-location*
-: Cloud location of the Yugabyted node in the format `cloudprovider.region.zone`. This information is used for multi-zone, multi-region, and multi-cloud deployments of YugabyteDB clusters.
+: Cloud location of the yugabyted node in the format `cloudprovider.region.zone`. This information is used for multi-zone, multi-region, and multi-cloud deployments of YugabyteDB clusters.
 
 --fault_tolerance *fault_tolerance*
-: Determines the fault tolerance constraint to be applied on the data placement policy of the YugabyteDB cluster. This flag can accept the following values - none, zone, region, and cloud.
+: Determines the fault tolerance constraint to be applied on the data placement policy of the YugabyteDB cluster. This flag can accept the following values: none, zone, region, cloud.
 
 --ui *bool*
 : Enable or disable the webserver UI. Default: `false`
@@ -165,13 +165,13 @@ Advanced flags can be set by using the configuration file in the `--config` flag
 : Specify extra [tserver flags](../../../reference/configuration/yb-tserver#configuration-flags) as a set of key value pairs. Format (key=value,key=value).
 
 --ysql_enable_auth *bool*
-: Enable or disable YSQL Authentication. Default: `false`.
-: If the `YSQL_PASSWORD` [environment variable](#environment-variables) exists, then authentication mode is automatically set to true.
+: Enable or disable YSQL authentication. Default: `false`.
+: If the `YSQL_PASSWORD` [environment variable](#environment-variables) exists, then authentication mode is automatically set to `true`.
 
 --use_cassandra_authentication *bool*
-: Enable or disable YCQL Authentication. Default: `false`.
-: If the `YCQL_USER` or `YCQL_PASSWORD` [environment variables](#environment-variables) exist, then authentication mode is automatically set to true.
-: **Note**: The corresponding environment variables have higher priority than the command-line flags.
+: Enable or disable YCQL authentication. Default: `false`.
+: If the `YCQL_USER` or `YCQL_PASSWORD` [environment variables](#environment-variables) exist, then authentication mode is automatically set to `true`.
+Note that the corresponding environment variables have higher priority than the command-line flags.
 
 --initial_scripts_dir *initial-scripts-dir*
 : The directory from where yugabyted reads initialization scripts.
@@ -227,13 +227,13 @@ yugabyted configure data_placement --fault_tolerance=zone
 #### Flags
 
 -h | --help
-: Print the command line help and exit.
+: Print the command-line help and exit.
 
 --fault_tolerance *fault-tolerance*
-: Specify the fault tolerance for the cluster. This flag can accept one of these values - zone, region, or cloud. For example, when the flag is set to zone (`--fault_tolerance=zone`), yugabyted applies zone fault tolerance to the cluster, placing the nodes in 3 different zones, if available.
+: Specify the fault tolerance for the cluster. This flag can accept one of the following values: zone, region, cloud. For example, when the flag is set to zone (`--fault_tolerance=zone`), yugabyted applies zone fault tolerance to the cluster, placing the nodes in three different zones, if available.
 
 --constraint_value *data-placement-constraint-value*
-: Specify the data placement for the YugabyteDB cluster. This is an optional flag. The flag takes comma-seperated values in the format `cloud.region.zone`.
+: Specify the data placement for the YugabyteDB cluster. This is an optional flag. The flag takes comma-separated values in the format `cloud.region.zone`.
 
 --rf *replication-factor*
 : Specify the replication factor for the cluster. This is an optional flag which takes a value of `3` or `5`.
@@ -277,13 +277,13 @@ Examples:
 #### Flags
 
 -h | --help
-: Print the command line help and exit.
+: Print the command-line help and exit.
 
 --disable *disable*
-: Disable encryption at rest for the cluster. No need to set a value for the flag. Use --enable or --disable flag to toggle encryption features on a YugabyteDB cluster.
+: Disable encryption at rest for the cluster. There is no need to set a value for the flag. Use `--enable` or `--disable` flag to toggle encryption features on a YugabyteDB cluster.
 
 --enable *enable*
-: Enable encryption at rest for the cluster. No need to set a value for the flag. Use --enable or --disable flag to toggle encryption features on a YugabyteDB cluster.
+: Enable encryption at rest for the cluster. There is no need to set a value for the flag. Use `--enable` or `--disable` flag to toggle encryption features on a YugabyteDB cluster.
 
 --config *config-file*
 : The path to the configuration file of the yugabyted server.
@@ -333,7 +333,7 @@ Usage: yugabyted cert generate_server_certs --hostnames=127.0.0.1,127.0.0.2,127.
 #### Flags
 
 -h | --help
-: Print the command line help and exit.
+: Print the command-line help and exit.
 
 --hostnames *hostnames*
 : Hostnames of the nodes to be added in the cluster. Mandatory flag.
@@ -365,7 +365,7 @@ Usage: yugabyted stop [flags]
 #### Flags
 
 -h | --help
-: Print the command line help and exit.
+: Print the command-line help and exit.
 
 --config *config-file*
 : The path to the configuration file of the yugabyted server that needs to be stopped.
@@ -394,7 +394,7 @@ Usage: yugabyted destroy [flags]
 #### Flags
 
 -h, --help
-: Print the command line help and exit.
+: Print the command-line help and exit.
 
 --config *config-file*
 : The path to the configuration file of the yugabyted server that needs to be destroyed.
@@ -423,7 +423,7 @@ Usage: yugabyted status [flags]
 #### Flags
 
 -h | --help
-: Print the command line help and exit.
+: Print the command-line help and exit.
 
 --config *config-file*
 : The path to the configuration file of the yugabyted server whose status is desired.
@@ -452,7 +452,7 @@ Usage: yugabyted version [flags]
 #### Flags
 
 -h | --help
-: Print the command line help and exit.
+: Print the command-line help and exit.
 
 --config *config-file*
 : The path to the configuration file of the yugabyted server whose version is desired.
@@ -481,7 +481,7 @@ Usage: yugabyted collect_logs [flags]
 #### Flags
 
 -h | --help
-: Print the command line help and exit.
+: Print the command-line help and exit.
 
 --stdout *stdout*
 : Redirect the `logs.tar.gz` file's content to stdout. For example, `docker exec \<container-id\> bin/yugabyted collect_logs --stdout > yugabyted.tar.gz`
@@ -530,7 +530,7 @@ Usage: yugabyted connect ysql [flags]
 #### Flags
 
 -h | --help
-: Print the command line help and exit.
+: Print the command-line help and exit.
 
 --config *config-file*
 : The path to the configuration file of the yugabyted server whose logs are desired.
@@ -557,7 +557,7 @@ Usage: yugabyted connect ycql [flags]
 #### Flags
 
 -h | --help
-: Print the command line help and exit.
+: Print the command-line help and exit.
 
 --config *config-file*
 : The path to the configuration file of the yugabyted server whose logs are desired.
@@ -656,7 +656,7 @@ Changing the values of the environment variables after the first run has no effe
 
 Set `YSQL_PASSWORD` to use the cluster in enforced authentication mode.
 
-Combinations of environment variables and their uses.
+The following are combinations of environment variables and their uses:
 
 - `YSQL_PASSWORD`
 
@@ -690,7 +690,7 @@ Combinations of environment variables and their uses.
 
 Set `YCQL_USER` or `YCQL_PASSWORD` to use the cluster in enforced authentication mode.
 
-Combinations of environment variables and their uses.
+The following are combinations of environment variables and their uses:
 
 - `YCQL_PASSWORD`
 
@@ -739,11 +739,7 @@ Combinations of environment variables and their uses.
   </li>
 </ul>
 
-{{< note title="Note" >}}
-
-For any type of secure cluster deployment or using encryption at rest, `openssl` must be installed in the machine.
-
-{{< /note >}}
+For any type of secure cluster deployment or using encryption at rest, `openssl` must be installed on the machine.
 
 ### Create a single-node cluster
 
@@ -801,7 +797,7 @@ To destroy the multi-node cluster, execute the following:
 
 ### Create a multi-zone cluster
 
-To create a multi-node secrue cluster, start the first node by running the `yugabyted start` command, using the `--secure` flag and passing in the `--cloud_location` and `--fault_tolerance` flags to set the node location details, as follows:
+To create a multi-node secure cluster, start the first node by running the `yugabyted start` command, using the `--secure` flag and passing in the `--cloud_location` and `--fault_tolerance` flags to set the node location details, as follows:
 
 ```sh
 ./bin/yugabyted start --secure --advertise_address=<host-ip> --cloud_location=aws.us-east.us-east-1a --fault_tolerance=zone
@@ -813,7 +809,7 @@ Create certificates for the second and third virtual machine (VM) for SSL and TL
 ./bin/yugabyted cert generate_server_certs --hostnames=<IP_of_VM_2>,<IP_of_VM_3>
 ```
 
-Manually copy the generated certificates in the first VM to the second and third VM.
+Manually copy the generated certificates in the first VM to the second and third VM, as follows:
 
 Copy the certificates for the second VM from `$HOME/var/generated_certs/<IP_of_VM_2>` in the first VM to `$HOME/var/certs` in the second VM.
 Copy the certificates for third VM from `$HOME/var/generated_certs/<IP_of_VM_3>` in first VM to `$HOME/var/certs` in the third VM.
@@ -850,7 +846,7 @@ You can set the replication factor of the cluster manually using the `--rf` flag
 
 ### Create a multi-region cluster
 
-To create a multi-region secrue cluster, start the first node by running the `yugabyted start` command, using the `--secure` flag and passing in the `--cloud_location` and `--fault_tolerance` flags to set the node location details, as follows:
+To create a multi-region secure cluster, start the first node by running the `yugabyted start` command, using the `--secure` flag and passing in the `--cloud_location` and `--fault_tolerance` flags to set the node location details, as follows:
 
 ```sh
 ./bin/yugabyted start --secure --advertise_address=<host-ip> --cloud_location=aws.us-east.us-east-1a --fault_tolerance=region
@@ -897,7 +893,7 @@ You can set the replication factor of the cluster manually using the `--rf` flag
 ./bin/yugabyted configure data_placement --fault_tolerance=region --data_placement_constraint=aws.us-east.us-east-1a,aws.us-west.us-west-1a,aws.us-central.us-central-1a --rf=3
 ```
 
-### Enabling and Disabling encryption at rest
+### Enable and disable encryption at rest
 
 Create a cluster using the desired deployment example.
 
@@ -916,14 +912,14 @@ To disable encryption at rest in a local cluster with encryption at rest enabled
 ./bin/yugabyted configure encrypt_at_rest --disable --base_dir=$HOME/yugabyte-{{< yb-version version="preview" >}}/node1
 ```
 
-To disbale encryption-at-rest in a multi-zone or multi-region cluster with encryption-at-rest enabled, run the following command from any VM:
+To disable encryption at rest in a multi-zone or multi-region cluster with this type of encryption enabled, run the following command from any VM:
 ```sh
 ./bin/yugabyted configure encrypt_at_rest --disable
 ```
 
 ### Pass additional flags to YB-TServer
 
-Create a single-node cluster and set additional flags for the YB-TServer process.
+Create a single-node cluster and set additional flags for the YB-TServer process:
 
 ```sh
 ./bin/yugabyted start --tserver_flags="pg_yb_session_timeout_ms=1200000,ysql_max_connections=400"
@@ -942,12 +938,6 @@ Upgrading an existing YugabyteDB cluster that was deployed using yugabyted inclu
 Repeat the steps on all the nodes of the cluster, one node at a time.
 
 ### Upgrade a cluster from single to multi zone
-
-{{< note title="Note" >}}
-
-Multi-zone, multi-region deployment using yugabyted is supported in YugabyteDB 2.15.0.0 and later.
-
-{{< /note >}}
 
 The following steps assume that you have a running YugabyteDB cluster deployed using `yugabyted`, and have [downloaded the update](https://download.yugabyte.com/).
 

--- a/docs/content/preview/reference/configuration/yugabyted.md
+++ b/docs/content/preview/reference/configuration/yugabyted.md
@@ -451,10 +451,10 @@ Usage: yugabyted status [flags]
 : The data directory for the yugabyted server whose status is desired.
 
 --base_dir *base-directory*
-: The base directory for the yugabyted server that whose status is desired.
+: The base directory for the yugabyted server whose status is desired.
 
 --log_dir *log-directory*
-: The log directory for the yugabyted server that whose status is desired.
+: The log directory for the yugabyted server whose status is desired.
 
 -----
 
@@ -480,10 +480,10 @@ Usage: yugabyted version [flags]
 : The data directory for the yugabyted server whose version is desired.
 
 --base_dir *base-directory*
-: The base directory for the yugabyted server that whose version is desired.
+: The base directory for the yugabyted server whose version is desired.
 
 --log_dir *log-directory*
-: The log directory for the yugabyted server that whose version is desired.
+: The log directory for the yugabyted server whose version is desired.
 
 -----
 

--- a/docs/content/preview/reference/configuration/yugabyted.md
+++ b/docs/content/preview/reference/configuration/yugabyted.md
@@ -89,7 +89,7 @@ Examples:
   yugabyted start
   ```
 
-- Create a secure local single-node cluster:
+- Create a local single-node cluster with encryption-in-transit and authentication:
 
   ```sh
   yugabyted start --secure
@@ -113,7 +113,7 @@ Examples:
 : The IP address of the existing yugabyted server to which the new yugabyted server will join.
 
 --config *config-file*
-: Yugabyted configuration file path.
+: Yugabyted configuration file path. Refer to [Advanced Flags](#advanced-flags).
 
 --base_dir *base-directory*
 : The directory where yugabyted stores data, configurations, and logs. Must be an absolute path.

--- a/docs/content/preview/reference/configuration/yugabyted.md
+++ b/docs/content/preview/reference/configuration/yugabyted.md
@@ -75,6 +75,8 @@ The following commands are available:
 
 Use the `yugabyted start` command to start a one-node YugabyteDB cluster for running [YSQL](../../../architecture/layered-architecture/#yugabyte-sql-ysql) and [YCQL](../../../architecture/layered-architecture/#yugabyte-cloud-ql-ycql) workloads in your local environment.
 
+Note that to use encryption in transit, OpenSSL must be installed on the nodes.
+
 #### Syntax
 
 ```text
@@ -89,7 +91,7 @@ Examples:
   yugabyted start
   ```
 
-- Create a local single-node cluster with encryption-in-transit and authentication:
+- Create a local single-node cluster with encryption in transit and authentication:
 
   ```sh
   yugabyted start --secure
@@ -137,8 +139,8 @@ Examples:
 : Enable or disable the webserver UI. Default: `false`
 
 --secure
-: Enable [encryption-in-transit](../../../secure/tls-encryption/) and [authentication](../../../secure/enable-authentication/ysql/) for the node.
-: Encryption-in-transit requires SSL/TLS certificates for each node in the cluster.
+: Enable [encryption in transit](../../../secure/tls-encryption/) and [authentication](../../../secure/enable-authentication/ysql/) for the node.
+: Encryption in transit requires SSL/TLS certificates for each node in the cluster.
 : - When starting a local single-node cluster, a certificate is automatically generated for the cluster.
 : - When deploying a node in a multi-node cluster, you need to generate the certificate for the node using the `--cert generate_server_certs` command and copy it to the node *before* you start the node using the `--secure` flag, or the node creation will fail.
 : When authentication is enabled, the default user and password is `yugabyte` and `yugabyte` in YSQL, and `cassandra` and `cassandra` in YCQL.
@@ -268,6 +270,8 @@ yugabyted configure data_placement --fault_tolerance=zone
 
 Use the `yugabyted configure encrypt_at_rest` subcommand to enable or disable [encryption at rest](../../../secure/encryption-at-rest/) for the deployed cluster.
 
+To use encryption at rest, OpenSSL must be installed on the nodes.
+
 #### Syntax
 
 ```text
@@ -315,7 +319,7 @@ Examples:
 
 ### cert
 
-Use the `yugabyted cert` command to create TLS or SSL certificates for deploying a secure YugabyteDB cluster.
+Use the `yugabyted cert` command to create TLS/SSL certificates for deploying a secure YugabyteDB cluster.
 
 #### Commands
 
@@ -751,7 +755,7 @@ Create a single-node cluster with a given base directory. Note the need to provi
 ./bin/yugabyted start --advertise_address=127.0.0.1 --base_dir=/Users/username/yugabyte-{{< yb-version version="preview" >}}/data1
 ```
 
-To create secure single-node cluster with [encryption-in-transit](../../../secure/tls-encryption/) and [authentication](../../../secure/enable-authentication/ysql/) enabled, add the `--secure` flag as follows:
+To create secure single-node cluster with [encryption in transit](../../../secure/tls-encryption/) and [authentication](../../../secure/enable-authentication/ysql/) enabled, add the `--secure` flag as follows:
 
 ```sh
 ./bin/yugabyted start --secure --advertise_address=127.0.0.1 --base_dir=/Users/username/yugabyte-{{< yb-version version="preview" >}}/data1
@@ -761,7 +765,7 @@ When authentication is enabled, the default user and password is `yugabyte` and 
 
 ### Create certificates for a secure local multi-node cluster
 
-Secure clusters use [encryption-in-transit](../../../secure/tls-encryption/), which requires SSL/TLS certificates for each node in the cluster. Generate the SSL/TLS certificates using the `--cert generate_server_certs` command and then copy them to the respective node base directories *before* you create a secure local multi-node cluster.
+Secure clusters use [encryption in transit](../../../secure/tls-encryption/), which requires SSL/TLS certificates for each node in the cluster. Generate the SSL/TLS certificates using the `--cert generate_server_certs` command and then copy them to the respective node base directories *before* you create a secure local multi-node cluster.
 
 Create the certificates for SSL and TLS connection:
 
@@ -851,7 +855,7 @@ Start the second and the third node on two separate VMs, as follows:
 
   {{% /tab %}}
 
-  {{% tab header="Basic" lang="basic" %}}
+  {{% tab header="Insecure" lang="basic" %}}
 
 To create a multi-zone cluster, start the first node by running the `yugabyted start` command, passing in the `--cloud_location` and `--fault_tolerance` flags to set the node location details, as follows:
 
@@ -930,7 +934,7 @@ Start the second and the third node on two separate VMs, as follows:
 
   {{% /tab %}}
 
-  {{% tab header="Basic" lang="basic-2" %}}
+  {{% tab header="Insecure" lang="basic-2" %}}
 
 To create a multi-region cluster, start the first yugabyted node by running the `yugabyted start` command, pass in the `--cloud_location` and `--fault_tolerance` flags to set the node location details as follows:
 

--- a/docs/content/preview/reference/configuration/yugabyted.md
+++ b/docs/content/preview/reference/configuration/yugabyted.md
@@ -115,7 +115,7 @@ Examples:
 : The IP address of the existing yugabyted server to which the new yugabyted server will join.
 
 --config *config-file*
-: Yugabyted configuration file path. Refer to [Advanced Flags](#advanced-flags).
+: Yugabyted configuration file path. Refer to [Advanced flags](#advanced-flags).
 
 --base_dir *base-directory*
 : The directory where yugabyted stores data, configurations, and logs. Must be an absolute path.
@@ -146,7 +146,7 @@ Examples:
 : When authentication is enabled, the default user and password is `yugabyte` and `yugabyte` in YSQL, and `cassandra` and `cassandra` in YCQL.
 : For examples creating secure local multi-node, multi-zone, and multi-region clusters, refer to [Examples](#examples).
 
-#### Advanced Flags
+#### Advanced flags
 
 Advanced flags can be set by using the configuration file in the `--config` flag. The advanced flags support for the `start` command is as follows:
 
@@ -194,7 +194,7 @@ Note that the corresponding environment variables have higher priority than the 
 : Script format - YSQL `.sql`, YCQL `.cql`.
 : Initialization scripts are executed in sorted name order.
 
-#### Deprecated Flags
+#### Deprecated flags
 
 --daemon *bool*
 : Enable or disable running yugabyted in the background as a daemon. Does not persist on restart. Default: `true`.
@@ -234,7 +234,7 @@ For example, you would use the following command to create a multi-zone Yugabyte
 ./bin/yugabyted configure data_placement --fault_tolerance=zone
 ```
 
-#### data_placement Flags
+#### data_placement flags
 
 -h | --help
 : Print the command-line help and exit.
@@ -278,7 +278,7 @@ To disable encryption at rest for a YugabyteDB cluster which has encryption at r
 ./bin/yugabyted configure encrypt_at_rest --disable
 ```
 
-#### encrypt_at_rest Flags
+#### encrypt_at_rest flags
 
 -h | --help
 : Print the command-line help and exit.

--- a/docs/content/preview/reference/configuration/yugabyted.md
+++ b/docs/content/preview/reference/configuration/yugabyted.md
@@ -345,7 +345,7 @@ Usage: yugabyted cert generate_server_certs --hostnames=127.0.0.1,127.0.0.2,127.
 : The data directory for the yugabyted server.
 
 --base_dir *base-directory*
-: The base directory for the yugabyted server. 
+: The base directory for the yugabyted server.
 
 --log_dir *log-directory*
 : The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
@@ -533,13 +533,13 @@ Usage: yugabyted connect ysql [flags]
 : Print the command-line help and exit.
 
 --config *config-file*
-: The path to the configuration file of the yugabyted server whose logs are desired.
+: The path to the configuration file of the yugabyted server to connect to.
 
 --data_dir *data-directory*
-: The data directory for the yugabyted server whose logs are desired.
+: The data directory for the yugabyted server to connect to.
 
 --base_dir *base-directory*
-: The base directory for the yugabyted server whose logs are desired.
+: The base directory for the yugabyted server to connect to.
 
 --log_dir *log-directory*
 : The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
@@ -560,13 +560,13 @@ Usage: yugabyted connect ycql [flags]
 : Print the command-line help and exit.
 
 --config *config-file*
-: The path to the configuration file of the yugabyted server whose logs are desired.
+: The path to the configuration file of the yugabyted server to connect to.
 
 --data_dir *data-directory*
-: The data directory for the yugabyted server whose logs are desired.
+: The data directory for the yugabyted server to connect to.
 
 --base_dir *base-directory*
-: The base directory for the yugabyted server whose logs are desired.
+: The base directory for the yugabyted server to connect to.
 
 --log_dir *log-directory*
 : The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
@@ -606,13 +606,13 @@ Usage: yugabyted demo connect [flags]
 : Print the help message and exit.
 
 --config *config-file*
-: The path to the configuration file of the yugabyted server whose logs are desired.
+: The path to the configuration file of the yugabyted server to connect to.
 
 --data_dir *data-directory*
-: The data directory for the yugabyted server whose logs are desired.
+: The data directory for the yugabyted server to connect to.
 
 --base_dir *base-directory*
-: The base directory for the yugabyted server whose logs are desired.
+: The base directory for the yugabyted server to connect to.
 
 --log_dir *log-directory*
 : The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
@@ -633,13 +633,13 @@ Usage: yugabyted demo destroy [flags]
 : Print the help message and exit.
 
 --config *config-file*
-: The path to the configuration file of the yugabyted server whose logs are desired.
+: The path to the configuration file of the yugabyted server to destroy.
 
 --data_dir *data-directory*
-: The data directory for the yugabyted server whose logs are desired.
+: The data directory for the yugabyted server to destroy.
 
 --base_dir *base-directory*
-: The base directory for the yugabyted server whose logs are desired.
+: The base directory for the yugabyted server to destroy.
 
 --log_dir *log-directory*
 : The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.

--- a/docs/content/preview/reference/configuration/yugabyted.md
+++ b/docs/content/preview/reference/configuration/yugabyted.md
@@ -89,6 +89,12 @@ Examples:
   yugabyted start
   ```
 
+- Create a secure local single-node cluster:
+
+  ```sh
+  yugabyted start --secure
+  ```
+
 - Create a single-node locally and join other nodes that are part of the same cluster:
 
   ```sh
@@ -129,6 +135,14 @@ Examples:
 
 --ui *bool*
 : Enable or disable the webserver UI. Default: `false`
+
+--secure
+: Enable [encryption-in-transit](../../../secure/tls-encryption/) and [authentication](../../../secure/enable-authentication/ysql/) for the node.
+: Encryption-in-transit requires SSL/TLS certificates for each node in the cluster.
+: - When starting a local single-node cluster, a certificate is automatically generated for the cluster.
+: - When deploying a node in a multi-node cluster, you need to generate the certificate for the node using the `--cert generate_server_certs` command and copy it to the node *before* you start the node using the `--secure` flag, or the node creation will fail.
+: When authentication is enabled, the default user and password is `yugabyte` and `yugabyte` in YSQL, and `cassandra` and `cassandra` in YCQL.
+: For examples creating secure local multi-node, multi-zone, and multi-region clusters, refer to [Examples](#examples).
 
 #### Advanced Flags
 
@@ -248,11 +262,11 @@ yugabyted configure data_placement --fault_tolerance=zone
 : The base directory for the yugabyted server.
 
 --log_dir *log-directory*
-: The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
+: The log directory for the yugabyted server.
 
 #### encrypt_at_rest
 
-Use the `yugabyted configure encrypt_at_rest` subcommand to enable or disable encryption at rest for the deployed cluster.
+Use the `yugabyted configure encrypt_at_rest` subcommand to enable or disable [encryption at rest](../../../secure/encryption-at-rest/) for the deployed cluster.
 
 #### Syntax
 
@@ -295,7 +309,8 @@ Examples:
 : The base directory for the yugabyted server.
 
 --log_dir *log-directory*
-: The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
+: : The log directory for the yugabyted server.
+
 -----
 
 ### cert
@@ -348,7 +363,7 @@ Usage: yugabyted cert generate_server_certs --hostnames=127.0.0.1,127.0.0.2,127.
 : The base directory for the yugabyted server.
 
 --log_dir *log-directory*
-: The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
+: The log directory for the yugabyted server.
 
 -----
 
@@ -377,7 +392,7 @@ Usage: yugabyted stop [flags]
 : The base directory for the yugabyted server that needs to be stopped.
 
 --log_dir *log-directory*
-: The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
+: The log directory for the yugabyted server that needs to be stopped.
 
 -----
 
@@ -406,7 +421,7 @@ Usage: yugabyted destroy [flags]
 : The base directory for the yugabyted server that needs to be destroyed.
 
 --log_dir *log-directory*
-: The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
+: The log directory for the yugabyted server that needs to be destroyed.
 
 -----
 
@@ -435,7 +450,7 @@ Usage: yugabyted status [flags]
 : The base directory for the yugabyted server that whose status is desired.
 
 --log_dir *log-directory*
-: The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
+: The log directory for the yugabyted server that whose status is desired.
 
 -----
 
@@ -464,7 +479,7 @@ Usage: yugabyted version [flags]
 : The base directory for the yugabyted server that whose version is desired.
 
 --log_dir *log-directory*
-: The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
+: The log directory for the yugabyted server that whose version is desired.
 
 -----
 
@@ -496,7 +511,7 @@ Usage: yugabyted collect_logs [flags]
 : The base directory for the yugabyted server whose logs are desired.
 
 --log_dir *log-directory*
-: The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
+: The log directory for the yugabyted server whose logs are desired.
 
 -----
 
@@ -542,7 +557,7 @@ Usage: yugabyted connect ysql [flags]
 : The base directory for the yugabyted server to connect to.
 
 --log_dir *log-directory*
-: The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
+: The log directory for the yugabyted server to connect to.
 
 #### ycql
 
@@ -569,7 +584,7 @@ Usage: yugabyted connect ycql [flags]
 : The base directory for the yugabyted server to connect to.
 
 --log_dir *log-directory*
-: The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
+: The log directory for the yugabyted server to connect to.
 
 -----
 
@@ -615,7 +630,7 @@ Usage: yugabyted demo connect [flags]
 : The base directory for the yugabyted server to connect to.
 
 --log_dir *log-directory*
-: The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
+: The log directory for the yugabyted server to connect to.
 
 #### destroy
 
@@ -642,7 +657,7 @@ Usage: yugabyted demo destroy [flags]
 : The base directory for the yugabyted server to destroy.
 
 --log_dir *log-directory*
-: The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
+: The log directory for the yugabyted server to destroy.
 
 -----
 
@@ -746,7 +761,7 @@ When authentication is enabled, the default user and password is `yugabyte` and 
 
 ### Create certificates for a secure local multi-node cluster
 
-Secure clusters use encryption-in-transit, which requires SSL/TLS certificates for each node in the cluster. Generate the SSL/TLS certificates and then copy them to the respective node base directories *before* you create a secure local multi-node cluster.
+Secure clusters use [encryption-in-transit](../../../secure/tls-encryption/), which requires SSL/TLS certificates for each node in the cluster. Generate the SSL/TLS certificates using the `--cert generate_server_certs` command and then copy them to the respective node base directories *before* you create a secure local multi-node cluster.
 
 Create the certificates for SSL and TLS connection:
 
@@ -961,7 +976,7 @@ You can set the replication factor of the cluster manually using the `--rf` flag
 
 ### Enable and disable encryption at rest
 
-To enable encryption at rest in a deployed local cluster, run the following command:
+To enable [encryption at rest](../../../secure/encryption-at-rest/) in a deployed local cluster, run the following command:
 
 ```sh
 ./bin/yugabyted configure encrypt_at_rest --enable --base_dir=$HOME/yugabyte-{{< yb-version version="preview" >}}/node1

--- a/docs/content/preview/reference/configuration/yugabyted.md
+++ b/docs/content/preview/reference/configuration/yugabyted.md
@@ -88,24 +88,24 @@ Examples:
 - Create a local single-node cluster:
 
   ```sh
-  yugabyted start
+  ./bin/yugabyted start
   ```
 
 - Create a local single-node cluster with encryption in transit and authentication:
 
   ```sh
-  yugabyted start --secure
+  ./bin/yugabyted start --secure
   ```
 
 - Create a single-node locally and join other nodes that are part of the same cluster:
 
   ```sh
-  yugabyted start --join=host:port,[host:port]
+  ./bin/yugabyted start --join=host:port,[host:port]
   ```
 
 #### Flags
 
--h, --help
+-h | --help
 : Print the command-line help and exit.
 
 --advertise_address *bind-ip*
@@ -211,6 +211,12 @@ Use the `yugabyted configure` command to do the following:
 - Configure the data placement policy of the cluster.
 - Enable or disable encryption at rest.
 
+#### Syntax
+
+```sh
+Usage: yugabyted configure [command] [flags]
+```
+
 #### Commands
 
 The following subcommands are available for `yugabyted configure` command:
@@ -218,29 +224,17 @@ The following subcommands are available for `yugabyted configure` command:
 - [data_placement](#data-placement)
 - [encrypt_at_rest](#encrypt-at-rest)
 
-#### Syntax
-
-```sh
-Usage: yugabyted configure [command] [flags]
-```
-
 #### data_placement
 
 Use the `yugabyted configure data_placement` subcommand to set or modify placement policy of the nodes of the deployed cluster.
 
-#### Syntax
-
-```sh
-Usage: yugabyted configure data_placement [flags]
-```
-
 For example, you would use the following command to create a multi-zone YugabyteDB cluster:
 
 ```sh
-yugabyted configure data_placement --fault_tolerance=zone
+./bin/yugabyted configure data_placement --fault_tolerance=zone
 ```
 
-#### Flags
+#### data_placement Flags
 
 -h | --help
 : Print the command-line help and exit.
@@ -272,27 +266,19 @@ Use the `yugabyted configure encrypt_at_rest` subcommand to enable or disable [e
 
 To use encryption at rest, OpenSSL must be installed on the nodes.
 
-#### Syntax
+For example, to enable encryption at rest for a deployed YugabyteDB cluster, execute the following:
 
-```text
-Usage: yugabyted configure encrypt_at_rest [flags]
+```sh
+./bin/yugabyted configure encrypt_at_rest --enable
 ```
 
-Examples:
+To disable encryption at rest for a YugabyteDB cluster which has encryption at rest enabled, execute the following:
 
-- To enable encryption at rest for a deployed YugabyteDB cluster, execute the following:
+```sh
+./bin/yugabyted configure encrypt_at_rest --disable
+```
 
-  ```sh
-  yugabyted configure encrypt_at_rest --enable
-  ```
-
-- To disable encryption at rest for a YugabyteDB cluster which has encryption at rest enabled, execute the following:
-
-  ```sh
-  yugabyted configure encrypt_at_rest --disable
-  ```
-
-#### Flags
+#### encrypt_at_rest Flags
 
 -h | --help
 : Print the command-line help and exit.
@@ -321,32 +307,26 @@ Examples:
 
 Use the `yugabyted cert` command to create TLS/SSL certificates for deploying a secure YugabyteDB cluster.
 
-#### Commands
-
-The following subcommands are available for the `yugabyted cert` command:
-
-- [generate_server_certs](#generate-server-certs)
-
 #### Syntax
 
 ```text
 Usage: yugabyted cert [command] [flags]
 ```
 
+#### Commands
+
+The following subcommands are available for the `yugabyted cert` command:
+
+- [generate_server_certs](#generate-server-certs)
+
 #### generate_server_certs
 
 Use the `yugabyted cert generate_server_certs` subcommand to generate keys and certificates for the specified hostnames.
 
-#### Syntax
-
-```text
-Usage: yugabyted cert generate_server_certs [flags]
-```
-
 For example, to create node server certificates for hostnames 127.0.0.1, 127.0.0.2, 127.0.0.3, execute the following command:
 
 ```sh
-Usage: yugabyted cert generate_server_certs --hostnames=127.0.0.1,127.0.0.2,127.0.0.3
+./bin/yugabyted cert generate_server_certs --hostnames=127.0.0.1,127.0.0.2,127.0.0.3
 ```
 
 #### Flags
@@ -412,7 +392,7 @@ Usage: yugabyted destroy [flags]
 
 #### Flags
 
--h, --help
+-h | --help
 : Print the command-line help and exit.
 
 --config *config-file*
@@ -523,6 +503,12 @@ Usage: yugabyted collect_logs [flags]
 
 Use the `yugabyted connect` command to connect to the cluster using [ysqlsh](../../../admin/ysqlsh/) or [ycqlsh](../../../admin/ycqlsh).
 
+#### Syntax
+
+```sh
+Usage: yugabyted connect [command] [flags]
+```
+
 #### Commands
 
 The following subcommands are available for the `yugabyted connect` command:
@@ -530,48 +516,13 @@ The following subcommands are available for the `yugabyted connect` command:
 - [ysql](#ysql)
 - [ycql](#ycql)
 
-#### Syntax
-
-```sh
-Usage: yugabyted connect [command] [flags]
-```
-
 #### ysql
 
 Use the `yugabyted connect ysql` subcommand to connect to YugabyteDB with [ysqlsh](../../../admin/ysqlsh/).
 
-#### Syntax
-
-```sh
-Usage: yugabyted connect ysql [flags]
-```
-
-#### Flags
-
--h | --help
-: Print the command-line help and exit.
-
---config *config-file*
-: The path to the configuration file of the yugabyted server to connect to.
-
---data_dir *data-directory*
-: The data directory for the yugabyted server to connect to.
-
---base_dir *base-directory*
-: The base directory for the yugabyted server to connect to.
-
---log_dir *log-directory*
-: The log directory for the yugabyted server to connect to.
-
 #### ycql
 
 Use the `yugabyted connect ycql` subcommand to connect to YugabyteDB with [ycqlsh](../../../admin/ycqlsh).
-
-#### Syntax
-
-```sh
-Usage: yugabyted connect ycql [flags]
-```
 
 #### Flags
 
@@ -596,6 +547,12 @@ Usage: yugabyted connect ycql [flags]
 
 Use the `yugabyted demo` command to use the demo [Northwind sample dataset](../../../sample-data/northwind/) with YugabyteDB.
 
+#### Syntax
+
+```sh
+Usage: yugabyted demo [command] [flags]
+```
+
 #### Commands
 
 The following subcommands are available for the `yugabyted demo` command:
@@ -603,69 +560,34 @@ The following subcommands are available for the `yugabyted demo` command:
 - [connect](#connect-1)
 - [destroy](#destroy-1)
 
-#### Syntax
-
-```sh
-Usage: yugabyted demo [command] [flags]
-```
-
 #### connect
 
 Use the `yugabyted demo connect` subcommand to load the  [Northwind sample dataset](../../../sample-data/northwind/) into a new `yb_demo_northwind` SQL database, and then open the `ysqlsh` prompt for the same database.
-
-#### Syntax
-
-```sh
-Usage: yugabyted demo connect [flags]
-```
-
-#### Flags
-
--h | --help
-: Print the help message and exit.
-
---config *config-file*
-: The path to the configuration file of the yugabyted server to connect to.
-
---data_dir *data-directory*
-: The data directory for the yugabyted server to connect to.
-
---base_dir *base-directory*
-: The base directory for the yugabyted server to connect to.
-
---log_dir *log-directory*
-: The log directory for the yugabyted server to connect to.
 
 #### destroy
 
 Use the `yuagbyted demo destroy` subcommand to shut down the yugabyted single-node cluster and remove data, configuration, and log directories. This subcommand also deletes the `yb_demo_northwind` database.
 
-#### Syntax
-
-```sh
-Usage: yugabyted demo destroy [flags]
-```
-
 #### Flags
 
 -h | --help
 : Print the help message and exit.
 
 --config *config-file*
-: The path to the configuration file of the yugabyted server to destroy.
+: The path to the configuration file of the yugabyted server to connect to or destroy.
 
 --data_dir *data-directory*
-: The data directory for the yugabyted server to destroy.
+: The data directory for the yugabyted server to connect to or destroy.
 
 --base_dir *base-directory*
-: The base directory for the yugabyted server to destroy.
+: The base directory for the yugabyted server to connect to or destroy.
 
 --log_dir *log-directory*
-: The log directory for the yugabyted server to destroy.
+: The log directory for the yugabyted server to connect to or destroy.
 
 -----
 
-## Environment Variables
+## Environment variables
 
 In the case of multi-node deployments, all nodes should have similar environment variables.
 

--- a/docs/content/preview/reference/configuration/yugabyted.md
+++ b/docs/content/preview/reference/configuration/yugabyted.md
@@ -743,9 +743,7 @@ The following are combinations of environment variables and their uses:
 
 ## Examples
 
-{{< note title="Note" >}}
-To deploy any type of secure cluster (that is, using the `--secure` flag) or use encryption at rest, OpenSSL must be installed.
-{{< /note >}}
+To deploy any type of secure cluster (that is, using the `--secure` flag) or use encryption at rest, OpenSSL must be installed on your machine.
 
 ### Create a single-node cluster
 
@@ -765,7 +763,7 @@ When authentication is enabled, the default user and password is `yugabyte` and 
 
 ### Create certificates for a secure local multi-node cluster
 
-Secure clusters use [encryption in transit](../../../secure/tls-encryption/), which requires SSL/TLS certificates for each node in the cluster. Generate the SSL/TLS certificates using the `--cert generate_server_certs` command and then copy them to the respective node base directories *before* you create a secure local multi-node cluster.
+Secure clusters use [encryption in transit](../../../secure/tls-encryption/), which requires SSL/TLS certificates for each node in the cluster. Generate the certificates using the `--cert generate_server_certs` command and then copy them to the respective node base directories *before* you create a secure local multi-node cluster.
 
 Create the certificates for SSL and TLS connection:
 
@@ -785,7 +783,7 @@ cp $HOME/var/generated_certs/127.0.0.3/* $HOME/yugabyte-{{< yb-version version="
 
 ### Create a local multi-node cluster
 
-To create a secure multi-node cluster, ensure you have generated and copied the certificates for each node.
+To create a secure multi-node cluster, ensure you have [generated and copied the certificates](#create-certificates-for-a-secure-local-multi-node-cluster) for each node.
 
 To create a cluster without encryption and authentication, omit the `--secure` flag.
 
@@ -877,7 +875,7 @@ Start the second and the third node on two separate VMs as follows:
 
 {{< /tabpane >}}
 
-After starting the yugabyted processes on all the nodes, configure the data placement constraint of the cluster:
+After starting the yugabyted processes on all the nodes, configure the data placement constraint of the cluster as follows:
 
 ```sh
 ./bin/yugabyted configure data_placement --fault_tolerance=zone

--- a/docs/content/preview/reference/configuration/yugabyted.md
+++ b/docs/content/preview/reference/configuration/yugabyted.md
@@ -884,7 +884,7 @@ You can set the replication factor of the cluster manually using the `--rf` flag
 
 {{< tabpane text=true >}}
 
-  {{% tab header="Secure" lang="secure" %}}
+  {{% tab header="Secure" lang="secure-2" %}}
 
 To create a secure multi-region cluster, start the first node by running the `yugabyted start` command, using the `--secure` flag and passing in the `--cloud_location` and `--fault_tolerance` flags to set the node location details, as follows:
 
@@ -915,7 +915,7 @@ Start the second and the third node on two separate VMs, as follows:
 
   {{% /tab %}}
 
-  {{% tab header="Basic" lang="basic" %}}
+  {{% tab header="Basic" lang="basic-2" %}}
 
 To create a multi-region cluster, start the first yugabyted node by running the `yugabyted start` command, pass in the `--cloud_location` and `--fault_tolerance` flags to set the node location details as follows:
 

--- a/docs/content/preview/reference/configuration/yugabyted.md
+++ b/docs/content/preview/reference/configuration/yugabyted.md
@@ -60,6 +60,7 @@ The following commands are available:
 
 - [start](#start)
 - [configure](#configure)
+- [cert](#cert)
 - [stop](#stop)
 - [destroy](#destroy)
 - [status](#status)
@@ -189,18 +190,35 @@ Advanced flags can be set by using the configuration file in the `--config` flag
 
 ### configure
 
-Use the `yugabyted configure` command to configure the data placement constraints for the YugabyteDB cluster.
+Use the `yugabyted configure` command to configure the data placement policy of the cluster or enable/disable encryption-at-rest.
+
+#### Commands
+
+The following sub-commands are available for `yugabyted configure` command:
+
+- [data_placement](#data-placement)
+- [encrypt_at_rest](#encrypt-at-rest)
 
 #### Syntax
 
-```text
-Usage: yugabyted configure [flags]
+```sh
+Usage: yugabyted configure [command] [flags]
+```
+
+#### data_placement
+
+Use the `yugabyted configure data_placement` sub-command to set or modify placement policy of the nodes of the deployed cluster.
+
+#### Syntax
+
+```sh
+Usage: yugabyted configure data_placement [flags]
 ```
 
 For example, to create a multi zone YugabyteDB cluster:
 
 ```sh
-yugabyted configure --fault_tolerance=zone
+yugabyted configure data_placement --fault_tolerance=zone
 ```
 
 #### Flags
@@ -208,10 +226,10 @@ yugabyted configure --fault_tolerance=zone
 -h | --help
 : Print the command line help and exit.
 
---fault_tolerance *fault_tolerance*
+--fault_tolerance *fault-tolerance*
 : Specify the fault tolerance for the cluster. This flag can accept one of these values - zone, region, or cloud. For example, when the flag is set to zone (`--fault_tolerance=zone`), yugabyted applies zone fault tolerance to the cluster, placing the nodes in 3 different zones, if available.
 
---data_placement_constraint *data-placement-constraint*
+--constraint_value *data-placement-constraint-value*
 : Specify the data placement for the YugabyteDB cluster. This is an optional flag. The flag takes comma-seperated values in the format `cloud.region.zone`.
 
 --rf *replication-factor*
@@ -226,7 +244,110 @@ yugabyted configure --fault_tolerance=zone
 --base_dir *base-directory*
 : The base directory for the yugabyted server.
 
+--log_dir *log-directory*
+: The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
+
+
+#### encrypt_at_rest
+
+Use the `yugabyted configure encrypt_at_rest` sub-command to enable/disable encryption-at-rest for the deployed cluster.
+
+#### Syntax
+
+```text
+Usage: yugabyted configure encrypt_at_rest [flags]
+```
+
+Examples:
+- To enable encryption-at-rest for a deployed YugabyteDB cluster:
+
+  ```sh
+  yugabyted configure encrypt_at_rest --enable
+  ```
+
+- To diable encryption-at-rest for YugabyteDB cluster which has encryption-at-rest enabled:
+
+  ```sh
+  yugabyted configure encrypt_at_rest --disable
+  ```
+
+#### Flags
+
+-h | --help
+: Print the command line help and exit.
+
+--disable *disable*
+: Disable encryption at rest for the cluster. No need to set a value for the flag. Use --enable or --disable flag to toggle encryption features on a YugabyteDB cluster.
+
+--enable *enable*
+: Enable encryption at rest for the cluster. No need to set a value for the flag. Use --enable or --disable flag to toggle encryption features on a YugabyteDB cluster.
+
+--config *config-file*
+: The path to the configuration file of the yugabyted server.
+
+--data_dir *data-directory*
+: The data directory for the yugabyted server.
+
+--base_dir *base-directory*
+: The base directory for the yugabyted server.
+
+--log_dir *log-directory*
+: The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
 -----
+
+### cert
+
+Use the `yugabyted cert` command to create TLS/SSL certificates for deploying a secure YugabyteDB cluster.
+
+#### Commands
+
+The following sub-commands are available for `yugabyted cert` command:
+
+- [generate_server_certs](#generate-server-certs)
+
+#### Syntax
+
+```text
+Usage: yugabyted cert [command] [flags]
+```
+
+#### generate_server_certs
+
+Use the `yugabyted cert generate_server_certs` sub-command to generate keys and certificates for the specified hostnames.
+
+#### Syntax
+
+```text
+Usage: yugabyted cert generate_server_certs [flags]
+```
+
+For example, to create node server certificates for hostnames 127.0.0.1, 127.0.0.2, 127.0.0.3:
+
+```sh
+Usage: yugabyted cert generate_server_certs --hostnames=127.0.0.1,127.0.0.2,127.0.0.3
+```
+
+#### Flags
+
+-h | --help
+: Print the command line help and exit.
+
+--hostnames *hostnames*
+: Hostnames of the nodes to be added in the cluster. Mandatory flag.
+
+--config *config-file*
+: The path to the configuration file of the yugabyted server.
+
+--data_dir *data-directory*
+: The data directory for the yugabyted server.
+
+--base_dir *base-directory*
+: The base directory for the yugabyted server. 
+
+--log_dir *log-directory*
+: The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
+
+------
 
 ### stop
 
@@ -235,8 +356,7 @@ Use the `yugabyted stop` command to stop a YugabyteDB cluster.
 #### Syntax
 
 ```sh
-Usage: yugabyted stop [-h] [--config CONFIG] [--data_dir DATA_DIR]
-                               [--base_dir BASE_DIR]
+Usage: yugabyted stop [flags]
 ```
 
 #### Flags
@@ -253,6 +373,9 @@ Usage: yugabyted stop [-h] [--config CONFIG] [--data_dir DATA_DIR]
 --base_dir *base-directory*
 : The base directory for the yugabyted server that needs to be stopped.
 
+--log_dir *log-directory*
+: The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
+
 -----
 
 ### destroy
@@ -262,8 +385,7 @@ Use the `yugabyted destroy` command to delete a cluster.
 #### Syntax
 
 ```sh
-Usage: yugabyted destroy [-h] [--config CONFIG] [--data_dir DATA_DIR]
-                                [--base_dir BASE_DIR]
+Usage: yugabyted destroy [flags]
 ```
 
 #### Flags
@@ -280,6 +402,9 @@ Usage: yugabyted destroy [-h] [--config CONFIG] [--data_dir DATA_DIR]
 --base_dir *base-directory*
 : The base directory for the yugabyted server that needs to be destroyed.
 
+--log_dir *log-directory*
+: The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
+
 -----
 
 ### status
@@ -289,8 +414,7 @@ Use the `yugabyted status` command to check the status.
 #### Syntax
 
 ```sh
-Usage: yugabyted status [-h] [--config CONFIG] [--data_dir DATA_DIR]
-                                 [--base_dir BASE_DIR]
+Usage: yugabyted status [flags]
 ```
 
 #### Flags
@@ -307,6 +431,9 @@ Usage: yugabyted status [-h] [--config CONFIG] [--data_dir DATA_DIR]
 --base_dir *base-directory*
 : The base directory for the yugabyted server that whose status is desired.
 
+--log_dir *log-directory*
+: The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
+
 -----
 
 ### version
@@ -316,8 +443,7 @@ Use the `yugabyted version` command to check the version number.
 #### Syntax
 
 ```sh
-Usage: yugabyted version [-h] [--config CONFIG] [--data_dir DATA_DIR]
-                                  [--base_dir BASE_DIR]
+Usage: yugabyted version [flags]
 ```
 
 #### Flags
@@ -334,6 +460,9 @@ Usage: yugabyted version [-h] [--config CONFIG] [--data_dir DATA_DIR]
 --base_dir *base-directory*
 : The base directory for the yugabyted server that whose version is desired.
 
+--log_dir *log-directory*
+: The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
+
 -----
 
 ### collect_logs
@@ -343,9 +472,56 @@ Use the `yugabyted collect_logs` command to generate a zipped file with all logs
 #### Syntax
 
 ```sh
-Usage: yugabyted collect_logs [-h] [--config CONFIG]
-                                       [--data_dir DATA_DIR]
-                                       [--base_dir BASE_DIR]
+Usage: yugabyted collect_logs [flags]
+```
+
+#### Flags
+
+-h | --help
+: Print the command line help and exit.
+
+--stdout *stdout*
+: Redirect the logs.tar.gz file's content to stdout. Ex: docker exec \<container-id\> bin/yugabyted collect_logs --stdout > yugabyted.tar.gz
+
+--config *config-file*
+: The path to the configuration file of the yugabyted server whose logs are desired.
+
+--data_dir *data-directory*
+: The data directory for the yugabyted server whose logs are desired.
+
+--base_dir *base-directory*
+: The base directory for the yugabyted server whose logs are desired.
+
+--log_dir *log-directory*
+: The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
+
+-----
+
+### connect
+
+Use the `yugabyted connect` command to connect to the cluster using [ysqlsh](../../../admin/ysqlsh/) or [ycqlsh](../../../admin/ycqlsh).
+
+#### Commands
+
+The following sub-commands are available for `yugabyted connect` command:
+
+- [ysql](#ysql)
+- [ycql](#ycql)
+
+#### Syntax
+
+```sh
+Usage: yugabyted connect [command] [flags]
+```
+
+#### ysql
+
+Use the `yugabyted connect ysql` sub-command to connect to YugabyteDB with [ysqlsh](../../../admin/ysqlsh/).
+
+#### Syntax
+
+```sh
+Usage: yugabyted connect ysql [flags]
 ```
 
 #### Flags
@@ -362,16 +538,17 @@ Usage: yugabyted collect_logs [-h] [--config CONFIG]
 --base_dir *base-directory*
 : The base directory for the yugabyted server whose logs are desired.
 
------
+--log_dir *log-directory*
+: The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
 
-### connect
+#### ycql
 
-Use the `yugabyted connect` command to connect to the cluster using [ysqlsh](../../../admin/ysqlsh/) or [ycqlsh](../../../admin/ycqlsh).
+Use the `yugabyted connect ycql` sub-command to connect to YugabyteDB with [ycqlsh](../../../admin/ycqlsh).
 
 #### Syntax
 
 ```sh
-Usage: yugabyted connect [-h] {ycql,ysql} ...
+Usage: yugabyted connect ycql [flags]
 ```
 
 #### Flags
@@ -379,22 +556,45 @@ Usage: yugabyted connect [-h] {ycql,ysql} ...
 -h | --help
 : Print the command line help and exit.
 
---ysql
-: Connect with ysqlsh.
+--config *config-file*
+: The path to the configuration file of the yugabyted server whose logs are desired.
 
---ycql
-: Connect with ycqlsh.
+--data_dir *data-directory*
+: The data directory for the yugabyted server whose logs are desired.
+
+--base_dir *base-directory*
+: The base directory for the yugabyted server whose logs are desired.
+
+--log_dir *log-directory*
+: The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
 
 -----
 
 ### demo
 
-Use the `yugabyted demo connect` command to start YugabyteDB with the [Northwind sample dataset](../../../sample-data/northwind/).
+Use the `yugabyted demo` command to use the demo [Northwind sample dataset](../../../sample-data/northwind/) with YugabyteDB.
+
+#### Commands
+
+The following sub-commands are available for `yugabyted demo` command:
+
+- [connect](#connect-1)
+- [destroy](#destroy-1)
 
 #### Syntax
 
 ```sh
-Usage: yugabyted demo [-h] {connect,destroy} ...
+Usage: yugabyted demo [command] [flags]
+```
+
+#### connect
+
+Use the `yugabyted demo connect` sub-command to load the [Northwind sample dataset](../../../sample-data/northwind/) into a new `yb_demo_northwind` SQL database and then open the `ysqlsh` prompt for the same database. Skips the data load if data is already loaded.
+
+#### Syntax
+
+```sh
+Usage: yugabyted demo connect [flags]
 ```
 
 #### Flags
@@ -402,12 +602,44 @@ Usage: yugabyted demo [-h] {connect,destroy} ...
 -h | --help
 : Print the help message and exit.
 
-connect
-: Loads the Northwind sample dataset into a new `yb_demo_northwind` SQL database and then opens the `ysqlsh` prompt for the same database. Skips the data load if data is already loaded.
+--config *config-file*
+: The path to the configuration file of the yugabyted server whose logs are desired.
 
-destroy
-: Shuts down the yugabyted single-node cluster and removes data, configuration, and log directories.
-: Deletes the `yb_demo_northwind` database.
+--data_dir *data-directory*
+: The data directory for the yugabyted server whose logs are desired.
+
+--base_dir *base-directory*
+: The base directory for the yugabyted server whose logs are desired.
+
+--log_dir *log-directory*
+: The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
+
+#### destroy
+
+Use the `yuagbyted demo destroy` sub-command to shut down the yugabyted single-node cluster and remove data, configuration, and log directories. This sub-command also deletes the `yb_demo_northwind` database.
+
+#### Syntax
+
+```sh
+Usage: yugabyted demo destroy [flags]
+```
+
+#### Flags
+
+-h | --help
+: Print the help message and exit.
+
+--config *config-file*
+: The path to the configuration file of the yugabyted server whose logs are desired.
+
+--data_dir *data-directory*
+: The data directory for the yugabyted server whose logs are desired.
+
+--base_dir *base-directory*
+: The base directory for the yugabyted server whose logs are desired.
+
+--log_dir *log-directory*
+: The directory to store yugabyted logs. Must be an absolute path. This flag controls where the logs of the YugabyteDB nodes are stored.
 
 -----
 
@@ -489,12 +721,26 @@ Combinations of environment variables and their uses.
 
 ## Examples
 
-### Create a single-node cluster
+### Create a single-node cluster (Insecure)
 
 Create a single-node cluster with a given base directory. Note the need to provide a fully-qualified directory path for the `base_dir` parameter.
 
 ```sh
 ./bin/yugabyted start --advertise_address=127.0.0.1 --base_dir=/Users/username/yugabyte-{{< yb-version version="preview" >}}/data1
+```
+
+### Create a single-node cluster (Secure)
+
+{{< note title="Note" >}}
+
+openssl must be installed in the machine to deploy a secure cluster.
+
+{{< /note >}}
+
+Create a single-node secure cluster with a given base directory. Note the need to provide a fully-qualified directory path for the `base_dir` parameter.
+
+```sh
+./bin/yugabyted start --secure --advertise_address=127.0.0.1 --base_dir=/Users/username/yugabyte-{{< yb-version version="preview" >}}/data1
 ```
 
 ### Pass additional flags to YB-TServer
@@ -505,7 +751,7 @@ Create a single-node cluster and set additional flags for the YB-TServer process
 ./bin/yugabyted start --tserver_flags="pg_yb_session_timeout_ms=1200000,ysql_max_connections=400"
 ```
 
-### Create a local multi-node cluster
+### Create a local multi-node cluster (Insecure)
 
 Run the following command:
 
@@ -527,17 +773,79 @@ Add two more nodes to the cluster using the `join` option.
 ./bin/yugabyted start --advertise_address=127.0.0.3 --join=127.0.0.1 --base_dir=$HOME/yugabyte-{{< yb-version version="preview" >}}/node3 --cloud_location=aws.us-east.us-east-3a
 ```
 
+### Create a local multi-node cluster (Secure)
+
+{{< note title="Note" >}}
+
+openssl must be installed in the machine to deploy a secure cluster.
+
+{{< /note >}}
+
+Create the certificates for SSL/TLS connection:
+
+```sh
+./bin/yugabyted cert generate_server_certs --hostnames=127.0.0.1,127.0.0.2,127.0.0.3
+```
+
+The certs are generated at `<HOME>/var/generated_certs/<hostname>`. Copy the certificates to the respective node's `<base_dir>/certs`.
+
+```sh
+cp $HOME/var/generated_certs/127.0.0.1/* $HOME/yugabyte-{{< yb-version version="preview" >}}/node1/certs
+cp $HOME/var/generated_certs/127.0.0.2/* $HOME/yugabyte-{{< yb-version version="preview" >}}/node2/certs
+cp $HOME/var/generated_certs/127.0.0.3/* $HOME/yugabyte-{{< yb-version version="preview" >}}/node3/certs
+```
+
+Start the 1st node by running the following command:
+
+```sh
+./bin/yugabyted start --secure --advertise_address=127.0.0.1 --base_dir=$HOME/yugabyte-{{< yb-version version="preview" >}}/node1 --cloud_location=aws.us-east.us-east-1a
+```
+
+On MacOS and Linux, the additional nodes need loopback addresses configured:
+
+```sh
+sudo ifconfig lo0 alias 127.0.0.2
+sudo ifconfig lo0 alias 127.0.0.3
+```
+
+Add two more nodes to the cluster using the `join` option.
+
+```sh
+./bin/yugabyted start --secure --advertise_address=127.0.0.2 --join=127.0.0.1 --base_dir=$HOME/yugabyte-{{< yb-version version="preview" >}}/node2 --cloud_location=aws.us-east.us-east-2a
+./bin/yugabyted start --secure --advertise_address=127.0.0.3 --join=127.0.0.1 --base_dir=$HOME/yugabyte-{{< yb-version version="preview" >}}/node3 --cloud_location=aws.us-east.us-east-3a
+```
+
+### Toggling Encryption-at-rest in a local cluster
+
+{{< note title="Note" >}}
+
+openssl must be installed in the machine to enable encryption-at-rest.
+
+{{< /note >}}
+
+Create a cluster using desired local deployment example given above.
+
+To enable encryption-at-rest in a deployed cluster, run:
+```sh
+./bin/yugabyted configure encrypt_at_rest --enable --base_dir=$HOME/yugabyte-{{< yb-version version="preview" >}}/node1
+```
+
+To disbale encryption-at-rest in a cluster with encryption-at-rest enabled, run:
+```sh
+./bin/yugabyted configure encrypt_at_rest --disable --base_dir=$HOME/yugabyte-{{< yb-version version="preview" >}}/node1
+```
+
 ### Destroy a local multi-node cluster
 
 Destroy the above multi-node cluster.
 
 ```sh
-./bin/yugabyted destroy --base_dir=/Users/username/yugabyte-{{< yb-version version="preview" >}}/data1
-./bin/yugabyted destroy --base_dir=/Users/username/yugabyte-{{< yb-version version="preview" >}}/data2
-./bin/yugabyted destroy --base_dir=/Users/username/yugabyte-{{< yb-version version="preview" >}}/data3
+./bin/yugabyted destroy --base_dir=$HOME/yugabyte-{{< yb-version version="preview" >}}/node1
+./bin/yugabyted destroy --base_dir=$HOME/yugabyte-{{< yb-version version="preview" >}}/node2
+./bin/yugabyted destroy --base_dir=$HOME/yugabyte-{{< yb-version version="preview" >}}/node3
 ```
 
-### Create a multi-zone cluster
+### Create a multi-zone cluster (Insecure)
 
 To create a multi-node cluster, you start the first node by running the `yugabyted start` command, passing in the `--cloud_location` and `--fault_tolerance` flags to set the node location details, as follows:
 
@@ -556,26 +864,81 @@ Start the second and the third node on two separate VMs:
 After starting the yugabyted processes on all the nodes, configure the data placement constraint of the cluster:
 
 ```sh
-./bin/yugabyted configure --fault_tolerance=zone
+./bin/yugabyted configure data_placement --fault_tolerance=zone
 ```
 
 This command automatically determines the data placement constraint based on the `--cloud_location` of each node in the cluster. If there are 3 or more zones available in the cluster, the configure command configures the cluster to survive at least 1 availability zone failure. Otherwise, it outputs a warning message.
 
 The replication factor of the cluster defaults to 3.
 
-You can set the data placement constraint manually using the `--data_placement_constraint` flag, which takes the comma-separated value of `cloud.region.zone`. For example:
+You can set the data placement constraint manually using the `--constraint_value` flag, which takes the comma-separated value of `cloud.region.zone`. For example:
 
 ```sh
-./bin/yugabyted configure --fault_tolerance=zone --data_placement_constraint=aws.us-east.us-east-1a,aws.us-east.us-east-2a,aws.us-east.us-east-3a
+./bin/yugabyted configure data_placement --fault_tolerance=zone --constraint_value=aws.us-east.us-east-1a,aws.us-east.us-east-2a,aws.us-east.us-east-3a
 ```
 
 You can set the replication factor of the cluster manually using the `--rf` flag. For example:
 
 ```sh
-./bin/yugabyted configure --fault_tolerance=zone --data_placement_constraint=aws.us-east.us-east-1a,aws.us-east.us-east-2a,aws.us-east.us-east-3a --rf=3
+./bin/yugabyted configure data_placement --fault_tolerance=zone --constraint_value=aws.us-east.us-east-1a,aws.us-east.us-east-2a,aws.us-east.us-east-3a --rf=3
 ```
 
-### Create a multi-region cluster
+### Create a multi-zone cluster (Secure)
+
+{{< note title="Note" >}}
+
+openssl must be installed in the 1st VM to deploy a secure cluster.
+
+{{< /note >}}
+
+To create a multi-node secrue cluster, you start the first node by running the `yugabyted start` command, using the `--secure` flag and passing in the `--cloud_location` and `--fault_tolerance` flags to set the node location details, as follows:
+
+```sh
+./bin/yugabyted start --secure --advertise_address=<host-ip> --cloud_location=aws.us-east.us-east-1a --fault_tolerance=zone
+```
+
+Create the certificates for 2nd and 3rd VM for SSL/TLS connection.
+
+```sh
+./bin/yugabyted cert generate_server_certs --hostnames=<IP_of_VM_2>,<IP_of_VM_3>
+```
+
+Manually copy the generated certificates in the 1st VM to 2nd and 3rd VM.
+
+Copy the certificates for 2nd VM from `$HOME/var/generated_certs/<IP_of_VM_2>` in 1st VM to `$HOME/var/certs` in 2nd VM.
+Copy the certificates for 3nd VM from `$HOME/var/generated_certs/<IP_of_VM_3>` in 1st VM to `$HOME/var/certs` in 3nd VM.
+
+Start the second and the third node on two separate VMs:
+
+```sh
+./bin/yugabyted start --secure --advertise_address=<host-ip> --join=<ip-address-first-yugabyted-node> --cloud_location=aws.us-east.us-east-2a --fault_tolerance=zone
+
+./bin/yugabyted start --secure --advertise_address=<host-ip> --join=<ip-address-first-yugabyted-node> --cloud_location=aws.us-east.us-east-3a --fault_tolerance=zone
+```
+
+After starting the yugabyted processes on all the nodes, configure the data placement constraint of the cluster:
+
+```sh
+./bin/yugabyted configure data_placement --fault_tolerance=zone
+```
+
+This command automatically determines the data placement constraint based on the `--cloud_location` of each node in the cluster. If there are 3 or more zones available in the cluster, the configure command configures the cluster to survive at least 1 availability zone failure. Otherwise, it outputs a warning message.
+
+The replication factor of the cluster defaults to 3.
+
+You can set the data placement constraint manually using the `--constraint_value` flag, which takes the comma-separated value of `cloud.region.zone`. For example:
+
+```sh
+./bin/yugabyted configure data_placement --fault_tolerance=zone --data_placement_constraint=aws.us-east.us-east-1a,aws.us-east.us-east-2a,aws.us-east.us-east-3a
+```
+
+You can set the replication factor of the cluster manually using the `--rf` flag. For example:
+
+```sh
+./bin/yugabyted configure data_placement --fault_tolerance=zone --data_placement_constraint=aws.us-east.us-east-1a,aws.us-east.us-east-2a,aws.us-east.us-east-3a --rf=3
+```
+
+### Create a multi-region cluster (Insecure)
 
 To create a multi-region cluster, start the first yugabyted node by running the `yugabyted start` command, pass in the `--cloud_location` and `--fault_tolerance` flags to set the node location details as follows:
 
@@ -594,23 +957,43 @@ Start the second and the third nodes on two separate VMs as follows:
 After starting the yugabyted processes on all the nodes, configure the data placement constraint of the YugabyteDB cluster as follows:
 
 ```sh
-./bin/yugabyted configure --fault_tolerance=region
+./bin/yugabyted configure data_placement --fault_tolerance=region
 ```
 
 This command determines the data placement constraint based on the `--cloud_location` of each node in the cluster. If there are 3 or more regions available in the cluster, the command configures the cluster to survive at least 1 region failure. Otherwise, it outputs a warning message.
 
 The replication factor of the cluster defaults to 3.
 
-You can set the data placement constraint manually using the `--data_placement_constraint` flag, which takes the comma-separated value of `cloud.region.zone` as follows:
+You can set the data placement constraint manually using the `--constraint_value` flag, which takes the comma-separated value of `cloud.region.zone` as follows:
 
 ```sh
-./bin/yugabyted configure --fault_tolerance=region --data_placement_constraint=aws.us-east.us-east-1a,aws.us-west.us-west-1a,aws.us-central.us-central-1a
+./bin/yugabyted configure data_placement --fault_tolerance=region --constraint_value=aws.us-east.us-east-1a,aws.us-west.us-west-1a,aws.us-central.us-central-1a
 ```
 
 You can set the replication factor of the cluster manually using the `--rf` flag as follows:
 
 ```sh
-./bin/yugabyted configure --fault_tolerance=region --data_placement_constraint=aws.us-east.us-east-1a,aws.us-west.us-west-1a,aws.us-central.us-central-1a --rf=3
+./bin/yugabyted configure data_placement --fault_tolerance=region --constraint_value=aws.us-east.us-east-1a,aws.us-west.us-west-1a,aws.us-central.us-central-1a --rf=3
+```
+
+### Toggling Encryption-at-rest in a multi-zone or multi-region cluster
+
+{{< note title="Note" >}}
+
+openssl must be installed in the machine to enable encryption-at-rest.
+
+{{< /note >}}
+
+Create a cluster using desired deployment example given above.
+
+To enable encryption-at-rest in a deployed cluster, run the following command from any VM:
+```sh
+./bin/yugabyted configure encrypt_at_rest --enable
+```
+
+To disbale encryption-at-rest in a cluster with encryption-at-rest enabled, run the following command from any VM:
+```sh
+./bin/yugabyted configure encrypt_at_rest --disable
 ```
 
 ## Upgrade a YugabyteDB cluster


### PR DESCRIPTION
Summary: Updated the yugabyted CLI reference page:
* Added description, sub-command and flags for command 'cert'.
* Added description and flags for sub-commands 'data_placement' and 'encrypt_at_rest' under 'configure' command.
* Added examples for secure deployment and toggling encryption-at-rest.

Reviewers: nchandrappa

Subscribers: gargsans-yb