### PR TITLE
Fix shellcheck warnings and lower the required CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@
 # under the License.
 #
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.17.3)
 
 project(YugabyteDB)
 

--- a/build-support/run-test.sh
+++ b/build-support/run-test.sh
@@ -130,6 +130,7 @@ fi
 
 yb_ninja_executable_not_needed=true
 if [[ -z ${BUILD_ROOT:-} ]]; then
+  # shellcheck disable=SC2119
   set_build_root
 fi
 readonly BUILD_ROOT

--- a/yb_build.sh
+++ b/yb_build.sh
@@ -478,13 +478,13 @@ run_cxx_build() {
     if [[ ${cmake_exit_code} != 0 ]]; then
       log "CMake failed with exit code ${cmake_exit_code}."
       (
-        find "${BUILD_ROOT}" -name "CMake*.log" | while read log_path; do
+        find "${BUILD_ROOT}" -name "CMake*.log" | while read -r cmake_log_path; do
           echo
           echo "----------------------------------------------------------------------------------"
-          echo "Contents of ${log_path}:"
+          echo "Contents of ${cmake_log_path}:"
           echo "----------------------------------------------------------------------------------"
           echo
-          cat "${log_path}"
+          cat "${cmake_log_path}"
           echo
           echo "----------------------------------------------------------------------------------"
           echo


### PR DESCRIPTION
- Fix shellcheck warnings in run-test.sh and yb_build.sh.
- Change required CMake version to 3.17.3.