### PR TITLE
[docs] Quote urls in wget command to work under macos zsh shell because it's interpreting the `?` in the URL as a globbing wildcard

### DIFF
--- a/docs/content/preview/benchmark/key-value-workload-ycql.md
+++ b/docs/content/preview/benchmark/key-value-workload-ycql.md
@@ -67,7 +67,7 @@ We will use the [YugabyteDB Workload Generator](https://github.com/yugabyte/yb-s
 To get the tool (``yb-sample-apps.jar`), run the following command.
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 To run the workload generator tool, you must have:

--- a/docs/content/preview/explore/ysql-language-features/going-beyond-sql/follower-reads-ycql.md
+++ b/docs/content/preview/explore/ysql-language-features/going-beyond-sql/follower-reads-ycql.md
@@ -76,7 +76,7 @@ $ ./bin/yb-ctl add_node
 Download the [YugabyteDB workload generator](https://github.com/yugabyte/yb-sample-apps) JAR file (`yb-sample-apps.jar`) by running the following command:
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 By default, the YugabyteDB workload generator runs with strong read consistency, where all data is read from the tablet leader. Note that the `yb-sample-apps.jar` sets the [consistency](../../../../admin/ycqlsh/#consistency) level to ONE by default. You can populate exactly one key with a `10KB` value into the system. Because the replication factor is `3`, this key is replicated to only three of the four nodes in the cluster.

--- a/docs/content/stable/benchmark/key-value-workload-ycql.md
+++ b/docs/content/stable/benchmark/key-value-workload-ycql.md
@@ -64,7 +64,7 @@ We will use the [YugabyteDB Workload Generator](https://github.com/yugabyte/yb-s
 To get the tool (``yb-sample-apps.jar`), run the following command.
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 To run the workload generator tool, you must have:

--- a/docs/content/stable/explore/linear-scalability/scaling-transactions.md
+++ b/docs/content/stable/explore/linear-scalability/scaling-transactions.md
@@ -80,7 +80,7 @@ Each table now has four tablet-leaders in each YB-TServer and with a replication
 Download the YugabyteDB workload generator JAR file (`yb-sample-apps.jar`).
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 Run the `SqlInserts` workload app against the local cluster using the following command.

--- a/docs/content/stable/explore/ysql-language-features/going-beyond-sql/follower-reads-ycql.md
+++ b/docs/content/stable/explore/ysql-language-features/going-beyond-sql/follower-reads-ycql.md
@@ -70,7 +70,7 @@ $ ./bin/yb-ctl add_node
 Download the [YugabyteDB workload generator](https://github.com/yugabyte/yb-sample-apps) JAR file (`yb-sample-apps.jar`) by running the following command:
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 By default, the YugabyteDB workload generator runs with strong read consistency, where all data is read from the tablet leader. Note that the `yb-sample-apps.jar` sets the [consistency](../../../../admin/ycqlsh/#consistency) level to ONE by default. You can populate exactly one key with a `10KB` value into the system. Because the replication factor is `3`, this key is replicated to only three of the four nodes in the cluster.

--- a/docs/content/v2.12/benchmark/key-value-workload-ycql.md
+++ b/docs/content/v2.12/benchmark/key-value-workload-ycql.md
@@ -64,7 +64,7 @@ We will use the [YugabyteDB Workload Generator](https://github.com/yugabyte/yb-s
 To get the tool (``yb-sample-apps.jar`), run the following command.
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 To run the workload generator tool, you must have:

--- a/docs/content/v2.12/explore/linear-scalability/scaling-transactions.md
+++ b/docs/content/v2.12/explore/linear-scalability/scaling-transactions.md
@@ -79,7 +79,7 @@ Each table now has four tablet-leaders in each YB-TServer and with a replication
 Download the YugabyteDB workload generator JAR file (`yb-sample-apps.jar`).
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 Run the `SqlInserts` workload app against the local universe using the following command.

--- a/docs/content/v2.12/explore/multi-region-deployments/synchronous-replication-ycql.md
+++ b/docs/content/v2.12/explore/multi-region-deployments/synchronous-replication-ycql.md
@@ -63,7 +63,7 @@ You can view the tablet servers on the [tablet servers page](http://localhost:70
 Download the [YugabyteDB workload generator](https://github.com/yugabyte/yb-sample-apps) JAR file (`yb-sample-apps.jar`) by running the following command.
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 Run a `SqlInserts` workload in a separate shell.

--- a/docs/content/v2.12/explore/multi-region-deployments/synchronous-replication-ysql.md
+++ b/docs/content/v2.12/explore/multi-region-deployments/synchronous-replication-ysql.md
@@ -63,7 +63,7 @@ You can view the tablet servers on the [tablet servers page](http://localhost:70
 Download the [YugabyteDB workload generator](https://github.com/yugabyte/yb-sample-apps) JAR file (`yb-sample-apps.jar`) by running the following command.
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 Run a `SqlInserts` workload in a separate shell.

--- a/docs/content/v2.12/explore/observability/prometheus-integration/macos.md
+++ b/docs/content/v2.12/explore/observability/prometheus-integration/macos.md
@@ -54,7 +54,7 @@ $ ./bin/yugabyted start \
 Download the [YugabyteDB workload generator](https://github.com/yugabyte/yb-sample-apps) JAR file (`yb-sample-apps.jar`) by running the following command.
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 Run the `CassandraKeyValue` workload application in a separate shell.

--- a/docs/content/v2.12/explore/ysql-language-features/going-beyond-sql/follower-reads-ycql.md
+++ b/docs/content/v2.12/explore/ysql-language-features/going-beyond-sql/follower-reads-ycql.md
@@ -70,7 +70,7 @@ $ ./bin/yb-ctl add_node
 Download the [YugabyteDB workload generator](https://github.com/yugabyte/yb-sample-apps) JAR file (`yb-sample-apps.jar`) by running the following command:
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 By default, the YugabyteDB workload generator runs with strong read consistency, where all data is read from the tablet leader. Note that the `yb-sample-apps.jar` sets the [consistency](../../../../admin/ycqlsh/#consistency) level to ONE by default. You can populate exactly one key with a `10KB` value into the system. Because the replication factor is `3`, this key is replicated to only three of the four nodes in the universe.

--- a/docs/content/v2.14/benchmark/key-value-workload-ycql.md
+++ b/docs/content/v2.14/benchmark/key-value-workload-ycql.md
@@ -64,7 +64,7 @@ We will use the [YugabyteDB Workload Generator](https://github.com/yugabyte/yb-s
 To get the tool (``yb-sample-apps.jar`), run the following command.
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 To run the workload generator tool, you must have:

--- a/docs/content/v2.14/explore/linear-scalability/scaling-transactions.md
+++ b/docs/content/v2.14/explore/linear-scalability/scaling-transactions.md
@@ -79,7 +79,7 @@ Each table now has four tablet-leaders in each YB-TServer and with a replication
 Download the YugabyteDB workload generator JAR file (`yb-sample-apps.jar`).
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 Run the `SqlInserts` workload app against the local universe using the following command.

--- a/docs/content/v2.14/explore/multi-region-deployments/synchronous-replication-ycql.md
+++ b/docs/content/v2.14/explore/multi-region-deployments/synchronous-replication-ycql.md
@@ -63,7 +63,7 @@ You can view the tablet servers on the [tablet servers page](http://localhost:70
 Download the [YugabyteDB workload generator](https://github.com/yugabyte/yb-sample-apps) JAR file (`yb-sample-apps.jar`) by running the following command.
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 Run a `SqlInserts` workload in a separate shell.

--- a/docs/content/v2.14/explore/multi-region-deployments/synchronous-replication-ysql.md
+++ b/docs/content/v2.14/explore/multi-region-deployments/synchronous-replication-ysql.md
@@ -63,7 +63,7 @@ You can view the tablet servers on the [tablet servers page](http://localhost:70
 Download the [YugabyteDB workload generator](https://github.com/yugabyte/yb-sample-apps) JAR file (`yb-sample-apps.jar`) by running the following command.
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 Run a `SqlInserts` workload in a separate shell.

--- a/docs/content/v2.14/explore/observability/prometheus-integration/macos.md
+++ b/docs/content/v2.14/explore/observability/prometheus-integration/macos.md
@@ -54,7 +54,7 @@ $ ./bin/yugabyted start \
 Download the [YugabyteDB workload generator](https://github.com/yugabyte/yb-sample-apps) JAR file (`yb-sample-apps.jar`) by running the following command.
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 Run the `CassandraKeyValue` workload application in a separate shell.

--- a/docs/content/v2.14/explore/ysql-language-features/going-beyond-sql/follower-reads-ycql.md
+++ b/docs/content/v2.14/explore/ysql-language-features/going-beyond-sql/follower-reads-ycql.md
@@ -70,7 +70,7 @@ $ ./bin/yb-ctl add_node
 Download the [YugabyteDB workload generator](https://github.com/yugabyte/yb-sample-apps) JAR file (`yb-sample-apps.jar`) by running the following command:
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 By default, the YugabyteDB workload generator runs with strong read consistency, where all data is read from the tablet leader. Note that the `yb-sample-apps.jar` sets the [consistency](../../../../admin/ycqlsh/#consistency) level to ONE by default. You can populate exactly one key with a `10KB` value into the system. Because the replication factor is `3`, this key will get replicated to only three of the four nodes in the universe.

--- a/docs/content/v2.6/benchmark/key-value-workload-ycql.md
+++ b/docs/content/v2.6/benchmark/key-value-workload-ycql.md
@@ -64,7 +64,7 @@ We will use the [YugabyteDB Workload Generator](https://github.com/yugabyte/yb-s
 To get the tool (``yb-sample-apps.jar`), run the following command.
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 To run the workload generator tool, you must have:

--- a/docs/content/v2.6/explore/fault-tolerance/linux.md
+++ b/docs/content/v2.6/explore/fault-tolerance/linux.md
@@ -78,7 +78,7 @@ Next, create a 3 node cluster by joining two more nodes with the previous node. 
 Download the YugabyteDB workload generator JAR file (`yb-sample-apps.jar`).
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 Run the `SqlInserts` workload against the local universe using the following command.

--- a/docs/content/v2.6/explore/fault-tolerance/macos.md
+++ b/docs/content/v2.6/explore/fault-tolerance/macos.md
@@ -78,7 +78,7 @@ Next, create a 3 node cluster by joining two more nodes with the previous node. 
 Download the YugabyteDB workload generator JAR file (`yb-sample-apps.jar`).
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 Run the `SqlInserts` workload against the local universe using the following command.

--- a/docs/content/v2.6/explore/linear-scalability/scaling-transactions.md
+++ b/docs/content/v2.6/explore/linear-scalability/scaling-transactions.md
@@ -79,7 +79,7 @@ Each table now has four tablet-leaders in each YB-TServer and with a replication
 Download the YugabyteDB workload generator JAR file (`yb-sample-apps.jar`).
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 Run the `SqlInserts` workload app against the local universe using the following command.

--- a/docs/content/v2.6/explore/linear-scalability/sharding-data.md
+++ b/docs/content/v2.6/explore/linear-scalability/sharding-data.md
@@ -250,7 +250,7 @@ Let's get started:
 1. Download the YugabyteDB workload generator JAR file (`yb-sample-apps.jar`):
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 1. Run the `CassandraKeyValue` workload application.

--- a/docs/content/v2.6/explore/multi-region-deployments/follower-reads-ycql.md
+++ b/docs/content/v2.6/explore/multi-region-deployments/follower-reads-ycql.md
@@ -54,7 +54,7 @@ $ ./bin/yb-ctl add_node
 Download the [YugabyteDB workload generator](https://github.com/yugabyte/yb-sample-apps) JAR file (`yb-sample-apps.jar`) by running the following command:
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 By default, the YugabyteDB workload generator runs with strong read consistency, where all data is read from the tablet leader. We are going to populate exactly one key with a `10KB` value into the system. Since the replication factor is `3`, this key will get replicated to only three of the four nodes in the universe.

--- a/docs/content/v2.6/explore/multi-region-deployments/synchronous-replication-ycql.md
+++ b/docs/content/v2.6/explore/multi-region-deployments/synchronous-replication-ycql.md
@@ -63,7 +63,7 @@ You can view the tablet servers on the [tablet servers page](http://localhost:70
 Download the [YugabyteDB workload generator](https://github.com/yugabyte/yb-sample-apps) JAR file (`yb-sample-apps.jar`) by running the following command.
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 Run a `SqlInserts` workload in a separate shell.

--- a/docs/content/v2.6/explore/multi-region-deployments/synchronous-replication-ysql.md
+++ b/docs/content/v2.6/explore/multi-region-deployments/synchronous-replication-ysql.md
@@ -63,7 +63,7 @@ You can view the tablet servers on the [tablet servers page](http://localhost:70
 Download the [YugabyteDB workload generator](https://github.com/yugabyte/yb-sample-apps) JAR file (`yb-sample-apps.jar`) by running the following command.
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 Run a `SqlInserts` workload in a separate shell.

--- a/docs/content/v2.6/explore/observability/prometheus-integration/linux.md
+++ b/docs/content/v2.6/explore/observability/prometheus-integration/linux.md
@@ -86,7 +86,7 @@ $ ./bin/yugabyted start \
 Download the [YugabyteDB workload generator](https://github.com/yugabyte/yb-sample-apps) JAR file (`yb-sample-apps.jar`) by running the following command.
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 Run the `CassandraKeyValue` workload application in a separate shell.

--- a/docs/content/v2.6/explore/observability/prometheus-integration/macos.md
+++ b/docs/content/v2.6/explore/observability/prometheus-integration/macos.md
@@ -86,7 +86,7 @@ $ ./bin/yugabyted start \
 Download the [YugabyteDB workload generator](https://github.com/yugabyte/yb-sample-apps) JAR file (`yb-sample-apps.jar`) by running the following command.
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 Run the `CassandraKeyValue` workload application in a separate shell.

--- a/docs/content/v2.8/benchmark/key-value-workload-ycql.md
+++ b/docs/content/v2.8/benchmark/key-value-workload-ycql.md
@@ -64,7 +64,7 @@ We will use the [YugabyteDB Workload Generator](https://github.com/yugabyte/yb-s
 To get the tool (``yb-sample-apps.jar`), run the following command.
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 To run the workload generator tool, you must have:

--- a/docs/content/v2.8/explore/fault-tolerance/linux.md
+++ b/docs/content/v2.8/explore/fault-tolerance/linux.md
@@ -78,7 +78,7 @@ Next, create a 3 node cluster by joining two more nodes with the previous node. 
 Download the YugabyteDB workload generator JAR file (`yb-sample-apps.jar`).
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 Run the `SqlInserts` workload against the local universe using the following command.

--- a/docs/content/v2.8/explore/fault-tolerance/macos.md
+++ b/docs/content/v2.8/explore/fault-tolerance/macos.md
@@ -78,7 +78,7 @@ Next, create a 3 node cluster by joining two more nodes with the previous node. 
 Download the YugabyteDB workload generator JAR file (`yb-sample-apps.jar`).
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 Run the `SqlInserts` workload against the local universe using the following command.

--- a/docs/content/v2.8/explore/linear-scalability/scaling-transactions.md
+++ b/docs/content/v2.8/explore/linear-scalability/scaling-transactions.md
@@ -79,7 +79,7 @@ Each table now has four tablet-leaders in each YB-TServer and with a replication
 Download the YugabyteDB workload generator JAR file (`yb-sample-apps.jar`).
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 Run the `SqlInserts` workload app against the local universe using the following command.

--- a/docs/content/v2.8/explore/multi-region-deployments/follower-reads-ycql.md
+++ b/docs/content/v2.8/explore/multi-region-deployments/follower-reads-ycql.md
@@ -54,7 +54,7 @@ $ ./bin/yb-ctl add_node
 Download the [YugabyteDB workload generator](https://github.com/yugabyte/yb-sample-apps) JAR file (`yb-sample-apps.jar`) by running the following command:
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 By default, the YugabyteDB workload generator runs with strong read consistency, where all data is read from the tablet leader. We are going to populate exactly one key with a `10KB` value into the system. Since the replication factor is `3`, this key will get replicated to only three of the four nodes in the universe.

--- a/docs/content/v2.8/explore/multi-region-deployments/synchronous-replication-ycql.md
+++ b/docs/content/v2.8/explore/multi-region-deployments/synchronous-replication-ycql.md
@@ -63,7 +63,7 @@ You can view the tablet servers on the [tablet servers page](http://localhost:70
 Download the [YugabyteDB workload generator](https://github.com/yugabyte/yb-sample-apps) JAR file (`yb-sample-apps.jar`) by running the following command.
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 Run a `SqlInserts` workload in a separate shell.

--- a/docs/content/v2.8/explore/multi-region-deployments/synchronous-replication-ysql.md
+++ b/docs/content/v2.8/explore/multi-region-deployments/synchronous-replication-ysql.md
@@ -63,7 +63,7 @@ You can view the tablet servers on the [tablet servers page](http://localhost:70
 Download the [YugabyteDB workload generator](https://github.com/yugabyte/yb-sample-apps) JAR file (`yb-sample-apps.jar`) by running the following command.
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 Run a `SqlInserts` workload in a separate shell.

--- a/docs/content/v2.8/explore/observability/prometheus-integration/linux.md
+++ b/docs/content/v2.8/explore/observability/prometheus-integration/linux.md
@@ -86,7 +86,7 @@ $ ./bin/yugabyted start \
 Download the [YugabyteDB workload generator](https://github.com/yugabyte/yb-sample-apps) JAR file (`yb-sample-apps.jar`) by running the following command.
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 Run the `CassandraKeyValue` workload application in a separate shell.

--- a/docs/content/v2.8/explore/observability/prometheus-integration/macos.md
+++ b/docs/content/v2.8/explore/observability/prometheus-integration/macos.md
@@ -86,7 +86,7 @@ $ ./bin/yugabyted start \
 Download the [YugabyteDB workload generator](https://github.com/yugabyte/yb-sample-apps) JAR file (`yb-sample-apps.jar`) by running the following command.
 
 ```sh
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true -O yb-sample-apps.jar
+wget 'https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.9/yb-sample-apps.jar?raw=true' -O yb-sample-apps.jar
 ```
 
 Run the `CassandraKeyValue` workload application in a separate shell.


### PR DESCRIPTION
fixes #15467 

Searching `wget zsh: no matches found` brought me to https://old.reddit.com/r/zsh/comments/h9mdvc/why_do_i_get_this_error_zsh_no_matches_found/ so I quoted the URL.

Works on linux ubuntu 18.04, should work on macos too.

cc @yushenng please try and confirm the changes?