### PR TITLE
[docs][PLAT-6511] Document Helm overrides for YBA chart

### DIFF
--- a/docs/content/preview/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/kubernetes.md
+++ b/docs/content/preview/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/kubernetes.md
@@ -207,26 +207,7 @@ Continue configuring your Kubernetes provider by clicking **Add region** and com
 
 1. Use the **Zone** field to select a zone label that should match the value of failure domain zone label on the nodes. `topology.kubernetes.io/zone` would place the pods in that zone.
 
-1. Optionally, use the **Storage Class** field to enter a comma-delimited value. If you do not specify this value, it would default to standard. You need to ensure that this storage class exists in your Kubernetes cluster and the following guidelines are taken into consideration:
-
-   - Volume binding mode should be set to `WaitForFirstConsumer`, as described in [Configure storage class volume binding](../../../troubleshoot/universe-issues/#configure-storage-class-volume-binding).
-
-   - An SSD-based storage class and an extent-based file system (XFS) should be used, as per recommendations provided in [Deployment checklist - Disks](../../../../deploy/checklist/#disks).
-
-     The following is a sample storage class YAML file for Google Kubernetes Engine (GKE). You are expected to modify it to suit your Kubernetes cluster:
-
-      ```yaml
-      kind: StorageClass
-      metadata:
-      	name: yb-storage
-      provisioner: kubernetes.io/gce-pd
-      volumeBindingMode: WaitForFirstConsumer
-      allowVolumeExpansion: true
-      reclaimPolicy: Delete
-      parameters:
-      	type: pd-ssd
-      	fstype: xfs
-      ```
+1. Optionally, use the **Storage Class** field to enter a comma-delimited value. If you do not specify this value, it would default to standard. You need to ensure that this storage class exists in your Kubernetes cluster and the storage class is according to the [Storage class considerations](../../../install-yugabyte-platform/prepare-environment/kubernetes/#storage-class-considerations) section.
 
 1. Use the **Namespace** field to specify the namespace. If provided service account has the `Cluster Admin` permissions, you are not required to complete this field. The service account used in the provided `kubeconfig` file should have access to this namespace.
 

--- a/docs/content/preview/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/kubernetes.md
+++ b/docs/content/preview/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/kubernetes.md
@@ -207,7 +207,7 @@ Continue configuring your Kubernetes provider by clicking **Add region** and com
 
 1. Use the **Zone** field to select a zone label that should match the value of failure domain zone label on the nodes. `topology.kubernetes.io/zone` would place the pods in that zone.
 
-1. Optionally, use the **Storage Class** field to enter a comma-delimited value. If you do not specify this value, it would default to standard. You need to ensure that this storage class exists in your Kubernetes cluster and the storage class is according to the [Storage class considerations](../../../install-yugabyte-platform/prepare-environment/kubernetes/#storage-class-considerations) section.
+1. Optionally, use the **Storage Class** field to enter a comma-delimited value. If you do not specify this value, it would default to standard. You need to ensure that this storage class exists in your Kubernetes cluster and the storage class is based on [storage class considerations](../../../install-yugabyte-platform/prepare-environment/kubernetes/#storage-class-considerations).
 
 1. Use the **Namespace** field to specify the namespace. If provided service account has the `Cluster Admin` permissions, you are not required to complete this field. The service account used in the provided `kubeconfig` file should have access to this namespace.
 

--- a/docs/content/preview/yugabyte-platform/install-yugabyte-platform/install-software/kubernetes.md
+++ b/docs/content/preview/yugabyte-platform/install-yugabyte-platform/install-software/kubernetes.md
@@ -210,6 +210,9 @@ yugaware:
   service:
     # other values…
     annotations:
+      # used by builtin load balancer controller of Kubernetes
+      service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+      # required if using AWS load balancer controller
       service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
 ```
 
@@ -223,9 +226,16 @@ tls:
   hostname: "yba.example.com"
 ```
 
-<!-- TODO: move things from the following section to this page -->
-<!-- https://docs.yugabyte.com/preview/yugabyte-platform/troubleshoot/install-upgrade-yp-issues/#configure-load-balancer-for-helm-charts  -->
-<!-- it was added as part of PLAT-3570 -->
+Similarly, if you want to access YugabyteDB Anywhere from multiple domains or you have a complex reverse-proxy setup, you can add those domains to CORS configuration, as follows:
+
+```yaml
+# yba-values.yaml
+yugaware:
+  # other values…
+  additionAllowedCorsOrigins:
+  - "yba-east.example.com"
+  - "yba-test.example.com"
+```
 
 ### Configure TLS
 

--- a/docs/content/preview/yugabyte-platform/install-yugabyte-platform/install-software/kubernetes.md
+++ b/docs/content/preview/yugabyte-platform/install-yugabyte-platform/install-software/kubernetes.md
@@ -302,8 +302,8 @@ When your Kubernetes cluster nodes are spread across multiple zones, you can use
 ```yaml
 # yba-values.yaml
 zoneAffinity:
-  - us-west1-a
-  - us-west1-b
+- us-west1-a
+- us-west1-b
 ```
 
 #### tolerations

--- a/docs/content/preview/yugabyte-platform/install-yugabyte-platform/install-software/kubernetes.md
+++ b/docs/content/preview/yugabyte-platform/install-yugabyte-platform/install-software/kubernetes.md
@@ -128,7 +128,7 @@ You install YugabyteDB Anywhere on a Kubernetes cluster as follows:
     [info] AkkaHttpServer.scala:447 [main] Listening for HTTP on /0.0.0.0:9000
     ```
 
-    If YugabyteDB Anywhere fails to start for the first time, verify that your system meets the installation requirements, as per [Prerequisites for Kubernetes-based installations](../../prepare-environment/prerequisites/#kubernetes-based-installations-1).
+    If YugabyteDB Anywhere fails to start for the first time, verify that your system meets the installation requirements, as per [Prerequisites for Kubernetes-based installations](../../prerequisites/#kubernetes-based-installations-1).
     <!-- TODO: link to the [troubleshoot>Install and upgrade issues>Kubernetes](../../../troubleshoot/install-upgrade-issues/kubernetes/) page once it is available as part of PLAT-6523, PR: <https://github.com/yugabyte/yugabyte-db/pull/15395>  -->
 
 ## Customize YugabyteDB Anywhere

--- a/docs/content/preview/yugabyte-platform/install-yugabyte-platform/install-software/kubernetes.md
+++ b/docs/content/preview/yugabyte-platform/install-yugabyte-platform/install-software/kubernetes.md
@@ -88,7 +88,7 @@ You install YugabyteDB Anywhere on a Kubernetes cluster as follows:
     helm install yw-test yugabytedb/yugaware --version {{<yb-version version="preview" format="short">}} -n yb-platform --wait
     ```
 
-    You can enable TLS by following the [Configure TLS](#configure-tls) section below.
+    You can enable TLS by following instructions provided in [Configure TLS](#configure-tls).
 
 1. Use the following command to check the service:
 
@@ -133,9 +133,7 @@ You install YugabyteDB Anywhere on a Kubernetes cluster as follows:
 
 ## Customize YugabyteDB Anywhere
 
-You can customize YugabyteDB Anywhere on a Kubernetes cluster in a number of ways. This can be done by passing a YAML file or specifying the values on CLI to the `helm install` command.
-
-The following sections show you how to do it with a values YAML file. You can copy the code blocks into a file called `yba-values.yaml` and then install YugabyteDB Anywhere with this command:
+You can customize YugabyteDB Anywhere on a Kubernetes cluster in a number of ways, such as by specifying the values on CLI or passing a YAML file to the `helm install` command, as per the following:
 
 ```sh
 helm install yw-test yugabytedb/yugaware \
@@ -145,19 +143,18 @@ helm install yw-test yugabytedb/yugaware \
   --wait
 ```
 
-Alternatively, you can pass the values using `--set key=value` flag. For more details about that, see [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing) section from Helm documentation. It is recommend to use a values file and store it in a version control system.
+You can copy the preceding code blocks into a file called `yba-values.yaml` and then install YugabyteDB Anywhere using this command. Alternatively, you can pass the values using the `--set key=value` flag. For more details about that, see [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). It is recommend to use a values file and store it in a version control system.
 
-{{< tip title="View all the supported values of the Helm chart" >}}
-If you are looking for a customization which is not listed here, you can view all the supported options with their default values by running the `helm show values yugabytedb/yugaware --version {{<yb-version version="preview" format="short">}}` command and copy the specific section to your own values file.
-{{< /tip >}}
+If you are looking for a customization which is not listed, you can view all the supported options and their default values by running the `helm show values yugabytedb/yugaware --version {{<yb-version version="preview" format="short">}}` command and copy the specific section to your own values file.
+
 
 ### Configure load balancer
 
 By default, a load balancer is created to make YugabyteDB Anywhere accessible. It can be customized as follows:
 
-#### Turn off the load balancer
+#### Disable the load balancer
 
-There are scenarios where you want to access YugabyteDB Anywhere via other ways like port-forward, other gateway/ingress solution, etc. In that case you can disable the load balancer by changing the service type to `ClusterIP`:
+To access YugabyteDB Anywhere by other means, such as port-forward, other gateway or ingress solutions, and so on, you can disable the load balancer by changing the service type to `ClusterIP`, as follows:
 
 ```yaml
 # yba-values.yaml
@@ -167,7 +164,7 @@ yugaware:
     type: "ClusterIP"
 ```
 
-If you plan to access YugabyteDB Anywhere by doing port-forwarding, you need to set `tls.hostname`. You can read more about it in the [Set DNS name](#set-dns-name) section.
+If you plan to access YugabyteDB Anywhere by doing port-forwarding, you need to set `tls.hostname`. For more information, see [Set DNS name](#set-dns-name).
 
 ```yaml
 # yba-values.yaml
@@ -175,7 +172,7 @@ tls:
   hostname: "localhost:8080"
 ```
 
-Use the kubectl port-forward command to access the interface locally:
+Use the kubectl port-forward command to access the interface locally, as follows:
 
 ```sh
 # For TLS. Available at https://localhost:8080
@@ -192,7 +189,7 @@ You can add annotations to the YugabyteDB Anywhere service to create an internal
 - For Google Cloud, see [GKE docs](https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing).
 - For Azure, see [AKS docs](https://docs.microsoft.com/en-us/azure/aks/internal-lb).
 - For AWS, see [EKS docs](https://docs.aws.amazon.com/eks/latest/userguide/load-balancing.html) and [AWS Load Balancer Controller docs](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/service/annotations/#lb-scheme).
-- For other providers, see [Internal load balancer](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer) section from Kubernetes docs.
+- For other providers, see [Internal load balancer](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer).
 
 For example, for a GKE cluster, you would add following lines to your values file:
 
@@ -218,7 +215,7 @@ yugaware:
 
 #### Set DNS name
 
-If you want to access YugabyteDB Anywhere via a domain or localhost, you need to set the `tls.hostname` field. This will make sure that the correct TLS and Cross-Origin Resource Sharing (CORS) settings are used.
+If you want to access YugabyteDB Anywhere via a domain or localhost, you need to set the `tls.hostname` field to ensure that the correct TLS and Cross-Origin Resource Sharing (CORS) settings are used, as follows:
 
 ```yaml
 # yba-values.yaml
@@ -232,11 +229,11 @@ tls:
 
 ### Configure TLS
 
-YugabyteDB Anywhere can be configured to use TLS, the following customization options are available:
+You can configure YugabyteDB Anywhere to use TLS.
 
-#### Enabled TLS
+#### Enable TLS
 
-Add the following lines to your values files to enable TLS. The Helm chart takes care of creating a self signed certificate for you.
+Add the following lines to your values file to enable TLS:
 
 ```yaml
 # yba-values.yaml
@@ -244,9 +241,11 @@ tls:
   enabled: true
 ```
 
+The Helm chart will create a self signed certificate for you.
+
 #### Use custom TLS certificate
 
-You can use custom TLS certificate instead of using the default self signed certificate. Set the value of `certificate` and `key` to the base64 encoded string value of the certificate and the key.
+You can use custom TLS certificate instead of using the default self signed certificate. Set the value of `certificate` and `key` to the base64-encoded string value of the certificate and the key, as follows:
 
 ```yaml
 # yba-values.yaml
@@ -258,7 +257,7 @@ tls:
 
 #### Change TLS versions
 
-When using TLS with YugabyteDB Anywhere, you can change the supported TLS versions. The value is passed to Nginx frontend as [ssl_protocols](https://nginx.org/r/ssl_protocols) operational directive.
+When using TLS with YugabyteDB Anywhere, you can change the supported TLS versions, as follows:
 
 ```yaml
 # yba-values.yaml
@@ -268,9 +267,11 @@ tls:
   sslProtocols: "TLSv1.2 TLSv1.3"
 ```
 
+The value is passed to Nginx frontend as [ssl_protocols](https://nginx.org/r/ssl_protocols) operational directive.
+
 ### Control placement of YugabyteDB Anywhere pods
 
-The Helm chart allows you to control the placement of the pods when installing YugabyteDB Anywhere in your Kubernetes cluster via `nodeSelector`, `zoneAffinity` and `toleration`. When you are using these constraints, make sure the storage class is setup according to the [Storage class considerations](../../prepare-environment/kubernetes/#storage-class-considerations) section. You can read more about pod placement in Kubernetes documentation page [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
+The Helm chart allows you to control the placement of the pods when installing YugabyteDB Anywhere in your Kubernetes cluster via `nodeSelector`, `zoneAffinity` and `toleration`. When you are using these constraints, ensure that the storage class is setup based on [storage class considerations](../../prepare-environment/kubernetes/#storage-class-considerations). For more information about pod placement, see [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
 
 #### nodeSelector
 
@@ -300,7 +301,7 @@ zoneAffinity:
 Kubernetes nodes could have taints that repel pods from being placed on it. Only pods with a toleration for the same taint are permitted. For more information, see 
 [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
 
-For example, if some of the nodes in your Kubernetes cluster are earmarked for experimentation and have a taint `dedicated=experimental:NoSchedule`, only pods with the matching toleration will be allowed; other pods will be prevented from being placed on these nodes.
+For example, if some of the nodes in your Kubernetes cluster are earmarked for experimentation and have a taint `dedicated=experimental:NoSchedule`, only pods with the matching toleration will be allowed, whereas other pods will be prevented from being placed on these nodes:
 
 ```yaml
 # yba-values.yaml
@@ -312,12 +313,12 @@ tolerations:
 ```
 
 {{< note title="Scheduling the pods on dedicated nodes" >}}
-Tolerations don't guarantee scheduling on the tainted nodes. To make sure the YugabyteDB Anywhere pods use a dedicated set of nodes, you need to use [nodeSelector](#nodeselector) along with taints and tolerations to repel other pods.
+Note that tolerations do not guarantee scheduling on the tainted nodes. To ensure that the YugabyteDB Anywhere pods use a dedicated set of nodes, you need to use [nodeSelector](#nodeselector) along with taints and tolerations to repel other pods.
 {{< /note >}}
 
 ### Modify resources
 
-You can modify the resource requests and limits set for the various components of YugabyteDB Anywhere, these include CPU and memory resources. See Kubernetes documentation about [Memory resources](https://kubernetes.io/docs/tasks/configure-pod-container/assign-memory-resource/) and the [CPU resources](https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/) for more details.
+You can modify the resource requests and limits set for the various components of YugabyteDB Anywhere, including CPU and memory resources, as per the following:
 
 ```yaml
 # yba-values.yaml
@@ -332,8 +333,9 @@ yugaware:
       cpu: "5"
       memory: "8Gi"
 ```
+For more information, see [Memory resources](https://kubernetes.io/docs/tasks/configure-pod-container/assign-memory-resource/) and [CPU resources](https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/).
 
-Similarly, you can modify the values for Prometheus and Postgres containers which are part of the chart.
+Similarly, you can modify the values for Prometheus and PostgreSQL containers which are part of the chart, as per the following:
 
 ```yaml
 # yba-values.yaml
@@ -354,7 +356,7 @@ postgres:
 
 ### Run containers as non-root
 
-The Postgres and Nginx containers always run as non-root. To run rest of the containers as non-root, you can set the following values:
+The PostgreSQL and Nginx containers always run as non-root. To run the rest of the containers as non-root, you can set the following values:
 
 ```yaml
 securityContext:
@@ -363,7 +365,7 @@ securityContext:
 
 ### Set pod labels and annotations
 
-Kubernetes resources like pods can have extra metadata in the form of labels and annotations. These key value pairs are used by other tools such as Prometheus. You can add extra labels and/or annotations to the YugabyteDB Anywhere pods as follows:
+Kubernetes resources such as pods can have additional metadata in the form of labels and annotations. These key-value pairs are used by other tools such as Prometheus. You can add labels and annotations to the YugabyteDB Anywhere pods as follows:
 
 ```yaml
 # yba-values.yaml
@@ -377,9 +379,9 @@ yugaware:
       prometheus.io/scrape: true
 ```
 
-### Set custom storage class
+### Specify custom storage class
 
-The storage class used by YugabyteDB Anywhere pods can be changed along with the size of the volume by using following values:
+The storage class used by YugabyteDB Anywhere pods can be changed, along with the size of the volume, by using following values:
 
 ```yaml
 # yba-values.yaml
@@ -388,16 +390,14 @@ yugaware:
   storage: "200Gi"
 ```
 
-It is recommend to use a storage class which is according to the [Storage class considerations](../../prepare-environment/kubernetes/#storage-class-considerations) section.
+It is recommend to use a storage class based on [storage class considerations](../../prepare-environment/kubernetes/#storage-class-considerations).
 
-{{< note title="The initial volume size" >}}
-It is recommend to set a large initial storage size because resizing the volumes later is challenging.
-{{< /note >}}
+It is also recommend to set a large initial storage size, because resizing the volumes later is challenging.
 
 <!-- TODO: update this when we revisit the "Pull and push YugabyteDB Docker images to private container registry" section as part of PLAT-6797  -->
 <!-- ### Pull images from private registry -->
 
-## Delete the Helm Installation of YugabyteDB Anywhere
+## Delete the Helm installation of YugabyteDB Anywhere
 
 To delete the Helm installation, run the following command:
 

--- a/docs/content/preview/yugabyte-platform/install-yugabyte-platform/prepare-environment/kubernetes.md
+++ b/docs/content/preview/yugabyte-platform/install-yugabyte-platform/prepare-environment/kubernetes.md
@@ -81,6 +81,40 @@ helm repo add prometheus-community https://prometheus-community.github.io/helm-c
 helm install -n kube-system --version 2.13.2 kube-state-metrics prometheus-community/kube-state-metrics
 ```
 
+## Storage class considerations
+
+The type of volume provisioned for YugabyteDB Anywhere as well as YugabyteDB depends on the Kubernetes storage class being used. Consider following points when choosing or creating a storage class:
+
+1. It is recommended to set volume binding mode on a storage class to `WaitForFirstConsumer` for dynamically provisioned volumes. This will delay provisioning until a pod using the persistent volume claim (PVC) is created. The pod topology or scheduling constraints will be respected.
+
+   However, scheduling might fail if the storage volume is not accessible from all the nodes in a cluster and the default volume binding mode is set to `Immediate` for certain regional cloud deployments. The volume may get created in a location/zone that is not accessible to the pod causing the failure.
+
+   For more information, see [Kubernetes: volume binding mode](https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode).
+
+   On Google Cloud Provider (GCP), if you choose not to set binding mode to `WaitForFirstConsumer`, you might use regional persistent disks to replicate data between two zones in the same region on Google Kubernetes Engine (GKE). This can be used by the pod, in cases when the pod reschedules to another node in a different zone. For more information, see the following:
+   - [Google Kubernetes Engine: persistent volumes and dynamic provisioning](https://cloud.google.com/kubernetes-engine/docs/concepts/persistent-volumes)
+   - [Google Cloud: regional persistent disks](https://cloud.google.com/compute/docs/disks/high-availability-regional-persistent-disk)
+
+
+1. Use an SSD-based storage class and an extent-based file system (XFS) should be used, as per recommendations provided in [Deployment checklist - Disks](../../../../deploy/checklist/#disks).
+
+1. Set the `allowVolumeExpansion` to `true`, so that you can expand the volumes later with some extra steps in case you run out of disk space. Some storage providers might not support this feature, see [Expanding Persistent Volumes Claims](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#expanding-persistent-volumes-claims) for more information.
+
+The following is a sample storage class YAML file for Google Kubernetes Engine (GKE). You are expected to modify it to suit your Kubernetes cluster:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: yb-storage
+provisioner: kubernetes.io/gce-pd
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  type: pd-ssd
+  fstype: xfs
+```
+
 ## Specify ulimit and remember the location of core dumps
 
 The core dump collection in Kubernetes requires special care due to the fact that `core_pattern` is not isolated in cgroup drivers.
@@ -377,5 +411,3 @@ You need to perform the following steps:
    ```sh
    helm install yugaware **.** -f values.yaml
    ```
-
-   

--- a/docs/content/preview/yugabyte-platform/install-yugabyte-platform/prepare-environment/kubernetes.md
+++ b/docs/content/preview/yugabyte-platform/install-yugabyte-platform/prepare-environment/kubernetes.md
@@ -83,22 +83,22 @@ helm install -n kube-system --version 2.13.2 kube-state-metrics prometheus-commu
 
 ## Storage class considerations
 
-The type of volume provisioned for YugabyteDB Anywhere as well as YugabyteDB depends on the Kubernetes storage class being used. Consider following points when choosing or creating a storage class:
+The type of volume provisioned for YugabyteDB Anywhere and YugabyteDB depends on the Kubernetes storage class being used. Consider following points when choosing or creating a storage class:
 
-1. It is recommended to set volume binding mode on a storage class to `WaitForFirstConsumer` for dynamically provisioned volumes. This will delay provisioning until a pod using the persistent volume claim (PVC) is created. The pod topology or scheduling constraints will be respected.
+1. It is recommended to set volume binding mode on a storage class to `WaitForFirstConsumer` for dynamically-provisioned volumes. This delays provisioning until a pod using the persistent volume claim (PVC) is created. The pod topology or scheduling constraints are respected.
 
-   However, scheduling might fail if the storage volume is not accessible from all the nodes in a cluster and the default volume binding mode is set to `Immediate` for certain regional cloud deployments. The volume may get created in a location/zone that is not accessible to the pod causing the failure.
+   However, scheduling might fail if the storage volume is not accessible from all the nodes in a cluster and the default volume binding mode is set to `Immediate` for certain regional cloud deployments. The volume may be created in a location or zone that is not accessible to the pod causing the failure.
 
    For more information, see [Kubernetes: volume binding mode](https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode).
 
-   On Google Cloud Provider (GCP), if you choose not to set binding mode to `WaitForFirstConsumer`, you might use regional persistent disks to replicate data between two zones in the same region on Google Kubernetes Engine (GKE). This can be used by the pod, in cases when the pod reschedules to another node in a different zone. For more information, see the following:
+   On Google Cloud Provider (GCP), if you choose not to set binding mode to `WaitForFirstConsumer`, you might use regional persistent disks to replicate data between two zones in the same region on Google Kubernetes Engine (GKE). This can be used by the pod when it reschedules to another node in a different zone. For more information, see the following:
    - [Google Kubernetes Engine: persistent volumes and dynamic provisioning](https://cloud.google.com/kubernetes-engine/docs/concepts/persistent-volumes)
    - [Google Cloud: regional persistent disks](https://cloud.google.com/compute/docs/disks/high-availability-regional-persistent-disk)
 
 
-1. Use an SSD-based storage class and an extent-based file system (XFS) should be used, as per recommendations provided in [Deployment checklist - Disks](../../../../deploy/checklist/#disks).
+1. Use an SSD-based storage class and an extent-based file system (XFS), as per recommendations provided in [Deployment checklist - Disks](../../../../deploy/checklist/#disks).
 
-1. Set the `allowVolumeExpansion` to `true`, so that you can expand the volumes later with some extra steps in case you run out of disk space. Some storage providers might not support this feature, see [Expanding Persistent Volumes Claims](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#expanding-persistent-volumes-claims) for more information.
+1. Set the `allowVolumeExpansion` to `true`. This allows you to expand the volumes later by performing additional steps if you run out of disk space. Note that some storage providers might not support this setting. For more information, see [Expanding Persistent Volumes Claims](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#expanding-persistent-volumes-claims).
 
 The following is a sample storage class YAML file for Google Kubernetes Engine (GKE). You are expected to modify it to suit your Kubernetes cluster:
 

--- a/docs/content/preview/yugabyte-platform/install-yugabyte-platform/prepare-on-prem-nodes.md
+++ b/docs/content/preview/yugabyte-platform/install-yugabyte-platform/prepare-on-prem-nodes.md
@@ -123,16 +123,3 @@ curl --location --request PUT 'http://<ip>/api/v1/customers/<customer_uuid>/runt
 --header 'Content-Type: text/plain'
 --data-raw '"true"'
 ```
-
-## Configure storage class volume binding
-
-On Kubernetes, it is recommended to set volume binding mode on a StorageClass to `WaitForFirstConsumer` for dynamically provisioned volumes. This will delay provisioning until a pod using the persistent volume claim (PVC) is created. The pod topology or scheduling constraints will be respected. However, scheduling might fail if the storage volume is not accessible from all the nodes in a cluster and the default volume binding mode is set to `Immediate` for certain regional cloud deployments.
-
-For more information, see [Kubernetes: volume binding mode](https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode).
-
-On Google Cloud Provider (GCP), if you choose not to set binding mode to `WaitForFirstConsumer`, you might use regional persistent disks to replicate data between two zones in the same region on Google Kubernetes Engine (GKE). This can be used by the pod, in cases when the pod reschedules to another node in a different  zone.
-
-For more information, see the following:
-
-- [Google Kubernetes Engine: persistent volumes and dynamic provisioning](https://cloud.google.com/kubernetes-engine/docs/concepts/persistent-volumes)
-- [Google Cloud: regional persistent disks](https://cloud.google.com/compute/docs/disks/high-availability-regional-persistent-disk)

--- a/docs/content/preview/yugabyte-platform/install-yugabyte-platform/prerequisites.md
+++ b/docs/content/preview/yugabyte-platform/install-yugabyte-platform/prerequisites.md
@@ -98,4 +98,4 @@ In addition, ensure the following:
 - Core dumps are enabled and configured on the underlying Kubernetes node. For details, see [Specify ulimit and remember the location of core dumps](../prepare-environment/kubernetes#specify-ulimit-and-remember-the-location-of-core-dumps).
 - You have the kube-state-metrics add-on version 1.9 in your Kubernetes cluster. For more information, see [Install kube-state-metrics](../prepare-environment/kubernetes#install-kube-state-metrics).
 - A load balancer controller is available in your Kubernetes cluster.
-- A StorageClass is available with the SSD and `WaitForFirstConsumer` preferably set to `allowVolumeExpansion`. For more information, see [Control placement of YugabyteDB Anywhere pod](../install-software/kubernetes/#control-placement-of-yugabytedb-anywhere-pod).
+- A StorageClass is available with the SSD and `WaitForFirstConsumer` preferably set to `allowVolumeExpansion`. For more information, see [Storage class considerations](../prepare-environment/kubernetes/#storage-class-considerations).

--- a/docs/content/stable/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/kubernetes.md
+++ b/docs/content/stable/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/kubernetes.md
@@ -203,26 +203,7 @@ Continue configuring your Kubernetes provider by clicking **Add region** and com
 
 - Use the **Zone** field to select a zone label that should match with your failure domain zone label `failure-domain.beta.kubernetes.io/zone`.
 
-- Optionally, use the **Storage Class** field to enter a comma-delimited value. If you do not specify this value, it would default to standard. You need to ensure that this storage class exists in your Kubernetes cluster and the following guidelines are taken into consideration:
-
-  - Volume binding mode should be set to `WaitForFirstConsumer`, as described in [Configure storage class volume binding](../../../troubleshoot/universe-issues/#configure-storage-class-volume-binding).
-
-  - An SSD-based storage class and an extent-based file system (XFS) should be used, as per recommendations provided in [Deployment checklist - Disks](../../../../deploy/checklist/#disks).
-
-    The following is a sample storage class YAML file for Google Kubernetes Engine (GKE). You are expected to modify it to suit your Kubernetes cluster:
-
-    ```yaml
-    kind: StorageClass
-    metadata:
-    	name: yb-storage
-    provisioner: kubernetes.io/gce-pd
-    volumeBindingMode: WaitForFirstConsumer
-    allowVolumeExpansion: true
-    reclaimPolicy: Delete
-    parameters:
-    	type: pd-ssd
-    	fstype: xfs
-    ```
+- Optionally, use the **Storage Class** field to enter a comma-delimited value. If you do not specify this value, it would default to standard. You need to ensure that this storage class exists in your Kubernetes cluster and the storage class is based on [storage class considerations](../../../install-yugabyte-platform/prepare-environment/kubernetes/#storage-class-considerations).
 
 - Use the **Namespace** field to specify the namespace. If provided service account has the `Cluster Admin` permissions, you are not required to complete this field. The service account used in the provided `kubeconfig` file should have access to this namespace.
 

--- a/docs/content/stable/yugabyte-platform/install-yugabyte-platform/install-software/kubernetes.md
+++ b/docs/content/stable/yugabyte-platform/install-yugabyte-platform/install-software/kubernetes.md
@@ -72,20 +72,20 @@ You install YugabyteDB Anywhere on a Kubernetes cluster as follows:
     To search for the available chart version, run the following command:
 
     ```sh
-    helm search repo yugabytedb/yugaware --version {{<yb-version version="preview" format="short">}}
+    helm search repo yugabytedb/yugaware --version {{<yb-version version="stable" format="short">}}
     ```
 
     The latest Helm chart version and application version is displayed via the output similar to the following:
 
     ```output
     NAME                 CHART VERSION  APP VERSION  DESCRIPTION
-    yugabytedb/yugaware {{<yb-version version="preview" format="short">}}          {{<yb-version version="preview" format="build">}}  YugaWare is YugaByte Database's Orchestration a...
+    yugabytedb/yugaware {{<yb-version version="stable" format="short">}}          {{<yb-version version="stable" format="build">}}  YugaWare is YugaByte Database's Orchestration a...
     ```
 
 1. Run the following `helm install` command to install the YugabyteDB Anywhere (`yugaware`) Helm chart:
 
     ```sh
-    helm install yw-test yugabytedb/yugaware --version {{<yb-version version="preview" format="short">}} -n yb-platform --wait
+    helm install yw-test yugabytedb/yugaware --version {{<yb-version version="stable" format="short">}} -n yb-platform --wait
     ```
 
     You can enable TLS by following instructions provided in [Configure TLS](#configure-tls).
@@ -137,7 +137,7 @@ You can customize YugabyteDB Anywhere on a Kubernetes cluster in a number of way
 
 ```sh
 helm install yw-test yugabytedb/yugaware \
-  --version {{<yb-version version="preview" format="short">}} \
+  --version {{<yb-version version="stable" format="short">}} \
   -n yb-platform \
   --values yba-values.yaml \
   --wait
@@ -145,7 +145,7 @@ helm install yw-test yugabytedb/yugaware \
 
 You can copy the preceding code blocks into a file called `yba-values.yaml` and then install YugabyteDB Anywhere using this command. Alternatively, you can pass the values using the `--set key=value` flag. For more details about that, see [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). It is recommend to use a values file and store it in a version control system.
 
-If you are looking for a customization which is not listed, you can view all the supported options and their default values by running the `helm show values yugabytedb/yugaware --version {{<yb-version version="preview" format="short">}}` command and copy the specific section to your own values file.
+If you are looking for a customization which is not listed, you can view all the supported options and their default values by running the `helm show values yugabytedb/yugaware --version {{<yb-version version="stable" format="short">}}` command and copy the specific section to your own values file.
 
 
 ### Configure load balancer

--- a/docs/content/stable/yugabyte-platform/install-yugabyte-platform/install-software/kubernetes.md
+++ b/docs/content/stable/yugabyte-platform/install-yugabyte-platform/install-software/kubernetes.md
@@ -72,35 +72,23 @@ You install YugabyteDB Anywhere on a Kubernetes cluster as follows:
     To search for the available chart version, run the following command:
 
     ```sh
-    helm search repo yugabytedb/yugaware --version {{<yb-version version="stable" format="short">}}
+    helm search repo yugabytedb/yugaware --version {{<yb-version version="preview" format="short">}}
     ```
 
     The latest Helm chart version and application version is displayed via the output similar to the following:
 
     ```output
     NAME                 CHART VERSION  APP VERSION  DESCRIPTION
-    yugabytedb/yugaware {{<yb-version version="stable" format="short">}}          {{<yb-version version="stable" format="build">}}  YugaWare is YugaByte Database's Orchestration a...
+    yugabytedb/yugaware {{<yb-version version="preview" format="short">}}          {{<yb-version version="preview" format="build">}}  YugaWare is YugaByte Database's Orchestration a...
     ```
 
 1. Run the following `helm install` command to install the YugabyteDB Anywhere (`yugaware`) Helm chart:
 
     ```sh
-    helm install yw-test yugabytedb/yugaware --version {{<yb-version version="stable" format="short">}} -n yb-platform --wait
+    helm install yw-test yugabytedb/yugaware --version {{<yb-version version="preview" format="short">}} -n yb-platform --wait
     ```
 
-1. Optionally, set the TLS version for Nginx frontend by using `ssl_protocols` operational directive in the Helm installation, as follows:
-
-    ```sh
-    helm install yw-test yugabytedb/yugaware --version {{<yb-version version="stable" format="short">}} -n yb-platform --wait --set tls.sslProtocols="TLSv1.2"
-    ```
-
-    In addition, you may provide a custom TLS certificate in the Helm chart, as follows:
-
-    ```sh
-    helm install yw-test yugabytedb/yugaware --version {{<yb-version version="stable" format="short">}} -n yb-platform --wait --set tls.sslProtocols="TLSv1.2" tls.certificate="LS0tLS1CRUdJTiBDRVJUSUZJQ..." tls.key="LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0t..."
-    ```
-
-    where `certificate` and `key` are set to full string values of your custom certificate and its corresponding key.
+    You can enable TLS by following instructions provided in [Configure TLS](#configure-tls).
 
 1. Use the following command to check the service:
 
@@ -128,105 +116,205 @@ You install YugabyteDB Anywhere on a Kubernetes cluster as follows:
     yw-test-yugaware-0   4/4     Running   0          12s
     ```
 
-    Note that even though the preceding output indicates that the `yw-test-yugaware-0` pod is running, it does not mean that YugabyteDB Anywhere is ready to accept your queries. If you open `localhost:80` and see an error (such as 502), it means that `yugaware` is still being initialized. You can check readiness of `yugaware` by executing the following command:
+    Note that even though the preceding output indicates that the `yw-test-yugaware-0` pod is running, it does not mean that YugabyteDB Anywhere is ready to accept your queries. If you open the load balancer IP `34.93.169.64:80` and see an error (such as 502), it means that `yugaware` is still being initialized. You can check readiness of `yugaware` by executing the following command:
 
     ```sh
     kubectl logs --follow -n yb-platform yw-test-yugaware-0 yugaware
     ```
-    
+
     An output similar to the following would confirm that there are no errors and that the server is running:
 
     ```
     [info] AkkaHttpServer.scala:447 [main] Listening for HTTP on /0.0.0.0:9000
     ```
 
-    If YugabyteDB Anywhere fails to start for the first time, verify that your system meets the installation requirements, as per [Prepare the Kubernetes environment](../../prepare-environment/kubernetes/).
+    If YugabyteDB Anywhere fails to start for the first time, verify that your system meets the installation requirements, as per [Prerequisites for Kubernetes-based installations](../../prepare-environment/prerequisites/#kubernetes-based-installations-1).
+    <!-- TODO: link to the [troubleshoot>Install and upgrade issues>Kubernetes](../../../troubleshoot/install-upgrade-issues/kubernetes/) page once it is available as part of PLAT-6523, PR: <https://github.com/yugabyte/yugabyte-db/pull/15395>  -->
 
 ## Customize YugabyteDB Anywhere
 
-You can customize YugabyteDB Anywhere on a Kubernetes cluster in a number of ways, such as the following:
-
-- You can change CPU and memory resources by executing a command similar to the following:
-
-  ```sh
-  helm install yw-test yugabytedb/yugaware -n yb-platform \
-    --version {{<yb-version version="stable" format="short">}} \
-    --set yugaware.resources.requests.cpu=2 \
-    --set yugaware.resources.requests.memory=4Gi \
-    --set yugaware.resources.limits.cpu=2 \
-    --set yugaware.resources.limits.memory=4Gi \
-    --set prometheus.resources.requests.mem=6Gi
-  ```
-
-- You can disable the public-facing load balancer by providing the annotations to YugabyteDB Anywhere service for disabling that load balancer. Since every cloud provider has different annontations for doing this, refer to the following documentation:
-
-  - For Google Cloud, see [GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing).
-  - For Azure, see [AKS](https://docs.microsoft.com/en-us/azure/aks/internal-lb).
-  - For AWS, see [EKS](https://docs.aws.amazon.com/eks/latest/userguide/load-balancing.html).
-
-  For example, for a GKE version earlier than 1.17, you would run a command similar to the following:
-
-  ```sh
-  helm install yw-test yugabytedb/yugaware -n yb-platform \
-    --version {{<yb-version version="stable" format="short">}} \
-    --set yugaware.service.annotations."cloud\.google\.com\/load-balancer-type"="Internal"
-  ```
-
-## Control placement of YugabyteDB Anywhere pod
-
-The Helm chart allows you to control the placement of the pod when installing YugabyteDB Anywhere in your Kubernetes cluster via `nodeSelector`, `zoneAffinity` and `toleration`. When you use these mechanisms to restrict placement of the YugabyteDB Anywhere pod, you should delay the creation of storage volumes (known as PersistentVolumeClaim (PVC)) until the pod has been placed. To do this, you would use a `StorageClass` with its `VolumeBindingMode` set to `WaitForFirstConsumer`, as described in [Configure storage class volume binding](../../prepare-on-prem-nodes/#configure-storage-class-volume-binding). The following is a storage class YAML file for Google Kubernetes Engine (GKE):
-
-```yaml
-kind: StorageClass
-metadata:
-  name: yb-storage
-provisioner: kubernetes.io/gce-pd
-volumeBindingMode: WaitForFirstConsumer
-allowVolumeExpansion: true
-reclaimPolicy: Delete
-parameters:
-  type: pd-ssd
-  fstype: xfs
-```
-If you do not delay the creation of the PVC, it may be created in a location that is not accessible to the pod, resulting in a failure to bring up the pod to a running state.
-
-### nodeSelector
-
-The Kubernetes `nodeSelector` field provides the means to constrain pods to nodes with specific labels, allowing you to restrict the placement of YugabyteDB Anywhere pod on a particular node, as demonstrated by the following example:
+You can customize YugabyteDB Anywhere on a Kubernetes cluster in a number of ways, such as by specifying the values on CLI or passing a YAML file to the `helm install` command, as per the following:
 
 ```sh
-helm install yw-test yugabytedb/yugaware/ -n yb-platform \
---version 2.15.2 --set yugaware.storageClass=yb-storage \
---set nodeSelector.kubernetes\\.io/hostname=node-name-1
+helm install yw-test yugabytedb/yugaware \
+  --version {{<yb-version version="preview" format="short">}} \
+  -n yb-platform \
+  --values yba-values.yaml \
+  --wait
 ```
 
-### zoneAffinity
+You can copy the preceding code blocks into a file called `yba-values.yaml` and then install YugabyteDB Anywhere using this command. Alternatively, you can pass the values using the `--set key=value` flag. For more details about that, see [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). It is recommend to use a values file and store it in a version control system.
+
+If you are looking for a customization which is not listed, you can view all the supported options and their default values by running the `helm show values yugabytedb/yugaware --version {{<yb-version version="preview" format="short">}}` command and copy the specific section to your own values file.
+
+
+### Configure load balancer
+
+By default, a load balancer is created to make YugabyteDB Anywhere accessible. It can be customized as follows:
+
+#### Disable the load balancer
+
+To access YugabyteDB Anywhere by other means, such as port-forward, other gateway or ingress solutions, and so on, you can disable the load balancer by changing the service type to `ClusterIP`, as follows:
+
+```yaml
+# yba-values.yaml
+yugaware:
+  # other values…
+  service:
+    type: "ClusterIP"
+```
+
+If you plan to access YugabyteDB Anywhere by doing port-forwarding, you need to set `tls.hostname`. For more information, see [Set DNS name](#set-dns-name).
+
+```yaml
+# yba-values.yaml
+tls:
+  hostname: "localhost:8080"
+```
+
+Use the kubectl port-forward command to access the interface locally, as follows:
+
+```sh
+# For TLS. Available at https://localhost:8080
+kubectl port-forward -n yb-platform svc/yw-test-yugaware-ui 8080:443
+
+# For non-TLS. Available at http://localhost:8080
+kubectl port-forward -n yb-platform svc/yw-test-yugaware-ui 8080:80
+```
+
+#### Set up internal load balancer
+
+You can add annotations to the YugabyteDB Anywhere service to create an internal load balancer instead of a public-facing one. Since every cloud provider has different annotations for doing this, refer to the following documentation:
+
+- For Google Cloud, see [GKE docs](https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing).
+- For Azure, see [AKS docs](https://docs.microsoft.com/en-us/azure/aks/internal-lb).
+- For AWS, see [EKS docs](https://docs.aws.amazon.com/eks/latest/userguide/load-balancing.html) and [AWS Load Balancer Controller docs](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/service/annotations/#lb-scheme).
+- For other providers, see [Internal load balancer](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer).
+
+For example, for a GKE cluster, you would add following lines to your values file:
+
+```yaml
+# yba-values.yaml
+yugaware:
+  service:
+    # other values…
+    annotations:
+      networking.gke.io/load-balancer-type: "Internal"
+```
+
+For an EKS cluster, you would use following:
+
+```yaml
+# yba-values.yaml
+yugaware:
+  service:
+    # other values…
+    annotations:
+      # used by builtin load balancer controller of Kubernetes
+      service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+      # required if using AWS load balancer controller
+      service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
+```
+
+#### Set DNS name
+
+If you want to access YugabyteDB Anywhere via a domain or localhost, you need to set the `tls.hostname` field to ensure that the correct TLS and Cross-Origin Resource Sharing (CORS) settings are used, as follows:
+
+```yaml
+# yba-values.yaml
+tls:
+  hostname: "yba.example.com"
+```
+
+Similarly, if you want to access YugabyteDB Anywhere from multiple domains or you have a complex reverse-proxy setup, you can add those domains to CORS configuration, as follows:
+
+```yaml
+# yba-values.yaml
+yugaware:
+  # other values…
+  additionAllowedCorsOrigins:
+  - "yba-east.example.com"
+  - "yba-test.example.com"
+```
+
+### Configure TLS
+
+You can configure YugabyteDB Anywhere to use TLS.
+
+#### Enable TLS
+
+Add the following lines to your values file to enable TLS:
+
+```yaml
+# yba-values.yaml
+tls:
+  enabled: true
+```
+
+The Helm chart will use a pre-defined self signed certificate.
+
+#### Use custom TLS certificate
+
+You can use custom TLS certificate instead of using the default self signed certificate. Set the value of `certificate` and `key` to the base64-encoded string value of the certificate and the key, as follows:
+
+```yaml
+# yba-values.yaml
+tls:
+  enabled: true
+  certificate: "LS0tLS1CRUdJTiBDRVJUSUZJQ..."
+  key: "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0t..."
+```
+
+#### Change TLS versions
+
+When using TLS with YugabyteDB Anywhere, you can change the supported TLS versions, as follows:
+
+```yaml
+# yba-values.yaml
+tls:
+  enabled: true
+  # other values…
+  sslProtocols: "TLSv1.2 TLSv1.3"
+```
+
+The value is passed to Nginx frontend as [ssl_protocols](https://nginx.org/r/ssl_protocols) operational directive.
+
+### Control placement of YugabyteDB Anywhere pods
+
+The Helm chart allows you to control the placement of the pods when installing YugabyteDB Anywhere in your Kubernetes cluster via `nodeSelector`, `zoneAffinity` and `toleration`. When you are using these constraints, ensure that the storage class is setup based on [storage class considerations](../../prepare-environment/kubernetes/#storage-class-considerations). For more information about pod placement, see [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
+
+#### nodeSelector
+
+The Kubernetes `nodeSelector` field provides the means to constrain pods to nodes with specific labels, allowing you to restrict the placement of YugabyteDB Anywhere pods on a particular node, as demonstrated by the following example:
+
+```yaml
+# yba-values.yaml
+nodeSelector:
+  kubernetes.io/hostname: "node-name-1"
+```
+
+#### zoneAffinity
 
 Kubernetes provides a flexible `nodeAffinity` construct to constrain the placement of pods to nodes in a given zone.
 
-When your Kubernetes cluster nodes are spread across multiple zones, you can use this command to explicitly place the YugabyteDB Anywhere pod on specific zones, as demonstrated by the following example:
-
-```sh
-helm install yw-test yugabytedb/yugaware/ -n yb-platform \
---version 2.15.2 --set yugaware.storageClass=yb-storage \
---set "zoneAffinity={us-west1-a,us-west1-b}"
-```
-
-### toleration
-
-Kubernetes nodes could have `taints` that repel pods from being placed on it. Only pods with a `toleration` for the same `taint` are permitted. For more information, see [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
-
-For example, if some of the nodes in your Kubernetes cluster are earmarked for experimentation and have a taint `dedicated=experimental:NoSchedule`, only pods with the matching toleration will be allowed; other pods will be prevented from being placed on these nodes.
-
-```sh
-helm install yw-test yugabytedb/yugaware/ -n yb-platform \
---version 2.15.2 --set yugaware.storageClass=yb-storage \
---values=/tmp/overrides.yaml
-```
-
-Where the `/tmp/overrides.yaml` has the contents:
+When your Kubernetes cluster nodes are spread across multiple zones, you can use this command to explicitly place the YugabyteDB Anywhere pods on specific zones, as demonstrated by the following example:
 
 ```yaml
+# yba-values.yaml
+zoneAffinity:
+  - us-west1-a
+  - us-west1-b
+```
+
+#### tolerations
+
+Kubernetes nodes could have taints that repel pods from being placed on it. Only pods with a toleration for the same taint are permitted. For more information, see 
+[Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
+
+For example, if some of the nodes in your Kubernetes cluster are earmarked for experimentation and have a taint `dedicated=experimental:NoSchedule`, only pods with the matching toleration will be allowed, whereas other pods will be prevented from being placed on these nodes:
+
+```yaml
+# yba-values.yaml
 tolerations:
 - key: "dedicated"
   operator: "Equal"
@@ -234,7 +322,92 @@ tolerations:
   effect: "NoSchedule"
 ```
 
-## Delete the Helm Installation of YugabyteDB Anywhere
+{{< note title="Scheduling the pods on dedicated nodes" >}}
+Note that tolerations do not guarantee scheduling on the tainted nodes. To ensure that the YugabyteDB Anywhere pods use a dedicated set of nodes, you need to use [nodeSelector](#nodeselector) along with taints and tolerations to repel other pods.
+{{< /note >}}
+
+### Modify resources
+
+You can modify the resource requests and limits set for the various components of YugabyteDB Anywhere, including CPU and memory resources, as per the following:
+
+```yaml
+# yba-values.yaml
+yugaware:
+  # other values…
+  resources:
+    requests:
+      cpu: "4"
+      memory: "5Gi"
+    # optionally set limits
+    limits:
+      cpu: "5"
+      memory: "8Gi"
+```
+For more information, see [Memory resources](https://kubernetes.io/docs/tasks/configure-pod-container/assign-memory-resource/) and [CPU resources](https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/).
+
+Similarly, you can modify the values for Prometheus and PostgreSQL containers which are part of the chart, as per the following:
+
+```yaml
+# yba-values.yaml
+prometheus:
+  # other values…
+  resources:
+    requests:
+      cpu: "2"
+      memory: "6Gi"
+
+postgres:
+  # other values…
+  resources:
+    requests:
+      cpu: "1.5"
+      memory: "2Gi"
+```
+
+### Run containers as non-root
+
+The PostgreSQL and Nginx containers always run as non-root. To run the rest of the containers as non-root, you can set the following values:
+
+```yaml
+securityContext:
+  enabled: true
+```
+
+### Set pod labels and annotations
+
+Kubernetes resources such as pods can have additional metadata in the form of labels and annotations. These key-value pairs are used by other tools such as Prometheus. You can add labels and annotations to the YugabyteDB Anywhere pods as follows:
+
+```yaml
+# yba-values.yaml
+yugaware:
+  # other values…
+  pod:
+    annotations:
+      sidecar.istio.io/proxyCPU: "200m"
+    labels:
+      sidecar.istio.io/inject: true
+      prometheus.io/scrape: true
+```
+
+### Specify custom storage class
+
+The storage class used by YugabyteDB Anywhere pods can be changed, along with the size of the volume, by using following values:
+
+```yaml
+# yba-values.yaml
+yugaware:
+  storageClass: "custom-sc"
+  storage: "200Gi"
+```
+
+It is recommend to use a storage class based on [storage class considerations](../../prepare-environment/kubernetes/#storage-class-considerations).
+
+It is also recommend to set a large initial storage size, because resizing the volumes later is challenging.
+
+<!-- TODO: update this when we revisit the "Pull and push YugabyteDB Docker images to private container registry" section as part of PLAT-6797  -->
+<!-- ### Pull images from private registry -->
+
+## Delete the Helm installation of YugabyteDB Anywhere
 
 To delete the Helm installation, run the following command:
 

--- a/docs/content/stable/yugabyte-platform/install-yugabyte-platform/install-software/kubernetes.md
+++ b/docs/content/stable/yugabyte-platform/install-yugabyte-platform/install-software/kubernetes.md
@@ -302,8 +302,8 @@ When your Kubernetes cluster nodes are spread across multiple zones, you can use
 ```yaml
 # yba-values.yaml
 zoneAffinity:
-  - us-west1-a
-  - us-west1-b
+- us-west1-a
+- us-west1-b
 ```
 
 #### tolerations

--- a/docs/content/stable/yugabyte-platform/install-yugabyte-platform/install-software/kubernetes.md
+++ b/docs/content/stable/yugabyte-platform/install-yugabyte-platform/install-software/kubernetes.md
@@ -128,7 +128,7 @@ You install YugabyteDB Anywhere on a Kubernetes cluster as follows:
     [info] AkkaHttpServer.scala:447 [main] Listening for HTTP on /0.0.0.0:9000
     ```
 
-    If YugabyteDB Anywhere fails to start for the first time, verify that your system meets the installation requirements, as per [Prerequisites for Kubernetes-based installations](../../prepare-environment/prerequisites/#kubernetes-based-installations-1).
+    If YugabyteDB Anywhere fails to start for the first time, verify that your system meets the installation requirements, as per [Prerequisites for Kubernetes-based installations](../../prerequisites/#kubernetes-based-installations-1).
     <!-- TODO: link to the [troubleshoot>Install and upgrade issues>Kubernetes](../../../troubleshoot/install-upgrade-issues/kubernetes/) page once it is available as part of PLAT-6523, PR: <https://github.com/yugabyte/yugabyte-db/pull/15395>  -->
 
 ## Customize YugabyteDB Anywhere

--- a/docs/content/stable/yugabyte-platform/install-yugabyte-platform/prepare-on-prem-nodes.md
+++ b/docs/content/stable/yugabyte-platform/install-yugabyte-platform/prepare-on-prem-nodes.md
@@ -123,16 +123,3 @@ curl --location --request PUT 'http://<ip>/api/v1/customers/<customer_uuid>/runt
 --header 'Content-Type: text/plain'
 --data-raw '"true"'
 ```
-
-## Configure storage class volume binding
-
-On Kubernetes, it is recommended to set volume binding mode on a StorageClass to `WaitForFirstConsumer` for dynamically provisioned volumes. This will delay provisioning until a pod using the persistent volume claim (PVC) is created. The pod topology or scheduling constraints will be respected. However, scheduling might fail if the storage volume is not accessible from all the nodes in a cluster and the default volume binding mode is set to `Immediate` for certain regional cloud deployments.
-
-For more information, see [Kubernetes: volume binding mode](https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode).
-
-On Google Cloud Provider (GCP), if you choose not to set binding mode to `WaitForFirstConsumer`, you might use regional persistent disks to replicate data between two zones in the same region on Google Kubernetes Engine (GKE). This can be used by the pod, in cases when the pod reschedules to another node in a different  zone.
-
-For more information, see the following:
-
-- [Google Kubernetes Engine: persistent volumes and dynamic provisioning](https://cloud.google.com/kubernetes-engine/docs/concepts/persistent-volumes)
-- [Google Cloud: regional persistent disks](https://cloud.google.com/compute/docs/disks/high-availability-regional-persistent-disk)

--- a/docs/content/stable/yugabyte-platform/install-yugabyte-platform/prerequisites.md
+++ b/docs/content/stable/yugabyte-platform/install-yugabyte-platform/prerequisites.md
@@ -98,4 +98,4 @@ In addition, ensure the following:
 - Core dumps are enabled and configured on the underlying Kubernetes node. For details, see [Specify ulimit and remember the location of core dumps](../prepare-environment/kubernetes#specify-ulimit-and-remember-the-location-of-core-dumps).
 - You have the kube-state-metrics add-on version 1.9 in your Kubernetes cluster. For more information, see [Install kube-state-metrics](../prepare-environment/kubernetes#install-kube-state-metrics).
 - A load balancer controller is available in your Kubernetes cluster.
-- A StorageClass is available with the SSD and `WaitForFirstConsumer` preferably set to `allowVolumeExpansion`. For more information, see [Control placement of YugabyteDB Anywhere pod](../install-software/kubernetes/#control-placement-of-yugabytedb-anywhere-pod).
+- A StorageClass is available with the SSD and `WaitForFirstConsumer` preferably set to `allowVolumeExpansion`. For more information, see [Storage class considerations](../prepare-environment/kubernetes/#storage-class-considerations).


### PR DESCRIPTION
- Adds section for each override, that way we can link to them.
- Switch to using a values YAML file instead of just --set flag. The flag is hard to use in most of the cases, and some users tend to forget what all they had applied. On the other hand using YAML is easier, and it can be version controlled.
- Consolidate all the storage class related section to one section in Prepare the environment.

Preview: 
- https://deploy-preview-15495--infallible-bardeen-164bc9.netlify.app/preview/yugabyte-platform/install-yugabyte-platform/install-software/kubernetes
- https://deploy-preview-15495--infallible-bardeen-164bc9.netlify.app/preview/yugabyte-platform/install-yugabyte-platform/prepare-environment/kubernetes/#storage-class-considerations