### PR TITLE
[docs] Correct the file name for the example

### DIFF
--- a/docs/content/preview/drivers-orms/go/pgx.md
+++ b/docs/content/preview/drivers-orms/go/pgx.md
@@ -120,7 +120,7 @@ $ export PGSSLROOTCERT=~/root.crt  # Here, the CA certificate file is downloaded
 
 ### Step 3: Write your application
 
-Create a file called `QuickStart.go` and add the following contents into it:
+Create a file called `QuickStartApp.go` and add the following contents into it:
 
 ```go
 package main


### PR DESCRIPTION
The two lines below were in conflict.

Create a file called QuickStart.go ...
Run the project QuickStartApp.go ...

Changed the filename to `QuickStartApp.go` so it would run.