### PR TITLE
Handle transparent hugepages not present on Linux

### DIFF
--- a/bin/yugabyted
+++ b/bin/yugabyted
@@ -1029,10 +1029,15 @@ class ControlScript(object):
 
         transparent_hugepages_check = run_process(shlex
                 .split(LINUX_PREREQS_CMDS.get('transparent_hugepages')))
-        transparent_hugepages = re.search("\[(.*)\]", transparent_hugepages_check[0]).group(1)
-        if transparent_hugepages != REQUIRED_TRANSPARENT_HUGEPAGES_LINUX:
+        transparent_hugepages_match = re.search("\[(.*)\]", transparent_hugepages_check[0])
+        if not transparent_hugepages_match:
             prereqs_warn.add('transparent_hugepages')
             prereqs_warn_flag = True
+        else:
+            transparent_hugepages = transparent_hugepages_match.group(1)
+            if transparent_hugepages != REQUIRED_TRANSPARENT_HUGEPAGES_LINUX:
+                prereqs_warn.add('transparent_hugepages')
+                prereqs_warn_flag = True
 
         ntp_check = run_process(shlex.split(LINUX_PREREQS_CMDS.get('ntp')))
         chrony_check = run_process(shlex.split(LINUX_PREREQS_CMDS.get('chrony')))


### PR DESCRIPTION
Gracefully handle the case where the Linux kernel is compiled without transparent hugepage support.
When the Linux kernel is compiled without transparent hugepage support the /sys/kernel/mm/transparent_hugepage folder is non-exiting, and therefore the re.search function will return None. Handle this the same way as if it is disabled.