### PR TITLE
[docs] fix to remove duplicate packages

### DIFF
--- a/docs/content/preview/contribute/core-database/build-from-src-ubuntu.md
+++ b/docs/content/preview/contribute/core-database/build-from-src-ubuntu.md
@@ -55,9 +55,6 @@ packages=(
   cmake
   curl
   git
-  git
-  git
-  libtool
   libtool
   locales
   maven


### PR DESCRIPTION
Hi, the patch removes the lines that appear to be typos.