### PR TITLE
[docs] added ysql and ycql tabs for Akka

### DIFF
--- a/docs/content/preview/integrations/akka-ycql.md
+++ b/docs/content/preview/integrations/akka-ycql.md
@@ -10,6 +10,20 @@ menu:
 type: docs
 ---
 
+<ul class="nav nav-tabs-alt nav-tabs-yb">
+  <li>
+    <a href="../akka-ysql/" class="nav-link">
+      YSQL
+    </a>
+  </li>
+
+  <li class="active">
+    <a href="../akka-ycql/" class="nav-link">
+      YCQL
+    </a>
+  </li>
+</ul>
+
 Akka is a toolkit for building highly concurrent, distributed, and resilient message-driven applications for Java and Scala.
 
 Akka's approach to handling concurrency is based on the Actor Model.

--- a/docs/content/preview/integrations/akka-ycql.md
+++ b/docs/content/preview/integrations/akka-ycql.md
@@ -1,6 +1,6 @@
 ---
 title: Akka Persistence Cassandra
-linkTitle: Akka Persistence Cassandra
+linkTitle: Akka Persistence
 description: Use Akka Persistence Cassandra with YCQL API
 menu:
   preview_integrations:

--- a/docs/content/preview/integrations/akka-ysql.md
+++ b/docs/content/preview/integrations/akka-ysql.md
@@ -1,0 +1,27 @@
+---
+title: Akka Persistence R2DBC
+linkTitle: Akka Persistence
+description: Use Akka Persistence Cassandra with YSQL API
+menu:
+  preview_integrations:
+    identifier: ysql-akka
+    parent: integrations
+    weight: 572
+type: docs
+---
+
+<ul class="nav nav-tabs-alt nav-tabs-yb">
+  <li class="active">
+    <a href="../akka-ysql/" class="nav-link">
+      YSQL
+    </a>
+  </li>
+
+  <li>
+    <a href="../akka-ycql/" class="nav-link">
+      YCQL
+    </a>
+  </li>
+</ul>
+
+Documentation for Akka persistence R2DBC is forthcoming.


### PR DESCRIPTION
Included YSQL and YCQL tabs for Akka persistence integration with YugabyteDB. 
Content for YSQL remaining.
