### PR TITLE
[docs] modified incorrect code syntax for postgres jdbc page

### DIFF
--- a/docs/content/preview/drivers-orms/java/postgres-jdbc.md
+++ b/docs/content/preview/drivers-orms/java/postgres-jdbc.md
@@ -135,7 +135,7 @@ The following table describes the connection parameters required to connect usin
 The following is an example JDBC URL for connecting to a YugabyteDB cluster with SSL encryption enabled.
 
 ```java
-string yburl = "jdbc:postgresql://hostname:port/database?user=yugabyte&password=yugabyte&ssl=true&sslmode=verify-full&sslrootcert=~/.postgresql/root.crt"
+String yburl = "jdbc:postgresql://hostname:port/database?user=yugabyte&password=yugabyte&ssl=true&sslmode=verify-full&sslrootcert=~/.postgresql/root.crt"
 Connection conn = DriverManager.getConnection(yburl);
 ```
 

--- a/docs/content/preview/drivers-orms/java/postgres-jdbc.md
+++ b/docs/content/preview/drivers-orms/java/postgres-jdbc.md
@@ -118,7 +118,8 @@ jdbc:postgresql://hostname:port/database
 Following is an example JDBC URL for connecting to YugabyteDB:
 
 ```sh
-Connection conn = DriverManager.getConnection("jdbc:postgresql://localhost:5433/yugabyte","yugabyte", "yugabyte");
+String yburl = "jdbc:postgresql://localhost:5433/yugabyte";
+Connection conn = DriverManager.getConnection(yburl, "yugabyte", "yugabyte");
 ```
 
 #### Use SSL
@@ -163,7 +164,7 @@ public class QuickStartApp {
   public static void main(String[] args) throws ClassNotFoundException, SQLException {
     Class.forName("org.postgresql.Driver");
     String yburl = "jdbc:postgresql://localhost:5433/yugabyte";
-    Connection conn = DriverManager.getConnection(yburl,"yugabyte", "yugabyte");
+    Connection conn = DriverManager.getConnection(yburl, "yugabyte", "yugabyte");
     Statement stmt = conn.createStatement();
     try {
         System.out.println("Connected to the PostgreSQL server successfully.");
@@ -192,7 +193,7 @@ If you're using SSL, replace the connection string `yburl` with the following co
 
 ```java
 String yburl = "jdbc:postgresql://localhost:5433/yugabyte?ssl=true&sslmode=require&sslcert=src/main/resources/ssl/yugabytedb.crt.der&sslkey=src/main/resources/ssl/yugabytedb.key.pk8";
-Connection conn = DriverManager.getConnection(yburl,"yugabyte", "yugabyte");
+Connection conn = DriverManager.getConnection(yburl, "yugabyte", "yugabyte");
 ```
 
 Run the project `QuickStartApp.java` using the following command:

--- a/docs/content/preview/drivers-orms/java/postgres-jdbc.md
+++ b/docs/content/preview/drivers-orms/java/postgres-jdbc.md
@@ -162,8 +162,8 @@ import java.sql.ResultSet;
 public class QuickStartApp {
   public static void main(String[] args) throws ClassNotFoundException, SQLException {
     Class.forName("org.postgresql.Driver");
-    String yburl = "jdbc:postgresql://localhost:5433/yugabyte", "yugabyte", "yugabyte";
-    Connection conn = DriverManager.getConnection(yburl);
+    String yburl = "jdbc:postgresql://localhost:5433/yugabyte";
+    Connection conn = DriverManager.getConnection(yburl,"yugabyte", "yugabyte");
     Statement stmt = conn.createStatement();
     try {
         System.out.println("Connected to the PostgreSQL server successfully.");
@@ -191,7 +191,8 @@ public class QuickStartApp {
 If you're using SSL, replace the connection string `yburl` with the following code:
 
 ```java
-String yburl = "jdbc:postgresql://localhost:5433/yugabyte?ssl=true&sslmode=require&sslcert=src/main/resources/ssl/yugabytedb.crt.der&sslkey=src/main/resources/ssl/yugabytedb.key.pk8", "yugabyte", "yugabyte";
+String yburl = "jdbc:postgresql://localhost:5433/yugabyte?ssl=true&sslmode=require&sslcert=src/main/resources/ssl/yugabytedb.crt.der&sslkey=src/main/resources/ssl/yugabytedb.key.pk8";
+Connection conn = DriverManager.getConnection(yburl,"yugabyte", "yugabyte");
 ```
 
 Run the project `QuickStartApp.java` using the following command:

--- a/docs/content/preview/drivers-orms/java/postgres-jdbc.md
+++ b/docs/content/preview/drivers-orms/java/postgres-jdbc.md
@@ -135,7 +135,7 @@ The following table describes the connection parameters required to connect usin
 The following is an example JDBC URL for connecting to a YugabyteDB cluster with SSL encryption enabled.
 
 ```java
-String yburl = "jdbc:postgresql://hostname:port/database?user=yugabyte&password=yugabyte&ssl=true&sslmode=verify-full&sslrootcert=~/.postgresql/root.crt"
+String yburl = "jdbc:postgresql://hostname:port/database?user=yugabyte&password=yugabyte&ssl=true&sslmode=verify-full&sslrootcert=~/.postgresql/root.crt";
 Connection conn = DriverManager.getConnection(yburl);
 ```
 

--- a/docs/content/preview/faq/smart-drivers-faq.md
+++ b/docs/content/preview/faq/smart-drivers-faq.md
@@ -50,7 +50,7 @@ Different language drivers initialize connections in different ways, but in all 
 For example, In JDBC, you change the URL to use the load balance property:
 
 ```java
-string yburl = "jdbc:yugabytedb://hostname:port/database?user=yugabyte&password=yugabyte&load-balance=true"
+String yburl = "jdbc:yugabytedb://hostname:port/database?user=yugabyte&password=yugabyte&load-balance=true"
 DriverManager.getConnection(yburl);
 ```
 

--- a/docs/content/preview/faq/smart-drivers-faq.md
+++ b/docs/content/preview/faq/smart-drivers-faq.md
@@ -50,7 +50,7 @@ Different language drivers initialize connections in different ways, but in all 
 For example, In JDBC, you change the URL to use the load balance property:
 
 ```java
-String yburl = "jdbc:yugabytedb://hostname:port/database?user=yugabyte&password=yugabyte&load-balance=true"
+String yburl = "jdbc:yugabytedb://hostname:port/database?user=yugabyte&password=yugabyte&load-balance=true";
 DriverManager.getConnection(yburl);
 ```
 

--- a/docs/content/stable/drivers-orms/java/postgres-jdbc.md
+++ b/docs/content/stable/drivers-orms/java/postgres-jdbc.md
@@ -118,7 +118,8 @@ jdbc:postgresql://hostname:port/database
 Following is an example JDBC URL for connecting to YugabyteDB:
 
 ```sh
-Connection conn = DriverManager.getConnection("jdbc:postgresql://localhost:5433/yugabyte","yugabyte", "yugabyte");
+String yburl = "jdbc:postgresql://localhost:5433/yugabyte";
+Connection conn = DriverManager.getConnection(yburl, "yugabyte", "yugabyte");
 ```
 
 #### Use SSL
@@ -163,7 +164,7 @@ public class QuickStartApp {
   public static void main(String[] args) throws ClassNotFoundException, SQLException {
     Class.forName("org.postgresql.Driver");
     String yburl = "jdbc:postgresql://localhost:5433/yugabyte";
-    Connection conn = DriverManager.getConnection(yburl,"yugabyte", "yugabyte");
+    Connection conn = DriverManager.getConnection(yburl, "yugabyte", "yugabyte");
     Statement stmt = conn.createStatement();
     try {
         System.out.println("Connected to the PostgreSQL server successfully.");

--- a/docs/content/stable/drivers-orms/java/postgres-jdbc.md
+++ b/docs/content/stable/drivers-orms/java/postgres-jdbc.md
@@ -162,8 +162,8 @@ import java.sql.ResultSet;
 public class QuickStartApp {
   public static void main(String[] args) throws ClassNotFoundException, SQLException {
     Class.forName("org.postgresql.Driver");
-    String yburl = "jdbc:postgresql://localhost:5433/yugabyte", "yugabyte", "yugabyte";
-    Connection conn = DriverManager.getConnection(yburl);
+    String yburl = "jdbc:postgresql://localhost:5433/yugabyte";
+    Connection conn = DriverManager.getConnection(yburl,"yugabyte", "yugabyte");
     Statement stmt = conn.createStatement();
     try {
         System.out.println("Connected to the PostgreSQL server successfully.");

--- a/docs/content/stable/drivers-orms/java/postgres-jdbc.md
+++ b/docs/content/stable/drivers-orms/java/postgres-jdbc.md
@@ -135,7 +135,7 @@ The following table describes the connection parameters required to connect usin
 The following is an example JDBC URL for connecting to a YugabyteDB cluster with SSL encryption enabled.
 
 ```java
-string yburl = "jdbc:postgresql://hostname:port/database?user=yugabyte&password=yugabyte&ssl=true&sslmode=verify-full&sslrootcert=~/.postgresql/root.crt"
+String yburl = "jdbc:postgresql://hostname:port/database?user=yugabyte&password=yugabyte&ssl=true&sslmode=verify-full&sslrootcert=~/.postgresql/root.crt"
 Connection conn = DriverManager.getConnection(yburl);
 ```
 

--- a/docs/content/stable/drivers-orms/java/postgres-jdbc.md
+++ b/docs/content/stable/drivers-orms/java/postgres-jdbc.md
@@ -135,7 +135,7 @@ The following table describes the connection parameters required to connect usin
 The following is an example JDBC URL for connecting to a YugabyteDB cluster with SSL encryption enabled.
 
 ```java
-String yburl = "jdbc:postgresql://hostname:port/database?user=yugabyte&password=yugabyte&ssl=true&sslmode=verify-full&sslrootcert=~/.postgresql/root.crt"
+String yburl = "jdbc:postgresql://hostname:port/database?user=yugabyte&password=yugabyte&ssl=true&sslmode=verify-full&sslrootcert=~/.postgresql/root.crt";
 Connection conn = DriverManager.getConnection(yburl);
 ```
 

--- a/docs/content/v2.14/drivers-orms/java/postgres-jdbc.md
+++ b/docs/content/v2.14/drivers-orms/java/postgres-jdbc.md
@@ -90,7 +90,7 @@ Connection conn = DriverManager.getConnection("jdbc:postgresql://localhost:5433/
 Example JDBC URL for connecting to YugabyteDB cluster enabled with on the wire SSL encryption.
 
 ```java
-string yburl = "jdbc:postgresql://hostname:port/database?user=yugabyte&password=yugabyte&ssl=true&sslmode=verify-full&sslrootcert=~/.postgresql/root.crt"
+String yburl = "jdbc:postgresql://hostname:port/database?user=yugabyte&password=yugabyte&ssl=true&sslmode=verify-full&sslrootcert=~/.postgresql/root.crt"
 Connection conn = DriverManager.getConnection(yburl);
 ```
 

--- a/docs/content/v2.14/drivers-orms/java/postgres-jdbc.md
+++ b/docs/content/v2.14/drivers-orms/java/postgres-jdbc.md
@@ -90,7 +90,7 @@ Connection conn = DriverManager.getConnection("jdbc:postgresql://localhost:5433/
 Example JDBC URL for connecting to YugabyteDB cluster enabled with on the wire SSL encryption.
 
 ```java
-String yburl = "jdbc:postgresql://hostname:port/database?user=yugabyte&password=yugabyte&ssl=true&sslmode=verify-full&sslrootcert=~/.postgresql/root.crt"
+String yburl = "jdbc:postgresql://hostname:port/database?user=yugabyte&password=yugabyte&ssl=true&sslmode=verify-full&sslrootcert=~/.postgresql/root.crt";
 Connection conn = DriverManager.getConnection(yburl);
 ```
 

--- a/docs/content/v2.14/drivers-orms/java/yugabyte-jdbc.md
+++ b/docs/content/v2.14/drivers-orms/java/yugabyte-jdbc.md
@@ -74,7 +74,7 @@ Use the `DriverManager.getConnection` method for getting connection object for t
 The following is an example JDBC URL for connecting to YugabyteDB.
 
 ```java
-string yburl = "jdbc:yugabytedb://hostname:port/database?user=yugabyte&password=yugabyte&load-balance=true"
+String yburl = "jdbc:yugabytedb://hostname:port/database?user=yugabyte&password=yugabyte&load-balance=true"
 DriverManager.getConnection(yburl);
 ```
 
@@ -90,7 +90,7 @@ DriverManager.getConnection(yburl);
 The following is an example JDBC URL for connecting to a YugabyteDB cluster with SSL encryption enabled.
 
 ```java
-string yburl = "jdbc:yugabytedb://hostname:port/database?user=yugabyte&password=yugabyte&load-balance=true&ssl=true&sslmode=verify-full&sslrootcert=~/.postgresql/root.crt"
+String yburl = "jdbc:yugabytedb://hostname:port/database?user=yugabyte&password=yugabyte&load-balance=true&ssl=true&sslmode=verify-full&sslrootcert=~/.postgresql/root.crt"
 Connection conn = DriverManager.getConnection(yburl);
 ```
 

--- a/docs/content/v2.14/drivers-orms/java/yugabyte-jdbc.md
+++ b/docs/content/v2.14/drivers-orms/java/yugabyte-jdbc.md
@@ -74,7 +74,7 @@ Use the `DriverManager.getConnection` method for getting connection object for t
 The following is an example JDBC URL for connecting to YugabyteDB.
 
 ```java
-String yburl = "jdbc:yugabytedb://hostname:port/database?user=yugabyte&password=yugabyte&load-balance=true"
+String yburl = "jdbc:yugabytedb://hostname:port/database?user=yugabyte&password=yugabyte&load-balance=true";
 DriverManager.getConnection(yburl);
 ```
 
@@ -90,7 +90,7 @@ DriverManager.getConnection(yburl);
 The following is an example JDBC URL for connecting to a YugabyteDB cluster with SSL encryption enabled.
 
 ```java
-String yburl = "jdbc:yugabytedb://hostname:port/database?user=yugabyte&password=yugabyte&load-balance=true&ssl=true&sslmode=verify-full&sslrootcert=~/.postgresql/root.crt"
+String yburl = "jdbc:yugabytedb://hostname:port/database?user=yugabyte&password=yugabyte&load-balance=true&ssl=true&sslmode=verify-full&sslrootcert=~/.postgresql/root.crt";
 Connection conn = DriverManager.getConnection(yburl);
 ```
 


### PR DESCRIPTION
Some changes were needed 
- Replaced occurrences of "string" with "String"
- Changed code snippets with incorrect syntax like the following :
 ```
String yburl = "jdbc:postgresql://localhost:5433/yugabyte", "yugabyte", "yugabyte";
Connection conn = DriverManager.getConnection(yburl);
```
to :
```
String yburl = "jdbc:postgresql://localhost:5433/yugabyte";
Connection conn = DriverManager.getConnection(yburl,"yugabyte", "yugabyte");
```

Slack conversation link reporting the issue - https://yugabyte.slack.com/archives/CDQB8MEAU/p1675110021134259