### PR TITLE
[docs] CDCSDK: Modify section to mention steps to DROP/TRUNCATE tables with CDC

### DIFF
--- a/docs/content/preview/explore/change-data-capture/debezium-connector-yugabytedb.md
+++ b/docs/content/preview/explore/change-data-capture/debezium-connector-yugabytedb.md
@@ -694,11 +694,11 @@ A `delete` change event record provides a consumer with the information it needs
 
 When a row is deleted, the _delete_ event value still works with log compaction, because Kafka can remove all earlier messages that have that same key. However, for Kafka to remove all messages that have that same key, the message value must be `null`. To make this possible, the YugabyteDB connector follows a delete event with a special _tombstone_ event that has the same key but a null value.
 
-{{< warning title="DROP and ALTER table commands" >}}
+{{< tip title="Enable GFlag to DROP or TRUNCATE" >}}
 
-The YugabyteDB CDC implementation doesn't yet support DROP TABLE and TRUNCATE TABLE commands, and the behavior of these commands while streaming data from CDC is undefined. If you need to drop or truncate a table, delete the stream ID using [yb-admin](../../../admin/yb-admin/#change-data-capture-cdc-commands). Also, see the [limitations](../../change-data-capture/#limitations) section.
+The YugabyteDB CDC implementation will not let you DROP or TRUNCATE a table while an active CDC stream is present on the namespace. If you need to perform these operations while CDC is enabled, set the value of a GFlag `enable_delete_truncate_cdcsdk_table` to `true` and then you can DROP or TRUNCATE the table.
 
-{{< /warning >}}
+{{< /tip >}}
 
 #### Suppressing tombstone events
 

--- a/docs/content/preview/integrations/cdc/debezium.md
+++ b/docs/content/preview/integrations/cdc/debezium.md
@@ -156,13 +156,11 @@ Do the following:
 
 For a list of all the configuration options provided with the Debezium YugabyteDB connector, see [Connector configuration properties](../../../explore/change-data-capture/debezium-connector-yugabytedb/#connector-configuration-properties).
 
-{{< warning title="Warning" >}}
+{{< tip title="Enable GFlag to DROP or TRUNCATE" >}}
 
-YugabyteDB's CDC implementation doesn't currently support DROP TABLE and TRUNCATE TABLE, and the behavior of these commands while streaming data from CDC is undefined. If you need to drop or truncate a table, delete the stream ID using [yb-admin](../../../admin/yb-admin/#change-data-capture-cdc-commands).
+The YugabyteDB CDC implementation will not let you DROP or TRUNCATE a table while an active CDC stream is present on the namespace. If you need to perform these operations while CDC is enabled, set the value of a [GFlag](../../reference/configuration/yb-tserver/#change-data-capture-cdc-flags) `enable_delete_truncate_cdcsdk_table` to `true` and then you can DROP or TRUNCATE the table.
 
-See [limitations](../../../explore/change-data-capture/#limitations) for more details on upcoming feature support.
-
-{{< /warning >}}
+{{< /tip >}}
 
 ### Start a Kafka Topic console consumer (optional)
 

--- a/docs/content/stable/explore/change-data-capture/debezium-connector-yugabytedb.md
+++ b/docs/content/stable/explore/change-data-capture/debezium-connector-yugabytedb.md
@@ -690,11 +690,11 @@ A `delete` change event record provides a consumer with the information it needs
 
 When a row is deleted, the _delete_ event value still works with log compaction, because Kafka can remove all earlier messages that have that same key. However, for Kafka to remove all messages that have that same key, the message value must be `null`. To make this possible, the YugabyteDB connector follows a delete event with a special _tombstone_ event that has the same key but a null value.
 
-{{< warning title="DROP and ALTER table commands" >}}
+{{< tip title="Enable GFlag to DROP or TRUNCATE" >}}
 
-The YugabyteDB CDC implementation doesn't yet support DROP TABLE and TRUNCATE TABLE commands, and the behavior of these commands while streaming data from CDC is undefined. If you need to drop or truncate a table, delete the stream ID using [yb-admin](../../../admin/yb-admin/#change-data-capture-cdc-commands). Also, see the [limitations](../../change-data-capture/#limitations) section.
+The YugabyteDB CDC implementation will not let you DROP or TRUNCATE a table while an active CDC stream is present on the namespace. If you need to perform these operations while CDC is enabled, set the value of a GFlag `enable_delete_truncate_cdcsdk_table` to `true` and then you can DROP or TRUNCATE the table.
 
-{{< /warning >}}
+{{< /tip >}}
 
 #### Suppressing tombstone events
 

--- a/docs/content/v2.14/explore/change-data-capture/debezium-connector-yugabytedb.md
+++ b/docs/content/v2.14/explore/change-data-capture/debezium-connector-yugabytedb.md
@@ -690,11 +690,11 @@ A `delete` change event record provides a consumer with the information it needs
 
 When a row is deleted, the _delete_ event value still works with log compaction, because Kafka can remove all earlier messages that have that same key. However, for Kafka to remove all messages that have that same key, the message value must be `null`. To make this possible, the YugabyteDB connector follows a delete event with a special _tombstone_ event that has the same key but a null value.
 
-{{< warning title="DROP and ALTER table commands" >}}
+{{< tip title="Enable GFlag to DROP or TRUNCATE" >}}
 
-The YugabyteDB CDC implementation doesn't yet support DROP TABLE and TRUNCATE TABLE commands, and the behavior of these commands while streaming data from CDC is undefined. If you need to drop or truncate a table, delete the stream ID using [yb-admin](../../../admin/yb-admin/#change-data-capture-cdc-commands). Also, see the [limitations](../../change-data-capture/#limitations) section.
+The YugabyteDB CDC implementation will not let you DROP or TRUNCATE a table while an active CDC stream is present on the namespace. If you need to perform these operations while CDC is enabled, set the value of a GFlag `enable_delete_truncate_cdcsdk_table` to `true` and then you can DROP or TRUNCATE the table.
 
-{{< /warning >}}
+{{< /tip >}}
 
 #### Suppressing tombstone events
 


### PR DESCRIPTION
This PR modifies a section and adds the steps which guides the user on how to DROP or TRUNCATE a table which is a part of an active CDC stream ID.