### PR TITLE
[docs] Remove absolute links in 2.12

### DIFF
--- a/docs/content/v2.12/benchmark/resilience/jepsen-testing-ycql.md
+++ b/docs/content/v2.12/benchmark/resilience/jepsen-testing-ycql.md
@@ -15,14 +15,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/benchmark/resilience/jepsen-testing-ysql" class="nav-link">
+    <a href="../jepsen-testing-ysql" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/benchmark/resilience/jepsen-testing-ycql" class="nav-link active">
+    <a href="../jepsen-testing-ycql" class="nav-link active">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/benchmark/resilience/jepsen-testing-ysql.md
+++ b/docs/content/v2.12/benchmark/resilience/jepsen-testing-ysql.md
@@ -15,14 +15,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/benchmark/resilience/jepsen-testing-ysql" class="nav-link active">
+    <a href="../jepsen-testing-ysql" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/benchmark/resilience/jepsen-testing-ycql" class="nav-link">
+    <a href="../jepsen-testing-ycql" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/benchmark/scalability/scaling-queries-ycql.md
+++ b/docs/content/v2.12/benchmark/scalability/scaling-queries-ycql.md
@@ -15,14 +15,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/benchmark/scalability/scaling-queries-ysql" class="nav-link">
+    <a href="../scaling-queries-ysql" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/benchmark/scalability/scaling-queries-ycql" class="nav-link active">
+    <a href="../scaling-queries-ycql" class="nav-link active">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/benchmark/scalability/scaling-queries-ysql.md
+++ b/docs/content/v2.12/benchmark/scalability/scaling-queries-ysql.md
@@ -15,14 +15,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/benchmark/scalability/scaling-queries-ysql" class="nav-link active">
+    <a href="../scaling-queries-ysql" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/benchmark/scalability/scaling-queries-ycql" class="nav-link">
+    <a href="../scaling-queries-ycql" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/deploy/kubernetes/multi-cluster/gke/helm-chart.md
+++ b/docs/content/v2.12/deploy/kubernetes/multi-cluster/gke/helm-chart.md
@@ -14,7 +14,7 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/deploy/kubernetes/multi-cluster/gke/helm-chart" class="nav-link active">
+    <a href="../helm-chart" class="nav-link active">
       <i class="fa-solid fa-cubes" aria-hidden="true"></i>
       Helm chart
     </a>

--- a/docs/content/v2.12/deploy/kubernetes/multi-zone/eks/helm-chart.md
+++ b/docs/content/v2.12/deploy/kubernetes/multi-zone/eks/helm-chart.md
@@ -14,7 +14,7 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/deploy/kubernetes/multi-zone/eks/helm-chart" class="nav-link active">
+    <a href="../helm-chart" class="nav-link active">
       <i class="fa-solid fa-cubes" aria-hidden="true"></i>
       Helm chart
     </a>

--- a/docs/content/v2.12/deploy/kubernetes/multi-zone/gke/helm-chart.md
+++ b/docs/content/v2.12/deploy/kubernetes/multi-zone/gke/helm-chart.md
@@ -14,7 +14,7 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/deploy/kubernetes/multi-zone/gke/helm-chart" class="nav-link active">
+    <a href="../helm-chart" class="nav-link active">
       <i class="fa-solid fa-cubes" aria-hidden="true"></i>
       Helm chart
     </a>

--- a/docs/content/v2.12/deploy/kubernetes/single-zone/aks/helm-chart.md
+++ b/docs/content/v2.12/deploy/kubernetes/single-zone/aks/helm-chart.md
@@ -15,13 +15,13 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/deploy/kubernetes/single-zone/aks/helm-chart" class="nav-link active">
+    <a href="../helm-chart" class="nav-link active">
       <i class="fa-solid fa-cubes" aria-hidden="true"></i>
       Helm chart
     </a>
   </li>
   <li >
-    <a href="/preview/deploy/kubernetes/single-zone/aks/statefulset-yaml" class="nav-link">
+    <a href="../statefulset-yaml" class="nav-link">
       <i class="fa-solid fa-cubes" aria-hidden="true"></i>
       StatefulSet YAML
     </a>

--- a/docs/content/v2.12/deploy/kubernetes/single-zone/aks/statefulset-yaml.md
+++ b/docs/content/v2.12/deploy/kubernetes/single-zone/aks/statefulset-yaml.md
@@ -15,13 +15,13 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/deploy/kubernetes/single-zone/aks/helm-chart" class="nav-link">
+    <a href="../helm-chart" class="nav-link">
       <i class="fa-solid fa-cubes" aria-hidden="true"></i>
       Helm chart
     </a>
   </li>
   <li >
-    <a href="/preview/deploy/kubernetes/single-zone/aks/statefulset-yaml" class="nav-link active">
+    <a href="../statefulset-yaml" class="nav-link active">
       <i class="fa-solid fa-cubes" aria-hidden="true"></i>
       StatefulSet YAML
     </a>

--- a/docs/content/v2.12/deploy/kubernetes/single-zone/eks/helm-chart.md
+++ b/docs/content/v2.12/deploy/kubernetes/single-zone/eks/helm-chart.md
@@ -14,7 +14,7 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/deploy/kubernetes/single-zone/eks/helm-chart" class="nav-link active">
+    <a href="../helm-chart" class="nav-link active">
       <i class="fa-solid fa-cubes" aria-hidden="true"></i>
       Helm chart
     </a>

--- a/docs/content/v2.12/deploy/kubernetes/single-zone/gke/helm-chart.md
+++ b/docs/content/v2.12/deploy/kubernetes/single-zone/gke/helm-chart.md
@@ -14,19 +14,19 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/deploy/kubernetes/single-zone/gke/helm-chart" class="nav-link active">
+    <a href="../helm-chart" class="nav-link active">
       <i class="fa-solid fa-cubes" aria-hidden="true"></i>
       Helm chart
     </a>
   </li>
   <li >
-    <a href="/preview/deploy/kubernetes/single-zone/gke/statefulset-yaml" class="nav-link">
+    <a href="../statefulset-yaml" class="nav-link">
       <i class="fa-solid fa-cubes" aria-hidden="true"></i>
       YAML (remote disk)
     </a>
   </li>
    <li >
-    <a href="/preview/deploy/kubernetes/single-zone/gke/statefulset-yaml-local-ssd" class="nav-link">
+    <a href="../statefulset-yaml-local-ssd" class="nav-link">
       <i class="fa-solid fa-cubes" aria-hidden="true"></i>
       YAML (local disk)
     </a>

--- a/docs/content/v2.12/deploy/kubernetes/single-zone/gke/statefulset-yaml-local-ssd.md
+++ b/docs/content/v2.12/deploy/kubernetes/single-zone/gke/statefulset-yaml-local-ssd.md
@@ -14,19 +14,19 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/deploy/kubernetes/single-zone/gke/helm-chart" class="nav-link">
+    <a href="../helm-chart" class="nav-link">
       <i class="fa-solid fa-cubes" aria-hidden="true"></i>
       Helm Chart
     </a>
   </li>
   <li >
-    <a href="/preview/deploy/kubernetes/single-zone/gke/statefulset-yaml" class="nav-link">
+    <a href="../statefulset-yaml" class="nav-link">
       <i class="fa-solid fa-cubes" aria-hidden="true"></i>
       YAML (remote disk)
     </a>
   </li>
    <li >
-    <a href="/preview/deploy/kubernetes/single-zone/gke/statefulset-yaml-local-ssd" class="nav-link active">
+    <a href="../statefulset-yaml-local-ssd" class="nav-link active">
       <i class="fa-solid fa-cubes" aria-hidden="true"></i>
       YAML (local disk)
     </a>

--- a/docs/content/v2.12/deploy/kubernetes/single-zone/gke/statefulset-yaml.md
+++ b/docs/content/v2.12/deploy/kubernetes/single-zone/gke/statefulset-yaml.md
@@ -14,19 +14,19 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/deploy/kubernetes/single-zone/gke/helm-chart" class="nav-link">
+    <a href="../helm-chart" class="nav-link">
       <i class="fa-solid fa-cubes" aria-hidden="true"></i>
       Helm chart
     </a>
   </li>
   <li >
-    <a href="/preview/deploy/kubernetes/single-zone/gke/statefulset-yaml" class="nav-link active">
+    <a href="../statefulset-yaml" class="nav-link active">
       <i class="fa-solid fa-cubes" aria-hidden="true"></i>
       YAML (remote disk)
     </a>
   </li>
   <li >
-    <a href="/preview/deploy/kubernetes/single-zone/gke/statefulset-yaml-local-ssd" class="nav-link">
+    <a href="../statefulset-yaml-local-ssd" class="nav-link">
       <i class="fa-solid fa-cubes" aria-hidden="true"></i>
       YAML (local disk)
     </a>

--- a/docs/content/v2.12/develop/learn/acid-transactions-ycql.md
+++ b/docs/content/v2.12/develop/learn/acid-transactions-ycql.md
@@ -14,14 +14,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/develop/learn/acid-transactions-ysql" class="nav-link">
+    <a href="../acid-transactions-ysql" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/develop/learn/acid-transactions-ycql" class="nav-link active">
+    <a href="../acid-transactions-ycql" class="nav-link active">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/develop/learn/acid-transactions-ysql.md
+++ b/docs/content/v2.12/develop/learn/acid-transactions-ysql.md
@@ -14,14 +14,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/develop/learn/acid-transactions-ysql" class="nav-link active">
+    <a href="../acid-transactions-ysql" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/develop/learn/acid-transactions-ycql" class="nav-link">
+    <a href="../acid-transactions-ycql" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/develop/learn/aggregations-ycql.md
+++ b/docs/content/v2.12/develop/learn/aggregations-ycql.md
@@ -14,14 +14,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/develop/learn/aggregations-ysql" class="nav-link">
+    <a href="../aggregations-ysql" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/develop/learn/aggregations-ycql" class="nav-link active">
+    <a href="../aggregations-ycql" class="nav-link active">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/develop/learn/aggregations-ysql.md
+++ b/docs/content/v2.12/develop/learn/aggregations-ysql.md
@@ -14,14 +14,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/develop/learn/aggregations-ysql" class="nav-link active">
+    <a href="../aggregations-ysql" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/develop/learn/aggregations-ycql" class="nav-link">
+    <a href="../aggregations-ycql" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/develop/learn/data-modeling-ysql.md
+++ b/docs/content/v2.12/develop/learn/data-modeling-ysql.md
@@ -14,14 +14,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/develop/learn/data-modeling-ysql" class="nav-link active">
+    <a href="../data-modeling-ysql" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/develop/learn/data-modeling-ycql" class="nav-link">
+    <a href="../data-modeling-ycql" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/develop/learn/data-types-ycql.md
+++ b/docs/content/v2.12/develop/learn/data-types-ycql.md
@@ -14,14 +14,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/develop/learn/data-types-ysql" class="nav-link">
+    <a href="../data-types-ysql" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/develop/learn/data-types-ycql" class="nav-link active">
+    <a href="../data-types-ycql" class="nav-link active">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/develop/learn/data-types-ysql.md
+++ b/docs/content/v2.12/develop/learn/data-types-ysql.md
@@ -14,14 +14,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/develop/learn/data-types" class="nav-link active">
+    <a href="../data-types" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/develop/learn/data-types-ycql" class="nav-link">
+    <a href="../data-types-ycql" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/develop/learn/date-and-time-ycql.md
+++ b/docs/content/v2.12/develop/learn/date-and-time-ycql.md
@@ -15,14 +15,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/develop/learn/date-and-time-ysql" class="nav-link">
+    <a href="../date-and-time-ysql" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/develop/learn/date-and-time-ycql" class="nav-link active">
+    <a href="../date-and-time-ycql" class="nav-link active">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/develop/learn/date-and-time-ysql.md
+++ b/docs/content/v2.12/develop/learn/date-and-time-ysql.md
@@ -15,14 +15,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/develop/learn/date-and-time-ysql" class="nav-link active">
+    <a href="../date-and-time-ysql" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/develop/learn/date-and-time-ycql" class="nav-link">
+    <a href="../date-and-time-ycql" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/develop/learn/strings-and-text-ycql.md
+++ b/docs/content/v2.12/develop/learn/strings-and-text-ycql.md
@@ -14,14 +14,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/develop/learn/strings-and-text-ysql" class="nav-link">
+    <a href="../strings-and-text-ysql" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/develop/learn/strings-and-text-ycql" class="nav-link active">
+    <a href="../strings-and-text-ycql" class="nav-link active">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/develop/learn/strings-and-text-ysql.md
+++ b/docs/content/v2.12/develop/learn/strings-and-text-ysql.md
@@ -14,14 +14,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/develop/learn/strings-and-text-ysql" class="nav-link active">
+    <a href="../strings-and-text-ysql" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/develop/learn/strings-and-text-ycql" class="nav-link">
+    <a href="../strings-and-text-ycql" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/develop/learn/ttl-data-expiration-ycql.md
+++ b/docs/content/v2.12/develop/learn/ttl-data-expiration-ycql.md
@@ -14,14 +14,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/develop/learn/ttl-data-expiration-ysql" class="nav-link">
+    <a href="../ttl-data-expiration-ysql" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/develop/learn/ttl-data-expiration-ycql" class="nav-link active">
+    <a href="../ttl-data-expiration-ycql" class="nav-link active">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/develop/learn/ttl-data-expiration-ysql.md
+++ b/docs/content/v2.12/develop/learn/ttl-data-expiration-ysql.md
@@ -14,14 +14,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/develop/learn/ttl-data-expiration-ysql" class="nav-link active">
+    <a href="../ttl-data-expiration-ysql" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/develop/learn/ttl-data-expiration-ycql" class="nav-link">
+    <a href="../ttl-data-expiration-ycql" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/explore/cluster-management/point-in-time-recovery-ycql.md
+++ b/docs/content/v2.12/explore/cluster-management/point-in-time-recovery-ycql.md
@@ -13,13 +13,13 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/explore/cluster-management/point-in-time-recovery-ysql" class="nav-link">
+    <a href="../point-in-time-recovery-ysql" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
   <li >
-    <a href="/preview/explore/cluster-management/point-in-time-recovery-ycql" class="nav-link active">
+    <a href="../point-in-time-recovery-ycql" class="nav-link active">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/explore/cluster-management/point-in-time-recovery-ysql.md
+++ b/docs/content/v2.12/explore/cluster-management/point-in-time-recovery-ysql.md
@@ -14,13 +14,13 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/explore/cluster-management/point-in-time-recovery-ysql" class="nav-link active">
+    <a href="../point-in-time-recovery-ysql" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
   <li >
-    <a href="/preview/explore/cluster-management/point-in-time-recovery-ycql" class="nav-link">
+    <a href="../point-in-time-recovery-ycql" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/explore/json-support/jsonb-ycql.md
+++ b/docs/content/v2.12/explore/json-support/jsonb-ycql.md
@@ -19,14 +19,14 @@ JSON data types are for storing JSON (JavaScript Object Notation) data, as speci
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/explore/json-support/jsonb-ysql/" class="nav-link">
+    <a href="../jsonb-ysql/" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/explore/json-support/jsonb-ycql/" class="nav-link active">
+    <a href="../jsonb-ycql/" class="nav-link active">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/explore/json-support/jsonb-ysql.md
+++ b/docs/content/v2.12/explore/json-support/jsonb-ysql.md
@@ -19,14 +19,14 @@ JSON data types are for storing JSON (JavaScript Object Notation) data, as speci
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/explore/json-support/jsonb-ysql/" class="nav-link active">
+    <a href="../jsonb-ysql/" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/explore/json-support/jsonb-ycql/" class="nav-link">
+    <a href="../jsonb-ycql/" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/explore/linear-scalability/scaling-transactions.md
+++ b/docs/content/v2.12/explore/linear-scalability/scaling-transactions.md
@@ -16,14 +16,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/explore/linear-scalability/scaling-transactions/" class="nav-link active">
+    <a href="../scaling-transactions/" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 <!--
   <li >
-    <a href="/preview/explore/linear-scalability/scaling-transactions-ycql/" class="nav-link">
+    <a href="../scaling-transactions-ycql/" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/explore/linear-scalability/sharding-data.md
+++ b/docs/content/v2.12/explore/linear-scalability/sharding-data.md
@@ -17,14 +17,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/explore/transactions/scaling-transactions/" class="nav-link active">
+    <a href="../scaling-transactions/" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/explore/transactions/distributed-transactions-ycql/" class="nav-link">
+    <a href="../distributed-transactions-ycql/" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/explore/multi-region-deployments/asynchronous-replication-ycql.md
+++ b/docs/content/v2.12/explore/multi-region-deployments/asynchronous-replication-ycql.md
@@ -15,14 +15,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/explore/multi-region-deployments/asynchronous-replication-ysql/" class="nav-link">
+    <a href="../asynchronous-replication-ysql/" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/explore/multi-region-deployments/asynchronous-replication-ycql/" class="nav-link active">
+    <a href="../asynchronous-replication-ycql/" class="nav-link active">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/explore/transactions/distributed-transactions-ycql.md
+++ b/docs/content/v2.12/explore/transactions/distributed-transactions-ycql.md
@@ -16,14 +16,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/explore/transactions/distributed-transactions-ysql/" class="nav-link">
+    <a href="../distributed-transactions-ysql/" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/explore/transactions/distributed-transactions-ycql/" class="nav-link active">
+    <a href="../distributed-transactions-ycql/" class="nav-link active">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/explore/transactions/distributed-transactions-ysql.md
+++ b/docs/content/v2.12/explore/transactions/distributed-transactions-ysql.md
@@ -16,14 +16,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/explore/transactions/distributed-transactions-ysql/" class="nav-link active">
+    <a href="../distributed-transactions-ysql/" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/explore/transactions/distributed-transactions-ycql/" class="nav-link">
+    <a href="../distributed-transactions-ycql/" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/explore/transactions/explicit-locking.md
+++ b/docs/content/v2.12/explore/transactions/explicit-locking.md
@@ -17,7 +17,7 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/explore/multi-region-deployments/synchronous-replication-ysql/" class="nav-link active">
+    <a href="../synchronous-replication-ysql/" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>

--- a/docs/content/v2.12/explore/transactions/isolation-levels.md
+++ b/docs/content/v2.12/explore/transactions/isolation-levels.md
@@ -17,14 +17,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/explore/transactions/isolation-levels/" class="nav-link active">
+    <a href="../isolation-levels/" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 <!--
   <li >
-    <a href="/preview/explore/multi-region-deployments/synchronous-replication-ycql/" class="nav-link">
+    <a href="../synchronous-replication-ycql/" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/manage/backup-restore/back-up-data-ycql.md
+++ b/docs/content/v2.12/manage/backup-restore/back-up-data-ycql.md
@@ -13,13 +13,13 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/manage/backup-restore/back-up-data" class="nav-link">
+    <a href="../back-up-data" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
   <li >
-    <a href="/preview/manage/backup-restore/back-up-data-ycql" class="nav-link active">
+    <a href="../back-up-data-ycql" class="nav-link active">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/manage/backup-restore/back-up-data.md
+++ b/docs/content/v2.12/manage/backup-restore/back-up-data.md
@@ -13,13 +13,13 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/manage/backup-restore/back-up-data" class="nav-link active">
+    <a href="../back-up-data" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
   <li >
-    <a href="/preview/manage/backup-restore/back-up-data-ycql" class="nav-link">
+    <a href="../back-up-data-ycql" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/manage/backup-restore/restore-data-ycql.md
+++ b/docs/content/v2.12/manage/backup-restore/restore-data-ycql.md
@@ -13,13 +13,13 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/manage/backup-restore/restore-data" class="nav-link">
+    <a href="../restore-data" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
   <li >
-    <a href="/preview/manage/backup-restore/restore-data-ycql" class="nav-link active">
+    <a href="../restore-data-ycql" class="nav-link active">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/manage/backup-restore/restore-data.md
+++ b/docs/content/v2.12/manage/backup-restore/restore-data.md
@@ -13,13 +13,13 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/manage/backup-restore/restore-data" class="nav-link active">
+    <a href="../restore-data" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
   <li >
-    <a href="/preview/manage/backup-restore/restore-data-ycql" class="nav-link">
+    <a href="../restore-data-ycql" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/manage/backup-restore/snapshot-ysql.md
+++ b/docs/content/v2.12/manage/backup-restore/snapshot-ysql.md
@@ -15,14 +15,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/manage/backup-restore/snapshot-ysql" class="nav-link active">
+    <a href="../snapshot-ysql" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/manage/backup-restore/snapshots-ycql" class="nav-link">
+    <a href="../snapshots-ycql" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/manage/backup-restore/snapshots-ycql.md
+++ b/docs/content/v2.12/manage/backup-restore/snapshots-ycql.md
@@ -15,14 +15,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/manage/backup-restore/snapshot-ysql" class="nav-link">
+    <a href="../snapshot-ysql" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/manage/backup-restore/snapshots-ycql" class="nav-link active">
+    <a href="../snapshots-ycql" class="nav-link active">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/secure/authentication/host-based-authentication.md
+++ b/docs/content/v2.12/secure/authentication/host-based-authentication.md
@@ -15,7 +15,7 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/secure/authentication/host-based-authentication" class="nav-link active">
+    <a href="../host-based-authentication" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>

--- a/docs/content/v2.12/secure/authentication/password-authentication.md
+++ b/docs/content/v2.12/secure/authentication/password-authentication.md
@@ -13,7 +13,7 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/secure/authentication/password-authentication" class="nav-link active">
+    <a href="../password-authentication" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>

--- a/docs/content/v2.12/secure/authentication/trust-authentication.md
+++ b/docs/content/v2.12/secure/authentication/trust-authentication.md
@@ -15,7 +15,7 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/secure/authentication/trust-authentication" class="nav-link active">
+    <a href="../trust-authentication" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>

--- a/docs/content/v2.12/secure/authorization/column-level-security.md
+++ b/docs/content/v2.12/secure/authorization/column-level-security.md
@@ -14,7 +14,7 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/secure/authorization/ysql-grant-permissions" class="nav-link active">
+    <a href="../ysql-grant-permissions" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>

--- a/docs/content/v2.12/secure/authorization/create-roles-ycql.md
+++ b/docs/content/v2.12/secure/authorization/create-roles-ycql.md
@@ -16,14 +16,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/secure/authorization/create-roles" class="nav-link">
+    <a href="../create-roles" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/secure/authorization/create-roles-ycql" class="nav-link active">
+    <a href="../create-roles-ycql" class="nav-link active">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/secure/authorization/create-roles.md
+++ b/docs/content/v2.12/secure/authorization/create-roles.md
@@ -15,14 +15,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/secure/authorization/create-roles" class="nav-link active">
+    <a href="../create-roles" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/secure/authorization/create-roles-ycql" class="nav-link">
+    <a href="../create-roles-ycql" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/secure/authorization/rbac-model-ycql.md
+++ b/docs/content/v2.12/secure/authorization/rbac-model-ycql.md
@@ -16,14 +16,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/secure/authorization/rbac-model" class="nav-link">
+    <a href="../rbac-model" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/secure/authorization/rbac-model-ycql" class="nav-link active">
+    <a href="../rbac-model-ycql" class="nav-link active">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/secure/authorization/rbac-model.md
+++ b/docs/content/v2.12/secure/authorization/rbac-model.md
@@ -16,14 +16,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/secure/authorization/rbac-model" class="nav-link active">
+    <a href="../rbac-model" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/secure/authorization/rbac-model-ycql" class="nav-link">
+    <a href="../rbac-model-ycql" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/secure/authorization/row-level-security.md
+++ b/docs/content/v2.12/secure/authorization/row-level-security.md
@@ -14,7 +14,7 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/secure/authorization/ysql-grant-permissions" class="nav-link active">
+    <a href="../ysql-grant-permissions" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>

--- a/docs/content/v2.12/secure/authorization/ycql-grant-permissions.md
+++ b/docs/content/v2.12/secure/authorization/ycql-grant-permissions.md
@@ -14,13 +14,13 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/secure/authorization/ysql-grant-permissions" class="nav-link">
+    <a href="../ysql-grant-permissions" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
   <li >
-    <a href="/preview/secure/authorization/ycql-grant-permissions" class="nav-link active">
+    <a href="../ycql-grant-permissions" class="nav-link active">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/secure/authorization/ysql-grant-permissions.md
+++ b/docs/content/v2.12/secure/authorization/ysql-grant-permissions.md
@@ -14,13 +14,13 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/secure/authorization/ysql-grant-permissions" class="nav-link active">
+    <a href="../ysql-grant-permissions" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
   <li >
-    <a href="/preview/secure/authorization/ycql-grant-permissions" class="nav-link">
+    <a href="../ycql-grant-permissions" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/secure/enable-authentication/ycql.md
+++ b/docs/content/v2.12/secure/enable-authentication/ycql.md
@@ -16,19 +16,19 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/secure/enable-authentication/ysql" class="nav-link">
+    <a href="../ysql" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
   <li >
-    <a href="/preview/secure/enable-authentication/ycql" class="nav-link active">
+    <a href="../ycql" class="nav-link active">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>
   </li>
   <li>
-    <a href="/preview/secure/enable-authentication/yedis" class="nav-link">
+    <a href="../yedis" class="nav-link">
       <i class="icon-redis" aria-hidden="true"></i>
       YEDIS
     </a>

--- a/docs/content/v2.12/secure/enable-authentication/yedis.md
+++ b/docs/content/v2.12/secure/enable-authentication/yedis.md
@@ -16,19 +16,19 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/secure/enable-authentication/ysql" class="nav-link">
+    <a href="../ysql" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
   <li >
-    <a href="/preview/secure/enable-authentication/ycql" class="nav-link">
+    <a href="../ycql" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>
   </li>
   <li>
-    <a href="/preview/secure/enable-authentication/yedis" class="nav-link active">
+    <a href="../yedis" class="nav-link active">
       <i class="icon-redis" aria-hidden="true"></i>
       YEDIS
     </a>

--- a/docs/content/v2.12/secure/enable-authentication/ysql.md
+++ b/docs/content/v2.12/secure/enable-authentication/ysql.md
@@ -16,19 +16,19 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/secure/enable-authentication/ysql" class="nav-link active">
+    <a href="../ysql" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
   <li >
-    <a href="/preview/secure/enable-authentication/ycql" class="nav-link">
+    <a href="../ycql" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>
   </li>
   <li>
-    <a href="/preview/secure/enable-authentication/yedis" class="nav-link">
+    <a href="../yedis" class="nav-link">
       <i class="icon-redis" aria-hidden="true"></i>
       YEDIS
     </a>

--- a/docs/content/v2.12/secure/enable-authentication/ysql_hba_conf-configuration.md
+++ b/docs/content/v2.12/secure/enable-authentication/ysql_hba_conf-configuration.md
@@ -13,7 +13,7 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/secure/enable-authentication/ysql_hba_conf-configuration" class="nav-link active">
+    <a href="../ysql_hba_conf-configuration" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>

--- a/docs/content/v2.12/secure/tls-encryption/tls-authentication.md
+++ b/docs/content/v2.12/secure/tls-encryption/tls-authentication.md
@@ -15,7 +15,7 @@ type: docs
 
 <ul class="nav nav-tabs-alt nav-tabs-yb">
   <li >
-    <a href="/preview/secure/authentication/tls-authentication" class="nav-link active">
+    <a href="../tls-authentication" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>

--- a/docs/content/v2.12/tools/dbeaver-ycql.md
+++ b/docs/content/v2.12/tools/dbeaver-ycql.md
@@ -14,14 +14,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/tools/dbeaver-ysql/" class="nav-link">
+    <a href="../dbeaver-ysql/" class="nav-link">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/tools/dbeaver-ycql/" class="nav-link active">
+    <a href="../dbeaver-ycql/" class="nav-link active">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>

--- a/docs/content/v2.12/tools/dbeaver-ysql.md
+++ b/docs/content/v2.12/tools/dbeaver-ysql.md
@@ -16,14 +16,14 @@ type: docs
 <ul class="nav nav-tabs-alt nav-tabs-yb">
 
   <li >
-    <a href="/preview/tools/dbeaver-ysql/" class="nav-link active">
+    <a href="../dbeaver-ysql/" class="nav-link active">
       <i class="icon-postgres" aria-hidden="true"></i>
       YSQL
     </a>
   </li>
 
   <li >
-    <a href="/preview/tools/dbeaver-ycql/" class="nav-link">
+    <a href="../dbeaver-ycql/" class="nav-link">
       <i class="icon-cassandra" aria-hidden="true"></i>
       YCQL
     </a>


### PR DESCRIPTION
Replace absolute links in 2.12 (except platform, to be done in separate PR)

@netlify /v2.12/secure/enable-authentication/ysql/