### PR TITLE
[docs] update yb-admin add_transaction_tablet ops argument

### DIFF
--- a/docs/content/preview/admin/yb-admin.md
+++ b/docs/content/preview/admin/yb-admin.md
@@ -562,12 +562,11 @@ Add a tablet to a transaction status table.
 yb-admin \
     -master_addresses <master-addresses> \
     add_transaction_tablet \
-    <keyspace> <table_name>
+    <table_id>
 ```
 
 * *master_addresses*: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.
-* *keyspace*: The name of the keyspace.
-* *table_name*: The name of the transaction status table name.
+* *table_id*: The `system.transactions` table UUID.
 
 **Example**
 
@@ -575,7 +574,7 @@ yb-admin \
 ./bin/yb-admin \
     -master_addresses ip1:7100,ip2:7100,ip3:7100 \
     add_transaction_tablet \
-    system transactions
+    dae037bea8374d7caeca701d12f736d5
 ```
 
 To verify that the new status tablet has been created, run the [`list_tablets`](#list-tablets) command.

--- a/docs/content/stable/admin/yb-admin.md
+++ b/docs/content/stable/admin/yb-admin.md
@@ -562,12 +562,11 @@ Add a tablet to a transaction status table.
 yb-admin \
     -master_addresses <master-addresses> \
     add_transaction_tablet \
-    <keyspace> <table_name>
+    <table_id>
 ```
 
 * *master_addresses*: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.
-* *keyspace*: The name of the keyspace.
-* *table_name*: The name of the transaction status table name.
+* *table_id*: The `system.transactions` table UUID.
 
 **Example**
 
@@ -575,7 +574,7 @@ yb-admin \
 ./bin/yb-admin \
     -master_addresses ip1:7100,ip2:7100,ip3:7100 \
     add_transaction_tablet \
-    system transactions
+    dae037bea8374d7caeca701d12f736d5
 ```
 
 To verify that the new status tablet has been created, run the [`list_tablets`](#list-tablets) command.


### PR DESCRIPTION
`yb-admin -master_addresses <master-addresses> add_transaction_tablet <keyspace> <table_name>` - The arguments to the `add_transaction_tablet` operation is not correct. It requires `table_id` instead of `keyspace` and `table_name`.

Updated the doc to reflect `table_id`

PR for the issue id #16659 