### PR TITLE
Skipping ToC (suppress specific headings of the same level on a page)

### DIFF
--- a/docs/layouts/shortcodes/header.html
+++ b/docs/layouts/shortcodes/header.html
@@ -1,0 +1,6 @@
+{{ $headingAnchor := urlize .Inner }}
+{{- if .Params.id -}}
+  {{ $headingAnchor = .Params.id }}
+{{- end -}}
+
+<h{{ .Params.Level }} id="{{ $headingAnchor | safeURL }}">{{- .Inner | safeHTML -}}</h{{ .Params.Level }}>


### PR DESCRIPTION
Use shortcode to remove heading from TOC

```hugo
# For Heading 2
{{< header Level="2" >}}Consistency{{< /header >}}

# For Heading 3
{{< header Level="3" >}}Consistency{{< /header >}}

# For Heading 4
{{< header Level="4" >}}Consistency{{< /header >}}
```
