### PR TITLE
removing explicit rendering

### DIFF
--- a/docs/layouts/shortcodes/tabs.html
+++ b/docs/layouts/shortcodes/tabs.html
@@ -1,3 +1,3 @@
 <ul class="nav nav-tabs-alt nav-tabs-yb">
-  {{ .Inner | .Page.RenderString }}
+  {{ .Inner }}
 </ul>


### PR DESCRIPTION
- The `.Page.Rending` was creating additional space between the header and the tabs