### PR TITLE
[#16883][YCQL]Fix java unit test setUpCqlClient maybe endless loop

### DIFF
--- a/java/yb-cql/src/test/java/org/yb/cql/BaseCQLTest.java
+++ b/java/yb-cql/src/test/java/org/yb/cql/BaseCQLTest.java
@@ -186,6 +186,7 @@ public class BaseCQLTest extends BaseMiniClusterTest {
         break;
       }
       LOG.info("system.peers still contains only " + numPeers + " entries, waiting");
+      attemptsMade++;
       Thread.sleep(1000);
     }
     if (waitSuccessful) {


### PR DESCRIPTION
attemptsMade is not change in loop.
So add attemptsMade++;
```
    while (attemptsMade < 30) {
      int numPeers = execute("SELECT peer FROM system.peers").all().size();
      if (numPeers >= expectedNumPeers) {
        waitSuccessful = true;
        break;
      }
      LOG.info("system.peers still contains only " + numPeers + " entries, waiting");
      Thread.sleep(1000);
    }
```