### PR TITLE
[#16561] YCQL: Restart cluster in TestCreateTable.testCreateTableNumTablets

### DIFF
--- a/java/yb-cql/src/test/java/org/yb/cql/TestCreateTable.java
+++ b/java/yb-cql/src/test/java/org/yb/cql/TestCreateTable.java
@@ -13,7 +13,6 @@
 package org.yb.cql;
 
 import java.util.HashMap;
-import java.util.Map;
 
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;


### PR DESCRIPTION
Fixes #16561

testCreateTableNumTablets need to restart cluster to make sure system.transactions is not exist, because other test case before create system.transactions.
To make sure this pass, we need to restart cluster.
 `assertFalse(miniCluster.getClient().tableExists("system", "transactions"));`