### PR TITLE
[PLAT-8332][docs] Added securityContext.enabled=false for YBA installation in OCP docs

### DIFF
--- a/docs/content/preview/yugabyte-platform/install-yugabyte-platform/install-software/openshift.md
+++ b/docs/content/preview/yugabyte-platform/install-yugabyte-platform/install-software/openshift.md
@@ -374,7 +374,7 @@ To create a YugabyteDB Anywhere instance, perform the following:
   ```
 
   - ClusterRole or ClusterRoleBinding with the cluster-admin role are recommended if your intention is to create clusters across multiple namespaces.
-  - Few metrics (CPU, memory) will be unavailable without the above `ClusterRoleBinding`.
+  - Certain container-level metrics like CPU, memory will be unavailable without the above `ClusterRoleBinding`.
 
 ### Delete the Helm installation of YugabyteDB Anywhere
 

--- a/docs/content/preview/yugabyte-platform/install-yugabyte-platform/install-software/openshift.md
+++ b/docs/content/preview/yugabyte-platform/install-yugabyte-platform/install-software/openshift.md
@@ -344,7 +344,8 @@ To create a YugabyteDB Anywhere instance, perform the following:
   helm install yw-test yugabytedb/yugaware -n yb-platform \
      --version {{<yb-version version="preview" format="short">}} \
      --set image.repository=quay.io/yugabyte/yugaware-ubi \
-     --set ocpCompatibility.enabled=true --set rbac.create=false --wait
+     --set ocpCompatibility.enabled=true --set rbac.create=false \
+     --set securityContext.enabled=false --wait
   ```
 
   Expect to see a message notifying you whether or not the deployment is successful.
@@ -372,7 +373,8 @@ To create a YugabyteDB Anywhere instance, perform the following:
   EOF
   ```
 
-  ClusterRole or ClusterRoleBinding with the cluster-admin role are recommended if your intention is to create clusters across multiple namespaces.
+  - ClusterRole or ClusterRoleBinding with the cluster-admin role are recommended if your intention is to create clusters across multiple namespaces.
+  - Few metrics (CPU, memory) will be unavailable without the above `ClusterRoleBinding`.
 
 ### Delete the Helm installation of YugabyteDB Anywhere
 


### PR DESCRIPTION
### Summary

- Added `securityContext.enabled=false` for YBA installation in OCP docs.
- Recently, we have enabled the security context for all the installations.

Fix: https://yugabyte.atlassian.net/browse/PLAT-8332