### PR TITLE
Issue #16139 - Fix: Add check to detect whether cmake exists

### DIFF
--- a/yb_build.sh
+++ b/yb_build.sh
@@ -462,8 +462,8 @@ run_cxx_build() {
       cmake_binary=/opt/homebrew/bin/cmake
     else
       if ! which cmake &> /dev/null; then
-          echo "Error: cmake not found in PATH" >&2
-          exit 1
+        echo "Error: cmake not found in PATH" >&2
+        exit 1
       fi
       cmake_binary=$( which cmake )
     fi

--- a/yb_build.sh
+++ b/yb_build.sh
@@ -461,6 +461,10 @@ run_cxx_build() {
     if is_mac && [[ "${YB_TARGET_ARCH:-}" == "arm64" ]]; then
       cmake_binary=/opt/homebrew/bin/cmake
     else
+      if ! which cmake &> /dev/null; then
+          echo "Error: cmake not found in PATH" >&2
+          exit 1
+      fi
       cmake_binary=$( which cmake )
     fi
     log "Using cmake binary: $cmake_binary"


### PR DESCRIPTION
Issue https://github.com/yugabyte/yugabyte-db/issues/16139, added check to only execute `which cmake` if cmake exists. Otherwise, print error and exit with Code 1.