### PR TITLE
Relax tablet-splitting restrictions for XCluster

### DIFF
--- a/docs/content/preview/architecture/docdb-replication/async-replication.md
+++ b/docs/content/preview/architecture/docdb-replication/async-replication.md
@@ -128,11 +128,12 @@ A number of interactions across features is supported.
 - Encryption at rest is supported. Note that the universes can technically use different Key Management Service (KMS) configurations. However, for bootstrapping a target universe, the reliance is on the backup and restore flow. As such, a limitation from that is inherited, which requires that the universe being restored has at least access to the same KMS as the one in which the backup was taken. This means both the source and the target must have access to the same KMS configurations.
 - YSQL colocation is supported.
 - YSQL geo-partitioning is supported. Note that you must configure replication on all new partitions manually, as DDL changes are not replicated automatically.
+- Source and Target universes can have different number of tablets.
+- Tablet splitting is supported on both source and target universes.
 
 #### Not currently supported
 
 - Tablegroups are not supported, as per [#11157](https://github.com/yugabyte/yugabyte-db/issues/11157).
-- Tablet splitting is disabled for tables involved in replication, as per [#10175](https://github.com/yugabyte/yugabyte-db/issues/10175).
 - [Savepoints](../../../explore/ysql-language-features/advanced-features/savepoints/) are not supported, as per [#14308](https://github.com/yugabyte/yugabyte-db/issues/14308).
 
 ## Transactional guarantees


### PR DESCRIPTION
Relax the tablet-splitting restriction with XCluster as it is supported for all releases 2.14 and above.