### PR TITLE
[docs] Fix typo/warnings in ycql_grammar.ebnf for `table_properties` & `alter_keyspace`

### DIFF
--- a/docs/content/preview/api/ycql/syntax_resources/ycql_grammar.ebnf
+++ b/docs/content/preview/api/ycql/syntax_resources/ycql_grammar.ebnf
@@ -30,7 +30,7 @@ create_table ::= 'CREATE' 'TABLE' [ 'IF' 'NOT' 'EXISTS' ] table_name '(' table_s
 
 table_schema ::= ( ( column_name column_type ( 'PRIMARY' 'KEY' | 'STATIC' )+ ) | ( 'PRIMARY' 'KEY' '(' '(' column_name {',' column_name } ')' { ','  column_name } ')' ) ) { ','  ( ( column_name column_type ( 'PRIMARY' 'KEY' | 'STATIC' )+ ) | ( 'PRIMARY' 'KEY' '(' '(' column_name {',' column_name } ')' { ','  column_name } ')' ) ) } ;
 
-table_properties ::= 'WITH' ( property_name = property_literal | 'CLUSTERING' 'ORDER' 'BY' '(' ( column_name [ 'ASC' | 'DESC' ] ) { ',' ( column_name [ 'ASC' | 'DESC' ] ) } ')' | 'COMPACT' 'STORAGE' ) { 'AND' ( property_name = property_literal | 'CLUSTERING' 'ORDER' 'BY' '(' ( column_name [ 'ASC' | 'DESC' ] ) { ',' ( column_name [ 'ASC' | 'DESC' ] ) } ')' | 'COMPACT' 'STORAGE' ) } ;
+table_properties ::= 'WITH' ( property_name '=' property_literal | 'CLUSTERING' 'ORDER' 'BY' '(' ( column_name [ 'ASC' | 'DESC' ] ) { ',' ( column_name [ 'ASC' | 'DESC' ] ) } ')' | 'COMPACT' 'STORAGE' ) { 'AND' ( property_name '=' property_literal | 'CLUSTERING' 'ORDER' 'BY' '(' ( column_name [ 'ASC' | 'DESC' ] ) { ',' ( column_name [ 'ASC' | 'DESC' ] ) } ')' | 'COMPACT' 'STORAGE' ) } ;
 
 create_type ::= 'CREATE' 'TYPE' [ 'IF' 'NOT' 'EXISTS' ] type_name
                     '(' (field_name field_type ) { ',' ( field_name field_type ) } ')' ;
@@ -143,6 +143,6 @@ resource ::=   'ALL' ('KEYSPACES' | 'ROLES')
              | [ 'TABLE' ] table_name
              | 'ROLE' role_name ;
 
-alter_keyspace ::= 'ALTER' ('KEYSPACE' | 'SCHEMA') keyspae_name keyspace_properties;
+alter_keyspace ::= 'ALTER' ('KEYSPACE' | 'SCHEMA') keyspace_name keyspace_properties;
 
 explain ::= 'EXPLAIN' (select | update | insert | delete);


### PR DESCRIPTION
Found when making other changes. Fixes the following errors:
```
WARNING: Undefined rules referenced in rule 'table_properties': [=]
WARNING: Undefined rules referenced in rule 'alter_keyspace': [keyspae_name]
```