### PR TITLE
[docs][CDCSDK] Moving GFlag under correct yb-master reference

### DIFF
--- a/docs/content/preview/reference/configuration/yb-master.md
+++ b/docs/content/preview/reference/configuration/yb-master.md
@@ -683,6 +683,12 @@ WAL retention time, in seconds, to be used for tables for which a CDC stream was
 
 Default: `14400` (4 hours)
 
+##### --enable_delete_truncate_cdcsdk_table
+
+By default, TRUNCATE commands on tables on which CDCSDK stream is active will fail. Changing the value of this flag from `false` to `true` will enable truncating the tables part of the CDCSDK stream.
+
+Default: `false`
+
 ## Admin UI
 
 The Admin UI for YB-Master is available at <http://localhost:7000>.

--- a/docs/content/preview/reference/configuration/yb-tserver.md
+++ b/docs/content/preview/reference/configuration/yb-tserver.md
@@ -949,12 +949,6 @@ Stop retaining logs if the space available for the logs falls below this limit, 
 
 Default: `102400`
 
-##### --enable_delete_truncate_cdcsdk_table
-
-By default, TRUNCATE commands on tables on which CDCSDK stream is active will fail. Changing the value of this flag from `false` to `true` will enable truncating the tables part of the CDCSDK stream.
-
-Default: `false`
-
 ##### --cdc_intent_retention_ms
 
 The time period, in milliseconds, after which the intents will be cleaned up if there is no client polling for the change records.


### PR DESCRIPTION
A GFlag `enable_delete_truncate_cdcsdk_table` was incorrectly listed under `yb-tserver` while it is a `yb-master` flag. This PR fixes the listing of the flag's information.