### PR TITLE
Adding table shortcode for multi-line tables

### DIFF
--- a/docs/content/preview/contribute/docs/docs-style.md
+++ b/docs/content/preview/contribute/docs/docs-style.md
@@ -10,6 +10,8 @@ menu:
     parent: docs
     weight: 2950
 type: docs
+rightNav:
+  hideH4: true
 ---
 
 The YugabyteDB documentation style is based on the [Microsoft style guide](https://docs.microsoft.com/en-us/style-guide/welcome/), with some input from [Apple's style guide](https://help.apple.com/applestyleguide/#/). We aim to automate as much as possible through Vale.
@@ -56,7 +58,54 @@ ysqlsh> CREATE TABLE $$__banking__$$;
 
 #### YSQL and YCQL code blocks
 
-Tag YSQL code blocks as `sql`, and YCQL code blocks as `cql`. The source highlighting differs slightly between the two.
+Tag YSQL code blocks as `plpgsql`, and YCQL code blocks as `cql`. The source highlighting differs slightly between the two.
+
+### Tables
+
+Markdown supports [tables](https://www.markdownguide.org/extended-syntax/#tables). By design the table rows have to be in one line. This makes adding bullets and multi-line code blocks impossible in table cells. For this, use the shortcode `table`. For example,
+
+```md
+{{</*table*/>}}
+| col-1 | col-2 |
+| ----- | ----- |
+<!-- row with bullets and code block -->
+|
+- 1
+- 2
+- 3|
+```output
+ k | v
+---+---
+ 1 | 2
+(1 row)
+```|
+<!-- row with tip block -->
+| {{</*warning title="Beware" */>}} start and end rows with the pipe symbol {{</*/warning*/>}} | 
+{{</*tip title="Awesome tip" */>}} Use 3 ticks for code blocks with pipe symbols {{</*/tip*/>}} |
+{{</*/table*/>}}
+```
+
+The above markdown should render as,
+
+{{<table>}}
+| col-1 | col-2 |
+| ----- | ----- |
+<!-- row with bullets and code block -->
+|
+- 1
+- 2
+- 3|
+```output
+ k | v
+---+---
+ 1 | 2
+(1 row)
+```|
+<!-- row with tip block -->
+| {{< warning title="Beware" >}} start and end rows with the pipe symbol {{</warning>}} | 
+{{< tip title="Awesome tip" >}} Use 3 ticks for code blocks with pipe symbols {{</tip>}} |
+{{</table>}}
+
 
 ### Admonitions
 

--- a/docs/content/preview/contribute/docs/docs-style.md
+++ b/docs/content/preview/contribute/docs/docs-style.md
@@ -85,7 +85,7 @@ Markdown supports [tables](https://www.markdownguide.org/extended-syntax/#tables
 {{</*/table*/>}}
 ```
 
-The above markdown should render as,
+The above markdown should render a table as follows:
 
 {{<table>}}
 | col-1 | col-2 |

--- a/docs/content/preview/contribute/docs/docs-style.md
+++ b/docs/content/preview/contribute/docs/docs-style.md
@@ -60,53 +60,6 @@ ysqlsh> CREATE TABLE $$__banking__$$;
 
 Tag YSQL code blocks as `plpgsql`, and YCQL code blocks as `cql`. The source highlighting differs slightly between the two.
 
-### Tables
-
-Markdown supports [tables](https://www.markdownguide.org/extended-syntax/#tables). By design, Markdown table rows are on a single line, and adding bullets and multi-line code blocks in table cells has to be done using HTML on a single line. To make creating custom tables simpler, use the _table_ shortcode. For example:
-
-```md
-{{</*table*/>}}
-| col-1 | col-2 |
-| ----- | ----- |
-<!-- row with bullets and code block -->
-|
-- 1
-- 2
-- 3 |
-```output
- k | v
----+---
- 1 | 2
-(1 row)
-```|
-<!-- row with tip block -->
-| {{</*warning title="Beware" */>}} start and end rows with the pipe symbol {{</*/warning*/>}} | 
-{{</*tip title="Awesome tip" */>}} Use 3 ticks for code blocks with pipe symbols {{</*/tip*/>}} |
-{{</*/table*/>}}
-```
-
-The above markdown should render a table as follows:
-
-{{<table>}}
-| col-1 | col-2 |
-| ----- | ----- |
-<!-- row with bullets and code block -->
-|
-- 1
-- 2
-- 3|
-```output
- k | v
----+---
- 1 | 2
-(1 row)
-```|
-<!-- row with tip block -->
-| {{< warning title="Beware" >}} start and end rows with the pipe symbol {{</warning>}} | 
-{{< tip title="Awesome tip" >}} Use 3 ticks for code blocks with pipe symbols {{</tip>}} |
-{{</table>}}
-
-
 ### Admonitions
 
 Use admonitions sparingly. They lose their effectiveness if they appear too often. Avoid multiple admonitions in a row, and in most cases don't place them immediately after a heading.

--- a/docs/content/preview/contribute/docs/docs-style.md
+++ b/docs/content/preview/contribute/docs/docs-style.md
@@ -72,7 +72,7 @@ Markdown supports [tables](https://www.markdownguide.org/extended-syntax/#tables
 |
 - 1
 - 2
-- 3|
+- 3 |
 ```output
  k | v
 ---+---

--- a/docs/content/preview/contribute/docs/docs-style.md
+++ b/docs/content/preview/contribute/docs/docs-style.md
@@ -62,7 +62,7 @@ Tag YSQL code blocks as `plpgsql`, and YCQL code blocks as `cql`. The source hig
 
 ### Tables
 
-Markdown supports [tables](https://www.markdownguide.org/extended-syntax/#tables). By design the table rows have to be in one line. This makes adding bullets and multi-line code blocks impossible in table cells. For this, use the shortcode `table`. For example,
+Markdown supports [tables](https://www.markdownguide.org/extended-syntax/#tables). By design, Markdown table rows are on a single line, and adding bullets and multi-line code blocks in table cells has to be done using HTML on a single line. To make creating custom tables simpler, use the _table_ shortcode. For example:
 
 ```md
 {{</*table*/>}}

--- a/docs/content/preview/contribute/docs/widgets-and-shortcodes.md
+++ b/docs/content/preview/contribute/docs/widgets-and-shortcodes.md
@@ -79,6 +79,53 @@ This is a warning with a [link](https://www.yugabyte.com).
 {{</* /warning */>}}
 ```
 
+## Tables
+
+Markdown supports [tables](https://www.markdownguide.org/extended-syntax/#tables). By design, Markdown table rows are on a single line, and adding bullets and multi-line code blocks in table cells has to be done using HTML on a single line. To make creating custom tables simpler, use the _table_ shortcode. For example:
+
+```md
+{{</*table*/>}}
+| col-1 | col-2 |
+| ----- | ----- |
+<!-- row with bullets and code block -->
+|
+- 1
+- 2
+- 3 |
+```output
+ k | v
+---+---
+ 1 | 2
+(1 row)
+```|
+<!-- row with tip block -->
+| {{</*warning title="Beware" */>}} start and end rows with the pipe symbol {{</*/warning*/>}} | 
+{{</*tip title="Awesome tip" */>}} Use 3 ticks for code blocks with pipe symbols {{</*/tip*/>}} |
+{{</*/table*/>}}
+```
+
+The above markdown should render a table as follows:
+
+{{<table>}}
+| col-1 | col-2 |
+| ----- | ----- |
+<!-- row with bullets and code block -->
+|
+- 1
+- 2
+- 3 |
+```output
+ k | v
+---+---
+ 1 | 2
+(1 row)
+```|
+<!-- row with tip block -->
+| {{< warning title="Beware" >}} start and end rows with the pipe symbol {{</warning>}} | 
+{{< tip title="Awesome tip" >}} Use 3 ticks for code blocks with pipe symbols {{</tip>}} |
+{{</table>}}
+
+
 ## Inline section switcher
 
 An inline section switcher lets you switch between content sections **without a separate URL**. If you want to link to sub-sections inside a switcher, use tabs. This widget looks as follows:

--- a/docs/layouts/shortcodes/table.html
+++ b/docs/layouts/shortcodes/table.html
@@ -1,0 +1,53 @@
+{{/* trim the data */}}
+{{- $origdata := trim .Inner " \n\t\r" -}}
+{{- $newdata := "" -}}
+{{/* replace | within ``` with ;-vert-;  \x01 is used for matching blocks */}}
+{{- $origdata := replaceRE "```([^`\x01]*)(\\|)([^`]*)```" "```$1;-vert-;$3```\x01" $origdata -}}
+{{- range seq 1000 -}}
+    {{- $newdata := replaceRE "```([^`\x01]*)(\\|)([^`]*)```\x01" "```$1;-vert-;$3```\x01" $origdata -}}
+    {{- if (eq $origdata $newdata) -}} {{- break -}} {{- end -}}
+    {{- $origdata = $newdata -}}
+{{- end -}}
+{{- $origdata := replace $origdata "\x01" "" -}}
+{{/* fetch the header row to calculate no.of columns */}}
+{{- $header := index (findRE `[^|]*\|[^\n]*` $origdata 1) 0 -}}
+{{/* NOTE: numcols is no.of real columns + 1 -- because of split */}}
+{{- $numcols := sub (len (split $header "|")) 1 -}}
+{{/* process only if there are columns in the table */}}
+{{- if ge $numcols 2 -}}
+    {{- $cells := split $origdata "|" -}}
+    {{/* check for proper table structure */}}
+    {{- if ne (mod (sub (len $cells) 1) $numcols) 0 -}}
+        {{- $totalcells := len $cells -}}
+        {{- warnf "incomplete table: cols:%d pipes[total:%d expected:%d] in [%q]"
+                    (sub $numcols 1) (sub $totalcells 1) 
+                    (mul $numcols (div $totalcells $numcols)) $.Page.Permalink -}}
+    {{- end -}}
+    {{- $table := "" -}}
+    {{- $row := "" -}}
+    {{- $startclean := mul 2 $numcols -}}
+    {{- range $index, $cell := $cells -}}
+        {{/* No operations on the header and alignment rows */}}
+        {{- if ge $index $startclean -}}
+            {{/* markdown each cell & convert into single line */}}
+            {{- $cell = replace (markdownify $cell) "\n" "\x01" -}}
+        {{- end -}}
+        {{- if (eq (mod $index $numcols) 0) -}}
+            {{/* first column of the row (empty(or whitespace) because of split) */}}
+            {{- $row = "" -}}
+            {{- continue -}}
+        {{- else if (eq (mod $index $numcols) (sub $numcols 1)) -}}
+            {{/* last column */}}
+            {{- $row = print $row "|" $cell "|" -}}
+            {{- /*print "{" $row "}"*/ -}}
+            {{- $table = print $table "\n" $row -}}
+        {{- else -}}
+            {{/* other columns */}}
+            {{- $row = print $row "|" $cell -}}
+        {{- end -}}
+    {{- end -}}
+    {{- replace (replace (markdownify $table) ";-vert-;" "|") "\x01" "\n" | markdownify  -}}
+    {{- /* warnf "%s" (replace (replace (markdownify $table) ";-vert-;" "|") "\x01" "\n" | markdownify ) */ -}}
+{{- else -}}
+    {{- warnf "empty table in [%q]" $.Page.Permalink -}}
+{{- end -}}


### PR DESCRIPTION
- Use `{{<table>}} ...{{</table>}}`
- Supports multi-line rows
- supports bullets, code blocks
- Needs full table structure specified in markdown
 