### PR TITLE
[docs] Remove note that says range sharded tablets can't be manually split

### DIFF
--- a/docs/content/preview/admin/yb-admin.md
+++ b/docs/content/preview/admin/yb-admin.md
@@ -284,12 +284,6 @@ yb-admin \
 
 Splits the specified hash-sharded tablet and computes the split point as the middle of tablet's sharding range.
 
-{{< note title="Note" >}}
-
-The `yb-admin split_tablet` command is not yet supported for use with range-sharded tablets. To follow plans on this, see [GitHub #5166](https://github.com/yugabyte/yugabyte-db/issues/5166)
-
-{{< /note >}}
-
 ```sh
 split_tablet -master_addresses <master-addresses> <tablet_id_to_split>
 ```

--- a/docs/content/stable/admin/yb-admin.md
+++ b/docs/content/stable/admin/yb-admin.md
@@ -284,12 +284,6 @@ yb-admin \
 
 Splits the specified hash-sharded tablet and computes the split point as the middle of tablet's sharding range.
 
-{{< note title="Note" >}}
-
-The `yb-admin split_tablet` command is not yet supported for use with range-sharded tablets. To follow plans on this, see [GitHub #5166](https://github.com/yugabyte/yugabyte-db/issues/5166)
-
-{{< /note >}}
-
 ```sh
 split_tablet -master_addresses <master-addresses> <tablet_id_to_split>
 ```

--- a/docs/content/v2.12/admin/yb-admin.md
+++ b/docs/content/v2.12/admin/yb-admin.md
@@ -284,12 +284,6 @@ yb-admin \
 
 Splits the specified hash-sharded tablet and computes the split point as the middle of tablet's sharding range.
 
-{{< note title="Note" >}}
-
-The `yb-admin split_tablet` command is not yet supported for use with range-sharded tablets. To follow plans on this, see [GitHub #5166](https://github.com/yugabyte/yugabyte-db/issues/5166)
-
-{{< /note >}}
-
 ```sh
 split_tablet -master_addresses <master-addresses> <tablet_id_to_split>
 ```

--- a/docs/content/v2.14/admin/yb-admin.md
+++ b/docs/content/v2.14/admin/yb-admin.md
@@ -285,12 +285,6 @@ yb-admin \
 
 Splits the specified hash-sharded tablet and computes the split point as the middle of tablet's sharding range.
 
-{{< note title="Note" >}}
-
-The `yb-admin split_tablet` command is not yet supported for use with range-sharded tablets. To follow plans on this, see [GitHub #5166](https://github.com/yugabyte/yugabyte-db/issues/5166)
-
-{{< /note >}}
-
 ```sh
 split_tablet -master_addresses <master-addresses> <tablet_id_to_split>
 ```

--- a/docs/content/v2.16/admin/yb-admin.md
+++ b/docs/content/v2.16/admin/yb-admin.md
@@ -281,12 +281,6 @@ yb-admin \
 
 Splits the specified hash-sharded tablet and computes the split point as the middle of tablet's sharding range.
 
-{{< note title="Note" >}}
-
-The `yb-admin split_tablet` command is not yet supported for use with range-sharded tablets. To follow plans on this, see [GitHub #5166](https://github.com/yugabyte/yugabyte-db/issues/5166)
-
-{{< /note >}}
-
 ```sh
 split_tablet -master_addresses <master-addresses> <tablet_id_to_split>
 ```


### PR DESCRIPTION
Internal thread https://yugabyte.slack.com/archives/C4K1838GL/p1685431092510919

The commit in question: https://github.com/yugabyte/yugabyte-db/commit/f9c8d2ff443c06d41074c7115b85d128779c4597#diff-0ba0805e8f4b95723324d7862ebd1144f917008cee55f0806c43e43fc646d762R2447

Left it in place in 2.8 since the commit above is not in 2.8.