### PR TITLE
[docs] Explain what types can't be used in the columns of a PRIMARY KEY/INDEX in YCQL

### DIFF
--- a/docs/content/preview/api/ycql/ddl_create_index.md
+++ b/docs/content/preview/api/ycql/ddl_create_index.md
@@ -86,6 +86,7 @@ Where
 - `table_name` may be qualified with a keyspace name. 
 - `index_name` cannot be qualified with a keyspace name because an index must be created in the table's keyspace.
 - `property_literal` is a literal of either [boolean](../type_bool), [text](../type_text), or [map](../type_collection) data type.
+- `index_column` can be any data type except `MAP`, `SET`, `LIST`, `JSONB`, `USER_DEFINED_TYPE`.
 
 
 ## Semantics

--- a/docs/content/preview/api/ycql/ddl_create_table.md
+++ b/docs/content/preview/api/ycql/ddl_create_table.md
@@ -78,6 +78,7 @@ Where
 - If primary key is set as a table constraint then:
   - The partition columns are given by the first entry in the primary key list: the nested column list (if given), otherwise the first column.
   - The clustering columns are the rest of the columns in the primary key list (if any).
+- Types `MAP`, `SET`, `LIST`, `JSONB`, `USER_DEFINED_TYPE` cannot be used in the primary key.
 
 #### PARTITION KEY
 


### PR DESCRIPTION
Fixes https://yugabyte.atlassian.net/browse/DOC-42