### PR TITLE
[Doc][DocDB] improve architecture isolation levels page

### DIFF
--- a/docs/content/preview/architecture/transactions/isolation-levels.md
+++ b/docs/content/preview/architecture/transactions/isolation-levels.md
@@ -24,17 +24,19 @@ Transaction isolation level support differs between the YSQL and YCQL APIs:
 - [YSQL](../../../api/ysql/) supports Serializable, Snapshot, and Read Committed<sup>$</sup> isolation levels.
 - [YCQL](../../../api/ycql/dml_transaction/) supports only Snapshot isolation using the `BEGIN TRANSACTION` syntax.
 
-<sup>$</sup> Read Committed support is currently in [Beta](/preview/faq/general/#what-is-the-definition-of-the-beta-feature-tag). This level is supported only if the YB-TServer flag `yb_enable_read_committed_isolation` is set to `true`. By default, this flag is `false`, in which case the Read Committed isolation level of YugabyteDB's transactional layer falls back to the stricter Snapshot isolation (together with YSQL Read Committed and Read Uncommitted also in turn using the Snapshot isolation). The default isolation level for the YSQL API is essentially Snapshot because Read Committed, which is the YSQL API and PostgreSQL syntactic default, maps to Snapshot isolation.
+Similarly to PostgreSQL, you can specify Read Uncommitted for YSQL, but it behaves the same as Read Committed.
+
+<sup>$</sup> Read Committed support is currently in [Beta](/preview/faq/general/#what-is-the-definition-of-the-beta-feature-tag). This level is supported only if the YB-TServer flag `yb_enable_read_committed_isolation` is set to `true`. By default, this flag is `false`, in which case the Read Committed isolation level of YugabyteDB's transactional layer falls back to the stricter Snapshot isolation. The default isolation level for the YSQL API is essentially Snapshot because Read Committed, which is the YSQL API and PostgreSQL syntactic default, maps to Snapshot isolation.
 
 ## Internal locking in DocDB
 
 In order to support the three isolation levels, the lock manager internally supports the following three types of locks:
 
-- Snapshot isolation write lock is taken by a snapshot isolation (and also read committed) transaction on values that it modifies.
-
 - Serializable read lock is taken by serializable transactions on values that they read in order to guarantee they are not modified until the transaction commits.
 
 - Serializable write lock is taken by serializable transactions on values they write.
+
+- Snapshot isolation write lock is taken by a snapshot isolation (and also read committed) transaction on values that it modifies.
 
 The following matrix shows conflicts between these types of locks at a high level:
 
@@ -75,39 +77,42 @@ Although described here as a separate lock type for simplicity, the snapshot iso
 
 ## Locking granularities
 
-Locks can be taken at many levels of granularity.  For example, a serializable read lock could be taken at the level of an entire tablet, a single row, or a single column of a single row.  Such a lock will block attempts to take write locks at that or lower granularities. Thus, for example, a read lock taken at the row level will block attempts to write to that entire row or any sub column of it.
+Locks can be taken at many levels of granularity.  For example, a serializable read lock could be taken at the level of an entire tablet, a single row, or a single column of a single row.  Such a lock will block attempts to take write locks at that or finer granularities. Thus, for example, a read lock taken at the row level will block attempts to write to that entire row or any sub column of it.
 
-In addition to the above-mentioned levels of granularity, locks in DocDB can be taken at prefixes of the primary key, treating the hash columns as a single unit.  For example, if you created a YSQL table via:
+In addition to the above-mentioned levels of granularity, locks in DocDB can be taken at  prefixes of the primary key columns, treating the hash columns as a single unit.  For example, if you created a YSQL table via:
 ```sql
 CREATE TABLE test (h1 INT, h2 INT, r1 INT, r2 INT, v INT w INT PRIMARY KEY ((h1,h2) HASH, r1 ASC, r2 ASC);
 ```
 
-then any of the following could be locked:
+then any of the following objects could be locked:
 - the entire tablet
 - all rows having h1=2, h2=3
 - all rows having h1=2, h2=3, r1=4
 - the row having h1=2, h2=3, r1=4, r2=5
 - column v of the row having h1=2, h2=3, r1=4, r2=5
 
-With YCQL, granularities exist below the column level; for example, only one key of a column map can be locked.
+With YCQL, granularities exist below the column level; for example, only one key of a column of map data type can be locked.
 
 ## Efficiently detecting conflicts between locks of different granularities
 
-The straightforward way to handle locks of different granularities would be to have a map from location to lock types.  However, this is too inefficient for detecting conflicts: attempting, for example, to add a lock at the tablet level would require checking for locks at every row and column in that tablet.
+The straightforward way to handle locks of different granularities would be to have a map from lockable objects to lock types.  However, this is too inefficient for detecting conflicts: attempting, for example, to add a lock at the tablet level would require checking for locks at every row and column in that tablet.
 
-To make conflict detection efficient, YugabyteDB stores extra information at each location about the locks at granularities below it. In particular, it takes a normal lock at the original granularity and weaker versions of that lock at all the granularities that enclose the original granularity.  The normal locks are called _strong_ locks and the weaker variants _weak_ locks.
+To make conflict detection efficient, YugabyteDB stores extra information for each lockable object about any locks on subobjects of it.  In particular, instead of just taking a lock on _X_, it takes a normal lock on _X_ and also weaker versions of that lock on all objects that enclose _X_.  The normal locks are called _strong_ locks and the weaker variants _weak_ locks.
 
-As an example, pretend YugabyteDB has only tablet- and row-level granularities. To take a serializable write lock at the row level, it would take a strong write lock at the row level and a weak write lock at the tablet level.  To take a serializable read lock at the tablet level, YugabyteDB would just take a strong read lock at the tablet level.
+As an example, pretend YugabyteDB has only tablet- and row-level granularities. To take a serializable write lock at the row level (say on row _r_ of tablet _b_), it would take a strong write lock at the row level (on _r_) and a weak write lock at the tablet level (on _b_).  To take a serializable read lock at the tablet level (assume also on _b_), YugabyteDB would just take a strong read lock at the tablet level (on _b_).
 
-Using the following conflict rules, YugabyteDB can decide if two original locks would conflict based only on whether or not their strong/weak locks at any location would conflict:
+Using the following conflict rules, YugabyteDB can decide if two original locks would conflict based only on whether or not their strong/weak locks at any lockable object would conflict:
 
-- two strong locks conflict if and only if they would've conflicted as normal locks
+- two strong locks conflict if and only if they conflict ignoring their strength
+  - e.g., serializable write conflicts with serializable read per the previous matrix
 - two weak locks never conflict
-- a strong lock conflicts with a weak lock if and only if they would've conflicted as normal locks
+- a strong lock conflicts with a weak lock if and only if they conflict ignoring their strength
 
-That is, for each location that would have two locks, would they conflict under the above rules?  There is no need to enumerate the sublocations of any location.
+That is, for each lockable object that would have two locks, would they conflict under the above rules?  There is no need to enumerate the subobjects of any object.
 
-In the example, a conflict would be detected at the tablet level between the strong read lock and the weak write lock. What if the example had instead involved attempting to take the serializable read lock at the row level?  Then there would've been no conflict at the tablet level (both locks there are weak) but there might have been at the row level if the two locks were taken on the same row.
+Consider our example with a serializable write lock at the row level and a serializable read lock at the tablet level.  A conflict is detected at the tablet level because the strong read and the weak write locks on _b_ conflict because ordinary read and write locks conflict.
+
+What about a case involving two row-level snapshot isolation write locks on different rows in the same tablet?  No conflict is detected because the tablet-level locks are weak and the strong row-level locks are on different rows. If they had involved the same row then a conflict would be detected because two strong snapshot isolation write locks conflict.
 
 Including the strong/weak distinction, the full conflict matrix becomes:
 

--- a/docs/content/preview/architecture/transactions/isolation-levels.md
+++ b/docs/content/preview/architecture/transactions/isolation-levels.md
@@ -104,7 +104,7 @@ As an example, pretend YugabyteDB has only tablet- and row-level granularities. 
 Using the following conflict rules, YugabyteDB can decide if two original locks would conflict based only on whether or not their strong/weak locks at any lockable object would conflict:
 
 - two strong locks conflict if and only if they conflict ignoring their strength
-  - e.g., serializable write conflicts with serializable read per the previous matrix
+  - for example, serializable write conflicts with serializable read per the previous matrix
 - two weak locks never conflict
 - a strong lock conflicts with a weak lock if and only if they conflict ignoring their strength
 

--- a/docs/content/preview/architecture/transactions/isolation-levels.md
+++ b/docs/content/preview/architecture/transactions/isolation-levels.md
@@ -30,13 +30,13 @@ Transaction isolation level support differs between the YSQL and YCQL APIs:
 
 In order to support the three isolation levels, the lock manager internally supports the following three types of locks:
 
-- Snapshot isolation write lock is taken by a snapshot (and also read committed) isolation transaction on values that it modifies.
+- Snapshot isolation write lock is taken by a snapshot isolation (and also read committed) transaction on values that it modifies.
 
-- Serializable read lock is taken by serializable read-modify-write transactions on values that they read in order to guarantee they are not modified until the transaction commits.
+- Serializable read lock is taken by serializable transactions on values that they read in order to guarantee they are not modified until the transaction commits.
 
-- Serializable write lock is taken by serializable transactions on values they write, as well as by pure-write snapshot isolation transactions. Multiple snapshot-isolation transactions writing the same item can thus proceed in parallel.
+- Serializable write lock is taken by serializable transactions on values they write.
 
-The following matrix shows conflicts between locks of different types at a high level:
+The following matrix shows conflicts between these types of locks at a high level:
 
 <table>
   <tbody>
@@ -67,11 +67,49 @@ The following matrix shows conflicts between locks of different types at a high 
   </tbody>
 </table>
 
+That is, serializable read locks block writers but allow other simultaneous readers.  Serializable write locks block readers as expected but not other serializable writers.  Finally, snapshot isolation write locks block all other readers and writers.
 
-## Fine-grained locking
+Because serializable write locks do not block other serializable writers, concurrent blind writes are allowed at the serializable isolation level.  A blind write is a write to a location that has not been previously read by that transaction.  Two serializable transactions blindly writing to the same location can proceed in parallel assuming there are no other conflicts; the value of the location afterwards will be the value written by the transaction that committed last.
 
-Further distinction exists between locks acquired on a DocDB node that is being written to by any
-transaction or read by a read-modify-write serializable transaction, and locks acquired on its parent nodes. The former types of locks are referred to as strong locks and the latter as weak locks. For example, if a snapshot isolation transaction is setting column `col1` to a new value in row `row1`, it acquires a weak snapshot isolation write lock on `row1` but a strong snapshot isolation write lock on `row1.col1`. Because of this distinction, the full conflict matrix actually looks more complex, as follows:
+Although described here as a separate lock type for simplicity, the snapshot isolation write lock type is actually implemented internally as a combination of the other two lock types.  That is, taking a single snapshot isolation write lock is equivalent to taking both a serializable read lock and a serializable write lock.
+
+## Locking granularities
+
+Locks can be taken at many levels of granularity.  For example, a serializable read lock could be taken at the level of an entire tablet, a single row, or a single column of a single row.  Such a lock will block attempts to take write locks at that or lower granularities. Thus, for example, a read lock taken at the row level will block attempts to write to that entire row or any sub column of it.
+
+In addition to the above-mentioned levels of granularity, locks in DocDB can be taken at prefixes of the primary key, treating the hash columns as a single unit.  For example, if we have created a YSQL table via:
+```sql
+CREATE TABLE test (h1 INT, h2 INT, r1 INT, r2 INT, v INT w INT PRIMARY KEY ((h1,h2) HASH, r1 ASC, r2 ASC);
+```
+
+then we could lock at any of the following:
+- the entire tablet
+- all rows having h1=2, h2=3
+- all rows having h1=2, h2=3, r1=4
+- the row having h1=2, h2=3, r1=4, r2=5
+- column v of the row having h1=2, h2=3, r1=4, r2=5
+
+With YCQL, granularities exist below the column level; for example only one key of a column map can be locked.
+
+## Efficiently detecting conflicts between locks of different granularities
+
+The straightforward way to handle locks of different granularities would be to have a map from location to lock types.  However, this is too inefficient for detecting conflicts: attempting, for example, to add a lock at the tablet level would require checking for locks at every row and column in that tablet.
+
+To make conflict detection efficient, YugabyteDB stores extra information at each location about the locks at lower granularities below it.  In particular, it takes a normal lock at the original granularity and weaker versions of that lock at all the granularities that enclose the original granularity.  We call the normal locks _strong_ locks and the weaker variants _weak_ locks.
+
+As an example, pretend we have only tablet- and row-level granularities. To take a serializable write lock at the row level, we would take a strong write lock at the row level and a weak write lock at the tablet level.  To take a serializable read lock at the tablet level, we would just take a strong read lock at the tablet level.
+
+By using the following conflict rules, we can decide if two original locks would conflict based only on whether or not their strong/weak locks at any location would conflict:
+
+- two strong locks conflict iff they would've conflicted as normal locks
+- two weak locks never conflict
+- a strong lock conflicts with a weak lock iff they would've conflicted as normal locks
+
+That is, for each location that would have two locks, would they conflict under the above rules?  There is no need to enumerate the sublocations of any location.
+
+In our example, we would detect a conflict at the tablet level between the strong read lock and the weak write lock.  If we had instead tried to take the serializable read lock at the row level then there would've been no conflict at the tablet level (both locks there are weak) but there might have been at the row level if the two locks were taken on the same row.
+
+When we include the strong/weak distinction, the full conflict matrix becomes:
 
 <table>
   <tbody>
@@ -140,9 +178,3 @@ transaction or read by a read-modify-write serializable transaction, and locks a
     </tr>
   </tbody>
 </table>
-
-
-Here are some examples explaining possible concurrency scenarios from the preceding matrix:
-
-- Multiple snapshot isolation transactions could be modifying different columns in the same row concurrently. They acquire weak snapshot isolation locks on the row key, and strong snapshot isolation locks on the individual columns to which they are writing. The weak snapshot isolation locks on the row do not conflict with each other.
-- Multiple write-only transactions can write to the same column, and the strong serializable write locks that they acquire on this column do not conflict. The final value is determined using the hybrid timestamp (the latest hybrid timestamp wins). Note that pure-write snapshot isolation and serializable write operations use the same lock type, because they share the same pattern of conflicts with other lock types.

--- a/docs/content/stable/architecture/transactions/isolation-levels.md
+++ b/docs/content/stable/architecture/transactions/isolation-levels.md
@@ -24,17 +24,19 @@ Transaction isolation level support differs between the YSQL and YCQL APIs:
 - [YSQL](../../../api/ysql/) supports Serializable, Snapshot, and Read Committed<sup>$</sup> isolation levels.
 - [YCQL](../../../api/ycql/dml_transaction/) supports only Snapshot isolation using the `BEGIN TRANSACTION` syntax.
 
-<sup>$</sup> Read Committed support is currently in [Beta](/preview/faq/general/#what-is-the-definition-of-the-beta-feature-tag). This level is supported only if the YB-TServer flag `yb_enable_read_committed_isolation` is set to `true`. By default, this flag is `false`, in which case the Read Committed isolation level of YugabyteDB's transactional layer falls back to the stricter Snapshot isolation (together with YSQL Read Committed and Read Uncommitted also in turn using the Snapshot isolation). The default isolation level for the YSQL API is essentially Snapshot because Read Committed, which is the YSQL API and PostgreSQL syntactic default, maps to Snapshot isolation.
+Similarly to PostgreSQL, you can specify Read Uncommitted for YSQL, but it behaves the same as Read Committed.
+
+<sup>$</sup> Read Committed support is currently in [Beta](/preview/faq/general/#what-is-the-definition-of-the-beta-feature-tag). This level is supported only if the YB-TServer flag `yb_enable_read_committed_isolation` is set to `true`. By default, this flag is `false`, in which case the Read Committed isolation level of YugabyteDB's transactional layer falls back to the stricter Snapshot isolation. The default isolation level for the YSQL API is essentially Snapshot because Read Committed, which is the YSQL API and PostgreSQL syntactic default, maps to Snapshot isolation.
 
 ## Internal locking in DocDB
 
 In order to support the three isolation levels, the lock manager internally supports the following three types of locks:
 
-- Snapshot isolation write lock is taken by a snapshot isolation (and also read committed) transaction on values that it modifies.
-
 - Serializable read lock is taken by serializable transactions on values that they read in order to guarantee they are not modified until the transaction commits.
 
 - Serializable write lock is taken by serializable transactions on values they write.
+
+- Snapshot isolation write lock is taken by a snapshot isolation (and also read committed) transaction on values that it modifies.
 
 The following matrix shows conflicts between these types of locks at a high level:
 
@@ -75,39 +77,42 @@ Although described here as a separate lock type for simplicity, the snapshot iso
 
 ## Locking granularities
 
-Locks can be taken at many levels of granularity.  For example, a serializable read lock could be taken at the level of an entire tablet, a single row, or a single column of a single row.  Such a lock will block attempts to take write locks at that or lower granularities. Thus, for example, a read lock taken at the row level will block attempts to write to that entire row or any sub column of it.
+Locks can be taken at many levels of granularity.  For example, a serializable read lock could be taken at the level of an entire tablet, a single row, or a single column of a single row.  Such a lock will block attempts to take write locks at that or finer granularities. Thus, for example, a read lock taken at the row level will block attempts to write to that entire row or any sub column of it.
 
-In addition to the above-mentioned levels of granularity, locks in DocDB can be taken at prefixes of the primary key, treating the hash columns as a single unit.  For example, if you created a YSQL table via:
+In addition to the above-mentioned levels of granularity, locks in DocDB can be taken at  prefixes of the primary key columns, treating the hash columns as a single unit.  For example, if you created a YSQL table via:
 ```sql
 CREATE TABLE test (h1 INT, h2 INT, r1 INT, r2 INT, v INT w INT PRIMARY KEY ((h1,h2) HASH, r1 ASC, r2 ASC);
 ```
 
-then any of the following could be locked:
+then any of the following objects could be locked:
 - the entire tablet
 - all rows having h1=2, h2=3
 - all rows having h1=2, h2=3, r1=4
 - the row having h1=2, h2=3, r1=4, r2=5
 - column v of the row having h1=2, h2=3, r1=4, r2=5
 
-With YCQL, granularities exist below the column level; for example, only one key of a column map can be locked.
+With YCQL, granularities exist below the column level; for example, only one key of a column of map data type can be locked.
 
 ## Efficiently detecting conflicts between locks of different granularities
 
-The straightforward way to handle locks of different granularities would be to have a map from location to lock types.  However, this is too inefficient for detecting conflicts: attempting, for example, to add a lock at the tablet level would require checking for locks at every row and column in that tablet.
+The straightforward way to handle locks of different granularities would be to have a map from lockable objects to lock types.  However, this is too inefficient for detecting conflicts: attempting, for example, to add a lock at the tablet level would require checking for locks at every row and column in that tablet.
 
-To make conflict detection efficient, YugabyteDB stores extra information at each location about the locks at granularities below it. In particular, it takes a normal lock at the original granularity and weaker versions of that lock at all the granularities that enclose the original granularity.  The normal locks are called _strong_ locks and the weaker variants _weak_ locks.
+To make conflict detection efficient, YugabyteDB stores extra information for each lockable object about any locks on subobjects of it.  In particular, instead of just taking a lock on _X_, it takes a normal lock on _X_ and also weaker versions of that lock on all objects that enclose _X_.  The normal locks are called _strong_ locks and the weaker variants _weak_ locks.
 
-As an example, pretend YugabyteDB has only tablet- and row-level granularities. To take a serializable write lock at the row level, it would take a strong write lock at the row level and a weak write lock at the tablet level.  To take a serializable read lock at the tablet level, YugabyteDB would just take a strong read lock at the tablet level.
+As an example, pretend YugabyteDB has only tablet- and row-level granularities. To take a serializable write lock at the row level (say on row _r_ of tablet _b_), it would take a strong write lock at the row level (on _r_) and a weak write lock at the tablet level (on _b_).  To take a serializable read lock at the tablet level (assume also on _b_), YugabyteDB would just take a strong read lock at the tablet level (on _b_).
 
-Using the following conflict rules, YugabyteDB can decide if two original locks would conflict based only on whether or not their strong/weak locks at any location would conflict:
+Using the following conflict rules, YugabyteDB can decide if two original locks would conflict based only on whether or not their strong/weak locks at any lockable object would conflict:
 
-- two strong locks conflict if and only if they would've conflicted as normal locks
+- two strong locks conflict if and only if they conflict ignoring their strength
+  - e.g., serializable write conflicts with serializable read per the previous matrix
 - two weak locks never conflict
-- a strong lock conflicts with a weak lock if and only if they would've conflicted as normal locks
+- a strong lock conflicts with a weak lock if and only if they conflict ignoring their strength
 
-That is, for each location that would have two locks, would they conflict under the above rules?  There is no need to enumerate the sublocations of any location.
+That is, for each lockable object that would have two locks, would they conflict under the above rules?  There is no need to enumerate the subobjects of any object.
 
-In the example, a conflict would be detected at the tablet level between the strong read lock and the weak write lock. What if the example had instead involved attempting to take the serializable read lock at the row level?  Then there would've been no conflict at the tablet level (both locks there are weak) but there might have been at the row level if the two locks were taken on the same row.
+Consider our example with a serializable write lock at the row level and a serializable read lock at the tablet level.  A conflict is detected at the tablet level because the strong read and the weak write locks on _b_ conflict because ordinary read and write locks conflict.
+
+What about a case involving two row-level snapshot isolation write locks on different rows in the same tablet?  No conflict is detected because the tablet-level locks are weak and the strong row-level locks are on different rows. If they had involved the same row then a conflict would be detected because two strong snapshot isolation write locks conflict.
 
 Including the strong/weak distinction, the full conflict matrix becomes:
 

--- a/docs/content/stable/architecture/transactions/isolation-levels.md
+++ b/docs/content/stable/architecture/transactions/isolation-levels.md
@@ -104,7 +104,7 @@ As an example, pretend YugabyteDB has only tablet- and row-level granularities. 
 Using the following conflict rules, YugabyteDB can decide if two original locks would conflict based only on whether or not their strong/weak locks at any lockable object would conflict:
 
 - two strong locks conflict if and only if they conflict ignoring their strength
-  - e.g., serializable write conflicts with serializable read per the previous matrix
+  - for example, serializable write conflicts with serializable read per the previous matrix
 - two weak locks never conflict
 - a strong lock conflicts with a weak lock if and only if they conflict ignoring their strength
 

--- a/docs/content/stable/architecture/transactions/isolation-levels.md
+++ b/docs/content/stable/architecture/transactions/isolation-levels.md
@@ -30,13 +30,13 @@ Transaction isolation level support differs between the YSQL and YCQL APIs:
 
 In order to support the three isolation levels, the lock manager internally supports the following three types of locks:
 
-- Snapshot isolation write lock is taken by a snapshot (and also read committed) isolation transaction on values that it modifies.
+- Snapshot isolation write lock is taken by a snapshot isolation (and also read committed) transaction on values that it modifies.
 
-- Serializable read lock is taken by serializable read-modify-write transactions on values that they read in order to guarantee they are not modified until the transaction commits.
+- Serializable read lock is taken by serializable transactions on values that they read in order to guarantee they are not modified until the transaction commits.
 
-- Serializable write lock is taken by serializable transactions on values they write, as well as by pure-write snapshot isolation transactions. Multiple snapshot-isolation transactions writing the same item can thus proceed in parallel.
+- Serializable write lock is taken by serializable transactions on values they write.
 
-The following matrix shows conflicts between locks of different types at a high level:
+The following matrix shows conflicts between these types of locks at a high level:
 
 <table>
   <tbody>
@@ -67,11 +67,49 @@ The following matrix shows conflicts between locks of different types at a high 
   </tbody>
 </table>
 
+That is, serializable read locks block writers but allow other simultaneous readers.  Serializable write locks block readers as expected but not other serializable writers.  Finally, snapshot isolation write locks block all other readers and writers.
 
-## Fine-grained locking
+Because serializable write locks do not block other serializable writers, concurrent blind writes are allowed at the serializable isolation level.  A blind write is a write to a location that has not been previously read by that transaction.  Two serializable transactions blindly writing to the same location can proceed in parallel assuming there are no other conflicts; the value of the location afterwards will be the value written by the transaction that committed last.
 
-Further distinction exists between locks acquired on a DocDB node that is being written to by any
-transaction or read by a read-modify-write serializable transaction, and locks acquired on its parent nodes. The former types of locks are referred to as strong locks and the latter as weak locks. For example, if a snapshot isolation transaction is setting column `col1` to a new value in row `row1`, it acquires a weak snapshot isolation write lock on `row1` but a strong snapshot isolation write lock on `row1.col1`. Because of this distinction, the full conflict matrix actually looks more complex, as follows:
+Although described here as a separate lock type for simplicity, the snapshot isolation write lock type is actually implemented internally as a combination of the other two lock types.  That is, taking a single snapshot isolation write lock is equivalent to taking both a serializable read lock and a serializable write lock.
+
+## Locking granularities
+
+Locks can be taken at many levels of granularity.  For example, a serializable read lock could be taken at the level of an entire tablet, a single row, or a single column of a single row.  Such a lock will block attempts to take write locks at that or lower granularities. Thus, for example, a read lock taken at the row level will block attempts to write to that entire row or any sub column of it.
+
+In addition to the above-mentioned levels of granularity, locks in DocDB can be taken at prefixes of the primary key, treating the hash columns as a single unit.  For example, if we have created a YSQL table via:
+```sql
+CREATE TABLE test (h1 INT, h2 INT, r1 INT, r2 INT, v INT w INT PRIMARY KEY ((h1,h2) HASH, r1 ASC, r2 ASC);
+```
+
+then we could lock at any of the following:
+- the entire tablet
+- all rows having h1=2, h2=3
+- all rows having h1=2, h2=3, r1=4
+- the row having h1=2, h2=3, r1=4, r2=5
+- column v of the row having h1=2, h2=3, r1=4, r2=5
+
+With YCQL, granularities exist below the column level; for example only one key of a column map can be locked.
+
+## Efficiently detecting conflicts between locks of different granularities
+
+The straightforward way to handle locks of different granularities would be to have a map from location to lock types.  However, this is too inefficient for detecting conflicts: attempting, for example, to add a lock at the tablet level would require checking for locks at every row and column in that tablet.
+
+To make conflict detection efficient, YugabyteDB stores extra information at each location about the locks at lower granularities below it.  In particular, it takes a normal lock at the original granularity and weaker versions of that lock at all the granularities that enclose the original granularity.  We call the normal locks _strong_ locks and the weaker variants _weak_ locks.
+
+As an example, pretend we have only tablet- and row-level granularities. To take a serializable write lock at the row level, we would take a strong write lock at the row level and a weak write lock at the tablet level.  To take a serializable read lock at the tablet level, we would just take a strong read lock at the tablet level.
+
+By using the following conflict rules, we can decide if two original locks would conflict based only on whether or not their strong/weak locks at any location would conflict:
+
+- two strong locks conflict iff they would've conflicted as normal locks
+- two weak locks never conflict
+- a strong lock conflicts with a weak lock iff they would've conflicted as normal locks
+
+That is, for each location that would have two locks, would they conflict under the above rules?  There is no need to enumerate the sublocations of any location.
+
+In our example, we would detect a conflict at the tablet level between the strong read lock and the weak write lock.  If we had instead tried to take the serializable read lock at the row level then there would've been no conflict at the tablet level (both locks there are weak) but there might have been at the row level if the two locks were taken on the same row.
+
+When we include the strong/weak distinction, the full conflict matrix becomes:
 
 <table>
   <tbody>
@@ -140,9 +178,3 @@ transaction or read by a read-modify-write serializable transaction, and locks a
     </tr>
   </tbody>
 </table>
-
-
-Here are some examples explaining possible concurrency scenarios from the preceding matrix:
-
-- Multiple snapshot isolation transactions could be modifying different columns in the same row concurrently. They acquire weak snapshot isolation locks on the row key, and strong snapshot isolation locks on the individual columns to which they are writing. The weak snapshot isolation locks on the row do not conflict with each other.
-- Multiple write-only transactions can write to the same column, and the strong serializable write locks that they acquire on this column do not conflict. The final value is determined using the hybrid timestamp (the latest hybrid timestamp wins). Note that pure-write snapshot isolation and serializable write operations use the same lock type, because they share the same pattern of conflicts with other lock types.


### PR DESCRIPTION
Changes:
* internal locking in DocDB section:
  * removed references to nonexistent pure-write transactions
  * summarized the conflict table in English
  * explained why write locks don't block other writers and what that means for concurrent blind writes
  * explained that snapshot lock is really a combination of the other two locks

* added section explicitly explaining locking granularities, including which levels we can take lock set

* added an explanation of what strong and weak locks are accomplishing and how they work
* English explanation of the giant conflict table

* removed text talking about how snapshot isolation transactions modifying different columns in the same row can run concurrently
  * Piyush says we are removing this functionality

Same changes to both preview and stable versions:
```
diff preview/architecture/transactions/isolation-levels.md stable/architecture/transactions/isolation-levels.md
7c7
<   preview:
---
>   stable:
```