### PR TITLE
[Docs][DocDB] Statistics-based full compactions documentation

### DIFF
--- a/docs/content/preview/architecture/concepts/yb-tserver.md
+++ b/docs/content/preview/architecture/concepts/yb-tserver.md
@@ -47,6 +47,10 @@ In addition to throttling controls for compactions, YugabyteDB does a variety of
 
 YugabyteDB allows compactions to be externally triggered on a table using the [`compact_table`](../../../admin/yb-admin/#compact-table) command in the [yb-admin utility](../../../admin/yb-admin/). This is useful when new data is no longer coming into the system for a table and you might want to reclaim disk space due to overwrites or deletes that have already happened, or due to TTL expiry.
 
+### Scheduled full compactions (beta)
+
+ YugabyteDB allows full compactions over all data in a tablet to be scheduled automatically using the [`scheduled_full_compaction_frequency_hours`](../../reference/configuration/yb-tserver.md#scheduled_full_compaction_frequency_hours) and [`scheduled_full_compaction_jitter_factor_percentage`](../../reference/configuration/yb-tserver.md#scheduled_full_compaction_jitter_factor_percentage) gflags. This can be useful for performance and disk space reclamation for workloads with a large number of overwrites or deletes on a regular basis. Can be used with tables with TTL as well, but is not compatible with the [TTL file expiration](../../develop/learn/ttl-data-expiration-ycql/#efficient-data-expiration-for-ttl) feature.
+
 ### Server-global memstore limit
 
 Server-global memstore limit tracks and enforces a global size across the memstores for different tablets. This is useful when there is a skew in the write rate across tablets. For example, if there are tablets belonging to multiple tables in a single YB-TServer and one of the tables gets a lot more writes than the other tables, the write-heavy table is allowed to grow much larger than it could if there was a per-tablet memory limit. This allows good write efficiency.

--- a/docs/content/preview/architecture/concepts/yb-tserver.md
+++ b/docs/content/preview/architecture/concepts/yb-tserver.md
@@ -49,19 +49,19 @@ YugabyteDB allows compactions to be externally triggered on a table using the [`
 
 ### Statistics-based full compactions to improve read performance
 
-YugabyteDB tracks the number of key-value pairs that are read at the DocDB level over a sliding period of time (dictated by the [`auto_compact_stat_window_seconds](../../../reference/configuration/yb-tserver#auto_compact_stat_window_seconds) YB-TServer flag). If YugabyteDB detects an overwhelming amount of the DocDB reads in a tablet are skipping over tombstoned and obsolete keys, then a full compaction will be triggered to remove the unnecessary keys.
+YugabyteDB tracks the number of key-value pairs that are read at the DocDB level over a sliding period of time (dictated by the [auto_compact_stat_window_seconds](../../../reference/configuration/yb-tserver#auto-compact-stat-window-seconds) YB-TServer flag). If YugabyteDB detects an overwhelming amount of the DocDB reads in a tablet are skipping over tombstoned and obsolete keys, then a full compaction will be triggered to remove the unnecessary keys.
 
-Once all of the following conditions are met, an full compaction will automatically be triggered on the tablet. Once all of the following conditions are met, a full compaction is automatically triggered on the tablet:
+Once all of the following conditions are met in the sliding window, a full compaction is automatically triggered on the tablet:
 
-- The ratio of obsolete (for example, deleted or removed due to TTL) versus active keys read reaches the threshold [auto_compact_percent_obsolete](../../../reference/configuration/yb-tserver/#auto_compact_percent_obsolete).
+- The ratio of obsolete (for example, deleted or removed due to TTL) versus active keys read reaches the threshold [auto_compact_percent_obsolete](../../../reference/configuration/yb-tserver/#auto-compact-percent-obsolete).
 
-- Enough keys have been read within the window [auto_compact_min_obsolete_keys_found](../../../reference/configuration/yb-tserver/#auto_compact_min_obsolete_keys_found).
+- Enough keys have been read ([auto_compact_min_obsolete_keys_found](../../../reference/configuration/yb-tserver/#auto-compact-min-obsolete-keys-found)).
 
 While this feature is compatible with tables with TTL, YugabyteDB won't schedule compactions on tables with TTL if the [TTL file expiration](../../../develop/learn/ttl-data-expiration-ycql/#efficient-data-expiration-for-ttl) feature is active.
 
 ### Scheduled full compactions
 
- YugabyteDB allows full compactions over all data in a tablet to be scheduled automatically using the [scheduled_full_compaction_frequency_hours](../../../reference/configuration/yb-tserver#scheduled_full_compaction_frequency_hours) and [scheduled_full_compaction_jitter_factor_percentage](../../../reference/configuration/yb-tserver#scheduled_full_compaction_jitter_factor_percentage) YB-TServer flags. This can be useful for performance and disk space reclamation for workloads with a large number of overwrites or deletes on a regular basis. This can be used with tables with TTL as well, but is not compatible with the [TTL file expiration](../../../develop/learn/ttl-data-expiration-ycql/#efficient-data-expiration-for-ttl) feature.
+ YugabyteDB allows full compactions over all data in a tablet to be scheduled automatically using the [scheduled_full_compaction_frequency_hours](../../../reference/configuration/yb-tserver#scheduled-full-compaction-frequency-hours) and [scheduled_full_compaction_jitter_factor_percentage](../../../reference/configuration/yb-tserver#scheduled-full-compaction-jitter-factor-percentage) YB-TServer flags. This can be useful for performance and disk space reclamation for workloads with a large number of overwrites or deletes on a regular basis. This can be used with tables with TTL as well, but is not compatible with the [TTL file expiration](../../../develop/learn/ttl-data-expiration-ycql/#efficient-data-expiration-for-ttl) feature.
 
 ### Server-global memstore limit
 

--- a/docs/content/preview/architecture/concepts/yb-tserver.md
+++ b/docs/content/preview/architecture/concepts/yb-tserver.md
@@ -49,13 +49,19 @@ YugabyteDB allows compactions to be externally triggered on a table using the [`
 
 ### Statistics-based full compactions to improve read performance
 
-YugabyteDB tracks the number of key/value pairs that are read at the DocDB level over a sliding period of time (dectated by the [`auto_compact_stat_window_seconds](../../reference/configuration/yb-tserver.md#auto_compact_stat_window_seconds) gflag). If it is detected that an overwhelming amount of the DocDB reads in a tablet is spent skipping over tombstoned and obsolete keys, then a full compaction will be triggered to remove the unnecessary keys.
+YugabyteDB tracks the number of key-value pairs that are read at the DocDB level over a sliding period of time (dictated by the [`auto_compact_stat_window_seconds](../../../reference/configuration/yb-tserver#auto_compact_stat_window_seconds) YB-TServer flag). If YugabyteDB detects an overwhelming amount of the DocDB reads in a tablet are skipping over tombstoned and obsolete keys, then a full compaction will be triggered to remove the unnecessary keys.
 
-Once all of the following conditions are met, an full compaction will automatically be triggered on the tablet. Those conditions include: the ratio of obsolete (e.g. deleted or removed due to TTL) versus active keys read reaches a threshold [`auto_compact_percent_obsolete`](../../reference/configuration/yb-tserver.md#auto_compact_percent_obsolete), and enough keys have been read within the window(`[auto_compact_min_obsolete_keys_found`](../../reference/configuration/yb-tserver.md#auto_compact_min_obsolete_keys_found)). This feature is compatible with tables with TTL, but will not schedule compactions on tables with TTL if the [TTL file expiration](../../develop/learn/ttl-data-expiration-ycql/#efficient-data-expiration-for-ttl) feature is active.
+Once all of the following conditions are met, an full compaction will automatically be triggered on the tablet. Once all of the following conditions are met, a full compaction is automatically triggered on the tablet:
+
+- The ratio of obsolete (for example, deleted or removed due to TTL) versus active keys read reaches the threshold [auto_compact_percent_obsolete](../../../reference/configuration/yb-tserver/#auto_compact_percent_obsolete).
+
+- Enough keys have been read within the window [auto_compact_min_obsolete_keys_found](../../../reference/configuration/yb-tserver/#auto_compact_min_obsolete_keys_found).
+
+While this feature is compatible with tables with TTL, YugabyteDB won't schedule compactions on tables with TTL if the [TTL file expiration](../../../develop/learn/ttl-data-expiration-ycql/#efficient-data-expiration-for-ttl) feature is active.
 
 ### Scheduled full compactions
 
- YugabyteDB allows full compactions over all data in a tablet to be scheduled automatically using the [`scheduled_full_compaction_frequency_hours`](../../reference/configuration/yb-tserver.md#scheduled_full_compaction_frequency_hours) and [`scheduled_full_compaction_jitter_factor_percentage`](../../reference/configuration/yb-tserver.md#scheduled_full_compaction_jitter_factor_percentage) gflags. This can be useful for performance and disk space reclamation for workloads with a large number of overwrites or deletes on a regular basis. Can be used with tables with TTL as well, but is not compatible with the [TTL file expiration](../../develop/learn/ttl-data-expiration-ycql/#efficient-data-expiration-for-ttl) feature.
+ YugabyteDB allows full compactions over all data in a tablet to be scheduled automatically using the [scheduled_full_compaction_frequency_hours](../../../reference/configuration/yb-tserver#scheduled_full_compaction_frequency_hours) and [scheduled_full_compaction_jitter_factor_percentage](../../../reference/configuration/yb-tserver#scheduled_full_compaction_jitter_factor_percentage) YB-TServer flags. This can be useful for performance and disk space reclamation for workloads with a large number of overwrites or deletes on a regular basis. This can be used with tables with TTL as well, but is not compatible with the [TTL file expiration](../../../develop/learn/ttl-data-expiration-ycql/#efficient-data-expiration-for-ttl) feature.
 
 ### Server-global memstore limit
 

--- a/docs/content/preview/reference/configuration/yb-tserver.md
+++ b/docs/content/preview/reference/configuration/yb-tserver.md
@@ -377,15 +377,39 @@ This value must match on all `yb-master` and `yb-tserver` configurations of a Yu
 
 ##### --post_split_trigger_compaction_pool_max_threads
 
-The maximum number of threads allowed for post-split compactions (that is, compactions that remove irrelevant data from new tablets after splits).
-
-Default: `1`
+Deprecated. Use `full_compaction_pool_max_threads`.
 
 ##### --post_split_trigger_compaction_pool_max_queue_size
 
-The maximum number of post-split compaction tasks that can be queued simultaneously (compactions that remove irrelevant data from new tablets after splits).
+Deprecated. Use `full_compaction_pool_max_queue_size`.
 
-Default: `16`
+##### --full_compaction_pool_max_threads
+
+The maximum number of threads allowed for non-admin full compactions. This includes post-split compactions (compactions that remove irrelevant data from new tablets after splits) and scheduled full compactions.
+
+Default: `1`
+
+##### --full_compaction_pool_max_queue_size
+
+The maximum number of full compaction tasks that can be queued simultaneously. This includes post-split compactions (compactions that remove irrelevant data from new tablets after splits) and scheduled full compactions.
+
+Default: `200`
+
+##### --scheduled_full_compaction_frequency_hours
+
+The frequency with which full compactions should be scheduled on tablets. `0` indicates that the feature is disabled. Recommended value: `720` hours or greater (i.e. 30 days).
+
+Default: `0`
+
+##### --scheduled_full_compaction_jitter_factor_percentage
+
+Percentage of `scheduled_full_compaction_frequency_hours` to be used as jitter when determining full compaction schedule per tablet. Must be a value between `0` and `100`. Jitter is introduced to prevent many tablets from being scheduled for full compactions at the same time.
+
+Jitter will be deterministically computed when scheduling a compaction, between 0 and (frequency * jitter factor) hours. Once computed, the jitter will be subtracted from the intended compaction frequency to determined the tablet's next compaction time.
+
+Example: If `scheduled_full_compaction_frequency_hours` is `720` hours (i.e. 30 days), and `scheduled_full_compaction_jitter_factor_percentage` is `33` percent, each tablet will be scheduled for compaction every `482` hours to `720` hours.
+
+Default: `33`
 
 ##### --automatic_compaction_extra_priority
 

--- a/docs/content/preview/reference/configuration/yb-tserver.md
+++ b/docs/content/preview/reference/configuration/yb-tserver.md
@@ -395,6 +395,40 @@ The maximum number of full compaction tasks that can be queued simultaneously. T
 
 Default: `200`
 
+##### --auto_compact_check_interval_sec
+
+The interval at which the full compaction task will check for tablets eligible for compaction (both for the statistics-based full compaction and scheduled full compaction features). `0` indicates that the statistics-based full compactions feature is disabled.
+
+Default: `60`
+
+##### --auto_compact_stat_window_seconds
+
+Window of time in seconds over which DocDB read statistics are analyzed for the purpose of triggering full compactions to improve read performance. Both `auto_compact_percent_obsolete` and `auto_compact_min_obsolete_keys_found` are evaluated over this period of time.
+
+`auto_compact_stat_window_seconds` must be evaluated as a multiple of `auto_compact_check_interval_sec`, and will be rounded up to meet this constraint. For example, if `auto_compact_stat_window_seconds` is set to `100` and `auto_compact_check_interval_sec` is set to `60`, it will be rounded up to `120` at runtime.
+
+Default: `300`
+
+##### --auto_compact_percent_obsolete
+
+The percentage of obsolete keys (over total keys) read over the `auto_compact_stat_window_seconds` window of time required to trigger an automatic full compaction on a tablet. Only keys that are past their history retention (and thus can be garbage collected) are counted towards this threshold.
+
+For example, if the flag is set to `99` and 100000 keys are read over that window of time, and 99900 of those are obsolete and past their history retention, a full compaction will be triggered (subject to other conditions).
+
+Default: `99`
+
+##### --auto_compact_min_obsolete_keys_found
+
+Minimum number of keys that must be read over the last `auto_compact_stat_window_seconds` to trigger a statistics-based full compaction.
+
+Default: `10000`
+
+##### --auto_compact_min_wait_between_seconds
+
+Minimum wait time between statistics-based and scheduled full compactions. To be used if statistics-based compactions are triggering too frequently.
+
+Default: `0`
+
 ##### --scheduled_full_compaction_frequency_hours
 
 The frequency with which full compactions should be scheduled on tablets. `0` indicates that the feature is disabled. Recommended value: `720` hours or greater (i.e. 30 days).

--- a/docs/content/preview/reference/configuration/yb-tserver.md
+++ b/docs/content/preview/reference/configuration/yb-tserver.md
@@ -431,7 +431,7 @@ Default: `0`
 
 ##### --scheduled_full_compaction_frequency_hours
 
-The frequency with which full compactions should be scheduled on tablets. `0` indicates that the feature is disabled. Recommended value: `720` hours or greater (i.e. 30 days).
+The frequency with which full compactions should be scheduled on tablets. `0` indicates that the feature is disabled. Recommended value: `720` hours or greater (that is, 30 days).
 
 Default: `0`
 
@@ -439,9 +439,9 @@ Default: `0`
 
 Percentage of `scheduled_full_compaction_frequency_hours` to be used as jitter when determining full compaction schedule per tablet. Must be a value between `0` and `100`. Jitter is introduced to prevent many tablets from being scheduled for full compactions at the same time.
 
-Jitter will be deterministically computed when scheduling a compaction, between 0 and (frequency * jitter factor) hours. Once computed, the jitter will be subtracted from the intended compaction frequency to determined the tablet's next compaction time.
+Jitter is deterministically computed when scheduling a compaction, between 0 and (frequency * jitter factor) hours. Once computed, the jitter is subtracted from the intended compaction frequency to determine the tablet's next compaction time.
 
-Example: If `scheduled_full_compaction_frequency_hours` is `720` hours (i.e. 30 days), and `scheduled_full_compaction_jitter_factor_percentage` is `33` percent, each tablet will be scheduled for compaction every `482` hours to `720` hours.
+Example: If `scheduled_full_compaction_frequency_hours` is `720` hours (that is, 30 days), and `scheduled_full_compaction_jitter_factor_percentage` is `33` percent, each tablet will be scheduled for compaction every `482` hours to `720` hours.
 
 Default: `33`
 


### PR DESCRIPTION
Adds statistics-based full compaction documentation to the `preview` section. This includes:

- Addition of a new section (Statistics-based full compactions to improve read performance) to the `yb-tserver` page, near the other compaction documentation.
- Documentation of the following gflags:
-- auto_compact_check_interval_sec
-- auto_compact_stat_window_seconds
-- auto_compact_percent_obsolete
-- auto_compact_min_obsolete_keys_found
-- auto_compact_min_wait_between_seconds

Also adds the Scheduled Full Compactions documentation to the `preview` documentation (it already exists in the `stable` documentation).

Addresses https://github.com/yugabyte/yugabyte-db/issues/15188