### PR TITLE
[Doc][DocDB] Improve documentation for architecture storage model

### DIFF
--- a/docs/content/preview/architecture/docdb/persistence.md
+++ b/docs/content/preview/architecture/docdb/persistence.md
@@ -17,13 +17,15 @@ Once data is replicated using Raft across a majority of the YugabyteDB tablet-pe
 
 ## Storage model
 
-This storage layer is a persistent key-to-object (or to-document) store. The following diagram depicts the storage model:
+This storage layer is a persistent key-to-object (or to-document) store. The following diagram depicts the storage model where not every element is always present:
 
 ![cql_row_encoding](/images/architecture/cql_row_encoding.png)
 
 ### DocDB key
 
-The keys in a DocDB document model are compound keys consisting of one or more hash-organized components followed by zero or more ordered (range) components. These components are stored in their data type-specific sort order, with both ascending and descending sort order supported for each ordered component of the key.
+The keys in a DocDB document model are compound keys consisting of zero or more hash-organized components followed by zero or more ordered (range) components. These components are stored in their data type-specific sort order, with both ascending and descending sort order supported for each ordered component of the key.  If any hash columns are present then they are proceeded by a 16-bit hash of the hash column values.
+
+If [colocation](../../docdb-sharding/colocated-tables/) is being used then the key will be prefixed with the colocation Id of the table it is referring to (not shown in the diagram); this separates data from different tables colocated in the same tablet.
 
 ### DocDB value
 
@@ -50,8 +52,7 @@ DocumentKey1 = {
 }
 ```
 
-Keys stored in RocksDB consist of a number of components, where the first component is a document
-key, followed by several scalar components, and finally followed by a MVCC timestamp (sorted in reverse order). Each component in the DocumentKey, SubKey, and Value, are PrimitiveValues, which are type value pairs that can be encoded to and decoded from strings. When encoding primitive values in keys, a binary-comparable encoding is used for the value, so that sort order of the encoding is the same as the sort order of the value.
+Keys stored in RocksDB consist of a number of components, where the first component is a document key, followed by several scalar components, and finally followed by a MVCC timestamp (sorted in reverse order). Each component in the DocumentKey, SubKey, and Value, are PrimitiveValues, which are type value pairs that can be encoded to and decoded from strings. When encoding primitive values in keys, a binary-comparable encoding is used for the value, so that sort order of the encoding is the same as the sort order of the value.
 
 #### Updates and deletes
 
@@ -75,7 +76,7 @@ For YSQL and YCQL tables, every row is a document in DocDB.
 
 The document key contains the full primary key with column values organized in the following order:
 
-1. A 16-bit hash of the hash column values is stored.
+1. A 16-bit hash of the hash column values is stored if any hash columns are present.
 2. The hash columns are stored.
 3. The clustering (range) columns are stored.
 
@@ -136,7 +137,7 @@ The packed row feature works for the YSQL API using the YSQL-specific GFlags wit
 
 In YCQL, there are two types of TTL: the table TTL, and column-level TTL. Column TTLs are stored with the value using the same encoding as Redis. The table's TTL is not stored in DocDB (instead, it is stored in the master's syscatalog as part of the table's schema). If no TTL is present at the column's value, the table TTL acts as the default value.
 
-Furthermore, YCQL has a distinction between rows created using Insert vs Update. YugabyteDB keeps track of this difference (and column-level TTLs) using a "liveness column", a special system column invisible to the user. It is added for inserts, but not updates, which ensures the row is present even if all non-primary key columns are deleted only in the case of inserts.
+Furthermore, YCQL has a distinction between rows created using Insert vs Update. YugabyteDB keeps track of this difference (and row-level TTLs) using a "liveness column", a special system column invisible to the user. It is added for inserts, but not updates, which ensures the row is present even if all non-primary key columns are deleted only in the case of inserts.
 
 ## Collection type examples for YCQL
 

--- a/docs/content/preview/architecture/docdb/persistence.md
+++ b/docs/content/preview/architecture/docdb/persistence.md
@@ -25,7 +25,7 @@ This storage layer is a persistent key-to-object (or to-document) store. The fol
 
 The keys in a DocDB document model are compound keys consisting of zero or more hash-organized components followed by zero or more ordered (range) components. These components are stored in their data type-specific sort order, with both ascending and descending sort order supported for each ordered component of the key.  If any hash columns are present then they are proceeded by a 16-bit hash of the hash column values.
 
-If [colocation](../../docdb-sharding/colocated-tables/) is being used then the key will be prefixed with the colocation Id of the table it is referring to (not shown in the diagram); this separates data from different tables colocated in the same tablet.
+If [colocation](../../docdb-sharding/colocated-tables/) is being used then the key will be prefixed with the colocation ID of the table it is referring to (not shown in the diagram); this separates data from different tables colocated in the same tablet.
 
 ### DocDB value
 

--- a/docs/content/preview/architecture/docdb/persistence.md
+++ b/docs/content/preview/architecture/docdb/persistence.md
@@ -23,7 +23,7 @@ This storage layer is a persistent key-to-object (or to-document) store. The fol
 
 ### DocDB key
 
-The keys in a DocDB document model are compound keys consisting of zero or more hash-organized components followed by zero or more ordered (range) components. These components are stored in their data type-specific sort order, with both ascending and descending sort order supported for each ordered component of the key.  If any hash columns are present then they are proceeded by a 16-bit hash of the hash column values.
+The keys in a DocDB document model are compound keys consisting of zero or more hash-organized components followed by zero or more ordered (range) components. These components are stored in their data type-specific sort order, with both ascending and descending sort order supported for each ordered component of the key.  If any hash columns are present then they are preceded by a 16-bit hash of the hash column values.
 
 If [colocation](../../docdb-sharding/colocated-tables/) is being used then the key will be prefixed with the colocation ID of the table it is referring to (not shown in the diagram); this separates data from different tables colocated in the same tablet.
 
@@ -52,7 +52,7 @@ DocumentKey1 = {
 }
 ```
 
-Keys stored in RocksDB consist of a number of components, where the first component is a document key, followed by several scalar components, and finally followed by a MVCC timestamp (sorted in reverse order). Each component in the DocumentKey, SubKey, and Value, are PrimitiveValues, which are type value pairs that can be encoded to and decoded from strings. When encoding primitive values in keys, a binary-comparable encoding is used for the value, so that sort order of the encoding is the same as the sort order of the value.
+Keys stored in RocksDB consist of a number of components, where the first component is a document key, followed by several scalar components, and finally followed by a MVCC timestamp (sorted in reverse order). Each component in the DocumentKey, SubKey, and Value, are PrimitiveValues, which are type value pairs that can be encoded to and decoded from byte arrays. When encoding primitive values in keys, a binary-comparable encoding is used for the value, so that sort order of the encoding is the same as the sort order of the value.
 
 #### Updates and deletes
 

--- a/docs/content/stable/architecture/docdb/persistence.md
+++ b/docs/content/stable/architecture/docdb/persistence.md
@@ -21,7 +21,7 @@ This storage layer is a persistent key-to-object (or to-document) store. The fol
 
 ### DocDB key
 
-The keys in a DocDB document model are compound keys consisting of zero or more hash-organized components followed by zero or more ordered (range) components. These components are stored in their data type-specific sort order, with both ascending and descending sort order supported for each ordered component of the key.  If any hash columns are present then they are proceeded by a 16-bit hash of the hash column values.
+The keys in a DocDB document model are compound keys consisting of zero or more hash-organized components followed by zero or more ordered (range) components. These components are stored in their data type-specific sort order, with both ascending and descending sort order supported for each ordered component of the key.  If any hash columns are present then they are preceded by a 16-bit hash of the hash column values.
 
 If [colocation](../../docdb-sharding/colocated-tables/) is being used then the key will be prefixed with the colocation ID of the table it is referring to (not shown in the diagram); this separates data from different tables colocated in the same tablet.
 
@@ -50,7 +50,7 @@ DocumentKey1 = {
 }
 ```
 
-Keys stored in RocksDB consist of a number of components, where the first component is a document key, followed by several scalar components, and finally followed by a MVCC timestamp (sorted in reverse order). Each component in the DocumentKey, SubKey, and Value, are PrimitiveValues, which are type value pairs that can be encoded to and decoded from strings. When encoding primitive values in keys, a binary-comparable encoding is used for the value, so that sort order of the encoding is the same as the sort order of the value.
+Keys stored in RocksDB consist of a number of components, where the first component is a document key, followed by several scalar components, and finally followed by a MVCC timestamp (sorted in reverse order). Each component in the DocumentKey, SubKey, and Value, are PrimitiveValues, which are type value pairs that can be encoded to and decoded from byte arrays. When encoding primitive values in keys, a binary-comparable encoding is used for the value, so that sort order of the encoding is the same as the sort order of the value.
 
 #### Updates and deletes
 

--- a/docs/content/stable/architecture/docdb/persistence.md
+++ b/docs/content/stable/architecture/docdb/persistence.md
@@ -23,7 +23,7 @@ This storage layer is a persistent key-to-object (or to-document) store. The fol
 
 The keys in a DocDB document model are compound keys consisting of zero or more hash-organized components followed by zero or more ordered (range) components. These components are stored in their data type-specific sort order, with both ascending and descending sort order supported for each ordered component of the key.  If any hash columns are present then they are proceeded by a 16-bit hash of the hash column values.
 
-If [colocation](../../docdb-sharding/colocated-tables/) is being used then the key will be prefixed with the colocation Id of the table it is referring to (not shown in the diagram); this separates data from different tables colocated in the same tablet.
+If [colocation](../../docdb-sharding/colocated-tables/) is being used then the key will be prefixed with the colocation ID of the table it is referring to (not shown in the diagram); this separates data from different tables colocated in the same tablet.
 
 ### DocDB value
 

--- a/docs/content/stable/architecture/docdb/persistence.md
+++ b/docs/content/stable/architecture/docdb/persistence.md
@@ -15,13 +15,15 @@ Once data is replicated using Raft across a majority of the YugabyteDB tablet-pe
 
 ## Storage model
 
-This storage layer is a persistent key-to-object (or to-document) store. The following diagram depicts the storage model:
+This storage layer is a persistent key-to-object (or to-document) store. The following diagram depicts the storage model where not every element is always present:
 
 ![cql_row_encoding](/images/architecture/cql_row_encoding.png)
 
 ### DocDB key
 
-The keys in a DocDB document model are compound keys consisting of one or more hash-organized components followed by zero or more ordered (range) components. These components are stored in their data type-specific sort order, with both ascending and descending sort order supported for each ordered component of the key.
+The keys in a DocDB document model are compound keys consisting of zero or more hash-organized components followed by zero or more ordered (range) components. These components are stored in their data type-specific sort order, with both ascending and descending sort order supported for each ordered component of the key.  If any hash columns are present then they are proceeded by a 16-bit hash of the hash column values.
+
+If [colocation](../../docdb-sharding/colocated-tables/) is being used then the key will be prefixed with the colocation Id of the table it is referring to (not shown in the diagram); this separates data from different tables colocated in the same tablet.
 
 ### DocDB value
 
@@ -48,8 +50,7 @@ DocumentKey1 = {
 }
 ```
 
-Keys stored in RocksDB consist of a number of components, where the first component is a document
-key, followed by several scalar components, and finally followed by a MVCC timestamp (sorted in reverse order). Each component in the DocumentKey, SubKey, and Value, are PrimitiveValues, which are type value pairs that can be encoded to and decoded from strings. When encoding primitive values in keys, a binary-comparable encoding is used for the value, so that sort order of the encoding is the same as the sort order of the value.
+Keys stored in RocksDB consist of a number of components, where the first component is a document key, followed by several scalar components, and finally followed by a MVCC timestamp (sorted in reverse order). Each component in the DocumentKey, SubKey, and Value, are PrimitiveValues, which are type value pairs that can be encoded to and decoded from strings. When encoding primitive values in keys, a binary-comparable encoding is used for the value, so that sort order of the encoding is the same as the sort order of the value.
 
 #### Updates and deletes
 
@@ -73,7 +74,7 @@ For YSQL and YCQL tables, every row is a document in DocDB.
 
 The document key contains the full primary key with column values organized in the following order:
 
-1. A 16-bit hash of the hash column values is stored.
+1. A 16-bit hash of the hash column values is stored if any hash columns are present.
 2. The hash columns are stored.
 3. The clustering (range) columns are stored.
 
@@ -134,7 +135,7 @@ The packed row feature works for the YSQL API using the YSQL-specific GFlags wit
 
 In YCQL, there are two types of TTL: the table TTL, and column-level TTL. Column TTLs are stored with the value using the same encoding as Redis. The table's TTL is not stored in DocDB (instead, it is stored in the master's syscatalog as part of the table's schema). If no TTL is present at the column's value, the table TTL acts as the default value.
 
-Furthermore, YCQL has a distinction between rows created using Insert vs Update. YugabyteDB keeps track of this difference (and column-level TTLs) using a "liveness column", a special system column invisible to the user. It is added for inserts, but not updates, which ensures the row is present even if all non-primary key columns are deleted only in the case of inserts.
+Furthermore, YCQL has a distinction between rows created using Insert vs Update. YugabyteDB keeps track of this difference (and row-level TTLs) using a "liveness column", a special system column invisible to the user. It is added for inserts, but not updates, which ensures the row is present even if all non-primary key columns are deleted only in the case of inserts.
 
 ## Collection type examples for YCQL
 


### PR DESCRIPTION
Changes:
  * clarify that there can be zero hash columns
  * clarify that the 16-bit hash is only present if there are one or more hash columns
  * mention the colocation ID
  * fix the discussion of the liveliness column to indicate that it has a row-level TTL not a per-column level TTL.