### PR TITLE
[Doc][DocDB] Fix unavailability window in documentation

### DIFF
--- a/docs/content/preview/architecture/core-functions/high-availability.md
+++ b/docs/content/preview/architecture/core-functions/high-availability.md
@@ -23,7 +23,7 @@ Failures of each of the YQL layer, tablet peer followers, and tablet peer leader
 
 ### YQL failure
 
-From the application’s perspective, YQL is stateless. Hence the client that issued the request simply sends the request to YQL on a different node. In the case of smart clients, they search for the ideal YB-TServer location based on the tablet owning the keys, and then send the request directly to that node.
+From the application's perspective, YQL is stateless. Hence the client that issued the request simply sends the request to YQL on a different node. In the case of smart clients, they search for the ideal YB-TServer location based on the tablet owning the keys, and then send the request directly to that node.
 
 ### Tablet peer follower failure
 

--- a/docs/content/preview/architecture/core-functions/high-availability.md
+++ b/docs/content/preview/architecture/core-functions/high-availability.md
@@ -31,7 +31,7 @@ The tablet peer followers are not in the critical path. Their failure does not i
 
 ### Tablet peer leader failure
 
-The failure of any tablet peer leader automatically triggers a new Raft-level leader election within seconds, and another tablet peer on a different YB-TServer takes its place as the new leader. The unavailability window is approximately 2 seconds (assuming the default heartbeat interval of 500 ms) in the event of a failure of the tablet peer leader.
+The failure of any tablet peer leader automatically triggers a new Raft-level leader election within seconds, and another tablet peer on a different YB-TServer takes its place as the new leader. The unavailability window is approximately 3 seconds (assuming the default heartbeat interval of 500 ms) in the event of a failure of the tablet peer leader.
 
 ## YB-Master failure
 

--- a/docs/content/stable/architecture/core-functions/high-availability.md
+++ b/docs/content/stable/architecture/core-functions/high-availability.md
@@ -23,7 +23,7 @@ Failures of each of the YQL layer, tablet peer followers, and tablet peer leader
 
 ### YQL failure
 
-From the application’s perspective, YQL is stateless. Hence the client that issued the request simply sends the request to YQL on a different node. In the case of smart clients, they search for the ideal YB-TServer location based on the tablet owning the keys, and then send the request directly to that node.
+From the application's perspective, YQL is stateless. Hence the client that issued the request simply sends the request to YQL on a different node. In the case of smart clients, they search for the ideal YB-TServer location based on the tablet owning the keys, and then send the request directly to that node.
 
 ### Tablet peer follower failure
 

--- a/docs/content/stable/architecture/core-functions/high-availability.md
+++ b/docs/content/stable/architecture/core-functions/high-availability.md
@@ -31,7 +31,7 @@ The tablet peer followers are not in the critical path. Their failure does not i
 
 ### Tablet peer leader failure
 
-The failure of any tablet peer leader automatically triggers a new Raft-level leader election within seconds, and another tablet peer on a different YB-TServer takes its place as the new leader. The unavailability window is approximately 2 seconds (assuming the default heartbeat interval of 500 ms) in the event of a failure of the tablet peer leader.
+The failure of any tablet peer leader automatically triggers a new Raft-level leader election within seconds, and another tablet peer on a different YB-TServer takes its place as the new leader. The unavailability window is approximately 3 seconds (assuming the default heartbeat interval of 500 ms) in the event of a failure of the tablet peer leader.
 
 ## YB-Master failure
 

--- a/docs/content/v2.12/architecture/core-functions/high-availability.md
+++ b/docs/content/v2.12/architecture/core-functions/high-availability.md
@@ -11,28 +11,28 @@ menu:
 type: docs
 ---
 
-As discussed before, YugabyteDB is a CP database (consistent and partition tolerant), but achieves very high availability (HA). It achieves this HA by having an active replica that is ready to take over as a new leader in a matter of seconds after the failure of the current leader and serve requests.
+YugabyteDB is a consistent and partition-tolerant database that at the same time achieves very high availability (HA) by having an active replica which is ready to take over as a new leader immediately after a failure of the current leader and serve requests.
 
-If a node fails, it causes the outage of the servers running on it. These would be a YB-TServer and the YB-Master (if one was running on that node). Let us look at what happens in each of these cases.
+If a node fails, it causes the outage of the servers running on it. These would be a YB-TServer and the YB-Master (if one was running on that node).
 
 ## YB-TServer failure
 
-A YB-TServer hosts the YQL layer and a bunch of tablets. Some of these tablets are tablet-peer leaders that actively serve IOs, and other tablets are tablet-peer followers that replicate data and are active standbys to their corresponding leaders.
+A YB-TServer hosts the YQL layer and tablets, some of which are tablet peer leaders that actively serve I/O, whereas other tablets are tablet peer followers that replicate data and are active standbys to their corresponding leaders.
 
-Let us look at how the failures of each of the YQL layer, tablet-peer followers and tablet-peer leaders are handled.
+Failures of each of the YQL layer, tablet peer followers, and tablet peer leaders are handled in specific ways.
 
 ### YQL failure
 
-Recall that from the application’s perspective, YQL is stateless. Hence the client that issued the request just sends the request to YQL on a different node. In the case of smart-clients, they lookup the ideal YB-TServer location based on the tablet owning the keys, and send the request directly to that node.
+From the application's perspective, YQL is stateless. Hence the client that issued the request simply sends the request to YQL on a different node. In the case of smart clients, they search for the ideal YB-TServer location based on the tablet owning the keys, and then send the request directly to that node.
 
-### Tablet-peer follower failure
+### Tablet peer follower failure
 
-The tablet-peer followers are not in the critical path. Their failure does not impact availability of the user requests.
+The tablet peer followers are not in the critical path. Their failure does not impact availability of the user requests.
 
-### Tablet-peer leader failure
+### Tablet peer leader failure
 
-The failure of any tablet-peer leader automatically triggers a new RAFT level leader election within seconds, and another tablet-peer on a different YB-TServer takes its place as the new leader. The unavailability window is in the order of a couple of seconds (assuming the default heartbeat interval of 500 ms) in the event of a failure of the tablet-peer leader.
+The failure of any tablet peer leader automatically triggers a new Raft-level leader election within seconds, and another tablet peer on a different YB-TServer takes its place as the new leader. The unavailability window is approximately 3 seconds (assuming the default heartbeat interval of 500 ms) in the event of a failure of the tablet peer leader.
 
 ## YB-Master failure
 
-The YB-Master is not in the critical path of normal IO operations, so its failure will not affect a functioning universe. Nevertheless, the YB-Master is a part of a Raft group with the peers running on different nodes. One of these peers is the active master and the others are active stand-bys. If the active master (the YB-Master leader) fails, these peers detect the leader failure and re-elect a new YB-Master leader which now becomes the active master within seconds of the failure.
+The YB-Master is not in the critical path of normal I/O operations, therefore its failure does not affect a functioning universe. Nevertheless, the YB-Master is a part of a Raft group with the peers running on different nodes. One of these peers is the active master and the others are active standbys. If the active master (the YB-Master leader) fails, these peers detect the leader failure and re-elect a new YB-Master leader which becomes the active master within seconds of the failure.

--- a/docs/content/v2.14/architecture/core-functions/high-availability.md
+++ b/docs/content/v2.14/architecture/core-functions/high-availability.md
@@ -11,19 +11,19 @@ menu:
 type: docs
 ---
 
-As discussed before, YugabyteDB is a CP database (consistent and partition tolerant), but achieves very high availability (HA). It achieves this HA by having an active replica that is ready to take over as a new leader in a matter of seconds after the failure of the current leader and serve requests.
+YugabyteDB is a consistent and partition-tolerant database that at the same time achieves very high availability (HA) by having an active replica which is ready to take over as a new leader immediately after a failure of the current leader and serve requests.
 
-If a node fails, it causes the outage of the servers running on it. These would be a YB-TServer and the YB-Master (if one was running on that node). Let us look at what happens in each of these cases.
+If a node fails, it causes the outage of the servers running on it. These would be a YB-TServer and the YB-Master (if one was running on that node).
 
 ## YB-TServer failure
 
-A YB-TServer hosts the YQL layer and a bunch of tablets. Some of these tablets are tablet-peer leaders that actively serve IOs, and other tablets are tablet-peer followers that replicate data and are active standbys to their corresponding leaders.
+A YB-TServer hosts the YQL layer and tablets, some of which are tablet peer leaders that actively serve I/O, whereas other tablets are tablet peer followers that replicate data and are active standbys to their corresponding leaders.
 
-Let us look at how the failures of each of the YQL layer, tablet-peer followers and tablet-peer leaders are handled.
+Failures of each of the YQL layer, tablet peer followers, and tablet peer leaders are handled in specific ways.
 
 ### YQL failure
 
-Recall that from the application’s perspective, YQL is stateless. Hence the client that issued the request just sends the request to YQL on a different node. In the case of smart-clients, they lookup the ideal YB-TServer location based on the tablet owning the keys, and send the request directly to that node.
+From the application's perspective, YQL is stateless. Hence the client that issued the request simply sends the request to YQL on a different node. In the case of smart clients, they search for the ideal YB-TServer location based on the tablet owning the keys, and then send the request directly to that node.
 
 ### Tablet-peer follower failure
 
@@ -31,8 +31,8 @@ The tablet-peer followers are not in the critical path. Their failure does not i
 
 ### Tablet-peer leader failure
 
-The failure of any tablet-peer leader automatically triggers a new RAFT level leader election within seconds, and another tablet-peer on a different YB-TServer takes its place as the new leader. The unavailability window is in the order of a couple of seconds (assuming the default heartbeat interval of 500 ms) in the event of a failure of the tablet-peer leader.
+The failure of any tablet peer leader automatically triggers a new Raft-level leader election within seconds, and another tablet peer on a different YB-TServer takes its place as the new leader. The unavailability window is approximately 3 seconds (assuming the default heartbeat interval of 500 ms) in the event of a failure of the tablet peer leader.
 
 ## YB-Master failure
 
-The YB-Master is not in the critical path of normal IO operations, so its failure will not affect a functioning universe. Nevertheless, the YB-Master is a part of a Raft group with the peers running on different nodes. One of these peers is the active master and the others are active stand-bys. If the active master (the YB-Master leader) fails, these peers detect the leader failure and re-elect a new YB-Master leader which now becomes the active master within seconds of the failure.
+The YB-Master is not in the critical path of normal I/O operations, therefore its failure does not affect a functioning universe. Nevertheless, the YB-Master is a part of a Raft group with the peers running on different nodes. One of these peers is the active master and the others are active standbys. If the active master (the YB-Master leader) fails, these peers detect the leader failure and re-elect a new YB-Master leader which becomes the active master within seconds of the failure.

--- a/docs/content/v2.16/architecture/core-functions/high-availability.md
+++ b/docs/content/v2.16/architecture/core-functions/high-availability.md
@@ -11,28 +11,28 @@ menu:
 type: docs
 ---
 
-As discussed before, YugabyteDB is a CP database (consistent and partition tolerant), but achieves very high availability (HA). It achieves this HA by having an active replica that is ready to take over as a new leader in a matter of seconds after the failure of the current leader and serve requests.
+YugabyteDB is a consistent and partition-tolerant database that at the same time achieves very high availability (HA) by having an active replica which is ready to take over as a new leader immediately after a failure of the current leader and serve requests.
 
-If a node fails, it causes the outage of the servers running on it. These would be a YB-TServer and the YB-Master (if one was running on that node). Let us look at what happens in each of these cases.
+If a node fails, it causes the outage of the servers running on it. These would be a YB-TServer and the YB-Master (if one was running on that node).
 
 ## YB-TServer failure
 
-A YB-TServer hosts the YQL layer and a bunch of tablets. Some of these tablets are tablet-peer leaders that actively serve IOs, and other tablets are tablet-peer followers that replicate data and are active standbys to their corresponding leaders.
+A YB-TServer hosts the YQL layer and tablets, some of which are tablet peer leaders that actively serve I/O, whereas other tablets are tablet peer followers that replicate data and are active standbys to their corresponding leaders.
 
-Let us look at how the failures of each of the YQL layer, tablet-peer followers and tablet-peer leaders are handled.
+Failures of each of the YQL layer, tablet peer followers, and tablet peer leaders are handled in specific ways.
 
 ### YQL failure
 
-Recall that from the application’s perspective, YQL is stateless. Hence the client that issued the request just sends the request to YQL on a different node. In the case of smart-clients, they lookup the ideal YB-TServer location based on the tablet owning the keys, and send the request directly to that node.
+From the application's perspective, YQL is stateless. Hence the client that issued the request simply sends the request to YQL on a different node. In the case of smart clients, they search for the ideal YB-TServer location based on the tablet owning the keys, and then send the request directly to that node.
 
 ### Tablet-peer follower failure
 
-The tablet-peer followers are not in the critical path. Their failure does not impact availability of the user requests.
+The tablet peer followers are not in the critical path. Their failure does not impact availability of the user requests.
 
 ### Tablet-peer leader failure
 
-The failure of any tablet-peer leader automatically triggers a new RAFT level leader election within seconds, and another tablet-peer on a different YB-TServer takes its place as the new leader. The unavailability window is in the order of a couple of seconds (assuming the default heartbeat interval of 500 ms) in the event of a failure of the tablet-peer leader.
+The failure of any tablet peer leader automatically triggers a new Raft-level leader election within seconds, and another tablet peer on a different YB-TServer takes its place as the new leader. The unavailability window is approximately 3 seconds (assuming the default heartbeat interval of 500 ms) in the event of a failure of the tablet peer leader.
 
 ## YB-Master failure
 
-The YB-Master is not in the critical path of normal IO operations, so its failure will not affect a functioning universe. Nevertheless, the YB-Master is a part of a Raft group with the peers running on different nodes. One of these peers is the active master and the others are active stand-bys. If the active master (the YB-Master leader) fails, these peers detect the leader failure and re-elect a new YB-Master leader which now becomes the active master within seconds of the failure.
+The YB-Master is not in the critical path of normal I/O operations, therefore its failure does not affect a functioning universe. Nevertheless, the YB-Master is a part of a Raft group with the peers running on different nodes. One of these peers is the active master and the others are active standbys. If the active master (the YB-Master leader) fails, these peers detect the leader failure and re-elect a new YB-Master leader which becomes the active master within seconds of the failure.

--- a/docs/content/v2.8/architecture/core-functions/high-availability.md
+++ b/docs/content/v2.8/architecture/core-functions/high-availability.md
@@ -11,28 +11,28 @@ menu:
 type: docs
 ---
 
-As discussed before, YugabyteDB is a CP database (consistent and partition tolerant), but achieves very high availability (HA). It achieves this HA by having an active replica that is ready to take over as a new leader in a matter of seconds after the failure of the current leader and serve requests.
+YugabyteDB is a consistent and partition-tolerant database that at the same time achieves very high availability (HA) by having an active replica which is ready to take over as a new leader immediately after a failure of the current leader and serve requests.
 
-If a node fails, it causes the outage of the servers running on it. These would be a YB-TServer and the YB-Master (if one was running on that node). Let us look at what happens in each of these cases.
+If a node fails, it causes the outage of the servers running on it. These would be a YB-TServer and the YB-Master (if one was running on that node).
 
 ## YB-TServer failure
 
-A YB-TServer hosts the YQL layer and a bunch of tablets. Some of these tablets are tablet-peer leaders that actively serve IOs, and other tablets are tablet-peer followers that replicate data and are active standbys to their corresponding leaders.
+A YB-TServer hosts the YQL layer and tablets, some of which are tablet peer leaders that actively serve I/O, whereas other tablets are tablet peer followers that replicate data and are active standbys to their corresponding leaders.
 
-Let us look at how the failures of each of the YQL layer, tablet-peer followers and tablet-peer leaders are handled.
+Failures of each of the YQL layer, tablet peer followers, and tablet peer leaders are handled in specific ways.
 
 ### YQL failure
 
-Recall that from the application’s perspective, YQL is stateless. Hence the client that issued the request just sends the request to YQL on a different node. In the case of smart-clients, they lookup the ideal YB-TServer location based on the tablet owning the keys, and send the request directly to that node.
+From the application's perspective, YQL is stateless. Hence the client that issued the request simply sends the request to YQL on a different node. In the case of smart clients, they search for the ideal YB-TServer location based on the tablet owning the keys, and then send the request directly to that node.
 
-### Tablet-peer follower failure
+### Tablet peer follower failure
 
-The tablet-peer followers are not in the critical path. Their failure does not impact availability of the user requests.
+The tablet peer followers are not in the critical path. Their failure does not impact availability of the user requests.
 
-### Tablet-peer leader failure
+### Tablet peer leader failure
 
-The failure of any tablet-peer leader automatically triggers a new RAFT level leader election within seconds, and another tablet-peer on a different YB-TServer takes its place as the new leader. The unavailability window is in the order of a couple of seconds (assuming the default heartbeat interval of 500 ms) in the event of a failure of the tablet-peer leader.
+The failure of any tablet peer leader automatically triggers a new Raft-level leader election within seconds, and another tablet peer on a different YB-TServer takes its place as the new leader. The unavailability window is approximately 3 seconds (assuming the default heartbeat interval of 500 ms) in the event of a failure of the tablet peer leader.
 
 ## YB-Master failure
 
-The YB-Master is not in the critical path of normal IO operations, so its failure will not affect a functioning universe. Nevertheless, the YB-Master is a part of a Raft group with the peers running on different nodes. One of these peers is the active master and the others are active stand-bys. If the active master (the YB-Master leader) fails, these peers detect the leader failure and re-elect a new YB-Master leader which now becomes the active master within seconds of the failure.
+The YB-Master is not in the critical path of normal I/O operations, therefore its failure does not affect a functioning universe. Nevertheless, the YB-Master is a part of a Raft group with the peers running on different nodes. One of these peers is the active master and the others are active standbys. If the active master (the YB-Master leader) fails, these peers detect the leader failure and re-elect a new YB-Master leader which becomes the active master within seconds of the failure.


### PR DESCRIPTION
Documentation currently says two seconds, which is wrong.  It should say three seconds.

Fixing both preview and stable.