### PR TITLE
[docs] Fix 2.19 links

### DIFF
--- a/docs/content/preview/releases/release-notes/v2.19.md
+++ b/docs/content/preview/releases/release-notes/v2.19.md
@@ -27,25 +27,25 @@ For an RSS feed of all release series, point your feed reader to the [RSS feed f
 
 ## v2.19.0.0 - June 20, 2023 {#v2.19.0.0}
 
-**Build:** `v2.19.0.0-b190`
+**Build:** `2.19.0.0-b190`
 
 ### Downloads
 
 <ul class="nav yb-pills">
   <li>
-    <a href="https://downloads.yugabyte.com/releases/2.19.0.0/yugabyte-v2.19.0.0-b190-darwin-x86_64.tar.gz">
+    <a href="https://downloads.yugabyte.com/releases/2.19.0.0/yugabyte-2.19.0.0-b190-darwin-x86_64.tar.gz">
       <i class="fa-brands fa-apple"></i>
       <span>macOS</span>
     </a>
   </li>
   <li>
-    <a href="https://downloads.yugabyte.com/releases/v2.19.0.0/yugabyte-v2.19.0.0-b190-linux-x86_64.tar.gz">
+    <a href="https://downloads.yugabyte.com/releases/2.19.0.0/yugabyte-2.19.0.0-b190-linux-x86_64.tar.gz">
       <i class="fa-brands fa-linux"></i>
       <span>Linux x86</span>
     </a>
   </li>
   <li>
-    <a href="https://downloads.yugabyte.com/releases/v2.19.0.0/yugabyte-v2.19.0.0-b190-el8-aarch64.tar.gz">
+    <a href="https://downloads.yugabyte.com/releases/2.19.0.0/yugabyte-2.19.0.0-b190-el8-aarch64.tar.gz">
       <i class="fa-brands fa-linux"></i>
       <span>Linux ARM</span>
     </a>
@@ -55,7 +55,7 @@ For an RSS feed of all release series, point your feed reader to the [RSS feed f
 ### Docker
 
 ```sh
-docker pull yugabytedb/yugabyte:v2.19.0.0-b190
+docker pull yugabytedb/yugabyte:2.19.0.0-b190
 ```
 
 ### New Features


### PR DESCRIPTION
Fix links on 2.19 RN page

@netlify /preview/releases/release-notes/v2.19/