### PR TITLE
[doc][yba][PLAT-9283] Add SELinux step for on-prem

### DIFF
--- a/docs/content/preview/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises.md
+++ b/docs/content/preview/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises.md
@@ -289,12 +289,12 @@ Physical nodes (or cloud instances) are installed with a standard CentOS 7 serve
 1. Add a new `yugabyte:yugabyte` user and group with the default login shell `/bin/bash` that you set via the `-s` flag, as follows:
 
     ```bash
-    sudo useradd -s /bin/bash --create-home --home-dir <yugabyte-home> yugabyte  # (add user yugabyte and create /home/yugabyte)
+    sudo useradd -s /bin/bash --create-home --home-dir <yugabyte-home> yugabyte  # (add user yugabyte and create its home directory as specified in <yugabyte-home>)
     sudo passwd yugabyte   # (add a password to the yugabyte user)
     sudo su - yugabyte   # (change to yugabyte user for execution of next steps)
     ```
 
-    `yugabyte-home` is the path to the Yugabyte home directory. You can omit this flag if you are using the default `/home/yugabyte`.
+    `yugabyte-home` is the path to the Yugabyte home directory. If you set a custom path for the yugabyte user's home in the YugabyteDB Anywhere UI, you must use the same path here. Otherwise, you can omit the `--home-dir` flag.
 
     Ensure that the `yugabyte` user has permissions to SSH into the YugabyteDB nodes (as defined in `/etc/ssh/sshd_config`).
 

--- a/docs/content/preview/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises.md
+++ b/docs/content/preview/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises.md
@@ -289,14 +289,16 @@ Physical nodes (or cloud instances) are installed with a standard CentOS 7 serve
 1. Add a new `yugabyte:yugabyte` user and group with the default login shell `/bin/bash` that you set via the `-s` flag, as follows:
 
     ```bash
-    sudo useradd -s /bin/bash -m yugabyte   # (add user yugabyte and create /home/yugabyte)
+    sudo useradd -s /bin/bash --create-home --home-dir <yugabyte-home-set-in-the-ui> yugabyte  # (add user yugabyte and create /home/yugabyte)
     sudo passwd yugabyte   # (add a password to the yugabyte user)
     sudo su - yugabyte   # (change to yugabyte user for execution of next steps)
     ```
 
+    `yugabyte-home-set-in-the-ui` is the path to the Yugabyte home directory. You can omit this flag if you are using the default `/home/yugabyte`.
+
     Ensure that the `yugabyte` user has permissions to SSH into the YugabyteDB nodes (as defined in `/etc/ssh/sshd_config`).
 
-1. If the node is running SELinux and the home directory is customized, set the correct SELinux ssh context, as follows:
+1. If the node is running SELinux and the home directory is not the default, set the correct SELinux ssh context, as follows:
 
     ```bash
     chcon -R -t ssh_home_t <yugabyte_home>

--- a/docs/content/preview/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises.md
+++ b/docs/content/preview/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises.md
@@ -289,12 +289,12 @@ Physical nodes (or cloud instances) are installed with a standard CentOS 7 serve
 1. Add a new `yugabyte:yugabyte` user and group with the default login shell `/bin/bash` that you set via the `-s` flag, as follows:
 
     ```bash
-    sudo useradd -s /bin/bash --create-home --home-dir <yugabyte-home-set-in-the-ui> yugabyte  # (add user yugabyte and create /home/yugabyte)
+    sudo useradd -s /bin/bash --create-home --home-dir <yugabyte-home> yugabyte  # (add user yugabyte and create /home/yugabyte)
     sudo passwd yugabyte   # (add a password to the yugabyte user)
     sudo su - yugabyte   # (change to yugabyte user for execution of next steps)
     ```
 
-    `yugabyte-home-set-in-the-ui` is the path to the Yugabyte home directory. You can omit this flag if you are using the default `/home/yugabyte`.
+    `yugabyte-home` is the path to the Yugabyte home directory. You can omit this flag if you are using the default `/home/yugabyte`.
 
     Ensure that the `yugabyte` user has permissions to SSH into the YugabyteDB nodes (as defined in `/etc/ssh/sshd_config`).
 

--- a/docs/content/preview/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises.md
+++ b/docs/content/preview/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises.md
@@ -296,6 +296,12 @@ Physical nodes (or cloud instances) are installed with a standard CentOS 7 serve
 
     Ensure that the `yugabyte` user has permissions to SSH into the YugabyteDB nodes (as defined in `/etc/ssh/sshd_config`).
 
+1. If the node is running SELinux and the home directory is customized, set the correct SELinux ssh context, as follows:
+
+    ```bash
+    chcon -R -t ssh_home_t <yugabyte_home>
+    ```
+
 1. Copy the SSH public key to each DB node. This public key should correspond to the private key entered into the YugabyteDB Anywhere provider.
 
 1. Run the following commands as the `yugabyte` user, after copying the SSH public key file to the user home directory:


### PR DESCRIPTION
If the node is running SELinux and the home directory is customized, set the correct SELinux ssh context

PLAT-9283

@netlify /preview/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises/#set-up-database-nodes-manually