### PR TITLE
Fetch TServer UUID and send AUH Metadata along with the Perform protobuf

### DIFF
--- a/src/postgres/src/backend/parser/analyze.c
+++ b/src/postgres/src/backend/parser/analyze.c
@@ -156,6 +156,9 @@ parse_analyze_varparams(RawStmt *parseTree, const char *sourceText,
 
 	query = transformTopLevelStmt(pstate, parseTree);
 
+	if (IsYugaByteEnabled())
+		YBCSetQueryId(query->queryId);
+
 	if (pstate->p_target_relation &&
 		pstate->p_target_relation->rd_rel->relpersistence == RELPERSISTENCE_TEMP
 		&& IsYugaByteEnabled())

--- a/src/postgres/src/backend/tcop/postgres.c
+++ b/src/postgres/src/backend/tcop/postgres.c
@@ -44,6 +44,7 @@
 #include "commands/async.h"
 #include "commands/portalcmds.h"
 #include "commands/prepare.h"
+#include "common/ip.h"
 #include "executor/spi.h"
 #include "jit/jit.h"
 #include "libpq/libpq.h"
@@ -73,6 +74,7 @@
 #include "tcop/pquery.h"
 #include "tcop/tcopprot.h"
 #include "tcop/utility.h"
+#include "utils/builtins.h"
 #include "utils/inval.h"
 #include "utils/relcache.h"
 #include "utils/catcache.h"
@@ -731,6 +733,8 @@ pg_analyze_and_rewrite(RawStmt *parsetree, const char *query_string,
 
 	query = parse_analyze(parsetree, query_string, paramTypes, numParams,
 						  queryEnv);
+
+	YBCSetQueryId(query->queryId);
 
 	if (log_parser_stats)
 		ShowUsage("PARSE ANALYSIS STATISTICS");
@@ -5129,6 +5133,81 @@ PostgresMain(int argc, char *argv[],
 	if (!ignore_till_sync)
 		send_ready_for_query = true;	/* initially, or after error */
 
+	int	num_backends = pgstat_fetch_stat_numbackends();
+	for (int curr_backend = 1; curr_backend <= num_backends; curr_backend++)
+	{
+		PgBackendStatus *beentry = pgstat_fetch_stat_beentry(curr_backend);
+		SockAddr	zero_clientaddr;
+		char		remote_host[NI_MAXHOST];
+		char		remote_port[NI_MAXSERV];
+		remote_host[0] = '\0';
+		remote_port[0] = '\0';
+
+		ereport(LOG, (errmsg("backend pid: %d ------- my pid: %d", beentry->st_procpid, MyProcPid)));
+
+		if (beentry->st_procpid != MyProcPid)
+			continue;
+		
+		/* A zeroed client addr means we don't know */
+		memset(&zero_clientaddr, 0, sizeof(zero_clientaddr));
+		if (memcmp(&(beentry->st_clientaddr), &zero_clientaddr,
+					sizeof(zero_clientaddr)) == 0)
+		{
+			ereport(LOG, (errmsg("PG client ip and port not found")));
+		}
+		else
+		{
+			if (beentry->st_clientaddr.addr.ss_family == AF_INET
+#ifdef HAVE_IPV6
+				|| beentry->st_clientaddr.addr.ss_family == AF_INET6
+#endif
+				)
+			{
+
+				ereport(LOG, (errmsg("ip: %s ------- port : %s", remote_host, remote_port)));
+
+				int ret = pg_getnameinfo_all(&beentry->st_clientaddr.addr,
+											beentry->st_clientaddr.salen,
+											remote_host, sizeof(remote_host),
+											remote_port, sizeof(remote_port),
+											NI_NUMERICHOST | NI_NUMERICSERV);
+
+				ereport(LOG, (errmsg("ip: %s ------- port : %s", remote_host, remote_port)));
+
+				if (ret == 0)
+				{
+					clean_ipv6_addr(beentry->st_clientaddr.addr.ss_family, remote_host);
+				}
+				else
+				{
+					ereport(LOG, (errmsg("PG client ip and port not found")));
+				}
+			}
+			else if (beentry->st_clientaddr.addr.ss_family == AF_UNIX)
+			{
+					/*
+						* Unix sockets always reports NULL for host and -1 for
+						* port, so it's possible to tell the difference to
+						* connections we have no permissions to view, or with
+						* errors.
+						*/
+					ereport(LOG, (errmsg("PG client ip and port not found")));
+			}
+			else
+			{
+				/* Unknown address type, should never happen */
+				ereport(LOG, (errmsg("PG client ip and port not found")));
+			}
+		}
+
+		ereport(LOG, (errmsg("ip: %s ------- port : %s", remote_host, remote_port)));
+
+		if (IsYugaByteEnabled())
+			HandleYBStatus(YBCPgSetAUHMetadata(remote_host, atoi(remote_port)));
+		else
+		 	ereport(LOG, (errmsg("yugabyte not enabled yet")));
+	}
+
 	/*
 	 * Non-error queries loop here.
 	 */
@@ -5271,6 +5350,7 @@ PostgresMain(int argc, char *argv[],
 
 		if (IsYugaByteEnabled())
 		{
+			YBCSetTopLevelRequestId();
 			yb_pgstat_set_has_catalog_version(true);
 			YBCPgResetCatalogReadTime();
 			YBCheckSharedCatalogCacheVersion();

--- a/src/postgres/src/backend/tcop/postgres.c
+++ b/src/postgres/src/backend/tcop/postgres.c
@@ -5157,7 +5157,7 @@ PostgresMain(int argc, char *argv[],
 		if (memcmp(&(beentry->st_clientaddr), &zero_clientaddr,
 					sizeof(zero_clientaddr)) == 0)
 		{
-			ereport(LOG, (errmsg("PG client ip and port not found")));
+			ereport(LOG, (errmsg("zeroed client addr found")));
 		}
 		else
 		{
@@ -5180,7 +5180,7 @@ PostgresMain(int argc, char *argv[],
 				}
 				else
 				{
-					ereport(LOG, (errmsg("PG client ip and port not found")));
+					ereport(LOG, (errmsg("non-zero pg_getnameinfo_all value")));
 				}
 			}
 			else if (beentry->st_clientaddr.addr.ss_family == AF_UNIX)
@@ -5191,19 +5191,17 @@ PostgresMain(int argc, char *argv[],
 						* connections we have no permissions to view, or with
 						* errors.
 						*/
-					ereport(LOG, (errmsg("PG client ip and port not found")));
+					ereport(LOG, (errmsg("client addr type is unix")));
 			}
 			else
 			{
 				/* Unknown address type, should never happen */
-				ereport(LOG, (errmsg("PG client ip and port not found")));
+				ereport(LOG, (errmsg("unknown addr type, should never happen")));
 			}
 		}
 
 		if (IsYugaByteEnabled())
 			HandleYBStatus(YBCPgSetAUHMetadata(remote_host, atoi(remote_port)));
-		else
-		 	ereport(LOG, (errmsg("yugabyte not enabled yet")));
 	}
 
 	/*

--- a/src/postgres/src/backend/tcop/postgres.c
+++ b/src/postgres/src/backend/tcop/postgres.c
@@ -5682,8 +5682,6 @@ PostgresMain(int argc, char *argv[],
 
 				HandleFunctionRequest(&input_message);
 
-				ereport(LOG, (errmsg("Fastpath function call")));
-
 				/* commit the function-invocation transaction */
 				finish_xact_command();
 

--- a/src/postgres/src/backend/tcop/postgres.c
+++ b/src/postgres/src/backend/tcop/postgres.c
@@ -5143,8 +5143,6 @@ PostgresMain(int argc, char *argv[],
 		remote_host[0] = '\0';
 		remote_port[0] = '\0';
 
-		ereport(LOG, (errmsg("backend pid: %d ------- my pid: %d", beentry->st_procpid, MyProcPid)));
-
 		if (beentry->st_procpid != MyProcPid)
 			continue;
 		
@@ -5164,15 +5162,11 @@ PostgresMain(int argc, char *argv[],
 				)
 			{
 
-				ereport(LOG, (errmsg("ip: %s ------- port : %s", remote_host, remote_port)));
-
 				int ret = pg_getnameinfo_all(&beentry->st_clientaddr.addr,
 											beentry->st_clientaddr.salen,
 											remote_host, sizeof(remote_host),
 											remote_port, sizeof(remote_port),
 											NI_NUMERICHOST | NI_NUMERICSERV);
-
-				ereport(LOG, (errmsg("ip: %s ------- port : %s", remote_host, remote_port)));
 
 				if (ret == 0)
 				{
@@ -5199,8 +5193,6 @@ PostgresMain(int argc, char *argv[],
 				ereport(LOG, (errmsg("PG client ip and port not found")));
 			}
 		}
-
-		ereport(LOG, (errmsg("ip: %s ------- port : %s", remote_host, remote_port)));
 
 		if (IsYugaByteEnabled())
 			HandleYBStatus(YBCPgSetAUHMetadata(remote_host, atoi(remote_port)));

--- a/src/yb/client/client.cc
+++ b/src/yb/client/client.cc
@@ -1065,6 +1065,13 @@ Status YBClient::GetYsqlCatalogMasterVersion(uint64_t *ysql_catalog_version) {
   return Status::OK();
 }
 
+Status YBClient::GetTServerUUID(std::string &node_uuid) {
+  if (data_->meta_cache_->local_tserver())
+    node_uuid = data_->meta_cache_->local_tserver()->permanent_uuid();
+
+  return Status::OK();
+}
+
 Status YBClient::GrantRevokePermission(GrantRevokeStatementType statement_type,
                                        const PermissionType& permission,
                                        const ResourceType& resource_type,

--- a/src/yb/client/client.cc
+++ b/src/yb/client/client.cc
@@ -1065,11 +1065,11 @@ Status YBClient::GetYsqlCatalogMasterVersion(uint64_t *ysql_catalog_version) {
   return Status::OK();
 }
 
-Status YBClient::GetTServerUUID(std::string &node_uuid) {
+Result<std::string> YBClient::GetTServerUUID() {
   if (data_->meta_cache_->local_tserver())
-    node_uuid = data_->meta_cache_->local_tserver()->permanent_uuid();
+    return data_->meta_cache_->local_tserver()->permanent_uuid();
 
-  return Status::OK();
+  return "";
 }
 
 Status YBClient::GrantRevokePermission(GrantRevokeStatementType statement_type,

--- a/src/yb/client/client.h
+++ b/src/yb/client/client.h
@@ -437,7 +437,7 @@ class YBClient {
 
   Status GetYsqlCatalogMasterVersion(uint64_t *ysql_catalog_version);
 
-  Status GetTServerUUID(std::string &node_uuid);
+  Result<std::string> GetTServerUUID();
 
   // Grant permission with given arguments.
   Status GrantRevokePermission(GrantRevokeStatementType statement_type,

--- a/src/yb/client/client.h
+++ b/src/yb/client/client.h
@@ -437,6 +437,8 @@ class YBClient {
 
   Status GetYsqlCatalogMasterVersion(uint64_t *ysql_catalog_version);
 
+  Status GetTServerUUID(std::string &node_uuid);
+
   // Grant permission with given arguments.
   Status GrantRevokePermission(GrantRevokeStatementType statement_type,
                                const PermissionType& permission,

--- a/src/yb/common/common.proto
+++ b/src/yb/common/common.proto
@@ -609,3 +609,11 @@ message PgDatumPB {
     bool datum_missing = 8;
   }
 }
+
+message AUHMetadataPB {
+  required string top_level_request_id = 1;
+  required string client_node_ip = 2;
+  required string top_level_node_id = 3;
+  required int64 request_id = 4;
+  required uint64 query_id = 5;
+}

--- a/src/yb/common/common.proto
+++ b/src/yb/common/common.proto
@@ -614,6 +614,6 @@ message AUHMetadataPB {
   required string top_level_request_id = 1;
   required string client_node_ip = 2;
   required string top_level_node_id = 3;
-  required int64 request_id = 4;
+  required uint64 request_id = 4;
   required uint64 query_id = 5;
 }

--- a/src/yb/tserver/pg_client.proto
+++ b/src/yb/tserver/pg_client.proto
@@ -43,6 +43,7 @@ service PgClientService {
   rpc FinishTransaction(PgFinishTransactionRequestPB) returns (PgFinishTransactionResponsePB);
   rpc GetCatalogMasterVersion(PgGetCatalogMasterVersionRequestPB)
       returns (PgGetCatalogMasterVersionResponsePB);
+  rpc GetTServerUUID (PgGetTServerUUIDRequestPB) returns (PgGetTServerUUIDResponsePB);
   rpc GetDatabaseInfo(PgGetDatabaseInfoRequestPB) returns (PgGetDatabaseInfoResponsePB);
   rpc IsInitDbDone(PgIsInitDbDoneRequestPB) returns (PgIsInitDbDoneResponsePB);
   rpc GetLockStatus(PgGetLockStatusRequestPB) returns (PgGetLockStatusResponsePB);
@@ -263,6 +264,14 @@ message PgDropTablegroupResponsePB {
 message PgGetCatalogMasterVersionRequestPB {
 }
 
+message PgGetTServerUUIDRequestPB {
+}
+
+message PgGetTServerUUIDResponsePB {
+  AppStatusPB status = 1;
+  string node_uuid = 2;
+}
+
 message PgFinishTransactionRequestPB {
   uint64 session_id = 1;
   bool commit = 2;
@@ -429,6 +438,7 @@ message PgPerformOptionsPB {
   CachingInfoPB caching_info = 17;
   bool read_from_followers = 18;
   bool trace_requested = 19;
+  AUHMetadataPB auh_metadata = 20;
 }
 
 message PgPerformRequestPB {

--- a/src/yb/tserver/pg_client_service.cc
+++ b/src/yb/tserver/pg_client_service.cc
@@ -327,9 +327,7 @@ class PgClientServiceImpl::Impl {
       const PgGetTServerUUIDRequestPB& req,
       PgGetTServerUUIDResponsePB* resp,
       rpc::RpcContext* context) {
-    std::string node_uuid;
-    RETURN_NOT_OK(client().GetTServerUUID(node_uuid));
-    resp->set_node_uuid(node_uuid);
+    resp->set_node_uuid(VERIFY_RESULT(client().GetTServerUUID()));
     return Status::OK();
   }
 

--- a/src/yb/tserver/pg_client_service.cc
+++ b/src/yb/tserver/pg_client_service.cc
@@ -323,6 +323,16 @@ class PgClientServiceImpl::Impl {
     return Status::OK();
   }
 
+  Status GetTServerUUID(
+      const PgGetTServerUUIDRequestPB& req,
+      PgGetTServerUUIDResponsePB* resp,
+      rpc::RpcContext* context) {
+    std::string node_uuid;
+    RETURN_NOT_OK(client().GetTServerUUID(node_uuid));
+    resp->set_node_uuid(node_uuid);
+    return Status::OK();
+  }
+
   Status CreateSequencesDataTable(
       const PgCreateSequencesDataTableRequestPB& req,
       PgCreateSequencesDataTableResponsePB* resp,

--- a/src/yb/tserver/pg_client_service.h
+++ b/src/yb/tserver/pg_client_service.h
@@ -69,6 +69,7 @@ class PgMutationCounter;
     (GetTserverCatalogVersionInfo) \
     (WaitForBackendsCatalogVersion) \
     (CancelTransaction) \
+    (GetTServerUUID) \
     /**/
 
 class PgClientServiceImpl : public PgClientServiceIf {

--- a/src/yb/yql/pggate/pg_client.cc
+++ b/src/yb/yql/pggate/pg_client.cc
@@ -434,6 +434,7 @@ class PgClient::Impl {
     req.set_session_id(session_id_);
     *req.mutable_options() = std::move(*options);
     PrepareOperations(&req, operations);
+    req.mutable_options()->mutable_auh_metadata()->set_request_id(reinterpret_cast<uint64_t>(&req));
 
     if (exchange_) {
       PerformData data(&arena, std::move(*operations), callback);
@@ -538,6 +539,15 @@ class PgClient::Impl {
     RETURN_NOT_OK(proxy_->GetCatalogMasterVersion(req, &resp, PrepareController()));
     RETURN_NOT_OK(ResponseStatus(resp));
     return resp.version();
+  }
+
+  Result<std::string> GetTServerUUID() {
+    tserver::PgGetTServerUUIDRequestPB req;
+    tserver::PgGetTServerUUIDResponsePB resp;
+
+    RETURN_NOT_OK(proxy_->GetTServerUUID(req, &resp, PrepareController()));
+    RETURN_NOT_OK(ResponseStatus(resp));
+    return resp.node_uuid();     
   }
 
   Status CreateSequencesDataTable() {
@@ -784,6 +794,10 @@ Result<bool> PgClient::IsInitDbDone() {
 
 Result<uint64_t> PgClient::GetCatalogMasterVersion() {
   return impl_->GetCatalogMasterVersion();
+}
+
+Result<std::string> PgClient::GetTServerUUID() {
+  return impl_->GetTServerUUID();
 }
 
 Status PgClient::CreateSequencesDataTable() {

--- a/src/yb/yql/pggate/pg_client.h
+++ b/src/yb/yql/pggate/pg_client.h
@@ -97,6 +97,8 @@ class PgClient {
 
   Result<uint64_t> GetCatalogMasterVersion();
 
+  Result<std::string> GetTServerUUID();
+
   Status CreateSequencesDataTable();
 
   Result<client::YBTableName> DropTable(

--- a/src/yb/yql/pggate/pg_session.cc
+++ b/src/yb/yql/pggate/pg_session.cc
@@ -658,6 +658,8 @@ Result<PerformFuture> PgSession::Perform(BufferableOperations&& ops, PerformOpti
   }
   options.set_trace_requested(pg_txn_manager_->ShouldEnableTracing());
 
+  FillAUHMetadata(*options.mutable_auh_metadata());
+
   if (ops_options.cache_options) {
     auto& cache_options = *ops_options.cache_options;
     auto& caching_info = *options.mutable_caching_info();
@@ -671,6 +673,13 @@ Result<PerformFuture> PgSession::Perform(BufferableOperations&& ops, PerformOpti
     promise->set_value(result);
   });
   return PerformFuture(promise->get_future(), this, std::move(ops.relations));
+}
+
+void PgSession::FillAUHMetadata(AUHMetadataPB& auh_metadata) {
+  auh_metadata.set_top_level_request_id(top_level_request_id_);
+  auh_metadata.set_client_node_ip(client_node_ip_);
+  auh_metadata.set_top_level_node_id(node_uuid_);
+  auh_metadata.set_query_id(query_id_);
 }
 
 void PgSession::ProcessPerformOnTxnSerialNo(
@@ -895,6 +904,22 @@ Result<PerformFuture> PgSession::RunAsync(
 
 Result<bool> PgSession::CheckIfPitrActive() {
   return pg_client_.CheckIfPitrActive();
+}
+
+Status PgSession::SetAUHMetadata(const char* remote_host, int remote_port) {
+  node_uuid_ = VERIFY_RESULT(pg_client_.GetTServerUUID());
+  client_node_ip_ = remote_host;
+  client_node_ip_ += ":";
+  client_node_ip_ += std::to_string(remote_port);
+  return Status::OK();
+}
+
+void PgSession::SetQueryId(uint64_t query_id) {
+  query_id_ = query_id;
+}
+
+void PgSession::SetTopLevelRequestId() {
+  top_level_request_id_ = GenerateObjectId();
 }
 
 }  // namespace pggate

--- a/src/yb/yql/pggate/pg_session.h
+++ b/src/yb/yql/pggate/pg_session.h
@@ -353,6 +353,12 @@ class PgSession : public RefCountedThreadSafe<PgSession> {
 
   PgDocMetrics& metrics() { return metrics_; }
 
+  Status SetAUHMetadata(const char* remote_host, int remote_port);
+
+  void SetQueryId(uint64_t query_id);
+
+  void SetTopLevelRequestId();
+
  private:
   Result<PgTableDescPtr> DoLoadTable(const PgObjectId& table_id, bool fail_on_cache_hit);
   Result<PerformFuture> FlushOperations(BufferableOperations ops, bool transactional);
@@ -367,6 +373,8 @@ class PgSession : public RefCountedThreadSafe<PgSession> {
   };
 
   Result<PerformFuture> Perform(BufferableOperations&& ops, PerformOptions&& options);
+
+  void FillAUHMetadata(AUHMetadataPB& auh_metadata);
 
   void ProcessPerformOnTxnSerialNo(
       uint64_t txn_serial_no,
@@ -422,6 +430,11 @@ class PgSession : public RefCountedThreadSafe<PgSession> {
   const YBCPgCallbacks& pg_callbacks_;
   bool has_write_ops_in_ddl_mode_ = false;
   std::variant<TxnSerialNoPerformInfo> last_perform_on_txn_serial_no_;
+
+  std::string top_level_request_id_;
+  std::string client_node_ip_;
+  std::string node_uuid_;
+  uint64_t query_id_;
 };
 
 }  // namespace pggate

--- a/src/yb/yql/pggate/pggate.cc
+++ b/src/yb/yql/pggate/pggate.cc
@@ -1936,5 +1936,18 @@ Result<bool> PgApiImpl::CheckIfPitrActive() {
   return pg_session_->CheckIfPitrActive();
 }
 
+
+Status PgApiImpl::SetAUHMetadata(const char* remote_host, int remote_port) {
+  return pg_session_->SetAUHMetadata(remote_host, remote_port);
+}
+
+void PgApiImpl::SetQueryId(uint64_t query_id) {
+  pg_session_->SetQueryId(query_id);
+}
+
+void PgApiImpl::SetTopLevelRequestId() {
+  pg_session_->SetTopLevelRequestId();
+}
+
 } // namespace pggate
 } // namespace yb

--- a/src/yb/yql/pggate/pggate.h
+++ b/src/yb/yql/pggate/pggate.h
@@ -643,6 +643,12 @@ class PgApiImpl {
 
   MemTracker &GetRootMemTracker() { return *MemTracker::GetRootTracker(); }
 
+  Status SetAUHMetadata(const char* remote_host, int remote_port);
+
+  void SetQueryId(uint64_t query_id);
+
+  void SetTopLevelRequestId();
+
  private:
   class Interrupter;
 

--- a/src/yb/yql/pggate/ybc_pg_typedefs.h
+++ b/src/yb/yql/pggate/ybc_pg_typedefs.h
@@ -340,8 +340,6 @@ typedef struct PgCallbacks {
   YBCPgMemctx (*GetCurrentYbMemctx)();
   const char* (*GetDebugQueryString)();
   void (*WriteExecOutParam)(PgExecOutParam *, const YbcPgExecOutParamValue *);
-  void (*UpdateAUHMetadata)(const char* top_level_request_id, const char* top_level_node_id,
-                            uint64_t request_id);
 } YBCPgCallbacks;
 
 typedef struct PgGFlagsAccessor {

--- a/src/yb/yql/pggate/ybc_pg_typedefs.h
+++ b/src/yb/yql/pggate/ybc_pg_typedefs.h
@@ -340,6 +340,8 @@ typedef struct PgCallbacks {
   YBCPgMemctx (*GetCurrentYbMemctx)();
   const char* (*GetDebugQueryString)();
   void (*WriteExecOutParam)(PgExecOutParam *, const YbcPgExecOutParamValue *);
+  void (*UpdateAUHMetadata)(const char* top_level_request_id, const char* top_level_node_id,
+                            uint64_t request_id);
 } YBCPgCallbacks;
 
 typedef struct PgGFlagsAccessor {

--- a/src/yb/yql/pggate/ybc_pggate.cc
+++ b/src/yb/yql/pggate/ybc_pggate.cc
@@ -1561,6 +1561,18 @@ YBCStatus YBCPgCheckIfPitrActive(bool* is_active) {
   return ToYBCStatus(res.status());
 }
 
+YBCStatus YBCPgSetAUHMetadata(const char* remote_host, int remote_port) {
+  return ToYBCStatus(pgapi->SetAUHMetadata(remote_host, remote_port));
+}
+
+void YBCSetQueryId(uint64_t query_id) {
+  pgapi->SetQueryId(query_id);
+}
+
+void YBCSetTopLevelRequestId() {
+  pgapi->SetTopLevelRequestId();
+}
+
 } // extern "C"
 
 } // namespace yb::pggate

--- a/src/yb/yql/pggate/ybc_pggate.h
+++ b/src/yb/yql/pggate/ybc_pggate.h
@@ -669,6 +669,12 @@ YBCStatus YBCPrefetchRegisteredSysTables();
 
 YBCStatus YBCPgCheckIfPitrActive(bool* is_active);
 
+YBCStatus YBCPgSetAUHMetadata(const char* remote_host, int remote_port);
+
+void YBCSetQueryId(uint64_t query_id);
+
+void YBCSetTopLevelRequestId();
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif


### PR DESCRIPTION
This diff fetches TServer UUID and stores it in the pg_session object so that it can be used to fill up the outgoing rpcs and also be accessible from PG.

Also, another field is added to the PgPerformOptionsPB called AUHMetadataPB, which is required for the necessary data to be sent from PG to TServer.