### PR TITLE
Circular buffer size flag: yb_auh.circular_buf_size_kb 

### DIFF
--- a/src/postgres/contrib/yb_auh/Makefile
+++ b/src/postgres/contrib/yb_auh/Makefile
@@ -6,7 +6,7 @@ OBJS = yb_auh.o $(WIN32RES)
 EXTENSION = yb_auh
 DATA = yb_auh--1.0.sql
 PGFILEDESC = "yb_auh - YugaByte Active Universe History"
-SHLIB_LINK += -L$(YB_BUILD_ROOT)/lib -lserver_process -lyb_pggate_util
+SHLIB_LINK += -L$(YB_BUILD_ROOT)/lib -lserver_process -lyb_util -lyb_pggate -lyb_pggate_util
 LDFLAGS_SL += $(filter -lm, $(LIBS))
 
 REGRESS_OPTS = --temp-config $(top_srcdir)/contrib/yb_auh/yb_auh.conf

--- a/src/postgres/contrib/yb_auh/yb_auh--1.0.sql
+++ b/src/postgres/contrib/yb_auh/yb_auh--1.0.sql
@@ -5,8 +5,15 @@ CREATE FUNCTION pg_active_universe_history(
     OUT auh_sample_time timestamptz,
     OUT top_level_request_id text,
     OUT request_id INTEGER,
+    OUT wait_event_component text,
     OUT wait_event_class text,
-    OUT wait_event text
+    OUT wait_event text,
+    OUT wait_event_aux text,
+    OUT top_level_node_id text,
+    OUT query_id BIGINT,
+    OUT client_node_ip text,
+    OUT start_ts_of_wait_event timestamptz,
+    OUT sample_rate SMALLINT
 )
 
 RETURNS SETOF record

--- a/src/postgres/contrib/yb_auh/yb_auh.c
+++ b/src/postgres/contrib/yb_auh/yb_auh.c
@@ -180,8 +180,8 @@ static void pg_collect_samples(TimestampTz auh_sample_time)
     if (proc != NULL && proc->pid != 0)
     {
       //TODO:
-      auh_entry_store(auh_sample_time, proc->top_level_request_id, 1,
-                      proc->wait_event_info, "tabletid=123", proc->node_uuid,
+      auh_entry_store(auh_sample_time, proc->top_level_request_id, proc->top_level_request_id,
+                      proc->wait_event_info, "", proc->node_uuid,
                       proc->remote_host, proc->remote_port, proc->queryid, auh_sample_time,
                       1);
     }
@@ -192,6 +192,7 @@ static void pg_collect_samples(TimestampTz auh_sample_time)
 static void tserver_collect_samples(TimestampTz auh_sample_time)
 {
   //TODO:
+
 }
 
 void

--- a/src/postgres/contrib/yb_auh/yb_auh.c
+++ b/src/postgres/contrib/yb_auh/yb_auh.c
@@ -35,13 +35,20 @@
 PG_MODULE_MAGIC;
 PG_FUNCTION_INFO_V1(pg_active_universe_history);
 
-#define PG_ACTIVE_UNIVERSE_HISTORY_COLS        5
+#define PG_ACTIVE_UNIVERSE_HISTORY_COLS        11
 
 typedef struct ybauhEntry {
   TimestampTz auh_sample_time;
   char top_level_request_id[16];
-  int request_id;
+  long request_id;
   uint32 wait_event;
+  char wait_event_aux[16];
+  char top_level_node_id[16];
+  char client_node_ip[16];
+  uint16 client_node_port;
+  long query_id;
+  TimestampTz start_ts_of_wait_event;
+  uint16 sample_rate;
 } ybauhEntry;
 
 /* counters */
@@ -67,12 +74,19 @@ static Size yb_auh_circularBufferIndexSize(void);
 static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
 static void ybauh_startup_hook(void);
 static void pg_active_universe_history_internal(FunctionCallInfo fcinfo);
-
-
 static void auh_entry_store(TimestampTz auh_time,
                             const char* top_level_request_id,
-                            int request_id,
-                            uint32 wait_event);
+                            long request_id,
+                            uint32 wait_event,
+                            const char* wait_event_aux,
+                            const char* top_level_node_id,
+                            const char* client_node_ip,
+                            uint16 client_node_port,
+                            long query_id,
+                            TimestampTz start_ts_of_wait_event,
+                            uint16 sample_rate);
+static void pg_collect_samples(TimestampTz auh_sample_time);
+static void tserver_collect_samples(TimestampTz auh_sample_time);
 
 static volatile sig_atomic_t got_sigterm = false;
 static volatile sig_atomic_t got_sighup = false;
@@ -142,26 +156,42 @@ yb_auh_main(Datum main_arg) {
     auh_sample_time = GetCurrentTimestamp();
 
     MemoryContext oldcxt = MemoryContextSwitchTo(uppercxt);
-    LWLockAcquire(ProcArrayLock, LW_SHARED);
-    LWLockAcquire(auh_entry_array_lock, LW_EXCLUSIVE);
 
-    int		procCount = ProcGlobal->allProcCount;
-    for (int i = 0; i < procCount; i++)
-    {
-      PGPROC *proc = &ProcGlobal->allProcs[i];
+    pg_collect_samples(auh_sample_time);
+    tserver_collect_samples(auh_sample_time);
 
-      if (proc != NULL && proc->pid != 0)
-      {
-        auh_entry_store(auh_sample_time, "abc", proc->pid, proc->wait_event_info);
-      }
-    }
-    LWLockRelease(auh_entry_array_lock);
-    LWLockRelease(ProcArrayLock);
-    
     MemoryContextSwitchTo(oldcxt);
     /* No problems, so clean exit */
   }
   proc_exit(0);
+}
+
+static void pg_collect_samples(TimestampTz auh_sample_time)
+{
+  LWLockAcquire(ProcArrayLock, LW_SHARED);
+  LWLockAcquire(auh_entry_array_lock, LW_EXCLUSIVE);
+
+  int		procCount = ProcGlobal->allProcCount;
+  for (int i = 0; i < procCount; i++)
+  {
+    PGPROC *proc = &ProcGlobal->allProcs[i];
+
+    if (proc != NULL && proc->pid != 0)
+    {
+      //TODO:
+      auh_entry_store(auh_sample_time, "abc", proc->pid,
+                      proc->wait_event_info, "tabletid=123", "0xffee",
+                      "127.0.0.1", 1234, 123456, auh_sample_time,
+                      500);
+    }
+  }
+  LWLockRelease(auh_entry_array_lock);
+  LWLockRelease(ProcArrayLock);
+}
+
+static void tserver_collect_samples(TimestampTz auh_sample_time)
+{
+  //TODO:
 }
 
 void
@@ -225,8 +255,15 @@ yb_auh_circularBufferIndexSize(void)
 
 static void auh_entry_store(TimestampTz auh_time,
                             const char* top_level_request_id,
-                            int request_id,
-                            uint32 wait_event)
+                            long request_id,
+                            uint32 wait_event,
+                            const char* wait_event_aux,
+                            const char* top_level_node_id,
+                            const char* client_node_ip,
+                            uint16 client_node_port,
+                            long query_id,
+                            TimestampTz start_ts_of_wait_event,
+                            uint16 sample_rate)
 {
   int inserted;
   if (!AUHEntryArray) { return; }
@@ -239,6 +276,16 @@ static void auh_entry_store(TimestampTz auh_time,
   AUHEntryArray[inserted].request_id = request_id;
   memcpy(AUHEntryArray[inserted].top_level_request_id, top_level_request_id,
          Min(strlen(top_level_request_id) + 1, 15));
+  memcpy(AUHEntryArray[inserted].wait_event_aux, wait_event_aux,
+         Min(strlen(wait_event_aux) + 1, 15));
+  memcpy(AUHEntryArray[inserted].top_level_node_id, top_level_node_id,
+         Min(strlen(top_level_node_id) + 1, 15));
+  memcpy(AUHEntryArray[inserted].client_node_ip, client_node_ip,
+         Min(strlen(client_node_ip) + 1, 15));
+  AUHEntryArray[inserted].client_node_port = client_node_port;
+  AUHEntryArray[inserted].query_id = query_id;
+  AUHEntryArray[inserted].start_ts_of_wait_event = start_ts_of_wait_event;
+  AUHEntryArray[inserted].sample_rate = sample_rate;
 }
 
 static void
@@ -306,7 +353,7 @@ pg_active_universe_history_internal(FunctionCallInfo fcinfo)
     Datum           values[PG_ACTIVE_UNIVERSE_HISTORY_COLS];
     bool            nulls[PG_ACTIVE_UNIVERSE_HISTORY_COLS];
     int                     j = 0;
-    const char *event_type, *event;
+    const char *event_type, *event, *event_component;
 
     memset(values, 0, sizeof(values));
     memset(nulls, 0, sizeof(nulls));
@@ -328,8 +375,18 @@ pg_active_universe_history_internal(FunctionCallInfo fcinfo)
       values[j++] = Int64GetDatum(AUHEntryArray[i].request_id);
     else
       nulls[j++] = true;
+
+    // Wait event, wait event component, wait event class
     event_type = pgstat_get_wait_event_type(AUHEntryArray[i].wait_event);
     event = pgstat_get_wait_event(AUHEntryArray[i].wait_event);
+    // TODO: Change this to return class
+    event_component = pgstat_get_wait_event_type(AUHEntryArray[i].wait_event);
+
+    if (event_component)
+      values[j++] = CStringGetTextDatum(event_component);
+    else
+      nulls[j++] = true;
+
     if (event_type)
       values[j++] = CStringGetTextDatum(event_type);
     else
@@ -337,6 +394,46 @@ pg_active_universe_history_internal(FunctionCallInfo fcinfo)
 
     if (event)
       values[j++] = CStringGetTextDatum(event);
+    else
+      nulls[j++] = true;
+
+    // wait event's auxillary info
+    if (AUHEntryArray[i].wait_event_aux[0] != '\0')
+      values[j++] = CStringGetTextDatum(AUHEntryArray[i].wait_event_aux);
+    else
+      nulls[j++] = true;
+
+    // Top level node id
+    if (AUHEntryArray[i].top_level_node_id[0] != '\0')
+      values[j++] = CStringGetTextDatum(AUHEntryArray[i].top_level_node_id);
+    else
+      nulls[j++] = true;
+
+    // query id
+    if (AUHEntryArray[i].query_id)
+      values[j++] = Int64GetDatum(AUHEntryArray[i].query_id);
+    else
+      nulls[j++] = true;
+
+    // Originating client node
+    char client_node[22];
+    if (AUHEntryArray[i].client_node_ip[0] != '\0')
+    {
+      sprintf(client_node, "%s:%d", AUHEntryArray[i].client_node_ip,
+              AUHEntryArray[i].client_node_port);
+      values[j++] = CStringGetTextDatum(client_node);
+    }
+    else
+      nulls[j++] = true;
+    // start timestamp of wait event
+    if (TimestampTzGetDatum(AUHEntryArray[i].start_ts_of_wait_event))
+      values[j++] = TimestampTzGetDatum(AUHEntryArray[i].start_ts_of_wait_event);
+    else
+      break;
+
+    // Sample rate
+    if (AUHEntryArray[i].sample_rate)
+      values[j++] = Int16GetDatum(AUHEntryArray[i].sample_rate);
     else
       nulls[j++] = true;
 


### PR DESCRIPTION
- Changed the flag to be circular buffer size in kb rather than the count of items in circular buffer
- Added remaining parameters to the circular buffer and to the auh view. 