### PR TITLE
Add AUH metadata to procarray

### DIFF
--- a/src/postgres/src/backend/parser/analyze.c
+++ b/src/postgres/src/backend/parser/analyze.c
@@ -157,7 +157,10 @@ parse_analyze_varparams(RawStmt *parseTree, const char *sourceText,
 	query = transformTopLevelStmt(pstate, parseTree);
 
 	if (IsYugaByteEnabled())
+	{
 		YBCSetQueryId(query->queryId);
+		MyProc->queryid = query->queryId;
+	}
 
 	if (pstate->p_target_relation &&
 		pstate->p_target_relation->rd_rel->relpersistence == RELPERSISTENCE_TEMP

--- a/src/postgres/src/backend/storage/lmgr/proc.c
+++ b/src/postgres/src/backend/storage/lmgr/proc.c
@@ -439,6 +439,12 @@ InitProcess(void)
 
 	MyProc->ybAnyLockAcquired = false;
 
+	MyProc->queryid = 0;
+	MyProc->remote_host[0] = '\0';
+	MyProc->remote_port = 0;
+	MyProc->node_uuid[0] = '\0';
+	MyProc->top_level_request_id[0] = '\0';
+
 	/*
 	 * Acquire ownership of the PGPROC's latch, so that we can use WaitLatch
 	 * on it.  That allows us to repoint the process latch, which so far
@@ -582,6 +588,11 @@ InitAuxiliaryProcess(void)
 	MyProc->lwWaitMode = 0;
 	MyProc->waitLock = NULL;
 	MyProc->waitProcLock = NULL;
+	MyProc->queryid = 0;
+	MyProc->remote_host[0] = '\0';
+	MyProc->remote_port = 0;
+	MyProc->node_uuid[0] = '\0';
+	MyProc->top_level_request_id[0] = '\0';
 #ifdef USE_ASSERT_CHECKING
 	{
 		int			i;

--- a/src/postgres/src/backend/utils/adt/pgstatfuncs.c
+++ b/src/postgres/src/backend/utils/adt/pgstatfuncs.c
@@ -2152,3 +2152,73 @@ yb_pg_stat_retrieve_concurrent_index_progress()
 
 	return progress;
 }
+
+Datum
+yb_wait_metadata(PG_FUNCTION_ARGS)
+{
+	int32		beid = PG_GETARG_INT32(0);
+	PgBackendStatus *beentry;
+	PGPROC	   *proc;
+
+	if ((beentry = pgstat_fetch_stat_beentry(beid)) == NULL)
+		PG_RETURN_NULL();
+	else if (!has_privs_of_role(GetUserId(), beentry->st_userid))
+		PG_RETURN_NULL();
+	else if ((proc = BackendPidGetProc(beentry->st_procpid)) == NULL)
+		PG_RETURN_NULL();
+
+#define YB_WAIT_METADATA_COLS	5
+	Datum		values[YB_WAIT_METADATA_COLS];
+	bool		nulls[YB_WAIT_METADATA_COLS];
+	TupleDesc	tupdesc;
+
+	MemSet(values, 0, sizeof(values));
+	MemSet(nulls, 0, sizeof(nulls));
+
+		/* Initialise attributes information in the tuple descriptor */
+	tupdesc = CreateTemplateTupleDesc(YB_WAIT_METADATA_COLS, false);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 1, "remote_host",
+					   TEXTOID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 2, "remote_port",
+					   INT8OID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 3, "queryid",
+					   INT8OID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 4, "node_uuid",
+					   TEXTOID, -1, 0);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 5, "top_level_request_id",
+					   TEXTOID, -1, 0);
+
+	BlessTupleDesc(tupdesc);
+
+	if (strlen(proc->remote_host) > 0)
+		values[0] = CStringGetTextDatum(proc->remote_host);
+	else
+		nulls[0] = true;
+	ereport(LOG, (errmsg("Set remote host: %s: %s", proc->remote_host, DatumGetCString(values[0]))));
+
+	if (proc->remote_port != 0)
+		values[1] = Int32GetDatum(proc->remote_port);
+	else
+		nulls[1] = true;
+
+	ereport(LOG, (errmsg("Set remote port: %d", proc->remote_port)));
+
+	values[2] = Int64GetDatum(proc->queryid);
+	ereport(LOG, (errmsg("Set queryid: " INT64_FORMAT, proc->queryid)));
+
+	if (strlen(proc->node_uuid) > 0)
+		values[3] = CStringGetTextDatum(proc->node_uuid);
+	else
+		nulls[3] = true;
+	ereport(LOG, (errmsg("Set node uuid: %s", proc->node_uuid)));
+
+	if (strlen(proc->top_level_request_id) > 0)
+		values[4] = CStringGetTextDatum(proc->top_level_request_id);
+	else
+	 	nulls[4] = true;
+	ereport(LOG, (errmsg("Set top level request id: %s", proc->top_level_request_id)));
+
+	/* Returns the record as Datum */
+	PG_RETURN_DATUM(HeapTupleGetDatum(
+									  heap_form_tuple(tupdesc, values, nulls)));
+}

--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -640,6 +640,8 @@ YBInitPostgresBackend(
 		callbacks.WriteExecOutParam = &YbWriteExecOutParam;
 		callbacks.SignalWaitStart = &pgstat_report_wait_start;
 		callbacks.SignalWaitEnd = &pgstat_report_wait_end;
+		callbacks.ProcSetNodeUUID = &ProcSetNodeUUID;
+		callbacks.ProcSetTopRequestId = &ProcSetTopRequestId;
 		YBCInitPgGate(type_table, count, callbacks);
 		YBCInstallTxnDdlHook();
 
@@ -3351,4 +3353,12 @@ bool YbIsBatchedExecution() {
 
 void YbSetIsBatchedExecution(bool value) {
 	yb_is_batched_execution = value;
+}
+
+void ProcSetNodeUUID(const char *node_uuid) {
+	strcpy(MyProc->node_uuid, node_uuid);
+}
+
+void ProcSetTopRequestId(const char *top_level_request_id) {
+	strcpy(MyProc->top_level_request_id, top_level_request_id);
 }

--- a/src/postgres/src/include/catalog/catalog.h
+++ b/src/postgres/src/include/catalog/catalog.h
@@ -29,7 +29,7 @@
  * If you increment it, make sure you didn't forget to add a new SQL migration
  * (see pg_yb_migration.dat and src/yb/yql/pgwrapper/ysql_migrations/README.md)
  */
-#define YB_LAST_USED_OID 8060
+#define YB_LAST_USED_OID 8061
 
 extern bool IsSystemRelation(Relation relation);
 extern bool IsToastRelation(Relation relation);

--- a/src/postgres/src/include/catalog/pg_proc.dat
+++ b/src/postgres/src/include/catalog/pg_proc.dat
@@ -10447,4 +10447,12 @@
   prorettype => 'cstring', proargtypes => '',
   prosrc => 'yb_get_effective_transaction_isolation_level' },
 
+{ oid => '8061',
+  descr => 'Display Wait Event Info Metadata',
+  proname => 'yb_wait_metadata', provolatile => 's',
+  proparallel => 'r', prorettype => 'record', proargtypes => 'int4',
+  proallargtypes => '{varchar,int8,int8,varchar,varchar}',
+  proargmodes => '{o,o,o,o,o}',
+  proargnames => '{remote_host, remote_port, queryid, node_uuid, top_request_id}',
+  prosrc => 'yb_wait_metadata' },
 ]

--- a/src/postgres/src/include/catalog/pg_yb_migration.dat
+++ b/src/postgres/src/include/catalog/pg_yb_migration.dat
@@ -12,7 +12,7 @@
 [
 
 # For better version control conflict detection, list latest migration filename
-# here: V38__14445__alter_pg_stat_statements.sql
-{ major => '38', minor => '0', name => '<baseline>', time_applied => '_null_' }
+# here: V39__22222__add_wait_event_info.sql
+{ major => '39', minor => '0', name => '<baseline>', time_applied => '_null_' }
 
 ]

--- a/src/postgres/src/include/pg_yb_utils.h
+++ b/src/postgres/src/include/pg_yb_utils.h
@@ -878,4 +878,7 @@ void YbSetIsBatchedExecution(bool value);
 	} while (0)
 #endif
 
+void ProcSetNodeUUID(const char *);
+void ProcSetTopRequestId(const char *);
+
 #endif /* PG_YB_UTILS_H */

--- a/src/postgres/src/include/storage/proc.h
+++ b/src/postgres/src/include/storage/proc.h
@@ -216,10 +216,10 @@ struct PGPROC
 	 * Metadata for wait events.
 	 */
 	int64 queryid;
-	char	remote_host[32];
+	char	remote_host[100];
 	int		remote_port;
-	char	node_uuid[32];
-	char	top_level_request_id[32];
+	char	node_uuid[100];
+	char	top_level_request_id[100];
 };
 
 /* NOTE: "typedef struct PGPROC PGPROC" appears in storage/lock.h. */

--- a/src/postgres/src/include/storage/proc.h
+++ b/src/postgres/src/include/storage/proc.h
@@ -211,6 +211,15 @@ struct PGPROC
 	 * pg_buffercache extension locks all buffer partitions simultaneously.
 	 */
 	bool 		ybAnyLockAcquired;
+
+	/*
+	 * Metadata for wait events.
+	 */
+	int64 queryid;
+	char	remote_host[32];
+	int		remote_port;
+	char	node_uuid[32];
+	char	top_level_request_id[32];
 };
 
 /* NOTE: "typedef struct PGPROC PGPROC" appears in storage/lock.h. */

--- a/src/yb/yql/pggate/pg_session.cc
+++ b/src/yb/yql/pggate/pg_session.cc
@@ -911,6 +911,7 @@ Status PgSession::SetAUHMetadata(const char* remote_host, int remote_port) {
   client_node_ip_ = remote_host;
   client_node_ip_ += ":";
   client_node_ip_ += std::to_string(remote_port);
+  pg_callbacks_.ProcSetNodeUUID(node_uuid_.c_str());
   return Status::OK();
 }
 
@@ -920,6 +921,7 @@ void PgSession::SetQueryId(uint64_t query_id) {
 
 void PgSession::SetTopLevelRequestId() {
   top_level_request_id_ = GenerateObjectId();
+  pg_callbacks_.ProcSetTopRequestId(top_level_request_id_.c_str());
 }
 
 }  // namespace pggate

--- a/src/yb/yql/pggate/ybc_pg_typedefs.h
+++ b/src/yb/yql/pggate/ybc_pg_typedefs.h
@@ -342,6 +342,8 @@ typedef struct PgCallbacks {
   void (*WriteExecOutParam)(PgExecOutParam *, const YbcPgExecOutParamValue *);
   void (*SignalWaitStart)(uint32_t);
   void (*SignalWaitEnd)();
+  void (*ProcSetNodeUUID)(const char *);
+  void (*ProcSetTopRequestId)(const char*);
 } YBCPgCallbacks;
 
 typedef struct PgGFlagsAccessor {

--- a/src/yb/yql/pgwrapper/ysql_migrations/V39_22222_add_wait_event_info.sql
+++ b/src/yb/yql/pgwrapper/ysql_migrations/V39_22222_add_wait_event_info.sql
@@ -1,0 +1,30 @@
+SET LOCAL yb_non_ddl_txn_for_sys_tables_allowed TO true;
+
+SET LOCAL yb_non_ddl_txn_for_sys_tables_allowed TO true;
+
+INSERT INTO pg_catalog.pg_proc (
+  oid, proname, pronamespace, proowner, prolang, procost, prorows, provariadic, protransform,
+  prokind, prosecdef, proleakproof, proisstrict, proretset, provolatile, proparallel, pronargs,
+  pronargdefaults, prorettype, proargtypes, proallargtypes, proargmodes, proargnames,
+  proargdefaults, protrftypes, prosrc, probin, proconfig, proacl
+) VALUES
+  (8061, 'yb_wait_metadata', 11, 10, 12, 1, 0, 0, '-', 'f', false, false, true, false,
+   'v', 's', 0, 0, 2249, 23, '{25,20,20,25,25}', '{o,o,o,o,o}',
+   '{host,port,queryid,node_uuid,top_request_id}',
+   NULL, NULL, 'yb_wait_metadata', NULL, NULL, NULL)
+ON CONFLICT DO NOTHING;
+
+-- Create dependency records for everything we (possibly) created.
+-- Since pg_depend has no OID or unique constraint, using PL/pgSQL instead.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT FROM pg_catalog.pg_depend
+      WHERE refclassid = 1255 AND refobjid = 8019
+  ) THEN
+    INSERT INTO pg_catalog.pg_depend (
+      classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype
+    ) VALUES
+      (0, 0, 0, 1255, 8061, 0, 'p');
+  END IF;
+END $$;


### PR DESCRIPTION
Also add `yb_wait_metadata` fn to list the metadata in the procarray.

```
yugabyte=# select * FROM (pg_stat_get_backend_idset() beid CROSS JOIN yb_wait_metadata(beid)) B;
 beid | remote_host | remote_port |       queryid        |            node_uuid             |          top_request_id
------+-------------+-------------+----------------------+----------------------------------+----------------------------------
    1 |             |             |                    0 |                                  |
    2 |             |             |                    0 |                                  |
    3 | 127.0.0.1   |       57985 | -7867685903730603530 | 57dd688b2ce049f2ab28e31e5d544f38 | 2f5abc82761d4c8b9ec241b75e2329d7
    4 |             |             |                      |                                  |
(4 rows)
```