### PR TITLE
[docs][DOC-64] Auto tablet splitting clarification

### DIFF
--- a/docs/content/preview/architecture/docdb-sharding/tablet-splitting.md
+++ b/docs/content/preview/architecture/docdb-sharding/tablet-splitting.md
@@ -225,7 +225,7 @@ To control automatic tablet splitting, use the `yb-master` [`--enable_automatic_
 
 {{< note title="Note" >}}
 
-Newly-created tables with [range sharding](../../../architecture/docdb-sharding/sharding/#range-sharding) always have one tablet _per table_ unless table partitioning is specified explicitly during table creation.
+Newly-created tables with [range sharding](../../../architecture/docdb-sharding/sharding/#range-sharding) always have one tablet _per cluster_ unless table partitioning is specified explicitly during table creation.
 
 {{< /note >}}
 

--- a/docs/content/preview/architecture/docdb-sharding/tablet-splitting.md
+++ b/docs/content/preview/architecture/docdb-sharding/tablet-splitting.md
@@ -94,7 +94,7 @@ For information on the relevant YCQL API, see the following:
 
 #### Range-sharded tables
 
-In range-sharded YSQL tables, the start and end key for each tablet is not immediately known since this depends on the column type and the intended usage. For example, if the primary key is a `percentage NUMBER` column where the range of values is in the `[0, 100]` range, presplitting on the entire `NUMBER` space would not be effective.
+In range-sharded YSQL tables, the start and end key for each tablet is not immediately known as this depends on the column type and the intended usage. For example, if the primary key is a `percentage NUMBER` column where the range of values is in the `[0, 100]` range, presplitting on the entire `NUMBER` space would not be effective.
 
 For this reason, in order to presplit range-sharded tables, you must explicitly specify the split points, as per the following example:
 
@@ -215,13 +215,20 @@ For details on the architecture design, see [Automatic resharding of data with t
 
 #### Enable automatic tablet splitting
 
-To enable automatic tablet splitting, use the `yb-master` [`--enable_automatic_tablet_splitting`](../../../reference/configuration/yb-master/#enable-automatic-tablet-splitting) flag and specify the associated flags to configure when tablets should split, and use `yb-tserver` [`--enable_automatic_tablet_splitting`](../../../reference/configuration/yb-tserver/#enable-automatic-tablet-splitting). The flag usage must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
+When automatic tablet splitting is enabled, newly-created tables with [hash sharding](../../../architecture/docdb-sharding/sharding/#hash-sharding) have one tablet per node by default.
 
-When automatic tablet splitting is enabled, newly-created tables with [hash sharding](../../../architecture/docdb-sharding/sharding/#hash-sharding) have one shard **per _yb-tserver_** by default; from version `2.14.10` such tables have one shard (for servers with up to 2 CPU cores) or two shards (for servers with up to 4 CPU cores) **per _cluster_** by default.
+The following additional defaults apply:
+
+* From version 2.14.10, for servers with up to 2 CPU cores, newly-created tables have one tablet or, for servers with up to 4 CPU cores, two tablets **per _cluster_** by default.
+* From version 2.18, for servers with up to 2 CPU cores, newly-created tables have one tablet per table, and servers with up to 4 CPU cores have 2 tablets per table.
+
+From version 2.18.0, automatic tablet splitting is turned on by default.
+
+To control automatic tablet splitting, use the `yb-master` [`--enable_automatic_tablet_splitting`](../../../reference/configuration/yb-master/#enable-automatic-tablet-splitting) flag and specify the associated flags to configure when tablets should split, and use `yb-tserver` [`--enable_automatic_tablet_splitting`](../../../reference/configuration/yb-tserver/#enable-automatic-tablet-splitting). The flags must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
 
 {{< note title="Note" >}}
 
-Newly-created tables with [range sharding](../../../architecture/docdb-sharding/sharding/#range-sharding) always have one shard *per cluster* unless table partitioning is specified explicitly during table creation.
+Newly-created tables with [range sharding](../../../architecture/docdb-sharding/sharding/#range-sharding) always have one shard _per cluster_ unless table partitioning is specified explicitly during table creation.
 
 {{< /note >}}
 
@@ -311,7 +318,7 @@ In the following example, a three-node cluster is created and uses a YCSB worklo
 
 ## Limitations
 
-* Tablet splitting is disabled for index tables with range partitioning that are being restored in version `2.14.5` or later from a backup taken in any version prior to `2.14.5`. It is not recommended to use tablet splitting for range partitioned index tables prior to version `2.14.5` to prevent possible data loss for index tables. For details, see [#12190](https://github.com/yugabyte/yugabyte-db/issues/12190) and [#17169](https://github.com/yugabyte/yugabyte-db/issues/17169).
+* Tablet splitting is disabled for index tables with range partitioning that are being restored in version 2.14.5 or later from a backup taken in any version prior to 2.14.5. It is not recommended to use tablet splitting for range partitioned index tables prior to version 2.14.5 to prevent possible data loss for index tables. For details, see [#12190](https://github.com/yugabyte/yugabyte-db/issues/12190) and [#17169](https://github.com/yugabyte/yugabyte-db/issues/17169).
 
 The following known limitations are planned to be resolved in upcoming releases:
 

--- a/docs/content/preview/architecture/docdb-sharding/tablet-splitting.md
+++ b/docs/content/preview/architecture/docdb-sharding/tablet-splitting.md
@@ -217,7 +217,7 @@ For details on the architecture design, see [Automatic resharding of data with t
 
 When automatic tablet splitting is enabled, newly-created tables with [hash sharding](../../../architecture/docdb-sharding/sharding/#hash-sharding) have one tablet per node by default.
 
-In addition, from version 2.14.10, for servers with up to 2 CPU cores, newly-created tables have one tablet per table, and servers with up to 4 CPU cores have 2 tablets per table.
+In addition, from version 2.14.10, for servers with up to 2 CPU cores, newly-created tables have one tablet per cluster, and servers with up to 4 CPU cores have 2 tablets per cluster.
 
 From version 2.18.0, automatic tablet splitting is turned on by default.
 

--- a/docs/content/preview/architecture/docdb-sharding/tablet-splitting.md
+++ b/docs/content/preview/architecture/docdb-sharding/tablet-splitting.md
@@ -160,7 +160,7 @@ Note that misuse or overuse of manual tablet splitting (for example, splitting t
 
 #### Verify the table has one tablet
 
-In order to verify that the table `t` has only one tablet, list all the tablets for table `t` using the following [`yb-admin list_tablets`](../../../admin/yb-admin/#list-tablets) command:
+To verify that the table `t` has only one tablet, list all the tablets for table `t` using the following [`yb-admin list_tablets`](../../../admin/yb-admin/#list-tablets) command:
 
 ```bash
 ./bin/yb-admin --master_addresses 127.0.0.1:7100 list_tablets ysql.yugabyte t
@@ -217,10 +217,7 @@ For details on the architecture design, see [Automatic resharding of data with t
 
 When automatic tablet splitting is enabled, newly-created tables with [hash sharding](../../../architecture/docdb-sharding/sharding/#hash-sharding) have one tablet per node by default.
 
-The following additional defaults apply:
-
-* From version 2.14.10, for servers with up to 2 CPU cores, newly-created tables have one tablet or, for servers with up to 4 CPU cores, two tablets **per _cluster_** by default.
-* From version 2.18, for servers with up to 2 CPU cores, newly-created tables have one tablet per table, and servers with up to 4 CPU cores have 2 tablets per table.
+In addition, from version 2.14.10, for servers with up to 2 CPU cores, newly-created tables have one tablet per table, and servers with up to 4 CPU cores have 2 tablets per table.
 
 From version 2.18.0, automatic tablet splitting is turned on by default.
 
@@ -228,7 +225,7 @@ To control automatic tablet splitting, use the `yb-master` [`--enable_automatic_
 
 {{< note title="Note" >}}
 
-Newly-created tables with [range sharding](../../../architecture/docdb-sharding/sharding/#range-sharding) always have one shard _per cluster_ unless table partitioning is specified explicitly during table creation.
+Newly-created tables with [range sharding](../../../architecture/docdb-sharding/sharding/#range-sharding) always have one tablet _per table_ unless table partitioning is specified explicitly during table creation.
 
 {{< /note >}}
 
@@ -244,7 +241,7 @@ In the high phase, each node has fewer than [`tablet_split_high_phase_shard_coun
 
 ##### Final phase
 
-Once the shard count exceeds the high phase count (determined by `tablet_split_high_phase_shard_count_per_node`, 24 by default), YugabyteDB splits tablets larger than [`tablet_force_split_threshold_bytes`](../../../reference/configuration/yb-master/#tablet-force-split-threshold-bytes) (100 GB by default). This will continue until the [`tablet_split_limit_per_table`](../../../reference/configuration/yb-master/#tablet-split-limit-per-table) tablets per table limit is reached (256 tablets by default; if set to 0, there will be no limit).
+When the shard count exceeds the high phase count (determined by `tablet_split_high_phase_shard_count_per_node`, 24 by default), YugabyteDB splits tablets larger than [`tablet_force_split_threshold_bytes`](../../../reference/configuration/yb-master/#tablet-force-split-threshold-bytes) (100 GB by default). This will continue until the [`tablet_split_limit_per_table`](../../../reference/configuration/yb-master/#tablet-split-limit-per-table) tablets per table limit is reached (256 tablets by default; if set to 0, there will be no limit).
 
 #### Post-split compactions
 
@@ -252,13 +249,13 @@ Once a split has been executed on a tablet, the two resulting tablets require a 
 
 In the event that performance suffers due to automatic tablet splitting, the following flags can be used for tuning:
 
-- [YB-Master flags](../../../reference/configuration/yb-master/#tablet-splitting-flags):
-  - `outstanding_tablet_split_limit` limits the total number of outstanding tablet splits to 1 by default. Tablets that are performing post-split compactions count against this limit.
-  - `outstanding_tablet_split_limit_per_tserver` limits the total number of outstanding tablet splits per node to 1 by default. Tablets that are performing post-split compactions count against this limit.
-- [YB-TServer flags](../../../reference/configuration/yb-tserver/#sharding-flags):
-  - `post_split_trigger_compaction_pool_max_threads` indicates the number of threads dedicated to post-split compaction tasks per node. By default, this is limited to 1. Increasing this may complete tablet splits faster, but would require more CPU and disk resources.
-  - `post_split_trigger_compaction_pool_max_queue_size` indicates the number of outstanding post-split compaction tasks that can be queued at once per node, limited to 16 by default.
-  - `automatic_compaction_extra_priority` provides additional compaction priorities to [smaller compactions](../../concepts/yb-tserver/#small-and-large-compaction-queues) when automatic tablet splitting is enabled. This prevents smaller compactions from being starved for resources by the larger post-split compactions. This is set to 50 by default (the maximum recommended), and can be reduced to 0.
+* [YB-Master flags](../../../reference/configuration/yb-master/#tablet-splitting-flags):
+  * `outstanding_tablet_split_limit` limits the total number of outstanding tablet splits to 1 by default. Tablets that are performing post-split compactions count against this limit.
+  * `outstanding_tablet_split_limit_per_tserver` limits the total number of outstanding tablet splits per node to 1 by default. Tablets that are performing post-split compactions count against this limit.
+* [YB-TServer flags](../../../reference/configuration/yb-tserver/#sharding-flags):
+  * `post_split_trigger_compaction_pool_max_threads` indicates the number of threads dedicated to post-split compaction tasks per node. By default, this is limited to 1. Increasing this may complete tablet splits faster, but would require more CPU and disk resources.
+  * `post_split_trigger_compaction_pool_max_queue_size` indicates the number of outstanding post-split compaction tasks that can be queued at once per node, limited to 16 by default.
+  * `automatic_compaction_extra_priority` provides additional compaction priorities to [smaller compactions](../../concepts/yb-tserver/#small-and-large-compaction-queues) when automatic tablet splitting is enabled. This prevents smaller compactions from being starved for resources by the larger post-split compactions. This is set to 50 by default (the maximum recommended), and can be reduced to 0.
 
 #### YCSB workload with automatic tablet splitting example
 

--- a/docs/content/preview/explore/linear-scalability/sharding-data.md
+++ b/docs/content/preview/explore/linear-scalability/sharding-data.md
@@ -160,7 +160,7 @@ To create a universe, do the following:
 
     `memstore_size_mb=1` sets the total size of memstores on the tablet-servers to `1MB`. This forces a flush of the data to disk when a value greater than 1MB is added, allowing you to observe to which tablets the data is written.
 
-1. Add two more nodes to make this a 3-node by joining them with the previous node. (If you are running on macOS, first [configure loopback addresses](../../../reference/configuration/yugabyted/#running-on-macos).) You need to pass the `memstore_size` flag to each of the added YB-TServer servers, as follows:
+1. Add two more nodes to make this a 3-node by joining them with the previous node. You need to pass the `memstore_size` flag to each of the added YB-TServer servers, as follows:
 
     ```sh
     ./bin/yugabyted start \

--- a/docs/content/preview/explore/linear-scalability/sharding-data.md
+++ b/docs/content/preview/explore/linear-scalability/sharding-data.md
@@ -40,7 +40,7 @@ The primary key for each row in the table uniquely identifies the location of th
 
 ![Sharding a table into tablets](/images/architecture/partitioning-table-into-tablets.png)
 
-By default, YugabyteDB creates eight tablets per node in the universe for each table and automatically distributes the data across various tablets, which in turn are distributed evenly across the nodes. In the [Examples](#Examples), you explore how automatic sharding is done internally for tables. The system Redis table works in exactly the same way.
+By default, YugabyteDB creates one tablet per node in the universe for each table and automatically distributes the data across them. In the [Examples](#Examples), you explore how automatic sharding is done internally for tables. The system Redis table works in exactly the same way.
 
 ## Sharding strategies
 
@@ -160,7 +160,7 @@ To create a universe, do the following:
 
     `memstore_size_mb=1` sets the total size of memstores on the tablet-servers to `1MB`. This forces a flush of the data to disk when a value greater than 1MB is added, allowing you to observe to which tablets the data is written.
 
-1. Add two more nodes to make this a 3-node by joining them with the previous node. You need to pass the `memstore_size` flag to each of the added YB-TServer servers, as follows:
+1. Add two more nodes to make this a 3-node by joining them with the previous node. (If you are running on macOS, first [configure loopback addresses](../../../reference/configuration/yugabyted/#running-on-macos).) You need to pass the `memstore_size` flag to each of the added YB-TServer servers, as follows:
 
     ```sh
     ./bin/yugabyted start \

--- a/docs/content/preview/reference/configuration/yb-master.md
+++ b/docs/content/preview/reference/configuration/yb-master.md
@@ -464,8 +464,9 @@ Default: `-1`, where the number of shards is determined at runtime, as follows:
   - For servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
 
 - If `enable_automatic_tablet_splitting` is `false`
-  - For servers with up to two CPU cores, the default value is considered as `4`.
-  - For three or more CPU cores, the default value is considered as `8`.
+  - For servers with up to two CPU cores, the default value is considered as `2`.
+  - For servers with three or four CPU cores, the default value is considered as `4`.
+  - Beyond four cores, the default value is considered as `8`.
 
 Local cluster installations created using `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
 

--- a/docs/content/preview/reference/configuration/yb-master.md
+++ b/docs/content/preview/reference/configuration/yb-master.md
@@ -429,50 +429,52 @@ Default: `3`
 
 ##### --yb_num_shards_per_tserver
 
-The number of shards per YB-TServer for each YCQL table when a user table is created.
+The number of shards (tablets) per YB-TServer for each YCQL table when a user table is created.
 
-Default: `-1` (the value based on the CPU cores is calculated at runtime).
-\
-For servers with up to two CPU cores, the default value is considered as `4`.
-\
-For three or more CPU cores, the default value is considered as `8`.
-\
-If [`enable_automatic_tablet_splitting`](#enable-automatic-tablet-splitting) is `true`, then the default value is considered as `1` and tables will begin with 1 tablet *per node*; for version `2.18` and later, for servers with up to 4 CPU cores, the value *is not defined* and tables will begin with 1 tablet (for servers with up to 2 CPU cores), or 2 tablets (for servers with up to 4 CPU cores) *per cluster*.
+Default: `-1`, where the number of shards is determined at runtime, as follows:
 
-Local cluster installations created with `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
-\
-Clusters created with `yugabyted` always use a default value of `1`.
+- If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`
+  - The default value is considered as `1`.
+  - For servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
+
+- If `enable_automatic_tablet_splitting` is `false`
+  - For servers with up to two CPU cores, the default value is considered as `4`.
+  - For three or more CPU cores, the default value is considered as `8`.
+
+Local cluster installations created using `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
+
+Clusters created using `yugabyted` always use a default value of `1`.
 
 {{< note title="Note" >}}
 
 - This value must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
-- If the value is set to *Default* (`-1`), then the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version `2.18` and the flag remains *unchanged* starting from version `2.18`.
+- If the value is set to *Default* (`-1`), then the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version 2.18 and the flag remains *unchanged* starting from version 2.18.
 - The [`CREATE TABLE ... WITH TABLETS = <num>`](../../../api/ycql/ddl_create_table/#create-a-table-specifying-the-number-of-tablets) clause can be used on a per-table basis to override the `yb_num_shards_per_tserver` value.
 
 {{< /note >}}
 
 ##### --ysql_num_shards_per_tserver
 
-The number of shards per YB-TServer for each YSQL table when a user table is created.
+The number of shards (tablets) per YB-TServer for each YSQL table when a user table is created.
 
-Default: `-1` (the value based on the CPU cores is calculated at runtime).
-\
-For servers with up to two CPU cores, the default value is considered as `2`.
-\
-For servers with three or four CPU cores, the default value is considered as `4`.
-\
-Beyond four cores, the default value is considered as `8`.
-\
-If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`, then the default value is *considered* as `1` and tables will begin with 1 tablet *per node*; for versions `2.18`and later, for servers with up to 4 CPU cores, the value *is not defined* and tables will begin with 1 tablet (for servers with up to 2 CPU cores), or 2 tablets (for servers with up to 4 CPU cores) *per cluster*.
+Default: `-1`, where the number of shards is determined at runtime, as follows:
 
-Local cluster installations created with `yb-ctl` and `yb-docker-ctl` use a default value of `2`.
-\
-Clusters created with `yugabyted` always use a default value of `1`.
+- If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`
+  - The default value is considered as `1`.
+  - For servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
+
+- If `enable_automatic_tablet_splitting` is `false`
+  - For servers with up to two CPU cores, the default value is considered as `4`.
+  - For three or more CPU cores, the default value is considered as `8`.
+
+Local cluster installations created using `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
+
+Clusters created using `yugabyted` always use a default value of `1`.
 
 {{< note title="Note" >}}
 
 - This value must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
-- If the value is set to *Default* (`-1`), the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version `2.18.0` and the flag remains *unchanged* starting from version `2.18.0`.
+- If the value is set to *Default* (`-1`), the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version 2.18 and the flag remains *unchanged* starting from version 2.18.
 - The [`CREATE TABLE ...SPLIT INTO`](../../../api/ysql/the-sql-language/statements/ddl_create_table/#split-into) clause can be used on a per-table basis to override the `ysql_num_shards_per_tserver` value.
 
 {{< /note >}}

--- a/docs/content/preview/reference/configuration/yb-tserver.md
+++ b/docs/content/preview/reference/configuration/yb-tserver.md
@@ -317,14 +317,15 @@ Default: The default value in `2.18.1` is `-1` - feature is disabled by default.
 
 The number of shards per YB-TServer for each YCQL table when a user table is created.
 
-Default: `-1`, where the number of shards is calculated at runtime, as follows:
+Default: `-1`, where the number of shards is determined at runtime, as follows:
 
-- If [`enable_automatic_tablet_splitting`](#enable-automatic-tablet-splitting) is `false`
+- If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`
+  - The default value is considered as `1`.
+  - In version 2.18 and later, for servers with 4 CPU cores or less, the number of tablets per table doesn't depend on the number of YB-TServers. Instead, only 1 tablet per table is created for 2 CPU cores or less, and 2 tablets per table are created for 4 CPU cores or less.
+
+- If `enable_automatic_tablet_splitting` is `false`
   - For servers with up to two CPU cores, the default value is considered as `4`.
   - For three or more CPU cores, the default value is considered as `8`.
-- If [`enable_automatic_tablet_splitting`](#enable-automatic-tablet-splitting) is `true`
-  - The default value is considered as `1` and tables begin with 1 tablet *per node*.
-  - In version 2.18 and later, for servers with 4 CPU cores or less, the number of tablets per table doesn't depend on the number of YB-TServers. Instead, only 1 tablet per table is created for 2 CPU cores or less, and 2 tablets per table are created for 4 CPU cores or less.
 
 Local cluster installations created using `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
 
@@ -804,7 +805,12 @@ Default: `4`
 
 Maximum number of threads to do background compactions (used when compactions need to catch up.) Unless `rocksdb_disable_compactions=true`, this cannot be set to zero.
 
-Default: `-1` (the value is calculated at runtime). For servers with up to 4 CPU cores, the default value is considered as `1`. For servers with up to 8 CPU cores, the default value is considered as `2`. For servers with up to 32 CPU cores, the default value is considered as `3`. Beyond 32 cores, the default value is considered as `4`.
+Default: `-1`, where the value is calculated at runtime as follows:
+
+- For servers with up to 4 CPU cores, the default value is considered as `1`.
+- For servers with up to 8 CPU cores, the default value is considered as `2`.
+- For servers with up to 32 CPU cores, the default value is considered as `3`.
+- Beyond 32 cores, the default value is considered as `4`.
 
 ##### --rocksdb_compaction_size_threshold_bytes
 

--- a/docs/content/preview/reference/configuration/yb-tserver.md
+++ b/docs/content/preview/reference/configuration/yb-tserver.md
@@ -321,7 +321,7 @@ Default: `-1`, where the number of shards is determined at runtime, as follows:
 
 - If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`
   - The default value is considered as `1`.
-  - In version 2.18 and later, for servers with 4 CPU cores or less, the number of tablets per table doesn't depend on the number of YB-TServers. Instead, only 1 tablet per table is created for 2 CPU cores or less, and 2 tablets per table are created for 4 CPU cores or less.
+  - For servers with 4 CPU cores or less, the number of tablets per table doesn't depend on the number of YB-TServers. Instead, only 1 tablet per table is created for 2 CPU cores or less, and 2 tablets per table are created for 4 CPU cores or less.
 
 - If `enable_automatic_tablet_splitting` is `false`
   - For servers with up to two CPU cores, the default value is considered as `4`.
@@ -343,19 +343,19 @@ Clusters created using `yugabyted` always use a default value of `1`.
 
 The number of shards per YB-TServer for each YSQL table when a user table is created.
 
-Default: `-1` (the value based on the CPU cores is calculated at runtime).
-\
-For servers with up to two CPU cores, the default value is considered as `2`.
-\
-For servers with three or four CPU cores, the default value is considered as `4`.
-\
-Beyond four cores, the default value is considered as `8`.
-\
-If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`, then the default value is *considered* as `1` and tables will begin with 1 tablet *per node*; for versions `2.18` and later, for servers with up to 4 CPU cores, the value *is not defined* and tables will begin with 1 tablet (for servers with up to 2 CPU cores), or 2 tablets (for servers with up to 4 CPU cores) *per cluster*.
+Default: `-1`, where the number of shards is determined at runtime, as follows:
 
-Local cluster installations created with `yb-ctl` and `yb-docker-ctl` use a default value of `2`.
-\
-Clusters created with `yugabyted` always use a default value of `1`.
+- If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`
+  - The default value is considered as `1`.
+  - For servers with 4 CPU cores or less, the number of tablets per table doesn't depend on the number of YB-TServers. Instead, only 1 tablet per table is created for 2 CPU cores or less, and 2 tablets per table are created for 4 CPU cores or less.
+
+- If `enable_automatic_tablet_splitting` is `false`
+  - For servers with up to two CPU cores, the default value is considered as `4`.
+  - For three or more CPU cores, the default value is considered as `8`.
+
+Local cluster installations created using `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
+
+Clusters created using `yugabyted` always use a default value of `1`.
 
 {{< note title="Note" >}}
 

--- a/docs/content/preview/reference/configuration/yb-tserver.md
+++ b/docs/content/preview/reference/configuration/yb-tserver.md
@@ -317,22 +317,23 @@ Default: The default value in `2.18.1` is `-1` - feature is disabled by default.
 
 The number of shards per YB-TServer for each YCQL table when a user table is created.
 
-Default: `-1` (the value based on the CPU cores is calculated at runtime).
-\
-For servers with up to two CPU cores, the default value is considered as `4`.
-\
-For three or more CPU cores, the default value is considered as `8`.
-\
-If [`enable_automatic_tablet_splitting`](#enable-automatic-tablet-splitting) is `true`, then the default value is considered as `1` and tables will begin with 1 tablet *per node*; for version `2.18` and later, for servers with up to 4 CPU cores, the value *is not defined* and tables will begin with 1 tablet (for servers with up to 2 CPU cores), or 2 tablets (for servers with up to 4 CPU cores) *per cluster*.
+Default: `-1`, where the number of shards is calculated at runtime, as follows:
 
-Local cluster installations created with `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
-\
-Clusters created with `yugabyted` always use a default value of `1`.
+- If [`enable_automatic_tablet_splitting`](#enable-automatic-tablet-splitting) is `false`
+  - For servers with up to two CPU cores, the default value is considered as `4`.
+  - For three or more CPU cores, the default value is considered as `8`.
+- If [`enable_automatic_tablet_splitting`](#enable-automatic-tablet-splitting) is `true`
+  - The default value is considered as `1` and tables begin with 1 tablet *per node*.
+  - In version 2.18 and later, for servers with 4 CPU cores or less, the number of tablets per table doesn't depend on the number of YB-TServers. Instead, only 1 tablet per table is created for 2 CPU cores or less, and 2 tablets per table are created for 4 CPU cores or less.
+
+Local cluster installations created using `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
+
+Clusters created using `yugabyted` always use a default value of `1`.
 
 {{< note title="Note" >}}
 
 - This value must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
-- If the value is set to *Default* (`-1`), then the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version `2.18` and the flag remains *unchanged* starting from version `2.18`.
+- If the value is set to *Default* (`-1`), then the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version 2.18 and the flag remains *unchanged* starting from version 2.18.
 - The [`CREATE TABLE ... WITH TABLETS = <num>`](../../../api/ycql/ddl_create_table/#create-a-table-specifying-the-number-of-tablets) clause can be used on a per-table basis to override the `yb_num_shards_per_tserver` value.
 
 {{< /note >}}

--- a/docs/content/preview/reference/configuration/yb-tserver.md
+++ b/docs/content/preview/reference/configuration/yb-tserver.md
@@ -360,7 +360,7 @@ Clusters created using `yugabyted` always use a default value of `1`.
 {{< note title="Note" >}}
 
 - This value must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
-- If the value is set to *Default* (`-1`), the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version `2.18.0` and the flag remains *unchanged* starting from version `2.18.0`.
+- If the value is set to *Default* (`-1`), the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version 2.18 and the flag remains *unchanged* starting from version 2.18.
 - The [`CREATE TABLE ...SPLIT INTO`](../../../api/ysql/the-sql-language/statements/ddl_create_table/#split-into) clause can be used on a per-table basis to override the `ysql_num_shards_per_tserver` value.
 
 {{< /note >}}

--- a/docs/content/preview/reference/configuration/yb-tserver.md
+++ b/docs/content/preview/reference/configuration/yb-tserver.md
@@ -350,8 +350,9 @@ Default: `-1`, where the number of shards is determined at runtime, as follows:
   - For servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
 
 - If `enable_automatic_tablet_splitting` is `false`
-  - For servers with up to two CPU cores, the default value is considered as `4`.
-  - For three or more CPU cores, the default value is considered as `8`.
+  - For servers with up to two CPU cores, the default value is considered as `2`.
+  - For servers with three or four CPU cores, the default value is considered as `4`.
+  - Beyond four cores, the default value is considered as `8`.
 
 Local cluster installations created using `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
 

--- a/docs/content/preview/reference/configuration/yb-tserver.md
+++ b/docs/content/preview/reference/configuration/yb-tserver.md
@@ -315,13 +315,13 @@ Default: The default value in `2.18.1` is `-1` - feature is disabled by default.
 
 ##### --yb_num_shards_per_tserver
 
-The number of shards per YB-TServer for each YCQL table when a user table is created.
+The number of shards (tablets) per YB-TServer for each YCQL table when a user table is created.
 
 Default: `-1`, where the number of shards is determined at runtime, as follows:
 
 - If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`
   - The default value is considered as `1`.
-  - For servers with 4 CPU cores or less, the number of tablets per table doesn't depend on the number of YB-TServers. Instead, only 1 tablet per table is created for 2 CPU cores or less, and 2 tablets per table are created for 4 CPU cores or less.
+  - For servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
 
 - If `enable_automatic_tablet_splitting` is `false`
   - For servers with up to two CPU cores, the default value is considered as `4`.
@@ -341,13 +341,13 @@ Clusters created using `yugabyted` always use a default value of `1`.
 
 ##### --ysql_num_shards_per_tserver
 
-The number of shards per YB-TServer for each YSQL table when a user table is created.
+The number of shards (tablets) per YB-TServer for each YSQL table when a user table is created.
 
 Default: `-1`, where the number of shards is determined at runtime, as follows:
 
 - If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`
   - The default value is considered as `1`.
-  - For servers with 4 CPU cores or less, the number of tablets per table doesn't depend on the number of YB-TServers. Instead, only 1 tablet per table is created for 2 CPU cores or less, and 2 tablets per table are created for 4 CPU cores or less.
+  - For servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
 
 - If `enable_automatic_tablet_splitting` is `false`
   - For servers with up to two CPU cores, the default value is considered as `4`.

--- a/docs/content/preview/reference/configuration/yugabyted.md
+++ b/docs/content/preview/reference/configuration/yugabyted.md
@@ -23,18 +23,6 @@ For examples of using yugabyted to deploy single- and multi-node clusters, see [
 Note that yugabyted is not recommended for production deployments. For production deployments with fully-distributed multi-node clusters, use [`yb-tserver`](../yb-tserver/) and [`yb-master`](../yb-master/) directly. Refer to [Deploy YugabyteDB](../../../deploy).
 {{</note>}}
 
-{{% note title="macOS Monterey" %}}
-
-macOS Monterey enables AirPlay receiving by default, which listens on port 7000. This conflicts with YugabyteDB and causes `yugabyted start` to fail. Use the [--master_webserver_port flag](#advanced-flags) when you start the cluster to change the default port number, as follows:
-
-```sh
-./bin/yugabyted start --master_webserver_port=9999
-```
-
-Alternatively, you can disable AirPlay receiving, then start YugabyteDB normally, and then, optionally, re-enable AirPlay receiving.
-
-{{% /note %}}
-
 ## Syntax
 
 ```sh
@@ -680,6 +668,27 @@ The following are combinations of environment variables and their uses:
 ## Examples
 
 To deploy any type of secure cluster (that is, using the `--secure` flag) or use encryption at rest, OpenSSL must be installed on your machine.
+
+### Running on macOS
+
+macOS Monterey enables AirPlay receiving by default, which listens on port 7000. This conflicts with YugabyteDB and causes `yugabyted start` to fail. Use the [--master_webserver_port flag](#advanced-flags) when you start the cluster to change the default port number, as follows:
+
+```sh
+./bin/yugabyted start --master_webserver_port=9999
+```
+
+Alternatively, you can disable AirPlay receiving, then start YugabyteDB normally, and then, optionally, re-enable AirPlay receiving.
+
+#### Loopback addresses
+
+On macOS, every additional node after the first needs a loopback address configured to simulate the use of multiple hosts or nodes. For example, for a three-node cluster, you add two additional addresses as follows:
+
+```sh
+sudo ifconfig lo0 alias 127.0.0.2
+sudo ifconfig lo0 alias 127.0.0.3
+```
+
+The loopback addresses do not persist upon rebooting your computer.
 
 ### Destroy a local cluster
 

--- a/docs/content/preview/reference/configuration/yugabyted.md
+++ b/docs/content/preview/reference/configuration/yugabyted.md
@@ -23,6 +23,18 @@ For examples of using yugabyted to deploy single- and multi-node clusters, see [
 Note that yugabyted is not recommended for production deployments. For production deployments with fully-distributed multi-node clusters, use [`yb-tserver`](../yb-tserver/) and [`yb-master`](../yb-master/) directly. Refer to [Deploy YugabyteDB](../../../deploy).
 {{</note>}}
 
+{{% note title="macOS Monterey" %}}
+
+macOS Monterey enables AirPlay receiving by default, which listens on port 7000. This conflicts with YugabyteDB and causes `yugabyted start` to fail. Use the [--master_webserver_port flag](#advanced-flags) when you start the cluster to change the default port number, as follows:
+
+```sh
+./bin/yugabyted start --master_webserver_port=9999
+```
+
+Alternatively, you can disable AirPlay receiving, then start YugabyteDB normally, and then, optionally, re-enable AirPlay receiving.
+
+{{% /note %}}
+
 ## Syntax
 
 ```sh

--- a/docs/content/preview/reference/configuration/yugabyted.md
+++ b/docs/content/preview/reference/configuration/yugabyted.md
@@ -669,27 +669,6 @@ The following are combinations of environment variables and their uses:
 
 To deploy any type of secure cluster (that is, using the `--secure` flag) or use encryption at rest, OpenSSL must be installed on your machine.
 
-### Running on macOS
-
-macOS Monterey enables AirPlay receiving by default, which listens on port 7000. This conflicts with YugabyteDB and causes `yugabyted start` to fail. Use the [--master_webserver_port flag](#advanced-flags) when you start the cluster to change the default port number, as follows:
-
-```sh
-./bin/yugabyted start --master_webserver_port=9999
-```
-
-Alternatively, you can disable AirPlay receiving, then start YugabyteDB normally, and then, optionally, re-enable AirPlay receiving.
-
-#### Loopback addresses
-
-On macOS, every additional node after the first needs a loopback address configured to simulate the use of multiple hosts or nodes. For example, for a three-node cluster, you add two additional addresses as follows:
-
-```sh
-sudo ifconfig lo0 alias 127.0.0.2
-sudo ifconfig lo0 alias 127.0.0.3
-```
-
-The loopback addresses do not persist upon rebooting your computer.
-
 ### Destroy a local cluster
 
 If you are running YugabyteDB on your local computer, you can't run more than one cluster at a time. To set up a new local YugabyteDB cluster using yugabyted, first destroy the currently running cluster.

--- a/docs/content/stable/architecture/docdb-sharding/tablet-splitting.md
+++ b/docs/content/stable/architecture/docdb-sharding/tablet-splitting.md
@@ -215,13 +215,17 @@ For details on the architecture design, see [Automatic resharding of data with t
 
 #### Enable automatic tablet splitting
 
-Automatic tablet splitting is enabled by default starting from version `2.18`.
+When automatic tablet splitting is enabled, newly-created tables with [hash sharding](../../../architecture/docdb-sharding/sharding/#hash-sharding) have one tablet per node by default.
 
-When automatic tablet splitting is enabled, newly-created tables with [hash sharding](../../../architecture/docdb-sharding/sharding/#hash-sharding) have one shard **per _yb-tserver_** by default; from version `2.14.10` such tables have one shard (for servers with up to 2 CPU cores) or two shards (for servers with up to 4 CPU cores) **per _cluster_** by default.
+In addition, from version 2.14.10, for servers with up to 2 CPU cores, newly-created tables have one tablet per cluster, and servers with up to 4 CPU cores have 2 tablets per cluster.
+
+From version 2.18.0, automatic tablet splitting is turned on by default.
+
+To control automatic tablet splitting, use the `yb-master` [`--enable_automatic_tablet_splitting`](../../../reference/configuration/yb-master/#enable-automatic-tablet-splitting) flag and specify the associated flags to configure when tablets should split, and use `yb-tserver` [`--enable_automatic_tablet_splitting`](../../../reference/configuration/yb-tserver/#enable-automatic-tablet-splitting). The flags must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
 
 {{< note title="Note" >}}
 
-Newly-created tables with [range sharding](../../../architecture/docdb-sharding/sharding/#range-sharding) always have one shard *per cluster* unless table partitioning is specified explicitly during table creation.
+Newly-created tables with [range sharding](../../../architecture/docdb-sharding/sharding/#range-sharding) always have one tablet _per cluster_ unless table partitioning is specified explicitly during table creation.
 
 {{< /note >}}
 
@@ -237,7 +241,7 @@ In the high phase, each node has fewer than [`tablet_split_high_phase_shard_coun
 
 ##### Final phase
 
-Once the shard count exceeds the high phase count (determined by `tablet_split_high_phase_shard_count_per_node`, 24 by default), YugabyteDB splits tablets larger than [`tablet_force_split_threshold_bytes`](../../../reference/configuration/yb-master/#tablet-force-split-threshold-bytes) (100 GB by default). This will continue until the [`tablet_split_limit_per_table`](../../../reference/configuration/yb-master/#tablet-split-limit-per-table) tablets per table limit is reached (256 tablets by default; if set to 0, there will be no limit).
+When the shard count exceeds the high phase count (determined by `tablet_split_high_phase_shard_count_per_node`, 24 by default), YugabyteDB splits tablets larger than [`tablet_force_split_threshold_bytes`](../../../reference/configuration/yb-master/#tablet-force-split-threshold-bytes) (100 GB by default). This will continue until the [`tablet_split_limit_per_table`](../../../reference/configuration/yb-master/#tablet-split-limit-per-table) tablets per table limit is reached (256 tablets by default; if set to 0, there will be no limit).
 
 #### Post-split compactions
 
@@ -245,13 +249,13 @@ Once a split has been executed on a tablet, the two resulting tablets require a 
 
 In the event that performance suffers due to automatic tablet splitting, the following flags can be used for tuning:
 
-- [YB-Master flags](../../../reference/configuration/yb-master/#tablet-splitting-flags):
-  - `outstanding_tablet_split_limit` limits the total number of outstanding tablet splits to 1 by default. Tablets that are performing post-split compactions count against this limit.
-  - `outstanding_tablet_split_limit_per_tserver` limits the total number of outstanding tablet splits per node to 1 by default. Tablets that are performing post-split compactions count against this limit.
-- [YB-TServer flags](../../../reference/configuration/yb-tserver/#sharding-flags):
-  - `post_split_trigger_compaction_pool_max_threads` indicates the number of threads dedicated to post-split compaction tasks per node. By default, this is limited to 1. Increasing this may complete tablet splits faster, but would require more CPU and disk resources.
-  - `post_split_trigger_compaction_pool_max_queue_size` indicates the number of outstanding post-split compaction tasks that can be queued at once per node, limited to 16 by default.
-  - `automatic_compaction_extra_priority` provides additional compaction priorities to [smaller compactions](../../concepts/yb-tserver/#small-and-large-compaction-queues) when automatic tablet splitting is enabled. This prevents smaller compactions from being starved for resources by the larger post-split compactions. This is set to 50 by default (the maximum recommended), and can be reduced to 0.
+* [YB-Master flags](../../../reference/configuration/yb-master/#tablet-splitting-flags):
+  * `outstanding_tablet_split_limit` limits the total number of outstanding tablet splits to 1 by default. Tablets that are performing post-split compactions count against this limit.
+  * `outstanding_tablet_split_limit_per_tserver` limits the total number of outstanding tablet splits per node to 1 by default. Tablets that are performing post-split compactions count against this limit.
+* [YB-TServer flags](../../../reference/configuration/yb-tserver/#sharding-flags):
+  * `post_split_trigger_compaction_pool_max_threads` indicates the number of threads dedicated to post-split compaction tasks per node. By default, this is limited to 1. Increasing this may complete tablet splits faster, but would require more CPU and disk resources.
+  * `post_split_trigger_compaction_pool_max_queue_size` indicates the number of outstanding post-split compaction tasks that can be queued at once per node, limited to 16 by default.
+  * `automatic_compaction_extra_priority` provides additional compaction priorities to [smaller compactions](../../concepts/yb-tserver/#small-and-large-compaction-queues) when automatic tablet splitting is enabled. This prevents smaller compactions from being starved for resources by the larger post-split compactions. This is set to 50 by default (the maximum recommended), and can be reduced to 0.
 
 #### YCSB workload with automatic tablet splitting example
 

--- a/docs/content/stable/explore/linear-scalability/sharding-data.md
+++ b/docs/content/stable/explore/linear-scalability/sharding-data.md
@@ -40,7 +40,7 @@ The primary key for each row in the table uniquely identifies the location of th
 
 ![Sharding a table into tablets](/images/architecture/partitioning-table-into-tablets.png)
 
-By default, YugabyteDB creates eight tablets per node in the universe for each table and automatically distributes the data across various tablets, which in turn are distributed evenly across the nodes. In the [Examples](#Examples), you explore how automatic sharding is done internally for tables. The system Redis table works in exactly the same way.
+By default, YugabyteDB creates one tablet per node in the universe for each table and automatically distributes the data across them. In the [Examples](#Examples), you explore how automatic sharding is done internally for tables. The system Redis table works in exactly the same way.
 
 ## Sharding strategies
 

--- a/docs/content/stable/reference/configuration/yb-master.md
+++ b/docs/content/stable/reference/configuration/yb-master.md
@@ -429,50 +429,52 @@ Default: `3`
 
 ##### --yb_num_shards_per_tserver
 
-The number of shards per YB-TServer for each YCQL table when a user table is created.
+The number of shards (tablets) per YB-TServer for each YCQL table when a user table is created.
 
-Default: `-1` (the value based on the CPU cores is calculated at runtime).
-\
-For servers with up to two CPU cores, the default value is considered as `4`.
-\
-For three or more CPU cores, the default value is considered as `8`.
-\
-If [`enable_automatic_tablet_splitting`](#enable-automatic-tablet-splitting) is `true`, then the default value is considered as `1` and tables will begin with 1 tablet *per node*; for version `2.18` and later, for servers with up to 4 CPU cores, the value *is not defined* and tables will begin with 1 tablet (for servers with up to 2 CPU cores), or 2 tablets (for servers with up to 4 CPU cores) *per cluster*.
+Default: `-1`, where the number of shards is determined at runtime, as follows:
 
-Local cluster installations created with `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
-\
-Clusters created with `yugabyted` always use a default value of `1`.
+- If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`
+  - The default value is considered as `1`.
+  - For servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
+
+- If `enable_automatic_tablet_splitting` is `false`
+  - For servers with up to two CPU cores, the default value is considered as `4`.
+  - For three or more CPU cores, the default value is considered as `8`.
+
+Local cluster installations created using `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
+
+Clusters created using `yugabyted` always use a default value of `1`.
 
 {{< note title="Note" >}}
 
 - This value must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
-- If the value is set to *Default* (`-1`), then the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version `2.18` and the flag remains *unchanged* starting from version `2.18`.
+- If the value is set to *Default* (`-1`), then the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version 2.18 and the flag remains *unchanged* starting from version 2.18.
 - The [`CREATE TABLE ... WITH TABLETS = <num>`](../../../api/ycql/ddl_create_table/#create-a-table-specifying-the-number-of-tablets) clause can be used on a per-table basis to override the `yb_num_shards_per_tserver` value.
 
 {{< /note >}}
 
 ##### --ysql_num_shards_per_tserver
 
-The number of shards per YB-TServer for each YSQL table when a user table is created.
+The number of shards (tablets) per YB-TServer for each YSQL table when a user table is created.
 
-Default: `-1` (the value based on the CPU cores is calculated at runtime).
-\
-For servers with up to two CPU cores, the default value is considered as `2`.
-\
-For servers with three or four CPU cores, the default value is considered as `4`.
-\
-Beyond four cores, the default value is considered as `8`.
-\
-If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`, then the default value is *considered* as `1` and tables will begin with 1 tablet *per node*; for versions `2.18`and later, for servers with up to 4 CPU cores, the value *is not defined* and tables will begin with 1 tablet (for servers with up to 2 CPU cores), or 2 tablets (for servers with up to 4 CPU cores) *per cluster*.
+Default: `-1`, where the number of shards is determined at runtime, as follows:
 
-Local cluster installations created with `yb-ctl` and `yb-docker-ctl` use a default value of `2`.
-\
-Clusters created with `yugabyted` always use a default value of `1`.
+- If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`
+  - The default value is considered as `1`.
+  - For servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
+
+- If `enable_automatic_tablet_splitting` is `false`
+  - For servers with up to two CPU cores, the default value is considered as `4`.
+  - For three or more CPU cores, the default value is considered as `8`.
+
+Local cluster installations created using `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
+
+Clusters created using `yugabyted` always use a default value of `1`.
 
 {{< note title="Note" >}}
 
 - This value must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
-- If the value is set to *Default* (`-1`), the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version `2.18.0` and the flag remains *unchanged* starting from version `2.18.0`.
+- If the value is set to *Default* (`-1`), the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version 2.18 and the flag remains *unchanged* starting from version 2.18.
 - The [`CREATE TABLE ...SPLIT INTO`](../../../api/ysql/the-sql-language/statements/ddl_create_table/#split-into) clause can be used on a per-table basis to override the `ysql_num_shards_per_tserver` value.
 
 {{< /note >}}

--- a/docs/content/stable/reference/configuration/yb-master.md
+++ b/docs/content/stable/reference/configuration/yb-master.md
@@ -464,8 +464,9 @@ Default: `-1`, where the number of shards is determined at runtime, as follows:
   - For servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
 
 - If `enable_automatic_tablet_splitting` is `false`
-  - For servers with up to two CPU cores, the default value is considered as `4`.
-  - For three or more CPU cores, the default value is considered as `8`.
+  - For servers with up to two CPU cores, the default value is considered as 2.
+  - For servers with three or four CPU cores, the default value is considered as 4.
+  - Beyond four cores, the default value is considered as 8.
 
 Local cluster installations created using `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
 

--- a/docs/content/stable/reference/configuration/yb-tserver.md
+++ b/docs/content/stable/reference/configuration/yb-tserver.md
@@ -350,8 +350,9 @@ Default: `-1`, where the number of shards is determined at runtime, as follows:
   - For servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
 
 - If `enable_automatic_tablet_splitting` is `false`
-  - For servers with up to two CPU cores, the default value is considered as `4`.
-  - For three or more CPU cores, the default value is considered as `8`.
+  - For servers with up to two CPU cores, the default value is considered as 2.
+  - For servers with three or four CPU cores, the default value is considered as 4.
+  - Beyond four cores, the default value is considered as 8.
 
 Local cluster installations created using `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
 

--- a/docs/content/stable/reference/configuration/yb-tserver.md
+++ b/docs/content/stable/reference/configuration/yb-tserver.md
@@ -315,50 +315,52 @@ Default: The default value in `2.18.1` is `-1` - feature is disabled by default.
 
 ##### --yb_num_shards_per_tserver
 
-The number of shards per YB-TServer for each YCQL table when a user table is created.
+The number of shards (tablets) per YB-TServer for each YCQL table when a user table is created.
 
-Default: `-1` (the value based on the CPU cores is calculated at runtime).
-\
-For servers with up to two CPU cores, the default value is considered as `4`.
-\
-For three or more CPU cores, the default value is considered as `8`.
-\
-If [`enable_automatic_tablet_splitting`](#enable-automatic-tablet-splitting) is `true`, then the default value is considered as `1` and tables will begin with 1 tablet *per node*; for version `2.18` and later, for servers with up to 4 CPU cores, the value *is not defined* and tables will begin with 1 tablet (for servers with up to 2 CPU cores), or 2 tablets (for servers with up to 4 CPU cores) *per cluster*.
+Default: `-1`, where the number of shards is determined at runtime, as follows:
 
-Local cluster installations created with `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
-\
-Clusters created with `yugabyted` always use a default value of `1`.
+- If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`
+  - The default value is considered as `1`.
+  - For servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
+
+- If `enable_automatic_tablet_splitting` is `false`
+  - For servers with up to two CPU cores, the default value is considered as `4`.
+  - For three or more CPU cores, the default value is considered as `8`.
+
+Local cluster installations created using `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
+
+Clusters created using `yugabyted` always use a default value of `1`.
 
 {{< note title="Note" >}}
 
 - This value must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
-- If the value is set to *Default* (`-1`), then the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version `2.18` and the flag remains *unchanged* starting from version `2.18`.
+- If the value is set to *Default* (`-1`), then the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version 2.18 and the flag remains *unchanged* starting from version 2.18.
 - The [`CREATE TABLE ... WITH TABLETS = <num>`](../../../api/ycql/ddl_create_table/#create-a-table-specifying-the-number-of-tablets) clause can be used on a per-table basis to override the `yb_num_shards_per_tserver` value.
 
 {{< /note >}}
 
 ##### --ysql_num_shards_per_tserver
 
-The number of shards per YB-TServer for each YSQL table when a user table is created.
+The number of shards (tablets) per YB-TServer for each YSQL table when a user table is created.
 
-Default: `-1` (the value based on the CPU cores is calculated at runtime).
-\
-For servers with up to two CPU cores, the default value is considered as `2`.
-\
-For servers with three or four CPU cores, the default value is considered as `4`.
-\
-Beyond four cores, the default value is considered as `8`.
-\
-If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`, then the default value is *considered* as `1` and tables will begin with 1 tablet *per node*; for versions `2.18` and later, for servers with up to 4 CPU cores, the value *is not defined* and tables will begin with 1 tablet (for servers with up to 2 CPU cores), or 2 tablets (for servers with up to 4 CPU cores) *per cluster*.
+Default: `-1`, where the number of shards is determined at runtime, as follows:
 
-Local cluster installations created with `yb-ctl` and `yb-docker-ctl` use a default value of `2`.
-\
-Clusters created with `yugabyted` always use a default value of `1`.
+- If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`
+  - The default value is considered as `1`.
+  - For servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
+
+- If `enable_automatic_tablet_splitting` is `false`
+  - For servers with up to two CPU cores, the default value is considered as `4`.
+  - For three or more CPU cores, the default value is considered as `8`.
+
+Local cluster installations created using `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
+
+Clusters created using `yugabyted` always use a default value of `1`.
 
 {{< note title="Note" >}}
 
 - This value must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
-- If the value is set to *Default* (`-1`), the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version `2.18.0` and the flag remains *unchanged* starting from version `2.18.0`.
+- If the value is set to *Default* (`-1`), the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version 2.18 and the flag remains *unchanged* starting from version 2.18.
 - The [`CREATE TABLE ...SPLIT INTO`](../../../api/ysql/the-sql-language/statements/ddl_create_table/#split-into) clause can be used on a per-table basis to override the `ysql_num_shards_per_tserver` value.
 
 {{< /note >}}

--- a/docs/content/v2.14/architecture/docdb-sharding/tablet-splitting.md
+++ b/docs/content/v2.14/architecture/docdb-sharding/tablet-splitting.md
@@ -219,9 +219,13 @@ For details on the architecture design, see [Automatic re-sharding of data with 
 
 ### Enable automatic tablet splitting
 
-To enable automatic tablet splitting, use the `yb-master` [`--enable_automatic_tablet_splitting`](../../../reference/configuration/yb-master/#enable-automatic-tablet-splitting) flag and specify the associated flags to configure when tablets should split, and use `yb-tserver` [`--enable_automatic_tablet_splitting`](../../../reference/configuration/yb-tserver/#enable-automatic-tablet-splitting). The flag usage must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
+When automatic tablet splitting is enabled, newly-created tables with [hash sharding](../../../architecture/docdb-sharding/sharding/#hash-sharding) have one tablet per node by default.
 
-When automatic tablet splitting is enabled, newly-created tables with [hash sharding](../../../architecture/docdb-sharding/sharding/#hash-sharding) have one shard **per _yb-tserver_** by default; from version `2.14.10` such tables have one shard (for servers with up to 2 CPU cores) or two shards (for servers with up to 4 CPU cores) **per _cluster_** by default.
+In addition, from version 2.14.10, for servers with up to 2 CPU cores, newly-created tables have one tablet per cluster, and servers with up to 4 CPU cores have 2 tablets per cluster.
+
+From version 2.18.0, automatic tablet splitting is turned on by default.
+
+To control automatic tablet splitting, use the `yb-master` [`--enable_automatic_tablet_splitting`](../../../reference/configuration/yb-master/#enable-automatic-tablet-splitting) flag and specify the associated flags to configure when tablets should split, and use `yb-tserver` [`--enable_automatic_tablet_splitting`](../../../reference/configuration/yb-tserver/#enable-automatic-tablet-splitting). The flags must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
 
 {{< note title="Note" >}}
 

--- a/docs/content/v2.14/reference/configuration/yb-master.md
+++ b/docs/content/v2.14/reference/configuration/yb-master.md
@@ -444,50 +444,53 @@ Default: `3`
 
 ##### --yb_num_shards_per_tserver
 
-The number of shards per YB-TServer for each YCQL table when a user table is created.
+The number of shards (tablets) per YB-TServer for each YCQL table when a user table is created.
 
-Default: `-1` (the value based on the CPU cores is calculated at runtime).
-\
-For servers with up to two CPU cores, the default value is considered as `4`.
-\
-For three or more CPU cores, the default value is considered as `8`.
-\
-If [`enable_automatic_tablet_splitting`](#enable-automatic-tablet-splitting) is `true`, then the default value is considered as `1` and tables will begin with 1 tablet *per node*; for version `2.14.10` and later, for servers with up to 4 CPU cores, the value *is not defined* and tables will begin with 1 tablet (for servers with up to 2 CPU cores), or 2 tablets (for servers with up to 4 CPU cores) *per cluster*.
+Default: `-1`, where the number of shards is determined at runtime, as follows:
 
-Local cluster installations created with `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
-\
-Clusters created with `yugabyted` always use a default value of `1`.
+- If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`
+  - The default value is considered as `1`.
+  - For version 2.14.10 and later, for servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
+
+- If `enable_automatic_tablet_splitting` is `false`
+  - For servers with up to two CPU cores, the default value is considered as `4`.
+  - For three or more CPU cores, the default value is considered as `8`.
+
+Local cluster installations created using `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
+
+Clusters created using `yugabyted` always use a default value of `1`.
 
 {{< note title="Note" >}}
 
 - This value must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
-- If the value is set to *Default* (`-1`), then the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version `2.14.10` and the flag remains *unchanged* starting from version `2.14.10`.
+- If the value is set to *Default* (`-1`), then the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version 2.14.10 and the flag remains *unchanged* starting from version 2.14.10.
 - The [`CREATE TABLE ... WITH TABLETS = <num>`](../../../api/ycql/ddl_create_table/#create-a-table-specifying-the-number-of-tablets) clause can be used on a per-table basis to override the `yb_num_shards_per_tserver` value.
 
 {{< /note >}}
 
 ##### --ysql_num_shards_per_tserver
 
-The number of shards per YB-TServer for each YSQL table when a user table is created.
+The number of shards (tablets) per YB-TServer for each YSQL table when a user table is created.
 
-Default: `-1` (the value based on the CPU cores is calculated at runtime).
-\
-For servers with up to two CPU cores, the default value is considered as `2`.
-\
-For servers with three or four CPU cores, the default value is considered as `4`.
-\
-Beyond four cores, the default value is considered as `8`.
-\
-If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`, then the default value is *considered* as `1` and tables will begin with 1 tablet *per node*; for versions `2.14.10` and later, for servers with up to 4 CPU cores, the value *is not defined* and tables will begin with 1 tablet (for servers with up to 2 CPU cores), or 2 tablets (for servers with up to 4 CPU cores) *per cluster*.
+Default: `-1`, where the number of shards is determined at runtime, as follows:
 
-Local cluster installations created with `yb-ctl` and `yb-docker-ctl` use a default value of `2`.
-\
-Clusters created with `yugabyted` always use a default value of `1`.
+- If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`
+  - The default value is considered as `1`.
+  - For version 2.14.10 and later, for servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
+
+- If `enable_automatic_tablet_splitting` is `false`
+  - For servers with up to two CPU cores, the default value is considered as `2`.
+  - For servers with three or four CPU cores, the default value is considered as `4`.
+  - Beyond four cores, the default value is considered as `8`.
+
+Local cluster installations created using `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
+
+Clusters created using `yugabyted` always use a default value of `1`.
 
 {{< note title="Note" >}}
 
 - This flag must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
-- If the value is set to *Default* (`-1`), the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup.
+- If the value is set to *Default* (`-1`), the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version 2.14.10 and the flag remains *unchanged* starting from version 2.14.10.
 - The [`CREATE TABLE ...SPLIT INTO`](../../../api/ysql/the-sql-language/statements/ddl_create_table/#split-into) clause can be used on a per-table basis to override the `ysql_num_shards_per_tserver` value.
 
 {{< /note >}}

--- a/docs/content/v2.14/reference/configuration/yb-tserver.md
+++ b/docs/content/v2.14/reference/configuration/yb-tserver.md
@@ -324,50 +324,53 @@ Default: `64`
 
 ##### --yb_num_shards_per_tserver
 
-The number of shards per YB-TServer for each YCQL table when a user table is created.
+The number of shards (tablets) per YB-TServer for each YCQL table when a user table is created.
 
-Default: `-1` (the value based on the CPU cores is calculated at runtime).
-\
-For servers with up to two CPU cores, the default value is considered as `4`.
-\
-For three or more CPU cores, the default value is considered as `8`.
-\
-If [`enable_automatic_tablet_splitting`](#enable-automatic-tablet-splitting) is `true`, then the default value is considered as `1` and tables will begin with 1 tablet *per node*; for version `2.14.10` and later, for servers with up to 4 CPU cores, the value *is not defined* and tables will begin with 1 tablet (for servers with up to 2 CPU cores), or 2 tablets (for servers with up to 4 CPU cores) *per cluster*.
+Default: `-1`, where the number of shards is determined at runtime, as follows:
 
-Local cluster installations created with `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
-\
-Clusters created with `yugabyted` always use a default value of `1`.
+- If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`
+  - The default value is considered as `1`.
+  - For version 2.14.10 and later, for servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
+
+- If `enable_automatic_tablet_splitting` is `false`
+  - For servers with up to two CPU cores, the default value is considered as `4`.
+  - For three or more CPU cores, the default value is considered as `8`.
+
+Local cluster installations created using `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
+
+Clusters created using `yugabyted` always use a default value of `1`.
 
 {{< note title="Note" >}}
 
 - This value must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
-- If the value is set to *Default* (`-1`), then the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version `2.14.10` and the flag remains *unchanged* starting from version `2.14.10`.
+- If the value is set to *Default* (`-1`), then the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version 2.14.10 and the flag remains *unchanged* starting from version 2.14.10.
 - The [`CREATE TABLE ... WITH TABLETS = <num>`](../../../api/ycql/ddl_create_table/#create-a-table-specifying-the-number-of-tablets) clause can be used on a per-table basis to override the `yb_num_shards_per_tserver` value.
 
 {{< /note >}}
 
 ##### --ysql_num_shards_per_tserver
 
-The number of shards per YB-TServer for each YSQL table when a user table is created.
+The number of shards (tablets) per YB-TServer for each YSQL table when a user table is created.
 
-Default: `-1` (the value based on the CPU cores is calculated at runtime).
-\
-For servers with up to two CPU cores, the default value is considered as `2`.
-\
-For servers with three or four CPU cores, the default value is considered as `4`.
-\
-Beyond four cores, the default value is considered as `8`.
-\
-If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`, then the default value is *considered* as `1` and tables will begin with 1 tablet *per node*; for versions `2.14.10` and later, for servers with up to 4 CPU cores, the value *is not defined* and tables will begin with 1 tablet (for servers with up to 2 CPU cores), or 2 tablets (for servers with up to 4 CPU cores) *per cluster*.
+Default: `-1`, where the number of shards is determined at runtime, as follows:
 
-Local cluster installations created with `yb-ctl` and `yb-docker-ctl` use a default value of `2`.
-\
-Clusters created with `yugabyted` always use a default value of `1`.
+- If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`
+  - The default value is considered as `1`.
+  - For version 2.14.10 and later, for servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
+
+- If `enable_automatic_tablet_splitting` is `false`
+  - For servers with up to two CPU cores, the default value is considered as `2`.
+  - For servers with three or four CPU cores, the default value is considered as `4`.
+  - Beyond four cores, the default value is considered as `8`.
+
+Local cluster installations created using `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
+
+Clusters created using `yugabyted` always use a default value of `1`.
 
 {{< note title="Note" >}}
 
 - This value must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
-- If the value is set to *Default* (`-1`), the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version `2.14.10` and the flag remains *unchanged* starting from version `2.14.10`.
+- If the value is set to *Default* (`-1`), the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version 2.14.10 and the flag remains *unchanged* starting from version 2.14.10.
 - The [`CREATE TABLE ...SPLIT INTO`](../../../api/ysql/the-sql-language/statements/ddl_create_table/#split-into) clause can be used on a per-table basis to override the `ysql_num_shards_per_tserver` value.
 
 {{< /note >}}

--- a/docs/content/v2.16/architecture/docdb-sharding/tablet-splitting.md
+++ b/docs/content/v2.16/architecture/docdb-sharding/tablet-splitting.md
@@ -219,9 +219,13 @@ For details on the architecture design, see [Automatic re-sharding of data with 
 
 ### Enable automatic tablet splitting
 
-To enable automatic tablet splitting, use the `yb-master` [`--enable_automatic_tablet_splitting`](../../../reference/configuration/yb-master/#enable-automatic-tablet-splitting) flag and specify the associated flags to configure when tablets should split, and use `yb-tserver` [`--enable_automatic_tablet_splitting`](../../../reference/configuration/yb-tserver/#enable-automatic-tablet-splitting). The flag usage must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
+When automatic tablet splitting is enabled, newly-created tables with [hash sharding](../../../architecture/docdb-sharding/sharding/#hash-sharding) have one tablet per node by default.
 
-When automatic tablet splitting is enabled, newly-created tables with [hash sharding](../../../architecture/docdb-sharding/sharding/#hash-sharding) have one shard **per _yb-tserver_** by default; from version `2.14.10` such tables have one shard (for servers with up to 2 CPU cores) or two shards (for servers with up to 4 CPU cores) **per _cluster_** by default.
+In addition, from version 2.14.10, for servers with up to 2 CPU cores, newly-created tables have one tablet per cluster, and servers with up to 4 CPU cores have 2 tablets per cluster.
+
+From version 2.18.0, automatic tablet splitting is turned on by default.
+
+To control automatic tablet splitting, use the `yb-master` [`--enable_automatic_tablet_splitting`](../../../reference/configuration/yb-master/#enable-automatic-tablet-splitting) flag and specify the associated flags to configure when tablets should split, and use `yb-tserver` [`--enable_automatic_tablet_splitting`](../../../reference/configuration/yb-tserver/#enable-automatic-tablet-splitting). The flags must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
 
 {{< note title="Note" >}}
 

--- a/docs/content/v2.16/architecture/docdb-sharding/tablet-splitting.md
+++ b/docs/content/v2.16/architecture/docdb-sharding/tablet-splitting.md
@@ -153,7 +153,7 @@ Misuse or overuse of manual tablet splitting (for example, splitting tablets whi
     SELECT count(*) FROM t;
     ```
 
-    <br>Expect the following output:
+    Expect the following output:
 
     ```output
     count
@@ -221,7 +221,7 @@ For details on the architecture design, see [Automatic re-sharding of data with 
 
 When automatic tablet splitting is enabled, newly-created tables with [hash sharding](../../../architecture/docdb-sharding/sharding/#hash-sharding) have one tablet per node by default.
 
-In addition, from version 2.14.10, for servers with up to 2 CPU cores, newly-created tables have one tablet per cluster, and servers with up to 4 CPU cores have 2 tablets per cluster.
+In addition, from version 2.16.5, for servers with up to 2 CPU cores, newly-created tables have one tablet per cluster, and servers with up to 4 CPU cores have 2 tablets per cluster.
 
 From version 2.18.0, automatic tablet splitting is turned on by default.
 
@@ -245,7 +245,7 @@ In the high phase, each node has fewer than [`tablet_split_high_phase_shard_coun
 
 #### Final Phase
 
-Once the shard count exceeds the high phase count (determined by `tablet_split_high_phase_shard_count_per_node`, 24 by default), YugabyteDB splits tablets larger than [`tablet_force_split_threshold_bytes`](../../../reference/configuration/yb-master/#tablet-force-split-threshold-bytes) (100 GB by default). This will continue until we reach the [`tablet_split_limit_per_table`](../../../reference/configuration/yb-master/#tablet-split-limit-per-table) tablets per table limit (256 tablets by default; if set to 0, there will be no limit).
+When the shard count exceeds the high phase count (determined by `tablet_split_high_phase_shard_count_per_node`, 24 by default), YugabyteDB splits tablets larger than [`tablet_force_split_threshold_bytes`](../../../reference/configuration/yb-master/#tablet-force-split-threshold-bytes) (100 GB by default). This will continue until we reach the [`tablet_split_limit_per_table`](../../../reference/configuration/yb-master/#tablet-split-limit-per-table) tablets per table limit (256 tablets by default; if set to 0, there will be no limit).
 
 ### Post-split compactions
 
@@ -322,7 +322,7 @@ In the following example, a three-node cluster is created and uses a YCSB worklo
 
 ## Limitations
 
-* Tablet splitting is disabled for index tables with range partitioning that are being restored in version `2.14.5` or later from a backup taken in any version prior to `2.14.5`. It is not recommended to use tablet splitting for range partitioned index tables prior to version `2.14.5` to prevent possible data loss for index tables. For details, see [#12190](https://github.com/yugabyte/yugabyte-db/issues/12190) and [#17169](https://github.com/yugabyte/yugabyte-db/issues/17169).
+* Tablet splitting is disabled for index tables with range partitioning that are being restored in version 2.14.5 or later from a backup taken in any version prior to 2.14.5. It is not recommended to use tablet splitting for range partitioned index tables prior to version 2.14.5 to prevent possible data loss for index tables. For details, see [#12190](https://github.com/yugabyte/yugabyte-db/issues/12190) and [#17169](https://github.com/yugabyte/yugabyte-db/issues/17169).
 
 The following known limitations are planned to be resolved in upcoming releases:
 

--- a/docs/content/v2.16/reference/configuration/yb-master.md
+++ b/docs/content/v2.16/reference/configuration/yb-master.md
@@ -421,7 +421,7 @@ Default: `-1`, where the number of shards is determined at runtime, as follows:
 
 - If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`
   - The default value is considered as `1`.
-  - For version `2.16.5` and later, for servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
+  - For version 2.16.5 and later, for servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
 
 - If `enable_automatic_tablet_splitting` is `false`
   - For servers with up to two CPU cores, the default value is considered as `4`.
@@ -434,20 +434,20 @@ Clusters created using `yugabyted` always use a default value of `1`.
 {{< note title="Note" >}}
 
 - This value must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
-- If the value is set to *Default* (`-1`), then the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version `2.16.5` and the flag remains *unchanged* starting from version `2.16.5`.
+- If the value is set to *Default* (`-1`), then the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version 2.16.5 and the flag remains *unchanged* starting from version 2.16.5.
 - The [`CREATE TABLE ... WITH TABLETS = <num>`](../../../api/ycql/ddl_create_table/#create-a-table-specifying-the-number-of-tablets) clause can be used on a per-table basis to override the `yb_num_shards_per_tserver` value.
 
 {{< /note >}}
 
 ##### --ysql_num_shards_per_tserver
 
-The number of shards (tablets) per YB-TServer for each YCQL table when a user table is created.
+The number of shards (tablets) per YB-TServer for each YSQL table when a user table is created.
 
 Default: `-1`, where the number of shards is determined at runtime, as follows:
 
 - If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`
   - The default value is considered as `1`.
-  - For version `2.16.5` and later, for servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
+  - For version 2.16.5 and later, for servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
 
 - If `enable_automatic_tablet_splitting` is `false`
   - For servers with up to two CPU cores, the default value is considered as `2`.
@@ -461,7 +461,7 @@ Clusters created using `yugabyted` always use a default value of `1`.
 {{< note title="Note" >}}
 
 - This value must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
-- If the value is set to *Default* (`-1`), the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version `2.16.5` and the flag remains *unchanged* starting from version `2.16.5`.
+- If the value is set to *Default* (`-1`), the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version 2.16.5 and the flag remains *unchanged* starting from version 2.16.5.
 - The [`CREATE TABLE ...SPLIT INTO`](../../../api/ysql/the-sql-language/statements/ddl_create_table/#split-into) clause can be used on a per-table basis to override the `ysql_num_shards_per_tserver` value.
 
 {{< /note >}}

--- a/docs/content/v2.16/reference/configuration/yb-master.md
+++ b/docs/content/v2.16/reference/configuration/yb-master.md
@@ -415,19 +415,21 @@ Default: `3`
 
 ##### --yb_num_shards_per_tserver
 
-The number of shards per YB-TServer for each YCQL table when a user table is created.
+The number of shards (tablets) per YB-TServer for each YCQL table when a user table is created.
 
-Default: `-1` (the value based on the CPU cores is calculated at runtime).
-\
-For servers with up to two CPU cores, the default value is considered as `4`.
-\
-For three or more CPU cores, the default value is considered as `8`.
-\
-If [`enable_automatic_tablet_splitting`](#enable-automatic-tablet-splitting) is `true`, then the default value is considered as `1` and tables will begin with 1 tablet *per node*; for version `2.16.5` and later, for servers with up to 4 CPU cores, the value *is not defined* and tables will begin with 1 tablet (for servers with up to 2 CPU cores), or 2 tablets (for servers with up to 4 CPU cores) *per cluster*.
+Default: `-1`, where the number of shards is determined at runtime, as follows:
 
-Local cluster installations created with `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
-\
-Clusters created with `yugabyted` always use a default value of `1`.
+- If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`
+  - The default value is considered as `1`.
+  - For version `2.16.5` and later, for servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
+
+- If `enable_automatic_tablet_splitting` is `false`
+  - For servers with up to two CPU cores, the default value is considered as `4`.
+  - For three or more CPU cores, the default value is considered as `8`.
+
+Local cluster installations created using `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
+
+Clusters created using `yugabyted` always use a default value of `1`.
 
 {{< note title="Note" >}}
 
@@ -439,25 +441,26 @@ Clusters created with `yugabyted` always use a default value of `1`.
 
 ##### --ysql_num_shards_per_tserver
 
-The number of shards per YB-TServer for each YSQL table when a user table is created.
+The number of shards (tablets) per YB-TServer for each YCQL table when a user table is created.
 
-Default: `-1` (the value based on the CPU cores is calculated at runtime).
-\
-For servers with up to two CPU cores, the default value is considered as `2`.
-\
-For servers with three or four CPU cores, the default value is considered as `4`.
-\
-Beyond four cores, the default value is considered as `8`.
-\
-If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`, then the default value is *considered* as `1` and tables will begin with 1 tablet *per node*; for versions `2.16.5` and later, for servers with up to 4 CPU cores, the value *is not defined* and tables will begin with 1 tablet (for servers with up to 2 CPU cores), or 2 tablets (for servers with up to 4 CPU cores) *per cluster*.
+Default: `-1`, where the number of shards is determined at runtime, as follows:
 
-Local cluster installations created with `yb-ctl` and `yb-docker-ctl` use a default value of `2`.
-\
-Clusters created with `yugabyted` always use a default value of `1`.
+- If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`
+  - The default value is considered as `1`.
+  - For version `2.16.5` and later, for servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
+
+- If `enable_automatic_tablet_splitting` is `false`
+  - For servers with up to two CPU cores, the default value is considered as `2`.
+  - For servers with three or four CPU cores, the default value is considered as `4`.
+  - Beyond four cores, the default value is considered as `8`.
+
+Local cluster installations created using `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
+
+Clusters created using `yugabyted` always use a default value of `1`.
 
 {{< note title="Note" >}}
 
-- This flag must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
+- This value must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
 - If the value is set to *Default* (`-1`), the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version `2.16.5` and the flag remains *unchanged* starting from version `2.16.5`.
 - The [`CREATE TABLE ...SPLIT INTO`](../../../api/ysql/the-sql-language/statements/ddl_create_table/#split-into) clause can be used on a per-table basis to override the `ysql_num_shards_per_tserver` value.
 

--- a/docs/content/v2.16/reference/configuration/yb-tserver.md
+++ b/docs/content/v2.16/reference/configuration/yb-tserver.md
@@ -329,7 +329,7 @@ Clusters created using `yugabyted` always use a default value of `1`.
 
 ##### --ysql_num_shards_per_tserver
 
-The number of shards (tablets) per YB-TServer for each YCQL table when a user table is created.
+The number of shards (tablets) per YB-TServer for each YSQL table when a user table is created.
 
 Default: `-1`, where the number of shards is determined at runtime, as follows:
 

--- a/docs/content/v2.16/reference/configuration/yb-tserver.md
+++ b/docs/content/v2.16/reference/configuration/yb-tserver.md
@@ -309,7 +309,7 @@ Default: `-1`, where the number of shards is determined at runtime, as follows:
 
 - If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`
   - The default value is considered as `1`.
-  - For version `2.16.5` and later, for servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
+  - For version 2.16.5 and later, for servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
 
 - If `enable_automatic_tablet_splitting` is `false`
   - For servers with up to two CPU cores, the default value is considered as `4`.
@@ -322,7 +322,7 @@ Clusters created using `yugabyted` always use a default value of `1`.
 {{< note title="Note" >}}
 
 - This value must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
-- If the value is set to *Default* (`-1`), then the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version `2.16.5` and the flag remains *unchanged* starting from version `2.16.5`.
+- If the value is set to *Default* (`-1`), then the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version 2.16.5 and the flag remains *unchanged* starting from version 2.16.5.
 - The [`CREATE TABLE ... WITH TABLETS = <num>`](../../../api/ycql/ddl_create_table/#create-a-table-specifying-the-number-of-tablets) clause can be used on a per-table basis to override the `yb_num_shards_per_tserver` value.
 
 {{< /note >}}
@@ -335,7 +335,7 @@ Default: `-1`, where the number of shards is determined at runtime, as follows:
 
 - If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`
   - The default value is considered as `1`.
-  - For version `2.16.5` and later, for servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
+  - For version 2.16.5 and later, for servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
 
 - If `enable_automatic_tablet_splitting` is `false`
   - For servers with up to two CPU cores, the default value is considered as `2`.
@@ -349,7 +349,7 @@ Clusters created using `yugabyted` always use a default value of `1`.
 {{< note title="Note" >}}
 
 - This value must match on all `yb-master` and `yb-tserver` configurations of a YugabyteDB cluster.
-- If the value is set to *Default* (`-1`), the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version `2.16.5` and the flag remains *unchanged* starting from version `2.16.5`.
+- If the value is set to *Default* (`-1`), the system automatically determines an appropriate value based on the number of CPU cores and internally *updates* the flag with the intended value during startup prior to version 2.16.5 and the flag remains *unchanged* starting from version 2.16.5.
 - The [`CREATE TABLE ...SPLIT INTO`](../../../api/ysql/the-sql-language/statements/ddl_create_table/#split-into) clause can be used on a per-table basis to override the `ysql_num_shards_per_tserver` value.
 
 {{< /note >}}

--- a/docs/content/v2.16/reference/configuration/yb-tserver.md
+++ b/docs/content/v2.16/reference/configuration/yb-tserver.md
@@ -303,19 +303,21 @@ Default: `64`
 
 ##### --yb_num_shards_per_tserver
 
-The number of shards per YB-TServer for each YCQL table when a user table is created.
+The number of shards (tablets) per YB-TServer for each YCQL table when a user table is created.
 
-Default: `-1` (the value based on the CPU cores is calculated at runtime).
-\
-For servers with up to two CPU cores, the default value is considered as `4`.
-\
-For three or more CPU cores, the default value is considered as `8`.
-\
-If [`enable_automatic_tablet_splitting`](#enable-automatic-tablet-splitting) is `true`, then the default value is considered as `1` and tables will begin with 1 tablet *per node*; for version `2.16.5` and later, for servers with up to 4 CPU cores, the value *is not defined* and tables will begin with 1 tablet (for servers with up to 2 CPU cores), or 2 tablets (for servers with up to 4 CPU cores) *per cluster*.
+Default: `-1`, where the number of shards is determined at runtime, as follows:
 
-Local cluster installations created with `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
-\
-Clusters created with `yugabyted` always use a default value of `1`.
+- If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`
+  - The default value is considered as `1`.
+  - For version `2.16.5` and later, for servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
+
+- If `enable_automatic_tablet_splitting` is `false`
+  - For servers with up to two CPU cores, the default value is considered as `4`.
+  - For three or more CPU cores, the default value is considered as `8`.
+
+Local cluster installations created using `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
+
+Clusters created using `yugabyted` always use a default value of `1`.
 
 {{< note title="Note" >}}
 
@@ -327,21 +329,22 @@ Clusters created with `yugabyted` always use a default value of `1`.
 
 ##### --ysql_num_shards_per_tserver
 
-The number of shards per YB-TServer for each YSQL table when a user table is created.
+The number of shards (tablets) per YB-TServer for each YCQL table when a user table is created.
 
-Default: `-1` (the value based on the CPU cores is calculated at runtime).
-\
-For servers with up to two CPU cores, the default value is considered as `2`.
-\
-For servers with three or four CPU cores, the default value is considered as `4`.
-\
-Beyond four cores, the default value is considered as `8`.
-\
-If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`, then the default value is *considered* as `1` and tables will begin with 1 tablet *per node*; for versions `2.16.5` and later, for servers with up to 4 CPU cores, the value *is not defined* and tables will begin with 1 tablet (for servers with up to 2 CPU cores), or 2 tablets (for servers with up to 4 CPU cores) *per cluster*.
+Default: `-1`, where the number of shards is determined at runtime, as follows:
 
-Local cluster installations created with `yb-ctl` and `yb-docker-ctl` use a default value of `2`.
-\
-Clusters created with `yugabyted` always use a default value of `1`.
+- If [enable_automatic_tablet_splitting](#enable-automatic-tablet-splitting) is `true`
+  - The default value is considered as `1`.
+  - For version `2.16.5` and later, for servers with 4 CPU cores or less, the number of tablets for each table doesn't depend on the number of YB-TServers. Instead, for 2 CPU cores or less, 1 tablet per cluster is created; for 4 CPU cores or less, 2 tablets per cluster are created.
+
+- If `enable_automatic_tablet_splitting` is `false`
+  - For servers with up to two CPU cores, the default value is considered as `2`.
+  - For servers with three or four CPU cores, the default value is considered as `4`.
+  - Beyond four cores, the default value is considered as `8`.
+
+Local cluster installations created using `yb-ctl` and `yb-docker-ctl` use a default value of `2` for this flag.
+
+Clusters created using `yugabyted` always use a default value of `1`.
 
 {{< note title="Note" >}}
 


### PR DESCRIPTION
Update automatic tablet splitting description for 2.18

preview/reference/configuration/yb-tserver/#yb-num-shards-per-tserver

preview/architecture/docdb-sharding/tablet-splitting/#automatic-tablet-splitting

preview/explore/linear-scalability/sharding-data/

@netlify /preview/architecture/docdb-sharding/tablet-splitting/