### PR TITLE
Replication architecture pages: cluster->universe

### DIFF
--- a/docs/content/preview/architecture/docdb-replication/_index.md
+++ b/docs/content/preview/architecture/docdb-replication/_index.md
@@ -17,8 +17,8 @@ This section describes how replication works in DocDB. The data in a DocDB table
 
 YugabyteDB also provides other advanced replication features. These include two forms of asynchronous replication of data:
 
-* **xCluster** Data is asynchronously replicated between different YugabyteDB clusters - both unidirectional replication (master-slave) or  bidirectional replication across two clusters.
-* **Read replicas** The in-cluster asynchronous replicas are called read replicas.
+* **xCluster** Data is asynchronously replicated between different YugabyteDB universes - both unidirectional replication (master-slave) or  bidirectional replication across two universes.
+* **Read replicas** The in-universe asynchronous replicas are called read replicas.
 
 The YugabyteDB synchronous replication architecture is inspired by <a href="https://research.google.com/archive/spanner-osdi2012.pdf">Google Spanner</a>.
 
@@ -33,7 +33,7 @@ The YugabyteDB xCluster replication architecture is inspired by RDBMS databases 
         <div class="title">Default synchronous replication</div>
       </div>
       <div class="body">
-        In-cluster synchronous replication with Raft consensus.
+        In-primary-cluster synchronous replication with Raft consensus.
       </div>
     </a>
   </div>
@@ -45,7 +45,7 @@ The YugabyteDB xCluster replication architecture is inspired by RDBMS databases 
         <div class="title">xCluster</div>
       </div>
       <div class="body">
-        Cross-cluster asynchronous replication of data.
+        Cross-universe asynchronous replication of data.
       </div>
     </a>
   </div>
@@ -57,7 +57,7 @@ The YugabyteDB xCluster replication architecture is inspired by RDBMS databases 
         <div class="title">Read replicas</div>
       </div>
       <div class="body">
-        In-cluster asynchronous replicas to enable reading data that is a bit stale with lower read latencies.
+        In-universe asynchronous replicas to enable reading data that is a bit stale with lower read latencies.
       </div>
     </a>
   </div>

--- a/docs/content/preview/architecture/docdb-replication/change-data-capture.md
+++ b/docs/content/preview/architecture/docdb-replication/change-data-capture.md
@@ -94,7 +94,7 @@ Using the Debezium connector for YugabyteDB, changes are pushed from YugabyteDB 
 
 ### CDC guarantees
 
-There is a number of guarantees that CDC makes.
+There are a number of guarantees that CDC makes.
 
 #### Per-tablet ordered delivery guarantee
 
@@ -120,6 +120,6 @@ When you have received a change for a row for timestamp `t`, you do not receive 
 
 {{< note title="Note" >}}
 
-See the [reference page](../../../explore/change-data-capture/) for more details & limitations.
+See the [exploration page](../../../explore/change-data-capture/) for more details & limitations.
 
 {{< /note >}}

--- a/docs/content/preview/architecture/docdb-replication/change-data-capture.md
+++ b/docs/content/preview/architecture/docdb-replication/change-data-capture.md
@@ -94,7 +94,7 @@ Using the Debezium connector for YugabyteDB, changes are pushed from YugabyteDB 
 
 ### CDC guarantees
 
-There are a number of guarantees that CDC makes.
+CDC makes the following guarantees.
 
 #### Per-tablet ordered delivery guarantee
 
@@ -120,6 +120,6 @@ When you have received a change for a row for timestamp `t`, you do not receive 
 
 {{< note title="Note" >}}
 
-See the [exploration page](../../../explore/change-data-capture/) for more details & limitations.
+See [Change data capture](../../../explore/change-data-capture/) in Explore for more details and limitations.
 
 {{< /note >}}

--- a/docs/content/preview/architecture/docdb-replication/read-replicas.md
+++ b/docs/content/preview/architecture/docdb-replication/read-replicas.md
@@ -14,7 +14,7 @@ type: docs
 
 In addition to the core distributed consensus-based replication, DocDB extends Raft to add read replicas (also known observer nodes) that do not participate in writes but get a timeline consistent copy of the data in an asynchronous manner.
 
-Read replicas are a read-only extension to the primary data in the cluster. With read replicas, the primary data of the cluster is deployed across multiple zones in one region, or across nearby regions. Read replicas do not add to the write latencies since the write does not synchronously replicate data to them. Instead, the data is replicated to read replicas asynchronously.
+Read replicas are a read-only extension to the primary data in the universe. With read replicas, the primary data of the universe is replicated across multiple zones in one region, or across nearby regions. Read replicas do not add to the write latencies since the write does not synchronously replicate data to them. Instead, the data is replicated to read replicas asynchronously.
 
 Nodes in remote data centers can be added in read-only mode. This is typically used in cases where latency of doing a distributed consensus-based write is not tolerable for some workloads.
 
@@ -27,7 +27,7 @@ The replication factor of a read replica cluster can be an even number as well. 
 
 ## Writing to read replicas
 
-An application can send write requests to read replicas, but these write requests are internally redirected to the source of truth. This is because the read replicas are aware of the topology of the cluster.
+An application can send write requests to read replicas, but these write requests are internally redirected to the source of truth. This is because the read replicas are aware of the topology of the universe.
 
 ## Schema changes
 

--- a/docs/content/preview/architecture/docdb-replication/replication.md
+++ b/docs/content/preview/architecture/docdb-replication/replication.md
@@ -14,7 +14,7 @@ menu:
 type: docs
 ---
 
-Using the Raft distributed consensus protocol, DocDB automatically replicates data synchronously in order to survive failures while maintaining data consistency and avoiding operator intervention.
+Using the Raft distributed consensus protocol, DocDB automatically replicates data synchronously across the primary cluster in order to survive failures while maintaining data consistency and avoiding operator intervention.
 
 ## Concepts
 
@@ -58,7 +58,7 @@ The set of DocDB updates depends on the user-issued write, and involves locking 
 
 After the Raft log is replicated to a majority of tablet-peers and successfully persisted on the majority, the write is applied into the DocDB document storage layer and is subsequently available for reads. After the write is persisted on disk by the document storage layer, the write entries can be purged from the Raft log. This is performed as a controlled background operation without any impact to the foreground operations.
 
-## Replication in a cluster
+## Replication in the primary cluster
 
 The replicas of data can be placed across multiple fault domains. The following examples of a multi-zone deployment with three zones and the replication factor assumed to be 3 demonstrate how replication across fault domains is performed in a cluster.
 

--- a/docs/content/stable/architecture/docdb-replication/_index.md
+++ b/docs/content/stable/architecture/docdb-replication/_index.md
@@ -17,8 +17,8 @@ This section describes how replication works in DocDB. The data in a DocDB table
 
 YugabyteDB also provides other advanced replication features. These include two forms of asynchronous replication of data:
 
-* **xCluster** Data is asynchronously replicated between different YugabyteDB clusters - both unidirectional replication (master-slave) or  bidirectional replication across two clusters.
-* **Read replicas** The in-cluster asynchronous replicas are called read replicas.
+* **xCluster** Data is asynchronously replicated between different YugabyteDB universes - both unidirectional replication (master-slave) or  bidirectional replication across two universes.
+* **Read replicas** The in-universe asynchronous replicas are called read replicas.
 
 The YugabyteDB synchronous replication architecture is inspired by <a href="https://research.google.com/archive/spanner-osdi2012.pdf">Google Spanner</a>.
 
@@ -33,7 +33,7 @@ The YugabyteDB xCluster replication architecture is inspired by RDBMS databases 
         <div class="title">Default synchronous replication</div>
       </div>
       <div class="body">
-        In-cluster synchronous replication with Raft consensus.
+        In-primary-cluster synchronous replication with Raft consensus.
       </div>
     </a>
   </div>
@@ -45,7 +45,7 @@ The YugabyteDB xCluster replication architecture is inspired by RDBMS databases 
         <div class="title">xCluster</div>
       </div>
       <div class="body">
-        Cross-cluster asynchronous replication of data.
+        Cross-universe asynchronous replication of data.
       </div>
     </a>
   </div>
@@ -57,7 +57,7 @@ The YugabyteDB xCluster replication architecture is inspired by RDBMS databases 
         <div class="title">Read replicas</div>
       </div>
       <div class="body">
-        In-cluster asynchronous replicas to enable reading data that is a bit stale with lower read latencies.
+        In-universe asynchronous replicas to enable reading data that is a bit stale with lower read latencies.
       </div>
     </a>
   </div>

--- a/docs/content/stable/architecture/docdb-replication/change-data-capture.md
+++ b/docs/content/stable/architecture/docdb-replication/change-data-capture.md
@@ -92,7 +92,7 @@ Using the Debezium connector for YugabyteDB, changes are pushed from YugabyteDB 
 
 ### CDC guarantees
 
-There is a number of guarantees that CDC makes.
+CDC makes the following guarantees.
 
 #### Per-tablet ordered delivery guarantee
 
@@ -118,6 +118,6 @@ When you have received a change for a row for timestamp `t`, you do not receive 
 
 {{< note title="Note" >}}
 
-See the [reference page](../../../explore/change-data-capture/) for more details & limitations.
+See [Change data capture](../../../explore/change-data-capture/) in Explore for more details and limitations.
 
 {{< /note >}}

--- a/docs/content/stable/architecture/docdb-replication/read-replicas.md
+++ b/docs/content/stable/architecture/docdb-replication/read-replicas.md
@@ -14,7 +14,7 @@ type: docs
 
 In addition to the core distributed consensus-based replication, DocDB extends Raft to add read replicas (also known observer nodes) that do not participate in writes but get a timeline consistent copy of the data in an asynchronous manner.
 
-Read replicas are a read-only extension to the primary data in the cluster. With read replicas, the primary data of the cluster is deployed across multiple zones in one region, or across nearby regions. Read replicas do not add to the write latencies since the write does not synchronously replicate data to them. Instead, the data is replicated to read replicas asynchronously.
+Read replicas are a read-only extension to the primary data in the universe. With read replicas, the primary data of the universe is replicated across multiple zones in one region, or across nearby regions. Read replicas do not add to the write latencies since the write does not synchronously replicate data to them. Instead, the data is replicated to read replicas asynchronously.
 
 Nodes in remote data centers can be added in read-only mode. This is typically used in cases where latency of doing a distributed consensus-based write is not tolerable for some workloads.
 
@@ -27,7 +27,7 @@ The replication factor of a read replica cluster can be an even number as well. 
 
 ## Writing to read replicas
 
-An application can send write requests to read replicas, but these write requests are internally redirected to the source of truth. This is because the read replicas are aware of the topology of the cluster.
+An application can send write requests to read replicas, but these write requests are internally redirected to the source of truth. This is because the read replicas are aware of the topology of the universe.
 
 ## Schema changes
 

--- a/docs/content/stable/architecture/docdb-replication/replication.md
+++ b/docs/content/stable/architecture/docdb-replication/replication.md
@@ -12,7 +12,7 @@ menu:
 type: docs
 ---
 
-Using the Raft distributed consensus protocol, DocDB automatically replicates data synchronously in order to survive failures while maintaining data consistency and avoiding operator intervention.
+Using the Raft distributed consensus protocol, DocDB automatically replicates data synchronously across the primary cluster in order to survive failures while maintaining data consistency and avoiding operator intervention.
 
 ## Concepts
 
@@ -56,7 +56,7 @@ The set of DocDB updates depends on the user-issued write, and involves locking 
 
 After the Raft log is replicated to a majority of tablet-peers and successfully persisted on the majority, the write is applied into the DocDB document storage layer and is subsequently available for reads. After the write is persisted on disk by the document storage layer, the write entries can be purged from the Raft log. This is performed as a controlled background operation without any impact to the foreground operations.
 
-## Replication in a cluster
+## Replication in the primary cluster
 
 The replicas of data can be placed across multiple fault domains. The following examples of a multi-zone deployment with three zones and the replication factor assumed to be 3 demonstrate how replication across fault domains is performed in a cluster.
 


### PR DESCRIPTION
Changing from using cluster to universe for replication architecture pages

This is fixing the terminology; fixes were already made to the xCluster page -- this is fixing the other pages in this section.

A few other minor fixes are made.

I will backport this to stable once accepted.