### PR TITLE
Fix propagation of event type to PerformFuture

### DIFF
--- a/src/yb/util/wait_state.h
+++ b/src/yb/util/wait_state.h
@@ -71,7 +71,7 @@ namespace util {
 YB_DEFINE_ENUM_TYPE(
     WaitStateCode,
     uint32_t,
-    (Unused)
+    ((Unused, 0))
     // General states for incoming RPCs
     ((Created, YB_TSERVER_WAIT_RPC))(Queued)(Handling)(QueueingResponse)(ResponseQueued)
     // Writes
@@ -100,7 +100,7 @@ YB_DEFINE_ENUM_TYPE(
     (StartSubcompactionThreads)(WaitOnSubcompactionThreads)
 
     // Perform Wait Events
-    ((DmlRead, YB_PG_WAIT_PERFORM)) (DmlWrite)
+    ((DmlRead, YB_PG_WAIT_PERFORM)) (DmlWrite) (DmlReadWrite)
     )
 
 struct AUHMetadata {

--- a/src/yb/yql/pggate/pg_doc_op.cc
+++ b/src/yb/yql/pggate/pg_doc_op.cc
@@ -213,11 +213,11 @@ Status PgDocResult::ProcessSparseSystemColumns(std::string *reservoir) {
 
 //--------------------------------------------------------------------------------------------------
 
-PgDocResponse::PgDocResponse(PerformFuture future, util::WaitStateCode wait_event)
-    : holder_(std::move(future)), wait_event_(wait_event) {}
+PgDocResponse::PgDocResponse(PerformFuture future)
+    : holder_(std::move(future)) {}
 
-PgDocResponse::PgDocResponse(ProviderPtr provider, util::WaitStateCode wait_event)
-    : holder_(std::move(provider)), wait_event_(wait_event) {}
+PgDocResponse::PgDocResponse(ProviderPtr provider)
+    : holder_(std::move(provider)) {}
 
 bool PgDocResponse::Valid() const {
   return std::holds_alternative<PerformFuture>(holder_)
@@ -226,10 +226,8 @@ bool PgDocResponse::Valid() const {
 }
 
 Result<PgDocResponse::Data> PgDocResponse::Get() {
-  if (std::holds_alternative<PerformFuture>(holder_)) {
-    std::get<PerformFuture>(holder_).SignalWait(wait_event_);
+  if (std::holds_alternative<PerformFuture>(holder_))
     return std::get<PerformFuture>(holder_).Get();
-  }
 
   // Detach provider pointer after first usage to make PgDocResponse::Valid return false.
   ProviderPtr provider;
@@ -466,7 +464,7 @@ Result<PgDocResponse> PgDocOp::DefaultSender(
     PgSession* session, const PgsqlOpPtr* ops, size_t ops_count, const PgTableDesc& table,
     HybridTime in_txn_limit, ForceNonBufferable force_non_bufferable) {
   return PgDocResponse(VERIFY_RESULT(session->RunAsync(
-      ops, ops_count, table, in_txn_limit, force_non_bufferable)), ops->get()->getWaitEvent());
+      ops, ops_count, table, in_txn_limit, force_non_bufferable)));
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/src/yb/yql/pggate/pg_doc_op.h
+++ b/src/yb/yql/pggate/pg_doc_op.h
@@ -226,15 +226,14 @@ class PgDocResponse {
   using ProviderPtr = std::unique_ptr<Provider>;
 
   PgDocResponse() = default;
-  explicit PgDocResponse(PerformFuture future, util::WaitStateCode wait_event);
-  explicit PgDocResponse(ProviderPtr provider, util::WaitStateCode wait_event);
+  explicit PgDocResponse(PerformFuture future);
+  explicit PgDocResponse(ProviderPtr provider);
 
   bool Valid() const;
   Result<Data> Get();
 
  private:
   std::variant<PerformFuture, ProviderPtr> holder_;
-  util::WaitStateCode wait_event_;
 };
 
 class PgDocOp : public std::enable_shared_from_this<PgDocOp> {

--- a/src/yb/yql/pggate/pg_operation_buffer.h
+++ b/src/yb/yql/pggate/pg_operation_buffer.h
@@ -38,6 +38,7 @@ struct BufferingSettings {
 struct BufferableOperations {
   PgsqlOps operations;
   PgObjectIds relations;
+  util::WaitStateCode wait_event_ = util::WaitStateCode::Unused;
 
   void Add(PgsqlOpPtr op, const PgObjectId& relation);
   void Swap(BufferableOperations* rhs);

--- a/src/yb/yql/pggate/pg_perform_future.h
+++ b/src/yb/yql/pggate/pg_perform_future.h
@@ -37,7 +37,9 @@ class PerformFuture {
   };
 
   PerformFuture() = default;
-  PerformFuture(std::future<PerformResult> future, PgSession* session, PgObjectIds&& relations);
+  PerformFuture(
+      std::future<PerformResult> future, PgSession* session, PgObjectIds&& relations,
+      util::WaitStateCode wait_event);
   PerformFuture(PerformFuture&&) = default;
   PerformFuture& operator=(PerformFuture&&) = default;
   ~PerformFuture();
@@ -45,12 +47,12 @@ class PerformFuture {
   bool Valid() const;
   bool Ready() const;
   Result<Data> Get();
-  void SignalWait(util::WaitStateCode wait_event);
 
  private:
   std::future<PerformResult> future_;
   PgSession* session_ = nullptr;
   PgObjectIds relations_;
+  util::WaitStateCode wait_event_;
 };
 
 } // namespace pggate

--- a/src/yb/yql/pggate/pg_session.cc
+++ b/src/yb/yql/pggate/pg_session.cc
@@ -672,7 +672,7 @@ Result<PerformFuture> PgSession::Perform(BufferableOperations&& ops, PerformOpti
   pg_client_.PerformAsync(&options, &ops.operations, [promise](const PerformResult& result) {
     promise->set_value(result);
   });
-  return PerformFuture(promise->get_future(), this, std::move(ops.relations));
+  return PerformFuture(promise->get_future(), this, std::move(ops.relations), ops.wait_event_);
 }
 
 void PgSession::ProcessPerformOnTxnSerialNo(

--- a/src/yb/yql/pggate/pggate.cc
+++ b/src/yb/yql/pggate/pggate.cc
@@ -184,7 +184,7 @@ class PrecastRequestSender {
     if (!collecting_mode_) {
       auto future = VERIFY_RESULT(session->RunAsync(
           ops, ops_count, table, in_txn_limit, force_non_bufferable));
-      return PgDocResponse(std::move(future), ops->get()->getWaitEvent());
+      return PgDocResponse(std::move(future));
     }
     // For now PrecastRequestSender can work only with a new in txn limit set to the current time
     // for each batch of ops. It doesn't use a single in txn limit for all read ops in a statement.
@@ -197,7 +197,7 @@ class PrecastRequestSender {
     if (!provider_state_) {
       provider_state_ = std::make_shared<ResponseProvider::State>();
     }
-    return PgDocResponse(std::make_unique<ResponseProvider>(provider_state_), ops->get()->getWaitEvent());
+    return PgDocResponse(std::make_unique<ResponseProvider>(provider_state_));
   }
 
   Status TransmitCollected(PgSession* session) {


### PR DESCRIPTION
The previous approach of setting the wait_event in PgDocResponse was wrong. It assumed that each Response represented a single Request. That is not true. A response or PerformFuture represents multiple ops. There is no restriction on the type of ops. So a batch may contain reads/writes. Therefore I have introduced a new type `DmlReadWrite` for batches that may have a mix of reads/writes. I am not sure if a mixed batch can occur in practice. 

The old approach has been removed.

Tested that both DmlRead and DmlWrite are set in ProcArray.

```
yugabyte=# select pid, wait_event_type, wait_event, state, query from pg_stat_activity where state='active';
  pid  | wait_event_type | wait_event | state  |                                              query
-------+-----------------+------------+--------+-------------------------------------------------------------------------------------------------
 82449 | Perform         | DmlWrite   | active | insert into foo(k,v) select g, g from generate_series(4,6) as t(g);
 82685 |                 |            | active | select pid, wait_event_type, wait_event, state, query from pg_stat_activity where state=active;
(2 rows)
```