### PR TITLE
Filter out rpcs which doesn't have top level request id

### DIFF
--- a/src/postgres/src/backend/executor/execMain.c
+++ b/src/postgres/src/backend/executor/execMain.c
@@ -470,6 +470,9 @@ standard_ExecutorEnd(QueryDesc *queryDesc)
 	EState	   *estate;
 	MemoryContext oldcontext;
 
+	if (IsYugaByteEnabled() && queryDesc->plannedstmt->queryId)
+		YBCSetQueryId(queryDesc->plannedstmt->queryId);
+
 	/* sanity checks */
 	Assert(queryDesc != NULL);
 

--- a/src/postgres/src/backend/tcop/utility.c
+++ b/src/postgres/src/backend/tcop/utility.c
@@ -408,6 +408,9 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 	bool		isAtomicContext = (!(context == PROCESS_UTILITY_TOPLEVEL || context == PROCESS_UTILITY_QUERY_NONATOMIC) || IsTransactionBlock());
 	ParseState *pstate;
 
+	if (IsYugaByteEnabled() && pstmt->queryId)
+		YBCSetQueryId(pstmt->queryId);
+
 	/* This can recurse, so check for excessive recursion */
 	check_stack_depth();
 

--- a/src/yb/client/client.cc
+++ b/src/yb/client/client.cc
@@ -2225,7 +2225,7 @@ std::vector<WaitStateInfoPB> YBClient::ActiveUniverseHistory() {
   
   for (auto conns : dump_resp.inbound_connections()) {
     for (auto call : conns.calls_in_flight()) {
-      if (call.has_header() && call.header().remote_method().method_name() != "ActiveUniverseHistory") {
+      if (call.has_header() && call.header().remote_method().method_name() != "ActiveUniverseHistory" && call.has_wait_state()) {
         res.push_back(call.wait_state());
       }
     }
@@ -2233,7 +2233,7 @@ std::vector<WaitStateInfoPB> YBClient::ActiveUniverseHistory() {
 
   for (auto conns : dump_resp.outbound_connections()) {
     for (auto call : conns.calls_in_flight()) {
-      if (call.has_header() && call.header().remote_method().method_name() != "ActiveUniverseHistory") {
+      if (call.has_header() && call.header().remote_method().method_name() != "ActiveUniverseHistory" && call.has_wait_state()) {
         res.push_back(call.wait_state());
       }
     }

--- a/src/yb/tserver/pg_client_service.cc
+++ b/src/yb/tserver/pg_client_service.cc
@@ -466,7 +466,9 @@ class PgClientServiceImpl::Impl {
     auto tserver_wait_states = client().ActiveUniverseHistory();
 
     for (auto wait_state : tserver_wait_states) {
-      resp->add_wait_states()->CopyFrom(wait_state);
+      if (!wait_state.metadata().top_level_request_id().empty()) {
+        resp->add_wait_states()->CopyFrom(wait_state);
+      }
     }
 
     auto bg_wait_states = tablet_server_.GetThreadpoolWaitStates();

--- a/src/yb/tserver/pg_client_session.cc
+++ b/src/yb/tserver/pg_client_session.cc
@@ -916,7 +916,7 @@ template <class DataPtr>
 Status PgClientSession::DoPerform(const DataPtr& data, CoarseTimePoint deadline,
                                   rpc::RpcContext* context) {
   auto& options = *data->req.mutable_options();
-  if (options.has_auh_metadata()) {
+  if (options.has_auh_metadata() && !options.auh_metadata().top_level_request_id().empty()) {
     util::WaitStateInfo::UpdateMetadataFromPB(options.auh_metadata());
   }
   if (!options.ddl_mode() && xcluster_context_ && xcluster_context_->is_xcluster_read_only_mode()) {

--- a/src/yb/yql/pggate/pg_session.cc
+++ b/src/yb/yql/pggate/pg_session.cc
@@ -658,7 +658,9 @@ Result<PerformFuture> PgSession::Perform(BufferableOperations&& ops, PerformOpti
   }
   options.set_trace_requested(pg_txn_manager_->ShouldEnableTracing());
 
-  auh_metadata_.ToPB(options.mutable_auh_metadata());
+  if (!auh_metadata_.top_level_request_id.empty()) {
+    auh_metadata_.ToPB(options.mutable_auh_metadata());
+  }
 
   if (ops_options.cache_options) {
     auto& cache_options = *ops_options.cache_options;
@@ -906,6 +908,7 @@ Result<client::RpcsInfo> PgSession::ActiveUniverseHistory() {
 Status PgSession::SetAUHMetadata(const char* remote_host, int remote_port) {
   auto node_uuid = VERIFY_RESULT(pg_client_.GetTServerUUID());
   pg_callbacks_.ProcSetNodeUUID(node_uuid.c_str());
+  auh_metadata_.top_level_node_id = node_uuid;
   auh_metadata_.client_node_ip = yb::Format("$0:$1", remote_host, remote_port);
   return Status::OK();
 }


### PR DESCRIPTION
Some wait states keeps getting generated at Pggate and TServer side which doesn't have top_level_request_id, top_level_node_ip and query_id. The reason for this is still unknown.

This diff filters out those wait states, so they don't take up space in the circular buffer