### PR TITLE
[docs] secondary and covering indexes backport, systemd cmd for service identification.

### DIFF
--- a/docs/content/preview/explore/indexes-constraints/secondary-indexes-ysql.md
+++ b/docs/content/preview/explore/indexes-constraints/secondary-indexes-ysql.md
@@ -12,6 +12,7 @@ menu:
     weight: 210
 aliases:
   - /preview/explore/ysql-language-features/indexes-1/
+  - /preview/explore/indexes-constraints/secondary-indexes/
 type: docs
 ---
 <ul class="nav nav-tabs-alt nav-tabs-yb">

--- a/docs/content/preview/troubleshoot/cluster/recover_server.md
+++ b/docs/content/preview/troubleshoot/cluster/recover_server.md
@@ -22,6 +22,20 @@ It is recommended to have a cron or systemd setup to ensure that the YB-TServer 
 
 This handles transient failures, such as a node rebooting or process crash due to an unexpected behavior.
 
+If you are using systemd and want to find the names of the services to restart, use the following command:
+
+```sh
+sudo systemctl list-units --type=service | grep yb
+```
+
+You should see output similar to the following:
+
+```output
+yb-controller.service                       loaded active running Yugabyte Controller
+yb-master.service                           loaded active running Yugabyte master service
+yb-tserver.service                          loaded active running Yugabyte tserver service
+```
+
 ## Node failure
 
 Typically, if a node has failed, the system automatically recovers and continues to function with the remaining N-1 nodes. If the failed node does not recover soon enough, and N-1 >= 3, then the under-replicated tablets will be re-replicated automatically to return to RF=3 on the remaining N-1 nodes.

--- a/docs/content/stable/explore/indexes-constraints/covering-index-ycql.md
+++ b/docs/content/stable/explore/indexes-constraints/covering-index-ycql.md
@@ -1,0 +1,135 @@
+---
+title: Covering indexes in YugabyteDB YCQL
+headerTitle: Covering indexes
+linkTitle: Covering indexes
+description: Using covering indexes in YCQL
+headContent: Explore covering indexes in YugabyteDB using YCQL
+image: /images/section_icons/secure/create-roles.png
+menu:
+  stable:
+    identifier: covering-index-ycql
+    parent: explore-indexes-constraints
+    weight: 255
+type: docs
+---
+<ul class="nav nav-tabs-alt nav-tabs-yb">
+  <li >
+    <a href="../covering-index-ysql/" class="nav-link">
+      <i class="icon-postgres" aria-hidden="true"></i>
+      YSQL
+    </a>
+  </li>
+  <li >
+    <a href="../covering-index-ycql/" class="nav-link active">
+      <i class="icon-cassandra" aria-hidden="true"></i>
+      YCQL
+    </a>
+  </li>
+</ul>
+
+A covering index is an index that includes all the columns required by a query, including columns that would typically not be a part of an index. This is done by using the INCLUDE keyword to list the columns you want to include.
+
+A covering index is an efficient way to perform `index-only` scans, where you don't need to scan the table, just the index, to satisfy the query.
+
+## Syntax
+
+```cql
+CREATE INDEX columnA_index_name ON table_name(columnA) INCLUDE (columnC);
+```
+
+For additional information on creating indexes, see [CREATE INDEX](../../../api/ycql/ddl_create_index/).
+
+## Example
+
+{{% explore-setup-single %}}
+
+The following exercise demonstrates how to optimize query performance using a covering index.
+
+1. Create a sample HR keyspace as follows:
+
+    ```cql
+    ycqlsh> CREATE KEYSPACE HR;
+    ycqlsh> USE HR;
+    ```
+
+1. Create and insert some rows into a table `employees` with two columns `id` and `username`
+
+    ```cql
+    CREATE TABLE employees (
+    employee_no integer PRIMARY KEY,
+    name text,
+    department text
+    )
+    WITH TRANSACTIONS = {'enabled':'true'};
+    ```
+
+    ```cql
+    INSERT INTO employees(employee_no, name,department) VALUES(1221, 'John Smith', 'Marketing');
+    INSERT INTO employees(employee_no, name,department) VALUES(1222, 'Bette Davis', 'Sales');
+    INSERT INTO employees(employee_no, name,department) VALUES(1223, 'Lucille Ball', 'Operations');
+    ```
+
+1. Run a select query to fetch a row with a particular username
+
+    ```sql
+    SELECT name FROM employees WHERE department='Sales';
+    ```
+
+    ```output
+     name
+    -------------
+     Bette Davis
+    ```
+
+1. Run `EXPLAIN` on select query to show that the query does a sequential scan before creating an index
+
+    ```cql
+    EXPLAIN SELECT name FROM employees WHERE department='Sales';
+    ```
+
+    ```output
+     QUERY PLAN
+     ----------------------------------
+     Seq Scan on docs.employees
+      Filter: (department = 'Sales')
+    ```
+
+1. Optimize the SELECT query by creating an index as follows
+
+    ```cql
+    CREATE INDEX index_employees_department ON employees(department);
+    ```
+
+    ```cql
+    EXPLAIN SELECT name FROM employees WHERE department='Sales';
+    ```
+
+    ```output
+     QUERY PLAN
+     --------------------------------------------------------------------
+     Index Scan using index_employees_department on employees
+      Key Conditions: (department = 'Sales')
+    ```
+
+   As the select query includes a column that is not included in the index, the query still reaches out to the table to get the column values.
+
+1. Create a covering index by specifying the username column in the INCLUDE clause as follows:
+
+    ```sql
+    CREATE INDEX index_employees_department_nm ON employees(department) include(name);
+    ```
+
+    A covering index allows you to perform an index-only scan if the query select list matches the columns that are included in the index and the additional columns added using the INCLUDE keyword.
+
+    Ideally, specify columns that are updated frequently in the INCLUDE clause. For other cases, it is probably faster to index all the key columns.
+
+    ```sql
+    EXPLAIN SELECT name FROM employees WHERE department='Sales';
+    ```
+
+    ```output
+     QUERY PLAN
+    ----------------------------------------------------------------------------
+    Index Only Scan using HR.index_employees_department_nm on HR.employees
+      Key Conditions: (department = 'Sales')
+    ```

--- a/docs/content/stable/explore/indexes-constraints/covering-index-ysql.md
+++ b/docs/content/stable/explore/indexes-constraints/covering-index-ysql.md
@@ -20,6 +20,12 @@ type: docs
       YSQL
     </a>
   </li>
+    <li >
+    <a href="../covering-index-ycql/" class="nav-link">
+      <i class="icon-cassandra" aria-hidden="true"></i>
+      YCQL
+    </a>
+  </li>
 </ul>
 
 A covering index is an index that includes all the columns required by a query, including columns that would typically not be a part of an index. This is done by using the INCLUDE keyword to list the columns you want to include.

--- a/docs/content/stable/explore/indexes-constraints/secondary-indexes-with-jsonb-ycql.md
+++ b/docs/content/stable/explore/indexes-constraints/secondary-indexes-with-jsonb-ycql.md
@@ -1,0 +1,136 @@
+---
+title: Secondary indexes with JSONB in YugabyteDB YCQL
+headerTitle: Secondary indexes with JSONB
+linkTitle: Secondary indexes with JSONB
+description: Secondary indexes with JSONB in YugabyteDB YCQL
+headContent: Explore secondary indexes with JSONB in YugabyteDB using YCQL
+image: /images/section_icons/secure/create-roles.png
+menu:
+  stable:
+    identifier: secondary-indexes-with-jsonb-ycql
+    parent: explore-indexes-constraints
+    weight: 260
+type: docs
+---
+
+<ul class="nav nav-tabs-alt nav-tabs-yb">
+  <li >
+    <a href="../secondary-indexes-with-jsonb-ysql/" class="nav-link">
+      <i class="icon-postgres" aria-hidden="true"></i>
+      YSQL
+    </a>
+  </li>
+  <li >
+    <a href="../secondary-indexes-with-jsonb-ycql/" class="nav-link active">
+      <i class="icon-cassandra" aria-hidden="true"></i>
+      YCQL
+    </a>
+  </li>
+</ul>
+
+Secondary indexes can be created with a JSONB datatype column in YCQL. Secondary Indexes in YCQL are global and distributed and similar to tables.  So the use of indexes can enhance database performance by enabling the database server to find rows faster.  You can create covering indexes as well as partial indexes with JSONB columns.
+
+The following section describes secondary indexes with JSONB column in YCQL using examples.
+
+{{% explore-setup-single %}}
+
+## Create table
+
+Secondary indexes in YCQL can be created only on tables with `transaction = {'enabled':'true'}`. This is due to the use of distributed ACID transactions under the hood to maintain the consistency of secondary indexes in YCQL.
+
+Any attempt to create a secondary index on a table without `transactions = {'enabled':'true'}` results in an error.
+
+Create a `users` table that has a JSONB column as follows:
+
+```cql
+CREATE TABLE users(
+   id int PRIMARY KEY,
+   first_name TEXT,
+   last_name TEXT,
+   email TEXT,
+   address JSONB
+)
+WITH transactions = {'enabled':'true'};
+```
+
+Insert a few records into `users` table as follows:
+
+```cql
+INSERT INTO users(id, first_name, last_name, email, address) VALUES(1, 'Luke', 'Skywalker','lskywalker@yb.com','{"lane":"551 Starwars way","city":"Skyriver","zip":"327"}');
+INSERT INTO users(id, first_name, last_name, email, address ) VALUES(2, 'Obi-Wan', 'Kenobi','owkenobi@yb.com','{"lane":"552 Starwars way","city":"Skyriver","zip":"327"}');
+INSERT INTO users(id, first_name, last_name, email, address) VALUES(3, 'Yoda',null,'yoda@yb.com','{"lane":"553 Starwars way","city":"Skyriver","zip":"327"}');
+INSERT INTO users(id, first_name, last_name, email, address) VALUES(4, 'Din','Djarin','ddjarin@yb.com','{"lane":"554 Starwars way","city":"Skyriver","zip":"327"}');
+INSERT INTO users(id, first_name, last_name, email) VALUES(5, 'R2','D2','r2d2@yb.com');
+INSERT INTO users(id, first_name, last_name, email) VALUES(6, 'Leia','Princess','lprincess@yb.com');
+
+```
+
+## Create indexes
+
+### Syntax
+
+You can create indexes with JSON column in YCQL using the `CREATE INDEX` statement that has the following syntax:
+
+```cql
+CREATE INDEX index_name ON table_name(column->>'attribute');
+```
+
+*column* represents a JSONB datatype column of the table. *'attribute'* refers to an attribute of the JSON document stored in the JSONB column.
+
+Create an index on the *'zip'* attribute of the JSON document stored in the address column of the users table as follows:
+
+```cql
+CREATE INDEX idx_users_jsonb ON users(address->>'zip');
+```
+
+## List the index and verify the query plan
+
+You can use the `DESCRIBE INDEX` command to check the index as follows:
+
+```cql
+DESCRIBE INDEX idx_users_jsonb;
+```
+
+For additional information regarding the DESCRIBE INDEX command, see [DESCRIBE INDEX](../../../admin/ycqlsh/#describe).
+
+You can also use the `EXPLAIN` statement to check if a query uses an index and determine the query plan before execution.
+
+```cql
+EXPLAIN SELECT * FROM users WHERE address->>'zip' = '327';
+```
+
+For additional information, see the [EXPLAIN](../../../api/ycql/explain/) statement.
+
+## Covering index and Partial index with JSONB column
+
+You can also create covering and partial indexes with a JSONB column.
+
+### Covering index
+
+A covering index includes all columns used in the query in the index definition. You do this using the `INCLUDE` keyword in the `CREATE INDEX` syntax as follows:
+
+```cql
+CREATE INDEX idx_users_jsonb_cov ON users((address->>'zip'))
+     INCLUDE (first_name,last_name);
+```
+
+### Partial index
+
+A partial index is created on a subset of data when you want to restrict the index to a specific condition. You do this using the `WHERE` clause in the `CREATE INDEX` syntax as follows:
+
+``` cql
+CREATE INDEX idx_users_jsonb_part ON users (address->>'zip')
+       WHERE email = 'lskywalker@yb.com';
+```
+
+For additional information on the CREATE INDEX statement, see [CREATE INDEX](../../../api/ycql/ddl_create_index/).
+
+## Remove indexes
+
+You can remove an index created with the JSONB datatype column using the `DROP INDEX` statement in YCQL with the following syntax:
+
+```sql
+DROP INDEX idx_users_jsonb;
+```
+
+For additional information, see [DROP INDEX](../../../api/ycql/ddl_drop_index/).

--- a/docs/content/stable/explore/indexes-constraints/secondary-indexes-with-jsonb-ysql.md
+++ b/docs/content/stable/explore/indexes-constraints/secondary-indexes-with-jsonb-ysql.md
@@ -1,0 +1,31 @@
+---
+title: Secondary indexes with JSONB in YugabyteDB YSQL
+headerTitle: Secondary indexes with JSONB
+linkTitle: Secondary indexes with JSONB
+description: Secondary indexes with JSONB in YugabyteDB YSQL
+headContent: Explore secondary indexes with JSONB in YugabyteDB using YSQL
+image: /images/section_icons/secure/create-roles.png
+menu:
+  stable:
+    identifier: secondary-indexes-with-jsonb-ysql
+    parent: explore-indexes-constraints
+    weight: 265
+type: docs
+---
+
+<ul class="nav nav-tabs-alt nav-tabs-yb">
+  <li >
+    <a href="../secondary-indexes-with-jsonb-ysql/" class="nav-link active">
+      <i class="icon-postgres" aria-hidden="true"></i>
+      YSQL
+    </a>
+  </li>
+  <li >
+    <a href="../secondary-indexes-with-jsonb-ycql/" class="nav-link">
+      <i class="icon-cassandra" aria-hidden="true"></i>
+      YCQL
+    </a>
+  </li>
+</ul>
+
+Coming soon !!!

--- a/docs/content/stable/explore/indexes-constraints/secondary-indexes-ycql.md
+++ b/docs/content/stable/explore/indexes-constraints/secondary-indexes-ycql.md
@@ -1,0 +1,137 @@
+---
+title: Secondary indexes in YugabyteDB YCQL
+headerTitle: Secondary indexes
+linkTitle: Secondary indexes
+description: Overview of Secondary indexes in YCQL
+headContent: Explore secondary indexes in YugabyteDB using YCQL
+image: /images/section_icons/secure/create-roles.png
+menu:
+  stable:
+    identifier: secondary-indexes-ycql
+    parent: explore-indexes-constraints
+    weight: 220
+type: docs
+---
+<ul class="nav nav-tabs-alt nav-tabs-yb">
+  <li >
+    <a href="../secondary-indexes-ysql/" class="nav-link">
+      <i class="icon-postgres" aria-hidden="true"></i>
+      YSQL
+    </a>
+  </li>
+  <li >
+    <a href="../secondary-indexes-ycql/" class="nav-link active">
+      <i class="icon-cassandra" aria-hidden="true"></i>
+      YCQL
+    </a>
+  </li>
+</ul>
+
+The use of indexes can enhance database performance by enabling the database server to find rows faster. You can create, drop, and list indexes in YCQL.
+
+## Create indexes
+
+You can create indexes in YCQL using the `CREATE INDEX` statement using the following syntax:
+
+```sql
+CREATE INDEX index_name ON table_name(column_list);
+```
+
+YCQL supports [Unique](../../../explore/indexes-constraints/unique-index-ycql/), [Partial](../../../explore/indexes-constraints/partial-index-ycql/), and [Covering](../../../explore/indexes-constraints/covering-index-ycql/) secondary indexes.
+
+For additional information on creating indexes, see [CREATE INDEX](../../../api/ycql/ddl_create_index/).
+
+## List indexes and verify the query plan
+
+You can use the [DESCRIBE INDEX](../../../admin/ycqlsh/#describe) command to check the indexes as follows:
+
+```cql
+DESCRIBE INDEX <index_name>
+```
+
+For additional information, see [DESCRIBE INDEX](../../../admin/ycqlsh/#describe).
+
+You can also use the `EXPLAIN` statement to check if a query uses an index and determine the query plan before execution.
+
+For more information, see [EXPLAIN statement in YCQL](../../../api/ycql/explain/).
+
+## Remove indexes
+
+You can remove an index using the `DROP INDEX` statement in YCQL using the following syntax:
+
+```sql
+DROP INDEX index_name;
+```
+
+For additional information, see [DROP INDEX](../../../api/ycql/ddl_drop_index/).
+
+## Example scenario using YCQL
+
+{{% explore-setup-single %}}
+
+Suppose you work with a database that includes the following table populated with data:
+
+```cql
+CREATE TABLE employees (
+  employee_no integer PRIMARY KEY,
+  name text,
+  department text
+)
+WITH TRANSACTIONS = {'enabled':'true'};
+```
+
+```cql
+INSERT INTO employees(employee_no, name,department) VALUES(1221, 'John Smith', 'Marketing');
+INSERT INTO employees(employee_no, name,department) VALUES(1222, 'Bette Davis', 'Sales');
+INSERT INTO employees(employee_no, name,department) VALUES(1223, 'Lucille Ball', 'Operations');
+```
+
+The following example shows a query that finds employees working in Operations:
+
+```cql
+SELECT * FROM employees WHERE department = 'Operations';
+```
+
+To process the preceding query, the whole `employees` table needs to be scanned and all the shards have to be accessed. For large organizations, this will take a significant amount of time. You can confirm this using the following `EXPLAIN` statement which indicates `seq scan` on the table.
+
+```cql
+EXPLAIN SELECT * FROM employees WHERE department = 'Operations';
+```
+
+```output
+ QUERY PLAN
+---------------------------------------
+ Seq Scan on employees
+   Filter: (department = 'Operations')
+```
+
+To speed up the process, you create an index for the department column, as follows:
+
+```cql
+CREATE INDEX index_employees_department ON employees(department);
+```
+
+The following example executes the query after the index has been applied to `department` and uses the `EXPLAIN` statement to prove that the index is used during query execution:
+
+```cql
+EXPLAIN SELECT * FROM employees WHERE department = 'Operations';
+```
+
+Following is the output produced by the preceding example:
+
+```output
+ QUERY PLAN
+--------------------------------------------------------------------
+ Index Scan using docs.index_employees_department on docs.employees
+   Key Conditions: (department = 'Operations')
+```
+
+To remove the index `index_employees_department`, use the following command:
+
+```cql
+DROP INDEX index_employees_department;
+```
+
+## Learn more
+
+- [Secondary indexes with JSONB](../secondary-indexes-with-jsonb-ycql/)

--- a/docs/content/stable/explore/indexes-constraints/secondary-indexes-ysql.md
+++ b/docs/content/stable/explore/indexes-constraints/secondary-indexes-ysql.md
@@ -5,6 +5,8 @@ linkTitle: Secondary indexes
 description: Overview of Secondary indexes in YSQL and YCQL
 headContent: Explore secondary indexes in YugabyteDB using YSQL and YCQL
 image: /images/section_icons/secure/create-roles.png
+aliases:
+  - /stable/explore/indexes-constraints/secondary-indexes/
 menu:
   stable:
     identifier: secondary-indexes
@@ -12,6 +14,21 @@ menu:
     weight: 220
 type: docs
 ---
+
+<ul class="nav nav-tabs-alt nav-tabs-yb">
+  <li >
+    <a href="../secondary-indexes-ysql/" class="nav-link active">
+      <i class="icon-postgres" aria-hidden="true"></i>
+      YSQL
+    </a>
+  </li>
+  <li >
+    <a href="../secondary-indexes-ycql/" class="nav-link">
+      <i class="icon-cassandra" aria-hidden="true"></i>
+      YCQL
+    </a>
+  </li>
+</ul>
 
 The use of indexes can enhance database performance by enabling the database server to find rows faster. You can create, drop, and list indexes, as well as use indexes on expressions.
 


### PR DESCRIPTION
- fixes #18243 , #17628
@netlify /stable/explore/indexes-constraints/covering-index-ycql/