### PR TITLE
[Docs] Fix Release section left navigation

### DIFF
--- a/docs/config/_default/menus.toml
+++ b/docs/config/_default/menus.toml
@@ -500,18 +500,26 @@
 [[preview_releases]]
   name = "Releases"
   weight = 2
-  identifier = "release-notes"
+  identifier = "release-versioning"
+  url = "/releases/versioning/"
   [preview_releases.params]
     showSection = true
-    hideLink = true
+
+[[preview_releases]]
+  name = "Releases"
+  weight = 3
+  identifier = "releases"
+  url = "/preview/releases/"
+  [preview_releases.params]
+    showSection = true
 
 [[preview_releases]]
   name = "YBA Releases"
-  weight = 3
-  identifier = "yba-release-notes"
+  weight = 4
+  identifier = "yba-releases"
+  url = "/preview/releases/yba-releases/"
   [preview_releases.params]
     showSection = true
-    hideLink = true
 
 ########## Menus (in preview) for FAQ section
 

--- a/docs/config/_default/menus.toml
+++ b/docs/config/_default/menus.toml
@@ -498,10 +498,10 @@
     showSection = true
 
 [[preview_releases]]
-  name = "Releases"
+  name = "Release versioning"
   weight = 2
   identifier = "release-versioning"
-  url = "/releases/versioning/"
+  url = "/preview/releases/versioning/"
   [preview_releases.params]
     showSection = true
 
@@ -514,7 +514,7 @@
     showSection = true
 
 [[preview_releases]]
-  name = "YBA Releases"
+  name = "YugabyteDB Anywhere releases"
   weight = 4
   identifier = "yba-releases"
   url = "/preview/releases/yba-releases/"

--- a/docs/content/preview/releases/_index.md
+++ b/docs/content/preview/releases/_index.md
@@ -7,11 +7,6 @@ image: /images/section_icons/index/quick_start.png
 aliases:
   - /preview/releases/releases-overview/
   - /preview/releases/whats-new/
-menu:
-  preview_releases:
-    identifier: releases
-    parent: release-notes
-    weight: 1060
 type: indexpage
 showRightNav: true
 cascade:

--- a/docs/content/preview/releases/versioning.md
+++ b/docs/content/preview/releases/versioning.md
@@ -9,11 +9,6 @@ aliases:
   - /v2.14/releases/versioning/
   - /v2.12/releases/versioning/
   - /v2.8/releases/versioning/
-menu:
-  preview_releases:
-    identifier: versioning
-    parent: release-notes
-    weight: 1000
 type: docs
 ---
 

--- a/docs/content/preview/releases/yba-releases/_index.md
+++ b/docs/content/preview/releases/yba-releases/_index.md
@@ -4,11 +4,6 @@ headerTitle: YugabyteDB Anywhere releases
 linkTitle: YugabyteDB Anywhere releases
 description: An overview of YugabyteDB Anywhere releases, including preview and current stable releases.
 image: /images/section_icons/index/quick_start.png
-menu:
-  preview_releases:
-    identifier: yba-releases
-    parent: release-notes
-    weight: 1070
 type: indexpage
 showRightNav: true
 cascade:


### PR DESCRIPTION
In Releases section, leftnav, when selecting a release under YBA releases, the core releases menu opens. And selecting item in YBA releases doesn't close Releases menu. 