### PR TITLE
[docs] Fix typo `unit64_t` -> `uint64_t`

### DIFF
--- a/docs/content/preview/architecture/transactions/transaction-priorities.md
+++ b/docs/content/preview/architecture/transactions/transaction-priorities.md
@@ -182,7 +182,7 @@ The following examples demonstrate how to set priorities for your transactions a
 
 {{< note title="Internal representation of priorities" >}}
 
-Internally, both the normal and high-priority buckets are mapped to a `unit64_t` space. The 64 bit range is used by the two priority buckets as follows:
+Internally, both the normal and high-priority buckets are mapped to a `uint64_t` space. The 64 bit range is used by the two priority buckets as follows:
 
 1. Normal-priority bucket: `[yb::kRegularTxnLowerBound, yb::kRegularTxnUpperBound]`, that is, 0 to  `uint32_t_max`-1
 

--- a/docs/content/stable/architecture/transactions/transaction-priorities.md
+++ b/docs/content/stable/architecture/transactions/transaction-priorities.md
@@ -182,7 +182,7 @@ The following examples demonstrate how to set priorities for your transactions a
 
 {{< note title="Internal representation of priorities" >}}
 
-Internally, both the normal and high-priority buckets are mapped to a `unit64_t` space. The 64 bit range is used by the two priority buckets as follows:
+Internally, both the normal and high-priority buckets are mapped to a `uint64_t` space. The 64 bit range is used by the two priority buckets as follows:
 
 1. Normal-priority bucket: `[yb::kRegularTxnLowerBound, yb::kRegularTxnUpperBound]`, that is, 0 to  `uint32_t_max`-1
 

--- a/src/postgres/src/test/regress/expected/yb_get_current_transaction_priority.out
+++ b/src/postgres/src/test/regress/expected/yb_get_current_transaction_priority.out
@@ -2,7 +2,7 @@
 -- priority of a distributed transaction in Yugabyte if one has been started. If a distributed
 -- transaction hasn't been started, it returns 0.
 --
--- The priority space of distributed transactions is unit64_t. The 64 bit range is split into 2
+-- The priority space of distributed transactions is uint64_t. The 64 bit range is split into 2
 -- priority buckets -
 --   1. Normal priority bucket:
 --        [yb::kRegularTxnLowerBound, yb::kRegularTxnUpperBound] i.e., 0 to uint32_t_max-1

--- a/src/postgres/src/test/regress/sql/yb_get_current_transaction_priority.sql
+++ b/src/postgres/src/test/regress/sql/yb_get_current_transaction_priority.sql
@@ -2,7 +2,7 @@
 -- priority of a distributed transaction in Yugabyte if one has been started. If a distributed
 -- transaction hasn't been started, it returns 0.
 --
--- The priority space of distributed transactions is unit64_t. The 64 bit range is split into 2
+-- The priority space of distributed transactions is uint64_t. The 64 bit range is split into 2
 -- priority buckets -
 --   1. Normal priority bucket:
 --        [yb::kRegularTxnLowerBound, yb::kRegularTxnUpperBound] i.e., 0 to uint32_t_max-1


### PR DESCRIPTION
Fixes #18297