### PR TITLE
Add method name in wait_event_aux for TServer RPCs

### DIFF
--- a/src/postgres/contrib/yb_auh/yb_auh.c
+++ b/src/postgres/contrib/yb_auh/yb_auh.c
@@ -205,7 +205,7 @@ static void tserver_collect_samples(TimestampTz auh_sample_time)
   for (int i = 0; i < numrpcs; i++) {
     auh_entry_store(auh_sample_time, rpcs[i].metadata.top_level_request_id,
                     rpcs[i].metadata.current_request_id, rpcs[i].wait_status_code,
-                    rpcs[i].aux_info.tablet_id, rpcs[i].metadata.top_level_node_id,
+                    rpcs[i].aux_info.method, rpcs[i].metadata.top_level_node_id,
                     rpcs[i].metadata.client_node_ip, 0, rpcs[i].metadata.query_id,
                     auh_sample_time, 1);
   }

--- a/src/yb/common/common.proto
+++ b/src/yb/common/common.proto
@@ -621,6 +621,7 @@ message AUHMetadataPB {
 message AUHAuxDataPB {
   optional string tablet_id = 1;
   optional string table_id = 2;
+  optional string method = 3;
 }
 
 message WaitStateInfoPB {

--- a/src/yb/rpc/yb_rpc.cc
+++ b/src/yb/rpc/yb_rpc.cc
@@ -28,7 +28,6 @@
 #include "yb/rpc/rpc_introspection.pb.h"
 #include "yb/rpc/serialization.h"
 
-#include "yb/util/debug-util.h"
 #include "yb/util/debug/trace_event.h"
 #include "yb/util/flags.h"
 #include "yb/util/format.h"

--- a/src/yb/rpc/yb_rpc.cc
+++ b/src/yb/rpc/yb_rpc.cc
@@ -28,6 +28,7 @@
 #include "yb/rpc/rpc_introspection.pb.h"
 #include "yb/rpc/serialization.h"
 
+#include "yb/util/debug-util.h"
 #include "yb/util/debug/trace_event.h"
 #include "yb/util/flags.h"
 #include "yb/util/format.h"
@@ -281,9 +282,12 @@ Status YBInboundCall::ParseFrom(const MemTrackerPtr& mem_tracker, CallData* call
   auto wait_state = this->wait_state();
   if (wait_state) {
     wait_state->UpdateMetadata({
-              .current_request_id = header_.call_id,
-              .client_node_ip = yb::ToString(remote_address())
-            });
+      .current_request_id = header_.call_id,
+      .client_node_ip = yb::ToString(remote_address())
+    });
+    wait_state->UpdateAuxInfo({
+      .method = method_name().ToBuffer(),
+    });
   } else {
     LOG(ERROR) << "Wait state is nullptr for " << ToString();
   }

--- a/src/yb/tserver/tablet_service.cc
+++ b/src/yb/tserver/tablet_service.cc
@@ -2054,7 +2054,13 @@ void TabletServiceImpl::Write(const WriteRequestPB* req,
   }
 
   if (req->has_auh_metadata()) {
-    util::WaitStateInfo::UpdateMetadataFromPB(req->auh_metadata());
+    auto wait_state = util::WaitStateInfo::CurrentWaitState();
+    if (wait_state && req->has_tablet_id()) {
+      wait_state->UpdateAuxInfo(util::AUHAuxInfo{ .tablet_id = req->tablet_id() });
+    }
+    if (wait_state && req->has_auh_metadata()) {
+      wait_state->UpdateMetadataFromPB(req->auh_metadata());
+    }
   }
   auto status = PerformWrite(req, resp, &context);
   if (!status.ok()) {
@@ -2071,7 +2077,13 @@ void TabletServiceImpl::Read(const ReadRequestPB* req,
   }
 
   if (req->has_auh_metadata()) {
-    util::WaitStateInfo::UpdateMetadataFromPB(req->auh_metadata());
+    auto wait_state = util::WaitStateInfo::CurrentWaitState();
+    if (wait_state && req->has_tablet_id()) {
+      wait_state->UpdateAuxInfo(util::AUHAuxInfo{ .tablet_id = req->tablet_id() });
+    }
+    if (wait_state && req->has_auh_metadata()) {
+      wait_state->UpdateMetadataFromPB(req->auh_metadata());
+    }
   }
   PerformRead(server_, this, req, resp, std::move(context));
 }

--- a/src/yb/util/wait_state.cc
+++ b/src/yb/util/wait_state.cc
@@ -23,7 +23,19 @@ namespace yb::util {
 thread_local WaitStateInfoPtr WaitStateInfo::threadlocal_wait_state_;
 
 std::string AUHAuxInfo::ToString() const {
-  return YB_STRUCT_TO_STRING(table_id, tablet_id);
+  return YB_STRUCT_TO_STRING(table_id, tablet_id, method);
+}
+
+void AUHAuxInfo::UpdateFrom(const AUHAuxInfo &other) {
+  if (!other.tablet_id.empty()) {
+    tablet_id = other.tablet_id;
+  }
+  if (!other.table_id.empty()) {
+    table_id = other.table_id;
+  }
+  if (!other.method.empty()) {
+    method = other.method;
+  }
 }
 
 WaitStateInfo::WaitStateInfo(AUHMetadata meta)
@@ -75,6 +87,11 @@ void WaitStateInfo::set_current_request_id(int64_t current_request_id) {
 void WaitStateInfo::UpdateMetadata(const AUHMetadata& meta) {
   std::lock_guard<simple_spinlock> l(mutex_);
   metadata_.UpdateFrom(meta);
+}
+
+void WaitStateInfo::UpdateAuxInfo(const AUHAuxInfo& aux) {
+  std::lock_guard<simple_spinlock> l(mutex_);
+  aux_info_.UpdateFrom(aux);
 }
 
 void WaitStateInfo::SetCurrentWaitState(WaitStateInfoPtr wait_state) {

--- a/src/yb/util/wait_state.h
+++ b/src/yb/util/wait_state.h
@@ -188,20 +188,25 @@ struct AUHMetadata {
 struct AUHAuxInfo {
   std::string tablet_id;
   std::string table_id;
+  std::string method;
 
   std::string ToString() const;
+
+  void UpdateFrom(const AUHAuxInfo &other);
 
   template <class PB>
   void ToPB(PB* pb) const {
     pb->set_tablet_id(tablet_id);
     pb->set_table_id(table_id);
+    pb->set_method(method);
   }
 
   template <class PB>
   static AUHAuxInfo FromPB(const PB& pb) {
     return AUHAuxInfo{
       .tablet_id = pb.tablet_id(),
-      .table_id = pb.table_id()
+      .table_id = pb.table_id(),
+      .method = pb.method()
     };
   }
 };
@@ -222,6 +227,7 @@ class WaitStateInfo {
   static void SetCurrentWaitState(WaitStateInfoPtr);
 
   void UpdateMetadata(const AUHMetadata& meta) EXCLUDES(mutex_);
+  void UpdateAuxInfo(const AUHAuxInfo& aux) EXCLUDES(mutex_);
   void set_current_request_id(int64_t id) EXCLUDES(mutex_);
 
   template <class PB>

--- a/src/yb/yql/pggate/ybc_pg_typedefs.h
+++ b/src/yb/yql/pggate/ybc_pg_typedefs.h
@@ -408,6 +408,7 @@ typedef struct AUHMetadataDescriptor {
 typedef struct AUHAuxDescriptor {
   const char* table_id;
   const char* tablet_id;
+  const char* method;
 } YBCAUHAuxDescriptor;
 
 typedef struct AUHDescriptor {

--- a/src/yb/yql/pggate/ybc_pggate.cc
+++ b/src/yb/yql/pggate/ybc_pggate.cc
@@ -1586,6 +1586,7 @@ YBCStatus YBCActiveUniverseHistory(YBCAUHDescriptor **rpcs, size_t* count) {
         .aux_info = {
           .table_id = YBCPAllocStdString(info.aux_info.table_id),
           .tablet_id = YBCPAllocStdString(info.aux_info.tablet_id),
+          .method = YBCPAllocStdString(info.aux_info.method),
         },
         .wait_status_code_as_string = YBCPAllocStdString(info.wait_status_code_as_string),
       };


### PR DESCRIPTION
There are some RPCs in the TServer which are not from Perform() like CreateTablet, FinishTransaction, Heartbeat, and even ActiveUniverseHistory. Right now, these don't have metadata like top_level_request_id, top_level_node_id, query_id.

This PR adds the method name in the aux_info so we can identify these.