### PR TITLE
[docs] CDCSDK: Add documentation for transaction ordering with CDC

### DIFF
--- a/docs/content/preview/admin/yb-admin.md
+++ b/docs/content/preview/admin/yb-admin.md
@@ -1622,6 +1622,8 @@ For example:
     create_change_data_stream ysql.yugabyte
 ```
 
+
+
 ##### Enabling before image
 
 To create a change data capture (CDC) DB stream which also supports sending the before image of the record, use the following command.
@@ -1638,6 +1640,28 @@ yb-admin \
 * *namespace_name*: The namespace on which the DB stream ID is to be created.
 * `IMPLICIT`: Checkpointing type on the server.
 * `ALL`: Record type indicating the server that the stream should send the before image too.
+
+A successful operation of the above command returns a message with a DB stream ID:
+
+```output
+CDC Stream ID: d540f5e4890c4d3b812933cbfd703ed3
+```
+
+##### Creating stream in EXPLICIT checkpointing mode
+
+To create a change data capture (CDC) DB stream which works in the EXPLICIT checkpointing mode where the client is responsible for managing the checkpoints, use the following command:
+
+**Syntax**
+
+```sh
+yb-admin \
+    -master_addresses <master-addresses> \
+    create_change_data_stream ysql.<namespace_name> EXPLICIT
+```
+
+* *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.
+* *namespace_name*: The namespace on which the DB stream ID is to be created.
+* `EXPLICIT`: Checkpointing type on the server.
 
 A successful operation of the above command returns a message with a DB stream ID:
 

--- a/docs/content/preview/explore/change-data-capture/debezium-connector-yugabytedb.md
+++ b/docs/content/preview/explore/change-data-capture/debezium-connector-yugabytedb.md
@@ -1139,7 +1139,7 @@ For usage example, refer to YugabyteDB CDC Consistent Streaming Pipeline in the 
 The connector publishes metadata that can be used to distinguish transaction boundaries for a downstream application to implement atomicity. Once the configuration property `provide.transaction.metadata` is enabled, the connector will also publish events indicating the beginning and end of the transaction. For more information, see [Transaction metadata](#transaction-metadata).
 
 ### Prerequisites
-* Create the Stream ID should in the `EXPLICIT` checkpointing mode. For more information, see [yb-admin create\_change\_data_stream](../../../admin/yb-admin#create_change_data_stream).
+* Create the Stream ID should in the `EXPLICIT` checkpointing mode. For more information, see [yb-admin create\_change\_data_stream](../../../admin/yb-admin#create-change-data-stream).
 * You should always run the connector with a single task, that is, `tasks.max` should always be set to 1.
 
 ### Known limitations

--- a/docs/content/stable/admin/yb-admin.md
+++ b/docs/content/stable/admin/yb-admin.md
@@ -1638,6 +1638,28 @@ A successful operation of the above command returns a message with a DB stream I
 CDC Stream ID: d540f5e4890c4d3b812933cbfd703ed3
 ```
 
+##### Creating stream in EXPLICIT checkpointing mode
+
+To create a change data capture (CDC) DB stream which works in the EXPLICIT checkpointing mode where the client is responsible for managing the checkpoints, use the following command:
+
+**Syntax**
+
+```sh
+yb-admin \
+    -master_addresses <master-addresses> \
+    create_change_data_stream ysql.<namespace_name> EXPLICIT
+```
+
+* *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.
+* *namespace_name*: The namespace on which the DB stream ID is to be created.
+* `EXPLICIT`: Checkpointing type on the server.
+
+A successful operation of the above command returns a message with a DB stream ID:
+
+```output
+CDC Stream ID: d540f5e4890c4d3b812933cbfd703ed3
+```
+
 #### list_change_data_streams
 
 Lists all the created CDC DB streams.

--- a/docs/content/stable/explore/change-data-capture/debezium-connector-yugabytedb.md
+++ b/docs/content/stable/explore/change-data-capture/debezium-connector-yugabytedb.md
@@ -1051,6 +1051,7 @@ Advanced connector configuration properties:
 | tombstones.on.delete | `true` | Controls whether a delete event is followed by a tombstone event.<br/><br/> `true` - a delete operation is represented by a delete event and a subsequent tombstone event.<br/><br/> `false` - only a delete event is emitted.<br/><br/> After a source record is deleted, emitting a tombstone event (the default behavior) allows Kafka to completely delete all events that pertain to the key of the deleted row in case log compaction is enabled for the topic. |
 | auto.add.new.tables | `true` | Controls whether the connector should keep polling the server to check if any new table has been added to the configured change data stream ID. If a new table has been found in the stream ID and if it has been included in the `table.include.list`, the connector will be restarted automatically. |
 | new.table.poll.interval.ms | 300000 | The interval at which the poller thread will poll the server to check if there are any new tables in the configured change data stream ID. |
+| transaction.ordering | `false` | Whether to order transactions by their commit time. |
 
 ### Transformers
 
@@ -1105,6 +1106,40 @@ By default, the YugabyteDB CDC service publishes events with a schema that only 
 However, some sink connectors may not understand the preceding format. `PGCompatible` transforms the payload to a format that is compatible with the format of the standard change data events. Specifically, it transforms column schema and value to remove the set field and collapse the payload such that it only contains the data type schema and value.
 
 PGCompatible differs from `YBExtractNewRecordState` by recursively modifying all the fields in a payload.
+
+## Transaction ordering
+
+In a CDC Stream, events from different transactions in different tablets across tables may appear at different times. This works well in use cases such as archiving, or with applications where only eventual consistency is required. There is another class of applications, where the end destination is another OLTP / operational database. These databases can have constraints (such as foreign keys) and strict transactional consistency requirements. In these cases, the stream of events cannot be applied as is, as events of the same transaction may appear out of order because transactions in YugabyteDB can span two tablets.
+
+The YugabyteDB source connector supports transaction ordering, which guarantees consistent streaming of records in the sorted order based on time. With transaction ordering enabled, the connector can be used to stream change events while honoring the constraints.
+
+To use transaction ordering, you need to set the configuration property `transaction.ordering` to `true`. Additionally, a transformer [ByLogicalTableRouter](https://debezium.io/documentation/reference/stable/transformations/topic-routing.html) is required to send all the events to a common topic to ensure that the published change events are published in the same sorted order as they are meant to be.
+
+The following table describes properties for configuring transaction ordering.
+
+| Property | Definition |
+| :--- | :--- |
+| transaction.ordering | Whether to enable ordering of transactions by their commit time. |
+| transforms | Logical name for the transformer to use. For example, the following property definitions use `Reroute`. |
+| transforms.Reroute.topic.regex | Specifies a regular expression that the transformation applies to each change event record to determine if it should be routed to a particular topic. |
+| transforms.Reroute.topic.replacement | A regular expression that represents the destination topic name. |
+| transforms.Reroute.type | Transformer class to be used. |
+| transforms.Reroute.key.field.regex | Specifies a regular expression that the transformation applies to the default destination topic name to capture one or more groups of characters. |
+| transforms.Reroute.key.field.replacement | Specifies a regular expression for determining the value of the inserted key field in terms of those captured groups. |
+| provide.transaction.metadata | Whether to generate events with transaction boundaries. |
+
+For usage example, refer to YugabyteDB CDC Consistent Streaming Pipeline in the [example repository](https://github.com/yugabyte/cdc-examples/tree/main/consistent-streaming).
+
+### Transaction boundaries
+
+The connector publishes metadata that can be used to distinguish transaction boundaries for a downstream application to implement atomicity. Once the configuration property `provide.transaction.metadata` is enabled, the connector will also publish events indicating the beginning and end of the transaction. For more information, see [Transaction metadata](#transaction-metadata).
+
+### Prerequisites
+* Create the Stream ID should in the `EXPLICIT` checkpointing mode. For more information, see [yb-admin create\_change\_data_stream](../../../admin/yb-admin#create-change-data-stream).
+* You should always run the connector with a single task, that is, `tasks.max` should always be set to 1.
+
+### Known limitations
+* Transactional ordering is currently not supported with schema evolution. See issue [18476](https://github.com/yugabyte/yugabyte-db/issues/18476).
 
 ## Monitoring
 


### PR DESCRIPTION
This PR adds the documentation related to using transaction ordering with CDC in YugabyteDB.