### PR TITLE
[#19018] yb-admin get_xcluster_info should return valid JSON

### DIFF
--- a/src/yb/tools/yb-admin_client.cc
+++ b/src/yb/tools/yb-admin_client.cc
@@ -2105,8 +2105,8 @@ Status ClusterAdminClient::GetXClusterConfig() {
   MessageToJsonString(
       cluster_config.cluster_config().consumer_registry(), &consumer_registry_output);
   cout << Format(
-              "{\"version\":$0,\"xcluster_producer_registry\":$1,consumer_"
-              "registry:$2}",
+              "{\"version\":$0,\"xcluster_producer_registry\":$1,\"consumer_"
+              "registry\":$2}",
               xcluster_config.xcluster_config().version(), producer_registry_output,
               consumer_registry_output)
        << endl;


### PR DESCRIPTION
Currently `yb-admin get_xcluster_info` returns invalid JSON which makes parsing long output with tools like `jq` difficult.

Steps to reproduce

Before:
```
$ yb-admin get_xcluster_info | jq
parse error: Invalid numeric literal at line 1, column 63
```

After:
```
$ yb-admin get_xcluster_info | jq
{
  "version": 0,
  "xcluster_producer_registry": {},
  "consumer_registry": {}
}
```