### PR TITLE
Ability to Freeze WaitState in time while fetching waitstates.

### DIFF
--- a/src/postgres/contrib/yb_auh/yb_auh.c
+++ b/src/postgres/contrib/yb_auh/yb_auh.c
@@ -116,6 +116,7 @@ yb_auh_sighup(SIGNAL_ARGS)
 void
 yb_auh_main(Datum main_arg) {
   // TODO:
+  MyAuxProcType = YbAUHProcess;
   YBInitPostgresBackend("postgres", "", "hemant");
 
   ereport(LOG, (errmsg("starting bgworker yb_auh with buffer size %d", circular_buf_size)));

--- a/src/postgres/src/include/miscadmin.h
+++ b/src/postgres/src/include/miscadmin.h
@@ -410,6 +410,7 @@ typedef enum
 	CheckpointerProcess,
 	WalWriterProcess,
 	WalReceiverProcess,
+	YbAUHProcess,
 
 	NUM_AUXPROCTYPES			/* Must be last! */
 } AuxProcType;

--- a/src/yb/common/ql_protocol.proto
+++ b/src/yb/common/ql_protocol.proto
@@ -198,6 +198,8 @@ message QLWriteRequestPB {
   // Does this request correspond to backfilling an index table?
   optional bool is_backfill = 19 [default = false];
   optional bool is_compatible_with_previous_version = 20 [ default = false ];
+
+  optional AUHMetadataPB auh_metadata = 21;
 }
 
 //-------------------------------------- Read request ----------------------------------------
@@ -291,6 +293,8 @@ message QLReadRequestPB {
   // Flag for reading aggregate values.
   optional bool is_aggregate = 19 [default = false];
   optional bool is_compatible_with_previous_version = 22 [ default = false ];
+
+  optional AUHMetadataPB auh_metadata = 24;
 }
 
 //------------------------------ Response (for both read and write) -----------------------------

--- a/src/yb/master/master_tserver.cc
+++ b/src/yb/master/master_tserver.cc
@@ -187,8 +187,9 @@ std::vector<yb::util::WaitStateInfoPtr> MasterTabletServer::GetThreadpoolWaitSta
   return {};
 }
 
-std::vector<WaitStateInfoPB> MasterTabletServer::ActiveUniverseHistory() const {
-  return {};
+rpc::Messenger* MasterTabletServer::GetMessenger(yb::util::MessengerType messenger_type) const {
+  LOG(FATAL) << "Unexpected call of GetMessenger()";
+  return nullptr;
 }
 
 } // namespace master

--- a/src/yb/master/master_tserver.h
+++ b/src/yb/master/master_tserver.h
@@ -80,7 +80,9 @@ class MasterTabletServer : public tserver::TabletServerIf,
 
   std::vector<yb::util::WaitStateInfoPtr> GetThreadpoolWaitStates() const override;
 
-  std::vector<WaitStateInfoPB> ActiveUniverseHistory() const override;
+  void SetCQLServerMessenger(tserver::CQLServerMessenger messenger) override {};
+
+rpc::Messenger* GetMessenger(yb::util::MessengerType messenger_type) const override;
 
  private:
   Master* master_ = nullptr;

--- a/src/yb/tserver/pg_client.proto
+++ b/src/yb/tserver/pg_client.proto
@@ -709,7 +709,9 @@ message PgActiveUniverseHistoryRequestPB {}
 
 message PgActiveUniverseHistoryResponsePB {
   AppStatusPB status = 1;
-  repeated WaitStateInfoPB wait_states = 2;
+  repeated WaitStateInfoPB tserver_wait_states = 2;
+  repeated WaitStateInfoPB cql_wait_states = 3;
+  repeated WaitStateInfoPB bg_wait_states = 4;
 }
 
 message PgGetActiveTransactionListRequestPB { OptionalUint64PB session_id = 1; }

--- a/src/yb/tserver/tablet_server.h
+++ b/src/yb/tserver/tablet_server.h
@@ -292,11 +292,13 @@ class TabletServer : public DbServerBase, public TabletServerIf {
 
   std::vector<yb::util::WaitStateInfoPtr> GetThreadpoolWaitStates() const override;
 
-  std::vector<WaitStateInfoPB> ActiveUniverseHistory() const override;
-  
   std::optional<uint64_t> GetCatalogVersionsFingerprint() const {
     return catalog_versions_fingerprint_.load(std::memory_order_acquire);
   }
+
+  void SetCQLServerMessenger(CQLServerMessenger messenger) override;
+
+  rpc::Messenger* GetMessenger(util::MessengerType messenger_type) const override;
 
  protected:
   virtual Status RegisterServices();
@@ -420,6 +422,8 @@ class TabletServer : public DbServerBase, public TabletServerIf {
 
   std::unique_ptr<rocksdb::Env> rocksdb_env_;
   std::unique_ptr<encryption::UniverseKeyManager> universe_key_manager_;
+
+  CQLServerMessenger cql_server_messenger_;
 
   DISALLOW_COPY_AND_ASSIGN(TabletServer);
 };

--- a/src/yb/tserver/tablet_server_interface.h
+++ b/src/yb/tserver/tablet_server_interface.h
@@ -36,6 +36,7 @@ namespace tserver {
 
 using CertificateReloader = std::function<Status(void)>;
 using PgConfigReloader = std::function<Status(void)>;
+using CQLServerMessenger = std::function<rpc::Messenger*(void)>;
 
 class TabletServerIf : public LocalTabletServer {
  public:
@@ -80,8 +81,9 @@ class TabletServerIf : public LocalTabletServer {
 
   virtual std::vector<yb::util::WaitStateInfoPtr> GetThreadpoolWaitStates() const = 0;
 
-  virtual std::vector<WaitStateInfoPB> ActiveUniverseHistory() const = 0;
+  virtual void SetCQLServerMessenger(CQLServerMessenger messenger) = 0;
 
+  virtual rpc::Messenger* GetMessenger(util::MessengerType messenger_type) const = 0;
 };
 
 } // namespace tserver

--- a/src/yb/util/wait_state.cc
+++ b/src/yb/util/wait_state.cc
@@ -65,7 +65,7 @@ WaitStateCode WaitStateInfo::get_frozen_state() const {
   }
   return code_;
 }
-`
+
 void WaitStateInfo::set_state(WaitStateCode c) {
   VLOG(3) << this << " " << ToString() << " setting state to " << util::ToString(c);
   if (freeze_) {

--- a/src/yb/util/wait_state.cc
+++ b/src/yb/util/wait_state.cc
@@ -126,6 +126,11 @@ void WaitStateInfo::set_top_level_request_id(uint64_t top_level_request_id) {
   metadata_.top_level_request_id = {top_level_request_id, top_level_request_id * top_level_request_id};
 }
 
+void WaitStateInfo::set_query_id(int64_t query_id) {
+  std::lock_guard<simple_spinlock> l(mutex_);
+  metadata_.query_id = query_id;
+}
+
 void WaitStateInfo::UpdateMetadata(const AUHMetadata& meta) {
   std::lock_guard<simple_spinlock> l(mutex_);
   metadata_.UpdateFrom(meta);

--- a/src/yb/util/wait_state.h
+++ b/src/yb/util/wait_state.h
@@ -12,6 +12,7 @@
 //
 #pragma once
 
+#include <array>
 #include <atomic>
 #include <functional>
 #include <iosfwd>

--- a/src/yb/util/wait_state.h
+++ b/src/yb/util/wait_state.h
@@ -55,6 +55,7 @@
  */
 #define YB_PGGATE    0xF0000000U
 #define YB_TSERVER   0xE0000000U
+#define YB_CQL       0xD0000000U
 #define YB_PG        0x00000000U
 /* ----------
  * YB AUH Wait Classes
@@ -67,6 +68,7 @@
 #define YB_TABLET_WAIT               0xEC000000U
 #define YB_ROCKSDB                   0xEB000000U
 #define YB_CLIENT                    0xEA000000U
+#define YB_CQL_WAIT_STATE            0xDF000000U
 
 // For debugging purposes:
 // Uncomment the following line to track state changes in wait events.
@@ -129,6 +131,10 @@ YB_DEFINE_ENUM_TYPE(
     (OpenFile)(CloseFile)(DeleteFile)(WriteToFile)
     (StartSubcompactionThreads)(WaitOnSubcompactionThreads)
 
+    // CQL Wait Events
+    ((Parse, YB_CQL_WAIT_STATE))(Analyze)(Execute)(ExecuteWaitingForCB)
+    (CQLRead)(CQLWrite)
+
     ((RocksDB, YB_ROCKSDB))
        (BlockCacheLookupInCache)
        (BlockCacheLookupCompressed)
@@ -145,6 +151,8 @@ YB_DEFINE_ENUM_TYPE(
       (LookingUpTablet)
       (TabletLookupFinished)
     )
+
+YB_DEFINE_ENUM(MessengerType, (kTserver)(kCQLServer))
 
 struct AUHMetadata {
   std::vector<uint64_t> top_level_request_id;
@@ -273,6 +281,7 @@ class WaitStateInfo {
   void UpdateAuxInfo(const AUHAuxInfo& aux) EXCLUDES(mutex_);
   void set_current_request_id(int64_t id) EXCLUDES(mutex_);
   void set_top_level_request_id(uint64_t id) EXCLUDES(mutex_);
+  void set_query_id(int64_t query_id) EXCLUDES(mutex_);
 
   template <class PB>
   static void UpdateMetadataFromPB(const PB& pb) {
@@ -347,6 +356,7 @@ class ScopedWaitStatus {
   const WaitStateCode state_;
   WaitStateCode prev_state_;
 };
+
 
 // Link to source codes for the classes below
 // https://github.com/open-telemetry/opentelemetry-cpp/blob/main/sdk/src/common/fast_random_number_generator.h

--- a/src/yb/yql/cql/cqlserver/cql_processor.cc
+++ b/src/yb/yql/cql/cqlserver/cql_processor.cc
@@ -412,6 +412,9 @@ unique_ptr<CQLResponse> CQLProcessor::ProcessRequest(const PrepareRequest& req) 
   const CQLMessage::QueryId query_id = CQLStatement::GetQueryId(
       ql_env_.CurrentKeyspace(), req.query());
   VLOG(1) << "Generated Query Id = " << query_id;
+  ql_env_.auh_metadata().query_id = std::stoull(
+    b2a_hex(query_id).substr(0, std::min(16, (int)query_id.size())), 0, 16);
+  // LOG(ERROR) << " ------------ " << query_id << " " << ql_env_.auh_metadata().query_id;
   // To prevent multiple clients from preparing the same new statement in parallel and trying to
   // cache the same statement (a typical "login storm" scenario), each caller will try to allocate
   // the statement in the cached statement first. If it already exists, the existing one will be
@@ -448,6 +451,9 @@ unique_ptr<CQLResponse> CQLProcessor::ProcessRequest(const PrepareRequest& req) 
 }
 
 unique_ptr<CQLResponse> CQLProcessor::ProcessRequest(const ExecuteRequest& req) {
+  LOG(ERROR) << req.query_id();
+  ql_env_.auh_metadata().query_id = std::stoull(
+    b2a_hex(req.query_id()).substr(0, std::min(16, (int)req.query_id().size())), 0, 16);
   VLOG(1) << "EXECUTE " << b2a_hex(req.query_id());
   auto stmt_res = GetPreparedStatement(req.query_id(), req.params().schema_version());
   if (!stmt_res.ok()) {
@@ -474,6 +480,8 @@ unique_ptr<CQLResponse> CQLProcessor::ProcessRequest(const QueryRequest& req) {
   const CQLMessage::QueryId query_id =
       CQLStatement::GetQueryId(ql_env_.CurrentKeyspace(), req.query());
   // Allocates space to unprepared statements in the cache.
+  ql_env_.auh_metadata().query_id = std::stoull(
+    b2a_hex(query_id).substr(0, std::min(16, (int)query_id.size())), 0, 16);
   const shared_ptr<CQLStatement> stmt = service_impl_->AllocateStatement(
       query_id, req.query(), &ql_env_, IsPrepare::kFalse);
 

--- a/src/yb/yql/cql/cqlserver/cql_rpc.cc
+++ b/src/yb/yql/cql/cqlserver/cql_rpc.cc
@@ -354,6 +354,12 @@ bool CQLInboundCall::DumpPB(const rpc::DumpRunningRpcsRequestPB& req,
   if (req.include_traces() && trace_) {
     resp->set_trace_buffer(trace_->DumpToString(true));
   }
+  if (req.get_wait_state()) {
+    auto wait_state = this->wait_state();
+    if (wait_state) {
+      wait_state->ToPB(resp->mutable_wait_state());
+    }
+  }
   resp->set_elapsed_millis(
       MonoTime::Now().GetDeltaSince(timing_.time_received).ToMilliseconds());
   GetCallDetails(resp);

--- a/src/yb/yql/cql/cqlserver/cql_server.cc
+++ b/src/yb/yql/cql/cqlserver/cql_server.cc
@@ -108,6 +108,11 @@ Status CQLServer::Start() {
   // Start the CQL node list refresh timer.
   timer_.async_wait(boost::bind(&CQLServer::CQLNodeListRefresh, this,
                                 boost::asio::placeholders::error));
+
+  if (tserver_) {
+    tserver_->SetCQLServerMessenger(std::bind(&CQLServer::messenger, this));
+  }
+
   return Status::OK();
 }
 

--- a/src/yb/yql/cql/cqlserver/cql_service.cc
+++ b/src/yb/yql/cql/cqlserver/cql_service.cc
@@ -20,6 +20,7 @@
 
 #include <boost/compute/detail/lru_cache.hpp>
 
+#include "yb/client/client.h"
 #include "yb/client/meta_data_cache.h"
 
 #include "yb/gutil/casts.h"
@@ -209,6 +210,8 @@ void CQLServiceImpl::Handle(yb::rpc::InboundCallPtr inbound_call) {
     inbound_call->RespondFailure(rpc::ErrorStatusPB::ERROR_SERVER_TOO_BUSY, processor.status());
     return;
   }
+  (**processor).auh_metadata().top_level_request_id = {util::AUHRandom::GenerateRandom64(), util::AUHRandom::GenerateRandom64()};
+  (**processor).auh_metadata().client_node_ip = yb::ToString(inbound_call->remote_address());
   MonoTime got_processor = MonoTime::Now();
   cql_metrics_->time_to_get_cql_processor_->Increment(
       got_processor.GetDeltaSince(start).ToMicroseconds());
@@ -236,6 +239,7 @@ Result<CQLProcessor*> CQLServiceImpl::GetProcessor() {
   }
 
   *pos = std::make_unique<CQLProcessor>(this, pos);
+  (**pos).auh_metadata().top_level_node_id = VERIFY_RESULT(client()->GetTServerUUID());
   return pos->get();
 }
 

--- a/src/yb/yql/cql/ql/exec/executor.cc
+++ b/src/yb/yql/cql/ql/exec/executor.cc
@@ -45,6 +45,7 @@
 #include "yb/util/status_format.h"
 #include "yb/util/trace.h"
 
+#include "yb/util/wait_state.h"
 #include "yb/yql/cql/ql/exec/exec_context.h"
 #include "yb/yql/cql/ql/ptree/column_desc.h"
 #include "yb/yql/cql/ql/ptree/parse_tree.h"
@@ -862,6 +863,7 @@ Status Executor::GetOffsetOrLimit(
 //   calls within the same process. These two different cases can be cleaned up later to avoid
 //   confusion.
 Status Executor::ExecPTNode(const PTSelectStmt *tnode, TnodeContext* tnode_context) {
+  SET_WAIT_STATUS(util::WaitStateCode::CQLRead);
   const shared_ptr<client::YBTable>& table = tnode->table();
   if (table == nullptr) {
     // If this is a request for 'system.peers_v2' table make sure that we send the appropriate error
@@ -1268,6 +1270,7 @@ Result<bool> Executor::FetchRowsByKeys(const PTSelectStmt* tnode,
 //--------------------------------------------------------------------------------------------------
 
 Status Executor::ExecPTNode(const PTInsertStmt *tnode, TnodeContext* tnode_context) {
+  SET_WAIT_STATUS(util::WaitStateCode::CQLWrite);
   // Create write request.
   const shared_ptr<client::YBTable>& table = tnode->table();
   YBqlWriteOpPtr insert_op(table->NewQLInsert());
@@ -1338,6 +1341,7 @@ Status Executor::ExecPTNode(const PTInsertStmt *tnode, TnodeContext* tnode_conte
 //--------------------------------------------------------------------------------------------------
 
 Status Executor::ExecPTNode(const PTDeleteStmt *tnode, TnodeContext* tnode_context) {
+  SET_WAIT_STATUS(util::WaitStateCode::CQLWrite);
   // Create write request.
   const shared_ptr<client::YBTable>& table = tnode->table();
   YBqlWriteOpPtr delete_op(table->NewQLDelete());
@@ -1392,6 +1396,7 @@ Status Executor::ExecPTNode(const PTDeleteStmt *tnode, TnodeContext* tnode_conte
 //--------------------------------------------------------------------------------------------------
 
 Status Executor::ExecPTNode(const PTUpdateStmt *tnode, TnodeContext* tnode_context) {
+  SET_WAIT_STATUS(util::WaitStateCode::CQLWrite);
   // Create write request.
   const shared_ptr<client::YBTable>& table = tnode->table();
   YBqlWriteOpPtr update_op(table->NewQLUpdate());
@@ -2441,6 +2446,10 @@ void Executor::AddOperation(const YBqlReadOpPtr& op, TnodeContext *tnode_context
 
   // reuse this request id for AUH?
   op->mutable_request()->set_request_id(exec_context_->params().request_id());
+  auto wait_state = util::WaitStateInfo::CurrentWaitState();
+  if (wait_state) {
+    wait_state->set_current_request_id(exec_context_->params().request_id());
+  }
   tnode_context->AddOperation(op);
 
   // We need consistent read point if statement is executed in multiple RPC commands.

--- a/src/yb/yql/cql/ql/exec/executor.cc
+++ b/src/yb/yql/cql/ql/exec/executor.cc
@@ -1090,6 +1090,8 @@ Status Executor::ExecPTNode(const PTSelectStmt *tnode, TnodeContext* tnode_conte
     return Status::OK();
   }
 
+  ql_env_->auh_metadata().ToPB(req->mutable_auh_metadata());
+
   // Add the operation.
   AddOperation(select_op, tnode_context);
   return Status::OK();
@@ -1326,6 +1328,8 @@ Status Executor::ExecPTNode(const PTInsertStmt *tnode, TnodeContext* tnode_conte
   // Set whether write op writes to the static/primary row.
   insert_op->set_writes_static_row(tnode->ModifiesStaticRow());
   insert_op->set_writes_primary_row(tnode->ModifiesPrimaryRow());
+
+  ql_env_->auh_metadata().ToPB(req->mutable_auh_metadata());
 
   // Add the operation.
   return AddOperation(insert_op, tnode_context);
@@ -2435,6 +2439,7 @@ bool Executor::WriteBatch::Empty() const {
 void Executor::AddOperation(const YBqlReadOpPtr& op, TnodeContext *tnode_context) {
   DCHECK(write_batch_.Empty()) << "Concurrent read and write operations not supported yet";
 
+  // reuse this request id for AUH?
   op->mutable_request()->set_request_id(exec_context_->params().request_id());
   tnode_context->AddOperation(op);
 

--- a/src/yb/yql/cql/ql/ql_processor.h
+++ b/src/yb/yql/cql/ql/ql_processor.h
@@ -96,6 +96,10 @@ class QLProcessor : public Rescheduler {
   TreeNodeOpcode RunAsync(const std::string& stmt, const StatementParameters& params,
                           StatementExecutedCallback cb, bool reparsed = false);
 
+  util::AUHMetadata& auh_metadata() {
+    return ql_env_.auh_metadata();
+  }
+
  protected:
   void SetCurrentSession(const QLSessionPtr& ql_session) {
     ql_env_.set_ql_session(ql_session);

--- a/src/yb/yql/cql/ql/util/ql_env.h
+++ b/src/yb/yql/cql/ql/util/ql_env.h
@@ -28,6 +28,7 @@
 #include "yb/server/hybrid_clock.h"
 
 #include "yb/util/enums.h"
+#include "yb/util/wait_state.h"
 
 #include "yb/yql/cql/ql/ptree/pt_option.h"
 #include "yb/yql/cql/ql/ql_session.h"
@@ -206,6 +207,10 @@ class QLEnv {
     return ql_session_;
   }
 
+  util::AUHMetadata& auh_metadata() {
+    return auh_metadata_;
+  }
+
  private:
   //------------------------------------------------------------------------------------------------
   // Persistent attributes.
@@ -230,6 +235,8 @@ class QLEnv {
 
   // The QL session processing the statement.
   mutable QLSession::SharedPtr ql_session_;
+
+  util::AUHMetadata auh_metadata_;
 };
 
 }  // namespace ql

--- a/src/yb/yql/pggate/pg_client.cc
+++ b/src/yb/yql/pggate/pg_client.cc
@@ -752,8 +752,14 @@ class PgClient::Impl {
     tserver::PgActiveUniverseHistoryResponsePB resp;
     RETURN_NOT_OK(proxy_->ActiveUniverseHistory(req, &resp, PrepareController()));
     client::RpcsInfo result;
-    result.reserve(resp.wait_states_size());
-    for (const auto& wait_state : resp.wait_states()) {
+    result.reserve(resp.tserver_wait_states_size() + resp.cql_wait_states_size());
+    for (const auto& wait_state : resp.tserver_wait_states()) {
+      result.push_back(client::YBActiveUniverseHistoryInfo::FromPB(wait_state));
+    }
+    for (const auto& wait_state : resp.cql_wait_states()) {
+      result.push_back(client::YBActiveUniverseHistoryInfo::FromPB(wait_state));
+    }
+    for (const auto& wait_state : resp.bg_wait_states()) {
       result.push_back(client::YBActiveUniverseHistoryInfo::FromPB(wait_state));
     }
     return result;

--- a/src/yb/yql/pggate/util/ybc_stat.cpp
+++ b/src/yb/yql/pggate/util/ybc_stat.cpp
@@ -53,6 +53,9 @@ ybcstat_get_wait_event_component(uint32_t wait_event_info) {
         case YB_PG:
             event_component = "PG";
             break;
+        case YB_CQL:
+            event_component = "CQL";
+            break;
         default:
             event_component = "???";
             break;
@@ -99,6 +102,9 @@ ybcstat_get_wait_event_type(uint32_t wait_event_info) {
             break;
         case YB_FLUSH_AND_COMPACTION:
             event_type = "Flush and Compaction";
+            break;
+        case YB_CQL_WAIT_STATE:
+            event_type = "Query Processing";
             break;
         default:
             event_type = "???";


### PR DESCRIPTION
Implement a GFlag that allows us to "freeze" wait-states in time to avoid/prevent the jagged-edge effect which could happen if the API to fetch wait-states itself takes too long.

