### PR TITLE
 Fix to reset QueryId at the end of a call. 

### DIFF
--- a/src/postgres/src/backend/tcop/postgres.c
+++ b/src/postgres/src/backend/tcop/postgres.c
@@ -5979,6 +5979,7 @@ PostgresMain(int argc, char *argv[],
 		if (IsYugaByteEnabled())
 		{
 			MyProc->queryid = 0;
+			YBCSetQueryId(0);
 			MyProc->top_level_request_id[0] = '\0';
 		}
 	}							/* end of input-reading loop */


### PR DESCRIPTION
Fix to reset QueryId at the end of a call . May have been causing a check failure