### PR TITLE
[Docs] Update limitations section in Read Committed isolation docs page

### DIFF
--- a/docs/content/stable/architecture/transactions/read-committed.md
+++ b/docs/content/stable/architecture/transactions/read-committed.md
@@ -1551,7 +1551,7 @@ commit;
 
 Read Committed interacts with the following feature:
 
-* [Follower reads](../../../develop/build-global-apps/follower-reads/) (integration in progress): When follower reads is enabled, the read point for each statement in a read committed transaction is selected as `Now()` - `yb_follower_read_staleness_ms` (if the transaction or statement is known to be explicitly or implicitly read-only).
+* [Follower reads](../../../develop/build-global-apps/follower-reads/): When follower reads is enabled and the transaction block is explicitly marked `READ ONLY`, the read point for each statement in a read committed transaction is selected as `Now()` - `yb_follower_read_staleness_ms`.
 
 ## Limitations
 
@@ -1565,7 +1565,7 @@ Read Committed interacts with the following feature:
 
 * Read restart and serialization are not internally handled in read committed isolation if the query's response size exceeds the YB-TServer GFlag `ysql_output_buffer_size`, which has a default value of 256KB (see [#11572](https://github.com/yugabyte/yugabyte-db/issues/11572)).
 
-* Non-transactional side-effects can occur more than once when a conflict or read restart occurs in functions or procedures in read committed isolation. This is because in read committed isolation, the retry logic in the database will undo all work done as part of that statement until the error and re-attempt the whole client-issued statement. (See [#12958](https://github.com/yugabyte/yugabyte-db/issues/12958))
+* Non-transactional side-effects can occur more than once when a `conflict` or `read restart` occurs in functions or procedures in read committed isolation. This is because in read committed isolation, the retry logic in the database will undo all work done as part of that statement and re-attempt the whole client-issued statement. (See [#12958](https://github.com/yugabyte/yugabyte-db/issues/12958))
 
 ## Considerations
 

--- a/docs/content/v2.16/architecture/transactions/read-committed.md
+++ b/docs/content/v2.16/architecture/transactions/read-committed.md
@@ -12,75 +12,74 @@ menu:
 type: docs
 ---
 
-Read Committed is one of the three isolation levels in PostgreSQL, and also its default. A unique property of this isolation level is that, for transactions running with this isolation, clients don't need to retry/handle serialization errors (40001) in application logic.
+Read Committed is one of the three isolation levels in PostgreSQL, and also its default. A unique property of this isolation level is that, for transactions running with this isolation, clients do not need to retry or handle serialization errors (40001) in application logic.
 
-The other two isolation levels (Serializable and Repeatable Read) require apps to have retry logic for serialization errors. Read Committed in PostgreSQL works around conflicts by allowing single statements to work on an _inconsistent snapshot_ (in other words, non-conflicting rows are read as of the statement's snapshot, but conflict resolution is done by reading and attempting re-execution/ locking on the latest version of the row).
+The other two isolation levels (Serializable and Repeatable Read) require applications to have retry logic for serialization errors. Read Committed in PostgreSQL works around conflicts by allowing single statements to work on an inconsistent snapshot (in other words, non-conflicting rows are read as of the statement's snapshot, but conflict resolution is done by reading and attempting re-execution or  locking on the latest version of the row).
 
-YSQL supports the Read Committed isolation level, and its behavior is the same as that of PostgreSQL's [Read Committed level (section 13.2.1)](https://www.postgresql.org/docs/13/transaction-iso.html#XACT-READ-COMMITTED).
+YSQL supports the Read Committed isolation level, and its behavior is the same as that of PostgreSQL's [Read Committed level](https://www.postgresql.org/docs/13/transaction-iso.html#XACT-READ-COMMITTED).
 
 ## Semantics
 
 The following two key semantics set apart Read Committed isolation from Repeatable Read in PostgreSQL:
 
 1. Each statement should be able to read everything that was committed before the statement was issued. In other words, each statement runs on the latest snapshot of the database as of when the statement was issued.
-1. Clients never face serialization errors (40001) in read committed isolation level. To achieve this, PostgreSQL re-evaluates statements for conflicting rows based on some rules as described in the next section.
+1. Clients never face serialization errors (40001) in read committed isolation level. To achieve this, PostgreSQL re-evaluates statements for conflicting rows based on a set of rules.
 
-In addition to the two key requirements, there is an extra YSQL specific requirement for its read committed isolation level: ensure that external clients don't face `kReadRestart` errors. `Read restart` errors stem from clock skew which is inherent in distributed databases due to the distribution of data across more than one physical node. PostgreSQL doesn't require defining semantics around read restart errors because it is a single node database without clock skew. When there is clock skew, the following situation can arise in a distributed database like YugabyteDB:
+### Read restart errors
 
-* A client starts a distributed transaction by connecting to YSQL on some node N1 in the YugabyteDB cluster and issuing some statement which reads data from multiple shards on different physical YB-TServers in the cluster. For this issued statement, the read point which defines the snapshot of the database at which the data will be read, is picked on some YB-TServer node M based on the current time of that YB-TServer. Depending on the scenario, node M could be the same as N1 or not, but that isn't relevant to this discussion. Consider T1 to be the chosen read time.
-* The node N1 might collect data from many shards on different physical YB-TServers. In this pursuit, it will issue requests to many other nodes to read data.
-* Assuming that node N1 reads from some node N2, it could be the case that there exists some data written on node N2 at time T2 (> T1) but was written before the read was issued. This can happen because of clock skew where the physical clock on node N2 might be running slightly ahead of node M, and hence the write which was actually done in the past, still has a timestamp higher than T1.
-* Note that the clock skew between all nodes in the cluster is always in a [`max_clock_skew`](/preview/reference/configuration/yb-tserver/#max-clock-skew-usec) bound due to clock synchronization algorithms.
-* For writes at some time higher than T1 + `max_clock_skew`, the database can be sure that they were done after the read timestamp was chosen on any node. But for writes at a time between T1 and T1 + `max_clock_skew`, node N2 can find itself in an ambiguous situation such as the following:
+In addition to the two key requirements, there is an extra YSQL-specific requirement for read committed isolation level: ensure that external clients don't face `kReadRestart` errors that stem from clock skew which is inherent in distributed databases due to the distribution of data across more than one physical node. PostgreSQL doesn't require defining semantics around read restart errors because it is a single-node database without clock skew. When there is clock skew, the following situation can arise in a distributed database like YugabyteDB:
 
-  * it should still return the data if the client issued the read after the data was committed, because it could be the same client connecting to YSQL from a different node and the following guarantee needs to be maintained; the database always returns data that was committed in the past.
+* A client starts a distributed transaction by connecting to YSQL on a node `N1` in the YugabyteDB cluster and issues a statement which reads data from multiple shards on different physical YB-TServers in the cluster. For this issued statement, the read point that defines the snapshot of the database at which the data will be read, is picked on a YB-TServer node `M` based on the current time of that YB-TServer. Depending on the scenario, node `M` may or may not be the same as `N1`, but that is not relevant to this discussion. Consider `T1` to be the chosen read time.
+* The node `N1` might collect data from many shards on different physical YB-TServers. In this pursuit, it will issue requests to many other nodes to read data.
+* Assuming that node `N1` reads from node `N2`, it is possible that data had already been written on node `N2` with a write timestamp `T2` (> `T1`) but it had been written before the read was issued. This could be caused by clock skew if the physical clock on node `N2` ran ahead of node `M`, resulting in the write done in the past still having a write timestamp later than `T1`.
 
-  * it should not return the data if the write was actually performed in the future, that is, after the read point (aka snapshot) was chosen.
+  Note that the clock skew between all nodes in the cluster is always in a [max_clock_skew_usec](../../../reference/configuration/yb-tserver/#max-clock-skew-usec) bound due to clock synchronization algorithms.
+* For writes with a write timestamp later than `T1` + `max_clock_skew`, the database can be sure that these writes were done after the read timestamp had been chosen. But for writes with a write timestamp between `T1` and `T1` + `max_clock_skew`, node `N2` can find itself in an ambiguous situation, such as the following:
 
-* In such a situation, where node N2 finds writes in the range `(T1, T1+max_clock_skew]`, to avoid breaking the strong guarantee of _a reader should always be able to read what was committed earlier_, node N2 avoids giving incorrect results and raises a `Read restart` error.
+  * It should return the data even if the client issued the read from a different node after writing the data, because the following guarantee needs to be maintained: the database should always return data that was committed in the past (past refers to the user-perceived past, and not based on machine clocks).
 
-Some distributed databases handle this uncertainty due to clock skew by using algorithms to maintain a tight bound on the clock skew, and then taking the conservative approach of waiting out the clock skew before acknowledging the commit request from the client for each transaction that writes data. YugabyteDB instead uses various mechanisms internally to reduce the scope of this ambiguity, and if there is still ambiguity in rare scenarios, the error is surfaced to the client.
+  * It should not return the data if the write was performed in the future (that is, after the read point had been chosen) **and** had a write timestamp later than the read point. Because if that was allowed, everything written in future would be trivially visible to the read. Note that the latter condition is important because it is okay to return data that was written after the read point was picked if the write timestamp was earlier than the read point (this doesn't break and consistency or isolation guarantees).
 
-However, for Read Committed isolation, YugabyteDB has stronger mechanisms in place to ensure that the ambiguity is always resolved internally, and `Read restart` errors are not surfaced to the client. So, in read committed transactions, clients don't have to add any retry logic for `Read restart` errors (similar to serialization errors).
+* If node `N2` finds writes in the range `(T1, T1+max_clock_skew]`, to avoid breaking the strong guarantee that a reader should always be able to read what was committed earlier and to avoid reading data with a later write timestamp which was also actually written after the read had been issued, node `N2` raises a `Read restart` error.
 
-## Handling serialization errors
+Some distributed databases handle this specific uncertainty due to clock skew by using algorithms to maintain a tight bound on the clock skew, and then taking the conservative approach of waiting out the clock skew before acknowledging the commit request from the client for each transaction that writes data. YugabyteDB, however, uses various internal mechanisms to reduce the scope of this ambiguity, and if there is still ambiguity in rare cases, the `Read restart` error is surfaced to the client.
 
-To handle serialization errors in the database (without surfacing them to the client), PostgreSQL takes the following steps based on the statement type.
+For Read Committed isolation, YugabyteDB has stronger mechanisms to ensure that the ambiguity is always resolved internally and `Read restart` errors are not surfaced to the client. In Read Committed transactions, clients do not have to add any retry logic for read restart errors (similarly to serialization errors).
 
-### UPDATE, DELETE, SELECT FOR UPDATE, FOR SHARE, FOR NO KEY UPDATE, FOR KEY SHARE
+### Handling serialization errors
 
-(The last two are not mentioned in the PostgreSQL documentation, but the same behavior is seen for these as follows.)
+To handle serialization errors in the database without surfacing them to the client, PostgreSQL takes a number of steps based on the statement type.
 
-If the row of interest:
+#### UPDATE, DELETE, SELECT FOR UPDATE, FOR SHARE, FOR NO KEY UPDATE, FOR KEY SHARE
 
-* is being updated (or deleted) by other concurrent transactions in a conflicting way, wait for the conflicting transactions to commit or rollback, and then perform [recheck steps](#recheck-steps).
+* If the subject row is being updated or deleted by other concurrent transactions in a conflicting way, wait for the conflicting transactions to commit or rollback, and then perform validation steps.
 
-* has been updated (or deleted) by other concurrent transactions in a conflicting way, perform [recheck steps](#recheck-steps).
+* If the subject row has been updated or deleted by other concurrent transactions in a conflicting way, perform validation steps.
 
-* has been locked by other concurrent transactions in a conflicting way, wait for them to commit or rollback, then perform recheck steps.
+* If the subject row has been locked by other concurrent transactions in a conflicting way, wait for them to commit or rollback, and then perform validation steps.
 
-Note that two transactions are `concurrent` if their `read time` to `commit time` ranges overlap. If a transaction hasn't yet committed, the closing range is the current time. Also, for read committed isolation, there is a `read time` for each statement, and not one for the whole transaction.
+Note that two transactions are `concurrent` if their `read time` to `commit time` ranges overlap. If a transaction has not yet committed, the closing range is the current time. Also, for read committed isolation, there is a `read time` for each statement, and not one for the whole transaction.
 
-#### Recheck steps
+##### Validation steps
 
-The recheck steps are as follows:
+The validation steps are as follows:
 
 1. Read the latest version of the conflicting row and lock it appropriately. The latest version could have a different primary key as well. PostgreSQL finds it by following the chain of updates for a row even across primary key changes. Note that locking is necessary so that another conflict isn't seen on this row while re-evaluating the row again and possibly updating/acquiring a lock on it in step 3. If the locking faces a conflict, it would wait and resume traversing the chain further once unblocked.
 1. If the updated version of a row is deleted, ignore it.
-1. Apply update/delete/acquire lock on updated version of row if the where clause evaluates to true on the updated version of row.
+1. Apply update, delete, or acquire lock on updated version of the row if the `WHERE` clause evaluates to `true` on the updated version of the row.
 
-### INSERT
+#### INSERT
 
-1. ON CONFLICT DO UPDATE: if a conflict occurs, wait for the conflicting transaction(s) to commit or rollback.
-    1. If all conflicting transaction(s) rollback, proceed as usual.
-    1. On commit of any conflicting transaction, traverse the chain of updates as described above and re-evaluate the latest version of the row for any conflict. If there is no conflict, `insert` the original row. Else, perform the `do update` part on the latest version of the row.
-1. ON CONFLICT DO NOTHING: do nothing if a conflict occurs.
+* `ON CONFLICT DO UPDATE`: if a conflict occurs, wait for the conflicting transactions to commit or rollback.
+  * If all conflicting transactions rollback, proceed as usual.
+  * On commit of any conflicting transaction, traverse the chain of updates, as described in validation step 1, and re-evaluate the latest version of the row for any conflict. If there is no conflict, insert the original row. Otherwise, perform the `DO UPDATE` part on the latest version of the row.
+* `ON CONFLICT DO NOTHING`: if a conflict occurs, do not do anything.
 
-Note that the preceding methodology in PostgreSQL can lead to two different user visible semantics. One is the common case, and the other is a degenerate situation that can never be seen in practice, but is nevertheless possible and still upholds the semantics of Read Committed isolation. The common case is as follows:
+Note that the preceding methodology in PostgreSQL can lead to two different visible semantics. One is the common case, and the other is a degenerate situation that can never be seen in practice, but is nevertheless possible and still upholds the semantics of Read Committed isolation. The common case is as follows:
 
 ```sql
-create table test (k int primary key, v int);
-insert into test values (2, 5);
+CREATE TABLE test (k int primary key, v int);
+INSERT INTO test VALUES (2, 5);
 ```
 
 <table class="no-alter-colors">
@@ -316,189 +315,48 @@ select * from test;
 </tbody>
 </table>
 
-The above can occur via the following step: till Client 1 commits, PostgreSQL on Client 2 is busy with some other processing and only after Client 1 commits, transaction on Client 2 is able to pick a snapshot based off the current time for the statement. This leads to both rows being read as part of the snapshot and updated, without any conflicts seen. Both outcomes are valid and satisfy the semantics of read committed isolation level. And theoretically, the user can't figure out which one will be seen because the user can't differentiate between a pause due to _waiting for a conflicting transaction_ or a pause due to the database just being _busy_ or _slow_. In the second case, the whole statement runs off a single snapshot and it is easier to reason the output.
+The preceding outcome can occur via the following step: until Client 1 commits, PostgreSQL on Client 2 is busy with other processing and only after Client 1 commits, transaction on Client 2 is able to pick a snapshot based off the current time for the statement. This leads to both rows being read as part of the snapshot and updated without any observable conflicts. Both outcomes are valid and satisfy the semantics of Read Committed isolation level. And theoretically, the user cannot figure out which one will be seen because the user cannot differentiate between a pause due to waiting for a conflicting transaction or a pause due to the database just being busy or slow. In the second case, the whole statement runs off a single snapshot and it is easier to reason the output.
 
-These two possibilities show that the client can't have application logic that relies on the expectation that the common case occurs always. Given this, YugabyteDB provides a stronger guarantee that each statement always works off just a single snapshot and no inconsistency is allowed even in case of a some conflicting rows. This leads to YugabyteDB always returning output similar to the second outcome in the above example which is also simpler to reason.
+These two possibilities show that the client cannot have application logic that relies on the expectation that the common case occurs always. Given this, YugabyteDB provides a stronger guarantee that each statement always works off just a single snapshot and no inconsistency is allowed even in case of a some conflicting rows. This leads to YugabyteDB always returning output similar to the second outcome in the above example which is also simpler to reason.
 
-This can change after [#11573](https://github.com/yugabyte/yugabyte-db/issues/11573) as mentioned in the roadmap for read committed isolation [#13557](https://github.com/yugabyte/yugabyte-db/issues/13557).
+This can change after [#11573](https://github.com/yugabyte/yugabyte-db/issues/11573) is resolved, as mentioned in the roadmap for Read Committed isolation available at [#13557](https://github.com/yugabyte/yugabyte-db/issues/13557).
+
+### Interaction with concurrency control
+
+Semantics of Read Committed isolation adheres only with the [Wait-on-Conflict](../concurrency-control/#wait-on-conflict-beta-preview-faq-general-what-is-the-definition-of-the-beta-feature-tag) concurrency control policy. This is because a Read Committed transaction has to wait for other transactions to commit or rollback in case of a conflict, and then perform the re-check steps to make progress.
+
+As the [Fail-on-Conflict](../concurrency-control/#fail-on-conflict) concurrency control policy doesn't make sense for Read Committed, even if this policy is set for use on the cluster (by having the YB-TServer flag `enable_wait_queues=false`), transactions in Read Committed isolation will still provide `Wait-on-Conflict` semantics. For providing `Wait-on-Conflict` semantics without wait queues, YugabyteDB relies on an indefinite retry-backoff mechanism with exponential delays when conflicts are detected. The retries are at the statement level. Each retry will use a newer snapshot of the database in anticipation that the conflicts might not occur. This is done because if the read time of the new snapshot is higher than the commit time of the earlier conflicting transaction T2, the conflicts with T2 would essentially be voided as T1's statement and T2 would no longer be "concurrent".
+
+However, when Read Committed isolation provides Wait-on-Conflict semantics without wait queues, the following limitations exist:
+
+* You may have to manually tune the exponential backoff parameters for performance, as explained in [Performance tuning](../read-committed/#performance-tuning).
+* The app may have to rely on statement timeouts to [avoid deadlocks](#avoid-deadlocks-in-read-committed-transactions).
+* There may be unfairness during contention due to the retry-backoff mechanism, resulting in high P99 latencies.
 
 ## Usage
 
-By setting the YB-TServer gflag `yb_enable_read_committed_isolation=true`, the syntactic `Read Committed` isolation in YSQL will actually map to the Read Committed implementation in DocDB. If set to false, it will have the earlier behavior of mapping syntactic `Read Committed` on YSQL to Snapshot Isolation in DocDB, meaning it will behave same as `Repeatable Read`.
+By setting the YB-TServer flag `yb_enable_read_committed_isolation=true`, the syntactic `Read Committed` isolation in YSQL maps to the Read Committed implementation in DocDB. If set to `false`, it has the earlier behavior of mapping syntactic `Read Committed` on YSQL to Snapshot isolation in DocDB, meaning it behaves as `Repeatable Read`.
 
-The following ways can be used to start a Read Committed transaction after setting the gflag:
+The following ways can be used to start a Read Committed transaction after setting the flag:
 
 1. `START TRANSACTION isolation level read committed [read write | read only];`
-2. `BEGIN [TRANSACTION] isolation level read committed [read write | read only];`
-3. `BEGIN [TRANSACTION]; SET TRANSACTION ISOLATION LEVEL READ COMMITTED;` (this will be supported after [#12494](https://github.com/yugabyte/yugabyte-db/issues/12494))
-4. `BEGIN [TRANSACTION]; SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED;` (this will be supported after #12494)
-
-Read Committed on YSQL will have pessimistic locking behavior; in other words, a Read Committed transaction will wait for other Read Committed transactions to commit or rollback in case of a conflict. Two or more transactions could be waiting on each other in a cycle. Hence, to avoid a deadlock, be sure to configure a statement timeout (by setting the `statement_timeout` parameter in `ysql_pg_conf_csv` YB-TServer gflag on cluster startup). Statement timeouts will help avoid deadlocks (see [Avoid deadlocks in Read Committed transactions](#avoid-deadlocks-in-read-committed-transactions)). This limitation will be resolved with [#13211](https://github.com/yugabyte/yugabyte-db/issues/13211)
+1. `BEGIN [TRANSACTION] isolation level read committed [read write | read only];`
+1. `BEGIN [TRANSACTION]; SET TRANSACTION ISOLATION LEVEL READ COMMITTED;` (this will be supported after [#12494](https://github.com/yugabyte/yugabyte-db/issues/12494) is resolved)
+1. `BEGIN [TRANSACTION]; SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED;` (this will be supported after [#12494](https://github.com/yugabyte/yugabyte-db/issues/12494) is resolved)
 
 ## Examples
 
-Start by setting up the table you'll use in all of the examples in this section.
+Start by creating the table to be used in all of the examples, as follows:
 
 ```sql
-create table test (k int primary key, v int);
+CREATE TABLE test (k int primary key, v int);
 ```
-
-### Avoid deadlocks in Read Committed transactions
-
-You can avoid deadlocks in Read Committed transactions by relying on statement timeout.
-
-```sql
-truncate table test;
-insert into test values (1, 5);
-insert into test values (2, 5);
-```
-
-<table class="no-alter-colors">
-  <thead>
-    <tr>
-    <th>
-    Client 1
-    </th>
-    <th>
-    Client 2
-    </th>
-    </tr>
-  </thead>
-  <tbody>
-  <tr>
-   <td>
-
-```sql
-begin transaction isolation level read committed;
-```
-
-   </td>
-   <td>
-   </td>
-  </tr>
-  <tr>
-   <td>
-   </td>
-   <td>
-
-```sql
-begin transaction isolation level read committed;
-```
-
-   </td>
-  </tr>
-  <tr>
-   <td>
-   </td>
-   <td>
-
-```sql
-set statement_timeout=2000;
-```
-
-   </td>
-  </tr>
-  <tr>
-   <td>
-
-```sql
-update test set v=5 where k=1;
-```
-
-```output
-UPDATE 1
-```
-
-   </td>
-   <td>
-   </td>
-  </tr>
-  <tr>
-   <td>
-   </td>
-   <td>
-
-```sql
-update test set v=5 where k=2;
-```
-
-```output
-UPDATE 1
-```
-
-   </td>
-  </tr>
-  <tr>
-   <td>
-
-```sql
-update test set v=5 where k=2;
-```
-
-```output
-(waits)
-```
-
-   </td>
-   <td>
-   </td>
-  </tr>
-  <tr>
-   <td>
-   </td>
-   <td>
-
-```sql
-update test set v=5 where k=1;
-```
-
-```output
-ERROR:  cancelling statement due to statement timeout
-```
-
-   </td>
-  </tr>
-  <tr>
-   <td>
-   </td>
-   <td>
-
-```sql
-rollback;
-```
-
-   </td>
-  </tr>
-  <tr>
-   <td>
-
-```output
-UPDATE 1
-```
-
-   </td>
-   <td>
-   </td>
-  </tr>
-  <tr>
-   <td>
-
-```sql
-commit;
-```
-
-   </td>
-   <td>
-   </td>
-  </tr>
-</tbody>
-</table>
 
 ### SELECT behavior without explicit locking
 
 ```sql
-truncate table test;
-insert into test values (1, 5);
+TRUNCATE TABLE test;
+INSERT INTO test VALUES (1, 5);
 ```
 
 <table class="no-alter-colors">
@@ -668,8 +526,8 @@ commit;
 ### UPDATE behavior
 
 ```sql
-truncate table test;
-insert into test values (0, 5), (1, 5), (2, 5), (3, 5), (4, 1);
+TRUNCATE TABLE test;
+INSERT INTO test VALUES (0, 5), (1, 5), (2, 5), (3, 5), (4, 1);
 ```
 
 <table class="no-alter-colors">
@@ -865,8 +723,8 @@ commit;
 ### SELECT FOR UPDATE behavior
 
 ```sql
-truncate table test;
-insert into test values (0, 5), (1, 5), (2, 5), (3, 5), (4, 1);
+TRUNCATE TABLE test;
+INSERT INTO test VALUES (0, 5), (1, 5), (2, 5), (3, 5), (4, 1);
 ```
 
 <table class="no-alter-colors">
@@ -1052,11 +910,11 @@ commit;
 
 ### INSERT behavior
 
-**Insert a new key that is also just changed by another transaction**
+Insert a new key that has just been changed by another transaction, as follows:
 
 ```sql
-truncate table test;
-insert into test values (1, 1);
+TRUNCATE TABLE test;
+INSERT INTO test VALUES (1, 1);
 ```
 
 <table class="no-alter-colors">
@@ -1159,11 +1017,11 @@ rollback;
 </tbody>
 </table>
 
-**Same as previous, but with ON CONFLICT**
+Insert a new key that has just been changed by another transaction, with `ON CONFLICT`:
 
 ```sql
-truncate table test;
-insert into test values (1, 1);
+TRUNCATE TABLE test;
+INSERT INTO test VALUES (1, 1);
 ```
 
 <table class="no-alter-colors">
@@ -1284,11 +1142,11 @@ commit;
 </tbody>
 </table>
 
-**INSERT old key that is removed by other transaction**
+Insert an old key that has been removed by another transaction, as follows:
 
 ```sql
-truncate table test;
-insert into test values (1, 1);
+TRUNCATE TALE test;
+INSERT INTO test VALUES (1, 1);
 ```
 
 <table class="no-alter-colors">
@@ -1410,11 +1268,11 @@ commit;
 </tbody>
 </table>
 
-**Same as previous, but with ON CONFLICT**
+Insert an old key that has been removed by another transaction, with `ON CONFLICT`:
 
 ```sql
-truncate table test;
-insert into test values (1, 1);
+TRUNCATE TABLE test;
+INSERT INTO test VALUES (1, 1);
 ```
 
 <table class="no-alter-colors">
@@ -1536,32 +1394,193 @@ commit;
 </tbody>
 </table>
 
-## Cross feature interaction
+### Avoid deadlocks in read committed transactions
 
-This feature interacts with the following features:
+When wait queues are not enabled, that is, YB-TServer GFlag `enable_wait_queues=false`, configure a statement timeout to avoid deadlocks. A different statement timeout can be set for each session using the `statement_timeout` YSQL parameter. Also, a single statement timeout can be applied globally to all sessions by setting the `statement_timeout` YSQL parameter in `ysql_pg_conf_csv` YB-TServer GFlag on cluster startup.
 
-1. **Follower reads (integration in progress):** When follower reads is turned on, the read point for each statement in a Read Committed transaction will be picked as _Now()_ - _yb_follower_read_staleness_ms_ (if the transaction/statement is known to be explicitly/implicitly read only).
+When using wait queues, automatic deadlock detection and resolution can be enabled using YB-TServer GFlag `enable_deadlock_detection=true`. It is strongly recommended to use this setting when using wait queues.
 
-2. **Pessimistic locking:** Read Committed has a dependency on pessimistic locking to work fully. Pessimistic locking means: on facing a conflict, a transaction has to wait for the conflicting transaction(s) to rollback/commit before resuming and making progress appropriately. Pessimistic locking behavior can already be seen for Read Committed isolation level, because without pessimistic locking, the semantics of read committed isolation can't be fulfilled. An optimized wait-queue based version of pessimistic locking will be available in the near future ([#5680](https://github.com/yugabyte/yugabyte-db/issues/5680)), which will provide better performance and will also work for REPEATABLE READ and SERIALIZABLE isolation levels. The optimized version will also help detect deadlocks proactively instead of relying on statement timeouts for deadlock avoidance (see example 1).
+```sql
+truncate table test;
+insert into test values (1, 5);
+insert into test values (2, 5);
+```
+
+<table class="no-alter-colors">
+  <thead>
+    <tr>
+    <th>
+    Client 1
+    </th>
+    <th>
+    Client 2
+    </th>
+    </tr>
+  </thead>
+  <tbody>
+  <tr>
+   <td>
+
+```sql
+begin transaction isolation level read committed;
+```
+
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>
+   </td>
+   <td>
+
+```sql
+begin transaction isolation level read committed;
+```
+
+   </td>
+  </tr>
+  <tr>
+   <td>
+   </td>
+   <td>
+
+```sql
+set statement_timeout=2000;
+```
+
+   </td>
+  </tr>
+  <tr>
+   <td>
+
+```sql
+update test set v=5 where k=1;
+```
+
+```output
+UPDATE 1
+```
+
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>
+   </td>
+   <td>
+
+```sql
+update test set v=5 where k=2;
+```
+
+```output
+UPDATE 1
+```
+
+   </td>
+  </tr>
+  <tr>
+   <td>
+
+```sql
+update test set v=5 where k=2;
+```
+
+```output
+(waits)
+```
+
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>
+   </td>
+   <td>
+
+```sql
+update test set v=5 where k=1;
+```
+
+```output
+ERROR:  cancelling statement due to statement timeout
+```
+
+   </td>
+  </tr>
+  <tr>
+   <td>
+   </td>
+   <td>
+
+```sql
+rollback;
+```
+
+   </td>
+  </tr>
+  <tr>
+   <td>
+
+```output
+UPDATE 1
+```
+
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>
+
+```sql
+commit;
+```
+
+   </td>
+   <td>
+   </td>
+  </tr>
+</tbody>
+</table>
+
+## Cross-feature interaction
+
+Read Committed interacts with the following feature:
+
+* [Follower reads](../../../develop/build-global-apps/follower-reads/): When follower reads is enabled and the transaction block is explicitly marked `READ ONLY`, the read point for each statement in a read committed transaction is selected as `Now()` - `yb_follower_read_staleness_ms`.
 
 ## Limitations
 
-Refer to [#13557](https://github.com/yugabyte/yugabyte-db/issues/13557) for limitations.
+* A `SET TRANSACTION ISOLATION LEVEL ...` statement immediately issued after `BEGIN;` or `BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;` will fail if the YB-TServer GFlag `yb_enable_read_committed_isolation=true`, and the following error will be issued:
 
-## Noteworthy considerations
+    ```output
+    ERROR:  SET TRANSACTION ISOLATION LEVEL must not be called in a subtransaction
+    ```
 
-This isolation level allows both phantom and non-repeatable reads (as in [SELECT behavior without explicit locking](#select-behavior-without-explicit-locking)).
+    For more details, see [#12494](https://github.com/yugabyte/yugabyte-db/issues/12494).
 
-Adding this new isolation level doesn't affect the performance of existing isolation levels.
+* Read restart and serialization are not internally handled in read committed isolation if the query's response size exceeds the YB-TServer GFlag `ysql_output_buffer_size`, which has a default value of 256KB (see [#11572](https://github.com/yugabyte/yugabyte-db/issues/11572)).
+
+* Non-transactional side-effects can occur more than once when a `conflict` or `read restart` occurs in functions or procedures in read committed isolation. This is because in read committed isolation, the retry logic in the database will undo all work done as part of that statement and re-attempt the whole client-issued statement. (See [#12958](https://github.com/yugabyte/yugabyte-db/issues/12958))
+
+## Considerations
+
+This isolation level allows both phantom and non-repeatable reads (as demonstrated in [SELECT behavior without explicit locking](#select-behavior-without-explicit-locking)).
+
+Adding this new isolation level does not affect the performance of existing isolation levels.
 
 ### Performance tuning
 
-If a statement in the Read Committed isolation level faces a conflict, it will be retried with exponential backoff till the statement times out. The following parameters control the backoff:
+If a statement in the Read Committed isolation level faces a conflict, it is retried with exponential backoff until the statement times out. The following parameters control the backoff:
 
-* _retry_max_backoff_ is the maximum backoff in milliseconds between retries.
-* _retry_min_backoff_ is the minimum backoff in milliseconds between retries.
-* _retry_backoff_multiplier_ is the multiplier used to calculate the next retry backoff.
+* `retry_max_backoff` is the maximum backoff in milliseconds between retries.
+* `retry_min_backoff` is the minimum backoff in milliseconds between retries.
+* `retry_backoff_multiplier` is the multiplier used to calculate the next retry backoff.
 
-You can set these parameters on a per-session basis, or in the `ysql_pg_conf_csv` YB-TServer gflag on cluster startup.
+You can set these parameters on a per-session basis, or in the `ysql_pg_conf_csv` YB-TServer flag on cluster startup.
 
-After the optimized version of pessimistic locking (as described in [Cross-feature interaction](#cross-feature-interaction)) is completed, there won't be a need to manually tune these parameters for performance. Statements will restart only when all conflicting transactions have committed or rolled back, instead of retrying with an exponential backoff.
+If the [Wait-on-Conflict](../concurrency-control/#wait-on-conflict) concurrency control policy is enabled, there won't be a need to manually tune these parameters for performance. Statements will restart only when all conflicting transactions have committed or rolled back, instead of retrying with an exponential backoff.


### PR DESCRIPTION
- Also add back the example that uses statement timeouts to workaround deadlocks when not using wait queues.