### PR TITLE
[docs] Use `bytes` instead of kilobytes for systemd `LimitSTACK`

### DIFF
--- a/docs/content/preview/deploy/manual-deployment/system-config.md
+++ b/docs/content/preview/deploy/manual-deployment/system-config.md
@@ -134,7 +134,7 @@ Directive       | ulimit equivalent    | Value |
 LimitCPU=       | ulimit -t            | infinity |
 LimitFSIZE=     | ulimit -f            | infinity |
 LimitDATA=      | ulimit -d            | infinity |
-LimitSTACK=     | ulimit -s            | 8192 |
+LimitSTACK=     | ulimit -s            | 8388608 |
 LimitCORE=      | ulimit -c            | infinity |
 LimitRSS=       | ulimit -m            | infinity |
 LimitNOFILE=    | ulimit -n            | 1048576  |

--- a/docs/content/stable/deploy/manual-deployment/system-config.md
+++ b/docs/content/stable/deploy/manual-deployment/system-config.md
@@ -134,7 +134,7 @@ Directive       | ulimit equivalent    | Value |
 LimitCPU=       | ulimit -t            | infinity |
 LimitFSIZE=     | ulimit -f            | infinity |
 LimitDATA=      | ulimit -d            | infinity |
-LimitSTACK=     | ulimit -s            | 8192 |
+LimitSTACK=     | ulimit -s            | 8388608 |
 LimitCORE=      | ulimit -c            | infinity |
 LimitRSS=       | ulimit -m            | infinity |
 LimitNOFILE=    | ulimit -n            | 1048576  |

--- a/docs/content/v2.12/deploy/manual-deployment/system-config.md
+++ b/docs/content/v2.12/deploy/manual-deployment/system-config.md
@@ -134,7 +134,7 @@ Directive       | ulimit equivalent    | Value |
 LimitCPU=       | ulimit -t            | infinity |
 LimitFSIZE=     | ulimit -f            | infinity |
 LimitDATA=      | ulimit -d            | infinity |
-LimitSTACK=     | ulimit -s            | 8192 |
+LimitSTACK=     | ulimit -s            | 8388608 |
 LimitCORE=      | ulimit -c            | infinity |
 LimitRSS=       | ulimit -m            | infinity |
 LimitNOFILE=    | ulimit -n            | 1048576  |

--- a/docs/content/v2.14/deploy/manual-deployment/system-config.md
+++ b/docs/content/v2.14/deploy/manual-deployment/system-config.md
@@ -134,7 +134,7 @@ Directive       | ulimit equivalent    | Value |
 LimitCPU=       | ulimit -t            | infinity |
 LimitFSIZE=     | ulimit -f            | infinity |
 LimitDATA=      | ulimit -d            | infinity |
-LimitSTACK=     | ulimit -s            | 8192 |
+LimitSTACK=     | ulimit -s            | 8388608 |
 LimitCORE=      | ulimit -c            | infinity |
 LimitRSS=       | ulimit -m            | infinity |
 LimitNOFILE=    | ulimit -n            | 1048576  |

--- a/docs/content/v2.16/deploy/manual-deployment/system-config.md
+++ b/docs/content/v2.16/deploy/manual-deployment/system-config.md
@@ -134,7 +134,7 @@ Directive       | ulimit equivalent    | Value |
 LimitCPU=       | ulimit -t            | infinity |
 LimitFSIZE=     | ulimit -f            | infinity |
 LimitDATA=      | ulimit -d            | infinity |
-LimitSTACK=     | ulimit -s            | 8192 |
+LimitSTACK=     | ulimit -s            | 8388608 |
 LimitCORE=      | ulimit -c            | infinity |
 LimitRSS=       | ulimit -m            | infinity |
 LimitNOFILE=    | ulimit -n            | 1048576  |

--- a/docs/content/v2.8/deploy/manual-deployment/system-config.md
+++ b/docs/content/v2.8/deploy/manual-deployment/system-config.md
@@ -134,7 +134,7 @@ Directive       | ulimit equivalent    | Value |
 LimitCPU=       | ulimit -t            | infinity |
 LimitFSIZE=     | ulimit -f            | infinity |
 LimitDATA=      | ulimit -d            | infinity |
-LimitSTACK=     | ulimit -s            | 8192 |
+LimitSTACK=     | ulimit -s            | 8388608 |
 LimitCORE=      | ulimit -c            | infinity |
 LimitRSS=       | ulimit -m            | infinity |
 LimitNOFILE=    | ulimit -n            | 1048576  |


### PR DESCRIPTION
Fixes #18840

systemd docs saying the same thing https://www.freedesktop.org/software/systemd/man/systemd.exec.html