### PR TITLE
Improved yb-check-consistency.py

### DIFF
--- a/bin/yb-check-consistency.py
+++ b/bin/yb-check-consistency.py
@@ -4,53 +4,77 @@ import argparse
 import glob
 import subprocess
 import os
+import logging
+from multiprocessing import Pool
 
 
 LDB_PATH = "/home/yugabyte/tserver/bin/ldb"
 
-def print_colored_status(status, filename):
-    if status == "OK":
-        color_code = 32  # 32 is the ANSI code for green
-    elif status == "ERROR":
-        color_code = 31  # 31 is the ANSI code for red
-    else:
-        color_code = 0  # Default color (normal)
+parser = argparse.ArgumentParser()
+parser.add_argument('--fs_data_dirs', type=str, help="Path to data directories")
+parser.add_argument('--ldb_path', type=str, default=LDB_PATH, help="Path to ldb binary")
+parser.add_argument('--mode', type=int, default=1, choices=[1,2], help="Mode to run ldb in: 1=checkconsistency, 2=scan --only_verify_checksum")
+parser.add_argument('--uuid', type=str, default=None, help="Table or tablet uuid to check")
+parser.add_argument('--num_processes', type=int, default=1, help="Number of processes to run in parallel")
+args = parser.parse_args()
 
-    colored_status = "\033[{0}m{1}\033[0m".format(color_code, status)
-    print(colored_status + " - " + filename)
+# Logger for STDOUT
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--fs_data_dirs', type=str, help="Path to data directories")
-    parser.add_argument('--ldb_path', type=str, default=LDB_PATH, help="Path to ldb binary")
-    parser.add_argument('--mode', type=int, default=1, choices=[1,2], help="Mode to run ldb in: 1=checkconsistency, 2=scan --only_verify_checksum")
+## Create file handler which logs even debug messages
+file_handler = logging.FileHandler("checkconsistency.log")
+file_handler.setLevel(logging.DEBUG)
+
+## Create console handler with a higher log level
+console_handler = logging.StreamHandler()
+console_handler.setLevel(logging.INFO)
+
+## Create formatter and add it to the handlers
+formatter = logging.Formatter('%(asctime)s:[%(levelname)s]:%(message)s')
+file_handler.setFormatter(formatter)
+console_handler.setFormatter(formatter)
+
+## Add the handlers to the logger
+logger.addHandler(file_handler)
+logger.addHandler(console_handler)
+
+
+def get_docdb_paths():
+    paths = []
+    for dir in args.fs_data_dirs.split(","):
+        paths.extend(glob.glob("{}/yb-data/tserver/data/rocksdb/table-*/tablet-*".format(dir)))
+    if args.uuid:
+        # Get only the paths that match the tablet uuid
+        paths = [path for path in paths if args.tablet in path]
     
-    args = parser.parse_args()
-    for d in args.fs_data_dirs.split(","):
-        print("Checking dir: {}".format(d))
-        paths = glob.glob("{}/yb-data/tserver/data/rocksdb/table-*/tablet-*".format(d))
-        for p in paths:
-            # Ignore snapshots.
-            if p.endswith("snapshots"):
-                continue
-            cmd_list = [args.ldb_path, "--db={}".format(p)]
-            if args.mode == 1:
-                cmd_list.append("checkconsistency")
-            if args.mode == 2:
-                cmd_list.append("scan")
-                cmd_list.append("--only_verify_checksums")
-            proc = subprocess.Popen(cmd_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            stdout, stderr = proc.communicate()
-            if proc.returncode != 0:
-                if not os.path.exists("checkconsistency_errors"):
-                    os.makedirs("checkconsistency_errors")
-                filename = p.split("/")[-1]
-                with open("checkconsistency_errors/{}.txt".format(filename), "w") as f:
-                    f.write(stderr)
-                print_colored_status("ERROR", p)
-            else:
-                print_colored_status("OK", p)
+    # Remove snapshots
+    paths = [path for path in paths if not path.endswith("snapshots")]
+    return paths
 
+def run_ldb(path):
+    if args.mode == 1:
+        cmd_list = [args.ldb_path, "checkconsistency"]
+    elif args.mode == 2:
+        cmd_list = [args.ldb_path, "scan", "--only_verify_checksums"]
+    cmd_list = cmd_list + ["--db={}".format(path)]
+    logger.debug("Running: {}".format(" ".join(cmd_list)))
+    proc = subprocess.Popen(cmd_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = proc.communicate()
+    if proc.returncode != 0:
+        if not os.path.exists("checkconsistency_errors"):
+            os.makedirs("checkconsistency_errors")
+        filename = path.split("/")[-1]
+        with open("checkconsistency_errors/{}.txt".format(filename), "w") as f:
+            f.write(str(stderr))
+        logger.error("{}".format(path))
+    else:
+        logger.info("OK: {}".format(path))
+    
 
 if __name__ == "__main__":
-    main()
+    paths = get_docdb_paths()
+    pool = Pool(processes=args.num_processes)
+    pool.map(run_ldb, paths)
+    pool.close()
+    pool.join()

--- a/bin/yb-check-consistency.py
+++ b/bin/yb-check-consistency.py
@@ -46,7 +46,7 @@ def get_docdb_paths():
         paths.extend(glob.glob("{}/yb-data/tserver/data/rocksdb/table-*/tablet-*".format(dir)))
     if args.uuid:
         # Get only the paths that match the tablet uuid
-        paths = [path for path in paths if args.tablet in path]
+        paths = [path for path in paths if args.uuid in path]
     
     # Remove snapshots
     paths = [path for path in paths if not path.endswith("snapshots")]

--- a/bin/yb-check-consistency.py
+++ b/bin/yb-check-consistency.py
@@ -3,15 +3,28 @@
 import argparse
 import glob
 import subprocess
+import os
 
 
 LDB_PATH = "/home/yugabyte/tserver/bin/ldb"
 
+def print_colored_status(status, filename):
+    if status == "OK":
+        color_code = 32  # 32 is the ANSI code for green
+    elif status == "ERROR":
+        color_code = 31  # 31 is the ANSI code for red
+    else:
+        color_code = 0  # Default color (normal)
+
+    colored_status = "\033[{0}m{1}\033[0m".format(color_code, status)
+    print(colored_status + " - " + filename)
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--fs_data_dirs', type=str, help="Path to data directories")
     parser.add_argument('--ldb_path', type=str, default=LDB_PATH, help="Path to ldb binary")
+    parser.add_argument('--mode', type=int, default=1, choices=[1,2], help="Mode to run ldb in: 1=checkconsistency, 2=scan --only_verify_checksum")
+    
     args = parser.parse_args()
     for d in args.fs_data_dirs.split(","):
         print("Checking dir: {}".format(d))
@@ -20,13 +33,23 @@ def main():
             # Ignore snapshots.
             if p.endswith("snapshots"):
                 continue
-            cmd_list = [args.ldb_path, "--db={}".format(p), "checkconsistency"]
+            cmd_list = [args.ldb_path, "--db={}".format(p)]
+            if args.mode == 1:
+                cmd_list.append("checkconsistency")
+            if args.mode == 2:
+                cmd_list.append("scan")
+                cmd_list.append("--only_verify_checksums")
             proc = subprocess.Popen(cmd_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             stdout, stderr = proc.communicate()
             if proc.returncode != 0:
-                print(stderr)
+                if not os.path.exists("checkconsistency_errors"):
+                    os.makedirs("checkconsistency_errors")
+                filename = p.split("/")[-1]
+                with open("checkconsistency_errors/{}.txt".format(filename), "w") as f:
+                    f.write(stderr)
+                print_colored_status("ERROR", p)
             else:
-                print("OK -- {}".format(p))
+                print_colored_status("OK", p)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Added color for OK(Green) and ERROR(Red).
- Added `mode` option
	- 1 - `checkconsistency`
	- 2 - `scan --only_verify_checksum`
- Reports will be saved in `./checkconsistency_errors/tablet-<uuid>.txt` separately for each tablet with errors.