### PR TITLE
[docs][CDCSDK] Documentation Changes in Connector config

### DIFF
--- a/docs/content/preview/explore/change-data-capture/debezium-connector-yugabytedb.md
+++ b/docs/content/preview/explore/change-data-capture/debezium-connector-yugabytedb.md
@@ -989,7 +989,7 @@ The following properties are _required_ unless a default value is available:
 | Property | Default value | Description |
 | :------- | :------------ | :---------- |
 | connector.class | N/A | Specifies the connector to use to connect Debezium to the database. For YugabyteDB, use `io.debezium.connector.yugabytedb.YugabyteDBConnector`. |
-| database.hostname | N/A | The IP address of the database host machine. For a distributed cluster, use the leader node's IP address.  Alternatively, a coma separated list of multiple host addresses along with corresponding ports can be specified, for ex: `ip1:port1,ip2:port2,ip3:port3`. This is useful for connection fail-over cases. |
+| database.hostname | N/A | The IP address of the database host machine. For a distributed cluster, use the leader node's IP address. Alternatively, you can specify a comma-separated list of multiple host addresses and corresponding ports (for example,`ip1:port1,ip2:port2,ip3:port3`). This is useful for connection fail-over cases. |
 | database.port | N/A | The port at which the YSQL process is running. |
 | database.master.addresses | N/A | Comma-separated list of `host:port` values. |
 | database.user | N/A | The user which will be used to connect to the database. |

--- a/docs/content/preview/explore/change-data-capture/debezium-connector-yugabytedb.md
+++ b/docs/content/preview/explore/change-data-capture/debezium-connector-yugabytedb.md
@@ -989,7 +989,7 @@ The following properties are _required_ unless a default value is available:
 | Property | Default value | Description |
 | :------- | :------------ | :---------- |
 | connector.class | N/A | Specifies the connector to use to connect Debezium to the database. For YugabyteDB, use `io.debezium.connector.yugabytedb.YugabyteDBConnector`. |
-| database.hostname | N/A | The IP address of the database host machine. For a distributed cluster, use the leader node's IP address. |
+| database.hostname | N/A | The IP address of the database host machine. For a distributed cluster, use the leader node's IP address.  Alternatively, a coma separated list of multiple host addresses along with corresponding ports can be specified, for ex: `ip1:port1,ip2:port2,ip3:port3`. This is useful for connection fail-over cases. |
 | database.port | N/A | The port at which the YSQL process is running. |
 | database.master.addresses | N/A | Comma-separated list of `host:port` values. |
 | database.user | N/A | The user which will be used to connect to the database. |

--- a/docs/content/preview/explore/change-data-capture/debezium-connector-yugabytedb.md
+++ b/docs/content/preview/explore/change-data-capture/debezium-connector-yugabytedb.md
@@ -989,7 +989,7 @@ The following properties are _required_ unless a default value is available:
 | Property | Default value | Description |
 | :------- | :------------ | :---------- |
 | connector.class | N/A | Specifies the connector to use to connect Debezium to the database. For YugabyteDB, use `io.debezium.connector.yugabytedb.YugabyteDBConnector`. |
-| database.hostname | N/A | The IP address of the database host machine. For a distributed cluster, use the leader node's IP address. Alternatively, you can specify a comma-separated list of multiple host addresses and corresponding ports (for example,`ip1:port1,ip2:port2,ip3:port3`). This is useful for connection fail-over cases. |
+| database.hostname | N/A | The IP address of the database host machine. For a distributed cluster, use the leader node's IP address. Alternatively, you can specify a comma-separated list of multiple host addresses and corresponding ports (for example,`ip1:port1,ip2:port2,ip3:port3`). This is useful for connection fail-over. |
 | database.port | N/A | The port at which the YSQL process is running. |
 | database.master.addresses | N/A | Comma-separated list of `host:port` values. |
 | database.user | N/A | The user which will be used to connect to the database. |
@@ -1139,10 +1139,12 @@ For usage example, refer to YugabyteDB CDC Consistent Streaming Pipeline in the 
 The connector publishes metadata that can be used to distinguish transaction boundaries for a downstream application to implement atomicity. Once the configuration property `provide.transaction.metadata` is enabled, the connector will also publish events indicating the beginning and end of the transaction. For more information, see [Transaction metadata](#transaction-metadata).
 
 ### Prerequisites
+
 * Create the Stream ID should in the `EXPLICIT` checkpointing mode. For more information, see [yb-admin create\_change\_data_stream](../../../admin/yb-admin#create-change-data-stream).
 * You should always run the connector with a single task, that is, `tasks.max` should always be set to 1.
 
 ### Known limitations
+
 * Transactional ordering is currently not supported with schema evolution. See issue [18476](https://github.com/yugabyte/yugabyte-db/issues/18476).
 
 ## Monitoring

--- a/docs/content/preview/releases/release-notes/v2.17.md
+++ b/docs/content/preview/releases/release-notes/v2.17.md
@@ -84,7 +84,7 @@ docker pull yugabytedb/yugabyte:2.17.3.0-b152
 * [[16290](https://github.com/yugabyte/yugabyte-db/issues/16290)] [DocDB] add gflag ysql_enable_pack_full_row_update (default false)
 * [[16303](https://github.com/yugabyte/yugabyte-db/issues/16303)] [DocDB] Initialize current_scan_target_ with the correct prefix
 * [[16424](https://github.com/yugabyte/yugabyte-db/issues/16424)] [CDCSDK] Add table_id to GetCheckpointRequestPB
-* [DEVOPS-2617] Add required chcekbox to GitHub issues templates.
+* [DEVOPS-2617] Add required checkbox to GitHub issues templates.
 
 ### Improvements
 

--- a/docs/content/stable/explore/change-data-capture/debezium-connector-yugabytedb.md
+++ b/docs/content/stable/explore/change-data-capture/debezium-connector-yugabytedb.md
@@ -985,7 +985,7 @@ The following properties are _required_ unless a default value is available:
 | Property | Default value | Description |
 | :------- | :------------ | :---------- |
 | connector.class | N/A | Specifies the connector to use to connect Debezium to the database. For YugabyteDB, use `io.debezium.connector.yugabytedb.YugabyteDBConnector`. |
-| database.hostname | N/A | The IP address of the database host machine. For a distributed cluster, use the leader node's IP address. |
+| database.hostname | N/A | The IP address of the database host machine. For a distributed cluster, use the leader node's IP address.  Alternatively, a coma separated list of multiple host addresses along with corresponding ports can be specified, for ex: `ip1:port1,ip2:port2,ip3:port3`. This is useful for connection fail-over cases. |
 | database.port | N/A | The port at which the YSQL process is running. |
 | database.master.addresses | N/A | Comma-separated list of `host:port` values. |
 | database.user | N/A | The user which will be used to connect to the database. |

--- a/docs/content/stable/explore/change-data-capture/debezium-connector-yugabytedb.md
+++ b/docs/content/stable/explore/change-data-capture/debezium-connector-yugabytedb.md
@@ -985,7 +985,7 @@ The following properties are _required_ unless a default value is available:
 | Property | Default value | Description |
 | :------- | :------------ | :---------- |
 | connector.class | N/A | Specifies the connector to use to connect Debezium to the database. For YugabyteDB, use `io.debezium.connector.yugabytedb.YugabyteDBConnector`. |
-| database.hostname | N/A | The IP address of the database host machine. For a distributed cluster, use the leader node's IP address.  Alternatively, a coma separated list of multiple host addresses along with corresponding ports can be specified, for ex: `ip1:port1,ip2:port2,ip3:port3`. This is useful for connection fail-over cases. |
+| database.hostname | N/A | The IP address of the database host machine. For a distributed cluster, use the leader node's IP address. Alternatively, you can specify a comma-separated list of multiple host addresses and corresponding ports (for example,`ip1:port1,ip2:port2,ip3:port3`). This is useful for connection fail-over. |
 | database.port | N/A | The port at which the YSQL process is running. |
 | database.master.addresses | N/A | Comma-separated list of `host:port` values. |
 | database.user | N/A | The user which will be used to connect to the database. |
@@ -1135,10 +1135,12 @@ For usage example, refer to YugabyteDB CDC Consistent Streaming Pipeline in the 
 The connector publishes metadata that can be used to distinguish transaction boundaries for a downstream application to implement atomicity. Once the configuration property `provide.transaction.metadata` is enabled, the connector will also publish events indicating the beginning and end of the transaction. For more information, see [Transaction metadata](#transaction-metadata).
 
 ### Prerequisites
+
 * Create the Stream ID should in the `EXPLICIT` checkpointing mode. For more information, see [yb-admin create\_change\_data_stream](../../../admin/yb-admin#create-change-data-stream).
 * You should always run the connector with a single task, that is, `tasks.max` should always be set to 1.
 
 ### Known limitations
+
 * Transactional ordering is currently not supported with schema evolution. See issue [18476](https://github.com/yugabyte/yugabyte-db/issues/18476).
 
 ## Monitoring


### PR DESCRIPTION
This PR contains a documentation change to the connector config `database.hostname`. Earlier, this config used to take the IP address of leader node. After a recent change to support fail-over connection in multi-node clusters, this config can now also accept a coma separated list of multiple node addresses (ex: `ip1:port1,ip2:port2,ip3:port3`).