### PR TITLE
[Docs] Add target on external links

### DIFF
--- a/docs/layouts/partials/hooks/body-end.html
+++ b/docs/layouts/partials/hooks/body-end.html
@@ -1,6 +1,31 @@
 <script src="/js/site.js"></script>
+<!-- Add target/rel on external links -->
+<script type="module">
+import detectExternalLink from 'https://cdn.jsdelivr.net/npm/detect-external-link@2/+esm';
+if (typeof detectExternalLink === 'function') {
+  const selectLinks = document.querySelectorAll('.td-content a');
+  selectLinks.forEach(element => {
+    const linkHref = element.getAttribute('href');
+    if (linkHref !== null) {
+      const isExternal = detectExternalLink(linkHref, {
+        'hosts': [
+          'https://docs.yugabyte.com/'
+        ]
+      });
+      if (isExternal) {
+        if (!element.target) {
+          element.target = '_blank';
+          if (!element.rel) {
+            element.rel = 'noopener';
+          }
+        }
+      }
+    }
+  });
+}
+</script>
 
 {{ $layoutType := .Type }}
-{{ with .Site.Params.algolia }}
+{{ with .Site.Params.algolia_docsearch }}
   <script src="/js/search.js"></script>
 {{ end }}


### PR DESCRIPTION
There are couple of instances where we have links that goes outside from the docs and technically all those links needs to be open in a new tab, this PR is to fix them. Few examples are mentioned below:

Live Site examples:

1. [Google Spanner](https://docs.yugabyte.com/preview/architecture/docdb-replication/)
2. [Kubernetes multi-zone documentation](https://docs.yugabyte.com/preview/deploy/kubernetes/multi-zone/)
3. [YugabyteDB Managed API](https://docs.yugabyte.com/preview/yugabyte-cloud/managed-automation/)

Preview examples:

1. [Google Spanner](https://deploy-preview-19319--infallible-bardeen-164bc9.netlify.app/preview/architecture/docdb-replication/)
2. [Kubernetes multi-zone documentation](https://deploy-preview-19319--infallible-bardeen-164bc9.netlify.app/preview/deploy/kubernetes/multi-zone/)
3. [YugabyteDB Managed API](https://deploy-preview-19319--infallible-bardeen-164bc9.netlify.app/preview/yugabyte-cloud/managed-automation/)

