### PR TITLE
Updating to rrdiagram@0.0.7

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -32,7 +32,7 @@
         "webpack": "5.88.2",
         "webpack-cli": "5.1.4",
         "webpack-dev-server": "4.15.1",
-        "yb-rrdiagram": "0.0.4"
+        "yb-rrdiagram": "0.0.7"
       },
       "devDependencies": {
         "autoprefixer": "10.4.14",
@@ -11079,9 +11079,9 @@
       }
     },
     "node_modules/yb-rrdiagram": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/yb-rrdiagram/-/yb-rrdiagram-0.0.4.tgz",
-      "integrity": "sha512-H8hj8xab3TNNxOnMfSAgtUpRfyVipj2bolr9o90AhhLDjpz5hZnOkyZcWfu9VQa1N0RMI9SDEH3i6849zAaYvQ=="
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/yb-rrdiagram/-/yb-rrdiagram-0.0.7.tgz",
+      "integrity": "sha512-AS/VLfdWy1c3UyEbKKg7Ofr06cuGoLowu/1GeJjgPAJviOhbOAvKMm4Utw2S8I5LyW7erJ1NkdNIq0ZQWcziiA=="
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -19152,9 +19152,9 @@
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
     },
     "yb-rrdiagram": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/yb-rrdiagram/-/yb-rrdiagram-0.0.4.tgz",
-      "integrity": "sha512-H8hj8xab3TNNxOnMfSAgtUpRfyVipj2bolr9o90AhhLDjpz5hZnOkyZcWfu9VQa1N0RMI9SDEH3i6849zAaYvQ=="
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/yb-rrdiagram/-/yb-rrdiagram-0.0.7.tgz",
+      "integrity": "sha512-AS/VLfdWy1c3UyEbKKg7Ofr06cuGoLowu/1GeJjgPAJviOhbOAvKMm4Utw2S8I5LyW7erJ1NkdNIq0ZQWcziiA=="
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -50,7 +50,7 @@
     "webpack": "5.88.2",
     "webpack-cli": "5.1.4",
     "webpack-dev-server": "4.15.1",
-    "yb-rrdiagram": "0.0.4"
+    "yb-rrdiagram": "0.0.7"
   },
   "devDependencies": {
     "autoprefixer": "10.4.14",


### PR DESCRIPTION
- fix for invalid rules
- forcing `--oldformat` as param to use the previous scheme.