### PR TITLE
[docs] Host authentication and UNIX socket address

### DIFF
--- a/docs/content/preview/admin/yb-ctl.md
+++ b/docs/content/preview/admin/yb-ctl.md
@@ -23,6 +23,12 @@ yb-ctl is meant for managing local clusters only. This means that a single host 
 
 yb-ctl can manage a cluster if and only if it was initially created via yb-ctl. This means that clusters created through any other means including those in the [Deploy](../../deploy/) section cannot be administered using yb-ctl.
 
+{{% note title="Running on macOS" %}}
+
+Running YugabyteDB on macOS requires additional settings. For more information, refer to [Running on macOS](#running-on-macos).
+
+{{% /note %}}
+
 ### Installation
 
 yb-ctl is installed with YugabyteDB and is located in the `bin` directory of the YugabyteDB home directory.
@@ -207,6 +213,8 @@ Flag to log internal debug messages to `stderr`.
 ## Using yb-ctl
 
 ### Running on macOS
+
+#### Port conflicts
 
 macOS Monterey enables AirPlay receiving by default, which listens on port 7000. This conflicts with YugabyteDB and causes `yb-ctl start` to fail. Use the [--master_flags](#master-flags) flag when you start the cluster to change the default port number, as follows:
 

--- a/docs/content/preview/reference/configuration/yugabyted.md
+++ b/docs/content/preview/reference/configuration/yugabyted.md
@@ -23,6 +23,12 @@ For examples of using yugabyted to deploy single- and multi-node clusters, see [
 Note that yugabyted is not recommended for production deployments. For production deployments with fully-distributed multi-node clusters, use [`yb-tserver`](../yb-tserver/) and [`yb-master`](../yb-master/) directly. Refer to [Deploy YugabyteDB](../../../deploy).
 {{</note>}}
 
+{{% note title="Running on macOS" %}}
+
+Running YugabyteDB on macOS requires additional settings. For more information, refer to [Running on macOS](#running-on-macos).
+
+{{% /note %}}
+
 ## Syntax
 
 ```sh
@@ -670,6 +676,8 @@ The following are combinations of environment variables and their uses:
 To deploy any type of secure cluster (that is, using the `--secure` flag) or use encryption at rest, OpenSSL must be installed on your machine.
 
 ### Running on macOS
+
+#### Port conflicts
 
 macOS Monterey enables AirPlay receiving by default, which listens on port 7000. This conflicts with YugabyteDB and causes `yugabyted start` to fail. Use the [--master_webserver_port flag](#advanced-flags) when you start the cluster to change the default port number, as follows:
 

--- a/docs/content/preview/secure/authentication/host-based-authentication.md
+++ b/docs/content/preview/secure/authentication/host-based-authentication.md
@@ -97,6 +97,29 @@ hostnossl  database  user  IP-address  netmask  auth-method  [auth-options]
 
 This record matches connection attempts made via the UNIX socket.
 
+Similarly to PostgreSQL, YugabyteDB supports opening connections via the UNIX sockets when local authentication is used. However, unlike PostgreSQL, YugabyteDB requires ysqlsh, psql and other tools to provide the full path to the socket location when using the following authentication methods:
+
+- local authentication using [peer](#peer)
+- local authentication using [trust](#trust)
+
+The path to the socket location is written to YB-TServer logs, similar to the following:
+
+```output
+2023-09-05 13:56:20.154 UTC [1261] LOG:  listening on Unix socket "/tmp/.yb.127.0.0.1:5433/.s.PGSQL.5433"
+```
+
+If you use ysqlsh, use the `-h` flag, and pass in the first part of the path (in the preceding example, `/tmp/.yb.127.0.0.1:5433/`) as follows:
+
+```sh
+./bin/ysqlsh -h /tmp/.yb.127.0.0.1:5433
+```
+
+For psql you also need specify the port number:
+
+```sh
+psql -h /tmp/.yb.127.0.0.1:5433/ -p 5433
+```
+
 ### host
 
 This record matches connection attempts made using TCP/IP, including localhost. `host` records match either SSL or non-SSL connection attempts.

--- a/docs/content/preview/secure/authentication/host-based-authentication.md
+++ b/docs/content/preview/secure/authentication/host-based-authentication.md
@@ -93,16 +93,16 @@ hostssl    database  user  IP-address  netmask  auth-method  [auth-options]
 hostnossl  database  user  IP-address  netmask  auth-method  [auth-options]
 ```
 
-### local
+### Connection
 
-This record matches connection attempts made via the UNIX socket.
+#### local
 
 Similarly to PostgreSQL, YugabyteDB supports opening connections via the UNIX sockets when local authentication is used. However, unlike PostgreSQL, YugabyteDB requires ysqlsh, psql and other tools to provide the full path to the socket location when using the following authentication methods:
 
 - local authentication using [peer](#peer)
 - local authentication using [trust](#trust)
 
-The path to the socket location is written to YB-TServer logs, similar to the following:
+One way to obtain the path to the socket location is from the YB-TServer logs, similar to the following:
 
 ```output
 2023-09-05 13:56:20.154 UTC [1261] LOG:  listening on Unix socket "/tmp/.yb.127.0.0.1:5433/.s.PGSQL.5433"
@@ -114,21 +114,21 @@ If you use ysqlsh, use the `-h` flag, and pass in the first part of the path (in
 ./bin/ysqlsh -h /tmp/.yb.127.0.0.1:5433
 ```
 
-For psql you also need specify the port number:
+For psql, you also need specify the port number as follows:
 
 ```sh
 psql -h /tmp/.yb.127.0.0.1:5433/ -p 5433
 ```
 
-### host
+#### host
 
 This record matches connection attempts made using TCP/IP, including localhost. `host` records match either SSL or non-SSL connection attempts.
 
-### hostssl
+#### hostssl
 
 This record specifies a local or remote host that can connect to a YugabyteDB cluster using SSL.
 
-### hostnossl
+#### hostnossl
 
 This record only matches connection attempts made over TCP/IP that do not use SSL.
 

--- a/docs/content/stable/admin/yb-ctl.md
+++ b/docs/content/stable/admin/yb-ctl.md
@@ -21,6 +21,12 @@ yb-ctl is meant for managing local clusters only. This means that a single host 
 
 yb-ctl can manage a cluster if and only if it was initially created via yb-ctl. This means that clusters created through any other means including those in the [Deploy](../../deploy/) section cannot be administered using yb-ctl.
 
+{{% note title="Running on macOS" %}}
+
+Running YugabyteDB on macOS requires additional settings. For more information, refer to [Running on macOS](#running-on-macos).
+
+{{% /note %}}
+
 ### Installation
 
 yb-ctl is installed with YugabyteDB and is located in the `bin` directory of the YugabyteDB home directory.
@@ -205,6 +211,8 @@ Flag to log internal debug messages to `stderr`.
 ## Using yb-ctl
 
 ### Running on macOS
+
+#### Port conflicts
 
 macOS Monterey enables AirPlay receiving by default, which listens on port 7000. This conflicts with YugabyteDB and causes `yb-ctl start` to fail. Use the [--master_flags](#master-flags) flag when you start the cluster to change the default port number, as follows:
 

--- a/docs/content/stable/reference/configuration/yugabyted.md
+++ b/docs/content/stable/reference/configuration/yugabyted.md
@@ -23,15 +23,9 @@ Using yugabyted, you can create single-node clusters. To create multi-node clust
 Note that yugabyted is not recommended for production deployments. For production deployments with fully-distributed multi-node clusters, use [`yb-tserver`](../yb-tserver/) and [`yb-master`](../yb-master/) directly. Refer to [Deploy YugabyteDB](../../../deploy).
 {{</note>}}
 
-{{% note title="macOS Monterey" %}}
+{{% note title="Running on macOS" %}}
 
-macOS Monterey enables AirPlay receiving by default, which listens on port 7000. This conflicts with YugabyteDB and causes `yugabyted start` to fail. Use the [--master_webserver_port flag](#advanced-flags) when you start the cluster to change the default port number, as follows:
-
-```sh
-./bin/yugabyted start --master_webserver_port=9999
-```
-
-Alternatively, you can disable AirPlay receiving, then start YugabyteDB normally, and then, optionally, re-enable AirPlay receiving.
+Running YugabyteDB on macOS requires additional settings. For more information, refer to [Running on macOS](#running-on-macos).
 
 {{% /note %}}
 
@@ -680,6 +674,29 @@ The following are combinations of environment variables and their uses:
 ## Examples
 
 To deploy any type of secure cluster (that is, using the `--secure` flag) or use encryption at rest, OpenSSL must be installed on your machine.
+
+### Running on macOS
+
+#### Port conflicts
+
+macOS Monterey enables AirPlay receiving by default, which listens on port 7000. This conflicts with YugabyteDB and causes `yugabyted start` to fail. Use the [--master_webserver_port flag](#advanced-flags) when you start the cluster to change the default port number, as follows:
+
+```sh
+./bin/yugabyted start --master_webserver_port=9999
+```
+
+Alternatively, you can disable AirPlay receiving, then start YugabyteDB normally, and then, optionally, re-enable AirPlay receiving.
+
+#### Loopback addresses
+
+On macOS, every additional node after the first needs a loopback address configured to simulate the use of multiple hosts or nodes. For example, for a three-node cluster, you add two additional addresses as follows:
+
+```sh
+sudo ifconfig lo0 alias 127.0.0.2
+sudo ifconfig lo0 alias 127.0.0.3
+```
+
+The loopback addresses do not persist upon rebooting your computer.
 
 ### Destroy a local cluster
 

--- a/docs/content/stable/secure/authentication/host-based-authentication.md
+++ b/docs/content/stable/secure/authentication/host-based-authentication.md
@@ -93,19 +93,42 @@ hostssl    database  user  IP-address  netmask  auth-method  [auth-options]
 hostnossl  database  user  IP-address  netmask  auth-method  [auth-options]
 ```
 
-### local
+### Connection
 
-This record matches connection attempts made via the UNIX socket.
+#### local
 
-### host
+Similarly to PostgreSQL, YugabyteDB supports opening connections via the UNIX sockets when local authentication is used. However, unlike PostgreSQL, YugabyteDB requires ysqlsh, psql and other tools to provide the full path to the socket location when using the following authentication methods:
+
+- local authentication using [peer](#peer)
+- local authentication using [trust](#trust)
+
+One way to obtain the path to the socket location is from the YB-TServer logs, similar to the following:
+
+```output
+2023-09-05 13:56:20.154 UTC [1261] LOG:  listening on Unix socket "/tmp/.yb.127.0.0.1:5433/.s.PGSQL.5433"
+```
+
+If you use ysqlsh, use the `-h` flag, and pass in the first part of the path (in the preceding example, `/tmp/.yb.127.0.0.1:5433/`) as follows:
+
+```sh
+./bin/ysqlsh -h /tmp/.yb.127.0.0.1:5433
+```
+
+For psql, you also need specify the port number as follows:
+
+```sh
+psql -h /tmp/.yb.127.0.0.1:5433/ -p 5433
+```
+
+#### host
 
 This record matches connection attempts made using TCP/IP, including localhost. `host` records match either SSL or non-SSL connection attempts.
 
-### hostssl
+#### hostssl
 
 This record specifies a local or remote host that can connect to a YugabyteDB cluster using SSL.
 
-### hostnossl
+#### hostnossl
 
 This record only matches connection attempts made over TCP/IP that do not use SSL.
 

--- a/docs/content/v2.16/secure/authentication/host-based-authentication.md
+++ b/docs/content/v2.16/secure/authentication/host-based-authentication.md
@@ -93,19 +93,42 @@ hostssl    database  user  IP-address  netmask  auth-method  [auth-options]
 hostnossl  database  user  IP-address  netmask  auth-method  [auth-options]
 ```
 
-### local
+### Connection
 
-This record matches connection attempts made via the UNIX socket.
+#### local
 
-### host
+Similarly to PostgreSQL, YugabyteDB supports opening connections via the UNIX sockets when local authentication is used. However, unlike PostgreSQL, YugabyteDB requires ysqlsh, psql and other tools to provide the full path to the socket location when using the following authentication methods:
+
+- local authentication using [peer](#peer)
+- local authentication using [trust](#trust)
+
+One way to obtain the path to the socket location is from the YB-TServer logs, similar to the following:
+
+```output
+2023-09-05 13:56:20.154 UTC [1261] LOG:  listening on Unix socket "/tmp/.yb.127.0.0.1:5433/.s.PGSQL.5433"
+```
+
+If you use ysqlsh, use the `-h` flag, and pass in the first part of the path (in the preceding example, `/tmp/.yb.127.0.0.1:5433/`) as follows:
+
+```sh
+./bin/ysqlsh -h /tmp/.yb.127.0.0.1:5433
+```
+
+For psql, you also need specify the port number as follows:
+
+```sh
+psql -h /tmp/.yb.127.0.0.1:5433/ -p 5433
+```
+
+#### host
 
 This record matches connection attempts made using TCP/IP, including localhost. `host` records match either SSL or non-SSL connection attempts.
 
-### hostssl
+#### hostssl
 
 This record specifies a local or remote host that can connect to a YugabyteDB cluster using SSL.
 
-### hostnossl
+#### hostnossl
 
 This record only matches connection attempts made over TCP/IP that do not use SSL.
 


### PR DESCRIPTION
Add info on using local connections with host authentication and need to provide the path to the UNIX socket using -h flag

@netlify /preview/secure/authentication/host-based-authentication/