### PR TITLE
[docs] Update create-universe-multi-zone.md

### DIFF
--- a/docs/content/preview/yugabyte-platform/create-deployments/create-universe-multi-zone.md
+++ b/docs/content/preview/yugabyte-platform/create-deployments/create-universe-multi-zone.md
@@ -28,7 +28,7 @@ Generic</a>
 
 </ul>
 
-You can create a YugabyteDB universe using any cloud provider, except Kubernetes, in one geographic region across multiple availability zones.
+YugabyteDB Anywhere allows you to create a universe in one geographic region across multiple availability zones using one of the cloud providers.
 
 ## Prerequisites
 


### PR DESCRIPTION
This gives semantic parity to the first sentence of each of the two tabs: generic and kubernetes.  The existing generic phrasing seems to imply that you cannot create a kubernetes universe in one geographic region across multiple AZs.  But you can; all it takes is using the kubernetes provider -- which is explained on the other tab.