### PR TITLE
[Docs] Remove Universal Analytics code

### DIFF
--- a/docs/config/_default/config.toml
+++ b/docs/config/_default/config.toml
@@ -1,7 +1,6 @@
 baseurl = 'https://docs.yugabyte.com'
 languageCode = 'en-us'
 title = 'YugabyteDB Docs'
-googleAnalytics = 'UA-104956980-3'
 # Highlighting config (Pygments)
 pygmentsCodefences = true
 pygmentsStyle = 'pygments'
@@ -32,4 +31,3 @@ enableGitInfo = true
 
 [markup.goldmark.parser.attribute]
     block = true
-

--- a/docs/layouts/partials/hooks/head-end.html
+++ b/docs/layouts/partials/hooks/head-end.html
@@ -2,44 +2,6 @@
   <meta name="robots" content="noindex, nofollow">
 {{ end }}
 
-{{ with .Site.GoogleAnalytics }}
-  <script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', '{{ . }}', {
-      'anonymize_ip': true
-    });
-    /* Track outbound links */
-    var buttons = document.querySelectorAll('a');
-    Array.prototype.map.call(buttons, function(item) {
-      if (item.host != document.location.host) {
-        item.addEventListener('click', function() {
-          var action = item.getAttribute('data-action') || 'follow';
-          gtag('event', 'outbound', {
-            'event_category': action,
-            'value': item.href
-          });
-        });
-      }
-    });
-    /* Register handler to log search on blur */
-    var query = document.querySelector('.td-search-input');
-    if (query) {
-      query.addEventListener('blur', function() {
-        if (this.value) {
-          var path = document.location.pathname;
-          gtag('event', 'search', {
-            search_term: path + '?q=' + this.value
-          });
-        }
-      });
-    }
-  </script>
-{{ end }}
-
 <!-- Google Tag Manager -->
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
Universal Analytics properties stopped processing new data so it is better to remove unused code from the website. GA4 was already implemented few months back through GTM.
https://support.google.com/analytics/answer/11583528?hl=en