### PR TITLE
[Docs] Show the page title rather than first heading

### DIFF
--- a/docs/src/algolia-search.js
+++ b/docs/src/algolia-search.js
@@ -64,10 +64,12 @@ import algoliasearch from 'algoliasearch';
       let pageHash = '';
       let pageTitle = '';
 
-      if (hit.headers[0]) {
-        pageTitle = hit.headers[0];
-      } else if (hit.title) {
+      if (hit.title) {
         pageTitle = hit.title;
+      } else if (hit.headers[0]) {
+        pageTitle = hit.headers[0];
+      } else {
+        return;
       }
 
       if (hit.breadcrumb) {


### PR DESCRIPTION
On search result, it should show the page title rather than first heading.