### PR TITLE
[docs] Fix ubuntu contributor instructions

### DIFF
--- a/docs/content/preview/contribute/core-database/build-from-src-ubuntu.md
+++ b/docs/content/preview/contribute/core-database/build-from-src-ubuntu.md
@@ -51,7 +51,7 @@ AlmaLinux 8 is the recommended Linux development platform for YugabyteDB.
 
 {{< /note >}}
 
-The following instructions are for Ubuntu 20.04 or Ubuntu 22.04.
+The following instructions are for Ubuntu 20.04, 22.04, and 23.04.
 
 ## Install necessary packages
 

--- a/docs/content/preview/contribute/core-database/build-from-src-ubuntu.md
+++ b/docs/content/preview/contribute/core-database/build-from-src-ubuntu.md
@@ -141,6 +141,12 @@ export YB_CCACHE_DIR="$HOME/.cache/yb_ccache"
 
 {{% readfile "includes/build-the-code.md" %}}
 
+{{< note title="Note" >}}
+
+For Ubuntu 23.04, the `--clang17` build option is needed in order to use [downloaded third-party](#opt-yb-build).
+
+{{< /note >}}
+
 ### Build release package (optional)
 
 Perform the following steps to build a release package:

--- a/docs/content/preview/contribute/core-database/build-from-src-ubuntu.md
+++ b/docs/content/preview/contribute/core-database/build-from-src-ubuntu.md
@@ -119,6 +119,8 @@ sudo apt install -y npm golang-1.18
 export PATH="/usr/lib/go-1.18/bin:$PATH"
 ```
 
+For Ubuntu 23.04, install `golang-1.20` instead since 1.18 is not available.
+
 ### Ninja (optional)
 
 {{% readfile "includes/ninja.md" %}}
@@ -137,13 +139,24 @@ sudo apt install -y ccache
 export YB_CCACHE_DIR="$HOME/.cache/yb_ccache"
 ```
 
+### GCC (optional)
+
+To compile with GCC, install the following packages, and adjust the version numbers to match the GCC version you plan to use.
+
+```sh
+sudo apt install -y gcc-13 g++-13
+```
+
 ## Build the code
 
 {{% readfile "includes/build-the-code.md" %}}
 
 {{< note title="Note" >}}
 
-For Ubuntu 23.04, the `--clang17` build option is needed in order to use [downloaded third-party](#opt-yb-build).
+For Ubuntu 23.04, in order to use [downloaded third-party](#opt-yb-build), there are some additional restrictions:
+
+- build type: `debug`, `fastdebug`, or `release`
+- compiler: `--clang17` or `--gcc13`
 
 {{< /note >}}
 

--- a/docs/content/preview/contribute/core-database/build-from-src-ubuntu.md
+++ b/docs/content/preview/contribute/core-database/build-from-src-ubuntu.md
@@ -67,7 +67,6 @@ packages=(
   gettext
   git
   locales
-  ninja-build
   pkg-config
   rsync
 )

--- a/docs/content/preview/contribute/core-database/build-from-src-ubuntu.md
+++ b/docs/content/preview/contribute/core-database/build-from-src-ubuntu.md
@@ -62,20 +62,14 @@ sudo apt update
 sudo apt upgrade -y
 packages=(
   autoconf
-  bison
   build-essential
-  cmake
   curl
+  gettext
   git
-  libtool
   locales
   ninja-build
-  patchelf
   pkg-config
-  python3
-  python3-venv
   rsync
-  unzip
 )
 sudo apt install -y "${packages[@]}"
 sudo locale-gen en_US.UTF-8


### PR DESCRIPTION
Ubuntu contributor instructions were incorrectly changed by commit
a6a0f8d52b3fbf7ecdfce49ba2140969416928a1:

- gettext package was removed from instructions.  It is needed by
  Ubuntu 20.04 (and possibly others).
- Unnecessary packages were added to the instructions, some of which are
  duplicates because they show up again later in the page.

Revert those changes to the file.

Also notice that ninja-build package is duplicated in the top section
and "Ninja (optional)" section, so remove it from the top section.  And
update instructions to officially support 23.04.

Validate the instructions using ubuntu:23.04 docker image:

    # Perform minimal steps plus install ninja-build, then...
    ./yb_build.sh release --clang17
    sudo apt install file patchelf
    ./yb_release --no_yugabyted_ui --build_args=--clang17
    ./yb_release --no_yugabyted_ui --build_args='debug --clang17'
    ./yb_release --no_yugabyted_ui --build_args='debug --clang17 --make'
    ./yb_release --no_yugabyted_ui --build_args='release --gcc13'
    sudo apt install -y npm golang-1.20
    export PATH="/usr/lib/go-1.20/bin:$PATH"
    ./yb_release --build_args='release --gcc13'
    ./yb_build.sh fastdebug --gcc13 && exit 1 # issue #19961
    ./yb_build.sh fastdebug --clang17