### PR TITLE
Fix retryable requests logs to follow standard format

### DIFF
--- a/src/yb/consensus/retryable_requests.cc
+++ b/src/yb/consensus/retryable_requests.cc
@@ -40,10 +40,7 @@
 #include "yb/util/rw_mutex.h"
 #include "yb/util/status_format.h"
 
-#include "yb/gutil/strings/substitute.h"
-
 using namespace std::literals;
-using strings::Substitute;
 
 // We use this limit to prevent request range from infinite grow, because it will block log
 // cleanup. I.e. even we have continous request range, it will be split by blocks, that could be

--- a/src/yb/consensus/retryable_requests.h
+++ b/src/yb/consensus/retryable_requests.h
@@ -106,13 +106,7 @@ class RetryableRequestsManager {
 
   RetryableRequestsManager(
       const TabletId& tablet_id, FsManager* const fs_manager, const std::string& wal_dir,
-      const MemTrackerPtr& mem_tracker, std::string log_prefix)
-          : tablet_id_(tablet_id),
-            fs_manager_(fs_manager),
-            dir_(wal_dir),
-            retryable_requests_(
-                std::make_unique<RetryableRequests>(mem_tracker,
-                                                    std::move(log_prefix))) {}
+      const MemTrackerPtr& mem_tracker, const std::string log_prefix);
 
   Status Init(const server::ClockPtr& clock);
 
@@ -142,6 +136,10 @@ class RetryableRequestsManager {
   // Take the snapshot of the retryable requests, return the copy if success.
   std::unique_ptr<RetryableRequests> TakeSnapshotOfRetryableRequests();
 
+  void set_log_prefix(const std::string& log_prefix);
+
+  std::string LogPrefix() const;
+
  private:
   std::string CurrentFilePath() {
     return FilePath(dir_);
@@ -168,6 +166,7 @@ class RetryableRequestsManager {
   FsManager* fs_manager_ = nullptr;
   std::string dir_;
   std::unique_ptr<RetryableRequests> retryable_requests_;
+  std::string log_prefix_;
 
   static constexpr char kSuffixNew[] = ".NEW";
   static constexpr char kRetryableRequestsFileName[] = "retryable_requests";


### PR DESCRIPTION
Adds tablet ID and FS Manager UUID to logging code in retryable_requests.cc, fixing #19516 .