### PR TITLE
[#20087] YSQL: Fix gcc11 compilation failure by making iterator non-const

### DIFF
--- a/src/yb/yql/pgwrapper/pg_libpq-test.cc
+++ b/src/yb/yql/pgwrapper/pg_libpq-test.cc
@@ -3234,7 +3234,7 @@ TEST_F_EX(PgLibPqTest,
   string webserver_pid;
   RunShellProcess(Format("pgrep -f 'YSQL webserver' -P $0", postmaster_pid), &webserver_pid);
   webserver_pid.erase(std::remove(webserver_pid.begin(), webserver_pid.end(), '\n'),
-                      webserver_pid.cend());
+                      webserver_pid.end());
 
   // Check the webserver's OOM score
   std::string file_name = "/proc/" + webserver_pid + "/oom_score_adj";


### PR DESCRIPTION
Summary: 
GCC11 on CentOS does not support std::string::erase with const iterators. 

Test Plan: 
```
./yb_build.sh --gcc11 --cxx-test pgwrapper_pg_libpq-test --gtest_filter PgLibPqTest.TestOomScoreAdjPGWebserver
```
passed on AlmaLinux. 

Will check the GitHub builds for CentOS gcc. 