### PR TITLE
[Doc] Fix promote-auto-flags doc

### DIFF
--- a/docs/content/preview/admin/yb-admin.md
+++ b/docs/content/preview/admin/yb-admin.md
@@ -2485,7 +2485,7 @@ yb-admin \
 ```
 
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.
-* *max_flags_class*: The maximum AutoFlag class to promote. Allowed values are `kLocalVolatile`, `kLocalPersisted`, `kExternal`, `kNewInstallsOnly`. Default value is `kExternal`.
+* *max_flags_class*: The maximum AutoFlag class to promote. Allowed values are `kLocalVolatile`, `kLocalPersisted` and `kExternal`. Default value is `kExternal`.
 * *promote_non_runtime_flags*: Weather to promote non-runtime flags. Allowed values are `true` and `false`. Default value is `true`.
 * *force*: Forces the generation of a new AutoFlag configuration and sends it to all YugabyteDB processes even if there are no new AutoFlags to promote.
 

--- a/docs/content/preview/manage/upgrade-deployment.md
+++ b/docs/content/preview/manage/upgrade-deployment.md
@@ -81,7 +81,7 @@ New YugabyteDB features may require changes to the format of data that is sent o
 
 [AutoFlags](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/auto_flags.md) simplify this process so that you don't need to identify these features, find their corresponding flags, or determine what values to set them to. All new AutoFlags can be promoted to their desired target value using a single command.
 
-Use the [yb-admin](../../admin/yb-admin/) utility to promote the new AutoFlags, as follows:
+Use the [yb-admin](../../admin/yb-admin/#promote-auto-flags) utility to promote the new AutoFlags, as follows:
 
 ```sh
 ./bin/yb-admin \

--- a/docs/content/stable/manage/upgrade-deployment.md
+++ b/docs/content/stable/manage/upgrade-deployment.md
@@ -81,7 +81,7 @@ New YugabyteDB features may require changes to the format of data that is sent o
 
 [AutoFlags](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/auto_flags.md) simplify this process so that you don't need to identify these features, find their corresponding flags, or determine what values to set them to. All new AutoFlags can be promoted to their desired target value using a single command.
 
-Use the [yb-admin](../../admin/yb-admin/#promote-auto-flags) utility to promote the new AutoFlags, as follows:
+Use the [yb-admin](../../admin/yb-admin/) utility to promote the new AutoFlags, as follows:
 
 ```sh
 ./bin/yb-admin \

--- a/docs/content/stable/manage/upgrade-deployment.md
+++ b/docs/content/stable/manage/upgrade-deployment.md
@@ -81,7 +81,7 @@ New YugabyteDB features may require changes to the format of data that is sent o
 
 [AutoFlags](https://github.com/yugabyte/yugabyte-db/blob/master/architecture/design/auto_flags.md) simplify this process so that you don't need to identify these features, find their corresponding flags, or determine what values to set them to. All new AutoFlags can be promoted to their desired target value using a single command.
 
-Use the [yb-admin](../../admin/yb-admin/) utility to promote the new AutoFlags, as follows:
+Use the [yb-admin](../../admin/yb-admin/#promote-auto-flags) utility to promote the new AutoFlags, as follows:
 
 ```sh
 ./bin/yb-admin \


### PR DESCRIPTION
Update the link in upgrade-deployment to point to the promote-auto-flags command in the yb-admin page.
Remove kNewInstallOnly from the allowed values in promote_auto_flags command. 