### PR TITLE
Option to add icons to type: docs pages

### DIFF
--- a/docs/layouts/_default/content.html
+++ b/docs/layouts/_default/content.html
@@ -1,12 +1,17 @@
 <div class="td-content">
-	<div class="main-heading-with-version heading-without-image">
+  <div class="main-heading-with-version {{- if not .Params.image }} heading-without-image{{- end }}">
+    {{ if .Page.Params.image }}
+      <div class="heading-image">
+        <img alt="{{ .Title }}" title="{{ .Title }}" src="{{ .Params.image }}" />
+      </div>
+    {{ end }}
     <div class="heading-content">
       <div>
         <h1>{{ if .Params.headerTitle }}{{ .Params.headerTitle }}{{ else }}{{ .Title }}{{ end }} {{ if .Draft }} (Draft){{ end }}{{ partial "badges.html" . }}</h1>
         {{ with .Params.headcontent }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
       </div>
     </div>
-	</div>
+  </div>
 
   {{ partial "contribute_list" . }}
 	<header class="article-meta">


### PR DESCRIPTION
To add icon with H1 `type: docs`, you can pass image parameter same as for `type: indexpage`.