### PR TITLE
[Docs] Glitch on code block in Safari

### DIFF
--- a/docs/assets/scss/_code_block.scss
+++ b/docs/assets/scss/_code_block.scss
@@ -282,6 +282,24 @@ main {
   }
 }
 
+body.is-safari {
+  main {
+    .td-content {
+      pre {
+        button.copy {
+          z-index: 2;
+        }
+      }
+
+      pre.can-be-copied {
+        &::after {
+          z-index: 1;
+        }
+      }
+    }
+  }
+}
+
 body .tab-content .tab-pane li .highlight {
   margin: 20px 0;
 }


### PR DESCRIPTION
Glitch on code block where copy button and text are overlapping in Safari.
![image](https://github.com/yugabyte/yugabyte-db/assets/16156106/5ecb721d-9609-452b-933c-4e3cdb1a3c78)
