### PR TITLE
[yugabyte#10948] Sys Catalog Compaction and Flush should work across Peers.

### DIFF
--- a/src/yb/tools/yb-admin-test.cc
+++ b/src/yb/tools/yb-admin-test.cc
@@ -947,8 +947,7 @@ TEST_F(AdminCliTest, FlushSysCatalog) {
     master_addr_strs.push_back(ToString(addr));
   }
 
-  auto client = ASSERT_RESULT(
-      YBClientBuilder().master_server_addrs(master_addr_strs).Build());
+  auto client = ASSERT_RESULT(YBClientBuilder().master_server_addrs(master_addr_strs).Build());
   ASSERT_OK(CallAdmin("flush_sys_catalog"));
 }
 
@@ -960,8 +959,7 @@ TEST_F(AdminCliTest, CompactSysCatalog) {
     master_addr_strs.push_back(ToString(addr));
   }
   
-  auto client = ASSERT_RESULT(
-      YBClientBuilder().master_server_addrs(master_addr_strs).Build());
+  auto client = ASSERT_RESULT(YBClientBuilder().master_server_addrs(master_addr_strs).Build());
   ASSERT_OK(CallAdmin("compact_sys_catalog"));
 }
 

--- a/src/yb/tools/yb-admin-test.cc
+++ b/src/yb/tools/yb-admin-test.cc
@@ -941,15 +941,27 @@ TEST_F(AdminCliTest, DdlLog) {
 
 TEST_F(AdminCliTest, FlushSysCatalog) {
   BuildAndStart();
-  string master_address = ToString(cluster_->master()->bound_rpc_addr());
-  auto client = ASSERT_RESULT(YBClientBuilder().add_master_server_addr(master_address).Build());
+  const auto master_addrs = cluster_->GetMasterAddresses();
+  std::vector<string> master_addr_strs;
+  for (const auto& addr : master_addrs) {
+    master_addr_strs.push_back(ToString(addr));
+  }
+
+  auto client = ASSERT_RESULT(
+      YBClientBuilder().master_server_addrs(master_addr_strs).Build());
   ASSERT_OK(CallAdmin("flush_sys_catalog"));
 }
 
 TEST_F(AdminCliTest, CompactSysCatalog) {
   BuildAndStart();
-  string master_address = ToString(cluster_->master()->bound_rpc_addr());
-  auto client = ASSERT_RESULT(YBClientBuilder().add_master_server_addr(master_address).Build());
+  const auto master_addrs = cluster_->GetMasterAddresses();
+  std::vector<string> master_addr_strs;
+  for (const auto& addr : master_addrs) {
+    master_addr_strs.push_back(ToString(addr));
+  }
+  
+  auto client = ASSERT_RESULT(
+      YBClientBuilder().master_server_addrs(master_addr_strs).Build());
   ASSERT_OK(CallAdmin("compact_sys_catalog"));
 }
 


### PR DESCRIPTION
- Fixes #10948 to extend sys catalog compaction and flush to work across peers
- Updated existing `AdminCliTest` unit tests `FlushSysCatalog` and `CompactSysCatalog` to test all masters in cluster

Please check MasterAdminProxy instantiation, could not find similar cases where MasterAdminProxy RPC is invoked on all peers as  well. Follows other similar code for getting all masters and instantiating proxies to invoke RPCs.