### PR TITLE
[DocDB] Expose APIs via Master-leader for adding/removing Master nodes

### DIFF
--- a/src/yb/tools/yb-admin_cli.cc
+++ b/src/yb/tools/yb-admin_cli.cc
@@ -967,7 +967,27 @@ Status add_master_action(
 }
 
 const auto remove_master_args = "<ip_addr> <port> [<uuid>]";
+Status remove_master_action(
+    const ClusterAdminCli::CLIArguments& args, ClusterAdminClient* client) {
+  uint16_t new_port = 0;
+  string new_host;
 
+  if (args.size() < 2 || args.size() > 3) {
+    return ClusterAdminCli::kInvalidArguments;
+  }
+
+  new_host = args[0];
+  new_port = VERIFY_RESULT(CheckedStoi(args[1]));
+
+  string given_uuid;
+  if (args.size() == 3) {
+    given_uuid = args[2];
+  }
+  RETURN_NOT_OK_PREPEND(
+      client->RemoveMaster(new_host, new_port, given_uuid), "Unable to remove master");
+
+  return Status::OK();
+}
 
 
 const auto dump_masters_state_args = "[CONSOLE]";

--- a/src/yb/tools/yb-admin_cli.cc
+++ b/src/yb/tools/yb-admin_cli.cc
@@ -944,10 +944,6 @@ Status change_master_config_action(
 }
 
 const auto add_master_args = "<ip_addr> <port> [<uuid>]";
-// The goal here is to use the same code as change_master_config_action,
-// but add more checks like waiting for remote bootstrap to finish,
-// calling ListMasters to check if the master is healthy,
-// and ensure that follower lag is within a reasonable range.
 Status add_master_action(
     const ClusterAdminCli::CLIArguments& args, ClusterAdminClient* client) {
   uint16_t new_port = 0;
@@ -957,8 +953,6 @@ Status add_master_action(
     return ClusterAdminCli::kInvalidArguments;
   }
 
-  const string change_type = "ADD_SERVER";
-
   new_host = args[0];
   new_port = VERIFY_RESULT(CheckedStoi(args[1]));
 
@@ -966,15 +960,14 @@ Status add_master_action(
   if (args.size() == 3) {
     given_uuid = args[2];
   }
-  
-  Status s = client->ChangeMasterConfig(change_type, new_host, new_port, given_uuid);
-  if (!s.ok()) {
-    RETURN_NOT_OK_PREPEND(s, "Unable to change master config");
-  }
+  RETURN_NOT_OK_PREPEND(
+      client->AddMaster(new_host, new_port, given_uuid), "Unable to add master");
 
-  // Wait for the new master to finish remote bootstrap.
-  
+  return Status::OK();
 }
+
+const auto remove_master_args = "<ip_addr> <port> [<uuid>]";
+
 
 
 const auto dump_masters_state_args = "[CONSOLE]";

--- a/src/yb/tools/yb-admin_client.h
+++ b/src/yb/tools/yb-admin_client.h
@@ -168,6 +168,16 @@ class ClusterAdminClient {
       uint16_t peer_port,
       const std::string& peer_uuid = "");
 
+  Status AddMaster(
+      const std::string& peer_host,
+      uint16_t peer_port,
+      const std::string& peer_uuid = "");
+
+  Status RemoveMaster(
+      const std::string& peer_host,
+      uint16_t peer_port,
+      const std::string& peer_uuid = "");
+
   Status DumpMasterState(bool to_console);
 
   // List all the tables.


### PR DESCRIPTION
Adding APIs for adding and removing master nodes, that add additional checks around `change_master_config`, fixing #18333 .