### PR TITLE
[docs][PLAT-11979] Added the volume node affinity error in the troubleshooting guide

### DIFF
--- a/docs/content/preview/yugabyte-platform/troubleshoot/install-upgrade-issues/kubernetes.md
+++ b/docs/content/preview/yugabyte-platform/troubleshoot/install-upgrade-issues/kubernetes.md
@@ -121,7 +121,7 @@ If the issue you are experiencing is due to the incorrect setting for the storag
 Events:
   Type     Reason             Age                From                Message
   ----     ------             ----               ----                -------
-Warning  FailedScheduling   75s (x40 over 55m)    default-scheduler   0/10 nodes are available: 3 node(s) had volume node affinity conflict, 7 node(s) didn't match Pod's node affinity/selector. preemption: 0/10 nodes are available: 10 Preemption is not helpful for scheduling..
+Warning  FailedScheduling   75s (x40 over 55m)    default-scheduler   0/10 nodes are available: 3 node(s) had volume node affinity conflict, 7 node(s) didn't match Pod's node affinity/selector.
 ```
 
 You can obtain information related to storage classes, as follows:

--- a/docs/content/preview/yugabyte-platform/troubleshoot/install-upgrade-issues/kubernetes.md
+++ b/docs/content/preview/yugabyte-platform/troubleshoot/install-upgrade-issues/kubernetes.md
@@ -121,7 +121,7 @@ If the issue you are experiencing is due to the incorrect setting for the storag
 Events:
   Type     Reason             Age                From                Message
   ----     ------             ----               ----                -------
-Warning  FailedScheduling   75s (x40 over 55m)    default-scheduler   0/55 nodes are available: 19 Insufficient cpu, 36 node(s) didn't match Pod's node affinity/selector
+Warning  FailedScheduling   75s (x40 over 55m)    default-scheduler   0/10 nodes are available: 3 node(s) had volume node affinity conflict, 7 node(s) didn't match Pod's node affinity/selector. preemption: 0/10 nodes are available: 10 Preemption is not helpful for scheduling..
 ```
 
 You can obtain information related to storage classes, as follows:

--- a/docs/content/stable/yugabyte-platform/troubleshoot/install-upgrade-issues/kubernetes.md
+++ b/docs/content/stable/yugabyte-platform/troubleshoot/install-upgrade-issues/kubernetes.md
@@ -121,7 +121,7 @@ If the issue you are experiencing is due to the incorrect setting for the storag
 Events:
   Type     Reason             Age                From                Message
   ----     ------             ----               ----                -------
-Warning  FailedScheduling   75s (x40 over 55m)    default-scheduler   0/10 nodes are available: 3 node(s) had volume node affinity conflict, 7 node(s) didn't match Pod's node affinity/selector. preemption: 0/10 nodes are available: 10 Preemption is not helpful for scheduling..
+Warning  FailedScheduling   75s (x40 over 55m)    default-scheduler   0/10 nodes are available: 3 node(s) had volume node affinity conflict, 7 node(s) didn't match Pod's node affinity/selector.
 ```
 
 You can obtain information related to storage classes, as follows:

--- a/docs/content/stable/yugabyte-platform/troubleshoot/install-upgrade-issues/kubernetes.md
+++ b/docs/content/stable/yugabyte-platform/troubleshoot/install-upgrade-issues/kubernetes.md
@@ -121,7 +121,7 @@ If the issue you are experiencing is due to the incorrect setting for the storag
 Events:
   Type     Reason             Age                From                Message
   ----     ------             ----               ----                -------
-Warning  FailedScheduling   75s (x40 over 55m)    default-scheduler   0/55 nodes are available: 19 Insufficient cpu, 36 node(s) didn't match Pod's node affinity/selector
+Warning  FailedScheduling   75s (x40 over 55m)    default-scheduler   0/10 nodes are available: 3 node(s) had volume node affinity conflict, 7 node(s) didn't match Pod's node affinity/selector. preemption: 0/10 nodes are available: 10 Preemption is not helpful for scheduling..
 ```
 
 You can obtain information related to storage classes, as follows:


### PR DESCRIPTION
### Summary 
- I observed the following error `0/10 nodes are available: 3 node(s) had volume node affinity conflict, 7 node(s) didn't match Pod's node affinity/selector. preemption: 0/10 nodes are available: 10 Preemption is not helpful for scheduling..` while deploying the YB DB universe through the local(auto) k8s provider. It used the `standard` storage class and had immediate as `volumebindingmode`. I used the troubleshooting guide and observed we haven't mentioned the volume node affinity error. 

### Test plan
- I used the resolution steps from the troubleshooting guide and it worked well. 