### PR TITLE
Fix two typos with YBA Node agent commands

### DIFF
--- a/docs/content/preview/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises-manual.md
+++ b/docs/content/preview/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises-manual.md
@@ -721,7 +721,7 @@ You can install the YugabyteDB node agent manually. As the `yugabyte` user, do t
    For example, if you run the following:
 
    ```sh
-   node-agent node configure -t 1ba391bc-b522-4c18-813e-71a0e76b060a -u http://10.98.0.42:9000
+   ./installer.sh  -c install -u http://10.98.0.42:9000 -t 301fc382-cf06-4a1b-b5ef-0c8c45273aef
    ```
 
    You should get output similar to the following:
@@ -851,7 +851,7 @@ If you need to reconfigure a node agent, you can use the following procedure:
     For example, if you run the following:
 
     ```sh
-    ./installer.sh  -c install -u http://10.98.0.42:9000 -t 301fc382-cf06-4a1b-b5ef-0c8c45273aef
+    node-agent node configure -t 1ba391bc-b522-4c18-813e-71a0e76b060a -u http://10.98.0.42:9000
     ```
 
     ```output

--- a/docs/content/stable/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises-manual.md
+++ b/docs/content/stable/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises-manual.md
@@ -721,7 +721,7 @@ You can install the YugabyteDB node agent manually. As the `yugabyte` user, do t
    For example, if you run the following:
 
    ```sh
-   node-agent node configure -t 1ba391bc-b522-4c18-813e-71a0e76b060a -u http://10.98.0.42:9000
+   ./installer.sh  -c install -u http://10.98.0.42:9000 -t 301fc382-cf06-4a1b-b5ef-0c8c45273aef
    ```
 
    You should get output similar to the following:
@@ -851,7 +851,7 @@ If you need to reconfigure a node agent, you can use the following procedure:
     For example, if you run the following:
 
     ```sh
-    ./installer.sh  -c install -u http://10.98.0.42:9000 -t 301fc382-cf06-4a1b-b5ef-0c8c45273aef
+    node-agent node configure -t 1ba391bc-b522-4c18-813e-71a0e76b060a -u http://10.98.0.42:9000
     ```
 
     ```output

--- a/docs/content/v2.18/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises-manual.md
+++ b/docs/content/v2.18/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises-manual.md
@@ -721,7 +721,7 @@ You can install the YugabyteDB node agent manually. As the `yugabyte` user, do t
    For example, if you run the following:
 
    ```sh
-   node-agent node configure -t 1ba391bc-b522-4c18-813e-71a0e76b060a -u http://10.98.0.42:9000
+   ./installer.sh  -c install -u http://10.98.0.42:9000 -t 301fc382-cf06-4a1b-b5ef-0c8c45273aef
    ```
 
    You should get output similar to the following:
@@ -851,7 +851,7 @@ If you need to reconfigure a node agent, you can use the following procedure:
     For example, if you run the following:
 
     ```sh
-    ./installer.sh  -c install -u http://10.98.0.42:9000 -t 301fc382-cf06-4a1b-b5ef-0c8c45273aef
+    node-agent node configure -t 1ba391bc-b522-4c18-813e-71a0e76b060a -u http://10.98.0.42:9000
     ```
 
     ```output


### PR DESCRIPTION
Fix these typos

Typo 1: In the first section, Install Node Agent the third bullet talks about installation of node agent with this template ./installer.sh -c install -u https://<yba_address>:9000 -t <api_token> But then immediately below lists an instance of the above template with a different command node configure node-agent node configure -t 1ba391bc-b522-4c18-813e-71a0e76b060a -u http://10.98.0.42:9000 

Typo 2 - In the Reconfigure a node agent section its the opposite of Typo 1. That is, in point 4, we show the template for node configure node-agent node configure -t <api_token> -u https://<yba_address>:9000 But the instance we show is for the install command ./installer.sh  -c install -u http://10.98.0.42:9000 -t 301fc382-cf06-4a1b-b5ef-0c8c45273aef