### PR TITLE
[docs] Document #19259: Add a note in xCluster docs for ADD COLUMN ... DEFAULT 

### DIFF
--- a/docs/content/preview/deploy/multi-dc/async-replication/async-deployment.md
+++ b/docs/content/preview/deploy/multi-dc/async-replication/async-deployment.md
@@ -608,3 +608,34 @@ Alters involving adding/removing columns or modifying data types require replica
     ```output
     Replication enabled successfully
     ```
+#### Adding a column with a non-volatile default value
+
+When adding a new column with a (non-volatile) default expression, make sure to perform the schema modification on the target with the **computed** default value. 
+
+Example:
+
+Let's say we have a replicated table `test_table`.
+1. Pause replication
+1. Execute add column command on the source:
+   ```sql
+   ALTER TABLE test_table ADD COLUMN test_column TIMESTAMP DEFAULT NOW()
+   ```
+1. Perform the above `ALTER TABLE` command with the computed default value on the target.
+   
+    1.1 The computed default value can be retrieved from `pg_attribute.attmissingval`.
+        Example:
+   
+      ```sql
+      SELECT attmissingval FROM pg_attribute WHERE attrelid='test'::regclass AND attname='test_column';
+      ```
+      ```output
+                attmissingval         
+       -------------------------------
+        {"2024-01-09 12:29:11.88894"}
+       (1 row)
+      ```
+   
+    1.1 Finally, execute the `ADD COLUMN` command on the target with the computed default value.
+      ```sql
+         ALTER TABLE test ADD COLUMN test_column TIMESTAMP DEFAULT "2024-01-09 12:29:11.88894"
+      ```

--- a/docs/content/preview/deploy/multi-dc/async-replication/async-deployment.md
+++ b/docs/content/preview/deploy/multi-dc/async-replication/async-deployment.md
@@ -621,7 +621,7 @@ For example, say you have a replicated table `test_table`.
    ```
 1. Run the preceding `ALTER TABLE` command with the computed default value on the target as follows:
    
-    - The computed default value can be retrieved from `pg_attribute.attmissingval`.
+    - The computed default value can be retrieved from the `attmissingval` column in the `pg_attribute` catalog table.
 
       Example:
    

--- a/docs/content/preview/deploy/multi-dc/async-replication/async-deployment.md
+++ b/docs/content/preview/deploy/multi-dc/async-replication/async-deployment.md
@@ -620,10 +620,11 @@ Let's say we have a replicated table `test_table`.
    ```sql
    ALTER TABLE test_table ADD COLUMN test_column TIMESTAMP DEFAULT NOW()
    ```
-1. Perform the above `ALTER TABLE` command with the computed default value on the target.
+1. Perform the above `ALTER TABLE` command with the computed default value on the target:
    
-    1.1 The computed default value can be retrieved from `pg_attribute.attmissingval`.
-        Example:
+    - The computed default value can be retrieved from `pg_attribute.attmissingval`.
+
+      Example:
    
       ```sql
       SELECT attmissingval FROM pg_attribute WHERE attrelid='test'::regclass AND attname='test_column';
@@ -635,7 +636,7 @@ Let's say we have a replicated table `test_table`.
        (1 row)
       ```
    
-    1.1 Finally, execute the `ADD COLUMN` command on the target with the computed default value.
+    - Execute the `ADD COLUMN` command on the target with the computed default value.
       ```sql
          ALTER TABLE test ADD COLUMN test_column TIMESTAMP DEFAULT "2024-01-09 12:29:11.88894"
       ```

--- a/docs/content/preview/deploy/multi-dc/async-replication/async-deployment.md
+++ b/docs/content/preview/deploy/multi-dc/async-replication/async-deployment.md
@@ -610,17 +610,16 @@ Alters involving adding/removing columns or modifying data types require replica
     ```
 #### Adding a column with a non-volatile default value
 
-When adding a new column with a (non-volatile) default expression, make sure to perform the schema modification on the target with the **computed** default value. 
+When adding a new column with a (non-volatile) default expression, make sure to perform the schema modification on the target with the _computed_ default value. 
 
-Example:
+For example, say you have a replicated table `test_table`.
 
-Let's say we have a replicated table `test_table`.
-1. Pause replication
+1. Pause replication on both sides. 
 1. Execute add column command on the source:
    ```sql
    ALTER TABLE test_table ADD COLUMN test_column TIMESTAMP DEFAULT NOW()
    ```
-1. Perform the above `ALTER TABLE` command with the computed default value on the target:
+1. Run the preceding `ALTER TABLE` command with the computed default value on the target as follows:
    
     - The computed default value can be retrieved from `pg_attribute.attmissingval`.
 

--- a/docs/content/stable/deploy/multi-dc/async-replication/async-deployment.md
+++ b/docs/content/stable/deploy/multi-dc/async-replication/async-deployment.md
@@ -607,8 +607,11 @@ Alters involving adding/removing columns or modifying data types require replica
     Replication enabled successfully
     ```
 #### Adding a column with a non-volatile default value
+
 When adding a new column with a (non-volatile) default expression, make sure to perform the schema modification on the target with the _computed_ default value. 
+
 For example, say you have a replicated table `test_table`.
+
 1. Pause replication on both sides. 
 1. Execute add column command on the source:
    ```sql
@@ -617,6 +620,7 @@ For example, say you have a replicated table `test_table`.
 1. Run the preceding `ALTER TABLE` command with the computed default value on the target as follows:
    
     - The computed default value can be retrieved from the `attmissingval` column in the `pg_attribute` catalog table.
+
       Example:
    
       ```sql

--- a/docs/content/stable/deploy/multi-dc/async-replication/async-deployment.md
+++ b/docs/content/stable/deploy/multi-dc/async-replication/async-deployment.md
@@ -606,3 +606,30 @@ Alters involving adding/removing columns or modifying data types require replica
     ```output
     Replication enabled successfully
     ```
+#### Adding a column with a non-volatile default value
+When adding a new column with a (non-volatile) default expression, make sure to perform the schema modification on the target with the _computed_ default value. 
+For example, say you have a replicated table `test_table`.
+1. Pause replication on both sides. 
+1. Execute add column command on the source:
+   ```sql
+   ALTER TABLE test_table ADD COLUMN test_column TIMESTAMP DEFAULT NOW()
+   ```
+1. Run the preceding `ALTER TABLE` command with the computed default value on the target as follows:
+   
+    - The computed default value can be retrieved from the `attmissingval` column in the `pg_attribute` catalog table.
+      Example:
+   
+      ```sql
+      SELECT attmissingval FROM pg_attribute WHERE attrelid='test'::regclass AND attname='test_column';
+      ```
+      ```output
+                attmissingval         
+       -------------------------------
+        {"2024-01-09 12:29:11.88894"}
+       (1 row)
+      ```
+   
+    - Execute the `ADD COLUMN` command on the target with the computed default value.
+      ```sql
+         ALTER TABLE test ADD COLUMN test_column TIMESTAMP DEFAULT "2024-01-09 12:29:11.88894"
+      ```


### PR DESCRIPTION
Add a note in xCluster docs for ADD COLUMN ... DEFAULT:

The user must perform the ADD COLUMN ... DEFAULT operation on the target with the computed default value. 