### PR TITLE
[docs] Add `ADD/DROP PRIMARY KEY` warning that explains table rewrite that happens underneath

### DIFF
--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_table.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_table.md
@@ -182,6 +182,18 @@ It quietly succeeds. Now `\d children` shows that the foreign key constraint `ch
 
 Add the specified constraint to the table.
 
+
+{{< warning >}}
+Adding a `PRIMARY KEY` constraint will result in a full table rewrite and full-rewrite of all indexes associated with the table.
+This happens because of the clustered storage by primary-key that YugabyteDB uses to store rows and indexes. 
+Tables without a `PRIMARY KEY` have a hidden one underneath and rows are stored clustered on it. The secondary indexes of the table
+link to this hidden `PRIMARY KEY`.
+During this time, you may lose modification made to the table. 
+For reference, the same semantics as [Alter type with table rewrite](#alter-type-with-table-rewrite) apply.
+{{< /warning >}}
+
+
+
 #### [*alter_column_type*]
 
 Change the type of an existing column. The following semantics apply:
@@ -246,6 +258,14 @@ Drop the named constraint from the table.
 
 - `RESTRICT` — Remove only the specified constraint.
 - `CASCADE` — Remove the specified constraint and any dependent objects.
+
+{{< warning >}}
+Dropping the `PRIMARY KEY` constraint will result in a full table rewrite and full-rewrite of all indexes associated with the table.
+This happens because of the clustered storage by primary-key that YugabyteDB uses to store rows and indexes.
+During this time, you may lose modification made to the table. 
+For reference, the same semantics as [Alter type with table rewrite](#alter-type-with-table-rewrite) apply.
+{{< /warning >}}
+
 
 #### RENAME [ COLUMN ] *column_name* TO *column_name*
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_table.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_table.md
@@ -184,7 +184,7 @@ Add the specified constraint to the table.
 
 
 {{< warning >}}
-Adding a `PRIMARY KEY` constraint will result in a full table rewrite and full-rewrite of all indexes associated with the table.
+Adding a `PRIMARY KEY` constraint results in a full table rewrite and full rewrite of all indexes associated with the table.
 This happens because of the clustered storage by primary-key that YugabyteDB uses to store rows and indexes. 
 Tables without a `PRIMARY KEY` have a hidden one underneath and rows are stored clustered on it. The secondary indexes of the table
 link to this hidden `PRIMARY KEY`.

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_table.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_table.md
@@ -188,7 +188,7 @@ Adding a `PRIMARY KEY` constraint results in a full table rewrite and full rewri
 This happens because of the clustered storage by primary key that YugabyteDB uses to store rows and indexes. 
 Tables without a `PRIMARY KEY` have a hidden one underneath and rows are stored clustered on it. The secondary indexes of the table
 link to this hidden `PRIMARY KEY`.
-During this time, you may lose modification made to the table. 
+While the tables and indexes are being rewritten, you may lose any modifications made to the table. 
 For reference, the same semantics as [Alter type with table rewrite](#alter-type-with-table-rewrite) apply.
 {{< /warning >}}
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_table.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_table.md
@@ -185,7 +185,7 @@ Add the specified constraint to the table.
 
 {{< warning >}}
 Adding a `PRIMARY KEY` constraint results in a full table rewrite and full rewrite of all indexes associated with the table.
-This happens because of the clustered storage by primary-key that YugabyteDB uses to store rows and indexes. 
+This happens because of the clustered storage by primary key that YugabyteDB uses to store rows and indexes. 
 Tables without a `PRIMARY KEY` have a hidden one underneath and rows are stored clustered on it. The secondary indexes of the table
 link to this hidden `PRIMARY KEY`.
 During this time, you may lose modification made to the table. 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_table.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_table.md
@@ -261,7 +261,7 @@ Drop the named constraint from the table.
 
 {{< warning >}}
 Dropping the `PRIMARY KEY` constraint results in a full table rewrite and full rewrite of all indexes associated with the table.
-This happens because of the clustered storage by primary-key that YugabyteDB uses to store rows and indexes.
+This happens because of the clustered storage by primary key that YugabyteDB uses to store rows and indexes.
 While the tables and indexes are being rewritten, you may lose any modifications made to the table. 
 For reference, the same semantics as [Alter type with table rewrite](#alter-type-with-table-rewrite) apply.
 {{< /warning >}}

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_table.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_table.md
@@ -260,7 +260,7 @@ Drop the named constraint from the table.
 - `CASCADE` — Remove the specified constraint and any dependent objects.
 
 {{< warning >}}
-Dropping the `PRIMARY KEY` constraint will result in a full table rewrite and full-rewrite of all indexes associated with the table.
+Dropping the `PRIMARY KEY` constraint results in a full table rewrite and full rewrite of all indexes associated with the table.
 This happens because of the clustered storage by primary-key that YugabyteDB uses to store rows and indexes.
 During this time, you may lose modification made to the table. 
 For reference, the same semantics as [Alter type with table rewrite](#alter-type-with-table-rewrite) apply.

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_table.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_alter_table.md
@@ -262,7 +262,7 @@ Drop the named constraint from the table.
 {{< warning >}}
 Dropping the `PRIMARY KEY` constraint results in a full table rewrite and full rewrite of all indexes associated with the table.
 This happens because of the clustered storage by primary-key that YugabyteDB uses to store rows and indexes.
-During this time, you may lose modification made to the table. 
+While the tables and indexes are being rewritten, you may lose any modifications made to the table. 
 For reference, the same semantics as [Alter type with table rewrite](#alter-type-with-table-rewrite) apply.
 {{< /warning >}}
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_alter_table.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_alter_table.md
@@ -180,6 +180,18 @@ It quietly succeeds. Now `\d children` shows that the foreign key constraint `ch
 
 Add the specified constraint to the table.
 
+
+{{< warning >}}
+Adding a `PRIMARY KEY` constraint results in a full table rewrite and full rewrite of all indexes associated with the table.
+This happens because of the clustered storage by primary key that YugabyteDB uses to store rows and indexes. 
+Tables without a `PRIMARY KEY` have a hidden one underneath and rows are stored clustered on it. The secondary indexes of the table
+link to this hidden `PRIMARY KEY`.
+While the tables and indexes are being rewritten, you may lose any modifications made to the table. 
+For reference, the same semantics as [Alter type with table rewrite](#alter-type-with-table-rewrite) apply.
+{{< /warning >}}
+
+
+
 #### [*alter_column_type*]
 
 Change the type of an existing column. The following semantics apply:
@@ -244,6 +256,14 @@ Drop the named constraint from the table.
 
 - `RESTRICT` — Remove only the specified constraint.
 - `CASCADE` — Remove the specified constraint and any dependent objects.
+
+{{< warning >}}
+Dropping the `PRIMARY KEY` constraint results in a full table rewrite and full rewrite of all indexes associated with the table.
+This happens because of the clustered storage by primary key that YugabyteDB uses to store rows and indexes.
+While the tables and indexes are being rewritten, you may lose any modifications made to the table. 
+For reference, the same semantics as [Alter type with table rewrite](#alter-type-with-table-rewrite) apply.
+{{< /warning >}}
+
 
 #### RENAME [ COLUMN ] *column_name* TO *column_name*
 


### PR DESCRIPTION
Fixes #18238