### PR TITLE
DB-7418: throttle log message

### DIFF
--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -7971,7 +7971,7 @@ void CatalogManager::NotifyTabletDeleteFinished(
                  << " doesn't exist";
   } else {
     LOG(INFO) << "Clearing pending delete for tablet " << tablet_id << " in ts " << tserver_uuid;
- //   ts_desc->ClearPendingTabletDelete(tablet_id);
+    ts_desc->ClearPendingTabletDelete(tablet_id);
   }
   CheckTableDeleted(table, epoch);
 }

--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -7971,7 +7971,7 @@ void CatalogManager::NotifyTabletDeleteFinished(
                  << " doesn't exist";
   } else {
     LOG(INFO) << "Clearing pending delete for tablet " << tablet_id << " in ts " << tserver_uuid;
-    ts_desc->ClearPendingTabletDelete(tablet_id);
+ //   ts_desc->ClearPendingTabletDelete(tablet_id);
   }
   CheckTableDeleted(table, epoch);
 }

--- a/src/yb/master/cluster_balance_util.cc
+++ b/src/yb/master/cluster_balance_util.cc
@@ -500,7 +500,7 @@ Result<bool> PerTableLoadState::CanAddTabletToTabletServer(
   }
   // If this server has a pending tablet delete, don't use it.
   if (global_state_->servers_with_pending_deletes_.count(to_ts)) {
-    LOG(INFO) << "tablet server " << to_ts << " has a pending delete. "
+    YB_LOG_EVERY_N_SECS(INFO, 20) << "tablet server " << to_ts << " has a pending delete. "
               << "Not allowing it to take more tablets";
     return false;
   }

--- a/src/yb/master/cluster_balance_util.cc
+++ b/src/yb/master/cluster_balance_util.cc
@@ -500,7 +500,7 @@ Result<bool> PerTableLoadState::CanAddTabletToTabletServer(
   }
   // If this server has a pending tablet delete, don't use it.
   if (global_state_->servers_with_pending_deletes_.count(to_ts)) {
-    YB_LOG_EVERY_N_SECS(INFO, 30) << "tablet server " << to_ts << " has a pending delete. "
+    LOG(INFO) << "tablet server " << to_ts << " has a pending delete. "
               << "Not allowing it to take more tablets";
     return false;
   }

--- a/src/yb/master/cluster_balance_util.cc
+++ b/src/yb/master/cluster_balance_util.cc
@@ -500,7 +500,7 @@ Result<bool> PerTableLoadState::CanAddTabletToTabletServer(
   }
   // If this server has a pending tablet delete, don't use it.
   if (global_state_->servers_with_pending_deletes_.count(to_ts)) {
-    LOG(INFO) << "tablet server " << to_ts << " has a pending delete. "
+    YB_LOG_EVERY_N_SECS(INFO, 30) << "tablet server " << to_ts << " has a pending delete. "
               << "Not allowing it to take more tablets";
     return false;
   }


### PR DESCRIPTION
https://yugabyte.atlassian.net/jira/software/c/projects/DB/issues/DB-7418?filter=myopenissues 
Instead of using LOG(INFO), changed to use YB_LOG_EVERY_N_SECS(INFO, 20) to make sure that this repeated log message will not appear millions of times in an hour.