### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/create-repository-dispatch.yml
+++ b/.github/workflows/create-repository-dispatch.yml
@@ -25,7 +25,7 @@ jobs:
             fi
           fi
           echo "Release train determined: $train"
-          echo "::set-output name=yb_train::${train}"
+          echo "yb_train=${train}" >> "$GITHUB_OUTPUT"
           
       - name: "Trigger Repository Dispatch - yugabyte/terraform-gcp-yugabyte"
         run: |


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter