### PR TITLE
[docs] Correct the statement used to sync YBA with command-line changes

### DIFF
--- a/docs/content/preview/deploy/multi-dc/async-replication/async-transactional-tables.md
+++ b/docs/content/preview/deploy/multi-dc/async-replication/async-transactional-tables.md
@@ -116,8 +116,8 @@ To ensure changes made outside of YugabyteDB Anywhere are reflected in YBA, resy
 
 Before you can use the command, you need an API token, your customer ID, and the UUID of the Standby universe; refer to [Automation](../../../../yugabyte-platform/anywhere-automation/).
 
-To resynchronize the YBA UI, run the following command:
+To resynchronize the YBA UI, run the following on the command line on the YBA host:
 
 ```sh
-curl -k --location --request POST 'https://<yourportal.yugabyte.com>/api/v1/customers/<Customer_ID>/xcluster_configs/sync?<standby_universe_uuid>' --header 'X-AUTH-YW-API-TOKEN: <API_token>' --data
+curl -k --location --request POST 'https://<yourportal.yugabyte.com>/api/v1/customers/<Customer_ID>/xcluster_configs/sync?targetUniverseUUID=<standby_universe_uuid>' --header 'X-AUTH-YW-API-TOKEN: <API_token>' --data ''
 ```

--- a/docs/content/stable/deploy/multi-dc/async-replication/async-transactional-tables.md
+++ b/docs/content/stable/deploy/multi-dc/async-replication/async-transactional-tables.md
@@ -116,8 +116,8 @@ To ensure changes made outside of YugabyteDB Anywhere are reflected in YBA, resy
 
 Before you can use the command, you need an API token, your customer ID, and the UUID of the Standby universe; refer to [Automation](../../../../yugabyte-platform/anywhere-automation/).
 
-To resynchronize the YBA UI, run the following command:
+To resynchronize the YBA UI, run the following on the command line on the YBA host:
 
 ```sh
-curl -k --location --request POST 'https://<yourportal.yugabyte.com>/api/v1/customers/<Customer_ID>/xcluster_configs/sync?<standby_universe_uuid>' --header 'X-AUTH-YW-API-TOKEN: <API_token>' --data
+curl -k --location --request POST 'https://<yourportal.yugabyte.com>/api/v1/customers/<Customer_ID>/xcluster_configs/sync?targetUniverseUUID=<standby_universe_uuid>' --header 'X-AUTH-YW-API-TOKEN: <API_token>' --data ''
 ```


### PR DESCRIPTION
Two typos in the curl command:
- missing single quotes after data (payload missing)
- missing key targetUniverseUUID