### PR TITLE
[docs] Clarify difference between ysql and ycql in restarting replication

### DIFF
--- a/docs/content/preview/yugabyte-platform/create-deployments/async-replication-platform.md
+++ b/docs/content/preview/yugabyte-platform/create-deployments/async-replication-platform.md
@@ -121,7 +121,7 @@ This page allows you to do the following:
 
 - Pause the replication process (stop the traffic) by clicking **Pause Replication**. This is helpful when performing maintenance. Paused replications can be resumed from the last checkpoint.
 
-- Restart the replication by clicking **Actions > Restart Replication** and using the dialog shown in the following illustration to select the tables or database for which to restart the replication:
+- Restart the replication by clicking **Actions > Restart Replication**. Use the dialog shown in the following illustration to select the databases (YSQL) or keyspaces and tables (YCQL) for which to restart the replication:
 
   ![Replication Details](/images/yp/asynch-replication-551.png)
 

--- a/docs/content/stable/yugabyte-platform/create-deployments/async-replication-platform.md
+++ b/docs/content/stable/yugabyte-platform/create-deployments/async-replication-platform.md
@@ -120,7 +120,7 @@ This page allows you to do the following:
 
 - Pause the replication process (stop the traffic) by clicking **Pause Replication**. This is helpful when performing maintenance. Paused replications can be resumed from the last checkpoint.
 
-- Restart the replication by clicking **Actions > Restart Replication** and using the dialog shown in the following illustration to select the tables or database for which to restart the replication:
+- Restart the replication by clicking **Actions > Restart Replication**. For YCQL, additionally use the dialog shown in the following illustration to select the tables or database for which to restart the replication:
 
   ![Replication Details](/images/yp/asynch-replication-551.png)
 

--- a/docs/content/stable/yugabyte-platform/create-deployments/async-replication-platform.md
+++ b/docs/content/stable/yugabyte-platform/create-deployments/async-replication-platform.md
@@ -120,7 +120,7 @@ This page allows you to do the following:
 
 - Pause the replication process (stop the traffic) by clicking **Pause Replication**. This is helpful when performing maintenance. Paused replications can be resumed from the last checkpoint.
 
-- Restart the replication by clicking **Actions > Restart Replication**. For YCQL, additionally use the dialog shown in the following illustration to select the tables or database for which to restart the replication:
+- Restart the replication by clicking **Actions > Restart Replication**. Use the dialog shown in the following illustration to select the databases (YSQL) or keyspaces and tables (YCQL) for which to restart the replication:
 
   ![Replication Details](/images/yp/asynch-replication-551.png)
 

--- a/docs/content/v2.18/yugabyte-platform/create-deployments/async-replication-platform.md
+++ b/docs/content/v2.18/yugabyte-platform/create-deployments/async-replication-platform.md
@@ -120,7 +120,7 @@ This page allows you to do the following:
 
 - Pause the replication process (stop the traffic) by clicking **Pause Replication**. This is helpful when performing maintenance. Paused replications can be resumed from the last checkpoint.
 
-- Restart the replication by clicking **Actions > Restart Replication** and using the dialog shown in the following illustration to select the tables or database for which to restart the replication:
+- Restart the replication by clicking **Actions > Restart Replication**. Use the dialog shown in the following illustration to select the databases (YSQL) or keyspaces and tables (YCQL) for which to restart the replication:
 
   ![Replication Details](/images/yp/asynch-replication-551.png)
 


### PR DESCRIPTION
For ysql, clicking replication cannot be restarted for a subset of tables in the UI. There will not be an intermediary screen to choose which tables should have replication restarted. The proposed text clarifies that this is for ycql.