### PR TITLE
[docs] Ensure users are pointing python & python3 to appropriate version

### DIFF
--- a/docs/content/preview/yugabyte-platform/install-yugabyte-platform/prerequisites/installer.md
+++ b/docs/content/preview/yugabyte-platform/install-yugabyte-platform/prerequisites/installer.md
@@ -49,7 +49,22 @@ Licensing (such as a license file in the case of YBA Installer or Replicated, or
 
     YugabyteDB Anywhere may also work on other Linux distributions; contact your YugabyteDB support representative if you need added support.
 
-- Python v3.8 to 3.11 must be installed.
+- Python v3.8 to 3.11 must be installed, and both `python` and `python3` must point to the selected Python3 version. One way to achieve this is to use `alternatives` - see example:
+
+```
+sudo yum install @python38 -y
+sudo alternatives --config python
+# choose Python 3.8 from list
+
+sudo alternatives --config python3
+# choose Python 3.8 from list
+
+python -V
+# output: Python 3.8.16
+
+python3 -V
+# output: Python 3.8.16
+```
 
 ## Hardware requirements
 

--- a/docs/content/preview/yugabyte-platform/install-yugabyte-platform/prerequisites/installer.md
+++ b/docs/content/preview/yugabyte-platform/install-yugabyte-platform/prerequisites/installer.md
@@ -49,22 +49,22 @@ Licensing (such as a license file in the case of YBA Installer or Replicated, or
 
     YugabyteDB Anywhere may also work on other Linux distributions; contact your YugabyteDB support representative if you need added support.
 
-- Python v3.8 to 3.11 must be installed, and both `python` and `python3` must point to the selected Python3 version. One way to achieve this is to use `alternatives` - see example:
+- Python v3.8 to 3.11 must be installed, and both `python` and `python3` must point to Python 3. One way to achieve this is to use `alternatives`. For example:
 
-```
-sudo yum install @python38 -y
-sudo alternatives --config python
-# choose Python 3.8 from list
+    ```sh
+    sudo yum install @python38 -y
+    sudo alternatives --config python
+    # choose Python 3.8 from list
 
-sudo alternatives --config python3
-# choose Python 3.8 from list
+    sudo alternatives --config python3
+    # choose Python 3.8 from list
 
-python -V
-# output: Python 3.8.16
+    python -V
+    # output: Python 3.8.16
 
-python3 -V
-# output: Python 3.8.16
-```
+    python3 -V
+    # output: Python 3.8.16
+    ```
 
 ## Hardware requirements
 

--- a/docs/content/stable/yugabyte-platform/install-yugabyte-platform/prerequisites/installer.md
+++ b/docs/content/stable/yugabyte-platform/install-yugabyte-platform/prerequisites/installer.md
@@ -49,7 +49,22 @@ Licensing (such as a license file in the case of YBA Installer or Replicated, or
 
     YugabyteDB Anywhere may also work on other Linux distributions; contact your YugabyteDB support representative if you need added support.
 
-- Python v3.8 to 3.11 must be installed.
+- Python v3.8 to 3.11 must be installed, and both `python` and `python3` must point to Python 3. One way to achieve this is to use `alternatives`. For example:
+
+    ```sh
+    sudo yum install @python38 -y
+    sudo alternatives --config python
+    # choose Python 3.8 from list
+
+    sudo alternatives --config python3
+    # choose Python 3.8 from list
+
+    python -V
+    # output: Python 3.8.16
+
+    python3 -V
+    # output: Python 3.8.16
+    ```
 
 ## Hardware requirements
 

--- a/docs/content/v2.18/yugabyte-platform/install-yugabyte-platform/prerequisites/installer.md
+++ b/docs/content/v2.18/yugabyte-platform/install-yugabyte-platform/prerequisites/installer.md
@@ -56,7 +56,22 @@ YugabyteDB Anywhere may also work on other Linux distributions; contact your Yug
 
 ## Software requirements
 
-- Python v3.8 to 3.11 must be installed.
+- Python v3.8 to 3.11 must be installed, and both `python` and `python3` must point to Python 3. One way to achieve this is to use `alternatives`. For example:
+
+    ```sh
+    sudo yum install @python38 -y
+    sudo alternatives --config python
+    # choose Python 3.8 from list
+
+    sudo alternatives --config python3
+    # choose Python 3.8 from list
+
+    python -V
+    # output: Python 3.8.16
+
+    python3 -V
+    # output: Python 3.8.16
+    ```
 
 ## Hardware requirements
 


### PR DESCRIPTION
The docs specified that python 3.8 - 3.11 was installed, but not that the system used that version, as required by the installation scripts. 

The addition provides this clarification as well as an example of how to achieve this on some systems.