### PR TITLE
[yugabyte/yugabyte-db#21044] Log AsyncYBClient DNS lookup failures at warning level

### DIFF
--- a/java/yb-client/src/main/java/org/yb/client/AsyncYBClient.java
+++ b/java/yb-client/src/main/java/org/yb/client/AsyncYBClient.java
@@ -3306,8 +3306,8 @@ public class AsyncYBClient implements AutoCloseable {
       }
       return ip;
     } catch (UnknownHostException e) {
-      LOG.error("Failed to resolve the IP of `" + host + "' in "
-          + (System.nanoTime() - start) + "ns");
+      LOG.warn("Failed to resolve the IP of `" + host + "' in "
+          + (System.nanoTime() - start) + "ns", e);
       return null;
     }
   }


### PR DESCRIPTION
Also include the exception that caused the lookup error so when it occurs the user of the client has information to help them diagnose the problem.

The function `getIP` is an internal function that returns null when there's a DNS resolution error. The callers then wrap this and throw a useful exception to the user of the client. As a consequence of this there's no good reason to log this at the error level, and there's a very good reason to include the exception in the log entry to help diagnose the underlying root cause of any DNS resolution errors.