### PR TITLE
Add guidance for complex configuration values on edit-config-flags.md

### DIFF
--- a/docs/content/stable/yugabyte-platform/manage-deployments/edit-config-flags.md
+++ b/docs/content/stable/yugabyte-platform/manage-deployments/edit-config-flags.md
@@ -32,6 +32,12 @@ Depending on the flag, the universe may need to be restarted to apply the change
 - Immediately using a concurrent restart.
 - Immediately apply any changes that do not require a restart and wait until the next time the universe is restarted to apply the remaining changes.
 
+If any configuration flag value contains commas or single quotation marks, enclose that configuration flag/value pair in double quotation marks. For example, for the flag ysql_pg_conf_csv, the value could be formatted as the following:
+
+```sh
+"log_line_prefix='%m [%p %l %c] %q[%C %R %Z %H] [%r %a %u %d] '","log_connections='on'","log_disconnections='on'"
+```
+
 ### Add flags
 
 Click **Add Flags > Add to Master** to open the **Add to Master** dialog, then select the flag you want to add to YB-Master and set its value, as per the following illustration:


### PR DESCRIPTION
Update edit-config-flags.md to provide guidance on complex configuration values. The common example provided is for ysql_pg_conf_csv.