### PR TITLE
[Docs] Disable unsupported versions links in the version dropdown

### DIFF
--- a/docs/assets/scss/_dropdown_list.scss
+++ b/docs/assets/scss/_dropdown_list.scss
@@ -24,6 +24,15 @@
       &:hover {
         background: #f2f6ff !important;
       }
+
+      &[role="button"] {
+        cursor: not-allowed;
+        opacity: 0.6;
+
+        &:hover {
+          background: #fff !important;
+        }
+      }
     }
   }
 
@@ -47,7 +56,7 @@
     border-radius: 8px;
     min-height: 32px;
 
-    > span {
+    >span {
       font-weight: 500;
       font-size: 10px;
       line-height: 16px;
@@ -100,13 +109,14 @@
 
       .dropdown-menu {
         width: 100%;
-        transform:translate3d(0px, 38px, 0px)!important;
+        transform: translate3d(0px, 38px, 0px) !important;
       }
     }
 
     @media (min-width: 992px) {
       display: none;
     }
+
     @media (max-width: 991px) and (min-width: 768px) {
       margin-top: 18px;
       width: calc(100% - 85px);

--- a/docs/layouts/partials/navbar-version-selector.html
+++ b/docs/layouts/partials/navbar-version-selector.html
@@ -37,6 +37,18 @@
     {{- else if in .version "Unsupported" -}}
       {{ $path = "/" }}
     {{ end }}
-    <a class="dropdown-item" href="{{ .url }}{{ $path }}"{{- if .newTab }} target="_blank" rel="noopener"{{- end }}>{{ $versionName | safeHTML }}</a>
+
+    {{ $content_path := printf "content%s%s" .url $path }}
+    {{ $content_path = $content_path | replaceRE "/$" "" }}
+    {{ $check_file_md := printf "%s.md" $content_path }}
+    {{ $check_file_html := printf "%s.html" $content_path }}
+    {{ $check_index_md := printf "%s/_index.md" $content_path }}
+    {{ $check_index_html := printf "%s/_index.html" $content_path }}
+
+    {{ if or (fileExists $check_file_md) (fileExists $check_file_html) (fileExists $check_index_md) (fileExists $check_index_html) (in .url "https://") }}
+      <a class="dropdown-item" href="{{ .url }}{{ $path }}"{{- if .newTab }} target="_blank" rel="noopener"{{- end }}>{{ $versionName | safeHTML }}</a>
+    {{ else }}
+      <a class="dropdown-item" role="button" title="This is not available in {{ $versionName | safeHTML }}.">{{ $versionName | safeHTML }}</a>
+    {{ end }}
   {{ end }}
 </div>

--- a/docs/layouts/partials/navbar-version-selector.html
+++ b/docs/layouts/partials/navbar-version-selector.html
@@ -48,7 +48,7 @@
     {{ if or (fileExists $check_file_md) (fileExists $check_file_html) (fileExists $check_index_md) (fileExists $check_index_html) (in .url "https://") }}
       <a class="dropdown-item" href="{{ .url }}{{ $path }}"{{- if .newTab }} target="_blank" rel="noopener"{{- end }}>{{ $versionName | safeHTML }}</a>
     {{ else }}
-      <a class="dropdown-item" role="button" title="This is not available in {{ $versionName | safeHTML }}.">{{ $versionName | safeHTML }}</a>
+      <a class="dropdown-item" role="button">{{ $versionName | safeHTML }}</a>
     {{ end }}
   {{ end }}
 </div>


### PR DESCRIPTION
Remove the link for the prior versions and add a tool tip indicating that "this feature is not available in the respective version". By using this approach, we can prevent “page not found” issues for the upcoming features.
https://deploy-preview-21311--infallible-bardeen-164bc9.netlify.app/stable/yugabyte-platform/back-up-restore-universes/disaster-recovery/
