### PR TITLE
[Docs] Site-wide and Page-level settings to enable/disable list icons

### DIFF
--- a/docs/assets/scss/_styles_project.scss
+++ b/docs/assets/scss/_styles_project.scss
@@ -264,7 +264,14 @@ html {
         min-height: 40px;
         justify-content: center;
         align-items: flex-start;
-        padding-left: 40px;
+
+        &.list-icon-with-title {
+          padding-left: 40px;
+
+          .title {
+            margin-left: 16px;
+          }
+        }
 
         .icon {
           width: 40px;
@@ -299,7 +306,6 @@ html {
 
         .title {
           margin: 0;
-          margin-left: 16px;
           font-weight: 600;
           font-size: 16px;
           line-height: 24px;

--- a/docs/config/_default/params.toml
+++ b/docs/config/_default/params.toml
@@ -74,6 +74,8 @@ version_menu_pagelinks = true
   terms_of_service = "https://www.yugabyte.com/terms-of-service/"
   preview_version = "v2.19"
   preview_version_slug = "stable"
+  # To disable list icons for particular page, define `hideListIcons: true` on that page params.
+  list_icons = true
 
 # Header logo link
 [yb.navbar_logo]

--- a/docs/layouts/shortcodes/index/item.html
+++ b/docs/layouts/shortcodes/index/item.html
@@ -1,18 +1,20 @@
 {{- $icon := .Get "icon" -}}
 <div class="col-12 col-md-6 col-lg-12 col-xl-6">
     <a class="section-link icon-offset" href="{{.Get "href"}}">
-      <div class="head">
-        {{ if in $icon "/" }}
-        <img class="icon" src="{{ $icon }}" aria-hidden="true" />
-        {{ else }}
-        <div class="icon">
-            <i class="{{ $icon }}"></i>
-          </div>
-        {{ end }}
+      <div class="head{{- if and (.Site.Params.yb.list_icons) (not .Page.Params.hideListIcons) }} list-icon-with-title{{- end -}}">
+        {{- if and (.Site.Params.yb.list_icons) (not .Page.Params.hideListIcons) -}}
+          {{- if (in $icon "/") -}}
+            <img class="icon" src="{{ $icon }}" aria-hidden="true" />
+          {{- else -}}
+            <div class="icon">
+              <i class="{{ $icon }}"></i>
+            </div>
+          {{- end -}}
+        {{- end -}}
         <div class="title">{{.Get "title"}}</div>
       </div>
       <div class="body">
-        {{.Get "body"}}
+        {{- .Get "body" -}}
       </div>
     </a>
   </div>


### PR DESCRIPTION
### Site-wide settings:

To disable list icons for the site-wide, define `list_icons = false` in the `params.toml` file as shown [here](#).

### Page-level settings:

To disable list icons for any particular page, define `hideListIcons: true` on that page parameter.