### PR TITLE
[docs] CDCSDK: Update CDC documentation with missing sections

### DIFF
--- a/docs/content/preview/admin/yb-admin.md
+++ b/docs/content/preview/admin/yb-admin.md
@@ -1733,19 +1733,21 @@ To create a change data capture (CDC) DB stream which also supports sending the 
 ```sh
 yb-admin \
     -master_addresses <master-addresses> \
-    create_change_data_stream ysql.<namespace_name> IMPLICIT ALL
+    create_change_data_stream ysql.<namespace_name> EXPLICIT <before_image_mode>
 ```
 
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.
 * *namespace_name*: The namespace on which the DB stream ID is to be created.
-* `IMPLICIT`: Checkpointing type on the server.
-* `ALL`: Record type indicating to the server that the stream should send the before image too.
+* `EXPLICIT`: Checkpointing type on the server.
+* *before_image_mode*: Record type indicating the server that the stream should send the before image too.
 
 A successful operation of the above command returns a message with a DB stream ID:
 
 ```output
 CDC Stream ID: d540f5e4890c4d3b812933cbfd703ed3
 ```
+
+For a full list of supported before image modes, see [before image modes](../explore/change-data-capture/cdc-get-started#before-image-modes).
 
 ##### Creating stream in EXPLICIT checkpointing mode
 

--- a/docs/content/preview/admin/yb-admin.md
+++ b/docs/content/preview/admin/yb-admin.md
@@ -1739,7 +1739,7 @@ yb-admin \
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.
 * *namespace_name*: The namespace on which the DB stream ID is to be created.
 * `EXPLICIT`: Checkpointing type on the server.
-* *before_image_mode*: Record type indicating the server that the stream should send the before image too.
+* *before_image_mode*: Record type indicating the stream should include the before image.
 
 A successful operation of the above command returns a message with a DB stream ID:
 
@@ -1747,7 +1747,7 @@ A successful operation of the above command returns a message with a DB stream I
 CDC Stream ID: d540f5e4890c4d3b812933cbfd703ed3
 ```
 
-For a full list of supported before image modes, see [before image modes](../explore/change-data-capture/cdc-get-started#before-image-modes).
+For a full list of supported before image modes, see [before image modes](../../explore/change-data-capture/cdc-get-started#before-image-modes).
 
 ##### Creating stream in EXPLICIT checkpointing mode
 

--- a/docs/content/preview/admin/yb-admin.md
+++ b/docs/content/preview/admin/yb-admin.md
@@ -1747,8 +1747,6 @@ A successful operation of the above command returns a message with a DB stream I
 CDC Stream ID: d540f5e4890c4d3b812933cbfd703ed3
 ```
 
-For a full list of supported before image modes, see [before image modes](../../explore/change-data-capture/cdc-get-started#before-image-modes).
-
 ##### Creating stream in EXPLICIT checkpointing mode
 
 To create a change data capture (CDC) DB stream which works in the EXPLICIT checkpointing mode where the client is responsible for managing the checkpoints, use the following command:

--- a/docs/content/preview/explore/change-data-capture/cdc-get-started.md
+++ b/docs/content/preview/explore/change-data-capture/cdc-get-started.md
@@ -264,12 +264,6 @@ With before image enabled, the update and delete records look like the following
 
 </td> </tr> </table>
 
-### Before image modes
-
-YugabyteDB supports multiple before image modes which can be leveraged by creating a stream ID accordingly.
-
-// TODO Vaibhav: Add information on complete before image modes.
-
 ## Schema evolution
 
 Table schema is needed for decoding and processing the changes and populating CDC records. Thus, older schemas are retained if CDC streams are lagging. Also, older schemas that are not needed for any of the existing active CDC streams are garbage collected. In addition, if before image is enabled, the schema needed for populating before image is also retained. The YugabyteDB source connector caches schema at the tablet level. This means that for every tablet the connector has a copy of the current schema for the tablet it is polling the changes for. As soon as a DDL command is executed on the source table, the CDC service emits a record with the new schema for all the tablets. The YugabyteDB source connector then reads those records and modifies its cached schema gracefully.

--- a/docs/content/preview/explore/change-data-capture/cdc-get-started.md
+++ b/docs/content/preview/explore/change-data-capture/cdc-get-started.md
@@ -264,6 +264,10 @@ With before image enabled, the update and delete records look like the following
 
 </td> </tr> </table>
 
+### Before image modes
+
+YugabyteDB support multiple before image modes which can be leveraged by creating a stream ID accordingly.
+
 ## Schema evolution
 
 Table schema is needed for decoding and processing the changes and populating CDC records. Thus, older schemas are retained if CDC streams are lagging. Also, older schemas that are not needed for any of the existing active CDC streams are garbage collected. In addition, if before image is enabled, the schema needed for populating before image is also retained. The YugabyteDB source connector caches schema at the tablet level. This means that for every tablet the connector has a copy of the current schema for the tablet it is polling the changes for. As soon as a DDL command is executed on the source table, the CDC service emits a record with the new schema for all the tablets. The YugabyteDB source connector then reads those records and modifies its cached schema gracefully.
@@ -332,6 +336,18 @@ CDC record for UPDATE (using schema version 1):
     "op": "u"
 }
 ```
+
+## Colocated tables
+
+YugabyteDB supports streaming of changes from [colocated tables](../../architecture/docdb-sharding/colocated-tables). The connector can be configured with regular configuration properties and deployed for streaming.
+
+{{< note title="Note" >}}
+
+If a connector is already streaming a set of colocated tables from a database and if a new table is created in the same database, one cannot deploy a new connector for this newly created table.
+
+To stream the changes for the new table, delete the existing connector and deploy it again with the updated configuration property after adding the new table to `table.include.list`.
+
+{{< /note >}}
 
 ## Important configuration settings
 

--- a/docs/content/preview/explore/change-data-capture/cdc-get-started.md
+++ b/docs/content/preview/explore/change-data-capture/cdc-get-started.md
@@ -63,7 +63,7 @@ The YugabyteDB source connector also supports AVRO serialization with schema reg
 
   {{% tab header="JSON" lang="json" %}}
 
-For JSON schema serialization, you can use the [Kafka JSON Serializer](https://mvnrepository.com/artifact/io.confluent/kafka-json-serializer) and equivalent deserializer. After downloading and including the required `JAR` file in the Kafka-Connect environment, you can directly configure the CDC source and sink connectors to use this converter.
+For JSON schema serialization, you can use the [Kafka JSON Serializer](https://mvnrepository.com/artifact/io.confluent/kafka-json-serializer) and equivalent de-serializer. After downloading and including the required `JAR` file in the Kafka-Connect environment, you can directly configure the CDC source and sink connectors to use this converter.
 
 For source connectors:
 
@@ -182,14 +182,14 @@ The highlighted fields in the update event are:
 
 ### Before image modes
 
-YugabyteDB supports the following type of records types in the context of before image:
+YugabyteDB supports the following record types in the context of before image:
 
-* ALL
-* FULL_ROW_NEW_IMAGE
-* MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES
-* CHANGE
+- ALL
+- FULL_ROW_NEW_IMAGE
+- MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES
+- CHANGE
 
-Here is one more example, consider the following employee table into which a row is inserted, subsquently updated, and deleted:
+Consider the following employee table into which a row is inserted, subsequently updated, and deleted:
 
 ```sql
 create table employee (employee_id int primary key, employee_name varchar, employee_dept text);
@@ -201,7 +201,7 @@ update employee set employee_name='Bob' where employee_id=1001;
 delete from employee where employee_id=1001;
 ```
 
-CDC records for update and delete statements without enabling before image i.e. the default record type `CHANGE` would be as follows:
+CDC records for update and delete statements without enabling before image (that is, the default record type `CHANGE`) would be as follows:
 
 <table>
 <tr>
@@ -567,7 +567,7 @@ To configure a content-based router, you need to add the following lines to your
 
 The `<routing-expression>` contains the logic for routing of the events. For example, if you want to re-route the events based on the `country` column in user's table, you may use a expression similar to the following:
 
-```
+```regexp
 value.after != null ? (value.after?.country?.value == '\''UK'\'' ? '\''uk_users'\'' : null) : (value.before?.country?.value == '\''UK'\'' ? '\''uk_users'\'' : null)"
 ```
 

--- a/docs/content/preview/explore/change-data-capture/cdc-get-started.md
+++ b/docs/content/preview/explore/change-data-capture/cdc-get-started.md
@@ -268,6 +268,8 @@ With before image enabled, the update and delete records look like the following
 
 YugabyteDB support multiple before image modes which can be leveraged by creating a stream ID accordingly.
 
+// TODO Vaibhav: Add information on complete before image modes.
+
 ## Schema evolution
 
 Table schema is needed for decoding and processing the changes and populating CDC records. Thus, older schemas are retained if CDC streams are lagging. Also, older schemas that are not needed for any of the existing active CDC streams are garbage collected. In addition, if before image is enabled, the schema needed for populating before image is also retained. The YugabyteDB source connector caches schema at the tablet level. This means that for every tablet the connector has a copy of the current schema for the tablet it is polling the changes for. As soon as a DDL command is executed on the source table, the CDC service emits a record with the new schema for all the tablets. The YugabyteDB source connector then reads those records and modifies its cached schema gracefully.

--- a/docs/content/preview/explore/change-data-capture/cdc-get-started.md
+++ b/docs/content/preview/explore/change-data-capture/cdc-get-started.md
@@ -266,7 +266,7 @@ With before image enabled, the update and delete records look like the following
 
 ### Before image modes
 
-YugabyteDB support multiple before image modes which can be leveraged by creating a stream ID accordingly.
+YugabyteDB supports multiple before image modes which can be leveraged by creating a stream ID accordingly.
 
 // TODO Vaibhav: Add information on complete before image modes.
 
@@ -341,11 +341,11 @@ CDC record for UPDATE (using schema version 1):
 
 ## Colocated tables
 
-YugabyteDB supports streaming of changes from [colocated tables](../../architecture/docdb-sharding/colocated-tables). The connector can be configured with regular configuration properties and deployed for streaming.
+YugabyteDB supports streaming of changes from [colocated tables](../../../architecture/docdb-sharding/colocated-tables). The connector can be configured with regular configuration properties and deployed for streaming.
 
 {{< note title="Note" >}}
 
-If a connector is already streaming a set of colocated tables from a database and if a new table is created in the same database, one cannot deploy a new connector for this newly created table.
+If a connector is already streaming a set of colocated tables from a database and if a new table is created in the same database, you cannot deploy a new connector for this newly created table.
 
 To stream the changes for the new table, delete the existing connector and deploy it again with the updated configuration property after adding the new table to `table.include.list`.
 

--- a/docs/content/preview/explore/change-data-capture/debezium-connector-yugabytedb.md
+++ b/docs/content/preview/explore/change-data-capture/debezium-connector-yugabytedb.md
@@ -1208,14 +1208,14 @@ This can happen in the following 2 scenarios:
 
 When the connector is running, the YugabyteDB server that it is connected to could become unavailable for any number of reasons. If this happens, the connector fails with an error and stops. When the server is available again, restart the connector.
 
-The YugabyteDB connector externally stores the last processed offset in the form of a checkpoint. After a connector restarts and connects to a server instance, the connector communicates with the server to continue streaming from that particular offset. This offset is available as long as the stream ID remains intact. Never delete a stream ID without deleting all the associated connectors with it otherwise you will lose data.
+The YugabyteDB connector externally stores the last processed offset in the form of a checkpoint. After a connector restarts and connects to a server instance, the connector communicates with the server to continue streaming from that particular offset. This offset is available as long as the stream ID remains intact. Never delete a stream ID without deleting all the associated connectors with it, otherwise you will lose data.
 
 ## Dropping a table part of the replication
 
-While the connector is running with a set of tables configured to capture the changes, if one of the tables in the set is dropped, the connector will fail with an appropriate error message indicating that the object is not found.
+While the connector is running with a set of tables configured to capture the changes, if one of the tables in the set is dropped, the connector will fail with an error message indicating that the object is not found.
 
-To avoid a connector failure or to resolve the failure, the recommended way is to follow these steps:
-1. Delete the connector which contains the dropped or the table to be dropped.
+To avoid or resolve a failure due to a dropped table, follow these steps:
+1. Delete the connector that contains the table that was dropped, or that you want to drop.
 2. Edit the configuration and remove the given table from `table.include.list`.
 3. Deploy a new connector with the updated configuration.
 

--- a/docs/content/preview/explore/change-data-capture/debezium-connector-yugabytedb.md
+++ b/docs/content/preview/explore/change-data-capture/debezium-connector-yugabytedb.md
@@ -41,19 +41,21 @@ Debezium supports databases with UTF-8 character encoding only. With a single-by
 
 ## Connector compatibility
 
+The connector is compatible with the following versions of YugabyteDB.
+
 | YugabyteDB | Connector |
 | :--- | :--- |
 | 2.14 (EA) | 1.9.5.y.3 |
 | 2.16 | 1.9.5.y.24 |
 | 2.18.2 | 1.9.5.y.33.2 |
-| 2.20 | 1.9.5.y.220 |
+| 2.20 | 1.9.5.y.220.2 |
 
 {{< note title="Note" >}}
 
-Starting 2.20, the release naming convention has changed and we follow a scheme *major.y.minor* where
-* *major*: Release of Debezium the connector is based on
-* *minor*: YB version the connector would work with
-  * The connector would be backward compatible with the previous YugabyteDB releases unless stated otherwise.
+Starting with YugabyteDB v2.20, the naming convention for releases of the connector uses the scheme *major.y.minor*, as follows:
+- *major* - Debezium release the connector is based on
+- *minor* - version of YugabyteDB the connector works with
+The connector is backward compatible with previous releases of YugabyteDB unless stated otherwise.
 
 {{< /note >}}
 

--- a/docs/content/preview/reference/configuration/yb-master.md
+++ b/docs/content/preview/reference/configuration/yb-master.md
@@ -877,7 +877,7 @@ Toggle automatic tablet splitting for tables in a CDCSDK stream, enhancing user 
 
 ##### --enable_truncate_cdcsdk_table
 
-By default, TRUNCATE commands on tables on which CDCSDK stream is active will fail. Changing the value of this flag from `false` to `true` will enable truncating the tables part of the CDCSDK stream.
+By default, TRUNCATE commands on tables with an active CDCSDK stream will fail. Change this flag to `true` to enable truncating tables. 
 
 Default: `false`
 

--- a/docs/content/preview/reference/configuration/yb-master.md
+++ b/docs/content/preview/reference/configuration/yb-master.md
@@ -877,7 +877,7 @@ Toggle automatic tablet splitting for tables in a CDCSDK stream, enhancing user 
 
 ##### --enable_truncate_cdcsdk_table
 
-By default, TRUNCATE commands on tables with an active CDCSDK stream will fail. Change this flag to `true` to enable truncating tables. 
+By default, TRUNCATE commands on tables with an active CDCSDK stream will fail. Change this flag to `true` to enable truncating tables.
 
 Default: `false`
 

--- a/docs/content/preview/reference/configuration/yb-master.md
+++ b/docs/content/preview/reference/configuration/yb-master.md
@@ -875,6 +875,10 @@ Default: `14400` (4 hours)
 
 Toggle automatic tablet splitting for tables in a CDCSDK stream, enhancing user control over replication processes.
 
+##### --enable_truncate_cdcsdk_table
+
+By default, TRUNCATE commands on tables on which CDCSDK stream is active will fail. Changing the value of this flag from `false` to `true` will enable truncating the tables part of the CDCSDK stream.
+
 Default: `false`
 
 ## Metric export flags

--- a/docs/content/preview/reference/configuration/yb-tserver.md
+++ b/docs/content/preview/reference/configuration/yb-tserver.md
@@ -1276,12 +1276,6 @@ Stop retaining logs if the space available for the logs falls below this limit, 
 
 Default: `102400`
 
-##### --enable_truncate_cdcsdk_table
-
-By default, TRUNCATE commands on tables on which CDCSDK stream is active will fail. Changing the value of this flag from `false` to `true` will enable truncating the tables part of the CDCSDK stream.
-
-Default: `false`
-
 ##### --cdc_intent_retention_ms
 
 The time period, in milliseconds, after which the intents will be cleaned up if there is no client polling for the change records.

--- a/docs/content/stable/explore/change-data-capture/cdc-get-started.md
+++ b/docs/content/stable/explore/change-data-capture/cdc-get-started.md
@@ -339,7 +339,7 @@ YugabyteDB supports streaming of changes from [colocated tables](../../architect
 
 {{< note title="Note" >}}
 
-If a connector is already streaming a set of colocated tables from a database and if a new table is created in the same database, one cannot deploy a new connector for this newly created table.
+If a connector is already streaming a set of colocated tables from a database and if a new table is created in the same database, you can't deploy a new connector for the newly created table.
 
 To stream the changes for the new table, delete the existing connector and deploy it again with the updated configuration property after adding the new table to `table.include.list`.
 

--- a/docs/content/stable/explore/change-data-capture/cdc-get-started.md
+++ b/docs/content/stable/explore/change-data-capture/cdc-get-started.md
@@ -333,6 +333,18 @@ CDC record for UPDATE (using schema version 1):
 }
 ```
 
+## Colocated tables
+
+YugabyteDB supports streaming of changes from [colocated tables](../../architecture/docdb-sharding/colocated-tables). The connector can be configured with regular configuration properties and deployed for streaming.
+
+{{< note title="Note" >}}
+
+If a connector is already streaming a set of colocated tables from a database and if a new table is created in the same database, one cannot deploy a new connector for this newly created table.
+
+To stream the changes for the new table, delete the existing connector and deploy it again with the updated configuration property after adding the new table to `table.include.list`.
+
+{{< /note >}}
+
 ## Important configuration settings
 
 You can use several flags to fine-tune YugabyteDB's CDC behavior. These flags are documented in the [Change data capture flags](../../../reference/configuration/yb-tserver/#change-data-capture-cdc-flags) section of the YB-TServer reference and [Change data capture flags](../../../reference/configuration/yb-master/#change-data-capture-cdc-flags) section of the YB-Master reference. The following flags are particularly important for configuring CDC:

--- a/docs/content/stable/explore/change-data-capture/cdc-get-started.md
+++ b/docs/content/stable/explore/change-data-capture/cdc-get-started.md
@@ -182,14 +182,14 @@ The highlighted fields in the update event are:
 
 ### Before image modes
 
-YugabyteDB supports the following type of records types in the context of before image:
+YugabyteDB supports the following record types in the context of before image:
 
-* ALL
-* FULL_ROW_NEW_IMAGE
-* MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES
-* CHANGE
+- ALL
+- FULL_ROW_NEW_IMAGE
+- MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES
+- CHANGE
 
-Here is one more example, consider the following employee table into which a row is inserted, subsquently updated, and deleted:
+Consider the following employee table into which a row is inserted, subsequently updated, and deleted:
 
 ```sql
 create table employee (employee_id int primary key, employee_name varchar, employee_dept text);
@@ -201,7 +201,7 @@ update employee set employee_name='Bob' where employee_id=1001;
 delete from employee where employee_id=1001;
 ```
 
-CDC records for update and delete statements without enabling before image i.e. the default record type `CHANGE` would be as follows:
+CDC records for update and delete statements without enabling before image (that is, the default record type `CHANGE`) would be as follows:
 
 <table>
 <tr>
@@ -567,7 +567,7 @@ To configure a content-based router, you need to add the following lines to your
 
 The `<routing-expression>` contains the logic for routing of the events. For example, if you want to re-route the events based on the `country` column in user's table, you may use a expression similar to the following:
 
-```
+```regexp
 value.after != null ? (value.after?.country?.value == '\''UK'\'' ? '\''uk_users'\'' : null) : (value.before?.country?.value == '\''UK'\'' ? '\''uk_users'\'' : null)"
 ```
 

--- a/docs/content/stable/explore/change-data-capture/debezium-connector-yugabytedb.md
+++ b/docs/content/stable/explore/change-data-capture/debezium-connector-yugabytedb.md
@@ -45,6 +45,7 @@ The connector is compatible with the following versions of YugabyteDB.
 | 2.16 | 1.9.5.y.24 |
 | 2.18.2 | 1.9.5.y.33.2 |
 | 2.20 | 1.9.5.y.220.2 |
+| 2024.1 | 1.9.5.y.220.2 |
 
 {{< note title="Note" >}}
 

--- a/docs/content/stable/explore/change-data-capture/debezium-connector-yugabytedb.md
+++ b/docs/content/stable/explore/change-data-capture/debezium-connector-yugabytedb.md
@@ -37,19 +37,21 @@ Debezium supports databases with UTF-8 character encoding only. With a single-by
 
 ## Connector compatibility
 
+The connector is compatible with the following versions of YugabyteDB.
+
 | YugabyteDB | Connector |
 | :--- | :--- |
 | 2.14 (EA) | 1.9.5.y.3 |
 | 2.16 | 1.9.5.y.24 |
 | 2.18.2 | 1.9.5.y.33.2 |
-| 2.20 | 1.9.5.y.220 |
+| 2.20 | 1.9.5.y.220.2 |
 
 {{< note title="Note" >}}
 
-Starting 2.20, the release naming convention has changed and we follow a scheme *major.y.minor* where
-* *major*: Release of Debezium the connector is based on
-* *minor*: YB version the connector would work with
-  * The connector would be backward compatible with the previous YugabyteDB releases unless stated otherwise.
+Starting with YugabyteDB v2.20, the naming convention for releases of the connector uses the scheme *major.y.minor*, as follows:
+- *major* - Debezium release the connector is based on
+- *minor* - version of YugabyteDB the connector works with
+The connector is backward compatible with previous releases of YugabyteDB unless stated otherwise.
 
 {{< /note >}}
 

--- a/docs/content/stable/explore/change-data-capture/debezium-connector-yugabytedb.md
+++ b/docs/content/stable/explore/change-data-capture/debezium-connector-yugabytedb.md
@@ -35,6 +35,24 @@ Debezium supports databases with UTF-8 character encoding only. With a single-by
 
 {{< /tip >}}
 
+## Connector compatibility
+
+| YugabyteDB | Connector |
+| :--- | :--- |
+| 2.14 (EA) | 1.9.5.y.3 |
+| 2.16 | 1.9.5.y.24 |
+| 2.18.2 | 1.9.5.y.33.2 |
+| 2.20 | 1.9.5.y.220 |
+
+{{< note title="Note" >}}
+
+Starting 2.20, the release naming convention has changed and we follow a scheme *major.y.minor* where
+* *major*: Release of Debezium the connector is based on
+* *minor*: YB version the connector would work with
+  * The connector would be backward compatible with the previous YugabyteDB releases unless stated otherwise.
+
+{{< /note >}}
+
 ## How the connector works
 
 To optimally configure and run a Debezium YugabyteDB connector, it is helpful to understand how the connector performs snapshots, streams change events, determines Kafka topic names, and uses metadata.
@@ -1186,7 +1204,16 @@ This can happen in the following 2 scenarios:
 
 When the connector is running, the YugabyteDB server that it is connected to could become unavailable for any number of reasons. If this happens, the connector fails with an error and stops. When the server is available again, restart the connector.
 
-The YugabyteDB connector externally stores the last processed offset in the form of a checkpoint. After a connector restarts and connects to a server instance, the connector communicates with the server to continue streaming from that particular offset. This offset is available as long as the Debezium replication slot remains intact. Never drop a replication slot on the primary server or you will lose data.
+The YugabyteDB connector externally stores the last processed offset in the form of a checkpoint. After a connector restarts and connects to a server instance, the connector communicates with the server to continue streaming from that particular offset. This offset is available as long as the stream ID remains intact. Never delete a stream ID without deleting all the associated connectors with it otherwise you will lose data.
+
+## Dropping a table part of the replication
+
+While the connector is running with a set of tables configured to capture the changes, if one of the tables in the set is dropped, the connector will fail with an appropriate error message indicating that the object is not found.
+
+To avoid a connector failure or to resolve the failure, the recommended way is to follow these steps:
+1. Delete the connector which contains the dropped or the table to be dropped.
+2. Edit the configuration and remove the given table from `table.include.list`.
+3. Deploy a new connector with the updated configuration.
 
 ### Kafka Connect process stops gracefully
 

--- a/docs/content/stable/reference/configuration/yb-master.md
+++ b/docs/content/stable/reference/configuration/yb-master.md
@@ -877,7 +877,7 @@ Toggle automatic tablet splitting for tables in a CDCSDK stream, enhancing user 
 
 ##### --enable_truncate_cdcsdk_table
 
-By default, TRUNCATE commands on tables on which CDCSDK stream is active will fail. Changing the value of this flag from `false` to `true` will enable truncating the tables part of the CDCSDK stream.
+By default, TRUNCATE commands on tables with an active CDCSDK stream will fail. Change this flag to `true` to enable truncating tables.
 
 Default: `false`
 

--- a/docs/content/stable/reference/configuration/yb-master.md
+++ b/docs/content/stable/reference/configuration/yb-master.md
@@ -875,6 +875,10 @@ Default: `14400` (4 hours)
 
 Toggle automatic tablet splitting for tables in a CDCSDK stream, enhancing user control over replication processes.
 
+##### --enable_truncate_cdcsdk_table
+
+By default, TRUNCATE commands on tables on which CDCSDK stream is active will fail. Changing the value of this flag from `false` to `true` will enable truncating the tables part of the CDCSDK stream.
+
 Default: `false`
 
 ## Metric export flags

--- a/docs/content/stable/reference/configuration/yb-tserver.md
+++ b/docs/content/stable/reference/configuration/yb-tserver.md
@@ -1276,12 +1276,6 @@ Stop retaining logs if the space available for the logs falls below this limit, 
 
 Default: `102400`
 
-##### --enable_truncate_cdcsdk_table
-
-By default, TRUNCATE commands on tables on which CDCSDK stream is active will fail. Changing the value of this flag from `false` to `true` will enable truncating the tables part of the CDCSDK stream.
-
-Default: `false`
-
 ##### --cdc_intent_retention_ms
 
 The time period, in milliseconds, after which the intents will be cleaned up if there is no client polling for the change records.

--- a/docs/content/v2.16/explore/change-data-capture/debezium-connector-yugabytedb.md
+++ b/docs/content/v2.16/explore/change-data-capture/debezium-connector-yugabytedb.md
@@ -1305,7 +1305,16 @@ In these cases, the error message has details about the problem and possibly a s
 
 When the connector is running, the YugabyteDB server that it is connected to could become unavailable for any number of reasons. If this happens, the connector fails with an error and stops. When the server is available again, restart the connector.
 
-The YugabyteDB connector externally stores the last processed offset in the form of a checkpoint. After a connector restarts and connects to a server instance, the connector communicates with the server to continue streaming from that particular offset. This offset is available as long as the Debezium replication slot remains intact. Never drop a replication slot on the primary server or you will lose data.
+The YugabyteDB connector externally stores the last processed offset in the form of a checkpoint. After a connector restarts and connects to a server instance, the connector communicates with the server to continue streaming from that particular offset. This offset is available as long as the stream ID remains intact. Never delete a stream ID without deleting all the associated connectors with it otherwise you will lose data.
+
+## Dropping a table part of the replication
+
+While the connector is running with a set of tables configured to capture the changes, if one of the tables in the set is dropped, the connector will fail with an appropriate error message indicating that the object is not found.
+
+To avoid a connector failure or to resolve the failure, the recommended way is to follow these steps:
+1. Delete the connector which contains the dropped or the table to be dropped.
+2. Edit the configuration and remove the given table from `table.include.list`.
+3. Deploy a new connector with the updated configuration.
 
 ### Kafka Connect process stops gracefully
 

--- a/docs/content/v2.16/reference/configuration/yb-master.md
+++ b/docs/content/v2.16/reference/configuration/yb-master.md
@@ -712,6 +712,12 @@ WAL retention time, in seconds, to be used for tables for which a CDC stream was
 
 Default: `14400` (4 hours)
 
+##### --enable_truncate_cdcsdk_table
+
+By default, TRUNCATE commands on tables on which CDCSDK stream is active will fail. Changing the value of this flag from `false` to `true` will enable truncating the tables part of the CDCSDK stream.
+
+Default: `false`
+
 ## Admin UI
 
 The Admin UI for YB-Master is available at <http://localhost:7000>.

--- a/docs/content/v2.16/reference/configuration/yb-tserver.md
+++ b/docs/content/v2.16/reference/configuration/yb-tserver.md
@@ -986,12 +986,6 @@ Stop retaining logs if the space available for the logs falls below this limit, 
 
 Default: `102400`
 
-##### --enable_truncate_cdcsdk_table
-
-By default, TRUNCATE commands on tables on which CDCSDK stream is active will fail. Changing the value of this flag from `false` to `true` will enable truncating the tables part of the CDCSDK stream.
-
-Default: `false`
-
 ##### --cdc_intent_retention_ms
 
 The time period, in milliseconds, after which the intents will be cleaned up if there is no client polling for the change records.

--- a/docs/content/v2.18/explore/change-data-capture/cdc-get-started.md
+++ b/docs/content/v2.18/explore/change-data-capture/cdc-get-started.md
@@ -333,6 +333,18 @@ CDC record for UPDATE (using schema version 1):
 }
 ```
 
+## Colocated tables
+
+YugabyteDB supports streaming of changes from [colocated tables](../../architecture/docdb-sharding/colocated-tables). The connector can be configured with regular configuration properties and deployed for streaming.
+
+{{< note title="Note" >}}
+
+If a connector is already streaming a set of colocated tables from a database and if a new table is created in the same database, one cannot deploy a new connector for this newly created table.
+
+To stream the changes for the new table, delete the existing connector and deploy it again with the updated configuration property after adding the new table to `table.include.list`.
+
+{{< /note >}}
+
 ## Important configuration settings
 
 You can use several flags to fine-tune YugabyteDB's CDC behavior. These flags are documented in the [Change data capture flags](../../../reference/configuration/yb-tserver/#change-data-capture-cdc-flags) section of the YB-TServer reference and [Change data capture flags](../../../reference/configuration/yb-master/#change-data-capture-cdc-flags) section of the YB-Master reference. The following flags are particularly important for configuring CDC:

--- a/docs/content/v2.18/explore/change-data-capture/cdc-get-started.md
+++ b/docs/content/v2.18/explore/change-data-capture/cdc-get-started.md
@@ -180,7 +180,7 @@ The highlighted fields in the update event are:
 | 3 | source | Mandatory field that describes the source metadata for the event. This has the same fields as a create event, but some values are different. The source metadata includes: <ul><li> Debezium version <li> Connector type and name <li> Database and table that contains the new row <li> Schema name <li> If the event was part of a snapshot (always `false` for update events) <li> ID of the transaction in which the operation was performed <li> Offset of the operation in the database log <li> Timestamp for when the change was made in the database </ul> |
 | 4 | op | In an update event, this field's value is `u`, signifying that this row changed because of an update. |
 
-Here is one more example, consider the following employee table into which a row is inserted, subsquently updated, and deleted:
+Consider the following employee table into which a row is inserted, subsequently updated, and deleted:
 
 ```sql
 create table employee(employee_id int primary key, employee_name varchar);
@@ -401,7 +401,7 @@ To configure a content-based router, you need to add the following lines to your
 
 The `<routing-expression>` contains the logic for routing of the events. For example, if you want to re-route the events based on the `country` column in user's table, you may use a expression similar to the following:
 
-```
+```regexp
 value.after != null ? (value.after?.country?.value == '\''UK'\'' ? '\''uk_users'\'' : null) : (value.before?.country?.value == '\''UK'\'' ? '\''uk_users'\'' : null)"
 ```
 

--- a/docs/content/v2.18/explore/change-data-capture/debezium-connector-yugabytedb.md
+++ b/docs/content/v2.18/explore/change-data-capture/debezium-connector-yugabytedb.md
@@ -35,6 +35,14 @@ Debezium supports databases with UTF-8 character encoding only. With a single-by
 
 {{< /tip >}}
 
+## Connector compatibility
+
+| YugabyteDB | Connector |
+| :--- | :--- |
+| 2.14 (EA) | 1.9.5.y.3 |
+| 2.16 | 1.9.5.y.24 |
+| 2.18.2 | 1.9.5.y.33.2 |
+
 ## How the connector works
 
 To optimally configure and run a Debezium YugabyteDB connector, it is helpful to understand how the connector performs snapshots, streams change events, determines Kafka topic names, and uses metadata.
@@ -1186,7 +1194,16 @@ This can happen in the following 2 scenarios:
 
 When the connector is running, the YugabyteDB server that it is connected to could become unavailable for any number of reasons. If this happens, the connector fails with an error and stops. When the server is available again, restart the connector.
 
-The YugabyteDB connector externally stores the last processed offset in the form of a checkpoint. After a connector restarts and connects to a server instance, the connector communicates with the server to continue streaming from that particular offset. This offset is available as long as the Debezium replication slot remains intact. Never drop a replication slot on the primary server or you will lose data.
+The YugabyteDB connector externally stores the last processed offset in the form of a checkpoint. After a connector restarts and connects to a server instance, the connector communicates with the server to continue streaming from that particular offset. This offset is available as long as the stream ID remains intact. Never delete a stream ID without deleting all the associated connectors with it otherwise you will lose data.
+
+## Dropping a table part of the replication
+
+While the connector is running with a set of tables configured to capture the changes, if one of the tables in the set is dropped, the connector will fail with an appropriate error message indicating that the object is not found.
+
+To avoid a connector failure or to resolve the failure, the recommended way is to follow these steps:
+1. Delete the connector which contains the dropped or the table to be dropped.
+2. Edit the configuration and remove the given table from `table.include.list`.
+3. Deploy a new connector with the updated configuration.
 
 ### Kafka Connect process stops gracefully
 

--- a/docs/content/v2.18/reference/configuration/yb-master.md
+++ b/docs/content/v2.18/reference/configuration/yb-master.md
@@ -734,6 +734,12 @@ WAL retention time, in seconds, to be used for tables for which a CDC stream was
 
 Default: `14400` (4 hours)
 
+##### --enable_truncate_cdcsdk_table
+
+By default, TRUNCATE commands on tables on which CDCSDK stream is active will fail. Changing the value of this flag from `false` to `true` will enable truncating the tables part of the CDCSDK stream.
+
+Default: `false`
+
 ## Metric export flags
 
 ##### --export_help_and_type_in_prometheus_metrics

--- a/docs/content/v2.18/reference/configuration/yb-master.md
+++ b/docs/content/v2.18/reference/configuration/yb-master.md
@@ -736,7 +736,7 @@ Default: `14400` (4 hours)
 
 ##### --enable_truncate_cdcsdk_table
 
-By default, TRUNCATE commands on tables on which CDCSDK stream is active will fail. Changing the value of this flag from `false` to `true` will enable truncating the tables part of the CDCSDK stream.
+By default, TRUNCATE commands on tables with an active CDCSDK stream will fail. Change this flag to `true` to enable truncating tables.
 
 Default: `false`
 

--- a/docs/content/v2.18/reference/configuration/yb-tserver.md
+++ b/docs/content/v2.18/reference/configuration/yb-tserver.md
@@ -1052,12 +1052,6 @@ Stop retaining logs if the space available for the logs falls below this limit, 
 
 Default: `102400`
 
-##### --enable_truncate_cdcsdk_table
-
-By default, TRUNCATE commands on tables on which CDCSDK stream is active will fail. Changing the value of this flag from `false` to `true` will enable truncating the tables part of the CDCSDK stream.
-
-Default: `false`
-
 ##### --cdc_intent_retention_ms
 
 The time period, in milliseconds, after which the intents will be cleaned up if there is no client polling for the change records.

--- a/docs/content/v2.20/explore/change-data-capture/cdc-get-started.md
+++ b/docs/content/v2.20/explore/change-data-capture/cdc-get-started.md
@@ -182,14 +182,14 @@ The highlighted fields in the update event are:
 
 ### Before image modes
 
-YugabyteDB supports the following type of records types in the context of before image:
+YugabyteDB supports the following record types in the context of before image:
 
-* ALL
-* FULL_ROW_NEW_IMAGE
-* MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES
-* CHANGE
+- ALL
+- FULL_ROW_NEW_IMAGE
+- MODIFIED_COLUMNS_OLD_AND_NEW_IMAGES
+- CHANGE
 
-Here is one more example, consider the following employee table into which a row is inserted, subsquently updated, and deleted:
+Consider the following employee table into which a row is inserted, subsequently updated, and deleted:
 
 ```sql
 create table employee (employee_id int primary key, employee_name varchar, employee_dept text);
@@ -201,7 +201,7 @@ update employee set employee_name='Bob' where employee_id=1001;
 delete from employee where employee_id=1001;
 ```
 
-CDC records for update and delete statements without enabling before image i.e. the default record type `CHANGE` would be as follows:
+CDC records for update and delete statements without enabling before image (that is, the default record type `CHANGE`) would be as follows:
 
 <table>
 <tr>
@@ -555,7 +555,7 @@ To configure a content-based router, you need to add the following lines to your
 
 The `<routing-expression>` contains the logic for routing of the events. For example, if you want to re-route the events based on the `country` column in user's table, you may use a expression similar to the following:
 
-```
+```regexp
 value.after != null ? (value.after?.country?.value == '\''UK'\'' ? '\''uk_users'\'' : null) : (value.before?.country?.value == '\''UK'\'' ? '\''uk_users'\'' : null)"
 ```
 

--- a/docs/content/v2.20/explore/change-data-capture/debezium-connector-yugabytedb.md
+++ b/docs/content/v2.20/explore/change-data-capture/debezium-connector-yugabytedb.md
@@ -35,6 +35,26 @@ Debezium supports databases with UTF-8 character encoding only. With a single-by
 
 {{< /tip >}}
 
+## Connector compatibility
+
+The connector is compatible with the following versions of YugabyteDB.
+
+| YugabyteDB | Connector |
+| :--- | :--- |
+| 2.14 (EA) | 1.9.5.y.3 |
+| 2.16 | 1.9.5.y.24 |
+| 2.18.2 | 1.9.5.y.33.2 |
+| 2.20 | 1.9.5.y.220.2 |
+
+{{< note title="Note" >}}
+
+Starting with YugabyteDB v2.20, the naming convention for releases of the connector uses the scheme *major.y.minor*, as follows:
+- *major* - Debezium release the connector is based on
+- *minor* - version of YugabyteDB the connector works with
+The connector is backward compatible with previous releases of YugabyteDB unless stated otherwise.
+
+{{< /note >}}
+
 ## How the connector works
 
 To optimally configure and run a Debezium YugabyteDB connector, it is helpful to understand how the connector performs snapshots, streams change events, determines Kafka topic names, and uses metadata.

--- a/docs/content/v2.20/reference/configuration/yb-master.md
+++ b/docs/content/v2.20/reference/configuration/yb-master.md
@@ -748,6 +748,12 @@ WAL retention time, in seconds, to be used for tables for which a CDC stream was
 
 Default: `14400` (4 hours)
 
+##### --enable_truncate_cdcsdk_table
+
+By default, TRUNCATE commands on tables on which CDCSDK stream is active will fail. Changing the value of this flag from `false` to `true` will enable truncating the tables part of the CDCSDK stream.
+
+Default: `false`
+
 ## Metric export flags
 
 ##### --export_help_and_type_in_prometheus_metrics

--- a/docs/content/v2.20/reference/configuration/yb-tserver.md
+++ b/docs/content/v2.20/reference/configuration/yb-tserver.md
@@ -1170,12 +1170,6 @@ Stop retaining logs if the space available for the logs falls below this limit, 
 
 Default: `102400`
 
-##### --enable_truncate_cdcsdk_table
-
-By default, TRUNCATE commands on tables on which CDCSDK stream is active will fail. Changing the value of this flag from `false` to `true` will enable truncating the tables part of the CDCSDK stream.
-
-Default: `false`
-
 ##### --cdc_intent_retention_ms
 
 The time period, in milliseconds, after which the intents will be cleaned up if there is no client polling for the change records.


### PR DESCRIPTION
This PR adds the following sections missing from the CDC documentation:
1. Connector compatibility matrix - this lists the version of connector which will be compatible with a given YugabyteDB version.
2. Instructions on troubleshooting failures in case of a table being dropped; this is also valid if a table needs to be dropped.
3. Multiple before image modes supported by YugabyteDB.

DOC-296