### PR TITLE
[Docs] Repeated tabs with the same look

### DIFF
--- a/docs/assets/scss/_yb_tabs.scss
+++ b/docs/assets/scss/_yb_tabs.scss
@@ -185,7 +185,7 @@ ul.nav.nav-tabs-yb:not(.yb-pills) {
   }
 }
 
-ul.nav.nav-tabs-yb:not(.yb-pills) ~ .nav-tabs-yb:not(.yb-pills) {
+ul.nav.nav-tabs-yb:not(.yb-pills) ~ .nav-tabs-yb:not(.yb-pills):not(.repeated-tabs) {
   li {
     font-size: 13px;
     line-height: 16px;

--- a/docs/layouts/shortcodes/nav/tabs.html
+++ b/docs/layouts/shortcodes/nav/tabs.html
@@ -1,10 +1,11 @@
 {{- $tabs := default "local,cloud,anywhere" (.Get "list") -}}
 {{- $active := default "local" (.Get "active") -}}
+{{- $repeatedTabs := default false (.Get "repeatedTabs") -}}
 {{ $suffix := "" }}
 {{ $name := "" }}
 {{ $numpanels := .Page.Scratch.Get "numpanels" }}
 {{ if $numpanels }}{{ $suffix = printf "-%d" $numpanels }}{{ end }}
-<ul class="nav nav-tabs-alt nav-tabs-yb custom-tabs">
+<ul class="nav nav-tabs-alt nav-tabs-yb custom-tabs{{- if $repeatedTabs }} repeated-tabs{{ end }}">
     {{if strings.Contains $tabs "local"}}
     {{$name = printf "%s%s" "local" $suffix}}
     <li>


### PR DESCRIPTION
Allow multiple tabs to show as same size, not the different size as shown here:
https://docs.yugabyte.com/preview/explore/fault-tolerance/handling-region-failures/#third-region-failure

Add `repeatedTabs="true"` parameter on the `nav/tabs` shortcode where you like to have the tabs to be same size.

Current shortcode example:
```
{{<nav/tabs list="local,anywhere" active="local"/>}}
```

Shortcode with repeated tabs example:

```
{{<nav/tabs list="local,anywhere" active="local" repeatedTabs="true" />}}
```