### PR TITLE
Update doc for the clearing of meta-cache

### DIFF
--- a/docs/content/preview/admin/yb-ts-cli.md
+++ b/docs/content/preview/admin/yb-ts-cli.md
@@ -86,6 +86,7 @@ Clears all metacaches that are stored on a specified server. Works on both YB-Ma
 
 Metacache is a YBClient cache on a Tablet/Master server which is used to find out which tablet server hosts which tablet. Because this cache can be stale in some cases, you can use this command to clear the metacache on a particular YB-TServer or YB-Master.
 
+
 **Syntax**
 ```sh
 yb-ts-cli [ --server_address=<host>:<port> ] clear_server_metacache

--- a/docs/content/preview/admin/yb-ts-cli.md
+++ b/docs/content/preview/admin/yb-ts-cli.md
@@ -273,7 +273,7 @@ yb-ts-cli [ --server_address=<host>:<port> ] refresh_flags
 
 * *host*:*port*: The *host* and *port* of the YB-Master or YB-TServer. Default is `localhost:9100`.
 
-##### Clear the current metacache on a tablet server or master server
+##### clear_server_metacache
 **Syntax**
 ```sh
 yb-ts-cli [ --server_address=<host>:<port> ] clear_server_metacache

--- a/docs/content/preview/admin/yb-ts-cli.md
+++ b/docs/content/preview/admin/yb-ts-cli.md
@@ -82,7 +82,7 @@ yb-ts-cli [ --server_address=<host>:<port> ] is_server_ready
 
 ##### clear_server_metacache
 
-Clears all metacaches that are stored on a specified server. Works on both YB-Master (port 9100) and YB-TServer (port 7100) processes. Metacache is a YBClient cache on a Tablet/Master server which is used to find out which tablet server hosts which tablet. Because this cache can be stale in some cases, you can use this command to clear the metacache on a particular YB-TServer or YB-Master.
+Clears all metacaches that are stored on a specified server. Works on both YB-Master (port 9100) and YB-TServer (port 7100) processes. Tablet servers and masters use MetaCaches to cache information about which tablet server hosts which tablet. Because these caches could become stale in some cases, you may want to use this command to clear the MetaCaches on a particular tablet server or master.
 
 **Syntax**
 ```sh

--- a/docs/content/preview/admin/yb-ts-cli.md
+++ b/docs/content/preview/admin/yb-ts-cli.md
@@ -82,7 +82,7 @@ yb-ts-cli [ --server_address=<host>:<port> ] is_server_ready
 
 ##### clear_server_metacache
 
-Clear all metacaches that are stored on a specified server. Works on both YB-Master (port 9100) and YB-TServer (port 7100) process. No parameters needed.
+Clear all metacaches that are stored on a specified server. Works on both YB-Master (port 9100) and YB-TServer (port 7100) processes.
 
 Metacache is a YBClient cache on a Tablet/Master server to find out which Tablet Server hosts which tablet. This cache can be stale in some cases, this 
 

--- a/docs/content/preview/admin/yb-ts-cli.md
+++ b/docs/content/preview/admin/yb-ts-cli.md
@@ -39,6 +39,7 @@ The following commands are available:
 
 * [are_tablets_running](#are-tablets-running)
 * [is_server_ready](#is-server-ready)
+* [clear_server_metacache](#clear-server-metacache0
 * [compact_all_tablets](#compact-all-tablets)
 * [compact_tablet](#compact-tablet)
 * [count_intents](#count-intents)
@@ -75,6 +76,21 @@ If all tablets have bootstrapped, returns "Tablet server is ready".
 
 ```sh
 yb-ts-cli [ --server_address=<host>:<port> ] is_server_ready
+```
+
+* *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
+
+##### clear_server_metacache
+
+Clear all metacaches that are stored on a specified server. Works on both YB-Master (port 9100) and YB-TServer (port 7100) process. No parameters needed.
+
+Metacache is a YBClient cache on a Tablet/Master server to find out which Tablet Server hosts which tablet. This cache can be stale in some cases, this 
+
+command is introduced for users to clear the metacache on a particular YB-TServer or YB-Master.
+
+**Syntax**
+```sh
+yb-ts-cli [ --server_address=<host>:<port> ] clear_server_metacache
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
@@ -272,21 +288,6 @@ yb-ts-cli [ --server_address=<host>:<port> ] refresh_flags
 ```
 
 * *host*:*port*: The *host* and *port* of the YB-Master or YB-TServer. Default is `localhost:9100`.
-
-##### clear_server_metacache
-
-Clear all metacaches that are stored on a specified server. Works on both YB-Master (port 9100) and YB-TServer (port 7100) process. No parameters needed.
-
-Metacache is a YBClient cache on a Tablet/Master server to find out which Tablet Server hosts which tablet. This cache can be stale in some cases, this 
-
-command is introduced for users to clear the metacache on a particular YB-TServer or YB-Master.
-
-**Syntax**
-```sh
-yb-ts-cli [ --server_address=<host>:<port> ] clear_server_metacache
-```
-
-* *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
 
 ## Flags
 

--- a/docs/content/preview/admin/yb-ts-cli.md
+++ b/docs/content/preview/admin/yb-ts-cli.md
@@ -273,6 +273,14 @@ yb-ts-cli [ --server_address=<host>:<port> ] refresh_flags
 
 * *host*:*port*: The *host* and *port* of the YB-Master or YB-TServer. Default is `localhost:9100`.
 
+##### Clear the current metacache on a tablet server or master server
+**Syntax**
+```sh
+yb-ts-cli [ --server_address=<host>:<port> ] clear_server_metacache
+```
+
+* *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
+
 ## Flags
 
 The following flags can be used, when specified, with the commands above.

--- a/docs/content/preview/admin/yb-ts-cli.md
+++ b/docs/content/preview/admin/yb-ts-cli.md
@@ -39,7 +39,7 @@ The following commands are available:
 
 * [are_tablets_running](#are-tablets-running)
 * [is_server_ready](#is-server-ready)
-* [clear_server_metacache](#clear-server-metacache]
+* [clear_server_metacache](#clear-server-metacache)
 * [compact_all_tablets](#compact-all-tablets)
 * [compact_tablet](#compact-tablet)
 * [count_intents](#count-intents)
@@ -85,7 +85,6 @@ yb-ts-cli [ --server_address=<host>:<port> ] is_server_ready
 Clears all metacaches that are stored on a specified server. Works on both YB-Master (port 9100) and YB-TServer (port 7100) processes.
 
 Metacache is a YBClient cache on a Tablet/Master server which is used to find out which tablet server hosts which tablet. Because this cache can be stale in some cases, you can use this command to clear the metacache on a particular YB-TServer or YB-Master.
-
 
 **Syntax**
 ```sh

--- a/docs/content/preview/admin/yb-ts-cli.md
+++ b/docs/content/preview/admin/yb-ts-cli.md
@@ -274,6 +274,13 @@ yb-ts-cli [ --server_address=<host>:<port> ] refresh_flags
 * *host*:*port*: The *host* and *port* of the YB-Master or YB-TServer. Default is `localhost:9100`.
 
 ##### clear_server_metacache
+
+Clear all metacaches that are stored on a specified server. Works on both YB-Master (port 9100) and YB-TServer (port 7100) process. No parameters needed.
+
+Metacache is a YBClient cache on a Tablet/Master server to find out which Tablet Server hosts which tablet. This cache can be stale in some cases, this 
+
+command is introduced for users to clear the metacache on a particular YB-TServer or YB-Master.
+
 **Syntax**
 ```sh
 yb-ts-cli [ --server_address=<host>:<port> ] clear_server_metacache

--- a/docs/content/preview/admin/yb-ts-cli.md
+++ b/docs/content/preview/admin/yb-ts-cli.md
@@ -39,7 +39,7 @@ The following commands are available:
 
 * [are_tablets_running](#are-tablets-running)
 * [is_server_ready](#is-server-ready)
-* [clear_server_metacache](#clear-server-metacache0
+* [clear_server_metacache](#clear-server-metacache]
 * [compact_all_tablets](#compact-all-tablets)
 * [compact_tablet](#compact-tablet)
 * [count_intents](#count-intents)
@@ -82,18 +82,16 @@ yb-ts-cli [ --server_address=<host>:<port> ] is_server_ready
 
 ##### clear_server_metacache
 
-Clear all metacaches that are stored on a specified server. Works on both YB-Master (port 9100) and YB-TServer (port 7100) processes.
+Clears all metacaches that are stored on a specified server. Works on both YB-Master (port 9100) and YB-TServer (port 7100) processes.
 
-Metacache is a YBClient cache on a Tablet/Master server to find out which Tablet Server hosts which tablet. This cache can be stale in some cases, this 
-
-command is introduced for users to clear the metacache on a particular YB-TServer or YB-Master.
+Metacache is a YBClient cache on a Tablet/Master server which is used to find out which Tablet Server hosts which tablet. Because this cache can be stale in some cases, this command is introduced for users to clear the metacache on a particular YB-TServer or YB-Master.
 
 **Syntax**
 ```sh
 yb-ts-cli [ --server_address=<host>:<port> ] clear_server_metacache
 ```
 
-* *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
+* *host*:*port*: The *host* and *port* of the tablet/master server. Default is `localhost:9100`.
 
 ##### compact_all_tablets
 

--- a/docs/content/preview/admin/yb-ts-cli.md
+++ b/docs/content/preview/admin/yb-ts-cli.md
@@ -84,7 +84,7 @@ yb-ts-cli [ --server_address=<host>:<port> ] is_server_ready
 
 Clears all metacaches that are stored on a specified server. Works on both YB-Master (port 9100) and YB-TServer (port 7100) processes.
 
-Metacache is a YBClient cache on a Tablet/Master server which is used to find out which Tablet Server hosts which tablet. Because this cache can be stale in some cases, this command is introduced for users to clear the metacache on a particular YB-TServer or YB-Master.
+Metacache is a YBClient cache on a Tablet/Master server which is used to find out which tablet server hosts which tablet. Because this cache can be stale in some cases, you can use this command to clear the metacache on a particular YB-TServer or YB-Master.
 
 **Syntax**
 ```sh

--- a/docs/content/preview/admin/yb-ts-cli.md
+++ b/docs/content/preview/admin/yb-ts-cli.md
@@ -82,9 +82,7 @@ yb-ts-cli [ --server_address=<host>:<port> ] is_server_ready
 
 ##### clear_server_metacache
 
-Clears all metacaches that are stored on a specified server. Works on both YB-Master (port 9100) and YB-TServer (port 7100) processes.
-
-Metacache is a YBClient cache on a Tablet/Master server which is used to find out which tablet server hosts which tablet. Because this cache can be stale in some cases, you can use this command to clear the metacache on a particular YB-TServer or YB-Master.
+Clears all metacaches that are stored on a specified server. Works on both YB-Master (port 9100) and YB-TServer (port 7100) processes. Metacache is a YBClient cache on a Tablet/Master server which is used to find out which tablet server hosts which tablet. Because this cache can be stale in some cases, you can use this command to clear the metacache on a particular YB-TServer or YB-Master.
 
 **Syntax**
 ```sh


### PR DESCRIPTION
This commit introduces a new command called clear_server_metacache which helps the user to delete all the meta-cache stored on a tablet server.