### PR TITLE
[Docs] Arrows on the left nav

### DIFF
--- a/docs/assets/scss/_dropdown_list.scss
+++ b/docs/assets/scss/_dropdown_list.scss
@@ -75,6 +75,7 @@
       content: "\f107";
       color: #97a5b0;
       font-family: $font-awesome-font-name;
+      font-weight: 700;
       border: 0;
     }
   }

--- a/docs/assets/scss/_sidebar-tree.scss
+++ b/docs/assets/scss/_sidebar-tree.scss
@@ -74,6 +74,7 @@
         color: #6d7c88;
         height: 10px;
         font-family: $font-awesome-font-name;
+        font-weight: 700;
         transition: margin-right 0.2s linear;
         font-size: 11px;
         line-height: 10px;
@@ -207,6 +208,7 @@
             &::before {
               content: "\f0da";
               font-family: $font-awesome-font-name;
+              font-weight: 700;
               color: #97a5b0;
             }
           }


### PR DESCRIPTION
Fix arrows on the left nav. They are supposed to be filled but after updating to Font Awesome Pro some are filled now and some outlined.
<img width="1321" alt="Screenshot 2024-03-27 at 10 52 30 AM" src="https://github.com/yugabyte/yugabyte-db/assets/16156106/f0a2430f-53da-4163-855e-b3430690c718">

@netlify /preview/explore/