### PR TITLE
[doc] Fix unix timestamp units for PITR page

### DIFF
--- a/docs/content/preview/manage/backup-restore/point-in-time-recovery.md
+++ b/docs/content/preview/manage/backup-restore/point-in-time-recovery.md
@@ -151,7 +151,7 @@ If a database or a keyspace has an associated snapshot schedule, you can use tha
 
   - Restore to an absolute time, providing a specific timestamp in one of the following formats:
 
-    - [Unix timestamp](https://www.unixtimestamp.com) in seconds, milliseconds, or microseconds.
+    - [Unix timestamp](https://www.unixtimestamp.com) in microseconds.
     - [YSQL timestamp](../../../api/ysql/datatypes/type_datetime/).
     - [YCQL timestamp](../../../api/ycql/type_datetime/#timestamp).
 

--- a/docs/content/preview/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises-manual.md
+++ b/docs/content/preview/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises-manual.md
@@ -48,6 +48,10 @@ For each node, perform the following:
 
 After you have provisioned the nodes, you can proceed to [Add instances to the on-prem provider](../on-premises-nodes/#add-instances).
 
+{{<note title="Root-level systemd or cron">}}
+The following instructions use user-level systemd to provide the necessary access to system resources. Versions prior to v2.20 use root-level systemd or cron. If you have previously provisioned nodes for this provider using either root-level systemd or cron, you should use the same steps, as all nodes in a provider need to be provisioned in the same way. For instructions on provisioning using root-level systemd or cron, see the [instructions for v2.18](/v2.18/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises-manual/).
+{{</note>}}
+
 ## Set up time synchronization
 
 A local Network Time Protocol (NTP) server or equivalent must be available.
@@ -154,15 +158,6 @@ Physical nodes (or cloud instances) are installed with a standard AlmaLinux 8 se
     ```text
     *          soft    nproc     12000
     ```
-
-1. Install the rsync and OpenSSL packages (if not already included with your Linux distribution) using the following commands:
-
-    ```sh
-    sudo dnf install openssl
-    sudo dnf install rsync
-    ```
-
-    For airgapped environments, make sure your DNF repository mirror contains these packages.
 
 1. If running on a virtual machine, execute the following to tune kernel settings:
 

--- a/docs/content/stable/manage/backup-restore/point-in-time-recovery.md
+++ b/docs/content/stable/manage/backup-restore/point-in-time-recovery.md
@@ -148,7 +148,7 @@ If a database or a keyspace has an associated snapshot schedule, you can use tha
 
   - Restore to an absolute time, providing a specific timestamp in one of the following formats:
 
-    - [Unix timestamp](https://www.unixtimestamp.com) in seconds, milliseconds, or microseconds.
+    - [Unix timestamp](https://www.unixtimestamp.com) in microseconds.
     - [YSQL timestamp](../../../api/ysql/datatypes/type_datetime/).
     - [YCQL timestamp](../../../api/ycql/type_datetime/#timestamp).
 

--- a/docs/content/stable/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises-manual.md
+++ b/docs/content/stable/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises-manual.md
@@ -48,6 +48,10 @@ For each node, perform the following:
 
 After you have provisioned the nodes, you can proceed to [Add instances to the on-prem provider](../on-premises-nodes/#add-instances).
 
+{{<note title="Root-level systemd or cron">}}
+The following instructions use user-level systemd to provide the necessary access to system resources. Versions prior to v2.20 use root-level systemd or cron. If you have previously provisioned nodes for this provider using either root-level systemd or cron, you should use the same steps, as all nodes in a provider need to be provisioned in the same way. For instructions on provisioning using root-level systemd or cron, see the [instructions for v2.18](/v2.18/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises-manual/).
+{{</note>}}
+
 ## Set up time synchronization
 
 A local Network Time Protocol (NTP) server or equivalent must be available.
@@ -154,15 +158,6 @@ Physical nodes (or cloud instances) are installed with a standard AlmaLinux 8 se
     ```text
     *          soft    nproc     12000
     ```
-
-1. Install the rsync and OpenSSL packages (if not already included with your Linux distribution) using the following commands:
-
-    ```sh
-    sudo dnf install openssl
-    sudo dnf install rsync
-    ```
-
-    For airgapped environments, make sure your DNF repository mirror contains these packages.
 
 1. If running on a virtual machine, execute the following to tune kernel settings:
 

--- a/docs/content/v2.14/manage/backup-restore/point-in-time-recovery.md
+++ b/docs/content/v2.14/manage/backup-restore/point-in-time-recovery.md
@@ -140,7 +140,7 @@ If a database or a keyspace has an associated snapshot schedule, you can use tha
 
   * Restore to an absolute time, providing a specific timestamp in one of the following formats:
 
-    * [Unix timestamp](https://www.unixtimestamp.com) in seconds, milliseconds, or microseconds.
+    * [Unix timestamp](https://www.unixtimestamp.com) in microseconds.
     * [YSQL timestamp](../../../api/ysql/datatypes/type_datetime/).
     * [YCQL timestamp](../../../api/ycql/type_datetime/#timestamp).
 

--- a/docs/content/v2.14/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises.md
+++ b/docs/content/v2.14/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises.md
@@ -197,6 +197,10 @@ For each node, perform the following:
 - [Set crontab permissions](#set-crontab-permissions)
 - [Install systemd-related database service unit files (optional)](#install-systemd-related-database-service-unit-files)
 
+{{<note title="Root-level systemd or cron">}}
+You can configure nodes to use either cron or root-level systemd to provide the necessary access to system resources. All nodes in a provider need to be provisioned in the same way. If you use cron or root-level systemd on one node, be sure to provision all nodes in the provider using cron or root-level systemd, respectively.
+{{</note>}}
+
 ##### Set up time synchronization
 
 A local Network Time Protocol (NTP) server or equivalent must be available.

--- a/docs/content/v2.16/manage/backup-restore/point-in-time-recovery.md
+++ b/docs/content/v2.16/manage/backup-restore/point-in-time-recovery.md
@@ -140,7 +140,7 @@ If a database or a keyspace has an associated snapshot schedule, you can use tha
 
   * Restore to an absolute time, providing a specific timestamp in one of the following formats:
 
-    * [Unix timestamp](https://www.unixtimestamp.com) in seconds, milliseconds, or microseconds.
+    * [Unix timestamp](https://www.unixtimestamp.com) in microseconds.
     * [YSQL timestamp](../../../api/ysql/datatypes/type_datetime/).
     * [YCQL timestamp](../../../api/ycql/type_datetime/#timestamp).
 

--- a/docs/content/v2.16/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises.md
+++ b/docs/content/v2.16/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises.md
@@ -207,6 +207,10 @@ For each node, perform the following:
   - [Delete database server nodes](#delete-database-server-nodes)
   - [Delete YugabyteDB Anywhere from the server](#delete-yugabytedb-anywhere-from-the-server)
 
+{{<note title="Root-level systemd or cron">}}
+You can configure nodes to use either cron or root-level systemd to provide the necessary access to system resources. All nodes in a provider need to be provisioned in the same way. If you use cron or root-level systemd on one node, be sure to provision all nodes in the provider using cron or root-level systemd, respectively.
+{{</note>}}
+
 ##### Set up time synchronization
 
 A local Network Time Protocol (NTP) server or equivalent must be available.

--- a/docs/content/v2.18/manage/backup-restore/point-in-time-recovery.md
+++ b/docs/content/v2.18/manage/backup-restore/point-in-time-recovery.md
@@ -132,7 +132,7 @@ If a database or a keyspace has an associated snapshot schedule, you can use tha
 
   * Restore to an absolute time, providing a specific timestamp in one of the following formats:
 
-    * [Unix timestamp](https://www.unixtimestamp.com) in seconds, milliseconds, or microseconds.
+    * [Unix timestamp](https://www.unixtimestamp.com) in microseconds.
     * [YSQL timestamp](../../../api/ysql/datatypes/type_datetime/).
     * [YCQL timestamp](../../../api/ycql/type_datetime/#timestamp).
 

--- a/docs/content/v2.18/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises-manual.md
+++ b/docs/content/v2.18/yugabyte-platform/configure-yugabyte-platform/set-up-cloud-provider/on-premises-manual.md
@@ -50,6 +50,10 @@ For each node, perform the following:
 
 After you have provisioned the nodes, you can proceed to [add instances to the on-prem provider](../on-premises/#add-instances).
 
+{{<note title="Root-level systemd or cron">}}
+You can configure nodes to use either cron or root-level systemd to provide the necessary access to system resources. All nodes in a provider need to be provisioned in the same way. If you use cron or root-level systemd on one node, be sure to provision all nodes in the provider using cron or root-level systemd, respectively.
+{{</note>}}
+
 ## Set up time synchronization
 
 A local Network Time Protocol (NTP) server or equivalent must be available.


### PR DESCRIPTION
Fix unix timestamp units for PITR page

@netlify /preview/manage/backup-restore/point-in-time-recovery/#restore-to-a-point-in-time