### PR TITLE
Updated the interpretation of log_stop_retaining_min_disk_mb

### DIFF
--- a/docs/content/preview/reference/configuration/yb-tserver.md
+++ b/docs/content/preview/reference/configuration/yb-tserver.md
@@ -1167,7 +1167,7 @@ Default: `86400`
 
 Stop retaining logs if the space available for the logs falls below this limit, specified in megabytes. As with `log_max_seconds_to_retain`, this flag is ignored if a log segment contains unflushed entries.
 
-Default: `102400`
+Default: `100`
 
 ##### --enable_truncate_cdcsdk_table
 

--- a/docs/content/stable/reference/configuration/yb-tserver.md
+++ b/docs/content/stable/reference/configuration/yb-tserver.md
@@ -1168,7 +1168,7 @@ Default: `86400`
 
 Stop retaining logs if the space available for the logs falls below this limit, specified in megabytes. As with `log_max_seconds_to_retain`, this flag is ignored if a log segment contains unflushed entries.
 
-Default: `102400`
+Default: `100`
 
 ##### --enable_truncate_cdcsdk_table
 

--- a/docs/content/v2.14/reference/configuration/yb-tserver.md
+++ b/docs/content/v2.14/reference/configuration/yb-tserver.md
@@ -998,7 +998,7 @@ Default: `86400`
 
 Stop retaining logs if the space available for the logs falls below this limit, specified in megabytes. As with `log_max_seconds_to_retain`, this flag is ignored if a log segment contains unflushed entries.
 
-Default: `102400`
+Default: `100`
 
 ##### --stream_truncate_record
 

--- a/docs/content/v2.16/reference/configuration/yb-tserver.md
+++ b/docs/content/v2.16/reference/configuration/yb-tserver.md
@@ -984,7 +984,7 @@ Default: `86400`
 
 Stop retaining logs if the space available for the logs falls below this limit, specified in megabytes. As with `log_max_seconds_to_retain`, this flag is ignored if a log segment contains unflushed entries.
 
-Default: `102400`
+Default: `100`
 
 ##### --enable_truncate_cdcsdk_table
 

--- a/docs/content/v2.18/reference/configuration/yb-tserver.md
+++ b/docs/content/v2.18/reference/configuration/yb-tserver.md
@@ -1050,7 +1050,7 @@ Default: `86400`
 
 Stop retaining logs if the space available for the logs falls below this limit, specified in megabytes. As with `log_max_seconds_to_retain`, this flag is ignored if a log segment contains unflushed entries.
 
-Default: `102400`
+Default: `100`
 
 ##### --enable_truncate_cdcsdk_table
 

--- a/src/yb/consensus/log_reader.cc
+++ b/src/yb/consensus/log_reader.cc
@@ -62,7 +62,7 @@ DEFINE_UNKNOWN_int32(log_max_seconds_to_retain, 24 * 3600, "Log files that are o
              "ignored. This flag is ignored if a log segment contains entries that haven't been"
              "flushed to RocksDB.");
 
-DEFINE_UNKNOWN_int64(log_stop_retaining_min_disk_mb, 100 * 1024, "Stop retaining logs if the space "
+DEFINE_UNKNOWN_int64(log_stop_retaining_min_disk_mb, 100, "Stop retaining logs if the space "
              "available for the logs falls below this limit. This flag is ignored if a log segment "
              "contains unflushed entries.");
 
@@ -275,7 +275,7 @@ bool LogReader::ViolatesMinSpacePolicy(const scoped_refptr<ReadableLogSegment>& 
   } else {
     uint64_t free_space = *free_space_result;
     if (free_space + *potential_reclaimed_space <
-            implicit_cast<size_t>(FLAGS_log_stop_retaining_min_disk_mb) * 1024) {
+            implicit_cast<size_t>(FLAGS_log_stop_retaining_min_disk_mb) * 1024 * 1024) {
       YB_LOG_EVERY_N_SECS(WARNING, 300)
           << "Segment " << segment->path() << " violates minimum free space policy "
           << "specified by log_stop_retaining_min_disk_mb: "


### PR DESCRIPTION
### Description
The gflag log_stop_retaining_min_disk_mb was internally interpreted as kilobytes (kb) instead of megabytes (mb), leading to a unit mismatch. This inconsistency could result in unexpected behavior when users attempted to modify the value of this flag.

### Changes
Updated the interpretation of log_stop_retaining_min_disk_mb to use megabytes internally to align with its specified unit.

Fixes: #21849, #19391