### PR TITLE
Add aliases for external links

### DIFF
--- a/docs/content/preview/architecture/_index.md
+++ b/docs/content/preview/architecture/_index.md
@@ -5,6 +5,8 @@ linkTitle: Architecture
 description: Learn about the YugabyteDB architecture, including query, transactions, sharding, replication, and storage layers.
 image: fa-sharp fa-thin fa-puzzle
 headcontent: Internals of query, transactions, sharding, replication, and storage layers
+aliases:
+  - /architecture/layerered-architecture/
 menu:
   preview:
     identifier: architecture

--- a/docs/content/preview/architecture/query-layer/_index.md
+++ b/docs/content/preview/architecture/query-layer/_index.md
@@ -5,7 +5,7 @@ linkTitle: YQL - Query layer
 description: Understand how a query is processed
 image: fa-sharp fa-thin fa-language
 aliases:
-  - /architecture/query-layer/overview
+  - /architecture/query-layer/overview/
 menu:
   preview:
     identifier: architecture-query-layer

--- a/docs/content/preview/architecture/query-layer/_index.md
+++ b/docs/content/preview/architecture/query-layer/_index.md
@@ -5,7 +5,7 @@ linkTitle: YQL - Query layer
 description: Understand how a query is processed
 image: fa-sharp fa-thin fa-language
 aliases:
-  - /architecture/query-layer/
+  - /architecture/query-layer/overview
 menu:
   preview:
     identifier: architecture-query-layer

--- a/docs/content/preview/explore/observability/pg-stat-activity.md
+++ b/docs/content/preview/explore/observability/pg-stat-activity.md
@@ -3,7 +3,7 @@ title: View live queries with pg_stat_activity
 linkTitle: Live queries
 description: Using pg_stat_activity to troubleshoot issues and help to identify long running transactions.
 aliases:
-  - - /explore/query-1-performance/pg-stat-activity/
+  - /preview/explore/query-1-performance/pg-stat-activity/
 headerTitle: View live queries with pg_stat_activity
 menu:
   preview:

--- a/docs/content/preview/explore/observability/pg-stat-progress-copy.md
+++ b/docs/content/preview/explore/observability/pg-stat-progress-copy.md
@@ -4,7 +4,7 @@ linkTitle: Data transfer status
 description: Use pg_stat_progress_copy to get the COPY command status, number of tuples processed, and other COPY progress reports.
 headerTitle: View COPY status with pg_stat_progress_copy
 aliases:
-  - /explore/query-1-performance/pg-stat-progress-copy/
+  - /preview/explore/query-1-performance/pg-stat-progress-copy/
 menu:
   preview:
     identifier: pg-stat-progress-copy

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -759,11 +759,6 @@
   from = "/preview/develop/build-apps/*"
   to = "/preview/tutorials/build-apps/:splat"
 
-# from 404 report (referrer: youtube)
-[[redirects]]
-  from = "/preview/tutorials/build-and-learn/*"
-  to = "/preview/tutorials/build-apps/:splat"
-
 [[redirects]]
   from = "/preview/quick-start/build-apps/*"
   to = "/preview/tutorials/build-apps/"

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -113,8 +113,8 @@
   to = "/preview/drivers-orms/"
 
 [[redirects]]
-  from = "/explore/fault-tolerance/"
-  to = "/preview/explore/fault-tolerance/"
+  from = "/explore/*"
+  to = "/preview/explore/:splat"
 
 [[redirects]]
   from = "/preview/explore/indexes-constraints/covering-index-ycql/"
@@ -340,6 +340,11 @@
   from = "/preview/architecture/concepts"
   to = "/preview/architecture/key-concepts"
 
+# from 404 report (referrer: ycombinator)
+[[redirects]]
+  from = "/preview/architecture/concepts/acknowledgements"
+  to = "/preview/architecture/key-concepts"
+
 [[redirects]]
   from = "/preview/architecture/docdb/replication/"
   to = "/preview/architecture/docdb-replication/"
@@ -557,6 +562,10 @@
   to = "/preview/releases/ybdb-releases/:splat"
 
 [[redirects]]
+  from = "/preview/releases/ybdb-release/*"
+  to = "/preview/releases/ybdb-releases/:splat"
+
+[[redirects]]
   from = "/preview/secure/authentication/client-authentication/"
   to = "/preview/secure/enable-authentication/ysql_hba_conf-configuration/"
 
@@ -748,6 +757,11 @@
 
 [[redirects]]
   from = "/preview/develop/build-apps/*"
+  to = "/preview/tutorials/build-apps/:splat"
+
+# from 404 report (referrer: youtube)
+[[redirects]]
+  from = "/preview/tutorials/build-and-learn/*"
   to = "/preview/tutorials/build-apps/:splat"
 
 [[redirects]]


### PR DESCRIPTION
- We noticed 404s for certain architecture pages that were recently reorganized.