### PR TITLE
Enhancing copy throughput by retrieving datums with checkpointing available in TupleTableSlot

### DIFF
--- a/src/postgres/src/backend/bootstrap/bootstrap.c
+++ b/src/postgres/src/backend/bootstrap/bootstrap.c
@@ -823,9 +823,13 @@ InsertOneTuple(Oid objectid)
 	tuple = heap_form_tuple(tupDesc, values, Nulls);
 	if (objectid != (Oid) 0)
 		HeapTupleSetOid(tuple, objectid);
-
 	if (IsYugaByteEnabled())
-		YBCExecuteInsert(boot_reldesc, tupDesc, tuple, ONCONFLICT_NONE);
+	{
+		TupleTableSlot *slot = MakeSingleTupleTableSlot(tupDesc);
+		ExecStoreHeapTuple(tuple, slot, false);
+		YBCExecuteInsert(boot_reldesc, slot, ONCONFLICT_NONE);
+		ExecDropSingleTupleTableSlot(slot);
+	}
 	else
 		simple_heap_insert(boot_reldesc, tuple);
 

--- a/src/postgres/src/backend/catalog/indexing.c
+++ b/src/postgres/src/backend/catalog/indexing.c
@@ -288,7 +288,8 @@ YBCatalogTupleInsert(Relation heapRel, HeapTuple tup, bool yb_shared_insert)
 	{
 		/* Keep ybctid consistent across all databases. */
 		Datum ybctid = 0;
-
+		TupleTableSlot *slot = MakeSingleTupleTableSlot(RelationGetDescr(heapRel));
+		ExecStoreHeapTuple(tup, slot, false);
 		if (yb_shared_insert)
 		{
 			if (!IsYsqlUpgrade)
@@ -304,16 +305,17 @@ YBCatalogTupleInsert(Relation heapRel, HeapTuple tup, bool yb_shared_insert)
 				if (dboid == YBCGetDatabaseOid(heapRel))
 					continue; /* Will be done after the loop. */
 				YBCExecuteInsertForDb(
-						dboid, heapRel, RelationGetDescr(heapRel), tup, ONCONFLICT_NONE, &ybctid,
+						dboid, heapRel, slot, ONCONFLICT_NONE, &ybctid,
 						YB_TRANSACTIONAL);
 			}
 			YB_FOR_EACH_DB_END;
 		}
 		oid = YBCExecuteInsertForDb(
-				YBCGetDatabaseOid(heapRel), heapRel, RelationGetDescr(heapRel), tup, ONCONFLICT_NONE,
+				YBCGetDatabaseOid(heapRel), heapRel, slot, ONCONFLICT_NONE,
 				&ybctid, YB_TRANSACTIONAL);
 		/* Update the local cache automatically */
 		YbSetSysCacheTuple(heapRel, tup);
+		ExecDropSingleTupleTableSlot(slot);
 	}
 	else
 	{
@@ -351,7 +353,8 @@ CatalogTupleInsertWithInfo(Relation heapRel, HeapTuple tup,
 	{
 		/* Keep ybctid consistent across all databases. */
 		Datum ybctid = 0;
-
+		TupleTableSlot *slot = MakeSingleTupleTableSlot(RelationGetDescr(heapRel));
+		ExecStoreHeapTuple(tup, slot, false);
 		if (yb_shared_insert)
 		{
 			if (!IsYsqlUpgrade)
@@ -367,16 +370,17 @@ CatalogTupleInsertWithInfo(Relation heapRel, HeapTuple tup,
 				if (dboid == YBCGetDatabaseOid(heapRel))
 					continue; /* Will be done after the loop. */
 				YBCExecuteInsertForDb(
-						dboid, heapRel, RelationGetDescr(heapRel), tup, ONCONFLICT_NONE, &ybctid,
+						dboid, heapRel, slot, ONCONFLICT_NONE, &ybctid,
 						YB_TRANSACTIONAL);
 			}
 			YB_FOR_EACH_DB_END;
 		}
 		oid = YBCExecuteInsertForDb(
-				YBCGetDatabaseOid(heapRel), heapRel, RelationGetDescr(heapRel), tup, ONCONFLICT_NONE,
+				YBCGetDatabaseOid(heapRel), heapRel, slot, ONCONFLICT_NONE,
 				&ybctid, YB_TRANSACTIONAL);
 		/* Update the local cache automatically */
 		YbSetSysCacheTuple(heapRel, tup);
+		ExecDropSingleTupleTableSlot(slot);
 	}
 	else
 	{

--- a/src/postgres/src/backend/commands/copy.c
+++ b/src/postgres/src/backend/commands/copy.c
@@ -3082,15 +3082,13 @@ CopyFrom(CopyState cstate)
 							if (useNonTxnInsert)
 							{
 								YBCExecuteNonTxnInsert(resultRelInfo->ri_RelationDesc,
-													   tupDesc,
-													   tuple,
+													   slot,
 													   cstate->on_conflict_action);
 							}
 							else
 							{
 								YBCExecuteInsert(resultRelInfo->ri_RelationDesc,
-												 tupDesc,
-												 tuple,
+												 slot,
 												 cstate->on_conflict_action);
 							}
 						}

--- a/src/postgres/src/backend/commands/createas.c
+++ b/src/postgres/src/backend/commands/createas.c
@@ -627,8 +627,7 @@ intorel_receive(TupleTableSlot *slot, DestReceiver *self)
 	if (IsYBRelation(myState->rel))
 	{
 		YBCExecuteInsert(myState->rel,
-						 RelationGetDescr(myState->rel),
-						 tuple,
+						 slot,
 						 ONCONFLICT_NONE);
 	}
 	else

--- a/src/postgres/src/backend/commands/matview.c
+++ b/src/postgres/src/backend/commands/matview.c
@@ -486,8 +486,7 @@ transientrel_receive(TupleTableSlot *slot, DestReceiver *self)
 	if (IsYBRelation(myState->transientrel))
 	{
 		YBCExecuteInsert(myState->transientrel,
-						 RelationGetDescr(myState->transientrel),
-						 tuple,
+						 slot,
 						 ONCONFLICT_NONE);
 	}
 	else

--- a/src/postgres/src/backend/commands/tablecmds.c
+++ b/src/postgres/src/backend/commands/tablecmds.c
@@ -5419,8 +5419,7 @@ ATRewriteTable(AlteredTableInfo *tab, Oid OIDNewHeap, LOCKMODE lockmode)
 			{
 				if (IsYBRelation(newrel))
 					YBCExecuteInsert(newrel,
-									 RelationGetDescr(newrel),
-									 tuple,
+					                 newslot,
 									 ONCONFLICT_NONE);
 				else
 					heap_insert(newrel, tuple, mycid, hi_options, bistate);
@@ -18211,8 +18210,7 @@ YbATCopyTableRowsUnchecked(Relation old_rel, Relation new_rel,
 		ExecStoreHeapTuple(tuple, newslot, false);
 
 		/* Write the tuple out to the new relation */
-		YBCExecuteInsert(new_rel, newslot->tts_tupleDescriptor, tuple,
-						 ONCONFLICT_NONE);
+		YBCExecuteInsert(new_rel, newslot, ONCONFLICT_NONE);
 
 		MemoryContextReset(econtext->ecxt_per_tuple_memory);
 

--- a/src/postgres/src/backend/executor/nodeModifyTable.c
+++ b/src/postgres/src/backend/executor/nodeModifyTable.c
@@ -560,7 +560,7 @@ ExecInsert(ModifyTableState *mtstate,
 				 * locked and released in this call.
 				 * TODO(Mikhail) Verify the YugaByte transaction support works properly for on-conflict.
 				 */
-				newId = YBCHeapInsert(slot, tuple, blockInsertStmt, estate);
+				newId = YBCHeapInsert(slot, blockInsertStmt, estate);
 
 				/* insert index entries for tuple */
 				recheckIndexes = ExecInsertIndexTuples(slot, tuple,
@@ -629,7 +629,7 @@ ExecInsert(ModifyTableState *mtstate,
 			if (IsYBRelation(resultRelationDesc))
 			{
 				MemoryContext oldContext = MemoryContextSwitchTo(GetPerTupleMemoryContext(estate));
-				newId = YBCHeapInsert(slot, tuple, blockInsertStmt, estate);
+				newId = YBCHeapInsert(slot, blockInsertStmt, estate);
 
 				/* insert index entries for tuple */
 				if (YBCRelInfoHasSecondaryIndices(resultRelInfo))
@@ -1573,7 +1573,8 @@ ExecUpdate(ModifyTableState *mtstate,
 		ModifyTable *plan = (ModifyTable *) mtstate->ps.plan;
 		if (is_pk_updated)
 		{
-			YBCExecuteUpdateReplace(resultRelationDesc, planSlot, tuple, estate);
+			slot->tts_tuple->t_ybctid = YBCGetYBTupleIdFromSlot(planSlot);
+			YBCExecuteUpdateReplace(resultRelationDesc, slot, estate);
 			row_found = true;
 		}
 		else

--- a/src/postgres/src/include/executor/ybcModifyTable.h
+++ b/src/postgres/src/include/executor/ybcModifyTable.h
@@ -60,7 +60,6 @@ typedef void (*yb_bind_for_write_function) (YBCPgStatement stmt,
  * to the generated value.
  */
 extern Oid YBCHeapInsert(TupleTableSlot *slot,
-                         HeapTuple tuple,
                          YBCPgStatement blockInsertStmt,
                          EState *estate);
 
@@ -73,13 +72,11 @@ extern Oid YBCHeapInsert(TupleTableSlot *slot,
  * to the generated value.
  */
 extern Oid YBCExecuteInsert(Relation rel,
-                            TupleDesc tupleDesc,
-                            HeapTuple tuple,
+							TupleTableSlot *slot,
                             OnConflictAction onConflictAction);
 extern Oid YBCExecuteInsertForDb(Oid dboid,
                                  Relation rel,
-                                 TupleDesc tupleDesc,
-                                 HeapTuple tuple,
+								 TupleTableSlot *slot,
                                  OnConflictAction onConflictAction,
                                  Datum *ybctid,
                                  YBCPgTransactionSetting transaction_setting);
@@ -95,13 +92,11 @@ extern void YBCApplyWriteStmt(YBCPgStatement handle, Relation relation);
  * to the generated value.
  */
 extern Oid YBCExecuteNonTxnInsert(Relation rel,
-                                  TupleDesc tupleDesc,
-                                  HeapTuple tuple,
+								  TupleTableSlot *slot,
                                   OnConflictAction onConflictAction);
 extern Oid YBCExecuteNonTxnInsertForDb(Oid dboid,
                                        Relation rel,
-                                       TupleDesc tupleDesc,
-                                       HeapTuple tuple,
+									   TupleTableSlot *slot,
                                        OnConflictAction onConflictAction,
                                        Datum *ybctid);
 
@@ -188,7 +183,6 @@ extern bool YBCExecuteUpdateLoginAttempts(Oid roleid,
  */
 extern Oid YBCExecuteUpdateReplace(Relation rel,
 								   TupleTableSlot *slot,
-								   HeapTuple tuple,
 								   EState *estate);
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
In the sample table we have almost all char columns and few varchar columns for both of these data types attlen in pg_attribute table is -1.  Since we have varlen attributes in nocachegetattr function it is going to this part of the code [(nocachecode,](https://github.com/naanagon/yugabyte-db/blob/master/src/postgres/src/backend/access/common/heaptuple.c#L607) [ybcModifyTable](https://github.com/yugabyte/yugabyte-db/blob/master/src/postgres/src/backend/executor/ybcModifyTable.c#L326)) . In this way the time complexity is O(n*n) where n is number of attributes.

there is an another for loop in ([nocachecode](https://github.com/naanagon/yugabyte-db/blob/master/src/postgres/src/backend/access/common/heaptuple.c#L607)) as it is doing the same work every time, whey can't we build a prefix sum array once for the row and just use that for all the attributes.