### PR TITLE
[docs] Fix ubuntu coredb contributor instructions

### DIFF
--- a/docs/content/preview/contribute/core-database/build-from-src-macos.md
+++ b/docs/content/preview/contribute/core-database/build-from-src-macos.md
@@ -72,6 +72,10 @@ YugabyteDB build scripts require at least Bash version 4. Make sure that `bash -
 
 {{< /note >}}
 
+### /opt/yb-build
+
+{{% readfile "includes/opt-yb-build.md" %}}
+
 ### Java
 
 {{% readfile "includes/java.md" %}}

--- a/docs/content/preview/contribute/core-database/build-from-src-ubuntu.md
+++ b/docs/content/preview/contribute/core-database/build-from-src-ubuntu.md
@@ -50,7 +50,7 @@ AlmaLinux 8 is the recommended Linux development platform for YugabyteDB.
 
 {{< /note >}}
 
-The following instructions are for Ubuntu 20.04, 22.04, and 23.04.
+The following instructions are for Ubuntu 20.04 and 22.04.
 
 ## Install necessary packages
 
@@ -113,12 +113,10 @@ sudo apt install -y maven
 {{% readfile "includes/yugabyted-ui.md" %}}
 
 ```sh
-sudo apt install -y npm golang-1.18
+sudo apt install -y npm golang-1.20
 # Also add the following line to your .bashrc or equivalent.
-export PATH="/usr/lib/go-1.18/bin:$PATH"
+export PATH="/usr/lib/go-1.20/bin:$PATH"
 ```
-
-For Ubuntu 23.04, install `golang-1.20` instead since 1.18 is not available.
 
 ### Ninja (optional)
 
@@ -149,15 +147,6 @@ sudo apt install -y gcc-13 g++-13
 ## Build the code
 
 {{% readfile "includes/build-the-code.md" %}}
-
-{{< note title="Note" >}}
-
-For Ubuntu 23.04, in order to use [downloaded third-party](#opt-yb-build), there are some additional restrictions:
-
-- build type: `debug`, `fastdebug`, or `release`
-- compiler: `--clang17` or `--gcc13`
-
-{{< /note >}}
 
 ### Build release package (optional)
 

--- a/docs/content/preview/contribute/core-database/includes/build-the-code.md
+++ b/docs/content/preview/contribute/core-database/includes/build-the-code.md
@@ -27,7 +27,7 @@ If you get an error message such as
 > ValueError: Found no third-party release archives to download for OS type ubuntu20.04, compiler type matching gcc11, architecture x86_64, is_linuxbrew=False. See more details above.
 
 it means that there is no [third-party download](#opt-yb-build) available for that build configuration.
-Check the list output above that message for supported configurations.
+Check the output above that message for supported configurations.
 
 {{< /note >}}
 

--- a/docs/content/preview/contribute/core-database/includes/build-the-code.md
+++ b/docs/content/preview/contribute/core-database/includes/build-the-code.md
@@ -20,6 +20,17 @@ Try again by running the build script with less concurrency, for example, `-j1`.
 
 {{< /note >}}
 
+{{< note title="Note" >}}
+
+If you get an error message such as
+
+> ValueError: Found no third-party release archives to download for OS type ubuntu20.04, compiler type matching gcc11, architecture x86_64, is_linuxbrew=False. See more details above.
+
+it means that there is no [third-party download](#opt-yb-build) available for that build configuration.
+Check the list output above that message for supported configurations.
+
+{{< /note >}}
+
 For more details about building and testing, refer to [Build and test][build-and-test].
 
 [repo]: https://github.com/yugabyte/yugabyte-db

--- a/docs/content/preview/contribute/core-database/includes/build-the-code.md
+++ b/docs/content/preview/contribute/core-database/includes/build-the-code.md
@@ -27,7 +27,7 @@ If you get an error message such as
 > ValueError: Found no third-party release archives to download for OS type ubuntu20.04, compiler type matching gcc11, architecture x86_64, is_linuxbrew=False. See more details above.
 
 it means that there is no [third-party download](#opt-yb-build) available for that build configuration.
-Check the output above that message for supported configurations.
+Check the output that precedes the message for supported configurations.
 
 {{< /note >}}
 

--- a/docs/content/preview/contribute/core-database/includes/yugabyted-ui.md
+++ b/docs/content/preview/contribute/core-database/includes/yugabyted-ui.md
@@ -6,7 +6,7 @@ private = true
 
 yugabyted-ui is a UI for [yugabyted][yugabyted].
 By default, it is not built unless the corresponding build option is specified or a release package is being built.
-To build it, [npm][npm] and [Go][go] 1.18 or higher are required.
+To build it, [npm][npm] and [Go][go] 1.20 or higher are required.
 
 [yugabyted]: ../../../reference/configuration/yugabyted
 [npm]: https://www.npmjs.com


### PR DESCRIPTION
At some point, yugabyted-ui started requiring Go version >= 1.20.  While
this generally affects all platforms, only the Ubuntu Go installation
instruction suffered from explicitly specifying the old 1.18 version.
Fix both the Go instructions and the Ubuntu instructions.

Secondly, there are issues building with third-party archive on Ubuntu
20.04 without specifying `--clang16` because the defaults changed to
clang17 at some point.  Since this will probably be a recurring theme,
put a general catch-all note in the build instructions to guide users in
case such an issue is encountered.  (Also, since these instructions
reference `#opt-yb-build`, add that missing section to the macos
instructions.)

Lastly, no longer explicitly mention Ubuntu 23.04 as supported since it
is EOL.  This also involves removing Ubuntu 23.04-specific notes.