### PR TITLE
[Docs] Remove console.log from the script

### DIFF
--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -361,7 +361,6 @@ $(document).ready(() => {
           tabId = `${found.groups.name}-tab`;
         }
 
-        console.log('id:', tabId);
         $(element).addClass(tabId);
       }
     });
@@ -377,8 +376,6 @@ $(document).ready(() => {
             tabId = `${found.groups.name}-tab`;
           }
 
-          console.log('clicked id:', tabId);
-          console.log($(`.td-content .nav-tabs-yb .nav-link.${tabId}`));
           $(`.td-content .nav-tabs-yb .nav-link.${tabId}`).trigger('click');
         }
       }


### PR DESCRIPTION
Removing `console.log`. `console.log()` outputs a message to the console which is mainly used for development purposes.