### PR TITLE
[Docs] Correct cloud URL in header menu

### DIFF
--- a/docs/config/_default/menus.toml
+++ b/docs/config/_default/menus.toml
@@ -28,7 +28,7 @@
 [[start_now]]
   name = "YugabyteDB Managed"
   weight = 1
-  url = "https://devcloud.yugabyte.com/signup?utm_medium=direct&utm_source=docs&utm_campaign=YBM_signup"
+  url = "https://cloud.yugabyte.com/signup?utm_medium=direct&utm_source=docs&utm_campaign=YBM_signup"
   [start_now.params]
     buttonText = "Sign up"
     classes = "primary-btn sm-btn"


### PR DESCRIPTION
In header, cloud URL is pointing to the dev environment which was changed for the Segment integration testing. 