### PR TITLE
bugfix:  only cache successfult record

### DIFF
--- a/src/yb/util/net/dns_resolver.cc
+++ b/src/yb/util/net/dns_resolver.cc
@@ -160,7 +160,10 @@ class DnsResolver::Impl {
                 const Resolver::results_type& entries) mutable {
           // Unfortunately there is no safe way to set promise value from 2 different threads, w/o
           // catching exception in case of concurrency.
-          SetResult(PickResolvedAddress(host, error, entries), promise.get());
+          if (error == boost::system::error_code()) {
+            //only cache successful record in case of udp packet lost
+            SetResult(PickResolvedAddress(host, error, entries), promise.get());
+          }
         });
 
         if (io_service->stopped()) {


### PR DESCRIPTION
By default, yb will cache 60s (both good and bad record). 
But DNS resolve use udp by default, sometimes the DNS rsp packet may lost, in this case yb will cache 'Host not found (authoritative)'.

For example, I got the 
the rsp packet is drop by network stack
<img width="964" alt="image" src="https://github.com/yugabyte/yugabyte-db/assets/142382355/bf8749ca-dd96-4ce1-ab0a-b279cf971cea">

<img width="761" alt="image" src="https://github.com/yugabyte/yugabyte-db/assets/142382355/75b29903-3508-413b-b0cf-c87d4e993135">

Yb DNS resolve timeout, but will cache 60s error record(During this time period, the pod is ok). But yb will believe 'Host not found'
<img width="1405" alt="image" src="https://github.com/yugabyte/yugabyte-db/assets/142382355/672ec20c-0dbf-4086-a0dc-380199743bf6">
