### PR TITLE
[docs] renaming docs to be consistent with #14503

### DIFF
--- a/docs/content/preview/develop/common-patterns/timeseries/partitioning-by-time.md
+++ b/docs/content/preview/develop/common-patterns/timeseries/partitioning-by-time.md
@@ -116,7 +116,7 @@ EXPLAIN ANALYZE SELECT * FROM part_demo WHERE ts > '2023-07-01' AND ts < '2023-0
  Append (actual time=2.288..2.310 rows=25 loops=1)
    ->  Seq Scan on public.part_7_23 (actual time=2.285..2.301 rows=25 loops=1)
          Output: part_7_23.ts, part_7_23.car, part_7_23.speed
-         Remote Filter: ((part_7_23.ts > '2023-07-01 00:00:00'::timestamp without time zone)
+         Storage Filter: ((part_7_23.ts > '2023-07-01 00:00:00'::timestamp without time zone)
                 AND (part_7_23.ts < '2023-08-01 00:00:00'::timestamp without time zone))
  Planning Time: 0.309 ms
  Execution Time: 2.411 ms

--- a/docs/content/preview/explore/ysql-language-features/indexes-constraints/secondary-indexes-ysql.md
+++ b/docs/content/preview/explore/ysql-language-features/indexes-constraints/secondary-indexes-ysql.md
@@ -183,7 +183,7 @@ EXPLAIN SELECT * FROM employees WHERE last_name='Davolio' AND first_name='Nancy'
                                             QUERY PLAN
 ---------------------------------------------------------------------------------------------------
  Seq Scan on employees  (cost=0.00..105.00 rows=1000 width=1240)
-   Remote Filter: (((last_name)::text = 'Davolio'::text) AND ((first_name)::text = 'Nancy'::text))
+   Storage Filter: (((last_name)::text = 'Davolio'::text) AND ((first_name)::text = 'Nancy'::text))
 (2 rows)
 ```
 

--- a/docs/content/preview/explore/ysql-language-features/join-strategies.md
+++ b/docs/content/preview/explore/ysql-language-features/join-strategies.md
@@ -101,12 +101,12 @@ The query plan would be similar to the following:
 ```yaml
  Nested Loop (actual time=2002.483..9011.038 rows=18 loops=1)
    ->  Seq Scan on students (actual time=1001.369..1001.393 rows=8 loops=1)
-         Remote Filter: ((name)::text = 'Natasha'::text)
+         Storage Filter: ((name)::text = 'Natasha'::text)
          Storage Table Read Requests: 1
          Storage Table Read Execution Time: 1001.245 ms
    ->  Index Scan using scores_pkey on scores (actual time=1001.141..1001.146 rows=2 loops=8)
          Index Cond: (id = students.id)
-         Remote Filter: (score > 70)
+         Storage Filter: (score > 70)
          Storage Table Read Requests: 1
          Storage Table Read Execution Time: 1001.050 ms
  Planning Time: 0.308 ms
@@ -147,14 +147,14 @@ The query plan would be similar to the following:
          Sort Key: students.id
          Sort Method: quicksort  Memory: 25kB
          ->  Seq Scan on students (actual time=1001.418..1001.424 rows=8 loops=1)
-               Remote Filter: ((name)::text = 'Natasha'::text)
+               Storage Filter: ((name)::text = 'Natasha'::text)
                Storage Table Read Requests: 1
                Storage Table Read Execution Time: 1001.243 ms
    ->  Sort (actual time=1001.447..1001.455 rows=51 loops=1)
          Sort Key: scores.id
          Sort Method: quicksort  Memory: 27kB
          ->  Seq Scan on scores (actual time=1001.370..1001.390 rows=51 loops=1)
-               Remote Filter: (score > 70)
+               Storage Filter: (score > 70)
                Storage Table Read Requests: 1
                Storage Table Read Execution Time: 1001.250 ms
  Planning Time: 0.252 ms
@@ -190,13 +190,13 @@ The query plan would be similar to the following:
  Hash Join (actual time=2002.431..2002.477 rows=18 loops=1)
    Hash Cond: (scores.id = students.id)
    ->  Seq Scan on scores (actual time=1001.043..1001.061 rows=51 loops=1)
-         Remote Filter: (score > 70)
+         Storage Filter: (score > 70)
          Storage Table Read Requests: 1
          Storage Table Read Execution Time: 1000.927 ms
    ->  Hash (actual time=1001.360..1001.361 rows=8 loops=1)
          Buckets: 1024  Batches: 1  Memory Usage: 9kB
          ->  Seq Scan on students (actual time=1001.327..1001.335 rows=8 loops=1)
-               Remote Filter: ((name)::text = 'Natasha'::text)
+               Storage Filter: ((name)::text = 'Natasha'::text)
                Storage Table Read Requests: 1
                Storage Table Read Execution Time: 1001.211 ms
  Planning Time: 0.231 ms
@@ -248,7 +248,7 @@ The query plan would be similar to the following:
          Storage Index Read Execution Time: 1000.589 ms
    ->  Index Scan using idx_id on scores (actual time=2002.290..2002.305 rows=18 loops=1)
          Index Cond: (id = ANY (ARRAY[students.id, $1, $2, ..., $1023]))
-         Remote Filter: (score > 70)
+         Storage Filter: (score > 70)
          Storage Table Read Requests: 1
          Storage Table Read Execution Time: 1001.356 ms
          Storage Index Read Requests: 1

--- a/docs/content/preview/explore/ysql-language-features/pg-extensions/extension-auto-explain.md
+++ b/docs/content/preview/explore/ysql-language-features/pg-extensions/extension-auto-explain.md
@@ -63,7 +63,7 @@ LOG:  duration: 316.556 ms  plan:
         Aggregate  (cost=216.39..216.40 rows=1 width=8) (actual time=316.489..316.489 rows=1 loops=1)
           ->  Nested Loop  (cost=0.00..213.89 rows=1000 width=0) (actual time=10.828..316.200 rows=110 loops=1)
                 ->  Seq Scan on pg_index  (cost=0.00..100.00 rows=1000 width=4) (actual time=7.465..8.068 rows=110 loops=1)
-                      Remote Filter: indisunique
+                      Storage Filter: indisunique
                 ->  Index Scan using pg_class_oid_index on pg_class  (cost=0.00..0.11 rows=1 width=4) (actual time=2.673..2.673 rows=1 loops=110)
                       Index Cond: (oid = pg_index.indrelid)
 ```


### PR DESCRIPTION
[This commit](https://github.com/yugabyte/yugabyte-db/commit/7df8abd1a2db3e2d8c6d7b9eac49d948617065cc) updated some of the terminology for the EXPLAIN field names. This diff updates the documentation accordingly.