### PR TITLE
[docs] Fix coredb contributor instructions for alma, centos

### DIFF
--- a/docs/content/preview/contribute/core-database/build-from-src-almalinux.md
+++ b/docs/content/preview/contribute/core-database/build-from-src-almalinux.md
@@ -148,6 +148,12 @@ sudo dnf install -y gcc-toolset-11 gcc-toolset-11-libatomic-devel
 Perform the following steps to build a release package:
 
 1. [Satisfy requirements for building yugabyted-ui](#yugabyted-ui).
+1. Install patchelf:
+
+   ```sh
+   sudo dnf install -y patchelf
+   ```
+
 1. Run the `yb_release` script using the following command:
 
    ```sh

--- a/docs/content/preview/contribute/core-database/build-from-src-centos.md
+++ b/docs/content/preview/contribute/core-database/build-from-src-centos.md
@@ -146,6 +146,12 @@ sudo yum install -y devtoolset-11 devtoolset-11-libatomic-devel
 Perform the following steps to build a release package:
 
 1. [Satisfy requirements for building yugabyted-ui](#yugabyted-ui).
+1. Install patchelf:
+
+   ```sh
+   sudo yum install -y patchelf
+   ```
+
 1. Run the `yb_release` script using the following command:
 
    ```sh

--- a/docs/content/preview/contribute/core-database/build-from-src-centos.md
+++ b/docs/content/preview/contribute/core-database/build-from-src-centos.md
@@ -137,6 +137,8 @@ To compile with GCC, install the following packages, and adjust the version numb
 sudo yum install -y devtoolset-11 devtoolset-11-libatomic-devel
 ```
 
+Note: there may be compilation issues ([#22059](https://github.com/yugabyte/yugabyte-db/issues/22059)).
+
 ## Build the code
 
 {{% readfile "includes/build-the-code.md" %}}


### PR DESCRIPTION
Update CoreDB contributor instructions, which went out of date some time
ago.

- Add patchelf package to installation instructions.  It was always
  required, but what likely happened is that it used to be implicitly
  installed as part of a dependency of a different required package, and
  that is no longer the case today.
- Note that there may be compilation issues with centos + gcc.