### PR TITLE
Include a restart after replicated migration

### DIFF
--- a/docs/content/preview/yugabyte-platform/install-yugabyte-platform/install-software/installer.md
+++ b/docs/content/preview/yugabyte-platform/install-yugabyte-platform/install-software/installer.md
@@ -258,7 +258,7 @@ To migrate your installation from Replicated, do the following:
 1. Start the migration, passing in your license file:
 
     ```sh
-    $ sudo ./yba-ctl replicated-migrate start -l /path/to/license && sudo /opt/yba-ctl/yba-ctl restart
+    $ sudo ./yba-ctl replicated-migrate start -l /path/to/license && sudo /opt/yba-ctl/yba-ctl restart yb-platform
     ```
 
     The `start` command runs all [preflight checks](#run-preflight-checks) and then proceeds to do the migration, and then waits for YBA to start.

--- a/docs/content/preview/yugabyte-platform/install-yugabyte-platform/install-software/installer.md
+++ b/docs/content/preview/yugabyte-platform/install-yugabyte-platform/install-software/installer.md
@@ -258,7 +258,7 @@ To migrate your installation from Replicated, do the following:
 1. Start the migration, passing in your license file:
 
     ```sh
-    $ sudo ./yba-ctl replicated-migrate start -l /path/to/license
+    $ sudo ./yba-ctl replicated-migrate start -l /path/to/license && sudo /opt/yba-ctl/yba-ctl restart
     ```
 
     The `start` command runs all [preflight checks](#run-preflight-checks) and then proceeds to do the migration, and then waits for YBA to start.

--- a/docs/content/stable/yugabyte-platform/install-yugabyte-platform/install-software/installer.md
+++ b/docs/content/stable/yugabyte-platform/install-yugabyte-platform/install-software/installer.md
@@ -256,7 +256,7 @@ To migrate your installation from Replicated, do the following:
 1. Start the migration, passing in your license file:
 
     ```sh
-    $ sudo ./yba-ctl replicated-migrate start -l /path/to/license
+    $ sudo ./yba-ctl replicated-migrate start -l /path/to/license && sudo /opt/yba-ctl/yba-ctl restart yb-platform
     ```
 
     The `start` command runs all [preflight checks](#run-preflight-checks) and then proceeds to do the migration, and then waits for YBA to start.


### PR DESCRIPTION
Include a restart after replicated migration to workaround a specific issue affecting ybc release migration.