### PR TITLE
Support IPV6 in yugabyted --advertise_address

### DIFF
--- a/bin/yugabyted
+++ b/bin/yugabyted
@@ -2047,11 +2047,17 @@ class ControlScript(object):
                 mandatory_port_available, recommended_port_available)
 
     def is_port_available(self, advertise_ip, port):
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        try:
-            return s.connect_ex((advertise_ip, int(port))) != 0
-        finally:
-            s.close()
+        addr_info = socket.getaddrinfo(advertise_ip, port, socket.AF_UNSPEC, socket.SOCK_STREAM)
+        for family, socktype, proto, canonname, sockaddr in addr_info:
+            try:
+                s = socket.socket(family, socktype, proto)
+                try:
+                    return s.connect_ex(sockaddr) != 0
+                finally:
+                    s.close()
+            except OSError:
+                continue
+        return False
 
     def get_mandatory_ports(self):
         mandatory_ports = []


### PR DESCRIPTION
Without this, starting yugabyted witih an ipv6 host always fails with an address family not supported error.