### PR TITLE
[docs] Update consumer safe time metric unit from microseconds to milliseconds

### DIFF
--- a/docs/content/preview/launch-and-manage/monitor-and-alert/metrics/replication.md
+++ b/docs/content/preview/launch-and-manage/monitor-and-alert/metrics/replication.md
@@ -24,5 +24,5 @@ The following table describes key replication metrics. All metrics are counters 
 | :------ | :---------- |
 | `async_replication_committed_lag_micros` | The time in microseconds for the replication lag on the target cluster. This metric is available only on the source cluster. |
 | `time_since_last_getchanges` | The time elapsed in microseconds from when the source cluster got a request to replicate from the target cluster. This metric is available only on the source cluster. |
-| `consumer_safe_time_lag` | The time elapsed in microseconds between the physical time and safe time. Safe time is when data has been replicated to all the tablets on the consumer cluster. This metric is available only on the target cluster. |
-| `consumer_safe_time_skew` | The time elapsed in microseconds for replication between the first and the last tablet replica on the consumer cluster. This metric is available only on the target cluster. |
+| `consumer_safe_time_lag` | The time elapsed in milliseconds between the physical time and safe time. Safe time is when data has been replicated to all the tablets on the consumer cluster. This metric is available only on the target cluster. |
+| `consumer_safe_time_skew` | The time elapsed in milliseconds for replication between the first and the last tablet replica on the consumer cluster. This metric is available only on the target cluster. |

--- a/docs/content/stable/launch-and-manage/monitor-and-alert/metrics/replication.md
+++ b/docs/content/stable/launch-and-manage/monitor-and-alert/metrics/replication.md
@@ -24,5 +24,5 @@ The following table describes key replication metrics. All metrics are counters 
 | :------ | :---------- |
 | `async_replication_committed_lag_micros` | The time in microseconds for the replication lag on the target cluster. This metric is available only on the source cluster. |
 | `time_since_last_getchanges` | The time elapsed in microseconds from when the source cluster got a request to replicate from the target cluster. This metric is available only on the source cluster. |
-| `consumer_safe_time_lag` | The time elapsed in microseconds between the physical time and safe time. Safe time is when data has been replicated to all the tablets on the consumer cluster. This metric is available only on the target cluster. |
-| `consumer_safe_time_skew` | The time elapsed in microseconds for replication between the first and the last tablet replica on the consumer cluster. This metric is available only on the target cluster. |
+| `consumer_safe_time_lag` | The time elapsed in milliseconds between the physical time and safe time. Safe time is when data has been replicated to all the tablets on the consumer cluster. This metric is available only on the target cluster. |
+| `consumer_safe_time_skew` | The time elapsed in milliseconds for replication between the first and the last tablet replica on the consumer cluster. This metric is available only on the target cluster. |

--- a/docs/content/v2.18/launch-and-manage/monitor-and-alert/metrics/replication.md
+++ b/docs/content/v2.18/launch-and-manage/monitor-and-alert/metrics/replication.md
@@ -24,5 +24,5 @@ The following table describes key replication metrics. All metrics are counters 
 | :------ | :---------- |
 | `async_replication_committed_lag_micros` | The time in microseconds for the replication lag on the target cluster. This metric is available only on the source cluster. |
 | `time_since_last_getchanges` | The time elapsed in microseconds from when the source cluster got a request to replicate from the target cluster. This metric is available only on the source cluster. |
-| `consumer_safe_time_lag` | The time elapsed in microseconds between the physical time and safe time. Safe time is when data has been replicated to all the tablets on the consumer cluster. This metric is available only on the target cluster. |
-| `consumer_safe_time_skew` | The time elapsed in microseconds for replication between the first and the last tablet replica on the consumer cluster. This metric is available only on the target cluster. |
+| `consumer_safe_time_lag` | The time elapsed in milliseconds between the physical time and safe time. Safe time is when data has been replicated to all the tablets on the consumer cluster. This metric is available only on the target cluster. |
+| `consumer_safe_time_skew` | The time elapsed in milliseconds for replication between the first and the last tablet replica on the consumer cluster. This metric is available only on the target cluster. |

--- a/docs/content/v2.20/launch-and-manage/monitor-and-alert/metrics/replication.md
+++ b/docs/content/v2.20/launch-and-manage/monitor-and-alert/metrics/replication.md
@@ -24,5 +24,5 @@ The following table describes key replication metrics. All metrics are counters 
 | :------ | :---------- |
 | `async_replication_committed_lag_micros` | The time in microseconds for the replication lag on the target cluster. This metric is available only on the source cluster. |
 | `time_since_last_getchanges` | The time elapsed in microseconds from when the source cluster got a request to replicate from the target cluster. This metric is available only on the source cluster. |
-| `consumer_safe_time_lag` | The time elapsed in microseconds between the physical time and safe time. Safe time is when data has been replicated to all the tablets on the consumer cluster. This metric is available only on the target cluster. |
-| `consumer_safe_time_skew` | The time elapsed in microseconds for replication between the first and the last tablet replica on the consumer cluster. This metric is available only on the target cluster. |
+| `consumer_safe_time_lag` | The time elapsed in milliseconds between the physical time and safe time. Safe time is when data has been replicated to all the tablets on the consumer cluster. This metric is available only on the target cluster. |
+| `consumer_safe_time_skew` | The time elapsed in milliseconds for replication between the first and the last tablet replica on the consumer cluster. This metric is available only on the target cluster. |


### PR DESCRIPTION
These consumer safe time metrics are reported from yugabyte db in milliseconds and not microseconds: https://github.com/yugabyte/yugabyte-db/blob/master/src/yb/master/xcluster/xcluster_consumer_metrics.cc#L40

Have also verified by stopping the source universe in a DR setup and observing that the reported number is indeed in milliseconds.

@netlify /preview/launch-and-manage/monitor-and-alert/metrics/replication