### PR TITLE
[docs] OS support pages update for v2.20, v2024.1, v2.21.

### DIFF
--- a/docs/config/_default/params.toml
+++ b/docs/config/_default/params.toml
@@ -58,7 +58,7 @@ version_menu_pagelinks = true
   version = "v2024.1 (STS)"
 [[versions]]
   url = "/v2.20"
-  version = "v2.20 (STS)"
+  version = "v2.20 (LTS)"
 [[versions]]
   url = "/v2.18"
   version = "v2.18 (STS)"

--- a/docs/content/preview/reference/configuration/operating-systems.md
+++ b/docs/content/preview/reference/configuration/operating-systems.md
@@ -21,15 +21,10 @@ Unless otherwise noted, operating systems are supported by all supported version
 | :--------------- | :------------- | :------------- | :---- |
 | AlmaLinux 8      | {{<icon/yes>}} | {{<icon/yes>}} | Recommended for production<br>Recommended development platform<br>Default for YBA-deployed nodes |
 | AlmaLinux 9      | {{<icon/yes>}} | {{<icon/yes>}} |       |
-| Amazon Linux 2   | {{<icon/yes>}} | {{<icon/yes>}} | v2.18.0 and later<br>Deprecated in v2.20.0; not supported in v2.21.0.0 release and [upcoming release series](/preview/releases/#upcoming-release-series) |
 | Amazon Linux 2 (ARM, CIS-hardened) | {{<icon/no>}} | {{<icon/yes>}} | Supported in v2.20.x. Database performance in this environment varies both due to CIS-hardening and ARM. For more information, contact {{% support-general %}}.|
-| CentOS7          | {{<icon/yes>}} |                | Deprecated in v2.20.0; not supported in v2.21.0.0 release and [upcoming release series](/preview/releases/#upcoming-release-series) |
-| Oracle Linux 7         | {{<icon/yes>}} |                | Deprecated in v2.20.0; not supported in v2.21.0.0 release and [upcoming release series](/preview/releases/#upcoming-release-series)|
 | Oracle Linux 8         | {{<icon/yes>}} |                | |
-| Red Hat Enterprise Linux 7 | {{<icon/yes>}} |      | Deprecated in v2.20.0; not supported in v2.21.0.0 release and [upcoming release series](/preview/releases/#upcoming-release-series) |
 | Red Hat Enterprise Linux 8 | {{<icon/yes>}} |      | Recommended for production |
 | Red Hat Enterprise Linux&nbsp;9.3 | {{<icon/yes>}} |  | v2.20.3 and later.  {{<badge/ea>}} |
 | SUSE&nbsp;Linux&nbsp;Enterprise&nbsp;Server&nbsp;15&nbsp;SP5 | {{<icon/yes>}} |     | {{<badge/ea>}} |
-| Ubuntu 18        | {{<icon/yes>}} | {{<icon/yes>}} | Deprecated in v2.20.0; not supported in v2.21.0.0 release and [upcoming release series](/preview/releases/#upcoming-release-series) |
 | Ubuntu 20        | {{<icon/yes>}} | {{<icon/yes>}} |       |
 | Ubuntu 22        | {{<icon/yes>}} | {{<icon/yes>}} | Supported in v2.18.5, v2.20.1 |

--- a/docs/content/preview/reference/configuration/operating-systems.md
+++ b/docs/content/preview/reference/configuration/operating-systems.md
@@ -21,15 +21,15 @@ Unless otherwise noted, operating systems are supported by all supported version
 | :--------------- | :------------- | :------------- | :---- |
 | AlmaLinux 8      | {{<icon/yes>}} | {{<icon/yes>}} | Recommended for production<br>Recommended development platform<br>Default for YBA-deployed nodes |
 | AlmaLinux 9      | {{<icon/yes>}} | {{<icon/yes>}} |       |
-| Amazon Linux 2   | {{<icon/no>}} | {{<icon/no>}} | v2.18.0 and later<br>Deprecated in v2.20.0 |
+| Amazon Linux 2   | {{<icon/no>}} | {{<icon/no>}} | v2.18.0 and later<br>Deprecated in v2.20 |
 | Amazon Linux 2 (ARM, CIS-hardened) |  | {{<icon/yes>}} | Supported in v2.20.x. Database performance in this environment varies both due to CIS-hardening and ARM. For more information, contact {{% support-general %}}.|
-| CentOS7          | {{<icon/no>}}  |                | Deprecated in v2.20.0 |
-| Oracle Linux 7   | {{<icon/no>}}  |                | Deprecated in v2.20.0 |
+| CentOS7          | {{<icon/no>}}  |                | Deprecated in v2.20 |
+| Oracle Linux 7   | {{<icon/no>}}  |                | Deprecated in v2.20 |
 | Oracle Linux 8   | {{<icon/yes>}} |                | |
-| Red Hat Enterprise Linux 7 | {{<icon/no>}} |       | Deprecated in v2.20.0 |
+| Red Hat Enterprise Linux 7 | {{<icon/no>}} |       | Deprecated in v2.20 |
 | Red Hat Enterprise Linux 8 | {{<icon/yes>}} |      | Recommended for production |
 | Red Hat Enterprise Linux&nbsp;9.3 | {{<icon/yes>}} |  | v2.20.3 and later.  {{<badge/ea>}} |
 | SUSE&nbsp;Linux&nbsp;Enterprise&nbsp;Server&nbsp;15&nbsp;SP5 | {{<icon/yes>}} |     | {{<badge/ea>}} |
-| Ubuntu 18        | {{<icon/no>}}  | {{<icon/no>}}  | Deprecated in v2.20.0 |
+| Ubuntu 18        | {{<icon/no>}}  | {{<icon/no>}}  | Deprecated in v2.20 |
 | Ubuntu 20        | {{<icon/yes>}} | {{<icon/yes>}} |       |
 | Ubuntu 22        | {{<icon/yes>}} | {{<icon/yes>}} | Supported in v2.18.5, v2.20.1 |

--- a/docs/content/preview/reference/configuration/operating-systems.md
+++ b/docs/content/preview/reference/configuration/operating-systems.md
@@ -21,10 +21,15 @@ Unless otherwise noted, operating systems are supported by all supported version
 | :--------------- | :------------- | :------------- | :---- |
 | AlmaLinux 8      | {{<icon/yes>}} | {{<icon/yes>}} | Recommended for production<br>Recommended development platform<br>Default for YBA-deployed nodes |
 | AlmaLinux 9      | {{<icon/yes>}} | {{<icon/yes>}} |       |
+| Amazon Linux 2   | {{<icon/no>}} | {{<icon/no>}} |  |
 | Amazon Linux 2 (ARM, CIS-hardened) | {{<icon/no>}} | {{<icon/yes>}} | Supported in v2.20.x. Database performance in this environment varies both due to CIS-hardening and ARM. For more information, contact {{% support-general %}}.|
+| CentOS7          | {{<icon/no>}} |                |  |
+| Oracle Linux 7         | {{<icon/no>}} |                | |
 | Oracle Linux 8         | {{<icon/yes>}} |                | |
+| Red Hat Enterprise Linux 7 | {{<icon/no>}} |      |  |
 | Red Hat Enterprise Linux 8 | {{<icon/yes>}} |      | Recommended for production |
 | Red Hat Enterprise Linux&nbsp;9.3 | {{<icon/yes>}} |  | v2.20.3 and later.  {{<badge/ea>}} |
 | SUSE&nbsp;Linux&nbsp;Enterprise&nbsp;Server&nbsp;15&nbsp;SP5 | {{<icon/yes>}} |     | {{<badge/ea>}} |
+| Ubuntu 18        | {{<icon/no>}} | {{<icon/no>}} | |
 | Ubuntu 20        | {{<icon/yes>}} | {{<icon/yes>}} |       |
 | Ubuntu 22        | {{<icon/yes>}} | {{<icon/yes>}} | Supported in v2.18.5, v2.20.1 |

--- a/docs/content/preview/reference/configuration/operating-systems.md
+++ b/docs/content/preview/reference/configuration/operating-systems.md
@@ -21,15 +21,15 @@ Unless otherwise noted, operating systems are supported by all supported version
 | :--------------- | :------------- | :------------- | :---- |
 | AlmaLinux 8      | {{<icon/yes>}} | {{<icon/yes>}} | Recommended for production<br>Recommended development platform<br>Default for YBA-deployed nodes |
 | AlmaLinux 9      | {{<icon/yes>}} | {{<icon/yes>}} |       |
-| Amazon Linux 2   | {{<icon/no>}} | {{<icon/no>}} |  |
-| Amazon Linux 2 (ARM, CIS-hardened) | {{<icon/no>}} | {{<icon/yes>}} | Supported in v2.20.x. Database performance in this environment varies both due to CIS-hardening and ARM. For more information, contact {{% support-general %}}.|
-| CentOS7          | {{<icon/no>}} |                |  |
-| Oracle Linux 7         | {{<icon/no>}} |                | |
-| Oracle Linux 8         | {{<icon/yes>}} |                | |
-| Red Hat Enterprise Linux 7 | {{<icon/no>}} |      |  |
+| Amazon Linux 2   | {{<icon/no>}} | {{<icon/no>}} | v2.18.0 and later<br>Deprecated in v2.20.0 |
+| Amazon Linux 2 (ARM, CIS-hardened) |  | {{<icon/yes>}} | Supported in v2.20.x. Database performance in this environment varies both due to CIS-hardening and ARM. For more information, contact {{% support-general %}}.|
+| CentOS7          | {{<icon/no>}}  |                | Deprecated in v2.20.0 |
+| Oracle Linux 7   | {{<icon/no>}}  |                | Deprecated in v2.20.0 |
+| Oracle Linux 8   | {{<icon/yes>}} |                | |
+| Red Hat Enterprise Linux 7 | {{<icon/no>}} |       | Deprecated in v2.20.0 |
 | Red Hat Enterprise Linux 8 | {{<icon/yes>}} |      | Recommended for production |
 | Red Hat Enterprise Linux&nbsp;9.3 | {{<icon/yes>}} |  | v2.20.3 and later.  {{<badge/ea>}} |
 | SUSE&nbsp;Linux&nbsp;Enterprise&nbsp;Server&nbsp;15&nbsp;SP5 | {{<icon/yes>}} |     | {{<badge/ea>}} |
-| Ubuntu 18        | {{<icon/no>}} | {{<icon/no>}} | |
+| Ubuntu 18        | {{<icon/no>}}  | {{<icon/no>}}  | Deprecated in v2.20.0 |
 | Ubuntu 20        | {{<icon/yes>}} | {{<icon/yes>}} |       |
 | Ubuntu 22        | {{<icon/yes>}} | {{<icon/yes>}} | Supported in v2.18.5, v2.20.1 |

--- a/docs/content/preview/releases/ybdb-releases/v2024.1.md
+++ b/docs/content/preview/releases/ybdb-releases/v2024.1.md
@@ -98,8 +98,6 @@ Rolling back to the pre-upgrade version if you're not satisfied with the upgrade
 
 - DocDB Availability: Hardening raft. Reduced time window for retryable requests by honoring write RPC timeouts.
 
-- CoreDB-FIPS 140-2 crypto support. The FIPS provider has been upgraded to be FIPS 140-2 compliant. {{<badge/tp>}}
-
 - [Batched nested loop joins](/stable/explore/ysql-language-features/join-strategies/#batched-nested-loop-join-bnl). A join execution strategy that is an improvement on Nested Loop joins that sends one request to the inner table per batch of outer table tuples instead of once per individual outer table tuple.
 
 - [Tablet splitting on range sharded tables](/stable/architecture/docdb-sharding/tablet-splitting/#range-sharded-tables). Optimize tablet splitting to efficiently process incoming data and maximize cross-tablet parallelism.
@@ -107,8 +105,6 @@ Rolling back to the pre-upgrade version if you're not satisfied with the upgrade
 - [Catalog Caching](/stable/reference/configuration/yb-tserver/#catalog-flags). Reduce master requests during PostgreSQL system catalog refresh by populating YB-TServer catalog cache. {{<badge/ea>}}
 
 - [Catalog Caching](/stable/reference/configuration/yb-tserver/#ysql-yb-toast-catcache-threshold). Use TOAST compression to reduce PG catalog cache memory. Compressed catalog tuples when storing in the PG catalog cache to reduce the memory consumption. {{<badge/ea>}}
-
-- Shared memory. Implement shared memory for PostgreSQL to TServer communication to minimize latency and enhance query performance by reducing communication overhead. {{<badge/tp>}}
 
 - [Index backfill](/stable/explore/ysql-language-features/indexes-constraints/index-backfill/) stability improvements. Ensure timely notification to all nodes and PostgreSQL backends before initiating index backfill to prevent missing entries during index creation.
 

--- a/docs/content/stable/reference/configuration/operating-systems.md
+++ b/docs/content/stable/reference/configuration/operating-systems.md
@@ -21,15 +21,15 @@ Unless otherwise noted, operating systems are supported by all supported version
 | :--------------- | :------------- | :------------- | :---- |
 | AlmaLinux 8      | {{<icon/yes>}} | {{<icon/yes>}} | Recommended for production<br>Recommended development platform<br>Default for YBA-deployed nodes |
 | AlmaLinux 9      | {{<icon/yes>}} | {{<icon/yes>}} |       |
-| Amazon Linux 2   | {{<icon/no>}} | {{<icon/no>}} |  |
-| Amazon Linux 2 (ARM, CIS-hardened) | {{<icon/no>}} | {{<icon/yes>}} | Supported in v2.20.x. Database performance in this environment varies both due to CIS-hardening and ARM. For more information, contact {{% support-general %}}.|
-| CentOS7          | {{<icon/no>}} |                |  |
-| Oracle Linux 7         | {{<icon/no>}} |                | |
-| Oracle Linux 8         | {{<icon/yes>}} |                | |
-| Red Hat Enterprise Linux 7 | {{<icon/no>}} |      |  |
+| Amazon Linux 2   | {{<icon/no>}}  | {{<icon/no>}}  | v2.18.0 and later<br>Deprecated in v2.20.0 |
+| Amazon Linux 2<br>(ARM, CIS-hardened) |  | {{<icon/yes>}} | Supported in v2.20.x. Database performance in this environment varies both due to CIS-hardening and ARM. For more information, contact {{% support-general %}}.|
+| CentOS7          | {{<icon/no>}}  |                | Deprecated in v2.20.0 |
+| Oracle Linux 7   | {{<icon/no>}}  |                | Deprecated in v2.20.0 |
+| Oracle Linux 8   | {{<icon/yes>}} |                | |
+| Red Hat Enterprise Linux 7 | {{<icon/no>}} |       | Deprecated in v2.20.0 |
 | Red Hat Enterprise Linux 8 | {{<icon/yes>}} |      | Recommended for production |
 | Red Hat Enterprise Linux&nbsp;9.3 | {{<icon/yes>}} |  | v2.20.3 and later.  {{<badge/ea>}} |
 | SUSE&nbsp;Linux&nbsp;Enterprise&nbsp;Server&nbsp;15&nbsp;SP5 | {{<icon/yes>}} |     | {{<badge/ea>}} |
-| Ubuntu 18        | {{<icon/no>}} | {{<icon/no>}} | |
+| Ubuntu 18        | {{<icon/no>}}  | {{<icon/no>}}  | Deprecated in v2.20.0 |
 | Ubuntu 20        | {{<icon/yes>}} | {{<icon/yes>}} |       |
 | Ubuntu 22        | {{<icon/yes>}} | {{<icon/yes>}} | Supported in v2.18.5, v2.20.1 |

--- a/docs/content/stable/reference/configuration/operating-systems.md
+++ b/docs/content/stable/reference/configuration/operating-systems.md
@@ -21,17 +21,10 @@ Unless otherwise noted, operating systems are supported by all supported version
 | :--------------- | :------------- | :------------- | :---- |
 | AlmaLinux 8      | {{<icon/yes>}} | {{<icon/yes>}} | Recommended for production<br>Recommended development platform<br>Default for YBA-deployed nodes |
 | AlmaLinux 9      | {{<icon/yes>}} | {{<icon/yes>}} |       |
-| Amazon Linux 2   | {{<icon/yes>}} | {{<icon/yes>}} | v2.18.0 and later<br>Deprecated in v2.20.0; not supported in v2.21.0.0 release and [upcoming release series](/preview/releases/#upcoming-release-series) |
 | Amazon Linux 2 (ARM, CIS-hardened) | {{<icon/no>}} | {{<icon/yes>}} | Supported in v2.20.x. Database performance in this environment varies both due to CIS-hardening and ARM. For more information, contact {{% support-general %}}.|
-| CentOS7          | {{<icon/yes>}} |                | Deprecated in v2.20.0; not supported in v2.21.0.0 release and [upcoming release series](/preview/releases/#upcoming-release-series) |
-| Oracle Linux 7         | {{<icon/yes>}} |                | Deprecated in v2.20.0; not supported in v2.21.0.0 release and [upcoming release series](/preview/releases/#upcoming-release-series)|
 | Oracle Linux 8         | {{<icon/yes>}} |                | |
-| Red Hat Enterprise Linux 7 | {{<icon/yes>}} |      | Deprecated in v2.20.0; not supported in v2.21.0.0 release and [upcoming release series](/preview/releases/#upcoming-release-series) |
 | Red Hat Enterprise Linux 8 | {{<icon/yes>}} |      | Recommended for production |
 | Red Hat Enterprise Linux&nbsp;9.3 | {{<icon/yes>}} |  | v2.20.3 and later.  {{<badge/ea>}} |
 | SUSE&nbsp;Linux&nbsp;Enterprise&nbsp;Server&nbsp;15&nbsp;SP5 | {{<icon/yes>}} |     | {{<badge/ea>}} |
-| Ubuntu 18        | {{<icon/yes>}} | {{<icon/yes>}} | Deprecated in v2.20.0; not supported in v2.21.0.0 release and [upcoming release series](/preview/releases/#upcoming-release-series) |
 | Ubuntu 20        | {{<icon/yes>}} | {{<icon/yes>}} |       |
 | Ubuntu 22        | {{<icon/yes>}} | {{<icon/yes>}} | Supported in v2.18.5, v2.20.1 |
-
-<!-- | Red Hat Enterprise Linux&nbsp;9.3 | {{<icon/yes>}} |  | v2.20.3 and later<br>Recommended for production | -->

--- a/docs/content/stable/reference/configuration/operating-systems.md
+++ b/docs/content/stable/reference/configuration/operating-systems.md
@@ -21,10 +21,15 @@ Unless otherwise noted, operating systems are supported by all supported version
 | :--------------- | :------------- | :------------- | :---- |
 | AlmaLinux 8      | {{<icon/yes>}} | {{<icon/yes>}} | Recommended for production<br>Recommended development platform<br>Default for YBA-deployed nodes |
 | AlmaLinux 9      | {{<icon/yes>}} | {{<icon/yes>}} |       |
+| Amazon Linux 2   | {{<icon/no>}} | {{<icon/no>}} |  |
 | Amazon Linux 2 (ARM, CIS-hardened) | {{<icon/no>}} | {{<icon/yes>}} | Supported in v2.20.x. Database performance in this environment varies both due to CIS-hardening and ARM. For more information, contact {{% support-general %}}.|
+| CentOS7          | {{<icon/no>}} |                |  |
+| Oracle Linux 7         | {{<icon/no>}} |                | |
 | Oracle Linux 8         | {{<icon/yes>}} |                | |
+| Red Hat Enterprise Linux 7 | {{<icon/no>}} |      |  |
 | Red Hat Enterprise Linux 8 | {{<icon/yes>}} |      | Recommended for production |
 | Red Hat Enterprise Linux&nbsp;9.3 | {{<icon/yes>}} |  | v2.20.3 and later.  {{<badge/ea>}} |
 | SUSE&nbsp;Linux&nbsp;Enterprise&nbsp;Server&nbsp;15&nbsp;SP5 | {{<icon/yes>}} |     | {{<badge/ea>}} |
+| Ubuntu 18        | {{<icon/no>}} | {{<icon/no>}} | |
 | Ubuntu 20        | {{<icon/yes>}} | {{<icon/yes>}} |       |
 | Ubuntu 22        | {{<icon/yes>}} | {{<icon/yes>}} | Supported in v2.18.5, v2.20.1 |

--- a/docs/content/stable/reference/configuration/operating-systems.md
+++ b/docs/content/stable/reference/configuration/operating-systems.md
@@ -21,15 +21,15 @@ Unless otherwise noted, operating systems are supported by all supported version
 | :--------------- | :------------- | :------------- | :---- |
 | AlmaLinux 8      | {{<icon/yes>}} | {{<icon/yes>}} | Recommended for production<br>Recommended development platform<br>Default for YBA-deployed nodes |
 | AlmaLinux 9      | {{<icon/yes>}} | {{<icon/yes>}} |       |
-| Amazon Linux 2   | {{<icon/no>}}  | {{<icon/no>}}  | v2.18.0 and later<br>Deprecated in v2.20.0 |
+| Amazon Linux 2   | {{<icon/no>}}  | {{<icon/no>}}  | v2.18.0 and later<br>Deprecated in v2.20 |
 | Amazon Linux 2<br>(ARM, CIS-hardened) |  | {{<icon/yes>}} | Supported in v2.20.x. Database performance in this environment varies both due to CIS-hardening and ARM. For more information, contact {{% support-general %}}.|
-| CentOS7          | {{<icon/no>}}  |                | Deprecated in v2.20.0 |
-| Oracle Linux 7   | {{<icon/no>}}  |                | Deprecated in v2.20.0 |
+| CentOS7          | {{<icon/no>}}  |                | Deprecated in v2.20 |
+| Oracle Linux 7   | {{<icon/no>}}  |                | Deprecated in v2.20 |
 | Oracle Linux 8   | {{<icon/yes>}} |                | |
-| Red Hat Enterprise Linux 7 | {{<icon/no>}} |       | Deprecated in v2.20.0 |
+| Red Hat Enterprise Linux 7 | {{<icon/no>}} |       | Deprecated in v2.20 |
 | Red Hat Enterprise Linux 8 | {{<icon/yes>}} |      | Recommended for production |
 | Red Hat Enterprise Linux&nbsp;9.3 | {{<icon/yes>}} |  | v2.20.3 and later.  {{<badge/ea>}} |
 | SUSE&nbsp;Linux&nbsp;Enterprise&nbsp;Server&nbsp;15&nbsp;SP5 | {{<icon/yes>}} |     | {{<badge/ea>}} |
-| Ubuntu 18        | {{<icon/no>}}  | {{<icon/no>}}  | Deprecated in v2.20.0 |
+| Ubuntu 18        | {{<icon/no>}}  | {{<icon/no>}}  | Deprecated in v2.20 |
 | Ubuntu 20        | {{<icon/yes>}} | {{<icon/yes>}} |       |
 | Ubuntu 22        | {{<icon/yes>}} | {{<icon/yes>}} | Supported in v2.18.5, v2.20.1 |

--- a/docs/content/v2.20/reference/configuration/operating-systems.md
+++ b/docs/content/v2.20/reference/configuration/operating-systems.md
@@ -21,15 +21,15 @@ Unless otherwise noted, operating systems are supported by all supported version
 | :--------------- | :------------- | :------------- | :---- |
 | AlmaLinux 8      | {{<icon/yes>}} | {{<icon/yes>}} | Recommended for production<br>Recommended development platform<br>Default for YBA-deployed nodes |
 | AlmaLinux 9      | {{<icon/yes>}} | {{<icon/yes>}} |       |
-| Amazon Linux 2   | {{<icon/partial>}} | {{<icon/partial>}} | v2.18.0 and later<br>Deprecated in v2.20; not supported in v2.21.0.0 release and [upcoming release series](/preview/releases/#upcoming-release-series) |
+| Amazon Linux 2   | {{<icon/partial>}} | {{<icon/partial>}} | v2.18.0 and later<br>Deprecated in v2.20; not supported in v2.21 release and [upcoming release series](/preview/releases/#upcoming-release-series) |
 | Amazon Linux 2<br>(ARM, CIS-hardened) |  | {{<icon/yes>}} | Supported in v2.20.x. Database performance in this environment varies both due to CIS-hardening and ARM. For more information, contact {{% support-general %}}.|
-| CentOS7          | {{<icon/partial>}} |                | Deprecated in v2.20; not supported in v2.21.0.0 release and [upcoming release series](/preview/releases/#upcoming-release-series) |
+| CentOS7          | {{<icon/partial>}} |                | Deprecated in v2.20; not supported in v2.21 and [upcoming release series](/preview/releases/#upcoming-release-series) |
 | Oracle 7         | {{<icon/yes>}} |                | |
 | Oracle 8         | {{<icon/yes>}} |                | |
 | Red Hat Enterprise Linux 7 | {{<icon/yes>}} |      |       |
 | Red Hat Enterprise Linux 8 | {{<icon/yes>}} |      | Recommended for production |
 | Red Hat Enterprise Linux&nbsp;9.3 | {{<icon/yes>}} |  | v2.20.3 and later.  {{<badge/ea>}} |
 | SUSE&nbsp;Linux&nbsp;Enterprise&nbsp;Server&nbsp;15&nbsp;SP5 | {{<icon/yes>}} |     | {{<badge/ea>}} |
-| Ubuntu 18        | {{<icon/partial>}} | {{<icon/partial>}} | Deprecated in v2.20; not supported in v2.21.0.0 release and [upcoming release series](/preview/releases/#upcoming-release-series) |
+| Ubuntu 18        | {{<icon/partial>}} | {{<icon/partial>}} | Deprecated in v2.20; not supported in v2.21 and [upcoming release series](/preview/releases/#upcoming-release-series) |
 | Ubuntu 20        | {{<icon/yes>}} | {{<icon/yes>}} |       |
 | Ubuntu 22        | {{<icon/yes>}} | {{<icon/yes>}} | Supported in v2.18.5, v2.20.1 |

--- a/docs/content/v2.20/reference/configuration/operating-systems.md
+++ b/docs/content/v2.20/reference/configuration/operating-systems.md
@@ -21,15 +21,15 @@ Unless otherwise noted, operating systems are supported by all supported version
 | :--------------- | :------------- | :------------- | :---- |
 | AlmaLinux 8      | {{<icon/yes>}} | {{<icon/yes>}} | Recommended for production<br>Recommended development platform<br>Default for YBA-deployed nodes |
 | AlmaLinux 9      | {{<icon/yes>}} | {{<icon/yes>}} |       |
-| Amazon Linux 2   | {{<icon/partial>}} | {{<icon/partial>}} | v2.18.0 and later<br>Deprecated in v2.20.0; not supported in v2.21.0.0 release and [upcoming release series](/preview/releases/#upcoming-release-series) |
+| Amazon Linux 2   | {{<icon/partial>}} | {{<icon/partial>}} | v2.18.0 and later<br>Deprecated in v2.20; not supported in v2.21.0.0 release and [upcoming release series](/preview/releases/#upcoming-release-series) |
 | Amazon Linux 2<br>(ARM, CIS-hardened) |  | {{<icon/yes>}} | Supported in v2.20.x. Database performance in this environment varies both due to CIS-hardening and ARM. For more information, contact {{% support-general %}}.|
-| CentOS7          | {{<icon/partial>}} |                | Deprecated in v2.20.0; not supported in v2.21.0.0 release and [upcoming release series](/preview/releases/#upcoming-release-series) |
+| CentOS7          | {{<icon/partial>}} |                | Deprecated in v2.20; not supported in v2.21.0.0 release and [upcoming release series](/preview/releases/#upcoming-release-series) |
 | Oracle 7         | {{<icon/yes>}} |                | |
 | Oracle 8         | {{<icon/yes>}} |                | |
 | Red Hat Enterprise Linux 7 | {{<icon/yes>}} |      |       |
 | Red Hat Enterprise Linux 8 | {{<icon/yes>}} |      | Recommended for production |
 | Red Hat Enterprise Linux&nbsp;9.3 | {{<icon/yes>}} |  | v2.20.3 and later.  {{<badge/ea>}} |
 | SUSE&nbsp;Linux&nbsp;Enterprise&nbsp;Server&nbsp;15&nbsp;SP5 | {{<icon/yes>}} |     | {{<badge/ea>}} |
-| Ubuntu 18        | {{<icon/partial>}} | {{<icon/partial>}} | Deprecated in v2.20.0; not supported in v2.21.0.0 release and [upcoming release series](/preview/releases/#upcoming-release-series) |
+| Ubuntu 18        | {{<icon/partial>}} | {{<icon/partial>}} | Deprecated in v2.20; not supported in v2.21.0.0 release and [upcoming release series](/preview/releases/#upcoming-release-series) |
 | Ubuntu 20        | {{<icon/yes>}} | {{<icon/yes>}} |       |
 | Ubuntu 22        | {{<icon/yes>}} | {{<icon/yes>}} | Supported in v2.18.5, v2.20.1 |

--- a/docs/content/v2.20/reference/configuration/operating-systems.md
+++ b/docs/content/v2.20/reference/configuration/operating-systems.md
@@ -21,7 +21,7 @@ Unless otherwise noted, operating systems are supported by all supported version
 | :--------------- | :------------- | :------------- | :---- |
 | AlmaLinux 8      | {{<icon/yes>}} | {{<icon/yes>}} | Recommended for production<br>Recommended development platform<br>Default for YBA-deployed nodes |
 | AlmaLinux 9      | {{<icon/yes>}} | {{<icon/yes>}} |       |
-| Amazon Linux 2   | {{<icon/partial>}} | {{<icon/partial>}} | v2.18.0 and later<br>Deprecated in v2.20; not supported in v2.21 release and [upcoming release series](/preview/releases/#upcoming-release-series) |
+| Amazon Linux 2   | {{<icon/partial>}} | {{<icon/partial>}} | v2.18.0 and later<br>Deprecated in v2.20; not supported in v2.21 and [upcoming release series](/preview/releases/#upcoming-release-series) |
 | Amazon Linux 2<br>(ARM, CIS-hardened) |  | {{<icon/yes>}} | Supported in v2.20.x. Database performance in this environment varies both due to CIS-hardening and ARM. For more information, contact {{% support-general %}}.|
 | CentOS7          | {{<icon/partial>}} |                | Deprecated in v2.20; not supported in v2.21 and [upcoming release series](/preview/releases/#upcoming-release-series) |
 | Oracle 7         | {{<icon/yes>}} |                | |

--- a/docs/content/v2.20/reference/configuration/operating-systems.md
+++ b/docs/content/v2.20/reference/configuration/operating-systems.md
@@ -21,13 +21,15 @@ Unless otherwise noted, operating systems are supported by all supported version
 | :--------------- | :------------- | :------------- | :---- |
 | AlmaLinux 8      | {{<icon/yes>}} | {{<icon/yes>}} | Recommended for production<br>Recommended development platform<br>Default for YBA-deployed nodes |
 | AlmaLinux 9      | {{<icon/yes>}} | {{<icon/yes>}} |       |
-| Amazon Linux 2   | {{<icon/no>}} | {{<icon/no>}} | v2.18.0 and later<br>Deprecated in v2.20.0; not supported in v2.21.0.0 release and [upcoming release series](/preview/releases/#upcoming-release-series) |
-| CentOS7          | {{<icon/no>}} |                | Deprecated in v2.20.0 |
+| Amazon Linux 2   | {{<icon/partial>}} | {{<icon/partial>}} | v2.18.0 and later<br>Deprecated in v2.20.0; not supported in v2.21.0.0 release and [upcoming release series](/preview/releases/#upcoming-release-series) |
+| Amazon Linux 2<br>(ARM, CIS-hardened) |  | {{<icon/yes>}} | Supported in v2.20.x. Database performance in this environment varies both due to CIS-hardening and ARM. For more information, contact {{% support-general %}}.|
+| CentOS7          | {{<icon/partial>}} |                | Deprecated in v2.20.0; not supported in v2.21.0.0 release and [upcoming release series](/preview/releases/#upcoming-release-series) |
 | Oracle 7         | {{<icon/yes>}} |                | |
 | Oracle 8         | {{<icon/yes>}} |                | |
 | Red Hat Enterprise Linux 7 | {{<icon/yes>}} |      |       |
 | Red Hat Enterprise Linux 8 | {{<icon/yes>}} |      | Recommended for production |
-| SUSE Linux Enterprise Server 15 SP5 | {{<icon/yes>}} |     | {{<badge/ea>}} |
-| Ubuntu 18        | {{<icon/no>}} | {{<icon/no>}} | Deprecated in v2.20.0 |
+| Red Hat Enterprise Linux&nbsp;9.3 | {{<icon/yes>}} |  | v2.20.3 and later.  {{<badge/ea>}} |
+| SUSE&nbsp;Linux&nbsp;Enterprise&nbsp;Server&nbsp;15&nbsp;SP5 | {{<icon/yes>}} |     | {{<badge/ea>}} |
+| Ubuntu 18        | {{<icon/partial>}} | {{<icon/partial>}} | Deprecated in v2.20.0; not supported in v2.21.0.0 release and [upcoming release series](/preview/releases/#upcoming-release-series) |
 | Ubuntu 20        | {{<icon/yes>}} | {{<icon/yes>}} |       |
 | Ubuntu 22        | {{<icon/yes>}} | {{<icon/yes>}} | Supported in v2.18.5, v2.20.1 |

--- a/docs/content/v2.20/reference/configuration/operating-systems.md
+++ b/docs/content/v2.20/reference/configuration/operating-systems.md
@@ -27,7 +27,7 @@ Unless otherwise noted, operating systems are supported by all supported version
 | Oracle 8         | {{<icon/yes>}} |                | |
 | Red Hat Enterprise Linux 7 | {{<icon/yes>}} |      |       |
 | Red Hat Enterprise Linux 8 | {{<icon/yes>}} |      | Recommended for production |
-<!-- | Red Hat Enterprise Linux&nbsp;9.3 | {{<icon/yes>}} |  | v2.20.3 and later<br>Recommended for production | -->
+| Red Hat Enterprise Linux&nbsp;9.3 | {{<icon/yes>}} |  | v2.20.3 and later.  {{<badge/ea>}} |
 | SUSE Linux Enterprise Server 15 SP5 | {{<icon/yes>}} |     | {{<badge/ea>}} |
 | Ubuntu 18        | {{<icon/yes>}} | {{<icon/yes>}} | Deprecated in v2.20.0 |
 | Ubuntu 20        | {{<icon/yes>}} | {{<icon/yes>}} |       |

--- a/docs/content/v2.20/reference/configuration/operating-systems.md
+++ b/docs/content/v2.20/reference/configuration/operating-systems.md
@@ -21,15 +21,13 @@ Unless otherwise noted, operating systems are supported by all supported version
 | :--------------- | :------------- | :------------- | :---- |
 | AlmaLinux 8      | {{<icon/yes>}} | {{<icon/yes>}} | Recommended for production<br>Recommended development platform<br>Default for YBA-deployed nodes |
 | AlmaLinux 9      | {{<icon/yes>}} | {{<icon/yes>}} |       |
-| Amazon Linux 2   | {{<icon/yes>}} | {{<icon/yes>}} | v2.18.0 and later<br>Deprecated in v2.20.0 |
-| Amazon Linux 2 (ARM, CIS-hardened) | {{<icon/no>}} | {{<icon/yes>}} | Supported in v2.20.x. Database performance in this environment varies both due to CIS-hardening and ARM. For more information, contact {{% support-general %}}.|
-| CentOS7          | {{<icon/yes>}} |                | Deprecated in v2.20.0 |
+| Amazon Linux 2   | {{<icon/no>}} | {{<icon/no>}} | v2.18.0 and later<br>Deprecated in v2.20.0; not supported in v2.21.0.0 release and [upcoming release series](/preview/releases/#upcoming-release-series) |
+| CentOS7          | {{<icon/no>}} |                | Deprecated in v2.20.0 |
 | Oracle 7         | {{<icon/yes>}} |                | |
 | Oracle 8         | {{<icon/yes>}} |                | |
 | Red Hat Enterprise Linux 7 | {{<icon/yes>}} |      |       |
 | Red Hat Enterprise Linux 8 | {{<icon/yes>}} |      | Recommended for production |
-| Red Hat Enterprise Linux&nbsp;9.3 | {{<icon/yes>}} |  | v2.20.3 and later.  {{<badge/ea>}} |
 | SUSE Linux Enterprise Server 15 SP5 | {{<icon/yes>}} |     | {{<badge/ea>}} |
-| Ubuntu 18        | {{<icon/yes>}} | {{<icon/yes>}} | Deprecated in v2.20.0 |
+| Ubuntu 18        | {{<icon/no>}} | {{<icon/no>}} | Deprecated in v2.20.0 |
 | Ubuntu 20        | {{<icon/yes>}} | {{<icon/yes>}} |       |
 | Ubuntu 22        | {{<icon/yes>}} | {{<icon/yes>}} | Supported in v2.18.5, v2.20.1 |

--- a/docs/content/v2.20/reference/configuration/operating-systems.md
+++ b/docs/content/v2.20/reference/configuration/operating-systems.md
@@ -22,6 +22,7 @@ Unless otherwise noted, operating systems are supported by all supported version
 | AlmaLinux 8      | {{<icon/yes>}} | {{<icon/yes>}} | Recommended for production<br>Recommended development platform<br>Default for YBA-deployed nodes |
 | AlmaLinux 9      | {{<icon/yes>}} | {{<icon/yes>}} |       |
 | Amazon Linux 2   | {{<icon/yes>}} | {{<icon/yes>}} | v2.18.0 and later<br>Deprecated in v2.20.0 |
+| Amazon Linux 2 (ARM, CIS-hardened) | {{<icon/no>}} | {{<icon/yes>}} | Supported in v2.20.x. Database performance in this environment varies both due to CIS-hardening and ARM. For more information, contact {{% support-general %}}.|
 | CentOS7          | {{<icon/yes>}} |                | Deprecated in v2.20.0 |
 | Oracle 7         | {{<icon/yes>}} |                | |
 | Oracle 8         | {{<icon/yes>}} |                | |


### PR DESCRIPTION
Slack threads:
- Formatting issue - https://yugabyte.slack.com/archives/CDQB8MEAU/p1717726111046699
- https://docs.yugabyte.com/preview/reference/configuration/operating-systems/
For "Ubuntu 18" it is mentioned as "Deprecated in v2.20.0; not supported in v2.21.0.0 release and [upcoming release series](https://docs.yugabyte.com/preview/releases/#upcoming-release-series)", but why are we still listing it with a green tick mark in 2.21 doc section when it is not supported? Same for Red Hat Enterprise Linux 7, Oracle Linux 7, CentOS7, Amazon Linux2 - https://yugabyte.slack.com/archives/CDQB8MEAU/p1717726701546229

On release notes page- https://yugabyte.slack.com/archives/C04RTHBC1M2/p1717712767125199