### PR TITLE
Support IPV6  hosts in yugabyted

### DIFF
--- a/bin/yugabyted
+++ b/bin/yugabyted
@@ -2063,11 +2063,6 @@ class ControlScript(object):
                 mandatory_port_available, recommended_port_available)
 
     def is_port_available(self, advertise_ip, port):
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        try:
-            return s.connect_ex((advertise_ip, int(port))) != 0
-        finally:
-            s.close()
         addr_info = socket.getaddrinfo(advertise_ip, port, socket.AF_UNSPEC, socket.SOCK_STREAM)
         for family, socktype, proto, canonname, sockaddr in addr_info:
             try:

--- a/bin/yugabyted
+++ b/bin/yugabyted
@@ -2068,6 +2068,17 @@ class ControlScript(object):
             return s.connect_ex((advertise_ip, int(port))) != 0
         finally:
             s.close()
+        addr_info = socket.getaddrinfo(advertise_ip, port, socket.AF_UNSPEC, socket.SOCK_STREAM)
+        for family, socktype, proto, canonname, sockaddr in addr_info:
+            try:
+                s = socket.socket(family, socktype, proto)
+                try:
+                    return s.connect_ex(sockaddr) != 0
+                finally:
+                    s.close()
+            except OSError:
+                continue
+        return False
 
     def get_mandatory_ports(self):
         mandatory_ports = []


### PR DESCRIPTION
Prior to this change, IPV6 advertise hosts would fail because the `is_port_available` check assumed IPV4