### PR TITLE
[docs] Add ysql_output_buffer_size to yb-tserver config reference.

### DIFF
--- a/docs/content/preview/reference/configuration/yb-tserver.md
+++ b/docs/content/preview/reference/configuration/yb-tserver.md
@@ -855,6 +855,14 @@ Default: `-1` (disables logging statement durations)
 
 Specifies the lowest YSQL message level to log.
 
+##### --ysql_output_buffer_size
+
+Size of YSQL layer output buffer, in bytes. YSQL buffers query responses in this output buffer until either a buffer flush is requested by the client or the buffer overflows.
+
+As long as no data has been flushed from the buffer, the database can retry queries on retryable errors. For example, you can increase the size of the buffer so that YSQL can retry [read restart errors](../../../architecture/transactions/read-restart-error).
+
+Default: `262144` (256kB, type: int32)
+
 ### YCQL
 
 The following flags support the use of the [YCQL API](../../../api/ycql/):

--- a/docs/content/stable/reference/configuration/yb-tserver.md
+++ b/docs/content/stable/reference/configuration/yb-tserver.md
@@ -855,6 +855,14 @@ Default: `-1` (disables logging statement durations)
 
 Specifies the lowest YSQL message level to log.
 
+##### --ysql_output_buffer_size
+
+Size of YSQL layer output buffer, in bytes. YSQL buffers query responses in this output buffer until either a buffer flush is requested by the client or the buffer overflows.
+
+As long as no data has been flushed from the buffer, the database can retry queries on retryable errors. For example, you can increase the size of the buffer so that YSQL can retry [read restart errors](../../../architecture/transactions/read-restart-error).
+
+Default: `262144` (256kB, type: int32)
+
 ### YCQL
 
 The following flags support the use of the [YCQL API](../../../api/ycql/):

--- a/docs/content/v2.20/reference/configuration/yb-tserver.md
+++ b/docs/content/v2.20/reference/configuration/yb-tserver.md
@@ -732,6 +732,14 @@ Default: `-1` (disables logging statement durations)
 
 Specifies the lowest YSQL message level to log.
 
+##### --ysql_output_buffer_size
+
+Size of YSQL layer output buffer, in bytes. YSQL buffers query responses in this output buffer until either a buffer flush is requested by the client or the buffer overflows.
+
+As long as no data has been flushed from the buffer, the database can retry queries on retryable errors. For example, you can increase the size of the buffer so that YSQL can retry [read restart errors](../../../architecture/transactions/read-restart-error).
+
+Default: `262144` (256kB, type: int32)
+
 ### YCQL
 
 The following flags support the use of the [YCQL API](../../../api/ycql/):


### PR DESCRIPTION
@netlify preview/reference/configuration/yb-tserver/

Resolves #23232