### PR TITLE
New Tutorial for Elixir Using Phoenix Framework

### DIFF
--- a/docs/content/preview/drivers-orms/_index.md
+++ b/docs/content/preview/drivers-orms/_index.md
@@ -55,7 +55,7 @@ In addition to the compatible upstream PostgreSQL (YSQL) and Cassandra (YCQL) dr
 
   <li>
     <a href="elixir/" class="orange">
-      <i class="fa-brands fa-node-js"></i>
+      <i class="fa-classic fa-droplet"></i>
       Elixir
     </a>
   </li>

--- a/docs/content/preview/drivers-orms/_index.md
+++ b/docs/content/preview/drivers-orms/_index.md
@@ -54,6 +54,13 @@ In addition to the compatible upstream PostgreSQL (YSQL) and Cassandra (YCQL) dr
   </li>
 
   <li>
+    <a href="elixir/" class="orange">
+      <i class="fa-brands fa-node-js"></i>
+      Elixir
+    </a>
+  </li>
+
+  <li>
     <a href="c/" class="orange">
       <i class="icon-c"></i>
       C

--- a/docs/content/preview/drivers-orms/c/_index.md
+++ b/docs/content/preview/drivers-orms/c/_index.md
@@ -8,7 +8,7 @@ menu:
   preview:
     identifier: c-drivers
     parent: drivers-orms
-    weight: 540
+    weight: 550
 type: indexpage
 showRightNav: true
 ---

--- a/docs/content/preview/drivers-orms/c/_index.md
+++ b/docs/content/preview/drivers-orms/c/_index.md
@@ -3,7 +3,7 @@ title: Build applications with C Drivers and ORMs
 headerTitle: C
 linkTitle: C
 description: C Drivers and ORMs support for YugabyteDB.
-image: /images/section_icons/sample-data/s_s1-sampledata-3x.png
+image: fa-classic fa-c
 menu:
   preview:
     identifier: c-drivers

--- a/docs/content/preview/drivers-orms/cpp/_index.md
+++ b/docs/content/preview/drivers-orms/cpp/_index.md
@@ -3,7 +3,7 @@ title: Build apps with C++ Drivers and ORMs
 headerTitle: C++
 linkTitle: C++
 description: C++ Drivers and ORMs support for YugabyteDB.
-image: /images/section_icons/sample-data/s_s1-sampledata-3x.png
+image: fa-classic fa-plus
 menu:
   preview:
     identifier: cpp-drivers

--- a/docs/content/preview/drivers-orms/cpp/_index.md
+++ b/docs/content/preview/drivers-orms/cpp/_index.md
@@ -8,7 +8,7 @@ menu:
   preview:
     identifier: cpp-drivers
     parent: drivers-orms
-    weight: 550
+    weight: 560
 type: indexpage
 showRightNav: true
 ---

--- a/docs/content/preview/drivers-orms/csharp/_index.md
+++ b/docs/content/preview/drivers-orms/csharp/_index.md
@@ -3,7 +3,7 @@ title: Build apps using C# drivers and ORMs
 headerTitle: C#
 linkTitle: C#
 description: C# Drivers and ORMs support for YugabyteDB.
-image: /images/section_icons/sample-data/s_s1-sampledata-3x.png
+image: fa-classic fa-hashtag
 aliases:
   - /preview/develop/client-drivers/csharp/
 menu:

--- a/docs/content/preview/drivers-orms/csharp/_index.md
+++ b/docs/content/preview/drivers-orms/csharp/_index.md
@@ -10,7 +10,7 @@ menu:
   preview:
     identifier: csharp-drivers
     parent: drivers-orms
-    weight: 560
+    weight: 570
 type: indexpage
 showRightNav: true
 ---

--- a/docs/content/preview/drivers-orms/elixir/_index.md
+++ b/docs/content/preview/drivers-orms/elixir/_index.md
@@ -1,0 +1,40 @@
+---
+title: Elixir drivers and ORMs
+headerTitle: Elixir
+linkTitle: Elixir
+description: Elixir Drivers and ORMs support for YugabyteDB.
+image: /images/section_icons/sample-data/s_s1-sampledata-3x.png
+menu:
+  preview:
+    identifier: elixir-drivers
+    parent: drivers-orms
+    weight: 540
+type: indexpage
+showRightNav: true
+---
+
+## Supported projects
+
+The following projects can be used to implement Elixir applications using the YugabyteDB YSQL APIs.
+
+| Project | Documentation and Guides | Latest Driver Version | Supported YugabyteDB Version |
+| ------- | ------------------------ | ------------------------ | ---------------------|
+| Postgrex Driver | [Documentation](../../tutorials/build-apps/elixir/cloud-ysql-elixir/) | [v0.18.0](https://github.com/elixir-ecto/postgrex) | |
+| Phoenix Framework | [Documentation](phoenix/) | [1.7.14](https://www.phoenixframework.org) | |
+
+Learn how to establish a connection to a YugabyteDB database and begin basic CRUD operations by referring to a [sample Elixir app using Postgrex](../../tutorials/build-apps/elixir/cloud-ysql-elixir/) or building an app using [Phoenix framework](phoenix/).
+
+## Prerequisites
+
+To develop Elixir applications for YugabyteDB, you need the following:
+
+- **Elixir**\
+  Install the latest versions of [Elixir, Erlang VM, IEx and Mix](https://elixir-lang.org/docs.html) (tested with Elixir 1.17.1 and Erlang/OTP 26 erts-14.2.5).
+
+- **YugabyteDB cluster**
+  - Create a free cluster on YugabyteDB Aeon. Refer to [Use a cloud cluster](../../quick-start-yugabytedb-managed/). Note that YugabyteDB Aeon requires SSL.
+  - Alternatively, set up a standalone YugabyteDB cluster by following the steps in [Install YugabyteDB](../../quick-start/).
+
+## Next step
+
+- [Simple app using Phoenix framework](phoenix/)

--- a/docs/content/preview/drivers-orms/elixir/_index.md
+++ b/docs/content/preview/drivers-orms/elixir/_index.md
@@ -19,10 +19,10 @@ The following projects can be used to implement Elixir applications using the Yu
 
 | Project | Documentation and Guides | Latest Driver Version | Supported YugabyteDB Version |
 | ------- | ------------------------ | ------------------------ | ---------------------|
-| Postgrex Driver | [Documentation](../../tutorials/build-apps/elixir/cloud-ysql-elixir/) | [v0.18.0](https://github.com/elixir-ecto/postgrex) | |
+| Postgrex Driver | [Documentation](/preview/tutorials/build-apps/elixir/cloud-ysql-elixir/) | [v0.18.0](https://github.com/elixir-ecto/postgrex) | |
 | Phoenix Framework | [Documentation](phoenix/) | [1.7.14](https://www.phoenixframework.org) | |
 
-Learn how to establish a connection to a YugabyteDB database and begin basic CRUD operations by referring to a [sample Elixir app using Postgrex](../../tutorials/build-apps/elixir/cloud-ysql-elixir/) or building an app using [Phoenix framework](phoenix/).
+Learn how to establish a connection to a YugabyteDB database and begin basic CRUD operations by referring to a [sample Elixir app using Postgrex](/preview/tutorials/build-apps/elixir/cloud-ysql-elixir/) or building an app using [Phoenix framework](phoenix/).
 
 ## Prerequisites
 

--- a/docs/content/preview/drivers-orms/elixir/_index.md
+++ b/docs/content/preview/drivers-orms/elixir/_index.md
@@ -3,7 +3,7 @@ title: Elixir drivers and ORMs
 headerTitle: Elixir
 linkTitle: Elixir
 description: Elixir Drivers and ORMs support for YugabyteDB.
-image: /images/section_icons/sample-data/s_s1-sampledata-3x.png
+image: fa-classic fa-droplet
 menu:
   preview:
     identifier: elixir-drivers
@@ -37,4 +37,4 @@ To develop Elixir applications for YugabyteDB, you need the following:
 
 ## Next step
 
-- [Simple app using Phoenix framework](phoenix/)
+- [Basic application using Phoenix framework](phoenix/)

--- a/docs/content/preview/drivers-orms/elixir/phoenix.md
+++ b/docs/content/preview/drivers-orms/elixir/phoenix.md
@@ -22,19 +22,19 @@ type: docs
 
 The following tutorial shows how to implement an Elixir app using the Phoenix framework with the Ecto ORM. The app connects to a YugabyteDB cluster, creates a sample table, populates it with a few records, and changes data transactionally.
 
-The source for the application can be found in the [following repository](https://github.com/YugabyteDB-Samples/yugabytedb-simple-elixir-app/tree/main/phoenix/simple_app).
+The source for the application can be found in the [yugabytedb-simple-elixir-app](https://github.com/YugabyteDB-Samples/yugabytedb-simple-elixir-app/tree/main/phoenix/simple_app) repository.
 
 ## Prerequisites
 
 This tutorial assumes that you have:
 
-- YugabyteDB up and running. Download and install YugabyteDB by following the steps in [Quick start](../../../../quick-start/).
+- YugabyteDB up and running. Download and install YugabyteDB by following the steps in [Quick start](../../../quick-start/).
 
 - The latest versions of [Elixir, Erlang VM, IEx and Mix](https://elixir-lang.org/docs.html) (tested with Elixir 1.17.1 and Erlang/OTP 26 erts-14.2.5).
 
-## Create Phoenix Project
+## Create Phoenix project
 
-In this section you create a Phoenix project and configure it working with an existing YugabyteDB cluster.
+In this section you create a Phoenix project and configure it to work with an existing YugabyteDB cluster.
 
 First, use the `mix` tool to create a project template and pull all required dependencies:
 
@@ -64,7 +64,7 @@ config :sample_yugabytedb_phoenix_app, SampleYugabytedbPhoenixApp.Repo,
   pool_size: 10
 ```
 
-As YugabyteDB is built on PostgreSQL, you only need to update the configuration settings above. Both Ecto and the underlying Postgrex driver will work with YugabyteDB as they do with vanilla PostgreSQL.
+As YugabyteDB is built on PostgreSQL, you only need to update the `config` settings. Both Ecto and the underlying Postgrex driver will work with YugabyteDB as they do with vanilla PostgreSQL.
 
 Assuming that your YugabyteDB cluster is running locally, do the following:
 
@@ -84,7 +84,7 @@ Assuming that your YugabyteDB cluster is running locally, do the following:
     pool_size: 10
     ```
 
-- Add the `migration_lock: false` setting to the database configuration. Ecto acquires exclusive table locks while running database migrations, but this type of lock is not supported by YugabyteDB yet. Track the [following GitHub ticket](https://github.com/yugabyte/yugabyte-db/issues/5384) to understand details and get updates.
+- Add the `migration_lock: false` setting to the database configuration. Ecto acquires exclusive table locks while running database migrations, but this type of lock is not currently supported by YugabyteDB. Track [GitHub issue 5384](https://github.com/yugabyte/yugabyte-db/issues/5384) to understand details and get updates.
 
     ```elixir
     config :sample_yugabytedb_phoenix_app, SampleYugabytedbPhoenixApp.Repo,
@@ -107,7 +107,7 @@ Generated sample_yugabytedb_phoenix_app app
 The database for SampleYugabytedbPhoenixApp.Repo has already been created
 ```
 
-## Generate Sample Schema
+## Generate sample schema
 
 In this section, you use Phoenix and Ecto to generate a sample database schema for the `Account` entity and to apply database migrations.
 
@@ -169,11 +169,11 @@ yugabyte=# \d
 (3 rows)
 ```
 
-## Persist and Query Data
+## Persist and query data
 
 In this final section, you use Phoenix APIs and the IEx interactive shell to persist and query data in YugabyteDB.
 
-- Start a IEx session in your terminal:
+- Start an IEx session in your terminal:
 
     ```shell
     iex -S mix
@@ -225,10 +225,13 @@ In this final section, you use Phoenix APIs and the IEx interactive shell to per
     ]
     ```
 
-Note, that the `id` of the `Mary Black` account is `101` and not `2`. This happens because sequences in YugabyteDB cache `100` ids by default per connection. It means that records were inserted into the database using different database connections.
+Note that the `id` of the `Mary Black` account is `101` and not `2`. This happens because sequences in YugabyteDB cache `100` IDs per connection by default. This means that records were inserted into the database using different database connections.
 
 ```sql
 yugabyte=# \d account_id_seq
+```
+
+```output
                        Sequence "public.account_id_seq"
   Type  | Start | Minimum |       Maximum       | Increment | Cycles? | Cache
 --------+-------+---------+---------------------+-----------+---------+-------
@@ -236,7 +239,7 @@ yugabyte=# \d account_id_seq
 Owned by: public.account.id
 ```
 
-Refer to the [following blog post](https://www.yugabyte.com/blog/create-database-sequences/) for details on how sequences work in YugabyteDB and how to scale them.
+For details on how sequences work in YugabyteDB and how to scale them, refer to the [Scaling Sequences with Server-Level Caching in YugabyteDB](https://www.yugabyte.com/blog/create-database-sequences/).
 
 Finally, use the `Ecto.Query` interface to query specific data:
 
@@ -257,8 +260,8 @@ Congratulations! You've successfully completed the tutorial.
 
 Now, explore the [final version of the application](https://github.com/YugabyteDB-Samples/yugabytedb-simple-elixir-app/tree/main/phoenix/simple_app) to see how work with YugabyteDB using the same APIs but programmatically.
 
-## Next Steps
+## Next steps
 
 - [Watch](https://www.youtube.com/live/_utOXl3eWoA?feature=shared) Chris McCord, the creator of the Phoenix framework, joining YugabyteDB Community Open Hours and demonstrating how to build multi-region applications using Phoenix, Fly.io and YugabyteDB.
 
-- Create a [sample Elixir app](../../tutorials/build-apps/elixir/cloud-ysql-elixir/) using the Postgrex driver.
+- Create a [sample Elixir app](../../../tutorials/build-apps/elixir/cloud-ysql-elixir/) using the Postgrex driver.

--- a/docs/content/preview/drivers-orms/elixir/phoenix.md
+++ b/docs/content/preview/drivers-orms/elixir/phoenix.md
@@ -264,4 +264,4 @@ Now, explore the [final version of the application](https://github.com/YugabyteD
 
 - [Watch](https://www.youtube.com/live/_utOXl3eWoA?feature=shared) Chris McCord, the creator of the Phoenix framework, joining YugabyteDB Community Open Hours and demonstrating how to build multi-region applications using Phoenix, Fly.io and YugabyteDB.
 
-- Create a [sample Elixir app](../../../tutorials/build-apps/elixir/cloud-ysql-elixir/) using the Postgrex driver.
+- Create a [sample Elixir app](/preview/tutorials/build-apps/elixir/cloud-ysql-elixir/) using the Postgrex driver.

--- a/docs/content/preview/drivers-orms/elixir/phoenix.md
+++ b/docs/content/preview/drivers-orms/elixir/phoenix.md
@@ -1,0 +1,264 @@
+---
+title: Elixir application that uses Phoenix, Ecto and YSQL
+headerTitle: Phoenix Example Application
+linkTitle: Phoenix
+description: Elixir application that uses Phoenix, Ecto and YSQL
+menu:
+  preview:
+    identifier: elixir-phoenix
+    parent: elixir-drivers
+    weight: 550
+type: docs
+---
+
+<ul class="nav nav-tabs-alt nav-tabs-yb">
+  <li >
+    <a href="../elixir/phoenix" class="nav-link active">
+      <i class="icon-postgres" aria-hidden="true"></i>
+      Phoenix/Ecto
+    </a>
+  </li>
+</ul>
+
+The following tutorial shows how to implement an Elixir app using the Phoenix framework with the Ecto ORM. The app connects to a YugabyteDB cluster, creates a sample table, populates it with a few records, and changes data transactionally.
+
+The source for the application can be found in the [following repository](https://github.com/YugabyteDB-Samples/yugabytedb-simple-elixir-app/tree/main/phoenix/simple_app).
+
+## Prerequisites
+
+This tutorial assumes that you have:
+
+- YugabyteDB up and running. Download and install YugabyteDB by following the steps in [Quick start](../../../../quick-start/).
+
+- The latest versions of [Elixir, Erlang VM, IEx and Mix](https://elixir-lang.org/docs.html) (tested with Elixir 1.17.1 and Erlang/OTP 26 erts-14.2.5).
+
+## Create Phoenix Project
+
+In this section you create a Phoenix project and configure it working with an existing YugabyteDB cluster.
+
+First, use the `mix` tool to create a project template and pull all required dependencies:
+
+- Generate the project template and navigate to its root folder:
+
+    ```shell
+    mix phx.new sample_yugabytedb_phoenix_app && cd sample_yugabytedb_phoenix_app
+    ```
+
+- Pull the required dependencies, unless you've already done this during the project generation:
+
+    ```shell
+    mix deps.get
+    ```
+
+Phoenix uses PostgreSQL as a default database option. Open the `config/dev.exs` file to confirm that the Ecto ORM is configured to work PostgreSQL:
+
+```elixir
+# Configure your database
+config :sample_yugabytedb_phoenix_app, SampleYugabytedbPhoenixApp.Repo,
+  username: "postgres",
+  password: "postgres",
+  hostname: "localhost",
+  database: "sample_yugabytedb_phoenix_app_dev",
+  stacktrace: true,
+  show_sensitive_data_on_connection_error: true,
+  pool_size: 10
+```
+
+As YugabyteDB is built on PostgreSQL, you only need to update the configuration settings above. Both Ecto and the underlying Postgrex driver will work with YugabyteDB as they do with vanilla PostgreSQL.
+
+Assuming that your YugabyteDB cluster is running locally, do the following:
+
+- Open the `config/dev.exs` file
+
+- Update the database settings to the following:
+
+    ```elixir
+    config :sample_yugabytedb_phoenix_app, SampleYugabytedbPhoenixApp.Repo,
+    username: "yugabyte",
+    password: "yugabyte",
+    hostname: "localhost",
+    port: 5433,
+    database: "yugabyte",
+    stacktrace: true,
+    show_sensitive_data_on_connection_error: true,
+    pool_size: 10
+    ```
+
+- Add the `migration_lock: false` setting to the database configuration. Ecto acquires exclusive table locks while running database migrations, but this type of lock is not supported by YugabyteDB yet. Track the [following GitHub ticket](https://github.com/yugabyte/yugabyte-db/issues/5384) to understand details and get updates.
+
+    ```elixir
+    config :sample_yugabytedb_phoenix_app, SampleYugabytedbPhoenixApp.Repo,
+    <!-- other database specific settings -->
+    pool_size: 10,
+    migration_lock: false
+    ```
+
+- Have Ecto connecting to YugabyteDB to complete and confirm the configuration settings:
+
+    ```shell
+    mix ecto.create
+    ```
+
+The output should be as follows:
+
+```output
+Compiling 15 files (.ex)
+Generated sample_yugabytedb_phoenix_app app
+The database for SampleYugabytedbPhoenixApp.Repo has already been created
+```
+
+## Generate Sample Schema
+
+In this section, you use Phoenix and Ecto to generate a sample database schema for the `Account` entity and to apply database migrations.
+
+- Generate the schema for the `Account` entity. Note, the `id` field of the `bigint` type will be added to the generated table automatically:
+
+    ```shell
+    mix phx.gen.schema Account account name:string balance:decimal
+    ```
+
+- Open the `lib/sample_yugabytedb_phoenix_app/account.ex` to see the generated Ecto schema:
+
+    ```elixir
+    defmodule SampleYugabytedbPhoenixApp.Account do
+    use Ecto.Schema
+    import Ecto.Changeset
+
+    schema "account" do
+        field :name, :string
+        field :balance, :decimal
+
+        timestamps(type: :utc_datetime)
+    end
+
+    <!-- other logic -->
+
+    end
+    ```
+
+- Run the database migration file that was also generated automatically and placed under the `priv/repo/migrations` directory:
+
+    ```shell
+    mix ecto.migrate
+    ```
+
+    The output should be as follows:
+
+    ```output
+    Compiling 1 file (.ex)
+
+    Generated sample_yugabytedb_phoenix_app app
+
+    10:58:16.251 [info] == Running 20240725145331 SampleYugabytedbPhoenixApp.Repo.Migrations.CreateAccount.change/0 forward
+
+    10:58:16.252 [info] create table account
+
+    10:58:16.443 [info] == Migrated 20240725145331 in 0.1s
+    ```
+
+Next, connect to your YugabyteDB cluster using psql, ysqlsh, or another SQL tool to confirm the tables were successfully created:
+
+```sql
+yugabyte=# \d
+                List of relations
+ Schema |       Name        |   Type   |  Owner
+--------+-------------------+----------+----------
+ public | account           | table    | yugabyte
+ public | account_id_seq    | sequence | yugabyte
+ public | schema_migrations | table    | yugabyte
+(3 rows)
+```
+
+## Persist and Query Data
+
+In this final section, you use Phoenix APIs and the IEx interactive shell to persist and query data in YugabyteDB.
+
+- Start a IEx session in your terminal:
+
+    ```shell
+    iex -S mix
+    ```
+
+- Create aliases for the `Repo` and `Account` modules:
+
+    ```elixir
+    alias SampleYugabytedbPhoenixApp.{Repo, Account}
+    ```
+
+- Insert two user accounts into the database:
+
+    ```elixir
+    Repo.insert(%Account{name: "John Smith", balance: 1000})
+    Repo.insert(%Account{name: "Mary Black", balance: 1500})
+    ```
+
+- Fetch the accounts from the database:
+
+    ```elixir
+    Repo.all(Account)
+    ```
+
+    The output should be as follows:
+
+    ```elixir
+    [debug] QUERY OK source="account" db=25.7ms queue=47.5ms idle=1922.1ms
+
+    SELECT a0."id", a0."name", a0."balance", a0."inserted_at", a0."updated_at" FROM "account" AS a0 []
+    ↳ :elixir.eval_external_handler/3, at: src/elixir.erl:386
+    [
+    %SampleYugabytedbPhoenixApp.Account{
+        __meta__: #Ecto.Schema.Metadata<:loaded, "account">,
+        id: 101,
+        name: "Mary Black",
+        balance: Decimal.new("1500"),
+        inserted_at: ~U[2024-07-25 15:11:12Z],
+        updated_at: ~U[2024-07-25 15:11:12Z]
+    },
+    %SampleYugabytedbPhoenixApp.Account{
+        __meta__: #Ecto.Schema.Metadata<:loaded, "account">,
+        id: 1,
+        name: "John Smith",
+        balance: Decimal.new("1000"),
+        inserted_at: ~U[2024-07-25 15:11:12Z],
+        updated_at: ~U[2024-07-25 15:11:12Z]
+    }
+    ]
+    ```
+
+Note, that the `id` of the `Mary Black` account is `101` and not `2`. This happens because sequences in YugabyteDB cache `100` ids by default per connection. It means that records were inserted into the database using different database connections.
+
+```sql
+yugabyte=# \d account_id_seq
+                       Sequence "public.account_id_seq"
+  Type  | Start | Minimum |       Maximum       | Increment | Cycles? | Cache
+--------+-------+---------+---------------------+-----------+---------+-------
+ bigint |     1 |       1 | 9223372036854775807 |         1 | no      |   100
+Owned by: public.account.id
+```
+
+Refer to the [following blog post](https://www.yugabyte.com/blog/create-database-sequences/) for details on how sequences work in YugabyteDB and how to scale them.
+
+Finally, use the `Ecto.Query` interface to query specific data:
+
+```elixir
+import Ecto.Query
+
+Repo.all(from a in Account, where: a.balance >= 1100,
+    select: %{a.name => a.balance})
+```
+
+The output should be as follows:
+
+```elixir
+[%{"Mary Black" => Decimal.new("1500")}]
+```
+
+Congratulations! You've successfully completed the tutorial.
+
+Now, explore the [final version of the application](https://github.com/YugabyteDB-Samples/yugabytedb-simple-elixir-app/tree/main/phoenix/simple_app) to see how work with YugabyteDB using the same APIs but programmatically.
+
+## Next Steps
+
+- [Watch](https://www.youtube.com/live/_utOXl3eWoA?feature=shared) Chris McCord, the creator of the Phoenix framework, joining YugabyteDB Community Open Hours and demonstrating how to build multi-region applications using Phoenix, Fly.io and YugabyteDB.
+
+- Create a [sample Elixir app](../../tutorials/build-apps/elixir/cloud-ysql-elixir/) using the Postgrex driver.

--- a/docs/content/preview/drivers-orms/go/_index.md
+++ b/docs/content/preview/drivers-orms/go/_index.md
@@ -3,7 +3,7 @@ title: Go drivers and ORMs
 headerTitle: Go
 linkTitle: Go
 description: Go Drivers and ORMs support for YugabyteDB.
-image: /images/section_icons/sample-data/s_s1-sampledata-3x.png
+image: fa-brands fa-golang
 menu:
   preview:
     identifier: go-drivers

--- a/docs/content/preview/drivers-orms/include-drivers-orms-list.md
+++ b/docs/content/preview/drivers-orms/include-drivers-orms-list.md
@@ -72,7 +72,7 @@ private = true
 
   {{% /tab %}}
 
-    {{% tab header="Elixir" lang="elixir" %}}
+  {{% tab header="Elixir" lang="elixir" %}}
 
 |            | Version | Support Level | Example apps |
 | :--------- | :------ | :------------ | :----------- |

--- a/docs/content/preview/drivers-orms/include-drivers-orms-list.md
+++ b/docs/content/preview/drivers-orms/include-drivers-orms-list.md
@@ -72,6 +72,17 @@ private = true
 
   {{% /tab %}}
 
+    {{% tab header="Elixir" lang="elixir" %}}
+
+|            | Version | Support Level | Example apps |
+| :--------- | :------ | :------------ | :----------- |
+| **Drivers** | | | |
+| Postgrex Driver | [0.18.0](https://github.com/elixir-ecto/postgrex) | Full | [CRUD](/preview/tutorials/build-apps/elixir/cloud-ysql-elixir/) |
+| **ORMs** | | | |
+| Phoenix with Ecto | [1.7.14](https://www.phoenixframework.org) | Full | [CRUD](/preview/drivers-orms/elixir/phoenix/) |
+
+  {{% /tab %}}
+
   {{% tab header="C" lang="c" %}}
 
 | Driver        | Version | Support Level | Example apps |

--- a/docs/content/preview/drivers-orms/java/_index.md
+++ b/docs/content/preview/drivers-orms/java/_index.md
@@ -3,7 +3,7 @@ title: Java drivers, ORMs, and frameworks
 headerTitle: Java
 linkTitle: Java
 description: Java drivers and ORMs support for YugabyteDB.
-image: /images/section_icons/sample-data/s_s1-sampledata-3x.png
+image: fa-brands fa-java
 aliases:
   - /preview/integrations/jdbc-drivers/
 menu:
@@ -21,20 +21,20 @@ The following projects can be used to implement Java applications using the Yuga
 
 | Driver | Documentation and Guides | Latest Driver Version | Supported YugabyteDB Version |
 | ------- | ------------------------ | ------------------------ | ---------------------|
-| YugabyteDB JDBC Driver [Recommended] | [Documentation](yugabyte-jdbc/)<br />[Blog](https://dev.to/yugabyte/yugabytedb-jdbc-smart-driver-for-proxyless-halb-2k8a/)<br />[Reference](../../reference/drivers/java/yugabyte-jdbc-reference/) | [42.3.5-yb-5](https://mvnrepository.com/artifact/com.yugabyte/jdbc-yugabytedb/42.3.5-yb-5) | 2.8 and above
-| YugabyteDB R2DBC Driver | [Documentation](yb-r2dbc/) | [1.1.0-yb-1-ea](https://mvnrepository.com/artifact/com.yugabyte/r2dbc-postgresql) | 2.18 and above
-| PostgreSQL JDBC Driver | [Documentation](postgres-jdbc/)<br /> [Reference](../../reference/drivers/java/postgres-jdbc-reference/) | [42.3.4](https://mvnrepository.com/artifact/org.postgresql/postgresql/42.3.4) | 2.4 and above
+| YugabyteDB JDBC Driver [Recommended] | [Documentation](yugabyte-jdbc/)<br />[Blog](https://dev.to/yugabyte/yugabytedb-jdbc-smart-driver-for-proxyless-halb-2k8a/)<br />[Reference](../../reference/drivers/java/yugabyte-jdbc-reference/) | [42.3.5-yb-5](https://mvnrepository.com/artifact/com.yugabyte/jdbc-yugabytedb/42.3.5-yb-5) | 2.8 and above |
+| YugabyteDB R2DBC Driver | [Documentation](yb-r2dbc/) | [1.1.0-yb-1-ea](https://mvnrepository.com/artifact/com.yugabyte/r2dbc-postgresql) | 2.18 and above |
+| PostgreSQL JDBC Driver | [Documentation](postgres-jdbc/)<br /> [Reference](../../reference/drivers/java/postgres-jdbc-reference/) | [42.3.4](https://mvnrepository.com/artifact/org.postgresql/postgresql/42.3.4) | 2.4 and above |
 | Vert.x Pg Client | [Documentation](ysql-vertx-pg-client/) | [4.3.2](https://mvnrepository.com/artifact/io.vertx/vertx-core/4.3.2) |
 | YugabyteDB YCQL (3.10) Driver | [Documentation](ycql)<br />[Reference](../../reference/drivers/ycql-client-drivers/#java) | [3.10.3-yb-2](https://mvnrepository.com/artifact/com.yugabyte/cassandra-driver-core/3.10.3-yb-2) | |
 | YugabyteDB YCQL (4.15) Driver | [Documentation](ycql-4.x)<br />[Reference](../../reference/drivers/ycql-client-drivers/#java) | [4.15.0-yb-1](https://mvnrepository.com/artifact/com.yugabyte/java-driver-core/4.15.0-yb-1) | |
 
 | Projects | Documentation and Guides | Example Apps |
 | ------- | ------------------------ | ------------ |
-| Hibernate ORM | [Documentation](hibernate/)<br />[Hello World](../orms/java/ysql-hibernate/)<br />[Blog](https://www.yugabyte.com/blog/run-the-rest-version-of-spring-petclinic-with-angular-and-distributed-sql-on-gke/)<br /> | [Hibernate ORM App](https://github.com/yugabyte/orm-examples/tree/master/java/hibernate/)
+| Hibernate ORM | [Documentation](hibernate/)<br />[Hello World](../orms/java/ysql-hibernate/)<br />[Blog](https://www.yugabyte.com/blog/run-the-rest-version-of-spring-petclinic-with-angular-and-distributed-sql-on-gke/)<br /> | [Hibernate ORM App](https://github.com/yugabyte/orm-examples/tree/master/java/hibernate/) |
 | Spring Data JPA | [Documentation](../../integrations/spring-framework/sd-jpa/)<br />[Hello World](../orms/java/ysql-spring-data/)<br />[Blog](https://www.yugabyte.com/blog/run-the-rest-version-of-spring-petclinic-with-angular-and-distributed-sql-on-gke/) | [Spring Data JPA App](https://github.com/yugabyte/orm-examples/tree/master/java/spring/)
-| Ebean ORM | [Documentation](ebean/)<br /> [Hello World](../orms/java/ysql-ebean/)<br /> [Blog](https://www.yugabyte.com/blog/ebean-orm-yugabytedb/)| [Ebean ORM App](https://github.com/yugabyte/orm-examples/tree/master/java/ebean/)
+| Ebean ORM | [Documentation](ebean/)<br /> [Hello World](../orms/java/ysql-ebean/)<br /> [Blog](https://www.yugabyte.com/blog/ebean-orm-yugabytedb/)| [Ebean ORM App](https://github.com/yugabyte/orm-examples/tree/master/java/ebean/) |
 | MyBatis ORM | [Documentation](mybatis/)<br /> [Hello World](../orms/java/ysql-mybatis/) | [MyBatis ORM App](https://github.com/yugabyte/orm-examples/tree/master/java/mybatis/)
-| Spring Data YugabyteDB | [Documentation](../../integrations/spring-framework/sdyb/)<br/>[Blog](https://www.yugabyte.com/blog/spring-data-yugabytedb-getting-started/) | [Spring Data YugabyteDB Sample App](https://github.com/yugabyte/spring-data-yugabytedb-example/)
+| Spring Data YugabyteDB | [Documentation](../../integrations/spring-framework/sdyb/)<br/>[Blog](https://www.yugabyte.com/blog/spring-data-yugabytedb-getting-started/) | [Spring Data YugabyteDB Sample App](https://github.com/yugabyte/spring-data-yugabytedb-example/) |
 
 Learn how to establish a connection to a YugabyteDB database and begin basic CRUD operations by referring to [Connect an app](yugabyte-jdbc/) or [Use an ORM](hibernate/).
 

--- a/docs/content/preview/drivers-orms/nodejs/_index.md
+++ b/docs/content/preview/drivers-orms/nodejs/_index.md
@@ -3,7 +3,7 @@ title: Node.js drivers and ORMs
 headerTitle: Node.js
 linkTitle: Node.js
 description: Node.js Drivers and ORMs support for YugabyteDB.
-image: /images/section_icons/sample-data/s_s1-sampledata-3x.png
+image: fa-brands fa-node-js
 menu:
   preview:
     identifier: nodejs-drivers

--- a/docs/content/preview/drivers-orms/php/_index.md
+++ b/docs/content/preview/drivers-orms/php/_index.md
@@ -3,7 +3,7 @@ title: PHP
 headerTitle: PHP
 linkTitle: PHP
 description: PHP Drivers and ORMs support for YugabyteDB.
-image: /images/section_icons/sample-data/s_s1-sampledata-3x.png
+image: fa-brands fa-php
 menu:
   preview:
     identifier: php-drivers

--- a/docs/content/preview/drivers-orms/python/_index.md
+++ b/docs/content/preview/drivers-orms/python/_index.md
@@ -3,7 +3,7 @@ title: Python drivers and ORMs
 headerTitle: Python
 linkTitle: Python
 description: Python Drivers and ORMs support for YugabyteDB.
-image: /images/section_icons/sample-data/s_s1-sampledata-3x.png
+image: fa-brands fa-python
 menu:
   preview:
     identifier: python-drivers

--- a/docs/content/preview/drivers-orms/ruby/_index.md
+++ b/docs/content/preview/drivers-orms/ruby/_index.md
@@ -3,7 +3,7 @@ title: Ruby
 headerTitle: Ruby
 linkTitle: Ruby
 description: Ruby Drivers and ORMs support for YugabyteDB.
-image: /images/section_icons/sample-data/s_s1-sampledata-3x.png
+image: fa-regular fa-gem
 menu:
   preview:
     identifier: ruby-drivers

--- a/docs/content/preview/drivers-orms/ruby/_index.md
+++ b/docs/content/preview/drivers-orms/ruby/_index.md
@@ -8,7 +8,7 @@ menu:
   preview:
     identifier: ruby-drivers
     parent: drivers-orms
-    weight: 570
+    weight: 580
 type: indexpage
 showRightNav: true
 ---

--- a/docs/content/preview/drivers-orms/rust/_index.md
+++ b/docs/content/preview/drivers-orms/rust/_index.md
@@ -8,7 +8,7 @@ menu:
   preview:
     identifier: rust-drivers
     parent: drivers-orms
-    weight: 580
+    weight: 600
 type: indexpage
 showRightNav: true
 ---

--- a/docs/content/preview/drivers-orms/rust/_index.md
+++ b/docs/content/preview/drivers-orms/rust/_index.md
@@ -3,7 +3,7 @@ title: Rust
 headerTitle: Rust
 linkTitle: Rust
 description: Rust Drivers and ORMs support for YugabyteDB.
-image: /images/section_icons/sample-data/s_s1-sampledata-3x.png
+image: fa-brands fa-rust
 menu:
   preview:
     identifier: rust-drivers

--- a/docs/content/preview/drivers-orms/scala/_index.md
+++ b/docs/content/preview/drivers-orms/scala/_index.md
@@ -8,7 +8,7 @@ menu:
   preview:
     identifier: scala-drivers
     parent: drivers-orms
-    weight: 600
+    weight: 610
 type: indexpage
 showRightNav: true
 ---

--- a/docs/content/preview/drivers-orms/scala/_index.md
+++ b/docs/content/preview/drivers-orms/scala/_index.md
@@ -3,7 +3,7 @@ title: Scala
 headerTitle: Scala
 linkTitle: Scala
 description: Scala Drivers and ORMs support for YugabyteDB.
-image: /images/section_icons/sample-data/s_s1-sampledata-3x.png
+image: fa-solid fa-bars
 menu:
   preview:
     identifier: scala-drivers

--- a/docs/content/preview/tutorials/build-apps/_index.md
+++ b/docs/content/preview/tutorials/build-apps/_index.md
@@ -68,6 +68,13 @@ The tutorials assume you have deployed a YugabyteDB cluster in YugabyteDB Aeon o
   </li>
 
   <li>
+    <a href="elixir/cloud-ysql-elixir/" class="orange">
+      <i class="fa-brands fa-node-js"></i>
+      Elixir
+    </a>
+  </li>
+
+  <li>
     <a href="c/cloud-ysql-c/" class="orange">
       <i class="icon-c"></i>
       C

--- a/docs/content/preview/tutorials/build-apps/_index.md
+++ b/docs/content/preview/tutorials/build-apps/_index.md
@@ -20,20 +20,15 @@ The tutorials in this section show how to connect applications to YugabyteDB usi
 
 The tutorials assume you have deployed a YugabyteDB cluster in YugabyteDB Aeon or locally. Refer to [Quick start](../../quick-start-yugabytedb-managed/).<br><br>
 
-<div class="row">
+{{<index/block>}}
 
-  <div class="col-12 col-md-12 col-lg-6 col-xl-6">
-  <a class="section-link icon-offset" href="cloud-add-ip/">
-    <div class="head">
-        <img class="icon" src="/images/section_icons/deploy/checklist.png" aria-hidden="true" />
-      <div class="title">Before you begin</div>
-    </div>
-    <div class="body">
-      If your cluster is in YugabyteDB Aeon, start here.
-    </div>
-  </a>
-  </div>
-</div>
+  {{<index/item
+    title="Before you begin"
+    body="If your cluster is in YugabyteDB Aeon, start here."
+    href="cloud-add-ip/"
+    icon="/images/section_icons/deploy/checklist.png">}}
+
+{{</index/block>}}
 
 ### Choose your language
 
@@ -69,7 +64,7 @@ The tutorials assume you have deployed a YugabyteDB cluster in YugabyteDB Aeon o
 
   <li>
     <a href="elixir/cloud-ysql-elixir/" class="orange">
-      <i class="fa-brands fa-node-js"></i>
+      <i class="fa-classic fa-droplet"></i>
       Elixir
     </a>
   </li>

--- a/docs/content/preview/tutorials/build-apps/c/cloud-ysql-c.md
+++ b/docs/content/preview/tutorials/build-apps/c/cloud-ysql-c.md
@@ -10,7 +10,7 @@ menu:
     parent: build-apps
     name: C
     identifier: cloud-c
-    weight: 500
+    weight: 600
 type: docs
 ---
 

--- a/docs/content/preview/tutorials/build-apps/cpp/cloud-ysql-cpp.md
+++ b/docs/content/preview/tutorials/build-apps/cpp/cloud-ysql-cpp.md
@@ -10,7 +10,7 @@ menu:
     parent: build-apps
     name: C++
     identifier: cloud-cpp
-    weight: 500
+    weight: 700
 type: docs
 ---
 

--- a/docs/content/preview/tutorials/build-apps/csharp/cloud-ysql-csharp.md
+++ b/docs/content/preview/tutorials/build-apps/csharp/cloud-ysql-csharp.md
@@ -8,7 +8,7 @@ menu:
     parent: build-apps
     name: C#
     identifier: cloud-csharp
-    weight: 600
+    weight: 800
 type: docs
 ---
 

--- a/docs/content/preview/tutorials/build-apps/elixir/cloud-ysql-elixir.md
+++ b/docs/content/preview/tutorials/build-apps/elixir/cloud-ysql-elixir.md
@@ -1,0 +1,152 @@
+---
+title: Build an Elixir application that uses YSQL
+headerTitle: Build an Elixir application
+linkTitle: Elixir
+description: Build a simple Elixir application using the Postgrex driver and YSQL API to connect to and interact with a YugabyteDB Aeon cluster.
+headContent: "Client driver: Postgrex"
+menu:
+  preview_tutorials:
+    parent: build-apps
+    name: Elixir
+    identifier: cloud-elixir
+    weight: 500
+type: docs
+---
+
+The following tutorial shows a small [Elixir application](https://github.com/YugabyteDB-Samples/yugabytedb-simple-elixir-app/tree/main) that connects to a YugabyteDB cluster using the [Elixir Postgrex driver](https://github.com/elixir-ecto/postgrex) and performs basic SQL operations. Use the application as a template to get started with YugabyteDB Aeon in Elixir.
+
+## Prerequisites
+
+The latest versions of [Elixir, Erlang VM, IEx and Mix](https://elixir-lang.org/docs.html) (tested with Elixir 1.17.1 and Erlang/OTP 26 erts-14.2.5).
+
+### Clone the application from GitHub
+
+Clone the sample application to your computer:
+
+```sh
+git clone https://github.com/YugabyteDB-Samples/yugabytedb-simple-elixir-app.git && cd yugabytedb-simple-elixir-app/postgrex/simple_app
+```
+
+## Provide connection parameters
+
+If your cluster is running on YugabyteDB Aeon, you need to modify the connection parameters so that the application can establish a connection to the YugabyteDB cluster. (You can skip this step if your cluster is running locally and listening on 127.0.0.1:5433.)
+
+To do this:
+
+1. Open the `lib/simple_app.ex` file.
+
+2. Set the following configuration parameter constants:
+
+    - **hostname** - the host name of your YugabyteDB cluster. For local clusters, use the default (127.0.0.1). For YugabyteDB Aeon, select your cluster on the **Clusters** page, and click **Settings**. The host is displayed under **Connection Parameters**.
+    - **port** - the port number for the driver to use (the default YugabyteDB YSQL port is 5433).
+    - **database** - the name of the database you are connecting to (the default is `yugabyte`).
+    - **username** and **password** - the username and password for the YugabyteDB database. For local clusters, use the defaults (`yugabyte` and `yugabyte`). For YugabyteDB Aeon, use the credentials in the credentials file you downloaded.
+    - **ssl: \[cacertfile:...\]** - the full path to the YugabyteDB Aeon cluster CA certificate. For local clusters, skip or remove this parameter.
+
+3. Save the file.
+
+## Build and run the application
+
+First, add all required dependencies.
+
+```sh
+mix deps.get
+```
+
+Compile the application and start an IEx session:
+
+```sh
+iex -S mix
+```
+
+Start the application.
+
+```sh
+SimpleApp.start
+```
+
+You should see output similar to the following:
+
+```output
+>>>> Successfully connected to YugabyteDB! PID: #PID<0.221.0>
+>>>> Successfully created table DemoAccount.
+>>>> Selecting accounts:
+["Jessica", 28, "USA", 10000]
+["John", 28, "Canada", 9000]
+>>>> Transferred 800 between accounts.
+>>>> Selecting accounts:
+["Jessica", 28, "USA", 9200]
+["John", 28, "Canada", 9800]
+:ok
+```
+
+You have successfully executed a basic Elixir application that works with YugabyteDB.
+
+## Explore the application logic
+
+Open the `simple_app.ex` file in the `yugabytedb-simple-elixir-app/postgrex/simple_app/lib` folder to review the methods.
+
+### start
+
+The `start` method establishes a connection with your cluster via the Elixir Postgrex driver and executes the rest of the application logic.
+
+```elixir
+db_config = @db_config
+{:ok, pid} = Postgrex.start_link(db_config)
+```
+
+### create_database
+
+The `create_database` method creates a sample table and loads it with a few records.
+
+```elixir
+Postgrex.query!(pid, "DROP TABLE IF EXISTS DemoAccount", [])
+
+Postgrex.query!(pid, """
+CREATE TABLE DemoAccount (
+    id int PRIMARY KEY,
+    name varchar,
+    age int,
+    country varchar,
+    balance int)
+""",[])
+
+Postgrex.query!(pid, """
+INSERT INTO DemoAccount VALUES
+    (1, 'Jessica', 28, 'USA', 10000),
+    (2, 'John', 28, 'Canada', 9000)
+""",[])
+```
+
+### select_accounts
+
+The `select_accounts` method queries the data from the database.
+
+```elixir
+result = Postgrex.query!(pid,
+    "SELECT name, age, country, balance FROM DemoAccount", [])
+
+Enum.each(result.rows, fn row ->
+    IO.inspect(row)
+end)
+```
+
+### transfer_money
+
+The `transfer_money` method updates your data consistently with distributed transactions.
+
+```elixir
+Postgrex.transaction(pid, fn(conn) ->
+    # Deduct amount from Jessica's account
+    Postgrex.query!(conn,
+    "UPDATE DemoAccount SET balance = balance - $1 WHERE name = 'Jessica'", [amount])
+
+    # Add amount to John's account
+    Postgrex.query!(conn,
+    "UPDATE DemoAccount SET balance = balance + $1 WHERE name = 'John'", [amount])
+end)
+```
+
+## Learn more
+
+[Watch](https://www.youtube.com/live/_utOXl3eWoA?feature=shared) Chris McCord, the creator of the Phoenix framework, joining YugabyteDB Community Open Hours and demonstrating how to build multi-region applications using Phoenix, Fly.io and YugabyteDB.

--- a/docs/content/preview/tutorials/build-apps/elixir/cloud-ysql-elixir.md
+++ b/docs/content/preview/tutorials/build-apps/elixir/cloud-ysql-elixir.md
@@ -35,7 +35,7 @@ To do this:
 
 1. Open the `lib/simple_app.ex` file.
 
-2. Set the following configuration parameter constants:
+1. Set the following configuration parameter constants:
 
     - **hostname** - the host name of your YugabyteDB cluster. For local clusters, use the default (127.0.0.1). For YugabyteDB Aeon, select your cluster on the **Clusters** page, and click **Settings**. The host is displayed under **Connection Parameters**.
     - **port** - the port number for the driver to use (the default YugabyteDB YSQL port is 5433).
@@ -43,7 +43,7 @@ To do this:
     - **username** and **password** - the username and password for the YugabyteDB database. For local clusters, use the defaults (`yugabyte` and `yugabyte`). For YugabyteDB Aeon, use the credentials in the credentials file you downloaded.
     - **ssl: \[cacertfile:...\]** - the full path to the YugabyteDB Aeon cluster CA certificate. For local clusters, skip or remove this parameter.
 
-3. Save the file.
+1. Save the file.
 
 ## Build and run the application
 
@@ -149,4 +149,4 @@ end)
 
 ## Learn more
 
-[Watch](https://www.youtube.com/live/_utOXl3eWoA?feature=shared) Chris McCord, the creator of the Phoenix framework, joining YugabyteDB Community Open Hours and demonstrating how to build multi-region applications using Phoenix, Fly.io and YugabyteDB.
+[YugabyteDB Community Open Hours](https://www.youtube.com/live/_utOXl3eWoA?feature=shared) - featuring Chris McCord, the creator of the Phoenix framework, demonstrating how to build multi-region applications using Phoenix, Fly.io, and YugabyteDB.

--- a/docs/content/preview/tutorials/build-apps/php/cloud-ysql-php.md
+++ b/docs/content/preview/tutorials/build-apps/php/cloud-ysql-php.md
@@ -10,7 +10,7 @@ menu:
     parent: build-apps
     name: PHP
     identifier: cloud-php
-    weight: 900
+    weight: 1100
 type: docs
 ---
 

--- a/docs/content/preview/tutorials/build-apps/ruby/cloud-ysql-ruby.md
+++ b/docs/content/preview/tutorials/build-apps/ruby/cloud-ysql-ruby.md
@@ -10,7 +10,7 @@ menu:
     parent: build-apps
     name: Ruby
     identifier: cloud-ruby
-    weight: 700
+    weight: 900
 type: docs
 ---
 

--- a/docs/content/preview/tutorials/build-apps/rust/cloud-ysql-rust.md
+++ b/docs/content/preview/tutorials/build-apps/rust/cloud-ysql-rust.md
@@ -10,7 +10,7 @@ menu:
     parent: build-apps
     name: Rust
     identifier: cloud-rust
-    weight: 800
+    weight: 1000
 type: docs
 ---
 

--- a/docs/content/stable/drivers-orms/_index.md
+++ b/docs/content/stable/drivers-orms/_index.md
@@ -51,6 +51,13 @@ In addition to the compatible upstream PostgreSQL (YSQL) and Cassandra (YCQL) dr
   </li>
 
   <li>
+    <a href="elixir/" class="orange">
+      <i class="fa-classic fa-droplet"></i>
+      Elixir
+    </a>
+  </li>
+
+  <li>
     <a href="c/" class="orange">
       <i class="icon-c"></i>
       C

--- a/docs/content/stable/drivers-orms/c/_index.md
+++ b/docs/content/stable/drivers-orms/c/_index.md
@@ -3,12 +3,12 @@ title: Build applications with C Drivers and ORMs
 headerTitle: C
 linkTitle: C
 description: C Drivers and ORMs support for YugabyteDB.
-image: /images/section_icons/sample-data/s_s1-sampledata-3x.png
+image: fa-classic fa-c
 menu:
   stable:
     identifier: c-drivers
     parent: drivers-orms
-    weight: 540
+    weight: 550
 type: indexpage
 showRightNav: true
 ---

--- a/docs/content/stable/drivers-orms/cpp/_index.md
+++ b/docs/content/stable/drivers-orms/cpp/_index.md
@@ -3,12 +3,12 @@ title: Build apps with C++ Drivers and ORMs
 headerTitle: C++
 linkTitle: C++
 description: C++ Drivers and ORMs support for YugabyteDB.
-image: /images/section_icons/sample-data/s_s1-sampledata-3x.png
+image: fa-classic fa-plus
 menu:
   stable:
     identifier: cpp-drivers
     parent: drivers-orms
-    weight: 550
+    weight: 560
 type: indexpage
 showRightNav: true
 ---

--- a/docs/content/stable/drivers-orms/csharp/_index.md
+++ b/docs/content/stable/drivers-orms/csharp/_index.md
@@ -3,12 +3,12 @@ title: Build apps using C# drivers and ORMs
 headerTitle: C#
 linkTitle: C#
 description: C# Drivers and ORMs support for YugabyteDB.
-image: /images/section_icons/sample-data/s_s1-sampledata-3x.png
+image: fa-classic fa-hashtag
 menu:
   stable:
     identifier: csharp-drivers
     parent: drivers-orms
-    weight: 560
+    weight: 570
 type: indexpage
 showRightNav: true
 ---

--- a/docs/content/stable/drivers-orms/elixir/_index.md
+++ b/docs/content/stable/drivers-orms/elixir/_index.md
@@ -1,0 +1,40 @@
+---
+title: Elixir drivers and ORMs
+headerTitle: Elixir
+linkTitle: Elixir
+description: Elixir Drivers and ORMs support for YugabyteDB.
+image: fa-classic fa-droplet
+menu:
+  stable:
+    identifier: elixir-drivers
+    parent: drivers-orms
+    weight: 540
+type: indexpage
+showRightNav: true
+---
+
+## Supported projects
+
+The following projects can be used to implement Elixir applications using the YugabyteDB YSQL APIs.
+
+| Project | Documentation and Guides | Latest Driver Version | Supported YugabyteDB Version |
+| ------- | ------------------------ | ------------------------ | ---------------------|
+| Postgrex Driver | [Documentation](../../tutorials/build-apps/elixir/cloud-ysql-elixir/) | [v0.18.0](https://github.com/elixir-ecto/postgrex) | |
+| Phoenix Framework | [Documentation](phoenix/) | [1.7.14](https://www.phoenixframework.org) | |
+
+Learn how to establish a connection to a YugabyteDB database and begin basic CRUD operations by referring to a [sample Elixir app using Postgrex](../../tutorials/build-apps/elixir/cloud-ysql-elixir/) or building an app using [Phoenix framework](phoenix/).
+
+## Prerequisites
+
+To develop Elixir applications for YugabyteDB, you need the following:
+
+- **Elixir**\
+  Install the latest versions of [Elixir, Erlang VM, IEx and Mix](https://elixir-lang.org/docs.html) (tested with Elixir 1.17.1 and Erlang/OTP 26 erts-14.2.5).
+
+- **YugabyteDB cluster**
+  - Create a free cluster on YugabyteDB Aeon. Refer to [Use a cloud cluster](../../quick-start-yugabytedb-managed/). Note that YugabyteDB Aeon requires SSL.
+  - Alternatively, set up a standalone YugabyteDB cluster by following the steps in [Install YugabyteDB](../../quick-start/).
+
+## Next step
+
+- [Basic application using Phoenix framework](phoenix/)

--- a/docs/content/stable/drivers-orms/elixir/_index.md
+++ b/docs/content/stable/drivers-orms/elixir/_index.md
@@ -19,10 +19,10 @@ The following projects can be used to implement Elixir applications using the Yu
 
 | Project | Documentation and Guides | Latest Driver Version | Supported YugabyteDB Version |
 | ------- | ------------------------ | ------------------------ | ---------------------|
-| Postgrex Driver | [Documentation](../../tutorials/build-apps/elixir/cloud-ysql-elixir/) | [v0.18.0](https://github.com/elixir-ecto/postgrex) | |
+| Postgrex Driver | [Documentation](/preview/tutorials/build-apps/elixir/cloud-ysql-elixir/) | [v0.18.0](https://github.com/elixir-ecto/postgrex) | |
 | Phoenix Framework | [Documentation](phoenix/) | [1.7.14](https://www.phoenixframework.org) | |
 
-Learn how to establish a connection to a YugabyteDB database and begin basic CRUD operations by referring to a [sample Elixir app using Postgrex](../../tutorials/build-apps/elixir/cloud-ysql-elixir/) or building an app using [Phoenix framework](phoenix/).
+Learn how to establish a connection to a YugabyteDB database and begin basic CRUD operations by referring to a [sample Elixir app using Postgrex](/preview/tutorials/build-apps/elixir/cloud-ysql-elixir/) or building an app using [Phoenix framework](phoenix/).
 
 ## Prerequisites
 

--- a/docs/content/stable/drivers-orms/elixir/phoenix.md
+++ b/docs/content/stable/drivers-orms/elixir/phoenix.md
@@ -264,4 +264,4 @@ Now, explore the [final version of the application](https://github.com/YugabyteD
 
 - [Watch](https://www.youtube.com/live/_utOXl3eWoA?feature=shared) Chris McCord, the creator of the Phoenix framework, joining YugabyteDB Community Open Hours and demonstrating how to build multi-region applications using Phoenix, Fly.io and YugabyteDB.
 
-- Create a [sample Elixir app](../../../tutorials/build-apps/elixir/cloud-ysql-elixir/) using the Postgrex driver.
+- Create a [sample Elixir app](/preview/tutorials/build-apps/elixir/cloud-ysql-elixir/) using the Postgrex driver.

--- a/docs/content/stable/drivers-orms/elixir/phoenix.md
+++ b/docs/content/stable/drivers-orms/elixir/phoenix.md
@@ -1,0 +1,267 @@
+---
+title: Elixir application that uses Phoenix, Ecto and YSQL
+headerTitle: Phoenix Example Application
+linkTitle: Phoenix
+description: Elixir application that uses Phoenix, Ecto and YSQL
+menu:
+  stable:
+    identifier: elixir-phoenix
+    parent: elixir-drivers
+    weight: 550
+type: docs
+---
+
+<ul class="nav nav-tabs-alt nav-tabs-yb">
+  <li >
+    <a href="../elixir/phoenix" class="nav-link active">
+      <i class="icon-postgres" aria-hidden="true"></i>
+      Phoenix/Ecto
+    </a>
+  </li>
+</ul>
+
+The following tutorial shows how to implement an Elixir app using the Phoenix framework with the Ecto ORM. The app connects to a YugabyteDB cluster, creates a sample table, populates it with a few records, and changes data transactionally.
+
+The source for the application can be found in the [yugabytedb-simple-elixir-app](https://github.com/YugabyteDB-Samples/yugabytedb-simple-elixir-app/tree/main/phoenix/simple_app) repository.
+
+## Prerequisites
+
+This tutorial assumes that you have:
+
+- YugabyteDB up and running. Download and install YugabyteDB by following the steps in [Quick start](../../../quick-start/).
+
+- The latest versions of [Elixir, Erlang VM, IEx and Mix](https://elixir-lang.org/docs.html) (tested with Elixir 1.17.1 and Erlang/OTP 26 erts-14.2.5).
+
+## Create Phoenix project
+
+In this section you create a Phoenix project and configure it to work with an existing YugabyteDB cluster.
+
+First, use the `mix` tool to create a project template and pull all required dependencies:
+
+- Generate the project template and navigate to its root folder:
+
+    ```shell
+    mix phx.new sample_yugabytedb_phoenix_app && cd sample_yugabytedb_phoenix_app
+    ```
+
+- Pull the required dependencies, unless you've already done this during the project generation:
+
+    ```shell
+    mix deps.get
+    ```
+
+Phoenix uses PostgreSQL as a default database option. Open the `config/dev.exs` file to confirm that the Ecto ORM is configured to work PostgreSQL:
+
+```elixir
+# Configure your database
+config :sample_yugabytedb_phoenix_app, SampleYugabytedbPhoenixApp.Repo,
+  username: "postgres",
+  password: "postgres",
+  hostname: "localhost",
+  database: "sample_yugabytedb_phoenix_app_dev",
+  stacktrace: true,
+  show_sensitive_data_on_connection_error: true,
+  pool_size: 10
+```
+
+As YugabyteDB is built on PostgreSQL, you only need to update the `config` settings. Both Ecto and the underlying Postgrex driver will work with YugabyteDB as they do with vanilla PostgreSQL.
+
+Assuming that your YugabyteDB cluster is running locally, do the following:
+
+- Open the `config/dev.exs` file
+
+- Update the database settings to the following:
+
+    ```elixir
+    config :sample_yugabytedb_phoenix_app, SampleYugabytedbPhoenixApp.Repo,
+    username: "yugabyte",
+    password: "yugabyte",
+    hostname: "localhost",
+    port: 5433,
+    database: "yugabyte",
+    stacktrace: true,
+    show_sensitive_data_on_connection_error: true,
+    pool_size: 10
+    ```
+
+- Add the `migration_lock: false` setting to the database configuration. Ecto acquires exclusive table locks while running database migrations, but this type of lock is not currently supported by YugabyteDB. Track [GitHub issue 5384](https://github.com/yugabyte/yugabyte-db/issues/5384) to understand details and get updates.
+
+    ```elixir
+    config :sample_yugabytedb_phoenix_app, SampleYugabytedbPhoenixApp.Repo,
+    <!-- other database specific settings -->
+    pool_size: 10,
+    migration_lock: false
+    ```
+
+- Have Ecto connecting to YugabyteDB to complete and confirm the configuration settings:
+
+    ```shell
+    mix ecto.create
+    ```
+
+The output should be as follows:
+
+```output
+Compiling 15 files (.ex)
+Generated sample_yugabytedb_phoenix_app app
+The database for SampleYugabytedbPhoenixApp.Repo has already been created
+```
+
+## Generate sample schema
+
+In this section, you use Phoenix and Ecto to generate a sample database schema for the `Account` entity and to apply database migrations.
+
+- Generate the schema for the `Account` entity. Note, the `id` field of the `bigint` type will be added to the generated table automatically:
+
+    ```shell
+    mix phx.gen.schema Account account name:string balance:decimal
+    ```
+
+- Open the `lib/sample_yugabytedb_phoenix_app/account.ex` to see the generated Ecto schema:
+
+    ```elixir
+    defmodule SampleYugabytedbPhoenixApp.Account do
+    use Ecto.Schema
+    import Ecto.Changeset
+
+    schema "account" do
+        field :name, :string
+        field :balance, :decimal
+
+        timestamps(type: :utc_datetime)
+    end
+
+    <!-- other logic -->
+
+    end
+    ```
+
+- Run the database migration file that was also generated automatically and placed under the `priv/repo/migrations` directory:
+
+    ```shell
+    mix ecto.migrate
+    ```
+
+    The output should be as follows:
+
+    ```output
+    Compiling 1 file (.ex)
+
+    Generated sample_yugabytedb_phoenix_app app
+
+    10:58:16.251 [info] == Running 20240725145331 SampleYugabytedbPhoenixApp.Repo.Migrations.CreateAccount.change/0 forward
+
+    10:58:16.252 [info] create table account
+
+    10:58:16.443 [info] == Migrated 20240725145331 in 0.1s
+    ```
+
+Next, connect to your YugabyteDB cluster using psql, ysqlsh, or another SQL tool to confirm the tables were successfully created:
+
+```sql
+yugabyte=# \d
+                List of relations
+ Schema |       Name        |   Type   |  Owner
+--------+-------------------+----------+----------
+ public | account           | table    | yugabyte
+ public | account_id_seq    | sequence | yugabyte
+ public | schema_migrations | table    | yugabyte
+(3 rows)
+```
+
+## Persist and query data
+
+In this final section, you use Phoenix APIs and the IEx interactive shell to persist and query data in YugabyteDB.
+
+- Start an IEx session in your terminal:
+
+    ```shell
+    iex -S mix
+    ```
+
+- Create aliases for the `Repo` and `Account` modules:
+
+    ```elixir
+    alias SampleYugabytedbPhoenixApp.{Repo, Account}
+    ```
+
+- Insert two user accounts into the database:
+
+    ```elixir
+    Repo.insert(%Account{name: "John Smith", balance: 1000})
+    Repo.insert(%Account{name: "Mary Black", balance: 1500})
+    ```
+
+- Fetch the accounts from the database:
+
+    ```elixir
+    Repo.all(Account)
+    ```
+
+    The output should be as follows:
+
+    ```elixir
+    [debug] QUERY OK source="account" db=25.7ms queue=47.5ms idle=1922.1ms
+
+    SELECT a0."id", a0."name", a0."balance", a0."inserted_at", a0."updated_at" FROM "account" AS a0 []
+    ↳ :elixir.eval_external_handler/3, at: src/elixir.erl:386
+    [
+    %SampleYugabytedbPhoenixApp.Account{
+        __meta__: #Ecto.Schema.Metadata<:loaded, "account">,
+        id: 101,
+        name: "Mary Black",
+        balance: Decimal.new("1500"),
+        inserted_at: ~U[2024-07-25 15:11:12Z],
+        updated_at: ~U[2024-07-25 15:11:12Z]
+    },
+    %SampleYugabytedbPhoenixApp.Account{
+        __meta__: #Ecto.Schema.Metadata<:loaded, "account">,
+        id: 1,
+        name: "John Smith",
+        balance: Decimal.new("1000"),
+        inserted_at: ~U[2024-07-25 15:11:12Z],
+        updated_at: ~U[2024-07-25 15:11:12Z]
+    }
+    ]
+    ```
+
+Note that the `id` of the `Mary Black` account is `101` and not `2`. This happens because sequences in YugabyteDB cache `100` IDs per connection by default. This means that records were inserted into the database using different database connections.
+
+```sql
+yugabyte=# \d account_id_seq
+```
+
+```output
+                       Sequence "public.account_id_seq"
+  Type  | Start | Minimum |       Maximum       | Increment | Cycles? | Cache
+--------+-------+---------+---------------------+-----------+---------+-------
+ bigint |     1 |       1 | 9223372036854775807 |         1 | no      |   100
+Owned by: public.account.id
+```
+
+For details on how sequences work in YugabyteDB and how to scale them, refer to the [Scaling Sequences with Server-Level Caching in YugabyteDB](https://www.yugabyte.com/blog/create-database-sequences/).
+
+Finally, use the `Ecto.Query` interface to query specific data:
+
+```elixir
+import Ecto.Query
+
+Repo.all(from a in Account, where: a.balance >= 1100,
+    select: %{a.name => a.balance})
+```
+
+The output should be as follows:
+
+```elixir
+[%{"Mary Black" => Decimal.new("1500")}]
+```
+
+Congratulations! You've successfully completed the tutorial.
+
+Now, explore the [final version of the application](https://github.com/YugabyteDB-Samples/yugabytedb-simple-elixir-app/tree/main/phoenix/simple_app) to see how work with YugabyteDB using the same APIs but programmatically.
+
+## Next steps
+
+- [Watch](https://www.youtube.com/live/_utOXl3eWoA?feature=shared) Chris McCord, the creator of the Phoenix framework, joining YugabyteDB Community Open Hours and demonstrating how to build multi-region applications using Phoenix, Fly.io and YugabyteDB.
+
+- Create a [sample Elixir app](../../../tutorials/build-apps/elixir/cloud-ysql-elixir/) using the Postgrex driver.

--- a/docs/content/stable/drivers-orms/go/_index.md
+++ b/docs/content/stable/drivers-orms/go/_index.md
@@ -3,7 +3,7 @@ title: Go drivers and ORMs
 headerTitle: Go
 linkTitle: Go
 description: Go Drivers and ORMs support for YugabyteDB.
-image: /images/section_icons/sample-data/s_s1-sampledata-3x.png
+image: fa-brands fa-golang
 menu:
   stable:
     identifier: go-drivers

--- a/docs/content/stable/drivers-orms/include-drivers-orms-list.md
+++ b/docs/content/stable/drivers-orms/include-drivers-orms-list.md
@@ -72,6 +72,17 @@ private = true
 
   {{% /tab %}}
 
+  {{% tab header="Elixir" lang="elixir" %}}
+
+|            | Version | Support Level | Example apps |
+| :--------- | :------ | :------------ | :----------- |
+| **Drivers** | | | |
+| Postgrex Driver | [0.18.0](https://github.com/elixir-ecto/postgrex) | Full | [CRUD](/preview/tutorials/build-apps/elixir/cloud-ysql-elixir/) |
+| **ORMs** | | | |
+| Phoenix with Ecto | [1.7.14](https://www.phoenixframework.org) | Full | [CRUD](/preview/drivers-orms/elixir/phoenix/) |
+
+  {{% /tab %}}
+
   {{% tab header="C" lang="c" %}}
 
 | Driver        | Version | Support Level | Example apps |

--- a/docs/content/stable/drivers-orms/java/_index.md
+++ b/docs/content/stable/drivers-orms/java/_index.md
@@ -3,7 +3,7 @@ title: Java drivers, ORMs, and frameworks
 headerTitle: Java
 linkTitle: Java
 description: Java drivers and ORMs support for YugabyteDB.
-image: /images/section_icons/sample-data/s_s1-sampledata-3x.png
+image: fa-brands fa-java
 menu:
   stable:
     identifier: java-drivers

--- a/docs/content/stable/drivers-orms/nodejs/_index.md
+++ b/docs/content/stable/drivers-orms/nodejs/_index.md
@@ -3,7 +3,7 @@ title: Node.js drivers and ORMs
 headerTitle: Node.js
 linkTitle: Node.js
 description: Node.js Drivers and ORMs support for YugabyteDB.
-image: /images/section_icons/sample-data/s_s1-sampledata-3x.png
+image: fa-brands fa-node-js
 menu:
   stable:
     identifier: nodejs-drivers

--- a/docs/content/stable/drivers-orms/php/_index.md
+++ b/docs/content/stable/drivers-orms/php/_index.md
@@ -3,7 +3,7 @@ title: PHP
 headerTitle: PHP
 linkTitle: PHP
 description: PHP Drivers and ORMs support for YugabyteDB.
-image: /images/section_icons/sample-data/s_s1-sampledata-3x.png
+image: fa-brands fa-php
 menu:
   stable:
     identifier: php-drivers

--- a/docs/content/stable/drivers-orms/python/_index.md
+++ b/docs/content/stable/drivers-orms/python/_index.md
@@ -3,7 +3,7 @@ title: Python drivers and ORMs
 headerTitle: Python
 linkTitle: Python
 description: Python Drivers and ORMs support for YugabyteDB.
-image: /images/section_icons/sample-data/s_s1-sampledata-3x.png
+image: fa-brands fa-python
 menu:
   stable:
     identifier: python-drivers

--- a/docs/content/stable/drivers-orms/ruby/_index.md
+++ b/docs/content/stable/drivers-orms/ruby/_index.md
@@ -3,12 +3,12 @@ title: Ruby
 headerTitle: Ruby
 linkTitle: Ruby
 description: Ruby Drivers and ORMs support for YugabyteDB.
-image: /images/section_icons/sample-data/s_s1-sampledata-3x.png
+image: fa-regular fa-gem
 menu:
   stable:
     identifier: ruby-drivers
     parent: drivers-orms
-    weight: 570
+    weight: 580
 type: indexpage
 showRightNav: true
 ---

--- a/docs/content/stable/drivers-orms/rust/_index.md
+++ b/docs/content/stable/drivers-orms/rust/_index.md
@@ -3,12 +3,12 @@ title: Rust
 headerTitle: Rust
 linkTitle: Rust
 description: Rust Drivers and ORMs support for YugabyteDB.
-image: /images/section_icons/sample-data/s_s1-sampledata-3x.png
+image: fa-brands fa-rust
 menu:
   stable:
     identifier: rust-drivers
     parent: drivers-orms
-    weight: 580
+    weight: 600
 type: indexpage
 showRightNav: true
 ---

--- a/docs/content/stable/drivers-orms/scala/_index.md
+++ b/docs/content/stable/drivers-orms/scala/_index.md
@@ -3,12 +3,12 @@ title: Scala
 headerTitle: Scala
 linkTitle: Scala
 description: Scala Drivers and ORMs support for YugabyteDB.
-image: /images/section_icons/sample-data/s_s1-sampledata-3x.png
+image: fa-solid fa-bars
 menu:
   stable:
     identifier: scala-drivers
     parent: drivers-orms
-    weight: 600
+    weight: 610
 type: indexpage
 showRightNav: true
 ---


### PR DESCRIPTION
The Phoenix framework tool is a go-to framework for building web-based apps in Elixir. It uses the Ecto ORM under the hood to communicate to the database.

Adding a new tutorial to our "Drivers and ORMs" category for Phoenix.

Also, @ddhodge could you please update the Elixir icon on the `/preview/drivers-orms/` as well? See the screenshot.

<img width="1496" alt="Screenshot 2024-07-25 at 12 04 40 PM" src="https://github.com/user-attachments/assets/3c2fa04f-76a3-4900-8f57-8cc47d046a74">
