### PR TITLE
[DOC-435] Split supported versus unsupported OSs into two tables.

### DIFF
--- a/docs/content/preview/reference/configuration/operating-systems.md
+++ b/docs/content/preview/reference/configuration/operating-systems.md
@@ -28,7 +28,7 @@ Unless otherwise noted, operating systems are supported by all supported version
 | Ubuntu 20        | {{<icon/yes>}} | {{<icon/yes>}} |       |
 | Ubuntu 22        | {{<icon/yes>}} | {{<icon/yes>}} | Supported in v2.18.5, v2.20.1 |
 
-The following operating systems and architectures are no longer supported for [deploying YugabyteDB](../../../deploy/manual-deployment/).
+The following operating systems and architectures are no longer supported for deploying YugabyteDB.
 
 | Operating system | x86            | ARM            | Notes |
 | :--------------- | :------------- | :------------- | :---- |

--- a/docs/content/preview/reference/configuration/operating-systems.md
+++ b/docs/content/preview/reference/configuration/operating-systems.md
@@ -13,7 +13,7 @@ type: docs
 
 ## YugabyteDB
 
-The following operating systems and architectures are supported for [deploying YugabyteDB](../../../deploy/manual-deployment/).
+The following table describes the operating system and architecture support for [deploying YugabyteDB](../../../deploy/manual-deployment/).
 
 Unless otherwise noted, operating systems are supported by all supported versions of YugabyteDB and YugabyteDB Anywhere. YugabyteDB Anywhere added support for deploying YugabyteDB to ARM-based systems for non-Kubernetes platforms in v2.18.
 
@@ -28,7 +28,7 @@ Unless otherwise noted, operating systems are supported by all supported version
 | Ubuntu 20        | {{<icon/yes>}} | {{<icon/yes>}} |       |
 | Ubuntu 22        | {{<icon/yes>}} | {{<icon/yes>}} | Supported in v2.18.5, v2.20.1 |
 
-The following operating systems and architectures are no longer supported for deploying YugabyteDB.
+The following table describes operating systems and architectures that are no longer supported for deploying YugabyteDB.
 
 | Operating system | x86            | ARM            | Notes |
 | :--------------- | :------------- | :------------- | :---- |

--- a/docs/content/preview/reference/configuration/operating-systems.md
+++ b/docs/content/preview/reference/configuration/operating-systems.md
@@ -21,14 +21,19 @@ Unless otherwise noted, operating systems are supported by all supported version
 | :--------------- | :------------- | :------------- | :---- |
 | AlmaLinux 8      | {{<icon/yes>}} | {{<icon/yes>}} | Recommended for production<br>Recommended development platform<br>Default for YugabyteDB Anywhere-deployed nodes |
 | AlmaLinux 9      | {{<icon/yes>}} | {{<icon/yes>}} |       |
-| Amazon Linux 2   | {{<icon/no>}} | {{<icon/no>}} | Supported in v2.18.0 and later<br>Deprecated in v2.20 |
-| CentOS 7          | {{<icon/no>}}  |                | Deprecated in v2.20 |
-| Oracle Linux 7   | {{<icon/no>}}  |                | Deprecated in v2.20 |
 | Oracle Linux 8   | {{<icon/yes>}} |                | |
-| Red Hat Enterprise Linux 7 | {{<icon/no>}} |       | Deprecated in v2.20 |
 | Red Hat Enterprise Linux 8 | {{<icon/yes>}} |      | Recommended for production |
 | Red Hat Enterprise Linux&nbsp;9.3 | {{<icon/yes>}} |  | Supported in v2.20.3 and later.  {{<badge/ea>}} |
 | SUSE&nbsp;Linux&nbsp;Enterprise&nbsp;Server&nbsp;15&nbsp;SP5 | {{<icon/yes>}} |     | {{<badge/ea>}} |
-| Ubuntu 18        | {{<icon/no>}}  | {{<icon/no>}}  | Deprecated in v2.20 |
 | Ubuntu 20        | {{<icon/yes>}} | {{<icon/yes>}} |       |
 | Ubuntu 22        | {{<icon/yes>}} | {{<icon/yes>}} | Supported in v2.18.5, v2.20.1 |
+
+The following operating systems and architectures are no longer supported for [deploying YugabyteDB](../../../deploy/manual-deployment/).
+
+| Operating system | x86            | ARM            | Notes |
+| :--------------- | :------------- | :------------- | :---- |
+| Amazon Linux 2   | {{<icon/no>}} | {{<icon/no>}} | Supported in v2.18.0 and later<br>Deprecated in v2.20 |
+| CentOS 7          | {{<icon/no>}}  |                | Deprecated in v2.20 |
+| Oracle Linux 7   | {{<icon/no>}}  |                | Deprecated in v2.20 |
+| Red Hat Enterprise Linux 7 | {{<icon/no>}} |       | Deprecated in v2.20 |
+| Ubuntu 18        | {{<icon/no>}}  | {{<icon/no>}}  | Deprecated in v2.20 |

--- a/docs/content/preview/reference/configuration/operating-systems.md
+++ b/docs/content/preview/reference/configuration/operating-systems.md
@@ -32,8 +32,8 @@ The following operating systems and architectures are no longer supported for [d
 
 | Operating system | x86            | ARM            | Notes |
 | :--------------- | :------------- | :------------- | :---- |
-| Amazon Linux 2   | {{<icon/no>}} | {{<icon/no>}} | Supported in v2.18.0 and later<br>Deprecated in v2.20 |
-| CentOS 7          | {{<icon/no>}}  |                | Deprecated in v2.20 |
-| Oracle Linux 7   | {{<icon/no>}}  |                | Deprecated in v2.20 |
-| Red Hat Enterprise Linux 7 | {{<icon/no>}} |       | Deprecated in v2.20 |
-| Ubuntu 18        | {{<icon/no>}}  | {{<icon/no>}}  | Deprecated in v2.20 |
+| Amazon Linux 2   | {{<icon/no>}} | {{<icon/no>}} | Supported in v2.18.0 and later<br>Deprecated in v2.20<br> Removed support in v2.21. |
+| CentOS 7          | {{<icon/no>}}  |                | Deprecated in v2.20<br> Removed support in v2.21. |
+| Oracle Linux 7   | {{<icon/no>}}  |                | Deprecated in v2.20<br> Removed support in v2.21. |
+| Red Hat Enterprise Linux 7 | {{<icon/no>}} |       | Deprecated in v2.20<br> Removed support in v2.21. |
+| Ubuntu 18        | {{<icon/no>}}  | {{<icon/no>}}  | Deprecated in v2.20<br> Removed support in v2.21. |

--- a/docs/content/stable/reference/configuration/operating-systems.md
+++ b/docs/content/stable/reference/configuration/operating-systems.md
@@ -21,14 +21,19 @@ Unless otherwise noted, operating systems are supported by all supported version
 | :--------------- | :------------- | :------------- | :---- |
 | AlmaLinux 8      | {{<icon/yes>}} | {{<icon/yes>}} | Recommended for production<br>Recommended development platform<br>Default for YBA-deployed nodes |
 | AlmaLinux 9      | {{<icon/yes>}} | {{<icon/yes>}} |       |
-| Amazon Linux 2   | {{<icon/no>}}  | {{<icon/no>}}  | Supported in v2.18.0 and later<br>Deprecated in v2.20 |
-| CentOS 7          | {{<icon/no>}}  |                | Deprecated in v2.20 |
-| Oracle Linux 7   | {{<icon/no>}}  |                | Deprecated in v2.20 |
 | Oracle Linux 8   | {{<icon/yes>}} |                | |
-| Red Hat Enterprise Linux 7 | {{<icon/no>}} |       | Deprecated in v2.20 |
 | Red Hat Enterprise Linux 8 | {{<icon/yes>}} |      | Recommended for production |
 | Red Hat Enterprise Linux&nbsp;9.3 | {{<icon/yes>}} |  | Supported in v2.20.3 and later.  {{<badge/ea>}} |
 | SUSE&nbsp;Linux&nbsp;Enterprise&nbsp;Server&nbsp;15&nbsp;SP5 | {{<icon/yes>}} |     | {{<badge/ea>}} |
-| Ubuntu 18        | {{<icon/no>}}  | {{<icon/no>}}  | Deprecated in v2.20 |
 | Ubuntu 20        | {{<icon/yes>}} | {{<icon/yes>}} |       |
 | Ubuntu 22        | {{<icon/yes>}} | {{<icon/yes>}} | Supported in v2.18.5, v2.20.1 |
+
+The following operating systems and architectures are no longer supported for [deploying YugabyteDB](../../../deploy/manual-deployment/).
+
+| Operating system | x86            | ARM            | Notes |
+| :--------------- | :------------- | :------------- | :---- |
+| Amazon Linux 2   | {{<icon/no>}}  | {{<icon/no>}}  | Supported in v2.18.0 and later<br>Deprecated in v2.20 |
+| CentOS 7          | {{<icon/no>}}  |                | Deprecated in v2.20 |
+| Oracle Linux 7   | {{<icon/no>}}  |                | Deprecated in v2.20 |
+| Red Hat Enterprise Linux 7 | {{<icon/no>}} |       | Deprecated in v2.20 |
+| Ubuntu 18        | {{<icon/no>}}  | {{<icon/no>}}  | Deprecated in v2.20 |

--- a/docs/content/stable/reference/configuration/operating-systems.md
+++ b/docs/content/stable/reference/configuration/operating-systems.md
@@ -13,7 +13,7 @@ type: docs
 
 ## YugabyteDB
 
-The following operating systems and architectures are supported for [deploying YugabyteDB](../../../deploy/manual-deployment/).
+The following table describes the operating system and architecture support for [deploying YugabyteDB](../../../deploy/manual-deployment/).
 
 Unless otherwise noted, operating systems are supported by all supported versions of YugabyteDB and YugabyteDB Anywhere. YugabyteDB Anywhere added support for deploying YugabyteDB to ARM-based systems for non-Kubernetes platforms in v2.18.
 
@@ -28,7 +28,7 @@ Unless otherwise noted, operating systems are supported by all supported version
 | Ubuntu 20        | {{<icon/yes>}} | {{<icon/yes>}} |       |
 | Ubuntu 22        | {{<icon/yes>}} | {{<icon/yes>}} | Supported in v2.18.5, v2.20.1 |
 
-The following operating systems and architectures are no longer supported for [deploying YugabyteDB](../../../deploy/manual-deployment/).
+The following table describes operating systems and architectures that are no longer supported for deploying YugabyteDB.
 
 | Operating system | x86            | ARM            | Notes |
 | :--------------- | :------------- | :------------- | :---- |

--- a/docs/content/stable/reference/configuration/operating-systems.md
+++ b/docs/content/stable/reference/configuration/operating-systems.md
@@ -32,8 +32,8 @@ The following operating systems and architectures are no longer supported for [d
 
 | Operating system | x86            | ARM            | Notes |
 | :--------------- | :------------- | :------------- | :---- |
-| Amazon Linux 2   | {{<icon/no>}}  | {{<icon/no>}}  | Supported in v2.18.0 and later<br>Deprecated in v2.20 |
-| CentOS 7          | {{<icon/no>}}  |                | Deprecated in v2.20 |
-| Oracle Linux 7   | {{<icon/no>}}  |                | Deprecated in v2.20 |
-| Red Hat Enterprise Linux 7 | {{<icon/no>}} |       | Deprecated in v2.20 |
-| Ubuntu 18        | {{<icon/no>}}  | {{<icon/no>}}  | Deprecated in v2.20 |
+| Amazon Linux 2   | {{<icon/no>}}  | {{<icon/no>}}  | Supported in v2.18.0 and later<br>Deprecated in v2.20 <br> Removed support in v2024.1. |
+| CentOS 7          | {{<icon/no>}}  |                | Deprecated in v2.20<br> Removed support in v2024.1. |
+| Oracle Linux 7   | {{<icon/no>}}  |                | Deprecated in v2.20<br> Removed support in v2024.1. |
+| Red Hat Enterprise Linux 7 | {{<icon/no>}} |       | Deprecated in v2.20<br> Removed support in v2024.1. |
+| Ubuntu 18        | {{<icon/no>}}  | {{<icon/no>}}  | Deprecated in v2.20<br> Removed support in v2024.1. |

--- a/docs/content/v2.20/reference/configuration/operating-systems.md
+++ b/docs/content/v2.20/reference/configuration/operating-systems.md
@@ -22,11 +22,11 @@ Unless otherwise noted, operating systems are supported by all supported version
 | AlmaLinux 8      | {{<icon/yes>}} | {{<icon/yes>}} | Recommended for production<br>Recommended development platform<br>Default for YBA-deployed nodes |
 | AlmaLinux 9      | {{<icon/yes>}} | {{<icon/yes>}} |       |
 | Amazon Linux 2   | {{<icon/partial>}} | {{<icon/partial>}} |Supported in v2.18.0 and later<br>Deprecated in v2.20; not supported in v2.21 and subsequent release series. |
-| Amazon Linux 2<br>(ARM, CIS-hardened) |  | {{<icon/yes>}} | Supported only in v2.20.x. Database performance in this environment varies both due to CIS-hardening and ARM. For more information, contact {{% support-general %}}.|
+| Amazon Linux 2<br>(ARM, CIS-hardened) |  | {{<icon/partial>}} | Supported only in v2.20.x. Database performance in this environment varies both due to CIS-hardening and ARM. For more information, contact {{% support-general %}}.|
 | CentOS 7          | {{<icon/partial>}} |                | Deprecated in v2.20; not supported in v2.20.6, v2.21 and subsequent release series. |
-| Oracle 7         | {{<icon/yes>}} |                | Deprecated in v2.20; not supported in v2.20.6, v2.21 and subsequent release series. |
+| Oracle 7         | {{<icon/partial>}} |                | Deprecated in v2.20; not supported in v2.20.6, v2.21 and subsequent release series. |
 | Oracle 8         | {{<icon/yes>}} |                | |
-| Red Hat Enterprise Linux 7 | {{<icon/yes>}} |      | Deprecated in v2.20; not supported in v2.20.6, v2.21 and subsequent release series.|
+| Red Hat Enterprise Linux 7 | {{<icon/partial>}} |      | Deprecated in v2.20; not supported in v2.20.6, v2.21 and subsequent release series.|
 | Red Hat Enterprise Linux 8 | {{<icon/yes>}} |      | Recommended for production |
 | Red Hat Enterprise Linux&nbsp;9.3 | {{<icon/yes>}} |  | Supported in v2.20.3 and later.  {{<badge/ea>}} |
 | SUSE&nbsp;Linux&nbsp;Enterprise&nbsp;Server&nbsp;15&nbsp;SP5 | {{<icon/yes>}} |     | {{<badge/ea>}} |

--- a/docs/content/v2.20/reference/configuration/operating-systems.md
+++ b/docs/content/v2.20/reference/configuration/operating-systems.md
@@ -23,10 +23,10 @@ Unless otherwise noted, operating systems are supported by all supported version
 | AlmaLinux 9      | {{<icon/yes>}} | {{<icon/yes>}} |       |
 | Amazon Linux 2   | {{<icon/partial>}} | {{<icon/partial>}} |Supported in v2.18.0 and later<br>Deprecated in v2.20; not supported in v2.21 and [upcoming release series](/preview/releases/#upcoming-release-series) |
 | Amazon Linux 2<br>(ARM, CIS-hardened) |  | {{<icon/yes>}} | Supported only in v2.20.x. Database performance in this environment varies both due to CIS-hardening and ARM. For more information, contact {{% support-general %}}.|
-| CentOS 7          | {{<icon/partial>}} |                | Deprecated in v2.20; not supported in v2.21 and [upcoming release series](/preview/releases/#upcoming-release-series) |
-| Oracle 7         | {{<icon/yes>}} |                | |
+| CentOS 7          | {{<icon/partial>}} |                | Deprecated in v2.20; not supported in v2.20.6, v2.21 and subsequent release series. |
+| Oracle 7         | {{<icon/yes>}} |                | Deprecated in v2.20; not supported in v2.20.6, v2.21 and subsequent release series. |
 | Oracle 8         | {{<icon/yes>}} |                | |
-| Red Hat Enterprise Linux 7 | {{<icon/yes>}} |      |       |
+| Red Hat Enterprise Linux 7 | {{<icon/yes>}} |      | Deprecated in v2.20; not supported in v2.20.6, v2.21 and subsequent release series.|
 | Red Hat Enterprise Linux 8 | {{<icon/yes>}} |      | Recommended for production |
 | Red Hat Enterprise Linux&nbsp;9.3 | {{<icon/yes>}} |  | Supported in v2.20.3 and later.  {{<badge/ea>}} |
 | SUSE&nbsp;Linux&nbsp;Enterprise&nbsp;Server&nbsp;15&nbsp;SP5 | {{<icon/yes>}} |     | {{<badge/ea>}} |

--- a/docs/content/v2.20/reference/configuration/operating-systems.md
+++ b/docs/content/v2.20/reference/configuration/operating-systems.md
@@ -21,7 +21,7 @@ Unless otherwise noted, operating systems are supported by all supported version
 | :--------------- | :------------- | :------------- | :---- |
 | AlmaLinux 8      | {{<icon/yes>}} | {{<icon/yes>}} | Recommended for production<br>Recommended development platform<br>Default for YBA-deployed nodes |
 | AlmaLinux 9      | {{<icon/yes>}} | {{<icon/yes>}} |       |
-| Amazon Linux 2   | {{<icon/partial>}} | {{<icon/partial>}} |Supported in v2.18.0 and later<br>Deprecated in v2.20; not supported in v2.21 and [upcoming release series](/preview/releases/#upcoming-release-series) |
+| Amazon Linux 2   | {{<icon/partial>}} | {{<icon/partial>}} |Supported in v2.18.0 and later<br>Deprecated in v2.20; not supported in v2.21 and subsequent release series. |
 | Amazon Linux 2<br>(ARM, CIS-hardened) |  | {{<icon/yes>}} | Supported only in v2.20.x. Database performance in this environment varies both due to CIS-hardening and ARM. For more information, contact {{% support-general %}}.|
 | CentOS 7          | {{<icon/partial>}} |                | Deprecated in v2.20; not supported in v2.20.6, v2.21 and subsequent release series. |
 | Oracle 7         | {{<icon/yes>}} |                | Deprecated in v2.20; not supported in v2.20.6, v2.21 and subsequent release series. |
@@ -30,6 +30,6 @@ Unless otherwise noted, operating systems are supported by all supported version
 | Red Hat Enterprise Linux 8 | {{<icon/yes>}} |      | Recommended for production |
 | Red Hat Enterprise Linux&nbsp;9.3 | {{<icon/yes>}} |  | Supported in v2.20.3 and later.  {{<badge/ea>}} |
 | SUSE&nbsp;Linux&nbsp;Enterprise&nbsp;Server&nbsp;15&nbsp;SP5 | {{<icon/yes>}} |     | {{<badge/ea>}} |
-| Ubuntu 18        | {{<icon/partial>}} | {{<icon/partial>}} | Deprecated in v2.20; not supported in v2.21 and [upcoming release series](/preview/releases/#upcoming-release-series) |
+| Ubuntu 18        | {{<icon/partial>}} | {{<icon/partial>}} | Deprecated in v2.20; not supported in v2.21 and subsequent release series. |
 | Ubuntu 20        | {{<icon/yes>}} | {{<icon/yes>}} |       |
 | Ubuntu 22        | {{<icon/yes>}} | {{<icon/yes>}} | Supported in v2.18.5, v2.20.1 |

--- a/docs/content/v2.20/reference/configuration/operating-systems.md
+++ b/docs/content/v2.20/reference/configuration/operating-systems.md
@@ -13,7 +13,7 @@ type: docs
 
 ## YugabyteDB
 
-The following operating systems and architectures are supported for [deploying YugabyteDB](../../../deploy/manual-deployment/).
+The following table describes the operating system and architecture support for [deploying YugabyteDB](../../../deploy/manual-deployment/).
 
 Unless otherwise noted, operating systems are supported by all supported versions of YugabyteDB and YugabyteDB Anywhere. YugabyteDB Anywhere added support for deploying YugabyteDB to ARM-based systems for non-Kubernetes platforms in v2.18.
 


### PR DESCRIPTION
Summary: 
- For the 2.20 OS support page, made the changes as suggested in the ticket: https://deploy-preview-23372--infallible-bardeen-164bc9.netlify.app/v2.20/reference/configuration/operating-systems/
- For the v2.21 and v2024.1 pages, the tables are split into supported entries in one and unsupported entries in a second one. 
https://deploy-preview-23372--infallible-bardeen-164bc9.netlify.app/preview/reference/configuration/operating-systems/
https://deploy-preview-23372--infallible-bardeen-164bc9.netlify.app/stable/reference/configuration/operating-systems/

@netlify /preview/reference/configuration/operating-systems/