### PR TITLE
[Docs] Fix table layout to utilize maximum available space

### DIFF
--- a/docs/assets/scss/_tables.scss
+++ b/docs/assets/scss/_tables.scss
@@ -9,6 +9,10 @@ main {
       margin: 20px 0;
       max-width: 828px;
 
+      @media (min-width:1200px) {
+        max-width: 100%;
+      }
+
       > table {
         margin: 0 !important;
         border: none;


### PR DESCRIPTION
When the right side panel is hidden, HTML table should cover the entire available content space.