### PR TITLE
Update distributed-transactions-ysql.md

### DIFF
--- a/docs/content/preview/explore/transactions/distributed-transactions-ysql.md
+++ b/docs/content/preview/explore/transactions/distributed-transactions-ysql.md
@@ -156,9 +156,7 @@ Each update performed as a part of the transaction is replicated across multiple
 
 ### Concurrency control
 
-[Concurrency control](../../../architecture/transactions/concurrency-control/) in databases ensures that multiple transactions can execute concurrently while preserving data integrity. Concurrency control is essential for correctness in environments where two or more transactions can access the same data at the same time. The two primary mechanisms to achieve concurrency control are optimistic and pessimistic.
-
-YugabyteDB currently supports optimistic concurrency control, with pessimistic concurrency control being worked on actively.
+[Concurrency control](../../../architecture/transactions/concurrency-control/) in databases ensures that multiple transactions can execute concurrently while preserving data integrity. Concurrency control is essential for correctness in environments where two or more transactions can access the same data at the same time.
 
 ## Transaction options
 


### PR DESCRIPTION
Remove usage of the phrases "optimistic locking" and "pessimistic locking". Because "optimistic locking" doesn't really mean anything and is confused with Optimistic Concurrency Control is a totally different concept in the database community. We were using the phrase "optimistic locking" to point to the semantics of Fail-on-Conflict concurrency control mode and "pessimistic locking" to point to the semantics of Wait-on-Conflict concurrency control.