### PR TITLE
[DOC] Remove restart from replicated-migrate start

### DIFF
--- a/docs/content/preview/yugabyte-platform/install-yugabyte-platform/migrate-replicated.md
+++ b/docs/content/preview/yugabyte-platform/install-yugabyte-platform/migrate-replicated.md
@@ -53,7 +53,7 @@ To migrate in place, do the following:
 1. Start the migration, passing in your license file:
 
     ```sh
-    $ sudo ./yba-ctl replicated-migrate start -l /path/to/license && sudo /opt/yba-ctl/yba-ctl restart yb-platform
+    $ sudo ./yba-ctl replicated-migrate start -l /path/to/license
     ```
 
     The `start` command runs all [preflight checks](../../install-yugabyte-platform/install-software/installer/#run-preflight-checks) and then proceeds to do the migration, and then waits for YBA to start.

--- a/docs/content/stable/yugabyte-platform/install-yugabyte-platform/migrate-replicated.md
+++ b/docs/content/stable/yugabyte-platform/install-yugabyte-platform/migrate-replicated.md
@@ -53,7 +53,7 @@ To migrate in place, do the following:
 1. Start the migration, passing in your license file:
 
     ```sh
-    $ sudo ./yba-ctl replicated-migrate start -l /path/to/license && sudo /opt/yba-ctl/yba-ctl restart yb-platform
+    $ sudo ./yba-ctl replicated-migrate start -l /path/to/license
     ```
 
     The `start` command runs all [preflight checks](../../install-yugabyte-platform/install-software/installer/#run-preflight-checks) and then proceeds to do the migration, and then waits for YBA to start.

--- a/docs/content/v2.20/yugabyte-platform/install-yugabyte-platform/install-software/installer.md
+++ b/docs/content/v2.20/yugabyte-platform/install-yugabyte-platform/install-software/installer.md
@@ -253,7 +253,7 @@ To migrate your installation from Replicated, do the following:
 1. Start the migration, passing in your license file:
 
     ```sh
-    $ sudo ./yba-ctl replicated-migrate start -l /path/to/license && sudo /opt/yba-ctl/yba-ctl restart yb-platform
+    $ sudo ./yba-ctl replicated-migrate start -l /path/to/license
     ```
 
     The `start` command runs all [preflight checks](#run-preflight-checks) and then proceeds to do the migration, and then waits for YBA to start.


### PR DESCRIPTION
Don't need to restart YBA after replicated migrate