### PR TITLE
Fix warning/note for preview/stable

### DIFF
--- a/docs/layouts/partials/earlier-version-warning.html
+++ b/docs/layouts/partials/earlier-version-warning.html
@@ -27,6 +27,7 @@
   {{- else if eq .alias "preview" -}}
     {{- $previewVersion = .series -}}
   {{- end -}}
+
 {{- end -}}
 
 {{/** Do nothing if this is the latest stable and preview is behind stable **/}}

--- a/docs/layouts/partials/earlier-version-warning.html
+++ b/docs/layouts/partials/earlier-version-warning.html
@@ -45,7 +45,7 @@
                   use the <a href="{{ $previewUrl }}">preview ({{ $previewVersion }}) version.</a>
                   {{/** For older stable versions, Add link to latest stable **/}}
                   {{ if not (eq .alias "stable") }}
-                  For the latest stable version, go to <a href="{{ $stableUrl }}">stable ({{ $stableVersion }})</a> version.
+                  For the latest stable version, see <a href="{{ $stableUrl }}">({{ $stableVersion }})</a>.
                   {{- end -}}
                 </p>
               </div>
@@ -54,8 +54,8 @@
             {{/** If a stable page does not exist, this is an unversioned page!!!! **/}}
             {{- if $stableExists -}}
               <div class="admonition warning">
-                <p>This page documents the preview ({{ $previewVersion }}) version that is to be used for testing and development with the
-                  latest features only. For production, use the <a href="{{ $stableUrl }}"> stable ({{ $stableVersion }})</a> version.</p>
+                <p>This page documents the preview ({{ $previewVersion }}) version. Preview includes features under active development and is for development and testing only.
+                 For production, use the <a href="{{ $stableUrl }}"> stable ({{ $stableVersion }})</a> version.</p>
               </div>
             {{- end -}}
           {{- else -}}

--- a/docs/layouts/partials/earlier-version-warning.html
+++ b/docs/layouts/partials/earlier-version-warning.html
@@ -10,12 +10,14 @@
 
 {{ $pathsplit := after 1 (split .Page.File "/")}}
 {{/** Keep track of whether preview version exists for this file **/}}
-{{ $previewExists := fileExists (path.Join "content/preview" $pathsplit) }}
+{{ $previewPath := path.Join "content/preview" $pathsplit }}
+{{ $previewExists := fileExists $previewPath }}
 
 {{/** Keep track of whether stable version exists for this file **/}}
-{{ $stableExists := fileExists (path.Join "content/stable" $pathsplit) }}
+{{ $stablePath := path.Join "content/stable" $pathsplit }}
+{{ $stableExists := fileExists $stablePath }}
 
-{{/* warnf "%s - %s-%s/%s" (path.Join "content/preview" $pathsplit) $previewExists $stableExists */}}
+{{warnf "%s(%s) - %s(%s)" $previewPath $previewExists $stablePath $stableExists }}
 
 {{/** Identify is preview is behind stable and which versions are preview and stable **/}}
 {{ range .Site.Data.currentVersions.dbVersions }}

--- a/docs/layouts/partials/earlier-version-warning.html
+++ b/docs/layouts/partials/earlier-version-warning.html
@@ -1,27 +1,46 @@
-{{ if not (eq ($.Scratch.Get "docVersion") "preview") }}
-  {{ $docVersion := $.Scratch.Get "docVersion" }}
-  {{ $urlArray := split (urls.Parse .Permalink).Path "/" }}
-  {{ $previewUrl := path.Join "preview" (after 2 $urlArray) }}
-  {{ $previewUrl = add (add "/" $previewUrl) "/" }}
-  {{ $previewVersion := "" }}
+{{ $docVersion := $.Scratch.Get "docVersion" }}
+{{ $urlArray := split (urls.Parse .Permalink).Path "/" }}
+{{ $previewUrl := path.Join "preview" (after 2 $urlArray) }}
+{{ $previewUrl = add (add "/" $previewUrl) "/" }}
+{{ $stableUrl := path.Join "stable" (after 2 $urlArray) }}
+{{ $stableUrl = add (add "/" $stableUrl) "/" }}
+{{ $previewVersion := "" }}
+{{ $stableVersion := "" }}
+{{ $previewBehindStable := false }}
 
-  {{- if .Site.Params.yb.preview_version -}}
-    {{ $previewVersion = printf "(%s)" .Site.Params.yb.preview_version }}
+{{ range .Site.Data.currentVersions.dbVersions }}
+  {{- if eq .alias "stable" -}}
+    {{ $stableVersion = .series -}}
+    {{- if in .PreviewBehindStable true -}}
+      {{ $previewBehindStable = true }}
+    {{- end -}}
+  {{- else if eq .alias "preview" -}}
+    {{- $previewVersion = .series -}}
   {{- end -}}
+{{- end -}}
 
+{{- if not (and (eq $docVersion "stable") $previewBehindStable) -}}
   {{ range .Site.Data.currentVersions.dbVersions }}
-    {{- if not (in .PreviewBehindStable true) -}}
       {{- if or (eq $docVersion .series) (eq $docVersion .alias)  -}}
-        <div class="admonition note">
+        <div class="admonition {{if eq .alias "preview"}}warning{{else}}note{{end}}">
           {{- if or (eq .isLTS true) (eq .isSTS true) -}}
-            <!-- <p class="admonition-title">Attention</p> -->
-            <p>This page documents a stable (production) version. For testing and development with the latest features, use the <a href="{{ $previewUrl }}">preview {{ $previewVersion }} version.</a></p>
+            <p>This page documents a stable (production) version. For testing and development with the latest features,
+              use the <a href="{{ $previewUrl }}">preview ({{ $previewVersion }}) version.</a>
+            {{ if not (eq .alias "stable") }}
+            For the latest stable version, go to <a href="{{ $stableUrl }}">stable ({{ $stableVersion }})</a> version.
+            {{ end }}
+            </p>
+          {{- else if eq .alias "preview" -}}
+            <p>This page documents the preview ({{ $previewVersion }}) version that is to be used for testing and development with the
+              latest features only. For production, use the <a href="{{ $stableUrl }}"> stable ({{ $stableVersion }})</a> version.</p>
           {{- else -}}
-            <!-- <p class="admonition-title">Attention</p> -->
-            <p>This page documents an earlier version. <a href="{{ $previewUrl }}">Go to the preview {{ $previewVersion }} version.</a></p>
+            {{- if $previewBehindStable -}}
+              <p>This page documents an earlier version. Go to the <a href="{{ $stableUrl }}">stable ({{ $stableVersion }})</a> version.</p>
+            {{- else -}}
+              <p>This page documents an earlier version. Go to the <a href="{{ $previewUrl }}">preview ({{ $previewVersion }})</a> version.</p>
+            {{- end -}}
           {{- end -}}
         </div>
       {{- end -}}
-    {{- end -}}
   {{- end -}}
-{{ end }}
+{{- end -}}

--- a/docs/layouts/partials/earlier-version-warning.html
+++ b/docs/layouts/partials/earlier-version-warning.html
@@ -8,6 +8,16 @@
 {{ $stableVersion := "" }}
 {{ $previewBehindStable := false }}
 
+{{ $pathsplit := after 1 (split .Page.File "/")}}
+{{/** Keep track of whether preview version exists for this file **/}}
+{{ $previewExists := fileExists (path.Join "content/preview" $pathsplit) }}
+
+{{/** Keep track of whether stable version exists for this file **/}}
+{{ $stableExists := fileExists (path.Join "content/stable" $pathsplit) }}
+
+{{/* warnf "%s - %s-%s/%s" (path.Join "content/preview" $pathsplit) $previewExists $stableExists */}}
+
+{{/** Identify is preview is behind stable and which versions are preview and stable **/}}
 {{ range .Site.Data.currentVersions.dbVersions }}
   {{- if eq .alias "stable" -}}
     {{ $stableVersion = .series -}}
@@ -19,28 +29,43 @@
   {{- end -}}
 {{- end -}}
 
+{{/** Do nothing if this is the latest stable and preview is behind stable **/}}
 {{- if not (and (eq $docVersion "stable") $previewBehindStable) -}}
   {{ range .Site.Data.currentVersions.dbVersions }}
       {{- if or (eq $docVersion .series) (eq $docVersion .alias)  -}}
-        <div class="admonition {{if eq .alias "preview"}}warning{{else}}note{{end}}">
+          {{/** for LTS and STS **/}}
           {{- if or (eq .isLTS true) (eq .isSTS true) -}}
-            <p>This page documents a stable (production) version. For testing and development with the latest features,
-              use the <a href="{{ $previewUrl }}">preview ({{ $previewVersion }}) version.</a>
-            {{ if not (eq .alias "stable") }}
-            For the latest stable version, go to <a href="{{ $stableUrl }}">stable ({{ $stableVersion }})</a> version.
-            {{ end }}
-            </p>
+            {{/** Do nothing if preview does not exist for this file **/}}
+            {{- if $previewExists -}}
+              <div class="admonition note">
+                <p>This page documents a stable (production) version. For testing and development with the latest features,
+                  use the <a href="{{ $previewUrl }}">preview ({{ $previewVersion }}) version.</a>
+                  {{/** For older stable versions, Add link to latest stable **/}}
+                  {{ if not (eq .alias "stable") }}
+                  For the latest stable version, go to <a href="{{ $stableUrl }}">stable ({{ $stableVersion }})</a> version.
+                  {{- end -}}
+                </p>
+              </div>
+            {{- end -}}
           {{- else if eq .alias "preview" -}}
-            <p>This page documents the preview ({{ $previewVersion }}) version that is to be used for testing and development with the
-              latest features only. For production, use the <a href="{{ $stableUrl }}"> stable ({{ $stableVersion }})</a> version.</p>
+            {{/** If a stable page does not exist, this is an unversioned page!!!! **/}}
+            {{- if $stableExists -}}
+              <div class="admonition warning">
+                <p>This page documents the preview ({{ $previewVersion }}) version that is to be used for testing and development with the
+                  latest features only. For production, use the <a href="{{ $stableUrl }}"> stable ({{ $stableVersion }})</a> version.</p>
+              </div>
+            {{- end -}}
           {{- else -}}
-            {{- if $previewBehindStable -}}
-              <p>This page documents an earlier version. Go to the <a href="{{ $stableUrl }}">stable ({{ $stableVersion }})</a> version.</p>
-            {{- else -}}
-              <p>This page documents an earlier version. Go to the <a href="{{ $previewUrl }}">preview ({{ $previewVersion }})</a> version.</p>
+            {{- if and $previewBehindStable $stableExists }}
+              <div class="admonition note">
+                <p>This page documents an earlier version. Go to the <a href="{{ $stableUrl }}">stable ({{ $stableVersion }})</a> version.</p>
+              </div>
+            {{- else if $previewExists -}}
+            <div class="admonition note">
+                <p>This page documents an earlier version. Go to the <a href="{{ $previewUrl }}">preview ({{ $previewVersion }})</a> version.</p>
+              </div>
             {{- end -}}
           {{- end -}}
-        </div>
       {{- end -}}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
- On stable when preview is behind stable - do nothing.
- For preview: warning box and link to the stable
- For stable: note with link to preview
- For older LTS/STS other than stable :  note with link to preview and to the latest stable