### PR TITLE
Change flags list from table to sections

### DIFF
--- a/docs/content/preview/reference/configuration/all-flags-yb-master.md
+++ b/docs/content/preview/reference/configuration/all-flags-yb-master.md
@@ -13,4 +13,4 @@ Use the yb-master binary and its flags to configure the [YB-Master](../../../arc
 
 For a list of all YB-TServer flags, see [All YB-TServer flags](../all-flags-yb-tserver/).
 
-{{<flags/flag-table process="master">}}
+{{%all-flags-list process="master"%}}

--- a/docs/content/preview/reference/configuration/all-flags-yb-tserver.md
+++ b/docs/content/preview/reference/configuration/all-flags-yb-tserver.md
@@ -13,4 +13,4 @@ Use the yb-tserver binary and its flags to configure the [YB-TServer](../../../a
 
 For a list of all YB-Master flags, see [All YB-Master flags](../all-flags-yb-master/).
 
-{{<flags/flag-table process="tserver">}}
+{{%all-flags-list process="tserver"%}}

--- a/docs/content/stable/reference/configuration/all-flags-yb-master.md
+++ b/docs/content/stable/reference/configuration/all-flags-yb-master.md
@@ -13,4 +13,4 @@ Use the yb-master binary and its flags to configure the [YB-Master](../../../arc
 
 For a list of all YB-TServer flags, see [All YB-TServer flags](../all-flags-yb-tserver/).
 
-{{<flags/flag-table process="master">}}
+{{%all-flags-list process="master"%}}

--- a/docs/content/stable/reference/configuration/all-flags-yb-tserver.md
+++ b/docs/content/stable/reference/configuration/all-flags-yb-tserver.md
@@ -13,4 +13,4 @@ Use the yb-tserver binary and its flags to configure the [YB-TServer](../../../a
 
 For a list of all YB-Master flags, see [All YB-Master flags](../all-flags-yb-master/).
 
-{{<flags/flag-table process="tserver">}}
+{{%all-flags-list process="tserver"%}}

--- a/docs/content/v2.14/reference/configuration/all-flags-yb-master.md
+++ b/docs/content/v2.14/reference/configuration/all-flags-yb-master.md
@@ -13,4 +13,4 @@ Use the yb-master binary and its flags to configure the [YB-Master](../../../arc
 
 For a list of all YB-TServer flags, see [All YB-TServer flags](../all-flags-yb-tserver/).
 
-{{<flags/flag-table process="master">}}
+{{%all-flags-list process="master"%}}

--- a/docs/content/v2.14/reference/configuration/all-flags-yb-tserver.md
+++ b/docs/content/v2.14/reference/configuration/all-flags-yb-tserver.md
@@ -13,4 +13,4 @@ Use the yb-tserver binary and its flags to configure the [YB-TServer](../../../a
 
 For a list of all YB-Master flags, see [All YB-Master flags](../all-flags-yb-master/).
 
-{{<flags/flag-table process="tserver">}}
+{{%all-flags-list process="tserver"%}}

--- a/docs/content/v2.18/reference/configuration/all-flags-yb-master.md
+++ b/docs/content/v2.18/reference/configuration/all-flags-yb-master.md
@@ -13,4 +13,4 @@ Use the yb-master binary and its flags to configure the [YB-Master](../../../arc
 
 For a list of all YB-TServer flags, see [All YB-TServer flags](../all-flags-yb-tserver/).
 
-{{<flags/flag-table process="master">}}
+{{%all-flags-list process="master"%}}

--- a/docs/content/v2.18/reference/configuration/all-flags-yb-tserver.md
+++ b/docs/content/v2.18/reference/configuration/all-flags-yb-tserver.md
@@ -13,4 +13,4 @@ Use the yb-tserver binary and its flags to configure the [YB-TServer](../../../a
 
 For a list of all YB-Master flags, see [All YB-Master flags](../all-flags-yb-master/).
 
-{{<flags/flag-table process="tserver">}}
+{{%all-flags-list process="tserver"%}}

--- a/docs/content/v2.20/reference/configuration/all-flags-yb-master.md
+++ b/docs/content/v2.20/reference/configuration/all-flags-yb-master.md
@@ -13,4 +13,4 @@ Use the yb-master binary and its flags to configure the [YB-Master](../../../arc
 
 For a list of all YB-TServer flags, see [All YB-TServer flags](../all-flags-yb-tserver/).
 
-{{<flags/flag-table process="master">}}
+{{%all-flags-list process="master"%}}

--- a/docs/content/v2.20/reference/configuration/all-flags-yb-tserver.md
+++ b/docs/content/v2.20/reference/configuration/all-flags-yb-tserver.md
@@ -13,4 +13,4 @@ Use the yb-tserver binary and its flags to configure the [YB-TServer](../../../a
 
 For a list of all YB-Master flags, see [All YB-Master flags](../all-flags-yb-master/).
 
-{{<flags/flag-table process="tserver">}}
+{{%all-flags-list process="tserver"%}}

--- a/docs/layouts/shortcodes/all-flags-list.html
+++ b/docs/layouts/shortcodes/all-flags-list.html
@@ -47,7 +47,7 @@
 <!-- XML to table -->
 
 {{ range $data.flag}}
-## {{.name}}
+#### {{.name}}
 {{.meaning}} (**_Default_: {{ default "None" (or .default .target)}}**{{if .tags}} - _{{replaceRE "," ", " .tags}}_{{end}})
 
 {{ end }}

--- a/docs/layouts/shortcodes/all-flags-list.html
+++ b/docs/layouts/shortcodes/all-flags-list.html
@@ -1,6 +1,6 @@
 {{/*
 	Syntax:
-	  {{<flags/flag-table process="<process>">}}
+	  {{<all-flags-list process="<process>">}}
 
 	process:
 	  * "tserver"
@@ -45,23 +45,9 @@
 
 <!-- <pre>{{ debug.Dump $data }}</pre> -->
 <!-- XML to table -->
-<table class="sno-1">
-	<thead>
-		<tr>
-			<th style="text-align:right" >NAME</th>
-			<th>ATTRIBUTES</th>
-		</tr>
-	</thead>
-	<tbody>
-		{{ range $data.flag}}
-		<tr >
-			<td style="text-align:right">{{ .name }}</td>
-			<td>
-				<b>DEFAULT:</b> {{ or .default .target}} <br>
-				<b>TAGS:</b> {{ or .tags "N/A"}} <br>
-				<b>DESCRIPTION:</b> {{ .meaning }}
-			</td>
-		</tr>
-		{{ end }}
-	</tbody>
-</table>
+
+{{ range $data.flag}}
+## {{.name}}
+{{.meaning}} (**_Default_: {{ default "None" (or .default .target)}}**{{if .tags}} - _{{replaceRE "," ", " .tags}}_{{end}})
+
+{{ end }}


### PR DESCRIPTION
- Because it is a plain page with one large table, the page is not indexed by Algolia.
- Separating it into sections with linkable headers

@netlify /preview/reference/configuration/all-flags-yb-master/