### PR TITLE
[docs] changed flag "enable_pg_parity_early_access" to "enable_pg_parity_tech_preview" in stable

### DIFF
--- a/docs/content/preview/reference/configuration/yugabyted.md
+++ b/docs/content/preview/reference/configuration/yugabyted.md
@@ -751,7 +751,7 @@ For on-premises deployments, consider racks as zones to treat them as fault doma
 : Enable or disable the backup daemon with yugabyted start. Default: `false`
 : If you start a cluster using the `--backup_daemon` flag, you also need to download and extract the [YB Controller release](https://downloads.yugabyte.com/ybc/2.1.0.0-b9/ybc-2.1.0.0-b9-linux-x86_64.tar.gz) to the yugabyte-{{< yb-version version="preview" >}} release directory.
 
---enable_pg_parity_tech_preview *PostgreSQL-compatibilty*
+--enable_pg_parity_early_access *PostgreSQL-compatibilty*
 : Enable Enhanced PostgreSQL Compatibility Mode. Default: `false`
 
 #### Advanced flags
@@ -1240,7 +1240,7 @@ To create a secure multi-zone cluster:
     ```sh
     ./bin/yugabyted start --secure --advertise_address=<host-ip> \
         --cloud_location=aws.us-east-1.us-east-1a \
-        --fault_tolerance=zone 
+        --fault_tolerance=zone
     ```
 
 1. Create certificates for the second and third virtual machine (VM) for SSL and TLS connection, as follows:
@@ -1614,7 +1614,7 @@ To create the read replica cluster, do the following:
         --base_dir=$HOME/yugabyte-{{< yb-version version="preview" >}}/node6 \
         --cloud_location=aws.us-east-1.us-east-1e \
         --read_replica
-    
+
     ./bin/yugabyted start \
         --advertise_address=127.0.0.7 \
         --join=127.0.0.1 \

--- a/docs/content/preview/releases/ybdb-releases/v2.21.md
+++ b/docs/content/preview/releases/ybdb-releases/v2.21.md
@@ -345,12 +345,12 @@ Converted the `ysql_skip_row_lock_for_update` to an auto-flag to resolve compati
 
 We're pleased to announce the tech preview of the new Enhanced Postgres Compatibility Mode in the 2.21.0.0 release. This mode enables you to take advantage of many new improvements in both PostgreSQL compatibility and performance parity, making it even easier to lift and shift your applications from PostgreSQL to YugabyteDB. When this mode is turned on, YugabyteDB uses the [Read-Committed](../../../architecture/transactions/read-committed/) isolation mode, the [Wait-on-Conflict](../../../architecture/transactions/concurrency-control/#wait-on-conflict) concurrency mode for predictable P99 latencies, and the new Cost Based Optimizer that takes advantage of the distributed storage layer architecture and includes query pushdowns, LSM indexes, and [batched nested loop joins](../../../explore/ysql-language-features/join-strategies/#batched-nested-loop-join-bnl) to offer PostgreSQL-like performance.
 
-You can enable the compatibility mode by passing the `enable_pg_parity_tech_preview` flag to [yugabyted](../../../reference/configuration/yugabyted/#yugabyted), when bringing up your cluster.
+You can enable the compatibility mode by passing the `enable_pg_parity_early_access` flag to [yugabyted](../../../reference/configuration/yugabyted/#yugabyted), when bringing up your cluster.
 
 For example, from your YugabyteDB home directory, run the following command:
 
 ```sh
-./bin/yugabyted start --enable_pg_parity_tech_preview
+./bin/yugabyted start --enable_pg_parity_early_access
 ```
 
 Note: When enabling the cost models, ensure that packed row for colocated tables is enabled by setting the `--ysql_enable_packed_row_for_colocated_table` flag to true.

--- a/docs/content/preview/releases/ybdb-releases/v2024.1.md
+++ b/docs/content/preview/releases/ybdb-releases/v2024.1.md
@@ -447,7 +447,7 @@ Rolling back to the pre-upgrade version if you're not satisfied with the upgrade
 
 * Directly enables `yb_enable_read_committed_isolation` and `ysql_enable_read_request_caching` on yb-master and yb-tserver processes. {{<issue 22061>}}
 * Simplifies yugabyted by dropping Python2 support and transitioning the script to use Python3, replacing deprecated distutils package with shutil. {{<issue 22072>}},{{<issue 21409>}}
-* Changes the flag name for enabling PostgreSQL feature parity from `enable_pg_parity_tech_preview` to `enable_pg_parity_early_access` in yugabyted. {{<issue 21221>}}
+* Changes the flag name for enabling PostgreSQL feature parity from `` to `enable_pg_parity_early_access` in yugabyted. {{<issue 21221>}}
 
 ### Bug fixes
 

--- a/docs/content/preview/releases/ybdb-releases/v2024.1.md
+++ b/docs/content/preview/releases/ybdb-releases/v2024.1.md
@@ -447,7 +447,7 @@ Rolling back to the pre-upgrade version if you're not satisfied with the upgrade
 
 * Directly enables `yb_enable_read_committed_isolation` and `ysql_enable_read_request_caching` on yb-master and yb-tserver processes. {{<issue 22061>}}
 * Simplifies yugabyted by dropping Python2 support and transitioning the script to use Python3, replacing deprecated distutils package with shutil. {{<issue 22072>}},{{<issue 21409>}}
-* Changes the flag name for enabling PostgreSQL feature parity from `` to `enable_pg_parity_early_access` in yugabyted. {{<issue 21221>}}
+* Changes the flag name for enabling PostgreSQL feature parity from `enable_pg_parity_tech_preview` to `enable_pg_parity_early_access` in yugabyted. {{<issue 21221>}}
 
 ### Bug fixes
 

--- a/docs/content/preview/releases/ybdb-releases/v2024.1.md
+++ b/docs/content/preview/releases/ybdb-releases/v2024.1.md
@@ -447,7 +447,6 @@ Rolling back to the pre-upgrade version if you're not satisfied with the upgrade
 
 * Directly enables `yb_enable_read_committed_isolation` and `ysql_enable_read_request_caching` on yb-master and yb-tserver processes. {{<issue 22061>}}
 * Simplifies yugabyted by dropping Python2 support and transitioning the script to use Python3, replacing deprecated distutils package with shutil. {{<issue 22072>}},{{<issue 21409>}}
-* Changes the flag name for enabling PostgreSQL feature parity from `enable_pg_parity_tech_preview` to `enable_pg_parity_early_access` in yugabyted. {{<issue 21221>}}
 
 ### Bug fixes
 

--- a/docs/content/stable/explore/ysql-language-features/postgresql-compatibility.md
+++ b/docs/content/stable/explore/ysql-language-features/postgresql-compatibility.md
@@ -133,12 +133,12 @@ Enables the use of PostgreSQL [parallel queries](https://www.postgresql.org/docs
 
 To enable EPCM in YugabyteDB:
 
-- Pass the `enable_pg_parity_early_access` flag to [yugabyted](../../../reference/configuration/yugabyted/) when starting your cluster.
+- Pass the `enable_pg_parity_tech_preview` flag to [yugabyted](../../../reference/configuration/yugabyted/) when starting your cluster.
 
 For example, from your YugabyteDB home directory, run the following command:
 
 ```sh
-./bin/yugabyted start --enable_pg_parity_early_access
+./bin/yugabyted start --enable_pg_parity_tech_preview
 ```
 
 Note: When enabling the cost models, ensure that packed row for colocated tables is enabled by setting the `--ysql_enable_packed_row_for_colocated_table` flag to true.

--- a/docs/content/stable/reference/configuration/yugabyted.md
+++ b/docs/content/stable/reference/configuration/yugabyted.md
@@ -324,13 +324,13 @@ Enable point-in-time recovery for a database:
 Disable point-in-time recovery for a database:
 
 ```sh
-./bin/yugabyted configure point_in_time_recovery --disable --database <database_name> 
+./bin/yugabyted configure point_in_time_recovery --disable --database <database_name>
 ```
 
 Display point-in-time schedules configured on the cluster:
 
 ```sh
-./bin/yugabyted configure point_in_time_recovery --status 
+./bin/yugabyted configure point_in_time_recovery --status
 ```
 
 #### admin_operation
@@ -747,7 +747,7 @@ For on-premises deployments, consider racks as zones to treat them as fault doma
 : Enable or disable the backup daemon with yugabyted start. Default: `false`
 : If you start a cluster using the `--backup_daemon` flag, you also need to download and extract the [YB Controller release](https://downloads.yugabyte.com/ybc/2.1.0.0-b9/ybc-2.1.0.0-b9-linux-x86_64.tar.gz) to the yugabyte-{{< yb-version version="stable" >}} release directory.
 
---enable_pg_parity_early_access *PostgreSQL-compatibilty*
+--enable_pg_parity_tech_preview *PostgreSQL-compatibilty*
 : Enable Enhanced PostgreSQL Compatibility Mode. Default: `false`
 
 #### Advanced flags
@@ -1236,7 +1236,7 @@ To create a secure multi-zone cluster:
     ```sh
     ./bin/yugabyted start --secure --advertise_address=<host-ip> \
         --cloud_location=aws.us-east-1.us-east-1a \
-        --fault_tolerance=zone 
+        --fault_tolerance=zone
     ```
 
 1. Create certificates for the second and third virtual machine (VM) for SSL and TLS connection, as follows:
@@ -1610,7 +1610,7 @@ To create the read replica cluster, do the following:
         --base_dir=$HOME/yugabyte-{{< yb-version version="stable" >}}/node6 \
         --cloud_location=aws.us-east-1.us-east-1e \
         --read_replica
-    
+
     ./bin/yugabyted start \
         --advertise_address=127.0.0.7 \
         --join=127.0.0.1 \


### PR DESCRIPTION
As per https://yugabyte.slack.com/archives/CDQB8MEAU/p1726095196976899?thread_ts=1726065292.830579&cid=CDQB8MEAU, 
- enable_pg_parity_early_access is in 2.21
- enable_pg_parity_tech_preview is in 2024.1