### PR TITLE
[#24166] DOCS: CDCSDK: Fix lag metric name in documentation

### DIFF
--- a/docs/content/preview/explore/change-data-capture/using-logical-replication/monitor.md
+++ b/docs/content/preview/explore/change-data-capture/using-logical-replication/monitor.md
@@ -77,7 +77,7 @@ Provide information about CDC service in YugabyteDB.
 | :---- | :---- | :---- |
 | cdcsdk_change_event_count | `long` | The number of records sent by the CDC Service. |
 | cdcsdk_traffic_sent | `long` | Total traffic sent, in bytes. |
-| cdcsdk_event_lag_micros | `long` | The LAG metric is calculated by subtracting the timestamp of the latest record in the WAL of a tablet from the last record sent to the CDC connector. |
+| cdcsdk_sent_lag_micros | `long` | The LAG metric is calculated by subtracting the timestamp of the latest record in the WAL of a tablet from the last record sent to the CDC connector. |
 | cdcsdk_expiry_time_ms | `long` | The time left to read records from WAL is tracked by the Stream Expiry Time (ms). |
 
 ## Connector metrics

--- a/docs/content/preview/explore/change-data-capture/using-yugabytedb-grpc-replication/cdc-monitor.md
+++ b/docs/content/preview/explore/change-data-capture/using-yugabytedb-grpc-replication/cdc-monitor.md
@@ -60,7 +60,7 @@ Provide information about CDC service in YugabyteDB.
 | :---- | :---- | :---- |
 | cdcsdk_change_event_count | `long` | The Change Event Count metric shows the number of records sent by the CDC Service. |
 | cdcsdk_traffic_sent | `long` | Total traffic sent, in bytes. |
-| cdcsdk_event_lag_micros | `long` | The LAG metric is calculated by subtracting the timestamp of the latest record in the WAL of a tablet from the last record sent to the CDC connector. |
+| cdcsdk_sent_lag_micros | `long` | The LAG metric is calculated by subtracting the timestamp of the latest record in the WAL of a tablet from the last record sent to the CDC connector. |
 | cdcsdk_expiry_time_ms | `long` | The time left to read records from WAL is tracked by the Stream Expiry Time (ms). |
 
 ### Snapshot metrics

--- a/docs/content/stable/explore/change-data-capture/using-logical-replication/monitor.md
+++ b/docs/content/stable/explore/change-data-capture/using-logical-replication/monitor.md
@@ -77,7 +77,7 @@ Provide information about CDC service in YugabyteDB.
 | :---- | :---- | :---- |
 | cdcsdk_change_event_count | `long` | The number of records sent by the CDC Service. |
 | cdcsdk_traffic_sent | `long` | Total traffic sent, in bytes. |
-| cdcsdk_event_lag_micros | `long` | The LAG metric is calculated by subtracting the timestamp of the latest record in the WAL of a tablet from the last record sent to the CDC connector. |
+| cdcsdk_sent_lag_micros | `long` | The LAG metric is calculated by subtracting the timestamp of the latest record in the WAL of a tablet from the last record sent to the CDC connector. |
 | cdcsdk_expiry_time_ms | `long` | The time left to read records from WAL is tracked by the Stream Expiry Time (ms). |
 
 ## Connector metrics

--- a/docs/content/stable/explore/change-data-capture/using-yugabytedb-grpc-replication/cdc-monitor.md
+++ b/docs/content/stable/explore/change-data-capture/using-yugabytedb-grpc-replication/cdc-monitor.md
@@ -58,7 +58,7 @@ Provide information about CDC service in YugabyteDB.
 | :---- | :---- | :---- |
 | cdcsdk_change_event_count | `long` | The Change Event Count metric shows the number of records sent by the CDC Service. |
 | cdcsdk_traffic_sent | `long` | Total traffic sent, in bytes. |
-| cdcsdk_event_lag_micros | `long` | The LAG metric is calculated by subtracting the timestamp of the latest record in the WAL of a tablet from the last record sent to the CDC connector. |
+| cdcsdk_sent_lag_micros | `long` | The LAG metric is calculated by subtracting the timestamp of the latest record in the WAL of a tablet from the last record sent to the CDC connector. |
 | cdcsdk_expiry_time_ms | `long` | The time left to read records from WAL is tracked by the Stream Expiry Time (ms). |
 
 ### Snapshot metrics

--- a/docs/content/v2.18/explore/change-data-capture/cdc-monitor.md
+++ b/docs/content/v2.18/explore/change-data-capture/cdc-monitor.md
@@ -58,7 +58,7 @@ Provide information about CDC service in YugabyteDB.
 | :---- | :---- | :---- |
 | cdcsdk_change_event_count | `long` | The Change Event Count metric shows the number of records sent by the CDC Service. |
 | cdcsdk_traffic_sent | `long` | Total traffic sent, in bytes. |
-| cdcsdk_event_lag_micros | `long` | The LAG metric is calculated by subtracting the timestamp of the latest record in the WAL of a tablet from the last record sent to the CDC connector. |
+| cdcsdk_sent_lag_micros | `long` | The LAG metric is calculated by subtracting the timestamp of the latest record in the WAL of a tablet from the last record sent to the CDC connector. |
 | cdcsdk_expiry_time_ms | `long` | The time left to read records from WAL is tracked by the Stream Expiry Time (ms). |
 
 ### Snapshot metrics

--- a/docs/content/v2.20/explore/change-data-capture/cdc-monitor.md
+++ b/docs/content/v2.20/explore/change-data-capture/cdc-monitor.md
@@ -58,7 +58,7 @@ Provide information about CDC service in YugabyteDB.
 | :---- | :---- | :---- |
 | cdcsdk_change_event_count | `long` | The Change Event Count metric shows the number of records sent by the CDC Service. |
 | cdcsdk_traffic_sent | `long` | Total traffic sent, in bytes. |
-| cdcsdk_event_lag_micros | `long` | The LAG metric is calculated by subtracting the timestamp of the latest record in the WAL of a tablet from the last record sent to the CDC connector. |
+| cdcsdk_sent_lag_micros | `long` | The LAG metric is calculated by subtracting the timestamp of the latest record in the WAL of a tablet from the last record sent to the CDC connector. |
 | cdcsdk_expiry_time_ms | `long` | The time left to read records from WAL is tracked by the Stream Expiry Time (ms). |
 
 ### Snapshot metrics


### PR DESCRIPTION
In the current CDC documentation, the name of the lag metric is incorrectly mentioned as `cdcsdk_event_lag_micros`. (For example [here](https://docs.yugabyte.com/preview/explore/change-data-capture/using-logical-replication/monitor/#cdc-service-metrics)).

This PR corrects the name to `cdcsdk_sent_lag_micros`.