### PR TITLE
[Docs] Fix Code snippet

### DIFF
--- a/docs/assets/scss/_code_block.scss
+++ b/docs/assets/scss/_code_block.scss
@@ -15,7 +15,7 @@ main {
       border: 1px solid #d7dee4;
       border-radius: 4px;
       color: $yb-font-gray;
-      padding: 3 6px;
+      padding: 3px 6px;
     }
 
     p > a {


### PR DESCRIPTION
Code snippet style inside the call out section is broken. Missing all paddings [View the issue](https://docs.yugabyte.com/stable/explore/going-beyond-sql/#cluster-topology).