### PR TITLE
Update default ycql password to match default cassandra password

### DIFF
--- a/yugabyted-ui/apiserver/cmd/server/helpers/parse_command_line_flags.go
+++ b/yugabyted-ui/apiserver/cmd/server/helpers/parse_command_line_flags.go
@@ -43,7 +43,7 @@ func init() {
         "username for connecting to ycql.")
     flag.StringVar(&DbYsqlPassword, "ysql_password", "yugabyte",
         "password for connecting to the ysql database.")
-    flag.StringVar(&DbYcqlPassword, "ycql_password", "yugabyte",
+    flag.StringVar(&DbYcqlPassword, "ycql_password", "cassandra",
         "password for connecting to the ycql database.")
     flag.StringVar(&SslMode, "ssl_mode", "require",
         "ssl mode for connecting to the database.")


### PR DESCRIPTION
When you enable cassandra authentication default creds are cassandra:cassandra ([docs](https://docs.yugabyte.com/preview/secure/enable-authentication/authentication-ycql/)). If you don't specify otherwise UI will try to use it's own default creds which are cassandra:yugabyte which will result in error on UI. This commit aims to fix that problem by replacing old default password with present one.