### PR TITLE
Fix division by zero error in selectivity calculation

### DIFF
--- a/src/postgres/src/backend/optimizer/util/pathnode.c
+++ b/src/postgres/src/backend/optimizer/util/pathnode.c
@@ -4918,13 +4918,13 @@ yb_create_distinct_index_path(PlannerInfo *root,
 		prefixExprs = lappend(prefixExprs, tle->expr);
 		i++;
 	}
-
+	pathnode->path.rows = clamp_row_est(pathnode->path.rows);
 	numDistinctRows = estimate_num_groups(root,
 										  prefixExprs,
 										  pathnode->path.rows,
 										  NULL,
 										  NULL);
-	selectivity = ((Cost) numDistinctRows + 1) / ((Cost) pathnode->path.rows + 1);
+	selectivity = ((Cost) numDistinctRows) / ((Cost) pathnode->path.rows);
 
 	run_cost = pathnode->path.total_cost - pathnode->path.startup_cost;
 	run_cost *= selectivity;

--- a/src/postgres/src/backend/optimizer/util/pathnode.c
+++ b/src/postgres/src/backend/optimizer/util/pathnode.c
@@ -4924,7 +4924,7 @@ yb_create_distinct_index_path(PlannerInfo *root,
 										  pathnode->path.rows,
 										  NULL,
 										  NULL);
-	selectivity = ((Cost) numDistinctRows) / ((Cost) pathnode->path.rows);
+	selectivity = ((Cost) numDistinctRows + 1) / ((Cost) pathnode->path.rows + 1);
 
 	run_cost = pathnode->path.total_cost - pathnode->path.startup_cost;
 	run_cost *= selectivity;


### PR DESCRIPTION
This PR addresses a bug that can result in a division by zero when calculating selectivity in yb_create_distinct_index_path.

This addresses issue [#24568](https://github.com/yugabyte/yugabyte-db/issues/24568) by enhancing the reliability of the selectivity computation.

Please review my implementation and provide feedback.