### PR TITLE
[Docs] Remove old Netlify preview URL from CSP Frame Ancestors header

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1462,7 +1462,6 @@
 
         frame-ancestors 'self'
             https://*.yugabyte.com/
-            https://deploy-preview-12849--infallible-bardeen-164bc9.netlify.app/
             https://yugabyte.thinkific.com/
         ;
 


### PR DESCRIPTION
The Content Security Policy (CSP) Frame Ancestors header contains a legacy Netlify preview URL. Following internal deliberation, we may consider removing this header to enhance security posture.