### PR TITLE
[docs] fix terraform.md to account for changes in terraform-aws-yugabyte

### DIFF
--- a/docs/content/stable/deploy/public-clouds/aws/terraform.md
+++ b/docs/content/stable/deploy/public-clouds/aws/terraform.md
@@ -81,7 +81,7 @@ module "yugabyte-db-cluster" {
   # AWS key pair that you want to use to ssh into the instances.
   # Make sure this key pair is already present in the noted region of your account.
   ssh_keypair = "SSH_KEYPAIR_HERE"
-  ssh_key_path = "SSH_KEY_PATH_HERE"
+  ssh_private_key = "SSH_PRIVATE_KEY_PATH_HERE"
 
   # Existing vpc and subnet ids where the instances should be spawned.
   vpc_id = "VPC_ID_HERE"
@@ -92,6 +92,13 @@ module "yugabyte-db-cluster" {
 
   # The number of nodes in the cluster, this cannot be lower than the replication factor.
   num_instances = "3"
+
+  # The AWS region for the cluster to be created
+  region_name = "REGION_NAME_HERE"
+
+  # The availability zones for the instances, the length
+  # of AZs must match num_instances and can contain duplicates.
+  availability_zones = ["AZ1_HERE", "AZ2_HERE", "AZ3_HERE"]
 }
 ```
 


### PR DESCRIPTION
While running through the AWS Terraform guide [here](https://docs.yugabyte.com/preview/deploy/public-clouds/aws/terraform/), I hit a coupled of snags due to the [upstream Terraform module](https://github.com/yugabyte/terraform-aws-yugabyte/tree/master) having some breaking changes. 

These are the incompatibilities I discovered:
- `ssh_key_path` was renamed to `ssh_private_key`
- `region_name` and `availability_zones` are required parameters

This PR fixes the docs to account for these changes