### PR TITLE
[Docs] Improved version selector

### DIFF
--- a/docs/assets/scss/_dropdown_list.scss
+++ b/docs/assets/scss/_dropdown_list.scss
@@ -9,7 +9,7 @@
 
   .dropdown-menu {
     background: #fff;
-    border: 1px solid #d7dee4;
+    border: 1px solid #E9EEF2;
     box-shadow: 0 1px 4px rgba(153, 153, 153, 0.5);
     border-radius: 8px;
     padding: 8px 0;
@@ -21,6 +21,10 @@
       color: $yb-font-dark;
       padding: 8px 16px;
 
+      .tag.release {
+        top: 0;
+      }
+
       &:hover {
         background: #f2f6ff !important;
       }
@@ -28,6 +32,10 @@
       &[role="button"] {
         cursor: not-allowed;
         opacity: 0.6;
+
+        .tag.release .popup-details {
+          display: none;
+        }
 
         &:hover {
           background: #fff !important;
@@ -37,26 +45,31 @@
   }
 
   .dropdown-toggle {
-    padding: 8px 12px;
+    padding: 4px 12px;
+    padding-right: 5px;
     transition: all 0.2s;
     vertical-align: middle;
     box-shadow: none;
     position: relative;
     letter-spacing: -0.02em;
-    min-width: 145px;
     justify-content: space-between;
     font-weight: 400;
     font-size: 13px;
     line-height: 16px;
     display: flex;
     align-items: center;
-    color: $yb-font-gray;
+    color: #0B1117;
     background: #fff;
-    border: 1px solid #d7dee4;
     border-radius: 8px;
     min-height: 32px;
+    border: 1px solid transparent;
 
-    >span {
+    &.show,
+    &:hover {
+      border: 1px solid #d7dee4;
+    }
+
+    > span {
       font-weight: 500;
       font-size: 10px;
       line-height: 16px;
@@ -64,19 +77,24 @@
       height: 20px;
       border-radius: 4px;
       padding: 2px 6px;
-      margin-left: 6px;
+      margin-left: 8px;
       margin-right: auto;
+      position: static;
     }
 
     &::after {
       display: inline-block;
-      margin-left: 0.255em;
-      vertical-align: 0.255em;
+      margin-left: 8px;
+      vertical-align: middle;
       content: "\f107";
       color: #97a5b0;
-      font-family: $font-awesome-font-name;
+      font-family: "Font Awesome 6 Pro";
       font-weight: 700;
       border: 0;
+      width: 20px;
+      height: 24px;
+      text-align: center;
+      line-height: 24px;
     }
   }
 

--- a/docs/assets/scss/_styles_project.scss
+++ b/docs/assets/scss/_styles_project.scss
@@ -104,9 +104,13 @@ a {
 .td-breadcrumbs {
   margin-bottom: 20px;
   padding-right: 120px;
-  @media(max-width:991px){
-    padding-right: 0;
 
+	@media(max-width:991px) {
+    padding-right: 0;
+  }
+
+   + .td-content .dropdown-list {
+    margin-top: 14px!important;
   }
 
   &:has(.breadcrumb-item:only-child) {
@@ -166,7 +170,6 @@ a {
 @media (min-width: 992px) {
   .td-main main {
     padding-top: 116px;
-    //margin-top: 32px;
     margin-top: 52px;
   }
 }
@@ -453,6 +456,7 @@ body:not(.td-home) .td-main main {
     margin-top: 16px;
     display: flex;
     align-items: center;
+    flex-flow: wrap;
     justify-content: space-between;
 
     @media (max-width: 991px) {
@@ -462,6 +466,11 @@ body:not(.td-home) .td-main main {
 
     @media (min-width: 991px) {
       margin: 20px 0 72px;
+    }
+
+    .header-version-dropdown {
+      width: 100%;
+      margin: 0 0 4px 0;
     }
   }
 }

--- a/docs/assets/scss/_yb_tags.scss
+++ b/docs/assets/scss/_yb_tags.scss
@@ -145,3 +145,11 @@
     }
   }
 }
+
+.dropdown-list .dropdown-toggle:hover,
+.dropdown-list .dropdown-menu .dropdown-item:hover {
+  .popup-details {
+    opacity: 1;
+    visibility: visible;
+  }
+}

--- a/docs/assets/scss/_yb_tags.scss
+++ b/docs/assets/scss/_yb_tags.scss
@@ -1,7 +1,8 @@
 .td-content {
-  h1 > .tag{
+  h1 > .tag {
     margin: 0 10px;
   }
+
   .tag {
     display: inline-flex;
     padding: 4px 6px;
@@ -45,9 +46,10 @@
       background: #E5EDFF;
       color: #2B59C3;
     }
-  &:hover{
-    text-decoration: none !important  ;
-  }
+
+    &:hover {
+      text-decoration: none !important;
+    }
   }
 }
 
@@ -79,5 +81,54 @@
     background: #CDEFE1;
     color: #097345;
   }
-}
 
+  &:hover {
+    .popup-details {
+      opacity: 1;
+      visibility: visible;
+    }
+  }
+
+  .popup-details {
+    border-radius: 8px;
+    border: 1px solid #E9EDF0;
+    padding: 10px;
+    background: #FFF;
+    box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, 0.1);
+    color: #4E5F6D;
+    width: 165px;
+    font-size: 11.5px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 16px;
+    position: absolute;
+    top: 0px;
+    left: calc(100% + 10px);
+    opacity: 0;
+    visibility: hidden;
+		transition: visibility,opacity 0.3s ease-in-out;
+    transform: translate(0, calc(-50% + 10px));
+    transform-origin: center;
+    white-space: wrap;
+    text-transform: none;
+
+    &:before {
+      position: absolute;
+      left: -13px;
+      content: "";
+      display: inline-block;
+      width: 20px;
+      background: transparent;
+      height: 100%;
+      top: 0;
+      z-index: -40;
+    }
+  }
+
+  &.sts,
+  &.lts {
+    .popup-details {
+      width: 150px;
+    }
+  }
+}

--- a/docs/assets/scss/_yb_tags.scss
+++ b/docs/assets/scss/_yb_tags.scss
@@ -106,10 +106,10 @@
     left: calc(100% + 10px);
     opacity: 0;
     visibility: hidden;
-		transition: visibility,opacity 0.3s ease-in-out;
+    transition: visibility, opacity 0.3s ease-in-out;
     transform: translate(0, calc(-50% + 10px));
     transform-origin: center;
-    white-space: wrap;
+    white-space: normal;
     text-transform: none;
 
     &:before {
@@ -125,10 +125,23 @@
     }
   }
 
-  &.sts,
   &.lts {
     .popup-details {
       width: 150px;
+    }
+  }
+}
+
+.is-safari {
+  .td-content {
+    @media(min-width: 2500px) {
+      .tag.release {
+        line-height: 0.9;
+
+        .popup-details {
+          width: 200px;
+        }
+      }
     }
   }
 }

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -8,6 +8,7 @@ layout: list
 breadcrumbDisable: true
 weight: 1
 showRightNav: true
+unversioned: true
 resourcesIntro: Products
 resources:
   - title: Open source

--- a/docs/layouts/_default/content.html
+++ b/docs/layouts/_default/content.html
@@ -19,9 +19,9 @@
   <div class="main-heading-with-version {{- if and (not $headingImage) (not $headingIcon) }} heading-without-image{{- end }}">
     {{- if and (.Site.Params.versions) (not .Params.unversioned) -}}
       <div class="header-version-dropdown dropdown-list">
-				<div class="dropdown">
-					{{- partial "navbar-version-selector.html" . -}}
-				</div>
+        <div class="dropdown">
+          {{- partial "navbar-version-selector.html" . -}}
+        </div>
       </div>
     {{- end -}}
     {{- if $headingImage -}}

--- a/docs/layouts/_default/content.html
+++ b/docs/layouts/_default/content.html
@@ -62,7 +62,6 @@
 			{{ partial "reading-time.html" . }}
 		{{ end }}
 	</header>
-  {{ partial "earlier-version-warning" . }}
   <!-- Wrap table in div for responsive -->
   {{ .Content | replaceRE "(<table(?:.|\n)+?</table>)" "<div class=table-responsive> ${1} </div>"  | safeHTML }}
 	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}

--- a/docs/layouts/_default/content.html
+++ b/docs/layouts/_default/content.html
@@ -17,6 +17,13 @@
   {{- end -}}
 
   <div class="main-heading-with-version {{- if and (not $headingImage) (not $headingIcon) }} heading-without-image{{- end }}">
+    {{- if and (.Site.Params.versions) (not .Params.unversioned) -}}
+      <div class="header-version-dropdown dropdown-list">
+				<div class="dropdown">
+					{{- partial "navbar-version-selector.html" . -}}
+				</div>
+      </div>
+    {{- end -}}
     {{- if $headingImage -}}
       <div class="heading-image">
         <img alt="{{ .Title }}" title="{{ .Title }}" src="{{ .Params.image }}" />

--- a/docs/layouts/_default/single.html
+++ b/docs/layouts/_default/single.html
@@ -11,7 +11,6 @@
 			{{ partial "reading-time.html" . }}
 		{{ end }}
 	</header>
-  {{ partial "earlier-version-warning" . }}
   <!-- Wrap table in div for responsive -->
   {{ .Content | replaceRE "(<table(?:.|\n)+?</table>)" "<div class=table-responsive> ${1} </div>"  | safeHTML }}
   {{ partial "section-index.html" . }}

--- a/docs/layouts/indexpage/list.html
+++ b/docs/layouts/indexpage/list.html
@@ -68,7 +68,6 @@
   {{- if ne .Params.showRightNav true -}}
     {{- partial "contribute_list" . -}}
   {{- end -}}
-  {{ partial "earlier-version-warning" . }}
   <!-- Wrap table in div for responsive -->
   {{ .Content | replaceRE "(<table(?:.|\n)+?</table>)" "<div class=table-responsive> ${1} </div>"  | safeHTML }}
   {{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}

--- a/docs/layouts/indexpage/list.html
+++ b/docs/layouts/indexpage/list.html
@@ -29,6 +29,13 @@
   {{- end -}}
 
   <div class="main-heading-with-version {{- if and (not $headingImage) (not $headingIcon) }} heading-without-image{{- end }}">
+    {{- if and (.Site.Params.versions) (not .Params.unversioned) -}}
+      <div class="header-version-dropdown dropdown-list">
+        <div class="dropdown">
+          {{- partial "navbar-version-selector.html" . -}}
+        </div>
+      </div>
+    {{- end -}}
     {{- if $headingImage -}}
       <div class="heading-image">
         <img alt="{{ .Title }}" title="{{ .Title }}" src="{{ .Params.image }}" />

--- a/docs/layouts/partials/navbar-version-selector.html
+++ b/docs/layouts/partials/navbar-version-selector.html
@@ -30,11 +30,11 @@
   {{ range .Site.Params.versions }}
     {{ $versionName := .version }}
     {{- if in .version "(Preview)" -}}
-      {{ $versionName = replace .version "(Preview)" "<span class='tag release preview'>Preview</span>" }}
+      {{ $versionName = replace .version "(Preview)" "<span class='tag release preview'>Preview <span class='popup-details'>Preview release - not for production</span></span>" }}
     {{- else if in .version "(STS)" -}}
-      {{ $versionName = replace .version "(STS)" "<span class='tag release sts'>STS</span>" }}
+      {{ $versionName = replace .version "(STS)" "<span class='tag release sts'>STS <span class='popup-details'>Stable release with standard-term support</span></span>" }}
     {{- else if in .version "(LTS)" -}}
-      {{ $versionName = replace .version "(LTS)" "<span class='tag release lts'>LTS</span>" }}
+      {{ $versionName = replace .version "(LTS)" "<span class='tag release lts'>LTS <span class='popup-details'>Stable release with long-term support</span></span>" }}
     {{- else if in .version "Unsupported" -}}
       {{ $path = "/" }}
     {{ end }}

--- a/docs/layouts/partials/navbar-version-selector.html
+++ b/docs/layouts/partials/navbar-version-selector.html
@@ -6,11 +6,11 @@
     {{ if hasPrefix $pagePermalink $versionUrl }}
       {{ $versionName = .version }}
       {{- if in .version "(Preview)" -}}
-        {{ $versionName = replace .version "(Preview)" "<span class='tag release preview'>Preview</span>" }}
+        {{ $versionName = replace .version "(Preview)" "<span class='tag release preview'>Preview <span class='popup-details'>Preview release - not for production</span></span>" }}
       {{- else if in .version "(STS)" -}}
-        {{ $versionName = replace .version "(STS)" "<span class='tag release sts'>STS</span>" }}
+        {{ $versionName = replace .version "(STS)" "<span class='tag release sts'>STS <span class='popup-details'>Stable release with standard-term support</span></span>" }}
       {{- else if in .version "(LTS)" -}}
-        {{ $versionName = replace .version "(LTS)" "<span class='tag release lts'>LTS</span>" }}
+        {{ $versionName = replace .version "(LTS)" "<span class='tag release lts'>LTS <span class='popup-details'>Stable release with long-term support</span></span>" }}
       {{ end }}
     {{ end }}
   {{ end }}

--- a/docs/layouts/partials/navbar.html
+++ b/docs/layouts/partials/navbar.html
@@ -124,15 +124,6 @@
         </li>
       {{- end -}}
     </ul>
-    {{- if and .Site.Params.versions (not .Params.unversioned) -}}
-      <div class="header-version-dropdown dropdown-list">
-        <ul class="mt-2 mt-lg-0">
-          <li class="nav-item dropdown d-none d-lg-block">
-            {{- partial "navbar-version-selector.html" . -}}
-          </li>
-        </ul>
-      </div>
-    {{- end -}}
   </div>
 </nav>
 

--- a/docs/layouts/partials/sidebar-tree.html
+++ b/docs/layouts/partials/sidebar-tree.html
@@ -10,15 +10,6 @@
 <div class="left-sidebar-wrap">
   <div class="left-sidebar-wrap-inner">
     <nav>
-      {{- if and .Site.Params.versions (not .Params.unversioned) -}}
-        <div class="dd-change-showmobile desktop-hide dropdown-list">
-          <ul>
-            <li class="nav-item dropdown">
-              {{- partial "navbar-version-selector.html" . -}}
-            </li>
-          </ul>
-        </div>
-      {{- end -}}
       <ul class="list pa0 nl2">
         {{- range $key, $value := .Site.Menus -}}
           {{- if eq $menuName $key -}}


### PR DESCRIPTION
- [x] Remove the large call out from all pages 
- [x] Remove the existing version selector on the top left of the header.
- [x] Add the version selector on top of H1 according to Figma