### PR TITLE
[Doc] Clarify usage of odd RF numbers

### DIFF
--- a/docs/content/preview/architecture/docdb-replication/async-replication.md
+++ b/docs/content/preview/architecture/docdb-replication/async-replication.md
@@ -20,10 +20,9 @@ YugabyteDB's [synchronous replication](../replication/) can be used to tolerate 
 
 However, synchronous replication has two important drawbacks when used this way:
 
-- __High write latency__: each write must achieve consensus across at least two data centers, which means at least one round trip between data centers.  This can add tens or even hundreds of milliseconds of extra latency in a multi-region deployment.
+- _High write latency_: each write must achieve consensus across at least two data centers, which means at least one round trip between data centers.  This can add tens or even hundreds of milliseconds of extra latency in a multi-region deployment.
 
-- __Need for at least three data centers__: inorder to tolerate the failure of `f` fault domain you need at least 2f +1 fault domains. So to survive the loss of one data center, at least three data centers must be used, which adds operational cost.
-See [Fault tolerance](./docdb-replication/replication/#fault-tolerance) for more information.
+- _Need for at least three data centers_: to tolerate the failure of `f` fault domains, you need at least `2f + 1` fault domains. So, to survive the loss of one data center, you need at least three data centers, which adds operational cost. See [fault tolerance](../replication/#fault-tolerance) for more information.
 
 As an alternative, YugabyteDB provides asynchronous replication that replicates data between two or more separate universes.  It does not suffer from the drawbacks of synchronous replication: because it is done in the background, it does not impact write latency, and because it does not use consensus it does not require a third data center.
 

--- a/docs/content/preview/architecture/docdb-replication/async-replication.md
+++ b/docs/content/preview/architecture/docdb-replication/async-replication.md
@@ -22,7 +22,8 @@ However, synchronous replication has two important drawbacks when used this way:
 
 - __High write latency__: each write must achieve consensus across at least two data centers, which means at least one round trip between data centers.  This can add tens or even hundreds of milliseconds of extra latency in a multi-region deployment.
 
-- __Need for at least three data centers__: because consensus requires an odd number of fault domains so ties can be broken, at least three data centers must be used, which adds operational cost.
+- __Need for at least three data centers__: inorder to tolerate the failure of `f` fault domain you need at least 2f +1 fault domains. So to survive the loss of one data center, at least three data centers must be used, which adds operational cost.
+See [Fault tolerance](./docdb-replication/replication/#fault-tolerance) for more information.
 
 As an alternative, YugabyteDB provides asynchronous replication that replicates data between two or more separate universes.  It does not suffer from the drawbacks of synchronous replication: because it is done in the background, it does not impact write latency, and because it does not use consensus it does not require a third data center.
 

--- a/docs/content/preview/architecture/docdb-replication/replication.md
+++ b/docs/content/preview/architecture/docdb-replication/replication.md
@@ -24,17 +24,20 @@ YugabyteDB replicates data across [fault domains](../../key-concepts#fault-domai
 
 The fault tolerance (FT) of a YugabyteDB cluster is the maximum number of fault domain failures it can survive while continuing to preserve correctness of data. Fault tolerance and replication factor are correlated as follows:
 
-* To achieve a FT of `f` fault domains, the primary cluster has to be configured with a RF of at least (2f + 1).
+* To achieve a FT of `f` fault domains, the primary cluster has to be configured with a RF of at least `2f + 1`.
 
 The following diagram shows a cluster with FT 1. Data is replicated across 3 nodes, and the cluster can survive the failure of one fault domain. To make the cluster able to survive the failure of a zone or region, you would place the nodes in different zones or regions.
 
 ![Raft group](/images/architecture/replication/raft-group.png)
 
-To survive the outage of 2 fault domains, a cluster needs at least 2 * 2 + 1 fault domains (RF > 5). With RF=5, if 2 fault domains are offline, the remaining 3 fault domains can continue to serve reads and writes without interruption.
-Clusters with an RF of 1 or 2 can tolerate 0 faults.
-Clusters with an RF of 3 or 4 can tolerate 1 fault.
-Clusters with an RF of 5 or 6 can tolerate 2 faults.
-And so on...
+To survive the outage of 2 fault domains, a cluster needs at least 2 * 2 + 1 fault domains; that is, an RF of 5. With RF >= 5, if 2 fault domains are offline, the remaining 3 fault domains can continue to serve reads and writes without interruption.
+
+| Replication factor | Fault tolerance | Can survive failure of |
+| :--- | :--- | :--- |
+| 1 or 2 | 0 | 0 fault domains |
+| 3 or 4 | 1 | 1 fault domain |
+| 5 or 6 | 2 | 2 fault domains |
+| 7 or 8 | 3 | 3 fault domains |
 
 ## Tablet peers
 

--- a/docs/content/preview/architecture/docdb-replication/replication.md
+++ b/docs/content/preview/architecture/docdb-replication/replication.md
@@ -24,13 +24,17 @@ YugabyteDB replicates data across [fault domains](../../key-concepts#fault-domai
 
 The fault tolerance (FT) of a YugabyteDB cluster is the maximum number of fault domain failures it can survive while continuing to preserve correctness of data. Fault tolerance and replication factor are correlated as follows:
 
-* To achieve a FT of `f` fault domains, the primary cluster has to be configured with a RF of (2f + 1).
+* To achieve a FT of `f` fault domains, the primary cluster has to be configured with a RF of at least (2f + 1).
 
 The following diagram shows a cluster with FT 1. Data is replicated across 3 nodes, and the cluster can survive the failure of one fault domain. To make the cluster able to survive the failure of a zone or region, you would place the nodes in different zones or regions.
 
 ![Raft group](/images/architecture/replication/raft-group.png)
 
-To survive the outage of 2 fault domains, a cluster needs 2 * 2 + 1 fault domains (RF = 5). While the 2 fault domains are offline, the remaining 3 fault domains can continue to serve reads and writes without interruption. Clusters with an RF of 1 can tolerate 0 faults.
+To survive the outage of 2 fault domains, a cluster needs at least 2 * 2 + 1 fault domains (RF > 5). With RF=5, if 2 fault domains are offline, the remaining 3 fault domains can continue to serve reads and writes without interruption.
+Clusters with an RF of 1 or 2 can tolerate 0 faults.
+Clusters with an RF of 3 or 4 can tolerate 1 fault.
+Clusters with an RF of 5 or 6 can tolerate 2 faults.
+And so on...
 
 ## Tablet peers
 

--- a/docs/content/preview/deploy/checklist.md
+++ b/docs/content/preview/deploy/checklist.md
@@ -24,14 +24,14 @@ A YugabyteDB cluster consists of two distributed services - the [YB-TServer](../
 
 YugabyteDB internally replicates data in a consistent manner using the Raft consensus protocol to survive node failure without compromising data correctness. This distributed consensus replication is applied at a per-shard (also known as tablet) level similar to Google Spanner.
 
-The replication factor (RF) corresponds to the number of copies of the data. You need at least as many nodes as the RF, which means one node for RF1, three nodes for RF3, and so on. With a RF of 3, your cluster can tolerate one node failure. With a RF of 5, it can tolerate two node failures. More generally, if RF is n, YugabyteDB can survive (n - 1) / 2 failures without compromising correctness or availability of data.
+The replication factor (RF) corresponds to the number of copies of the data. You need at least as many nodes as the RF, which means one node for RF1, three nodes for RF3, and so on. With a RF of 3, your cluster can tolerate one node failure. With a RF of 5, it can tolerate two node failures. More generally, if RF is n, YugabyteDB can survive floor((n - 1) / 2) failures without compromising correctness or availability of data.
 
 When deploying a cluster, keep in mind the following:
 
-- The RF should be an odd number to ensure majority consensus can be established during failures.
 - The default replication factor is 3.
 - The number of YB-Master servers running in a cluster should match RF. Run each server on a separate machine to prevent losing availability on failures. You need to specify the RF using the `--replication_factor` flag when bringing up the YB-Master servers.
 - The number of YB-TServer servers running in the cluster should not be less than the RF. Run each server on a separate machine to prevent losing availability on failures.
+- An even RF number offers the same protection as its preceding odd number. For example both RF 4 and RF 3 can only tolerate the loss of only 1 node. So it's preferable to use an odd RF number to keep costs low.
 
 Note that YugabyteDB works with both hostnames or IP addresses. The latter are preferred at this point, as they are more extensively tested.
 

--- a/docs/content/preview/deploy/checklist.md
+++ b/docs/content/preview/deploy/checklist.md
@@ -25,6 +25,8 @@ A YugabyteDB cluster consists of two distributed services - the [YB-TServer](../
 YugabyteDB internally replicates data in a consistent manner using the Raft consensus protocol to survive node failure without compromising data correctness. This distributed consensus replication is applied at a per-shard (also known as tablet) level similar to Google Spanner.
 
 The replication factor (RF) corresponds to the number of copies of the data. You need at least as many nodes as the RF, which means one node for RF1, three nodes for RF3, and so on. With a RF of 3, your cluster can tolerate one node failure. With a RF of 5, it can tolerate two node failures. More generally, if RF is n, YugabyteDB can survive floor((n - 1) / 2) failures without compromising correctness or availability of data.
+See [Fault tolerance](./docdb-replication/replication/#fault-tolerance) for more information.
+
 
 When deploying a cluster, keep in mind the following:
 

--- a/docs/content/preview/deploy/checklist.md
+++ b/docs/content/preview/deploy/checklist.md
@@ -24,16 +24,16 @@ A YugabyteDB cluster consists of two distributed services - the [YB-TServer](../
 
 YugabyteDB internally replicates data in a consistent manner using the Raft consensus protocol to survive node failure without compromising data correctness. This distributed consensus replication is applied at a per-shard (also known as tablet) level similar to Google Spanner.
 
-The replication factor (RF) corresponds to the number of copies of the data. You need at least as many nodes as the RF, which means one node for RF1, three nodes for RF3, and so on. With a RF of 3, your cluster can tolerate one node failure. With a RF of 5, it can tolerate two node failures. More generally, if RF is n, YugabyteDB can survive floor((n - 1) / 2) failures without compromising correctness or availability of data.
-See [Fault tolerance](./docdb-replication/replication/#fault-tolerance) for more information.
+The replication factor (RF) corresponds to the number of copies of the data. You need at least as many nodes as the RF, which means one node for RF 1, three nodes for RF 3, and so on. With a RF of 3, your cluster can tolerate one node failure. With a RF of 5, it can tolerate two node failures. More generally, if RF is n, YugabyteDB can survive floor((n - 1) / 2) failures without compromising correctness or availability of data.
 
+See [Fault tolerance](./docdb-replication/replication/#fault-tolerance) for more information.
 
 When deploying a cluster, keep in mind the following:
 
 - The default replication factor is 3.
 - The number of YB-Master servers running in a cluster should match RF. Run each server on a separate machine to prevent losing availability on failures. You need to specify the RF using the `--replication_factor` flag when bringing up the YB-Master servers.
 - The number of YB-TServer servers running in the cluster should not be less than the RF. Run each server on a separate machine to prevent losing availability on failures.
-- An even RF number offers the same protection as its preceding odd number. For example both RF 4 and RF 3 can only tolerate the loss of only 1 node. So it's preferable to use an odd RF number to keep costs low.
+- An even RF number offers the same fault tolerance as its preceding odd number. For example, both RF 4 and RF 3 can only tolerate the loss of 1 node. So to keep costs low, it's preferable to use an odd RF number.
 
 Note that YugabyteDB works with both hostnames or IP addresses. The latter are preferred at this point, as they are more extensively tested.
 

--- a/docs/content/stable/architecture/docdb-replication/async-replication.md
+++ b/docs/content/stable/architecture/docdb-replication/async-replication.md
@@ -18,9 +18,9 @@ YugabyteDB's [synchronous replication](../replication/) can be used to tolerate 
 
 However, synchronous replication has two important drawbacks when used this way:
 
-- __High write latency__: each write must achieve consensus across at least two data centers, which means at least one round trip between data centers.  This can add tens or even hundreds of milliseconds of extra latency in a multi-region deployment.
+- _High write latency_: each write must achieve consensus across at least two data centers, which means at least one round trip between data centers.  This can add tens or even hundreds of milliseconds of extra latency in a multi-region deployment.
 
-- __Need for at least three data centers__: because consensus requires an odd number of fault domains so ties can be broken, at least three data centers must be used, which adds operational cost.
+- _Need for at least three data centers_: to tolerate the failure of `f` fault domains, you need at least `2f + 1` fault domains. So, to survive the loss of one data center, you need at least three data centers, which adds operational cost. See [fault tolerance](../replication/#fault-tolerance) for more information.
 
 As an alternative, YugabyteDB provides asynchronous replication that replicates data between two or more separate universes.  It does not suffer from the drawbacks of synchronous replication: because it is done in the background, it does not impact write latency, and because it does not use consensus it does not require a third data center.
 

--- a/docs/content/stable/architecture/docdb-replication/replication.md
+++ b/docs/content/stable/architecture/docdb-replication/replication.md
@@ -22,13 +22,20 @@ YugabyteDB replicates data across [fault domains](../../key-concepts#fault-domai
 
 The fault tolerance (FT) of a YugabyteDB cluster is the maximum number of fault domain failures it can survive while continuing to preserve correctness of data. Fault tolerance and replication factor are correlated as follows:
 
-* To achieve a FT of `f` fault domains, the primary cluster has to be configured with a RF of (2f + 1).
+* To achieve a FT of `f` fault domains, the primary cluster has to be configured with a RF of at least `2f + 1`.
 
 The following diagram shows a cluster with FT 1. Data is replicated across 3 nodes, and the cluster can survive the failure of one fault domain. To make the cluster able to survive the failure of a zone or region, you would place the nodes in different zones or regions.
 
 ![Raft group](/images/architecture/replication/raft-group.png)
 
-To survive the outage of 2 fault domains, a cluster needs 2 * 2 + 1 fault domains (RF = 5). While the 2 fault domains are offline, the remaining 3 fault domains can continue to serve reads and writes without interruption. Clusters with an RF of 1 can tolerate 0 faults.
+To survive the outage of 2 fault domains, a cluster needs at least 2 * 2 + 1 fault domains; that is, an RF of 5. With RF >= 5, if 2 fault domains are offline, the remaining 3 fault domains can continue to serve reads and writes without interruption.
+
+| Replication factor | Fault tolerance | Can survive failure of |
+| :--- | :--- | :--- |
+| 1 or 2 | 0 | 0 fault domains |
+| 3 or 4 | 1 | 1 fault domain |
+| 5 or 6 | 2 | 2 fault domains |
+| 7 or 8 | 3 | 3 fault domains |
 
 ## Tablet peers
 

--- a/docs/content/stable/deploy/checklist.md
+++ b/docs/content/stable/deploy/checklist.md
@@ -24,14 +24,16 @@ A YugabyteDB cluster consists of two distributed services - the [YB-TServer](../
 
 YugabyteDB internally replicates data in a consistent manner using the Raft consensus protocol to survive node failure without compromising data correctness. This distributed consensus replication is applied at a per-shard (also known as tablet) level similar to Google Spanner.
 
-The replication factor (RF) corresponds to the number of copies of the data. You need at least as many nodes as the RF, which means one node for RF1, three nodes for RF3, and so on. With a RF of 3, your cluster can tolerate one node failure. With a RF of 5, it can tolerate two node failures. More generally, if RF is n, YugabyteDB can survive (n - 1) / 2 failures without compromising correctness or availability of data.
+The replication factor (RF) corresponds to the number of copies of the data. You need at least as many nodes as the RF, which means one node for RF 1, three nodes for RF 3, and so on. With a RF of 3, your cluster can tolerate one node failure. With a RF of 5, it can tolerate two node failures. More generally, if RF is n, YugabyteDB can survive floor((n - 1) / 2) failures without compromising correctness or availability of data.
+
+See [Fault tolerance](./docdb-replication/replication/#fault-tolerance) for more information.
 
 When deploying a cluster, keep in mind the following:
 
-- The RF should be an odd number to ensure majority consensus can be established during failures.
 - The default replication factor is 3.
 - The number of YB-Master servers running in a cluster should match RF. Run each server on a separate machine to prevent losing availability on failures. You need to specify the RF using the `--replication_factor` flag when bringing up the YB-Master servers.
 - The number of YB-TServer servers running in the cluster should not be less than the RF. Run each server on a separate machine to prevent losing availability on failures.
+- An even RF number offers the same fault tolerance as its preceding odd number. For example, both RF 4 and RF 3 can only tolerate the loss of 1 node. So to keep costs low, it's preferable to use an odd RF number.
 
 Note that YugabyteDB works with both hostnames or IP addresses. The latter are preferred at this point, as they are more extensively tested.
 


### PR DESCRIPTION
Odd RF numbers are allowed and safe. Clarifying why even RF us preferable to odd RF.