### PR TITLE
Add a notebook for example user management platform API endpoint calls

### DIFF
--- a/managed/api-examples/python-simple/user-management.ipynb
+++ b/managed/api-examples/python-simple/user-management.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# User Management\n",
-    "This notebook will demonstrate the platform APIs for user management. "
+    "This notebook will demonstrate the platform APIs for user management. Note that RBAC uses a different workflow."
    ]
   },
   {
@@ -137,7 +137,7 @@
     "email = \"name@email.tld\" # Replace with user's email\n",
     "password = \"Yo4rPassw*rd\" # Replace with user's password\n",
     "confirm_password = \"Yo4rPassw*rd\" # Replace with user's password\n",
-    "role = \"ReadOnly\" # Replace with user's role (ConnectOnly, ReadOnly, BackupAdmin, Admin, SuperAdmin)\n",
+    "role = \"ReadOnly\" # Replace with user's role (ConnectOnly, ReadOnly, BackupAdmin, Admin)\n",
     "timezone = \"America/New_York\" # Replace with user's timezone\n",
     "\n",
     "route = f\"{yba_url}/api/v1/customers/{customer_uuid}/users\"\n",

--- a/managed/api-examples/python-simple/user-management.ipynb
+++ b/managed/api-examples/python-simple/user-management.ipynb
@@ -1,0 +1,205 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# User Management\n",
+    "This notebook will demonstrate the platform APIs for user management. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Set the `YB_PLATFORM_URL` and `YB_API_KEY` environment variables in a .env file before running this notebook.\n",
+    "\n",
+    "Note: \"verify=False\" is used to disable SSL verification for the purposes of this demonstration, but you should use appropriate certificates in a production environment.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import requests\n",
+    "from pprint import pprint\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv()\n",
+    "\n",
+    "yba_url = os.getenv(\"YBA_PLATFORM_URL\")\n",
+    "yba_api_key = os.getenv(\"YBA_API_KEY\")\n",
+    "\n",
+    "headers = {\n",
+    "  'Content-Type': \"application/json\",\n",
+    "  'X-AUTH-YW-API-TOKEN': f\"{yba_api_key}\"\n",
+    "}\n",
+    "\n",
+    "session = requests.Session()\n",
+    "session.verify = False\n",
+    "session.headers = headers\n",
+    "\n",
+    "pprint(yba_url)\n",
+    "pprint(yba_api_key)\n",
+    "pprint(headers)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get the customer ID\n",
+    "\n",
+    "The customer ID is unique to the YBA platform and is required for the following Platform API calls. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "route = f\"{yba_url}/api/v1/session_info\"\n",
+    "response = session.get(url=route).json()\n",
+    "customer_uuid = response[\"customerUUID\"]\n",
+    "\n",
+    "print(customer_uuid)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## List current users\n",
+    "\n",
+    "List users that can login to the YBA platform.\n",
+    "\n",
+    "ref: https://api-docs.yugabyte.com/docs/yugabyte-platform/18e7f5bab7963-list-all-users"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "route = f\"{yba_url}/api/v1/customers/{customer_uuid}/users\"\n",
+    "response = session.get(url=route).json()\n",
+    "pprint(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get details for a specific user\n",
+    "\n",
+    "Choose a user from the above list and get their details. Place the user's UUID in the `user_uuid` variable below.\n",
+    "\n",
+    "ref: https://api-docs.yugabyte.com/docs/yugabyte-platform/c11938226a50a-get-a-user-s-details"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "user_uuid=\"asdfasdf-asdf-asdf-asdf-asdfasdfasdf\" # Replace with your user UUID\n",
+    "\n",
+    "route = f\"{yba_url}/api/v1/customers/{customer_uuid}/users/{user_uuid}\"\n",
+    "response = session.get(url=route).json()\n",
+    "pprint(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create a user\n",
+    "\n",
+    "Create a new user of the YBA platform.\n",
+    "\n",
+    "ref: https://api-docs.yugabyte.com/docs/yugabyte-platform/b37e8d3b835f1-create-a-user"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "email = \"name@email.tld\" # Replace with user's email\n",
+    "password = \"Yo4rPassw*rd\" # Replace with user's password\n",
+    "confirm_password = \"Yo4rPassw*rd\" # Replace with user's password\n",
+    "role = \"ReadOnly\" # Replace with user's role (ConnectOnly, ReadOnly, BackupAdmin, Admin, SuperAdmin)\n",
+    "timezone = \"America/New_York\" # Replace with user's timezone\n",
+    "\n",
+    "route = f\"{yba_url}/api/v1/customers/{customer_uuid}/users\"\n",
+    "payload = {\n",
+    "  \"email\": email,\n",
+    "  \"password\": password,\n",
+    "  \"confirmPassword\": confirm_password,\n",
+    "  \"role\": role,\n",
+    "  \"timezone\": timezone\n",
+    "}\n",
+    "\n",
+    "# avoids no CSRF token error by emptying the cookie jar\n",
+    "session.cookies = requests.cookies.RequestsCookieJar()\n",
+    "\n",
+    "response = session.post(url=route, json=payload).json()\n",
+    "pprint(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Delete a user\n",
+    "\n",
+    "Delete a user from the YBA platform.\n",
+    "\n",
+    "ref: https://api-docs.yugabyte.com/docs/yugabyte-platform/9fbb314f9b10f-delete-a-user"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "user_uuid=\"asdfasdf-asdf-asdf-asdf-asdfasdfasdf\" # Replace with your user UUID\n",
+    "\n",
+    "route = f\"{yba_url}/api/v1/customers/{customer_uuid}/users/{user_uuid}\"\n",
+    "response = session.delete(url=route).json()\n",
+    "pprint(response)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/managed/api-examples/python-simple/user-management.ipynb
+++ b/managed/api-examples/python-simple/user-management.ipynb
@@ -5,7 +5,9 @@
    "metadata": {},
    "source": [
     "# User Management\n",
-    "This notebook will demonstrate the platform APIs for user management. Note that RBAC uses a different workflow."
+    "This notebook will demonstrate the platform APIs for local user management. Note that RBAC uses a different workflow.\n",
+    "\n",
+    "Additionally note that YBA can also be configured to authenticate users using LDAP [https://docs.yugabyte.com/preview/yugabyte-platform/administer-yugabyte-platform/ldap-authentication/] or OIDC [https://docs.yugabyte.com/preview/yugabyte-platform/administer-yugabyte-platform/oidc-authentication/]. The user management APIs in this notebook are not applicable in those cases. "
    ]
   },
   {


### PR DESCRIPTION
The notebook provides examples for the following YBA platform user management tasks:

- list current users
- get details for a specific user
- create a user
- delete a user