### PR TITLE
[Docs] Right nav heading links are misdirected

### DIFF
--- a/docs/assets/scss/_yb_headings.scss
+++ b/docs/assets/scss/_yb_headings.scss
@@ -19,6 +19,8 @@
     &::before {
       height: calc(7.5rem + 20px);
       margin-top: calc(-7.5rem - 20px);
+      display: block;
+      content: "";
     }
 
     > a[aria-hidden] {
@@ -32,6 +34,34 @@
 
       svg {
         display: none;
+      }
+    }
+  }
+
+  &.with-topbar {
+    h1[id],
+    h2[id],
+    h3[id],
+    h4[id],
+    h5[id] {
+      &::before {
+        height: calc(7.5rem + 100px);
+        margin-top: calc(-7.5rem - 100px);
+
+        @media (max-width: 1549px) {
+          height: calc(7.5rem + 70px);
+          margin-top: calc(-7.5rem - 70px);
+        }
+
+        @media (max-width: 991px) {
+          height: 7.1rem;
+          margin-top: -7.1rem;
+        }
+
+        @media (max-width: 767px) {
+          height: calc(7.5rem + 50px);
+          margin-top: calc(-7.5rem - 50px);
+        }
       }
     }
   }
@@ -60,7 +90,6 @@
     }
 
     &:not(:first-child) {
-      margin: 64px 0 24px 0;
       margin: 72px 0 16px 0;
     }
   }
@@ -80,6 +109,7 @@
       color: $yb-font-darkgray;
       margin-top: 16px;
     }
+
     & + {
       .lead {
         margin-top: 16px;
@@ -172,7 +202,6 @@
   }
 }
 
-
-.td-searchpage .td-content  h1{
+.td-searchpage .td-content h1 {
   margin-bottom: 16px;
 }

--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -163,11 +163,17 @@ $(document).ready(() => {
    * Main (Header) Nav.
    */
   (() => {
-    const closeTopbar = document.querySelector('.info-topbar-close');
-    if (closeTopbar) {
-      closeTopbar.addEventListener('click', () => {
-        document.querySelector('.info-topbar').classList.add('closed');
-      });
+    const infoTopbar = document.querySelector('.info-topbar');
+    if (infoTopbar) {
+      document.querySelector('.td-content').classList.add('with-topbar');
+
+      const closeTopbar = document.querySelector('.info-topbar-close');
+      if (closeTopbar) {
+        closeTopbar.addEventListener('click', () => {
+          document.querySelector('.info-topbar').classList.add('closed');
+          document.querySelector('.td-content').classList.remove('with-topbar');
+        });
+      }
     }
 
     // Active main Nav.


### PR DESCRIPTION
When the banner is enabled, clicking on a heading link in the right navigation takes the user to a location below the actual heading section.