### PR TITLE
[DOC-502] [DOC-536] [DOC-551] [DOC-533] [2024.2]Changing tags for DB features 

### DIFF
--- a/docs/content/stable/reference/configuration/yugabyted.md
+++ b/docs/content/stable/reference/configuration/yugabyted.md
@@ -923,6 +923,8 @@ Usage: yugabyted version [flags]
 
 ### xcluster
 
+xCluster support in yugabyted is {{<tags/feature/ea>}}.
+
 Use the `yugabyted xcluster` command to set up or delete [xCluster replication](../../../architecture/docdb-replication/async-replication/) between two clusters.
 
 #### Syntax

--- a/docs/content/v2024.2/explore/observability/active-session-history.md
+++ b/docs/content/v2024.2/explore/observability/active-session-history.md
@@ -83,6 +83,7 @@ This view provides a list of wait events and their metadata. The columns of the 
 | pid | bigint | PID of the process that is executing the query. For YCQL and background activites, this will be the YB-TServer PID. |
 | client_node_ip | text | IP address of the client which sent the query to YSQL/YCQL. Null for background activities. |
 | sample_weight | float | If in any sampling interval there are too many events, YugabyteDB only collects `ysql_yb_ash_sample_size` samples/events. Based on how many were sampled, weights are assigned to the collected events. <br><br>For example, if there are 200 events, but only 100 events are collected, each of the collected samples will have a weight of (200 / 100) = 2.0 |
+| ysql_dbid | oid | Database OID of the YSQL database. This is 0 for YCQL databases.  |
 
 ## Wait events
 
@@ -94,13 +95,24 @@ These are the wait events introduced by YugabyteDB, however some of the followin
 
 | Wait Event Class | Wait Event | Wait Event Type | Wait Event Aux | Description |
 | :--------------- |:---------- | :-------------- |:--- | :---------- |
-| TServerWait | StorageRead | Network  |  | A YSQL backend is waiting for a table read from DocDB. |
+| TServerWait | TableRead | Network  |  | A YSQL backend is waiting for a table read from DocDB. |
 | TServerWait | CatalogRead | Network  |   | A YSQL backend is waiting for a catalog read from master. |
 | TServerWait | IndexRead | Network |   | A YSQL backend is waiting for a secondary index read from DocDB.  |
 | TServerWait | StorageFlush  | Network |  | A YSQL backend is waiting for a table/index read/write from DocDB. |
+| TServerWait | TableWrite  | Network |  | A YSQL backend is waiting for a table write from DocDB. |
+| TServerWait | CatalogWrite  | Network |  | A YSQL backend is waiting for a catalog write from master. |
+| TServerWait | IndexWrite | Network |   | A YSQL backend is waiting for a secondary index write from DocDB.  |
 | YSQLQuery | QueryProcessing| CPU |  | Doing CPU work |
 | YSQLQuery | yb_ash_metadata | LWLock |  | A YSQL backend is waiting to update ASH metadata for a query. |
-| Timeout | YBTxnConflictBackoff | Timeout |  | A YSQL backend is waiting due to conflict in DocDB. |
+| YSQLQuery | YBParallelScanEmpty| IPC |  | A YSQL backend is waiting on an empty queue while fetching parallel range keys. |
+| YSQLQuery | CopyCommandStreamRead| IO |  | A YSQL backend is waiting for a read from a file or program during COPY. |
+| YSQLQuery | CopyCommandStreamWrite| IO |  | A YSQL backend is waiting for a write to a file or program during COPY. |
+| YSQLQuery | YbAshMain| Activity |  | The YugabyteDB ASH collector background worker is waiting in the main loop. |
+| YSQLQuery | YbAshCircularBuffer| LWLock |  | A YSQL backend is waiting for YugabyteDB ASH circular buffer memory access. |
+| YSQLQuery | QueryDiagnosticsMain| Activity |  | The YugabyteDB query diagnostics background worker is waiting in the main loop. |
+| YSQLQuery | YbQueryDiagnostics| LWLock |  | A YSQL backend is waiting for YugabyteDB query diagnostics hash table memory access. |
+| YSQLQuery | YbQueryDiagnosticsCircularBuffer| LWLock |  | A YSQL backend is waiting for YugabyteDB query diagnostics circular buffer memory access. |
+| Timeout | YSQLQuery | Timeout |  | A YSQL backend is waiting for transaction conflict resolution with an exponential backoff. |
 
 ### YB-TServer
 
@@ -203,7 +215,7 @@ ORDER BY
   6107501747146929242 | TServer              | MVCC_WaitForSafeTime               | WaitOnCondition |    10
   6107501747146929242 | TServer              | Rpc_Done                           | WaitOnCondition |    15
   6107501747146929242 | YSQL                 | QueryProcessing                    | Cpu             |   285
-  6107501747146929242 | YSQL                 | StorageRead                        | Network         |   658
+  6107501747146929242 | YSQL                 | TableRead                        | Network         |   658
   6107501747146929242 | YSQL                 | CatalogRead                        | Network         |     1
 ```
 

--- a/docs/content/v2024.2/explore/observability/active-session-history.md
+++ b/docs/content/v2024.2/explore/observability/active-session-history.md
@@ -42,7 +42,7 @@ You can also use the following flags based on your requirements.
 
 | Flag | Description |
 | :--- | :---------- |
-| ysql_yb_ash_circular_buffer_size | Size (in KBs) of circular buffer where the samples are stored. <br> Default: 16*1024. Changing this flag requires a VM restart. |
+| ysql_yb_ash_circular_buffer_size | Size (in KBs) of circular buffer where the samples are stored. <br> Defaults:<ul><li>32 MB for 1-2 cores</li><li>64 MB for 3-4 cores</li><li>128 MB for 5-8 cores</li><li>256 MB for 9-16 cores</li><li>512 MB for 17-32 cores</li><li>1024 MB for more than 32 cores</li></ul> Changing this flag requires a VM restart. |
 | ysql_yb_ash_sampling_interval_ms | Sampling interval (in milliseconds). <br>Default: 1000. Changing this flag doesn't require a VM restart. |
 | ysql_yb_ash_sample_size | Maximum number of events captured per sampling interval. <br>Default: 500. Changing this flag doesn't require a VM restart. |
 
@@ -84,6 +84,30 @@ This view provides a list of wait events and their metadata. The columns of the 
 | client_node_ip | text | IP address of the client which sent the query to YSQL/YCQL. Null for background activities. |
 | sample_weight | float | If in any sampling interval there are too many events, YugabyteDB only collects `ysql_yb_ash_sample_size` samples/events. Based on how many were sampled, weights are assigned to the collected events. <br><br>For example, if there are 200 events, but only 100 events are collected, each of the collected samples will have a weight of (200 / 100) = 2.0 |
 | ysql_dbid | oid | Database OID of the YSQL database. This is 0 for YCQL databases.  |
+
+### yb_wait_event_desc
+
+This view displays the class, type, name, and description of each wait event. The columns of the view are described in the following table.
+
+| Column | Type | Description |
+| :----- | :--- | :---------- |
+| wait_event_class | text | Class of the wait event, such as TabletWait, RocksDB, and so on. |
+| wait_event_type | text | Type of the wait event such as CPU, WaitOnCondition, Network, Disk IO, and so on. |
+| wait_event | text | Name of the wait event. |
+| wait_event_description | text | Description of the wait event. |
+
+## Constant query identifiers
+
+These fixed constants are used to identify various YugabyteDB background activities. They also include a placeholder "query id" for instances where the actual "query id" has not been calculated yet, but the ASH collector samples the system. The query ids of the fixed constants are described in the following table.
+
+| Query id | Wait Event Component | Description |
+| :------- | :------------------- | :---------- |
+| 1 | TServer | Query id for write ahead log (WAL) appender thread. |
+| 2 | TServer | Query id for background flush tasks. |
+| 3 | TServer | Query id for background compaction tasks. |
+| 4 | TServer | Query id for Raft update consensus. |
+| 5 | YSQL/TServer | Default query id before it's calculated in YSQL. |
+| 6 | TServer | Query id for write ahead log (WAL) background sync. |
 
 ## Wait events
 

--- a/docs/content/v2024.2/explore/observability/active-session-history.md
+++ b/docs/content/v2024.2/explore/observability/active-session-history.md
@@ -98,7 +98,7 @@ This view displays the class, type, name, and description of each wait event. Th
 
 ## Constant query identifiers
 
-These fixed constants are used to identify various YugabyteDB background activities. They also include a placeholder "query id" for instances where the actual "query id" has not been calculated yet, but the ASH collector samples the system. The query ids of the fixed constants are described in the following table.
+These fixed constants are used to identify various YugabyteDB background activities. The query ids of the fixed constants are described in the following table.
 
 | Query id | Wait Event Component | Description |
 | :------- | :------------------- | :---------- |
@@ -126,7 +126,7 @@ These are the wait events introduced by YugabyteDB, however some of the followin
 | TServerWait | TableWrite  | Network |  | A YSQL backend is waiting for a table write from DocDB. |
 | TServerWait | CatalogWrite  | Network |  | A YSQL backend is waiting for a catalog write from master. |
 | TServerWait | IndexWrite | Network |   | A YSQL backend is waiting for a secondary index write from DocDB.  |
-| YSQLQuery | QueryProcessing| CPU |  | Doing CPU work |
+| YSQLQuery | QueryProcessing| CPU |  | A YSQL backend is doing CPU work.|
 | YSQLQuery | yb_ash_metadata | LWLock |  | A YSQL backend is waiting to update ASH metadata for a query. |
 | YSQLQuery | YBParallelScanEmpty| IPC |  | A YSQL backend is waiting on an empty queue while fetching parallel range keys. |
 | YSQLQuery | CopyCommandStreamRead| IO |  | A YSQL backend is waiting for a read from a file or program during COPY. |
@@ -136,7 +136,7 @@ These are the wait events introduced by YugabyteDB, however some of the followin
 | YSQLQuery | QueryDiagnosticsMain| Activity |  | The YugabyteDB query diagnostics background worker is waiting in the main loop. |
 | YSQLQuery | YbQueryDiagnostics| LWLock |  | A YSQL backend is waiting for YugabyteDB query diagnostics hash table memory access. |
 | YSQLQuery | YbQueryDiagnosticsCircularBuffer| LWLock |  | A YSQL backend is waiting for YugabyteDB query diagnostics circular buffer memory access. |
-| Timeout | YSQLQuery | Timeout |  | A YSQL backend is waiting for transaction conflict resolution with an exponential backoff. |
+| YSQLQuery | YBTxnConflictBackoff | Timeout |  | A YSQL backend is waiting for transaction conflict resolution with an exponential backoff. |
 
 ### YB-TServer
 

--- a/docs/content/v2024.2/explore/observability/active-session-history.md
+++ b/docs/content/v2024.2/explore/observability/active-session-history.md
@@ -5,7 +5,7 @@ linkTitle: Active Session History
 description: Use Active Session History to get current and past views of the database system activity.
 headcontent: Get real-time and historical information about active sessions to analyze and troubleshoot performance issues
 tags:
-  feature: tech-preview
+  feature: early-access
 menu:
   v2024.2:
     identifier: ash

--- a/docs/content/v2024.2/explore/ysql-language-features/pg-extensions/extension-pgcron.md
+++ b/docs/content/v2024.2/explore/ysql-language-features/pg-extensions/extension-pgcron.md
@@ -4,7 +4,7 @@ headerTitle: pg_cron extension
 linkTitle: pg_cron
 description: Using the pg_cron extension in YugabyteDB
 tags:
-  feature: tech-preview
+  feature: early-access
 menu:
   v2024.2:
     identifier: extension-pgcron
@@ -21,7 +21,7 @@ If the pg_cron leader node fails, another node is automatically elected as the n
 
 ## Set up pg_cron
 
-pg_cron in YugabyteDB is {{<tags/feature/tp>}}. Before you can use the feature, you must enable it by setting the `enable_pg_cron` flag. To do this, add `enable_pg_cron` to the `allowed_preview_flags_csv` flag and set the `enable_pg_cron` flag to true on all YB-Masters and YB-TServers.
+pg_cron in YugabyteDB is {{<tags/feature/ea>}}. Before you can use the feature, you must enable it by setting the `enable_pg_cron` flag. To do this, add `enable_pg_cron` to the `allowed_preview_flags_csv` flag and set the `enable_pg_cron` flag to true on all YB-Masters and YB-TServers.
 
 The pg_cron extension is installed on only one database, which stores the extension data. The default cron database is `yugabyte`. You can change it by setting the `ysql_cron_database_name` flag on all YB-TServers. You can create the database after setting the flag.
 

--- a/docs/content/v2024.2/explore/ysql-language-features/pg-extensions/extension-pgcron.md
+++ b/docs/content/v2024.2/explore/ysql-language-features/pg-extensions/extension-pgcron.md
@@ -3,8 +3,6 @@ title: pg_cron extension
 headerTitle: pg_cron extension
 linkTitle: pg_cron
 description: Using the pg_cron extension in YugabyteDB
-tags:
-  feature: early-access
 menu:
   v2024.2:
     identifier: extension-pgcron
@@ -21,7 +19,7 @@ If the pg_cron leader node fails, another node is automatically elected as the n
 
 ## Set up pg_cron
 
-pg_cron in YugabyteDB is {{<tags/feature/ea>}}. Before you can use the feature, you must enable it by setting the `enable_pg_cron` flag. To do this, add `enable_pg_cron` to the `allowed_preview_flags_csv` flag and set the `enable_pg_cron` flag to true on all YB-Masters and YB-TServers.
+Before you can use the feature, you must enable it by setting the `enable_pg_cron` flag. To do this, add `enable_pg_cron` to the `allowed_preview_flags_csv` flag and set the `enable_pg_cron` flag to true on all YB-Masters and YB-TServers.
 
 The pg_cron extension is installed on only one database, which stores the extension data. The default cron database is `yugabyte`. You can change it by setting the `ysql_cron_database_name` flag on all YB-TServers. You can create the database after setting the flag.
 

--- a/docs/content/v2024.2/manage/backup-restore/instant-db-cloning.md
+++ b/docs/content/v2024.2/manage/backup-restore/instant-db-cloning.md
@@ -289,3 +289,5 @@ Although creating a clone database is quick and initially doesn't take up much a
 
 - Cloning is not currently supported for databases that use sequences. See GitHub issue [21467](https://github.com/yugabyte/yugabyte-db/issues/21467) for tracking.
 - Cloning to a time before dropping Materialized views is not currently supported. See GitHub issue [23740](https://github.com/yugabyte/yugabyte-db/issues/23740) for tracking.
+- Cloning to a time before table rewrite operation is not currently supported. See GitHub issue [24385](https://github.com/yugabyte/yugabyte-db/issues/24385) for tracking.
+- Cloning to a time before rename of index column is not currently supported. See GitHub issue [24127](https://github.com/yugabyte/yugabyte-db/issues/24127) for tracking.

--- a/docs/content/v2024.2/manage/backup-restore/instant-db-cloning.md
+++ b/docs/content/v2024.2/manage/backup-restore/instant-db-cloning.md
@@ -4,7 +4,7 @@ headerTitle: Instant database cloning
 linkTitle: Instant database cloning
 description: Clone your database in YugabyteDB for data recovery, development, and testing.
 tags:
-  feature: tech-preview
+  feature: early-access
 menu:
   v2024.2:
     identifier: instant-db-clone
@@ -27,7 +27,7 @@ Cloning has two main use cases:
 
 ## Enable database cloning
 
-To enable database cloning in a cluster, set the yb-master flag `enable_db_clone` to true. Because cloning is in {{<tags/feature/tp>}}, you must also add the `enable_db_clone` flag to the [allowed_preview_flags_csv](../../../reference/configuration/yb-master/#allowed-preview-flags-csv) list.
+To enable database cloning in a cluster, set the yb-master flag `enable_db_clone` to true. Because cloning is in {{<tags/feature/ea>}}, you must also add the `enable_db_clone` flag to the [allowed_preview_flags_csv](../../../reference/configuration/yb-master/#allowed-preview-flags-csv) list.
 
 For example, to set these flags when creating a cluster using yugabyted, use the `--master_flags` option of the [start](../../../reference/configuration/yugabyted/#start) command as follows:
 

--- a/docs/content/v2024.2/reference/configuration/yb-tserver.md
+++ b/docs/content/v2024.2/reference/configuration/yb-tserver.md
@@ -799,7 +799,7 @@ Default: `false`
 
 ##### --pg_client_use_shared_memory
 
-{{<tags/feature/ea>}} Enables the use of shared memory between PostgreSQL and the YB-TServer. Using shared memory can potentially improve the performance of your database operations.
+Enables the use of shared memory between PostgreSQL and the YB-TServer. Using shared memory can potentially improve the performance of your database operations.
 
 Default: `false`
 


### PR DESCRIPTION
Summary:
- https://yugabyte.atlassian.net/issues/DOC-536 - xCluster support in yugabyted - This is supposed to be EA in 2024.1 (so added the ea tag in stable (2024.1) as it was missing)
- https://yugabyte.atlassian.net/issues/DOC-502 - [tp->ga] pg_cron extension - Changed this.
- https://yugabyte.atlassian.net/jira/polaris/projects/IDEA/ideas/view/5361900?selectedIssue=IDEA-990&issueViewSection=comments - [tp->ea] DB cloning done, added limitations.
- https://yugabyte.atlassian.net/jira/polaris/projects/IDEA/ideas/view/5361900?selectedIssue=IDEA-830&issueViewLayout=sidebar&issueViewSection=overview - [tp->ea] ASH done.
[IDEA-260](https://yugabyte.atlassian.net/jira/polaris/projects/IDEA/ideas/view/5162660?selectedIssue=IDEA-260&issueViewSection=comments) - removed EA tag for this flag `--pg_client_use_shared_memory`


[IDEA-260]: https://yugabyte.atlassian.net/browse/IDEA-260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ