### PR TITLE
Introducing YugabyteDB Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Ask in forum](https://img.shields.io/badge/ask%20us-forum-orange.svg)](https://forum.yugabyte.com/)
 [![Slack chat](https://img.shields.io/badge/Slack:-%23yugabyte_db-blueviolet.svg?logo=slack)](https://communityinviter.com/apps/yugabyte-db/register)
 [![Analytics](https://yugabyte.appspot.com/UA-104956980-4/home?pixel&useReferer)](https://github.com/yugabyte/ga-beacon)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20YugabyteDB%20Guru-006BFF)](https://gurubase.io/g/yugabytedb)
 
 # What is YugabyteDB?
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [YugabyteDB Guru](https://gurubase.io/g/yugabytedb) to Gurubase. YugabyteDB Guru uses the data from this repo and data from the [docs](https://docs.yugabyte.com/) to answer questions by leveraging the LLM.

In this PR, I showcased the "YugabyteDB Guru", which highlights that YugabyteDB now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable YugabyteDB Guru in Gurubase, just let me know that's totally fine.
