### PR TITLE
[DOC-529] Add requirements for roles and scoping to GCP cloud logging for DBAL

### DIFF
--- a/docs/content/preview/yugabyte-platform/alerts-monitoring/anywhere-export-configuration.md
+++ b/docs/content/preview/yugabyte-platform/alerts-monitoring/anywhere-export-configuration.md
@@ -113,9 +113,8 @@ To create an export configuration, do the following:
 
 The GCP Cloud Logging export configuration requires the following:
 
-- Google Service Account credentials JSON key
-- The Service Account should have the following role: roles/logging.logWriter
-- The credentials should be scoped to the project where the log group is located
+- Google Service Account with the `roles/logging.logWriter` role.
+- The Service Account credentials JSON key. The credentials should be scoped to the project where the log group is located.
 
 To create an export configuration, do the following:
 

--- a/docs/content/preview/yugabyte-platform/alerts-monitoring/anywhere-export-configuration.md
+++ b/docs/content/preview/yugabyte-platform/alerts-monitoring/anywhere-export-configuration.md
@@ -113,7 +113,9 @@ To create an export configuration, do the following:
 
 The GCP Cloud Logging export configuration requires the following:
 
-- Google Service Account credentials JSON
+- Google Service Account credentials JSON key
+- The Service Account should have the following role: roles/logging.logWriter
+- The credentials should be scoped to the project where the log group is located
 
 To create an export configuration, do the following:
 

--- a/docs/content/stable/yugabyte-platform/alerts-monitoring/anywhere-export-configuration.md
+++ b/docs/content/stable/yugabyte-platform/alerts-monitoring/anywhere-export-configuration.md
@@ -113,9 +113,8 @@ To create an export configuration, do the following:
 
 The GCP Cloud Logging export configuration requires the following:
 
-- Google Service Account credentials JSON key
-- The Service Account should have the following role: roles/logging.logWriter
-- The credentials should be scoped to the project where the log group is located
+- Google Service Account with the `roles/logging.logWriter` role.
+- The Service Account credentials JSON key. The credentials should be scoped to the project where the log group is located.
 
 To create an export configuration, do the following:
 

--- a/docs/content/stable/yugabyte-platform/alerts-monitoring/anywhere-export-configuration.md
+++ b/docs/content/stable/yugabyte-platform/alerts-monitoring/anywhere-export-configuration.md
@@ -113,7 +113,9 @@ To create an export configuration, do the following:
 
 The GCP Cloud Logging export configuration requires the following:
 
-- Google Service Account credentials JSON
+- Google Service Account credentials JSON key
+- The Service Account should have the following role: roles/logging.logWriter
+- The credentials should be scoped to the project where the log group is located
 
 To create an export configuration, do the following:
 

--- a/docs/content/v2024.2/yugabyte-platform/alerts-monitoring/anywhere-export-configuration.md
+++ b/docs/content/v2024.2/yugabyte-platform/alerts-monitoring/anywhere-export-configuration.md
@@ -113,7 +113,8 @@ To create an export configuration, do the following:
 
 The GCP Cloud Logging export configuration requires the following:
 
-- Google Service Account credentials JSON
+- Google Service Account with the `roles/logging.logWriter` role.
+- The Service Account credentials JSON key. The credentials should be scoped to the project where the log group is located.
 
 To create an export configuration, do the following:
 


### PR DESCRIPTION
Add requirements for logWriter role and project scoping detail to the section on configuring GCP cloud logging, to make it easier for user to understand the full requirements when setting up this integration.