### PR TITLE
[docs] CDC: Update CDC documentation for tablet splitting

### DIFF
--- a/docs/content/preview/explore/change-data-capture/using-logical-replication/_index.md
+++ b/docs/content/preview/explore/change-data-capture/using-logical-replication/_index.md
@@ -112,3 +112,5 @@ For reference documentation, see [YugabyteDB Connector](./yugabytedb-connector/)
 - Support for transaction savepoints is tracked in issue [10936](https://github.com/yugabyte/yugabyte-db/issues/10936).
 
 - Support for enabling CDC on Read Replicas is tracked in issue [11116](https://github.com/yugabyte/yugabyte-db/issues/11116).
+
+- Support for tablet splitting is disabled from YB version 2024.2.1. It is tracked in issue [24918](https://github.com/yugabyte/yugabyte-db/issues/24918).

--- a/docs/content/preview/explore/change-data-capture/using-logical-replication/_index.md
+++ b/docs/content/preview/explore/change-data-capture/using-logical-replication/_index.md
@@ -113,4 +113,4 @@ For reference documentation, see [YugabyteDB Connector](./yugabytedb-connector/)
 
 - Support for enabling CDC on Read Replicas is tracked in issue [11116](https://github.com/yugabyte/yugabyte-db/issues/11116).
 
-- Support for tablet splitting is disabled from YB version 2024.2.1. It is tracked in issue [24918](https://github.com/yugabyte/yugabyte-db/issues/24918).
+- Support for tablet splitting with logical replication is disabled from YB version 2024.1.4 & 2024.2.1. It is tracked in issue [24918](https://github.com/yugabyte/yugabyte-db/issues/24918).


### PR DESCRIPTION
This PR makes changes indicating that tablet split support is disabled in logical replication.