### PR TITLE
[docs] Set `pg_client_use_shared_memory` default to `true`

### DIFF
--- a/docs/content/stable/reference/configuration/yb-tserver.md
+++ b/docs/content/stable/reference/configuration/yb-tserver.md
@@ -809,7 +809,7 @@ Default: `false`
 
 Enables the use of shared memory between PostgreSQL and the YB-TServer. Using shared memory can potentially improve the performance of your database operations.
 
-Default: `false`
+Default: `true`
 
 ##### --ysql_disable_index_backfill
 


### PR DESCRIPTION
In 2024.2 the default is true.