### PR TITLE
[Docs] Vertically align text in note

### DIFF
--- a/docs/assets/scss/_admonition.scss
+++ b/docs/assets/scss/_admonition.scss
@@ -71,6 +71,10 @@ main {
       position: relative;
       margin: 1em 0;
 
+      &.note {
+        padding: 16px 16px 16px 50px;
+      }
+
       &::before {
         content: "";
         width: 18px;


### PR DESCRIPTION
Some of our banners seem to be not aligned right in this example.
![CleanShot 2024-12-13 at 14 29 12@2x](https://github.com/user-attachments/assets/3ec61f8f-c81e-4175-8cf3-262d0501b0dd)

The icon is vertically centered but the copy is more top aligned.


@netlify /preview/tutorials/build-apps/cloud-add-ip/