### PR TITLE
[doc][2024.2.1] Added limitations for YSQL Connection Manager

### DIFF
--- a/docs/content/stable/explore/going-beyond-sql/connection-mgr-ysql.md
+++ b/docs/content/stable/explore/going-beyond-sql/connection-mgr-ysql.md
@@ -100,7 +100,7 @@ The following table describes YB-TServer flags related to YSQL Connection Manage
 
 ## Limitations
 
-- Changes to default GUC values for a user or database (ALTER ROLE SET/ALTER DATABASE SET queries) may reflect in other pre-existing active sessions.
+- Changes to [configuration parameters](../../../reference/configuration/yb-tserver/#postgresql-server-options) for a user or database that are set using ALTER ROLE SET or ALTER DATABASE SET queries may reflect in other pre-existing active sessions.
 - YSQL Connection Manager can route up to 10,000 connection pools. This includes pools corresponding to dropped users and databases.
 - Prepared statements may be visible to other sessions in the same connection pool. [#24652](https://github.com/yugabyte/yugabyte-db/issues/24652)
 - Attempting to use DEALLOCATE/DEALLOCATE ALL queries can result in unexpected behavior. [#24653](https://github.com/yugabyte/yugabyte-db/issues/24653)

--- a/docs/content/stable/explore/going-beyond-sql/connection-mgr-ysql.md
+++ b/docs/content/stable/explore/going-beyond-sql/connection-mgr-ysql.md
@@ -105,5 +105,5 @@ The following table describes YB-TServer flags related to YSQL Connection Manage
 - Prepared statements may be visible to other sessions in the same connection pool. [#24652](https://github.com/yugabyte/yugabyte-db/issues/24652)
 - Attempting to use DEALLOCATE/DEALLOCATE ALL queries can result in unexpected behavior. [#24653](https://github.com/yugabyte/yugabyte-db/issues/24653)
 - Currently, you can't apply custom configurations to individual pools. The YSQL Connection Manager configuration applies to all pools.
-- When YSQL Connection Manager is enabled, the backend PID stored using JDBC drivers may not accurate. This does not affect backend-specific functionalities (for example, cancel queries), but this PID should not be used to identify the backend process.
+- When YSQL Connection Manager is enabled, the backend PID stored using JDBC drivers may not be accurate. This does not affect backend-specific functionalities (for example, cancel queries), but this PID should not be used to identify the backend process.
 - By default, `currval` and `nextval` functions do not work when YSQL Connection Manager is enabled. They can be supported with the help of the `ysql_conn_mgr_sequence_support_mode` flag.

--- a/docs/content/stable/explore/going-beyond-sql/connection-mgr-ysql.md
+++ b/docs/content/stable/explore/going-beyond-sql/connection-mgr-ysql.md
@@ -106,4 +106,4 @@ The following table describes YB-TServer flags related to YSQL Connection Manage
 - Attempting to use DEALLOCATE/DEALLOCATE ALL queries can result in unexpected behavior. [#24653](https://github.com/yugabyte/yugabyte-db/issues/24653)
 - Currently, you can't apply custom configurations to individual pools. The YSQL Connection Manager configuration applies to all pools.
 - When YSQL Connection Manager is enabled, the backend PID stored using JDBC drivers may not accurate. This does not affect backend-specific functionalities (for example, cancel queries), but this PID should not be used to identify the backend process.
-- `currval` and `nextval` functions do not work by default with connection manager enabled. They can be supported with the help of the `ysql_conn_mgr_sequence_support_mode` flag.
+- By default, `currval` and `nextval` functions do not work when YSQL Connection Manager is enabled. They can be supported with the help of the `ysql_conn_mgr_sequence_support_mode` flag.

--- a/docs/content/stable/explore/going-beyond-sql/connection-mgr-ysql.md
+++ b/docs/content/stable/explore/going-beyond-sql/connection-mgr-ysql.md
@@ -101,9 +101,9 @@ The following table describes YB-TServer flags related to YSQL Connection Manage
 ## Limitations
 
 - Changes to default GUC values for a user or database (ALTER ROLE SET/ALTER DATABASE SET queries) may reflect in other pre-existing active sessions.
-- Connection Manager can only support upto a total of 10,000 pools to route. This includes pools corresponding to dropped users and databases as well.
-- Prepared statements may be visible to other sessions within the same connection pool. [#24652](https://github.com/yugabyte/yugabyte-db/issues/24652)
+- YSQL Connection Manager can route up to 10,000 connection pools. This includes pools corresponding to dropped users and databases.
+- Prepared statements may be visible to other sessions in the same connection pool. [#24652](https://github.com/yugabyte/yugabyte-db/issues/24652)
 - Attempting to use DEALLOCATE/DEALLOCATE ALL queries can result in unexpected behavior. [#24653](https://github.com/yugabyte/yugabyte-db/issues/24653)
-- As of now, Connection Manager does not facilitate custom configurations per pool. All configurations used will apply to every pool that Connection Manager routes through.
-- With connection manager enabled, the backend PID stored using JDBC drivers may not accurate. This does not affect backend-specific functionalities (eg. cancel queries), but this PID should not be used to identify the backend process.
+- Currently, you can't apply custom configurations to individual pools. The YSQL Connection Manager configuration applies to all pools.
+- When YSQL Connection Manager is enabled, the backend PID stored using JDBC drivers may not accurate. This does not affect backend-specific functionalities (for example, cancel queries), but this PID should not be used to identify the backend process.
 - `currval` and `nextval` functions do not work by default with connection manager enabled. They can be supported with the help of the `ysql_conn_mgr_sequence_support_mode` flag.

--- a/docs/content/stable/explore/going-beyond-sql/connection-mgr-ysql.md
+++ b/docs/content/stable/explore/going-beyond-sql/connection-mgr-ysql.md
@@ -97,3 +97,13 @@ The following table describes YB-TServer flags related to YSQL Connection Manage
 | ysql_conn_mgr_server_lifetime | The maximum duration (in seconds) that a backend PostgreSQL connection managed by YSQL Connection Manager can remain open after creation. | 3600 |
 | ysql_conn_mgr_log_settings | Comma-separated list of log settings for YSQL Connection Manger. Can include  'log_debug', 'log_config', 'log_session', 'log_query', and 'log_stats'. | "" |
 | ysql_conn_mgr_use_auth_backend | Enable the use of the auth-backend for authentication of logical connections. When false, the older auth-passthrough implementation is used. | true |
+
+## Limitations
+
+- Changes to default GUC values for a user or database (ALTER ROLE SET/ALTER DATABASE SET queries) may reflect in other pre-existing active sessions.
+- Connection Manager can only support upto a total of 10,000 pools to route. This includes pools corresponding to dropped users and databases as well.
+- Prepared statements may be visible to other sessions within the same connection pool. [#24652](https://github.com/yugabyte/yugabyte-db/issues/24652)
+- Attempting to use DEALLOCATE/DEALLOCATE ALL queries can result in unexpected behavior. [#24653](https://github.com/yugabyte/yugabyte-db/issues/24653)
+- As of now, Connection Manager does not facilitate custom configurations per pool. All configurations used will apply to every pool that Connection Manager routes through.
+- With connection manager enabled, the backend PID stored using JDBC drivers may not accurate. This does not affect backend-specific functionalities (eg. cancel queries), but this PID should not be used to identify the backend process.
+- `currval` and `nextval` functions do not work by default with connection manager enabled. They can be supported with the help of the `ysql_conn_mgr_sequence_support_mode` flag.


### PR DESCRIPTION
This PR adds the "Limitations" section for v2024.2 docs of YSQL Connection Manager.

@netlify /stable/explore/going-beyond-sql/connection-mgr-ysql/