### PR TITLE
[doc][cdc] Update logical replication limitation on table rewrite DDLs

### DIFF
--- a/docs/content/preview/develop/change-data-capture/using-logical-replication/_index.md
+++ b/docs/content/preview/develop/change-data-capture/using-logical-replication/_index.md
@@ -105,7 +105,7 @@ For reference documentation, see [YugabyteDB Connector](./yugabytedb-connector/)
 
 - CDC is not supported on a target table for xCluster replication [11829](https://github.com/yugabyte/yugabyte-db/issues/11829).
 
-- Currently, CDC doesn't support schema evolution for changes that require table rewrites (for example, [ALTER TYPE](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-type-with-table-rewrite)), or DROP TABLE and TRUNCATE TABLE operations.
+- Currently, CDC doesn't support schema evolution for changes that require table rewrites (for example, [ALTER TYPE](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-type-with-table-rewrite)), or DROP TABLE and TRUNCATE TABLE operations after the replication slot is created. However, you can perform these operations before creating the replication slot without any issues.
 
 - YCQL tables aren't currently supported. Issue [11320](https://github.com/yugabyte/yugabyte-db/issues/11320).
 

--- a/docs/content/stable/develop/change-data-capture/using-logical-replication/_index.md
+++ b/docs/content/stable/develop/change-data-capture/using-logical-replication/_index.md
@@ -103,7 +103,7 @@ For reference documentation, see [YugabyteDB Connector](./yugabytedb-connector/)
 
 - CDC is not supported on a target table for xCluster replication [11829](https://github.com/yugabyte/yugabyte-db/issues/11829).
 
-- Currently, CDC doesn't support schema evolution for changes that require table rewrites (for example, [ALTER TYPE](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-type-with-table-rewrite)), or DROP TABLE and TRUNCATE TABLE operations.
+- Currently, CDC doesn't support schema evolution for changes that require table rewrites (for example, [ALTER TYPE](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-type-with-table-rewrite)), or DROP TABLE and TRUNCATE TABLE operations  after the replication slot is created. However, these operations can be performed before the replication slot creation without any issues.
 
 - YCQL tables aren't currently supported. Issue [11320](https://github.com/yugabyte/yugabyte-db/issues/11320).
 

--- a/docs/content/stable/develop/change-data-capture/using-logical-replication/_index.md
+++ b/docs/content/stable/develop/change-data-capture/using-logical-replication/_index.md
@@ -103,7 +103,7 @@ For reference documentation, see [YugabyteDB Connector](./yugabytedb-connector/)
 
 - CDC is not supported on a target table for xCluster replication [11829](https://github.com/yugabyte/yugabyte-db/issues/11829).
 
-- Currently, CDC doesn't support schema evolution for changes that require table rewrites (for example, [ALTER TYPE](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-type-with-table-rewrite)), or DROP TABLE and TRUNCATE TABLE operations  after the replication slot is created. However, these operations can be performed before the replication slot creation without any issues.
+- Currently, CDC doesn't support schema evolution for changes that require table rewrites (for example, [ALTER TYPE](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-type-with-table-rewrite)), or DROP TABLE and TRUNCATE TABLE operations after the replication slot is created. However, you can perform these operations before creating the replication slot without any issues.
 
 - YCQL tables aren't currently supported. Issue [11320](https://github.com/yugabyte/yugabyte-db/issues/11320).
 

--- a/docs/content/v2024.1/develop/change-data-capture/using-logical-replication/_index.md
+++ b/docs/content/v2024.1/develop/change-data-capture/using-logical-replication/_index.md
@@ -103,7 +103,7 @@ For reference documentation, see [YugabyteDB Connector](./yugabytedb-connector/)
 
 - CDC is not supported on a target table for xCluster replication [11829](https://github.com/yugabyte/yugabyte-db/issues/11829).
 
-- Currently, CDC doesn't support schema evolution for changes that require table rewrites (for example, [ALTER TYPE](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-type-with-table-rewrite)), or DROP TABLE and TRUNCATE TABLE operations after the replication slot is created. However, these operations can be performed before the replication slot creation without any issues.
+- Currently, CDC doesn't support schema evolution for changes that require table rewrites (for example, [ALTER TYPE](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-type-with-table-rewrite)), or DROP TABLE and TRUNCATE TABLE operations after the replication slot is created. However, you can perform these operations before creating the replication slot without any issues.
 
 - YCQL tables aren't currently supported. Issue [11320](https://github.com/yugabyte/yugabyte-db/issues/11320).
 

--- a/docs/content/v2024.1/develop/change-data-capture/using-logical-replication/_index.md
+++ b/docs/content/v2024.1/develop/change-data-capture/using-logical-replication/_index.md
@@ -103,7 +103,7 @@ For reference documentation, see [YugabyteDB Connector](./yugabytedb-connector/)
 
 - CDC is not supported on a target table for xCluster replication [11829](https://github.com/yugabyte/yugabyte-db/issues/11829).
 
-- Currently, CDC doesn't support schema evolution for changes that require table rewrites (for example, [ALTER TYPE](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-type-with-table-rewrite)), or DROP TABLE and TRUNCATE TABLE operations.
+- Currently, CDC doesn't support schema evolution for changes that require table rewrites (for example, [ALTER TYPE](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-type-with-table-rewrite)), or DROP TABLE and TRUNCATE TABLE operations after the replication slot is created. However, these operations can be performed before the replication slot creation without any issues.
 
 - YCQL tables aren't currently supported. Issue [11320](https://github.com/yugabyte/yugabyte-db/issues/11320).
 


### PR DESCRIPTION
Updated logical replication limitations to reflect the recent changes of allowing table re-write DDLs before the slot creation.
For more info:

1. [Table Re-write DDLs Before Slot Creation](https://docs.google.com/document/d/1AYq1OXyJLbH7kVdtyOC8KvG7RAgiO8tLYsHYEZK2B4M/edit?tab=t.0#heading=h.rdfsjqxh6mj8)
2. [Issues with DDLs in Logical Replication](https://docs.google.com/document/d/1KQvVOi-tB4TKw1uEOAMZ-4Ur7AP-AwKccvk-LVWln5M/edit?tab=t.0#heading=h.kr5zym3bg5pk)

DOC-611