### PR TITLE
[doc] xCluster target backup limitation

### DIFF
--- a/docs/content/preview/architecture/docdb-replication/async-replication.md
+++ b/docs/content/preview/architecture/docdb-replication/async-replication.md
@@ -270,7 +270,7 @@ When the source universe is lost, an explicit decision must be made to switch ov
 
 ### Backups
 
-Backups are supported. However for backups on target clusters, consistency across tablets or across tables is not guaranteed.
+Backups are supported. However for backups on target clusters, if there is an active workload, consistency of the latest data is not guaranteed.
 
 ## Cross-feature interactions
 

--- a/docs/content/preview/architecture/docdb-replication/async-replication.md
+++ b/docs/content/preview/architecture/docdb-replication/async-replication.md
@@ -268,6 +268,10 @@ When the source universe is lost, an explicit decision must be made to switch ov
 - Technically, xCluster replication can be set up with Kubernetes-deployed universes.  However, the source and target must be able to communicate by directly referencing the pods in the other universe.  In practice, this either means that the two universes must be part of the same Kubernetes cluster or that two Kubernetes clusters must have DNS and routing properly set up amongst themselves.
 - Being able to have two YugabyteDB universes, each in their own standalone Kubernetes cluster, communicating with each other via a load balancer, is not currently supported, as per [#2422](https://github.com/yugabyte/yugabyte-db/issues/2422).
 
+### Backups
+
+Backups are supported. However for backups on target clusters, consistency across tablets or across tables is not guaranteed.
+
 ## Cross-feature interactions
 
 A number of interactions across features are supported.

--- a/docs/content/preview/deploy/multi-dc/async-replication/async-replication-transactional.md
+++ b/docs/content/preview/deploy/multi-dc/async-replication/async-replication-transactional.md
@@ -44,6 +44,8 @@ Transactional xCluster can be set up in the following ways:
 - Supports only Active-Standby setups with transactional atomicity and global ordering.
 - Transactional consistency is currently not supported for YCQL, only for YSQL.
 
+For more information on the YugabyteDB xCluster implementation and its limitations, refer to [xCluster implementation limitations](../../../../architecture/docdb-replication/async-replication/#limitations).
+
 ## Best practices
 
 - Keep CPU use below 65%.

--- a/docs/content/stable/architecture/docdb-replication/async-replication.md
+++ b/docs/content/stable/architecture/docdb-replication/async-replication.md
@@ -266,6 +266,10 @@ When the source universe is lost, an explicit decision must be made to switch ov
 - Technically, xCluster replication can be set up with Kubernetes-deployed universes.  However, the source and target must be able to communicate by directly referencing the pods in the other universe.  In practice, this either means that the two universes must be part of the same Kubernetes cluster or that two Kubernetes clusters must have DNS and routing properly set up amongst themselves.
 - Being able to have two YugabyteDB universes, each in their own standalone Kubernetes cluster, communicating with each other via a load balancer, is not currently supported, as per [#2422](https://github.com/yugabyte/yugabyte-db/issues/2422).
 
+### Backups
+
+Backups are supported. However for backups on target clusters, if there is an active workload, consistency of the latest data is not guaranteed.
+
 ## Cross-feature interactions
 
 A number of interactions across features are supported.

--- a/docs/content/stable/deploy/multi-dc/async-replication/async-replication-transactional.md
+++ b/docs/content/stable/deploy/multi-dc/async-replication/async-replication-transactional.md
@@ -42,6 +42,8 @@ Transactional xCluster can be set up in the following ways:
 - Supports only Active-Standby setups with transactional atomicity and global ordering.
 - Transactional consistency is currently not supported for YCQL, only for YSQL.
 
+For more information on the YugabyteDB xCluster implementation and its limitations, refer to [xCluster implementation limitations](../../../../architecture/docdb-replication/async-replication/#limitations).
+
 ## Best practices
 
 - Keep CPU use below 65%.

--- a/docs/content/v2.18/architecture/docdb-replication/async-replication.md
+++ b/docs/content/v2.18/architecture/docdb-replication/async-replication.md
@@ -264,6 +264,10 @@ When the source universe is lost, an explicit decision must be made to switch ov
 - Technically, xCluster replication can be set up with Kubernetes-deployed universes.  However, the source and target must be able to communicate by directly referencing the pods in the other universe.  In practice, this either means that the two universes must be part of the same Kubernetes cluster or that two Kubernetes clusters must have DNS and routing properly set up amongst themselves.
 - Being able to have two YugabyteDB universes, each in their own standalone Kubernetes cluster, communicating with each other via a load balancer, is not currently supported, as per [#2422](https://github.com/yugabyte/yugabyte-db/issues/2422).
 
+### Backups
+
+Backups are supported. However for backups on target clusters, if there is an active workload, consistency of the latest data is not guaranteed.
+
 ## Cross-feature interactions
 
 A number of interactions across features are supported.

--- a/docs/content/v2.20/architecture/docdb-replication/async-replication.md
+++ b/docs/content/v2.20/architecture/docdb-replication/async-replication.md
@@ -266,6 +266,10 @@ When the source universe is lost, an explicit decision must be made to switch ov
 - Technically, xCluster replication can be set up with Kubernetes-deployed universes.  However, the source and target must be able to communicate by directly referencing the pods in the other universe.  In practice, this either means that the two universes must be part of the same Kubernetes cluster or that two Kubernetes clusters must have DNS and routing properly set up amongst themselves.
 - Being able to have two YugabyteDB universes, each in their own standalone Kubernetes cluster, communicating with each other via a load balancer, is not currently supported, as per [#2422](https://github.com/yugabyte/yugabyte-db/issues/2422).
 
+### Backups
+
+Backups are supported. However for backups on target clusters, if there is an active workload, consistency of the latest data is not guaranteed.
+
 ## Cross-feature interactions
 
 A number of interactions across features are supported.

--- a/docs/content/v2.20/deploy/multi-dc/async-replication/async-replication-transactional.md
+++ b/docs/content/v2.20/deploy/multi-dc/async-replication/async-replication-transactional.md
@@ -38,6 +38,8 @@ xCluster safe time is the transactionally consistent time across all tables in a
 - Supports only Active-Standby setups with transactional atomicity and global ordering.
 - Transactional consistency is currently not supported for YCQL, only for YSQL.
 
+For more information on the YugabyteDB xCluster implementation and its limitations, refer to [xCluster implementation limitations](../../../../architecture/docdb-replication/async-replication/#limitations).
+
 ## Best practices
 
 - Keep CPU use below 65%.

--- a/docs/content/v2024.1/architecture/docdb-replication/async-replication.md
+++ b/docs/content/v2024.1/architecture/docdb-replication/async-replication.md
@@ -266,6 +266,10 @@ When the source universe is lost, an explicit decision must be made to switch ov
 - Technically, xCluster replication can be set up with Kubernetes-deployed universes.  However, the source and target must be able to communicate by directly referencing the pods in the other universe.  In practice, this either means that the two universes must be part of the same Kubernetes cluster or that two Kubernetes clusters must have DNS and routing properly set up amongst themselves.
 - Being able to have two YugabyteDB universes, each in their own standalone Kubernetes cluster, communicating with each other via a load balancer, is not currently supported, as per [#2422](https://github.com/yugabyte/yugabyte-db/issues/2422).
 
+### Backups
+
+Backups are supported. However for backups on target clusters, if there is an active workload, consistency of the latest data is not guaranteed.
+
 ## Cross-feature interactions
 
 A number of interactions across features are supported.

--- a/docs/content/v2024.1/deploy/multi-dc/async-replication/async-replication-transactional.md
+++ b/docs/content/v2024.1/deploy/multi-dc/async-replication/async-replication-transactional.md
@@ -42,6 +42,8 @@ Transactional xCluster can be set up in the following ways:
 - Supports only Active-Standby setups with transactional atomicity and global ordering.
 - Transactional consistency is currently not supported for YCQL, only for YSQL.
 
+For more information on the YugabyteDB xCluster implementation and its limitations, refer to [xCluster implementation limitations](../../../../architecture/docdb-replication/async-replication/#limitations).
+
 ## Best practices
 
 - Keep CPU use below 65%.


### PR DESCRIPTION
xCluster target backup limitation

@netlify /preview/architecture/docdb-replication/async-replication/#limitations