### PR TITLE
[DOC-610] Clarify the meaning of clientcert=1 in TLS docs

### DIFF
--- a/docs/content/preview/secure/authentication/host-based-authentication.md
+++ b/docs/content/preview/secure/authentication/host-based-authentication.md
@@ -244,7 +244,7 @@ Specify that any user requires GSSAPI authentication to connect.
 
 After the [auth-method](#auth-method) field, you can add fields in the form `name=value` that specify options specific to the authentication method.
 
-In addition to the method-specific options, there is one method-independent authentication option `clientcert`, which can be specified in any `hostssl` record. When set to 1, this option requires the client to present a valid (trusted) SSL certificate, in addition to the other requirements of the authentication method.
+In addition to the method-specific options, there is one method-independent authentication option `clientcert`, which can be specified in any `hostssl` record. When set to `verify-full`, this option requires the client to present a valid (trusted) SSL certificate, in addition to the other requirements of the authentication method.
 
 ### Examples
 

--- a/docs/content/preview/secure/tls-encryption/tls-authentication.md
+++ b/docs/content/preview/secure/tls-encryption/tls-authentication.md
@@ -25,10 +25,9 @@ The default (auto-generated) configuration in the `ysql_hba.conf` file depends o
 The four default cases are shown in the following table.
 
 | | Auth disabled | Auth enabled |
-| ---|---|---|
+| :--- | :--- | :--- |
 | TLS disabled | `host all all all trust`</br>(no ssl, no password) | `host all all all md5`</br>(no ssl, password required) |
 | TLS enabled | `hostssl all all all trust`</br>(require ssl, no password) | `hostssl all all all md5`</br>(require ssl and password) |
-
 
 Additionally, `ysql_hba_conf_csv` can be used to manually configure a custom HBA configuration.
 
@@ -37,6 +36,10 @@ For instance, to use TLS with both password authentication and client certificat
 ```sh
 hostssl all all all md5 clientcert=verify-full
 ```
+
+{{< note title="Note" >}}
+To use the client certificate only for verification (signed by the CA) but not for authentication, you can set `clientcert` to verify-ca.
+{{< /note >}}
 
 The `ysql_hba_conf_csv` rules are added above the auto-generated rules in the `ysql_hba.conf` file, so if they do not match the connection type, database, user, or host, then the auto-generated rules (that is, from the table above) may still be used.
 
@@ -208,7 +211,3 @@ ysqlsh (11.2-YB-{{<yb-version version="preview" format="build">}})
 SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 256, compression: off)
 Type "help" for help.
 ```
-
-{{< note title="Note" >}}
-To use the client certificate only for verification (signed by the CA) but not for authentication, the clientcert parameter can be set to verify-ca.
-{{< /note >}}

--- a/docs/content/preview/secure/tls-encryption/tls-authentication.md
+++ b/docs/content/preview/secure/tls-encryption/tls-authentication.md
@@ -30,12 +30,12 @@ The four default cases are shown in the following table.
 | TLS enabled | `hostssl all all all trust`</br>(require ssl, no password) | `hostssl all all all md5`</br>(require ssl and password) |
 
 {{< note title="Note" >}}
-Before version 2.5.2, when TLS was enabled the default was to use the more strict `cert` option when auth was disabled, and `md5 clientcert=verify-ca` (password auth + cert verification) when auth was enabled.
+Before YugabyteDB v2.5.2, when TLS was enabled the default was to use the more strict `cert` option when auth was disabled, and `md5 clientcert=verify-ca` (password auth + cert verification) when auth was enabled.
 {{< /note >}}
 
 Additionally, `ysql_hba_conf_csv` can be used to manually configure a custom HBA configuration.
 
-For instance, to use TLS with both `md5` and `cert` authentication, you can set the `ysql_hba_conf_csv` flag as follows:
+For instance, to use TLS with both password authentication and client certificate verification, you can set the `ysql_hba_conf_csv` flag as follows:
 
 ```sh
 hostssl all all all md5 clientcert=verify-full

--- a/docs/content/preview/secure/tls-encryption/tls-authentication.md
+++ b/docs/content/preview/secure/tls-encryption/tls-authentication.md
@@ -175,10 +175,6 @@ Type "help" for help.
 
 This configuration requires the client to use client-to-server encryption and authenticate with both the appropriate certificate and the password to connect.
 
-{{< note title="Note" >}}
-To use the client certificate only for verification (signed by the CA) but not for authentication, the clientcert parameter can be set to verify-ca.
-{{< /note >}}
-
 To create the database, execute the following command:
 
 ```sh
@@ -212,3 +208,7 @@ ysqlsh (11.2-YB-{{<yb-version version="preview" format="build">}})
 SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 256, compression: off)
 Type "help" for help.
 ```
+
+{{< note title="Note" >}}
+To use the client certificate only for verification (signed by the CA) but not for authentication, the clientcert parameter can be set to verify-ca.
+{{< /note >}}

--- a/docs/content/preview/secure/tls-encryption/tls-authentication.md
+++ b/docs/content/preview/secure/tls-encryption/tls-authentication.md
@@ -30,7 +30,7 @@ The four default cases are shown in the following table.
 | TLS enabled | `hostssl all all all trust`</br>(require ssl, no password) | `hostssl all all all md5`</br>(require ssl and password) |
 
 {{< note title="Note" >}}
-Before version 2.5.2, when TLS was enabled the default was to use the more strict `cert` option when auth was disabled, and `md5 clientcert=1` (effectively md5 + cert) when auth was enabled.
+Before version 2.5.2, when TLS was enabled the default was to use the more strict `cert` option when auth was disabled, and `md5 clientcert=verify-ca` (password auth + cert verification) when auth was enabled.
 {{< /note >}}
 
 Additionally, `ysql_hba_conf_csv` can be used to manually configure a custom HBA configuration.
@@ -38,7 +38,7 @@ Additionally, `ysql_hba_conf_csv` can be used to manually configure a custom HBA
 For instance, to use TLS with both `md5` and `cert` authentication, you can set the `ysql_hba_conf_csv` flag as follows:
 
 ```sh
-hostssl all all all md5 clientcert=1
+hostssl all all all md5 clientcert=verify-full
 ```
 
 The `ysql_hba_conf_csv` rules are added above the auto-generated rules in the `ysql_hba.conf` file, so if they do not match the connection type, database, user, or host, then the auto-generated rules (that is, from the table above) may still be used.
@@ -192,7 +192,7 @@ To create the database, execute the following command:
 ```sh
 $ ./bin/yb-ctl destroy && ./bin/yb-ctl create \
     --tserver_flags="$ENABLE_TLS,ysql_enable_auth=true" \
-    --ysql_hba_conf_csv="hostssl all all all md5 clientcert=1"
+    --ysql_hba_conf_csv="hostssl all all all md5 clientcert=verify-full"
 ```
 
 The `ysql_enable_auth=true` flag is redundant in this case, but included to demonstrate the ability to override the auto-generated configuration using `ysql_hba_conf_csv`.

--- a/docs/content/preview/secure/tls-encryption/tls-authentication.md
+++ b/docs/content/preview/secure/tls-encryption/tls-authentication.md
@@ -29,9 +29,6 @@ The four default cases are shown in the following table.
 | TLS disabled | `host all all all trust`</br>(no ssl, no password) | `host all all all md5`</br>(no ssl, password required) |
 | TLS enabled | `hostssl all all all trust`</br>(require ssl, no password) | `hostssl all all all md5`</br>(require ssl and password) |
 
-{{< note title="Note" >}}
-Before YugabyteDB v2.5.2, when TLS was enabled the default was to use the more strict `cert` option when auth was disabled, and `md5 clientcert=verify-ca` (password auth + cert verification) when auth was enabled.
-{{< /note >}}
 
 Additionally, `ysql_hba_conf_csv` can be used to manually configure a custom HBA configuration.
 
@@ -143,10 +140,6 @@ The other modes (that is, `sslmode=require` or `disable`) behave analogously.
 
 This configuration requires the client to use client-to-server encryption and authenticate with the appropriate certificate to connect.
 
-{{< note title="Note" >}}
-Before version 2.5.2, this was the default for TLS without authentication. This example shows the `ysql_hba_conf_csv` configuration to use to replicate the previous behavior.
-{{< /note >}}
-
 To create the database, execute the following command:
 
 ```sh
@@ -183,8 +176,7 @@ Type "help" for help.
 This configuration requires the client to use client-to-server encryption and authenticate with both the appropriate certificate and the password to connect.
 
 {{< note title="Note" >}}
-Before version 2.5.2, this was the default for TLS with authentication. This example shows the `ysql_hba_conf_csv` configuration to use to replicate the previous behavior.
-
+To use the client certificate only for verification (signed by the CA) but not for authentication, the clientcert parameter can be set to verify-ca.
 {{< /note >}}
 
 To create the database, execute the following command:

--- a/docs/content/stable/secure/tls-encryption/tls-authentication.md
+++ b/docs/content/stable/secure/tls-encryption/tls-authentication.md
@@ -25,7 +25,7 @@ The default (auto-generated) configuration in the `ysql_hba.conf` file depends o
 The four default cases are shown in the following table.
 
 | | Auth disabled | Auth enabled |
----|---|---|
+| :--- | :--- | :--- |
 | TLS disabled | `host all all all trust`</br>(no ssl, no password) | `host all all all md5`</br>(no ssl, password required) |
 | TLS enabled | `hostssl all all all trust`</br>(require ssl, no password) | `hostssl all all all md5`</br>(require ssl and password) |
 
@@ -144,7 +144,7 @@ The other modes (that is, `sslmode=require` or `disable`) behave analogously.
 This configuration requires the client to use client-to-server encryption and authenticate with the appropriate certificate to connect.
 
 {{< note title="Note" >}}
-Before version 2.5.2, this was the default for TLS without authentication. This example shows the `ysql_hba_conf_csv` configuration to use to replicate the previous behavior.
+Before YugabyteDB v2.5.2, this was the default for TLS without authentication. This example shows the `ysql_hba_conf_csv` configuration to use to replicate the previous behavior.
 {{< /note >}}
 
 To create the database, execute the following command:
@@ -183,7 +183,7 @@ Type "help" for help.
 This configuration requires the client to use client-to-server encryption, supplying a signed client certificate, while using a password to authenticate. Note that the server verifies that the client certificate is signed by the configured CA but it does not use the CN (Common Name) of the client certificate to authenticate the user. It is not possible to configure the server to require authentication via both password and client certificate.
 
 {{< note title="Note" >}}
-Before version 2.5.2, this was the default for TLS with authentication. This example shows the `ysql_hba_conf_csv` configuration to use to replicate the previous behavior.
+Before YugabyteDB v2.5.2, this was the default for TLS with authentication. This example shows the `ysql_hba_conf_csv` configuration to use to replicate the previous behavior.
 
 {{< /note >}}
 

--- a/docs/content/stable/secure/tls-encryption/tls-authentication.md
+++ b/docs/content/stable/secure/tls-encryption/tls-authentication.md
@@ -30,12 +30,12 @@ The four default cases are shown in the following table.
 | TLS enabled | `hostssl all all all trust`</br>(require ssl, no password) | `hostssl all all all md5`</br>(require ssl and password) |
 
 {{< note title="Note" >}}
-Before version 2.5.2, when TLS was enabled the default was to use the more strict `cert` option when auth was disabled, and `md5 clientcert=1` (effectively md5 + cert) when auth was enabled.
+Before version 2.5.2, when TLS was enabled the default was to use the more strict `cert` option when auth was disabled, and `md5 clientcert=1` (md5 auth + cert verification) when auth was enabled.
 {{< /note >}}
 
 Additionally, `ysql_hba_conf_csv` can be used to manually configure a custom HBA configuration.
 
-For instance, to use TLS with both `md5` and `cert` authentication, you can set the `ysql_hba_conf_csv` flag as follows:
+For instance, to use TLS with both password authentication and client certificate verification, you can set the `ysql_hba_conf_csv` flag as follows:
 
 ```sh
 hostssl all all all md5 clientcert=1
@@ -180,7 +180,7 @@ Type "help" for help.
 
 ### TLS with password authentication and certificate verification
 
-This configuration requires the client to use client-to-server encryption, supplying a signed client certificate, while using a password to authenticate. Note that the server verifies that the client certificate is signed by a known CA but it does not use the CN (Common Name) of the client certificate to authenticate the user. It is not possible to configure the server to require authentication via both password and client certificate.
+This configuration requires the client to use client-to-server encryption, supplying a signed client certificate, while using a password to authenticate. Note that the server verifies that the client certificate is signed by the configured CA but it does not use the CN (Common Name) of the client certificate to authenticate the user. It is not possible to configure the server to require authentication via both password and client certificate.
 
 {{< note title="Note" >}}
 Before version 2.5.2, this was the default for TLS with authentication. This example shows the `ysql_hba_conf_csv` configuration to use to replicate the previous behavior.

--- a/docs/content/stable/secure/tls-encryption/tls-authentication.md
+++ b/docs/content/stable/secure/tls-encryption/tls-authentication.md
@@ -30,7 +30,7 @@ The four default cases are shown in the following table.
 | TLS enabled | `hostssl all all all trust`</br>(require ssl, no password) | `hostssl all all all md5`</br>(require ssl and password) |
 
 {{< note title="Note" >}}
-Before version 2.5.2, when TLS was enabled the default was to use the more strict `cert` option when auth was disabled, and `md5 clientcert=1` (md5 auth + cert verification) when auth was enabled.
+Before YugabyteDB v2.5.2, when TLS was enabled the default was to use the more strict `cert` option when auth was disabled, and `md5 clientcert=1` (md5 auth + cert verification) when auth was enabled.
 {{< /note >}}
 
 Additionally, `ysql_hba_conf_csv` can be used to manually configure a custom HBA configuration.

--- a/docs/content/stable/secure/tls-encryption/tls-authentication.md
+++ b/docs/content/stable/secure/tls-encryption/tls-authentication.md
@@ -178,9 +178,9 @@ SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 25
 Type "help" for help.
 ```
 
-### TLS with password and certificate authentication
+### TLS with password authentication and certificate verification
 
-This configuration requires the client to use client-to-server encryption and authenticate with both the appropriate certificate and the password to connect.
+This configuration requires the client to use client-to-server encryption, supplying a signed client certificate, while using a password to authenticate. Note that the server verifies that the client certificate is signed by a known CA but it does not use the CN (Common Name) of the client certificate to authenticate the user. It is not possible to configure the server to require authentication via both password and client certificate.
 
 {{< note title="Note" >}}
 Before version 2.5.2, this was the default for TLS with authentication. This example shows the `ysql_hba_conf_csv` configuration to use to replicate the previous behavior.

--- a/docs/content/v2.20/secure/tls-encryption/tls-authentication.md
+++ b/docs/content/v2.20/secure/tls-encryption/tls-authentication.md
@@ -25,17 +25,17 @@ The default (auto-generated) configuration in the `ysql_hba.conf` file depends o
 The four default cases are shown in the following table.
 
 | | Auth disabled | Auth enabled |
-| ---|---|---|
+| :--- | :--- | :--- |
 | TLS disabled | `host all all all trust`</br>(no ssl, no password) | `host all all all md5`</br>(no ssl, password required) |
 | TLS enabled | `hostssl all all all trust`</br>(require ssl, no password) | `hostssl all all all md5`</br>(require ssl and password) |
 
 {{< note title="Note" >}}
-Before version 2.5.2, when TLS was enabled the default was to use the more strict `cert` option when auth was disabled, and `md5 clientcert=1` (effectively md5 + cert) when auth was enabled.
+Before YugabyteDB v2.5.2, when TLS was enabled the default was to use the more strict `cert` option when auth was disabled, and `md5 clientcert=1` (md5 auth + cert verification) when auth was enabled.
 {{< /note >}}
 
 Additionally, `ysql_hba_conf_csv` can be used to manually configure a custom HBA configuration.
 
-For instance, to use TLS with both `md5` and `cert` authentication, you can set the `ysql_hba_conf_csv` flag as follows:
+For instance, to use TLS with both password authentication and client certificate verification, you can set the `ysql_hba_conf_csv` flag as follows:
 
 ```sh
 hostssl all all all md5 clientcert=1
@@ -144,7 +144,7 @@ The other modes (that is, `sslmode=require` or `disable`) behave analogously.
 This configuration requires the client to use client-to-server encryption and authenticate with the appropriate certificate to connect.
 
 {{< note title="Note" >}}
-Before version 2.5.2, this was the default for TLS without authentication. This example shows the `ysql_hba_conf_csv` configuration to use to replicate the previous behavior.
+Before YugabyteDB v2.5.2, this was the default for TLS without authentication. This example shows the `ysql_hba_conf_csv` configuration to use to replicate the previous behavior.
 {{< /note >}}
 
 To create the database, execute the following command:
@@ -178,12 +178,12 @@ SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 25
 Type "help" for help.
 ```
 
-### TLS with password and certificate authentication
+### TLS with password authentication and certificate verification
 
-This configuration requires the client to use client-to-server encryption and authenticate with both the appropriate certificate and the password to connect.
+This configuration requires the client to use client-to-server encryption, supplying a signed client certificate, while using a password to authenticate. Note that the server verifies that the client certificate is signed by the configured CA but it does not use the CN (Common Name) of the client certificate to authenticate the user. It is not possible to configure the server to require authentication via both password and client certificate.
 
 {{< note title="Note" >}}
-Before version 2.5.2, this was the default for TLS with authentication. This example shows the `ysql_hba_conf_csv` configuration to use to replicate the previous behavior.
+Before YugabyteDB v2.5.2, this was the default for TLS with authentication. This example shows the `ysql_hba_conf_csv` configuration to use to replicate the previous behavior.
 
 {{< /note >}}
 

--- a/docs/content/v2024.1/secure/tls-encryption/tls-authentication.md
+++ b/docs/content/v2024.1/secure/tls-encryption/tls-authentication.md
@@ -25,17 +25,17 @@ The default (auto-generated) configuration in the `ysql_hba.conf` file depends o
 The four default cases are shown in the following table.
 
 | | Auth disabled | Auth enabled |
-| ---|---|---|
+| :--- | :--- | :--- |
 | TLS disabled | `host all all all trust`</br>(no ssl, no password) | `host all all all md5`</br>(no ssl, password required) |
 | TLS enabled | `hostssl all all all trust`</br>(require ssl, no password) | `hostssl all all all md5`</br>(require ssl and password) |
 
 {{< note title="Note" >}}
-Before version 2.5.2, when TLS was enabled the default was to use the more strict `cert` option when auth was disabled, and `md5 clientcert=1` (effectively md5 + cert) when auth was enabled.
+Before YugabyteDB v2.5.2, when TLS was enabled the default was to use the more strict `cert` option when auth was disabled, and `md5 clientcert=1` (md5 auth + cert verification) when auth was enabled.
 {{< /note >}}
 
 Additionally, `ysql_hba_conf_csv` can be used to manually configure a custom HBA configuration.
 
-For instance, to use TLS with both `md5` and `cert` authentication, you can set the `ysql_hba_conf_csv` flag as follows:
+For instance, to use TLS with both password authentication and client certificate verification, you can set the `ysql_hba_conf_csv` flag as follows:
 
 ```sh
 hostssl all all all md5 clientcert=1
@@ -144,7 +144,7 @@ The other modes (that is, `sslmode=require` or `disable`) behave analogously.
 This configuration requires the client to use client-to-server encryption and authenticate with the appropriate certificate to connect.
 
 {{< note title="Note" >}}
-Before version 2.5.2, this was the default for TLS without authentication. This example shows the `ysql_hba_conf_csv` configuration to use to replicate the previous behavior.
+Before YugabyteDB v2.5.2, this was the default for TLS without authentication. This example shows the `ysql_hba_conf_csv` configuration to use to replicate the previous behavior.
 {{< /note >}}
 
 To create the database, execute the following command:
@@ -178,12 +178,12 @@ SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 25
 Type "help" for help.
 ```
 
-### TLS with password and certificate authentication
+### TLS with password authentication and certificate verification
 
-This configuration requires the client to use client-to-server encryption and authenticate with both the appropriate certificate and the password to connect.
+This configuration requires the client to use client-to-server encryption, supplying a signed client certificate, while using a password to authenticate. Note that the server verifies that the client certificate is signed by the configured CA but it does not use the CN (Common Name) of the client certificate to authenticate the user. It is not possible to configure the server to require authentication via both password and client certificate.
 
 {{< note title="Note" >}}
-Before version 2.5.2, this was the default for TLS with authentication. This example shows the `ysql_hba_conf_csv` configuration to use to replicate the previous behavior.
+Before YugabyteDB v2.5.2, this was the default for TLS with authentication. This example shows the `ysql_hba_conf_csv` configuration to use to replicate the previous behavior.
 
 {{< /note >}}
 


### PR DESCRIPTION
`md5 clientcert=1` in the hba conf file was documented to mean a combination of md5 and cert - however, there is a slight distinction. The cert method verifies the client cert and authenticates the user using the CN of the client cert. clientcert=1 only verifies the client cert.