### PR TITLE
[DOCS] Rust Smart driver (rust-postgres) docs update for Read replica cluster support.

### DIFF
--- a/docs/content/preview/drivers-orms/rust/_index.md
+++ b/docs/content/preview/drivers-orms/rust/_index.md
@@ -18,7 +18,7 @@ The following project is recommended for implementing Rust applications using th
 
 | Project | Documentation and Guides | Latest Driver Version | Supported YugabyteDB Version | Example Apps |
 | ------- | ------------------------ | --------------------- | ---------------------------- | ------------ |
-| YugabyteDB Rust-Postgres Smart Driver [Recommended] | [Documentation](yb-rust-postgres/)<br /> [Reference](rust-postgres-reference/) | [yb-postgres](https://crates.io/crates/yb-postgres) (synchronous YSQL client): v0.19.7-yb-1-beta <br/> [yb-tokio-postgres](https://crates.io/crates/yb-tokio-postgres) (asynchronous YSQL client): v0.7.10-yb-1-beta | 2.19 and later | |
+| YugabyteDB Rust-Postgres Smart Driver [Recommended] | [Documentation](yb-rust-postgres/)<br /> [Reference](rust-postgres-reference/) | [yb-postgres](https://crates.io/crates/yb-postgres) (synchronous YSQL client): v0.19.7-yb-1-beta.3 <br/> [yb-tokio-postgres](https://crates.io/crates/yb-tokio-postgres) (asynchronous YSQL client): v0.7.10-yb-1-beta.3 | 2.19 and later | |
 | Diesel | [Documentation](diesel/) <br/> [Hello World](../orms/rust/ysql-diesel/) | | |[Diesel app](https://github.com/YugabyteDB-Samples/orm-examples/tree/master/rust/diesel) |
 
 Learn how to establish a connection to a YugabyteDB database and begin basic CRUD operations using the **Hello World** examples.

--- a/docs/content/preview/drivers-orms/rust/rust-postgres-reference.md
+++ b/docs/content/preview/drivers-orms/rust/rust-postgres-reference.md
@@ -36,10 +36,10 @@ You can use the YugabyteDB Rust driver [crates](https://crates.io/) by adding th
 
 ```toml
 # For yb-postgres
-yb-postgres = "0.19.7-yb-1-beta"
+yb-postgres = "0.19.7-yb-1-beta.3"
 
 # For yb-tokio-postgres
-yb-tokio-postgres = "0.7.10-yb-1-beta"
+yb-tokio-postgres = "0.7.10-yb-1-beta.3"
 ```
 
 Or, run the following command from your project directory:
@@ -60,7 +60,7 @@ Learn how to perform common tasks required for Rust application development usin
 
 The following connection properties need to be added to enable load balancing:
 
-- `load_balance` - enable [cluster-aware load balancing](../../smart-drivers/#cluster-aware-load-balancing) by setting this property to true; disabled by default.
+- `load_balance` - enable [cluster-aware load balancing](../../smart-drivers/#cluster-aware-load-balancing) by setting this property to one of the allowed values other than `false`; disabled by default.
 - `topology_keys` - provide comma-separated geo-location values to enable [topology-aware load balancing](../../smart-drivers/#topology-aware-load-balancing). Geo-locations can be provided as `cloud.region.zone`. Specify all zones in a region as `cloud.region.*`. To designate fallback locations for when the primary location is unreachable, specify a priority in the form `:n`, where `n` is the order of precedence. For example, `cloud1.datacenter1.rack1:1,cloud1.datacenter1.rack2:2`.
 
 By default, the driver refreshes the list of nodes every 300 seconds (5 minutes). You can change this value by including the `yb_servers_refresh_interval` parameter.
@@ -75,10 +75,10 @@ Following are other connection properties offered with the Rust smart driver:
 
 To use the driver, pass new connection properties for load balancing in the connection string.
 
-To enable uniform load balancing across all servers, you set the load-balance property to true in the connection string, as per the following examples:
+To enable uniform load balancing across all servers, you set the load-balance property to `true` or `any` in the connection string, as per the following examples:
 
 ```sh
-let url: String = String::from( "postgresql://localhost:5434/yugabyte?user=yugabyte&password=yugabyte&load_balance=true", );
+let url: String = String::from( "postgresql://localhost:5434/yugabyte?user=yugabyte&password=yugabyte&load_balance=any", );
 let conn = yb_postgres::Client::connect(&connection_url,NoTls,)?;
 ```
 
@@ -159,7 +159,7 @@ To check uniform load balancing, do the following:
     # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
     [dependencies]
-    yb-tokio-postgres = "0.7.10-yb-1-beta"
+    yb-tokio-postgres = "0.7.10-yb-1-beta.3"
     ```
 
 1. Replace the existing code in the file `src/main.rs` with the following code:
@@ -174,7 +174,7 @@ To check uniform load balancing, do the following:
        println!("Starting the example ...");
 
        let url: String = String::from(
-       "postgresql://127.0.0.1:5433/yugabyte?user=yugabyte&password=yugabyte&load_balance=true",
+       "postgresql://127.0.0.1:5433/yugabyte?user=yugabyte&password=yugabyte&load_balance=any",
        );
        println!("Using connection url: {}", url);
        let (_clients, _connections) = createconn(30, url).await.unwrap();
@@ -257,7 +257,7 @@ async fn main() -> Result<(), Error> {
    println!("Starting the example ...");
 
    let url: String = String::from(
-       "postgresql://127.0.0.1:5433/yugabyte?user=yugabyte&password=yugabyte&load_balance=true&topology_keys=aws.us-east-1.us-east-1a",
+       "postgresql://127.0.0.1:5433/yugabyte?user=yugabyte&password=yugabyte&load_balance=any&topology_keys=aws.us-east-1.us-east-1a",
    );
    println!("Using connection url: {}", url);
    let (_clients, _connections) = createconn(30, url).await.unwrap();
@@ -360,7 +360,7 @@ If you created a cluster on YugabyteDB Aeon, use the cluster credentials and dow
 
 The following is an example application for connecting to a YugabyteDB cluster with SSL enabled:
 
-Add `yb-postgres-openssl = "0.5.0-yb-1"`, `yb-postgres = "0.19.7-yb-1-beta"`, and `openssl = "0.10.61"` dependencies in the `Cargo.toml` file before executing the application.
+Add `yb-postgres-openssl = "0.5.0-yb-1-beta.3"`, `yb-postgres = "0.19.7-yb-1-beta.3"`, and `openssl = "0.10.61"` dependencies in the `Cargo.toml` file before executing the application.
 
 ```rust
 use openssl::ssl::{SslConnector, SslMethod};

--- a/docs/content/preview/drivers-orms/rust/yb-rust-postgres.md
+++ b/docs/content/preview/drivers-orms/rust/yb-rust-postgres.md
@@ -53,11 +53,11 @@ The following table describes the connection parameters required to connect, inc
 | database/dbname | Database name |  |
 | user | User connecting to the database |  |
 | password | User password |  |
-| `load_balance` | [Uniform load balancing](../../smart-drivers/#cluster-aware-load-balancing) | Defaults to upstream driver behavior unless set to 'true' |
-| `topology_keys` | [Topology-aware load balancing](../../smart-drivers/#topology-aware-load-balancing) | If `load_balance` is true, uses uniform load balancing unless set to comma-separated geo-locations in the form `cloud.region.zone`. |
-| yb_servers_refresh_interval | If load_balance is true, the interval in seconds to refresh the servers list | 300 |
-| fallback_to_topology_keys_only | If all the servers in the primary and fallback topology key placements are down, fall back to the host(s) specified in the connection URL, instead of to nodes across the entire cluster. | false |
-| failed_host_reconnect_delay_secs | Mark the server as "UP" only if the server is currently present in `yb_servers()` response and `failed-host-reconnect-delay-secs` duration has elapsed from the last time it was marked "DOWN". | 5 seconds |
+| `load_balance` | Enables [Uniform load balancing](../../smart-drivers/#cluster-aware-load-balancing) | false (Disabled) |
+| `topology_keys` | Enables [Topology-aware load balancing](../../smart-drivers/#topology-aware-load-balancing). It can be set to comma-separated geo-locations in the form `cloud.region.zone:priority`. Ignored if `load_balance` is false | Empty |
+| `yb_servers_refresh_interval` | The interval in seconds to refresh the servers list; ignored if `load-balance` is false | 300 |
+| `fallback_to_topology_keys_only` | If set to true and `topology_keys` are specified, the driver only tries to connect to nodes specified in `topology_keys` | false |
+| `failed_host_ttl_seconds` | Time, in seconds, to wait before trying to connect to failed nodes. When the driver is unable to connect to a node, it marks the node as failed using a timestamp, and ignores the node when trying new connections until this time elapses. | 5 |
 
 The following is an example connection string for connecting to YugabyteDB:
 
@@ -93,7 +93,7 @@ The hosts are only used during the initial connection attempt. If the first host
 
 Make sure that you have created a new rust project as part of the [prerequisites](../#prerequisites).
 
-1. Add `yb-postgres = "0.19.7-yb-1-beta` dependency in the `Cargo.toml` file as follows:
+1. Add `yb-postgres = "0.19.7-yb-1-beta.3` dependency in the `Cargo.toml` file as follows:
 
     ```toml
     [package]
@@ -104,7 +104,7 @@ Make sure that you have created a new rust project as part of the [prerequisites
     # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
     [dependencies]
-    yb-postgres = "0.19.7-yb-1-beta"
+    yb-postgres = "0.19.7-yb-1-beta.3"
     ```
 
 1. Replace the existing code in `src/main.rs` with the following sample code to set up tables and query the table contents. Replace the values in the connection string `connection_url` with the database credentials, if required.

--- a/docs/content/stable/drivers-orms/rust/_index.md
+++ b/docs/content/stable/drivers-orms/rust/_index.md
@@ -18,7 +18,7 @@ The following project is recommended for implementing Rust applications using th
 
 | Project | Documentation and Guides | Latest Driver Version | Supported YugabyteDB Version | Example Apps |
 | ------- | ------------------------ | --------------------- | ---------------------------- | ------------ |
-| YugabyteDB Rust-Postgres Smart Driver [Recommended] | [Documentation](yb-rust-postgres/)<br /> [Reference](rust-postgres-reference/) | [yb-postgres](https://crates.io/crates/yb-postgres) (synchronous YSQL client): v0.19.7-yb-1-beta <br/> [yb-tokio-postgres](https://crates.io/crates/yb-tokio-postgres) (asynchronous YSQL client): v0.7.10-yb-1-beta | 2.19 and later | |
+| YugabyteDB Rust-Postgres Smart Driver [Recommended] | [Documentation](yb-rust-postgres/)<br /> [Reference](rust-postgres-reference/) | [yb-postgres](https://crates.io/crates/yb-postgres) (synchronous YSQL client): v0.19.7-yb-1-beta.3 <br/> [yb-tokio-postgres](https://crates.io/crates/yb-tokio-postgres) (asynchronous YSQL client): v0.7.10-yb-1-beta.3 | 2.19 and later | |
 | Diesel | [Documentation](diesel/) <br/> [Hello World](../orms/rust/ysql-diesel/) | | |[Diesel app](https://github.com/YugabyteDB-Samples/orm-examples/tree/master/rust/diesel) |
 
 Learn how to establish a connection to a YugabyteDB database and begin basic CRUD operations using the **Hello World** examples.

--- a/docs/content/stable/drivers-orms/rust/rust-postgres-reference.md
+++ b/docs/content/stable/drivers-orms/rust/rust-postgres-reference.md
@@ -34,10 +34,10 @@ You can use the YugabyteDB Rust driver [crates](https://crates.io/) by adding th
 
 ```toml
 # For yb-postgres
-yb-postgres = "0.19.7-yb-1-beta"
+yb-postgres = "0.19.7-yb-1-beta.3"
 
 # For yb-tokio-postgres
-yb-tokio-postgres = "0.7.10-yb-1-beta"
+yb-tokio-postgres = "0.7.10-yb-1-beta.3"
 ```
 
 Or, run the following command from your project directory:
@@ -58,7 +58,7 @@ Learn how to perform common tasks required for Rust application development usin
 
 The following connection properties need to be added to enable load balancing:
 
-- `load_balance` - enable [cluster-aware load balancing](../../smart-drivers/#cluster-aware-load-balancing) by setting this property to true; disabled by default.
+- `load_balance` - enable [cluster-aware load balancing](../../smart-drivers/#cluster-aware-load-balancing) by setting this property to one of the allowed values other than `false`; disabled by default.
 - `topology_keys` - provide comma-separated geo-location values to enable [topology-aware load balancing](../../smart-drivers/#topology-aware-load-balancing). Geo-locations can be provided as `cloud.region.zone`. Specify all zones in a region as `cloud.region.*`. To designate fallback locations for when the primary location is unreachable, specify a priority in the form `:n`, where `n` is the order of precedence. For example, `cloud1.datacenter1.rack1:1,cloud1.datacenter1.rack2:2`.
 
 By default, the driver refreshes the list of nodes every 300 seconds (5 minutes). You can change this value by including the `yb_servers_refresh_interval` parameter.
@@ -73,10 +73,10 @@ Following are other connection properties offered with the Rust smart driver:
 
 To use the driver, pass new connection properties for load balancing in the connection string.
 
-To enable uniform load balancing across all servers, you set the load-balance property to true in the connection string, as per the following examples:
+To enable uniform load balancing across all servers, you set the load-balance property to `true` or `any` in the connection string, as per the following examples:
 
 ```sh
-let url: String = String::from( "postgresql://localhost:5434/yugabyte?user=yugabyte&password=yugabyte&load_balance=true", );
+let url: String = String::from( "postgresql://localhost:5434/yugabyte?user=yugabyte&password=yugabyte&load_balance=any", );
 let conn = yb_postgres::Client::connect(&connection_url,NoTls,)?;
 ```
 
@@ -157,7 +157,7 @@ To check uniform load balancing, do the following:
     # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
     [dependencies]
-    yb-tokio-postgres = "0.7.10-yb-1-beta"
+    yb-tokio-postgres = "0.7.10-yb-1-beta.3"
     ```
 
 1. Replace the existing code in the file `src/main.rs` with the following code:
@@ -172,7 +172,7 @@ To check uniform load balancing, do the following:
        println!("Starting the example ...");
 
        let url: String = String::from(
-       "postgresql://127.0.0.1:5433/yugabyte?user=yugabyte&password=yugabyte&load_balance=true",
+       "postgresql://127.0.0.1:5433/yugabyte?user=yugabyte&password=yugabyte&load_balance=any",
        );
        println!("Using connection url: {}", url);
        let (_clients, _connections) = createconn(30, url).await.unwrap();
@@ -255,7 +255,7 @@ async fn main() -> Result<(), Error> {
    println!("Starting the example ...");
 
    let url: String = String::from(
-       "postgresql://127.0.0.1:5433/yugabyte?user=yugabyte&password=yugabyte&load_balance=true&topology_keys=aws.us-east-1.us-east-1a",
+       "postgresql://127.0.0.1:5433/yugabyte?user=yugabyte&password=yugabyte&load_balance=any&topology_keys=aws.us-east-1.us-east-1a",
    );
    println!("Using connection url: {}", url);
    let (_clients, _connections) = createconn(30, url).await.unwrap();
@@ -358,7 +358,7 @@ If you created a cluster on YugabyteDB Aeon, use the cluster credentials and dow
 
 The following is an example application for connecting to a YugabyteDB cluster with SSL enabled:
 
-Add `yb-postgres-openssl = "0.5.0-yb-1"`, `yb-postgres = "0.19.7-yb-1-beta"`, and `openssl = "0.10.61"` dependencies in the `Cargo.toml` file before executing the application.
+Add `yb-postgres-openssl = "0.5.0-yb-1-beta.3"`, `yb-postgres = "0.19.7-yb-1-beta.3"`, and `openssl = "0.10.61"` dependencies in the `Cargo.toml` file before executing the application.
 
 ```rust
 use openssl::ssl::{SslConnector, SslMethod};

--- a/docs/content/stable/drivers-orms/rust/yb-rust-postgres.md
+++ b/docs/content/stable/drivers-orms/rust/yb-rust-postgres.md
@@ -53,11 +53,11 @@ The following table describes the connection parameters required to connect, inc
 | database/dbname | Database name |  |
 | user | User connecting to the database |  |
 | password | User password |  |
-| `load_balance` | [Uniform load balancing](../../smart-drivers/#cluster-aware-load-balancing) | Defaults to upstream driver behavior unless set to 'true' |
-| `topology_keys` | [Topology-aware load balancing](../../smart-drivers/#topology-aware-load-balancing) | If `load_balance` is true, uses uniform load balancing unless set to comma-separated geo-locations in the form `cloud.region.zone`. |
-| yb_servers_refresh_interval | If load_balance is true, the interval in seconds to refresh the servers list | 300 |
-| fallback_to_topology_keys_only | If all the servers in the primary and fallback topology key placements are down, fall back to the host(s) specified in the connection URL, instead of to nodes across the entire cluster. | false |
-| failed_host_reconnect_delay_secs | Mark the server as "UP" only if the server is currently present in `yb_servers()` response and `failed-host-reconnect-delay-secs` duration has elapsed from the last time it was marked "DOWN". | 5 seconds |
+| `load_balance` | Enables [Uniform load balancing](../../smart-drivers/#cluster-aware-load-balancing) | false (Disabled) |
+| `topology_keys` | Enables [Topology-aware load balancing](../../smart-drivers/#topology-aware-load-balancing). It can be set to comma-separated geo-locations in the form `cloud.region.zone:priority`. Ignored if `load_balance` is false | Empty |
+| `yb_servers_refresh_interval` | The interval in seconds to refresh the servers list; ignored if `load-balance` is false | 300 |
+| `fallback_to_topology_keys_only` | If set to true and `topology_keys` are specified, the driver only tries to connect to nodes specified in `topology_keys` | false |
+| `failed_host_ttl_seconds` | Time, in seconds, to wait before trying to connect to failed nodes. When the driver is unable to connect to a node, it marks the node as failed using a timestamp, and ignores the node when trying new connections until this time elapses. | 5 |
 
 The following is an example connection string for connecting to YugabyteDB:
 
@@ -93,7 +93,7 @@ The hosts are only used during the initial connection attempt. If the first host
 
 Make sure that you have created a new rust project as part of the [prerequisites](../#prerequisites).
 
-1. Add `yb-postgres = "0.19.7-yb-1-beta` dependency in the `Cargo.toml` file as follows:
+1. Add `yb-postgres = "0.19.7-yb-1-beta.3` dependency in the `Cargo.toml` file as follows:
 
     ```toml
     [package]
@@ -104,7 +104,7 @@ Make sure that you have created a new rust project as part of the [prerequisites
     # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
     [dependencies]
-    yb-postgres = "0.19.7-yb-1-beta"
+    yb-postgres = "0.19.7-yb-1-beta.3"
     ```
 
 1. Replace the existing code in `src/main.rs` with the following sample code to set up tables and query the table contents. Replace the values in the connection string `connection_url` with the database credentials, if required.

--- a/docs/content/v2.20/drivers-orms/rust/_index.md
+++ b/docs/content/v2.20/drivers-orms/rust/_index.md
@@ -18,7 +18,7 @@ The following project is recommended for implementing Rust applications using th
 
 | Project | Documentation and Guides | Latest Driver Version | Supported YugabyteDB Version | Example Apps |
 | ------- | ------------------------ | --------------------- | ---------------------------- | ------------ |
-| YugabyteDB Rust-Postgres Smart Driver [Recommended] | [Documentation](yb-rust-postgres/)<br /> [Reference](../../reference/drivers/rust/rust-postgres-reference/) | [yb-postgres](https://crates.io/crates/yb-postgres) (synchronous YSQL client): v0.19.7-yb-1-beta <br/> [yb-tokio-postgres](https://crates.io/crates/yb-tokio-postgres) (asynchronous YSQL client): v0.7.10-yb-1-beta | 2.19 and later
+| YugabyteDB Rust-Postgres Smart Driver [Recommended] | [Documentation](yb-rust-postgres/)<br /> [Reference](../../reference/drivers/rust/rust-postgres-reference/) | [yb-postgres](https://crates.io/crates/yb-postgres) (synchronous YSQL client): v0.19.7-yb-1-beta.3 <br/> [yb-tokio-postgres](https://crates.io/crates/yb-tokio-postgres) (asynchronous YSQL client): v0.7.10-yb-1-beta.3 | 2.19 and later
 | Diesel | [Documentation](diesel/) <br/> [Hello World](../orms/rust/ysql-diesel/) | | |[Diesel app](https://github.com/YugabyteDB-Samples/orm-examples/tree/master/rust/diesel) |
 
 Learn how to establish a connection to a YugabyteDB database and begin basic CRUD operations using the **Hello World** examples.

--- a/docs/content/v2.20/drivers-orms/rust/yb-rust-postgres.md
+++ b/docs/content/v2.20/drivers-orms/rust/yb-rust-postgres.md
@@ -53,11 +53,11 @@ The following table describes the connection parameters required to connect, inc
 | database/dbname | Database name |  |
 | user | User connecting to the database |  |
 | password | User password |  |
-| `load_balance` | [Uniform load balancing](../../smart-drivers/#cluster-aware-load-balancing) | Defaults to upstream driver behavior unless set to 'true' |
-| `topology_keys` | [Topology-aware load balancing](../../smart-drivers/#topology-aware-load-balancing) | If `load_balance` is true, uses uniform load balancing unless set to comma-separated geo-locations in the form `cloud.region.zone`. |
-| yb_servers_refresh_interval | If load_balance is true, the interval in seconds to refresh the servers list | 300 seconds|
-| fallback_to_topology_keys_only | When set to true, if all the servers in the primary and fallback placements are down, the smart driver does not fallback to the rest of the servers in the cluster, instead to the nodes given in the connection URL. | false |
-| failed_host_reconnect_delay_secs | Mark the server as "UP" only if the server is currently present in `yb_servers()` response and `failed-host-reconnect-delay-secs` duration has elapsed from the last time it was marked "DOWN". | 5 seconds |
+| `load_balance` | Enables [Uniform load balancing](../../smart-drivers/#cluster-aware-load-balancing) | false (Disabled) |
+| `topology_keys` | Enables [Topology-aware load balancing](../../smart-drivers/#topology-aware-load-balancing). It can be set to comma-separated geo-locations in the form `cloud.region.zone:priority`. Ignored if `load_balance` is false | Empty |
+| `yb_servers_refresh_interval` | The interval in seconds to refresh the servers list; ignored if `load-balance` is false | 300 |
+| `fallback_to_topology_keys_only` | If set to true and `topology_keys` are specified, the driver only tries to connect to nodes specified in `topology_keys` | false |
+| `failed_host_ttl_seconds` | Time, in seconds, to wait before trying to connect to failed nodes. When the driver is unable to connect to a node, it marks the node as failed using a timestamp, and ignores the node when trying new connections until this time elapses. | 5 |
 
 The following is an example connection string for connecting to YugabyteDB:
 
@@ -93,7 +93,7 @@ The hosts are only used during the initial connection attempt. If the first host
 
 Make sure that you have created a new rust project as part of the [prerequisites](../#prerequisites).
 
-1. Add `yb-postgres = "0.19.7-yb-1-beta` dependency in the `Cargo.toml` file as follows:
+1. Add `yb-postgres = "0.19.7-yb-1-beta.3` dependency in the `Cargo.toml` file as follows:
 
     ```toml
     [package]
@@ -104,7 +104,7 @@ Make sure that you have created a new rust project as part of the [prerequisites
     # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
     [dependencies]
-    yb-postgres = "0.19.7-yb-1-beta"
+    yb-postgres = "0.19.7-yb-1-beta.3"
     ```
 
 1. Replace the existing code in `src/main.rs` with the following sample code to set up tables and query the table contents. Replace the connection string `connection_url` with the cluster credential, if required.

--- a/docs/content/v2.20/reference/drivers/rust/rust-postgres-reference.md
+++ b/docs/content/v2.20/reference/drivers/rust/rust-postgres-reference.md
@@ -33,10 +33,10 @@ You can use the YugabyteDB Rust driver [crates](https://crates.io/) by adding th
 
 ```toml
 # For yb-postgres
-yb-postgres = "0.19.7-yb-1-beta"
+yb-postgres = "0.19.7-yb-1-beta.3"
 
 # For yb-tokio-postgres
-yb-tokio-postgres = "0.7.10-yb-1-beta"
+yb-tokio-postgres = "0.7.10-yb-1-beta.3"
 ```
 
 Or, run the following command from your project directory:
@@ -57,7 +57,7 @@ Learn how to perform common tasks required for Rust application development usin
 
 The following connection properties need to be added to enable load balancing:
 
-- `load_balance` - enable [cluster-aware load balancing](../../../../drivers-orms/smart-drivers/#cluster-aware-load-balancing) by setting this property to true; disabled by default.
+- `load_balance` - enable [cluster-aware load balancing](../../smart-drivers/#cluster-aware-load-balancing) by setting this property to one of the allowed values other than `false`; disabled by default.
 - `topology_keys` - provide comma-separated geo-location values to enable [topology-aware load balancing](../../../../drivers-orms/smart-drivers/#topology-aware-load-balancing). Geo-locations can be provided as `cloud.region.zone`. Specify all zones in a region as `cloud.region.*`. To designate fallback locations for when the primary location is unreachable, specify a priority in the form `:n`, where `n` is the order of precedence. For example, `cloud1.datacenter1.rack1:1,cloud1.datacenter1.rack2:2`.
 
 By default, the driver refreshes the list of nodes every 300 seconds (5 minutes). You can change this value by including the `yb_servers_refresh_interval` parameter.
@@ -72,10 +72,10 @@ Following are other connection properties offered with the Rust smart driver:
 
 To use the driver, pass new connection properties for load balancing in the connection string.
 
-To enable uniform load balancing across all servers, you set the load-balance property to true in the connection string, as per the following examples:
+To enable uniform load balancing across all servers, you set the load-balance property to `true` or `any` in the connection string, as per the following examples:
 
 ```sh
-let url: String = String::from( "postgresql://localhost:5434/yugabyte?user=yugabyte&password=yugabyte&load_balance=true", );
+let url: String = String::from( "postgresql://localhost:5434/yugabyte?user=yugabyte&password=yugabyte&load_balance=any", );
 let conn = yb_postgres::Client::connect(&connection_url,NoTls,)?;
 ```
 
@@ -156,7 +156,7 @@ To check uniform load balancing, do the following:
     # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
     [dependencies]
-    yb-tokio-postgres = "0.7.10-yb-1-beta"
+    yb-tokio-postgres = "0.7.10-yb-1-beta.3"
     ```
 
 1. Replace the existing code in the file `src/main.rs` with the following code:
@@ -171,7 +171,7 @@ To check uniform load balancing, do the following:
        println!("Starting the example ...");
 
        let url: String = String::from(
-       "postgresql://127.0.0.1:5433/yugabyte?user=yugabyte&password=yugabyte&load_balance=true",
+       "postgresql://127.0.0.1:5433/yugabyte?user=yugabyte&password=yugabyte&load_balance=any",
        );
        println!("Using connection url: {}", url);
        let (_clients, _connections) = createconn(30, url).await.unwrap();
@@ -254,7 +254,7 @@ async fn main() -> Result<(), Error> {
    println!("Starting the example ...");
 
    let url: String = String::from(
-       "postgresql://127.0.0.1:5433/yugabyte?user=yugabyte&password=yugabyte&load_balance=true&topology_keys=aws.us-east-1.us-east-1a",
+       "postgresql://127.0.0.1:5433/yugabyte?user=yugabyte&password=yugabyte&load_balance=any&topology_keys=aws.us-east-1.us-east-1a",
    );
    println!("Using connection url: {}", url);
    let (_clients, _connections) = createconn(30, url).await.unwrap();
@@ -357,7 +357,7 @@ If you created a cluster on [YugabyteDB Aeon](/preview/yugabyte-cloud/), use the
 
 The following is an example application for connecting to a YugabyteDB cluster with SSL enabled:
 
-Add `yb-postgres-openssl = "0.5.0-yb-1"`, `yb-postgres = "0.19.7-yb-1-beta"`, and `openssl = "0.10.61"` dependencies in the `Cargo.toml` file before executing the application.
+Add `yb-postgres-openssl = "0.5.0-yb-1-beta.3"`, `yb-postgres = "0.19.7-yb-1-beta.3"`, and `openssl = "0.10.61"` dependencies in the `Cargo.toml` file before executing the application.
 
 ```rust
 use openssl::ssl::{SslConnector, SslMethod};


### PR DESCRIPTION
This PR makes changes in YugabyteDB rust-postgres Smart Driver documentation to reflect changes involved to support Node-type aware load balancing added via this https://github.com/yugabyte/rust-postgres/pull/6.