### PR TITLE
[doc][cdc][2024.2.1] Update CDC flags controlling response size in logical replication

### DIFF
--- a/docs/content/preview/reference/configuration/yb-tserver.md
+++ b/docs/content/preview/reference/configuration/yb-tserver.md
@@ -1364,11 +1364,11 @@ Interval in seconds at which the table list in the publication will be refreshed
 
 Default: `3600`
 
-##### --cdcsdk_max_consistent_records
+##### --cdc_stream_records_threshold_size_bytes
 
-Controls the maximum number of records sent from Virtual WAL (VWAL) to walsender in consistent order.
+Max size (in bytes) of changes from a tablet sent from CDC Service to gRPC connector in gRPC Protocol. Max size (in bytes) of changes sent from [Virtual WAL](../../../architecture/docdb-replication/cdc-logical-replication)(VWAL) to Walsender process in PostgreSQL Protocol. 
 
-Default: `500`
+Default: `4MB`
 
 ##### --cdcsdk_vwal_getchanges_resp_max_size_bytes
 

--- a/docs/content/stable/reference/configuration/yb-tserver.md
+++ b/docs/content/stable/reference/configuration/yb-tserver.md
@@ -1372,11 +1372,11 @@ Interval in seconds at which the table list in the publication will be refreshed
 
 Default: `3600`
 
-##### --cdcsdk_max_consistent_records
+##### --cdc_stream_records_threshold_size_bytes
 
-Controls the maximum number of records sent from Virtual WAL (VWAL) to walsender in consistent order.
+Max size (in bytes) of changes from a tablet sent from CDC Service to gRPC connector in gRPC Protocol. Max size (in bytes) of changes sent from [Virtual WAL](../../../architecture/docdb-replication/cdc-logical-replication)(VWAL) to Walsender process in PostgreSQL Protocol. 
 
-Default: `500`
+Default: `4MB`
 
 ##### --cdcsdk_vwal_getchanges_resp_max_size_bytes
 

--- a/docs/content/v2024.1/reference/configuration/yb-tserver.md
+++ b/docs/content/v2024.1/reference/configuration/yb-tserver.md
@@ -1344,11 +1344,11 @@ Interval in seconds at which the table list in the publication will be refreshed
 
 Default: `3600`
 
-##### --cdcsdk_max_consistent_records
+##### --cdc_stream_records_threshold_size_bytes
 
-Controls the maximum number of records sent from Virtual WAL (VWAL) to walsender in consistent order.
+Max size (in bytes) of changes from a tablet sent from CDC Service to gRPC connector in gRPC Protocol. Max size (in bytes) of changes sent from [Virtual WAL](../../../architecture/docdb-replication/cdc-logical-replication)(VWAL) to Walsender process in PostgreSQL Protocol. 
 
-Default: `500`
+Default: `4MB`
 
 ##### --cdcsdk_vwal_getchanges_resp_max_size_bytes
 


### PR DESCRIPTION
In logical replication, size of response from Virtual WAL to Walsender process was limited by a record count (configured by flag `cdcsdk_max_consistent_records`). This is now changed to limit the response using a byte size of records (configured by flag `cdc_stream_records_threshold_size_bytes`). 