### PR TITLE
[#1348] DocDB: Add validator for leader lease to be larger than heartbeat interval

### DIFF
--- a/src/yb/consensus/raft_consensus.cc
+++ b/src/yb/consensus/raft_consensus.cc
@@ -201,7 +201,7 @@ DEFINE_UNKNOWN_int32(leader_lease_duration_ms, yb::consensus::kDefaultLeaderLeas
 DEFINE_validator(leader_lease_duration_ms,
     FLAG_DELAYED_COND_VALIDATOR(
         FLAGS_raft_heartbeat_interval_ms <= _value,
-        "Must be greater than raft_heartbeat_interval_ms"));
+        yb::Format("Must be greater than or equal to raft_heartbeat_interval_ms: $0", FLAGS_raft_heartbeat_interval_ms)));
 
 DEFINE_validator(raft_heartbeat_interval_ms,
     FLAG_DELAYED_COND_VALIDATOR(

--- a/src/yb/consensus/raft_consensus.cc
+++ b/src/yb/consensus/raft_consensus.cc
@@ -71,6 +71,7 @@
 #include "yb/util/debug/trace_event.h"
 #include "yb/util/enums.h"
 #include "yb/util/flags.h"
+#include "yb/util/flag_validators.h"
 #include "yb/util/format.h"
 #include "yb/util/logging.h"
 #include "yb/util/memory/memory.h"
@@ -195,6 +196,17 @@ DEFINE_UNKNOWN_int32(leader_lease_duration_ms, yb::consensus::kDefaultLeaderLeas
              "existing one with every UpdateConsensus. A new server is not allowed to serve as a "
              "leader (i.e. serve up-to-date read requests or acknowledge write requests) until a "
              "lease of this duration has definitely expired on the old leader's side.");
+
+
+DEFINE_validator(leader_lease_duration_ms,
+    FLAG_DELAYED_COND_VALIDATOR(
+        FLAGS_raft_heartbeat_interval_ms <= _value,
+        "Must be greater than raft_heartbeat_interval_ms"));
+
+DEFINE_validator(raft_heartbeat_interval_ms,
+    FLAG_DELAYED_COND_VALIDATOR(
+        _value <= FLAGS_leader_lease_duration_ms,
+        "Must be less than leader_lease_duration_ms"));
 
 DEFINE_UNKNOWN_int32(ht_lease_duration_ms, 2000,
              "Hybrid time leader lease duration. A leader keeps establishing a new lease or "

--- a/src/yb/consensus/raft_consensus.cc
+++ b/src/yb/consensus/raft_consensus.cc
@@ -197,7 +197,6 @@ DEFINE_NON_RUNTIME_int32(leader_lease_duration_ms, yb::consensus::kDefaultLeader
              "leader (i.e. serve up-to-date read requests or acknowledge write requests) until a "
              "lease of this duration has definitely expired on the old leader's side.");
 
-
 DEFINE_validator(leader_lease_duration_ms,
     FLAG_DELAYED_COND_VALIDATOR(
         FLAGS_raft_heartbeat_interval_ms < _value,

--- a/src/yb/consensus/raft_consensus.cc
+++ b/src/yb/consensus/raft_consensus.cc
@@ -201,12 +201,12 @@ DEFINE_NON_RUNTIME_int32(leader_lease_duration_ms, yb::consensus::kDefaultLeader
 DEFINE_validator(leader_lease_duration_ms,
     FLAG_DELAYED_COND_VALIDATOR(
         FLAGS_raft_heartbeat_interval_ms < _value,
-        yb::Format("Must be greater than or equal to raft_heartbeat_interval_ms: $0", FLAGS_raft_heartbeat_interval_ms)));
+        yb::Format("Must be strictly greater than raft_heartbeat_interval_ms: $0", FLAGS_raft_heartbeat_interval_ms)));
 
 DEFINE_validator(raft_heartbeat_interval_ms,
     FLAG_DELAYED_COND_VALIDATOR(
         _value < FLAGS_leader_lease_duration_ms,
-        yb::Format("Must be less than or equal to leader_lease_duration_ms: $0", FLAGS_leader_lease_duration_ms)));
+        yb::Format("Must be strictly less than leader_lease_duration_ms: $0", FLAGS_leader_lease_duration_ms)));
 
 DEFINE_UNKNOWN_int32(ht_lease_duration_ms, 2000,
              "Hybrid time leader lease duration. A leader keeps establishing a new lease or "

--- a/src/yb/consensus/raft_consensus.cc
+++ b/src/yb/consensus/raft_consensus.cc
@@ -191,7 +191,7 @@ METRIC_DEFINE_event_stats(
   yb::MetricUnit::kMicroseconds,
   "Microseconds spent resolving DNS requests during RaftConsensus::UpdateRaftConfig");
 
-DEFINE_UNKNOWN_int32(leader_lease_duration_ms, yb::consensus::kDefaultLeaderLeaseDurationMs,
+DEFINE_NON_RUNTIME_int32(leader_lease_duration_ms, yb::consensus::kDefaultLeaderLeaseDurationMs,
              "Leader lease duration. A leader keeps establishing a new lease or extending the "
              "existing one with every UpdateConsensus. A new server is not allowed to serve as a "
              "leader (i.e. serve up-to-date read requests or acknowledge write requests) until a "

--- a/src/yb/consensus/raft_consensus.cc
+++ b/src/yb/consensus/raft_consensus.cc
@@ -91,7 +91,7 @@
 using namespace std::literals;
 using namespace std::placeholders;
 
-DEFINE_UNKNOWN_int32(raft_heartbeat_interval_ms, yb::NonTsanVsTsan(500, 1000),
+DEFINE_NON_RUNTIME_int32(raft_heartbeat_interval_ms, yb::NonTsanVsTsan(500, 1000),
              "The heartbeat interval for Raft replication. The leader produces heartbeats "
              "to followers at this interval. The followers expect a heartbeat at this interval "
              "and consider a leader to have failed if it misses several in a row.");
@@ -200,12 +200,12 @@ DEFINE_NON_RUNTIME_int32(leader_lease_duration_ms, yb::consensus::kDefaultLeader
 
 DEFINE_validator(leader_lease_duration_ms,
     FLAG_DELAYED_COND_VALIDATOR(
-        FLAGS_raft_heartbeat_interval_ms <= _value,
+        FLAGS_raft_heartbeat_interval_ms < _value,
         yb::Format("Must be greater than or equal to raft_heartbeat_interval_ms: $0", FLAGS_raft_heartbeat_interval_ms)));
 
 DEFINE_validator(raft_heartbeat_interval_ms,
     FLAG_DELAYED_COND_VALIDATOR(
-        _value <= FLAGS_leader_lease_duration_ms,
+        _value < FLAGS_leader_lease_duration_ms,
         yb::Format("Must be less than or equal to leader_lease_duration_ms: $0", FLAGS_leader_lease_duration_ms)));
 
 DEFINE_UNKNOWN_int32(ht_lease_duration_ms, 2000,

--- a/src/yb/consensus/raft_consensus.cc
+++ b/src/yb/consensus/raft_consensus.cc
@@ -202,13 +202,13 @@ DEFINE_validator(leader_lease_duration_ms,
     FLAG_DELAYED_COND_VALIDATOR(
         FLAGS_raft_heartbeat_interval_ms < _value,
         yb::Format("Must be strictly greater than raft_heartbeat_interval_ms: $0",
-          FLAGS_raft_heartbeat_interval_ms)));
+            FLAGS_raft_heartbeat_interval_ms)));
 
 DEFINE_validator(raft_heartbeat_interval_ms,
     FLAG_DELAYED_COND_VALIDATOR(
         _value < FLAGS_leader_lease_duration_ms,
         yb::Format("Must be strictly less than leader_lease_duration_ms: $0",
-          FLAGS_leader_lease_duration_ms)));
+            FLAGS_leader_lease_duration_ms)));
 
 DEFINE_UNKNOWN_int32(ht_lease_duration_ms, 2000,
              "Hybrid time leader lease duration. A leader keeps establishing a new lease or "

--- a/src/yb/consensus/raft_consensus.cc
+++ b/src/yb/consensus/raft_consensus.cc
@@ -206,7 +206,7 @@ DEFINE_validator(leader_lease_duration_ms,
 DEFINE_validator(raft_heartbeat_interval_ms,
     FLAG_DELAYED_COND_VALIDATOR(
         _value <= FLAGS_leader_lease_duration_ms,
-        "Must be less than leader_lease_duration_ms"));
+        yb::Format("Must be less than or equal to leader_lease_duration_ms: $0", FLAGS_leader_lease_duration_ms)));
 
 DEFINE_UNKNOWN_int32(ht_lease_duration_ms, 2000,
              "Hybrid time leader lease duration. A leader keeps establishing a new lease or "

--- a/src/yb/consensus/raft_consensus.cc
+++ b/src/yb/consensus/raft_consensus.cc
@@ -201,12 +201,14 @@ DEFINE_NON_RUNTIME_int32(leader_lease_duration_ms, yb::consensus::kDefaultLeader
 DEFINE_validator(leader_lease_duration_ms,
     FLAG_DELAYED_COND_VALIDATOR(
         FLAGS_raft_heartbeat_interval_ms < _value,
-        yb::Format("Must be strictly greater than raft_heartbeat_interval_ms: $0", FLAGS_raft_heartbeat_interval_ms)));
+        yb::Format("Must be strictly greater than raft_heartbeat_interval_ms: $0",
+          FLAGS_raft_heartbeat_interval_ms)));
 
 DEFINE_validator(raft_heartbeat_interval_ms,
     FLAG_DELAYED_COND_VALIDATOR(
         _value < FLAGS_leader_lease_duration_ms,
-        yb::Format("Must be strictly less than leader_lease_duration_ms: $0", FLAGS_leader_lease_duration_ms)));
+        yb::Format("Must be strictly less than leader_lease_duration_ms: $0",
+          FLAGS_leader_lease_duration_ms)));
 
 DEFINE_UNKNOWN_int32(ht_lease_duration_ms, 2000,
              "Hybrid time leader lease duration. A leader keeps establishing a new lease or "


### PR DESCRIPTION
This PR fixes https://github.com/yugabyte/yugabyte-db/issues/1348

It brings in delayed validators to make sure `raft_heartbeat_interval_ms` is less than `leader_lease_duration_ms`
