### PR TITLE
[Docs] Update spark ysql doc to add spark yugabytedb dialect

### DIFF
--- a/docs/content/preview/integrations/_index.md
+++ b/docs/content/preview/integrations/_index.md
@@ -130,7 +130,7 @@ Version refers to the latest tested version of the integration.
 | :----------- | :------ | :------ | :------- |
 | Apache Atlas | 2.3.0   | Partial | [Apache Atlas](atlas-ycql/) |
 | Apache Hudi  | 0.14.1  | Full    | [Apache Hudi](apache-hudi/) |
-| Apache Spark | 3.3.0   | Full    | [Apache Spark](apache-spark/) |
+| Apache Spark | 3.5.4   | Full    | [Apache Spark](apache-spark/) |
 | Jaeger       | 1.43.0  | Full    | [Jaeger](jaeger/) |
 | JanusGraph   | 0.6.2   | Full    | [JanusGraph](janusgraph/) |
 | KairosDB     | 1.3.0   | Full    | [KairosDB](kairosdb/) |

--- a/docs/content/preview/integrations/apache-spark/java-ycql.md
+++ b/docs/content/preview/integrations/apache-spark/java-ycql.md
@@ -46,7 +46,7 @@ This tutorial assumes that you have:
 
 - YugabyteDB running. If you are new to YugabyteDB, follow the steps in [Quick start](/preview/tutorials/quick-start/macos/).
 - Java Development Kit (JDK) 1.8. JDK installers for Linux and macOS can be downloaded from [OpenJDK](http://jdk.java.net/), [AdoptOpenJDK](https://adoptopenjdk.net/), or [Azul Systems](https://www.azul.com/downloads/zulu-community/). Homebrew users on macOS can install using `brew install AdoptOpenJDK/openjdk/adoptopenjdk8`.
-- [Apache Spark 3.3.0](https://spark.apache.org/downloads.html).
+- [Apache Spark 3.5.4](https://spark.apache.org/downloads.html).
 - [Apache Maven 3.3](https://maven.apache.org/index.html) or later.
 
 ## Setting Up a Project with Maven

--- a/docs/content/preview/integrations/apache-spark/java-ycql.md
+++ b/docs/content/preview/integrations/apache-spark/java-ycql.md
@@ -46,7 +46,7 @@ This tutorial assumes that you have:
 
 - YugabyteDB running. If you are new to YugabyteDB, follow the steps in [Quick start](/preview/tutorials/quick-start/macos/).
 - Java Development Kit (JDK) 1.8. JDK installers for Linux and macOS can be downloaded from [OpenJDK](http://jdk.java.net/), [AdoptOpenJDK](https://adoptopenjdk.net/), or [Azul Systems](https://www.azul.com/downloads/zulu-community/). Homebrew users on macOS can install using `brew install AdoptOpenJDK/openjdk/adoptopenjdk8`.
-- [Apache Spark 3.5.4](https://spark.apache.org/downloads.html).
+- [Apache Spark 3.3.0](https://spark.apache.org/downloads.html).
 - [Apache Maven 3.3](https://maven.apache.org/index.html) or later.
 
 ## Setting Up a Project with Maven

--- a/docs/content/preview/integrations/apache-spark/java-ysql.md
+++ b/docs/content/preview/integrations/apache-spark/java-ysql.md
@@ -110,7 +110,7 @@ Create the database and table you will read and write to as follows:
     </dependency>
     ```
   
-  To use the JDBC smart driver with spark, `spark-yugabytedb-dialect_2.12` needs to be added as a dependency because of  the `jdbc:yugabytedb:` in the url, the no-op dialect is selected on spark side, limiting the behaviour, for eg. in case of support of array string type data. If the upstream driver is being used, the dialect dependency is not required. More details of the usage are mentioned here: [spark-yugabytedb-dialect](https://github.com/yugabyte/spark-yugabytedb-dialect)  
+  The dependency `spark-yugabytedb-dialect_2.12`  must be added to use the YugabyteDB JDBC Smart driver in your Spark application. This dialect is based on the PostgreSQL dialect and differs only in the url-prefix it handles: `jdbc:yugabytedb:` instead of `jdbc:postgresql:`. This dialect dependency is not required for using the PostgreSQL driver in your Spark application. More details of the usage are mentioned here: [spark-yugabytedb-dialect](https://github.com/yugabyte/spark-yugabytedb-dialect)  
 
 1. Install the added dependencies.
 
@@ -118,7 +118,7 @@ Create the database and table you will read and write to as follows:
     $ mvn install
     ```
 
-1. Create a java file `sparkSQLJavaExample.java` under `src/main/java` directory of your `sparkSample` project and add the following code to the file:
+1. Create a java file `SparkSQLJavaExample.java` under `src/main/java` directory of your `sparkSample` project and add the following code to the file:
 
     ```java
     import org.apache.spark.sql.SparkSession;
@@ -126,10 +126,10 @@ Create the database and table you will read and write to as follows:
     import org.apache.spark.sql.Row;
     import java.util.Properties;
 
-    public class sparkSQLJavaExample {
+    public class SparkSQLJavaExample {
 
        public static void main(String[] args) {
-          //Register the yugabytedb dialect if using the jdbc smart driver
+          // Register the YugabyteDB Dialect. Needed for using the YugabyteDB JDBC Smart driver
           YugabyteDBDialect.register();
 
            //Create the spark session to work with spark
@@ -265,8 +265,8 @@ Create the database and table you will read and write to as follows:
     $ mvn compile
     ```
 
-1. Run the application using the following command and verify your output as mentioned in the comments of the `sparkSQLJavaExample` file:
+1. Run the application using the following command and verify your output as mentioned in the comments of the `SparkSQLJavaExample` file:
 
     ```sh
-    $  mvn exec:java -Dexec.mainClass="sparkSQLJavaExample"
+    $  mvn exec:java -Dexec.mainClass="SparkSQLJavaExample"
     ```

--- a/docs/content/preview/integrations/apache-spark/java-ysql.md
+++ b/docs/content/preview/integrations/apache-spark/java-ysql.md
@@ -95,15 +95,22 @@ Create the database and table you will read and write to as follows:
     ```xml
     <dependency>
         <groupId>org.apache.spark</groupId>
-        <artifactId>spark-sql_2.11</artifactId>
-        <version>2.4.2</version>
+        <artifactId>spark-sql_2.12</artifactId>
+        <version>3.5.4</version>
     </dependency>
     <dependency>
         <groupId> com.yugabyte</groupId>
         <artifactId>jdbc-yugabytedb</artifactId>
         <version>42.7.3-yb-1</version>
     </dependency>
+    <dependency>
+        <groupId>com.yugabyte</groupId>
+        <artifactId>spark-yugabytedb-dialect_2.12</artifactId>
+        <version>3.5.4-yb-1</version>
+    </dependency>
     ```
+  
+  To use the JDBC smart driver with spark, `spark-yugabytedb-dialect_2.12` needs to be added as a dependency because of  the `jdbc:yugabytedb:` in the url, the no-op dialect is selected on spark side, limiting the behaviour, for eg. in case of support of array string type data. If the upstream driver is being used, the dialect dependency is not required. More details of the usage are mentioned here: [spark-yugabytedb-dialect](https://github.com/yugabyte/spark-yugabytedb-dialect)  
 
 1. Install the added dependencies.
 
@@ -122,6 +129,9 @@ Create the database and table you will read and write to as follows:
     public class sparkSQLJavaExample {
 
        public static void main(String[] args) {
+          //Register the yugabytedb dialect if using the jdbc smart driver
+          YugabyteDBDialect.register();
+
            //Create the spark session to work with spark
            SparkSession spark = SparkSession
                    .builder()

--- a/docs/content/preview/integrations/apache-spark/java-ysql.md
+++ b/docs/content/preview/integrations/apache-spark/java-ysql.md
@@ -50,7 +50,7 @@ This tutorial assumes that you have:
 
 - YugabyteDB running. If you are new to YugabyteDB, follow the steps in [Quick start](/preview/tutorials/quick-start/macos/).
 - Java Development Kit (JDK) 1.8. JDK installers for Linux and macOS can be downloaded from [OpenJDK](http://jdk.java.net/), [AdoptOpenJDK](https://adoptopenjdk.net/), or [Azul Systems](https://www.azul.com/downloads/zulu-community/). Homebrew users on macOS can install using `brew install AdoptOpenJDK/openjdk/adoptopenjdk8`.
-- [Apache Spark 3.3.0](https://spark.apache.org/downloads.html).
+- [Apache Spark 3.5.4](https://spark.apache.org/downloads.html).
 - [Apache Maven 3.3](https://maven.apache.org/index.html) or later.
 
 ## Set up the database
@@ -109,8 +109,8 @@ Create the database and table you will read and write to as follows:
         <version>3.5.4-yb-1</version>
     </dependency>
     ```
-  
-  The dependency `spark-yugabytedb-dialect_2.12`  must be added to use the YugabyteDB JDBC Smart driver in your Spark application. This dialect is based on the PostgreSQL dialect and differs only in the url-prefix it handles: `jdbc:yugabytedb:` instead of `jdbc:postgresql:`. This dialect dependency is not required for using the PostgreSQL driver in your Spark application. More details of the usage are mentioned here: [spark-yugabytedb-dialect](https://github.com/yugabyte/spark-yugabytedb-dialect)  
+
+    You must add the `spark-yugabytedb-dialect_2.12` dependency to use the YugabyteDB JDBC Smart driver in your Spark application. This dialect is based on the PostgreSQL dialect and differs only in the URL prefix it handles: `jdbc:yugabytedb:` instead of `jdbc:postgresql:`. (You don't need this dialect dependency to use the PostgreSQL driver in your Spark application.) For more information, refer to the [YugabyteDB Dialect for Apache Spark](https://github.com/yugabyte/spark-yugabytedb-dialect) project.
 
 1. Install the added dependencies.
 

--- a/docs/content/preview/integrations/apache-spark/python-ysql.md
+++ b/docs/content/preview/integrations/apache-spark/python-ysql.md
@@ -50,7 +50,7 @@ This tutorial assumes that you have:
 
 - YugabyteDB running. If you are new to YugabyteDB, follow the steps in [Quick start](/preview/tutorials/quick-start/macos/).
 - Java Development Kit (JDK) 1.8. JDK installers for Linux and macOS can be downloaded from [OpenJDK](http://jdk.java.net/), [AdoptOpenJDK](https://adoptopenjdk.net/), or [Azul Systems](https://www.azul.com/downloads/zulu-community/). Homebrew users on macOS can install using `brew install AdoptOpenJDK/openjdk/adoptopenjdk8`.
-- [Apache Spark 3.3.0](https://spark.apache.org/downloads.html).
+- [Apache Spark 3.5.4](https://spark.apache.org/downloads.html).
 
 ## Start Python Spark shell with YugabyteDB driver
 
@@ -67,7 +67,7 @@ Welcome to
       ____              __
      / __/__  ___ _____/ /__
     _\ \/ _ \/ _ `/ __/  '_/
-   /__ / .__/\_,_/_/ /_/\_\   version 3.3.0
+   /__ / .__/\_,_/_/ /_/\_\   version 3.5.4
       /_/
 
 Using Python version 3.8.9 (default, Jul 19 2021 09:37:30)

--- a/docs/content/preview/integrations/apache-spark/scala-ysql.md
+++ b/docs/content/preview/integrations/apache-spark/scala-ysql.md
@@ -50,7 +50,7 @@ This tutorial assumes that you have:
 
 - YugabyteDB running. If you are new to YugabyteDB, follow the steps in [Quick start](/preview/tutorials/quick-start/macos/).
 - Java Development Kit (JDK) 1.8. JDK installers for Linux and macOS can be downloaded from [OpenJDK](http://jdk.java.net/), [AdoptOpenJDK](https://adoptopenjdk.net/), or [Azul Systems](https://www.azul.com/downloads/zulu-community/). Homebrew users on macOS can install using `brew install AdoptOpenJDK/openjdk/adoptopenjdk8`.
-- [Apache Spark 3.3.0](https://spark.apache.org/downloads.html).
+- [Apache Spark 3.5.4](https://spark.apache.org/downloads.html).
 
 ## Start Scala Spark shell with YugabyteDB driver
 
@@ -67,7 +67,7 @@ Welcome to
       ____              __
      / __/__  ___ _____/ /__
     _\ \/ _ \/ _ `/ __/  '_/
-   /___/ .__/\_,_/_/ /_/\_\   version 3.3.0
+   /___/ .__/\_,_/_/ /_/\_\   version 3.5.4
       /_/
 
 Using Scala version 2.12.15 (OpenJDK 64-Bit Server VM, Java 1.8.0_292)

--- a/docs/content/preview/integrations/apache-spark/spark-sql.md
+++ b/docs/content/preview/integrations/apache-spark/spark-sql.md
@@ -51,7 +51,7 @@ This tutorial assumes that you have:
 
 - YugabyteDB running. If you are new to YugabyteDB, follow the steps in [Quick start](/preview/tutorials/quick-start/macos/).
 - Java Development Kit (JDK) 1.8. JDK installers for Linux and macOS can be downloaded from [OpenJDK](http://jdk.java.net/), [AdoptOpenJDK](https://adoptopenjdk.net/), or [Azul Systems](https://www.azul.com/downloads/zulu-community/). Homebrew users on macOS can install using `brew install AdoptOpenJDK/openjdk/adoptopenjdk8`.
-- [Apache Spark 3.3.0](https://spark.apache.org/downloads.html).
+- [Apache Spark 3.5.4](https://spark.apache.org/downloads.html).
 
 ## Start Spark SQL shell with YugabyteDB driver
 


### PR DESCRIPTION
A new plugin, `spark-yugabytedb-dialect`, has been created for spark to use it with yugabytedb. Updating the doc to add that as a dependency. More details on the plugin are in the [doc](https://docs.google.com/document/d/1Bf8A3cfG8XXh2j203m2UeiHX6u0k2UE36D4-w5GUuws/edit?tab=t.0#heading=h.xjdxcpkwfbzt) and the [spark-yugabytedb-dialect](https://github.com/yugabyte/spark-yugabytedb-dialect) repository.