### PR TITLE
[doc] Update include syntax in quick-start tutorials for Linux and macOS

### DIFF
--- a/docs/content/preview/tutorials/quick-start/linux.md
+++ b/docs/content/preview/tutorials/quick-start/linux.md
@@ -119,7 +119,7 @@ To create a single-node local cluster with a replication factor (RF) of 1, run t
 ./bin/yugabyted start
 ```
 
-{{% includeMarkdown "./include-connect.md" %}}
+{{< readfile "/preview/tutorials/quick-start/include-connect.md" >}}
 
 ## Build an application
 

--- a/docs/content/preview/tutorials/quick-start/macos.md
+++ b/docs/content/preview/tutorials/quick-start/macos.md
@@ -222,7 +222,7 @@ Alternatively, you can disable AirPlay receiving, then start YugabyteDB normally
 
 {{< /tabpane >}}
 
-{{% includeMarkdown "./include-connect.md" %}}
+{{< readfile "/preview/tutorials/quick-start/include-connect.md" >}}
 
 ## Build an application
 


### PR DESCRIPTION
@netlify /preview/tutorials/quick-start/linux/#connect-to-the-database