### PR TITLE
[DEVOPS-3352] build: Update github runners' OS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: ${{ matrix.name }}
 
     # Grab the latest docker images from here:
@@ -43,22 +43,22 @@ jobs:
       matrix:
         include:
           - name: "GCC 11, fastdebug, AlmaLinux 8"
-            os: ubuntu-20.04
+            os: ubuntu-24.04
             yb_build_args: --gcc11 fastdebug --no-linuxbrew
             docker_image: yugabyteci/yb_build_infra_almalinux8_x86_64:v2024-04-25T17_54_46
 
           - name: "GCC 12, debug, AlmaLinux 9"
-            os: ubuntu-20.04
+            os: ubuntu-24.04
             yb_build_args: --gcc12 debug --no-linuxbrew
             docker_image: yugabyteci/yb_build_infra_almalinux9_x86_64:v2024-04-25T17_54_47
 
           - name: "Clang 17, release, AlmaLinux 8"
-            os: ubuntu-20.04
+            os: ubuntu-24.04
             yb_build_args: --clang17 release --no-linuxbrew
             docker_image: yugabyteci/yb_build_infra_almalinux8_x86_64:v2024-04-25T17_54_46
 
           - name: "Clang 17, debug, Ubuntu 22.04"
-            os: ubuntu-20.04
+            os: ubuntu-24.04
             yb_build_args: --clang17 debug --no-linuxbrew
             docker_image: yugabyteci/yb_build_infra_ubuntu2204_x86_64:v2024-04-25T17_54_47
 


### PR DESCRIPTION
Ubuntu-20.04 is being deprecated by github. Run docker on 24.04 instead.