### PR TITLE
[Docs] Node.js Smart driver (node-postgres) docs update for Node-type aware laod balancing support.

### DIFF
--- a/docs/content/preview/drivers-orms/nodejs/_index.md
+++ b/docs/content/preview/drivers-orms/nodejs/_index.md
@@ -18,7 +18,7 @@ The following projects are recommended for implementing Node applications using 
 
 | Project | Documentation and Guides | Latest Driver Version | Supported YugabyteDB Version |
 | :------ | :----------------------- | :----------------------- | :--------------------|
-| YugabyteDB node-postgres Smart Driver| [Documentation](yugabyte-node-driver/) <br />[Reference](yugabyte-pg-reference/) | [8.7.3-yb-1](https://www.npmjs.com/package/pg) | 2.8 and above |
+| YugabyteDB node-postgres Smart Driver| [Documentation](yugabyte-node-driver/) <br />[Reference](yugabyte-pg-reference/) | [8.7.3-yb-9](https://www.npmjs.com/package/pg) | 2.8 and above |
 | PostgreSQL node-postgres Driver| [Documentation](postgres-node-driver/) <br />[Reference](postgres-pg-reference/) | [8.7.3](https://www.npmjs.com/package/pg) | 2.6 and above |
 | YugabyteDB Node.js Driver for YCQL | [Documentation](ycql/) | [4.0.0](https://github.com/yugabyte/cassandra-nodejs-driver) | |
 

--- a/docs/content/preview/drivers-orms/nodejs/yugabyte-node-driver.md
+++ b/docs/content/preview/drivers-orms/nodejs/yugabyte-node-driver.md
@@ -75,9 +75,11 @@ The following table describes the connection parameters required to connect, inc
 | database | Database name | yugabyte |
 | user | Database user | yugabyte |
 | password | User password | yugabyte |
-| loadBalance | Enables [uniform load balancing](../../smart-drivers/#cluster-aware-load-balancing) | false |
-| topologyKeys | Enables [topology-aware load balancing](../../smart-drivers/#topology-aware-load-balancing). Specify comma-separated geo-locations in the form `cloud.region.zone:priority`. Ignored if `loadBalance` is false | Empty |
+| loadBalance | Enables [uniform load balancing](../../smart-drivers/#cluster-aware-load-balancing) | false(Disabled) |
+| topologyKeys | Enables [Topology-aware load balancing](../../smart-drivers/#topology-aware-load-balancing). It can be set to comma-separated geo-locations in the form `cloud.region.zone:priority`. Ignored if `load_balance` is false | Empty |
 | ybServersRefreshInterval | The interval (in seconds) to refresh the servers list; ignored if `loadBalance` is false | 300 |
+| fallbackToTopologyKeysOnly | If set to true and `topologyKeys` are specified, the driver only tries to connect to nodes specified in `topologyKeys` | false |
+| failedHostReconnectDelaySecs | Time, in seconds, to wait before trying to connect to failed nodes. When the driver is unable to connect to a node, it marks the node as failed using a timestamp, and ignores the node when trying new connections until this time elapses. | 5 |
 
 Create a client to connect to the cluster using a connection string. The following is an example connection string for connecting to a YugabyteDB cluster with uniform and topology load balancing:
 

--- a/docs/content/preview/drivers-orms/nodejs/yugabyte-pg-reference.md
+++ b/docs/content/preview/drivers-orms/nodejs/yugabyte-pg-reference.md
@@ -62,7 +62,7 @@ Learn how to perform the common tasks required for Node.js application developme
 
 The following connection properties need to be added to enable load balancing:
 
-- `loadBalance` - enable cluster-aware load balancing by setting this property to `true`; disabled by default.
+- `loadBalance` - enable [cluster-aware load balancing](../../smart-drivers/#cluster-aware-load-balancing) by setting this property to one of the allowed values other than `false`; disabled by default.
 - `topologyKeys` - provide comma-separated geo-location values to enable topology-aware load balancing. Geo-locations can be provided as `cloud.region.zone`. Specify all zones in a region as `cloud.region.*`. To designate fallback locations for when the primary location is unreachable, specify a priority in the form `:n`, where `n` is the order of precedence. For example, `cloud1.datacenter1.rack1:1,cloud1.datacenter1.rack2:2`.
 
 By default, the driver refreshes the list of nodes every 300 seconds (5 minutes). You can change this value by including the `ybServersRefreshInterval` parameter.
@@ -73,10 +73,10 @@ To use the driver, do the following:
 
 - Pass new connection properties for load balancing in the connection URL.
 
-    To enable uniform load balancing across all servers, set the `loadBalance` property to `true` in the URL, as per the following connection string:
+    To enable uniform load balancing across all servers, set the `loadBalance` property to `true` or `any` in the URL, as per the following connection string:
 
     ```javascript
-    const connectionString = "postgresql://user:password@localhost:port/database?loadBalance=true"
+    const connectionString = "postgresql://user:password@localhost:port/database?loadBalance=any"
     const client = new Client(connectionString);
     client.connect()
     ```
@@ -86,7 +86,7 @@ To use the driver, do the following:
 - To specify topology keys, set the `topologyKeys` property to comma separated values, as per the following connection string:
 
     ```js
-    const connectionString = "postgresql://user:password@localhost:port/database?loadBalance=true&topologyKeys=cloud1.datacenter1.rack1,cloud1.datacenter1.rack2"
+    const connectionString = "postgresql://user:password@localhost:port/database?loadBalance=any&topologyKeys=cloud1.datacenter1.rack1,cloud1.datacenter1.rack2"
     const client = new Client(connectionString);
     client.conn
     ```
@@ -99,7 +99,7 @@ To use the driver, do the following:
         password: 'yugabyte',
         host: 'localhost',
         port: 5433,
-        loadBalance: true,
+        loadBalance: 'any',
         database: 'yugabyte',
         max: 100
     })

--- a/docs/content/stable/drivers-orms/nodejs/_index.md
+++ b/docs/content/stable/drivers-orms/nodejs/_index.md
@@ -18,7 +18,7 @@ The following projects are recommended for implementing Node applications using 
 
 | Project | Documentation and Guides | Latest Driver Version | Supported YugabyteDB Version |
 | :------ | :----------------------- | :----------------------- | :--------------------|
-| YugabyteDB node-postgres Smart Driver| [Documentation](yugabyte-node-driver/) <br />[Reference](yugabyte-pg-reference/) | [8.7.3-yb-1](https://www.npmjs.com/package/pg) | 2.8 and above |
+| YugabyteDB node-postgres Smart Driver| [Documentation](yugabyte-node-driver/) <br />[Reference](yugabyte-pg-reference/) | [8.7.3-yb-9](https://www.npmjs.com/package/pg) | 2.8 and above |
 | PostgreSQL node-postgres Driver| [Documentation](postgres-node-driver/) <br />[Reference](postgres-pg-reference/) | [8.7.3](https://www.npmjs.com/package/pg) | 2.6 and above |
 | YugabyteDB Node.js Driver for YCQL | [Documentation](ycql/) | [4.0.0](https://github.com/yugabyte/cassandra-nodejs-driver) | |
 

--- a/docs/content/stable/drivers-orms/nodejs/yugabyte-node-driver.md
+++ b/docs/content/stable/drivers-orms/nodejs/yugabyte-node-driver.md
@@ -75,9 +75,11 @@ The following table describes the connection parameters required to connect, inc
 | database | Database name | yugabyte |
 | user | Database user | yugabyte |
 | password | User password | yugabyte |
-| loadBalance | Enables [uniform load balancing](../../smart-drivers/#cluster-aware-load-balancing) | false |
-| topologyKeys | Specify comma-separated geo-locations in the form `cloud.region.zone:priority`. Ignored if `loadBalance` is false | Empty |
+| loadBalance | Enables [uniform load balancing](../../smart-drivers/#cluster-aware-load-balancing) | false(Disabled) |
+| topologyKeys | Enables [Topology-aware load balancing](../../smart-drivers/#topology-aware-load-balancing). It can be set to comma-separated geo-locations in the form `cloud.region.zone:priority`. Ignored if `load_balance` is false | Empty |
 | ybServersRefreshInterval | The interval (in seconds) to refresh the servers list; ignored if `loadBalance` is false | 300 |
+| fallbackToTopologyKeysOnly | If set to true and `topologyKeys` are specified, the driver only tries to connect to nodes specified in `topologyKeys` | false |
+| failedHostReconnectDelaySecs | Time, in seconds, to wait before trying to connect to failed nodes. When the driver is unable to connect to a node, it marks the node as failed using a timestamp, and ignores the node when trying new connections until this time elapses. | 5 |
 
 Create a client to connect to the cluster using a connection string. The following is an example connection string for connecting to a YugabyteDB cluster with uniform and topology load balancing:
 

--- a/docs/content/stable/drivers-orms/nodejs/yugabyte-pg-reference.md
+++ b/docs/content/stable/drivers-orms/nodejs/yugabyte-pg-reference.md
@@ -60,7 +60,7 @@ Learn how to perform the common tasks required for Node.js application developme
 
 The following connection properties need to be added to enable load balancing:
 
-- `loadBalance` - enable cluster-aware load balancing by setting this property to `true`; disabled by default.
+- `loadBalance` - enable [cluster-aware load balancing](../../smart-drivers/#cluster-aware-load-balancing) by setting this property to one of the allowed values other than `false`; disabled by default.
 - `topologyKeys` - provide comma-separated geo-location values to enable topology-aware load balancing. Geo-locations can be provided as `cloud.region.zone`. Specify all zones in a region as `cloud.region.*`. To designate fallback locations for when the primary location is unreachable, specify a priority in the form `:n`, where `n` is the order of precedence. For example, `cloud1.datacenter1.rack1:1,cloud1.datacenter1.rack2:2`.
 
 By default, the driver refreshes the list of nodes every 300 seconds (5 minutes). You can change this value by including the `ybServersRefreshInterval` parameter.
@@ -71,10 +71,10 @@ To use the driver, do the following:
 
 - Pass new connection properties for load balancing in the connection URL.
 
-    To enable uniform load balancing across all servers, set the `loadBalance` property to `true` in the URL, as per the following connection string:
+    To enable uniform load balancing across all servers, set the `loadBalance` property to `true` or `any` in the URL, as per the following connection string:
 
     ```javascript
-    const connectionString = "postgresql://user:password@localhost:port/database?loadBalance=true"
+    const connectionString = "postgresql://user:password@localhost:port/database?loadBalance=any"
     const client = new Client(connectionString);
     client.connect()
     ```
@@ -84,7 +84,7 @@ To use the driver, do the following:
 - To specify topology keys, set the `topologyKeys` property to comma separated values, as per the following connection string:
 
     ```js
-    const connectionString = "postgresql://user:password@localhost:port/database?loadBalance=true&topologyKeys=cloud1.datacenter1.rack1,cloud1.datacenter1.rack2"
+    const connectionString = "postgresql://user:password@localhost:port/database?loadBalance=any&topologyKeys=cloud1.datacenter1.rack1,cloud1.datacenter1.rack2"
     const client = new Client(connectionString);
     client.conn
     ```
@@ -97,7 +97,7 @@ To use the driver, do the following:
         password: 'yugabyte',
         host: 'localhost',
         port: 5433,
-        loadBalance: true,
+        loadBalance: 'any',
         database: 'yugabyte',
         max: 100
     })

--- a/docs/content/v2.20/drivers-orms/nodejs/_index.md
+++ b/docs/content/v2.20/drivers-orms/nodejs/_index.md
@@ -18,7 +18,7 @@ The following projects are recommended for implementing Node applications using 
 
 | Project | Documentation and Guides | Latest Driver Version | Supported YugabyteDB Version |
 | :------ | :----------------------- | :----------------------- | :--------------------|
-| YugabyteDB node-postgres Smart Driver| [Documentation](yugabyte-node-driver/) <br />[Reference](../../reference/drivers/nodejs/yugabyte-pg-reference/) | [8.7.3-yb-1](https://www.npmjs.com/package/pg) | 2.8 and above |
+| YugabyteDB node-postgres Smart Driver| [Documentation](yugabyte-node-driver/) <br />[Reference](../../reference/drivers/nodejs/yugabyte-pg-reference/) | [8.7.3-yb-9](https://www.npmjs.com/package/pg) | 2.8 and above |
 | PostgreSQL node-postgres Driver| [Documentation](postgres-node-driver/) <br />[Reference](../../reference/drivers/nodejs/postgres-pg-reference/) | [8.7.3](https://www.npmjs.com/package/pg) | 2.6 and above |
 | YugabyteDB Node.js Driver for YCQL | [Documentation](ycql/) | [4.0.0](https://github.com/yugabyte/cassandra-nodejs-driver) | |
 

--- a/docs/content/v2.20/drivers-orms/nodejs/yugabyte-node-driver.md
+++ b/docs/content/v2.20/drivers-orms/nodejs/yugabyte-node-driver.md
@@ -75,9 +75,11 @@ The following table describes the connection parameters required to connect, inc
 | database | Database name | yugabyte |
 | user | Database user | yugabyte |
 | password | User password | yugabyte |
-| loadBalance | Enables [uniform load balancing](../../smart-drivers/#cluster-aware-load-balancing) | false |
-| topologyKeys | Enables [topology-aware load balancing](../../smart-drivers/#topology-aware-load-balancing). Specify comma-separated geo-locations in the form `cloud.region.zone:priority`. Ignored if `loadBalance` is false | Empty |
+| loadBalance | Enables [uniform load balancing](../../smart-drivers/#cluster-aware-load-balancing) | false(Disabled) |
+| topologyKeys | Enables [Topology-aware load balancing](../../smart-drivers/#topology-aware-load-balancing). It can be set to comma-separated geo-locations in the form `cloud.region.zone:priority`. Ignored if `load_balance` is false | Empty |
 | ybServersRefreshInterval | The interval (in seconds) to refresh the servers list; ignored if `loadBalance` is false | 300 |
+| fallbackToTopologyKeysOnly | If set to true and `topologyKeys` are specified, the driver only tries to connect to nodes specified in `topologyKeys` | false |
+| failedHostReconnectDelaySecs | Time, in seconds, to wait before trying to connect to failed nodes. When the driver is unable to connect to a node, it marks the node as failed using a timestamp, and ignores the node when trying new connections until this time elapses. | 5 |
 
 Create a client to connect to the cluster using a connection string. The following is an example connection string for connecting to a YugabyteDB cluster with uniform and topology load balancing:
 

--- a/docs/content/v2.20/reference/drivers/nodejs/yugabyte-pg-reference.md
+++ b/docs/content/v2.20/reference/drivers/nodejs/yugabyte-pg-reference.md
@@ -59,7 +59,7 @@ Learn how to perform the common tasks required for Node.js application developme
 
 The following connection properties need to be added to enable load balancing:
 
-- `loadBalance` - enable cluster-aware load balancing by setting this property to `true`; disabled by default.
+- `loadBalance` - enable [cluster-aware load balancing](../../smart-drivers/#cluster-aware-load-balancing) by setting this property to one of the allowed values other than `false`; disabled by default.
 - `topologyKeys` - provide comma-separated geo-location values to enable topology-aware load balancing. Geo-locations can be provided as `cloud.region.zone`. Specify all zones in a region as `cloud.region.*`. To designate fallback locations for when the primary location is unreachable, specify a priority in the form `:n`, where `n` is the order of precedence. For example, `cloud1.datacenter1.rack1:1,cloud1.datacenter1.rack2:2`.
 
 By default, the driver refreshes the list of nodes every 300 seconds (5 minutes). You can change this value by including the `ybServersRefreshInterval` parameter.
@@ -70,10 +70,10 @@ To use the driver, do the following:
 
 - Pass new connection properties for load balancing in the connection URL.
 
-    To enable uniform load balancing across all servers, set the `loadBalance` property to `true` in the URL, as per the following connection string:
+    To enable uniform load balancing across all servers, set the `loadBalance` property to `true` or `any` in the URL, as per the following connection string:
 
     ```javascript
-    const connectionString = "postgresql://user:password@localhost:port/database?loadBalance=true"
+    const connectionString = "postgresql://user:password@localhost:port/database?loadBalance=any"
     const client = new Client(connectionString);
     client.connect()
     ```
@@ -83,7 +83,7 @@ To use the driver, do the following:
 - To specify topology keys, set the `topologyKeys` property to comma separated values, as per the following connection string:
 
     ```js
-    const connectionString = "postgresql://user:password@localhost:port/database?loadBalance=true&topologyKeys=cloud1.datacenter1.rack1,cloud1.datacenter1.rack2"
+    const connectionString = "postgresql://user:password@localhost:port/database?loadBalance=any&topologyKeys=cloud1.datacenter1.rack1,cloud1.datacenter1.rack2"
     const client = new Client(connectionString);
     client.conn
     ```
@@ -96,7 +96,7 @@ To use the driver, do the following:
         password: 'yugabyte',
         host: 'localhost',
         port: 5433,
-        loadBalance: true,
+        loadBalance: 'any',
         database: 'yugabyte',
         max: 100
     })


### PR DESCRIPTION
This PR makes changes in YugabyteDB node-postgres Smart Driver documentation to reflect changes involved to support Node-type aware load balancing added via this https://github.com/yugabyte/node-postgres/pull/11.