### PR TITLE
[Docs] Create a Note block to link to other product pages

### DIFF
--- a/docs/assets/scss/_styles_project.scss
+++ b/docs/assets/scss/_styles_project.scss
@@ -25,6 +25,7 @@
 @import "./_yb_image.scss";
 @import "./_yb_kapa_ai.scss";
 @import "./_yb_buttons.scss";
+@import "./_yb_page_finder.scss";
 @import "./_yb_page_style.scss";
 @import "./_yb_resources.scss";
 @import "./_yb_tags.scss";

--- a/docs/assets/scss/_yb_page_finder.scss
+++ b/docs/assets/scss/_yb_page_finder.scss
@@ -12,6 +12,11 @@
   background: #FFF;
 }
 
+.page-finder .finder-panel .head {
+  padding: 9px 16px;
+  border-bottom: 1px solid #E9EEF2;
+}
+
 .page-finder .finder-panel .head p {
   color: #97A5B0;
   font-size: 11.5px;
@@ -26,9 +31,13 @@
   color: #6D7C88;
 }
 
-.page-finder .finder-panel .head {
-  padding: 9px 16px;
-  border-bottom: 1px solid #E9EEF2;
+.page-finder .finder-panel.vertical .inner-container {
+  max-width: 100%;
+  width: 420px;
+}
+
+.page-finder .finder-panel.vertical .inner-container .head p {
+  line-height: 1.4;
 }
 
 .page-finder .finder-panel .body {
@@ -42,14 +51,6 @@
   align-items: flex-start;
 }
 
-.page-finder .finder-panel.vertical .inner-container .head p {
-  line-height: 1.4;
-}
-.page-finder .finder-panel.vertical .inner-container {
-  max-width: 100%;
-  width: 420px;
-}
-
 .page-finder .finder-panel .body a {
   padding: 6px 12px;
   display: flex;
@@ -58,19 +59,12 @@
   position: relative;
 }
 
-.page-finder .finder-panel .body a:not(:hover):not(:first-child) .icon img {
-  filter: brightness(0) invert(30%);
-}
-
-.page-finder .finder-panel .body a:first-child .icon img {
-  filter: brightness(0) invert(30%);
-}
-
 .page-finder .finder-panel .body a .icon {
   width: 16px;
   height: 16px;
   line-height: 0;
 }
+
 .page-finder .finder-panel .body a .icon svg {
   width: 16px;
   height: 16px;
@@ -90,32 +84,70 @@
   text-underline-position: from-font;
   white-space: nowrap
 }
-.page-finder .finder-panel .body a:not(:first-child):hover .icon svg path {
-  fill: #507CE1;
-}
 
 .page-finder .finder-panel .body a  .icon svg path {
   fill: #6D7C88;
 }
 
-.page-finder .finder-panel .body a:not(:first-child):hover .title {
+.page-finder .finder-panel .body a .icon img {
+  filter: brightness(0) invert(30%);
+}
+
+.page-finder .finder-panel .body a.active ~ .active:hover .icon img,
+.page-finder .finder-panel .body a:hover .icon img {
+  filter: none;
+}
+
+.page-finder .finder-panel .body a.active .icon img {
+  filter: brightness(0) invert(30%);
+}
+
+.page-finder .finder-panel .body a:hover .title {
   color: #507CE1;
 }
 
-.page-finder .finder-panel .body a:first-child {
+.page-finder .finder-panel .body a.active {
   border-radius: 6px;
   border: 1px solid #E9EEF2;
   background: #F7F9FB;
   padding-right: 8px;
 }
 
-.page-finder .finder-panel .body a:first-child .title {
+.page-finder .finder-panel .body a.active ~ .active {
+  border-radius: 0;
+  border: 0;
+  background: transparent;
+  padding-right: 12px;
+}
+
+.page-finder .finder-panel .body a.active .title {
   color: #4E5F6D;
   font-size: 11.5px;
   font-style: normal;
   font-weight: 500;
   line-height: normal;
   text-decoration: none;
+}
+.page-finder .finder-panel .body a.active ~ .active:hover .title {
+  color: #507CE1;
+}
+
+.page-finder .finder-panel .body a.active ~ .active .title {
+  color: #6D7C88;
+  font-size: 11.5px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+  text-decoration-line: underline;
+  text-decoration-style: solid;
+  text-decoration-skip-ink: none;
+  text-decoration-thickness: auto;
+  text-underline-offset: auto;
+  text-underline-position: from-font;
+}
+
+.page-finder .finder-panel .body a.active ~ .active .bookmark-icon {
+  display: none;
 }
 
 .page-finder .finder-panel .body .bookmark-icon {

--- a/docs/assets/scss/_yb_page_finder.scss
+++ b/docs/assets/scss/_yb_page_finder.scss
@@ -1,0 +1,119 @@
+.links-panels {
+  margin: 48px 0;
+  font-family: Inter;
+  display: flex;
+  flex-flow: column;
+  align-items: flex-start;
+}
+.links-panels .inner-container {
+  border-radius: 8px;
+  border: 1px solid #E9EEF2;
+  background: #FFF;
+}
+.links-panels .head p {
+  color: #97A5B0;
+  font-size: 11.5px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+  margin: 0;
+}
+.links-panels .head p b {
+  font-weight: 600;
+  color: #6D7C88;
+}
+.links-panels .head {
+  padding: 9px 16px;
+  border-bottom: 1px solid #E9EEF2;
+}
+.links-panels .body {
+  padding: 12px 16px;
+  display: flex;
+  gap: 8px 24px;
+}
+
+.links-panels.vertical .inner-container .body {
+  flex-flow: column;
+  align-items: flex-start;
+}
+
+.links-panels.vertical .inner-container .head p {
+  line-height: 1.4;
+}
+.links-panels.vertical .inner-container {
+  max-width: 100%;
+  width: 420px;
+}
+
+.links-panels .body a {
+  padding: 6px 12px;
+  display: flex;
+  height: 30px;
+  gap: 4px;
+  position: relative;
+}
+
+.links-panels .body a:not(:hover):not(:first-child) .icon img{
+  filter: brightness(0) invert(30%);
+}
+.links-panels .body a:first-child .icon img{
+  filter: brightness(0) invert(30%);
+}
+.links-panels .body a .icon {
+  width: 16px;
+  height: 16px;
+  line-height: 0;
+}
+.links-panels .body a .icon svg{
+  width: 16px;
+  height: 16px;
+}
+.links-panels .body a .title {
+  color: #6D7C88;
+  font-size: 11.5px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+  text-decoration-line: underline;
+  text-decoration-style: solid;
+  text-decoration-skip-ink: none;
+  text-decoration-thickness: auto;
+  text-underline-offset: auto;
+  text-underline-position: from-font;
+  white-space: nowrap
+}
+.links-panels .body a:not(:first-child):hover .icon svg path{
+  fill: #507CE1;
+
+}
+.links-panels .body a  .icon svg path{
+  fill: #6D7C88;
+}
+
+.links-panels .body a:not(:first-child):hover .title {
+  color: #507CE1;
+}
+
+.links-panels .body a:first-child {
+  border-radius: 6px;
+  border: 1px solid #E9EEF2;
+  background: #F7F9FB;
+  padding-right: 8px;
+}
+.links-panels .body a:first-child .title {
+  color: #4E5F6D;
+  font-size: 11.5px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+  text-decoration: none;
+}
+
+.links-panels .body .bookmark-icon {
+  width: 12.1px;
+  height: 22.1px;
+  display: inline-block;
+  margin-top: -7px;
+  margin-left: 3.4px;
+}
+    

--- a/docs/assets/scss/_yb_page_finder.scss
+++ b/docs/assets/scss/_yb_page_finder.scss
@@ -1,16 +1,18 @@
-.links-panels {
+.page-finder .finder-panel {
   margin: 48px 0;
   font-family: Inter;
   display: flex;
   flex-flow: column;
   align-items: flex-start;
 }
-.links-panels .inner-container {
+
+.page-finder .finder-panel .inner-container {
   border-radius: 8px;
   border: 1px solid #E9EEF2;
   background: #FFF;
 }
-.links-panels .head p {
+
+.page-finder .finder-panel .head p {
   color: #97A5B0;
   font-size: 11.5px;
   font-style: normal;
@@ -18,34 +20,37 @@
   line-height: normal;
   margin: 0;
 }
-.links-panels .head p b {
+
+.page-finder .finder-panel .head p b {
   font-weight: 600;
   color: #6D7C88;
 }
-.links-panels .head {
+
+.page-finder .finder-panel .head {
   padding: 9px 16px;
   border-bottom: 1px solid #E9EEF2;
 }
-.links-panels .body {
+
+.page-finder .finder-panel .body {
   padding: 12px 16px;
   display: flex;
   gap: 8px 24px;
 }
 
-.links-panels.vertical .inner-container .body {
+.page-finder .finder-panel.vertical .inner-container .body {
   flex-flow: column;
   align-items: flex-start;
 }
 
-.links-panels.vertical .inner-container .head p {
+.page-finder .finder-panel.vertical .inner-container .head p {
   line-height: 1.4;
 }
-.links-panels.vertical .inner-container {
+.page-finder .finder-panel.vertical .inner-container {
   max-width: 100%;
   width: 420px;
 }
 
-.links-panels .body a {
+.page-finder .finder-panel .body a {
   padding: 6px 12px;
   display: flex;
   height: 30px;
@@ -53,22 +58,25 @@
   position: relative;
 }
 
-.links-panels .body a:not(:hover):not(:first-child) .icon img{
+.page-finder .finder-panel .body a:not(:hover):not(:first-child) .icon img {
   filter: brightness(0) invert(30%);
 }
-.links-panels .body a:first-child .icon img{
+
+.page-finder .finder-panel .body a:first-child .icon img {
   filter: brightness(0) invert(30%);
 }
-.links-panels .body a .icon {
+
+.page-finder .finder-panel .body a .icon {
   width: 16px;
   height: 16px;
   line-height: 0;
 }
-.links-panels .body a .icon svg{
+.page-finder .finder-panel .body a .icon svg {
   width: 16px;
   height: 16px;
 }
-.links-panels .body a .title {
+
+.page-finder .finder-panel .body a .title {
   color: #6D7C88;
   font-size: 11.5px;
   font-style: normal;
@@ -82,25 +90,26 @@
   text-underline-position: from-font;
   white-space: nowrap
 }
-.links-panels .body a:not(:first-child):hover .icon svg path{
+.page-finder .finder-panel .body a:not(:first-child):hover .icon svg path {
   fill: #507CE1;
-
 }
-.links-panels .body a  .icon svg path{
+
+.page-finder .finder-panel .body a  .icon svg path {
   fill: #6D7C88;
 }
 
-.links-panels .body a:not(:first-child):hover .title {
+.page-finder .finder-panel .body a:not(:first-child):hover .title {
   color: #507CE1;
 }
 
-.links-panels .body a:first-child {
+.page-finder .finder-panel .body a:first-child {
   border-radius: 6px;
   border: 1px solid #E9EEF2;
   background: #F7F9FB;
   padding-right: 8px;
 }
-.links-panels .body a:first-child .title {
+
+.page-finder .finder-panel .body a:first-child .title {
   color: #4E5F6D;
   font-size: 11.5px;
   font-style: normal;
@@ -109,11 +118,10 @@
   text-decoration: none;
 }
 
-.links-panels .body .bookmark-icon {
+.page-finder .finder-panel .body .bookmark-icon {
   width: 12.1px;
   height: 22.1px;
   display: inline-block;
   margin-top: -7px;
   margin-left: 3.4px;
 }
-    

--- a/docs/assets/scss/_yb_page_finder.scss
+++ b/docs/assets/scss/_yb_page_finder.scss
@@ -18,8 +18,8 @@
 }
 
 .page-finder .finder-panel .head p {
-  color: #97A5B0;
-  font-size: 11.5px;
+  color: #6D7C88;
+  font-size: 13px;
   font-style: normal;
   font-weight: 500;
   line-height: normal;
@@ -28,7 +28,7 @@
 
 .page-finder .finder-panel .head p b {
   font-weight: 600;
-  color: #6D7C88;
+  color: $yb-font-dark;
 }
 
 .page-finder .finder-panel.vertical .inner-container {
@@ -103,7 +103,7 @@
 }
 
 .page-finder .finder-panel .body a:hover .title {
-  color: #507CE1;
+  color: $yb-anchor-color;
 }
 
 .page-finder .finder-panel .body a.active {
@@ -121,7 +121,7 @@
 }
 
 .page-finder .finder-panel .body a.active .title {
-  color: #4E5F6D;
+  color: $yb-font-gray;
   font-size: 11.5px;
   font-style: normal;
   font-weight: 500;
@@ -129,7 +129,7 @@
   text-decoration: none;
 }
 .page-finder .finder-panel .body a.active ~ .active:hover .title {
-  color: #507CE1;
+  color: $yb-anchor-color;
 }
 
 .page-finder .finder-panel .body a.active ~ .active .title {

--- a/docs/content/preview/manage/backup-restore/_index.md
+++ b/docs/content/preview/manage/backup-restore/_index.md
@@ -15,6 +15,12 @@ menu:
 type: indexpage
 ---
 
+{{< page-finder/head text="Back Up and Restore" subtle="across different products">}}
+  {{< page-finder/list text="YugabyteDB" url="#test" icon="/icons/database-hover.svg" >}}
+  {{< page-finder/list text="YugabyteDB Anywhere" url="../../yugabyte-platform/back-up-restore-universes/" icon="/icons/server-hover.svg" >}}
+  {{< page-finder/list text="YugabyteDB Aeon" url="../../yugabyte-cloud/cloud-clusters/backup-clusters/" icon="/icons/cloud-hover.svg" >}}
+{{< /page-finder/head >}}
+
 Backup and restoration is the process of creating and storing copies of your data for protection against data loss. With a proper backup strategy, you can always restore your data to a most-recent known working state and minimize application downtime. This in turn guarantees business and application continuity.
 
 Unlike traditional single-instance databases, YugabyteDB is designed for fault tolerance. By maintaining at least three copies of your data across multiple data regions or multiple clouds, it makes sure no losses occur if a single node or single data region becomes unavailable. Thus, with YugabyteDB, you would mainly use backups to:

--- a/docs/content/preview/manage/backup-restore/_index.md
+++ b/docs/content/preview/manage/backup-restore/_index.md
@@ -16,9 +16,9 @@ type: indexpage
 ---
 
 {{< page-finder/head text="Back Up and Restore" subtle="across different products">}}
-  {{< page-finder/list text="YugabyteDB" url="#test" icon="/icons/database-hover.svg" >}}
-  {{< page-finder/list text="YugabyteDB Anywhere" url="../../yugabyte-platform/back-up-restore-universes/" icon="/icons/server-hover.svg" >}}
-  {{< page-finder/list text="YugabyteDB Aeon" url="../../yugabyte-cloud/cloud-clusters/backup-clusters/" icon="/icons/cloud-hover.svg" >}}
+  {{< page-finder/list icon="/icons/database-hover.svg" text="YugabyteDB" current="" >}}
+  {{< page-finder/list icon="/icons/server-hover.svg" text="YugabyteDB Anywhere" url="../../yugabyte-platform/back-up-restore-universes/" >}}
+  {{< page-finder/list icon="/icons/cloud-hover.svg" text="YugabyteDB Aeon" url="../../yugabyte-cloud/cloud-clusters/backup-clusters/" >}}
 {{< /page-finder/head >}}
 
 Backup and restoration is the process of creating and storing copies of your data for protection against data loss. With a proper backup strategy, you can always restore your data to a most-recent known working state and minimize application downtime. This in turn guarantees business and application continuity.

--- a/docs/content/preview/yugabyte-cloud/cloud-clusters/backup-clusters.md
+++ b/docs/content/preview/yugabyte-cloud/cloud-clusters/backup-clusters.md
@@ -12,9 +12,9 @@ type: docs
 ---
 
 {{< page-finder/head text="Back Up and Restore" subtle="across different products">}}
-  {{< page-finder/list text="YugabyteDB" url="../../../manage/backup-restore/" icon="/icons/database-hover.svg" >}}
-  {{< page-finder/list text="YugabyteDB Anywhere" url="../../../yugabyte-platform/back-up-restore-universes/" icon="/icons/server-hover.svg" >}}
-  {{< page-finder/list text="YugabyteDB Aeon" url="../../../yugabyte-cloud/cloud-clusters/backup-clusters/" icon="/icons/cloud-hover.svg" >}}
+  {{< page-finder/list icon="/icons/database-hover.svg" text="YugabyteDB" url="../../../manage/backup-restore/" >}}
+  {{< page-finder/list icon="/icons/server-hover.svg" text="YugabyteDB Anywhere" url="../../../yugabyte-platform/back-up-restore-universes/" >}}
+  {{< page-finder/list icon="/icons/cloud-hover.svg" text="YugabyteDB Aeon" current="" >}}
 {{< /page-finder/head >}}
 
 YugabyteDB Aeon can perform full and incremental cluster (all namespaces) level backups, and the backups are stored in the same region as your cluster.

--- a/docs/content/preview/yugabyte-cloud/cloud-clusters/backup-clusters.md
+++ b/docs/content/preview/yugabyte-cloud/cloud-clusters/backup-clusters.md
@@ -11,6 +11,12 @@ menu:
 type: docs
 ---
 
+{{< page-finder/head text="Back Up and Restore" subtle="across different products">}}
+  {{< page-finder/list text="YugabyteDB" url="../../../manage/backup-restore/" icon="/icons/database-hover.svg" >}}
+  {{< page-finder/list text="YugabyteDB Anywhere" url="../../../yugabyte-platform/back-up-restore-universes/" icon="/icons/server-hover.svg" >}}
+  {{< page-finder/list text="YugabyteDB Aeon" url="../../../yugabyte-cloud/cloud-clusters/backup-clusters/" icon="/icons/cloud-hover.svg" >}}
+{{< /page-finder/head >}}
+
 YugabyteDB Aeon can perform full and incremental cluster (all namespaces) level backups, and the backups are stored in the same region as your cluster.
 
 {{< youtube id="3qzAdrVFgxc" title="Back up and restore clusters in YugabyteDB Aeon" >}}

--- a/docs/content/preview/yugabyte-platform/back-up-restore-universes/_index.md
+++ b/docs/content/preview/yugabyte-platform/back-up-restore-universes/_index.md
@@ -17,6 +17,12 @@ weight: 650
 type: indexpage
 ---
 
+{{< page-finder/head text="Back Up and Restore" subtle="across different products">}}
+  {{< page-finder/list text="YugabyteDB" url="../../manage/backup-restore/" icon="/icons/database-hover.svg" >}}
+  {{< page-finder/list text="YugabyteDB Anywhere" url="" icon="/icons/server-hover.svg" >}}
+  {{< page-finder/list text="YugabyteDB Aeon" url="../../yugabyte-cloud/cloud-clusters/backup-clusters/" icon="/icons/cloud-hover.svg" >}}
+{{< /page-finder/head >}}
+
 You can use YugabyteDB to schedule and manage backups of your universe data. This includes the following features:
 
 - On-demand [backup](back-up-universe-data/) and [restore](restore-universe-data/).

--- a/docs/content/preview/yugabyte-platform/back-up-restore-universes/_index.md
+++ b/docs/content/preview/yugabyte-platform/back-up-restore-universes/_index.md
@@ -18,9 +18,9 @@ type: indexpage
 ---
 
 {{< page-finder/head text="Back Up and Restore" subtle="across different products">}}
-  {{< page-finder/list text="YugabyteDB" url="../../manage/backup-restore/" icon="/icons/database-hover.svg" >}}
-  {{< page-finder/list text="YugabyteDB Anywhere" url="" icon="/icons/server-hover.svg" >}}
-  {{< page-finder/list text="YugabyteDB Aeon" url="../../yugabyte-cloud/cloud-clusters/backup-clusters/" icon="/icons/cloud-hover.svg" >}}
+  {{< page-finder/list icon="/icons/database-hover.svg" text="YugabyteDB" url="../../manage/backup-restore/" >}}
+  {{< page-finder/list icon="/icons/server-hover.svg" text="YugabyteDB Anywhere" current="" >}}
+  {{< page-finder/list icon="/icons/cloud-hover.svg" text="YugabyteDB Aeon" url="../../yugabyte-cloud/cloud-clusters/backup-clusters/" >}}
 {{< /page-finder/head >}}
 
 You can use YugabyteDB to schedule and manage backups of your universe data. This includes the following features:

--- a/docs/layouts/shortcodes/page-finder/head.html
+++ b/docs/layouts/shortcodes/page-finder/head.html
@@ -2,7 +2,11 @@
   <div class="finder-panel">
     <div class="inner-container">
       <div class="head">
-        <p><b>{{- .Params.text -}}</b> &nbsp; {{- .Params.subtle -}} </p>
+        {{- if and (.Params.text) (.Params.subtle) -}}
+          <p><b>{{- .Params.text -}} &nbsp; &#x2192;</b> &nbsp; {{- .Params.subtle -}}</p>
+        {{- else -}}
+          <p><b>{{- .Params.text -}}</b></p>
+        {{- end -}}
       </div>
       <div class="body">{{ .Inner }}</div>
     </div>

--- a/docs/layouts/shortcodes/page-finder/head.html
+++ b/docs/layouts/shortcodes/page-finder/head.html
@@ -1,5 +1,5 @@
-<div class="content-area">
-  <div class="links-panels">
+<div class="page-finder">
+  <div class="finder-panel">
     <div class="inner-container">
       <div class="head">
         <p><b>{{- .Params.text -}}</b> &nbsp; {{- .Params.subtle -}} </p>

--- a/docs/layouts/shortcodes/page-finder/head.html
+++ b/docs/layouts/shortcodes/page-finder/head.html
@@ -3,7 +3,7 @@
     <div class="inner-container">
       <div class="head">
         {{- if and (.Params.text) (.Params.subtle) -}}
-          <p><b>{{- .Params.text -}} &nbsp; &#x2192;</b> &nbsp; {{- .Params.subtle -}}</p>
+          <p><b>{{- .Params.text }} &#x2192;</b> &nbsp; {{- .Params.subtle -}}</p>
         {{- else -}}
           <p><b>{{- .Params.text -}}</b></p>
         {{- end -}}

--- a/docs/layouts/shortcodes/page-finder/head.html
+++ b/docs/layouts/shortcodes/page-finder/head.html
@@ -1,0 +1,10 @@
+<div class="content-area">
+  <div class="links-panels">
+    <div class="inner-container">
+      <div class="head">
+        <p><b>{{- .Params.text -}}</b> &nbsp; {{- .Params.subtle -}} </p>
+      </div>
+      <div class="body">{{ .Inner }}</div>
+    </div>
+  </div>
+</div>

--- a/docs/layouts/shortcodes/page-finder/list.html
+++ b/docs/layouts/shortcodes/page-finder/list.html
@@ -1,11 +1,22 @@
-{{- $isFirst := eq .Ordinal 0 -}}
-<a href="{{- .Params.url -}}" title="{{- .Params.text -}}">
-  <span class="icon">
-    <img src="{{- .Params.icon -}}" alt="{{- .Params.text -}}" title="{{- .Params.text -}}" width="16" height="16">
-  </span>
-  <span class="title">{{- .Params.text -}}</span>
-
-  {{- if $isFirst -}}
-    {{- readFile "static/icons/bookmark.svg" | safeHTML -}}
+{{- if .Params.text -}}
+  {{- $isActive := false -}}
+  {{- if isset .Params "current" -}}
+    {{- $isActive = true -}}
   {{- end -}}
-</a>
+
+  {{- if $isActive -}}
+    <a role="button" class="active" title="{{- .Params.text -}}">
+  {{- else -}}
+    <a href="{{- .Params.url -}}" title="{{- .Params.text -}}">
+  {{- end -}}
+    <span class="icon">
+      {{- if .Params.icon -}}
+        <img src="{{- .Params.icon -}}" alt="{{- .Params.text -}}" title="{{- .Params.text -}}" width="16" height="16">
+      {{- end -}}
+    </span>
+    <span class="title">{{- .Params.text -}}</span>
+    {{- if $isActive -}}
+      {{- readFile "static/icons/bookmark.svg" | safeHTML -}}
+    {{- end -}}
+  </a>
+{{- end -}}

--- a/docs/layouts/shortcodes/page-finder/list.html
+++ b/docs/layouts/shortcodes/page-finder/list.html
@@ -1,0 +1,11 @@
+{{- $isFirst := eq .Ordinal 0 -}}
+<a href="{{- .Params.url -}}" title="{{- .Params.text -}}">
+  <span class="icon">
+    <img src="{{- .Params.icon -}}" alt="{{- .Params.text -}}" title="{{- .Params.text -}}" width="16" height="16">
+  </span>
+  <span class="title">{{- .Params.text -}}</span>
+
+  {{- if $isFirst -}}
+    {{- readFile "static/icons/bookmark.svg" | safeHTML -}}
+  {{- end -}}
+</a>

--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -1,13 +1,14 @@
 import Clipboard from 'clipboard';
 
 const $ = window.jQuery;
+const innerWidthsArray = [...document.querySelectorAll('.links-panels .inner-container')].map(el => ({ width: el.offsetWidth, parent: el.parentNode }));
 
 /**
  * Create Cookie.
  */
 function setCookie(name, value, monthToLive) {
   let cookie = `${name}=${encodeURIComponent(value)}; max-age=${(monthToLive * 30 * (24 * 60 * 60))}; path=/`;
-  if (location.hostname !== 'localhost') {
+  if (location.hostname !== 'localhost' || location.hostname !== '192.168.10.8') {
     cookie += '; secure=true';
   }
 
@@ -98,6 +99,26 @@ function yugabyteScrollLeftNav(activeLink) {
   setTimeout(() => {
     leftSidebar.style.overflow = 'auto';
   }, 600);
+}
+
+/**
+ * Function to calculate width for the page finder functionality.
+ */
+function yugabytePageFinderWidth(width) {
+  width.forEach((innerEach) => {
+    const parent = innerEach.parent;
+    if (parent) {
+      const innerContainer = document.querySelector('.content-area');
+      const width = innerEach.width;
+      if (width > innerContainer.offsetWidth) {
+        parent.classList.add('vertical');
+        parent.classList.remove('horizontal');
+      } else {
+        parent.classList.add('horizontal');
+        parent.classList.remove('vertical');
+      }
+    }
+  });
 }
 
 /**
@@ -246,6 +267,7 @@ $(document).ready(() => {
           maxWidth: mouseMoveX,
         });
         $('body').addClass('dragging');
+        yugabytePageFinderWidth(innerWidthsArray);
       });
     });
 
@@ -624,6 +646,13 @@ $(document).ready(() => {
       window.location.href = `/search/?q=${searchValue}`;
     }
   });
+
+  yugabytePageFinderWidth(innerWidthsArray);
+  document.querySelector('.side-nav-collapse-toggle-2').addEventListener('click', () => {
+    setTimeout(() => {
+      yugabytePageFinderWidth(innerWidthsArray);
+    }, 500);
+  });
 });
 
 $(window).resize(() => {
@@ -634,4 +663,5 @@ $(window).resize(() => {
   setTimeout(() => {
     setCookie('leftMenuWidth', 300, 3);
   }, 1000);
+  yugabytePageFinderWidth(innerWidthsArray);
 });

--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -1,6 +1,7 @@
 import Clipboard from 'clipboard';
 
 const $ = window.jQuery;
+let yugabytePageFinderList = [];
 
 /**
  * Create Cookie.
@@ -105,12 +106,10 @@ function yugabyteScrollLeftNav(activeLink) {
  * based on the container width.
  */
 function yugabytePageFinderWidth() {
-  document.querySelectorAll('.page-finder .finder-panel .inner-container').forEach((finderContainer) => {
-    if (finderContainer.parentNode) {
+  yugabytePageFinderList.forEach(({width, parent}) => {
+    if (parent) {
       const innerContainer = document.querySelector('.content-area');
-      const innerWidth = finderContainer.offsetWidth;
-      const parent = finderContainer.parentNode;
-      if (innerWidth > innerContainer.offsetWidth) {
+      if (width > innerContainer.offsetWidth) {
         parent.classList.add('vertical');
         parent.classList.remove('horizontal');
       } else {
@@ -176,6 +175,14 @@ $(document).ready(() => {
   const isSafari = /Safari/.test(navigator.userAgent) && /Apple Computer/.test(navigator.vendor);
   if (isSafari) {
     $('body').addClass('is-safari');
+  }
+
+  const pageFinderContainer = document.querySelectorAll('.page-finder .finder-panel .inner-container');
+  if (pageFinderContainer) {
+    yugabytePageFinderList = Array.from(pageFinderContainer).map((element) => ({
+      width: element.offsetWidth,
+      parent: element.parentElement,
+    }));
   }
 
   let searchValue = '';

--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -7,7 +7,7 @@ const $ = window.jQuery;
  */
 function setCookie(name, value, monthToLive) {
   let cookie = `${name}=${encodeURIComponent(value)}; max-age=${(monthToLive * 30 * (24 * 60 * 60))}; path=/`;
-  if (location.hostname !== 'localhost' || location.hostname !== '192.168.10.8') {
+  if (location.hostname !== 'localhost') {
     cookie += '; secure=true';
   }
 

--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -1,7 +1,6 @@
 import Clipboard from 'clipboard';
 
 const $ = window.jQuery;
-const innerWidthsArray = [...document.querySelectorAll('.links-panels .inner-container')].map(el => ({ width: el.offsetWidth, parent: el.parentNode }));
 
 /**
  * Create Cookie.
@@ -102,15 +101,16 @@ function yugabyteScrollLeftNav(activeLink) {
 }
 
 /**
- * Function to calculate width for the page finder functionality.
+ * Function to calculate and rotate "Page Finder" to horizontal or vertical design
+ * based on the container width.
  */
-function yugabytePageFinderWidth(width) {
-  width.forEach((innerEach) => {
-    const parent = innerEach.parent;
-    if (parent) {
+function yugabytePageFinderWidth() {
+  document.querySelectorAll('.page-finder .finder-panel .inner-container').forEach((finderContainer) => {
+    if (finderContainer.parentNode) {
       const innerContainer = document.querySelector('.content-area');
-      const width = innerEach.width;
-      if (width > innerContainer.offsetWidth) {
+      const innerWidth = finderContainer.offsetWidth;
+      const parent = finderContainer.parentNode;
+      if (innerWidth > innerContainer.offsetWidth) {
         parent.classList.add('vertical');
         parent.classList.remove('horizontal');
       } else {
@@ -267,7 +267,7 @@ $(document).ready(() => {
           maxWidth: mouseMoveX,
         });
         $('body').addClass('dragging');
-        yugabytePageFinderWidth(innerWidthsArray);
+        yugabytePageFinderWidth();
       });
     });
 
@@ -647,10 +647,10 @@ $(document).ready(() => {
     }
   });
 
-  yugabytePageFinderWidth(innerWidthsArray);
+  yugabytePageFinderWidth();
   document.querySelector('.side-nav-collapse-toggle-2').addEventListener('click', () => {
     setTimeout(() => {
-      yugabytePageFinderWidth(innerWidthsArray);
+      yugabytePageFinderWidth();
     }, 500);
   });
 });
@@ -663,5 +663,5 @@ $(window).resize(() => {
   setTimeout(() => {
     setCookie('leftMenuWidth', 300, 3);
   }, 1000);
-  yugabytePageFinderWidth(innerWidthsArray);
+  yugabytePageFinderWidth();
 });

--- a/docs/static/icons/bookmark.svg
+++ b/docs/static/icons/bookmark.svg
@@ -1,0 +1,9 @@
+<svg class="bookmark-icon" xmlns="http://www.w3.org/2000/svg" width="13" height="22" viewBox="0 0 13 22" fill="none">
+  <path d="M12.4 22L6.40002 16.4504L0.400024 22V1.58559C0.400024 0.70955 1.07127 0 1.90002 0H10.9C11.7288 0 12.4 0.70955 12.4 1.58559V22Z" fill="url(#paint0_linear_4417_299)"/>
+  <defs>
+    <linearGradient id="paint0_linear_4417_299" x1="6.40002" y1="0" x2="6.40002" y2="22" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#CBCCFB"/>
+      <stop offset="1" stop-color="#A5A6F6"/>
+    </linearGradient>
+  </defs>
+</svg>


### PR DESCRIPTION
Create a Hugo shortcode to convey that the workflow can be done in the other products (as applicable) and incorporating link to relevant page.

```md
{{< page-finder/head text="Back Up and Restore" subtle="across different products">}}
  {{< page-finder/list icon="/icons/database-hover.svg" text="YugabyteDB" current="" >}}
  {{< page-finder/list icon="/icons/server-hover.svg" text="YugabyteDB Anywhere" url="../../yugabyte-platform/back-up-restore-universes/" >}}
  {{< page-finder/list icon="/icons/cloud-hover.svg" text="YugabyteDB Aeon" url="../../yugabyte-cloud/cloud-clusters/backup-clusters/" >}}
{{< /page-finder/head >}}
```

<img width="832" alt="Screenshot 2025-03-05 at 4 50 58 PM" src="https://github.com/user-attachments/assets/a69e51ea-bd26-4ce2-8603-6d4cf8530c79" />
<img width="507" alt="Screenshot 2025-03-05 at 4 51 12 PM" src="https://github.com/user-attachments/assets/ceb94a90-0bc3-4fab-b560-67344dd39055" />
