### PR TITLE
[DOC-264][#26448] Add airgapped cloud provider node requirements

### DIFF
--- a/docs/content/preview/yugabyte-platform/configure-yugabyte-platform/azure.md
+++ b/docs/content/preview/yugabyte-platform/configure-yugabyte-platform/azure.md
@@ -178,6 +178,12 @@ To add your own machine images to the catalog:
 
 To edit custom Linux versions, remove Linux versions, and set a version as the default to use when creating universes, click **...** for the version you want to modify.
 
+    {{< warning title="Important" >}}
+
+Starting in version 2025.1 if you want to deploy an Azure universe in an airgapped environment you MUST provide your own Linux version.
+
+    {{< /warning >}}
+
 ### SSH Key Pairs
 
 To be able to provision cloud instances with YugabyteDB, YBA requires SSH access.

--- a/docs/content/preview/yugabyte-platform/prepare/server-nodes-software/_index.md
+++ b/docs/content/preview/yugabyte-platform/prepare/server-nodes-software/_index.md
@@ -104,3 +104,4 @@ Additionally, if not connected to the public Internet (that is, airgapped); and 
 - libatomic (for Redhat-based aarch64)
 - libatomic1, libncurses6 (for Debian-based aarch64)
 - chrony (for time synchronization). When using a Public Cloud Provider, chrony is the only choice. When using an On-Premises provider, chrony is recommended; ntpd and systemd-timesyncd are also supported.
+- polkit (for YBA versions including v2024.2 and later)

--- a/docs/content/stable/yugabyte-platform/prepare/server-nodes-software/_index.md
+++ b/docs/content/stable/yugabyte-platform/prepare/server-nodes-software/_index.md
@@ -101,3 +101,4 @@ Additionally, if not connected to the public Internet (that is, airgapped); and 
 - libatomic (for Redhat-based aarch64)
 - libatomic1, libncurses6 (for Debian-based aarch64)
 - chrony (for time synchronization). When using a Public Cloud Provider, chrony is the only choice. When using an On-Premises provider, chrony is recommended; ntpd and systemd-timesyncd are also supported.
+- polkit (for YBA versions including v2024.2 and later)


### PR DESCRIPTION
Adding different doc updates regarding airgapped environments.
1. Requiring polkit to be installed on any airgapped machine
2. Specifying that Azure default image in 2025.1+ is not suitable for airgapped and customer must provide their own image. 