### PR TITLE
Fix incorrect deleted row count

### DIFF
--- a/java/yb-pgsql/src/test/java/org/yb/pgsql/TestPgDelete.java
+++ b/java/yb-pgsql/src/test/java/org/yb/pgsql/TestPgDelete.java
@@ -238,4 +238,28 @@ public class TestPgDelete extends BasePgSQLTest {
       assertEquals(expectedRows, getSortedRowList(returning));
     }
   }
+
+  @Test
+  public void testBasicDelete3() throws SQLException {
+    String tableName = "test_basic_del3";
+    createSimpleTable(tableName);
+
+    // Fill in the table:
+    List<Row> expectedRows = new ArrayList<>();
+    try (Statement insert_stmt = connection.createStatement()) {
+      String insert_format = "INSERT INTO %s(h, r, vi) VALUES(%d, %d, %d)";
+      for (long h = 0; h < 3; h++) {
+        String insert_text = String.format(insert_format, tableName, 1, h, h);
+        insert_stmt.execute(insert_text);
+      }
+    }
+
+    // Verify RETURNING clause.
+    try (Statement statement = connection.createStatement()) {
+      int deletedRowCount  = statement.executeUpdate("DELETE FROM test_basic_del3 f1 "
+          + "USING test_basic_del3 f2 WHERE f1.r < f2.r and f1.h = f2.h;");
+
+      assertEquals(2, deletedRowCount);
+    }
+  }
 }

--- a/src/postgres/src/backend/executor/ybModifyTable.c
+++ b/src/postgres/src/backend/executor/ybModifyTable.c
@@ -914,11 +914,9 @@ YBCExecuteDelete(Relation rel,
 			CacheInvalidateCatalog(relid);
 		}
 	}
-
-	YBCExecWriteStmt(delete_stmt,
-					 rel,
-					 target_tuple_fetched ? NULL : &rows_affected_count);
-
+	int rows_affected_aux = 0;
+	YBCExecWriteStmt(delete_stmt, rel, &rows_affected_aux);
+	rows_affected_count += rows_affected_aux;
 	/*
 	 * Fetch values of the columns required to evaluate returning clause
 	 * expressions. They are put into the slot Postgres uses to evaluate
@@ -969,7 +967,7 @@ YBCExecuteDelete(Relation rel,
 	/* Cleanup. */
 	YBCPgDeleteStatement(delete_stmt);
 
-	return target_tuple_fetched || rows_affected_count > 0;
+	return rows_affected_count > 0;
 }
 
 void


### PR DESCRIPTION
The deleted row count was incorrect when using the `USING` clause. The problem was caused by the `target_tuple_fetched` variable always being set to true, preventing `rows_affected_count` from updating correctly and skipping the break statement. As a result, `es_processed` was not incremented as expected.

The fix involves introducing an auxiliary variable (`rows_affected_aux`) to store the number of rows affected by `YBCExecWriteStmt`. Then, this value is accumulated into `rows_affected_count`, ensuring accurate tracking.

Fix #25305