### PR TITLE
[docs] Remove `backup_daemon` from 2.20 docs because it's not available

### DIFF
--- a/docs/content/v2.20/reference/configuration/yugabyted.md
+++ b/docs/content/v2.20/reference/configuration/yugabyted.md
@@ -442,8 +442,6 @@ Use the `yugabyted start` command to start a one-node YugabyteDB cluster for run
 
 To use encryption in transit, OpenSSL must be installed on the nodes.
 
-If you want to use backup and restore, start the node with `--backup_daemon=true` to initialize the backup and restore agent. You also need to download and extract the [YB Controller release](https://downloads.yugabyte.com/ybc/2.1.0.0-b9/ybc-2.1.0.0-b9-linux-x86_64.tar.gz) to the yugabyte-{{< yb-version version="v2.20" >}} release directory.
-
 #### Syntax
 
 ```text
@@ -513,10 +511,6 @@ For on-premises deployments, consider racks as zones to treat them as fault doma
 
 --read_replica *read_replica_node*
 : Use this flag to start a read replica node.
-
---backup_daemon *backup-daemon-process*
-: Enable or disable the backup daemon with yugabyted start. Default: `false`
-: If you start a cluster using the `--backup_daemon` flag, you also need to download and extract the [YB Controller release](https://downloads.yugabyte.com/ybc/2.1.0.0-b9/ybc-2.1.0.0-b9-linux-x86_64.tar.gz) to the yugabyte-{{< yb-version version="v2.20" >}} release directory.
 
 --enable_pg_parity_early_access *PostgreSQL-compatibilty*
 : Enable Enhanced PostgreSQL Compatibility Mode. Default: `false`


### PR DESCRIPTION
Looks like `backup_daemon` is only available in 2.21+ after checking source code and releases https://github.com/yugabyte/yugabyte-db/issues/18416

This was added mistakenly in this commit https://github.com/yugabyte/yugabyte-db/pull/24425/files#diff-0e3061a60df89f868758027263270653dc1ac6bb20b5f9ead17c8dfb3e752594.