### PR TITLE
Fix constraint error when moving rows between partitions

### DIFF
--- a/src/postgres/src/backend/executor/nodeModifyTable.c
+++ b/src/postgres/src/backend/executor/nodeModifyTable.c
@@ -2440,12 +2440,6 @@ yb_lreplace:;
 	HeapTuple	tuple = ExecFetchSlotHeapTuple(slot, true /* materialize */ , NULL);
 
 	/*
-	 * Check the constraints of the tuple.
-	 */
-	if (resultRelationDesc->rd_att->constr)
-		ExecConstraints(resultRelInfo, slot, estate, context->mtstate);
-
-	/*
 	 * If partition constraint fails, this row might get moved to another
 	 * partition, in which case we should check the RLS CHECK policy just
 	 * before inserting into the new partition, rather than doing it here.
@@ -2552,6 +2546,12 @@ yb_lreplace:;
 		slot = context->cpUpdateRetrySlot;
 		goto yb_lreplace;
 	}
+
+	/*
+	 * Check the constraints of the tuple.
+	 */
+	if (resultRelationDesc->rd_att->constr)
+		ExecConstraints(resultRelInfo, slot, estate, context->mtstate);
 
 	bool		row_found = false;
 	bool		beforeRowUpdateTriggerFired = (resultRelInfo->ri_TrigDesc &&


### PR DESCRIPTION
When trying to move a row across partitions of the same partitioned table, the constraints of the source partition were checked before determining whether the row would remain in it after the update, potentially leading to an incorrect constraint violation.

The fix involves only checking constraint violations on the source partition after confirming that the update did not cause the row to move to another partition.

Fix #25911 