### PR TITLE
[doc] Add db clone to CREATE DATABASE railroad diagram

### DIFF
--- a/docs/content/preview/api/ysql/syntax_resources/ysql_grammar.ebnf
+++ b/docs/content/preview/api/ysql/syntax_resources/ysql_grammar.ebnf
@@ -489,6 +489,9 @@ create_cast_with_inout = 'CREATE' 'CAST' '(' cast_signature ')'
 cast_signature = source_type 'AS' target_type ;
 
 (* 'CREATE' 'DATABASE' *)
+clone_timestamp = timestamp
+                | positive_int_literal ;
+
 create_database = 'CREATE' 'DATABASE' name [ create_database_options ] ;
 
 create_database_options =  [ 'WITH' ] [ 'OWNER' [ '=' ] user_name ]  \
@@ -499,7 +502,8 @@ create_database_options =  [ 'WITH' ] [ 'OWNER' [ '=' ] user_name ]  \
                              [ 'ALLOW_CONNECTIONS' [ '=' ] allowconn ]  \
                              [ 'CONNECTION' 'LIMIT' [ '=' ] connlimit ]  \
                              [ 'IS_TEMPLATE' [ '=' ] istemplate ] \
-                             [ 'COLOCATION' [ '=' ] ('true' | 'false') ] ;
+                             [ 'COLOCATION' [ '=' ] ('true' | 'false') ] \
+                             [ 'AS OF' [ '=' ] clone_timestamp ] ;
 
 user_name = name ;
 template_name = name ;

--- a/docs/content/preview/api/ysql/syntax_resources/ysql_grammar.ebnf
+++ b/docs/content/preview/api/ysql/syntax_resources/ysql_grammar.ebnf
@@ -489,8 +489,10 @@ create_cast_with_inout = 'CREATE' 'CAST' '(' cast_signature ')'
 cast_signature = source_type 'AS' target_type ;
 
 (* 'CREATE' 'DATABASE' *)
-clone_timestamp = timestamp
-                | positive_int_literal ;
+timestamptz_string = '<DateTime Literal>' ;
+unix_timestamp_microseconds = positive_int_literal ;
+clone_timestamp = timestamptz_string
+                | unix_timestamp_microseconds ;
 
 create_database = 'CREATE' 'DATABASE' name [ create_database_options ] ;
 

--- a/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_database.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/ddl_create_database.md
@@ -70,6 +70,10 @@ Specify `true` if tables (and their indexes) for this database should be colocat
 
 Default is `false` and every table in the database will have its own set of tablets.
 
+### AS OF
+
+Specify the [Unix timestamp](https://www.unixtimestamp.com/) (in microseconds) to create a clone of the original database at a specific point in time, within the history retention period specified when creating the snapshot schedule for the database. See [Instant database cloning](../../../../../manage/backup-restore/instant-db-cloning/).
+
 ## Examples
 
 ### Create a colocated database

--- a/docs/content/stable/api/ysql/syntax_resources/ysql_grammar.ebnf
+++ b/docs/content/stable/api/ysql/syntax_resources/ysql_grammar.ebnf
@@ -479,6 +479,11 @@ create_cast_with_inout = 'CREATE' 'CAST' '(' cast_signature ')'
 cast_signature = source_type 'AS' target_type ;
 
 (* 'CREATE' 'DATABASE' *)
+timestamptz_string = '<DateTime Literal>' ;
+unix_timestamp_microseconds = positive_int_literal ;
+clone_timestamp = timestamptz_string
+                | unix_timestamp_microseconds ;
+
 create_database = 'CREATE' 'DATABASE' name [ create_database_options ] ;
 
 create_database_options =  [ 'WITH' ] [ 'OWNER' [ '=' ] user_name ]  \
@@ -489,7 +494,8 @@ create_database_options =  [ 'WITH' ] [ 'OWNER' [ '=' ] user_name ]  \
                              [ 'ALLOW_CONNECTIONS' [ '=' ] allowconn ]  \
                              [ 'CONNECTION' 'LIMIT' [ '=' ] connlimit ]  \
                              [ 'IS_TEMPLATE' [ '=' ] istemplate ] \
-                             [ 'COLOCATION' [ '=' ] ('true' | 'false') ] ;
+                             [ 'COLOCATION' [ '=' ] ('true' | 'false') ] \
+                             [ 'AS OF' [ '=' ] clone_timestamp ] ;
 
 user_name = name ;
 template_name = name ;

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_database.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_database.md
@@ -70,6 +70,10 @@ Specify `true` if tables (and their indexes) for this database should be colocat
 
 Default is `false` and every table in the database will have its own set of tablets.
 
+### AS OF
+
+Specify the [Unix timestamp](https://www.unixtimestamp.com/) (in microseconds) to create a clone of the original database at a specific point in time, within the history retention period specified when creating the snapshot schedule for the database. See [Instant database cloning](../../../../../manage/backup-restore/instant-db-cloning/).
+
 ## Examples
 
 ### Create a colocated database


### PR DESCRIPTION
Adds `CREATE DATABASE ... AS OF <timestamp>` syntax to the railroad diagram for `CREATE DATABASE`.