### PR TITLE
Resolve logger warnings

### DIFF
--- a/managed/devops/opscli/ybops/cloud/aws/cloud.py
+++ b/managed/devops/opscli/ybops/cloud/aws/cloud.py
@@ -149,7 +149,7 @@ class AwsCloud(AbstractCloud):
             except ClientError as e:
                 code = e.response['Error']['Code']
                 if code == 'AuthFailure' and args.ignore_auth_failure:
-                    logging.warn("Ignoring error: {}".format(str(e)))
+                    logging.warning("Ignoring error: {}".format(str(e)))
                 else:
                     raise e
 
@@ -270,7 +270,7 @@ class AwsCloud(AbstractCloud):
 
     def get_current_host_info(self, args):
         """This method would fetch current host information by calling AWS metadata api
-        to fetch requested metatdata's.
+        to fetch requested metadata's.
         """
         try:
             metadata = {}
@@ -406,7 +406,7 @@ class AwsCloud(AbstractCloud):
             server_tags = None
             launched_by_tags = None
             if data.get("Tags") is not None:
-                # Server Type is an optinal flag only for cluster servers.
+                # Server Type is an optional flag only for cluster servers.
                 server_tags = [t["Value"] for t in data["Tags"] if t["Key"] == "yb-server-type"]
                 name_tags = [t["Value"] for t in data["Tags"] if t["Key"] == "Name"]
                 launched_by_tags = [t["Value"] for t in data["Tags"] if t["Key"] == "launched-by"]
@@ -567,7 +567,7 @@ class AwsCloud(AbstractCloud):
         waiter.wait(VolumeIds=[vol_id])
 
     def get_disk(self, host_info, vol_id, args):
-        logging.info("Retreiving volume {} from host {}".format(vol_id, host_info['id']))
+        logging.info("Retrieving volume {} from host {}".format(vol_id, host_info['id']))
         ec2 = boto3.client('ec2', region_name=host_info['region'])
         try:
             response = ec2.describe_volumes(VolumeIds=[vol_id])

--- a/managed/devops/opscli/ybops/cloud/aws/cloud.py
+++ b/managed/devops/opscli/ybops/cloud/aws/cloud.py
@@ -270,7 +270,7 @@ class AwsCloud(AbstractCloud):
 
     def get_current_host_info(self, args):
         """This method would fetch current host information by calling AWS metadata api
-        to fetch requested metadata's.
+        to fetch requested metadata.
         """
         try:
             metadata = {}

--- a/managed/devops/opscli/ybops/cloud/azure/utils.py
+++ b/managed/devops/opscli/ybops/cloud/azure/utils.py
@@ -740,7 +740,7 @@ class AzureCloudAdmin():
             disk_del.wait()
             logging.info("[app] Deleted disk {}".format(disk_name))
 
-        logging.info("[app] Sucessfully destroyed orphaned resources for {}".format(vm_name))
+        logging.info("[app] Successfully destroyed orphaned resources for {}".format(vm_name))
 
     def change_instance_type(self, vm_name, instance_type, cloud_instance_types=[]):
         vm = self.compute_client.virtual_machines.get(RESOURCE_GROUP, vm_name)
@@ -811,7 +811,7 @@ class AzureCloudAdmin():
             disk_del.wait()
             logging.info("[app] Deleted disk {}".format(disk_name))
 
-        logging.info("[app] Sucessfully destroyed instance {}".format(vm_name))
+        logging.info("[app] Successfully destroyed instance {}".format(vm_name))
 
     def get_subnet_id(self, vnet, subnet):
         # subnet URN can be used directly
@@ -947,7 +947,7 @@ class AzureCloudAdmin():
                         "name": image_identifier["sku"],
                     }
             if plan is None:
-                logging.warn("Plan info absent from the following VM image: " + str(image))
+                logging.warning("Plan info absent from the following VM image: " + str(image))
         else:
             # machine image URN - "OpenLogic:CentOS:7_8:7.8.2020051900"
             pub, offer, sku, version = image.split(':')

--- a/managed/devops/opscli/ybops/cloud/common/method.py
+++ b/managed/devops/opscli/ybops/cloud/common/method.py
@@ -364,7 +364,7 @@ class AbstractInstancesMethod(AbstractMethod):
                 "node_agent_ip": host_info["private_ip"],
                 "node_agent_port": self.extra_vars["node_agent_port"]
             }
-        raise YBOpsRuntimeError("Unknown connction type: {}".format(connection_type))
+        raise YBOpsRuntimeError("Unknown connection type: {}".format(connection_type))
 
     def get_server_ports_to_check(self, args):
         server_ports = []
@@ -1569,7 +1569,7 @@ class ConfigureInstancesMethod(AbstractInstancesMethod):
         if args.local_package_path:
             self.extra_vars.update({"local_package_path": args.local_package_path})
         else:
-            logging.warn("Local Directory Tarball Path not specified skipping")
+            logging.warning("Local Directory Tarball Path not specified skipping")
             return
 
         if args.install_third_party_packages:
@@ -2173,7 +2173,7 @@ class RunHooks(AbstractInstancesMethod):
         remove_command = "rm " + os.path.join(args.remote_tmp_dir, os.path.basename(args.hook_path))
         rc, _, stderr = remote_exec_command(self.extra_vars, remove_command)
         if rc:
-            logging.warn("Failed deleting custom hook:\n" + ''.join(stderr))
+            logging.warning("Failed deleting custom hook:\n" + ''.join(stderr))
 
 
 class WaitForConnection(AbstractInstancesMethod):

--- a/managed/devops/opscli/ybops/cloud/common/method.py
+++ b/managed/devops/opscli/ybops/cloud/common/method.py
@@ -1569,7 +1569,7 @@ class ConfigureInstancesMethod(AbstractInstancesMethod):
         if args.local_package_path:
             self.extra_vars.update({"local_package_path": args.local_package_path})
         else:
-            logging.warning("Local Directory Tarball Path not specified skipping")
+            logging.warning("Local Directory Tarball Path not specified; skipping")
             return
 
         if args.install_third_party_packages:

--- a/managed/devops/opscli/ybops/cloud/common/utils.py
+++ b/managed/devops/opscli/ybops/cloud/common/utils.py
@@ -35,7 +35,7 @@ def request_retry_decorator(fn_to_call, exc_handler):
                 if i < MAX_ATTEMPTS and exc_handler(e):
                     sleep_duration_sec = \
                         SLEEP_SEC_MIN + random.random() * (SLEEP_SEC_MAX - SLEEP_SEC_MIN)
-                    logging.warn(
+                    logging.warning(
                         "API call failed, waiting for {} seconds before re-trying (this was attempt"
                         " {} out of {}).".format(sleep_duration_sec, i, MAX_ATTEMPTS))
                     time.sleep(sleep_duration_sec)

--- a/managed/devops/opscli/ybops/cloud/gcp/cloud.py
+++ b/managed/devops/opscli/ybops/cloud/gcp/cloud.py
@@ -301,7 +301,7 @@ class GcpCloud(AbstractCloud):
                                                                                result[name]["numCores"],
                                                                                result[name]["isShared"])
                     except Exception as e:
-                        logging.warn("[app] Error {} getting price info for {}".format(e, name))
+                        logging.warning("[app] Error {} getting price info for {}".format(e, name))
                         result[name]["prices"][region] = 0.0
         to_delete_instance_types = []
         for name in result:

--- a/python/yugabyte/common_util.py
+++ b/python/yugabyte/common_util.py
@@ -256,7 +256,7 @@ def get_yb_src_root_from_build_root(
                     yb_src_root, build_dir)
     else:
         error_msg = "Could not find git repository root by walking up from %s" % build_dir
-        logging.warn(error_msg)
+        logging.warning(error_msg)
         if must_succeed:
             raise RuntimeError(error_msg)
 

--- a/python/yugabyte/kill_long_running_minicluster_daemons.py
+++ b/python/yugabyte/kill_long_running_minicluster_daemons.py
@@ -51,7 +51,7 @@ def main() -> None:
 
         match = PS_OUTPUT_LINE_RE.match(line)
         if not match:
-            logging.warn("Could not parse ps output line: %s", line)
+            logging.warning("Could not parse ps output line: %s", line)
             continue
 
         num_processes_found += 1

--- a/python/yugabyte/lto.py
+++ b/python/yugabyte/lto.py
@@ -227,7 +227,7 @@ def find_shared_lib_from_static(static_lib_path: str) -> str:
     assert is_static_lib(static_lib_path)
     shared_lib_path = static_lib_path[:-2] + '.so'
     if not os.path.exists(shared_lib_path):
-        logging.warn("Shared library path does not exist: %s", shared_lib_path)
+        logging.warning("Shared library path does not exist: %s", shared_lib_path)
     return shared_lib_path
 
 

--- a/scripts/installation/bin/yb-ctl
+++ b/scripts/installation/bin/yb-ctl
@@ -303,7 +303,7 @@ def download_file(url, dest_path):
                 remote_file.close()
     except:  # noqa
         if os.path.exists(dest_path):
-            logging.warn("Deleting the unfinished download: %s", dest_path)
+            logging.warning("Deleting the unfinished download: %s", dest_path)
             os.remove(dest_path)
         raise
 


### PR DESCRIPTION
# PR Summary
This PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
It also fixes a few typos along the way.