### PR TITLE
[Docs] Fix flag tags height with icon

### DIFF
--- a/docs/assets/scss/_yb_tags.scss
+++ b/docs/assets/scss/_yb_tags.scss
@@ -49,7 +49,7 @@
         background: url(/icons/t-server.svg) center no-repeat;
         width: 18px;
         height: 18px;
-        margin-right: 4px;
+        margin: -1px 4px -1px 0px;
       }
     }
 


### PR DESCRIPTION
Flag tags should have a 24px height. With or without icon. Seems like in the implementation adding an icon is also making the tag taller.
![CleanShot 2025-05-26 at 21 30 26@2x](https://github.com/user-attachments/assets/c9190b6f-5ca7-41b6-bc9d-b3aca66b0a94)
