### PR TITLE
[Docs] Allow indentation in the code block inside table shortcode

### DIFF
--- a/docs/assets/scss/_code_block.scss
+++ b/docs/assets/scss/_code_block.scss
@@ -65,15 +65,15 @@ main {
     > pre,
     .highlight {
       margin: 20px 0;
-	  position: relative;
-	  display: flex;
-	  flex-direction: column;
-	  min-width: 0;
-	  word-wrap: break-word;
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+      word-wrap: break-word;
       background-color: #fff;
-	  background-clip: border-box;
-	  border: 1px solid rgba(0, 0, 0, .125);
-	  border-radius: .25rem;
+      background-clip: border-box;
+      border: 1px solid rgba(0, 0, 0, .125);
+      border-radius: .25rem;
     }
 
     li > p + pre,
@@ -230,6 +230,16 @@ main {
       pre {
         > code {
           white-space: pre-line !important;
+        }
+      }
+    }
+
+    div.custom-yb-table {
+      table {
+        pre > code {
+          > span {
+            white-space: pre;
+          }
         }
       }
     }

--- a/docs/assets/scss/_tables.scss
+++ b/docs/assets/scss/_tables.scss
@@ -20,15 +20,15 @@ main {
         display: table;
 
         @media (max-width:900px) {
-          min-width:650px;
+          min-width: 650px;
         }
 
         tbody {
-          border-bottom:0;
+          border-bottom: 0;
 
           tr:last-child {
             td {
-              border-bottom:0px;
+              border-bottom: 0;
             }
           }
         }
@@ -48,7 +48,7 @@ main {
     .table > :not(caption) > * > *,
     .td-table:not(.td-initial) > :not(caption) > * > *,
     .td-content table:not(.td-initial) > :not(caption) > * > *,
-    .td-box table:not(.td-initial) > :not(caption) > * > *{
+    .td-box table:not(.td-initial) > :not(caption) > * > * {
       padding: 12.75px 15px;
     }
 
@@ -61,7 +61,6 @@ main {
       background-color: transparent;
       border-width: 0;
     }
-
 
     table {
       box-shadow: 0 0 0 1px #e9eef2;

--- a/docs/layouts/shortcodes/table.html
+++ b/docs/layouts/shortcodes/table.html
@@ -51,7 +51,7 @@
             {{- $row = print $row "|" $cell -}}
         {{- end -}}
     {{- end -}}
-    {{- replace (replace (markdownify $table) ";-vert-;" "|") "\x01" "\n" | markdownify  -}}
+    <div class="custom-yb-table">{{- replace (replace (markdownify $table) ";-vert-;" "|") "\x01" "\n" | markdownify  -}}</div>
     {{- /* warnf "%s" (replace (replace (markdownify $table) ";-vert-;" "|") "\x01" "\n" | markdownify ) */ -}}
 {{- else -}}
     {{- warnf "empty table in [%q]" $.Page.Permalink -}}


### PR DESCRIPTION
Currently, table short code allows adding code block in between the columns. However in short code, it doesn't respect the indentation if there are any in the code block. 

This PR fixes this issue and allows indentation inside code block under table short code.
