### PR TITLE
[tserver] Add YSQL enabled check to UpgradeYsql and corresponding test (#27167)

### DIFF
--- a/src/yb/integration-tests/upgrade-tests/ysql_major_upgrade-test.cc
+++ b/src/yb/integration-tests/upgrade-tests/ysql_major_upgrade-test.cc
@@ -118,6 +118,15 @@ TEST_F(YsqlMajorUpgradeTest, CheckVersion) {
 
 TEST_F(YsqlMajorUpgradeTest, SimpleTableUpgrade) { ASSERT_OK(TestUpgradeWithSimpleTable()); }
 
+TEST_F(YsqlMajorUpgradeTest, YsqlNotEnabled) {
+  auto old_flag = FLAGS_enable_ysql;
+  FLAGS_enable_ysql = false;
+  auto status = client_->UpgradeYsql();
+  ASSERT_NOK(status);
+  ASSERT_STR_CONTAINS(status.ToString(), "YSQL is not enabled");
+  FLAGS_enable_ysql = old_flag;
+}
+
 TEST_F(YsqlMajorUpgradeTest, SimpleTableRollback) {
   ASSERT_OK(TestRollbackWithSimpleTable());
 

--- a/src/yb/tserver/tablet_service.cc
+++ b/src/yb/tserver/tablet_service.cc
@@ -2300,6 +2300,13 @@ void TabletServiceAdminImpl::UpgradeYsql(
     rpc::RpcContext context) {
   LOG(INFO) << "Starting YSQL upgrade";
 
+  if(!FLAGS_enable_ysql) {
+    const auto status = STATUS(IllegalState, "YSQL is not enabled");
+    LOG(INFO) << "YSQL upgrade failed: " << status;
+    SetupErrorAndRespond(resp->mutable_error(), status, &context);
+    return;
+  }
+
   pgwrapper::YsqlUpgradeHelper upgrade_helper(server_->pgsql_proxy_bind_address(),
                                               server_->GetSharedMemoryPostgresAuthKey(),
                                               FLAGS_heartbeat_interval_ms,


### PR DESCRIPTION
This PR addresses issue #27167.

- Added an early exit check in `TabletServiceAdminImpl::UpgradeYsql` to handle the case when YSQL is not enabled.
- Added a corresponding integration test in `YsqlMajorUpgradeTest` to verify correct behavior when YSQL is disabled.
- Unable to fully verify locally due to macOS build environment conflicts, but submitting for alternative validation. 