### PR TITLE
[DOC-804][v2025.1] Remove k82 limitation for export of audit logs

### DIFF
--- a/docs/content/v2025.1/yugabyte-platform/alerts-monitoring/universe-logging.md
+++ b/docs/content/v2025.1/yugabyte-platform/alerts-monitoring/universe-logging.md
@@ -30,7 +30,6 @@ If you want to set pgaudit.log_level to a [severity level](https://www.postgresq
 
 ## Limitations
 
-- Kubernetes universes are not supported.
 - Only YSQL database audit logs can be exported, not YCQL.
 
 ## Best practices


### PR DESCRIPTION
Remove k82 limitation for export of audit logs

@netlify /v2025.1/yugabyte-platform/alerts-monitoring/universe-logging/#limitations