### PR TITLE
[DOC-760] Tweak pgcron text

### DIFF
--- a/docs/content/preview/explore/ysql-language-features/pg-extensions/extension-pgcron.md
+++ b/docs/content/preview/explore/ysql-language-features/pg-extensions/extension-pgcron.md
@@ -21,15 +21,13 @@ If the pg_cron leader node fails, another node is automatically elected as the n
 
 Before you can use the feature, you must set the `enable_pg_cron` flag to true on all YB-Masters and YB-TServers. This starts the pg_cron PostgreSQL background worker for the extension.
 
-The pg_cron extension is installed on only one database, which stores the extension data. The default cron database is `yugabyte`. You can change it by setting the `ysql_cron_database_name` flag on all YB-TServers. You can create the database after setting the flag.
+The pg_cron extension is installed on only one database, which stores the extension data. The default cron database is `yugabyte`. You can change it by setting the `ysql_cron_database_name` flag on all YB-TServers. You can create the database after setting the flag. To change the database after the extension is created, you must first _drop the extension_ and then change the flag value.
 
 For example, to create a single-node [yugabyted](../../../../reference/configuration/yugabyted/) cluster with pg_cron on database 'db1', use the following command:
 
 ```sh
 ./bin/yugabyted start --master_flags "enable_pg_cron=true" --tserver_flags "enable_pg_cron=true,ysql_cron_database_name=db1" --ui false
 ```
-
-To change the database after the extension is created, you must first drop the extension and then change the flag value.
 
 ## Enable pg_cron
 

--- a/docs/content/stable/explore/ysql-language-features/pg-extensions/extension-pgcron.md
+++ b/docs/content/stable/explore/ysql-language-features/pg-extensions/extension-pgcron.md
@@ -21,15 +21,13 @@ If the pg_cron leader node fails, another node is automatically elected as the n
 
 Before you can use the feature, you must set the `enable_pg_cron` flag to true on all YB-Masters and YB-TServers. This starts the pg_cron PostgreSQL background worker for the extension.
 
-The pg_cron extension is installed on only one database, which stores the extension data. The default cron database is `yugabyte`. You can change it by setting the `ysql_cron_database_name` flag on all YB-TServers. You can create the database after setting the flag.
+The pg_cron extension is installed on only one database, which stores the extension data. The default cron database is `yugabyte`. You can change it by setting the `ysql_cron_database_name` flag on all YB-TServers. You can create the database after setting the flag. To change the database after the extension is created, you must first _drop the extension_ and then change the flag value.
 
 For example, to create a single-node [yugabyted](../../../../reference/configuration/yugabyted/) cluster with pg_cron on database 'db1', use the following command:
 
 ```sh
 ./bin/yugabyted start --master_flags "enable_pg_cron=true" --tserver_flags "enable_pg_cron=true,ysql_cron_database_name=db1" --ui false
 ```
-
-To change the database after the extension is created, you must first drop the extension and then change the flag value.
 
 ## Enable pg_cron
 

--- a/docs/content/v2025.1/explore/ysql-language-features/pg-extensions/extension-pgcron.md
+++ b/docs/content/v2025.1/explore/ysql-language-features/pg-extensions/extension-pgcron.md
@@ -21,15 +21,13 @@ If the pg_cron leader node fails, another node is automatically elected as the n
 
 Before you can use the feature, you must set the `enable_pg_cron` flag to true on all YB-Masters and YB-TServers. This starts the pg_cron PostgreSQL background worker for the extension.
 
-The pg_cron extension is installed on only one database, which stores the extension data. The default cron database is `yugabyte`. You can change it by setting the `ysql_cron_database_name` flag on all YB-TServers. You can create the database after setting the flag.
+The pg_cron extension is installed on only one database, which stores the extension data. The default cron database is `yugabyte`. You can change it by setting the `ysql_cron_database_name` flag on all YB-TServers. You can create the database after setting the flag. To change the database after the extension is created, you must first _drop the extension_ and then change the flag value.
 
 For example, to create a single-node [yugabyted](../../../../reference/configuration/yugabyted/) cluster with pg_cron on database 'db1', use the following command:
 
 ```sh
 ./bin/yugabyted start --master_flags "enable_pg_cron=true" --tserver_flags "enable_pg_cron=true,ysql_cron_database_name=db1" --ui false
 ```
-
-To change the database after the extension is created, you must first drop the extension and then change the flag value.
 
 ## Enable pg_cron
 


### PR DESCRIPTION
The recommendation is to first drop the extension and then change the cron database name. Already present, tweaked text to make it more prominent

@netlify /preview/explore/ysql-language-features/pg-extensions/extension-pgcron/#set-up-pg-cron