### PR TITLE
Fix edit page URL for child pages underneath

### DIFF
--- a/docs/layouts/partials/contribute_list.html
+++ b/docs/layouts/partials/contribute_list.html
@@ -1,3 +1,10 @@
+{{ $editPage := "" }}
+{{ $changeFilePath := "" }}
+{{ if not .File.Path }}
+  {{- $editPage = "https://github.com/yugabyte/yugabyte-db/tree/master/docs/content/ADD_FILE_PATH_HERE" -}}
+  {{- $changeFilePath = " contribute-edit-file-path" -}}
+{{- end -}}
+
 <div class="dropdown dropdown-list" id="contribute-list">
   <ul class="navbar-nav mt-2 mt-lg-0">
     <li class="nav-item dropdown mr-4 d-none d-lg-block">
@@ -13,7 +20,7 @@
         <a class="dropdown-item" href="https://github.com/yugabyte/yugabyte-db/issues/new?title=%5BDocs%5D+New+docs+proposal&labels=area/documentation&template=docs.yml" title="Suggest new content" target="_blank" rel="noopener">
           Suggest new content
         </a>
-        <a class="dropdown-item" href="https://github.com/yugabyte/yugabyte-db/tree/master/docs/content/{{ .File.Path }}" title="Edit this page" target="_blank" rel="noopener">
+        <a class="dropdown-item{{$changeFilePath}}" href="https://github.com/yugabyte/yugabyte-db/tree/master/docs/content/{{ .File.Path }}"{{- if $editPage }} data-git="{{ $editPage }}"{{- end }} title="Edit this page" target="_blank" rel="noopener">
           Edit this page
         </a>
         <a class="dropdown-item" href="/preview/contribute/docs/" title="Contributor guide" target="_blank" rel="noopener">

--- a/docs/layouts/partials/navbar.html
+++ b/docs/layouts/partials/navbar.html
@@ -27,7 +27,7 @@
   {{ $startNow = .Site.Menus.start_now }}
 {{- end -}}
 
-<nav id="nav_bar" class="js-navbar-scroll navbar navbar-expand navbar-dark flex-column td-navbar">
+<nav id="nav_bar" class="js-navbar-scroll navbar navbar-expand navbar-dark flex-column td-navbar"{{- if (and .File .File.Path) }} data-file="{{ .File.Path }}"{{ end -}}>
   <div class="container-fluid top-nav">
     {{- if .Site.Params.ui.navbar_logo -}}
       {{- if .Site.Params.yb.navbar_logo.url -}}

--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -183,6 +183,7 @@ function rightnavAutoScroll() {
 }
 
 $(document).ready(() => {
+  console.log('ready ....');
   const isSafari = /Safari/.test(navigator.userAgent) && /Apple Computer/.test(navigator.vendor);
   if (isSafari) {
     $('body').addClass('is-safari');
@@ -260,6 +261,21 @@ $(document).ready(() => {
       $('body').removeClass('hidden-scroll');
       $('.mobile-search').toggleClass('open');
     });
+  })();
+
+  (() => {
+    const contributeEditFilePath = document.querySelector('.contribute-edit-file-path');
+    if (contributeEditFilePath) {
+      const gitURL = contributeEditFilePath.getAttribute('data-git');
+      if (gitURL && gitURL.indexOf('ADD_FILE_PATH_HERE') !== -1) {
+        const navBar = document.getElementById('nav_bar');
+        const filePath = navBar.getAttribute('data-file');
+        if (filePath) {
+          const newEditUrl = gitURL.replace('ADD_FILE_PATH_HERE', filePath);
+          contributeEditFilePath.setAttribute('href', newEditUrl);
+        }
+      }
+    }
   })();
 
   /**


### PR DESCRIPTION
The "Contribute-> Edit this page" option is working for index pages, but not for child pages underneath. Example - [TPC-C Benchmark on YugabyteDB](https://docs.yugabyte.com/preview/benchmark/tpcc/) works and navigates correctly to its source file on GitHub - https://github.com/yugabyte/yugabyte-db/blob/master/docs/content/preview/benchmark/tpcc/_index.md, but [Run the TPC-C performance benchmark](https://docs.yugabyte.com/preview/benchmark/tpcc/running-tpcc/) takes me only to https://github.com/yugabyte/yugabyte-db/tree/master/docs/content/.