### PR TITLE
[DOC-825] [2025.1] [EA->GA] Active session history changes

### DIFF
--- a/docs/content/preview/explore/observability/active-session-history.md
+++ b/docs/content/preview/explore/observability/active-session-history.md
@@ -4,6 +4,8 @@ headerTitle: Active Session History
 linkTitle: Active Session History
 description: Use Active Session History to get current and past views of the database system activity.
 headcontent: Get real-time and historical information about active sessions to analyze and troubleshoot performance issues
+tags:
+  feature: early-access
 menu:
   preview:
     identifier: ash
@@ -105,7 +107,7 @@ SELECT * FROM pg_catalog.yb_servers() WHERE uuid = <top_level_node_id>;
 ```
 
 ``` output
-     host     | port | num_connections | node_type | cloud |  region   |    zone    | public_ip |               uuid               
+     host     | port | num_connections | node_type | cloud |  region   |    zone    | public_ip |               uuid
 --------------+------+-----------------+-----------+-------+-----------+------------+-----------+----------------------------------
  10.9.111.111 | 5433 |               0 | primary   | aws   | us-west-2 | us-west-2a |           | 5cac7c86ba4e4f0e838bf180d75bcad5
 ```

--- a/docs/content/preview/releases/ybdb-releases/v2.25.md
+++ b/docs/content/preview/releases/ybdb-releases/v2.25.md
@@ -721,7 +721,7 @@ As part of this release, we have upgraded our PostgreSQL fork from version 11.2 
 
 This feature significantly simplifies tuning poorly performing SQL queries by allowing you to capture and export detailed diagnostic information, including bind variables and constants, pg_stat_statements statistics, schema details, active session history, and execution plans. Refer to [Query diagnostics](../../../explore/query-1-performance/query-diagnostics/).
 
-**Active session history** {{<tags/feature/ea>}}
+**Active session history** {{<tags/feature/ea idea="830">}}
 
 In addition, the Active Session History, which provides real-time and historical views of system activity, is now enabled by default. For more information, refer to [Active Session History](../../../explore/observability/active-session-history/).
 

--- a/docs/content/preview/releases/ybdb-releases/v2.25.md
+++ b/docs/content/preview/releases/ybdb-releases/v2.25.md
@@ -721,7 +721,7 @@ As part of this release, we have upgraded our PostgreSQL fork from version 11.2 
 
 This feature significantly simplifies tuning poorly performing SQL queries by allowing you to capture and export detailed diagnostic information, including bind variables and constants, pg_stat_statements statistics, schema details, active session history, and execution plans. Refer to [Query diagnostics](../../../explore/query-1-performance/query-diagnostics/).
 
-**Active session history**
+**Active session history** {{<tags/feature/ea>}}
 
 In addition, the Active Session History, which provides real-time and historical views of system activity, is now enabled by default. For more information, refer to [Active Session History](../../../explore/observability/active-session-history/).
 


### PR DESCRIPTION
Verify that - 2.25 docs has the EA badge. No changes needed for 2025.1.
@netlify /preview/explore/observability/active-session-history/