### PR TITLE
[docs] CDC: Update docs related to CDC and xcluster usage

### DIFF
--- a/docs/content/preview/develop/change-data-capture/using-logical-replication/_index.md
+++ b/docs/content/preview/develop/change-data-capture/using-logical-replication/_index.md
@@ -103,7 +103,7 @@ For reference documentation, see [YugabyteDB Connector](./yugabytedb-connector/)
 
 - There should be a primary key on the table you want to stream the changes from.
 
-- CDC is not supported on tables (both source and target) for xCluster replication. Issues [25371](https://github.com/yugabyte/yugabyte-db/issues/25371) and [15534](https://github.com/yugabyte/yugabyte-db/issues/15534).
+- CDC is not supported on xCluster target universe [15534](https://github.com/yugabyte/yugabyte-db/issues/15534). However, both CDC and xCluster can work simultaneously on the same source universe.
 
 - Currently, CDC doesn't support schema evolution for changes that require table rewrites (for example, [ALTER TYPE](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-type-with-table-rewrite)), or DROP TABLE and TRUNCATE TABLE operations after the replication slot is created. However, you can perform these operations before creating the replication slot without any issues.
 

--- a/docs/content/preview/develop/change-data-capture/using-yugabytedb-grpc-replication/_index.md
+++ b/docs/content/preview/develop/change-data-capture/using-yugabytedb-grpc-replication/_index.md
@@ -58,7 +58,7 @@ For reference documentation, see [YugabyteDB gRPC Connector](./debezium-connecto
 
 * A single stream can only be used to stream data from one namespace only.
 * There should be a primary key on the table you want to stream the changes from.
-* CDC is not supported on tables (both source and target) for xCluster replication. Issues [25371](https://github.com/yugabyte/yugabyte-db/issues/25371) and [15534](https://github.com/yugabyte/yugabyte-db/issues/15534).
+* CDC is not supported on xCluster target universe [15534](https://github.com/yugabyte/yugabyte-db/issues/15534). However, both CDC and xCluster can work simultaneously on the same source universe.
 * Currently, CDC doesn't support schema evolution for changes that require table rewrites (for example, [ALTER TYPE](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-type-with-table-rewrite)), or DROP TABLE and TRUNCATE TABLE operations.
 * YCQL tables aren't currently supported. Issue [11320](https://github.com/yugabyte/yugabyte-db/issues/11320).
 * [Composite types](../../../explore/ysql-language-features/data-types#composite-types) are currently not supported. Issue [25221](https://github.com/yugabyte/yugabyte-db/issues/25221).

--- a/docs/content/stable/develop/change-data-capture/using-logical-replication/_index.md
+++ b/docs/content/stable/develop/change-data-capture/using-logical-replication/_index.md
@@ -101,7 +101,7 @@ For reference documentation, see [YugabyteDB Connector](./yugabytedb-connector/)
 
 - There should be a primary key on the table you want to stream the changes from.
 
-- CDC is not supported on tables (both source and target) for xCluster replication. Issues [25371](https://github.com/yugabyte/yugabyte-db/issues/25371) and [15534](https://github.com/yugabyte/yugabyte-db/issues/15534).
+- CDC is not supported on xCluster target universe [15534](https://github.com/yugabyte/yugabyte-db/issues/15534). However, both CDC and xCluster can work simultaneously on the same source universe.
 
 - Currently, CDC doesn't support schema evolution for changes that require table rewrites (for example, [ALTER TYPE](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-type-with-table-rewrite)), or DROP TABLE and TRUNCATE TABLE operations after the replication slot is created. However, you can perform these operations before creating the replication slot without any issues.
 

--- a/docs/content/stable/develop/change-data-capture/using-yugabytedb-grpc-replication/_index.md
+++ b/docs/content/stable/develop/change-data-capture/using-yugabytedb-grpc-replication/_index.md
@@ -55,7 +55,7 @@ For reference documentation, see [YugabyteDB gRPC Connector](./debezium-connecto
 
 * A single stream can only be used to stream data from one namespace only.
 * There should be a primary key on the table you want to stream the changes from.
-* CDC is not supported on tables (both source and target) for xCluster replication. Issues [25371](https://github.com/yugabyte/yugabyte-db/issues/25371) and [15534](https://github.com/yugabyte/yugabyte-db/issues/15534).
+* CDC is not supported on xCluster target universe [15534](https://github.com/yugabyte/yugabyte-db/issues/15534). However, both CDC and xCluster can work simultaneously on the same source universe.
 * Currently, CDC doesn't support schema evolution for changes that require table rewrites (for example, [ALTER TYPE](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-type-with-table-rewrite)), or DROP TABLE and TRUNCATE TABLE operations.
 * YCQL tables aren't currently supported. Issue [11320](https://github.com/yugabyte/yugabyte-db/issues/11320).
 * If a row is updated or deleted in the same transaction in which it was inserted, CDC cannot retrieve the before-image values for the UPDATE / DELETE event. If the replica identity is not CHANGE, then CDC will throw an error while processing such events.

--- a/docs/content/v2025.1/develop/change-data-capture/using-logical-replication/_index.md
+++ b/docs/content/v2025.1/develop/change-data-capture/using-logical-replication/_index.md
@@ -101,7 +101,7 @@ For reference documentation, see [YugabyteDB Connector](./yugabytedb-connector/)
 
 - There should be a primary key on the table you want to stream the changes from.
 
-- CDC is not supported on tables (both source and target) for xCluster replication. Issues [25371](https://github.com/yugabyte/yugabyte-db/issues/25371) and [15534](https://github.com/yugabyte/yugabyte-db/issues/15534).
+- CDC is not supported on xCluster target universe [15534](https://github.com/yugabyte/yugabyte-db/issues/15534). However, both CDC and xCluster can work simultaneously on the same source universe.
 
 - Currently, CDC doesn't support schema evolution for changes that require table rewrites (for example, [ALTER TYPE](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-type-with-table-rewrite)), or DROP TABLE and TRUNCATE TABLE operations after the replication slot is created. However, you can perform these operations before creating the replication slot without any issues.
 

--- a/docs/content/v2025.1/develop/change-data-capture/using-yugabytedb-grpc-replication/_index.md
+++ b/docs/content/v2025.1/develop/change-data-capture/using-yugabytedb-grpc-replication/_index.md
@@ -55,7 +55,7 @@ For reference documentation, see [YugabyteDB gRPC Connector](./debezium-connecto
 
 * A single stream can only be used to stream data from one namespace only.
 * There should be a primary key on the table you want to stream the changes from.
-* CDC is not supported on tables (both source and target) for xCluster replication. Issues [25371](https://github.com/yugabyte/yugabyte-db/issues/25371) and [15534](https://github.com/yugabyte/yugabyte-db/issues/15534).
+* CDC is not supported on xCluster target universe [15534](https://github.com/yugabyte/yugabyte-db/issues/15534). However, both CDC and xCluster can work simultaneously on the same source universe.
 * Currently, CDC doesn't support schema evolution for changes that require table rewrites (for example, [ALTER TYPE](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-type-with-table-rewrite)), or DROP TABLE and TRUNCATE TABLE operations.
 * YCQL tables aren't currently supported. Issue [11320](https://github.com/yugabyte/yugabyte-db/issues/11320).
 * [Composite types](../../../explore/ysql-language-features/data-types#composite-types) are currently not supported. Issue [25221](https://github.com/yugabyte/yugabyte-db/issues/25221).


### PR DESCRIPTION
This PR updates the limitations regarding the simultaneous use of CDC and xCluster. CDC and xCluster are supported simultaneously from the same source but not from the target universe.