### PR TITLE
[DOC-359][yba] Sign in after HA failover

### DIFF
--- a/docs/content/preview/yugabyte-platform/administer-yugabyte-platform/high-availability.md
+++ b/docs/content/preview/yugabyte-platform/administer-yugabyte-platform/high-availability.md
@@ -206,7 +206,7 @@ When possible, only promote a standby when both standby and active are on the sa
 
 1. Click **Continue**. The restore takes a few seconds, after which expect to be signed out.
 
-1. Sign in using the credentials that you had configured on the previously active instance.
+1. Sign in using the credentials that you had configured on the previously active instance. If you are performing failover, you must sign in using your Super Admin account.
 
 In cases of failover, the previous active instance may be unavailable or unreachable during promotion. In this case, you must perform a force promotion that will promote the standby without demoting the active as per the following illustration:
 
@@ -303,6 +303,7 @@ The following HA-related [alerts](../../alerts-monitoring/alert/) are automatica
 ## Limitations
 
 - No automatic failover. If the active instance fails, follow the steps in [Promote a standby instance to active](#promote-a-standby-instance-to-active).
+- When performing failover, the first time you sign in after failover, you must use you Super Admin account.
 - Promotion will fail when HA is configured with an active instance at YBA version earlier than 2024.1, and a standby instance at version 2024.1 or later. It is not recommended to run in this configuration for an extended period. Reach out to {{% support-platform %}} if this is required.
 - If you are making API calls to YBA through custom automation, note that the [API token](../../anywhere-automation/#authentication) is different on the YBA active and standby until the standby has been promoted at least once to be an active instance. If you are using YBA with an API token, either generate a new token before every request, or perform a switchover after generating the API token (this process will have to be repeated when the API token is regenerated).
 - If you have an older Replicated installation that uses HTTP, the default port is 80. Use `http` when specifying addresses.

--- a/docs/content/preview/yugabyte-platform/administer-yugabyte-platform/high-availability.md
+++ b/docs/content/preview/yugabyte-platform/administer-yugabyte-platform/high-availability.md
@@ -303,7 +303,7 @@ The following HA-related [alerts](../../alerts-monitoring/alert/) are automatica
 ## Limitations
 
 - No automatic failover. If the active instance fails, follow the steps in [Promote a standby instance to active](#promote-a-standby-instance-to-active).
-- When performing failover, the first time you sign in after failover, you must use you Super Admin account.
+- When performing failover, the first time you sign in after failover, you must use your Super Admin account.
 - Promotion will fail when HA is configured with an active instance at YBA version earlier than 2024.1, and a standby instance at version 2024.1 or later. It is not recommended to run in this configuration for an extended period. Reach out to {{% support-platform %}} if this is required.
 - If you are making API calls to YBA through custom automation, note that the [API token](../../anywhere-automation/#authentication) is different on the YBA active and standby until the standby has been promoted at least once to be an active instance. If you are using YBA with an API token, either generate a new token before every request, or perform a switchover after generating the API token (this process will have to be repeated when the API token is regenerated).
 - If you have an older Replicated installation that uses HTTP, the default port is 80. Use `http` when specifying addresses.

--- a/docs/content/stable/yugabyte-platform/administer-yugabyte-platform/high-availability.md
+++ b/docs/content/stable/yugabyte-platform/administer-yugabyte-platform/high-availability.md
@@ -203,7 +203,7 @@ When possible, only promote a standby when both standby and active are on the sa
 
 1. Click **Continue**. The restore takes a few seconds, after which expect to be signed out.
 
-1. Sign in using the credentials that you had configured on the previously active instance.
+1. Sign in using the credentials that you had configured on the previously active instance. If you are performing failover, you must sign in using your Super Admin account.
 
 In cases of failover, the previous active instance may be unavailable or unreachable during promotion. In this case, you must perform a force promotion that will promote the standby without demoting the active as per the following illustration:
 
@@ -300,6 +300,7 @@ The following HA-related [alerts](../../alerts-monitoring/alert/) are automatica
 ## Limitations
 
 - No automatic failover. If the active instance fails, follow the steps in [Promote a standby instance to active](#promote-a-standby-instance-to-active).
+- When performing failover, the first time you sign in after failover, you must use your Super Admin account.
 - Promotion will fail when HA is configured with an active instance at YBA version earlier than 2024.1, and a standby instance at version 2024.1 or later. It is not recommended to run in this configuration for an extended period. Reach out to {{% support-platform %}} if this is required.
 - If you are making API calls to YBA through custom automation, note that the [API token](../../anywhere-automation/#authentication) is different on the YBA active and standby until the standby has been promoted at least once to be an active instance. If you are using YBA with an API token, either generate a new token before every request, or perform a switchover after generating the API token (this process will have to be repeated when the API token is regenerated).
 - If you have an older Replicated installation that uses HTTP, the default port is 80. Use `http` when specifying addresses.

--- a/docs/content/v2.20/yugabyte-platform/administer-yugabyte-platform/high-availability.md
+++ b/docs/content/v2.20/yugabyte-platform/administer-yugabyte-platform/high-availability.md
@@ -151,7 +151,7 @@ You can make a standby instance active as follows:
 
 1. Click **Continue**. The restore takes a few seconds, after which expect to be signed out.
 
-1. Sign in using the credentials that you had configured on the previously active instance.
+1. Sign in using the credentials that you had configured on the previously active instance. If you are performing failover, you must sign in using your Super Admin account.
 
 You should be able to see that all of the data has been restored into the instance, including universes, users, metrics, alerts, task history, cloud providers, and so on.
 
@@ -243,6 +243,7 @@ After you have returned a standby instance to standalone mode, the information o
 ## Limitations
 
 - No automatic failover. If the active instance fails, follow the steps in [Promote a standby instance to active](#promote-a-standby-instance-to-active).
+- When performing failover, the first time you sign in after failover, you must use your Super Admin account.
 - The last backup time updates regardless of successful synchronization. To validate that backups are running, check the YBA logs for errors during synchronization.
 - After promotion, you may be unable to sign in to the new active instance for under a minute. You can wait and then reload the page, or you can restart the newly active YBA.
 - If you have a reverse proxy in front of the standby or primary instance (such as a Kubernetes ingress or a load balancer), ensure that it does not limit large requests. For example, if you are using nginx ingress, you might need to set the following annotations in your ingress specification to raise the default limit to 100 MB:

--- a/docs/content/v2024.1/yugabyte-platform/administer-yugabyte-platform/high-availability.md
+++ b/docs/content/v2024.1/yugabyte-platform/administer-yugabyte-platform/high-availability.md
@@ -203,7 +203,7 @@ When possible, only promote a standby when both standby and active are on the sa
 
 1. Click **Continue**. The restore takes a few seconds, after which expect to be signed out.
 
-1. Sign in using the credentials that you had configured on the previously active instance.
+1. Sign in using the credentials that you had configured on the previously active instance. If you are performing failover, you must sign in using your Super Admin account.
 
 In cases of failover, the previous active instance may be unavailable or unreachable during promotion. In this case, you must perform a force promotion that will promote the standby without demoting the active as per the following illustration:
 
@@ -300,6 +300,7 @@ The following HA-related [alerts](../../alerts-monitoring/alert/) are automatica
 ## Limitations
 
 - No automatic failover. If the active instance fails, follow the steps in [Promote a standby instance to active](#promote-a-standby-instance-to-active).
+- When performing failover, the first time you sign in after failover, you must use your Super Admin account.
 - Promotion will fail when HA is configured with an active instance at YBA version earlier than 2024.1, and a standby instance at version 2024.1 or later. It is not recommended to run in this configuration for an extended period. Reach out to {{% support-platform %}} if this is required.
 - If you are making API calls to YBA through custom automation, note that the [API token](../../anywhere-automation/#authentication) is different on the YBA active and standby until the standby has been promoted at least once to be an active instance. If you are using YBA with an API token, either generate a new token before every request, or perform a switchover after generating the API token (this process will have to be repeated when the API token is regenerated).
 - If you have an older Replicated installation that uses HTTP, the default port is 80. Use `http` when specifying addresses.

--- a/docs/content/v2025.1/yugabyte-platform/administer-yugabyte-platform/high-availability.md
+++ b/docs/content/v2025.1/yugabyte-platform/administer-yugabyte-platform/high-availability.md
@@ -203,7 +203,7 @@ When possible, only promote a standby when both standby and active are on the sa
 
 1. Click **Continue**. The restore takes a few seconds, after which expect to be signed out.
 
-1. Sign in using the credentials that you had configured on the previously active instance.
+1. Sign in using the credentials that you had configured on the previously active instance. If you are performing failover, you must sign in using your Super Admin account.
 
 In cases of failover, the previous active instance may be unavailable or unreachable during promotion. In this case, you must perform a force promotion that will promote the standby without demoting the active as per the following illustration:
 
@@ -300,6 +300,7 @@ The following HA-related [alerts](../../alerts-monitoring/alert/) are automatica
 ## Limitations
 
 - No automatic failover. If the active instance fails, follow the steps in [Promote a standby instance to active](#promote-a-standby-instance-to-active).
+- When performing failover, the first time you sign in after failover, you must use your Super Admin account.
 - Promotion will fail when HA is configured with an active instance at YBA version earlier than 2024.1, and a standby instance at version 2024.1 or later. It is not recommended to run in this configuration for an extended period. Reach out to {{% support-platform %}} if this is required.
 - If you are making API calls to YBA through custom automation, note that the [API token](../../anywhere-automation/#authentication) is different on the YBA active and standby until the standby has been promoted at least once to be an active instance. If you are using YBA with an API token, either generate a new token before every request, or perform a switchover after generating the API token (this process will have to be repeated when the API token is regenerated).
 - If you have an older Replicated installation that uses HTTP, the default port is 80. Use `http` when specifying addresses.


### PR DESCRIPTION
Sign in after HA failover must use Super User

@netlify /preview/yugabyte-platform/administer-yugabyte-platform/high-availability/#promote-a-standby-instance-to-active