### PR TITLE
[DOC-866] Added warning to avoid using REPLACE for tables with secondary indexes

### DIFF
--- a/docs/content/preview/api/ysql/the-sql-language/statements/cmd_copy.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/cmd_copy.md
@@ -103,12 +103,12 @@ First 3000 rows will be persisted to the table and `tuples_processed` will show 
 
 The REPLACE option replaces the existing row in the table if the new row's primary/unique key conflicts with that of the existing row.
 
-Note that REPLACE doesn't work on tables that have more than 1 unique constraints (see [#13687](https://github.com/yugabyte/yugabyte-db/issues/13687)).
+Note that REPLACE doesn't work on tables that have more than 1 unique constraint (see [#13687](https://github.com/yugabyte/yugabyte-db/issues/13687)).
 
 Default: by default conflict error is reported.
 
-{{< warning title="Avoid using REPLACE if the target table has any secondary indexes." >}}
-If the table has secondary indexes a workaround is to COPY (without REPLACE) data into a temporary table, and then use [`INSERT ... ON CONFLICT`](../dml_insert/#on-conflict-clause) to transfer data from the temporary table to the target table.
+{{< warning title="Avoid using REPLACE if the target table has secondary indexes." >}}
+If the table has secondary indexes, a workaround is to COPY (without REPLACE) data into a temporary table, and then use [`INSERT ... ON CONFLICT`](../dml_insert/#on-conflict-clause) to transfer data from the temporary table to the target table.
 {{< /warning >}}
 
 ### DISABLE_FK_CHECK

--- a/docs/content/preview/api/ysql/the-sql-language/statements/cmd_copy.md
+++ b/docs/content/preview/api/ysql/the-sql-language/statements/cmd_copy.md
@@ -103,9 +103,13 @@ First 3000 rows will be persisted to the table and `tuples_processed` will show 
 
 The REPLACE option replaces the existing row in the table if the new row's primary/unique key conflicts with that of the existing row.
 
-Note that REPLACE doesn't work on tables that have more than 1 unique constraints (see [#13687](https://github.com/yugabyte/yugabyte-db/issues/13687) for explanation)
+Note that REPLACE doesn't work on tables that have more than 1 unique constraints (see [#13687](https://github.com/yugabyte/yugabyte-db/issues/13687)).
 
 Default: by default conflict error is reported.
+
+{{< warning title="Avoid using REPLACE if the target table has any secondary indexes." >}}
+If the table has secondary indexes a workaround is to COPY (without REPLACE) data into a temporary table, and then use [`INSERT ... ON CONFLICT`](../dml_insert/#on-conflict-clause) to transfer data from the temporary table to the target table.
+{{< /warning >}}
 
 ### DISABLE_FK_CHECK
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/cmd_copy.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/cmd_copy.md
@@ -95,9 +95,13 @@ First 3000 rows will be persisted to the table and `tuples_processed` will show 
 
 The `REPLACE` option replaces the existing row in the table if the new row's primary/unique key conflicts with that of the existing row.
 
-Note that `REPLACE` doesn't work on tables that have more than 1 unique constraints (see [#13687](https://github.com/yugabyte/yugabyte-db/issues/13687) for explanation)
+Note that REPLACE doesn't work on tables that have more than 1 unique constraint (see [#13687](https://github.com/yugabyte/yugabyte-db/issues/13687)).
 
 Default: by default conflict error is reported.
+
+{{< warning title="Avoid using REPLACE if the target table has secondary indexes." >}}
+If the table has secondary indexes, a workaround is to COPY (without REPLACE) data into a temporary table, and then use [`INSERT ... ON CONFLICT`](../dml_insert/#on-conflict-clause) to transfer data from the temporary table to the target table.
+{{< /warning >}}
 
 ### DISABLE_FK_CHECK
 

--- a/docs/content/v2.20/api/ysql/the-sql-language/statements/cmd_copy.md
+++ b/docs/content/v2.20/api/ysql/the-sql-language/statements/cmd_copy.md
@@ -95,9 +95,13 @@ First 3000 rows will be persisted to the table and `tuples_processed` will show 
 
 The `REPLACE` option replaces the existing row in the table if the new row's primary/unique key conflicts with that of the existing row.
 
-Note that `REPLACE` doesn't work on tables that have more than 1 unique constraints (see [#13687](https://github.com/yugabyte/yugabyte-db/issues/13687) for explanation)
+Note that REPLACE doesn't work on tables that have more than 1 unique constraint (see [#13687](https://github.com/yugabyte/yugabyte-db/issues/13687)).
 
 Default: by default conflict error is reported.
+
+{{< warning title="Avoid using REPLACE if the target table has secondary indexes." >}}
+If the table has secondary indexes, a workaround is to COPY (without REPLACE) data into a temporary table, and then use [`INSERT ... ON CONFLICT`](../dml_insert/#on-conflict-clause) to transfer data from the temporary table to the target table.
+{{< /warning >}}
 
 ### DISABLE_FK_CHECK
 

--- a/docs/content/v2024.1/api/ysql/the-sql-language/statements/cmd_copy.md
+++ b/docs/content/v2024.1/api/ysql/the-sql-language/statements/cmd_copy.md
@@ -95,9 +95,13 @@ First 3000 rows will be persisted to the table and `tuples_processed` will show 
 
 The `REPLACE` option replaces the existing row in the table if the new row's primary/unique key conflicts with that of the existing row.
 
-Note that `REPLACE` doesn't work on tables that have more than 1 unique constraints (see [#13687](https://github.com/yugabyte/yugabyte-db/issues/13687) for explanation)
+Note that REPLACE doesn't work on tables that have more than 1 unique constraint (see [#13687](https://github.com/yugabyte/yugabyte-db/issues/13687)).
 
 Default: by default conflict error is reported.
+
+{{< warning title="Avoid using REPLACE if the target table has secondary indexes." >}}
+If the table has secondary indexes, a workaround is to COPY (without REPLACE) data into a temporary table, and then use [`INSERT ... ON CONFLICT`](../dml_insert/#on-conflict-clause) to transfer data from the temporary table to the target table.
+{{< /warning >}}
 
 ### DISABLE_FK_CHECK
 

--- a/docs/content/v2025.1/api/ysql/the-sql-language/statements/cmd_copy.md
+++ b/docs/content/v2025.1/api/ysql/the-sql-language/statements/cmd_copy.md
@@ -101,9 +101,13 @@ First 3000 rows will be persisted to the table and `tuples_processed` will show 
 
 The REPLACE option replaces the existing row in the table if the new row's primary/unique key conflicts with that of the existing row.
 
-Note that REPLACE doesn't work on tables that have more than 1 unique constraints (see [#13687](https://github.com/yugabyte/yugabyte-db/issues/13687) for explanation)
+Note that REPLACE doesn't work on tables that have more than 1 unique constraint (see [#13687](https://github.com/yugabyte/yugabyte-db/issues/13687)).
 
 Default: by default conflict error is reported.
+
+{{< warning title="Avoid using REPLACE if the target table has secondary indexes." >}}
+If the table has secondary indexes, a workaround is to COPY (without REPLACE) data into a temporary table, and then use [`INSERT ... ON CONFLICT`](../dml_insert/#on-conflict-clause) to transfer data from the temporary table to the target table.
+{{< /warning >}}
 
 ### DISABLE_FK_CHECK
 


### PR DESCRIPTION
@netlify /preview/api/ysql/the-sql-language/statements/cmd_copy/#replace