### PR TITLE
[Docs] Specify container hostname in Docker quick-start

### DIFF
--- a/docs/content/preview/tutorials/quick-start/docker.md
+++ b/docs/content/preview/tutorials/quick-start/docker.md
@@ -141,7 +141,7 @@ In the preceding `docker run` command, the data stored in YugabyteDB does not pe
 - Run Docker with the volume mount option by executing the following command:
 
   ```sh
-  docker run -d --name yugabyte \
+  docker run -d --name yugabyte --hostname yugabyte \
            -p 7000:7000 -p 9000:9000 -p 15433:15433 -p 5433:5433 -p 9042:9042 \
            -v ~/yb_data:/home/yugabyte/yb_data \
            yugabytedb/yugabyte:latest bin/yugabyted start \
@@ -156,6 +156,12 @@ In the preceding `docker run` command, the data stored in YugabyteDB does not pe
 yugabyted uses `$HOME/var` by default to store data, configurations, and logs. You can change the base directory when starting a cluster using the `--base_dir` flag. If you change the base directory, you _must_ specify the base directory using the `--base-dir` flag when running subsequent commands on the cluster.
 
 For example, to get the status of the cluster you just created, you would enter `bin/yugabyted status --base_dir=/home/yugabyte/yb_data`.
+{{< /note >}}
+
+{{< note title="Hostname" >}}
+
+It is important to use a static container hostname to avoid startup errors if the hostname changes, such as when recreating the container with the same volume.
+
 {{< /note >}}
 
 ## Connect to the database


### PR DESCRIPTION
This PR adds the `--hostname` flag to the [persistent Docker](https://docs.yugabyte.com/preview/tutorials/quick-start/docker/#run-docker-in-a-persistent-volume) example, in order to prevent the `socket.gaierror: [Errno -2] Name or service not known` startup error from occurring if the hostname ever changes, such as when removing and re-creating the container with an existing volume/config.

It also adds an information note explaining this.