### PR TITLE
Unify yb tools argument syntax to double dash

### DIFF
--- a/docs/content/preview/admin/yb-admin.md
+++ b/docs/content/preview/admin/yb-admin.md
@@ -21,10 +21,10 @@ To use yb-admin from the YugabyteDB home directory, run `./bin/yb-admin` using t
 
 ```sh
 yb-admin \
-    [ -master_addresses <master-addresses> ]  \
-    [ -init_master_addrs <master-address> ]  \
-    [ -timeout_ms <millisec> ] \
-    [ -certs_dir_name <dir-name> ] \
+    [ --master_addresses <master-addresses> ]  \
+    [ --init_master_addrs <master-address> ]  \
+    [ --timeout_ms <millisec> ] \
+    [ --certs_dir_name <dir-name> ] \
     <command> [ command_flags ]
 ```
 
@@ -73,7 +73,7 @@ Gets the configuration for the universe.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_universe_config
 ```
 
@@ -87,7 +87,7 @@ Changes the configuration of a tablet.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     change_config <tablet-id> \
     [ ADD_SERVER | REMOVE_SERVER ] \
     <peer-uuid> \
@@ -117,7 +117,7 @@ Changes the master configuration.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     change_master_config \
     [ ADD_SERVER|REMOVE_SERVER ] \
     <ip-addr> <port> \
@@ -138,7 +138,7 @@ yb-admin \
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_tablet_servers <tablet-id>
 ```
 
@@ -155,7 +155,7 @@ Use this to find out who the LEADER of a tablet is.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_tablets <keyspace-type>.<keyspace-name> <table> [<max-tablets>]
 ```
 
@@ -169,7 +169,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     list_tablets ysql.db_name table_name 0
 ```
 
@@ -187,7 +187,7 @@ Lists all tablet servers.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_all_tablet_servers
 ```
 
@@ -201,7 +201,7 @@ Displays a list of all YB-Master servers in a table listing the master UUID, RPC
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_all_masters
 ```
 
@@ -211,7 +211,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses node7:7100,node8:7100,node9:7100 \
+    --master_addresses node7:7100,node8:7100,node9:7100 \
     list_all_masters
 ```
 
@@ -230,7 +230,7 @@ Prints a list of replica types and counts for the specified table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_replica_type_counts <keyspace> <table-name>
 ```
 
@@ -246,7 +246,7 @@ Prints the status of the YB-Master servers.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     dump_masters_state
 ```
 
@@ -260,7 +260,7 @@ List the locations of the tablet server logs.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_tablet_server_log_locations
 ```
 
@@ -274,7 +274,7 @@ Lists all tablets for the specified tablet server (YB-TServer).
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_tablets_for_tablet_server <ts-uuid>
 ```
 
@@ -287,7 +287,7 @@ Splits the specified hash-sharded tablet and computes the split point as the mid
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     split_tablet <tablet-id-to-split>
 ```
 
@@ -315,7 +315,7 @@ Forces the master leader to step down. The specified YB-Master node will take it
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     master_leader_stepdown [ <new-leader-id> ]
 ```
 
@@ -330,7 +330,7 @@ Prints the current YSQL schema catalog version.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     ysql_catalog_version
 ```
 
@@ -340,7 +340,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     ysql_catalog_version
 ```
 
@@ -362,14 +362,14 @@ Prints a list of all tables. Optionally, include the database type, table ID, an
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_tables \
     [ include_db_type ] [ include_table_id ] [ include_table_type ]
 ```
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> list_tables
+    --master_addresses <master-addresses> list_tables
 ```
 
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default is `localhost:7100`.
@@ -399,7 +399,7 @@ To display a list of tables and their UUID (`table_id`) values, open the **YB-Ma
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     list_tables
 ```
 
@@ -434,7 +434,7 @@ Triggers manual compaction on a table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     compact_table <db-type>.<namespace> <table> [<timeout-in-seconds>] [ADD_INDEXES]
 ```
 
@@ -449,7 +449,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     compact_table ysql.yugabyte table_name
 ```
 
@@ -461,7 +461,7 @@ Compacted [yugabyte.table_name] tables.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     compact_table tableid.<table-id> [<timeout-in-seconds>] [ADD_INDEXES]
 ```
 
@@ -474,7 +474,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     compact_table tableid.000033eb000030008000000000004002
 ```
 
@@ -488,7 +488,7 @@ Show the status of full compaction on a table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     compaction_status <db-type>.<namespace> <table> [show_tablets]
 ```
 
@@ -502,7 +502,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     compaction_status ysql.yugabyte table_name show_tablets
 ```
 
@@ -549,7 +549,7 @@ Modifies the placement information (cloud, region, and zone) for a table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     modify_table_placement_info <keyspace> <table-name> <placement-info> <replication-factor> \
     [ <placement-id> ]
 ```
@@ -558,7 +558,7 @@ or alternatively:
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     modify_table_placement_info tableid.<table-id> <placement-info> <replication-factor> \
     [ <placement-id> ]
 ```
@@ -575,7 +575,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     modify_table_placement_info  testdatabase testtable \
     aws.us-west.us-west-2a,aws.us-west.us-west-2b,aws.us-west.us-west-2c 3
 ```
@@ -597,7 +597,7 @@ Creates a transaction status table to be used in a region. This command should a
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_transaction_table \
     <table-name>
 ```
@@ -611,7 +611,7 @@ The transaction status table will be created as `system.<table-name>`.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     create_transaction_table \
     transactions_us_east
 ```
@@ -622,7 +622,7 @@ Next, set the placement on the newly created transactions table:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     modify_table_placement_info system transactions_us_east \
     aws.us-east.us-east-1a,aws.us-east.us-east-1b,aws.us-east.us-east-1c 3
 ```
@@ -643,7 +643,7 @@ Add a tablet to a transaction status table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     add_transaction_tablet \
     <table-id>
 ```
@@ -655,7 +655,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     add_transaction_tablet 000033eb000030008000000000004002
 ```
 
@@ -669,7 +669,7 @@ Flush the memstores of the specified table on all tablet servers to disk.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     flush_table <db-type>.<namespace> <table> [<timeout-in-seconds>] [ADD_INDEXES]
 ```
 
@@ -684,7 +684,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     flush_table ysql.yugabyte table_name
 
 ```
@@ -697,7 +697,7 @@ Flushed [yugabyte.table_name] tables.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     flush_table tableid.<table-id> [<timeout-in-seconds>] [ADD_INDEXES]
 ```
 
@@ -710,7 +710,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     flush_table tableid.000033eb000030008000000000004002
 ```
 
@@ -726,7 +726,7 @@ Backfill all DEFERRED indexes in a YCQL table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     backfill_indexes_for_table <keyspace> <table-name>
 ```
 
@@ -738,7 +738,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     backfill_indexes_for_table ybdemo table_name
 ```
 
@@ -779,7 +779,7 @@ Creates a snapshot of the specified YSQL database.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_database_snapshot <database>
 ```
 
@@ -792,7 +792,7 @@ When this command runs, a `snapshot_id` is generated and printed.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     create_database_snapshot
 ```
 
@@ -806,7 +806,7 @@ Creates a snapshot of the specified YCQL keyspace.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_keyspace_snapshot <keyspace>
 ```
 
@@ -819,7 +819,7 @@ When this command runs, a `snapshot_id` is generated and printed.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     create_keyspace_snapshot
 ```
 
@@ -833,7 +833,7 @@ Prints a list of all snapshot IDs, restoration IDs, and states. Optionally, prin
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_snapshots \
     [ show_details ] [ not_show_restored ]
 ```
@@ -883,7 +883,7 @@ In this example, the optional `show_details` flag is added to generate the snaps
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     list_snapshots show_details
 ```
 
@@ -919,7 +919,7 @@ Use the [create_snapshot_schedule](#create-snapshot-schedule) command to create 
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_snapshot <keyspace> <table-name> | <table_id> \
     [<keyspace> <table-name> | <table-id> ]... \
     [<flush-timeout-in-seconds>]
@@ -937,7 +937,7 @@ When this command runs, a `snapshot_id` is generated and printed.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     create_snapshot ydb test_tb
 ```
 
@@ -959,7 +959,7 @@ Restores the specified snapshot, including the tables and indexes. When the oper
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     restore_snapshot <snapshot-id> <restore-target>
 ```
 
@@ -1009,7 +1009,7 @@ Returns one or more restorations in JSON format.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_snapshot_restorations <restoration-id>
 ```
 
@@ -1020,7 +1020,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     list_snapshot_restorations 26ed9053-0c26-4277-a2b8-c12d0fa4c8cf
 ```
 
@@ -1044,7 +1044,7 @@ Generates a metadata file for the specified snapshot, listing all the relevant i
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     export_snapshot <snapshot-id> <file-name>
 ```
 
@@ -1056,7 +1056,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     export_snapshot 4963ed18fc1e4f1ba38c8fcf4058b295 \
     test_tb.snapshot
 ```
@@ -1074,7 +1074,7 @@ Imports the specified snapshot metadata file.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     import_snapshot <file-name> \
     [<keyspace> <table-name> [<keyspace> <table-name>]...]
 ```
@@ -1094,7 +1094,7 @@ The *keyspace* and the *table* can be different from the exported one.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     import_snapshot test_tb.snapshot ydb test_tb
 ```
 
@@ -1120,7 +1120,7 @@ Imports only the specified tables from the specified snapshot metadata file.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     import_snapshot_selective <file-name> \
     [<keyspace> <table-name> [<keyspace> <table-name>]...]
 ```
@@ -1140,7 +1140,7 @@ The *keyspace* can be different from the exported one. The name of the table nee
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     import_snapshot_selective test_tb.snapshot ydb test_tb
 ```
 
@@ -1166,7 +1166,7 @@ Deletes the specified snapshot.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     delete_snapshot <snapshot-id>
 ```
 
@@ -1183,7 +1183,7 @@ Returns a schedule ID in JSON format.
 
 ```sh
 yb-admin create_snapshot_schedule \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     <snapshot-interval>\
     <retention-time>\
     <filter-expression>
@@ -1202,7 +1202,7 @@ Take a snapshot of the YSQL database `yugabyte` once per minute, and retain each
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     create_snapshot_schedule 1 10 ysql.yugabyte
 ```
 
@@ -1210,7 +1210,7 @@ The equivalent command for the YCQL keyspace `yugabyte` would be the following:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     create_snapshot_schedule 1 10 yugabyte
 ```
 
@@ -1242,7 +1242,7 @@ Returns one or more schedule lists in JSON format.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_snapshot_schedules <schedule-id>
 ```
 
@@ -1253,7 +1253,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     list_snapshot_schedules 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
 ```
 
@@ -1290,7 +1290,7 @@ Schedules group a set of items into a single tracking object (the *schedule*). W
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     restore_snapshot_schedule <schedule-id> <restore-target>
 ```
 
@@ -1322,7 +1322,7 @@ Restore from an absolute timestamp:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 1617670679185100
 ```
 
@@ -1330,7 +1330,7 @@ Restore from a relative time:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 minus 60s
 ```
 
@@ -1353,7 +1353,7 @@ Returns a JSON object with the `schedule_id` that was just deleted.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     delete_snapshot_schedule <schedule-id>
 ```
 
@@ -1364,7 +1364,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     delete_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
 ```
 
@@ -1390,7 +1390,7 @@ Modifies the placement information (cloud, region, and zone) for a deployment.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     modify_placement_info <placement-info> <replication-factor> \
     [ <placement-id> ]
 ```
@@ -1404,7 +1404,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     modify_placement_info  \
     aws.us-west.us-west-2a:2,aws.us-west.us-west-2b:2,aws.us-west.us-west-2c 5
 ```
@@ -1447,7 +1447,7 @@ Having all tablet leaders reside in a single region reduces the number of networ
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     set_preferred_zones <cloud.region.zone>[:<preference>] \
     [<cloud.region.zone>[:<preference>]]...
 ```
@@ -1594,7 +1594,7 @@ Add a read replica cluster to the master configuration.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     add_read_replica_placement_info <placement-info> \
     <replication-factor> \
     [ <placement-id> ]
@@ -1612,7 +1612,7 @@ yb-admin \
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     modify_read_replica_placement_info <placement-info> \
     <replication-factor> \
     [ <placement-id> ]
@@ -1631,7 +1631,7 @@ Delete the read replica.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     delete_read_replica_placement_info
 ```
 
@@ -1653,7 +1653,7 @@ Sets the contents of *key-path* in-memory on each YB-Master node.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     add_universe_key_to_all_masters <key-id> <key-path>
 ```
 
@@ -1673,7 +1673,7 @@ Checks whether the universe key associated with the provided *key-id* exists in-
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> all_masters_have_universe_key_in_memory <key-id>
+    --master_addresses <master-addresses> all_masters_have_universe_key_in_memory <key-id>
 ```
 
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default is `localhost:7100`.
@@ -1693,7 +1693,7 @@ The [all_masters_have_universe_key_in_memory](#all-masters-have-universe-key-in-
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> rotate_universe_key_in_memory <key-id>
+    --master_addresses <master-addresses> rotate_universe_key_in_memory <key-id>
 ```
 
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default is `localhost:7100`.
@@ -1707,7 +1707,7 @@ Disables the in-memory encryption at rest for newly-written data files.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     disable_encryption_in_memory
 ```
 
@@ -1721,7 +1721,7 @@ Checks if cluster-wide encryption is enabled.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     is_encryption_enabled
 ```
 
@@ -1739,7 +1739,7 @@ The new key ID (`<key_id_2>`) should be different from the previous one (`<key_i
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     is_encryption_enabled
 ```
 
@@ -1757,7 +1757,7 @@ Create a change data capture (CDC) DB stream for the specified namespace using t
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_change_data_stream ysql.<namespace-name>
 ```
 
@@ -1768,7 +1768,7 @@ For example:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100 \
+    --master_addresses 127.0.0.1:7100 \
     create_change_data_stream ysql.yugabyte
 ```
 
@@ -1781,7 +1781,7 @@ This feature is {{<tags/feature/tp>}}. Use the [yb_enable_cdc_consistent_snapsho
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_change_data_stream ysql.<namespace-name> [EXPLICIT] [<before-image-mode>] [USE_SNAPSHOT | NOEXPORT_SNAPSHOT]
 ```
 
@@ -1795,7 +1795,7 @@ For example:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100 \
+    --master_addresses 127.0.0.1:7100 \
     create_change_data_stream ysql.yugabyte EXPLICIT CHANGE USE_SNAPSHOT
 ```
 
@@ -1807,7 +1807,7 @@ To create a change data capture (CDC) DB stream which also supports sending the 
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_change_data_stream ysql.<namespace-name> [EXPLICIT] <before-image-mode>
 ```
 
@@ -1830,7 +1830,7 @@ To create a change data capture (CDC) DB stream which works in the EXPLICIT chec
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_change_data_stream ysql.<namespace-name> EXPLICIT
 ```
 
@@ -1858,7 +1858,7 @@ Lists all the created CDC DB streams.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_change_data_streams [namespace-name]
 ```
 
@@ -1869,7 +1869,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100 \
+    --master_addresses 127.0.0.1:7100 \
     list_change_data_streams
 ```
 
@@ -1915,7 +1915,7 @@ Get the information associated with a particular CDC DB stream.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_change_data_stream_info <db-stream-id>
 ```
 
@@ -1926,7 +1926,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100 \
+    --master_addresses 127.0.0.1:7100 \
     get_change_data_stream_info d540f5e4890c4d3b812933cbfd703ed3
 ```
 
@@ -1949,7 +1949,7 @@ Delete the specified CDC DB stream.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     delete_change_data_stream <db-stream-id>
 ```
 
@@ -1960,7 +1960,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100 \
+    --master_addresses 127.0.0.1:7100 \
     delete_change_data_stream d540f5e4890c4d3b812933cbfd703ed3
 ```
 
@@ -1984,7 +1984,7 @@ To verify if any tables are already configured for replication, use [list_cdc_st
 
 ```sh
 yb-admin \
-    -master_addresses <target-master-addresses> \
+    --master_addresses <target-master-addresses> \
     setup_universe_replication \
     <replication-group-id> \
     <source-master-addresses> \
@@ -2014,7 +2014,7 @@ To display a list of tables and their UUID (`table_id`) values, open the **YB-Ma
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     setup_universe_replication e260b8b6-e89f-4505-bb8e-b31f74aa29f3_xClusterSetup1 \
     127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     000030a5000030008000000000004000,000030a5000030008000000000004005,dfef757c415c4b2cacc9315b8acb539a
@@ -2036,7 +2036,7 @@ To check if any tables are configured for replication, use [list_cdc_streams](#l
 Use the `set_master_addresses` subcommand to replace the source master address list. Use this if the set of masters on the source changes:
 
 ```sh
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
     alter_universe_replication <replication-group-id> \
     set_master_addresses <source-master-addresses>
 ```
@@ -2048,7 +2048,7 @@ yb-admin -master_addresses <target-master-addresses> \
 Use the `add_table` subcommand to add one or more tables to the existing list:
 
 ```sh
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
     alter_universe_replication <replication-group-id> \
     add_table <source-table-ids> \
     [ <bootstrap-ids> ]
@@ -2066,7 +2066,7 @@ Enter the source universe bootstrap IDs in the same order as their corresponding
 Use the `remove_table` subcommand to remove one or more tables from the existing list:
 
 ```sh
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
     alter_universe_replication <replication-group-id> \
     remove_table <source-table-ids> [ignore-errors]
 ```
@@ -2079,7 +2079,7 @@ yb-admin -master_addresses <target-master-addresses> \
 Use the `rename_id` subcommand to rename xCluster replication streams.
 
 ```sh
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
     alter_universe_replication <replication-group-id> \
     rename_id <new-replication-group-id>
 ```
@@ -2096,7 +2096,7 @@ Deletes universe replication for the specified source universe.
 
 ```sh
 yb-admin \
-    -master_addresses <target-master-addresses> \
+    --master_addresses <target-master-addresses> \
     delete_universe_replication <replication-group-id>
 ```
 
@@ -2111,7 +2111,7 @@ Sets the universe replication to be enabled or disabled.
 
 ```sh
 yb-admin \
-    -master_addresses <target-master-addresses> \
+    --master_addresses <target-master-addresses> \
     set_universe_replication_enabled <replication-group-id> [0|1]
 ```
 
@@ -2127,7 +2127,7 @@ Reports the current xCluster safe time for each namespace, which is the time at 
 
 ```sh
 yb-admin \
-    -master_addresses <target-master-addresses> \
+    --master_addresses <target-master-addresses> \
     get_xcluster_safe_time \
     [include_lag_and_skew]
 ```
@@ -2139,7 +2139,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     get_xcluster_safe_time include_lag_and_skew
 ```
 
@@ -2169,7 +2169,7 @@ Verify when the producer and consumer are in sync for a given list of `stream_id
 
 ```sh
 yb-admin \
-    -master_addresses <source-master-addresses> \
+    --master_addresses <source-master-addresses> \
     wait_for_replication_drain \
     <stream-ids> [<timestamp> | minus <interval>]
 ```
@@ -2183,7 +2183,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+    --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     wait_for_replication_drain 000033f1000030008000000000000000,200033f1000030008000000000000002 minus 1m
 ```
 
@@ -2214,7 +2214,7 @@ Use this command when setting up xCluster replication to verify if any tables ar
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_cdc_streams
 ```
 
@@ -2224,7 +2224,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     list_cdc_streams
 ```
 
@@ -2236,7 +2236,7 @@ Deletes underlying xCluster outbound streams.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     delete_cdc_stream <stream-id> \
     [force_delete]
 ```
@@ -2257,7 +2257,7 @@ Mark a set of tables in preparation for setting up xCluster replication.
 
 ```sh
 yb-admin \
-    -master_addresses <source-master-addresses> \
+    --master_addresses <source-master-addresses> \
     bootstrap_cdc_producer <source-table-ids>
 ```
 
@@ -2268,7 +2268,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 172.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 172.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     bootstrap_cdc_producer 000030ad000030008000000000004000
 ```
 
@@ -2288,7 +2288,7 @@ Returns the xCluster replication status of all inbound replication groups. If *r
 
 ```sh
 yb-admin \
-    -master_addresses <target-master-addresses> \
+    --master_addresses <target-master-addresses> \
     get_replication_status [ <replication-group-id> ]
 ```
 
@@ -2299,7 +2299,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 172.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 172.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     get_replication_status e260b8b6-e89f-4505-bb8e-b31f74aa29f3
 ```
 
@@ -2322,7 +2322,7 @@ Checkpoint namespaces for use in xCluster replication.
 
 ```sh
 yb-admin \
-    -master_addresses <source-master-addresses> \
+    --master_addresses <source-master-addresses> \
     create_xcluster_checkpoint \
     <replication-group-id> \
     <namespace_names> \
@@ -2342,7 +2342,7 @@ Checks if the databases of a previously checkpointed replication group requires 
 
 ```sh
 yb-admin \
-    -master_addresses <source-master-addresses> \
+    --master_addresses <source-master-addresses> \
     is_xcluster_bootstrap_required \
     <replication-group-id> \
     <namespace-names>
@@ -2360,7 +2360,7 @@ Setup xCluster replication using a previously created [checkpoint](#create-xclus
 
 ```sh
 yb-admin \
-    -master_addresses <source-master-addresses> \
+    --master_addresses <source-master-addresses> \
     setup_xcluster_replication \
     <replication-group-id> \
     <target-master-addresses>
@@ -2378,7 +2378,7 @@ Drops the xCluster replication group. If *target-master-addresses* are provided,
 
 ```sh
 yb-admin \
-    -master_addresses <source-master-addresses> \
+    --master_addresses <source-master-addresses> \
     drop_xcluster_replication \
     <replication-group-id> \
     [<target-master-addresses>]
@@ -2396,7 +2396,7 @@ Adds a database to an existing xCluster checkpoint.
 
 ```sh
 yb-admin \
-    -master_addresses <source-master-addresses> \
+    --master_addresses <source-master-addresses> \
     add_namespace_to_xcluster_checkpoint \
     <replication-group-id> \
     <namespace-name>
@@ -2414,7 +2414,7 @@ Adds a database to an existing xCluster replication after it has been checkpoint
 
 ```sh
 yb-admin \
-    -master_addresses <source-master-addresses> \
+    --master_addresses <source-master-addresses> \
     add_namespace_to_xcluster_replication \
     <replication-group-id> \
     <namespace-name> \
@@ -2434,7 +2434,7 @@ Removes a database from an existing xCluster replication. If target master addre
 
 ```sh
 yb-admin \
-    -master_addresses <source-master-addresses> \
+    --master_addresses <source-master-addresses> \
     remove_namespace_from_xcluster_replication \
     <replication-group-id> \
     <namespace-name> \
@@ -2454,7 +2454,7 @@ List The replication group identifiers for all outbound xCluster replications. I
 
 ```sh
 yb-admin \
-    -master_addresses <source-master-addresses> \
+    --master_addresses <source-master-addresses> \
     list_xcluster_outbound_replication_groups \
     [<namespace-id>]
 ```
@@ -2470,7 +2470,7 @@ Display the status of a specific outbound xCluster replication group.
 
 ```sh
 yb-admin \
-    -master_addresses <source-master-addresses> \
+    --master_addresses <source-master-addresses> \
     get_xcluster_outbound_replication_group_info \
     <replication-group-id>
 ```
@@ -2486,7 +2486,7 @@ List The replication group identifiers for all inbound xCluster replications. If
 
 ```sh
 yb-admin \
-    -master_addresses <target-master-addresses> \
+    --master_addresses <target-master-addresses> \
     list_universe_replications \
     [<namespace-id>]
 ```
@@ -2506,7 +2506,7 @@ Gets the tablet load move completion percentage for blacklisted nodes.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_leader_blacklist_completion
 ```
 
@@ -2516,7 +2516,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     get_leader_blacklist_completion
 ```
 
@@ -2530,7 +2530,7 @@ After old YB-TServer servers are terminated, you can use this command to clean u
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     change_blacklist [ ADD | REMOVE ] <ip_addr>:<port> \
     [ <ip_addr>:<port> ]...
 ```
@@ -2543,7 +2543,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     change_blacklist \
       ADD node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
 ```
@@ -2554,7 +2554,7 @@ yb-admin \
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     change_leader_blacklist [ ADD | REMOVE ] <ip_addr>:<port> \
     [ <ip_addr>:<port> ]...
 ```
@@ -2567,7 +2567,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     change_leader_blacklist \
       ADD node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
 ```
@@ -2588,7 +2588,7 @@ There is a possibility of downtime.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     leader_stepdown <tablet-id> <dest-ts-uuid>
 ```
 
@@ -2618,7 +2618,7 @@ Enables or disables the load balancer.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     set_load_balancer_enabled [ 0 | 1 ]
 ```
 
@@ -2629,7 +2629,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     set_load_balancer_enabled 0
 ```
 
@@ -2641,7 +2641,7 @@ Returns the cluster load balancer state.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> get_load_balancer_state
+    --master_addresses <master-addresses> get_load_balancer_state
 ```
 
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default is `localhost:7100`.
@@ -2656,7 +2656,7 @@ You can rerun this command periodically until the value reaches `100.0`, indicat
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_load_move_completion
 ```
 
@@ -2681,7 +2681,7 @@ In the following example, the data move is `66.6` percent done.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     get_load_move_completion
 ```
 
@@ -2699,7 +2699,7 @@ Finds out if the load balancer is idle.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_is_load_balancer_idle
 ```
 
@@ -2709,7 +2709,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     get_is_load_balancer_idle
 ```
 
@@ -2729,7 +2729,7 @@ Returns the current AutoFlags configuration of the universe.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_auto_flags_config
 ```
 
@@ -2738,7 +2738,7 @@ yb-admin \
 **Example**
 
 ```sh
-./bin/yb-admin -master_addresses ip1:7100,ip2:7100,ip3:7100 get_auto_flags_config
+./bin/yb-admin --master_addresses ip1:7100,ip2:7100,ip3:7100 get_auto_flags_config
 ```
 
 If the operation is successful you should see output similar to the following:
@@ -2784,7 +2784,7 @@ Note that `promote_auto_flags` is a cluster-level operation; you don't need to r
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     promote_auto_flags \
     [<max-flags-class> [<promote-non-runtime-flags> [force]]]
 ```
@@ -2798,7 +2798,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     promote_auto_flags kLocalPersisted
 ```
 
@@ -2826,7 +2826,7 @@ YSQL upgrades are not required for clusters where [YSQL is not enabled](../../re
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     upgrade_ysql
 ```
 
@@ -2836,7 +2836,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     upgrade_ysql
 ```
 
@@ -2850,8 +2850,8 @@ In certain scenarios, a YSQL upgrade can take longer than 60 seconds, which is t
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
-    -timeout_ms 180000 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --timeout_ms 180000 \
     upgrade_ysql
 ```
 
@@ -2871,7 +2871,7 @@ Note that `finalize_upgrade` is a cluster-level operation; you don't need to run
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     finalize_upgrade
 ```
 

--- a/docs/content/preview/api/ycql/ddl_create_index.md
+++ b/docs/content/preview/api/ycql/ddl_create_index.md
@@ -189,7 +189,7 @@ After creating a set of indexes with their backfill deferred, you can then trigg
    Launch a backfill job for backfilling all the deferred indexes using the `backfill_indexes_for_table` command as follows:
 
     ```bash
-    bin/yb-admin -master_addresses <ip:port> backfill_indexes_for_table ycql.ybdemo table_name
+    bin/yb-admin --master_addresses <ip:port> backfill_indexes_for_table ycql.ybdemo table_name
     ```
 - Use the [`--defer_index_backfill`](../../../reference/configuration/yb-master#defer-index-backfill) YB-Master flag to force all indexes to be DEFERRED, and run `yb-admin backfill_indexes_for_table` to backfill indexes.
 

--- a/docs/content/preview/api/ysql/exprs/geo_partitioning_helper_functions/func_yb_is_local_table.md
+++ b/docs/content/preview/api/ysql/exprs/geo_partitioning_helper_functions/func_yb_is_local_table.md
@@ -55,7 +55,7 @@ This function is helpful while implementing [Row-level geo-partitioning](../../.
 1. Use [yb-admin](../../../../../admin/yb-admin/) to specify the placement configuration to be used by the cluster as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses <IP1>:7100 modify_placement_info aws.us-west-1.us-west-1c:1,aws.us-east-1.us-east-1a:1,aws.us-east-2.us-east-2c:1 3
+    ./bin/yb-admin --master_addresses <IP1>:7100 modify_placement_info aws.us-west-1.us-west-1c:1,aws.us-east-1.us-east-1a:1,aws.us-east-2.us-east-2c:1 3
     ```
 
 1. Create tablespaces corresponding to the regions used by the cluster created above [using ysqlsh](../../../../ysqlsh/#using-ysqlsh) as follows:

--- a/docs/content/preview/api/ysql/exprs/geo_partitioning_helper_functions/func_yb_server_region.md
+++ b/docs/content/preview/api/ysql/exprs/geo_partitioning_helper_functions/func_yb_server_region.md
@@ -63,7 +63,7 @@ Do the following to create a 3-node multi-region cluster and a geo-partitioned t
 1. Use [yb-admin](../../../../../admin/yb-admin/) to specify the placement configuration to be used by the cluster:
 
     ```sh
-    ./bin/yb-admin -master_addresses <IP1>:7100 modify_placement_info aws.us-west-1.us-west-1c:1,aws.us-east-1.us-east-1a:1,aws.us-east-2.us-east-2c:1 3
+    ./bin/yb-admin --master_addresses <IP1>:7100 modify_placement_info aws.us-west-1.us-west-1c:1,aws.us-east-1.us-east-1a:1,aws.us-east-2.us-east-2c:1 3
     ```
 
 1. Create tablespaces corresponding to the regions used by the cluster created above [using ysqlsh](../../../../ysqlsh/#using-ysqlsh):

--- a/docs/content/preview/deploy/multi-dc/async-replication/async-deployment.md
+++ b/docs/content/preview/deploy/multi-dc/async-replication/async-deployment.md
@@ -37,20 +37,20 @@ After you created the required tables, you can set up unidirectional replication
   - To find a table ID, execute the following command as an admin user:
 
       ```sh
-      ./bin/yb-admin -master_addresses <source_universe_master_addresses> list_tables include_table_id
+      ./bin/yb-admin --master_addresses <source_universe_master_addresses> list_tables include_table_id
       ```
 
       The preceding command lists all the tables, including system tables. To locate a specific table, you can add grep as follows:
 
       ```sh
-      ./bin/yb-admin -master_addresses <source_universe_master_addresses> list_tables include_table_id | grep table_name
+      ./bin/yb-admin --master_addresses <source_universe_master_addresses> list_tables include_table_id | grep table_name
       ```
 
 - Run the following yb-admin [`setup_universe_replication`](../../../../admin/yb-admin/#setup-universe-replication) command from the YugabyteDB home directory in the source universe:
 
     ```sh
     ./bin/yb-admin \
-      -master_addresses <target_universe_master_addresses> \
+      --master_addresses <target_universe_master_addresses> \
       setup_universe_replication <source_universe_UUID>_<replication_stream_name> \
         <source_universe_master_addresses> \
         <table_id>,[<table_id>..]
@@ -60,7 +60,7 @@ After you created the required tables, you can set up unidirectional replication
 
     ```sh
     ./bin/yb-admin \
-      -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+      --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
       setup_universe_replication e260b8b6-e89f-4505-bb8e-b31f74aa29f3_xClusterSetup1 \
         127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         000030a5000030008000000000004000,000030a5000030008000000000004005,dfef757c415c4b2cacc9315b8acb539a
@@ -136,7 +136,7 @@ You can use yb-admin to return the current replication status. The `get_replicat
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7000,127.0.0.2:7000,127.0.0.3:7000 \
+    --master_addresses 127.0.0.1:7000,127.0.0.2:7000,127.0.0.3:7000 \
     get_replication_status
 ```
 
@@ -160,8 +160,8 @@ If both universes use the same certificates, run `yb-admin setup_universe_replic
 Consider the following example:
 
 ```sh
-./bin/yb-admin -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
-  -certs_dir_name /home/yugabyte/yugabyte-tls-config \
+./bin/yb-admin --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+  --certs_dir_name /home/yugabyte/yugabyte-tls-config \
   setup_universe_replication e260b8b6-e89f-4505-bb8e-b31f74aa29f3_xClusterSetup1 \
   127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
   000030a5000030008000000000004000,000030a5000030008000000000004005,dfef757c415c4b2cacc9315b8acb539a
@@ -184,8 +184,8 @@ When universes use different certificates, you need to store the certificates fo
     For example, if you have the target universe's certificates in `/home/yugabyte/yugabyte-tls-config`, then you would run the following:
 
     ```sh
-    ./bin/yb-admin -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
-      -certs_dir_name /home/yugabyte/yugabyte-tls-config \
+    ./bin/yb-admin --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+      --certs_dir_name /home/yugabyte/yugabyte-tls-config \
       setup_universe_replication 00000000-1111-2222-3333-444444444444_xClusterSetup1 \
       127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
       000030a5000030008000000000004000,000030a5000030008000000000004005,dfef757c415c4b2cacc9315b8acb539a
@@ -263,7 +263,7 @@ To create unidirectional replication, perform the following:
 1. Run the replication setup command for the source universe, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses <target_master_addresses> \
+    ./bin/yb-admin --master_addresses <target_master_addresses> \
     setup_universe_replication <source_universe_UUID>_<replication_stream_name> \
     <source_master_addresses> <comma_separated_table_ids>
     ```
@@ -271,7 +271,7 @@ To create unidirectional replication, perform the following:
     Consider the following example:
 
     ```sh
-    ./bin/yb-admin -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    ./bin/yb-admin --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     setup_universe_replication 00000000-1111-2222-3333-444444444444_xClusterSetup1 \
     127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     000033e1000030008000000000004007,000033e100003000800000000000400d,000033e1000030008000000000004013
@@ -324,7 +324,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
 
   ```sh
   kubectl exec -it -n <source_universe_namespace> -t <source_universe_master_leader> -c \
-    <source_universe_container> -- bash -c "/home/yugabyte/bin/yb-admin -master_addresses \
+    <source_universe_container> -- bash -c "/home/yugabyte/bin/yb-admin --master_addresses \
     <target_universe_master_addresses> setup_universe_replication \
     <source_universe_UUID>_<replication_stream_name> <source_universe_master_addresses> \
     <comma_separated_table_ids>"
@@ -334,7 +334,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
 
   ```sh
   kubectl exec -it -n xcluster-source -t yb-master-2 -c yb-master -- bash -c \
-    "/home/yugabyte/bin/yb-admin -master_addresses yb-master-2.yb-masters.xcluster-target.svc.cluster.local, \
+    "/home/yugabyte/bin/yb-admin --master_addresses yb-master-2.yb-masters.xcluster-target.svc.cluster.local, \
     yb-master-1.yb-masters.xcluster-target.svc.cluster.local,yb-master-0.yb-masters.xcluster-target.svc.cluster.local \
     setup_universe_replication ac39666d-c183-45d3-945a-475452deac9f_xCluster_1 \
     yb-master-2.yb-masters.xcluster-source.svc.cluster.local,yb-master-1.yb-masters.xcluster-source.svc.cluster.local, \
@@ -389,14 +389,14 @@ Proceed as follows:
 1. Create a checkpoint on the source universe for all the tables you want to replicate by executing the following command:
 
     ```sh
-    ./bin/yb-admin -master_addresses <source_universe_master_addresses> \
+    ./bin/yb-admin --master_addresses <source_universe_master_addresses> \
     bootstrap_cdc_producer <comma_separated_source_universe_table_ids>
     ```
 
     Consider the following example:
 
     ```sh
-    ./bin/yb-admin -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+    ./bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     bootstrap_cdc_producer 000033e1000030008000000000004000,000033e1000030008000000000004003,000033e1000030008000000000004006
     ```
 
@@ -412,7 +412,7 @@ Proceed as follows:
 1. Execute the following command to set up the replication stream using the bootstrap IDs generated in step 1. Ensure that the bootstrap IDs are in the same order as their corresponding table IDs.
 
     ```sh
-    ./bin/yb-admin -master_addresses <target_universe_master_addresses> setup_universe_replication \
+    ./bin/yb-admin --master_addresses <target_universe_master_addresses> setup_universe_replication \
       <source_universe_uuid>_<replication_stream_name> <source_universe_master_addresses> \
       <comma_separated_source_universe_table_ids> <comma_separated_bootstrap_ids>
     ```
@@ -420,7 +420,7 @@ Proceed as follows:
     Consider the following example:
 
     ```sh
-    ./bin/yb-admin -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 setup_universe_replication \
+    ./bin/yb-admin --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 setup_universe_replication \
       00000000-1111-2222-3333-444444444444_xCluster1 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
       000033e1000030008000000000004000,000033e1000030008000000000004003,000033e1000030008000000000004006 \
       fb156717174941008e54fa958e613c10,a2a46f5cbf8446a3a5099b5ceeaac28b,c967967523eb4e03bcc201bb464e0679
@@ -472,8 +472,8 @@ When new tables (or partitions) are created, to ensure that all changes from the
 1. Get table IDs of the new partition from the source as follows:
 
     ```sql
-    yb-admin -master_addresses <source_master_ips> \
-    -certs_dir_name <cert_dir> \
+    yb-admin --master_addresses <source_master_ips> \
+    --certs_dir_name <cert_dir> \
     list_tables include_table_id|grep 'order_changes_2023_01'
     ```
 
@@ -486,8 +486,8 @@ When new tables (or partitions) are created, to ensure that all changes from the
 1. Add the new table (or partition) to replication.
 
    ```sql
-   yb-admin -master_addresses <target_master_ips> \
-   -certs_dir_name <cert_dir> \
+   yb-admin --master_addresses <target_master_ips> \
+   --certs_dir_name <cert_dir> \
    alter_universe_replication <replication_group_name> \
    add_table  000033e800003000800000000000410b
    ```
@@ -510,8 +510,8 @@ However, to add a new index to a table that already has data, the following addi
 
    ```sql
    yb-admin
-   -master_addresses <source_master_ips> \
-   -certs_dir_name <cert_dir> \
+   --master_addresses <source_master_ips> \
+   --certs_dir_name <cert_dir> \
    list_tables include_table_id|grep 'my_new_index'
    ```
 
@@ -525,8 +525,8 @@ However, to add a new index to a table that already has data, the following addi
 
    ```sql
    yb-admin
-   -master_addresses <source_master_ips> \
-   -certs_dir_name <cert_dir> \
+   --master_addresses <source_master_ips> \
+   --certs_dir_name <cert_dir> \
    bootstrap_cdc_producer 000033e8000030008000000000004028
    ```
 
@@ -543,8 +543,8 @@ However, to add a new index to a table that already has data, the following addi
 
     ```sql
     yb-admin
-    -master_addresses <target_master_ips> \
-    -certs_dir_name <cert_dir> \
+    --master_addresses <target_master_ips> \
+    --certs_dir_name <cert_dir> \
     alter_universe_replication 59e58153-eec6-4cb5-a858-bf685df52316_east-west \
     add_table  000033e8000030008000000000004028 c8cba563e39c43feb66689514488591c
     ```
@@ -579,16 +579,16 @@ Objects (tables, indexes, partitions) need to be removed from replication before
 1. Get the table ID for the object to be removed from the source.
 
     ```sql
-    yb-admin -master_addresses <source_master_ips> \
-    -certs_dir_name <cert_dir> \
+    yb-admin --master_addresses <source_master_ips> \
+    --certs_dir_name <cert_dir> \
     list_tables include_table_id |grep '<partition_name>'
     ```
 
 1. Remove the table from replication on the target.
 
     ```sql
-    yb-admin -master_addresses <target_master_ips> \
-    -certs_dir_name <cert_dir> \
+    yb-admin --master_addresses <target_master_ips> \
+    --certs_dir_name <cert_dir> \
     alter_universe_replication <replication_group_name> \
     remove_table  000033e800003000800000000000410b
     ```
@@ -601,8 +601,8 @@ Alters involving adding/removing columns or modifying data types require replica
 
     ```sql
     yb-admin
-    -master_addresses <target_master_ips>
-    -certs_dir_name <cert_dir> \
+    --master_addresses <target_master_ips>
+    --certs_dir_name <cert_dir> \
     set_universe_replication_enabled <replication_group_name> 0
     ```
 
@@ -617,8 +617,8 @@ Alters involving adding/removing columns or modifying data types require replica
 
     ```sql
     yb-admin
-    -master_addresses <target_master_ips>
-    -certs_dir_name <cert_dir> \
+    --master_addresses <target_master_ips>
+    --certs_dir_name <cert_dir> \
     set_universe_replication_enabled <replication_group_name> 0
     ```
 

--- a/docs/content/preview/deploy/multi-dc/async-replication/async-transactional-failover.md
+++ b/docs/content/preview/deploy/multi-dc/async-replication/async-transactional-failover.md
@@ -36,7 +36,7 @@ Pause replication on the Standby (B). This step is required to avoid unexpected 
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses <B_master_addresses> \
+    --master_addresses <B_master_addresses> \
     set_universe_replication_enabled <replication_name> 0
 ```
 
@@ -52,7 +52,7 @@ Get the latest consistent time on Standby (B). The `get_xcluster_safe_time` comm
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses <B_master_addresses> \
+    --master_addresses <B_master_addresses> \
     get_xcluster_safe_time include_lag_and_skew
 ```
 
@@ -122,7 +122,7 @@ Restore the database to the `safe_time`:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <B_master_addresses> \
+        --master_addresses <B_master_addresses> \
         list_snapshot_schedules
     ```
 
@@ -153,7 +153,7 @@ Restore the database to the `safe_time`:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <B_master_addresses> \
+        --master_addresses <B_master_addresses> \
         restore_snapshot_schedule <schedule_id> "<safe_time>"
     ```
 
@@ -170,7 +170,7 @@ Restore the database to the `safe_time`:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <B_master_addresses> \
+        --master_addresses <B_master_addresses> \
         list_snapshot_restorations
     ```
 
@@ -195,7 +195,7 @@ Restore the database to the `safe_time`:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses <B_master_addresses> \
+    --master_addresses <B_master_addresses> \
     delete_universe_replication <replication_group_id>
 ```
 
@@ -261,7 +261,7 @@ Disable point-in-time recovery for the database(s) on A:
 - List the snapshot schedules to obtain the schedule ID:
 
     ```sh
-    ./bin/yb-admin -master_addresses <A_master_addresses> \
+    ./bin/yb-admin --master_addresses <A_master_addresses> \
         list_snapshot_schedules
     ```
 
@@ -269,7 +269,7 @@ Disable point-in-time recovery for the database(s) on A:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <A_master_addresses> \
+        --master_addresses <A_master_addresses> \
         delete_snapshot_schedule <schedule_id>
     ```
 
@@ -299,7 +299,7 @@ Drop the replication group on A using the following command:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses <A_master_addresses> \
+    --master_addresses <A_master_addresses> \
     drop_xcluster_replication <replication_group_id>
 ```
 
@@ -317,7 +317,7 @@ Outbound xCluster Replication group rg1 deleted successfully
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses <A_master_ips> \
+    --master_addresses <A_master_ips> \
     list_cdc_streams
     ```
 
@@ -325,7 +325,7 @@ Outbound xCluster Replication group rg1 deleted successfully
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses <A_master_ips> \
+    --master_addresses <A_master_ips> \
     delete_cdc_stream <streamID>
     ```
 

--- a/docs/content/preview/deploy/multi-dc/async-replication/async-transactional-setup-manual.md
+++ b/docs/content/preview/deploy/multi-dc/async-replication/async-transactional-setup-manual.md
@@ -115,7 +115,7 @@ To set up unidirectional transactional replication manually, do the following:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
+        --master_addresses <standby_master_addresses> \
         create_snapshot_schedule 1 10 ysql.yugabyte
     ```
 
@@ -125,8 +125,8 @@ To set up unidirectional transactional replication manually, do the following:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
-        -certs_dir_name <cert_dir> \
+        --master_addresses <standby_master_addresses> \
+        --certs_dir_name <cert_dir> \
         setup_universe_replication \
         <primary_universe_uuid>_<replication_name> \
         <primary_universe_master_addresses> \
@@ -138,8 +138,8 @@ To set up unidirectional transactional replication manually, do the following:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
-        -certs_dir_name <dir_name> \
+        --master_addresses <standby_master_addresses> \
+        --certs_dir_name <dir_name> \
         change_xcluster_role STANDBY
     ```
 
@@ -246,7 +246,7 @@ get_xcluster_safe_time
 For example:
 
 ```sh
-./tserver/bin/yb-admin -master_addresses 172.150.21.61:7100,172.150.44.121:7100,172.151.23.23:7100 \
+./tserver/bin/yb-admin --master_addresses 172.150.21.61:7100,172.150.44.121:7100,172.151.23.23:7100 \
     get_xcluster_safe_time
 ```
 

--- a/docs/content/preview/deploy/multi-dc/async-replication/includes/automatic-setup.md
+++ b/docs/content/preview/deploy/multi-dc/async-replication/includes/automatic-setup.md
@@ -112,7 +112,7 @@ The following assumes you have set up Primary and Standby universes. Refer to [S
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <primary_master_addresses> \
+        --master_addresses <primary_master_addresses> \
         create_xcluster_checkpoint \
         <replication_group_id> \
         <comma_separated_namespace_names> \
@@ -133,7 +133,7 @@ The following assumes you have set up Primary and Standby universes. Refer to [S
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+    --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     is_xcluster_bootstrap_required repl_group1 yugabyte
     ```
 
@@ -154,7 +154,7 @@ The following assumes you have set up Primary and Standby universes. Refer to [S
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
+        --master_addresses <standby_master_addresses> \
         create_snapshot_schedule \
         <snapshot-interval> \
         <retention-time> \
@@ -167,7 +167,7 @@ The following assumes you have set up Primary and Standby universes. Refer to [S
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses <primary_master_addresses> \
+    --master_addresses <primary_master_addresses> \
     setup_xcluster_replication \
     <replication_group_id> \
     <standby_master_addresses>

--- a/docs/content/preview/deploy/multi-dc/async-replication/includes/semi-automatic-setup.md
+++ b/docs/content/preview/deploy/multi-dc/async-replication/includes/semi-automatic-setup.md
@@ -106,7 +106,7 @@ The following assumes you have set up Primary and Standby universes. Refer to [S
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <primary_master_addresses> \
+        --master_addresses <primary_master_addresses> \
         create_xcluster_checkpoint <replication_group_id> <comma_separated_namespace_names>
     ```
 
@@ -124,7 +124,7 @@ The following assumes you have set up Primary and Standby universes. Refer to [S
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+    --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     is_xcluster_bootstrap_required repl_group1 yugabyte
     ```
 
@@ -141,7 +141,7 @@ The following assumes you have set up Primary and Standby universes. Refer to [S
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
+        --master_addresses <standby_master_addresses> \
         create_snapshot_schedule 1 10 ysql.yugabyte
     ```
 
@@ -149,7 +149,7 @@ The following assumes you have set up Primary and Standby universes. Refer to [S
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses <primary_master_addresses> \
+    --master_addresses <primary_master_addresses> \
     setup_xcluster_replication <replication_group_id> <standby_master_addresses>
     ```
 

--- a/docs/content/preview/deploy/multi-dc/async-replication/includes/transactional-add-db.md
+++ b/docs/content/preview/deploy/multi-dc/async-replication/includes/transactional-add-db.md
@@ -77,7 +77,7 @@ The database should have at least one table in order to be added to replication.
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses <primary_master_addresses> \
+    --master_addresses <primary_master_addresses> \
     add_namespace_to_xcluster_checkpoint <replication_group_id> <namespace_name>
     ```
 
@@ -96,7 +96,7 @@ The database should have at least one table in order to be added to replication.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
+        --master_addresses <standby_master_addresses> \
         create_snapshot_schedule 1 10 ysql.yugabyte
     ```
 
@@ -104,7 +104,7 @@ The database should have at least one table in order to be added to replication.
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses <primary_master_addresses> \
+    --master_addresses <primary_master_addresses> \
     add_namespace_to_xcluster_replication <replication_group_id> <namespace_name> <standby_master_addresses>
     ```
 

--- a/docs/content/preview/deploy/multi-dc/read-replica-clusters.md
+++ b/docs/content/preview/deploy/multi-dc/read-replica-clusters.md
@@ -117,7 +117,7 @@ You can deploy a read replica cluster that asynchronously replicates data with a
 1. Define the primary cluster placement using the [`yb-admin modify_placement_info`](../../../admin/yb-admin/#modify-placement-info) command, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses ip1:7100,ip2:7100,ip3:7100 modify_placement_info <placement_info> <replication_factor> [placement_uuid]
+    ./bin/yb-admin --master_addresses ip1:7100,ip2:7100,ip3:7100 modify_placement_info <placement_info> <replication_factor> [placement_uuid]
     ```
 
     - *placement_info*: Comma-separated list of availability zones using the format `<cloud1.region1.zone1>,<cloud2.region2.zone2>, ...`
@@ -127,7 +127,7 @@ You can deploy a read replica cluster that asynchronously replicates data with a
 1. Define the read replica placement using the [`yb-admin add_read_replica_placement_info`](../../../admin/yb-admin/#add-read-replica-placement-info) command, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses ip1:7100,ip2:7100,ip3:7100 add_read_replica_placement_info <placement_info> <replication_factor> [placement_uuid]
+    ./bin/yb-admin --master_addresses ip1:7100,ip2:7100,ip3:7100 add_read_replica_placement_info <placement_info> <replication_factor> [placement_uuid]
     ```
 
     - *placement_info*: Comma-separated list of availability zones, using the format `<cloud1.region1.zone1>:<num_replicas_in_zone1>,<cloud2.region2.zone2>:<num_replicas_in_zone2>,...` These read replica availability zones must be uniquely different from the primary availability zones defined in step 2. If you want to use the same cloud, region, and availability zone as a primary cluster, one option is to suffix the zone with `_rr` (for read replica). For example, `c1.r1.z1_rr:2`.

--- a/docs/content/preview/develop/multi-cloud/multicloud-migration.md
+++ b/docs/content/preview/develop/multi-cloud/multicloud-migration.md
@@ -66,7 +66,7 @@ The basic flow of bootstrapping is as follows:
 1. Create a checkpoint for all the tables in the AWS universe. For example:
 
     ```bash
-    ./bin/yb-admin -master_addresses <AWS_universe_master_addresses> \
+    ./bin/yb-admin --master_addresses <AWS_universe_master_addresses> \
             bootstrap_cdc_producer <comma_separated_source_universe_table_ids>
     ```
 
@@ -85,7 +85,7 @@ For detailed instructions on how to set up replication, see [Set up unidirection
 A simple way to set up replication is as follows:
 
 ```bash
-./bin/yb-admin -master_addresses <GCP_universe_master_addresses> setup_universe_replication \
+./bin/yb-admin --master_addresses <GCP_universe_master_addresses> setup_universe_replication \
   <AWS_universe_uuid>_<replication_stream_name> <AWS_universe_master_addresses> \
   <comma_separated_source_universe_table_ids> <comma_separated_bootstrap_ids>
 ```
@@ -111,8 +111,8 @@ The basic flow of switchover is as follows:
 
   ```bash
   ./bin/yb-admin \
-      -master_addresses <GCP_master_addresses> \
-      -certs_dir_name <cert_dir> \
+      --master_addresses <GCP_master_addresses> \
+      --certs_dir_name <cert_dir> \
       change_xcluster_role ACTIVE
   ```
 

--- a/docs/content/preview/explore/cluster-management/point-in-time-recovery-ycql.md
+++ b/docs/content/preview/explore/cluster-management/point-in-time-recovery-ycql.md
@@ -82,7 +82,7 @@ Create and populate a table, get a timestamp to which you'll restore, and then w
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         create_snapshot_schedule 1 10 ycql.pitr
     ```
 
@@ -96,7 +96,7 @@ Create and populate a table, get a timestamp to which you'll restore, and then w
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshot_schedules
     ```
 
@@ -156,7 +156,7 @@ Create and populate a table, get a timestamp to which you'll restore, and then w
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 0e4ceb83-fe3d-43da-83c3-013a8ef592ca 1620418817729963
     ```
 
@@ -171,7 +171,7 @@ Create and populate a table, get a timestamp to which you'll restore, and then w
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 

--- a/docs/content/preview/explore/cluster-management/point-in-time-recovery-ysql.md
+++ b/docs/content/preview/explore/cluster-management/point-in-time-recovery-ysql.md
@@ -80,7 +80,7 @@ Create a snapshot as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         create_snapshot_schedule 1 10 ysql.yugabyte
     ```
 
@@ -94,7 +94,7 @@ Create a snapshot as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshot_schedules
     ```
 
@@ -155,7 +155,7 @@ Create a snapshot as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 0e4ceb83-fe3d-43da-83c3-013a8ef592ca 1620418817729963
     ```
 
@@ -170,7 +170,7 @@ Create a snapshot as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 
@@ -235,7 +235,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         create_snapshot_schedule 1 10 ysql.yugabyte
     ```
 
@@ -249,7 +249,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshot_schedules
     ```
 
@@ -290,7 +290,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 1fb2d85a-3608-4cb1-af63-3e4062300dc1 1681964544554620
     ```
 
@@ -305,7 +305,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 
@@ -342,7 +342,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshot_schedules
     ```
 
@@ -402,7 +402,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 1fb2d85a-3608-4cb1-af63-3e4062300dc1 1681965106732671
     ```
 
@@ -417,7 +417,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 
@@ -465,7 +465,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshot_schedules
     ```
 
@@ -533,7 +533,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 1fb2d85a-3608-4cb1-af63-3e4062300dc1 1681965472490517
     ```
 
@@ -548,7 +548,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 
@@ -620,7 +620,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 1fb2d85a-3608-4cb1-af63-3e4062300dc1 1681965684502460
     ```
 
@@ -635,7 +635,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 
@@ -710,7 +710,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 1fb2d85a-3608-4cb1-af63-3e4062300dc1 1681965868912921
     ```
 
@@ -725,7 +725,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 

--- a/docs/content/preview/explore/colocation.md
+++ b/docs/content/preview/explore/colocation.md
@@ -218,7 +218,7 @@ To set up xCluster for colocated tables, do the following:
 1. Get the parent table UUID for the colocated database.
 
     ```sh
-    ./yb-admin -master_addresses <source_master_addresses> list_tables include_table_id | grep -i <database_name> | grep -i "colocation.parent.uuid"
+    ./yb-admin --master_addresses <source_master_addresses> list_tables include_table_id | grep -i <database_name> | grep -i "colocation.parent.uuid"
     ```
 
     ```output
@@ -228,13 +228,13 @@ To set up xCluster for colocated tables, do the following:
 1. Set up replication for the parent colocation table using yb-admin.
 
     ```sh
-    ./yb-admin -master_addresses <target_master_addresses> setup_universe_replication <replication_group_name> <source_master_addresses> <parent_colocated_table_uuid>
+    ./yb-admin --master_addresses <target_master_addresses> setup_universe_replication <replication_group_name> <source_master_addresses> <parent_colocated_table_uuid>
     ```
 
     For example:
 
     ```sh
-    ./yb-admin -master_addresses 127.0.0.2 setup_universe_replication A1-B2 127.0.0.1 00004000000030008000000000004004.colocation.parent.uuid
+    ./yb-admin --master_addresses 127.0.0.2 setup_universe_replication A1-B2 127.0.0.1 00004000000030008000000000004004.colocation.parent.uuid
     ```
 
     ```output

--- a/docs/content/preview/explore/multi-region-deployments/read-replicas-ycql.md
+++ b/docs/content/preview/explore/multi-region-deployments/read-replicas-ycql.md
@@ -62,7 +62,7 @@ For more info, please use: yb-ctl status
 The following command instructs the masters to create three replicas for each tablet distributed across the three zones:
 
 ```shell
-$ ./bin/yb-admin -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 modify_placement_info c.r.z1,c.r.z2,c.r.z3 3 live
+$ ./bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 modify_placement_info c.r.z1,c.r.z2,c.r.z3 3 live
 ```
 
 The following illustration demonstrates the primary cluster visible via [YugabyteDB Anywhere](../../../yugabyte-platform/):
@@ -166,7 +166,7 @@ The following commands add three new nodes to a read replica cluster in region `
 ./bin/yb-ctl add_node --placement_info "c.r2.z22" --tserver_flags "placement_uuid=rr"
 ./bin/yb-ctl add_node --placement_info "c.r2.z23" --tserver_flags "placement_uuid=rr"
 
-./bin/yb-admin -master_addresses 127.0.0.1:7100,127.0.0.2,127.0.0.3 add_read_replica_placement_info c.r2.z21:1,c.r2.z22:1,c.r2.z23:1 3 rr
+./bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2,127.0.0.3 add_read_replica_placement_info c.r2.z21:1,c.r2.z22:1,c.r2.z23:1 3 rr
 ```
 
 The following illustration demonstrates the setup of the two clusters, one of which is primary and another one is read replica visible via YugabyteDB Anywhere:

--- a/docs/content/preview/launch-and-manage/monitor-and-alert/xcluster-monitor.md
+++ b/docs/content/preview/launch-and-manage/monitor-and-alert/xcluster-monitor.md
@@ -77,7 +77,7 @@ To list outgoing groups on the Primary universe, use the [list_xcluster_outbound
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses <primary_master_addresses> \
+    --master_addresses <primary_master_addresses> \
     list_xcluster_outbound_replication_groups \
     [namespace_id]
 ```
@@ -86,7 +86,7 @@ To list inbound groups on the Standby universe, use the [list_universe_replicati
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses <standby_master_addresses> \
+    --master_addresses <standby_master_addresses> \
     list_universe_replications \
     [namespace_id]
 ```
@@ -95,7 +95,7 @@ To get the status of the replication group, use [get_replication_status](../../.
 
 ```sh
 yb-admin \
-    -master_addresses <target-master-addresses> \
+    --master_addresses <target-master-addresses> \
     get_replication_status \
     [<replication_id>]
 ```
@@ -160,7 +160,7 @@ Inbound xCluster Replications:
 
   ```sh
   yb-admin \
-      -master_addresses <standby_master_addresses> \
+      --master_addresses <standby_master_addresses> \
       get_xcluster_safe_time \
       [include_lag_and_skew]
   ```

--- a/docs/content/preview/manage/backup-restore/point-in-time-recovery.md
+++ b/docs/content/preview/manage/backup-restore/point-in-time-recovery.md
@@ -88,13 +88,13 @@ To create a schedule and enable PITR, use the [`create_snapshot_schedule`](../..
 For example, to create a schedule that produces a snapshot of a YSQL database once a day (every 1,440 minutes) and retains it for three days (4,320 minutes), you would execute the following command:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot_schedule 1440 4320 ysql.<database_name>
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot_schedule 1440 4320 ysql.<database_name>
 ```
 
 The equivalent command for a YCQL keyspace would be the following:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot_schedule 1440 4320 <keyspace_name>
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot_schedule 1440 4320 <keyspace_name>
 ```
 
 The following output is a unique ID of the newly-created snapshot schedule:
@@ -112,7 +112,7 @@ You can use this ID to [delete the schedule](#delete-a-schedule) or [restore to 
 To delete a schedule and disable PITR, use the following [`delete_snapshot_schedule`](../../../admin/yb-admin/#delete-snapshot-schedule) command that takes the ID of the schedule to be deleted as a parameter:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
 ```
 
 ### List schedules
@@ -120,7 +120,7 @@ To delete a schedule and disable PITR, use the following [`delete_snapshot_sched
 To see a list of schedules that currently exist in the cluster, use the following [`list_snapshot_schedules`](../../../admin/yb-admin/#list-snapshot-schedules) command:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshot_schedules
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshot_schedules
 ```
 
 ```output.json
@@ -151,7 +151,7 @@ To see a list of schedules that currently exist in the cluster, use the followin
 You can also use the same command to view the information about a particular schedule by providing its ID as a parameter, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshot_schedules 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshot_schedules 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
 ```
 
 ## Restore to a point in time
@@ -172,7 +172,7 @@ If a database or a keyspace has an associated snapshot schedule, you can use tha
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <ip1:7100,ip2:7100,ip3:7100> \
+        --master_addresses <ip1:7100,ip2:7100,ip3:7100> \
         restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 1651435200
     ```
 
@@ -180,7 +180,7 @@ If a database or a keyspace has an associated snapshot schedule, you can use tha
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <ip1:7100,ip2:7100,ip3:7100> \
+        --master_addresses <ip1:7100,ip2:7100,ip3:7100> \
         restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 "2022-05-01 13:00-0700"
     ```
 
@@ -190,7 +190,7 @@ If a database or a keyspace has an associated snapshot schedule, you can use tha
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <ip1:7100,ip2:7100,ip3:7100> \
+        --master_addresses <ip1:7100,ip2:7100,ip3:7100> \
         restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 minus 5m
     ```
 
@@ -198,7 +198,7 @@ If a database or a keyspace has an associated snapshot schedule, you can use tha
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <ip1:7100,ip2:7100,ip3:7100> \
+        --master_addresses <ip1:7100,ip2:7100,ip3:7100> \
         restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 minus 1h
     ```
 

--- a/docs/content/preview/manage/backup-restore/snapshot-ysql.md
+++ b/docs/content/preview/manage/backup-restore/snapshot-ysql.md
@@ -42,7 +42,7 @@ Using distributed snapshots allows you to back up a database and then restore it
 To back up a database, create a snapshot using the [`create_database_snapshot`](../../../admin/yb-admin/#create-database-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> create_database_snapshot ysql.<database_name>
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> create_database_snapshot ysql.<database_name>
 ```
 
 A unique ID for the snapshot is returned, as shown in the following sample output:
@@ -56,7 +56,7 @@ You can then use this ID to check the status of the snapshot, [delete it](#delet
 The `create_database_snapshot` command exits immediately, but the snapshot may take some time to complete. Before using the snapshot, verify its status by executing the [`list_snapshots`](../../../admin/yb-admin/#list-snapshots) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshots
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshots
 ```
 
 All the snapshots in the cluster are listed, along with their statuses. You can find the ID of the new snapshot and make sure it has been completed, as shown in the following  sample output:
@@ -71,7 +71,7 @@ Snapshot UUID                           State       Creation Time
 Snapshots never expire and are retained as long as the cluster exists. If you no longer need a snapshot, you can delete it by executing the [`delete_snapshot`](../../../admin/yb-admin/#delete-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794
 ```
 
 ## Restore a snapshot
@@ -79,7 +79,7 @@ Snapshots never expire and are retained as long as the cluster exists. If you no
 To restore the data backed up in one of the previously created snapshots, run the [`restore_snapshot`](../../../admin/yb-admin/#restore-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> restore_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> restore_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794
 ```
 
 This command rolls back the database to the state which it had when the snapshot was created. The restore happens in-place: it changes the state of the existing database in the same cluster.
@@ -127,7 +127,7 @@ To move a snapshot to external storage, gather all the relevant files from all t
 1. Create the snapshot metadata file by executing the [`export_snapshot`](../../../admin/yb-admin/#export-snapshot) command and providing the ID of the snapshot, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> export_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794 <database_name>.snapshot
+    ./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> export_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794 <database_name>.snapshot
     ```
 
 1. Copy the newly-created YSQL metadata file (`<database_name>_schema.sql`) and the snapshot metadata file (`<database_name>.snapshot`) to the external storage.
@@ -176,7 +176,7 @@ You can restore a snapshot that you have [moved to external storage](#move-a-sna
 1. Fetch the snapshot metadata file from the external storage and apply it by running the [`import_snapshot`](../../../admin/yb-admin/#import-snapshot) command, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> import_snapshot <database_name>.snapshot <database_name>
+    ./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> import_snapshot <database_name>.snapshot <database_name>
     ```
 
     Notice that the following output contains the mapping between the old tablet IDs and the new tablet IDs:

--- a/docs/content/preview/manage/backup-restore/snapshots-ycql.md
+++ b/docs/content/preview/manage/backup-restore/snapshots-ycql.md
@@ -41,13 +41,13 @@ Using distributed snapshots allows you to back up a database and then restore it
 To back up a keyspace with all its tables and indexes, create a snapshot using the [`create_keyspace_snapshot`](../../../admin/yb-admin/#create-keyspace-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> create_keyspace_snapshot my_keyspace
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> create_keyspace_snapshot my_keyspace
 ```
 
 To back up a single table with its indexes, use the [`create_snapshot`](../../../admin/yb-admin/#create-snapshot) command instead, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot my_keyspace my_table
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot my_keyspace my_table
 ```
 
 When you execute either of the preceding commands, a unique ID for the snapshot is returned, as per the following output:
@@ -61,7 +61,7 @@ You can then use this ID to check the status of the snapshot, [delete it](#delet
 Even though the `create_keyspace_snapshot` and `create_snapshot` commands exit immediately, the snapshot may take some time to complete. Before using the snapshot, verify its status with the [`list_snapshots`](../../../admin/yb-admin/#list-snapshots) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshots
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshots
 ```
 
 The preceding command lists the snapshots in the cluster, along with their states. You can find the ID of the new snapshot and make sure it has been completed, as shown in the following  sample output:
@@ -76,7 +76,7 @@ Snapshot UUID                           State       Creation Time
 Snapshots never expire and are retained as long as the cluster exists. If you no longer need a snapshot, you can delete it with the [`delete_snapshot`](../../../admin/yb-admin/#delete-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef
 ```
 
 ## Restore a snapshot
@@ -84,7 +84,7 @@ Snapshots never expire and are retained as long as the cluster exists. If you no
 To restore the data backed up in one of the previously created snapshots, run the [`restore_snapshot`](../../../admin/yb-admin/#restore-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> restore_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> restore_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef
 ```
 
 This command rolls back the database to the state which it had when the snapshot was created. The restore happens in-place: it changes the state of the existing database in the same cluster.
@@ -102,7 +102,7 @@ To move a snapshot to external storage, gather all the relevant files from all t
 1. Create the snapshot metadata file by running the [`export_snapshot`](../../../admin/yb-admin/#export-snapshot) command and providing the ID of the snapshot:
 
     ```sh
-    ./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> export_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef my_keyspace.snapshot
+    ./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> export_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef my_keyspace.snapshot
     ```
 
 1. Copy the newly created snapshot metadata file (`my_keyspace.snapshot`) to the external storage.
@@ -133,7 +133,7 @@ You can restore a snapshot that you have [moved to external storage](#move-a-sna
 1. Retrieve the snapshot metadata file from the external storage and apply it by running the [`import_snapshot`](../../../admin/yb-admin/#import-snapshot) command, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> import_snapshot my_keyspace.snapshot my_keyspace
+    ./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> import_snapshot my_keyspace.snapshot my_keyspace
     ```
 
     Notice that the following output contains the mapping between the old tablet IDs and the new tablet IDs:

--- a/docs/content/preview/manage/change-cluster-config.md
+++ b/docs/content/preview/manage/change-cluster-config.md
@@ -103,13 +103,13 @@ The following commands can be run from one of the old master nodes. You can firs
 
 ```sh
 export MASTERS=node1:7100,node2:7100,node3:7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_blacklist ADD node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
+~/master/bin/yb-admin --master_addresses $MASTERS change_blacklist ADD node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
 ```
 
 Verify that the blacklist information looks similar to the following:
 
 ```sh
-~/master/bin/yb-admin -master_addresses $MASTERS get_universe_config
+~/master/bin/yb-admin --master_addresses $MASTERS get_universe_config
 Config:
 version: 5
 server_blacklist {
@@ -133,7 +133,7 @@ server_blacklist {
 Next, wait for the data move to complete. You can check the percentage completion by running the following command:
 
 ```sh
-~/master/bin/yb-admin -master_addresses $MASTERS get_load_move_completion
+~/master/bin/yb-admin --master_addresses $MASTERS get_load_move_completion
 Percent complete = 66.6
 ```
 
@@ -160,19 +160,19 @@ If any error log is reported on the command line from the following steps, check
 
 ```sh
 export MASTERS=node1:7100,node2:7100,node3:7100,node7:7100,node8:7100,node9:7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config ADD_SERVER node7 7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config REMOVE_SERVER node1 7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config ADD_SERVER node8 7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config REMOVE_SERVER node2 7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config ADD_SERVER node9 7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config REMOVE_SERVER node3 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config ADD_SERVER node7 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config REMOVE_SERVER node1 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config ADD_SERVER node8 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config REMOVE_SERVER node2 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config ADD_SERVER node9 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config REMOVE_SERVER node3 7100
 ```
 
 Now ensure that the master leader is one of the new master nodes as follows:
 
 ```sh
 $ export MASTERS=node7:7100,node8:7100,node9:7100
-$ ~/master/bin/yb-admin -master_addresses $MASTERS list_all_masters
+$ ~/master/bin/yb-admin --master_addresses $MASTERS list_all_masters
 ```
 
 ```output
@@ -199,7 +199,7 @@ Updating master addresses is needed in case the yb-tserver server is restarted.
 The old nodes are not part of the universe any more and can be shut down. After the old YB-TServers are terminated, you can cleanup the blacklist from the master configuration using the following command:
 
 ```sh
-~/master/bin/yb-admin -master_addresses $MASTERS change_blacklist REMOVE node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
+~/master/bin/yb-admin --master_addresses $MASTERS change_blacklist REMOVE node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
 ```
 
 {{< note title="Tip" >}}
@@ -209,5 +209,5 @@ Cleaning up the blacklist server will help reuse the older IPs in case they get 
 Ensure there are no `server_blacklist` entries returned by the command:
 
 ```sh
-~/master/bin/yb-admin -master_addresses $MASTERS get_universe_config
+~/master/bin/yb-admin --master_addresses $MASTERS get_universe_config
 ```

--- a/docs/content/preview/manage/upgrade-deployment.md
+++ b/docs/content/preview/manage/upgrade-deployment.md
@@ -158,7 +158,7 @@ New YugabyteDB features may require changes to the format of data that is sent o
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <master-addresses> \
+        --master_addresses <master-addresses> \
         promote_auto_flags
     ```
 
@@ -198,7 +198,7 @@ Use the [yb-admin](../../admin/yb-admin/) utility to upgrade the YSQL system cat
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     upgrade_ysql
 ```
 
@@ -212,8 +212,8 @@ In certain scenarios, a YSQL upgrade can take longer than 60 seconds, which is t
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
-    -timeout_ms 180000 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --timeout_ms 180000 \
     upgrade_ysql
 ```
 
@@ -302,7 +302,7 @@ During the Monitor phase, do the following:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <master-addresses> \
+        --master_addresses <master-addresses> \
         promote_auto_flags kLocalVolatile
     ```
 
@@ -333,7 +333,7 @@ If you need to roll back an upgrade where volatile AutoFlags were enabled, depen
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <master-addresses> \
+        --master_addresses <master-addresses> \
         rollback_auto_flags <previous_config_version>
     ```
 
@@ -351,7 +351,7 @@ If you need to roll back an upgrade where volatile AutoFlags were enabled, depen
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+        --master_addresses ip1:7100,ip2:7100,ip3:7100 \
         rollback_auto_flags 2
     ```
 

--- a/docs/content/preview/reference/configuration/yugabyted.md
+++ b/docs/content/preview/reference/configuration/yugabyted.md
@@ -78,7 +78,7 @@ $ ./bin/yugabyted -h
 ```
 
 ```sh
-$ ./bin/yugabyted -help
+$ ./bin/yugabyted --help
 ```
 
 For help with specific yugabyted commands, run 'yugabyted [ command ] -h'. For example, you can print the command-line help for the `yugabyted start` command by running the following:

--- a/docs/content/preview/secure/encryption-at-rest.md
+++ b/docs/content/preview/secure/encryption-at-rest.md
@@ -46,7 +46,7 @@ You enable encryption as follows:
 1. Copy the key to master nodes. In the following example, assume a 3-node RF=3 cluster with `MASTER_ADDRESSES=ip1:7100,ip2:7100,ip3:7100`. Choose any string `<key_id>` for this key and use yb-admin to copy the key to each of the masters:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES add_universe_key_to_all_masters <key_id> /<path_to_universe_key>
+    yb-admin --master_addresses $MASTER_ADDRESSES add_universe_key_to_all_masters <key_id> /<path_to_universe_key>
     ```
 
     The preceding operation does not perform the key rotation, but rather seeds each master's in-memory state. The key only lives in memory, and the plaintext key is never persisted to the disk.
@@ -54,13 +54,13 @@ You enable encryption as follows:
 1. Enable cluster-wide encryption. Before rotating the key, ensure that the masters know about `<key_id>`:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES all_masters_have_universe_key_in_memory <key_id>
+    yb-admin --master_addresses $MASTER_ADDRESSES all_masters_have_universe_key_in_memory <key_id>
     ```
 
     If the preceding command fails, rerun step 2. Once this succeeds, instruct the cluster to start using the new universe key, as follows:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES rotate_universe_key_in_memory <key_id>
+    yb-admin --master_addresses $MASTER_ADDRESSES rotate_universe_key_in_memory <key_id>
     ```
 
     Because data is encrypted in the background as part of flushes to disk and compactions, only new data is encrypted. Therefore, the call should return quickly.
@@ -68,7 +68,7 @@ You enable encryption as follows:
 1. Verify that encryption has been enabled. To do this, check the encryption status of the cluster by executing the following yb-admin command:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES is_encryption_enabled
+    yb-admin --master_addresses $MASTER_ADDRESSES is_encryption_enabled
     ```
 
     Expect the following output:
@@ -92,7 +92,7 @@ You can rotate the new key as follows:
 1. Copy the new key to master nodes, informing the master nodes about the new key, as follows:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES add_universe_key_to_all_masters
+    yb-admin --master_addresses $MASTER_ADDRESSES add_universe_key_to_all_masters
     <key_id_2> /path_to_universe_key_2
     ```
 
@@ -101,7 +101,7 @@ You can rotate the new key as follows:
 1. Ensure that the masters know about the key, and then perform the rotation, as follows:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES rotate_universe_key_in_memory <key_id_2>
+    yb-admin --master_addresses $MASTER_ADDRESSES rotate_universe_key_in_memory <key_id_2>
     ```
 
     Because this key is only used for new data and can only eventually encrypt older data through compactions, it is best to ensure old keys remain secure.
@@ -109,7 +109,7 @@ You can rotate the new key as follows:
 1. Verify the new key. To do this, check that the new key is encrypting the cluster, as follows:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES is_encryption_enabled
+    yb-admin --master_addresses $MASTER_ADDRESSES is_encryption_enabled
     ```
 
     Expect the following output:
@@ -127,13 +127,13 @@ You can disable cluster-wide encryption as follows:
 1. Disable encryption by executing the following yb-admin command:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES disable_encryption
+    yb-admin --master_addresses $MASTER_ADDRESSES disable_encryption
     ```
 
 1. Verify that the encryption has been disabled by executing the following command:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES is_encryption_enabled
+    yb-admin --master_addresses $MASTER_ADDRESSES is_encryption_enabled
     ```
 
     Expect the following output:

--- a/docs/content/preview/secure/tls-encryption/connect-to-cluster.md
+++ b/docs/content/preview/secure/tls-encryption/connect-to-cluster.md
@@ -61,7 +61,7 @@ For example, the following command lists the master information for the TLS-enab
 
 ```sh
 export MASTERS=node1:7100,node2:7100,node3:7100
-./bin/yb-admin --master_addresses $MASTERS -certs_dir_name ~/yugabyte-tls-config list_all_masters
+./bin/yb-admin --master_addresses $MASTERS --certs_dir_name ~/yugabyte-tls-config list_all_masters
 ```
 
 You should see the following output format:

--- a/docs/content/preview/troubleshoot/cluster/performance-troubleshooting.md
+++ b/docs/content/preview/troubleshoot/cluster/performance-troubleshooting.md
@@ -119,22 +119,22 @@ You can run various commands using yb-admin. You need to specify the full set of
 
 ```sh
 # Get all tables
-./yb-admin -master_addresses 127.0.0.1:7000,127.0.0.2:7000,127.0.0.3:7000 list_tables
+./yb-admin --master_addresses 127.0.0.1:7000,127.0.0.2:7000,127.0.0.3:7000 list_tables
 
 # Get all tablets for a specific table
-./yb-admin -master_addresses 127.0.0.1:7000,127.0.0.2:7000,127.0.0.3:7000 list_tablets yb_load_test
+./yb-admin --master_addresses 127.0.0.1:7000,127.0.0.2:7000,127.0.0.3:7000 list_tablets yb_load_test
 
 # List the tablet servers for each tablet
-./yb-admin -master_addresses 127.0.0.1:7000,127.0.0.2:7000,127.0.0.3:7000 list_tablet_servers $(./yb-admin -master_addresses 127.0.0.1:7000,127.0.0.2:7000,127.0.0.3:7000 list_tablets yb_load_test)
+./yb-admin --master_addresses 127.0.0.1:7000,127.0.0.2:7000,127.0.0.3:7000 list_tablet_servers $(./yb-admin --master_addresses 127.0.0.1:7000,127.0.0.2:7000,127.0.0.3:7000 list_tablets yb_load_test)
 
 # List all tablet servers
-./yb-admin -master_addresses 127.0.0.1:7000,127.0.0.2:7000,127.0.0.3:7000 list_all_tablet_servers
+./yb-admin --master_addresses 127.0.0.1:7000,127.0.0.2:7000,127.0.0.3:7000 list_all_tablet_servers
 
 # List all masters
-./yb-admin -master_addresses 127.0.0.1:7000,127.0.0.2:7000,127.0.0.3:7000 list_all_masters
+./yb-admin --master_addresses 127.0.0.1:7000,127.0.0.2:7000,127.0.0.3:7000 list_all_masters
 
 # Output master state to console
-./yb-admin -master_addresses 127.0.0.1:7000,127.0.0.2:7000,127.0.0.3:7000 dump_masters_state
+./yb-admin --master_addresses 127.0.0.1:7000,127.0.0.2:7000,127.0.0.3:7000 dump_masters_state
 ```
 
 ## Real-time metrics

--- a/docs/content/preview/troubleshoot/cluster/recover_server.md
+++ b/docs/content/preview/troubleshoot/cluster/recover_server.md
@@ -48,8 +48,8 @@ If a new YB-Master needs to be started to replace a failed one, the master quoru
 Suppose, the original YB-Masters were n1, n2, n3. And n3 needs to be replaced with a new YB-Master n4. Then you need to use the yb-admin subcommand `change_master_config`, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses n1:7100,n2:7100 change_master_config REMOVE_SERVER n3 7100
-./bin/yb-admin -master_addresses n1:7100,n2:7100 change_master_config ADD_SERVER n4 7100
+./bin/yb-admin --master_addresses n1:7100,n2:7100 change_master_config REMOVE_SERVER n3 7100
+./bin/yb-admin --master_addresses n1:7100,n2:7100 change_master_config ADD_SERVER n4 7100
 ```
 
 The YB-TServer's in-memory state automatically learns of the new master after the `ADD_SERVER` step and does not need a restart.

--- a/docs/content/preview/troubleshoot/cluster/replace_master.md
+++ b/docs/content/preview/troubleshoot/cluster/replace_master.md
@@ -36,13 +36,13 @@ If the YB-Master to be replaced is already dead (for example, the VM was termina
 2. Add the replacement YB-Master server into the existing cluster by running the [`yb-admin change_master_config ADD_SERVER`](../../../admin/yb-admin/#change-master-config) command, as follows:
 
    ```sh
-   ./bin/yb-admin -master_addresses M1:7100,M2:7100,M3:7100 change_master_config ADD_SERVER M4 7100
+   ./bin/yb-admin --master_addresses M1:7100,M2:7100,M3:7100 change_master_config ADD_SERVER M4 7100
    ```
 
 3. Remove the failed YB-Master server from the cluster by using the [`yb-admin change_master_config REMOVE_SERVER`](../../../admin/yb-admin/#change-master-config) command, as follows:
 
    ```sh
-   ./yb-admin -master_addresses M1:7100,M2:7100,M3:7100,M4:7100 change_master_config REMOVE_SERVER M1 7100
+   ./yb-admin --master_addresses M1:7100,M2:7100,M3:7100,M4:7100 change_master_config REMOVE_SERVER M1 7100
    ```
 
    Make sure to specify all YB-Master addresses, including M4, to make sure that if M4 becomes the leader, then yb-admin can find it.
@@ -50,7 +50,7 @@ If the YB-Master to be replaced is already dead (for example, the VM was termina
 4. Validate cluster by checking that your set of masters is now `M2`, `M3` and `M4`, as follows:
 
    ```bash
-   ./yb-admin -master_addresses M2:7100,M3:7100,M4:7100 list_all_masters
+   ./yb-admin --master_addresses M2:7100,M3:7100,M4:7100 list_all_masters
    ```
 
 Until [#1542](https://github.com/yugabyte/yugabyte-db/issues/1542) is implemented, the YB-TServer by default can only be aware of the YB-Master servers that are encoded in the `--tserver_master_addrs` flag with which they are started. If any of those YB-Master servers are still part of the active quorum, then they can propagate the new master quorum via heartbeats. If none of the current YB-Master servers are present in the YB-TServer flag, then the YB-TServer cannot join the cluster. Therefore, it is important to update `--tserver_master_addrs` on every YB-TServer to the new set of master addresses as `M2:7100,M3:7100,M4:7100`.

--- a/docs/content/preview/troubleshoot/cluster/replace_tserver.md
+++ b/docs/content/preview/troubleshoot/cluster/replace_tserver.md
@@ -18,7 +18,7 @@ You can replace a failed YB-TServer in a YugabyteDB cluster, as follows:
 2. Blacklist the failed YB-TServer by using the following command:
 
    ```sh
-   ~/master/bin/yb-admin -master_addresses $MASTERS change_blacklist ADD $OLD_IP:9100
+   ~/master/bin/yb-admin --master_addresses $MASTERS change_blacklist ADD $OLD_IP:9100
    ```
 
    For details, see [change_blacklist](../../../admin/yb-admin/#change-blacklist) in the yb-admin reference page.
@@ -26,7 +26,7 @@ You can replace a failed YB-TServer in a YugabyteDB cluster, as follows:
 3. Wait for the data to drain from the failed YB-TServer and for the data to be loaded into the new one. You can check for the completion of rebalancing by running the following command:
 
    ```sh
-   ~/master/bin/yb-admin -master_addresses $MASTERS get_load_move_completion
+   ~/master/bin/yb-admin --master_addresses $MASTERS get_load_move_completion
    ```
 
    Loading and rebalancing will complete only if data from the failed YB-TServer has someplace to be stored. You would need to start the new YB-TServer first, or ensure your remaining YB-TServers have enough capacity and are in the correct placement zones.
@@ -40,5 +40,5 @@ You can replace a failed YB-TServer in a YugabyteDB cluster, as follows:
 5. Because the replacement YB-TServer is running and is loaded with data, remove the address for the failed YB-TServer from the blacklist, as follows:
 
    ```sh
-   ~/master/bin/yb-admin -master_addresses $MASTERS change_blacklist REMOVE $OLD_IP:9100
+   ~/master/bin/yb-admin --master_addresses $MASTERS change_blacklist REMOVE $OLD_IP:9100
    ```

--- a/docs/content/preview/troubleshoot/nodes/trouble-common.md
+++ b/docs/content/preview/troubleshoot/nodes/trouble-common.md
@@ -42,7 +42,7 @@ The limits are controlled by the following YB-TServer configuration flags: `--ss
 After configuring [encryption in transit](../../../secure/tls-encryption/) for a YugabyteDB cluster, you may encounter the following error when trying to use yb-admin:
 
 ```sh
-./bin/yb-admin -master_addresses <master-addresses> list_all_masters
+./bin/yb-admin --master_addresses <master-addresses> list_all_masters
 ```
 
 ```output

--- a/docs/content/preview/tutorials/build-and-learn/chapter3-tolerating-outages.md
+++ b/docs/content/preview/tutorials/build-and-learn/chapter3-tolerating-outages.md
@@ -223,7 +223,7 @@ Complete the multi-region cluster configuration by setting the US East region as
 
 ```shell
 docker exec -it yugabytedb-node1 bin/yb-admin \
-    -master_addresses yugabytedb-node1:7100,yugabytedb-node2:7100,yugabytedb-node3:7100 \
+    --master_addresses yugabytedb-node1:7100,yugabytedb-node2:7100,yugabytedb-node3:7100 \
     set_preferred_zones gcp.us-east1.us-east1-a:1 gcp.us-central1.us-central1-a:2 gcp.us-west2.us-west2-a:3
 ```
 

--- a/docs/content/preview/tutorials/cdc-tutorials/cdc-aws-msk.md
+++ b/docs/content/preview/tutorials/cdc-tutorials/cdc-aws-msk.md
@@ -191,9 +191,9 @@ Ensure that YugabyteDB is up and running. To install YugabyteDB on your cloud vi
 1. Enable CDC using the yb-admin [create_change_data_stream](../../../admin/yb-admin/#create-change-data-stream) command to enable CDC on all the schemas and tables in the YugabyteDB database as follows:
 
     ```sh
-    ./yb-admin -master_addresses <master_addresses>:7100 \
+    ./yb-admin --master_addresses <master_addresses>:7100 \
          create_change_data_stream ysql.yugabyte \
-        -certs_dir_name /home/yugabyte/yugabyte-tls-config/
+        --certs_dir_name /home/yugabyte/yugabyte-tls-config/
     ```
 
     If you have a multi-node YugabyteDB setup, you need to provide a comma-separated list of **host:port** values of both the leader and the follower nodes as the `master_addresses` argument.

--- a/docs/content/stable/admin/yb-admin.md
+++ b/docs/content/stable/admin/yb-admin.md
@@ -21,10 +21,10 @@ To use yb-admin from the YugabyteDB home directory, run `./bin/yb-admin` using t
 
 ```sh
 yb-admin \
-    [ -master_addresses <master-addresses> ]  \
-    [ -init_master_addrs <master-address> ]  \
-    [ -timeout_ms <millisec> ] \
-    [ -certs_dir_name <dir-name> ] \
+    [ --master_addresses <master-addresses> ]  \
+    [ --init_master_addrs <master-address> ]  \
+    [ --timeout_ms <millisec> ] \
+    [ --certs_dir_name <dir-name> ] \
     <command> [ command_flags ]
 ```
 
@@ -73,7 +73,7 @@ Gets the configuration for the universe.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_universe_config
 ```
 
@@ -87,7 +87,7 @@ Changes the configuration of a tablet.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     change_config <tablet-id> \
     [ ADD_SERVER | REMOVE_SERVER ] \
     <peer-uuid> \
@@ -117,7 +117,7 @@ Changes the master configuration.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     change_master_config \
     [ ADD_SERVER|REMOVE_SERVER ] \
     <ip-addr> <port> \
@@ -138,7 +138,7 @@ yb-admin \
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_tablet_servers <tablet-id>
 ```
 
@@ -155,7 +155,7 @@ Use this to find out who the LEADER of a tablet is.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_tablets <keyspace-type>.<keyspace-name> <table> [<max-tablets>]
 ```
 
@@ -169,7 +169,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     list_tablets ysql.db_name table_name 0
 ```
 
@@ -187,7 +187,7 @@ Lists all tablet servers.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_all_tablet_servers
 ```
 
@@ -201,7 +201,7 @@ Displays a list of all YB-Master servers in a table listing the master UUID, RPC
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_all_masters
 ```
 
@@ -211,7 +211,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses node7:7100,node8:7100,node9:7100 \
+    --master_addresses node7:7100,node8:7100,node9:7100 \
     list_all_masters
 ```
 
@@ -230,7 +230,7 @@ Prints a list of replica types and counts for the specified table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_replica_type_counts <keyspace> <table-name>
 ```
 
@@ -246,7 +246,7 @@ Prints the status of the YB-Master servers.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     dump_masters_state
 ```
 
@@ -260,7 +260,7 @@ List the locations of the tablet server logs.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_tablet_server_log_locations
 ```
 
@@ -274,7 +274,7 @@ Lists all tablets for the specified tablet server (YB-TServer).
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_tablets_for_tablet_server <ts-uuid>
 ```
 
@@ -287,7 +287,7 @@ Splits the specified hash-sharded tablet and computes the split point as the mid
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     split_tablet <tablet-id-to-split>
 ```
 
@@ -315,7 +315,7 @@ Forces the master leader to step down. The specified YB-Master node will take it
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     master_leader_stepdown [ <new-leader-id> ]
 ```
 
@@ -330,7 +330,7 @@ Prints the current YSQL schema catalog version.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     ysql_catalog_version
 ```
 
@@ -340,7 +340,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     ysql_catalog_version
 ```
 
@@ -362,14 +362,14 @@ Prints a list of all tables. Optionally, include the database type, table ID, an
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_tables \
     [ include_db_type ] [ include_table_id ] [ include_table_type ]
 ```
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> list_tables
+    --master_addresses <master-addresses> list_tables
 ```
 
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default is `localhost:7100`.
@@ -399,7 +399,7 @@ To display a list of tables and their UUID (`table_id`) values, open the **YB-Ma
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     list_tables
 ```
 
@@ -434,7 +434,7 @@ Triggers manual compaction on a table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     compact_table <db-type>.<namespace> <table> [<timeout-in-seconds>] [ADD_INDEXES]
 ```
 
@@ -449,7 +449,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     compact_table ysql.yugabyte table_name
 ```
 
@@ -461,7 +461,7 @@ Compacted [yugabyte.table_name] tables.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     compact_table tableid.<table-id> [<timeout-in-seconds>] [ADD_INDEXES]
 ```
 
@@ -474,7 +474,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     compact_table tableid.000033eb000030008000000000004002
 ```
 
@@ -488,7 +488,7 @@ Show the status of full compaction on a table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     compaction_status <db-type>.<namespace> <table> [show_tablets]
 ```
 
@@ -502,7 +502,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     compaction_status ysql.yugabyte table_name show_tablets
 ```
 
@@ -549,7 +549,7 @@ Modifies the placement information (cloud, region, and zone) for a table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     modify_table_placement_info <keyspace> <table-name> <placement-info> <replication-factor> \
     [ <placement-id> ]
 ```
@@ -558,7 +558,7 @@ or alternatively:
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     modify_table_placement_info tableid.<table-id> <placement-info> <replication-factor> \
     [ <placement-id> ]
 ```
@@ -575,7 +575,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     modify_table_placement_info  testdatabase testtable \
     aws.us-west.us-west-2a,aws.us-west.us-west-2b,aws.us-west.us-west-2c 3
 ```
@@ -597,7 +597,7 @@ Creates a transaction status table to be used in a region. This command should a
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_transaction_table \
     <table-name>
 ```
@@ -611,7 +611,7 @@ The transaction status table will be created as `system.<table-name>`.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     create_transaction_table \
     transactions_us_east
 ```
@@ -622,7 +622,7 @@ Next, set the placement on the newly created transactions table:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     modify_table_placement_info system transactions_us_east \
     aws.us-east.us-east-1a,aws.us-east.us-east-1b,aws.us-east.us-east-1c 3
 ```
@@ -643,7 +643,7 @@ Add a tablet to a transaction status table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     add_transaction_tablet \
     <table-id>
 ```
@@ -655,7 +655,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     add_transaction_tablet 000033eb000030008000000000004002
 ```
 
@@ -669,7 +669,7 @@ Flush the memstores of the specified table on all tablet servers to disk.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     flush_table <db-type>.<namespace> <table> [<timeout-in-seconds>] [ADD_INDEXES]
 ```
 
@@ -684,7 +684,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     flush_table ysql.yugabyte table_name
 
 ```
@@ -697,7 +697,7 @@ Flushed [yugabyte.table_name] tables.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     flush_table tableid.<table-id> [<timeout-in-seconds>] [ADD_INDEXES]
 ```
 
@@ -710,7 +710,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     flush_table tableid.000033eb000030008000000000004002
 ```
 
@@ -726,7 +726,7 @@ Backfill all DEFERRED indexes in a YCQL table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     backfill_indexes_for_table <keyspace> <table-name>
 ```
 
@@ -738,7 +738,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     backfill_indexes_for_table ybdemo table_name
 ```
 
@@ -779,7 +779,7 @@ Creates a snapshot of the specified YSQL database.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_database_snapshot <database>
 ```
 
@@ -792,7 +792,7 @@ When this command runs, a `snapshot_id` is generated and printed.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     create_database_snapshot
 ```
 
@@ -806,7 +806,7 @@ Creates a snapshot of the specified YCQL keyspace.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_keyspace_snapshot <keyspace>
 ```
 
@@ -819,7 +819,7 @@ When this command runs, a `snapshot_id` is generated and printed.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     create_keyspace_snapshot
 ```
 
@@ -833,7 +833,7 @@ Prints a list of all snapshot IDs, restoration IDs, and states. Optionally, prin
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_snapshots \
     [ show_details ] [ not_show_restored ]
 ```
@@ -883,7 +883,7 @@ In this example, the optional `show_details` flag is added to generate the snaps
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     list_snapshots show_details
 ```
 
@@ -919,7 +919,7 @@ Use the [create_snapshot_schedule](#create-snapshot-schedule) command to create 
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_snapshot <keyspace> <table-name> | <table_id> \
     [<keyspace> <table-name> | <table-id> ]... \
     [<flush-timeout-in-seconds>]
@@ -937,7 +937,7 @@ When this command runs, a `snapshot_id` is generated and printed.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     create_snapshot ydb test_tb
 ```
 
@@ -959,7 +959,7 @@ Restores the specified snapshot, including the tables and indexes. When the oper
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     restore_snapshot <snapshot-id> <restore-target>
 ```
 
@@ -1009,7 +1009,7 @@ Returns one or more restorations in JSON format.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_snapshot_restorations <restoration-id>
 ```
 
@@ -1020,7 +1020,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     list_snapshot_restorations 26ed9053-0c26-4277-a2b8-c12d0fa4c8cf
 ```
 
@@ -1044,7 +1044,7 @@ Generates a metadata file for the specified snapshot, listing all the relevant i
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     export_snapshot <snapshot-id> <file-name>
 ```
 
@@ -1056,7 +1056,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     export_snapshot 4963ed18fc1e4f1ba38c8fcf4058b295 \
     test_tb.snapshot
 ```
@@ -1074,7 +1074,7 @@ Imports the specified snapshot metadata file.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     import_snapshot <file-name> \
     [<keyspace> <table-name> [<keyspace> <table-name>]...]
 ```
@@ -1094,7 +1094,7 @@ The *keyspace* and the *table* can be different from the exported one.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     import_snapshot test_tb.snapshot ydb test_tb
 ```
 
@@ -1120,7 +1120,7 @@ Imports only the specified tables from the specified snapshot metadata file.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     import_snapshot_selective <file-name> \
     [<keyspace> <table-name> [<keyspace> <table-name>]...]
 ```
@@ -1140,7 +1140,7 @@ The *keyspace* can be different from the exported one. The name of the table nee
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     import_snapshot_selective test_tb.snapshot ydb test_tb
 ```
 
@@ -1166,7 +1166,7 @@ Deletes the specified snapshot.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     delete_snapshot <snapshot-id>
 ```
 
@@ -1183,7 +1183,7 @@ Returns a schedule ID in JSON format.
 
 ```sh
 yb-admin create_snapshot_schedule \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     <snapshot-interval>\
     <retention-time>\
     <filter-expression>
@@ -1202,7 +1202,7 @@ Take a snapshot of the YSQL database `yugabyte` once per minute, and retain each
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     create_snapshot_schedule 1 10 ysql.yugabyte
 ```
 
@@ -1210,7 +1210,7 @@ The equivalent command for the YCQL keyspace `yugabyte` would be the following:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     create_snapshot_schedule 1 10 yugabyte
 ```
 
@@ -1242,7 +1242,7 @@ Returns one or more schedule lists in JSON format.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_snapshot_schedules <schedule-id>
 ```
 
@@ -1253,7 +1253,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     list_snapshot_schedules 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
 ```
 
@@ -1290,7 +1290,7 @@ Schedules group a set of items into a single tracking object (the *schedule*). W
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     restore_snapshot_schedule <schedule-id> <restore-target>
 ```
 
@@ -1322,7 +1322,7 @@ Restore from an absolute timestamp:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 1617670679185100
 ```
 
@@ -1330,7 +1330,7 @@ Restore from a relative time:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 minus 60s
 ```
 
@@ -1353,7 +1353,7 @@ Returns a JSON object with the `schedule_id` that was just deleted.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     delete_snapshot_schedule <schedule-id>
 ```
 
@@ -1364,7 +1364,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     delete_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
 ```
 
@@ -1390,7 +1390,7 @@ Modifies the placement information (cloud, region, and zone) for a deployment.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     modify_placement_info <placement-info> <replication-factor> \
     [ <placement-id> ]
 ```
@@ -1404,7 +1404,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     modify_placement_info  \
     aws.us-west.us-west-2a:2,aws.us-west.us-west-2b:2,aws.us-west.us-west-2c 5
 ```
@@ -1447,7 +1447,7 @@ Having all tablet leaders reside in a single region reduces the number of networ
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     set_preferred_zones <cloud.region.zone>[:<preference>] \
     [<cloud.region.zone>[:<preference>]]...
 ```
@@ -1594,7 +1594,7 @@ Add a read replica cluster to the master configuration.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     add_read_replica_placement_info <placement-info> \
     <replication-factor> \
     [ <placement-id> ]
@@ -1612,7 +1612,7 @@ yb-admin \
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     modify_read_replica_placement_info <placement-info> \
     <replication-factor> \
     [ <placement-id> ]
@@ -1631,7 +1631,7 @@ Delete the read replica.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     delete_read_replica_placement_info
 ```
 
@@ -1653,7 +1653,7 @@ Sets the contents of *key-path* in-memory on each YB-Master node.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     add_universe_key_to_all_masters <key-id> <key-path>
 ```
 
@@ -1673,7 +1673,7 @@ Checks whether the universe key associated with the provided *key-id* exists in-
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> all_masters_have_universe_key_in_memory <key-id>
+    --master_addresses <master-addresses> all_masters_have_universe_key_in_memory <key-id>
 ```
 
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default is `localhost:7100`.
@@ -1693,7 +1693,7 @@ The [all_masters_have_universe_key_in_memory](#all-masters-have-universe-key-in-
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> rotate_universe_key_in_memory <key-id>
+    --master_addresses <master-addresses> rotate_universe_key_in_memory <key-id>
 ```
 
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default is `localhost:7100`.
@@ -1707,7 +1707,7 @@ Disables the in-memory encryption at rest for newly-written data files.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     disable_encryption_in_memory
 ```
 
@@ -1721,7 +1721,7 @@ Checks if cluster-wide encryption is enabled.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     is_encryption_enabled
 ```
 
@@ -1739,7 +1739,7 @@ The new key ID (`<key_id_2>`) should be different from the previous one (`<key_i
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     is_encryption_enabled
 ```
 
@@ -1757,7 +1757,7 @@ Create a change data capture (CDC) DB stream for the specified namespace using t
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_change_data_stream ysql.<namespace-name>
 ```
 
@@ -1768,7 +1768,7 @@ For example:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100 \
+    --master_addresses 127.0.0.1:7100 \
     create_change_data_stream ysql.yugabyte
 ```
 
@@ -1781,7 +1781,7 @@ This feature is {{<tags/feature/tp>}}. Use the [yb_enable_cdc_consistent_snapsho
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_change_data_stream ysql.<namespace-name> [EXPLICIT] [<before-image-mode>] [USE_SNAPSHOT | NOEXPORT_SNAPSHOT]
 ```
 
@@ -1795,7 +1795,7 @@ For example:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100 \
+    --master_addresses 127.0.0.1:7100 \
     create_change_data_stream ysql.yugabyte EXPLICIT CHANGE USE_SNAPSHOT
 ```
 
@@ -1807,7 +1807,7 @@ To create a change data capture (CDC) DB stream which also supports sending the 
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_change_data_stream ysql.<namespace-name> [EXPLICIT] <before-image-mode>
 ```
 
@@ -1830,7 +1830,7 @@ To create a change data capture (CDC) DB stream which works in the EXPLICIT chec
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_change_data_stream ysql.<namespace-name> EXPLICIT
 ```
 
@@ -1858,7 +1858,7 @@ Lists all the created CDC DB streams.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_change_data_streams [namespace-name]
 ```
 
@@ -1869,7 +1869,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100 \
+    --master_addresses 127.0.0.1:7100 \
     list_change_data_streams
 ```
 
@@ -1915,7 +1915,7 @@ Get the information associated with a particular CDC DB stream.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_change_data_stream_info <db-stream-id>
 ```
 
@@ -1926,7 +1926,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100 \
+    --master_addresses 127.0.0.1:7100 \
     get_change_data_stream_info d540f5e4890c4d3b812933cbfd703ed3
 ```
 
@@ -1949,7 +1949,7 @@ Delete the specified CDC DB stream.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     delete_change_data_stream <db-stream-id>
 ```
 
@@ -1960,7 +1960,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100 \
+    --master_addresses 127.0.0.1:7100 \
     delete_change_data_stream d540f5e4890c4d3b812933cbfd703ed3
 ```
 
@@ -1984,7 +1984,7 @@ To verify if any tables are already configured for replication, use [list_cdc_st
 
 ```sh
 yb-admin \
-    -master_addresses <target-master-addresses> \
+    --master_addresses <target-master-addresses> \
     setup_universe_replication \
     <replication-group-id> \
     <source-master-addresses> \
@@ -2014,7 +2014,7 @@ To display a list of tables and their UUID (`table_id`) values, open the **YB-Ma
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     setup_universe_replication e260b8b6-e89f-4505-bb8e-b31f74aa29f3_xClusterSetup1 \
     127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     000030a5000030008000000000004000,000030a5000030008000000000004005,dfef757c415c4b2cacc9315b8acb539a
@@ -2036,7 +2036,7 @@ To check if any tables are configured for replication, use [list_cdc_streams](#l
 Use the `set_master_addresses` subcommand to replace the source master address list. Use this if the set of masters on the source changes:
 
 ```sh
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
     alter_universe_replication <replication-group-id> \
     set_master_addresses <source-master-addresses>
 ```
@@ -2048,7 +2048,7 @@ yb-admin -master_addresses <target-master-addresses> \
 Use the `add_table` subcommand to add one or more tables to the existing list:
 
 ```sh
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
     alter_universe_replication <replication-group-id> \
     add_table <source-table-ids> \
     [ <bootstrap-ids> ]
@@ -2066,7 +2066,7 @@ Enter the source universe bootstrap IDs in the same order as their corresponding
 Use the `remove_table` subcommand to remove one or more tables from the existing list:
 
 ```sh
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
     alter_universe_replication <replication-group-id> \
     remove_table <source-table-ids> [ignore-errors]
 ```
@@ -2079,7 +2079,7 @@ yb-admin -master_addresses <target-master-addresses> \
 Use the `rename_id` subcommand to rename xCluster replication streams.
 
 ```sh
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
     alter_universe_replication <replication-group-id> \
     rename_id <new-replication-group-id>
 ```
@@ -2096,7 +2096,7 @@ Deletes universe replication for the specified source universe.
 
 ```sh
 yb-admin \
-    -master_addresses <target-master-addresses> \
+    --master_addresses <target-master-addresses> \
     delete_universe_replication <replication-group-id>
 ```
 
@@ -2111,7 +2111,7 @@ Sets the universe replication to be enabled or disabled.
 
 ```sh
 yb-admin \
-    -master_addresses <target-master-addresses> \
+    --master_addresses <target-master-addresses> \
     set_universe_replication_enabled <replication-group-id> [0|1]
 ```
 
@@ -2127,7 +2127,7 @@ Reports the current xCluster safe time for each namespace, which is the time at 
 
 ```sh
 yb-admin \
-    -master_addresses <target-master-addresses> \
+    --master_addresses <target-master-addresses> \
     get_xcluster_safe_time \
     [include_lag_and_skew]
 ```
@@ -2139,7 +2139,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     get_xcluster_safe_time include_lag_and_skew
 ```
 
@@ -2169,7 +2169,7 @@ Verify when the producer and consumer are in sync for a given list of `stream_id
 
 ```sh
 yb-admin \
-    -master_addresses <source-master-addresses> \
+    --master_addresses <source-master-addresses> \
     wait_for_replication_drain \
     <stream-ids> [<timestamp> | minus <interval>]
 ```
@@ -2183,7 +2183,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+    --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     wait_for_replication_drain 000033f1000030008000000000000000,200033f1000030008000000000000002 minus 1m
 ```
 
@@ -2214,7 +2214,7 @@ Use this command when setting up xCluster replication to verify if any tables ar
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_cdc_streams
 ```
 
@@ -2224,7 +2224,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     list_cdc_streams
 ```
 
@@ -2236,7 +2236,7 @@ Deletes underlying xCluster outbound streams.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     delete_cdc_stream <stream-id> \
     [force_delete]
 ```
@@ -2257,7 +2257,7 @@ Mark a set of tables in preparation for setting up xCluster replication.
 
 ```sh
 yb-admin \
-    -master_addresses <source-master-addresses> \
+    --master_addresses <source-master-addresses> \
     bootstrap_cdc_producer <source-table-ids>
 ```
 
@@ -2268,7 +2268,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 172.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 172.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     bootstrap_cdc_producer 000030ad000030008000000000004000
 ```
 
@@ -2288,7 +2288,7 @@ Returns the xCluster replication status of all inbound replication groups. If *r
 
 ```sh
 yb-admin \
-    -master_addresses <target-master-addresses> \
+    --master_addresses <target-master-addresses> \
     get_replication_status [ <replication-group-id> ]
 ```
 
@@ -2299,7 +2299,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 172.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 172.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     get_replication_status e260b8b6-e89f-4505-bb8e-b31f74aa29f3
 ```
 
@@ -2322,7 +2322,7 @@ Checkpoint namespaces for use in xCluster replication.
 
 ```sh
 yb-admin \
-    -master_addresses <source-master-addresses> \
+    --master_addresses <source-master-addresses> \
     create_xcluster_checkpoint \
     <replication-group-id> \
     <namespace_names> \
@@ -2342,7 +2342,7 @@ Checks if the databases of a previously checkpointed replication group requires 
 
 ```sh
 yb-admin \
-    -master_addresses <source-master-addresses> \
+    --master_addresses <source-master-addresses> \
     is_xcluster_bootstrap_required \
     <replication-group-id> \
     <namespace-names>
@@ -2360,7 +2360,7 @@ Setup xCluster replication using a previously created [checkpoint](#create-xclus
 
 ```sh
 yb-admin \
-    -master_addresses <source-master-addresses> \
+    --master_addresses <source-master-addresses> \
     setup_xcluster_replication \
     <replication-group-id> \
     <target-master-addresses>
@@ -2378,7 +2378,7 @@ Drops the xCluster replication group. If *target-master-addresses* are provided,
 
 ```sh
 yb-admin \
-    -master_addresses <source-master-addresses> \
+    --master_addresses <source-master-addresses> \
     drop_xcluster_replication \
     <replication-group-id> \
     [<target-master-addresses>]
@@ -2396,7 +2396,7 @@ Adds a database to an existing xCluster checkpoint.
 
 ```sh
 yb-admin \
-    -master_addresses <source-master-addresses> \
+    --master_addresses <source-master-addresses> \
     add_namespace_to_xcluster_checkpoint \
     <replication-group-id> \
     <namespace-name>
@@ -2414,7 +2414,7 @@ Adds a database to an existing xCluster replication after it has been checkpoint
 
 ```sh
 yb-admin \
-    -master_addresses <source-master-addresses> \
+    --master_addresses <source-master-addresses> \
     add_namespace_to_xcluster_replication \
     <replication-group-id> \
     <namespace-name> \
@@ -2434,7 +2434,7 @@ Removes a database from an existing xCluster replication. If target master addre
 
 ```sh
 yb-admin \
-    -master_addresses <source-master-addresses> \
+    --master_addresses <source-master-addresses> \
     remove_namespace_from_xcluster_replication \
     <replication-group-id> \
     <namespace-name> \
@@ -2454,7 +2454,7 @@ List The replication group identifiers for all outbound xCluster replications. I
 
 ```sh
 yb-admin \
-    -master_addresses <source-master-addresses> \
+    --master_addresses <source-master-addresses> \
     list_xcluster_outbound_replication_groups \
     [<namespace-id>]
 ```
@@ -2470,7 +2470,7 @@ Display the status of a specific outbound xCluster replication group.
 
 ```sh
 yb-admin \
-    -master_addresses <source-master-addresses> \
+    --master_addresses <source-master-addresses> \
     get_xcluster_outbound_replication_group_info \
     <replication-group-id>
 ```
@@ -2486,7 +2486,7 @@ List The replication group identifiers for all inbound xCluster replications. If
 
 ```sh
 yb-admin \
-    -master_addresses <target-master-addresses> \
+    --master_addresses <target-master-addresses> \
     list_universe_replications \
     [<namespace-id>]
 ```
@@ -2506,7 +2506,7 @@ Gets the tablet load move completion percentage for blacklisted nodes.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_leader_blacklist_completion
 ```
 
@@ -2516,7 +2516,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     get_leader_blacklist_completion
 ```
 
@@ -2530,7 +2530,7 @@ After old YB-TServer servers are terminated, you can use this command to clean u
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     change_blacklist [ ADD | REMOVE ] <ip_addr>:<port> \
     [ <ip_addr>:<port> ]...
 ```
@@ -2543,7 +2543,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     change_blacklist \
       ADD node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
 ```
@@ -2554,7 +2554,7 @@ yb-admin \
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     change_leader_blacklist [ ADD | REMOVE ] <ip_addr>:<port> \
     [ <ip_addr>:<port> ]...
 ```
@@ -2567,7 +2567,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     change_leader_blacklist \
       ADD node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
 ```
@@ -2588,7 +2588,7 @@ There is a possibility of downtime.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     leader_stepdown <tablet-id> <dest-ts-uuid>
 ```
 
@@ -2618,7 +2618,7 @@ Enables or disables the load balancer.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     set_load_balancer_enabled [ 0 | 1 ]
 ```
 
@@ -2629,7 +2629,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     set_load_balancer_enabled 0
 ```
 
@@ -2641,7 +2641,7 @@ Returns the cluster load balancer state.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> get_load_balancer_state
+    --master_addresses <master-addresses> get_load_balancer_state
 ```
 
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default is `localhost:7100`.
@@ -2656,7 +2656,7 @@ You can rerun this command periodically until the value reaches `100.0`, indicat
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_load_move_completion
 ```
 
@@ -2681,7 +2681,7 @@ In the following example, the data move is `66.6` percent done.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     get_load_move_completion
 ```
 
@@ -2699,7 +2699,7 @@ Finds out if the load balancer is idle.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_is_load_balancer_idle
 ```
 
@@ -2709,7 +2709,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     get_is_load_balancer_idle
 ```
 
@@ -2729,7 +2729,7 @@ Returns the current AutoFlags configuration of the universe.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_auto_flags_config
 ```
 
@@ -2738,7 +2738,7 @@ yb-admin \
 **Example**
 
 ```sh
-./bin/yb-admin -master_addresses ip1:7100,ip2:7100,ip3:7100 get_auto_flags_config
+./bin/yb-admin --master_addresses ip1:7100,ip2:7100,ip3:7100 get_auto_flags_config
 ```
 
 If the operation is successful you should see output similar to the following:
@@ -2784,7 +2784,7 @@ Note that `promote_auto_flags` is a cluster-level operation; you don't need to r
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     promote_auto_flags \
     [<max-flags-class> [<promote-non-runtime-flags> [force]]]
 ```
@@ -2798,7 +2798,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     promote_auto_flags kLocalPersisted
 ```
 
@@ -2826,7 +2826,7 @@ YSQL upgrades are not required for clusters where [YSQL is not enabled](../../re
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     upgrade_ysql
 ```
 
@@ -2836,7 +2836,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     upgrade_ysql
 ```
 
@@ -2850,8 +2850,8 @@ In certain scenarios, a YSQL upgrade can take longer than 60 seconds, which is t
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
-    -timeout_ms 180000 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --timeout_ms 180000 \
     upgrade_ysql
 ```
 
@@ -2869,7 +2869,7 @@ Finalizes an upgrade after a successful [YSQL major upgrade](../../manage/ysql-m
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     finalize_upgrade
 ```
 

--- a/docs/content/stable/api/ycql/ddl_create_index.md
+++ b/docs/content/stable/api/ycql/ddl_create_index.md
@@ -187,7 +187,7 @@ After creating a set of indexes with their backfill deferred, you can then trigg
    Launch a backfill job for backfilling all the deferred indexes using the `backfill_indexes_for_table` command as follows:
 
     ```bash
-    bin/yb-admin -master_addresses <ip:port> backfill_indexes_for_table ycql.ybdemo table_name
+    bin/yb-admin --master_addresses <ip:port> backfill_indexes_for_table ycql.ybdemo table_name
     ```
 - Use the [`--defer_index_backfill`](../../../reference/configuration/yb-master#defer-index-backfill) YB-Master flag to force all indexes to be DEFERRED, and run `yb-admin backfill_indexes_for_table` to backfill indexes.
 

--- a/docs/content/stable/api/ysql/exprs/geo_partitioning_helper_functions/func_yb_is_local_table.md
+++ b/docs/content/stable/api/ysql/exprs/geo_partitioning_helper_functions/func_yb_is_local_table.md
@@ -55,7 +55,7 @@ This function is helpful while implementing [Row-level geo-partitioning](../../.
 1. Use [yb-admin](../../../../../admin/yb-admin/) to specify the placement configuration to be used by the cluster as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses <IP1>:7100 modify_placement_info aws.us-west-1.us-west-1c:1,aws.us-east-1.us-east-1a:1,aws.us-east-2.us-east-2c:1 3
+    ./bin/yb-admin --master_addresses <IP1>:7100 modify_placement_info aws.us-west-1.us-west-1c:1,aws.us-east-1.us-east-1a:1,aws.us-east-2.us-east-2c:1 3
     ```
 
 1. Create tablespaces corresponding to the regions used by the cluster created above [using ysqlsh](../../../../ysqlsh/#using-ysqlsh) as follows:

--- a/docs/content/stable/api/ysql/exprs/geo_partitioning_helper_functions/func_yb_server_region.md
+++ b/docs/content/stable/api/ysql/exprs/geo_partitioning_helper_functions/func_yb_server_region.md
@@ -63,7 +63,7 @@ Do the following to create a 3-node multi-region cluster and a geo-partitioned t
 1. Use [yb-admin](../../../../../admin/yb-admin/) to specify the placement configuration to be used by the cluster:
 
     ```sh
-    ./bin/yb-admin -master_addresses <IP1>:7100 modify_placement_info aws.us-west-1.us-west-1c:1,aws.us-east-1.us-east-1a:1,aws.us-east-2.us-east-2c:1 3
+    ./bin/yb-admin --master_addresses <IP1>:7100 modify_placement_info aws.us-west-1.us-west-1c:1,aws.us-east-1.us-east-1a:1,aws.us-east-2.us-east-2c:1 3
     ```
 
 1. Create tablespaces corresponding to the regions used by the cluster created above [using ysqlsh](../../../../ysqlsh/#using-ysqlsh):

--- a/docs/content/stable/deploy/multi-dc/async-replication/async-deployment.md
+++ b/docs/content/stable/deploy/multi-dc/async-replication/async-deployment.md
@@ -35,20 +35,20 @@ After you created the required tables, you can set up unidirectional replication
   - To find a table ID, execute the following command as an admin user:
 
       ```sh
-      ./bin/yb-admin -master_addresses <source_universe_master_addresses> list_tables include_table_id
+      ./bin/yb-admin --master_addresses <source_universe_master_addresses> list_tables include_table_id
       ```
 
       The preceding command lists all the tables, including system tables. To locate a specific table, you can add grep as follows:
 
       ```sh
-      ./bin/yb-admin -master_addresses <source_universe_master_addresses> list_tables include_table_id | grep table_name
+      ./bin/yb-admin --master_addresses <source_universe_master_addresses> list_tables include_table_id | grep table_name
       ```
 
 - Run the following yb-admin [`setup_universe_replication`](../../../../admin/yb-admin/#setup-universe-replication) command from the YugabyteDB home directory in the source universe:
 
     ```sh
     ./bin/yb-admin \
-      -master_addresses <target_universe_master_addresses> \
+      --master_addresses <target_universe_master_addresses> \
       setup_universe_replication <source_universe_UUID>_<replication_stream_name> \
         <source_universe_master_addresses> \
         <table_id>,[<table_id>..]
@@ -58,7 +58,7 @@ After you created the required tables, you can set up unidirectional replication
 
     ```sh
     ./bin/yb-admin \
-      -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+      --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
       setup_universe_replication e260b8b6-e89f-4505-bb8e-b31f74aa29f3_xClusterSetup1 \
         127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         000030a5000030008000000000004000,000030a5000030008000000000004005,dfef757c415c4b2cacc9315b8acb539a
@@ -134,7 +134,7 @@ You can use yb-admin to return the current replication status. The `get_replicat
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7000,127.0.0.2:7000,127.0.0.3:7000 \
+    --master_addresses 127.0.0.1:7000,127.0.0.2:7000,127.0.0.3:7000 \
     get_replication_status
 ```
 
@@ -158,8 +158,8 @@ If both universes use the same certificates, run `yb-admin setup_universe_replic
 Consider the following example:
 
 ```sh
-./bin/yb-admin -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
-  -certs_dir_name /home/yugabyte/yugabyte-tls-config \
+./bin/yb-admin --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+  --certs_dir_name /home/yugabyte/yugabyte-tls-config \
   setup_universe_replication e260b8b6-e89f-4505-bb8e-b31f74aa29f3_xClusterSetup1 \
   127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
   000030a5000030008000000000004000,000030a5000030008000000000004005,dfef757c415c4b2cacc9315b8acb539a
@@ -182,8 +182,8 @@ When universes use different certificates, you need to store the certificates fo
     For example, if you have the target universe's certificates in `/home/yugabyte/yugabyte-tls-config`, then you would run the following:
 
     ```sh
-    ./bin/yb-admin -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
-      -certs_dir_name /home/yugabyte/yugabyte-tls-config \
+    ./bin/yb-admin --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+      --certs_dir_name /home/yugabyte/yugabyte-tls-config \
       setup_universe_replication 00000000-1111-2222-3333-444444444444_xClusterSetup1 \
       127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
       000030a5000030008000000000004000,000030a5000030008000000000004005,dfef757c415c4b2cacc9315b8acb539a
@@ -261,7 +261,7 @@ To create unidirectional replication, perform the following:
 1. Run the replication setup command for the source universe, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses <target_master_addresses> \
+    ./bin/yb-admin --master_addresses <target_master_addresses> \
     setup_universe_replication <source_universe_UUID>_<replication_stream_name> \
     <source_master_addresses> <comma_separated_table_ids>
     ```
@@ -269,7 +269,7 @@ To create unidirectional replication, perform the following:
     Consider the following example:
 
     ```sh
-    ./bin/yb-admin -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    ./bin/yb-admin --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     setup_universe_replication 00000000-1111-2222-3333-444444444444_xClusterSetup1 \
     127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     000033e1000030008000000000004007,000033e100003000800000000000400d,000033e1000030008000000000004013
@@ -322,7 +322,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
 
   ```sh
   kubectl exec -it -n <source_universe_namespace> -t <source_universe_master_leader> -c \
-    <source_universe_container> -- bash -c "/home/yugabyte/bin/yb-admin -master_addresses \
+    <source_universe_container> -- bash -c "/home/yugabyte/bin/yb-admin --master_addresses \
     <target_universe_master_addresses> setup_universe_replication \
     <source_universe_UUID>_<replication_stream_name> <source_universe_master_addresses> \
     <comma_separated_table_ids>"
@@ -332,7 +332,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
 
   ```sh
   kubectl exec -it -n xcluster-source -t yb-master-2 -c yb-master -- bash -c \
-    "/home/yugabyte/bin/yb-admin -master_addresses yb-master-2.yb-masters.xcluster-target.svc.cluster.local, \
+    "/home/yugabyte/bin/yb-admin --master_addresses yb-master-2.yb-masters.xcluster-target.svc.cluster.local, \
     yb-master-1.yb-masters.xcluster-target.svc.cluster.local,yb-master-0.yb-masters.xcluster-target.svc.cluster.local \
     setup_universe_replication ac39666d-c183-45d3-945a-475452deac9f_xCluster_1 \
     yb-master-2.yb-masters.xcluster-source.svc.cluster.local,yb-master-1.yb-masters.xcluster-source.svc.cluster.local, \
@@ -387,14 +387,14 @@ Proceed as follows:
 1. Create a checkpoint on the source universe for all the tables you want to replicate by executing the following command:
 
     ```sh
-    ./bin/yb-admin -master_addresses <source_universe_master_addresses> \
+    ./bin/yb-admin --master_addresses <source_universe_master_addresses> \
     bootstrap_cdc_producer <comma_separated_source_universe_table_ids>
     ```
 
     Consider the following example:
 
     ```sh
-    ./bin/yb-admin -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+    ./bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     bootstrap_cdc_producer 000033e1000030008000000000004000,000033e1000030008000000000004003,000033e1000030008000000000004006
     ```
 
@@ -410,7 +410,7 @@ Proceed as follows:
 1. Execute the following command to set up the replication stream using the bootstrap IDs generated in step 1. Ensure that the bootstrap IDs are in the same order as their corresponding table IDs.
 
     ```sh
-    ./bin/yb-admin -master_addresses <target_universe_master_addresses> setup_universe_replication \
+    ./bin/yb-admin --master_addresses <target_universe_master_addresses> setup_universe_replication \
       <source_universe_uuid>_<replication_stream_name> <source_universe_master_addresses> \
       <comma_separated_source_universe_table_ids> <comma_separated_bootstrap_ids>
     ```
@@ -418,7 +418,7 @@ Proceed as follows:
     Consider the following example:
 
     ```sh
-    ./bin/yb-admin -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 setup_universe_replication \
+    ./bin/yb-admin --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 setup_universe_replication \
       00000000-1111-2222-3333-444444444444_xCluster1 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
       000033e1000030008000000000004000,000033e1000030008000000000004003,000033e1000030008000000000004006 \
       fb156717174941008e54fa958e613c10,a2a46f5cbf8446a3a5099b5ceeaac28b,c967967523eb4e03bcc201bb464e0679
@@ -470,8 +470,8 @@ When new tables (or partitions) are created, to ensure that all changes from the
 1. Get table IDs of the new partition from the source as follows:
 
     ```sql
-    yb-admin -master_addresses <source_master_ips> \
-    -certs_dir_name <cert_dir> \
+    yb-admin --master_addresses <source_master_ips> \
+    --certs_dir_name <cert_dir> \
     list_tables include_table_id|grep 'order_changes_2023_01'
     ```
 
@@ -484,8 +484,8 @@ When new tables (or partitions) are created, to ensure that all changes from the
 1. Add the new table (or partition) to replication.
 
    ```sql
-   yb-admin -master_addresses <target_master_ips> \
-   -certs_dir_name <cert_dir> \
+   yb-admin --master_addresses <target_master_ips> \
+   --certs_dir_name <cert_dir> \
    alter_universe_replication <replication_group_name> \
    add_table  000033e800003000800000000000410b
    ```
@@ -508,8 +508,8 @@ However, to add a new index to a table that already has data, the following addi
 
    ```sql
    yb-admin
-   -master_addresses <source_master_ips> \
-   -certs_dir_name <cert_dir> \
+   --master_addresses <source_master_ips> \
+   --certs_dir_name <cert_dir> \
    list_tables include_table_id|grep 'my_new_index'
    ```
 
@@ -523,8 +523,8 @@ However, to add a new index to a table that already has data, the following addi
 
    ```sql
    yb-admin
-   -master_addresses <source_master_ips> \
-   -certs_dir_name <cert_dir> \
+   --master_addresses <source_master_ips> \
+   --certs_dir_name <cert_dir> \
    bootstrap_cdc_producer 000033e8000030008000000000004028
    ```
 
@@ -541,8 +541,8 @@ However, to add a new index to a table that already has data, the following addi
 
     ```sql
     yb-admin
-    -master_addresses <target_master_ips> \
-    -certs_dir_name <cert_dir> \
+    --master_addresses <target_master_ips> \
+    --certs_dir_name <cert_dir> \
     alter_universe_replication 59e58153-eec6-4cb5-a858-bf685df52316_east-west \
     add_table  000033e8000030008000000000004028 c8cba563e39c43feb66689514488591c
     ```
@@ -577,16 +577,16 @@ Objects (tables, indexes, partitions) need to be removed from replication before
 1. Get the table ID for the object to be removed from the source.
 
     ```sql
-    yb-admin -master_addresses <source_master_ips> \
-    -certs_dir_name <cert_dir> \
+    yb-admin --master_addresses <source_master_ips> \
+    --certs_dir_name <cert_dir> \
     list_tables include_table_id |grep '<partition_name>'
     ```
 
 1. Remove the table from replication on the target.
 
     ```sql
-    yb-admin -master_addresses <target_master_ips> \
-    -certs_dir_name <cert_dir> \
+    yb-admin --master_addresses <target_master_ips> \
+    --certs_dir_name <cert_dir> \
     alter_universe_replication <replication_group_name> \
     remove_table  000033e800003000800000000000410b
     ```
@@ -599,8 +599,8 @@ Alters involving adding/removing columns or modifying data types require replica
 
     ```sql
     yb-admin
-    -master_addresses <target_master_ips>
-    -certs_dir_name <cert_dir> \
+    --master_addresses <target_master_ips>
+    --certs_dir_name <cert_dir> \
     set_universe_replication_enabled <replication_group_name> 0
     ```
 
@@ -615,8 +615,8 @@ Alters involving adding/removing columns or modifying data types require replica
 
     ```sql
     yb-admin
-    -master_addresses <target_master_ips>
-    -certs_dir_name <cert_dir> \
+    --master_addresses <target_master_ips>
+    --certs_dir_name <cert_dir> \
     set_universe_replication_enabled <replication_group_name> 0
     ```
 

--- a/docs/content/stable/deploy/multi-dc/async-replication/async-transactional-failover.md
+++ b/docs/content/stable/deploy/multi-dc/async-replication/async-transactional-failover.md
@@ -36,7 +36,7 @@ Pause replication on the Standby (B). This step is required to avoid unexpected 
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses <B_master_addresses> \
+    --master_addresses <B_master_addresses> \
     set_universe_replication_enabled <replication_name> 0
 ```
 
@@ -52,7 +52,7 @@ Get the latest consistent time on Standby (B). The `get_xcluster_safe_time` comm
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses <B_master_addresses> \
+    --master_addresses <B_master_addresses> \
     get_xcluster_safe_time include_lag_and_skew
 ```
 
@@ -122,7 +122,7 @@ Restore the database to the `safe_time`:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <B_master_addresses> \
+        --master_addresses <B_master_addresses> \
         list_snapshot_schedules
     ```
 
@@ -153,7 +153,7 @@ Restore the database to the `safe_time`:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <B_master_addresses> \
+        --master_addresses <B_master_addresses> \
         restore_snapshot_schedule <schedule_id> "<safe_time>"
     ```
 
@@ -170,7 +170,7 @@ Restore the database to the `safe_time`:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <B_master_addresses> \
+        --master_addresses <B_master_addresses> \
         list_snapshot_restorations
     ```
 
@@ -195,7 +195,7 @@ Restore the database to the `safe_time`:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses <B_master_addresses> \
+    --master_addresses <B_master_addresses> \
     delete_universe_replication <replication_group_id>
 ```
 
@@ -261,7 +261,7 @@ Disable point-in-time recovery for the database(s) on A:
 - List the snapshot schedules to obtain the schedule ID:
 
     ```sh
-    ./bin/yb-admin -master_addresses <A_master_addresses> \
+    ./bin/yb-admin --master_addresses <A_master_addresses> \
         list_snapshot_schedules
     ```
 
@@ -269,7 +269,7 @@ Disable point-in-time recovery for the database(s) on A:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <A_master_addresses> \
+        --master_addresses <A_master_addresses> \
         delete_snapshot_schedule <schedule_id>
     ```
 
@@ -299,7 +299,7 @@ Drop the replication group on A using the following command:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses <A_master_addresses> \
+    --master_addresses <A_master_addresses> \
     drop_xcluster_replication <replication_group_id>
 ```
 
@@ -317,7 +317,7 @@ Outbound xCluster Replication group rg1 deleted successfully
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses <A_master_ips> \
+    --master_addresses <A_master_ips> \
     list_cdc_streams
     ```
 
@@ -325,7 +325,7 @@ Outbound xCluster Replication group rg1 deleted successfully
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses <A_master_ips> \
+    --master_addresses <A_master_ips> \
     delete_cdc_stream <streamID>
     ```
 

--- a/docs/content/stable/deploy/multi-dc/async-replication/async-transactional-setup-manual.md
+++ b/docs/content/stable/deploy/multi-dc/async-replication/async-transactional-setup-manual.md
@@ -115,7 +115,7 @@ To set up unidirectional transactional replication manually, do the following:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
+        --master_addresses <standby_master_addresses> \
         create_snapshot_schedule 1 10 ysql.yugabyte
     ```
 
@@ -125,8 +125,8 @@ To set up unidirectional transactional replication manually, do the following:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
-        -certs_dir_name <cert_dir> \
+        --master_addresses <standby_master_addresses> \
+        --certs_dir_name <cert_dir> \
         setup_universe_replication \
         <primary_universe_uuid>_<replication_name> \
         <primary_universe_master_addresses> \
@@ -138,8 +138,8 @@ To set up unidirectional transactional replication manually, do the following:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
-        -certs_dir_name <dir_name> \
+        --master_addresses <standby_master_addresses> \
+        --certs_dir_name <dir_name> \
         change_xcluster_role STANDBY
     ```
 
@@ -246,7 +246,7 @@ get_xcluster_safe_time
 For example:
 
 ```sh
-./tserver/bin/yb-admin -master_addresses 172.150.21.61:7100,172.150.44.121:7100,172.151.23.23:7100 \
+./tserver/bin/yb-admin --master_addresses 172.150.21.61:7100,172.150.44.121:7100,172.151.23.23:7100 \
     get_xcluster_safe_time
 ```
 

--- a/docs/content/stable/deploy/multi-dc/async-replication/includes/automatic-setup.md
+++ b/docs/content/stable/deploy/multi-dc/async-replication/includes/automatic-setup.md
@@ -112,7 +112,7 @@ The following assumes you have set up Primary and Standby universes. Refer to [S
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <primary_master_addresses> \
+        --master_addresses <primary_master_addresses> \
         create_xcluster_checkpoint \
         <replication_group_id> \
         <comma_separated_namespace_names> \
@@ -133,7 +133,7 @@ The following assumes you have set up Primary and Standby universes. Refer to [S
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+    --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     is_xcluster_bootstrap_required repl_group1 yugabyte
     ```
 
@@ -154,7 +154,7 @@ The following assumes you have set up Primary and Standby universes. Refer to [S
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
+        --master_addresses <standby_master_addresses> \
         create_snapshot_schedule \
         <snapshot-interval> \
         <retention-time> \
@@ -167,7 +167,7 @@ The following assumes you have set up Primary and Standby universes. Refer to [S
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses <primary_master_addresses> \
+    --master_addresses <primary_master_addresses> \
     setup_xcluster_replication \
     <replication_group_id> \
     <standby_master_addresses>

--- a/docs/content/stable/deploy/multi-dc/async-replication/includes/semi-automatic-setup.md
+++ b/docs/content/stable/deploy/multi-dc/async-replication/includes/semi-automatic-setup.md
@@ -106,7 +106,7 @@ The following assumes you have set up Primary and Standby universes. Refer to [S
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <primary_master_addresses> \
+        --master_addresses <primary_master_addresses> \
         create_xcluster_checkpoint <replication_group_id> <comma_separated_namespace_names>
     ```
 
@@ -124,7 +124,7 @@ The following assumes you have set up Primary and Standby universes. Refer to [S
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+    --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     is_xcluster_bootstrap_required repl_group1 yugabyte
     ```
 
@@ -141,7 +141,7 @@ The following assumes you have set up Primary and Standby universes. Refer to [S
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
+        --master_addresses <standby_master_addresses> \
         create_snapshot_schedule 1 10 ysql.yugabyte
     ```
 
@@ -149,7 +149,7 @@ The following assumes you have set up Primary and Standby universes. Refer to [S
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses <primary_master_addresses> \
+    --master_addresses <primary_master_addresses> \
     setup_xcluster_replication <replication_group_id> <standby_master_addresses>
     ```
 

--- a/docs/content/stable/deploy/multi-dc/async-replication/includes/transactional-add-db.md
+++ b/docs/content/stable/deploy/multi-dc/async-replication/includes/transactional-add-db.md
@@ -77,7 +77,7 @@ The database should have at least one table in order to be added to replication.
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses <primary_master_addresses> \
+    --master_addresses <primary_master_addresses> \
     add_namespace_to_xcluster_checkpoint <replication_group_id> <namespace_name>
     ```
 
@@ -96,7 +96,7 @@ The database should have at least one table in order to be added to replication.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
+        --master_addresses <standby_master_addresses> \
         create_snapshot_schedule 1 10 ysql.yugabyte
     ```
 
@@ -104,7 +104,7 @@ The database should have at least one table in order to be added to replication.
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses <primary_master_addresses> \
+    --master_addresses <primary_master_addresses> \
     add_namespace_to_xcluster_replication <replication_group_id> <namespace_name> <standby_master_addresses>
     ```
 

--- a/docs/content/stable/deploy/multi-dc/read-replica-clusters.md
+++ b/docs/content/stable/deploy/multi-dc/read-replica-clusters.md
@@ -117,7 +117,7 @@ You can deploy a read replica cluster that asynchronously replicates data with a
 1. Define the primary cluster placement using the [`yb-admin modify_placement_info`](../../../admin/yb-admin/#modify-placement-info) command, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses ip1:7100,ip2:7100,ip3:7100 modify_placement_info <placement_info> <replication_factor> [placement_uuid]
+    ./bin/yb-admin --master_addresses ip1:7100,ip2:7100,ip3:7100 modify_placement_info <placement_info> <replication_factor> [placement_uuid]
     ```
 
     - *placement_info*: Comma-separated list of availability zones using the format `<cloud1.region1.zone1>,<cloud2.region2.zone2>, ...`
@@ -127,7 +127,7 @@ You can deploy a read replica cluster that asynchronously replicates data with a
 1. Define the read replica placement using the [`yb-admin add_read_replica_placement_info`](../../../admin/yb-admin/#add-read-replica-placement-info) command, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses ip1:7100,ip2:7100,ip3:7100 add_read_replica_placement_info <placement_info> <replication_factor> [placement_uuid]
+    ./bin/yb-admin --master_addresses ip1:7100,ip2:7100,ip3:7100 add_read_replica_placement_info <placement_info> <replication_factor> [placement_uuid]
     ```
 
     - *placement_info*: Comma-separated list of availability zones, using the format `<cloud1.region1.zone1>:<num_replicas_in_zone1>,<cloud2.region2.zone2>:<num_replicas_in_zone2>,...` These read replica availability zones must be uniquely different from the primary availability zones defined in step 2. If you want to use the same cloud, region, and availability zone as a primary cluster, one option is to suffix the zone with `_rr` (for read replica). For example, `c1.r1.z1_rr:2`.

--- a/docs/content/stable/develop/multi-cloud/multicloud-migration.md
+++ b/docs/content/stable/develop/multi-cloud/multicloud-migration.md
@@ -66,7 +66,7 @@ The basic flow of bootstrapping is as follows:
 1. Create a checkpoint for all the tables in the AWS universe. For example:
 
     ```bash
-    ./bin/yb-admin -master_addresses <AWS_universe_master_addresses> \
+    ./bin/yb-admin --master_addresses <AWS_universe_master_addresses> \
             bootstrap_cdc_producer <comma_separated_source_universe_table_ids>
     ```
 
@@ -85,7 +85,7 @@ For detailed instructions on how to set up replication, see [Set up unidirection
 A simple way to set up replication is as follows:
 
 ```bash
-./bin/yb-admin -master_addresses <GCP_universe_master_addresses> setup_universe_replication \
+./bin/yb-admin --master_addresses <GCP_universe_master_addresses> setup_universe_replication \
   <AWS_universe_uuid>_<replication_stream_name> <AWS_universe_master_addresses> \
   <comma_separated_source_universe_table_ids> <comma_separated_bootstrap_ids>
 ```
@@ -111,8 +111,8 @@ The basic flow of switchover is as follows:
 
   ```bash
   ./bin/yb-admin \
-      -master_addresses <GCP_master_addresses> \
-      -certs_dir_name <cert_dir> \
+      --master_addresses <GCP_master_addresses> \
+      --certs_dir_name <cert_dir> \
       change_xcluster_role ACTIVE
   ```
 

--- a/docs/content/stable/explore/cluster-management/point-in-time-recovery-ycql.md
+++ b/docs/content/stable/explore/cluster-management/point-in-time-recovery-ycql.md
@@ -78,7 +78,7 @@ Create and populate a table, get a timestamp to which you'll restore, and then w
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         create_snapshot_schedule 1 10 ycql.pitr
     ```
 
@@ -92,7 +92,7 @@ Create and populate a table, get a timestamp to which you'll restore, and then w
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshot_schedules
     ```
 
@@ -152,7 +152,7 @@ Create and populate a table, get a timestamp to which you'll restore, and then w
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 0e4ceb83-fe3d-43da-83c3-013a8ef592ca 1620418817729963
     ```
 
@@ -167,7 +167,7 @@ Create and populate a table, get a timestamp to which you'll restore, and then w
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 

--- a/docs/content/stable/explore/cluster-management/point-in-time-recovery-ysql.md
+++ b/docs/content/stable/explore/cluster-management/point-in-time-recovery-ysql.md
@@ -77,7 +77,7 @@ Create a snapshot as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         create_snapshot_schedule 1 10 ysql.yugabyte
     ```
 
@@ -91,7 +91,7 @@ Create a snapshot as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshot_schedules
     ```
 
@@ -152,7 +152,7 @@ Create a snapshot as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 0e4ceb83-fe3d-43da-83c3-013a8ef592ca 1620418817729963
     ```
 
@@ -167,7 +167,7 @@ Create a snapshot as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 
@@ -232,7 +232,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         create_snapshot_schedule 1 10 ysql.yugabyte
     ```
 
@@ -246,7 +246,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshot_schedules
     ```
 
@@ -287,7 +287,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 1fb2d85a-3608-4cb1-af63-3e4062300dc1 1681964544554620
     ```
 
@@ -302,7 +302,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 
@@ -339,7 +339,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshot_schedules
     ```
 
@@ -399,7 +399,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 1fb2d85a-3608-4cb1-af63-3e4062300dc1 1681965106732671
     ```
 
@@ -414,7 +414,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 
@@ -462,7 +462,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshot_schedules
     ```
 
@@ -530,7 +530,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 1fb2d85a-3608-4cb1-af63-3e4062300dc1 1681965472490517
     ```
 
@@ -545,7 +545,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 
@@ -617,7 +617,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 1fb2d85a-3608-4cb1-af63-3e4062300dc1 1681965684502460
     ```
 
@@ -632,7 +632,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 
@@ -707,7 +707,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 1fb2d85a-3608-4cb1-af63-3e4062300dc1 1681965868912921
     ```
 
@@ -722,7 +722,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 

--- a/docs/content/stable/explore/colocation.md
+++ b/docs/content/stable/explore/colocation.md
@@ -215,7 +215,7 @@ To set up xCluster for colocated tables, do the following:
 1. Get the parent table UUID for the colocated database.
 
     ```sh
-    ./yb-admin -master_addresses <source_master_addresses> list_tables include_table_id | grep -i <database_name> | grep -i "colocation.parent.uuid"
+    ./yb-admin --master_addresses <source_master_addresses> list_tables include_table_id | grep -i <database_name> | grep -i "colocation.parent.uuid"
     ```
 
     ```output
@@ -225,13 +225,13 @@ To set up xCluster for colocated tables, do the following:
 1. Set up replication for the parent colocation table using yb-admin.
 
     ```sh
-    ./yb-admin -master_addresses <target_master_addresses> setup_universe_replication <replication_group_name> <source_master_addresses> <parent_colocated_table_uuid>
+    ./yb-admin --master_addresses <target_master_addresses> setup_universe_replication <replication_group_name> <source_master_addresses> <parent_colocated_table_uuid>
     ```
 
     For example:
 
     ```sh
-    ./yb-admin -master_addresses 127.0.0.2 setup_universe_replication A1-B2 127.0.0.1 00004000000030008000000000004004.colocation.parent.uuid
+    ./yb-admin --master_addresses 127.0.0.2 setup_universe_replication A1-B2 127.0.0.1 00004000000030008000000000004004.colocation.parent.uuid
     ```
 
     ```output

--- a/docs/content/stable/explore/multi-region-deployments/read-replicas-ycql.md
+++ b/docs/content/stable/explore/multi-region-deployments/read-replicas-ycql.md
@@ -62,7 +62,7 @@ For more info, please use: yb-ctl status
 The following command instructs the masters to create three replicas for each tablet distributed across the three zones:
 
 ```shell
-$ ./bin/yb-admin -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 modify_placement_info c.r.z1,c.r.z2,c.r.z3 3 live
+$ ./bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 modify_placement_info c.r.z1,c.r.z2,c.r.z3 3 live
 ```
 
 The following illustration demonstrates the primary cluster visible via [YugabyteDB Anywhere](../../../yugabyte-platform/):
@@ -166,7 +166,7 @@ The following commands add three new nodes to a read replica cluster in region `
 ./bin/yb-ctl add_node --placement_info "c.r2.z22" --tserver_flags "placement_uuid=rr"
 ./bin/yb-ctl add_node --placement_info "c.r2.z23" --tserver_flags "placement_uuid=rr"
 
-./bin/yb-admin -master_addresses 127.0.0.1:7100,127.0.0.2,127.0.0.3 add_read_replica_placement_info c.r2.z21:1,c.r2.z22:1,c.r2.z23:1 3 rr
+./bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2,127.0.0.3 add_read_replica_placement_info c.r2.z21:1,c.r2.z22:1,c.r2.z23:1 3 rr
 ```
 
 The following illustration demonstrates the setup of the two clusters, one of which is primary and another one is read replica visible via YugabyteDB Anywhere:

--- a/docs/content/stable/launch-and-manage/monitor-and-alert/xcluster-monitor.md
+++ b/docs/content/stable/launch-and-manage/monitor-and-alert/xcluster-monitor.md
@@ -77,7 +77,7 @@ To list outgoing groups on the Primary universe, use the [list_xcluster_outbound
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses <primary_master_addresses> \
+    --master_addresses <primary_master_addresses> \
     list_xcluster_outbound_replication_groups \
     [namespace_id]
 ```
@@ -86,7 +86,7 @@ To list inbound groups on the Standby universe, use the [list_universe_replicati
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses <standby_master_addresses> \
+    --master_addresses <standby_master_addresses> \
     list_universe_replications \
     [namespace_id]
 ```
@@ -95,7 +95,7 @@ To get the status of the replication group, use [get_replication_status](../../.
 
 ```sh
 yb-admin \
-    -master_addresses <target-master-addresses> \
+    --master_addresses <target-master-addresses> \
     get_replication_status \
     [<replication_id>]
 ```
@@ -160,7 +160,7 @@ Inbound xCluster Replications:
 
   ```sh
   yb-admin \
-      -master_addresses <standby_master_addresses> \
+      --master_addresses <standby_master_addresses> \
       get_xcluster_safe_time \
       [include_lag_and_skew]
   ```

--- a/docs/content/stable/manage/backup-restore/point-in-time-recovery.md
+++ b/docs/content/stable/manage/backup-restore/point-in-time-recovery.md
@@ -78,13 +78,13 @@ To create a schedule and enable PITR, use the [`create_snapshot_schedule`](../..
 For example, to create a schedule that produces a snapshot of a YSQL database once a day (every 1,440 minutes) and retains it for three days (4,320 minutes), you would execute the following command:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot_schedule 1440 4320 ysql.<database_name>
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot_schedule 1440 4320 ysql.<database_name>
 ```
 
 The equivalent command for a YCQL keyspace would be the following:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot_schedule 1440 4320 <keyspace_name>
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot_schedule 1440 4320 <keyspace_name>
 ```
 
 The following output is a unique ID of the newly-created snapshot schedule:
@@ -102,7 +102,7 @@ You can use this ID to [delete the schedule](#delete-a-schedule) or [restore to 
 To delete a schedule and disable PITR, use the following [`delete_snapshot_schedule`](../../../admin/yb-admin/#delete-snapshot-schedule) command that takes the ID of the schedule to be deleted as a parameter:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
 ```
 
 ### List schedules
@@ -110,7 +110,7 @@ To delete a schedule and disable PITR, use the following [`delete_snapshot_sched
 To see a list of schedules that currently exist in the cluster, use the following [`list_snapshot_schedules`](../../../admin/yb-admin/#list-snapshot-schedules) command:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshot_schedules
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshot_schedules
 ```
 
 ```output.json
@@ -141,7 +141,7 @@ To see a list of schedules that currently exist in the cluster, use the followin
 You can also use the same command to view the information about a particular schedule by providing its ID as a parameter, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshot_schedules 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshot_schedules 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
 ```
 
 ## Restore to a point in time
@@ -162,7 +162,7 @@ If a database or a keyspace has an associated snapshot schedule, you can use tha
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <ip1:7100,ip2:7100,ip3:7100> \
+        --master_addresses <ip1:7100,ip2:7100,ip3:7100> \
         restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 1651435200
     ```
 
@@ -170,7 +170,7 @@ If a database or a keyspace has an associated snapshot schedule, you can use tha
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <ip1:7100,ip2:7100,ip3:7100> \
+        --master_addresses <ip1:7100,ip2:7100,ip3:7100> \
         restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 "2022-05-01 13:00-0700"
     ```
 
@@ -180,7 +180,7 @@ If a database or a keyspace has an associated snapshot schedule, you can use tha
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <ip1:7100,ip2:7100,ip3:7100> \
+        --master_addresses <ip1:7100,ip2:7100,ip3:7100> \
         restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 minus 5m
     ```
 
@@ -188,7 +188,7 @@ If a database or a keyspace has an associated snapshot schedule, you can use tha
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <ip1:7100,ip2:7100,ip3:7100> \
+        --master_addresses <ip1:7100,ip2:7100,ip3:7100> \
         restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 minus 1h
     ```
 

--- a/docs/content/stable/manage/backup-restore/snapshot-ysql.md
+++ b/docs/content/stable/manage/backup-restore/snapshot-ysql.md
@@ -42,7 +42,7 @@ Using distributed snapshots allows you to back up a database and then restore it
 To back up a database, create a snapshot using the [`create_database_snapshot`](../../../admin/yb-admin/#create-database-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> create_database_snapshot ysql.<database_name>
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> create_database_snapshot ysql.<database_name>
 ```
 
 A unique ID for the snapshot is returned, as shown in the following sample output:
@@ -56,7 +56,7 @@ You can then use this ID to check the status of the snapshot, [delete it](#delet
 The `create_database_snapshot` command exits immediately, but the snapshot may take some time to complete. Before using the snapshot, verify its status by executing the [`list_snapshots`](../../../admin/yb-admin/#list-snapshots) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshots
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshots
 ```
 
 All the snapshots in the cluster are listed, along with their statuses. You can find the ID of the new snapshot and make sure it has been completed, as shown in the following  sample output:
@@ -71,7 +71,7 @@ Snapshot UUID                           State       Creation Time
 Snapshots never expire and are retained as long as the cluster exists. If you no longer need a snapshot, you can delete it by executing the [`delete_snapshot`](../../../admin/yb-admin/#delete-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794
 ```
 
 ## Restore a snapshot
@@ -79,7 +79,7 @@ Snapshots never expire and are retained as long as the cluster exists. If you no
 To restore the data backed up in one of the previously created snapshots, run the [`restore_snapshot`](../../../admin/yb-admin/#restore-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> restore_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> restore_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794
 ```
 
 This command rolls back the database to the state which it had when the snapshot was created. The restore happens in-place: it changes the state of the existing database in the same cluster.
@@ -127,7 +127,7 @@ To move a snapshot to external storage, gather all the relevant files from all t
 1. Create the snapshot metadata file by executing the [`export_snapshot`](../../../admin/yb-admin/#export-snapshot) command and providing the ID of the snapshot, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> export_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794 <database_name>.snapshot
+    ./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> export_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794 <database_name>.snapshot
     ```
 
 1. Copy the newly-created YSQL metadata file (`<database_name>_schema.sql`) and the snapshot metadata file (`<database_name>.snapshot`) to the external storage.
@@ -176,7 +176,7 @@ You can restore a snapshot that you have [moved to external storage](#move-a-sna
 1. Fetch the snapshot metadata file from the external storage and apply it by running the [`import_snapshot`](../../../admin/yb-admin/#import-snapshot) command, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> import_snapshot <database_name>.snapshot <database_name>
+    ./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> import_snapshot <database_name>.snapshot <database_name>
     ```
 
     Notice that the following output contains the mapping between the old tablet IDs and the new tablet IDs:

--- a/docs/content/stable/manage/backup-restore/snapshots-ycql.md
+++ b/docs/content/stable/manage/backup-restore/snapshots-ycql.md
@@ -41,13 +41,13 @@ Using distributed snapshots allows you to back up a database and then restore it
 To back up a keyspace with all its tables and indexes, create a snapshot using the [`create_keyspace_snapshot`](../../../admin/yb-admin/#create-keyspace-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> create_keyspace_snapshot my_keyspace
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> create_keyspace_snapshot my_keyspace
 ```
 
 To back up a single table with its indexes, use the [`create_snapshot`](../../../admin/yb-admin/#create-snapshot) command instead, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot my_keyspace my_table
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot my_keyspace my_table
 ```
 
 When you execute either of the preceding commands, a unique ID for the snapshot is returned, as per the following output:
@@ -61,7 +61,7 @@ You can then use this ID to check the status of the snapshot, [delete it](#delet
 Even though the `create_keyspace_snapshot` and `create_snapshot` commands exit immediately, the snapshot may take some time to complete. Before using the snapshot, verify its status with the [`list_snapshots`](../../../admin/yb-admin/#list-snapshots) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshots
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshots
 ```
 
 The preceding command lists the snapshots in the cluster, along with their states. You can find the ID of the new snapshot and make sure it has been completed, as shown in the following  sample output:
@@ -76,7 +76,7 @@ Snapshot UUID                           State       Creation Time
 Snapshots never expire and are retained as long as the cluster exists. If you no longer need a snapshot, you can delete it with the [`delete_snapshot`](../../../admin/yb-admin/#delete-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef
 ```
 
 ## Restore a snapshot
@@ -84,7 +84,7 @@ Snapshots never expire and are retained as long as the cluster exists. If you no
 To restore the data backed up in one of the previously created snapshots, run the [`restore_snapshot`](../../../admin/yb-admin/#restore-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> restore_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> restore_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef
 ```
 
 This command rolls back the database to the state which it had when the snapshot was created. The restore happens in-place: it changes the state of the existing database in the same cluster.
@@ -102,7 +102,7 @@ To move a snapshot to external storage, gather all the relevant files from all t
 1. Create the snapshot metadata file by running the [`export_snapshot`](../../../admin/yb-admin/#export-snapshot) command and providing the ID of the snapshot:
 
     ```sh
-    ./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> export_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef my_keyspace.snapshot
+    ./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> export_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef my_keyspace.snapshot
     ```
 
 1. Copy the newly created snapshot metadata file (`my_keyspace.snapshot`) to the external storage.
@@ -133,7 +133,7 @@ You can restore a snapshot that you have [moved to external storage](#move-a-sna
 1. Retrieve the snapshot metadata file from the external storage and apply it by running the [`import_snapshot`](../../../admin/yb-admin/#import-snapshot) command, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> import_snapshot my_keyspace.snapshot my_keyspace
+    ./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> import_snapshot my_keyspace.snapshot my_keyspace
     ```
 
     Notice that the following output contains the mapping between the old tablet IDs and the new tablet IDs:

--- a/docs/content/stable/manage/change-cluster-config.md
+++ b/docs/content/stable/manage/change-cluster-config.md
@@ -101,13 +101,13 @@ The following commands can be run from one of the old master nodes. You can firs
 
 ```sh
 export MASTERS=node1:7100,node2:7100,node3:7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_blacklist ADD node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
+~/master/bin/yb-admin --master_addresses $MASTERS change_blacklist ADD node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
 ```
 
 Verify that the blacklist information looks similar to the following:
 
 ```sh
-~/master/bin/yb-admin -master_addresses $MASTERS get_universe_config
+~/master/bin/yb-admin --master_addresses $MASTERS get_universe_config
 Config:
 version: 5
 server_blacklist {
@@ -131,7 +131,7 @@ server_blacklist {
 Next, wait for the data move to complete. You can check the percentage completion by running the following command:
 
 ```sh
-~/master/bin/yb-admin -master_addresses $MASTERS get_load_move_completion
+~/master/bin/yb-admin --master_addresses $MASTERS get_load_move_completion
 Percent complete = 66.6
 ```
 
@@ -158,19 +158,19 @@ If any error log is reported on the command line from the following steps, check
 
 ```sh
 export MASTERS=node1:7100,node2:7100,node3:7100,node7:7100,node8:7100,node9:7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config ADD_SERVER node7 7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config REMOVE_SERVER node1 7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config ADD_SERVER node8 7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config REMOVE_SERVER node2 7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config ADD_SERVER node9 7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config REMOVE_SERVER node3 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config ADD_SERVER node7 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config REMOVE_SERVER node1 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config ADD_SERVER node8 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config REMOVE_SERVER node2 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config ADD_SERVER node9 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config REMOVE_SERVER node3 7100
 ```
 
 Now ensure that the master leader is one of the new master nodes as follows:
 
 ```sh
 $ export MASTERS=node7:7100,node8:7100,node9:7100
-$ ~/master/bin/yb-admin -master_addresses $MASTERS list_all_masters
+$ ~/master/bin/yb-admin --master_addresses $MASTERS list_all_masters
 ```
 
 ```output
@@ -197,7 +197,7 @@ Updating master addresses is needed in case the yb-tserver server is restarted.
 The old nodes are not part of the universe any more and can be shut down. After the old YB-TServers are terminated, you can cleanup the blacklist from the master configuration using the following command:
 
 ```sh
-~/master/bin/yb-admin -master_addresses $MASTERS change_blacklist REMOVE node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
+~/master/bin/yb-admin --master_addresses $MASTERS change_blacklist REMOVE node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
 ```
 
 {{< note title="Tip" >}}
@@ -207,5 +207,5 @@ Cleaning up the blacklist server will help reuse the older IPs in case they get 
 Ensure there are no `server_blacklist` entries returned by the command:
 
 ```sh
-~/master/bin/yb-admin -master_addresses $MASTERS get_universe_config
+~/master/bin/yb-admin --master_addresses $MASTERS get_universe_config
 ```

--- a/docs/content/stable/manage/upgrade-deployment.md
+++ b/docs/content/stable/manage/upgrade-deployment.md
@@ -158,7 +158,7 @@ New YugabyteDB features may require changes to the format of data that is sent o
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <master-addresses> \
+        --master_addresses <master-addresses> \
         promote_auto_flags
     ```
 
@@ -198,7 +198,7 @@ Use the [yb-admin](../../admin/yb-admin/) utility to upgrade the YSQL system cat
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     upgrade_ysql
 ```
 
@@ -212,8 +212,8 @@ In certain scenarios, a YSQL upgrade can take longer than 60 seconds, which is t
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
-    -timeout_ms 180000 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --timeout_ms 180000 \
     upgrade_ysql
 ```
 
@@ -302,7 +302,7 @@ During the Monitor phase, do the following:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <master-addresses> \
+        --master_addresses <master-addresses> \
         promote_auto_flags kLocalVolatile
     ```
 
@@ -333,7 +333,7 @@ If you need to roll back an upgrade where volatile AutoFlags were enabled, depen
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <master-addresses> \
+        --master_addresses <master-addresses> \
         rollback_auto_flags <previous_config_version>
     ```
 
@@ -351,7 +351,7 @@ If you need to roll back an upgrade where volatile AutoFlags were enabled, depen
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+        --master_addresses ip1:7100,ip2:7100,ip3:7100 \
         rollback_auto_flags 2
     ```
 

--- a/docs/content/stable/reference/configuration/yugabyted.md
+++ b/docs/content/stable/reference/configuration/yugabyted.md
@@ -76,7 +76,7 @@ $ ./bin/yugabyted -h
 ```
 
 ```sh
-$ ./bin/yugabyted -help
+$ ./bin/yugabyted --help
 ```
 
 For help with specific yugabyted commands, run 'yugabyted [ command ] -h'. For example, you can print the command-line help for the `yugabyted start` command by running the following:

--- a/docs/content/stable/secure/encryption-at-rest.md
+++ b/docs/content/stable/secure/encryption-at-rest.md
@@ -44,7 +44,7 @@ You enable encryption as follows:
 1. Copy the key to master nodes. In the following example, assume a 3-node RF=3 cluster with `MASTER_ADDRESSES=ip1:7100,ip2:7100,ip3:7100`. Choose any string `<key_id>` for this key and use yb-admin to copy the key to each of the masters:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES add_universe_key_to_all_masters <key_id> /<path_to_universe_key>
+    yb-admin --master_addresses $MASTER_ADDRESSES add_universe_key_to_all_masters <key_id> /<path_to_universe_key>
     ```
 
     The preceding operation does not perform the key rotation, but rather seeds each master's in-memory state. The key only lives in memory, and the plaintext key is never persisted to the disk.
@@ -52,13 +52,13 @@ You enable encryption as follows:
 1. Enable cluster-wide encryption. Before rotating the key, ensure that the masters know about `<key_id>`:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES all_masters_have_universe_key_in_memory <key_id>
+    yb-admin --master_addresses $MASTER_ADDRESSES all_masters_have_universe_key_in_memory <key_id>
     ```
 
     If the preceding command fails, rerun step 2. Once this succeeds, instruct the cluster to start using the new universe key, as follows:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES rotate_universe_key_in_memory <key_id>
+    yb-admin --master_addresses $MASTER_ADDRESSES rotate_universe_key_in_memory <key_id>
     ```
 
     Because data is encrypted in the background as part of flushes to disk and compactions, only new data is encrypted. Therefore, the call should return quickly.
@@ -66,7 +66,7 @@ You enable encryption as follows:
 1. Verify that encryption has been enabled. To do this, check the encryption status of the cluster by executing the following yb-admin command:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES is_encryption_enabled
+    yb-admin --master_addresses $MASTER_ADDRESSES is_encryption_enabled
     ```
 
     Expect the following output:
@@ -90,7 +90,7 @@ You can rotate the new key as follows:
 1. Copy the new key to master nodes, informing the master nodes about the new key, as follows:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES add_universe_key_to_all_masters
+    yb-admin --master_addresses $MASTER_ADDRESSES add_universe_key_to_all_masters
     <key_id_2> /path_to_universe_key_2
     ```
 
@@ -99,7 +99,7 @@ You can rotate the new key as follows:
 1. Ensure that the masters know about the key, and then perform the rotation, as follows:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES rotate_universe_key_in_memory <key_id_2>
+    yb-admin --master_addresses $MASTER_ADDRESSES rotate_universe_key_in_memory <key_id_2>
     ```
 
     Because this key is only used for new data and can only eventually encrypt older data through compactions, it is best to ensure old keys remain secure.
@@ -107,7 +107,7 @@ You can rotate the new key as follows:
 1. Verify the new key. To do this, check that the new key is encrypting the cluster, as follows:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES is_encryption_enabled
+    yb-admin --master_addresses $MASTER_ADDRESSES is_encryption_enabled
     ```
 
     Expect the following output:
@@ -125,13 +125,13 @@ You can disable cluster-wide encryption as follows:
 1. Disable encryption by executing the following yb-admin command:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES disable_encryption
+    yb-admin --master_addresses $MASTER_ADDRESSES disable_encryption
     ```
 
 1. Verify that the encryption has been disabled by executing the following command:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES is_encryption_enabled
+    yb-admin --master_addresses $MASTER_ADDRESSES is_encryption_enabled
     ```
 
     Expect the following output:

--- a/docs/content/stable/secure/tls-encryption/connect-to-cluster.md
+++ b/docs/content/stable/secure/tls-encryption/connect-to-cluster.md
@@ -59,7 +59,7 @@ For example, the following command lists the master information for the TLS-enab
 
 ```sh
 export MASTERS=node1:7100,node2:7100,node3:7100
-./bin/yb-admin --master_addresses $MASTERS -certs_dir_name ~/yugabyte-tls-config list_all_masters
+./bin/yb-admin --master_addresses $MASTERS --certs_dir_name ~/yugabyte-tls-config list_all_masters
 ```
 
 You should see the following output format:

--- a/docs/content/v2.20/admin/yb-admin.md
+++ b/docs/content/v2.20/admin/yb-admin.md
@@ -21,10 +21,10 @@ To use the `yb-admin` utility from the YugabyteDB home directory, run `./bin/yb-
 
 ```sh
 yb-admin \
-    [ -master_addresses <master-addresses> ]  \
-    [ -init_master_addrs <master-address> ]  \
-    [ -timeout_ms <millisec> ] \
-    [ -certs_dir_name <dir_name> ] \
+    [ --master_addresses <master-addresses> ]  \
+    [ --init_master_addrs <master-address> ]  \
+    [ --timeout_ms <millisec> ] \
+    [ --certs_dir_name <dir_name> ] \
     <command> [ command_flags ]
 ```
 
@@ -73,7 +73,7 @@ Gets the configuration for the universe.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_universe_config
 ```
 
@@ -87,7 +87,7 @@ Changes the configuration of a tablet.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     change_config <tablet_id> \
     [ ADD_SERVER | REMOVE_SERVER ] \
     <peer_uuid> \
@@ -117,7 +117,7 @@ Changes the master configuration.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     change_master_config \
     [ ADD_SERVER|REMOVE_SERVER ] \
     <ip_addr> <port> \
@@ -137,7 +137,7 @@ yb-admin \
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_tablet_servers <tablet_id>
 ```
 
@@ -154,7 +154,7 @@ Use this to find out who the LEADER of a tablet is.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_tablets <keyspace_type>.<keyspace_name> <table> [max_tablets]
 ```
 
@@ -168,7 +168,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     list_tablets ysql.db_name table_name 0
 ```
 
@@ -186,7 +186,7 @@ Lists all tablet servers.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_all_tablet_servers
 ```
 
@@ -200,7 +200,7 @@ Displays a list of all YB-Master servers in a table listing the master UUID, RPC
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_all_masters
 ```
 
@@ -210,7 +210,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses node7:7100,node8:7100,node9:7100 \
+    --master_addresses node7:7100,node8:7100,node9:7100 \
     list_all_masters
 ```
 
@@ -229,7 +229,7 @@ Prints a list of replica types and counts for the specified table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_replica_type_counts <keyspace> <table_name>
 ```
 
@@ -245,7 +245,7 @@ Prints the status of the YB-Master servers.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     dump_masters_state
 ```
 
@@ -259,7 +259,7 @@ List the locations of the tablet server logs.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_tablet_server_log_locations
 ```
 
@@ -273,7 +273,7 @@ Lists all tablets for the specified tablet server (YB-TServer).
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_tablets_for_tablet_server <ts_uuid>
 ```
 
@@ -286,7 +286,7 @@ Splits the specified hash-sharded tablet and computes the split point as the mid
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     split_tablet <tablet_id_to_split>
 ```
 
@@ -314,7 +314,7 @@ Forces the master leader to step down. The specified YB-Master node will take it
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     master_leader_stepdown [ <new_leader_id> ]
 ```
 
@@ -329,7 +329,7 @@ Prints the current YSQL schema catalog version.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     ysql_catalog_version
 ```
 
@@ -339,7 +339,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     ysql_catalog_version
 ```
 
@@ -361,14 +361,14 @@ Prints a list of all tables. Optionally, include the database type, table ID, an
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_tables \
     [ include_db_type ] [ include_table_id ] [ include_table_type ]
 ```
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> list_tables
+    --master_addresses <master-addresses> list_tables
 ```
 
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.
@@ -397,7 +397,7 @@ To display a list of tables and their UUID (`table_id`) values, open the **YB-Ma
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     list_tables
 ```
 
@@ -432,7 +432,7 @@ Triggers manual compaction on a table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     compact_table <db_type>.<namespace> <table> [timeout_in_seconds] [ADD_INDEXES]
 ```
 
@@ -447,7 +447,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     compact_table ysql.yugabyte table_name
 ```
 
@@ -459,7 +459,7 @@ Compacted [yugabyte.table_name] tables.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     compact_table tableid.<table_id> [timeout_in_seconds] [ADD_INDEXES]
 ```
 
@@ -472,7 +472,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     compact_table tableid.000033eb000030008000000000004002
 ```
 
@@ -486,7 +486,7 @@ Show the status of full compaction on a table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     compaction_status <db-type>.<namespace> <table> [show_tablets]
 ```
 
@@ -500,7 +500,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     compaction_status ysql.yugabyte table_name show_tablets
 ```
 
@@ -547,7 +547,7 @@ Modifies the placement information (cloud, region, and zone) for a table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     modify_table_placement_info <keyspace> <table_name> <placement_info> <replication_factor> \
     [ <placement_id> ]
 ```
@@ -556,7 +556,7 @@ or alternatively:
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     modify_table_placement_info tableid.<table_id> <placement_info> <replication_factor> \
     [ <placement_id> ]
 ```
@@ -573,7 +573,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     modify_table_placement_info  testdatabase testtable \
     aws.us-west.us-west-2a,aws.us-west.us-west-2b,aws.us-west.us-west-2c 3
 ```
@@ -595,7 +595,7 @@ Creates a transaction status table to be used in a region. This command should a
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_transaction_table \
     <table_name>
 ```
@@ -609,7 +609,7 @@ The transaction status table will be created as `system.<table_name>`.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     create_transaction_table \
     transactions_us_east
 ```
@@ -620,7 +620,7 @@ Next, set the placement on the newly created transactions table:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     modify_table_placement_info system transactions_us_east \
     aws.us-east.us-east-1a,aws.us-east.us-east-1b,aws.us-east.us-east-1c 3
 ```
@@ -641,7 +641,7 @@ Add a tablet to a transaction status table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     add_transaction_tablet \
     <table_id>
 ```
@@ -653,7 +653,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     add_transaction_tablet 000033eb000030008000000000004002
 ```
 
@@ -667,7 +667,7 @@ Flush the memstores of the specified table on all tablet servers to disk.
 
 ```sh
 yb-admin \
-    -master_addresses <master_addresses> \
+    --master_addresses <master_addresses> \
     flush_table <db_type>.<namespace> <table> [timeout_in_seconds] [ADD_INDEXES]
 ```
 
@@ -682,7 +682,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     flush_table ysql.yugabyte table_name
 
 ```
@@ -695,7 +695,7 @@ Flushed [yugabyte.table_name] tables.
 
 ```sh
 yb-admin \
-    -master_addresses <master_addresses> \
+    --master_addresses <master_addresses> \
     flush_table tableid.<table_id> [timeout_in_seconds] [ADD_INDEXES]
 ```
 
@@ -708,7 +708,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     flush_table tableid.000033eb000030008000000000004002
 ```
 
@@ -724,7 +724,7 @@ Backfill all DEFERRED indexes in a YCQL table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     backfill_indexes_for_table <keyspace> <table_name>
 ```
 
@@ -736,7 +736,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     backfill_indexes_for_table ybdemo table_name
 ```
 
@@ -778,7 +778,7 @@ Creates a snapshot of the specified YSQL database.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_database_snapshot <database_name>
 ```
 
@@ -791,7 +791,7 @@ When this command runs, a `snapshot_id` is generated and printed.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     create_database_snapshot
 ```
 
@@ -805,7 +805,7 @@ Creates a snapshot of the specified YCQL keyspace.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_keyspace_snapshot <keyspace_name>
 ```
 
@@ -818,7 +818,7 @@ When this command runs, a `snapshot_id` is generated and printed.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     create_keyspace_snapshot
 ```
 
@@ -832,7 +832,7 @@ Prints a list of all snapshot IDs, restoration IDs, and states. Optionally, prin
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_snapshots \
     [ show_details ] [ not_show_restored ]
 ```
@@ -882,7 +882,7 @@ In this example, the optional `show_details` flag is added to generate the snaps
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     list_snapshots show_details
 ```
 
@@ -918,7 +918,7 @@ Use the [`create_snapshot_schedule`](#create-snapshot-schedule) command to creat
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_snapshot <keyspace> <table_name> | <table_id> \
     [<keyspace> <table_name> | <table_id> ]... \
     [flush_timeout_in_seconds]
@@ -936,7 +936,7 @@ When this command runs, a `snapshot_id` is generated and printed.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     create_snapshot ydb test_tb
 ```
 
@@ -958,7 +958,7 @@ Restores the specified snapshot, including the tables and indexes. When the oper
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     restore_snapshot <snapshot_id> <restore-target>
 ```
 
@@ -1008,7 +1008,7 @@ Returns one or more restorations in JSON format.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_snapshot_restorations <restoration_id>
 ```
 
@@ -1019,7 +1019,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     list_snapshot_restorations 26ed9053-0c26-4277-a2b8-c12d0fa4c8cf
 ```
 
@@ -1043,7 +1043,7 @@ Generates a metadata file for the specified snapshot, listing all the relevant i
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     export_snapshot <snapshot_id> <file_name>
 ```
 
@@ -1055,7 +1055,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     export_snapshot 4963ed18fc1e4f1ba38c8fcf4058b295 \
     test_tb.snapshot
 ```
@@ -1073,7 +1073,7 @@ Imports the specified snapshot metadata file.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     import_snapshot <file_name> \
     [<keyspace> <table_name> [<keyspace> <table_name>]...]
 ```
@@ -1093,7 +1093,7 @@ The *keyspace* and the *table* can be different from the exported one.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     import_snapshot test_tb.snapshot ydb test_tb
 ```
 
@@ -1119,7 +1119,7 @@ Imports only the specified tables from the specified snapshot metadata file.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     import_snapshot_selective <file_name> \
     [<keyspace> <table_name> [<keyspace> <table_name>]...]
 ```
@@ -1139,7 +1139,7 @@ The *keyspace* can be different from the exported one. The name of the table nee
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     import_snapshot_selective test_tb.snapshot ydb test_tb
 ```
 
@@ -1165,7 +1165,7 @@ Deletes the specified snapshot.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     delete_snapshot <snapshot_id>
 ```
 
@@ -1182,7 +1182,7 @@ Returns a schedule ID in JSON format.
 
 ```sh
 yb-admin create_snapshot_schedule \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     <snapshot-interval>\
     <retention-time>\
     <filter-expression>
@@ -1201,7 +1201,7 @@ Take a snapshot of the YSQL database `yugabyte` once per minute, and retain each
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     create_snapshot_schedule 1 10 ysql.yugabyte
 ```
 
@@ -1209,7 +1209,7 @@ The equivalent command for a YCQL keyspace (for example, yugabyte) would be the 
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     create_snapshot_schedule 1 10 yugabyte
 ```
 
@@ -1241,7 +1241,7 @@ Returns one or more schedule lists in JSON format.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_snapshot_schedules <schedule-id>
 ```
 
@@ -1252,7 +1252,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     list_snapshot_schedules 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
 ```
 
@@ -1289,7 +1289,7 @@ Schedules group a set of items into a single tracking object (the *schedule*). W
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     restore_snapshot_schedule <schedule-id> <restore-target>
 ```
 
@@ -1321,7 +1321,7 @@ Restore from an absolute timestamp:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 1617670679185100
 ```
 
@@ -1329,7 +1329,7 @@ Restore from a relative time:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 minus 60s
 ```
 
@@ -1352,7 +1352,7 @@ Returns a JSON object with the `schedule_id` that was just deleted.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     delete_snapshot_schedule <schedule-id>
 ```
 
@@ -1363,7 +1363,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     delete_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
 ```
 
@@ -1389,7 +1389,7 @@ Modifies the placement information (cloud, region, and zone) for a deployment.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     modify_placement_info <placement_info> <replication_factor> \
     [ <placement_id> ]
 ```
@@ -1403,7 +1403,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     modify_placement_info  \
     aws.us-west.us-west-2a:2,aws.us-west.us-west-2b:2,aws.us-west.us-west-2c 5
 ```
@@ -1446,7 +1446,7 @@ Having all tablet leaders reside in a single region reduces the number of networ
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     set_preferred_zones <cloud.region.zone>[:preference] \
     [<cloud.region.zone>[:preference]]...
 ```
@@ -1593,7 +1593,7 @@ Add a read replica cluster to the master configuration.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     add_read_replica_placement_info <placement_info> \
     <replication_factor> \
     [ <placement_id> ]
@@ -1611,7 +1611,7 @@ yb-admin \
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     modify_read_replica_placement_info <placement_info> \
     <replication_factor> \
     [ <placement_id> ]
@@ -1630,7 +1630,7 @@ Delete the read replica.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     delete_read_replica_placement_info
 ```
 
@@ -1652,7 +1652,7 @@ Sets the contents of `key_path` in-memory on each YB-Master node.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     add_universe_key_to_all_masters <key_id> <key_path>
 ```
 
@@ -1671,7 +1671,7 @@ Checks whether the universe key associated with the provided *key_id* exists in-
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> all_masters_have_universe_key_in_memory <key_id>
+    --master_addresses <master-addresses> all_masters_have_universe_key_in_memory <key_id>
 ```
 
 * *key_id*: Universe-unique identifier (can be any string, such as a string of a UUID) that will be associated to the universe key contained in the contents of `key_path` as a byte[].
@@ -1690,7 +1690,7 @@ The [`all_masters_have_universe_key_in_memory`](#all-masters-have-universe-key-i
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> rotate_universe_key_in_memory <key_id>
+    --master_addresses <master-addresses> rotate_universe_key_in_memory <key_id>
 ```
 
 * *key_id*: Universe-unique identifier (can be any string, such as a string of a UUID) that will be associated to the universe key contained in the contents of `key_path` as a byte[].
@@ -1703,7 +1703,7 @@ Disables the in-memory encryption at rest for newly-written data files.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     disable_encryption_in_memory
 ```
 
@@ -1715,7 +1715,7 @@ Checks if cluster-wide encryption is enabled.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     is_encryption_enabled
 ```
 
@@ -1733,7 +1733,7 @@ The new key ID (`<key_id_2>`) should be different from the previous one (`<key_i
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     is_encryption_enabled
 ```
 
@@ -1751,7 +1751,7 @@ Create a change data capture (CDC) DB stream for the specified namespace using t
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_change_data_stream ysql.<namespace_name>
 ```
 
@@ -1762,7 +1762,7 @@ For example:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100 \
+    --master_addresses 127.0.0.1:7100 \
     create_change_data_stream ysql.yugabyte
 ```
 
@@ -1775,7 +1775,7 @@ This feature is {{<tags/feature/tp>}}. Use the [yb_enable_cdc_consistent_snapsho
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_change_data_stream ysql.<namespace_name> EXPLICIT CHANGE USE_SNAPSHOT
 ```
 
@@ -1789,7 +1789,7 @@ For example:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100 \
+    --master_addresses 127.0.0.1:7100 \
     create_change_data_stream ysql.yugabyte EXPLICIT CHANGE USE_SNAPSHOT
 ```
 
@@ -1802,7 +1802,7 @@ To create a change data capture (CDC) DB stream which also supports sending the 
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_change_data_stream ysql.<namespace_name> IMPLICIT ALL
 ```
 
@@ -1825,7 +1825,7 @@ To create a change data capture (CDC) DB stream which works in the EXPLICIT chec
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_change_data_stream ysql.<namespace_name> EXPLICIT
 ```
 
@@ -1847,7 +1847,7 @@ Lists all the created CDC DB streams.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_change_data_streams [namespace_name]
 ```
 
@@ -1858,7 +1858,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100 \
+    --master_addresses 127.0.0.1:7100 \
     list_change_data_streams
 ```
 
@@ -1904,7 +1904,7 @@ Get the information associated with a particular CDC DB stream.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_change_data_stream_info <db_stream_id>
 ```
 
@@ -1915,7 +1915,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100 \
+    --master_addresses 127.0.0.1:7100 \
     get_change_data_stream_info d540f5e4890c4d3b812933cbfd703ed3
 ```
 
@@ -1938,7 +1938,7 @@ Delete the specified CDC DB stream.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     delete_change_data_stream <db_stream_id>
 ```
 
@@ -1949,7 +1949,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100 \
+    --master_addresses 127.0.0.1:7100 \
     delete_change_data_stream d540f5e4890c4d3b812933cbfd703ed3
 ```
 
@@ -1971,7 +1971,7 @@ To verify if any tables are already configured for replication, use [list_cdc_st
 
 ```sh
 yb-admin \
-    -master_addresses <target_master_addresses> \
+    --master_addresses <target_master_addresses> \
     setup_universe_replication \
     <source_universe_uuid>_<replication_name> \
     <source_master_addresses> \
@@ -2002,7 +2002,7 @@ To display a list of tables and their UUID (`table_id`) values, open the **YB-Ma
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     setup_universe_replication e260b8b6-e89f-4505-bb8e-b31f74aa29f3_xClusterSetup1 \
     127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     000030a5000030008000000000004000,000030a5000030008000000000004005,dfef757c415c4b2cacc9315b8acb539a
@@ -2024,7 +2024,7 @@ To check if any tables are configured for replication, use [list_cdc_streams](#l
 Use the `set_master_addresses` subcommand to replace the source master address list. Use this if the set of masters on the source changes:
 
 ```sh
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
     alter_universe_replication <source-universe-uuid>_<replication-name> \
     set_master_addresses <source-master-addresses>
 ```
@@ -2037,7 +2037,7 @@ yb-admin -master_addresses <target-master-addresses> \
 Use the `add_table` subcommand to add one or more tables to the existing list:
 
 ```sh
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
     alter_universe_replication <source-universe-uuid>_<replication-name> \
     add_table [ <source-table-ids> ] \
     [ <source-bootstrap-ids> ]
@@ -2056,7 +2056,7 @@ Enter the source universe bootstrap IDs in the same order as their corresponding
 Use the `remove_table` subcommand to remove one or more tables from the existing list:
 
 ```sh
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
     alter_universe_replication <source-universe-uuid>_<replication-name> \
     remove_table <source-table-ids> [ignore-errors]
 ```
@@ -2070,7 +2070,7 @@ yb-admin -master_addresses <target-master-addresses> \
 Use the `rename_id` subcommand to rename xCluster replication streams.
 
 ```sh
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
     alter_universe_replication <source-universe-uuid>_<replication-name> \
     rename_id <source-universe-uuid>_<new-replication-name>
 ```
@@ -2088,7 +2088,7 @@ Deletes universe replication for the specified source universe.
 
 ```sh
 yb-admin \
-    -master_addresses <target_master_addresses> \
+    --master_addresses <target_master_addresses> \
     delete_universe_replication <source_universe_uuid>_<replication_name>
 ```
 
@@ -2104,7 +2104,7 @@ Sets the universe replication to be enabled or disabled.
 
 ```sh
 yb-admin \
-    -master_addresses <target_master_addresses> \
+    --master_addresses <target_master_addresses> \
     set_universe_replication_enabled <source_universe_uuid>_<replication_name>
 ```
 
@@ -2121,7 +2121,7 @@ Sets the xCluster role to `STANDBY` or `ACTIVE`.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     change_xcluster_role \
     <role>
 ```
@@ -2133,7 +2133,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     change_xcluster_role STANDBY
 ```
 
@@ -2145,7 +2145,7 @@ Reports the current xCluster safe time for each namespace, which is the time at 
 
 ```sh
 yb-admin \
-    -master_addresses <target_master_addresses> \
+    --master_addresses <target_master_addresses> \
     get_xcluster_safe_time \
     [include_lag_and_skew]
 ```
@@ -2157,7 +2157,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     get_xcluster_safe_time
 ```
 
@@ -2187,7 +2187,7 @@ Verify when the producer and consumer are in sync for a given list of `stream_id
 
 ```sh
 yb-admin \
-    -master_addresses <source_master_addresses> \
+    --master_addresses <source_master_addresses> \
     wait_for_replication_drain \
     <comma_separated_list_of_stream_ids> [<timestamp> | minus <interval>]
 ```
@@ -2201,7 +2201,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+    --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     wait_for_replication_drain 000033f1000030008000000000000000,200033f1000030008000000000000002 minus 1m
 ```
 
@@ -2232,7 +2232,7 @@ Use this command when setting up universe replication to verify if any tables ar
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_cdc_streams
 ```
 
@@ -2242,7 +2242,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     list_cdc_streams
 ```
 
@@ -2254,7 +2254,7 @@ Deletes underlying CDC stream for the specified YB-Master servers.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     delete_cdc_stream <stream_id [force_delete]>
 ```
 
@@ -2274,7 +2274,7 @@ Mark a set of tables in preparation for setting up universe level replication.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     bootstrap_cdc_producer <comma_separated_list_of_table_ids>
 ```
 
@@ -2285,7 +2285,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 172.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 172.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     bootstrap_cdc_producer 000030ad000030008000000000004000
 ```
 
@@ -2305,7 +2305,7 @@ Returns the replication status of all consumer streams. If *source_universe_uuid
 
 ```sh
 yb-admin \
-    -master_addresses <target-master-addresses> \
+    --master_addresses <target-master-addresses> \
     get_replication_status [ <source_universe_uuid>_<replication_name> ]
 ```
 
@@ -2316,7 +2316,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 172.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 172.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     get_replication_status e260b8b6-e89f-4505-bb8e-b31f74aa29f3
 ```
 
@@ -2343,7 +2343,7 @@ Gets the tablet load move completion percentage for blacklisted nodes.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_leader_blacklist_completion
 ```
 
@@ -2353,7 +2353,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     get_leader_blacklist_completion
 ```
 
@@ -2367,7 +2367,7 @@ After old YB-TServer servers are terminated, you can use this command to clean u
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     change_blacklist [ ADD | REMOVE ] <ip_addr>:<port> \
     [ <ip_addr>:<port> ]...
 ```
@@ -2380,7 +2380,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     change_blacklist \
       ADD node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
 ```
@@ -2391,7 +2391,7 @@ yb-admin \
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     change_leader_blacklist [ ADD | REMOVE ] <ip_addr>:<port> \
     [ <ip_addr>:<port> ]...
 ```
@@ -2404,7 +2404,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     change_leader_blacklist \
       ADD node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
 ```
@@ -2425,7 +2425,7 @@ There is a possibility of downtime.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     leader_stepdown <tablet_id> <dest_ts_uuid>
 ```
 
@@ -2455,7 +2455,7 @@ Enables or disables the load balancer.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     set_load_balancer_enabled [ 0 | 1 ]
 ```
 
@@ -2466,7 +2466,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     set_load_balancer_enabled 0
 ```
 
@@ -2478,7 +2478,7 @@ Returns the cluster load balancer state.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> get_load_balancer_state
+    --master_addresses <master-addresses> get_load_balancer_state
 ```
 
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.
@@ -2493,7 +2493,7 @@ You can rerun this command periodically until the value reaches `100.0`, indicat
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_load_move_completion
 ```
 
@@ -2518,7 +2518,7 @@ In the following example, the data move is `66.6` percent done.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     get_load_move_completion
 ```
 
@@ -2536,7 +2536,7 @@ Finds out if the load balancer is idle.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_is_load_balancer_idle
 ```
 
@@ -2546,7 +2546,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     get_is_load_balancer_idle
 ```
 
@@ -2566,7 +2566,7 @@ Note that `promote_auto_flags` is a cluster-level operation; you don't need to r
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     promote_auto_flags \
     [<max_flags_class> [<promote_non_runtime_flags> [force]]]
 ```
@@ -2580,7 +2580,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     promote_auto_flags kLocalPersisted
 ```
 
@@ -2608,7 +2608,7 @@ YSQL upgrades are not required for clusters where [YSQL is not enabled](../../re
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     upgrade_ysql
 ```
 
@@ -2616,7 +2616,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     upgrade_ysql
 ```
 
@@ -2630,8 +2630,8 @@ In certain scenarios, a YSQL upgrade can take longer than 60 seconds, which is t
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
-    -timeout_ms 180000 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --timeout_ms 180000 \
     upgrade_ysql
 ```
 

--- a/docs/content/v2.20/api/ycql/ddl_create_index.md
+++ b/docs/content/v2.20/api/ycql/ddl_create_index.md
@@ -187,7 +187,7 @@ After creating a set of indexes with their backfill deferred, you can then trigg
    Launch a backfill job for backfilling all the deferred indexes using the `backfill_indexes_for_table` command as follows:
 
     ```bash
-    bin/yb-admin -master_addresses <ip:port> backfill_indexes_for_table ycql.ybdemo table_name
+    bin/yb-admin --master_addresses <ip:port> backfill_indexes_for_table ycql.ybdemo table_name
     ```
 - Use the [`--defer_index_backfill`](../../../reference/configuration/yb-master#defer-index-backfill) YB-Master flag to force all indexes to be DEFERRED, and run `yb-admin backfill_indexes_for_table` to backfill indexes.
 

--- a/docs/content/v2.20/api/ysql/exprs/geo_partitioning_helper_functions/func_yb_is_local_table.md
+++ b/docs/content/v2.20/api/ysql/exprs/geo_partitioning_helper_functions/func_yb_is_local_table.md
@@ -55,7 +55,7 @@ This function is helpful while implementing [Row-level geo-partitioning](../../.
 1. Use [yb-admin](../../../../../admin/yb-admin/) to specify the placement configuration to be used by the cluster as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses <IP1>:7100 modify_placement_info aws.us-west-1.us-west-1c:1,aws.us-east-1.us-east-1a:1,aws.us-east-2.us-east-2c:1 3
+    ./bin/yb-admin --master_addresses <IP1>:7100 modify_placement_info aws.us-west-1.us-west-1c:1,aws.us-east-1.us-east-1a:1,aws.us-east-2.us-east-2c:1 3
     ```
 
 1. Create tablespaces corresponding to the regions used by the cluster created above [using ysqlsh](../../../../../admin/ysqlsh/#using-ysqlsh) as follows:

--- a/docs/content/v2.20/api/ysql/exprs/geo_partitioning_helper_functions/func_yb_server_region.md
+++ b/docs/content/v2.20/api/ysql/exprs/geo_partitioning_helper_functions/func_yb_server_region.md
@@ -63,7 +63,7 @@ Do the following to create a 3-node multi-region cluster and a geo-partitioned t
 1. Use [yb-admin](../../../../../admin/yb-admin/) to specify the placement configuration to be used by the cluster:
 
     ```sh
-    ./bin/yb-admin -master_addresses <IP1>:7100 modify_placement_info aws.us-west-1.us-west-1c:1,aws.us-east-1.us-east-1a:1,aws.us-east-2.us-east-2c:1 3
+    ./bin/yb-admin --master_addresses <IP1>:7100 modify_placement_info aws.us-west-1.us-west-1c:1,aws.us-east-1.us-east-1a:1,aws.us-east-2.us-east-2c:1 3
     ```
 
 1. Create tablespaces corresponding to the regions used by the cluster created above [using ysqlsh](../../../../../admin/ysqlsh/#using-ysqlsh):

--- a/docs/content/v2.20/deploy/multi-dc/async-replication/async-deployment.md
+++ b/docs/content/v2.20/deploy/multi-dc/async-replication/async-deployment.md
@@ -35,20 +35,20 @@ After you created the required tables, you can set up unidirectional replication
   - To find a table ID, execute the following command as an admin user:
 
       ```sh
-      ./bin/yb-admin -master_addresses <source_universe_master_addresses> list_tables include_table_id
+      ./bin/yb-admin --master_addresses <source_universe_master_addresses> list_tables include_table_id
       ```
 
       The preceding command lists all the tables, including system tables. To locate a specific table, you can add grep as follows:
 
       ```sh
-      ./bin/yb-admin -master_addresses <source_universe_master_addresses> list_tables include_table_id | grep table_name
+      ./bin/yb-admin --master_addresses <source_universe_master_addresses> list_tables include_table_id | grep table_name
       ```
 
 - Run the following `yb-admin` [`setup_universe_replication`](../../../../admin/yb-admin/#setup-universe-replication) command from the YugabyteDB home directory in the source universe:
 
     ```sh
     ./bin/yb-admin \
-      -master_addresses <target_universe_master_addresses> \
+      --master_addresses <target_universe_master_addresses> \
       setup_universe_replication <source_universe_UUID>_<replication_stream_name> \
         <source_universe_master_addresses> \
         <table_id>,[<table_id>..]
@@ -58,7 +58,7 @@ After you created the required tables, you can set up unidirectional replication
 
     ```sh
     ./bin/yb-admin \
-      -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+      --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
       setup_universe_replication e260b8b6-e89f-4505-bb8e-b31f74aa29f3_xClusterSetup1 \
         127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         000030a5000030008000000000004000,000030a5000030008000000000004005,dfef757c415c4b2cacc9315b8acb539a
@@ -134,7 +134,7 @@ You can use `yb-admin` to return the current replication status. The `get_replic
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7000,127.0.0.2:7000,127.0.0.3:7000 \
+    --master_addresses 127.0.0.1:7000,127.0.0.2:7000,127.0.0.3:7000 \
     get_replication_status
 ```
 
@@ -158,8 +158,8 @@ If both universes use the same certificates, run `yb-admin setup_universe_replic
 Consider the following example:
 
 ```sh
-./bin/yb-admin -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
-  -certs_dir_name /home/yugabyte/yugabyte-tls-config \
+./bin/yb-admin --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+  --certs_dir_name /home/yugabyte/yugabyte-tls-config \
   setup_universe_replication e260b8b6-e89f-4505-bb8e-b31f74aa29f3_xClusterSetup1 \
   127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
   000030a5000030008000000000004000,000030a5000030008000000000004005,dfef757c415c4b2cacc9315b8acb539a
@@ -182,8 +182,8 @@ When universes use different certificates, you need to store the certificates fo
     For example, if you have the target universe's certificates in `/home/yugabyte/yugabyte-tls-config`, then you would run the following:
 
     ```sh
-    ./bin/yb-admin -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
-      -certs_dir_name /home/yugabyte/yugabyte-tls-config \
+    ./bin/yb-admin --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+      --certs_dir_name /home/yugabyte/yugabyte-tls-config \
       setup_universe_replication 00000000-1111-2222-3333-444444444444_xClusterSetup1 \
       127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
       000030a5000030008000000000004000,000030a5000030008000000000004005,dfef757c415c4b2cacc9315b8acb539a
@@ -261,7 +261,7 @@ To create unidirectional replication, perform the following:
 1. Run the replication setup command for the source universe, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses <target_master_addresses> \
+    ./bin/yb-admin --master_addresses <target_master_addresses> \
     setup_universe_replication <source_universe_UUID>_<replication_stream_name> \
     <source_master_addresses> <comma_separated_table_ids>
     ```
@@ -269,7 +269,7 @@ To create unidirectional replication, perform the following:
     Consider the following example:
 
     ```sh
-    ./bin/yb-admin -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    ./bin/yb-admin --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     setup_universe_replication 00000000-1111-2222-3333-444444444444_xClusterSetup1 \
     127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     000033e1000030008000000000004007,000033e100003000800000000000400d,000033e1000030008000000000004013
@@ -322,7 +322,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
 
   ```sh
   kubectl exec -it -n <source_universe_namespace> -t <source_universe_master_leader> -c \
-    <source_universe_container> -- bash -c "/home/yugabyte/bin/yb-admin -master_addresses \
+    <source_universe_container> -- bash -c "/home/yugabyte/bin/yb-admin --master_addresses \
     <target_universe_master_addresses> setup_universe_replication \
     <source_universe_UUID>_<replication_stream_name> <source_universe_master_addresses> \
     <comma_separated_table_ids>"
@@ -332,7 +332,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
 
   ```sh
   kubectl exec -it -n xcluster-source -t yb-master-2 -c yb-master -- bash -c \
-    "/home/yugabyte/bin/yb-admin -master_addresses yb-master-2.yb-masters.xcluster-target.svc.cluster.local, \
+    "/home/yugabyte/bin/yb-admin --master_addresses yb-master-2.yb-masters.xcluster-target.svc.cluster.local, \
     yb-master-1.yb-masters.xcluster-target.svc.cluster.local,yb-master-0.yb-masters.xcluster-target.svc.cluster.local \
     setup_universe_replication ac39666d-c183-45d3-945a-475452deac9f_xCluster_1 \
     yb-master-2.yb-masters.xcluster-source.svc.cluster.local,yb-master-1.yb-masters.xcluster-source.svc.cluster.local, \
@@ -387,14 +387,14 @@ Proceed as follows:
 1. Create a checkpoint on the source universe for all the tables you want to replicate by executing the following command:
 
     ```sh
-    ./bin/yb-admin -master_addresses <source_universe_master_addresses> \
+    ./bin/yb-admin --master_addresses <source_universe_master_addresses> \
     bootstrap_cdc_producer <comma_separated_source_universe_table_ids>
     ```
 
     Consider the following example:
 
     ```sh
-    ./bin/yb-admin -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+    ./bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     bootstrap_cdc_producer 000033e1000030008000000000004000,000033e1000030008000000000004003,000033e1000030008000000000004006
     ```
 
@@ -410,7 +410,7 @@ Proceed as follows:
 1. Execute the following command to set up the replication stream using the bootstrap IDs generated in step 1. Ensure that the bootstrap IDs are in the same order as their corresponding table IDs.
 
     ```sh
-    ./bin/yb-admin -master_addresses <target_universe_master_addresses> setup_universe_replication \
+    ./bin/yb-admin --master_addresses <target_universe_master_addresses> setup_universe_replication \
       <source_universe_uuid>_<replication_stream_name> <source_universe_master_addresses> \
       <comma_separated_source_universe_table_ids> <comma_separated_bootstrap_ids>
     ```
@@ -418,7 +418,7 @@ Proceed as follows:
     Consider the following example:
 
     ```sh
-    ./bin/yb-admin -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 setup_universe_replication \
+    ./bin/yb-admin --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 setup_universe_replication \
       00000000-1111-2222-3333-444444444444_xCluster1 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
       000033e1000030008000000000004000,000033e1000030008000000000004003,000033e1000030008000000000004006 \
       fb156717174941008e54fa958e613c10,a2a46f5cbf8446a3a5099b5ceeaac28b,c967967523eb4e03bcc201bb464e0679
@@ -470,8 +470,8 @@ When new tables (or partitions) are created, to ensure that all changes from the
 1. Get table IDs of the new partition from the source as follows:
 
     ```sql
-    yb-admin -master_addresses <source_master_ips> \
-    -certs_dir_name <cert_dir> \
+    yb-admin --master_addresses <source_master_ips> \
+    --certs_dir_name <cert_dir> \
     list_tables include_table_id|grep 'order_changes_2023_01'
     ```
 
@@ -484,8 +484,8 @@ When new tables (or partitions) are created, to ensure that all changes from the
 1. Add the new table (or partition) to replication.
 
    ```sql
-   yb-admin -master_addresses <target_master_ips> \
-   -certs_dir_name <cert_dir> \
+   yb-admin --master_addresses <target_master_ips> \
+   --certs_dir_name <cert_dir> \
    alter_universe_replication <replication_group_name> \
    add_table  000033e800003000800000000000410b
    ```
@@ -508,8 +508,8 @@ However, to add a new index to a table that already has data, the following addi
 
    ```sql
    yb-admin
-   -master_addresses <source_master_ips> \
-   -certs_dir_name <cert_dir> \
+   --master_addresses <source_master_ips> \
+   --certs_dir_name <cert_dir> \
    list_tables include_table_id|grep 'my_new_index'
    ```
 
@@ -523,8 +523,8 @@ However, to add a new index to a table that already has data, the following addi
 
    ```sql
    yb-admin
-   -master_addresses <source_master_ips> \
-   -certs_dir_name <cert_dir> \
+   --master_addresses <source_master_ips> \
+   --certs_dir_name <cert_dir> \
    bootstrap_cdc_producer 000033e8000030008000000000004028
    ```
 
@@ -541,8 +541,8 @@ However, to add a new index to a table that already has data, the following addi
 
     ```sql
     yb-admin
-    -master_addresses <target_master_ips> \
-    -certs_dir_name <cert_dir> \
+    --master_addresses <target_master_ips> \
+    --certs_dir_name <cert_dir> \
     alter_universe_replication 59e58153-eec6-4cb5-a858-bf685df52316_east-west \
     add_table  000033e8000030008000000000004028 c8cba563e39c43feb66689514488591c
     ```
@@ -566,16 +566,16 @@ Objects (tables, indexes, partitions) need to be removed from replication before
 1. Get the table ID for the object to be removed from the source.
 
     ```sql
-    yb-admin -master_addresses <source_master_ips> \
-    -certs_dir_name <cert_dir> \
+    yb-admin --master_addresses <source_master_ips> \
+    --certs_dir_name <cert_dir> \
     list_tables include_table_id |grep '<partition_name>'
     ```
 
 1. Remove the table from replication on the target.
 
     ```sql
-    yb-admin -master_addresses <target_master_ips> \
-    -certs_dir_name <cert_dir> \
+    yb-admin --master_addresses <target_master_ips> \
+    --certs_dir_name <cert_dir> \
     alter_universe_replication <replication_group_name> \
     remove_table  000033e800003000800000000000410b
     ```
@@ -588,8 +588,8 @@ Alters involving adding/removing columns or modifying data types require replica
 
     ```sql
     yb-admin
-    -master_addresses <target_master_ips>
-    -certs_dir_name <cert_dir> \
+    --master_addresses <target_master_ips>
+    --certs_dir_name <cert_dir> \
     set_universe_replication_enabled <replication_group_name> 0
     ```
 
@@ -604,8 +604,8 @@ Alters involving adding/removing columns or modifying data types require replica
 
     ```sql
     yb-admin
-    -master_addresses <target_master_ips>
-    -certs_dir_name <cert_dir> \
+    --master_addresses <target_master_ips>
+    --certs_dir_name <cert_dir> \
     set_universe_replication_enabled <replication_group_name> 0
     ```
 

--- a/docs/content/v2.20/deploy/multi-dc/async-replication/async-transactional-failover.md
+++ b/docs/content/v2.20/deploy/multi-dc/async-replication/async-transactional-failover.md
@@ -28,8 +28,8 @@ If the Primary (A) is terminated for some reason, do the following:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
-        -certs_dir_name <cert_dir> \
+        --master_addresses <standby_master_addresses> \
+        --certs_dir_name <cert_dir> \
         set_universe_replication_enabled <replication_name> 0
     ```
 
@@ -43,8 +43,8 @@ If the Primary (A) is terminated for some reason, do the following:
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses <standby_master_addresses> \
-    -certs_dir_name <cert_dir> \
+    --master_addresses <standby_master_addresses> \
+    --certs_dir_name <cert_dir> \
     get_xcluster_safe_time include_lag_and_skew
     ```
 
@@ -102,8 +102,8 @@ To do a PITR on a database:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
-        -certs_dir_name <cert_dir> \
+        --master_addresses <standby_master_addresses> \
+        --certs_dir_name <cert_dir> \
         list_snapshot_schedules
     ```
 
@@ -134,8 +134,8 @@ To do a PITR on a database:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
-        -certs_dir_name <cert_dir> \
+        --master_addresses <standby_master_addresses> \
+        --certs_dir_name <cert_dir> \
         restore_snapshot_schedule <schedule_id> "<safe_time>"
     ```
 
@@ -152,8 +152,8 @@ To do a PITR on a database:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
-        -certs_dir_name <cert_dir> \
+        --master_addresses <standby_master_addresses> \
+        --certs_dir_name <cert_dir> \
         list_snapshot_restorations
     ```
 
@@ -174,8 +174,8 @@ To do a PITR on a database:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
-        -certs_dir_name <cert_dir> \
+        --master_addresses <standby_master_addresses> \
+        --certs_dir_name <cert_dir> \
         change_xcluster_role ACTIVE
     ```
 
@@ -187,7 +187,7 @@ To do a PITR on a database:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
+        --master_addresses <standby_master_addresses> \
         delete_universe_replication <primary_universe_uuid>_<replication_name>
     ```
 
@@ -221,8 +221,8 @@ To do a PITR on a database:
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses <standby_master_addresses> \
-    -certs_dir_name <cert_dir> \
+    --master_addresses <standby_master_addresses> \
+    --certs_dir_name <cert_dir> \
     change_xcluster_role ACTIVE
     ```
 
@@ -286,7 +286,7 @@ Do the following:
     - List the snapshot schedules to obtain the schedule ID:
 
         ```sh
-        ./bin/yb-admin -master_addresses <A_master_addresses> \
+        ./bin/yb-admin --master_addresses <A_master_addresses> \
         list_snapshot_schedules
         ```
 
@@ -294,7 +294,7 @@ Do the following:
 
         ```sh
         ./bin/yb-admin \
-            -master_addresses <A_master_addresses> \
+            --master_addresses <A_master_addresses> \
             delete_snapshot_schedule <schedule_id>
         ```
 
@@ -312,8 +312,8 @@ Do the following:
 
         ```sh
         ./bin/yb-admin \
-        -master_addresses <A_master_ips> \
-        -certs_dir_name <dir_name> \
+        --master_addresses <A_master_ips> \
+        --certs_dir_name <dir_name> \
         list_cdc_streams
         ```
 
@@ -321,8 +321,8 @@ Do the following:
 
         ```sh
         ./bin/yb-admin \
-        -master_addresses <A_master_ips> \
-        -certs_dir_name <dir_name> \
+        --master_addresses <A_master_ips> \
+        --certs_dir_name <dir_name> \
         delete_cdc_stream <streamID>
         ```
 
@@ -356,8 +356,8 @@ Do the following:
 
         ```sh
         ./bin/yb-admin \
-        -master_addresses <A_master_ips> \
-        -certs_dir_name <dir_name> \
+        --master_addresses <A_master_ips> \
+        --certs_dir_name <dir_name> \
         list_cdc_streams
         ```
 
@@ -365,8 +365,8 @@ Do the following:
 
         ```sh
         ./bin/yb-admin \
-        -master_addresses <A_master_ips> \
-        -certs_dir_name <dir_name> \
+        --master_addresses <A_master_ips> \
+        --certs_dir_name <dir_name> \
         delete_cdc_stream <streamID>
         ```
 

--- a/docs/content/v2.20/deploy/multi-dc/async-replication/async-transactional-setup.md
+++ b/docs/content/v2.20/deploy/multi-dc/async-replication/async-transactional-setup.md
@@ -85,7 +85,7 @@ To set up unidirectional transactional replication manually, do the following:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
+        --master_addresses <standby_master_addresses> \
         create_snapshot_schedule 1 10 ysql.yugabyte
     ```
 
@@ -95,8 +95,8 @@ To set up unidirectional transactional replication manually, do the following:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
-        -certs_dir_name <cert_dir> \
+        --master_addresses <standby_master_addresses> \
+        --certs_dir_name <cert_dir> \
         setup_universe_replication \
         <primary_universe_uuid>_<replication_name> \
         <primary_universe_master_addresses> \
@@ -108,8 +108,8 @@ To set up unidirectional transactional replication manually, do the following:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
-        -certs_dir_name <dir_name> \
+        --master_addresses <standby_master_addresses> \
+        --certs_dir_name <dir_name> \
         change_xcluster_role STANDBY
     ```
 
@@ -216,7 +216,7 @@ get_xcluster_safe_time
 For example:
 
 ```sh
-./tserver/bin/yb-admin -master_addresses 172.150.21.61:7100,172.150.44.121:7100,172.151.23.23:7100 \
+./tserver/bin/yb-admin --master_addresses 172.150.21.61:7100,172.150.44.121:7100,172.151.23.23:7100 \
     get_xcluster_safe_time
 ```
 

--- a/docs/content/v2.20/deploy/multi-dc/async-replication/async-transactional-switchover.md
+++ b/docs/content/v2.20/deploy/multi-dc/async-replication/async-transactional-switchover.md
@@ -30,8 +30,8 @@ Proceed as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <A_master_addresses> \
-        -certs_dir_name <dir_name>  \
+        --master_addresses <A_master_addresses> \
+        --certs_dir_name <dir_name>  \
         list_cdc_streams
     ```
 
@@ -84,8 +84,8 @@ Proceed as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <A_master_addresses> \
-        -certs_dir_name <dir_name> \
+        --master_addresses <A_master_addresses> \
+        --certs_dir_name <dir_name> \
         wait_for_replication_drain 56bf794172da49c6804cbab59b978c7e,..,..<comma_separated_list_of_stream_ids> 1665548814177072
     ```
 
@@ -112,8 +112,8 @@ Proceed as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <B_master_addresses> \ 
-        -certs_dir_name <dir_name> \
+        --master_addresses <B_master_addresses> \ 
+        --certs_dir_name <dir_name> \
         change_xcluster_role ACTIVE
     ```
 
@@ -121,7 +121,7 @@ Proceed as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <B_master_addresses> \
+        --master_addresses <B_master_addresses> \
         delete_universe_replication <A_universe_uuid>_<replication_name>
     ```
 
@@ -133,8 +133,8 @@ In the second stage, set up replication from the new Primary (B) universe as fol
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <B_master_addresses> 
-        -certs_dir_name <cert_dir> \
+        --master_addresses <B_master_addresses> 
+        --certs_dir_name <cert_dir> \
         bootstrap_cdc_producer <comma_separated_B_table_ids>
     ```
 
@@ -160,8 +160,8 @@ In the second stage, set up replication from the new Primary (B) universe as fol
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <A_master_addresses> \
-        -certs_dir_name <cert_dir> \
+        --master_addresses <A_master_addresses> \
+        --certs_dir_name <cert_dir> \
         setup_universe_replication \
         <B_universe_uuid>_<replication_name> \
         <B_master_addresses> \
@@ -173,8 +173,8 @@ In the second stage, set up replication from the new Primary (B) universe as fol
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <A_master-addresses> \ 
-        -certs_dir_name <dir_name> \
+        --master_addresses <A_master-addresses> \ 
+        --certs_dir_name <dir_name> \
         change_xcluster_role STANDBY
     ```
 

--- a/docs/content/v2.20/deploy/multi-dc/read-replica-clusters.md
+++ b/docs/content/v2.20/deploy/multi-dc/read-replica-clusters.md
@@ -27,7 +27,7 @@ You can deploy a read replica cluster that asynchronously replicates data with a
 1. Define the primary cluster placement using the [`yb-admin modify_placement_info`](../../../admin/yb-admin/#modify-placement-info) command, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses ip1:7100,ip2:7100,ip3:7100 modify_placement_info <placement_info> <replication_factor> [placement_uuid]
+    ./bin/yb-admin --master_addresses ip1:7100,ip2:7100,ip3:7100 modify_placement_info <placement_info> <replication_factor> [placement_uuid]
     ```
 
     - *placement_info*: Comma-separated list of availability zones using the format `<cloud1.region1.zone1>,<cloud2.region2.zone2>, ...`
@@ -37,7 +37,7 @@ You can deploy a read replica cluster that asynchronously replicates data with a
 1. Define the read replica placement using the [`yb-admin add_read_replica_placement_info`](../../../admin/yb-admin/#add-read-replica-placement-info) command, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses ip1:7100,ip2:7100,ip3:7100 add_read_replica_placement_info <placement_info> <replication_factor> [placement_uuid]
+    ./bin/yb-admin --master_addresses ip1:7100,ip2:7100,ip3:7100 add_read_replica_placement_info <placement_info> <replication_factor> [placement_uuid]
     ```
 
     - *placement_info*: Comma-separated list of availability zones, using the format `<cloud1.region1.zone1>:<num_replicas_in_zone1>,<cloud2.region2.zone2>:<num_replicas_in_zone2>,...` These read replica availability zones must be uniquely different from the primary availability zones defined in step 2. If you want to use the same cloud, region, and availability zone as a primary cluster, one option is to suffix the zone with `_rr` (for read replica). For example, `c1.r1.z1_rr:2`.

--- a/docs/content/v2.20/develop/multi-cloud/multicloud-migration.md
+++ b/docs/content/v2.20/develop/multi-cloud/multicloud-migration.md
@@ -66,7 +66,7 @@ The basic flow of bootstrapping is as follows:
 1. Create a checkpoint for all the tables in the AWS universe. For example:
 
     ```bash
-    ./bin/yb-admin -master_addresses <AWS_universe_master_addresses> \
+    ./bin/yb-admin --master_addresses <AWS_universe_master_addresses> \
             bootstrap_cdc_producer <comma_separated_source_universe_table_ids>
     ```
 
@@ -85,7 +85,7 @@ For detailed instructions on how to set up replication, see [Set up unidirection
 A simple way to set up replication is as follows:
 
 ```bash
-./bin/yb-admin -master_addresses <GCP_universe_master_addresses> setup_universe_replication \
+./bin/yb-admin --master_addresses <GCP_universe_master_addresses> setup_universe_replication \
   <AWS_universe_uuid>_<replication_stream_name> <AWS_universe_master_addresses> \
   <comma_separated_source_universe_table_ids> <comma_separated_bootstrap_ids>
 ```
@@ -111,8 +111,8 @@ The basic flow of switchover is as follows:
 
   ```bash
   ./bin/yb-admin \
-      -master_addresses <GCP_master_addresses> \
-      -certs_dir_name <cert_dir> \
+      --master_addresses <GCP_master_addresses> \
+      --certs_dir_name <cert_dir> \
       change_xcluster_role ACTIVE
   ```
 

--- a/docs/content/v2.20/explore/cluster-management/point-in-time-recovery-ycql.md
+++ b/docs/content/v2.20/explore/cluster-management/point-in-time-recovery-ycql.md
@@ -91,7 +91,7 @@ Create and populate a table, get a timestamp to which you'll restore, and then w
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         create_snapshot_schedule 1 10 ycql.pitr
     ```
 
@@ -105,7 +105,7 @@ Create and populate a table, get a timestamp to which you'll restore, and then w
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshot_schedules
     ```
 
@@ -165,7 +165,7 @@ Create and populate a table, get a timestamp to which you'll restore, and then w
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 0e4ceb83-fe3d-43da-83c3-013a8ef592ca 1620418817729963
     ```
 
@@ -180,7 +180,7 @@ Create and populate a table, get a timestamp to which you'll restore, and then w
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 

--- a/docs/content/v2.20/explore/cluster-management/point-in-time-recovery-ysql.md
+++ b/docs/content/v2.20/explore/cluster-management/point-in-time-recovery-ysql.md
@@ -90,7 +90,7 @@ Create a snapshot as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         create_snapshot_schedule 1 10 ysql.yugabyte
     ```
 
@@ -104,7 +104,7 @@ Create a snapshot as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshot_schedules
     ```
 
@@ -165,7 +165,7 @@ Create a snapshot as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 0e4ceb83-fe3d-43da-83c3-013a8ef592ca 1620418817729963
     ```
 
@@ -180,7 +180,7 @@ Create a snapshot as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 
@@ -245,7 +245,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         create_snapshot_schedule 1 10 ysql.yugabyte
     ```
 
@@ -259,7 +259,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshot_schedules
     ```
 
@@ -300,7 +300,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 1fb2d85a-3608-4cb1-af63-3e4062300dc1 1681964544554620
     ```
 
@@ -315,7 +315,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 
@@ -352,7 +352,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshot_schedules
     ```
 
@@ -412,7 +412,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 1fb2d85a-3608-4cb1-af63-3e4062300dc1 1681965106732671
     ```
 
@@ -427,7 +427,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 
@@ -475,7 +475,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshot_schedules
     ```
 
@@ -543,7 +543,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 1fb2d85a-3608-4cb1-af63-3e4062300dc1 1681965472490517
     ```
 
@@ -558,7 +558,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 
@@ -630,7 +630,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 1fb2d85a-3608-4cb1-af63-3e4062300dc1 1681965684502460
     ```
 
@@ -645,7 +645,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 
@@ -720,7 +720,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 1fb2d85a-3608-4cb1-af63-3e4062300dc1 1681965868912921
     ```
 
@@ -735,7 +735,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 

--- a/docs/content/v2.20/explore/colocation.md
+++ b/docs/content/v2.20/explore/colocation.md
@@ -212,7 +212,7 @@ To set up xCluster for colocated tables, do the following:
 1. Get the parent table UUID for the colocated database.
 
     ```sh
-    ./yb-admin -master_addresses <source_master_addresses> list_tables include_table_id | grep -i <database_name> | grep -i "colocation.parent.uuid"
+    ./yb-admin --master_addresses <source_master_addresses> list_tables include_table_id | grep -i <database_name> | grep -i "colocation.parent.uuid"
     ```
 
     ```output
@@ -222,13 +222,13 @@ To set up xCluster for colocated tables, do the following:
 1. Set up replication for the parent colocation table using yb-admin.
 
     ```sh
-    ./yb-admin -master_addresses <target_master_addresses> setup_universe_replication <replication_group_name> <source_master_addresses> <parent_colocated_table_uuid>
+    ./yb-admin --master_addresses <target_master_addresses> setup_universe_replication <replication_group_name> <source_master_addresses> <parent_colocated_table_uuid>
     ```
 
     For example:
 
     ```sh
-    ./yb-admin -master_addresses 127.0.0.2 setup_universe_replication A1-B2 127.0.0.1 00004000000030008000000000004004.colocation.parent.uuid
+    ./yb-admin --master_addresses 127.0.0.2 setup_universe_replication A1-B2 127.0.0.1 00004000000030008000000000004004.colocation.parent.uuid
     ```
 
     ```output

--- a/docs/content/v2.20/explore/multi-region-deployments/asynchronous-replication-ysql.md
+++ b/docs/content/v2.20/explore/multi-region-deployments/asynchronous-replication-ysql.md
@@ -96,7 +96,7 @@ Having two identical tables on your clusters allows you to set up xCluster repli
 To configure "Data Center - West" to be the target of data changes from the "Data Center - East" cluster, you need to use the [yb-admin](../../../admin/yb-admin/) utility [setup_universe_replication](../../../admin/yb-admin/#xcluster-replication-commands) command. The syntax is as follows:
 
 ```sh.output
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
     setup_universe_replication <source-universe-uuid> \
     <source-master-addresses> <source-table-ids>
 ```
@@ -109,7 +109,7 @@ yb-admin -master_addresses <target-master-addresses> \
 Based on actual values you obtained from the YB-Master UI, run the yb-admin `setup_universe_replication` command from your YugabyteDB home directory similar to the one shown in the following example:
 
 ```sh
-./bin/yb-admin -master_addresses 127.0.0.2:7100 \
+./bin/yb-admin --master_addresses 127.0.0.2:7100 \
     setup_universe_replication 7acd6399-657d-42dc-a90a-646869898c2d \
     127.0.0.1:7100 000033e8000030008000000000004000
 ```
@@ -170,7 +170,7 @@ Look up the source UUID in the source YB-Master UI (<http://127.0.0.2:7000>), an
 Based on actual values you obtained from the YB-Master UI, run the yb-admin `setup_universe_replication` command similar to the one shown in the following example:
 
 ```sh
-./bin/yb-admin -master_addresses 127.0.0.1:7100 \
+./bin/yb-admin --master_addresses 127.0.0.1:7100 \
     setup_universe_replication 0a315687-e9bd-430f-b6f4-ac831193a394 \
     127.0.0.2:7100 000030a9000030008000000000004000
 ```
@@ -227,7 +227,7 @@ When the bidirectional replication has been configured, you can add data to the 
 You can add more tables to an existing replication using the yb-admin command `alter_universe_replication` `add_table`:
 
 ```sh.output
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
         alter_universe_replication <source-universe-uuid> \
         add_table <source-table-ids>
 ```
@@ -235,7 +235,7 @@ yb-admin -master_addresses <target-master-addresses> \
 The following is an example command:
 
 ```sh
-./bin/yb-admin -master_addresses 127.0.0.2:7100 \
+./bin/yb-admin --master_addresses 127.0.0.2:7100 \
     alter_universe_replication 7acd6399-657d-42dc-a90a-646869898c2d \
     add_table 000030a9000030008000000000004000
 ```

--- a/docs/content/v2.20/explore/multi-region-deployments/read-replicas-ycql.md
+++ b/docs/content/v2.20/explore/multi-region-deployments/read-replicas-ycql.md
@@ -63,7 +63,7 @@ For more info, please use: yb-ctl status
 The following command instructs the masters to create three replicas for each tablet distributed across the three zones:
 
 ```shell
-$ ./bin/yb-admin -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 modify_placement_info c.r.z1,c.r.z2,c.r.z3 3 live
+$ ./bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 modify_placement_info c.r.z1,c.r.z2,c.r.z3 3 live
 ```
 
 The following illustration demonstrates the primary cluster visible via [YugabyteDB Anywhere](../../../yugabyte-platform/):
@@ -167,7 +167,7 @@ The following commands add three new nodes to a read replica cluster in region `
 ./bin/yb-ctl add_node --placement_info "c.r2.z22" --tserver_flags "placement_uuid=rr"
 ./bin/yb-ctl add_node --placement_info "c.r2.z23" --tserver_flags "placement_uuid=rr"
 
-./bin/yb-admin -master_addresses 127.0.0.1:7100,127.0.0.2,127.0.0.3 add_read_replica_placement_info c.r2.z21:1,c.r2.z22:1,c.r2.z23:1 3 rr
+./bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2,127.0.0.3 add_read_replica_placement_info c.r2.z21:1,c.r2.z22:1,c.r2.z23:1 3 rr
 ```
 
 The following illustration demonstrates the setup of the two clusters, one of which is primary and another one is read replica visible via YugabyteDB Anywhere:

--- a/docs/content/v2.20/explore/query-1-performance/query-tuning-intro.md
+++ b/docs/content/v2.20/explore/query-1-performance/query-tuning-intro.md
@@ -23,7 +23,7 @@ Before trying to optimize individual statements, make sure the YugabyteDB cluste
 To view the nodes and servers that make up your cluster, use the `yb-admin` command to request the master and tablet servers. For example:
 
 ```sh
-$ ./bin/yb-admin -init_master_addrs=$(hostname):7100 list_all_masters
+$ ./bin/yb-admin --init_master_addrs=$(hostname):7100 list_all_masters
 ```
 
 ```output
@@ -34,7 +34,7 @@ a637b88dfc0c4476862ca79872d763d7   172.158.22.229:7100     ALIVE       LEADER
 ```
 
 ```sh
-$ ./bin/yb-admin -init_master_addrs=$(hostname):7100 list_all_tablet_servers
+$ ./bin/yb-admin --init_master_addrs=$(hostname):7100 list_all_tablet_servers
 ```
 
 ```output

--- a/docs/content/v2.20/manage/backup-restore/point-in-time-recovery.md
+++ b/docs/content/v2.20/manage/backup-restore/point-in-time-recovery.md
@@ -78,13 +78,13 @@ To create a schedule and enable PITR, use the [`create_snapshot_schedule`](../..
 For example, to create a schedule that produces a snapshot of a YSQL database once a day (every 1,440 minutes) and retains it for three days (4,320 minutes), you would execute the following command:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot_schedule 1440 4320 ysql.<database_name>
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot_schedule 1440 4320 ysql.<database_name>
 ```
 
 The equivalent command for a YCQL keyspace would be the following:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot_schedule 1440 4320 <keyspace_name>
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot_schedule 1440 4320 <keyspace_name>
 ```
 
 The following output is a unique ID of the newly-created snapshot schedule:
@@ -102,7 +102,7 @@ You can use this ID to [delete the schedule](#delete-a-schedule) or [restore to 
 To delete a schedule and disable PITR, use the following [`delete_snapshot_schedule`](../../../admin/yb-admin/#delete-snapshot-schedule) command that takes the ID of the schedule to be deleted as a parameter:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
 ```
 
 ### List schedules
@@ -110,7 +110,7 @@ To delete a schedule and disable PITR, use the following [`delete_snapshot_sched
 To see a list of schedules that currently exist in the cluster, use the following [`list_snapshot_schedules`](../../../admin/yb-admin/#list-snapshot-schedules) command:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshot_schedules
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshot_schedules
 ```
 
 ```output.json
@@ -141,7 +141,7 @@ To see a list of schedules that currently exist in the cluster, use the followin
 You can also use the same command to view the information about a particular schedule by providing its ID as a parameter, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshot_schedules 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshot_schedules 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
 ```
 
 ## Restore to a point in time
@@ -162,7 +162,7 @@ If a database or a keyspace has an associated snapshot schedule, you can use tha
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <ip1:7100,ip2:7100,ip3:7100> \
+        --master_addresses <ip1:7100,ip2:7100,ip3:7100> \
         restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 1651435200
     ```
 
@@ -170,7 +170,7 @@ If a database or a keyspace has an associated snapshot schedule, you can use tha
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <ip1:7100,ip2:7100,ip3:7100> \
+        --master_addresses <ip1:7100,ip2:7100,ip3:7100> \
         restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 "2022-05-01 13:00-0700"
     ```
 
@@ -180,7 +180,7 @@ If a database or a keyspace has an associated snapshot schedule, you can use tha
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <ip1:7100,ip2:7100,ip3:7100> \
+        --master_addresses <ip1:7100,ip2:7100,ip3:7100> \
         restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 minus 5m
     ```
 
@@ -188,7 +188,7 @@ If a database or a keyspace has an associated snapshot schedule, you can use tha
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <ip1:7100,ip2:7100,ip3:7100> \
+        --master_addresses <ip1:7100,ip2:7100,ip3:7100> \
         restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 minus 1h
     ```
 

--- a/docs/content/v2.20/manage/backup-restore/snapshot-ysql.md
+++ b/docs/content/v2.20/manage/backup-restore/snapshot-ysql.md
@@ -42,7 +42,7 @@ Using distributed snapshots allows you to back up a database and then restore it
 To back up a database, create a snapshot using the [`create_database_snapshot`](../../../admin/yb-admin/#create-database-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> create_database_snapshot ysql.<database_name>
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> create_database_snapshot ysql.<database_name>
 ```
 
 A unique ID for the snapshot is returned, as shown in the following sample output:
@@ -56,7 +56,7 @@ You can then use this ID to check the status of the snapshot, [delete it](#delet
 The `create_database_snapshot` command exits immediately, but the snapshot may take some time to complete. Before using the snapshot, verify its status by executing the [`list_snapshots`](../../../admin/yb-admin/#list-snapshots) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshots
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshots
 ```
 
 All the snapshots in the cluster are listed, along with their statuses. You can find the ID of the new snapshot and make sure it has been completed, as shown in the following  sample output:
@@ -71,7 +71,7 @@ Snapshot UUID                           State       Creation Time
 Snapshots never expire and are retained as long as the cluster exists. If you no longer need a snapshot, you can delete it by executing the [`delete_snapshot`](../../../admin/yb-admin/#delete-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794
 ```
 
 ## Restore a snapshot
@@ -79,7 +79,7 @@ Snapshots never expire and are retained as long as the cluster exists. If you no
 To restore the data backed up in one of the previously created snapshots, run the [`restore_snapshot`](../../../admin/yb-admin/#restore-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> restore_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> restore_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794
 ```
 
 This command rolls back the database to the state which it had when the snapshot was created. The restore happens in-place: it changes the state of the existing database in the same cluster.
@@ -127,7 +127,7 @@ To move a snapshot to external storage, gather all the relevant files from all t
 1. Create the snapshot metadata file by executing the [`export_snapshot`](../../../admin/yb-admin/#export-snapshot) command and providing the ID of the snapshot, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> export_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794 <database_name>.snapshot
+    ./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> export_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794 <database_name>.snapshot
     ```
 
 1. Copy the newly-created YSQL metadata file (`<database_name>_schema.sql`) and the snapshot metadata file (`<database_name>.snapshot`) to the external storage.
@@ -176,7 +176,7 @@ You can restore a snapshot that you have [moved to external storage](#move-a-sna
 1. Fetch the snapshot metadata file from the external storage and apply it by running the [`import_snapshot`](../../../admin/yb-admin/#import-snapshot) command, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> import_snapshot <database_name>.snapshot <database_name>
+    ./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> import_snapshot <database_name>.snapshot <database_name>
     ```
 
     Notice that the following output contains the mapping between the old tablet IDs and the new tablet IDs:

--- a/docs/content/v2.20/manage/backup-restore/snapshots-ycql.md
+++ b/docs/content/v2.20/manage/backup-restore/snapshots-ycql.md
@@ -41,13 +41,13 @@ Using distributed snapshots allows you to back up a database and then restore it
 To back up a keyspace with all its tables and indexes, create a snapshot using the [`create_keyspace_snapshot`](../../../admin/yb-admin/#create-keyspace-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> create_keyspace_snapshot my_keyspace
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> create_keyspace_snapshot my_keyspace
 ```
 
 To back up a single table with its indexes, use the [`create_snapshot`](../../../admin/yb-admin/#create-snapshot) command instead, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot my_keyspace my_table
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot my_keyspace my_table
 ```
 
 When you execute either of the preceding commands, a unique ID for the snapshot is returned, as per the following output:
@@ -61,7 +61,7 @@ You can then use this ID to check the status of the snapshot, [delete it](#delet
 Even though the `create_keyspace_snapshot` and `create_snapshot` commands exit immediately, the snapshot may take some time to complete. Before using the snapshot, verify its status with the [`list_snapshots`](../../../admin/yb-admin/#list-snapshots) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshots
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshots
 ```
 
 The preceding command lists the snapshots in the cluster, along with their states. You can find the ID of the new snapshot and make sure it has been completed, as shown in the following  sample output:
@@ -76,7 +76,7 @@ Snapshot UUID                           State       Creation Time
 Snapshots never expire and are retained as long as the cluster exists. If you no longer need a snapshot, you can delete it with the [`delete_snapshot`](../../../admin/yb-admin/#delete-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef
 ```
 
 ## Restore a snapshot
@@ -84,7 +84,7 @@ Snapshots never expire and are retained as long as the cluster exists. If you no
 To restore the data backed up in one of the previously created snapshots, run the [`restore_snapshot`](../../../admin/yb-admin/#restore-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> restore_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> restore_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef
 ```
 
 This command rolls back the database to the state which it had when the snapshot was created. The restore happens in-place: it changes the state of the existing database in the same cluster.
@@ -102,7 +102,7 @@ To move a snapshot to external storage, gather all the relevant files from all t
 1. Create the snapshot metadata file by running the [`export_snapshot`](../../../admin/yb-admin/#export-snapshot) command and providing the ID of the snapshot:
 
     ```sh
-    ./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> export_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef my_keyspace.snapshot
+    ./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> export_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef my_keyspace.snapshot
     ```
 
 1. Copy the newly created snapshot metadata file (`my_keyspace.snapshot`) to the external storage.
@@ -133,7 +133,7 @@ You can restore a snapshot that you have [moved to external storage](#move-a-sna
 1. Retrieve the snapshot metadata file from the external storage and apply it by running the [`import_snapshot`](../../../admin/yb-admin/#import-snapshot) command, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> import_snapshot my_keyspace.snapshot my_keyspace
+    ./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> import_snapshot my_keyspace.snapshot my_keyspace
     ```
 
     Notice that the following output contains the mapping between the old tablet IDs and the new tablet IDs:

--- a/docs/content/v2.20/manage/change-cluster-config.md
+++ b/docs/content/v2.20/manage/change-cluster-config.md
@@ -101,13 +101,13 @@ The following commands can be run from one of the old master nodes. You can firs
 
 ```sh
 export MASTERS=node1:7100,node2:7100,node3:7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_blacklist ADD node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
+~/master/bin/yb-admin --master_addresses $MASTERS change_blacklist ADD node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
 ```
 
 Verify that the blacklist information looks similar to the following:
 
 ```sh
-~/master/bin/yb-admin -master_addresses $MASTERS get_universe_config
+~/master/bin/yb-admin --master_addresses $MASTERS get_universe_config
 Config:
 version: 5
 server_blacklist {
@@ -131,7 +131,7 @@ server_blacklist {
 Next, wait for the data move to complete. You can check the percentage completion by running the following command:
 
 ```sh
-~/master/bin/yb-admin -master_addresses $MASTERS get_load_move_completion
+~/master/bin/yb-admin --master_addresses $MASTERS get_load_move_completion
 Percent complete = 66.6
 ```
 
@@ -158,19 +158,19 @@ If any error log is reported on the command line from the following steps, check
 
 ```sh
 export MASTERS=node1:7100,node2:7100,node3:7100,node7:7100,node8:7100,node9:7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config ADD_SERVER node7 7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config REMOVE_SERVER node1 7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config ADD_SERVER node8 7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config REMOVE_SERVER node2 7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config ADD_SERVER node9 7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config REMOVE_SERVER node3 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config ADD_SERVER node7 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config REMOVE_SERVER node1 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config ADD_SERVER node8 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config REMOVE_SERVER node2 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config ADD_SERVER node9 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config REMOVE_SERVER node3 7100
 ```
 
 Now ensure that the master leader is one of the new master nodes as follows:
 
 ```sh
 $ export MASTERS=node7:7100,node8:7100,node9:7100
-$ ~/master/bin/yb-admin -master_addresses $MASTERS list_all_masters
+$ ~/master/bin/yb-admin --master_addresses $MASTERS list_all_masters
 ```
 
 ```output
@@ -197,7 +197,7 @@ Updating master addresses is needed in case the yb-tserver server is restarted.
 The old nodes are not part of the universe any more and can be shut down. After the old YB-TServers are terminated, you can cleanup the blacklist from the master configuration using the following command:
 
 ```sh
-~/master/bin/yb-admin -master_addresses $MASTERS change_blacklist REMOVE node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
+~/master/bin/yb-admin --master_addresses $MASTERS change_blacklist REMOVE node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
 ```
 
 {{< note title="Tip" >}}
@@ -207,5 +207,5 @@ Cleaning up the blacklist server will help reuse the older IPs in case they get 
 Ensure there are no `server_blacklist` entries returned by the command:
 
 ```sh
-~/master/bin/yb-admin -master_addresses $MASTERS get_universe_config
+~/master/bin/yb-admin --master_addresses $MASTERS get_universe_config
 ```

--- a/docs/content/v2.20/manage/upgrade-deployment.md
+++ b/docs/content/v2.20/manage/upgrade-deployment.md
@@ -149,7 +149,7 @@ New YugabyteDB features may require changes to the format of data that is sent o
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <master-addresses> \
+        --master_addresses <master-addresses> \
         promote_auto_flags
     ```
 
@@ -189,7 +189,7 @@ Use the [yb-admin](../../admin/yb-admin/) utility to upgrade the YSQL system cat
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     upgrade_ysql
 ```
 
@@ -203,8 +203,8 @@ In certain scenarios, a YSQL upgrade can take longer than 60 seconds, which is t
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
-    -timeout_ms 180000 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --timeout_ms 180000 \
     upgrade_ysql
 ```
 
@@ -293,7 +293,7 @@ During the Monitor phase, do the following:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <master-addresses> \
+        --master_addresses <master-addresses> \
         promote_auto_flags kLocalVolatile
     ```
 
@@ -324,7 +324,7 @@ If you need to roll back an upgrade where volatile AutoFlags were enabled, depen
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <master-addresses> \
+        --master_addresses <master-addresses> \
         rollback_auto_flags <previous_config_version>
     ```
 
@@ -342,7 +342,7 @@ If you need to roll back an upgrade where volatile AutoFlags were enabled, depen
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+        --master_addresses ip1:7100,ip2:7100,ip3:7100 \
         rollback_auto_flags 2
     ```
 

--- a/docs/content/v2.20/reference/configuration/yugabyted.md
+++ b/docs/content/v2.20/reference/configuration/yugabyted.md
@@ -56,7 +56,7 @@ $ ./bin/yugabyted -h
 ```
 
 ```sh
-$ ./bin/yugabyted -help
+$ ./bin/yugabyted --help
 ```
 
 For help with specific yugabyted commands, run 'yugabyted [ command ] -h'. For example, you can print the command-line help for the `yugabyted start` command by running the following:

--- a/docs/content/v2.20/secure/encryption-at-rest.md
+++ b/docs/content/v2.20/secure/encryption-at-rest.md
@@ -34,7 +34,7 @@ You enable encryption as follows:
 2. Copy the key to master nodes. In the following example, assume a 3-node RF=3 cluster with `MASTER_ADDRESSES=ip1:7100,ip2:7100,ip3:7100`. Choose any string `<key_id>` for this key and use yb-admin to copy the key to each of the masters:
 
      ```sh
-     yb-admin -master_addresses $MASTER_ADDRESSES add_universe_key_to_all_masters <key_id> /<path_to_universe_key>
+     yb-admin --master_addresses $MASTER_ADDRESSES add_universe_key_to_all_masters <key_id> /<path_to_universe_key>
    ```
 
    The preceding operation does not perform the key rotation, but rather seeds each master's in-memory state. The key only lives in memory, and the plaintext key is never persisted to the disk.
@@ -42,13 +42,13 @@ You enable encryption as follows:
 3. Enable cluster-wide encryption. Before rotating the key, ensure that the masters know about `<key_id>`:
 
      ```sh
-     yb-admin -master_addresses $MASTER_ADDRESSES all_masters_have_universe_key_in_memory <key_id>
+     yb-admin --master_addresses $MASTER_ADDRESSES all_masters_have_universe_key_in_memory <key_id>
    ```
 
    If the preceding command fails, rerun step 2. Once this succeeds, instruct the cluster to start using the new universe key, as follows:
 
      ```sh
-     yb-admin -master_addresses $MASTER_ADDRESSES rotate_universe_key_in_memory <key_id>
+     yb-admin --master_addresses $MASTER_ADDRESSES rotate_universe_key_in_memory <key_id>
      ```
 
    Because data is encrypted in the background as part of flushes to disk and compactions, only new data is encrypted. Therefore, the call should return quickly.
@@ -56,7 +56,7 @@ You enable encryption as follows:
 4. Verify that encryption has been enabled. To do this, check the encryption status of the cluster by executing the following yb-admin command:
 
      ```sh
-     yb-admin -master_addresses $MASTER_ADDRESSES is_encryption_enabled
+     yb-admin --master_addresses $MASTER_ADDRESSES is_encryption_enabled
    ```
 
    Expect the following output:
@@ -80,7 +80,7 @@ You can rotate the new key as follows:
 2. Copy the new key to master nodes, informing the master nodes about the new key, as follows:
 
      ```sh
-   yb-admin -master_addresses $MASTER_ADDRESSES add_universe_key_to_all_masters
+   yb-admin --master_addresses $MASTER_ADDRESSES add_universe_key_to_all_masters
    <key_id_2> /path_to_universe_key_2
    ```
 
@@ -89,7 +89,7 @@ You can rotate the new key as follows:
 3. Ensure that the masters know about the key, and then perform the rotation, as follows:
 
      ```sh
-   yb-admin -master_addresses $MASTER_ADDRESSES rotate_universe_key_in_memory <key_id_2>
+   yb-admin --master_addresses $MASTER_ADDRESSES rotate_universe_key_in_memory <key_id_2>
    ```
 
    Since this key is only used for new data and can only eventually encrypt older data through compactions, it is best to ensure old keys remain secure.
@@ -97,7 +97,7 @@ You can rotate the new key as follows:
 4. Verify the new key. To do this, check that the new key is encrypting the cluster, as follows:
 
      ```sh
-   yb-admin -master_addresses $MASTER_ADDRESSES is_encryption_enabled
+   yb-admin --master_addresses $MASTER_ADDRESSES is_encryption_enabled
    ```
    
    Expect the following output:
@@ -115,13 +115,13 @@ You can disable cluster-wide encryption as follows:
 1. Disable encryption by executing the following yb-admin command:
 
      ```sh
-   yb-admin -master_addresses $MASTER_ADDRESSES disable_encryption
+   yb-admin --master_addresses $MASTER_ADDRESSES disable_encryption
    ```
 
 2. Verify that the encryption has been disabled by executing the following command:
 
      ```sh
-   yb-admin -master_addresses $MASTER_ADDRESSES is_encryption_enabled
+   yb-admin --master_addresses $MASTER_ADDRESSES is_encryption_enabled
    ```
    
    Expect the following output:

--- a/docs/content/v2.20/secure/tls-encryption/connect-to-cluster.md
+++ b/docs/content/v2.20/secure/tls-encryption/connect-to-cluster.md
@@ -59,7 +59,7 @@ For example, the following command lists the master information for the TLS-enab
 
 ```sh
 export MASTERS=node1:7100,node2:7100,node3:7100
-./bin/yb-admin --master_addresses $MASTERS -certs_dir_name ~/yugabyte-tls-config list_all_masters
+./bin/yb-admin --master_addresses $MASTERS --certs_dir_name ~/yugabyte-tls-config list_all_masters
 ```
 
 You should see the following output format:

--- a/docs/content/v2024.1/admin/yb-admin.md
+++ b/docs/content/v2024.1/admin/yb-admin.md
@@ -21,10 +21,10 @@ To use the `yb-admin` utility from the YugabyteDB home directory, run `./bin/yb-
 
 ```sh
 yb-admin \
-    [ -master_addresses <master-addresses> ]  \
-    [ -init_master_addrs <master-address> ]  \
-    [ -timeout_ms <millisec> ] \
-    [ -certs_dir_name <dir_name> ] \
+    [ --master_addresses <master-addresses> ]  \
+    [ --init_master_addrs <master-address> ]  \
+    [ --timeout_ms <millisec> ] \
+    [ --certs_dir_name <dir_name> ] \
     <command> [ command_flags ]
 ```
 
@@ -73,7 +73,7 @@ Gets the configuration for the universe.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_universe_config
 ```
 
@@ -87,7 +87,7 @@ Changes the configuration of a tablet.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     change_config <tablet_id> \
     [ ADD_SERVER | REMOVE_SERVER ] \
     <peer_uuid> \
@@ -117,7 +117,7 @@ Changes the master configuration.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     change_master_config \
     [ ADD_SERVER|REMOVE_SERVER ] \
     <ip_addr> <port> \
@@ -137,7 +137,7 @@ yb-admin \
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_tablet_servers <tablet_id>
 ```
 
@@ -154,7 +154,7 @@ Use this to find out who the LEADER of a tablet is.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_tablets <keyspace_type>.<keyspace_name> <table> [max_tablets]
 ```
 
@@ -168,7 +168,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     list_tablets ysql.db_name table_name 0
 ```
 
@@ -186,7 +186,7 @@ Lists all tablet servers.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_all_tablet_servers
 ```
 
@@ -200,7 +200,7 @@ Displays a list of all YB-Master servers in a table listing the master UUID, RPC
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_all_masters
 ```
 
@@ -210,7 +210,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses node7:7100,node8:7100,node9:7100 \
+    --master_addresses node7:7100,node8:7100,node9:7100 \
     list_all_masters
 ```
 
@@ -229,7 +229,7 @@ Prints a list of replica types and counts for the specified table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_replica_type_counts <keyspace> <table_name>
 ```
 
@@ -245,7 +245,7 @@ Prints the status of the YB-Master servers.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     dump_masters_state
 ```
 
@@ -259,7 +259,7 @@ List the locations of the tablet server logs.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_tablet_server_log_locations
 ```
 
@@ -273,7 +273,7 @@ Lists all tablets for the specified tablet server (YB-TServer).
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_tablets_for_tablet_server <ts_uuid>
 ```
 
@@ -286,7 +286,7 @@ Splits the specified hash-sharded tablet and computes the split point as the mid
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     split_tablet <tablet_id_to_split>
 ```
 
@@ -314,7 +314,7 @@ Forces the master leader to step down. The specified YB-Master node will take it
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     master_leader_stepdown [ <new_leader_id> ]
 ```
 
@@ -329,7 +329,7 @@ Prints the current YSQL schema catalog version.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     ysql_catalog_version
 ```
 
@@ -339,7 +339,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     ysql_catalog_version
 ```
 
@@ -361,14 +361,14 @@ Prints a list of all tables. Optionally, include the database type, table ID, an
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_tables \
     [ include_db_type ] [ include_table_id ] [ include_table_type ]
 ```
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> list_tables
+    --master_addresses <master-addresses> list_tables
 ```
 
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.
@@ -397,7 +397,7 @@ To display a list of tables and their UUID (`table_id`) values, open the **YB-Ma
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     list_tables
 ```
 
@@ -432,7 +432,7 @@ Triggers manual compaction on a table.
 
 ```sh
 yb-admin \
-    -master_addresses <master_addresses> \
+    --master_addresses <master_addresses> \
     compact_table <db_type>.<namespace> <table> [timeout_in_seconds] [ADD_INDEXES]
 ```
 
@@ -447,7 +447,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     compact_table ysql.yugabyte table_name
 ```
 
@@ -459,7 +459,7 @@ Compacted [yugabyte.table_name] tables.
 
 ```sh
 yb-admin \
-    -master_addresses <master_addresses> \
+    --master_addresses <master_addresses> \
     compact_table tableid.<table_id> [timeout_in_seconds] [ADD_INDEXES]
 ```
 
@@ -472,7 +472,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     compact_table tableid.000033eb000030008000000000004002
 ```
 
@@ -486,7 +486,7 @@ Show the status of full compaction on a table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     compaction_status <db-type>.<namespace> <table> [show_tablets]
 ```
 
@@ -500,7 +500,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     compaction_status ysql.yugabyte table_name show_tablets
 ```
 
@@ -547,7 +547,7 @@ Modifies the placement information (cloud, region, and zone) for a table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     modify_table_placement_info <keyspace> <table_name> <placement_info> <replication_factor> \
     [ <placement_id> ]
 ```
@@ -556,7 +556,7 @@ or alternatively:
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     modify_table_placement_info tableid.<table_id> <placement_info> <replication_factor> \
     [ <placement_id> ]
 ```
@@ -573,7 +573,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     modify_table_placement_info  testdatabase testtable \
     aws.us-west.us-west-2a,aws.us-west.us-west-2b,aws.us-west.us-west-2c 3
 ```
@@ -595,7 +595,7 @@ Creates a transaction status table to be used in a region. This command should a
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_transaction_table \
     <table_name>
 ```
@@ -609,7 +609,7 @@ The transaction status table will be created as `system.<table_name>`.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     create_transaction_table \
     transactions_us_east
 ```
@@ -620,7 +620,7 @@ Next, set the placement on the newly created transactions table:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     modify_table_placement_info system transactions_us_east \
     aws.us-east.us-east-1a,aws.us-east.us-east-1b,aws.us-east.us-east-1c 3
 ```
@@ -641,7 +641,7 @@ Add a tablet to a transaction status table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     add_transaction_tablet \
     <table_id>
 ```
@@ -653,7 +653,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     add_transaction_tablet 000033eb000030008000000000004002
 ```
 
@@ -667,7 +667,7 @@ Flush the memstores of the specified table on all tablet servers to disk.
 
 ```sh
 yb-admin \
-    -master_addresses <master_addresses> \
+    --master_addresses <master_addresses> \
     flush_table <db_type>.<namespace> <table> [timeout_in_seconds] [ADD_INDEXES]
 ```
 
@@ -682,7 +682,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     flush_table ysql.yugabyte table_name
 
 ```
@@ -695,7 +695,7 @@ Flushed [yugabyte.table_name] tables.
 
 ```sh
 yb-admin \
-    -master_addresses <master_addresses> \
+    --master_addresses <master_addresses> \
     flush_table tableid.<table_id> [timeout_in_seconds] [ADD_INDEXES]
 ```
 
@@ -708,7 +708,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     flush_table tableid.000033eb000030008000000000004002
 ```
 
@@ -724,7 +724,7 @@ Backfill all DEFERRED indexes in a YCQL table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     backfill_indexes_for_table <keyspace> <table_name>
 ```
 
@@ -736,7 +736,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     backfill_indexes_for_table ybdemo table_name
 ```
 
@@ -777,7 +777,7 @@ Creates a snapshot of the specified YSQL database.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_database_snapshot <database_name>
 ```
 
@@ -790,7 +790,7 @@ When this command runs, a `snapshot_id` is generated and printed.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     create_database_snapshot
 ```
 
@@ -804,7 +804,7 @@ Creates a snapshot of the specified YCQL keyspace.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_keyspace_snapshot <keyspace_name>
 ```
 
@@ -817,7 +817,7 @@ When this command runs, a `snapshot_id` is generated and printed.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     create_keyspace_snapshot
 ```
 
@@ -831,7 +831,7 @@ Prints a list of all snapshot IDs, restoration IDs, and states. Optionally, prin
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_snapshots \
     [ show_details ] [ not_show_restored ]
 ```
@@ -881,7 +881,7 @@ In this example, the optional `show_details` flag is added to generate the snaps
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     list_snapshots show_details
 ```
 
@@ -917,7 +917,7 @@ Use the [`create_snapshot_schedule`](#create-snapshot-schedule) command to creat
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_snapshot <keyspace> <table_name> | <table_id> \
     [<keyspace> <table_name> | <table_id> ]... \
     [flush_timeout_in_seconds]
@@ -935,7 +935,7 @@ When this command runs, a `snapshot_id` is generated and printed.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     create_snapshot ydb test_tb
 ```
 
@@ -957,7 +957,7 @@ Restores the specified snapshot, including the tables and indexes. When the oper
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     restore_snapshot <snapshot_id> <restore-target>
 ```
 
@@ -1007,7 +1007,7 @@ Returns one or more restorations in JSON format.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_snapshot_restorations <restoration_id>
 ```
 
@@ -1018,7 +1018,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     list_snapshot_restorations 26ed9053-0c26-4277-a2b8-c12d0fa4c8cf
 ```
 
@@ -1042,7 +1042,7 @@ Generates a metadata file for the specified snapshot, listing all the relevant i
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     export_snapshot <snapshot_id> <file_name>
 ```
 
@@ -1054,7 +1054,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     export_snapshot 4963ed18fc1e4f1ba38c8fcf4058b295 \
     test_tb.snapshot
 ```
@@ -1072,7 +1072,7 @@ Imports the specified snapshot metadata file.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     import_snapshot <file_name> \
     [<keyspace> <table_name> [<keyspace> <table_name>]...]
 ```
@@ -1092,7 +1092,7 @@ The *keyspace* and the *table* can be different from the exported one.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     import_snapshot test_tb.snapshot ydb test_tb
 ```
 
@@ -1118,7 +1118,7 @@ Imports only the specified tables from the specified snapshot metadata file.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     import_snapshot_selective <file_name> \
     [<keyspace> <table_name> [<keyspace> <table_name>]...]
 ```
@@ -1138,7 +1138,7 @@ The *keyspace* can be different from the exported one. The name of the table nee
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     import_snapshot_selective test_tb.snapshot ydb test_tb
 ```
 
@@ -1164,7 +1164,7 @@ Deletes the specified snapshot.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     delete_snapshot <snapshot_id>
 ```
 
@@ -1181,7 +1181,7 @@ Returns a schedule ID in JSON format.
 
 ```sh
 yb-admin create_snapshot_schedule \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     <snapshot-interval>\
     <retention-time>\
     <filter-expression>
@@ -1200,7 +1200,7 @@ Take a snapshot of the YSQL database `yugabyte` once per minute, and retain each
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     create_snapshot_schedule 1 10 ysql.yugabyte
 ```
 
@@ -1208,7 +1208,7 @@ The equivalent command for a YCQL keyspace (for example, yugabyte) would be the 
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     create_snapshot_schedule 1 10 yugabyte
 ```
 
@@ -1240,7 +1240,7 @@ Returns one or more schedule lists in JSON format.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_snapshot_schedules <schedule-id>
 ```
 
@@ -1251,7 +1251,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     list_snapshot_schedules 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
 ```
 
@@ -1288,7 +1288,7 @@ Schedules group a set of items into a single tracking object (the *schedule*). W
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     restore_snapshot_schedule <schedule-id> <restore-target>
 ```
 
@@ -1320,7 +1320,7 @@ Restore from an absolute timestamp:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 1617670679185100
 ```
 
@@ -1328,7 +1328,7 @@ Restore from a relative time:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 minus 60s
 ```
 
@@ -1351,7 +1351,7 @@ Returns a JSON object with the `schedule_id` that was just deleted.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     delete_snapshot_schedule <schedule-id>
 ```
 
@@ -1362,7 +1362,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     delete_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
 ```
 
@@ -1388,7 +1388,7 @@ Modifies the placement information (cloud, region, and zone) for a deployment.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     modify_placement_info <placement_info> <replication_factor> \
     [ <placement_id> ]
 ```
@@ -1402,7 +1402,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     modify_placement_info  \
     aws.us-west.us-west-2a:2,aws.us-west.us-west-2b:2,aws.us-west.us-west-2c 5
 ```
@@ -1445,7 +1445,7 @@ Having all tablet leaders reside in a single region reduces the number of networ
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     set_preferred_zones <cloud.region.zone>[:preference] \
     [<cloud.region.zone>[:preference]]...
 ```
@@ -1592,7 +1592,7 @@ Add a read replica cluster to the master configuration.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     add_read_replica_placement_info <placement_info> \
     <replication_factor> \
     [ <placement_id> ]
@@ -1610,7 +1610,7 @@ yb-admin \
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     modify_read_replica_placement_info <placement_info> \
     <replication_factor> \
     [ <placement_id> ]
@@ -1629,7 +1629,7 @@ Delete the read replica.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     delete_read_replica_placement_info
 ```
 
@@ -1651,7 +1651,7 @@ Sets the contents of `key_path` in-memory on each YB-Master node.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     add_universe_key_to_all_masters <key_id> <key_path>
 ```
 
@@ -1670,7 +1670,7 @@ Checks whether the universe key associated with the provided *key_id* exists in-
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> all_masters_have_universe_key_in_memory <key_id>
+    --master_addresses <master-addresses> all_masters_have_universe_key_in_memory <key_id>
 ```
 
 * *key_id*: Universe-unique identifier (can be any string, such as a string of a UUID) that will be associated to the universe key contained in the contents of `key_path` as a byte[].
@@ -1689,7 +1689,7 @@ The [`all_masters_have_universe_key_in_memory`](#all-masters-have-universe-key-i
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> rotate_universe_key_in_memory <key_id>
+    --master_addresses <master-addresses> rotate_universe_key_in_memory <key_id>
 ```
 
 * *key_id*: Universe-unique identifier (can be any string, such as a string of a UUID) that will be associated to the universe key contained in the contents of `key_path` as a byte[].
@@ -1702,7 +1702,7 @@ Disables the in-memory encryption at rest for newly-written data files.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     disable_encryption_in_memory
 ```
 
@@ -1714,7 +1714,7 @@ Checks if cluster-wide encryption is enabled.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     is_encryption_enabled
 ```
 
@@ -1732,7 +1732,7 @@ The new key ID (`<key_id_2>`) should be different from the previous one (`<key_i
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     is_encryption_enabled
 ```
 
@@ -1750,7 +1750,7 @@ Create a change data capture (CDC) DB stream for the specified namespace using t
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_change_data_stream ysql.<namespace_name>
 ```
 
@@ -1761,7 +1761,7 @@ For example:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100 \
+    --master_addresses 127.0.0.1:7100 \
     create_change_data_stream ysql.yugabyte
 ```
 
@@ -1774,7 +1774,7 @@ This feature is {{<tags/feature/tp>}}. Use the [yb_enable_cdc_consistent_snapsho
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_change_data_stream ysql.<namespace_name> EXPLICIT CHANGE USE_SNAPSHOT
 ```
 
@@ -1788,7 +1788,7 @@ For example:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100 \
+    --master_addresses 127.0.0.1:7100 \
     create_change_data_stream ysql.yugabyte EXPLICIT CHANGE USE_SNAPSHOT
 ```
 
@@ -1800,7 +1800,7 @@ To create a change data capture (CDC) DB stream which also supports sending the 
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_change_data_stream ysql.<namespace_name> IMPLICIT ALL
 ```
 
@@ -1823,7 +1823,7 @@ To create a change data capture (CDC) DB stream which works in the EXPLICIT chec
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_change_data_stream ysql.<namespace_name> EXPLICIT
 ```
 
@@ -1845,7 +1845,7 @@ Lists all the created CDC DB streams.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_change_data_streams [namespace_name]
 ```
 
@@ -1856,7 +1856,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100 \
+    --master_addresses 127.0.0.1:7100 \
     list_change_data_streams
 ```
 
@@ -1902,7 +1902,7 @@ Get the information associated with a particular CDC DB stream.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_change_data_stream_info <db_stream_id>
 ```
 
@@ -1913,7 +1913,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100 \
+    --master_addresses 127.0.0.1:7100 \
     get_change_data_stream_info d540f5e4890c4d3b812933cbfd703ed3
 ```
 
@@ -1936,7 +1936,7 @@ Delete the specified CDC DB stream.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     delete_change_data_stream <db_stream_id>
 ```
 
@@ -1947,7 +1947,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100 \
+    --master_addresses 127.0.0.1:7100 \
     delete_change_data_stream d540f5e4890c4d3b812933cbfd703ed3
 ```
 
@@ -1969,7 +1969,7 @@ To verify if any tables are already configured for replication, use [list_cdc_st
 
 ```sh
 yb-admin \
-    -master_addresses <target_master_addresses> \
+    --master_addresses <target_master_addresses> \
     setup_universe_replication \
     <source_universe_uuid>_<replication_name> \
     <source_master_addresses> \
@@ -2000,7 +2000,7 @@ To display a list of tables and their UUID (`table_id`) values, open the **YB-Ma
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     setup_universe_replication e260b8b6-e89f-4505-bb8e-b31f74aa29f3_xClusterSetup1 \
     127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     000030a5000030008000000000004000,000030a5000030008000000000004005,dfef757c415c4b2cacc9315b8acb539a
@@ -2022,7 +2022,7 @@ To check if any tables are configured for replication, use [list_cdc_streams](#l
 Use the `set_master_addresses` subcommand to replace the source master address list. Use this if the set of masters on the source changes:
 
 ```sh
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
     alter_universe_replication <source-universe-uuid>_<replication-name> \
     set_master_addresses <source-master-addresses>
 ```
@@ -2035,7 +2035,7 @@ yb-admin -master_addresses <target-master-addresses> \
 Use the `add_table` subcommand to add one or more tables to the existing list:
 
 ```sh
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
     alter_universe_replication <source-universe-uuid>_<replication-name> \
     add_table [ <source-table-ids> ] \
     [ <source-bootstrap-ids> ]
@@ -2054,7 +2054,7 @@ Enter the source universe bootstrap IDs in the same order as their corresponding
 Use the `remove_table` subcommand to remove one or more tables from the existing list:
 
 ```sh
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
     alter_universe_replication <source-universe-uuid>_<replication-name> \
     remove_table <source-table-ids> [ignore-errors]
 ```
@@ -2068,7 +2068,7 @@ yb-admin -master_addresses <target-master-addresses> \
 Use the `rename_id` subcommand to rename xCluster replication streams.
 
 ```sh
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
     alter_universe_replication <source-universe-uuid>_<replication-name> \
     rename_id <source-universe-uuid>_<new-replication-name>
 ```
@@ -2086,7 +2086,7 @@ Deletes universe replication for the specified source universe.
 
 ```sh
 yb-admin \
-    -master_addresses <target_master_addresses> \
+    --master_addresses <target_master_addresses> \
     delete_universe_replication <source_universe_uuid>_<replication_name>
 ```
 
@@ -2102,7 +2102,7 @@ Sets the universe replication to be enabled or disabled.
 
 ```sh
 yb-admin \
-    -master_addresses <target_master_addresses> \
+    --master_addresses <target_master_addresses> \
     set_universe_replication_enabled <source_universe_uuid>_<replication_name>
 ```
 
@@ -2119,7 +2119,7 @@ Sets the xCluster role to `STANDBY` or `ACTIVE`.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     change_xcluster_role \
     <role>
 ```
@@ -2131,7 +2131,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     change_xcluster_role STANDBY
 ```
 
@@ -2143,7 +2143,7 @@ Reports the current xCluster safe time for each namespace, which is the time at 
 
 ```sh
 yb-admin \
-    -master_addresses <target_master_addresses> \
+    --master_addresses <target_master_addresses> \
     get_xcluster_safe_time \
     [include_lag_and_skew]
 ```
@@ -2155,7 +2155,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     get_xcluster_safe_time
 ```
 
@@ -2185,7 +2185,7 @@ Verify when the producer and consumer are in sync for a given list of `stream_id
 
 ```sh
 yb-admin \
-    -master_addresses <source_master_addresses> \
+    --master_addresses <source_master_addresses> \
     wait_for_replication_drain \
     <comma_separated_list_of_stream_ids> [<timestamp> | minus <interval>]
 ```
@@ -2199,7 +2199,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+    --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     wait_for_replication_drain 000033f1000030008000000000000000,200033f1000030008000000000000002 minus 1m
 ```
 
@@ -2230,7 +2230,7 @@ Use this command when setting up universe replication to verify if any tables ar
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_cdc_streams
 ```
 
@@ -2240,7 +2240,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     list_cdc_streams
 ```
 
@@ -2252,7 +2252,7 @@ Deletes underlying CDC stream for the specified YB-Master servers.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     delete_cdc_stream <stream_id [force_delete]>
 ```
 
@@ -2272,7 +2272,7 @@ Mark a set of tables in preparation for setting up universe level replication.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     bootstrap_cdc_producer <comma_separated_list_of_table_ids>
 ```
 
@@ -2283,7 +2283,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 172.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 172.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     bootstrap_cdc_producer 000030ad000030008000000000004000
 ```
 
@@ -2303,7 +2303,7 @@ Returns the replication status of all consumer streams. If *source_universe_uuid
 
 ```sh
 yb-admin \
-    -master_addresses <target-master-addresses> \
+    --master_addresses <target-master-addresses> \
     get_replication_status [ <source_universe_uuid>_<replication_name> ]
 ```
 
@@ -2314,7 +2314,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 172.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 172.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     get_replication_status e260b8b6-e89f-4505-bb8e-b31f74aa29f3
 ```
 
@@ -2341,7 +2341,7 @@ Gets the tablet load move completion percentage for blacklisted nodes.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_leader_blacklist_completion
 ```
 
@@ -2351,7 +2351,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     get_leader_blacklist_completion
 ```
 
@@ -2365,7 +2365,7 @@ After old YB-TServer servers are terminated, you can use this command to clean u
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     change_blacklist [ ADD | REMOVE ] <ip_addr>:<port> \
     [ <ip_addr>:<port> ]...
 ```
@@ -2378,7 +2378,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     change_blacklist \
       ADD node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
 ```
@@ -2389,7 +2389,7 @@ yb-admin \
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     change_leader_blacklist [ ADD | REMOVE ] <ip_addr>:<port> \
     [ <ip_addr>:<port> ]...
 ```
@@ -2402,7 +2402,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     change_leader_blacklist \
       ADD node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
 ```
@@ -2423,7 +2423,7 @@ There is a possibility of downtime.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     leader_stepdown <tablet_id> <dest_ts_uuid>
 ```
 
@@ -2453,7 +2453,7 @@ Enables or disables the load balancer.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     set_load_balancer_enabled [ 0 | 1 ]
 ```
 
@@ -2464,7 +2464,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     set_load_balancer_enabled 0
 ```
 
@@ -2476,7 +2476,7 @@ Returns the cluster load balancer state.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> get_load_balancer_state
+    --master_addresses <master-addresses> get_load_balancer_state
 ```
 
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.
@@ -2491,7 +2491,7 @@ You can rerun this command periodically until the value reaches `100.0`, indicat
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_load_move_completion
 ```
 
@@ -2516,7 +2516,7 @@ In the following example, the data move is `66.6` percent done.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     get_load_move_completion
 ```
 
@@ -2534,7 +2534,7 @@ Finds out if the load balancer is idle.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_is_load_balancer_idle
 ```
 
@@ -2544,7 +2544,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     get_is_load_balancer_idle
 ```
 
@@ -2564,14 +2564,14 @@ Returns the current AutoFlags configuration of the universe.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_auto_flags_config
 ```
 
 **Example**
 
 ```sh
-./bin/yb-admin -master_addresses ip1:7100,ip2:7100,ip3:7100 get_auto_flags_config
+./bin/yb-admin --master_addresses ip1:7100,ip2:7100,ip3:7100 get_auto_flags_config
 ```
 
 If the operation is successful you should see output similar to the following:
@@ -2617,7 +2617,7 @@ Note that `promote_auto_flags` is a cluster-level operation; you don't need to r
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     promote_auto_flags \
     [<max_flags_class> [<promote_non_runtime_flags> [force]]]
 ```
@@ -2631,7 +2631,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     promote_auto_flags kLocalPersisted
 ```
 
@@ -2659,7 +2659,7 @@ YSQL upgrades are not required for clusters where [YSQL is not enabled](../../re
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     upgrade_ysql
 ```
 
@@ -2667,7 +2667,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     upgrade_ysql
 ```
 
@@ -2681,8 +2681,8 @@ In certain scenarios, a YSQL upgrade can take longer than 60 seconds, which is t
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
-    -timeout_ms 180000 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --timeout_ms 180000 \
     upgrade_ysql
 ```
 

--- a/docs/content/v2024.1/api/ycql/ddl_create_index.md
+++ b/docs/content/v2024.1/api/ycql/ddl_create_index.md
@@ -183,7 +183,7 @@ After creating a set of indexes with their backfill deferred, you can then trigg
    Launch a backfill job for backfilling all the deferred indexes using the `backfill_indexes_for_table` command as follows:
 
     ```bash
-    bin/yb-admin -master_addresses <ip:port> backfill_indexes_for_table ycql.ybdemo table_name
+    bin/yb-admin --master_addresses <ip:port> backfill_indexes_for_table ycql.ybdemo table_name
     ```
 - Use the [`--defer_index_backfill`](../../../reference/configuration/yb-master#defer-index-backfill) YB-Master flag to force all indexes to be DEFERRED, and run `yb-admin backfill_indexes_for_table` to backfill indexes.
 

--- a/docs/content/v2024.1/api/ysql/exprs/geo_partitioning_helper_functions/func_yb_is_local_table.md
+++ b/docs/content/v2024.1/api/ysql/exprs/geo_partitioning_helper_functions/func_yb_is_local_table.md
@@ -55,7 +55,7 @@ This function is helpful while implementing [Row-level geo-partitioning](../../.
 1. Use [yb-admin](../../../../../admin/yb-admin/) to specify the placement configuration to be used by the cluster as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses <IP1>:7100 modify_placement_info aws.us-west-1.us-west-1c:1,aws.us-east-1.us-east-1a:1,aws.us-east-2.us-east-2c:1 3
+    ./bin/yb-admin --master_addresses <IP1>:7100 modify_placement_info aws.us-west-1.us-west-1c:1,aws.us-east-1.us-east-1a:1,aws.us-east-2.us-east-2c:1 3
     ```
 
 1. Create tablespaces corresponding to the regions used by the cluster created above [using ysqlsh](../../../../../api/ysqlsh/#using-ysqlsh) as follows:

--- a/docs/content/v2024.1/api/ysql/exprs/geo_partitioning_helper_functions/func_yb_server_region.md
+++ b/docs/content/v2024.1/api/ysql/exprs/geo_partitioning_helper_functions/func_yb_server_region.md
@@ -63,7 +63,7 @@ Do the following to create a 3-node multi-region cluster and a geo-partitioned t
 1. Use [yb-admin](../../../../../admin/yb-admin/) to specify the placement configuration to be used by the cluster:
 
     ```sh
-    ./bin/yb-admin -master_addresses <IP1>:7100 modify_placement_info aws.us-west-1.us-west-1c:1,aws.us-east-1.us-east-1a:1,aws.us-east-2.us-east-2c:1 3
+    ./bin/yb-admin --master_addresses <IP1>:7100 modify_placement_info aws.us-west-1.us-west-1c:1,aws.us-east-1.us-east-1a:1,aws.us-east-2.us-east-2c:1 3
     ```
 
 1. Create tablespaces corresponding to the regions used by the cluster created above [using ysqlsh](../../../../../api/ysqlsh/#using-ysqlsh):

--- a/docs/content/v2024.1/deploy/multi-dc/async-replication/async-deployment.md
+++ b/docs/content/v2024.1/deploy/multi-dc/async-replication/async-deployment.md
@@ -35,20 +35,20 @@ After you created the required tables, you can set up unidirectional replication
   - To find a table ID, execute the following command as an admin user:
 
       ```sh
-      ./bin/yb-admin -master_addresses <source_universe_master_addresses> list_tables include_table_id
+      ./bin/yb-admin --master_addresses <source_universe_master_addresses> list_tables include_table_id
       ```
 
       The preceding command lists all the tables, including system tables. To locate a specific table, you can add grep as follows:
 
       ```sh
-      ./bin/yb-admin -master_addresses <source_universe_master_addresses> list_tables include_table_id | grep table_name
+      ./bin/yb-admin --master_addresses <source_universe_master_addresses> list_tables include_table_id | grep table_name
       ```
 
 - Run the following `yb-admin` [`setup_universe_replication`](../../../../admin/yb-admin/#setup-universe-replication) command from the YugabyteDB home directory in the source universe:
 
     ```sh
     ./bin/yb-admin \
-      -master_addresses <target_universe_master_addresses> \
+      --master_addresses <target_universe_master_addresses> \
       setup_universe_replication <source_universe_UUID>_<replication_stream_name> \
         <source_universe_master_addresses> \
         <table_id>,[<table_id>..]
@@ -58,7 +58,7 @@ After you created the required tables, you can set up unidirectional replication
 
     ```sh
     ./bin/yb-admin \
-      -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+      --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
       setup_universe_replication e260b8b6-e89f-4505-bb8e-b31f74aa29f3_xClusterSetup1 \
         127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         000030a5000030008000000000004000,000030a5000030008000000000004005,dfef757c415c4b2cacc9315b8acb539a
@@ -134,7 +134,7 @@ You can use `yb-admin` to return the current replication status. The `get_replic
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7000,127.0.0.2:7000,127.0.0.3:7000 \
+    --master_addresses 127.0.0.1:7000,127.0.0.2:7000,127.0.0.3:7000 \
     get_replication_status
 ```
 
@@ -158,8 +158,8 @@ If both universes use the same certificates, run `yb-admin setup_universe_replic
 Consider the following example:
 
 ```sh
-./bin/yb-admin -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
-  -certs_dir_name /home/yugabyte/yugabyte-tls-config \
+./bin/yb-admin --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+  --certs_dir_name /home/yugabyte/yugabyte-tls-config \
   setup_universe_replication e260b8b6-e89f-4505-bb8e-b31f74aa29f3_xClusterSetup1 \
   127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
   000030a5000030008000000000004000,000030a5000030008000000000004005,dfef757c415c4b2cacc9315b8acb539a
@@ -182,8 +182,8 @@ When universes use different certificates, you need to store the certificates fo
     For example, if you have the target universe's certificates in `/home/yugabyte/yugabyte-tls-config`, then you would run the following:
 
     ```sh
-    ./bin/yb-admin -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
-      -certs_dir_name /home/yugabyte/yugabyte-tls-config \
+    ./bin/yb-admin --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+      --certs_dir_name /home/yugabyte/yugabyte-tls-config \
       setup_universe_replication 00000000-1111-2222-3333-444444444444_xClusterSetup1 \
       127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
       000030a5000030008000000000004000,000030a5000030008000000000004005,dfef757c415c4b2cacc9315b8acb539a
@@ -261,7 +261,7 @@ To create unidirectional replication, perform the following:
 1. Run the replication setup command for the source universe, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses <target_master_addresses> \
+    ./bin/yb-admin --master_addresses <target_master_addresses> \
     setup_universe_replication <source_universe_UUID>_<replication_stream_name> \
     <source_master_addresses> <comma_separated_table_ids>
     ```
@@ -269,7 +269,7 @@ To create unidirectional replication, perform the following:
     Consider the following example:
 
     ```sh
-    ./bin/yb-admin -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    ./bin/yb-admin --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     setup_universe_replication 00000000-1111-2222-3333-444444444444_xClusterSetup1 \
     127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     000033e1000030008000000000004007,000033e100003000800000000000400d,000033e1000030008000000000004013
@@ -322,7 +322,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
 
   ```sh
   kubectl exec -it -n <source_universe_namespace> -t <source_universe_master_leader> -c \
-    <source_universe_container> -- bash -c "/home/yugabyte/bin/yb-admin -master_addresses \
+    <source_universe_container> -- bash -c "/home/yugabyte/bin/yb-admin --master_addresses \
     <target_universe_master_addresses> setup_universe_replication \
     <source_universe_UUID>_<replication_stream_name> <source_universe_master_addresses> \
     <comma_separated_table_ids>"
@@ -332,7 +332,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
 
   ```sh
   kubectl exec -it -n xcluster-source -t yb-master-2 -c yb-master -- bash -c \
-    "/home/yugabyte/bin/yb-admin -master_addresses yb-master-2.yb-masters.xcluster-target.svc.cluster.local, \
+    "/home/yugabyte/bin/yb-admin --master_addresses yb-master-2.yb-masters.xcluster-target.svc.cluster.local, \
     yb-master-1.yb-masters.xcluster-target.svc.cluster.local,yb-master-0.yb-masters.xcluster-target.svc.cluster.local \
     setup_universe_replication ac39666d-c183-45d3-945a-475452deac9f_xCluster_1 \
     yb-master-2.yb-masters.xcluster-source.svc.cluster.local,yb-master-1.yb-masters.xcluster-source.svc.cluster.local, \
@@ -387,14 +387,14 @@ Proceed as follows:
 1. Create a checkpoint on the source universe for all the tables you want to replicate by executing the following command:
 
     ```sh
-    ./bin/yb-admin -master_addresses <source_universe_master_addresses> \
+    ./bin/yb-admin --master_addresses <source_universe_master_addresses> \
     bootstrap_cdc_producer <comma_separated_source_universe_table_ids>
     ```
 
     Consider the following example:
 
     ```sh
-    ./bin/yb-admin -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+    ./bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     bootstrap_cdc_producer 000033e1000030008000000000004000,000033e1000030008000000000004003,000033e1000030008000000000004006
     ```
 
@@ -410,7 +410,7 @@ Proceed as follows:
 1. Execute the following command to set up the replication stream using the bootstrap IDs generated in step 1. Ensure that the bootstrap IDs are in the same order as their corresponding table IDs.
 
     ```sh
-    ./bin/yb-admin -master_addresses <target_universe_master_addresses> setup_universe_replication \
+    ./bin/yb-admin --master_addresses <target_universe_master_addresses> setup_universe_replication \
       <source_universe_uuid>_<replication_stream_name> <source_universe_master_addresses> \
       <comma_separated_source_universe_table_ids> <comma_separated_bootstrap_ids>
     ```
@@ -418,7 +418,7 @@ Proceed as follows:
     Consider the following example:
 
     ```sh
-    ./bin/yb-admin -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 setup_universe_replication \
+    ./bin/yb-admin --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 setup_universe_replication \
       00000000-1111-2222-3333-444444444444_xCluster1 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
       000033e1000030008000000000004000,000033e1000030008000000000004003,000033e1000030008000000000004006 \
       fb156717174941008e54fa958e613c10,a2a46f5cbf8446a3a5099b5ceeaac28b,c967967523eb4e03bcc201bb464e0679
@@ -470,8 +470,8 @@ When new tables (or partitions) are created, to ensure that all changes from the
 1. Get table IDs of the new partition from the source as follows:
 
     ```sql
-    yb-admin -master_addresses <source_master_ips> \
-    -certs_dir_name <cert_dir> \
+    yb-admin --master_addresses <source_master_ips> \
+    --certs_dir_name <cert_dir> \
     list_tables include_table_id|grep 'order_changes_2023_01'
     ```
 
@@ -484,8 +484,8 @@ When new tables (or partitions) are created, to ensure that all changes from the
 1. Add the new table (or partition) to replication.
 
    ```sql
-   yb-admin -master_addresses <target_master_ips> \
-   -certs_dir_name <cert_dir> \
+   yb-admin --master_addresses <target_master_ips> \
+   --certs_dir_name <cert_dir> \
    alter_universe_replication <replication_group_name> \
    add_table  000033e800003000800000000000410b
    ```
@@ -508,8 +508,8 @@ However, to add a new index to a table that already has data, the following addi
 
    ```sql
    yb-admin
-   -master_addresses <source_master_ips> \
-   -certs_dir_name <cert_dir> \
+   --master_addresses <source_master_ips> \
+   --certs_dir_name <cert_dir> \
    list_tables include_table_id|grep 'my_new_index'
    ```
 
@@ -523,8 +523,8 @@ However, to add a new index to a table that already has data, the following addi
 
    ```sql
    yb-admin
-   -master_addresses <source_master_ips> \
-   -certs_dir_name <cert_dir> \
+   --master_addresses <source_master_ips> \
+   --certs_dir_name <cert_dir> \
    bootstrap_cdc_producer 000033e8000030008000000000004028
    ```
 
@@ -541,8 +541,8 @@ However, to add a new index to a table that already has data, the following addi
 
     ```sql
     yb-admin
-    -master_addresses <target_master_ips> \
-    -certs_dir_name <cert_dir> \
+    --master_addresses <target_master_ips> \
+    --certs_dir_name <cert_dir> \
     alter_universe_replication 59e58153-eec6-4cb5-a858-bf685df52316_east-west \
     add_table  000033e8000030008000000000004028 c8cba563e39c43feb66689514488591c
     ```
@@ -566,16 +566,16 @@ Objects (tables, indexes, partitions) need to be removed from replication before
 1. Get the table ID for the object to be removed from the source.
 
     ```sql
-    yb-admin -master_addresses <source_master_ips> \
-    -certs_dir_name <cert_dir> \
+    yb-admin --master_addresses <source_master_ips> \
+    --certs_dir_name <cert_dir> \
     list_tables include_table_id |grep '<partition_name>'
     ```
 
 1. Remove the table from replication on the target.
 
     ```sql
-    yb-admin -master_addresses <target_master_ips> \
-    -certs_dir_name <cert_dir> \
+    yb-admin --master_addresses <target_master_ips> \
+    --certs_dir_name <cert_dir> \
     alter_universe_replication <replication_group_name> \
     remove_table  000033e800003000800000000000410b
     ```
@@ -588,8 +588,8 @@ Alters involving adding/removing columns or modifying data types require replica
 
     ```sql
     yb-admin
-    -master_addresses <target_master_ips>
-    -certs_dir_name <cert_dir> \
+    --master_addresses <target_master_ips>
+    --certs_dir_name <cert_dir> \
     set_universe_replication_enabled <replication_group_name> 0
     ```
 
@@ -604,8 +604,8 @@ Alters involving adding/removing columns or modifying data types require replica
 
     ```sql
     yb-admin
-    -master_addresses <target_master_ips>
-    -certs_dir_name <cert_dir> \
+    --master_addresses <target_master_ips>
+    --certs_dir_name <cert_dir> \
     set_universe_replication_enabled <replication_group_name> 0
     ```
 

--- a/docs/content/v2024.1/deploy/multi-dc/async-replication/async-transactional-failover.md
+++ b/docs/content/v2024.1/deploy/multi-dc/async-replication/async-transactional-failover.md
@@ -30,8 +30,8 @@ If the Primary (A) is terminated for some reason, do the following:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
-        -certs_dir_name <cert_dir> \
+        --master_addresses <standby_master_addresses> \
+        --certs_dir_name <cert_dir> \
         set_universe_replication_enabled <replication_name> 0
     ```
 
@@ -45,8 +45,8 @@ If the Primary (A) is terminated for some reason, do the following:
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses <standby_master_addresses> \
-    -certs_dir_name <cert_dir> \
+    --master_addresses <standby_master_addresses> \
+    --certs_dir_name <cert_dir> \
     get_xcluster_safe_time include_lag_and_skew
     ```
 
@@ -104,8 +104,8 @@ To do a PITR on a database:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
-        -certs_dir_name <cert_dir> \
+        --master_addresses <standby_master_addresses> \
+        --certs_dir_name <cert_dir> \
         list_snapshot_schedules
     ```
 
@@ -136,8 +136,8 @@ To do a PITR on a database:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
-        -certs_dir_name <cert_dir> \
+        --master_addresses <standby_master_addresses> \
+        --certs_dir_name <cert_dir> \
         restore_snapshot_schedule <schedule_id> "<safe_time>"
     ```
 
@@ -154,8 +154,8 @@ To do a PITR on a database:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
-        -certs_dir_name <cert_dir> \
+        --master_addresses <standby_master_addresses> \
+        --certs_dir_name <cert_dir> \
         list_snapshot_restorations
     ```
 
@@ -176,8 +176,8 @@ To do a PITR on a database:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
-        -certs_dir_name <cert_dir> \
+        --master_addresses <standby_master_addresses> \
+        --certs_dir_name <cert_dir> \
         change_xcluster_role ACTIVE
     ```
 
@@ -189,7 +189,7 @@ To do a PITR on a database:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
+        --master_addresses <standby_master_addresses> \
         delete_universe_replication <primary_universe_uuid>_<replication_name>
     ```
 
@@ -223,8 +223,8 @@ To do a PITR on a database:
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses <standby_master_addresses> \
-    -certs_dir_name <cert_dir> \
+    --master_addresses <standby_master_addresses> \
+    --certs_dir_name <cert_dir> \
     change_xcluster_role ACTIVE
     ```
 
@@ -288,7 +288,7 @@ Do the following:
     - List the snapshot schedules to obtain the schedule ID:
 
         ```sh
-        ./bin/yb-admin -master_addresses <A_master_addresses> \
+        ./bin/yb-admin --master_addresses <A_master_addresses> \
         list_snapshot_schedules
         ```
 
@@ -296,7 +296,7 @@ Do the following:
 
         ```sh
         ./bin/yb-admin \
-            -master_addresses <A_master_addresses> \
+            --master_addresses <A_master_addresses> \
             delete_snapshot_schedule <schedule_id>
         ```
 
@@ -314,8 +314,8 @@ Do the following:
 
         ```sh
         ./bin/yb-admin \
-        -master_addresses <A_master_ips> \
-        -certs_dir_name <dir_name> \
+        --master_addresses <A_master_ips> \
+        --certs_dir_name <dir_name> \
         list_cdc_streams
         ```
 
@@ -323,8 +323,8 @@ Do the following:
 
         ```sh
         ./bin/yb-admin \
-        -master_addresses <A_master_ips> \
-        -certs_dir_name <dir_name> \
+        --master_addresses <A_master_ips> \
+        --certs_dir_name <dir_name> \
         delete_cdc_stream <streamID>
         ```
 
@@ -358,8 +358,8 @@ Do the following:
 
         ```sh
         ./bin/yb-admin \
-        -master_addresses <A_master_ips> \
-        -certs_dir_name <dir_name> \
+        --master_addresses <A_master_ips> \
+        --certs_dir_name <dir_name> \
         list_cdc_streams
         ```
 
@@ -367,8 +367,8 @@ Do the following:
 
         ```sh
         ./bin/yb-admin \
-        -master_addresses <A_master_ips> \
-        -certs_dir_name <dir_name> \
+        --master_addresses <A_master_ips> \
+        --certs_dir_name <dir_name> \
         delete_cdc_stream <streamID>
         ```
 

--- a/docs/content/v2024.1/deploy/multi-dc/async-replication/async-transactional-setup-dblevel.md
+++ b/docs/content/v2024.1/deploy/multi-dc/async-replication/async-transactional-setup-dblevel.md
@@ -49,7 +49,7 @@ To set up unidirectional transactional replication, do the following:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
+        --master_addresses <standby_master_addresses> \
         create_snapshot_schedule 1 10 ysql.yugabyte
     ```
 
@@ -57,7 +57,7 @@ To set up unidirectional transactional replication, do the following:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <primary_master_addresses> \
+        --master_addresses <primary_master_addresses> \
         create_xcluster_checkpoint <replication_group_id> <comma_separated_namespace_names>
     ```
 
@@ -77,7 +77,7 @@ To set up unidirectional transactional replication, do the following:
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+    --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     is_xcluster_bootstrap_required repl_group1 yugabyte
     ```
 
@@ -95,7 +95,7 @@ To set up unidirectional transactional replication, do the following:
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses <primary_master_addresses> \
+    --master_addresses <primary_master_addresses> \
     setup_xcluster_replication <replication_group_id> <standby_master_addresses>
     ```
 
@@ -147,7 +147,7 @@ To add a database to replication, do the following:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
+        --master_addresses <standby_master_addresses> \
         create_snapshot_schedule 1 10 ysql.yugabyte
     ```
 
@@ -155,7 +155,7 @@ To add a database to replication, do the following:
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses <primary_master_addresses> \
+    --master_addresses <primary_master_addresses> \
     add_namespace_to_xcluster_checkpoint <replication_group_id> <namespace_name>
     ```
 
@@ -174,7 +174,7 @@ To add a database to replication, do the following:
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses <primary_master_addresses> \
+    --master_addresses <primary_master_addresses> \
     add_namespace_to_xcluster_replication <replication_group_id> <namespace_name> <standby_master_addresses>
     ```
 

--- a/docs/content/v2024.1/deploy/multi-dc/async-replication/async-transactional-setup.md
+++ b/docs/content/v2024.1/deploy/multi-dc/async-replication/async-transactional-setup.md
@@ -104,7 +104,7 @@ To set up unidirectional transactional replication manually, do the following:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
+        --master_addresses <standby_master_addresses> \
         create_snapshot_schedule 1 10 ysql.yugabyte
     ```
 
@@ -114,8 +114,8 @@ To set up unidirectional transactional replication manually, do the following:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
-        -certs_dir_name <cert_dir> \
+        --master_addresses <standby_master_addresses> \
+        --certs_dir_name <cert_dir> \
         setup_universe_replication \
         <primary_universe_uuid>_<replication_name> \
         <primary_universe_master_addresses> \
@@ -127,8 +127,8 @@ To set up unidirectional transactional replication manually, do the following:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
-        -certs_dir_name <dir_name> \
+        --master_addresses <standby_master_addresses> \
+        --certs_dir_name <dir_name> \
         change_xcluster_role STANDBY
     ```
 
@@ -235,7 +235,7 @@ get_xcluster_safe_time
 For example:
 
 ```sh
-./tserver/bin/yb-admin -master_addresses 172.150.21.61:7100,172.150.44.121:7100,172.151.23.23:7100 \
+./tserver/bin/yb-admin --master_addresses 172.150.21.61:7100,172.150.44.121:7100,172.151.23.23:7100 \
     get_xcluster_safe_time
 ```
 

--- a/docs/content/v2024.1/deploy/multi-dc/async-replication/async-transactional-switchover.md
+++ b/docs/content/v2024.1/deploy/multi-dc/async-replication/async-transactional-switchover.md
@@ -32,8 +32,8 @@ Proceed as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <A_master_addresses> \
-        -certs_dir_name <dir_name>  \
+        --master_addresses <A_master_addresses> \
+        --certs_dir_name <dir_name>  \
         list_cdc_streams
     ```
 
@@ -86,8 +86,8 @@ Proceed as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <A_master_addresses> \
-        -certs_dir_name <dir_name> \
+        --master_addresses <A_master_addresses> \
+        --certs_dir_name <dir_name> \
         wait_for_replication_drain 56bf794172da49c6804cbab59b978c7e,..,..<comma_separated_list_of_stream_ids> 1665548814177072
     ```
 
@@ -114,8 +114,8 @@ Proceed as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <B_master_addresses> \
-        -certs_dir_name <dir_name> \
+        --master_addresses <B_master_addresses> \
+        --certs_dir_name <dir_name> \
         change_xcluster_role ACTIVE
     ```
 
@@ -123,7 +123,7 @@ Proceed as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <B_master_addresses> \
+        --master_addresses <B_master_addresses> \
         delete_universe_replication <A_universe_uuid>_<replication_name>
     ```
 
@@ -135,8 +135,8 @@ In the second stage, set up replication from the new Primary (B) universe as fol
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <B_master_addresses>
-        -certs_dir_name <cert_dir> \
+        --master_addresses <B_master_addresses>
+        --certs_dir_name <cert_dir> \
         bootstrap_cdc_producer <comma_separated_B_table_ids>
     ```
 
@@ -162,8 +162,8 @@ In the second stage, set up replication from the new Primary (B) universe as fol
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <A_master_addresses> \
-        -certs_dir_name <cert_dir> \
+        --master_addresses <A_master_addresses> \
+        --certs_dir_name <cert_dir> \
         setup_universe_replication \
         <B_universe_uuid>_<replication_name> \
         <B_master_addresses> \
@@ -175,8 +175,8 @@ In the second stage, set up replication from the new Primary (B) universe as fol
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <A_master-addresses> \
-        -certs_dir_name <dir_name> \
+        --master_addresses <A_master-addresses> \
+        --certs_dir_name <dir_name> \
         change_xcluster_role STANDBY
     ```
 

--- a/docs/content/v2024.1/deploy/multi-dc/read-replica-clusters.md
+++ b/docs/content/v2024.1/deploy/multi-dc/read-replica-clusters.md
@@ -27,7 +27,7 @@ You can deploy a read replica cluster that asynchronously replicates data with a
 1. Define the primary cluster placement using the [`yb-admin modify_placement_info`](../../../admin/yb-admin/#modify-placement-info) command, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses ip1:7100,ip2:7100,ip3:7100 modify_placement_info <placement_info> <replication_factor> [placement_uuid]
+    ./bin/yb-admin --master_addresses ip1:7100,ip2:7100,ip3:7100 modify_placement_info <placement_info> <replication_factor> [placement_uuid]
     ```
 
     - *placement_info*: Comma-separated list of availability zones using the format `<cloud1.region1.zone1>,<cloud2.region2.zone2>, ...`
@@ -37,7 +37,7 @@ You can deploy a read replica cluster that asynchronously replicates data with a
 1. Define the read replica placement using the [`yb-admin add_read_replica_placement_info`](../../../admin/yb-admin/#add-read-replica-placement-info) command, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses ip1:7100,ip2:7100,ip3:7100 add_read_replica_placement_info <placement_info> <replication_factor> [placement_uuid]
+    ./bin/yb-admin --master_addresses ip1:7100,ip2:7100,ip3:7100 add_read_replica_placement_info <placement_info> <replication_factor> [placement_uuid]
     ```
 
     - *placement_info*: Comma-separated list of availability zones, using the format `<cloud1.region1.zone1>:<num_replicas_in_zone1>,<cloud2.region2.zone2>:<num_replicas_in_zone2>,...` These read replica availability zones must be uniquely different from the primary availability zones defined in step 2. If you want to use the same cloud, region, and availability zone as a primary cluster, one option is to suffix the zone with `_rr` (for read replica). For example, `c1.r1.z1_rr:2`.

--- a/docs/content/v2024.1/develop/multi-cloud/multicloud-migration.md
+++ b/docs/content/v2024.1/develop/multi-cloud/multicloud-migration.md
@@ -66,7 +66,7 @@ The basic flow of bootstrapping is as follows:
 1. Create a checkpoint for all the tables in the AWS universe. For example:
 
     ```bash
-    ./bin/yb-admin -master_addresses <AWS_universe_master_addresses> \
+    ./bin/yb-admin --master_addresses <AWS_universe_master_addresses> \
             bootstrap_cdc_producer <comma_separated_source_universe_table_ids>
     ```
 
@@ -85,7 +85,7 @@ For detailed instructions on how to set up replication, see [Set up unidirection
 A simple way to set up replication is as follows:
 
 ```bash
-./bin/yb-admin -master_addresses <GCP_universe_master_addresses> setup_universe_replication \
+./bin/yb-admin --master_addresses <GCP_universe_master_addresses> setup_universe_replication \
   <AWS_universe_uuid>_<replication_stream_name> <AWS_universe_master_addresses> \
   <comma_separated_source_universe_table_ids> <comma_separated_bootstrap_ids>
 ```
@@ -111,8 +111,8 @@ The basic flow of switchover is as follows:
 
   ```bash
   ./bin/yb-admin \
-      -master_addresses <GCP_master_addresses> \
-      -certs_dir_name <cert_dir> \
+      --master_addresses <GCP_master_addresses> \
+      --certs_dir_name <cert_dir> \
       change_xcluster_role ACTIVE
   ```
 

--- a/docs/content/v2024.1/explore/cluster-management/point-in-time-recovery-ycql.md
+++ b/docs/content/v2024.1/explore/cluster-management/point-in-time-recovery-ycql.md
@@ -91,7 +91,7 @@ Create and populate a table, get a timestamp to which you'll restore, and then w
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         create_snapshot_schedule 1 10 ycql.pitr
     ```
 
@@ -105,7 +105,7 @@ Create and populate a table, get a timestamp to which you'll restore, and then w
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshot_schedules
     ```
 
@@ -165,7 +165,7 @@ Create and populate a table, get a timestamp to which you'll restore, and then w
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 0e4ceb83-fe3d-43da-83c3-013a8ef592ca 1620418817729963
     ```
 
@@ -180,7 +180,7 @@ Create and populate a table, get a timestamp to which you'll restore, and then w
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 

--- a/docs/content/v2024.1/explore/cluster-management/point-in-time-recovery-ysql.md
+++ b/docs/content/v2024.1/explore/cluster-management/point-in-time-recovery-ysql.md
@@ -90,7 +90,7 @@ Create a snapshot as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         create_snapshot_schedule 1 10 ysql.yugabyte
     ```
 
@@ -104,7 +104,7 @@ Create a snapshot as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshot_schedules
     ```
 
@@ -165,7 +165,7 @@ Create a snapshot as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 0e4ceb83-fe3d-43da-83c3-013a8ef592ca 1620418817729963
     ```
 
@@ -180,7 +180,7 @@ Create a snapshot as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 
@@ -245,7 +245,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         create_snapshot_schedule 1 10 ysql.yugabyte
     ```
 
@@ -259,7 +259,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshot_schedules
     ```
 
@@ -300,7 +300,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 1fb2d85a-3608-4cb1-af63-3e4062300dc1 1681964544554620
     ```
 
@@ -315,7 +315,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 
@@ -352,7 +352,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshot_schedules
     ```
 
@@ -412,7 +412,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 1fb2d85a-3608-4cb1-af63-3e4062300dc1 1681965106732671
     ```
 
@@ -427,7 +427,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 
@@ -475,7 +475,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshot_schedules
     ```
 
@@ -543,7 +543,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 1fb2d85a-3608-4cb1-af63-3e4062300dc1 1681965472490517
     ```
 
@@ -558,7 +558,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 
@@ -630,7 +630,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 1fb2d85a-3608-4cb1-af63-3e4062300dc1 1681965684502460
     ```
 
@@ -645,7 +645,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 
@@ -720,7 +720,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 1fb2d85a-3608-4cb1-af63-3e4062300dc1 1681965868912921
     ```
 
@@ -735,7 +735,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 

--- a/docs/content/v2024.1/explore/colocation.md
+++ b/docs/content/v2024.1/explore/colocation.md
@@ -212,7 +212,7 @@ To set up xCluster for colocated tables, do the following:
 1. Get the parent table UUID for the colocated database.
 
     ```sh
-    ./yb-admin -master_addresses <source_master_addresses> list_tables include_table_id | grep -i <database_name> | grep -i "colocation.parent.uuid"
+    ./yb-admin --master_addresses <source_master_addresses> list_tables include_table_id | grep -i <database_name> | grep -i "colocation.parent.uuid"
     ```
 
     ```output
@@ -222,13 +222,13 @@ To set up xCluster for colocated tables, do the following:
 1. Set up replication for the parent colocation table using yb-admin.
 
     ```sh
-    ./yb-admin -master_addresses <target_master_addresses> setup_universe_replication <replication_group_name> <source_master_addresses> <parent_colocated_table_uuid>
+    ./yb-admin --master_addresses <target_master_addresses> setup_universe_replication <replication_group_name> <source_master_addresses> <parent_colocated_table_uuid>
     ```
 
     For example:
 
     ```sh
-    ./yb-admin -master_addresses 127.0.0.2 setup_universe_replication A1-B2 127.0.0.1 00004000000030008000000000004004.colocation.parent.uuid
+    ./yb-admin --master_addresses 127.0.0.2 setup_universe_replication A1-B2 127.0.0.1 00004000000030008000000000004004.colocation.parent.uuid
     ```
 
     ```output

--- a/docs/content/v2024.1/explore/going-beyond-sql/asynchronous-replication-ysql.md
+++ b/docs/content/v2024.1/explore/going-beyond-sql/asynchronous-replication-ysql.md
@@ -77,7 +77,7 @@ Having two identical tables on your clusters allows you to set up xCluster repli
 To configure "Data Center - West" to be the target of data changes from the "Data Center - East" cluster, you need to use the [yb-admin](../../../admin/yb-admin/) utility [setup_universe_replication](../../../admin/yb-admin/#xcluster-replication-commands) command. The syntax is as follows:
 
 ```sh.output
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
     setup_universe_replication <source-universe-uuid> \
     <source-master-addresses> <source-table-ids>
 ```
@@ -90,7 +90,7 @@ yb-admin -master_addresses <target-master-addresses> \
 Based on actual values you obtained from the YB-Master UI, run the yb-admin `setup_universe_replication` command from your YugabyteDB home directory similar to the one shown in the following example:
 
 ```sh
-./bin/yb-admin -master_addresses 127.0.0.2:7100 \
+./bin/yb-admin --master_addresses 127.0.0.2:7100 \
     setup_universe_replication 7acd6399-657d-42dc-a90a-646869898c2d \
     127.0.0.1:7100 000033e8000030008000000000004000
 ```
@@ -151,7 +151,7 @@ Look up the source UUID in the source YB-Master UI (<http://127.0.0.2:7000>), an
 Based on actual values you obtained from the YB-Master UI, run the yb-admin `setup_universe_replication` command similar to the one shown in the following example:
 
 ```sh
-./bin/yb-admin -master_addresses 127.0.0.1:7100 \
+./bin/yb-admin --master_addresses 127.0.0.1:7100 \
     setup_universe_replication 0a315687-e9bd-430f-b6f4-ac831193a394 \
     127.0.0.2:7100 000030a9000030008000000000004000
 ```
@@ -208,7 +208,7 @@ When the bidirectional replication has been configured, you can add data to the 
 You can add more tables to an existing replication using the yb-admin command `alter_universe_replication` `add_table`:
 
 ```sh.output
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
         alter_universe_replication <source-universe-uuid> \
         add_table <source-table-ids>
 ```
@@ -216,7 +216,7 @@ yb-admin -master_addresses <target-master-addresses> \
 The following is an example command:
 
 ```sh
-./bin/yb-admin -master_addresses 127.0.0.2:7100 \
+./bin/yb-admin --master_addresses 127.0.0.2:7100 \
     alter_universe_replication 7acd6399-657d-42dc-a90a-646869898c2d \
     add_table 000030a9000030008000000000004000
 ```

--- a/docs/content/v2024.1/explore/multi-region-deployments/read-replicas-ycql.md
+++ b/docs/content/v2024.1/explore/multi-region-deployments/read-replicas-ycql.md
@@ -62,7 +62,7 @@ For more info, please use: yb-ctl status
 The following command instructs the masters to create three replicas for each tablet distributed across the three zones:
 
 ```shell
-$ ./bin/yb-admin -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 modify_placement_info c.r.z1,c.r.z2,c.r.z3 3 live
+$ ./bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 modify_placement_info c.r.z1,c.r.z2,c.r.z3 3 live
 ```
 
 The following illustration demonstrates the primary cluster visible via [YugabyteDB Anywhere](../../../yugabyte-platform/):
@@ -166,7 +166,7 @@ The following commands add three new nodes to a read replica cluster in region `
 ./bin/yb-ctl add_node --placement_info "c.r2.z22" --tserver_flags "placement_uuid=rr"
 ./bin/yb-ctl add_node --placement_info "c.r2.z23" --tserver_flags "placement_uuid=rr"
 
-./bin/yb-admin -master_addresses 127.0.0.1:7100,127.0.0.2,127.0.0.3 add_read_replica_placement_info c.r2.z21:1,c.r2.z22:1,c.r2.z23:1 3 rr
+./bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2,127.0.0.3 add_read_replica_placement_info c.r2.z21:1,c.r2.z22:1,c.r2.z23:1 3 rr
 ```
 
 The following illustration demonstrates the setup of the two clusters, one of which is primary and another one is read replica visible via YugabyteDB Anywhere:

--- a/docs/content/v2024.1/manage/backup-restore/point-in-time-recovery.md
+++ b/docs/content/v2024.1/manage/backup-restore/point-in-time-recovery.md
@@ -78,13 +78,13 @@ To create a schedule and enable PITR, use the [`create_snapshot_schedule`](../..
 For example, to create a schedule that produces a snapshot of a YSQL database once a day (every 1,440 minutes) and retains it for three days (4,320 minutes), you would execute the following command:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot_schedule 1440 4320 ysql.<database_name>
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot_schedule 1440 4320 ysql.<database_name>
 ```
 
 The equivalent command for a YCQL keyspace would be the following:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot_schedule 1440 4320 <keyspace_name>
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot_schedule 1440 4320 <keyspace_name>
 ```
 
 The following output is a unique ID of the newly-created snapshot schedule:
@@ -102,7 +102,7 @@ You can use this ID to [delete the schedule](#delete-a-schedule) or [restore to 
 To delete a schedule and disable PITR, use the following [`delete_snapshot_schedule`](../../../admin/yb-admin/#delete-snapshot-schedule) command that takes the ID of the schedule to be deleted as a parameter:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
 ```
 
 ### List schedules
@@ -110,7 +110,7 @@ To delete a schedule and disable PITR, use the following [`delete_snapshot_sched
 To see a list of schedules that currently exist in the cluster, use the following [`list_snapshot_schedules`](../../../admin/yb-admin/#list-snapshot-schedules) command:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshot_schedules
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshot_schedules
 ```
 
 ```output.json
@@ -141,7 +141,7 @@ To see a list of schedules that currently exist in the cluster, use the followin
 You can also use the same command to view the information about a particular schedule by providing its ID as a parameter, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshot_schedules 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshot_schedules 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
 ```
 
 ## Restore to a point in time
@@ -162,7 +162,7 @@ If a database or a keyspace has an associated snapshot schedule, you can use tha
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <ip1:7100,ip2:7100,ip3:7100> \
+        --master_addresses <ip1:7100,ip2:7100,ip3:7100> \
         restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 1651435200
     ```
 
@@ -170,7 +170,7 @@ If a database or a keyspace has an associated snapshot schedule, you can use tha
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <ip1:7100,ip2:7100,ip3:7100> \
+        --master_addresses <ip1:7100,ip2:7100,ip3:7100> \
         restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 "2022-05-01 13:00-0700"
     ```
 
@@ -180,7 +180,7 @@ If a database or a keyspace has an associated snapshot schedule, you can use tha
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <ip1:7100,ip2:7100,ip3:7100> \
+        --master_addresses <ip1:7100,ip2:7100,ip3:7100> \
         restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 minus 5m
     ```
 
@@ -188,7 +188,7 @@ If a database or a keyspace has an associated snapshot schedule, you can use tha
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <ip1:7100,ip2:7100,ip3:7100> \
+        --master_addresses <ip1:7100,ip2:7100,ip3:7100> \
         restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 minus 1h
     ```
 

--- a/docs/content/v2024.1/manage/backup-restore/snapshot-ysql.md
+++ b/docs/content/v2024.1/manage/backup-restore/snapshot-ysql.md
@@ -42,7 +42,7 @@ Using distributed snapshots allows you to back up a database and then restore it
 To back up a database, create a snapshot using the [`create_database_snapshot`](../../../admin/yb-admin/#create-database-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> create_database_snapshot ysql.<database_name>
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> create_database_snapshot ysql.<database_name>
 ```
 
 A unique ID for the snapshot is returned, as shown in the following sample output:
@@ -56,7 +56,7 @@ You can then use this ID to check the status of the snapshot, [delete it](#delet
 The `create_database_snapshot` command exits immediately, but the snapshot may take some time to complete. Before using the snapshot, verify its status by executing the [`list_snapshots`](../../../admin/yb-admin/#list-snapshots) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshots
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshots
 ```
 
 All the snapshots in the cluster are listed, along with their statuses. You can find the ID of the new snapshot and make sure it has been completed, as shown in the following  sample output:
@@ -71,7 +71,7 @@ Snapshot UUID                           State       Creation Time
 Snapshots never expire and are retained as long as the cluster exists. If you no longer need a snapshot, you can delete it by executing the [`delete_snapshot`](../../../admin/yb-admin/#delete-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794
 ```
 
 ## Restore a snapshot
@@ -79,7 +79,7 @@ Snapshots never expire and are retained as long as the cluster exists. If you no
 To restore the data backed up in one of the previously created snapshots, run the [`restore_snapshot`](../../../admin/yb-admin/#restore-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> restore_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> restore_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794
 ```
 
 This command rolls back the database to the state which it had when the snapshot was created. The restore happens in-place: it changes the state of the existing database in the same cluster.
@@ -127,7 +127,7 @@ To move a snapshot to external storage, gather all the relevant files from all t
 1. Create the snapshot metadata file by executing the [`export_snapshot`](../../../admin/yb-admin/#export-snapshot) command and providing the ID of the snapshot, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> export_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794 <database_name>.snapshot
+    ./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> export_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794 <database_name>.snapshot
     ```
 
 1. Copy the newly-created YSQL metadata file (`<database_name>_schema.sql`) and the snapshot metadata file (`<database_name>.snapshot`) to the external storage.
@@ -176,7 +176,7 @@ You can restore a snapshot that you have [moved to external storage](#move-a-sna
 1. Fetch the snapshot metadata file from the external storage and apply it by running the [`import_snapshot`](../../../admin/yb-admin/#import-snapshot) command, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> import_snapshot <database_name>.snapshot <database_name>
+    ./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> import_snapshot <database_name>.snapshot <database_name>
     ```
 
     Notice that the following output contains the mapping between the old tablet IDs and the new tablet IDs:

--- a/docs/content/v2024.1/manage/backup-restore/snapshots-ycql.md
+++ b/docs/content/v2024.1/manage/backup-restore/snapshots-ycql.md
@@ -41,13 +41,13 @@ Using distributed snapshots allows you to back up a database and then restore it
 To back up a keyspace with all its tables and indexes, create a snapshot using the [`create_keyspace_snapshot`](../../../admin/yb-admin/#create-keyspace-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> create_keyspace_snapshot my_keyspace
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> create_keyspace_snapshot my_keyspace
 ```
 
 To back up a single table with its indexes, use the [`create_snapshot`](../../../admin/yb-admin/#create-snapshot) command instead, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot my_keyspace my_table
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot my_keyspace my_table
 ```
 
 When you execute either of the preceding commands, a unique ID for the snapshot is returned, as per the following output:
@@ -61,7 +61,7 @@ You can then use this ID to check the status of the snapshot, [delete it](#delet
 Even though the `create_keyspace_snapshot` and `create_snapshot` commands exit immediately, the snapshot may take some time to complete. Before using the snapshot, verify its status with the [`list_snapshots`](../../../admin/yb-admin/#list-snapshots) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshots
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshots
 ```
 
 The preceding command lists the snapshots in the cluster, along with their states. You can find the ID of the new snapshot and make sure it has been completed, as shown in the following  sample output:
@@ -76,7 +76,7 @@ Snapshot UUID                           State       Creation Time
 Snapshots never expire and are retained as long as the cluster exists. If you no longer need a snapshot, you can delete it with the [`delete_snapshot`](../../../admin/yb-admin/#delete-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef
 ```
 
 ## Restore a snapshot
@@ -84,7 +84,7 @@ Snapshots never expire and are retained as long as the cluster exists. If you no
 To restore the data backed up in one of the previously created snapshots, run the [`restore_snapshot`](../../../admin/yb-admin/#restore-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> restore_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> restore_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef
 ```
 
 This command rolls back the database to the state which it had when the snapshot was created. The restore happens in-place: it changes the state of the existing database in the same cluster.
@@ -102,7 +102,7 @@ To move a snapshot to external storage, gather all the relevant files from all t
 1. Create the snapshot metadata file by running the [`export_snapshot`](../../../admin/yb-admin/#export-snapshot) command and providing the ID of the snapshot:
 
     ```sh
-    ./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> export_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef my_keyspace.snapshot
+    ./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> export_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef my_keyspace.snapshot
     ```
 
 1. Copy the newly created snapshot metadata file (`my_keyspace.snapshot`) to the external storage.
@@ -133,7 +133,7 @@ You can restore a snapshot that you have [moved to external storage](#move-a-sna
 1. Retrieve the snapshot metadata file from the external storage and apply it by running the [`import_snapshot`](../../../admin/yb-admin/#import-snapshot) command, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> import_snapshot my_keyspace.snapshot my_keyspace
+    ./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> import_snapshot my_keyspace.snapshot my_keyspace
     ```
 
     Notice that the following output contains the mapping between the old tablet IDs and the new tablet IDs:

--- a/docs/content/v2024.1/manage/change-cluster-config.md
+++ b/docs/content/v2024.1/manage/change-cluster-config.md
@@ -101,13 +101,13 @@ The following commands can be run from one of the old master nodes. You can firs
 
 ```sh
 export MASTERS=node1:7100,node2:7100,node3:7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_blacklist ADD node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
+~/master/bin/yb-admin --master_addresses $MASTERS change_blacklist ADD node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
 ```
 
 Verify that the blacklist information looks similar to the following:
 
 ```sh
-~/master/bin/yb-admin -master_addresses $MASTERS get_universe_config
+~/master/bin/yb-admin --master_addresses $MASTERS get_universe_config
 Config:
 version: 5
 server_blacklist {
@@ -131,7 +131,7 @@ server_blacklist {
 Next, wait for the data move to complete. You can check the percentage completion by running the following command:
 
 ```sh
-~/master/bin/yb-admin -master_addresses $MASTERS get_load_move_completion
+~/master/bin/yb-admin --master_addresses $MASTERS get_load_move_completion
 Percent complete = 66.6
 ```
 
@@ -158,19 +158,19 @@ If any error log is reported on the command line from the following steps, check
 
 ```sh
 export MASTERS=node1:7100,node2:7100,node3:7100,node7:7100,node8:7100,node9:7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config ADD_SERVER node7 7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config REMOVE_SERVER node1 7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config ADD_SERVER node8 7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config REMOVE_SERVER node2 7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config ADD_SERVER node9 7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config REMOVE_SERVER node3 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config ADD_SERVER node7 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config REMOVE_SERVER node1 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config ADD_SERVER node8 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config REMOVE_SERVER node2 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config ADD_SERVER node9 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config REMOVE_SERVER node3 7100
 ```
 
 Now ensure that the master leader is one of the new master nodes as follows:
 
 ```sh
 $ export MASTERS=node7:7100,node8:7100,node9:7100
-$ ~/master/bin/yb-admin -master_addresses $MASTERS list_all_masters
+$ ~/master/bin/yb-admin --master_addresses $MASTERS list_all_masters
 ```
 
 ```output
@@ -197,7 +197,7 @@ Updating master addresses is needed in case the yb-tserver server is restarted.
 The old nodes are not part of the universe any more and can be shut down. After the old YB-TServers are terminated, you can cleanup the blacklist from the master configuration using the following command:
 
 ```sh
-~/master/bin/yb-admin -master_addresses $MASTERS change_blacklist REMOVE node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
+~/master/bin/yb-admin --master_addresses $MASTERS change_blacklist REMOVE node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
 ```
 
 {{< note title="Tip" >}}
@@ -207,5 +207,5 @@ Cleaning up the blacklist server will help reuse the older IPs in case they get 
 Ensure there are no `server_blacklist` entries returned by the command:
 
 ```sh
-~/master/bin/yb-admin -master_addresses $MASTERS get_universe_config
+~/master/bin/yb-admin --master_addresses $MASTERS get_universe_config
 ```

--- a/docs/content/v2024.1/manage/upgrade-deployment.md
+++ b/docs/content/v2024.1/manage/upgrade-deployment.md
@@ -149,7 +149,7 @@ New YugabyteDB features may require changes to the format of data that is sent o
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <master-addresses> \
+        --master_addresses <master-addresses> \
         promote_auto_flags
     ```
 
@@ -189,7 +189,7 @@ Use the [yb-admin](../../admin/yb-admin/) utility to upgrade the YSQL system cat
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     upgrade_ysql
 ```
 
@@ -203,8 +203,8 @@ In certain scenarios, a YSQL upgrade can take longer than 60 seconds, which is t
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
-    -timeout_ms 180000 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --timeout_ms 180000 \
     upgrade_ysql
 ```
 
@@ -293,7 +293,7 @@ During the Monitor phase, do the following:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <master-addresses> \
+        --master_addresses <master-addresses> \
         promote_auto_flags kLocalVolatile
     ```
 
@@ -324,7 +324,7 @@ If you need to roll back an upgrade where volatile AutoFlags were enabled, depen
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <master-addresses> \
+        --master_addresses <master-addresses> \
         rollback_auto_flags <previous_config_version>
     ```
 
@@ -342,7 +342,7 @@ If you need to roll back an upgrade where volatile AutoFlags were enabled, depen
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+        --master_addresses ip1:7100,ip2:7100,ip3:7100 \
         rollback_auto_flags 2
     ```
 

--- a/docs/content/v2024.1/reference/configuration/yugabyted.md
+++ b/docs/content/v2024.1/reference/configuration/yugabyted.md
@@ -82,7 +82,7 @@ $ ./bin/yugabyted -h
 ```
 
 ```sh
-$ ./bin/yugabyted -help
+$ ./bin/yugabyted --help
 ```
 
 For help with specific `yugabyted` commands, run 'yugabyted [ command ] -h'. For example, you can print the command-line help for the `yugabyted start` command by running the following:

--- a/docs/content/v2024.1/secure/encryption-at-rest.md
+++ b/docs/content/v2024.1/secure/encryption-at-rest.md
@@ -38,7 +38,7 @@ You enable encryption as follows:
 1. Copy the key to master nodes. In the following example, assume a 3-node RF=3 cluster with `MASTER_ADDRESSES=ip1:7100,ip2:7100,ip3:7100`. Choose any string `<key_id>` for this key and use yb-admin to copy the key to each of the masters:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES add_universe_key_to_all_masters <key_id> /<path_to_universe_key>
+    yb-admin --master_addresses $MASTER_ADDRESSES add_universe_key_to_all_masters <key_id> /<path_to_universe_key>
     ```
 
     The preceding operation does not perform the key rotation, but rather seeds each master's in-memory state. The key only lives in memory, and the plaintext key is never persisted to the disk.
@@ -46,13 +46,13 @@ You enable encryption as follows:
 1. Enable cluster-wide encryption. Before rotating the key, ensure that the masters know about `<key_id>`:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES all_masters_have_universe_key_in_memory <key_id>
+    yb-admin --master_addresses $MASTER_ADDRESSES all_masters_have_universe_key_in_memory <key_id>
     ```
 
     If the preceding command fails, rerun step 2. Once this succeeds, instruct the cluster to start using the new universe key, as follows:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES rotate_universe_key_in_memory <key_id>
+    yb-admin --master_addresses $MASTER_ADDRESSES rotate_universe_key_in_memory <key_id>
     ```
 
     Because data is encrypted in the background as part of flushes to disk and compactions, only new data is encrypted. Therefore, the call should return quickly.
@@ -60,7 +60,7 @@ You enable encryption as follows:
 1. Verify that encryption has been enabled. To do this, check the encryption status of the cluster by executing the following yb-admin command:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES is_encryption_enabled
+    yb-admin --master_addresses $MASTER_ADDRESSES is_encryption_enabled
     ```
 
     Expect the following output:
@@ -84,7 +84,7 @@ You can rotate the new key as follows:
 1. Copy the new key to master nodes, informing the master nodes about the new key, as follows:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES add_universe_key_to_all_masters
+    yb-admin --master_addresses $MASTER_ADDRESSES add_universe_key_to_all_masters
     <key_id_2> /path_to_universe_key_2
     ```
 
@@ -93,7 +93,7 @@ You can rotate the new key as follows:
 1. Ensure that the masters know about the key, and then perform the rotation, as follows:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES rotate_universe_key_in_memory <key_id_2>
+    yb-admin --master_addresses $MASTER_ADDRESSES rotate_universe_key_in_memory <key_id_2>
     ```
 
     Because this key is only used for new data and can only eventually encrypt older data through compactions, it is best to ensure old keys remain secure.
@@ -101,7 +101,7 @@ You can rotate the new key as follows:
 1. Verify the new key. To do this, check that the new key is encrypting the cluster, as follows:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES is_encryption_enabled
+    yb-admin --master_addresses $MASTER_ADDRESSES is_encryption_enabled
     ```
 
     Expect the following output:
@@ -119,13 +119,13 @@ You can disable cluster-wide encryption as follows:
 1. Disable encryption by executing the following yb-admin command:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES disable_encryption
+    yb-admin --master_addresses $MASTER_ADDRESSES disable_encryption
     ```
 
 1. Verify that the encryption has been disabled by executing the following command:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES is_encryption_enabled
+    yb-admin --master_addresses $MASTER_ADDRESSES is_encryption_enabled
     ```
 
     Expect the following output:

--- a/docs/content/v2024.1/secure/tls-encryption/connect-to-cluster.md
+++ b/docs/content/v2024.1/secure/tls-encryption/connect-to-cluster.md
@@ -59,7 +59,7 @@ For example, the following command lists the master information for the TLS-enab
 
 ```sh
 export MASTERS=node1:7100,node2:7100,node3:7100
-./bin/yb-admin --master_addresses $MASTERS -certs_dir_name ~/yugabyte-tls-config list_all_masters
+./bin/yb-admin --master_addresses $MASTERS --certs_dir_name ~/yugabyte-tls-config list_all_masters
 ```
 
 You should see the following output format:

--- a/docs/content/v2024.2/admin/yb-admin.md
+++ b/docs/content/v2024.2/admin/yb-admin.md
@@ -21,10 +21,10 @@ To use yb-admin from the YugabyteDB home directory, run `./bin/yb-admin` using t
 
 ```sh
 yb-admin \
-    [ -master_addresses <master-addresses> ]  \
-    [ -init_master_addrs <master-address> ]  \
-    [ -timeout_ms <millisec> ] \
-    [ -certs_dir_name <dir-name> ] \
+    [ --master_addresses <master-addresses> ]  \
+    [ --init_master_addrs <master-address> ]  \
+    [ --timeout_ms <millisec> ] \
+    [ --certs_dir_name <dir-name> ] \
     <command> [ command_flags ]
 ```
 
@@ -73,7 +73,7 @@ Gets the configuration for the universe.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_universe_config
 ```
 
@@ -87,7 +87,7 @@ Changes the configuration of a tablet.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     change_config <tablet-id> \
     [ ADD_SERVER | REMOVE_SERVER ] \
     <peer-uuid> \
@@ -117,7 +117,7 @@ Changes the master configuration.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     change_master_config \
     [ ADD_SERVER|REMOVE_SERVER ] \
     <ip-addr> <port> \
@@ -138,7 +138,7 @@ yb-admin \
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_tablet_servers <tablet-id>
 ```
 
@@ -155,7 +155,7 @@ Use this to find out who the LEADER of a tablet is.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_tablets <keyspace-type>.<keyspace-name> <table> [<max-tablets>]
 ```
 
@@ -169,7 +169,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     list_tablets ysql.db_name table_name 0
 ```
 
@@ -187,7 +187,7 @@ Lists all tablet servers.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_all_tablet_servers
 ```
 
@@ -201,7 +201,7 @@ Displays a list of all YB-Master servers in a table listing the master UUID, RPC
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_all_masters
 ```
 
@@ -211,7 +211,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses node7:7100,node8:7100,node9:7100 \
+    --master_addresses node7:7100,node8:7100,node9:7100 \
     list_all_masters
 ```
 
@@ -230,7 +230,7 @@ Prints a list of replica types and counts for the specified table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_replica_type_counts <keyspace> <table-name>
 ```
 
@@ -246,7 +246,7 @@ Prints the status of the YB-Master servers.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     dump_masters_state
 ```
 
@@ -260,7 +260,7 @@ List the locations of the tablet server logs.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_tablet_server_log_locations
 ```
 
@@ -274,7 +274,7 @@ Lists all tablets for the specified tablet server (YB-TServer).
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_tablets_for_tablet_server <ts-uuid>
 ```
 
@@ -287,7 +287,7 @@ Splits the specified hash-sharded tablet and computes the split point as the mid
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     split_tablet <tablet-id-to-split>
 ```
 
@@ -315,7 +315,7 @@ Forces the master leader to step down. The specified YB-Master node will take it
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     master_leader_stepdown [ <new-leader-id> ]
 ```
 
@@ -330,7 +330,7 @@ Prints the current YSQL schema catalog version.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     ysql_catalog_version
 ```
 
@@ -340,7 +340,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     ysql_catalog_version
 ```
 
@@ -362,14 +362,14 @@ Prints a list of all tables. Optionally, include the database type, table ID, an
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_tables \
     [ include_db_type ] [ include_table_id ] [ include_table_type ]
 ```
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> list_tables
+    --master_addresses <master-addresses> list_tables
 ```
 
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default is `localhost:7100`.
@@ -399,7 +399,7 @@ To display a list of tables and their UUID (`table_id`) values, open the **YB-Ma
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     list_tables
 ```
 
@@ -434,7 +434,7 @@ Triggers manual compaction on a table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     compact_table <db-type>.<namespace> <table> [<timeout-in-seconds>] [ADD_INDEXES]
 ```
 
@@ -449,7 +449,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     compact_table ysql.yugabyte table_name
 ```
 
@@ -461,7 +461,7 @@ Compacted [yugabyte.table_name] tables.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     compact_table tableid.<table-id> [<timeout-in-seconds>] [ADD_INDEXES]
 ```
 
@@ -474,7 +474,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     compact_table tableid.000033eb000030008000000000004002
 ```
 
@@ -488,7 +488,7 @@ Show the status of full compaction on a table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     compaction_status <db-type>.<namespace> <table> [show_tablets]
 ```
 
@@ -502,7 +502,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     compaction_status ysql.yugabyte table_name show_tablets
 ```
 
@@ -549,7 +549,7 @@ Modifies the placement information (cloud, region, and zone) for a table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     modify_table_placement_info <keyspace> <table-name> <placement-info> <replication-factor> \
     [ <placement-id> ]
 ```
@@ -558,7 +558,7 @@ or alternatively:
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     modify_table_placement_info tableid.<table-id> <placement-info> <replication-factor> \
     [ <placement-id> ]
 ```
@@ -575,7 +575,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     modify_table_placement_info  testdatabase testtable \
     aws.us-west.us-west-2a,aws.us-west.us-west-2b,aws.us-west.us-west-2c 3
 ```
@@ -597,7 +597,7 @@ Creates a transaction status table to be used in a region. This command should a
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_transaction_table \
     <table-name>
 ```
@@ -611,7 +611,7 @@ The transaction status table will be created as `system.<table-name>`.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     create_transaction_table \
     transactions_us_east
 ```
@@ -622,7 +622,7 @@ Next, set the placement on the newly created transactions table:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     modify_table_placement_info system transactions_us_east \
     aws.us-east.us-east-1a,aws.us-east.us-east-1b,aws.us-east.us-east-1c 3
 ```
@@ -643,7 +643,7 @@ Add a tablet to a transaction status table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     add_transaction_tablet \
     <table-id>
 ```
@@ -655,7 +655,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     add_transaction_tablet 000033eb000030008000000000004002
 ```
 
@@ -669,7 +669,7 @@ Flush the memstores of the specified table on all tablet servers to disk.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     flush_table <db-type>.<namespace> <table> [<timeout-in-seconds>] [ADD_INDEXES]
 ```
 
@@ -684,7 +684,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     flush_table ysql.yugabyte table_name
 
 ```
@@ -697,7 +697,7 @@ Flushed [yugabyte.table_name] tables.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     flush_table tableid.<table-id> [<timeout-in-seconds>] [ADD_INDEXES]
 ```
 
@@ -710,7 +710,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     flush_table tableid.000033eb000030008000000000004002
 ```
 
@@ -726,7 +726,7 @@ Backfill all DEFERRED indexes in a YCQL table.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     backfill_indexes_for_table <keyspace> <table-name>
 ```
 
@@ -738,7 +738,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     backfill_indexes_for_table ybdemo table_name
 ```
 
@@ -779,7 +779,7 @@ Creates a snapshot of the specified YSQL database.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_database_snapshot <database>
 ```
 
@@ -792,7 +792,7 @@ When this command runs, a `snapshot_id` is generated and printed.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     create_database_snapshot
 ```
 
@@ -806,7 +806,7 @@ Creates a snapshot of the specified YCQL keyspace.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_keyspace_snapshot <keyspace>
 ```
 
@@ -819,7 +819,7 @@ When this command runs, a `snapshot_id` is generated and printed.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     create_keyspace_snapshot
 ```
 
@@ -833,7 +833,7 @@ Prints a list of all snapshot IDs, restoration IDs, and states. Optionally, prin
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_snapshots \
     [ show_details ] [ not_show_restored ]
 ```
@@ -883,7 +883,7 @@ In this example, the optional `show_details` flag is added to generate the snaps
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     list_snapshots show_details
 ```
 
@@ -919,7 +919,7 @@ Use the [create_snapshot_schedule](#create-snapshot-schedule) command to create 
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_snapshot <keyspace> <table-name> | <table_id> \
     [<keyspace> <table-name> | <table-id> ]... \
     [<flush-timeout-in-seconds>]
@@ -937,7 +937,7 @@ When this command runs, a `snapshot_id` is generated and printed.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     create_snapshot ydb test_tb
 ```
 
@@ -959,7 +959,7 @@ Restores the specified snapshot, including the tables and indexes. When the oper
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     restore_snapshot <snapshot-id> <restore-target>
 ```
 
@@ -1009,7 +1009,7 @@ Returns one or more restorations in JSON format.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_snapshot_restorations <restoration-id>
 ```
 
@@ -1020,7 +1020,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     list_snapshot_restorations 26ed9053-0c26-4277-a2b8-c12d0fa4c8cf
 ```
 
@@ -1044,7 +1044,7 @@ Generates a metadata file for the specified snapshot, listing all the relevant i
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     export_snapshot <snapshot-id> <file-name>
 ```
 
@@ -1056,7 +1056,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     export_snapshot 4963ed18fc1e4f1ba38c8fcf4058b295 \
     test_tb.snapshot
 ```
@@ -1074,7 +1074,7 @@ Imports the specified snapshot metadata file.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     import_snapshot <file-name> \
     [<keyspace> <table-name> [<keyspace> <table-name>]...]
 ```
@@ -1094,7 +1094,7 @@ The *keyspace* and the *table* can be different from the exported one.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     import_snapshot test_tb.snapshot ydb test_tb
 ```
 
@@ -1120,7 +1120,7 @@ Imports only the specified tables from the specified snapshot metadata file.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     import_snapshot_selective <file-name> \
     [<keyspace> <table-name> [<keyspace> <table-name>]...]
 ```
@@ -1140,7 +1140,7 @@ The *keyspace* can be different from the exported one. The name of the table nee
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     import_snapshot_selective test_tb.snapshot ydb test_tb
 ```
 
@@ -1166,7 +1166,7 @@ Deletes the specified snapshot.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     delete_snapshot <snapshot-id>
 ```
 
@@ -1183,7 +1183,7 @@ Returns a schedule ID in JSON format.
 
 ```sh
 yb-admin create_snapshot_schedule \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     <snapshot-interval>\
     <retention-time>\
     <filter-expression>
@@ -1202,7 +1202,7 @@ Take a snapshot of the YSQL database `yugabyte` once per minute, and retain each
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     create_snapshot_schedule 1 10 ysql.yugabyte
 ```
 
@@ -1210,7 +1210,7 @@ The equivalent command for the YCQL keyspace `yugabyte` would be the following:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     create_snapshot_schedule 1 10 yugabyte
 ```
 
@@ -1242,7 +1242,7 @@ Returns one or more schedule lists in JSON format.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_snapshot_schedules <schedule-id>
 ```
 
@@ -1253,7 +1253,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     list_snapshot_schedules 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
 ```
 
@@ -1290,7 +1290,7 @@ Schedules group a set of items into a single tracking object (the *schedule*). W
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     restore_snapshot_schedule <schedule-id> <restore-target>
 ```
 
@@ -1322,7 +1322,7 @@ Restore from an absolute timestamp:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 1617670679185100
 ```
 
@@ -1330,7 +1330,7 @@ Restore from a relative time:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 minus 60s
 ```
 
@@ -1353,7 +1353,7 @@ Returns a JSON object with the `schedule_id` that was just deleted.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     delete_snapshot_schedule <schedule-id>
 ```
 
@@ -1364,7 +1364,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     delete_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
 ```
 
@@ -1390,7 +1390,7 @@ Modifies the placement information (cloud, region, and zone) for a deployment.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     modify_placement_info <placement-info> <replication-factor> \
     [ <placement-id> ]
 ```
@@ -1404,7 +1404,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses $MASTER_RPC_ADDRS \
+    --master_addresses $MASTER_RPC_ADDRS \
     modify_placement_info  \
     aws.us-west.us-west-2a:2,aws.us-west.us-west-2b:2,aws.us-west.us-west-2c 5
 ```
@@ -1447,7 +1447,7 @@ Having all tablet leaders reside in a single region reduces the number of networ
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     set_preferred_zones <cloud.region.zone>[:<preference>] \
     [<cloud.region.zone>[:<preference>]]...
 ```
@@ -1594,7 +1594,7 @@ Add a read replica cluster to the master configuration.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     add_read_replica_placement_info <placement-info> \
     <replication-factor> \
     [ <placement-id> ]
@@ -1612,7 +1612,7 @@ yb-admin \
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     modify_read_replica_placement_info <placement-info> \
     <replication-factor> \
     [ <placement-id> ]
@@ -1631,7 +1631,7 @@ Delete the read replica.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     delete_read_replica_placement_info
 ```
 
@@ -1653,7 +1653,7 @@ Sets the contents of *key-path* in-memory on each YB-Master node.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     add_universe_key_to_all_masters <key-id> <key-path>
 ```
 
@@ -1673,7 +1673,7 @@ Checks whether the universe key associated with the provided *key-id* exists in-
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> all_masters_have_universe_key_in_memory <key-id>
+    --master_addresses <master-addresses> all_masters_have_universe_key_in_memory <key-id>
 ```
 
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default is `localhost:7100`.
@@ -1693,7 +1693,7 @@ The [all_masters_have_universe_key_in_memory](#all-masters-have-universe-key-in-
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> rotate_universe_key_in_memory <key-id>
+    --master_addresses <master-addresses> rotate_universe_key_in_memory <key-id>
 ```
 
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default is `localhost:7100`.
@@ -1707,7 +1707,7 @@ Disables the in-memory encryption at rest for newly-written data files.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     disable_encryption_in_memory
 ```
 
@@ -1721,7 +1721,7 @@ Checks if cluster-wide encryption is enabled.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     is_encryption_enabled
 ```
 
@@ -1739,7 +1739,7 @@ The new key ID (`<key_id_2>`) should be different from the previous one (`<key_i
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     is_encryption_enabled
 ```
 
@@ -1757,7 +1757,7 @@ Create a change data capture (CDC) DB stream for the specified namespace using t
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_change_data_stream ysql.<namespace-name>
 ```
 
@@ -1768,7 +1768,7 @@ For example:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100 \
+    --master_addresses 127.0.0.1:7100 \
     create_change_data_stream ysql.yugabyte
 ```
 
@@ -1781,7 +1781,7 @@ This feature is {{<tags/feature/tp>}}. Use the [yb_enable_cdc_consistent_snapsho
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_change_data_stream ysql.<namespace-name> [EXPLICIT] [<before-image-mode>] [USE_SNAPSHOT | NOEXPORT_SNAPSHOT]
 ```
 
@@ -1795,7 +1795,7 @@ For example:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100 \
+    --master_addresses 127.0.0.1:7100 \
     create_change_data_stream ysql.yugabyte EXPLICIT CHANGE USE_SNAPSHOT
 ```
 
@@ -1807,7 +1807,7 @@ To create a change data capture (CDC) DB stream which also supports sending the 
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_change_data_stream ysql.<namespace-name> [EXPLICIT] <before-image-mode>
 ```
 
@@ -1830,7 +1830,7 @@ To create a change data capture (CDC) DB stream which works in the EXPLICIT chec
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     create_change_data_stream ysql.<namespace-name> EXPLICIT
 ```
 
@@ -1858,7 +1858,7 @@ Lists all the created CDC DB streams.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_change_data_streams [namespace-name]
 ```
 
@@ -1869,7 +1869,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100 \
+    --master_addresses 127.0.0.1:7100 \
     list_change_data_streams
 ```
 
@@ -1915,7 +1915,7 @@ Get the information associated with a particular CDC DB stream.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_change_data_stream_info <db-stream-id>
 ```
 
@@ -1926,7 +1926,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100 \
+    --master_addresses 127.0.0.1:7100 \
     get_change_data_stream_info d540f5e4890c4d3b812933cbfd703ed3
 ```
 
@@ -1949,7 +1949,7 @@ Delete the specified CDC DB stream.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     delete_change_data_stream <db-stream-id>
 ```
 
@@ -1960,7 +1960,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100 \
+    --master_addresses 127.0.0.1:7100 \
     delete_change_data_stream d540f5e4890c4d3b812933cbfd703ed3
 ```
 
@@ -1984,7 +1984,7 @@ To verify if any tables are already configured for replication, use [list_cdc_st
 
 ```sh
 yb-admin \
-    -master_addresses <target-master-addresses> \
+    --master_addresses <target-master-addresses> \
     setup_universe_replication \
     <source-universe-uuid>_<replication-name> \
     <source-master-addresses> \
@@ -2015,7 +2015,7 @@ To display a list of tables and their UUID (`table_id`) values, open the **YB-Ma
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     setup_universe_replication e260b8b6-e89f-4505-bb8e-b31f74aa29f3_xClusterSetup1 \
     127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     000030a5000030008000000000004000,000030a5000030008000000000004005,dfef757c415c4b2cacc9315b8acb539a
@@ -2037,7 +2037,7 @@ To check if any tables are configured for replication, use [list_cdc_streams](#l
 Use the `set_master_addresses` subcommand to replace the source master address list. Use this if the set of masters on the source changes:
 
 ```sh
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
     alter_universe_replication <source-universe-uuid>_<replication-name> \
     set_master_addresses <source-master-addresses>
 ```
@@ -2050,7 +2050,7 @@ yb-admin -master_addresses <target-master-addresses> \
 Use the `add_table` subcommand to add one or more tables to the existing list:
 
 ```sh
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
     alter_universe_replication <source-universe-uuid>_<replication-name> \
     add_table [ <source-table-ids> ] \
     [ <source-bootstrap-ids> ]
@@ -2069,7 +2069,7 @@ Enter the source universe bootstrap IDs in the same order as their corresponding
 Use the `remove_table` subcommand to remove one or more tables from the existing list:
 
 ```sh
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
     alter_universe_replication <source-universe-uuid>_<replication-name> \
     remove_table <source-table-ids> [ignore-errors]
 ```
@@ -2083,7 +2083,7 @@ yb-admin -master_addresses <target-master-addresses> \
 Use the `rename_id` subcommand to rename xCluster replication streams.
 
 ```sh
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
     alter_universe_replication <source-universe-uuid>_<replication-name> \
     rename_id <source-universe-uuid>_<new-replication-name>
 ```
@@ -2101,7 +2101,7 @@ Deletes universe replication for the specified source universe.
 
 ```sh
 yb-admin \
-    -master_addresses <target-master-addresses> \
+    --master_addresses <target-master-addresses> \
     delete_universe_replication <source-universe-uuid>_<replication-name>
 ```
 
@@ -2117,7 +2117,7 @@ Sets the universe replication to be enabled or disabled.
 
 ```sh
 yb-admin \
-    -master_addresses <target-master-addresses> \
+    --master_addresses <target-master-addresses> \
     set_universe_replication_enabled <source-universe-uuid>_<replication-name>
 ```
 
@@ -2134,7 +2134,7 @@ Sets the xCluster role to STANDBY or ACTIVE.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     change_xcluster_role \
     <role>
 ```
@@ -2146,7 +2146,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     change_xcluster_role STANDBY
 ```
 
@@ -2158,7 +2158,7 @@ Reports the current xCluster safe time for each namespace, which is the time at 
 
 ```sh
 yb-admin \
-    -master_addresses <target-master-addresses> \
+    --master_addresses <target-master-addresses> \
     get_xcluster_safe_time \
     [include_lag_and_skew]
 ```
@@ -2170,7 +2170,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     get_xcluster_safe_time include_lag_and_skew
 ```
 
@@ -2200,7 +2200,7 @@ Verify when the producer and consumer are in sync for a given list of `stream_id
 
 ```sh
 yb-admin \
-    -master_addresses <source-master-addresses> \
+    --master_addresses <source-master-addresses> \
     wait_for_replication_drain \
     <stream-ids> [<timestamp> | minus <interval>]
 ```
@@ -2214,7 +2214,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+    --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     wait_for_replication_drain 000033f1000030008000000000000000,200033f1000030008000000000000002 minus 1m
 ```
 
@@ -2245,7 +2245,7 @@ Use this command when setting up xCluster replication to verify if any tables ar
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     list_cdc_streams
 ```
 
@@ -2255,7 +2255,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     list_cdc_streams
 ```
 
@@ -2267,7 +2267,7 @@ Deletes underlying CDC stream for the specified YB-Master servers.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     delete_cdc_stream <stream-id> \
     [force_delete]
 ```
@@ -2288,7 +2288,7 @@ Mark a set of tables in preparation for setting up xCluster replication.
 
 ```sh
 yb-admin \
-    -master_addresses <source-master-addresses> \
+    --master_addresses <source-master-addresses> \
     bootstrap_cdc_producer <source-table-ids>
 ```
 
@@ -2299,7 +2299,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 172.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 172.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     bootstrap_cdc_producer 000030ad000030008000000000004000
 ```
 
@@ -2319,7 +2319,7 @@ Returns the replication status of all consumer streams. If *source-universe-uuid
 
 ```sh
 yb-admin \
-    -master_addresses <target-master-addresses> \
+    --master_addresses <target-master-addresses> \
     get_replication_status [ <source-universe-uuid>_<replication-name> ]
 ```
 
@@ -2331,7 +2331,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 172.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    --master_addresses 172.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     get_replication_status e260b8b6-e89f-4505-bb8e-b31f74aa29f3
 ```
 
@@ -2358,7 +2358,7 @@ Gets the tablet load move completion percentage for blacklisted nodes.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_leader_blacklist_completion
 ```
 
@@ -2368,7 +2368,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     get_leader_blacklist_completion
 ```
 
@@ -2382,7 +2382,7 @@ After old YB-TServer servers are terminated, you can use this command to clean u
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     change_blacklist [ ADD | REMOVE ] <ip_addr>:<port> \
     [ <ip_addr>:<port> ]...
 ```
@@ -2395,7 +2395,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     change_blacklist \
       ADD node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
 ```
@@ -2406,7 +2406,7 @@ yb-admin \
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     change_leader_blacklist [ ADD | REMOVE ] <ip_addr>:<port> \
     [ <ip_addr>:<port> ]...
 ```
@@ -2419,7 +2419,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     change_leader_blacklist \
       ADD node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
 ```
@@ -2440,7 +2440,7 @@ There is a possibility of downtime.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     leader_stepdown <tablet-id> <dest-ts-uuid>
 ```
 
@@ -2470,7 +2470,7 @@ Enables or disables the load balancer.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     set_load_balancer_enabled [ 0 | 1 ]
 ```
 
@@ -2481,7 +2481,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     set_load_balancer_enabled 0
 ```
 
@@ -2493,7 +2493,7 @@ Returns the cluster load balancer state.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> get_load_balancer_state
+    --master_addresses <master-addresses> get_load_balancer_state
 ```
 
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default is `localhost:7100`.
@@ -2508,7 +2508,7 @@ You can rerun this command periodically until the value reaches `100.0`, indicat
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_load_move_completion
 ```
 
@@ -2533,7 +2533,7 @@ In the following example, the data move is `66.6` percent done.
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     get_load_move_completion
 ```
 
@@ -2551,7 +2551,7 @@ Finds out if the load balancer is idle.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_is_load_balancer_idle
 ```
 
@@ -2561,7 +2561,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     get_is_load_balancer_idle
 ```
 
@@ -2581,7 +2581,7 @@ Returns the current AutoFlags configuration of the universe.
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     get_auto_flags_config
 ```
 
@@ -2590,7 +2590,7 @@ yb-admin \
 **Example**
 
 ```sh
-./bin/yb-admin -master_addresses ip1:7100,ip2:7100,ip3:7100 get_auto_flags_config
+./bin/yb-admin --master_addresses ip1:7100,ip2:7100,ip3:7100 get_auto_flags_config
 ```
 
 If the operation is successful you should see output similar to the following:
@@ -2636,7 +2636,7 @@ Note that `promote_auto_flags` is a cluster-level operation; you don't need to r
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     promote_auto_flags \
     [<max-flags-class> [<promote-non-runtime-flags> [force]]]
 ```
@@ -2650,7 +2650,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     promote_auto_flags kLocalPersisted
 ```
 
@@ -2678,7 +2678,7 @@ YSQL upgrades are not required for clusters where [YSQL is not enabled](../../re
 
 ```sh
 yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     upgrade_ysql
 ```
 
@@ -2688,7 +2688,7 @@ yb-admin \
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
     upgrade_ysql
 ```
 
@@ -2702,8 +2702,8 @@ In certain scenarios, a YSQL upgrade can take longer than 60 seconds, which is t
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
-    -timeout_ms 180000 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --timeout_ms 180000 \
     upgrade_ysql
 ```
 

--- a/docs/content/v2024.2/api/ycql/ddl_create_index.md
+++ b/docs/content/v2024.2/api/ycql/ddl_create_index.md
@@ -187,7 +187,7 @@ After creating a set of indexes with their backfill deferred, you can then trigg
    Launch a backfill job for backfilling all the deferred indexes using the `backfill_indexes_for_table` command as follows:
 
     ```bash
-    bin/yb-admin -master_addresses <ip:port> backfill_indexes_for_table ycql.ybdemo table_name
+    bin/yb-admin --master_addresses <ip:port> backfill_indexes_for_table ycql.ybdemo table_name
     ```
 - Use the [`--defer_index_backfill`](../../../reference/configuration/yb-master#defer-index-backfill) YB-Master flag to force all indexes to be DEFERRED, and run `yb-admin backfill_indexes_for_table` to backfill indexes.
 

--- a/docs/content/v2024.2/api/ysql/exprs/geo_partitioning_helper_functions/func_yb_is_local_table.md
+++ b/docs/content/v2024.2/api/ysql/exprs/geo_partitioning_helper_functions/func_yb_is_local_table.md
@@ -55,7 +55,7 @@ This function is helpful while implementing [Row-level geo-partitioning](../../.
 1. Use [yb-admin](../../../../../admin/yb-admin/) to specify the placement configuration to be used by the cluster as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses <IP1>:7100 modify_placement_info aws.us-west-1.us-west-1c:1,aws.us-east-1.us-east-1a:1,aws.us-east-2.us-east-2c:1 3
+    ./bin/yb-admin --master_addresses <IP1>:7100 modify_placement_info aws.us-west-1.us-west-1c:1,aws.us-east-1.us-east-1a:1,aws.us-east-2.us-east-2c:1 3
     ```
 
 1. Create tablespaces corresponding to the regions used by the cluster created above [using ysqlsh](../../../../ysqlsh/#using-ysqlsh) as follows:

--- a/docs/content/v2024.2/api/ysql/exprs/geo_partitioning_helper_functions/func_yb_server_region.md
+++ b/docs/content/v2024.2/api/ysql/exprs/geo_partitioning_helper_functions/func_yb_server_region.md
@@ -63,7 +63,7 @@ Do the following to create a 3-node multi-region cluster and a geo-partitioned t
 1. Use [yb-admin](../../../../../admin/yb-admin/) to specify the placement configuration to be used by the cluster:
 
     ```sh
-    ./bin/yb-admin -master_addresses <IP1>:7100 modify_placement_info aws.us-west-1.us-west-1c:1,aws.us-east-1.us-east-1a:1,aws.us-east-2.us-east-2c:1 3
+    ./bin/yb-admin --master_addresses <IP1>:7100 modify_placement_info aws.us-west-1.us-west-1c:1,aws.us-east-1.us-east-1a:1,aws.us-east-2.us-east-2c:1 3
     ```
 
 1. Create tablespaces corresponding to the regions used by the cluster created above [using ysqlsh](../../../../ysqlsh/#using-ysqlsh):

--- a/docs/content/v2024.2/deploy/multi-dc/async-replication/async-deployment.md
+++ b/docs/content/v2024.2/deploy/multi-dc/async-replication/async-deployment.md
@@ -35,20 +35,20 @@ After you created the required tables, you can set up unidirectional replication
   - To find a table ID, execute the following command as an admin user:
 
       ```sh
-      ./bin/yb-admin -master_addresses <source_universe_master_addresses> list_tables include_table_id
+      ./bin/yb-admin --master_addresses <source_universe_master_addresses> list_tables include_table_id
       ```
 
       The preceding command lists all the tables, including system tables. To locate a specific table, you can add grep as follows:
 
       ```sh
-      ./bin/yb-admin -master_addresses <source_universe_master_addresses> list_tables include_table_id | grep table_name
+      ./bin/yb-admin --master_addresses <source_universe_master_addresses> list_tables include_table_id | grep table_name
       ```
 
 - Run the following yb-admin [`setup_universe_replication`](../../../../admin/yb-admin/#setup-universe-replication) command from the YugabyteDB home directory in the source universe:
 
     ```sh
     ./bin/yb-admin \
-      -master_addresses <target_universe_master_addresses> \
+      --master_addresses <target_universe_master_addresses> \
       setup_universe_replication <source_universe_UUID>_<replication_stream_name> \
         <source_universe_master_addresses> \
         <table_id>,[<table_id>..]
@@ -58,7 +58,7 @@ After you created the required tables, you can set up unidirectional replication
 
     ```sh
     ./bin/yb-admin \
-      -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+      --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
       setup_universe_replication e260b8b6-e89f-4505-bb8e-b31f74aa29f3_xClusterSetup1 \
         127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         000030a5000030008000000000004000,000030a5000030008000000000004005,dfef757c415c4b2cacc9315b8acb539a
@@ -134,7 +134,7 @@ You can use yb-admin to return the current replication status. The `get_replicat
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7000,127.0.0.2:7000,127.0.0.3:7000 \
+    --master_addresses 127.0.0.1:7000,127.0.0.2:7000,127.0.0.3:7000 \
     get_replication_status
 ```
 
@@ -158,8 +158,8 @@ If both universes use the same certificates, run `yb-admin setup_universe_replic
 Consider the following example:
 
 ```sh
-./bin/yb-admin -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
-  -certs_dir_name /home/yugabyte/yugabyte-tls-config \
+./bin/yb-admin --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+  --certs_dir_name /home/yugabyte/yugabyte-tls-config \
   setup_universe_replication e260b8b6-e89f-4505-bb8e-b31f74aa29f3_xClusterSetup1 \
   127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
   000030a5000030008000000000004000,000030a5000030008000000000004005,dfef757c415c4b2cacc9315b8acb539a
@@ -182,8 +182,8 @@ When universes use different certificates, you need to store the certificates fo
     For example, if you have the target universe's certificates in `/home/yugabyte/yugabyte-tls-config`, then you would run the following:
 
     ```sh
-    ./bin/yb-admin -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
-      -certs_dir_name /home/yugabyte/yugabyte-tls-config \
+    ./bin/yb-admin --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+      --certs_dir_name /home/yugabyte/yugabyte-tls-config \
       setup_universe_replication 00000000-1111-2222-3333-444444444444_xClusterSetup1 \
       127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
       000030a5000030008000000000004000,000030a5000030008000000000004005,dfef757c415c4b2cacc9315b8acb539a
@@ -261,7 +261,7 @@ To create unidirectional replication, perform the following:
 1. Run the replication setup command for the source universe, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses <target_master_addresses> \
+    ./bin/yb-admin --master_addresses <target_master_addresses> \
     setup_universe_replication <source_universe_UUID>_<replication_stream_name> \
     <source_master_addresses> <comma_separated_table_ids>
     ```
@@ -269,7 +269,7 @@ To create unidirectional replication, perform the following:
     Consider the following example:
 
     ```sh
-    ./bin/yb-admin -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
+    ./bin/yb-admin --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
     setup_universe_replication 00000000-1111-2222-3333-444444444444_xClusterSetup1 \
     127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     000033e1000030008000000000004007,000033e100003000800000000000400d,000033e1000030008000000000004013
@@ -322,7 +322,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
 
   ```sh
   kubectl exec -it -n <source_universe_namespace> -t <source_universe_master_leader> -c \
-    <source_universe_container> -- bash -c "/home/yugabyte/bin/yb-admin -master_addresses \
+    <source_universe_container> -- bash -c "/home/yugabyte/bin/yb-admin --master_addresses \
     <target_universe_master_addresses> setup_universe_replication \
     <source_universe_UUID>_<replication_stream_name> <source_universe_master_addresses> \
     <comma_separated_table_ids>"
@@ -332,7 +332,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
 
   ```sh
   kubectl exec -it -n xcluster-source -t yb-master-2 -c yb-master -- bash -c \
-    "/home/yugabyte/bin/yb-admin -master_addresses yb-master-2.yb-masters.xcluster-target.svc.cluster.local, \
+    "/home/yugabyte/bin/yb-admin --master_addresses yb-master-2.yb-masters.xcluster-target.svc.cluster.local, \
     yb-master-1.yb-masters.xcluster-target.svc.cluster.local,yb-master-0.yb-masters.xcluster-target.svc.cluster.local \
     setup_universe_replication ac39666d-c183-45d3-945a-475452deac9f_xCluster_1 \
     yb-master-2.yb-masters.xcluster-source.svc.cluster.local,yb-master-1.yb-masters.xcluster-source.svc.cluster.local, \
@@ -387,14 +387,14 @@ Proceed as follows:
 1. Create a checkpoint on the source universe for all the tables you want to replicate by executing the following command:
 
     ```sh
-    ./bin/yb-admin -master_addresses <source_universe_master_addresses> \
+    ./bin/yb-admin --master_addresses <source_universe_master_addresses> \
     bootstrap_cdc_producer <comma_separated_source_universe_table_ids>
     ```
 
     Consider the following example:
 
     ```sh
-    ./bin/yb-admin -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+    ./bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     bootstrap_cdc_producer 000033e1000030008000000000004000,000033e1000030008000000000004003,000033e1000030008000000000004006
     ```
 
@@ -410,7 +410,7 @@ Proceed as follows:
 1. Execute the following command to set up the replication stream using the bootstrap IDs generated in step 1. Ensure that the bootstrap IDs are in the same order as their corresponding table IDs.
 
     ```sh
-    ./bin/yb-admin -master_addresses <target_universe_master_addresses> setup_universe_replication \
+    ./bin/yb-admin --master_addresses <target_universe_master_addresses> setup_universe_replication \
       <source_universe_uuid>_<replication_stream_name> <source_universe_master_addresses> \
       <comma_separated_source_universe_table_ids> <comma_separated_bootstrap_ids>
     ```
@@ -418,7 +418,7 @@ Proceed as follows:
     Consider the following example:
 
     ```sh
-    ./bin/yb-admin -master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 setup_universe_replication \
+    ./bin/yb-admin --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 setup_universe_replication \
       00000000-1111-2222-3333-444444444444_xCluster1 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
       000033e1000030008000000000004000,000033e1000030008000000000004003,000033e1000030008000000000004006 \
       fb156717174941008e54fa958e613c10,a2a46f5cbf8446a3a5099b5ceeaac28b,c967967523eb4e03bcc201bb464e0679
@@ -470,8 +470,8 @@ When new tables (or partitions) are created, to ensure that all changes from the
 1. Get table IDs of the new partition from the source as follows:
 
     ```sql
-    yb-admin -master_addresses <source_master_ips> \
-    -certs_dir_name <cert_dir> \
+    yb-admin --master_addresses <source_master_ips> \
+    --certs_dir_name <cert_dir> \
     list_tables include_table_id|grep 'order_changes_2023_01'
     ```
 
@@ -484,8 +484,8 @@ When new tables (or partitions) are created, to ensure that all changes from the
 1. Add the new table (or partition) to replication.
 
    ```sql
-   yb-admin -master_addresses <target_master_ips> \
-   -certs_dir_name <cert_dir> \
+   yb-admin --master_addresses <target_master_ips> \
+   --certs_dir_name <cert_dir> \
    alter_universe_replication <replication_group_name> \
    add_table  000033e800003000800000000000410b
    ```
@@ -508,8 +508,8 @@ However, to add a new index to a table that already has data, the following addi
 
    ```sql
    yb-admin
-   -master_addresses <source_master_ips> \
-   -certs_dir_name <cert_dir> \
+   --master_addresses <source_master_ips> \
+   --certs_dir_name <cert_dir> \
    list_tables include_table_id|grep 'my_new_index'
    ```
 
@@ -523,8 +523,8 @@ However, to add a new index to a table that already has data, the following addi
 
    ```sql
    yb-admin
-   -master_addresses <source_master_ips> \
-   -certs_dir_name <cert_dir> \
+   --master_addresses <source_master_ips> \
+   --certs_dir_name <cert_dir> \
    bootstrap_cdc_producer 000033e8000030008000000000004028
    ```
 
@@ -541,8 +541,8 @@ However, to add a new index to a table that already has data, the following addi
 
     ```sql
     yb-admin
-    -master_addresses <target_master_ips> \
-    -certs_dir_name <cert_dir> \
+    --master_addresses <target_master_ips> \
+    --certs_dir_name <cert_dir> \
     alter_universe_replication 59e58153-eec6-4cb5-a858-bf685df52316_east-west \
     add_table  000033e8000030008000000000004028 c8cba563e39c43feb66689514488591c
     ```
@@ -581,16 +581,16 @@ Objects (tables, indexes, partitions) need to be removed from replication before
 1. Get the table ID for the object to be removed from the source.
 
     ```sql
-    yb-admin -master_addresses <source_master_ips> \
-    -certs_dir_name <cert_dir> \
+    yb-admin --master_addresses <source_master_ips> \
+    --certs_dir_name <cert_dir> \
     list_tables include_table_id |grep '<partition_name>'
     ```
 
 1. Remove the table from replication on the target.
 
     ```sql
-    yb-admin -master_addresses <target_master_ips> \
-    -certs_dir_name <cert_dir> \
+    yb-admin --master_addresses <target_master_ips> \
+    --certs_dir_name <cert_dir> \
     alter_universe_replication <replication_group_name> \
     remove_table  000033e800003000800000000000410b
     ```
@@ -603,8 +603,8 @@ Alters involving adding/removing columns or modifying data types require replica
 
     ```sql
     yb-admin
-    -master_addresses <target_master_ips>
-    -certs_dir_name <cert_dir> \
+    --master_addresses <target_master_ips>
+    --certs_dir_name <cert_dir> \
     set_universe_replication_enabled <replication_group_name> 0
     ```
 
@@ -619,8 +619,8 @@ Alters involving adding/removing columns or modifying data types require replica
 
     ```sql
     yb-admin
-    -master_addresses <target_master_ips>
-    -certs_dir_name <cert_dir> \
+    --master_addresses <target_master_ips>
+    --certs_dir_name <cert_dir> \
     set_universe_replication_enabled <replication_group_name> 0
     ```
 

--- a/docs/content/v2024.2/deploy/multi-dc/async-replication/async-transactional-failover.md
+++ b/docs/content/v2024.2/deploy/multi-dc/async-replication/async-transactional-failover.md
@@ -36,7 +36,7 @@ Pause replication on the Standby (B). This step is required to avoid unexpected 
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses <B_master_addresses> \
+    --master_addresses <B_master_addresses> \
     set_universe_replication_enabled <replication_name> 0
 ```
 
@@ -52,7 +52,7 @@ Get the latest consistent time on Standby (B). The `get_xcluster_safe_time` comm
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses <B_master_addresses> \
+    --master_addresses <B_master_addresses> \
     get_xcluster_safe_time include_lag_and_skew
 ```
 
@@ -122,7 +122,7 @@ Restore the database to the `safe_time`:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <B_master_addresses> \
+        --master_addresses <B_master_addresses> \
         list_snapshot_schedules
     ```
 
@@ -153,7 +153,7 @@ Restore the database to the `safe_time`:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <B_master_addresses> \
+        --master_addresses <B_master_addresses> \
         restore_snapshot_schedule <schedule_id> "<safe_time>"
     ```
 
@@ -170,7 +170,7 @@ Restore the database to the `safe_time`:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <B_master_addresses> \
+        --master_addresses <B_master_addresses> \
         list_snapshot_restorations
     ```
 
@@ -195,7 +195,7 @@ Restore the database to the `safe_time`:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses <B_master_addresses> \
+    --master_addresses <B_master_addresses> \
     delete_universe_replication <replication_group_id>
 ```
 
@@ -261,7 +261,7 @@ Disable point-in-time recovery for the database(s) on A:
 - List the snapshot schedules to obtain the schedule ID:
 
     ```sh
-    ./bin/yb-admin -master_addresses <A_master_addresses> \
+    ./bin/yb-admin --master_addresses <A_master_addresses> \
         list_snapshot_schedules
     ```
 
@@ -269,7 +269,7 @@ Disable point-in-time recovery for the database(s) on A:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <A_master_addresses> \
+        --master_addresses <A_master_addresses> \
         delete_snapshot_schedule <schedule_id>
     ```
 
@@ -299,7 +299,7 @@ Drop the replication group on A using the following command:
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses <A_master_addresses> \
+    --master_addresses <A_master_addresses> \
     drop_xcluster_replication <replication_group_id>
 ```
 
@@ -317,7 +317,7 @@ Outbound xCluster Replication group rg1 deleted successfully
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses <A_master_ips> \
+    --master_addresses <A_master_ips> \
     list_cdc_streams
     ```
 
@@ -325,7 +325,7 @@ Outbound xCluster Replication group rg1 deleted successfully
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses <A_master_ips> \
+    --master_addresses <A_master_ips> \
     delete_cdc_stream <streamID>
     ```
 

--- a/docs/content/v2024.2/deploy/multi-dc/async-replication/async-transactional-setup-manual.md
+++ b/docs/content/v2024.2/deploy/multi-dc/async-replication/async-transactional-setup-manual.md
@@ -110,7 +110,7 @@ To set up unidirectional transactional replication manually, do the following:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
+        --master_addresses <standby_master_addresses> \
         create_snapshot_schedule 1 10 ysql.yugabyte
     ```
 
@@ -120,8 +120,8 @@ To set up unidirectional transactional replication manually, do the following:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
-        -certs_dir_name <cert_dir> \
+        --master_addresses <standby_master_addresses> \
+        --certs_dir_name <cert_dir> \
         setup_universe_replication \
         <primary_universe_uuid>_<replication_name> \
         <primary_universe_master_addresses> \
@@ -133,8 +133,8 @@ To set up unidirectional transactional replication manually, do the following:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
-        -certs_dir_name <dir_name> \
+        --master_addresses <standby_master_addresses> \
+        --certs_dir_name <dir_name> \
         change_xcluster_role STANDBY
     ```
 
@@ -241,7 +241,7 @@ get_xcluster_safe_time
 For example:
 
 ```sh
-./tserver/bin/yb-admin -master_addresses 172.150.21.61:7100,172.150.44.121:7100,172.151.23.23:7100 \
+./tserver/bin/yb-admin --master_addresses 172.150.21.61:7100,172.150.44.121:7100,172.151.23.23:7100 \
     get_xcluster_safe_time
 ```
 

--- a/docs/content/v2024.2/deploy/multi-dc/async-replication/includes/semi-automatic-setup.md
+++ b/docs/content/v2024.2/deploy/multi-dc/async-replication/includes/semi-automatic-setup.md
@@ -106,7 +106,7 @@ The following assumes you have set up Primary and Standby universes. Refer to [S
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <primary_master_addresses> \
+        --master_addresses <primary_master_addresses> \
         create_xcluster_checkpoint <replication_group_id> <comma_separated_namespace_names>
     ```
 
@@ -124,7 +124,7 @@ The following assumes you have set up Primary and Standby universes. Refer to [S
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+    --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
     is_xcluster_bootstrap_required repl_group1 yugabyte
     ```
 
@@ -141,7 +141,7 @@ The following assumes you have set up Primary and Standby universes. Refer to [S
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
+        --master_addresses <standby_master_addresses> \
         create_snapshot_schedule 1 10 ysql.yugabyte
     ```
 
@@ -149,7 +149,7 @@ The following assumes you have set up Primary and Standby universes. Refer to [S
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses <primary_master_addresses> \
+    --master_addresses <primary_master_addresses> \
     setup_xcluster_replication <replication_group_id> <standby_master_addresses>
     ```
 

--- a/docs/content/v2024.2/deploy/multi-dc/async-replication/includes/transactional-add-db.md
+++ b/docs/content/v2024.2/deploy/multi-dc/async-replication/includes/transactional-add-db.md
@@ -77,7 +77,7 @@ The database should have at least one table in order to be added to replication.
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses <primary_master_addresses> \
+    --master_addresses <primary_master_addresses> \
     add_namespace_to_xcluster_checkpoint <replication_group_id> <namespace_name>
     ```
 
@@ -96,7 +96,7 @@ The database should have at least one table in order to be added to replication.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <standby_master_addresses> \
+        --master_addresses <standby_master_addresses> \
         create_snapshot_schedule 1 10 ysql.yugabyte
     ```
 
@@ -104,7 +104,7 @@ The database should have at least one table in order to be added to replication.
 
     ```sh
     ./bin/yb-admin \
-    -master_addresses <primary_master_addresses> \
+    --master_addresses <primary_master_addresses> \
     add_namespace_to_xcluster_replication <replication_group_id> <namespace_name> <standby_master_addresses>
     ```
 

--- a/docs/content/v2024.2/deploy/multi-dc/read-replica-clusters.md
+++ b/docs/content/v2024.2/deploy/multi-dc/read-replica-clusters.md
@@ -27,7 +27,7 @@ You can deploy a read replica cluster that asynchronously replicates data with a
 1. Define the primary cluster placement using the [`yb-admin modify_placement_info`](../../../admin/yb-admin/#modify-placement-info) command, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses ip1:7100,ip2:7100,ip3:7100 modify_placement_info <placement_info> <replication_factor> [placement_uuid]
+    ./bin/yb-admin --master_addresses ip1:7100,ip2:7100,ip3:7100 modify_placement_info <placement_info> <replication_factor> [placement_uuid]
     ```
 
     - *placement_info*: Comma-separated list of availability zones using the format `<cloud1.region1.zone1>,<cloud2.region2.zone2>, ...`
@@ -37,7 +37,7 @@ You can deploy a read replica cluster that asynchronously replicates data with a
 1. Define the read replica placement using the [`yb-admin add_read_replica_placement_info`](../../../admin/yb-admin/#add-read-replica-placement-info) command, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses ip1:7100,ip2:7100,ip3:7100 add_read_replica_placement_info <placement_info> <replication_factor> [placement_uuid]
+    ./bin/yb-admin --master_addresses ip1:7100,ip2:7100,ip3:7100 add_read_replica_placement_info <placement_info> <replication_factor> [placement_uuid]
     ```
 
     - *placement_info*: Comma-separated list of availability zones, using the format `<cloud1.region1.zone1>:<num_replicas_in_zone1>,<cloud2.region2.zone2>:<num_replicas_in_zone2>,...` These read replica availability zones must be uniquely different from the primary availability zones defined in step 2. If you want to use the same cloud, region, and availability zone as a primary cluster, one option is to suffix the zone with `_rr` (for read replica). For example, `c1.r1.z1_rr:2`.

--- a/docs/content/v2024.2/develop/multi-cloud/multicloud-migration.md
+++ b/docs/content/v2024.2/develop/multi-cloud/multicloud-migration.md
@@ -66,7 +66,7 @@ The basic flow of bootstrapping is as follows:
 1. Create a checkpoint for all the tables in the AWS universe. For example:
 
     ```bash
-    ./bin/yb-admin -master_addresses <AWS_universe_master_addresses> \
+    ./bin/yb-admin --master_addresses <AWS_universe_master_addresses> \
             bootstrap_cdc_producer <comma_separated_source_universe_table_ids>
     ```
 
@@ -85,7 +85,7 @@ For detailed instructions on how to set up replication, see [Set up unidirection
 A simple way to set up replication is as follows:
 
 ```bash
-./bin/yb-admin -master_addresses <GCP_universe_master_addresses> setup_universe_replication \
+./bin/yb-admin --master_addresses <GCP_universe_master_addresses> setup_universe_replication \
   <AWS_universe_uuid>_<replication_stream_name> <AWS_universe_master_addresses> \
   <comma_separated_source_universe_table_ids> <comma_separated_bootstrap_ids>
 ```
@@ -111,8 +111,8 @@ The basic flow of switchover is as follows:
 
   ```bash
   ./bin/yb-admin \
-      -master_addresses <GCP_master_addresses> \
-      -certs_dir_name <cert_dir> \
+      --master_addresses <GCP_master_addresses> \
+      --certs_dir_name <cert_dir> \
       change_xcluster_role ACTIVE
   ```
 

--- a/docs/content/v2024.2/explore/cluster-management/point-in-time-recovery-ycql.md
+++ b/docs/content/v2024.2/explore/cluster-management/point-in-time-recovery-ycql.md
@@ -78,7 +78,7 @@ Create and populate a table, get a timestamp to which you'll restore, and then w
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         create_snapshot_schedule 1 10 ycql.pitr
     ```
 
@@ -92,7 +92,7 @@ Create and populate a table, get a timestamp to which you'll restore, and then w
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshot_schedules
     ```
 
@@ -152,7 +152,7 @@ Create and populate a table, get a timestamp to which you'll restore, and then w
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 0e4ceb83-fe3d-43da-83c3-013a8ef592ca 1620418817729963
     ```
 
@@ -167,7 +167,7 @@ Create and populate a table, get a timestamp to which you'll restore, and then w
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 

--- a/docs/content/v2024.2/explore/cluster-management/point-in-time-recovery-ysql.md
+++ b/docs/content/v2024.2/explore/cluster-management/point-in-time-recovery-ysql.md
@@ -77,7 +77,7 @@ Create a snapshot as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         create_snapshot_schedule 1 10 ysql.yugabyte
     ```
 
@@ -91,7 +91,7 @@ Create a snapshot as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshot_schedules
     ```
 
@@ -152,7 +152,7 @@ Create a snapshot as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 0e4ceb83-fe3d-43da-83c3-013a8ef592ca 1620418817729963
     ```
 
@@ -167,7 +167,7 @@ Create a snapshot as follows:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 
@@ -232,7 +232,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         create_snapshot_schedule 1 10 ysql.yugabyte
     ```
 
@@ -246,7 +246,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshot_schedules
     ```
 
@@ -287,7 +287,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 1fb2d85a-3608-4cb1-af63-3e4062300dc1 1681964544554620
     ```
 
@@ -302,7 +302,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 
@@ -339,7 +339,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshot_schedules
     ```
 
@@ -399,7 +399,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 1fb2d85a-3608-4cb1-af63-3e4062300dc1 1681965106732671
     ```
 
@@ -414,7 +414,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 
@@ -462,7 +462,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshot_schedules
     ```
 
@@ -530,7 +530,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 1fb2d85a-3608-4cb1-af63-3e4062300dc1 1681965472490517
     ```
 
@@ -545,7 +545,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 
@@ -617,7 +617,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 1fb2d85a-3608-4cb1-af63-3e4062300dc1 1681965684502460
     ```
 
@@ -632,7 +632,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 
@@ -707,7 +707,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         restore_snapshot_schedule 1fb2d85a-3608-4cb1-af63-3e4062300dc1 1681965868912921
     ```
 
@@ -722,7 +722,7 @@ Before you begin, if a local universe is currently running, first [destroy it](.
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+        --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
         list_snapshots
     ```
 

--- a/docs/content/v2024.2/explore/colocation.md
+++ b/docs/content/v2024.2/explore/colocation.md
@@ -211,7 +211,7 @@ To set up xCluster for colocated tables, do the following:
 1. Get the parent table UUID for the colocated database.
 
     ```sh
-    ./yb-admin -master_addresses <source_master_addresses> list_tables include_table_id | grep -i <database_name> | grep -i "colocation.parent.uuid"
+    ./yb-admin --master_addresses <source_master_addresses> list_tables include_table_id | grep -i <database_name> | grep -i "colocation.parent.uuid"
     ```
 
     ```output
@@ -221,13 +221,13 @@ To set up xCluster for colocated tables, do the following:
 1. Set up replication for the parent colocation table using yb-admin.
 
     ```sh
-    ./yb-admin -master_addresses <target_master_addresses> setup_universe_replication <replication_group_name> <source_master_addresses> <parent_colocated_table_uuid>
+    ./yb-admin --master_addresses <target_master_addresses> setup_universe_replication <replication_group_name> <source_master_addresses> <parent_colocated_table_uuid>
     ```
 
     For example:
 
     ```sh
-    ./yb-admin -master_addresses 127.0.0.2 setup_universe_replication A1-B2 127.0.0.1 00004000000030008000000000004004.colocation.parent.uuid
+    ./yb-admin --master_addresses 127.0.0.2 setup_universe_replication A1-B2 127.0.0.1 00004000000030008000000000004004.colocation.parent.uuid
     ```
 
     ```output

--- a/docs/content/v2024.2/explore/going-beyond-sql/asynchronous-replication-ysql.md
+++ b/docs/content/v2024.2/explore/going-beyond-sql/asynchronous-replication-ysql.md
@@ -77,7 +77,7 @@ Having two identical tables on your clusters allows you to set up xCluster repli
 To configure "Data Center - West" to be the target of data changes from the "Data Center - East" cluster, you need to use the [yb-admin](../../../admin/yb-admin/) utility [setup_universe_replication](../../../admin/yb-admin/#xcluster-replication-commands) command. The syntax is as follows:
 
 ```sh.output
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
     setup_universe_replication <source-universe-uuid> \
     <source-master-addresses> <source-table-ids>
 ```
@@ -90,7 +90,7 @@ yb-admin -master_addresses <target-master-addresses> \
 Based on actual values you obtained from the YB-Master UI, run the yb-admin `setup_universe_replication` command from your YugabyteDB home directory similar to the one shown in the following example:
 
 ```sh
-./bin/yb-admin -master_addresses 127.0.0.2:7100 \
+./bin/yb-admin --master_addresses 127.0.0.2:7100 \
     setup_universe_replication 7acd6399-657d-42dc-a90a-646869898c2d \
     127.0.0.1:7100 000033e8000030008000000000004000
 ```
@@ -151,7 +151,7 @@ Look up the source UUID in the source YB-Master UI (<http://127.0.0.2:7000>), an
 Based on actual values you obtained from the YB-Master UI, run the yb-admin `setup_universe_replication` command similar to the one shown in the following example:
 
 ```sh
-./bin/yb-admin -master_addresses 127.0.0.1:7100 \
+./bin/yb-admin --master_addresses 127.0.0.1:7100 \
     setup_universe_replication 0a315687-e9bd-430f-b6f4-ac831193a394 \
     127.0.0.2:7100 000030a9000030008000000000004000
 ```
@@ -208,7 +208,7 @@ When the bidirectional replication has been configured, you can add data to the 
 You can add more tables to an existing replication using the yb-admin command `alter_universe_replication` `add_table`:
 
 ```sh.output
-yb-admin -master_addresses <target-master-addresses> \
+yb-admin --master_addresses <target-master-addresses> \
         alter_universe_replication <source-universe-uuid> \
         add_table <source-table-ids>
 ```
@@ -216,7 +216,7 @@ yb-admin -master_addresses <target-master-addresses> \
 The following is an example command:
 
 ```sh
-./bin/yb-admin -master_addresses 127.0.0.2:7100 \
+./bin/yb-admin --master_addresses 127.0.0.2:7100 \
     alter_universe_replication 7acd6399-657d-42dc-a90a-646869898c2d \
     add_table 000030a9000030008000000000004000
 ```

--- a/docs/content/v2024.2/explore/multi-region-deployments/read-replicas-ycql.md
+++ b/docs/content/v2024.2/explore/multi-region-deployments/read-replicas-ycql.md
@@ -62,7 +62,7 @@ For more info, please use: yb-ctl status
 The following command instructs the masters to create three replicas for each tablet distributed across the three zones:
 
 ```shell
-$ ./bin/yb-admin -master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 modify_placement_info c.r.z1,c.r.z2,c.r.z3 3 live
+$ ./bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 modify_placement_info c.r.z1,c.r.z2,c.r.z3 3 live
 ```
 
 The following illustration demonstrates the primary cluster visible via [YugabyteDB Anywhere](../../../yugabyte-platform/):
@@ -166,7 +166,7 @@ The following commands add three new nodes to a read replica cluster in region `
 ./bin/yb-ctl add_node --placement_info "c.r2.z22" --tserver_flags "placement_uuid=rr"
 ./bin/yb-ctl add_node --placement_info "c.r2.z23" --tserver_flags "placement_uuid=rr"
 
-./bin/yb-admin -master_addresses 127.0.0.1:7100,127.0.0.2,127.0.0.3 add_read_replica_placement_info c.r2.z21:1,c.r2.z22:1,c.r2.z23:1 3 rr
+./bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2,127.0.0.3 add_read_replica_placement_info c.r2.z21:1,c.r2.z22:1,c.r2.z23:1 3 rr
 ```
 
 The following illustration demonstrates the setup of the two clusters, one of which is primary and another one is read replica visible via YugabyteDB Anywhere:

--- a/docs/content/v2024.2/launch-and-manage/monitor-and-alert/xcluster-monitor.md
+++ b/docs/content/v2024.2/launch-and-manage/monitor-and-alert/xcluster-monitor.md
@@ -77,7 +77,7 @@ To list outgoing groups on the Primary universe, use the [list_xcluster_outbound
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses <primary_master_addresses> \
+    --master_addresses <primary_master_addresses> \
     list_xcluster_outbound_replication_groups \
     [namespace_id]
 ```
@@ -86,7 +86,7 @@ To list inbound groups on the Standby universe, use the [list_universe_replicati
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses <standby_master_addresses> \
+    --master_addresses <standby_master_addresses> \
     list_universe_replications \
     [namespace_id]
 ```
@@ -95,7 +95,7 @@ To get the status of the replication group, use [get_replication_status](../../.
 
 ```sh
 yb-admin \
-    -master_addresses <target-master-addresses> \
+    --master_addresses <target-master-addresses> \
     get_replication_status \
     [<replication_id>]
 ```
@@ -160,7 +160,7 @@ Inbound xCluster Replications:
 
   ```sh
   yb-admin \
-      -master_addresses <standby_master_addresses> \
+      --master_addresses <standby_master_addresses> \
       get_xcluster_safe_time \
       [include_lag_and_skew]
   ```

--- a/docs/content/v2024.2/manage/backup-restore/point-in-time-recovery.md
+++ b/docs/content/v2024.2/manage/backup-restore/point-in-time-recovery.md
@@ -78,13 +78,13 @@ To create a schedule and enable PITR, use the [`create_snapshot_schedule`](../..
 For example, to create a schedule that produces a snapshot of a YSQL database once a day (every 1,440 minutes) and retains it for three days (4,320 minutes), you would execute the following command:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot_schedule 1440 4320 ysql.<database_name>
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot_schedule 1440 4320 ysql.<database_name>
 ```
 
 The equivalent command for a YCQL keyspace would be the following:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot_schedule 1440 4320 <keyspace_name>
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot_schedule 1440 4320 <keyspace_name>
 ```
 
 The following output is a unique ID of the newly-created snapshot schedule:
@@ -102,7 +102,7 @@ You can use this ID to [delete the schedule](#delete-a-schedule) or [restore to 
 To delete a schedule and disable PITR, use the following [`delete_snapshot_schedule`](../../../admin/yb-admin/#delete-snapshot-schedule) command that takes the ID of the schedule to be deleted as a parameter:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
 ```
 
 ### List schedules
@@ -110,7 +110,7 @@ To delete a schedule and disable PITR, use the following [`delete_snapshot_sched
 To see a list of schedules that currently exist in the cluster, use the following [`list_snapshot_schedules`](../../../admin/yb-admin/#list-snapshot-schedules) command:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshot_schedules
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshot_schedules
 ```
 
 ```output.json
@@ -141,7 +141,7 @@ To see a list of schedules that currently exist in the cluster, use the followin
 You can also use the same command to view the information about a particular schedule by providing its ID as a parameter, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshot_schedules 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshot_schedules 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256
 ```
 
 ## Restore to a point in time
@@ -162,7 +162,7 @@ If a database or a keyspace has an associated snapshot schedule, you can use tha
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <ip1:7100,ip2:7100,ip3:7100> \
+        --master_addresses <ip1:7100,ip2:7100,ip3:7100> \
         restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 1651435200
     ```
 
@@ -170,7 +170,7 @@ If a database or a keyspace has an associated snapshot schedule, you can use tha
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <ip1:7100,ip2:7100,ip3:7100> \
+        --master_addresses <ip1:7100,ip2:7100,ip3:7100> \
         restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 "2022-05-01 13:00-0700"
     ```
 
@@ -180,7 +180,7 @@ If a database or a keyspace has an associated snapshot schedule, you can use tha
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <ip1:7100,ip2:7100,ip3:7100> \
+        --master_addresses <ip1:7100,ip2:7100,ip3:7100> \
         restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 minus 5m
     ```
 
@@ -188,7 +188,7 @@ If a database or a keyspace has an associated snapshot schedule, you can use tha
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <ip1:7100,ip2:7100,ip3:7100> \
+        --master_addresses <ip1:7100,ip2:7100,ip3:7100> \
         restore_snapshot_schedule 6eaaa4fb-397f-41e2-a8fe-a93e0c9f5256 minus 1h
     ```
 

--- a/docs/content/v2024.2/manage/backup-restore/snapshot-ysql.md
+++ b/docs/content/v2024.2/manage/backup-restore/snapshot-ysql.md
@@ -42,7 +42,7 @@ Using distributed snapshots allows you to back up a database and then restore it
 To back up a database, create a snapshot using the [`create_database_snapshot`](../../../admin/yb-admin/#create-database-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> create_database_snapshot ysql.<database_name>
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> create_database_snapshot ysql.<database_name>
 ```
 
 A unique ID for the snapshot is returned, as shown in the following sample output:
@@ -56,7 +56,7 @@ You can then use this ID to check the status of the snapshot, [delete it](#delet
 The `create_database_snapshot` command exits immediately, but the snapshot may take some time to complete. Before using the snapshot, verify its status by executing the [`list_snapshots`](../../../admin/yb-admin/#list-snapshots) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshots
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshots
 ```
 
 All the snapshots in the cluster are listed, along with their statuses. You can find the ID of the new snapshot and make sure it has been completed, as shown in the following  sample output:
@@ -71,7 +71,7 @@ Snapshot UUID                           State       Creation Time
 Snapshots never expire and are retained as long as the cluster exists. If you no longer need a snapshot, you can delete it by executing the [`delete_snapshot`](../../../admin/yb-admin/#delete-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794
 ```
 
 ## Restore a snapshot
@@ -79,7 +79,7 @@ Snapshots never expire and are retained as long as the cluster exists. If you no
 To restore the data backed up in one of the previously created snapshots, run the [`restore_snapshot`](../../../admin/yb-admin/#restore-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> restore_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> restore_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794
 ```
 
 This command rolls back the database to the state which it had when the snapshot was created. The restore happens in-place: it changes the state of the existing database in the same cluster.
@@ -127,7 +127,7 @@ To move a snapshot to external storage, gather all the relevant files from all t
 1. Create the snapshot metadata file by executing the [`export_snapshot`](../../../admin/yb-admin/#export-snapshot) command and providing the ID of the snapshot, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> export_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794 <database_name>.snapshot
+    ./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> export_snapshot 0d4b4935-2c95-4523-95ab-9ead1e95e794 <database_name>.snapshot
     ```
 
 1. Copy the newly-created YSQL metadata file (`<database_name>_schema.sql`) and the snapshot metadata file (`<database_name>.snapshot`) to the external storage.
@@ -176,7 +176,7 @@ You can restore a snapshot that you have [moved to external storage](#move-a-sna
 1. Fetch the snapshot metadata file from the external storage and apply it by running the [`import_snapshot`](../../../admin/yb-admin/#import-snapshot) command, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> import_snapshot <database_name>.snapshot <database_name>
+    ./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> import_snapshot <database_name>.snapshot <database_name>
     ```
 
     Notice that the following output contains the mapping between the old tablet IDs and the new tablet IDs:

--- a/docs/content/v2024.2/manage/backup-restore/snapshots-ycql.md
+++ b/docs/content/v2024.2/manage/backup-restore/snapshots-ycql.md
@@ -41,13 +41,13 @@ Using distributed snapshots allows you to back up a database and then restore it
 To back up a keyspace with all its tables and indexes, create a snapshot using the [`create_keyspace_snapshot`](../../../admin/yb-admin/#create-keyspace-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> create_keyspace_snapshot my_keyspace
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> create_keyspace_snapshot my_keyspace
 ```
 
 To back up a single table with its indexes, use the [`create_snapshot`](../../../admin/yb-admin/#create-snapshot) command instead, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot my_keyspace my_table
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> create_snapshot my_keyspace my_table
 ```
 
 When you execute either of the preceding commands, a unique ID for the snapshot is returned, as per the following output:
@@ -61,7 +61,7 @@ You can then use this ID to check the status of the snapshot, [delete it](#delet
 Even though the `create_keyspace_snapshot` and `create_snapshot` commands exit immediately, the snapshot may take some time to complete. Before using the snapshot, verify its status with the [`list_snapshots`](../../../admin/yb-admin/#list-snapshots) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshots
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> list_snapshots
 ```
 
 The preceding command lists the snapshots in the cluster, along with their states. You can find the ID of the new snapshot and make sure it has been completed, as shown in the following  sample output:
@@ -76,7 +76,7 @@ Snapshot UUID                           State       Creation Time
 Snapshots never expire and are retained as long as the cluster exists. If you no longer need a snapshot, you can delete it with the [`delete_snapshot`](../../../admin/yb-admin/#delete-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> delete_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef
 ```
 
 ## Restore a snapshot
@@ -84,7 +84,7 @@ Snapshots never expire and are retained as long as the cluster exists. If you no
 To restore the data backed up in one of the previously created snapshots, run the [`restore_snapshot`](../../../admin/yb-admin/#restore-snapshot) command, as follows:
 
 ```sh
-./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> restore_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef
+./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> restore_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef
 ```
 
 This command rolls back the database to the state which it had when the snapshot was created. The restore happens in-place: it changes the state of the existing database in the same cluster.
@@ -102,7 +102,7 @@ To move a snapshot to external storage, gather all the relevant files from all t
 1. Create the snapshot metadata file by running the [`export_snapshot`](../../../admin/yb-admin/#export-snapshot) command and providing the ID of the snapshot:
 
     ```sh
-    ./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> export_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef my_keyspace.snapshot
+    ./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> export_snapshot 6e7e85b0-13ef-4073-9ab7-224cb77f22ef my_keyspace.snapshot
     ```
 
 1. Copy the newly created snapshot metadata file (`my_keyspace.snapshot`) to the external storage.
@@ -133,7 +133,7 @@ You can restore a snapshot that you have [moved to external storage](#move-a-sna
 1. Retrieve the snapshot metadata file from the external storage and apply it by running the [`import_snapshot`](../../../admin/yb-admin/#import-snapshot) command, as follows:
 
     ```sh
-    ./bin/yb-admin -master_addresses <ip1:7100,ip2:7100,ip3:7100> import_snapshot my_keyspace.snapshot my_keyspace
+    ./bin/yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> import_snapshot my_keyspace.snapshot my_keyspace
     ```
 
     Notice that the following output contains the mapping between the old tablet IDs and the new tablet IDs:

--- a/docs/content/v2024.2/manage/change-cluster-config.md
+++ b/docs/content/v2024.2/manage/change-cluster-config.md
@@ -101,13 +101,13 @@ The following commands can be run from one of the old master nodes. You can firs
 
 ```sh
 export MASTERS=node1:7100,node2:7100,node3:7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_blacklist ADD node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
+~/master/bin/yb-admin --master_addresses $MASTERS change_blacklist ADD node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
 ```
 
 Verify that the blacklist information looks similar to the following:
 
 ```sh
-~/master/bin/yb-admin -master_addresses $MASTERS get_universe_config
+~/master/bin/yb-admin --master_addresses $MASTERS get_universe_config
 Config:
 version: 5
 server_blacklist {
@@ -131,7 +131,7 @@ server_blacklist {
 Next, wait for the data move to complete. You can check the percentage completion by running the following command:
 
 ```sh
-~/master/bin/yb-admin -master_addresses $MASTERS get_load_move_completion
+~/master/bin/yb-admin --master_addresses $MASTERS get_load_move_completion
 Percent complete = 66.6
 ```
 
@@ -158,19 +158,19 @@ If any error log is reported on the command line from the following steps, check
 
 ```sh
 export MASTERS=node1:7100,node2:7100,node3:7100,node7:7100,node8:7100,node9:7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config ADD_SERVER node7 7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config REMOVE_SERVER node1 7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config ADD_SERVER node8 7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config REMOVE_SERVER node2 7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config ADD_SERVER node9 7100
-~/master/bin/yb-admin -master_addresses $MASTERS change_master_config REMOVE_SERVER node3 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config ADD_SERVER node7 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config REMOVE_SERVER node1 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config ADD_SERVER node8 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config REMOVE_SERVER node2 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config ADD_SERVER node9 7100
+~/master/bin/yb-admin --master_addresses $MASTERS change_master_config REMOVE_SERVER node3 7100
 ```
 
 Now ensure that the master leader is one of the new master nodes as follows:
 
 ```sh
 $ export MASTERS=node7:7100,node8:7100,node9:7100
-$ ~/master/bin/yb-admin -master_addresses $MASTERS list_all_masters
+$ ~/master/bin/yb-admin --master_addresses $MASTERS list_all_masters
 ```
 
 ```output
@@ -197,7 +197,7 @@ Updating master addresses is needed in case the yb-tserver server is restarted.
 The old nodes are not part of the universe any more and can be shut down. After the old YB-TServers are terminated, you can cleanup the blacklist from the master configuration using the following command:
 
 ```sh
-~/master/bin/yb-admin -master_addresses $MASTERS change_blacklist REMOVE node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
+~/master/bin/yb-admin --master_addresses $MASTERS change_blacklist REMOVE node1:9100 node2:9100 node3:9100 node4:9100 node5:9100 node6:9100
 ```
 
 {{< note title="Tip" >}}
@@ -207,5 +207,5 @@ Cleaning up the blacklist server will help reuse the older IPs in case they get 
 Ensure there are no `server_blacklist` entries returned by the command:
 
 ```sh
-~/master/bin/yb-admin -master_addresses $MASTERS get_universe_config
+~/master/bin/yb-admin --master_addresses $MASTERS get_universe_config
 ```

--- a/docs/content/v2024.2/manage/upgrade-deployment.md
+++ b/docs/content/v2024.2/manage/upgrade-deployment.md
@@ -149,7 +149,7 @@ New YugabyteDB features may require changes to the format of data that is sent o
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <master-addresses> \
+        --master_addresses <master-addresses> \
         promote_auto_flags
     ```
 
@@ -189,7 +189,7 @@ Use the [yb-admin](../../admin/yb-admin/) utility to upgrade the YSQL system cat
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses <master-addresses> \
+    --master_addresses <master-addresses> \
     upgrade_ysql
 ```
 
@@ -203,8 +203,8 @@ In certain scenarios, a YSQL upgrade can take longer than 60 seconds, which is t
 
 ```sh
 ./bin/yb-admin \
-    -master_addresses ip1:7100,ip2:7100,ip3:7100 \
-    -timeout_ms 180000 \
+    --master_addresses ip1:7100,ip2:7100,ip3:7100 \
+    --timeout_ms 180000 \
     upgrade_ysql
 ```
 
@@ -293,7 +293,7 @@ During the Monitor phase, do the following:
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <master-addresses> \
+        --master_addresses <master-addresses> \
         promote_auto_flags kLocalVolatile
     ```
 
@@ -324,7 +324,7 @@ If you need to roll back an upgrade where volatile AutoFlags were enabled, depen
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses <master-addresses> \
+        --master_addresses <master-addresses> \
         rollback_auto_flags <previous_config_version>
     ```
 
@@ -342,7 +342,7 @@ If you need to roll back an upgrade where volatile AutoFlags were enabled, depen
 
     ```sh
     ./bin/yb-admin \
-        -master_addresses ip1:7100,ip2:7100,ip3:7100 \
+        --master_addresses ip1:7100,ip2:7100,ip3:7100 \
         rollback_auto_flags 2
     ```
 

--- a/docs/content/v2024.2/reference/configuration/yugabyted.md
+++ b/docs/content/v2024.2/reference/configuration/yugabyted.md
@@ -82,7 +82,7 @@ $ ./bin/yugabyted -h
 ```
 
 ```sh
-$ ./bin/yugabyted -help
+$ ./bin/yugabyted --help
 ```
 
 For help with specific yugabyted commands, run 'yugabyted [ command ] -h'. For example, you can print the command-line help for the `yugabyted start` command by running the following:

--- a/docs/content/v2024.2/secure/encryption-at-rest.md
+++ b/docs/content/v2024.2/secure/encryption-at-rest.md
@@ -38,7 +38,7 @@ You enable encryption as follows:
 1. Copy the key to master nodes. In the following example, assume a 3-node RF=3 cluster with `MASTER_ADDRESSES=ip1:7100,ip2:7100,ip3:7100`. Choose any string `<key_id>` for this key and use yb-admin to copy the key to each of the masters:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES add_universe_key_to_all_masters <key_id> /<path_to_universe_key>
+    yb-admin --master_addresses $MASTER_ADDRESSES add_universe_key_to_all_masters <key_id> /<path_to_universe_key>
     ```
 
     The preceding operation does not perform the key rotation, but rather seeds each master's in-memory state. The key only lives in memory, and the plaintext key is never persisted to the disk.
@@ -46,13 +46,13 @@ You enable encryption as follows:
 1. Enable cluster-wide encryption. Before rotating the key, ensure that the masters know about `<key_id>`:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES all_masters_have_universe_key_in_memory <key_id>
+    yb-admin --master_addresses $MASTER_ADDRESSES all_masters_have_universe_key_in_memory <key_id>
     ```
 
     If the preceding command fails, rerun step 2. Once this succeeds, instruct the cluster to start using the new universe key, as follows:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES rotate_universe_key_in_memory <key_id>
+    yb-admin --master_addresses $MASTER_ADDRESSES rotate_universe_key_in_memory <key_id>
     ```
 
     Because data is encrypted in the background as part of flushes to disk and compactions, only new data is encrypted. Therefore, the call should return quickly.
@@ -60,7 +60,7 @@ You enable encryption as follows:
 1. Verify that encryption has been enabled. To do this, check the encryption status of the cluster by executing the following yb-admin command:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES is_encryption_enabled
+    yb-admin --master_addresses $MASTER_ADDRESSES is_encryption_enabled
     ```
 
     Expect the following output:
@@ -84,7 +84,7 @@ You can rotate the new key as follows:
 1. Copy the new key to master nodes, informing the master nodes about the new key, as follows:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES add_universe_key_to_all_masters
+    yb-admin --master_addresses $MASTER_ADDRESSES add_universe_key_to_all_masters
     <key_id_2> /path_to_universe_key_2
     ```
 
@@ -93,7 +93,7 @@ You can rotate the new key as follows:
 1. Ensure that the masters know about the key, and then perform the rotation, as follows:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES rotate_universe_key_in_memory <key_id_2>
+    yb-admin --master_addresses $MASTER_ADDRESSES rotate_universe_key_in_memory <key_id_2>
     ```
 
     Because this key is only used for new data and can only eventually encrypt older data through compactions, it is best to ensure old keys remain secure.
@@ -101,7 +101,7 @@ You can rotate the new key as follows:
 1. Verify the new key. To do this, check that the new key is encrypting the cluster, as follows:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES is_encryption_enabled
+    yb-admin --master_addresses $MASTER_ADDRESSES is_encryption_enabled
     ```
 
     Expect the following output:
@@ -119,13 +119,13 @@ You can disable cluster-wide encryption as follows:
 1. Disable encryption by executing the following yb-admin command:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES disable_encryption
+    yb-admin --master_addresses $MASTER_ADDRESSES disable_encryption
     ```
 
 1. Verify that the encryption has been disabled by executing the following command:
 
     ```sh
-    yb-admin -master_addresses $MASTER_ADDRESSES is_encryption_enabled
+    yb-admin --master_addresses $MASTER_ADDRESSES is_encryption_enabled
     ```
 
     Expect the following output:

--- a/docs/content/v2024.2/secure/tls-encryption/connect-to-cluster.md
+++ b/docs/content/v2024.2/secure/tls-encryption/connect-to-cluster.md
@@ -59,7 +59,7 @@ For example, the following command lists the master information for the TLS-enab
 
 ```sh
 export MASTERS=node1:7100,node2:7100,node3:7100
-./bin/yb-admin --master_addresses $MASTERS -certs_dir_name ~/yugabyte-tls-config list_all_masters
+./bin/yb-admin --master_addresses $MASTERS --certs_dir_name ~/yugabyte-tls-config list_all_masters
 ```
 
 You should see the following output format:


### PR DESCRIPTION
We use a mix of single dash and double dash flags in our docs. This creates a bit of confusion. Single dash is usually used for "short" names, so this diff changes all the long-form flags (like `--master_addresses`) to use two dashes.
DOC-910