### PR TITLE
[DOC-911] Language tabs are not working in Quick start for macOS page

### DIFF
--- a/docs/content/preview/tutorials/quick-start/include-prerequisites-macos.md
+++ b/docs/content/preview/tutorials/quick-start/include-prerequisites-macos.md
@@ -1,0 +1,30 @@
+<!--
++++
+private = true
+block_indexing = true
++++
+-->
+
+Before installing YugabyteDB, ensure that you have the following available:
+
+- <i class="fa-brands fa-apple" aria-hidden="true"></i> macOS 10.12 or later. If you are on Apple silicon, you need to download the macOS ARM package.
+
+- Python 3. To check the version, execute the following command:
+
+    ```sh
+    python --version
+    ```
+
+    ```output
+    Python 3.7.3
+    ```
+
+- `wget` or `curl`.
+
+    Note that the following instructions use the `wget` command to download files. If you prefer to use `curl` (included in macOS), you can replace `wget` with `curl -O`.
+
+    To install `wget` on your Mac, you can run the following command if you use Homebrew:
+
+    ```sh
+    brew install wget
+    ```

--- a/docs/content/preview/tutorials/quick-start/macos.md
+++ b/docs/content/preview/tutorials/quick-start/macos.md
@@ -67,29 +67,7 @@ Installing YugabyteDB involves completing [prerequisites](#prerequisites) and [d
 
 ### Prerequisites
 
-Before installing YugabyteDB, ensure that you have the following available:
-
-- <i class="fa-brands fa-apple" aria-hidden="true"></i> macOS 10.12 or later. If you are on Apple silicon, you need to download the macOS ARM package.
-
-- Python 3. To check the version, execute the following command:
-
-    ```sh
-    python --version
-    ```
-
-    ```output
-    Python 3.7.3
-    ```
-
-- `wget` or `curl`.
-
-    Note that the following instructions use the `wget` command to download files. If you prefer to use `curl` (included in macOS), you can replace `wget` with `curl -O`.
-
-    To install `wget` on your Mac, you can run the following command if you use Homebrew:
-
-    ```sh
-    brew install wget
-    ```
+{{% readfile "include-prerequisites-macos.md" %}}
 
 #### Set file limits
 


### PR DESCRIPTION
Odd behavior:
- https://docs.yugabyte.com/preview/tutorials/quick-start/linux/#build-an-application
- https://docs.yugabyte.com/preview/tutorials/quick-start/macos/#build-an-application

The tabs in this section don't work correctly on the macos page, but work fine on the linux page.

@netlify /preview/tutorials/quick-start/macos/