### PR TITLE
[doc] Correct units for wait queue metric

### DIFF
--- a/docs/content/preview/architecture/transactions/concurrency-control.md
+++ b/docs/content/preview/architecture/transactions/concurrency-control.md
@@ -1252,8 +1252,8 @@ All metrics are per tablet.
 
 #### Histograms
 
-1. `wait_queue_pending_time_waiting` (ms): the amount of time a still-waiting transaction has been in the wait queue
-2. `wait_queue_finished_waiting_latency` (ms): the amount of time an unblocked transaction spent in the wait queue
+1. `wait_queue_pending_time_waiting`: the amount of time in microseconds a still-waiting transaction has been in the wait queue
+2. `wait_queue_finished_waiting_latency`: the amount of time in microseconds an unblocked transaction spent in the wait queue
 3. `wait_queue_blockers_per_waiter`: the number of blockers a waiter is stuck on in the wait queue
 
 #### Counters

--- a/docs/content/stable/architecture/transactions/concurrency-control.md
+++ b/docs/content/stable/architecture/transactions/concurrency-control.md
@@ -1252,8 +1252,8 @@ All metrics are per tablet.
 
 #### Histograms
 
-1. `wait_queue_pending_time_waiting` (ms): the amount of time a still-waiting transaction has been in the wait queue
-2. `wait_queue_finished_waiting_latency` (ms): the amount of time an unblocked transaction spent in the wait queue
+1. `wait_queue_pending_time_waiting`: the amount of time in microseconds a still-waiting transaction has been in the wait queue
+2. `wait_queue_finished_waiting_latency`: the amount of time in microseconds an unblocked transaction spent in the wait queue
 3. `wait_queue_blockers_per_waiter`: the number of blockers a waiter is stuck on in the wait queue
 
 #### Counters

--- a/docs/content/v2.20/architecture/transactions/concurrency-control.md
+++ b/docs/content/v2.20/architecture/transactions/concurrency-control.md
@@ -1232,8 +1232,8 @@ All metrics are per tablet.
 
 #### Histograms
 
-1. `wait_queue_pending_time_waiting` (ms): the amount of time a still-waiting transaction has been in the wait queue
-2. `wait_queue_finished_waiting_latency` (ms): the amount of time an unblocked transaction spent in the wait queue
+1. `wait_queue_pending_time_waiting`: the amount of time in microseconds a still-waiting transaction has been in the wait queue
+2. `wait_queue_finished_waiting_latency`: the amount of time in microseconds an unblocked transaction spent in the wait queue
 3. `wait_queue_blockers_per_waiter`: the number of blockers a waiter is stuck on in the wait queue
 
 #### Counters

--- a/docs/content/v2024.1/architecture/transactions/concurrency-control.md
+++ b/docs/content/v2024.1/architecture/transactions/concurrency-control.md
@@ -1252,8 +1252,8 @@ All metrics are per tablet.
 
 #### Histograms
 
-1. `wait_queue_pending_time_waiting` (ms): the amount of time a still-waiting transaction has been in the wait queue
-2. `wait_queue_finished_waiting_latency` (ms): the amount of time an unblocked transaction spent in the wait queue
+1. `wait_queue_pending_time_waiting`: the amount of time in microseconds a still-waiting transaction has been in the wait queue
+2. `wait_queue_finished_waiting_latency`: the amount of time in microseconds an unblocked transaction spent in the wait queue
 3. `wait_queue_blockers_per_waiter`: the number of blockers a waiter is stuck on in the wait queue
 
 #### Counters

--- a/docs/content/v2024.2/architecture/transactions/concurrency-control.md
+++ b/docs/content/v2024.2/architecture/transactions/concurrency-control.md
@@ -1252,8 +1252,8 @@ All metrics are per tablet.
 
 #### Histograms
 
-1. `wait_queue_pending_time_waiting` (ms): the amount of time a still-waiting transaction has been in the wait queue
-2. `wait_queue_finished_waiting_latency` (ms): the amount of time an unblocked transaction spent in the wait queue
+1. `wait_queue_pending_time_waiting`: the amount of time in microseconds a still-waiting transaction has been in the wait queue
+2. `wait_queue_finished_waiting_latency`: the amount of time in microseconds an unblocked transaction spent in the wait queue
 3. `wait_queue_blockers_per_waiter`: the number of blockers a waiter is stuck on in the wait queue
 
 #### Counters


### PR DESCRIPTION
Correct units for wait queue metric

@netlify /preview/architecture/transactions/concurrency-control/#metrics