### PR TITLE
fixing rhel links

### DIFF
--- a/docs/content/preview/yugabyte-voyager/rhel.md
+++ b/docs/content/preview/yugabyte-voyager/rhel.md
@@ -19,7 +19,7 @@ Perform the following steps to install yb-voyager using yum for RHEL 8 and CentO
 1. Install the `yugabyte` yum repository using the following command:
 
     ```sh
-    sudo yum install https://software.yugabyte.com/repos/reporpms/yb-yum-repo-1.1-0.noarch.rpm?os=rhel-8
+    sudo yum install https://software.yugabyte.com/repos/reporpms/rhel-8/yb-yum-repo-1.1-0.noarch.rpm
     ```
 
     This repository contains the yb-voyager rpm and other dependencies required to run `yb-voyager`.
@@ -103,7 +103,7 @@ Perform the following steps to install yb-voyager using yum for RHEL 9 and CentO
 1. Install the `yugabyte` yum repository using the following command:
 
     ```sh
-    sudo dnf install https://software.yugabyte.com/repos/reporpms/yb-yum-repo-1.1-0.noarch.rpm?os=rhel-9 -y
+    sudo dnf install https://software.yugabyte.com/repos/reporpms/rhel-9/yb-yum-repo-1.1-0.noarch.rpm -y
     ```
 
 1. Install the `epel-release` repository using the following command:


### PR DESCRIPTION
### Problem
The current RHEL installation documentation uses query parameter-based URLs for the YugabyteDB repository installation, which causes URL encoding issues when using `yum`/`dnf` install commands:

```bash
# Problematic URLs (before)
https://software.yugabyte.com/repos/reporpms/yb-yum-repo-1.1-0.noarch.rpm?os=rhel-8
https://software.yugabyte.com/repos/reporpms/yb-yum-repo-1.1-0.noarch.rpm?os=rhel-9
```

**Issue:** The `?` character gets URL-encoded to `%3f`, causing 404 errors:
```
Status code: 404 for https://software.yugabyte.com/repos/reporpms/yb-yum-repo-1.1-0.noarch.rpm%3fos%3drhel-9
```

### Solution
Updated both RHEL 8 and RHEL 9 installation documentation to use path-based URLs that avoid query parameter encoding issues:

```bash
# Fixed URLs (after)
https://software.yugabyte.com/repos/reporpms/rhel-8/yb-yum-repo-1.1-0.noarch.rpm
https://software.yugabyte.com/repos/reporpms/rhel-9/yb-yum-repo-1.1-0.noarch.rpm
```