### PR TITLE
[#15872] docdb: show tserver uptime as "unknown" during leader failover gap

### DIFF
--- a/src/yb/master/master-path-handlers.cc
+++ b/src/yb/master/master-path-handlers.cc
@@ -912,6 +912,11 @@ void MasterPathHandlers::HandleGetTserverStatus(const Webserver::WebRequest& req
 
           jw.String("uptime_seconds");
           jw.Uint64(desc->uptime_seconds());
+          if(desc->uptime_seconds() > 0) {
+            jw.Uint64(desc->uptime_seconds());
+          } else {
+            jw.String("unknown");
+          }
         } else {
           jw.String("status");
           jw.String(kTserverDead);


### PR DESCRIPTION
summary:
When the master leader fails over, there’s a short window before the new leader receives heartbeats from tablet servers. During this gap, the master reports uptime=0 for alive tservers, which is misleading (the tserver has been up; the leader just hasn’t learned its uptime yet).

If a tablet server is marked ALIVE but the reported uptime is 0, display the uptime as "unknown" instead of 0. This prevents falsely implying a restart during leader transitions.