### PR TITLE
Doc: Remove references to `local all all trust` hba conf setting

### DIFF
--- a/docs/content/preview/manage/backup-restore/instant-db-cloning.md
+++ b/docs/content/preview/manage/backup-restore/instant-db-cloning.md
@@ -49,18 +49,6 @@ You can also set the runtime flags while the yb-master process is running using 
 
     For example, creating a snapshot schedule with retention period of 7 days allows you to create a clone of the original database to any time in the past 7 days.
 
-- You have to trust local YSQL connections (that use UNIX domain sockets) in the [host-based authentication](../../../secure/authentication/host-based-authentication/). You have to do this for all YB-TServers in the cluster. You can do this when starting the YB-TServer process by adding the authentication line `local all all trust` to the [ysql_hba_conf_csv](../../../reference/configuration/yb-tserver/#ysql-hba-conf-csv) flag.
-
-    For example, if you are using yugabyted you can use the `--tserver_flags` option of the `start` command as follows:
-
-    ```sh
-    --tserver_flags "ysql_hba_conf_csv={host all all 0.0.0.0/0 trust,local all all trust}"
-    ```
-
-{{<note title="Note">}}
-Do not override your default host-based authentication rules when trusting the local connection. You may need to add additional authentication lines to `ysql_hba_conf_csv` based on your specific configuration. For more information, see [host-based authentication](../../../secure/authentication/host-based-authentication/).
-{{</note>}}
-
 ### Clone a YSQL database
 
 Because YugabyteDB is PostgreSQL compatible, you can create a database as a clone of another using the `TEMPLATE` SQL option of `CREATE DATABASE` command as follows:
@@ -150,8 +138,7 @@ The following example demonstrates how to use a database clone to recover from a
 
     ```sh
     ./bin/yugabyted start --advertise_address=127.0.0.1 \
-        --master_flags "enable_db_clone=true" \
-        --tserver_flags "ysql_hba_conf_csv={host all all 0.0.0.0/0 trust,local all all trust}"
+        --master_flags "enable_db_clone=true"
     ```
 
 1. Start [ysqlsh](../../../api/ysqlsh/) and create the database:

--- a/docs/content/preview/yugabyte-platform/back-up-restore-universes/back-up-universe-data.md
+++ b/docs/content/preview/yugabyte-platform/back-up-restore-universes/back-up-universe-data.md
@@ -55,8 +55,6 @@ The universe **Backups** page allows you to create new backups that start immedi
 
 If the universe has [encryption at rest enabled](../../security/enable-encryption-at-rest), data files are backed up as-is (encrypted) to reduce the computation cost of a backup and to keep the files encrypted. A universe key metadata file containing key references is also backed up.
 
-For YSQL, you can allow YugabyteDB Anywhere to back up your data with the user authentication enabled by following the instructions in [Edit configuration flags](../../manage-deployments/edit-config-flags) to add the `ysql_enable_auth=true` and `ysql_hba_conf_csv="local all all trust"` YB-TServer flags.
-
 ### View backup details
 
 To view detailed backup information, click on the backup (row) in the **Backups** list to open **Backup Details**.

--- a/docs/content/stable/manage/backup-restore/instant-db-cloning.md
+++ b/docs/content/stable/manage/backup-restore/instant-db-cloning.md
@@ -49,18 +49,6 @@ You can also set the runtime flags while the yb-master process is running using 
 
     For example, creating a snapshot schedule with retention period of 7 days allows you to create a clone of the original database to any time in the past 7 days.
 
-- You have to trust local YSQL connections (that use UNIX domain sockets) in the [host-based authentication](../../../secure/authentication/host-based-authentication/). You have to do this for all YB-TServers in the cluster. You can do this when starting the YB-TServer process by adding the authentication line `local all all trust` to the [ysql_hba_conf_csv](../../../reference/configuration/yb-tserver/#ysql-hba-conf-csv) flag.
-
-    For example, if you are using yugabyted you can use the `--tserver_flags` option of the `start` command as follows:
-
-    ```sh
-    --tserver_flags "ysql_hba_conf_csv={host all all 0.0.0.0/0 trust,local all all trust}"
-    ```
-
-{{<note title="Note">}}
-Do not override your default host-based authentication rules when trusting the local connection. You may need to add additional authentication lines to `ysql_hba_conf_csv` based on your specific configuration. For more information, see [host-based authentication](../../../secure/authentication/host-based-authentication/).
-{{</note>}}
-
 ### Clone a YSQL database
 
 Because YugabyteDB is PostgreSQL compatible, you can create a database as a clone of another using the `TEMPLATE` SQL option of `CREATE DATABASE` command as follows:
@@ -150,8 +138,7 @@ The following example demonstrates how to use a database clone to recover from a
 
     ```sh
     ./bin/yugabyted start --advertise_address=127.0.0.1 \
-        --master_flags "enable_db_clone=true" \
-        --tserver_flags "ysql_hba_conf_csv={host all all 0.0.0.0/0 trust,local all all trust}"
+        --master_flags "enable_db_clone=true"
     ```
 
 1. Start [ysqlsh](../../../api/ysqlsh/) and create the database:

--- a/docs/content/stable/yugabyte-platform/back-up-restore-universes/back-up-universe-data.md
+++ b/docs/content/stable/yugabyte-platform/back-up-restore-universes/back-up-universe-data.md
@@ -52,8 +52,6 @@ The universe **Backups** page allows you to create new backups that start immedi
 
 If the universe has [encryption at rest enabled](../../security/enable-encryption-at-rest), data files are backed up as-is (encrypted) to reduce the computation cost of a backup and to keep the files encrypted. A universe key metadata file containing key references is also backed up.
 
-For YSQL, you can allow YugabyteDB Anywhere to back up your data with the user authentication enabled by following the instructions in [Edit configuration flags](../../manage-deployments/edit-config-flags) to add the `ysql_enable_auth=true` and `ysql_hba_conf_csv="local all all trust"` YB-TServer flags.
-
 ### View backup details
 
 To view detailed backup information, click on the backup (row) in the **Backups** list to open **Backup Details**.

--- a/docs/content/v2024.2/manage/backup-restore/instant-db-cloning.md
+++ b/docs/content/v2024.2/manage/backup-restore/instant-db-cloning.md
@@ -51,18 +51,6 @@ Note: Database cloning is {{<tags/feature/tp idea="990">}} in versions of 2024.2
 
     For example, creating a snapshot schedule with retention period of 7 days allows you to create a clone of the original database to any time in the past 7 days.
 
-- You have to trust local YSQL connections (that use UNIX domain sockets) in the [host-based authentication](../../../secure/authentication/host-based-authentication/). You have to do this for all YB-TServers in the cluster. You can do this when starting the YB-TServer process by adding the authentication line `local all all trust` to the [ysql_hba_conf_csv](../../../reference/configuration/yb-tserver/#ysql-hba-conf-csv) flag.
-
-    For example, if you are using yugabyted you can use the `--tserver_flags` option of the `start` command as follows:
-
-    ```sh
-    --tserver_flags "ysql_hba_conf_csv={host all all 0.0.0.0/0 trust,local all all trust}"
-    ```
-
-{{<note title="Note">}}
-Do not override your default host-based authentication rules when trusting the local connection. You may need to add additional authentication lines to `ysql_hba_conf_csv` based on your specific configuration. For more information, see [host-based authentication](../../../secure/authentication/host-based-authentication/).
-{{</note>}}
-
 ### Clone a YSQL database
 
 Because YugabyteDB is PostgreSQL compatible, you can create a database as a clone of another using the `TEMPLATE` SQL option of `CREATE DATABASE` command as follows:
@@ -150,8 +138,7 @@ The following example demonstrates how to use a database clone to recover from a
 
     ```sh
     ./bin/yugabyted start --advertise_address=127.0.0.1 \
-        --master_flags "enable_db_clone=true" \
-        --tserver_flags "ysql_hba_conf_csv={host all all 0.0.0.0/0 trust,local all all trust}"
+        --master_flags "enable_db_clone=true"
     ```
 
 1. Start [ysqlsh](../../../api/ysqlsh/) and create the database:

--- a/docs/content/v2024.2/yugabyte-platform/back-up-restore-universes/back-up-universe-data.md
+++ b/docs/content/v2024.2/yugabyte-platform/back-up-restore-universes/back-up-universe-data.md
@@ -52,8 +52,6 @@ The universe **Backups** page allows you to create new backups that start immedi
 
 If the universe has [encryption at rest enabled](../../security/enable-encryption-at-rest), data files are backed up as-is (encrypted) to reduce the computation cost of a backup and to keep the files encrypted. A universe key metadata file containing key references is also backed up.
 
-For YSQL, you can allow YugabyteDB Anywhere to back up your data with the user authentication enabled by following the instructions in [Edit configuration flags](../../manage-deployments/edit-config-flags) to add the `ysql_enable_auth=true` and `ysql_hba_conf_csv="local all all trust"` YB-TServer flags.
-
 ### View backup details
 
 To view detailed backup information, click on the backup (row) in the **Backups** list to open **Backup Details**.


### PR DESCRIPTION
From version 2025.1 the DB automatically adds `local all yugabyte trust` to the pg hba conf, so this is not necessary for the user to do anymore.