### PR TITLE
fix default values

### DIFF
--- a/docs/content/stable/architecture/transactions/concurrency-control.md
+++ b/docs/content/stable/architecture/transactions/concurrency-control.md
@@ -1290,7 +1290,7 @@ You configure the lease duration and behavior using the following additional fla
 
 #### master_ysql_operation_lease_ttl_ms
 
-Default: `30000` (30 seconds)
+Default: `5 * 60 * 1000` (5 minutes)
 
 Specifies base YSQL lease Time-To-Live (TTL). The YB-Master leader uses this value to determine the validity of a YB-TServer's YSQL lease.
 

--- a/docs/content/stable/reference/configuration/yb-master.md
+++ b/docs/content/stable/reference/configuration/yb-master.md
@@ -218,7 +218,7 @@ Default: `true`
 
 ##### --master_ysql_operation_lease_ttl_ms
 
-Default: `30000` (30 seconds)
+Default: `5 * 60 * 1000` (5 minutes)
 
 Specifies base YSQL lease Time-To-Live (TTL). The YB-Master leader uses this value to determine the validity of a YB-TServer's YSQL lease.
 


### PR DESCRIPTION
Fix default values for the `master_ysql_operation_lease_ttl_ms` flag. The value is 5 minutes in the 2025.1 branch, which uses the `stable` branch of documentation currently.