### PR TITLE
[DOC-959] Add missing line in service files for Legacy provisioning

### DIFF
--- a/docs/content/preview/yugabyte-platform/prepare/server-nodes-software/software-on-prem-manual.md
+++ b/docs/content/preview/yugabyte-platform/prepare/server-nodes-software/software-on-prem-manual.md
@@ -387,6 +387,7 @@ You can install systemd-specific database service unit files, as follows:
 
     [Service]
     # Start
+    ExecStartPre=/home/yugabyte/bin/clock-sync.sh
     ExecStart=/home/yugabyte/master/bin/yb-master --flagfile /home/yugabyte/master/conf/server.conf
     Restart=on-failure
     RestartSec=5
@@ -424,6 +425,7 @@ You can install systemd-specific database service unit files, as follows:
 
     [Service]
     # Start
+    ExecStartPre=/home/yugabyte/bin/clock-sync.sh
     ExecStart=/home/yugabyte/tserver/bin/yb-tserver --flagfile /home/yugabyte/tserver/conf/server.conf
     Restart=on-failure
     RestartSec=5


### PR DESCRIPTION
Add missing line in service files for Legacy provisioning

@netlify /preview/yugabyte-platform/prepare/server-nodes-software/software-on-prem-manual/#install-systemd-related-database-service-unit-files