### PR TITLE
[DOC-960] Clarify WoC is default in YSQL

### DIFF
--- a/docs/content/preview/architecture/transactions/concurrency-control.md
+++ b/docs/content/preview/architecture/transactions/concurrency-control.md
@@ -19,7 +19,7 @@ For information on how row-level explicit locking clauses behave with these conc
 
 ## Fail-on-Conflict
 
-This is the default concurrency control strategy and is applicable for `Repeatable Read` and `Serializable` isolation levels.
+This concurrency control strategy is applicable for `Repeatable Read` and `Serializable` isolation levels.
 
 In this mode, transactions are assigned random priorities with some exceptions as described in [Transaction Priorities](../transaction-priorities/). As an exception, all transactions in Read Committed isolation have the same priority set to the highest value (in other words, no transaction can preempt an active Read Committed isolation transaction).
 
@@ -308,7 +308,7 @@ Note that the retries will not be performed in case the amount of data to be sen
 
 ## Wait-on-Conflict
 
-This mode of concurrency control is applicable only for YSQL and provides the same semantics as PostgreSQL.
+This mode of concurrency control is applicable only for YSQL (where it is the default) and provides the same semantics as PostgreSQL.
 
 In this mode, transactions are not assigned priorities. If a conflict occurs when a transaction T1 tries to read, write, or lock a row in a conflicting mode with a few other concurrent transactions, T1 will **wait** until all conflicting transactions finish by either committing or rolling back. Once all conflicting transactions have finished, T1 will:
 

--- a/docs/content/stable/architecture/transactions/concurrency-control.md
+++ b/docs/content/stable/architecture/transactions/concurrency-control.md
@@ -19,7 +19,7 @@ For information on how row-level explicit locking clauses behave with these conc
 
 ## Fail-on-Conflict
 
-This is the default concurrency control strategy and is applicable for `Repeatable Read` and `Serializable` isolation levels.
+This concurrency control strategy is applicable for `Repeatable Read` and `Serializable` isolation levels.
 
 In this mode, transactions are assigned random priorities with some exceptions as described in [Transaction Priorities](../transaction-priorities/). As an exception, all transactions in Read Committed isolation have the same priority set to the highest value (in other words, no transaction can preempt an active Read Committed isolation transaction).
 
@@ -308,7 +308,7 @@ Note that the retries will not be performed in case the amount of data to be sen
 
 ## Wait-on-Conflict
 
-This mode of concurrency control is applicable only for YSQL and provides the same semantics as PostgreSQL.
+This mode of concurrency control is applicable only for YSQL (where it is the default) and provides the same semantics as PostgreSQL.
 
 In this mode, transactions are not assigned priorities. If a conflict occurs when a transaction T1 tries to read, write, or lock a row in a conflicting mode with a few other concurrent transactions, T1 will **wait** until all conflicting transactions finish by either committing or rolling back. Once all conflicting transactions have finished, T1 will:
 

--- a/docs/content/v2024.1/architecture/transactions/concurrency-control.md
+++ b/docs/content/v2024.1/architecture/transactions/concurrency-control.md
@@ -19,7 +19,7 @@ For information on how row-level explicit locking clauses behave with these conc
 
 ## Fail-on-Conflict
 
-This is the default concurrency control strategy and is applicable for `Repeatable Read` and `Serializable` isolation levels.
+This concurrency control strategy is applicable for `Repeatable Read` and `Serializable` isolation levels.
 
 In this mode, transactions are assigned random priorities with some exceptions as described in [Transaction Priorities](../transaction-priorities/). As an exception, all transactions in Read Committed isolation have the same priority set to the highest value (in other words, no transaction can preempt an active Read Committed isolation transaction).
 
@@ -308,7 +308,7 @@ Note that the retries will not be performed in case the amount of data to be sen
 
 ## Wait-on-Conflict
 
-This mode of concurrency control is applicable only for YSQL and provides the same semantics as PostgreSQL.
+This mode of concurrency control is applicable only for YSQL (where it is the default) and provides the same semantics as PostgreSQL.
 
 In this mode, transactions are not assigned priorities. If a conflict occurs when a transaction T1 tries to read, write, or lock a row in a conflicting mode with a few other concurrent transactions, T1 will **wait** until all conflicting transactions finish by either committing or rolling back. Once all conflicting transactions have finished, T1 will:
 

--- a/docs/content/v2024.2/architecture/transactions/concurrency-control.md
+++ b/docs/content/v2024.2/architecture/transactions/concurrency-control.md
@@ -19,7 +19,7 @@ For information on how row-level explicit locking clauses behave with these conc
 
 ## Fail-on-Conflict
 
-This is the default concurrency control strategy and is applicable for `Repeatable Read` and `Serializable` isolation levels.
+This concurrency control strategy is applicable for `Repeatable Read` and `Serializable` isolation levels.
 
 In this mode, transactions are assigned random priorities with some exceptions as described in [Transaction Priorities](../transaction-priorities/). As an exception, all transactions in Read Committed isolation have the same priority set to the highest value (in other words, no transaction can preempt an active Read Committed isolation transaction).
 
@@ -308,7 +308,7 @@ Note that the retries will not be performed in case the amount of data to be sen
 
 ## Wait-on-Conflict
 
-This mode of concurrency control is applicable only for YSQL and provides the same semantics as PostgreSQL.
+This mode of concurrency control is applicable only for YSQL (where it is the default) and provides the same semantics as PostgreSQL.
 
 In this mode, transactions are not assigned priorities. If a conflict occurs when a transaction T1 tries to read, write, or lock a row in a conflicting mode with a few other concurrent transactions, T1 will **wait** until all conflicting transactions finish by either committing or rolling back. Once all conflicting transactions have finished, T1 will:
 


### PR DESCRIPTION
Clarify WoC is default in YSQL (2024.1 and later)

@netlify /preview/architecture/transactions/concurrency-control/