### PR TITLE
Add linter check for form yb defs

### DIFF
--- a/src/lint/typedefs_list.sh
+++ b/src/lint/typedefs_list.sh
@@ -25,6 +25,20 @@ if [[ "$1" == */yb_typedefs.list ]]; then
   grep -Env "$pattern" "$1" \
     | sed 's/^/error:missing_yb_in_type_name:'\
 'Types in yb_typedefs.list should have "yb":/'
+
+  grep -o 'Form_[a-zA-Z0-9_]*' "$1" | while read -r form; do
+    formdata="FormData_${form#Form_}"
+    if ! grep -q "^$formdata$" "$1"; then
+      echo "error:missing_FormData:$formdata is missing for $form"
+    fi
+  done
+  
+  grep -o 'FormData_[a-zA-Z0-9_]*' "$1" | while read -r formdata; do
+    form="Form_${formdata#FormData_}"
+    if ! grep -q "^$form$" "$1"; then
+      echo "error:missing_Form:$form is missing for $formdata"
+    fi
+  done
 else
   grep -En "$pattern" "$1" \
     | sed 's/^/error:bad_yb_in_type_name:'\

--- a/src/lint/typedefs_list.sh
+++ b/src/lint/typedefs_list.sh
@@ -39,6 +39,15 @@ if [[ "$1" == */yb_typedefs.list ]]; then
       echo "error:missing_Form:$form is missing for $formdata"
     fi
   done
+  
+  find src -name '*.h' -exec grep -l 'YB_DEFINE_HANDLE_TYPE' {} \; 2>/dev/null | \
+    xargs grep -ho 'YB_DEFINE_HANDLE_TYPE([A-Z][a-zA-Z0-9_]*)' 2>/dev/null | \
+    sed 's/YB_DEFINE_HANDLE_TYPE(//' | sed 's/)//' | sort -u | while read -r handle_type; do
+      transformed_type="Ybc${handle_type}"
+      if ! grep -q "^$transformed_type$" "$1"; then
+        echo "error:missing_handle_type:$transformed_type is missing for YB_DEFINE_HANDLE_TYPE($handle_type)"
+      fi
+    done
 else
   grep -En "$pattern" "$1" \
     | sed 's/^/error:bad_yb_in_type_name:'\


### PR DESCRIPTION
## Summary

Add lint checks for Form/FormData pairs and handle type transformations

Enhancements:
- Validate that each Form_* type in yb_typedefs.list has a corresponding FormData_* entry and vice versa
- Ensure YB_DEFINE_HANDLE_TYPE macros correspond to Ybc-prefixed types in yb_typedefs.list