### PR TITLE
Update IndexAMProperty API to sync with YB additions to IndexAmRoutine

### DIFF
--- a/src/postgres/src/backend/utils/adt/amutils.c
+++ b/src/postgres/src/backend/utils/adt/amutils.c
@@ -84,6 +84,16 @@ static const struct am_propname am_propnames[] =
 	{
 		"can_include", AMPROP_CAN_INCLUDE
 	},
+	/* YB properties */
+	{
+		"yb_is_for_yb_relation", AMPROP_YB_IS_FOR_YB_RELATION
+	},
+	{
+		"yb_is_copartitioned", AMPROP_YB_IS_COPARTITIONED
+	},
+	{
+		"yb_can_update_tuple_inplace", AMPROP_YB_CAN_UPDATE_TUPLE_INPLACE
+	},
 };
 
 static IndexAMProperty
@@ -399,6 +409,16 @@ indexam_property(FunctionCallInfo fcinfo,
 
 		case AMPROP_CAN_INCLUDE:
 			PG_RETURN_BOOL(routine->amcaninclude);
+
+		/* YB properties */
+		case AMPROP_YB_IS_FOR_YB_RELATION:
+			PG_RETURN_BOOL(routine->yb_amisforybrelation);
+
+		case AMPROP_YB_IS_COPARTITIONED:
+			PG_RETURN_BOOL(routine->yb_amiscopartitioned);
+
+		case AMPROP_YB_CAN_UPDATE_TUPLE_INPLACE:
+			PG_RETURN_BOOL(routine->ybamcanupdatetupleinplace);
 
 		default:
 			PG_RETURN_NULL();

--- a/src/postgres/src/include/access/amapi.h
+++ b/src/postgres/src/include/access/amapi.h
@@ -57,7 +57,11 @@ typedef enum IndexAMProperty
 	AMPROP_CAN_UNIQUE,
 	AMPROP_CAN_MULTI_COL,
 	AMPROP_CAN_EXCLUDE,
-	AMPROP_CAN_INCLUDE
+	AMPROP_CAN_INCLUDE,
+	/* YB properties */
+	AMPROP_YB_IS_FOR_YB_RELATION,	/* is AM for YB relations? */
+	AMPROP_YB_IS_COPARTITIONED,		/* is AM for YB copartitioned index? */
+	AMPROP_YB_CAN_UPDATE_TUPLE_INPLACE	/* does AM support in-place update? */
 } IndexAMProperty;
 
 /*


### PR DESCRIPTION
- Add YB properties to IndexAMProperty enum:
  - AMPROP_YB_IS_FOR_YB_RELATION
  - AMPROP_YB_IS_COPARTITIONED
  - AMPROP_YB_CAN_UPDATE_TUPLE_INPLACE
- Add corresponding property names to am_propnames array
- Add property handling logic in indexam_property function
- Enable pg_indexam_has_property, pg_index_has_property, and pg_index_column_has_property functions to access YB properties

Fixes #22246