### PR TITLE
[DOC-966] xCluster pgvector index limitation

### DIFF
--- a/docs/content/preview/architecture/docdb-replication/async-replication.md
+++ b/docs/content/preview/architecture/docdb-replication/async-replication.md
@@ -254,6 +254,8 @@ The following deployment scenarios are not yet supported:
 
   Table columns whose types involve row types are not supported.
 
+- [pgvector](../../../additional-features/pg-extensions/extension-pgvector/) indexes are not supported.
+
 <ul class="nav nav-tabs-alt nav-tabs-yb custom-tabs">
 <li>
     <a href="#ysql-transactional" class="nav-link active" id="ysql-transactional-tab" data-bs-toggle="tab"

--- a/docs/content/stable/architecture/docdb-replication/async-replication.md
+++ b/docs/content/stable/architecture/docdb-replication/async-replication.md
@@ -252,6 +252,8 @@ The following deployment scenarios are not yet supported:
 
   Table columns whose types involve row types are not supported.
 
+- [pgvector](../../../additional-features/pg-extensions/extension-pgvector/) indexes are not supported.
+
 <ul class="nav nav-tabs-alt nav-tabs-yb custom-tabs">
 <li>
     <a href="#ysql-transactional" class="nav-link active" id="ysql-transactional-tab" data-bs-toggle="tab"


### PR DESCRIPTION
xCluster pgvector index limitation

@netlify /preview/architecture/docdb-replication/async-replication/#limitations