### PR TITLE
[DocDB] Add log line when servicing RestoreSnapshotSchedule

### DIFF
--- a/src/yb/master/catalog_manager_ext.cc
+++ b/src/yb/master/catalog_manager_ext.cc
@@ -3280,6 +3280,9 @@ Status CatalogManager::RestoreSnapshotSchedule(
   HybridTime ht = HybridTime(req->restore_ht());
   auto deadline = rpc->GetClientDeadline();
 
+  LOG(INFO) << "Servicing RestoreSnapshotSchedule request: " << id
+            << " to restore to time " << ht;
+
   RETURN_NOT_OK(master_->tablet_split_manager().PrepareForPitr(deadline));
 
   return master_->snapshot_coordinator().RestoreSnapshotSchedule(


### PR DESCRIPTION
## Description

Fixes #28707 

This PR adds a log line when the master leader services a `RestoreSnapshotSchedule` RPC request. This follows the same pattern used by other "major" RPC handlers like `CreateSnapshot`, `DeleteSnapshot`, and `RestoreSnapshot`.

## Changes

- Added `LOG(INFO)` line in `CatalogManager::RestoreSnapshotSchedule()` 
- Log includes schedule ID and restore time for debugging
- Follows existing logging patterns in the codebase

