### PR TITLE
[#23181] YSQL: Fix pg_total_relation_size to include index sizes

### DIFF
--- a/src/postgres/src/backend/utils/adt/dbsize.c
+++ b/src/postgres/src/backend/utils/adt/dbsize.c
@@ -493,7 +493,7 @@ calculate_indexes_size(Relation rel)
 					continue;
 				}
 
-				/* Colcoated tables do not have size info */
+				/* Colocated relations do not have size info */
 				if (YbGetTableProperties(idxRel)->is_colocated)
 				{
 					relation_close(idxRel, AccessShareLock);

--- a/src/postgres/src/backend/utils/adt/dbsize.c
+++ b/src/postgres/src/backend/utils/adt/dbsize.c
@@ -481,14 +481,51 @@ calculate_indexes_size(Relation rel)
 		{
 			Oid			idxOid = lfirst_oid(cell);
 			Relation	idxRel;
-			ForkNumber	forkNum;
 
 			idxRel = relation_open(idxOid, AccessShareLock);
 
-			for (forkNum = 0; forkNum <= MAX_FORKNUM; forkNum++)
-				size += calculate_relation_size(&(idxRel->rd_node),
-												idxRel->rd_backend,
-												forkNum);
+			if (IsYBRelation(idxRel))
+			{
+				/* Primary index relation doesn't have dedicated table in DocDB */
+				if (idxRel->rd_index && idxRel->rd_index->indisprimary)
+				{
+					relation_close(idxRel, AccessShareLock);
+					continue;
+				}
+
+				/* Colcoated tables do not have size info */
+				if (YbGetTableProperties(idxRel)->is_colocated)
+				{
+					relation_close(idxRel, AccessShareLock);
+					continue;
+				}
+
+				int64		index_size = 0;
+				int32		num_missing_tablets = 0;
+
+				HandleYBStatus(YBCPgGetTableDiskSize(YbGetRelfileNodeId(idxRel),
+													 YBCGetDatabaseOid(idxRel), (int64_t *) &index_size, &num_missing_tablets));
+				if (num_missing_tablets > 0)
+				{
+					elog(NOTICE,
+						 "%d tablets of index %s did not provide disk size "
+						 "estimates, and were not added to the displayed totals.",
+						 num_missing_tablets,
+						 RelationGetRelationName(idxRel));
+				}
+
+				if (index_size > 0)
+					size += index_size;
+			}
+			else
+			{
+				ForkNumber	forkNum;
+
+				for (forkNum = 0; forkNum <= MAX_FORKNUM; forkNum++)
+					size += calculate_relation_size(&(idxRel->rd_node),
+													idxRel->rd_backend,
+													forkNum);
+			}
 
 			relation_close(idxRel, AccessShareLock);
 		}

--- a/src/postgres/src/backend/utils/adt/dbsize.c
+++ b/src/postgres/src/backend/utils/adt/dbsize.c
@@ -414,7 +414,7 @@ calculate_toast_table_size(Oid toastrelid)
 static int64
 calculate_table_size(Relation rel)
 {
-	int64		size = 0;
+	int64_t		size = 0;
 	ForkNumber	forkNum;
 
 	if (IsYBRelation(rel))
@@ -430,7 +430,7 @@ calculate_table_size(Relation rel)
 		int32		num_missing_tablets = 0;
 
 		HandleYBStatus(YBCPgGetTableDiskSize(YbGetRelfileNodeId(rel),
-											 YBCGetDatabaseOid(rel), (int64_t *) &size, &num_missing_tablets));
+											 YBCGetDatabaseOid(rel), &size, &num_missing_tablets));
 		if (num_missing_tablets > 0)
 		{
 			elog(NOTICE,
@@ -500,11 +500,11 @@ calculate_indexes_size(Relation rel)
 					continue;
 				}
 
-				int64		index_size = 0;
+				int64_t		index_size = 0;
 				int32		num_missing_tablets = 0;
 
 				HandleYBStatus(YBCPgGetTableDiskSize(YbGetRelfileNodeId(idxRel),
-													 YBCGetDatabaseOid(idxRel), (int64_t *) &index_size, &num_missing_tablets));
+													 YBCGetDatabaseOid(idxRel), &index_size, &num_missing_tablets));
 				if (num_missing_tablets > 0)
 				{
 					elog(NOTICE,


### PR DESCRIPTION
https://github.com/yugabyte/yugabyte-db/issues/23181

## Changes Made:

`pg_total_relation_size` returns incorrect total sizes because the calculate_indexes_size function consider only local filesystem-based calculation and not considering the path for querying DocDB (Context: in https://github.com/yugabyte/yugabyte-db/commit/2e767c443d80ac1144bfe75739dff84801f763b0 table sizes takes into account of DocDB layer, but this did not add a same behaviour to indexes). **This results in indexes reporting 0 bytes**, making `pg_total_relation_size` **only reflect table size** without indexes.

This fix modifies calculate_indexes_size in [`src/postgres/src/backend/utils/adt/dbsize.c`](https://github.com/yugabyte/yugabyte-db/blob/adacff9f274ce1ffc270db7aa0a91d31fb2ba66c/src/postgres/src/backend/utils/adt/dbsize.c#L574-L597) to handle YB relations using the same pattern already implemented for calculate_table_size. The fix uses the existing [YBCPgGetTableDiskSize RPC](https://github.com/yugabyte/yugabyte-db/blob/adacff9f274ce1ffc270db7aa0a91d31fb2ba66c/src/yb/yql/pggate/ybc_pggate.cc#L1283-L1292) to get actual index sizes from DocDB, ensuring consistent size reporting across YugabyteDB's distributed storage.

## Testing

✅ Confirmed by the following set up

- `./bin/yugabyted start` to run a local cluster
- Seed test data
- Show `pg_total_relation_size` and `pg_indexes_size` result data

### Seed Data

Here is the SQL to seed test data in my local cluster. The critical part is to create indexes for testing purposes.

<details>
<summary>SQL to seed test data</summary>

```sql
CREATE TABLE users (
    id SERIAL PRIMARY KEY,
    name TEXT NOT NULL,
    email TEXT UNIQUE,
    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
);

CREATE TABLE products (
    id SERIAL PRIMARY KEY,
    name TEXT NOT NULL,
    price DECIMAL(10,2),
    category TEXT,
    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
);

CREATE TABLE shops (
    id SERIAL PRIMARY KEY,
    name TEXT NOT NULL,
    location TEXT,
    owner_email TEXT,
    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
);

INSERT INTO users (name, email) 
SELECT 
    'Test User ' || i,
    'testuser' || i || '@example.com'
FROM generate_series(1, 1000) i;

INSERT INTO products (name, price, category) 
SELECT 
    'Test Product ' || i,
    (10 + (i % 500))::decimal(10,2),
    CASE (i % 4) 
        WHEN 0 THEN 'Electronics'
        WHEN 1 THEN 'Sports' 
        WHEN 2 THEN 'Kitchen'
        ELSE 'Office'
    END
FROM generate_series(1, 1000) i;

INSERT INTO cache_test (data)
SELECT 'test_data_' || generate_series(1, 10000);

-- Add secondary indexes to existing tables

CREATE INDEX idx_products_category ON products(category);
CREATE INDEX idx_products_price ON products(price);
CREATE INDEX idx_products_name ON products(name);
CREATE INDEX idx_products_composite ON products(category, price);

CREATE INDEX idx_users_name ON users(name);
CREATE INDEX idx_users_created_at ON users(created_at);

CREATE INDEX idx_shops_location ON shops(location);
CREATE INDEX idx_shops_name ON shops(name);
CREATE INDEX idx_shops_owner ON shops(owner_email);
```
</details>

### Result

Before/after the test, I've executed the following SQL to compare results.

```sql
SELECT 
    tablename,
    pg_size_pretty(pg_total_relation_size(tablename::regclass)) as total_size,
    pg_size_pretty(pg_table_size(tablename::regclass)) as table_size,
    pg_size_pretty(pg_indexes_size(tablename::regclass)) as indexes_size,
    pg_indexes_size(tablename::regclass) as indexes_size_bytes,
    CASE 
        WHEN pg_indexes_size(tablename::regclass) = 0 THEN '❌ BROKEN: indexes show 0'
        WHEN pg_indexes_size(tablename::regclass) > 10240 THEN '✅ FIXED: meaningful index size'
    END as status
FROM pg_tables 
WHERE schemaname = 'public' AND tablename IN ('users', 'products', 'shops')
ORDER BY tablename;
```

**Before** - **does NOT show any size form index sizes**

```
 tablename | total_size | table_size | indexes_size | indexes_size_bytes |          status
-----------+------------+------------+--------------+--------------------+---------------------------
 products  | 2048 kB    | 2048 kB    | 0 bytes      |                  0 | ❌ BROKEN: indexes show 0
 shops     | 2048 kB    | 2048 kB    | 0 bytes      |                  0 | ❌ BROKEN: indexes show 0
 users     | 2048 kB    | 2048 kB    | 0 bytes      |                  0 | ❌ BROKEN: indexes show 0
(3 rows)
```

**After** - **does show index size, also total_size is a summed up value of table + indexes** ✅ 

```
 tablename | total_size | table_size | indexes_size | indexes_size_bytes |             status
-----------+------------+------------+--------------+--------------------+---------------------------------
 products  | 10 MB      | 2048 kB    | 8192 kB      |            8388608 | ✅ FIXED: meaningful index size
 shops     | 8192 kB    | 2048 kB    | 6144 kB      |            6291456 | ✅ FIXED: meaningful index size
 users     | 8192 kB    | 2048 kB    | 6144 kB      |            6291456 | ✅ FIXED: meaningful index size
(3 rows)
```