### PR TITLE
[#21603] Add missing --read-time help text to ysql_dump

### DIFF
--- a/src/postgres/src/bin/pg_dump/pg_dump.c
+++ b/src/postgres/src/bin/pg_dump/pg_dump.c
@@ -1259,6 +1259,7 @@ help(const char *progname)
 	printf(_("  --no-unlogged-table-data     do not dump unlogged table data\n"));
 	printf(_("  --on-conflict-do-nothing     add ON CONFLICT DO NOTHING to INSERT commands\n"));
 	printf(_("  --quote-all-identifiers      quote all identifiers, even if not key words\n"));
+	printf(_("  --read-time=TIMESTAMP        read data as of specific time (Unix timestamp in microseconds)\n"));
 	printf(_("  --rows-per-insert=NROWS      number of rows per INSERT; implies --inserts\n"));
 	printf(_("  --section=SECTION            dump named section (pre-data, data, or post-data)\n"));
 	printf(_("  --serializable-deferrable    wait until the dump can run without anomalies\n"));


### PR DESCRIPTION
close https://github.com/yugabyte/yugabyte-db/issues/21603

## Changes Made:

Add missing `--read-time` option to `ysql_dump` scriptl.

## Validated Via:

Validated that the flag help text is shown in a locally built binaries:

```sh
$ ./yb_build.sh --ninja release --target postgres
$ ./build/release-clang-dynamic-arm64-ninja/postgres/bin/ysql_dump --help | grep "read-time"
  --read-time=TIMESTAMP    read data as of specific time (Unix timestamp in microseconds)
```