### PR TITLE
[#28579] yb-admin: Add AdminCli.TestFlushTable* unit tests

### DIFF
--- a/src/yb/tools/yb-admin-test.cc
+++ b/src/yb/tools/yb-admin-test.cc
@@ -1614,6 +1614,52 @@ TEST_F(AdminCliTest, PrintArgumentExpressions) {
   ASSERT_EQ(status.ToString().find(index_expression), std::string::npos);
 }
 
+TEST_F(AdminCliTest, TestFlushTableOutputFormat) {
+  BuildAndStart();
+  const string output = ASSERT_RESULT(CallAdmin("flush_table", kTableName.namespace_name(), kTableName.table_name(), "30" /* timeout */));
+  const string expected_table_name = Format("$0.$1", kTableName.namespace_name(), kTableName.table_name());
+  const std::regex regex(Format(R"(Flushed \[$0.*\] tables\.)", expected_table_name));
+  ASSERT_TRUE(std::regex_search(output, regex)) << "Unexpected output format: " << output;
+}
+
+TEST_F(AdminCliTest, TestFlushTableWithMissingTable) {
+  BuildAndStart();
+  const auto result = CallAdmin("flush_table");
+  ASSERT_FALSE(result.ok());
+  ASSERT_STR_CONTAINS(result.status().ToString(), "Empty list of tables");
+  ASSERT_STR_CONTAINS(result.status().ToString(), "Usage:");
+}
+
+TEST_F(AdminCliTest, TestFlushTableWithInvalidTable) {
+  BuildAndStart();
+  const auto result = CallAdmin("flush_table", "ycql.nonexistent_namespace", "nonexistent_table");
+  ASSERT_FALSE(result.ok());
+  ASSERT_STR_CONTAINS(result.status().ToString(), "not found");
+}
+
+TEST_F(AdminCliTest, TestFlushTableWithTableId) {
+  BuildAndStart();
+  const string master_address = ToString(cluster_->master()->bound_rpc_addr());
+  auto client = ASSERT_RESULT(YBClientBuilder().add_master_server_addr(master_address).Build());
+
+  auto tables = ASSERT_RESULT(client->ListTables(/* filter */ kTableName.table_name(), /* exclude_ysql */ true));
+  ASSERT_EQ(1, tables.size());
+  const auto table_id = tables.front().table_id();
+  const auto table_id_arg = Format("tableid.$0", table_id);
+
+  const string output = ASSERT_RESULT(CallAdmin("flush_table", table_id_arg, /* timeout */ "30"));
+  const string expected_table_name = Format("$0.$1", kTableName.namespace_name(), kTableName.table_name());
+  const std::regex regex(Format(R"(Flushed \[$0.*\] tables\.)", expected_table_name));
+  ASSERT_TRUE(std::regex_search(output, regex)) << "Unexpected output format: " << output;
+}
+
+TEST_F(AdminCliTest, TestFlushTableWithTableIdAndInvalidTableId) {
+  BuildAndStart();
+  const auto result = CallAdmin("flush_table", "tableid.nonexistent_table_id", /* timeout */ "30");
+  ASSERT_FALSE(result.ok());
+  ASSERT_STR_CONTAINS(result.status().ToString(), "not found");
+}
+
 TEST_F(AdminCliTest, TestCompactionStatusBeforeCompaction) {
   BuildAndStart();
   const string master_address = ToString(cluster_->master()->bound_rpc_addr());


### PR DESCRIPTION
https://github.com/yugabyte/yugabyte-db/issues/28579

## Changes Made

Added a couple of new test cases for [yb-admin flush_table](https://docs.yugabyte.com/preview/admin/yb-admin/#flush-table) commands in `src/yb/tools/yb-admin-test.cc`.

Example use cases: 

```sh
# with namespace and table name
./bin/yb-admin flush_table flush_table ysql.yugabyte users 30

# with tableid
./bin/yb-admin flush_table tableid.000034d400003000800000000000431edd 30
```

Confirmed that those pass locally:

```sh
$ ./yb_build.sh release --cxx-test yb-admin-test --gtest_filter="AdminCliTest.TestFlushTable*"
```

```
1/1 Test #323: tools_yb-admin-test ..............   Passed    9.44 sec

The following tests passed:
	tools_yb-admin-test

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   9.46 sec
```