### PR TITLE
Add schema_name as an attribute to table metrics

### DIFF
--- a/src/yb/master/async_rpc_tasks.cc
+++ b/src/yb/master/async_rpc_tasks.cc
@@ -90,6 +90,9 @@ AsyncCreateReplica::AsyncCreateReplica(Master *master,
   req_.mutable_partition()->CopyFrom(tablet_pb.partition());
   req_.set_namespace_id(table_pb.namespace_id());
   req_.set_namespace_name(table_pb.namespace_name());
+  if (table_pb.has_schema_name()) {
+    req_.set_schema_name(table_pb.schema_name());
+  }
   req_.set_pg_table_id(table_pb.pg_table_id());
   req_.set_table_name(table_pb.name());
   req_.mutable_schema()->CopyFrom(table_pb.schema());

--- a/src/yb/master/catalog_entity_info.proto
+++ b/src/yb/master/catalog_entity_info.proto
@@ -86,6 +86,8 @@ message SysTablesEntryPB {
   optional bytes namespace_id = 11;
   // The table namespace name.
   optional bytes namespace_name = 30;
+  // The PostgreSQL schema name.
+  optional string schema_name = 48;
 
   // sequence-id for the table metadata.
   // Used on tablet-report to avoid sending "alter-table" notifications.

--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -5624,6 +5624,17 @@ scoped_refptr<TableInfo> CatalogManager::CreateTableInfo(const CreateTableReques
     // Use empty string (default proto val) so that this passes has_pgschema_name() checks.
     metadata->mutable_schema()->set_deprecated_pgschema_name("");
   }
+
+  // Extract schema_name from the DEPRECATED field and store it in table metadata
+  // for propagation to tablets and metrics.
+  if (metadata->has_schema() && metadata->schema().has_deprecated_pgschema_name()) {
+    metadata->set_schema_name(metadata->schema().deprecated_pgschema_name());
+  } else if (req.table_type() == PGSQL_TABLE_TYPE) {
+    // Default to "public" for YSQL tables without explicit schema
+    metadata->set_schema_name("public");
+  }
+  // For YCQL tables, leave schema_name empty (no schema concept)
+
   partition_schema.ToPB(metadata->mutable_partition_schema());
   // For index table, set index details (indexed table id and whether the index is local).
   if (req.has_index_info()) {

--- a/src/yb/tablet/metadata.proto
+++ b/src/yb/tablet/metadata.proto
@@ -52,6 +52,7 @@ message TableInfoPB {
   optional string namespace_name = 10;
   optional string namespace_id = 13;
   optional string table_name = 2;
+  optional string schema_name = 18;  // PostgreSQL schema name
   optional TableType table_type = 3 [ default = DEFAULT_TABLE_TYPE ];
 
   // Id of operation that added this table to the tablet.

--- a/src/yb/tablet/tablet.cc
+++ b/src/yb/tablet/tablet.cc
@@ -721,6 +721,10 @@ Tablet::Tablet(const TabletInitData& data)
     attrs["table_name"] = metadata_->table_name();
     attrs["table_type"] = TableType_Name(metadata_->table_type());
     attrs["namespace_name"] = metadata_->namespace_name();
+    // Add schema_name for YSQL tables (will be empty for YCQL tables)
+    if (!metadata_->schema_name().empty()) {
+      attrs["schema_name"] = metadata_->schema_name();
+    }
     metric_mem_tracker_ = MemTracker::CreateTracker(
         "Metrics", mem_tracker_, AddToParent::kTrue, CreateMetrics::kFalse);
     table_metrics_entity_ =

--- a/src/yb/tablet/tablet_metadata.cc
+++ b/src/yb/tablet/tablet_metadata.cc
@@ -156,10 +156,12 @@ TableInfo::TableInfo(const std::string& tablet_log_prefix,
                      const OpId& op_id_,
                      HybridTime ht,
                      TableId pg_table_id_,
-                     SkipTableTombstoneCheck skip_table_tombstone_check_)
+                     SkipTableTombstoneCheck skip_table_tombstone_check_,
+                     std::string schema_name_)
     : table_id(std::move(table_id_)),
       namespace_name(std::move(namespace_name)),
       table_name(std::move(table_name)),
+      schema_name(std::move(schema_name_)),
       table_type(table_type),
       cotable_id(CHECK_RESULT(ParseCotableId(primary, table_id))),
       log_prefix(MakeTableInfoLogPrefix(tablet_log_prefix, primary, table_id)),
@@ -186,6 +188,7 @@ TableInfo::TableInfo(const TableInfo& other,
       namespace_name(other.namespace_name),
       namespace_id(other.namespace_id),
       table_name(other.table_name),
+      schema_name(other.schema_name),
       table_type(other.table_type),
       cotable_id(other.cotable_id),
       log_prefix(other.log_prefix),
@@ -214,6 +217,7 @@ TableInfo::TableInfo(const TableInfo& other,
       namespace_name(other.namespace_name),
       namespace_id(other.namespace_id),
       table_name(other.table_name),
+      schema_name(other.schema_name),
       table_type(other.table_type),
       cotable_id(other.cotable_id),
       log_prefix(other.log_prefix),
@@ -235,6 +239,7 @@ TableInfo::TableInfo(const TableInfo& other, SchemaVersion min_schema_version)
       namespace_name(other.namespace_name),
       namespace_id(other.namespace_id),
       table_name(other.table_name),
+      schema_name(other.schema_name),
       table_type(other.table_type),
       cotable_id(other.cotable_id),
       log_prefix(other.log_prefix),
@@ -282,6 +287,7 @@ Status TableInfo::DoLoadFromPB(Primary primary, const TableInfoPB& pb) {
   namespace_name = pb.namespace_name();
   namespace_id = pb.namespace_id();
   table_name = pb.table_name();
+  schema_name = pb.has_schema_name() ? pb.schema_name() : "";
   table_type = pb.table_type();
   cotable_id = VERIFY_RESULT(ParseCotableId(primary, table_id));
   op_id = OpId::FromPB(pb.op_id());
@@ -351,6 +357,7 @@ void TableInfo::ToPB(TableInfoPB* pb) const {
   pb->set_namespace_name(namespace_name);
   pb->set_namespace_id(namespace_id);
   pb->set_table_name(table_name);
+  pb->set_schema_name(schema_name);
   pb->set_table_type(table_type);
 
   doc_read_context->ToPB(schema_version, pb);

--- a/src/yb/tablet/tablet_metadata.h
+++ b/src/yb/tablet/tablet_metadata.h
@@ -87,6 +87,7 @@ struct TableInfo {
   // transaction path.  In some cases this may be empty due to lack of backfilling.
   NamespaceId namespace_id;
   std::string table_name;
+  std::string schema_name;  // PostgreSQL schema name (e.g., "public", "shop", "bloodhound")
   TableType table_type;
   Uuid cotable_id; // table_id as Uuid
 
@@ -143,7 +144,8 @@ struct TableInfo {
             const OpId& op_id,
             HybridTime ht,
             TableId pg_table_id,
-            SkipTableTombstoneCheck skip_table_tombstone_check);
+            SkipTableTombstoneCheck skip_table_tombstone_check,
+            std::string schema_name = "");
   TableInfo(const TableInfo& other,
             const Schema& schema,
             const qlexpr::IndexMap& index_map,

--- a/src/yb/tserver/tablet_service.cc
+++ b/src/yb/tserver/tablet_service.cc
@@ -1723,7 +1723,8 @@ Status TabletServiceAdminImpl::DoCreateTablet(const CreateTabletRequestPB* req,
       req->table_type(), schema, qlexpr::IndexMap(),
       req->has_index_info() ? std::optional<qlexpr::IndexInfo>(req->index_info()) : std::nullopt,
       0 /* schema_version */, partition_schema, OpId{}, HybridTime{}, req->pg_table_id(),
-      tablet::SkipTableTombstoneCheck(FLAGS_ysql_yb_enable_alter_table_rewrite));
+      tablet::SkipTableTombstoneCheck(FLAGS_ysql_yb_enable_alter_table_rewrite),
+      req->has_schema_name() ? req->schema_name() : "");
 
   if (req->has_wal_retention_secs()) {
     table_info->wal_retention_secs = req->wal_retention_secs();

--- a/src/yb/tserver/tserver_admin.proto
+++ b/src/yb/tserver/tserver_admin.proto
@@ -139,6 +139,7 @@ message CreateTabletRequestPB {
 
   optional bytes namespace_id = 14;
   optional bytes namespace_name = 15;
+  optional string schema_name = 20;  // PostgreSQL schema name
   required string table_name = 5;
   optional TableType table_type = 11;
   required SchemaPB schema = 6;


### PR DESCRIPTION
Towards https://github.com/yugabyte/yugabyte-db/issues/28866

This change propagates PostgreSQL schema names from the PgGate layer through the Master to Tablets, and exposes them as a metric attribute for YSQL tables. This enables filtering and aggregation of table-related metrics by schema name, allowing distinction between tables with the same name in different schemas within the same database.

Changes:
- Add schema_name field to TableInfoPB and SysTablesEntryPB protobufs
- Extract schema_name from DEPRECATED_pgschema_name in Master's CreateTable
- Propagate schema_name through CreateTabletRequestPB to tablet servers
- Add schema_name to TableInfo struct and all copy constructors
- Expose schema_name as a metric attribute in Tablet::Init for YSQL tables
- Maintain backward compatibility with empty schema_name default

🤖 Generated with [Claude Code](https://claude.com/claude-code)