### PR TITLE
[#29581] DocDB: Reduce spammy logs in cdc service, tx manager, and rocksdb operations

### DIFF
--- a/src/yb/cdc/cdc_service.cc
+++ b/src/yb/cdc/cdc_service.cc
@@ -4713,8 +4713,7 @@ void CDCServiceImpl::RemoveXReplTabletMetrics(
   }
   auto tablet = tablet_peer->shared_tablet_maybe_null();
   if (tablet == nullptr) {
-    YB_LOG_EVERY_N_SECS_OR_VLOG(WARNING, 300, 4)
-        << "Could not find tablet for tablet peer: " << tablet_peer->tablet_id();
+    VLOG_WITH_FUNC(2) << "Could not find tablet for tablet peer: " << tablet_peer->tablet_id();
     return;
   }
 

--- a/src/yb/client/transaction_manager.cc
+++ b/src/yb/client/transaction_manager.cc
@@ -111,7 +111,7 @@ class TransactionTableState {
     if (PickStatusTabletId(tablets, callback)) {
       return;
     }
-    YB_LOG_EVERY_N_SECS(WARNING, 1) << "No local transaction status tablet found";
+    YB_LOG_EVERY_N_SECS(WARNING, 10) << "No local transaction status tablet found";
     callback(RandomElement(tablets));
   }
 

--- a/src/yb/master/xrepl_catalog_manager.cc
+++ b/src/yb/master/xrepl_catalog_manager.cc
@@ -3004,7 +3004,7 @@ Status CatalogManager::CleanupXReplStreamFromMaps(CDCStreamInfoPtr stream) {
 
 Status CatalogManager::GetCDCStream(
     const GetCDCStreamRequestPB* req, GetCDCStreamResponsePB* resp, rpc::RpcContext* rpc) {
-  LOG(INFO) << "GetCDCStream from " << RequestorString(rpc) << ": " << req->DebugString();
+  VLOG(2) << "GetCDCStream from " << RequestorString(rpc) << ": " << req->DebugString();
 
   if (!req->has_stream_id() && !req->has_cdcsdk_ysql_replication_slot_name()) {
     return STATUS(

--- a/src/yb/rocksdb/db/db_impl.cc
+++ b/src/yb/rocksdb/db/db_impl.cc
@@ -2150,7 +2150,7 @@ Result<FileNumbersHolder> DBImpl::FlushMemTableToOutputFile(
       *made_progress = 1;
     }
     VersionStorageInfo::LevelSummaryStorage tmp;
-    YB_LOG_EVERY_N_SECS(INFO, 1)
+    YB_LOG_EVERY_N_SECS(INFO, 10)
         << "[" << cfd->GetName() << "] Level summary: "
         << cfd->current()->storage_info()->LevelSummary(&tmp);
   }

--- a/src/yb/rpc/reactor.cc
+++ b/src/yb/rpc/reactor.cc
@@ -635,7 +635,7 @@ void Reactor::ScanIdleConnections() {
     if (connection_delta > connection_keepalive_time_) {
       conn->Shutdown(STATUS_FORMAT(
           NetworkError, "Connection timed out after $0", ToSeconds(connection_delta)));
-      LOG_WITH_PREFIX(INFO)
+      VLOG(2)
           << "DEBUG: Closing idle connection: " << conn->ToString()
           << " - it has been idle for " << ToSeconds(connection_delta) << "s";
       VLOG(1) << "(delta: " << ToSeconds(connection_delta)


### PR DESCRIPTION
Reduces overly spammy logs that are exacerbated in larger clusters. In a cluster with 100s of tservers some of these logs were logged millions of times per hour.

Fixes #29581
https://phorge.dev.yugabyte.com/D48824