### PR TITLE
[DOC-1012][ybm] New Relic and Amazon S3 export

### DIFF
--- a/docs/content/stable/yugabyte-cloud/cloud-monitor/managed-integrations.md
+++ b/docs/content/stable/yugabyte-cloud/cloud-monitor/managed-integrations.md
@@ -224,7 +224,7 @@ The [Google Cloud Logging](https://docs.cloud.google.com/logging/docs) integrati
 
 To create an export configuration for Google Cloud Logging, do the following:
 
-1. On the **Integrations** page, click **Configure** for the **Google Cloud Storage** integration or, if a configuration is already available, **Add Configuration**.
+1. On the **Integrations** page, click **Configure** for the **Google Cloud Logging** integration or, if a configuration is already available, **Add Configuration**.
 1. Enter a name for the configuration.
 1. Upload the JSON key file.
 1. Click **Test Configuration** to make sure your connection is working.

--- a/docs/content/stable/yugabyte-cloud/release-notes.md
+++ b/docs/content/stable/yugabyte-cloud/release-notes.md
@@ -176,7 +176,7 @@ rightNav:
 ##### New features
 
 - Support for [Change Data Capture](../cloud-clusters/aeon-cdc/) (CDC) for streaming changes to external processes, applications, or other databases. If you have a new cluster running v2024.1.1 or later, CDC is available automatically. If you have a cluster that was upgraded to v2024.1.1 or later and want to use CDC, contact {{% support-cloud %}}.
-- Support for exporting [pgaudit logs](../cloud-monitor/logging-export/) to third-party tools (Datadog and Google Cloud Storage) for compliance with government, financial, or ISO certification audits.
+- Support for exporting [pgaudit logs](../cloud-monitor/logging-export/) to third-party tools (Datadog and Google Cloud Logging) for compliance with government, financial, or ISO certification audits.
 - General availability for [exporting cluster metrics](../cloud-monitor/managed-integrations/) from clusters deployed in AWS and GCP to [Prometheus](https://prometheus.io/docs/introduction/overview/).
 
 ##### Database


### PR DESCRIPTION
New Relic export for metrics
DOC-1200 Amazon S3 export for logs
DOC-1081 Google Cloud Logging rename

@netlify /stable/yugabyte-cloud/cloud-monitor/managed-integrations/


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (new integration guidance and minor wording fixes) with no runtime or security-impacting code changes.
> 
> **Overview**
> Documents two new third-party export integrations in `managed-integrations.md`: **New Relic** for metric export (OTLP endpoint + license key) and **Amazon S3** for query log export (bucket/region, IAM credentials, path/prefix, partitioning), and adds both to the “Available integrations” table.
> 
> Fixes a docs error by correcting the Google Cloud Logging configuration step (was incorrectly labeled Google Cloud Storage), and updates `release-notes.md` to reference **Google Cloud Logging** (not Storage) as the supported pgaudit log export target.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac09a520b7695ee6b203ad11d7c08bd1ee261435. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->