### PR TITLE
[#7335][#26138] YSQL: Fix postgres to work with node_to_node_encryption_use_client_certificates

### DIFF
--- a/bin/yugabyted
+++ b/bin/yugabyted
@@ -9500,8 +9500,9 @@ class ControlScript(object):
 
         # Initialize the binary path of ybadmin
         # TODO(Sanket): Clean up and refactor this file
-        YBAdminProxy.set_certs_dir(self.configs.saved_data.get("master_flags"), \
-            self.configs.saved_data.get("secure"), self.configs.saved_data.get("certs_dir"))
+        YBAdminProxy.set_certs_dir(
+            self.configs.saved_data.get("master_flags"), self.configs.saved_data.get("secure"),
+            self.configs.saved_data.get("certs_dir"), self.find_hostname_of_node())
 
         YBTableServerCLIProxy.set_certs_dir(self.configs.saved_data.get("master_flags"), \
             self.configs.saved_data.get("secure"), self.configs.saved_data.get("certs_dir"))
@@ -10399,22 +10400,31 @@ class YBAdminProxy(object):
         YBAdminProxy.cmd_args.append(find_binary_location("yb-admin"))
 
     @staticmethod
-    def set_certs_dir(master_flags, secure, certs_dir):
+    def set_certs_dir(master_flags, secure, certs_dir, hostname):
         # If the user is attempting to use TLS, let's point yb-admin to
         # the same certs dir as the master
+
         if secure:
             YBAdminProxy.cmd_args.append("--certs_dir_name={}".format(certs_dir))
-        elif master_flags:
+
+        if master_flags:
+
             flags_list = master_flags.split(",")
-            if 'use_node_to_node_encryption=true' not in flags_list:
-                return
-            certs_dir_name = [y for y in
-                [re.match('certs_dir=(.*)', x) for x in flags_list]
-                if y is not None]
-            if not certs_dir_name[0]:
-                raise RuntimeError("use_node_to_node_encryption=true must "
-                                "be accompanied by a certs_dir setting")
-            YBAdminProxy.cmd_args.append('--certs_dir_name={}'.format(certs_dir_name[0].group(1)))
+
+            if not secure:
+                if 'use_node_to_node_encryption=true' not in flags_list:
+                    return
+                certs_dir_name = [y for y in
+                    [re.match('certs_dir=(.*)', x) for x in flags_list]
+                    if y is not None]
+                if not certs_dir_name[0]:
+                    raise RuntimeError("use_node_to_node_encryption=true must "
+                                    "be accompanied by a certs_dir setting")
+                YBAdminProxy.cmd_args.append(
+                  '--certs_dir_name={}'.format(certs_dir_name[0].group(1)))
+
+            if 'node_to_node_encryption_use_client_certificates=true' in flags_list:
+                YBAdminProxy.cmd_args.append('--client_node_name={}'.format(hostname))
 
     @staticmethod
     def add_master(master_addrs, new_master_ip, new_master_rpc_port, timeout=30):

--- a/src/yb/integration-tests/external_mini_cluster_secure_test.cc
+++ b/src/yb/integration-tests/external_mini_cluster_secure_test.cc
@@ -217,13 +217,12 @@ TEST_F_EX(ExternalMiniClusterSecureTest, InsecureCql, ExternalMiniClusterSecureA
 class ExternalMiniClusterSecureWithClientCertsTest : public ExternalMiniClusterSecureTest {
   void SetUp() override {
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_node_to_node_encryption_use_client_certificates) = true;
-    // TODO: enable ysql after #26138 is fixed
     ExternalMiniClusterSecureTest::SetUp();
   }
 
   ExternalMiniClusterOptions CreateExternalMiniClusterOptions() override {
     auto opts = ExternalMiniClusterSecureTest::CreateExternalMiniClusterOptions();
-    opts.enable_ysql = false;
+    opts.enable_ysql = true;
     return opts;
   }
 };

--- a/src/yb/yql/pggate/pggate.cc
+++ b/src/yb/yql/pggate/pggate.cc
@@ -127,7 +127,8 @@ Result<PgApiImpl::MessengerHolder> BuildMessenger(
   if (FLAGS_use_node_to_node_encryption) {
     secure_context = VERIFY_RESULT(rpc::CreateSecureContext(
         FLAGS_certs_dir,
-        rpc::UseClientCerts(FLAGS_node_to_node_encryption_use_client_certificates)));
+        rpc::UseClientCerts(FLAGS_node_to_node_encryption_use_client_certificates),
+        FLAGS_pggate_cert_base_name));
   }
   return PgApiImpl::MessengerHolder{
       std::move(secure_context),

--- a/src/yb/yql/pggate/pggate_flags.cc
+++ b/src/yb/yql/pggate/pggate_flags.cc
@@ -35,6 +35,9 @@ DEFINE_UNKNOWN_int32(pggate_ybclient_reactor_threads, 2,
 DEFINE_UNKNOWN_string(pggate_master_addresses, "",
               "Addresses of the master servers to which the PostgreSQL proxy server connects.");
 
+DEFINE_NON_RUNTIME_string(pggate_cert_base_name, "",
+              "Certificate base name computed by pg_wrapper");
+
 DEFINE_NON_RUNTIME_string(pggate_tserver_shared_memory_uuid, "",
                           "UUID for shared memory allocator files. This is used by tserver when "
                           "starting postmaster and should never be set explicitly.");

--- a/src/yb/yql/pggate/pggate_flags.h
+++ b/src/yb/yql/pggate/pggate_flags.h
@@ -18,6 +18,7 @@
 DECLARE_int32(pggate_rpc_timeout_secs);
 DECLARE_int32(pggate_ybclient_reactor_threads);
 DECLARE_string(pggate_master_addresses);
+DECLARE_string(pggate_cert_base_name);
 DECLARE_string(pggate_tserver_shared_memory_uuid);
 DECLARE_int32(ysql_request_limit);
 DECLARE_uint64(ysql_prefetch_limit);

--- a/src/yb/yql/pgwrapper/pg_wrapper.cc
+++ b/src/yb/yql/pgwrapper/pg_wrapper.cc
@@ -1236,6 +1236,7 @@ void PgWrapper::SetCommonEnv(Subprocess* proc, bool yb_enabled) {
     // Solution is to specify it explicitly.
     proc->SetEnv("FLAGS_certs_dir", conf_.certs_dir);
     proc->SetEnv("FLAGS_certs_for_client_dir", conf_.certs_for_client_dir);
+    proc->SetEnv("FLAGS_pggate_cert_base_name", conf_.cert_base_name);
 
     proc->SetEnv("YB_PG_TRANSACTIONS_ENABLED", FLAGS_pg_transactions_enabled ? "1" : "0");
 
@@ -1255,6 +1256,7 @@ void PgWrapper::SetCommonEnv(Subprocess* proc, bool yb_enabled) {
     static const std::vector<string> explicit_flags{"pggate_master_addresses",
                                                     "certs_dir",
                                                     "certs_for_client_dir",
+                                                    "pggate_cert_base_name",
                                                     "mem_tracker_tcmalloc_gc_release_bytes",
                                                     "mem_tracker_update_consumption_interval_us"};
     std::vector<google::CommandLineFlagInfo> flag_infos;


### PR DESCRIPTION
This PR fix an issue with postgres not working when using the node_to_node_encryption_use_client_certificates option.

As described in https://github.com/yugabyte/yugabyte-db/issues/7335, this fix it by passing the node name correctly, assuring the client certificate is used.

I had to move around some flags in common to have then in pggate.

Tested in a local cluster, without any issue. I was not able to create some tests for that, if needed I will need some pointers ^^'

This should fix at least #7335 and #26138
