### PR TITLE
OpenTelemetry Prototype Draft

### DIFF
--- a/build-support/build_opentelemetry.sh
+++ b/build-support/build_opentelemetry.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+
+# Copyright (c) YugabyteDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations
+# under the License.
+
+# Build OpenTelemetry C++ SDK with static libraries for YugabyteDB
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+YB_SRC_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Configuration
+OTEL_VERSION="v1.24.0"
+# Default to installing in thirdparty directory (no sudo required)
+OTEL_INSTALL_PREFIX="${OTEL_INSTALL_PREFIX:-${YB_SRC_ROOT}/thirdparty/installed/opentelemetry}"
+BUILD_DIR="/tmp/opentelemetry-cpp-build"
+NUM_JOBS="${NUM_JOBS:-$(sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || echo 4)}"
+
+echo "================================================================"
+echo "Building OpenTelemetry C++ SDK ${OTEL_VERSION}"
+echo "================================================================"
+echo "Install prefix: ${OTEL_INSTALL_PREFIX}"
+echo "Build directory: ${BUILD_DIR}"
+echo "Parallel jobs: ${NUM_JOBS}"
+echo ""
+
+# Check for required tools
+for tool in git cmake make; do
+  if ! command -v "$tool" &> /dev/null; then
+    echo "ERROR: $tool is required but not installed"
+    exit 1
+  fi
+done
+
+# Clean up old build directory
+if [[ -d "${BUILD_DIR}" ]]; then
+  echo "Removing old build directory..."
+  rm -rf "${BUILD_DIR}"
+fi
+
+# Clone OpenTelemetry C++ SDK
+echo "Cloning OpenTelemetry C++ SDK..."
+git clone --recurse-submodules --depth 1 --branch "${OTEL_VERSION}" \
+  https://github.com/open-telemetry/opentelemetry-cpp.git "${BUILD_DIR}"
+
+cd "${BUILD_DIR}"
+
+# Create build directory
+mkdir -p build
+cd build
+
+echo ""
+echo "Configuring OpenTelemetry build..."
+echo ""
+
+# Configure with CMake
+# - Static libraries only (BUILD_SHARED_LIBS=OFF)
+# - OTLP HTTP exporter (avoids gRPC/protobuf conflicts with YugabyteDB)
+# - No examples, tests, or benchmarks
+# - Use libc++ to match YugabyteDB's ABI (required for Linux builds)
+
+# On Linux, use clang with libc++ to match YugabyteDB's ABI
+# macOS uses libc++ by default with Apple clang
+CMAKE_EXTRA_FLAGS=""
+if [[ "$(uname)" != "Darwin" ]]; then
+  # Find clang in YB's LLVM installation
+  CLANG_PATH=""
+  CLANGXX_PATH=""
+  
+  # Check /opt/yb-build/llvm for YB's clang installation
+  for llvm_dir in /opt/yb-build/llvm/yb-llvm-*/; do
+    if [[ -x "${llvm_dir}bin/clang++" ]]; then
+      CLANG_PATH="${llvm_dir}bin/clang"
+      CLANGXX_PATH="${llvm_dir}bin/clang++"
+      break
+    fi
+  done
+  
+  # Fallback to system clang if not found
+  if [[ -z "${CLANGXX_PATH}" ]]; then
+    if command -v clang++ &> /dev/null; then
+      CLANG_PATH="clang"
+      CLANGXX_PATH="clang++"
+    fi
+  fi
+  
+  if [[ -n "${CLANGXX_PATH}" ]]; then
+    echo "Using clang: ${CLANGXX_PATH}"
+    CMAKE_EXTRA_FLAGS="-DCMAKE_C_COMPILER=${CLANG_PATH} -DCMAKE_CXX_COMPILER=${CLANGXX_PATH} -DCMAKE_CXX_FLAGS=-stdlib=libc++ -DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++ -DCMAKE_SHARED_LINKER_FLAGS=-stdlib=libc++"
+  else
+    echo "WARNING: clang++ not found, using default compiler (may cause ABI issues)"
+  fi
+fi
+
+# shellcheck disable=SC2086
+cmake .. \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="${OTEL_INSTALL_PREFIX}" \
+  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+  -DCMAKE_CXX_STANDARD=17 \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DWITH_OTLP_GRPC=OFF \
+  -DWITH_OTLP_HTTP=OFF \
+  -DWITH_HTTP_CLIENT_CURL=OFF \
+  -DWITH_PROMETHEUS=OFF \
+  -DWITH_ZIPKIN=OFF \
+  -DWITH_JAEGER=OFF \
+  -DWITH_ELASTICSEARCH=OFF \
+  -DWITH_EXAMPLES=OFF \
+  -DWITH_LOGS_PREVIEW=OFF \
+  -DWITH_METRICS_PREVIEW=OFF \
+  -DBUILD_TESTING=OFF \
+  -DWITH_BENCHMARK=OFF \
+  ${CMAKE_EXTRA_FLAGS}
+
+echo ""
+echo "Building OpenTelemetry (this may take a few minutes)..."
+echo ""
+
+# Build
+make -j"${NUM_JOBS}"
+
+echo ""
+echo "Installing OpenTelemetry to ${OTEL_INSTALL_PREFIX}..."
+echo ""
+
+# Create install prefix directory if it doesn't exist
+mkdir -p "${OTEL_INSTALL_PREFIX}"
+
+# Install (no sudo - use a writable prefix or set OTEL_INSTALL_PREFIX)
+if [[ -w "${OTEL_INSTALL_PREFIX}" ]]; then
+  make install
+else
+  echo "ERROR: Install directory ${OTEL_INSTALL_PREFIX} is not writable"
+  echo "Either:"
+  echo "  1. Set OTEL_INSTALL_PREFIX to a writable location, or"
+  echo "  2. Create the directory with appropriate permissions first"
+  exit 1
+fi
+
+# Verify installation
+echo ""
+echo "Verifying installation..."
+if [[ -f "${OTEL_INSTALL_PREFIX}/include/opentelemetry/version.h" ]]; then
+  echo "✓ Headers installed"
+else
+  echo "✗ Headers not found"
+  exit 1
+fi
+
+if [[ -f "${OTEL_INSTALL_PREFIX}/lib/libopentelemetry_trace.a" ]]; then
+  echo "✓ Static libraries installed"
+else
+  echo "✗ Static libraries not found"
+  exit 1
+fi
+
+# List installed libraries
+echo ""
+echo "Installed static libraries:"
+ls -lh "${OTEL_INSTALL_PREFIX}/lib/"*.a | awk '{print "  " $9 " (" $5 ")"}'
+
+# Clean up build directory
+echo ""
+echo "Removing build directory ${BUILD_DIR}..."
+rm -rf "${BUILD_DIR}"
+echo "Build directory removed"
+
+echo ""
+echo "================================================================"
+echo "OpenTelemetry C++ SDK installed successfully!"
+echo "================================================================"
+echo ""
+echo "Installation directory: ${OTEL_INSTALL_PREFIX}"
+echo ""
+echo "Next steps:"
+echo "  1. Rebuild YugabyteDB: ./yb_build.sh release"
+echo "  2. CMake will automatically detect and use OpenTelemetry"
+echo ""
+echo "To uninstall:"
+echo "  rm -rf ${OTEL_INSTALL_PREFIX}"
+echo ""
+

--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,44 @@
+name: yugabyte-db
+
+up:
+  - packages:
+      - llvm@16
+      - cmake
+  - go: 1.24.6
+  - python: 3.12.7
+
+  - custom:
+      name: Verify Clang 16
+      met?: /opt/homebrew/opt/llvm@16/bin/clang --version | grep -q "clang version 16"
+      meet: echo "Clang 16 installed via llvm@16"
+  
+#  - custom:
+#      name: Verify CMake >= 3.31
+#      met?: cmake --version | grep -E "cmake version (3\.3[1-9]|3\.[4-9][0-9]|[4-9]\.[0-9]+)"
+#      meet: echo "CMake version check passed"
+
+  # Setup Yugabyte build dir
+  - custom:
+      name: Setup build directory
+      met?: test -d /opt/yb-build && [ "$(stat -f '%Su' /opt/yb-build 2>/dev/null || echo '')" = "$USER" ]
+      meet: sudo mkdir -p /opt/yb-build && sudo chown "$USER" /opt/yb-build
+
+env:
+  # Point to Clang 16
+  CC: /opt/homebrew/opt/llvm@16/bin/clang
+  CXX: /opt/homebrew/opt/llvm@16/bin/clang++
+  LDFLAGS: "-L/opt/homebrew/opt/llvm@16/lib"
+  CPPFLAGS: "-I/opt/homebrew/opt/llvm@16/include"
+
+commands:
+  build:
+    desc: Build Yugabyte 
+    run: ./yb_build.sh release
+  
+#  test:
+#    desc: Run tests
+#    run: ./build/your-test-binary
+  
+#  clean:
+#    desc: Clean build artifacts
+#    run: rm -rf build

--- a/src/postgres/src/backend/access/transam/xact.c
+++ b/src/postgres/src/backend/access/transam/xact.c
@@ -2450,6 +2450,7 @@ CommitTransaction(void)
 		 * Postgres transaction can be aborted at this point without an issue
 		 * in case of YBCCommitTransaction failure.
 		 */
+		YBCOtelCommitStart();
 		YBCCommitTransaction();
 		if (increment_pg_txns)
 			YbIncrementPgTxnsCommitted();
@@ -2486,6 +2487,7 @@ CommitTransaction(void)
 	}
 
 	TRACE_POSTGRESQL_TRANSACTION_COMMIT(MyProc->lxid);
+	YBCOtelCommitDone();
 
 	/*
 	 * Let others know about no transaction in progress by me. Note that this
@@ -3044,6 +3046,7 @@ AbortTransaction(void)
 		XLogSetAsyncXactLSN(XactLastRecEnd);
 	}
 
+	YBCOtelAbortStart();
 	TRACE_POSTGRESQL_TRANSACTION_ABORT(MyProc->lxid);
 
 	/*
@@ -3095,6 +3098,7 @@ AbortTransaction(void)
 	}
 
 	YBCAbortTransaction();
+	YBCOtelAbortDone();
 
 	/* Reset the value of the sticky connection */
 	s->ybUncommittedStickyObjectCount = 0;

--- a/src/postgres/src/backend/tcop/postgres.c
+++ b/src/postgres/src/backend/tcop/postgres.c
@@ -768,6 +768,7 @@ pg_analyze_and_rewrite_fixedparams(RawStmt *parsetree,
 	List	   *querytree_list;
 
 	TRACE_POSTGRESQL_QUERY_REWRITE_START(query_string);
+	YBCOtelRewriteStart();
 
 	/*
 	 * (1) Perform parse analysis.
@@ -786,6 +787,7 @@ pg_analyze_and_rewrite_fixedparams(RawStmt *parsetree,
 	 */
 	querytree_list = pg_rewrite_query(query);
 
+	YBCOtelRewriteDone();
 	TRACE_POSTGRESQL_QUERY_REWRITE_DONE(query_string);
 
 	return querytree_list;
@@ -807,6 +809,7 @@ pg_analyze_and_rewrite_varparams(RawStmt *parsetree,
 	List	   *querytree_list;
 
 	TRACE_POSTGRESQL_QUERY_REWRITE_START(query_string);
+	YBCOtelRewriteStart();
 
 	/*
 	 * (1) Perform parse analysis.
@@ -839,6 +842,7 @@ pg_analyze_and_rewrite_varparams(RawStmt *parsetree,
 	 */
 	querytree_list = pg_rewrite_query(query);
 
+	YBCOtelRewriteDone();
 	TRACE_POSTGRESQL_QUERY_REWRITE_DONE(query_string);
 
 	return querytree_list;
@@ -861,6 +865,7 @@ pg_analyze_and_rewrite_withcb(RawStmt *parsetree,
 	List	   *querytree_list;
 
 	TRACE_POSTGRESQL_QUERY_REWRITE_START(query_string);
+	YBCOtelRewriteStart();
 
 	/*
 	 * (1) Perform parse analysis.
@@ -879,6 +884,7 @@ pg_analyze_and_rewrite_withcb(RawStmt *parsetree,
 	 */
 	querytree_list = pg_rewrite_query(query);
 
+	YBCOtelRewriteDone();
 	TRACE_POSTGRESQL_QUERY_REWRITE_DONE(query_string);
 
 	return querytree_list;

--- a/src/postgres/src/backend/tcop/pquery.c
+++ b/src/postgres/src/backend/tcop/pquery.c
@@ -714,8 +714,7 @@ PortalRun(Portal portal, long count, bool isTopLevel, bool run_once,
 	AssertArg(PortalIsValid(portal));
 
 	TRACE_POSTGRESQL_QUERY_EXECUTE_START();
-	/* Note: YBCOtelExecuteStart() is called in PortalRunMulti for plannable queries
-	 * to avoid duplicate nested execute spans */
+	YBCOtelExecuteStart();
 
 	/* Initialize empty completion data */
 	if (qc)
@@ -868,7 +867,7 @@ PortalRun(Portal portal, long count, bool isTopLevel, bool run_once,
 	if (log_executor_stats && portal->strategy != PORTAL_MULTI_QUERY)
 		ShowUsage("EXECUTOR STATISTICS");
 
-	/* Note: YBCOtelExecuteDone() is called in PortalRunMulti for plannable queries */
+	YBCOtelExecuteDone();
 	TRACE_POSTGRESQL_QUERY_EXECUTE_DONE();
 
 	return result;
@@ -1258,7 +1257,6 @@ PortalRunMulti(Portal portal,
 			 * process a plannable query.
 			 */
 			TRACE_POSTGRESQL_QUERY_EXECUTE_START();
-			YBCOtelExecuteStart();
 
 			if (log_executor_stats)
 				ResetUsage();
@@ -1323,7 +1321,6 @@ PortalRunMulti(Portal portal,
 			if (log_executor_stats)
 				ShowUsage("EXECUTOR STATISTICS");
 
-			YBCOtelExecuteDone();
 			TRACE_POSTGRESQL_QUERY_EXECUTE_DONE();
 		}
 		else

--- a/src/postgres/src/backend/tcop/pquery.c
+++ b/src/postgres/src/backend/tcop/pquery.c
@@ -714,8 +714,7 @@ PortalRun(Portal portal, long count, bool isTopLevel, bool run_once,
 	AssertArg(PortalIsValid(portal));
 
 	TRACE_POSTGRESQL_QUERY_EXECUTE_START();
-	/* Note: YBCOtelExecuteStart() is called in PortalRunMulti for plannable queries
-	 * to avoid duplicate nested execute spans */
+	YBCOtelExecuteStart();
 
 	/* Initialize empty completion data */
 	if (qc)
@@ -868,7 +867,7 @@ PortalRun(Portal portal, long count, bool isTopLevel, bool run_once,
 	if (log_executor_stats && portal->strategy != PORTAL_MULTI_QUERY)
 		ShowUsage("EXECUTOR STATISTICS");
 
-	/* Note: YBCOtelExecuteDone() is called in PortalRunMulti for plannable queries */
+	YBCOtelExecuteDone();
 	TRACE_POSTGRESQL_QUERY_EXECUTE_DONE();
 
 	return result;

--- a/src/postgres/src/backend/tcop/pquery.c
+++ b/src/postgres/src/backend/tcop/pquery.c
@@ -1257,7 +1257,6 @@ PortalRunMulti(Portal portal,
 			 * process a plannable query.
 			 */
 			TRACE_POSTGRESQL_QUERY_EXECUTE_START();
-			YBCOtelExecuteStart();
 
 			if (log_executor_stats)
 				ResetUsage();
@@ -1322,7 +1321,6 @@ PortalRunMulti(Portal portal,
 			if (log_executor_stats)
 				ShowUsage("EXECUTOR STATISTICS");
 
-			YBCOtelExecuteDone();
 			TRACE_POSTGRESQL_QUERY_EXECUTE_DONE();
 		}
 		else

--- a/src/postgres/src/include/pg_yb_utils.h
+++ b/src/postgres/src/include/pg_yb_utils.h
@@ -352,6 +352,25 @@ extern void YBCRollbackToSubTransaction(SubTransactionId id);
 extern bool YBIsPgLockingEnabled();
 
 /*
+ * Parse and store the traceparent from a SQL query comment.
+ * Expected format: comment with traceparent:00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
+ * This should be called at the start of query execution.
+ */
+extern void YbSetTraceparentFromQuery(const char *query_string);
+
+/*
+ * Get the current traceparent string (may be empty if none was set).
+ * Returns a pointer to an internal buffer that is valid until the next call to
+ * YbSetTraceparentFromQuery or YbClearTraceparent.
+ */
+extern const char *YbGetCurrentTraceparent(void);
+
+/*
+ * Clear the current traceparent.
+ */
+extern void YbClearTraceparent(void);
+
+/*
  * Get the type ID of a real or virtual attribute (column).
  * Returns InvalidOid if the attribute number is invalid.
  */

--- a/src/yb/rpc/outbound_call.cc
+++ b/src/yb/rpc/outbound_call.cc
@@ -243,24 +243,19 @@ OutboundCall::OutboundCall(const RemoteMethod& remote_method,
   IncrementCounter(rpc_metrics_->outbound_calls_created);
   IncrementGauge(rpc_metrics_->outbound_calls_alive);
 
-  // Start an OpenTelemetry span for this RPC call
-  // Only create spans when there's an active parent context to reduce noise
-  if (OtelTracing::HasActiveContext()) {
-    otel_span_ = OtelTracing::StartSpan(Format("rpc.client $0", remote_method_.ToString()));
+  const auto& traceparent = controller_->traceparent();
+  if (!traceparent.empty()) {
+    otel_span_ = OtelTracing::StartSpanFromTraceparent(
+        Format("rpc.client $0", remote_method_.ToString()), traceparent);
     if (otel_span_.IsActive()) {
-      LOG(INFO) << "[OTEL DEBUG] Created RPC span (child) for call_id=" << call_id_ 
-                << " method=" << remote_method_.ToString();
       otel_span_.SetAttribute("rpc.system", "yugabytedb");
       otel_span_.SetAttribute("rpc.service", remote_method_.service_name());
       otel_span_.SetAttribute("rpc.method", remote_method_.method_name());
       otel_span_.SetAttribute("rpc.call_id", static_cast<int64_t>(call_id_));
       if (controller_->timeout().Initialized()) {
-        otel_span_.SetAttribute("rpc.timeout_ms", 
-                                static_cast<int64_t>(controller_->timeout().ToMilliseconds()));
+        otel_span_.SetAttribute("rpc.timeout_ms", controller_->timeout().ToMilliseconds());
       }
     }
-  } else {
-    VLOG(3) << "[OTEL DEBUG] No active context, skipping RPC span creation for call_id=" << call_id_;
   }
 }
 

--- a/src/yb/rpc/outbound_call.cc
+++ b/src/yb/rpc/outbound_call.cc
@@ -243,24 +243,17 @@ OutboundCall::OutboundCall(const RemoteMethod& remote_method,
   IncrementCounter(rpc_metrics_->outbound_calls_created);
   IncrementGauge(rpc_metrics_->outbound_calls_alive);
 
-  // Start an OpenTelemetry span for this RPC call
-  // Only create spans when there's an active parent context to reduce noise
   if (OtelTracing::HasActiveContext()) {
     otel_span_ = OtelTracing::StartSpan(Format("rpc.client $0", remote_method_.ToString()));
     if (otel_span_.IsActive()) {
-      LOG(INFO) << "[OTEL DEBUG] Created RPC span (child) for call_id=" << call_id_ 
-                << " method=" << remote_method_.ToString();
       otel_span_.SetAttribute("rpc.system", "yugabytedb");
       otel_span_.SetAttribute("rpc.service", remote_method_.service_name());
       otel_span_.SetAttribute("rpc.method", remote_method_.method_name());
       otel_span_.SetAttribute("rpc.call_id", static_cast<int64_t>(call_id_));
       if (controller_->timeout().Initialized()) {
-        otel_span_.SetAttribute("rpc.timeout_ms", 
-                                static_cast<int64_t>(controller_->timeout().ToMilliseconds()));
+        otel_span_.SetAttribute("rpc.timeout_ms", controller_->timeout().ToMilliseconds());
       }
     }
-  } else {
-    VLOG(3) << "[OTEL DEBUG] No active context, skipping RPC span creation for call_id=" << call_id_;
   }
 }
 

--- a/src/yb/rpc/rpc_controller.h
+++ b/src/yb/rpc/rpc_controller.h
@@ -32,6 +32,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 #include "yb/util/logging.h"
 
@@ -139,6 +140,11 @@ class RpcController {
 
   InvokeCallbackMode invoke_callback_mode() { return invoke_callback_mode_; }
 
+  // Set the traceparent for distributed tracing. If set, the RPC will create
+  // a child span under this traceparent. If not set, no tracing span is created.
+  void set_traceparent(const std::string& traceparent) { traceparent_ = traceparent; }
+  const std::string& traceparent() const { return traceparent_; }
+
   // Return the configured timeout.
   MonoDelta timeout() const;
 
@@ -183,6 +189,7 @@ class RpcController {
 
   std::unique_ptr<Sidecars> outbound_sidecars_;
   bool TEST_disable_outbound_call_response_processing = false;
+  std::string traceparent_;
 
   DISALLOW_COPY_AND_ASSIGN(RpcController);
 };

--- a/src/yb/tserver/tablet_server_main_impl.cc
+++ b/src/yb/tserver/tablet_server_main_impl.cc
@@ -66,6 +66,7 @@
 #include "yb/util/logging.h"
 #include "yb/util/main_util.h"
 #include "yb/util/mem_tracker.h"
+#include "yb/util/otel_tracing.h"
 #include "yb/util/port_picker.h"
 #include "yb/util/result.h"
 #include "yb/util/size_literals.h"
@@ -247,6 +248,9 @@ int TabletServerMain(int argc, char** argv) {
 
   LOG_AND_RETURN_FROM_MAIN_NOT_OK(MasterTServerParseFlagsAndInit(
       TabletServerOptions::kServerType, /*is_master=*/false, &argc, &argv));
+
+  // Initialize OpenTelemetry tracing (if enabled via environment variables)
+  LOG_AND_RETURN_FROM_MAIN_NOT_OK(OtelTracing::InitFromEnv("yb-tserver"));
 
   auto termination_monitor = TerminationMonitor::Create();
 
@@ -436,6 +440,9 @@ int TabletServerMain(int argc, char** argv) {
 
   LOG(WARNING) << "Stopping Tablet server";
   server->Shutdown();
+
+  // Shutdown OpenTelemetry tracing
+  OtelTracing::Shutdown();
 
   return EXIT_SUCCESS;
 }

--- a/src/yb/util/CMakeLists.txt
+++ b/src/yb/util/CMakeLists.txt
@@ -183,6 +183,8 @@ set(UTIL_SRCS
   oid_generator.cc
   once.cc
   operation_counter.cc
+  otel_tracing.cc
+  otel_http_exporter.cc
   os-util.cc
   path_util.cc
   pb_util-internal.cc
@@ -264,6 +266,65 @@ set(UTIL_LIBS
   zlib
   ${OPENSSL_CRYPTO_LIBRARY}
   ${OPENSSL_SSL_LIBRARY})
+
+# Add OpenTelemetry static libraries
+# OpenTelemetry must be built from source with static libraries.
+# See build-support/build_opentelemetry.sh for the build script.
+# Look for OpenTelemetry in standard locations
+# First check thirdparty/installed (default for build_opentelemetry.sh)
+set(OTEL_SEARCH_PATHS
+  "${YB_SRC_ROOT}/thirdparty/installed/opentelemetry"
+  "/usr/local/opentelemetry"
+  "/opt/opentelemetry"
+  "$ENV{HOME}/.local/opentelemetry")
+
+foreach(SEARCH_PATH ${OTEL_SEARCH_PATHS})
+  if(EXISTS "${SEARCH_PATH}/include/opentelemetry/version.h")
+    set(OTEL_ROOT "${SEARCH_PATH}")
+    break()
+  endif()
+endforeach()
+
+if(OTEL_ROOT)
+  message(STATUS "Found OpenTelemetry at ${OTEL_ROOT}")
+  include_directories(SYSTEM "${OTEL_ROOT}/include")
+
+  # Find required static libraries (using ostream exporter for simplicity)
+  find_library(OTEL_TRACE_LIB
+    NAMES libopentelemetry_trace.a
+    PATHS "${OTEL_ROOT}/lib"
+    NO_DEFAULT_PATH)
+  find_library(OTEL_COMMON_LIB
+    NAMES libopentelemetry_common.a
+    PATHS "${OTEL_ROOT}/lib"
+    NO_DEFAULT_PATH)
+  find_library(OTEL_RESOURCES_LIB
+    NAMES libopentelemetry_resources.a
+    PATHS "${OTEL_ROOT}/lib"
+    NO_DEFAULT_PATH)
+  find_library(OTEL_EXPORTER_OSTREAM_LIB
+    NAMES libopentelemetry_exporter_ostream_span.a
+    PATHS "${OTEL_ROOT}/lib"
+    NO_DEFAULT_PATH)
+
+  if(OTEL_TRACE_LIB AND OTEL_COMMON_LIB AND OTEL_EXPORTER_OSTREAM_LIB)
+    message(STATUS "OpenTelemetry static libraries found - OTEL support enabled")
+
+    # Use ostream exporter (logs spans to stderr) to avoid complex dependencies
+    # This is a simple, reliable exporter with no external dependencies
+    list(APPEND UTIL_LIBS
+      ${OTEL_EXPORTER_OSTREAM_LIB}
+      ${OTEL_TRACE_LIB}
+      ${OTEL_RESOURCES_LIB}
+      ${OTEL_COMMON_LIB})
+  else()
+    message(STATUS "OpenTelemetry static libraries not found - OTEL support disabled")
+    message(STATUS "  To enable OTEL: run build-support/build_opentelemetry.sh")
+  endif()
+else()
+  message(STATUS "OpenTelemetry not found - OTEL support disabled")
+  message(STATUS "  To enable OTEL: run build-support/build_opentelemetry.sh")
+endif()
 
 if(NOT APPLE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DROCKSDB_FALLOCATE_PRESENT")

--- a/src/yb/util/otel_http_exporter.cc
+++ b/src/yb/util/otel_http_exporter.cc
@@ -1,0 +1,219 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/util/otel_http_exporter.h"
+
+#include <cstdlib>
+#include <iomanip>
+#include <sstream>
+
+#include "yb/util/curl_util.h"
+#include "yb/util/faststring.h"
+#include "yb/util/logging.h"
+#include "yb/util/status.h"
+
+namespace yb {
+
+namespace {
+
+// Global singleton instance
+SimpleOtlpHttpSender g_otlp_sender;
+
+}  // namespace
+
+SimpleOtlpHttpSender::SimpleOtlpHttpSender()
+    : service_name_("yugabyte"), enabled_(false) {}
+
+SimpleOtlpHttpSender::~SimpleOtlpHttpSender() = default;
+
+void SimpleOtlpHttpSender::SetEndpoint(const std::string& endpoint) {
+  endpoint_ = endpoint;
+  enabled_.store(!endpoint_.empty(), std::memory_order_release);
+}
+
+void SimpleOtlpHttpSender::SetServiceName(const std::string& service_name) {
+  service_name_ = service_name;
+}
+
+bool SimpleOtlpHttpSender::IsEnabled() const {
+  return enabled_.load(std::memory_order_acquire);
+}
+
+bool SimpleOtlpHttpSender::SendSpan(const SimpleSpanData& span) {
+  std::vector<SimpleSpanData> spans;
+  spans.push_back(span);
+  return SendSpans(spans);
+}
+
+bool SimpleOtlpHttpSender::SendSpans(const std::vector<SimpleSpanData>& spans) {
+  if (!IsEnabled()) {
+    VLOG(2) << "[OTEL] HTTP sender not enabled, skipping export";
+    return true;
+  }
+
+  if (spans.empty()) {
+    return true;  // Nothing to do
+  }
+
+  std::string json_payload = SpansToJson(spans);
+
+  LOG(INFO) << "[OTEL] Sending " << spans.size() << " span(s) to " << endpoint_;
+  VLOG(3) << "[OTEL] Payload: " << json_payload;
+
+  try {
+    EasyCurl curl;
+    faststring response;
+
+    auto status = curl.PostToURL(
+        endpoint_,
+        json_payload,
+        "application/json",
+        &response,
+        5  // 5 second timeout
+    );
+
+    if (!status.ok()) {
+      LOG(WARNING) << "[OTEL] HTTP POST to " << endpoint_ << " failed: " << status.ToString();
+      return false;
+    }
+
+    LOG(INFO) << "[OTEL] Successfully sent " << spans.size() << " span(s), response: " 
+              << response.size() << " bytes";
+    return true;
+
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "[OTEL] Exception sending to collector: " << e.what();
+    return false;
+  }
+}
+
+std::string SimpleOtlpHttpSender::JsonEscape(const std::string& str) {
+  std::ostringstream oss;
+  for (size_t i = 0; i < str.size(); ++i) {
+    unsigned char c = static_cast<unsigned char>(str[i]);
+    switch (c) {
+      case '"':  oss << "\\\""; break;
+      case '\\': oss << "\\\\"; break;
+      case '\b': oss << "\\b"; break;
+      case '\f': oss << "\\f"; break;
+      case '\n': oss << "\\n"; break;
+      case '\r': oss << "\\r"; break;
+      case '\t': oss << "\\t"; break;
+      default:
+        if (c < 0x20) {
+          oss << "\\u" << std::hex << std::setw(4) << std::setfill('0') << static_cast<int>(c);
+        } else {
+          oss << c;
+        }
+        break;
+    }
+  }
+  return oss.str();
+}
+
+std::string SimpleOtlpHttpSender::SpansToJson(const std::vector<SimpleSpanData>& spans) const {
+  std::ostringstream json;
+
+  // OTLP JSON structure
+  json << R"({"resourceSpans":[{"resource":{"attributes":[)";
+  json << R"({"key":"service.name","value":{"stringValue":")" << JsonEscape(service_name_) << R"("}},)";
+  json << R"({"key":"telemetry.sdk.language","value":{"stringValue":"cpp"}},)";
+  json << R"({"key":"telemetry.sdk.name","value":{"stringValue":"yugabyte-simple"}})";
+  json << R"(]},"scopeSpans":[{"scope":{"name":"yugabyte","version":"1.0.0"},"spans":[)";
+
+  bool first_span = true;
+  for (size_t i = 0; i < spans.size(); ++i) {
+    const SimpleSpanData& span = spans[i];
+
+    if (!first_span) {
+      json << ",";
+    }
+    first_span = false;
+
+    json << "{";
+    json << R"("traceId":")" << span.trace_id << R"(",)";
+    json << R"("spanId":")" << span.span_id << R"(",)";
+
+    if (!span.parent_span_id.empty()) {
+      json << R"("parentSpanId":")" << span.parent_span_id << R"(",)";
+    }
+
+    json << R"("name":")" << JsonEscape(span.name) << R"(",)";
+    json << R"("kind":)" << span.kind << ",";
+    json << R"("startTimeUnixNano":")" << span.start_time_ns << R"(",)";
+    json << R"("endTimeUnixNano":")" << span.end_time_ns << R"(",)";
+
+    // Attributes
+    json << R"("attributes":[)";
+    bool first_attr = true;
+    for (size_t j = 0; j < span.string_attributes.size(); ++j) {
+      if (!first_attr) json << ",";
+      first_attr = false;
+      json << R"({"key":")" << JsonEscape(span.string_attributes[j].first)
+           << R"(","value":{"stringValue":")" << JsonEscape(span.string_attributes[j].second) << R"("}})";
+    }
+    for (size_t j = 0; j < span.int_attributes.size(); ++j) {
+      if (!first_attr) json << ",";
+      first_attr = false;
+      json << R"({"key":")" << JsonEscape(span.int_attributes[j].first)
+           << R"(","value":{"intValue":")" << span.int_attributes[j].second << R"("}})";
+    }
+    json << "],";
+
+    // Status
+    json << R"("status":{"code":)" << span.status_code;
+    if (!span.status_message.empty()) {
+      json << R"(,"message":")" << JsonEscape(span.status_message) << R"(")";
+    }
+    json << "}}";
+  }
+
+  json << "]}]}]}";
+  return json.str();
+}
+
+SimpleOtlpHttpSender& GetGlobalOtlpSender() {
+  return g_otlp_sender;
+}
+
+void InitGlobalOtlpSenderFromEnv(const std::string& service_name) {
+  // Read endpoint from OTEL_EXPORTER_OTLP_ENDPOINT environment variable
+  std::string endpoint;
+  const char* endpoint_env = std::getenv("OTEL_EXPORTER_OTLP_ENDPOINT");
+  
+  if (endpoint_env && endpoint_env[0] != '\0') {
+    // Per OTLP spec, OTEL_EXPORTER_OTLP_ENDPOINT is the base URL
+    // Append /v1/traces for the traces signal
+    endpoint = endpoint_env;
+    // Only append /v1/traces if it's not already part of the URL
+    if (endpoint.find("/v1/traces") == std::string::npos) {
+      // Remove trailing slash if present before appending
+      if (!endpoint.empty() && endpoint.back() == '/') {
+        endpoint.pop_back();
+      }
+      endpoint += "/v1/traces";
+    }
+  } else {
+    // Default endpoint for local development
+    endpoint = "http://localhost:4318/v1/traces";
+  }
+  
+  g_otlp_sender.SetEndpoint(endpoint);
+  LOG(INFO) << "[OTEL] HTTP exporter endpoint: " << endpoint;
+
+  // Set the service name (already resolved by caller)
+  g_otlp_sender.SetServiceName(service_name);
+  LOG(INFO) << "[OTEL] HTTP exporter service name: " << service_name;
+}
+
+}  // namespace yb

--- a/src/yb/util/otel_http_exporter.h
+++ b/src/yb/util/otel_http_exporter.h
@@ -1,0 +1,95 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace yb {
+
+// Simple span data structure - no OTEL SDK dependencies.
+// This allows us to capture span data without pulling in any OTEL headers.
+struct SimpleSpanData {
+  std::string trace_id;        // 32-char hex string
+  std::string span_id;         // 16-char hex string
+  std::string parent_span_id;  // 16-char hex string or empty
+  std::string name;
+  int64_t start_time_ns;       // Nanoseconds since Unix epoch
+  int64_t end_time_ns;         // Nanoseconds since Unix epoch
+  int kind;                    // 1=internal, 2=server, 3=client, 4=producer, 5=consumer
+  int status_code;             // 0=unset, 1=ok, 2=error
+  std::string status_message;
+  std::vector<std::pair<std::string, std::string> > string_attributes;
+  std::vector<std::pair<std::string, int64_t> > int_attributes;
+
+  SimpleSpanData()
+      : start_time_ns(0), end_time_ns(0), kind(1), status_code(0) {}
+};
+
+// Minimal OTLP/HTTP JSON sender for OpenTelemetry traces.
+// This class has ZERO OTEL SDK dependencies - it works entirely with SimpleSpanData
+// and standard C++ types, avoiding any potential ABI/template issues.
+//
+// Usage:
+//   SimpleOtlpHttpSender sender;
+//   sender.SetServiceName("my-service");
+//   sender.SetEndpoint("http://localhost:4318/v1/traces");
+//
+//   SimpleSpanData span;
+//   span.trace_id = "...";
+//   // ... fill in other fields
+//   sender.SendSpan(span);
+//
+class SimpleOtlpHttpSender {
+ public:
+  SimpleOtlpHttpSender();
+  ~SimpleOtlpHttpSender();
+
+  // Configuration
+  void SetEndpoint(const std::string& endpoint);
+  void SetServiceName(const std::string& service_name);
+
+  // Send a single span to the collector. Returns true on success.
+  bool SendSpan(const SimpleSpanData& span);
+
+  // Send multiple spans in a single request. Returns true on success.
+  bool SendSpans(const std::vector<SimpleSpanData>& spans);
+
+  // Check if the sender is enabled (endpoint is set)
+  bool IsEnabled() const;
+
+ private:
+  // Convert spans to OTLP/HTTP JSON format
+  std::string SpansToJson(const std::vector<SimpleSpanData>& spans) const;
+
+  // Escape a string for JSON
+  static std::string JsonEscape(const std::string& str);
+
+  std::string endpoint_;
+  std::string service_name_;
+  std::atomic<bool> enabled_;
+};
+
+// Global singleton accessor for convenience
+SimpleOtlpHttpSender& GetGlobalOtlpSender();
+
+// Initialize the global sender from environment variables:
+// - OTEL_EXPORTER_OTLP_ENDPOINT: Base endpoint (default: http://localhost:4318)
+// The service_name parameter should be the already-resolved service name.
+void InitGlobalOtlpSenderFromEnv(const std::string& service_name);
+
+}  // namespace yb

--- a/src/yb/util/otel_tracing.cc
+++ b/src/yb/util/otel_tracing.cc
@@ -1,0 +1,510 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/util/otel_tracing.h"
+
+#include <chrono>
+#include <cstdlib>
+#include <iomanip>
+#include <mutex>
+#include <sstream>
+
+#include <opentelemetry/exporters/ostream/span_exporter_factory.h>
+#include <opentelemetry/sdk/trace/processor.h>
+#include <opentelemetry/sdk/trace/simple_processor_factory.h>
+#include <opentelemetry/sdk/trace/tracer_provider.h>
+#include <opentelemetry/sdk/trace/tracer_provider_factory.h>
+#include <opentelemetry/trace/propagation/http_trace_context.h>
+#include <opentelemetry/trace/provider.h>
+#include <opentelemetry/trace/span.h>
+#include <opentelemetry/trace/span_context.h>
+#include <opentelemetry/trace/tracer.h>
+#include <opentelemetry/context/propagation/text_map_propagator.h>
+#include <opentelemetry/context/propagation/global_propagator.h>
+#include <opentelemetry/context/runtime_context.h>
+
+#include "yb/util/logging.h"
+#include "yb/util/otel_http_exporter.h"
+#include "yb/util/status.h"
+
+// -------------------------------------------------------------------------------------------------
+// Bridging stubs for PostgreSQL traceparent helpers
+//
+// The PostgreSQL backend defines real C functions with these names in
+// src/postgres/src/backend/utils/misc/pg_yb_utils.c. We also link a number of
+// non-Postgres tools (e.g. log-dump, protoc-gen-yrpc) against libyb_pggate.so,
+// which declares these symbols but does not link against the Postgres backend.
+//
+// Because YugabyteDB executables are linked with -Wl,--no-allow-shlib-undefined,
+// any shared library on the link line must have all of its undefined references
+// resolved. To avoid forcing every non-Postgres tool to link against the
+// Postgres backend library, we provide weak, no-op fallbacks here in libyb_util.
+//
+// When the Postgres backend is linked into a process, its strong definitions of
+// these functions override these weak stubs, so query-level traceparent
+// propagation continues to work as intended.
+// -------------------------------------------------------------------------------------------------
+extern "C" {
+
+__attribute__((weak)) const char* YbGetCurrentTraceparent(void) {
+  // No active traceparent in non-Postgres contexts.
+  return "";
+}
+
+__attribute__((weak)) void YbClearTraceparent(void) {
+  // No-op when running outside the Postgres backend.
+}
+
+}  // extern "C"
+
+namespace nostd = opentelemetry::nostd;
+namespace trace_api = opentelemetry::trace;
+namespace trace_sdk = opentelemetry::sdk::trace;
+namespace ostream_exporter = opentelemetry::exporter::trace;
+
+namespace yb {
+
+namespace otel_internal {
+
+// Internal span context - holds the actual OpenTelemetry span and metadata for HTTP export
+struct SpanContext {
+  bool active = false;
+  nostd::shared_ptr<trace_api::Span> span;
+  nostd::shared_ptr<trace_api::Scope> scope;
+
+  // Metadata for HTTP export (stored at span creation time)
+  std::string name;
+  std::string parent_span_id;  // 16-char hex or empty
+  int64_t start_time_ns = 0;
+  int span_kind = 1;  // 1=internal, 2=server, 3=client
+  int status_code = 0;  // 0=unset, 1=ok, 2=error
+  std::string status_message;
+  std::vector<std::pair<std::string, std::string> > string_attributes;
+  std::vector<std::pair<std::string, int64_t> > int_attributes;
+};
+
+}  // namespace otel_internal
+
+namespace {
+
+// Global state
+std::atomic<bool> g_otel_enabled{false};
+std::string g_service_name;
+std::mutex g_init_mutex;
+nostd::shared_ptr<trace_api::TracerProvider> g_tracer_provider;
+nostd::shared_ptr<trace_api::Tracer> g_tracer;
+
+// Helper to convert trace ID to 32-char hex string
+std::string TraceIdToHex(const trace_api::TraceId& trace_id) {
+  std::ostringstream oss;
+  oss << std::hex << std::setfill('0');
+  for (size_t i = 0; i < trace_api::TraceId::kSize; ++i) {
+    oss << std::setw(2) << static_cast<int>(trace_id.Id()[i]);
+  }
+  return oss.str();
+}
+
+// Helper to convert span ID to 16-char hex string
+std::string SpanIdToHex(const trace_api::SpanId& span_id) {
+  std::ostringstream oss;
+  oss << std::hex << std::setfill('0');
+  for (size_t i = 0; i < trace_api::SpanId::kSize; ++i) {
+    oss << std::setw(2) << static_cast<int>(span_id.Id()[i]);
+  }
+  return oss.str();
+}
+
+// Get current time in nanoseconds since Unix epoch
+int64_t GetCurrentTimeNanos() {
+  auto now = std::chrono::system_clock::now();
+  auto duration = now.time_since_epoch();
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count();
+}
+
+}  // anonymous namespace
+
+// OtelSpanHandle implementation
+
+OtelSpanHandle::OtelSpanHandle() : context_(nullptr) {}
+
+OtelSpanHandle::OtelSpanHandle(std::unique_ptr<otel_internal::SpanContext> context)
+    : context_(std::move(context)) {}
+
+OtelSpanHandle::~OtelSpanHandle() {
+  if (context_ && context_->active && context_->span) {
+    // Export via HTTP before ending the span
+    if (GetGlobalOtlpSender().IsEnabled()) {
+      SimpleSpanData span_data;
+
+      // Extract trace_id and span_id from the OTEL span
+      auto span_context = context_->span->GetContext();
+      span_data.trace_id = TraceIdToHex(span_context.trace_id());
+      span_data.span_id = SpanIdToHex(span_context.span_id());
+      span_data.parent_span_id = context_->parent_span_id;
+
+      span_data.name = context_->name;
+      span_data.start_time_ns = context_->start_time_ns;
+      span_data.end_time_ns = GetCurrentTimeNanos();
+      span_data.kind = context_->span_kind;
+      span_data.status_code = context_->status_code;
+      span_data.status_message = context_->status_message;
+      span_data.string_attributes = context_->string_attributes;
+      span_data.int_attributes = context_->int_attributes;
+
+      LOG(INFO) << "[OTEL] Exporting span via HTTP: " << span_data.name
+                << " trace_id=" << span_data.trace_id
+                << " span_id=" << span_data.span_id;
+
+      bool sent = GetGlobalOtlpSender().SendSpan(span_data);
+      if (!sent) {
+        LOG(WARNING) << "[OTEL] Failed to send span via HTTP: " << span_data.name;
+      }
+    }
+
+    context_->span->End();
+  }
+}
+
+OtelSpanHandle::OtelSpanHandle(OtelSpanHandle&& other) noexcept
+    : context_(std::move(other.context_)) {}
+
+OtelSpanHandle& OtelSpanHandle::operator=(OtelSpanHandle&& other) noexcept {
+  if (this != &other) {
+    context_ = std::move(other.context_);
+  }
+  return *this;
+}
+
+void OtelSpanHandle::SetStatus(bool ok, const std::string& description) {
+  if (!context_ || !context_->active) return;
+
+  // Store for HTTP export
+  context_->status_code = ok ? 1 : 2;
+  context_->status_message = description;
+
+  if (context_->span) {
+    if (ok) {
+      context_->span->SetStatus(trace_api::StatusCode::kOk, description);
+    } else {
+      context_->span->SetStatus(trace_api::StatusCode::kError, description);
+    }
+  }
+}
+
+void OtelSpanHandle::SetAttribute(const std::string& key, const std::string& value) {
+  if (!context_ || !context_->active) return;
+
+  // Store for HTTP export
+  context_->string_attributes.push_back(std::make_pair(key, value));
+
+  if (context_->span) {
+    context_->span->SetAttribute(key, value);
+  }
+}
+
+void OtelSpanHandle::SetAttribute(const std::string& key, int64_t value) {
+  if (!context_ || !context_->active) return;
+
+  // Store for HTTP export
+  context_->int_attributes.push_back(std::make_pair(key, value));
+
+  if (context_->span) {
+    context_->span->SetAttribute(key, value);
+  }
+}
+
+void OtelSpanHandle::SetAttribute(const std::string& key, double value) {
+  if (!context_ || !context_->active) return;
+  // Note: double attributes not stored for HTTP export yet (could add if needed)
+  if (context_->span) {
+    context_->span->SetAttribute(key, value);
+  }
+}
+
+void OtelSpanHandle::SetAttribute(const std::string& key, bool value) {
+  if (!context_ || !context_->active) return;
+  // Note: bool attributes not stored for HTTP export yet (could add if needed)
+  if (context_->span) {
+    context_->span->SetAttribute(key, value);
+  }
+}
+
+bool OtelSpanHandle::IsActive() const {
+  return context_ && context_->active;
+}
+
+// OtelTracing implementation
+
+Status OtelTracing::InitFromEnv(const std::string& default_service_name) {
+  std::lock_guard<std::mutex> lock(g_init_mutex);
+
+  LOG(INFO) << "[OTEL DEBUG] InitFromEnv called with service name: " << default_service_name;
+
+  g_service_name = default_service_name;
+
+  // Initialize the HTTP exporter from environment, passing the service name
+  InitGlobalOtlpSenderFromEnv(g_service_name);
+
+  LOG(INFO) << "[OTEL DEBUG] Initializing OpenTelemetry tracing (ostream exporter). "
+            << "Service: " << g_service_name;
+
+  try {
+    LOG(INFO) << "[OTEL DEBUG] Creating ostream exporter...";
+    // Create ostream exporter (outputs to stdout for debugging)
+    auto exporter = ostream_exporter::OStreamSpanExporterFactory::Create();
+    if (!exporter) {
+      LOG(ERROR) << "[OTEL DEBUG] Failed to create ostream exporter";
+      return STATUS(RuntimeError, "Failed to create ostream exporter");
+    }
+    LOG(INFO) << "[OTEL DEBUG] Ostream exporter created";
+
+    LOG(INFO) << "[OTEL DEBUG] Creating span processor...";
+    // Create simple span processor
+    auto processor = trace_sdk::SimpleSpanProcessorFactory::Create(std::move(exporter));
+    if (!processor) {
+      LOG(ERROR) << "[OTEL DEBUG] Failed to create span processor";
+      return STATUS(RuntimeError, "Failed to create span processor");
+    }
+    LOG(INFO) << "[OTEL DEBUG] Span processor created";
+
+    LOG(INFO) << "[OTEL DEBUG] Creating tracer provider...";
+    // Create tracer provider
+    auto provider = trace_sdk::TracerProviderFactory::Create(std::move(processor));
+    if (!provider) {
+      LOG(ERROR) << "[OTEL DEBUG] Failed to create tracer provider";
+      return STATUS(RuntimeError, "Failed to create tracer provider");
+    }
+    LOG(INFO) << "[OTEL DEBUG] Tracer provider created";
+
+    g_tracer_provider = nostd::shared_ptr<trace_api::TracerProvider>(provider.release());
+
+    LOG(INFO) << "[OTEL DEBUG] Setting global tracer provider...";
+    // Set as global provider
+    trace_api::Provider::SetTracerProvider(g_tracer_provider);
+
+    LOG(INFO) << "[OTEL DEBUG] Getting tracer...";
+    // Get tracer
+    g_tracer = g_tracer_provider->GetTracer(g_service_name, "1.0.0");
+    if (!g_tracer) {
+      LOG(ERROR) << "[OTEL DEBUG] Failed to get tracer";
+      return STATUS(RuntimeError, "Failed to get tracer");
+    }
+    LOG(INFO) << "[OTEL DEBUG] Tracer obtained successfully";
+
+    // Set up the global propagator for W3C trace context
+    LOG(INFO) << "[OTEL DEBUG] Setting up global W3C trace context propagator...";
+    auto propagator = nostd::shared_ptr<opentelemetry::context::propagation::TextMapPropagator>(
+        new opentelemetry::trace::propagation::HttpTraceContext());
+    opentelemetry::context::propagation::GlobalTextMapPropagator::SetGlobalPropagator(propagator);
+    LOG(INFO) << "[OTEL DEBUG] Global propagator set";
+
+    g_otel_enabled.store(true, std::memory_order_release);
+    LOG(INFO) << "[OTEL DEBUG] g_otel_enabled set to TRUE";
+
+    if (GetGlobalOtlpSender().IsEnabled()) {
+      LOG(INFO) << "[OTEL DEBUG] HTTP exporter is enabled, spans will be sent via HTTP";
+    } else {
+      LOG(INFO) << "[OTEL DEBUG] HTTP exporter not configured (set OTEL_EXPORTER_OTLP_ENDPOINT)";
+    }
+
+    LOG(INFO) << "[OTEL DEBUG] OpenTelemetry tracing initialized successfully";
+
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "[OTEL DEBUG] Exception during OTEL initialization: " << e.what();
+    return STATUS_FORMAT(RuntimeError, "Failed to initialize OpenTelemetry: $0", e.what());
+  }
+
+  LOG(INFO) << "[OTEL DEBUG] InitFromEnv returning OK";
+  return Status::OK();
+}
+
+void OtelTracing::Shutdown() {
+  std::lock_guard<std::mutex> lock(g_init_mutex);
+
+  if (g_otel_enabled.load(std::memory_order_acquire)) {
+    LOG(INFO) << "Shutting down OpenTelemetry tracing";
+    if (g_tracer_provider) {
+      // Flush any pending spans
+      auto* raw_provider = g_tracer_provider.get();
+      if (auto* sdk_provider = dynamic_cast<trace_sdk::TracerProvider*>(raw_provider)) {
+        // Some OpenTelemetry C++ versions / build configurations may not provide a
+        // concrete Shutdown implementation on TracerProvider, so just force-flush
+        // and rely on process teardown for cleanup.
+        sdk_provider->ForceFlush();
+      }
+    }
+    g_tracer = nullptr;
+    g_tracer_provider = nullptr;
+    g_otel_enabled.store(false, std::memory_order_release);
+  }
+}
+
+bool OtelTracing::IsEnabled() {
+  return g_otel_enabled.load(std::memory_order_acquire);
+}
+
+OtelSpanHandle OtelTracing::StartSpan(const std::string& name) {
+  if (!IsEnabled()) {
+    return OtelSpanHandle();
+  }
+
+  auto context = std::make_unique<otel_internal::SpanContext>();
+  context->active = true;
+  context->name = name;
+  context->start_time_ns = GetCurrentTimeNanos();
+  context->span_kind = 1;  // internal
+
+  if (g_tracer) {
+    // Capture parent span ID immediately before any state changes
+    auto current_span = trace_api::Tracer::GetCurrentSpan();
+    if (current_span && current_span->GetContext().IsValid()) {
+      context->parent_span_id = SpanIdToHex(current_span->GetContext().span_id());
+    }
+    
+    context->span = g_tracer->StartSpan(name);
+    VLOG(2) << "Started OTEL span: " << name;
+  }
+
+  return OtelSpanHandle(std::move(context));
+}
+
+OtelSpanHandle OtelTracing::StartSpanFromTraceparent(
+    const std::string& name,
+    const std::string& traceparent) {
+  LOG(INFO) << "[OTEL DEBUG] StartSpanFromTraceparent called: name='" << name
+            << "', traceparent='" << traceparent << "', IsEnabled=" << IsEnabled();
+
+  if (!IsEnabled()) {
+    LOG(INFO) << "[OTEL DEBUG] OTEL is not enabled, returning inactive span";
+    return OtelSpanHandle();
+  }
+
+  if (traceparent.empty()) {
+    LOG(INFO) << "[OTEL DEBUG] traceparent is empty, returning inactive span";
+    return OtelSpanHandle();
+  }
+
+  // Parse W3C traceparent format: "version-trace_id-span_id-trace_flags"
+  // Example: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+
+  LOG(INFO) << "[OTEL DEBUG] Validating traceparent format, length=" << traceparent.length();
+
+  // Simple validation
+  if (traceparent.length() < 55 || traceparent[2] != '-' || traceparent[35] != '-' ||
+      traceparent[52] != '-') {
+    LOG(WARNING) << "[OTEL DEBUG] Invalid traceparent format: " << traceparent
+                 << " (length=" << traceparent.length() << ")";
+    return OtelSpanHandle();
+  }
+
+  // Extract parent span ID from traceparent (positions 36-51)
+  std::string parent_span_id = traceparent.substr(36, 16);
+
+  LOG(INFO) << "[OTEL DEBUG] Traceparent validation passed, creating span context";
+
+  auto context = std::make_unique<otel_internal::SpanContext>();
+  context->active = true;
+  context->name = name;
+  context->parent_span_id = parent_span_id;
+  context->start_time_ns = GetCurrentTimeNanos();
+  context->span_kind = 2;  // server (receiving a remote call)
+
+  if (g_tracer) {
+    LOG(INFO) << "[OTEL DEBUG] g_tracer exists, using global propagator to parse traceparent";
+
+    // Create a carrier that holds the traceparent header
+    class TraceparentCarrier : public opentelemetry::context::propagation::TextMapCarrier {
+     public:
+      explicit TraceparentCarrier(const std::string& traceparent_value)
+          : traceparent_(traceparent_value) {}
+
+      nostd::string_view Get(nostd::string_view key) const noexcept override {
+        if (key == "traceparent") {
+          return nostd::string_view(traceparent_);
+        }
+        return "";
+      }
+
+      void Set(nostd::string_view key, nostd::string_view value) noexcept override {
+        if (key == "traceparent") {
+          traceparent_ = std::string(value);
+        }
+      }
+
+     private:
+      std::string traceparent_;
+    };
+
+    TraceparentCarrier carrier(traceparent);
+
+    // Use the global propagator to extract the context from the traceparent
+    auto propagator = opentelemetry::context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
+    auto current_ctx = opentelemetry::context::RuntimeContext::GetCurrent();
+    auto new_ctx = propagator->Extract(carrier, current_ctx);
+
+    LOG(INFO) << "[OTEL DEBUG] Extracted context from traceparent using global propagator";
+
+    // Get the remote span from the extracted context
+    auto remote_span = opentelemetry::trace::GetSpan(new_ctx);
+    auto remote_context = remote_span->GetContext();
+
+    if (remote_context.IsValid()) {
+      LOG(INFO) << "[OTEL DEBUG] Remote context is valid, creating span with remote parent";
+
+      // Create StartSpanOptions with the remote parent context
+      trace_api::StartSpanOptions options;
+      options.parent = remote_context;
+      options.kind = trace_api::SpanKind::kServer;
+
+      // Start the span with the remote parent context
+      context->span = g_tracer->StartSpan(name, options);
+
+      if (context->span) {
+        LOG(INFO) << "[OTEL DEBUG] Span created successfully with remote parent: " << name;
+      }
+    } else {
+      LOG(WARNING) << "[OTEL DEBUG] Remote context is not valid, creating regular span";
+      context->span = g_tracer->StartSpan(name);
+    }
+  } else {
+    LOG(WARNING) << "[OTEL DEBUG] g_tracer is null!";
+  }
+
+  return OtelSpanHandle(std::move(context));
+}
+
+void OtelTracing::AdoptSpan(const OtelSpanHandle& span) {
+  if (!span.IsActive()) return;
+
+  if (span.context_ && span.context_->span) {
+    // Create a scope to make this span active on the current thread
+    span.context_->scope = nostd::shared_ptr<trace_api::Scope>(
+        new trace_api::Scope(span.context_->span));
+  }
+}
+
+void OtelTracing::EndCurrentSpan() {
+  // The scope will be destroyed automatically when the ScopedOtelSpan goes out of scope
+}
+
+bool OtelTracing::HasActiveContext() {
+  if (!IsEnabled()) {
+    return false;
+  }
+
+  // Check if there's an active span in the current context
+  auto current_span = trace_api::Tracer::GetCurrentSpan();
+  return current_span && current_span->GetContext().IsValid();
+}
+
+}  // namespace yb

--- a/src/yb/util/otel_tracing.cc
+++ b/src/yb/util/otel_tracing.cc
@@ -76,18 +76,16 @@ namespace yb {
 
 namespace otel_internal {
 
-// Internal span context - holds the actual OpenTelemetry span and metadata for HTTP export
 struct SpanContext {
   bool active = false;
   nostd::shared_ptr<trace_api::Span> span;
   nostd::shared_ptr<trace_api::Scope> scope;
 
-  // Metadata for HTTP export (stored at span creation time)
   std::string name;
-  std::string parent_span_id;  // 16-char hex or empty
+  std::string parent_span_id;
   int64_t start_time_ns = 0;
-  int span_kind = 1;  // 1=internal, 2=server, 3=client
-  int status_code = 0;  // 0=unset, 1=ok, 2=error
+  int span_kind = 1;
+  int status_code = 0;
   std::string status_message;
   std::vector<std::pair<std::string, std::string> > string_attributes;
   std::vector<std::pair<std::string, int64_t> > int_attributes;
@@ -133,46 +131,37 @@ int64_t GetCurrentTimeNanos() {
 
 }  // anonymous namespace
 
-// OtelSpanHandle implementation
-
 OtelSpanHandle::OtelSpanHandle() : context_(nullptr) {}
 
 OtelSpanHandle::OtelSpanHandle(std::unique_ptr<otel_internal::SpanContext> context)
     : context_(std::move(context)) {}
 
 OtelSpanHandle::~OtelSpanHandle() {
-  if (context_ && context_->active && context_->span) {
-    // Export via HTTP before ending the span
-    if (GetGlobalOtlpSender().IsEnabled()) {
-      SimpleSpanData span_data;
-
-      // Extract trace_id and span_id from the OTEL span
-      auto span_context = context_->span->GetContext();
-      span_data.trace_id = TraceIdToHex(span_context.trace_id());
-      span_data.span_id = SpanIdToHex(span_context.span_id());
-      span_data.parent_span_id = context_->parent_span_id;
-
-      span_data.name = context_->name;
-      span_data.start_time_ns = context_->start_time_ns;
-      span_data.end_time_ns = GetCurrentTimeNanos();
-      span_data.kind = context_->span_kind;
-      span_data.status_code = context_->status_code;
-      span_data.status_message = context_->status_message;
-      span_data.string_attributes = context_->string_attributes;
-      span_data.int_attributes = context_->int_attributes;
-
-      LOG(INFO) << "[OTEL] Exporting span via HTTP: " << span_data.name
-                << " trace_id=" << span_data.trace_id
-                << " span_id=" << span_data.span_id;
-
-      bool sent = GetGlobalOtlpSender().SendSpan(span_data);
-      if (!sent) {
-        LOG(WARNING) << "[OTEL] Failed to send span via HTTP: " << span_data.name;
-      }
-    }
-
-    context_->span->End();
+  if (!context_ || !context_->active || !context_->span) {
+    return;
   }
+
+  if (GetGlobalOtlpSender().IsEnabled()) {
+    SimpleSpanData span_data;
+    auto span_context = context_->span->GetContext();
+    span_data.trace_id = TraceIdToHex(span_context.trace_id());
+    span_data.span_id = SpanIdToHex(span_context.span_id());
+    span_data.parent_span_id = context_->parent_span_id;
+    span_data.name = context_->name;
+    span_data.start_time_ns = context_->start_time_ns;
+    span_data.end_time_ns = GetCurrentTimeNanos();
+    span_data.kind = context_->span_kind;
+    span_data.status_code = context_->status_code;
+    span_data.status_message = context_->status_message;
+    span_data.string_attributes = context_->string_attributes;
+    span_data.int_attributes = context_->int_attributes;
+
+    if (!GetGlobalOtlpSender().SendSpan(span_data)) {
+      LOG(WARNING) << "[OTEL] Failed to send span via HTTP: " << span_data.name;
+    }
+  }
+
+  context_->span->End();
 }
 
 OtelSpanHandle::OtelSpanHandle(OtelSpanHandle&& other) noexcept
@@ -188,7 +177,6 @@ OtelSpanHandle& OtelSpanHandle::operator=(OtelSpanHandle&& other) noexcept {
 void OtelSpanHandle::SetStatus(bool ok, const std::string& description) {
   if (!context_ || !context_->active) return;
 
-  // Store for HTTP export
   context_->status_code = ok ? 1 : 2;
   context_->status_message = description;
 
@@ -204,7 +192,6 @@ void OtelSpanHandle::SetStatus(bool ok, const std::string& description) {
 void OtelSpanHandle::SetAttribute(const std::string& key, const std::string& value) {
   if (!context_ || !context_->active) return;
 
-  // Store for HTTP export
   context_->string_attributes.push_back(std::make_pair(key, value));
 
   if (context_->span) {
@@ -215,7 +202,6 @@ void OtelSpanHandle::SetAttribute(const std::string& key, const std::string& val
 void OtelSpanHandle::SetAttribute(const std::string& key, int64_t value) {
   if (!context_ || !context_->active) return;
 
-  // Store for HTTP export
   context_->int_attributes.push_back(std::make_pair(key, value));
 
   if (context_->span) {
@@ -225,7 +211,6 @@ void OtelSpanHandle::SetAttribute(const std::string& key, int64_t value) {
 
 void OtelSpanHandle::SetAttribute(const std::string& key, double value) {
   if (!context_ || !context_->active) return;
-  // Note: double attributes not stored for HTTP export yet (could add if needed)
   if (context_->span) {
     context_->span->SetAttribute(key, value);
   }
@@ -233,7 +218,6 @@ void OtelSpanHandle::SetAttribute(const std::string& key, double value) {
 
 void OtelSpanHandle::SetAttribute(const std::string& key, bool value) {
   if (!context_ || !context_->active) return;
-  // Note: bool attributes not stored for HTTP export yet (could add if needed)
   if (context_->span) {
     context_->span->SetAttribute(key, value);
   }
@@ -243,88 +227,66 @@ bool OtelSpanHandle::IsActive() const {
   return context_ && context_->active;
 }
 
-// OtelTracing implementation
-
 Status OtelTracing::InitFromEnv(const std::string& default_service_name) {
   std::lock_guard<std::mutex> lock(g_init_mutex);
 
-  LOG(INFO) << "[OTEL DEBUG] InitFromEnv called with service name: " << default_service_name;
-
   g_service_name = default_service_name;
 
-  // Initialize the HTTP exporter from environment, passing the service name
-  InitGlobalOtlpSenderFromEnv(g_service_name);
+  const char* debug_env = std::getenv("OTEL_EXPORTER_DEBUG");
+  bool use_debug_exporter = debug_env && (std::string(debug_env) == "true" || 
+                                           std::string(debug_env) == "1" ||
+                                           std::string(debug_env) == "TRUE");
 
-  LOG(INFO) << "[OTEL DEBUG] Initializing OpenTelemetry tracing (ostream exporter). "
-            << "Service: " << g_service_name;
+  if (use_debug_exporter) {
+    LOG(INFO) << "[OTEL] Debug mode enabled (OTEL_EXPORTER_DEBUG=true), using OStream exporter";
+  } else {
+    InitGlobalOtlpSenderFromEnv(g_service_name);
+  }
 
   try {
-    LOG(INFO) << "[OTEL DEBUG] Creating ostream exporter...";
-    // Create ostream exporter (outputs to stdout for debugging)
     auto exporter = ostream_exporter::OStreamSpanExporterFactory::Create();
     if (!exporter) {
-      LOG(ERROR) << "[OTEL DEBUG] Failed to create ostream exporter";
       return STATUS(RuntimeError, "Failed to create ostream exporter");
     }
-    LOG(INFO) << "[OTEL DEBUG] Ostream exporter created";
 
-    LOG(INFO) << "[OTEL DEBUG] Creating span processor...";
-    // Create simple span processor
     auto processor = trace_sdk::SimpleSpanProcessorFactory::Create(std::move(exporter));
     if (!processor) {
-      LOG(ERROR) << "[OTEL DEBUG] Failed to create span processor";
       return STATUS(RuntimeError, "Failed to create span processor");
     }
-    LOG(INFO) << "[OTEL DEBUG] Span processor created";
 
-    LOG(INFO) << "[OTEL DEBUG] Creating tracer provider...";
-    // Create tracer provider
     auto provider = trace_sdk::TracerProviderFactory::Create(std::move(processor));
     if (!provider) {
-      LOG(ERROR) << "[OTEL DEBUG] Failed to create tracer provider";
       return STATUS(RuntimeError, "Failed to create tracer provider");
     }
-    LOG(INFO) << "[OTEL DEBUG] Tracer provider created";
 
     g_tracer_provider = nostd::shared_ptr<trace_api::TracerProvider>(provider.release());
-
-    LOG(INFO) << "[OTEL DEBUG] Setting global tracer provider...";
-    // Set as global provider
     trace_api::Provider::SetTracerProvider(g_tracer_provider);
 
-    LOG(INFO) << "[OTEL DEBUG] Getting tracer...";
-    // Get tracer
     g_tracer = g_tracer_provider->GetTracer(g_service_name, "1.0.0");
     if (!g_tracer) {
-      LOG(ERROR) << "[OTEL DEBUG] Failed to get tracer";
       return STATUS(RuntimeError, "Failed to get tracer");
     }
-    LOG(INFO) << "[OTEL DEBUG] Tracer obtained successfully";
 
-    // Set up the global propagator for W3C trace context
-    LOG(INFO) << "[OTEL DEBUG] Setting up global W3C trace context propagator...";
     auto propagator = nostd::shared_ptr<opentelemetry::context::propagation::TextMapPropagator>(
         new opentelemetry::trace::propagation::HttpTraceContext());
     opentelemetry::context::propagation::GlobalTextMapPropagator::SetGlobalPropagator(propagator);
-    LOG(INFO) << "[OTEL DEBUG] Global propagator set";
 
     g_otel_enabled.store(true, std::memory_order_release);
-    LOG(INFO) << "[OTEL DEBUG] g_otel_enabled set to TRUE";
 
-    if (GetGlobalOtlpSender().IsEnabled()) {
-      LOG(INFO) << "[OTEL DEBUG] HTTP exporter is enabled, spans will be sent via HTTP";
+    if (use_debug_exporter) {
+      LOG(INFO) << "[OTEL] Using OStream exporter (debug mode) - spans will be written to stdout";
+    } else if (GetGlobalOtlpSender().IsEnabled()) {
+      LOG(INFO) << "[OTEL] HTTP exporter is enabled, spans will be sent via HTTP";
     } else {
-      LOG(INFO) << "[OTEL DEBUG] HTTP exporter not configured (set OTEL_EXPORTER_OTLP_ENDPOINT)";
+      LOG(INFO) << "[OTEL] HTTP exporter not configured (set OTEL_EXPORTER_OTLP_ENDPOINT)";
     }
 
-    LOG(INFO) << "[OTEL DEBUG] OpenTelemetry tracing initialized successfully";
+    LOG(INFO) << "[OTEL] OpenTelemetry tracing initialized successfully";
 
   } catch (const std::exception& e) {
-    LOG(ERROR) << "[OTEL DEBUG] Exception during OTEL initialization: " << e.what();
     return STATUS_FORMAT(RuntimeError, "Failed to initialize OpenTelemetry: $0", e.what());
   }
 
-  LOG(INFO) << "[OTEL DEBUG] InitFromEnv returning OK";
   return Status::OK();
 }
 
@@ -334,12 +296,8 @@ void OtelTracing::Shutdown() {
   if (g_otel_enabled.load(std::memory_order_acquire)) {
     LOG(INFO) << "Shutting down OpenTelemetry tracing";
     if (g_tracer_provider) {
-      // Flush any pending spans
       auto* raw_provider = g_tracer_provider.get();
       if (auto* sdk_provider = dynamic_cast<trace_sdk::TracerProvider*>(raw_provider)) {
-        // Some OpenTelemetry C++ versions / build configurations may not provide a
-        // concrete Shutdown implementation on TracerProvider, so just force-flush
-        // and rely on process teardown for cleanup.
         sdk_provider->ForceFlush();
       }
     }
@@ -365,14 +323,15 @@ OtelSpanHandle OtelTracing::StartSpan(const std::string& name) {
   context->span_kind = 1;  // internal
 
   if (g_tracer) {
-    // Capture parent span ID immediately before any state changes
     auto current_span = trace_api::Tracer::GetCurrentSpan();
     if (current_span && current_span->GetContext().IsValid()) {
       context->parent_span_id = SpanIdToHex(current_span->GetContext().span_id());
+      trace_api::StartSpanOptions options;
+      options.parent = current_span->GetContext();
+      context->span = g_tracer->StartSpan(name, options);
+    } else {
+      context->span = g_tracer->StartSpan(name);
     }
-    
-    context->span = g_tracer->StartSpan(name);
-    VLOG(2) << "Started OTEL span: " << name;
   }
 
   return OtelSpanHandle(std::move(context));
@@ -381,48 +340,26 @@ OtelSpanHandle OtelTracing::StartSpan(const std::string& name) {
 OtelSpanHandle OtelTracing::StartSpanFromTraceparent(
     const std::string& name,
     const std::string& traceparent) {
-  LOG(INFO) << "[OTEL DEBUG] StartSpanFromTraceparent called: name='" << name
-            << "', traceparent='" << traceparent << "', IsEnabled=" << IsEnabled();
-
-  if (!IsEnabled()) {
-    LOG(INFO) << "[OTEL DEBUG] OTEL is not enabled, returning inactive span";
+  if (!IsEnabled() || traceparent.empty()) {
     return OtelSpanHandle();
   }
 
-  if (traceparent.empty()) {
-    LOG(INFO) << "[OTEL DEBUG] traceparent is empty, returning inactive span";
-    return OtelSpanHandle();
-  }
-
-  // Parse W3C traceparent format: "version-trace_id-span_id-trace_flags"
-  // Example: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
-
-  LOG(INFO) << "[OTEL DEBUG] Validating traceparent format, length=" << traceparent.length();
-
-  // Simple validation
   if (traceparent.length() < 55 || traceparent[2] != '-' || traceparent[35] != '-' ||
       traceparent[52] != '-') {
-    LOG(WARNING) << "[OTEL DEBUG] Invalid traceparent format: " << traceparent
-                 << " (length=" << traceparent.length() << ")";
+    LOG(WARNING) << "[OTEL] Invalid traceparent format: " << traceparent;
     return OtelSpanHandle();
   }
 
-  // Extract parent span ID from traceparent (positions 36-51)
   std::string parent_span_id = traceparent.substr(36, 16);
-
-  LOG(INFO) << "[OTEL DEBUG] Traceparent validation passed, creating span context";
 
   auto context = std::make_unique<otel_internal::SpanContext>();
   context->active = true;
   context->name = name;
   context->parent_span_id = parent_span_id;
   context->start_time_ns = GetCurrentTimeNanos();
-  context->span_kind = 2;  // server (receiving a remote call)
+  context->span_kind = 2;
 
   if (g_tracer) {
-    LOG(INFO) << "[OTEL DEBUG] g_tracer exists, using global propagator to parse traceparent";
-
-    // Create a carrier that holds the traceparent header
     class TraceparentCarrier : public opentelemetry::context::propagation::TextMapCarrier {
      public:
       explicit TraceparentCarrier(const std::string& traceparent_value)
@@ -446,65 +383,60 @@ OtelSpanHandle OtelTracing::StartSpanFromTraceparent(
     };
 
     TraceparentCarrier carrier(traceparent);
-
-    // Use the global propagator to extract the context from the traceparent
     auto propagator = opentelemetry::context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
     auto current_ctx = opentelemetry::context::RuntimeContext::GetCurrent();
     auto new_ctx = propagator->Extract(carrier, current_ctx);
 
-    LOG(INFO) << "[OTEL DEBUG] Extracted context from traceparent using global propagator";
-
-    // Get the remote span from the extracted context
     auto remote_span = opentelemetry::trace::GetSpan(new_ctx);
     auto remote_context = remote_span->GetContext();
 
     if (remote_context.IsValid()) {
-      LOG(INFO) << "[OTEL DEBUG] Remote context is valid, creating span with remote parent";
-
-      // Create StartSpanOptions with the remote parent context
       trace_api::StartSpanOptions options;
       options.parent = remote_context;
       options.kind = trace_api::SpanKind::kServer;
-
-      // Start the span with the remote parent context
       context->span = g_tracer->StartSpan(name, options);
-
-      if (context->span) {
-        LOG(INFO) << "[OTEL DEBUG] Span created successfully with remote parent: " << name;
-      }
     } else {
-      LOG(WARNING) << "[OTEL DEBUG] Remote context is not valid, creating regular span";
       context->span = g_tracer->StartSpan(name);
     }
-  } else {
-    LOG(WARNING) << "[OTEL DEBUG] g_tracer is null!";
   }
 
   return OtelSpanHandle(std::move(context));
 }
 
 void OtelTracing::AdoptSpan(const OtelSpanHandle& span) {
-  if (!span.IsActive()) return;
-
-  if (span.context_ && span.context_->span) {
-    // Create a scope to make this span active on the current thread
-    span.context_->scope = nostd::shared_ptr<trace_api::Scope>(
-        new trace_api::Scope(span.context_->span));
+  if (!span.IsActive() || !span.context_ || !span.context_->span) {
+    return;
   }
+  span.context_->scope = nostd::shared_ptr<trace_api::Scope>(
+      new trace_api::Scope(span.context_->span));
 }
 
 void OtelTracing::EndCurrentSpan() {
-  // The scope will be destroyed automatically when the ScopedOtelSpan goes out of scope
 }
 
 bool OtelTracing::HasActiveContext() {
   if (!IsEnabled()) {
     return false;
   }
-
-  // Check if there's an active span in the current context
   auto current_span = trace_api::Tracer::GetCurrentSpan();
   return current_span && current_span->GetContext().IsValid();
+}
+
+std::string OtelTracing::GetCurrentTraceparent() {
+  if (!IsEnabled()) {
+    return "";
+  }
+  auto current_span = trace_api::Tracer::GetCurrentSpan();
+  if (!current_span || !current_span->GetContext().IsValid()) {
+    return "";
+  }
+
+  auto span_context = current_span->GetContext();
+  std::string trace_id = TraceIdToHex(span_context.trace_id());
+  std::string span_id = SpanIdToHex(span_context.span_id());
+  std::string flags = span_context.IsSampled() ? "01" : "00";
+
+  return "00-" + trace_id + "-" + span_id + "-" + flags;
 }
 
 }  // namespace yb

--- a/src/yb/util/otel_tracing.cc
+++ b/src/yb/util/otel_tracing.cc
@@ -418,4 +418,21 @@ bool OtelTracing::HasActiveContext() {
   return current_span && current_span->GetContext().IsValid();
 }
 
+std::string OtelTracing::GetCurrentTraceparent() {
+  if (!IsEnabled()) {
+    return "";
+  }
+  auto current_span = trace_api::Tracer::GetCurrentSpan();
+  if (!current_span || !current_span->GetContext().IsValid()) {
+    return "";
+  }
+
+  auto span_context = current_span->GetContext();
+  std::string trace_id = TraceIdToHex(span_context.trace_id());
+  std::string span_id = SpanIdToHex(span_context.span_id());
+  std::string flags = span_context.IsSampled() ? "01" : "00";
+
+  return "00-" + trace_id + "-" + span_id + "-" + flags;
+}
+
 }  // namespace yb

--- a/src/yb/util/otel_tracing.h
+++ b/src/yb/util/otel_tracing.h
@@ -44,6 +44,9 @@ class OtelSpanHandle {
   void SetAttribute(const std::string& key, double value);
   void SetAttribute(const std::string& key, bool value);
 
+  // Explicitly end the span. Safe to call multiple times.
+  void End();
+
   bool IsActive() const;
 
  private:

--- a/src/yb/util/otel_tracing.h
+++ b/src/yb/util/otel_tracing.h
@@ -1,0 +1,142 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "yb/util/status.h"
+
+namespace yb {
+
+// Minimal OpenTelemetry tracing wrapper for YugabyteDB.
+// This provides a simple interface for creating distributed traces with minimal overhead.
+// When OTEL is disabled (default), all operations become no-ops with minimal cost.
+
+// Forward declarations to avoid exposing OTEL types in headers
+namespace otel_internal {
+struct SpanContext;
+}  // namespace otel_internal
+
+// Opaque handle for an active span. Use RAII semantics - the span ends when destroyed.
+class OtelSpanHandle {
+ public:
+  OtelSpanHandle();
+  ~OtelSpanHandle();
+
+  // Move-only type
+  OtelSpanHandle(OtelSpanHandle&& other) noexcept;
+  OtelSpanHandle& operator=(OtelSpanHandle&& other) noexcept;
+
+  OtelSpanHandle(const OtelSpanHandle&) = delete;
+  OtelSpanHandle& operator=(const OtelSpanHandle&) = delete;
+
+  // Set the span status. Call before the span ends (before destruction).
+  // ok=true means success, ok=false means error.
+  void SetStatus(bool ok, const std::string& description = "");
+
+  // Add an attribute to the span
+  void SetAttribute(const std::string& key, const std::string& value);
+  void SetAttribute(const std::string& key, int64_t value);
+  void SetAttribute(const std::string& key, double value);
+  void SetAttribute(const std::string& key, bool value);
+
+  // Check if this handle represents an active span
+  bool IsActive() const;
+
+ private:
+  friend class OtelTracing;
+  explicit OtelSpanHandle(std::unique_ptr<otel_internal::SpanContext> context);
+  
+  std::unique_ptr<otel_internal::SpanContext> context_;
+};
+
+// Main interface for OpenTelemetry tracing
+class OtelTracing {
+ public:
+  // Initialize OpenTelemetry tracing for the current process.
+  // Reads configuration from environment variables:
+  //   YB_ENABLE_OTEL_TRACING=1         - Enable tracing (default: disabled)
+  //   OTEL_EXPORTER_OTLP_ENDPOINT      - OTLP endpoint (default: http://localhost:4317)
+  //   OTEL_SERVICE_NAME                - Override service name
+  //
+  // Should be called once during process startup, before any spans are created.
+  // Returns OK on success, or an error if initialization fails.
+  static Status InitFromEnv(const std::string& default_service_name);
+
+  // Shutdown OpenTelemetry tracing. Should be called during process shutdown.
+  static void Shutdown();
+
+  // Check if OpenTelemetry tracing is enabled
+  static bool IsEnabled();
+
+  // Start a new span with the given name.
+  // If a span is currently active on this thread, the new span becomes its child.
+  // Returns an RAII handle that ends the span when destroyed.
+  static OtelSpanHandle StartSpan(const std::string& name);
+
+  // Start a span from a W3C traceparent string (for distributed tracing).
+  // The traceparent format is: "version-trace_id-span_id-trace_flags"
+  // Example: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+  //
+  // If traceparent is invalid or empty, returns an inactive span handle.
+  static OtelSpanHandle StartSpanFromTraceparent(
+      const std::string& name,
+      const std::string& traceparent);
+
+  // Adopt a span as the current span for this thread.
+  // This is used to propagate context across thread boundaries.
+  // The span must remain valid until EndCurrentSpan() is called.
+  static void AdoptSpan(const OtelSpanHandle& span);
+
+  // End the current span for this thread (restore previous context).
+  static void EndCurrentSpan();
+
+  // Check if there's currently an active span context on this thread.
+  // This can be used to conditionally create child spans only when there's a parent.
+  static bool HasActiveContext();
+
+ private:
+  OtelTracing() = delete;
+};
+
+// RAII helper to adopt a span for the duration of a scope
+class ScopedOtelSpan {
+ public:
+  explicit ScopedOtelSpan(OtelSpanHandle&& span)
+      : span_(std::move(span)) {
+    if (span_.IsActive()) {
+      OtelTracing::AdoptSpan(span_);
+    }
+  }
+
+  ~ScopedOtelSpan() {
+    if (span_.IsActive()) {
+      OtelTracing::EndCurrentSpan();
+    }
+  }
+
+  ScopedOtelSpan(const ScopedOtelSpan&) = delete;
+  ScopedOtelSpan& operator=(const ScopedOtelSpan&) = delete;
+
+  OtelSpanHandle& span() { return span_; }
+  const OtelSpanHandle& span() const { return span_; }
+
+ private:
+  OtelSpanHandle span_;
+};
+
+}  // namespace yb
+

--- a/src/yb/util/otel_tracing.h
+++ b/src/yb/util/otel_tracing.h
@@ -21,16 +21,10 @@
 
 namespace yb {
 
-// Minimal OpenTelemetry tracing wrapper for YugabyteDB.
-// This provides a simple interface for creating distributed traces with minimal overhead.
-// When OTEL is disabled (default), all operations become no-ops with minimal cost.
-
-// Forward declarations to avoid exposing OTEL types in headers
 namespace otel_internal {
 struct SpanContext;
 }  // namespace otel_internal
 
-// Opaque handle for an active span. Use RAII semantics - the span ends when destroyed.
 class OtelSpanHandle {
  public:
   OtelSpanHandle();
@@ -43,17 +37,13 @@ class OtelSpanHandle {
   OtelSpanHandle(const OtelSpanHandle&) = delete;
   OtelSpanHandle& operator=(const OtelSpanHandle&) = delete;
 
-  // Set the span status. Call before the span ends (before destruction).
-  // ok=true means success, ok=false means error.
   void SetStatus(bool ok, const std::string& description = "");
 
-  // Add an attribute to the span
   void SetAttribute(const std::string& key, const std::string& value);
   void SetAttribute(const std::string& key, int64_t value);
   void SetAttribute(const std::string& key, double value);
   void SetAttribute(const std::string& key, bool value);
 
-  // Check if this handle represents an active span
   bool IsActive() const;
 
  private:
@@ -63,56 +53,23 @@ class OtelSpanHandle {
   std::unique_ptr<otel_internal::SpanContext> context_;
 };
 
-// Main interface for OpenTelemetry tracing
 class OtelTracing {
  public:
-  // Initialize OpenTelemetry tracing for the current process.
-  // Reads configuration from environment variables:
-  //   YB_ENABLE_OTEL_TRACING=1         - Enable tracing (default: disabled)
-  //   OTEL_EXPORTER_OTLP_ENDPOINT      - OTLP endpoint (default: http://localhost:4317)
-  //   OTEL_SERVICE_NAME                - Override service name
-  //
-  // Should be called once during process startup, before any spans are created.
-  // Returns OK on success, or an error if initialization fails.
   static Status InitFromEnv(const std::string& default_service_name);
-
-  // Shutdown OpenTelemetry tracing. Should be called during process shutdown.
   static void Shutdown();
-
-  // Check if OpenTelemetry tracing is enabled
   static bool IsEnabled();
-
-  // Start a new span with the given name.
-  // If a span is currently active on this thread, the new span becomes its child.
-  // Returns an RAII handle that ends the span when destroyed.
   static OtelSpanHandle StartSpan(const std::string& name);
-
-  // Start a span from a W3C traceparent string (for distributed tracing).
-  // The traceparent format is: "version-trace_id-span_id-trace_flags"
-  // Example: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
-  //
-  // If traceparent is invalid or empty, returns an inactive span handle.
   static OtelSpanHandle StartSpanFromTraceparent(
       const std::string& name,
       const std::string& traceparent);
-
-  // Adopt a span as the current span for this thread.
-  // This is used to propagate context across thread boundaries.
-  // The span must remain valid until EndCurrentSpan() is called.
   static void AdoptSpan(const OtelSpanHandle& span);
-
-  // End the current span for this thread (restore previous context).
   static void EndCurrentSpan();
-
-  // Check if there's currently an active span context on this thread.
-  // This can be used to conditionally create child spans only when there's a parent.
   static bool HasActiveContext();
 
  private:
   OtelTracing() = delete;
 };
 
-// RAII helper to adopt a span for the duration of a scope
 class ScopedOtelSpan {
  public:
   explicit ScopedOtelSpan(OtelSpanHandle&& span)

--- a/src/yb/util/otel_tracing.h
+++ b/src/yb/util/otel_tracing.h
@@ -65,6 +65,7 @@ class OtelTracing {
   static void AdoptSpan(const OtelSpanHandle& span);
   static void EndCurrentSpan();
   static bool HasActiveContext();
+  static std::string GetCurrentTraceparent();
 
  private:
   OtelTracing() = delete;

--- a/src/yb/util/otel_tracing.h
+++ b/src/yb/util/otel_tracing.h
@@ -21,16 +21,10 @@
 
 namespace yb {
 
-// Minimal OpenTelemetry tracing wrapper for YugabyteDB.
-// This provides a simple interface for creating distributed traces with minimal overhead.
-// When OTEL is disabled (default), all operations become no-ops with minimal cost.
-
-// Forward declarations to avoid exposing OTEL types in headers
 namespace otel_internal {
 struct SpanContext;
 }  // namespace otel_internal
 
-// Opaque handle for an active span. Use RAII semantics - the span ends when destroyed.
 class OtelSpanHandle {
  public:
   OtelSpanHandle();
@@ -43,17 +37,13 @@ class OtelSpanHandle {
   OtelSpanHandle(const OtelSpanHandle&) = delete;
   OtelSpanHandle& operator=(const OtelSpanHandle&) = delete;
 
-  // Set the span status. Call before the span ends (before destruction).
-  // ok=true means success, ok=false means error.
   void SetStatus(bool ok, const std::string& description = "");
 
-  // Add an attribute to the span
   void SetAttribute(const std::string& key, const std::string& value);
   void SetAttribute(const std::string& key, int64_t value);
   void SetAttribute(const std::string& key, double value);
   void SetAttribute(const std::string& key, bool value);
 
-  // Check if this handle represents an active span
   bool IsActive() const;
 
  private:
@@ -63,56 +53,24 @@ class OtelSpanHandle {
   std::unique_ptr<otel_internal::SpanContext> context_;
 };
 
-// Main interface for OpenTelemetry tracing
 class OtelTracing {
  public:
-  // Initialize OpenTelemetry tracing for the current process.
-  // Reads configuration from environment variables:
-  //   YB_ENABLE_OTEL_TRACING=1         - Enable tracing (default: disabled)
-  //   OTEL_EXPORTER_OTLP_ENDPOINT      - OTLP endpoint (default: http://localhost:4317)
-  //   OTEL_SERVICE_NAME                - Override service name
-  //
-  // Should be called once during process startup, before any spans are created.
-  // Returns OK on success, or an error if initialization fails.
   static Status InitFromEnv(const std::string& default_service_name);
-
-  // Shutdown OpenTelemetry tracing. Should be called during process shutdown.
   static void Shutdown();
-
-  // Check if OpenTelemetry tracing is enabled
   static bool IsEnabled();
-
-  // Start a new span with the given name.
-  // If a span is currently active on this thread, the new span becomes its child.
-  // Returns an RAII handle that ends the span when destroyed.
   static OtelSpanHandle StartSpan(const std::string& name);
-
-  // Start a span from a W3C traceparent string (for distributed tracing).
-  // The traceparent format is: "version-trace_id-span_id-trace_flags"
-  // Example: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
-  //
-  // If traceparent is invalid or empty, returns an inactive span handle.
   static OtelSpanHandle StartSpanFromTraceparent(
       const std::string& name,
       const std::string& traceparent);
-
-  // Adopt a span as the current span for this thread.
-  // This is used to propagate context across thread boundaries.
-  // The span must remain valid until EndCurrentSpan() is called.
   static void AdoptSpan(const OtelSpanHandle& span);
-
-  // End the current span for this thread (restore previous context).
   static void EndCurrentSpan();
-
-  // Check if there's currently an active span context on this thread.
-  // This can be used to conditionally create child spans only when there's a parent.
   static bool HasActiveContext();
+  static std::string GetCurrentTraceparent();
 
  private:
   OtelTracing() = delete;
 };
 
-// RAII helper to adopt a span for the duration of a scope
 class ScopedOtelSpan {
  public:
   explicit ScopedOtelSpan(OtelSpanHandle&& span)

--- a/src/yb/yql/pggate/pg_client.cc
+++ b/src/yb/yql/pggate/pg_client.cc
@@ -1656,6 +1656,7 @@ class PgClient::Impl : public BigDataFetcher {
     } else {
       controller->set_timeout(timeout_);
     }
+    controller->set_traceparent(OtelTracing::GetCurrentTraceparent());
     return controller;
   }
 

--- a/src/yb/yql/pggate/pg_client.cc
+++ b/src/yb/yql/pggate/pg_client.cc
@@ -52,6 +52,11 @@
 
 #include "yb/util/otel_tracing.h"
 
+// Forward declarations for Postgres C functions to access traceparent
+extern "C" {
+  const char* YbGetCurrentTraceparent(void);
+}
+
 DECLARE_bool(enable_object_lock_fastpath);
 DECLARE_bool(use_node_hostname_for_local_tserver);
 DECLARE_int32(backfill_index_client_rpc_timeout_ms);
@@ -608,17 +613,13 @@ class PgClient::Impl : public BigDataFetcher {
   Result<PgTableDescPtr> OpenTable(
       const PgObjectId& table_id, bool reopen, uint64_t min_ysql_catalog_version,
       master::IncludeHidden include_hidden) {
-    // OTEL: Create wrapper span for OpenTable with table identification
     OtelSpanHandle open_table_span;
     std::unique_ptr<ScopedOtelSpan> scoped_span;
     if (OtelTracing::HasActiveContext()) {
       open_table_span = OtelTracing::StartSpan("pggate.open_table");
       if (open_table_span.IsActive()) {
-        // Set table identifiers before the RPC
-        open_table_span.SetAttribute("db.table_oid",
-            static_cast<int64_t>(table_id.object_oid));
-        open_table_span.SetAttribute("db.database_oid",
-            static_cast<int64_t>(table_id.database_oid));
+        open_table_span.SetAttribute("db.table_oid", static_cast<int64_t>(table_id.object_oid));
+        open_table_span.SetAttribute("db.database_oid", static_cast<int64_t>(table_id.database_oid));
         scoped_span = std::make_unique<ScopedOtelSpan>(std::move(open_table_span));
       }
     }
@@ -640,7 +641,6 @@ class PgClient::Impl : public BigDataFetcher {
         table_id, resp.info(), BuildTablePartitionList(resp.partitions(), table_id));
     RETURN_NOT_OK(result->Init());
 
-    // OTEL: Add table name now that we have it from the response
     if (scoped_span && scoped_span->span().IsActive()) {
       scoped_span->span().SetAttribute("db.table", result->table_name().table_name());
     }
@@ -1661,6 +1661,11 @@ class PgClient::Impl : public BigDataFetcher {
     } else {
       controller->set_timeout(timeout_);
     }
+    const char* c_traceparent = YbGetCurrentTraceparent();
+    if (c_traceparent && c_traceparent[0] != '\0') {
+      controller->set_traceparent(c_traceparent);
+    }
+    
     return controller;
   }
 

--- a/src/yb/yql/pggate/pg_session.cc
+++ b/src/yb/yql/pggate/pg_session.cc
@@ -797,11 +797,7 @@ Result<FlushFuture> PgSession::FlushOperations(BufferableOperations&& ops, bool 
 
 Result<PerformFuture> PgSession::Perform(BufferableOperations&& ops, PerformOptions&& ops_options) {
   DCHECK(!ops.Empty());
-  
-  // NOTE: Query-level OTEL spans are now created at the PostgreSQL layer
-  // (in postgres.c at the DTrace probe points). RPC spans created here
-  // will automatically be children of the active query span.
-  
+
   tserver::PgPerformOptionsPB options;
   if (ops_options.use_catalog_session) {
     if (catalog_read_time_) {
@@ -1117,27 +1113,23 @@ Result<PerformFuture> PgSession::DoRunAsync(
   RunHelper runner(
       this, group_session_type, in_txn_limit, force_non_bufferable);
   const auto ddl_force_catalog_mod_opt = pg_txn_manager_->GetDdlForceCatalogModification();
-  
-  // OTEL: Create span for this batch with rich metadata
-  // Only create if there's an active context (i.e., we're inside a traced query)
+
   OtelSpanHandle batch_span;
   std::unique_ptr<ScopedOtelSpan> scoped_batch_span;
-  
-  // Counters for OTEL attributes
   int64_t catalog_read_count = 0;
   int64_t catalog_write_count = 0;
   int64_t user_read_count = 0;
   int64_t user_write_count = 0;
-  std::string table_names;  // Comma-separated list of unique table names
+  std::string table_names;
   std::set<std::string> seen_tables;
-  
+
   if (OtelTracing::HasActiveContext()) {
     batch_span = OtelTracing::StartSpan("pggate.batch");
     if (batch_span.IsActive()) {
       scoped_batch_span = std::make_unique<ScopedOtelSpan>(std::move(batch_span));
     }
   }
-  
+
   auto processor =
       [this,
        is_ddl = ddl_force_catalog_mod_opt.has_value(),
@@ -1167,8 +1159,7 @@ Result<PerformFuture> PgSession::DoRunAsync(
         has_catalog_write_ops_in_ddl_mode_ =
             has_catalog_write_ops_in_ddl_mode_ ||
             (is_ddl && op->is_write() && is_ysql_catalog_table);
-        
-        // OTEL: Collect table metadata for span attributes
+
         if (is_ysql_catalog_table) {
           if (op->is_read()) {
             catalog_read_count++;
@@ -1182,7 +1173,6 @@ Result<PerformFuture> PgSession::DoRunAsync(
             user_write_count++;
           }
         }
-        // Collect unique table names
         const auto& tbl_name = table.table_name().table_name();
         if (seen_tables.find(tbl_name) == seen_tables.end()) {
           seen_tables.insert(tbl_name);
@@ -1191,17 +1181,15 @@ Result<PerformFuture> PgSession::DoRunAsync(
           }
           table_names += tbl_name;
         }
-        
+
         return runner.Apply(table, op);
     };
   RETURN_NOT_OK(processor(first_table_op));
   for (; !table_op.IsEmpty(); table_op = generator()) {
     RETURN_NOT_OK(processor(table_op));
   }
-  
-  // OTEL: Set collected attributes on the span before it ends
+
   if (scoped_batch_span && scoped_batch_span->span().IsActive()) {
-    // Set session type
     std::string session_type_str;
     switch (group_session_type) {
       case SessionType::kCatalog: session_type_str = "catalog"; break;

--- a/src/yb/yql/pggate/ybc_pggate.h
+++ b/src/yb/yql/pggate/ybc_pggate.h
@@ -144,6 +144,12 @@ void YBCOtelPlanDone(void);
 void YBCOtelExecuteStart(void);
 void YBCOtelExecuteDone(void);
 
+// Transaction phase spans
+void YBCOtelCommitStart(void);
+void YBCOtelCommitDone(void);
+void YBCOtelAbortStart(void);
+void YBCOtelAbortDone(void);
+
 int64_t YBCGetPgggateCurrentAllocatedBytes();
 
 int64_t YBCGetActualHeapSizeBytes();

--- a/src/yb/yql/pggate/ybc_pggate.h
+++ b/src/yb/yql/pggate/ybc_pggate.h
@@ -119,6 +119,29 @@ const unsigned char* YBCGetLocalTserverUuid();
 // Get access to callbacks.
 const YbcPgCallbacks* YBCGetPgCallbacks();
 
+// Initialize OpenTelemetry tracing for the current process (e.g., postgres backend).
+// Should be called once during process startup.
+void YBCInitOtelTracing(const char* service_name);
+
+// Get the current traceparent string for OTEL tracing (may be empty).
+const char* YBCGetCurrentTraceparent();
+
+// Clear the current traceparent.
+void YBCResetTraceparent();
+
+// OTEL Query-level tracing functions (called from DTrace probe points)
+// Main query span - extracts traceparent from query_string if present
+void YBCOtelQueryStart(const char* query_string);
+void YBCOtelQueryDone(void);
+
+// Query phase child spans
+void YBCOtelParseStart(void);
+void YBCOtelParseDone(void);
+void YBCOtelPlanStart(void);
+void YBCOtelPlanDone(void);
+void YBCOtelExecuteStart(void);
+void YBCOtelExecuteDone(void);
+
 int64_t YBCGetPgggateCurrentAllocatedBytes();
 
 int64_t YBCGetActualHeapSizeBytes();

--- a/src/yb/yql/pggate/ybc_pggate.h
+++ b/src/yb/yql/pggate/ybc_pggate.h
@@ -137,6 +137,8 @@ void YBCOtelQueryDone(void);
 // Query phase child spans
 void YBCOtelParseStart(void);
 void YBCOtelParseDone(void);
+void YBCOtelRewriteStart(void);
+void YBCOtelRewriteDone(void);
 void YBCOtelPlanStart(void);
 void YBCOtelPlanDone(void);
 void YBCOtelExecuteStart(void);


### PR DESCRIPTION
### How it works

Traces are triggered by the client. If a traceparent comment exists in the query
```sql
/* traceparent:00-456e5d656857f12406b34e87c8f63553-6a44c13332fba2c1-01 */ SELECT * FROM test6;
```

Then a span is started from that parent. This allows the sample rate to be controlled by the upstream client. IE if App includes verbose tracing so will Yugabyte and the spans will match. Without this parent there are so spans emitted. Thread-local storage manages active span context stack.

Postgres provides DTrace probe points. This PR adds OTEL beside those native points. This provides query / parse / plan / execute lifecycle and should be easy to maintain longterm.

Outbound RPCs are also instrumented so the client can see what RPCs were send for their query, how long they took and what they were for.

### Current problems

- Correctness. Accurate time / clock measurements should be looked into, as well as accurate trace results. Need to use a timing with precise clock.
- Performance. OTEL has an impact on performance. Client controlled spans are less impactful because they are rare, but still needs to be measured.
- Most of the code is very naive. I have NOT attempted to make it nice or remove unneeded parts, just tried to get it to work.
- Currently there are no tests for the span creation / propagation. It also parses the traceparent manually instead of using the standard library.
- There are some unneeded, unoptimized paths for collect table metadata for span attributes. This does not have to make it into the final version. If it is, it should be thought about more.
- There are comments everywhere to make it easier to follow, they might not be wanted in the final version.
- Instead of using https://github.com/yugabyte/yugabyte-db-thirdparty to build the dependencies, I only used a build script: https://github.com/Shopify/yugabyte-db/blob/cd0d79f82477cd8438a83d3a9acae2990043ad1d/build-support/build_opentelemetry.sh#L19 The production solution would build these deps as others in Yugabyte are built.
- The OTEL library HTTP or proto exporter could not built with Yugabyte due to conflicting protobuf versions. There may be a way to do this, it should be explored. As an alternative I created a prototype HTTP exporter. https://github.com/Shopify/yugabyte-db/blob/cd0d79f82477cd8438a83d3a9acae2990043ad1d/src/yb/util/otel_http_exporter.cc#L25 This exporter is very dumb and does not support things we probably need like batching, various failure modes, it does not have any tests etc. Ideally we just use the built in version.
- The current version has a lot of debugger logs. This is intentional for prototype but they are too frequent to be deployed at scale.
- Forward declarations for Postgres C functions were added to get my x86 build to complete. There is probably a better way.
- A production version should have a runtime flag to disable tracing as well an ENV variable control to enable it at startup. The runtime flag would be important to ship to production.