### PR TITLE
Introduce colocate_allow_hash_schema option

### DIFF
--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -561,6 +561,7 @@ DEFINE_test_flag(int32, delay_split_registration_secs, 0,
                  "Delay creating child tablets and upserting them to sys catalog");
 
 DECLARE_bool(ysql_enable_colocated_tables_with_tablespaces);
+DECLARE_bool(ysql_colocate_allow_hash_schema);
 
 DEFINE_NON_RUNTIME_bool(enable_heartbeat_pg_catalog_versions_cache, false,
     "Whether to enable the use of heartbeat catalog versions cache for the "
@@ -4056,7 +4057,11 @@ Status CatalogManager::CreateTable(const CreateTableRequestPB* orig_req,
   // This is because postgres does not know that this index table is in a colocated database.
   // When we get to the "tablespaces" step where we store this into PG metadata, then PG will know
   // if db/table is colocated and do the work there.
-  if (colocated && IsIndex(req)) {
+  //
+  // When ysql_colocate_allow_hash_schema is enabled, we also convert hash columns for regular
+  // colocated tables. This allows development setups to use HASH schemas while still benefiting
+  // from colocated tablet reuse for faster table creation.
+  if (colocated && (IsIndex(req) || FLAGS_ysql_colocate_allow_hash_schema)) {
     for (auto& col_pb : *req.mutable_schema()->mutable_columns()) {
       col_pb.set_is_hash_key(false);
     }
@@ -4083,9 +4088,11 @@ Status CatalogManager::CreateTable(const CreateTableRequestPB* orig_req,
     schema.InitColumnIdsByDefault();
   }
 
-  if (colocated) {
+  if (colocated && !FLAGS_ysql_colocate_allow_hash_schema) {
     // If the table is colocated, then there should be no hash partition columns.
     // Do the same for tables that are being placed in tablegroups.
+    // Skip this check when ysql_colocate_allow_hash_schema is enabled, as we convert
+    // hash columns to range columns above.
     if (schema.num_hash_key_columns() > 0) {
       Status s = STATUS(InvalidArgument, "Cannot colocate hash partitioned table");
       return SetupError(resp->mutable_error(), MasterErrorPB::INVALID_SCHEMA, s);

--- a/src/yb/yql/pggate/pggate_flags.cc
+++ b/src/yb/yql/pggate/pggate_flags.cc
@@ -123,6 +123,11 @@ TAG_FLAG(ysql_beta_feature_tablegroup, hidden);
 DEFINE_UNKNOWN_bool(
     ysql_colocate_database_by_default, false, "Enable colocation by default on each database.");
 
+DEFINE_UNKNOWN_bool(
+    ysql_colocate_allow_hash_schema, false,
+    "Development only: Allow HASH primary keys in colocated databases by converting them to "
+    "range keys. This enables faster table creation while keeping HASH in the schema definition.");
+
 DEFINE_UNKNOWN_bool(ysql_beta_feature_tablespace_alteration, false,
             "Whether to enable the incomplete 'tablespace_alteration' beta feature");
 

--- a/src/yb/yql/pggate/pggate_flags.h
+++ b/src/yb/yql/pggate/pggate_flags.h
@@ -42,6 +42,7 @@ DECLARE_bool(ysql_suppress_unsafe_alter_notice);
 DECLARE_bool(ysql_beta_features);
 DECLARE_bool(ysql_beta_feature_tablegroup);
 DECLARE_bool(ysql_colocate_database_by_default);
+DECLARE_bool(ysql_colocate_allow_hash_schema);
 DECLARE_bool(ysql_beta_feature_tablespace_alteration);
 DECLARE_bool(ysql_serializable_isolation_for_ddl_txn);
 DECLARE_bool(ysql_sleep_before_retry_on_txn_conflict);


### PR DESCRIPTION
When running `yugabyted` in development on local machines, we need to populate it with ~1500 tables.

We found that `ysql_colocate_database_by_default=true` significantly speeds up schema population.

However, it doesn't allow primary keys with `HASH` by design.

All of our tables use `HASH` partitioning, and even though it doesn't make a lot of sense in development, we feel strongly that we want to let developers `CREATE TABLE` with the same primary key as they'll use in production.

This PR adds `colocate_allow_hash_schema` as an option, which is intended to be used with `ysql_colocate_database_by_default=true` to let you populate schema with HASH partitioned tables.