### PR TITLE
`yugabyted`: stop child processes with `SIGTERM` instead of `SIGKILL`

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -165,3 +165,4 @@ This is a list of people who have contributed code to the [YugabyteDB](https://g
 * [utkarsh-um-yb](https://github.com/utkarsh-um-yb)
 * [aashir24-yb](https://github.com/aashir24-yb)
 * [keisku](https://github.com/keisku)
+* [Rylan12](https://github.com/Rylan12)

--- a/bin/yugabyted
+++ b/bin/yugabyted
@@ -3605,14 +3605,18 @@ class ControlScript(object):
             os._exit(os.EX_OK)
         self.set_signals(SIG_DFL)
 
-        for p in self.processes.values():
-            p.delete_pidfile()
-        self.script.delete_pidfile()
-
         try:
+            for p in self.processes.values():
+                p.kill()
+
+            for p in self.processes.values():
+                p.wait_until_stop()
+
+            self.script.delete_pidfile()
+
             # Kill process group instead of self.processes to ensure
-            # any spawned child processes are killed. Use SIGKILL because YugaWare
-            # requires KILL signal to terminate and nodes currently do not gracefully terminate.
+            # any spawned child processes are killed.
+            # This will terminate any processes that didn't respond to SIGTERM.
             os.killpg(pgid, SIGKILL)
             Output.log(
                 "{} may not have terminated properly... "


### PR DESCRIPTION
Currently, `yugabyted` kills child processes with `SIGKILL`, which does not allow them to perform any cleanup. For `tserver`, this means not cleaning up shared memory segments that were created. The current approach to cleaning these up is to use the previous `tserver` UUID from the configuration files in the base directory to determine the previous segment name and remove it. However, if the base directory no longer exists, this cleanup cannot be performed. As a consequence, the shared memory segments build up over time. On my machine, the limit for shared memory identifiers is 32, which means it doesn't take too long to encounter an issue with this.

This PR proposes a way to cleanup these shared segments at termination without replacing the `SIGKILL` signal. It doesn't replace the previous approach, so anything that slips through here should still be cleaned up on the next startup. However, I think this may be a slightly cleaner way to handle this.

When `yugabyted` is cleaning up child processes, it now does the following:

1. Terminate the `tserver` process using the pid stored in `self.processes`
    - This means the process will only be killed if it was actually started by `yugabyted`, which should preserve existing behavior
2. Wait 0.5 seconds for the process to clean up
3. Cleanup the shared memory segment using the `tserver` UUID from `self.configs` to generate the segment name
4. Kill the remaining child processes by stopping the entire process group, as it currently done

This should be a relatively minimal change that fails gracefully if any of the required information isn't available, but may help to avoid building up orphaned shared segments in certain cases.
