### PR TITLE
Connection Manager not supported on MacOS

### DIFF
--- a/docs/content/stable/additional-features/connection-manager-ysql/ycm-setup.md
+++ b/docs/content/stable/additional-features/connection-manager-ysql/ycm-setup.md
@@ -173,4 +173,4 @@ When using YSQL Connection Manager, sticky connections can form in the following
 - Currently, [auth-method](../../../secure/authentication/host-based-authentication/#auth-method) `cert` is not supported for host-based authentication. {{<issue 20658>}}
 - Although the use of auth-backends (`ysql_conn_mgr_use_auth_backend=true`) to authenticate client connections can result in higher connection acquisition latencies, using auth-passthrough (`ysql_conn_mgr_use_auth_backend=false`) may not be suitable depending on your workload. Contact {{% support-general %}} before setting `ysql_conn_mgr_use_auth_backend` to false. {{<issue 25313>}}
 - Unix socket connections to YSQL Connection Manager are not supported. {{<issue 20048>}}
-- Connection manager is not supported or present in the MacOS YugabyteDB releases and there are no plans to support it in near future.
+- Connection manager is not supported or included in the MacOS YugabyteDB releases, and there are currently no plans to support it.

--- a/docs/content/v2.25/additional-features/connection-manager-ysql/ycm-setup.md
+++ b/docs/content/v2.25/additional-features/connection-manager-ysql/ycm-setup.md
@@ -173,4 +173,4 @@ When using YSQL Connection Manager, sticky connections can form in the following
 - Although the use of auth-backends (`ysql_conn_mgr_use_auth_backend=true`) to authenticate client connections can result in higher connection acquisition latencies, using auth-passthrough (`ysql_conn_mgr_use_auth_backend=false`) may not be suitable depending on your workload. Contact {{% support-general %}} before setting `ysql_conn_mgr_use_auth_backend` to false. {{<issue 25313>}}
 - Salted Challenge Response Authentication Mechanism ([SCRAM](https://docs.yugabyte.com/preview/secure/authentication/password-authentication/#scram-sha-256)) is not supported with YSQL Connection Manager. {{<issue 25870>}}
 - Unix socket connections to YSQL Connection Manager are not supported. {{<issue 20048>}}
-- Connection manager is not supported or present in the MacOS YugabyteDB releases and there are no plans to support it in near future.
+- Connection manager is not supported or included in the MacOS YugabyteDB releases, and there are currently no plans to support it.

--- a/docs/content/v2024.1/additional-features/connection-manager-ysql/ycm-setup.md
+++ b/docs/content/v2024.1/additional-features/connection-manager-ysql/ycm-setup.md
@@ -109,4 +109,4 @@ When using YSQL Connection Manager, sticky connections can form in the following
 - Although the use of auth-backends (`ysql_conn_mgr_use_auth_backend=true`) to authenticate client connections can result in higher connection acquisition latencies, using auth-passthrough (`ysql_conn_mgr_use_auth_backend=false`) may not be suitable depending on your workload. Contact {{% support-general %}} before setting `ysql_conn_mgr_use_auth_backend` to false. {{<issue 25313>}}
 - Salted Challenge Response Authentication Mechanism ([SCRAM](https://docs.yugabyte.com/preview/secure/authentication/password-authentication/#scram-sha-256)) is not supported with YSQL Connection Manager. {{<issue 25870>}}
 - Unix socket connections to YSQL Connection Manager are not supported. {{<issue 20048>}}
-- Connection manager is not supported or present in the MacOS YugabyteDB releases and there are no plans to support it in near future.
+- Connection manager is not supported or included in the MacOS YugabyteDB releases, and there are currently no plans to support it.

--- a/docs/content/v2024.2/additional-features/connection-manager-ysql/ycm-setup.md
+++ b/docs/content/v2024.2/additional-features/connection-manager-ysql/ycm-setup.md
@@ -173,4 +173,4 @@ When using YSQL Connection Manager, sticky connections can form in the following
 - Currently, [auth-method](https://docs.yugabyte.com/preview/secure/authentication/host-based-authentication/#auth-method) `cert` is not supported for host-based authentication. {{<issue 20658>}}
 - Although the use of auth-backends (`ysql_conn_mgr_use_auth_backend=true`) to authenticate client connections can result in higher connection acquisition latencies, using auth-passthrough (`ysql_conn_mgr_use_auth_backend=false`) may not be suitable depending on your workload. Contact {{% support-general %}} before setting `ysql_conn_mgr_use_auth_backend` to false. {{<issue 25313>}}
 - Unix socket connections to YSQL Connection Manager are not supported. {{<issue 20048>}}
-- Connection manager is not supported or present in the MacOS YugabyteDB releases and there are no plans to support it in near future.
+- Connection manager is not supported or included in the MacOS YugabyteDB releases, and there are currently no plans to support it.

--- a/docs/content/v2025.1/additional-features/connection-manager-ysql/ycm-setup.md
+++ b/docs/content/v2025.1/additional-features/connection-manager-ysql/ycm-setup.md
@@ -173,4 +173,4 @@ When using YSQL Connection Manager, sticky connections can form in the following
 - Currently, [auth-method](../../../secure/authentication/host-based-authentication/#auth-method) `cert` is not supported for host-based authentication. {{<issue 20658>}}
 - Although the use of auth-backends (`ysql_conn_mgr_use_auth_backend=true`) to authenticate client connections can result in higher connection acquisition latencies, using auth-passthrough (`ysql_conn_mgr_use_auth_backend=false`) may not be suitable depending on your workload. Contact {{% support-general %}} before setting `ysql_conn_mgr_use_auth_backend` to false. {{<issue 25313>}}
 - Unix socket connections to YSQL Connection Manager are not supported. {{<issue 20048>}}
-- Connection manager is not supported or present in the MacOS YugabyteDB releases and there are no plans to support it in near future.
+- Connection manager is not supported or included in the MacOS YugabyteDB releases, and there are currently no plans to support it.


### PR DESCRIPTION
This diff adds a limitation about CM not been supported on MacOS.