### PR TITLE
[DOC-1121] Updated some CDC feature tags for 2025.2

### DIFF
--- a/docs/content/stable/additional-features/change-data-capture/using-logical-replication/yugabytedb-connector.md
+++ b/docs/content/stable/additional-features/change-data-capture/using-logical-replication/yugabytedb-connector.md
@@ -1549,7 +1549,7 @@ The following table lists the streaming metrics that are available.
 
 ### Parallel streaming
 
-YugabyteDB also supports parallel streaming of a single table using logical replication. This means that you can start the replication for the table using parallel tasks, where each task polls on specific tablets.
+{{<tags/feature/tp idea="1549">}} YugabyteDB also supports parallel streaming of a single table using logical replication. This means that you can start the replication for the table using parallel tasks, where each task polls on specific tablets.
 
 To enable the feature, set the `ysql_enable_pg_export_snapshot` and `ysql_yb_enable_consistent_replication_from_hash_range` flags to true.
 

--- a/docs/content/stable/releases/ybdb-releases/v2025.2.md
+++ b/docs/content/stable/releases/ybdb-releases/v2025.2.md
@@ -96,13 +96,7 @@ For more information, refer to [ClockBound](/stable/deploy/manual-deployment/sys
 
 <!-- * [YSQL index consistency checker](/stable/api/ysql/exprs/func_yb_index_check/). yb_index_check() is a built-in utility that helps detect and diagnose index inconsistencies in your database to ensure reliable query results. {{<tags/feature/ga idea="2160">}} -->
 
-* CDC
-
-  * Enables [parallel streaming](/stable/additional-features/change-data-capture/using-logical-replication/yugabytedb-connector/#parallel-streaming) in PG replication protocol, offering options to consume data in key-specific order. {{<tags/feature/ga idea="1549">}}
-
-  * Added [CDC Logical Replication support](/stable/additional-features/change-data-capture/using-logical-replication/get-started/) for xCluster feature where both CDC and xCluster can work simultaneously on the same source tables. {{<tags/feature/ga idea="82">}}
-
-  * Allows immediate reflection of newly added tables in publication, eliminating the need for manual setting. {{<tags/feature/ga idea="1841">}}
+* Added [CDC Logical Replication support](/stable/additional-features/change-data-capture/using-logical-replication/get-started/) for xCluster feature where both CDC and xCluster can work simultaneously on the same source tables. {{<tags/feature/ga idea="82">}}
 
 * ASH
 

--- a/docs/content/v2.25/additional-features/change-data-capture/using-logical-replication/yugabytedb-connector.md
+++ b/docs/content/v2.25/additional-features/change-data-capture/using-logical-replication/yugabytedb-connector.md
@@ -1549,11 +1549,7 @@ The following table lists the streaming metrics that are available.
 
 {{<tags/feature/tp idea="1549">}}YugabyteDB also supports parallel streaming of a single table using logical replication. This means that you can start the replication for the table using parallel tasks, where each task polls on specific tablets.
 
-{{< note title="Important" >}}
-
-Parallel streaming is {{<tags/feature/tp idea="1549">}}. To enable the feature, set the `ysql_enable_pg_export_snapshot` and `ysql_yb_enable_consistent_replication_from_hash_range` flags to true.
-
-{{< /note >}}
+To enable the feature, set the `ysql_enable_pg_export_snapshot` and `ysql_yb_enable_consistent_replication_from_hash_range` flags to true.
 
 Use the following steps to configure parallel streaming using the YugabyteDB Connector.
 
@@ -1585,7 +1581,7 @@ Execute the following query in YSQL for a `table_name` and number of tasks to ge
 
 ```sql
 WITH params AS (
-  SELECT 
+  SELECT
     num_ranges::int AS num_ranges,
     'table_name'::text AS table_name
 ),
@@ -1598,14 +1594,14 @@ yb_local_tablets_cte AS (
 ),
 
 grouped AS (
-  SELECT 
+  SELECT
     yt.*,
     NTILE((SELECT num_ranges FROM params)) OVER (ORDER BY partition_key_start_int) AS bucket_num
   FROM yb_local_tablets_cte yt
 ),
 
 buckets AS (
-  SELECT 
+  SELECT
     bucket_num,
     MIN(partition_key_start_int) AS bucket_start,
     MAX(partition_key_end_int) AS bucket_end

--- a/docs/content/v2024.2/additional-features/change-data-capture/using-logical-replication/yugabytedb-connector.md
+++ b/docs/content/v2024.2/additional-features/change-data-capture/using-logical-replication/yugabytedb-connector.md
@@ -1547,11 +1547,7 @@ The following table lists the streaming metrics that are available.
 
 {{<tags/feature/tp idea="1549">}}YugabyteDB also supports parallel streaming of a single table using logical replication. This means that you can start the replication for the table using parallel tasks, where each task polls on specific tablets.
 
-{{< note title="Important" >}}
-
-Parallel streaming is {{<tags/feature/tp idea="1549">}}. To enable the feature, set the `ysql_enable_pg_export_snapshot` and `ysql_yb_enable_consistent_replication_from_hash_range` flags to true.
-
-{{< /note >}}
+To enable the feature, set the `ysql_enable_pg_export_snapshot` and `ysql_yb_enable_consistent_replication_from_hash_range` flags to true.
 
 Use the following steps to configure parallel streaming using the YugabyteDB Connector.
 
@@ -1583,7 +1579,7 @@ Execute the following query in YSQL for a `table_name` and number of tasks to ge
 
 ```sql
 WITH params AS (
-  SELECT 
+  SELECT
     num_ranges::int AS num_ranges,
     'table_name'::text AS table_name
 ),
@@ -1596,14 +1592,14 @@ yb_local_tablets_cte AS (
 ),
 
 grouped AS (
-  SELECT 
+  SELECT
     yt.*,
     NTILE((SELECT num_ranges FROM params)) OVER (ORDER BY partition_key_start_int) AS bucket_num
   FROM yb_local_tablets_cte yt
 ),
 
 buckets AS (
-  SELECT 
+  SELECT
     bucket_num,
     MIN(partition_key_start_int) AS bucket_start,
     MAX(partition_key_end_int) AS bucket_end

--- a/docs/content/v2025.1/additional-features/change-data-capture/using-logical-replication/yugabytedb-connector.md
+++ b/docs/content/v2025.1/additional-features/change-data-capture/using-logical-replication/yugabytedb-connector.md
@@ -1549,11 +1549,7 @@ The following table lists the streaming metrics that are available.
 
 {{<tags/feature/tp idea="1549">}}YugabyteDB also supports parallel streaming of a single table using logical replication. This means that you can start the replication for the table using parallel tasks, where each task polls on specific tablets.
 
-{{< note title="Important" >}}
-
-Parallel streaming is {{<tags/feature/tp idea="1549">}}. To enable the feature, set the `ysql_enable_pg_export_snapshot` and `ysql_yb_enable_consistent_replication_from_hash_range` flags to true.
-
-{{< /note >}}
+To enable the feature, set the `ysql_enable_pg_export_snapshot` and `ysql_yb_enable_consistent_replication_from_hash_range` flags to true.
 
 Use the following steps to configure parallel streaming using the YugabyteDB Connector.
 


### PR DESCRIPTION
- Parallel streaming stays TP in 2025.2. So updated the tag and removed the RN.
- [IDEA-1841](https://yugabyte.atlassian.net/jira/polaris/projects/IDEA/ideas/view/7844718?selectedIssue=IDEA-1841) is going EA only in 2025.2.1 - so removed the RN

[IDEA-1841]: https://yugabyte.atlassian.net/browse/IDEA-1841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ