### PR TITLE
[DOC-1127] Clarify that SCRAM-SHA-256 auth method is supported in v2024.2.4 and later for Connection Manager

### DIFF
--- a/docs/content/stable/releases/ybdb-releases/v2024.2.md
+++ b/docs/content/stable/releases/ybdb-releases/v2024.2.md
@@ -717,8 +717,10 @@ docker pull yugabytedb/yugabyte:2024.2.4.0-b89
 
 ### New feature
 
-* [Connection Manager](/v2024.2/explore/going-beyond-sql/connection-mgr-ysql/). Reduced the cost of binding logical to physical connections to improve performance and lower application-level latencies, specifically by optimizing the GUC workflow.
-{{<tags/feature/ea idea="2197">}}
+* [Connection Manager](/v2024.2/explore/going-beyond-sql/connection-mgr-ysql/).
+
+    - Reduced the cost of binding logical to physical connections to improve performance and lower application-level latencies, specifically by optimizing the GUC workflow. {{<tags/feature/ea idea="2197">}}
+    - Added SCRAM-SHA-256 [authentication method](/v2024.2/additional-features/connection-manager-ysql/ycm-setup/#authentication-methods) support for Connection Manager.
 
 ### Improvements
 

--- a/docs/content/v2024.2/additional-features/connection-manager-ysql/ycm-setup.md
+++ b/docs/content/v2024.2/additional-features/connection-manager-ysql/ycm-setup.md
@@ -134,7 +134,7 @@ The following table outlines the various authentication methods supported by Yug
 | {{<icon/yes>}} | JWT Authentication (OIDC) | Uses JSON Web Tokens (JWT) from an external Identity Provider (IDP) to securely transmit authentication and authorization information. |
 | {{<icon/yes>}} | LDAP Authentication | Verifies users against a centralized directory service using Lightweight Directory Access Protocol (LDAP). |
 | {{<icon/no>}} | GSS API or Kerberos| Enables Kerberos-based authentication through a standardized API, allowing secure, enterprise-grade Single Sign-On (SSO) logins without passwords. <br> **Note**: Testing of this feature with YugabyteDB is currently limited.|
-| {{<icon/yes>}} | SCRAM-SHA-256  | A secure password-based authentication that protects credentials using hashing, salting, and challenge-response. |
+| {{<icon/yes>}} | SCRAM-SHA-256  | A secure password-based authentication that protects credentials using hashing, salting, and challenge-response. Supported in {{<release "2024.2.4.0">}} and later. |
 | {{<icon/no>}} | SCRAM-SHA-256-PLUS  | A variant of SCRAM-SHA-256 over TLS channels that performs TLS channel-binding as part of authentication. |
 | {{<icon/yes>}} | MD5 | Password-based authentication where the user's password is by default stored in MD5 encryption format in the database. |
 | {{<icon/no>}} | Cert  | Certificate-based authentication requires the client to provide certificates to the server over a TLS connection for authentication. |


### PR DESCRIPTION
@netlify /v2024.2/additional-features/connection-manager-ysql/ycm-setup/#authentication-methods