### PR TITLE
Respect `PGHOST` environment variable in `ysql_dump`

### DIFF
--- a/java/yb-pgsql/src/test/java/org/yb/pgsql/TestYsqlDump.java
+++ b/java/yb-pgsql/src/test/java/org/yb/pgsql/TestYsqlDump.java
@@ -15,8 +15,10 @@ package org.yb.pgsql;
 
 import static org.yb.AssertionWrappers.*;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -26,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -470,6 +473,97 @@ public class TestYsqlDump extends BasePgSQLTest {
       "results/yb.orig.ysql_dump_describe_colocated_tables_with_tablespaces.out"
       /* outputDescribeFileRelativePath */
     );
+  }
+
+  @Test
+  public void ysqlDumpRespectsPGHOSTEnvVar() throws Exception {
+    File pgBinDir = PgRegressBuilder.getPgBinDir();
+    File ysqlDumpExec = new File(pgBinDir, "ysql_dump");
+
+    String invalidHost = "nosuchhost.invalid";
+
+    List<String> args = Arrays.asList(
+        ysqlDumpExec.toString(),
+        "-d", "testdb"
+    );
+
+    ProcessBuilder pb = new ProcessBuilder(args);
+    pb.environment().put("PGHOST", invalidHost);
+    pb.redirectErrorStream(true);
+
+    LOG.info("Running ysql_dump with PGHOST=" + invalidHost);
+    Process process = pb.start();
+
+    // Capture output (stdout + stderr merged)
+    BufferedReader reader = new BufferedReader(
+        new InputStreamReader(process.getInputStream()));
+    StringBuilder output = new StringBuilder();
+    String line;
+    while ((line = reader.readLine()) != null) {
+      output.append(line).append("\n");
+    }
+
+    process.waitFor(60, TimeUnit.SECONDS);
+
+    // The process should fail (non-zero exit code)
+    assertNotEquals("ysql_dump should fail when PGHOST points to invalid host",
+        0, process.exitValue());
+
+    // The error message should contain the invalid host name, proving PGHOST was respected
+    String outputStr = output.toString();
+    assertTrue("Error message should mention the invalid PGHOST value '" + invalidHost +
+        "', but got: " + outputStr,
+        outputStr.contains(invalidHost));
+
+    LOG.info("ysql_dump correctly respected PGHOST environment variable");
+  }
+
+  /**
+   * Test that the --host flag takes precedence over the PGHOST environment variable.
+   * When both are set, ysql_dump should use the --host value and succeed.
+   */
+  @Test
+  public void ysqlDumpHostFlagOverridesPGHOSTEnvVar() throws Exception {
+    int tserverIndex = 0;
+    File pgBinDir = PgRegressBuilder.getPgBinDir();
+    File ysqlDumpExec = new File(pgBinDir, "ysql_dump");
+
+    // Set PGHOST to an invalid host - if this were used, the dump would fail
+    String invalidEnvHost = "invalid-env-host.invalid";
+
+    List<String> args = Arrays.asList(
+        ysqlDumpExec.toString(),
+        "-h", getPgHost(tserverIndex),
+        "-p", Integer.toString(getPgPort(tserverIndex)),
+        "-U", DEFAULT_PG_USER,
+        "-d", DEFAULT_PG_DATABASE
+    );
+
+    ProcessBuilder pb = new ProcessBuilder(args);
+    pb.environment().put("PGHOST", invalidEnvHost);
+    pb.redirectErrorStream(true);
+
+    LOG.info("Running ysql_dump with PGHOST=" + invalidEnvHost +
+        " and -h " + getPgHost(tserverIndex));
+    Process process = pb.start();
+
+    // Capture output (stdout + stderr merged)
+    BufferedReader reader = new BufferedReader(
+        new InputStreamReader(process.getInputStream()));
+    StringBuilder output = new StringBuilder();
+    String line;
+    while ((line = reader.readLine()) != null) {
+      output.append(line).append("\n");
+    }
+
+    process.waitFor(60, TimeUnit.SECONDS);
+
+    // The process should succeed (exit code 0) because -h flag overrides PGHOST
+    assertEquals("ysql_dump should succeed when -h flag points to valid host, " +
+        "even with invalid PGHOST. Output: " + output.toString(),
+        0, process.exitValue());
+
+    LOG.info("ysql_dump correctly prioritized --host flag over PGHOST environment variable");
   }
 
   @Test

--- a/src/postgres/src/bin/pg_dump/pg_dump.c
+++ b/src/postgres/src/bin/pg_dump/pg_dump.c
@@ -920,10 +920,6 @@ main(int argc, char **argv)
 
 	fout->numWorkers = numWorkers;
 
-	/* YB */
-	if (dopt.cparams.pghost == NULL || dopt.cparams.pghost[0] == '\0')
-		dopt.cparams.pghost = DefaultHost;
-
 	/*
 	 * Open the database using the Archiver, so it knows about it. Errors mean
 	 * death.

--- a/src/postgres/src/interfaces/libpq/libpq-fe.h
+++ b/src/postgres/src/interfaces/libpq/libpq-fe.h
@@ -50,7 +50,6 @@ extern "C"
 /* YB */
 #define DEF_YBPORT 5433
 #define DEF_YBPORT_STR "5433"
-#define DefaultHost "localhost"
 
 /* Application-visible enum types */
 


### PR DESCRIPTION
Fixes https://github.com/yugabyte/yugabyte-db/issues/13182

Previously `ysql_dump` would ignore the PGHOST environment variable so this fixes that. The specificity is now:

- `-h` flag (highest priority)
- `PGHOST` environment variable
- localhost default (lowest priority)

_prefers `-h` if present regardless of PGHOST_

```bash
➜ PGHOST=invalid-test-host.example.com ./build/release-clang-dynamic-arm64/postgres/bin/ysql_dump -d postgres -h another-host.foo.com
ysql_dump: error: connection to server at "another-host.foo.com" (50.16.218.27), port 5433 failed: Network is unreachable
        Is the server running on that host and accepting TCP/IP connections?
```

_respects PGHOST_

```bash
➜ PGHOST=invalid-test-host.example.com ./build/release-clang-dynamic-arm64/postgres/bin/ysql_dump -d postgres
ysql_dump: error: could not translate host name "invalid-test-host.example.com" to address: nodename nor servname provided, or not known
```

_defaults to localhost if not provided_

```bash
➜ ./build/release-clang-dynamic-arm64/postgres/bin/ysql_dump -d postgres               
ysql_dump: error: connection to server at "localhost" (::1), port 5433 failed: Connection refused
        Is the server running on that host and accepting TCP/IP connections?
connection to server at "localhost" (127.0.0.1), port 5433 failed: Connection refused
        Is the server running on that host and accepting TCP/IP connections?
```