### PR TITLE
[Docs] Fix error on building the docs site

### DIFF
--- a/docs/assets/scss/_styles_project.scss
+++ b/docs/assets/scss/_styles_project.scss
@@ -1,4 +1,3 @@
-@import "./fontawesome/_default.scss";
 @import "./_yb_headings.scss";
 @import "./_yb_bullets-and-number-list.scss";
 @import "./_dropdown_list.scss";

--- a/docs/assets/scss/_variables_project.scss
+++ b/docs/assets/scss/_variables_project.scss
@@ -1,3 +1,5 @@
+@import "./fontawesome/_default.scss";
+
 $primary: #fe6f42;
 $secondary: #312965;
 $google_font_name: "Inter";


### PR DESCRIPTION
While building the docs site from a new path using our [docs build instructions](https://docs.yugabyte.com/stable/contribute/docs/docs-build/) encountered following errosrs.
```
Error: error building site: TOCSS: failed to transform "/scss/main.scss" (text/x-scss): "/Users/aishwarya/yb-docs-2026/yugabyte-db/docs/assets/scss/_sidebar-tree.scss:80:22": Undefined variable: "$font-awesome-font-name".
[webpack-cli] Gracefully shutting down. To force exit, press ^C again. Please wait...
ERROR: "hugo-server-fast" exited with 1.
```