### PR TITLE
Remove duplicated front matter

### DIFF
--- a/docs/content/stable/faq/comparisons/azure-cosmos.md
+++ b/docs/content/stable/faq/comparisons/azure-cosmos.md
@@ -8,7 +8,6 @@ aliases:
 menu:
   stable_faq:
     identifier: azure-cosmos
-    identifier: comparisons-cosmos
     parent: comparisons
     weight: 1110
 type: docs

--- a/docs/content/stable/releases/techadvisories/_template.md
+++ b/docs/content/stable/releases/techadvisories/_template.md
@@ -9,7 +9,6 @@ cascade:
   unversioned: true
 rightNav:
   hideH2: true
-type: docs
 ---
 
 |          Product           |  Affected Versions  |  Related Issues   | Fixed In |

--- a/docs/content/stable/releases/techadvisories/ta-14696.md
+++ b/docs/content/stable/releases/techadvisories/ta-14696.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 rightNav:
   hideH2: true
-type: docs
 ---
 
 | Product | Affected Versions | Related Issues | Fixed In |

--- a/docs/content/stable/releases/techadvisories/ta-20398.md
+++ b/docs/content/stable/releases/techadvisories/ta-20398.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 rightNav:
   hideH2: true
-type: docs
 ---
 
 |          Product           |  Affected Versions  |  Related Issues   | Fixed In |

--- a/docs/content/stable/releases/techadvisories/ta-20648.md
+++ b/docs/content/stable/releases/techadvisories/ta-20648.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 rightNav:
   hideH2: true
-type: docs
 ---
 
 |          Product           |  Affected Versions  |  Related Issues   | Fixed In |

--- a/docs/content/stable/releases/techadvisories/ta-20827.md
+++ b/docs/content/stable/releases/techadvisories/ta-20827.md
@@ -9,7 +9,6 @@ cascade:
   unversioned: true
 rightNav:
   hideH2: true
-type: docs
 ---
 
 |          Product           |  Affected Versions  |  Related Issues   | Fixed In |

--- a/docs/content/stable/releases/techadvisories/ta-20864.md
+++ b/docs/content/stable/releases/techadvisories/ta-20864.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 rightNav:
   hideH2: true
-type: docs
 ---
 
 |          Product           |  Affected Versions  |  Related Issues   | Fixed In |

--- a/docs/content/stable/releases/techadvisories/ta-21218.md
+++ b/docs/content/stable/releases/techadvisories/ta-21218.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 rightNav:
   hideH2: true
-type: docs
 ---
 
 |          Product           |  Affected Versions  |  Related Issues   | Fixed In |

--- a/docs/content/stable/releases/techadvisories/ta-21297.md
+++ b/docs/content/stable/releases/techadvisories/ta-21297.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 rightNav:
   hideH2: true
-type: docs
 ---
 
 |          Product           |  Affected Versions  |  Related Issues   | Fixed In |

--- a/docs/content/stable/releases/techadvisories/ta-21491.md
+++ b/docs/content/stable/releases/techadvisories/ta-21491.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 rightNav:
   hideH2: true
-type: docs
 ---
 
 |          Product           |  Affected Versions  |  Related Issues   | Fixed In |

--- a/docs/content/stable/releases/techadvisories/ta-22057.md
+++ b/docs/content/stable/releases/techadvisories/ta-22057.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 rightNav:
   hideH2: true
-type: docs
 ---
 
 |          Product           |  Affected Versions  |  Related Issues   | Fixed In |

--- a/docs/content/stable/releases/techadvisories/ta-22802.md
+++ b/docs/content/stable/releases/techadvisories/ta-22802.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 rightNav:
   hideH2: true
-type: docs
 ---
 
 |          Product           |  Affected Versions  |  Related Issues   | Fixed In |

--- a/docs/content/stable/releases/techadvisories/ta-22935.md
+++ b/docs/content/stable/releases/techadvisories/ta-22935.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 rightNav:
   hideH2: true
-type: docs
 ---
 
 |          Product           |  Affected Versions  |  Related Issues   | Fixed In |

--- a/docs/content/stable/releases/techadvisories/ta-23476.md
+++ b/docs/content/stable/releases/techadvisories/ta-23476.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 rightNav:
   hideH2: true
-type: docs
 ---
 
 |          Product           |  Affected Versions  |  Related Issues   | Fixed In |

--- a/docs/content/stable/releases/techadvisories/ta-24313.md
+++ b/docs/content/stable/releases/techadvisories/ta-24313.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 rightNav:
   hideH2: true
-type: docs
 ---
 
 |          Product           |  Affected Versions  |  Related Issues   | Fixed In |

--- a/docs/content/stable/releases/techadvisories/ta-24992.md
+++ b/docs/content/stable/releases/techadvisories/ta-24992.md
@@ -13,9 +13,7 @@ menu:
     weight: 1
 rightNav:
   hideH2: true
-type: docs
 ---
-
 
 |          Product           |  Affected Versions  |  Related Issues   | Fixed In |
 | :------------------------- | :------------------ | :---------------- | :------- |

--- a/docs/content/stable/releases/techadvisories/ta-25106.md
+++ b/docs/content/stable/releases/techadvisories/ta-25106.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 rightNav:
   hideH2: true
-type: docs
 ---
 
 |          Product           |  Affected Versions  |  Related Issues   | Fixed In |

--- a/docs/content/stable/releases/techadvisories/ta-25193.md
+++ b/docs/content/stable/releases/techadvisories/ta-25193.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 rightNav:
   hideH2: true
-type: docs
 ---
 
 |          Product           |  Affected Versions  |  Related Issues   | Fixed In |

--- a/docs/content/stable/releases/techadvisories/ta-26440.md
+++ b/docs/content/stable/releases/techadvisories/ta-26440.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 rightNav:
   hideH2: true
-type: docs
 ---
 
 | Product | Affected Versions | Related Issues | Fixed In |

--- a/docs/content/stable/releases/techadvisories/ta-26666.md
+++ b/docs/content/stable/releases/techadvisories/ta-26666.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 rightNav:
   hideH2: true
-type: docs
 ---
 
 | Product | Affected Versions | Related Issues | Fixed In |

--- a/docs/content/stable/releases/techadvisories/ta-27177.md
+++ b/docs/content/stable/releases/techadvisories/ta-27177.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 rightNav:
   hideH2: true
-type: docs
 ---
 
 | Product |  Affected Versions  |  Related Issues   | Fixed In |

--- a/docs/content/stable/releases/techadvisories/ta-27380.md
+++ b/docs/content/stable/releases/techadvisories/ta-27380.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 rightNav:
   hideH2: true
-type: docs
 ---
 
 |          Product           |  Affected Versions  |  Related Issues   | Fixed In |

--- a/docs/content/stable/releases/techadvisories/ta-28222.md
+++ b/docs/content/stable/releases/techadvisories/ta-28222.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 rightNav:
   hideH2: true
-type: docs
 ---
 
 |          Product           |  Affected Versions  |  Related Issues   | Fixed In |

--- a/docs/content/stable/releases/techadvisories/ta-28267.md
+++ b/docs/content/stable/releases/techadvisories/ta-28267.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 rightNav:
   hideH2: true
-type: docs
 ---
 
 |          Product           |  Affected Versions  |  Related Issues   | Fixed In |
@@ -71,7 +70,7 @@ Use one of the following workarounds / solutions to the issue:
     should instead be defined as
 
     ```sql
-    CREATE INDEX name ON table ( func(a, b) ) INCLUDE (a, b)  
+    CREATE INDEX name ON table ( func(a, b) ) INCLUDE (a, b)
     ```
 
 ## Details

--- a/docs/content/stable/releases/techadvisories/ta-29060.md
+++ b/docs/content/stable/releases/techadvisories/ta-29060.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 rightNav:
   hideH2: true
-type: docs
 ---
 
 |          Product           |  Affected Versions  |  Related Issues   | Fixed In |

--- a/docs/content/stable/releases/techadvisories/ta-2968.md
+++ b/docs/content/stable/releases/techadvisories/ta-2968.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 rightNav:
   hideH2: true
-type: docs
 ---
 
 | Product | Affected Versions | Related Issues | Fixed In |

--- a/docs/content/stable/releases/techadvisories/ta-cl-23623.md
+++ b/docs/content/stable/releases/techadvisories/ta-cl-23623.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 rightNav:
   hideH2: true
-type: docs
 ---
 
 |          Product           |  Affected Versions  |  Related Issues   | Fixed In |

--- a/docs/content/stable/releases/techadvisories/ta-reol-24.md
+++ b/docs/content/stable/releases/techadvisories/ta-reol-24.md
@@ -13,7 +13,6 @@ menu:
     weight: 1
 rightNav:
   hideH2: true
-type: docs
 ---
 
 |          Product           |  Affected Versions   | Fixed In |

--- a/docs/content/stable/releases/ybdb-releases/end-of-life/v2.19.md
+++ b/docs/content/stable/releases/ybdb-releases/end-of-life/v2.19.md
@@ -5,8 +5,6 @@ linkTitle: v2.19 series
 description: Enhancements, changes, and resolved issues in the v2.19 release series.
 aliases:
   - /stable/releases/ybdb-releases/v2.19/
-rightNav:
-  hideH4: true
 menu:
   stable_releases:
     identifier: v2.19


### PR DESCRIPTION
With the latest version of Hugo, duplicate front matter in Markdown files now causes errors. This PR removes all duplicated front matter.