### PR TITLE
[Docs] Fix link symbol for the H3 on configuration pages

### DIFF
--- a/docs/assets/scss/_yb_headings.scss
+++ b/docs/assets/scss/_yb_headings.scss
@@ -267,7 +267,7 @@ body.configuration {
     h3 + h5:not(:first-child),
     h4 + h5:not(:first-child) {
       margin-top: 32px;
-      // position: static;
+      position: static;
 
       &::after {
         display: none;


### PR DESCRIPTION
The link symbol for the h3 doesn't show up when it should. This is the `yb-tserver` page
https://docs.yugabyte.com/stable/reference/configuration/yb-tserver/#allowed-preview-flags-csv