### PR TITLE
[#29974] odyssey/postgres: remove IPV6_ONLY socket option

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -83,7 +83,7 @@ This is a list of people who have contributed code to the [YugabyteDB](https://g
 * [aegershman](https://github.com/aegershman)
 * [hasheddan](https://github.com/hasheddan)
 * [ameyb](https://github.com/ameyb)
-* [fastest963](https://github.com/fastest963)
+* [jameshartig](https://github.com/jameshartig)
 * [eliahburns](https://github.com/eliahburns)
 * [bhavin192](https://github.com/bhavin192)
 * [graffido](https://github.com/graffido)

--- a/src/odyssey/third_party/machinarium/sources/bind.c
+++ b/src/odyssey/third_party/machinarium/sources/bind.c
@@ -30,6 +30,10 @@ MACHINE_API int machine_bind(machine_io_t *obj, struct sockaddr *sa, int flags)
 		mm_errno_set(errno);
 		goto error;
 	}
+	/*
+	 * YB Change: Allow dual-stack binding by not forcing IPV6_V6ONLY.
+	 */
+#if 0
 	if (sa->sa_family == AF_INET6) {
 		rc = mm_socket_set_ipv6only(io->fd, 1);
 		if (rc == -1) {
@@ -37,6 +41,7 @@ MACHINE_API int machine_bind(machine_io_t *obj, struct sockaddr *sa, int flags)
 			goto error;
 		}
 	}
+#endif
 	rc = mm_socket_bind(io->fd, sa);
 	if (rc == -1) {
 		mm_errno_set(errno);

--- a/src/postgres/src/backend/libpq/pqcomm.c
+++ b/src/postgres/src/backend/libpq/pqcomm.c
@@ -536,6 +536,10 @@ StreamServerPort(int family, const char *hostName, unsigned short portNumber,
 #endif
 
 #ifdef IPV6_V6ONLY
+		/*
+		 * YB Change: We want to allow dual-stack binding when the OS supports it.
+		 */
+#if 0
 		if (addr->ai_family == AF_INET6)
 		{
 			if (setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY,
@@ -551,6 +555,7 @@ StreamServerPort(int family, const char *hostName, unsigned short portNumber,
 				continue;
 			}
 		}
+#endif
 #endif
 
 		/*

--- a/src/yb/yql/pgwrapper/pg_wrapper-test.cc
+++ b/src/yb/yql/pgwrapper/pg_wrapper-test.cc
@@ -879,5 +879,28 @@ TEST_F(PgWrapperTest, GetPgSocketDir) {
   ASSERT_EQ(result, 1);
 }
 
+class PgWrapperDualStackTest : public PgWrapperOneNodeClusterTest {
+};
+
+// Ensure that listening on :: also means listening on 0.0.0.0.
+TEST_F(PgWrapperDualStackTest, TestIPv4Connectivity) {
+  MonoDelta timeout = 15s;
+
+  auto port = pg_ts->ysql_port();
+  // Restart the tablet server with the bind address set to [::] and the same port.
+  ASSERT_OK(pg_ts->Restart(
+      false /* start_cql_proxy */,
+      {{"pgsql_proxy_bind_address", Format("[::]:$0", port)}}));
+
+  ASSERT_OK(WaitForPostgresToStart(timeout));
+
+  auto conn = ASSERT_RESULT(PGConnBuilder({
+      .host = "127.0.0.1",
+      .port = port,
+      .dbname = "postgres"
+  }).Connect());
+  ASSERT_OK(conn.Execute("SELECT 1"));
+}
+
 }  // namespace pgwrapper
 }  // namespace yb


### PR DESCRIPTION
odyssey and postgres both forced IPV6 sockets to IPv6-only with the IPV6_ONLY socket option. This meant that listening on `[::]` did not additionally listen on IPv4 addresses like CQL does.

I didn't want to comment out the code as that could cause merge conflicts later as things are brought in from upstream so I used #if 0 like I saw in other parts of the postgres codebase. I thought about plumbing down a configuration flag into that code but it would've been a lot larger of a change and fairly difficult.

I tested this locally by running:

```
bin/yugabyted start --tserver_flags 'pgsql_proxy_bind_address=[::]:5433,cql_proxy_bind_address=[::]:9042'
```

and then connecting with both `127.0.0.1` and `::1`.

I similarly tested odyssey by running:

```
bin/yugabyted start --tserver_flags 'pgsql_proxy_bind_address=[::]:5433,cql_proxy_bind_address=[::]:9042,enable_ysql_conn_mgr=true'
```

I would like some guidance on the unit test for Postgres. I tried to verify it locally but I keep getting an error saying there isn't enough tablet servers to make the various initdb tables during setup before it even gets to my code. Is there something I'm missing about the test harness that I need to do?

Fixes #29974