### PR TITLE
Add start_time_us to tablet server JSON API

### DIFF
--- a/src/yb/master/catalog_entity_info.proto
+++ b/src/yb/master/catalog_entity_info.proto
@@ -1054,4 +1054,6 @@ message SysTabletServerEntryPB {
   optional bool persisted = 6;
 
   optional VersionInfoPB version_info = 9;
+
+  optional uint64 start_time_us = 10;
 }

--- a/src/yb/master/master-path-handlers.cc
+++ b/src/yb/master/master-path-handlers.cc
@@ -928,6 +928,9 @@ void MasterPathHandlers::HandleGetTserverStatus(const Webserver::WebRequest& req
           jw.Uint(0);
         }
 
+        jw.String("start_time_us");
+        jw.Uint64(desc->start_time_us());
+
         jw.String("ram_used");
         jw.String(HumanizeBytes(desc->total_memory_usage()));
         jw.String("ram_used_bytes");

--- a/src/yb/master/ts_descriptor.cc
+++ b/src/yb/master/ts_descriptor.cc
@@ -139,6 +139,9 @@ Result<TSDescriptor::WriteLock> TSDescriptor::UpdateRegistration(
   // After re-registering, make the TS re-report its tablets.
   has_tablet_report_ = false;
   l.mutable_data()->pb.set_instance_seqno(instance.instance_seqno());
+  if (instance.has_start_time_us()) {
+    l.mutable_data()->pb.set_start_time_us(instance.start_time_us());
+  }
   *l.mutable_data()->pb.mutable_registration() = registration.common();
   *l.mutable_data()->pb.mutable_resources() = registration.resources();
   if (registration.has_version_info()) {
@@ -215,6 +218,11 @@ MonoTime TSDescriptor::LastHeartbeatTime() const {
 
 int64_t TSDescriptor::latest_seqno() const {
   return LockForRead()->pb.instance_seqno();
+}
+
+uint64_t TSDescriptor::start_time_us() const {
+  auto l = LockForRead();
+  return l->pb.has_start_time_us() ? l->pb.start_time_us() : 0;
 }
 
 int32_t TSDescriptor::latest_report_seqno() const {

--- a/src/yb/master/ts_descriptor.h
+++ b/src/yb/master/ts_descriptor.h
@@ -161,6 +161,7 @@ class TSDescriptor : public MetadataCowWrapper<PersistentTServerInfo> {
 
   int64_t latest_seqno() const;
   int32_t latest_report_seqno() const;
+  uint64_t start_time_us() const;
 
   bool has_tablet_report() const;
   void set_has_tablet_report(bool has_report);


### PR DESCRIPTION
The masters JSON endpoint (`/api/v1/masters`) returns a start time in microseconds (`start_time_us`) for each master instance but the tablet server JSON endpoint only returns the uptime in seconds (`uptime_seconds`).

We would like to display uptime in some internal tooling which requires periodically reconciling YB cluster state with our application but since the uptime changes essentially every time we fetch the data, we either need to constantly be updating this value or debouncing it manually. Additionally, deriving the start time from the uptime could lead to a jittery value since the reference point is unknown and the calculation will depend on API response latency.

Rather than doing this, the tablet server JSON endpoint should just return the start timestamp like the masters endpoint. This allows us to ignore the uptime value but still display an accurate uptime in our tooling based on the start time.

Output from running this branch locally:

```json
{
  "be68218c-b81d-48d4-97fc-92f93bc0cf2d": {
    "127.0.0.1:9000": {
      "time_since_hb": "0.1s",
      "time_since_hb_sec": 0.05357075,
      "status": "ALIVE",
      "uptime_seconds": 3,
      "start_time_us": 1770127257138343,
      "ram_used": "9.20 MB",
      "ram_used_bytes": 9199616,
      "num_sst_files": 0,
      "total_sst_file_size": "0 B",
      "total_sst_file_size_bytes": 0,
      "uncompressed_sst_file_size": "0 B",
      "uncompressed_sst_file_size_bytes": 0,
      "path_metrics": [
        {
          "path": "/Users/alex/var/data",
          "space_used": 641347555328,
          "total_space_size": 994662584320
        }
      ],
      "read_ops_per_sec": 0,
      "write_ops_per_sec": 0,
      "user_tablets_total": 0,
      "user_tablets_leaders": 0,
      "system_tablets_total": 10,
      "system_tablets_leaders": 10,
      "active_tablets": 10,
      "cloud": "cloud1",
      "region": "datacenter1",
      "zone": "rack1",
      "permanent_uuid": "bee53e2a1bd948bca7601393277ca8bc"
    }
  }
}

```

**Upgrade/Rollback safety:**
`start_time_us` was added to `catalog_entity_info.proto` and is populated from data received from tserver heartbeats. This is only used in JSON endpoint so is upgrade and rollback safe.