### PR TITLE
[docs] Fix two commands in the tablet-splitting document

### DIFF
--- a/docs/content/stable/architecture/docdb-sharding/tablet-splitting.md
+++ b/docs/content/stable/architecture/docdb-sharding/tablet-splitting.md
@@ -165,7 +165,9 @@ Note that misuse or overuse of manual tablet splitting (for example, splitting t
 To verify that the table `t` has only one tablet, list all the tablets for table `t` using the following [`yb-admin list_tablets`](../../../admin/yb-admin/#list-tablets) command:
 
 ```bash
-./bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 list_tablets ysql.yugabyte t
+./bin/yb-admin \
+    --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+    list_tablets ysql.yugabyte t
 ```
 
 Expect the following output:

--- a/docs/content/v2.20/architecture/docdb-sharding/tablet-splitting.md
+++ b/docs/content/v2.20/architecture/docdb-sharding/tablet-splitting.md
@@ -165,7 +165,9 @@ Note that misuse or overuse of manual tablet splitting (for example, splitting t
 To verify that the table `t` has only one tablet, list all the tablets for table `t` using the following [`yb-admin list_tablets`](../../../admin/yb-admin/#list-tablets) command:
 
 ```bash
-./bin/yb-admin --master_addresses 127.0.0.1:7100 list_tablets ysql.yugabyte t
+./bin/yb-admin \
+    --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+    list_tablets ysql.yugabyte t
 ```
 
 Expect the following output:
@@ -183,7 +185,7 @@ The tablet should have some data persisted on the disk. If you insert small amou
 
 ```sh
 ./bin/yb-ts-cli \
-    --server_address=127.0.0.1:9100,127.0.0.2:9100,127.0.0.3:9100 \
+    --server_address=127.0.0.1:9100 \
     flush_tablet 9991368c4b85456988303cd65a3c6503
 ```
 

--- a/docs/content/v2.25/architecture/docdb-sharding/tablet-splitting.md
+++ b/docs/content/v2.25/architecture/docdb-sharding/tablet-splitting.md
@@ -165,7 +165,9 @@ Note that misuse or overuse of manual tablet splitting (for example, splitting t
 To verify that the table `t` has only one tablet, list all the tablets for table `t` using the following [`yb-admin list_tablets`](../../../admin/yb-admin/#list-tablets) command:
 
 ```bash
-./bin/yb-admin --master_addresses 127.0.0.1:7100 list_tablets ysql.yugabyte t
+./bin/yb-admin \
+    --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+    list_tablets ysql.yugabyte t
 ```
 
 Expect the following output:
@@ -183,7 +185,7 @@ The tablet should have some data persisted on the disk. If you insert small amou
 
 ```sh
 ./bin/yb-ts-cli \
-    --server_address=127.0.0.1:9100,127.0.0.2:9100,127.0.0.3:9100 \
+    --server_address=127.0.0.1:9100 \
     flush_tablet 9991368c4b85456988303cd65a3c6503
 ```
 

--- a/docs/content/v2024.1/architecture/docdb-sharding/tablet-splitting.md
+++ b/docs/content/v2024.1/architecture/docdb-sharding/tablet-splitting.md
@@ -165,7 +165,9 @@ Note that misuse or overuse of manual tablet splitting (for example, splitting t
 To verify that the table `t` has only one tablet, list all the tablets for table `t` using the following [`yb-admin list_tablets`](../../../admin/yb-admin/#list-tablets) command:
 
 ```bash
-./bin/yb-admin --master_addresses 127.0.0.1:7100 list_tablets ysql.yugabyte t
+./bin/yb-admin \
+    --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+    list_tablets ysql.yugabyte t
 ```
 
 Expect the following output:
@@ -183,7 +185,7 @@ The tablet should have some data persisted on the disk. If you insert small amou
 
 ```sh
 ./bin/yb-ts-cli \
-    --server_address=127.0.0.1:9100,127.0.0.2:9100,127.0.0.3:9100 \
+    --server_address=127.0.0.1:9100 \
     flush_tablet 9991368c4b85456988303cd65a3c6503
 ```
 

--- a/docs/content/v2024.2/architecture/docdb-sharding/tablet-splitting.md
+++ b/docs/content/v2024.2/architecture/docdb-sharding/tablet-splitting.md
@@ -165,7 +165,9 @@ Note that misuse or overuse of manual tablet splitting (for example, splitting t
 To verify that the table `t` has only one tablet, list all the tablets for table `t` using the following [`yb-admin list_tablets`](../../../admin/yb-admin/#list-tablets) command:
 
 ```bash
-./bin/yb-admin --master_addresses 127.0.0.1:7100 list_tablets ysql.yugabyte t
+./bin/yb-admin \
+    --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+    list_tablets ysql.yugabyte t
 ```
 
 Expect the following output:
@@ -183,7 +185,7 @@ The tablet should have some data persisted on the disk. If you insert small amou
 
 ```sh
 ./bin/yb-ts-cli \
-    --server_address=127.0.0.1:9100,127.0.0.2:9100,127.0.0.3:9100 \
+    --server_address=127.0.0.1:9100 \
     flush_tablet 9991368c4b85456988303cd65a3c6503
 ```
 

--- a/docs/content/v2025.1/architecture/docdb-sharding/tablet-splitting.md
+++ b/docs/content/v2025.1/architecture/docdb-sharding/tablet-splitting.md
@@ -165,7 +165,9 @@ Note that misuse or overuse of manual tablet splitting (for example, splitting t
 To verify that the table `t` has only one tablet, list all the tablets for table `t` using the following [`yb-admin list_tablets`](../../../admin/yb-admin/#list-tablets) command:
 
 ```bash
-./bin/yb-admin --master_addresses 127.0.0.1:7100 list_tablets ysql.yugabyte t
+./bin/yb-admin \
+    --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+    list_tablets ysql.yugabyte t
 ```
 
 Expect the following output:
@@ -183,7 +185,7 @@ The tablet should have some data persisted on the disk. If you insert small amou
 
 ```sh
 ./bin/yb-ts-cli \
-    --server_address=127.0.0.1:9100,127.0.0.2:9100,127.0.0.3:9100 \
+    --server_address=127.0.0.1:9100 \
     flush_tablet 9991368c4b85456988303cd65a3c6503
 ```
 


### PR DESCRIPTION
Two commands in this [page](https://docs.yugabyte.com/stable/architecture/docdb-sharding/tablet-splitting/) seem to be incorrect. Based on the documentation, `--master_addresses` should receive a comma-separated list of YB master server addresses, and `--server_address` should only receive the address of the server this command should run against. This PR fixes those commands.