### PR TITLE
Update GUC for manual dump of catalog cache misses

### DIFF
--- a/docs/content/stable/best-practices-operations/ysql-catalog-cache-tuning-guide.md
+++ b/docs/content/stable/best-practices-operations/ysql-catalog-cache-tuning-guide.md
@@ -555,7 +555,7 @@ If the catalog reads can be traced to a specific query, set the following config
 
 ```sql
 SET yb_debug_log_catcache_events = 1;
-SET yb_debug_report_error_stacktrace = 1;
+SET backtrace_functions = 'SearchCatCacheMiss';
 SET client_min_messages = LOG;
 ```
 


### PR DESCRIPTION
The GUC mentioned in docs was retired in 2025.2 