### PR TITLE
Refactor: Replaced redundant HasDefaultTimeToLive function and fixed TTL = 0 logic (#30230)

### DIFF
--- a/java/yb-client/src/main/java/org/yb/client/ProtobufHelper.java
+++ b/java/yb-client/src/main/java/org/yb/client/ProtobufHelper.java
@@ -113,7 +113,7 @@ public class ProtobufHelper {
     List<ColumnSchema> columns = new ArrayList<>(schemaPB.getColumnsCount());
     List<Integer> columnIds = new ArrayList<>(schemaPB.getColumnsCount());
     long timeToLive = Schema.defaultTTL;
-    if (schemaPB.hasTableProperties() && schemaPB.getTableProperties().hasDefaultTimeToLive()) {
+    if (schemaPB.hasTableProperties() && schemaPB.getTableProperties().HasEffectiveDefaultTimeToLive()) {
       timeToLive = schemaPB.getTableProperties().getDefaultTimeToLive();
     }
     for (Common.ColumnSchemaPB columnPb : schemaPB.getColumnsList()) {

--- a/src/yb/common/schema-test.cc
+++ b/src/yb/common/schema-test.cc
@@ -292,10 +292,10 @@ TEST(TestSchema, TestSchemaBuilder) {
 
 TEST(TestSchema, TestTableProperties) {
   TableProperties properties;
-  ASSERT_FALSE(properties.HasDefaultTimeToLive());
+  ASSERT_FALSE(properties.HasEffectiveDefaultTimeToLive());
 
   properties.SetDefaultTimeToLive(1000);
-  ASSERT_TRUE(properties.HasDefaultTimeToLive());
+  ASSERT_TRUE(properties.HasEffectiveDefaultTimeToLive());
   ASSERT_EQ(1000, properties.DefaultTimeToLive());
 
   TableProperties properties1;
@@ -308,16 +308,16 @@ TEST(TestSchema, TestTableProperties) {
   ASSERT_EQ(1000, pb.default_time_to_live());
 
   auto properties2 = TableProperties::FromTablePropertiesPB(pb);
-  ASSERT_TRUE(properties2.HasDefaultTimeToLive());
+  ASSERT_TRUE(properties2.HasEffectiveDefaultTimeToLive());
   ASSERT_EQ(1000, properties2.DefaultTimeToLive());
 
   properties.Reset();
   pb.Clear();
-  ASSERT_FALSE(properties.HasDefaultTimeToLive());
+  ASSERT_FALSE(properties.HasEffectiveDefaultTimeToLive());
   properties.ToTablePropertiesPB(&pb);
   ASSERT_FALSE(pb.has_default_time_to_live());
   auto properties3 = TableProperties::FromTablePropertiesPB(pb);
-  ASSERT_FALSE(properties3.HasDefaultTimeToLive());
+  ASSERT_FALSE(properties3.HasEffectiveDefaultTimeToLive());
 }
 
 } // namespace tablet

--- a/src/yb/common/schema.cc
+++ b/src/yb/common/schema.cc
@@ -188,7 +188,7 @@ SortingType ColumnSchema::sorting_type() const {
 // ------------------------------------------------------------------------------------------------
 
 void TableProperties::ToTablePropertiesPB(TablePropertiesPB *pb) const {
-  if (HasDefaultTimeToLive()) {
+  if (HasEffectiveDefaultTimeToLive()) {
     pb->set_default_time_to_live(default_time_to_live_);
   }
   pb->set_contain_counters(contain_counters_);
@@ -283,17 +283,13 @@ void TableProperties::Reset() {
   ysql_replica_identity_ = std::nullopt;
 }
 
-bool TableProperties::IsValidTTL(int64_t ttl_msec) {
-  return ttl_msec >= 0;
-}
-
 bool TableProperties::IsEffectiveTTL(int64_t ttl_msec) {
-  return IsValidTTL(ttl_msec) && (ttl_msec > 0);
+  return ttl_msec > 0;
 }
 
 string TableProperties::ToString() const {
   std::string result("{ ");
-  if (HasDefaultTimeToLive()) {
+  if (HasEffectiveDefaultTimeToLive()) {
     result += Format("default_time_to_live: $0 ", default_time_to_live_);
   }
   result += Format("contain_counters: $0 is_transactional: $1 ",

--- a/src/yb/common/schema.h
+++ b/src/yb/common/schema.h
@@ -395,12 +395,6 @@ class TableProperties {
     return true;
   }
 
-  // Returns true if default TTL is configured with a valid value.
-  // The method could be redundant, refer to https://github.com/yugabyte/yugabyte-db/issues/30230.
-  bool HasDefaultTimeToLive() const {
-    return IsValidTTL(default_time_to_live_);
-  }
-
   // Return true if default TTL is configred with a valid and effective value.
   bool HasEffectiveDefaultTimeToLive() const {
     return IsEffectiveTTL(default_time_to_live_);

--- a/src/yb/docdb/cql_operation.cc
+++ b/src/yb/docdb/cql_operation.cc
@@ -882,7 +882,7 @@ Status QLWriteOperation::ApplyForSubscriptArgs(const QLColumnValueMsg& column_va
       break;
     }
     case DataType::LIST: {
-      MonoDelta default_ttl = doc_read_context_->schema().table_properties().HasDefaultTimeToLive()
+      MonoDelta default_ttl = doc_read_context_->schema().table_properties().HasEffectiveDefaultTimeToLive()
           ? MonoDelta::FromMilliseconds(
                 doc_read_context_->schema().table_properties().DefaultTimeToLive())
           : MonoDelta::kMax;
@@ -1287,7 +1287,7 @@ Status QLWriteOperation::DeleteSubscriptedColumnElement(
     }
     case DataType::LIST: {
       const MonoDelta default_ttl =
-          doc_read_context_->schema().table_properties().HasDefaultTimeToLive()
+          doc_read_context_->schema().table_properties().HasEffectiveDefaultTimeToLive()
               ? MonoDelta::FromMilliseconds(
                     doc_read_context_->schema().table_properties().DefaultTimeToLive())
               : MonoDelta::kMax;

--- a/src/yb/dockv/doc_ttl_util.cc
+++ b/src/yb/dockv/doc_ttl_util.cc
@@ -47,7 +47,7 @@ bool HasExpiredTTL(const HybridTime& expiration_time, const HybridTime& read_hyb
 const MonoDelta TableTTL(const Schema& schema) {
   // In this context, a ttl of kMaxTtl indicates that the table has no default TTL.
   MonoDelta ttl = ValueControlFields::kMaxTtl;
-  if (schema.table_properties().HasDefaultTimeToLive()) {
+  if (schema.table_properties().HasEffectiveDefaultTimeToLive()) {
     uint64_t default_ttl = schema.table_properties().DefaultTimeToLive();
     return default_ttl == kResetTTL
         ? ValueControlFields::kMaxTtl : MonoDelta::FromMilliseconds(default_ttl);


### PR DESCRIPTION
Changed HasDefaultTimeToLive to HasEffectiveDefaultTimeToLive which treats 0 as an invalid TTL to improve readability and consistency.