### PR TITLE
Reflect `webserver_port` override in status output

### DIFF
--- a/scripts/installation/bin/yb-ctl
+++ b/scripts/installation/bin/yb-ctl
@@ -703,6 +703,15 @@ class ClusterOptions:
                 parser_arg = None
             setattr(self, arg, self.parse_flag_args(parser_arg))
 
+        # Reflect webserver_port overrides from --master_flags / --tserver_flags
+        # so the status output shows the actual port the daemon will bind to.
+        for flag in self.master_flags:
+            if flag.startswith("webserver_port="):
+                self.base_ports[DAEMON_TYPE_MASTER]["http"] = int(flag.split("=", 1)[1])
+        for flag in self.tserver_flags:
+            if flag.startswith("webserver_port="):
+                self.base_ports[DAEMON_TYPE_TSERVER]["http"] = int(flag.split("=", 1)[1])
+
         try:
             self.placement_info_raw = getattr(args, "placement_info")
             placement_list = self.placement_info_raw.split(",")


### PR DESCRIPTION
Fixes https://github.com/yugabyte/yugabyte-db/issues/30258

How to verify this fix.

```bash
bin/yb-ctl create --rf 1 --master_flags "webserver_port=7001" --tserver_flags "webserver_port=9001"
Creating cluster.
Waiting for cluster to be ready.
----------------------------------------------------------------------------------------------------
| Node Count: 1 | Replication Factor: 1                                                            |
----------------------------------------------------------------------------------------------------
| JDBC                : jdbc:postgresql://127.0.0.1:5433/yugabyte                                  |
| YSQL Shell          : bin/ysqlsh                                                                 |
| YCQL Shell          : bin/ycqlsh                                                                 |
| YEDIS Shell         : bin/redis-cli                                                              |
| Web UI              : http://127.0.0.1:7001/                                                     |
| Cluster Data        : /Users/keisukeumegaki/yugabyte-data                                        |
----------------------------------------------------------------------------------------------------
```