### PR TITLE
DocDB: Log when master marks a tserver as UNRESPONSIVE

### DIFF
--- a/src/yb/master/ts_descriptor.cc
+++ b/src/yb/master/ts_descriptor.cc
@@ -508,6 +508,13 @@ std::optional<TSDescriptor::WriteLock> TSDescriptor::MaybeUpdateLiveness(MonoTim
       time.GetDeltaSince(last_heartbeat_).ToMilliseconds() >
           GetAtomicFlag(&FLAGS_tserver_unresponsive_timeout_ms)) {
     proto_lock.mutable_data()->pb.set_state(SysTabletServerEntryPB::UNRESPONSIVE);
+    const auto& addr = DesiredHostPort(proto_lock->pb.registration(), local_master_cloud_info_);
+    LOG(WARNING) << "Marking tserver " << permanent_uuid()
+                 << " (" << addr.host() << ":" << addr.port() << ")"
+                 << " as UNRESPONSIVE: no heartbeat received for "
+                 << time.GetDeltaSince(last_heartbeat_).ToMilliseconds() << "ms"
+                 << " (threshold: " << GetAtomicFlag(&FLAGS_tserver_unresponsive_timeout_ms)
+                 << "ms)";
     return std::move(proto_lock);
   }
   return std::nullopt;


### PR DESCRIPTION
Fixes https://github.com/yugabyte/yugabyte-db/issues/30048

Test steps:

1. Create a cluster in my local - `bin/yb-ctl create --rf 3 --master_flags "tserver_unresponsive_timeout_ms=5000"`
2. Stop a tserver-3 - `bin/yb-ctl stop_node 3`
3. Confirmed the following log and `DEAD` on UI.

```bash
/Users/keisukeumegaki/yugabyte-data/node-2/disk-1/yb-data/master/logs/yb-master.WARNING:W0210 16:41:07.384261 1826353152 ts_descriptor.cc:527] Marking tserver 78bbc219918d48e8891162efd6953419 (127.0.0.3:9100) as UNRESPONSIVE: no heartbeat received for 5835ms (threshold: 5000ms)
```

<img width="1897" height="676" alt="Screenshot 2026-02-10 at 17 47 33" src="https://github.com/user-attachments/assets/1c523081-417a-422e-b322-fe1ebf077513" />