### PR TITLE
[DOC-1183] Added restart needed badge on all-flags page

### DIFF
--- a/docs/layouts/_shortcodes/all-flags-list.html
+++ b/docs/layouts/_shortcodes/all-flags-list.html
@@ -47,7 +47,12 @@
 <!-- XML to table -->
 
 {{ range $data.flag}}
+{{ $tagsStr := default "" .tags }}
+{{ $isRuntime := findRE "runtime" $tagsStr }}
+{{ $needsRestart := not $isRuntime }}
 #### {{.name}}
-{{.meaning}} (**_Default_: {{ default "None" (or .default .target)}}**{{if .tags}} - _{{replaceRE "," ", " .tags}}_{{end}})
+{{ if $needsRestart }}<span class="tag feature restart-needed">Restart Needed <span class="popup-details">Changes to this flag require a restart</span></span>
+
+{{ end }}{{.meaning}} (**_Default_: {{ default "None" (or .default .target)}}**{{if .tags}} - _{{replaceRE "," ", " .tags}}_{{end}})
 
 {{ end }}


### PR DESCRIPTION
@netlify /stable/reference/configuration/all-flags-yb-tserver/

Summary:
- The `all-flags-list.html` shortcode is shared by both All YB-TServer flags and All YB-Master flags (they only differ by process="tserver" vs process="master"), so both pages get the badge.
- The badge is driven by the tags in the flags XML from the build: if runtime is present, no badge; if it’s absent (or tags are empty), the “Restart Needed” badge is shown.
- Styling matches the existing “Restart Needed” tag (same classes and popup text).

To verify, check the [deploy preview](https://deploy-preview-30281--infallible-bardeen-164bc9.netlify.app/stable/reference/configuration/all-flags-yb-tserver/) for flags that are not tagged as runtime in the XML should show the “Restart Needed” badge.