### PR TITLE
Fix an overflow in is_staleness_acceptable

### DIFF
--- a/src/postgres/src/backend/commands/variable.c
+++ b/src/postgres/src/backend/commands/variable.c
@@ -625,7 +625,7 @@ is_staleness_acceptable(int32_t staleness_ms)
 	int32_t		max_clock_skew_usec = YBGetMaxClockSkewUsec();
 	const int	kMargin = 2;
 
-	if (staleness_ms * 1000 < kMargin * max_clock_skew_usec)
+	if ((int64_t) staleness_ms * 1000 < (int64_t) kMargin * max_clock_skew_usec)
 	{
 		GUC_check_errcode(ERRCODE_FEATURE_NOT_SUPPORTED);
 		GUC_check_errmsg("cannot enable yb_read_from_followers with a staleness of less than "

--- a/src/yb/yql/pgwrapper/pg_mini-test.cc
+++ b/src/yb/yql/pgwrapper/pg_mini-test.cc
@@ -281,6 +281,8 @@ TEST_F(PgMiniTest, FollowerReads) {
     ASSERT_NOK(conn.Execute(Format("SET yb_follower_read_staleness_ms = $0", 999)));
     // Setting a value > 2 * max_clock_skew should work.
     ASSERT_OK(conn.Execute(Format("SET yb_follower_read_staleness_ms = $0", 1001)));
+    // Setting a large value (INT_MAX) should not overflow.
+    ASSERT_OK(conn.Execute(Format("SET yb_follower_read_staleness_ms = $0", INT_MAX)));
 
     ASSERT_OK(conn.ExecuteFormat("SET yb_read_from_followers = false"));
     if (expect_old_behavior_before_20482) {


### PR DESCRIPTION
DO NOT MERGE!! [CSI](<https://csiweb.dev.yugabyte.com/pull/30286/>) ❌. Once CSI passes, comment `trigger jenkins` to clear this warning.

Resolves https://github.com/yugabyte/yugabyte-db/issues/15011.

Right now, the maximum value for `yb_follower_read_staleness_ms` is set to `INT_MAX` ([source](https://github.com/yugabyte/yugabyte-db/blob/ed0ea8a65669af2df36fba7b8925ef1f20b7e543/src/postgres/src/backend/utils/misc/guc.c#L5527)), and the current code overflows when it gets multiplied by 1000 in `is_staleness_acceptable`. This PR fixes this problem by casting it into `int64_t` while doing the comparison.