### PR TITLE
Clarify licensing boundaries between YugabyteDB and YugabyteDB Anywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,7 @@ managed/src/main/java/com/yugabyte/yw/common/operator/io/*
 
 # jenv local version
 **/.java-version
+
+# AI assistant configuration (local only)
+CLAUDE.md
+.claude/

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,8 +1,44 @@
 ## YugabyteDB Licensing
-Source code in this repository is variously licensed under the [Apache License 2.0](licenses/APACHE-LICENSE-2.0.txt) and the [Polyform Free Trial License 1.0.0](licenses/POLYFORM-FREE-TRIAL-LICENSE-1.0.0.txt). A copy of each license can be found in the [licenses](licenses) directory.
 
-The build produces two sets of binaries:
+Source code in this repository is licensed under two different licenses depending on the component:
 
-(1) YugabyteDB, available [here](https://download.yugabyte.com/local#linux) and licensed under Apache License 2.0
+### Apache License 2.0
 
-(2) YugabyteDB Anywhere (Self-Managed), available [here](https://docs.yugabyte.com/preview/yugabyte-platform/install-yugabyte-platform/install-software/installer/) and licensed under Polyform Free Trial License 1.0.0. 
+The following components are licensed under the [Apache License 2.0](licenses/APACHE-LICENSE-2.0.txt):
+
+- **YugabyteDB Core Database** - The distributed SQL database engine
+  - `src/yb/` - Core C++ storage engine (DocDB, consensus, tablets, servers)
+  - `src/postgres/` - Modified PostgreSQL fork for YSQL compatibility
+  - `src/odyssey/` - Connection pooling (note: has its own BSD-style license)
+  - `java/` - Java client libraries
+  - `python/` - Python build and test utilities
+  - `build-support/` - Build scripts and tooling
+  - `bin/` - Command-line utilities
+  - `cmake_modules/` - CMake build configuration
+
+### Polyform Free Trial License 1.0.0
+
+The following components are licensed under the [Polyform Free Trial License 1.0.0](licenses/POLYFORM-FREE-TRIAL-LICENSE-1.0.0.txt):
+
+- **YugabyteDB Anywhere (YBA)** - The management and orchestration platform
+  - `managed/` - YBA backend (Scala/Java), UI (React), CLI, installers, and DevOps tooling
+  - `troubleshoot/` - Troubleshooting framework
+
+The Polyform Free Trial License permits evaluation use for up to 32 consecutive calendar days. For production use of YugabyteDB Anywhere, a commercial license is required. Contact [Yugabyte Sales](https://www.yugabyte.com/contact/) for licensing options.
+
+### Build Artifacts
+
+The build produces two sets of binaries corresponding to the above licenses:
+
+1. **YugabyteDB** - Available at [download.yugabyte.com](https://download.yugabyte.com/local#linux), licensed under Apache License 2.0
+
+2. **YugabyteDB Anywhere** - Available via [installer](https://docs.yugabyte.com/preview/yugabyte-platform/install-yugabyte-platform/install-software/installer/), licensed under Polyform Free Trial License 1.0.0
+
+### Third-Party Licenses
+
+Individual subdirectories may contain third-party code with their own licenses. These are documented in LICENSE files within those directories.
+
+### License Files
+
+- [Apache License 2.0](licenses/APACHE-LICENSE-2.0.txt)
+- [Polyform Free Trial License 1.0.0](licenses/POLYFORM-FREE-TRIAL-LICENSE-1.0.0.txt)

--- a/README.md
+++ b/README.md
@@ -177,14 +177,12 @@ As an open-source project with a strong focus on the user community, we welcome 
 
 # License
 
-Source code in this repository is variously licensed under the Apache License 2.0 and the Polyform Free Trial License 1.0.0. A copy of each license can be found in the [licenses](licenses) directory.
+This repository contains two differently licensed components. See [LICENSE.md](LICENSE.md) for detailed directory mappings.
 
-The build produces two sets of binaries:
+* **YugabyteDB** (core database in `src/`, `java/`, etc.) - [Apache License 2.0](licenses/APACHE-LICENSE-2.0.txt)
+* **YugabyteDB Anywhere** (management platform in `managed/`) - [Polyform Free Trial License 1.0.0](licenses/POLYFORM-FREE-TRIAL-LICENSE-1.0.0.txt)
 
-* The entire database with all its features (including the enterprise ones) is licensed under the Apache License 2.0
-* The binaries that contain `-managed` in the artifact and help run a managed service are licensed under the Polyform Free Trial License 1.0.0.
-
-> By default, the build options generate only the Apache License 2.0 binaries.
+> By default, the build generates only the Apache 2.0 licensed database binaries.
 
 # Read More
 


### PR DESCRIPTION
## Context

During recent discussions with customers about source code escrow, we identified that our licensing documentation was unclear about which parts of the repository fall under which license. This made it difficult to clearly communicate our licensing model.

**Important:** This change does not alter how any code is licensed. It only clarifies the existing licensing structure by explicitly mapping directories to their respective licenses.

## Summary

- Clarify which source code directories fall under which license
- Apache 2.0: core database (`src/`, `java/`, etc.)
- Polyform Free Trial: YugabyteDB Anywhere (`managed/`, `troubleshoot/`)

## Changes

- **LICENSE.md**: Expanded with explicit directory-to-license mappings
- **README.md**: Simplified license section, references LICENSE.md for details