### PR TITLE
[docs] Update CDC connector docs with poll interval changes and deployment warning

### DIFF
--- a/docs/content/stable/additional-features/change-data-capture/using-logical-replication/yugabytedb-connector.md
+++ b/docs/content/stable/additional-features/change-data-capture/using-logical-replication/yugabytedb-connector.md
@@ -1424,11 +1424,11 @@ To deploy the connector, you install the connector archive, configure the connec
 
 {{< note title="Note" >}}
 
-Using connector version dz.2.5.2.yb.2025.2, you may get the following error while deploying the connector:
+Using connector version `dz.2.5.2.yb.2025.2`, you may get the following error while deploying the connector:
 
 `ERROR: cannot export or import snapshot when ysql_enable_pg_export_snapshot is disabled.`
 
-Use connector version dz.2.5.2.yb.2025.2.2, or dz.2.5.2.yb.2025.1.2 and earlier versions instead.
+Use connector version `dz.2.5.2.yb.2025.2.2`, or `dz.2.5.2.yb.2025.1.2` and earlier versions instead.
 
 {{< /note >}}
 

--- a/docs/content/stable/additional-features/change-data-capture/using-yugabytedb-grpc-replication/debezium-connector-yugabytedb.md
+++ b/docs/content/stable/additional-features/change-data-capture/using-yugabytedb-grpc-replication/debezium-connector-yugabytedb.md
@@ -1088,9 +1088,9 @@ Advanced connector configuration properties:
 | :------- | :------ | :---------- |
 | snapshot.mode | N/A | `never` - Don't take a snapshot <br/> `initial` - Take a snapshot when the connector is first started <br/> `initial_only` - Only take a snapshot of the table, do not stream further changes |
 | snapshot.include.collection.list | All tables specified in `table.include.list` | An optional, comma-separated list of regular expressions that match the fully-qualified names (`<schemaName>.<tableName>`) of the tables to include in a snapshot. The specified items must also be named in the connector's `table.include.list` property. This property takes effect only if the connector's `snapshot.mode` property is set to a value other than `never`. |
-| cdc.poll.interval.ms | 500 | The interval at which the connector will poll the database for the changes. <br/><br/> **Note:** This flag is only valid for dz.1.9.5.yb.grpc.2025.1 and earlier. For dz.1.9.5.yb.grpc.2025.2 and later, use `cdc.poll.interval.active.ms` and `cdc.poll.interval.idle.ms`. |
-| cdc.poll.interval.active.ms | 10 | Poll interval when actively receiving data. <br/><br/> **Note:** This flag is only available in dz.1.9.5.yb.grpc.2025.2 and later. |
-| cdc.poll.interval.idle.ms | 500 | Poll interval when no data is being received. <br/><br/> **Note:** This flag is only available in dz.1.9.5.yb.grpc.2025.2 and later. |
+| cdc.poll.interval.ms | 500 | The interval at which the connector will poll the database for the changes. <br/><br/> **Note:** This flag is only valid for `dz.1.9.5.yb.grpc.2025.1` and earlier. For `dz.1.9.5.yb.grpc.2025.2` and later, use `cdc.poll.interval.active.ms` and `cdc.poll.interval.idle.ms`. |
+| cdc.poll.interval.active.ms | 10 | Poll interval when actively receiving data. <br/><br/> **Note:** This flag is only available in `dz.1.9.5.yb.grpc.2025.2` and later. |
+| cdc.poll.interval.idle.ms | 500 | Poll interval when no data is being received. <br/><br/> **Note:** This flag is only available in `dz.1.9.5.yb.grpc.2025.2` and later. |
 | admin.operation.timeout.ms | 60000 | The default timeout used for administrative operations (such as createTable, deleteTable, getTables, etc). |
 | operation.timeout.ms | 60000 | The default timeout used for user operations (using sessions and scanners). |
 | socket.read.timeout.ms | 60000 | The default timeout to use when waiting on data from a socket. |

--- a/docs/content/v2.20/additional-features/change-data-capture/debezium-connector-yugabytedb.md
+++ b/docs/content/v2.20/additional-features/change-data-capture/debezium-connector-yugabytedb.md
@@ -1049,9 +1049,9 @@ Advanced connector configuration properties:
 | :------- | :------ | :---------- |
 | snapshot.mode | N/A | `never` - Don't take a snapshot <br/> `initial` - Take a snapshot when the connector is first started <br/> `initial_only` - Only take a snapshot of the table, do not stream further changes |
 | snapshot.include.collection.list | All tables specified in `table.include.list` | An optional, comma-separated list of regular expressions that match the fully-qualified names (`<schemaName>.<tableName>`) of the tables to include in a snapshot. The specified items must also be named in the connector's `table.include.list` property. This property takes effect only if the connector's `snapshot.mode` property is set to a value other than `never`. |
-| cdc.poll.interval.ms | 500 | The interval at which the connector will poll the database for the changes. <br/><br/> **Note:** This flag is only valid for dz.1.9.5.yb.grpc.2025.1 and earlier. For dz.1.9.5.yb.grpc.2025.2 and later, use `cdc.poll.interval.active.ms` and `cdc.poll.interval.idle.ms`. |
-| cdc.poll.interval.active.ms | 10 | Poll interval when actively receiving data. <br/><br/> **Note:** This flag is only available in dz.1.9.5.yb.grpc.2025.2 and later. |
-| cdc.poll.interval.idle.ms | 500 | Poll interval when no data is being received. <br/><br/> **Note:** This flag is only available in dz.1.9.5.yb.grpc.2025.2 and later. |
+| cdc.poll.interval.ms | 500 | The interval at which the connector will poll the database for the changes. <br/><br/> **Note:** This flag is only valid for `dz.1.9.5.yb.grpc.2025.1` and earlier. For `dz.1.9.5.yb.grpc.2025.2` and later, use `cdc.poll.interval.active.ms` and `cdc.poll.interval.idle.ms`. |
+| cdc.poll.interval.active.ms | 10 | Poll interval when actively receiving data. <br/><br/> **Note:** This flag is only available in `dz.1.9.5.yb.grpc.2025.2` and later. |
+| cdc.poll.interval.idle.ms | 500 | Poll interval when no data is being received. <br/><br/> **Note:** This flag is only available in `dz.1.9.5.yb.grpc.2025.2` and later. |
 | admin.operation.timeout.ms | 60000 | The default timeout used for administrative operations (such as createTable, deleteTable, getTables, etc). |
 | operation.timeout.ms | 60000 | The default timeout used for user operations (using sessions and scanners). |
 | socket.read.timeout.ms | 60000 | The default timeout to use when waiting on data from a socket. |

--- a/docs/content/v2.25/additional-features/change-data-capture/using-logical-replication/yugabytedb-connector.md
+++ b/docs/content/v2.25/additional-features/change-data-capture/using-logical-replication/yugabytedb-connector.md
@@ -1422,11 +1422,11 @@ To deploy the connector, you install the connector archive, configure the connec
 
 {{< note title="Note" >}}
 
-Using connector version dz.2.5.2.yb.2025.2, you may get the following error while deploying the connector:
+Using connector version `dz.2.5.2.yb.2025.2`, you may get the following error while deploying the connector:
 
 `ERROR: cannot export or import snapshot when ysql_enable_pg_export_snapshot is disabled.`
 
-Use connector version dz.2.5.2.yb.2025.2.2, or dz.2.5.2.yb.2025.1.2 and earlier versions instead.
+Use connector version `dz.2.5.2.yb.2025.2.2`, or `dz.2.5.2.yb.2025.1.2` and earlier versions instead.
 
 {{< /note >}}
 

--- a/docs/content/v2.25/additional-features/change-data-capture/using-yugabytedb-grpc-replication/debezium-connector-yugabytedb.md
+++ b/docs/content/v2.25/additional-features/change-data-capture/using-yugabytedb-grpc-replication/debezium-connector-yugabytedb.md
@@ -1079,9 +1079,9 @@ Advanced connector configuration properties:
 | :------- | :------ | :---------- |
 | snapshot.mode | N/A | `never` - Don't take a snapshot <br/> `initial` - Take a snapshot when the connector is first started <br/> `initial_only` - Only take a snapshot of the table, do not stream further changes |
 | snapshot.include.collection.list | All tables specified in `table.include.list` | An optional, comma-separated list of regular expressions that match the fully-qualified names (`<schemaName>.<tableName>`) of the tables to include in a snapshot. The specified items must also be named in the connector's `table.include.list` property. This property takes effect only if the connector's `snapshot.mode` property is set to a value other than `never`. |
-| cdc.poll.interval.ms | 500 | The interval at which the connector will poll the database for the changes. <br/><br/> **Note:** This flag is only valid for dz.1.9.5.yb.grpc.2025.1 and earlier. For dz.1.9.5.yb.grpc.2025.2 and later, use `cdc.poll.interval.active.ms` and `cdc.poll.interval.idle.ms`. |
-| cdc.poll.interval.active.ms | 10 | Poll interval when actively receiving data. <br/><br/> **Note:** This flag is only available in dz.1.9.5.yb.grpc.2025.2 and later. |
-| cdc.poll.interval.idle.ms | 500 | Poll interval when no data is being received. <br/><br/> **Note:** This flag is only available in dz.1.9.5.yb.grpc.2025.2 and later. |
+| cdc.poll.interval.ms | 500 | The interval at which the connector will poll the database for the changes. <br/><br/> **Note:** This flag is only valid for `dz.1.9.5.yb.grpc.2025.1` and earlier. For `dz.1.9.5.yb.grpc.2025.2` and later, use `cdc.poll.interval.active.ms` and `cdc.poll.interval.idle.ms`. |
+| cdc.poll.interval.active.ms | 10 | Poll interval when actively receiving data. <br/><br/> **Note:** This flag is only available in `dz.1.9.5.yb.grpc.2025.2` and later. |
+| cdc.poll.interval.idle.ms | 500 | Poll interval when no data is being received. <br/><br/> **Note:** This flag is only available in `dz.1.9.5.yb.grpc.2025.2` and later. |
 | admin.operation.timeout.ms | 60000 | The default timeout used for administrative operations (such as createTable, deleteTable, getTables, etc). |
 | operation.timeout.ms | 60000 | The default timeout used for user operations (using sessions and scanners). |
 | socket.read.timeout.ms | 60000 | The default timeout to use when waiting on data from a socket. |

--- a/docs/content/v2024.1/additional-features/change-data-capture/using-logical-replication/yugabytedb-connector.md
+++ b/docs/content/v2024.1/additional-features/change-data-capture/using-logical-replication/yugabytedb-connector.md
@@ -1414,11 +1414,11 @@ To deploy the connector, you install the connector archive, configure the connec
 
 {{< note title="Note" >}}
 
-Using connector version dz.2.5.2.yb.2025.2, you may get the following error while deploying the connector:
+Using connector version `dz.2.5.2.yb.2025.2`, you may get the following error while deploying the connector:
 
 `ERROR: cannot export or import snapshot when ysql_enable_pg_export_snapshot is disabled.`
 
-Use connector version dz.2.5.2.yb.2025.2.2, or dz.2.5.2.yb.2025.1.2 and earlier versions instead.
+Use connector version `dz.2.5.2.yb.2025.2.2`, or `dz.2.5.2.yb.2025.1.2` and earlier versions instead.
 
 {{< /note >}}
 

--- a/docs/content/v2024.1/additional-features/change-data-capture/using-yugabytedb-grpc-replication/debezium-connector-yugabytedb.md
+++ b/docs/content/v2024.1/additional-features/change-data-capture/using-yugabytedb-grpc-replication/debezium-connector-yugabytedb.md
@@ -1084,9 +1084,9 @@ Advanced connector configuration properties:
 | :------- | :------ | :---------- |
 | snapshot.mode | N/A | `never` - Don't take a snapshot <br/> `initial` - Take a snapshot when the connector is first started <br/> `initial_only` - Only take a snapshot of the table, do not stream further changes |
 | snapshot.include.collection.list | All tables specified in `table.include.list` | An optional, comma-separated list of regular expressions that match the fully-qualified names (`<schemaName>.<tableName>`) of the tables to include in a snapshot. The specified items must also be named in the connector's `table.include.list` property. This property takes effect only if the connector's `snapshot.mode` property is set to a value other than `never`. |
-| cdc.poll.interval.ms | 500 | The interval at which the connector will poll the database for the changes. <br/><br/> **Note:** This flag is only valid for dz.1.9.5.yb.grpc.2025.1 and earlier. For dz.1.9.5.yb.grpc.2025.2 and later, use `cdc.poll.interval.active.ms` and `cdc.poll.interval.idle.ms`. |
-| cdc.poll.interval.active.ms | 10 | Poll interval when actively receiving data. <br/><br/> **Note:** This flag is only available in dz.1.9.5.yb.grpc.2025.2 and later. |
-| cdc.poll.interval.idle.ms | 500 | Poll interval when no data is being received. <br/><br/> **Note:** This flag is only available in dz.1.9.5.yb.grpc.2025.2 and later. |
+| cdc.poll.interval.ms | 500 | The interval at which the connector will poll the database for the changes. <br/><br/> **Note:** This flag is only valid for `dz.1.9.5.yb.grpc.2025.1` and earlier. For `dz.1.9.5.yb.grpc.2025.2` and later, use `cdc.poll.interval.active.ms` and `cdc.poll.interval.idle.ms`. |
+| cdc.poll.interval.active.ms | 10 | Poll interval when actively receiving data. <br/><br/> **Note:** This flag is only available in `dz.1.9.5.yb.grpc.2025.2` and later. |
+| cdc.poll.interval.idle.ms | 500 | Poll interval when no data is being received. <br/><br/> **Note:** This flag is only available in `dz.1.9.5.yb.grpc.2025.2` and later. |
 | admin.operation.timeout.ms | 60000 | The default timeout used for administrative operations (such as createTable, deleteTable, getTables, etc). |
 | operation.timeout.ms | 60000 | The default timeout used for user operations (using sessions and scanners). |
 | socket.read.timeout.ms | 60000 | The default timeout to use when waiting on data from a socket. |

--- a/docs/content/v2024.2/additional-features/change-data-capture/using-logical-replication/yugabytedb-connector.md
+++ b/docs/content/v2024.2/additional-features/change-data-capture/using-logical-replication/yugabytedb-connector.md
@@ -1420,11 +1420,11 @@ To deploy the connector, you install the connector archive, configure the connec
 
 {{< note title="Note" >}}
 
-Using connector version dz.2.5.2.yb.2025.2, you may get the following error while deploying the connector:
+Using connector version `dz.2.5.2.yb.2025.2`, you may get the following error while deploying the connector:
 
 `ERROR: cannot export or import snapshot when ysql_enable_pg_export_snapshot is disabled.`
 
-Use connector version dz.2.5.2.yb.2025.2.2, or dz.2.5.2.yb.2025.1.2 and earlier versions instead.
+Use connector version `dz.2.5.2.yb.2025.2.2`, or `dz.2.5.2.yb.2025.1.2` and earlier versions instead.
 
 {{< /note >}}
 

--- a/docs/content/v2024.2/additional-features/change-data-capture/using-yugabytedb-grpc-replication/debezium-connector-yugabytedb.md
+++ b/docs/content/v2024.2/additional-features/change-data-capture/using-yugabytedb-grpc-replication/debezium-connector-yugabytedb.md
@@ -1079,9 +1079,9 @@ Advanced connector configuration properties:
 | :------- | :------ | :---------- |
 | snapshot.mode | N/A | `never` - Don't take a snapshot <br/> `initial` - Take a snapshot when the connector is first started <br/> `initial_only` - Only take a snapshot of the table, do not stream further changes |
 | snapshot.include.collection.list | All tables specified in `table.include.list` | An optional, comma-separated list of regular expressions that match the fully-qualified names (`<schemaName>.<tableName>`) of the tables to include in a snapshot. The specified items must also be named in the connector's `table.include.list` property. This property takes effect only if the connector's `snapshot.mode` property is set to a value other than `never`. |
-| cdc.poll.interval.ms | 500 | The interval at which the connector will poll the database for the changes. <br/><br/> **Note:** This flag is only valid for dz.1.9.5.yb.grpc.2025.1 and earlier. For dz.1.9.5.yb.grpc.2025.2 and later, use `cdc.poll.interval.active.ms` and `cdc.poll.interval.idle.ms`. |
-| cdc.poll.interval.active.ms | 10 | Poll interval when actively receiving data. <br/><br/> **Note:** This flag is only available in dz.1.9.5.yb.grpc.2025.2 and later. |
-| cdc.poll.interval.idle.ms | 500 | Poll interval when no data is being received. <br/><br/> **Note:** This flag is only available in dz.1.9.5.yb.grpc.2025.2 and later. |
+| cdc.poll.interval.ms | 500 | The interval at which the connector will poll the database for the changes. <br/><br/> **Note:** This flag is only valid for `dz.1.9.5.yb.grpc.2025.1` and earlier. For `dz.1.9.5.yb.grpc.2025.2` and later, use `cdc.poll.interval.active.ms` and `cdc.poll.interval.idle.ms`. |
+| cdc.poll.interval.active.ms | 10 | Poll interval when actively receiving data. <br/><br/> **Note:** This flag is only available in `dz.1.9.5.yb.grpc.2025.2` and later. |
+| cdc.poll.interval.idle.ms | 500 | Poll interval when no data is being received. <br/><br/> **Note:** This flag is only available in `dz.1.9.5.yb.grpc.2025.2` and later. |
 | admin.operation.timeout.ms | 60000 | The default timeout used for administrative operations (such as createTable, deleteTable, getTables, etc). |
 | operation.timeout.ms | 60000 | The default timeout used for user operations (using sessions and scanners). |
 | socket.read.timeout.ms | 60000 | The default timeout to use when waiting on data from a socket. |

--- a/docs/content/v2025.1/additional-features/change-data-capture/using-logical-replication/yugabytedb-connector.md
+++ b/docs/content/v2025.1/additional-features/change-data-capture/using-logical-replication/yugabytedb-connector.md
@@ -1422,11 +1422,11 @@ To deploy the connector, you install the connector archive, configure the connec
 
 {{< note title="Note" >}}
 
-Using connector version dz.2.5.2.yb.2025.2, you may get the following error while deploying the connector:
+Using connector version `dz.2.5.2.yb.2025.2`, you may get the following error while deploying the connector:
 
 `ERROR: cannot export or import snapshot when ysql_enable_pg_export_snapshot is disabled.`
 
-Use connector version dz.2.5.2.yb.2025.2.2, or dz.2.5.2.yb.2025.1.2 and earlier versions instead.
+Use connector version `dz.2.5.2.yb.2025.2.2`, or `dz.2.5.2.yb.2025.1.2` and earlier versions instead.
 
 {{< /note >}}
 

--- a/docs/content/v2025.1/additional-features/change-data-capture/using-yugabytedb-grpc-replication/debezium-connector-yugabytedb.md
+++ b/docs/content/v2025.1/additional-features/change-data-capture/using-yugabytedb-grpc-replication/debezium-connector-yugabytedb.md
@@ -1081,9 +1081,9 @@ Advanced connector configuration properties:
 | :------- | :------ | :---------- |
 | snapshot.mode | N/A | `never` - Don't take a snapshot <br/> `initial` - Take a snapshot when the connector is first started <br/> `initial_only` - Only take a snapshot of the table, do not stream further changes |
 | snapshot.include.collection.list | All tables specified in `table.include.list` | An optional, comma-separated list of regular expressions that match the fully-qualified names (`<schemaName>.<tableName>`) of the tables to include in a snapshot. The specified items must also be named in the connector's `table.include.list` property. This property takes effect only if the connector's `snapshot.mode` property is set to a value other than `never`. |
-| cdc.poll.interval.ms | 500 | The interval at which the connector will poll the database for the changes. <br/><br/> **Note:** This flag is only valid for dz.1.9.5.yb.grpc.2025.1 and earlier. For dz.1.9.5.yb.grpc.2025.2 and later, use `cdc.poll.interval.active.ms` and `cdc.poll.interval.idle.ms`. |
-| cdc.poll.interval.active.ms | 10 | Poll interval when actively receiving data. <br/><br/> **Note:** This flag is only available in dz.1.9.5.yb.grpc.2025.2 and later. |
-| cdc.poll.interval.idle.ms | 500 | Poll interval when no data is being received. <br/><br/> **Note:** This flag is only available in dz.1.9.5.yb.grpc.2025.2 and later. |
+| cdc.poll.interval.ms | 500 | The interval at which the connector will poll the database for the changes. <br/><br/> **Note:** This flag is only valid for `dz.1.9.5.yb.grpc.2025.1` and earlier. For `dz.1.9.5.yb.grpc.2025.2` and later, use `cdc.poll.interval.active.ms` and `cdc.poll.interval.idle.ms`. |
+| cdc.poll.interval.active.ms | 10 | Poll interval when actively receiving data. <br/><br/> **Note:** This flag is only available in `dz.1.9.5.yb.grpc.2025.2` and later. |
+| cdc.poll.interval.idle.ms | 500 | Poll interval when no data is being received. <br/><br/> **Note:** This flag is only available in `dz.1.9.5.yb.grpc.2025.2` and later. |
 | admin.operation.timeout.ms | 60000 | The default timeout used for administrative operations (such as createTable, deleteTable, getTables, etc). |
 | operation.timeout.ms | 60000 | The default timeout used for user operations (using sessions and scanners). |
 | socket.read.timeout.ms | 60000 | The default timeout to use when waiting on data from a socket. |


### PR DESCRIPTION

This PR does the following:

- Updated the `cdc.poll.interval.ms` flag description across all gRPC connector docs to note
  that it is only valid up to vdz.1.9.5.yb.grpc.2025.1 and below connector versions, and that
  vdz.1.9.5.yb.grpc.2025.2 and above should use the new `cdc.poll.interval.active.ms` and
  `cdc.poll.interval.idle.ms` flags instead.
- Added the two new flags (`cdc.poll.interval.active.ms` with default 10, and `cdc.poll.interval.idle.ms` with
  default 500) to the connector properties table of gRPC Connector in all versioned docs.
- Added a deployment warning to all YB connector docs (logical replication) about connector version
  dz.2.5.2.yb.2025.2 causing `ERROR: cannot export or import snapshot when ysql_enable_pg_export_snapshot is
  disabled`, recommending users to use dz.2.5.2.yb.2025.2.2 or dz.2.5.2.yb.2025.1.2 and below versions instead.

