### PR TITLE
Reuse safe time during consistent prefix reads

### DIFF
--- a/src/yb/master/master_tablet_service.cc
+++ b/src/yb/master/master_tablet_service.cc
@@ -58,7 +58,7 @@ MasterTabletServiceImpl::MasterTabletServiceImpl(MasterTabletServer* server, Mas
 Result<std::shared_ptr<tablet::AbstractTablet>> MasterTabletServiceImpl::GetTabletForRead(
   TabletIdView tablet_id, tablet::TabletPeerPtr tablet_peer,
   YBConsistencyLevel consistency_level, tserver::AllowSplitTablet allow_split_tablet,
-  tserver::ReadResponseMsg* resp) {
+  tserver::ReadResponseMsg* resp, HybridTime* follower_safe_time) {
   // Ignore looked_up_tablet_peer.
 
   SCOPED_LEADER_SHARED_LOCK(l, master_->catalog_manager_impl());

--- a/src/yb/master/master_tablet_service.h
+++ b/src/yb/master/master_tablet_service.h
@@ -73,7 +73,7 @@ class MasterTabletServiceImpl : public tserver::TabletServiceImpl {
   Result<std::shared_ptr<tablet::AbstractTablet>> GetTabletForRead(
     TabletIdView tablet_id, tablet::TabletPeerPtr tablet_peer,
     YBConsistencyLevel consistency_level, tserver::AllowSplitTablet allow_split_tablet,
-    tserver::ReadResponseMsg* resp) override;
+    tserver::ReadResponseMsg* resp, HybridTime* follower_safe_time = nullptr) override;
 
   Master *const master_;
   DISALLOW_COPY_AND_ASSIGN(MasterTabletServiceImpl);

--- a/src/yb/tserver/read_query.h
+++ b/src/yb/tserver/read_query.h
@@ -40,7 +40,7 @@ class ReadTabletProvider {
   virtual Result<std::shared_ptr<tablet::AbstractTablet>> GetTabletForRead(
       TabletIdView tablet_id, tablet::TabletPeerPtr tablet_peer,
       YBConsistencyLevel consistency_level, AllowSplitTablet allow_split_tablet,
-      ReadResponseMsg* resp) = 0;
+      ReadResponseMsg* resp, HybridTime* follower_safe_time = nullptr) = 0;
 
   virtual ~ReadTabletProvider() = default;
 };

--- a/src/yb/tserver/service_util.h
+++ b/src/yb/tserver/service_util.h
@@ -327,7 +327,8 @@ Status CheckPeerIsReady(
 Result<std::shared_ptr<tablet::AbstractTablet>> GetTablet(
     TabletPeerLookupIf* tablet_manager, TabletIdView tablet_id,
     tablet::TabletPeerPtr tablet_peer, YBConsistencyLevel consistency_level,
-    AllowSplitTablet allow_split_tablet, ReadResponseMsg* resp = nullptr);
+    AllowSplitTablet allow_split_tablet, ReadResponseMsg* resp = nullptr,
+    HybridTime* follower_safe_time = nullptr);
 
 Status CheckWriteThrottling(double score, tablet::TabletPeer* tablet_peer);
 

--- a/src/yb/tserver/tablet_service.cc
+++ b/src/yb/tserver/tablet_service.cc
@@ -633,9 +633,9 @@ class ScanResultChecksummer {
 Result<std::shared_ptr<tablet::AbstractTablet>> TabletServiceImpl::GetTabletForRead(
   TabletIdView tablet_id, tablet::TabletPeerPtr tablet_peer,
   YBConsistencyLevel consistency_level, tserver::AllowSplitTablet allow_split_tablet,
-  tserver::ReadResponseMsg* resp) {
+  tserver::ReadResponseMsg* resp, HybridTime* follower_safe_time) {
   return GetTablet(server_->tablet_peer_lookup(), tablet_id, std::move(tablet_peer),
-                   consistency_level, allow_split_tablet, resp);
+                   consistency_level, allow_split_tablet, resp, follower_safe_time);
 }
 
 TabletServiceImpl::TabletServiceImpl(TabletServerIf* server)

--- a/src/yb/tserver/tablet_service.h
+++ b/src/yb/tserver/tablet_service.h
@@ -278,7 +278,7 @@ class TabletServiceImpl : public TabletServerServiceIf, public ReadTabletProvide
   Result<std::shared_ptr<tablet::AbstractTablet>> GetTabletForRead(
     TabletIdView tablet_id, tablet::TabletPeerPtr tablet_peer,
     YBConsistencyLevel consistency_level, tserver::AllowSplitTablet allow_split_tablet,
-    tserver::ReadResponseMsg* resp) override;
+    tserver::ReadResponseMsg* resp, HybridTime* follower_safe_time = nullptr) override;
 
   Result<uint64_t> DoChecksum(const ChecksumRequestPB* req, CoarseTimePoint deadline);
 


### PR DESCRIPTION
Resolves https://github.com/yugabyte/yugabyte-db/issues/5060.

During consistent prefix (follower) reads, we compute safe time in `GetTablet()` to check if the follower is too stale, and then compute it again in `DoPickReadTime()` to pick the read time. This PR passes the safe time from the staleness check through to the read path so we don't compute it twice.

NOTE: It should be safe to reuse the safe time because it only moves forward, and we have already passed the staleness check. The linearization point for the safe time happens at the time we check the staleness, not `DoPickReadTime()`.