### PR TITLE
[#14906] xCluster: Reject sequences_data table in manual setup_universe_replication

### DIFF
--- a/src/yb/integration-tests/xcluster/xcluster_ysql-test.cc
+++ b/src/yb/integration-tests/xcluster/xcluster_ysql-test.cc
@@ -25,6 +25,7 @@
 #include "yb/client/yb_table_name.h"
 
 #include "yb/common/common.pb.h"
+#include "yb/common/entity_ids.h"
 #include "yb/common/wire_protocol.h"
 
 #include "yb/consensus/log.h"
@@ -159,6 +160,14 @@ class XClusterYsqlTest : public XClusterYsqlTestBase {
     return 3s * FLAGS_cdc_parent_tablet_deletion_task_retry_secs * kTimeMultiplier;
   }
 };
+
+TEST_F(XClusterYsqlTest, RejectSequencesDataTableInManualSetup) {
+  ASSERT_OK(SetUpWithParams({1}, {1}, 1, 1));
+
+  auto setup_status = SetupUniverseReplication({kPgSequencesDataTableId});
+  ASSERT_NOK(setup_status);
+  ASSERT_STR_CONTAINS(setup_status.ToString(), "sequences_data");
+}
 
 TEST_F(XClusterYsqlTest, GenerateSeries) {
   ASSERT_OK(SetUpWithParams({4}, {4}, 3, 1));

--- a/src/yb/master/xcluster/xcluster_inbound_replication_group_setup_task.cc
+++ b/src/yb/master/xcluster/xcluster_inbound_replication_group_setup_task.cc
@@ -209,6 +209,12 @@ Status XClusterInboundReplicationGroupSetupTask::ValidateInputArguments() {
         !IsColocatedDbParentTableId(source_table_id), NotSupported,
         "Pre GA colocated databases are not supported with xCluster replication: $0",
         source_table_id);
+    SCHECK_FORMAT(
+        is_db_scoped_ ||
+        xcluster::StripSequencesDataAliasIfPresent(source_table_id) != kPgSequencesDataTableId,
+        NotSupported,
+        "Replication of the sequences_data table is not supported: $0",
+        source_table_id);
     SCHECK(source_table_ids.insert(source_table_id).second, InvalidArgument,
            "Duplicate table source table id: $0", data_.source_table_ids);
   }


### PR DESCRIPTION
Resolves https://github.com/yugabyte/yugabyte-db/issues/14906

## Problem

When a user runs `setup_universe_replication` and accidentally includes the
`sequences_data` table ID (`kPgSequencesDataTableId`), the setup fails with:

> "Table with identifier not found: OBJECT_NOT_FOUND"

This doesn't say which table failed or why. Users have to dig through server
logs to discover that `0000ffff00003000800000000000ffff` (the sequences_data
table) was the problematic ID.

## Root Cause

The manual `setup_universe_replication` path has no validation for unsupported
table types in `ValidateInputArguments()`. The sequences_data table ID passes
all existing checks (not empty, not duplicate, not a colocated parent), then
gets sent to the producer via `GetTableSchemaById`, which fails with a generic
"not found" error.

The existing system table check in `ProcessTable()` (`namespace_name != "system"`)
doesn't catch it either — `sequences_data` lives in the `"system_postgres"`
namespace, not `"system"`.

The DB-scoped (automatic DDL mode) path already handles this correctly via
`IsTableEligibleForXClusterReplication()`, which explicitly filters out
sequences_data. This bug only affects the manual table-ID path.

## Fix

Added an early check in `ValidateInputArguments()` that rejects the
sequences_data table ID (and aliases) before any RPC to the producer.
Uses `StripSequencesDataAliasIfPresent()` to catch both the raw ID and
namespace-specific aliases in a single comparison.

This follows the existing pattern used for colocated parent table IDs
(`IsColocatedDbParentTableId` check at the same location).

## Alternatives Considered

- **Check in `ProcessTable()` after schema fetch**: Not viable — `GetTableSchemaById`
  fails on the producer before `ProcessTable()` is ever called.
- **Reuse `IsTableEligibleForXClusterReplication()` in the manual path**: Would catch
  all unsupported types, but requires a `master::TableInfo` catalog lookup. The target
  table may not exist on the consumer, causing the lookup to fail before the eligibility
  check runs. Better suited as a follow-up.
- **Check in CLI/client layer**: Only helps `yb-admin` users, not API/UI clients.
  Not centralized.

## Testing

**New test:**
- `xcluster_ysql-test.cc: RejectSequencesDataTableInManualSetup` — verifies the
  manual path rejects `kPgSequencesDataTableId` with a clear error containing
  "sequences_data"

**Existing regression tests (verified locally):**
- `xcluster_sequences-test.cc: StraightforwardSequenceReplication` — confirms
  DB-scoped replication with sequences_data aliases still works. The `is_db_scoped_`
  guard was added after Cursor Bugbot flagged that the original check (without the
  guard) would break this path. Verified locally: fails without the guard, passes
  with it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted input validation plus a new test; behavior change is limited to rejecting an unsupported system table ID in the manual xCluster setup path.
> 
> **Overview**
> Prevents manual `SetupUniverseReplication` requests from including the internal `sequences_data` table by adding an early validation check in `XClusterInboundReplicationGroupSetupTask::ValidateInputArguments()` (including alias IDs via `StripSequencesDataAliasIfPresent`).
> 
> Adds an integration test (`RejectSequencesDataTableInManualSetup`) asserting the RPC fails with a `NotSupported`-style error that mentions `sequences_data`, instead of a later generic “table not found” failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35a68a8145284f0185f486d696a9e34d2ceea1f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->