### PR TITLE
Auto single-quote `ysql_` prefixed gflags in PG config

### DIFF
--- a/src/yb/yql/pgwrapper/pg_wrapper-test.cc
+++ b/src/yb/yql/pgwrapper/pg_wrapper-test.cc
@@ -34,6 +34,7 @@
 #include "yb/client/client.h"
 #include "yb/client/table_info.h"
 
+#include "yb/yql/pgwrapper/pg_wrapper.h"
 #include "yb/yql/pgwrapper/pg_wrapper_test_base.h"
 #include "yb/yql/pgwrapper/libpq_utils.h"
 
@@ -72,6 +73,30 @@ class PgWrapperTestHelper: public PgCommandTestBase {
 
 } // namespace
 
+TEST(FormatPgGFlagValueTest, QuotingBehavior) {
+  // Pre-quoted string values should pass through unchanged.
+  ASSERT_EQ(FormatPgGFlagValue("'read committed'", "string"), "'read committed'");
+  ASSERT_EQ(FormatPgGFlagValue("'serializable'", "string"), "'serializable'");
+
+  // Unquoted string values should be wrapped in single quotes.
+  // ysql_default_transaction_isolation: spaces cause PG config parse failure without quotes.
+  ASSERT_EQ(FormatPgGFlagValue("read committed", "string"), "'read committed'");
+  ASSERT_EQ(FormatPgGFlagValue("repeatable read", "string"), "'repeatable read'");
+  // ysql_datestyle: comma+space causes PG config parse failure without quotes.
+  ASSERT_EQ(FormatPgGFlagValue("ISO, MDY", "string"), "'ISO, MDY'");
+  // ysql_timezone: no spaces, quoting is harmless.
+  ASSERT_EQ(FormatPgGFlagValue("America/New_York", "string"), "'America/New_York'");
+  ASSERT_EQ(FormatPgGFlagValue("GMT+5", "string"), "'GMT+5'");
+  ASSERT_EQ(FormatPgGFlagValue("none", "string"), "'none'");
+
+  // Internal single quotes should be escaped by doubling.
+  ASSERT_EQ(FormatPgGFlagValue("foo'bar", "string"), "'foo''bar'");
+  ASSERT_EQ(FormatPgGFlagValue("foo'''bar", "string"), "'foo''''''bar'");
+
+  // Non-string types should pass through unchanged without quoting.
+  ASSERT_EQ(FormatPgGFlagValue("42", "int32"), "42");
+  ASSERT_EQ(FormatPgGFlagValue("true", "bool"), "true");
+}
 
 YB_DEFINE_ENUM(FlushOrCompaction, (kFlush)(kFlushRegularOnly)(kCompaction));
 

--- a/src/yb/yql/pgwrapper/pg_wrapper.cc
+++ b/src/yb/yql/pgwrapper/pg_wrapper.cc
@@ -445,6 +445,20 @@ using namespace std::literals;  // NOLINT
 namespace yb {
 namespace pgwrapper {
 
+string FormatPgGFlagValue(const string& value, const string& type) {
+  if (type == "string") {
+    auto trimmed = boost::algorithm::trim_copy(value);
+    if (trimmed.size() >= 2 && trimmed.front() == '\'' && trimmed.back() == '\'') {
+      // Already single-quoted — pass through unchanged.
+      return value;
+    }
+    // Add single quotes and escape internal single quotes.
+    string escaped_value = boost::replace_all_copy(value, "'", "''");
+    return Format("'$0'", escaped_value);
+  }
+  return value;
+}
+
 namespace {
 
 Status WriteConfigFile(const string& path, const vector<string>& lines) {
@@ -594,8 +608,8 @@ void AppendPgGFlags(vector<string>* lines) {
     }
 
     string pg_variable_name = flag.name.substr(pg_flag_prefix.length());
-    string escaped_value = boost::replace_all_copy(flag.current_value, "'", "''");
-    lines->push_back(Format("$0='$1'", pg_variable_name, escaped_value));
+    lines->push_back(
+        Format("$0=$1", pg_variable_name, FormatPgGFlagValue(flag.current_value, flag.type)));
   }
 
   // Special handling for deprecated ysql_enable_pg_export_snapshot flag.

--- a/src/yb/yql/pgwrapper/pg_wrapper.h
+++ b/src/yb/yql/pgwrapper/pg_wrapper.h
@@ -205,5 +205,10 @@ class PgSupervisor : public ProcessSupervisor {
   }
 };
 
+// Formats a gflag value for use in postgresql.conf.
+// String-type flags are single-quoted (with internal quotes escaped), unless already quoted.
+// Non-string-type flags are returned as-is.
+std::string FormatPgGFlagValue(const std::string& value, const std::string& type);
+
 }  // namespace pgwrapper
 }  // namespace yb


### PR DESCRIPTION
Closes https://github.com/yugabyte/yugabyte-db/issues/29808

---

This PR resolves this issue. 

```bash
./bin/yb-ctl --rf 3 create --tserver_flags "ysql_default_transaction_isolation='read committed'"

tail -n 5 ~/yugabyte-data/node-1/disk-1/tserver.err
2026-02-14 01:54:23.090 GMT [34439] WARNING:  the parameter "yb_enable_advisory_locks" is deprecated, toggle the runtime flag "ysql_yb_enable_advisory_locks" instead.
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0214 10:54:23.090657 71117888 tcmalloc_util.cc:266] Setting TCMalloc profiler sampling period to 1048576 bytes
2026-02-14 01:54:23.091 GMT [34439] LOG:  syntax error in file "/Users/keisukeumegaki/yugabyte-data/node-1/disk-1/pg_data/ysql_pg.conf" line 834, near token "committed"
2026-02-14 01:54:23.091 GMT [34439] FATAL:  configuration file "/Users/keisukeumegaki/yugabyte-data/node-1/disk-1/pg_data/ysql_pg.conf" contains errors

./bin/ysqlsh -c "SHOW default_transaction_isolation;"
ysqlsh: error: connection to server at "localhost" (127.0.0.1), port 5433 failed: Connection refused
        Is the server running on that host and accepting TCP/IP connections?
connection to server at "localhost" (::1), port 5433 failed: Connection refused
        Is the server running on that host and accepting TCP/IP connections?
```

With this PR, we can see `read committed` as this command result.

```bash
./bin/yb-ctl --rf 3 create --tserver_flags "ysql_default_transaction_isolation='read committed'"

./bin/ysqlsh -c "SHOW default_transaction_isolation;"
 default_transaction_isolation
-------------------------------
 read committed
(1 row)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to config-file generation plus added tests; main risk is unintended quoting changes for string flags, but behavior is constrained to `type == "string"` and preserves already-quoted values.
> 
> **Overview**
> Fixes Postgres startup failures caused by unquoted string-valued `ysql_` gflags (e.g. `read committed`, `ISO, YMD`) being written into `ysql_pg.conf` without quoting.
> 
> Adds `FormatPgGFlagValue` and uses it when emitting Pg-tagged gflags into the generated config: string types are single-quoted with internal quotes escaped, while non-string values pass through unchanged. Updates tests to cover quoting/escaping behavior and extends the flag override integration test to include `ysql_default_transaction_isolation` and `ysql_datestyle` values that require quoting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a578f21c9ff5cf6620ec8058a3ebf91ee247fa0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->