### PR TITLE
[DOC-1180][yba] Auto provision requires Admin role

### DIFF
--- a/docs/content/stable/yugabyte-platform/prepare/server-nodes-software/software-on-prem.md
+++ b/docs/content/stable/yugabyte-platform/prepare/server-nodes-software/software-on-prem.md
@@ -50,7 +50,7 @@ curl -k https://<yba_address>/api/v1/node_agents/download\?downloadType\=package
 ```
 
 - `<yba_address>` is the address of your YugabyteDB Anywhere installation.
-- `<api_token>` is an API token you created. For information on creating an API token, refer to [API authentication](../../../anywhere-automation/#authentication).
+- `<api_token>` is an API token you created. For information on creating an API token, refer to [API authentication](../../../anywhere-automation/#authentication). The user creating the API token must have [Admin role](../../../administer-yugabyte-platform/anywhere-rbac/#built-in-roles) privileges or better.
 - You can change the architecture from AMD64 to ARM64 as appropriate.
 
 Use this method if you don't have internet connectivity. This downloads the same version of node agent as the version of YugabyteDB Anywhere you are running.
@@ -117,7 +117,7 @@ Set the following options to have node agent create (or update) the [on-premises
 | :--- | :--- |
 | `url` | The base URL of your YugabyteDB Anywhere instance. |
 | `customer_uuid` | Your customer ID. To view your customer ID, in YugabyteDB Anywhere, click the **Profile** icon in the top right corner of the window, and choose **User Profile**. |
-| `api_key` | Your API token. To obtain this, in YugabyteDB Anywhere, click the Profile icon in the top right corner of the window, and choose **User Profile**. Then click **Generate Key**. |
+| `api_key` | Your API token. To obtain this, in YugabyteDB Anywhere, click the Profile icon in the top right corner of the window, and choose **User Profile**. Then click **Generate Key**. The user creating the API token must have [Admin role](../../../administer-yugabyte-platform/anywhere-rbac/#built-in-roles) privileges or better. |
 | `node_name` | A name for the node. |
 | `node_external_fqdn` | The fully qualified domain name or IP address of the node, must be accessible from the YugabyteDB Anywhere server. |
 

--- a/docs/content/v2.20/yugabyte-platform/prepare/server-nodes-software/software-on-prem.md
+++ b/docs/content/v2.20/yugabyte-platform/prepare/server-nodes-software/software-on-prem.md
@@ -50,7 +50,7 @@ curl -k https://<yba_address>/api/v1/node_agents/download\?downloadType\=package
 ```
 
 - `<yba_address>` is the address of your YugabyteDB Anywhere installation.
-- `<api_token>` is an API token you created. For information on creating an API token, refer to [API authentication](../../../anywhere-automation/#authentication).
+- `<api_token>` is an API token you created. For information on creating an API token, refer to [API authentication](../../../anywhere-automation/#authentication). The user creating the API token must have [Admin role](../../../administer-yugabyte-platform/anywhere-rbac/#built-in-roles) privileges or better.
 - You can change the architecture from AMD64 to ARM64 as appropriate.
 
 Use this method if you don't have internet connectivity. This downloads the same version of node agent as the version of YugabyteDB Anywhere you are running.
@@ -116,7 +116,7 @@ Set the following options to have node agent create (or update) the [on-premises
 | :--- | :--- |
 | `url` | The base URL of your YugabyteDB Anywhere instance. |
 | `customer_uuid` | Your customer ID. To view your customer ID, in YugabyteDB Anywhere, click the **Profile** icon in the top right corner of the window, and choose **User Profile**. |
-| `api_key` | Your API token. To obtain this, in YugabyteDB Anywhere, click the Profile icon in the top right corner of the window, and choose **User Profile**. Then click **Generate Key**. |
+| `api_key` | Your API token. To obtain this, in YugabyteDB Anywhere, click the Profile icon in the top right corner of the window, and choose **User Profile**. Then click **Generate Key**. The user creating the API token must have [Admin role](../../../administer-yugabyte-platform/anywhere-rbac/#built-in-roles) privileges or better. |
 | `node_name` | A name for the node. |
 | `node_external_fqdn` | The fully qualified domain name or IP address of the node, must be accessible from the YugabyteDB Anywhere server. |
 

--- a/docs/content/v2024.1/yugabyte-platform/prepare/server-nodes-software/software-on-prem.md
+++ b/docs/content/v2024.1/yugabyte-platform/prepare/server-nodes-software/software-on-prem.md
@@ -50,7 +50,7 @@ curl -k https://<yba_address>/api/v1/node_agents/download\?downloadType\=package
 ```
 
 - `<yba_address>` is the address of your YugabyteDB Anywhere installation.
-- `<api_token>` is an API token you created. For information on creating an API token, refer to [API authentication](../../../anywhere-automation/#authentication).
+- `<api_token>` is an API token you created. For information on creating an API token, refer to [API authentication](../../../anywhere-automation/#authentication). The user creating the API token must have [Admin role](../../../administer-yugabyte-platform/anywhere-rbac/#built-in-roles) privileges or better.
 - You can change the architecture from AMD64 to ARM64 as appropriate.
 
 Use this method if you don't have internet connectivity. This downloads the same version of node agent as the version of YugabyteDB Anywhere you are running.
@@ -116,7 +116,7 @@ Set the following options to have node agent create (or update) the [on-premises
 | :--- | :--- |
 | `url` | The base URL of your YugabyteDB Anywhere instance. |
 | `customer_uuid` | Your customer ID. To view your customer ID, in YugabyteDB Anywhere, click the **Profile** icon in the top right corner of the window, and choose **User Profile**. |
-| `api_key` | Your API token. To obtain this, in YugabyteDB Anywhere, click the Profile icon in the top right corner of the window, and choose **User Profile**. Then click **Generate Key**. |
+| `api_key` | Your API token. To obtain this, in YugabyteDB Anywhere, click the Profile icon in the top right corner of the window, and choose **User Profile**. Then click **Generate Key**. The user creating the API token must have [Admin role](../../../administer-yugabyte-platform/anywhere-rbac/#built-in-roles) privileges or better. |
 | `node_name` | A name for the node. |
 | `node_external_fqdn` | The fully qualified domain name or IP address of the node, must be accessible from the YugabyteDB Anywhere server. |
 

--- a/docs/content/v2024.2/yugabyte-platform/prepare/server-nodes-software/software-on-prem.md
+++ b/docs/content/v2024.2/yugabyte-platform/prepare/server-nodes-software/software-on-prem.md
@@ -50,7 +50,7 @@ curl -k https://<yba_address>/api/v1/node_agents/download\?downloadType\=package
 ```
 
 - `<yba_address>` is the address of your YugabyteDB Anywhere installation.
-- `<api_token>` is an API token you created. For information on creating an API token, refer to [API authentication](../../../anywhere-automation/#authentication).
+- `<api_token>` is an API token you created. For information on creating an API token, refer to [API authentication](../../../anywhere-automation/#authentication). The user creating the API token must have [Admin role](../../../administer-yugabyte-platform/anywhere-rbac/#built-in-roles) privileges or better.
 - You can change the architecture from AMD64 to ARM64 as appropriate.
 
 Use this method if you don't have internet connectivity. This downloads the same version of node agent as the version of YugabyteDB Anywhere you are running.
@@ -116,7 +116,7 @@ Set the following options to have node agent create (or update) the [on-premises
 | :--- | :--- |
 | `url` | The base URL of your YugabyteDB Anywhere instance. |
 | `customer_uuid` | Your customer ID. To view your customer ID, in YugabyteDB Anywhere, click the **Profile** icon in the top right corner of the window, and choose **User Profile**. |
-| `api_key` | Your API token. To obtain this, in YugabyteDB Anywhere, click the Profile icon in the top right corner of the window, and choose **User Profile**. Then click **Generate Key**. |
+| `api_key` | Your API token. To obtain this, in YugabyteDB Anywhere, click the Profile icon in the top right corner of the window, and choose **User Profile**. Then click **Generate Key**. The user creating the API token must have [Admin role](../../../administer-yugabyte-platform/anywhere-rbac/#built-in-roles) privileges or better. |
 | `node_name` | A name for the node. |
 | `node_external_fqdn` | The fully qualified domain name or IP address of the node, must be accessible from the YugabyteDB Anywhere server. |
 

--- a/docs/content/v2025.1/yugabyte-platform/prepare/server-nodes-software/software-on-prem.md
+++ b/docs/content/v2025.1/yugabyte-platform/prepare/server-nodes-software/software-on-prem.md
@@ -50,7 +50,7 @@ curl -k https://<yba_address>/api/v1/node_agents/download\?downloadType\=package
 ```
 
 - `<yba_address>` is the address of your YugabyteDB Anywhere installation.
-- `<api_token>` is an API token you created. For information on creating an API token, refer to [API authentication](../../../anywhere-automation/#authentication).
+- `<api_token>` is an API token you created. For information on creating an API token, refer to [API authentication](../../../anywhere-automation/#authentication). The user creating the API token must have [Admin role](../../../administer-yugabyte-platform/anywhere-rbac/#built-in-roles) privileges or better.
 - You can change the architecture from AMD64 to ARM64 as appropriate.
 
 Use this method if you don't have internet connectivity. This downloads the same version of node agent as the version of YugabyteDB Anywhere you are running.
@@ -116,7 +116,7 @@ Set the following options to have node agent create (or update) the [on-premises
 | :--- | :--- |
 | `url` | The base URL of your YugabyteDB Anywhere instance. |
 | `customer_uuid` | Your customer ID. To view your customer ID, in YugabyteDB Anywhere, click the **Profile** icon in the top right corner of the window, and choose **User Profile**. |
-| `api_key` | Your API token. To obtain this, in YugabyteDB Anywhere, click the Profile icon in the top right corner of the window, and choose **User Profile**. Then click **Generate Key**. |
+| `api_key` | Your API token. To obtain this, in YugabyteDB Anywhere, click the Profile icon in the top right corner of the window, and choose **User Profile**. Then click **Generate Key**. The user creating the API token must have [Admin role](../../../administer-yugabyte-platform/anywhere-rbac/#built-in-roles) privileges or better. |
 | `node_name` | A name for the node. |
 | `node_external_fqdn` | The fully qualified domain name or IP address of the node, must be accessible from the YugabyteDB Anywhere server. |
 


### PR DESCRIPTION
@netlify /stable/yugabyte-platform/prepare/server-nodes-software/software-on-prem/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds an RBAC prerequisite; no product behavior or APIs are modified.
> 
> **Overview**
> Clarifies in the on-prem auto-provisioning docs (stable, `v2.20`, `v2024.1`, `v2024.2`, `v2025.1`) that the API token used to download the node agent package and the `api_key` used for provider configuration must be created by a user with **Admin** (or higher) RBAC privileges.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c9dd17186eeef1c13277253e1979fc58a773165. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->