### PR TITLE
[DOC-1181][yba] Helm upgrade flags

### DIFF
--- a/docs/content/stable/yugabyte-platform/upgrade/upgrade-yp-kubernetes.md
+++ b/docs/content/stable/yugabyte-platform/upgrade/upgrade-yp-kubernetes.md
@@ -42,7 +42,14 @@ helm repo update
 To upgrade to a specific version while preserving overrides you might have applied to your initial YugabyteDB Anywhere installation or previous upgrades, execute the following command:
 
 ```sh
-helm upgrade yw-test yugabytedb/yugaware --version {{<yb-version version="stable" format="short">}} -n yb-platform --reset-then-reuse-values --set image.tag={{<yb-version version="stable" format="build">}} --wait
+helm upgrade yw-test yugabytedb/yugaware \
+  --version {{<yb-version version="stable" format="short">}} \
+  -n yb-platform \
+  --reset-then-reuse-values \
+  --set image.tag={{<yb-version version="stable" format="build">}} \
+  --atomic \
+  --timeout 30m \
+  --wait
 ```
 
 To obtain the value for `--set image.tag`, execute the following command:
@@ -52,6 +59,12 @@ helm list | awk '{if (NR!=1) print $NF}'
 ```
 
 If you do not wish to port your overrides, do not include `--reset-then-reuse-values`. Instead, you may choose to pass your existing overrides file by adding `--values custom-values.yaml` to your command during the upgrade.
+
+When `--atomic` is used, if the upgrade fails for any reason (pods not Ready, hooks fail, timeout, and so on), Helm will automatically roll back to the last successful release.
+
+Use `--timeout` to give the upgrade enough time; if the upgrade exceeds this time, Helm treats it as a failure, and (if `--atomic` is set) triggers a rollback.
+
+When `--wait` is used, Helm waits for workloads to become Ready.
 
 If you have upgraded YugabyteDB Anywhere to version 2.12 or later and [xCluster replication](../../../explore/going-beyond-sql/asynchronous-replication-ysql/) for your universe was set up via yb-admin instead of the UI, follow the instructions provided in [Synchronize replication after upgrade](../upgrade-yp-xcluster-ybadmin/).
 


### PR DESCRIPTION
@netlify /stable/yugabyte-platform/upgrade/upgrade-yp-kubernetes/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adjusts recommended Helm flags; no product code or runtime behavior is modified.
> 
> **Overview**
> Updates the Kubernetes Helm upgrade instructions for YugabyteDB Anywhere to include `--atomic` and a `--timeout 30m`, and reformats the sample command for readability.
> 
> Adds brief guidance explaining how `--atomic`, `--timeout`, and `--wait` affect upgrade behavior (automatic rollback on failure, time-based failure triggering rollback, and waiting for readiness).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b17eccc58aaa6f29a383c71bcf2f1cd339f828b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->