### PR TITLE
Add `vector_index_compact_read_bytes` metric to track compaction input size

### DIFF
--- a/src/yb/vector_index/vector_lsm.cc
+++ b/src/yb/vector_index/vector_lsm.cc
@@ -2533,6 +2533,11 @@ Status VectorLSM<Vector, DistanceResult>::DoCompact(
   auto merged_chunk = VERIFY_RESULT(DoCompactChunks(scope.chunks()));
 
   if (metrics_) {
+    uint64_t read_bytes = 0;
+    for (const auto& chunk : scope.chunks()) {
+      read_bytes += chunk->file_size();
+    }
+    metrics_->compact_read_bytes->IncrementBy(read_bytes);
     // TODO(vector_index): include metadata file update in write metrics.
     metrics_->compact_write_bytes->IncrementBy(merged_chunk->file_size());
   }

--- a/src/yb/vector_index/vector_lsm_metrics.cc
+++ b/src/yb/vector_index/vector_lsm_metrics.cc
@@ -19,6 +19,10 @@ METRIC_DEFINE_counter(table, vector_index_compact_write_bytes,
     "Vector index compaction write bytes", yb::MetricUnit::kBytes,
     "Number of bytes written during vector index compaction");
 
+METRIC_DEFINE_counter(table, vector_index_compact_read_bytes,
+    "Vector index compaction read bytes", yb::MetricUnit::kBytes,
+    "Number of bytes read during vector index compaction");
+
 METRIC_DEFINE_event_stats(table, vector_index_num_chunks,
     "Vector index lookup chunks", yb::MetricUnit::kEntries,
     "Number of chunks used during vector index search.");
@@ -39,6 +43,7 @@ namespace yb::vector_index {
 
 VectorLSMMetrics::VectorLSMMetrics(const MetricEntityPtr& entity)
     : compact_write_bytes(METRIC_vector_index_compact_write_bytes.Instantiate(entity)),
+      compact_read_bytes(METRIC_vector_index_compact_read_bytes.Instantiate(entity)),
       num_chunks(METRIC_vector_index_num_chunks.Instantiate(entity)),
       total_found_entries(METRIC_vector_index_total_found_entries.Instantiate(entity)),
       insert_registry_entries(METRIC_vector_index_insert_registry_entries.Instantiate(entity)),

--- a/src/yb/vector_index/vector_lsm_metrics.h
+++ b/src/yb/vector_index/vector_lsm_metrics.h
@@ -21,6 +21,7 @@ struct VectorLSMMetrics {
   explicit VectorLSMMetrics(const MetricEntityPtr& entity);
 
   CounterPtr compact_write_bytes;
+  CounterPtr compact_read_bytes;
   EventStatsPtr num_chunks;
   EventStatsPtr total_found_entries;
   EventStatsPtr insert_registry_entries;


### PR DESCRIPTION
Part of https://github.com/yugabyte/yugabyte-db/issues/28578 and follow up on https://github.com/yugabyte/yugabyte-db/commit/82e7741eb35860007f3eafe53adb9cb3ee369598#diff-c2003959336de6b22d907014e32e29d09f1d194097b380dd542a91f4d6505680

---

Set up a testing env.

```bash
./bin/ysqlsh -c "CREATE EXTENSION IF NOT EXISTS vector;"
./bin/ysqlsh -c "CREATE TABLE IF NOT EXISTS items (id int PRIMARY KEY, embedding vector(3));"
./bin/ysqlsh -c "CREATE INDEX IF NOT EXISTS items_embedding_idx ON items USING ybhnsw (embedding vector_l2_ops);"
```

The metrics are per-tserver, so we need to query the correct node. Find which tserver leads the index tablet.

```bash
./build/latest/bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 list_all_masters
Master UUID                             RPC Host/Port           State           Role    Broadcast Host/Port
1e72c027e9d74934bfebcba681588fa0        127.0.0.1:7100          ALIVE           FOLLOWER        N/A
eac81bb7e1fb4bf1bd277978cd1aec35        127.0.0.2:7100          ALIVE           FOLLOWER        N/A
89979012063047b895171a8301ffedcc        127.0.0.3:7100          ALIVE           LEADER  N/A
```

Verify metrics start at zero.

```bash
curl -s http://127.0.0.3:9000/metrics | jq . | grep -A2 vector_index_compact
        "name": "vector_index_compact_write_bytes",
        "value": 0
      },
--
        "name": "vector_index_compact_read_bytes",
        "value": 0
      },
```

Metrics remain at 0 after INSERT — 10k vectors is well below the 100k flush threshold (`vector_index_initial_chunk_size`), so no chunks reach disk and compaction never triggers.

```bash
./bin/ysqlsh -c "INSERT INTO items SELECT i, ARRAY[random(), random(), random()]::vector FROM generate_series(1, 10000) i;"

curl -s http://127.0.0.3:9000/varz\?raw 2>&1 | grep vector_index_initial_chunk_size
--vector_index_initial_chunk_size=100000
```

Force vector index compaction.

```bash
./build/latest/bin/yb-admin -master_addresses 127.0.0.3:7100 compact_table ysql.yugabyte items ADD_VECTOR_INDEXES
Compacted [yugabyte.items [ysql_schema=public] [000034e10000300080000000000040f9]] tables and associated vector indexes.

grep -hr 'Compaction input' /Users/keisukeumegaki/yugabyte-data/node-3/disk-1/yb-data/tserver/logs
I0218 10:34:03.594872 1884237824 vector_lsm.cc:2472] T 6d235c3f23a54e90889eb0a6475f4126 P 703f5f16dcd340be9142b5a3bf82d9c9 VI 000034e10000300080000000000040fe: Compaction input [chunks: 2, indexes: 1, vectors: 10000]

curl -s http://127.0.0.3:9000/metrics | jq . | grep -A2 vector_index_compact
        "name": "vector_index_compact_write_bytes",
        "value": 840357
      },
--
        "name": "vector_index_compact_read_bytes",
        "value": 841451
      },
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new counter and increments it during compaction without changing compaction behavior or persistence logic; main risk is metric miscounting due to relying on chunk `file_size()`.
> 
> **Overview**
> Adds a new per-tserver metric, `vector_index_compact_read_bytes`, to track total input bytes read during Vector LSM compactions.
> 
> `VectorLSM::DoCompact` now sums `file_size()` across the compaction scope and increments the new counter alongside existing `compact_write_bytes`, and unit tests are updated/extended to assert the read metric stays at 0 when no compaction occurs and increases appropriately for both background and manual compactions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a18f30f59e81a749de6b5e4181aa3fe04d859be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

Phorge: [D51638](https://phorge.dev.yugabyte.com/D51638)