### PR TITLE
Pass comments to CDC events

### DIFF
--- a/src/postgres/src/backend/catalog/yb_catalog/yb_catalog_version.c
+++ b/src/postgres/src/backend/catalog/yb_catalog/yb_catalog_version.c
@@ -555,7 +555,8 @@ YbIncrementMasterDBCatalogVersionTableEntryImpl(Oid db_oid,
 
 	Relation	rel = RelationIdGetRelation(YBCatalogVersionRelationId);
 
-	YbcPgStatement update_stmt = YbNewUpdate(rel, YB_TRANSACTIONAL);
+	YbcPgStatement update_stmt = YbNewUpdate(rel, YB_TRANSACTIONAL,
+										 NULL /* query_comment */);
 
 	Datum		ybctid = YbGetMasterCatalogVersionTableEntryYbctid(rel, db_oid);
 
@@ -737,7 +738,8 @@ YbCreateMasterDBCatalogVersionTableEntry(Oid db_oid)
 	 */
 	Relation	rel = RelationIdGetRelation(YBCatalogVersionRelationId);
 
-	YbcPgStatement insert_stmt = YbNewInsert(rel, YB_SINGLE_SHARD_TRANSACTION);
+	YbcPgStatement insert_stmt = YbNewInsert(rel, YB_SINGLE_SHARD_TRANSACTION,
+										 NULL /* query_comment */);
 
 	Datum		ybctid = YbGetMasterCatalogVersionTableEntryYbctid(rel, db_oid);
 
@@ -841,7 +843,8 @@ YbDeleteMasterDBCatalogVersionTableEntry(Oid db_oid)
 
 	Relation	rel = RelationIdGetRelation(YBCatalogVersionRelationId);
 
-	YbcPgStatement delete_stmt = YbNewDelete(rel, YB_SINGLE_SHARD_TRANSACTION);
+	YbcPgStatement delete_stmt = YbNewDelete(rel, YB_SINGLE_SHARD_TRANSACTION,
+										 NULL /* query_comment */);
 
 	Datum		ybctid = YbGetMasterCatalogVersionTableEntryYbctid(rel, db_oid);
 

--- a/src/postgres/src/backend/catalog/yb_logical_client/yb_logical_client_version.c
+++ b/src/postgres/src/backend/catalog/yb_logical_client/yb_logical_client_version.c
@@ -152,7 +152,8 @@ YbIncrementMasterDBLogicalClientVersionTableEntryImpl(Oid db_oid)
 
 	Relation rel = RelationIdGetRelation(YBLogicalClientVersionRelationId);
 
-	YbcPgStatement update_stmt = YbNewUpdate(rel, YB_TRANSACTIONAL);
+	YbcPgStatement update_stmt = YbNewUpdate(rel, YB_TRANSACTIONAL,
+										 NULL /* query_comment */);
 
 	Datum		ybctid = YbGetMasterLogicalClientVersionTableEntryYbctid(rel, db_oid);
 
@@ -253,7 +254,8 @@ YbCreateMasterDBLogicalClientVersionTableEntry(Oid db_oid)
 	 */
 	Relation rel = RelationIdGetRelation(YBLogicalClientVersionRelationId);
 
-	YbcPgStatement insert_stmt = YbNewInsert(rel, YB_SINGLE_SHARD_TRANSACTION);
+	YbcPgStatement insert_stmt = YbNewInsert(rel, YB_SINGLE_SHARD_TRANSACTION,
+										 NULL /* query_comment */);
 
 	Datum		ybctid = YbGetMasterLogicalClientVersionTableEntryYbctid(rel, db_oid);
 
@@ -301,7 +303,8 @@ YbDeleteMasterDBLogicalClientVersionTableEntry(Oid db_oid)
 	 */
 	Relation rel = RelationIdGetRelation(YBLogicalClientVersionRelationId);
 
-	YbcPgStatement delete_stmt = YbNewDelete(rel, YB_SINGLE_SHARD_TRANSACTION);
+	YbcPgStatement delete_stmt = YbNewDelete(rel, YB_SINGLE_SHARD_TRANSACTION,
+										 NULL /* query_comment */);
 
 	Datum		ybctid = YbGetMasterLogicalClientVersionTableEntryYbctid(rel, db_oid);
 

--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -8624,51 +8624,60 @@ YbNewSelect(Relation rel, const YbcPgPrepareParameters *prepare_params)
 }
 
 YbcPgStatement
-YbNewUpdateForDb(Oid db_oid, Relation rel, YbcPgTransactionSetting transaction_setting)
+YbNewUpdateForDb(Oid db_oid, Relation rel, YbcPgTransactionSetting transaction_setting,
+				 const char *query_comment)
 {
 	YbcPgStatement result = NULL;
 	HandleYBStatus(YBCPgNewUpdate(db_oid, YbGetRelfileNodeId(rel),
-								  YbBuildTableLocalityInfo(rel), transaction_setting, &result));
+								  YbBuildTableLocalityInfo(rel), transaction_setting, &result,
+								  query_comment));
 	return result;
 }
 
 YbcPgStatement
-YbNewUpdate(Relation rel, YbcPgTransactionSetting transaction_setting)
+YbNewUpdate(Relation rel, YbcPgTransactionSetting transaction_setting,
+			const char *query_comment)
 {
-	return YbNewUpdateForDb(YBCGetDatabaseOid(rel), rel, transaction_setting);
+	return YbNewUpdateForDb(YBCGetDatabaseOid(rel), rel, transaction_setting, query_comment);
 }
 
 YbcPgStatement
-YbNewDelete(Relation rel, YbcPgTransactionSetting transaction_setting)
+YbNewDelete(Relation rel, YbcPgTransactionSetting transaction_setting,
+			const char *query_comment)
 {
 	YbcPgStatement result = NULL;
 	HandleYBStatus(YBCPgNewDelete(YBCGetDatabaseOid(rel), YbGetRelfileNodeId(rel),
-								  YbBuildTableLocalityInfo(rel), transaction_setting, &result));
+								  YbBuildTableLocalityInfo(rel), transaction_setting, &result,
+								  query_comment));
 	return result;
 }
 
 YbcPgStatement
-YbNewInsertForDb(Oid db_oid, Relation rel, YbcPgTransactionSetting transaction_setting)
+YbNewInsertForDb(Oid db_oid, Relation rel, YbcPgTransactionSetting transaction_setting,
+				 const char *query_comment)
 {
 	YbcPgStatement result = NULL;
 	HandleYBStatus(YBCPgNewInsert(db_oid, YbGetRelfileNodeId(rel),
-								  YbBuildTableLocalityInfo(rel), transaction_setting, &result));
+								  YbBuildTableLocalityInfo(rel), transaction_setting, &result,
+								  query_comment));
 	return result;
 }
 
 YbcPgStatement
-YbNewInsert(Relation rel, YbcPgTransactionSetting transaction_setting)
+YbNewInsert(Relation rel, YbcPgTransactionSetting transaction_setting,
+			const char *query_comment)
 {
-	return YbNewInsertForDb(YBCGetDatabaseOid(rel), rel, transaction_setting);
+	return YbNewInsertForDb(YBCGetDatabaseOid(rel), rel, transaction_setting, query_comment);
 }
 
 extern YbcPgStatement
-YbNewInsertBlock(Relation rel, YbcPgTransactionSetting transaction_setting)
+YbNewInsertBlock(Relation rel, YbcPgTransactionSetting transaction_setting,
+				 const char *query_comment)
 {
 	YbcPgStatement result = NULL;
 	HandleYBStatus(YBCPgNewInsertBlock(YBCGetDatabaseOid(rel), YbGetRelfileNodeId(rel),
 									   YbBuildTableLocalityInfo(rel), transaction_setting,
-									   &result));
+									   &result, query_comment));
 	return result;
 }
 

--- a/src/postgres/src/include/parser/parser.h
+++ b/src/postgres/src/include/parser/parser.h
@@ -65,4 +65,7 @@ extern List *raw_parser(const char *str, RawParseMode mode);
 extern List *SystemFuncName(char *name);
 extern TypeName *SystemTypeName(char *name);
 
+/* Extract SQL comment for CDC tracking */
+extern char *extract_first_sql_comment(const char *query_string);
+
 #endif							/* PARSER_H */

--- a/src/postgres/src/include/pg_yb_utils.h
+++ b/src/postgres/src/include/pg_yb_utils.h
@@ -1564,18 +1564,24 @@ extern YbcPgStatement YbNewSample(Relation rel, int targrows, double rstate_w,
 extern YbcPgStatement YbNewSelect(Relation rel, const YbcPgPrepareParameters *prepare_params);
 
 extern YbcPgStatement YbNewUpdateForDb(Oid db_oid, Relation rel,
-									  YbcPgTransactionSetting transaction_setting);
+									  YbcPgTransactionSetting transaction_setting,
+									  const char *query_comment);
 
-extern YbcPgStatement YbNewUpdate(Relation rel, YbcPgTransactionSetting transaction_setting);
+extern YbcPgStatement YbNewUpdate(Relation rel, YbcPgTransactionSetting transaction_setting,
+								  const char *query_comment);
 
-extern YbcPgStatement YbNewDelete(Relation rel, YbcPgTransactionSetting transaction_setting);
+extern YbcPgStatement YbNewDelete(Relation rel, YbcPgTransactionSetting transaction_setting,
+								  const char *query_comment);
 
 extern YbcPgStatement YbNewInsertForDb(Oid db_oid, Relation rel,
-									   YbcPgTransactionSetting transaction_setting);
+									   YbcPgTransactionSetting transaction_setting,
+									   const char *query_comment);
 
-extern YbcPgStatement YbNewInsert(Relation rel, YbcPgTransactionSetting transaction_setting);
+extern YbcPgStatement YbNewInsert(Relation rel, YbcPgTransactionSetting transaction_setting,
+								  const char *query_comment);
 
-extern YbcPgStatement YbNewInsertBlock(Relation rel, YbcPgTransactionSetting transaction_setting);
+extern YbcPgStatement YbNewInsertBlock(Relation rel, YbcPgTransactionSetting transaction_setting,
+									   const char *query_comment);
 
 extern YbcPgStatement YbNewTruncateColocated(Relation rel,
 											 YbcPgTransactionSetting transaction_setting);

--- a/src/yb/cdc/CMakeLists.txt
+++ b/src/yb/cdc/CMakeLists.txt
@@ -117,7 +117,8 @@ ADD_YB_LIBRARY(
     cdc
     SRCS ${CDC_SRCS}
     DEPS protobuf cdc_service_proto cdc_util master_proto consensus_proto log_proto log consensus
-         yrpc server_common server_process tablet yb_util ql_util gutil yb_client)
+         yrpc server_common server_process tablet yb_util ql_util gutil yb_client
+         yb_pggate_flags)
 
 # Tests
 set(YB_TEST_LINK_LIBS integration-tests ${YB_MIN_TEST_LIBS})

--- a/src/yb/cdc/cdc_service.proto
+++ b/src/yb/cdc/cdc_service.proto
@@ -560,6 +560,12 @@ message RowMessage {
 
   // Replication origin id associated with the transaction. Only set for COMMIT Ops.
   optional uint32 xrepl_origin_id = 19;
+
+  // SQL comment extracted from the leading block comment of the query (/* comment */).
+  // Set on INSERT/UPDATE/DELETE ops when cdc_propagate_query_comments is enabled.
+  // For multi-shard transactions, reflects the comment from the first DML statement
+  // in the transaction; per-statement granularity is not supported in that case.
+  optional string query_comment = 20;
 }
 
 message CDCSDKProtoRecordPB {

--- a/src/yb/common/pgsql_protocol.proto
+++ b/src/yb/common/pgsql_protocol.proto
@@ -321,6 +321,9 @@ message PgsqlWriteRequestPB {
 
   // Table space oid of the table specified by table_id.
   optional uint32 tablespace_oid = 29;
+
+  // SQL comment from query for CDC tracking
+  optional string query_comment = 30;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/src/yb/integration-tests/cdcsdk_ysql-test.cc
+++ b/src/yb/integration-tests/cdcsdk_ysql-test.cc
@@ -35,6 +35,7 @@
 
 DECLARE_bool(ysql_use_packed_row_v2);
 DECLARE_bool(ysql_mark_update_packed_row);
+DECLARE_bool(cdc_propagate_query_comments);
 
 namespace yb {
 
@@ -12833,6 +12834,245 @@ TEST_F(CDCSDKYsqlTest, TestHitDeadlineOnWalReadMidTransaction) {
 
   // 1 DDL + 200 INSERTs + 1 BEGIN + 1 COMMIT = 203 records
   ASSERT_EQ(record_count, 203);
+}
+
+// Verify that SQL comments (/* ... */) are propagated to CDC events as query_comment
+// for single-shard (auto-commit) writes.
+TEST_F(CDCSDKYsqlTest, YB_DISABLE_TEST_IN_TSAN(QueryCommentSingleShard)) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdc_propagate_query_comments) = true;
+  auto tablets = ASSERT_RESULT(SetUpCluster());
+  ASSERT_EQ(tablets.size(), 1);
+  xrepl::StreamId stream_id = ASSERT_RESULT(CreateDBStreamWithReplicationSlot());
+  auto set_resp = ASSERT_RESULT(SetCDCCheckpoint(stream_id, tablets));
+  ASSERT_FALSE(set_resp.has_error());
+
+  // Insert with SQL comment (single-shard, auto-commit)
+  auto conn = ASSERT_RESULT(test_cluster_.ConnectToDB(kNamespaceName));
+  ASSERT_OK(conn.Execute("/* pod_id=pod42 */ INSERT INTO test_table VALUES (1, 2)"));
+  // Insert without comment
+  ASSERT_OK(conn.Execute("INSERT INTO test_table VALUES (2, 3)"));
+
+  GetChangesResponsePB change_resp;
+  ASSERT_OK(WaitForGetChangesToFetchRecords(&change_resp, stream_id, tablets, 2));
+
+  int inserts_with_comment = 0;
+  int inserts_without_comment = 0;
+  for (const auto& record : change_resp.cdc_sdk_proto_records()) {
+    if (record.row_message().op() == RowMessage::INSERT) {
+      if (record.row_message().has_query_comment()) {
+        ASSERT_EQ(record.row_message().query_comment(), "pod_id=pod42");
+        inserts_with_comment++;
+      } else {
+        inserts_without_comment++;
+      }
+    }
+  }
+  ASSERT_EQ(inserts_with_comment, 1);
+  ASSERT_EQ(inserts_without_comment, 1);
+}
+
+// Verify that SQL comments are propagated to CDC events for transactional writes
+// (explicit BEGIN/COMMIT).
+TEST_F(CDCSDKYsqlTest, YB_DISABLE_TEST_IN_TSAN(QueryCommentTransactional)) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdc_propagate_query_comments) = true;
+  // Disable packed rows so that UPDATE operations are correctly classified as UPDATE
+  // in CDC records. With packed row V1 (the default), UPDATEs appear as INSERTs because
+  // V1 format lacks an update flag in the header.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_ysql_enable_packed_row) = false;
+  auto tablets = ASSERT_RESULT(SetUpCluster());
+  ASSERT_EQ(tablets.size(), 1);
+  xrepl::StreamId stream_id = ASSERT_RESULT(CreateDBStreamWithReplicationSlot());
+  auto set_resp = ASSERT_RESULT(SetCDCCheckpoint(stream_id, tablets));
+  ASSERT_FALSE(set_resp.has_error());
+
+  // Transactional insert with SQL comment
+  auto conn = ASSERT_RESULT(test_cluster_.ConnectToDB(kNamespaceName));
+  ASSERT_OK(conn.Execute("BEGIN"));
+  ASSERT_OK(conn.Execute("/* shop_id=12345 */ INSERT INTO test_table VALUES (1, 2)"));
+  ASSERT_OK(conn.Execute("COMMIT"));
+
+  // Transactional update with different comment
+  ASSERT_OK(conn.Execute("BEGIN"));
+  ASSERT_OK(conn.Execute("/* request_id=abc */ UPDATE test_table SET value_1 = 99 WHERE key = 1"));
+  ASSERT_OK(conn.Execute("COMMIT"));
+
+  GetChangesResponsePB change_resp;
+  // Expect 1 INSERT + 1 UPDATE (plus DDL, BEGIN, COMMIT records)
+  ASSERT_OK(WaitForGetChangesToFetchRecords(&change_resp, stream_id, tablets, 2));
+
+  std::string insert_comment;
+  std::string update_comment;
+  for (const auto& record : change_resp.cdc_sdk_proto_records()) {
+    if (record.row_message().op() == RowMessage::INSERT &&
+        record.row_message().has_query_comment()) {
+      insert_comment = record.row_message().query_comment();
+    }
+    if (record.row_message().op() == RowMessage::UPDATE &&
+        record.row_message().has_query_comment()) {
+      update_comment = record.row_message().query_comment();
+    }
+  }
+  ASSERT_EQ(insert_comment, "shop_id=12345");
+  ASSERT_EQ(update_comment, "request_id=abc");
+}
+
+// Verify that query_comment is NOT propagated when cdc_propagate_query_comments is false.
+TEST_F(CDCSDKYsqlTest, YB_DISABLE_TEST_IN_TSAN(QueryCommentDisabledByFlag)) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdc_propagate_query_comments) = false;
+  auto tablets = ASSERT_RESULT(SetUpCluster());
+  ASSERT_EQ(tablets.size(), 1);
+  xrepl::StreamId stream_id = ASSERT_RESULT(CreateDBStreamWithReplicationSlot());
+  auto set_resp = ASSERT_RESULT(SetCDCCheckpoint(stream_id, tablets));
+  ASSERT_FALSE(set_resp.has_error());
+
+  auto conn = ASSERT_RESULT(test_cluster_.ConnectToDB(kNamespaceName));
+  ASSERT_OK(conn.Execute("/* pod_id=pod42 */ INSERT INTO test_table VALUES (1, 2)"));
+
+  GetChangesResponsePB change_resp;
+  ASSERT_OK(WaitForGetChangesToFetchRecords(&change_resp, stream_id, tablets, 1));
+
+  for (const auto& record : change_resp.cdc_sdk_proto_records()) {
+    if (record.row_message().op() == RowMessage::INSERT) {
+      ASSERT_FALSE(record.row_message().has_query_comment());
+    }
+  }
+}
+
+// Verify edge cases: empty comment, comment embedded in string literal (should not match),
+// and mid-query comment (should not match since only leading comments are extracted).
+TEST_F(CDCSDKYsqlTest, YB_DISABLE_TEST_IN_TSAN(QueryCommentEdgeCases)) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdc_propagate_query_comments) = true;
+  auto tablets = ASSERT_RESULT(SetUpCluster());
+  ASSERT_EQ(tablets.size(), 1);
+  xrepl::StreamId stream_id = ASSERT_RESULT(CreateDBStreamWithReplicationSlot());
+  auto set_resp = ASSERT_RESULT(SetCDCCheckpoint(stream_id, tablets));
+  ASSERT_FALSE(set_resp.has_error());
+
+  auto conn = ASSERT_RESULT(test_cluster_.ConnectToDB(kNamespaceName));
+
+  // Empty comment: /* */ — should not produce query_comment
+  ASSERT_OK(conn.Execute("/*  */ INSERT INTO test_table VALUES (1, 2)"));
+  // Mid-query comment: should not produce query_comment (comment is not leading)
+  ASSERT_OK(conn.Execute("INSERT INTO test_table VALUES (2, 3) /* trailing_comment */"));
+  // Query hint only: /*+ SeqScan(t) */ — optimizer directive, should be rejected
+  ASSERT_OK(conn.Execute("/*+ SeqScan(test_table) */ INSERT INTO test_table VALUES (3, 4)"));
+  // Query hint followed by real comment — hint skipped, comment extracted
+  ASSERT_OK(conn.Execute(
+      "/*+ SeqScan(test_table) */ /* hint_then_comment=yes */ INSERT INTO test_table VALUES (4, 5)"));
+  // Valid leading comment
+  ASSERT_OK(conn.Execute("/* valid=yes */ INSERT INTO test_table VALUES (5, 6)"));
+
+  GetChangesResponsePB change_resp;
+  ASSERT_OK(WaitForGetChangesToFetchRecords(&change_resp, stream_id, tablets, 5));
+
+  std::map<int32_t, std::string> key_to_comment;
+  int without_comment = 0;
+  for (const auto& record : change_resp.cdc_sdk_proto_records()) {
+    if (record.row_message().op() == RowMessage::INSERT) {
+      if (record.row_message().has_query_comment()) {
+        // First column (key) value
+        int32_t key = record.row_message().new_tuple(0).datum_int32();
+        key_to_comment[key] = record.row_message().query_comment();
+      } else {
+        without_comment++;
+      }
+    }
+  }
+  ASSERT_EQ(key_to_comment.size(), 2);
+  ASSERT_EQ(key_to_comment[4], "hint_then_comment=yes");
+  ASSERT_EQ(key_to_comment[5], "valid=yes");
+  ASSERT_EQ(without_comment, 3);
+}
+
+// Verify that SQL comments are propagated for single-shard DELETE and UPDATE operations.
+TEST_F(CDCSDKYsqlTest, YB_DISABLE_TEST_IN_TSAN(QueryCommentDeleteAndUpdate)) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdc_propagate_query_comments) = true;
+  // Disable packed rows so that UPDATE operations are correctly classified as UPDATE
+  // in CDC records. With packed row V1 (the default), UPDATEs appear as INSERTs because
+  // V1 format lacks an update flag in the header.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_ysql_enable_packed_row) = false;
+  auto tablets = ASSERT_RESULT(SetUpCluster());
+  ASSERT_EQ(tablets.size(), 1);
+  xrepl::StreamId stream_id = ASSERT_RESULT(CreateDBStreamWithReplicationSlot());
+  auto set_resp = ASSERT_RESULT(SetCDCCheckpoint(stream_id, tablets));
+  ASSERT_FALSE(set_resp.has_error());
+
+  auto conn = ASSERT_RESULT(test_cluster_.ConnectToDB(kNamespaceName));
+  // Insert a row first (no comment)
+  ASSERT_OK(conn.Execute("INSERT INTO test_table VALUES (1, 2)"));
+  // Update with comment
+  ASSERT_OK(conn.Execute("/* update_ctx=u1 */ UPDATE test_table SET value_1 = 99 WHERE key = 1"));
+  // Delete with comment
+  ASSERT_OK(conn.Execute("/* delete_ctx=d1 */ DELETE FROM test_table WHERE key = 1"));
+
+  GetChangesResponsePB change_resp;
+  // 1 INSERT + 1 UPDATE + 1 DELETE
+  ASSERT_OK(WaitForGetChangesToFetchRecords(&change_resp, stream_id, tablets, 3));
+
+  std::string update_comment;
+  std::string delete_comment;
+  for (const auto& record : change_resp.cdc_sdk_proto_records()) {
+    if (record.row_message().op() == RowMessage::UPDATE &&
+        record.row_message().has_query_comment()) {
+      update_comment = record.row_message().query_comment();
+    }
+    if (record.row_message().op() == RowMessage::DELETE &&
+        record.row_message().has_query_comment()) {
+      delete_comment = record.row_message().query_comment();
+    }
+  }
+  ASSERT_EQ(update_comment, "update_ctx=u1");
+  ASSERT_EQ(delete_comment, "delete_ctx=d1");
+}
+
+// Verify that SQL comments are propagated through the intent/APPLY path for
+// multi-shard transactional writes. With multiple tablets, writes go through
+// distributed transactions (intents → APPLY), exercising the txn_query_comments
+// stashing logic in GetWALRecords/GetConsistentWALRecords.
+TEST_F(CDCSDKYsqlTest, YB_DISABLE_TEST_IN_TSAN(QueryCommentMultiTabletTransaction)) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdc_propagate_query_comments) = true;
+
+  ASSERT_OK(SetUpWithParams(3, 1, false));
+  const uint32_t num_tablets = 3;
+  auto table = ASSERT_RESULT(
+      CreateTable(&test_cluster_, kNamespaceName, kTableName, num_tablets));
+  google::protobuf::RepeatedPtrField<master::TabletLocationsPB> tablets;
+  ASSERT_OK(test_client()->GetTablets(table, 0, &tablets, nullptr));
+  ASSERT_EQ(tablets.size(), num_tablets);
+
+  xrepl::StreamId stream_id = ASSERT_RESULT(CreateDBStreamWithReplicationSlot());
+  for (uint32_t idx = 0; idx < num_tablets; idx++) {
+    auto resp = ASSERT_RESULT(
+        SetCDCCheckpoint(stream_id, tablets, OpId::Min(), kuint64max, true, idx));
+    ASSERT_FALSE(resp.has_error());
+  }
+
+  // Transactional inserts spanning multiple tablets (different key ranges)
+  auto conn = ASSERT_RESULT(test_cluster_.ConnectToDB(kNamespaceName));
+  ASSERT_OK(conn.Execute("BEGIN"));
+  ASSERT_OK(conn.Execute("/* txn_ctx=multi_shard */ INSERT INTO test_table VALUES (1, 10)"));
+  ASSERT_OK(conn.Execute("/* txn_ctx=multi_shard */ INSERT INTO test_table VALUES (2, 20)"));
+  ASSERT_OK(conn.Execute("/* txn_ctx=multi_shard */ INSERT INTO test_table VALUES (3, 30)"));
+  ASSERT_OK(conn.Execute("COMMIT"));
+
+  // Collect records across all tablets
+  int inserts_with_comment = 0;
+  int total_inserts = 0;
+  for (uint32_t idx = 0; idx < num_tablets; idx++) {
+    GetChangesResponsePB change_resp =
+        ASSERT_RESULT(GetChangesFromCDC(stream_id, tablets, nullptr, idx));
+    for (const auto& record : change_resp.cdc_sdk_proto_records()) {
+      if (record.row_message().op() == RowMessage::INSERT) {
+        total_inserts++;
+        if (record.row_message().has_query_comment()) {
+          ASSERT_EQ(record.row_message().query_comment(), "txn_ctx=multi_shard");
+          inserts_with_comment++;
+        }
+      }
+    }
+  }
+  ASSERT_EQ(total_inserts, 3);
+  ASSERT_EQ(inserts_with_comment, total_inserts);
 }
 
 }  // namespace cdc

--- a/src/yb/tablet/operations.proto
+++ b/src/yb/tablet/operations.proto
@@ -107,6 +107,9 @@ message WritePB {
   optional uint64 start_time_micros = 21;
 
   optional uint32 xrepl_origin_id = 22;
+
+  // SQL comment for CDC tracking
+  optional string query_comment = 23;
 }
 
 message ChangeMetadataRequestPB {

--- a/src/yb/yql/pggate/pg_dml_write.cc
+++ b/src/yb/yql/pggate/pg_dml_write.cc
@@ -122,6 +122,11 @@ Status PgDmlWrite::Exec(ForceNonBufferable force_non_bufferable) {
   // First update protobuf with new bind values.
   RETURN_NOT_OK(UpdateAssignPBs());
 
+  // Add query comment to write request for CDC
+  if (!query_comment_.empty()) {
+    write_req_->dup_query_comment(query_comment_);
+  }
+
   if (write_req_->has_ybctid_column_value()) {
     auto* exprpb = write_req_->mutable_ybctid_column_value();
     CHECK(exprpb->has_value() && exprpb->value().has_binary_value())

--- a/src/yb/yql/pggate/pg_dml_write.h
+++ b/src/yb/yql/pggate/pg_dml_write.h
@@ -46,6 +46,11 @@ class PgDmlWrite : public PgDml {
 
   Status SetWriteTime(const HybridTime& write_time);
 
+  // Set SQL query comment for CDC tracking
+  void SetQueryComment(const std::string& comment) {
+    query_comment_ = comment;
+  }
+
   Status BindRow(uint64_t ybctid, YbcBindColumn* columns, int count);
 
   [[nodiscard]] bool packed() const { return packed_; }
@@ -75,6 +80,8 @@ class PgDmlWrite : public PgDml {
   int32_t rows_affected_count_ = 0;
 
   bool packed_;
+
+  std::string query_comment_;
 
  private:
   [[nodiscard]] ArenaList<LWPgsqlColRefPB>& ColRefPBs() override;

--- a/src/yb/yql/pggate/pggate.h
+++ b/src/yb/yql/pggate/pggate.h
@@ -552,12 +552,14 @@ class PgApiImpl {
   Result<PgStatement*> NewInsertBlock(
       const PgObjectId& table_id,
       const YbcPgTableLocalityInfo& locality_info,
-      YbcPgTransactionSetting transaction_setting);
+      YbcPgTransactionSetting transaction_setting,
+      const char *query_comment = nullptr);
 
   Status NewInsert(const PgObjectId& table_id,
                    const YbcPgTableLocalityInfo& locality_info,
                    YbcPgTransactionSetting transaction_setting,
-                   PgStatement **handle);
+                   PgStatement **handle,
+                   const char *query_comment = nullptr);
 
   Status ExecInsert(PgStatement *handle);
 
@@ -572,7 +574,8 @@ class PgApiImpl {
   Status NewUpdate(const PgObjectId& table_id,
                    const YbcPgTableLocalityInfo& locality_info,
                    YbcPgTransactionSetting transaction_setting,
-                   PgStatement **handle);
+                   PgStatement **handle,
+                   const char *query_comment = nullptr);
 
   Status ExecUpdate(PgStatement *handle);
 
@@ -581,7 +584,8 @@ class PgApiImpl {
   Status NewDelete(const PgObjectId& table_id,
                    const YbcPgTableLocalityInfo& locality_info,
                    YbcPgTransactionSetting transaction_setting,
-                   PgStatement **handle);
+                   PgStatement **handle,
+                   const char *query_comment = nullptr);
 
   Status ExecDelete(PgStatement *handle);
 

--- a/src/yb/yql/pggate/pggate_flags.cc
+++ b/src/yb/yql/pggate/pggate_flags.cc
@@ -195,3 +195,11 @@ DEFINE_RUNTIME_double(max_buffer_size_to_rpc_limit_ratio, 0.9, "the max buffer s
 DEFINE_RUNTIME_bool(ysql_optimize_index_row_rewrites, true, "When enabled, operations that rewrite "
     "index rows will be optimized to reduce the number of network round trips.");
 TAG_FLAG(ysql_optimize_index_row_rewrites, advanced);
+
+DEFINE_RUNTIME_bool(cdc_propagate_query_comments, false,
+                    "If 'true', SQL block comments (/* ... */) are extracted from queries and "
+                    "propagated through the write path into CDC change events as query_comment. "
+                    "This allows CDC consumers to correlate change events with application-level "
+                    "context such as tenant ID or request ID. For multi-shard transactions, the "
+                    "comment from the first DML statement is used for all records in the "
+                    "transaction.");

--- a/src/yb/yql/pggate/test/pggate_test_catalog.cc
+++ b/src/yb/yql/pggate/test/pggate_test_catalog.cc
@@ -78,7 +78,7 @@ TEST_F(PggateTestCatalog, TestDml) {
   // Allocate new insert.
   CHECK_YBC_STATUS(YBCPgNewInsert(
       kDefaultDatabaseOid, tab_oid, kDefaultTableLocality,
-      YbcPgTransactionSetting::YB_TRANSACTIONAL, &pg_stmt));
+      YbcPgTransactionSetting::YB_TRANSACTIONAL, &pg_stmt, nullptr /* query_comment */));
 
   // Allocate constant expressions.
   // TODO(neil) We can also allocate expression with bind.
@@ -258,7 +258,8 @@ TEST_F(PggateTestCatalog, TestDml) {
   // UPDATE ----------------------------------------------------------------------------------------
   // Allocate new update.
   CHECK_YBC_STATUS(YBCPgNewUpdate(
-      kDefaultDatabaseOid, tab_oid, kDefaultTableLocality, YB_TRANSACTIONAL, &pg_stmt));
+      kDefaultDatabaseOid, tab_oid, kDefaultTableLocality, YB_TRANSACTIONAL, &pg_stmt,
+      nullptr /* query_comment */));
 
   // Allocate constant expressions.
   // TODO(neil) We can also allocate expression with bind.
@@ -422,7 +423,7 @@ TEST_F(PggateTestCatalog, TestCopydb) {
 
   CHECK_YBC_STATUS(YBCPgNewInsert(
       kDefaultDatabaseOid, tab_oid, kDefaultTableLocality,
-      YbcPgTransactionSetting::YB_TRANSACTIONAL, &pg_stmt));
+      YbcPgTransactionSetting::YB_TRANSACTIONAL, &pg_stmt, nullptr /* query_comment */));
 
   YbcPgExpr expr_key;
   YbcPgExpr expr_value;

--- a/src/yb/yql/pggate/test/pggate_test_delete.cc
+++ b/src/yb/yql/pggate/test/pggate_test_delete.cc
@@ -72,7 +72,7 @@ TEST_F(PggateTestDelete, TestDelete) {
   // Allocate new insert.
   CHECK_YBC_STATUS(YBCPgNewInsert(
       kDefaultDatabaseOid, tab_oid, kDefaultTableLocality,
-      YbcPgTransactionSetting::YB_TRANSACTIONAL, &pg_stmt));
+      YbcPgTransactionSetting::YB_TRANSACTIONAL, &pg_stmt, nullptr /* query_comment */));
 
   // Allocate constant expressions.
   // TODO(neil) We can also allocate expression with bind.
@@ -126,7 +126,8 @@ TEST_F(PggateTestDelete, TestDelete) {
   // DELETE ----------------------------------------------------------------------------------------
   // Allocate new delete.
   CHECK_YBC_STATUS(YBCPgNewDelete(
-      kDefaultDatabaseOid, tab_oid, kDefaultTableLocality, YB_TRANSACTIONAL, &pg_stmt));
+      kDefaultDatabaseOid, tab_oid, kDefaultTableLocality, YB_TRANSACTIONAL, &pg_stmt,
+      nullptr /* query_comment */));
 
   // Allocate constant expressions.
   // TODO(neil) We can also allocate expression with bind.

--- a/src/yb/yql/pggate/test/pggate_test_select.cc
+++ b/src/yb/yql/pggate/test/pggate_test_select.cc
@@ -99,7 +99,7 @@ TEST_F(PggateTestSelect, TestSelectOneTablet) {
   // Allocate new insert.
   CHECK_YBC_STATUS(YBCPgNewInsert(
       kDefaultDatabaseOid, tab_oid, kDefaultTableLocality,
-      YbcPgTransactionSetting::YB_TRANSACTIONAL, &pg_stmt));
+      YbcPgTransactionSetting::YB_TRANSACTIONAL, &pg_stmt, nullptr /* query_comment */));
 
   // Allocate constant expressions.
   // TODO(neil) We can also allocate expression with bind.
@@ -726,7 +726,7 @@ class PggateTestBucketizedSelect : public PggateTest {
     YbcPgStatement pg_stmt;
     CHECK_YBC_STATUS(YBCPgNewInsert(
         kDefaultDatabaseOid, tab_oid, kDefaultTableLocality,
-        YbcPgTransactionSetting::YB_TRANSACTIONAL, &pg_stmt));
+        YbcPgTransactionSetting::YB_TRANSACTIONAL, &pg_stmt, nullptr /* query_comment */));
 
     // Allocate constant expressions.
     YbcPgExpr expr_bkt;

--- a/src/yb/yql/pggate/test/pggate_test_select_inequality.cc
+++ b/src/yb/yql/pggate/test/pggate_test_select_inequality.cc
@@ -68,7 +68,7 @@ TEST_F(PggateTestSelectInequality, TestSelectInequality) {
   // Allocate new insert.
   CHECK_YBC_STATUS(YBCPgNewInsert(
       kDefaultDatabaseOid, tab_oid, kDefaultTableLocality,
-      YbcPgTransactionSetting::YB_TRANSACTIONAL, &pg_stmt));
+      YbcPgTransactionSetting::YB_TRANSACTIONAL, &pg_stmt, nullptr /* query_comment */));
 
   int h = 0, r = 0;
   // Allocate constant expressions.

--- a/src/yb/yql/pggate/test/pggate_test_select_multi_tablets.cc
+++ b/src/yb/yql/pggate/test/pggate_test_select_multi_tablets.cc
@@ -110,7 +110,7 @@ TEST_F(PggateTestSelectMultiTablets, TestSelectMultiTablets) {
   // Allocate new insert.
   CHECK_YBC_STATUS(YBCPgNewInsert(
       kDefaultDatabaseOid, tab_oid, kDefaultTableLocality,
-      YbcPgTransactionSetting::YB_TRANSACTIONAL, &pg_stmt));
+      YbcPgTransactionSetting::YB_TRANSACTIONAL, &pg_stmt, nullptr /* query_comment */));
 
   // Allocate constant expressions.
   // TODO(neil) We can also allocate expression with bind.

--- a/src/yb/yql/pggate/test/pggate_test_table_size.cc
+++ b/src/yb/yql/pggate/test/pggate_test_table_size.cc
@@ -129,7 +129,7 @@ TEST_F(PggateTestTableSize, TestSimpleTable) {
   // Allocate new insert.
   CHECK_YBC_STATUS(YBCPgNewInsert(
       kDefaultDatabaseOid, kTabOid, kDefaultTableLocality,
-      YbcPgTransactionSetting::YB_TRANSACTIONAL, &pg_stmt));
+      YbcPgTransactionSetting::YB_TRANSACTIONAL, &pg_stmt, nullptr /* query_comment */));
 
   // Allocate constant expressions.
   int seed = 1;
@@ -233,7 +233,7 @@ TEST_F(PggateTestTableSize, TestMissingTablets) {
   // Allocate new insert.
   CHECK_YBC_STATUS(YBCPgNewInsert(
       kDefaultDatabaseOid, kTabOid, kDefaultTableLocality,
-      YbcPgTransactionSetting::YB_TRANSACTIONAL, &pg_stmt));
+      YbcPgTransactionSetting::YB_TRANSACTIONAL, &pg_stmt, nullptr /* query_comment */));
 
   // Allocate constant expressions.
   int seed = 1;

--- a/src/yb/yql/pggate/test/pggate_test_update.cc
+++ b/src/yb/yql/pggate/test/pggate_test_update.cc
@@ -74,7 +74,7 @@ TEST_F(PggateTestUpdate, TestUpdate) {
   // Allocate new insert.
   CHECK_YBC_STATUS(YBCPgNewInsert(
       kDefaultDatabaseOid, tab_oid, kDefaultTableLocality,
-      YbcPgTransactionSetting::YB_TRANSACTIONAL, &pg_stmt));
+      YbcPgTransactionSetting::YB_TRANSACTIONAL, &pg_stmt, nullptr /* query_comment */));
 
   // Allocate constant expressions.
   // TODO(neil) We can also allocate expression with bind.
@@ -127,7 +127,8 @@ TEST_F(PggateTestUpdate, TestUpdate) {
   // UPDATE ----------------------------------------------------------------------------------------
   // Allocate new update.
   CHECK_YBC_STATUS(YBCPgNewUpdate(
-      kDefaultDatabaseOid, tab_oid, kDefaultTableLocality, YB_TRANSACTIONAL, &pg_stmt));
+      kDefaultDatabaseOid, tab_oid, kDefaultTableLocality, YB_TRANSACTIONAL, &pg_stmt,
+      nullptr /* query_comment */));
 
   // Allocate constant expressions.
   // TODO(neil) We can also allocate expression with bind.

--- a/src/yb/yql/pggate/ybc_gflags.cc
+++ b/src/yb/yql/pggate/ybc_gflags.cc
@@ -145,6 +145,7 @@ DECLARE_string(placement_cloud);
 DECLARE_string(placement_region);
 DECLARE_string(placement_zone);
 DECLARE_bool(TEST_ysql_yb_enable_listen_notify);
+DECLARE_bool(cdc_propagate_query_comments);
 
 namespace {
 
@@ -246,6 +247,7 @@ const YbcPgGFlagsAccessor* YBCGetGFlags() {
       .TEST_delay_after_table_analyze_ms = &FLAGS_TEST_delay_after_table_analyze_ms,
       .TEST_ysql_yb_enable_listen_notify = &FLAGS_TEST_ysql_yb_enable_listen_notify,
       .TEST_enable_obj_tuple_locks = &FLAGS_TEST_enable_obj_tuple_locks,
+      .cdc_propagate_query_comments = &FLAGS_cdc_propagate_query_comments,
   };
   // clang-format on
   return &accessor;

--- a/src/yb/yql/pggate/ybc_gflags.h
+++ b/src/yb/yql/pggate/ybc_gflags.h
@@ -77,6 +77,7 @@ typedef struct {
   const int64_t*  TEST_delay_after_table_analyze_ms;
   const bool*     TEST_ysql_yb_enable_listen_notify;
   const bool*     TEST_enable_obj_tuple_locks;
+  const bool*     cdc_propagate_query_comments;
 } YbcPgGFlagsAccessor;
 
 const YbcPgGFlagsAccessor* YBCGetGFlags();

--- a/src/yb/yql/pggate/ybc_pggate.cc
+++ b/src/yb/yql/pggate/ybc_pggate.cc
@@ -1589,9 +1589,10 @@ YbcStatus YBCPgNewInsertBlock(
     YbcPgOid table_oid,
     YbcPgTableLocalityInfo locality_info,
     YbcPgTransactionSetting transaction_setting,
-    YbcPgStatement *handle) {
+    YbcPgStatement *handle,
+    const char *query_comment) {
   auto result = pgapi->NewInsertBlock(
-      PgObjectId(database_oid, table_oid), locality_info, transaction_setting);
+      PgObjectId(database_oid, table_oid), locality_info, transaction_setting, query_comment);
   if (result.ok()) {
     *handle = *result;
     return nullptr;
@@ -1603,9 +1604,10 @@ YbcStatus YBCPgNewInsert(const YbcPgOid database_oid,
                          const YbcPgOid table_relfilenode_oid,
                          YbcPgTableLocalityInfo locality_info,
                          YbcPgTransactionSetting transaction_setting,
-                         YbcPgStatement *handle) {
+                         YbcPgStatement *handle,
+                         const char *query_comment) {
   const PgObjectId table_id(database_oid, table_relfilenode_oid);
-  return ToYBCStatus(pgapi->NewInsert(table_id, locality_info, transaction_setting, handle));
+  return ToYBCStatus(pgapi->NewInsert(table_id, locality_info, transaction_setting, handle, query_comment));
 }
 
 YbcStatus YBCPgExecInsert(YbcPgStatement handle) {
@@ -1635,9 +1637,10 @@ YbcStatus YBCPgNewUpdate(const YbcPgOid database_oid,
                          const YbcPgOid table_relfilenode_oid,
                          YbcPgTableLocalityInfo locality_info,
                          YbcPgTransactionSetting transaction_setting,
-                         YbcPgStatement *handle) {
+                         YbcPgStatement *handle,
+                         const char *query_comment) {
   const PgObjectId table_id(database_oid, table_relfilenode_oid);
-  return ToYBCStatus(pgapi->NewUpdate(table_id, locality_info, transaction_setting, handle));
+  return ToYBCStatus(pgapi->NewUpdate(table_id, locality_info, transaction_setting, handle, query_comment));
 }
 
 YbcStatus YBCPgExecUpdate(YbcPgStatement handle) {
@@ -1649,9 +1652,10 @@ YbcStatus YBCPgNewDelete(const YbcPgOid database_oid,
                          const YbcPgOid table_relfilenode_oid,
                          YbcPgTableLocalityInfo locality_info,
                          YbcPgTransactionSetting transaction_setting,
-                         YbcPgStatement *handle) {
+                         YbcPgStatement *handle,
+                         const char *query_comment) {
   const PgObjectId table_id(database_oid, table_relfilenode_oid);
-  return ToYBCStatus(pgapi->NewDelete(table_id, locality_info, transaction_setting, handle));
+  return ToYBCStatus(pgapi->NewDelete(table_id, locality_info, transaction_setting, handle, query_comment));
 }
 
 YbcStatus YBCPgExecDelete(YbcPgStatement handle) {

--- a/src/yb/yql/pggate/ybc_pggate.h
+++ b/src/yb/yql/pggate/ybc_pggate.h
@@ -647,13 +647,15 @@ YbcStatus YBCPgNewInsertBlock(
     YbcPgOid table_oid,
     YbcPgTableLocalityInfo locality_info,
     YbcPgTransactionSetting transaction_setting,
-    YbcPgStatement *handle);
+    YbcPgStatement *handle,
+    const char *query_comment);
 
 YbcStatus YBCPgNewInsert(YbcPgOid database_oid,
                          YbcPgOid table_relfilenode_oid,
                          YbcPgTableLocalityInfo locality_info,
                          YbcPgTransactionSetting transaction_setting,
-                         YbcPgStatement *handle);
+                         YbcPgStatement *handle,
+                         const char *query_comment);
 
 YbcStatus YBCPgExecInsert(YbcPgStatement handle);
 
@@ -668,7 +670,8 @@ YbcStatus YBCPgNewUpdate(YbcPgOid database_oid,
                          YbcPgOid table_relfilenode_oid,
                          YbcPgTableLocalityInfo locality_info,
                          YbcPgTransactionSetting transaction_setting,
-                         YbcPgStatement *handle);
+                         YbcPgStatement *handle,
+                         const char *query_comment);
 
 YbcStatus YBCPgExecUpdate(YbcPgStatement handle);
 
@@ -677,7 +680,8 @@ YbcStatus YBCPgNewDelete(YbcPgOid database_oid,
                          YbcPgOid table_relfilenode_oid,
                          YbcPgTableLocalityInfo locality_info,
                          YbcPgTransactionSetting transaction_setting,
-                         YbcPgStatement *handle);
+                         YbcPgStatement *handle,
+                         const char *query_comment);
 
 YbcStatus YBCPgExecDelete(YbcPgStatement handle);
 


### PR DESCRIPTION
## Summary
- Extract SQL comments (`/* ... */`) at query parse time in the PostgreSQL layer and propagate them through the write path into CDC change events
- Works for both single-shard and transactional (multi-shard) writes
- Enables CDC consumers to correlate change events with application-level context (e.g., tenant ID, pod ID, request ID) embedded in SQL comments

## Motivation

When consuming CDC events from YugabyteDB, there is no way to correlate a change record back to the application context that produced it. This is especially important for multi-tenant systems where a single table serves multiple tenants — CDC consumers need to know which tenant a write belongs to.

SQL comments (`/* pod_id=42*/`) are a natural, non-intrusive way to attach metadata to queries. This PR makes those comments available in CDC output so downstream consumers can filter, route, or tag events accordingly.

## Feature flag

The entire feature is gated behind the GFlag `cdc_propagate_query_comments` (default `false`):
- **PG layer**: `extract_first_sql_comment()` returns NULL immediately when flag is false
- **Write path**: `write_query.cc` skips copying `query_comment` into the Raft `WritePB` when flag is false
- **Result**: zero WAL overhead and zero protobuf overhead on the Raft write path when the feature is disabled

## Limitations

- The comment must appear **before** the SQL statement: `/* pod_id=42 */ INSERT INTO ...`. Only leading comments (after optional whitespace) are extracted. Mid-query or trailing comments are ignored.

- **Comment size limit**: extracted comments are truncated to 1024 bytes to prevent unbounded WAL bloat.

- **One comment per transaction.** For transactional writes, the comment from the first WRITE_OP in the WAL is used for all records in that transaction. This is correct for the target use case where all statements in a request share the same application context (pod_id, shop_id, etc.).

- **Large transactions spanning GetChanges batches.** The `txn_query_comments` map is scoped to a single `GetChanges` call. If a transaction's intent WRITE_OP is in one batch and the APPLY record is in a later batch (very large transactions exceeding the response size), the comment may be missing from the later batch's records. In practice, the consistent WAL reader batches WRITE_OPs and APPLYs together by safe time, and the non-consistent reader with `skip_intents=false` keeps intents in the batch. This edge case only affects partially-streamed large transactions.

## How it works

### Single-shard writes (non-transactional)
1. **Parse time** (`parser.c`): `extract_first_sql_comment()` extracts the content between `/*` and `*/` from the beginning of the query string (gated by flag)
2. **PG executor** (`nodeModifyTable.c`, `ybModifyTable.c`, `pg_yb_utils.c`): The extracted comment is passed to pggate via `YBCPgNewInsert`/`Update`/`Delete` as a new `query_comment` parameter
3. **PgGate** (`pg_dml_write.cc`): Stores the comment on the write request and copies it into `PgsqlWriteRequestPB.query_comment` (field 30)
4. **Write path** (`write_query.cc`): Copies `query_comment` from the first PgsqlWriteRequestPB into the Raft `WriteRequestPB` (field 23 in `operations.proto`) — gated by flag
5. **CDC producer** (`cdcsdk_producer.cc`): `PopulateCDCSDKWriteRecord` reads `query_comment` from the WAL entry and sets it on `RowMessage.query_comment` (field 20 in `cdc_service.proto`)

### Transactional writes
1. Steps 1-4 are the same — the `query_comment` is written to the WAL in the intent WRITE_OP
2. **WAL scan** (`GetConsistentWALRecords`/`GetWALRecords`): Before skipping intent WRITE_OPs, the CDC producer extracts `query_comment` and stashes it in a `txn_query_comments` map keyed by `TransactionId`
3. **Intent processing**: When the APPLY record triggers `ProcessIntents` → `PopulateCDCSDKIntentRecord`, the stashed comment is looked up by transaction ID and set on each `RowMessage`

## Files changed (feature-specific)

| Layer | Files | What |
|-------|-------|------|
| Proto | `cdc_service.proto`, `pgsql_protocol.proto`, `operations.proto` | Added `query_comment` fields |
| Parser | `parser.c`, `parser.h` | `extract_first_sql_comment()` with position validation and size cap |
| PG executor | `nodeModifyTable.c`, `ybModifyTable.c`, `pg_yb_utils.c/h` | Pass comment to pggate |
| PgGate | `ybc_pggate.h/cc`, `pg_dml_write.h/cc`, `pggate.cc/h` | New parameter on Insert/Update/Delete/InsertBlock |
| GFlags | `pggate_flags.cc` (DEFINE), `ybc_gflags.h/cc`, `cdcsdk_producer.cc`, `write_query.cc` (DECLARE) | `cdc_propagate_query_comments` flag |
| Write path | `write_query.cc` | Copy comment into Raft write request (gated by flag) |
| CDC producer | `cdcsdk_producer.cc` | Emit comment in CDC `RowMessage`; `txn_query_comments` map uses `TransactionId` key |
| Tests | `cdcsdk_ysql-test.cc`, `pggate_test_*.cc` | Integration tests including edge cases and flag-disabled test |

## Test plan

- [x] Single-shard INSERT with comment: `query_comment` appears in CDC event
- [x] Single-shard INSERT without comment: no `query_comment` field in CDC event
- [x] Transactional INSERT (`BEGIN`/`COMMIT`) with comment: `query_comment` appears in CDC event
- [x] Transactional UPDATE (`BEGIN`/`COMMIT`) with comment: `query_comment` appears in CDC event
- [x] Flag disabled: no `query_comment` in CDC events even with comment in SQL
- [x] Edge cases: empty comment, trailing comment, mid-query comment — all correctly excluded
- [x] Single-shard DELETE and UPDATE with comment: `query_comment` appears in CDC event
- [x] Multi-tablet transactional writes: `query_comment` propagated via intent/APPLY path across tablets
- [x] C++ integration tests: `QueryCommentSingleShard`, `QueryCommentTransactional`, `QueryCommentDisabledByFlag`, `QueryCommentEdgeCases`, `QueryCommentDeleteAndUpdate`, `QueryCommentMultiTabletTransaction`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the YSQL write path, protobuf/WAL payloads, and CDC WAL processing; although gated by a default-off flag, enabling it changes replication output and adds per-write metadata that could impact WAL/CDC behavior if buggy.
> 
> **Overview**
> Adds an **optional SQL `query_comment` field to CDC records** and plumbs it end-to-end from YSQL statements into CDC output.
> 
> When the new runtime flag `cdc_propagate_query_comments` is enabled, the PG layer extracts the first leading `/* ... */` comment (trimmed and capped) and passes it through updated pggate statement constructors into `PgsqlWriteRequestPB`/raft `WritePB`, and the CDC producer emits it on `RowMessage` for both single-shard writes and distributed transactions (by stashing intent comments per `TransactionId` during WAL scans and reusing them when processing APPLY/intents). New integration tests validate inserts/updates/deletes, transactional vs single-shard behavior, edge cases, and flag-off behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2621b753ad60ff8f05d9fc35c4de4823f3a4068. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->