### PR TITLE
Fix yb-ctl-test.sh

### DIFF
--- a/.github/workflows/yb-ctl-test.yml
+++ b/.github/workflows/yb-ctl-test.yml
@@ -24,8 +24,8 @@ jobs:
 
     strategy:
       matrix:
-        os: [ macos-latest, ubuntu-18.04 ]
-        python-version: [ 2.7, 3.8 ]
+        os: [ macos-latest, ubuntu-24.04 ]
+        python-version: [ 3.8 ]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change limited to the workflow matrix; main risk is reduced coverage for older OS/Python versions or new failures on Ubuntu 24.04.
> 
> **Overview**
> Updates the `yb-ctl-test` GitHub Actions workflow matrix by moving Linux CI from `ubuntu-18.04` to `ubuntu-24.04` and dropping Python 2.7 testing, leaving only Python 3.8 across macOS and Ubuntu.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1f4c13c45c17c990b88ca7b06d41c08d0d3bb36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->