### PR TITLE
[doc][ybm] Fix alias

### DIFF
--- a/docs/content/stable/develop/tutorials/build-apps/_index.md
+++ b/docs/content/stable/develop/tutorials/build-apps/_index.md
@@ -6,7 +6,7 @@ description: Build an application using your favorite programming language.
 headcontent: Use your favorite programming language to build an application that uses YSQL or YCQL APIs
 aliases:
   - /stable/quick-start/build-apps/
-  - /stable/develop/tutorials/build-apps/
+  - /stable/develop/build-apps/
 menu:
   stable_develop:
     parent: tutorials


### PR DESCRIPTION
@netlify /stable/develop/build-apps/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs front-matter alias change only; low risk aside from potential redirect/link inconsistencies if other pages still reference the removed alias.
> 
> **Overview**
> Fixes routing for the `Build a hello world application` docs landing page by replacing the outdated alias `/stable/develop/tutorials/build-apps/` with `/stable/develop/build-apps/`, ensuring the old URL redirects to the intended page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64b757847d2b65ce7741288f3b98ad4b97b56e44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->