### PR TITLE
[DOC-1156][ybm] Back up roles

### DIFF
--- a/docs/content/stable/yugabyte-cloud/cloud-clusters/backup-clusters.md
+++ b/docs/content/stable/yugabyte-cloud/cloud-clusters/backup-clusters.md
@@ -124,6 +124,9 @@ To restore a backup of a cluster:
 1. Click **Next**.
 1. Select the target cluster.
 1. To rename databases, select the **Rename database/s before restoring** option and click **Next**.
+
+    Note that if the target cluster already has databases with the same name, you must rename databases.
+
 1. If you are renaming databases, enter a new name for the databases you want to rename in the **Assign new name** column.
 1. Click **Restore Now**.
 


### PR DESCRIPTION
@netlify /stable/yugabyte-cloud/cloud-clusters/backup-clusters/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates describing optional role/grant backup and restore behavior; no product logic changes.
> 
> **Overview**
> Updates the Aeon “Back up and restore clusters” doc to cover **YSQL role and grant backup/restore**.
> 
> Adds steps for selecting **Include roles and grants** when creating on-demand or scheduled backups, documents the new **Restore global roles** option during restore, and clarifies reconciliation behavior via a new “Grants and permissions” section (how existing roles/credentials are handled).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e5484177ae0d4090cb292f1ae3d0ac13e481541. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->