### PR TITLE
[docs] Update CDC savepoint limitation to reflect fix availability in recent releases

### DIFF
--- a/docs/content/stable/additional-features/change-data-capture/using-logical-replication/_index.md
+++ b/docs/content/stable/additional-features/change-data-capture/using-logical-replication/_index.md
@@ -111,7 +111,7 @@ For reference documentation, see [YugabyteDB Connector](./yugabytedb-connector/)
 
 - Support for point-in-time recovery (PITR) is tracked in issue {{<issue 10938>}}.
 
-- Support for transaction savepoints is tracked in issue {{<issue 10936>}}.
+- Transaction savepoints are supported starting from v2025.2.1.0. Issue {{<issue 10936>}}.
 
 - Support for enabling CDC on Read Replicas is tracked in issue {{<issue 11116>}}.
 

--- a/docs/content/stable/additional-features/change-data-capture/using-yugabytedb-grpc-replication/_index.md
+++ b/docs/content/stable/additional-features/change-data-capture/using-yugabytedb-grpc-replication/_index.md
@@ -73,7 +73,7 @@ For reference documentation, see [YugabyteDB gRPC Connector](./debezium-connecto
 In addition, CDC support for the following features will be added in upcoming releases:
 
 * Support for point-in-time recovery (PITR) is tracked in issue {{<issue 10938>}}.
-* Support for transaction savepoints is tracked in issue {{<issue 10936>}}.
+* Transaction savepoints are supported starting from v2025.2.1.0. Issue {{<issue 10936>}}.
 * Support for enabling CDC on Read Replicas is tracked in issue {{<issue 11116>}}.
 * Support for schema evolution with before image is tracked in issue {{<issue 15197>}}.
 

--- a/docs/content/v2024.2/additional-features/change-data-capture/using-logical-replication/_index.md
+++ b/docs/content/v2024.2/additional-features/change-data-capture/using-logical-replication/_index.md
@@ -109,7 +109,7 @@ For reference documentation, see [YugabyteDB Connector](./yugabytedb-connector/)
 
 - Support for point-in-time recovery (PITR) is tracked in issue {{<issue 10938>}}.
 
-- Support for transaction savepoints is tracked in issue {{<issue 10936>}}.
+- Transaction savepoints are supported starting from v2024.2.8.0. Issue {{<issue 10936>}}.
 
 - Support for enabling CDC on Read Replicas is tracked in issue {{<issue 11116>}}.
 

--- a/docs/content/v2024.2/additional-features/change-data-capture/using-yugabytedb-grpc-replication/_index.md
+++ b/docs/content/v2024.2/additional-features/change-data-capture/using-yugabytedb-grpc-replication/_index.md
@@ -65,7 +65,7 @@ For reference documentation, see [YugabyteDB gRPC Connector](./debezium-connecto
 In addition, CDC support for the following features will be added in upcoming releases:
 
 * Support for point-in-time recovery (PITR) is tracked in issue {{<issue 10938>}}.
-* Support for transaction savepoints is tracked in issue {{<issue 10936>}}.
+* Transaction savepoints are supported starting from v2024.2.8.0. Issue {{<issue 10936>}}.
 * Support for enabling CDC on Read Replicas is tracked in issue {{<issue 11116>}}.
 * Support for schema evolution with before image is tracked in issue {{<issue 15197>}}.
 

--- a/docs/content/v2025.1/additional-features/change-data-capture/using-logical-replication/_index.md
+++ b/docs/content/v2025.1/additional-features/change-data-capture/using-logical-replication/_index.md
@@ -111,7 +111,7 @@ For reference documentation, see [YugabyteDB Connector](./yugabytedb-connector/)
 
 - Support for point-in-time recovery (PITR) is tracked in issue {{<issue 10938>}}.
 
-- Support for transaction savepoints is tracked in issue {{<issue 10936>}}.
+- Transaction savepoints are supported starting from v2025.1.3.0. Issue {{<issue 10936>}}.
 
 - Support for enabling CDC on Read Replicas is tracked in issue {{<issue 11116>}}.
 

--- a/docs/content/v2025.1/additional-features/change-data-capture/using-yugabytedb-grpc-replication/_index.md
+++ b/docs/content/v2025.1/additional-features/change-data-capture/using-yugabytedb-grpc-replication/_index.md
@@ -70,7 +70,7 @@ For reference documentation, see [YugabyteDB gRPC Connector](./debezium-connecto
 In addition, CDC support for the following features will be added in upcoming releases:
 
 * Support for point-in-time recovery (PITR) is tracked in issue {{<issue 10938>}}.
-* Support for transaction savepoints is tracked in issue {{<issue 10936>}}.
+* Transaction savepoints are supported starting from v2025.1.3.0. Issue {{<issue 10936>}}.
 * Support for enabling CDC on Read Replicas is tracked in issue {{<issue 11116>}}.
 * Support for schema evolution with before image is tracked in issue {{<issue 15197>}}.
 


### PR DESCRIPTION
This PR does the following:

- Updated the transaction savepoints limitation in CDC logical replication docs (`v2024.2`,
  `v2025.1`, `stable`) to note that savepoints are supported starting from v2024.2.8.0,
  v2025.1.3.0, and v2025.2.1.0 respectively, replacing the previous "tracked in issue" wording.
- Updated the same savepoint limitation in CDC gRPC replication docs (`v2024.2`, `v2025.1`,
  `stable`) with the corresponding version availability.
- Left `v2024.1` and `v2.25` docs unchanged as the fix has not been backported to those release
  branches.
