### PR TITLE
Add architecture check to installation script

### DIFF
--- a/build-support/post_install.sh
+++ b/build-support/post_install.sh
@@ -15,49 +15,51 @@
 set -euo pipefail
 
 check_architecture() {
-    
+
     local release_root_arg="$1"
-    
+
     # Retrieve the expected architecture from the package metadata (if available)
     # If not available, return early since we can't perform the check
     local metadata_file="$release_root_arg/version_metadata.json"
     if [[ ! -f "$metadata_file" ]]; then
         return
     fi
-    
+
     # Ensure jq is available before attempting to parse the metadata.
     if ! command -v jq >/dev/null 2>&1; then
         echo "WARNING: 'jq' is not installed; skipping architecture check." >&2
         return
     fi
-    
+
     # Extract the "architecture" field from the JSON metadata using jq.
     # If we can't access the file, or if it's missing or null, return early.
     local package_arch
     if ! package_arch=$(jq -r '.architecture' "$metadata_file"); then
-        echo "WARNING: Failed to parse architecture from $metadata_file; skipping architecture check." >&2
+        echo "WARNING: Failed to parse architecture from" \
+        "$metadata_file; skipping architecture check." >&2
         return
     fi
     if [[ -z "$package_arch" || "$package_arch" == "null" ]]; then
         return
     fi
-    
+
     # Retrieve the system architecture
     local system_arch
     if ! system_arch=$(uname -m); then
         echo "WARNING: Could not determine system architecture; skipping check." >&2
         return
     fi
-    
+
     # Normalize: replace "arm64" with "aarch64" since these terms are often used interchangeably
     # Use for comparison but use original values for messaging
     local norm_sys norm_pkg
     norm_sys="${system_arch/arm64/aarch64}"
     norm_pkg="${package_arch/arm64/aarch64}"
-    
+
     # Warn if there's a mismatch between the system architecture and the package architecture.
     if [[ "$norm_sys" != "$norm_pkg" ]]; then
-        echo "WARNING: Architecture mismatch ($package_arch package on $system_arch system). Installation may not work." >&2
+        echo "WARNING: Architecture mismatch " \
+        "($package_arch package on $system_arch system). Installation may not work." >&2
         return
     fi
 


### PR DESCRIPTION
Adds an architecture check with warning or success message to post_install.sh.

Fixes #30422

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a best-effort preflight check that only emits warnings and does not alter install flow; low blast radius limited to the post-install script and optional `jq`/metadata presence.
> 
> **Overview**
> Adds a best-effort architecture preflight to `build-support/post_install.sh` that reads `version_metadata.json` (via `jq`) to compare the package’s expected architecture with `uname -m`.
> 
> The script now prints a warning and continues when metadata/`jq` is missing or architectures differ (normalizing `arm64` vs `aarch64`), and prints a success message when they match before running `bin/fips_install.sh`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99b82a785ab9e65060b9ec58fb981c29c7ceab26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->