### PR TITLE
DocDB: Plumb `target_namespace_id` through the clone tablet path

### DIFF
--- a/src/yb/master/clone/clone_state_manager-test.cc
+++ b/src/yb/master/clone/clone_state_manager-test.cc
@@ -440,6 +440,7 @@ TEST_F(CloneStateManagerTest, ScheduleCloneOps) {
     expected_req.set_target_snapshot_id(kTargetSnapshotId.data(), kTargetSnapshotId.size());
     expected_req.set_target_table_id(kTargetTableId);
     expected_req.set_target_namespace_name(kTargetNamespaceName);
+    expected_req.set_target_namespace_id(kTargetNamespaceId);
     expected_req.set_clone_request_seq_no(1);
     expected_req.set_target_pg_table_id(target_table_->pg_table_id());
     *expected_req.mutable_target_schema() = target_table_->LockForRead()->schema();

--- a/src/yb/master/clone/clone_state_manager.cc
+++ b/src/yb/master/clone/clone_state_manager.cc
@@ -633,6 +633,7 @@ Status CloneStateManager::ScheduleCloneOps(
         clone_state->TargetSnapshotId().data(), clone_state->TargetSnapshotId().size());
     req.set_target_table_id(target_table->id());
     req.set_target_namespace_name(target_table_lock->namespace_name());
+    req.set_target_namespace_id(target_table_lock->namespace_id());
     req.set_clone_request_seq_no(clone_pb_lock->pb.clone_request_seq_no());
     req.set_target_pg_table_id(target_table_lock->pb.pg_table_id());
     if (target_table_lock->pb.has_index_info()) {

--- a/src/yb/tablet/operations.proto
+++ b/src/yb/tablet/operations.proto
@@ -210,6 +210,7 @@ message CloneTabletRequestPB {
 
   optional string target_table_id = 7;
   optional string target_namespace_name = 8;
+  optional string target_namespace_id = 17;
 
   optional uint32 clone_request_seq_no = 9;
 

--- a/src/yb/tserver/clone_operation-test.cc
+++ b/src/yb/tserver/clone_operation-test.cc
@@ -107,6 +107,7 @@ class CloneOperationTest : public TabletServerTestBase {
     req.set_target_snapshot_id(kTargetSnapshotId.data(), kTargetSnapshotId.size());
     req.set_target_table_id(kTargetTableId);
     req.set_target_namespace_name("target_namespace_name");
+    req.set_target_namespace_id("target_namespace_id");
     req.set_clone_request_seq_no(clone_request_seq_no);
     *req.mutable_target_schema() = schema_pb;
     req.set_target_pg_table_id("target_pg_table_id");
@@ -167,7 +168,7 @@ TEST_F(CloneOperationTest, Hardlink) {
 
   auto target_tablet = ASSERT_RESULT(
       mini_server_->server()->tablet_manager()->GetTablet(kTargetTabletId));
-  ASSERT_TRUE(target_tablet->tablet_metadata()->namespace_id().empty());
+  ASSERT_EQ(target_tablet->tablet_metadata()->namespace_id(), "target_namespace_id");
 
   const string source_snapshot_dir = GetSnapshotDir(source_tablet, kSourceSnapshotId);
   const string target_snapshot_dir = GetSnapshotDir(target_tablet, kTargetSnapshotId);

--- a/src/yb/tserver/ts_tablet_manager.cc
+++ b/src/yb/tserver/ts_tablet_manager.cc
@@ -1319,6 +1319,7 @@ Status TSTabletManager::DoApplyCloneTablet(
   const auto target_table_id = request->target_table_id().ToBuffer();
   const auto target_tablet_id = request->target_tablet_id().ToBuffer();
   const auto target_namespace_name = request->target_namespace_name().ToBuffer();
+  const auto target_namespace_id = request->target_namespace_id().ToBuffer();
   const auto target_pg_table_id = request->target_pg_table_id().ToBuffer();
   const auto target_skip_table_tombstone_check =
       request->target_skip_table_tombstone_check();
@@ -1391,9 +1392,7 @@ Status TSTabletManager::DoApplyCloneTablet(
       tablet::Primary(source_table->primary()),
       target_table_id,
       target_namespace_name,
-      // TODO: Plumb target_namespace_id through the clone path.
-      // https://github.com/yugabyte/yugabyte-db/pull/30308#discussion_r2828653802
-      "" /* namespace_id */,
+      target_namespace_id,
       source_table->table_name,
       source_table->table_type,
       /* Fixed by restore, but we need it to get partition_schema so might as well set it. */


### PR DESCRIPTION
### Motivation

- Closes https://github.com/yugabyte/yugabyte-db/issues/29982
- Follow up on https://github.com/yugabyte/yugabyte-db/pull/30308#discussion_r2828653802

### Testing

Create a single-node cluster with database cloning enabled, set up a  source database with a table, and clone it:

```bash
./bin/yb-ctl --rf 1 create --master_flags "enable_db_clone=true"
./bin/ysqlsh -c "CREATE DATABASE source_db;"
./bin/ysqlsh -d source_db -c "CREATE TABLE t(k INT PRIMARY KEY, v TEXT);"
./bin/ysqlsh -d source_db -c "INSERT INTO t VALUES (1, 'hello'), (2, 'world');"
```

Clone requires a snapshot schedule on the source database:

```bash
./build/latest/bin/yb-admin -master_addresses 127.0.0.1:7100 create_snapshot_schedule 1 10 ysql.source_db
{
    "schedule_id": "a25cf65d-f2a1-41f7-90c7-803ff84212fc"
}

./build/latest/bin/yb-admin -master_addresses 127.0.0.1:7100 list_snapshot_schedules
{
    "schedules": [
        {
            "id": "a25cf65d-f2a1-41f7-90c7-803ff84212fc",
            "options": {
                "filter": "ysql.source_db",
                "interval": "1 min",
                "retention": "10 min"
            },
            "snapshots": []
        }
    ]
}
```

Clone the database. This triggers the CloneTablet RPC path where `target_namespace_id` is now plumbed:

```bash
./bin/ysqlsh -c "CREATE DATABASE cloned_db TEMPLATE source_db;"
```

Dump the cloned tablet's superblock to verify namespace_id is populated:

```bash
./build/latest/bin/yb-admin -master_addresses 127.0.0.1:7100 list_tablets ysql.cloned_db t
Tablet-UUID                             Range                                                           Leader-IP               Leader-UUID
ae36d3e51e0840629bb2a9cb96d78ed6        hash_split: [0x0000, 0xFFFF]                                    127.0.0.1:9100          1826868e9213455d9f4446a83a6beea6

# It used to be empty before this PR.
./build/latest/bin/yb-pbc-dump ~/yugabyte-data/node-1/disk-1/yb-data/tserver/tablet-meta/ae36d3e51e0840629bb2a9cb96d78ed6 2>&1 | grep namespace_id
    namespace_id: "00004002000030008000000000000000"
```

Compare with the source tablet to confirm they have different namespace IDs:

```bash
./build/latest/bin/yb-admin -master_addresses 127.0.0.1:7100 list_tablets ysql.source_db t
Tablet-UUID                             Range                                                           Leader-IP               Leader-UUID
848fde19c87e4fa1b8ab471086e495cb        hash_split: [0x0000, 0xFFFF]                                    127.0.0.1:9100          1826868e9213455d9f4446a83a6beea6

./build/latest/bin/yb-pbc-dump ~/yugabyte-data/node-1/disk-1/yb-data/tserver/tablet-meta/848fde19c87e4fa1b8ab471086e495cb 2>&1 | grep namespace_id
    namespace_id: "00004000000030008000000000000000"
```