### PR TITLE
[DOC-730] Comment out old roles supademo

### DIFF
--- a/docs/content/stable/yugabyte-cloud/managed-security/managed-roles.md
+++ b/docs/content/stable/yugabyte-cloud/managed-security/managed-roles.md
@@ -16,7 +16,9 @@ type: docs
 
 YugabyteDB Aeon uses role-based access control (RBAC) to manage access to your YugabyteDB Aeon account. Using roles, you can enforce the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege) (PoLP) by ensuring that users have the precise permissions needed to fulfill their roles while mitigating the risk of unauthorized access or accidental breaches. A role defines a set of permissions that determine what features can be accessed by account users who have been assigned that role.
 
+<!--
 <div style="position: relative; padding-bottom: calc(48.5% + 44px); height: 0;"><iframe src="https://app.supademo.com/embed/8qhuZOgCCzczVXY_5pydu" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
+-->
 
 YugabyteDB Aeon includes [built-in roles](#built-in-roles), and you can [define custom roles](#create-a-role) for team members to restrict access to specific account features. For information on assigning roles to users, refer to [Change a user's role](../manage-access/#change-a-user-s-role).
 


### PR DESCRIPTION
@netlify /stable/yugabyte-cloud/managed-security/managed-roles/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that disables an embedded iframe; no code or runtime behavior is affected.
> 
> **Overview**
> Removes (by HTML-commenting) the embedded Supademo iframe from the `managed-roles` RBAC documentation page, preventing the interactive demo from rendering while leaving the surrounding content unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41b62b68df56a18400070dad1288126dd06256c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->