### PR TITLE
YSQL: Handle multiple addresses in pgsql_proxy_bind_address

### DIFF
--- a/src/yb/tserver/tablet_server.cc
+++ b/src/yb/tserver/tablet_server.cc
@@ -273,10 +273,9 @@ namespace yb::tserver {
 namespace {
 
 uint16_t GetPostgresPort() {
-  yb::HostPort postgres_address;
-  CHECK_OK(postgres_address.ParseString(
-      FLAGS_pgsql_proxy_bind_address, yb::pgwrapper::PgProcessConf().kDefaultPort));
-  return postgres_address.port();
+  auto parsed = CHECK_RESULT(pgwrapper::ParsePgBindAddresses(
+      FLAGS_pgsql_proxy_bind_address, pgwrapper::PgProcessConf::kDefaultPort));
+  return parsed.port;
 }
 
 bool PostgresAndYsqlConnMgrPortValidator(const char* flag_name, uint32 value) {
@@ -578,8 +577,11 @@ Status TabletServer::Init() {
 
   auto shared = shared_object();
 
-  // 5433 is kDefaultPort in src/yb/yql/pgwrapper/pg_wrapper.h.
-  RETURN_NOT_OK(pgsql_proxy_bind_address_.ParseString(FLAGS_pgsql_proxy_bind_address, 5433));
+  // pgsql_proxy_bind_address_ is used to register with the master and for internal connections,
+  // so only the first address is needed. PostgreSQL listens on all addresses via listen_addresses.
+  auto parsed = VERIFY_RESULT(
+      pgwrapper::ParsePgBindAddresses(FLAGS_pgsql_proxy_bind_address, pgwrapper::PgProcessConf::kDefaultPort));
+  pgsql_proxy_bind_address_ = HostPort(parsed.first_host, parsed.port);
   if (PREDICT_FALSE(FLAGS_TEST_pg_auth_key != 0)) {
     shared->SetPostgresAuthKey(FLAGS_TEST_pg_auth_key);
   } else {

--- a/src/yb/tserver/tablet_server_main_impl.cc
+++ b/src/yb/tserver/tablet_server_main_impl.cc
@@ -217,7 +217,8 @@ void SetProxyAddresses() {
   uint16_t freeport = pp.AllocateFreePort();
   if (!FLAGS_pgsql_proxy_bind_address.empty()) {
     std::vector<HostPort> bind_addresses;
-    Status status = HostPort::ParseStrings(FLAGS_pgsql_proxy_bind_address, 0, &bind_addresses);
+    Status status = HostPort::ParseStrings(
+        FLAGS_pgsql_proxy_bind_address, PgProcessConf::kDefaultPort, &bind_addresses);
     LOG_IF(DFATAL, !status.ok())
     << "Bad pgsql_proxy_bind_address " << FLAGS_pgsql_proxy_bind_address << ": " << status;
     for (const auto& addr : bind_addresses) {
@@ -248,10 +249,13 @@ void SetProxyAddresses() {
     }
   }
 
-  yb::HostPort postgres_address;
-  CHECK_OK(postgres_address.ParseString(FLAGS_pgsql_proxy_bind_address, freeport));
+  // The port-conflict handling above may have overridden the port in pgsql_proxy_bind_address.
+  // Parse and validate that all addresses use the same port (PostgreSQL only supports one).
+  const auto parsed = CHECK_RESULT(
+      pgwrapper::ParsePgBindAddresses(FLAGS_pgsql_proxy_bind_address, freeport));
   LOG(INFO) << "ysql connection manager is enabled";
   LOG(INFO) << "Using pgsql_proxy_bind_address = " << FLAGS_pgsql_proxy_bind_address;
+  LOG(INFO) << "Using ysql backend port = " << parsed.port;
   LOG(INFO) << "Using ysql_connection_manager port = " << FLAGS_ysql_conn_mgr_port;
 }
 

--- a/src/yb/yql/pgwrapper/pg_wrapper-test.cc
+++ b/src/yb/yql/pgwrapper/pg_wrapper-test.cc
@@ -98,6 +98,56 @@ TEST(FormatPgGFlagValueTest, QuotingBehavior) {
   ASSERT_EQ(FormatPgGFlagValue("true", "bool"), "true");
 }
 
+TEST(ParsePgBindAddressesTest, All) {
+  auto check = [](const std::string& input, uint16_t default_port,
+                   const std::string& expected_addrs, const std::string& expected_first_host,
+                   uint16_t expected_port) {
+    auto result = ASSERT_RESULT(ParsePgBindAddresses(input, default_port));
+    ASSERT_EQ(result.listen_addresses, expected_addrs) << "input: " << input;
+    ASSERT_EQ(result.first_host, expected_first_host) << "input: " << input;
+    ASSERT_EQ(result.port, expected_port) << "input: " << input;
+  };
+  // Single address
+  check("127.0.0.1:5434", 5433, "127.0.0.1", "127.0.0.1", 5434);
+  check("127.0.0.1", 5433, "127.0.0.1", "127.0.0.1", 5433);
+  check("0.0.0.0:5434", 5433, "0.0.0.0", "0.0.0.0", 5434);
+  // Multiple addresses, same port
+  check("127.0.0.1:5434,127.0.0.2:5434", 5433, "127.0.0.1,127.0.0.2", "127.0.0.1", 5434);
+  check("127.0.0.1,127.0.0.2", 5433, "127.0.0.1,127.0.0.2", "127.0.0.1", 5433);
+  check("127.0.0.1:5433,127.0.0.2", 5433, "127.0.0.1,127.0.0.2", "127.0.0.1", 5433);
+  // Multiple addresses, custom port
+  check("127.0.0.1:5555,127.0.0.2:5555", 5433, "127.0.0.1,127.0.0.2", "127.0.0.1", 5555);
+  // Three addresses
+  check("10.0.0.1:5434,10.0.0.2:5434,10.0.0.3:5434", 5433,
+        "10.0.0.1,10.0.0.2,10.0.0.3", "10.0.0.1", 5434);
+  // IPv6
+  check("[::1]:5434", 5433, "::1", "::1", 5434);
+  check("[::1]:5434,[::2]:5434", 5433, "::1,::2", "::1", 5434);
+  // Mixed IPv4 and IPv6
+  check("127.0.0.1:5434,[::1]:5434", 5433, "127.0.0.1,::1", "127.0.0.1", 5434);
+
+  // Invalid: different ports
+  ASSERT_NOK(ParsePgBindAddresses("127.0.0.1:5434,127.0.0.2:5436", 5433));
+  // Invalid: explicit port vs different default
+  ASSERT_NOK(ParsePgBindAddresses("127.0.0.1:5434,127.0.0.2", 5433));
+  // Invalid: explicit custom port vs different default
+  ASSERT_NOK(ParsePgBindAddresses("127.0.0.1:5555,127.0.0.2", 5433));
+  // Invalid: three addresses, one different
+  ASSERT_NOK(ParsePgBindAddresses("127.0.0.1:5434,127.0.0.2:5434,127.0.0.3:5436", 5433));
+  // Invalid: IPv6 different ports
+  ASSERT_NOK(ParsePgBindAddresses("[::1]:5434,[::2]:5436", 5433));
+  // Invalid: empty string
+  ASSERT_NOK(ParsePgBindAddresses("", 5433));
+  // Error message is descriptive
+  auto bad = ParsePgBindAddresses("127.0.0.1:5434,127.0.0.2:5436", 5433);
+  ASSERT_NOK(bad);
+  auto msg = bad.status().ToString();
+  ASSERT_STR_CONTAINS(msg, "same port");
+  ASSERT_STR_CONTAINS(msg, "Got port 5436");
+  ASSERT_STR_CONTAINS(msg, "expected port 5434");
+  ASSERT_STR_CONTAINS(msg, "127.0.0.2");
+}
+
 TEST(PgWrapperPathTest, PostgresExecutablePath) {
   const auto install_root = GetPostgresInstallRoot();
   const auto executable_path = PgWrapper::GetPostgresExecutablePath();

--- a/src/yb/yql/pgwrapper/pg_wrapper.cc
+++ b/src/yb/yql/pgwrapper/pg_wrapper.cc
@@ -652,7 +652,16 @@ void AppendPgGFlags(vector<string>* lines) {
 }
 
 HostPort GetPgHostPort(const PgProcessConf& conf) {
-  return HostPort(conf.listen_addresses, conf.pg_port);
+  // Use only the first address for the socket directory path. PostgreSQL's -k flag
+  // (unix_socket_directories) treats commas as separators between directory paths. If
+  // listen_addresses is "127.0.0.1,127.0.0.2", PgDeriveSocketDir would produce
+  // "/tmp/.yb.127.0.0.1,127.0.0.2:5433", but PG splits this at the comma and looks for
+  // "/tmp/.yb.127.0.0.1" instead, which does not exist.
+  auto comma_pos = conf.listen_addresses.find(',');
+  auto host = comma_pos == std::string::npos
+      ? conf.listen_addresses
+      : conf.listen_addresses.substr(0, comma_pos);
+  return HostPort(std::move(host), conf.pg_port);
 }
 
 }  // namespace
@@ -832,15 +841,43 @@ string GetPostgresInstallRoot() {
   return JoinPathSegments(yb::env_util::GetRootDir("postgres"), "postgres");
 }
 
+Result<PgListenAddressAndPort> ParsePgBindAddresses(
+    const std::string& bind_addresses, uint16_t default_port) {
+  auto host_ports = VERIFY_RESULT_PREPEND(
+      HostPort::ParseStrings(bind_addresses, default_port),
+      "Failed to parse bind addresses");
+  SCHECK(!host_ports.empty(), InvalidArgument, "No bind addresses specified");
+  const uint16_t port = host_ports.front().port();
+  std::string listen_addresses;
+  for (const auto& hp : host_ports) {
+    SCHECK_EQ(
+        hp.port(), port, InvalidArgument,
+        Format(
+            "All addresses in pgsql_proxy_bind_address must use the same port. "
+            "PostgreSQL does not support listening on different ports for different addresses. "
+            "Got port $0 for address '$1' but expected port $2",
+            hp.port(), hp.host(), port));
+    if (!listen_addresses.empty()) {
+      listen_addresses += ',';
+    }
+    listen_addresses += hp.host();
+  }
+  auto first_host = host_ports.front().host();
+  return PgListenAddressAndPort{
+      .listen_addresses = std::move(listen_addresses),
+      .first_host = std::move(first_host),
+      .port = port};
+}
+
 Result<PgProcessConf> PgProcessConf::CreateValidateAndRunInitDb(
     const std::string& bind_addresses,
     const std::string& data_dir) {
   PgProcessConf conf;
   if (!bind_addresses.empty()) {
-    auto pg_host_port = VERIFY_RESULT(HostPort::FromString(
+    auto parsed = VERIFY_RESULT(ParsePgBindAddresses(
         bind_addresses, PgProcessConf::kDefaultPort));
-    conf.listen_addresses = pg_host_port.host();
-    conf.pg_port = pg_host_port.port();
+    conf.listen_addresses = std::move(parsed.listen_addresses);
+    conf.pg_port = parsed.port;
   }
   conf.data_dir = data_dir;
   PgWrapper pg_wrapper(conf);

--- a/src/yb/yql/pgwrapper/pg_wrapper.h
+++ b/src/yb/yql/pgwrapper/pg_wrapper.h
@@ -64,6 +64,20 @@ struct PgProcessConf : public ProcessWrapperCommonConfig {
   bool run_in_binary_upgrade = false;
 };
 
+// Result of parsing a potentially comma-separated bind address string (e.g.,
+// "127.0.0.1:5433,127.0.0.2:5433") into PostgreSQL-compatible listen_addresses and port.
+struct PgListenAddressAndPort {
+  std::string listen_addresses;  // Comma-separated hosts, e.g. "127.0.0.1,127.0.0.2"
+  std::string first_host;        // First host, e.g. "127.0.0.1"
+  uint16_t port;
+};
+
+// Parses a comma-separated list of "host:port" pairs into a comma-separated listen_addresses
+// string and a single port. All addresses must use the same port (PostgreSQL only supports a
+// single port for all listen addresses). Returns an error if ports differ.
+Result<PgListenAddressAndPort> ParsePgBindAddresses(
+    const std::string& bind_addresses, uint16_t default_port);
+
 // Invokes a PostgreSQL child process once. Also allows invoking initdb. Not thread-safe.
 class PgWrapper : public ProcessWrapper {
  public:

--- a/src/yb/yql/ysql_conn_mgr_wrapper/ysql_conn_mgr_conf.cc
+++ b/src/yb/yql/ysql_conn_mgr_wrapper/ysql_conn_mgr_conf.cc
@@ -340,8 +340,9 @@ Status YsqlConnMgrConf::UpdateConfigFromGFlags() {
   conf.ysql_max_connections = max_connections;
   conf_ = conf;
 
-  CHECK_OK(postgres_address_.ParseString(
-      FLAGS_pgsql_proxy_bind_address, pgwrapper::PgProcessConf().kDefaultPort));
+  auto parsed = CHECK_RESULT(
+      pgwrapper::ParsePgBindAddresses(FLAGS_pgsql_proxy_bind_address, pgwrapper::PgProcessConf::kDefaultPort));
+  postgres_address_ = HostPort(parsed.first_host, parsed.port);
   return Status::OK();
 }
 


### PR DESCRIPTION
### Motivation

Closes https://github.com/yugabyte/yugabyte-db/issues/28643

None of the following commands succeeded in the "before" state.

### Testing

Default bind address, conn mgr disabled:

```bash
./bin/yb-ctl --rf 1 create
sudo ss -tlpn | grep 'postgres\|odyssey'
LISTEN 0      128        127.0.0.1:13000      0.0.0.0:*    users:(("postgres",pid=236690,fd=4))
LISTEN 0      644        127.0.0.1:5433       0.0.0.0:*    users:(("postgres",pid=236686,fd=6))
```

Default bind address, conn mgr enabled (default port):

```bash
./bin/yb-ctl --rf 1 create --tserver_flags 'enable_ysql_conn_mgr=true'
sudo ss -tlpn | grep 'postgres\|odyssey'
LISTEN 0      644        127.0.0.1:6433       0.0.0.0:*    users:(("postgres",pid=237100,fd=6))
LISTEN 0      128        127.0.0.1:13000      0.0.0.0:*    users:(("postgres",pid=237104,fd=4))
LISTEN 0      128        127.0.0.1:5433       0.0.0.0:*    users:(("odyssey",pid=237041,fd=28))
```

Multiple IPs with default port, conn mgr disabled:

```bash
./bin/yb-ctl --rf 1 create --tserver_flags '"pgsql_proxy_bind_address=127.0.0.1,127.0.0.2"'
 sudo ss -tlpn | grep 'postgres\|odyssey'
LISTEN 0      128        127.0.0.2:13000      0.0.0.0:*    users:(("postgres",pid=235783,fd=5))
LISTEN 0      644        127.0.0.2:5433       0.0.0.0:*    users:(("postgres",pid=235778,fd=7))
LISTEN 0      128        127.0.0.1:80         0.0.0.0:*    users:(("postgres",pid=235783,fd=4))
LISTEN 0      644        127.0.0.1:5433       0.0.0.0:*    users:(("postgres",pid=235778,fd=6))
```

Multiple IPs with default port, conn mgr enabled (default port):

```bash
./bin/yb-ctl --rf 1 create --tserver_flags '"pgsql_proxy_bind_address=127.0.0.1,127.0.0.2",enable_ysql_conn_mgr=true'

sudo ss -tlpn | grep 'postgres\|odyssey'
LISTEN 0      128        127.0.0.2:13000      0.0.0.0:*    users:(("postgres",pid=236213,fd=5))
LISTEN 0      128        127.0.0.1:80         0.0.0.0:*    users:(("postgres",pid=236213,fd=4))
LISTEN 0      644        127.0.0.2:6433       0.0.0.0:*    users:(("postgres",pid=236209,fd=7))
LISTEN 0      644        127.0.0.1:6433       0.0.0.0:*    users:(("postgres",pid=236209,fd=6))
LISTEN 0      128        127.0.0.1:5433       0.0.0.0:*    users:(("odyssey",pid=236149,fd=28))
```

Multiple IPs with default port, conn mgr enabled (custom port 7777):

```bash
./bin/yb-ctl --rf 1 create --tserver_flags '"pgsql_proxy_bind_address=127.0.0.1,127.0.0.2",enable_ysql_conn_mgr=true,ysql_conn_mgr_port=7777'
sudo ss -tlpn | grep 'postgres\|odyssey'
LISTEN 0      128        127.0.0.2:13000      0.0.0.0:*    users:(("postgres",pid=237597,fd=5))
LISTEN 0      644        127.0.0.2:5433       0.0.0.0:*    users:(("postgres",pid=237593,fd=7))
LISTEN 0      128        127.0.0.1:80         0.0.0.0:*    users:(("postgres",pid=237597,fd=4))
LISTEN 0      128        127.0.0.1:7777       0.0.0.0:*    users:(("odyssey",pid=237533,fd=28))
LISTEN 0      644        127.0.0.1:5433       0.0.0.0:*    users:(("postgres",pid=237593,fd=6))
```

Multiple IPs with custom port 5555, conn mgr disabled:

```bash
./bin/yb-ctl --rf 1 create --tserver_flags '"pgsql_proxy_bind_address=127.0.0.1:5555,127.0.0.2:5555"'
sudo ss -tlpn | grep 'postgres\|odyssey'
LISTEN 0      128        127.0.0.2:13000      0.0.0.0:*    users:(("postgres",pid=238264,fd=5))
LISTEN 0      644        127.0.0.2:5555       0.0.0.0:*    users:(("postgres",pid=238260,fd=7))
LISTEN 0      128        127.0.0.1:80         0.0.0.0:*    users:(("postgres",pid=238264,fd=4))
LISTEN 0      644        127.0.0.1:5555       0.0.0.0:*    users:(("postgres",pid=238260,fd=6))
```

Multiple IPs with custom port 5555, conn mgr enabled (default port):

```bash
./bin/yb-ctl --rf 1 create --tserver_flags '"pgsql_proxy_bind_address=127.0.0.1:5555,127.0.0.2:5555",enable_ysql_conn_mgr=true'
sudo ss -tlpn | grep 'postgres\|odyssey'
LISTEN 0      128        127.0.0.2:13000      0.0.0.0:*    users:(("postgres",pid=238699,fd=5))
LISTEN 0      644        127.0.0.2:5555       0.0.0.0:*    users:(("postgres",pid=238695,fd=7))
LISTEN 0      128        127.0.0.1:80         0.0.0.0:*    users:(("postgres",pid=238699,fd=4))
LISTEN 0      128        127.0.0.1:5433       0.0.0.0:*    users:(("odyssey",pid=238636,fd=28))
LISTEN 0      644        127.0.0.1:5555       0.0.0.0:*    users:(("postgres",pid=238695,fd=6))
```

Multiple IPs with custom port 5555, conn mgr enabled (custom port 7777):

```bash
./bin/yb-ctl --rf 1 create --tserver_flags '"pgsql_proxy_bind_address=127.0.0.1:5555,127.0.0.2:5555",enable_ysql_conn_mgr=true,ysql_conn_mgr_port=7777'
sudo ss -tlpn | grep 'postgres\|odyssey'
LISTEN 0      128        127.0.0.2:13000      0.0.0.0:*    users:(("postgres",pid=239125,fd=5))
LISTEN 0      644        127.0.0.2:5555       0.0.0.0:*    users:(("postgres",pid=239121,fd=7))
LISTEN 0      128        127.0.0.1:80         0.0.0.0:*    users:(("postgres",pid=239125,fd=4))
LISTEN 0      128        127.0.0.1:7777       0.0.0.0:*    users:(("odyssey",pid=239061,fd=28))
LISTEN 0      644        127.0.0.1:5555       0.0.0.0:*    users:(("postgres",pid=239121,fd=6))
```

Mixed ports per IP (5555 and default), conn mgr disabled — expects FATAL:

```bash
./bin/yb-ctl --rf 1 create --tserver_flags '"pgsql_proxy_bind_address=127.0.0.1:5555,127.0.0.2"'
Creating cluster.
Waiting for cluster to be ready.
Viewing file /home/keisukeumegaki.linux/yugabyte-data/node-1/disk-1/tserver.err:
Started process id: 233969 logfile(s): /home/keisukeumegaki.linux/yugabyte-data/node-1/disk-1/yb-data/tserver/logs/yb-tserver*20260310-084002.233969
F0310 08:40:06.695772 233969 tablet_server_main_impl.cc:484] Invalid argument (yb/yql/pgwrapper/pg_wrapper.cc:826): All addresses in pgsql_proxy_bind_address must use the same port. PostgreSQL does not support listening on different ports for different addresses. Got port 5433 for address '127.0.0.2' but expected port 5555: 5433 vs 5555
Fatal failure details written to /home/keisukeumegaki.linux/yugabyte-data/node-1/disk-1/yb-data/tserver/logs/yb-tserver.FATAL.details.2026-03-10T08_40_06.pid233969.txt
F20260310 08:40:06 /Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/src/yb/tserver/tablet_server_main_impl.cc:484] Invalid argument (yb/yql/pgwrapper/pg_wrapper.cc:826): All addresses in pgsql_proxy_bind_address must use the same port. PostgreSQL does not support listening on different ports for different addresses. Got port 5433 for address '127.0.0.2' but expected port 5555: 5433 vs 5555
    @     0xffffa72b7f74  google::LogMessage::SendToLog()
    @     0xffffa72b89a8  google::LogMessage::Flush()
    @     0xffffa72bb42c  google::LogMessageFatal::~LogMessageFatal()
    @     0xffffad56cf18  yb::tserver::TabletServerMain()
    @     0xffffa6079540  __libc_start_call_main
    @     0xffffa6079618  __libc_start_main_alias_2
    @     0xaaaac85a55b0  _start

*** Check failure stack trace: ***
    @     0xffffa72b8368  google::LogMessage::SendToLog()
    @     0xffffa72b89a8  google::LogMessage::Flush()
    @     0xffffa72bb42c  google::LogMessageFatal::~LogMessageFatal()
    @     0xffffad56cf18  yb::tserver::TabletServerMain()
    @     0xffffa6079540  __libc_start_call_main
    @     0xffffa6079618  __libc_start_main_alias_2
    @     0xaaaac85a55b0  _start
Viewing file /tmp/tmpk75ol4_f:
2026-03-10 08:40:02,371 INFO: Using binaries path: /Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/latest
2026-03-10 08:40:02,373 INFO: Using binaries path: /Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/latest
2026-03-10 08:40:02,373 INFO: Starting master-1 with:
/Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/latest/bin/yb-master --fs_data_dirs "/home/keisukeumegaki.linux/yugabyte-data/node-1/disk-1" --webserver_interface 127.0.0.1 --rpc_bind_addresses 127.0.0.1 --v 0 --version_file_json_path=/Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/release-clang21-dynamic-ninja --replication_factor=1 --yb_num_shards_per_tserver 2 --ysql_num_shards_per_tserver=2 --default_memory_limit_to_ram_ratio=0.35 --master_addresses 127.0.0.1:7100 --enable_ysql=true >"/home/keisukeumegaki.linux/yugabyte-data/node-1/disk-1/master.out" 2>"/home/keisukeumegaki.linux/yugabyte-data/node-1/disk-1/master.err" &
2026-03-10 08:40:02,374 INFO: Using binaries path: /Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/latest
2026-03-10 08:40:02,376 INFO: Using binaries path: /Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/latest
2026-03-10 08:40:02,377 INFO: Starting tserver-1 with:
/Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/latest/bin/yb-tserver --fs_data_dirs "/home/keisukeumegaki.linux/yugabyte-data/node-1/disk-1" --webserver_interface 127.0.0.1 --rpc_bind_addresses 127.0.0.1 --v 0 --version_file_json_path=/Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/release-clang21-dynamic-ninja --tserver_master_addrs=127.0.0.1:7100 --yb_num_shards_per_tserver=2 --redis_proxy_bind_address=127.0.0.1:6379 --cql_proxy_bind_address=127.0.0.1:9042 --local_ip_for_outbound_sockets=127.0.0.1 --use_cassandra_authentication=false --ysql_num_shards_per_tserver=2 --default_memory_limit_to_ram_ratio=0.65 --enable_ysql=true --pgsql_proxy_bind_address=127.0.0.1:5433 --pgsql_proxy_bind_address=127.0.0.1:5555,127.0.0.2 >"/home/keisukeumegaki.linux/yugabyte-data/node-1/disk-1/tserver.out" 2>"/home/keisukeumegaki.linux/yugabyte-data/node-1/disk-1/tserver.err" &
2026-03-10 08:40:02,377 INFO: Waiting for master and tserver processes to come up.
2026-03-10 08:40:02,382 INFO: Using binaries path: /Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/latest
2026-03-10 08:40:02,383 INFO: Waiting for master leader election and tablet server registration.
2026-03-10 08:40:06,572 INFO: Waiting for all tablet servers to register: 0/1
2026-03-10 08:40:07,601 INFO: PIDs found: {'master': [233966], 'tserver': [None]}
2026-03-10 08:40:07,602 ERROR: At least one master or tserver process is down.
^^^ Encountered errors ^^^
```

Mixed ports per IP (5555 and default), conn mgr enabled — expects FATAL:

```bash
./bin/yb-ctl --rf 1 create --tserver_flags '"pgsql_proxy_bind_address=127.0.0.1:5555,127.0.0.2",enable_ysql_conn_mgr=true'
Creating cluster.
Waiting for cluster to be ready.
Viewing file /home/keisukeumegaki.linux/yugabyte-data/node-1/disk-1/tserver.err:
WARNING: Logging before InitGoogleLogging() is written to STDERR
F0310 08:37:58.425521 233710 tablet_server.cc:274] Check failed: _s.ok() Bad status: Invalid argument (yb/yql/pgwrapper/pg_wrapper.cc:826): All addresses in pgsql_proxy_bind_address must use the same port. PostgreSQL does not support listening on different ports for different addresses. Got port 5433 for address '127.0.0.2' but expected port 5555: 5433 vs 5555
*** Check failure stack trace: ***
Viewing file /tmp/tmprvglju9k:
2026-03-10 08:37:58,335 INFO: Using binaries path: /Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/latest
2026-03-10 08:37:58,338 INFO: Using binaries path: /Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/latest
2026-03-10 08:37:58,338 INFO: Starting master-1 with:
/Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/latest/bin/yb-master --fs_data_dirs "/home/keisukeumegaki.linux/yugabyte-data/node-1/disk-1" --webserver_interface 127.0.0.1 --rpc_bind_addresses 127.0.0.1 --v 0 --version_file_json_path=/Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/release-clang21-dynamic-ninja --replication_factor=1 --yb_num_shards_per_tserver 2 --ysql_num_shards_per_tserver=2 --default_memory_limit_to_ram_ratio=0.35 --master_addresses 127.0.0.1:7100 --enable_ysql=true >"/home/keisukeumegaki.linux/yugabyte-data/node-1/disk-1/master.out" 2>"/home/keisukeumegaki.linux/yugabyte-data/node-1/disk-1/master.err" &
2026-03-10 08:37:58,339 INFO: Using binaries path: /Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/latest
2026-03-10 08:37:58,341 INFO: Using binaries path: /Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/latest
2026-03-10 08:37:58,342 INFO: Starting tserver-1 with:
/Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/latest/bin/yb-tserver --fs_data_dirs "/home/keisukeumegaki.linux/yugabyte-data/node-1/disk-1" --webserver_interface 127.0.0.1 --rpc_bind_addresses 127.0.0.1 --v 0 --version_file_json_path=/Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/release-clang21-dynamic-ninja --tserver_master_addrs=127.0.0.1:7100 --yb_num_shards_per_tserver=2 --redis_proxy_bind_address=127.0.0.1:6379 --cql_proxy_bind_address=127.0.0.1:9042 --local_ip_for_outbound_sockets=127.0.0.1 --use_cassandra_authentication=false --ysql_num_shards_per_tserver=2 --default_memory_limit_to_ram_ratio=0.65 --enable_ysql=true --pgsql_proxy_bind_address=127.0.0.1:5433 --pgsql_proxy_bind_address=127.0.0.1:5555,127.0.0.2 --enable_ysql_conn_mgr=true >"/home/keisukeumegaki.linux/yugabyte-data/node-1/disk-1/tserver.out" 2>"/home/keisukeumegaki.linux/yugabyte-data/node-1/disk-1/tserver.err" &
2026-03-10 08:37:58,342 INFO: Waiting for master and tserver processes to come up.
2026-03-10 08:37:58,349 INFO: Using binaries path: /Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/latest
2026-03-10 08:37:58,349 INFO: Waiting for master leader election and tablet server registration.
2026-03-10 08:38:02,403 INFO: Waiting for all tablet servers to register: 0/1
2026-03-10 08:38:03,428 INFO: PIDs found: {'master': [233707], 'tserver': [None]}
2026-03-10 08:38:03,428 ERROR: At least one master or tserver process is down.
^^^ Encountered errors ^^^
```

Mixed ports per IP (5555 and default), conn mgr enabled (custom port 7777) — expects FATAL:

```bash
./bin/yb-ctl --rf 1 create --tserver_flags '"pgsql_proxy_bind_address=127.0.0.1:5555,127.0.0.2",enable_ysql_conn_mgr=true,ysql_conn_mgr_port=7777'
Creating cluster.
Waiting for cluster to be ready.
Viewing file /home/keisukeumegaki.linux/yugabyte-data/node-1/disk-1/tserver.err:
WARNING: Logging before InitGoogleLogging() is written to STDERR
F0310 09:06:32.205870 237780 tablet_server.cc:274] Check failed: _s.ok() Bad status: Invalid argument (yb/yql/pgwrapper/pg_wrapper.cc:826): All addresses in pgsql_proxy_bind_address must use the same port. PostgreSQL does not support listening on different ports for different addresses. Got port 5433 for address '127.0.0.2' but expected port 5555: 5433 vs 5555
*** Check failure stack trace: ***
Viewing file /tmp/tmpaxh_rp3s:
2026-03-10 09:06:32,121 INFO: Using binaries path: /Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/latest
2026-03-10 09:06:32,123 INFO: Using binaries path: /Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/latest
2026-03-10 09:06:32,123 INFO: Starting master-1 with:
/Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/latest/bin/yb-master --fs_data_dirs "/home/keisukeumegaki.linux/yugabyte-data/node-1/disk-1" --webserver_interface 127.0.0.1 --rpc_bind_addresses 127.0.0.1 --v 0 --version_file_json_path=/Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/release-clang21-dynamic-ninja --replication_factor=1 --yb_num_shards_per_tserver 2 --ysql_num_shards_per_tserver=2 --default_memory_limit_to_ram_ratio=0.35 --master_addresses 127.0.0.1:7100 --enable_ysql=true >"/home/keisukeumegaki.linux/yugabyte-data/node-1/disk-1/master.out" 2>"/home/keisukeumegaki.linux/yugabyte-data/node-1/disk-1/master.err" &
2026-03-10 09:06:32,124 INFO: Using binaries path: /Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/latest
2026-03-10 09:06:32,127 INFO: Using binaries path: /Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/latest
2026-03-10 09:06:32,127 INFO: Starting tserver-1 with:
/Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/latest/bin/yb-tserver --fs_data_dirs "/home/keisukeumegaki.linux/yugabyte-data/node-1/disk-1" --webserver_interface 127.0.0.1 --rpc_bind_addresses 127.0.0.1 --v 0 --version_file_json_path=/Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/release-clang21-dynamic-ninja --tserver_master_addrs=127.0.0.1:7100 --yb_num_shards_per_tserver=2 --redis_proxy_bind_address=127.0.0.1:6379 --cql_proxy_bind_address=127.0.0.1:9042 --local_ip_for_outbound_sockets=127.0.0.1 --use_cassandra_authentication=false --ysql_num_shards_per_tserver=2 --default_memory_limit_to_ram_ratio=0.65 --enable_ysql=true --pgsql_proxy_bind_address=127.0.0.1:5433 --pgsql_proxy_bind_address=127.0.0.1:5555,127.0.0.2 --enable_ysql_conn_mgr=true --ysql_conn_mgr_port=7777 >"/home/keisukeumegaki.linux/yugabyte-data/node-1/disk-1/tserver.out" 2>"/home/keisukeumegaki.linux/yugabyte-data/node-1/disk-1/tserver.err" &
2026-03-10 09:06:32,128 INFO: Waiting for master and tserver processes to come up.
2026-03-10 09:06:32,133 INFO: Using binaries path: /Users/keisukeumegaki/Workspace/yugabyte-db-almalinux9/build/latest
2026-03-10 09:06:32,133 INFO: Waiting for master leader election and tablet server registration.
2026-03-10 09:06:37,002 INFO: Waiting for all tablet servers to register: 0/1
2026-03-10 09:06:38,029 INFO: PIDs found: {'master': [237777], 'tserver': [None]}
2026-03-10 09:06:38,029 ERROR: At least one master or tserver process is down.
^^^ Encountered errors ^^^
```