### PR TITLE
[DOC-1210][yba][2026.1] Configure EarlyOOM for universes

### DIFF
--- a/docs/content/stable/yugabyte-platform/create-deployments/create-universe-multi-zone.md
+++ b/docs/content/stable/yugabyte-platform/create-deployments/create-universe-multi-zone.md
@@ -54,9 +54,9 @@ ClockBound is supported on AWS and GCP. Azure and Kubernetes deployments are not
 
 | Action | Details |
 | :----- | :------ |
-| Enable EarlyOOM | Set the Global runtime configuration flag `yb.ui.feature_flags.enable_earlyoom` to `true`. |
-| Enable by default for new universes | Set the Global runtime configuration flag `yb.node_agent.enable_earlyoom_by_default` to `true`. |
-| Disable EarlyOOM | Set the Global runtime configuration flag `yb.ui.feature_flags.enable_earlyoom` to `false`, then perform a [rolling restart](../../manage-deployments/edit-config-flags/#modify-configuration-flags) for the change to take effect. |
+| Enable EarlyOOM | Set the **Enables Earlyoom Installation on Nodes** Global Runtime Configuration option (config key `yb.ui.feature_flags.enable_earlyoom`) to true. |
+| Enable by default for new universes | Set the **Enable earlyoom by default** Global runtime configuration flag `yb.node_agent.enable_earlyoom_by_default` to `true`. |
+| Disable EarlyOOM | Set the **Enable earlyoom by default** Global runtime configuration flag `yb.ui.feature_flags.enable_earlyoom` to `false`, then perform a [rolling restart](../../manage-deployments/edit-config-flags/#modify-configuration-flags) for the change to take effect. |
 | Apply to existing universes | Enable or disable EarlyOOM as needed, then use **Edit Universe** > **Apply Changes** or a [rolling restart](../../manage-deployments/edit-config-flags/#modify-configuration-flags) for the change to take effect. See [Edit EarlyOOM](../../manage-deployments/edit-universe/#edit-earlyoom).|
 
 Note that only a Super Admin user can modify Global configuration settings. Refer to [Manage runtime configuration settings](../../administer-yugabyte-platform/manage-runtime-config/).

--- a/docs/content/stable/yugabyte-platform/create-deployments/create-universe-multi-zone.md
+++ b/docs/content/stable/yugabyte-platform/create-deployments/create-universe-multi-zone.md
@@ -38,13 +38,28 @@ For information on modifying or scaling an existing universe, refer to [Modify u
 
 Before you start creating a universe, ensure that you have created a provider configuration as described in [Create provider configurations](../../configure-yugabyte-platform/).
 
-### Configure ClockBound (optional)
+### Additional settings
+
+#### Configure ClockBound (optional)
 
 {{<tags/feature/ea idea="2133">}}[ClockBound](https://github.com/aws/clock-bound) improves clock accuracy and reduces read-restart errors in YSQL. To enable ClockBound for [cloud provider](../../configure-yugabyte-platform/aws/) universes, set the provider's `yb.provider.configure_clockbound_cloud_provisioning` runtime configuration flag to `true` (before creating the universe). Refer to [Manage runtime configuration settings](../../administer-yugabyte-platform/manage-runtime-config/).
 
 When enabled, ClockBound is automatically configured during node provisioning, and the universe creation task sets the [time_source](../../../reference/configuration/yb-master/#time-source) flag to `clockbound`.
 
 ClockBound is supported on AWS and GCP. Azure and Kubernetes deployments are not supported.
+
+#### Configure EarlyOOM (optional)
+
+{{<tags/feature/ea idea="1804">}} EarlyOOM runs on database nodes and kills processes under extreme memory pressure to prevent VM hangs (it prefers keeping PostgreSQL).
+
+| Action | Details |
+| :----- | :------ |
+| Enable EarlyOOM | Set the Global runtime configuration flag `yb.ui.feature_flags.enable_earlyoom` to `true`. |
+| Enable by default for new universes | Set the Global runtime configuration flag `yb.node_agent.enable_earlyoom_by_default` to `true`. |
+| Disable EarlyOOM | Set the Global runtime configuration flag `yb.ui.feature_flags.enable_earlyoom` to `false`, then perform a [rolling restart](../../manage-deployments/edit-config-flags/#modify-configuration-flags) for the change to take effect. |
+| Apply to existing universes | Enable or disable EarlyOOM as needed, then use **Edit Universe** > **Apply Changes** or a [rolling restart](../../manage-deployments/edit-config-flags/#modify-configuration-flags) for the change to take effect. See [Edit EarlyOOM](../../manage-deployments/edit-universe/#edit-earlyoom).|
+
+Note that only a Super Admin user can modify Global configuration settings. Refer to [Manage runtime configuration settings](../../administer-yugabyte-platform/manage-runtime-config/).
 
 ## Create a universe
 

--- a/docs/content/stable/yugabyte-platform/create-deployments/create-universe-multi-zone.md
+++ b/docs/content/stable/yugabyte-platform/create-deployments/create-universe-multi-zone.md
@@ -50,7 +50,7 @@ ClockBound is supported on AWS and GCP. Azure and Kubernetes deployments are not
 
 #### Configure EarlyOOM (optional)
 
-{{<tags/feature/ea idea="1804">}} EarlyOOM runs on database nodes and kills processes under extreme memory pressure to prevent VM hangs (it prefers keeping PostgreSQL).
+{{<tags/feature/ea idea="1804">}} EarlyOOM is a process that runs on database nodes. When the VM is under extreme memory pressure, EarlyOOM will selectively kill processes, while preserving PostgreSQL processes, to prevent the VM from crashing.
 
 | Action | Details |
 | :----- | :------ |

--- a/docs/content/stable/yugabyte-platform/manage-deployments/edit-universe.md
+++ b/docs/content/stable/yugabyte-platform/manage-deployments/edit-universe.md
@@ -72,7 +72,7 @@ To enable or disable connection pooling on a universe:
 
 {{<tags/feature/ea idea="1804">}} EarlyOOM runs on database nodes and kills processes under extreme memory pressure to prevent VM hangs (it prefers keeping PostgreSQL).
 
-To enable EarlyOOM on universes, set the **Enable EarlyOOM** Global Runtime Configuration option (config key `yb.ui.feature_flags.enable_earlyoom`) to true.
+While in Early Access, the feature is not available by default. To enable EarlyOOM on universes, set the **Enables Earlyoom Installation on Nodes** Global Runtime Configuration option (config key `yb.ui.feature_flags.enable_earlyoom`) to true.
 
 Note that only a Super Admin user can modify Global configuration settings.
 Refer to [Manage runtime configuration settings](../../administer-yugabyte-platform/manage-runtime-config/).

--- a/docs/content/stable/yugabyte-platform/manage-deployments/edit-universe.md
+++ b/docs/content/stable/yugabyte-platform/manage-deployments/edit-universe.md
@@ -68,6 +68,21 @@ To enable or disable connection pooling on a universe:
 1. Optionally, you can change the YSQL API port (used by applications to connect to a universe) and the Internal YSQL Port, which is the port that the YugabyteDB internal PostgreSQL process listens on when connection pooling is enabled. It defaults to 6433 and is only required for local binding, not external connectivity.
 1. Click **Apply Changes**.
 
+### Edit EarlyOOM
+
+{{<tags/feature/ea idea="1804">}} EarlyOOM runs on database nodes and kills processes under extreme memory pressure to prevent VM hangs (it prefers keeping PostgreSQL).
+
+To enable EarlyOOM on universes, set the **Enable EarlyOOM** Global Runtime Configuration option (config key `yb.ui.feature_flags.enable_earlyoom`) to true.
+
+Note that only a Super Admin user can modify Global configuration settings.
+Refer to [Manage runtime configuration settings](../../administer-yugabyte-platform/manage-runtime-config/).
+
+To enable or disable EarlyOOM on an existing universe:
+
+1. Navigate to your universe.
+1. Set the runtime configuration for EarlyOOM as needed (enable or disable at Global or Universe scope).
+1. Choose **Actions > Edit Universe** to open the **Edit universe** page, then click **Apply Changes**. Alternatively, perform a [rolling restart](../edit-config-flags/#modify-configuration-flags) so that node agents reprovision and EarlyOOM starts or stops on the nodes.
+
 ## Smart resize
 
 Normally when resizing a universe, YugabyteDB moves the data from the old nodes to the new nodes. However, if the universe is deployed on AWS, GCP, or Azure using a [cloud provider configuration](../../configure-yugabyte-platform/aws/), you can perform some resizing operations without migrating the data. This is referred to as smart resize, and can be significantly faster than a full copy of the data.


### PR DESCRIPTION
@netlify /stable/yugabyte-platform/manage-deployments/edit-universe/#edit-earlyoom

https://deploy-preview-30503--infallible-bardeen-164bc9.netlify.app/stable/yugabyte-platform/create-deployments/create-universe-multi-zone/#configure-earlyoom-optional


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; main risk is incorrect runtime config keys/steps leading to user confusion.
> 
> **Overview**
> Documents the new *Early Access* `EarlyOOM` feature and how to enable/disable it via runtime configuration when creating and operating universes.
> 
> Reorganizes the multi-zone universe prerequisites into an **Additional settings** section (keeping `ClockBound`) and adds a new **Edit EarlyOOM** section to the universe modification guide, including guidance to apply changes via **Apply Changes** or a rolling restart.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78a3b31427f5f522b96a17b26f7fc25a7813b937. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->