### PR TITLE
[DOC-1216] Updated defaults for parameters to fine-tune HNSW index options.

### DIFF
--- a/docs/content/stable/additional-features/pg-extensions/extension-pgvector.md
+++ b/docs/content/stable/additional-features/pg-extensions/extension-pgvector.md
@@ -198,8 +198,10 @@ YugabyteDB currently supports the `vector` type.
 
 You can fine-tune HNSW indexing using the following parameters:
 
-- `m` - specifies the maximum number of connections per layer.
-- `ef_construction` - Specifies the size of the dynamic candidate list for constructing the graph.
+| Parameter | Description | Default |
+| :--- | :--- | :--- |
+| m | Maximum number of connections per layer. Valid range: 5–64. | 32 |
+| ef_construction | Size of the dynamic candidate list for constructing the graph. Valid range: 50–1000. | 200 |
 
 For example:
 

--- a/docs/content/v2.25/additional-features/pg-extensions/extension-pgvector.md
+++ b/docs/content/v2.25/additional-features/pg-extensions/extension-pgvector.md
@@ -196,8 +196,10 @@ YugabyteDB currently supports the `vector` type.
 
 You can fine-tune HNSW indexing using the following parameters:
 
-- `m` - specifies the maximum number of connections per layer.
-- `ef_construction` - Specifies the size of the dynamic candidate list for constructing the graph.
+| Parameter | Description | Default |
+| :--- | :--- | :--- |
+| m | Maximum number of connections per layer. Valid range: 5–64. | 32 |
+| ef_construction | Size of the dynamic candidate list for constructing the graph. Valid range: 50–1000. | 200 |
 
 For example:
 

--- a/docs/content/v2025.1/additional-features/pg-extensions/extension-pgvector.md
+++ b/docs/content/v2025.1/additional-features/pg-extensions/extension-pgvector.md
@@ -196,8 +196,10 @@ YugabyteDB currently supports the `vector` type.
 
 You can fine-tune HNSW indexing using the following parameters:
 
-- `m` - specifies the maximum number of connections per layer.
-- `ef_construction` - Specifies the size of the dynamic candidate list for constructing the graph.
+| Parameter | Description | Default |
+| :--- | :--- | :--- |
+| m | Maximum number of connections per layer. Valid range: 5–64. | 32 |
+| ef_construction | Size of the dynamic candidate list for constructing the graph. Valid range: 50–1000. | 200 |
 
 For example:
 


### PR DESCRIPTION
Deploy preview- https://deploy-preview-30546--infallible-bardeen-164bc9.netlify.app/stable/additional-features/pg-extensions/extension-pgvector/#hnsw-index-options

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that reformats and clarifies HNSW tuning parameters; no code or behavior changes.
> 
> **Overview**
> Updates the pgvector docs (`stable`, `v2.25`, `v2025.1`) to replace the brief HNSW option bullets with a small table that explicitly lists `m` and `ef_construction` descriptions, valid ranges, and their defaults.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7090de8560ce631b739ee7f5a3a2796c87ae7274. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->