### PR TITLE
[doc] Linting and format 2025.1rn page

### DIFF
--- a/docs/content/stable/releases/ybdb-releases/v2025.1.md
+++ b/docs/content/stable/releases/ybdb-releases/v2025.1.md
@@ -105,11 +105,11 @@ docker pull yugabytedb/yugabyte:2025.1.3.1-b2
 
 #### YSQL
 
-- Ensures consistent index updates during `INSERT ... ON CONFLICT` operations. {{<issue 30104>}}
+* Ensures consistent index updates during `INSERT ... ON CONFLICT` operations. {{<issue 30104>}}
 
 #### DocDB
 
-- Fixes tablet split validation to handle 0x0000 as an empty key for hash partitions. {{<issue 30062>}}
+* Fixes tablet split validation to handle 0x0000 as an empty key for hash partitions. {{<issue 30062>}}
 
 ## v2025.1.3.0 - January 16, 2026 {#v2025.1.3.0}
 
@@ -159,7 +159,7 @@ docker pull yugabytedb/yugabyte:2025.1.3.0-b75
 * Introduced a GUC to allow users to revert to the previous foreign key triggers snapshot mode, with caution advised. {{<issue 29362>}}
 * Query Diagnostics upgrades to Early Access status in version 2025.1 {{<issue 28959>}}
 * Refined type conversions in index backfill code for better consistency and safety. {{<issue 29038>}}
-* Optimized the postgres build process by removing the redundant and time-consuming install_wrapper.py. {{<issue 29714>}}
+* Optimized the PostgreSQL build process by removing the redundant and time-consuming install_wrapper.py. {{<issue 29714>}}
 * Deprecated the flag `ysql_conn_mgr_max_phy_conn_percent` and introduced new flag `ysql_conn_mgr_reserve_internal_conns` for reserving connections for internal operations. {{<issue 28859>}}
 
 #### DocDB
@@ -169,8 +169,8 @@ docker pull yugabytedb/yugabyte:2025.1.3.0-b75
 * Refactored mutex acquisitions in larger clusters to mitigate contention issues. {{<issue 29186>}}
 * Now captures TCMalloc and MemTrackers stats in logs when root memtracker soft memory limit is exceeded, aiding in memory issues investigation. {{<issue 29050>}}
 * Added tablet replica SST and WAL size to master UI and sorted tablets by partition key. {{<issue 29407>}}
-* Added new `/snapshots` endpoint to tserver UI displaying space overhead information of snapshots, including snapshot ID, time, cumulative required space, exclusive data space, and schedule ID. {{<issue 29388>}}
-* Reenables LogReader memory limit in xCluster following resolution of TryConsume bug. {{<issue 29252>}}
+* Added new `/snapshots` endpoint to TServer UI displaying space overhead information of snapshots, including snapshot ID, time, cumulative required space, exclusive data space, and schedule ID. {{<issue 29388>}}
+* Re-enables LogReader memory limit in xCluster following resolution of TryConsume bug. {{<issue 29252>}}
 * Added compiler errors to Odyssey build for improved compile-time checking. {{<issue 28216>}}
 
 #### CDC
@@ -183,14 +183,14 @@ docker pull yugabytedb/yugabyte:2025.1.3.0-b75
 #### YSQL
 
 * Enhanced handling of empty strings in CatalogEntityPB to prevent parsing failures during table entry deletion. {{<issue 29240>}}
-* Introduced shared data feature for YSQL's pggate in parallel leader and worker processes to ensure each operation has a unique serial number for better execution order control. {{<issue 23648>}}
+* Introduced shared data feature for YSQL pggate in parallel leader and worker processes to ensure each operation has a unique serial number for better execution order control. {{<issue 23648>}}
 * Fixed an issue where integer overflow in the new cost model could lead to negative cost estimates, resulting in poor plan choices. {{<issue 29685>}}
 * Disallowed Batched Nested Loop joins when the inner relation is a temporary table to prevent cache lookup errors or assertion failures. {{<issue 28864>}}
 * Adjusted `CatalogManager::GetYsqlCatalogConfig` to use `catalog_version_table_in_perdb_mode_` over `ysql_enable_db_catalog_version_mode` for accurate per-db mode representation. {{<issue 28690>}}
-* Implemented statement timeouts and interrupt checking in pggate, providing an upper bound for query or operation time and terminating if deadline is reached. Deprecated the unused gflag `pggate_rpc_timeout_secs`. {{<issue 28863>}}
+* Implemented statement timeouts and interrupt checking in pggate, providing an upper bound for query or operation time and terminating if deadline is reached. Deprecated the unused flag `pggate_rpc_timeout_secs`. {{<issue 28863>}}
 * Fixed issue where unique index data was missing for colocated databases after restore, now preserving implicit tablegroup oid. {{<issue 28781>}}
 * Updates process exit behavior on pggate heartbeat failure during initialization. {{<issue 29242>}}
-* Fixed a bug in YugabyteDB's backup and restoration process involving the mismatch of colocation_id in colocated databases. The fix preserves the original colocation_id when implicit indexes are created during the ALTER TABLE statement, ensuring that the colocation ids are consistent after restoration. {{<issue 29260>}}
+* Fixed a bug in YugabyteDB's backup and restoration process involving the mismatch of `colocation_id` in colocated databases. The fix preserves the original `colocation_id` when implicit indexes are created during the ALTER TABLE statement, ensuring that the colocation ids are consistent after restoration. {{<issue 29260>}}
 * Fixed an issue where running ALTER TYPE on a table with dependent indexes triggered double index creation, causing replication conflicts on xCluster targets. {{<issue 27741>}}
 * Fixed a bug that caused crashes when arrays of more than two dimensions are passed to a scalar array operation. {{<issue 29188>}}
 * Fixes are introduced to address intra-query memory leaks during long-running write queries, reducing transient memory spikes and improving memory allocation. {{<issue 29056>}},{{<issue 29057>}}
@@ -199,9 +199,9 @@ docker pull yugabytedb/yugabyte:2025.1.3.0-b75
 * Restored legacy mode costing and path creation behavior in YSQL. This is achieved by reverting BNL specific changes and negating a side effect on row count estimation introduced by boolean index fix. {{<issue 29206>}}
 * Fixed read restart error occurring during concurrent execution of CREATE TEMP TABLE. {{<issue 29704>}}
 * Refactored index backfill code in YSQL for improved readability and efficiency by standardizing field names and optimizing row reading process. {{<issue 29052>}}
-* Introduces a new gflag `ysql_yb_enable_update_reltuples_after_create_index` to update `reltuples` for base table and index after CREATE INDEX, aligning with Postgres behavior. {{<issue 25394>}}
+* Introduces a new flag `ysql_yb_enable_update_reltuples_after_create_index` to update `reltuples` for base table and index after CREATE INDEX, aligning with PostgreSQL behavior. {{<issue 25394>}}
 * Fixed a missing build dependency issue in the yb_pgwrapper library that caused a failure when running build with clean-postgres. {{<issue 29728>}}
-* Adds gflag for GUC `yb_ignore_bool_cond_for_legacy_estimate`, allowing setting via gflag before upgrading from 2.20. {{<issue 29831>}}
+* Adds flag for GUC `yb_ignore_bool_cond_for_legacy_estimate`, allowing setting via flag before upgrading from 2.20. {{<issue 29831>}}
 * Fixed issue where server connection gets stuck due to full server write buffer after ungraceful client disconnects. {{<issue 29301>}}
 * Implemented a fix to remove stale entries from the server's hashmap during connection manager reset phase. {{<issue 29527>}}
 * Fixed the Connection Manager's support for replication connections, ensuring that it independently manages these connections, aligning with PostgreSQL's behavior. {{<issue 28521>}}
@@ -211,9 +211,9 @@ docker pull yugabytedb/yugabyte:2025.1.3.0-b75
 #### DocDB
 
 * Prevents sending of `YBParsePrepareErrorResponse` packet for unnamed prepared statements. {{<issue 29526>}}
-* Prevents TServer process crash and unusable Postgres connections by correctly handling thread creation failure and falling back to RPC mechanism. {{<issue 28968>}}
+* Prevents TServer process crash and unusable PostgreSQL connections by correctly handling thread creation failure and falling back to RPC mechanism. {{<issue 28968>}}
 * Now only live tablet servers are contacted when updating transaction version, enabling deletion of transaction tables even if a tablet server is down. {{<issue 29067>}}
-* Fixed deadlock in MasterSnapshotCoordinator by modifying PopulateDeleteRetainerInfoForTableDrop to pass table_info to IsTabletCoveredBySnapshot. {{<issue 28679>}}
+* Fixed deadlock in MasterSnapshotCoordinator by modifying PopulateDeleteRetainerInfoForTableDrop to pass `table_info` to IsTabletCoveredBySnapshot. {{<issue 28679>}}
 * Resolved backup restore failures by changing the `enable_export_snapshot_using_relfilenode` autoflag from `kLocalVolatile` to `kExternal`, protecting `format_version` field changes in `SnapshotInfoPB`. {{<issue 27155>}}
 * Switched from using SIGQUIT to SIGINT to stop the PostgreSQL postmaster, preventing core dump generation at TServer startup. {{<issue 29670>}}
 * Introduces `min_replay_txn_first_write_ht` to address transaction data loss that occurred due to incorrect filtering of transactions on bootstrap. {{<issue 29642>}}
@@ -222,7 +222,7 @@ docker pull yugabytedb/yugabyte:2025.1.3.0-b75
 * Fixes a process crash that could occur during unique index checks due to incorrect functioning of DBIter's fast next mode with backward iteration. {{<issue 28960>}}
 * Resolved issues related to Read Committed transactions encountering `kDeadlock` errors, especially in cases involving advisory locks and DDL transactions. {{<issue 28593>}}
 * Implemented root memtracker adjustment to limit deviation from TCMalloc stats, avoiding overestimation and false triggering of memory limits. {{<issue 29094>}}
-* Switched from using SIGKILL to SIGQUIT and SIGINT for stopping postmaster process during lease loss and tserver shutdown respectively. {{<issue 28670>}}
+* Switched from using SIGKILL to SIGQUIT and SIGINT for stopping postmaster process during lease loss and TServer shutdown respectively. {{<issue 28670>}}
 * Disables intent filtering for bootstrap due to transaction filtering issues with use_bootstrap_intent_ht_filter set to true. {{<issue 29664>}}
 * Fixes a regression that allowed restoring to a time earlier than the maximum retention window, potentially causing database instability. {{<issue 28699>}}
 * Eliminated potential TCP deadlock in YSQL by changing to asynchronous write in `od_frontend_remote_client`. {{<issue 29303>}}
@@ -379,7 +379,7 @@ docker pull yugabytedb/yugabyte:2025.1.2.0-b110
 * Ensures YSQL index backfill operations resume seamlessly after a master leader failover. {{<issue 6218>}}
 * Adds extra locality info from PostgreSQL to TServer for better transaction categorization and performance. {{<issue 28270>}}
 * Enhances row boundary settings for hash-partitioned tables using encoded DocKeys. {{<issue 28219>}}
-* Enables integration of YSQL with PG's snapshot management for Repeatable Read isolation level. {{<issue 28333>}}
+* Enables integration of YSQL with PostgreSQL snapshot management for Repeatable Read isolation level. {{<issue 28333>}}
 * Add a new counter to track new connections performing catalog preloads, aiding in debugging. {{<issue 28538>}}
 * Sets stricter copyright enforcement for C++ files on master but reduces rule severity on backport branches. {{<issue 28602>}}
 * Adds the ability to display commit stats with the EXPLAIN command, helping users understand latency in multi-region workloads. {{<issue 26964>}}
@@ -387,13 +387,13 @@ docker pull yugabytedb/yugabyte:2025.1.2.0-b110
 * Enhances logging for tracking unexpected full catalog refreshes in YSQL. {{<issue 27387>}}
 * Streamlines request pagination in scans for consistent behavior across all directions. {{<issue 27738>}}
 * Adds new YSQL configuration parameter `yb_enable_cbo=legacy_ignore_stats_bnl_mode`. {{<issue 28703>}}
-* Set YSQL configuration parameter `yb_read_after_commit_visibility` to `relaxed` to avoid `restart read required` errors during yb_index_check. {{<issue 27288>}}
+* Set YSQL configuration parameter `yb_read_after_commit_visibility` to `relaxed` to avoid `restart read required` errors during `yb_index_check`. {{<issue 27288>}}
 * Expands EXPLAIN (ANALYZE, DIST) output to include transaction type, enabling a more formal way to deduce transaction type. {{<issue 14804>}}
-* Increases timeout for tserver catalog version wait to 30 seconds, reducing connection time outs. {{<issue 28978>}}
-* Allows preloading of RANGEMULTIRANGE to reduce cache misses when pg_range is preloaded. {{<issue 28991>}}
+* Increases timeout for TServer catalog version wait to 30 seconds, reducing connection time outs. {{<issue 28978>}}
+* Allows preloading of RANGEMULTIRANGE to reduce cache misses when `pg_range` is preloaded. {{<issue 28991>}}
 * Fixes `pg_total_relation_size` to include index sizes, ensuring accurate and consistent size reporting across YugabyteDB's distributed storage. {{<issue 23181>}}
 * Displays storage flush reasons under debug logs for better query performance analysis. {{<issue 27588>}}
-* Reduces peak memory usage in yb_active_session_history by filtering out rows more quickly. {{<issue 29089>}}
+* Reduces peak memory usage in `yb_active_session_history` by filtering out rows more quickly. {{<issue 29089>}}
 * Enables viewing tcmalloc memory statistics for the connection manager. {{<issue 28371>}}
 * Enhances CM decision-making by always using a custom ParameterStatus packet. {{<issue 28012>}}
 
@@ -413,8 +413,8 @@ docker pull yugabytedb/yugabyte:2025.1.2.0-b110
 * Displays xCluster safe time on yb-master UI page for enhanced debugging. {{<issue 28910>}}
 * Adds server-level metrics to track the number of transactions started as global, region-local, and tablespace-local. {{<issue 28921>}}
 * Introduces two YSQL configuration parameters to control use of tablespace-local locality, offering workaround for suboptimal performance in certain cases. {{<issue 28604>}}
-* Calculates region locality on the tserver side for improved region local transactions handling. {{<issue 28828>}}
-* Reduces latency of YSQL write statements and lock-grabbing reads in distributed transactions by enabling async writes. {{<issue 28382>}}
+* Calculates region locality on the TServer side for improved region local transactions handling. {{<issue 28828>}}
+* Reduces latency of YSQL write statements and lock-grabbing reads in distributed transactions by enabling asynchronous writes. {{<issue 28382>}}
 * Allows reads and writes to proceed without waiting for a full quorum acknowledgment, reducing YSQL write and read latencies. {{<issue 28320>}}
 * Adds upgrade check to detect and require removal of invalid indexes. {{<issue 28484>}}
 * Enables skipping network compression for SST files during remote bootstrap, improving latencies and scale-out times. {{<issue 28360>}}
@@ -436,7 +436,7 @@ docker pull yugabytedb/yugabyte:2025.1.2.0-b110
 * Allows users to preload `pg_enum` in `ysql_catalog_preload_additional_table_list`. {{<issue 28757>}}
 * Prevents YSQL major upgrade failure caused by inconsistent namespace mapping during a failed upgrade attempt. {{<issue 28815>}}
 * Allows `yb-admin ysql_catalog_version` command to return per-DB Catalog Version value for a provided database. {{<issue 28690>}}
-* Allows group and others read permission on initdb log files by hardcoding the permission. {{<issue 28435>}}
+* Allows group and others read permission on initdb log files by hard coding the permission. {{<issue 28435>}}
 * Ensures `TimeZone` is not lowercased in connection manager for correct pgJDBC interpretation. {{<issue 28537>}}
 * Allows the use of PostgreSQL's snapshot management for foreign key triggers in YSQL, eliminating potential foreign key violations and enhancing data integrity. {{<issue 26163>}}
 * Disables writes to role profile tables during YSQL upgrades to prevent errors. {{<issue 28016>}}
@@ -647,7 +647,7 @@ For more information, refer to [xCluster replication](/v2025.1/architecture/docd
 * Includes transaction isolation level in serialization error messages. {{<issue 28114>}}
 * Enables bounded staleness for PostgreSQL authentication backend cache using `pg_cache_response_trust_auth_lifetime_limit_ms`. {{<issue 28261>}}
 * Allows dynamic updates to `ysql_hba_conf_csv` without server restarts. {{<issue 28361>}}
-* Reduces master RPCs for PG auth backends by using tserver cache. {{<issue 28144>}}
+* Reduces master RPCs for PG auth backends by using TServer cache. {{<issue 28144>}}
 * Disables Memoize under BNL to reduce CPU overhead without sacrificing performance. {{<issue 25251>}}
 * Ensures proper error handling for unsupported LISTEN commands in connection manager mode. {{<issue 27503>}},{{<issue 26929>}}
 * Adds a flag `ysql_enable_scram_channel_binding` to enable SCRAM with channel binding. {{<issue 28108>}}
@@ -660,7 +660,7 @@ For more information, refer to [xCluster replication](/v2025.1/architecture/docd
 * Ensures only voter peers are considered for leadership during a leader stepdown. {{<issue 27568>}}
 * Fixes overflow in `FormatBytesAsStr` to prevent large memory allocations. {{<issue 27924>}}
 * Ensures reliable xCluster history cutoff by backfilling `namespace_id` when necessary. {{<issue 28124>}}
-* Refactors shared memory management for better session control between tserver and pggate. {{<issue 27484>}}
+* Refactors shared memory management for better session control between TServer and pggate. {{<issue 27484>}}
 * Allows exporting snapshots with tables undergoing DDL operations. {{<issue 27425>}}
 * Reduces risks by not updating `master_ysql_operation_lease_ttl_ms` flag unnecessarily. {{<issue 27681>}}
 * Ensures xCluster DDL replication tables are included in backups. {{<issue 27959>}}
@@ -806,14 +806,14 @@ For more information, refer to [xCluster replication](/v2025.1/architecture/docd
 * Prevents deadlocks by setting status tablet ID for shared memory lock requests. {{<issue 27921>}}
 * Eliminates DFATAL error for unregistered lock owners handling exclusive locks. {{<issue 27968>}}
 * Ensures `TSLocalLockManager` is only created when both `enable_ysql` and `enable_object_locking_for_table_locks` are enabled. {{<issue 28126>}}
-* Enables `ALTER DEFAULT PRIVILEGES` commands in xCluster's automatic mode. {{<issue 27051>}}
+* Enables `ALTER DEFAULT PRIVILEGES` commands in xCluster automatic mode. {{<issue 27051>}}
 * Defers transaction priority assignment to the first read/write operation. {{<issue 28125>}}
 * Enhances metrics to better estimate cluster balancing times and validate the accuracy of the balancing algorithm. {{<issue 23908>}}
 * Restores deletion of table info objects to prevent memory overload. {{<issue 23721>}}
 * Stops xCluster polling when excessive DDL errors occur, preventing retries beyond limits. {{<issue 28363>}}
 * Fixes issues with aborted transactions during promotions preventing stuck operations. {{<issue 27853>}}
 * Ensures master metadata snapshots are consistent with `snapshot_hybrid_time` for accurate backups. {{<issue 27575>}}
-* Restores previous deadlock detection by retrying lock requests from the host tserver. {{<issue 28386>}}
+* Restores previous deadlock detection by retrying lock requests from the host TServer. {{<issue 28386>}}
 * Enforces TLS v1.2 for secure webserver connections. {{<issue 28417>}}
 * Ensures cloning databases functions correctly with table locks enabled. {{<issue 27800>}}
 * Preserves cluster balancer metrics correctly across all placements including read replicas. {{<issue 28366>}}
@@ -974,55 +974,55 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 
 ### New features
 
-- yugabyted
+* yugabyted
 
-  - Support for [upgrading to PG15](/v2025.1/manage/ysql-major-upgrade-yugabyted/) using yugabyted. {{<tags/feature/ea idea="1746">}}
+  * Support for [upgrading to PG15](/v2025.1/manage/ysql-major-upgrade-yugabyted/) using yugabyted. {{<tags/feature/ea idea="1746">}}
 
-  - A new yugabyted UI tab displays the [xCluster](/v2025.1/reference/configuration/yugabyted/#xcluster) replication details of the source and destination universe. {{<tags/feature/ga idea="1763">}}
+  * A new yugabyted UI tab displays the [xCluster](/v2025.1/reference/configuration/yugabyted/#xcluster) replication details of the source and destination universe. {{<tags/feature/ga idea="1763">}}
 
-  - Adds support for IPv6 addresses. {{<tags/feature/ga idea="1854">}}
+  * Adds support for IPv6 addresses. {{<tags/feature/ga idea="1854">}}
 
-  - [Voyager assessment UI enhancements](/stable/yugabyte-voyager/migrate/assess-migration/#get-started-with-migration-assessment) which provide detailed information on migration complexity and breakdown of schema recommendation. {{<tags/feature/ga idea="2184">}}
+  * [Voyager assessment UI enhancements](/stable/yugabyte-voyager/migrate/assess-migration/#get-started-with-migration-assessment) which provide detailed information on migration complexity and breakdown of schema recommendation. {{<tags/feature/ga idea="2184">}}
 
-- [Catalog caching](/v2025.1/best-practices-operations/ysql-catalog-cache-tuning-guide/).
+* [Catalog caching](/v2025.1/best-practices-operations/ysql-catalog-cache-tuning-guide/).
 
-  - Provides ability to find catalog tables which can be preloaded to improve latency for first query in connection or after DDL in the cluster. {{<tags/feature/ga idea="1781">}}
+  * Provides ability to find catalog tables which can be preloaded to improve latency for first query in connection or after DDL in the cluster. {{<tags/feature/ga idea="1781">}}
 
-  - Compressed catalog tuples when storing in the PG catalog cache to reduce the memory consumption. {{<tags/feature/ga idea="1229">}}
+  * Compressed catalog tuples when storing in the PG catalog cache to reduce the memory consumption. {{<tags/feature/ga idea="1229">}}
 
-  - Optimized DDL performance by enabling targeted catalog cache invalidation, significantly reducing impact on concurrent DMLs. This avoids rebuilding the entire cache in most cases. {{<tags/feature/ga idea="599">}}
+  * Optimized DDL performance by enabling targeted catalog cache invalidation, significantly reducing impact on concurrent DMLs. This avoids rebuilding the entire cache in most cases. {{<tags/feature/ga idea="599">}}
 
-- [Sampling schema in Analyze](/v2025.1/reference/configuration/yb-tserver/#yb-sampling-algorithm). With sampled analyze, the time to analyze a table is no longer proportional to the size of the table. This improvement brings the time to analyze down significantly. For example, time to analyze 1 TB table is down from 35 minutes to under 3 minutes. {{<tags/feature/ga idea="1790">}}
+* [Sampling schema in Analyze](/v2025.1/reference/configuration/yb-tserver/#yb-sampling-algorithm). With sampled analyze, the time to analyze a table is no longer proportional to the size of the table. This improvement brings the time to analyze down significantly. For example, time to analyze 1 TB table is down from 35 minutes to under 3 minutes. {{<tags/feature/ga idea="1790">}}
 
-- Improved bulk load performance for colocated tables. Introduced a fast path support for bulk load scenarios for colocated tables in particular (controlled by [ysql_colocated_fastpath_txn_copy](/v2025.1/api/ysql/the-sql-language/statements/cmd_copy/#copy-with-fast-path-transaction-for-colocated-tables)) that can improve `COPY` times up to 3x on colocated tables with multiple indexes. {{<tags/feature/ga idea="1802">}}
+* Improved bulk load performance for colocated tables. Introduced a fast path support for bulk load scenarios for colocated tables in particular (controlled by [ysql_colocated_fastpath_txn_copy](/v2025.1/api/ysql/the-sql-language/statements/cmd_copy/#copy-with-fast-path-transaction-for-colocated-tables)) that can improve `COPY` times up to 3x on colocated tables with multiple indexes. {{<tags/feature/ga idea="1802">}}
 
-- [Advisory locks](/v2025.1/explore/transactions/explicit-locking/#advisory-locks). Enables session-based and transactional advisory locks for coordination and concurrency control in distributed environments. {{<tags/feature/ga idea="812">}}
+* [Advisory locks](/v2025.1/explore/transactions/explicit-locking/#advisory-locks). Enables session-based and transactional advisory locks for coordination and concurrency control in distributed environments. {{<tags/feature/ga idea="812">}}
 
-- [Non-disruptive adding of indexes for xCluster](/v2025.1/deploy/multi-dc/async-replication/async-transactional-tables/). Adding an index to a database configured with [bi-directional xCluster Replication](/v2025.1/deploy/multi-dc/async-replication/async-deployment/#add-ysql-indexes-in-bidirectional-replication) (or other non-transactional xCluster Replication) is now a non-disruptive, no-downtime operation. {{<tags/feature/ga idea="1536">}}
+* [Non-disruptive adding of indexes for xCluster](/v2025.1/deploy/multi-dc/async-replication/async-transactional-tables/). Adding an index to a database configured with [bi-directional xCluster Replication](/v2025.1/deploy/multi-dc/async-replication/async-deployment/#add-ysql-indexes-in-bidirectional-replication) (or other non-transactional xCluster Replication) is now a non-disruptive, no-downtime operation. {{<tags/feature/ga idea="1536">}}
 
-- [PITR-flashback query](/v2025.1/manage/backup-restore/time-travel-query/). Allows querying historical database state by specifying a past timestamp, aiding in auditing, debugging, and data analysis. {{<tags/feature/ea idea="1182">}}
+* [PITR-flashback query](/v2025.1/manage/backup-restore/time-travel-query/). Allows querying historical database state by specifying a past timestamp, aiding in auditing, debugging, and data analysis. {{<tags/feature/ea idea="1182">}}
 
-- [Foreign key references](/v2025.1/explore/ysql-language-features/advanced-features/partitions/#foreign-key-references). Allows creation of the foreign keys on partitioned tables. {{<tags/feature/ga idea="467">}}
+* [Foreign key references](/v2025.1/explore/ysql-language-features/advanced-features/partitions/#foreign-key-references). Allows creation of the foreign keys on partitioned tables. {{<tags/feature/ga idea="467">}}
 
-- [NULLS NOT DISTINCT](/v2025.1/api/ysql/the-sql-language/statements/ddl_create_index/#nulls-not-distinct). By default unique indexes treat NULL values as distinct entries (and not equal), allowing multiple nulls for a column. NULLS NOT DISTINCT allows multiple NULL values to be treated equivalently. {{<tags/feature/ga idea="934">}}
+* [NULLS NOT DISTINCT](/v2025.1/api/ysql/the-sql-language/statements/ddl_create_index/#nulls-not-distinct). By default unique indexes treat NULL values as distinct entries (and not equal), allowing multiple nulls for a column. NULLS NOT DISTINCT allows multiple NULL values to be treated equivalently. {{<tags/feature/ga idea="934">}}
 
-- Execution for queries using [ON CONFLICT clause](/stable/develop/best-practices-develop/data-modeling-perf/#upsert-multiple-rows-wherever-possible) are optimized for efficient execution for YugabyteDB distributed architecture. {{<tags/feature/ga idea="1455">}}
+* Execution for queries using [ON CONFLICT clause](/stable/develop/best-practices-develop/data-modeling-perf/#upsert-multiple-rows-wherever-possible) are optimized for efficient execution for YugabyteDB distributed architecture. {{<tags/feature/ga idea="1455">}}
 
-- [Query Plan Management (QPM)](/v2025.1/launch-and-manage/monitor-and-alert/query-tuning/pg-hint-plan/) introduced to ensure stable and adaptable query performance by preventing plan regression and automatically detecting optimal new plans. {{<tags/feature/ea idea="1107">}}
+* [Query Plan Management (QPM)](/v2025.1/launch-and-manage/monitor-and-alert/query-tuning/pg-hint-plan/) introduced to ensure stable and adaptable query performance by preventing plan regression and automatically detecting optimal new plans. {{<tags/feature/ea idea="1107">}}
 
-- [YSQL table inheritance](/v2025.1/explore/ysql-language-features/advanced-features/inheritance/). Adds YSQL support for table inheritance using the INHERITS keyword, which allows creating child tables that inherit columns and certain constraints from one or more parent tables. {{<tags/feature/tp idea="2158">}}
+* [YSQL table inheritance](/v2025.1/explore/ysql-language-features/advanced-features/inheritance/). Adds YSQL support for table inheritance using the INHERITS keyword, which allows creating child tables that inherit columns and certain constraints from one or more parent tables. {{<tags/feature/tp idea="2158">}}
 
-- [YSQL index consistency checker](/v2025.1/api/ysql/exprs/func_yb_index_check/). yb_index_check() is a built-in utility that helps detect and diagnose index inconsistencies in your database to ensure reliable query results. {{<tags/feature/ea idea="2160">}}
+* [YSQL index consistency checker](/v2025.1/api/ysql/exprs/func_yb_index_check/). yb_index_check() is a built-in utility that helps detect and diagnose index inconsistencies in your database to ensure reliable query results. {{<tags/feature/ea idea="2160">}}
 
-- [YSQL lease mechanism](/v2025.1/architecture/transactions/concurrency-control/#ysql-lease-mechanism). Enabled a robust lease mechanism between YB-TServer and YB-Master to enhance fault tolerance and data consistency during network partitions. {{<tags/feature/ga>}}
+* [YSQL lease mechanism](/v2025.1/architecture/transactions/concurrency-control/#ysql-lease-mechanism). Enabled a robust lease mechanism between YB-TServer and YB-Master to enhance fault tolerance and data consistency during network partitions. {{<tags/feature/ga>}}
 
-- [Transactional DDL](/v2025.1/explore/transactions/transactional-ddl/). Support to align YSQL DDL semantics with PostgreSQL by allowing DDL statements to execute within the main transaction block. {{<tags/feature/tp idea="1677">}}
+* [Transactional DDL](/v2025.1/explore/transactions/transactional-ddl/). Support to align YSQL DDL semantics with PostgreSQL by allowing DDL statements to execute in the main transaction block. {{<tags/feature/tp idea="1677">}}
 
-- Added [CDC Logical Replication support](/v2025.1/additional-features/change-data-capture/using-logical-replication/get-started/) for xCluster feature where both CDC and xCluster can work simultaneously on the same source tables. {{<tags/feature/ea idea="82">}}
+* Added [CDC Logical Replication support](/v2025.1/additional-features/change-data-capture/using-logical-replication/get-started/) for xCluster feature where both CDC and xCluster can work simultaneously on the same source tables. {{<tags/feature/ea idea="82">}}
 
-- [Active Session History](/v2025.1/explore/observability/active-session-history/). Get real-time and historical information about active sessions to analyze and troubleshoot performance issues. {{<tags/feature/ga idea="830">}}
+* [Active Session History](/v2025.1/explore/observability/active-session-history/). Get real-time and historical information about active sessions to analyze and troubleshoot performance issues. {{<tags/feature/ga idea="830">}}
 
-- [PostgreSQL Anonymizer](/v2025.1/additional-features/pg-extensions/extension-pganon/) extension, which masks or replaces personally identifiable information (PII) or commercially sensitive data, is now bundled with Yugabyte. {{<tags/feature/ga idea="1497">}}
+* [PostgreSQL Anonymizer](/v2025.1/additional-features/pg-extensions/extension-pganon/) extension, which masks or replaces personally identifiable information (PII) or commercially sensitive data, is now bundled with Yugabyte. {{<tags/feature/ga idea="1497">}}
 
 ### Change log
 
@@ -1052,12 +1052,12 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 * Allows setting `enable_ysql_conn_mgr` to true for general availability. {{<issue 25578>}}
 * Enhances error transparency when dropping databases or users. {{<issue 21438>}}
 * Supports executing DDL statements in READ COMMITTED isolation with options to disable retries. {{<issue 27716>}}
-* Sets `yb_bnl_batch_size` to 1024 and `yb_prefer_bnl` to true by default, ensuring BNL's replace nested loop joins without altering non-NL join plans. {{<issue 19273>}}
-* Adds pg_hint_plan syntax and functionality to control batched nested loop joins, allows setting hints `YbBatchedNL(t1 t2)` and `NoYbBatchedNL`, and modifies `yb_prefer_bnl` handling. Also, it removes BNL's dependency on `enable_nestloop` and adjusts cost model. {{<issue 19494>}}
+* Sets `yb_bnl_batch_size` to 1024 and `yb_prefer_bnl` to true by default, ensuring BNL replace nested loop joins without altering non-NL join plans. {{<issue 19273>}}
+* Adds pg_hint_plan syntax and functionality to control batched nested loop joins, allows setting hints `YbBatchedNL(t1 t2)` and `NoYbBatchedNL`, and modifies `yb_prefer_bnl` handling. Also, it removes BNL dependency on `enable_nestloop` and adjusts cost model. {{<issue 19494>}}
 * Simplifies handling of ybctids from multiple sources in PgDml. {{<issue 25162>}}
 * Allows preloading of foreign key lists in relcache, avoiding on-demand master fetches, controlled by `yb_enable_fkey_catcache`. {{<issue 23686>}}
 * Enables creation of indexes that are covered by the main table. {{<issue 24123>}}
-* Enables faster LZ4 compression for large attributes in YSQL with upgraded thirdparty support. {{<issue 24290>}}
+* Enables faster LZ4 compression for large attributes in YSQL with upgraded third party support. {{<issue 24290>}}
 * Adds notes on pinned objects and script backporting to the README. {{<issue 24334>}}
 * Prevents catalog version bumps on no-op `ALTER ROLE` commands, saving system resources. {{<issue 24390>}}
 * Enhances object creation efficiency by using static factory methods in `PgDML` classes. {{<issue 24412>}}
@@ -1069,7 +1069,7 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 * Adds `ybctid` as a reserved, fully queryable system column for improved row identification. {{<issue 1284>}}
 * Fixes style issues and lint errors in `ybcModifyTable.c`. {{<issue 24882>}}
 * Simplifies `ybcSetupTargets` by using BMS only, enhancing target column handling. {{<issue 25007>}}
-* Simplifies index requests for copartitioned vector indexes, enhancing efficiency. {{<issue 25047>}}
+* Simplifies index requests for co-partitioned vector indexes, enhancing efficiency. {{<issue 25047>}}
 * Excludes third-party extensions from PostgreSQL linter checks. {{<issue 25054>}}
 * Fixes segmentation fault in `CREATE OR REPLACE TRIGGER` by ensuring `ybctid` is set. {{<issue 24941>}}
 * Simplifies DML read pushdown binding for enhanced coding efficiency. {{<issue 25151>}}
@@ -1128,11 +1128,11 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 * Enables on-demand logging and enhanced catalog cache statistics tracking. {{<issue 26023>}}
 * Enables conditional checks for role existence in `ysql_dump` outputs with the `dump_role_checks` flag. {{<issue 25877>}}
 * Removes the check that the first operation in a plain session must set the read time. {{<issue 26151>}}
-* Enhances code consistency in `ybgate_api.h` by matching Postgres style. {{<issue 26176>}}
+* Enhances code consistency in `ybgate_api.h` by matching PostgreSQL style. {{<issue 26176>}}
 * Consolidates multiple suppression flags into one for cleaner `pg_regress` outputs. {{<issue 26197>}}
 * Refactors `PgDocReadOp` to enhance modularity by isolating sampling logic into `PgDocSampleOp`. {{<issue 26165>}}
 * Restores CREATE permission on the public schema to `yb_db_admin`. {{<issue 26218>}}
-* Enables `ALTER TYPE ... SET SCHEMA` support for orafce extension upgrades. {{<issue 26215>}}
+* Enables `ALTER TYPE ... SET SCHEMA` support for Orafce extension upgrades. {{<issue 26215>}}
 * Enhances `pg_stat_get_progress_info` by adding new fields. {{<issue 26273>}}
 * Eliminates unnecessary workaround in `ALTER TABLE` operations related to constraint handling. {{<issue 26315>}}
 * Reinstates checks for `ash_metadata` in PgClient RPC requests with added code explanations. {{<issue 26268>}}
@@ -1151,7 +1151,7 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 * Excludes PostgreSQL owned code from `bad_variable_declaration_spacing` lint rule. {{<issue 26651>}}
 * Adds `server_type` option to differentiate foreign servers in `postgres_fdw`. {{<issue 25500>}}
 * Renames `switch_fallthrough` to `yb_switch_fallthrough` for consistency. {{<issue 26816>}}
-* Enables the PostgreSQL anonymizer extension via the `enable_pg_anonymizer` flag. {{<issue 26804>}}
+* Enables the PostgreSQL Anonymizer extension via the `enable_pg_anonymizer` flag. {{<issue 26804>}}
 * Enhances error reporting by including index names for missing rows. {{<issue 26819>}}
 * Displays rows removed by YugabyteDB index recheck in execution plans. {{<issue 26827>}}
 * Aligns `get_relation_constraint_attnos` function to use correct flag. {{<issue 26846>}}
@@ -1178,8 +1178,8 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 * Enhances the handling of response cache during major version upgrades to prevent errors. {{<issue 27435>}}
 * Streamlines the database by removing obsolete functions related to drop/remove object by OID. {{<issue 27352>}}
 * Enables automatic logging of peak heap snapshots on backend exits for enhanced debugging. {{<issue 27487>}}
-* Enables setting `ysql_yb_enable_cbo` flag on tserver for query optimization. {{<issue 27495>}}
-* Adds verbose logging for Perform RPCs between Pg and Tserver via shared memory. {{<issue 27571>}}
+* Enables setting `ysql_yb_enable_cbo` flag on TServer for query optimization. {{<issue 27495>}}
+* Adds verbose logging for Perform RPCs between Pg and TServer via shared memory. {{<issue 27571>}}
 * Enhances code style in `src/backend/tcop/` as per linting reports. {{<issue 25189>}}
 * Adds query ID and leader PID to the `/rpcz` endpoint response. {{<issue 25603>}}
 * Enhances `pg_stats` with length and bounds histograms for better query planning. {{<issue 6237>}}
@@ -1197,18 +1197,18 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 
 * Reduces unnecessary attribute map creations during Prometheus metric aggregation. {{<issue 24405>}}
 * Enhances load balancer to prioritize under-replicated tablets first. {{<issue 20263>}}
-* Limits concurrent remote bootstraps per tserver using `load_balancer_max_inbound_remote_bootstraps_per_tserver` flag. {{<issue 2426>}}
+* Limits concurrent remote bootstraps per TServer using `load_balancer_max_inbound_remote_bootstraps_per_tserver` flag. {{<issue 2426>}}
 * Enables placing intermediate CA certificates directly in the server cert file for node-to-node encryption. {{<issue 25972>}}
 * Tracks ByteBuffer memory usage with `MemTracker`. {{<issue 26875>}}
 * Adds data block consistency check to `sst_dump` tool. {{<issue 27233>}}
 * Adds flag to allow tablet writes after a compaction failure. {{<issue 27269>}}
 * Adds `remove_corrupt_data_blocks_unsafe` flag for `yb-ts-cli compact_tablet` command. {{<issue 27381>}}
 * Prevents overloading by correctly categorizing bootstrapping tablets in load balancing. {{<issue 23487>}}
-* Allows reduction of thread stack size to avoid Linux hugepage backing. {{<issue 23927>}}
+* Allows reduction of thread stack size to avoid Linux hugepages backing. {{<issue 23927>}}
 * Upgrades non-FIPS OpenSSL to 3.0.15 and removes CentOS 7 builds. {{<issue 24436>}}
 * Enhances RBS throttling by focusing on active fetch sessions and adjusts expiration logic. {{<issue 21563>}},{{<issue 24031>}}
 * Allows dynamic adjustment of `rocksdb_compact_flush_rate_limit_bytes_per_sec` across all tablets. {{<issue 25611>}}
-* Selects geographically closest tserver for faster clone operations. {{<issue 26788>}}
+* Selects geographically closest TServer for faster clone operations. {{<issue 26788>}}
 * Displays detailed RBS progress on the master's Cluster Balancer UI page. {{<issue 26853>}},{{<issue 27397>}}
 * Upgrades OpenSSL to version 3.0.16 and enhances aarch64 support. {{<issue 27491>}}
 * Optimizes backward scans by using `Seek` for faster access to recent updates when needed. {{<issue 22373>}}
@@ -1218,7 +1218,7 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 * Enables xCluster to support and replicate table rewrite DDL operations effectively. {{<issue 23955>}}
 * Updates and organizes third-party dependencies like `usearch` for better maintainability. {{<issue 23998>}}
 * Simplifies HNSW library structure by using a factory-based approach. {{<issue 24085>}}
-* Allows explicit addition of gFlags to `gflag_allowlist.txt` for secure callhome data collection, plus `version_info` in tserver data. {{<issue 24103>}}
+* Allows explicit addition of flags to `gflag_allowlist.txt` for secure callhome data collection, plus `version_info` in TServer data. {{<issue 24103>}}
 * Enables xCluster to handle non-colocated ALTER TABLE commands without pausing replication. {{<issue 23951>}}
 * Passes `automatic_ddl_mode` to xCluster pollers for enhanced replication handling. {{<issue 24091>}}
 * Adds a metric to alert users when the master follower heartbeat delay is too high. {{<issue 21178>}}
@@ -1239,7 +1239,7 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 * Renames the vector library to vector_index and updates the namespace accordingly. {{<issue 24636>}}
 * Introduces the `rocksdb_determine_compaction_input_at_start` flag, allowing the selection of SST files for compaction when the task starts rather than when it's queued. {{<issue 24541>}}
 * Creates vector index tablets colocated with the indexed table for effective data retrieval. {{<issue 24696>}}
-* Enables direct replication of specific DDL commands in XCluster. {{<issue 23953>}}
+* Enables direct replication of specific DDL commands in xCluster. {{<issue 23953>}}
 * Reduces Prometheus metric scrape time from 15 seconds to 2 seconds. {{<issue 24565>}}
 * Reverts a change that issued NOTICE on index creation in bi-directional xCluster setups. {{<issue 24362>}}
 * Enables creation of Vector LSM for tablets with vector indices. {{<issue 24892>}}
@@ -1251,7 +1251,7 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 * Enables ALTER operations on colocated tables with active replication. {{<issue 24910>}}
 * Adds packed row support for vector indexes during transaction apply. {{<issue 24912>}}
 * Fetches intents DB for vector index queries to account for unapplied committed transactions. {{<issue 24947>}}
-* Enables building with thirdparty PR artifacts using specific GitHub IDs. {{<issue 25089>}}
+* Enables building with third party PR artifacts using specific GitHub IDs. {{<issue 25089>}}
 * Enables vector indexes on colocated tables. {{<issue 24994>}}
 * Allows vector index inserts to use a dedicated thread pool, enhancing overall system performance. {{<issue 25029>}}
 * Replaces `vector_index::VertexId` with `StronglyTypedUuid` as `VectorId`. {{<issue 25038>}}
@@ -1264,7 +1264,7 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 * Enables DDL replication for common PostgreSQL extensions in YugabyteDB. {{<issue 25052>}}
 * Clarifies error messages during yb-master initialization. {{<issue 25176>}}
 * Reduces CPU usage by only setting `stmt_max_mem_base_bytes` during `EXPLAIN ANALYZE`. {{<issue 25174>}}
-* Reduces tserver CPU usage by using `serialized_request` size instead of `SpaceUsedLong`. {{<issue 25175>}}
+* Reduces TServer CPU usage by using `serialized_request` size instead of `SpaceUsedLong`. {{<issue 25175>}}
 * Enables advisory lock operations in DocDB, controlled by the flag `yb_enable_advisory_lock`. {{<issue 24357>}}
 * Enables monitoring of long tasks in Reactor threads with `rpc_reactor_task_timeout_ms`. {{<issue 25180>}}
 * Speeds up database creation by batching table lock acquisitions. {{<issue 25203>}}
@@ -1278,7 +1278,7 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 * Adds `automatic_ddl_mode` argument to `yb-admin create_xcluster_checkpoint`. {{<issue 25302>}}
 * Enables TSAN for RWCLock, fixing potential deadlocks. {{<issue 25391>}}
 * Refactors lock management code to use static dispatch for compatibility with shared memory. {{<issue 25322>}}
-* Ensures vector indexes are updated during tablet bootstrap if the tserver stops unexpectedly. {{<issue 25325>}}
+* Ensures vector indexes are updated during tablet bootstrap if the TServer stops unexpectedly. {{<issue 25325>}}
 * Enhances search by filtering vectors on TServer based on deletion, updates, and criteria. {{<issue 25357>}}
 * Enables remote bootstrap for vector index storage. {{<issue 25369>}}
 * Reduces the need for global mutex locks by introducing per-transaction LockTracker state. {{<issue 25379>}}
@@ -1317,7 +1317,7 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 * Enables sequence replication in xCluster by default, removing the need for a flag. {{<issue 26029>}}
 * Enhances the user message for setting `yb_read_time` to clarify read-only restrictions. {{<issue 26027>}}
 * Adds logging for vector index search stats when `vector_index_dump_stats` flag is true. {{<issue 26072>}}
-* Ensures consistent bootstrapping of vector indexes after a tserver restart. {{<issue 26087>}}
+* Ensures consistent bootstrapping of vector indexes after a TServer restart. {{<issue 26087>}}
 * Enhances handling of expired snapshots by retrying deletion tasks automatically. {{<issue 25628>}}
 * Correctly displays advisory lock details in `pg_locks` view. {{<issue 24712>}}
 * Ensures vector index contains all entries from the indexed table. {{<issue 26150>}}
@@ -1356,7 +1356,7 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 * Removes `-ftime-trace` from Clang builds to enhance compatibility with ccache. {{<issue 27499>}}
 * Defers processing of records with commit times exceeding the apply safe time to the next batch. {{<issue 27318>}}
 * Removes outdated code to streamline heartbeat processing. {{<issue 24872>}}
-* Simplifies load balancer's placement info management. {{<issue 25065>}}
+* Simplifies load balancer placement info management. {{<issue 25065>}}
 * Streamlines tablespace validation by centralizing logic, enhancing future feature support. {{<issue 25202>}}
 * Enhances maintainability by consolidating tablespace validation logic into `TablespaceParser`. {{<issue 25202>}}
 * Deprecates the `load_balancer_count_move_as_add` flag to simplify cluster balancing. {{<issue 26259>}}
@@ -1367,7 +1367,7 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 #### CDC
 
 * Enables asynchronous removal of user tables from CDC streams by adjusting how background threads process and persist stream metadata. {{<issue 23700>}}
-* Enables tablet splitting on tables under CDCSDK stream by default using the GFLAG `enable_tablet_split_of_cdcsdk_streamed_tables`. {{<issue 24190>}}
+* Enables tablet splitting on tables under CDCSDK stream by default using the flag `enable_tablet_split_of_cdcsdk_streamed_tables`. {{<issue 24190>}}
 * Adds a tag for the slot name attribute in the CDC metrics. {{<issue 24307>}}
 * Blocks creation of `IMPLICIT` streams by default; use flag to override. {{<issue 24023>}}
 * Enhances CDC accuracy by using the minimum of last WAL OP timestamp and transaction start time in segment footers. {{<issue 25163>}}
@@ -1380,7 +1380,7 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 * Adds parallel logical replication with consistent tablet subsetting under the `ysql_yb_enable_consistent_replication_from_hash_range` flag. {{<issue 25897>}}
 * Reduces `cdcsdk_publication_list_refresh_interval_secs` to 15 minutes by default. {{<issue 25793>}}
 * Adds `cdcsdk_flush_lag` metric and fixes bugs in other CDC metrics. {{<issue 19445>}},{{<issue 25819>}}
-* Limits the number of VirtualWAL instances per tserver with `cdc_max_virtual_wal_per_tserver` flag. {{<issue 25896>}}
+* Limits the number of VirtualWAL instances per TServer with `cdc_max_virtual_wal_per_tserver` flag. {{<issue 25896>}}
 * Enhances CDC streaming by advancing restart time in idle periods, supported by the new flag `cdcsdk_update_restart_time_interval_secs`. {{<issue 25562>}}
 * Reduces logging frequency for certain CDC errors to avoid clutter. {{<issue 26148>}}
 * Sets `wal_status` in `pg_replication_slots` based on CDC consumption timing. {{<issue 26272>}}
@@ -1401,9 +1401,9 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 
 * Removes `psutil` dependency in `yugabyted` for better compatibility. {{<issue 26350>}}
 * Enables better handling of complex YSQL configuration parameters using sticky connections. {{<issue 21637>}}
-* Stops sending gflags details in the callhome diagnostics to eliminate redundant data. {{<issue 24029>}}
+* Stops sending flags details in the callhome diagnostics to eliminate redundant data. {{<issue 24029>}}
 * Ensures the user interface accurately displays disk size, even when multiple data directories are used. {{<issue 23810>}}
-* Ensures `join` flag in config files is properly validated to prevent node misconfiguration. {{<issue 23007>}}
+* Ensures `join` flag in configuration files is properly validated to prevent node misconfiguration. {{<issue 23007>}}
 * Enables `tserver_master_addresses` to update immediately in multi-node deployments using `Yb-ts-cli`. {{<issue 24659>}}
 * Updates column names in `pg_stat_statements` to fix slow queries page on yugabyted UI. {{<issue 25094>}}
 * Increases row count capacity in metrics API by using `int64` instead of `int32`. {{<issue 25196>}}
@@ -1420,10 +1420,10 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 #### YSQL
 
 * Resets `current_hint_retrieved` after query execution to ensure consistent hint parsing. {{<issue 12741>}}
-* Introduces a per-database PG new OID allocator, ensuring OID uniqueness within the database and enhancing horizontal scalability in multi-node and multi-tenancy environments. This new mechanism mitigates OID collisions and allows OID consistency in backup-restore scenarios across clusters. A new GFlag `ysql_enable_pg_per_database_oid_allocator` is provided to return to old OID allocator behavior if necessary. {{<issue 16130>}}
+* Introduces a per-database PG new OID allocator, ensuring OID uniqueness in the database and enhancing horizontal scalability in multi-node and multi-tenancy environments. This new mechanism mitigates OID collisions and allows OID consistency in backup-restore scenarios across clusters. A new flag `ysql_enable_pg_per_database_oid_allocator` is provided to return to old OID allocator behavior if necessary. {{<issue 16130>}}
 * Modifies backup/restore process to skip column name checks for indexes, allowing for successful restoration even with renamed columns. {{<issue 24207>}}
 * Enables `ALTER SEQUENCE` commands to change sequence name, schema, and owner without errors. {{<issue 17271>}}
-* Enhances Postgres restart stability by refining shutdown handling and lock file management. {{<issue 24396>}}
+* Enhances PostgreSQL restart stability by refining shutdown handling and lock file management. {{<issue 24396>}}
 * Reduces memory usage during YugabyteDB connection startup. {{<issue 24925>}}
 * Removes an erroneous log entry that appeared in crashes or errors. {{<issue 24533>}}
 * Enhances protocol flow for consistency in batched query executions using a new flag `ysql_conn_mgr_optimized_extended_query_protocol`. {{<issue 24898>}}
@@ -1440,7 +1440,7 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 * Enables creating non-colocated leaf partitions on colocated partitioned tables. {{<issue 24542>}}
 * Ensures joins are only pruned when a Leading hint exists, avoiding errors. {{<issue 26670>}}
 * Fixes flag overlap to differentiate `sticky` settings from `explain` in configurations. {{<issue 24954>}}
-* Standardizes function usage for `ATExecSetTableSpaceNoStorage`to match PG's approach. {{<issue 25019>}}
+* Standardizes function usage for `ATExecSetTableSpaceNoStorage`to match PostgreSQL's approach. {{<issue 25019>}}
 * Removes an unnecessary code block to streamline backend selection in connection management. {{<issue 25154>}}
 * Corrects tuple ID construction for primary keys with out-of-order columns. {{<issue 25070>}}
 * Restores functionality by removing explicit packet parsing for `yb_is_client_ysqlconnmgr`. {{<issue 25220>}}
@@ -1453,7 +1453,7 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 * Avoids unnecessary catalog version bumps during in-place materialized view refreshes. {{<issue 26154>}}
 * Disables index-only scans on copartitioned indexes. {{<issue 26344>}}
 * Allows placement of table replicas in any specified region or zone using `*` wildcard. {{<issue 26671>}}
-* Corrects a queue ordering logic by using `std::lower_bound` to prevent tserver crashes. {{<issue 27170>}}
+* Corrects a queue ordering logic by using `std::lower_bound` to prevent TServer crashes. {{<issue 27170>}}
 * Fixes `ANALYZE` failures on wide tables by adjusting fetch size limits. {{<issue 27202>}}
 * Enhances session stickiness when acquiring session-scoped advisory locks. {{<issue 27249>}}
 * Reduces sequence-related errors when using `ysql_conn_mgr_sequence_support_mode=pooled_with_currval_lastval`. {{<issue 27024>}}
@@ -1463,7 +1463,7 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 * Prevents segmentation faults in parallel index scans with aggregate pushdown. {{<issue 21427>}}
 * Introduces custom SQL error codes for better error handling across processes. {{<issue 22353>}}
 * Increases performance by batching index reads during `INSERT ON CONFLICT`, with customizable batch sizes using `yb_insert_on_conflict_read_batch_size`. {{<issue 24179>}}
-* Improves cache re-invalidation for `ALTER TABLE` commands to avoid schema version mismatch errors within the same session. {{<issue 23882>}}
+* Improves cache re-invalidation for `ALTER TABLE` commands to avoid schema version mismatch errors in the same session. {{<issue 23882>}}
 * Fixes UPDATE errors on partitioned tables by correctly mapping column numbers. {{<issue 23857>}}
 * Ensures restart read time does not exceed the global limit to avoid inconsistent reads. {{<issue 24017>}}
 * Fixes the flaw in the current DDL atomicity workflow where only the first table's schema was compared, even if it doesn't change after a schema version increment. {{<issue 23988>}}
@@ -1529,7 +1529,7 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 * Fixes issues with `INSERT ON CONFLICT` queries using `SPI_execute_with_args`. {{<issue 25773>}}
 * Reverts `ALTER DATABASE RENAME` and `ALTER DATABASE OWNER` to global impact. {{<issue 25742>}}
 * Fixes memory leaks and segmentation faults in YSQL Connection Manager. {{<issue 25718>}}
-* Fixes memory leaks in the PostgreSQL anonymizer extension and optimizes test scheduling. {{<issue 25928>}}
+* Fixes memory leaks in the PostgreSQL Anonymizer extension and optimizes test scheduling. {{<issue 25928>}}
 * Fixes potential negative cost calculations for large table scans by using `double` for estimates. {{<issue 25862>}}
 * Fixes `\d` command for indexes with spaces in their names. {{<issue 25711>}}
 * Prevents returning corrupt data for `INSERT ON CONFLICT` with `RETURNING` when read batching is enabled. {{<issue 25836>}}
@@ -1565,7 +1565,7 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 * Fixes integer overflow in BNL cost estimation, preventing negative values. {{<issue 26463>}}
 * Prevents incorrect sharing of query limits in subplan executions. {{<issue 26485>}},{{<issue 26418>}}
 * Adds a YSQL configuration parameter to customize negative catalog caching. {{<issue 26311>}},{{<issue 26358>}}
-* Ensures the `vmodule` flag is respected by the Postgres process. {{<issue 26521>}}
+* Ensures the `vmodule` flag is respected by the postgres process. {{<issue 26521>}}
 * Adds `liblz4.1.dylib` to macOS `yugabyte-client` package for successful deployment. {{<issue 26523>}}
 * Enables `ANALYZE` to collect accurate stats for parent-level of partitioned tables. {{<issue 23592>}}
 * Prevents crashes by handling non-variable expressions in single-row updates or deletes. {{<issue 26536>}}
@@ -1621,7 +1621,7 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 
 #### DocDB
 
-* Allows the packed row size to exceed its limit during repacking, preventing tserver crash after `alter table add column` commands with a default value. {{<issue 24050>}}
+* Allows the packed row size to exceed its limit during repacking, preventing TServer crash after `alter table add column` commands with a default value. {{<issue 24050>}}
 * Prevents server crashes during table truncation by safely shutting down iterators before releasing locks. {{<issue 23243>}}
 * Prevents resource waste by checking disk space before remote bootstrap operations. {{<issue 23987>}}
 * Adds a flag to limit multiple pending compactions for priority pools. {{<issue 24540>}}
@@ -1633,13 +1633,13 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 * Prevents crashes when calling `ListMasterServers` RPC on a master by returning an error. {{<issue 20372>}}
 * Upgrades tcmalloc and abseil to prevent crashes from `malloc_usable_size(nullptr)`. {{<issue 25948>}}
 * Prevents creation of tablespaces with duplicate placement blocks. {{<issue 23406>}}
-* Prevents crashes by ensuring non-null frontiers during transaction apply after a tserver restart. {{<issue 396>}}
+* Prevents crashes by ensuring non-null frontiers during transaction apply after a TServer restart. {{<issue 396>}}
 * Fixes load balancing for rewritten tables in colocated databases. {{<issue 26262>}}
 * Prevents deadlocks in PG sessions when using shared memory, enhancing stability. {{<issue 26672>}}
 * Fixes crashes in ProcessSupervisor when unable to restart a process. {{<issue 26731>}}
 * Ensures yb-admin commands respect user-specified timeouts for table flushes and compactions. {{<issue 19957>}}
 * Prevents deadlocks and unresponsiveness during high-load schema changes by fetching table info asynchronously. {{<issue 26909>}}
-* Reduces follower lag by ensuring consistent Raft config during tablet splits. {{<issue 26644>}}
+* Reduces follower lag by ensuring consistent Raft configuration during tablet splits. {{<issue 26644>}}
 * Ensures accurate replication for transactional writes on xCluster range partitioned tables. {{<issue 27380>}}
 * Ensures post-split compactions complete even if background compactions are in progress. {{<issue 27426>}}
 * Ensures consistent data reads by setting propagated safe time only after successful operation replication. {{<issue 23696>}}
@@ -1652,7 +1652,7 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 * Resolves the shutdown issue with the shared exchange causing TServer to hang by properly managing concurrent threads and session destruction, and sets `pg_client_use_shared_memory` to false by default on Mac to enhance performance. {{<issue 24000>}}
 * Adds a null check to prevent a system crash when cleaning up a recently applied transaction state after a flush operation. {{<issue 24026>}}
 * Prevents crashes during compaction when `ysql_enable_packed_row` is off and existing packed rows are present. {{<issue 24545>}}
-* Updates YSQL migration script to align with Postgres 15 catalog changes. {{<issue 24593>}}
+* Updates YSQL migration script to align with PostgreSQL 15 catalog changes. {{<issue 24593>}}
 * Switches pg_cron back to using standard `SIGTERM` handling for cleaner shutdowns. {{<issue 24658>}}
 * Ensures tablets remain effectively managed during transition from RF1 to higher replication factors. {{<issue 24575>}}
 * Ensures consistent tablegroup assignments for colocated table backups without using explicit tablespaces. {{<issue 24809>}}
@@ -1663,7 +1663,7 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 * Ensures accurate `WaitForReplicationDrain` behavior by not mislabeling tablets as drained. {{<issue 25457>}}
 * Prevents crash during transaction abort by adjusting lock handling. {{<issue 25689>}}
 * Ensures fast backward scans return accurate results by fully checking row changes. {{<issue 26060>}}
-* Enables cloning databases to any time within the snapshot schedule retention period. {{<issue 26293>}}
+* Enables cloning databases to any time in the snapshot schedule retention period. {{<issue 26293>}}
 * Enables `lock_timeout` for advisory locks, enhancing timeout precision. {{<issue 26513>}}
 * Fixes handling of `db_max_flushing_bytes` to properly limit memory usage under high write loads. {{<issue 26916>}}
 * Fixes crashes when executing `SELECT * FROM pg_locks` during advisory lock waits. {{<issue 26972>}}
@@ -1688,7 +1688,7 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 * Enables merging of small vector index chunks to enhance search efficiency. {{<issue 24069>}}
 * Fixes shutdown path issues to prevent fatal errors during RPC completion. {{<issue 24524>}}
 * Ensures `pg_txn_start_us` is set for restarted transactions, fixing priority issues in waiter resumption. {{<issue 24778>}}
-* Fixes mini cluster restarts to ensure master leaders track all tserver reconnections. {{<issue 24772>}}
+* Fixes mini cluster restarts to ensure master leaders track all TServer reconnections. {{<issue 24772>}}
 * Reduces latency by enhancing early resume of RPCs blocked on aborted transactions. {{<issue 24799>}}
 * Fixes memory leak in MasterPathHandlers by properly managing shared pointers. {{<issue 24823>}}
 * Ensures callback triggers after loading tablet server data if the count meets requirements. {{<issue 23744>}}
@@ -1712,10 +1712,10 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 * Reduces false deadlock errors in session advisory lock handling. {{<issue 25753>}},{{<issue 25761>}}
 * Ensures correct database IDs are used for xCluster replication setup. {{<issue 25770>}}
 * Disallows write DML operations in time-traveling sessions set with `yb_read_time`. {{<issue 25834>}}
-* Disables pushdown of MD5 and SHA256 to prevent tserver crashes. {{<issue 25889>}}
+* Disables pushdown of MD5 and SHA256 to prevent TServer crashes. {{<issue 25889>}}
 * Ensures `pg_locks` functions correctly even with active advisory locks by ignoring advisory lock tablets. {{<issue 25939>}}
 * Corrects the namespace of `TSLocalLockManager` to `yb::tserver`. {{<issue 25941>}}
-* Ensures builds with thirdparty PR artifacts now function correctly. {{<issue 25970>}}
+* Ensures builds with third party PR artifacts now function correctly. {{<issue 25970>}}
 * Enables cloning databases with sequences to earlier states without errors. {{<issue 25929>}}
 * Enables `pg_locks` to show active PostgreSQL advisory locks. {{<issue 26057>}}
 * Prevents false conflict detection in snapshot isolation operations. {{<issue 26142>}}
@@ -1751,7 +1751,7 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 * Enables YSQL transaction tracing with `pg_client_use_shared_memory` enabled. {{<issue 27392>}}
 * Ensures no deadlock when threads wait on PgResponseCache for query results. {{<issue 27412>}}
 * Increases `RollbackYsqlMajorVersionUpgrade` RPC timeout to 3 minutes. {{<issue 24361>}}
-* Adds race conditions in the odyssey library to the TSAN suppressions list. {{<issue 24735>}}
+* Adds race conditions in the odyssey library to the TSAN suppression list. {{<issue 24735>}}
 * Reduces data race when changing RocksDB options during auto-compactions. {{<issue 24238>}}
 * Fixes deadlock issue by adjusting lock acquisition order in HierarchicalNSW. {{<issue 25017>}}
 * Ensures tasks don't hang during shutdown by removing unnecessary checks. {{<issue 17898>}}
@@ -1790,7 +1790,7 @@ Fast backward scans are now enabled by default (`use_fast_backward_scan=true`). 
 
 #### yugabyted
 
-* Checks for chrony service before enabling clockbound during node start. {{<issue 26255>}}
+* Checks for chrony service before enabling ClockBound during node start. {{<issue 26255>}}
 * Preserves the universe key locally after enabling EAR for recovery scenarios. {{<issue 26552>}}
 * Nodes now start using private IP as `advertise_address` instead of hostname. {{<issue 25037>}}
 * Adds `use_client_to_server_encryption` flag to secure login data. {{<issue 25332>}}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only edits (formatting and wording) with no runtime or behavioral changes.
> 
> **Overview**
> **Release notes formatting cleanup.** Standardizes bullet/list markup (fixing inconsistent `--` vs `*` usage and indentation) across the `v2025.1` release notes.
> 
> **Copy/terminology normalization.** Rewords and capitalizes terms for consistency (for example `Postgres`→`PostgreSQL`, `tserver`→`TServer`, `gflag`→`flag`) and adds backticks around identifiers like `colocation_id` and `table_info`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed49481ef138e6b0acbd968f766f364c4a96e00a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->