### PR TITLE
[DOC-1217] Added commands compact_vector_index and compact_table_by_id

### DIFF
--- a/docs/content/stable/admin/yb-admin.md
+++ b/docs/content/stable/admin/yb-admin.md
@@ -455,8 +455,8 @@ yb-admin \
 * *namespace*: The name of the database (for YSQL) or keyspace (for YCQL).
 * *table*: The name of the table to compact.
 * *timeout-in-seconds*: Specifies duration (in seconds) yb-admin waits for compaction to end. Default is `20`.
-* ADD_INDEXES: Whether to compact the secondary indexes associated with the table. Default is `false`. YCQL only.
-* ADD_VECTOR_INDEXES: Whether to compact the [vector indexes](../../additional-features/pg-extensions/extension-pgvector/#vector-indexing) (pgvector) associated with the table. Default is `false`.
+* ADD_INDEXES: Indicates to compact the secondary indexes associated with the table. YCQL only.
+* ADD_VECTOR_INDEXES: Indicates to compact the [vector indexes](../../additional-features/pg-extensions/extension-pgvector/#vector-indexing) (pgvector) associated with the table.
 
 **Example**
 
@@ -481,8 +481,8 @@ yb-admin \
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default is `localhost:7100`.
 * *table-id*: The unique UUID associated with the table.
 * *timeout-in-seconds*: Specifies duration (in seconds) yb-admin waits for compaction to end. Default is `20`.
-* ADD_INDEXES: Whether to compact the secondary indexes associated with the table. Default is `false`. YCQL only.
-* ADD_VECTOR_INDEXES: Whether to compact the [vector indexes](../../additional-features/pg-extensions/extension-pgvector/#vector-indexing) (pgvector) associated with the table. Default is `false`.
+* ADD_INDEXES: Indicates to compact the secondary indexes associated with the table. YCQL only.
+* ADD_VECTOR_INDEXES: Indicates to compact the [vector indexes](../../additional-features/pg-extensions/extension-pgvector/#vector-indexing) (pgvector) associated with the table.
 
 **Example**
 
@@ -511,8 +511,8 @@ yb-admin \
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default is `localhost:7100`.
 * *table-id*: The unique UUID associated with the table.
 * *timeout-in-seconds*: Specifies duration (in seconds) yb-admin waits for compaction to end. Default is `20`.
-* ADD_INDEXES: Whether to compact the secondary indexes associated with the table. Default is `false`. YCQL only.
-* ADD_VECTOR_INDEXES: Whether to compact the [vector indexes](/stable/additional-features/pg-extensions/extension-pgvector/) (pgvector) associated with the table. Default is `false`.
+* ADD_INDEXES: Indicates to compact the secondary indexes associated with the table. YCQL only.
+* ADD_VECTOR_INDEXES: Indicates to compact the [vector indexes](/stable/additional-features/pg-extensions/extension-pgvector/) (pgvector) associated with the table.
 
 **Example**
 
@@ -722,7 +722,7 @@ yb-admin \
 * *namespace*: The name of the database (for YSQL) or keyspace (for YCQL).
 * *table*: The name of the table to flush.
 * *timeout-in-seconds*: Specifies duration (in seconds) yb-admin waits for flushing to end. Default is `20`.
-* ADD_INDEXES: Whether to flush the secondary indexes associated with the table. Default is `false`.
+* ADD_INDEXES: Indicates to flush the secondary indexes associated with the table.
 
 **Example**
 
@@ -748,7 +748,7 @@ yb-admin \
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default is `localhost:7100`.
 * *table-id*: The unique UUID associated with the table.
 * *timeout-in-seconds*: Specifies duration (in seconds) yb-admin waits for flushing to end. Default is `20`.
-* ADD_INDEXES: Whether to flush the secondary indexes associated with the table. Default is `false`.
+* ADD_INDEXES: Indicates to flush the secondary indexes associated with the table.
 
 **Example**
 

--- a/docs/content/stable/admin/yb-ts-cli.md
+++ b/docs/content/stable/admin/yb-ts-cli.md
@@ -91,11 +91,11 @@ Compact the specified tablet on the tablet server.
 **Syntax**
 
 ```sh
-yb-ts-cli [ --server_address=<host>:<port> ] compact_tablet <tablet_id>
+yb-ts-cli [ --server_address=<host>:<port> ] compact_tablet <tablet-id>
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
-* *tablet_id*: The identifier of the tablet to compact.
+* *tablet-id*: The identifier of the tablet to compact.
 
 ### compact_vector_index
 
@@ -104,12 +104,12 @@ Trigger compaction of [vector indexes](../../additional-features/pg-extensions/e
 **Syntax**
 
 ```sh
-yb-ts-cli [ --server_address=<host>:<port> ] compact_vector_index <tablet_id> [<vector_index_id1> <vector_index_id2> ...]
+yb-ts-cli [ --server_address=<host>:<port> ] compact_vector_index <tablet-id> [<vector-index-id1> <vector-index-id2> ...]
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
-* *tablet_id*: The identifier of the tablet that contains the vector index(es).
-* *vector_index_id1*, *vector_index_id2*, ...: Optional. Table IDs of specific vector indexes to compact. If omitted, all vector indexes on the tablet are compacted.
+* *tablet-id*: The identifier of the tablet that contains the vector index(es).
+* *vector-index-id1*, *vector-index-id2*, ...: Optional. Table IDs of specific vector indexes to compact. If omitted, all vector indexes on the tablet are compacted.
 
 ### count_intents
 
@@ -137,30 +137,30 @@ yb-ts-cli  [ --server_address=<host>:<port> ] current_hybrid_time
 
 ### delete_tablet
 
-Deletes the tablet with the specified tablet ID (`tablet_id`) and reason.
+Deletes the tablet with the specified tablet ID (`tablet-id`) and reason.
 
 **Syntax**
 
 ```sh
-yb-ts-cli  [ --server_address=<host>:<port> ] delete_tablet <tablet_id> "<reason-string>"
+yb-ts-cli  [ --server_address=<host>:<port> ] delete_tablet <tablet-id> "<reason-string>"
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
-* *tablet_id*: The identifier (ID) for the tablet.
+* *tablet-id*: The identifier (ID) for the tablet.
 * *reason-string*: Text string providing information on why the tablet was deleted.
 
 ### dump_tablet
 
-Dump, or export, the specified tablet ID (`tablet_id`).
+Dump, or export, the specified tablet ID (`tablet-id`).
 
 **Syntax**
 
 ```sh
-yb-ts-cli [ --server_address=<host>:<port> ] dump_tablet <tablet_id>
+yb-ts-cli [ --server_address=<host>:<port> ] dump_tablet <tablet-id>
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
-* *tablet_id*: The identifier (ID) for the tablet.
+* *tablet-id*: The identifier (ID) for the tablet.
 
 ### flush_all_tablets
 
@@ -181,11 +181,11 @@ Flush the specified tablet on the tablet server.
 **Syntax**
 
 ```sh
-yb-ts-cli [ --server_address=<host>:<port> ] flush_tablet <tablet_id>
+yb-ts-cli [ --server_address=<host>:<port> ] flush_tablet <tablet-id>
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
-* *tablet_id*: The identifier of the tablet to compact.
+* *tablet-id*: The identifier of the tablet to flush.
 
 ### list_tablets
 
@@ -218,12 +218,12 @@ Trigger a remote bootstrap of a tablet from another tablet server to the specifi
 **Syntax**
 
 ```sh
-yb-ts-cli [ --server_address=<host>:<port> ] remote_bootstrap <source_host> <tablet_id>
+yb-ts-cli [ --server_address=<host>:<port> ] remote_bootstrap <source-host> <tablet-id>
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server running the remote bootstrap. Default is `localhost:9100`.
-* *source_host*: The *host* or *host* and *port* of the tablet server to bootstrap from.
-* *tablet_id*: The identifier of the tablet to trigger a remote bootstrap for.
+* *source-host*: The *host* or *host* and *port* of the tablet server to bootstrap from.
+* *tablet-id*: The identifier of the tablet to trigger a remote bootstrap for.
 
 See [Manual remote bootstrap of failed peer](/stable/troubleshoot/cluster/replace_failed_peers/) for example usage.
 

--- a/docs/content/v2.20/admin/yb-admin.md
+++ b/docs/content/v2.20/admin/yb-admin.md
@@ -453,7 +453,7 @@ yb-admin \
 * *namespace*: The name of the database (for YSQL) or keyspace (for YCQL).
 * *table*: The name of the table to compact.
 * *timeout_in_seconds*: Specifies duration (in seconds) yb-admin waits for compaction to end. Default value is `20`.
-* *ADD_INDEXES*: Whether to compact the secondary indexes associated with the table. Default is `false`.
+* *ADD_INDEXES*: Indicates to compact the secondary indexes associated with the table.
 
 **Example**
 
@@ -478,7 +478,7 @@ yb-admin \
 * *master_addresses*: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.
 * *table_id*: The unique UUID associated with the table.
 * *timeout_in_seconds*: Specifies duration (in seconds) yb-admin waits for compaction to end. Default value is `20`.
-* *ADD_INDEXES*: Whether to compact the secondary indexes associated with the table. Default is `false`.
+* *ADD_INDEXES*: Indicates to compact the secondary indexes associated with the table.
 
 **Example**
 
@@ -688,7 +688,7 @@ yb-admin \
 * *namespace*: The name of the database (for YSQL) or keyspace (for YCQL).
 * *table*: The name of the table to flush.
 * *timeout_in_seconds*: Specifies duration (in seconds) yb-admin waits for flushing to end. Default value is `20`.
-* *ADD_INDEXES*: Whether to flush the secondary indexes associated with the table. Default is `false`.
+* *ADD_INDEXES*: Indicates to flush the secondary indexes associated with the table.
 
 **Example**
 
@@ -714,7 +714,7 @@ yb-admin \
 * *master_addresses*: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.
 * *table_id*: The unique UUID associated with the table.
 * *timeout_in_seconds*: Specifies duration (in seconds) yb-admin waits for flushing to end. Default value is `20`.
-* *ADD_INDEXES*: Whether to flush the secondary indexes associated with the table. Default is `false`.
+* *ADD_INDEXES*: Indicates to flush the secondary indexes associated with the table.
 
 **Example**
 

--- a/docs/content/v2.20/admin/yb-ts-cli.md
+++ b/docs/content/v2.20/admin/yb-ts-cli.md
@@ -98,11 +98,11 @@ Compact the specified tablet on the tablet server.
 **Syntax**
 
 ```sh
-yb-ts-cli [ --server_address=<host>:<port> ] compact_tablet <tablet_id>
+yb-ts-cli [ --server_address=<host>:<port> ] compact_tablet <tablet-id>
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
-* *tablet_id*: The identifier of the tablet to compact.
+* *tablet-id*: The identifier of the tablet to compact.
 
 ##### count_intents
 
@@ -130,30 +130,30 @@ yb-ts-cli  [ --server_address=<host>:<port> ] current_hybrid_time
 
 ##### delete_tablet
 
-Deletes the tablet with the specified tablet ID (`tablet_id`) and reason.
+Deletes the tablet with the specified tablet ID (`tablet-id`) and reason.
 
 **Syntax**
 
 ```sh
-yb-ts-cli  [ --server_address=<host>:<port> ] delete_tablet <tablet_id> "<reason-string>"
+yb-ts-cli  [ --server_address=<host>:<port> ] delete_tablet <tablet-id> "<reason-string>"
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
-* *tablet_id*: The identifier (ID) for the tablet.
+* *tablet-id*: The identifier (ID) for the tablet.
 * *reason-string*: Text string providing useful information on why the tablet was deleted.
 
 ##### dump_tablet
 
-Dump, or export, the specified tablet ID (`tablet_id`).
+Dump, or export, the specified tablet ID (`tablet-id`).
 
 **Syntax**
 
 ```sh
-yb-ts-cli [ --server_address=<host>:<port> ] dump_tablet <tablet_id>
+yb-ts-cli [ --server_address=<host>:<port> ] dump_tablet <tablet-id>
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
-* *tablet_id*: The identifier (ID) for the tablet.
+* *tablet-id*: The identifier (ID) for the tablet.
 
 ##### flush_all_tablets
 
@@ -174,11 +174,11 @@ Flush the specified tablet on the tablet server.
 **Syntax**
 
 ```sh
-yb-ts-cli [ --server_address=<host>:<port> ] flush_tablet <tablet_id>
+yb-ts-cli [ --server_address=<host>:<port> ] flush_tablet <tablet-id>
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
-* *tablet_id*: The identifier of the tablet to compact.
+* *tablet-id*: The identifier of the tablet to flush.
 
 ##### list_tablets
 
@@ -211,12 +211,12 @@ Trigger a remote bootstrap of a tablet from another tablet server to the specifi
 **Syntax**
 
 ```sh
-yb-ts-cli [ --server_address=<host>:<port> ] remote_bootstrap <source_host> <tablet_id>
+yb-ts-cli [ --server_address=<host>:<port> ] remote_bootstrap <source-host> <tablet-id>
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server running the remote bootstrap. Default is `localhost:9100`.
-* *source_host*: The *host* or *host* and *port* of the tablet server to bootstrap from.
-* *tablet_id*: The identifier of the tablet to trigger a remote bootstrap for.
+* *source-host*: The *host* or *host* and *port* of the tablet server to bootstrap from.
+* *tablet-id*: The identifier of the tablet to trigger a remote bootstrap for.
 
 See [Manual remote bootstrap of failed peer](/stable/troubleshoot/cluster/replace_failed_peers/) for example usage.
 

--- a/docs/content/v2024.1/admin/yb-admin.md
+++ b/docs/content/v2024.1/admin/yb-admin.md
@@ -453,7 +453,7 @@ yb-admin \
 * *namespace*: The name of the database (for YSQL) or keyspace (for YCQL).
 * *table*: The name of the table to compact.
 * *timeout_in_seconds*: Specifies duration (in seconds) yb-admin waits for compaction to end. Default value is `20`.
-* *ADD_INDEXES*: Whether to compact the secondary indexes associated with the table. Default is `false`.
+* *ADD_INDEXES*: Indicates to compact the secondary indexes associated with the table.
 
 **Example**
 
@@ -478,7 +478,7 @@ yb-admin \
 * *master_addresses*: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.
 * *table_id*: The unique UUID associated with the table.
 * *timeout_in_seconds*: Specifies duration (in seconds) yb-admin waits for compaction to end. Default value is `20`.
-* *ADD_INDEXES*: Whether to compact the secondary indexes associated with the table. Default is `false`.
+* *ADD_INDEXES*: Indicates to compact the secondary indexes associated with the table.
 
 **Example**
 
@@ -688,7 +688,7 @@ yb-admin \
 * *namespace*: The name of the database (for YSQL) or keyspace (for YCQL).
 * *table*: The name of the table to flush.
 * *timeout_in_seconds*: Specifies duration (in seconds) yb-admin waits for flushing to end. Default value is `20`.
-* *ADD_INDEXES*: Whether to flush the secondary indexes associated with the table. Default is `false`.
+* *ADD_INDEXES*: Indicates to flush the secondary indexes associated with the table.
 
 **Example**
 
@@ -714,7 +714,7 @@ yb-admin \
 * *master_addresses*: Comma-separated list of YB-Master hosts and ports. Default value is `localhost:7100`.
 * *table_id*: The unique UUID associated with the table.
 * *timeout_in_seconds*: Specifies duration (in seconds) yb-admin waits for flushing to end. Default value is `20`.
-* *ADD_INDEXES*: Whether to flush the secondary indexes associated with the table. Default is `false`.
+* *ADD_INDEXES*: Indicates to flush the secondary indexes associated with the table.
 
 **Example**
 

--- a/docs/content/v2024.1/admin/yb-ts-cli.md
+++ b/docs/content/v2024.1/admin/yb-ts-cli.md
@@ -110,11 +110,11 @@ Compact the specified tablet on the tablet server.
 **Syntax**
 
 ```sh
-yb-ts-cli [ --server_address=<host>:<port> ] compact_tablet <tablet_id>
+yb-ts-cli [ --server_address=<host>:<port> ] compact_tablet <tablet-id>
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
-* *tablet_id*: The identifier of the tablet to compact.
+* *tablet-id*: The identifier of the tablet to compact.
 
 ##### count_intents
 
@@ -142,30 +142,30 @@ yb-ts-cli  [ --server_address=<host>:<port> ] current_hybrid_time
 
 ##### delete_tablet
 
-Deletes the tablet with the specified tablet ID (`tablet_id`) and reason.
+Deletes the tablet with the specified tablet ID (`tablet-id`) and reason.
 
 **Syntax**
 
 ```sh
-yb-ts-cli  [ --server_address=<host>:<port> ] delete_tablet <tablet_id> "<reason-string>"
+yb-ts-cli  [ --server_address=<host>:<port> ] delete_tablet <tablet-id> "<reason-string>"
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
-* *tablet_id*: The identifier (ID) for the tablet.
+* *tablet-id*: The identifier (ID) for the tablet.
 * *reason-string*: Text string providing information on why the tablet was deleted.
 
 ##### dump_tablet
 
-Dump, or export, the specified tablet ID (`tablet_id`).
+Dump, or export, the specified tablet ID (`tablet-id`).
 
 **Syntax**
 
 ```sh
-yb-ts-cli [ --server_address=<host>:<port> ] dump_tablet <tablet_id>
+yb-ts-cli [ --server_address=<host>:<port> ] dump_tablet <tablet-id>
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
-* *tablet_id*: The identifier (ID) for the tablet.
+* *tablet-id*: The identifier (ID) for the tablet.
 
 ##### flush_all_tablets
 
@@ -186,11 +186,11 @@ Flush the specified tablet on the tablet server.
 **Syntax**
 
 ```sh
-yb-ts-cli [ --server_address=<host>:<port> ] flush_tablet <tablet_id>
+yb-ts-cli [ --server_address=<host>:<port> ] flush_tablet <tablet-id>
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
-* *tablet_id*: The identifier of the tablet to compact.
+* *tablet-id*: The identifier of the tablet to flush.
 
 ##### list_tablets
 
@@ -223,12 +223,12 @@ Trigger a remote bootstrap of a tablet from another tablet server to the specifi
 **Syntax**
 
 ```sh
-yb-ts-cli [ --server_address=<host>:<port> ] remote_bootstrap <source_host> <tablet_id>
+yb-ts-cli [ --server_address=<host>:<port> ] remote_bootstrap <source-host> <tablet-id>
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server running the remote bootstrap. Default is `localhost:9100`.
-* *source_host*: The *host* or *host* and *port* of the tablet server to bootstrap from.
-* *tablet_id*: The identifier of the tablet to trigger a remote bootstrap for.
+* *source-host*: The *host* or *host* and *port* of the tablet server to bootstrap from.
+* *tablet-id*: The identifier of the tablet to trigger a remote bootstrap for.
 
 See [Manual remote bootstrap of failed peer](/stable/troubleshoot/cluster/replace_failed_peers/) for example usage.
 

--- a/docs/content/v2024.2/admin/yb-admin.md
+++ b/docs/content/v2024.2/admin/yb-admin.md
@@ -455,7 +455,7 @@ yb-admin \
 * *namespace*: The name of the database (for YSQL) or keyspace (for YCQL).
 * *table*: The name of the table to compact.
 * *timeout-in-seconds*: Specifies duration (in seconds) yb-admin waits for compaction to end. Default is `20`.
-* ADD_INDEXES: Whether to compact the secondary indexes associated with the table. Default is `false`.
+* ADD_INDEXES: Indicates to compact the secondary indexes associated with the table.
 
 **Example**
 
@@ -480,7 +480,7 @@ yb-admin \
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default is `localhost:7100`.
 * *table-id*: The unique UUID associated with the table.
 * *timeout-in-seconds*: Specifies duration (in seconds) yb-admin waits for compaction to end. Default is `20`.
-* ADD_INDEXES: Whether to compact the secondary indexes associated with the table. Default is `false`.
+* ADD_INDEXES: Indicates to compact the secondary indexes associated with the table.
 
 **Example**
 
@@ -690,7 +690,7 @@ yb-admin \
 * *namespace*: The name of the database (for YSQL) or keyspace (for YCQL).
 * *table*: The name of the table to flush.
 * *timeout-in-seconds*: Specifies duration (in seconds) yb-admin waits for flushing to end. Default is `20`.
-* ADD_INDEXES: Whether to flush the secondary indexes associated with the table. Default is `false`.
+* ADD_INDEXES: Indicates to flush the secondary indexes associated with the table.
 
 **Example**
 
@@ -716,7 +716,7 @@ yb-admin \
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default is `localhost:7100`.
 * *table-id*: The unique UUID associated with the table.
 * *timeout-in-seconds*: Specifies duration (in seconds) yb-admin waits for flushing to end. Default is `20`.
-* ADD_INDEXES: Whether to flush the secondary indexes associated with the table. Default is `false`.
+* ADD_INDEXES: Indicates to flush the secondary indexes associated with the table.
 
 **Example**
 

--- a/docs/content/v2024.2/admin/yb-ts-cli.md
+++ b/docs/content/v2024.2/admin/yb-ts-cli.md
@@ -91,11 +91,11 @@ Compact the specified tablet on the tablet server.
 **Syntax**
 
 ```sh
-yb-ts-cli [ --server_address=<host>:<port> ] compact_tablet <tablet_id>
+yb-ts-cli [ --server_address=<host>:<port> ] compact_tablet <tablet-id>
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
-* *tablet_id*: The identifier of the tablet to compact.
+* *tablet-id*: The identifier of the tablet to compact.
 
 ### count_intents
 
@@ -123,30 +123,30 @@ yb-ts-cli  [ --server_address=<host>:<port> ] current_hybrid_time
 
 ### delete_tablet
 
-Deletes the tablet with the specified tablet ID (`tablet_id`) and reason.
+Deletes the tablet with the specified tablet ID (`tablet-id`) and reason.
 
 **Syntax**
 
 ```sh
-yb-ts-cli  [ --server_address=<host>:<port> ] delete_tablet <tablet_id> "<reason-string>"
+yb-ts-cli  [ --server_address=<host>:<port> ] delete_tablet <tablet-id> "<reason-string>"
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
-* *tablet_id*: The identifier (ID) for the tablet.
+* *tablet-id*: The identifier (ID) for the tablet.
 * *reason-string*: Text string providing information on why the tablet was deleted.
 
 ### dump_tablet
 
-Dump, or export, the specified tablet ID (`tablet_id`).
+Dump, or export, the specified tablet ID (`tablet-id`).
 
 **Syntax**
 
 ```sh
-yb-ts-cli [ --server_address=<host>:<port> ] dump_tablet <tablet_id>
+yb-ts-cli [ --server_address=<host>:<port> ] dump_tablet <tablet-id>
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
-* *tablet_id*: The identifier (ID) for the tablet.
+* *tablet-id*: The identifier (ID) for the tablet.
 
 ### flush_all_tablets
 
@@ -167,11 +167,11 @@ Flush the specified tablet on the tablet server.
 **Syntax**
 
 ```sh
-yb-ts-cli [ --server_address=<host>:<port> ] flush_tablet <tablet_id>
+yb-ts-cli [ --server_address=<host>:<port> ] flush_tablet <tablet-id>
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
-* *tablet_id*: The identifier of the tablet to compact.
+* *tablet-id*: The identifier of the tablet to flush.
 
 ### list_tablets
 
@@ -204,12 +204,12 @@ Trigger a remote bootstrap of a tablet from another tablet server to the specifi
 **Syntax**
 
 ```sh
-yb-ts-cli [ --server_address=<host>:<port> ] remote_bootstrap <source_host> <tablet_id>
+yb-ts-cli [ --server_address=<host>:<port> ] remote_bootstrap <source-host> <tablet-id>
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server running the remote bootstrap. Default is `localhost:9100`.
-* *source_host*: The *host* or *host* and *port* of the tablet server to bootstrap from.
-* *tablet_id*: The identifier of the tablet to trigger a remote bootstrap for.
+* *source-host*: The *host* or *host* and *port* of the tablet server to bootstrap from.
+* *tablet-id*: The identifier of the tablet to trigger a remote bootstrap for.
 
 See [Manual remote bootstrap of failed peer](/stable/troubleshoot/cluster/replace_failed_peers/) for example usage.
 

--- a/docs/content/v2025.1/admin/yb-admin.md
+++ b/docs/content/v2025.1/admin/yb-admin.md
@@ -455,7 +455,7 @@ yb-admin \
 * *namespace*: The name of the database (for YSQL) or keyspace (for YCQL).
 * *table*: The name of the table to compact.
 * *timeout-in-seconds*: Specifies duration (in seconds) yb-admin waits for compaction to end. Default is `20`.
-* ADD_INDEXES: Whether to compact the secondary indexes associated with the table. Default is `false`.
+* ADD_INDEXES: Indicates to compact the secondary indexes associated with the table.
 
 **Example**
 
@@ -480,7 +480,7 @@ yb-admin \
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default is `localhost:7100`.
 * *table-id*: The unique UUID associated with the table.
 * *timeout-in-seconds*: Specifies duration (in seconds) yb-admin waits for compaction to end. Default is `20`.
-* ADD_INDEXES: Whether to compact the secondary indexes associated with the table. Default is `false`.
+* ADD_INDEXES: Indicates to compact the secondary indexes associated with the table.
 
 **Example**
 
@@ -690,7 +690,7 @@ yb-admin \
 * *namespace*: The name of the database (for YSQL) or keyspace (for YCQL).
 * *table*: The name of the table to flush.
 * *timeout-in-seconds*: Specifies duration (in seconds) yb-admin waits for flushing to end. Default is `20`.
-* ADD_INDEXES: Whether to flush the secondary indexes associated with the table. Default is `false`.
+* ADD_INDEXES: Indicates to flush the secondary indexes associated with the table.
 
 **Example**
 
@@ -716,7 +716,7 @@ yb-admin \
 * *master-addresses*: Comma-separated list of YB-Master hosts and ports. Default is `localhost:7100`.
 * *table-id*: The unique UUID associated with the table.
 * *timeout-in-seconds*: Specifies duration (in seconds) yb-admin waits for flushing to end. Default is `20`.
-* ADD_INDEXES: Whether to flush the secondary indexes associated with the table. Default is `false`.
+* ADD_INDEXES: Indicates to flush the secondary indexes associated with the table.
 
 **Example**
 

--- a/docs/content/v2025.1/admin/yb-ts-cli.md
+++ b/docs/content/v2025.1/admin/yb-ts-cli.md
@@ -91,11 +91,11 @@ Compact the specified tablet on the tablet server.
 **Syntax**
 
 ```sh
-yb-ts-cli [ --server_address=<host>:<port> ] compact_tablet <tablet_id>
+yb-ts-cli [ --server_address=<host>:<port> ] compact_tablet <tablet-id>
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
-* *tablet_id*: The identifier of the tablet to compact.
+* *tablet-id*: The identifier of the tablet to compact.
 
 ### count_intents
 
@@ -123,30 +123,30 @@ yb-ts-cli  [ --server_address=<host>:<port> ] current_hybrid_time
 
 ### delete_tablet
 
-Deletes the tablet with the specified tablet ID (`tablet_id`) and reason.
+Deletes the tablet with the specified tablet ID (`tablet-id`) and reason.
 
 **Syntax**
 
 ```sh
-yb-ts-cli  [ --server_address=<host>:<port> ] delete_tablet <tablet_id> "<reason-string>"
+yb-ts-cli  [ --server_address=<host>:<port> ] delete_tablet <tablet-id> "<reason-string>"
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
-* *tablet_id*: The identifier (ID) for the tablet.
+* *tablet-id*: The identifier (ID) for the tablet.
 * *reason-string*: Text string providing information on why the tablet was deleted.
 
 ### dump_tablet
 
-Dump, or export, the specified tablet ID (`tablet_id`).
+Dump, or export, the specified tablet ID (`tablet-id`).
 
 **Syntax**
 
 ```sh
-yb-ts-cli [ --server_address=<host>:<port> ] dump_tablet <tablet_id>
+yb-ts-cli [ --server_address=<host>:<port> ] dump_tablet <tablet-id>
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
-* *tablet_id*: The identifier (ID) for the tablet.
+* *tablet-id*: The identifier (ID) for the tablet.
 
 ### flush_all_tablets
 
@@ -167,11 +167,11 @@ Flush the specified tablet on the tablet server.
 **Syntax**
 
 ```sh
-yb-ts-cli [ --server_address=<host>:<port> ] flush_tablet <tablet_id>
+yb-ts-cli [ --server_address=<host>:<port> ] flush_tablet <tablet-id>
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server. Default is `localhost:9100`.
-* *tablet_id*: The identifier of the tablet to compact.
+* *tablet-id*: The identifier of the tablet to flush.
 
 ### list_tablets
 
@@ -204,12 +204,12 @@ Trigger a remote bootstrap of a tablet from another tablet server to the specifi
 **Syntax**
 
 ```sh
-yb-ts-cli [ --server_address=<host>:<port> ] remote_bootstrap <source_host> <tablet_id>
+yb-ts-cli [ --server_address=<host>:<port> ] remote_bootstrap <source-host> <tablet-id>
 ```
 
 * *host*:*port*: The *host* and *port* of the tablet server running the remote bootstrap. Default is `localhost:9100`.
-* *source_host*: The *host* or *host* and *port* of the tablet server to bootstrap from.
-* *tablet_id*: The identifier of the tablet to trigger a remote bootstrap for.
+* *source-host*: The *host* or *host* and *port* of the tablet server to bootstrap from.
+* *tablet-id*: The identifier of the tablet to trigger a remote bootstrap for.
 
 See [Manual remote bootstrap of failed peer](/stable/troubleshoot/cluster/replace_failed_peers/) for example usage.
 


### PR DESCRIPTION
@netlify /stable/admin/yb-admin/#compact-table-by-id

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that add/clarify CLI command syntax; low risk aside from potential user confusion if any syntax details are incorrect.
> 
> **Overview**
> Documents new compaction capabilities in admin CLIs. `yb-admin compact_table` is updated to accept `ADD_VECTOR_INDEXES`, and a new `compact_table_by_id` command is added for compaction by raw table ID without name/namespace resolution.
> 
> `yb-ts-cli` docs add `compact_vector_index` (tablet-level pgvector index compaction) and normalize parameter naming from `*_id` to `*-id` across multiple commands. Related `ADD_INDEXES` flag descriptions for `compact_table`/`flush_table` are clarified across supported doc versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18f102811d035281bbf85d12bd98608b5f629994. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->