### PR TITLE
[DOC-1178][2025.2.2] Add 3.12 for yba python support

### DIFF
--- a/docs/content/stable/yugabyte-platform/prepare/server-yba.md
+++ b/docs/content/stable/yugabyte-platform/prepare/server-yba.md
@@ -62,7 +62,7 @@ Installation requires a license file. To obtain your license, contact your sales
 
 ### Python for YugabyteDB Anywhere
 
-Python v3.10 to v3.12 must be pre-installed.
+Python v3.10 to v3.12 (v2025.2.2.0 and later) or v3.10 to v3.11 (V2025.2.0-2025.2.1) must be pre-installed.
 
 Both python and python3 must symbolically link to Python 3. One way to achieve this is to use alternatives. For example:
 


### PR DESCRIPTION
@netlify /stable/yugabyte-platform/prepare/server-yba/#python-for-yugabytedb-anywhere

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change adjusting stated Python version prerequisites; no product logic or configuration is modified.
> 
> **Overview**
> Updates the YugabyteDB Anywhere VM prerequisite docs to reflect Python version support by release: **Python 3.10–3.12 for v2025.2.2.0+**, and **Python 3.10–3.11 for v2025.2.0–2025.2.1**.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa124a7d51d94c275e757c9f688233532c76b721. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->