### PR TITLE
Fix THREAD_POOL_METRICS_INSTANCE macro using wrong metric

### DIFF
--- a/src/yb/util/threadpool.h
+++ b/src/yb/util/threadpool.h
@@ -89,7 +89,7 @@ class Runnable {
         label " - run time event stats, microseconds.")
 
 #define THREAD_POOL_METRICS_INSTANCE(entity, name) { \
-      BOOST_PP_CAT(METRIC_, BOOST_PP_CAT(name, _run_time_us)).Instantiate(entity), \
+      BOOST_PP_CAT(METRIC_, BOOST_PP_CAT(name, _queue_length)).Instantiate(entity), \
       BOOST_PP_CAT(METRIC_, BOOST_PP_CAT(name, _queue_time_us)).Instantiate(entity), \
       BOOST_PP_CAT(METRIC_, BOOST_PP_CAT(name, _run_time_us)).Instantiate(entity) \
     }


### PR DESCRIPTION
## Summary
- The first field in the `THREAD_POOL_METRICS_INSTANCE` macro was incorrectly using `_run_time_us` (duplicate of the third field) instead of `_queue_length`
- This caused the `queue_length` metric to never be instantiated for thread pools

## Test plan
- [x] Verified the macro fields match the `THREAD_POOL_METRICS_DEFINE` macro order: `queue_length`, `queue_time_us`, `run_time_us`
- [x] Built successfully with `./yb_build.sh release --ninja`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line macro fix that only affects which thread-pool metrics are instantiated/exposed, with no runtime behavior changes beyond metrics availability.
> 
> **Overview**
> Fixes a bug in `THREAD_POOL_METRICS_INSTANCE` (in `threadpool.h`) where the first instantiated metric incorrectly referenced `*_run_time_us` twice.
> 
> The macro now instantiates `*_queue_length`, ensuring thread pools actually expose the queue length event stats alongside queue and run time metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fc914428f8c3d0f115bd99953c98830aa271bcd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

Phorge: [D51631](https://phorge.dev.yugabyte.com/D51631)