### PR TITLE
CDC: expose getchangesRespMaxSizeBytes

### DIFF
--- a/java/yb-client/src/main/java/org/yb/client/AsyncYBClient.java
+++ b/java/yb-client/src/main/java/org/yb/client/AsyncYBClient.java
@@ -595,6 +595,43 @@ public class AsyncYBClient implements AutoCloseable {
       CdcSdkCheckpoint explicitCheckpoint,
       long safeHybridTime,
       int walSegmentIndex) {
+    return getChangesCDCSDK(table, streamId, tabletId, term, index, key, write_id, time,
+        needSchemaInfo, explicitCheckpoint, safeHybridTime, walSegmentIndex, null);
+  }
+
+  /**
+   * Get changes for a given tablet and stream, with an explicit per-request response size limit.
+   *
+   * @param table the table to get changes for.
+   * @param streamId the stream to get changes for.
+   * @param tabletId the tablet to get changes for.
+   * @param term the leader term to start getting changes for.
+   * @param index the log index to start get changes for.
+   * @param key the key to start get changes for.
+   * @param time the time to start get changes for.
+   * @param needSchemaInfo request schema from the response.
+   * @param explicitCheckpoint checkpoint works in explicit mode.
+   * @param safeHybridTime safe hybrid time received from the previous get changes call.
+   * @param walSegmentIndex wal segment index received from the previous get changes call.
+   * @param getchangesRespMaxSizeBytes when non-null, overrides the tserver flag
+   *     cdc_stream_records_threshold_size_bytes for this request. Honoured only when the tserver
+   *     flag enable_cdcsdk_setting_get_changes_response_byte_limit is true (the default).
+   * @return a deferred object for the response from server.
+   */
+  public Deferred<GetChangesResponse> getChangesCDCSDK(
+      YBTable table,
+      String streamId,
+      String tabletId,
+      long term,
+      long index,
+      byte[] key,
+      int write_id,
+      long time,
+      boolean needSchemaInfo,
+      CdcSdkCheckpoint explicitCheckpoint,
+      long safeHybridTime,
+      int walSegmentIndex,
+      Long getchangesRespMaxSizeBytes) {
     checkIsClosed();
     GetChangesRequest rpc =
         new GetChangesRequest(
@@ -610,7 +647,8 @@ public class AsyncYBClient implements AutoCloseable {
             explicitCheckpoint,
             table.getTableId(),
             safeHybridTime,
-            walSegmentIndex);
+            walSegmentIndex,
+            getchangesRespMaxSizeBytes);
     rpc.maxAttempts = this.maxAttempts;
     Deferred<GetChangesResponse> d = rpc.getDeferred();
     d.addErrback(

--- a/java/yb-client/src/main/java/org/yb/client/GetChangesRequest.java
+++ b/java/yb-client/src/main/java/org/yb/client/GetChangesRequest.java
@@ -39,6 +39,8 @@ public class GetChangesRequest extends YRpc<GetChangesResponse> {
   private final String tableId;
   private final long safeHybridTime;
   private final int walSegmentIndex;
+  // When set, overrides the tserver flag cdc_stream_records_threshold_size_bytes for this request.
+  private final Long getchangesRespMaxSizeBytes;
 
   public GetChangesRequest(YBTable table, String streamId, String tabletId,
    long term, long index, byte[] key, int write_id, long time, boolean needSchemaInfo) {
@@ -57,6 +59,14 @@ public class GetChangesRequest extends YRpc<GetChangesResponse> {
       byte[] key, int write_id, long time, boolean needSchemaInfo,
       CdcSdkCheckpoint explicitCheckpoint, String tableId, long safeHybridTime,
       int walSegmentIndex) {
+    this(table, streamId, tabletId, term, index, key, write_id, time, needSchemaInfo,
+        explicitCheckpoint, tableId, safeHybridTime, walSegmentIndex, null);
+  }
+
+  public GetChangesRequest(YBTable table, String streamId, String tabletId, long term, long index,
+      byte[] key, int write_id, long time, boolean needSchemaInfo,
+      CdcSdkCheckpoint explicitCheckpoint, String tableId, long safeHybridTime,
+      int walSegmentIndex, Long getchangesRespMaxSizeBytes) {
     super(table);
     this.streamId = streamId;
     this.tabletId = tabletId;
@@ -70,6 +80,7 @@ public class GetChangesRequest extends YRpc<GetChangesResponse> {
     this.tableId = tableId;
     this.safeHybridTime = safeHybridTime;
     this.walSegmentIndex = walSegmentIndex;
+    this.getchangesRespMaxSizeBytes = getchangesRespMaxSizeBytes;
   }
 
   @Override
@@ -113,6 +124,10 @@ public class GetChangesRequest extends YRpc<GetChangesResponse> {
     }
 
     builder.setWalSegmentIndex(walSegmentIndex);
+
+    if (getchangesRespMaxSizeBytes != null) {
+      builder.setGetchangesRespMaxSizeBytes(getchangesRespMaxSizeBytes);
+    }
 
     return toChannelBuffer(header, builder.build());
   }

--- a/java/yb-client/src/main/java/org/yb/client/YBClient.java
+++ b/java/yb-client/src/main/java/org/yb/client/YBClient.java
@@ -1945,6 +1945,25 @@ public class YBClient implements AutoCloseable {
       long safeHybridTime,
       int walSegmentIndex)
       throws Exception {
+    return getChangesCDCSDK(table, streamId, tabletId, term, index, key, write_id, time,
+        needSchemaInfo, explicitCheckpoint, safeHybridTime, walSegmentIndex, null);
+  }
+
+  public GetChangesResponse getChangesCDCSDK(
+      YBTable table,
+      String streamId,
+      String tabletId,
+      long term,
+      long index,
+      byte[] key,
+      int write_id,
+      long time,
+      boolean needSchemaInfo,
+      CdcSdkCheckpoint explicitCheckpoint,
+      long safeHybridTime,
+      int walSegmentIndex,
+      Long getchangesRespMaxSizeBytes)
+      throws Exception {
     Deferred<GetChangesResponse> d =
         asyncClient.getChangesCDCSDK(
             table,
@@ -1958,7 +1977,8 @@ public class YBClient implements AutoCloseable {
             needSchemaInfo,
             explicitCheckpoint,
             safeHybridTime,
-            walSegmentIndex);
+            walSegmentIndex,
+            getchangesRespMaxSizeBytes);
     return d.join(2 * getDefaultAdminOperationTimeoutMs());
   }
 


### PR DESCRIPTION
Exposes `getchangesRespMaxSizeBytes` in order to allow CDC clients to specify the size of changes from a tablet sent from the CDC service on calls  to  `getChangesCDCSDK`.  

This is essentially a counterpart to the `--cdc_stream_records_threshold_size_bytes` tserver flag at the client level.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CDC client RPC request construction/serialization; while the change is additive and opt-in, an incorrect limit could impact CDC throughput or memory/network usage.
> 
> **Overview**
> Adds an optional `getchangesRespMaxSizeBytes` parameter to CDC SDK `getChangesCDCSDK` calls, allowing clients to override the server-side `cdc_stream_records_threshold_size_bytes` limit on a per-request basis.
> 
> Plumbs the value through `YBClient`/`AsyncYBClient` overloads into `GetChangesRequest` serialization, where it conditionally sets `GetChangesRequestPB.getchanges_resp_max_size_bytes` when provided (preserving existing behavior when null).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa160521e09a65060d34d9db77f3494a1b192b57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->