### PR TITLE
[doc] Update TP to EA tag for Bucket-based indexes

### DIFF
--- a/docs/content/stable/develop/data-modeling/bucket-based-index-ysql.md
+++ b/docs/content/stable/develop/data-modeling/bucket-based-index-ysql.md
@@ -11,7 +11,7 @@ menu:
     weight: 310
 tags:
   other: ysql
-  feature: tech-preview
+  feature: early-access
 type: docs
 ---
 


### PR DESCRIPTION
The frontmatter missed the change. This PR addresses the change.