### PR TITLE
[docs] Add Rocky Linux and Alma Linux as supported Voyager platforms

### DIFF
--- a/docs/content/stable/yugabyte-voyager/install-yb-voyager.md
+++ b/docs/content/stable/yugabyte-voyager/install-yb-voyager.md
@@ -19,7 +19,7 @@ The following sections describe the prerequisites for installing YugabyteDB Voya
 
 You can install YugabyteDB Voyager on the following:
 
-- RHEL 8, 9
+- RHEL 8, 9 and compatible distributions (Rocky Linux, Alma Linux)
 - CentOS 8
 - Ubuntu 18.04, 20.04, 22.04
 - macOS (for MySQL/Oracle source databases on macOS, [install yb-voyager](#install-yb-voyager) using the Docker option.)


### PR DESCRIPTION
## Summary

Updates the YugabyteDB Voyager installation documentation to explicitly mention that RHEL-compatible distributions (Rocky Linux, Alma Linux) are also supported.

## Changes

- Updated the Operating System prerequisites section to include Rocky Linux and Alma Linux alongside RHEL 8, 9

## Rationale

Rocky Linux and Alma Linux are binary-compatible RHEL clones that are commonly used in enterprise environments. Since Voyager supports RHEL, it also works on these distributions, and this should be clearly documented.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates the supported OS list; no product or runtime behavior is affected.
> 
> **Overview**
> Clarifies the YugabyteDB Voyager installation prerequisites by expanding the supported OS entry from `RHEL 8, 9` to `RHEL 8, 9 and compatible distributions (Rocky Linux, Alma Linux)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03ae5db340b1308ed5b07e25c38836b560b64780. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->