### PR TITLE
Use LOG_DETAIL for TryAgain status in WriteQueryCompletionCallback.

### DIFF
--- a/src/yb/tserver/tablet_service.cc
+++ b/src/yb/tserver/tablet_service.cc
@@ -544,7 +544,11 @@ class WriteQueryCompletionCallback {
         status = STATUS_FORMAT(InvalidArgument, "Leader term changed");
       }
 
-      (status.IsTryAgain()? LOG_DETAIL : LOG(INFO)) << "Write failed: " << status;
+      if (status.IsTryAgain()) {
+          LOG_DETAIL << "Write failed: " << status;
+      } else {
+          LOG(INFO) << "Write failed: " << status;
+      }
 
       if (include_trace_ && trace_) {
         response_->set_trace_buffer(trace_->DumpToString(true));


### PR DESCRIPTION
Use LOG_DETAIL for TryAgain status in WriteQueryCompletionCallback. Allows filtering out routine TryAgain retry logs by using LOG_DETAIL instead of LOG(INFO).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts logging verbosity for `Status::TryAgain` in a write completion callback, without changing write/response logic.
> 
> **Overview**
> Reduces noise from routine write retries by logging `Status::TryAgain` completions in `WriteQueryCompletionCallback` with `LOG_DETAIL` instead of `VLOG(1)`, keeping the existing `VLOG(1)` path for all other statuses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1d5c1fc7a6475e790c0061e9fa6acc2579f0188. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

https://phorge.dev.yugabyte.com/D51349