### PR TITLE
[doc] Update QueryProcessing wait event name to OnCpu_Active in ASH

### DIFF
--- a/docs/content/stable/explore/observability/active-session-history.md
+++ b/docs/content/stable/explore/observability/active-session-history.md
@@ -82,14 +82,14 @@ ORDER BY
  -1970690938654296136 | TServer              | Raft_WaitingForReplication         | RPCWait         |   194
  -1970690938654296136 | TServer              | Rpc_Done                           | WaitOnCondition |    18
  -1970690938654296136 | TServer              | MVCC_WaitForSafeTime               | WaitOnCondition |     5
- -1970690938654296136 | YSQL                 | QueryProcessing                    | Cpu             |  1023
+ -1970690938654296136 | YSQL                 | OnCpu_Active                       | Cpu             |  1023
                     0 | TServer              | OnCpu_Passive                      | Cpu             |    10
                     0 | TServer              | OnCpu_Active                       | Cpu             |     9
   6107501747146929242 | TServer              | OnCpu_Active                       | Cpu             |   208
   6107501747146929242 | TServer              | RocksDB_NewIterator                | DiskIO          |     5
   6107501747146929242 | TServer              | MVCC_WaitForSafeTime               | WaitOnCondition |    10
   6107501747146929242 | TServer              | Rpc_Done                           | WaitOnCondition |    15
-  6107501747146929242 | YSQL                 | QueryProcessing                    | Cpu             |   285
+  6107501747146929242 | YSQL                 | OnCpu_Active                       | Cpu             |   285
   6107501747146929242 | YSQL                 | TableRead                          | RPCWait         |   658
   6107501747146929242 | YSQL                 | CatalogRead                        | RPCWait         |     1
 ```
@@ -136,7 +136,7 @@ ORDER BY
  UPDATE test_table set v = v + $1 where k = $2 | TServer              | ConflictResolution_WaitOnConflictingTxns | WaitOnCondition |  1359
  UPDATE test_table set v = v + $1 where k = $2 | TServer              | Rpc_Done                                 | WaitOnCondition |     5
  UPDATE test_table set v = v + $1 where k = $2 | TServer              | LockedBatchEntry_Lock                    | WaitOnCondition |   141
- UPDATE test_table set v = v + $1 where k = $2 | YSQL                 | QueryProcessing                          | Cpu             |  1929
+ UPDATE test_table set v = v + $1 where k = $2 | YSQL                 | OnCpu_Active                             | Cpu             |  1929
 ```
 
 ### Detect a hot shard
@@ -359,7 +359,7 @@ GROUP BY
 ```
 
 ```output
-                       query                        |          top_level_node_id           |   host    | port | cloud | region  |    zone    | count 
+                       query                        |          top_level_node_id           |   host    | port | cloud | region  |    zone    | count
 ----------------------------------------------------+--------------------------------------+-----------+------+-------+---------+------------+-------
  COMMIT                                             | 6b556919-0198-4617-a7bc-42b84c965ec4 | 127.0.0.1 | 5433 | aws   | us-west | us-west-2a |     2
  ANALYZE "public"."postgresqlkeyvalue"              | 6b556919-0198-4617-a7bc-42b84c965ec4 | 127.0.0.1 | 5433 | aws   | us-west | us-west-2a |    44

--- a/docs/content/stable/launch-and-manage/monitor-and-alert/active-session-history-monitor.md
+++ b/docs/content/stable/launch-and-manage/monitor-and-alert/active-session-history-monitor.md
@@ -142,7 +142,7 @@ These are the wait events introduced by YugabyteDB. Some of the following [wait 
 
 | Wait Event | Type |  Description |
 | :--------- | :--- | :---------- |
-| QueryProcessing| CPU | A YSQL backend is doing CPU work.|
+| OnCpu_Active| CPU | A YSQL backend is doing CPU work.|
 | yb_ash_metadata | LWLock | A YSQL backend is waiting to update ASH metadata for a query. |
 | YBParallelScanEmpty| IPC | A YSQL backend is waiting on an empty queue while fetching parallel range keys. |
 | CopyCommandStreamRead| IO | A YSQL backend is waiting for a read from a file or program during COPY. |

--- a/docs/content/v2.25/explore/observability/active-session-history.md
+++ b/docs/content/v2.25/explore/observability/active-session-history.md
@@ -76,14 +76,14 @@ ORDER BY
  -1970690938654296136 | TServer              | Raft_WaitingForReplication         | RPCWait         |   194
  -1970690938654296136 | TServer              | Rpc_Done                           | WaitOnCondition |    18
  -1970690938654296136 | TServer              | MVCC_WaitForSafeTime               | WaitOnCondition |     5
- -1970690938654296136 | YSQL                 | QueryProcessing                    | Cpu             |  1023
+ -1970690938654296136 | YSQL                 | OnCpu_Active                       | Cpu             |  1023
                     0 | TServer              | OnCpu_Passive                      | Cpu             |    10
                     0 | TServer              | OnCpu_Active                       | Cpu             |     9
   6107501747146929242 | TServer              | OnCpu_Active                       | Cpu             |   208
   6107501747146929242 | TServer              | RocksDB_NewIterator                | DiskIO          |     5
   6107501747146929242 | TServer              | MVCC_WaitForSafeTime               | WaitOnCondition |    10
   6107501747146929242 | TServer              | Rpc_Done                           | WaitOnCondition |    15
-  6107501747146929242 | YSQL                 | QueryProcessing                    | Cpu             |   285
+  6107501747146929242 | YSQL                 | OnCpu_Active                       | Cpu             |   285
   6107501747146929242 | YSQL                 | TableRead                          | RPCWait         |   658
   6107501747146929242 | YSQL                 | CatalogRead                        | RPCWait         |     1
 ```
@@ -130,7 +130,7 @@ ORDER BY
  UPDATE test_table set v = v + $1 where k = $2 | TServer              | ConflictResolution_WaitOnConflictingTxns | WaitOnCondition |  1359
  UPDATE test_table set v = v + $1 where k = $2 | TServer              | Rpc_Done                                 | WaitOnCondition |     5
  UPDATE test_table set v = v + $1 where k = $2 | TServer              | LockedBatchEntry_Lock                    | WaitOnCondition |   141
- UPDATE test_table set v = v + $1 where k = $2 | YSQL                 | QueryProcessing                          | Cpu             |  1929
+ UPDATE test_table set v = v + $1 where k = $2 | YSQL                 | OnCpu_Active                             | Cpu             |  1929
 ```
 
 ### Detect a hot shard

--- a/docs/content/v2.25/launch-and-manage/monitor-and-alert/active-session-history-monitor.md
+++ b/docs/content/v2.25/launch-and-manage/monitor-and-alert/active-session-history-monitor.md
@@ -123,7 +123,7 @@ These are the wait events introduced by YugabyteDB. Some of the following [wait 
 
 | Wait Event | Type |  Description |
 | :--------- | :--- | :---------- |
-| QueryProcessing| CPU | A YSQL backend is doing CPU work.|
+| OnCpu_Active| CPU | A YSQL backend is doing CPU work.|
 | yb_ash_metadata | LWLock | A YSQL backend is waiting to update ASH metadata for a query. |
 | YBParallelScanEmpty| IPC | A YSQL backend is waiting on an empty queue while fetching parallel range keys. |
 | CopyCommandStreamRead| IO | A YSQL backend is waiting for a read from a file or program during COPY. |

--- a/docs/content/v2024.2/explore/observability/active-session-history.md
+++ b/docs/content/v2024.2/explore/observability/active-session-history.md
@@ -82,14 +82,14 @@ ORDER BY
  -1970690938654296136 | TServer              | Raft_WaitingForReplication         | RPCWait         |   194
  -1970690938654296136 | TServer              | Rpc_Done                           | WaitOnCondition |    18
  -1970690938654296136 | TServer              | MVCC_WaitForSafeTime               | WaitOnCondition |     5
- -1970690938654296136 | YSQL                 | QueryProcessing                    | Cpu             |  1023
+ -1970690938654296136 | YSQL                 | OnCpu_Active                       | Cpu             |  1023
                     0 | TServer              | OnCpu_Passive                      | Cpu             |    10
                     0 | TServer              | OnCpu_Active                       | Cpu             |     9
   6107501747146929242 | TServer              | OnCpu_Active                       | Cpu             |   208
   6107501747146929242 | TServer              | RocksDB_NewIterator                | DiskIO          |     5
   6107501747146929242 | TServer              | MVCC_WaitForSafeTime               | WaitOnCondition |    10
   6107501747146929242 | TServer              | Rpc_Done                           | WaitOnCondition |    15
-  6107501747146929242 | YSQL                 | QueryProcessing                    | Cpu             |   285
+  6107501747146929242 | YSQL                 | OnCpu_Active                       | Cpu             |   285
   6107501747146929242 | YSQL                 | TableRead                          | RPCWait         |   658
   6107501747146929242 | YSQL                 | CatalogRead                        | RPCWait         |     1
 ```
@@ -136,7 +136,7 @@ ORDER BY
  UPDATE test_table set v = v + $1 where k = $2 | TServer              | ConflictResolution_WaitOnConflictingTxns | WaitOnCondition |  1359
  UPDATE test_table set v = v + $1 where k = $2 | TServer              | Rpc_Done                                 | WaitOnCondition |     5
  UPDATE test_table set v = v + $1 where k = $2 | TServer              | LockedBatchEntry_Lock                    | WaitOnCondition |   141
- UPDATE test_table set v = v + $1 where k = $2 | YSQL                 | QueryProcessing                          | Cpu             |  1929
+ UPDATE test_table set v = v + $1 where k = $2 | YSQL                 | OnCpu_Active                             | Cpu             |  1929
 ```
 
 ### Detect a hot shard
@@ -359,7 +359,7 @@ GROUP BY
 ```
 
 ```output
-                       query                        |          top_level_node_id           |   host    | port | cloud | region  |    zone    | count 
+                       query                        |          top_level_node_id           |   host    | port | cloud | region  |    zone    | count
 ----------------------------------------------------+--------------------------------------+-----------+------+-------+---------+------------+-------
  COMMIT                                             | 6b556919-0198-4617-a7bc-42b84c965ec4 | 127.0.0.1 | 5433 | aws   | us-west | us-west-2a |     2
  ANALYZE "public"."postgresqlkeyvalue"              | 6b556919-0198-4617-a7bc-42b84c965ec4 | 127.0.0.1 | 5433 | aws   | us-west | us-west-2a |    44

--- a/docs/content/v2024.2/launch-and-manage/monitor-and-alert/active-session-history-monitor.md
+++ b/docs/content/v2024.2/launch-and-manage/monitor-and-alert/active-session-history-monitor.md
@@ -115,7 +115,7 @@ These are the wait events introduced by YugabyteDB, however some of the followin
 
 | Wait Event | Type |  Description |
 | :--------- | :--- | :---------- |
-| QueryProcessing| CPU | A YSQL backend is doing CPU work.|
+| OnCpu_Active| CPU | A YSQL backend is doing CPU work.|
 | yb_ash_metadata | LWLock | A YSQL backend is waiting to update ASH metadata for a query. |
 | YBParallelScanEmpty| IPC | A YSQL backend is waiting on an empty queue while fetching parallel range keys. |
 | CopyCommandStreamRead| IO | A YSQL backend is waiting for a read from a file or program during COPY. |

--- a/docs/content/v2025.1/explore/observability/active-session-history.md
+++ b/docs/content/v2025.1/explore/observability/active-session-history.md
@@ -82,14 +82,14 @@ ORDER BY
  -1970690938654296136 | TServer              | Raft_WaitingForReplication         | RPCWait         |   194
  -1970690938654296136 | TServer              | Rpc_Done                           | WaitOnCondition |    18
  -1970690938654296136 | TServer              | MVCC_WaitForSafeTime               | WaitOnCondition |     5
- -1970690938654296136 | YSQL                 | QueryProcessing                    | Cpu             |  1023
+ -1970690938654296136 | YSQL                 | OnCpu_Active                       | Cpu             |  1023
                     0 | TServer              | OnCpu_Passive                      | Cpu             |    10
                     0 | TServer              | OnCpu_Active                       | Cpu             |     9
   6107501747146929242 | TServer              | OnCpu_Active                       | Cpu             |   208
   6107501747146929242 | TServer              | RocksDB_NewIterator                | DiskIO          |     5
   6107501747146929242 | TServer              | MVCC_WaitForSafeTime               | WaitOnCondition |    10
   6107501747146929242 | TServer              | Rpc_Done                           | WaitOnCondition |    15
-  6107501747146929242 | YSQL                 | QueryProcessing                    | Cpu             |   285
+  6107501747146929242 | YSQL                 | OnCpu_Active                       | Cpu             |   285
   6107501747146929242 | YSQL                 | TableRead                          | RPCWait         |   658
   6107501747146929242 | YSQL                 | CatalogRead                        | RPCWait         |     1
 ```
@@ -136,7 +136,7 @@ ORDER BY
  UPDATE test_table set v = v + $1 where k = $2 | TServer              | ConflictResolution_WaitOnConflictingTxns | WaitOnCondition |  1359
  UPDATE test_table set v = v + $1 where k = $2 | TServer              | Rpc_Done                                 | WaitOnCondition |     5
  UPDATE test_table set v = v + $1 where k = $2 | TServer              | LockedBatchEntry_Lock                    | WaitOnCondition |   141
- UPDATE test_table set v = v + $1 where k = $2 | YSQL                 | QueryProcessing                          | Cpu             |  1929
+ UPDATE test_table set v = v + $1 where k = $2 | YSQL                 | OnCpu_Active                             | Cpu             |  1929
 ```
 
 ### Detect a hot shard
@@ -359,7 +359,7 @@ GROUP BY
 ```
 
 ```output
-                       query                        |          top_level_node_id           |   host    | port | cloud | region  |    zone    | count 
+                       query                        |          top_level_node_id           |   host    | port | cloud | region  |    zone    | count
 ----------------------------------------------------+--------------------------------------+-----------+------+-------+---------+------------+-------
  COMMIT                                             | 6b556919-0198-4617-a7bc-42b84c965ec4 | 127.0.0.1 | 5433 | aws   | us-west | us-west-2a |     2
  ANALYZE "public"."postgresqlkeyvalue"              | 6b556919-0198-4617-a7bc-42b84c965ec4 | 127.0.0.1 | 5433 | aws   | us-west | us-west-2a |    44

--- a/docs/content/v2025.1/launch-and-manage/monitor-and-alert/active-session-history-monitor.md
+++ b/docs/content/v2025.1/launch-and-manage/monitor-and-alert/active-session-history-monitor.md
@@ -125,7 +125,7 @@ These are the wait events introduced by YugabyteDB. Some of the following [wait 
 
 | Wait Event | Type |  Description |
 | :--------- | :--- | :---------- |
-| QueryProcessing| CPU | A YSQL backend is doing CPU work.|
+| OnCpu_Active| CPU | A YSQL backend is doing CPU work.|
 | yb_ash_metadata | LWLock | A YSQL backend is waiting to update ASH metadata for a query. |
 | YBParallelScanEmpty| IPC | A YSQL backend is waiting on an empty queue while fetching parallel range keys. |
 | CopyCommandStreamRead| IO | A YSQL backend is waiting for a read from a file or program during COPY. |


### PR DESCRIPTION
3fad475 / 0e0b1a0 updated the name of the `QueryProcessing` wait event to `OnCpu_Active`, but the docs were not updated.

This PR updates the docs with the new wait event name and also updates the examples.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only updates; primary risk is minor doc inconsistency if any remaining references were missed.
> 
> **Overview**
> Aligns ASH docs and sample query outputs with the current YSQL CPU wait event name by replacing `QueryProcessing` with `OnCpu_Active` in both the wait-event reference tables and example result sets across `stable`, `v2.25`, `v2024.2`, and `v2025.1`.
> 
> Also includes a small formatting cleanup in example output headers (removing a stray trailing space) to keep rendered tables consistent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f74d7de868566de574d8604e7463edab09483623. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->