### PR TITLE
[docs] Explain DEAD yb-tservers will show up for 24 hours in yb-tserver list and how to refresh the cache by electing a new yb-master leader

### DIFF
--- a/docs/content/stable/manage/change-cluster-config.md
+++ b/docs/content/stable/manage/change-cluster-config.md
@@ -211,3 +211,12 @@ Ensure there are no `server_blacklist` entries returned by the command:
 ```sh
 ~/master/bin/yb-admin --master_addresses $MASTERS get_universe_config
 ```
+
+
+{{< note title="Note" >}}
+
+`DEAD` servers may appear in the yb-tserver list due to a cached state in the yb-master leader's memory. This cache is cleared after 24 hours by default (see [hide_dead_node_threshold_mins](../../reference/configuration/yb-master/#hide-dead-node-threshold-mins)).
+
+To refresh this cache immediately, elect a new yb-master leader using the `yb-admin` [`master_leader_stepdown`](../../admin/yb-admin/#master-leader-stepdown) command.
+
+{{< /note >}}

--- a/docs/content/v2024.2/manage/change-cluster-config.md
+++ b/docs/content/v2024.2/manage/change-cluster-config.md
@@ -209,3 +209,12 @@ Ensure there are no `server_blacklist` entries returned by the command:
 ```sh
 ~/master/bin/yb-admin --master_addresses $MASTERS get_universe_config
 ```
+
+
+{{< note title="Note" >}}
+
+`DEAD` servers may appear in the yb-tserver list due to a cached state in the yb-master leader's memory. This cache is cleared after 24 hours by default (see [hide_dead_node_threshold_mins](../../reference/configuration/yb-master/#hide-dead-node-threshold-mins)).
+
+To refresh this cache immediately, elect a new yb-master leader using the `yb-admin` [`master_leader_stepdown`](../../admin/yb-admin/#master-leader-stepdown) command.
+
+{{< /note >}}

--- a/docs/content/v2025.1/manage/change-cluster-config.md
+++ b/docs/content/v2025.1/manage/change-cluster-config.md
@@ -209,3 +209,12 @@ Ensure there are no `server_blacklist` entries returned by the command:
 ```sh
 ~/master/bin/yb-admin --master_addresses $MASTERS get_universe_config
 ```
+
+
+{{< note title="Note" >}}
+
+`DEAD` servers may appear in the yb-tserver list due to a cached state in the yb-master leader's memory. This cache is cleared after 24 hours by default (see [hide_dead_node_threshold_mins](../../reference/configuration/yb-master/#hide-dead-node-threshold-mins)).
+
+To refresh this cache immediately, elect a new yb-master leader using the `yb-admin` [`master_leader_stepdown`](../../admin/yb-admin/#master-leader-stepdown) command.
+
+{{< /note >}}


### PR DESCRIPTION
Part of https://github.com/yugabyte/yugabyte-db/issues/22363#issuecomment-2126976816. This confusion has happened multiple times that we need to document it.

Fixes https://github.com/yugabyte/yugabyte-db/issues/22363

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that clarifies operational behavior without modifying product code or configuration defaults.
> 
> **Overview**
> Clarifies in `change-cluster-config.md` that `DEAD` YB-TServers may continue to appear in the YB-Master tablet server list due to leader-local cached state, typically expiring after 24 hours.
> 
> Adds guidance to refresh the list sooner by electing a new master leader, linking to `hide_dead_node_threshold_mins` and the `yb-admin master_leader_stepdown` command.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40ea5b5c0be23d6f9be91cbd08e1f2dfa19d7e46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->