### PR TITLE
[#30180] YSQL: Add attributes in yb_tablet_metadata.tablet_attrs

### DIFF
--- a/src/postgres/src/backend/catalog/yb_system_views.sql
+++ b/src/postgres/src/backend/catalog/yb_system_views.sql
@@ -67,11 +67,13 @@ CREATE VIEW yb_tablet_metadata AS
         t.start_hash_code,
         t.end_hash_code,
         t.leader,
-        t.replicas
+        t.replicas,
+        t.tablet_attrs
     FROM
         yb_get_tablet_metadata() t
     LEFT JOIN
-        pg_class c ON c.relname = t.object_name
+        pg_class c ON c.oid = (CASE WHEN length(t.object_uuid) = 32
+            THEN ('x' || right(t.object_uuid, 8))::bit(32)::int::oid ELSE NULL END)
     LEFT JOIN
         pg_namespace n ON n.oid = c.relnamespace
     WHERE

--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -8507,10 +8507,13 @@ string_list_compare(const ListCell *a, const ListCell *b)
  * - end_hash_code: int32
  * - leader: text
  * - replicas: text[]
+ * - tablet_attrs: jsonb
  *
  * The start_hash_code and end_hash_code are the hash codes of the start and end
  * keys of the tablet for hash sharded tables. Leader is provided as a separate
  * column for simpler querying and self-explanatory access.
+ * tablet_attrs is a JSONB column containing miscellaneous tablet-level metadata
+ * such as SST file size, WAL file size, and uncompressed SST file size.
  */
 Datum
 yb_get_tablet_metadata(PG_FUNCTION_ARGS)
@@ -8520,7 +8523,7 @@ yb_get_tablet_metadata(PG_FUNCTION_ARGS)
 	Tuplestorestate *tupstore;
 	MemoryContext per_query_ctx;
 	MemoryContext oldcontext;
-	static int	ncols = 9;
+	static int	ncols = 10;
 
 	/* check to see if caller supports us returning a tuplestore */
 	if (rsinfo == NULL || !IsA(rsinfo, ReturnSetInfo))
@@ -8614,6 +8617,56 @@ yb_get_tablet_metadata(PG_FUNCTION_ARGS)
 		{
 			nulls[7] = true;
 			nulls[8] = true;
+		}
+
+		/* Build tablet_attrs JSONB with disk size information.
+		 * Only include keys for which data is available (sentinel -1 means
+		 * unavailable). If no data is available, set to NULL. */
+		{
+			StringInfoData tablet_attrs_buf;
+			bool		first_attr = true;
+
+			initStringInfo(&tablet_attrs_buf);
+			appendStringInfoChar(&tablet_attrs_buf, '{');
+
+			if (tablet->sst_files_disk_size >= 0)
+			{
+				appendStringInfo(&tablet_attrs_buf, "\"sst_files_disk_size\": %lld",
+								 (long long) tablet->sst_files_disk_size);
+				first_attr = false;
+			}
+
+			if (tablet->wal_files_disk_size >= 0)
+			{
+				if (!first_attr)
+					appendStringInfoString(&tablet_attrs_buf, ", ");
+				appendStringInfo(&tablet_attrs_buf, "\"wal_files_disk_size\": %lld",
+								 (long long) tablet->wal_files_disk_size);
+				first_attr = false;
+			}
+
+			if (tablet->uncompressed_sst_files_disk_size >= 0)
+			{
+				if (!first_attr)
+					appendStringInfoString(&tablet_attrs_buf, ", ");
+				appendStringInfo(&tablet_attrs_buf,
+								 "\"uncompressed_sst_files_disk_size\": %lld",
+								 (long long) tablet->uncompressed_sst_files_disk_size);
+				first_attr = false;
+			}
+
+			if (first_attr)
+			{
+				/* No disk size data available — return NULL instead of {} */
+				nulls[9] = true;
+			}
+			else
+			{
+				appendStringInfoChar(&tablet_attrs_buf, '}');
+				values[9] = DirectFunctionCall1(jsonb_in,
+												CStringGetDatum(tablet_attrs_buf.data));
+			}
+			pfree(tablet_attrs_buf.data);
 		}
 
 		tuplestore_putvalues(tupstore, tupdesc, values, nulls);

--- a/src/postgres/src/include/catalog/pg_proc.dat
+++ b/src/postgres/src/include/catalog/pg_proc.dat
@@ -12234,9 +12234,9 @@
   proname => 'yb_get_tablet_metadata', prorows => '100',
   proretset => 't', provolatile => 'v', proparallel => 'r',
   prorettype => 'record', proargtypes => '',
-  proallargtypes => '{text,text,text,text,text,int4,int4,text,_text}',
-  proargnames => '{tablet_id,object_uuid,namespace,object_name,type,start_hash_code,end_hash_code,leader,replicas}',
-  proargmodes => '{o,o,o,o,o,o,o,o,o}',
+  proallargtypes => '{text,text,text,text,text,int4,int4,text,_text,jsonb}',
+  proargnames => '{tablet_id,object_uuid,namespace,object_name,type,start_hash_code,end_hash_code,leader,replicas,tablet_attrs}',
+  proargmodes => '{o,o,o,o,o,o,o,o,o,o}',
   prosrc => 'yb_get_tablet_metadata'},
 
 { oid => '8101', descr => 'Get the UUID of the local tserver',

--- a/src/postgres/src/test/regress/expected/yb.orig.tablet_metadata.out
+++ b/src/postgres/src/test/regress/expected/yb.orig.tablet_metadata.out
@@ -15,6 +15,23 @@ ORDER BY start_hash_code NULLS FIRST;
  test_table_1 | yugabyte |           32768 |         65536
 (3 rows)
 
+-- Test that tablet_attrs column contains expected JSON keys
+SELECT
+    relname,
+    tablet_attrs ? 'sst_files_disk_size' AS has_sst_size,
+    tablet_attrs ? 'wal_files_disk_size' AS has_wal_size,
+    tablet_attrs ? 'uncompressed_sst_files_disk_size' AS has_uncompressed_sst_size,
+    (tablet_attrs->>'sst_files_disk_size')::bigint >= 0 AS sst_size_non_negative,
+    (tablet_attrs->>'wal_files_disk_size')::bigint >= 0 AS wal_size_non_negative,
+    (tablet_attrs->>'uncompressed_sst_files_disk_size')::bigint >= 0 AS uncompressed_sst_size_non_negative
+FROM yb_tablet_metadata WHERE relname = 'test_table_1'
+ORDER BY start_hash_code NULLS FIRST;
+   relname    | has_sst_size | has_wal_size | has_uncompressed_sst_size | sst_size_non_negative | wal_size_non_negative | uncompressed_sst_size_non_negative
+--------------+--------------+--------------+---------------------------+-----------------------+-----------------------+------------------------------------
+ test_table_1 | t            | t            | t                         | t                     | t                     | t
+ test_table_1 | t            | t            | t                         | t                     | t                     | t
+(2 rows)
+
 -- Test that we are able to join with yb_servers()
 SELECT
     ytm.relname,

--- a/src/postgres/src/test/regress/sql/yb.orig.tablet_metadata.sql
+++ b/src/postgres/src/test/regress/sql/yb.orig.tablet_metadata.sql
@@ -10,6 +10,18 @@ SELECT
 FROM yb_tablet_metadata WHERE relname IN ('test_table_1', 'test_table_2')
 ORDER BY start_hash_code NULLS FIRST;
 
+-- Test that tablet_attrs column contains expected JSON keys
+SELECT
+    relname,
+    tablet_attrs ? 'sst_files_disk_size' AS has_sst_size,
+    tablet_attrs ? 'wal_files_disk_size' AS has_wal_size,
+    tablet_attrs ? 'uncompressed_sst_files_disk_size' AS has_uncompressed_sst_size,
+    (tablet_attrs->>'sst_files_disk_size')::bigint >= 0 AS sst_size_non_negative,
+    (tablet_attrs->>'wal_files_disk_size')::bigint >= 0 AS wal_size_non_negative,
+    (tablet_attrs->>'uncompressed_sst_files_disk_size')::bigint >= 0 AS uncompressed_sst_size_non_negative
+FROM yb_tablet_metadata WHERE relname = 'test_table_1'
+ORDER BY start_hash_code NULLS FIRST;
+
 -- Test that we are able to join with yb_servers()
 SELECT
     ytm.relname,

--- a/src/yb/tserver/pg_client_service.cc
+++ b/src/yb/tserver/pg_client_service.cc
@@ -157,6 +157,10 @@ TAG_FLAG(check_pg_object_id_allocators_interval_secs, advanced);
 DEFINE_NON_RUNTIME_int64(shmem_exchange_idle_timeout_ms, 2000 * yb::kTimeMultiplier,
     "Idle timeout interval in milliseconds used by shared memory exchange thread pool.");
 
+DEFINE_RUNTIME_int32(tablet_disk_sizes_cache_ttl_sec, 30,
+    "TTL in seconds for cached tablet disk sizes used by yb_tablet_metadata. "
+    "Set to 0 to disable caching.");
+
 DEFINE_test_flag(bool, pause_get_lock_status, false,
     "Whether tservers should pause before sending GetLockStatus requests.");
 
@@ -169,6 +173,16 @@ DECLARE_bool(enable_object_locking_for_table_locks);
 
 namespace yb::tserver {
 namespace {
+
+// Timeout for ListTablets RPCs during disk size enrichment. Kept short since
+// this is best-effort enrichment within a synchronous SQL function.
+const auto kEnrichDiskSizesRpcTimeout = MonoDelta::FromMilliseconds(2000);
+
+struct TabletDiskSizeInfo {
+  int64_t sst_files_disk_size = -1;
+  int64_t wal_files_disk_size = -1;
+  int64_t uncompressed_sst_files_disk_size = -1;
+};
 
 template <class Resp>
 void Respond(const Status& status, Resp* resp, rpc::RpcContext* context) {
@@ -2709,8 +2723,160 @@ class PgClientServiceImpl::Impl : public SessionProvider {
     } else {
       auto tablet_metadatas = VERIFY_RESULT(client().GetTabletsMetadata());
       *resp->mutable_tablets() = {tablet_metadatas.begin(), tablet_metadatas.end()};
+
+      // Best-effort enrichment with disk size info from tservers.
+      // The master doesn't have per-tablet disk sizes; those live on tservers.
+      EnrichTabletsWithDiskSizes(resp);
     }
     return Status::OK();
+  }
+
+  // Best-effort enrichment: failures are logged but never fail the overall request.
+  // Uses a TTL-based cache to avoid fanning out ListTablets RPCs on every query.
+  void EnrichTabletsWithDiskSizes(PgTabletsMetadataResponsePB* resp) {
+    // Check if cache needs refreshing. If so, immediately push the expiry forward
+    // to prevent concurrent threads from also triggering a refresh (thundering herd).
+    bool needs_refresh = false;
+    {
+      std::lock_guard lock(disk_sizes_cache_mutex_);
+      auto now = CoarseMonoClock::now();
+      if (now >= disk_sizes_cache_expiry_) {
+        needs_refresh = true;
+        // Push expiry forward so other threads use stale cache while we refresh.
+        disk_sizes_cache_expiry_ = now + std::chrono::seconds(
+            FLAGS_tablet_disk_sizes_cache_ttl_sec);
+      }
+    }
+
+    if (needs_refresh) {
+      // Collect data without holding the lock to avoid blocking concurrent readers.
+      // Concurrent threads will use stale (but valid) cache data while this runs.
+      auto new_cache = CollectDiskSizes();
+
+      // Swap the new data into the cache under the lock.
+      std::lock_guard lock(disk_sizes_cache_mutex_);
+      disk_sizes_cache_ = std::move(new_cache);
+      disk_sizes_cache_populated_ = true;
+    }
+
+    // Apply cached sizes to response entries. Only set fields for known values
+    // (>= 0) so that unknown values remain unset in the protobuf, allowing the
+    // downstream YSQL layer to correctly omit them from the JSON output.
+    std::lock_guard lock(disk_sizes_cache_mutex_);
+    if (!disk_sizes_cache_populated_) {
+      // Cache not yet populated (first request still in flight). Skip enrichment
+      // rather than returning misleading empty data.
+      return;
+    }
+    for (int i = 0; i < resp->tablets_size(); ++i) {
+      auto* tablet = resp->mutable_tablets(i);
+      auto it = disk_sizes_cache_.find(tablet->tablet_id());
+      if (it != disk_sizes_cache_.end()) {
+        if (it->second.sst_files_disk_size >= 0) {
+          tablet->set_sst_files_disk_size(it->second.sst_files_disk_size);
+        }
+        if (it->second.wal_files_disk_size >= 0) {
+          tablet->set_wal_files_disk_size(it->second.wal_files_disk_size);
+        }
+        if (it->second.uncompressed_sst_files_disk_size >= 0) {
+          tablet->set_uncompressed_sst_files_disk_size(
+              it->second.uncompressed_sst_files_disk_size);
+        }
+      }
+    }
+  }
+
+  // Collects disk sizes from all tservers into a local map.
+  // Does NOT hold any locks, safe to call without disk_sizes_cache_mutex_.
+  std::unordered_map<std::string, TabletDiskSizeInfo> CollectDiskSizes() {
+    std::unordered_map<std::string, TabletDiskSizeInfo> result;
+
+    // Helper to merge disk sizes using MAX across replicas for consistency.
+    auto merge_disk_sizes = [&](const std::string& tablet_id,
+                                int64_t sst_size, int64_t wal_size,
+                                int64_t uncompressed_sst_size) {
+      auto& entry = result[tablet_id];
+      entry.sst_files_disk_size = std::max(entry.sst_files_disk_size, sst_size);
+      entry.wal_files_disk_size = std::max(entry.wal_files_disk_size, wal_size);
+      entry.uncompressed_sst_files_disk_size = std::max(
+          entry.uncompressed_sst_files_disk_size, uncompressed_sst_size);
+    };
+
+    // Collect disk sizes from local tserver.
+    auto local_tablets = tablet_server_.GetLocalTabletsMetadata();
+    if (local_tablets.ok()) {
+      for (const auto& local_tablet : *local_tablets) {
+        merge_disk_sizes(local_tablet.tablet_id(),
+                         local_tablet.sst_files_disk_size(),
+                         local_tablet.wal_files_disk_size(),
+                         local_tablet.uncompressed_sst_files_disk_size());
+      }
+    } else {
+      LOG(WARNING) << "Failed to get local tablets metadata for disk size enrichment: "
+                   << local_tablets.status();
+    }
+
+    // Fan out to all remote tservers to collect their local tablet disk sizes.
+    auto remote_tservers_result = tablet_server_.GetRemoteTabletServers();
+    if (!remote_tservers_result.ok()) {
+      LOG(WARNING) << "Failed to get remote tservers for disk size enrichment: "
+                   << remote_tservers_result.status();
+      return result;
+    }
+    const auto& remote_tservers = *remote_tservers_result;
+
+    std::vector<std::future<Status>> status_futures;
+    std::vector<std::shared_ptr<ListTabletsResponsePB>> node_responses;
+
+    ListTabletsRequestPB list_req;
+    status_futures.reserve(remote_tservers.size());
+    node_responses.reserve(remote_tservers.size());
+
+    for (const auto& remote_tserver : remote_tservers) {
+      auto init_status = remote_tserver->InitProxy(&client());
+      if (!init_status.ok()) {
+        LOG(WARNING) << "Failed to init proxy for tserver " << remote_tserver->permanent_uuid()
+                     << " during disk size enrichment: " << init_status;
+        continue;
+      }
+      auto proxy = remote_tserver->proxy();
+      auto status_promise = std::make_shared<std::promise<Status>>();
+      status_futures.push_back(status_promise->get_future());
+      auto node_resp = std::make_shared<ListTabletsResponsePB>();
+      node_responses.push_back(node_resp);
+
+      auto controller = std::make_shared<rpc::RpcController>();
+      controller->set_timeout(kEnrichDiskSizesRpcTimeout);
+
+      proxy->ListTabletsAsync(list_req, node_resp.get(), controller.get(),
+          [controller, status_promise] {
+            status_promise->set_value(controller->status());
+          });
+    }
+
+    for (size_t i = 0; i < status_futures.size(); ++i) {
+      auto s = status_futures[i].get();
+      if (!s.ok()) {
+        LOG(WARNING) << "ListTablets RPC failed for remote tserver during disk size enrichment: "
+                     << s;
+        continue;
+      }
+      const auto& node_resp = node_responses[i];
+      if (node_resp->has_error()) {
+        LOG(WARNING) << "ListTablets returned error during disk size enrichment: "
+                     << node_resp->error().status().message();
+        continue;
+      }
+      for (const auto& status_and_schema : node_resp->status_and_schema()) {
+        const auto& tablet_status = status_and_schema.tablet_status();
+        merge_disk_sizes(tablet_status.tablet_id(),
+                         tablet_status.sst_files_disk_size(),
+                         tablet_status.wal_files_disk_size(),
+                         tablet_status.uncompressed_sst_files_disk_size());
+      }
+    }
+
+    return result;
   }
 
   Status GetTabletForKey(
@@ -3176,6 +3342,13 @@ class PgClientServiceImpl::Impl : public SessionProvider {
 
   std::optional<cdc::CDCStateTable> cdc_state_table_;
   PgTxnSnapshotManager txn_snapshot_manager_;
+
+  std::mutex disk_sizes_cache_mutex_;
+  bool disk_sizes_cache_populated_ GUARDED_BY(disk_sizes_cache_mutex_) = false;
+  std::unordered_map<std::string, TabletDiskSizeInfo> disk_sizes_cache_
+      GUARDED_BY(disk_sizes_cache_mutex_);
+  CoarseTimePoint disk_sizes_cache_expiry_
+      GUARDED_BY(disk_sizes_cache_mutex_);
 
   bool shutting_down_ GUARDED_BY(mutex_) = false;
 };

--- a/src/yb/tserver/pg_client_service.cc
+++ b/src/yb/tserver/pg_client_service.cc
@@ -2734,17 +2734,16 @@ class PgClientServiceImpl::Impl : public SessionProvider {
   // Best-effort enrichment: failures are logged but never fail the overall request.
   // Uses a TTL-based cache to avoid fanning out ListTablets RPCs on every query.
   void EnrichTabletsWithDiskSizes(PgTabletsMetadataResponsePB* resp) {
-    // Check if cache needs refreshing. If so, immediately push the expiry forward
-    // to prevent concurrent threads from also triggering a refresh (thundering herd).
+    // Check if cache needs refreshing. Use a separate in-flight flag to prevent
+    // concurrent threads from all triggering refreshes (thundering herd), which
+    // is especially important when TTL is 0 (caching disabled).
     bool needs_refresh = false;
     {
       std::lock_guard lock(disk_sizes_cache_mutex_);
       auto now = CoarseMonoClock::now();
-      if (now >= disk_sizes_cache_expiry_) {
+      if (now >= disk_sizes_cache_expiry_ && !disk_sizes_refresh_in_flight_) {
         needs_refresh = true;
-        // Push expiry forward so other threads use stale cache while we refresh.
-        disk_sizes_cache_expiry_ = now + std::chrono::seconds(
-            FLAGS_tablet_disk_sizes_cache_ttl_sec);
+        disk_sizes_refresh_in_flight_ = true;
       }
     }
 
@@ -2757,6 +2756,9 @@ class PgClientServiceImpl::Impl : public SessionProvider {
       std::lock_guard lock(disk_sizes_cache_mutex_);
       disk_sizes_cache_ = std::move(new_cache);
       disk_sizes_cache_populated_ = true;
+      disk_sizes_refresh_in_flight_ = false;
+      disk_sizes_cache_expiry_ = CoarseMonoClock::now() + std::chrono::seconds(
+          FLAGS_tablet_disk_sizes_cache_ttl_sec);
     }
 
     // Apply cached sizes to response entries. Only set fields for known values
@@ -3345,6 +3347,7 @@ class PgClientServiceImpl::Impl : public SessionProvider {
 
   std::mutex disk_sizes_cache_mutex_;
   bool disk_sizes_cache_populated_ GUARDED_BY(disk_sizes_cache_mutex_) = false;
+  bool disk_sizes_refresh_in_flight_ GUARDED_BY(disk_sizes_cache_mutex_) = false;
   std::unordered_map<std::string, TabletDiskSizeInfo> disk_sizes_cache_
       GUARDED_BY(disk_sizes_cache_mutex_);
   CoarseTimePoint disk_sizes_cache_expiry_

--- a/src/yb/yql/pggate/ybc_pg_typedefs.h
+++ b/src/yb/yql/pggate/ybc_pg_typedefs.h
@@ -889,6 +889,9 @@ typedef struct {
   const char** replicas;
   size_t replicas_count;
   bool is_hash_partitioned;
+  int64_t sst_files_disk_size;
+  int64_t wal_files_disk_size;
+  int64_t uncompressed_sst_files_disk_size;
 } YbcPgGlobalTabletsDescriptor;
 
 typedef struct {

--- a/src/yb/yql/pggate/ybc_pggate.cc
+++ b/src/yb/yql/pggate/ybc_pggate.cc
@@ -3079,7 +3079,13 @@ YbcStatus YBCTabletsMetadata(YbcPgGlobalTabletsDescriptor** tablets, size_t* cou
         .tablet_descriptor = MakeYbcPgTabletsDescriptor(tablet_metadata),
         .replicas = replicas_array,
         .replicas_count = static_cast<size_t>(tablet_metadata.replicas().size()),
-        .is_hash_partitioned = tablet_metadata.is_hash_partitioned()
+        .is_hash_partitioned = tablet_metadata.is_hash_partitioned(),
+        .sst_files_disk_size = tablet_metadata.has_sst_files_disk_size()
+            ? tablet_metadata.sst_files_disk_size() : -1,
+        .wal_files_disk_size = tablet_metadata.has_wal_files_disk_size()
+            ? tablet_metadata.wal_files_disk_size() : -1,
+        .uncompressed_sst_files_disk_size = tablet_metadata.has_uncompressed_sst_files_disk_size()
+            ? tablet_metadata.uncompressed_sst_files_disk_size() : -1
       };
       ++dest;
     }
@@ -3380,7 +3386,7 @@ void YBCPgGlobalViewReadResetScan(YbcPgGlobalViewRead handle) {
 
 void YBCPgGlobalViewReadSetParams(
     YbcPgGlobalViewRead handle, int num_params, const char** param_values) {
-  DCHECK(param_values);
+  DCHECK(param_values || num_params == 0);
   handle->SetParams(std::span{param_values, param_values + num_params});
 }
 

--- a/src/yb/yql/pgwrapper/ysql_migrations/V102__30860__yb_tablet_metadata_attrs.sql
+++ b/src/yb/yql/pgwrapper/ysql_migrations/V102__30860__yb_tablet_metadata_attrs.sql
@@ -1,0 +1,43 @@
+BEGIN;
+  SET LOCAL yb_non_ddl_txn_for_sys_tables_allowed TO true;
+
+  -- Update yb_get_tablet_metadata function to add tablet_attrs (jsonb) output column.
+  UPDATE pg_catalog.pg_proc
+  SET
+    proallargtypes = '{25,25,25,25,25,23,23,25,1009,3802}',
+    proargmodes = '{o,o,o,o,o,o,o,o,o,o}',
+    proargnames = '{tablet_id,object_uuid,namespace,object_name,type,start_hash_code,end_hash_code,leader,replicas,tablet_attrs}'
+  WHERE oid = 8099;
+COMMIT;
+
+-- Recreate the view to include the new tablet_attrs column.
+CREATE OR REPLACE VIEW pg_catalog.yb_tablet_metadata
+WITH (use_initdb_acl = true) AS
+    SELECT
+        t.tablet_id,
+        CASE
+            WHEN t.namespace = 'system' AND t.object_name = 'transactions'
+                THEN NULL
+            WHEN length(t.object_uuid) != 32
+                THEN NULL
+            ELSE
+                ('x' || right(t.object_uuid, 8))::bit(32)::int::oid
+        END AS oid,
+        t.namespace    AS db_name,
+        t.object_name  AS relname,
+        t.start_hash_code,
+        t.end_hash_code,
+        t.leader,
+        t.replicas,
+        t.tablet_attrs
+    FROM
+        yb_get_tablet_metadata() t
+    LEFT JOIN
+        pg_class c ON c.oid = (CASE WHEN length(t.object_uuid) = 32
+            THEN ('x' || right(t.object_uuid, 8))::bit(32)::int::oid ELSE NULL END)
+    LEFT JOIN
+        pg_namespace n ON n.oid = c.relnamespace
+    WHERE
+        (t.namespace = 'system' AND t.object_name = 'transactions')
+    OR
+        (t.type = 'YSQL' AND n.nspname NOT IN ('pg_catalog', 'information_schema'));


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new `jsonb` output column backed by tserver-side fan-out RPCs to enrich tablet metadata, which could impact latency/robustness of the metadata call despite best-effort error handling. Changes touch cross-layer plumbing (tserver RPC -> pggate structs -> Postgres SRF/view) and require careful compatibility with existing callers.
> 
> **Overview**
> Exposes new per-tablet *disk size* metadata via `yb_tablet_metadata` by adding a `tablet_attrs` `jsonb` column (also returned from `yb_get_tablet_metadata`).
> 
> Implements end-to-end plumbing to populate these attributes: the tserver `TabletsMetadata` RPC now best-effort enriches master tablet metadata by fanning out `ListTablets` to all tservers (with a 5s timeout) to fetch SST/WAL/uncompressed SST sizes, and the Postgres-side SRF builds `tablet_attrs` JSONB from the returned sizes.
> 
> Adds a migration to update `pg_proc`/recreate the view, and extends regression tests to validate expected JSON keys and non-negative values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 976b0f3fbe227ec86f50cd83554ca12a832b8a56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->