### PR TITLE
Fix running threads metric to use gauge instead of counter

### DIFF
--- a/src/yb/util/thread.cc
+++ b/src/yb/util/thread.cc
@@ -260,7 +260,8 @@ std::atomic<uint64_t>& ThreadCategoryTracker::RegisterGaugeForAllMetricEntities(
 class ThreadMgr {
  public:
   ThreadMgr() {
-    started_category_tracker_ = std::make_unique<ThreadCategoryTracker>("threads_started", /*expose_as_counter=*/true);
+    started_category_tracker_ = std::make_unique<ThreadCategoryTracker>(
+        "threads_started", /*expose_as_counter=*/true);
     running_category_tracker_ = std::make_unique<ThreadCategoryTracker>("threads_running");
   }
 


### PR DESCRIPTION
The running threads metric was incorrectly reported as a counter, but it should be a gauge since it represents a current value that can go up and down.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to metrics registration that only affects how thread category gauges are exported/typed (counter vs gauge).
> 
> **Overview**
> Adjusts `ThreadCategoryTracker` to optionally mark its per-category gauges as `EXPOSE_AS_COUNTER`, instead of always exporting them as counters.
> 
> Updates `ThreadMgr` so only `threads_started` category metrics are exposed as counters, while `threads_running` category metrics are exported as gauges to correctly represent a value that can decrease.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65de39892d65488581b8a96bae9ae0057adf988a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

Phorge: [D51661](https://phorge.dev.yugabyte.com/D51661)