### PR TITLE
Change default bucketid range from 8 to 7

### DIFF
--- a/docs/content/stable/develop/data-modeling/common-patterns/timeseries/global-ordering.md
+++ b/docs/content/stable/develop/data-modeling/common-patterns/timeseries/global-ordering.md
@@ -94,7 +94,7 @@ CREATE TABLE global_order2 (
     ts timestamp,/* time at which the event was generated */
     car varchar, /* name of the car */
     speed int,   /* speed of your car */
-    bucketid smallint DEFAULT random()*7, /* bucket id*/
+    bucketid smallint DEFAULT floor(random()*8), /* bucket id*/
     PRIMARY KEY(bucketid HASH, ts ASC)
 ) SPLIT INTO 3 TABLETS;
 ```
@@ -112,7 +112,7 @@ INSERT INTO global_order2 (ts, car, speed)
             FROM generate_series(1,100) AS id);
 ```
 
-Because the default value of `bucketid` is set to `random()*7`, you do not have to explicitly insert the value.
+Because the default value of `bucketid` is set to `floor(random()*8)`, you do not have to explicitly insert the value.
 
 Retrieve the data from the table as follows:
 

--- a/docs/content/stable/develop/data-modeling/common-patterns/timeseries/global-ordering.md
+++ b/docs/content/stable/develop/data-modeling/common-patterns/timeseries/global-ordering.md
@@ -94,7 +94,7 @@ CREATE TABLE global_order2 (
     ts timestamp,/* time at which the event was generated */
     car varchar, /* name of the car */
     speed int,   /* speed of your car */
-    bucketid smallint DEFAULT random()*8, /* bucket id*/
+    bucketid smallint DEFAULT random()*7, /* bucket id*/
     PRIMARY KEY(bucketid HASH, ts ASC)
 ) SPLIT INTO 3 TABLETS;
 ```
@@ -112,7 +112,7 @@ INSERT INTO global_order2 (ts, car, speed)
             FROM generate_series(1,100) AS id);
 ```
 
-Because the default value of `bucketid` is set to `random()*8`, you do not have to explicitly insert the value.
+Because the default value of `bucketid` is set to `random()*7`, you do not have to explicitly insert the value.
 
 Retrieve the data from the table as follows:
 

--- a/docs/content/stable/develop/data-modeling/common-patterns/timeseries/ordering-by-entity.md
+++ b/docs/content/stable/develop/data-modeling/common-patterns/timeseries/ordering-by-entity.md
@@ -87,7 +87,7 @@ CREATE TABLE entity_order2 (
     ts timestamp,/* time at which the event was generated */
     car varchar, /* name of the car */
     speed int,   /* speed of your car */
-    bucketid smallint DEFAULT random()*8, /* bucket id*/
+    bucketid smallint DEFAULT floor(random()*8), /* bucket id*/
     PRIMARY KEY((car, bucketid) HASH, ts ASC)
 ) SPLIT INTO 3 TABLETS;
 ```
@@ -103,7 +103,7 @@ INSERT INTO entity_order2 (ts, car, speed)
             FROM generate_series(1,100) AS id);
 ```
 
-Because the default value of `bucketid` is set to `random()*8`, you do not have to explicitly insert the value.
+Because the default value of `bucketid` is set to `floor(random()*8)`, you do not have to explicitly insert the value.
 
 Retrieve the data from the table as follows:
 


### PR DESCRIPTION
(random()*7)::smallint - this should produce 8 steps `(0,1,2,3,4,5,6,7)`, unlike previous example which would produce 9 steps `(0,1,2,3,4,5,6,7,8)`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adjusting the `bucketid` default expression; no product code or runtime behavior is affected.
> 
> **Overview**
> Updates the time-series global ordering documentation to change the example `bucketid` default from `random()*8` to `random()*7`, and aligns the accompanying explanation accordingly so the example generates buckets `0..7` rather than `0..8`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83018f517c7cc007febf4bc82f853eef16700eec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->