### PR TITLE
Fix parallel ctest runs sharing the same TEST_TMPDIR

### DIFF
--- a/yb_build.sh
+++ b/yb_build.sh
@@ -1156,7 +1156,6 @@ fi
 run_tests_remotely
 
 if [[ ${ran_tests_remotely} != "true" ]]; then
-  ensure_test_tmp_dir_is_set
   if [[ -n $cxx_test_name ]]; then
     capture_sec_timestamp cxx_test_start
     run_cxx_test


### PR DESCRIPTION
yb_build.sh was calling ensure_test_tmp_dir_is_set() before launching
ctest, which exported TEST_TMPDIR with yb_build.sh's own PID into the
environment. All parallel run-test.sh processes spawned by ctest
inherited this value and skipped creating their own unique directories,
causing them to clobber each other's temp files mid-test.

The call is unnecessary since run-test.sh calls ensure_test_tmp_dir_is_set()
itself, creating a unique directory per process.


---

Phorge: [D51698](https://phorge.dev.yugabyte.com/D51698)