### PR TITLE
Fix ts-cli usage documentation for DumpTabletData command

### DIFF
--- a/src/yb/tools/ts-cli.cc
+++ b/src/yb/tools/ts-cli.cc
@@ -851,7 +851,7 @@ void SetUsage(const char* argv0) {
       << "  " << kClearUniverseUuidOp << "\n"
       << "  " << kClearYCQLMetaDataCacheOnServerOp << "\n"
       << "  " << kReleaseAllLocksForTxnOp << " <txn id> [subtxn id]\n"
-      << "  " << kDumpTabletDataOp << " <tablet_id> [<dest_path> | HASH_ONLY] [read_ht]\n";
+      << "  " << kDumpTabletDataOp << " <tablet_id> (<dest_path> | HASH_ONLY) [read_ht]\n";
   google::SetUsageMessage(str.str());
 }
 


### PR DESCRIPTION
## Summary
Updated the usage documentation for the `DumpTabletData` command in ts-cli to correctly reflect that the destination path parameter is required rather than optional.

## Changes
- Modified the usage string for `kDumpTabletDataOp` to use parentheses `()` instead of square brackets `[]` around the `<dest_path> | HASH_ONLY` parameter
- This change clarifies that either a destination path or the `HASH_ONLY` option must be provided (required parameter), rather than being optional
- The `[read_ht]` parameter remains in square brackets, correctly indicating it is optional

## Details
The syntax change from `[<dest_path> | HASH_ONLY]` to `(<dest_path> | HASH_ONLY)` follows standard command-line documentation conventions where:
- Square brackets `[]` denote optional parameters
- Parentheses `()` denote required parameters with alternatives

https://claude.ai/code/session_01RKBspnbuCDAJuYQw2ekn2g

Fixes #30920

---

Phorge: [D51727](https://phorge.dev.yugabyte.com/D51727)