### PR TITLE
Fix DynamicMemoryUsageOf(std::string) on macOS

### DIFF
--- a/src/yb/util/memory/memory_usage.h
+++ b/src/yb/util/memory/memory_usage.h
@@ -67,7 +67,8 @@ inline std::size_t DynamicMemoryUsageOf(const std::string& value) {
     return 0;
   } else {
 #if defined(__linux__)
-    // gperftools tcmalloc allocates 16*n bytes for std::string capacity from [16*(n - 1); 16*n - 1].
+    // gperftools tcmalloc allocates 16*n bytes for std::string capacity
+    // from [16*(n - 1); 16*n - 1].
     // 48 bytes for capacity in [32; 47], 64 bytes for capacity in [48; 63] and so on...
     return (capacity + 16) & ~(size_t(0xf));
 #else


### PR DESCRIPTION
The memory_usage-test is disabled on Linux because the build uses Google
tcmalloc, which does not support malloc hooks (YB_GPERFTOOLS_TCMALLOC is
not defined). However, on macOS, Google tcmalloc is not supported, so
the build uses gperftools tcmalloc instead (YB_GPERFTOOLS_TCMALLOC is
defined), which enables the test.

On macOS, gperftools tcmalloc is statically linked but does not replace
the system allocator (libsystem_malloc). It only provides malloc hooks
for observing allocations. The existing DynamicMemoryUsageOf formula for
clang used tcmalloc's 16-byte size class rounding ((capacity + 16) &
~0xf), which is incorrect on macOS where the system allocator allocates
exactly capacity + 1 bytes.

This caused memory_usage-test to fail on macOS, e.g. for a string with
capacity 24: DynamicMemoryUsageOf returned 32 but the actual allocation
was 25.

Split the clang path so that the tcmalloc rounding formula is only used
on Linux, where gperftools tcmalloc is the active allocator. On macOS
(and other non-Linux clang platforms), use capacity + 1, which matches
the system allocator behavior. The SSO capacity (22) is correct for
libc++ on both platforms.


---

Phorge: [D51803](https://phorge.dev.yugabyte.com/D51803)