### PR TITLE
Add build prerequisites and guidance for Claude Code sessions

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -28,13 +28,6 @@ sudo locale-gen en_US.UTF-8
 
 The primary build entry point is `yb_build.sh` at the repository root.
 
-The first build takes approximately 20 minutes. Incremental builds are much faster.
-
-Always pipe build output to a temp file so you can inspect errors without rebuilding:
-```bash
-./yb_build.sh release daemons initdb --sj --skip-pg-parquet --no-odyssey --no-ybc 2>&1 | tee /tmp/yb-build.log
-```
-
 Reuse existing build compiler/type if available (see `build/latest` symlink); default to `release` otherwise.
 
 Add these `yb_build.sh` options to reduce build time:
@@ -43,6 +36,13 @@ Add these `yb_build.sh` options to reduce build time:
 - Skip pg_parquet build (`--skip-pg-parquet`) unless you need it.
 - Skip odyssey build (`--no-odyssey`) unless you need it.
 - Skip YBC build (`--no-ybc`) unless you need it.
+
+The first build takes approximately 20 minutes. Incremental builds are much faster.
+
+Always pipe build output to a temp file so you can inspect errors without rebuilding:
+```bash
+./yb_build.sh release daemons initdb --sj --skip-pg-parquet --no-odyssey --no-ybc 2>&1 | tee /tmp/yb-build.log
+```
 
 Pitfalls when doing incremental build:
 - The `initdb` cmake target may not be built when specified in the same `yb_build.sh` command as test options.


### PR DESCRIPTION
## Summary
This PR adds documentation for setting up YugabyteDB builds in Claude Code sessions, including required dependencies and build best practices.

## Key Changes
- **AGENTS.md**: Added a new "Build Prerequisites for Claude Code" section documenting:
  - CMake >= 3.31 requirement (with pip installation instructions for Ubuntu 24.04)
  - Required system packages (rsync, gettext)
  - en_US.UTF-8 locale requirement for initdb
  - Installation commands for Ubuntu/Debian systems

- **src/AGENTS.md**: Enhanced build guidance with:
  - Estimated build time information (20 minutes for initial build, faster incremental builds)
  - Recommended practice of piping build output to a temp file for error inspection
  - Example build command with common optimization flags

## Implementation Details
The changes provide practical setup instructions tailored for Claude Code environments where default system packages may be outdated or missing required locales. The build guidance emphasizes efficiency by recommending output logging to avoid rebuilds when debugging errors.

https://claude.ai/code/session_01VxfWz6N4fdaZcFgP9RDTbg