### PR TITLE
Skip xcluster DDL replication tests requiring yb-controller on macOS

### DIFF
--- a/src/yb/integration-tests/xcluster/xcluster_ddl_replication-test.cc
+++ b/src/yb/integration-tests/xcluster/xcluster_ddl_replication-test.cc
@@ -4797,6 +4797,10 @@ TEST_F(XClusterDDLReplicationTest, VectorIndex) {
 // index's hybrid_time, so the write can be missing from the vector index. This test verifies
 // the fix.
 TEST_F(XClusterDDLReplicationTest, VectorIndexLateWriteAfterBackfillMissing) {
+  if (!UseYbController()) {
+    GTEST_SKIP() << "This test does not work with yb_backup.py";
+  }
+
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_usearch_exact) = true;
   auto params = XClusterDDLReplicationTestBase::kDefaultParams;
   params.start_yb_controller_servers = true;


### PR DESCRIPTION
`yb-controller-server` is a pre-built binary only available on Linux.
Tests that set `start_yb_controller_servers = true` crash on macOS because the binary doesn't exist.
All the tests in `XClusterDDLReplicationTest` test suite that require `yb-controller-server`, perform a check if this executable is available. The test is skipped then, if it is not available.
This check was omitted for `VectorIndexLateWriteAfterBackfillMissing` test case and it was failing on macOS. This PR provides a fix for this failure.



---

Phorge: [D52188](https://phorge.dev.yugabyte.com/D52188)