### PR TITLE
Skip macOS resource fork files in upgrade migration parser

### DIFF
--- a/src/yb/integration-tests/upgrade-tests/upgrade_test_base.cc
+++ b/src/yb/integration-tests/upgrade-tests/upgrade_test_base.cc
@@ -222,6 +222,16 @@ Status ValidateYsqlMigrationCompatibility(const std::string& old_version_base_pa
     RETURN_NOT_OK(env->GetChildren(migration_dir, &migration_files));
 
     for (const auto& file : migration_files) {
+      // macOS creates ._ resource fork companion files when extracting tarballs.
+      // These mirror the original filename (e.g., ._V53__22144__foo.sql), so they
+      // pass the .sql extension below but fail on migration_regex. The solution is
+      // to filter them out right away.
+      #ifdef __APPLE__
+      if (file.starts_with("._")) {
+        continue;
+      }
+      #endif
+
       if (!file.ends_with(".sql")) {
         continue;
       }

--- a/src/yb/integration-tests/upgrade-tests/upgrade_test_base.cc
+++ b/src/yb/integration-tests/upgrade-tests/upgrade_test_base.cc
@@ -226,11 +226,9 @@ Status ValidateYsqlMigrationCompatibility(const std::string& old_version_base_pa
       // These mirror the original filename (e.g., ._V53__22144__foo.sql), so they
       // pass the .sql extension below but fail on migration_regex. The solution is
       // to filter them out right away.
-      #ifdef __APPLE__
       if (file.starts_with("._")) {
         continue;
       }
-      #endif
 
       if (!file.ends_with(".sql")) {
         continue;

--- a/src/yb/integration-tests/upgrade-tests/upgrade_test_base.cc
+++ b/src/yb/integration-tests/upgrade-tests/upgrade_test_base.cc
@@ -168,8 +168,9 @@ Result<std::string> DownloadAndGetBinPath(const BuildInfo& build_info) {
     RETURN_NOT_OK(env->DeleteRecursively(extract_path));
   }
   RETURN_NOT_OK(env->CreateDir(extract_path));
-  RETURN_NOT_OK(
-      RunCommand({tar_bin, "xzf", tar_file_path, "--skip-old-files", "-C", version_root_path}));
+  RETURN_NOT_OK(RunCommand(
+      {tar_bin, "xzf", tar_file_path, "--skip-old-files", "--exclude=._*", "-C",
+       version_root_path}));
 
 #if defined(__linux__)
   RETURN_NOT_OK(RunCommand({"bash", JoinPathSegments(bin_path, "post_install.sh")}));
@@ -222,14 +223,6 @@ Status ValidateYsqlMigrationCompatibility(const std::string& old_version_base_pa
     RETURN_NOT_OK(env->GetChildren(migration_dir, &migration_files));
 
     for (const auto& file : migration_files) {
-      // macOS creates ._ resource fork companion files when extracting tarballs.
-      // These mirror the original filename (e.g., ._V53__22144__foo.sql), so they
-      // pass the .sql extension below but fail on migration_regex. The solution is
-      // to filter them out right away.
-      if (file.starts_with("._")) {
-        continue;
-      }
-
       if (!file.ends_with(".sql")) {
         continue;
       }


### PR DESCRIPTION
### Summary
Skip macOS AppleDouble resource-fork files (`._*`) during upgrade-test tarball extraction so they never reach `ValidateYsqlMigrationCompatibility`.

### Problem
Upgrade integration test, `xcluster_upgrade-itest`, fails on macOS when loading an old-version release tarball.

The release tarballs are built on macOS, which embeds `AppleDouble` companion files (.`_V53__22144__foo.sql` next to each `V53__22144__foo.sql`) to preserve HFS+ extended attributes. When `gtar` extracts the tarball on another macOS host, those companions are faithfully written to disk alongside the real migrations.

`ValidateYsqlMigrationCompatibility` walks `share/ysql_migrations/`, filters `.sql` by suffix (which `._V…sql` passes), and then fails the filename-regex check with:

Invalid migration file name: `._V53__22144__foo.sql`

### Fix
Pass `--exclude=._*` to the tar `xzf` invocation in `DownloadAndGetBinPath`. The junk never lands on disk, so no downstream code needs to know it existed.

Works with both `tar` on Linux and `gtar` on macOS (both GNU tar); the flag is a no-op on tarballs that don't contain `._*` entries.

### Why this approach
Earlier iterations filtered the files inside the migration reader. That's more fragile — any future code that walks the extracted tree (not just the migration validator) would hit the same problem and have to re-discover the fix. Excluding at extraction time fixes it once, at the source.

### Test plan

- Run `xcluster_upgrade-itest` on macOS — this is the reliable verifier: without the fix it fails at `ValidateYsqlMigrationCompatibility` on `._*` migration files, and with the fix it passes end-to-end.
- Run x`cluster_upgrade-itest` on Linux to confirm the extra `--exclude=._*` flag doesn't regress anything.

---

Phorge: [D52008](https://phorge.dev.yugabyte.com/D52008)