### PR TITLE
Fix timezone mismatch in CDC restart commit time test

### DIFF
--- a/src/yb/integration-tests/cdcsdk_ysql-test.cc
+++ b/src/yb/integration-tests/cdcsdk_ysql-test.cc
@@ -12048,7 +12048,9 @@ TEST_F(CDCSDKYsqlTest, TestYbRestartCommitTimeInPgReplicationSlots) {
 
   auto conn = ASSERT_RESULT(test_cluster_.ConnectToDB(kNamespaceName));
   auto result = ASSERT_RESULT(conn.Fetch(
-      "SELECT to_char(yb_restart_time AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS.USOF') FROM pg_replication_slots"));
+      "SELECT to_char(yb_restart_time AT TIME ZONE 'UTC',"
+          " 'YYYY-MM-DD HH24:MI:SS.US') || '+00'"
+          " FROM pg_replication_slots"));
 
   ASSERT_EQ(PQntuples(result.get()), 1);
 


### PR DESCRIPTION
The test compares a timestamp from pg_replication_slots (formatted in
the session's local timezone) against a UTC-formatted expected value.
Convert the query result to UTC so the comparison is consistent
regardless of the machine's timezone.



---

Phorge: [D51954](https://phorge.dev.yugabyte.com/D51954)