### PR TITLE
Guard memory usage implementation with YB_GPERFTOOLS_TCMALLOC

### DIFF
--- a/src/yb/util/memory/memory_usage.h
+++ b/src/yb/util/memory/memory_usage.h
@@ -66,14 +66,14 @@ inline std::size_t DynamicMemoryUsageOf(const std::string& value) {
   if (capacity <= kStdStringInternalCapacity) {
     return 0;
   } else {
-#if defined(__linux__)
-    // gperftools tcmalloc allocates 16*n bytes for std::string capacity
+#if defined(YB_GPERFTOOLS_TCMALLOC)
+    // gperftools tcmalloc allocates exactly capacity + 1 bytes.
+    return capacity + 1;
+#else
+    // Google tcmalloc allocates 16*n bytes for std::string capacity
     // from [16*(n - 1); 16*n - 1].
     // 48 bytes for capacity in [32; 47], 64 bytes for capacity in [48; 63] and so on...
     return (capacity + 16) & ~(size_t(0xf));
-#else
-    // macOS system allocator: allocates exactly capacity + 1 bytes.
-    return capacity + 1;
 #endif
   }
 }


### PR DESCRIPTION
The memory usage calculation has two code paths: one for gperftools
tcmalloc and one for google tcmalloc. The gperftools path now uses
the correct YB_GPERFTOOLS_TCMALLOC guard so the memory usage test
runs when building with --gperftools-tcmalloc on Linux and on macOS
where gperftools is the default allocator.



---

Phorge: [D52007](https://phorge.dev.yugabyte.com/D52007)