### PR TITLE
[DocDB] Add /api/v1/tasks JSON endpoint for Master UI tasks page

### DIFF
--- a/src/yb/integration-tests/master_path_handlers-itest.cc
+++ b/src/yb/integration-tests/master_path_handlers-itest.cc
@@ -1856,4 +1856,43 @@ TEST_F(MasterPathHandlersItest, TabletLimitsSkipBlacklistedTServers) {
       10s, "Reported tablet limit should decrease"));
 }
 
+TEST_F(MasterPathHandlersItest, TestTasksJsonEndpoint) {
+  // Create a table so that the cluster has some activity that may generate tasks.
+  auto table = CreateTestTable();
+
+  faststring result;
+  ASSERT_OK(GetUrl("/api/v1/tasks", &result));
+
+  JsonDocument doc;
+  auto json_obj = ASSERT_RESULT(doc.Parse(result.ToString()));
+  EXPECT_TRUE(json_obj.IsObject());
+
+  // Verify the three expected top-level arrays exist.
+  auto active_tasks = ASSERT_RESULT(json_obj["active_tasks"].GetArray());
+  auto recent_jobs = ASSERT_RESULT(json_obj["recent_jobs"].GetArray());
+  auto recent_tasks = ASSERT_RESULT(json_obj["recent_tasks"].GetArray());
+
+  // Helper to verify that a task object contains all fields produced by JsonOutputTask.
+  auto verifyTaskFields = [](const JsonValue& task) {
+    EXPECT_TRUE(task["task_type"].IsValid());
+    EXPECT_TRUE(task["task_state"].IsValid());
+    EXPECT_TRUE(task["task_time_since_started"].IsValid());
+    EXPECT_TRUE(task["task_running_secs"].IsValid());
+    EXPECT_TRUE(task["task_description"].IsValid());
+  };
+
+  for (size_t i = 0; i < active_tasks.size(); ++i) {
+    SCOPED_TRACE(Format("active_tasks[$0]", i));
+    verifyTaskFields(active_tasks[i]);
+  }
+  for (size_t i = 0; i < recent_jobs.size(); ++i) {
+    SCOPED_TRACE(Format("recent_jobs[$0]", i));
+    verifyTaskFields(recent_jobs[i]);
+  }
+  for (size_t i = 0; i < recent_tasks.size(); ++i) {
+    SCOPED_TRACE(Format("recent_tasks[$0]", i));
+    verifyTaskFields(recent_tasks[i]);
+  }
+}
+
 } // namespace yb::integration_tests

--- a/src/yb/integration-tests/master_path_handlers-itest.cc
+++ b/src/yb/integration-tests/master_path_handlers-itest.cc
@@ -37,6 +37,7 @@
 #include "yb/integration-tests/mini_cluster.h"
 #include "yb/integration-tests/path_handlers_util.h"
 #include "yb/integration-tests/yb_mini_cluster_test_base.h"
+#include "yb/yql/pgwrapper/libpq_utils.h"
 
 #include "yb/master/catalog_entity_info.h"
 #include "yb/master/catalog_manager_if.h"
@@ -1893,6 +1894,46 @@ TEST_F(MasterPathHandlersItest, TestTasksJsonEndpoint) {
     SCOPED_TRACE(Format("recent_tasks[$0]", i));
     verifyTaskFields(recent_tasks[i]);
   }
+}
+
+// Test that /api/v1/tasks captures an active DDL verification task by using
+// yb_test_delay_next_ddl to slow down DDL processing, then polling the endpoint.
+TEST_F_EX(MasterPathHandlersExternalItest, TestTasksJsonWithActiveDdlTask,
+          MasterPathHandlersExternalItest) {
+  // Connect to YSQL and trigger a DDL with an artificial delay so that the
+  // TableSchemaVerificationTask stays active long enough for us to observe it.
+  auto conn = ASSERT_RESULT(pgwrapper::PGConnBuilder({
+    .host = cluster_->tablet_server(0)->bound_rpc_addr().host(),
+    .port = cluster_->pgsql_hostport(0).port(),
+    .dbname = "yugabyte",
+  }).Connect());
+
+  // Delay DDL verification so the task is still running when we query /api/v1/tasks.
+  ASSERT_OK(conn.Execute("SET yb_test_delay_next_ddl='30s'"));
+  ASSERT_OK(conn.Execute("CREATE TABLE tasks_json_test_table(k INT PRIMARY KEY)"));
+
+  // Poll /api/v1/tasks until we see a TableSchemaVerificationTask in active_tasks.
+  ASSERT_OK(WaitFor(
+      [this]() -> Result<bool> {
+        faststring result;
+        RETURN_NOT_OK(GetUrl("/api/v1/tasks", &result));
+        JsonDocument doc;
+        auto json_obj = VERIFY_RESULT(doc.Parse(result.ToString()));
+        auto active_tasks = VERIFY_RESULT(json_obj["active_tasks"].GetArray());
+        for (size_t i = 0; i < active_tasks.size(); ++i) {
+          auto task_type = VERIFY_RESULT(active_tasks[i]["task_type"].GetString());
+          if (std::string(task_type) == "TableSchemaVerificationTask") {
+            // Also verify the other expected fields are present.
+            SCHECK(active_tasks[i]["task_state"].IsValid(), IllegalState,
+                   "Missing task_state field");
+            SCHECK(active_tasks[i]["task_description"].IsValid(), IllegalState,
+                   "Missing task_description field");
+            return true;
+          }
+        }
+        return false;
+      },
+      30s, "Waiting for TableSchemaVerificationTask in /api/v1/tasks"));
 }
 
 } // namespace yb::integration_tests

--- a/src/yb/integration-tests/master_path_handlers-itest.cc
+++ b/src/yb/integration-tests/master_path_handlers-itest.cc
@@ -1898,13 +1898,14 @@ TEST_F(MasterPathHandlersItest, TestTasksJsonEndpoint) {
 
 // Test that /api/v1/tasks captures an active DDL verification task by using
 // yb_test_delay_next_ddl to slow down DDL processing, then polling the endpoint.
-TEST_F_EX(MasterPathHandlersExternalItest, TestTasksJsonWithActiveDdlTask,
+TEST_F_EX(MasterPathHandlersItest, TestTasksJsonWithActiveDdlTask,
           MasterPathHandlersExternalItest) {
   // Connect to YSQL and trigger a DDL with an artificial delay so that the
   // TableSchemaVerificationTask stays active long enough for us to observe it.
+  auto host_port = cluster_->ysql_hostport(0);
   auto conn = ASSERT_RESULT(pgwrapper::PGConnBuilder({
-    .host = cluster_->tablet_server(0)->bound_rpc_addr().host(),
-    .port = cluster_->pgsql_hostport(0).port(),
+    .host = host_port.host(),
+    .port = host_port.port(),
     .dbname = "yugabyte",
   }).Connect());
 

--- a/src/yb/master/master-path-handlers.cc
+++ b/src/yb/master/master-path-handlers.cc
@@ -2252,6 +2252,52 @@ void MasterPathHandlers::HandleTasksPage(const Webserver::WebRequest& req,
   *output << "</table>\n";
 }
 
+void MasterPathHandlers::HandleTasksJSON(const Webserver::WebRequest& req,
+                                         Webserver::WebResponse* resp) {
+  std::stringstream *output = &resp->output;
+  JsonWriter jw(output, JsonWriter::COMPACT);
+  jw.StartObject();
+
+  // Active tasks from tables
+  auto tables = master_->catalog_manager()->GetTables(GetTablesMode::kAll);
+  jw.String("active_tasks");
+  jw.StartArray();
+  for (const auto& table : tables) {
+    for (const auto& task : table->GetTasks()) {
+      jw.StartObject();
+      JsonOutputTask(task, &jw);
+      jw.EndObject();
+    }
+  }
+  jw.EndArray();
+
+  // Recent user-initiated jobs
+  std::vector<std::shared_ptr<MonitoredTask>> jobs =
+      master_->catalog_manager()->GetRecentJobs();
+  jw.String("recent_jobs");
+  jw.StartArray();
+  for (auto iter = jobs.rbegin(); iter != jobs.rend(); ++iter) {
+    jw.StartObject();
+    JsonOutputTask(*iter, &jw);
+    jw.EndObject();
+  }
+  jw.EndArray();
+
+  // Recent tasks
+  std::vector<std::shared_ptr<MonitoredTask>> tasks =
+      master_->catalog_manager()->GetRecentTasks();
+  jw.String("recent_tasks");
+  jw.StartArray();
+  for (auto iter = tasks.rbegin(); iter != tasks.rend(); ++iter) {
+    jw.StartObject();
+    JsonOutputTask(*iter, &jw);
+    jw.EndObject();
+  }
+  jw.EndArray();
+
+  jw.EndObject();
+}
+
 Result<std::vector<TabletInfoPtr>> MasterPathHandlers::GetNonSystemTablets() {
   std::vector<TabletInfoPtr> nonsystem_tablets;
 
@@ -3457,6 +3503,9 @@ Status MasterPathHandlers::Register(Webserver* server) {
 
   RegisterLeaderOrRedirect(
       server, "/api/v1/xcluster", "xCluster", &MasterPathHandlers::HandleGetXClusterJSON);
+
+  RegisterLeaderOrRedirect(
+      server, "/api/v1/tasks", "Tasks", &MasterPathHandlers::HandleTasksJSON);
 
   server->RegisterPathHandler(
       "/api/v1/meta-cache", "MetaCache",

--- a/src/yb/master/master-path-handlers.h
+++ b/src/yb/master/master-path-handlers.h
@@ -273,6 +273,8 @@ class MasterPathHandlers {
                            Webserver::WebResponse* resp);
   void HandleTasksPage(const Webserver::WebRequest& req,
                        Webserver::WebResponse* resp);
+  void HandleTasksJSON(const Webserver::WebRequest& req,
+                       Webserver::WebResponse* resp);
   void HandleTabletReplicasPage(const Webserver::WebRequest &req, Webserver::WebResponse *resp);
   void HandleMasters(const Webserver::WebRequest& req,
                      Webserver::WebResponse* resp);


### PR DESCRIPTION
## Problem

Fixes #31006

The Master UI `/tasks` page only renders HTML. There is no `/api/v1/tasks` JSON equivalent, making it impossible for monitoring tools, scripts, or external dashboards to programmatically query active tasks, recent jobs, and recent tasks from the master.

Every other major Master UI page already has a JSON variant (`/api/v1/tablet-servers`, `/api/v1/namespaces`, `/api/v1/tables`, `/api/v1/xcluster`, etc.).

## Solution

Added `HandleTasksJSON` handler registered at `/api/v1/tasks`, returning the same three categories as the HTML `/tasks` page:

### Response format

```json
{
  "active_tasks": [
    {
      "task_type": "Alter Table",
      "task_state": "kRunning",
      "task_time_since_started": "5.2s",
      "task_running_secs": "5.2s",
      "task_description": "ALTER TABLE foo"
    }
  ],
  "recent_jobs": [...],
  "recent_tasks": [...]
}
```

### Implementation details

- Reuses the existing `JsonOutputTask` helper (line 1914) for consistent field names across the codebase
- Wraps each task in a JSON object (the existing helper writes key-value pairs into the current object context)
- Uses `JsonWriter::COMPACT` format matching other `/api/v1/*` endpoints
- Registered via `RegisterLeaderOrRedirect` so the request is redirected to the leader master, same as `/api/v1/tables`
- Active tasks sourced from `GetTables(kAll)` + `table->GetTasks()`
- Recent jobs from `GetRecentJobs()`, recent tasks from `GetRecentTasks()`
- Both recent collections are iterated in reverse (newest first), matching the HTML page behavior

## Changes

- `src/yb/master/master-path-handlers.cc` — added `HandleTasksJSON` handler + endpoint registration
- `src/yb/master/master-path-handlers.h` — added declaration