### PR TITLE
Filter cdc_state table scan by stream ID in GetTabletIdsToPoll

### DIFF
--- a/src/yb/cdc/cdc_service.cc
+++ b/src/yb/cdc/cdc_service.cc
@@ -3252,7 +3252,7 @@ Status CDCServiceImpl::GetTabletIdsToPoll(
   Status iteration_status;
   // Filter the cdc_state scan by stream_id to avoid reading all rows.
   // Without this filter, the full table (87K+ rows on large clusters) is scanned
-  // on every call, causing 30-60s latencies.
+  // on every call.
   auto entries = VERIFY_RESULT(cdc_state_table_->GetTableRange(
       CDCStateTableEntrySelector()
           .IncludeCheckpoint()

--- a/src/yb/cdc/cdc_service.cc
+++ b/src/yb/cdc/cdc_service.cc
@@ -3250,12 +3250,16 @@ Status CDCServiceImpl::GetTabletIdsToPoll(
   std::set<TabletId> polled_tablets;
 
   Status iteration_status;
+  // Filter the cdc_state scan by stream_id to avoid reading all rows.
+  // Without this filter, the full table (87K+ rows on large clusters) is scanned
+  // on every call, causing 30-60s latencies.
   auto entries = VERIFY_RESULT(cdc_state_table_->GetTableRange(
       CDCStateTableEntrySelector()
           .IncludeCheckpoint()
           .IncludeLastReplicationTime()
           .IncludeCDCSDKSafeTime(),
-      &iteration_status));
+      &iteration_status,
+      stream_id));
 
   for (auto entry_result : entries) {
     if (!entry_result) {
@@ -3263,9 +3267,6 @@ Status CDCServiceImpl::GetTabletIdsToPoll(
       continue;
     }
     auto& entry = *entry_result;
-    if (entry.key.stream_id != stream_id) {
-      continue;
-    }
 
     auto& tablet_id = entry.key.tablet_id;
     auto is_cur_tablet_polled = entry.last_replication_time.has_value();
@@ -3289,9 +3290,6 @@ Status CDCServiceImpl::GetTabletIdsToPoll(
     }
 
     auto& entry = *entry_result;
-    if (entry.key.stream_id != stream_id) {
-      continue;
-    }
 
     auto& tablet_id = entry.key.tablet_id;
     auto is_active_or_hidden =

--- a/src/yb/cdc/cdc_state_table.cc
+++ b/src/yb/cdc/cdc_state_table.cc
@@ -688,6 +688,35 @@ Result<CDCStateTableRange> CDCStateTable::GetTableRange(
   return CDCStateTableRange(VERIFY_RESULT(GetTable()), iteration_status, std::move(columns));
 }
 
+Result<CDCStateTableRange> CDCStateTable::GetTableRange(
+    CDCStateTableEntrySelector&& field_filter, Status* iteration_status,
+    const xrepl::StreamId& stream_id) {
+  std::vector<std::string> columns;
+  columns.emplace_back(kCdcTabletId);
+  columns.emplace_back(kCdcStreamId);
+  MoveCollection(&field_filter.columns_, &columns);
+  VLOG_WITH_FUNC(1) << yb::ToString(columns) << ", stream_id: " << stream_id;
+
+  // The stream_id column stores either "streamId" (non-colocated) or
+  // "streamId_tableId" (colocated). Use a range filter on the stream_id prefix
+  // so both forms are matched: >= "streamId" AND < "streamId~" where '~' (0x7e)
+  // sorts after '_' (0x5f) and any hex chars in table IDs.
+  auto stream_id_str = stream_id.ToString();
+  auto stream_id_upper = stream_id_str + "~";
+  client::TableFilter filter =
+      [stream_id_str, stream_id_upper](
+          const client::TableHandle& table, QLConditionPB* condition) {
+        condition->set_op(QL_OP_AND);
+        table.AddStringCondition(
+            condition, kCdcStreamId, QL_OP_GREATER_THAN_EQUAL, stream_id_str);
+        table.AddStringCondition(
+            condition, kCdcStreamId, QL_OP_LESS_THAN, stream_id_upper);
+      };
+
+  return CDCStateTableRange(
+      VERIFY_RESULT(GetTable()), iteration_status, std::move(columns), std::move(filter));
+}
+
 Result<CDCStateTableRange> CDCStateTable::GetTableRangeAsync(
     CDCStateTableEntrySelector&& field_filter, Status* iteration_status) {
   bool creation_in_progress = false;
@@ -861,9 +890,10 @@ CDCStateTableEntrySelector&& CDCStateTableEntrySelector::IncludeActivePid() {
 
 CDCStateTableRange::CDCStateTableRange(
     const std::shared_ptr<client::TableHandle>& table, Status* failure_status,
-    std::vector<std::string>&& columns)
+    std::vector<std::string>&& columns, client::TableFilter filter)
     : table_(table) {
   options_.columns = std::move(columns);
+  options_.filter = std::move(filter);
 
   options_.error_handler = [failure_status](const Status& status) {
     *failure_status = status.CloneAndPrepend(

--- a/src/yb/cdc/cdc_state_table.h
+++ b/src/yb/cdc/cdc_state_table.h
@@ -166,6 +166,11 @@ class CDCStateTable {
 
   Result<CDCStateTableRange> GetTableRange(
       CDCStateTableEntrySelector&& field_filter, Status* iteration_status) EXCLUDES(mutex_);
+  // Filtered variant that only returns rows matching the given stream_id.
+  // This avoids a full table scan when only a single stream's entries are needed.
+  Result<CDCStateTableRange> GetTableRange(
+      CDCStateTableEntrySelector&& field_filter, Status* iteration_status,
+      const xrepl::StreamId& stream_id) EXCLUDES(mutex_);
   // Returns early if the CDC state table doesn't exist.
   Result<CDCStateTableRange> GetTableRangeAsync(
       CDCStateTableEntrySelector&& field_filter, Status* iteration_status) EXCLUDES(mutex_);
@@ -226,7 +231,8 @@ class CDCStateTableRange {
 
   explicit CDCStateTableRange(
       const std::shared_ptr<client::TableHandle>& table, Status* failure_status,
-      std::vector<std::string>&& columns);
+      std::vector<std::string>&& columns,
+      client::TableFilter filter = {});
 
   const_iterator begin() const { return CdcStateTableIterator(table_.get(), options_); }
   const_iterator end() const { return CdcStateTableIterator(); }


### PR DESCRIPTION
## Problem

GetTabletIdsToPoll() calls cdc_state_table_->GetTableRange() which performs an unfiltered scan of the entire cdc_state table, then filters by stream_id in application code:

 ```cpp
   if (entry.key.stream_id != stream_id) {
       continue;
   }
 ```

On clusters with many CDC streams and tables, the cdc_state table can have tens of thousands of rows. Tserver logs confirm the scale of the problem:

 ```
   I0403 14:41:43.584196 cdc_service.cc:3195] Read 87128 records from cdc_state
 ```

 ```
   W0403 14:48:09.320588 yb_rpc.cc:383] Call yb.cdc.CDCService.GetTabletListToPollForCDC ... took 56875ms
 ```

Every GetTabletListToPollForCDC RPC scans all 87K+ rows to find the handful belonging to the requested stream, resulting in 30-57 second latencies per call.

## Changes

 - CDCStateTable::GetTableRange() — New overload accepts an xrepl::StreamId and constructs a TableFilter that pushes a range condition (>= streamId AND < streamId~) down to the storage layer via TableIteratorOptions::filter. The range handles both non-colocated rows (where the column stores a plain stream UUID) and colocated rows (where it stores streamId_tableId).
 - CDCStateTableRange — Constructor now accepts an optional client::TableFilter, passed through to TableIteratorOptions. Default is empty (no filter), preserving existing behavior for all other callers.
 - CDCServiceImpl::GetTabletIdsToPoll() — Uses the filtered overload and removes the now-redundant in-memory stream_id checks from both iteration loops.

No changes to the unfiltered GetTableRange signature — all other callers (UpdatePeersAndMetrics, etc.) are unaffected