### PR TITLE
[doc] CDC: Add limitation about adding unqualified table to publication

### DIFF
--- a/docs/content/stable/additional-features/change-data-capture/using-logical-replication/_index.md
+++ b/docs/content/stable/additional-features/change-data-capture/using-logical-replication/_index.md
@@ -127,3 +127,5 @@ For reference documentation, see [YugabyteDB Connector](./yugabytedb-connector/)
     To handle updates/deletes with a non-CHANGE replica identity, set the YB-TServer flag `cdc_send_null_before_image_if_not_exists` to true. With this flag enabled, CDC will send a null before-image instead of failing with an error.
 
 - Currently, to use [replication origins](./advanced-topic/#replication-origins), you must create the replication origin before you start streaming changes from a replication slot. Tracked in issue {{<issue 30068>}}.
+
+- Adding an expired or not-of-interest table to a publication renders the replication slot polling this publication unusable. In such a scenario, the slot must be dropped and new slot should be created to proceed. Tracked in issue {{<issue 28310>}}.

--- a/docs/content/stable/additional-features/change-data-capture/using-logical-replication/_index.md
+++ b/docs/content/stable/additional-features/change-data-capture/using-logical-replication/_index.md
@@ -128,4 +128,4 @@ For reference documentation, see [YugabyteDB Connector](./yugabytedb-connector/)
 
 - Currently, to use [replication origins](./advanced-topic/#replication-origins), you must create the replication origin before you start streaming changes from a replication slot. Tracked in issue {{<issue 30068>}}.
 
-- Adding an expired or not-of-interest table to a publication renders the replication slot polling this publication unusable. In such a scenario, the slot must be dropped and new slot should be created to proceed. Tracked in issue {{<issue 28310>}}.
+- Adding an expired or not-of-interest table to a publication renders the replication slot associated with this publication unusable. In such a scenario, the slot must be dropped and a new slot must be created to proceed. Tracked in issue {{<issue 28310>}}.

--- a/docs/content/v2024.1/additional-features/change-data-capture/using-logical-replication/_index.md
+++ b/docs/content/v2024.1/additional-features/change-data-capture/using-logical-replication/_index.md
@@ -116,4 +116,4 @@ For reference documentation, see [YugabyteDB Connector](./yugabytedb-connector/)
 
 - Support for tablet splitting with logical replication is disabled from v2024.1.4 and v2024.2.1. Tracked in issue {{<issue 24918>}}.
 
-- Adding an expired or not-of-interest table to a publication renders the replication slot polling this publication unusable. In such a scenario, the slot must be dropped and new slot should be created to proceed. Tracked in issue {{<issue 28310>}}.
+- Adding an expired or not-of-interest table to a publication renders the replication slot associated with this publication unusable. In such a scenario, the slot must be dropped and a new slot must be created to proceed. Tracked in issue {{<issue 28310>}}.

--- a/docs/content/v2024.1/additional-features/change-data-capture/using-logical-replication/_index.md
+++ b/docs/content/v2024.1/additional-features/change-data-capture/using-logical-replication/_index.md
@@ -115,3 +115,5 @@ For reference documentation, see [YugabyteDB Connector](./yugabytedb-connector/)
 - Support for enabling CDC on Read Replicas is tracked in issue {{<issue 11116>}}.
 
 - Support for tablet splitting with logical replication is disabled from v2024.1.4 and v2024.2.1. Tracked in issue {{<issue 24918>}}.
+
+- Adding an expired or not-of-interest table to a publication renders the replication slot polling this publication unusable. In such a scenario, the slot must be dropped and new slot should be created to proceed. Tracked in issue {{<issue 28310>}}.

--- a/docs/content/v2024.2/additional-features/change-data-capture/using-logical-replication/_index.md
+++ b/docs/content/v2024.2/additional-features/change-data-capture/using-logical-replication/_index.md
@@ -122,6 +122,6 @@ For reference documentation, see [YugabyteDB Connector](./yugabytedb-connector/)
 
     To handle updates/deletes with a non-CHANGE replica identity, set the YB-TServer flag `cdc_send_null_before_image_if_not_exists` to true. With this flag enabled, CDC will send a null before-image instead of failing with an error.
 
-- Adding an expired or not-of-interest table to a publication renders the replication slot polling this publication unusable. In such a scenario, the slot must be dropped and new slot should be created to proceed. Tracked in issue {{<issue 28310>}}.
+- Adding an expired or not-of-interest table to a publication renders the replication slot associated with this publication unusable. In such a scenario, the slot must be dropped and a new slot must be created to proceed. Tracked in issue {{<issue 28310>}}.
 
 

--- a/docs/content/v2024.2/additional-features/change-data-capture/using-logical-replication/_index.md
+++ b/docs/content/v2024.2/additional-features/change-data-capture/using-logical-replication/_index.md
@@ -122,4 +122,6 @@ For reference documentation, see [YugabyteDB Connector](./yugabytedb-connector/)
 
     To handle updates/deletes with a non-CHANGE replica identity, set the YB-TServer flag `cdc_send_null_before_image_if_not_exists` to true. With this flag enabled, CDC will send a null before-image instead of failing with an error.
 
+- Adding an expired or not-of-interest table to a publication renders the replication slot polling this publication unusable. In such a scenario, the slot must be dropped and new slot should be created to proceed. Tracked in issue {{<issue 28310>}}.
+
 

--- a/docs/content/v2025.1/additional-features/change-data-capture/using-logical-replication/_index.md
+++ b/docs/content/v2025.1/additional-features/change-data-capture/using-logical-replication/_index.md
@@ -124,4 +124,4 @@ For reference documentation, see [YugabyteDB Connector](./yugabytedb-connector/)
 
     To handle updates/deletes with a non-CHANGE replica identity, set the YB-TServer flag `cdc_send_null_before_image_if_not_exists` to true. With this flag enabled, CDC will send a null before-image instead of failing with an error.
 
-- Adding an expired or not-of-interest table to a publication renders the replication slot polling this publication unusable. In such a scenario, the slot must be dropped and new slot should be created to proceed. Tracked in issue {{<issue 28310>}}.
+- Adding an expired or not-of-interest table to a publication renders the replication slot associated with this publication unusable. In such a scenario, the slot must be dropped and a new slot must be created to proceed. Tracked in issue {{<issue 28310>}}.

--- a/docs/content/v2025.1/additional-features/change-data-capture/using-logical-replication/_index.md
+++ b/docs/content/v2025.1/additional-features/change-data-capture/using-logical-replication/_index.md
@@ -123,3 +123,5 @@ For reference documentation, see [YugabyteDB Connector](./yugabytedb-connector/)
 - If a row is updated or deleted in the same transaction in which it was inserted, CDC cannot retrieve the before-image values for the UPDATE / DELETE event. If the replica identity is not CHANGE, then CDC will throw an error while processing such events.
 
     To handle updates/deletes with a non-CHANGE replica identity, set the YB-TServer flag `cdc_send_null_before_image_if_not_exists` to true. With this flag enabled, CDC will send a null before-image instead of failing with an error.
+
+- Adding an expired or not-of-interest table to a publication renders the replication slot polling this publication unusable. In such a scenario, the slot must be dropped and new slot should be created to proceed. Tracked in issue {{<issue 28310>}}.


### PR DESCRIPTION
This PR adds a CDC limitation about adding unqualified table to publication in logical replication.