### PR TITLE
[docs]  Update Negative ts_ms from CDC docs

### DIFF
--- a/docs/content/stable/additional-features/change-data-capture/using-yugabytedb-grpc-replication/cdc-get-started.md
+++ b/docs/content/stable/additional-features/change-data-capture/using-yugabytedb-grpc-replication/cdc-get-started.md
@@ -160,7 +160,7 @@ UPDATE customers SET email = 'service@example.com' WHERE id = 1;
       "version": "1.9.5.y.11",
       "connector": "yugabytedb",
       "name": "dbserver1",
-      "ts_ms": -8881476960074,
+      "ts_ms": 1775704408457,
       "snapshot": "false",
       "db": "yugabyte",
       "sequence": "[null,\"1:5::0:0\"]",
@@ -171,7 +171,7 @@ UPDATE customers SET email = 'service@example.com' WHERE id = 1;
       "xmin": null
     },
     "op": "u", --> 4
-    "ts_ms": 1646149134341,
+    "ts_ms": 1775704408463,
     "transaction": null
   }
 }

--- a/docs/content/stable/additional-features/change-data-capture/using-yugabytedb-grpc-replication/debezium-connector-yugabytedb.md
+++ b/docs/content/stable/additional-features/change-data-capture/using-yugabytedb-grpc-replication/debezium-connector-yugabytedb.md
@@ -568,7 +568,7 @@ The following example shows the value portion of a change event that the connect
       "version": "1.9.5.y.11",
       "connector": "yugabytedb",
       "name": "dbserver1",
-      "ts_ms": -8898156066356,
+      "ts_ms": 1775704405230,
       "snapshot": "false",
       "db": "yugabyte",
       "sequence": "[null,\"1:4::0:0\"]",
@@ -579,7 +579,7 @@ The following example shows the value portion of a change event that the connect
       "xmin": null
     },
     "op": "c", --> 7
-    "ts_ms": 1646145062480, --> 8
+    "ts_ms": 1775704405236, --> 8
     "transaction": null
   }
 }
@@ -636,7 +636,7 @@ The update event is as follows:
       "version": "1.9.5.y.11",
       "connector": "yugabytedb",
       "name": "dbserver1",
-      "ts_ms": -8881476960074,
+      "ts_ms": 1775704408457,
       "snapshot": "false",
       "db": "yugabyte",
       "sequence": "[null,\"1:5::0:0\"]",
@@ -647,7 +647,7 @@ The update event is as follows:
       "xmin": null
     },
     "op": "u", --> 4
-    "ts_ms": 1646149134341,
+    "ts_ms": 1775704408463,
     "transaction": null
   }
 }
@@ -694,7 +694,7 @@ DELETE FROM customers WHERE id = 1;
       "version": "1.9.5.y.11",
       "connector": "yugabytedb",
       "name": "dbserver1",
-      "ts_ms": -8876894517738,
+      "ts_ms": 1775704411532,
       "snapshot": "false",
       "db": "yugabyte",
       "sequence": "[null,\"1:6::0:0\"]",
@@ -705,7 +705,7 @@ DELETE FROM customers WHERE id = 1;
       "xmin": null
     },
     "op": "d", --> 3
-    "ts_ms": 1646150253203,
+    "ts_ms": 1775704411538,
     "transaction": null
   }
 }

--- a/docs/content/v2.20/additional-features/change-data-capture/cdc-get-started.md
+++ b/docs/content/v2.20/additional-features/change-data-capture/cdc-get-started.md
@@ -156,7 +156,7 @@ UPDATE customers SET email = 'service@example.com' WHERE id = 1;
       "version": "1.9.5.y.11",
       "connector": "yugabytedb",
       "name": "dbserver1",
-      "ts_ms": -8881476960074,
+      "ts_ms": 1775704408457,
       "snapshot": "false",
       "db": "yugabyte",
       "sequence": "[null,\"1:5::0:0\"]",
@@ -167,7 +167,7 @@ UPDATE customers SET email = 'service@example.com' WHERE id = 1;
       "xmin": null
     },
     "op": "u", --> 4
-    "ts_ms": 1646149134341,
+    "ts_ms": 1775704408463,
     "transaction": null
   }
 }

--- a/docs/content/v2.20/additional-features/change-data-capture/debezium-connector-yugabytedb.md
+++ b/docs/content/v2.20/additional-features/change-data-capture/debezium-connector-yugabytedb.md
@@ -531,7 +531,7 @@ The following example shows the value portion of a change event that the connect
       "version": "1.9.5.y.11",
       "connector": "yugabytedb",
       "name": "dbserver1",
-      "ts_ms": -8898156066356,
+      "ts_ms": 1775704405230,
       "snapshot": "false",
       "db": "yugabyte",
       "sequence": "[null,\"1:4::0:0\"]",
@@ -542,7 +542,7 @@ The following example shows the value portion of a change event that the connect
       "xmin": null
     },
     "op": "c", --> 7
-    "ts_ms": 1646145062480, --> 8
+    "ts_ms": 1775704405236, --> 8
     "transaction": null
   }
 }
@@ -599,7 +599,7 @@ The update event is as follows:
       "version": "1.9.5.y.11",
       "connector": "yugabytedb",
       "name": "dbserver1",
-      "ts_ms": -8881476960074,
+      "ts_ms": 1775704408457,
       "snapshot": "false",
       "db": "yugabyte",
       "sequence": "[null,\"1:5::0:0\"]",
@@ -610,7 +610,7 @@ The update event is as follows:
       "xmin": null
     },
     "op": "u", --> 4
-    "ts_ms": 1646149134341,
+    "ts_ms": 1775704408463,
     "transaction": null
   }
 }
@@ -657,7 +657,7 @@ DELETE FROM customers WHERE id = 1;
       "version": "1.9.5.y.11",
       "connector": "yugabytedb",
       "name": "dbserver1",
-      "ts_ms": -8876894517738,
+      "ts_ms": 1775704411532,
       "snapshot": "false",
       "db": "yugabyte",
       "sequence": "[null,\"1:6::0:0\"]",
@@ -668,7 +668,7 @@ DELETE FROM customers WHERE id = 1;
       "xmin": null
     },
     "op": "d", --> 3
-    "ts_ms": 1646150253203,
+    "ts_ms": 1775704411538,
     "transaction": null
   }
 }

--- a/docs/content/v2.25/additional-features/change-data-capture/using-yugabytedb-grpc-replication/cdc-get-started.md
+++ b/docs/content/v2.25/additional-features/change-data-capture/using-yugabytedb-grpc-replication/cdc-get-started.md
@@ -157,7 +157,7 @@ UPDATE customers SET email = 'service@example.com' WHERE id = 1;
       "version": "1.9.5.y.11",
       "connector": "yugabytedb",
       "name": "dbserver1",
-      "ts_ms": -8881476960074,
+      "ts_ms": 1775704408457,
       "snapshot": "false",
       "db": "yugabyte",
       "sequence": "[null,\"1:5::0:0\"]",
@@ -168,7 +168,7 @@ UPDATE customers SET email = 'service@example.com' WHERE id = 1;
       "xmin": null
     },
     "op": "u", --> 4
-    "ts_ms": 1646149134341,
+    "ts_ms": 1775704408463,
     "transaction": null
   }
 }

--- a/docs/content/v2.25/additional-features/change-data-capture/using-yugabytedb-grpc-replication/debezium-connector-yugabytedb.md
+++ b/docs/content/v2.25/additional-features/change-data-capture/using-yugabytedb-grpc-replication/debezium-connector-yugabytedb.md
@@ -559,7 +559,7 @@ The following example shows the value portion of a change event that the connect
       "version": "1.9.5.y.11",
       "connector": "yugabytedb",
       "name": "dbserver1",
-      "ts_ms": -8898156066356,
+      "ts_ms": 1775704405230,
       "snapshot": "false",
       "db": "yugabyte",
       "sequence": "[null,\"1:4::0:0\"]",
@@ -570,7 +570,7 @@ The following example shows the value portion of a change event that the connect
       "xmin": null
     },
     "op": "c", --> 7
-    "ts_ms": 1646145062480, --> 8
+    "ts_ms": 1775704405236, --> 8
     "transaction": null
   }
 }
@@ -627,7 +627,7 @@ The update event is as follows:
       "version": "1.9.5.y.11",
       "connector": "yugabytedb",
       "name": "dbserver1",
-      "ts_ms": -8881476960074,
+      "ts_ms": 1775704408457,
       "snapshot": "false",
       "db": "yugabyte",
       "sequence": "[null,\"1:5::0:0\"]",
@@ -638,7 +638,7 @@ The update event is as follows:
       "xmin": null
     },
     "op": "u", --> 4
-    "ts_ms": 1646149134341,
+    "ts_ms": 1775704408463,
     "transaction": null
   }
 }
@@ -685,7 +685,7 @@ DELETE FROM customers WHERE id = 1;
       "version": "1.9.5.y.11",
       "connector": "yugabytedb",
       "name": "dbserver1",
-      "ts_ms": -8876894517738,
+      "ts_ms": 1775704411532,
       "snapshot": "false",
       "db": "yugabyte",
       "sequence": "[null,\"1:6::0:0\"]",
@@ -696,7 +696,7 @@ DELETE FROM customers WHERE id = 1;
       "xmin": null
     },
     "op": "d", --> 3
-    "ts_ms": 1646150253203,
+    "ts_ms": 1775704411538,
     "transaction": null
   }
 }

--- a/docs/content/v2024.1/additional-features/change-data-capture/using-yugabytedb-grpc-replication/cdc-get-started.md
+++ b/docs/content/v2024.1/additional-features/change-data-capture/using-yugabytedb-grpc-replication/cdc-get-started.md
@@ -157,7 +157,7 @@ UPDATE customers SET email = 'service@example.com' WHERE id = 1;
       "version": "1.9.5.y.11",
       "connector": "yugabytedb",
       "name": "dbserver1",
-      "ts_ms": -8881476960074,
+      "ts_ms": 1775704408457,
       "snapshot": "false",
       "db": "yugabyte",
       "sequence": "[null,\"1:5::0:0\"]",
@@ -168,7 +168,7 @@ UPDATE customers SET email = 'service@example.com' WHERE id = 1;
       "xmin": null
     },
     "op": "u", --> 4
-    "ts_ms": 1646149134341,
+    "ts_ms": 1775704408463,
     "transaction": null
   }
 }

--- a/docs/content/v2024.1/additional-features/change-data-capture/using-yugabytedb-grpc-replication/debezium-connector-yugabytedb.md
+++ b/docs/content/v2024.1/additional-features/change-data-capture/using-yugabytedb-grpc-replication/debezium-connector-yugabytedb.md
@@ -558,7 +558,7 @@ The following example shows the value portion of a change event that the connect
       "version": "1.9.5.y.11",
       "connector": "yugabytedb",
       "name": "dbserver1",
-      "ts_ms": -8898156066356,
+      "ts_ms": 1775704405230,
       "snapshot": "false",
       "db": "yugabyte",
       "sequence": "[null,\"1:4::0:0\"]",
@@ -569,7 +569,7 @@ The following example shows the value portion of a change event that the connect
       "xmin": null
     },
     "op": "c", --> 7
-    "ts_ms": 1646145062480, --> 8
+    "ts_ms": 1775704405236, --> 8
     "transaction": null
   }
 }
@@ -626,7 +626,7 @@ The update event is as follows:
       "version": "1.9.5.y.11",
       "connector": "yugabytedb",
       "name": "dbserver1",
-      "ts_ms": -8881476960074,
+      "ts_ms": 1775704408457,
       "snapshot": "false",
       "db": "yugabyte",
       "sequence": "[null,\"1:5::0:0\"]",
@@ -637,7 +637,7 @@ The update event is as follows:
       "xmin": null
     },
     "op": "u", --> 4
-    "ts_ms": 1646149134341,
+    "ts_ms": 1775704408463,
     "transaction": null
   }
 }
@@ -684,7 +684,7 @@ DELETE FROM customers WHERE id = 1;
       "version": "1.9.5.y.11",
       "connector": "yugabytedb",
       "name": "dbserver1",
-      "ts_ms": -8876894517738,
+      "ts_ms": 1775704411532,
       "snapshot": "false",
       "db": "yugabyte",
       "sequence": "[null,\"1:6::0:0\"]",
@@ -695,7 +695,7 @@ DELETE FROM customers WHERE id = 1;
       "xmin": null
     },
     "op": "d", --> 3
-    "ts_ms": 1646150253203,
+    "ts_ms": 1775704411538,
     "transaction": null
   }
 }

--- a/docs/content/v2024.2/additional-features/change-data-capture/using-yugabytedb-grpc-replication/cdc-get-started.md
+++ b/docs/content/v2024.2/additional-features/change-data-capture/using-yugabytedb-grpc-replication/cdc-get-started.md
@@ -157,7 +157,7 @@ UPDATE customers SET email = 'service@example.com' WHERE id = 1;
       "version": "1.9.5.y.11",
       "connector": "yugabytedb",
       "name": "dbserver1",
-      "ts_ms": -8881476960074,
+      "ts_ms": 1775704408457,
       "snapshot": "false",
       "db": "yugabyte",
       "sequence": "[null,\"1:5::0:0\"]",
@@ -168,7 +168,7 @@ UPDATE customers SET email = 'service@example.com' WHERE id = 1;
       "xmin": null
     },
     "op": "u", --> 4
-    "ts_ms": 1646149134341,
+    "ts_ms": 1775704408463,
     "transaction": null
   }
 }

--- a/docs/content/v2024.2/additional-features/change-data-capture/using-yugabytedb-grpc-replication/debezium-connector-yugabytedb.md
+++ b/docs/content/v2024.2/additional-features/change-data-capture/using-yugabytedb-grpc-replication/debezium-connector-yugabytedb.md
@@ -559,7 +559,7 @@ The following example shows the value portion of a change event that the connect
       "version": "1.9.5.y.11",
       "connector": "yugabytedb",
       "name": "dbserver1",
-      "ts_ms": -8898156066356,
+      "ts_ms": 1775704405230,
       "snapshot": "false",
       "db": "yugabyte",
       "sequence": "[null,\"1:4::0:0\"]",
@@ -570,7 +570,7 @@ The following example shows the value portion of a change event that the connect
       "xmin": null
     },
     "op": "c", --> 7
-    "ts_ms": 1646145062480, --> 8
+    "ts_ms": 1775704405236, --> 8
     "transaction": null
   }
 }
@@ -627,7 +627,7 @@ The update event is as follows:
       "version": "1.9.5.y.11",
       "connector": "yugabytedb",
       "name": "dbserver1",
-      "ts_ms": -8881476960074,
+      "ts_ms": 1775704408457,
       "snapshot": "false",
       "db": "yugabyte",
       "sequence": "[null,\"1:5::0:0\"]",
@@ -638,7 +638,7 @@ The update event is as follows:
       "xmin": null
     },
     "op": "u", --> 4
-    "ts_ms": 1646149134341,
+    "ts_ms": 1775704408463,
     "transaction": null
   }
 }
@@ -685,7 +685,7 @@ DELETE FROM customers WHERE id = 1;
       "version": "1.9.5.y.11",
       "connector": "yugabytedb",
       "name": "dbserver1",
-      "ts_ms": -8876894517738,
+      "ts_ms": 1775704411532,
       "snapshot": "false",
       "db": "yugabyte",
       "sequence": "[null,\"1:6::0:0\"]",
@@ -696,7 +696,7 @@ DELETE FROM customers WHERE id = 1;
       "xmin": null
     },
     "op": "d", --> 3
-    "ts_ms": 1646150253203,
+    "ts_ms": 1775704411538,
     "transaction": null
   }
 }

--- a/docs/content/v2025.1/additional-features/change-data-capture/using-yugabytedb-grpc-replication/cdc-get-started.md
+++ b/docs/content/v2025.1/additional-features/change-data-capture/using-yugabytedb-grpc-replication/cdc-get-started.md
@@ -157,7 +157,7 @@ UPDATE customers SET email = 'service@example.com' WHERE id = 1;
       "version": "1.9.5.y.11",
       "connector": "yugabytedb",
       "name": "dbserver1",
-      "ts_ms": -8881476960074,
+      "ts_ms": 1775704408457,
       "snapshot": "false",
       "db": "yugabyte",
       "sequence": "[null,\"1:5::0:0\"]",
@@ -168,7 +168,7 @@ UPDATE customers SET email = 'service@example.com' WHERE id = 1;
       "xmin": null
     },
     "op": "u", --> 4
-    "ts_ms": 1646149134341,
+    "ts_ms": 1775704408463,
     "transaction": null
   }
 }

--- a/docs/content/v2025.1/additional-features/change-data-capture/using-yugabytedb-grpc-replication/debezium-connector-yugabytedb.md
+++ b/docs/content/v2025.1/additional-features/change-data-capture/using-yugabytedb-grpc-replication/debezium-connector-yugabytedb.md
@@ -561,7 +561,7 @@ The following example shows the value portion of a change event that the connect
       "version": "1.9.5.y.11",
       "connector": "yugabytedb",
       "name": "dbserver1",
-      "ts_ms": -8898156066356,
+      "ts_ms": 1775704405230,
       "snapshot": "false",
       "db": "yugabyte",
       "sequence": "[null,\"1:4::0:0\"]",
@@ -572,7 +572,7 @@ The following example shows the value portion of a change event that the connect
       "xmin": null
     },
     "op": "c", --> 7
-    "ts_ms": 1646145062480, --> 8
+    "ts_ms": 1775704405236, --> 8
     "transaction": null
   }
 }
@@ -629,7 +629,7 @@ The update event is as follows:
       "version": "1.9.5.y.11",
       "connector": "yugabytedb",
       "name": "dbserver1",
-      "ts_ms": -8881476960074,
+      "ts_ms": 1775704408457,
       "snapshot": "false",
       "db": "yugabyte",
       "sequence": "[null,\"1:5::0:0\"]",
@@ -640,7 +640,7 @@ The update event is as follows:
       "xmin": null
     },
     "op": "u", --> 4
-    "ts_ms": 1646149134341,
+    "ts_ms": 1775704408463,
     "transaction": null
   }
 }
@@ -687,7 +687,7 @@ DELETE FROM customers WHERE id = 1;
       "version": "1.9.5.y.11",
       "connector": "yugabytedb",
       "name": "dbserver1",
-      "ts_ms": -8876894517738,
+      "ts_ms": 1775704411532,
       "snapshot": "false",
       "db": "yugabyte",
       "sequence": "[null,\"1:6::0:0\"]",
@@ -698,7 +698,7 @@ DELETE FROM customers WHERE id = 1;
       "xmin": null
     },
     "op": "d", --> 3
-    "ts_ms": 1646150253203,
+    "ts_ms": 1775704411538,
     "transaction": null
   }
 }


### PR DESCRIPTION
## Summary

The example CDC JSON payloads on the CDC Get Started and Debezium Connector pages contained invalid
negative `ts_ms` values (e.g. `-8881476960074`) in the `source` object. These were artifacts of a
known HybridTime-to-epoch-milliseconds conversion bug in connector version 1.9.5.y.11
(yugabyte/yugabyte-db#18512), which was fixed in
[yugabyte/debezium-connector-yugabytedb#258](https://github.com/yugabyte/debezium-connector-yugabytedb/pull/258).

This PR replaces the garbage negative values with valid epoch millisecond timestamps across all
affected doc versions (stable, v2025.1, v2024.2, v2024.1, v2.25, v2.20).
