### PR TITLE
Fix a spurious wakeup bug in BackendsCatalogVersionJob

### DIFF
--- a/src/yb/master/ysql_backends_manager.cc
+++ b/src/yb/master/ysql_backends_manager.cc
@@ -589,9 +589,7 @@ Result<int> BackendsCatalogVersionJob::WaitAndGetNumLaggingBackends(
   {
     std::lock_guard l(state_mutex_);
     if (!MonitoredTask::IsStateTerminal(state())) {
-      if (state_cv_.WaitUntil(ToSteady(deadline))) {
-        return HandleTerminalState();
-      }
+      state_cv_.WaitUntil(ToSteady(deadline));
     }
   }
   if (IsStateTerminal(state())) {


### PR DESCRIPTION
Fix a spurious wakeup bug in BackendsCatalogVersionJob::WaitAndGetNumLaggingBackends. ConditionVariable::WaitUntil returns true for both genuine signals and spurious wakeups, but the code called HandleTerminalState() on any true return. Then HandleTerminalState DCHECKs that the task state is terminal, so a spurious wakeup with state still kRunning would crash the master process in debug builds. Now we just wait for the deadline.

---

Phorge: [D52148](https://phorge.dev.yugabyte.com/D52148)