### PR TITLE
Update C# smart driver version to 9.0.2.2

### DIFF
--- a/docs/content/stable/develop/drivers-orms/csharp/_index.md
+++ b/docs/content/stable/develop/drivers-orms/csharp/_index.md
@@ -20,7 +20,7 @@ The following projects can be used to implement C# applications using the Yugaby
 
 | Project | Documentation and Guides | Latest Driver Version | Supported YugabyteDB Version |
 | :------ | :----------------------- | :-------------------- | :--------------------------- |
-| YugabyteDB C# Driver for YSQL [Recommended] | [Documentation](ysql/) <br /> [Reference](yb-npgsql-reference/) | [8.0.3-yb-1](https://www.nuget.org/packages/NpgsqlYugabyteDB/) | 2.8 and later |
+| YugabyteDB C# Driver for YSQL [Recommended] | [Documentation](ysql/) <br /> [Reference](yb-npgsql-reference/) | [9.0.2.2](https://www.nuget.org/packages/NpgsqlYugabyteDB/) | 2.8 and later |
 | PostgreSQL Npgsql Driver | [Documentation](postgres-npgsql/) <br /> [Reference](postgres-npgsql-reference/) | [6.0.3](https://www.nuget.org/packages/Npgsql/) | 2.6 and later |
 | YugabyteDB C# Driver for YCQL | [Documentation](ycql/) | [3.6.0](https://github.com/yugabyte/cassandra-csharp-driver/releases/tag/3.6.0) | |
 

--- a/docs/content/stable/develop/drivers-orms/include-drivers-orms-list.md
+++ b/docs/content/stable/develop/drivers-orms/include-drivers-orms-list.md
@@ -108,7 +108,7 @@ block_indexing = true
 |            | Version | Support Level | Example apps |
 | :--------- | :------ | :------------ | :----------- |
 | **Drivers** | | | |
-| YugabyteDB C# Smart Driver for YSQL | [8.0.3-yb-1](https://www.nuget.org/packages/NpgsqlYugabyteDB/) | Full | [CRUD](/stable/develop/drivers-orms/csharp/ysql/) |
+| YugabyteDB C# Smart Driver for YSQL | [9.0.2.2](https://www.nuget.org/packages/NpgsqlYugabyteDB/) | Full | [CRUD](/stable/develop/drivers-orms/csharp/ysql/) |
 | PostgreSQL Npgsql Driver            | [6.0.3](https://www.nuget.org/packages/Npgsql/6.0.3) | Full | [CRUD](/stable/develop/drivers-orms/csharp/postgres-npgsql/) |
 | YugabyteDB C# Driver for YCQL       | [3.6.0](https://github.com/yugabyte/cassandra-csharp-driver/releases/tag/3.6.0) | Full | [CRUD](/stable/develop/drivers-orms/csharp/ycql/) |
 | **ORM** | | | |


### PR DESCRIPTION
## Summary
- Update the YugabyteDB C# Smart Driver (NpgsqlYugabyteDB) version from 8.0.3-yb-1 to 9.0.2.2
- Updated in both `docs/content/stable/develop/drivers-orms/csharp/_index.md` and `docs/content/stable/develop/drivers-orms/include-drivers-orms-list.md`

## Test plan
- [ ] Verify NuGet link resolves correctly for the new version
- [ ] Verify docs render correctly with updated version