### PR TITLE
fix(ysql): suppress spurious checkpointer errors for YB relations without on-disk files

### DIFF
--- a/src/postgres/src/backend/storage/buffer/bufmgr.c
+++ b/src/postgres/src/backend/storage/buffer/bufmgr.c
@@ -2888,6 +2888,27 @@ FlushBuffer(BufferDesc *buf, SMgrRelation reln)
 	if (reln == NULL)
 		reln = smgropen(buf->tag.rnode, InvalidBackendId);
 
+	/*
+	 * YB: YugabyteDB user relations store data in DocDB rather than in
+	 * on-disk heap files.  The checkpointer has no catalog access, so we
+	 * cannot call IsYBRelation() here.  Instead, use smgrexists() (which
+	 * calls mdopenfork with EXTENSION_RETURN_NULL and never errors out) to
+	 * detect whether a physical file is present.  For YB user relations no
+	 * file is ever created, so smgrexists returns false; for PostgreSQL
+	 * system-catalog tables that YugabyteDB still stores on disk it returns
+	 * true and we proceed normally.
+	 *
+	 * When the file is absent we mark the buffer clean and return so that
+	 * the checkpointer does not spam "could not write block N of base/..."
+	 * errors for every dirty buffer belonging to a YB relation.
+	 */
+	if (IsYugaByteEnabled() && !smgrexists(reln, buf->tag.forkNum))
+	{
+		TerminateBufferIO(buf, true, 0);
+		error_context_stack = errcallback.previous;
+		return;
+	}
+
 	TRACE_POSTGRESQL_BUFFER_FLUSH_START(buf->tag.forkNum,
 										buf->tag.blockNum,
 										reln->smgr_rnode.node.spcNode,

--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -962,6 +962,18 @@ GetStatusMsgAndArgumentsByCode(const uint32_t pg_err_code, YbcStatus s,
 			*msg_nargs = 1;
 			*msg_args = (const char **) palloc(sizeof(const char *));
 			(*msg_args)[0] = FetchUniqueConstraintName(YBCStatusRelationOid(s));
+
+			/*
+			 * Include the original DocDB status message as DETAIL for
+			 * PG compatibility. PostgreSQL emits "Key (col)=(val) already
+			 * exists." in the DETAIL field for unique violations.
+			 */
+			if (status_msg && status_msg[0] != '\0')
+			{
+				*detail_buf = status_msg;
+				*detail_nargs = status_nargs;
+				*detail_args = status_args;
+			}
 			break;
 		case ERRCODE_YB_TXN_ABORTED:
 			*msg_buf = "current transaction is expired or aborted";

--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -967,12 +967,17 @@ GetStatusMsgAndArgumentsByCode(const uint32_t pg_err_code, YbcStatus s,
 			 * Include the original DocDB status message as DETAIL for
 			 * PG compatibility. PostgreSQL emits "Key (col)=(val) already
 			 * exists." in the DETAIL field for unique violations.
+			 *
+			 * Use "%s" as the format string rather than passing status_msg
+			 * directly, since it may contain '%' characters (e.g., in
+			 * column names) that would be misinterpreted as format specifiers.
 			 */
 			if (status_msg && status_msg[0] != '\0')
 			{
-				*detail_buf = status_msg;
-				*detail_nargs = status_nargs;
-				*detail_args = status_args;
+				*detail_buf = "%s";
+				*detail_nargs = 1;
+				*detail_args = (const char **) palloc(sizeof(const char *));
+				(*detail_args)[0] = status_msg;
 			}
 			break;
 		case ERRCODE_YB_TXN_ABORTED:


### PR DESCRIPTION
## Summary

Fixes #30973

The PostgreSQL checkpointer iterates all dirty shared buffers and calls `FlushBuffer()` on each one. YugabyteDB user relations store their data in DocDB — no physical `base/NNNN/...` heap file is ever created for them. When the checkpointer attempted to flush such a buffer it called `mdopenfork()` with `EXTENSION_FAIL`, which emitted:

```
ERROR: could not open file "base/13263/16466": No such file or directory
```

followed (on subsequent checkpoints, once `BM_IO_ERROR` was set) by:

```
WARNING: could not write block 0 of base/13263/16466: ...
         Multiple failures --- write error might be permanent.
```

These messages appear at a high rate during normal workloads and flood the server log, obscuring real errors.

## Root Cause

**Call chain:**
```
BufferSync()           [bufmgr.c]
  SyncOneBuffer()      [bufmgr.c]
    FlushBuffer()      [bufmgr.c]
      smgrwrite()      [smgr.c]
        mdwrite()      [md.c]
          _mdfd_getseg()
            mdopenfork(..., EXTENSION_FAIL)   <- error thrown here
```

The checkpointer is an auxiliary process that runs `AuxiliaryProcessMain()` without calling `InitPostgres()`, so the relcache is not initialised. This rules out using `IsYBRelation()` (which calls `RelationIdGetRelation`) as a guard.

## Fix

In `FlushBuffer()`, immediately after resolving the smgr relation and before the expensive flush path, call `smgrexists()`:

```c
if (IsYugaByteEnabled() && !smgrexists(reln, buf->tag.forkNum))
{
    TerminateBufferIO(buf, true, 0);
    error_context_stack = errcallback.previous;
    return;
}
```

**Why this is safe:**
- `IsYugaByteEnabled()` is a simple boolean flag — no catalog access.
- `smgrexists()` → `mdexists()` → `mdopenfork(..., EXTENSION_RETURN_NULL)`: checks file existence by attempting an `open(2)` syscall and returning `NULL` (not throwing) if the file is absent. No catalog access required.
- For YB user relations, no heap file is ever created → `smgrexists` returns `false` → we mark the buffer clean and return.
- PostgreSQL system-catalog tables that YugabyteDB still stores on disk (`pg_class`, `pg_attribute`, `pg_type`, etc.) have their files present → `smgrexists` returns `true` → they continue to be flushed normally.
- Marking the buffer clean with `TerminateBufferIO(buf, true, 0)` is correct: DocDB has already persisted any committed data, so the PostgreSQL dirty-bit is meaningless for durability on YB user relations. It also prevents the checkpointer from retrying the flush on every subsequent checkpoint cycle.

## Files Changed

- `src/postgres/src/backend/storage/buffer/bufmgr.c` — 21 lines added in `FlushBuffer()`, no other files touched.