### PR TITLE
Fix 'occured' -> 'occurred' typos in TabletSplit status and yba-cli REST errors

### DIFF
--- a/managed/yba-cli/internal/client/rest.go
+++ b/managed/yba-cli/internal/client/rest.go
@@ -46,7 +46,7 @@ func (a *AuthAPIClient) RestAPICall(
 	r, err := a.RestClient.Client.Do(req)
 	if err != nil {
 		return nil,
-			fmt.Errorf("Error occured during %s call for %s %s",
+			fmt.Errorf("Error occurred during %s call for %s %s",
 				params.method,
 				params.operationString,
 				err.Error())
@@ -88,7 +88,7 @@ func (a *AuthAPIClient) RestAPICallV1Path(
 
 	r, err := a.RestClient.Client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("Error occured during %s call for %s %s",
+		return nil, fmt.Errorf("Error occurred during %s call for %s %s",
 			params.method, params.operationString, err.Error())
 	}
 

--- a/src/yb/util/status_codes.h
+++ b/src/yb/util/status_codes.h
@@ -46,7 +46,7 @@ YB_STATUS_CODE(Combined, COMBINED_ERROR, 29,
                "Combined status representing multiple status failures")
 YB_STATUS_CODE(SnapshotTooOld, SNAPSHOT_TOO_OLD, 30, "Snapshot too old")
 YB_STATUS_CODE(CacheMissError, CACHE_MISS_ERROR, 32, "Cache miss error")
-YB_STATUS_CODE(TabletSplit, TABLET_SPLIT, 33, "Tablet split has occured")
+YB_STATUS_CODE(TabletSplit, TABLET_SPLIT, 33, "Tablet split has occurred")
 YB_STATUS_CODE(ReplicationSlotLimitReached, REPLICATION_SLOT_LIMIT_REACHED, 34,
                "Replication slot limit reached")
 YB_STATUS_CODE(Deleted, DELETED, 35, "Deleted")


### PR DESCRIPTION
Two unrelated `occured` fixes in user-visible strings:

- `src/yb/util/status_codes.h:49` — `TabletSplit` `YB_STATUS_CODE` message `Tablet split has occured`. Surfaced to clients as the `Status` error text whenever a TabletSplit status is returned.
- `managed/yba-cli/internal/client/rest.go` (lines 49 and 91) — two `fmt.Errorf` messages `Error occured during %s call for %s %s`. User-visible in yba CLI error output.

String-literal-only changes.