### PR TITLE
[#30991] DocDB: Change log level from FATAL to WARNING in ReadFromLogCache

### DIFF
--- a/src/yb/consensus/consensus_queue.cc
+++ b/src/yb/consensus/consensus_queue.cc
@@ -726,7 +726,7 @@ Result<ReadOpsResult> PeerMessageQueue::ReadFromLogCache(
           << ". Destination peer: " << peer_uuid;
       return s;
     } else {
-      LOG_WITH_PREFIX(FATAL)
+      LOG_WITH_PREFIX(WARNING)
           << "Error reading the log while preparing peer request or GetChanges response: "
           << s.ToString() << ". Destination peer: " << peer_uuid;
       return s;


### PR DESCRIPTION
## Summary
Changed the log level for an error condition in the consensus queue's log reading logic from FATAL to WARNING, allowing the system to continue operating when encountering errors while preparing peer requests or GetChanges responses. This can happen during a race between a tablet being shutdown and a xCluster/CDC GetChanges call is coming in.

## Key Changes
- Modified error handling in `PeerMessageQueue::ReadFromLogCache()` to log errors as WARNING instead of FATAL
- This prevents the process from terminating immediately when log read errors occur during peer communication preparation
- The error is still returned to the caller for appropriate handling at a higher level

https://claude.ai/code/session_01F1zGJsqpM42tNvfZ1gDKCx

Fixes #30991

---

Phorge: [D52146](https://phorge.dev.yugabyte.com/D52146)