### PR TITLE
[#30946] YSQL: Support traceparent comment anywhere in query

### DIFF
--- a/src/postgres/src/backend/tcop/postgres.c
+++ b/src/postgres/src/backend/tcop/postgres.c
@@ -7859,39 +7859,57 @@ disable_statement_timeout(void)
 }
 
 /*
- * Extract trace parent from a leading SQL comment in a query.
+ * Extract trace parent from any block comment in a query.
  *
  * traceparent_out must point to a buffer of at least
  * YB_TRACEPARENT_VALUE_LEN + 1 bytes.
  *
- * The traceparent must appear in a comment at the start of the query:
+ * The traceparent may appear in any block comment anywhere in the query:
+ * If multiple block comments contain a traceparent, the first one is returned.
+ *
  * "/\*traceparent='00-00000000000000000000000000000009-0000000000000005-01'*\/ SELECT 1;"
+ * "SELECT 1 /\*traceparent='00-00000000000000000000000000000009-0000000000000005-01'*\/;"
+
  */
 static YbTraceparentResult
 YbExtractTraceParentFromComment(const char *query, char *traceparent_out)
 {
 	const char *pos = query;
-	const char *comment_end;
 
-	/* Skip leading whitespace. */
-	while (isspace((unsigned char) *pos))
-		pos++;
+	while (*pos != '\0')
+	{
+		const char *comment_start;
+		const char *content;
+		const char *comment_end;
+		YbTraceparentResult result;
 
-	if (pos[0] != '/' || pos[1] != '*')
-		return YB_TRACEPARENT_NO_COMMENT;
+		/* Find the next block comment start. */
+		comment_start = strstr(pos, "/*");
+		if (!comment_start)
+			break;
 
-	/* Skip the comment start delimiters "/ *". */
-	pos += YB_TRACEPARENT_COMMENT_DELIMITERS_LEN;
+		content = comment_start + YB_TRACEPARENT_COMMENT_DELIMITERS_LEN;
 
-	/*
-	 * Find the comment end delimiters "* /".
-	 * This is required as without this we can match a YB_TRACEPARENT_KEY_PREFIX
-	 * after the comment end delimiters.
-	 */
-	comment_end = strstr(pos, "*/");
-	Assert(comment_end);
+		/* Find the matching comment end. */
+		comment_end = strstr(content, "*/");
+		if (!comment_end)
+			break; /* Unterminated comment, let the main query parser to deal with it. */
 
-	return YbGetTraceparentFromTraceContext(pos, comment_end - pos, traceparent_out);
+		result = YbGetTraceparentFromTraceContext(content, comment_end - content,
+												  traceparent_out);
+
+		/*
+		 * this comment block contained no traceparent; 
+         * continue scanning remaining comments.
+		 */
+		if (result != YB_TRACEPARENT_NO_FIELD)
+			return result;
+
+		/* Advance past the closing "* /" of this comment. */
+		pos = comment_end + YB_TRACEPARENT_COMMENT_DELIMITERS_LEN;
+	}
+
+	return YB_TRACEPARENT_NO_COMMENT;
 }
 
 /*

--- a/src/yb/yql/pgwrapper/dist_trace-test.cc
+++ b/src/yb/yql/pgwrapper/dist_trace-test.cc
@@ -599,6 +599,46 @@ TEST_F(DistTraceTest, TestFailedGucSetKeepsPreviousValue) {
   ASSERT_OK(VerifySpans(expected));
 }
 
+TEST_F(DistTraceTest, TestTraceparentCommentAppended) {
+  std::vector<OtlpHttpCollector::SpanRecord> expected;
+
+  // Traceparent comment appended after the query body.
+  {
+    auto tp = GenerateTraceparent();
+    auto query = Format("SELECT 1 /*traceparent='$0'*/", tp.full);
+    ASSERT_OK(conn_->Fetch(query));
+    expected.push_back(MakeExpected(query, tp.trace_id));
+  }
+
+  // Traceparent comment embedded between SQL tokens.
+  {
+    auto tp = GenerateTraceparent();
+    auto query = Format("SELECT /*traceparent='$0'*/ 2", tp.full);
+    ASSERT_OK(conn_->Fetch(query));
+    expected.push_back(MakeExpected(query, tp.trace_id));
+  }
+
+  // Non-traceparent leading comment followed by a trailing traceparent comment.
+  {
+    auto tp = GenerateTraceparent();
+    auto query = Format("/* regular comment */ SELECT 3 /*traceparent='$0'*/", tp.full);
+    ASSERT_OK(conn_->Fetch(query));
+    expected.push_back(MakeExpected(query, tp.trace_id));
+  }
+
+  // When multiple comments contain traceparent, the first one wins.
+  {
+    auto tp1 = GenerateTraceparent();
+    auto tp2 = GenerateTraceparent();
+    auto query = Format(
+        "/*traceparent='$0'*/ SELECT /*traceparent='$1'*/ 4", tp1.full, tp2.full);
+    ASSERT_OK(conn_->Fetch(query));
+    expected.push_back(MakeExpected(query, tp1.trace_id));
+  }
+
+  ASSERT_OK(VerifySpans(expected));
+}
+
 TEST_F(DistTraceDisabledTest, TestTraceparentWhenDistTraceDisabled) {
   auto tp = GenerateTraceparent();
 


### PR DESCRIPTION
Currently, OpenTelemetry tracing via SQL comment (/*traceparent='...'*/) only works when the comment appears at the very start of the query. This change scans all comment blocks in the query, so trailing and mid-query comments should work equally well. 
The first comment containing a valid traceparent field wins. Also adds TestTraceparentCommentAppended unit test for various cases.