### PR TITLE
[#30945] DistributedTracing: Add OpenTelemetry tracing to the SPI path

### DIFF
--- a/src/postgres/src/backend/executor/spi.c
+++ b/src/postgres/src/backend/executor/spi.c
@@ -37,6 +37,7 @@
 
 /* YB includes */
 #include "pg_yb_utils.h"
+#include "yb/yql/pggate/ybc_dist_trace.h"
 
 
 /*
@@ -2255,7 +2256,9 @@ _SPI_prepare_plan(const char *src, SPIPlanPtr plan)
 	/*
 	 * Parse the request string into a list of raw parse trees.
 	 */
+	YB_DIST_TRACE_START_SPAN("parse");
 	raw_parsetree_list = raw_parser(src, plan->parse_mode);
+	YB_DIST_TRACE_END_SPAN();
 
 	/*
 	 * Do parse analysis and rule rewrite for each raw parsetree, storing the
@@ -2363,7 +2366,9 @@ _SPI_prepare_oneshot_plan(const char *src, SPIPlanPtr plan)
 	/*
 	 * Parse the request string into a list of raw parse trees.
 	 */
+	YB_DIST_TRACE_START_SPAN("parse");
 	raw_parsetree_list = raw_parser(src, plan->parse_mode);
+	YB_DIST_TRACE_END_SPAN();
 
 	/*
 	 * Construct plancache entries, but don't do parse analysis yet.
@@ -2446,6 +2451,8 @@ _SPI_execute_plan(SPIPlanPtr plan, const SPIExecuteOptions *options,
 	spierrcontext.arg = &spicallbackarg;
 	spierrcontext.previous = error_context_stack;
 	error_context_stack = &spierrcontext;
+
+	YB_DIST_TRACE_START_SPAN("spi.query");
 
 	/*
 	 * We support four distinct snapshot management behaviors:
@@ -2599,8 +2606,10 @@ _SPI_execute_plan(SPIPlanPtr plan, const SPIExecuteOptions *options,
 		 * Replan if needed, and increment plan refcount.  If it's a saved
 		 * plan, the refcount must be backed by the plan_owner.
 		 */
+		YB_DIST_TRACE_START_SPAN("plan");
 		cplan = GetCachedPlan(plansource, options->params,
 							  plan_owner, _SPI_current->queryEnv);
+		YB_DIST_TRACE_END_SPAN();
 
 		stmt_list = cplan->stmt_list;
 
@@ -2848,6 +2857,9 @@ _SPI_execute_plan(SPIPlanPtr plan, const SPIExecuteOptions *options,
 
 fail:
 
+	/* end of the spi.query span */
+	YB_DIST_TRACE_END_SPAN();
+
 	/* Pop the snapshot off the stack if we pushed one */
 	if (pushed_active_snap)
 		PopActiveSnapshot();
@@ -2961,6 +2973,8 @@ _SPI_pquery(QueryDesc *queryDesc, bool fire_triggers, uint64 tcount)
 	else
 		eflags = EXEC_FLAG_SKIP_TRIGGERS;
 
+	YB_DIST_TRACE_START_SPAN("execute");
+
 	ExecutorStart(queryDesc, eflags);
 
 	ExecutorRun(queryDesc, ForwardScanDirection, tcount, true);
@@ -2976,6 +2990,9 @@ _SPI_pquery(QueryDesc *queryDesc, bool fire_triggers, uint64 tcount)
 
 	ExecutorFinish(queryDesc);
 	ExecutorEnd(queryDesc);
+
+	/* end of the execute span */
+	YB_DIST_TRACE_END_SPAN();
 	/* FreeQueryDesc is done by the caller */
 
 #ifdef SPI_EXECUTOR_STATS

--- a/src/postgres/src/backend/executor/spi.c
+++ b/src/postgres/src/backend/executor/spi.c
@@ -37,7 +37,19 @@
 
 /* YB includes */
 #include "pg_yb_utils.h"
+#include "yb/yql/pggate/ybc_dist_trace.h"
 
+#define YB_SPI_DIST_TRACE_START_SPAN(op_name) \
+	do { \
+		if (yb_enable_spi_dist_tracing) \
+			YB_DIST_TRACE_START_SPAN(op_name); \
+	} while (0)
+
+#define YB_SPI_DIST_TRACE_END_SPAN() \
+	do { \
+		if (yb_enable_spi_dist_tracing) \
+			YB_DIST_TRACE_END_SPAN(); \
+	} while (0)
 
 /*
  * These global variables are part of the API for various SPI functions
@@ -2255,7 +2267,9 @@ _SPI_prepare_plan(const char *src, SPIPlanPtr plan)
 	/*
 	 * Parse the request string into a list of raw parse trees.
 	 */
+	YB_SPI_DIST_TRACE_START_SPAN("parse");
 	raw_parsetree_list = raw_parser(src, plan->parse_mode);
+	YB_SPI_DIST_TRACE_END_SPAN();
 
 	/*
 	 * Do parse analysis and rule rewrite for each raw parsetree, storing the
@@ -2363,7 +2377,9 @@ _SPI_prepare_oneshot_plan(const char *src, SPIPlanPtr plan)
 	/*
 	 * Parse the request string into a list of raw parse trees.
 	 */
+	YB_SPI_DIST_TRACE_START_SPAN("parse");
 	raw_parsetree_list = raw_parser(src, plan->parse_mode);
+	YB_SPI_DIST_TRACE_END_SPAN();
 
 	/*
 	 * Construct plancache entries, but don't do parse analysis yet.
@@ -2446,6 +2462,8 @@ _SPI_execute_plan(SPIPlanPtr plan, const SPIExecuteOptions *options,
 	spierrcontext.arg = &spicallbackarg;
 	spierrcontext.previous = error_context_stack;
 	error_context_stack = &spierrcontext;
+
+	YB_SPI_DIST_TRACE_START_SPAN("spi.query");
 
 	/*
 	 * We support four distinct snapshot management behaviors:
@@ -2599,8 +2617,10 @@ _SPI_execute_plan(SPIPlanPtr plan, const SPIExecuteOptions *options,
 		 * Replan if needed, and increment plan refcount.  If it's a saved
 		 * plan, the refcount must be backed by the plan_owner.
 		 */
+		YB_SPI_DIST_TRACE_START_SPAN("get_cached_plan");
 		cplan = GetCachedPlan(plansource, options->params,
 							  plan_owner, _SPI_current->queryEnv);
+		YB_SPI_DIST_TRACE_END_SPAN();
 
 		stmt_list = cplan->stmt_list;
 
@@ -2848,6 +2868,9 @@ _SPI_execute_plan(SPIPlanPtr plan, const SPIExecuteOptions *options,
 
 fail:
 
+	/* YB: end of the spi.query span */
+	YB_SPI_DIST_TRACE_END_SPAN();
+
 	/* Pop the snapshot off the stack if we pushed one */
 	if (pushed_active_snap)
 		PopActiveSnapshot();
@@ -2961,6 +2984,8 @@ _SPI_pquery(QueryDesc *queryDesc, bool fire_triggers, uint64 tcount)
 	else
 		eflags = EXEC_FLAG_SKIP_TRIGGERS;
 
+	YB_SPI_DIST_TRACE_START_SPAN("execute");
+
 	ExecutorStart(queryDesc, eflags);
 
 	ExecutorRun(queryDesc, ForwardScanDirection, tcount, true);
@@ -2976,6 +3001,10 @@ _SPI_pquery(QueryDesc *queryDesc, bool fire_triggers, uint64 tcount)
 
 	ExecutorFinish(queryDesc);
 	ExecutorEnd(queryDesc);
+
+	/* YB: end of the execute span */
+	YB_SPI_DIST_TRACE_END_SPAN();
+
 	/* FreeQueryDesc is done by the caller */
 
 #ifdef SPI_EXECUTOR_STATS

--- a/src/postgres/src/backend/utils/misc/guc.c
+++ b/src/postgres/src/backend/utils/misc/guc.c
@@ -2498,6 +2498,17 @@ static struct config_bool ConfigureNamesBool[] =
 	},
 
 	{
+		{"yb_enable_spi_dist_tracing", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Enables distributed tracing for SPI (Server Programming Interface) calls."),
+			NULL,
+			GUC_NOT_IN_SAMPLE
+		},
+		&yb_enable_spi_dist_tracing,
+		true,
+		NULL, NULL, NULL
+	},
+
+	{
 		{"yb_silence_advisory_locks_not_supported_error", PGC_USERSET, LOCK_MANAGEMENT,
 			gettext_noop("Deprecated. This is no-op."),
 			NULL,

--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -355,6 +355,7 @@ int			ybc_disable_pg_locking = -1;
 static void YBCInstallTxnDdlHook();
 
 bool		yb_enable_docdb_tracing = false;
+bool		yb_enable_spi_dist_tracing = true;
 bool		yb_read_from_followers = false;
 bool		yb_follower_reads_behavior_before_fixing_20482 = false;
 int32_t		yb_follower_read_staleness_ms = 0;

--- a/src/postgres/src/include/pg_yb_utils.h
+++ b/src/postgres/src/include/pg_yb_utils.h
@@ -144,6 +144,8 @@ extern YbGeolocationDistance get_geolocation_distance(Oid tablespaceoid);
 extern bool IsYugaByteEnabled();
 
 extern bool yb_enable_docdb_tracing;
+extern bool yb_enable_spi_dist_tracing;
+
 extern bool yb_read_from_followers;
 extern bool yb_follower_reads_behavior_before_fixing_20482;
 extern int32_t yb_follower_read_staleness_ms;

--- a/src/yb/yql/pgwrapper/dist_trace-test.cc
+++ b/src/yb/yql/pgwrapper/dist_trace-test.cc
@@ -313,6 +313,24 @@ class OtlpHttpCollector {
     return Status::OK();
   }
 
+  // Waits until the trace contains at least expected_count spans with the given op name.
+  Status VerifySpanCountInTrace(
+      std::string_view trace_id, std::string_view span_op_name, size_t expected_count) const
+      EXCLUDES(mutex_) {
+    return WaitFor(
+        [this, trace_id, span_op_name, expected_count]() -> Result<bool> {
+          std::lock_guard lock(mutex_);
+          auto it = traces_.find(std::string(trace_id));
+          if (it == traces_.end()) return false;
+          auto count = std::count_if(
+              it->second.spans.begin(), it->second.spans.end(),
+              [span_op_name](const Span& s) { return s.op_name == span_op_name; });
+          return static_cast<size_t>(count) >= expected_count;
+        },
+        kOtelBatchScheduleDelayMs * kTimeMultiplier * 30ms,
+        Format("$0 '$1' span(s) in trace '$2'", expected_count, span_op_name, trace_id));
+  }
+
  private:
   void HandleTraceRequest(const Webserver::WebRequest& req, Webserver::WebResponse* resp) {
     if (req.request_method != "POST") {
@@ -585,6 +603,10 @@ class DistTraceTest : public LibPqTestBase {
 
     RETURN_NOT_OK(conn_->Execute("RESET yb_dist_tracecontext"));
     return Status::OK();
+  }
+
+  Status VerifySpiSpanCount(const std::string& trace_id, size_t expected_count) {
+    return collector_.VerifySpanCountInTrace(trace_id, "spi.query", expected_count);
   }
 
   std::vector<std::string>& CaptureWarnings() {
@@ -1105,6 +1127,78 @@ TEST_F(DistTraceTest, TestExtendedQueryProtocolGuc) {
            {SpanType::kExtSync, 1},
            {SpanType::kCommit, 1}}),
   }));
+}
+
+// --- SPI tracing tests ---
+// Verifies that SQL executed via the Server Programming Interface (SPI) - the
+// internal API used by PL/pgSQL functions and triggers - produces "spi.query"
+// child spans when distributed tracing is active.
+
+// Basic check: a PL/pgSQL function with a single SPI query produces one
+// "spi.query" span under the root trace.
+TEST_F(DistTraceTest, TestSpiTracingBasic) {
+  ASSERT_OK(conn_->Execute(
+      "CREATE OR REPLACE FUNCTION yb_spi_trace_basic() RETURNS integer AS $$"
+      " DECLARE v integer;"
+      " BEGIN"
+      "   SELECT 1 INTO v;"
+      "   RETURN v;"
+      " END;"
+      " $$ LANGUAGE plpgsql"));
+
+  auto tp = GenerateTraceparent();
+  ASSERT_OK(conn_->ExecuteFormat("SET yb_dist_tracecontext = 'traceparent=''$0'''", tp.full));
+  ASSERT_OK(conn_->Fetch("SELECT yb_spi_trace_basic()"));
+
+  ASSERT_OK(collector_.VerifyTraceContainsOpName(tp.trace_id, "spi.query"));
+}
+
+// Verifies that a function making N SPI calls produces at least N "spi.query" spans.
+TEST_F(DistTraceTest, TestSpiTracingMultipleQueriesProduceMultipleSpans) {
+  ASSERT_OK(conn_->Execute(
+      "CREATE OR REPLACE FUNCTION yb_spi_trace_multi() RETURNS void AS $$"
+      " DECLARE v integer;"
+      " BEGIN"
+      "   SELECT 1 INTO v;"
+      "   SELECT 2 INTO v;"
+      "   SELECT 3 INTO v;"
+      " END;"
+      " $$ LANGUAGE plpgsql"));
+
+  auto tp = GenerateTraceparent();
+  ASSERT_OK(conn_->ExecuteFormat("SET yb_dist_tracecontext = 'traceparent=''$0'''", tp.full));
+  ASSERT_OK(conn_->Fetch("SELECT yb_spi_trace_multi()"));
+
+  ASSERT_OK(VerifySpiSpanCount(tp.trace_id, 3));
+}
+
+// Verifies that nested PL/pgSQL functions each produce "spi.query" spans,
+// all under the same root trace.
+TEST_F(DistTraceTest, TestSpiTracingNestedFunctions) {
+  ASSERT_OK(conn_->Execute(
+      "CREATE OR REPLACE FUNCTION yb_spi_trace_inner() RETURNS integer AS $$"
+      " DECLARE v integer;"
+      " BEGIN"
+      "   SELECT 42 INTO v;"
+      "   RETURN v;"
+      " END;"
+      " $$ LANGUAGE plpgsql"));
+  ASSERT_OK(conn_->Execute(
+      "CREATE OR REPLACE FUNCTION yb_spi_trace_outer() RETURNS integer AS $$"
+      " DECLARE v integer;"
+      " BEGIN"
+      "   SELECT yb_spi_trace_inner() INTO v;"
+      "   RETURN v;"
+      " END;"
+      " $$ LANGUAGE plpgsql"));
+
+  auto tp = GenerateTraceparent();
+  ASSERT_OK(conn_->ExecuteFormat("SET yb_dist_tracecontext = 'traceparent=''$0'''", tp.full));
+  ASSERT_OK(conn_->Fetch("SELECT yb_spi_trace_outer()"));
+
+  // Outer function: 1 spi.query for "SELECT yb_spi_trace_inner() INTO v"
+  // Inner function: 1 spi.query for "SELECT 42 INTO v"
+  ASSERT_OK(VerifySpiSpanCount(tp.trace_id, 2));
 }
 
 }  // namespace yb::pgwrapper

--- a/src/yb/yql/pgwrapper/dist_trace-test.cc
+++ b/src/yb/yql/pgwrapper/dist_trace-test.cc
@@ -432,6 +432,57 @@ class OtlpHttpCollector {
     return Status::OK();
   }
 
+  // Waits until the trace contains at least expected_count spans with the given op name.
+  Status VerifySpanCountInTrace(
+      std::string_view trace_id, std::string_view span_op_name, size_t expected_count) const
+      EXCLUDES(mutex_) {
+    return WaitFor(
+        [this, trace_id, span_op_name, expected_count]() -> Result<bool> {
+          std::lock_guard lock(mutex_);
+          auto it = traces_.find(std::string(trace_id));
+          if (it == traces_.end()) return false;
+          auto count = std::count_if(
+              it->second.spans.begin(), it->second.spans.end(),
+              [span_op_name](const Span& s) { return s.op_name == span_op_name; });
+          return static_cast<size_t>(count) >= expected_count;
+        },
+        kOtelBatchScheduleDelayMs * kTimeMultiplier * 30ms,
+        Format("$0 '$1' span(s) in trace '$2'", expected_count, span_op_name, trace_id));
+  }
+
+  // Waits until each name in child_op_names has a span whose parent_span_id
+  // matches the span_id of the first span named parent_op_name.
+  Status VerifyChildSpansOf(
+      std::string_view trace_id,
+      std::string_view parent_op_name,
+      const std::vector<std::string>& child_op_names) const EXCLUDES(mutex_) {
+    return WaitFor(
+        [this, trace_id, parent_op_name, &child_op_names]() -> Result<bool> {
+          std::lock_guard lock(mutex_);
+          auto it = traces_.find(std::string(trace_id));
+          if (it == traces_.end()) return false;
+          const auto& spans = it->second.spans;
+
+          auto parent_it = std::find_if(
+              spans.begin(), spans.end(),
+              [parent_op_name](const Span& s) { return s.op_name == parent_op_name; });
+          if (parent_it == spans.end()) return false;
+
+          const auto& parent_id = parent_it->span_id;
+          for (const auto& child_name : child_op_names) {
+            auto found = std::any_of(
+                spans.begin(), spans.end(),
+                [&parent_id, &child_name](const Span& s) {
+                  return s.op_name == child_name && s.parent_span_id == parent_id;
+                });
+            if (!found) return false;
+          }
+          return true;
+        },
+        kOtelBatchScheduleDelayMs * kTimeMultiplier * 30ms,
+        Format("Child spans of '$0' in trace '$1'", parent_op_name, trace_id));
+  }
+
  private:
   void HandleTraceRequest(const Webserver::WebRequest& req, Webserver::WebResponse* resp) {
     if (req.request_method != "POST") {
@@ -728,6 +779,18 @@ class DistTraceTest : public LibPqTestBase {
     return Status::OK();
   }
 
+  Status VerifySpiSpanCount(const std::string& trace_id, size_t expected_count) {
+    return collector_.VerifySpanCountInTrace(trace_id, "spi.query", expected_count);
+  }
+
+  // Verifies that get_cached_plan and execute are child spans of spi.query.
+  // Note: parse is emitted before spi.query starts (at function compile time),
+  // so it is a sibling of spi.query, not a child.
+  Status VerifySpiQueryChildSpans(const std::string& trace_id) {
+    return collector_.VerifyChildSpansOf(
+        trace_id, "spi.query", {"get_cached_plan", "execute"});
+  }
+
   Result<Span> WaitForSpanWithTableName(
       const std::string& trace_id, std::string_view span_name_prefix,
       std::string_view table_name) const {
@@ -807,6 +870,8 @@ class DistTraceRpcTimeoutTest : public DistTraceRpcTest {
 TEST_F(DistTraceTest, TestTraceparentComment) {
   std::vector<Trace> expected_query_traces;
 
+  ASSERT_OK(conn_->Execute("SET yb_enable_spi_dist_tracing = false"));
+
   for (const auto& [mode, is_utility, query, expected_spans] : GetTestQueries("test_comment")) {
     auto tp = GenerateTraceparent();
     auto traced_query = Format("/*traceparent='$0'*/ $1;", tp.full, query);
@@ -819,6 +884,8 @@ TEST_F(DistTraceTest, TestTraceparentComment) {
 }
 
 TEST_F(DistTraceTest, TestTraceparentGuc) {
+  ASSERT_OK(conn_->Execute("SET yb_enable_spi_dist_tracing = false"));
+
   for (const auto& [mode, is_utility, query, expected_spans] : GetTestQueries("test_guc")) {
     auto tp = GenerateTraceparent();
     ASSERT_OK(conn_->ExecuteFormat("SET yb_dist_tracecontext = 'traceparent=''$0'''", tp.full));
@@ -1380,6 +1447,146 @@ TEST_F(DistTraceTest, TestExtendedQueryProtocolGuc) {
            {SpanType::kExtSync, 1},
            {SpanType::kCommit, 1}}),
   }));
+}
+
+// --- SPI tracing tests ---
+// Verifies that SQL executed via the Server Programming Interface (SPI) - the
+// internal API used by PL/pgSQL functions and triggers - produces "spi.query"
+// child spans when distributed tracing is active.
+
+// Basic check: a PL/pgSQL function with a single SPI query produces one
+// "spi.query" span under the root trace.
+TEST_F(DistTraceTest, TestSpiTracingBasic) {
+  ASSERT_OK(conn_->Execute(
+      "CREATE OR REPLACE FUNCTION yb_spi_trace_basic() RETURNS integer AS $$"
+      " DECLARE v integer;"
+      " BEGIN"
+      "   SELECT 1 INTO v;"
+      "   RETURN v;"
+      " END;"
+      " $$ LANGUAGE plpgsql"));
+
+  auto tp = GenerateTraceparent();
+  ASSERT_OK(conn_->ExecuteFormat("SET yb_dist_tracecontext = 'traceparent=''$0'''", tp.full));
+  ASSERT_OK(conn_->Fetch("SELECT yb_spi_trace_basic()"));
+
+  ASSERT_OK(collector_.VerifyTraceContainsOpName(tp.trace_id, "spi.query"));
+}
+
+// Verifies that a function making N SPI calls produces at least N "spi.query" spans.
+TEST_F(DistTraceTest, TestSpiTracingMultipleQueriesProduceMultipleSpans) {
+  ASSERT_OK(conn_->Execute(
+      "CREATE OR REPLACE FUNCTION yb_spi_trace_multi() RETURNS void AS $$"
+      " DECLARE v integer;"
+      " BEGIN"
+      "   SELECT 1 INTO v;"
+      "   SELECT 2 INTO v;"
+      "   SELECT 3 INTO v;"
+      " END;"
+      " $$ LANGUAGE plpgsql"));
+
+  auto tp = GenerateTraceparent();
+  ASSERT_OK(conn_->ExecuteFormat("SET yb_dist_tracecontext = 'traceparent=''$0'''", tp.full));
+  ASSERT_OK(conn_->Fetch("SELECT yb_spi_trace_multi()"));
+
+  ASSERT_OK(VerifySpiSpanCount(tp.trace_id, 3));
+}
+
+// Verifies that nested PL/pgSQL functions each produce "spi.query" spans,
+// all under the same root trace.
+TEST_F(DistTraceTest, TestSpiTracingNestedFunctions) {
+  ASSERT_OK(conn_->Execute(
+      "CREATE OR REPLACE FUNCTION yb_spi_trace_inner() RETURNS integer AS $$"
+      " DECLARE v integer;"
+      " BEGIN"
+      "   SELECT 42 INTO v;"
+      "   RETURN v;"
+      " END;"
+      " $$ LANGUAGE plpgsql"));
+  ASSERT_OK(conn_->Execute(
+      "CREATE OR REPLACE FUNCTION yb_spi_trace_outer() RETURNS integer AS $$"
+      " DECLARE v integer;"
+      " BEGIN"
+      "   SELECT yb_spi_trace_inner() INTO v;"
+      "   RETURN v;"
+      " END;"
+      " $$ LANGUAGE plpgsql"));
+
+  auto tp = GenerateTraceparent();
+  ASSERT_OK(conn_->ExecuteFormat("SET yb_dist_tracecontext = 'traceparent=''$0'''", tp.full));
+  ASSERT_OK(conn_->Fetch("SELECT yb_spi_trace_outer()"));
+
+  // Outer function: 1 spi.query for "SELECT yb_spi_trace_inner() INTO v"
+  // Inner function: 1 spi.query for "SELECT 42 INTO v"
+  ASSERT_OK(VerifySpiSpanCount(tp.trace_id, 2));
+}
+
+// Verifies that a trigger body executing SQL via SPI produces "spi.query" spans.
+TEST_F(DistTraceTest, TestSpiTracingTrigger) {
+  ASSERT_OK(conn_->Execute("CREATE TABLE yb_spi_trig_tbl(val integer)"));
+  ASSERT_OK(conn_->Execute(
+      "CREATE OR REPLACE FUNCTION yb_spi_trig_fn() RETURNS trigger AS $$"
+      " DECLARE v integer;"
+      " BEGIN"
+      "   SELECT count(*) INTO v FROM yb_spi_trig_tbl;"
+      "   RETURN NEW;"
+      " END;"
+      " $$ LANGUAGE plpgsql"));
+  ASSERT_OK(conn_->Execute(
+      "CREATE TRIGGER yb_spi_trig"
+      " AFTER INSERT ON yb_spi_trig_tbl"
+      " FOR EACH ROW EXECUTE FUNCTION yb_spi_trig_fn()"));
+
+  auto tp = GenerateTraceparent();
+  ASSERT_OK(conn_->ExecuteFormat("SET yb_dist_tracecontext = 'traceparent=''$0'''", tp.full));
+  ASSERT_OK(conn_->Execute("INSERT INTO yb_spi_trig_tbl VALUES (1)"));
+
+  ASSERT_OK(collector_.VerifyTraceContainsOpName(tp.trace_id, "spi.query"));
+}
+
+// Verifies that a PL/pgSQL EXCEPTION block catching a failed SPI query does not
+// corrupt tracing state: the connection must remain traceable afterward.
+TEST_F(DistTraceTest, TestSpiTracingErrorHandledGracefully) {
+  ASSERT_OK(conn_->Execute(
+      "CREATE OR REPLACE FUNCTION yb_spi_trace_caught_error() RETURNS text AS $$"
+      " BEGIN"
+      "   PERFORM 1/0;"
+      "   RETURN 'no_error';"
+      " EXCEPTION WHEN division_by_zero THEN"
+      "   RETURN 'caught';"
+      " END;"
+      " $$ LANGUAGE plpgsql"));
+
+  auto tp = GenerateTraceparent();
+  ASSERT_OK(conn_->ExecuteFormat("SET yb_dist_tracecontext = 'traceparent=''$0'''", tp.full));
+  auto result = ASSERT_RESULT(conn_->FetchRow<std::string>(
+      "SELECT yb_spi_trace_caught_error()"));
+  ASSERT_EQ(result, "caught");
+
+  // Verify that subsequent tracing still works after the caught SPI error.
+  auto tp2 = GenerateTraceparent();
+  ASSERT_OK(conn_->ExecuteFormat("SET yb_dist_tracecontext = 'traceparent=''$0'''", tp2.full));
+  ASSERT_OK(conn_->Fetch("SELECT 1"));
+  ASSERT_OK(collector_.VerifyTraceContainsOpName(tp2.trace_id, "query"));
+}
+
+// Verifies that get_cached_plan and execute appear as child spans of spi.query.
+TEST_F(DistTraceTest, TestSpiTracingChildSpans) {
+  ASSERT_OK(conn_->Execute(
+      "CREATE OR REPLACE FUNCTION yb_spi_trace_child_spans() RETURNS integer AS $$"
+      " DECLARE v integer;"
+      " BEGIN"
+      "   SELECT 1 INTO v;"
+      "   RETURN v;"
+      " END;"
+      " $$ LANGUAGE plpgsql"));
+
+  auto tp = GenerateTraceparent();
+  ASSERT_OK(conn_->ExecuteFormat("SET yb_dist_tracecontext = 'traceparent=''$0'''", tp.full));
+  ASSERT_OK(conn_->Fetch("SELECT yb_spi_trace_child_spans()"));
+
+  ASSERT_OK(VerifySpiQueryChildSpans(tp.trace_id));
+
 }
 
 TEST_F(DistTraceTest, TestSharedMemoryPerformSpanForRead) {


### PR DESCRIPTION
## Summary
Add OTel distributed tracing instrumentation to the PostgreSQL SPI
(Server Programming Interface) code path. When a PL/pgSQL function
or trigger executes SQL via SPI while a trace is active, child
"spi.query" spans are now emitted and associated with the root trace.

Includes three new dist-trace tests covering basic SPI tracing,
multiple SPI queries producing multiple spans, and nested PL/pgSQL
functions.

## Test plan
New integration tests in `DistTraceTest`: `TestSpiTracingBasic`,
`TestSpiTracingMultipleQueriesProduceMultipleSpans`,
`TestSpiTracingNestedFunctions`.


---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31228/>)