### PR TITLE
[#31230] DocDB: Fix typo in tserver status page: "Cluster Load is not Idle" -> "Cluster Load Balancer is not Idle"

### DIFF
--- a/src/yb/master/master-path-handlers.cc
+++ b/src/yb/master/master-path-handlers.cc
@@ -37,7 +37,7 @@
 #include <iomanip>
 #include <map>
 #include <memory>
-#include <regex>  // NOLINT(build/c++11)
+#include <regex>
 #include <sstream>
 #include <unordered_set>
 

--- a/src/yb/master/master-path-handlers.cc
+++ b/src/yb/master/master-path-handlers.cc
@@ -37,7 +37,7 @@
 #include <iomanip>
 #include <map>
 #include <memory>
-#include <regex>
+#include <regex>  // NOLINT(build/c++11)
 #include <sstream>
 #include <unordered_set>
 

--- a/src/yb/master/master-path-handlers.cc
+++ b/src/yb/master/master-path-handlers.cc
@@ -936,7 +936,7 @@ void MasterPathHandlers::HandleTabletServers(const Webserver::WebRequest& req,
         *output
             << "<h4 style=\"color:" << kYBOrange
             << "\"><i class='fa fa-tasks yb-dashboard-icon' aria-hidden='true'></i>Cluster Load "
-               "is not Idle</h4>\n";
+               "Balancer is not Idle</h4>\n";
       }
     }
   }


### PR DESCRIPTION
## Summary

Fix a typo in the master web UI's tserver status page: the load-balancer-active message was rendering as "Cluster Load is not Idle" instead of "Cluster Load Balancer is not Idle". This matches the wording of the adjacent "Cluster Balancer is Idle" success message.

- File: `src/yb/master/master-path-handlers.cc:938`
- Closes: #31230

## Test plan

- [x] Verified via visual inspection of the diff. No functional/code-path changes; this is a UI string edit only.

Fixes #31230

---

Phorge: [D52305](https://phorge.dev.yugabyte.com/D52305)