### PR TITLE
[#31233] Build: Fix lint.py cpplint filter to handle regex-escaped rule names

### DIFF
--- a/build-support/lint.py
+++ b/build-support/lint.py
@@ -193,13 +193,11 @@ def _cpplint_filter_arg(severity_rules: dict) -> str:
     # Keys in .lint are regex patterns matched against cpplint rule names (e.g.
     # "(^build/c[+][+]11$)"); strip the regex wrapping and unescape single-char classes so we
     # can pass bare rule names (e.g. "build/c++11") to cpplint's --filter flag.
-    disabled = []
-    for rule, sev in severity_rules.items():
-        if sev != "disabled":
-            continue
-        name = rule.strip("()^$")
-        name = re.sub(r"\[(.)\]", r"\1", name)
-        disabled.append(name)
+    disabled = [
+        re.sub(r"\[(.)\]", r"\1", rule.strip("()^$"))
+        for rule, sev in severity_rules.items()
+        if sev == "disabled"
+    ]
     return ",".join(f"-{d}" for d in disabled) if disabled else ""
 
 

--- a/build-support/lint.py
+++ b/build-support/lint.py
@@ -190,7 +190,16 @@ def run_pep8(linter: Linter, files: list[str]) -> list[Message]:
 
 
 def _cpplint_filter_arg(severity_rules: dict) -> str:
-    disabled = [rule.strip("()^$") for rule, sev in severity_rules.items() if sev == "disabled"]
+    # Keys in .lint are regex patterns matched against cpplint rule names (e.g.
+    # "(^build/c[+][+]11$)"); strip the regex wrapping and unescape single-char classes so we
+    # can pass bare rule names (e.g. "build/c++11") to cpplint's --filter flag.
+    disabled = []
+    for rule, sev in severity_rules.items():
+        if sev != "disabled":
+            continue
+        name = rule.strip("()^$")
+        name = re.sub(r"\[(.)\]", r"\1", name)
+        disabled.append(name)
     return ",".join(f"-{d}" for d in disabled) if disabled else ""
 
 


### PR DESCRIPTION
## Summary

`_cpplint_filter_arg()` stripped only `(`, `)`, `^`, and `$` from `.lint`
rule keys, leaving regex character classes like `[+]` intact. As a result
`-build/c[+][+]11` was sent to cpplint, which didn't match cpplint's actual
rule name `build/c++11`, so that rule stayed enabled despite being disabled
in `.arclint`/`.lint`. Unescape single-char classes so the filter passes
bare rule names.

Fixes #31233.

## Test plan

- [x] `_cpplint_filter_arg()` on the full `.lint` rule set now emits
  `-build/c++11` (and the other disabled rules unchanged).
- [x] `./build-support/lint.py src/yb/master/master-path-handlers.cc` no
  longer reports the `build/c++11` warning against `<regex>` — confirmed
  by running raw cpplint (reports the warning), then with the old filter
  string `-build/c[+][+]11` (warning still slips through), then with the
  new `-build/c++11` filter (warning suppressed).
- [x] `./build-support/lint.sh --rev upstream/master` reports 0 errors / 0 warnings.
