### PR TITLE
[#31230] DocDB: fix tserver status page label "Cluster Load is not Idle"

### DIFF
--- a/src/yb/master/master-path-handlers.cc
+++ b/src/yb/master/master-path-handlers.cc
@@ -936,7 +936,7 @@ void MasterPathHandlers::HandleTabletServers(const Webserver::WebRequest& req,
         *output
             << "<h4 style=\"color:" << kYBOrange
             << "\"><i class='fa fa-tasks yb-dashboard-icon' aria-hidden='true'></i>Cluster Load "
-               "is not Idle</h4>\n";
+               "Balancer is not Idle</h4>\n";
       }
     }
   }


### PR DESCRIPTION
Fixes #31230 (DB-21098).

The tserver master web UI shows "Cluster Load is not Idle" when the load balancer is active — missing the word "Balancer". The adjacent success path on line 934 correctly says "Cluster Balancer is Idle". One-word fix so the two messages line up.

```diff
  << "\"><i class='fa fa-tasks yb-dashboard-icon' aria-hidden='true'></i>Cluster Load "
-    "is not Idle</h4>\n";
+    "Balancer is not Idle</h4>\n";
```

File: `src/yb/master/master-path-handlers.cc:938`. Single-file, string-only change; no logic or test impact.