### PR TITLE
yugabyted: support JSON object syntax for master_flags and tserver_flags in config file

### DIFF
--- a/bin/yugabyted
+++ b/bin/yugabyted
@@ -10631,6 +10631,22 @@ class Configs(object):
 
         return configs
 
+    @staticmethod
+    def flags_dict_to_str(flags_dict):
+        parts = []
+        for key, value in flags_dict.items():
+            if value is None:
+                continue
+            if isinstance(value, bool):
+                parts.append("{}={}".format(key, str(value).lower()))
+            else:
+                str_value = str(value)
+                if ',' in str_value:
+                    parts.append("{}={{{}}}".format(key, str_value))
+                else:
+                    parts.append("{}={}".format(key, str_value))
+        return ','.join(parts)
+
     # Custom parser for reading user config file.
     @staticmethod
     def parse_user_config_file(user_conf_file):
@@ -10647,6 +10663,10 @@ class Configs(object):
         except Exception as e:
             Output.log_error_and_exit("Failed to read user config file {}: {}".format(
                                         user_conf_file, str(e)))
+
+        for flag_key in ("master_flags", "tserver_flags"):
+            if isinstance(user_configs.get(flag_key), dict):
+                user_configs[flag_key] = Configs.flags_dict_to_str(user_configs[flag_key])
 
         user_configs = Configs.expand_path_variables(user_configs)
 

--- a/docs/content/stable/reference/configuration/yugabyted.md
+++ b/docs/content/stable/reference/configuration/yugabyted.md
@@ -901,6 +901,28 @@ You can set advanced flags using a configuration file, specified using the `--co
     }
     ```
 
+    The `master_flags` and `tserver_flags` fields also accept a JSON object instead of a comma-separated string. This is especially useful for flags whose values contain commas (such as `ysql_catalog_preload_additional_table_list` or `ysql_pg_conf_csv`), eliminating the need to use `{...}` escaping:
+
+    ```json
+    {
+        "master_webserver_port": 7100,
+        "tserver_webserver_port": 9100,
+        "master_flags": {
+            "ysql_enable_packed_row": true,
+            "ysql_beta_features": true
+        },
+        "tserver_flags": {
+            "ysql_enable_packed_row": true,
+            "ysql_beta_features": true,
+            "yb_enable_read_committed_isolation": true,
+            "enable_deadlock_detection": true,
+            "enable_wait_queues": true,
+            "ysql_catalog_preload_additional_table_list": "pg_operator,pg_amop,pg_cast",
+            "ysql_pg_conf_csv": "shared_preload_libraries=auto_explain,auto_explain.log_min_duration=100,yb_enable_cbo=on"
+        }
+    }
+    ```
+
 1. Start the node using the `--config` flag.
 
     ```sh


### PR DESCRIPTION
## Problem

When using a yugabyted config file (`--config`), `master_flags` and `tserver_flags` are comma-delimited strings. This results in a configuration file that is difficult to maintain or read.

## Change

`master_flags` and `tserver_flags` in the config file now accept either a string (existing behaviour, unchanged) or a JSON object:

```json
{
    "tserver_flags": {
        "ysql_catalog_preload_additional_tables": true,
        "ysql_catalog_preload_additional_table_list": "pg_operator,pg_amop,pg_cast",
        "ysql_pg_conf_csv": "shared_preload_libraries=auto_explain,auto_explain.log_min_duration=100,yb_enable_cbo=on"
    }
}
```

When a dict is provided, `parse_user_config_file` converts it to the canonical comma-separated string before it enters `saved_data`. The conversion wraps any value containing a comma in `{...}` automatically, so the rest of the parsing pipeline (flag
splitting, `get_user_flag_value`, `get_user_csv_flag_value`, command assembly) is completely unaffected.

Conversion rules:

| JSON type | Output |
|---|---|
| `bool` | `key=true` / `key=false` |
| `null` | omitted |
| string/number, no commas | `key=value` |
| string with commas | `key={value}` (auto-escaped for the existing regex splitter) |

## Rationale

- **Zero downstream changes.** All flag-handling code operates on the string form; the   conversion happens at the single point of entry (`parse_user_config_file`).
- **Fully backwards compatible.** String-format configs continue to work identically.
- **Eliminates a class of silent misconfiguration.** Users no longer need to know about the  `{...}` escaping convention for comma-valued flags.

## Testing

- String-format configs: verified existing behaviour is unchanged (no code paths after   `parse_user_config_file` were modified).
- Dict-format configs: conversion produces the correct `{...}`-escaped string for   comma-containing values, which the existing regex splitter handles correctly.