### PR TITLE
[#30519] Docs: Mark timetz index key limitation

### DIFF
--- a/docs/content/stable/api/ysql/datatypes/_index.md
+++ b/docs/content/stable/api/ysql/datatypes/_index.md
@@ -58,7 +58,7 @@ The following table lists the primitive and compound data types in YSQL.
 | [serial](type_serial) | [serial4](type_serial) | Autoincrementing four-byte integer |
 | [text](type_character) | | Variable-length character string |
 | [time [ (p) ] [ without time zone ]](type_datetime/) | | Time of day (no time zone) |
-| [time [ (p) ] with time zone](type_datetime/) | [timetz](type_datetime/) | Time of day, including time zone |
+| [time [ (p) ] with time zone](type_datetime/) <sup>1</sup> | [timetz](type_datetime/) | Time of day, including time zone |
 | [timestamp [ (p) ] [ without time zone ]](type_datetime/) | | Date and time (no time zone) |
 | [timestamp [ (p) ] with time zone](type_datetime/) | [timestamptz](type_datetime/) | Date and time, including time zone |
 | `tsquery` <sup>1</sup> | | Text search query |

--- a/docs/content/stable/api/ysql/datatypes/_index.md
+++ b/docs/content/stable/api/ysql/datatypes/_index.md
@@ -58,7 +58,7 @@ The following table lists the primitive and compound data types in YSQL.
 | [serial](type_serial) | [serial4](type_serial) | Autoincrementing four-byte integer |
 | [text](type_character) | | Variable-length character string |
 | [time [ (p) ] [ without time zone ]](type_datetime/) | | Time of day (no time zone) |
-| [time [ (p) ] with time zone](type_datetime/) <sup>1</sup> | [timetz](type_datetime/) | Time of day, including time zone |
+| [time [ (p) ] with time zone](type_datetime/) <sup>1</sup> | [timetz](type_datetime/) <sup>1</sup> | Time of day, including time zone |
 | [timestamp [ (p) ] [ without time zone ]](type_datetime/) | | Date and time (no time zone) |
 | [timestamp [ (p) ] with time zone](type_datetime/) | [timestamptz](type_datetime/) | Date and time, including time zone |
 | `tsquery` <sup>1</sup> | | Text search query |

--- a/docs/content/stable/api/ysql/datatypes/_index.md
+++ b/docs/content/stable/api/ysql/datatypes/_index.md
@@ -33,7 +33,7 @@ The following table lists the primitive and compound data types in YSQL.
 | [double precision](type_numeric) | [float8](type_numeric) | Double precision floating-point number (8 bytes) |
 | `inet` <sup>1</sup> | | IPv4 or IPv6 host address |
 | [integer](type_numeric) | [int, int4](type_numeric) | Signed four-byte integer |
-| [interval [ fields ] [ (p) ]](type_datetime/) | | Time span |
+| [interval [ fields ] [ (p) ]](type_datetime/) <sup>1</sup> | | Time span |
 | [json](type_json/) <sup>1</sup> | | Textual JSON data |
 | [jsonb](type_json/) <sup>1</sup> | | JSON data, stored as decomposed binary |
 | `line` <sup>1</sup> | | Infinite line on a plane |
@@ -48,12 +48,12 @@ The following table lists the primitive and compound data types in YSQL.
 | `polygon` <sup>1</sup> | | Closed geometric path |
 | [real](type_numeric) | [float4](type_numeric) | Floating-point number (4 bytes) |
 | [smallint](type_numeric) | [int2](type_numeric) | Signed two-byte integer |
-| [int4range](type_range#synopsis) | | `integer` range |
-| [int8range](type_range#synopsis) | | `bigint` range |
-| [numrange](type_range#synopsis) | | `numeric` range |
-| [tsrange](type_range#synopsis) | | `timestamp without time zone` range |
-| [tstzrange](type_range#synopsis) | | `timestamp with time zone` range |
-| [daterange](type_range#synopsis) | | `date` range |
+| [int4range](type_range#synopsis) <sup>1</sup> | | `integer` range |
+| [int8range](type_range#synopsis) <sup>1</sup> | | `bigint` range |
+| [numrange](type_range#synopsis) <sup>1</sup> | | `numeric` range |
+| [tsrange](type_range#synopsis) <sup>1</sup> | | `timestamp without time zone` range |
+| [tstzrange](type_range#synopsis) <sup>1</sup> | | `timestamp with time zone` range |
+| [daterange](type_range#synopsis) <sup>1</sup> | | `date` range |
 | [smallserial](type_serial) | [serial2](type_serial) | Autoincrementing two-byte integer |
 | [serial](type_serial) | [serial4](type_serial) | Autoincrementing four-byte integer |
 | [text](type_character) | | Variable-length character string |

--- a/docs/content/stable/api/ysql/datatypes/type_datetime/_index.md
+++ b/docs/content/stable/api/ysql/datatypes/type_datetime/_index.md
@@ -40,6 +40,8 @@ The [PostgreSQL documentation](https://www.postgresql.org/docs/15/datatype-datet
 > The data type _time with time zone_ is defined by the SQL standard, but the definition exhibits properties which lead to questionable usefulness. In most cases, a combination of _date_, (plain) _time_, (plain) _timestamp_, and _timestamptz_ should provide the complete range of _date-time_ functionality that any application could require.
 
 The thinking is that a notion that expresses only what a clock might read in a particular timezone gives only part of the picture. For example when a clock reads 20:00 in _UTC_, it reads 03:00 in China Standard Time. But 20:00 _UTC_ is the evening of one day and 03:00 is in the small hours of the morning of the _next day_ in China Standard Time. (Neither _UTC_ nor China Standard Time adjusts its clocks for Daylight Savings.) The data type _timestamptz_ represents both the time of day and the date and so it handles the present use case naturally. No further reference will be made to _timetz_.
+
+YugabyteDB also doesn't support index key columns that use the _timetz_ data type.
 {{< /tip >}}
 <a name="maximum-and-minimum-supported-values"></br></a>
 {{< note title="Maximum and minimum supported values." >}}


### PR DESCRIPTION
## Summary

- Mark `time with time zone` / `timetz` with the existing unsupported-index-key footnote in the YSQL data types overview.
- Add the same `timetz` index key limitation to the date-time type page.

Fixes #30519.

## Testing

- `git diff --check`
- `PATH=/tmp/yb-hugo:$PATH npm run build`

