### PR TITLE
Use ascii_isprint for debug byte formatting

### DIFF
--- a/src/yb/util/bytes_formatter.cc
+++ b/src/yb/util/bytes_formatter.cc
@@ -56,7 +56,7 @@ string FormatBytesAsStr(const char* data,
       result.push_back(quote);
     } else if (c == '\\') {
       result.append("\\\\");
-    } else if (ascii_isgraph(c) || c == ' ') {
+    } else if (ascii_isprint(c)) {
       result.push_back(c);
     } else {
       result.append(StringPrintf("\\x%02x", c));

--- a/src/yb/util/bytes_formatter.cc
+++ b/src/yb/util/bytes_formatter.cc
@@ -14,6 +14,7 @@
 #include "yb/util/bytes_formatter.h"
 
 #include "yb/gutil/stringprintf.h"
+#include "yb/gutil/strings/ascii_ctype.h"
 #include "yb/gutil/strings/substitute.h"
 
 #include "yb/util/cast.h"
@@ -55,7 +56,7 @@ string FormatBytesAsStr(const char* data,
       result.push_back(quote);
     } else if (c == '\\') {
       result.append("\\\\");
-    } else if (isgraph(c) || c == ' ') {
+    } else if (ascii_isgraph(c) || c == ' ') {
       result.push_back(c);
     } else {
       result.append(StringPrintf("\\x%02x", c));


### PR DESCRIPTION
FormatBytesAsStr in bytes_formatter.cc decides whether a byte is shown
raw or escaped as \xNN using isgraph(). isgraph() is locale- and
libc-dependent: on macOS BSD libc under a UTF-8 locale it returns
non-zero for bytes in the 0x80-0xFF range, while glibc on Linux
returns zero for the same bytes. As a result, the same DocKey
rendered on macOS contains raw high bytes where the Linux rendering
would have \xbd, \xda, etc.

This broke tests that compare dumped DocDB output against checked-in
expected fixtures (e.g. ConflictResolveKeysVerificationITest.*), since
the fixtures were generated on Linux.

Switch to ascii_isprint() from gutil/strings/ascii_ctype.h, which is a
locale-independent ASCII-only check (0x20-0x7E). The output is now
identical across platforms.
