### PR TITLE
Disable PgHeapSnapshotTest.TestYsqlHeapSnapshotSimple on macOS

### DIFF
--- a/src/yb/yql/pgwrapper/pg_heap_snapshot-test.cc
+++ b/src/yb/yql/pgwrapper/pg_heap_snapshot-test.cc
@@ -49,7 +49,7 @@ class PgHeapSnapshotTest : public PgMiniTestBase {
   }
 };
 
-TEST_F(PgHeapSnapshotTest, YB_DISABLE_TEST_IN_SANITIZERS(TestYsqlHeapSnapshotSimple)) {
+TEST_F(PgHeapSnapshotTest, YB_DISABLE_TEST_IN_SANITIZERS_OR_MAC(TestYsqlHeapSnapshotSimple)) {
   auto conn1 = ASSERT_RESULT(Connect());
   auto conn2 = ASSERT_RESULT(Connect());
 


### PR DESCRIPTION
The test asserts that after dropping yb_tcmalloc_sample_period to 8
bytes, yb_backend_heap_snapshot() returns more than 10 rows (distinct
sampled call stacks). That threshold was tuned for google tcmalloc,
which is what the Linux build uses.

macOS builds link against gperftools tcmalloc (YB_GPERFTOOLS_TCMALLOC).
On that code path the snapshot goes through
GetAggregateAndSortHeapSnapshotGperftools(), which buckets live
MallocExtension::ReadStackTraces() samples by symbolized stack. The
number of distinct stacks with live sampled allocations in a PG child
backend between two snapshots is naturally lower than google tcmalloc
produces, so the >10 assertion fails with 2 rows despite sampling
working correctly.

Switch the existing YB_DISABLE_TEST_IN_SANITIZERS guard to
YB_DISABLE_TEST_IN_SANITIZERS_OR_MAC to cover the macOS path as well.


---

Phorge: [D52404](https://phorge.dev.yugabyte.com/D52404)