### PR TITLE
Fix Apache AGE README branding and image links

### DIFF
--- a/src/postgres/third-party-extensions/age/README.md
+++ b/src/postgres/third-party-extensions/age/README.md
@@ -28,7 +28,7 @@
   </a>
   &nbsp;
   <a href="https://www.postgresql.org/docs/15/index.html">
-    <img src="https://img.shields.io/badge/Version-Postgresql%2015-00008B?labelColor=gray&style=flat&link=https://www.postgresql.org/docs/15/index.html"/>
+    <img src="https://img.shields.io/badge/Version-PostgreSQL%2015-00008B?labelColor=gray&style=flat&link=https://www.postgresql.org/docs/15/index.html"/>
   </a>
   &nbsp;
   <a href="https://github.com/apache/age/issues">

--- a/src/postgres/third-party-extensions/age/README.md
+++ b/src/postgres/third-party-extensions/age/README.md
@@ -1,19 +1,13 @@
 <br>
 
 <p align="center">
-     <img src="https://age.apache.org/age-manual/master/_static/logo.png" width="30%" height="30%">
+    <a href="https://age.apache.org/">
+        <img src="https://age.apache.org/age-manual/master/_static/logo.png" alt="Apache AGE logo" width="30%">
+    </a>
 </p>
 <br>
 
-<h3 align="center">
-    <a href="https://age.apache.org/age-manual/master/_static/logo.png" target="_blank">
-        <img src="https://age.apache.org/age-manual/master/_static/logo.png" height="25" height="30% alt="Apache AGE style="margin: 0 0 -3px 0">
-    </a>
-    <a href="https://age.apache.org/age-manual/master/_static/logo.png" target="_blank">
-    </a>
-     is a leading multi-model graph database </h3>
-     
-</h3>
+<h3 align="center">Apache AGE&trade; is a leading multi-model graph database</h3>
 
 <h3 align="center">Graph Processing & Analytics for Relational Databases</h3>
 
@@ -34,7 +28,7 @@
   </a>
   &nbsp;
   <a href="https://www.postgresql.org/docs/15/index.html">
-    <img src="https://img.shields.io/badge/Version-Postgresql 15-00008B?labelColor=gray&style=flat&link=https://www.postgresql.org/docs/15/index.html"/>
+    <img src="https://img.shields.io/badge/Version-Postgresql%2015-00008B?labelColor=gray&style=flat&link=https://www.postgresql.org/docs/15/index.html"/>
   </a>
   &nbsp;
   <a href="https://github.com/apache/age/issues">
@@ -56,17 +50,11 @@
 <br>
 
 
-<h2><img height="30" src="/img/AGE.png">&nbsp;&nbsp;What is Apache AGE?</h2>
+<h2>What is Apache AGE&trade;?</h2>
 
-[Apache AGE](https://age.apache.org/#) is an extension for PostgreSQL that enables users to leverage a graph database on top of the existing relational databases. AGE is an acronym for A Graph Extension and is inspired by Bitnine's AgensGraph, a multi-model database fork of PostgreSQL. The basic principle of the project is to create a single storage that handles both the relational and graph data model so that the users can use the standard ANSI SQL along with openCypher, one of the most popular graph query languages today. 
+[Apache AGE&trade;](https://age.apache.org/#) is an extension for PostgreSQL that enables users to leverage a graph database on top of the existing relational databases. AGE is an acronym for A Graph Extension and is inspired by Bitnine's AgensGraph, a multi-model database fork of PostgreSQL. The basic principle of the project is to create a single storage that handles both the relational and graph data model so that the users can use the standard ANSI SQL along with openCypher, one of the most popular graph query languages today. 
 </br>
 </br>
-</br>
-
-<p align="center">
-<img src="/img/age-01.png" width="80%" height="80%">
-</p>
-
 </br>
 
 Since AGE is based on the powerful PostgreSQL RDBMS, it is robust and fully featured. AGE is optimized for handling complex connected graph data. It provides plenty of robust database features essential to the database environment, including ACID transactions, multi-version concurrency control (MVCC), stored procedure, triggers, constraints, sophisticated monitoring, and a flexible data model (JSON). Users with a relational database background who require graph data analytics can use this extension with minimal effort because they can use existing data without going through migration. 
@@ -74,7 +62,7 @@ Since AGE is based on the powerful PostgreSQL RDBMS, it is robust and fully feat
 There is a strong need for cohesive, easy-to-implement multi-model databases. As an extension of PostgreSQL, AGE supports all the functionalities and features of PostgreSQL while also offering a graph model to boot.
 
 
-<h2><img height="30" src="/img/tick.svg">&nbsp;&nbsp;Overview</h2>
+<h2><img height="30" src="img/tick.svg">&nbsp;&nbsp;Overview</h2>
 
 Apache AGE is :
 
@@ -82,13 +70,8 @@ Apache AGE is :
 - **Flexible**: allows you to perform openCypher queries, which makes complex queries much easier to write. It also enables querying multiple graphs at the same time.
 - **Intelligent**: allows you to perform graph queries that are the basis for many next-level web services such as fraud detection, master data management, product recommendations, identity and relationship management, experience personalization, knowledge management, and more.
 
-<h2><img height="30" src="/img/features.svg">&nbsp;&nbsp;Features</h2>
+<h2><img height="30" src="img/features.svg">&nbsp;&nbsp;Features</h2>
 </br>
-</br>
-
-<p align="center">
-<img src="/img/age-03.png" width="80%" height="80%">
-</p>
 </br>
 
 - **Cypher Query**: supports graph query language
@@ -100,13 +83,13 @@ Apache AGE is :
 
 
 
-<h2><img height="30" src="/img/documentation.svg">&nbsp;&nbsp;Documentation</h2>
+<h2><img height="30" src="img/documentation.svg">&nbsp;&nbsp;Documentation</h2>
 
 Refer to our latest [Apache AGE documentation](https://age.apache.org/age-manual/master/index.html) to learn about installation, features, built-in functions, and  Cypher queries.
 
 
 
-<h2><img height="30" src="/img/installation.svg">&nbsp;&nbsp;Pre-Installation</h2>
+<h2><img height="30" src="img/installation.svg">&nbsp;&nbsp;Pre-Installation</h2>
 
 Install the following essential libraries according to each OS. Building AGE from the source depends on the following Linux libraries (Ubuntu package names shown below):
 
@@ -123,13 +106,11 @@ dnf install gcc glibc bison flex readline readline-devel zlib zlib-devel
 sudo apt-get install build-essential libreadline-dev zlib1g-dev flex bison
 ```
 
-<h2><img height="30" src="/img/installation.svg">&nbsp;&nbsp;Installation</h2>
+<h2><img height="30" src="img/installation.svg">&nbsp;&nbsp;Installation</h2>
 
 Apache AGE is intended to be simple to install and run. It can be installed with Docker and other traditional ways. 
 
-<h4><a><img width="20" src="/img/pg.svg"></a>
-&nbsp;Install PostgreSQL
-</h4>
+<h4>Install PostgreSQL</h4>
 
 You will need to install an AGE compatible version of Postgres<a>, for now AGE supports Postgres 13, 14, 15, 16, & 17. Supporting the latest versions is on AGE roadmap.
 
@@ -153,7 +134,7 @@ You can <a href="https://www.postgresql.org/ftp/source/"> download the Postgres 
 
 
 
-<h4><img width="20" src="/img/tux.svg"><img width="20" src="/img/apple.svg"> &nbsp;Install AGE on Linux and MacOS
+<h4><img width="20" src="img/apple.svg"> &nbsp;Install AGE on Linux and MacOS
 </h4>
 
 Clone the <a href="https://github.com/apache/age">github repository</a> or download the <a href="https://github.com/apache/age/releases">download an official release.
@@ -176,9 +157,7 @@ make PG_CONFIG=/path/to/postgres/bin/pg_config install
 ```
 
 
-<h4></a><img width="30" src="/img/docker.svg"></a>
-&nbsp;Run using Docker
-</h4>
+<h4>Run using Docker</h4>
 
 <h5> Get the docker image </h5>
 
@@ -207,7 +186,7 @@ docker exec -it age psql -d postgresDB -U postgresUser
 
 
 
-<h2><img height="20" src="/img/contents.svg">&nbsp;&nbsp;Post Installation</h2>
+<h2><img height="20" src="img/contents.svg">&nbsp;&nbsp;Post Installation</h2>
 
 For every connection of AGE you start, you will need to load the AGE extension.
 
@@ -223,7 +202,7 @@ SET search_path = ag_catalog, "$user", public;
 
 
 
-<h2><img height="20" src="/img/contents.svg">&nbsp;&nbsp;Quick Start</h2>
+<h2><img height="20" src="img/contents.svg">&nbsp;&nbsp;Quick Start</h2>
 
 To create a graph, use the create_graph function located in the ag_catalog namespace.
 
@@ -308,16 +287,11 @@ $$) as (e agtype);
 
 
 
-<h2><img height="20" src="/img/gettingstarted.svg">&nbsp;&nbsp;Language Specific Drivers</h2>
+<h2><img height="20" src="img/gettingstarted.svg">&nbsp;&nbsp;Language Specific Drivers</h2>
 
 Starting with Apache AGE is very simple. You can easily select your platform and incorporate the relevant SDK into your code.
 </br>
 </br>
-
-<p align="center">
-<img src="/img/age-02.png" width="80%" height="80%">
-</p>
-
 
 <h4>Built-in</h4>
 
@@ -331,7 +305,7 @@ Starting with Apache AGE is very simple. You can easily select your platform and
 - [Apache AGE Rust Driver](https://github.com/Dzordzu/rust-apache-age.git)
 - [Apache AGE .NET Driver](https://github.com/Allison-E/pg-age)
 
-<h2><img height="20" src="/img/contributing.svg">&nbsp;&nbsp;Community</h2>
+<h2><img height="20" src="img/contributing.svg">&nbsp;&nbsp;Community</h2>
 
 Join the AGE community for help, questions, discussions, and contributions. 
 
@@ -345,7 +319,7 @@ Join the AGE community for help, questions, discussions, and contributions.
 - Subscribe to our committer mailing list (To become a committer) by sending an email to commits-subscribe@age.apache.org
 
 
-<h2><img height="20" src="/img/visualization.svg">&nbsp;&nbsp;Graph Visualization Tool for AGE</h2>
+<h2><img height="20" src="img/visualization.svg">&nbsp;&nbsp;Graph Visualization Tool for AGE</h2>
 
 
 Apache AGE Viewer is a user interface for Apache AGE that provides visualization and exploration of data.
@@ -356,11 +330,7 @@ Apache AGE Viewer will become a graph data administration and development platfo
 **This is a visualization tool.**
 After installing AGE Extension, you may use this tool to get access to the visualization features.
 
-
-![Viewer gdb, and graph](/img/agce.gif)
-
-
-<h2><img height="20" src="/img/videos.png">&nbsp;&nbsp;Video Links</h2>
+<h2>Video Links</h2>
 
 You can also get help from these videos. 
 
@@ -369,8 +339,12 @@ You can also get help from these videos.
 
 
 
-<h2><img height="20" src="/img/community.svg">&nbsp;&nbsp;Contributing</h2>
+<h2><img height="20" src="img/community.svg">&nbsp;&nbsp;Contributing</h2>
 
 You can improve ongoing efforts or initiate new ones by sending pull requests to [this repository](https://github.com/apache/age).
 Also, you can learn from the code review process, how to merge pull requests, and from code style compliance to documentation by visiting the [Apache AGE official site - Developer Guidelines](https://age.apache.org/contribution/guide).
 Send all your comments and inquiries to the user mailing list, users@age.apache.org.
+
+<h2>Trademarks</h2>
+
+Apache AGE, AGE, Apache&reg;, the Apache feather logo, and the Apache AGE project logo are either registered trademarks or trademarks of The Apache Software Foundation in the United States and/or other countries. No endorsement by The Apache Software Foundation is implied by the use of these marks. All other marks mentioned may be trademarks or registered trademarks of their respective owners.

--- a/src/postgres/third-party-extensions/age/drivers/golang/README.md
+++ b/src/postgres/third-party-extensions/age/drivers/golang/README.md
@@ -32,7 +32,7 @@ require  github.com/apache/age/drivers/golang {version}
 Check [latest version](https://github.com/apache/age/releases)
 
 ### For more information about [Apache AGE](https://age.apache.org/)
-* Apache Age : https://age.apache.org/
+* Apache AGE : https://age.apache.org/
 * GitHub : https://github.com/apache/age
 * Document : https://age.apache.org/docs/
 

--- a/src/postgres/third-party-extensions/age/drivers/jdbc/README.md
+++ b/src/postgres/third-party-extensions/age/drivers/jdbc/README.md
@@ -93,6 +93,6 @@ Vertex : Country, 	Props : {name=US}
 
 ## For more information about [Apache AGE](https://age.apache.org/)
 
-- Apache Age : [https://age.apache.org/](https://age.apache.org/)
+- Apache AGE : [https://age.apache.org/](https://age.apache.org/)
 - GitHub : [https://github.com/apache/age](https://github.com/apache/age)
 - Document : [https://age.apache.org/age-manual/master/index.html](https://age.apache.org/age-manual/master/index.html)

--- a/src/postgres/third-party-extensions/age/drivers/nodejs/README.md
+++ b/src/postgres/third-party-extensions/age/drivers/nodejs/README.md
@@ -47,6 +47,6 @@ const results: QueryResultRow = await client?.query<QueryResultRow>(`
 `)!
 ```
 ### For more information about [Apache AGE](https://age.apache.org/)
-* Apache Age : https://age.apache.org/
+* Apache AGE : https://age.apache.org/
 * GitHub : https://github.com/apache/age
 * Document : https://age.apache.org/age-manual/master/index.html

--- a/src/postgres/third-party-extensions/age/drivers/python/README.md
+++ b/src/postgres/third-party-extensions/age/drivers/python/README.md
@@ -13,7 +13,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 
-Apache AGE](https://age.apache.org/) is a PostgreSQL extension that provides graph database functionality. The goal of the Apache AGE project is to create single storage that can handle both relational and graph model data so that users can use standard ANSI SQL along with openCypher, the Graph query language. This repository hosts the development of the Python driver for this Apache extension (currently in Incubator status). Thanks for checking it out.
+[Apache AGE](https://age.apache.org/) is a PostgreSQL extension that provides graph database functionality. The goal of the Apache AGE project is to create single storage that can handle both relational and graph model data so that users can use standard ANSI SQL along with openCypher, the Graph query language. This repository hosts the development of the Python driver for this Apache extension. Thanks for checking it out.
 
 A graph consists of a set of vertices (also called nodes) and edges, where each individual vertex and edge possesses a map of properties. A vertex is the basic object of a graph, that can exist independently of everything else in the graph. An edge creates a directed connection between two vertices. A graph database is simply composed of vertices and edges. This type of database is useful when the meaning is in the relationships between the data. Relational databases can easily handle direct relationships, but indirect relationships are more difficult to deal with in relational databases. A graph database stores relationship information as a first-class entity. Apache AGE gives you the best of both worlds, simultaneously.
 
@@ -66,7 +66,7 @@ python setup.py install
 ```
 
 ### For more information about [Apache AGE](https://age.apache.org/)
-* Apache Age : https://age.apache.org/
+* Apache AGE : https://age.apache.org/
 * GitHub : https://github.com/apache/age
 * Document : https://age.apache.org/age-manual/master/index.html
 
@@ -85,10 +85,10 @@ SET search_path = ag_catalog, "$user", public;
 * Agtype converting samples: [Agtype Sample](samples/apache-age-agtypes.ipynb) in Samples.
 
 ### Non-Superuser Usage
-* For non-superuser usage see: [Allow Non-Superusers to Use Apache Age](https://age.apache.org/age-manual/master/intro/setup.html).
+* For non-superuser usage see: [Allow Non-Superusers to Use Apache AGE](https://age.apache.org/age-manual/master/intro/setup.html).
 * Make sure to give your non-superuser db account proper permissions to the graph schemas and corresponding objects
-* Make sure to initiate the Apache Age python driver with the ```load_from_plugins``` parameter. This parameter tries to
-  load the Apache Age extension from the PostgreSQL plugins directory located at ```$libdir/plugins/age```. Example:
+* Make sure to initiate the Apache AGE python driver with the ```load_from_plugins``` parameter. This parameter tries to
+  load the Apache AGE extension from the PostgreSQL plugins directory located at ```$libdir/plugins/age```. Example:
   ```python.
   ag = age.connect(host='localhost', port=5432, user='dbuser', password='strong_password', 
                    dbname=postgres, load_from_plugins=True, graph='graph_name)
@@ -148,7 +148,7 @@ networkx_to_age(connection, G, graphName)
 
 ### AGE to Netowkx
 
-Converts data from a Apache AGE graph database into a Networkx directed graph.
+Converts data from an Apache AGE graph database into a Networkx directed graph.
 
 #### Parameters
 

--- a/src/postgres/third-party-extensions/age/drivers/python/README.md
+++ b/src/postgres/third-party-extensions/age/drivers/python/README.md
@@ -13,7 +13,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 
-[Apache AGE](https://age.apache.org/) is a PostgreSQL extension that provides graph database functionality. The goal of the Apache AGE project is to create single storage that can handle both relational and graph model data so that users can use standard ANSI SQL along with openCypher, the Graph query language. This repository hosts the development of the Python driver for this Apache extension. Thanks for checking it out.
+[Apache AGE&trade;](https://age.apache.org/) is a PostgreSQL extension that provides graph database functionality. The goal of the Apache AGE project is to create a single storage that can handle both relational and graph model data so that users can use standard ANSI SQL along with openCypher, the Graph query language. This repository hosts the development of the Python driver for this Apache extension. Thanks for checking it out.
 
 A graph consists of a set of vertices (also called nodes) and edges, where each individual vertex and edge possesses a map of properties. A vertex is the basic object of a graph, that can exist independently of everything else in the graph. An edge creates a directed connection between two vertices. A graph database is simply composed of vertices and edges. This type of database is useful when the meaning is in the relationships between the data. Relational databases can easily handle direct relationships, but indirect relationships are more difficult to deal with in relational databases. A graph database stores relationship information as a first-class entity. Apache AGE gives you the best of both worlds, simultaneously.
 

--- a/src/postgres/third-party-extensions/age/drivers/python/README.md
+++ b/src/postgres/third-party-extensions/age/drivers/python/README.md
@@ -148,7 +148,7 @@ networkx_to_age(connection, G, graphName)
 
 ### AGE to Netowkx
 
-Converts data from an Apache AGE graph database into a Networkx directed graph.
+Converts data from an Apache AGE graph database into a NetworkX directed graph.
 
 #### Parameters
 


### PR DESCRIPTION
## Summary
- Fix Apache AGE README logo markup and use ASF-style first-use trademark treatment.
- Replace broken root-relative README image paths with relative paths and remove missing image references.
- Clean up related AGE driver README branding/link issues.

## Test plan
- Targeted searches verified no remaining `/img/...` AGE README image references, missing referenced assets, malformed logo tag, or unencoded PostgreSQL badge URL.
- `ReadLints` reported no diagnostics for the edited README files.


Made with [Cursor](https://cursor.com)