### PR TITLE
Bump OS/Python versions in yb-ctl-test workflow

### DIFF
--- a/.github/workflows/yb-ctl-test.yml
+++ b/.github/workflows/yb-ctl-test.yml
@@ -24,8 +24,8 @@ jobs:
 
     strategy:
       matrix:
-        os: [ macos-latest, ubuntu-18.04 ]
-        python-version: [ 2.7, 3.8 ]
+        os: [ macos-latest, ubuntu-24.04 ]
+        python-version: [ '3.10', '3.11' ]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
The yb-ctl-test workflow is currently broken due to use of old OS and Python versions. Bumping those up to something available to the runner.