### PR TITLE
[#31358] YSQL: Add yb_enable_mage gFlag to control mage extension load

### DIFF
--- a/java/yb-pgsql/src/test/java/org/yb/pgsql/TestPgRegressThirdPartyExtensionsMage.java
+++ b/java/yb-pgsql/src/test/java/org/yb/pgsql/TestPgRegressThirdPartyExtensionsMage.java
@@ -13,6 +13,7 @@
 package org.yb.pgsql;
 
 import java.io.File;
+import java.util.Map;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,6 +25,13 @@ public class TestPgRegressThirdPartyExtensionsMage extends BasePgRegressTest {
   @Override
   public int getTestMethodTimeoutSec() {
     return 1800;
+  }
+
+  @Override
+  protected Map<String, String> getTServerFlags() {
+    Map<String, String> flagMap = super.getTServerFlags();
+    flagMap.put("ysql_yb_enable_mage", "true");
+    return flagMap;
   }
 
   @Test

--- a/src/postgres/src/backend/commands/extension.c
+++ b/src/postgres/src/backend/commands/extension.c
@@ -1732,6 +1732,12 @@ CreateExtension(ParseState *pstate, CreateExtensionStmt *stmt)
 	/* Check extension name validity before any filesystem access */
 	check_valid_extension_name(stmt->extname);
 
+	/* YB: mage availability is gated by the ysql_yb_enable_mage gFlag. */
+	if (strcmp(stmt->extname, "mage") == 0 && !yb_enable_mage)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("extension \"mage\" is not available")));
+
 	/*
 	 * Check for duplicate extension name.  The unique index on
 	 * pg_extension.extname would catch this anyway, and serves as a backstop

--- a/src/postgres/src/backend/utils/misc/guc.c
+++ b/src/postgres/src/backend/utils/misc/guc.c
@@ -4042,10 +4042,11 @@ static struct config_bool ConfigureNamesBool[] =
 	},
 
 	{
-		{"yb_enable_mage", PGC_SIGHUP, DEVELOPER_OPTIONS,
-			gettext_noop("Enable the use of mage extension."),
+		{"yb_enable_mage", PGC_POSTMASTER, DEVELOPER_OPTIONS,
+			gettext_noop("Allow CREATE EXTENSION mage and preload mage into "
+						 "all backends."),
 			NULL,
-			GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL
 		},
 		&yb_enable_mage,
 		false,

--- a/src/postgres/src/backend/utils/misc/guc.c
+++ b/src/postgres/src/backend/utils/misc/guc.c
@@ -4041,6 +4041,18 @@ static struct config_bool ConfigureNamesBool[] =
 		NULL, NULL, NULL
 	},
 
+
+	{
+		{"yb_enable_mage", PGC_SIGHUP, DEVELOPER_OPTIONS,
+			gettext_noop("Enable the use of mage extension."),
+			NULL,
+			GUC_NOT_IN_SAMPLE
+		},
+		&yb_enable_mage,
+		false,
+		NULL, NULL, NULL
+	},
+
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, false, NULL, NULL, NULL

--- a/src/postgres/src/backend/utils/misc/guc.c
+++ b/src/postgres/src/backend/utils/misc/guc.c
@@ -4043,8 +4043,8 @@ static struct config_bool ConfigureNamesBool[] =
 
 	{
 		{"yb_enable_mage", PGC_POSTMASTER, DEVELOPER_OPTIONS,
-			gettext_noop("Allow CREATE EXTENSION mage and preload mage into "
-						 "all backends."),
+			gettext_noop("Enable the use of mage extension. "
+						 "NOTE: This is for internal use only."),
 			NULL,
 			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL
 		},

--- a/src/postgres/src/backend/utils/misc/guc.c
+++ b/src/postgres/src/backend/utils/misc/guc.c
@@ -4041,7 +4041,6 @@ static struct config_bool ConfigureNamesBool[] =
 		NULL, NULL, NULL
 	},
 
-
 	{
 		{"yb_enable_mage", PGC_SIGHUP, DEVELOPER_OPTIONS,
 			gettext_noop("Enable the use of mage extension."),

--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -7536,6 +7536,8 @@ bool		yb_ysql_conn_mgr_sticky_locks = false;
  */
 bool		yb_conn_mgr_selective_deallocate = true;
 
+bool		yb_enable_mage = false;
+
 bool
 YbIsSuperuserConnSticky()
 {

--- a/src/postgres/src/include/utils/guc.h
+++ b/src/postgres/src/include/utils/guc.h
@@ -324,6 +324,7 @@ extern PGDLLIMPORT bool yb_conn_mgr_selective_deallocate;
 extern PGDLLIMPORT int yb_notifications_poll_sleep_duration_nonempty_ms;
 extern PGDLLIMPORT int yb_notifications_poll_sleep_duration_empty_ms;
 extern PGDLLIMPORT bool yb_skip_ensure_read_time_in_parallel_execution;
+extern PGDLLIMPORT bool yb_enable_mage;
 
 /*
  * Functions exported by guc.c

--- a/src/postgres/third-party-extensions/mage/src/backend/age.c
+++ b/src/postgres/third-party-extensions/mage/src/backend/age.c
@@ -23,18 +23,12 @@
 #include "parser/cypher_analyze.h"
 #include "utils/ag_guc.h"
 
-/* YB includes */
-#include "utils/guc.h"
-
 PG_MODULE_MAGIC;
 
 void _PG_init(void);
 
 void _PG_init(void)
 {
-    if (!yb_enable_mage)
-        elog(ERROR, "Mage is not enabled");
-
     register_ag_nodes();
     set_rel_pathlist_init();
     object_access_hook_init();

--- a/src/postgres/third-party-extensions/mage/src/backend/age.c
+++ b/src/postgres/third-party-extensions/mage/src/backend/age.c
@@ -23,12 +23,18 @@
 #include "parser/cypher_analyze.h"
 #include "utils/ag_guc.h"
 
+/* YB includes */
+#include "utils/guc.h"
+
 PG_MODULE_MAGIC;
 
 void _PG_init(void);
 
 void _PG_init(void)
 {
+    if (!yb_enable_mage)
+        elog(ERROR, "Mage is not enabled");
+
     register_ag_nodes();
     set_rel_pathlist_init();
     object_access_hook_init();

--- a/src/yb/yql/pgwrapper/pg_wrapper-test.cc
+++ b/src/yb/yql/pgwrapper/pg_wrapper-test.cc
@@ -664,6 +664,11 @@ TEST_F(PgWrapperFlagsTest, VerifyGFlagDefaults) {
     if (!tags.contains(FlagTag::kPg)) {
       continue;
     }
+    // Hidden gFlags use GUC_NO_SHOW_ALL on the corresponding GUC, which excludes them from
+    // pg_settings, so ValidateDefaultGucValue cannot read boot_val.
+    if (tags.contains(FlagTag::kHidden)) {
+      continue;
+    }
 
     auto expected_val = flag.default_value;
 
@@ -693,6 +698,11 @@ TEST_F(PgWrapperFlagsTest, YB_DISABLE_TEST_IN_TSAN(VerifyGFlagRuntimeTag)) {
     std::unordered_set<FlagTag> tags;
     GetFlagTags(flag.name, &tags);
     if (!tags.contains(FlagTag::kPg)) {
+      continue;
+    }
+    // Hidden gFlags use GUC_NO_SHOW_ALL on the corresponding GUC, which excludes them from
+    // pg_settings, so ValidateGucIsRuntime cannot read context.
+    if (tags.contains(FlagTag::kHidden)) {
       continue;
     }
 

--- a/src/yb/yql/pgwrapper/pg_wrapper.cc
+++ b/src/yb/yql/pgwrapper/pg_wrapper.cc
@@ -478,7 +478,9 @@ DEFINE_validator(ysql_yb_notifications_poll_sleep_duration_empty_ms, FLAG_GE_VAL
 DEFINE_NON_RUNTIME_string(pg_upgrade_working_dir, "",
     "Working directory for pg_upgrade. If empty, defaults to the pg_upgrade data directory.");
 
-DEFINE_RUNTIME_PG_FLAG(bool, yb_enable_mage, false, "Enable the use of mage extension.");
+DEFINE_NON_RUNTIME_PG_FLAG(bool, yb_enable_mage, false,
+                           "Allow CREATE EXTENSION mage and preload mage into all backends. "
+                           "Takes effect on postmaster restart.");
 TAG_FLAG(ysql_yb_enable_mage, hidden);
 
 using gflags::CommandLineFlagInfo;
@@ -730,6 +732,10 @@ Result<string> WritePostgresConfig(const PgProcessConf& conf) {
     metricsLibs.push_back("pg_documentdb_core");
     metricsLibs.push_back("pg_documentdb");
     metricsLibs.push_back("pg_documentdb_gw_host");
+  }
+
+  if (FLAGS_ysql_yb_enable_mage) {
+    metricsLibs.push_back("mage");
   }
 
   vector<string> lines;

--- a/src/yb/yql/pgwrapper/pg_wrapper.cc
+++ b/src/yb/yql/pgwrapper/pg_wrapper.cc
@@ -478,6 +478,9 @@ DEFINE_validator(ysql_yb_notifications_poll_sleep_duration_empty_ms, FLAG_GE_VAL
 DEFINE_NON_RUNTIME_string(pg_upgrade_working_dir, "",
     "Working directory for pg_upgrade. If empty, defaults to the pg_upgrade data directory.");
 
+DEFINE_RUNTIME_PG_FLAG(bool, yb_enable_mage, false, "Enable the use of mage extension.");
+TAG_FLAG(ysql_yb_enable_mage, hidden);
+
 using gflags::CommandLineFlagInfo;
 using std::string;
 using std::vector;

--- a/src/yb/yql/pgwrapper/pg_wrapper.cc
+++ b/src/yb/yql/pgwrapper/pg_wrapper.cc
@@ -479,7 +479,8 @@ DEFINE_NON_RUNTIME_string(pg_upgrade_working_dir, "",
     "Working directory for pg_upgrade. If empty, defaults to the pg_upgrade data directory.");
 
 DEFINE_NON_RUNTIME_PG_FLAG(bool, yb_enable_mage, false,
-                           "Enable the use of mage extension. NOTE: This is for internal use only.");
+                           "Enable the use of mage extension. "
+                           "NOTE: This is for internal use only.");
 TAG_FLAG(ysql_yb_enable_mage, hidden);
 
 using gflags::CommandLineFlagInfo;

--- a/src/yb/yql/pgwrapper/pg_wrapper.cc
+++ b/src/yb/yql/pgwrapper/pg_wrapper.cc
@@ -479,8 +479,7 @@ DEFINE_NON_RUNTIME_string(pg_upgrade_working_dir, "",
     "Working directory for pg_upgrade. If empty, defaults to the pg_upgrade data directory.");
 
 DEFINE_NON_RUNTIME_PG_FLAG(bool, yb_enable_mage, false,
-                           "Allow CREATE EXTENSION mage and preload mage into all backends. "
-                           "Takes effect on postmaster restart.");
+                           "Enable the use of mage extension. NOTE: This is for internal use only.");
 TAG_FLAG(ysql_yb_enable_mage, hidden);
 
 using gflags::CommandLineFlagInfo;


### PR DESCRIPTION
## Summary

- Adds the `ysql_yb_enable_mage` gFlag (default `false`) and matching
  `yb_enable_mage` GUC. Both are non-runtime / `PGC_POSTMASTER` and only
  take effect on postmaster restart.
- When the gFlag is enabled, `pg_wrapper.cc` appends `mage` to
  `shared_preload_libraries` so its hooks are installed in every backend
  (mirrors the `pg_cron` / `documentdb` pattern).
- When the GUC is disabled, `CreateExtension` in `extension.c` rejects
  `CREATE EXTENSION mage` outright, so a stray invocation can't lazy-load
  mage into a single backend and leave the cluster in an inconsistent
  hook state.
- Adds `ysql_yb_enable_mage=true` to
  `TestPgRegressThirdPartyExtensionsMage` so the regression suite still
  exercises mage end to end.

## Test plan

- [x] `./yb_build.sh release --java-test org.yb.pgsql.TestPgRegressThirdPartyExtensionsMage`
