### PR TITLE
Drop macOS branch in TablePartitionByCollationTextColumn

### DIFF
--- a/src/yb/yql/pgwrapper/pg_libpq-test.cc
+++ b/src/yb/yql/pgwrapper/pg_libpq-test.cc
@@ -5304,12 +5304,7 @@ CREATE TABLE t1_default PARTITION OF t1 DEFAULT;
   conn = ASSERT_RESULT(ConnectToDB("test_en_us_utf8_db"));
   result = ASSERT_RESULT(conn.FetchAllAsString("SELECT * FROM t1 ORDER BY region"));
   LOG(INFO) << "test_en_us_utf8_db result: " << result;
-  // MacOS and Linux have different sort order of en_US.UTF-8 collation.
-#if defined(__linux__)
   ASSERT_EQ(result, utf8_expected);
-#else
-  ASSERT_EQ(result, c_expected);
-#endif
   conn = ASSERT_RESULT(ConnectToDB("test_en_us_x_icu_db"));
   result = ASSERT_RESULT(conn.FetchAllAsString("SELECT * FROM t1 ORDER BY region"));
   LOG(INFO) << "test_en_us_x_icu_db result: " << result;


### PR DESCRIPTION
The test split its expectation for the en_US.UTF-8 database between
Linux (utf8_expected) and macOS (c_expected) on the assumption that
macOS libc would fall back to byte-order sorting for UTF-8 collation.

That's no longer the case on currently-supported macOS versions —
libc en_US.UTF-8 now produces the same sort order as Linux glibc and
as the ICU branch of the same test, so the macOS branch fails on
every modern macOS build.

Drop the platform check and assert utf8_expected unconditionally,
matching the ICU case three lines belo
