### PR TITLE
[#31329] DocDB: Update yb-admin master_leader_stepdown help syntax

### DIFF
--- a/src/yb/tools/yb-admin_cli.cc
+++ b/src/yb/tools/yb-admin_cli.cc
@@ -1133,7 +1133,7 @@ Status change_leader_blacklist_action(
   return ChangeBlacklist(client, args, true, "Unable to change leader blacklist");
 }
 
-const auto master_leader_stepdown_args = "[<dest_uuid>]";
+const auto master_leader_stepdown_args = "[<new_leader_id>]";
 Status master_leader_stepdown_action(
     const ClusterAdminCli::CLIArguments& args, ClusterAdminClient* client) {
   return MasterLeaderStepDown(client, args);


### PR DESCRIPTION
## Summary

- Updates the argument label shown in `yb-admin master_leader_stepdown` help/syntax output from `[<dest_uuid>]` to `[<new_leader_id>]`.
- The new label more accurately describes what the argument represents (the UUID of the master to become the new leader) and aligns with the [public documentation](https://docs.yugabyte.com/stable/admin/yb-admin/#master-leader-stepdown).

## Test plan

- [x] Run `yb-admin --help` and confirm the `master_leader_stepdown` syntax shows `[<new_leader_id>]`.
- [x] Existing `yb-admin-multi-master-test` coverage (`master_leader_stepdown` with and without an argument) continues to pass — only the help string was changed; behavior is unchanged.

Jira: [DB-21182](https://yugabyte.atlassian.net/browse/DB-21182)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DB-21182]: https://yugabyte.atlassian.net/browse/DB-21182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

Phorge: [D52626](https://phorge.dev.yugabyte.com/D52626)