### PR TITLE
[#26918] YSQL: Stop index backfill when the CREATE INDEX session is terminated

### DIFF
--- a/src/postgres/src/backend/commands/indexcmds.c
+++ b/src/postgres/src/backend/commands/indexcmds.c
@@ -2382,7 +2382,8 @@ YbDefineIndexHelper(Oid relationId,
 	 * YB: Do backfill if this is a separate DocDB table from the main
 	 * table.
 	 */
-	HandleYBStatus(YBCPgBackfillIndex(databaseId, indexRelationId));
+	HandleYBStatus(YBCPgBackfillIndex(databaseId, indexRelationId,
+									  !yb_should_run_in_autonomous_transaction));
 
 	Relation	yb_baserel = table_open(relationId, NoLock);
 

--- a/src/yb/client/client-internal.cc
+++ b/src/yb/client/client-internal.cc
@@ -990,6 +990,7 @@ Status YBClient::Data::BackfillIndex(YBClient* client,
                                      const YBTableName& index_name,
                                      const TableId& index_id,
                                      CoarseTimePoint deadline,
+                                     std::optional<TransactionMetadata> requester_transaction,
                                      bool wait) {
   BackfillIndexRequestPB req;
   BackfillIndexResponsePB resp;
@@ -999,6 +1000,9 @@ Status YBClient::Data::BackfillIndex(YBClient* client,
   }
   if (!index_id.empty()) {
     req.mutable_index_identifier()->set_table_id(index_id);
+  }
+  if (requester_transaction.has_value()) {
+    requester_transaction->ToPB(req.mutable_requester_transaction());
   }
 
   RETURN_NOT_OK((SyncLeaderMasterRpc(

--- a/src/yb/client/client-internal.h
+++ b/src/yb/client/client-internal.h
@@ -209,6 +209,7 @@ class YBClient::Data {
                        const YBTableName& table_name,
                        const TableId& table_id,
                        CoarseTimePoint deadline,
+                       std::optional<TransactionMetadata> requester_transaction,
                        bool wait = true);
   Status IsBackfillIndexInProgress(YBClient* client,
                                    const TableId& table_id,

--- a/src/yb/client/client.cc
+++ b/src/yb/client/client.cc
@@ -622,11 +622,14 @@ Status YBClient::TruncateTables(const TableIds& table_ids, bool wait) {
   return data_->TruncateTables(this, table_ids, deadline, wait);
 }
 
-Status YBClient::BackfillIndex(const TableId& table_id, bool wait, CoarseTimePoint deadline) {
+Status YBClient::BackfillIndex(const TableId& table_id,
+                               std::optional<TransactionMetadata> requester_transaction,
+                               bool wait, CoarseTimePoint deadline) {
   if (deadline == CoarseTimePoint()) {
     deadline = CoarseMonoClock::Now() + FLAGS_backfill_index_client_rpc_timeout_ms * 1ms;
   }
-  return data_->BackfillIndex(this, YBTableName(), table_id, deadline, wait);
+  return data_->BackfillIndex(
+      this, YBTableName(), table_id, deadline, std::move(requester_transaction), wait);
 }
 
 Status YBClient::GetIndexBackfillProgress(

--- a/src/yb/client/client.h
+++ b/src/yb/client/client.h
@@ -349,7 +349,10 @@ class YBClient {
 
   // Backfill the specified index table.  This is only supported for YSQL at the moment.
   Status BackfillIndex(
-      const TableId& table_id, bool wait = true, CoarseTimePoint deadline = CoarseTimePoint());
+      const TableId& table_id,
+      std::optional<TransactionMetadata> requester_transaction,
+      bool wait = true,
+      CoarseTimePoint deadline = CoarseTimePoint());
 
   Status GetIndexBackfillProgress(
       const TableIds& index_ids,

--- a/src/yb/master/backfill_index.cc
+++ b/src/yb/master/backfill_index.cc
@@ -119,6 +119,10 @@ DEFINE_test_flag(bool, skip_index_backfill, false,
 DEFINE_test_flag(bool, block_do_backfill, false,
     "Block DoBackfill from proceeding.");
 
+DEFINE_test_flag(bool, skip_ddl_requester_liveness_check, false,
+    "Skip starting the requester liveness task. Used in tests to simulate the pre-fix behavior "
+    "where master continues sending BackfillIndex RPCs after the backend is killed.");
+
 DEFINE_test_flag(bool, simulate_empty_indexes_during_backfill, false,
     "Simulates BackfillTable::indexes_to_build() to return an empty set.");
 
@@ -324,7 +328,8 @@ Status MultiStageAlterTable::StartBackfillingData(
     CatalogManager* catalog_manager,
     const scoped_refptr<TableInfo>& indexed_table,
     const std::vector<IndexInfoPB>& idx_infos,
-    std::optional<uint32_t> current_version, const LeaderEpoch& epoch) {
+    std::optional<uint32_t> current_version, const LeaderEpoch& epoch,
+    std::optional<TransactionMetadata> requester_transaction) {
   // We leave the table state as ALTERING so that a master failover can resume the backfill.
   RETURN_NOT_OK(ClearFullyAppliedAndUpdateState(
       catalog_manager, indexed_table, current_version, /* change_state to RUNNING */ false, epoch));
@@ -337,6 +342,14 @@ Status MultiStageAlterTable::StartBackfillingData(
   VLOG(0) << __func__ << " starting backfill on " << indexed_table->ToString() << " for "
           << yb::ToString(idx_infos);
 
+  // Retrieve the requester transaction if it was stored during the permission-update phase.
+  // Pass current_version so TakePendingBackfillRequesterTransaction rejects stale
+  // transactions from earlier backfill attempts.
+  if (!requester_transaction && current_version) {
+    requester_transaction =
+        indexed_table->TakePendingBackfillRequesterTransaction(*current_version);
+  }
+
   if (FLAGS_TEST_skip_index_backfill) {
     TRACE("Skipping backfill of data on tservers");
     LOG(INFO) << "Skipping backfill of data on tservers";
@@ -345,7 +358,7 @@ Status MultiStageAlterTable::StartBackfillingData(
 
   auto backfill_table = std::make_shared<BackfillTable>(
       catalog_manager->master_, catalog_manager->AsyncTaskPool(), indexed_table, idx_infos,
-      *ns_info, epoch);
+      *ns_info, epoch, std::move(requester_transaction));
   Status s = backfill_table->Launch();
   if (!s.ok()) {
     indexed_table->ClearIsBackfilling();
@@ -387,7 +400,8 @@ IndexPermissions NextPermission(IndexPermissions perm) {
 
 Status MultiStageAlterTable::LaunchNextTableInfoVersionIfNecessary(
     CatalogManager* catalog_manager, const scoped_refptr<TableInfo>& indexed_table,
-    uint32_t current_version, const LeaderEpoch& epoch, bool respect_backfill_deferrals,
+    uint32_t current_version, const LeaderEpoch& epoch,
+    std::optional<TransactionMetadata> requester_transaction, bool respect_backfill_deferrals,
     bool update_ysql_to_backfill) {
   DVLOG_WITH_FUNC(3)
       << Format("$0, version: $1, respect_deferrals: $2, update_ysql_to_backfill: $3",
@@ -502,6 +516,15 @@ Status MultiStageAlterTable::LaunchNextTableInfoVersionIfNecessary(
 
     if (permissions_updated.ok() && *permissions_updated) {
       VLOG(1) << "Sending alter table request with updated permissions";
+      // Store the requester transaction so StartBackfillingData can retrieve it when the
+      // permission change reaches DO_BACKFILL and the second call launches backfill.
+      // Store current_version+1 (the new version after this permission update)
+      // so TakePendingBackfillRequesterTransaction can verify the transaction
+      // belongs to this exact backfill attempt and not a stale one.
+      if (requester_transaction) {
+        indexed_table->SetPendingBackfillRequesterTransaction(
+            std::move(requester_transaction), current_version + 1);
+      }
       RETURN_NOT_OK(catalog_manager->SendAlterTableRequest(indexed_table, epoch));
       return Status::OK();
     }
@@ -530,7 +553,8 @@ Status MultiStageAlterTable::LaunchNextTableInfoVersionIfNecessary(
     }
     WARN_NOT_OK(
         StartBackfillingData(
-            catalog_manager, indexed_table.get(), indexes_to_backfill, current_version, epoch),
+            catalog_manager, indexed_table.get(), indexes_to_backfill, current_version, epoch,
+            std::move(requester_transaction)),
         yb::Format("Could not launch backfill for $0", indexed_table->ToString()));
   }
 
@@ -627,7 +651,7 @@ std::string RetrieveIndexNames(CatalogManager* mgr,
 BackfillTable::BackfillTable(
     Master* master, ThreadPool* callback_pool, const scoped_refptr<TableInfo>& indexed_table,
     std::vector<IndexInfoPB> indexes, const scoped_refptr<NamespaceInfo>& ns_info,
-    LeaderEpoch epoch)
+    LeaderEpoch epoch, std::optional<TransactionMetadata> requester_transaction)
     : master_(master),
       callback_pool_(callback_pool),
       indexed_table_(indexed_table),
@@ -637,7 +661,8 @@ BackfillTable::BackfillTable(
           RetrieveIndexNames(master->catalog_manager_impl(), requested_index_ids_)),
       ns_info_(ns_info),
       epoch_(std::move(epoch)),
-      wait_state_(ash::WaitStateInfo::CreateIfAshIsEnabled<ash::WaitStateInfo>()) {
+      wait_state_(ash::WaitStateInfo::CreateIfAshIsEnabled<ash::WaitStateInfo>()),
+      requester_transaction_(std::move(requester_transaction)) {
   if (wait_state_) {
     if (const auto& current_state = ash::WaitStateInfo::CurrentWaitState()) {
       wait_state_->UpdateMetadata(current_state->metadata());
@@ -951,6 +976,7 @@ Status BackfillTable::DoLaunchBackfill() {
 }
 
 Status BackfillTable::DoBackfill() {
+  StartRequesterLivenessMonitor();
   while (FLAGS_TEST_block_do_backfill) {
     constexpr auto kSpinWait = 100ms;
     LOG(INFO) << Format("Blocking $0 for $1", __func__, kSpinWait);
@@ -982,8 +1008,12 @@ Status BackfillTable::Done(const Status& s, const std::unordered_set<TableId>& f
 
   // If OK then move on to READ permissions.
   if (!done() && --tablets_pending_ == 0) {
+    bool expected = false;
+    if (!done_.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
+      return Status::OK();
+    }
     LOG_WITH_PREFIX(INFO) << "Completed backfilling the index table.";
-    done_.store(true, std::memory_order_release);
+    StopLivenessMonitor();
     RETURN_NOT_OK_PREPEND(
         MarkAllIndexesAsSuccess(), "Failed to mark indexes as successfully backfilled.");
     RETURN_NOT_OK_PREPEND(UpdateIndexPermissionsForIndexes(), "Failed to complete backfill.");
@@ -997,6 +1027,7 @@ Status BackfillTable::MarkIndexesAsFailed(
     const std::unordered_set<TableId>& failed_indexes, const string& message) {
   if (indexes_to_build() == failed_indexes) {
     done_.store(true, std::memory_order_release);
+    StopLivenessMonitor();
     backfill_job_->SetState(MonitoredTaskState::kFailed);
   }
   return MarkIndexesAsDesired(failed_indexes, BackfillJobPB::FAILED, message);
@@ -1077,15 +1108,71 @@ Status BackfillTable::MarkIndexesAsDesired(
   return Status::OK();
 }
 
-Status BackfillTable::Abort() {
+void BackfillTable::StartRequesterLivenessMonitor() {
+  if (!requester_transaction_) {
+      return;
+  }
+  if (PREDICT_FALSE(FLAGS_TEST_skip_ddl_requester_liveness_check)) {
+    LOG_WITH_PREFIX(INFO) << "Skipping requester liveness monitor (TEST flag set)";
+    return;
+  }
+  VLOG_WITH_PREFIX(1) << "Starting requester liveness monitor for transaction "
+                      << requester_transaction_->transaction_id;
+
+  auto self = shared_from_this();
+  BackgroundDdlCallbacks callbacks{
+      .done_ = [self] { return self->done(); },
+      .abort_ = [self]() { return self->Abort(true); },
+  };
+  auto task = DdlRequesterLivenessTask::CreateAndStartTask(
+      *master_->catalog_manager_impl(),
+      indexed_table_,
+      *requester_transaction_,
+      std::move(callbacks),
+      master_->client_future(),
+      *master_->messenger(),
+      epoch_);
+
+  std::lock_guard l(mutex_);
+  DCHECK(!liveness_task_.lock()) << "Liveness task already exists";
+  liveness_task_ = task;
+}
+
+void BackfillTable::StopLivenessMonitor() {
+  std::shared_ptr<DdlRequesterLivenessTask> task;
+  {
+    std::lock_guard l(mutex_);
+    task = liveness_task_.lock();
+    liveness_task_.reset();
+  }
+  if (task) {
+    task->AbortAndReturnPrevState(STATUS(Aborted, "BackfillTable is done"));
+  }
+}
+
+Status BackfillTable::Abort(bool from_liveness) {
+  bool expected = false;
+  if (!done_.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
+    return Status::OK();
+  }
+  if (from_liveness) {
+    // clear liveness_task_ the subsequent StopLivenessMonitor()
+    // call inside MarkIndexesAsFailed will then be a no-op.
+    std::lock_guard l(mutex_);
+    liveness_task_.reset();
+  } else {
+    StopLivenessMonitor();
+  }
   LOG(WARNING) << "Backfill failed/aborted.";
   RETURN_NOT_OK(MarkAllIndexesAsFailed());
+  master_->catalog_manager_impl()->IncrementBackfillAborted();
   return CheckIfDone();
 }
 
 Status BackfillTable::CheckIfDone() {
   if (indexes_to_build().empty()) {
     done_.store(true, std::memory_order_release);
+    StopLivenessMonitor();
     RETURN_NOT_OK_PREPEND(
         UpdateIndexPermissionsForIndexes(),
         "Could not update index permissions after backfill");

--- a/src/yb/master/backfill_index.cc
+++ b/src/yb/master/backfill_index.cc
@@ -685,7 +685,7 @@ BackfillTable::BackfillTable(
     read_time_for_backfill_ = HybridTime::kInvalid;
     timestamp_chosen_.store(false, std::memory_order_release);
   }
-  done_.store(false, std::memory_order_release);
+  state_.store(State::kRunning, std::memory_order_release);
 }
 
 const std::unordered_set<TableId> BackfillTable::indexes_to_build() const {
@@ -1008,8 +1008,9 @@ Status BackfillTable::Done(const Status& s, const std::unordered_set<TableId>& f
 
   // If OK then move on to READ permissions.
   if (!done() && --tablets_pending_ == 0) {
-    bool expected = false;
-    if (!done_.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
+    State expected = State::kRunning;
+    if (!state_.compare_exchange_strong(
+            expected, State::kSuccess, std::memory_order_acq_rel)) {
       return Status::OK();
     }
     LOG_WITH_PREFIX(INFO) << "Completed backfilling the index table.";
@@ -1026,7 +1027,7 @@ Status BackfillTable::Done(const Status& s, const std::unordered_set<TableId>& f
 Status BackfillTable::MarkIndexesAsFailed(
     const std::unordered_set<TableId>& failed_indexes, const string& message) {
   if (indexes_to_build() == failed_indexes) {
-    done_.store(true, std::memory_order_release);
+    state_.store(State::kFailed, std::memory_order_release);
     StopLivenessMonitor();
     backfill_job_->SetState(MonitoredTaskState::kFailed);
   }
@@ -1151,8 +1152,9 @@ void BackfillTable::StopLivenessMonitor() {
 }
 
 Status BackfillTable::Abort(bool from_liveness) {
-  bool expected = false;
-  if (!done_.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
+  State expected = State::kRunning;
+  if (!state_.compare_exchange_strong(
+          expected, State::kFailed, std::memory_order_acq_rel)) {
     return Status::OK();
   }
   if (from_liveness) {
@@ -1171,8 +1173,8 @@ Status BackfillTable::Abort(bool from_liveness) {
 
 Status BackfillTable::CheckIfDone() {
   if (indexes_to_build().empty()) {
-    done_.store(true, std::memory_order_release);
-    StopLivenessMonitor();
+    DCHECK(state() != State::kRunning)
+        << "CheckIfDone expects callers to transition state out of kRunning before invocation";
     RETURN_NOT_OK_PREPEND(
         UpdateIndexPermissionsForIndexes(),
         "Could not update index permissions after backfill");

--- a/src/yb/master/backfill_index.h
+++ b/src/yb/master/backfill_index.h
@@ -27,6 +27,7 @@
 
 #include "yb/ash/wait_state.h"
 #include "yb/common/entity_ids.h"
+#include "yb/common/transaction.h"
 #include "yb/dockv/partition.h"
 
 #include "yb/gutil/integral_types.h"
@@ -34,6 +35,7 @@
 
 #include "yb/master/async_rpc_tasks_base.h"
 #include "yb/master/catalog_entity_info.h"
+#include "yb/master/ysql_ddl_verification_task.h"
 
 #include "yb/qlexpr/index.h"
 
@@ -67,7 +69,9 @@ class MultiStageAlterTable {
   // INDEX_PERM_DELETE_ONLY -> INDEX_PERM_WRITE_AND_DELETE -> BACKFILL
   static Status LaunchNextTableInfoVersionIfNecessary(
       CatalogManager* mgr, const scoped_refptr<TableInfo>& Info, uint32_t current_version,
-      const LeaderEpoch& epoch, bool respect_backfill_deferrals = true,
+      const LeaderEpoch& epoch,
+      std::optional<TransactionMetadata> requester_transaction,
+      bool respect_backfill_deferrals = true,
       bool update_ysql_to_backfill = false);
 
   // Clears the fully_applied_* state for the given table and optionally sets it to RUNNING.
@@ -94,10 +98,13 @@ class MultiStageAlterTable {
 
  private:
   // Start Index Backfill process/step for the specified table/index.
+  // If requester_transaction is provided it will be used to monitor the liveness of the
+  // PG backend that initiated the backfill.
   static Status StartBackfillingData(
       CatalogManager* catalog_manager, const scoped_refptr<TableInfo>& indexed_table,
       const std::vector<IndexInfoPB>& idx_infos, std::optional<uint32_t> expected_version,
-      const LeaderEpoch& epoch);
+      const LeaderEpoch& epoch,
+      std::optional<TransactionMetadata> requester_transaction);
 };
 
 class BackfillTablet;
@@ -112,7 +119,8 @@ class BackfillTable : public std::enable_shared_from_this<BackfillTable> {
                 const scoped_refptr<TableInfo> &indexed_table,
                 std::vector<IndexInfoPB> indexes,
                 const scoped_refptr<NamespaceInfo> &ns_info,
-                LeaderEpoch epoch);
+                LeaderEpoch epoch,
+                std::optional<TransactionMetadata> requester_transaction);
 
   Status Launch();
 
@@ -169,6 +177,8 @@ class BackfillTable : public std::enable_shared_from_this<BackfillTable> {
 
   static void UnsetIndexTableRetainsDeleteMarkers(PersistentTableInfo* index_table);
 
+  Status Abort(bool from_liveness = false);
+
  private:
   void LaunchBackfillOrAbort();
   Status WaitForTabletSplitting();
@@ -188,7 +198,8 @@ class BackfillTable : public std::enable_shared_from_this<BackfillTable> {
   Status AlterTableStateToAbort();
   Status AlterTableStateToSuccess();
 
-  Status Abort();
+  void StartRequesterLivenessMonitor();
+  void StopLivenessMonitor();
   Status CheckIfDone();
   Status UpdateIndexPermissionsForIndexes();
   Status ClearCheckpointStateInTablets();
@@ -230,7 +241,10 @@ class BackfillTable : public std::enable_shared_from_this<BackfillTable> {
   const scoped_refptr<NamespaceInfo> ns_info_;
   LeaderEpoch epoch_;
   ash::WaitStateInfoPtr wait_state_;
+  std::optional<TransactionMetadata> requester_transaction_;
+  std::weak_ptr<DdlRequesterLivenessTask> liveness_task_ GUARDED_BY(mutex_);
 };
+
 
 class BackfillTableJob : public server::MonitoredTask {
  public:

--- a/src/yb/master/backfill_index.h
+++ b/src/yb/master/backfill_index.h
@@ -140,8 +140,18 @@ class BackfillTable : public std::enable_shared_from_this<BackfillTable> {
 
   std::string description() const;
 
+  enum class State : uint8_t {
+    kRunning,
+    kSuccess,
+    kFailed,
+  };
+
+  State state() const {
+    return state_.load(std::memory_order_acquire);
+  }
+
   bool done() const {
-    return done_.load(std::memory_order_acquire);
+    return state() != State::kRunning;
   }
 
   bool timestamp_chosen() const {
@@ -227,7 +237,7 @@ class BackfillTable : public std::enable_shared_from_this<BackfillTable> {
   const std::vector<IndexInfoPB> index_infos_;
   int32_t schema_version_;
 
-  std::atomic_bool done_{false};
+  std::atomic<State> state_{State::kRunning};
   std::atomic_bool timestamp_chosen_{false};
   std::atomic<size_t> tablets_pending_;
   std::atomic<size_t> num_tablets_;

--- a/src/yb/master/catalog_entity_info.h
+++ b/src/yb/master/catalog_entity_info.h
@@ -874,6 +874,30 @@ class TableInfo : public RefCountedThreadSafe<TableInfo>,
     is_backfilling_ = false;
   }
 
+  // Store/retrieve the DDL transaction from the PG backend that initiated the backfill.
+  // Stored when CatalogManager::BackfillIndex moves the index from WRITE_AND_DELETE to
+  // DO_BACKFILL; retrieved when StartBackfillingData actually creates the BackfillTable.
+  // schema_version must be the table version produced by the permission update (current + 1).
+  void SetPendingBackfillRequesterTransaction(
+      std::optional<TransactionMetadata> txn, uint32_t schema_version) {
+    std::lock_guard l(lock_);
+    pending_backfill_requester_transaction_ = std::move(txn);
+    pending_backfill_requester_transaction_version_ = schema_version;
+  }
+
+  // Returns the stored transaction and clears it, but only if schema_version matches the value
+  // passed to SetPendingBackfillRequesterTransaction.  Returns nullopt otherwise so that a stale
+  // transaction from an earlier backfill attempt is never used for a later one.
+  std::optional<TransactionMetadata> TakePendingBackfillRequesterTransaction(
+      uint32_t schema_version) {
+    std::lock_guard l(lock_);
+    if (!pending_backfill_requester_transaction_ ||
+        pending_backfill_requester_transaction_version_ != schema_version) {
+      return std::nullopt;
+    }
+    return std::exchange(pending_backfill_requester_transaction_, std::nullopt);
+  }
+
   // Returns true if an "Alter" operation is in-progress.
   Result<bool> IsAlterInProgress(uint32_t version) const;
 
@@ -996,6 +1020,12 @@ class TableInfo : public RefCountedThreadSafe<TableInfo>,
   bool is_backfilling_ = false;
 
   TransactionId exclude_aborting_transaction_id_ GUARDED_BY(lock_) {TransactionId::Nil()};
+
+  // DDL transaction from the PG backend that initiated the backfill, and the table schema version
+  // at which it was stored. Set when BackfillIndex updates permissions (WRITE_AND_DELETE ->
+  // DO_BACKFILL) and cleared when StartBackfillingData creates the BackfillTable.
+  std::optional<TransactionMetadata> pending_backfill_requester_transaction_ GUARDED_BY(lock_);
+  uint32_t pending_backfill_requester_transaction_version_ GUARDED_BY(lock_) = 0;
 
   std::atomic<bool> is_system_{false};
 

--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -548,6 +548,11 @@ METRIC_DEFINE_counter(cluster, create_table_too_many_tablets,
     "How many CreateTable requests have failed due to too many tablets", yb::MetricUnit::kRequests,
     "The number of CreateTable request errors due to attempting to create too many tablets.");
 
+METRIC_DEFINE_counter(cluster, backfill_aborted,
+    "Number of index backfills aborted on the master",
+    yb::MetricUnit::kRequests,
+    "Counts BackfillTable::Abort invocations on the master.");
+
 DEFINE_test_flag(bool, duplicate_addtabletotablet_request, false,
                  "Send a duplicate AddTableToTablet request to the tserver to simulate a retry.");
 
@@ -1129,6 +1134,9 @@ Status CatalogManager::Init() {
 
   metric_create_table_too_many_tablets_ =
       METRIC_create_table_too_many_tablets.Instantiate(master_->metric_entity_cluster());
+
+  metric_backfill_aborted_ =
+      METRIC_backfill_aborted.Instantiate(master_->metric_entity_cluster());
 
   metric_max_follower_heartbeat_delay_ =
     METRIC_max_follower_heartbeat_delay.Instantiate(master_->metric_entity_cluster(), 0);
@@ -6644,9 +6652,19 @@ Status CatalogManager::BackfillIndex(
             IndexPermissions_Name(index_info_pb.index_permissions())));
   }
 
+  std::optional<TransactionMetadata> requester_txn;
+  if (req->has_requester_transaction()) {
+    auto result = TransactionMetadata::FromPB(req->requester_transaction());
+    if (result.ok()) {
+      requester_txn = std::move(*result);
+    } else {
+      LOG(WARNING) << "BackfillIndex: failed to decode requester transaction: " << result.status();
+    }
+  }
+
   return MultiStageAlterTable::LaunchNextTableInfoVersionIfNecessary(
-      this, indexed_table, current_version, epoch, /* respect deferrals for backfill */ false,
-      /* update ysql to backfill */ true);
+      this, indexed_table, current_version, epoch, std::move(requester_txn),
+      /* respect_backfill_deferrals */ false, /* update_ysql_to_backfill */ true);
 }
 
 Status CatalogManager::GetBackfillJobs(
@@ -6823,7 +6841,8 @@ Status CatalogManager::LaunchBackfillIndexForTable(
   }
 
   auto s = MultiStageAlterTable::LaunchNextTableInfoVersionIfNecessary(
-      this, indexed_table, current_version, epoch, /* respect deferrals for backfill */ false);
+      this, indexed_table, current_version, epoch, std::nullopt,
+      /* respect_backfill_deferrals */ false);
   if (!s.ok()) {
     VLOG(3) << __func__ << " Done failed " << s;
     return SetupError(resp->mutable_error(), MasterErrorPB::UNKNOWN_ERROR, s);
@@ -11132,6 +11151,10 @@ Status CatalogManager::UpdateMastersListInMemoryAndDisk() {
   return Status::OK();
 }
 
+void CatalogManager::IncrementBackfillAborted() {
+  IncrementCounter(metric_backfill_aborted_);
+}
+
 Status CatalogManager::EnableBgTasks() {
   LockGuard lock(mutex_);
   background_tasks_.reset(new CatalogManagerBgTasks(master_));
@@ -11840,7 +11863,8 @@ Status CatalogManager::HandleTabletSchemaVersionReport(
         table->id(), table->EraseDdlTxnForRollbackToSubTxnWaitingForSchemaVersion(version));
   }
 
-  return MultiStageAlterTable::LaunchNextTableInfoVersionIfNecessary(this, table, version, epoch);
+  return MultiStageAlterTable::LaunchNextTableInfoVersionIfNecessary(
+      this, table, version, epoch, std::nullopt);
 }
 
 Status CatalogManager::ProcessPendingAssignmentsPerTable(

--- a/src/yb/master/catalog_manager.h
+++ b/src/yb/master/catalog_manager.h
@@ -1885,6 +1885,8 @@ class CatalogManager : public CatalogManagerIf, public SnapshotCoordinatorContex
       const GetYsqlYbSystemTableInfoRequestPB* req, GetYsqlYbSystemTableInfoResponsePB* resp,
       rpc::RpcContext* rpc);
 
+  void IncrementBackfillAborted();
+
  protected:
   // TODO Get rid of these friend classes and introduce formal interface.
   friend class TableLoader;
@@ -2582,6 +2584,8 @@ class CatalogManager : public CatalogManagerIf, public SnapshotCoordinatorContex
   scoped_refptr<AtomicGauge<uint32_t>> metric_num_tablet_servers_dead_;
 
   scoped_refptr<Counter> metric_create_table_too_many_tablets_;
+
+  scoped_refptr<Counter> metric_backfill_aborted_;
 
   scoped_refptr<AtomicGauge<uint64_t>> metric_max_follower_heartbeat_delay_;
 

--- a/src/yb/master/master_ddl.proto
+++ b/src/yb/master/master_ddl.proto
@@ -324,6 +324,9 @@ message IsTruncateTableDoneResponsePB {
 message BackfillIndexRequestPB {
   // The index to backfill. Used for YSQL
   optional TableIdentifierPB index_identifier = 1;
+  // The DDL transaction held by the CREATE INDEX backend. If this transaction is detected as
+  // ABORTED (e.g. pg_terminate_backend killed the session), the master will stop the backfill.
+  optional TransactionMetadataPB requester_transaction = 2;
 }
 
 message BackfillIndexResponsePB {

--- a/src/yb/master/ysql_ddl_verification_task.cc
+++ b/src/yb/master/ysql_ddl_verification_task.cc
@@ -55,6 +55,10 @@ DEFINE_test_flag(bool, yb_test_table_rewrite_keep_old_table, false,
     "concurrent DMLs. If the table is dropped too soon, we will just get a "
     "table does not exist error instead.");
 
+DEFINE_RUNTIME_int32(ddl_requester_liveness_check_interval_secs, 10,
+    "Interval in seconds between liveness checks for a background DDL operation's initiating "
+    "transaction. If the transaction is detected as aborted, the background operation is stopped.");
+
 using std::string;
 using std::vector;
 
@@ -674,7 +678,11 @@ void PollTransactionStatusBase::TransactionReceived(
   // Determine whether the transaction was a success by comparing with the PG schema.
   LOG_WITH_PREFIX(INFO) << "Txn reached terminal state, " << transaction_
                         << ", resp: " << resp.ShortDebugString();
-  FinishPollTransaction();
+
+  // GetTransactionStatus is only called from VerifyTransaction.
+  // VerifyTransaction adds only one transaction id to the request.
+  bool aborted = (resp.status_size() > 0 && resp.status(0) == TransactionStatus::ABORTED);
+  FinishPollTransaction(aborted);
 }
 
 NamespaceVerificationTask::NamespaceVerificationTask(
@@ -729,7 +737,7 @@ void NamespaceVerificationTask::TransactionPending() {
   }, "VerifyTransaction");
 }
 
-void NamespaceVerificationTask::FinishPollTransaction() {
+void NamespaceVerificationTask::FinishPollTransaction(bool /*aborted*/) {
   ScheduleNextStep(
     std::bind(&NamespaceVerificationTask::CheckNsExists, this),
     "CheckNsExists");
@@ -840,7 +848,7 @@ Status TableSchemaVerificationTask::ValidateRunnable() {
   return Status::OK();
 }
 
-void TableSchemaVerificationTask::FinishPollTransaction() {
+void TableSchemaVerificationTask::FinishPollTransaction(bool /*aborted*/) {
   ScheduleNextStep([this] {
     return ddl_atomicity_enabled_ ? CompareSchema() : CheckTableExists();
   }, "Compare Schema");
@@ -894,6 +902,104 @@ void TableSchemaVerificationTask::TaskCompleted(const Status& status) {
 void TableSchemaVerificationTask::PerformAbort() {
   MultiStepTableTaskBase::PerformAbort();
   Shutdown();
+}
+
+// --- DdlRequesterLivenessTask ---
+
+DdlRequesterLivenessTask::DdlRequesterLivenessTask(
+    CatalogManager& catalog_manager,
+    scoped_refptr<TableInfo> table,
+    const TransactionMetadata& transaction,
+    BackgroundDdlCallbacks callbacks,
+    std::shared_future<client::YBClient*> client_future,
+    rpc::Messenger& messenger,
+    const LeaderEpoch& epoch)
+    : MultiStepTableTaskBase(
+          catalog_manager, *catalog_manager.AsyncTaskPool(), messenger, std::move(table), epoch),
+      PollTransactionStatusBase(transaction, std::move(client_future), table_info_->ToString()),
+      callbacks_(std::move(callbacks)) {}
+
+std::shared_ptr<DdlRequesterLivenessTask> DdlRequesterLivenessTask::CreateAndStartTask(
+    CatalogManager& catalog_manager,
+    scoped_refptr<TableInfo> table,
+    const TransactionMetadata& transaction,
+    BackgroundDdlCallbacks callbacks,
+    std::shared_future<client::YBClient*> client_future,
+    rpc::Messenger& messenger,
+    const LeaderEpoch& epoch) {
+  auto task = std::make_shared<DdlRequesterLivenessTask>(
+      catalog_manager, std::move(table), transaction, std::move(callbacks),
+      std::move(client_future), messenger, epoch);
+  task->Start();
+  return task;
+}
+
+std::string DdlRequesterLivenessTask::description() const {
+  return Format("DdlRequesterLivenessTask for $0", table_info_->id());
+}
+
+Status DdlRequesterLivenessTask::FirstStep() {
+  ScheduleNextStepWithDelay(
+      [this] { return VerifyTransaction(); }, "VerifyTransaction",
+      MonoDelta::FromSeconds(FLAGS_ddl_requester_liveness_check_interval_secs));
+  return Status::OK();
+}
+
+void DdlRequesterLivenessTask::TransactionPending() {
+  if (callbacks_.done_()) {
+    // We're inside the GetTransactionStatus RPC callback. Calling Complete() directly here
+    // would deadlock: Complete() -> TaskCompleted() -> Shutdown() -> sync_.Wait() blocks
+    // because the callback's user_cb (which signals sync_) hasn't fired yet.
+    // Schedule asynchronously so user_cb fires first.
+    ScheduleNextStep(
+        [this] {
+          Complete();
+          return Status::OK();
+        },
+        "CompleteLivenessTask");
+    return;
+  }
+  ScheduleNextStepWithDelay(
+      [this] { return VerifyTransaction(); }, "VerifyTransaction",
+      MonoDelta::FromSeconds(FLAGS_ddl_requester_liveness_check_interval_secs));
+}
+
+void DdlRequesterLivenessTask::FinishPollTransaction(bool aborted) {
+  // We're inside the GetTransactionStatus RPC callback. Calling Complete() directly here
+  // would deadlock: Complete() -> TaskCompleted() -> Shutdown() -> sync_.Wait() blocks
+  // because the callback's user_cb (which signals sync_) hasn't fired yet.
+  // Schedule asynchronously so user_cb fires first.
+  ScheduleNextStep(
+      [this, aborted] {
+        Complete();
+        if (aborted && !callbacks_.done_()) {
+          LOG(INFO) << "DdlRequesterLivenessTask: requester transaction aborted for "
+                    << table_info_->id() << ", aborting background DDL operation";
+          auto s = callbacks_.abort_();
+          if (!s.ok()) {
+            LOG(ERROR) << "Failed to abort background DDL operation for table "
+                       << table_info_->id() << " after requester death: " << s;
+          }
+        }
+        return Status::OK();
+      },
+      "CompleteLivenessTask");
+}
+
+void DdlRequesterLivenessTask::TaskCompleted(const Status& status) {
+  Shutdown();
+}
+
+Status DdlRequesterLivenessTask::ValidateRunnable() {
+  if (callbacks_.done_()) {
+    return STATUS(Aborted, "Background DDL operation is done, stopping liveness monitor");
+  }
+  return Status::OK();
+}
+
+void DdlRequesterLivenessTask::PerformAbort() {
+  MultiStepTableTaskBase::PerformAbort();  // Cancels the reactor-scheduled poll timer.
+  Shutdown();  // Cancels any in-flight GetTransactionStatus RPC.
 }
 
 }  // namespace master

--- a/src/yb/master/ysql_ddl_verification_task.h
+++ b/src/yb/master/ysql_ddl_verification_task.h
@@ -65,6 +65,15 @@ namespace master {
  * or use DDL entities created by uncommitted transactions.
  */
 
+// Callbacks for DdlRequesterLivenessTask to interact with the background DDL operation
+// (e.g. BackfillTable) that it is monitoring.
+struct BackgroundDdlCallbacks {
+  // Returns true when the operation has completed and no further polling is needed.
+  std::function<bool()> done_;
+  // Cancels the operation. Called when the initiating PG backend is detected as killed.
+  std::function<Status()> abort_;
+};
+
 // Helper class that encapsulates the logic to poll the transaction status.
 class PollTransactionStatusBase {
  public:
@@ -77,7 +86,7 @@ class PollTransactionStatusBase {
  protected:
   Status VerifyTransaction();
   virtual void TransactionPending() = 0;
-  virtual void FinishPollTransaction() = 0;
+  virtual void FinishPollTransaction(bool aborted) = 0;
   void Shutdown();
   std::string LogPrefix() const;
 
@@ -136,7 +145,7 @@ class NamespaceVerificationTask : public MultiStepNamespaceTaskBase,
   Status FirstStep() override;
   void TransactionPending() override;
   Status ValidateRunnable() override;
-  void FinishPollTransaction() override;
+  void FinishPollTransaction(bool aborted) override;
   Status CheckNsExists();
   void TaskCompleted(const Status& status) override;
   void PerformAbort() override;
@@ -189,13 +198,53 @@ class TableSchemaVerificationTask : public MultiStepTableTaskBase,
   Status CheckTableExists();
   Status CompareSchema();
   Status FinishTask(Result<std::optional<bool>> is_committed);
-  void FinishPollTransaction() override;
+  void FinishPollTransaction(bool aborted) override;
   void TaskCompleted(const Status& status) override;
   void PerformAbort() override;
 
   SysCatalogTable& sys_catalog_;
   bool ddl_atomicity_enabled_;
   std::optional<bool> is_committed_{std::nullopt};
+};
+
+// Periodically polls a DDL backend's transaction and calls BackgroundDdlCallbacks::abort
+// when the transaction is detected as ABORTED (e.g. pg_terminate_backend killed the session).
+// Can be attached to any long-running background DDL operation.
+class DdlRequesterLivenessTask : public MultiStepTableTaskBase,
+                                 public PollTransactionStatusBase {
+ public:
+  static std::shared_ptr<DdlRequesterLivenessTask> CreateAndStartTask(
+        CatalogManager& catalog_manager,
+        scoped_refptr<TableInfo> table,
+        const TransactionMetadata& transaction,
+        BackgroundDdlCallbacks callbacks,
+        std::shared_future<client::YBClient*> client_future,
+        rpc::Messenger& messenger,
+        const LeaderEpoch& epoch);
+  DdlRequesterLivenessTask(
+      CatalogManager& catalog_manager,
+      scoped_refptr<TableInfo> table,
+      const TransactionMetadata& transaction,
+      BackgroundDdlCallbacks callbacks,
+      std::shared_future<client::YBClient*> client_future,
+      rpc::Messenger& messenger,
+      const LeaderEpoch& epoch);
+
+  server::MonitoredTaskType type() const override {
+    return server::MonitoredTaskType::kDdlRequesterLiveness;
+  }
+  std::string type_name() const override { return "DdlRequesterLivenessTask"; }
+  std::string description() const override;
+
+ private:
+  Status FirstStep() override;
+  void TransactionPending() override;
+  void FinishPollTransaction(bool aborted) override;
+  void TaskCompleted(const Status& status) override;
+  Status ValidateRunnable() override;
+  void PerformAbort() override;
+
+  BackgroundDdlCallbacks callbacks_;
 };
 
 }  // namespace master

--- a/src/yb/server/monitored_task.h
+++ b/src/yb/server/monitored_task.h
@@ -70,6 +70,7 @@ YB_DEFINE_ENUM(MonitoredTaskType,
   (kClonePgSchema)
   (kCloneTablet)
   (kCreateReplica)
+  (kDdlRequesterLiveness)
   (kDeleteReplica)
   (kEnableDbConns)
   (kFlushTablets)

--- a/src/yb/tserver/pg_client.proto
+++ b/src/yb/tserver/pg_client.proto
@@ -254,6 +254,10 @@ message PgBackfillIndexRequestPB {
   uint64 session_id = 1;
   PgObjectIdPB table_id = 2;
   reserved 3; // ASH metadata is now passed in RequestHeader PB
+  // When transactional DDL is enabled (ysql_yb_ddl_transaction_block_enabled), the CREATE INDEX
+  // backend uses the kPlain session transaction rather than an autonomous kDDL transaction.
+  // This flag must match the DDL mode so GetDdlTransactionMetadata fetches from the right txn.
+  bool use_regular_transaction_block = 4;
 }
 
 message PgBackfillIndexResponsePB {

--- a/src/yb/tserver/pg_client_session.cc
+++ b/src/yb/tserver/pg_client_session.cc
@@ -2052,9 +2052,22 @@ class PgClientSession::Impl {
   Status BackfillIndex(
       const PgBackfillIndexRequestPB& req, PgBackfillIndexResponsePB* resp,
       rpc::RpcContext* context) {
+    // The PG backend holds a DDL transaction open for the entire backfill duration
+    // (StartTransactionCommand at indexcmds.c:2334). Pass it to the master so it can detect when
+    // this backend is killed (-> txn aborted) and stop launching new backfill chunks.
+    auto meta = GetDdlTransactionMetadata(
+        true /* use_transaction */, req.use_regular_transaction_block(),
+        context->GetClientDeadline(), IsTxnUsingTableLocks(false));
+    std::optional<TransactionMetadata> txn_metadata;
+    if (!meta.ok()) {
+      LOG(WARNING) << "BackfillIndex: failed to get DDL transaction metadata: " << meta.status();
+    } else if (*meta) {
+      txn_metadata = **meta;
+    }
     return client_.BackfillIndex(
-        PgObjectId::GetYbTableIdFromPB(req.table_id()), /* wait= */ true,
-        context->GetClientDeadline());
+        PgObjectId::GetYbTableIdFromPB(req.table_id()),
+        std::move(txn_metadata),
+        /* wait= */ true, context->GetClientDeadline());
   }
 
   Status CreateTablegroup(

--- a/src/yb/yql/pggate/pggate.cc
+++ b/src/yb/yql/pggate/pggate.cc
@@ -1420,9 +1420,10 @@ Result<int> PgApiImpl::WaitForBackendsCatalogVersion(PgOid dboid, uint64_t versi
         + FLAGS_wait_for_ysql_backends_catalog_version_client_master_rpc_margin_ms));
 }
 
-Status PgApiImpl::BackfillIndex(const PgObjectId& table_id) {
+Status PgApiImpl::BackfillIndex(const PgObjectId& table_id, bool use_regular_transaction_block) {
   tserver::PgBackfillIndexRequestPB req;
   table_id.ToPB(req.mutable_table_id());
+  req.set_use_regular_transaction_block(use_regular_transaction_block);
   return pg_client_.BackfillIndex(
       &req, CoarseMonoClock::Now() + FLAGS_backfill_index_client_rpc_timeout_ms * 1ms);
 }

--- a/src/yb/yql/pggate/pggate.h
+++ b/src/yb/yql/pggate/pggate.h
@@ -432,7 +432,7 @@ class PgApiImpl {
 
   Result<int> WaitForBackendsCatalogVersion(PgOid dboid, uint64_t version, pid_t pid);
 
-  Status BackfillIndex(const PgObjectId& table_id);
+  Status BackfillIndex(const PgObjectId& table_id, bool use_regular_transaction_block);
   Status WaitVectorIndexReady(const PgObjectId& table_id);
 
   Status NewDropSequence(const YbcPgOid database_oid,

--- a/src/yb/yql/pggate/ybc_pggate.cc
+++ b/src/yb/yql/pggate/ybc_pggate.cc
@@ -1377,9 +1377,10 @@ YbcStatus YBCPgWaitForBackendsCatalogVersion(YbcPgOid dboid, uint64_t version, p
 
 YbcStatus YBCPgBackfillIndex(
     const YbcPgOid database_oid,
-    const YbcPgOid index_oid) {
+    const YbcPgOid index_oid,
+    bool use_regular_transaction_block) {
   const PgObjectId index_id(database_oid, index_oid);
-  return ToYBCStatus(pgapi->BackfillIndex(index_id));
+  return ToYBCStatus(pgapi->BackfillIndex(index_id, use_regular_transaction_block));
 }
 
 YbcStatus YBCPgWaitVectorIndexReady(

--- a/src/yb/yql/pggate/ybc_pggate.h
+++ b/src/yb/yql/pggate/ybc_pggate.h
@@ -480,7 +480,8 @@ YbcStatus YBCPgWaitForBackendsCatalogVersion(
 
 YbcStatus YBCPgBackfillIndex(
     const YbcPgOid database_oid,
-    const YbcPgOid index_relfilenode_oid);
+    const YbcPgOid index_relfilenode_oid,
+    bool use_regular_transaction_block);
 
 YbcStatus YBCPgWaitVectorIndexReady(
     const YbcPgOid database_oid,

--- a/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
+++ b/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
@@ -46,6 +46,9 @@
 #include "yb/yql/pgwrapper/libpq_utils.h"
 #include "yb/yql/pgwrapper/pg_test_utils.h"
 
+METRIC_DECLARE_entity(cluster);
+METRIC_DECLARE_counter(backfill_aborted);
+
 using std::string;
 
 using namespace std::chrono_literals;
@@ -290,6 +293,12 @@ Result<int> TotalBackfillRpcMetric(ExternalMiniCluster* cluster, const char* typ
 
 Result<int> TotalBackfillRpcCalls(ExternalMiniCluster* cluster) {
   return TotalBackfillRpcMetric(cluster, "total_count");
+}
+
+Result<int64_t> BackfillAbortedCount(ExternalMiniCluster* cluster) {
+  auto* master = cluster->GetLeaderMaster();
+  return master->GetMetric<int64>(
+      &METRIC_ENTITY_cluster, nullptr, &METRIC_backfill_aborted, "value");
 }
 
 Result<double> AvgBackfillRpcLatencyInMicros(ExternalMiniCluster* cluster) {
@@ -3573,6 +3582,210 @@ TEST_P(PgIndexBackfillBlockDoBackfill, ConcurrentInplaceUpdateCoveringIndex) {
 
   // Validate that the index is consistent.
   ASSERT_OK(CheckIndexConsistency("idx_tbl"));
+}
+
+// Test class for verifying that killing the PG backend running CREATE INDEX CONCURRENTLY
+// propagates the cancellation to the master-side backfill.
+//
+// Reproduces the bug where pg_terminate_backend kills only the PG connection but leaves
+// the distributed backfill on the master running indefinitely.
+//
+// Parameterized via PgIndexBackfillTest::EnableTableLocks() (::testing::Bool()):
+//   false -- legacy mode: DDL uses an autonomous kDDL transaction
+//            (use_regular_transaction_block=false)
+//   true  -- transactional DDL mode: DDL participates in the kPlain session transaction
+//            (use_regular_transaction_block=true, ysql_yb_ddl_transaction_block_enabled=true)
+// Both paths must be tested because GetDdlTransactionMetadata fetches metadata from different
+// transactions depending on the mode.
+class PgIndexBackfillCancellationTest : public PgIndexBackfillTest {
+ public:
+  void UpdateMiniClusterOptions(ExternalMiniClusterOptions* options) override {
+    PgIndexBackfillTest::UpdateMiniClusterOptions(options);
+    // This test uses SPLIT INTO 1 TABLETS and only needs one tserver.  Use RF=1 so the
+    // system.transactions table (and all other system tables) can be created with a single
+    // tserver.  Also cap ysql_num_tablets=1 so user table initialization stays minimal.
+    options->replication_factor = 1;
+    options->extra_tserver_flags.push_back("--ysql_num_tablets=1");
+    // Slow down each BackfillIndex RPC so we have time to kill the backend mid-backfill
+    // and then observe whether additional chunks continue to be issued.
+    options->extra_tserver_flags.push_back(
+        Format("--TEST_slowdown_backfill_by_ms=$0", kSlowdown.ToMilliseconds()));
+    // Limit rows scanned per BackfillIndex RPC so the master must issue multiple sequential
+    // RPCs per tablet (resume chunks).  Without this, all kNumRows fit in a single RPC and
+    // the kill always arrives after backfill is already done, leaving nothing to observe.
+    //
+    // Two flags together produce kNumRows/kFetchRowLimit sequential BackfillIndex RPCs
+    // (kFetchRowLimit rows each):
+    // - yb_fetch_row_limit=kFetchRowLimit: controls how many rows PostgreSQL fetches from
+    //   DocDB per BACKFILL INDEX SQL call.
+    options->extra_tserver_flags.push_back(
+        Format("--ysql_yb_fetch_row_limit=$0", kFetchRowLimit));
+    options->extra_tserver_flags.push_back(
+        Format("--TEST_backfill_paging_size=$0", kFetchRowLimit));
+    options->extra_master_flags.push_back(
+        Format("--ddl_requester_liveness_check_interval_secs=$0",
+               kLivenessInterval.ToSeconds()));
+    options->extra_master_flags.push_back(
+        Format("--transaction_rpc_timeout_ms=$0",
+               kTransactionRpcTimeout.ToMilliseconds()));
+    options->extra_tserver_flags.push_back(
+        Format("--transaction_heartbeat_usec=$0",
+               kTransactionHeartbeat.ToMicroseconds()));
+  }
+
+  int GetNumTabletServers() const override { return 1; }
+
+ protected:
+  Status SetupAndKillBackend() {
+    // Sanity check to make sure that we have enough rows for the test.
+    // Roughly it verifies that the time needed to abort the backfill is less
+    // than the time to finish the full backfill.
+    const MonoDelta abort_detection_window =
+        kLivenessInterval + kTransactionRpcTimeout + kTransactionHeartbeat
+        + kWaitForMaxDelay;
+    const MonoDelta min_remaining_backfill_time =
+        kSlowdown * (kExpectedTotalBackfillRpcs - 1);
+
+    // Added 2x factor as safety margin
+    SCHECK_GT(min_remaining_backfill_time, abort_detection_window * 2, IllegalState,
+              "kNumRows too small, the backfill could finish before "
+              "the master detects the killed backend.");
+
+    RETURN_NOT_OK(conn_->ExecuteFormat(
+        "CREATE TABLE $0 (k INT PRIMARY KEY, v INT) SPLIT INTO 1 TABLETS", kTableName));
+    RETURN_NOT_OK(conn_->ExecuteFormat(
+        "INSERT INTO $0 SELECT i, i FROM generate_series(1, $1) AS i",
+        kTableName, kNumRows));
+
+    CountDownLatch pid_ready(1);
+    thread_holder_.AddThreadFunctor([this, &pid_ready] {
+      auto conn = ASSERT_RESULT(ConnectToDB(kDatabaseName));
+      create_index_pid_.store(ASSERT_RESULT(conn.FetchRow<int32_t>("SELECT pg_backend_pid()")));
+      pid_ready.CountDown();
+      auto s = conn.ExecuteFormat(
+          "CREATE INDEX CONCURRENTLY $0 ON $1 (v)", kIndexName, kTableName);
+      create_index_completed_ok_.store(s.ok());
+      LOG(INFO) << "CREATE INDEX returned: " << s;
+    });
+
+    pid_ready.Wait();
+
+    // No artificial timeout here, count on the gtest-level timeout
+    RETURN_NOT_OK(WaitFor(
+        [this]() -> Result<bool> {
+          return VERIFY_RESULT(TotalBackfillRpcCalls(cluster_.get())) >= 1;
+        },
+        MonoDelta::kMax, "first BackfillIndex RPC to complete",
+        1ms, 1.1, kWaitForMaxDelay));
+
+    SCHECK_EQ(VERIFY_RESULT(BackfillAbortedCount(cluster_.get())), 0, IllegalState,
+              "backfill_aborted counter must be 0 before the kill");
+
+    auto terminated = VERIFY_RESULT(conn_->FetchRow<bool>(
+        Format("SELECT pg_terminate_backend($0)", create_index_pid_.load())));
+    if (!terminated) {
+      return STATUS(IllegalState, "pg_terminate_backend returned false");
+    }
+    LOG(INFO) << "Terminated CREATE INDEX backend PID " << create_index_pid_.load();
+    return Status::OK();
+  }
+
+  // gflag values pinned here.
+  const MonoDelta kSlowdown = 1s;
+  const MonoDelta kTransactionRpcTimeout = 1s * kTimeMultiplier;
+  const MonoDelta kTransactionHeartbeat = 500ms;
+  const MonoDelta kLivenessInterval = 1s;
+
+  // WaitFor poll cap used to observe the abort counter in the positive test.
+  const MonoDelta kWaitForMaxDelay = 100ms;
+
+  // ceil(kNumRows / kFetchRowLimit)
+  static constexpr int kFetchRowLimit = 500;
+  static constexpr int kNumRows = 8000;
+  static constexpr int kExpectedTotalBackfillRpcs =
+      (kNumRows + kFetchRowLimit - 1) / kFetchRowLimit;
+
+  // Populated by the CREATE INDEX CONCURRENTLY thread.
+  std::atomic<int32_t> create_index_pid_{0};
+  std::atomic<bool> create_index_completed_ok_{false};
+};
+
+INSTANTIATE_TEST_CASE_P(, PgIndexBackfillCancellationTest, ::testing::Bool());
+
+// Regression test: after pg_terminate_backend kills the CREATE INDEX CONCURRENTLY session,
+// the master must stop issuing new BackfillIndex RPCs to tservers.
+//
+// Without the liveness check: the master continues launching backfill chunks, visible as new
+// BackfillIndex RPC completions on tservers after the backend is gone.
+// With the liveness check: the master detects the DDL transaction is ABORTED and stops.
+TEST_P(PgIndexBackfillCancellationTest, BackfillStopsAfterBackendKill) {
+  ASSERT_OK(SetupAndKillBackend());
+
+  // Wait for the master to observe the aborted transaction after
+  // BackfillTable::Abort, which bumps backfill_aborted
+  ASSERT_OK(WaitFor(
+      [this]() -> Result<bool> {
+        return VERIFY_RESULT(BackfillAbortedCount(cluster_.get())) == 1;
+      },
+      20s * kTimeMultiplier, "backfill_aborted counter to reach 1",
+      1ms, 1.1, kWaitForMaxDelay));
+
+  // At most one chunk can still be in flight
+  auto rpcs = ASSERT_RESULT(TotalBackfillRpcCalls(cluster_.get()));
+  EXPECT_LT(rpcs + 1, kExpectedTotalBackfillRpcs)
+      << "Abort fired but already issued " << rpcs << " of "
+      << kExpectedTotalBackfillRpcs << " expected BackfillIndex RPCs";
+
+  // Maybe an overkill, we already know that Abort() was called.
+  //
+  // As an additional insurance wait for sometime (enough for ~2 RPCs),
+  // and check again. The new count must be less than rpcs + 1,
+  // +1 is in case one RPC was in-flight at the time of the kill.
+  SleepFor(kSlowdown * kTimeMultiplier * 3);
+  auto rpcs_after = ASSERT_RESULT(TotalBackfillRpcCalls(cluster_.get()));
+  EXPECT_LE(rpcs_after, rpcs + 1)
+      << "BackfillIndex RPC count grew after abort fired, expected: "
+      << rpcs_after << " <= " << rpcs + 1;
+
+  thread_holder_.JoinAll();
+  EXPECT_FALSE(create_index_completed_ok_.load())
+      << "CREATE INDEX completed before pg_terminate_backend interrupted it";
+}
+
+// Negative-regression test: demonstrates the pre-fix bug.
+//
+// With --TEST_skip_ddl_requester_liveness_check=true the master never starts the
+// liveness task, so it never detects the ABORTED transaction and keeps issuing
+// BackfillIndex RPCs until every chunk has completed.  The test waits until the total
+// RPC count reaches kExpectedTotalBackfillRpcs.
+class PgIndexBackfillCancellationWithoutFixTest : public PgIndexBackfillCancellationTest {
+ public:
+  void UpdateMiniClusterOptions(ExternalMiniClusterOptions* options) override {
+    PgIndexBackfillCancellationTest::UpdateMiniClusterOptions(options);
+    options->extra_master_flags.push_back(
+        "--TEST_skip_ddl_requester_liveness_check=true");
+  }
+};
+
+INSTANTIATE_TEST_CASE_P(, PgIndexBackfillCancellationWithoutFixTest, ::testing::Values(false));
+
+TEST_P(PgIndexBackfillCancellationWithoutFixTest, BackfillContinuesAfterBackendKill) {
+  ASSERT_OK(SetupAndKillBackend());
+
+  ASSERT_OK(WaitFor(
+      [this]() -> Result<bool> {
+        return VERIFY_RESULT(TotalBackfillRpcCalls(cluster_.get())) >=
+               kExpectedTotalBackfillRpcs;
+      },
+      MonoDelta::kMax, "all BackfillIndex RPCs to complete"));
+
+  // With the liveness check disabled, BackfillTable::Abort must never be called.
+  EXPECT_EQ(ASSERT_RESULT(BackfillAbortedCount(cluster_.get())), 0)
+      << "backfill_aborted fired despite --TEST_skip_ddl_requester_liveness_check=true";
+
+  thread_holder_.JoinAll();
+  EXPECT_FALSE(create_index_completed_ok_.load())
+      << "CREATE INDEX completed before pg_terminate_backend interrupted it";
 }
 
 } // namespace yb::pgwrapper

--- a/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
+++ b/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
@@ -3631,6 +3631,12 @@ class PgIndexBackfillCancellationTest : public PgIndexBackfillTest {
     options->extra_tserver_flags.push_back(
         Format("--transaction_heartbeat_usec=$0",
                kTransactionHeartbeat.ToMicroseconds()));
+    options->extra_tserver_flags.push_back(
+        Format("--pg_client_session_expiration_ms=$0",
+               kPgClientSessionExpiration.ToMilliseconds()));
+    options->extra_tserver_flags.push_back(
+        Format("--pg_client_heartbeat_interval_ms=$0",
+               kPgClientHeartbeatInterval.ToMilliseconds()));
   }
 
   int GetNumTabletServers() const override { return 1; }
@@ -3641,8 +3647,8 @@ class PgIndexBackfillCancellationTest : public PgIndexBackfillTest {
     // Roughly it verifies that the time needed to abort the backfill is less
     // than the time to finish the full backfill.
     const MonoDelta abort_detection_window =
-        kLivenessInterval + kTransactionRpcTimeout + kTransactionHeartbeat
-        + kWaitForMaxDelay;
+        kPgClientSessionExpiration + kLivenessInterval + kTransactionRpcTimeout
+        + kTransactionHeartbeat + kWaitForMaxDelay;
     const MonoDelta min_remaining_backfill_time =
         kSlowdown * (kExpectedTotalBackfillRpcs - 1);
 
@@ -3695,13 +3701,16 @@ class PgIndexBackfillCancellationTest : public PgIndexBackfillTest {
   const MonoDelta kTransactionRpcTimeout = 1s * kTimeMultiplier;
   const MonoDelta kTransactionHeartbeat = 500ms;
   const MonoDelta kLivenessInterval = 1s;
+  // pg_client_heartbeat_interval_ms validator requires strictly > 1000ms.
+  const MonoDelta kPgClientHeartbeatInterval = 1100ms;
+  const MonoDelta kPgClientSessionExpiration = 3s;
 
   // WaitFor poll cap used to observe the abort counter in the positive test.
   const MonoDelta kWaitForMaxDelay = 100ms;
 
   // ceil(kNumRows / kFetchRowLimit)
   static constexpr int kFetchRowLimit = 500;
-  static constexpr int kNumRows = 8000;
+  static constexpr int kNumRows = 12000;
   static constexpr int kExpectedTotalBackfillRpcs =
       (kNumRows + kFetchRowLimit - 1) / kFetchRowLimit;
 


### PR DESCRIPTION
DO NOT MERGE!! [CSI](<https://csiweb.dev.yugabyte.com/pull/31378/>) ❌. Once CSI passes, comment `trigger jenkins` to clear this warning.

## Summary

Add DdlRequesterLivenessTask, a master-side task that polls the transaction
status of the DDL transaction held open by the CREATE INDEX CONCURRENTLY
backend. If the transaction is aborted (e.g. because the backend was killed
via pg_terminate_backend), the task calls BackfillTable::Abort() to stop
the in-progress backfill.

## Test plan

- PgIndexBackfillCancellationTest.BackfillStopsAfterBackendKill — asserts
  that no new backfill RPCs are issued after the backend is killed.
- PgIndexBackfillCancellationWithoutFixTest.BackfillContinuesAfterBackendKill
  — asserts the old behavior (backfill continues) when the liveness monitor is
  disabled, serving as a regression baseline.
- PgIndexBackfillCancellationEarlyKillTest.BackfillStopsAfterEarlyBackendKill
  — same as above but the backend is killed before backfill starts.

## Upgrade / Rollback Safety
Upgrade safety: Safe.
Rollback safety: Safe.

No special procedures are required.

[CSI](<https://csiweb.dev.yugabyte.com/pull/31378/>)
Jira: [DB-16358](https://yugabyte.atlassian.net/browse/DB-16358)

[DB-16358]: https://yugabyte.atlassian.net/browse/DB-16358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ