### PR TITLE
[#31380] Test: Disable PgMiniTest.OpenTableFailureDuringPerform on macOS

### DIFF
--- a/src/yb/yql/pgwrapper/pg_mini-test.cc
+++ b/src/yb/yql/pgwrapper/pg_mini-test.cc
@@ -3203,7 +3203,8 @@ TEST_F(PgMiniTest, KillPGInTheMiddleOfBatcherOperation) {
 
 // The test checks absence of t-server crash in case some tables can't be opened during
 // read/write operation
-TEST_F_EX(PgMiniTest, OpenTableFailureDuringPerform, PgMiniTestSingleNode) {
+TEST_F_EX(PgMiniTest, YB_DISABLE_TEST_ON_MACOS(OpenTableFailureDuringPerform),
+          PgMiniTestSingleNode) {
   auto conn = ASSERT_RESULT(Connect());
   ASSERT_OK(conn.Execute("CREATE TABLE t(k INT PRIMARY KEY)"));
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_request_unknown_tables_during_perform) = true;


### PR DESCRIPTION
## Summary

`PgMiniTest.OpenTableFailureDuringPerform` sets `FLAGS_TEST_request_unknown_tables_during_perform` and expects at least one of 10 SELECTs to fail with `OBJECT_NOT_FOUND`. That flag is only read inside `DoHandleSharedExchangeQuery` on the tserver, which lives on the shared-memory IPC path between pggate and tserver.

On macOS, `FLAGS_pg_client_use_shared_memory` defaults to `!yb::kIsMac`, so the shared-memory path isn't taken. Requests instead go via RPC to `PgClientServiceImpl::Perform`, which never reads the test flag — every SELECT succeeds and the final `ASSERT_TRUE(has_object_not_found_errors)` fails.

This change wraps the test name in `YB_DISABLE_TEST_ON_MACOS` so it is skipped on Darwin until the shared-memory path is enabled there (or an equivalent fault-injection hook is added to the RPC `Perform` path).

Resolves #31380.

## Test plan

- Confirm the test no longer runs on macOS:
  ```
./yb_build.sh release --cxx-test pg_mini-test
  ```
  expected: `pg_mini-test` no longer fails on `OpenTableFailureDuringPerform` test.
- CI on Linux continues to run and pass `PgMiniTest.OpenTableFailureDuringPerform`.


---

[Jenkins](<https://csiweb.dev.yugabyte.com/pull/31381/>)