### PR TITLE
[BACKPORT 2026.1][#31361] YSQL: Update mage python driver for extension/schema rename (#31360)

### DIFF
--- a/src/postgres/third-party-extensions/mage/drivers/python/README.md
+++ b/src/postgres/third-party-extensions/mage/drivers/python/README.md
@@ -74,9 +74,9 @@ python setup.py install
 Connect to your containerized Postgres instance and then run the following commands:
 ```
 # psql 
-CREATE EXTENSION age;
-LOAD 'age';
-SET search_path = ag_catalog, "$user", public;
+CREATE EXTENSION mage;
+LOAD 'mage';
+SET search_path = mag_catalog, "$user", public;
 ```
 
 ### Usage
@@ -88,7 +88,7 @@ SET search_path = ag_catalog, "$user", public;
 * For non-superuser usage see: [Allow Non-Superusers to Use Apache Age](https://age.apache.org/age-manual/master/intro/setup.html).
 * Make sure to give your non-superuser db account proper permissions to the graph schemas and corresponding objects
 * Make sure to initiate the Apache Age python driver with the ```load_from_plugins``` parameter. This parameter tries to
-  load the Apache Age extension from the PostgreSQL plugins directory located at ```$libdir/plugins/age```. Example:
+  load the Apache Age extension from the PostgreSQL plugins directory located at ```$libdir/plugins/mage```. Example:
   ```python.
   ag = age.connect(host='localhost', port=5432, user='dbuser', password='strong_password', 
                    dbname=postgres, load_from_plugins=True, graph='graph_name)

--- a/src/postgres/third-party-extensions/mage/drivers/python/age/age.py
+++ b/src/postgres/third-party-extensions/mage/drivers/python/age/age.py
@@ -46,12 +46,16 @@ class AgeLoader(psycopg.adapt.Loader):
 
 def setUpAge(conn:psycopg.connection, graphName:str, load_from_plugins:bool=False):
     with conn.cursor() as cursor:
-        if load_from_plugins:
-            cursor.execute("LOAD '$libdir/plugins/age';")
-        else:
-            cursor.execute("LOAD 'age';")
+        # YugabyteDB does not support LOAD; CREATE EXTENSION mage suffices.
+        try:
+            if load_from_plugins:
+                cursor.execute("LOAD '$libdir/plugins/mage';")
+            else:
+                cursor.execute("LOAD 'mage';")
+        except psycopg.errors.FeatureNotSupported:
+            conn.rollback()
 
-        cursor.execute("SET search_path = ag_catalog, '$user', public;")
+        cursor.execute("SET search_path = mag_catalog, '$user', public;")
 
         ag_info = TypeInfo.fetch(conn, 'agtype')
 

--- a/src/postgres/third-party-extensions/mage/drivers/python/age/networkx/lib.py
+++ b/src/postgres/third-party-extensions/mage/drivers/python/age/networkx/lib.py
@@ -28,7 +28,7 @@ def checkIfGraphNameExistInAGE(connection: psycopg.connect,
     with connection.cursor() as cursor:
         cursor.execute(sql.SQL("""
                     SELECT count(*) 
-                    FROM ag_catalog.ag_graph 
+                    FROM mag_catalog.ag_graph 
                     WHERE name='%s'
                 """ % (graphName)))
         if cursor.fetchone()[0] == 0:
@@ -41,7 +41,7 @@ def getOidOfGraph(connection: psycopg.connect,
     try:
         with connection.cursor() as cursor:
             cursor.execute(sql.SQL("""
-                        SELECT graphid FROM ag_catalog.ag_graph WHERE name='%s' ;
+                        SELECT graphid FROM mag_catalog.ag_graph WHERE name='%s' ;
                     """ % (graphName)))
             oid = cursor.fetchone()[0]
             return oid
@@ -56,7 +56,7 @@ def get_vlabel(connection: psycopg.connect,
     try:
         with connection.cursor() as cursor:
             cursor.execute(
-                """SELECT name FROM ag_catalog.ag_label WHERE kind='v' AND graph=%s;""" % oid)
+                """SELECT name FROM mag_catalog.ag_label WHERE kind='v' AND graph=%s;""" % oid)
             for row in cursor:
                 node_label_list.append(row[0])
 
@@ -92,7 +92,7 @@ def get_elabel(connection: psycopg.connect,
     try:
         with connection.cursor() as cursor:
             cursor.execute(
-                """SELECT name FROM ag_catalog.ag_label WHERE kind='e' AND graph=%s;""" % oid)
+                """SELECT name FROM mag_catalog.ag_label WHERE kind='e' AND graph=%s;""" % oid)
             for row in cursor:
                 edge_label_list.append(row[0])
     except Exception as ex:


### PR DESCRIPTION
## Summary

- Follow-up to the `age` -> `mage` extension rename (7965e6de67). The
python driver under `mage/drivers/python/` still issued `LOAD 'age'` and
queried the `ag_catalog` schema, so it failed against the renamed
extension.
- Updates `LOAD`/`search_path` to `mage` / `mag_catalog`, fixes
`mag_catalog.ag_graph` and `mag_catalog.ag_label` references in
`networkx/lib.py`, and refreshes the README's `CREATE EXTENSION` /
`LOAD` / `search_path` examples.
- Wraps the `LOAD` call in a `try/except
psycopg.errors.FeatureNotSupported` so the driver works on YugabyteDB,
which does not support `LOAD` (CREATE EXTENSION already loads the .so).

Table identifiers `ag_graph` and `ag_label` are intentionally kept (the
parent rename leaves SQL function/table names unchanged).

## Test plan

- [x] Built release locally and started a single-node yugabyted cluster.
- [x] Verification script: `CREATE EXTENSION mage`,
`age.connect(graph=...)`, assert `search_path` contains `mag_catalog`,
assert graph row appears in `mag_catalog.ag_graph`, cypher `CREATE` of
two `:Person` vertices and one `:KNOWS` edge, cypher `MATCH` reads them
back as VERTEX and tuple results - all pass.
- [x] Two upstream-style unittest cases (cypher CREATE/MATCH and
parameterised cypher) - all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

Phorge: [D52578](https://phorge.dev.yugabyte.com/D52578)

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Backport of: https://github.com/yugabyte/yugabyte-db/pull/31360 (commit 3467de394c9c1e25eeb2debf7fa39de56338d2c4)

---

Phorge: [D52639](https://phorge.dev.yugabyte.com/D52639)