### PR TITLE
[#31401] DocumentDB: Revert workaround in DeleteOneInternal

### DIFF
--- a/src/postgres/third-party-extensions/documentdb/pg_documentdb/src/commands/delete.c
+++ b/src/postgres/third-party-extensions/documentdb/pg_documentdb/src/commands/delete.c
@@ -1424,15 +1424,8 @@ DeleteOneInternal(MongoCollection *collection, DeleteOneParams *deleteOneParams,
 		}
 	}
 
-	/*
-	 * YB (yb#26307): Bug when locking rows inside a CTE.
-	 * Error: Some of the requested ybctids are missing: 0 vs 1
-	 */
-	if (IsYugaByteEnabled())
-		appendStringInfo(&selectQuery, " LIMIT 1)");
-	else
-		appendStringInfo(&selectQuery,
-					 " LIMIT 1 FOR UPDATE)");
+	appendStringInfo(&selectQuery,
+				 " LIMIT 1 FOR UPDATE)");
 
 	StringInfoData deleteQuery;
 	initStringInfo(&deleteQuery);

--- a/src/postgres/third-party-extensions/documentdb/pg_documentdb/src/commands/delete.c
+++ b/src/postgres/third-party-extensions/documentdb/pg_documentdb/src/commands/delete.c
@@ -1425,7 +1425,7 @@ DeleteOneInternal(MongoCollection *collection, DeleteOneParams *deleteOneParams,
 	}
 
 	appendStringInfo(&selectQuery,
-				 " LIMIT 1 FOR UPDATE)");
+					 " LIMIT 1 FOR UPDATE)");
 
 	StringInfoData deleteQuery;
 	initStringInfo(&deleteQuery);


### PR DESCRIPTION
The CTE row-locking bug tracked at yb#26307 has been fixed, so the YB-specific branch that omitted FOR UPDATE inside the delete CTE is no longer needed.

Fixes #31401