### PR TITLE
[BACKPORT 2026.1][#31358] YSQL: Add yb_enable_mage gFlag to control mage extension load (#31359)

### DIFF
--- a/java/yb-pgsql/src/test/java/org/yb/pgsql/TestPgRegressThirdPartyExtensionsMage.java
+++ b/java/yb-pgsql/src/test/java/org/yb/pgsql/TestPgRegressThirdPartyExtensionsMage.java
@@ -13,6 +13,7 @@
 package org.yb.pgsql;
 
 import java.io.File;
+import java.util.Map;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,6 +25,13 @@ public class TestPgRegressThirdPartyExtensionsMage extends BasePgRegressTest {
   @Override
   public int getTestMethodTimeoutSec() {
     return 1800;
+  }
+
+  @Override
+  protected Map<String, String> getTServerFlags() {
+    Map<String, String> flagMap = super.getTServerFlags();
+    flagMap.put("ysql_yb_enable_mage", "true");
+    return flagMap;
   }
 
   @Test

--- a/src/postgres/src/backend/commands/extension.c
+++ b/src/postgres/src/backend/commands/extension.c
@@ -1732,6 +1732,12 @@ CreateExtension(ParseState *pstate, CreateExtensionStmt *stmt)
 	/* Check extension name validity before any filesystem access */
 	check_valid_extension_name(stmt->extname);
 
+	/* YB: mage availability is gated by the ysql_yb_enable_mage gFlag. */
+	if (strcmp(stmt->extname, "mage") == 0 && !yb_enable_mage)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("extension \"mage\" is not available")));
+
 	/*
 	 * Check for duplicate extension name.  The unique index on
 	 * pg_extension.extname would catch this anyway, and serves as a backstop

--- a/src/postgres/src/backend/utils/misc/guc.c
+++ b/src/postgres/src/backend/utils/misc/guc.c
@@ -4041,6 +4041,18 @@ static struct config_bool ConfigureNamesBool[] =
 		NULL, NULL, NULL
 	},
 
+	{
+		{"yb_enable_mage", PGC_POSTMASTER, DEVELOPER_OPTIONS,
+			gettext_noop("Enable the use of mage extension. "
+						 "NOTE: This is for internal use only."),
+			NULL,
+			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL
+		},
+		&yb_enable_mage,
+		false,
+		NULL, NULL, NULL
+	},
+
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, false, NULL, NULL, NULL

--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -7536,6 +7536,8 @@ bool		yb_ysql_conn_mgr_sticky_locks = false;
  */
 bool		yb_conn_mgr_selective_deallocate = true;
 
+bool		yb_enable_mage = false;
+
 bool
 YbIsSuperuserConnSticky()
 {

--- a/src/postgres/src/include/utils/guc.h
+++ b/src/postgres/src/include/utils/guc.h
@@ -324,6 +324,7 @@ extern PGDLLIMPORT bool yb_conn_mgr_selective_deallocate;
 extern PGDLLIMPORT int yb_notifications_poll_sleep_duration_nonempty_ms;
 extern PGDLLIMPORT int yb_notifications_poll_sleep_duration_empty_ms;
 extern PGDLLIMPORT bool yb_skip_ensure_read_time_in_parallel_execution;
+extern PGDLLIMPORT bool yb_enable_mage;
 
 /*
  * Functions exported by guc.c

--- a/src/yb/yql/pgwrapper/pg_wrapper-test.cc
+++ b/src/yb/yql/pgwrapper/pg_wrapper-test.cc
@@ -664,6 +664,11 @@ TEST_F(PgWrapperFlagsTest, VerifyGFlagDefaults) {
     if (!tags.contains(FlagTag::kPg)) {
       continue;
     }
+    // Hidden gFlags use GUC_NO_SHOW_ALL on the corresponding GUC, which excludes them from
+    // pg_settings, so ValidateDefaultGucValue cannot read boot_val.
+    if (tags.contains(FlagTag::kHidden)) {
+      continue;
+    }
 
     auto expected_val = flag.default_value;
 
@@ -693,6 +698,11 @@ TEST_F(PgWrapperFlagsTest, YB_DISABLE_TEST_IN_TSAN(VerifyGFlagRuntimeTag)) {
     std::unordered_set<FlagTag> tags;
     GetFlagTags(flag.name, &tags);
     if (!tags.contains(FlagTag::kPg)) {
+      continue;
+    }
+    // Hidden gFlags use GUC_NO_SHOW_ALL on the corresponding GUC, which excludes them from
+    // pg_settings, so ValidateGucIsRuntime cannot read context.
+    if (tags.contains(FlagTag::kHidden)) {
       continue;
     }
 

--- a/src/yb/yql/pgwrapper/pg_wrapper.cc
+++ b/src/yb/yql/pgwrapper/pg_wrapper.cc
@@ -469,6 +469,11 @@ DEFINE_validator(ysql_yb_notifications_poll_sleep_duration_empty_ms, FLAG_GE_VAL
 DEFINE_NON_RUNTIME_string(pg_upgrade_working_dir, "",
     "Working directory for pg_upgrade. If empty, defaults to the pg_upgrade data directory.");
 
+DEFINE_NON_RUNTIME_PG_FLAG(bool, yb_enable_mage, false,
+                           "Enable the use of mage extension. "
+                           "NOTE: This is for internal use only.");
+TAG_FLAG(ysql_yb_enable_mage, hidden);
+
 using gflags::CommandLineFlagInfo;
 using std::string;
 using std::vector;
@@ -692,6 +697,10 @@ Result<string> WritePostgresConfig(const PgProcessConf& conf) {
   if (FLAGS_ysql_enable_documentdb) {
     metricsLibs.push_back("pg_documentdb_core");
     metricsLibs.push_back("pg_documentdb");
+  }
+
+  if (FLAGS_ysql_yb_enable_mage) {
+    metricsLibs.push_back("mage");
   }
 
   vector<string> lines;


### PR DESCRIPTION
## Summary

- Adds the `ysql_yb_enable_mage` gFlag (default `false`) and matching
  `yb_enable_mage` GUC. Both are non-runtime / `PGC_POSTMASTER` and only
  take effect on postmaster restart.
- When the gFlag is enabled, `pg_wrapper.cc` appends `mage` to
  `shared_preload_libraries` so its hooks are installed in every backend
  (mirrors the `pg_cron` / `documentdb` pattern).
- When the GUC is disabled, `CreateExtension` in `extension.c` rejects
`CREATE EXTENSION mage` outright, so a stray invocation can't lazy-load
  mage into a single backend and leave the cluster in an inconsistent
  hook state.
- Adds `ysql_yb_enable_mage=true` to
  `TestPgRegressThirdPartyExtensionsMage` so the regression suite still
  exercises mage end to end.

Original commit: 2f9453b13cf719494838d625a68298ea96944e6d

## Test plan

- [x] `./yb_build.sh release --java-test
org.yb.pgsql.TestPgRegressThirdPartyExtensionsMage`

Fixes #31358

---------

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

[Jenkins](<https://csiweb.dev.yugabyte.com/pull/31406/>)