### PR TITLE
[#31408] YSQL: Verify hidden PG gFlags are not discoverable via pg_settings

### DIFF
--- a/src/postgres/src/backend/utils/misc/guc.c
+++ b/src/postgres/src/backend/utils/misc/guc.c
@@ -3684,7 +3684,7 @@ static struct config_bool ConfigureNamesBool[] =
 						 "which creates database connection for query diagnostics. "
 						 "If this is set to true, ASH and schema details are not dumped"),
 			NULL,
-			GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL
 		},
 		&yb_query_diagnostics_disable_database_connection_bgworker,
 		false,

--- a/src/yb/yql/pgwrapper/pg_wrapper-test.cc
+++ b/src/yb/yql/pgwrapper/pg_wrapper-test.cc
@@ -59,6 +59,8 @@ namespace yb {
 namespace pgwrapper {
 namespace {
 
+constexpr std::string_view kPgFlagPrefix = "ysql_";
+
 template<bool Auth, bool Encrypted>
 struct ConnectionStrategy {
   static const bool UseAuth = Auth;
@@ -587,11 +589,10 @@ TEST_F(PgWrapperSingleNodeLongTxnTest, RestartMidApply) {
 class PgWrapperFlagsTest : public PgWrapperTest {
   void ValidateGucValue(
       const string& gflag_name, const string& expected_value, bool check_default_value) {
-    const string pg_flag_prefix = "ysql_";
-    ASSERT_TRUE(gflag_name.starts_with(pg_flag_prefix))
-        << "Flag " << gflag_name << " does not start with prefix " << pg_flag_prefix;
+    ASSERT_TRUE(gflag_name.starts_with(kPgFlagPrefix))
+        << "Flag " << gflag_name << " does not start with prefix " << kPgFlagPrefix;
 
-    auto guc_name = gflag_name.substr(pg_flag_prefix.length());
+    auto guc_name = gflag_name.substr(kPgFlagPrefix.size());
     boost::to_lower(guc_name);
 
     string normalized_expected_value = expected_value;
@@ -617,17 +618,21 @@ class PgWrapperFlagsTest : public PgWrapperTest {
     ValidateGucValue(gflag_name, expected_value, false /* check_default_value */);
   }
 
-  void ValidateGucIsHidden(const string& gflag_name) {
-    const string pg_flag_prefix = "ysql_";
-    ASSERT_TRUE(gflag_name.starts_with(pg_flag_prefix))
-        << "Flag " << gflag_name << " does not start with prefix " << pg_flag_prefix;
-
-    auto guc_name = gflag_name.substr(pg_flag_prefix.length());
-    boost::to_lower(guc_name);
-
-    ASSERT_NO_FATALS(RunPsqlCommand(
-        Format("SELECT count(*) FROM pg_settings WHERE LOWER(name)='$0'", guc_name),
-        "0", true /* tuples_only */));
+  // Returns the lowercased names of all GUCs visible in pg_settings. Hidden GUCs
+  // (those tagged GUC_NO_SHOW_ALL) are excluded from this view.
+  Result<std::unordered_set<string>> GetVisibleGucNames() {
+    auto output = VERIFY_RESULT(
+        RunPsqlCommand("SELECT LOWER(name) FROM pg_settings", TuplesOnly::kTrue));
+    std::unordered_set<string> names;
+    vector<string> lines;
+    boost::split(lines, output, boost::is_any_of("\n"));
+    for (auto& line : lines) {
+      boost::trim(line);
+      if (!line.empty()) {
+        names.insert(line);
+      }
+    }
+    return names;
   }
 
   void ValidateGucIsRuntime(const string& guc_name, const bool runtime_expected) {
@@ -671,6 +676,10 @@ TEST_F(PgWrapperFlagsTest, VerifyGFlagDefaults) {
   vector<CommandLineFlagInfo> flags;
   GetAllFlags(&flags);
 
+  // Cache pg_settings names so we can verify hidden flags are not discoverable
+  // without spawning a psql process per flag.
+  const auto visible_guc_names = ASSERT_RESULT(GetVisibleGucNames());
+
   for (const CommandLineFlagInfo& flag : flags) {
     std::unordered_set<FlagTag> tags;
     GetFlagTags(flag.name, &tags);
@@ -678,10 +687,14 @@ TEST_F(PgWrapperFlagsTest, VerifyGFlagDefaults) {
       continue;
     }
     // Hidden gFlags use GUC_NO_SHOW_ALL on the corresponding GUC, which excludes them from
-    // pg_settings, so ValidateDefaultGucValue cannot read boot_val. Verify the GUC is indeed
-    // not discoverable via pg_settings, then skip the boot_val comparison.
+    // pg_settings. Verify each hidden flag is not discoverable, then skip the boot_val
+    // comparison since boot_val cannot be read for GUCs with GUC_NO_SHOW_ALL.
     if (tags.contains(FlagTag::kHidden)) {
-      ASSERT_NO_FATALS(ValidateGucIsHidden(flag.name));
+      auto guc_name = flag.name.substr(kPgFlagPrefix.size());
+      boost::to_lower(guc_name);
+      EXPECT_FALSE(visible_guc_names.contains(guc_name))
+          << "Hidden flag " << flag.name << " has a discoverable GUC '" << guc_name
+          << "' in pg_settings; the GUC definition is missing GUC_NO_SHOW_ALL.";
       continue;
     }
 
@@ -708,7 +721,6 @@ TEST_F(PgWrapperFlagsTest, YB_DISABLE_TEST_IN_TSAN(VerifyGFlagRuntimeTag)) {
   vector<CommandLineFlagInfo> flags;
   GetAllFlags(&flags);
 
-  const string pg_flag_prefix = "ysql_";
   for (const CommandLineFlagInfo& flag : flags) {
     std::unordered_set<FlagTag> tags;
     GetFlagTags(flag.name, &tags);
@@ -721,10 +733,10 @@ TEST_F(PgWrapperFlagsTest, YB_DISABLE_TEST_IN_TSAN(VerifyGFlagRuntimeTag)) {
       continue;
     }
 
-    ASSERT_TRUE(flag.name.starts_with(pg_flag_prefix))
-        << "Flag " << flag.name << " does not start with prefix " << pg_flag_prefix;
+    ASSERT_TRUE(flag.name.starts_with(kPgFlagPrefix))
+        << "Flag " << flag.name << " does not start with prefix " << kPgFlagPrefix;
 
-    auto guc_name = flag.name.substr(pg_flag_prefix.length());
+    auto guc_name = flag.name.substr(kPgFlagPrefix.size());
     boost::to_lower(guc_name);
 
     ValidateGucIsRuntime(guc_name, tags.contains(FlagTag::kRuntime));

--- a/src/yb/yql/pgwrapper/pg_wrapper-test.cc
+++ b/src/yb/yql/pgwrapper/pg_wrapper-test.cc
@@ -621,18 +621,10 @@ class PgWrapperFlagsTest : public PgWrapperTest {
   // Returns the lowercased names of all GUCs visible in pg_settings. Hidden GUCs
   // (those tagged GUC_NO_SHOW_ALL) are excluded from this view.
   Result<std::unordered_set<string>> GetVisibleGucNames() {
-    auto output = VERIFY_RESULT(
-        RunPsqlCommand("SELECT LOWER(name) FROM pg_settings", TuplesOnly::kTrue));
-    std::unordered_set<string> names;
-    vector<string> lines;
-    boost::split(lines, output, boost::is_any_of("\n"));
-    for (auto& line : lines) {
-      boost::trim(line);
-      if (!line.empty()) {
-        names.insert(line);
-      }
-    }
-    return names;
+    auto conn = VERIFY_RESULT(ConnectToDB(/* dbname= */ ""));
+    auto rows = VERIFY_RESULT(
+        conn.FetchRows<std::string>("SELECT LOWER(name) FROM pg_settings"));
+    return std::unordered_set<string>(rows.begin(), rows.end());
   }
 
   void ValidateGucIsRuntime(const string& guc_name, const bool runtime_expected) {

--- a/src/yb/yql/pgwrapper/pg_wrapper-test.cc
+++ b/src/yb/yql/pgwrapper/pg_wrapper-test.cc
@@ -682,8 +682,7 @@ TEST_F(PgWrapperFlagsTest, VerifyGFlagDefaults) {
     // pg_settings. Verify each hidden flag is not discoverable, then skip the boot_val
     // comparison since boot_val cannot be read for GUCs with GUC_NO_SHOW_ALL.
     if (tags.contains(FlagTag::kHidden)) {
-      auto guc_name = flag.name.substr(kPgFlagPrefix.size());
-      boost::to_lower(guc_name);
+      const auto guc_name = flag.name.substr(kPgFlagPrefix.size());
       EXPECT_FALSE(visible_guc_names.contains(guc_name))
           << "Hidden flag " << flag.name << " has a discoverable GUC '" << guc_name
           << "' in pg_settings; the GUC definition is missing GUC_NO_SHOW_ALL.";

--- a/src/yb/yql/pgwrapper/pg_wrapper-test.cc
+++ b/src/yb/yql/pgwrapper/pg_wrapper-test.cc
@@ -617,6 +617,19 @@ class PgWrapperFlagsTest : public PgWrapperTest {
     ValidateGucValue(gflag_name, expected_value, false /* check_default_value */);
   }
 
+  void ValidateGucIsHidden(const string& gflag_name) {
+    const string pg_flag_prefix = "ysql_";
+    ASSERT_TRUE(gflag_name.starts_with(pg_flag_prefix))
+        << "Flag " << gflag_name << " does not start with prefix " << pg_flag_prefix;
+
+    auto guc_name = gflag_name.substr(pg_flag_prefix.length());
+    boost::to_lower(guc_name);
+
+    ASSERT_NO_FATALS(RunPsqlCommand(
+        Format("SELECT count(*) FROM pg_settings WHERE LOWER(name)='$0'", guc_name),
+        "0", true /* tuples_only */));
+  }
+
   void ValidateGucIsRuntime(const string& guc_name, const bool runtime_expected) {
     // internal and postmaster context flags cannot be updated after process startup. See GucContext
     // in guc.h for more information
@@ -665,8 +678,10 @@ TEST_F(PgWrapperFlagsTest, VerifyGFlagDefaults) {
       continue;
     }
     // Hidden gFlags use GUC_NO_SHOW_ALL on the corresponding GUC, which excludes them from
-    // pg_settings, so ValidateDefaultGucValue cannot read boot_val.
+    // pg_settings, so ValidateDefaultGucValue cannot read boot_val. Verify the GUC is indeed
+    // not discoverable via pg_settings, then skip the boot_val comparison.
     if (tags.contains(FlagTag::kHidden)) {
+      ASSERT_NO_FATALS(ValidateGucIsHidden(flag.name));
       continue;
     }
 


### PR DESCRIPTION
## Summary

Tighten `VerifyGFlagDefaults` to verify that PG gFlags tagged hidden are
in fact not discoverable as GUCs via `pg_settings`. Previously the test
silently skipped hidden flags, so an inconsistency between the gFlag
`hidden` tag and the GUC's `GUC_NO_SHOW_ALL` flag would go undetected.

The new check caught one real inconsistency, fixed in this PR:
`yb_query_diagnostics_disable_database_connection_bgworker` is tagged
`hidden` on the gFlag side but its GUC was missing `GUC_NO_SHOW_ALL`.
Added `GUC_NO_SHOW_ALL` to bring the GUC in line with the gFlag tag.

Fixes #31408

## Test plan

- [x] `./yb_build.sh release --cxx-test pg_wrapper-test --gtest_filter 'PgWrapperFlagsTest.*'`
