### PR TITLE
[Docs] Fix Netlify build triggers to only run on /docs changes

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -4,7 +4,7 @@
   # Default build command.
   command = "npm run build"
   # Skip builds unless this directory has changes.
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- docs/"
+  ignore = "git diff --name-only $CACHED_COMMIT_REF $COMMIT_REF -- docs/ | grep -q ."
 
 # Deploy contexts
 # Environment variables here override variables set in the web UI.

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -4,7 +4,7 @@
   # Default build command.
   command = "npm run build"
   # Skip builds unless this directory has changes.
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- ."
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- docs/"
 
 # Deploy contexts
 # Environment variables here override variables set in the web UI.


### PR DESCRIPTION
Updates the Netlify build ignore rule to scope change detection specifically to the `/docs` directory. The build will now only be triggered when files inside `/docs` are modified, using a git diff check between the cached commit and the current commit.