### PR TITLE
[#31420] tserver: Fix kNormal pool self-deadlock in TriggerRelcacheInitConnection

### DIFF
--- a/src/yb/master/master.cc
+++ b/src/yb/master/master.cc
@@ -733,10 +733,10 @@ Status Master::SetTserverCatalogMessageList(
   return Status::OK();
 }
 
-Status Master::TriggerRelcacheInitConnection(
+void Master::TriggerRelcacheInitConnection(
     const tserver::TriggerRelcacheInitConnectionRequestPB& req,
-    tserver::TriggerRelcacheInitConnectionResponsePB *resp) {
-  return STATUS_FORMAT(NotSupported, "Unexpected call of $0", __FUNCTION__);
+    StdStatusCallback callback) {
+  callback(STATUS_FORMAT(NotSupported, "Unexpected call of $0", __FUNCTION__));
 }
 
 void Master::EnableCDCService() {

--- a/src/yb/master/master.h
+++ b/src/yb/master/master.h
@@ -228,9 +228,9 @@ class Master : public tserver::DbServerBase {
       uint32_t db_oid, bool is_breaking_change, uint64_t new_catalog_version,
       const std::optional<std::string>& message_list);
 
-  Status TriggerRelcacheInitConnection(
+  void TriggerRelcacheInitConnection(
     const tserver::TriggerRelcacheInitConnectionRequestPB& req,
-    tserver::TriggerRelcacheInitConnectionResponsePB *resp);
+    StdStatusCallback callback);
 
   void EnableCDCService();
 

--- a/src/yb/master/master_tserver.cc
+++ b/src/yb/master/master_tserver.cc
@@ -228,11 +228,12 @@ Status MasterTabletServer::SetTserverCatalogMessageList(
                                                new_catalog_version, message_list);
 }
 
-Status MasterTabletServer::TriggerRelcacheInitConnection(
+void MasterTabletServer::TriggerRelcacheInitConnection(
     const tserver::TriggerRelcacheInitConnectionRequestPB& req,
-    tserver::TriggerRelcacheInitConnectionResponsePB *resp) {
-  return master_->TriggerRelcacheInitConnection(req, resp);
+    StdStatusCallback callback) {
+  master_->TriggerRelcacheInitConnection(req, std::move(callback));
 }
+
 const std::shared_future<client::YBClient*>& MasterTabletServer::client_future() const {
   return master_->client_future();
 }

--- a/src/yb/master/master_tserver.h
+++ b/src/yb/master/master_tserver.h
@@ -78,9 +78,9 @@ class MasterTabletServer : public tserver::TabletServerIf,
       uint32_t db_oid, bool is_breaking_change, uint64_t new_catalog_version,
       const std::optional<std::string>& message_list) override;
 
-  Status TriggerRelcacheInitConnection(
+  void TriggerRelcacheInitConnection(
       const tserver::TriggerRelcacheInitConnectionRequestPB& req,
-      tserver::TriggerRelcacheInitConnectionResponsePB *resp) override;
+      StdStatusCallback callback) override;
 
   client::TransactionPool& TransactionPool() override;
 

--- a/src/yb/tserver/pg_client_service.cc
+++ b/src/yb/tserver/pg_client_service.cc
@@ -2524,16 +2524,18 @@ class PgClientServiceImpl::Impl : public SessionProvider {
         db_oid, is_breaking_change, new_catalog_version, message_list);
   }
 
-  Status TriggerRelcacheInitConnection(
+  void TriggerRelcacheInitConnection(
       const PgTriggerRelcacheInitConnectionRequestPB& req,
       PgTriggerRelcacheInitConnectionResponsePB* resp,
-      rpc::RpcContext* context) {
+      rpc::RpcContext context) {
     TriggerRelcacheInitConnectionRequestPB request;
-    TriggerRelcacheInitConnectionResponsePB response;
-    const auto& database_name = req.database_name();
-    request.set_database_name(database_name);
-    return const_cast<TabletServerIf&>(tablet_server_).TriggerRelcacheInitConnection(
-        request, &response);
+    request.set_database_name(req.database_name());
+    auto shared_context = std::make_shared<rpc::RpcContext>(std::move(context));
+    const_cast<TabletServerIf&>(tablet_server_).TriggerRelcacheInitConnection(
+        request,
+        [resp, shared_context](const Status& status) {
+          Respond(status, resp, shared_context.get());
+        });
   }
 
   Status IsObjectPartOfXRepl(

--- a/src/yb/tserver/pg_client_service.h
+++ b/src/yb/tserver/pg_client_service.h
@@ -68,7 +68,6 @@ class TserverXClusterContextIf;
     (GetTablePartitionList) \
     (GetTserverCatalogMessageLists) \
     (SetTserverCatalogMessageList) \
-    (TriggerRelcacheInitConnection) \
     (GetTserverCatalogVersionInfo) \
     (GetXClusterRole) \
     (Heartbeat) \
@@ -123,6 +122,7 @@ class TserverXClusterContextIf;
 // PG_CLIENT_SESSION_ASYNC_METHODS).
 #define YB_PG_CLIENT_ASYNC_METHODS \
     (OpenTable) \
+    (TriggerRelcacheInitConnection) \
     /**/
 
 #define YB_PG_CLIENT_ASYNC_LW_METHODS \

--- a/src/yb/tserver/tablet_server.cc
+++ b/src/yb/tserver/tablet_server.cc
@@ -1321,6 +1321,7 @@ void TabletServer::RelcacheInitConnectionDone(
     std::lock_guard l(lock_);
     auto it = in_flight_superuser_connections_.find(dbname);
     if (it == in_flight_superuser_connections_.end()) {
+      LOG(DFATAL) << "Cannot find in-flight superuser connection for database " << dbname;
       return;
     }
     callbacks = std::move(it->second);

--- a/src/yb/tserver/tablet_server.cc
+++ b/src/yb/tserver/tablet_server.cc
@@ -1279,67 +1279,59 @@ Status TabletServer::SetTserverCatalogMessageList(
   return Status::OK();
 }
 
-Status TabletServer::TriggerRelcacheInitConnection(
+void TabletServer::TriggerRelcacheInitConnection(
     const TriggerRelcacheInitConnectionRequestPB& req,
-    TriggerRelcacheInitConnectionResponsePB *resp) {
+    StdStatusCallback callback) {
   const std::string dbname = req.database_name();
-  std::shared_future<Status> future_for_this_request;
 
   bool started_superuser_connection = false;
   {
     std::lock_guard l(lock_);
-    auto it = in_flight_superuser_connections_.find(dbname);
-
-    if (it != in_flight_superuser_connections_.end()) {
-      LOG(INFO) << "Relcache init connection request to database " << dbname << " in progress";
-      future_for_this_request = it->second;
-    } else {
-      // In case there are multiple concurrent racing threads, this thread is the winner.
+    auto& callbacks = in_flight_superuser_connections_[dbname];
+    if (callbacks.empty()) {
       started_superuser_connection = true;
       LOG(INFO) << "Relcache init connection request to database " << dbname
                 << " starting from tserver " << this << " to " << pgsql_proxy_bind_address();
-
-      auto p = std::make_shared<std::promise<Status>>();
-      future_for_this_request = p->get_future().share();
-      in_flight_superuser_connections_[dbname] = future_for_this_request;
-
-      messenger()->scheduler().Schedule(
-        [this, p, dbname](const Status& status) {
-          if (!status.ok()) {
-            LOG(INFO) << status;
-            RelcacheInitConnectionDone(p.get(), dbname, status);
-            return;
-          }
-          MakeRelcacheInitConnection(p.get(), dbname);
-        }, std::chrono::steady_clock::duration(0));
+    } else {
+      LOG(INFO) << "Relcache init connection request to database " << dbname << " in progress";
     }
+    callbacks.push_back(std::move(callback));
   }
-  auto timeout = default_client_timeout();
-  std::future_status status = future_for_this_request.wait_for(timeout.ToSteadyDuration());
 
-  if (started_superuser_connection) {
-    std::lock_guard l(lock_);
-    in_flight_superuser_connections_.erase(dbname);
+  if (!started_superuser_connection) {
+    return;
   }
-  if (status == std::future_status::ready) {
-    return future_for_this_request.get();
-  }
-  return STATUS_FORMAT(TimedOut, "Relcache init connection request to database $0 timed out",
-                       dbname);
+
+  messenger()->scheduler().Schedule(
+      [this, dbname](const Status& status) {
+        if (!status.ok()) {
+          LOG(INFO) << status;
+          RelcacheInitConnectionDone(dbname, status);
+          return;
+        }
+        MakeRelcacheInitConnection(dbname);
+      },
+      std::chrono::steady_clock::duration(0));
 }
 
 void TabletServer::RelcacheInitConnectionDone(
-    std::promise<Status>* p, const std::string& dbname, const Status& status) {
-  // Do set_value and erase atomically.
-  std::lock_guard l(lock_);
-
-  // Fulfill the promise, unblocking all waiting threads for this task.
-  p->set_value(status);
-  // Clean up dbname from the map so that next winner can create superuser connection.
-  in_flight_superuser_connections_.erase(dbname);
+    const std::string& dbname, const Status& status) {
+  std::vector<StdStatusCallback> callbacks;
+  {
+    std::lock_guard l(lock_);
+    auto it = in_flight_superuser_connections_.find(dbname);
+    if (it == in_flight_superuser_connections_.end()) {
+      return;
+    }
+    callbacks = std::move(it->second);
+    in_flight_superuser_connections_.erase(it);
+  }
+  for (auto& cb : callbacks) {
+    cb(status);
+  }
 }
 
-void TabletServer::MakeRelcacheInitConnection(std::promise<Status>* p, const std::string& dbname) {
+void TabletServer::MakeRelcacheInitConnection(const std::string& dbname) {
   auto deadline = CoarseMonoClock::Now() + default_client_timeout();
   auto status = ResultToStatus(CreateInternalPGConn(dbname, false, deadline));
   if (status.ok()) {
@@ -1347,7 +1339,7 @@ void TabletServer::MakeRelcacheInitConnection(std::promise<Status>* p, const std
   } else {
     LOG(INFO) << "Relcache init connection to database " << dbname << " failed: " << status;
   }
-  RelcacheInitConnectionDone(p, dbname, status);
+  RelcacheInitConnectionDone(dbname, status);
 }
 
 void TabletServer::SetYsqlCatalogVersion(uint64_t new_version, uint64_t new_breaking_version) {

--- a/src/yb/tserver/tablet_server.h
+++ b/src/yb/tserver/tablet_server.h
@@ -354,9 +354,9 @@ class TabletServer : public DbServerBase, public TabletServerIf {
       uint32_t db_oid, bool is_breaking_change, uint64_t new_catalog_version,
       const std::optional<std::string>& message_list) EXCLUDES(lock_) override;
 
-  Status TriggerRelcacheInitConnection(
+  void TriggerRelcacheInitConnection(
       const tserver::TriggerRelcacheInitConnectionRequestPB& req,
-      tserver::TriggerRelcacheInitConnectionResponsePB* resp) EXCLUDES(lock_) override;
+      StdStatusCallback callback) EXCLUDES(lock_) override;
 
   void UpdateTransactionTablesVersion(uint64_t new_version);
 
@@ -666,9 +666,9 @@ class TabletServer : public DbServerBase, public TabletServerIf {
       InvalidationMessagesQueue *db_message_lists,
       uint64_t debug_id) REQUIRES(lock_);
 
-  void MakeRelcacheInitConnection(std::promise<Status>* p, const std::string& dbname);
-  void RelcacheInitConnectionDone(std::promise<Status>* p, const std::string& dbname,
-                                  const Status& status);
+  void MakeRelcacheInitConnection(const std::string& dbname);
+  void RelcacheInitConnectionDone(const std::string& dbname, const Status& status)
+      EXCLUDES(lock_);
   void DoUpdateMasterAddresses();
 
   std::string log_prefix_;
@@ -712,7 +712,12 @@ class TabletServer : public DbServerBase, public TabletServerIf {
   std::unique_ptr<docdb::ObjectLockSharedStateManager> object_lock_shared_state_manager_;
   OneTimeBool shutting_down_;
 
-  std::map<std::string, std::shared_future<Status>> in_flight_superuser_connections_;
+  // Per-database list of pending relcache-init callbacks. The first caller for a database creates
+  // the entry and schedules MakeRelcacheInitConnection; subsequent callers append their callback
+  // and return without blocking. RelcacheInitConnectionDone drains the list when the operation
+  // finishes.
+  std::map<std::string, std::vector<StdStatusCallback>> in_flight_superuser_connections_
+      GUARDED_BY(lock_);
 
 #ifdef __linux__
   std::unique_ptr<TServerCgroupManager> cgroup_manager_;

--- a/src/yb/tserver/tablet_server_interface.h
+++ b/src/yb/tserver/tablet_server_interface.h
@@ -35,6 +35,7 @@
 #include "yb/tserver/ysql_lease.h"
 
 #include "yb/util/concurrent_value.h"
+#include "yb/util/status_callback.h"
 
 namespace yb {
 
@@ -89,9 +90,14 @@ class TabletServerIf : public LocalTabletServer {
       uint32_t db_oid, bool is_breaking_change, uint64_t new_catalog_version,
       const std::optional<std::string>& message_list) = 0;
 
-  virtual Status TriggerRelcacheInitConnection(
+  // Asynchronously triggers an internal superuser PG connection that rebuilds the relcache init
+  // file for `req.database_name()`. The callback is invoked once the operation finishes (or fails)
+  // with the final Status. Implementations must not block the caller's thread waiting for the
+  // result; multiple concurrent callers for the same database share a single underlying
+  // operation and each receives its own callback invocation.
+  virtual void TriggerRelcacheInitConnection(
       const tserver::TriggerRelcacheInitConnectionRequestPB& req,
-      tserver::TriggerRelcacheInitConnectionResponsePB *resp) = 0;
+      StdStatusCallback callback) = 0;
 
   virtual const scoped_refptr<MetricEntity>& MetricEnt() const = 0;
 

--- a/src/yb/tserver/tablet_service.cc
+++ b/src/yb/tserver/tablet_service.cc
@@ -3456,12 +3456,16 @@ void TabletServiceImpl::TriggerRelcacheInitConnection(
     const TriggerRelcacheInitConnectionRequestPB* req,
     TriggerRelcacheInitConnectionResponsePB* resp,
     rpc::RpcContext context) {
-  auto status = server_->TriggerRelcacheInitConnection(*req, resp);
-  if (!status.ok()) {
-    SetupErrorAndRespond(resp->mutable_error(), status, &context);
-    return;
-  }
-  context.RespondSuccess();
+  auto shared_context = std::make_shared<rpc::RpcContext>(std::move(context));
+  server_->TriggerRelcacheInitConnection(
+      *req,
+      [resp, shared_context](const Status& status) {
+        if (!status.ok()) {
+          SetupErrorAndRespond(resp->mutable_error(), status, shared_context.get());
+          return;
+        }
+        shared_context->RespondSuccess();
+      });
 }
 
 void TabletServiceImpl::ListMasterServers(const ListMasterServersRequestPB* req,


### PR DESCRIPTION
## Summary

Fixes a self-deadlock in the `kNormal` PgClient RPC pool that hangs
`PgSingleTServerTest.ManyYsqlConnections` on both Linux and macOS.

`PgClientService::TriggerRelcacheInitConnection` was a synchronous handler. It scheduled
`MakeRelcacheInitConnection` on the messenger's scheduler and then called `future::wait_for` on the
in-flight promise, parking the `kNormal` worker. `MakeRelcacheInitConnection` itself ran on
`kNormal`, and opened a libpq connection to the local PG listener whose backend issues PgClient
RPCs that also land on `kNormal`. Under enough concurrent relcache-init callers (e.g.
`ManyYsqlConnections` with 64 backends and a 32-thread `kNormal` pool), every `kNormal` worker
would park in `wait_for` and the only thing that could call `promise.set_value` would never get a
worker.

This change makes the handler async:

- Move `TriggerRelcacheInitConnection` from `YB_PG_CLIENT_METHODS` to `YB_PG_CLIENT_ASYNC_METHODS`
  in `pg_client_service.h`. The handler now takes `RpcContext` by value and responds from a
  callback.
- Change `TabletServerIf::TriggerRelcacheInitConnection` from `Status`-returning to `void`-returning
  with an `StdStatusCallback`. Concurrent callers for the same database register a callback under
  `lock_` and return; once `MakeRelcacheInitConnection` finishes, `RelcacheInitConnectionDone` fans
  out to all registered callbacks. The worker is freed before any wait, so the pool is never parked
  on its own future.
- Update `Master` / `MasterTabletServer` / `TabletServiceImpl` signatures to match.

The `kNormal` worker now returns to the pool immediately after registering its callback, so
`MakeRelcacheInitConnection` (and any inner PgClient RPCs spawned by the resulting PG backend) can
always run.

This fix removes the failure on Linux. On macOS it uncovered a separate problem that will be fixed
in a follow-up PR.

Resolves #31420.

For details about the fix refer to this document:
[document](https://docs.google.com/document/d/1wh_jsWeoOx0Jr8N6ld4j8wG1FCuCwnjjI1lVMnCi1F0/edit?tab=t.0)


---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31421/>)