### PR TITLE
[BACKPORT 2026.1][#31404] YSQL: Fix UBSan crash in mage cypher CREATE (#31405)

### DIFF
--- a/src/postgres/third-party-extensions/mage/src/backend/parser/cypher_analyze.c
+++ b/src/postgres/third-party-extensions/mage/src/backend/parser/cypher_analyze.c
@@ -927,9 +927,8 @@ static Query *analyze_cypher(List *stmt, ParseState *parent_pstate,
      * convert ParseState into cypher_parsestate temporarily to pass it to
      * make_cypher_parsestate()
      */
+    memset(&parent_cpstate, 0, sizeof(parent_cpstate)); /* YB */
     parent_cpstate.pstate = *parent_pstate;
-    parent_cpstate.graph_name = NULL;
-    parent_cpstate.params = NULL;
 
     cpstate = make_cypher_parsestate(&parent_cpstate);
 


### PR DESCRIPTION
## Summary

Fixes #31404. Zero-initialize the stack-allocated `parent_cpstate` in
`analyze_cypher()` before passing it to `make_cypher_parsestate()`.

The struct previously had only `pstate`, `graph_name`, and `params` set,
leaving `subquery_where_flag` (and other fields) as uninitialized stack
memory. `make_cypher_parsestate()` reads
`parent_cpstate->subquery_where_flag`
directly (`cypher_parse_node.c:62`), so under UndefinedBehaviorSanitizer
the
load aborts the backend whenever the stack byte is something other than
0 or
1. The first `cypher()` call in the asan/ubsan build was reliably
crashing
with:

```
runtime error: load of value 8, which is not a valid value for type 'bool'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior cypher_parse_node.c:62:56
```

This is a latent upstream Apache AGE bug; the file is a verbatim subtree
import. Worth reporting upstream as well.

The redundant `graph_name = NULL`/`params = NULL` assignments are
removed
since `memset` already zeros them.

Original commit: 154e1a6 / #31405

## Test plan

- `./yb_build.sh asan --java-test
'org.yb.pgsql.TestPgRegressThirdPartyExtensionsMage#schedule'`
  was failing on `yb.orig.basic` before this change and passes with it.

Upstream fix https://github.com/apache/age/pull/2423

---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31423/>)
