### PR TITLE
YSQL: [DO NOT MERGE] 2026.1 build for mage multitenancy + pg_dist_rag tenant

### DIFF
--- a/python/ai/rag_agent/db/yugabytedb_vector_store.py
+++ b/python/ai/rag_agent/db/yugabytedb_vector_store.py
@@ -35,8 +35,8 @@ class YugabyteDBVectorStore:
         """Return a connection to the pool."""
         self.pool.return_connection(conn)
 
-    def _table_exists(self, conn, table_name):
-        """Check if the table exists using information_schema."""
+    def _table_exists(self, conn, table_name, table_schema):
+        """Check if the table exists in the given schema using information_schema."""
         cur = conn.cursor()
         try:
             # Query information_schema to check if table exists
@@ -44,10 +44,10 @@ class YugabyteDBVectorStore:
                 """
                 SELECT EXISTS (
                     SELECT 1 FROM information_schema.tables
-                    WHERE table_name = %s
+                    WHERE table_schema = %s AND table_name = %s
                 )
                 """,
-                (table_name,)
+                (table_schema, table_name)
             )
             result = cur.fetchone()[0]
             cur.close()
@@ -58,18 +58,18 @@ class YugabyteDBVectorStore:
             conn.rollback()  # Rollback explicitly on error
             raise
 
-    def _ensure_table_exists(self, table_name):
-        """Ensure the vector store table exists, creating it only if needed."""
+    def _ensure_table_exists(self, table_name, schema):
+        """Ensure the vector store table exists in the given schema."""
         conn = None
         try:
             conn = self._get_connection()
 
             # Check if table exists first
-            if self._table_exists(conn, table_name):
-                self.logger.info(f"Table '{table_name}' exists.")
+            if self._table_exists(conn, table_name, schema):
+                self.logger.info(f"Table '{schema}.{table_name}' exists.")
                 return True
 
-            self.logger.info(f"Table '{self.schema}.{table_name}' doesn't exist.")
+            self.logger.info(f"Table '{schema}.{table_name}' doesn't exist.")
             return False
 
         except Exception as e:
@@ -88,9 +88,10 @@ class YugabyteDBVectorStore:
         table_name,
         embedding_iterator,
         pipeline_id,
-        schema="public",
+        schema=None,
         metadata=None,
-        batch_size=100
+        batch_size=100,
+        tenant_id=None
     ):
         """
         Insert (chunk_text, embedding_vector) from iterable generator into the vector store.
@@ -99,11 +100,20 @@ class YugabyteDBVectorStore:
             document_id: UUID of the source document
             table_name: Name of the table to insert into
             embedding_iterator: Generator yielding (chunk_text, embedding_vector) tuples
+            pipeline_id: Pipeline tracking id
+            schema: Schema the backing vector table lives in. If None, falls back
+                to the schema this instance was constructed with (default 'public').
+                Resolved per-call so a single store instance can write to indexes
+                that live in different schemas.
             metadata: Optional metadata dictionary
             batch_size: Number of records to insert per batch
+            tenant_id: Optional UUID identifying the tenant. When None, the
+                row is written with SQL NULL (i.e. "no tenant").
         """
-        if not self._ensure_table_exists(table_name):
-            raise ValueError(f"Table '{self.schema}.{table_name}' doesn't exist.")
+        # Resolve schema per call (caller-supplied beats constructor default).
+        target_schema = schema or self.schema
+        if not self._ensure_table_exists(table_name, target_schema):
+            raise ValueError(f"Table '{target_schema}.{table_name}' doesn't exist.")
 
         conn = None
         try:
@@ -113,21 +123,26 @@ class YugabyteDBVectorStore:
             # Convert metadata to JSON string if it's a dict
             metadata_json = json.dumps(metadata) if metadata is not None else json.dumps({})
 
+            insert_stmt = sql.SQL(
+                "INSERT INTO {schema}.{table} "
+                "(chunk_text, embeddings, document_id, tenant_id, "
+                "metadata_filters) VALUES (%s, %s, %s, %s, %s)"
+            ).format(
+                schema=sql.Identifier(target_schema),
+                table=sql.Identifier(table_name),
+            )
+
             batch = []
             total_inserted = 0
             items_yielded = 0
             for chunk_text, embedding_vector in embedding_iterator:
                 items_yielded += 1
                 batch.append(
-                    (chunk_text, embedding_vector, document_id, metadata_json)
+                    (chunk_text, embedding_vector, document_id,
+                     tenant_id, metadata_json)
                 )
                 if len(batch) >= batch_size:
-                    cur.executemany(
-                        f"INSERT INTO {self.schema}.{table_name} "
-                        "(chunk_text, embeddings, document_id, "
-                        "metadata_filters) VALUES (%s, %s, %s, %s)",
-                        batch,
-                    )
+                    cur.executemany(insert_stmt, batch)
                     rows_inserted = cur.rowcount
                     total_inserted += rows_inserted
                     self.pipeline_tracking.update_embeddings_persisted(
@@ -136,7 +151,7 @@ class YugabyteDBVectorStore:
                     )
                     self.logger.info(
                         f"Inserted batch of {rows_inserted} rows into "
-                        f"{self.schema}.{table_name} (total so far: "
+                        f"{target_schema}.{table_name} (total so far: "
                         f"{total_inserted}, items yielded: {items_yielded})"
                     )
                     conn.commit()
@@ -144,12 +159,7 @@ class YugabyteDBVectorStore:
 
             # Insert any remaining items in the batch
             if batch:
-                cur.executemany(
-                    f"INSERT INTO {self.schema}.{table_name} "
-                    "(chunk_text, embeddings, document_id, "
-                    "metadata_filters) VALUES (%s, %s, %s, %s)",
-                    batch
-                )
+                cur.executemany(insert_stmt, batch)
                 rows_inserted = cur.rowcount
                 total_inserted += rows_inserted
                 self.pipeline_tracking.update_embeddings_persisted(
@@ -158,13 +168,13 @@ class YugabyteDBVectorStore:
                 )
                 self.logger.info(
                     f"Inserted final batch of {rows_inserted} rows into "
-                    f"{self.schema}.{table_name} (total: {total_inserted})"
+                    f"{target_schema}.{table_name} (total: {total_inserted})"
                 )
                 conn.commit()
 
             self.logger.info(
                 f"Completed inserting all {total_inserted} embeddings into "
-                f"{self.schema}.{table_name} (total items yielded by "
+                f"{target_schema}.{table_name} (total items yielded by "
                 f"generator: {items_yielded})"
             )
             cur.close()
@@ -183,27 +193,41 @@ class YugabyteDBVectorStore:
         self,
         table_name,
         distance_metric="vector_cosine_ops",
-        index_type="ybhnsw"
+        index_type="ybhnsw",
+        table_schema=None
     ):
         """
         Create an index on the embeddings column of the table.
+
+        Args:
+            table_name: Backing vector table to index.
+            distance_metric: pgvector ops class (e.g. vector_cosine_ops).
+            index_type: Index method (currently always ybhnsw).
+            table_schema: Schema the table lives in. If None, falls back to
+                the schema this instance was constructed with.
         """
+        target_schema = table_schema or self.schema
         conn = None
         try:
             conn = self._get_connection()
             cur = conn.cursor()
 
             # Try to create the index, ignore error if it already exists
-            sql_create_index = f"""
-                CREATE INDEX IF NOT EXISTS idx_{table_name}_embeddings
-                ON {self.schema}.{table_name}
-                USING ybhnsw (embeddings {distance_metric});
-            """
+            sql_create_index = sql.SQL(
+                "CREATE INDEX IF NOT EXISTS {idx_name} "
+                "ON {schema}.{table} "
+                "USING ybhnsw (embeddings {ops_class})"
+            ).format(
+                idx_name=sql.Identifier(f"idx_{table_name}_embeddings"),
+                schema=sql.Identifier(target_schema),
+                table=sql.Identifier(table_name),
+                ops_class=sql.SQL(distance_metric),
+            )
             cur.execute(sql_create_index)
 
             conn.commit()
             cur.close()
-            self.logger.info(f"Index created successfully on {self.schema}.{table_name}")
+            self.logger.info(f"Index created successfully on {target_schema}.{table_name}")
         except Exception as e:
             if conn:
                 conn.rollback()

--- a/python/ai/rag_agent/rag_pipeline/document_preprocessor.py
+++ b/python/ai/rag_agent/rag_pipeline/document_preprocessor.py
@@ -5,7 +5,7 @@ from models.work_queue_task import WorkQueueTask
 from rag_pipeline.rag_handler import RagPipelineHandler
 from db.source_document_tracking import SourceDocumentTracking
 from uuid import UUID
-from typing import Dict, Any
+from typing import Dict, Any, Optional, Tuple
 
 
 class DocumentPreprocessor(TaskProcessor):
@@ -138,33 +138,36 @@ class DocumentPreprocessor(TaskProcessor):
                 self.connection_pool.return_connection(connection)
         return None
 
-    def _retrieve_rag_index_name(self, index_id: UUID) -> str:
+    def _retrieve_rag_index_name(
+        self, index_id: UUID
+    ) -> Tuple[Optional[str], Optional[str]]:
         """
-        Retrieve the RAG index name.
+        Retrieve (index_name, schema_name) for the given index.
         """
         connection = None
+        cursor = None
         try:
             connection = self.connection_pool.get_connection()
             cursor = connection.cursor()
             query = """
-                SELECT index_name
+                SELECT index_name, schema_name
                 FROM dist_rag.vector_indexes
                 WHERE id = %s
             """
             cursor.execute(query, (str(index_id),))
             result = cursor.fetchone()
             if result:
-                return result[0]  # name is the first column
+                return result[0], result[1]
         except Exception as e:
             connection.rollback()
             self.logger.error(f"Error fetching RAG index name for index_id {index_id}: {str(e)}")
-            return None
+            return None, None
         finally:
             if cursor:
                 cursor.close()
             if connection:
                 self.connection_pool.return_connection(connection)
-        return None
+        return None, None
 
     def process(self, task: WorkQueueTask) -> Dict[str, Any]:
         """
@@ -183,6 +186,9 @@ class DocumentPreprocessor(TaskProcessor):
             source_id = task_details.get('source_id')
             document_id = task_details.get('document_id')
             document_uri = task_details.get('document_uri')
+            # tenant_id is optional in task_details for backward compatibility
+            # with tasks queued before the tenant_id column was added.
+            tenant_id = task_details.get('tenant_id')
 
             # Validate extracted parameters
             if not all([index_id, source_id, document_id, document_uri]):
@@ -230,8 +236,25 @@ class DocumentPreprocessor(TaskProcessor):
                 self.logger.error(f"Error retrieving source metadata: {str(e)}")
                 raise
 
+            # Fall back to looking up tenant_id on the source if it wasn't
+            # included in the task payload (e.g. older queued tasks).
+            if not tenant_id:
+                try:
+                    source_details = (
+                        self.source_document_tracking.get_source_details(
+                            source_id=source_id
+                        )
+                    )
+                    if source_details:
+                        tenant_id = source_details.get('tenant_id')
+                except Exception as e:
+                    self.logger.warning(
+                        f"Failed to resolve tenant_id from sources table "
+                        f"for source_id {source_id}: {str(e)}"
+                    )
+
             try:
-                rag_index_name = self._retrieve_rag_index_name(index_id=index_id)
+                rag_index_name, rag_schema_name = self._retrieve_rag_index_name(index_id=index_id)
                 if not rag_index_name:
                     raise ValueError(f"Failed to retrieve RAG index name for index_id: {index_id}")
             except Exception as e:
@@ -248,9 +271,11 @@ class DocumentPreprocessor(TaskProcessor):
                     document_id=document_id,
                     document_uri=document_uri,
                     table_name=rag_index_name,
+                    schema_name=rag_schema_name,
                     metadata=source_metadata,
                     chunk_kwargs=chunking_params,
-                    embedding_model_params=embedding_model_params
+                    embedding_model_params=embedding_model_params,
+                    tenant_id=tenant_id
                 )
                 self.logger.info(f"Task {task.id} processed successfully")
                 self.source_document_tracking.update_document_status(

--- a/python/ai/rag_agent/rag_pipeline/rag_handler.py
+++ b/python/ai/rag_agent/rag_pipeline/rag_handler.py
@@ -34,18 +34,26 @@ class RagPipelineHandler:
         document_id,
         document_uri,
         table_name,
+        schema_name=None,
         metadata=None,
         chunk_kwargs=None,
-        embedding_model_params=None
+        embedding_model_params=None,
+        tenant_id=None
     ):
         """
         Runs the pipeline: splits document, creates embeddings, and stores in YugabyteDB.
 
         Args:
             document_uri (str): Document URI to process.
+            schema_name (str, optional): Schema the backing vector table lives in.
+                If None, the vector store falls back to its constructor default
+                (currently 'public').
             metadata (dict, optional): Additional metadata to store.
             document_id (int, optional): document identifier of the file to be ingested.
             chunk_kwargs (dict, optional): Additional arguments for text chunking (e.g. chunk_size).
+            tenant_id (UUID/str, optional): Tenant identifier propagated to the
+                vector store row. Falls back to the all-zero UUID default when
+                not provided.
         """
 
         self.logger.debug(f"Ingesting document: {document_uri} with chunk_kwargs: {chunk_kwargs}")
@@ -82,13 +90,18 @@ class RagPipelineHandler:
             pipeline_id=pipeline_id, file_location=document_uri, chunk_args=chunk_kwargs)
 
         # 2. Insert into vector store
-        self.logger.debug(f"Inserting embeddings into vector store for document: {document_uri}")
+        self.logger.debug(
+            f"Inserting embeddings into vector store for document: {document_uri} "
+            f"target=({schema_name or 'public'}.{table_name})"
+        )
         self.vector_store.insert_embeddings(
             document_id=document_id,
             table_name=table_name,
+            schema=schema_name,
             embedding_iterator=embedding_iterator,
             metadata=metadata or {},
-            pipeline_id=pipeline_id
+            pipeline_id=pipeline_id,
+            tenant_id=tenant_id
         )
         return True
 
@@ -98,9 +111,11 @@ class RagPipelineHandler:
         document_id,
         document_uri,
         table_name,
+        schema_name=None,
         metadata=None,
         chunk_kwargs=None,
-        embedding_model_params=None
+        embedding_model_params=None,
+        tenant_id=None
     ):
         """
         Starts the processing of the document.
@@ -118,13 +133,17 @@ class RagPipelineHandler:
                 pipeline_id=pipeline_id,
                 document_uri=document_uri,
                 table_name=table_name,
+                schema_name=schema_name,
                 metadata=metadata,
                 chunk_kwargs=chunk_kwargs,
-                embedding_model_params=embedding_model_params
+                embedding_model_params=embedding_model_params,
+                tenant_id=tenant_id
             )
             self.logger.info(f"Processing of document: {document_uri} completed")
-            self.vector_store.create_index(table_name=table_name)
-            self.logger.info(f"Vector Index created successfully on {table_name}")
+            self.vector_store.create_index(table_name=table_name, table_schema=schema_name)
+            self.logger.info(
+                f"Vector Index created successfully on {schema_name or 'public'}.{table_name}"
+            )
 
             self.pipeline_tracking.update_pipeline_status(
                 pipeline_id=pipeline_id,

--- a/python/ai/rag_agent/tests/test_yugabytedb_vector_store.py
+++ b/python/ai/rag_agent/tests/test_yugabytedb_vector_store.py
@@ -15,6 +15,20 @@ from db.yugabytedb_vector_store import YugabyteDBVectorStore
 PIPELINE_ID = 1
 
 
+def _sql_text(sql_obj):
+    """Render a psycopg.sql.Composed (or plain str) as a comparable string.
+
+    insert_embeddings / create_index now build their statements with
+    psycopg.sql.Identifier so user-controlled (schema, table) are safely
+    quoted. The downside is that test assertions that used to do
+    `"INSERT INTO" in call_args[0][0]` against an f-string now see a
+    Composed object instead.
+    """
+    if hasattr(sql_obj, 'as_string'):
+        return sql_obj.as_string(None)
+    return sql_obj
+
+
 def _create_store(mock_pool_cls, mock_pt_cls):
     """Helper to create a YugabyteDBVectorStore with mocked dependencies."""
     mock_pool = Mock()
@@ -77,9 +91,10 @@ class TestYugabyteDBVectorStore:
         )
         mock_cur.fetchone.return_value = (True,)
 
-        result = store._ensure_table_exists("test_table")
+        result = store._ensure_table_exists("test_table", "public")
 
         assert result is True
+        assert mock_cur.execute.call_args[0][1] == ("public", "test_table")
 
     @patch('db.yugabytedb_vector_store.PipelineTracking')
     @patch('db.yugabytedb_vector_store.ConnectionPool')
@@ -90,7 +105,7 @@ class TestYugabyteDBVectorStore:
         )
         mock_cur.fetchone.return_value = (False,)
 
-        result = store._ensure_table_exists("nonexistent_table")
+        result = store._ensure_table_exists("nonexistent_table", "public")
 
         assert result is False
 
@@ -120,8 +135,12 @@ class TestYugabyteDBVectorStore:
 
         mock_cur.executemany.assert_called_once()
         call_args = mock_cur.executemany.call_args
-        assert "INSERT INTO" in call_args[0][0]
-        assert "test_table" in call_args[0][0]
+        rendered_sql = _sql_text(call_args[0][0])
+        assert "INSERT INTO" in rendered_sql
+        # Identifier quoting wraps the name in double quotes.
+        assert '"test_table"' in rendered_sql
+        # Default schema (constructor fallback) is "public".
+        assert '"public"' in rendered_sql
         mock_conn.commit.assert_called()
 
     @patch('db.yugabytedb_vector_store.PipelineTracking')
@@ -251,7 +270,10 @@ class TestYugabyteDBVectorStore:
         call_args = mock_cur.executemany.call_args
         data = call_args[0][1]
         # metadata is serialized as JSON '{}' when None
-        assert data == [("chunk 1", [0.1, 0.2, 0.3], 1, '{}')]
+        assert data == [(
+            "chunk 1", [0.1, 0.2, 0.3], 1,
+            None, '{}',
+        )]
 
     @patch('db.yugabytedb_vector_store.PipelineTracking')
     @patch('db.yugabytedb_vector_store.ConnectionPool')
@@ -337,7 +359,8 @@ class TestYugabyteDBVectorStore:
         assert data[0][0] == "chunk 1"
         assert data[0][1] == [0.1, 0.2, 0.3]
         assert data[0][2] == 1
-        assert json.loads(data[0][3]) == complex_metadata
+        assert data[0][3] is None
+        assert json.loads(data[0][4]) == complex_metadata
 
     @patch('db.yugabytedb_vector_store.PipelineTracking')
     @patch('db.yugabytedb_vector_store.ConnectionPool')
@@ -372,10 +395,50 @@ class TestYugabyteDBVectorStore:
 
         assert result is True
         mock_cur.execute.assert_called_once()
-        call_sql = mock_cur.execute.call_args[0][0]
+        call_sql = _sql_text(mock_cur.execute.call_args[0][0])
         assert "CREATE INDEX IF NOT EXISTS" in call_sql
-        assert "test_table" in call_sql
+        # Identifier quoting wraps both the index name and the table.
+        assert '"idx_test_table_embeddings"' in call_sql
+        assert '"public"."test_table"' in call_sql
         mock_conn.commit.assert_called()
+
+    @patch('db.yugabytedb_vector_store.PipelineTracking')
+    @patch('db.yugabytedb_vector_store.ConnectionPool')
+    def test_create_index_custom_schema(self, mock_pool_cls, mock_pt_cls):
+        """create_index honors a per-call schema override."""
+        store, mock_pool, mock_pt, mock_conn, mock_cur = _create_store(
+            mock_pool_cls, mock_pt_cls
+        )
+
+        store.create_index(table_name="test_table", table_schema="tenant_a")
+
+        call_sql = _sql_text(mock_cur.execute.call_args[0][0])
+        assert '"tenant_a"."test_table"' in call_sql
+
+    @patch('db.yugabytedb_vector_store.PipelineTracking')
+    @patch('db.yugabytedb_vector_store.ConnectionPool')
+    def test_insert_embeddings_custom_schema(self, mock_pool_cls, mock_pt_cls):
+        """insert_embeddings honors a per-call schema override."""
+        store, mock_pool, mock_pt, mock_conn, mock_cur = _create_store(
+            mock_pool_cls, mock_pt_cls
+        )
+        # _ensure_table_exists must see the per-call schema, not the constructor default.
+        mock_cur.fetchone.return_value = (True,)
+
+        store.insert_embeddings(
+            document_id=1,
+            table_name="test_table",
+            embedding_iterator=[("chunk 1", [0.1, 0.2, 0.3])],
+            pipeline_id=PIPELINE_ID,
+            schema="tenant_a",
+            metadata={"source": "test"},
+            batch_size=16
+        )
+
+        # Existence query should have been parameterized with the override schema.
+        assert mock_cur.execute.call_args[0][1] == ("tenant_a", "test_table")
+        rendered_sql = _sql_text(mock_cur.executemany.call_args[0][0])
+        assert '"tenant_a"."test_table"' in rendered_sql
 
 
 if __name__ == "__main__":

--- a/src/postgres/src/include/catalog/catalog.h
+++ b/src/postgres/src/include/catalog/catalog.h
@@ -29,7 +29,7 @@
  * If you increment it, make sure you didn't forget to add a new SQL migration
  * (see pg_yb_migration.dat and src/yb/yql/pgwrapper/ysql_migrations/README.md)
  */
-#define YB_LAST_USED_OID 8113
+#define YB_LAST_USED_OID 8116
 
 extern bool IsSystemRelation(Relation relation);
 extern bool IsToastRelation(Relation relation);

--- a/src/postgres/src/include/catalog/pg_type.h
+++ b/src/postgres/src/include/catalog/pg_type.h
@@ -25,7 +25,7 @@
 
 #define BSONOID				8095
 #define VECTOROID			8078
-#define GRAPHIDOID			8113
+#define GRAPHIDOID			8116
 
 /* ----------------
  *		pg_type definition.  cpp turns this into

--- a/src/postgres/src/include/catalog/unused_oids
+++ b/src/postgres/src/include/catalog/unused_oids
@@ -44,7 +44,7 @@ push @{$oids}, 8095;
 push @{$oids}, 8078;
 
 # YB: GRAPHIDOID
-push @{$oids}, 8113;
+push @{$oids}, 8116;
 
 my $prev_oid = 0;
 my @sortedoids = sort { $a <=> $b } @{$oids};

--- a/src/postgres/third-party-extensions/mage/regress/expected/yb.orig.basic.out
+++ b/src/postgres/third-party-extensions/mage/regress/expected/yb.orig.basic.out
@@ -9,7 +9,6 @@ SET search_path TO mag_catalog;
 SELECT create_graph('basic');
 NOTICE:  substituting access method "lsm" for "btree" in YugabyteDB
 NOTICE:  substituting access method "lsm" for "btree" in YugabyteDB
-NOTICE:  substituting access method "lsm" for "btree" in YugabyteDB
 NOTICE:  graph "basic" has been created
  create_graph 
 --------------
@@ -22,15 +21,20 @@ SELECT name, namespace FROM ag_graph WHERE name = 'basic';
  basic | basic
 (1 row)
 
-SELECT * FROM cypher('basic', $$ CREATE (:person {name: 'Alice'}) $$) AS (a agtype);
-NOTICE:  substituting access method "lsm" for "btree" in YugabyteDB
-LINE 1: SELECT * FROM cypher('basic', $$ CREATE (:person {name: 'Ali...
-                                       ^
+-- meko_datapack_id, meko_user_id and meko_agent_id are NOT NULL on
+-- vertex/edge tables, so the cypher CREATE must supply them as properties.
+SELECT * FROM cypher('basic', $$ CREATE (:person {name: 'Alice',
+    meko_datapack_id: '00000000-0000-0000-0000-000000000001',
+    meko_user_id: '00000000-0000-0000-0000-000000000002',
+    meko_agent_id: 'agent-1'}) $$) AS (a agtype);
  a 
 ---
 (0 rows)
 
-SELECT * FROM cypher('basic', $$ CREATE (:person {name: 'Bob'}) $$) AS (a agtype);
+SELECT * FROM cypher('basic', $$ CREATE (:person {name: 'Bob',
+    meko_datapack_id: '00000000-0000-0000-0000-000000000001',
+    meko_user_id: '00000000-0000-0000-0000-000000000002',
+    meko_agent_id: 'agent-1'}) $$) AS (a agtype);
  a 
 ---
 (0 rows)
@@ -41,6 +45,30 @@ SELECT * FROM cypher('basic', $$ MATCH (n:person) RETURN count(n) $$) AS (cnt ag
  2
 (1 row)
 
+-- cypher CREATE without the required meko_* tenant properties errors out.
+SELECT * FROM cypher('basic', $$ CREATE (:person {name: 'NoTenant'}) $$) AS (a agtype);
+ERROR:  missing required tenant property "meko_datapack_id"
+-- SET cannot mutate meko_* tenant properties.
+SELECT * FROM cypher('basic', $$ MATCH (n:person {name: 'Alice'})
+    SET n.meko_user_id = '00000000-0000-0000-0000-000000000099' $$) AS (a agtype);
+ERROR:  tenant property "meko_user_id" cannot be modified by SET
+HINT:  Drop and recreate the vertex/edge to change its tenant identity.
+-- create_complete_graph and age_create_barbell_graph reach
+-- yb_insert_*_simple, which lacks tenant column support yet (#31338).
+-- Confirm they raise feature_not_supported rather than violating the
+-- meko_* NOT NULL constraints.
+SELECT create_complete_graph('basic', 3, 'gen_edge', 'gen_vertex');
+NOTICE:  VLabel "gen_vertex" has been created
+NOTICE:  substituting access method "lsm" for "btree" in YugabyteDB
+NOTICE:  substituting access method "lsm" for "btree" in YugabyteDB
+NOTICE:  ELabel "gen_edge" has been created
+ERROR:  simple vertex insert is not supported on YugabyteDB yet (#31338)
+SELECT age_create_barbell_graph('basic', 3, 0, 'bb_vertex', NULL, 'bb_edge', NULL);
+NOTICE:  VLabel "bb_vertex" has been created
+NOTICE:  substituting access method "lsm" for "btree" in YugabyteDB
+NOTICE:  substituting access method "lsm" for "btree" in YugabyteDB
+NOTICE:  ELabel "bb_edge" has been created
+ERROR:  simple vertex insert is not supported on YugabyteDB yet (#31338)
 RESET search_path;
 -- DROP EXTENSION must trigger ag_ProcessUtility_hook -> drop_age_extension,
 -- which cleans up the per-graph schema. The two count(*) queries below catch

--- a/src/postgres/third-party-extensions/mage/regress/sql/yb.orig.basic.sql
+++ b/src/postgres/third-party-extensions/mage/regress/sql/yb.orig.basic.sql
@@ -3,9 +3,28 @@ SELECT extname, extversion FROM pg_extension WHERE extname = 'mage';
 SET search_path TO mag_catalog;
 SELECT create_graph('basic');
 SELECT name, namespace FROM ag_graph WHERE name = 'basic';
-SELECT * FROM cypher('basic', $$ CREATE (:person {name: 'Alice'}) $$) AS (a agtype);
-SELECT * FROM cypher('basic', $$ CREATE (:person {name: 'Bob'}) $$) AS (a agtype);
+-- meko_datapack_id, meko_user_id and meko_agent_id are NOT NULL on
+-- vertex/edge tables, so the cypher CREATE must supply them as properties.
+SELECT * FROM cypher('basic', $$ CREATE (:person {name: 'Alice',
+    meko_datapack_id: '00000000-0000-0000-0000-000000000001',
+    meko_user_id: '00000000-0000-0000-0000-000000000002',
+    meko_agent_id: 'agent-1'}) $$) AS (a agtype);
+SELECT * FROM cypher('basic', $$ CREATE (:person {name: 'Bob',
+    meko_datapack_id: '00000000-0000-0000-0000-000000000001',
+    meko_user_id: '00000000-0000-0000-0000-000000000002',
+    meko_agent_id: 'agent-1'}) $$) AS (a agtype);
 SELECT * FROM cypher('basic', $$ MATCH (n:person) RETURN count(n) $$) AS (cnt agtype);
+-- cypher CREATE without the required meko_* tenant properties errors out.
+SELECT * FROM cypher('basic', $$ CREATE (:person {name: 'NoTenant'}) $$) AS (a agtype);
+-- SET cannot mutate meko_* tenant properties.
+SELECT * FROM cypher('basic', $$ MATCH (n:person {name: 'Alice'})
+    SET n.meko_user_id = '00000000-0000-0000-0000-000000000099' $$) AS (a agtype);
+-- create_complete_graph and age_create_barbell_graph reach
+-- yb_insert_*_simple, which lacks tenant column support yet (#31338).
+-- Confirm they raise feature_not_supported rather than violating the
+-- meko_* NOT NULL constraints.
+SELECT create_complete_graph('basic', 3, 'gen_edge', 'gen_vertex');
+SELECT age_create_barbell_graph('basic', 3, 0, 'bb_vertex', NULL, 'bb_edge', NULL);
 RESET search_path;
 -- DROP EXTENSION must trigger ag_ProcessUtility_hook -> drop_age_extension,
 -- which cleans up the per-graph schema. The two count(*) queries below catch

--- a/src/postgres/third-party-extensions/mage/sql/age_main.sql
+++ b/src/postgres/third-party-extensions/mage/sql/age_main.sql
@@ -149,7 +149,7 @@ CREATE FUNCTION mag_catalog.load_edges_from_file(graph_name name,
 
 -- YB: Set the hard coded oid.
 SET yb_binary_restore TO true;
-SELECT binary_upgrade_set_next_pg_type_oid(8113);
+SELECT binary_upgrade_set_next_pg_type_oid(8116);
 CREATE TYPE graphid;
 SET yb_binary_restore TO false;
 

--- a/src/postgres/third-party-extensions/mage/src/backend/commands/label_commands.c
+++ b/src/postgres/third-party-extensions/mage/src/backend/commands/label_commands.c
@@ -100,6 +100,10 @@ static void create_index_on_column(char *schema_name,
                                    char *rel_name,
                                    char *colname,
                                    bool unique);
+/* YB: composite tenant-scoped PK index helper (vertex and edge use the same shape) */
+static void yb_create_label_pk_index(char *schema_name, char *rel_name);
+/* YB: append meko_* tenant ColumnDefs to a vertex/edge column list */
+static List *yb_append_meko_column_defs(List *cols, bool is_edge);
 
 PG_FUNCTION_INFO_V1(age_is_valid_label_name);
 
@@ -444,13 +448,29 @@ static void create_table_for_label(char *graph_name, char *label_name,
                    PROCESS_UTILITY_SUBCOMMAND, NULL, NULL, None_Receiver,
                    NULL);
     
-    /* Create index on id columns */
+    /*
+     * Create index on id columns.
+     *
+     * YB: Upstream Apache AGE creates a single-column unique index on "id" for
+     * vertex tables (and no PK index for edge tables). On YugabyteDB we instead
+     * build a composite tenant-scoped primary key over (meko_datapack_id,
+     * meko_user_id, meko_agent_id, id) so that rows for different tenants are
+     * colocated/sharded by tenant and queries can prune to a single tenant.
+     * Edge tables get the same composite PK in YB mode (upstream has none),
+     * while the start_id/end_id secondary indexes are created unconditionally
+     * to match upstream behavior.
+     */
     if (label_type == LABEL_TYPE_VERTEX)
     {
-        create_index_on_column(schema_name, rel_name, "id", true);
+        if (IsYugaByteEnabled())
+            yb_create_label_pk_index(schema_name, rel_name); /* YB: tenant-scoped PK */
+        else
+            create_index_on_column(schema_name, rel_name, "id", true);
     }
     else if (label_type == LABEL_TYPE_EDGE)
     {
+        if (IsYugaByteEnabled())
+            yb_create_label_pk_index(schema_name, rel_name); /* YB: tenant-scoped PK */
         create_index_on_column(schema_name, rel_name, "start_id", false);
         create_index_on_column(schema_name, rel_name, "end_id", false);
     }
@@ -508,13 +528,174 @@ static void create_index_on_column(char *schema_name,
                    NULL);
 }
 
-/* 
- * CREATE TABLE `schema_name`.`rel_name` (
- * "id" graphid PRIMARY KEY DEFAULT "ag_catalog"."_graphid"(...),
- * "start_id" graphid NOT NULL
- * "end_id" graphid NOT NULL
- * "properties" agtype NOT NULL DEFAULT "ag_catalog"."agtype_build_map"()
- * )
+/*
+ * YB: Build a SORTBY_HASH IndexElem for `colname` (no opclass).
+ */
+static IndexElem *yb_make_meko_hash_elem(const char *colname)
+{
+    IndexElem *elem = makeNode(IndexElem);
+
+    elem->name = (char *) colname;
+    elem->expr = NULL;
+    elem->indexcolname = NULL;
+    elem->collation = NIL;
+    elem->opclass = NIL;
+    elem->opclassopts = NIL;
+    elem->ordering = SORTBY_HASH;
+    elem->nulls_ordering = SORTBY_NULLS_DEFAULT;
+    return elem;
+}
+
+/*
+ * YB: Build a SORTBY_ASC IndexElem for `colname`. If `opclass` is non-NULL,
+ * it is used as a single-element opclass list (needed for graphid_ops).
+ */
+static IndexElem *yb_make_meko_asc_elem(const char *colname, const char *opclass)
+{
+    IndexElem *elem = makeNode(IndexElem);
+
+    elem->name = (char *) colname;
+    elem->expr = NULL;
+    elem->indexcolname = NULL;
+    elem->collation = NIL;
+    elem->opclass = (opclass ? list_make1(makeString((char *) opclass)) : NIL);
+    elem->opclassopts = NIL;
+    elem->ordering = SORTBY_ASC;
+    elem->nulls_ordering = SORTBY_NULLS_DEFAULT;
+    return elem;
+}
+
+/*
+ * YB: Create the composite primary key index for both vertex and edge label
+ * tables:
+ *   PRIMARY KEY ((meko_datapack_id, meko_user_id) HASH,
+ *                meko_agent_id ASC, id ASC)
+ *
+ * Vertex and edge tables share the same column names for the tenant
+ * key, so a single helper covers both.
+ *
+ * Only meko_datapack_id and meko_user_id are part of the hash key — that is
+ * the granularity at which we want to spread rows across tablets. meko_agent_id
+ * is left as a range key (ASC) so that rows for all agents owned by the same
+ * (datapack, user) tenant land on the same tablet and can be range-scanned
+ * together; hashing on agent_id would scatter them, defeating tenant locality.
+ */
+static void yb_create_label_pk_index(char *schema_name, char *rel_name)
+{
+    IndexStmt *index_stmt;
+    PlannedStmt *index_wrapper;
+
+    index_stmt = makeNode(IndexStmt);
+    index_stmt->relation = makeRangeVar(schema_name, rel_name, -1);
+    index_stmt->accessMethod = "lsm";
+    index_stmt->tableSpace = NULL;
+    index_stmt->indexParams = list_make4(
+        yb_make_meko_hash_elem(AG_VERTEX_COLNAME_MEKO_DATAPACK_ID),
+        yb_make_meko_hash_elem(AG_VERTEX_COLNAME_MEKO_USER_ID),
+        yb_make_meko_asc_elem(AG_VERTEX_COLNAME_MEKO_AGENT_ID, NULL),
+        yb_make_meko_asc_elem(AG_VERTEX_COLNAME_ID, "graphid_ops"));
+    index_stmt->options = NIL;
+    index_stmt->whereClause = NULL;
+    index_stmt->excludeOpNames = NIL;
+    index_stmt->idxcomment = NULL;
+    index_stmt->indexOid = InvalidOid;
+    index_stmt->unique = true;
+    index_stmt->nulls_not_distinct = false;
+    index_stmt->primary = true;
+    index_stmt->isconstraint = true;
+    index_stmt->deferrable = false;
+    index_stmt->initdeferred = false;
+    index_stmt->transformed = false;
+    index_stmt->concurrent = false;
+    index_stmt->if_not_exists = false;
+    index_stmt->reset_default_tblspc = false;
+
+    index_wrapper = makeNode(PlannedStmt);
+    index_wrapper->commandType = CMD_UTILITY;
+    index_wrapper->canSetTag = false;
+    index_wrapper->utilityStmt = (Node *) index_stmt;
+    index_wrapper->stmt_location = -1;
+    index_wrapper->stmt_len = 0;
+
+    ProcessUtility(index_wrapper,
+                   "(generated CREATE INDEX command for label PK)", false,
+                   PROCESS_UTILITY_SUBCOMMAND, NULL, NULL, None_Receiver,
+                   NULL);
+}
+
+/*
+ * YB: Append the four meko_* tenant ColumnDefs to a vertex/edge column list:
+ *   "meko_datapack_id"     UUID NOT NULL,
+ *   "meko_user_id"         UUID NOT NULL,
+ *   "meko_agent_id"        TEXT NOT NULL,
+ *   "meko_conversation_id" UUID
+ *
+ * Vertex and edge label tables use identical column names for these (only
+ * the AG_VERTEX_COLNAME_* / AG_EDGE_COLNAME_* macro names differ), so the
+ * same helper produces both. `is_edge` selects the macro family for
+ * symmetry with the rest of the file but the resulting column names are
+ * the same string either way.
+ */
+static List *yb_append_meko_column_defs(List *cols, bool is_edge)
+{
+    ColumnDef *meko_datapack_id;
+    ColumnDef *meko_user_id;
+    ColumnDef *meko_agent_id;
+    ColumnDef *meko_conversation_id;
+
+    /* "meko_datapack_id" UUID NOT NULL */
+    meko_datapack_id = makeColumnDef(is_edge ? AG_EDGE_COLNAME_MEKO_DATAPACK_ID
+                                             : AG_VERTEX_COLNAME_MEKO_DATAPACK_ID,
+                                     UUIDOID, -1, InvalidOid);
+    meko_datapack_id->constraints = list_make1(build_not_null_constraint());
+
+    /* "meko_user_id" UUID NOT NULL */
+    meko_user_id = makeColumnDef(is_edge ? AG_EDGE_COLNAME_MEKO_USER_ID
+                                         : AG_VERTEX_COLNAME_MEKO_USER_ID,
+                                 UUIDOID, -1, InvalidOid);
+    meko_user_id->constraints = list_make1(build_not_null_constraint());
+
+    /* "meko_agent_id" TEXT NOT NULL */
+    meko_agent_id = makeColumnDef(is_edge ? AG_EDGE_COLNAME_MEKO_AGENT_ID
+                                          : AG_VERTEX_COLNAME_MEKO_AGENT_ID,
+                                  TEXTOID, -1, InvalidOid);
+    meko_agent_id->constraints = list_make1(build_not_null_constraint());
+
+    /* "meko_conversation_id" UUID (nullable) */
+    meko_conversation_id =
+        makeColumnDef(is_edge ? AG_EDGE_COLNAME_MEKO_CONVERSATION_ID
+                              : AG_VERTEX_COLNAME_MEKO_CONVERSATION_ID,
+                      UUIDOID, -1, InvalidOid);
+
+    cols = lappend(cols, meko_datapack_id);
+    cols = lappend(cols, meko_user_id);
+    cols = lappend(cols, meko_agent_id);
+    cols = lappend(cols, meko_conversation_id);
+    return cols;
+}
+
+/*
+ * Upstream Apache AGE layout:
+ *   CREATE TABLE `schema_name`.`rel_name` (
+ *     "id"         graphid PRIMARY KEY DEFAULT "ag_catalog"."_graphid"(...),
+ *     "start_id"   graphid NOT NULL,
+ *     "end_id"     graphid NOT NULL,
+ *     "properties" agtype  NOT NULL DEFAULT "ag_catalog"."agtype_build_map"()
+ *   )
+ *
+ * YB: Diverges from upstream Apache AGE in two ways (only when
+ * IsYugaByteEnabled() is true; vanilla PG builds preserve the upstream
+ * 4-column layout):
+ *   1. The "id" column is no longer declared PRIMARY KEY inline; the PK is
+ *      created later as a composite tenant-scoped index over
+ *      (meko_datapack_id, meko_user_id, meko_agent_id, id) via
+ *      yb_create_edge_pk_index().
+ *   2. Four meko_* tenant columns are appended so that all rows in an edge
+ *      label can be partitioned/sharded by tenant:
+ *        "meko_datapack_id"     UUID NOT NULL,
+ *        "meko_user_id"         UUID NOT NULL,
+ *        "meko_agent_id"        TEXT NOT NULL,
+ *        "meko_conversation_id" UUID
  */
 static List *create_edge_table_elements(char *graph_name, char *label_name,
                                         char *schema_name, char *rel_name,
@@ -524,12 +705,28 @@ static List *create_edge_table_elements(char *graph_name, char *label_name,
     ColumnDef *start_id;
     ColumnDef *end_id;
     ColumnDef *props;
+    List *yb_cols; /* YB: declared up front so we can lappend meko_* on YB */
 
     /* "id" graphid PRIMARY KEY DEFAULT "ag_catalog"."_graphid"(...) */
     id = makeColumnDef(AG_EDGE_COLNAME_ID, GRAPHIDOID, -1, InvalidOid);
-    id->constraints = list_make2(build_pk_constraint(),
-                                 build_id_default(graph_name, label_name,
-                                                  schema_name, seq_name));
+    if (IsYugaByteEnabled())
+    {
+        /*
+         * YB: "id" is only NOT NULL here; the PRIMARY KEY is added later
+         * as a composite tenant-scoped index over
+         * (meko_datapack_id, meko_user_id, meko_agent_id, id) by
+         * yb_create_edge_pk_index().
+         */
+        id->constraints = list_make2(build_not_null_constraint(),
+                                     build_id_default(graph_name, label_name,
+                                                      schema_name, seq_name));
+    }
+    else
+    {
+        id->constraints = list_make2(build_pk_constraint(),
+                                     build_id_default(graph_name, label_name,
+                                                      schema_name, seq_name));
+    }
 
     /* "start_id" graphid NOT NULL */
     start_id = makeColumnDef(AG_EDGE_COLNAME_START_ID, GRAPHIDOID, -1,
@@ -546,14 +743,35 @@ static List *create_edge_table_elements(char *graph_name, char *label_name,
     props->constraints = list_make2(build_not_null_constraint(),
                                     build_properties_default());
 
-    return list_make4(id, start_id, end_id, props);
+    yb_cols = list_make4(id, start_id, end_id, props);
+
+    /* YB: tenant columns are only added on YugabyteDB-hosted edge tables. */
+    if (IsYugaByteEnabled())
+        yb_cols = yb_append_meko_column_defs(yb_cols, true /* is_edge */);
+
+    return yb_cols;
 }
 
-/* 
- * CREATE TABLE `schema_name`.`rel_name` (
- * "id" graphid PRIMARY KEY DEFAULT "ag_catalog"."_graphid"(...),
- * "properties" agtype NOT NULL DEFAULT "ag_catalog"."agtype_build_map"()
- * )
+/*
+ * Upstream Apache AGE layout:
+ *   CREATE TABLE `schema_name`.`rel_name` (
+ *     "id"         graphid PRIMARY KEY DEFAULT "ag_catalog"."_graphid"(...),
+ *     "properties" agtype  NOT NULL DEFAULT "ag_catalog"."agtype_build_map"()
+ *   )
+ *
+ * YB: Diverges from upstream Apache AGE in two ways (only when
+ * IsYugaByteEnabled() is true; vanilla PG builds preserve the upstream
+ * 2-column layout):
+ *   1. The "id" column is no longer declared PRIMARY KEY inline; the PK is
+ *      created later as a composite tenant-scoped index over
+ *      (meko_datapack_id, meko_user_id, meko_agent_id, id) via
+ *      yb_create_vertex_pk_index().
+ *   2. Four meko_* tenant columns are appended so that all rows in a vertex
+ *      label can be partitioned/sharded by tenant:
+ *        "meko_datapack_id"     UUID NOT NULL,
+ *        "meko_user_id"         UUID NOT NULL,
+ *        "meko_agent_id"        TEXT NOT NULL,
+ *        "meko_conversation_id" UUID
  */
 static List *create_vertex_table_elements(char *graph_name, char *label_name,
                                           char *schema_name, char *rel_name,
@@ -561,6 +779,7 @@ static List *create_vertex_table_elements(char *graph_name, char *label_name,
 {
     ColumnDef *id;
     ColumnDef *props;
+    List *yb_cols; /* YB: declared up front so we can lappend meko_* on YB */
 
     /* "id" graphid PRIMARY KEY DEFAULT "ag_catalog"."_graphid"(...) */
     id = makeColumnDef(AG_VERTEX_COLNAME_ID, GRAPHIDOID, -1, InvalidOid);
@@ -574,7 +793,13 @@ static List *create_vertex_table_elements(char *graph_name, char *label_name,
     props->constraints = list_make2(build_not_null_constraint(),
                                     build_properties_default());
 
-    return list_make2(id, props);
+    yb_cols = list_make2(id, props);
+
+    /* YB: tenant columns are only added on YugabyteDB-hosted vertex tables. */
+    if (IsYugaByteEnabled())
+        yb_cols = yb_append_meko_column_defs(yb_cols, false /* is_edge */);
+
+    return yb_cols;
 }
 
 /* CREATE SEQUENCE `seq_range_var` MAXVALUE `LOCAL_ID_MAX` */

--- a/src/postgres/third-party-extensions/mage/src/backend/executor/cypher_create.c
+++ b/src/postgres/third-party-extensions/mage/src/backend/executor/cypher_create.c
@@ -24,6 +24,7 @@
 #include "executor/cypher_utils.h"
 
 /* YB includes */
+#include "pg_yb_utils.h"
 #include "utils/age_global_graph.h"
 
 static void begin_cypher_create(CustomScanState *node, EState *estate,
@@ -413,6 +414,11 @@ static void create_edge(cypher_create_custom_scan_state *css,
     elemTupleSlot->tts_isnull[edge_tuple_properties] =
         scanTupleSlot->tts_isnull[node->prop_attr_num];
 
+    if (IsYugaByteEnabled())
+        yb_populate_edge_meko_columns(elemTupleSlot,
+            yb_extract_meko_columns_from_properties(
+                scanTupleSlot->tts_values[node->prop_attr_num],
+                scanTupleSlot->tts_isnull[node->prop_attr_num]));
     /* Insert the new edge */
     insert_entity_tuple(resultRelInfo, elemTupleSlot, estate);
 
@@ -499,6 +505,12 @@ static Datum create_vertex(cypher_create_custom_scan_state *css,
             scanTupleSlot->tts_values[node->prop_attr_num];
         elemTupleSlot->tts_isnull[vertex_tuple_properties] =
             scanTupleSlot->tts_isnull[node->prop_attr_num];
+
+        if (IsYugaByteEnabled())
+            yb_populate_vertex_meko_columns(elemTupleSlot,
+                yb_extract_meko_columns_from_properties(
+                    scanTupleSlot->tts_values[node->prop_attr_num],
+                    scanTupleSlot->tts_isnull[node->prop_attr_num]));
 
         /* Insert the new vertex */
         insert_entity_tuple(resultRelInfo, elemTupleSlot, estate);

--- a/src/postgres/third-party-extensions/mage/src/backend/executor/cypher_merge.c
+++ b/src/postgres/third-party-extensions/mage/src/backend/executor/cypher_merge.c
@@ -23,6 +23,7 @@
 #include "executor/cypher_executor.h"
 #include "executor/cypher_utils.h"
 /* YB includes */
+#include "pg_yb_utils.h"
 #include "utils/age_global_graph.h"
 #include "utils/datum.h"
 
@@ -1066,6 +1067,10 @@ static Datum merge_vertex(cypher_merge_custom_scan_state *css,
         elemTupleSlot->tts_values[vertex_tuple_properties] = prop;
         elemTupleSlot->tts_isnull[vertex_tuple_properties] = isNull;
 
+        if (IsYugaByteEnabled())
+            yb_populate_vertex_meko_columns(elemTupleSlot,
+                yb_extract_meko_columns_from_properties(prop, isNull));
+
         /*
          * Insert the new vertex.
          *
@@ -1407,6 +1412,10 @@ static void merge_edge(cypher_merge_custom_scan_state *css,
     /* store the properties in the tuple slot */
     elemTupleSlot->tts_values[edge_tuple_properties] = prop;
     elemTupleSlot->tts_isnull[edge_tuple_properties] = isNull;
+
+    if (IsYugaByteEnabled())
+        yb_populate_edge_meko_columns(elemTupleSlot,
+            yb_extract_meko_columns_from_properties(prop, isNull));
 
     /*
      * Insert the new edge.

--- a/src/postgres/third-party-extensions/mage/src/backend/executor/cypher_set.c
+++ b/src/postgres/third-party-extensions/mage/src/backend/executor/cypher_set.c
@@ -25,6 +25,8 @@
 #include "executor/cypher_utils.h"
 
 /* YB includes */
+#include "catalog/ag_label.h"
+#include "commands/label_commands.h"
 #include "executor/ybModifyTable.h"
 #include "pg_yb_utils.h"
 #include "utils/age_global_graph.h"
@@ -42,6 +44,8 @@ static HeapTuple yb_update_entity_tuple(ResultRelInfo *resultRelInfo,
 static HeapTuple update_entity_tuple(ResultRelInfo *resultRelInfo,
                                      TupleTableSlot *elemTupleSlot,
                                      EState *estate, HeapTuple old_tuple);
+
+static const YbMekoDp EmptyYbMekoDp = {0};
 
 const CustomExecMethods cypher_set_exec_methods = {SET_SCAN_STATE_NAME,
                                                       begin_cypher_set,
@@ -522,6 +526,30 @@ static void process_update_list(CustomScanState *node)
                             clause_name)));
         }
 
+        /*
+         * YB: meko_* tenant columns are derived from row identity and must
+         * not be mutated by SET/REMOVE; they have to be re-set by dropping
+         * the row and recreating it.
+         */
+        if (IsYugaByteEnabled() &&
+            update_item->prop_name != NULL &&
+            (strcmp(update_item->prop_name,
+                    AG_VERTEX_COLNAME_MEKO_DATAPACK_ID) == 0 ||
+             strcmp(update_item->prop_name,
+                    AG_VERTEX_COLNAME_MEKO_USER_ID) == 0 ||
+             strcmp(update_item->prop_name,
+                    AG_VERTEX_COLNAME_MEKO_AGENT_ID) == 0 ||
+             strcmp(update_item->prop_name,
+                    AG_VERTEX_COLNAME_MEKO_CONVERSATION_ID) == 0))
+        {
+            ereport(ERROR,
+                    (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                     errmsg("tenant property \"%s\" cannot be modified by %s",
+                            update_item->prop_name, clause_name),
+                     errhint("Drop and recreate the vertex/edge to change "
+                             "its tenant identity.")));
+        }
+
         /* get the id and label for later */
         id = GET_AGTYPE_VALUE_OBJECT_VALUE(original_entity_value, "id");
         label = GET_AGTYPE_VALUE_OBJECT_VALUE(original_entity_value, "label");
@@ -603,7 +631,12 @@ static void process_update_list(CustomScanState *node)
                                      CStringGetDatum(label_name),
                                      AGTYPE_P_GET_DATUM(agtype_value_to_agtype(altered_properties)));
 
-            slot = populate_vertex_tts(slot, id, altered_properties);
+            /*
+             * YB: pass a zeroed YbMekoDp; the meko_* tenant columns are
+             * re-populated below from the existing on-disk tuple.
+             */
+            slot = populate_vertex_tts(slot, id, altered_properties,
+                                       EmptyYbMekoDp);
         }
         else if (original_entity_value->type == AGTV_EDGE)
         {
@@ -616,8 +649,13 @@ static void process_update_list(CustomScanState *node)
                                    CStringGetDatum(label_name),
                                    AGTYPE_P_GET_DATUM(agtype_value_to_agtype(altered_properties)));
 
+            /*
+             * YB: pass a zeroed YbMekoDp; the meko_* tenant columns are
+             * re-populated below from the existing on-disk tuple.
+             */
             slot = populate_edge_tts(slot, id, startid, endid,
-                                     altered_properties);
+                                     altered_properties,
+                                     EmptyYbMekoDp);
         }
         else
         {
@@ -667,6 +705,19 @@ static void process_update_list(CustomScanState *node)
              */
             if (HeapTupleIsValid(heap_tuple))
             {
+                /*
+                 * YB: SET only rewrites the properties column, so carry the
+                 * tenant columns over from the on-disk tuple to keep the
+                 * row's tenant identity intact.
+                 */
+                if (IsYugaByteEnabled() &&
+                    (original_entity_value->type == AGTV_VERTEX ||
+                     original_entity_value->type == AGTV_EDGE))
+                    yb_carry_meko_columns_from_tuple(
+                        slot, heap_tuple,
+                        RelationGetDescr(resultRelInfo->ri_RelationDesc),
+                        original_entity_value->type == AGTV_EDGE);
+
                 heap_tuple = update_entity_tuple(resultRelInfo, slot, estate,
                                                  heap_tuple);
             }

--- a/src/postgres/third-party-extensions/mage/src/backend/executor/cypher_utils.c
+++ b/src/postgres/third-party-extensions/mage/src/backend/executor/cypher_utils.c
@@ -34,7 +34,12 @@
 
 /* YB includes */
 #include "executor/ybModifyTable.h"
+#include "fmgr.h"
 #include "pg_yb_utils.h"
+#include "utils/builtins.h"
+#include "utils/uuid.h"
+
+extern Datum uuid_in(PG_FUNCTION_ARGS); /* YB: for yb_extract_meko_columns_from_properties */
 
 /*
  * Given the graph name and the label name, create a ResultRelInfo for the table
@@ -85,8 +90,89 @@ void destroy_entity_result_rel_info(ResultRelInfo *result_rel_info)
     table_close(result_rel_info->ri_RelationDesc, RowExclusiveLock);
 }
 
-TupleTableSlot *populate_vertex_tts(
-    TupleTableSlot *elemTupleSlot, agtype_value *id, agtype_value *properties)
+/*
+ * YB: Copy meko_* tenant column values from `meko` into the four
+ * corresponding slot offsets on a vertex tuple. Caller is expected to gate
+ * the call with IsYugaByteEnabled().
+ */
+void yb_populate_vertex_meko_columns(TupleTableSlot *slot, YbMekoDp meko)
+{
+    slot->tts_values[vertex_tuple_meko_datapack_id]     = meko.datapack_id;
+    slot->tts_isnull[vertex_tuple_meko_datapack_id]     = false;
+    slot->tts_values[vertex_tuple_meko_user_id]         = meko.user_id;
+    slot->tts_isnull[vertex_tuple_meko_user_id]         = false;
+    slot->tts_values[vertex_tuple_meko_agent_id]        = meko.agent_id;
+    slot->tts_isnull[vertex_tuple_meko_agent_id]        = false;
+    slot->tts_values[vertex_tuple_meko_conversation_id] = meko.conversation_id;
+    slot->tts_isnull[vertex_tuple_meko_conversation_id] = meko.conversation_id_isnull;
+}
+
+/* YB: edge counterpart of yb_populate_vertex_meko_columns. */
+void yb_populate_edge_meko_columns(TupleTableSlot *slot, YbMekoDp meko)
+{
+    slot->tts_values[edge_tuple_meko_datapack_id]     = meko.datapack_id;
+    slot->tts_isnull[edge_tuple_meko_datapack_id]     = false;
+    slot->tts_values[edge_tuple_meko_user_id]         = meko.user_id;
+    slot->tts_isnull[edge_tuple_meko_user_id]         = false;
+    slot->tts_values[edge_tuple_meko_agent_id]        = meko.agent_id;
+    slot->tts_isnull[edge_tuple_meko_agent_id]        = false;
+    slot->tts_values[edge_tuple_meko_conversation_id] = meko.conversation_id;
+    slot->tts_isnull[edge_tuple_meko_conversation_id] = meko.conversation_id_isnull;
+}
+
+/*
+ * YB: Helper for the SET path: copy the four meko_* columns from an
+ * on-disk tuple into the corresponding offsets on a slot. The first three
+ * columns are NOT NULL on the table so non-null is asserted; conversation
+ * is nullable and its flag is propagated.
+ */
+void yb_carry_meko_columns_from_tuple(TupleTableSlot *slot,
+                                      HeapTuple heap_tuple,
+                                      TupleDesc tupdesc,
+                                      bool is_edge)
+{
+    int dp_anum   = is_edge ? Anum_ag_label_edge_table_meko_datapack_id
+                            : Anum_ag_label_vertex_table_meko_datapack_id;
+    int user_anum = is_edge ? Anum_ag_label_edge_table_meko_user_id
+                            : Anum_ag_label_vertex_table_meko_user_id;
+    int ag_anum   = is_edge ? Anum_ag_label_edge_table_meko_agent_id
+                            : Anum_ag_label_vertex_table_meko_agent_id;
+    int conv_anum = is_edge ? Anum_ag_label_edge_table_meko_conversation_id
+                            : Anum_ag_label_vertex_table_meko_conversation_id;
+    int dp_off    = is_edge ? edge_tuple_meko_datapack_id
+                            : vertex_tuple_meko_datapack_id;
+    int user_off  = is_edge ? edge_tuple_meko_user_id
+                            : vertex_tuple_meko_user_id;
+    int ag_off    = is_edge ? edge_tuple_meko_agent_id
+                            : vertex_tuple_meko_agent_id;
+    int conv_off  = is_edge ? edge_tuple_meko_conversation_id
+                            : vertex_tuple_meko_conversation_id;
+    bool isnull;
+
+    slot->tts_values[dp_off] =
+        heap_getattr(heap_tuple, dp_anum, tupdesc, &isnull);
+    Assert(!isnull);
+    slot->tts_isnull[dp_off] = false;
+
+    slot->tts_values[user_off] =
+        heap_getattr(heap_tuple, user_anum, tupdesc, &isnull);
+    Assert(!isnull);
+    slot->tts_isnull[user_off] = false;
+
+    slot->tts_values[ag_off] =
+        heap_getattr(heap_tuple, ag_anum, tupdesc, &isnull);
+    Assert(!isnull);
+    slot->tts_isnull[ag_off] = false;
+
+    slot->tts_values[conv_off] =
+        heap_getattr(heap_tuple, conv_anum, tupdesc, &isnull);
+    slot->tts_isnull[conv_off] = isnull;
+}
+
+TupleTableSlot *populate_vertex_tts(TupleTableSlot *elemTupleSlot,
+                                    agtype_value *id,
+                                    agtype_value *properties,
+                                    YbMekoDp meko)
 {
     bool properties_isnull;
 
@@ -105,12 +191,15 @@ TupleTableSlot *populate_vertex_tts(
         AGTYPE_P_GET_DATUM(agtype_value_to_agtype(properties));
     elemTupleSlot->tts_isnull[vertex_tuple_properties] = properties_isnull;
 
+    if (IsYugaByteEnabled())
+        yb_populate_vertex_meko_columns(elemTupleSlot, meko);
+
     return elemTupleSlot;
 }
 
 TupleTableSlot *populate_edge_tts(
     TupleTableSlot *elemTupleSlot, agtype_value *id, agtype_value *startid,
-    agtype_value *endid, agtype_value *properties)
+    agtype_value *endid, agtype_value *properties,YbMekoDp meko)
 {
     bool properties_isnull;
 
@@ -148,6 +237,9 @@ TupleTableSlot *populate_edge_tts(
     elemTupleSlot->tts_values[edge_tuple_properties] =
         AGTYPE_P_GET_DATUM(agtype_value_to_agtype(properties));
     elemTupleSlot->tts_isnull[edge_tuple_properties] = properties_isnull;
+
+    if (IsYugaByteEnabled())
+        yb_populate_edge_meko_columns(elemTupleSlot, meko);
 
     return elemTupleSlot;
 }
@@ -278,6 +370,133 @@ HeapTuple insert_entity_tuple_cid(ResultRelInfo *resultRelInfo,
     }
 
     return tuple;
+}
+
+/*
+ * YB: Look up `key` in the agtype object `props` and, if present and a
+ * string, palloc a NUL-terminated copy of the value via pnstrdup() and
+ * return it through *out_str. Returns true if the lookup succeeded; the
+ * caller owns the returned cstring and is responsible for pfreeing it.
+ */
+static bool yb_lookup_meko_string(agtype *props, const char *key,
+                                  char **out_str)
+{
+    agtype_value search_key;
+    agtype_value *val;
+
+    search_key.type = AGTV_STRING;
+    search_key.val.string.val = (char *) key;
+    search_key.val.string.len = strlen(key);
+    val = find_agtype_value_from_container(&props->root, AGT_FOBJECT,
+                                           &search_key);
+    if (val == NULL || val->type != AGTV_STRING)
+        return false;
+    *out_str = pnstrdup(val->val.string.val, val->val.string.len);
+    return true;
+}
+
+/*
+ * Read meko_datapack_id, meko_user_id, meko_agent_id, meko_conversation_id
+ * from a vertex or edge properties map and materialize them as column
+ * Datums for the caller.
+ *
+ * The meko_* keys are intentionally left inside the properties map so that
+ * Cypher MATCH/MERGE patterns can match on those keys without parser-level
+ * changes. Callers that mutate the map (for example SET) are responsible
+ * for keeping the map and the columns in sync.
+ *
+ * meko_datapack_id, meko_user_id and meko_agent_id are NOT NULL on the
+ * underlying tables and so must be present in the properties map; this
+ * function raises ERRCODE_NOT_NULL_VIOLATION if any of them is missing or
+ * if the properties map itself is null/non-object. meko_conversation_id is
+ * nullable and reported via conversation_id_isnull.
+ */
+YbMekoDp yb_extract_meko_columns_from_properties(Datum props_datum,
+                                                 bool props_isnull)
+{
+    YbMekoDp result;
+    agtype *props_agtype;
+    char *str;
+
+    result.conversation_id = (Datum) 0;
+    result.conversation_id_isnull = true;
+
+    if (props_isnull)
+        ereport(ERROR,
+                (errcode(ERRCODE_NOT_NULL_VIOLATION),
+                 errmsg("missing required tenant properties on vertex/edge")));
+
+    props_agtype = DATUM_GET_AGTYPE_P(props_datum);
+    if (!AGT_ROOT_IS_OBJECT(props_agtype))
+        ereport(ERROR,
+                (errcode(ERRCODE_NOT_NULL_VIOLATION),
+                 errmsg("missing required tenant properties on vertex/edge")));
+
+    /*
+     * Look up each meko key from the root container. yb_lookup_meko_string()
+     * does the find + pnstrdup; we are responsible for pfreeing the returned
+     * cstring after passing it through the appropriate input function.
+     */
+    if (!yb_lookup_meko_string(props_agtype,
+                               AG_VERTEX_COLNAME_MEKO_DATAPACK_ID, &str))
+        ereport(ERROR,
+                (errcode(ERRCODE_NOT_NULL_VIOLATION),
+                 errmsg("missing required tenant property \"%s\"",
+                        AG_VERTEX_COLNAME_MEKO_DATAPACK_ID)));
+    result.datapack_id = DirectFunctionCall1(uuid_in, CStringGetDatum(str));
+    pfree(str);
+
+    if (!yb_lookup_meko_string(props_agtype,
+                               AG_VERTEX_COLNAME_MEKO_USER_ID, &str))
+        ereport(ERROR,
+                (errcode(ERRCODE_NOT_NULL_VIOLATION),
+                 errmsg("missing required tenant property \"%s\"",
+                        AG_VERTEX_COLNAME_MEKO_USER_ID)));
+    result.user_id = DirectFunctionCall1(uuid_in, CStringGetDatum(str));
+    pfree(str);
+
+    if (!yb_lookup_meko_string(props_agtype,
+                               AG_VERTEX_COLNAME_MEKO_AGENT_ID, &str))
+        ereport(ERROR,
+                (errcode(ERRCODE_NOT_NULL_VIOLATION),
+                 errmsg("missing required tenant property \"%s\"",
+                        AG_VERTEX_COLNAME_MEKO_AGENT_ID)));
+    result.agent_id = CStringGetTextDatum(str);
+    pfree(str);
+
+    /*
+     * meko_conversation_id is nullable, but if the user does supply it the
+     * value must be a string we can feed to uuid_in. Distinguish "missing"
+     * from "present but wrong type" so the latter raises a clear error
+     * instead of being silently treated as NULL.
+     */
+    {
+        agtype_value search_key;
+        agtype_value *val;
+
+        search_key.type = AGTV_STRING;
+        search_key.val.string.val =
+            (char *) AG_VERTEX_COLNAME_MEKO_CONVERSATION_ID;
+        search_key.val.string.len =
+            strlen(AG_VERTEX_COLNAME_MEKO_CONVERSATION_ID);
+        val = find_agtype_value_from_container(&props_agtype->root,
+                                               AGT_FOBJECT, &search_key);
+        if (val != NULL && val->type != AGTV_NULL)
+        {
+            if (val->type != AGTV_STRING)
+                ereport(ERROR,
+                        (errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+                         errmsg("tenant property \"%s\" must be a string",
+                                AG_VERTEX_COLNAME_MEKO_CONVERSATION_ID)));
+            str = pnstrdup(val->val.string.val, val->val.string.len);
+            result.conversation_id =
+                DirectFunctionCall1(uuid_in, CStringGetDatum(str));
+            result.conversation_id_isnull = false;
+            pfree(str);
+        }
+    }
+
+    return result;
 }
 
 /*

--- a/src/postgres/third-party-extensions/mage/src/backend/utils/load/ag_load_edges.c
+++ b/src/postgres/third-party-extensions/mage/src/backend/utils/load/ag_load_edges.c
@@ -22,6 +22,9 @@
 #include "utils/load/ag_load_edges.h"
 #include "utils/load/csv.h"
 
+/* YB includes */
+#include "pg_yb_utils.h"
+
 void edge_field_cb(void *field, size_t field_len, void *data)
 {
 
@@ -185,6 +188,18 @@ int create_edges_from_csv_file(char *file_path,
     unsigned char options = 0;
     csv_edge_reader cr;
     char *label_seq_name;
+
+    /*
+     * YB: bulk CSV load is not wired up for YB yet (insert_batch uses
+     * heap_multi_insert and the meko_* tenant columns are not supplied
+     * by the loader). Fail loudly until the insert path is made
+     * YB-aware. See #31338.
+     */
+    if (IsYugaByteEnabled())
+        ereport(ERROR,
+                (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                 errmsg("bulk CSV edge load is not supported on "
+                        "YugabyteDB yet (#31338)")));
 
     if (csv_init(&p, options) != 0)
     {

--- a/src/postgres/third-party-extensions/mage/src/backend/utils/load/ag_load_labels.c
+++ b/src/postgres/third-party-extensions/mage/src/backend/utils/load/ag_load_labels.c
@@ -24,6 +24,9 @@
 #include "utils/load/ag_load_labels.h"
 #include "utils/load/csv.h"
 
+/* YB includes */
+#include "pg_yb_utils.h"
+
 void vertex_field_cb(void *field, size_t field_len, void *data)
 {
 
@@ -182,6 +185,18 @@ int create_labels_from_csv_file(char *file_path,
     unsigned char options = 0;
     csv_vertex_reader cr;
     char *label_seq_name;
+
+    /*
+     * YB: bulk CSV load is not wired up for YB yet (insert_batch uses
+     * heap_multi_insert and the meko_* tenant columns are not supplied
+     * by the loader). Fail loudly until the insert path is made
+     * YB-aware. See #31338.
+     */
+    if (IsYugaByteEnabled())
+        ereport(ERROR,
+                (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                 errmsg("bulk CSV vertex load is not supported on "
+                        "YugabyteDB yet (#31338)")));
 
     if (csv_init(&p, options) != 0)
     {

--- a/src/postgres/third-party-extensions/mage/src/backend/utils/load/age_load.c
+++ b/src/postgres/third-party-extensions/mage/src/backend/utils/load/age_load.c
@@ -43,12 +43,6 @@ static bool json_validate(text *json);
 static Oid get_or_create_graph(const Name graph_name);
 static int32 get_or_create_label(Oid graph_oid, char *graph_name,
                                  char *label_name, char label_kind);
-static void yb_insert_edge_simple(Relation label_relation, graphid edge_id,
-                                  graphid start_id, graphid end_id,
-                                  agtype *edge_properties);
-static void yb_insert_vertex_simple(Relation label_relation, graphid vertex_id,
-                                    agtype *vertex_properties);
-
 agtype *create_empty_agtype(void)
 {
     agtype* out;
@@ -241,8 +235,9 @@ void insert_edge_simple(Oid graph_oid, char *label_name, graphid edge_id,
                         agtype *edge_properties)
 {
 
-    Datum values[6];
-    bool nulls[4] = {false, false, false, false};
+    /* YB: 4 extra slots hold meko_* tenant columns (all NULL by default) */
+    Datum values[8];
+    bool nulls[8] = {false, false, false, false, true, true, true, true};
     Relation label_relation;
     HeapTuple tuple;
 
@@ -262,15 +257,17 @@ void insert_edge_simple(Oid graph_oid, char *label_name, graphid edge_id,
     values[1] = GRAPHID_GET_DATUM(start_id);
     values[2] = GRAPHID_GET_DATUM(end_id);
     values[3] = AGTYPE_P_GET_DATUM((edge_properties));
+    /* YB: TODO(#31338) caller does not yet supply meko_* tenant values. */
+    values[4] = (Datum) 0;
+    values[5] = (Datum) 0;
+    values[6] = (Datum) 0;
+    values[7] = (Datum) 0;
 
     if (IsYBRelation(label_relation))
-    {
-        yb_insert_edge_simple(label_relation, edge_id, start_id, end_id,
-                              edge_properties);
-        table_close(label_relation, RowExclusiveLock);
-        YbCommandCounterIncrement();
-        return;
-    }
+        ereport(ERROR,
+                (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                 errmsg("simple edge insert is not supported on "
+                        "YugabyteDB yet (#31338)")));
 
     tuple = heap_form_tuple(RelationGetDescr(label_relation),
                             values, nulls);
@@ -319,13 +316,10 @@ void insert_vertex_simple(Oid graph_oid, char *label_name, graphid vertex_id,
                                 RowExclusiveLock);
 
     if (IsYBRelation(label_relation))
-    {
-        yb_insert_vertex_simple(label_relation, vertex_id,
-                                vertex_properties);
-        table_close(label_relation, RowExclusiveLock);
-        YbCommandCounterIncrement();
-        return;
-    }
+        ereport(ERROR,
+                (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                 errmsg("simple vertex insert is not supported on "
+                        "YugabyteDB yet (#31338)")));
 
     /* Form the tuple */
     values[0] = GRAPHID_GET_DATUM(vertex_id);
@@ -505,65 +499,6 @@ Datum load_edges_from_file(PG_FUNCTION_ARGS)
     create_edges_from_csv_file(file_path_str, graph_name_str, graph_oid,
                                label_name_str, label_id, load_as_agtype);
     PG_RETURN_VOID();
-}
-
-static void yb_insert_edge_simple(Relation label_relation, graphid edge_id,
-                                  graphid start_id, graphid end_id,
-                                  agtype *edge_properties)
-{
-    EState *estate = CreateExecutorState();
-    ResultRelInfo *resultRelInfo = makeNode(ResultRelInfo);
-    TupleTableSlot *slot;
-
-    InitResultRelInfo(resultRelInfo, label_relation, 1, NULL,
-                      estate->es_instrument);
-    estate->es_result_relations = &resultRelInfo;
-
-    slot = MakeSingleTupleTableSlot(RelationGetDescr(label_relation),
-                                    &TTSOpsVirtual);
-    ExecClearTuple(slot);
-
-    slot->tts_values[0] = GRAPHID_GET_DATUM(edge_id);
-    slot->tts_isnull[0] = false;
-    slot->tts_values[1] = GRAPHID_GET_DATUM(start_id);
-    slot->tts_isnull[1] = false;
-    slot->tts_values[2] = GRAPHID_GET_DATUM(end_id);
-    slot->tts_isnull[2] = false;
-    slot->tts_values[3] = AGTYPE_P_GET_DATUM(edge_properties);
-    slot->tts_isnull[3] = false;
-
-    ExecStoreVirtualTuple(slot);
-    YBCHeapInsert(resultRelInfo, slot, NULL, estate, ONCONFLICT_NONE);
-
-    ExecDropSingleTupleTableSlot(slot);
-    FreeExecutorState(estate);
-}
-
-static void yb_insert_vertex_simple(Relation label_relation, graphid vertex_id,
-                                    agtype *vertex_properties)
-{
-    EState *estate = CreateExecutorState();
-    ResultRelInfo *resultRelInfo = makeNode(ResultRelInfo);
-    TupleTableSlot *slot;
-
-    InitResultRelInfo(resultRelInfo, label_relation, 1, NULL,
-                      estate->es_instrument);
-    estate->es_result_relations = &resultRelInfo;
-
-    slot = MakeSingleTupleTableSlot(RelationGetDescr(label_relation),
-                                    &TTSOpsVirtual);
-    ExecClearTuple(slot);
-
-    slot->tts_values[0] = GRAPHID_GET_DATUM(vertex_id);
-    slot->tts_isnull[0] = false;
-    slot->tts_values[1] = AGTYPE_P_GET_DATUM(vertex_properties);
-    slot->tts_isnull[1] = false;
-
-    ExecStoreVirtualTuple(slot);
-    YBCHeapInsert(resultRelInfo, slot, NULL, estate, ONCONFLICT_NONE);
-
-    ExecDropSingleTupleTableSlot(slot);
-    FreeExecutorState(estate);
 }
 
 /*

--- a/src/postgres/third-party-extensions/mage/src/include/catalog/ag_label.h
+++ b/src/postgres/third-party-extensions/mage/src/include/catalog/ag_label.h
@@ -24,19 +24,39 @@
 
 #define Anum_ag_label_vertex_table_id 1
 #define Anum_ag_label_vertex_table_properties 2
+/* YB: meko_* tenant columns on vertex label tables */
+#define Anum_ag_label_vertex_table_meko_datapack_id 3
+#define Anum_ag_label_vertex_table_meko_user_id 4
+#define Anum_ag_label_vertex_table_meko_agent_id 5
+#define Anum_ag_label_vertex_table_meko_conversation_id 6
 
 #define Anum_ag_label_edge_table_id 1
 #define Anum_ag_label_edge_table_start_id 2
 #define Anum_ag_label_edge_table_end_id 3
 #define Anum_ag_label_edge_table_properties 4
+/* YB: meko_* tenant columns on edge label tables */
+#define Anum_ag_label_edge_table_meko_datapack_id 5
+#define Anum_ag_label_edge_table_meko_user_id 6
+#define Anum_ag_label_edge_table_meko_agent_id 7
+#define Anum_ag_label_edge_table_meko_conversation_id 8
 
 #define vertex_tuple_id Anum_ag_label_vertex_table_id - 1
 #define vertex_tuple_properties Anum_ag_label_vertex_table_properties - 1
+/* YB: tuple-offset aliases for meko_* tenant columns on vertex label tables */
+#define vertex_tuple_meko_datapack_id (Anum_ag_label_vertex_table_meko_datapack_id - 1)
+#define vertex_tuple_meko_user_id (Anum_ag_label_vertex_table_meko_user_id - 1)
+#define vertex_tuple_meko_agent_id (Anum_ag_label_vertex_table_meko_agent_id - 1)
+#define vertex_tuple_meko_conversation_id (Anum_ag_label_vertex_table_meko_conversation_id - 1)
 
 #define edge_tuple_id Anum_ag_label_edge_table_id - 1
 #define edge_tuple_start_id Anum_ag_label_edge_table_start_id - 1
 #define edge_tuple_end_id Anum_ag_label_edge_table_end_id - 1
 #define edge_tuple_properties Anum_ag_label_edge_table_properties - 1
+/* YB: tuple-offset aliases for meko_* tenant columns on edge label tables */
+#define edge_tuple_meko_datapack_id (Anum_ag_label_edge_table_meko_datapack_id - 1)
+#define edge_tuple_meko_user_id (Anum_ag_label_edge_table_meko_user_id - 1)
+#define edge_tuple_meko_agent_id (Anum_ag_label_edge_table_meko_agent_id - 1)
+#define edge_tuple_meko_conversation_id (Anum_ag_label_edge_table_meko_conversation_id - 1)
 
 
 

--- a/src/postgres/third-party-extensions/mage/src/include/commands/label_commands.h
+++ b/src/postgres/third-party-extensions/mage/src/include/commands/label_commands.h
@@ -28,6 +28,11 @@
 
 #define AG_VERTEX_COLNAME_ID "id"
 #define AG_VERTEX_COLNAME_PROPERTIES "properties"
+/* YB: vertex label tenant-column names (meko_*) */
+#define AG_VERTEX_COLNAME_MEKO_DATAPACK_ID "meko_datapack_id"
+#define AG_VERTEX_COLNAME_MEKO_USER_ID "meko_user_id"
+#define AG_VERTEX_COLNAME_MEKO_AGENT_ID "meko_agent_id"
+#define AG_VERTEX_COLNAME_MEKO_CONVERSATION_ID "meko_conversation_id"
 
 #define AG_ACCESS_FUNCTION_ID "age_id"
 
@@ -38,6 +43,11 @@
 #define AG_EDGE_COLNAME_START_ID "start_id"
 #define AG_EDGE_COLNAME_END_ID "end_id"
 #define AG_EDGE_COLNAME_PROPERTIES "properties"
+/* YB: edge label tenant-column names (meko_*) */
+#define AG_EDGE_COLNAME_MEKO_DATAPACK_ID "meko_datapack_id"
+#define AG_EDGE_COLNAME_MEKO_USER_ID "meko_user_id"
+#define AG_EDGE_COLNAME_MEKO_AGENT_ID "meko_agent_id"
+#define AG_EDGE_COLNAME_MEKO_CONVERSATION_ID "meko_conversation_id"
 
 #define AG_EDGE_ACCESS_FUNCTION_ID "age_id"
 #define AG_EDGE_ACCESS_FUNCTION_START_ID "age_start_id"

--- a/src/postgres/third-party-extensions/mage/src/include/executor/cypher_utils.h
+++ b/src/postgres/third-party-extensions/mage/src/include/executor/cypher_utils.h
@@ -109,11 +109,50 @@ typedef struct cypher_merge_custom_scan_state
     struct created_path *created_paths_list;
 } cypher_merge_custom_scan_state;
 
+/*
+ * YB: Bundle of meko_* tenant column values extracted from a vertex/edge
+ * properties map by yb_extract_meko_columns_from_properties(). The first
+ * three columns are NOT NULL on the underlying tables, so only
+ * meko_conversation_id carries an explicit isnull flag.
+ */
+typedef struct YbMekoDp
+{
+    Datum datapack_id;
+    Datum user_id;
+    Datum agent_id;
+    bool  conversation_id_isnull;
+    Datum conversation_id;
+} YbMekoDp;
+
+YbMekoDp yb_extract_meko_columns_from_properties(Datum props_datum,
+                                                 bool props_isnull);
+
+/*
+ * YB: Copy meko_* tenant column values from `meko` into the four corresponding
+ * slot offsets on a vertex/edge tuple. Caller is expected to gate the call
+ * with IsYugaByteEnabled() since the meko_* columns only exist on YB-hosted
+ * tables.
+ */
+void yb_populate_vertex_meko_columns(TupleTableSlot *slot, YbMekoDp meko);
+void yb_populate_edge_meko_columns(TupleTableSlot *slot, YbMekoDp meko);
+
+/*
+ * YB: Copy meko_* tenant column values from an existing on-disk tuple into
+ * the corresponding slot offsets on a vertex/edge tuple. is_edge selects
+ * the vertex or edge column layout. Used by the SET path so that updates
+ * preserve the row's tenant identity. Caller is expected to gate the call
+ * with IsYugaByteEnabled().
+ */
+void yb_carry_meko_columns_from_tuple(TupleTableSlot *slot,
+                                      HeapTuple heap_tuple,
+                                      TupleDesc tupdesc,
+                                      bool is_edge);
+
 TupleTableSlot *populate_vertex_tts(TupleTableSlot *elemTupleSlot,
-                                    agtype_value *id, agtype_value *properties);
+    agtype_value *id, agtype_value *properties, YbMekoDp meko); /* YB: tenant cols */
 TupleTableSlot *populate_edge_tts(
     TupleTableSlot *elemTupleSlot, agtype_value *id, agtype_value *startid,
-    agtype_value *endid, agtype_value *properties);
+    agtype_value *endid, agtype_value *properties, YbMekoDp meko); /* YB: tenant cols */
 
 ResultRelInfo *create_entity_result_rel_info(EState *estate, char *graph_name,
                                              char *label_name);

--- a/src/postgres/yb-extensions/pg_dist_rag/pg_dist_rag--0.0.1.sql
+++ b/src/postgres/yb-extensions/pg_dist_rag/pg_dist_rag--0.0.1.sql
@@ -12,6 +12,9 @@ CREATE TABLE dist_rag.sources (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   source_uri TEXT,
 
+  -- tenant identifier for multi-tenant isolation; NULL means "no tenant".
+  tenant_id UUID,
+
   --metadata filters for a specific source
   metadata JSONB,
   created_at TIMESTAMP NOT NULL DEFAULT NOW(),
@@ -37,6 +40,8 @@ CREATE TABLE dist_rag.vector_indexes (
 
   -- Vector Index details
   index_name VARCHAR(50) NOT NULL DEFAULT 'pg_rag_default_store',
+  -- Schema that holds the backing vector table named index_name.
+  schema_name VARCHAR(50) NOT NULL DEFAULT 'public',
   -- Specify m and ef construction 
   index_options JSONB,
   index_creation_status dist_rag.index_build_status NOT NULL,
@@ -79,6 +84,9 @@ CREATE TABLE dist_rag.documents (
   document_name TEXT,
   document_uri TEXT,
   document_checksum TEXT,
+
+  -- Document type (MIME type, e.g. 'text/plain', 'application/pdf')
+  document_type TEXT,
 
   -- Current state
   status dist_rag.document_processing_status_enum NOT NULL DEFAULT 'QUEUED'
@@ -154,7 +162,8 @@ CREATE OR REPLACE FUNCTION dist_rag.create_source(
     r_source_uri TEXT,
     r_metadata JSONB DEFAULT '{}',
     r_secrets_provider dist_rag.secrets_provider_enum DEFAULT 'LOCAL',
-    r_secrets_provider_params JSONB DEFAULT '{}'
+    r_secrets_provider_params JSONB DEFAULT '{}',
+    r_tenant_id UUID DEFAULT NULL
 )
 RETURNS UUID
 LANGUAGE plpgsql
@@ -168,9 +177,17 @@ BEGIN
         RAISE EXCEPTION 'source_uri is required and cannot be NULL or empty';
     END IF;
 
-    -- Insert source and capture the ID
-    INSERT INTO dist_rag.sources (source_uri, metadata, secrets_provider, secrets_provider_params)
-    VALUES (r_source_uri, COALESCE(r_metadata, '{}'::jsonb), r_secrets_provider, r_secrets_provider_params)
+    -- Insert source and capture the ID. COALESCE on r_metadata normalizes an
+    -- explicit NULL to '{}'; the parameter DEFAULT only applies when the
+    -- argument is omitted, not when the caller passes NULL. tenant_id is
+    -- nullable; passing NULL records "no tenant".
+    INSERT INTO dist_rag.sources (
+        source_uri, tenant_id, metadata, secrets_provider, secrets_provider_params
+    )
+    VALUES (
+        r_source_uri, r_tenant_id, COALESCE(r_metadata, '{}'::jsonb),
+        r_secrets_provider, r_secrets_provider_params
+    )
     RETURNING id INTO v_id;
 
     -- Validate insertion
@@ -183,7 +200,7 @@ BEGIN
     VALUES (
         'CREATE_SOURCE'::dist_rag.task_type_enum, 
         'QUEUED'::dist_rag.task_queue_status_enum,
-        jsonb_build_object('source_id', v_id)
+        jsonb_build_object('source_id', v_id, 'tenant_id', r_tenant_id)
     );
 
     RETURN v_id;
@@ -192,14 +209,17 @@ EXCEPTION WHEN OTHERS THEN
 END;
 $$;
 
-COMMENT ON FUNCTION dist_rag.create_source(TEXT, JSONB, dist_rag.secrets_provider_enum, JSONB)
+COMMENT ON FUNCTION dist_rag.create_source(
+    TEXT, JSONB, dist_rag.secrets_provider_enum, JSONB, UUID
+)
 IS 'Create a new RAG source';
 
 
 CREATE OR REPLACE FUNCTION dist_rag._create_vector_index_table(
     r_index_name VARCHAR(50),
     r_vector_dimensions INTEGER,
-    r_index_options JSONB DEFAULT '{}'
+    r_index_options JSONB DEFAULT '{}',
+    r_schema_name VARCHAR(50) DEFAULT 'public'
 )
 RETURNS VOID
 LANGUAGE plpgsql
@@ -210,11 +230,24 @@ DECLARE
     v_m INTEGER;
     v_ef_construction INTEGER;
     v_ops_class TEXT;
+    v_qualified_table TEXT;
 BEGIN
 
     -- validate required parameters
     IF r_index_name IS NULL OR r_index_name = '' THEN
         RAISE EXCEPTION 'index_name is required and cannot be NULL or empty';
+    END IF;
+
+    IF r_schema_name IS NULL OR r_schema_name = '' THEN
+        RAISE EXCEPTION 'schema_name is required and cannot be NULL or empty';
+    END IF;
+
+    -- Require the target schema to already exist; we deliberately do not
+    -- auto-create it so callers cannot silently spawn schemas via a typo.
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname = r_schema_name
+    ) THEN
+        RAISE EXCEPTION 'schema "%" does not exist', r_schema_name;
     END IF;
 
     IF r_vector_dimensions IS NULL OR r_vector_dimensions <= 0 THEN
@@ -238,18 +271,21 @@ BEGIN
         RAISE EXCEPTION 'Invalid distance_metric "%". Must be one of: cosine, l2, ip', v_distance_metric;
     END IF;
 
-    -- Create the vector store table
-    EXECUTE 'CREATE TABLE ' || quote_ident(r_index_name) || ' (
+    v_qualified_table := quote_ident(r_schema_name) || '.' || quote_ident(r_index_name);
+
+    -- Create the vector store table in the target schema
+    EXECUTE 'CREATE TABLE ' || v_qualified_table || ' (
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
         chunk_text TEXT NOT NULL,
         embeddings vector(' || r_vector_dimensions || ') NOT NULL,
         document_id UUID NOT NULL,
+        tenant_id UUID,
         metadata_filters JSONB NOT NULL DEFAULT ''' || '{}' || '''
     )';
 
     -- Create HNSW index on the embeddings column
     EXECUTE 'CREATE INDEX ' || quote_ident('idx_' || r_index_name || '_embeddings')
-        || ' ON ' || quote_ident(r_index_name)
+        || ' ON ' || v_qualified_table
         || ' USING ybhnsw (embeddings ' || v_ops_class || ')'
         || ' WITH (m = ' || v_m || ', ef_construction = ' || v_ef_construction || ')';
 
@@ -262,7 +298,8 @@ CREATE OR REPLACE FUNCTION dist_rag.init_vector_index(
     r_chunk_params JSONB DEFAULT '{}',
     r_ai_provider dist_rag.ai_provider_enum DEFAULT 'OPENAI',
     r_embedding_model_params JSONB DEFAULT '{}',
-    r_index_options JSONB DEFAULT '{"distance_metric": "cosine", "m": 16, "ef_construction": 64}'
+    r_index_options JSONB DEFAULT '{"distance_metric": "cosine", "m": 16, "ef_construction": 64}',
+    r_schema_name VARCHAR(50) DEFAULT 'public'
 )
 RETURNS UUID
 LANGUAGE plpgsql
@@ -314,22 +351,26 @@ BEGIN
     
     -- Step 1: Create the vector index table and HNSW index on embeddings
     BEGIN
-        PERFORM dist_rag._create_vector_index_table(r_index_name, v_vector_dimensions, r_index_options);
+        PERFORM dist_rag._create_vector_index_table(
+            r_index_name, v_vector_dimensions, r_index_options, r_schema_name);
     EXCEPTION WHEN OTHERS THEN
-        RAISE EXCEPTION 'Failed to create vector index table "%": % - %', r_index_name, SQLSTATE, SQLERRM;
+        RAISE EXCEPTION 'Failed to create vector index table "%.%": % - %',
+            r_schema_name, r_index_name, SQLSTATE, SQLERRM;
     END;
 
     -- Step 2: Insert vector index metadata
     BEGIN
         INSERT INTO dist_rag.vector_indexes (
-            index_name, 
+            index_name,
+            schema_name,
             index_options,
             index_creation_status, 
             ai_provider, 
             embedding_model_params
         )
         VALUES (
-            r_index_name, 
+            r_index_name,
+            r_schema_name,
             r_index_options,
             'INIT'::dist_rag.index_build_status, 
             r_ai_provider, 
@@ -366,7 +407,7 @@ EXCEPTION WHEN OTHERS THEN
 END;
 $$;
 
-COMMENT ON FUNCTION dist_rag.init_vector_index(VARCHAR, UUID[], JSONB, dist_rag.ai_provider_enum, JSONB, JSONB)
+COMMENT ON FUNCTION dist_rag.init_vector_index(VARCHAR, UUID[], JSONB, dist_rag.ai_provider_enum, JSONB, JSONB, VARCHAR)
 IS 'Initialize a new vector index with optional HNSW index configuration via r_index_options';
 
 CREATE OR REPLACE FUNCTION dist_rag.add_source_to_index(
@@ -401,6 +442,7 @@ AS $$
 DECLARE
     v_document RECORD;
     v_count INTEGER := 0;
+    v_tenant_id UUID;
 BEGIN
     -- Validate required parameter
     IF r_source_id IS NULL THEN
@@ -410,6 +452,15 @@ BEGIN
     -- Validate required parameter
     IF r_index_id IS NULL THEN
         RAISE EXCEPTION 'index_id is required and cannot be NULL';
+    END IF;
+
+    -- Resolve tenant_id once for this source (all documents share it).
+    SELECT tenant_id INTO v_tenant_id
+    FROM dist_rag.sources
+    WHERE id = r_source_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Source % does not exist', r_source_id;
     END IF;
 
     -- Insert work queue entries for all documents in this source
@@ -425,10 +476,12 @@ BEGIN
         jsonb_build_object(
             'index_id', r_index_id,
             'source_id', r_source_id,
+            'tenant_id', v_tenant_id,
             'document_id', d.document_id,
             'document_name', d.document_name,
             'document_uri', d.document_uri,
-            'document_status', d.status
+            'document_status', d.status,
+            'document_type', d.document_type
         ),
         NOW()
     FROM dist_rag.documents d
@@ -491,13 +544,16 @@ BEGIN
         jsonb_build_object(
             'index_id', v_index_id,
             'source_id', m.source_id,
+            'tenant_id', s.tenant_id,
             'document_id', d.document_id,
             'document_name', d.document_name,
             'document_uri', d.document_uri,
-            'document_status', d.status
+            'document_status', d.status,
+            'document_type', d.document_type
         ),
         NOW()
     FROM dist_rag.vector_index_source_mappings m
+    JOIN dist_rag.sources s ON s.id = m.source_id
     JOIN dist_rag.documents d ON d.source_id = m.source_id
     WHERE m.index_id = v_index_id;
 
@@ -522,6 +578,7 @@ SELECT
     vi.ai_provider,
     vi.index_creation_status,
     s.id as source_id,
+    s.tenant_id,
     s.source_uri,
     d.document_id,
     d.document_name,
@@ -537,7 +594,8 @@ SELECT
     pd.created_at as pipeline_created_at,
     pd.last_started_at as pipeline_last_started_at,
     pd.completed_at as pipeline_completed_at,
-    pd.metadata_snapshot
+    pd.metadata_snapshot,
+    vi.schema_name
 FROM dist_rag.vector_indexes vi
 INNER JOIN dist_rag.vector_index_source_mappings vism ON vi.id = vism.index_id
 INNER JOIN dist_rag.sources s ON vism.source_id = s.id
@@ -553,6 +611,7 @@ SELECT
     vi.id as index_id,
     vi.index_name,
     vi.ai_provider,
+    s.tenant_id,
     s.source_uri,
     d.document_id,
     d.document_name,
@@ -564,13 +623,15 @@ SELECT
     ROUND(100.0 * COUNT(CASE WHEN pd.status = 'COMPLETED' THEN 1 END) / NULLIF(COUNT(pd.pipeline_id), 0), 2) as completion_rate_percent,
     MAX(pd.completed_at) as last_completed_at,
     (array_agg(pd.last_error_message ORDER BY pd.created_at DESC) FILTER (WHERE pd.last_error_message IS NOT NULL))[1] as last_error_message,
-    MIN(pd.created_at) as first_pipeline_started_at
+    MIN(pd.created_at) as first_pipeline_started_at,
+    vi.schema_name
 FROM dist_rag.vector_indexes vi
 INNER JOIN dist_rag.vector_index_source_mappings vism ON vi.id = vism.index_id
 INNER JOIN dist_rag.sources s ON vism.source_id = s.id
 INNER JOIN dist_rag.documents d ON s.id = d.source_id
 LEFT JOIN dist_rag.pipeline_details pd ON d.document_id = pd.document_id
-GROUP BY vi.id, vi.index_name, vi.ai_provider, s.source_uri, d.document_id, d.document_name
+GROUP BY vi.id, vi.index_name, vi.ai_provider, vi.schema_name, s.tenant_id, s.source_uri,
+         d.document_id, d.document_name
 ORDER BY vi.index_name, s.source_uri, d.document_name;
 
 COMMENT ON VIEW dist_rag.pipeline_stats

--- a/src/postgres/yb-extensions/pg_dist_rag/sql/pg_dist_rag_test.sql
+++ b/src/postgres/yb-extensions/pg_dist_rag/sql/pg_dist_rag_test.sql
@@ -446,6 +446,61 @@ BEGIN
 END $$;
 
 -- ============================================
+-- Test 16d: init_vector_index respects r_schema_name
+-- ============================================
+DO $$
+DECLARE
+  v_index_id UUID;
+  v_table_schema TEXT;
+  v_index_schema TEXT;
+BEGIN
+  RAISE NOTICE '=== Test 16d: init_vector_index creates backing table in r_schema_name ===';
+  CREATE SCHEMA IF NOT EXISTS rag_custom_schema;
+  v_index_id := dist_rag.init_vector_index(
+    r_index_name := 'custom_schema_index',
+    r_embedding_model_params := jsonb_build_object('dimensions', 1536),
+    r_schema_name := 'rag_custom_schema'
+  );
+  ASSERT v_index_id IS NOT NULL, 'Index ID should not be NULL';
+
+  -- Verify the backing table was created in the requested schema, not public.
+  SELECT schemaname INTO v_table_schema
+  FROM pg_tables
+  WHERE tablename = 'custom_schema_index';
+  ASSERT v_table_schema = 'rag_custom_schema',
+    format('Expected backing table in rag_custom_schema, found in %s', v_table_schema);
+
+  -- And the HNSW index should live alongside the table.
+  SELECT schemaname INTO v_index_schema
+  FROM pg_indexes
+  WHERE indexname = 'idx_custom_schema_index_embeddings';
+  ASSERT v_index_schema = 'rag_custom_schema',
+    format('Expected HNSW index in rag_custom_schema, found in %s', v_index_schema);
+
+  RAISE NOTICE 'PASS: backing table and index created in rag_custom_schema';
+END $$;
+
+-- ============================================
+-- Test 16e: init_vector_index rejects missing schema
+-- ============================================
+DO $$
+DECLARE
+  v_index_id UUID;
+BEGIN
+  RAISE NOTICE '=== Test 16e: Reject init_vector_index with non-existent schema ===';
+  v_index_id := dist_rag.init_vector_index(
+    r_index_name := 'missing_schema_index',
+    r_embedding_model_params := jsonb_build_object('dimensions', 1536),
+    r_schema_name := 'this_schema_does_not_exist'
+  );
+  RAISE NOTICE 'FAIL: Should have raised an exception for missing schema';
+EXCEPTION WHEN OTHERS THEN
+  ASSERT SQLERRM LIKE '%does not exist%',
+    format('Expected schema-missing error, got: %s', SQLERRM);
+  RAISE NOTICE 'PASS: Correctly rejected missing schema - %', SQLERRM;
+END $$;
+
+-- ============================================
 -- Test 17: Views - vector_index_pipeline_details
 -- ============================================
 DO $$

--- a/src/yb/yql/pgwrapper/libpq_utils.cc
+++ b/src/yb/yql/pgwrapper/libpq_utils.cc
@@ -261,7 +261,7 @@ constexpr Oid UUIDOID = 2950;
 constexpr Oid JSONBOID = 3802;
 constexpr Oid VECTOROID = 8078;
 constexpr Oid BSONOID = 8095;
-constexpr Oid GRAPHIDOID = 8113;
+constexpr Oid GRAPHIDOID = 8116;
 
 template<BasePGType T>
 bool IsValidType(Oid pg_type) {


### PR DESCRIPTION
**This PR is only for generating a CI build and will NOT be merged.**

Combines two changes on top of `2026.1` so CI can build them together:

- `[MEKO-9]` pg_dist_rag: Add tenant_id and schema_name dimensions to RAG pipeline (D52466).
- `[MEKO-6]` Add multitenancy to apache mage graph tables for meko (squashed from #31399).


[MEKO-9]: https://yugabyte.atlassian.net/browse/MEKO-9?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MEKO-6]: https://yugabyte.atlassian.net/browse/MEKO-6?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ