### PR TITLE
[yugabyted] Set CA certificate expiration to 730 days

### DIFF
--- a/bin/openssl_proxy.sh
+++ b/bin/openssl_proxy.sh
@@ -92,7 +92,8 @@ generate_root_certs() {
     chmod 400 "$root_certs_path"/ca.key
     openssl req -new -x509 -config "$root_certs_path"/ca.conf \
                 -key "$root_certs_path"/ca.key \
-                -out "$root_certs_path"/ca.crt
+                -out "$root_certs_path"/ca.crt \
+                -days 730
 }
 
 generate_node_certs() {

--- a/bin/openssl_proxy.sh
+++ b/bin/openssl_proxy.sh
@@ -63,7 +63,7 @@ generate_root_certs() {
     default_ca = yugabyted_root_ca
 
     [ yugabyted_root_ca ]
-    default_days = 730
+    default_days = 1460
     serial = '"$root_certs_path"'/serial.txt
     database = '"$root_certs_path"'/index.txt
     default_md = sha256
@@ -93,7 +93,7 @@ generate_root_certs() {
     openssl req -new -x509 -config "$root_certs_path"/ca.conf \
                 -key "$root_certs_path"/ca.key \
                 -out "$root_certs_path"/ca.crt \
-                -days 730
+                -days 1460
 }
 
 generate_node_certs() {
@@ -135,7 +135,7 @@ generate_node_certs() {
                 -out "$temp_certs_path"/node."$hostname".crt \
                 -outdir "$temp_certs_path" \
                 -in "$temp_certs_path"/node.csr \
-                -days 730 \
+                -days 365 \
                 -batch \
                 -extfile "$temp_certs_path"/node.conf \
                 -extensions req_ext


### PR DESCRIPTION
## Summary

Fix `yugabyted cert generate_server_certs` generating a CA certificate with only 30-day validity instead of the intended 730 days.

The `generate_root_certs()` function in `openssl_proxy.sh` used `openssl req -new -x509` to generate the CA certificate without an explicit `-days` flag. Unlike `openssl ca`, the `openssl req -x509` command does not read `default_days` from the CA config section — it falls back to OpenSSL's built-in default of 30 days. Since TLS validation requires the CA cert to be valid, this effectively capped the usable lifetime of all generated certificates to 30 days regardless of the 730-day validity set on node certs.

## Changes

- `bin/openssl_proxy.sh`: Add `-days 730` to the `openssl req -new -x509` invocation in `generate_root_certs()`, matching the value already used for node cert signing via `openssl ca`.