### PR TITLE
[yugabyted] Remove timeout arg when calling ControlScript._send_upgrade_check_version_compatibility_callhome()

### DIFF
--- a/bin/yugabyted
+++ b/bin/yugabyted
@@ -1323,7 +1323,7 @@ class ControlScript(object):
         self.start_callhome_thread(
             CALLHOME_EVENT_UPGRADE_CHECK_VERSION_COMPATIBILITY,
             lambda: self._send_upgrade_check_version_compatibility_callhome(
-                timeout, compatible, time_taken))
+                compatible, time_taken))
         self.shutdown_callhome_thread(
             CALLHOME_EVENT_UPGRADE_CHECK_VERSION_COMPATIBILITY, timeout=5)
 


### PR DESCRIPTION
Fixes a small bug when checking for upgrades.