### PR TITLE
[PLAT-20765] YBA: Make gflag validation failure error message readable

### DIFF
--- a/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/subtasks/ValidateGFlags.java
+++ b/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/subtasks/ValidateGFlags.java
@@ -28,10 +28,13 @@ import com.yugabyte.yw.models.helpers.provider.LocalCloudInfo;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
@@ -504,23 +507,25 @@ public class ValidateGFlags extends UniverseDefinitionTaskBase {
           nodeUniverseManager.runCommand(
               node, universe, command, shellContext, false /* use bash */);
       if (response.code != 0) {
-        log.warn(
-            "Shell response returned with non-zero exit code with message: {}",
+        String redactedMessage =
             RedactingService.redactSensitiveInfoInString(
-                response.message, taskParams().ybSoftwareVersion, gFlagsValidation));
+                response.message, taskParams().ybSoftwareVersion, gFlagsValidation);
+        log.warn(
+            "Shell response returned with non-zero exit code with message: {}", redactedMessage);
         // All gflag validation errors from the binary start with "ERROR" prefix.
         if (response.message.contains("ERROR")) {
-          serverGFlagsValidationErrors.put(
-              serverType.toString(),
-              "Invalid gflags detected. "
-                  + RedactingService.redactSensitiveInfoInString(
-                      response.message, taskParams().ybSoftwareVersion, gFlagsValidation));
+          Map<String, String> perFlagErrors = extractGFlagBinaryErrors(redactedMessage);
+          if (!perFlagErrors.isEmpty()) {
+            serverGFlagsValidationErrors.putAll(perFlagErrors);
+          } else {
+            // Fallback when the output didn't match the expected ERROR format —
+            // surface the raw (redacted) message rather than silently swallowing it.
+            serverGFlagsValidationErrors.put(
+                serverType.toString(), "Invalid gflags detected. " + redactedMessage);
+          }
         } else {
           throw new PlatformServiceException(
-              INTERNAL_SERVER_ERROR,
-              "Command to call RPC failed: "
-                  + RedactingService.redactSensitiveInfoInString(
-                      response.message, taskParams().ybSoftwareVersion, gFlagsValidation));
+              INTERNAL_SERVER_ERROR, "Command to call RPC failed: " + redactedMessage);
         }
       }
     } catch (Exception e) {
@@ -542,6 +547,46 @@ public class ValidateGFlags extends UniverseDefinitionTaskBase {
                   e.getMessage(), taskParams().ybSoftwareVersion, gFlagsValidation));
     }
     return serverGFlagsValidationErrors;
+  }
+
+  // ERROR line emitted by the yb-server binary when a flag fails validation, e.g.:
+  //   ERROR: failed validation of new value '90' for flag 'default_memory_limit_to_ram_ratio'
+  private static final Pattern BINARY_ERROR_LINE =
+      Pattern.compile("ERROR: failed validation of new value '.*' for flag '([^']+)'");
+
+  // glog line preceding the ERROR line that contains the human-readable reason, e.g.:
+  //   E0506 15:36:40.347 110098 mem_tracker.cc:1003] Invalid value '90' for flag '...': <reason>
+  private static final Pattern BINARY_REASON_LINE =
+      Pattern.compile(".*\\]\\s*(Invalid value '.*' for flag '[^']+'.*)");
+
+  /**
+   * Extracts per-flag validation errors from the yb-server binary's stderr/stdout. Returns a map
+   * keyed by flag name with a concise human-readable reason as the value. Strips bash-trace lines,
+   * Python deprecation warnings, tracebacks, and the command-line arg dump that otherwise drown out
+   * the actual error.
+   */
+  static Map<String, String> extractGFlagBinaryErrors(String binaryOutput) {
+    Map<String, String> errorsByFlag = new LinkedHashMap<>();
+    if (StringUtils.isEmpty(binaryOutput)) {
+      return errorsByFlag;
+    }
+    String pendingReason = null;
+    for (String rawLine : binaryOutput.split("\\R")) {
+      String line = rawLine.trim();
+      Matcher reasonMatcher = BINARY_REASON_LINE.matcher(line);
+      if (reasonMatcher.matches()) {
+        pendingReason = reasonMatcher.group(1);
+        continue;
+      }
+      Matcher errorMatcher = BINARY_ERROR_LINE.matcher(line);
+      if (errorMatcher.find()) {
+        String flagName = errorMatcher.group(1);
+        String message = pendingReason != null ? pendingReason : line;
+        errorsByFlag.merge(flagName, message, (a, b) -> a + "; " + b);
+        pendingReason = null;
+      }
+    }
+    return errorsByFlag;
   }
 
   /**

--- a/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/subtasks/ValidateGFlags.java
+++ b/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/subtasks/ValidateGFlags.java
@@ -28,13 +28,10 @@ import com.yugabyte.yw.models.helpers.provider.LocalCloudInfo;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
@@ -507,25 +504,23 @@ public class ValidateGFlags extends UniverseDefinitionTaskBase {
           nodeUniverseManager.runCommand(
               node, universe, command, shellContext, false /* use bash */);
       if (response.code != 0) {
-        String redactedMessage =
-            RedactingService.redactSensitiveInfoInString(
-                response.message, taskParams().ybSoftwareVersion, gFlagsValidation);
         log.warn(
-            "Shell response returned with non-zero exit code with message: {}", redactedMessage);
+            "Shell response returned with non-zero exit code with message: {}",
+            RedactingService.redactSensitiveInfoInString(
+                response.message, taskParams().ybSoftwareVersion, gFlagsValidation));
         // All gflag validation errors from the binary start with "ERROR" prefix.
         if (response.message.contains("ERROR")) {
-          Map<String, String> perFlagErrors = extractGFlagBinaryErrors(redactedMessage);
-          if (!perFlagErrors.isEmpty()) {
-            serverGFlagsValidationErrors.putAll(perFlagErrors);
-          } else {
-            // Fallback when the output didn't match the expected ERROR format —
-            // surface the raw (redacted) message rather than silently swallowing it.
-            serverGFlagsValidationErrors.put(
-                serverType.toString(), "Invalid gflags detected. " + redactedMessage);
-          }
+          serverGFlagsValidationErrors.put(
+              serverType.toString(),
+              "Invalid gflags detected. "
+                  + RedactingService.redactSensitiveInfoInString(
+                      response.message, taskParams().ybSoftwareVersion, gFlagsValidation));
         } else {
           throw new PlatformServiceException(
-              INTERNAL_SERVER_ERROR, "Command to call RPC failed: " + redactedMessage);
+              INTERNAL_SERVER_ERROR,
+              "Command to call RPC failed: "
+                  + RedactingService.redactSensitiveInfoInString(
+                      response.message, taskParams().ybSoftwareVersion, gFlagsValidation));
         }
       }
     } catch (Exception e) {
@@ -547,46 +542,6 @@ public class ValidateGFlags extends UniverseDefinitionTaskBase {
                   e.getMessage(), taskParams().ybSoftwareVersion, gFlagsValidation));
     }
     return serverGFlagsValidationErrors;
-  }
-
-  // ERROR line emitted by the yb-server binary when a flag fails validation, e.g.:
-  //   ERROR: failed validation of new value '90' for flag 'default_memory_limit_to_ram_ratio'
-  private static final Pattern BINARY_ERROR_LINE =
-      Pattern.compile("ERROR: failed validation of new value '.*' for flag '([^']+)'");
-
-  // glog line preceding the ERROR line that contains the human-readable reason, e.g.:
-  //   E0506 15:36:40.347 110098 mem_tracker.cc:1003] Invalid value '90' for flag '...': <reason>
-  private static final Pattern BINARY_REASON_LINE =
-      Pattern.compile(".*\\]\\s*(Invalid value '.*' for flag '[^']+'.*)");
-
-  /**
-   * Extracts per-flag validation errors from the yb-server binary's stderr/stdout. Returns a map
-   * keyed by flag name with a concise human-readable reason as the value. Strips bash-trace lines,
-   * Python deprecation warnings, tracebacks, and the command-line arg dump that otherwise drown out
-   * the actual error.
-   */
-  static Map<String, String> extractGFlagBinaryErrors(String binaryOutput) {
-    Map<String, String> errorsByFlag = new LinkedHashMap<>();
-    if (StringUtils.isEmpty(binaryOutput)) {
-      return errorsByFlag;
-    }
-    String pendingReason = null;
-    for (String rawLine : binaryOutput.split("\\R")) {
-      String line = rawLine.trim();
-      Matcher reasonMatcher = BINARY_REASON_LINE.matcher(line);
-      if (reasonMatcher.matches()) {
-        pendingReason = reasonMatcher.group(1);
-        continue;
-      }
-      Matcher errorMatcher = BINARY_ERROR_LINE.matcher(line);
-      if (errorMatcher.find()) {
-        String flagName = errorMatcher.group(1);
-        String message = pendingReason != null ? pendingReason : line;
-        errorsByFlag.merge(flagName, message, (a, b) -> a + "; " + b);
-        pendingReason = null;
-      }
-    }
-    return errorsByFlag;
   }
 
   /**

--- a/managed/src/main/java/com/yugabyte/yw/common/gflags/GFlagsValidation.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/gflags/GFlagsValidation.java
@@ -783,22 +783,22 @@ public class GFlagsValidation {
     public Map<String, String> masterGFlagsErrors = new HashMap<>();
     public Map<String, String> tserverGFlagsErrors = new HashMap<>();
 
+    private static void appendErrors(StringBuilder sb, String label, Map<String, String> errors) {
+      if (errors == null || errors.isEmpty()) {
+        return;
+      }
+      sb.append("\n    ").append(label).append(":");
+      for (Map.Entry<String, String> entry : errors.entrySet()) {
+        sb.append("\n      ").append(entry.getKey()).append(": ").append(entry.getValue());
+      }
+    }
+
     @Override
     public String toString() {
       StringBuilder sb = new StringBuilder();
-      sb.append("GFlagsValidationErrorsPerAZ{");
-      sb.append("azUuid=").append(azUuid);
-      sb.append(", clusterUuid=").append(clusterUuid);
-
-      if (masterGFlagsErrors != null && !masterGFlagsErrors.isEmpty()) {
-        sb.append(", masterGFlagsErrors=").append(masterGFlagsErrors);
-      }
-
-      if (tserverGFlagsErrors != null && !tserverGFlagsErrors.isEmpty()) {
-        sb.append(", tserverGFlagsErrors=").append(tserverGFlagsErrors);
-      }
-
-      sb.append("}");
+      sb.append("Cluster=").append(clusterUuid).append(", AZ=").append(azUuid).append(":");
+      appendErrors(sb, "MASTER", masterGFlagsErrors);
+      appendErrors(sb, "TSERVER", tserverGFlagsErrors);
       return sb.toString();
     }
   }
@@ -808,21 +808,16 @@ public class GFlagsValidation {
 
     @Override
     public String toString() {
-      StringBuilder sb = new StringBuilder();
-      sb.append("GFlagsValidationErrors{");
-
-      if (gFlagsValidationErrorsPerAZs != null && !gFlagsValidationErrorsPerAZs.isEmpty()) {
-        sb.append("gFlagsValidationErrorsPerAZs=[");
-        for (int i = 0; i < gFlagsValidationErrorsPerAZs.size(); i++) {
-          if (i > 0) sb.append(", ");
-          sb.append(gFlagsValidationErrorsPerAZs.get(i));
-        }
-        sb.append("]");
-      } else {
-        sb.append("gFlagsValidationErrorsPerAZs=[]");
+      if (gFlagsValidationErrorsPerAZs == null || gFlagsValidationErrorsPerAZs.isEmpty()) {
+        return "(no errors)";
       }
-
-      sb.append("}");
+      StringBuilder sb = new StringBuilder();
+      for (GFlagsValidationErrorsPerAZ perAZ : gFlagsValidationErrorsPerAZs) {
+        if (perAZ.masterGFlagsErrors.isEmpty() && perAZ.tserverGFlagsErrors.isEmpty()) {
+          continue;
+        }
+        sb.append("\n  ").append(perAZ);
+      }
       return sb.toString();
     }
   }


### PR DESCRIPTION
## Summary

Parse the yb-server binary's stderr/stdout to extract just the per-flag
validation errors (keyed by flag name, matching the YBClient validation
path), instead of capturing the entire blob — bash trace, Python
deprecation warnings, traceback, and command-line args.

Reformat `GFlagsValidationErrors[PerAZ].toString()` to show one
flag-error per indented line.

Resulting user-visible message for the bug example:

```
GFlags validation failed
  Cluster=<uuid>, AZ=<uuid>:
    MASTER:
      default_memory_limit_to_ram_ratio: Invalid value '90' for flag 'default_memory_limit_to_ram_ratio': Must be in the range (0, 1] or -1000.
```

## Test plan

- [ ] Trigger a gflag validation failure (e.g. set `default_memory_limit_to_ram_ratio=90`) and confirm the surfaced error is the per-flag message above rather than the multi-KB blob.
- [ ] Verify the YBClient validation path (when `useCLIBinary=false`) still produces correct per-flag errors.
- [ ] Verify the fallback path still surfaces the raw redacted message when the binary output doesn't match the expected ERROR format.
