### PR TITLE
[#31497] tserver: Fix OpenTableFailureDuringPerform on macOS

### DIFF
--- a/src/yb/tserver/pg_client_session.cc
+++ b/src/yb/tserver/pg_client_session.cc
@@ -4649,9 +4649,10 @@ void PreparePgTablesQuery(
     AddIfMissing(table_ids, op.has_read() ? op.read().table_id() : op.write().table_id());
   }
   if (PREDICT_FALSE(FLAGS_TEST_request_unknown_tables_during_perform)) {
-    AddIfMissing(table_ids, GetPgsqlTableId(0, 0));
-    AddIfMissing(table_ids, GetPgsqlTableId(0, 1));
-    AddIfMissing(table_ids, GetPgsqlTableId(0, 2));
+    table_ids.insert(
+        table_ids.end(),
+        { GetPgsqlTableId(kPgInvalidOid, 0), GetPgsqlTableId(kPgInvalidOid, 1),
+          GetPgsqlTableId(kPgInvalidOid, 2) });
   }
 }
 

--- a/src/yb/tserver/pg_client_session.cc
+++ b/src/yb/tserver/pg_client_session.cc
@@ -2741,10 +2741,6 @@ class PgClientSession::Impl {
       CoarseTimePoint deadline) {
     boost::container::small_vector<TableId, 4> table_ids;
     PreparePgTablesQuery(data->req, table_ids);
-    if (PREDICT_FALSE(FLAGS_TEST_request_unknown_tables_during_perform)) {
-      table_ids.insert(
-          table_ids.end(), { GetPgsqlTableId(0, 0), GetPgsqlTableId(0, 1), GetPgsqlTableId(0, 2) });
-    }
     auto tables_future = GetTablesAsync(table_cache(), table_ids);
     RETURN_NOT_OK(Wait(tables_future, ToSteady(deadline)));
     RETURN_NOT_OK(precondition_waiter(data->req.serial_no(), deadline));
@@ -4651,6 +4647,10 @@ void PreparePgTablesQuery(
     const LWPgPerformRequestPB& req, boost::container::small_vector_base<TableId>& table_ids) {
   for (const auto& op : req.ops()) {
     AddIfMissing(table_ids, op.has_read() ? op.read().table_id() : op.write().table_id());
+  }
+  if (PREDICT_FALSE(FLAGS_TEST_request_unknown_tables_during_perform)) {
+    table_ids.insert(
+        table_ids.end(), { GetPgsqlTableId(0, 0), GetPgsqlTableId(0, 1), GetPgsqlTableId(0, 2) });
   }
 }
 

--- a/src/yb/tserver/pg_client_session.cc
+++ b/src/yb/tserver/pg_client_session.cc
@@ -4649,8 +4649,9 @@ void PreparePgTablesQuery(
     AddIfMissing(table_ids, op.has_read() ? op.read().table_id() : op.write().table_id());
   }
   if (PREDICT_FALSE(FLAGS_TEST_request_unknown_tables_during_perform)) {
-    table_ids.insert(
-        table_ids.end(), { GetPgsqlTableId(0, 0), GetPgsqlTableId(0, 1), GetPgsqlTableId(0, 2) });
+    AddIfMissing(table_ids, GetPgsqlTableId(0, 0));
+    AddIfMissing(table_ids, GetPgsqlTableId(0, 1));
+    AddIfMissing(table_ids, GetPgsqlTableId(0, 2));
   }
 }
 


### PR DESCRIPTION
## Summary

`FLAGS_TEST_request_unknown_tables_during_perform` was honoured only inside `DoHandleSharedExchangeQuery` — the shared-memory IPC path. On macOS that path is disabled (`pg_client_use_shared_memory` defaults to `!yb::kIsMac`), so requests are served by `PgClientServiceImpl::Perform` instead, which never read the flag. As a result every `SELECT` in `PgMiniTest.OpenTableFailureDuringPerform` succeeded and the final `ASSERT_TRUE(has_object_not_found_errors)` failed.

Move the injection into `PreparePgTablesQuery`, which both transports go through (`DoHandleSharedExchangeQuery` for shared memory, `PgClientServiceImpl::Perform` for RPC). The test now exercises the failure path on both platforms.

Fixes #31497.

## Test plan

- [x] `pgwrapper_pg_mini-test --gtest_filter=PgMiniTest.OpenTableFailureDuringPerform` passes on macOS (previously failing)
- [x] Same test still passes on Linux (no regression on the shared-memory path)


---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31498/>)