### PR TITLE
[#31504] macos-test: Skip anonymizer-backup tests on non-Linux platforms

### DIFF
--- a/src/yb/tools/yb-backup/yb-backup-during-ddl-test.cc
+++ b/src/yb/tools/yb-backup/yb-backup-during-ddl-test.cc
@@ -933,6 +933,9 @@ TEST_P(YBBackupDuringAlterTable, RenameColumn) {
 class YBBackupWithAnonymizerTest : public YBBackupDuringDdl {
  public:
   void SetUp() override {
+    if (!UseYbController()) {
+      GTEST_SKIP() << "Test requires YBC";
+    }
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_pg_anonymizer) = true;
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_use_yb_controller) = true;
     YBBackupDuringDdl::SetUp();
@@ -975,9 +978,6 @@ class YBBackupWithAnonymizerTest : public YBBackupDuringDdl {
 // encounters "role does not exist" errors for the GRANT statements. The restore itself
 // should succeed and ignore the errors because --dump-role-checks is used.
 TEST_F(YBBackupWithAnonymizerTest, RestoreAfterRoleRenameWithAnonymizer) {
-  if (!UseYbController()) {
-    GTEST_SKIP() << "Test requires YBC";
-  }
 
   auto conn = ASSERT_RESULT(SetUpAnonymizer());
   const string backup_dir = GetTempDir("backup");
@@ -1010,9 +1010,6 @@ class YBCloneWithAnonymizerTest : public YBBackupWithAnonymizerTest {
 // Same scenario as RestoreAfterRoleRenameWithAnonymizer but using database clone
 // instead of manual backup/restore.
 TEST_F(YBCloneWithAnonymizerTest, CloneAfterRoleRenameWithAnonymizer) {
-  if (!UseYbController()) {
-    GTEST_SKIP() << "Test requires YBC";
-  }
   auto conn = ASSERT_RESULT(SetUpAnonymizer());
 
   ASSERT_RESULT(snapshot_util_->CreateSchedule(

--- a/src/yb/tools/yb-backup/yb-backup-during-ddl-test.cc
+++ b/src/yb/tools/yb-backup/yb-backup-during-ddl-test.cc
@@ -54,7 +54,6 @@ using yb::client::YBTableName;
 DECLARE_bool(TEST_enable_sync_points);
 DECLARE_bool(TEST_mark_snapshot_as_failed);
 DECLARE_bool(TEST_use_custom_varz);
-DECLARE_bool(TEST_use_yb_controller);
 DECLARE_bool(enable_pg_anonymizer);
 DECLARE_bool(ysql_beta_features);
 

--- a/src/yb/tools/yb-backup/yb-backup-during-ddl-test.cc
+++ b/src/yb/tools/yb-backup/yb-backup-during-ddl-test.cc
@@ -937,7 +937,6 @@ class YBBackupWithAnonymizerTest : public YBBackupDuringDdl {
       GTEST_SKIP() << "Test requires YBC";
     }
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_pg_anonymizer) = true;
-    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_use_yb_controller) = true;
     YBBackupDuringDdl::SetUp();
     CreateDatabase(kBackupSourceDbName);
   }

--- a/src/yb/tools/yb-backup/yb-backup-during-ddl-test.cc
+++ b/src/yb/tools/yb-backup/yb-backup-during-ddl-test.cc
@@ -933,6 +933,9 @@ TEST_P(YBBackupDuringAlterTable, RenameColumn) {
 class YBBackupWithAnonymizerTest : public YBBackupDuringDdl {
  public:
   void SetUp() override {
+  #ifndef __linux__
+    GTEST_SKIP() << "YB Controller is only built/supported on Linux";
+  #endif
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_pg_anonymizer) = true;
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_use_yb_controller) = true;
     YBBackupDuringDdl::SetUp();

--- a/src/yb/tools/yb-backup/yb-backup-during-ddl-test.cc
+++ b/src/yb/tools/yb-backup/yb-backup-during-ddl-test.cc
@@ -933,9 +933,6 @@ TEST_P(YBBackupDuringAlterTable, RenameColumn) {
 class YBBackupWithAnonymizerTest : public YBBackupDuringDdl {
  public:
   void SetUp() override {
-  #ifndef __linux__
-    GTEST_SKIP() << "YB Controller is only built/supported on Linux";
-  #endif
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_pg_anonymizer) = true;
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_use_yb_controller) = true;
     YBBackupDuringDdl::SetUp();
@@ -1013,6 +1010,9 @@ class YBCloneWithAnonymizerTest : public YBBackupWithAnonymizerTest {
 // Same scenario as RestoreAfterRoleRenameWithAnonymizer but using database clone
 // instead of manual backup/restore.
 TEST_F(YBCloneWithAnonymizerTest, CloneAfterRoleRenameWithAnonymizer) {
+  if (!UseYbController()) {
+    GTEST_SKIP() << "Test requires YBC";
+  }
   auto conn = ASSERT_RESULT(SetUpAnonymizer());
 
   ASSERT_RESULT(snapshot_util_->CreateSchedule(


### PR DESCRIPTION
## Summary

`YBBackupWithAnonymizerTest` and the tests derived from its fixture (`RestoreAfterRoleRenameWithAnonymizer` and `CloneAfterRoleRenameWithAnonymizer`) require YB Controller, which is only built/supported on Linux. On non-Linux platforms (e.g. macOS) the fixture's `SetUp()` fails rather than skipping, so the tests are reported as failures.

This change skips the fixture's setup on non-Linux platforms via `GTEST_SKIP()`, which causes both tests to be reported as skipped on macOS instead of failing.

Fixes #31504.

## Test plan

- On macOS:
  - `RestoreAfterRoleRenameWithAnonymizer` and `CloneAfterRoleRenameWithAnonymizer` are reported as skipped instead of failing.
- On Linux:
  - Both tests continue to run as before (no behavioral change).


---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31505/>)