### PR TITLE
[#31508] Tests: Fix CqlTest.ReadTimeoutTest on macOS

### DIFF
--- a/src/yb/integration-tests/cql-test.cc
+++ b/src/yb/integration-tests/cql-test.cc
@@ -534,6 +534,7 @@ TEST_F(CqlTest, ReadTimeoutTest) {
   starting_time = CoarseMonoClock::now();
   auto result = session.ExecuteAndRenderToString(
       "select acctid from test_t WHERE custid = '123' AND roletitle = 'Manager'");
+  // Use a slightly lower bound to account for clock granularity and propagation latency on macOS.
   ASSERT_GE(MonoDelta(CoarseMonoClock::now() - starting_time).ToMilliseconds(),
       FLAGS_client_read_write_timeout_ms - 1);
   // Verify that read operation failed due to passed deadline.

--- a/src/yb/integration-tests/cql-test.cc
+++ b/src/yb/integration-tests/cql-test.cc
@@ -528,14 +528,14 @@ TEST_F(CqlTest, ReadTimeoutTest) {
 
   ASSERT_OK(cluster_->FlushTablets());
 
-  ANNOTATE_UNPROTECTED_WRITE(FLAGS_client_read_write_timeout_ms) = 10;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_client_read_write_timeout_ms) = 5;
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_disable_connection_timeout) = true;
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_read_deadline_check_granularity) = 1;
   starting_time = CoarseMonoClock::now();
   auto result = session.ExecuteAndRenderToString(
       "select acctid from test_t WHERE custid = '123' AND roletitle = 'Manager'");
   ASSERT_GE(MonoDelta(CoarseMonoClock::now() - starting_time).ToMilliseconds(),
-      FLAGS_client_read_write_timeout_ms);
+      FLAGS_client_read_write_timeout_ms - 1);
   // Verify that read operation failed due to passed deadline.
   ASSERT_NOK(result);
   ASSERT_STR_CONTAINS(result.status().message().ToBuffer(), "Deadline for query passed");


### PR DESCRIPTION
## Summary

Fixes #31508.

`CqlTest.ReadTimeoutTest` exhibits two macOS-specific problems that don't appear on Linux:

1. **Timeout=10ms is too long.** With `timeout=10ms`, the SELECT scan over 30,000 rows completes in under 9ms on macOS (faster CPU + finer-grained `CoarseMonoClock`), so the deadline never fires and the read returns `Status::OK()`. `ASSERT_NOK` then fails because the result is OK. The fix lowers the timeout to 5ms so the deadline reliably fires before the scan finishes.

2. **Elapsed time runs 1ms short of `client_read_write_timeout_ms`.** When the deadline does fire, the measured elapsed time is consistently ~1ms *less* than `FLAGS_client_read_write_timeout_ms` on macOS, while on Linux it is ~1ms *greater*. The asymmetry comes from `CoarseMonoClock` granularity: Linux's `CLOCK_MONOTONIC_COARSE` ticks at ~1ms+, so RPC propagation latency rounds away and the deadline check overruns by one tick. macOS lacks `CLOCK_MONOTONIC_COARSE` and uses a finer clock, so propagation latency is visible (the "client timeout 4ms" log line with `flag=5ms`) and deadline checks fire precisely. The fix subtracts 1ms from the asserted lower bound to accommodate this.

## Test plan

- `./yb_build.sh release --cxx-test integration-tests_cql-test --gtest_filter CqlTest.ReadTimeoutTest` on macOS arm64 — passes consistently across repeated runs.
- The same test continues to pass on Linux (the lower-bound relaxation by 1ms still leaves Linux's overrun comfortably above the asserted bound).


---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31509/>)