### PR TITLE
Langfuse tracing across RAG ingestion pipeline

### DIFF
--- a/python/ai/rag_agent/db/active_pipeline_tracking.py
+++ b/python/ai/rag_agent/db/active_pipeline_tracking.py
@@ -7,7 +7,7 @@ from typing import Optional, Dict, Any
 from enum import Enum
 from db.connection_pool import ConnectionPool
 
-
+from langfuse import observe
 class PipelineStatus(Enum):
     """Enum for pipeline status values"""
     PROCESSING = 'PROCESSING'
@@ -38,6 +38,7 @@ class PipelineTracking:
         """Return a connection to the pool."""
         self.pool.return_connection(conn)
 
+    @observe(name="Insert Pipeline Details / Active Pipeline Tracking", as_type="span")
     def insert_pipeline_details(
         self,
         document_id: str,
@@ -112,6 +113,7 @@ class PipelineTracking:
             if conn:
                 self._return_connection(conn)
 
+    @observe(name="Update Pipeline Status / Active Pipeline Tracking", as_type="span")
     def update_pipeline_status(
         self,
         pipeline_id: str,
@@ -164,6 +166,7 @@ class PipelineTracking:
             if conn:
                 self._return_connection(conn)
 
+    @observe(name="Mark Pipeline Completed / Active Pipeline Tracking", as_type="span")
     def mark_pipeline_completed(self, pipeline_id: str) -> bool:
         """
         Mark a pipeline as completed.
@@ -206,6 +209,7 @@ class PipelineTracking:
             if conn:
                 self._return_connection(conn)
 
+    @observe(name="Record Pipeline Error / Active Pipeline Tracking", as_type="span")
     def record_pipeline_error(
         self,
         pipeline_id: str,
@@ -256,6 +260,7 @@ class PipelineTracking:
             if conn:
                 self._return_connection(conn)
 
+    @observe(name="Update Chunks Processed / Active Pipeline Tracking", as_type="span")
     def update_chunks_processed(self, pipeline_id: str, chunks_count: int) -> bool:
         """
         Update the number of chunks processed for a pipeline.
@@ -301,6 +306,7 @@ class PipelineTracking:
             if conn:
                 self._return_connection(conn)
 
+    @observe(name="Update Embeddings Persisted / Active Pipeline Tracking", as_type="span")
     def update_embeddings_persisted(self, pipeline_id: str, embeddings_count: int) -> bool:
         """
         Update the number of embeddings persisted for a pipeline.

--- a/python/ai/rag_agent/db/yugabytedb_vector_store.py
+++ b/python/ai/rag_agent/db/yugabytedb_vector_store.py
@@ -6,6 +6,31 @@ import json
 from psycopg import sql
 from db.connection_pool import ConnectionPool
 from db.active_pipeline_tracking import PipelineTracking
+from langfuse import observe, get_client
+
+
+@observe(name="Execute SQL / YugabyteDB Vector Store", as_type="span", capture_input=False, capture_output=False)
+def execute_sql(cur, query: str, params=None, many: bool = False) -> int:
+    if many:
+        cur.executemany(query, params)
+    elif params is not None:
+        cur.execute(query, params)
+    else:
+        cur.execute(query)
+
+    rowcount = cur.rowcount
+
+    get_client().update_current_span(
+        input={
+            "query": query.strip(),
+            "mode": "executemany" if many else "execute",
+            **({"batch_size": len(params)} if many and params is not None else {}),
+            **({"param_count": len(params)} if not many and params is not None else {}),
+        },
+        output={"rowcount": rowcount}
+    )
+
+    return rowcount
 
 
 class YugabyteDBVectorStore:
@@ -40,7 +65,8 @@ class YugabyteDBVectorStore:
         cur = conn.cursor()
         try:
             # Query information_schema to check if table exists
-            cur.execute(
+            execute_sql(
+                cur,
                 """
                 SELECT EXISTS (
                     SELECT 1 FROM information_schema.tables
@@ -82,6 +108,7 @@ class YugabyteDBVectorStore:
             if conn:
                 self._return_connection(conn)
 
+    @observe(name="Insert Embeddings / YugabyteDB Vector Store", as_type="span")
     def insert_embeddings(
         self,
         document_id,
@@ -142,8 +169,12 @@ class YugabyteDBVectorStore:
                      tenant_id, metadata_json)
                 )
                 if len(batch) >= batch_size:
-                    cur.executemany(insert_stmt, batch)
-                    rows_inserted = cur.rowcount
+                    rows_inserted = execute_sql(
+                        cur,
+                        insert_stmt,
+                        batch,
+                        many=True
+                    )
                     total_inserted += rows_inserted
                     self.pipeline_tracking.update_embeddings_persisted(
                         pipeline_id=pipeline_id,
@@ -159,8 +190,12 @@ class YugabyteDBVectorStore:
 
             # Insert any remaining items in the batch
             if batch:
-                cur.executemany(insert_stmt, batch)
-                rows_inserted = cur.rowcount
+                rows_inserted = execute_sql(
+                    cur,
+                    insert_stmt,
+                    batch,
+                    many=True
+                )
                 total_inserted += rows_inserted
                 self.pipeline_tracking.update_embeddings_persisted(
                     pipeline_id=pipeline_id,
@@ -189,6 +224,7 @@ class YugabyteDBVectorStore:
             if conn:
                 self._return_connection(conn)
 
+    @observe(name="Create Index / YugabyteDB Vector Store", as_type="span")
     def create_index(
         self,
         table_name,
@@ -223,7 +259,7 @@ class YugabyteDBVectorStore:
                 table=sql.Identifier(table_name),
                 ops_class=sql.SQL(distance_metric),
             )
-            cur.execute(sql_create_index)
+            execute_sql(cur, sql_create_index)
 
             conn.commit()
             cur.close()

--- a/python/ai/rag_agent/embeddings/embed.py
+++ b/python/ai/rag_agent/embeddings/embed.py
@@ -2,6 +2,7 @@ from db.active_pipeline_tracking import PipelineTracking
 from langchain_openai import OpenAIEmbeddings
 from pdf_processing import PDFProcessor
 from html_processing import HTMLProcessor
+from langfuse import observe
 import logging
 import psycopg
 import os
@@ -118,6 +119,7 @@ class EmbeddingsGenerator:
             f"empty/whitespace chunks, {yielded_count} embeddings yielded"
         )
 
+    @observe(name="Generate Embeddings for PDF Files / EmbeddingsGenerator", as_type="embedding")
     def _generate_embeddings_for_pdf_files(
         self,
         pipeline_id: int,
@@ -167,6 +169,7 @@ class EmbeddingsGenerator:
             f"{chunk_count} total chunks, {yielded_count} embeddings yielded"
         )
 
+    @observe(name="Generate Embeddings for HTML Files / EmbeddingsGenerator", as_type="embedding")
     def _generate_embeddings_for_html_file(
         self,
         pipeline_id: int,
@@ -218,10 +221,12 @@ class EmbeddingsGenerator:
             f"{chunk_count} total chunks, {yielded_count} embeddings yielded"
         )
 
+    @observe(name="Generate Embeddings for Video Files / EmbeddingsGenerator", as_type="embedding")
     def _generate_embeddings_for_video_files(self, file_location: str, chunk_args=None):
         """Generate embeddings for video files."""
         pass
 
+    @observe(name="Generate Embeddings / EmbeddingsGenerator", as_type="chain")
     def generate_embeddings(self, pipeline_id: int, file_location: str, chunk_args=None):
         """
         Generator that yields (chunk_text, embedding_vector) tuples.
@@ -275,6 +280,7 @@ class EmbeddingsGenerator:
         else:
             raise ValueError(f"Unsupported file type: {file_type}")
 
+    @observe(name="Generate User Prompt Embeddings / EmbeddingsGenerator", as_type="embedding")
     def generate_user_prompt_embeddings(self, user_prompt: str) -> list[float]:
         """Generate embeddings for user prompt."""
 

--- a/python/ai/rag_agent/embeddings/embedding_user_promt.py
+++ b/python/ai/rag_agent/embeddings/embedding_user_promt.py
@@ -2,6 +2,7 @@ import os
 import logging
 import psycopg
 from langchain_openai import OpenAIEmbeddings
+from langfuse import observe
 
 
 class UserPromptEmbedder:
@@ -36,6 +37,7 @@ class UserPromptEmbedder:
         )
         self.logger = logging.getLogger(__name__)
 
+    @observe(name="Embed Prompt / UserPromptEmbedder", as_type="embedding")
     def embed_prompt(self, prompt: str):
         """Get OpenAI embedding for a single prompt."""
         try:
@@ -45,6 +47,7 @@ class UserPromptEmbedder:
             self.logger.error(f"Failed to generate embedding for prompt: {e}")
             raise
 
+    @observe(name="Similarity Search / UserPromptEmbedder", as_type="retriever")
     def similarity_search(self, prompt: str):
         """
         Embed the prompt and perform a vector similarity search using HNSW index in the PG table.

--- a/python/ai/rag_agent/pdf_processing/process_pdf.py
+++ b/python/ai/rag_agent/pdf_processing/process_pdf.py
@@ -9,6 +9,7 @@ from unstructured.partition.auto import partition
 from langchain_community.document_loaders import UnstructuredPDFLoader
 from langchain_core.documents import Document
 from rag_pipeline.chunk import chunk_langchain_docs, DEFAULT_SPLITTER, DEFAULT_ARGS
+from langfuse import observe
 
 
 class PDFProcessor:
@@ -17,6 +18,7 @@ class PDFProcessor:
         # self.model = model
         pass
 
+    @observe(name="Load PDF from Local / PDFProcessor", as_type="span")
     def _load_pdf_from_local(self, file_path):
         logging.info(f"Loading PDF data from {file_path}")
         try:
@@ -118,6 +120,7 @@ class PDFProcessor:
     #         logging.error(f"Failed to read file from S3: {e}")
     #         raise RuntimeError(f"Failed to read file from S3: {e}")
 
+    @observe(name="Load PDF from S3 / PDFProcessor", as_type="retriever")
     def _load_pdf_from_s3(self, file_path: str):
 
         logging.debug(f"Reading file from S3: {file_path}")
@@ -179,6 +182,7 @@ class PDFProcessor:
             logging.error(f"Failed to read file from S3: {e}")
             raise RuntimeError(f"Failed to read file from S3: {e}")
 
+    @observe(name="Process PDF Data / PDFProcessor", as_type="chain")
     def process_pdf_data(
         self, file_path: str, chunk_args: Dict[str, Any] = {}
     ) -> Generator[str, None, None]:

--- a/python/ai/rag_agent/rag_pipeline/chunk.py
+++ b/python/ai/rag_agent/rag_pipeline/chunk.py
@@ -7,6 +7,7 @@ from langchain_text_splitters import (
     RecursiveCharacterTextSplitter,
     SpacyTextSplitter
 )
+from langfuse import observe
 import json
 import mimetypes
 
@@ -54,6 +55,7 @@ def get_splitter_for_filetype(file_location: str) -> tuple[str, str]:
     return splitter, args
 
 
+@observe(name="Chunk Text / chunk", as_type="span")
 def chunk(splitter, text, args):
     kwargs = json.loads(args)
 
@@ -63,6 +65,7 @@ def chunk(splitter, text, args):
         raise ValueError("Unknown splitter: {}".format(splitter))
 
 
+@observe(name="Chunk LangChain Docs / chunk", as_type="span")
 def chunk_langchain_docs(splitter, docs, args):
     kwargs = json.loads(args)
 

--- a/python/ai/rag_agent/rag_pipeline/document_preprocessor.py
+++ b/python/ai/rag_agent/rag_pipeline/document_preprocessor.py
@@ -172,23 +172,14 @@ class DocumentPreprocessor(TaskProcessor):
                 cursor.close()
             if connection:
                 self.connection_pool.return_connection(connection)
-        return None, None
 
-    def _resolve_langfuse_client(self, document_uri: str) -> Tuple[str, str]:
+    def _resolve_langfuse_client(self, datapack_id: str) -> Tuple[str, str]:
         """
         Parse the datapack_id from document_uri and return a Langfuse client
         initialised with the matching project keys, or None if unavailable.
-        document_uri format: {userID}/{datapackID}/{filename}
         """
-        # s3://<bucket>/<user_id>/<datapack_id>/
-        # split('/') → ['s3:', '', '<bucket>', '<user_id>', '<datapack_id>', '']
-        self.logger.info(f"document_uri={document_uri}")
-        uri_parts = document_uri.split('/')
-        datapack_id = uri_parts[4] if len(uri_parts) >= 5 else None
-        self.logger.info(f"Parsed datapack_id={datapack_id} from document_uri={document_uri}")
 
-        if not datapack_id:
-            return None
+        self.logger.debug(f"Resolving Langfuse client for datapack_id={datapack_id}")
 
         try:
             connection = self.connection_pool.get_connection()
@@ -220,14 +211,14 @@ class DocumentPreprocessor(TaskProcessor):
         Process the task.
         """
         self.logger.info(f"Processing task: {task.id}")
-        document_uri = task.task_details.get('document_uri')
-        self.logger.debug(f"document_uri: {document_uri}")
+        datapack_id = task.task_details.get('tenant_id')
+        self.logger.info(f"Datapack ID: {datapack_id}")
         transform_span = None
         langfuse_public_key = None
         tracing_context = nullcontext()
         observation_context = nullcontext()
-        resolved_keys = self._resolve_langfuse_client(document_uri)
-        if resolved_keys:
+        resolved_keys = self._resolve_langfuse_client(datapack_id)
+        if resolved_keys and datapack_id:
             try:
                 langfuse_public_key, langfuse_secret_key = resolved_keys
                 langfuse_client = Langfuse(

--- a/python/ai/rag_agent/rag_pipeline/document_preprocessor.py
+++ b/python/ai/rag_agent/rag_pipeline/document_preprocessor.py
@@ -1,4 +1,5 @@
 import logging
+from contextlib import nullcontext
 from work_queue.task_router import TaskProcessor
 from db.connection_pool import ConnectionPool
 from models.work_queue_task import WorkQueueTask
@@ -221,16 +222,36 @@ class DocumentPreprocessor(TaskProcessor):
         self.logger.info(f"Processing task: {task.id}")
         document_uri = task.task_details.get('document_uri')
         self.logger.debug(f"document_uri: {document_uri}")
-        LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY = self._resolve_langfuse_client(document_uri)
-        langfuse_client = Langfuse(
-            public_key=LANGFUSE_PUBLIC_KEY,
-            secret_key=LANGFUSE_SECRET_KEY
-        )
-        with _set_current_public_key(LANGFUSE_PUBLIC_KEY):
-            with langfuse_client.start_as_current_observation(
-                as_type="agent",
-                name="Process Task / DocumentPreprocessor"
-            ) as transform_span:
+        transform_span = None
+        langfuse_public_key = None
+        tracing_context = nullcontext()
+        observation_context = nullcontext()
+        resolved_keys = self._resolve_langfuse_client(document_uri)
+        if resolved_keys:
+            try:
+                langfuse_public_key, langfuse_secret_key = resolved_keys
+                langfuse_client = Langfuse(
+                    public_key=langfuse_public_key,
+                    secret_key=langfuse_secret_key
+                )
+                tracing_context = _set_current_public_key(langfuse_public_key)
+                observation_context = langfuse_client.start_as_current_observation(
+                    as_type="agent",
+                    name="Process Task / DocumentPreprocessor"
+                )
+            except Exception as e:
+                self.logger.warning(
+                    f"Langfuse initialization failed for task {task.id}; continuing without tracing: {str(e)}"
+                )
+                tracing_context = nullcontext()
+                observation_context = nullcontext()
+        else:
+            self.logger.info(
+                f"No Langfuse keys resolved for task {task.id}; continuing without tracing"
+            )
+        with (tracing_context or nullcontext()):
+            with (observation_context or nullcontext()) as active_span:
+                transform_span = active_span
                 document_id = None
                 span_output = {"status": "error", "task_id": str(task.id)}
 
@@ -398,4 +419,10 @@ class DocumentPreprocessor(TaskProcessor):
                         "error_message": str(e)
                     }
                 finally:
-                    transform_span.update(output=span_output)
+                    if transform_span:
+                        try:
+                            transform_span.update(output=span_output)
+                        except Exception as e:
+                            self.logger.warning(
+                                f"Failed to update Langfuse span for task {task.id}: {str(e)}"
+                            )

--- a/python/ai/rag_agent/rag_pipeline/document_preprocessor.py
+++ b/python/ai/rag_agent/rag_pipeline/document_preprocessor.py
@@ -5,8 +5,9 @@ from models.work_queue_task import WorkQueueTask
 from rag_pipeline.rag_handler import RagPipelineHandler
 from db.source_document_tracking import SourceDocumentTracking
 from uuid import UUID
-from typing import Dict, Any, Optional, Tuple
-
+from typing import Dict, Any,Optional, Tuple
+from langfuse import Langfuse, observe
+from langfuse._client.get_client import _set_current_public_key
 
 class DocumentPreprocessor(TaskProcessor):
     """
@@ -37,7 +38,7 @@ class DocumentPreprocessor(TaskProcessor):
                 return False
 
         return True
-
+    @observe(name="Retrieve Embedding Parameters / DocumentPreprocessor", as_type="retriever")
     def _retrieve_embedding_parameters(self, index_id: UUID) -> Dict[str, Any]:
         """
         Retrieve the embedding parameters for the source.
@@ -73,6 +74,7 @@ class DocumentPreprocessor(TaskProcessor):
                 self.connection_pool.return_connection(connection)
         return None
 
+    @observe(name="Retrieve Chunking Parameters / DocumentPreprocessor", as_type="retriever")
     def _retrieve_chunking_parameters(self, index_id: UUID, source_id: UUID) -> Dict[str, Any]:
         """
         Retrieve the chunking parameters for the source.
@@ -110,6 +112,7 @@ class DocumentPreprocessor(TaskProcessor):
                 self.connection_pool.return_connection(connection)
         return None
 
+    @observe(name="Retrieve Source Metadata / DocumentPreprocessor", as_type="retriever")
     def _retrieve_source_metadata(self, source_id: UUID) -> Dict[str, Any]:
         """
         Retrieve the source metadata.
@@ -138,6 +141,7 @@ class DocumentPreprocessor(TaskProcessor):
                 self.connection_pool.return_connection(connection)
         return None
 
+    @observe(name="Retrieve RAG Index Name / DocumentPreprocessor", as_type="retriever")
     def _retrieve_rag_index_name(
         self, index_id: UUID
     ) -> Tuple[Optional[str], Optional[str]]:
@@ -169,149 +173,229 @@ class DocumentPreprocessor(TaskProcessor):
                 self.connection_pool.return_connection(connection)
         return None, None
 
+    def _resolve_langfuse_client(self, document_uri: str) -> Tuple[str, str]:
+        """
+        Parse the datapack_id from document_uri and return a Langfuse client
+        initialised with the matching project keys, or None if unavailable.
+        document_uri format: {userID}/{datapackID}/{filename}
+        """
+        # s3://<bucket>/<user_id>/<datapack_id>/
+        # split('/') → ['s3:', '', '<bucket>', '<user_id>', '<datapack_id>', '']
+        self.logger.info(f"document_uri={document_uri}")
+        uri_parts = document_uri.split('/')
+        datapack_id = uri_parts[4] if len(uri_parts) >= 5 else None
+        self.logger.info(f"Parsed datapack_id={datapack_id} from document_uri={document_uri}")
+
+        if not datapack_id:
+            return None
+
+        try:
+            connection = self.connection_pool.get_connection()
+            cursor = connection.cursor()
+            try:
+                cursor.execute(
+                    "SELECT langfuse_public_key, langfuse_secret_key "
+                    "FROM meko_system.langfuse_project_mapping WHERE datapack_id = %s::uuid",
+                    (datapack_id,),
+                )
+                row = cursor.fetchone()
+                if row:
+                    public_key=row[0]
+                    secret_key=row[1]
+                    return public_key, secret_key
+                else:
+                    self.logger.warning(f"No Langfuse keys found for datapack_id={datapack_id}")
+            finally:
+                cursor.close()
+                self.connection_pool.return_connection(connection)
+        except Exception as e:
+            self.logger.warning(
+                f"Failed to resolve Langfuse keys for datapack_id={datapack_id}: {str(e)}"
+            )
+
+        return None
     def process(self, task: WorkQueueTask) -> Dict[str, Any]:
         """
         Process the task.
         """
-
         self.logger.info(f"Processing task: {task.id}")
+        document_uri = task.task_details.get('document_uri')
+        self.logger.debug(f"document_uri: {document_uri}")
+        LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY = self._resolve_langfuse_client(document_uri)
+        langfuse_client = Langfuse(
+            public_key=LANGFUSE_PUBLIC_KEY,
+            secret_key=LANGFUSE_SECRET_KEY
+        )
+        with _set_current_public_key(LANGFUSE_PUBLIC_KEY):
+            with langfuse_client.start_as_current_observation(
+                as_type="agent",
+                name="Process Task / DocumentPreprocessor"
+            ) as transform_span:
+                document_id = None
+                span_output = {"status": "error", "task_id": str(task.id)}
 
-        try:
-            # Extract task details
-            task_details = task.task_details
-            if not task_details:
-                raise ValueError("Task details are missing or empty")
-
-            index_id = task_details.get('index_id')
-            source_id = task_details.get('source_id')
-            document_id = task_details.get('document_id')
-            document_uri = task_details.get('document_uri')
-            # tenant_id is optional in task_details for backward compatibility
-            # with tasks queued before the tenant_id column was added.
-            tenant_id = task_details.get('tenant_id')
-
-            # Validate extracted parameters
-            if not all([index_id, source_id, document_id, document_uri]):
-                raise ValueError(
-                    f"Missing required parameters - index_id: {index_id}, "
-                    f"source_id: {source_id}, document_id: {document_id}, "
-                    f"document_uri: {document_uri}"
-                )
-
-            # Retrieve required parameters
-            try:
-                embedding_model_params = self._retrieve_embedding_parameters(
-                    index_id=index_id
-                )
-                if not embedding_model_params:
-                    raise ValueError(
-                        f"Failed to retrieve embedding parameters for index_id: {index_id}"
-                    )
-            except Exception as e:
-                self.logger.error(f"Error retrieving embedding parameters: {str(e)}")
-                raise
-
-            try:
-                chunking_params = self._retrieve_chunking_parameters(
-                    index_id=index_id, source_id=source_id
-                )
-                if not chunking_params:
-                    raise ValueError(
-                        f"Failed to retrieve chunking parameters for index_id: {index_id}, "
-                        f"source_id: {source_id}"
-                    )
-            except Exception as e:
-                self.logger.error(f"Error retrieving chunking parameters: {str(e)}")
-                raise
-
-            try:
-                source_metadata = self._retrieve_source_metadata(source_id=source_id)
-                if source_metadata is None:
-                    self.logger.warning(
-                        f"Source metadata is None for source_id: {source_id}, "
-                        f"using empty dict"
-                    )
-                    source_metadata = {}
-            except Exception as e:
-                self.logger.error(f"Error retrieving source metadata: {str(e)}")
-                raise
-
-            # Fall back to looking up tenant_id on the source if it wasn't
-            # included in the task payload (e.g. older queued tasks).
-            if not tenant_id:
                 try:
-                    source_details = (
-                        self.source_document_tracking.get_source_details(
+                    # Extract task details
+                    task_details = task.task_details
+                    if not task_details:
+                        raise ValueError("Task details are missing or empty")
+
+                    index_id = task_details.get('index_id')
+                    source_id = task_details.get('source_id')
+                    document_id = task_details.get('document_id')
+                    document_uri = task_details.get('document_uri')
+                    # tenant_id is optional in task_details for backward compatibility
+                    # with tasks queued before the tenant_id column was added.
+                    tenant_id = task_details.get('tenant_id')
+
+                    # Validate extracted parameters
+                    if not all([index_id, source_id, document_id, document_uri]):
+                        raise ValueError(
+                            f"Missing required parameters - index_id: {index_id}, "
+                            f"source_id: {source_id}, document_id: {document_id}, "
+                            f"document_uri: {document_uri}"
+                        )
+
+                    # Retrieve embedding parameters
+                    try:
+                        embedding_model_params = self._retrieve_embedding_parameters(
+                            index_id=index_id
+                        )
+                        if not embedding_model_params:
+                            raise ValueError(
+                                f"Failed to retrieve embedding parameters for index_id: {index_id}"
+                            )
+                    except Exception as e:
+                        self.logger.error(f"Error retrieving embedding parameters: {str(e)}")
+                        raise
+
+                    # Retrieve chunking parameters
+                    try:
+                        chunking_params = self._retrieve_chunking_parameters(
+                            index_id=index_id,
                             source_id=source_id
                         )
+                        if not chunking_params:
+                            raise ValueError(
+                                f"Failed to retrieve chunking parameters for index_id: {index_id}, "
+                                f"source_id: {source_id}"
+                            )
+                    except Exception as e:
+                        self.logger.error(f"Error retrieving chunking parameters: {str(e)}")
+                        raise
+
+                    # Retrieve source metadata
+                    try:
+                        source_metadata = self._retrieve_source_metadata(source_id=source_id)
+                        if source_metadata is None:
+                            self.logger.warning(
+                                f"Source metadata is None for source_id: {source_id}, "
+                                f"using empty dict"
+                            )
+                            source_metadata = {}
+                    except Exception as e:
+                        self.logger.error(f"Error retrieving source metadata: {str(e)}")
+                        raise
+
+                    # Fall back to looking up tenant_id on the source if it wasn't
+                    # included in the task payload (e.g. older queued tasks).
+                    if not tenant_id:
+                        try:
+                            source_details = (
+                                self.source_document_tracking.get_source_details(
+                                    source_id=source_id
+                                )
+                            )
+                            if source_details:
+                                tenant_id = source_details.get('tenant_id')
+                        except Exception as e:
+                            self.logger.warning(
+                                f"Failed to resolve tenant_id from sources table "
+                                f"for source_id {source_id}: {str(e)}"
+                            )
+
+                    # Retrieve RAG index name and schema
+                    try:
+                        rag_index_name, rag_schema_name = self._retrieve_rag_index_name(index_id=index_id)
+                        if not rag_index_name:
+                            raise ValueError(f"Failed to retrieve RAG index name for index_id: {index_id}")
+                    except Exception as e:
+                        self.logger.error(f"Error retrieving RAG index name: {str(e)}")
+                        raise
+
+                    self.source_document_tracking.update_document_status(
+                        document_id=document_id, status="PROCESSING"
                     )
-                    if source_details:
-                        tenant_id = source_details.get('tenant_id')
+
+                    # Start processing
+                    try:
+                        self.rag_handler.start_processing(
+                            source_id=source_id,
+                            document_id=document_id,
+                            document_uri=document_uri,
+                            table_name=rag_index_name,
+                            schema_name=rag_schema_name,
+                            metadata=source_metadata,
+                            chunk_kwargs=chunking_params,
+                            embedding_model_params=embedding_model_params,
+                            tenant_id=tenant_id
+                        )
+                        self.logger.info(f"Task {task.id} processed successfully")
+                        self.source_document_tracking.update_document_status(
+                            document_id=document_id, status="COMPLETED"
+                        )
+                        span_output = {
+                            "status": "success",
+                            "task_id": str(task.id),
+                            "document_id": str(document_id)
+                        }
+                        return {
+                            "status": "success",
+                            "task_id": task.id,
+                            "document_id": document_id
+                        }
+                    except Exception as e:
+                        self.logger.error(f"Error during RAG pipeline processing: {str(e)}")
+                        raise
+
+                except ValueError as e:
+                    self.logger.error(f"Validation error while processing task {task.id}: {str(e)}")
+                    if document_id:
+                        self.source_document_tracking.update_document_status(
+                            document_id=document_id, status="FAILED"
+                        )
+                    span_output = {
+                        "status": "error",
+                        "task_id": str(task.id),
+                        "error_type": "ValidationError",
+                        "error_message": str(e)
+                    }
+                    return {
+                        "status": "error",
+                        "task_id": task.id,
+                        "error_type": "ValidationError",
+                        "error_message": str(e)
+                    }
                 except Exception as e:
-                    self.logger.warning(
-                        f"Failed to resolve tenant_id from sources table "
-                        f"for source_id {source_id}: {str(e)}"
+                    self.logger.error(
+                        f"Unexpected error while processing task {task.id}: {str(e)}",
+                        exc_info=True
                     )
-
-            try:
-                rag_index_name, rag_schema_name = self._retrieve_rag_index_name(index_id=index_id)
-                if not rag_index_name:
-                    raise ValueError(f"Failed to retrieve RAG index name for index_id: {index_id}")
-            except Exception as e:
-                self.logger.error(f"Error retrieving RAG index name: {str(e)}")
-                raise
-
-            self.source_document_tracking.update_document_status(
-                document_id=document_id, status="PROCESSING"
-            )
-            # Start processing
-            try:
-                self.rag_handler.start_processing(
-                    source_id=source_id,
-                    document_id=document_id,
-                    document_uri=document_uri,
-                    table_name=rag_index_name,
-                    schema_name=rag_schema_name,
-                    metadata=source_metadata,
-                    chunk_kwargs=chunking_params,
-                    embedding_model_params=embedding_model_params,
-                    tenant_id=tenant_id
-                )
-                self.logger.info(f"Task {task.id} processed successfully")
-                self.source_document_tracking.update_document_status(
-                    document_id=document_id, status="COMPLETED"
-                )
-                return {
-                    "status": "success",
-                    "task_id": task.id,
-                    "document_id": document_id
-                }
-            except Exception as e:
-                self.logger.error(f"Error during RAG pipeline processing: {str(e)}")
-                raise
-
-        except ValueError as e:
-            self.logger.error(f"Validation error while processing task {task.id}: {str(e)}")
-            self.source_document_tracking.update_document_status(
-                document_id=document_id, status="FAILED"
-            )
-            return {
-                "status": "error",
-                "task_id": task.id,
-                "error_type": "ValidationError",
-                "error_message": str(e)
-            }
-        except Exception as e:
-            self.logger.error(
-                f"Unexpected error while processing task {task.id}: {str(e)}",
-                exc_info=True
-            )
-            self.source_document_tracking.update_document_status(
-                document_id=document_id, status="FAILED"
-            )
-            return {
-                "status": "error",
-                "task_id": task.id,
-                "error_type": type(e).__name__,
-                "error_message": str(e)
-            }
+                    if document_id:
+                        self.source_document_tracking.update_document_status(
+                            document_id=document_id, status="FAILED"
+                        )
+                    span_output = {
+                        "status": "error",
+                        "task_id": str(task.id),
+                        "error_type": type(e).__name__,
+                        "error_message": str(e)
+                    }
+                    return {
+                        "status": "error",
+                        "task_id": task.id,
+                        "error_type": type(e).__name__,
+                        "error_message": str(e)
+                    }
+                finally:
+                    transform_span.update(output=span_output)

--- a/python/ai/rag_agent/rag_pipeline/partition_chunk_pipeline.py
+++ b/python/ai/rag_agent/rag_pipeline/partition_chunk_pipeline.py
@@ -4,7 +4,7 @@ import boto3
 import logging
 import requests
 from rag_pipeline.chunk import chunk, get_splitter_for_filetype
-
+from langfuse import observe
 
 def read_file_stream(
     file_location: str, chunk_size: int = 1024 * 1024
@@ -82,7 +82,7 @@ def read_file_stream(
                     break
                 yield chunk
 
-
+@observe(name="Chunking & Partitioning", as_type="span")
 def stream_partition_and_chunk(
     pipeline_id: int,  # pipeline id of the document being processed
     file_location: str,

--- a/python/ai/rag_agent/rag_pipeline/rag_handler.py
+++ b/python/ai/rag_agent/rag_pipeline/rag_handler.py
@@ -1,6 +1,7 @@
 from embeddings import EmbeddingsGenerator
 from db import YugabyteDBVectorStore, PipelineTracking, PipelineStatus
 from source_location_crawlers import S3BucketCrawler
+from langfuse import observe
 import logging
 
 
@@ -27,6 +28,7 @@ class RagPipelineHandler:
         self.vector_store = YugabyteDBVectorStore()
         self.pipeline_tracking = PipelineTracking()
 
+    @observe(name="Ingest Document / RagPipelineHandler", as_type="chain", capture_input=False)
     def _ingest_document(
         self,
         pipeline_id,
@@ -105,6 +107,7 @@ class RagPipelineHandler:
         )
         return True
 
+    @observe(name="Start Processing / RagPipelineHandler", as_type="agent", capture_input=False)
     def start_processing(
         self,
         source_id,

--- a/python/ai/rag_agent/requirements.txt
+++ b/python/ai/rag_agent/requirements.txt
@@ -37,3 +37,6 @@ httpx==0.25.2  # For testing API endpoints
 # Optional: For enhanced logging and monitoring
 structlog==23.2.0
 boto3==1.34.81  # AWS SDK for Python (latest as of 2024-06)
+
+# Langfuse
+langfuse>=3.0.0


### PR DESCRIPTION
Add Langfuse tracing across RAG ingestion pipeline with datapack-scoped project resolution

Instrument the RAG agent pipeline end-to-end with Langfuse spans/observations so ingestion,
chunking, embedding generation, vector writes, and pipeline state updates are traceable in a
single observability flow. This adds method-level @observe coverage to core pipeline layers
(`document_preprocessor`, `rag_handler`, `partition_chunk_pipeline`, `chunk`, `process_pdf`,
`embed`, `embedding_user_promt`, and active pipeline tracking DB methods), and introduces a
wrapped SQL executor in `yugabytedb_vector_store` to capture query metadata and row counts for
database operations.

In `DocumentPreprocessor`, add datapack-aware Langfuse key resolution from document URI and
`meko_system.langfuse_project_mapping`, then bind the active public key context so nested
observations are routed to the correct Langfuse project. Also wrap top-level task processing in
an observation span and ensure structured success/error output is emitted to tracing. Improve
failure handling by updating document status to FAILED only when `document_id` is available.

Update dependencies by adding `langfuse>=3.0.0` to support the new tracing instrumentation.