### PR TITLE
[#31519] Tests: Fix PgAshNestedQueryTracking on macOS by raising kNumRows

### DIFF
--- a/src/yb/yql/pgwrapper/pg_ash-test.cc
+++ b/src/yb/yql/pgwrapper/pg_ash-test.cc
@@ -469,7 +469,7 @@ class PgAshNestedQueryTracking : public PgAshSingleNode {
   }
 
   static constexpr auto kOuterQuery = "INSERT INTO trig_outer SELECT k, v FROM trig_data";
-  static constexpr int kNumRows = 1000;
+  static constexpr int kNumRows = 10000;
 
   int64_t outer_query_id_;
   int64_t inner_query_id_;


### PR DESCRIPTION
## Summary

Bumps `kNumRows` from 1000 to 10000 in `PgAshNestedQueryTracking` so the
inner trigger query stays active long enough to be sampled by ASH
(`kSamplingIntervalMs = 50ms`). On fast hardware (macOS arm64), 1000
trigger firings of the inner query complete inside a single sample
tick, so the sampler never catches it active and `InnerAshQpmMatch()`
returns 0.

Fixes #31519.

## Test plan

- [x] On macOS arm64: `./yb_build.sh release --cxx-test pg_ash-test --gtest_filter PgAshTest.PgAshNestedQueryTracking` passes.
- [x] On Linux: same command continues to pass (raising `kNumRows` only makes the inner query window larger, not smaller).


---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31520/>)