### PR TITLE
[#31522] tserver: Fix VerifyPgClientServiceCleanupQueue on macOS

### DIFF
--- a/src/yb/tserver/pg_client_service.cc
+++ b/src/yb/tserver/pg_client_service.cc
@@ -1017,7 +1017,11 @@ class PgClientServiceImpl::Impl : public SessionProvider {
     }
 
     context->ListenConnectionShutdown([this, session_id, pid = req.pid()]() {
+#if defined(__APPLE__)
+      auto delay = 250ms;
+#else
       auto delay = RegularBuildVsSanitizers(50ms, 1000ms);
+#endif
       messenger_.scheduler().Schedule([this, session_id, pid](const Status& status) {
         if (!status.ok()) {
           // Task was aborted.

--- a/src/yb/tserver/pg_client_service.cc
+++ b/src/yb/tserver/pg_client_service.cc
@@ -1017,11 +1017,7 @@ class PgClientServiceImpl::Impl : public SessionProvider {
     }
 
     context->ListenConnectionShutdown([this, session_id, pid = req.pid()]() {
-#if defined(__APPLE__)
-      auto delay = 250ms;
-#else
       auto delay = RegularBuildVsSanitizers(50ms, 1000ms);
-#endif
       messenger_.scheduler().Schedule([this, session_id, pid](const Status& status) {
         if (!status.ok()) {
           // Task was aborted.

--- a/src/yb/tserver/pg_client_service.cc
+++ b/src/yb/tserver/pg_client_service.cc
@@ -1075,7 +1075,11 @@ class PgClientServiceImpl::Impl : public SessionProvider {
     }
 
     context->ListenConnectionShutdown([this, session_id, pid = req.pid()]() {
+#if defined(__APPLE__)
+      auto delay = 250ms;
+#else
       auto delay = RegularBuildVsSanitizers(50ms, 1000ms);
+#endif
       messenger_.scheduler().Schedule([this, session_id, pid](const Status& status) {
         if (!status.ok()) {
           // Task was aborted.

--- a/src/yb/tserver/pg_client_service.cc
+++ b/src/yb/tserver/pg_client_service.cc
@@ -1075,11 +1075,7 @@ class PgClientServiceImpl::Impl : public SessionProvider {
     }
 
     context->ListenConnectionShutdown([this, session_id, pid = req.pid()]() {
-#if defined(__APPLE__)
-      auto delay = 250ms;
-#else
       auto delay = RegularBuildVsSanitizers(50ms, 1000ms);
-#endif
       messenger_.scheduler().Schedule([this, session_id, pid](const Status& status) {
         if (!status.ok()) {
           // Task was aborted.

--- a/src/yb/yql/pgwrapper/pg_mini-test.cc
+++ b/src/yb/yql/pgwrapper/pg_mini-test.cc
@@ -255,7 +255,14 @@ TEST_F_EX(PgMiniTest, VerifyPgClientServiceCleanupQueue, PgMiniPgClientServiceCl
   }
   auto* client_service =
       cluster_->mini_tablet_server(0)->server()->TEST_GetPgClientService();
-  ASSERT_EQ(connections.size() + kAshConnection, client_service->TEST_SessionsCount());
+  // The first Connect() to a fresh DB spawns an internal libpq backend
+  // (TriggerRelcacheInitConnection) whose session lingers in sessions_
+  // for the platform's ListenConnectionShutdown delay (up to 250ms on
+  // macOS, 1s under sanitizers). Poll until it drains instead of
+  // asserting immediately.
+  ASSERT_OK(WaitFor([client_service, expected_count = connections.size() + kAshConnection]() {
+    return client_service->TEST_SessionsCount() == expected_count;
+  }, 5s, "relcache-init session cleanup"));
 
   connections.erase(connections.begin() + connections.size() / 2, connections.end());
   ASSERT_OK(WaitFor([client_service, expected_count = connections.size() + kAshConnection]() {

--- a/src/yb/yql/pgwrapper/pg_mini-test.cc
+++ b/src/yb/yql/pgwrapper/pg_mini-test.cc
@@ -266,7 +266,14 @@ TEST_F_EX(PgMiniTest, VerifyPgClientServiceCleanupQueue, PgMiniPgClientServiceCl
   }
   auto* client_service =
       cluster_->mini_tablet_server(0)->server()->TEST_GetPgClientService();
-  ASSERT_EQ(connections.size() + kAshConnection, client_service->TEST_SessionsCount());
+  // The first Connect() to a fresh DB spawns an internal libpq backend
+  // (TriggerRelcacheInitConnection) whose session lingers in sessions_
+  // for the platform's ListenConnectionShutdown delay (up to 250ms on
+  // macOS, 1s under sanitizers). Poll until it drains instead of
+  // asserting immediately.
+  ASSERT_OK(WaitFor([client_service, expected_count = connections.size() + kAshConnection]() {
+    return client_service->TEST_SessionsCount() == expected_count;
+  }, 5s, "relcache-init session cleanup"));
 
   connections.erase(connections.begin() + connections.size() / 2, connections.end());
   ASSERT_OK(WaitFor([client_service, expected_count = connections.size() + kAshConnection]() {


### PR DESCRIPTION
## Summary

`VerifyPgClientServiceCleanupQueue` asserted the session count immediately after
opening its connections. The first `Connect()` to a fresh database also spawns an
internal libpq backend via `TriggerRelcacheInitConnection`, and that session stays
in `sessions_` until the `ListenConnectionShutdown` cleanup timer fires — 250ms on
macOS, 1s under sanitizers, 50ms elsewhere.

In the failing run the assertion ran about 220ms after that internal backend
closed, so on macOS the cleanup timer had not fired yet and the test saw one
session more than expected. On Linux the timer fires at 50ms, well before the
assertion, which is why this only ever failed on macOS.

Replace the immediate `ASSERT_EQ` with a `WaitFor` on the same expected count,
matching the check that already follows it a few lines later. No product code
changes.

Fixes #31522.

## Test plan

- [x] macOS arm64 release: `./yb_build.sh release --cxx-test pg_mini-test --gtest_filter PgMiniTest.VerifyPgClientServiceCleanupQueue` passes.
- [x] Linux release: same test.

---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31523/>)
