### PR TITLE
[#31530] YSQL: Stop object-lock RPCs from leaking read-time state into fast-path DML

### DIFF
--- a/src/yb/yql/pggate/pg_txn_manager.cc
+++ b/src/yb/yql/pggate/pg_txn_manager.cc
@@ -390,8 +390,7 @@ uint64_t PgTxnManager::NewPriority(YbcTxnPriorityRequirement txn_priority_requir
 }
 
 Status PgTxnManager::CalculateIsolation(
-    bool read_only_op, YbcTxnPriorityRequirement txn_priority_requirement,
-    IsLocalObjectLockOp is_local_object_lock_op) {
+    bool read_only_op, YbcTxnPriorityRequirement txn_priority_requirement) {
   if (yb_ddl_transaction_block_enabled ? IsDdlModeWithSeparateTransaction() : IsDdlMode()) {
     VLOG_TXN_STATE(2);
     priority_ = NewPriority(txn_priority_requirement);
@@ -403,7 +402,7 @@ Status PgTxnManager::CalculateIsolation(
     return RecreateTransaction(SavePriority::kFalse);
   }
 
-  if (!read_only_op && !is_local_object_lock_op) {
+  if (!read_only_op) {
     has_writes_ = true;
   }
 
@@ -444,22 +443,12 @@ Status PgTxnManager::CalculateIsolation(
   // The feature doesn't take affect for non-read only serializable isolation txns
   // and fast-path transactions because they don't face read restart errors in the first place.
   //
-  // (1) Serializable isolation txns don't face read restart errors because
-  //    they use the latest timestamp for reading.
-  // (2) Fast-path txns don't face read restart errors because
-  //    they pick a read time after conflict resolution.
-  //
-  // Skip recomputing need_defer_read_point_ when called from local-fastpath object lock
-  // acquisition. That path runs prior to a fast-path DML (ROW_EXCLUSIVE or below), and the
-  // unconditional yb_read_after_commit_visibility-based update below would otherwise leave
-  // need_defer_read_point_=true and leak into the subsequent fast-path write Perform — making
-  // PG client pick a deferred read time instead of letting docdb pick at the storage layer.
-  if (!is_local_object_lock_op) {
-    need_defer_read_point_ =
-        ((read_only_ && deferrable_)
-          || yb_read_after_commit_visibility == YB_DEFERRED_READ_AFTER_COMMIT_VISIBILITY)
-        && docdb_isolation != IsolationLevel::SERIALIZABLE_ISOLATION;
-  }
+  // We already skip (2) because CalculateIsolation is not called for fast-path
+  //    (i.e., NON_TRANSACTIONAL).
+  need_defer_read_point_ =
+      ((read_only_ && deferrable_)
+        || yb_read_after_commit_visibility == YB_DEFERRED_READ_AFTER_COMMIT_VISIBILITY)
+      && docdb_isolation != IsolationLevel::SERIALIZABLE_ISOLATION;
 
   VLOG_TXN_STATE(2) << "DocDB isolation level: " << IsolationLevel_Name(docdb_isolation);
 
@@ -478,7 +467,6 @@ Status PgTxnManager::CalculateIsolation(
   auto skip_picking_isolation_level = read_only_op &&
       (docdb_isolation == IsolationLevel::SNAPSHOT_ISOLATION ||
        docdb_isolation == IsolationLevel::READ_COMMITTED);
-  skip_picking_isolation_level |= is_local_object_lock_op;
   if (!skip_picking_isolation_level || (yb_ddl_transaction_block_enabled && IsDdlMode())) {
     if (IsDdlMode()) {
       DCHECK(yb_ddl_transaction_block_enabled)
@@ -748,17 +736,8 @@ Status PgTxnManager::SetupPerformOptions(
   if (!IsDdlModeWithSeparateTransaction() && !txn_in_progress_) {
     IncTxnSerialNo();
   }
-  const auto read_time_serial_no = serial_no_.read_time();
-  options->set_read_time_serial_no(read_time_serial_no);
+  options->set_read_time_serial_no(serial_no_.read_time());
   options->set_read_time_serial_no_history_min(serial_no_.min_read_time());
-  if (snapshot_read_time_is_used_) {
-    if (auto i = explicit_snapshot_read_time_.find(read_time_serial_no);
-        i != explicit_snapshot_read_time_.end()) {
-      ReadHybridTime::FromUint64(i->second).ToPB(options->mutable_read_time());
-    }
-
-    RETURN_NOT_OK(CheckSnapshotTimeConflict());
-  }
   options->set_isolation(isolation_level_);
   options->set_ddl_mode(IsDdlMode());
   options->set_ddl_use_regular_transaction_block(IsDdlModeWithRegularTransactionBlock());
@@ -780,16 +759,35 @@ Status PgTxnManager::SetupPerformOptions(
     need_restart_ = false;
   }
 
+  // Object lock RPCs perform no reads or writes; setting any read-time field would cause
+  // the tserver to pick a read time during lock acquisition and leak it into the next
+  // fast-path Perform. read_time_serial_no (above) is the exception — pg_client_session
+  // requires it for session-side ordering on kPlain sessions.
+  if (!is_local_object_lock_op) {
+    RETURN_NOT_OK(SetupReadTimeOptions(options, read_time_action));
+  }
+
+  options->set_force_global_transaction(yb_force_global_transaction);
+  options->set_force_tablespace_locality(yb_force_tablespace_locality);
+  options->set_force_tablespace_locality_oid(yb_force_tablespace_locality_oid);
+  return Status::OK();
+}
+
+Status PgTxnManager::SetupReadTimeOptions(
+    tserver::PgPerformOptionsPB* options,
+    std::optional<ReadTimeAction> read_time_action) {
+  if (snapshot_read_time_is_used_) {
+    const auto read_time_serial_no = serial_no_.read_time();
+    if (auto i = explicit_snapshot_read_time_.find(read_time_serial_no);
+        i != explicit_snapshot_read_time_.end()) {
+      ReadHybridTime::FromUint64(i->second).ToPB(options->mutable_read_time());
+    }
+    RETURN_NOT_OK(CheckSnapshotTimeConflict());
+  }
+
   // Do not clamp or defer read point when the read time is being reset
   // because RESET => read time needs to be empty.
-  //
-  // Skip the clamp/defer setup entirely for local-fastpath object lock RPCs. These RPCs
-  // perform no reads or writes; if they carried clamp/defer, the tserver would pick a
-  // (clamped/deferred) read time during lock acquisition and that read time would leak into
-  // the next fast-path Perform — making PG client provide a read time instead of letting
-  // docdb pick at the storage layer.
-  if (!is_local_object_lock_op
-      && !(read_time_action && *read_time_action == ReadTimeAction::RESET)) {
+  if (!(read_time_action && *read_time_action == ReadTimeAction::RESET)) {
     // Do not clamp in the serializable case (or fast path write) since
     // - SERIALIZABLE (and fast path) reads do not pick read time until they reach storage layer.
     // - SERIALIZABLE (and fast path) reads do not observe read restarts anyways.
@@ -844,10 +842,6 @@ Status PgTxnManager::SetupPerformOptions(
   if (read_time_action && *read_time_action == ReadTimeAction::RESET) {
     options->mutable_read_time()->Clear();
   }
-
-  options->set_force_global_transaction(yb_force_global_transaction);
-  options->set_force_tablespace_locality(yb_force_tablespace_locality);
-  options->set_force_tablespace_locality_oid(yb_force_tablespace_locality_oid);
   return Status::OK();
 }
 
@@ -1061,10 +1055,8 @@ Status PgTxnManager::AcquireObjectLock(
     std::optional<PgTablespaceOid> tablespace_oid) {
   const auto is_local_object_lock_op =
       IsLocalObjectLockOp(mode <= YbcObjectLockMode::YB_OBJECT_ROW_EXCLUSIVE_LOCK);
-  RETURN_NOT_OK(CalculateIsolation(
-      false /* read_only, doesn't matter */,
-      GetTxnPriorityRequirement(RowMarkType::ROW_MARK_ABSENT),
-      is_local_object_lock_op));
+  // No CalculateIsolation call here. Lock acquisition picks no read time, does no DML,
+  // and does not change isolation level. The subsequent statement runs its own setup.
   tserver::PgPerformOptionsPB options;
   RETURN_NOT_OK(SetupPerformOptions(
       tag, &options, /*read_time_action=*/{}, is_local_object_lock_op));

--- a/src/yb/yql/pggate/pg_txn_manager.cc
+++ b/src/yb/yql/pggate/pg_txn_manager.cc
@@ -448,12 +448,18 @@ Status PgTxnManager::CalculateIsolation(
   //    they use the latest timestamp for reading.
   // (2) Fast-path txns don't face read restart errors because
   //    they pick a read time after conflict resolution.
-  // We already skip (2) because CalculateIsolation is not called for fast-path
-  //    (i.e., NON_TRANSACTIONAL).
-  need_defer_read_point_ =
-      ((read_only_ && deferrable_)
-        || yb_read_after_commit_visibility == YB_DEFERRED_READ_AFTER_COMMIT_VISIBILITY)
-      && docdb_isolation != IsolationLevel::SERIALIZABLE_ISOLATION;
+  //
+  // Skip recomputing need_defer_read_point_ when called from local-fastpath object lock
+  // acquisition. That path runs prior to a fast-path DML (ROW_EXCLUSIVE or below), and the
+  // unconditional yb_read_after_commit_visibility-based update below would otherwise leave
+  // need_defer_read_point_=true and leak into the subsequent fast-path write Perform — making
+  // PG client pick a deferred read time instead of letting docdb pick at the storage layer.
+  if (!is_local_object_lock_op) {
+    need_defer_read_point_ =
+        ((read_only_ && deferrable_)
+          || yb_read_after_commit_visibility == YB_DEFERRED_READ_AFTER_COMMIT_VISIBILITY)
+        && docdb_isolation != IsolationLevel::SERIALIZABLE_ISOLATION;
+  }
 
   VLOG_TXN_STATE(2) << "DocDB isolation level: " << IsolationLevel_Name(docdb_isolation);
 
@@ -737,7 +743,8 @@ std::string PgTxnManager::TxnStateDebugStr() const {
 
 Status PgTxnManager::SetupPerformOptions(
     SetupPerformOptionsAccessorTag, tserver::PgPerformOptionsPB* options,
-    std::optional<ReadTimeAction> read_time_action) {
+    std::optional<ReadTimeAction> read_time_action,
+    IsLocalObjectLockOp is_local_object_lock_op) {
   if (!IsDdlModeWithSeparateTransaction() && !txn_in_progress_) {
     IncTxnSerialNo();
   }
@@ -775,7 +782,14 @@ Status PgTxnManager::SetupPerformOptions(
 
   // Do not clamp or defer read point when the read time is being reset
   // because RESET => read time needs to be empty.
-  if (!(read_time_action && *read_time_action == ReadTimeAction::RESET)) {
+  //
+  // Skip the clamp/defer setup entirely for local-fastpath object lock RPCs. These RPCs
+  // perform no reads or writes; if they carried clamp/defer, the tserver would pick a
+  // (clamped/deferred) read time during lock acquisition and that read time would leak into
+  // the next fast-path Perform — making PG client provide a read time instead of letting
+  // docdb pick at the storage layer.
+  if (!is_local_object_lock_op
+      && !(read_time_action && *read_time_action == ReadTimeAction::RESET)) {
     // Do not clamp in the serializable case (or fast path write) since
     // - SERIALIZABLE (and fast path) reads do not pick read time until they reach storage layer.
     // - SERIALIZABLE (and fast path) reads do not observe read restarts anyways.
@@ -1045,12 +1059,15 @@ Status PgTxnManager::AcquireObjectLock(
     const YbcObjectLockId& lock_id, YbcObjectLockMode mode,
     bool is_session_lock,
     std::optional<PgTablespaceOid> tablespace_oid) {
+  const auto is_local_object_lock_op =
+      IsLocalObjectLockOp(mode <= YbcObjectLockMode::YB_OBJECT_ROW_EXCLUSIVE_LOCK);
   RETURN_NOT_OK(CalculateIsolation(
       false /* read_only, doesn't matter */,
       GetTxnPriorityRequirement(RowMarkType::ROW_MARK_ABSENT),
-      IsLocalObjectLockOp(mode <= YbcObjectLockMode::YB_OBJECT_ROW_EXCLUSIVE_LOCK)));
+      is_local_object_lock_op));
   tserver::PgPerformOptionsPB options;
-  RETURN_NOT_OK(SetupPerformOptions(tag, &options));
+  RETURN_NOT_OK(SetupPerformOptions(
+      tag, &options, /*read_time_action=*/{}, is_local_object_lock_op));
   RETURN_NOT_OK(client_->AcquireObjectLock(
       &options, lock_id, mode, is_session_lock, tablespace_oid));
   DEBUG_ONLY(DEBUG_UpdateLastObjectLockingInfo());

--- a/src/yb/yql/pggate/pg_txn_manager.cc
+++ b/src/yb/yql/pggate/pg_txn_manager.cc
@@ -1055,8 +1055,15 @@ Status PgTxnManager::AcquireObjectLock(
     std::optional<PgTablespaceOid> tablespace_oid) {
   const auto is_local_object_lock_op =
       IsLocalObjectLockOp(mode <= YbcObjectLockMode::YB_OBJECT_ROW_EXCLUSIVE_LOCK);
-  // No CalculateIsolation call here. Lock acquisition picks no read time, does no DML,
-  // and does not change isolation level. The subsequent statement runs its own setup.
+  // Global object locks go through yb-master via a distributed YBTransaction. Creating that
+  // distributed txn requires the isolation level, so CalculateIsolation must run. Local-fastpath
+  // object lock acquisition picks no read time, does no DML, and does not change isolation level
+  // — the subsequent statement runs its own setup.
+  if (!is_local_object_lock_op) {
+    RETURN_NOT_OK(CalculateIsolation(
+        false /* read_only, doesn't matter */,
+        GetTxnPriorityRequirement(RowMarkType::ROW_MARK_ABSENT)));
+  }
   tserver::PgPerformOptionsPB options;
   RETURN_NOT_OK(SetupPerformOptions(
       tag, &options, /*read_time_action=*/{}, is_local_object_lock_op));

--- a/src/yb/yql/pggate/pg_txn_manager.h
+++ b/src/yb/yql/pggate/pg_txn_manager.h
@@ -118,7 +118,8 @@ class PgTxnManager : public RefCountedThreadSafe<PgTxnManager> {
   bool ShouldEnableTracing() const { return enable_tracing_; }
 
   Status SetupPerformOptions(SetupPerformOptionsAccessorTag tag,
-      tserver::PgPerformOptionsPB* options, std::optional<ReadTimeAction> read_time_action = {});
+      tserver::PgPerformOptionsPB* options, std::optional<ReadTimeAction> read_time_action = {},
+      IsLocalObjectLockOp is_local_object_lock_op = IsLocalObjectLockOp::kFalse);
 
   double GetTransactionPriority() const;
   YbcTxnPriorityRequirement GetTransactionPriorityType() const;

--- a/src/yb/yql/pggate/pg_txn_manager.h
+++ b/src/yb/yql/pggate/pg_txn_manager.h
@@ -75,8 +75,7 @@ class PgTxnManager : public RefCountedThreadSafe<PgTxnManager> {
   Status BeginTransaction(int64_t start_time);
 
   Status CalculateIsolation(
-      bool read_only_op, YbcTxnPriorityRequirement txn_priority_requirement,
-      IsLocalObjectLockOp is_local_object_lock_op = IsLocalObjectLockOp::kFalse);
+      bool read_only_op, YbcTxnPriorityRequirement txn_priority_requirement);
   Status RecreateTransaction();
   Status RestartTransaction();
   Status ResetTransactionReadPoint(bool is_catalog_snapshot);
@@ -210,6 +209,10 @@ class PgTxnManager : public RefCountedThreadSafe<PgTxnManager> {
   void StartNewSession();
   Status UpdateReadTimeForFollowerReadsIfRequired();
   Status RecreateTransaction(SavePriority save_priority);
+
+  Status SetupReadTimeOptions(
+      tserver::PgPerformOptionsPB* options,
+      std::optional<ReadTimeAction> read_time_action);
 
   static uint64_t NewPriority(YbcTxnPriorityRequirement txn_priority_requirement);
 


### PR DESCRIPTION
DO NOT MERGE!! [CSI](<https://csiweb.dev.yugabyte.com/pull/31531/>) ❌

Background
----------
For object locks (table locks, row locks during DML) there are two
paths between a PG client session and its local tserver:

  1. Shared-memory IPC fast path. pggate writes the lock entry into a
     shared memory region the tserver maps. No RPC.
  2. RPC fallback. pggate sends a PgAcquireObjectLockRequestPB to the
     local tserver's PgClientService.

The fast path is taken whenever shared memory is healthy and the lock
mode is fastpath-eligible (<= ROW EXCLUSIVE). Otherwise we fall back to
the RPC path. On macOS, shared-memory IPC currently fails, so every
fastpath-eligible object lock takes the RPC path.

The bug
-------
The RPC fallback (PgTxnManager::AcquireObjectLock) shares two helpers
with regular statement execution: CalculateIsolation and
SetupPerformOptions. Any call into these helpers is assumed to be
preparing options for a statement that reads or writes, so they mutate
per-transaction state derived from yb_read_after_commit_visibility:

  * CalculateIsolation unconditionally recomputes need_defer_read_point_.
    With yb_read_after_commit_visibility = 'deferred', this lands true.
  * SetupPerformOptions inspects need_defer_read_point_ and the relaxed
    GUC and sets defer_read_point or clamp_uncertainty_window on the
    outgoing PgPerformOptionsPB.

When AcquireObjectLock invokes these helpers, both pieces of state end
up on the *lock RPC's* options. The tserver, processing the lock RPC,
reads those flags and picks a (deferred or clamped) read time during
lock acquisition. The picked time is stored in the session's read
point. The fast-path UPDATE/INSERT/DELETE that immediately follows
inherits that pre-picked read time and never asks the storage layer to
pick its own.

This is a correctness issue, not just a test-visible one. Fast-path
writes skip conflict resolution on regulardb and rely on the storage
layer picking the right read time at execution. When lock acquisition
pre-picks a stale (deferred or clamped) read time, the write runs at
the wrong snapshot — the visibility guarantees the session asked for
via yb_read_after_commit_visibility are silently violated.

The symptom in test is picked_read_time_on_docdb (a per-tablet metric
incremented when the storage layer picks the read time) staying at 0,
which fails these tests on macOS:

  PgReadTimeTest.CheckDeferredReadAfterCommitVisibility
  PgReadTimeTest.CheckRelaxedReadAfterCommitVisibility

Linux passes only because shared-memory IPC succeeds — the RPC path,
and therefore CalculateIsolation/SetupPerformOptions, is never invoked
during lock acquisition. The bug is latent on Linux and would surface
the moment shared-memory acquisition isn't available (e.g., a higher
mode lock that's not fastpath-eligible, or any future regression in
the shared-memory channel).

The fix
-------

Object lock RPCs perform no reads or writes; their options must not
carry read-time manipulations meant for DML. Decouple lock acquisition
from DML option setup:

  * Extract SetupReadTimeOptions out of SetupPerformOptions. It owns
    every read-time mutator on PgPerformOptionsPB: snapshot read time,
    clamp/defer, parallel-mode ENSURE_READ_TIME_IS_SET,
    read_time_manipulation, read_time_for_follower_reads, and the
    RESET-clear path. SetupPerformOptions invokes it only when the op
    is not a local-fastpath object lock. read_time_serial_no still
    flows through SetupPerformOptions for lock RPCs — they need it to
    line up with the subsequent statement.

  * AcquireObjectLock no longer calls CalculateIsolation. Lock
    acquisition picks no read time, does no DML, and does not change
    the isolation level; the statement that follows runs its own
    CalculateIsolation.

The discriminator is IsLocalObjectLockOp(mode <= ROW EXCLUSIVE).
Higher-mode locks still take the RPC path on Linux and macOS, but
is_local_object_lock_op is false for them, so they continue to run
SetupReadTimeOptions and CalculateIsolation exactly as before — the
heavyweight DDL/DML that follows depends on it.

Test
----
Verified on macOS that both PgReadTimeTest.Check{Deferred,Relaxed}
ReadAfterCommitVisibility now pass. No behavior change on the Linux
shared-memory fast path since SetupPerformOptions and CalculateIsolation
are not invoked there.

Resolves #31530.
