### PR TITLE
[BACKPORT 2026.1][MEKO-6] YSQL: Add multitenancy to apache age graph tables for meko. (#31399)

### DIFF
--- a/src/postgres/third-party-extensions/mage/regress/expected/yb.orig.basic.out
+++ b/src/postgres/third-party-extensions/mage/regress/expected/yb.orig.basic.out
@@ -9,7 +9,6 @@ SET search_path TO mag_catalog;
 SELECT create_graph('basic');
 NOTICE:  substituting access method "lsm" for "btree" in YugabyteDB
 NOTICE:  substituting access method "lsm" for "btree" in YugabyteDB
-NOTICE:  substituting access method "lsm" for "btree" in YugabyteDB
 NOTICE:  graph "basic" has been created
  create_graph 
 --------------
@@ -22,15 +21,20 @@ SELECT name, namespace FROM ag_graph WHERE name = 'basic';
  basic | basic
 (1 row)
 
-SELECT * FROM cypher('basic', $$ CREATE (:person {name: 'Alice'}) $$) AS (a agtype);
-NOTICE:  substituting access method "lsm" for "btree" in YugabyteDB
-LINE 1: SELECT * FROM cypher('basic', $$ CREATE (:person {name: 'Ali...
-                                       ^
+-- meko_datapack_id, meko_user_id and meko_agent_id are NOT NULL on
+-- vertex/edge tables, so the cypher CREATE must supply them as properties.
+SELECT * FROM cypher('basic', $$ CREATE (:person {name: 'Alice',
+    meko_datapack_id: '00000000-0000-0000-0000-000000000001',
+    meko_user_id: '00000000-0000-0000-0000-000000000002',
+    meko_agent_id: 'agent-1'}) $$) AS (a agtype);
  a 
 ---
 (0 rows)
 
-SELECT * FROM cypher('basic', $$ CREATE (:person {name: 'Bob'}) $$) AS (a agtype);
+SELECT * FROM cypher('basic', $$ CREATE (:person {name: 'Bob',
+    meko_datapack_id: '00000000-0000-0000-0000-000000000001',
+    meko_user_id: '00000000-0000-0000-0000-000000000002',
+    meko_agent_id: 'agent-1'}) $$) AS (a agtype);
  a 
 ---
 (0 rows)
@@ -41,14 +45,94 @@ SELECT * FROM cypher('basic', $$ MATCH (n:person) RETURN count(n) $$) AS (cnt ag
  2
 (1 row)
 
+-- cypher CREATE without the required meko_* tenant properties errors out.
+SELECT * FROM cypher('basic', $$ CREATE (:person {name: 'NoTenant'}) $$) AS (a agtype);
+ERROR:  missing required tenant property "meko_datapack_id"
+-- SET cannot mutate meko_* tenant properties.
+SELECT * FROM cypher('basic', $$ MATCH (n:person {name: 'Alice'})
+    SET n.meko_user_id = '00000000-0000-0000-0000-000000000099' $$) AS (a agtype);
+ERROR:  tenant property "meko_user_id" cannot be modified by SET
+HINT:  Drop and recreate the vertex/edge to change its tenant identity.
+-- A full-map SET that targets meko_* keys is also rejected.
+SELECT * FROM cypher('basic', $$ MATCH (n:person {name: 'Alice'})
+    SET n = {name: 'Alice2',
+             meko_datapack_id: '00000000-0000-0000-0000-000000000099'} $$) AS (a agtype);
+ERROR:  tenant properties cannot be modified by SET
+HINT:  Drop and recreate the vertex/edge to change its tenant identity.
+-- A `+=` merge SET that targets meko_* keys is rejected too.
+SELECT * FROM cypher('basic', $$ MATCH (n:person {name: 'Alice'})
+    SET n += {meko_user_id: '00000000-0000-0000-0000-000000000099'} $$) AS (a agtype);
+ERROR:  tenant properties cannot be modified by SET
+HINT:  Drop and recreate the vertex/edge to change its tenant identity.
+-- A full-map SET that omits meko_* keys must NOT drop them from the JSON map,
+-- otherwise containment matches like {meko_user_id: ...} would miss the row.
+SELECT * FROM cypher('basic', $$ MATCH (n:person {name: 'Alice'})
+    SET n = {name: 'AliceRenamed'} $$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+SELECT * FROM cypher('basic', $$ MATCH (n:person {meko_user_id:
+    '00000000-0000-0000-0000-000000000002'}) RETURN count(n) $$) AS (cnt agtype);
+ cnt 
+-----
+ 2
+(1 row)
+
+-- create_complete_graph and age_create_barbell_graph reach
+-- yb_insert_*_simple, which lacks tenant column support yet (#31338).
+-- Confirm they raise feature_not_supported rather than violating the
+-- meko_* NOT NULL constraints. The labels are pre-created so the test
+-- is independent of whether DDL inside a function rolls back on the
+-- ereport (release vs debug builds differ on this).
+SELECT create_vlabel('basic', 'gen_vertex');
+NOTICE:  VLabel "gen_vertex" has been created
+ create_vlabel 
+---------------
+ 
+(1 row)
+
+SELECT create_elabel('basic', 'gen_edge');
+NOTICE:  substituting access method "lsm" for "btree" in YugabyteDB
+NOTICE:  substituting access method "lsm" for "btree" in YugabyteDB
+NOTICE:  ELabel "gen_edge" has been created
+ create_elabel 
+---------------
+ 
+(1 row)
+
+SELECT create_complete_graph('basic', 3, 'gen_edge', 'gen_vertex');
+ERROR:  simple vertex insert is not supported on YugabyteDB yet (#31338)
+SELECT create_vlabel('basic', 'bb_vertex');
+NOTICE:  VLabel "bb_vertex" has been created
+ create_vlabel 
+---------------
+ 
+(1 row)
+
+SELECT create_elabel('basic', 'bb_edge');
+NOTICE:  substituting access method "lsm" for "btree" in YugabyteDB
+NOTICE:  substituting access method "lsm" for "btree" in YugabyteDB
+NOTICE:  ELabel "bb_edge" has been created
+ create_elabel 
+---------------
+ 
+(1 row)
+
+SELECT age_create_barbell_graph('basic', 3, 0, 'bb_vertex', NULL, 'bb_edge', NULL);
+ERROR:  simple vertex insert is not supported on YugabyteDB yet (#31338)
 RESET search_path;
 -- DROP EXTENSION must trigger ag_ProcessUtility_hook -> drop_age_extension,
 -- which cleans up the per-graph schema. The two count(*) queries below catch
 -- regressions in is_age_drop()'s extension-name match.
 DROP EXTENSION mage;
-NOTICE:  drop cascades to 3 other objects
+NOTICE:  drop cascades to 7 other objects
 DETAIL:  drop cascades to table basic._ag_label_edge
 drop cascades to table basic._ag_label_vertex
+drop cascades to table basic.bb_edge
+drop cascades to table basic.bb_vertex
+drop cascades to table basic.gen_edge
+drop cascades to table basic.gen_vertex
 drop cascades to table basic.person
 NOTICE:  graph "basic" has been dropped
 SELECT count(*) FROM pg_extension WHERE extname = 'mage';

--- a/src/postgres/third-party-extensions/mage/regress/sql/yb.orig.basic.sql
+++ b/src/postgres/third-party-extensions/mage/regress/sql/yb.orig.basic.sql
@@ -3,9 +3,47 @@ SELECT extname, extversion FROM pg_extension WHERE extname = 'mage';
 SET search_path TO mag_catalog;
 SELECT create_graph('basic');
 SELECT name, namespace FROM ag_graph WHERE name = 'basic';
-SELECT * FROM cypher('basic', $$ CREATE (:person {name: 'Alice'}) $$) AS (a agtype);
-SELECT * FROM cypher('basic', $$ CREATE (:person {name: 'Bob'}) $$) AS (a agtype);
+-- meko_datapack_id, meko_user_id and meko_agent_id are NOT NULL on
+-- vertex/edge tables, so the cypher CREATE must supply them as properties.
+SELECT * FROM cypher('basic', $$ CREATE (:person {name: 'Alice',
+    meko_datapack_id: '00000000-0000-0000-0000-000000000001',
+    meko_user_id: '00000000-0000-0000-0000-000000000002',
+    meko_agent_id: 'agent-1'}) $$) AS (a agtype);
+SELECT * FROM cypher('basic', $$ CREATE (:person {name: 'Bob',
+    meko_datapack_id: '00000000-0000-0000-0000-000000000001',
+    meko_user_id: '00000000-0000-0000-0000-000000000002',
+    meko_agent_id: 'agent-1'}) $$) AS (a agtype);
 SELECT * FROM cypher('basic', $$ MATCH (n:person) RETURN count(n) $$) AS (cnt agtype);
+-- cypher CREATE without the required meko_* tenant properties errors out.
+SELECT * FROM cypher('basic', $$ CREATE (:person {name: 'NoTenant'}) $$) AS (a agtype);
+-- SET cannot mutate meko_* tenant properties.
+SELECT * FROM cypher('basic', $$ MATCH (n:person {name: 'Alice'})
+    SET n.meko_user_id = '00000000-0000-0000-0000-000000000099' $$) AS (a agtype);
+-- A full-map SET that targets meko_* keys is also rejected.
+SELECT * FROM cypher('basic', $$ MATCH (n:person {name: 'Alice'})
+    SET n = {name: 'Alice2',
+             meko_datapack_id: '00000000-0000-0000-0000-000000000099'} $$) AS (a agtype);
+-- A `+=` merge SET that targets meko_* keys is rejected too.
+SELECT * FROM cypher('basic', $$ MATCH (n:person {name: 'Alice'})
+    SET n += {meko_user_id: '00000000-0000-0000-0000-000000000099'} $$) AS (a agtype);
+-- A full-map SET that omits meko_* keys must NOT drop them from the JSON map,
+-- otherwise containment matches like {meko_user_id: ...} would miss the row.
+SELECT * FROM cypher('basic', $$ MATCH (n:person {name: 'Alice'})
+    SET n = {name: 'AliceRenamed'} $$) AS (a agtype);
+SELECT * FROM cypher('basic', $$ MATCH (n:person {meko_user_id:
+    '00000000-0000-0000-0000-000000000002'}) RETURN count(n) $$) AS (cnt agtype);
+-- create_complete_graph and age_create_barbell_graph reach
+-- yb_insert_*_simple, which lacks tenant column support yet (#31338).
+-- Confirm they raise feature_not_supported rather than violating the
+-- meko_* NOT NULL constraints. The labels are pre-created so the test
+-- is independent of whether DDL inside a function rolls back on the
+-- ereport (release vs debug builds differ on this).
+SELECT create_vlabel('basic', 'gen_vertex');
+SELECT create_elabel('basic', 'gen_edge');
+SELECT create_complete_graph('basic', 3, 'gen_edge', 'gen_vertex');
+SELECT create_vlabel('basic', 'bb_vertex');
+SELECT create_elabel('basic', 'bb_edge');
+SELECT age_create_barbell_graph('basic', 3, 0, 'bb_vertex', NULL, 'bb_edge', NULL);
 RESET search_path;
 -- DROP EXTENSION must trigger ag_ProcessUtility_hook -> drop_age_extension,
 -- which cleans up the per-graph schema. The two count(*) queries below catch

--- a/src/postgres/third-party-extensions/mage/src/backend/commands/label_commands.c
+++ b/src/postgres/third-party-extensions/mage/src/backend/commands/label_commands.c
@@ -100,6 +100,10 @@ static void create_index_on_column(char *schema_name,
                                    char *rel_name,
                                    char *colname,
                                    bool unique);
+/* YB: composite tenant-scoped PK index helper (vertex and edge use the same shape) */
+static void yb_create_label_pk_index(char *schema_name, char *rel_name);
+/* YB: append meko_* tenant ColumnDefs to a vertex/edge column list */
+static List *yb_append_meko_column_defs(List *cols);
 
 PG_FUNCTION_INFO_V1(age_is_valid_label_name);
 
@@ -444,13 +448,29 @@ static void create_table_for_label(char *graph_name, char *label_name,
                    PROCESS_UTILITY_SUBCOMMAND, NULL, NULL, None_Receiver,
                    NULL);
     
-    /* Create index on id columns */
+    /*
+     * Create index on id columns.
+     *
+     * YB: Upstream Apache AGE creates a single-column unique index on "id" for
+     * vertex tables (and no PK index for edge tables). On YugabyteDB we instead
+     * build a composite tenant-scoped primary key over (meko_datapack_id,
+     * meko_user_id, meko_agent_id, id) so that rows for different tenants are
+     * colocated/sharded by tenant and queries can prune to a single tenant.
+     * Edge tables get the same composite PK in YB mode (upstream has none),
+     * while the start_id/end_id secondary indexes are created unconditionally
+     * to match upstream behavior.
+     */
     if (label_type == LABEL_TYPE_VERTEX)
     {
-        create_index_on_column(schema_name, rel_name, "id", true);
+        if (IsYugaByteEnabled())
+            yb_create_label_pk_index(schema_name, rel_name); /* YB: tenant-scoped PK */
+        else
+            create_index_on_column(schema_name, rel_name, "id", true);
     }
     else if (label_type == LABEL_TYPE_EDGE)
     {
+        if (IsYugaByteEnabled())
+            yb_create_label_pk_index(schema_name, rel_name); /* YB: tenant-scoped PK */
         create_index_on_column(schema_name, rel_name, "start_id", false);
         create_index_on_column(schema_name, rel_name, "end_id", false);
     }
@@ -508,13 +528,166 @@ static void create_index_on_column(char *schema_name,
                    NULL);
 }
 
-/* 
- * CREATE TABLE `schema_name`.`rel_name` (
- * "id" graphid PRIMARY KEY DEFAULT "ag_catalog"."_graphid"(...),
- * "start_id" graphid NOT NULL
- * "end_id" graphid NOT NULL
- * "properties" agtype NOT NULL DEFAULT "ag_catalog"."agtype_build_map"()
- * )
+/*
+ * YB: Build a SORTBY_HASH IndexElem for `colname` (no opclass).
+ */
+static IndexElem *yb_make_meko_hash_elem(const char *colname)
+{
+    IndexElem *elem = makeNode(IndexElem);
+
+    elem->name = (char *) colname;
+    elem->expr = NULL;
+    elem->indexcolname = NULL;
+    elem->collation = NIL;
+    elem->opclass = NIL;
+    elem->opclassopts = NIL;
+    elem->ordering = SORTBY_HASH;
+    elem->nulls_ordering = SORTBY_NULLS_DEFAULT;
+    return elem;
+}
+
+/*
+ * YB: Build a SORTBY_ASC IndexElem for `colname`. If `opclass` is non-NULL,
+ * it is used as a single-element opclass list (needed for graphid_ops).
+ */
+static IndexElem *yb_make_meko_asc_elem(const char *colname, const char *opclass)
+{
+    IndexElem *elem = makeNode(IndexElem);
+
+    elem->name = (char *) colname;
+    elem->expr = NULL;
+    elem->indexcolname = NULL;
+    elem->collation = NIL;
+    elem->opclass = (opclass ? list_make1(makeString((char *) opclass)) : NIL);
+    elem->opclassopts = NIL;
+    elem->ordering = SORTBY_ASC;
+    elem->nulls_ordering = SORTBY_NULLS_DEFAULT;
+    return elem;
+}
+
+/*
+ * YB: Create the composite primary key index for both vertex and edge label
+ * tables:
+ *   PRIMARY KEY ((meko_datapack_id, meko_user_id) HASH,
+ *                meko_agent_id ASC, id ASC)
+ *
+ * Vertex and edge tables share the same column names for the tenant
+ * key, so a single helper covers both.
+ *
+ * Only meko_datapack_id and meko_user_id are part of the hash key — that is
+ * the granularity at which we want to spread rows across tablets. meko_agent_id
+ * is left as a range key (ASC) so that rows for all agents owned by the same
+ * (datapack, user) tenant land on the same tablet and can be range-scanned
+ * together; hashing on agent_id would scatter them, defeating tenant locality.
+ */
+static void yb_create_label_pk_index(char *schema_name, char *rel_name)
+{
+    IndexStmt *index_stmt;
+    PlannedStmt *index_wrapper;
+
+    index_stmt = makeNode(IndexStmt);
+    index_stmt->relation = makeRangeVar(schema_name, rel_name, -1);
+    index_stmt->accessMethod = "lsm";
+    index_stmt->tableSpace = NULL;
+    index_stmt->indexParams = list_make4(
+        yb_make_meko_hash_elem(AG_COLNAME_MEKO_DATAPACK_ID),
+        yb_make_meko_hash_elem(AG_COLNAME_MEKO_USER_ID),
+        yb_make_meko_asc_elem(AG_COLNAME_MEKO_AGENT_ID, NULL),
+        yb_make_meko_asc_elem("id", "graphid_ops"));
+    index_stmt->options = NIL;
+    index_stmt->whereClause = NULL;
+    index_stmt->excludeOpNames = NIL;
+    index_stmt->idxcomment = NULL;
+    index_stmt->indexOid = InvalidOid;
+    index_stmt->unique = true;
+    index_stmt->nulls_not_distinct = false;
+    index_stmt->primary = true;
+    index_stmt->isconstraint = true;
+    index_stmt->deferrable = false;
+    index_stmt->initdeferred = false;
+    index_stmt->transformed = false;
+    index_stmt->concurrent = false;
+    index_stmt->if_not_exists = false;
+    index_stmt->reset_default_tblspc = false;
+
+    index_wrapper = makeNode(PlannedStmt);
+    index_wrapper->commandType = CMD_UTILITY;
+    index_wrapper->canSetTag = false;
+    index_wrapper->utilityStmt = (Node *) index_stmt;
+    index_wrapper->stmt_location = -1;
+    index_wrapper->stmt_len = 0;
+
+    ProcessUtility(index_wrapper,
+                   "(generated CREATE INDEX command for label PK)", false,
+                   PROCESS_UTILITY_SUBCOMMAND, NULL, NULL, None_Receiver,
+                   NULL);
+}
+
+/*
+ * YB: Append the four meko_* tenant ColumnDefs to a vertex/edge column list:
+ *   "meko_datapack_id"     UUID NOT NULL,
+ *   "meko_user_id"         UUID NOT NULL,
+ *   "meko_agent_id"        TEXT NOT NULL,
+ *   "meko_conversation_id" UUID
+ *
+ * Vertex and edge label tables use the same set of meko_* column names so
+ * the same helper produces both.
+ */
+static List *yb_append_meko_column_defs(List *cols)
+{
+    ColumnDef *meko_datapack_id;
+    ColumnDef *meko_user_id;
+    ColumnDef *meko_agent_id;
+    ColumnDef *meko_conversation_id;
+
+    /* "meko_datapack_id" UUID NOT NULL */
+    meko_datapack_id = makeColumnDef(AG_COLNAME_MEKO_DATAPACK_ID,
+                                     UUIDOID, -1, InvalidOid);
+    meko_datapack_id->constraints = list_make1(build_not_null_constraint());
+
+    /* "meko_user_id" UUID NOT NULL */
+    meko_user_id = makeColumnDef(AG_COLNAME_MEKO_USER_ID,
+                                 UUIDOID, -1, InvalidOid);
+    meko_user_id->constraints = list_make1(build_not_null_constraint());
+
+    /* "meko_agent_id" TEXT NOT NULL */
+    meko_agent_id = makeColumnDef(AG_COLNAME_MEKO_AGENT_ID,
+                                  TEXTOID, -1, InvalidOid);
+    meko_agent_id->constraints = list_make1(build_not_null_constraint());
+
+    /* "meko_conversation_id" UUID (nullable) */
+    meko_conversation_id = makeColumnDef(AG_COLNAME_MEKO_CONVERSATION_ID,
+                                         UUIDOID, -1, InvalidOid);
+
+    cols = lappend(cols, meko_datapack_id);
+    cols = lappend(cols, meko_user_id);
+    cols = lappend(cols, meko_agent_id);
+    cols = lappend(cols, meko_conversation_id);
+    return cols;
+}
+
+/*
+ * Upstream Apache AGE layout:
+ *   CREATE TABLE `schema_name`.`rel_name` (
+ *     "id"         graphid PRIMARY KEY DEFAULT "ag_catalog"."_graphid"(...),
+ *     "start_id"   graphid NOT NULL,
+ *     "end_id"     graphid NOT NULL,
+ *     "properties" agtype  NOT NULL DEFAULT "ag_catalog"."agtype_build_map"()
+ *   )
+ *
+ * YB: Diverges from upstream Apache AGE in two ways (only when
+ * IsYugaByteEnabled() is true; vanilla PG builds preserve the upstream
+ * 4-column layout):
+ *   1. The "id" column is no longer declared PRIMARY KEY inline; the PK is
+ *      created later as a composite tenant-scoped index over
+ *      (meko_datapack_id, meko_user_id, meko_agent_id, id) via
+ *      yb_create_label_pk_index().
+ *   2. Four meko_* tenant columns are appended so that all rows in an edge
+ *      label can be partitioned/sharded by tenant:
+ *        "meko_datapack_id"     UUID NOT NULL,
+ *        "meko_user_id"         UUID NOT NULL,
+ *        "meko_agent_id"        TEXT NOT NULL,
+ *        "meko_conversation_id" UUID
  */
 static List *create_edge_table_elements(char *graph_name, char *label_name,
                                         char *schema_name, char *rel_name,
@@ -524,12 +697,28 @@ static List *create_edge_table_elements(char *graph_name, char *label_name,
     ColumnDef *start_id;
     ColumnDef *end_id;
     ColumnDef *props;
+    List *yb_cols; /* YB: declared up front so we can lappend meko_* on YB */
 
     /* "id" graphid PRIMARY KEY DEFAULT "ag_catalog"."_graphid"(...) */
     id = makeColumnDef(AG_EDGE_COLNAME_ID, GRAPHIDOID, -1, InvalidOid);
-    id->constraints = list_make2(build_pk_constraint(),
-                                 build_id_default(graph_name, label_name,
-                                                  schema_name, seq_name));
+    if (IsYugaByteEnabled())
+    {
+        /*
+         * YB: "id" is only NOT NULL here; the PRIMARY KEY is added later
+         * as a composite tenant-scoped index over
+         * (meko_datapack_id, meko_user_id, meko_agent_id, id) by
+         * yb_create_label_pk_index().
+         */
+        id->constraints = list_make2(build_not_null_constraint(),
+                                     build_id_default(graph_name, label_name,
+                                                      schema_name, seq_name));
+    }
+    else
+    {
+        id->constraints = list_make2(build_pk_constraint(),
+                                     build_id_default(graph_name, label_name,
+                                                      schema_name, seq_name));
+    }
 
     /* "start_id" graphid NOT NULL */
     start_id = makeColumnDef(AG_EDGE_COLNAME_START_ID, GRAPHIDOID, -1,
@@ -546,14 +735,35 @@ static List *create_edge_table_elements(char *graph_name, char *label_name,
     props->constraints = list_make2(build_not_null_constraint(),
                                     build_properties_default());
 
-    return list_make4(id, start_id, end_id, props);
+    yb_cols = list_make4(id, start_id, end_id, props);
+
+    /* YB: tenant columns are only added on YugabyteDB-hosted edge tables. */
+    if (IsYugaByteEnabled())
+        yb_cols = yb_append_meko_column_defs(yb_cols);
+
+    return yb_cols;
 }
 
-/* 
- * CREATE TABLE `schema_name`.`rel_name` (
- * "id" graphid PRIMARY KEY DEFAULT "ag_catalog"."_graphid"(...),
- * "properties" agtype NOT NULL DEFAULT "ag_catalog"."agtype_build_map"()
- * )
+/*
+ * Upstream Apache AGE layout:
+ *   CREATE TABLE `schema_name`.`rel_name` (
+ *     "id"         graphid PRIMARY KEY DEFAULT "ag_catalog"."_graphid"(...),
+ *     "properties" agtype  NOT NULL DEFAULT "ag_catalog"."agtype_build_map"()
+ *   )
+ *
+ * YB: Diverges from upstream Apache AGE in two ways (only when
+ * IsYugaByteEnabled() is true; vanilla PG builds preserve the upstream
+ * 2-column layout):
+ *   1. The "id" column is no longer declared PRIMARY KEY inline; the PK is
+ *      created later as a composite tenant-scoped index over
+ *      (meko_datapack_id, meko_user_id, meko_agent_id, id) via
+ *      yb_create_label_pk_index().
+ *   2. Four meko_* tenant columns are appended so that all rows in a vertex
+ *      label can be partitioned/sharded by tenant:
+ *        "meko_datapack_id"     UUID NOT NULL,
+ *        "meko_user_id"         UUID NOT NULL,
+ *        "meko_agent_id"        TEXT NOT NULL,
+ *        "meko_conversation_id" UUID
  */
 static List *create_vertex_table_elements(char *graph_name, char *label_name,
                                           char *schema_name, char *rel_name,
@@ -561,6 +771,7 @@ static List *create_vertex_table_elements(char *graph_name, char *label_name,
 {
     ColumnDef *id;
     ColumnDef *props;
+    List *yb_cols; /* YB: declared up front so we can lappend meko_* on YB */
 
     /* "id" graphid PRIMARY KEY DEFAULT "ag_catalog"."_graphid"(...) */
     id = makeColumnDef(AG_VERTEX_COLNAME_ID, GRAPHIDOID, -1, InvalidOid);
@@ -574,7 +785,13 @@ static List *create_vertex_table_elements(char *graph_name, char *label_name,
     props->constraints = list_make2(build_not_null_constraint(),
                                     build_properties_default());
 
-    return list_make2(id, props);
+    yb_cols = list_make2(id, props);
+
+    /* YB: tenant columns are only added on YugabyteDB-hosted vertex tables. */
+    if (IsYugaByteEnabled())
+        yb_cols = yb_append_meko_column_defs(yb_cols);
+
+    return yb_cols;
 }
 
 /* CREATE SEQUENCE `seq_range_var` MAXVALUE `LOCAL_ID_MAX` */

--- a/src/postgres/third-party-extensions/mage/src/backend/executor/cypher_create.c
+++ b/src/postgres/third-party-extensions/mage/src/backend/executor/cypher_create.c
@@ -24,6 +24,7 @@
 #include "executor/cypher_utils.h"
 
 /* YB includes */
+#include "pg_yb_utils.h"
 #include "utils/age_global_graph.h"
 
 static void begin_cypher_create(CustomScanState *node, EState *estate,
@@ -413,6 +414,10 @@ static void create_edge(cypher_create_custom_scan_state *css,
     elemTupleSlot->tts_isnull[edge_tuple_properties] =
         scanTupleSlot->tts_isnull[node->prop_attr_num];
 
+    if (IsYugaByteEnabled())
+        yb_populate_meko_columns(elemTupleSlot, yb_extract_meko_columns_from_properties(
+                scanTupleSlot->tts_values[node->prop_attr_num],
+                scanTupleSlot->tts_isnull[node->prop_attr_num]), true /* is_edge */);
     /* Insert the new edge */
     insert_entity_tuple(resultRelInfo, elemTupleSlot, estate);
 
@@ -499,6 +504,11 @@ static Datum create_vertex(cypher_create_custom_scan_state *css,
             scanTupleSlot->tts_values[node->prop_attr_num];
         elemTupleSlot->tts_isnull[vertex_tuple_properties] =
             scanTupleSlot->tts_isnull[node->prop_attr_num];
+
+        if (IsYugaByteEnabled())
+            yb_populate_meko_columns(elemTupleSlot, yb_extract_meko_columns_from_properties(
+                    scanTupleSlot->tts_values[node->prop_attr_num],
+                    scanTupleSlot->tts_isnull[node->prop_attr_num]), false /* is_edge */);
 
         /* Insert the new vertex */
         insert_entity_tuple(resultRelInfo, elemTupleSlot, estate);

--- a/src/postgres/third-party-extensions/mage/src/backend/executor/cypher_merge.c
+++ b/src/postgres/third-party-extensions/mage/src/backend/executor/cypher_merge.c
@@ -23,6 +23,7 @@
 #include "executor/cypher_executor.h"
 #include "executor/cypher_utils.h"
 /* YB includes */
+#include "pg_yb_utils.h"
 #include "utils/age_global_graph.h"
 #include "utils/datum.h"
 
@@ -1066,6 +1067,9 @@ static Datum merge_vertex(cypher_merge_custom_scan_state *css,
         elemTupleSlot->tts_values[vertex_tuple_properties] = prop;
         elemTupleSlot->tts_isnull[vertex_tuple_properties] = isNull;
 
+        if (IsYugaByteEnabled())
+            yb_populate_meko_columns(elemTupleSlot, yb_extract_meko_columns_from_properties(prop, isNull), false /* is_edge */);
+
         /*
          * Insert the new vertex.
          *
@@ -1407,6 +1411,9 @@ static void merge_edge(cypher_merge_custom_scan_state *css,
     /* store the properties in the tuple slot */
     elemTupleSlot->tts_values[edge_tuple_properties] = prop;
     elemTupleSlot->tts_isnull[edge_tuple_properties] = isNull;
+
+    if (IsYugaByteEnabled())
+        yb_populate_meko_columns(elemTupleSlot, yb_extract_meko_columns_from_properties(prop, isNull), true /* is_edge */);
 
     /*
      * Insert the new edge.

--- a/src/postgres/third-party-extensions/mage/src/backend/executor/cypher_set.c
+++ b/src/postgres/third-party-extensions/mage/src/backend/executor/cypher_set.c
@@ -25,9 +25,24 @@
 #include "executor/cypher_utils.h"
 
 /* YB includes */
+#include "catalog/ag_label.h"
+#include "commands/label_commands.h"
 #include "executor/ybModifyTable.h"
 #include "pg_yb_utils.h"
 #include "utils/age_global_graph.h"
+#include "utils/agtype.h"
+
+/*
+ * YB: Names of the four tenant-scoping properties / columns. The vertex and
+ * edge AG_*_COLNAME_MEKO_* macros all expand to the same strings, so this
+ * single list covers both.
+ */
+static const char *const yb_meko_property_keys[] = {
+    AG_COLNAME_MEKO_DATAPACK_ID,
+    AG_COLNAME_MEKO_USER_ID,
+    AG_COLNAME_MEKO_AGENT_ID,
+    AG_COLNAME_MEKO_CONVERSATION_ID,
+};
 
 static void begin_cypher_set(CustomScanState *node, EState *estate,
                                 int eflags);
@@ -36,12 +51,98 @@ static void end_cypher_set(CustomScanState *node);
 static void rescan_cypher_set(CustomScanState *node);
 
 static void process_update_list(CustomScanState *node);
+
+/*
+ * YB: Returns true if `key` is one of the meko_* tenant property names.
+ */
+static bool yb_is_meko_property_key(const char *key)
+{
+    if (key == NULL)
+        return false;
+    for (size_t i = 0; i < lengthof(yb_meko_property_keys); i++)
+        if (strcmp(key, yb_meko_property_keys[i]) == 0)
+            return true;
+    return false;
+}
+
+/*
+ * YB: Returns true if the agtype object contains any meko_* tenant key.
+ */
+static bool yb_props_contain_meko_key(agtype *props)
+{
+    if (props == NULL || !AGT_ROOT_IS_OBJECT(props))
+        return false;
+
+    for (size_t i = 0; i < lengthof(yb_meko_property_keys); i++)
+    {
+        agtype_value search_key;
+
+        search_key.type = AGTV_STRING;
+        search_key.val.string.val = (char *) yb_meko_property_keys[i];
+        search_key.val.string.len = strlen(yb_meko_property_keys[i]);
+        if (find_agtype_value_from_container(&props->root, AGT_FOBJECT,
+                                             &search_key) != NULL)
+            return true;
+    }
+    return false;
+}
+
+/*
+ * YB: Re-inject the meko_* tenant keys from `original` into `altered`. Used
+ * after a full-replacement SET (n = {...}) so the JSON map stays in sync
+ * with the copied-over tenant columns. Existing meko_* keys in `altered`
+ * are overwritten with the values from `original`; missing ones are added.
+ */
+static agtype_value *yb_inject_meko_keys(agtype_value *altered,
+                                         agtype *original)
+{
+    if (original == NULL || altered == NULL ||
+        !AGT_ROOT_IS_OBJECT(original))
+        return altered;
+
+    for (size_t i = 0; i < lengthof(yb_meko_property_keys); i++)
+    {
+        agtype_value search_key;
+        agtype_value *orig_val;
+
+        search_key.type = AGTV_STRING;
+        search_key.val.string.val = (char *) yb_meko_property_keys[i];
+        search_key.val.string.len = strlen(yb_meko_property_keys[i]);
+        orig_val = find_agtype_value_from_container(&original->root,
+                                                    AGT_FOBJECT, &search_key);
+
+        /*
+         * Skip absent keys but re-inject explicit JSON nulls so the map
+         * matches what the user had before the SET. This only matters for
+         * meko_conversation_id (the others are NOT NULL on the table); a
+         * present-but-null value is still a deliberate part of the map.
+         */
+        if (orig_val == NULL)
+            continue;
+
+        altered = alter_property_value(altered,
+                                       (char *) yb_meko_property_keys[i],
+                                       agtype_value_to_agtype(orig_val),
+                                       false /* remove_property */);
+    }
+    return altered;
+}
 static HeapTuple yb_update_entity_tuple(ResultRelInfo *resultRelInfo,
                                         TupleTableSlot *elemTupleSlot,
                                         EState *estate, HeapTuple old_tuple);
 static HeapTuple update_entity_tuple(ResultRelInfo *resultRelInfo,
                                      TupleTableSlot *elemTupleSlot,
                                      EState *estate, HeapTuple old_tuple);
+
+/*
+ * YB: Sentinel passed by callers (e.g. SET) that mean to leave the meko_*
+ * columns untouched in the slot. conversation_id_isnull is initialised to
+ * true so the value at least represents a coherent "no tenant info" state
+ * — the actual tenant values are filled in before insert by either
+ * yb_extract_meko_columns_from_properties() or
+ * yb_copy_meko_columns_from_tuple().
+ */
+static const YbMekoDp EmptyYbMekoDp = {.conversation_id_isnull = true};
 
 const CustomExecMethods cypher_set_exec_methods = {SET_SCAN_STATE_NAME,
                                                       begin_cypher_set,
@@ -522,6 +623,20 @@ static void process_update_list(CustomScanState *node)
                             clause_name)));
         }
 
+        /*
+         * YB: meko_* tenant columns are derived from row identity and must
+         * not be mutated by SET/REMOVE; they have to be re-set by dropping
+         * the row and recreating it.
+         */
+        if (IsYugaByteEnabled() &&
+            yb_is_meko_property_key(update_item->prop_name))
+            ereport(ERROR,
+                    (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                     errmsg("tenant property \"%s\" cannot be modified by %s",
+                            update_item->prop_name, clause_name),
+                     errhint("Drop and recreate the vertex/edge to change "
+                             "its tenant identity.")));
+
         /* get the id and label for later */
         id = GET_AGTYPE_VALUE_OBJECT_VALUE(original_entity_value, "id");
         label = GET_AGTYPE_VALUE_OBJECT_VALUE(original_entity_value, "label");
@@ -569,6 +684,21 @@ static void process_update_list(CustomScanState *node)
         }
         else
         {
+            /*
+             * YB: Reject full-map SETs (and `+=` merges) that carry meko_*
+             * tenant keys; otherwise the user could rebrand a row's tenant
+             * identity through the JSON map while the columns are silently
+             * carried over.
+             */
+            if (IsYugaByteEnabled() &&
+                yb_props_contain_meko_key(new_property_value))
+                ereport(ERROR,
+                        (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                         errmsg("tenant properties cannot be modified by %s",
+                                clause_name),
+                         errhint("Drop and recreate the vertex/edge to "
+                                 "change its tenant identity.")));
+
             altered_properties = alter_properties(
                 update_item->is_add ? original_properties : NULL,
                 new_property_value);
@@ -583,6 +713,18 @@ static void process_update_list(CustomScanState *node)
             {
                 remove_null_from_agtype_object(altered_properties);
             }
+
+            /*
+             * YB: A full-replacement SET (n = {...}) drops every key that
+             * isn't in the new map, so re-inject the meko_* keys from the
+             * original properties to keep the JSON map in sync with the
+             * copied-over tenant columns. The merge variant (n += {...})
+             * already preserves them.
+             */
+            if (IsYugaByteEnabled() && !update_item->is_add)
+                altered_properties =
+                    yb_inject_meko_keys(altered_properties,
+                                        agtype_value_to_agtype(original_properties));
         }
 
         resultRelInfo = create_entity_result_rel_info(
@@ -603,7 +745,12 @@ static void process_update_list(CustomScanState *node)
                                      CStringGetDatum(label_name),
                                      AGTYPE_P_GET_DATUM(agtype_value_to_agtype(altered_properties)));
 
-            slot = populate_vertex_tts(slot, id, altered_properties);
+            /*
+             * YB: pass a zeroed YbMekoDp; the meko_* tenant columns are
+             * re-populated below from the existing on-disk tuple.
+             */
+            slot = populate_vertex_tts(slot, id, altered_properties,
+                                       EmptyYbMekoDp);
         }
         else if (original_entity_value->type == AGTV_EDGE)
         {
@@ -616,8 +763,13 @@ static void process_update_list(CustomScanState *node)
                                    CStringGetDatum(label_name),
                                    AGTYPE_P_GET_DATUM(agtype_value_to_agtype(altered_properties)));
 
+            /*
+             * YB: pass a zeroed YbMekoDp; the meko_* tenant columns are
+             * re-populated below from the existing on-disk tuple.
+             */
             slot = populate_edge_tts(slot, id, startid, endid,
-                                     altered_properties);
+                                     altered_properties,
+                                     EmptyYbMekoDp);
         }
         else
         {
@@ -667,6 +819,19 @@ static void process_update_list(CustomScanState *node)
              */
             if (HeapTupleIsValid(heap_tuple))
             {
+                /*
+                 * YB: SET only rewrites the properties column, so carry the
+                 * tenant columns over from the on-disk tuple to keep the
+                 * row's tenant identity intact.
+                 */
+                if (IsYugaByteEnabled() &&
+                    (original_entity_value->type == AGTV_VERTEX ||
+                     original_entity_value->type == AGTV_EDGE))
+                    yb_copy_meko_columns_from_tuple(
+                        slot, heap_tuple,
+                        RelationGetDescr(resultRelInfo->ri_RelationDesc),
+                        original_entity_value->type == AGTV_EDGE);
+
                 heap_tuple = update_entity_tuple(resultRelInfo, slot, estate,
                                                  heap_tuple);
             }

--- a/src/postgres/third-party-extensions/mage/src/backend/executor/cypher_utils.c
+++ b/src/postgres/third-party-extensions/mage/src/backend/executor/cypher_utils.c
@@ -34,7 +34,12 @@
 
 /* YB includes */
 #include "executor/ybModifyTable.h"
+#include "fmgr.h"
 #include "pg_yb_utils.h"
+#include "utils/builtins.h"
+#include "utils/uuid.h"
+
+extern Datum uuid_in(PG_FUNCTION_ARGS); /* YB: for yb_extract_meko_columns_from_properties */
 
 /*
  * Given the graph name and the label name, create a ResultRelInfo for the table
@@ -85,8 +90,74 @@ void destroy_entity_result_rel_info(ResultRelInfo *result_rel_info)
     table_close(result_rel_info->ri_RelationDesc, RowExclusiveLock);
 }
 
-TupleTableSlot *populate_vertex_tts(
-    TupleTableSlot *elemTupleSlot, agtype_value *id, agtype_value *properties)
+/*
+ * YB: Copy meko_* tenant column values from `meko` into the four
+ * corresponding slot offsets on a vertex/edge tuple. is_edge selects the
+ * vertex or edge column layout. Caller is expected to gate the call with
+ * IsYugaByteEnabled().
+ */
+void yb_populate_meko_columns(TupleTableSlot *slot, YbMekoDp meko,
+                              bool is_edge)
+{
+    int dp_off    = is_edge ? edge_tuple_meko_datapack_id
+                            : vertex_tuple_meko_datapack_id;
+    int user_off  = is_edge ? edge_tuple_meko_user_id
+                            : vertex_tuple_meko_user_id;
+    int ag_off    = is_edge ? edge_tuple_meko_agent_id
+                            : vertex_tuple_meko_agent_id;
+    int conv_off  = is_edge ? edge_tuple_meko_conversation_id
+                            : vertex_tuple_meko_conversation_id;
+
+    slot->tts_values[dp_off]   = meko.datapack_id;
+    slot->tts_isnull[dp_off]   = false;
+    slot->tts_values[user_off] = meko.user_id;
+    slot->tts_isnull[user_off] = false;
+    slot->tts_values[ag_off]   = meko.agent_id;
+    slot->tts_isnull[ag_off]   = false;
+    slot->tts_values[conv_off] = meko.conversation_id;
+    slot->tts_isnull[conv_off] = meko.conversation_id_isnull;
+}
+
+/*
+ * YB: Helper for the SET path: copy the four meko_* columns from an
+ * on-disk tuple into a fresh YbMekoDp and hand it off to
+ * yb_populate_meko_columns() so the slot-population logic stays in one
+ * place. The first three columns are NOT NULL on the table so non-null
+ * is asserted; conversation is nullable and its flag is propagated.
+ */
+void yb_copy_meko_columns_from_tuple(TupleTableSlot *slot,
+                                     HeapTuple heap_tuple,
+                                     TupleDesc tupdesc,
+                                     bool is_edge)
+{
+    YbMekoDp meko;
+    bool isnull;
+    int dp_anum   = is_edge ? Anum_ag_label_edge_table_meko_datapack_id
+                            : Anum_ag_label_vertex_table_meko_datapack_id;
+    int user_anum = is_edge ? Anum_ag_label_edge_table_meko_user_id
+                            : Anum_ag_label_vertex_table_meko_user_id;
+    int ag_anum   = is_edge ? Anum_ag_label_edge_table_meko_agent_id
+                            : Anum_ag_label_vertex_table_meko_agent_id;
+    int conv_anum = is_edge ? Anum_ag_label_edge_table_meko_conversation_id
+                            : Anum_ag_label_vertex_table_meko_conversation_id;
+
+    meko.datapack_id = heap_getattr(heap_tuple, dp_anum, tupdesc, &isnull);
+    Assert(!isnull);
+    meko.user_id = heap_getattr(heap_tuple, user_anum, tupdesc, &isnull);
+    Assert(!isnull);
+    meko.agent_id = heap_getattr(heap_tuple, ag_anum, tupdesc, &isnull);
+    Assert(!isnull);
+    meko.conversation_id =
+        heap_getattr(heap_tuple, conv_anum, tupdesc, &isnull);
+    meko.conversation_id_isnull = isnull;
+
+    yb_populate_meko_columns(slot, meko, is_edge);
+}
+
+TupleTableSlot *populate_vertex_tts(TupleTableSlot *elemTupleSlot,
+                                    agtype_value *id,
+                                    agtype_value *properties,
+                                    YbMekoDp meko)
 {
     bool properties_isnull;
 
@@ -105,12 +176,15 @@ TupleTableSlot *populate_vertex_tts(
         AGTYPE_P_GET_DATUM(agtype_value_to_agtype(properties));
     elemTupleSlot->tts_isnull[vertex_tuple_properties] = properties_isnull;
 
+    if (IsYugaByteEnabled())
+        yb_populate_meko_columns(elemTupleSlot, meko, false /* is_edge */);
+
     return elemTupleSlot;
 }
 
 TupleTableSlot *populate_edge_tts(
     TupleTableSlot *elemTupleSlot, agtype_value *id, agtype_value *startid,
-    agtype_value *endid, agtype_value *properties)
+    agtype_value *endid, agtype_value *properties, YbMekoDp meko)
 {
     bool properties_isnull;
 
@@ -148,6 +222,9 @@ TupleTableSlot *populate_edge_tts(
     elemTupleSlot->tts_values[edge_tuple_properties] =
         AGTYPE_P_GET_DATUM(agtype_value_to_agtype(properties));
     elemTupleSlot->tts_isnull[edge_tuple_properties] = properties_isnull;
+
+    if (IsYugaByteEnabled())
+        yb_populate_meko_columns(elemTupleSlot, meko, true /* is_edge */);
 
     return elemTupleSlot;
 }
@@ -278,6 +355,172 @@ HeapTuple insert_entity_tuple_cid(ResultRelInfo *resultRelInfo,
     }
 
     return tuple;
+}
+
+/*
+ * YB: Require `key` to be present in `props` as a string and palloc a
+ * NUL-terminated copy. Distinguishes "missing" (ERRCODE_NOT_NULL_VIOLATION)
+ * from "present but not a string" (ERRCODE_INVALID_TEXT_REPRESENTATION).
+ * Caller pfrees the returned cstring.
+ */
+static char *yb_require_meko_string(agtype *props, const char *key)
+{
+    agtype_value search_key;
+    agtype_value *val;
+
+    search_key.type = AGTV_STRING;
+    search_key.val.string.val = (char *) key;
+    search_key.val.string.len = strlen(key);
+    val = find_agtype_value_from_container(&props->root, AGT_FOBJECT,
+                                           &search_key);
+    if (val == NULL || val->type == AGTV_NULL)
+        ereport(ERROR,
+                (errcode(ERRCODE_NOT_NULL_VIOLATION),
+                 errmsg("missing required tenant property \"%s\"", key)));
+    if (val->type != AGTV_STRING)
+        ereport(ERROR,
+                (errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+                 errmsg("tenant property \"%s\" must be a string", key)));
+    return pnstrdup(val->val.string.val, val->val.string.len);
+}
+
+/*
+ * YB: Look up an optional `key` in `props`. Returns true and sets *out_str
+ * to a palloc'd copy when the key is present and string-typed (caller
+ * pfrees). Returns false when the key is absent or set to JSON null. A
+ * present-but-non-string value raises ERRCODE_INVALID_TEXT_REPRESENTATION.
+ */
+static bool yb_optional_meko_string(agtype *props, const char *key,
+                                    char **out_str)
+{
+    agtype_value search_key;
+    agtype_value *val;
+
+    search_key.type = AGTV_STRING;
+    search_key.val.string.val = (char *) key;
+    search_key.val.string.len = strlen(key);
+    val = find_agtype_value_from_container(&props->root, AGT_FOBJECT,
+                                           &search_key);
+    if (val == NULL || val->type == AGTV_NULL)
+        return false;
+    if (val->type != AGTV_STRING)
+        ereport(ERROR,
+                (errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+                 errmsg("tenant property \"%s\" must be a string", key)));
+    *out_str = pnstrdup(val->val.string.val, val->val.string.len);
+    return true;
+}
+
+/*
+ * YB: Run an input function on `str`, but on failure rewrite the error to
+ * name the meko_* property that produced it. Without this, uuid_in /
+ * textin failures bubble up with no hint about which tenant column was
+ * malformed.
+ */
+static Datum yb_call_meko_input(PGFunction input_func, const char *str,
+                                const char *key)
+{
+    Datum result;
+
+    PG_TRY();
+    {
+        result = DirectFunctionCall1(input_func, CStringGetDatum(str));
+    }
+    PG_CATCH();
+    {
+        ErrorData *edata;
+        int sqlerrcode;
+        char *original_message;
+
+        MemoryContextSwitchTo(ErrorContext);
+        edata = CopyErrorData();
+        FlushErrorState();
+        sqlerrcode = edata->sqlerrcode;
+        original_message = pstrdup(edata->message);
+        FreeErrorData(edata);
+        ereport(ERROR,
+                (errcode(sqlerrcode),
+                 errmsg("invalid value for tenant property \"%s\"", key),
+                 errdetail("%s", original_message)));
+    }
+    PG_END_TRY();
+    return result;
+}
+
+/*
+ * Read meko_datapack_id, meko_user_id, meko_agent_id, meko_conversation_id
+ * from a vertex or edge properties map and materialize them as column
+ * Datums for the caller.
+ *
+ * The meko_* keys are intentionally left inside the properties map so that
+ * Cypher MATCH/MERGE patterns can match on those keys without parser-level
+ * changes. Callers that mutate the map (for example SET) are responsible
+ * for keeping the map and the columns in sync.
+ *
+ * meko_datapack_id, meko_user_id and meko_agent_id are NOT NULL on the
+ * underlying tables and so must be present in the properties map; this
+ * function raises ERRCODE_NOT_NULL_VIOLATION if any of them is missing or
+ * if the properties map itself is null/non-object. meko_conversation_id is
+ * nullable and reported via conversation_id_isnull.
+ */
+YbMekoDp yb_extract_meko_columns_from_properties(Datum props_datum,
+                                                 bool props_isnull)
+{
+    YbMekoDp result;
+    agtype *props_agtype;
+    char *str;
+
+    result.conversation_id = (Datum) 0;
+    result.conversation_id_isnull = true;
+
+    if (props_isnull)
+        ereport(ERROR,
+                (errcode(ERRCODE_NOT_NULL_VIOLATION),
+                 errmsg("missing required tenant properties on vertex/edge")));
+
+    props_agtype = DATUM_GET_AGTYPE_P(props_datum);
+    if (!AGT_ROOT_IS_OBJECT(props_agtype))
+        ereport(ERROR,
+                (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                 errmsg("vertex/edge tenant properties must be an object")));
+
+    /*
+     * The three NOT NULL keys must be present and string-typed; the helper
+     * raises an appropriate error otherwise. yb_call_meko_input wraps the
+     * input function so a malformed value (for example a non-UUID string)
+     * fails with the meko_* property name in the message instead of a
+     * bare uuid_in() error.
+     */
+    str = yb_require_meko_string(props_agtype, AG_COLNAME_MEKO_DATAPACK_ID);
+    result.datapack_id = yb_call_meko_input(uuid_in, str,
+                                            AG_COLNAME_MEKO_DATAPACK_ID);
+    pfree(str);
+
+    str = yb_require_meko_string(props_agtype, AG_COLNAME_MEKO_USER_ID);
+    result.user_id = yb_call_meko_input(uuid_in, str,
+                                        AG_COLNAME_MEKO_USER_ID);
+    pfree(str);
+
+    str = yb_require_meko_string(props_agtype, AG_COLNAME_MEKO_AGENT_ID);
+    result.agent_id = CStringGetTextDatum(str);
+    pfree(str);
+
+    /*
+     * meko_conversation_id is nullable. If the key is absent or set to JSON
+     * null, leave conversation_id_isnull = true. If it is present, require
+     * a string value (anything else is a clear user error).
+     */
+    if (yb_optional_meko_string(props_agtype,
+                                AG_COLNAME_MEKO_CONVERSATION_ID, &str))
+    {
+        result.conversation_id =
+            yb_call_meko_input(uuid_in, str,
+                               AG_COLNAME_MEKO_CONVERSATION_ID);
+        result.conversation_id_isnull = false;
+        pfree(str);
+    }
+
+    return result;
 }
 
 /*

--- a/src/postgres/third-party-extensions/mage/src/backend/utils/load/ag_load_edges.c
+++ b/src/postgres/third-party-extensions/mage/src/backend/utils/load/ag_load_edges.c
@@ -22,6 +22,9 @@
 #include "utils/load/ag_load_edges.h"
 #include "utils/load/csv.h"
 
+/* YB includes */
+#include "pg_yb_utils.h"
+
 void edge_field_cb(void *field, size_t field_len, void *data)
 {
 
@@ -185,6 +188,18 @@ int create_edges_from_csv_file(char *file_path,
     unsigned char options = 0;
     csv_edge_reader cr;
     char *label_seq_name;
+
+    /*
+     * YB: bulk CSV load is not wired up for YB yet (insert_batch uses
+     * heap_multi_insert and the meko_* tenant columns are not supplied
+     * by the loader). Fail loudly until the insert path is made
+     * YB-aware. See #31338.
+     */
+    if (IsYugaByteEnabled())
+        ereport(ERROR,
+                (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                 errmsg("bulk CSV edge load is not supported on "
+                        "YugabyteDB yet (#31338)")));
 
     if (csv_init(&p, options) != 0)
     {

--- a/src/postgres/third-party-extensions/mage/src/backend/utils/load/ag_load_labels.c
+++ b/src/postgres/third-party-extensions/mage/src/backend/utils/load/ag_load_labels.c
@@ -24,6 +24,9 @@
 #include "utils/load/ag_load_labels.h"
 #include "utils/load/csv.h"
 
+/* YB includes */
+#include "pg_yb_utils.h"
+
 void vertex_field_cb(void *field, size_t field_len, void *data)
 {
 
@@ -182,6 +185,18 @@ int create_labels_from_csv_file(char *file_path,
     unsigned char options = 0;
     csv_vertex_reader cr;
     char *label_seq_name;
+
+    /*
+     * YB: bulk CSV load is not wired up for YB yet (insert_batch uses
+     * heap_multi_insert and the meko_* tenant columns are not supplied
+     * by the loader). Fail loudly until the insert path is made
+     * YB-aware. See #31338.
+     */
+    if (IsYugaByteEnabled())
+        ereport(ERROR,
+                (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                 errmsg("bulk CSV vertex load is not supported on "
+                        "YugabyteDB yet (#31338)")));
 
     if (csv_init(&p, options) != 0)
     {

--- a/src/postgres/third-party-extensions/mage/src/backend/utils/load/age_load.c
+++ b/src/postgres/third-party-extensions/mage/src/backend/utils/load/age_load.c
@@ -43,12 +43,6 @@ static bool json_validate(text *json);
 static Oid get_or_create_graph(const Name graph_name);
 static int32 get_or_create_label(Oid graph_oid, char *graph_name,
                                  char *label_name, char label_kind);
-static void yb_insert_edge_simple(Relation label_relation, graphid edge_id,
-                                  graphid start_id, graphid end_id,
-                                  agtype *edge_properties);
-static void yb_insert_vertex_simple(Relation label_relation, graphid vertex_id,
-                                    agtype *vertex_properties);
-
 agtype *create_empty_agtype(void)
 {
     agtype* out;
@@ -240,8 +234,7 @@ void insert_edge_simple(Oid graph_oid, char *label_name, graphid edge_id,
                         graphid start_id, graphid end_id,
                         agtype *edge_properties)
 {
-
-    Datum values[6];
+    Datum values[4];
     bool nulls[4] = {false, false, false, false};
     Relation label_relation;
     HeapTuple tuple;
@@ -257,20 +250,17 @@ void insert_edge_simple(Oid graph_oid, char *label_name, graphid edge_id,
     label_relation = table_open(get_label_relation(label_name, graph_oid),
                                 RowExclusiveLock);
 
+    if (IsYBRelation(label_relation))
+        ereport(ERROR,
+                (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                 errmsg("simple edge insert is not supported on "
+                        "YugabyteDB yet (#31338)")));
+
     /* Form the tuple */
     values[0] = GRAPHID_GET_DATUM(edge_id);
     values[1] = GRAPHID_GET_DATUM(start_id);
     values[2] = GRAPHID_GET_DATUM(end_id);
     values[3] = AGTYPE_P_GET_DATUM((edge_properties));
-
-    if (IsYBRelation(label_relation))
-    {
-        yb_insert_edge_simple(label_relation, edge_id, start_id, end_id,
-                              edge_properties);
-        table_close(label_relation, RowExclusiveLock);
-        YbCommandCounterIncrement();
-        return;
-    }
 
     tuple = heap_form_tuple(RelationGetDescr(label_relation),
                             values, nulls);
@@ -319,13 +309,10 @@ void insert_vertex_simple(Oid graph_oid, char *label_name, graphid vertex_id,
                                 RowExclusiveLock);
 
     if (IsYBRelation(label_relation))
-    {
-        yb_insert_vertex_simple(label_relation, vertex_id,
-                                vertex_properties);
-        table_close(label_relation, RowExclusiveLock);
-        YbCommandCounterIncrement();
-        return;
-    }
+        ereport(ERROR,
+                (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                 errmsg("simple vertex insert is not supported on "
+                        "YugabyteDB yet (#31338)")));
 
     /* Form the tuple */
     values[0] = GRAPHID_GET_DATUM(vertex_id);
@@ -505,65 +492,6 @@ Datum load_edges_from_file(PG_FUNCTION_ARGS)
     create_edges_from_csv_file(file_path_str, graph_name_str, graph_oid,
                                label_name_str, label_id, load_as_agtype);
     PG_RETURN_VOID();
-}
-
-static void yb_insert_edge_simple(Relation label_relation, graphid edge_id,
-                                  graphid start_id, graphid end_id,
-                                  agtype *edge_properties)
-{
-    EState *estate = CreateExecutorState();
-    ResultRelInfo *resultRelInfo = makeNode(ResultRelInfo);
-    TupleTableSlot *slot;
-
-    InitResultRelInfo(resultRelInfo, label_relation, 1, NULL,
-                      estate->es_instrument);
-    estate->es_result_relations = &resultRelInfo;
-
-    slot = MakeSingleTupleTableSlot(RelationGetDescr(label_relation),
-                                    &TTSOpsVirtual);
-    ExecClearTuple(slot);
-
-    slot->tts_values[0] = GRAPHID_GET_DATUM(edge_id);
-    slot->tts_isnull[0] = false;
-    slot->tts_values[1] = GRAPHID_GET_DATUM(start_id);
-    slot->tts_isnull[1] = false;
-    slot->tts_values[2] = GRAPHID_GET_DATUM(end_id);
-    slot->tts_isnull[2] = false;
-    slot->tts_values[3] = AGTYPE_P_GET_DATUM(edge_properties);
-    slot->tts_isnull[3] = false;
-
-    ExecStoreVirtualTuple(slot);
-    YBCHeapInsert(resultRelInfo, slot, NULL, estate, ONCONFLICT_NONE);
-
-    ExecDropSingleTupleTableSlot(slot);
-    FreeExecutorState(estate);
-}
-
-static void yb_insert_vertex_simple(Relation label_relation, graphid vertex_id,
-                                    agtype *vertex_properties)
-{
-    EState *estate = CreateExecutorState();
-    ResultRelInfo *resultRelInfo = makeNode(ResultRelInfo);
-    TupleTableSlot *slot;
-
-    InitResultRelInfo(resultRelInfo, label_relation, 1, NULL,
-                      estate->es_instrument);
-    estate->es_result_relations = &resultRelInfo;
-
-    slot = MakeSingleTupleTableSlot(RelationGetDescr(label_relation),
-                                    &TTSOpsVirtual);
-    ExecClearTuple(slot);
-
-    slot->tts_values[0] = GRAPHID_GET_DATUM(vertex_id);
-    slot->tts_isnull[0] = false;
-    slot->tts_values[1] = AGTYPE_P_GET_DATUM(vertex_properties);
-    slot->tts_isnull[1] = false;
-
-    ExecStoreVirtualTuple(slot);
-    YBCHeapInsert(resultRelInfo, slot, NULL, estate, ONCONFLICT_NONE);
-
-    ExecDropSingleTupleTableSlot(slot);
-    FreeExecutorState(estate);
 }
 
 /*

--- a/src/postgres/third-party-extensions/mage/src/include/catalog/ag_label.h
+++ b/src/postgres/third-party-extensions/mage/src/include/catalog/ag_label.h
@@ -24,19 +24,39 @@
 
 #define Anum_ag_label_vertex_table_id 1
 #define Anum_ag_label_vertex_table_properties 2
+/* YB: meko_* tenant columns on vertex label tables */
+#define Anum_ag_label_vertex_table_meko_datapack_id 3
+#define Anum_ag_label_vertex_table_meko_user_id 4
+#define Anum_ag_label_vertex_table_meko_agent_id 5
+#define Anum_ag_label_vertex_table_meko_conversation_id 6
 
 #define Anum_ag_label_edge_table_id 1
 #define Anum_ag_label_edge_table_start_id 2
 #define Anum_ag_label_edge_table_end_id 3
 #define Anum_ag_label_edge_table_properties 4
+/* YB: meko_* tenant columns on edge label tables */
+#define Anum_ag_label_edge_table_meko_datapack_id 5
+#define Anum_ag_label_edge_table_meko_user_id 6
+#define Anum_ag_label_edge_table_meko_agent_id 7
+#define Anum_ag_label_edge_table_meko_conversation_id 8
 
 #define vertex_tuple_id Anum_ag_label_vertex_table_id - 1
 #define vertex_tuple_properties Anum_ag_label_vertex_table_properties - 1
+/* YB: tuple-offset aliases for meko_* tenant columns on vertex label tables */
+#define vertex_tuple_meko_datapack_id (Anum_ag_label_vertex_table_meko_datapack_id - 1)
+#define vertex_tuple_meko_user_id (Anum_ag_label_vertex_table_meko_user_id - 1)
+#define vertex_tuple_meko_agent_id (Anum_ag_label_vertex_table_meko_agent_id - 1)
+#define vertex_tuple_meko_conversation_id (Anum_ag_label_vertex_table_meko_conversation_id - 1)
 
 #define edge_tuple_id Anum_ag_label_edge_table_id - 1
 #define edge_tuple_start_id Anum_ag_label_edge_table_start_id - 1
 #define edge_tuple_end_id Anum_ag_label_edge_table_end_id - 1
 #define edge_tuple_properties Anum_ag_label_edge_table_properties - 1
+/* YB: tuple-offset aliases for meko_* tenant columns on edge label tables */
+#define edge_tuple_meko_datapack_id (Anum_ag_label_edge_table_meko_datapack_id - 1)
+#define edge_tuple_meko_user_id (Anum_ag_label_edge_table_meko_user_id - 1)
+#define edge_tuple_meko_agent_id (Anum_ag_label_edge_table_meko_agent_id - 1)
+#define edge_tuple_meko_conversation_id (Anum_ag_label_edge_table_meko_conversation_id - 1)
 
 
 

--- a/src/postgres/third-party-extensions/mage/src/include/commands/label_commands.h
+++ b/src/postgres/third-party-extensions/mage/src/include/commands/label_commands.h
@@ -28,6 +28,14 @@
 
 #define AG_VERTEX_COLNAME_ID "id"
 #define AG_VERTEX_COLNAME_PROPERTIES "properties"
+/*
+ * YB: tenant-column names (meko_*). Vertex and edge label tables use the
+ * same set of meko_* columns, so a single macro suffices for both.
+ */
+#define AG_COLNAME_MEKO_DATAPACK_ID "meko_datapack_id"
+#define AG_COLNAME_MEKO_USER_ID "meko_user_id"
+#define AG_COLNAME_MEKO_AGENT_ID "meko_agent_id"
+#define AG_COLNAME_MEKO_CONVERSATION_ID "meko_conversation_id"
 
 #define AG_ACCESS_FUNCTION_ID "age_id"
 

--- a/src/postgres/third-party-extensions/mage/src/include/executor/cypher_utils.h
+++ b/src/postgres/third-party-extensions/mage/src/include/executor/cypher_utils.h
@@ -109,11 +109,50 @@ typedef struct cypher_merge_custom_scan_state
     struct created_path *created_paths_list;
 } cypher_merge_custom_scan_state;
 
+/*
+ * YB: Bundle of meko_* tenant column values extracted from a vertex/edge
+ * properties map by yb_extract_meko_columns_from_properties(). The first
+ * three columns are NOT NULL on the underlying tables, so only
+ * meko_conversation_id carries an explicit isnull flag.
+ */
+typedef struct YbMekoDp
+{
+    Datum datapack_id;
+    Datum user_id;
+    Datum agent_id;
+    bool  conversation_id_isnull;
+    Datum conversation_id;
+} YbMekoDp;
+
+YbMekoDp yb_extract_meko_columns_from_properties(Datum props_datum,
+                                                 bool props_isnull);
+
+/*
+ * YB: Copy meko_* tenant column values from `meko` into the four corresponding
+ * slot offsets on a vertex/edge tuple. Caller is expected to gate the call
+ * with IsYugaByteEnabled() since the meko_* columns only exist on YB-hosted
+ * tables.
+ */
+void yb_populate_meko_columns(TupleTableSlot *slot, YbMekoDp meko,
+                              bool is_edge);
+
+/*
+ * YB: Copy meko_* tenant column values from an existing on-disk tuple into
+ * the corresponding slot offsets on a vertex/edge tuple. is_edge selects
+ * the vertex or edge column layout. Used by the SET path so that updates
+ * preserve the row's tenant identity. Caller is expected to gate the call
+ * with IsYugaByteEnabled().
+ */
+void yb_copy_meko_columns_from_tuple(TupleTableSlot *slot,
+                                     HeapTuple heap_tuple,
+                                     TupleDesc tupdesc,
+                                     bool is_edge);
+
 TupleTableSlot *populate_vertex_tts(TupleTableSlot *elemTupleSlot,
-                                    agtype_value *id, agtype_value *properties);
+    agtype_value *id, agtype_value *properties, YbMekoDp meko); /* YB: tenant cols */
 TupleTableSlot *populate_edge_tts(
     TupleTableSlot *elemTupleSlot, agtype_value *id, agtype_value *startid,
-    agtype_value *endid, agtype_value *properties);
+    agtype_value *endid, agtype_value *properties, YbMekoDp meko); /* YB: tenant cols */
 
 ResultRelInfo *create_entity_result_rel_info(EState *estate, char *graph_name,
                                              char *label_name);


### PR DESCRIPTION
## Summary
Extend the Apache AGE graph extension to make vertex and edge tables
tenant-scoped by adding `meko_conversation_id`, `meko_datapack_id`,
`meko_user_id`, and `meko_agent_id` columns, and by promoting
`meko_datapack_id`, `meko_user_id`, and `meko_agent_id` (together with
`id`) into the primary key.

Changes:
- `label_commands.c`: Replace the single-column `id` PK with a composite
primary key `((meko_datapack_id, meko_user_id) HASH, meko_agent_id ASC,
  id ASC)` via new helpers `create_vertex_pk_index` and
  `create_edge_pk_index` (LSM access method). Add tenant columns to
  vertex/edge table definitions.
- `cypher_create.c`, `cypher_merge.c`, `cypher_set.c`, `cypher_utils.c`:
  Thread new tenant columns through CREATE / MERGE / SET executor paths.
- `ag_load_edges.c`, `ag_load_labels.c`, `age_load.c`: Populate new
  tenant columns during bulk label/edge loading.
- `catalog/ag_label.h`, `commands/label_commands.h`,
  `executor/cypher_utils.h`: Add column-name macros and update helper
  signatures.

Original commit: 94f86ef36ab50fb973670df45ded7ff247fe721a / #31399

## Test plan
- [x] Manually verified via ysqlsh
- [x] Tested locally with the meko-mem0 Apache AGE connector test suite


---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31399/>)

---------

Co-authored-by: Harsh Daryani <harsh.daryani.6211@gmail.com>

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31538/>)