### PR TITLE
[BACKPORT 2026.1] YSQL: Stop retrying master RPCs when server is shutting down (#31436)

### DIFF
--- a/src/yb/client/client_master_rpc.cc
+++ b/src/yb/client/client_master_rpc.cc
@@ -145,7 +145,9 @@ void ClientMasterRpcBase::Finished(const Status& status) {
   }
 
   if (new_status.IsNetworkError() || new_status.IsRemoteError()) {
-    if (rpc::RpcError(new_status) != rpc::ErrorStatusPB::ERROR_NO_SUCH_METHOD) {
+    const auto rpc_error = rpc::RpcError(new_status);
+    if (rpc_error != rpc::ErrorStatusPB::ERROR_NO_SUCH_METHOD &&
+        rpc_error != rpc::ErrorStatusPB::FATAL_SERVER_SHUTTING_DOWN) {
       LOG(WARNING) << ToString() << ": Encountered a network error from the Master("
                    << client_data_->leader_master_hostport().ToString()
                    << "): " << new_status.ToString() << ", retrying...";


### PR DESCRIPTION
When a master RPC returns FATAL_SERVER_SHUTTING_DOWN, the client was
retrying indefinitely, treating it the same as a transient network
error. This change stops the retry loop for that error code, allowing
the caller to propagate the failure immediately instead of spinning.


---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31436/>)

Original commit: 7689eef56b489834da55595b050cd75ab770be9d / #31436

---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31569/>)