### PR TITLE
[BACKPORT 2026.1][#31439] YSQL: Don't FATAL on DDL/DML abort RPC failure when shutdown is in progress (#31470)

### DIFF
--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -116,6 +116,7 @@
 #ifndef HAVE_GETRUSAGE
 #include "rusagestub.h"
 #endif
+#include "storage/ipc.h"
 #include "storage/procarray.h"
 #include "tcop/utility.h"
 #include "utils/builtins.h"
@@ -1552,22 +1553,50 @@ YBCAbortTransaction()
 	YbcStatus	status = YBCPgClearSeparateDdlTxnMode();
 
 	/*
-	 * Aborting a transaction is likely to fail only when there are issues
-	 * communicating with the tserver. Close the backend connection in such
-	 * scenarios to avoid a recursive loop of aborting again and again as part
-	 * of error handling in PostgresMain() because of the error faced during
-	 * abort.
+	 * RPC failures here are most likely caused by a loss of communication with
+	 * the tserver.  The appropriate response depends on whether proc_exit is
+	 * already in progress:
 	 *
-	 * Note - If you are changing the behavior to not terminate the backend,
-	 * please consider its impact on sub-transaction abort failures
-	 * (YBCRollbackToSubTransaction) as well.
+	 * - When proc_exit is in progress (e.g. backend killed via
+	 *   pg_terminate_backend), PostgresMain() is no longer running and the
+	 *   tserver connection may already be tearing down.  Escalating to FATAL
+	 *   would trigger a second proc_exit before AbortTransaction finishes
+	 *   resetting PG transaction state, causing downstream assertions.  Log a
+	 *   message instead so that AbortTransaction can complete normally.
+	 *   Important: use LOG not WARNING.
+	 *   WARNING-level messages (elog.c) travel through shm_mq and confuse
+	 *   the pg_cron's ProcessBgwTaskFeedback into overwriting a prior
+	 *   'failed' job status. Some of the pg-cron tests rely on the 'failed'
+	 *   status to verify that a job failure is correctly reported.
+	 *
+	 * - Otherwise, FATAL to close the backend immediately.  This avoids a
+	 *   recursive loop where PostgresMain()'s error handler calls
+	 *   AbortCurrentTransaction(), which calls back here and fails again.
 	 */
 	if (unlikely(status))
-		elog(FATAL, "Failed to abort DDL transaction: %s", YBCMessageAsCString(status));
+	{
+		if (!proc_exit_inprogress)
+			elog(FATAL, "Failed to abort DDL transaction: %s",
+				 YBCMessageAsCString(status));
+		/* Only reached when proc_exit_inprogress: elog(FATAL) does not return. */
+		ereport(LOG,
+				(errmsg("failed to abort DDL transaction during shutdown: %s",
+						YBCMessageAsCString(status))));
+		YBCFreeStatus(status);
+	}
 
 	status = YBCPgAbortPlainTransaction();
 	if (unlikely(status))
-		elog(FATAL, "Failed to abort DML transaction: %s", YBCMessageAsCString(status));
+	{
+		if (!proc_exit_inprogress)
+			elog(FATAL, "Failed to abort DML transaction: %s",
+				 YBCMessageAsCString(status));
+		/* Only reached when proc_exit_inprogress: elog(FATAL) does not return. */
+		ereport(LOG,
+				(errmsg("failed to abort DML transaction during shutdown: %s",
+						YBCMessageAsCString(status))));
+		YBCFreeStatus(status);
+	}
 }
 
 void


### PR DESCRIPTION
When a backend is killed via pg_terminate_backend, ProcessInterrupts
fires
a FATAL mid-RPC. During the resulting proc_exit, AbortTransaction calls
YBCAbortTransaction, which tries to send an RPC to the tserver. In
fastdebug
builds, the pggate reactor may already be tearing down at this point,
causing
the RPC to fail with "Shutdown connection". The previous FATAL on that
error
triggered a second proc_exit before AbortTransaction finished resetting
PG
transaction state, leading to a downstream assertion in
pgstat_report_stat.

Fix: check proc_exit_inprogress before escalating to FATAL. When
shutdown is
already underway, log a warning and return so AbortTransaction can
complete
normally and PG transaction state is cleanly reset.


---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31470/>)

Original commit: 03480c2bb4614f69690e112382916b0372935b66 / #31470

---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31570/>)