### PR TITLE
[BACKPORT 2026.1] YSQL: Fix dangling reference: capture ts_uuid by value in thread pool lambda (#31437)

### DIFF
--- a/src/yb/master/ysql_backends_manager.cc
+++ b/src/yb/master/ysql_backends_manager.cc
@@ -544,7 +544,7 @@ Status BackendsCatalogVersionJob::Launch(int64_t term) {
 Status BackendsCatalogVersionJob::LaunchTS(TabletServerId ts_uuid, int num_lagging_backends) {
   auto task = std::make_shared<BackendsCatalogVersionTS>(
       shared_from_this(), object_lock_info_manager_, ts_uuid, num_lagging_backends);
-  Status s = threadpool()->SubmitFunc([this, &ts_uuid, task]() {
+  Status s = threadpool()->SubmitFunc([this, ts_uuid, task]() {
     Status s = task->Run();
     if (!s.ok()) {
       LOG_WITH_PREFIX(WARNING) << "got bad status " << s.ToString()


### PR DESCRIPTION
The ts_uuid string was captured by reference in a thread pool lambda in
ysql_backends_manager.cc, causing a dangling reference when the
enclosing scope exited before the lambda executed. Changed to capture
by value.


---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31437/>)

Original commit: 16b10b992c24191021479275b120a06607ea8bed / #31437

---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31571/>)