### PR TITLE
[BACKPORT 2026.1] Rename backport-review skill to review-backport (#31573)

### DIFF
--- a/.claude/skills/review-backport/SKILL.md
+++ b/.claude/skills/review-backport/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: backport-review
+name: review-backport
 description: >-
   Review YugabyteDB backport diffs by comparing them against their original
   commits/diffs. Use when the user provides a Phorge backport diff ID
@@ -7,9 +7,11 @@ description: >-
   reviewing backport revisions.
 ---
 
-# Backport Review
+# Review Backport
 
 Review a YugabyteDB backport diff by comparing it to the original commit/diff and identifying any differences.
+
+For the review *policy* (what counts as a backport, what to flag vs. ignore, byte-identical-hunk handling, and the `## Merge conflicts` convention), see the **Backport PRs** section of `@../../../.gemini/styleguide.md`. This skill covers the *mechanics* of fetching and comparing Phorge diffs and tracing unexplained code back to its origin on master.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- Rename `.claude/skills/backport-review` →
`.claude/skills/review-backport`.
- Replace the SKILL.md body with a pointer to `.gemini/styleguide.md`,
which already documents the backport review rules — keeps the
instructions in one place.

Original commit: eebd2809766596b1c03a8677f7f3e3d366bf302e / #31573

## Test plan
- [ ] Confirm the skill appears in Claude Code's available-skills list
as `review-backport`.
- [ ] Invoke `/review-backport` and confirm the referenced
`.gemini/styleguide.md` content loads.

---------

Co-authored-by: Kai Franz <kai-franz@users.noreply.github.com>

---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31576/>)