### PR TITLE
[#31734] lint: Keep name on same line as DEFINE macros

### DIFF
--- a/src/lint/cpplint.py
+++ b/src/lint/cpplint.py
@@ -285,6 +285,7 @@ _ERROR_CATEGORIES = [
     'readability/casting',
     'readability/check',
     'readability/constructors',
+    'readability/define_macros',
     'readability/fn_size',
     'readability/inheritance',
     'readability/multiline_comment',
@@ -6208,6 +6209,28 @@ def FlagCxx14Features(filename, clean_lines, linenum, error):
           ('<%s> is an unapproved C++14 header.') % include.group(1))
 
 
+def CheckDefineFormatting(filename, lines, error):
+  """Logs an error if our DEFINE_.. macros do not have the entity being defined on the same line."""
+
+  DEFINE_MACROS = [
+      'DEFINE_RUNTIME_',
+      'DEFINE_NON_RUNTIME_',
+      'DEFINE_UNKNOWN_',
+      'DEFINE_test_flag',
+      'DEFINE_validator',
+      'YB_DEFINE_ENUM',
+  ]
+
+  for line, line_str in enumerate(lines):
+    for macro in DEFINE_MACROS:
+      if line_str.startswith(macro) and '(' in line_str:
+        parts = line_str.split('(', 1)
+        if ',' not in parts[1]:
+          error(filename, line + 1, 'readability/define_macros', 5,
+                'The name should be on the same line as {0}'.format(parts[0]))
+        break
+
+
 def ProcessFileData(filename, file_extension, lines, error,
                     extra_check_functions=[]):
   """Performs lint checks and reports any errors to the given error function.
@@ -6258,6 +6281,9 @@ def ProcessFileData(filename, file_extension, lines, error,
   CheckForBadCharacters(filename, lines, error)
 
   CheckForNewlineAtEOF(filename, lines, error)
+
+  CheckDefineFormatting(filename, lines, error)
+
 
 def ProcessConfigOverrides(filename):
   """ Loads the configuration files and processes the config overrides.

--- a/src/yb/ann_methods/ann_methods.h
+++ b/src/yb/ann_methods/ann_methods.h
@@ -25,8 +25,7 @@
 
 namespace yb::ann_methods {
 
-YB_DEFINE_ENUM(
-    ANNMethodKind,
+YB_DEFINE_ENUM(ANNMethodKind,
     (kUsearch)
     (kHnswlib));
 

--- a/src/yb/bfpg/tserver_opcodes.h
+++ b/src/yb/bfpg/tserver_opcodes.h
@@ -24,8 +24,7 @@
 namespace yb {
 namespace bfpg {
 
-YB_DEFINE_ENUM(
-  TSOpcode,
+YB_DEFINE_ENUM(TSOpcode,
   ((kNoOp, 0))
 
   (kWriteTime)

--- a/src/yb/cdc/cdc_service.cc
+++ b/src/yb/cdc/cdc_service.cc
@@ -188,15 +188,14 @@ DEFINE_RUNTIME_uint32(xcluster_checkpoint_max_staleness_secs, 300,
     "and all WAL segments will be retained until the next refresh. "
     "Setting to 0 will disable Opid-based and time-based WAL segment retention for XCluster.");
 
-DEFINE_RUNTIME_int32(
-    cdcsdk_max_expired_tables_to_clean_per_run, 1,
+DEFINE_RUNTIME_int32(cdcsdk_max_expired_tables_to_clean_per_run, 1,
     "This flag determines the maximum number of tables to be cleaned up per run of "
     "UpdatePeersAndMetrics. Since a lot of tables can become not of interest at the same time, "
     "this flag is used to prevent storming of cleanup requests to master. When the flag value is "
     "1, the number of cleanup requests sent will be min(num_tables_to_cleanup, num_of_nodes)");
 
-DEFINE_RUNTIME_AUTO_bool(
-    cdcsdk_enable_cleanup_of_expired_table_entries, kLocalPersisted, false, true,
+DEFINE_RUNTIME_AUTO_bool(cdcsdk_enable_cleanup_of_expired_table_entries,
+    kLocalPersisted, false, true,
     "When enabled, Update Peers and Metrics will look for entries in the state table that have "
     "either become not of interest or have expired for a stream. The cleanup logic will then "
     "update these entries in cdc_state table and also move the corresponding table's entry to "

--- a/src/yb/cdc/cdcsdk_producer.cc
+++ b/src/yb/cdc/cdcsdk_producer.cc
@@ -61,39 +61,31 @@ DEPRECATE_FLAG(int32, cdc_snapshot_batch_size, "02_2026");
 
 DEFINE_RUNTIME_bool(stream_truncate_record, false, "Enable streaming of TRUNCATE record");
 
-DEFINE_RUNTIME_bool(
-    enable_single_record_update, true,
+DEFINE_RUNTIME_bool(enable_single_record_update, true,
     "Enable packing updates corresponding to a row in single CDC record");
 
-DEFINE_RUNTIME_bool(
-    cdc_populate_safepoint_record, true,
+DEFINE_RUNTIME_bool(cdc_populate_safepoint_record, true,
     "If 'true' we will also send a 'SAFEPOINT' record at the end of each GetChanges call.");
 
-DEFINE_NON_RUNTIME_bool(
-    cdc_enable_consistent_records, true,
+DEFINE_NON_RUNTIME_bool(cdc_enable_consistent_records, true,
     "If 'true' we will ensure that the records are order by the commit_time.");
 
-DEFINE_RUNTIME_uint64(
-    cdc_stream_records_threshold_size_bytes, 4_MB,
+DEFINE_RUNTIME_uint64(cdc_stream_records_threshold_size_bytes, 4_MB,
     "The threshold for the size of the response of a GetChanges call. The actual size may be a "
     "little higher than this value.");
 
-DEFINE_RUNTIME_uint64(
-    cdc_snapshot_records_threshold_size_bytes, 4_MB,
+DEFINE_RUNTIME_uint64(cdc_snapshot_records_threshold_size_bytes, 4_MB,
     "The threshold for the size of the CDC snapshot GetChanges response. The actual size may be "
     "slightly higher than this value.");
 
-DEFINE_test_flag(
-    bool, cdc_snapshot_failure, false,
+DEFINE_test_flag(bool, cdc_snapshot_failure, false,
     "For testing only, When it is set to true, the CDC snapshot operation will fail.");
 
-DEFINE_RUNTIME_bool(
-    cdc_populate_end_markers_transactions, true,
+DEFINE_RUNTIME_bool(cdc_populate_end_markers_transactions, true,
     "If 'true', we will also send 'BEGIN' and 'COMMIT' records for both single shard and multi "
     "shard transactions");
 
-DEFINE_NON_RUNTIME_int64(
-    cdc_resolve_intent_lag_threshold_ms, 5 * 60 * 1000,
+DEFINE_NON_RUNTIME_int64(cdc_resolve_intent_lag_threshold_ms, 5 * 60 * 1000,
     "The lag threshold in milli seconds between the hybrid time returned by "
     "GetMinStartHTRunningTxnsForCDCProducer and LeaderSafeTime, when we decide the "
     "ConsistentStreamSafeTime for CDCSDK by resolving all committed intetns");

--- a/src/yb/cdc/cdcsdk_virtual_wal.cc
+++ b/src/yb/cdc/cdcsdk_virtual_wal.cc
@@ -66,29 +66,24 @@ DEFINE_RUNTIME_uint32(cdcsdk_max_consistent_records, 500,
     "Controls the maximum number of records sent in GetConsistentChanges response. Only used when "
     "cdc_vwal_use_byte_threshold_for_consistent_changes flag is set to false.");
 
-DEFINE_RUNTIME_uint64(
-    cdcsdk_publication_list_refresh_interval_secs, 900 /* 15 mins */,
+DEFINE_RUNTIME_uint64(cdcsdk_publication_list_refresh_interval_secs, 900 /* 15 mins */,
     "Interval in seconds at which the table list in the publication will be refreshed");
 
-DEFINE_RUNTIME_uint64(
-    cdcsdk_vwal_getchanges_resp_max_size_bytes, 4_MB,
+DEFINE_RUNTIME_uint64(cdcsdk_vwal_getchanges_resp_max_size_bytes, 4_MB,
     "Max size (in bytes) of GetChanges response for all GetChanges requests sent "
     "from Virtual WAL.");
 
-DEFINE_test_flag(
-    bool, cdcsdk_use_microseconds_refresh_interval, false,
+DEFINE_test_flag(bool, cdcsdk_use_microseconds_refresh_interval, false,
     "Used in tests to simulate commit time ties of publication refresh record with transactions. "
     "When this flag is set to true the value of FLAGS_cdcsdk_publication_list_refresh_interval_secs"
     " will be ignored and publication refresh interval will be set to "
     "cdcsdk_publication_list_refresh_interval_micros.");
 
-DEFINE_test_flag(
-    uint64, cdcsdk_publication_list_refresh_interval_micros, 300000000 /* 5 minutes */,
+DEFINE_test_flag(uint64, cdcsdk_publication_list_refresh_interval_micros, 300000000 /* 5 minutes */,
     "Interval in micro seconds at which the table list in the publication will be refreshed. This "
     "will be used only when cdcsdk_use_microseconds_refresh_interval is set to true");
 
-DEFINE_RUNTIME_bool(
-    cdcsdk_enable_dynamic_table_support, true,
+DEFINE_RUNTIME_bool(cdcsdk_enable_dynamic_table_support, true,
     "This flag can be used to switch the dynamic addition of tables ON or OFF.");
 
 DEFINE_RUNTIME_bool(cdc_use_byte_threshold_for_vwal_changes, true,

--- a/src/yb/client/batcher.h
+++ b/src/yb/client/batcher.h
@@ -125,8 +125,7 @@ class TxnBatcherIf {
 
 // Batcher state changes sequentially in the order listed below, with the exception that kAborted
 // could be reached from any state.
-YB_DEFINE_ENUM(
-    BatcherState,
+YB_DEFINE_ENUM(BatcherState,
     (kGatheringOps)       // Initial state, while we adding operations to the batcher.
     (kResolvingTablets)   // Flush was invoked on batcher, waiting until tablets for all operations
                           // are resolved and move to the next state.

--- a/src/yb/client/client_error.h
+++ b/src/yb/client/client_error.h
@@ -25,8 +25,7 @@ using namespace std::literals;
 
 namespace yb::client {
 
-YB_DEFINE_ENUM(
-    ClientErrorCode,
+YB_DEFINE_ENUM(ClientErrorCode,
     // Special value used to indicate no error of this type.
     (kNone)
     (kTablePartitionListIsStale)

--- a/src/yb/client/table.cc
+++ b/src/yb/client/table.cc
@@ -34,8 +34,7 @@
 
 using std::string;
 
-DEFINE_UNKNOWN_int32(
-    max_num_tablets_for_table, 5000,
+DEFINE_UNKNOWN_int32(max_num_tablets_for_table, 5000,
     "Max number of tablets that can be specified in a CREATE TABLE statement");
 
 namespace yb::client {

--- a/src/yb/client/tablet_rpc.cc
+++ b/src/yb/client/tablet_rpc.cc
@@ -57,14 +57,12 @@ DEFINE_UNKNOWN_int32(lookup_cache_refresh_secs, 60, "When non-zero, specifies ho
 DEFINE_test_flag(int32, assert_failed_replicas_less_than, 0,
                  "If greater than 0, this process will crash if the number of failed replicas for "
                  "a RemoteTabletServer is greater than the specified number.");
-DEFINE_test_flag(
-    bool, always_return_consensus_info_for_succeeded_rpc, yb::kIsDebug,
+DEFINE_test_flag(bool, always_return_consensus_info_for_succeeded_rpc, yb::kIsDebug,
     "If set to true, we will always pass a stale raft_config_opid_index to the request when it is "
     "possible for the request. This is turned on in debug mode to test that our metacache "
     "will always be refreshed when a successful Write/Read/TransactionStatus/GetChanges RPC "
     "responds.");
-DEFINE_RUNTIME_bool(
-    enable_metacache_partial_refresh, true,
+DEFINE_RUNTIME_bool(enable_metacache_partial_refresh, true,
     "If set, we will attempt to refresh the tablet metadata cache with a TabletConsensusInfoPB in "
     "the tablet invoker.");
 

--- a/src/yb/client/universe_key_client.cc
+++ b/src/yb/client/universe_key_client.cc
@@ -32,8 +32,7 @@
 
 using namespace std::chrono_literals;
 
-DEFINE_RUNTIME_int32(
-    universe_key_client_max_delay_ms, 2000,
+DEFINE_RUNTIME_int32(universe_key_client_max_delay_ms, 2000,
     "Maximum Time in microseconds that an instance of Backoff_waiter waits before retrying to "
     "get the Universe key registry.");
 

--- a/src/yb/common/common_flags.cc
+++ b/src/yb/common/common_flags.cc
@@ -86,8 +86,7 @@ TAG_FLAG(wait_for_ysql_backends_catalog_version_client_master_rpc_margin_ms, adv
 
 DEPRECATE_FLAG(uint32, master_ts_ysql_catalog_lease_ms, "03_2026");
 
-DEFINE_NON_RUNTIME_bool(
-    ysql_enable_colocated_tables_with_tablespaces, false,
+DEFINE_NON_RUNTIME_bool(ysql_enable_colocated_tables_with_tablespaces, false,
     "Enable creation of colocated tables with a specified placement policy via a tablespace."
     "If true, creating a colocated table  will colocate the table on an implicit "
     "tablegroup that is determined by the tablespace it uses. We turn the feature off by default.");
@@ -109,18 +108,16 @@ DEFINE_NON_RUNTIME_bool(ysql_enable_pg_per_database_oid_allocator, true,
 TAG_FLAG(ysql_enable_pg_per_database_oid_allocator, advanced);
 TAG_FLAG(ysql_enable_pg_per_database_oid_allocator, hidden);
 
-DEFINE_RUNTIME_int32(
-    ysql_clone_pg_schema_rpc_timeout_ms, 10 * 60 * 1000,  // 10 min.
+DEFINE_RUNTIME_int32(ysql_clone_pg_schema_rpc_timeout_ms, 10 * 60 * 1000,  // 10 min.
     "Timeout used by the master when attempting to clone PG Schema objects using an async task to "
     "tserver");
 TAG_FLAG(ysql_clone_pg_schema_rpc_timeout_ms, advanced);
 
-DEFINE_RUNTIME_AUTO_bool(
-    yb_enable_cdc_consistent_snapshot_streams, kLocalPersisted, false, true,
+DEFINE_RUNTIME_AUTO_bool(yb_enable_cdc_consistent_snapshot_streams, kLocalPersisted, false, true,
     "Enable support for CDC Consistent Snapshot Streams");
 
-DEFINE_RUNTIME_AUTO_PG_FLAG(
-    bool, yb_enable_replication_slot_consumption, kLocalPersisted, false, true,
+DEFINE_RUNTIME_AUTO_PG_FLAG(bool, yb_enable_replication_slot_consumption,
+    kLocalPersisted, false, true,
     "Enable consumption of changes via replication slots."
     "Requires yb_enable_replication_commands to be true.");
 
@@ -184,8 +181,7 @@ DEFINE_NON_RUNTIME_PG_FLAG(bool, yb_disable_ddl_transaction_block_for_read_commi
     "ysql_yb_ddl_transaction_block_enabled is true. In other words, for Read Committed, fall back "
     "to the mode when ysql_yb_ddl_transaction_block_enabled is false.");
 
-DEFINE_RUNTIME_AUTO_PG_FLAG(
-    bool, yb_enable_ddl_savepoint_infra, kLocalPersisted, false, true,
+DEFINE_RUNTIME_AUTO_PG_FLAG(bool, yb_enable_ddl_savepoint_infra, kLocalPersisted, false, true,
     "Auto flag that controls whether DDL savepoint support can be safely enabled "
     "during upgrade. Both this flag and ysql_yb_enable_ddl_savepoint_support "
     "must be true to enable the feature.");
@@ -233,8 +229,7 @@ DEFINE_NON_RUNTIME_bool(enable_object_locking_for_table_locks,
     "This flag enables the object lock APIs provided by tservers and masters - "
     "AcquireObject(Global)Lock, ReleaseObject(Global)Lock. These APIs are used to "
     "implement pg table locks.");
-DEFINE_RUNTIME_AUTO_PG_FLAG(
-    bool, enable_object_locking_infra, kLocalPersisted, false, true,
+DEFINE_RUNTIME_AUTO_PG_FLAG(bool, enable_object_locking_infra, kLocalPersisted, false, true,
     "Auto flag that controls whether table-level object locking can be safely enabled "
     "during upgrade. Both this flag and enable_object_locking_for_table_locks "
     "must be true to enable the feature.");
@@ -404,12 +399,10 @@ DEFINE_RUNTIME_int32(timestamp_history_retention_interval_sec, 900,
 DEFINE_RUNTIME_PG_FLAG(bool, yb_enable_listen_notify, false, "Enable YSQL LISTEN/NOTIFY.");
 DEFINE_RUNTIME_PG_FLAG(int32, yb_test_notify_queue_max_pages, 0,
     "When positive, artificially limits the NOTIFY queue to this many pages for testing.");
-DEFINE_RUNTIME_AUTO_bool(
-    ysql_enable_auto_analyze_infra, kLocalPersisted, false, true,
+DEFINE_RUNTIME_AUTO_bool(ysql_enable_auto_analyze_infra, kLocalPersisted, false, true,
     "Enable the infra required for Auto Analyze");
 
-DEFINE_RUNTIME_bool(
-    ysql_enable_auto_analyze, false,
+DEFINE_RUNTIME_bool(ysql_enable_auto_analyze, false,
     "Enable Auto Analyze to automatically trigger ANALYZE for updating table statistics of tables "
     "which have changed more than a configurable threshold.");
 

--- a/src/yb/common/termination_monitor.cc
+++ b/src/yb/common/termination_monitor.cc
@@ -19,8 +19,8 @@
 #include "yb/util/signal_util.h"
 #include "yb/util/thread.h"
 
-DEFINE_NON_RUNTIME_bool(
-    graceful_shutdown, true, "Whether to shutdown gracefully when receiving SIGTERM.");
+DEFINE_NON_RUNTIME_bool(graceful_shutdown, true,
+    "Whether to shutdown gracefully when receiving SIGTERM.");
 
 namespace yb {
 

--- a/src/yb/common/version_info.h
+++ b/src/yb/common/version_info.h
@@ -48,8 +48,7 @@ struct VersionData {
   std::string json;
 };
 
-YB_DEFINE_ENUM(
-    ValidateVersionInfoOp,
+YB_DEFINE_ENUM(ValidateVersionInfoOp,
     (kVersionEQ)            // The version, build, and ysql major version are the same.
     (kYsqlMajorVersionLT)   // The ysql major version is lower.
     (kYsqlMajorVersionLE)   // The ysql major version is lower or equal.

--- a/src/yb/consensus/consensus_fwd.h
+++ b/src/yb/consensus/consensus_fwd.h
@@ -70,8 +70,7 @@ struct LeaderElectionData;
 // The elected Leader (this peer) can be in not-ready state because it's not yet synced.
 // The state reflects the real leader status: not-leader, leader-not-ready, leader-ready.
 // Not-ready status means that the leader is not ready to serve up-to-date read requests.
-YB_DEFINE_ENUM(
-    LeaderStatus,
+YB_DEFINE_ENUM(LeaderStatus,
     (NOT_LEADER)
     (LEADER_BUT_NO_OP_NOT_COMMITTED)
     (LEADER_BUT_OLD_LEADER_MAY_HAVE_LEASE)

--- a/src/yb/consensus/consensus_util.h
+++ b/src/yb/consensus/consensus_util.h
@@ -33,8 +33,7 @@ namespace consensus {
 
 // Specifies whether to send empty consensus requests from the leader to followers in case the queue
 // is empty.
-YB_DEFINE_ENUM(
-    RequestTriggerMode,
+YB_DEFINE_ENUM(RequestTriggerMode,
 
     // Only send a request if it is not empty.
     (kNonEmptyOnly)

--- a/src/yb/consensus/log.h
+++ b/src/yb/consensus/log.h
@@ -76,24 +76,21 @@ class CDCServiceTestMinSpace_TestLogRetentionByOpId_MinSpace_Test;
 
 namespace log {
 
-YB_DEFINE_ENUM(
-    SyncType,
+YB_DEFINE_ENUM(SyncType,
     (kNoSync)
     (kAsyncFsync)
     (kForceFsync)
 );
 
 YB_STRONGLY_TYPED_BOOL(CreateNewSegment);
-YB_DEFINE_ENUM(
-    SegmentAllocationState,
+YB_DEFINE_ENUM(SegmentAllocationState,
     (kAllocationNotStarted)  // No segment allocation requested
     (kAllocationInProgress)  // Next segment allocation started
     (kAllocationFinished)    // Next segment ready
     (kAllocationFailed)      // Next segment allocation failed
 );
 
-YB_DEFINE_ENUM(
-    SegmentOpIdRelation,
+YB_DEFINE_ENUM(SegmentOpIdRelation,
     // Segment is empty
     (kEmptySegment)
     // OpId is before the segment

--- a/src/yb/consensus/log_index.cc
+++ b/src/yb/consensus/log_index.cc
@@ -66,12 +66,11 @@
 #include "yb/util/logging.h"
 #include "yb/util/scope_exit.h"
 
-DEFINE_UNKNOWN_int32(
-    entries_per_index_block, 10000, "Number of entries per index block stored in WAL segment file");
+DEFINE_UNKNOWN_int32(entries_per_index_block, 10000,
+    "Number of entries per index block stored in WAL segment file");
 TAG_FLAG(entries_per_index_block, advanced);
 
-DEFINE_test_flag(
-    int32, entries_per_log_index_chuck, 0,
+DEFINE_test_flag(int32, entries_per_log_index_chuck, 0,
     "DO NOT CHANGE IN PRODUCTION. If set to value greater than 0 - overrides "
     "GetEntriesPerIndexChunk() for testing purposes.");
 

--- a/src/yb/consensus/raft_consensus.cc
+++ b/src/yb/consensus/raft_consensus.cc
@@ -261,13 +261,11 @@ DEFINE_UNKNOWN_bool(quick_leader_election_on_create, false,
 TAG_FLAG(quick_leader_election_on_create, advanced);
 TAG_FLAG(quick_leader_election_on_create, hidden);
 
-DEFINE_UNKNOWN_bool(
-    stepdown_disable_graceful_transition, false,
+DEFINE_UNKNOWN_bool(stepdown_disable_graceful_transition, false,
     "During a leader stepdown, disable graceful leadership transfer "
     "to an up to date peer");
 
-DEFINE_UNKNOWN_bool(
-    raft_disallow_concurrent_outstanding_report_failure_tasks, true,
+DEFINE_UNKNOWN_bool(raft_disallow_concurrent_outstanding_report_failure_tasks, true,
     "If true, only submit a new report failure task if there is not one outstanding.");
 TAG_FLAG(raft_disallow_concurrent_outstanding_report_failure_tasks, advanced);
 TAG_FLAG(raft_disallow_concurrent_outstanding_report_failure_tasks, hidden);

--- a/src/yb/docdb/cql_operation.cc
+++ b/src/yb/docdb/cql_operation.cc
@@ -88,8 +88,7 @@ DEFINE_RUNTIME_bool(ycql_enable_packed_row, kYcqlPackedRowEnabled,
 DEFINE_RUNTIME_bool(ycql_jsonb_use_member_cache, true,
                     "Whether we use member cache during jsonb processing in YCQL.");
 
-DEFINE_UNKNOWN_uint64(
-    ycql_packed_row_size_limit, 0,
+DEFINE_UNKNOWN_uint64(ycql_packed_row_size_limit, 0,
     "Packed row size limit for YCQL in bytes. 0 to make this equal to SSTable block size.");
 
 namespace yb {

--- a/src/yb/docdb/deadlock_detector.cc
+++ b/src/yb/docdb/deadlock_detector.cc
@@ -49,8 +49,7 @@
 using namespace std::literals;
 using namespace std::placeholders;
 
-DEFINE_UNKNOWN_int32(
-    clear_active_probes_older_than_seconds, 60,
+DEFINE_UNKNOWN_int32(clear_active_probes_older_than_seconds, 60,
     "Interval with which to clear active probes tracked at a deadlock detector. This ensures that "
     "the memory used to track both created and forwarded probes does not grow unbounded. If this "
     "is too low, we may remove entries too aggressively and end up failing to report deadlocks.");

--- a/src/yb/docdb/docdb_rocksdb_util.cc
+++ b/src/yb/docdb/docdb_rocksdb_util.cc
@@ -122,8 +122,7 @@ DEFINE_NON_RUNTIME_int32(rocksdb_max_write_buffer_number, 100500,
 DEFINE_NON_RUNTIME_uint64(rocksdb_max_manifest_file_size, 10_MB,
     "Maximum size of manifest file before which it is consolidated");
 
-DEFINE_RUNTIME_bool(
-    rocksdb_advise_random_on_open, true,
+DEFINE_RUNTIME_bool(rocksdb_advise_random_on_open, true,
     "If set to true, will hint the underlying file system that the file access pattern is random, "
     "when a sst file is opened.");
 
@@ -154,16 +153,16 @@ DEFINE_UNKNOWN_bool(use_docdb_aware_bloom_filter, true,
 
 DEFINE_UNKNOWN_bool(use_multi_level_index, true, "Whether to use multi-level data index.");
 
-DEFINE_RUNTIME_AUTO_bool(
-    allow_three_shared_parts_data_block_key_value_encoding, kExternal, false, true,
+DEFINE_RUNTIME_AUTO_bool(allow_three_shared_parts_data_block_key_value_encoding,
+    kExternal, false, true,
     "Allow to use three_shared_parts for writing RocksDB data blocks.");
 
 // DEPRECATED: replaced by ycql_regular_tablets_data_block_key_value_encoding and
 // ysql_regular_tablets_data_block_key_value_encoding.
 // Using class kExternal as this change affects the format of data in the SST files which are sent
 // to xClusters during bootstrap.
-DEFINE_RUNTIME_AUTO_string_DO_NOT_USE(
-    regular_tablets_data_block_key_value_encoding, kExternal, "shared_prefix", "three_shared_parts",
+DEFINE_RUNTIME_AUTO_string_DO_NOT_USE(regular_tablets_data_block_key_value_encoding,
+    kExternal, "shared_prefix", "three_shared_parts",
     "Key-value encoding to use for regular data blocks in RocksDB. Possible options: "
     "shared_prefix, three_shared_parts");
 

--- a/src/yb/docdb/docdb_types.h
+++ b/src/yb/docdb/docdb_types.h
@@ -30,8 +30,7 @@ YB_STRONGLY_TYPED_BOOL(IncludeBinary);
 YB_DEFINE_ENUM(StorageDbType, (kRegular)(kIntents));
 
 // Type of keys written by DocDB into RocksDB.
-YB_DEFINE_ENUM(
-    KeyType,
+YB_DEFINE_ENUM(KeyType,
     (kEmpty)
     (kIntentKey)
     (kReverseTxnKey)

--- a/src/yb/docdb/pgsql_operation.cc
+++ b/src/yb/docdb/pgsql_operation.cc
@@ -119,8 +119,7 @@ DEFINE_RUNTIME_AUTO_bool(ysql_enable_packed_row, kExternal,
 DEFINE_RUNTIME_bool(ysql_enable_packed_row_for_colocated_table, true,
                     "Whether to enable packed row for colocated tables.");
 
-DEFINE_UNKNOWN_uint64(
-    ysql_packed_row_size_limit, 0,
+DEFINE_UNKNOWN_uint64(ysql_packed_row_size_limit, 0,
     "Packed row size limit for YSQL in bytes. 0 to make this equal to SSTable block size.");
 
 DEFINE_RUNTIME_bool(ysql_enable_pack_full_row_update, false,

--- a/src/yb/dockv/doc_key.h
+++ b/src/yb/dockv/doc_key.h
@@ -60,8 +60,7 @@ namespace yb::dockv {
 //     1. Each range component consists of a type byte (ValueType) followed by the encoded
 //        representation of the respective type (see PrimitiveValue's key encoding).
 //     2. ValueType::kGroupEnd terminates the sequence.
-YB_DEFINE_ENUM(
-    DocKeyPart,
+YB_DEFINE_ENUM(DocKeyPart,
     (kUpToHashCode)
     (kUpToHash)
     (kUpToId)

--- a/src/yb/integration-tests/external_daemon.cc
+++ b/src/yb/integration-tests/external_daemon.cc
@@ -79,13 +79,11 @@ DECLARE_bool(mem_tracker_logging);
 DECLARE_bool(mem_tracker_log_stack_trace);
 DECLARE_bool(use_libbacktrace);
 
-DEFINE_NON_RUNTIME_string(
-    external_daemon_heap_profile_prefix, "",
+DEFINE_NON_RUNTIME_string(external_daemon_heap_profile_prefix, "",
     "If this is not empty, tcmalloc's HEAPPROFILE is set this, followed by a unique "
     "suffix for external mini-cluster daemons.");
 
-DEFINE_NON_RUNTIME_int64(
-    external_mini_cluster_max_log_bytes, 50_MB * 100,
+DEFINE_NON_RUNTIME_int64(external_mini_cluster_max_log_bytes, 50_MB * 100,
     "Max total size of log bytes produced by all external mini-cluster daemons. "
     "The test is shut down if this limit is exceeded.");
 

--- a/src/yb/master/async_snapshot_tasks.cc
+++ b/src/yb/master/async_snapshot_tasks.cc
@@ -34,8 +34,7 @@
 #include "yb/util/format.h"
 #include "yb/util/logging.h"
 
-DEFINE_test_flag(
-    bool, simulate_long_restore, false,
+DEFINE_test_flag(bool, simulate_long_restore, false,
     "Simulate a long restore failing to transition task to completion state if successful, thereby "
     "constantly retrying the RESTORE_ON_TABLET operation.");
 

--- a/src/yb/master/catalog_entity_info.cc
+++ b/src/yb/master/catalog_entity_info.cc
@@ -70,8 +70,7 @@ DECLARE_int32(tserver_unresponsive_timeout_ms);
 DECLARE_bool(cdcsdk_enable_dynamic_tables_disable_option);
 DECLARE_uint64(master_ysql_operation_lease_ttl_ms);
 
-DEFINE_RUNTIME_AUTO_bool(
-    use_parent_table_id_field, kLocalPersisted, false, true,
+DEFINE_RUNTIME_AUTO_bool(use_parent_table_id_field, kLocalPersisted, false, true,
     "Whether to use the new schema for colocated tables based on the parent_table_id field.");
 TAG_FLAG(use_parent_table_id_field, advanced);
 

--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -233,8 +233,7 @@ using namespace yb::size_literals;
 
 // The time is temporarly set to 600 sec to avoid hitting the tablet replacement code inherited from
 // Kudu. Removing tablet replacement code will be fixed in GH-6006
-DEFINE_RUNTIME_int32(
-    tablet_creation_timeout_ms, 600 * 1000,  // 600 sec
+DEFINE_RUNTIME_int32(tablet_creation_timeout_ms, 600 * 1000,  // 600 sec
     "Timeout used by the master when attempting to create tablet "
     "replicas during table creation.");
 TAG_FLAG(tablet_creation_timeout_ms, advanced);

--- a/src/yb/master/catalog_manager.h
+++ b/src/yb/master/catalog_manager.h
@@ -152,8 +152,7 @@ using TabletToTabletServerMap = std::unordered_map<TabletId, TabletServerId>;
 
 using TableToTabletInfos = std::unordered_map<TableId, std::vector<TabletInfoPtr>>;
 
-YB_DEFINE_ENUM(
-    CDCSDKStreamCreationState,
+YB_DEFINE_ENUM(CDCSDKStreamCreationState,
     // Stream has been initialized but no in-memory data structures or sys-catalog have been
     // modified.
     (kInitialized)
@@ -188,8 +187,7 @@ YB_DEFINE_ENUM(YsqlDdlSubTransactionRollbackState,
     (kDdlSubTxnRollbackInProgress)
     (kDdlSubTxnRollbackPostProcessingFailed));
 
-YB_DEFINE_ENUM(
-    DeleteYsqlDBTablesType,
+YB_DEFINE_ENUM(DeleteYsqlDBTablesType,
     (kNormal)                // Reglar DB drop. Can we used during both normal operations and major
                              // upgrade.
     (kMajorUpgradeRollback)  // Delete all rows and tables of the current catalog in order to

--- a/src/yb/master/catalog_manager_ext.cc
+++ b/src/yb/master/catalog_manager_ext.cc
@@ -112,8 +112,7 @@ DEPRECATE_FLAG(bool, enable_transaction_snapshots, "08_2024");
 
 DEPRECATE_FLAG(bool, allow_consecutive_restore, "10_2022");
 
-DEFINE_RUNTIME_bool(
-    enable_namespace_snapshot_workflow, true,
+DEFINE_RUNTIME_bool(enable_namespace_snapshot_workflow, true,
     "Enable namespace-based snapshot creation based on namespace_id. Can be disabled to fallback "
     "to the old snapshot creation workflow where client provides the set of tables to collect as "
     "part of snapshot");
@@ -138,14 +137,12 @@ DEFINE_RUNTIME_uint32(default_snapshot_retention_hours, 24,
     "Number of hours for which to keep the snapshot around. Only used if no value was provided "
     "by the client when creating the snapshot.");
 
-DEFINE_RUNTIME_bool(
-    import_snapshot_using_table_name, false,
+DEFINE_RUNTIME_bool(import_snapshot_using_table_name, false,
     "Use the old workflow of import snapshot where table names in backup/restore sides are used to "
     "build the mappings between tables in backup and restore side. This flag can be enabled as a "
     "safety button in case restore using relfilenode fails.");
 
-DEFINE_RUNTIME_AUTO_bool(
-    enable_export_snapshot_using_relfilenode, kExternal, false, true,
+DEFINE_RUNTIME_AUTO_bool(enable_export_snapshot_using_relfilenode, kExternal, false, true,
     "Enable exporting snapshots with the new format version = 3 that uses relfilenodes.");
 
 DECLARE_bool(enable_ysql);

--- a/src/yb/master/cluster_balance_activity_info.h
+++ b/src/yb/master/cluster_balance_activity_info.h
@@ -21,8 +21,7 @@
 
 namespace yb::master {
 
-YB_DEFINE_ENUM(
-    ClusterBalancerWarningType,
+YB_DEFINE_ENUM(ClusterBalancerWarningType,
     (kSkipTableLoadBalancing)
     (kTableRemoveReplicas)
     (kTableAddReplicas)

--- a/src/yb/master/master-path-handlers.cc
+++ b/src/yb/master/master-path-handlers.cc
@@ -107,8 +107,7 @@
 #include "yb/util/url-coding.h"
 #include "yb/common/version_info.h"
 
-DEFINE_RUNTIME_int32(
-    hide_dead_node_threshold_mins, 60 * 24,
+DEFINE_RUNTIME_int32(hide_dead_node_threshold_mins, 60 * 24,
     "After this many minutes of no heartbeat from a node, hide it from the UI "
     "(we presume it has been removed from the cluster). If -1, this flag is ignored and node is "
     "never hidden from the UI");

--- a/src/yb/master/master_fwd.h
+++ b/src/yb/master/master_fwd.h
@@ -145,8 +145,7 @@ YB_STRONGLY_TYPED_BOOL(IncludeDeleted);
 YB_STRONGLY_TYPED_BOOL(IsSystemObject);
 
 
-YB_DEFINE_ENUM(
-    CollectFlag,
+YB_DEFINE_ENUM(CollectFlag,
     (kAddIndexes)(kIncludeParentColocatedTable)(kSucceedIfCreateInProgress)(kAddUDTypes)
     (kIncludeHiddenTables));
 

--- a/src/yb/master/master_heartbeat_service.cc
+++ b/src/yb/master/master_heartbeat_service.cc
@@ -56,8 +56,7 @@ DEFINE_test_flag(string, master_universe_uuid, "",
                  "When set, use this mocked uuid to compare against the universe_uuid "
                  "from the tserver request.");
 
-DEFINE_RUNTIME_AUTO_bool(
-    master_enable_universe_uuid_heartbeat_check, kLocalPersisted, false, true,
+DEFINE_RUNTIME_AUTO_bool(master_enable_universe_uuid_heartbeat_check, kLocalPersisted, false, true,
     "When true, enables a sanity check between masters and tservers to prevent tservers from "
     "mistakenly heartbeating to masters in different universes. Master leader will check the "
     "universe_uuid passed by tservers against with its own copy of universe_uuid "

--- a/src/yb/master/master_snapshot_coordinator.cc
+++ b/src/yb/master/master_snapshot_coordinator.cc
@@ -93,8 +93,7 @@ DEFINE_RUNTIME_bool(skip_crash_on_duplicate_snapshot, false,
     "Should we not crash when we get a create snapshot request with the same "
     "id as one of the previous snapshots.");
 
-DEFINE_RUNTIME_AUTO_bool(
-    enable_object_retention_due_to_snapshots, kLocalPersisted, false, true,
+DEFINE_RUNTIME_AUTO_bool(enable_object_retention_due_to_snapshots, kLocalPersisted, false, true,
     "When true, tables and tablets are hidden instead of getting deleted on a drop if there are "
     "snapshots covering the object. Snapshots also get created with a TTL when "
     "this flag value is true.");

--- a/src/yb/master/object_lock_info_manager.cc
+++ b/src/yb/master/object_lock_info_manager.cc
@@ -74,8 +74,7 @@ DEFINE_NON_RUNTIME_uint64(object_lock_cleanup_interval_ms, 5000,
                           "The interval between runs of the background cleanup task for "
                           "table-level locks held by unresponsive TServers.");
 
-DEFINE_test_flag(
-    bool, skip_launch_release_request, false,
+DEFINE_test_flag(bool, skip_launch_release_request, false,
     "If true, skip launching the release request after persisting it to in progress requests.");
 
 DEFINE_test_flag(bool, allow_unknown_txn_release_request, false,

--- a/src/yb/master/permissions_manager.cc
+++ b/src/yb/master/permissions_manager.cc
@@ -42,8 +42,7 @@ using strings::Substitute;
 
 DECLARE_bool(ycql_cache_login_info);
 
-DEFINE_RUNTIME_AUTO_bool(
-    ycql_allow_cassandra_drop, kLocalPersisted, false, true,
+DEFINE_RUNTIME_AUTO_bool(ycql_allow_cassandra_drop, kLocalPersisted, false, true,
     "When true, stops the regeneration of the cassandra user on restart of the cluster.");
 
 // TODO: remove direct references to member fields in CatalogManager from here.

--- a/src/yb/master/snapshot_transfer_manager.cc
+++ b/src/yb/master/snapshot_transfer_manager.cc
@@ -17,8 +17,7 @@
 #include "yb/client/client.h"
 #include "yb/util/trace.h"
 
-DEFINE_test_flag(
-    bool, xcluster_fail_snapshot_transfer, false,
+DEFINE_test_flag(bool, xcluster_fail_snapshot_transfer, false,
     "In the SetupReplicationWithBootstrap flow, test failure to transfer snapshot on consumer.");
 
 namespace yb {

--- a/src/yb/master/xcluster/xcluster_inbound_replication_group_setup_task.cc
+++ b/src/yb/master/xcluster/xcluster_inbound_replication_group_setup_task.cc
@@ -50,8 +50,7 @@
 DEFINE_RUNTIME_bool(check_bootstrap_required, false,
     "Is it necessary to check whether bootstrap is required for Universe Replication.");
 
-DEFINE_RUNTIME_uint32(
-    xcluster_ensure_sequence_updates_in_wal_timeout_sec, 3 * 60,
+DEFINE_RUNTIME_uint32(xcluster_ensure_sequence_updates_in_wal_timeout_sec, 3 * 60,
     "Timeout for XClusterEnsureSequenceUpdatesAreInWal RPCs.");
 DEFINE_validator(xcluster_ensure_sequence_updates_in_wal_timeout_sec, FLAG_GT_VALUE_VALIDATOR(0));
 

--- a/src/yb/master/xcluster/xcluster_source_manager.cc
+++ b/src/yb/master/xcluster/xcluster_source_manager.cc
@@ -47,8 +47,7 @@ DEFINE_RUNTIME_bool(enable_tablet_split_of_xcluster_bootstrapping_tables, false,
     "When set, it enables automatic tablet splitting for tables that are part of an "
     "xCluster replication setup and are currently being bootstrapped for xCluster.");
 
-DEFINE_test_flag(
-    bool, simulate_EnsureSequenceUpdatesAreInWal_failure, false,
+DEFINE_test_flag(bool, simulate_EnsureSequenceUpdatesAreInWal_failure, false,
     "Simulate failure during EnsureSequenceUpdatesAreInWal RPC.");
 
 DECLARE_int32(master_yb_client_default_timeout_ms);

--- a/src/yb/master/xcluster_rpc_tasks.cc
+++ b/src/yb/master/xcluster_rpc_tasks.cc
@@ -44,12 +44,10 @@ DEFINE_RUNTIME_int32(list_snapshot_max_backoff_sec, 10,
 TAG_FLAG(list_snapshot_max_backoff_sec, stable);
 TAG_FLAG(list_snapshot_max_backoff_sec, advanced);
 
-DEFINE_test_flag(
-    bool, xcluster_fail_to_send_create_snapshot_request, false,
+DEFINE_test_flag(bool, xcluster_fail_to_send_create_snapshot_request, false,
     "Fail to send a CreateSnapshot request to the producer.");
 
-DEFINE_test_flag(
-    bool, xcluster_fail_create_producer_snapshot, false,
+DEFINE_test_flag(bool, xcluster_fail_create_producer_snapshot, false,
     "In the SetupReplicationWithBootstrap flow, fail to create snapshot on producer.");
 
 DECLARE_int32(cdc_read_rpc_timeout_ms);

--- a/src/yb/master/ysql/ysql_initdb_major_upgrade_handler.cc
+++ b/src/yb/master/ysql/ysql_initdb_major_upgrade_handler.cc
@@ -51,8 +51,7 @@ DECLARE_int32(master_ts_rpc_timeout_ms);
 DEFINE_RUNTIME_uint32(ysql_upgrade_postgres_port, 5434,
   "Port used to start the postgres process for ysql upgrade");
 
-DEFINE_test_flag(
-    string, fail_ysql_catalog_upgrade_state_transition_from, "",
+DEFINE_test_flag(string, fail_ysql_catalog_upgrade_state_transition_from, "",
     "When set fail the transition to the provided state");
 
 DEFINE_RUNTIME_string(ysql_major_upgrade_user, "yugabyte_upgrade",

--- a/src/yb/rocksdb/db/db_impl.cc
+++ b/src/yb/rocksdb/db/db_impl.cc
@@ -170,8 +170,7 @@ DEFINE_test_flag(double, simulated_crash_after_modify_flushed_frontier_probabili
 DEFINE_test_flag(bool, fail_flush_mem_table, false,
     "Fails all flush memtable requests when the flag is set.");
 
-DEFINE_RUNTIME_bool(
-    rocksdb_allow_multiple_pending_compactions_for_priority_thread_pool, false,
+DEFINE_RUNTIME_bool(rocksdb_allow_multiple_pending_compactions_for_priority_thread_pool, false,
     "Whether to allow multiple pending compactions for the same RocksDB instance. Only has effect "
     "when use_priority_thread_pool_for_compactions is set to true and "
     "rocksdb_determine_compaction_input_at_start is set to false.");

--- a/src/yb/rocksdb/db/memtablerep_bench.cc
+++ b/src/yb/rocksdb/db/memtablerep_bench.cc
@@ -80,16 +80,13 @@ DEFINE_UNKNOWN_int64(bucket_count, 1000000,
              "bucket_count parameter to pass into NewHashSkiplistRepFactory or "
              "NewHashLinkListRepFactory");
 
-DEFINE_UNKNOWN_int32(
-    hashskiplist_height, 4,
+DEFINE_UNKNOWN_int32(hashskiplist_height, 4,
     "skiplist_height parameter to pass into NewHashSkiplistRepFactory");
 
-DEFINE_UNKNOWN_int32(
-    hashskiplist_branching_factor, 4,
+DEFINE_UNKNOWN_int32(hashskiplist_branching_factor, 4,
     "branching_factor parameter to pass into NewHashSkiplistRepFactory");
 
-DEFINE_UNKNOWN_int32(
-    huge_page_tlb_size, 0,
+DEFINE_UNKNOWN_int32(huge_page_tlb_size, 0,
     "huge_page_tlb_size parameter to pass into NewHashLinkListRepFactory");
 
 DEFINE_UNKNOWN_int32(bucket_entries_logging_threshold, 4096,
@@ -100,12 +97,10 @@ DEFINE_UNKNOWN_bool(if_log_bucket_dist_when_flash, true,
             "if_log_bucket_dist_when_flash parameter to pass into "
             "NewHashLinkListRepFactory");
 
-DEFINE_UNKNOWN_int32(
-    threshold_use_skiplist, 256,
+DEFINE_UNKNOWN_int32(threshold_use_skiplist, 256,
     "threshold_use_skiplist parameter to pass into NewHashLinkListRepFactory");
 
-DEFINE_UNKNOWN_int32(
-    num_threads, 1,
+DEFINE_UNKNOWN_int32(num_threads, 1,
     "Number of concurrent threads to run. If the benchmark includes writes, "
     "then at most one thread will be a writer.");
 

--- a/src/yb/rocksdb/table/block_based_table_reader.cc
+++ b/src/yb/rocksdb/table/block_based_table_reader.cc
@@ -81,8 +81,7 @@ DEFINE_RUNTIME_uint64(rocksdb_iterator_sequential_disk_reads_for_auto_readahead,
     "will be enabled with the first disk read. If set to N > 1, iterator readahead will be used "
     "with the Nth sequential disk read.");
 
-DEFINE_RUNTIME_uint64(
-    rocksdb_iterator_sequential_disk_reads_factor, 1,
+DEFINE_RUNTIME_uint64(rocksdb_iterator_sequential_disk_reads_factor, 1,
     "Treat read as sequential for readahead purposes if next read operation is skipping up to "
     "readahead window size multiplied by rocksdb_iterator_sequential_disk_reads_factor bytes.");
 TAG_FLAG(rocksdb_iterator_sequential_disk_reads_for_auto_readahead, advanced);

--- a/src/yb/rocksdb/tools/db_bench_tool.cc
+++ b/src/yb/rocksdb/tools/db_bench_tool.cc
@@ -178,8 +178,7 @@ DEFINE_NON_RUNTIME_int64(merge_keys, -1,
              "If negative, there will be FLAGS_num keys.");
 DEFINE_NON_RUNTIME_int32(num_column_families, 1, "Number of Column Families to use.");
 
-DEFINE_NON_RUNTIME_int32(
-    num_hot_column_families, 0,
+DEFINE_NON_RUNTIME_int32(num_hot_column_families, 0,
     "Number of Hot Column Families. If more than 0, only write to this "
     "number of column families. After finishing all the writes to them, "
     "create new set of column families and insert to them. Only used "
@@ -609,8 +608,7 @@ DEFINE_NON_RUNTIME_bool(allow_concurrent_memtable_write, false,
 DEFINE_NON_RUNTIME_bool(enable_write_thread_adaptive_yield, false,
             "Use a yielding spin loop for brief writer thread waits.");
 
-DEFINE_NON_RUNTIME_uint64(
-    write_thread_max_yield_usec, 100,
+DEFINE_NON_RUNTIME_uint64(write_thread_max_yield_usec, 100,
     "Maximum microseconds for enable_write_thread_adaptive_yield operation.");
 
 DEFINE_NON_RUNTIME_uint64(write_thread_slow_yield_usec, 3,
@@ -623,8 +621,7 @@ DEFINE_NON_RUNTIME_int32(rate_limit_delay_max_milliseconds, 1000,
 
 DEFINE_NON_RUNTIME_uint64(rate_limiter_bytes_per_sec, 0, "Set options.rate_limiter value.");
 
-DEFINE_NON_RUNTIME_uint64(
-    benchmark_write_rate_limit, 0,
+DEFINE_NON_RUNTIME_uint64(benchmark_write_rate_limit, 0,
     "If non-zero, db_bench will rate-limit the writes going into RocksDB. This "
     "is the global rate in bytes/second.");
 

--- a/src/yb/rocksdb/tools/write_stress.cc
+++ b/src/yb/rocksdb/tools/write_stress.cc
@@ -106,8 +106,8 @@ DEFINE_NON_RUNTIME_double(first_char_mutate_probability, 0.1,
     "How likely are we to mutate the first char every period");
 DEFINE_NON_RUNTIME_double(second_char_mutate_probability, 0.2,
     "How likely are we to mutate the second char every period");
-DEFINE_NON_RUNTIME_double(
-    third_char_mutate_probability, 0.5, "How likely are we to mutate the third char every period");
+DEFINE_NON_RUNTIME_double(third_char_mutate_probability, 0.5,
+    "How likely are we to mutate the third char every period");
 
 DEFINE_NON_RUNTIME_int32(iterator_hold_sec, 5,
     "How long will the iterator hold files before it gets destroyed");

--- a/src/yb/rocksdb/types.h
+++ b/src/yb/rocksdb/types.h
@@ -47,8 +47,7 @@ YB_DEFINE_ENUM(FrontierModificationMode, (kForce)(kUpdate)(kUpdateIgnoreBackward
 
 // Specific how key value entries are encoded inside the block.
 // See Block and BlockBuilder for more details.
-YB_DEFINE_ENUM(
-    KeyValueEncodingFormat,
+YB_DEFINE_ENUM(KeyValueEncodingFormat,
     // <key_shared_prefix_size<key_non_shared_size><value_size><key_non_shared_bytes><value_bytes>
     ((kKeyDeltaEncodingSharedPrefix, 1))
     // Advanced key delta encoding optimized for docdb-specific encoded key structure.

--- a/src/yb/rpc/messenger.cc
+++ b/src/yb/rpc/messenger.cc
@@ -104,8 +104,7 @@ DEFINE_NON_RUNTIME_int32(rpc_reactor_task_timeout_ms, 0,
 
 DEFINE_UNKNOWN_int32(socket_receive_buffer_size, 0, "Socket receive buffer size, 0 to use default");
 
-DEFINE_test_flag(
-    int32, rpc_reactor_index_for_init_failure_simulation,
+DEFINE_test_flag(int32, rpc_reactor_index_for_init_failure_simulation,
     -1, "Index of reactor in Messenger to simulate failure of Reactor::Init method");
 
 namespace yb {

--- a/src/yb/rpc/network_error.h
+++ b/src/yb/rpc/network_error.h
@@ -25,8 +25,7 @@ using namespace std::literals;
 namespace yb {
 namespace rpc {
 
-YB_DEFINE_ENUM(
-    NetworkErrorCode,
+YB_DEFINE_ENUM(NetworkErrorCode,
     // Special value used to indicate no error of this type.
     (kNone)
     (kConnectFailed)

--- a/src/yb/server/server_common_flags.cc
+++ b/src/yb/server/server_common_flags.cc
@@ -32,12 +32,10 @@ DEFINE_NON_RUNTIME_bool(enable_pg_cron, false,
     "Enables the pg_cron extension. Jobs will be run on a single tserver node. The node should be "
     "assumed to be selected randomly.");
 
-DEFINE_RUNTIME_AUTO_PG_FLAG(
-    bool, yb_allow_replication_slot_lsn_types, kLocalPersisted, false, true,
+DEFINE_RUNTIME_AUTO_PG_FLAG(bool, yb_allow_replication_slot_lsn_types, kLocalPersisted, false, true,
     "Enable LSN types to be specified while creating replication slots.");
 
-DEFINE_RUNTIME_PG_PREVIEW_FLAG(
-    bool, yb_allow_replication_slot_ordering_modes, false,
+DEFINE_RUNTIME_PG_PREVIEW_FLAG(bool, yb_allow_replication_slot_ordering_modes, false,
     "Enable ordering modes to be specified while creating replication slots.");
 
 // This autoflag was introduced in commit 80def06f8c19ad7cbc52f41b4be48d158157a418, but it had some

--- a/src/yb/server/webserver.cc
+++ b/src/yb/server/webserver.cc
@@ -103,8 +103,7 @@ TAG_FLAG(webserver_compression_threshold_kb, advanced);
 DEFINE_UNKNOWN_bool(webserver_redirect_http_to_https, false,
             "Redirect HTTP requests to the embedded webserver to HTTPS if HTTPS is enabled.");
 
-DEFINE_RUNTIME_bool(
-    webserver_strict_transport_security, false,
+DEFINE_RUNTIME_bool(webserver_strict_transport_security, false,
     "Header is cached by the browser for the specified 'max-age' and forces it to redirect any "
     "http request to https to avoid man-in-the-middle attacks. The original http request is never "
     "sent.");

--- a/src/yb/tablet/operations/operation.h
+++ b/src/yb/tablet/operations/operation.h
@@ -59,8 +59,7 @@ namespace tablet {
 
 using OperationCompletionCallback = std::function<void(const Status&)>;
 
-YB_DEFINE_ENUM(
-    OperationType,
+YB_DEFINE_ENUM(OperationType,
     ((kWrite, consensus::WRITE_OP))
     ((kChangeMetadata, consensus::CHANGE_METADATA_OP))
     ((kUpdateTransaction, consensus::UPDATE_TRANSACTION_OP))

--- a/src/yb/tablet/operations/snapshot_operation.cc
+++ b/src/yb/tablet/operations/snapshot_operation.cc
@@ -24,8 +24,8 @@
 
 using std::string;
 
-DEFINE_UNKNOWN_bool(
-    consistent_restore, true, "Whether to enable consistent restoration of snapshots");
+DEFINE_UNKNOWN_bool(consistent_restore, true,
+    "Whether to enable consistent restoration of snapshots");
 
 DEFINE_test_flag(bool, modify_flushed_frontier_snapshot_op, true,
                  "Whether to modify flushed frontier after "

--- a/src/yb/tablet/tablet_peer.h
+++ b/src/yb/tablet/tablet_peer.h
@@ -130,8 +130,7 @@ struct TabletOnDiskSizeInfo {
   }
 };
 
-YB_DEFINE_ENUM(
-    TabletObjectState,
+YB_DEFINE_ENUM(TabletObjectState,
     (kUninitialized)
     (kAvailable)
     (kDestroyed));

--- a/src/yb/tablet/transaction_coordinator.cc
+++ b/src/yb/tablet/transaction_coordinator.cc
@@ -91,8 +91,7 @@ DEFINE_UNKNOWN_uint64(transaction_deadlock_detection_interval_usec, 60000000,
               "Deadlock detection interval in usec.");
 TAG_FLAG(transaction_deadlock_detection_interval_usec, advanced);
 
-DEFINE_RUNTIME_int32(
-    clear_deadlocked_txns_info_older_than_heartbeats, 10,
+DEFINE_RUNTIME_int32(clear_deadlocked_txns_info_older_than_heartbeats, 10,
     "Minimum number of transaction heartbeat periods for which a deadlocked transaction's info is "
     "retained, after it has been reported to be aborted. This ensures the memory used to track "
     "info of deadlocked transactions does not grow unbounded.");

--- a/src/yb/tserver/pg_client_service.cc
+++ b/src/yb/tserver/pg_client_service.cc
@@ -152,8 +152,7 @@ DEFINE_RUNTIME_uint64(ysql_cdc_active_replication_slot_window_ms, 60000,
                       "considered to be inactive.");
 TAG_FLAG(ysql_cdc_active_replication_slot_window_ms, advanced);
 
-DEFINE_RUNTIME_int32(
-    check_pg_object_id_allocators_interval_secs, 3600 * 3,
+DEFINE_RUNTIME_int32(check_pg_object_id_allocators_interval_secs, 3600 * 3,
     "Interval at which pg object id allocators are checked for dropped databases.");
 TAG_FLAG(check_pg_object_id_allocators_interval_secs, advanced);
 

--- a/src/yb/tserver/pg_client_session.cc
+++ b/src/yb/tserver/pg_client_session.cc
@@ -117,8 +117,7 @@ DEFINE_RUNTIME_bool(xcluster_target_manual_override, false,
     "YugabyteDB support before using.");
 TAG_FLAG(xcluster_target_manual_override, hidden);
 
-DEFINE_test_flag(
-    bool, request_unknown_tables_during_perform, false,
+DEFINE_test_flag(bool, request_unknown_tables_during_perform, false,
     "Add several unknown tables while processing perfrom request. "
     "It is expected that opening of such tables will fail");
 

--- a/src/yb/tserver/pg_response_cache.cc
+++ b/src/yb/tserver/pg_response_cache.cc
@@ -75,21 +75,19 @@ METRIC_DEFINE_gauge_uint32(server, pg_response_cache_entries,
                       yb::MetricUnit::kEntries,
                       "Number of entries in PgClientService response cache");
 
-DEFINE_NON_RUNTIME_uint64(
-    pg_response_cache_capacity, 1024, "PgClientService response cache capacity.");
+DEFINE_NON_RUNTIME_uint64(pg_response_cache_capacity, 1024,
+    "PgClientService response cache capacity.");
 
 DEFINE_NON_RUNTIME_uint64(pg_response_cache_size_bytes, 0,
                           "Size in bytes of the PgClientService response cache. "
                           "0 value (default) means that cache size is not limited by this flag.");
 
-DEFINE_NON_RUNTIME_uint32(
-    pg_response_cache_size_percentage, 5,
+DEFINE_NON_RUNTIME_uint32(pg_response_cache_size_percentage, 5,
     "Percentage of process' hard memory limit to use by the PgClientService response cache. "
     "Default value is 5, max is 100, min is 0 means that cache size is not limited by this flag.");
 
 
-DEFINE_NON_RUNTIME_uint32(
-    pg_response_cache_num_key_group_bucket, 512,
+DEFINE_NON_RUNTIME_uint32(pg_response_cache_num_key_group_bucket, 512,
     "Number of buckets for key group values which are used as part of response cache key. "
     "Response cache can be disabled for particular key group, but actually it will be disabled for "
     "all key groups in same bucket");

--- a/src/yb/tserver/remote_bootstrap_anchor_client.cc
+++ b/src/yb/tserver/remote_bootstrap_anchor_client.cc
@@ -44,8 +44,7 @@ using std::string;
 
 using namespace yb::size_literals;
 
-DEFINE_UNKNOWN_int32(
-    remote_bootstrap_anchor_session_timeout_ms, 5000,
+DEFINE_UNKNOWN_int32(remote_bootstrap_anchor_session_timeout_ms, 5000,
     "Tablet server RPC client timeout for RemoteBootstrapAnchor Service calls.");
 TAG_FLAG(remote_bootstrap_anchor_session_timeout_ms, hidden);
 

--- a/src/yb/tserver/remote_bootstrap_service.cc
+++ b/src/yb/tserver/remote_bootstrap_service.cc
@@ -84,8 +84,7 @@ using namespace std::literals;
     } \
   } while (false)
 
-DEFINE_RUNTIME_AUTO_uint64_DO_NOT_USE(
-    remote_bootstrap_idle_timeout_ms, kLocalVolatile,
+DEFINE_RUNTIME_AUTO_uint64_DO_NOT_USE(remote_bootstrap_idle_timeout_ms, kLocalVolatile,
     static_cast<uint64_t>(2 * yb::MonoTime::kMillisecondsPerHour),
     static_cast<uint64_t>(3 * yb::MonoTime::kMillisecondsPerMinute),
     "Amount of time without activity before a remote bootstrap session which hasn't yet fetched "
@@ -115,8 +114,7 @@ DEFINE_test_flag(uint64, delay_end_rbs_session_ms, 0,
 DEFINE_test_flag(uint64, inject_latency_before_fetch_data_secs, 0,
                  "Number of seconds to sleep before we call FetchData.");
 
-DEFINE_test_flag(
-    double, fault_crash_on_rbs_anchor_register, 0.0,
+DEFINE_test_flag(double, fault_crash_on_rbs_anchor_register, 0.0,
     "Fraction of the time when the peer will crash while "
     "servicing a RemoteBootstrapServiceImpl::RegisterLogAnchor() RPC call.");
 

--- a/src/yb/tserver/remote_client_base.cc
+++ b/src/yb/tserver/remote_client_base.cc
@@ -41,13 +41,11 @@
 
 #include "yb/util/logging.h"
 
-DEFINE_UNKNOWN_int32(
-    remote_bootstrap_begin_session_timeout_ms, 5000,
+DEFINE_UNKNOWN_int32(remote_bootstrap_begin_session_timeout_ms, 5000,
     "Tablet server RPC client timeout for BeginRemoteBootstrapSession calls.");
 TAG_FLAG(remote_bootstrap_begin_session_timeout_ms, hidden);
 
-DEFINE_UNKNOWN_int32(
-    remote_bootstrap_end_session_timeout_sec, 15,
+DEFINE_UNKNOWN_int32(remote_bootstrap_end_session_timeout_sec, 15,
     "Tablet server RPC client timeout for EndRemoteBootstrapSession calls. "
     "The timeout is usually a large value because we have to wait for the remote server "
     "to get a CHANGE_ROLE config change accepted.");

--- a/src/yb/tserver/server_main_util.cc
+++ b/src/yb/tserver/server_main_util.cc
@@ -40,8 +40,7 @@
 #include "yb/util/size_literals.h"
 #include "yb/util/status.h"
 
-DEFINE_NON_RUNTIME_bool(
-    use_memory_defaults_optimized_for_ysql, false,
+DEFINE_NON_RUNTIME_bool(use_memory_defaults_optimized_for_ysql, false,
     "If true, the recommended defaults for the memory usage settings take into account the amount "
     "of RAM and cores available and are optimized for using YSQL.  "
     "If false, the recommended defaults will be the old defaults, which are more suitable "

--- a/src/yb/tserver/tablet_server.cc
+++ b/src/yb/tserver/tablet_server.cc
@@ -251,13 +251,11 @@ DEFINE_NON_RUNTIME_int32(stateful_svc_default_queue_length, 50,
 DEFINE_RUNTIME_bool(tserver_heartbeat_add_replication_status, true,
     "Add replication status to heartbeats tserver sends to master");
 
-DEFINE_RUNTIME_int32(
-    check_lagging_catalog_versions_interval_secs, 900,
+DEFINE_RUNTIME_int32(check_lagging_catalog_versions_interval_secs, 900,
     "Interval at which pg backends are checked for lagging catalog versions.");
 TAG_FLAG(check_lagging_catalog_versions_interval_secs, advanced);
 
-DEFINE_RUNTIME_int32(
-    min_invalidation_message_retention_time_secs, 60,
+DEFINE_RUNTIME_int32(min_invalidation_message_retention_time_secs, 60,
     "Minimal time at which a catalog version with invalidation message is retained.");
 TAG_FLAG(min_invalidation_message_retention_time_secs, advanced);
 

--- a/src/yb/tserver/tablet_service.cc
+++ b/src/yb/tserver/tablet_service.cc
@@ -262,8 +262,8 @@ DEFINE_RUNTIME_bool(ysql_allow_duplicating_repeatable_read_queries, true,
 DECLARE_int32(ysql_transaction_abort_timeout_ms);
 DECLARE_bool(ysql_yb_disable_wait_for_backends_catalog_version);
 
-DEFINE_test_flag(
-    string, mini_cluster_pg_host_port, "", "The PG host:port used in PostgresMiniclusterTest");
+DEFINE_test_flag(string, mini_cluster_pg_host_port, "",
+    "The PG host:port used in PostgresMiniclusterTest");
 
 DEFINE_test_flag(bool, fail_alter_schema_after_abort_transactions, false,
     "If true, setup an error status in AlterSchema and respond success to rpc call. "

--- a/src/yb/tserver/ts_tablet_manager.cc
+++ b/src/yb/tserver/ts_tablet_manager.cc
@@ -302,8 +302,7 @@ DEFINE_NON_RUNTIME_uint32(deleted_tablet_cache_max_size, 10000,
     "Maximum size for the cache of recently deleted tablet ids. Used to "
     "reject remote bootstrap requests for recently deleted tablets.");
 
-DEFINE_RUNTIME_bool(
-    reject_rbs_for_deleted_tablet, true,
+DEFINE_RUNTIME_bool(reject_rbs_for_deleted_tablet, true,
     "Whether to reject a request to RBS a tablet that the receiving tserver has recently deleted.");
 
 DEFINE_UNKNOWN_int32(flush_bootstrap_state_pool_max_threads, -1,

--- a/src/yb/tserver/xcluster_consumer_replication_error.h
+++ b/src/yb/tserver/xcluster_consumer_replication_error.h
@@ -23,8 +23,7 @@
 
 namespace yb::tserver {
 
-YB_DEFINE_ENUM(
-    XClusterReplicationErrorSendState,
+YB_DEFINE_ENUM(XClusterReplicationErrorSendState,
     (kNotSent)  // Error has not been sent to master yet.
     (kSending)  // Error has been sent but master has not yet acknowledged it yet.
     (kSent));   // Error has been sent and master has acknowledged it.

--- a/src/yb/tserver/xcluster_poller.cc
+++ b/src/yb/tserver/xcluster_poller.cc
@@ -76,8 +76,7 @@ DEFINE_test_flag(bool, xcluster_simulate_get_changes_response_error, false,
 DEFINE_test_flag(bool, xcluster_disable_poller_term_check, false,
     "If true, the poller will not check the leader term.");
 
-DEFINE_test_flag(
-    double, xcluster_simulate_random_failure_after_apply, 0,
+DEFINE_test_flag(double, xcluster_simulate_random_failure_after_apply, 0,
     "If non-zero, simulate a random failure after writing rows to the target tablet.");
 
 DECLARE_int32(cdc_read_rpc_timeout_ms);

--- a/src/yb/tserver/xcluster_write_implementations.cc
+++ b/src/yb/tserver/xcluster_write_implementations.cc
@@ -46,8 +46,7 @@ DEPRECATE_FLAG(int32, cdc_max_apply_batch_num_records, "4_2023");
 
 DEPRECATE_FLAG(uint32, cdc_max_apply_batch_size_bytes, "4_2023");
 
-DEFINE_test_flag(
-    bool, xcluster_write_hybrid_time, false,
+DEFINE_test_flag(bool, xcluster_write_hybrid_time, false,
     "Override external_hybrid_time with initialHybridTimeValue for testing.");
 
 DECLARE_uint64(consensus_max_batch_size_bytes);

--- a/src/yb/tserver/ysql_lease_manager.cc
+++ b/src/yb/tserver/ysql_lease_manager.cc
@@ -28,8 +28,7 @@
 using namespace std::literals;
 using namespace std::placeholders;
 
-DEFINE_test_flag(
-    bool, enable_ysql_operation_lease_expiry_check, true,
+DEFINE_test_flag(bool, enable_ysql_operation_lease_expiry_check, true,
     "Whether tservers should monitor their ysql op lease and kill their hosted pg "
     "sessions when it expires. Only available as a flag for tests.");
 

--- a/src/yb/util/enums-test.cc
+++ b/src/yb/util/enums-test.cc
@@ -20,8 +20,7 @@ namespace yb {
 class EnumsTest : public YBTest {
 };
 
-YB_DEFINE_ENUM(
-    TestEnum,
+YB_DEFINE_ENUM(TestEnum,
     (kElement1)
     (kItem2)
     (kWidget3))

--- a/src/yb/util/flags/auto_flags.h
+++ b/src/yb/util/flags/auto_flags.h
@@ -56,8 +56,7 @@
 
 namespace yb {
 
-YB_DEFINE_ENUM(
-    AutoFlagClass,
+YB_DEFINE_ENUM(AutoFlagClass,
     // Adds/modifies format of data sent over the wire to another process within the universe. No
     // modification to persisted data.
     ((kLocalVolatile, 1))

--- a/src/yb/util/flags/flag_tags.h
+++ b/src/yb/util/flags/flag_tags.h
@@ -157,8 +157,7 @@
 
 namespace yb {
 
-YB_DEFINE_ENUM(
-    FlagTag,
+YB_DEFINE_ENUM(FlagTag,
     (kStable)
     (kEvolving)
     (kExperimental)

--- a/src/yb/util/mem_tracker.cc
+++ b/src/yb/util/mem_tracker.cc
@@ -111,8 +111,7 @@ DEFINE_NON_RUNTIME_int64(mem_tracker_update_consumption_interval_us, 2 * 1000 * 
     "Interval that is used to update memory consumption from external source. "
     "For instance from tcmalloc statistics.");
 
-DEFINE_RUNTIME_double(
-    mem_tracker_external_consumption_accuracy_percentage, 1.0,
+DEFINE_RUNTIME_double(mem_tracker_external_consumption_accuracy_percentage, 1.0,
     "If mem tracker consumption changed by more than specified percentage of the soft memory limit "
     "since the last update from external source, update it explicitly from that external source to "
     "avoid too much bias.");

--- a/src/yb/util/net/net_util.cc
+++ b/src/yb/util/net/net_util.cc
@@ -77,8 +77,7 @@ using std::string;
 using std::numeric_limits;
 using strings::Substitute;
 
-DEFINE_UNKNOWN_string(
-    net_address_filter,
+DEFINE_UNKNOWN_string(net_address_filter,
     "ipv4_external,ipv4_all,ipv6_external,ipv6_non_link_local,ipv6_all",
     "Order in which to select ip addresses returned by the resolver"
     "Can be set to something like \"ipv4_all,ipv6_all\" to prefer IPv4 over "

--- a/src/yb/util/pb_util.cc
+++ b/src/yb/util/pb_util.cc
@@ -133,8 +133,7 @@ DEFINE_NON_RUNTIME_uint64(rpc_max_message_size, 255_MB,
 // To permit parsing of very large PB messages, we must use parse through a CodedInputStream and
 // bump the byte limit. The SetTotalBytesLimit() docs say that 512MB is the shortest theoretical
 // message length that may produce integer overflow warnings, so that's what we'll use.
-DEFINE_NON_RUNTIME_uint32(
-    protobuf_message_total_bytes_limit, 511_MB,
+DEFINE_NON_RUNTIME_uint32(protobuf_message_total_bytes_limit, 511_MB,
     "Limits single protobuf message size for deserialization. This value must be greater than "
     "rpc_max_message_size and less than 512MB.");
 TAG_FLAG(protobuf_message_total_bytes_limit, advanced);

--- a/src/yb/vector_index/distance.h
+++ b/src/yb/vector_index/distance.h
@@ -27,8 +27,7 @@
 
 namespace yb::vector_index {
 
-YB_DEFINE_ENUM(
-    DistanceKind,
+YB_DEFINE_ENUM(DistanceKind,
 
     // Squared Euclidean (L2) distance -- sum of squares between coordinate differences.
     (kL2Squared)

--- a/src/yb/yql/cql/cqlserver/cql_server.cc
+++ b/src/yb/yql/cql/cqlserver/cql_server.cc
@@ -51,8 +51,7 @@ DEFINE_RUNTIME_int32(cql_nodelist_refresh_interval_secs, 300,
     "Interval after which a node list refresh event should be sent to all CQL clients.");
 TAG_FLAG(cql_nodelist_refresh_interval_secs, advanced);
 
-DEFINE_RUNTIME_bool(
-    cql_limit_nodelist_refresh_to_subscribed_conns, true,
+DEFINE_RUNTIME_bool(cql_limit_nodelist_refresh_to_subscribed_conns, true,
     "When enabled, the node list refresh events will only be sent to the connections which have "
     "subscribed to receiving the topology change events.");
 TAG_FLAG(cql_limit_nodelist_refresh_to_subscribed_conns, advanced);

--- a/src/yb/yql/cql/ql/ptree/pt_update.cc
+++ b/src/yb/yql/cql/ql/ptree/pt_update.cc
@@ -32,8 +32,7 @@
 using std::string;
 using std::max;
 
-DEFINE_RUNTIME_bool(
-    ycql_bind_collection_assignment_using_column_name, false,
+DEFINE_RUNTIME_bool(ycql_bind_collection_assignment_using_column_name, false,
     "Enable using column name for binding the value of subscripted collection column");
 
 namespace yb {

--- a/src/yb/yql/pggate/pg_sample.cc
+++ b/src/yb/yql/pggate/pg_sample.cc
@@ -36,8 +36,8 @@
 DEFINE_test_flag(bool, refresh_partitions_after_fetched_sample_blocks, false,
     "Force table partitions refresh after sample blocks are fetched.");
 
-DEFINE_RUNTIME_int32(
-    ysql_docdb_blocks_sampling_method, yb::DocDbBlocksSamplingMethod::SPLIT_INTERSECTING_BLOCKS_V3,
+DEFINE_RUNTIME_int32(ysql_docdb_blocks_sampling_method,
+    yb::DocDbBlocksSamplingMethod::SPLIT_INTERSECTING_BLOCKS_V3,
     "Controls how we define blocks for 1st phase of block-based sampling.");
 TAG_FLAG(ysql_docdb_blocks_sampling_method, hidden);
 

--- a/src/yb/yql/pggate/pg_sys_table_prefetcher.cc
+++ b/src/yb/yql/pggate/pg_sys_table_prefetcher.cc
@@ -49,11 +49,9 @@
 #include "yb/yql/pggate/util/ybc_util.h"
 
 DEFINE_NON_RUNTIME_bool(ysql_enable_read_request_caching, true, "Enable read request caching");
-DEFINE_NON_RUNTIME_uint32(
-    pg_cache_response_renew_soft_lifetime_limit_ms, 3 * 60 * 1000,
+DEFINE_NON_RUNTIME_uint32(pg_cache_response_renew_soft_lifetime_limit_ms, 3 * 60 * 1000,
     "Lifetime limit for response cache soft renewing process");
-DEFINE_NON_RUNTIME_uint32(
-    pg_cache_response_trust_auth_lifetime_limit_ms, 60 * 1000,
+DEFINE_NON_RUNTIME_uint32(pg_cache_response_trust_auth_lifetime_limit_ms, 60 * 1000,
     "Lifetime limit for response cache used for auth process when connection manager is used.");
 
 namespace yb::pggate {

--- a/src/yb/yql/pggate/pg_txn_manager.h
+++ b/src/yb/yql/pggate/pg_txn_manager.h
@@ -44,8 +44,7 @@ namespace yb::pggate {
 
 // These should match XACT_READ_UNCOMMITED, XACT_READ_COMMITED, XACT_REPEATABLE_READ,
 // XACT_SERIALIZABLE from xact.h. Please do not change this enum.
-YB_DEFINE_ENUM(
-  PgIsolationLevel,
+YB_DEFINE_ENUM(PgIsolationLevel,
   ((READ_UNCOMMITED, 0))
   ((READ_COMMITTED, 1))
   ((REPEATABLE_READ, 2))

--- a/src/yb/yql/pggate/pggate_flags.cc
+++ b/src/yb/yql/pggate/pggate_flags.cc
@@ -122,8 +122,8 @@ DEFINE_UNKNOWN_bool(ysql_beta_feature_tablegroup, false,
 
 TAG_FLAG(ysql_beta_feature_tablegroup, hidden);
 
-DEFINE_UNKNOWN_bool(
-    ysql_colocate_database_by_default, false, "Enable colocation by default on each database.");
+DEFINE_UNKNOWN_bool(ysql_colocate_database_by_default, false,
+    "Enable colocation by default on each database.");
 
 DEFINE_UNKNOWN_bool(ysql_beta_feature_tablespace_alteration, false,
             "Whether to enable the incomplete 'tablespace_alteration' beta feature");
@@ -153,8 +153,7 @@ DEPRECATE_FLAG(int32, ysql_max_write_restart_attempts, "12_2023");
 // left redundant, so D37419 removed it. See commit summary for details.
 DEPRECATE_FLAG(bool, ysql_disable_portal_run_context, "08_2024");
 
-DEFINE_NON_RUNTIME_uint32(
-    yb_max_recursion_depth, 2000,
+DEFINE_NON_RUNTIME_uint32(yb_max_recursion_depth, 2000,
     "Maximum recursion depth for YSQL functions. Currently, this affects only expression pushdown "
     "for regex functions. ");
 
@@ -163,8 +162,7 @@ constexpr bool kEnableReadCommitted = true;
 #else
 constexpr bool kEnableReadCommitted = false;
 #endif
-DEFINE_NON_RUNTIME_bool(
-    yb_enable_read_committed_isolation, kEnableReadCommitted,
+DEFINE_NON_RUNTIME_bool(yb_enable_read_committed_isolation, kEnableReadCommitted,
     "Defines how READ COMMITTED (which is our default SQL-layer isolation) and READ UNCOMMITTED "
     "are mapped internally. If false (default), both map to the stricter REPEATABLE READ "
     "implementation. If true, both use the new READ COMMITTED implementation instead.");

--- a/src/yb/yql/pggate/ybc_gflags.cc
+++ b/src/yb/yql/pggate/ybc_gflags.cc
@@ -79,16 +79,14 @@ DEFINE_NON_RUNTIME_bool(ysql_disable_global_impact_ddl_statements, false,
     "If true, disable global impact ddl statements in per database catalog "
     "version mode.");
 
-DEFINE_NON_RUNTIME_bool(
-    ysql_minimal_catalog_caches_preload, false,
+DEFINE_NON_RUNTIME_bool(ysql_minimal_catalog_caches_preload, false,
     "Fill postgres' caches with system items only");
 
 DEPRECATE_FLAG(bool, ysql_conn_mgr_version_matching, "2026_02");
 
 DEPRECATE_FLAG(bool, ysql_conn_mgr_version_matching_connect_higher_version, "2026_02");
 
-DEFINE_NON_RUNTIME_PREVIEW_string(
-    ysql_conn_mgr_alter_guc_adoption_strategy, "fluctuating",
+DEFINE_NON_RUNTIME_PREVIEW_string(ysql_conn_mgr_alter_guc_adoption_strategy, "fluctuating",
     "Defines strategy used by connection manager to adopt settings of ALTER statements modifying "
     "GUCs. The possible values are 'fluctuating', 'gradual' and 'connection_static'. 'fluctuating'"
     "means no handling is done, 'gradual' means existing sessions are gradually shifted to newer "
@@ -96,8 +94,7 @@ DEFINE_NON_RUNTIME_PREVIEW_string(
     "existing sessions will never see new GUC settings. In 'gradual' and 'connection_static' "
     "modes, new sessions will always see effects of ALTERs executed before they were created");
 
-DEFINE_NON_RUNTIME_PREVIEW_int32(
-    ysql_conn_mgr_alter_guc_stale_backend_ttl_ms, -1,
+DEFINE_NON_RUNTIME_PREVIEW_int32(ysql_conn_mgr_alter_guc_stale_backend_ttl_ms, -1,
     "TTL of backends which don't have latest settings of ALTER GUC commands. When set to a "
     "positive value, stale backends will be terminated uniformly till the TTL period after "
     "execution of ALTER. -1 means that no action is taken on stale backends. 0 means that stale "
@@ -120,8 +117,7 @@ DEFINE_NON_RUNTIME_bool(ysql_enable_read_request_cache_for_connection_auth, fals
     "during connection setup. Only applicable when connection manager "
     "is used.");
 
-DEFINE_NON_RUNTIME_bool(
-    ysql_enable_scram_channel_binding, false,
+DEFINE_NON_RUNTIME_bool(ysql_enable_scram_channel_binding, false,
     "Offer the option of SCRAM-SHA-256-PLUS (i.e. SCRAM with channel binding) as an SASL method if "
     "the server supports it in the SASL-Authentication message. This flag is disabled by default "
     "as connection manager does not support SCRAM with channel binding and enabling it would "
@@ -140,8 +136,8 @@ DEFINE_test_flag(bool, ysql_bypass_auto_analyze_auth_check, false,
 DEFINE_test_flag(int64, delay_after_table_analyze_ms, 0,
     "Add this delay after each table is analyzed.");
 
-DEFINE_test_flag(
-    bool, enable_obj_tuple_locks, false, "Enable object tuple locks in the lock manager.");
+DEFINE_test_flag(bool, enable_obj_tuple_locks, false,
+    "Enable object tuple locks in the lock manager.");
 
 DECLARE_bool(ysql_enable_colocated_tables_with_tablespaces);
 DECLARE_bool(TEST_ysql_enable_db_logical_client_version_mode);
@@ -174,8 +170,7 @@ bool PreloadAdditionalCatalogListValidator(const char* flag_name, const std::str
 }  // namespace
 
 DEFINE_validator(ysql_catalog_preload_additional_table_list, PreloadAdditionalCatalogListValidator);
-DEFINE_validator(
-    ysql_conn_mgr_alter_guc_adoption_strategy,
+DEFINE_validator(ysql_conn_mgr_alter_guc_adoption_strategy,
     FLAG_IN_SET_VALIDATOR("fluctuating", "gradual", "connection_static"));
 
 namespace yb::pggate {

--- a/src/yb/yql/pggate/ybc_pggate.cc
+++ b/src/yb/yql/pggate/ybc_pggate.cc
@@ -90,8 +90,7 @@ DECLARE_bool(ysql_enable_concurrent_ddl);
 
 DEPRECATE_FLAG(bool, ysql_disable_per_tuple_memory_context_in_update_relattrs, "06_2023");
 
-DEFINE_RUNTIME_PG_FLAG(
-    bool, yb_user_ddls_preempt_auto_analyze, true,
+DEFINE_RUNTIME_PG_FLAG(bool, yb_user_ddls_preempt_auto_analyze, true,
     "If object locking is off (i.e., enable_object_locking_for_table_locks=false), concurrent "
     "DDLs might face a conflict error on the catalog version increment at the end after doing all "
     "the work. Setting this flag enables a fail-fast strategy by locking the catalog version at "

--- a/src/yb/yql/pgwrapper/pg_wrapper.cc
+++ b/src/yb/yql/pgwrapper/pg_wrapper.cc
@@ -319,22 +319,20 @@ DEFINE_RUNTIME_AUTO_PG_FLAG(bool, yb_enable_replica_identity, kLocalPersisted, f
 DEFINE_RUNTIME_AUTO_PG_FLAG(bool, yb_allow_block_based_sampling_algorithm,
     kLocalVolatile, false, true, "Allow YsqlSamplingAlgorithm::BLOCK_BASED_SAMPLING");
 
-DEFINE_RUNTIME_AUTO_PG_FLAG(
-    bool, yb_allow_separate_requests_for_sampling_stages, kLocalVolatile, false, true,
+DEFINE_RUNTIME_AUTO_PG_FLAG(bool, yb_allow_separate_requests_for_sampling_stages,
+    kLocalVolatile, false, true,
     "Allow using separate requests for block-based sampling stages");
 
-DEFINE_RUNTIME_AUTO_PG_FLAG(
-    bool, yb_allow_dockey_bounds, kLocalVolatile, false, true,
+DEFINE_RUNTIME_AUTO_PG_FLAG(bool, yb_allow_dockey_bounds, kLocalVolatile, false, true,
     "If true, allow lower_bound/upper_bound fields of PgsqlReadRequestPB to be DocKeys. Only "
     "applicable for hash-sharded tables.");
 
-DEFINE_RUNTIME_AUTO_PG_FLAG(
-    bool, yb_test_make_all_ddl_statements_incrementing, kLocalVolatile, false, true,
+DEFINE_RUNTIME_AUTO_PG_FLAG(bool, yb_test_make_all_ddl_statements_incrementing,
+    kLocalVolatile, false, true,
     "When set, all DDL statements will cause the catalog version to increment. This mainly "
     "affects CREATE commands such as CREATE TABLE, CREATE VIEW, and CREATE SEQUENCE.");
 
-DEFINE_RUNTIME_PG_FLAG(
-    string, yb_default_replica_identity, "CHANGE",
+DEFINE_RUNTIME_PG_FLAG(string, yb_default_replica_identity, "CHANGE",
     "The default replica identity to be assigned to user defined tables at the time of creation. "
     "The flag is case sensitive and can take four possible values, 'FULL', 'DEFAULT', 'NOTHING' "
     "and 'CHANGE'. If any value other than these is assigned to the flag, the replica identity "
@@ -352,8 +350,7 @@ DEFINE_RUNTIME_PG_FLAG(uint32, yb_walsender_poll_sleep_duration_empty_ms, 10,  /
     "the CDC service in case the last received response was empty. The response can be empty in "
     "case there are no DMLs happening in the system.");
 
-DEFINE_RUNTIME_PG_FLAG(
-    uint32, yb_reorderbuffer_max_changes_in_memory, 4096,
+DEFINE_RUNTIME_PG_FLAG(uint32, yb_reorderbuffer_max_changes_in_memory, 4096,
     "Maximum number of changes kept in memory per transaction in reorder buffer, which is used in "
     "streaming changes via logical replication . After that, changes are spooled to disk.");
 
@@ -438,16 +435,14 @@ DEFINE_RUNTIME_PG_FLAG(bool, yb_test_fatal_after_notifs_queue_write, false,
 DECLARE_bool(enable_pg_cron);
 DECLARE_bool(enable_object_locking_for_table_locks);
 
-DEFINE_RUNTIME_PG_FLAG(
-    bool, yb_query_diagnostics_disable_database_connection_bgworker, false,
+DEFINE_RUNTIME_PG_FLAG(bool, yb_query_diagnostics_disable_database_connection_bgworker, false,
     "Disables the background worker that establishes a database connection for query diagnostics. "
     "If set to true, any diagnostics data requiring SPI or query execution will not be available.");
 
 TAG_FLAG(ysql_yb_query_diagnostics_disable_database_connection_bgworker, advanced);
 TAG_FLAG(ysql_yb_query_diagnostics_disable_database_connection_bgworker, hidden);
 
-DEFINE_RUNTIME_PG_FLAG(
-    int32, yb_log_heap_snapshot_on_exit_threshold, -1,
+DEFINE_RUNTIME_PG_FLAG(int32, yb_log_heap_snapshot_on_exit_threshold, -1,
     "When a process exits, log a peak heap snapshot showing the "
     "approximate memory usage of each malloc call stack if its peak RSS "
     "is greater than or equal to this threshold in KB. Set to -1 to disable.");

--- a/src/yb/yql/redis/redisserver/redis_rpc.cc
+++ b/src/yb/yql/redis/redisserver/redis_rpc.cc
@@ -56,8 +56,7 @@ DEFINE_UNKNOWN_uint64(redis_max_read_buffer_size, 128_MB,
 DEFINE_UNKNOWN_uint64(redis_max_queued_bytes, 128_MB,
               "Max number of bytes in queued redis commands.");
 
-DEFINE_UNKNOWN_int32(
-    redis_connection_soft_limit_grace_period_sec, 60,
+DEFINE_UNKNOWN_int32(redis_connection_soft_limit_grace_period_sec, 60,
     "The duration for which the outbound data needs to exceeed the softlimit "
     "before the connection gets closed down.");
 


### PR DESCRIPTION
Summary:
We generally follow the convention of putting the name on the same line as the DEFINE macro, e.g.:
```
// Bad
DEFINE_RUNTIME_int32(
    flag_name, 1, "...");

// Good
DEFINE_RUNTIME_int32(flag_name, 1, "...");
DEFINE_RUNTIME_int32(flag_name,
    1, "...");
```

This change adds a lint rule to enforce this convention for the following macros:
- `DEFINE_UNKNOWN_...`
- `DEFINE_RUNTIME_...`
- `DEFINE_NON_RUNTIME_...`
- `DEFINE_test_flag`
- `DEFINE_validator`
- `YB_DEFINE_ENUM`

and updates the codebase to adjust the existing cases that do not follow the convention by running:
```
find src/yb -type f \( -name '*.cc' -o -name '*.h' \) -not -path 'src/yb/gutil/*' \
    -exec sed -i -E -z 's/(DEFINE_(UNKNOWN|RUNTIME|NON_RUNTIME|validator|test_flag)\w*|YB_DEFINE_ENUM)\(\n\s*/\1(/g' {} \;
```
and then manually adjusting the lines that are too long.

Test Plan:
Jenkins: compile only

`find src/yb -type f | parallel -j16 src/lint/cpplint.py {} 2>&1 | grep define_macros`