### PR TITLE
[#31611] ClaudeCode: Add -D flag to create-pr.sh for opening draft PRs

### DIFF
--- a/.agents/scripts/create-pr.sh
+++ b/.agents/scripts/create-pr.sh
@@ -6,7 +6,7 @@
 # (issue, title, body, reviewers) has been gathered. Usable standalone too.
 #
 # usage: new-pr -i <issue> -t <title> -d <description-file> -T <test-plan-file>
-#               [-U <upgrade-file>] [-r <reviewers>] [-b <base>]
+#               [-U <upgrade-file>] [-r <reviewers>] [-b <base>] [-D]
 #
 # Required inputs:
 #   -i issue       GitHub issue number ("31151" or "#31151") or JIRA key
@@ -32,6 +32,10 @@
 #                  arrive as "org/slug"; the org/ prefix is stripped before
 #                  routing the slug to team_reviewers[].
 #   -b base        Base branch on the upstream repo (default: master).
+#   -D             Open the PR as a GitHub draft. Useful when you want to
+#                  read the rendered PR before notifications fire and before
+#                  reviewers are auto-pinged. Convert with
+#                  `gh pr ready <num>` when ready for review.
 #
 # Env overrides:
 #   GH_REPO         default: yugabyte/yugabyte-db
@@ -54,12 +58,13 @@ test_plan_file=""
 upgrade_file=""
 reviewers=""
 base_branch="master"
+draft=0
 GH_REPO="${GH_REPO:-yugabyte/yugabyte-db}"
 
 usage() {
   cat <<EOF >&2
 usage: $(basename "$0") -i <issue> -t <title> -d <description-file> -T <test-plan-file> \\
-                        [-U <upgrade-file>] [-r <reviewers>] [-b <base>]
+                        [-U <upgrade-file>] [-r <reviewers>] [-b <base>] [-D]
 
 Required:
   -i issue       GitHub issue (#NNNN, NNNN) or JIRA key (PLAT-NNN)
@@ -74,6 +79,8 @@ Optional:
                  .proto file** -- the script aborts otherwise.
   -r reviewers   Comma-separated handles and/or team slugs (org/slug)
   -b base        Base branch (default: master)
+  -D             Open the PR as a GitHub draft (\`gh pr create --draft\`).
+                 Convert with \`gh pr ready <num>\` when ready for review.
 
 Example:
   $(basename "$0") -i 31151 -t "DocDB: Fix flake in SamplingProfilerTest" \\
@@ -83,7 +90,7 @@ EOF
   exit 1
 }
 
-while getopts ":i:t:d:T:U:r:b:h" opt; do
+while getopts ":i:t:d:T:U:r:b:Dh" opt; do
   case "$opt" in
     i) issue="$OPTARG" ;;
     t) title="$OPTARG" ;;
@@ -92,6 +99,7 @@ while getopts ":i:t:d:T:U:r:b:h" opt; do
     U) upgrade_file="$OPTARG" ;;
     r) reviewers="$OPTARG" ;;
     b) base_branch="$OPTARG" ;;
+    D) draft=1 ;;
     h) usage ;;
     \?) echo "error: unknown option -$OPTARG" >&2; usage ;;
     :)  echo "error: -$OPTARG requires an argument" >&2; usage ;;
@@ -275,7 +283,11 @@ fi
 # same value (and got fragile for SSH aliases / non-standard remote URLs).
 pr_head="${gh_user}:${current_branch}"
 
-echo ">>> creating PR: ${full_title}"
+if (( draft )); then
+  echo ">>> creating PR (draft): ${full_title}"
+else
+  echo ">>> creating PR: ${full_title}"
+fi
 # Assemble the body: description -> ## Summary, optional -> ## Upgrade/
 # Rollback safety, test plan -> ## Test plan. Forcing each as a separate
 # arg means a caller can't accidentally omit a section.
@@ -300,8 +312,12 @@ trap 'rm -f "$combined_body"' EXIT
   echo
   cat "$test_plan_file"
 } > "$combined_body"
-pr_url=$(gh pr create -R "$GH_REPO" -B "$base_branch" -H "$pr_head" \
-                     -t "$full_title" -F "$combined_body")
+gh_pr_create_args=(-R "$GH_REPO" -B "$base_branch" -H "$pr_head"
+                   -t "$full_title" -F "$combined_body")
+if (( draft )); then
+  gh_pr_create_args+=(--draft)
+fi
+pr_url=$(gh pr create "${gh_pr_create_args[@]}")
 echo "$pr_url"
 pr_num="${pr_url##*/}"
 

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -101,6 +101,7 @@ Once you have the issue (Step 3.1), title (Step 4), and reviewers (Step 3 if use
   -d /tmp/claude/pr-desc-<issue>.md \
   -T /tmp/claude/pr-testplan-<issue>.md \
   [-U /tmp/claude/pr-upgrade-<issue>.md] \
+  [-D] \
   -r <reviewers>
 ```
 
@@ -113,6 +114,7 @@ Inputs:
 - **`-U` (optional, sometimes required)**: path to a markdown file with upgrade/rollback notes. The script makes this the `## Upgrade/Rollback safety` section, inserted **between Summary and Test plan**. **Pass this whenever the branch makes an upgrade-relevant decision.** The script enforces it **mechanically when any `.proto` file changes** (`exit 1` if `-U` is missing and a `*.proto` diff exists) — wire-format changes have to spell out forward and backward behavior on a mixed-version cluster and what rollback looks like. **Also include for** (script can't detect, but the src/AGENTS.md rule expects it): gflag default flips that change observable behavior, catalog schema bumps, on-disk-format changes, RPC-versioning tweaks, migration scripts. When unsure, pass `-U` with a brief note rather than skipping.
 - **`-T` (required)**: path to a markdown file with the test plan (typically a checkbox list). **Always supply this** — the script errors out if `-T` is missing or the file is empty. If the change is trivial enough that you think no test plan applies, write an explicit one-line checkbox saying so (e.g., `No runtime behavior change; visually inspected diff`) and confirm with the user before proceeding.
 - **`-r`**: comma-separated handles and/or team slugs (`alice,bob,yugabyte/db-approvers`). Optional.
+- **`-D` (optional)**: open the PR as a GitHub draft (`gh pr create --draft`). Use when the user wants to read the rendered PR before notifications fire and before reviewers are auto-pinged. After the user reviews, convert with `gh pr ready <num>`. **Use whenever the user asks for "draft PR(s)" or says they want to inspect the PR on GitHub before sending it out.** When `-D` is set, the script still requests reviewers via the REST endpoint as usual — GitHub silences review-requested notifications until the PR is marked ready, so the two settings combine cleanly.
 
 Exit codes:
 - `0` — PR created. Last stdout line is the PR URL.


### PR DESCRIPTION
## Summary

Adds a `-D` flag to `.agents/scripts/create-pr.sh` that passes `--draft` through to `gh pr create`, and documents it in `.claude/skills/create-pr/SKILL.md`.

### Motivation

When an agent prepares a branch end-to-end (commit, push, PR open), the contributor often wants to **read the rendered PR on GitHub** — diff, summary, test plan — before notifications go out, before reviewers are auto-pinged, and before CI consumes capacity on a not-yet-ready branch.

Workarounds today:

- `gh pr ready --undo <num>` immediately after the script finishes. Wastes one API round-trip per PR and briefly publishes the PR as ready before flipping it back, during which review-requested notifications can already fire.
- Skip the script entirely and hand-write `git push` + `gh pr create --draft`. Loses the script's rebase, lint, body assembly, and reviewer routing.

### What changed

- `.agents/scripts/create-pr.sh`: added a `-D` flag (no argument). When set, builds the `gh pr create` invocation with `--draft` appended.
- `.claude/skills/create-pr/SKILL.md`: documented the new flag in the standard usage block and added it to the inputs table with guidance on when to use it.

### Behavior preserved

- `-D` defaults to off. All existing callers and option parsing are unchanged.
- When `-D` is set, the reviewer-request step still runs as usual via the REST `requested_reviewers` endpoint. GitHub silences review-requested notifications while the PR is in draft, so the two settings combine cleanly: reviewers are pre-attached and get notified once the contributor flips the PR with `gh pr ready <num>`.

Closes #31611.

## Test plan

- [x] `bash -n .agents/scripts/create-pr.sh` — syntax OK.
- [x] `.agents/scripts/create-pr.sh -h` — usage block now lists `-D` under Optional and the synopsis line shows `[-D]`.
- [x] `shellcheck .agents/scripts/create-pr.sh` — no new warnings; only the pre-existing `SC2001` style hint on line 272 (unrelated).
- [ ] Dogfood: open a follow-up PR with `-D` and confirm GitHub renders it as a draft and suppresses review-requested notifications.
