### PR TITLE
[#31623] DocDB: Add cumulative per-service-pool RPC queue counters

### DIFF
--- a/src/yb/rpc/mt-rpc-test.cc
+++ b/src/yb/rpc/mt-rpc-test.cc
@@ -44,6 +44,7 @@
 
 #include "yb/util/countdown_latch.h"
 #include "yb/util/metrics.h"
+#include "yb/util/metrics_writer.h"
 #include "yb/util/net/net_util.h"
 #include "yb/util/status_log.h"
 #include "yb/util/test_macros.h"
@@ -52,6 +53,9 @@
 
 METRIC_DECLARE_counter(rpc_connections_accepted);
 METRIC_DECLARE_counter(rpcs_queue_overflow);
+METRIC_DECLARE_counter(rpcs_added_to_queue);
+METRIC_DECLARE_counter(rpcs_dequeued);
+METRIC_DECLARE_counter(rpcs_started_processing);
 
 using std::string;
 using std::shared_ptr;
@@ -241,10 +245,42 @@ TEST_F(MultiThreadedRpcTest, TestBlowOutServiceQueue) {
   ASSERT_EQ(1, errors_backpressure);
   ASSERT_EQ(2, errors_shutdown);
 
-  // Check that RPC queue overflow metric is 1
-  Counter *rpcs_queue_overflow =
-    METRIC_rpcs_queue_overflow.Instantiate(metric_entity()).get();
-  ASSERT_EQ(1, rpcs_queue_overflow->value());
+  // The aggregate counters should reflect: 2 calls successfully queued and 1 call rejected
+  // due to backpressure. The two queued calls are also dequeued during shutdown but never
+  // start processing because the thread pool has zero workers.
+  scoped_refptr<Counter> overflow =
+      METRIC_rpcs_queue_overflow.Instantiate(metric_entity());
+  scoped_refptr<Counter> added =
+      METRIC_rpcs_added_to_queue.Instantiate(metric_entity());
+  scoped_refptr<Counter> dequeued =
+      METRIC_rpcs_dequeued.Instantiate(metric_entity());
+  scoped_refptr<Counter> started =
+      METRIC_rpcs_started_processing.Instantiate(metric_entity());
+  EXPECT_EQ(1, overflow->value());
+  EXPECT_EQ(2, added->value());
+  EXPECT_EQ(2, dequeued->value());
+  EXPECT_EQ(0, started->value());
+
+  // The new metrics should also show up in a Prometheus scrape, including the lazily-created
+  // per-method counters for "Add". This guards against regressions where a metric is wired into
+  // a service pool but never makes it through PrometheusWriter (e.g. wrong aggregation level,
+  // missing label, or filtered out by default options).
+  std::stringstream prom_output;
+  MetricPrometheusOptions prom_opts;
+  PrometheusWriter prom_writer(&prom_output, prom_opts);
+  ASSERT_OK(metric_registry()->WriteForPrometheus(&prom_writer, prom_opts));
+  const std::string prom_text = prom_output.str();
+  for (const char* metric_name : {
+           "rpcs_added_to_queue",
+           "rpcs_dequeued",
+           "rpcs_started_processing",
+           "rpcs_added_to_queue_yb_rpc_test_CalculatorService_Add",
+           "rpcs_queue_overflow_yb_rpc_test_CalculatorService_Add",
+       }) {
+    EXPECT_NE(prom_text.find(metric_name), std::string::npos)
+        << "Metric '" << metric_name << "' missing from Prometheus output. Full output:\n"
+        << prom_text;
+  }
 }
 
 static void HammerServerWithTCPConns(const Endpoint& addr) {

--- a/src/yb/rpc/rpc-test-base.h
+++ b/src/yb/rpc/rpc-test-base.h
@@ -230,6 +230,7 @@ class RpcTestBase : public YBTest {
   Messenger* server_messenger() const { return server_->messenger(); }
   TestServer& server() const { return *server_; }
   const scoped_refptr<MetricEntity>& metric_entity() const { return metric_entity_; }
+  MetricRegistry* metric_registry() { return &metric_registry_; }
 
  private:
   MetricRegistry metric_registry_;

--- a/src/yb/rpc/service_pool.cc
+++ b/src/yb/rpc/service_pool.cc
@@ -45,6 +45,7 @@
 
 #include "yb/gutil/atomicops.h"
 #include "yb/gutil/ref_counted.h"
+#include "yb/gutil/stl_util.h"
 #include "yb/gutil/strings/substitute.h"
 
 #include "yb/rpc/inbound_call.h"
@@ -472,21 +473,29 @@ class ServicePoolImpl final : public InboundCallHandler {
     scoped_refptr<Counter> overflow;
   };
 
+  // The hot (steady-state) lookup path does a heterogeneous std::string_view lookup
+  // against per_method_counters_ under a SharedLock, so it does not allocate. We only
+  // materialize a std::string when we are about to insert a new entry (i.e. the first
+  // time we see a given method name on this service pool). See TransparentStringMap
+  // alias below.
+  //
   // TODO(#31673): once Abseil containers are available we should migrate
-  // per_method_counters_ to absl::flat_hash_map with a transparent string hash, which
-  // would let the hot lookup path skip the per-call Slice->std::string allocation
-  // performed below.
+  // per_method_counters_ to absl::flat_hash_map; the transparent-hash lookup story is
+  // already solved, so #31673 is now a cache-locality / open-addressing improvement
+  // rather than a fix for any per-call allocation.
   PerMethodCounters* GetPerMethodCounters(Slice method_name) EXCLUDES(per_method_mutex_) {
-    auto method_str = method_name.ToBuffer();
+    const std::string_view method_sv = method_name.AsStringView();
     {
       SharedLock<std::shared_mutex> lock(per_method_mutex_);
-      auto it = per_method_counters_.find(method_str);
+      auto it = per_method_counters_.find(method_sv);
       if (PREDICT_TRUE(it != per_method_counters_.end())) {
         return &it->second;
       }
     }
     std::lock_guard lock(per_method_mutex_);
-    auto it = per_method_counters_.find(method_str);
+    // Double-check after upgrading to the exclusive lock; someone else may have inserted
+    // this method's entry between the shared-lock release and the exclusive-lock acquire.
+    auto it = per_method_counters_.find(method_sv);
     if (it != per_method_counters_.end()) {
       return &it->second;
     }
@@ -496,11 +505,12 @@ class ServicePoolImpl final : public InboundCallHandler {
       YB_LOG_EVERY_N_SECS(WARNING, 60)
           << LogPrefix()
           << "Reached the per-service-pool cap of " << kMaxPerMethodMetrics
-          << " distinct RPC method names; new method '" << method_str
+          << " distinct RPC method names; new method '" << method_sv
           << "' will not get its own per-method metrics. Aggregate counters are unaffected.";
       return nullptr;
     }
-    auto [new_it, inserted] = per_method_counters_.try_emplace(std::move(method_str));
+    // Miss path: allocate the std::string only now, for use as the map key.
+    auto [new_it, inserted] = per_method_counters_.try_emplace(std::string(method_sv));
     if (inserted) {
       new_it->second = MakePerMethodCounters(new_it->first);
     }
@@ -548,7 +558,10 @@ class ServicePoolImpl final : public InboundCallHandler {
   scoped_refptr<Counter> rpcs_started_processing_;
   scoped_refptr<AtomicGauge<int64_t>> rpcs_in_queue_;
   std::shared_mutex per_method_mutex_;
-  std::unordered_map<std::string, PerMethodCounters> per_method_counters_
+  // UnorderedStringMap pairs StringHash (with is_transparent) and std::equal_to<void>
+  // so that the steady-state .find() call can accept a std::string_view without
+  // synthesizing a temporary std::string. See GetPerMethodCounters().
+  UnorderedStringMap<std::string, PerMethodCounters> per_method_counters_
       GUARDED_BY(per_method_mutex_);
   // Have to use CoarseDuration here, since CoarseTimePoint does not work with clang + libstdc++
   std::atomic<CoarseDuration> last_backpressure_at_{CoarseTimePoint().time_since_epoch()};

--- a/src/yb/rpc/service_pool.cc
+++ b/src/yb/rpc/service_pool.cc
@@ -59,6 +59,7 @@
 #include "yb/util/monotime.h"
 #include "yb/util/net/sockaddr.h"
 #include "yb/util/scope_exit.h"
+#include "yb/util/shared_lock.h"
 #include "yb/util/status.h"
 #include "yb/util/trace.h"
 
@@ -104,6 +105,27 @@ METRIC_DEFINE_counter(server, rpcs_queue_overflow,
                       "Number of RPCs dropped because the service queue "
                       "was full.");
 
+METRIC_DEFINE_counter(server, rpcs_added_to_queue,
+                      "RPCs Added To Service Queue",
+                      yb::MetricUnit::kRequests,
+                      "Cumulative count of RPCs that were successfully placed onto a service "
+                      "queue. Diff against rpcs_started_processing to tell whether the queue is "
+                      "growing because of an arrival surge or because of slow draining.");
+
+METRIC_DEFINE_counter(server, rpcs_dequeued,
+                      "RPCs Removed From Service Queue",
+                      yb::MetricUnit::kRequests,
+                      "Cumulative count of RPCs removed from a service queue. Includes both "
+                      "RPCs that were picked up for processing and RPCs that were popped off "
+                      "the queue because they had already timed out.");
+
+METRIC_DEFINE_counter(server, rpcs_started_processing,
+                      "RPCs That Started Service Handler",
+                      yb::MetricUnit::kRequests,
+                      "Cumulative count of RPCs for which the service handler began executing. "
+                      "rpcs_dequeued - rpcs_started_processing approximates the number of calls "
+                      "discarded after dequeue (e.g. timed out in the queue).");
+
 namespace yb {
 namespace rpc {
 
@@ -111,6 +133,12 @@ namespace {
 
 const CoarseDuration kTimeoutCheckGranularity = 100ms;
 const char* const kTimedOutInQueue = "Call waited in the queue past deadline";
+
+// The maximum number of distinct method names we will emit per-method metrics for.
+// In reality, we won't even come close to this number. This is just a safety measure
+// against DoS attacks (e.g. an attacker sending garbage method names in RPC headers
+// to unbounded-grow our metrics map and exhaust memory).
+constexpr size_t kMaxPerMethodMetrics = 1000;
 
 } // namespace
 
@@ -126,11 +154,15 @@ class ServicePoolImpl final : public InboundCallHandler {
         thread_pool_provider_(std::move(thread_pool_provider)),
         scheduler_(*scheduler),
         service_(std::move(service)),
+        metric_entity_(entity),
         incoming_queue_time_(METRIC_rpc_incoming_queue_time.Instantiate(entity)),
         rpcs_timed_out_in_queue_(METRIC_rpcs_timed_out_in_queue.Instantiate(entity)),
         rpcs_timed_out_early_in_queue_(
             METRIC_rpcs_timed_out_early_in_queue.Instantiate(entity)),
         rpcs_queue_overflow_(METRIC_rpcs_queue_overflow.Instantiate(entity)),
+        rpcs_added_to_queue_(METRIC_rpcs_added_to_queue.Instantiate(entity)),
+        rpcs_dequeued_(METRIC_rpcs_dequeued.Instantiate(entity)),
+        rpcs_started_processing_(METRIC_rpcs_started_processing.Instantiate(entity)),
         check_timeout_strand_(scheduler->io_service()),
         log_prefix_(Format("$0: ", service_->service_name())) {
 
@@ -196,6 +228,11 @@ class ServicePoolImpl final : public InboundCallHandler {
       return;
     }
 
+    rpcs_added_to_queue_->Increment();
+    if (auto* per_method_counters = GetPerMethodCounters(call->method_name())) {
+      per_method_counters->added->Increment();
+    }
+
     auto call_deadline = call->GetClientDeadline();
     if (call_deadline != CoarseTimePoint::max()) {
       pre_check_timeout_queue_.Push(new WeakInboundCall(std::move(call)));
@@ -233,6 +270,9 @@ class ServicePoolImpl final : public InboundCallHandler {
     YB_LOG_EVERY_N_SECS(WARNING, 3) << LogPrefix() << err_msg;
     const auto response_status = STATUS(ServiceUnavailable, err_msg);
     rpcs_queue_overflow_->Increment();
+    if (auto* per_method_counters = GetPerMethodCounters(call->method_name())) {
+      per_method_counters->overflow->Increment();
+    }
     call->RespondFailure(ErrorStatusPB::ERROR_SERVER_TOO_BUSY, response_status);
     last_backpressure_at_.store(
         CoarseMonoClock::Now().time_since_epoch(), std::memory_order_release);
@@ -272,6 +312,7 @@ class ServicePoolImpl final : public InboundCallHandler {
       error_message = "The server is overloaded. Call waited in the queue past max_time_in_queue.";
     } else {
       if (incoming->TryStartProcessing()) {
+        rpcs_started_processing_->Increment();
         TRACE_TO(incoming->trace(), "Handling call $0", AsString(incoming->method_name()));
         service_->Handle(std::move(incoming));
       }
@@ -410,17 +451,76 @@ class ServicePoolImpl final : public InboundCallHandler {
   void CallDequeued() override {
     queued_calls_.fetch_sub(1, std::memory_order_relaxed);
     rpcs_in_queue_->Decrement();
+    rpcs_dequeued_->Increment();
+  }
+
+  // Per-RPC-method counters. Lazily registered on first occurrence of each method name.
+  // Cardinality is bounded by the number of methods declared on the service (~10-30).
+  struct PerMethodCounters {
+    scoped_refptr<Counter> added;
+    scoped_refptr<Counter> overflow;
+  };
+
+  PerMethodCounters* GetPerMethodCounters(Slice method_name) EXCLUDES(per_method_mutex_) {
+    auto method_str = method_name.ToBuffer();
+    {
+      SharedLock<std::shared_mutex> lock(per_method_mutex_);
+      auto it = per_method_counters_.find(method_str);
+      if (PREDICT_TRUE(it != per_method_counters_.end())) {
+        return &it->second;
+      }
+    }
+    std::lock_guard lock(per_method_mutex_);
+    auto it = per_method_counters_.find(method_str);
+    if (it != per_method_counters_.end()) {
+      return &it->second;
+    }
+    if (per_method_counters_.size() >= kMaxPerMethodMetrics) {
+      return nullptr;
+    }
+    auto [new_it, inserted] = per_method_counters_.try_emplace(std::move(method_str));
+    if (inserted) {
+      new_it->second = MakePerMethodCounters(new_it->first);
+    }
+    return &new_it->second;
+  }
+
+  PerMethodCounters MakePerMethodCounters(const std::string& method) REQUIRES(per_method_mutex_) {
+    return {
+        .added = MakeCounter("rpcs_added_to_queue", method,
+                             "RPCs added to the service queue, by method"),
+        .overflow = MakeCounter("rpcs_queue_overflow", method,
+                                "RPCs dropped because the service queue was full, by method"),
+    };
+  }
+
+  scoped_refptr<Counter> MakeCounter(
+      const std::string& base_name, const std::string& method, const std::string& description) {
+    auto id = Format("$0_$1_$2", base_name, service_->metric_name(), method);
+    EscapeMetricNameForPrometheus(&id);
+    auto label = Format("$0 ($1::$2)", description, service_->service_name(), method);
+    return metric_entity_->FindOrCreateMetric<Counter>(
+        std::shared_ptr<CounterPrototype>(new OwningCounterPrototype(
+            metric_entity_->prototype().name(), id, label, MetricUnit::kRequests, description,
+            MetricLevel::kInfo)));
   }
 
   const size_t max_queued_calls_;
   ThreadPoolProvider thread_pool_provider_;
   Scheduler& scheduler_;
   ServiceIfPtr service_;
+  scoped_refptr<MetricEntity> metric_entity_;
   scoped_refptr<EventStats> incoming_queue_time_;
   scoped_refptr<Counter> rpcs_timed_out_in_queue_;
   scoped_refptr<Counter> rpcs_timed_out_early_in_queue_;
   scoped_refptr<Counter> rpcs_queue_overflow_;
+  scoped_refptr<Counter> rpcs_added_to_queue_;
+  scoped_refptr<Counter> rpcs_dequeued_;
+  scoped_refptr<Counter> rpcs_started_processing_;
   scoped_refptr<AtomicGauge<int64_t>> rpcs_in_queue_;
+  std::shared_mutex per_method_mutex_;
+  std::unordered_map<std::string, PerMethodCounters> per_method_counters_
+      GUARDED_BY(per_method_mutex_);
   // Have to use CoarseDuration here, since CoarseTimePoint does not work with clang + libstdc++
   std::atomic<CoarseDuration> last_backpressure_at_{CoarseTimePoint().time_since_epoch()};
   std::atomic<int64_t> queued_calls_{0};

--- a/src/yb/rpc/service_pool.cc
+++ b/src/yb/rpc/service_pool.cc
@@ -134,10 +134,13 @@ namespace {
 const CoarseDuration kTimeoutCheckGranularity = 100ms;
 const char* const kTimedOutInQueue = "Call waited in the queue past deadline";
 
-// The maximum number of distinct method names we will emit per-method metrics for.
-// In reality, we won't even come close to this number. This is just a safety measure
-// against DoS attacks (e.g. an attacker sending garbage method names in RPC headers
-// to unbounded-grow our metrics map and exhaust memory).
+// Hard cap on the number of distinct method names for which we emit per-method metrics.
+// Real services declare ~10-30 methods, so this is effectively unreachable in normal
+// operation. The cap exists purely as a safety net against pathological inputs that
+// could otherwise grow per_method_counters_ without bound (e.g. an attacker spraying
+// garbage method names in RPC headers, or a misconfigured / buggy peer that does the
+// same accidentally). When the cap is reached we silently drop per-method metric
+// granularity for new names; the aggregate counters keep working.
 constexpr size_t kMaxPerMethodMetrics = 1000;
 
 } // namespace
@@ -228,6 +231,12 @@ class ServicePoolImpl final : public InboundCallHandler {
       return;
     }
 
+    // Note: rpcs_in_queue_ is already incremented inside CallQueued() (called via
+    // BindTask above) before we get here. As a result, a Prometheus scrape that races
+    // with us can momentarily observe rpcs_in_queue_ == rpcs_added_to_queue_ -
+    // rpcs_dequeued_ + 1. Reordering would require pulling rpcs_in_queue_->Increment()
+    // out of CallQueued(), which complicates the rollback-on-overflow path; the brief
+    // skew is acceptable for monitoring purposes.
     rpcs_added_to_queue_->Increment();
     if (auto* per_method_counters = GetPerMethodCounters(call->method_name())) {
       per_method_counters->added->Increment();
@@ -455,12 +464,18 @@ class ServicePoolImpl final : public InboundCallHandler {
   }
 
   // Per-RPC-method counters. Lazily registered on first occurrence of each method name.
-  // Cardinality is bounded by the number of methods declared on the service (~10-30).
+  // In normal operation cardinality is the number of methods declared on the service
+  // (typically ~10-30); kMaxPerMethodMetrics is the absolute upper bound enforced as a
+  // safety net (see comment on the constant).
   struct PerMethodCounters {
     scoped_refptr<Counter> added;
     scoped_refptr<Counter> overflow;
   };
 
+  // TODO(#31673): once Abseil containers are available we should migrate
+  // per_method_counters_ to absl::flat_hash_map with a transparent string hash, which
+  // would let the hot lookup path skip the per-call Slice->std::string allocation
+  // performed below.
   PerMethodCounters* GetPerMethodCounters(Slice method_name) EXCLUDES(per_method_mutex_) {
     auto method_str = method_name.ToBuffer();
     {
@@ -476,6 +491,13 @@ class ServicePoolImpl final : public InboundCallHandler {
       return &it->second;
     }
     if (per_method_counters_.size() >= kMaxPerMethodMetrics) {
+      // Log at most once every 60s so a runaway / hostile peer can't drown the log,
+      // but visibility of "we are no longer creating per-method metrics" is preserved.
+      YB_LOG_EVERY_N_SECS(WARNING, 60)
+          << LogPrefix()
+          << "Reached the per-service-pool cap of " << kMaxPerMethodMetrics
+          << " distinct RPC method names; new method '" << method_str
+          << "' will not get its own per-method metrics. Aggregate counters are unaffected.";
       return nullptr;
     }
     auto [new_it, inserted] = per_method_counters_.try_emplace(std::move(method_str));
@@ -494,6 +516,13 @@ class ServicePoolImpl final : public InboundCallHandler {
     };
   }
 
+  // MakeCounter assumes that this ServicePoolImpl is the sole owner of `metric_entity_`
+  // for the synthesized metric name. MetricEntity::FindOrCreateMetric keys its dedup map
+  // by prototype pointer (not by name), and we allocate a fresh OwningCounterPrototype on
+  // every call, so two ServicePoolImpl instances sharing the same entity would register
+  // two distinct Counter objects under the same Prometheus name. In current YB usage each
+  // ServicePoolImpl is constructed with its own dedicated MetricEntity, so this is safe;
+  // revisit if that invariant ever changes.
   scoped_refptr<Counter> MakeCounter(
       const std::string& base_name, const std::string& method, const std::string& description) {
     auto id = Format("$0_$1_$2", base_name, service_->metric_name(), method);


### PR DESCRIPTION
## Summary

**This is the first of three planned PRs for [#26369](https://github.com/yugabyte/yugabyte-db/issues/26369). It is intentionally minimal so it can land without a wider design discussion. PR2 adds the high-water-mark gauge plus rate-limited diagnostic logs; PR3 adds stack-dump + per-RPC worker labelling for shared thread pools.**

### Motivation

Today the only cumulative counter we publish for a per-service RPC queue is `rpcs_queue_overflow`, which only fires once the queue is already full. The current depth is exposed as the `rpcs_in_queue_<service>` gauge, but by the time we see a sustained non-zero value in a Prometheus scrape we usually no longer know whether the queue grew because of an arrival surge (calls coming in faster than they can be serviced) or because of slow draining (handlers stuck on something downstream). #26369 asks for richer instrumentation so support can answer that question post-mortem.

### What this PR adds

Three monotonic per-service-pool counters in `ServicePoolImpl`:

- `rpcs_added_to_queue` — bumped in `Process()` once `BindTask()` succeeds, before the task is enqueued on the worker thread pool. Diffed against `rpcs_started_processing` over a window, it cleanly answers "input rate vs. service rate".
- `rpcs_dequeued` — bumped in `CallDequeued()`, which fires when an RPC leaves the queue for any reason (picked up by a worker or popped because it timed out).
- `rpcs_started_processing` — bumped in `Handle()` immediately before the service handler runs. `rpcs_dequeued - rpcs_started_processing` approximates calls that were queued but discarded after being pulled off (timed-out-in-queue, dropped under high load, etc.).

Plus lazily-registered per-method counters:

- `rpcs_added_to_queue_<service>_<method>`
- `rpcs_queue_overflow_<service>_<method>`

These are created on first sighting of each method name, mirroring the naming pattern used by the existing `rpcs_in_queue_<service>` and the codegen-emitted `handler_latency_<service>_<method>`. In normal operation cardinality is the number of methods declared on the service (~10-30); the hard cap is `kMaxPerMethodMetrics = 1000` per pool, enforced purely as a safety net against pathological inputs (an attacker spraying garbage method names in RPC headers, etc.). Hitting the cap emits a `YB_LOG_EVERY_N_SECS(WARNING, 60)` so operators see we have lost per-method granularity rather than the situation being silent.

`per_method_counters_` is backed by `UnorderedStringMap<std::string, PerMethodCounters>` (a transparent-hash `std::unordered_map` from `gutil/stl_util.h`), which lets the steady-state `.find()` accept a `std::string_view` directly. The only allocation is on the very first sighting of each method name; subsequent hot-path lookups are zero-alloc.

### What this PR explicitly does NOT add (deferred to PR2/PR3)

- The `rpcs_queue_max_size` gauge that exposes `max_queued_calls_` so dashboards can plot "% full" — deferred to PR2 because it lands together with the high-water-mark gauge it pairs with.
- `rpcs_queue_high_water_mark` (running max of `rpcs_in_queue_`) — deferred to PR2.
- Rate-limited `WARNING` logs when queue depth crosses a configurable percentage of `max_queued_calls_`, including periodic top-K-by-method snapshots — deferred to PR2.
- Rate-limited stack dumps for service-pool worker threads with `(service, method)` labels — deferred to PR3, where the bigger discussion is how to identify which RPC each worker thread is processing when a single thread pool is shared across multiple services (e.g. tag-0 normal pool).

### Cost / risk

No flag changes, no proto changes, no API changes. The hot path picks up:

- Two atomic counter increments on every successfully-queued RPC (one aggregate, one per-method).
- One atomic counter increment in `CallDequeued` (one aggregate).
- One atomic counter increment in `Handle` immediately before the service handler runs (one aggregate).
- One shared-locked `unordered_map::find` per call with a `std::string_view` key — zero allocations on the steady-state path.

The `Counter::Increment` path is a single relaxed atomic add, so this is well below the noise floor of the surrounding RPC handling work.

## Test plan

- [x] Extended `MultiThreadedRpcTest.TestBlowOutServiceQueue` to assert exact values for the four aggregate counters (`overflow=1`, `added=2`, `dequeued=2`, `started=0`) — the existing 2-slot queue + 3-call + 0-worker scenario produces these deterministically.
- [x] Same test renders the metric registry through `PrometheusWriter` and greps for the three new aggregate metrics plus the two new per-method metric names — guards against a metric being wired into the entity but never emitted (wrong aggregation level, filtered by default `MetricPrometheusOptions`, etc.).
- [x] `mt-rpc-test` full suite passes locally on `fastdebug-clang21-dynamic-ninja`.
- [x] `rpc-test` full suite passes locally on `fastdebug-clang21-dynamic-ninja`.
- [ ] CI: full Jenkins / GitHub-Actions matrix.


---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31613/>)