### PR TITLE
[#31625] DocDB: Stack dumps with per-RPC labelling

### DIFF
--- a/src/yb/rpc/inbound_call.cc
+++ b/src/yb/rpc/inbound_call.cc
@@ -180,7 +180,7 @@ MonoDelta InboundCall::GetTimeInQueue() const {
 
 ThreadPoolTask* InboundCall::BindTask(InboundCallHandler* handler, int64_t rpc_queue_limit) {
   auto shared_this = shared_from(this);
-  std::optional<int64_t> rpc_queue_position = handler->CallQueued(rpc_queue_limit);
+  std::optional<int64_t> rpc_queue_position = handler->CallQueued(this, rpc_queue_limit);
   if (!rpc_queue_position) {
     return nullptr;
   }

--- a/src/yb/rpc/inbound_call.h
+++ b/src/yb/rpc/inbound_call.h
@@ -77,9 +77,11 @@ class InboundCallHandler {
 
   virtual void Failure(const InboundCallPtr& call, const Status& status) = 0;
 
-  virtual std::optional<int64_t> CallQueued(int64_t rpc_queue_limit) = 0;
+  virtual std::optional<int64_t> CallQueued(InboundCall* call, int64_t rpc_queue_limit) = 0;
 
   virtual void CallDequeued(InboundCall* call) = 0;
+
+  virtual std::string name() const { return ""; }
 
  protected:
   ~InboundCallHandler() = default;
@@ -316,6 +318,17 @@ class InboundCall : public RpcCall, public MPSCQueueEntry<InboundCall> {
     void Run() override;
 
     void Done(const Status& status) override;
+
+    std::string ToString() const override {
+      if (call_) {
+        std::string res = call_->method_name().ToBuffer();
+        if (handler_ && !handler_->name().empty()) {
+          res += " (source: " + handler_->name() + ")";
+        }
+        return res;
+      }
+      return "";
+    }
 
     ~InboundCallTask() override = default;
 

--- a/src/yb/rpc/inbound_call.h
+++ b/src/yb/rpc/inbound_call.h
@@ -79,7 +79,7 @@ class InboundCallHandler {
 
   virtual std::optional<int64_t> CallQueued(int64_t rpc_queue_limit) = 0;
 
-  virtual void CallDequeued() = 0;
+  virtual void CallDequeued(InboundCall* call) = 0;
 
  protected:
   ~InboundCallHandler() = default;
@@ -193,10 +193,18 @@ class InboundCall : public RpcCall, public MPSCQueueEntry<InboundCall> {
       return false;
     }
     if (tracker_) {
-      tracker_->CallDequeued();
+      tracker_->CallDequeued(this);
     }
     return true;
   }
+
+  // Opaque per-call data slot reserved for the InboundCallHandler that owns this call.
+  // The handler is responsible for type-safety: it sets `tracker_data` to whatever
+  // pointer it wants to retrieve later in CallDequeued(this) (e.g. a per-method counter
+  // pointer cached from the queue-side lookup). The slot is never touched by InboundCall
+  // itself and lives for the lifetime of the call.
+  void set_tracker_data(void* data) { tracker_data_ = data; }
+  void* tracker_data() const { return tracker_data_; }
 
   std::string LogPrefix() const override;
 
@@ -318,6 +326,7 @@ class InboundCall : public RpcCall, public MPSCQueueEntry<InboundCall> {
 
   InboundCallTask task_;
   InboundCallHandler* tracker_ = nullptr;
+  void* tracker_data_ = nullptr;
 
   size_t method_index_ = 0;
   int64_t rpc_queue_position_ = -1;

--- a/src/yb/rpc/mt-rpc-test.cc
+++ b/src/yb/rpc/mt-rpc-test.cc
@@ -56,7 +56,7 @@ METRIC_DECLARE_counter(rpcs_queue_overflow);
 METRIC_DECLARE_counter(rpcs_added_to_queue);
 METRIC_DECLARE_counter(rpcs_dequeued);
 METRIC_DECLARE_counter(rpcs_started_processing);
-METRIC_DECLARE_gauge_int64(rpc_queue_max_size);
+METRIC_DECLARE_gauge_int64(rpcs_queue_max_size);
 METRIC_DECLARE_gauge_int64(rpcs_queue_high_water_mark);
 
 using std::string;
@@ -259,7 +259,7 @@ TEST_F(MultiThreadedRpcTest, TestBlowOutServiceQueue) {
   scoped_refptr<Counter> started =
       METRIC_rpcs_started_processing.Instantiate(metric_entity());
   auto max_size = metric_entity()->FindOrNull<AtomicGauge<int64_t>>(
-      METRIC_rpc_queue_max_size);
+      METRIC_rpcs_queue_max_size);
   auto hwm = metric_entity()->FindOrNull<FunctionGauge<int64_t>>(
       METRIC_rpcs_queue_high_water_mark);
 
@@ -270,8 +270,9 @@ TEST_F(MultiThreadedRpcTest, TestBlowOutServiceQueue) {
   ASSERT_TRUE(max_size);
   EXPECT_EQ(2, max_size->value());
   ASSERT_TRUE(hwm);
-  EXPECT_GE(hwm->value(), 2);
-  EXPECT_LE(hwm->value(), 3);
+  // Exactly 2 -- the rejected 3rd call is gated by HighWaterMark::fetch_add_if_below()
+  // and therefore never speculatively bumps the gauge past max_queued_calls_.
+  EXPECT_EQ(2, hwm->value());
 
   // The new metrics should also show up in a Prometheus scrape, including the lazily-created
   // per-method counters for "Add". This guards against regressions where a metric is wired into
@@ -283,17 +284,47 @@ TEST_F(MultiThreadedRpcTest, TestBlowOutServiceQueue) {
   ASSERT_OK(metric_registry()->WriteForPrometheus(&prom_writer, prom_opts));
   const std::string prom_text = prom_output.str();
   for (const char* metric_name : {
-           "rpc_queue_max_size",
+           "rpcs_queue_max_size",
            "rpcs_queue_high_water_mark",
            "rpcs_added_to_queue",
            "rpcs_dequeued",
            "rpcs_started_processing",
            "rpcs_added_to_queue_yb_rpc_test_CalculatorService_Add",
            "rpcs_queue_overflow_yb_rpc_test_CalculatorService_Add",
+           "rpcs_in_queue_yb_rpc_test_CalculatorService_Add",
        }) {
     EXPECT_NE(prom_text.find(metric_name), std::string::npos)
         << "Metric '" << metric_name << "' missing from Prometheus output. Full output:\n"
         << prom_text;
+  }
+
+  // Leak-free invariant for per-method currently_queued gauges (PR2 review item 2).
+  // At this point the thread pool has been shut down, all queued tasks have flowed
+  // through Done()/Failure()/TryStartProcessing() -> CallDequeued(), and every increment
+  // performed in ServicePool::Process() must have been matched by a Decrement() via the
+  // pmc pointer stashed on the InboundCall. If this asserts non-zero, the increment and
+  // its paired decrement have desynchronized somewhere -- typically a refactor that
+  // dropped set_tracker_data() or that bypassed TryStartProcessing().
+  //
+  // Prometheus text-format lines look like:
+  //   <metric_name>{<labels>} <value> <timestamp>
+  // so we anchor on the metric name + '{' and read the integer after the closing brace.
+  {
+    const std::string anchor =
+        "rpcs_in_queue_yb_rpc_test_CalculatorService_Add{";
+    auto pos = prom_text.find(anchor);
+    ASSERT_NE(pos, std::string::npos)
+        << "Per-method currently_queued gauge not exported. Full output:\n" << prom_text;
+    auto value_start = prom_text.find("} ", pos);
+    ASSERT_NE(value_start, std::string::npos);
+    value_start += 2;  // skip "} "
+    auto value_end = prom_text.find(' ', value_start);
+    ASSERT_NE(value_end, std::string::npos);
+    int64_t value = std::stoll(prom_text.substr(value_start, value_end - value_start));
+    EXPECT_EQ(0, value)
+        << "Per-method currently_queued gauge leaked after worker thread pool was "
+        << "drained. Some path in ServicePoolImpl is incrementing currently_queued "
+        << "without a paired CallDequeued()-driven decrement.";
   }
 }
 

--- a/src/yb/rpc/mt-rpc-test.cc
+++ b/src/yb/rpc/mt-rpc-test.cc
@@ -56,6 +56,8 @@ METRIC_DECLARE_counter(rpcs_queue_overflow);
 METRIC_DECLARE_counter(rpcs_added_to_queue);
 METRIC_DECLARE_counter(rpcs_dequeued);
 METRIC_DECLARE_counter(rpcs_started_processing);
+METRIC_DECLARE_gauge_int64(rpc_queue_max_size);
+METRIC_DECLARE_gauge_int64(rpcs_queue_high_water_mark);
 
 using std::string;
 using std::shared_ptr;
@@ -256,10 +258,20 @@ TEST_F(MultiThreadedRpcTest, TestBlowOutServiceQueue) {
       METRIC_rpcs_dequeued.Instantiate(metric_entity());
   scoped_refptr<Counter> started =
       METRIC_rpcs_started_processing.Instantiate(metric_entity());
+  auto max_size = metric_entity()->FindOrNull<AtomicGauge<int64_t>>(
+      METRIC_rpc_queue_max_size);
+  auto hwm = metric_entity()->FindOrNull<FunctionGauge<int64_t>>(
+      METRIC_rpcs_queue_high_water_mark);
+
   EXPECT_EQ(1, overflow->value());
   EXPECT_EQ(2, added->value());
   EXPECT_EQ(2, dequeued->value());
   EXPECT_EQ(0, started->value());
+  ASSERT_TRUE(max_size);
+  EXPECT_EQ(2, max_size->value());
+  ASSERT_TRUE(hwm);
+  EXPECT_GE(hwm->value(), 2);
+  EXPECT_LE(hwm->value(), 3);
 
   // The new metrics should also show up in a Prometheus scrape, including the lazily-created
   // per-method counters for "Add". This guards against regressions where a metric is wired into
@@ -271,6 +283,8 @@ TEST_F(MultiThreadedRpcTest, TestBlowOutServiceQueue) {
   ASSERT_OK(metric_registry()->WriteForPrometheus(&prom_writer, prom_opts));
   const std::string prom_text = prom_output.str();
   for (const char* metric_name : {
+           "rpc_queue_max_size",
+           "rpcs_queue_high_water_mark",
            "rpcs_added_to_queue",
            "rpcs_dequeued",
            "rpcs_started_processing",

--- a/src/yb/rpc/mt-rpc-test.cc
+++ b/src/yb/rpc/mt-rpc-test.cc
@@ -44,6 +44,7 @@
 
 #include "yb/util/countdown_latch.h"
 #include "yb/util/metrics.h"
+#include "yb/util/metrics_writer.h"
 #include "yb/util/net/net_util.h"
 #include "yb/util/status_log.h"
 #include "yb/util/test_macros.h"
@@ -52,6 +53,9 @@
 
 METRIC_DECLARE_counter(rpc_connections_accepted);
 METRIC_DECLARE_counter(rpcs_queue_overflow);
+METRIC_DECLARE_counter(rpcs_added_to_queue);
+METRIC_DECLARE_counter(rpcs_dequeued);
+METRIC_DECLARE_counter(rpcs_started_processing);
 
 using std::string;
 using std::shared_ptr;
@@ -241,10 +245,42 @@ TEST_F(MultiThreadedRpcTest, TestBlowOutServiceQueue) {
   ASSERT_EQ(1, errors_backpressure);
   ASSERT_EQ(2, errors_shutdown);
 
-  // Check that RPC queue overflow metric is 1
-  Counter *rpcs_queue_overflow =
-    METRIC_rpcs_queue_overflow.Instantiate(metric_entity()).get();
-  ASSERT_EQ(1, rpcs_queue_overflow->value());
+  // The aggregate counters should reflect: 2 calls successfully queued and 1 call rejected
+  // due to backpressure. The two queued calls are also dequeued during shutdown but never
+  // start processing because the thread pool has zero workers.
+  scoped_refptr<Counter> overflow =
+      METRIC_rpcs_queue_overflow.Instantiate(metric_entity());
+  scoped_refptr<Counter> added =
+      METRIC_rpcs_added_to_queue.Instantiate(metric_entity());
+  scoped_refptr<Counter> dequeued =
+      METRIC_rpcs_dequeued.Instantiate(metric_entity());
+  scoped_refptr<Counter> started =
+      METRIC_rpcs_started_processing.Instantiate(metric_entity());
+  EXPECT_EQ(1, overflow->value());
+  EXPECT_EQ(2, added->value());
+  EXPECT_EQ(2, dequeued->value());
+  EXPECT_EQ(0, started->value());
+
+  // The new metrics should also show up in a Prometheus scrape, including the lazily-created
+  // per-method counters for "Add". This guards against regressions where a metric is wired into
+  // a service pool but never makes it through PrometheusWriter (e.g. wrong aggregation level,
+  // missing label, or filtered out by default options).
+  std::stringstream prom_output;
+  MetricPrometheusOptions prom_opts;
+  PrometheusWriter prom_writer(&prom_output, prom_opts);
+  ASSERT_OK(metric_registry()->WriteForPrometheus(&prom_writer, prom_opts));
+  const std::string prom_text = prom_output.str();
+  for (const char* metric_name : {
+           "rpcs_added_to_queue",
+           "rpcs_dequeued",
+           "rpcs_started_processing",
+           "rpcs_added_to_queue_yb_rpc_test_CalculatorService_Add",
+           "rpcs_queue_overflow_yb_rpc_test_CalculatorService_Add",
+       }) {
+    EXPECT_NE(prom_text.find(metric_name), std::string::npos)
+        << "Metric '" << metric_name << "' missing from Prometheus output. Full output:\n"
+        << prom_text;
+  }
 }
 
 static void HammerServerWithTCPConns(const Endpoint& addr) {

--- a/src/yb/rpc/rpc-test-base.h
+++ b/src/yb/rpc/rpc-test-base.h
@@ -230,6 +230,7 @@ class RpcTestBase : public YBTest {
   Messenger* server_messenger() const { return server_->messenger(); }
   TestServer& server() const { return *server_; }
   const scoped_refptr<MetricEntity>& metric_entity() const { return metric_entity_; }
+  MetricRegistry* metric_registry() { return &metric_registry_; }
 
  private:
   MetricRegistry metric_registry_;

--- a/src/yb/rpc/service_pool.cc
+++ b/src/yb/rpc/service_pool.cc
@@ -201,9 +201,9 @@ class ServicePoolImpl final : public InboundCallHandler {
           EscapeMetricNameForPrometheus(&id);
           string description = id + " metric for ServicePoolImpl";
           rpcs_in_queue_ = entity->FindOrCreateMetric<AtomicGauge<int64_t>>(
-              std::shared_ptr<GaugePrototype<int64_t>>(new OwningGaugePrototype<int64_t>(
+              std::make_shared<OwningGaugePrototype<int64_t>>(
                   entity->prototype().name(), std::move(id),
-                  description, MetricUnit::kRequests, description, MetricLevel::kInfo)),
+                  description, MetricUnit::kRequests, description, MetricLevel::kInfo),
               static_cast<int64>(0) /* initial_value */);
 
           rpcs_queue_max_size_ = METRIC_rpcs_queue_max_size.Instantiate(entity, max_queued_calls_);
@@ -555,19 +555,27 @@ class ServicePoolImpl final : public InboundCallHandler {
     if (pct > 0) {
       size_t threshold = (max_queued_calls_ * pct) / 100;
       // queued_calls is the pre-add value; the actual post-add queue depth is +1.
-      int64_t new_depth = queued_calls + 1;
-      if (implicit_cast<size_t>(new_depth) >= threshold) {
-        auto thread_pool = thread_pool_provider_(call->pool_tag());
-        std::string thread_stacks;
-        if (thread_pool) {
-          thread_pool->DumpThreadStacks(&thread_stacks);
+      if (implicit_cast<size_t>(queued_calls + 1) >= threshold) {
+        // Use an explicit LogThrottler (rather than YB_LOG_EVERY_N_SECS) so that the
+        // expensive DumpThreadStacks() call is also gated by the throttle; the macro
+        // version would still pay the cost of the signal-based stack capture before
+        // discarding the log line.
+        static logging_internal::LogThrottler throttler;
+        int suppressed = throttler.ShouldLog(5);
+        if (suppressed >= 0) {
+          auto thread_pool = thread_pool_provider_(call->pool_tag());
+          std::string thread_stacks;
+          if (thread_pool) {
+            thread_pool->DumpThreadStacks(&thread_stacks);
+          }
+          LOG(WARNING) << LogPrefix()
+              << "Queue depth " << (queued_calls + 1) << " exceeds threshold of "
+              << threshold << " (" << pct << "% of " << max_queued_calls_ << "). "
+              << DumpTopKMethods() << "\n"
+              << "Thread pool stacks:\n"
+              << thread_stacks
+              << (suppressed > 0 ? Format(" [suppressed $0 similar messages]", suppressed) : "");
         }
-        YB_LOG_EVERY_N_SECS(WARNING, 5) << LogPrefix()
-            << "Queue depth " << new_depth << " exceeds threshold of "
-            << threshold << " (" << pct << "% of " << max_queued_calls_ << "). "
-            << DumpTopKMethods() << "\n"
-            << "Thread pool stacks:\n"
-            << thread_stacks;
       }
     }
 
@@ -672,9 +680,9 @@ class ServicePoolImpl final : public InboundCallHandler {
     EscapeMetricNameForPrometheus(&id);
     auto label = Format("$0 ($1::$2)", description, service_->service_name(), method);
     return metric_entity_->FindOrCreateMetric<Counter>(
-        std::shared_ptr<CounterPrototype>(new OwningCounterPrototype(
+        std::make_shared<OwningCounterPrototype>(
             metric_entity_->prototype().name(), id, label, MetricUnit::kRequests, description,
-            MetricLevel::kInfo)));
+            MetricLevel::kInfo));
   }
 
   scoped_refptr<AtomicGauge<int64_t>> MakeGauge(

--- a/src/yb/rpc/service_pool.cc
+++ b/src/yb/rpc/service_pool.cc
@@ -45,6 +45,7 @@
 
 #include "yb/gutil/atomicops.h"
 #include "yb/gutil/ref_counted.h"
+#include "yb/gutil/stl_util.h"
 #include "yb/gutil/strings/substitute.h"
 
 #include "yb/rpc/inbound_call.h"
@@ -472,21 +473,29 @@ class ServicePoolImpl final : public InboundCallHandler {
     scoped_refptr<Counter> overflow;
   };
 
+  // The hot (steady-state) lookup path does a heterogeneous std::string_view lookup
+  // against per_method_counters_ under a SharedLock, so it does not allocate. We only
+  // materialize a std::string when we are about to insert a new entry (i.e. the first
+  // time we see a given method name on this service pool). See TransparentStringMap
+  // alias below.
+  //
   // TODO(#31673): once Abseil containers are available we should migrate
-  // per_method_counters_ to absl::flat_hash_map with a transparent string hash, which
-  // would let the hot lookup path skip the per-call Slice->std::string allocation
-  // performed below.
+  // per_method_counters_ to absl::flat_hash_map; the transparent-hash lookup story is
+  // already solved, so #31673 is now a cache-locality / open-addressing improvement
+  // rather than a fix for any per-call allocation.
   PerMethodCounters* GetPerMethodCounters(Slice method_name) EXCLUDES(per_method_mutex_) {
-    auto method_str = method_name.ToBuffer();
+    const std::string_view method_sv = method_name.AsStringView();
     {
       SharedLock<std::shared_mutex> lock(per_method_mutex_);
-      auto it = per_method_counters_.find(method_str);
+      auto it = per_method_counters_.find(method_sv);
       if (PREDICT_TRUE(it != per_method_counters_.end())) {
         return &it->second;
       }
     }
     std::lock_guard lock(per_method_mutex_);
-    auto it = per_method_counters_.find(method_str);
+    // Double-check after upgrading to the exclusive lock; someone else may have inserted
+    // this method's entry between the shared-lock release and the exclusive-lock acquire.
+    auto it = per_method_counters_.find(method_sv);
     if (it != per_method_counters_.end()) {
       return &it->second;
     }
@@ -496,11 +505,12 @@ class ServicePoolImpl final : public InboundCallHandler {
       YB_LOG_EVERY_N_SECS(WARNING, 60)
           << LogPrefix()
           << "Reached the per-service-pool cap of " << kMaxPerMethodMetrics
-          << " distinct RPC method names; new method '" << method_str
+          << " distinct RPC method names; new method '" << method_sv
           << "' will not get its own per-method metrics. Aggregate counters are unaffected.";
       return nullptr;
     }
-    auto [new_it, inserted] = per_method_counters_.try_emplace(std::move(method_str));
+    // Miss path: allocate the std::string only now, for use as the map key.
+    auto [new_it, inserted] = per_method_counters_.try_emplace(std::string(method_sv));
     if (inserted) {
       new_it->second = MakePerMethodCounters(new_it->first);
     }
@@ -548,7 +558,10 @@ class ServicePoolImpl final : public InboundCallHandler {
   scoped_refptr<Counter> rpcs_started_processing_;
   scoped_refptr<AtomicGauge<int64_t>> rpcs_in_queue_;
   std::shared_mutex per_method_mutex_;
-  std::unordered_map<std::string, PerMethodCounters> per_method_counters_
+  // UnorderedStringMap pairs StringHash (with is_transparent) and std::equal_to<void>
+  // so that the steady-state .find() call can accept a std::string_view without
+  // synthesizing a temporary std::string. See GetPerMethodCounters().
+  UnorderedStringMap<std::string, PerMethodCounters> per_method_counters_
       GUARDED_BY(per_method_mutex_);
   // Have to use CoarseDuration here, since CoarseTimePoint does not work with clang + libstdc++
   std::atomic<CoarseDuration> last_backpressure_at_{CoarseTimePoint().time_since_epoch()};

--- a/src/yb/rpc/service_pool.cc
+++ b/src/yb/rpc/service_pool.cc
@@ -54,6 +54,7 @@
 
 #include "yb/util/countdown_latch.h"
 #include "yb/util/flags.h"
+#include "yb/util/high_water_mark.h"
 #include "yb/util/lockfree.h"
 #include "yb/util/logging.h"
 #include "yb/util/metrics.h"
@@ -78,6 +79,11 @@ TAG_FLAG(backpressure_recovery_period_ms, advanced);
 DEFINE_test_flag(bool, enable_backpressure_mode_for_testing, false,
             "For testing purposes. Enables the rpc's to be considered timed out in the queue even "
             "when we have not had any backpressure in the recent past.");
+
+DEFINE_RUNTIME_int32(rpc_queue_high_watermark_pct, 0,
+    "Threshold (percentage of queue capacity) at which to start logging diagnostic "
+    "warnings for high RPC queue depth. A value of 0 (default) disables the logging.");
+TAG_FLAG(rpc_queue_high_watermark_pct, advanced);
 
 DECLARE_bool(TEST_ash_debug_aux);
 
@@ -126,6 +132,16 @@ METRIC_DEFINE_counter(server, rpcs_started_processing,
                       "Cumulative count of RPCs for which the service handler began executing. "
                       "rpcs_dequeued - rpcs_started_processing approximates the number of calls "
                       "discarded after dequeue (e.g. timed out in the queue).");
+
+METRIC_DEFINE_gauge_int64(server, rpc_queue_max_size,
+                           "RPC Queue Max Size",
+                           yb::MetricUnit::kRequests,
+                           "Maximum number of RPCs that can be queued before the service queue is considered full.");
+
+METRIC_DEFINE_gauge_int64(server, rpcs_queue_high_water_mark,
+                           "RPC Queue High Water Mark",
+                           yb::MetricUnit::kRequests,
+                           "Highest number of RPCs concurrently queued in the service queue.");
 
 namespace yb {
 namespace rpc {
@@ -180,10 +196,17 @@ class ServicePoolImpl final : public InboundCallHandler {
                   description, MetricUnit::kRequests, description, MetricLevel::kInfo)),
               static_cast<int64>(0) /* initial_value */);
 
+          rpc_queue_max_size_ = METRIC_rpc_queue_max_size.Instantiate(entity, max_queued_calls_);
+          rpcs_queue_high_water_mark_ = METRIC_rpcs_queue_high_water_mark.InstantiateFunctionGauge(
+              entity, Bind(&ServicePoolImpl::GetQueueHighWaterMark, Unretained(this)));
+
           LOG_WITH_PREFIX(INFO) << "yb::rpc::ServicePoolImpl created at " << this;
   }
 
   ~ServicePoolImpl() {
+    if (rpcs_queue_high_water_mark_) {
+      rpcs_queue_high_water_mark_->DetachToCurrentValue();
+    }
     StartShutdown();
     CompleteShutdown();
   }
@@ -195,6 +218,10 @@ class ServicePoolImpl final : public InboundCallHandler {
     }
     LOG_IF(DFATAL, !pre_check_timeout_queue_.Empty())
         << "Entries pushed to pre_check_timeout_queue_ after shutdown";
+  }
+
+  int64_t GetQueueHighWaterMark() const {
+    return queued_calls_.max_value();
   }
 
   void StartShutdown() {
@@ -442,6 +469,26 @@ class ServicePoolImpl final : public InboundCallHandler {
 
   const std::string& LogPrefix() const { return log_prefix_; }
 
+  std::string DumpTopKMethods() {
+    std::vector<std::pair<std::string, int64_t>> snapshot;
+    {
+      SharedLock<std::shared_mutex> lock(per_method_mutex_);
+      snapshot.reserve(per_method_counters_.size());
+      for (const auto& [method, counters] : per_method_counters_) {
+        snapshot.emplace_back(method, counters.added->value());
+      }
+    }
+    std::sort(snapshot.begin(), snapshot.end(),
+              [](const auto& a, const auto& b) { return a.second > b.second; });
+    std::string result = "Top methods by added RPCs: ";
+    int k = 0;
+    for (const auto& [method, count] : snapshot) {
+      if (k++ >= 5) break;
+      result += Format("$0=$1, ", method, count);
+    }
+    return result;
+  }
+
   std::optional<int64_t> CallQueued(int64_t rpc_queue_limit) override {
     auto queued_calls = queued_calls_.fetch_add(1, std::memory_order_acq_rel);
     if (queued_calls < 0) {
@@ -452,6 +499,17 @@ class ServicePoolImpl final : public InboundCallHandler {
     if (implicit_cast<size_t>(queued_calls) >= max_queued_calls) {
       queued_calls_.fetch_sub(1, std::memory_order_relaxed);
       return std::nullopt;
+    }
+
+    int pct = FLAGS_rpc_queue_high_watermark_pct;
+    if (pct > 0 && pct <= 100) {
+      size_t threshold = (max_queued_calls_ * pct) / 100;
+      if (implicit_cast<size_t>(queued_calls) >= threshold) {
+        YB_LOG_EVERY_N_SECS(WARNING, 5) << LogPrefix()
+            << "Queue depth " << queued_calls << " exceeds threshold of "
+            << threshold << " (" << pct << "% of " << max_queued_calls_ << "). "
+            << DumpTopKMethods();
+      }
     }
 
     rpcs_in_queue_->Increment();
@@ -557,6 +615,8 @@ class ServicePoolImpl final : public InboundCallHandler {
   scoped_refptr<Counter> rpcs_dequeued_;
   scoped_refptr<Counter> rpcs_started_processing_;
   scoped_refptr<AtomicGauge<int64_t>> rpcs_in_queue_;
+  scoped_refptr<AtomicGauge<int64_t>> rpc_queue_max_size_;
+  scoped_refptr<FunctionGauge<int64_t>> rpcs_queue_high_water_mark_;
   std::shared_mutex per_method_mutex_;
   // UnorderedStringMap pairs StringHash (with is_transparent) and std::equal_to<void>
   // so that the steady-state .find() call can accept a std::string_view without
@@ -565,7 +625,7 @@ class ServicePoolImpl final : public InboundCallHandler {
       GUARDED_BY(per_method_mutex_);
   // Have to use CoarseDuration here, since CoarseTimePoint does not work with clang + libstdc++
   std::atomic<CoarseDuration> last_backpressure_at_{CoarseTimePoint().time_since_epoch()};
-  std::atomic<int64_t> queued_calls_{0};
+  HighWaterMark queued_calls_{0};
 
   // It is too expensive to update timeout priority queue when each call is received.
   // So we are doing the following trick.

--- a/src/yb/rpc/service_pool.cc
+++ b/src/yb/rpc/service_pool.cc
@@ -52,7 +52,10 @@
 #include "yb/rpc/scheduler.h"
 #include "yb/rpc/service_if.h"
 
+#include "yb/gutil/strings/join.h"
+
 #include "yb/util/countdown_latch.h"
+#include "yb/util/flag_validators.h"
 #include "yb/util/flags.h"
 #include "yb/util/high_water_mark.h"
 #include "yb/util/lockfree.h"
@@ -82,8 +85,10 @@ DEFINE_test_flag(bool, enable_backpressure_mode_for_testing, false,
 
 DEFINE_RUNTIME_int32(rpc_queue_high_watermark_pct, 0,
     "Threshold (percentage of queue capacity) at which to start logging diagnostic "
-    "warnings for high RPC queue depth. A value of 0 (default) disables the logging.");
+    "warnings for high RPC queue depth. A value of 0 (default) disables the logging. "
+    "Valid range is [0, 100].");
 TAG_FLAG(rpc_queue_high_watermark_pct, advanced);
+DEFINE_validator(rpc_queue_high_watermark_pct, FLAG_RANGE_VALIDATOR(0, 100));
 
 DECLARE_bool(TEST_ash_debug_aux);
 
@@ -133,11 +138,15 @@ METRIC_DEFINE_counter(server, rpcs_started_processing,
                       "rpcs_dequeued - rpcs_started_processing approximates the number of calls "
                       "discarded after dequeue (e.g. timed out in the queue).");
 
-METRIC_DEFINE_gauge_int64(server, rpc_queue_max_size,
+METRIC_DEFINE_gauge_int64(server, rpcs_queue_max_size,
                            "RPC Queue Max Size",
                            yb::MetricUnit::kRequests,
                            "Maximum number of RPCs that can be queued before the service "
-                           "queue is considered full.");
+                           "queue is considered full. This is a constant per service pool "
+                           "(initialized from max_tasks at construction time and never "
+                           "modified at runtime); dashboards aggregating across nodes "
+                           "should treat it as a static configuration value rather than "
+                           "summing it.");
 
 METRIC_DEFINE_gauge_int64(server, rpcs_queue_high_water_mark,
                            "RPC Queue High Water Mark",
@@ -197,7 +206,7 @@ class ServicePoolImpl final : public InboundCallHandler {
                   description, MetricUnit::kRequests, description, MetricLevel::kInfo)),
               static_cast<int64>(0) /* initial_value */);
 
-          rpc_queue_max_size_ = METRIC_rpc_queue_max_size.Instantiate(entity, max_queued_calls_);
+          rpcs_queue_max_size_ = METRIC_rpcs_queue_max_size.Instantiate(entity, max_queued_calls_);
           rpcs_queue_high_water_mark_ = METRIC_rpcs_queue_high_water_mark.InstantiateFunctionGauge(
               entity, Bind(&ServicePoolImpl::GetQueueHighWaterMark, Unretained(this)));
 
@@ -219,6 +228,14 @@ class ServicePoolImpl final : public InboundCallHandler {
     }
     LOG_IF(DFATAL, !pre_check_timeout_queue_.Empty())
         << "Entries pushed to pre_check_timeout_queue_ after shutdown";
+    // Note: we deliberately do NOT DCHECK that per-method currently_queued gauges are
+    // zero here. ServicePoolImpl::CompleteShutdown() runs before the worker thread pool
+    // has necessarily drained (the thread pool is externally owned and shut down on a
+    // separate path, e.g. Messenger::Shutdown() or the test's own thread_pool->Shutdown()
+    // call), so calls already enqueued onto the worker pool may not yet have flowed
+    // through TryStartProcessing() -> CallDequeued(). The leak-free invariant is instead
+    // verified at the test boundary (see mt-rpc-test.cc TestBlowOutServiceQueue), after
+    // the worker thread pool has been drained.
   }
 
   int64_t GetQueueHighWaterMark() const {
@@ -268,7 +285,19 @@ class ServicePoolImpl final : public InboundCallHandler {
     // skew is acceptable for monitoring purposes.
     rpcs_added_to_queue_->Increment();
     if (auto* per_method_counters = GetPerMethodCounters(call->method_name())) {
+      // Leak-free invariant: every Increment() of currently_queued here MUST be paired
+      // with a matching Decrement() in CallDequeued(). We rely on:
+      //   (1) set_tracker_data() and the two Increment()s below being noexcept and
+      //       executed unconditionally together inside this `if`, so we never publish a
+      //       call as queued without also stashing the pmc pointer.
+      //   (2) Every queued call eventually transitioning through InboundCall::
+      //       TryStartProcessing() exactly once (guarded by processing_started_ CAS),
+      //       which is the sole caller of InboundCallHandler::CallDequeued().
+      // If any future refactor breaks either property, currently_queued will leak
+      // permanently for this method until the process restarts.
       per_method_counters->added->Increment();
+      per_method_counters->currently_queued->Increment();
+      call->set_tracker_data(per_method_counters);
     }
 
     auto call_deadline = call->GetClientDeadline();
@@ -470,44 +499,62 @@ class ServicePoolImpl final : public InboundCallHandler {
 
   const std::string& LogPrefix() const { return log_prefix_; }
 
+  // Renders a "what is currently filling this queue?" summary. We rank by the per-method
+  // `currently_queued` gauge rather than the cumulative `added` counter so that the log
+  // emitted at threshold-crossing time reflects what is actually in the queue right now
+  // (e.g. a small fraction of a slow handler), not the most-frequent method since process
+  // start (which after a few hours is almost always dominated by Heartbeat / Read).
+  static constexpr int kTopKMethods = 5;
   std::string DumpTopKMethods() {
     std::vector<std::pair<std::string, int64_t>> snapshot;
     {
       SharedLock<std::shared_mutex> lock(per_method_mutex_);
       snapshot.reserve(per_method_counters_.size());
       for (const auto& [method, counters] : per_method_counters_) {
-        snapshot.emplace_back(method, counters.added->value());
+        int64_t depth = counters.currently_queued->value();
+        if (depth > 0) {
+          snapshot.emplace_back(method, depth);
+        }
       }
     }
     std::sort(snapshot.begin(), snapshot.end(),
               [](const auto& a, const auto& b) { return a.second > b.second; });
-    std::string result = "Top methods by added RPCs: ";
-    int k = 0;
-    for (const auto& [method, count] : snapshot) {
-      if (k++ >= 5) break;
-      result += Format("$0=$1, ", method, count);
+    if (snapshot.size() > kTopKMethods) {
+      snapshot.resize(kTopKMethods);
     }
-    return result;
+    std::vector<std::string> parts;
+    parts.reserve(snapshot.size());
+    for (const auto& [method, count] : snapshot) {
+      parts.push_back(Format("$0=$1", method, count));
+    }
+    return Format("Top methods currently queued: $0", JoinStrings(parts, ", "));
   }
 
   std::optional<int64_t> CallQueued(int64_t rpc_queue_limit) override {
-    auto queued_calls = queued_calls_.fetch_add(1, std::memory_order_acq_rel);
+    size_t max_queued_calls = std::min(max_queued_calls_, implicit_cast<size_t>(rpc_queue_limit));
+    // Use the bounded fetch-add so that a rejected enqueue does NOT speculatively
+    // increment queued_calls_ above max_queued_calls and pollute the high-water-mark
+    // gauge. Returns the pre-add (queue-position) value on success.
+    auto queued_calls_opt = queued_calls_.fetch_add_if_below(
+        1, static_cast<int64_t>(max_queued_calls));
+    if (!queued_calls_opt) {
+      return std::nullopt;
+    }
+    int64_t queued_calls = *queued_calls_opt;
     if (queued_calls < 0) {
       YB_LOG_EVERY_N_SECS(DFATAL, 5) << "Negative number of queued calls: " << queued_calls;
     }
 
-    size_t max_queued_calls = std::min(max_queued_calls_, implicit_cast<size_t>(rpc_queue_limit));
-    if (implicit_cast<size_t>(queued_calls) >= max_queued_calls) {
-      queued_calls_.fetch_sub(1, std::memory_order_relaxed);
-      return std::nullopt;
-    }
-
     int pct = FLAGS_rpc_queue_high_watermark_pct;
-    if (pct > 0 && pct <= 100) {
+    // Range-checked at flag-set time via DEFINE_validator(FLAG_RANGE_VALIDATOR(0, 100)),
+    // so we trust the bounds here and only need the >0 fast-path check.
+    if (pct > 0) {
       size_t threshold = (max_queued_calls_ * pct) / 100;
-      if (implicit_cast<size_t>(queued_calls) >= threshold) {
+      // queued_calls is the pre-add value; the actual post-add queue depth is +1.
+      int64_t new_depth = queued_calls + 1;
+      if (implicit_cast<size_t>(new_depth) >= threshold) {
         YB_LOG_EVERY_N_SECS(WARNING, 5) << LogPrefix()
-            << "Queue depth " << queued_calls << " exceeds threshold of "
+            << "Queue depth " << new_depth << " exceeds threshold of "
             << threshold << " (" << pct << "% of " << max_queued_calls_ << "). "
             << DumpTopKMethods();
       }
@@ -517,19 +564,32 @@ class ServicePoolImpl final : public InboundCallHandler {
     return queued_calls;
   }
 
-  void CallDequeued() override {
+  void CallDequeued(InboundCall* call) override {
     queued_calls_.fetch_sub(1, std::memory_order_relaxed);
     rpcs_in_queue_->Decrement();
     rpcs_dequeued_->Increment();
+    // Pair with the increment in Process() above. The pmc pointer was stashed via
+    // call->set_tracker_data() in the same `if (auto* per_method_counters = ...)` block
+    // that incremented currently_queued; if it's non-null here, the increment happened
+    // and we must decrement it.
+    if (auto* pmc = static_cast<PerMethodCounters*>(call->tracker_data())) {
+      pmc->currently_queued->Decrement();
+    }
   }
 
   // Per-RPC-method counters. Lazily registered on first occurrence of each method name.
   // In normal operation cardinality is the number of methods declared on the service
   // (typically ~10-30); kMaxPerMethodMetrics is the absolute upper bound enforced as a
   // safety net (see comment on the constant).
+  //
+  // `currently_queued` is the per-method partition of rpcs_in_queue_: incremented in
+  // Process() when a call is successfully queued, decremented in CallDequeued() via the
+  // pmc pointer stashed on the InboundCall. See the leak-free invariant documented at
+  // the call sites.
   struct PerMethodCounters {
     scoped_refptr<Counter> added;
     scoped_refptr<Counter> overflow;
+    scoped_refptr<AtomicGauge<int64_t>> currently_queued;
   };
 
   // The hot (steady-state) lookup path does a heterogeneous std::string_view lookup
@@ -582,16 +642,19 @@ class ServicePoolImpl final : public InboundCallHandler {
                              "RPCs added to the service queue, by method"),
         .overflow = MakeCounter("rpcs_queue_overflow", method,
                                 "RPCs dropped because the service queue was full, by method"),
+        .currently_queued = MakeGauge("rpcs_in_queue", method,
+                                      "RPCs currently queued in the service queue, by method"),
     };
   }
 
-  // MakeCounter assumes that this ServicePoolImpl is the sole owner of `metric_entity_`
-  // for the synthesized metric name. MetricEntity::FindOrCreateMetric keys its dedup map
-  // by prototype pointer (not by name), and we allocate a fresh OwningCounterPrototype on
-  // every call, so two ServicePoolImpl instances sharing the same entity would register
-  // two distinct Counter objects under the same Prometheus name. In current YB usage each
-  // ServicePoolImpl is constructed with its own dedicated MetricEntity, so this is safe;
-  // revisit if that invariant ever changes.
+  // MakeCounter / MakeGauge assume that this ServicePoolImpl is the sole owner of
+  // `metric_entity_` for the synthesized metric name. MetricEntity::FindOrCreateMetric
+  // keys its dedup map by prototype pointer (not by name), and we allocate a fresh
+  // OwningCounterPrototype / OwningGaugePrototype on every call, so two ServicePoolImpl
+  // instances sharing the same entity would register two distinct Metric objects under
+  // the same Prometheus name. In current YB usage each ServicePoolImpl is constructed
+  // with its own dedicated MetricEntity, so this is safe; revisit if that invariant
+  // ever changes.
   scoped_refptr<Counter> MakeCounter(
       const std::string& base_name, const std::string& method, const std::string& description) {
     auto id = Format("$0_$1_$2", base_name, service_->metric_name(), method);
@@ -601,6 +664,18 @@ class ServicePoolImpl final : public InboundCallHandler {
         std::shared_ptr<CounterPrototype>(new OwningCounterPrototype(
             metric_entity_->prototype().name(), id, label, MetricUnit::kRequests, description,
             MetricLevel::kInfo)));
+  }
+
+  scoped_refptr<AtomicGauge<int64_t>> MakeGauge(
+      const std::string& base_name, const std::string& method, const std::string& description) {
+    auto id = Format("$0_$1_$2", base_name, service_->metric_name(), method);
+    EscapeMetricNameForPrometheus(&id);
+    auto label = Format("$0 ($1::$2)", description, service_->service_name(), method);
+    return metric_entity_->FindOrCreateMetric<AtomicGauge<int64_t>>(
+        std::shared_ptr<GaugePrototype<int64_t>>(new OwningGaugePrototype<int64_t>(
+            metric_entity_->prototype().name(), id, label, MetricUnit::kRequests, description,
+            MetricLevel::kInfo)),
+        static_cast<int64_t>(0) /* initial_value */);
   }
 
   const size_t max_queued_calls_;
@@ -616,7 +691,7 @@ class ServicePoolImpl final : public InboundCallHandler {
   scoped_refptr<Counter> rpcs_dequeued_;
   scoped_refptr<Counter> rpcs_started_processing_;
   scoped_refptr<AtomicGauge<int64_t>> rpcs_in_queue_;
-  scoped_refptr<AtomicGauge<int64_t>> rpc_queue_max_size_;
+  scoped_refptr<AtomicGauge<int64_t>> rpcs_queue_max_size_;
   scoped_refptr<FunctionGauge<int64_t>> rpcs_queue_high_water_mark_;
   std::shared_mutex per_method_mutex_;
   // UnorderedStringMap pairs StringHash (with is_transparent) and std::equal_to<void>

--- a/src/yb/rpc/service_pool.cc
+++ b/src/yb/rpc/service_pool.cc
@@ -321,6 +321,10 @@ class ServicePoolImpl final : public InboundCallHandler {
     return service_->service_name();
   }
 
+  std::string name() const override {
+    return service_name();
+  }
+
   ServiceIfPtr TEST_get_service() const {
     return service_;
   }
@@ -530,7 +534,7 @@ class ServicePoolImpl final : public InboundCallHandler {
     return Format("Top methods currently queued: $0", JoinStrings(parts, ", "));
   }
 
-  std::optional<int64_t> CallQueued(int64_t rpc_queue_limit) override {
+  std::optional<int64_t> CallQueued(InboundCall* call, int64_t rpc_queue_limit) override {
     size_t max_queued_calls = std::min(max_queued_calls_, implicit_cast<size_t>(rpc_queue_limit));
     // Use the bounded fetch-add so that a rejected enqueue does NOT speculatively
     // increment queued_calls_ above max_queued_calls and pollute the high-water-mark
@@ -553,10 +557,17 @@ class ServicePoolImpl final : public InboundCallHandler {
       // queued_calls is the pre-add value; the actual post-add queue depth is +1.
       int64_t new_depth = queued_calls + 1;
       if (implicit_cast<size_t>(new_depth) >= threshold) {
+        auto thread_pool = thread_pool_provider_(call->pool_tag());
+        std::string thread_stacks;
+        if (thread_pool) {
+          thread_pool->DumpThreadStacks(&thread_stacks);
+        }
         YB_LOG_EVERY_N_SECS(WARNING, 5) << LogPrefix()
             << "Queue depth " << new_depth << " exceeds threshold of "
             << threshold << " (" << pct << "% of " << max_queued_calls_ << "). "
-            << DumpTopKMethods();
+            << DumpTopKMethods() << "\n"
+            << "Thread pool stacks:\n"
+            << thread_stacks;
       }
     }
 

--- a/src/yb/rpc/service_pool.cc
+++ b/src/yb/rpc/service_pool.cc
@@ -59,6 +59,7 @@
 #include "yb/util/monotime.h"
 #include "yb/util/net/sockaddr.h"
 #include "yb/util/scope_exit.h"
+#include "yb/util/shared_lock.h"
 #include "yb/util/status.h"
 #include "yb/util/trace.h"
 
@@ -104,6 +105,27 @@ METRIC_DEFINE_counter(server, rpcs_queue_overflow,
                       "Number of RPCs dropped because the service queue "
                       "was full.");
 
+METRIC_DEFINE_counter(server, rpcs_added_to_queue,
+                      "RPCs Added To Service Queue",
+                      yb::MetricUnit::kRequests,
+                      "Cumulative count of RPCs that were successfully placed onto a service "
+                      "queue. Diff against rpcs_started_processing to tell whether the queue is "
+                      "growing because of an arrival surge or because of slow draining.");
+
+METRIC_DEFINE_counter(server, rpcs_dequeued,
+                      "RPCs Removed From Service Queue",
+                      yb::MetricUnit::kRequests,
+                      "Cumulative count of RPCs removed from a service queue. Includes both "
+                      "RPCs that were picked up for processing and RPCs that were popped off "
+                      "the queue because they had already timed out.");
+
+METRIC_DEFINE_counter(server, rpcs_started_processing,
+                      "RPCs That Started Service Handler",
+                      yb::MetricUnit::kRequests,
+                      "Cumulative count of RPCs for which the service handler began executing. "
+                      "rpcs_dequeued - rpcs_started_processing approximates the number of calls "
+                      "discarded after dequeue (e.g. timed out in the queue).");
+
 namespace yb {
 namespace rpc {
 
@@ -111,6 +133,12 @@ namespace {
 
 const CoarseDuration kTimeoutCheckGranularity = 100ms;
 const char* const kTimedOutInQueue = "Call waited in the queue past deadline";
+
+// The maximum number of distinct method names we will emit per-method metrics for.
+// In reality, we won't even come close to this number. This is just a safety measure
+// against DoS attacks (e.g. an attacker sending garbage method names in RPC headers
+// to unbounded-grow our metrics map and exhaust memory).
+constexpr size_t kMaxPerMethodMetrics = 1000;
 
 } // namespace
 
@@ -126,11 +154,15 @@ class ServicePoolImpl final : public InboundCallHandler {
         thread_pool_provider_(std::move(thread_pool_provider)),
         scheduler_(*scheduler),
         service_(std::move(service)),
+        metric_entity_(entity),
         incoming_queue_time_(METRIC_rpc_incoming_queue_time.Instantiate(entity)),
         rpcs_timed_out_in_queue_(METRIC_rpcs_timed_out_in_queue.Instantiate(entity)),
         rpcs_timed_out_early_in_queue_(
             METRIC_rpcs_timed_out_early_in_queue.Instantiate(entity)),
         rpcs_queue_overflow_(METRIC_rpcs_queue_overflow.Instantiate(entity)),
+        rpcs_added_to_queue_(METRIC_rpcs_added_to_queue.Instantiate(entity)),
+        rpcs_dequeued_(METRIC_rpcs_dequeued.Instantiate(entity)),
+        rpcs_started_processing_(METRIC_rpcs_started_processing.Instantiate(entity)),
         check_timeout_strand_(scheduler->io_service()),
         log_prefix_(Format("$0: ", service_->service_name())) {
 
@@ -196,6 +228,11 @@ class ServicePoolImpl final : public InboundCallHandler {
       return;
     }
 
+    rpcs_added_to_queue_->Increment();
+    if (auto* per_method_counters = GetPerMethodCounters(call->method_name())) {
+      per_method_counters->added->Increment();
+    }
+
     auto call_deadline = call->GetClientDeadline();
     if (call_deadline != CoarseTimePoint::max()) {
       pre_check_timeout_queue_.Push(new WeakInboundCall(std::move(call)));
@@ -233,6 +270,9 @@ class ServicePoolImpl final : public InboundCallHandler {
     YB_LOG_EVERY_N_SECS(WARNING, 3) << LogPrefix() << err_msg;
     const auto response_status = STATUS(ServiceUnavailable, err_msg);
     rpcs_queue_overflow_->Increment();
+    if (auto* per_method_counters = GetPerMethodCounters(call->method_name())) {
+      per_method_counters->overflow->Increment();
+    }
     call->RespondFailure(ErrorStatusPB::ERROR_SERVER_TOO_BUSY, response_status);
     last_backpressure_at_.store(
         CoarseMonoClock::Now().time_since_epoch(), std::memory_order_release);
@@ -272,6 +312,7 @@ class ServicePoolImpl final : public InboundCallHandler {
       error_message = "The server is overloaded. Call waited in the queue past max_time_in_queue.";
     } else {
       if (incoming->TryStartProcessing()) {
+        rpcs_started_processing_->Increment();
         TRACE_TO(incoming->trace(), "Handling call $0", AsString(incoming->method_name()));
         service_->Handle(std::move(incoming));
       }
@@ -410,17 +451,76 @@ class ServicePoolImpl final : public InboundCallHandler {
   void CallDequeued() override {
     queued_calls_.fetch_sub(1, std::memory_order_relaxed);
     rpcs_in_queue_->Decrement();
+    rpcs_dequeued_->Increment();
+  }
+
+  // Per-RPC-method counters. Lazily registered on first occurrence of each method name.
+  // Cardinality is bounded by the number of methods declared on the service (~10-30).
+  struct PerMethodCounters {
+    scoped_refptr<Counter> added;
+    scoped_refptr<Counter> overflow;
+  };
+
+  PerMethodCounters* GetPerMethodCounters(Slice method_name) EXCLUDES(per_method_mutex_) {
+    auto method_str = method_name.ToBuffer();
+    {
+      SharedLock<std::shared_mutex> lock(per_method_mutex_);
+      auto it = per_method_counters_.find(method_str);
+      if (PREDICT_TRUE(it != per_method_counters_.end())) {
+        return &it->second;
+      }
+    }
+    std::lock_guard lock(per_method_mutex_);
+    auto it = per_method_counters_.find(method_str);
+    if (it != per_method_counters_.end()) {
+      return &it->second;
+    }
+    if (per_method_counters_.size() >= kMaxPerMethodMetrics) {
+      return nullptr;
+    }
+    auto [new_it, inserted] = per_method_counters_.try_emplace(std::move(method_str));
+    if (inserted) {
+      new_it->second = MakePerMethodCounters(new_it->first);
+    }
+    return &new_it->second;
+  }
+
+  PerMethodCounters MakePerMethodCounters(const std::string& method) REQUIRES(per_method_mutex_) {
+    return {
+        .added = MakeCounter("rpcs_added_to_queue", method,
+                             "RPCs added to the service queue, by method"),
+        .overflow = MakeCounter("rpcs_queue_overflow", method,
+                                "RPCs dropped because the service queue was full, by method"),
+    };
+  }
+
+  scoped_refptr<Counter> MakeCounter(
+      const std::string& base_name, const std::string& method, const std::string& description) {
+    auto id = Format("$0_$1_$2", base_name, service_->metric_name(), method);
+    EscapeMetricNameForPrometheus(&id);
+    auto label = Format("$0 ($1::$2)", description, service_->service_name(), method);
+    return metric_entity_->FindOrCreateMetric<Counter>(
+        std::shared_ptr<CounterPrototype>(new OwningCounterPrototype(
+            metric_entity_->prototype().name(), id, label, MetricUnit::kRequests, description,
+            MetricLevel::kInfo)));
   }
 
   const size_t max_queued_calls_;
   ThreadPoolProvider thread_pool_provider_;
   Scheduler& scheduler_;
   ServiceIfPtr service_;
+  scoped_refptr<MetricEntity> metric_entity_;
   scoped_refptr<EventStats> incoming_queue_time_;
   scoped_refptr<Counter> rpcs_timed_out_in_queue_;
   scoped_refptr<Counter> rpcs_timed_out_early_in_queue_;
   scoped_refptr<Counter> rpcs_queue_overflow_;
+  scoped_refptr<Counter> rpcs_added_to_queue_;
+  scoped_refptr<Counter> rpcs_dequeued_;
+  scoped_refptr<Counter> rpcs_started_processing_;
   scoped_refptr<AtomicGauge<int64_t>> rpcs_in_queue_;
+  std::shared_mutex per_method_mutex_;
+  std::unordered_map<std::string, PerMethodCounters> per_method_counters_
+      GUARDED_BY(per_method_mutex_);
   // Have to use CoarseDuration here, since CoarseTimePoint does not work with clang + libstdc++
   std::atomic<CoarseDuration> last_backpressure_at_{CoarseTimePoint().time_since_epoch()};
   std::atomic<int64_t> queued_calls_{0};

--- a/src/yb/rpc/service_pool.cc
+++ b/src/yb/rpc/service_pool.cc
@@ -134,10 +134,13 @@ namespace {
 const CoarseDuration kTimeoutCheckGranularity = 100ms;
 const char* const kTimedOutInQueue = "Call waited in the queue past deadline";
 
-// The maximum number of distinct method names we will emit per-method metrics for.
-// In reality, we won't even come close to this number. This is just a safety measure
-// against DoS attacks (e.g. an attacker sending garbage method names in RPC headers
-// to unbounded-grow our metrics map and exhaust memory).
+// Hard cap on the number of distinct method names for which we emit per-method metrics.
+// Real services declare ~10-30 methods, so this is effectively unreachable in normal
+// operation. The cap exists purely as a safety net against pathological inputs that
+// could otherwise grow per_method_counters_ without bound (e.g. an attacker spraying
+// garbage method names in RPC headers, or a misconfigured / buggy peer that does the
+// same accidentally). When the cap is reached we silently drop per-method metric
+// granularity for new names; the aggregate counters keep working.
 constexpr size_t kMaxPerMethodMetrics = 1000;
 
 } // namespace
@@ -228,6 +231,12 @@ class ServicePoolImpl final : public InboundCallHandler {
       return;
     }
 
+    // Note: rpcs_in_queue_ is already incremented inside CallQueued() (called via
+    // BindTask above) before we get here. As a result, a Prometheus scrape that races
+    // with us can momentarily observe rpcs_in_queue_ == rpcs_added_to_queue_ -
+    // rpcs_dequeued_ + 1. Reordering would require pulling rpcs_in_queue_->Increment()
+    // out of CallQueued(), which complicates the rollback-on-overflow path; the brief
+    // skew is acceptable for monitoring purposes.
     rpcs_added_to_queue_->Increment();
     if (auto* per_method_counters = GetPerMethodCounters(call->method_name())) {
       per_method_counters->added->Increment();
@@ -455,12 +464,18 @@ class ServicePoolImpl final : public InboundCallHandler {
   }
 
   // Per-RPC-method counters. Lazily registered on first occurrence of each method name.
-  // Cardinality is bounded by the number of methods declared on the service (~10-30).
+  // In normal operation cardinality is the number of methods declared on the service
+  // (typically ~10-30); kMaxPerMethodMetrics is the absolute upper bound enforced as a
+  // safety net (see comment on the constant).
   struct PerMethodCounters {
     scoped_refptr<Counter> added;
     scoped_refptr<Counter> overflow;
   };
 
+  // TODO(#31673): once Abseil containers are available we should migrate
+  // per_method_counters_ to absl::flat_hash_map with a transparent string hash, which
+  // would let the hot lookup path skip the per-call Slice->std::string allocation
+  // performed below.
   PerMethodCounters* GetPerMethodCounters(Slice method_name) EXCLUDES(per_method_mutex_) {
     auto method_str = method_name.ToBuffer();
     {
@@ -476,6 +491,13 @@ class ServicePoolImpl final : public InboundCallHandler {
       return &it->second;
     }
     if (per_method_counters_.size() >= kMaxPerMethodMetrics) {
+      // Log at most once every 60s so a runaway / hostile peer can't drown the log,
+      // but visibility of "we are no longer creating per-method metrics" is preserved.
+      YB_LOG_EVERY_N_SECS(WARNING, 60)
+          << LogPrefix()
+          << "Reached the per-service-pool cap of " << kMaxPerMethodMetrics
+          << " distinct RPC method names; new method '" << method_str
+          << "' will not get its own per-method metrics. Aggregate counters are unaffected.";
       return nullptr;
     }
     auto [new_it, inserted] = per_method_counters_.try_emplace(std::move(method_str));
@@ -494,6 +516,13 @@ class ServicePoolImpl final : public InboundCallHandler {
     };
   }
 
+  // MakeCounter assumes that this ServicePoolImpl is the sole owner of `metric_entity_`
+  // for the synthesized metric name. MetricEntity::FindOrCreateMetric keys its dedup map
+  // by prototype pointer (not by name), and we allocate a fresh OwningCounterPrototype on
+  // every call, so two ServicePoolImpl instances sharing the same entity would register
+  // two distinct Counter objects under the same Prometheus name. In current YB usage each
+  // ServicePoolImpl is constructed with its own dedicated MetricEntity, so this is safe;
+  // revisit if that invariant ever changes.
   scoped_refptr<Counter> MakeCounter(
       const std::string& base_name, const std::string& method, const std::string& description) {
     auto id = Format("$0_$1_$2", base_name, service_->metric_name(), method);

--- a/src/yb/rpc/service_pool.cc
+++ b/src/yb/rpc/service_pool.cc
@@ -136,7 +136,8 @@ METRIC_DEFINE_counter(server, rpcs_started_processing,
 METRIC_DEFINE_gauge_int64(server, rpc_queue_max_size,
                            "RPC Queue Max Size",
                            yb::MetricUnit::kRequests,
-                           "Maximum number of RPCs that can be queued before the service queue is considered full.");
+                           "Maximum number of RPCs that can be queued before the service "
+                           "queue is considered full.");
 
 METRIC_DEFINE_gauge_int64(server, rpcs_queue_high_water_mark,
                            "RPC Queue High Water Mark",

--- a/src/yb/util/high_water_mark.h
+++ b/src/yb/util/high_water_mark.h
@@ -79,6 +79,20 @@ class HighWaterMark {
     UpdateMax(current_value_.fetch_add(amount, std::memory_order_acq_rel) + amount);
   }
 
+  int64_t fetch_add(int64_t amount, std::memory_order order = std::memory_order_seq_cst) {
+    int64_t old_val = current_value_.fetch_add(amount, order);
+    UpdateMax(old_val + amount);
+    return old_val;
+  }
+
+  int64_t fetch_sub(int64_t amount, std::memory_order order = std::memory_order_seq_cst) {
+    return current_value_.fetch_sub(amount, order);
+  }
+
+  int64_t load(std::memory_order order = std::memory_order_seq_cst) const {
+    return current_value_.load(order);
+  }
+
   void set_value(int64_t v) {
     current_value_.store(v, std::memory_order_release);
     UpdateMax(v);

--- a/src/yb/util/high_water_mark.h
+++ b/src/yb/util/high_water_mark.h
@@ -32,6 +32,7 @@
 #pragma once
 
 #include <atomic>
+#include <optional>
 
 #include "yb/gutil/macros.h"
 
@@ -79,10 +80,29 @@ class HighWaterMark {
     UpdateMax(current_value_.fetch_add(amount, std::memory_order_acq_rel) + amount);
   }
 
-  int64_t fetch_add(int64_t amount, std::memory_order order = std::memory_order_seq_cst) {
-    int64_t old_val = current_value_.fetch_add(amount, order);
-    UpdateMax(old_val + amount);
-    return old_val;
+  // Atomically adds `amount` to the current value iff the post-add value would be <= `cap`,
+  // and on success updates the high-water-mark accordingly. Returns the pre-add value on
+  // success; returns std::nullopt (without modifying current_value_ or max_value_) if the
+  // add would exceed the cap.
+  //
+  // Unlike a plain fetch_add() followed by a rollback fetch_sub() on overflow, this never
+  // speculatively publishes a value > cap to current_value_ and therefore never inflates
+  // max_value_ with depths that the queue did not actually hold. This is the correct
+  // primitive for bounded queues that need a high-water-mark gauge.
+  std::optional<int64_t> fetch_add_if_below(int64_t amount, int64_t cap) {
+    int64_t old_val = current_value_.load(std::memory_order_acquire);
+    while (true) {
+      int64_t new_val = old_val + amount;
+      if (new_val > cap) {
+        return std::nullopt;
+      }
+      if (PREDICT_TRUE(current_value_.compare_exchange_weak(
+              old_val, new_val, std::memory_order_acq_rel))) {
+        UpdateMax(new_val);
+        return old_val;
+      }
+      // compare_exchange_weak refreshes old_val on failure; loop and retry.
+    }
   }
 
   int64_t fetch_sub(int64_t amount, std::memory_order order = std::memory_order_seq_cst) {

--- a/src/yb/util/thread_pool.cc
+++ b/src/yb/util/thread_pool.cc
@@ -122,6 +122,20 @@ class Worker : public boost::intrusive::list_base_hook<> {
   Worker(const Worker& worker) = delete;
   void operator=(const Worker& worker) = delete;
 
+  void DumpThreadStack(std::string* out) {
+    if (thread_) {
+      *out += yb::DumpThreadStack(thread_->tid_for_stack());
+      std::lock_guard lock(active_task_mutex_);
+      if (active_task_) {
+        std::string desc = active_task_->ToString();
+        if (!desc.empty()) {
+          *out += "  Currently processing: " + desc + "\n";
+        }
+      }
+      *out += "\n";
+    }
+  }
+
   void Stop() {
     ThreadPoolTask* task;
     {
@@ -213,15 +227,31 @@ class Worker : public boost::intrusive::list_base_hook<> {
       }
 #endif
       auto start = MonoTime::NowIf(has_run_metrics);
+      {
+        std::lock_guard lock(active_task_mutex_);
+        active_task_ = task;
+      }
       if (!task->run_token()) {
         task->Run();
+        {
+          std::lock_guard lock(active_task_mutex_);
+          active_task_ = nullptr;
+        }
         task->Done(Status::OK());
       } else {
         auto run_token = task->run_token()->lock();
         if (run_token) {
           task->Run();
+          {
+            std::lock_guard lock(active_task_mutex_);
+            active_task_ = nullptr;
+          }
           task->Done(Status::OK());
         } else {
+          {
+            std::lock_guard lock(active_task_mutex_);
+            active_task_ = nullptr;
+          }
           task->Done(kShuttingDownStatus);
         }
       }
@@ -318,6 +348,8 @@ class Worker : public boost::intrusive::list_base_hook<> {
   WorkerState state_ GUARDED_BY(mutex_) = WorkerState::kRunning;
   bool added_to_waiting_workers_ GUARDED_BY(mutex_) = false;
   ThreadPoolTask* task_ GUARDED_BY(mutex_) = nullptr;
+  std::mutex active_task_mutex_;
+  ThreadPoolTask* active_task_ GUARDED_BY(active_task_mutex_) = nullptr;
 };
 
 struct WorkerLink {
@@ -563,6 +595,13 @@ class YBThreadPool::Impl {
     workers.clear_and_dispose(std::default_delete<Worker>());
   }
 
+  void DumpThreadStacks(std::string* out) {
+    std::lock_guard lock(mutex_);
+    for (auto& worker : workers_) {
+      worker.DumpThreadStack(out);
+    }
+  }
+
   bool Owns(Thread* thread) {
     return thread && thread->user_data() == &share_;
   }
@@ -649,6 +688,10 @@ void YBThreadPool::Shutdown() {
 
 const ThreadPoolOptions& YBThreadPool::options() const {
   return impl_->options();
+}
+
+void YBThreadPool::DumpThreadStacks(std::string* out) {
+  impl_->DumpThreadStacks(out);
 }
 
 bool YBThreadPool::Owns(Thread* thread) {

--- a/src/yb/util/thread_pool.h
+++ b/src/yb/util/thread_pool.h
@@ -66,6 +66,8 @@ class ThreadPoolTask {
   void set_cgroup(Cgroup* cgroup) { task_cgroup_ = cgroup; }
   Cgroup* cgroup() const { return task_cgroup_; }
 
+  virtual std::string ToString() const { return ""; }
+
  protected:
   virtual ~ThreadPoolTask() {}
 
@@ -214,6 +216,8 @@ class YBThreadPool : public TaskRecipient<ThreadPoolTask> {
   bool Owns(Thread* thread);
   bool OwnsThisThread();
   bool BusyWait(MonoTime deadline);
+
+  void DumpThreadStacks(std::string* out);
 
   size_t NumWorkers() const;
   bool Idle() const;

--- a/src/yb/util/threadpool.h
+++ b/src/yb/util/threadpool.h
@@ -136,6 +136,10 @@ class ThreadPool {
     underlying_->BusyWait(MonoTime::kUninitialized);
   }
 
+  void DumpThreadStacks(std::string* out) {
+    underlying_->DumpThreadStacks(out);
+  }
+
   size_t NumWorkers() const {
     return underlying_->NumWorkers();
   }


### PR DESCRIPTION
## Summary
This is the third and final PR for #26369.

It hooks into the new backpressure warnings (from PR2) to append a full thread pool stack dump to help diagnose why the queue is blocked and what the threads are doing.

Key changes:
- `ThreadPoolTask` now has a virtual `ToString()` method.
- `InboundCallTask` overrides `ToString()` to return the RPC method name and the service name (e.g. `CreateTable (service: yb.master.MasterService)`).
- `Worker` tracks the actively executing `ThreadPoolTask` in a thread-safe manner (`active_task_` under `active_task_mutex_`).
- `DumpThreadStacks` safely dumps the stack trace (using signals) and appends the description of the currently executing task, so we get per-RPC labelling for each thread.

## Test Plan
- Run `mt-rpc-test` locally and verified compilation and successful execution.

Made with [Cursor](https://cursor.com)