### PR TITLE
[#31631] build: Fix cpplint parsing for class/struct attributes

### DIFF
--- a/src/lint/cpplint.py
+++ b/src/lint/cpplint.py
@@ -3356,7 +3356,7 @@ def CheckSpacing(filename, clean_lines, linenum, nesting_state, error):
 
   # You shouldn't have spaces before your brackets, except maybe after
   # 'delete []', 'return []() {};', or 'auto [abc, ...] = ...;'.
-  if Search(r'\w\s+\[', line) and not Search(r'(?:auto&?|delete|return)\s+\[', line):
+  if Search(r'\w\s+\[', line) and not Search(r'(?:auto&?|delete|return|class|struct)\s+\[', line):
     error(filename, linenum, 'whitespace/braces', 5,
           'Extra space before [')
 


### PR DESCRIPTION
Resolves #31631. Updates `cpplint.py` to correctly parse C++ attributes like `[[nodiscard]]` when they appear before the class or struct name.

Made with [Cursor](https://cursor.com)