### PR TITLE
[DOC-1324] Add DocumentDB extension page

### DIFF
--- a/docs/content/stable/additional-features/pg-extensions/_index.md
+++ b/docs/content/stable/additional-features/pg-extensions/_index.md
@@ -58,7 +58,7 @@ YugabyteDB supports the following additional extensions, some of which you must 
 | <div style="width:120px">Extension</div> | <div style="width:100px">Status</div> | Description |
 | :-------- | :----- | :---------- |
 | [Anonymizer](extension-pganon/) | Pre-bundled | Mask or replace personally identifiable information (PII) or commercially sensitive data in a database. |
-| [documentdb](extension-documentdb/){{<tags/feature/tp>}} | Pre-bundled | Adds a BSON data type, document-store APIs, and a wire-protocol gateway. Lets applications use open source MongoDB drivers against YugabyteDB. |
+| [DocumentDB](extension-documentdb/){{<tags/feature/tp>}} | Pre-bundled | Adds a BSON data type, document-store APIs, and a wire-protocol gateway. Lets applications use open source MongoDB drivers against YugabyteDB. |
 | [HypoPG](extension-hypopg/) | Pre-bundled | Create hypothetical indexes to test whether an index can increase performance for problematic queries without consuming any actual resources. |
 | Orafce | Pre-bundled | Provides compatibility with Oracle functions and packages that are either missing or implemented differently in YugabyteDB and PostgreSQL. This compatibility layer can help you port your Oracle applications to YugabyteDB.<br/>For more information, see the [Orafce](https://github.com/yugabyte/yugabyte-db/blob/master/src/postgres/third-party-extensions/orafce/README.asciidoc) documentation. |
 | [PGAudit](../../secure/audit-logging/audit-logging-ysql/) | Pre-bundled | The PostgreSQL Audit Extension (pgaudit) provides detailed session and/or object audit logging via the standard PostgreSQL logging facility. |

--- a/docs/content/stable/additional-features/pg-extensions/_index.md
+++ b/docs/content/stable/additional-features/pg-extensions/_index.md
@@ -58,7 +58,7 @@ YugabyteDB supports the following additional extensions, some of which you must 
 | <div style="width:120px">Extension</div> | <div style="width:100px">Status</div> | Description |
 | :-------- | :----- | :---------- |
 | [Anonymizer](extension-pganon/) | Pre-bundled | Mask or replace personally identifiable information (PII) or commercially sensitive data in a database. |
-| [DocumentDB](extension-documentdb/){{<tags/feature/tp>}} | Pre-bundled | Adds a BSON data type, document-store APIs, and a wire-protocol gateway. Lets applications use open source MongoDB drivers against YugabyteDB. |
+| [DocumentDB](extension-documentdb/){{<tags/feature/tp>}} | Pre-bundled | Adds a BSON data type, document-store APIs, and a wire-protocol gateway. Lets applications use MongoDB drivers and tools against YugabyteDB. |
 | [HypoPG](extension-hypopg/) | Pre-bundled | Create hypothetical indexes to test whether an index can increase performance for problematic queries without consuming any actual resources. |
 | Orafce | Pre-bundled | Provides compatibility with Oracle functions and packages that are either missing or implemented differently in YugabyteDB and PostgreSQL. This compatibility layer can help you port your Oracle applications to YugabyteDB.<br/>For more information, see the [Orafce](https://github.com/yugabyte/yugabyte-db/blob/master/src/postgres/third-party-extensions/orafce/README.asciidoc) documentation. |
 | [PGAudit](../../secure/audit-logging/audit-logging-ysql/) | Pre-bundled | The PostgreSQL Audit Extension (pgaudit) provides detailed session and/or object audit logging via the standard PostgreSQL logging facility. |

--- a/docs/content/stable/additional-features/pg-extensions/_index.md
+++ b/docs/content/stable/additional-features/pg-extensions/_index.md
@@ -58,6 +58,7 @@ YugabyteDB supports the following additional extensions, some of which you must 
 | <div style="width:120px">Extension</div> | <div style="width:100px">Status</div> | Description |
 | :-------- | :----- | :---------- |
 | [Anonymizer](extension-pganon/) | Pre-bundled | Mask or replace personally identifiable information (PII) or commercially sensitive data in a database. |
+| [documentdb](extension-documentdb/){{<tags/feature/tp>}} | Pre-bundled | Adds a BSON data type, document-store APIs, and a wire-protocol gateway. Lets applications use open source MongoDB drivers against YugabyteDB. |
 | [HypoPG](extension-hypopg/) | Pre-bundled | Create hypothetical indexes to test whether an index can increase performance for problematic queries without consuming any actual resources. |
 | Orafce | Pre-bundled | Provides compatibility with Oracle functions and packages that are either missing or implemented differently in YugabyteDB and PostgreSQL. This compatibility layer can help you port your Oracle applications to YugabyteDB.<br/>For more information, see the [Orafce](https://github.com/yugabyte/yugabyte-db/blob/master/src/postgres/third-party-extensions/orafce/README.asciidoc) documentation. |
 | [PGAudit](../../secure/audit-logging/audit-logging-ysql/) | Pre-bundled | The PostgreSQL Audit Extension (pgaudit) provides detailed session and/or object audit logging via the standard PostgreSQL logging facility. |

--- a/docs/content/stable/additional-features/pg-extensions/extension-documentdb.md
+++ b/docs/content/stable/additional-features/pg-extensions/extension-documentdb.md
@@ -121,7 +121,7 @@ for row in people.aggregate(pipeline):
 people.delete_one({"name": "Carol"})
 ```
 
-The same connection string works with the [mongosh](https://www.mongodb.com/docs/mongodb-shell/) shell:
+The same connection string works with the [mongosh](https://www.mongodb.com/docs/mongodb-shell/install/) shell:
 
 ```sh
 mongosh "mongodb://yugabyte:yugabyte@localhost:27017/?tls=true&tlsAllowInvalidCertificates=true&authMechanism=SCRAM-SHA-256"

--- a/docs/content/stable/additional-features/pg-extensions/extension-documentdb.md
+++ b/docs/content/stable/additional-features/pg-extensions/extension-documentdb.md
@@ -121,7 +121,7 @@ for row in people.aggregate(pipeline):
 people.delete_one({"name": "Carol"})
 ```
 
-The same connection string works with the `mongosh` shell:
+The same connection string works with the [mongosh](https://www.mongodb.com/docs/mongodb-shell/) shell:
 
 ```sh
 mongosh "mongodb://yugabyte:yugabyte@localhost:27017/?tls=true&tlsAllowInvalidCertificates=true&authMechanism=SCRAM-SHA-256"

--- a/docs/content/stable/additional-features/pg-extensions/extension-documentdb.md
+++ b/docs/content/stable/additional-features/pg-extensions/extension-documentdb.md
@@ -1,0 +1,129 @@
+---
+title: documentdb extension
+headerTitle: documentdb extension
+linkTitle: documentdb
+description: Using the documentdb extension in YugabyteDB
+tags:
+  feature: tech-preview
+menu:
+  stable:
+    identifier: extension-documentdb
+    parent: pg-extensions
+    weight: 20
+type: docs
+---
+
+{{< warning title="Extension support" >}}
+Support for the documentdb extension is in {{<tags/feature/tp>}}. It is not recommended for use in production.
+{{< /warning >}}
+
+The [documentdb](https://documentdb.io) extension adds a BSON data type and document-store APIs to YugabyteDB, enabling CRUD, aggregation, and indexing operations on JSON-style documents. A built-in gateway worker listens on a separate port and speaks the wire protocol used by open source MongoDB drivers (for example, [PyMongo](https://github.com/mongodb/mongo-python-driver) or [mongosh](https://github.com/mongodb-js/mongosh)).
+
+The extension ships as three components, all bundled with YugabyteDB:
+
+- `documentdb_core` — adds the BSON type and core operators.
+- `documentdb` — provides the CRUD, indexing, and aggregation API surface.
+- `pg_documentdb_gw_host` — a background worker that translates wire-protocol commands into SQL calls into the extension.
+
+## Set up documentdb
+
+Before you can use the extension, set the following flags on every YB-Master and YB-TServer:
+
+- `allowed_preview_flags_csv=ysql_enable_documentdb`
+- `ysql_enable_documentdb=true`
+- `enable_pg_cron=true` (the extension uses `pg_cron` for background maintenance)
+
+By default the gateway listens on port `27017`. You can change this with the `documentdb_port` flag on YB-TServers.
+
+For example, to start a single-node [yugabyted](../../../reference/configuration/yugabyted/) cluster with documentdb enabled:
+
+```sh
+./bin/yugabyted start \
+    --master_flags "allowed_preview_flags_csv=ysql_enable_documentdb,ysql_enable_documentdb=true,enable_pg_cron=true" \
+    --tserver_flags "allowed_preview_flags_csv=ysql_enable_documentdb,ysql_enable_documentdb=true,enable_pg_cron=true"
+```
+
+## Enable documentdb
+
+Connect to the `yugabyte` database with [ysqlsh](../../../api/ysqlsh/) and create the extension:
+
+```sql
+CREATE EXTENSION documentdb CASCADE;
+```
+
+`CASCADE` automatically creates the `documentdb_core` dependency.
+
+The gateway authenticates clients using SCRAM-SHA-256, so set a password on the YSQL user the application will use to connect:
+
+```sql
+ALTER USER yugabyte PASSWORD 'yugabyte';
+```
+
+After creating the extension, restart the cluster so the gateway background worker picks up the newly created schemas:
+
+```sh
+./bin/yugabyted stop
+./bin/yugabyted start \
+    --master_flags "allowed_preview_flags_csv=ysql_enable_documentdb,ysql_enable_documentdb=true,enable_pg_cron=true" \
+    --tserver_flags "allowed_preview_flags_csv=ysql_enable_documentdb,ysql_enable_documentdb=true,enable_pg_cron=true"
+```
+
+The restart is a current limitation; see [Limitations](#limitations).
+
+## Use documentdb
+
+The gateway authenticates using SCRAM-SHA-256 over TLS with an auto-generated certificate. Connect with any open source MongoDB driver and use the YSQL `yugabyte` user. For example, with [PyMongo](https://github.com/mongodb/mongo-python-driver):
+
+```python
+from pymongo import MongoClient
+
+client = MongoClient(
+    "mongodb://yugabyte:yugabyte@localhost:27017/"
+    "?tls=true&tlsAllowInvalidCertificates=true&authMechanism=SCRAM-SHA-256"
+)
+
+db = client["quickstart"]
+people = db["people"]
+
+# Insert a single document.
+people.insert_one({"name": "Alice", "age": 30, "city": "Anytown"})
+
+# Insert multiple documents.
+people.insert_many([
+    {"name": "Bob", "age": 45, "city": "Othertown"},
+    {"name": "Carol", "age": 29, "city": "Sometown"},
+])
+
+# Read.
+for doc in people.find({"age": {"$gt": 30}}):
+    print(doc)
+
+# Update.
+people.update_one({"name": "Alice"}, {"$set": {"age": 31}})
+
+# Aggregate.
+pipeline = [
+    {"$match": {"age": {"$gte": 30}}},
+    {"$group": {"_id": "$city", "count": {"$sum": 1}}},
+]
+for row in people.aggregate(pipeline):
+    print(row)
+
+# Delete.
+people.delete_one({"name": "Carol"})
+```
+
+The same connection string works with `mongosh`:
+
+```sh
+mongosh "mongodb://yugabyte:yugabyte@localhost:27017/?tls=true&tlsAllowInvalidCertificates=true&authMechanism=SCRAM-SHA-256"
+```
+
+## Limitations
+
+- A cluster restart is required after running `CREATE EXTENSION documentdb`. The gateway background worker starts before the extension schemas exist and caches that state, so it cannot serve requests until the cluster is restarted. {{<issue 31353>}}
+- Secondary indexes on collections are not yet supported. The extension relies on the RUM index access method, which is not currently available in YugabyteDB. Queries fall back to sequential scans of the underlying collection table. {{<issue 31634>}}
+
+## Learn more
+
+- [documentdb project](https://documentdb.io)

--- a/docs/content/stable/additional-features/pg-extensions/extension-documentdb.md
+++ b/docs/content/stable/additional-features/pg-extensions/extension-documentdb.md
@@ -17,7 +17,7 @@ type: docs
 Support for the DocumentDB extension is in {{<tags/feature/tp>}}. It is not recommended for use in production.
 {{< /warning >}}
 
-The [DocumentDB](https://documentdb.io) extension adds a BSON data type and document-store APIs to YugabyteDB, enabling CRUD, aggregation, and indexing operations on JSON-style documents. A built-in gateway worker listens on a separate port and speaks the wire protocol used by open source MongoDB drivers (for example, [PyMongo](https://github.com/mongodb/mongo-python-driver) or [mongosh](https://github.com/mongodb-js/mongosh)).
+The [DocumentDB](https://documentdb.io) extension adds a BSON data type and document-store APIs to YugabyteDB, enabling CRUD, aggregation, and indexing operations on JSON-style documents. A built-in gateway worker listens on a separate port and speaks the wire protocol used by MongoDB drivers and tools (for example, PyMongo or mongosh).
 
 The extension ships as three components, all bundled with YugabyteDB:
 
@@ -72,7 +72,15 @@ The restart is a current limitation; see [Limitations](#limitations).
 
 ## Use DocumentDB
 
-The gateway authenticates using SCRAM-SHA-256 over TLS with an auto-generated certificate. Connect with any open source MongoDB driver and use the YSQL `yugabyte` user. For example, with [PyMongo](https://github.com/mongodb/mongo-python-driver):
+The gateway authenticates using SCRAM-SHA-256 over TLS with an auto-generated certificate. Connect with any MongoDB driver using the YSQL `yugabyte` user.
+
+The following example uses the [PyMongo](https://pymongo.readthedocs.io/) Python driver. Install it with pip:
+
+```sh
+pip install pymongo
+```
+
+Then connect and run document operations:
 
 ```python
 from pymongo import MongoClient
@@ -113,7 +121,7 @@ for row in people.aggregate(pipeline):
 people.delete_one({"name": "Carol"})
 ```
 
-The same connection string works with `mongosh`:
+The same connection string works with the `mongosh` shell:
 
 ```sh
 mongosh "mongodb://yugabyte:yugabyte@localhost:27017/?tls=true&tlsAllowInvalidCertificates=true&authMechanism=SCRAM-SHA-256"
@@ -123,7 +131,3 @@ mongosh "mongodb://yugabyte:yugabyte@localhost:27017/?tls=true&tlsAllowInvalidCe
 
 - A cluster restart is required after running `CREATE EXTENSION documentdb`. The DocumentDB gateway background worker starts before the extension schemas exist and caches that state, so it cannot serve requests until the cluster is restarted. {{<issue 31353>}}
 - Secondary indexes on collections are not yet supported. The extension relies on the RUM index access method, which is not currently available in YugabyteDB. Queries fall back to sequential scans of the underlying collection table. {{<issue 31634>}}
-
-## Learn more
-
-- [DocumentDB project](https://documentdb.io)

--- a/docs/content/stable/additional-features/pg-extensions/extension-documentdb.md
+++ b/docs/content/stable/additional-features/pg-extensions/extension-documentdb.md
@@ -1,8 +1,8 @@
 ---
-title: documentdb extension
-headerTitle: documentdb extension
-linkTitle: documentdb
-description: Using the documentdb extension in YugabyteDB
+title: DocumentDB extension
+headerTitle: DocumentDB extension
+linkTitle: DocumentDB
+description: Using the DocumentDB extension in YugabyteDB
 tags:
   feature: tech-preview
 menu:
@@ -14,10 +14,10 @@ type: docs
 ---
 
 {{< warning title="Extension support" >}}
-Support for the documentdb extension is in {{<tags/feature/tp>}}. It is not recommended for use in production.
+Support for the DocumentDB extension is in {{<tags/feature/tp>}}. It is not recommended for use in production.
 {{< /warning >}}
 
-The [documentdb](https://documentdb.io) extension adds a BSON data type and document-store APIs to YugabyteDB, enabling CRUD, aggregation, and indexing operations on JSON-style documents. A built-in gateway worker listens on a separate port and speaks the wire protocol used by open source MongoDB drivers (for example, [PyMongo](https://github.com/mongodb/mongo-python-driver) or [mongosh](https://github.com/mongodb-js/mongosh)).
+The [DocumentDB](https://documentdb.io) extension adds a BSON data type and document-store APIs to YugabyteDB, enabling CRUD, aggregation, and indexing operations on JSON-style documents. A built-in gateway worker listens on a separate port and speaks the wire protocol used by open source MongoDB drivers (for example, [PyMongo](https://github.com/mongodb/mongo-python-driver) or [mongosh](https://github.com/mongodb-js/mongosh)).
 
 The extension ships as three components, all bundled with YugabyteDB:
 
@@ -25,7 +25,7 @@ The extension ships as three components, all bundled with YugabyteDB:
 - `documentdb` — provides the CRUD, indexing, and aggregation API surface.
 - `pg_documentdb_gw_host` — a background worker that translates wire-protocol commands into SQL calls into the extension.
 
-## Set up documentdb
+## Set up DocumentDB
 
 Before you can use the extension, set the following flags on every YB-Master and YB-TServer:
 
@@ -35,7 +35,7 @@ Before you can use the extension, set the following flags on every YB-Master and
 
 By default the gateway listens on port `27017`. You can change this with the `documentdb_port` flag on YB-TServers.
 
-For example, to start a single-node [yugabyted](../../../reference/configuration/yugabyted/) cluster with documentdb enabled:
+For example, to start a single-node [yugabyted](../../../reference/configuration/yugabyted/) cluster with DocumentDB enabled:
 
 ```sh
 ./bin/yugabyted start \
@@ -43,7 +43,7 @@ For example, to start a single-node [yugabyted](../../../reference/configuration
     --tserver_flags "allowed_preview_flags_csv=ysql_enable_documentdb,ysql_enable_documentdb=true,enable_pg_cron=true"
 ```
 
-## Enable documentdb
+## Enable DocumentDB
 
 Connect to the `yugabyte` database with [ysqlsh](../../../api/ysqlsh/) and create the extension:
 
@@ -70,7 +70,7 @@ After creating the extension, restart the cluster so the gateway background work
 
 The restart is a current limitation; see [Limitations](#limitations).
 
-## Use documentdb
+## Use DocumentDB
 
 The gateway authenticates using SCRAM-SHA-256 over TLS with an auto-generated certificate. Connect with any open source MongoDB driver and use the YSQL `yugabyte` user. For example, with [PyMongo](https://github.com/mongodb/mongo-python-driver):
 
@@ -121,9 +121,9 @@ mongosh "mongodb://yugabyte:yugabyte@localhost:27017/?tls=true&tlsAllowInvalidCe
 
 ## Limitations
 
-- A cluster restart is required after running `CREATE EXTENSION documentdb`. The gateway background worker starts before the extension schemas exist and caches that state, so it cannot serve requests until the cluster is restarted. {{<issue 31353>}}
+- A cluster restart is required after running `CREATE EXTENSION documentdb`. The DocumentDB gateway background worker starts before the extension schemas exist and caches that state, so it cannot serve requests until the cluster is restarted. {{<issue 31353>}}
 - Secondary indexes on collections are not yet supported. The extension relies on the RUM index access method, which is not currently available in YugabyteDB. Queries fall back to sequential scans of the underlying collection table. {{<issue 31634>}}
 
 ## Learn more
 
-- [documentdb project](https://documentdb.io)
+- [DocumentDB project](https://documentdb.io)

--- a/docs/content/stable/additional-features/pg-extensions/extension-documentdb.md
+++ b/docs/content/stable/additional-features/pg-extensions/extension-documentdb.md
@@ -16,7 +16,7 @@ type: docs
 {{< warning title="Extension support" >}}
 Support for the DocumentDB extension is in {{<tags/feature/tp>}}. It is not recommended for use in production.
 
-The extension is currently only available on the `master` branch of the [yugabyte/yugabyte-db](https://github.com/yugabyte/yugabyte-db) repository and is not included in released builds. To try it, build YugabyteDB from source by following [Build and test](../../../contribute/core-database/build-and-test/).
+The extension is currently only available on the `master` branch and is not included in released builds. To try it, build YugabyteDB from source by following [Build and test](../../../contribute/core-database/build-and-test/).
 {{< /warning >}}
 
 The [DocumentDB](https://documentdb.io) extension adds a BSON data type and document-store APIs to YugabyteDB, enabling CRUD, aggregation, and indexing operations on JSON-style documents. A built-in gateway worker listens on a separate port and speaks the wire protocol used by MongoDB drivers and tools (for example, PyMongo or mongosh).

--- a/docs/content/stable/additional-features/pg-extensions/extension-documentdb.md
+++ b/docs/content/stable/additional-features/pg-extensions/extension-documentdb.md
@@ -15,6 +15,8 @@ type: docs
 
 {{< warning title="Extension support" >}}
 Support for the DocumentDB extension is in {{<tags/feature/tp>}}. It is not recommended for use in production.
+
+The extension is currently only available on the `master` branch of the [yugabyte/yugabyte-db](https://github.com/yugabyte/yugabyte-db) repository and is not included in released builds. To try it, build YugabyteDB from source by following [Build and test](../../../contribute/core-database/build-and-test/).
 {{< /warning >}}
 
 The [DocumentDB](https://documentdb.io) extension adds a BSON data type and document-store APIs to YugabyteDB, enabling CRUD, aggregation, and indexing operations on JSON-style documents. A built-in gateway worker listens on a separate port and speaks the wire protocol used by MongoDB drivers and tools (for example, PyMongo or mongosh).


### PR DESCRIPTION
Add a Tech Preview docs page for the DocumentDB extension under PostgreSQL extensions.

- New page: docs/content/stable/additional-features/pg-extensions/extension-documentdb.md
- Index entry added to the extensions index with the TP tag.
- Covers: yugabyted flags (ysql_enable_documentdb, enable_pg_cron), CREATE EXTENSION + ALTER USER PASSWORD + cluster-restart bring-up, PyMongo example (with `pip install pymongo`), mongosh connection string.
- Limitations: cluster restart required after CREATE EXTENSION (#31353); no secondary indexes via the RUM access method (#31634).
- Validated end-to-end against a fresh release build: cluster start, CREATE EXTENSION documentdb CASCADE, password set, restart, PyMongo insert/find/update/aggregate/delete, and confirmed the index error reproduces.