### PR TITLE
[BACKPORT 2026.1][#31597] DocDB: Fix yb-ts-cli dump_tablet_data crash on YSQL tablets with NUMERIC columns (#31604)

### DIFF
--- a/src/yb/dockv/pg_row.cc
+++ b/src/yb/dockv/pg_row.cc
@@ -765,7 +765,11 @@ QLValuePB PgValue::ToQLValuePB(DataType data_type) const {
     case DataType::INT64:
       result.set_int64_value(int64_value());
       return result;
-    case DataType::DECIMAL: FALLTHROUGH_INTENDED;
+    case DataType::DECIMAL: {
+      auto data = string_value();
+      result.set_decimal_value(data.cdata(), data.size());
+      return result;
+    }
     case DataType::STRING: {
       auto data = string_value();
       result.set_string_value(data.cdata(), data.size());

--- a/src/yb/yql/pgwrapper/pg_libpq-test.cc
+++ b/src/yb/yql/pgwrapper/pg_libpq-test.cc
@@ -5486,9 +5486,11 @@ TEST_F(PgLibPqTest, DumpTabletData) {
   auto conn = ASSERT_RESULT(cluster_->ConnectToDB(namespace_name));
   const auto table_name = "tbl1";
   ASSERT_OK(conn.ExecuteFormat(
-      "CREATE TABLE $0 (id INT PRIMARY KEY, name TEXT) SPLIT INTO 1 TABLETS", table_name));
+      "CREATE TABLE $0 (id INT PRIMARY KEY, name TEXT, salary NUMERIC(12,2)) SPLIT INTO 1 TABLETS",
+      table_name));
   ASSERT_OK(conn.ExecuteFormat(
-      "INSERT INTO $0 (id, name) SELECT i, 'test' || i FROM generate_series(1, 10) i", table_name));
+      "INSERT INTO $0 (id, name, salary) SELECT i, 'test' || i, i + 0.50 "
+      "FROM generate_series(1, 10) i", table_name));
 
   std::vector<TabletId> tablet_ids;
   auto table_names = ASSERT_RESULT(client_->ListTables(table_name));
@@ -5500,6 +5502,21 @@ TEST_F(PgLibPqTest, DumpTabletData) {
 
   // Wait for rows to get replicated to followers.
   SleepFor(1s * kTimeMultiplier);
+
+  // Dump tablet data with a destination path to exercise the binary -> string conversion path,
+  // which is required to reproduce decoding bugs for types like NUMERIC.
+  const auto dest_path = GetTestPath("dump_tablet_data.out");
+  ASSERT_OK(DumpTabletData(/* tserver_idx */ 0, tablet_id, HybridTime(), dest_path));
+
+  faststring dumped;
+  ASSERT_OK(ReadFileToString(Env::Default(), dest_path, &dumped));
+  const auto dumped_str = dumped.ToString();
+  LOG(INFO) << "Dumped tablet data:\n" << dumped_str;
+  ASSERT_STR_CONTAINS(dumped_str, Format("Tablet ID: $0", tablet_id));
+  ASSERT_STR_CONTAINS(dumped_str, "Row count: 10");
+  for (int i = 1; i <= 10; ++i) {
+    ASSERT_STR_CONTAINS(dumped_str, Format("$0, test$0, $0.5", i));
+  }
 
   ASSERT_OK(ValidateTabletDataAcrossReplicas(tablet_id));
 }


### PR DESCRIPTION
## Summary

`yb-ts-cli dump_tablet_data <tablet_id> <dest_path>` crashes with
`Corruption: Cannot decode Decimal from empty slice` on any YSQL tablet
containing a `NUMERIC`/`DECIMAL` column.

**Root cause:** `PgValue::ToQLValuePB` in `src/yb/dockv/pg_row.cc` fell
`DataType::DECIMAL` through to `DataType::STRING` and wrote the
decimal's
comparable-encoding bytes into the protobuf `string_value` oneof field.
The
downstream consumer `SetValueFromQLBinaryHelper` (NUMERICOID case in
`src/yb/docdb/docdb_pgapi.cc`) reads from `ql_value.decimal_value()` —
the
oneof field used consistently everywhere else in the codebase
(`doc_expr.cc`,
`primitive_value.cc`, `ql_serialization.cc`, `cdcsdk_producer.cc`).
Since
the bytes ended up in `string_value`, `decimal_value()` returned an
empty
slice, causing `Decimal::DecodeFromComparable` to raise the corruption
error.

**Fix:** Give `DECIMAL` its own case in `PgValue::ToQLValuePB` that
calls
`set_decimal_value` instead of falling through to `set_string_value`.

The bug only triggers when `DumpTabletData` is called with a non-empty
`dest_path` (the human-readable text path). The hash-only path never
calls
`QLBinaryWrapperToString` so was unaffected.

### Audit of other call sites

`PgValue::ToQLValuePB` reaches production code only via
`PgTableRow::GetQLValuePB`. Production call sites:

- `src/yb/tablet/tablet_dump_helper.cc:63` — the bug site (fixed here).
- `src/yb/qlexpr/ql_expr.cc:635` (`EvalColumnRef`) — only reached for
YSQL
pushdown when a `where_clauses` entry has `condition` set, which today
is
  constructed in exactly one place: `pg_sys_table_prefetcher.cc:358`'s
`ApplySystemItemsFilter`, comparing a UINT32 OID column against a
constant.
  User-query predicates go through `PgOperator::PrepareForRead`
(`pg_expr.cc:905`) which always builds a `tscall` (libpostgres opcode
call)
rather than a `condition`; the `tscall` path uses `PgValueToDatumHelper`
  and never touches `ToQLValuePB`. **No user-facing path other than
  `tablet_dump_helper` actually sees a DECIMAL flowing through this
  function today.**

Two test files call `GetQLValuePB` (`docrowwiseiterator-test.cc`,
`pggate_test_type.cc`); neither has DECIMAL coverage so neither needs
updates.

## Upgrade/Rollback safety

Not required. The `QLValuePB` produced by `PgValue::ToQLValuePB` is
consumed
entirely in-process within a single tserver request — it is never
serialized
to the WAL, sent over RPC, or persisted to disk. No proto definition
changes
(field numbers for `string_value`=7 and `decimal_value`=15 are
unchanged).
Mixed-version clusters are unaffected because no wire-format or on-disk
surface has moved.

Original commit: ddc59eb09ab2c0c1bd652beda40e525b13df0f84 / #31604

## Test plan

- [x] `PgLibPqTest.DumpTabletData` — extended to include a
`NUMERIC(12,2)` column, to call `DumpTabletData` with a `dest_path` (the
exact failing path), and to read back the dumped file and assert the
per-row content. Confirmed:
  - Test **fails** (reproduces the bug) with the fix reverted
  - Test **passes** with the fix applied


---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31641/>)