### PR TITLE
[BACKPORT 2024.2][#31597] DocDB: Fix yb-ts-cli dump_tablet_data crash on YSQL tablets with NUMERIC columns (#31604)

### DIFF
--- a/src/yb/dockv/pg_row.cc
+++ b/src/yb/dockv/pg_row.cc
@@ -686,7 +686,11 @@ QLValuePB PgValue::ToQLValuePB(DataType data_type) const {
     case DataType::INT64:
       result.set_int64_value(int64_value());
       return result;
-    case DataType::DECIMAL: FALLTHROUGH_INTENDED;
+    case DataType::DECIMAL: {
+      auto data = string_value();
+      result.set_decimal_value(data.cdata(), data.size());
+      return result;
+    }
     case DataType::STRING: {
       auto data = string_value();
       result.set_string_value(data.cdata(), data.size());


### PR DESCRIPTION
## Summary

`yb-ts-cli dump_tablet_data <tablet_id> <dest_path>` crashes with
`Corruption: Cannot decode Decimal from empty slice` on any YSQL tablet
containing a `NUMERIC`/`DECIMAL` column.

**Root cause:** `PgValue::ToQLValuePB` in `src/yb/dockv/pg_row.cc` fell
`DataType::DECIMAL` through to `DataType::STRING` and wrote the
decimal's
comparable-encoding bytes into the protobuf `string_value` oneof field.
The
downstream consumer `SetValueFromQLBinaryHelper` (NUMERICOID case in
`src/yb/docdb/docdb_pgapi.cc`) reads from `ql_value.decimal_value()` —
the
oneof field used consistently everywhere else in the codebase
(`doc_expr.cc`,
`primitive_value.cc`, `ql_serialization.cc`, `cdcsdk_producer.cc`).
Since
the bytes ended up in `string_value`, `decimal_value()` returned an
empty
slice, causing `Decimal::DecodeFromComparable` to raise the corruption
error.

**Fix:** Give `DECIMAL` its own case in `PgValue::ToQLValuePB` that
calls
`set_decimal_value` instead of falling through to `set_string_value`.

The bug only triggers when `DumpTabletData` is called with a non-empty
`dest_path` (the human-readable text path). The hash-only path never
calls
`QLBinaryWrapperToString` so was unaffected.

### Audit of other call sites

`PgValue::ToQLValuePB` reaches production code only via
`PgTableRow::GetQLValuePB`. Production call sites:

- `src/yb/tablet/tablet_dump_helper.cc:63` — the bug site (fixed here).
- `src/yb/qlexpr/ql_expr.cc:635` (`EvalColumnRef`) — only reached for
YSQL
pushdown when a `where_clauses` entry has `condition` set, which today
is
  constructed in exactly one place: `pg_sys_table_prefetcher.cc:358`'s
`ApplySystemItemsFilter`, comparing a UINT32 OID column against a
constant.
  User-query predicates go through `PgOperator::PrepareForRead`
(`pg_expr.cc:905`) which always builds a `tscall` (libpostgres opcode
call)
rather than a `condition`; the `tscall` path uses `PgValueToDatumHelper`
  and never touches `ToQLValuePB`. **No user-facing path other than
  `tablet_dump_helper` actually sees a DECIMAL flowing through this
  function today.**

Two test files call `GetQLValuePB` (`docrowwiseiterator-test.cc`,
`pggate_test_type.cc`); neither has DECIMAL coverage so neither needs
updates.

## Upgrade/Rollback safety

Not required. The `QLValuePB` produced by `PgValue::ToQLValuePB` is
consumed
entirely in-process within a single tserver request — it is never
serialized
to the WAL, sent over RPC, or persisted to disk. No proto definition
changes
(field numbers for `string_value`=7 and `decimal_value`=15 are
unchanged).
Mixed-version clusters are unaffected because no wire-format or on-disk
surface has moved.

Original commit: ddc59eb09ab2c0c1bd652beda40e525b13df0f84 / #31604

## Test plan

- [x] `PgLibPqTest.DumpTabletData` — extended to include a
`NUMERIC(12,2)` column, to call `DumpTabletData` with a `dest_path` (the
exact failing path), and to read back the dumped file and assert the
per-row content. Confirmed:
  - Test **fails** (reproduces the bug) with the fix reverted
  - Test **passes** with the fix applied


---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31644/>)

## Backport-specific changes

Test changes from the original commit are **dropped** on this branch. The new `PgLibPqTest.DumpTabletData` assertions (NUMERIC column setup, `dest_path` dump, content checks) depend on test-infra helpers / refactors that were not backported to 2024.2, so the test failed here. Only the production fix in `src/yb/dockv/pg_row.cc` is carried over; the test continues to live on `master`/2026.1/2025.2 where its dependencies exist.
