### PR TITLE
[#31648] gutil: Cleanup NOLINTs for [[nodiscard]] after cpplint fix

### DIFF
--- a/src/yb/docdb/object_lock_shared_state_manager.h
+++ b/src/yb/docdb/object_lock_shared_state_manager.h
@@ -51,7 +51,7 @@ class ObjectLockOwnerRegistry {
   class Impl;
 
  public:
-  class [[nodiscard]] RegistrationGuard { // NOLINT(whitespace/braces)
+  class [[nodiscard]] RegistrationGuard {
    public:
     RegistrationGuard(Impl& registry, SessionLockOwnerTag tag) : registry_(registry), tag_(tag) {}
     ~RegistrationGuard();

--- a/src/yb/util/result.h
+++ b/src/yb/util/result.h
@@ -73,7 +73,7 @@ concept ConvertibleResultValueType = std::convertible_to<ResultValueType<R>, TVa
 void StatusCheck(bool);
 
 template<class TValue>
-class [[nodiscard]] Result { // NOLINT
+class [[nodiscard]] Result {
   using Traits = result::internal::ResultTraits<TValue>;
 
  public:

--- a/src/yb/util/scope_exit.h
+++ b/src/yb/util/scope_exit.h
@@ -40,7 +40,7 @@ namespace yb {
 //    return Status::OK();
 //  }
 template <InvocableAs<void()> F>
-class [[nodiscard]] CancelableScopeExit { // NOLINT
+class [[nodiscard]] CancelableScopeExit {
  public:
   explicit CancelableScopeExit(const F& f) : f_(f) {}
   explicit CancelableScopeExit(F&& f) : f_(std::move(f)) {}
@@ -65,7 +65,7 @@ class [[nodiscard]] CancelableScopeExit { // NOLINT
 // Execute the lambda when object goes out of scope.
 // Unlike CancelableScopeExit execution can't be dismissed (no Cancel method)
 template <InvocableAs<void()> F>
-class [[nodiscard]] ScopeExit { // NOLINT
+class [[nodiscard]] ScopeExit {
  public:
   explicit ScopeExit(const F& f) : impl_(f) {}
   explicit ScopeExit(F&& f) : impl_(std::move(f)) {}

--- a/src/yb/util/shmem/annotations.h
+++ b/src/yb/util/shmem/annotations.h
@@ -30,7 +30,7 @@ void MarkChildProcess();
 
 #define DCHECK_PARENT_PROCESS() DCHECK(!IsChildProcess()) << "Access from child process not allowed"
 
-class [[nodiscard]] SCOPED_CAPABILITY ParentProcessGuard { // NOLINT(whitespace/braces)
+class [[nodiscard]] SCOPED_CAPABILITY ParentProcessGuard {
  private:
   struct CAPABILITY("parent process") ParentProcessCapability { };
 

--- a/src/yb/util/thread_annotations_util.h
+++ b/src/yb/util/thread_annotations_util.h
@@ -23,7 +23,7 @@ namespace yb {
 struct CAPABILITY("thread role") ThreadRole {};
 
 template<class T>
-class [[nodiscard]] SCOPED_CAPABILITY CapabilityGuard {  // NOLINT
+class [[nodiscard]] SCOPED_CAPABILITY CapabilityGuard {
  public:
   CapabilityGuard() ACQUIRE(T::Alias()) {};
   ~CapabilityGuard() RELEASE(T::Alias()) {};


### PR DESCRIPTION
Resolves #31648.

Removes `// NOLINT(whitespace/braces)` and `// NOLINT` workarounds on `[[nodiscard]]` classes across the codebase. These were previously required to bypass a bug in `cpplint.py` which has now been fixed in PR #31632.