### PR TITLE
[#31649] YSQL: Preload pgvector to keep hnsw.ef_search across extension load

### DIFF
--- a/src/yb/yql/pgwrapper/pg_wrapper.cc
+++ b/src/yb/yql/pgwrapper/pg_wrapper.cc
@@ -719,6 +719,7 @@ Result<string> WritePostgresConfig(const PgProcessConf& conf, const string& ysql
   metricsLibs.push_back("pgaudit");
   metricsLibs.push_back("pg_hint_plan");
   metricsLibs.push_back("yb_xcluster_ddl_replication");
+  metricsLibs.push_back("vector");
 
   if (FLAGS_enable_pg_cron) {
     metricsLibs.push_back("pg_cron");


### PR DESCRIPTION
## Summary

Add the pgvector shared library (`vector`) to the default `shared_preload_libraries` assembled in `pg_wrapper.cc`. Previously the library was loaded on demand the first time a backend executed a vector operation, and the placeholder-promotion path for the extension's custom GUCs failed to preserve user-supplied values — `SET hnsw.ef_search = 999` issued before the first vector query was silently reset to the default (40) once the library loaded.

Preloading the library at postmaster start registers `hnsw.ef_search` / `ybhnsw.ef_search` in every backend up front, so `SET` no longer takes the placeholder path and the user's value survives into the first vector query.

Fixes #31649.

## Test plan

- [x] Manual repro (single-node release cluster from this branch):
  - Session 1: `CREATE EXTENSION vector`, create `ef_repro(id, embedding vector(3))`, insert 200 random rows, build `ybhnsw` index.
  - Session 2 (fresh backend): `SET hnsw.ef_search = 999;` then run a vector query that triggers extension load. `SHOW hnsw.ef_search` returns `999` (was `40` before this change). `SHOW ybhnsw.ef_search` returns `999` as well.
  - Confirmed `SHOW shared_preload_libraries;` includes `vector`.


---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31650/>)