### PR TITLE
[PLAT-20901] YBA: Pin pex builder manylinux base image to 2026.05.02-2

### DIFF
--- a/managed/devops/pex/Dockerfile
+++ b/managed/devops/pex/Dockerfile
@@ -1,5 +1,5 @@
 # Get the latest docker image
-FROM quay.io/pypa/manylinux_2_28_x86_64
+FROM quay.io/pypa/manylinux_2_28_x86_64:2026.05.02-2
 
 # Perform general yum updates
 RUN yum --enablerepo=extras -y install epel-release python3-pip


### PR DESCRIPTION
## Summary

The pex builder Dockerfile (`managed/devops/pex/Dockerfile`) used `quay.io/pypa/manylinux_2_28_x86_64` with no tag, which resolves to `:latest`. The upstream pypa project has been removing EOL CPython builds from the image (Python 3.8 went EOL in October 2024), causing `yb_release`'s pex build to fail with `Failed to find interpreter: python3.8` whenever the new latest image was pulled.

Pin the base image to the known-good tag `2026.05.02-2` so the pex builder is reproducible and won't be silently broken by future upstream image changes.

## Test plan

- [ ] Ran `./build-support/lint.sh`: 0 errors, 0 warnings.
- [ ] `yb_release` pex docker build uses the pinned `2026.05.02-2` image and no longer fails with `Failed to find interpreter: python3.8`.
