### PR TITLE
[#31656] DocDB: Add BSON-aware primary key comparator for DocumentDB

### DIFF
--- a/src/yb/common/schema.cc
+++ b/src/yb/common/schema.cc
@@ -612,6 +612,15 @@ size_t Schema::memory_footprint_including_this() const {
   return malloc_usable_size(this) + memory_footprint_excluding_this();
 }
 
+bool Schema::HasBsonKeyColumn() const {
+  for (size_t i = 0; i < num_key_columns_; ++i) {
+    if (cols_[i].type()->main() == DataType::BSON) {
+      return true;
+    }
+  }
+  return false;
+}
+
 Result<ssize_t> Schema::ColumnIndexByName(GStringPiece col_name) const {
   auto index = find_column(col_name);
   if (index == kColumnNotFound) {

--- a/src/yb/common/schema.h
+++ b/src/yb/common/schema.h
@@ -649,6 +649,11 @@ class Schema : public MissingValueProvider {
     return num_key_columns_ - num_hash_key_columns_;
   }
 
+  // True if any of the schema's primary (hash or range) key columns is BSON-typed.
+  // Used to decide whether DocDB should install the BSON-aware key comparator
+  // for the tablet's RocksDB instance.
+  bool HasBsonKeyColumn() const;
+
   // Return the byte offset within the row for the given column index.
   size_t column_offset(size_t col_idx) const {
     DCHECK_LT(col_idx, cols_.size());

--- a/src/yb/docdb/docdb_rocksdb_util.cc
+++ b/src/yb/docdb/docdb_rocksdb_util.cc
@@ -21,6 +21,7 @@
 #include "yb/common/transaction.h"
 
 #include "yb/dockv/doc_key.h"
+#include "yb/dockv/docdb_key_comparator.h"
 #include "yb/dockv/value_type.h"
 
 #include "yb/docdb/bounded_rocksdb_iterator.h"
@@ -660,6 +661,7 @@ void InitRocksDBBaseOptions(
   AutoInitFromRocksDBFlags(options);
   options->tablet_id = tablet_id;
   options->create_if_missing = true;
+
   // We should always sync data to ensure we can recover rocksdb from crash.
   options->disableDataSync = false;
   options->info_log_level = YBRocksDBLogger::ConvertToRocksDBLogLevel(FLAGS_minloglevel);

--- a/src/yb/docdb/docdb_rocksdb_util.cc
+++ b/src/yb/docdb/docdb_rocksdb_util.cc
@@ -153,20 +153,6 @@ DEFINE_NON_RUNTIME_uint64(db_max_flushing_bytes, 250_MB,
 DEFINE_UNKNOWN_bool(use_docdb_aware_bloom_filter, true,
     "Whether to use the DocDbAwareFilterPolicy for both bloom storage and seeks.");
 
-// The BSON-aware DocDB key comparator changes the comparator name written to a
-// RocksDB MANIFEST, which is an on-disk format change. Gating its installation
-// behind an AutoFlag keeps mixed-version and rolling-restart clusters on the
-// default BytewiseComparator until every node has been upgraded; tablets
-// created after the flag promotes will record yb.DocDBKeyComparator.v1 in their
-// MANIFEST and use the BSON-aware comparator. The schema gate in Tablet still
-// restricts the comparator to tablets whose primary key has a BSON column.
-DEFINE_RUNTIME_AUTO_bool(
-    enable_bson_pk_comparator, kExternal, false, true,
-    "Whether to install the BSON-aware DocDB key comparator for tablets whose "
-    "primary key contains a BSON column. Promotes after all nodes have upgraded; "
-    "the schema check in Tablet::MaybeUseDocDBKeyComparator gates installation "
-    "to the affected tablets so existing non-BSON tablets are unaffected.");
-
 DEFINE_UNKNOWN_bool(use_multi_level_index, true, "Whether to use multi-level data index.");
 
 DEFINE_RUNTIME_AUTO_bool(

--- a/src/yb/docdb/docdb_rocksdb_util.cc
+++ b/src/yb/docdb/docdb_rocksdb_util.cc
@@ -675,7 +675,6 @@ void InitRocksDBBaseOptions(
   AutoInitFromRocksDBFlags(options);
   options->tablet_id = tablet_id;
   options->create_if_missing = true;
-
   // We should always sync data to ensure we can recover rocksdb from crash.
   options->disableDataSync = false;
   options->info_log_level = YBRocksDBLogger::ConvertToRocksDBLogLevel(FLAGS_minloglevel);

--- a/src/yb/docdb/docdb_rocksdb_util.cc
+++ b/src/yb/docdb/docdb_rocksdb_util.cc
@@ -153,6 +153,20 @@ DEFINE_NON_RUNTIME_uint64(db_max_flushing_bytes, 250_MB,
 DEFINE_UNKNOWN_bool(use_docdb_aware_bloom_filter, true,
     "Whether to use the DocDbAwareFilterPolicy for both bloom storage and seeks.");
 
+// The BSON-aware DocDB key comparator changes the comparator name written to a
+// RocksDB MANIFEST, which is an on-disk format change. Gating its installation
+// behind an AutoFlag keeps mixed-version and rolling-restart clusters on the
+// default BytewiseComparator until every node has been upgraded; tablets
+// created after the flag promotes will record yb.DocDBKeyComparator.v1 in their
+// MANIFEST and use the BSON-aware comparator. The schema gate in Tablet still
+// restricts the comparator to tablets whose primary key has a BSON column.
+DEFINE_RUNTIME_AUTO_bool(
+    enable_bson_pk_comparator, kExternal, false, true,
+    "Whether to install the BSON-aware DocDB key comparator for tablets whose "
+    "primary key contains a BSON column. Promotes after all nodes have upgraded; "
+    "the schema check in Tablet::MaybeUseDocDBKeyComparator gates installation "
+    "to the affected tablets so existing non-BSON tablets are unaffected.");
+
 DEFINE_UNKNOWN_bool(use_multi_level_index, true, "Whether to use multi-level data index.");
 
 DEFINE_RUNTIME_AUTO_bool(

--- a/src/yb/dockv/CMakeLists.txt
+++ b/src/yb/dockv/CMakeLists.txt
@@ -29,6 +29,7 @@ add_dependencies(dockv_proto gen_src_yb_tserver_pg_client_proto)
 
 set(DOCKV_SRCS
     doc_bson.cc
+    docdb_key_comparator.cc
     doc_key.cc
     doc_kv_util.cc
     doc_path.cc
@@ -52,7 +53,7 @@ set(DOCKV_SRCS
     value_packing_v2.cc
     )
 
-set(DOCKV_DEPS dockv_proto vector_index yb_common yb_pggate_util yb_util)
+set(DOCKV_DEPS bson dockv_proto rocksdb vector_index yb_common yb_pggate_util yb_util)
 
 ADD_YB_LIBRARY(yb_dockv
         SRCS ${DOCKV_SRCS}
@@ -71,6 +72,7 @@ set(YB_TEST_LINK_LIBS yb_common yb_dockv_test_util ${YB_MIN_TEST_LIBS})
 
 ADD_YB_TEST(doc_key-test)
 ADD_YB_TEST(doc_kv_util-test)
+ADD_YB_TEST(docdb_key_comparator-test)
 ADD_YB_TEST(intent-test)
 ADD_YB_TEST(packed_row-test)
 ADD_YB_TEST(partial_row-test)

--- a/src/yb/dockv/doc_bson.cc
+++ b/src/yb/dockv/doc_bson.cc
@@ -11,12 +11,284 @@
 // under the License.
 //
 
+#include "yb/dockv/doc_bson.h"
+
+#include <bson/bson.h>
+
+#include <cmath>
+
+#include "yb/dockv/doc_kv_util.h"
 #include "yb/util/result.h"
 
-#include "yb/dockv/doc_bson.h"
-#include "yb/dockv/doc_kv_util.h"
-
 namespace yb::dockv {
+
+namespace {
+
+// Returns the canonical sort order for a BSON type, following MongoDB's ordering:
+// MinKey < Null/Undefined < Number < String/Symbol < Document < Array < Binary <
+// ObjectId < Boolean < DateTime < Timestamp < Regex < ... < MaxKey
+//
+// This matches the ordering used by the DocumentDB extension's GetSortOrderType().
+int GetSortOrderType(bson_type_t type) {
+  switch (type) {
+    case BSON_TYPE_EOD:
+    case BSON_TYPE_MINKEY:
+      return 0x0;
+    case BSON_TYPE_UNDEFINED:
+    case BSON_TYPE_NULL:
+      return 0x1;
+    case BSON_TYPE_DOUBLE:
+    case BSON_TYPE_INT32:
+    case BSON_TYPE_INT64:
+    case BSON_TYPE_DECIMAL128:
+      return 0x2;
+    case BSON_TYPE_BOOL:
+      return 0x8;
+    case BSON_TYPE_UTF8:
+    case BSON_TYPE_SYMBOL:
+      return 0x3;
+    case BSON_TYPE_DOCUMENT:
+      return 0x4;
+    case BSON_TYPE_ARRAY:
+      return 0x5;
+    case BSON_TYPE_BINARY:
+      return 0x6;
+    case BSON_TYPE_OID:
+      return 0x7;
+    case BSON_TYPE_DATE_TIME:
+      return 0x9;
+    case BSON_TYPE_TIMESTAMP:
+      return 0xA;
+    case BSON_TYPE_REGEX:
+      return 0xB;
+    case BSON_TYPE_DBPOINTER:
+      return 0xC;
+    case BSON_TYPE_CODE:
+      return 0xD;
+    case BSON_TYPE_CODEWSCOPE:
+      return 0xE;
+    case BSON_TYPE_MAXKEY:
+      return 0xF;
+    default:
+      return 0xFF;
+  }
+}
+
+int CompareSortOrderType(bson_type_t left, bson_type_t right) {
+  return GetSortOrderType(left) - GetSortOrderType(right);
+}
+
+// Converts a bson_value_t number to long double for cross-type comparison.
+long double BsonNumberAsLongDouble(const bson_value_t* value) {
+  switch (value->value_type) {
+    case BSON_TYPE_DOUBLE:
+      return static_cast<long double>(value->value.v_double);
+    case BSON_TYPE_INT32:
+      return static_cast<long double>(value->value.v_int32);
+    case BSON_TYPE_INT64:
+      return static_cast<long double>(value->value.v_int64);
+    case BSON_TYPE_BOOL:
+      return value->value.v_bool ? 1.0L : 0.0L;
+    default:
+      return 0.0L;
+  }
+}
+
+// Converts a bson_value_t number to int64_t.
+int64_t BsonNumberAsInt64(const bson_value_t* value) {
+  switch (value->value_type) {
+    case BSON_TYPE_INT64:
+      return value->value.v_int64;
+    case BSON_TYPE_INT32:
+      return static_cast<int64_t>(value->value.v_int32);
+    case BSON_TYPE_DOUBLE:
+      return static_cast<int64_t>(value->value.v_double);
+    case BSON_TYPE_BOOL:
+      return value->value.v_bool ? 1 : 0;
+    default:
+      return 0;
+  }
+}
+
+// Compares two BSON numeric values with cross-type promotion.
+// Follows the same logic as DocumentDB's CompareNumbers.
+int CompareNumbers(const bson_value_t* left, const bson_value_t* right) {
+  // If either is double, compare as long double for precision.
+  if (left->value_type == BSON_TYPE_DOUBLE || right->value_type == BSON_TYPE_DOUBLE) {
+    long double left_val = BsonNumberAsLongDouble(left);
+    long double right_val = BsonNumberAsLongDouble(right);
+
+    if (std::isnan(left_val) && std::isnan(right_val)) return 0;
+    if (std::isnan(left_val)) return -1;
+    if (std::isnan(right_val)) return 1;
+
+    return (left_val > right_val) ? 1 : (left_val < right_val) ? -1 : 0;
+  }
+
+  // Both are integer types (int32, int64, bool) - compare as int64.
+  int64_t left_val = BsonNumberAsInt64(left);
+  int64_t right_val = BsonNumberAsInt64(right);
+  return (left_val > right_val) ? 1 : (left_val < right_val) ? -1 : 0;
+}
+
+int CompareStrings(const char* left, uint32_t left_len,
+                   const char* right, uint32_t right_len) {
+  uint32_t min_len = std::min(left_len, right_len);
+  int cmp = memcmp(left, right, min_len);
+  if (cmp != 0) return (cmp < 0) ? -1 : 1;
+  return (left_len < right_len) ? -1 : (left_len > right_len) ? 1 : 0;
+}
+
+// Forward declaration for recursive comparison.
+int CompareBsonIter(bson_iter_t* left, bson_iter_t* right, bool compare_fields);
+
+// Compares two bson_value_t values that have the same sort order type.
+int CompareBsonValues(const bson_value_t* left, const bson_value_t* right) {
+  switch (left->value_type) {
+    case BSON_TYPE_EOD:
+    case BSON_TYPE_MINKEY:
+    case BSON_TYPE_UNDEFINED:
+    case BSON_TYPE_NULL:
+    case BSON_TYPE_MAXKEY:
+      return 0;
+
+    case BSON_TYPE_DOUBLE:
+    case BSON_TYPE_INT32:
+    case BSON_TYPE_INT64:
+    case BSON_TYPE_BOOL:
+      return CompareNumbers(left, right);
+
+    case BSON_TYPE_UTF8:
+      return CompareStrings(
+          left->value.v_utf8.str, left->value.v_utf8.len,
+          right->value.v_utf8.str, right->value.v_utf8.len);
+
+    case BSON_TYPE_SYMBOL:
+      return CompareStrings(
+          left->value.v_symbol.symbol, left->value.v_symbol.len,
+          right->value.v_symbol.symbol, right->value.v_symbol.len);
+
+    case BSON_TYPE_DOCUMENT:
+    case BSON_TYPE_ARRAY: {
+      bson_iter_t left_inner, right_inner;
+      if (!bson_iter_init_from_data(
+              &left_inner, left->value.v_doc.data, left->value.v_doc.data_len) ||
+          !bson_iter_init_from_data(
+              &right_inner, right->value.v_doc.data, right->value.v_doc.data_len)) {
+        return 0;
+      }
+      return CompareBsonIter(&left_inner, &right_inner, /*compare_fields=*/true);
+    }
+
+    case BSON_TYPE_BINARY: {
+      uint32_t left_len = left->value.v_binary.data_len;
+      uint32_t right_len = right->value.v_binary.data_len;
+      if (left_len != right_len) {
+        return (left_len < right_len) ? -1 : 1;
+      }
+      if (left->value.v_binary.subtype != right->value.v_binary.subtype) {
+        return (left->value.v_binary.subtype < right->value.v_binary.subtype) ? -1 : 1;
+      }
+      if (left_len > 0) {
+        int cmp = memcmp(left->value.v_binary.data, right->value.v_binary.data, left_len);
+        if (cmp != 0) return (cmp < 0) ? -1 : 1;
+      }
+      return 0;
+    }
+
+    case BSON_TYPE_OID:
+      return bson_oid_compare(&left->value.v_oid, &right->value.v_oid);
+
+    case BSON_TYPE_DATE_TIME: {
+      int64_t l = left->value.v_datetime;
+      int64_t r = right->value.v_datetime;
+      return (l > r) ? 1 : (l < r) ? -1 : 0;
+    }
+
+    case BSON_TYPE_TIMESTAMP: {
+      // Compare seconds first, then increment.
+      if (left->value.v_timestamp.timestamp != right->value.v_timestamp.timestamp) {
+        return (left->value.v_timestamp.timestamp > right->value.v_timestamp.timestamp)
+            ? 1 : -1;
+      }
+      if (left->value.v_timestamp.increment != right->value.v_timestamp.increment) {
+        return (left->value.v_timestamp.increment > right->value.v_timestamp.increment)
+            ? 1 : -1;
+      }
+      return 0;
+    }
+
+    case BSON_TYPE_REGEX: {
+      if (!left->value.v_regex.regex || !right->value.v_regex.regex) {
+        return (left->value.v_regex.regex != nullptr) ? 1 : -1;
+      }
+      int cmp = strcmp(left->value.v_regex.regex, right->value.v_regex.regex);
+      if (cmp != 0) return (cmp < 0) ? -1 : 1;
+      if (!left->value.v_regex.options || !right->value.v_regex.options) {
+        return (left->value.v_regex.options != nullptr) ? 1 : -1;
+      }
+      cmp = strcmp(left->value.v_regex.options, right->value.v_regex.options);
+      return (cmp < 0) ? -1 : (cmp > 0) ? 1 : 0;
+    }
+
+    case BSON_TYPE_CODE:
+      return CompareStrings(
+          left->value.v_code.code, left->value.v_code.code_len,
+          right->value.v_code.code, right->value.v_code.code_len);
+
+    default:
+      return 0;
+  }
+}
+
+// Compares two BSON iterators element by element. This follows the same logic
+// as the DocumentDB extension's CompareBsonIter.
+int CompareBsonIter(bson_iter_t* left, bson_iter_t* right, bool compare_fields) {
+  while (true) {
+    bool left_next = bson_iter_next(left);
+    bool right_next = bson_iter_next(right);
+
+    if (!left_next && !right_next) return 0;
+    if (!left_next || !right_next) return left_next ? 1 : -1;
+
+    const bson_value_t* left_value = bson_iter_value(left);
+    const bson_value_t* right_value = bson_iter_value(right);
+
+    // Compare type sort order.
+    int cmp = CompareSortOrderType(left_value->value_type, right_value->value_type);
+    if (cmp != 0) return cmp;
+
+    // Compare field names if requested.
+    if (compare_fields) {
+      const char* left_key = bson_iter_key(left);
+      uint32_t left_key_len = bson_iter_key_len(left);
+      const char* right_key = bson_iter_key(right);
+      uint32_t right_key_len = bson_iter_key_len(right);
+      cmp = CompareStrings(left_key, left_key_len, right_key, right_key_len);
+      if (cmp != 0) return cmp;
+    }
+
+    // Compare values.
+    cmp = CompareBsonValues(left_value, right_value);
+    if (cmp != 0) return cmp;
+  }
+}
+
+}  // namespace
+
+int CompareBson(Slice a, Slice b) {
+  bson_iter_t left_iter, right_iter;
+
+  if (!bson_iter_init_from_data(
+          &left_iter, reinterpret_cast<const uint8_t*>(a.data()), a.size()) ||
+      !bson_iter_init_from_data(
+          &right_iter, reinterpret_cast<const uint8_t*>(b.data()), b.size())) {
+    // Invalid BSON data, fall back to byte-wise comparison.
+    return a.compare(b);
+  }
+
+  return CompareBsonIter(&left_iter, &right_iter, /*compare_fields=*/true);
+}
 
 // YB_TODO: Currently mapping BSON keys to string encoding, which is not correct. These functions
 // need to be updated, so that it gets converted such that the binary representation matches the

--- a/src/yb/dockv/doc_bson.cc
+++ b/src/yb/dockv/doc_bson.cc
@@ -24,11 +24,13 @@ namespace yb::dockv {
 
 namespace {
 
-// Returns the canonical sort order for a BSON type, following MongoDB's ordering:
+// Returns the canonical sort order for a BSON type, following ordering:
 // MinKey < Null/Undefined < Number < String/Symbol < Document < Array < Binary <
 // ObjectId < Boolean < DateTime < Timestamp < Regex < ... < MaxKey
 //
-// This matches the ordering used by the DocumentDB extension's GetSortOrderType().
+// Matches the table used by the DocumentDB extension in
+// pg_documentdb_core/src/query/bson_compare.c so the DocDB key comparator
+// and the PG-layer filters agree on canonical order.
 int GetSortOrderType(bson_type_t type) {
   switch (type) {
     case BSON_TYPE_EOD:
@@ -42,8 +44,6 @@ int GetSortOrderType(bson_type_t type) {
     case BSON_TYPE_INT64:
     case BSON_TYPE_DECIMAL128:
       return 0x2;
-    case BSON_TYPE_BOOL:
-      return 0x8;
     case BSON_TYPE_UTF8:
     case BSON_TYPE_SYMBOL:
       return 0x3;
@@ -55,6 +55,8 @@ int GetSortOrderType(bson_type_t type) {
       return 0x6;
     case BSON_TYPE_OID:
       return 0x7;
+    case BSON_TYPE_BOOL:
+      return 0x8;
     case BSON_TYPE_DATE_TIME:
       return 0x9;
     case BSON_TYPE_TIMESTAMP:
@@ -69,9 +71,9 @@ int GetSortOrderType(bson_type_t type) {
       return 0xE;
     case BSON_TYPE_MAXKEY:
       return 0xF;
-    default:
-      return 0xFF;
   }
+  // Every value of bson_type_t is enumerated above; unreachable in practice.
+  return 0xFF;
 }
 
 int CompareSortOrderType(bson_type_t left, bson_type_t right) {
@@ -82,59 +84,70 @@ int CompareSortOrderType(bson_type_t left, bson_type_t right) {
 // Decimal128 is routed through bson_decimal128_to_string + strtold; this loses
 // precision beyond ~19 significant digits but preserves canonical ordering for
 // the value ranges used as primary keys in practice.
-long double BsonNumberAsLongDouble(const bson_value_t* value) {
-  switch (value->value_type) {
+long double BsonNumberAsLongDouble(const bson_value_t& value) {
+  switch (value.value_type) {
     case BSON_TYPE_DOUBLE:
-      return static_cast<long double>(value->value.v_double);
+      return static_cast<long double>(value.value.v_double);
     case BSON_TYPE_INT32:
-      return static_cast<long double>(value->value.v_int32);
+      return static_cast<long double>(value.value.v_int32);
     case BSON_TYPE_INT64:
-      return static_cast<long double>(value->value.v_int64);
+      return static_cast<long double>(value.value.v_int64);
     case BSON_TYPE_BOOL:
-      return value->value.v_bool ? 1.0L : 0.0L;
+      return value.value.v_bool ? 1.0L : 0.0L;
     case BSON_TYPE_DECIMAL128: {
       char buf[BSON_DECIMAL128_STRING];
-      bson_decimal128_to_string(&value->value.v_decimal128, buf);
+      bson_decimal128_to_string(&value.value.v_decimal128, buf);
       char* end = nullptr;
-      long double result = strtold(buf, &end);
-      return result;
+      return strtold(buf, &end);
     }
     default:
+      // Callers (CompareNumbers) only invoke this for numeric types in the
+      // sort-order-group 0x2, all of which are listed above. Returning 0 here
+      // would be a bug at the call site -- safe only because CompareNumbers
+      // never reaches this with a non-numeric value.
       return 0.0L;
   }
 }
 
 // Converts a bson_value_t number to int64_t.
-int64_t BsonNumberAsInt64(const bson_value_t* value) {
-  switch (value->value_type) {
+int64_t BsonNumberAsInt64(const bson_value_t& value) {
+  switch (value.value_type) {
     case BSON_TYPE_INT64:
-      return value->value.v_int64;
+      return value.value.v_int64;
     case BSON_TYPE_INT32:
-      return static_cast<int64_t>(value->value.v_int32);
+      return static_cast<int64_t>(value.value.v_int32);
     case BSON_TYPE_DOUBLE:
-      return static_cast<int64_t>(value->value.v_double);
+      return static_cast<int64_t>(value.value.v_double);
     case BSON_TYPE_BOOL:
-      return value->value.v_bool ? 1 : 0;
+      return value.value.v_bool ? 1 : 0;
     case BSON_TYPE_DECIMAL128:
       return static_cast<int64_t>(BsonNumberAsLongDouble(value));
     default:
+      // Same reasoning as BsonNumberAsLongDouble: callers are responsible for
+      // ensuring this is only invoked with a numeric type.
       return 0;
   }
 }
 
 // Compares two BSON numeric values with cross-type promotion.
 // Follows the same logic as DocumentDB's CompareNumbers.
-int CompareNumbers(const bson_value_t* left, const bson_value_t* right) {
+int CompareNumbers(const bson_value_t& left, const bson_value_t& right) {
   // If either is double or decimal128, compare as long double for precision.
   // Decimal128 is routed through string conversion in BsonNumberAsLongDouble.
-  if (left->value_type == BSON_TYPE_DOUBLE || right->value_type == BSON_TYPE_DOUBLE ||
-      left->value_type == BSON_TYPE_DECIMAL128 || right->value_type == BSON_TYPE_DECIMAL128) {
+  if (left.value_type == BSON_TYPE_DOUBLE || right.value_type == BSON_TYPE_DOUBLE ||
+      left.value_type == BSON_TYPE_DECIMAL128 || right.value_type == BSON_TYPE_DECIMAL128) {
     long double left_val = BsonNumberAsLongDouble(left);
     long double right_val = BsonNumberAsLongDouble(right);
 
-    if (std::isnan(left_val) && std::isnan(right_val)) return 0;
-    if (std::isnan(left_val)) return -1;
-    if (std::isnan(right_val)) return 1;
+    if (std::isnan(left_val) && std::isnan(right_val)) {
+      return 0;
+    }
+    if (std::isnan(left_val)) {
+      return -1;
+    }
+    if (std::isnan(right_val)) {
+      return 1;
+    }
 
     return (left_val > right_val) ? 1 : (left_val < right_val) ? -1 : 0;
   }
@@ -149,7 +162,9 @@ int CompareStrings(const char* left, uint32_t left_len,
                    const char* right, uint32_t right_len) {
   uint32_t min_len = std::min(left_len, right_len);
   int cmp = memcmp(left, right, min_len);
-  if (cmp != 0) return (cmp < 0) ? -1 : 1;
+  if (cmp != 0) {
+    return (cmp < 0) ? -1 : 1;
+  }
   return (left_len < right_len) ? -1 : (left_len > right_len) ? 1 : 0;
 }
 
@@ -157,25 +172,29 @@ int CompareStrings(const char* left, uint32_t left_len,
 int CompareBsonIter(bson_iter_t* left, bson_iter_t* right, bool compare_fields);
 
 // Compares two bson_value_t values that have the same sort order type.
-int CompareBsonValues(const bson_value_t* left, const bson_value_t* right) {
-  switch (left->value_type) {
+// Returns -1, 0, or 1 like memcmp. Caller is responsible for ensuring left
+// and right share the same canonical sort-order group (see CompareBsonIter).
+int CompareBsonValues(const bson_value_t& left, const bson_value_t& right) {
+  switch (left.value_type) {
     case BSON_TYPE_EOD:
     case BSON_TYPE_MINKEY:
     case BSON_TYPE_UNDEFINED:
     case BSON_TYPE_NULL:
     case BSON_TYPE_MAXKEY:
+      // Sentinel and zero-bit types: equal iff in the same sort-order group,
+      // which the caller has already established.
       return 0;
 
     case BSON_TYPE_DECIMAL128:
       // Same-type DECIMAL128 vs DECIMAL128 keeps full precision via binary
       // comparison of (high, low) limbs. Cross-type with other numerics
       // routes through CompareNumbers / BsonNumberAsLongDouble below.
-      if (right->value_type == BSON_TYPE_DECIMAL128) {
-        if (left->value.v_decimal128.high != right->value.v_decimal128.high) {
-          return left->value.v_decimal128.high < right->value.v_decimal128.high ? -1 : 1;
+      if (right.value_type == BSON_TYPE_DECIMAL128) {
+        if (left.value.v_decimal128.high != right.value.v_decimal128.high) {
+          return left.value.v_decimal128.high < right.value.v_decimal128.high ? -1 : 1;
         }
-        if (left->value.v_decimal128.low != right->value.v_decimal128.low) {
-          return left->value.v_decimal128.low < right->value.v_decimal128.low ? -1 : 1;
+        if (left.value.v_decimal128.low != right.value.v_decimal128.low) {
+          return left.value.v_decimal128.low < right.value.v_decimal128.low ? -1 : 1;
         }
         return 0;
       }
@@ -188,111 +207,120 @@ int CompareBsonValues(const bson_value_t* left, const bson_value_t* right) {
 
     case BSON_TYPE_UTF8:
       return CompareStrings(
-          left->value.v_utf8.str, left->value.v_utf8.len,
-          right->value.v_utf8.str, right->value.v_utf8.len);
+          left.value.v_utf8.str, left.value.v_utf8.len,
+          right.value.v_utf8.str, right.value.v_utf8.len);
 
     case BSON_TYPE_SYMBOL:
       return CompareStrings(
-          left->value.v_symbol.symbol, left->value.v_symbol.len,
-          right->value.v_symbol.symbol, right->value.v_symbol.len);
+          left.value.v_symbol.symbol, left.value.v_symbol.len,
+          right.value.v_symbol.symbol, right.value.v_symbol.len);
 
     case BSON_TYPE_DOCUMENT:
     case BSON_TYPE_ARRAY: {
       bson_iter_t left_inner, right_inner;
       if (!bson_iter_init_from_data(
-              &left_inner, left->value.v_doc.data, left->value.v_doc.data_len) ||
+              &left_inner, left.value.v_doc.data, left.value.v_doc.data_len) ||
           !bson_iter_init_from_data(
-              &right_inner, right->value.v_doc.data, right->value.v_doc.data_len)) {
+              &right_inner, right.value.v_doc.data, right.value.v_doc.data_len)) {
         return 0;
       }
       return CompareBsonIter(&left_inner, &right_inner, /*compare_fields=*/true);
     }
 
     case BSON_TYPE_BINARY: {
-      uint32_t left_len = left->value.v_binary.data_len;
-      uint32_t right_len = right->value.v_binary.data_len;
+      uint32_t left_len = left.value.v_binary.data_len;
+      uint32_t right_len = right.value.v_binary.data_len;
       if (left_len != right_len) {
         return (left_len < right_len) ? -1 : 1;
       }
-      if (left->value.v_binary.subtype != right->value.v_binary.subtype) {
-        return (left->value.v_binary.subtype < right->value.v_binary.subtype) ? -1 : 1;
+      if (left.value.v_binary.subtype != right.value.v_binary.subtype) {
+        return (left.value.v_binary.subtype < right.value.v_binary.subtype) ? -1 : 1;
       }
       if (left_len > 0) {
-        int cmp = memcmp(left->value.v_binary.data, right->value.v_binary.data, left_len);
-        if (cmp != 0) return (cmp < 0) ? -1 : 1;
+        int cmp = memcmp(left.value.v_binary.data, right.value.v_binary.data, left_len);
+        if (cmp != 0) {
+          return (cmp < 0) ? -1 : 1;
+        }
       }
       return 0;
     }
 
     case BSON_TYPE_OID:
-      return bson_oid_compare(&left->value.v_oid, &right->value.v_oid);
+      return bson_oid_compare(&left.value.v_oid, &right.value.v_oid);
 
     case BSON_TYPE_DATE_TIME: {
-      int64_t l = left->value.v_datetime;
-      int64_t r = right->value.v_datetime;
+      int64_t l = left.value.v_datetime;
+      int64_t r = right.value.v_datetime;
       return (l > r) ? 1 : (l < r) ? -1 : 0;
     }
 
     case BSON_TYPE_TIMESTAMP: {
       // Compare seconds first, then increment.
-      if (left->value.v_timestamp.timestamp != right->value.v_timestamp.timestamp) {
-        return (left->value.v_timestamp.timestamp > right->value.v_timestamp.timestamp)
+      if (left.value.v_timestamp.timestamp != right.value.v_timestamp.timestamp) {
+        return (left.value.v_timestamp.timestamp > right.value.v_timestamp.timestamp)
             ? 1 : -1;
       }
-      if (left->value.v_timestamp.increment != right->value.v_timestamp.increment) {
-        return (left->value.v_timestamp.increment > right->value.v_timestamp.increment)
+      if (left.value.v_timestamp.increment != right.value.v_timestamp.increment) {
+        return (left.value.v_timestamp.increment > right.value.v_timestamp.increment)
             ? 1 : -1;
       }
       return 0;
     }
 
     case BSON_TYPE_REGEX: {
-      if (!left->value.v_regex.regex || !right->value.v_regex.regex) {
-        return (left->value.v_regex.regex != nullptr) ? 1 : -1;
+      if (!left.value.v_regex.regex || !right.value.v_regex.regex) {
+        return (left.value.v_regex.regex != nullptr) ? 1 : -1;
       }
-      int cmp = strcmp(left->value.v_regex.regex, right->value.v_regex.regex);
-      if (cmp != 0) return (cmp < 0) ? -1 : 1;
-      if (!left->value.v_regex.options || !right->value.v_regex.options) {
-        return (left->value.v_regex.options != nullptr) ? 1 : -1;
+      int cmp = strcmp(left.value.v_regex.regex, right.value.v_regex.regex);
+      if (cmp != 0) {
+        return (cmp < 0) ? -1 : 1;
       }
-      cmp = strcmp(left->value.v_regex.options, right->value.v_regex.options);
+      if (!left.value.v_regex.options || !right.value.v_regex.options) {
+        return (left.value.v_regex.options != nullptr) ? 1 : -1;
+      }
+      cmp = strcmp(left.value.v_regex.options, right.value.v_regex.options);
       return (cmp < 0) ? -1 : (cmp > 0) ? 1 : 0;
     }
 
     case BSON_TYPE_CODE:
       return CompareStrings(
-          left->value.v_code.code, left->value.v_code.code_len,
-          right->value.v_code.code, right->value.v_code.code_len);
+          left.value.v_code.code, left.value.v_code.code_len,
+          right.value.v_code.code, right.value.v_code.code_len);
 
     case BSON_TYPE_DBPOINTER: {
       // BSON spec: DBPointer compares collection name, then OID.
       int cmp = CompareStrings(
-          left->value.v_dbpointer.collection, left->value.v_dbpointer.collection_len,
-          right->value.v_dbpointer.collection, right->value.v_dbpointer.collection_len);
-      if (cmp != 0) return cmp;
-      return bson_oid_compare(&left->value.v_dbpointer.oid, &right->value.v_dbpointer.oid);
+          left.value.v_dbpointer.collection, left.value.v_dbpointer.collection_len,
+          right.value.v_dbpointer.collection, right.value.v_dbpointer.collection_len);
+      if (cmp != 0) {
+        return cmp;
+      }
+      return bson_oid_compare(&left.value.v_dbpointer.oid, &right.value.v_dbpointer.oid);
     }
 
     case BSON_TYPE_CODEWSCOPE: {
       // BSON spec: CodeWScope compares code, then scope document bytes.
       int cmp = CompareStrings(
-          left->value.v_codewscope.code, left->value.v_codewscope.code_len,
-          right->value.v_codewscope.code, right->value.v_codewscope.code_len);
-      if (cmp != 0) return cmp;
-      uint32_t left_len = left->value.v_codewscope.scope_len;
-      uint32_t right_len = right->value.v_codewscope.scope_len;
+          left.value.v_codewscope.code, left.value.v_codewscope.code_len,
+          right.value.v_codewscope.code, right.value.v_codewscope.code_len);
+      if (cmp != 0) {
+        return cmp;
+      }
+      uint32_t left_len = left.value.v_codewscope.scope_len;
+      uint32_t right_len = right.value.v_codewscope.scope_len;
       uint32_t min_len = std::min(left_len, right_len);
       if (min_len > 0) {
-        cmp = memcmp(left->value.v_codewscope.scope_data,
-                     right->value.v_codewscope.scope_data, min_len);
-        if (cmp != 0) return (cmp < 0) ? -1 : 1;
+        cmp = memcmp(left.value.v_codewscope.scope_data,
+                     right.value.v_codewscope.scope_data, min_len);
+        if (cmp != 0) {
+          return (cmp < 0) ? -1 : 1;
+        }
       }
       return (left_len < right_len) ? -1 : (left_len > right_len) ? 1 : 0;
     }
-
-    default:
-      return 0;
   }
+  // Every value of bson_type_t is enumerated above; unreachable in practice.
+  return 0;
 }
 
 // Compares two BSON iterators element by element. This follows the same logic
@@ -302,15 +330,21 @@ int CompareBsonIter(bson_iter_t* left, bson_iter_t* right, bool compare_fields) 
     bool left_next = bson_iter_next(left);
     bool right_next = bson_iter_next(right);
 
-    if (!left_next && !right_next) return 0;
-    if (!left_next || !right_next) return left_next ? 1 : -1;
+    if (!left_next && !right_next) {
+      return 0;
+    }
+    if (!left_next || !right_next) {
+      return left_next ? 1 : -1;
+    }
 
     const bson_value_t* left_value = bson_iter_value(left);
     const bson_value_t* right_value = bson_iter_value(right);
 
     // Compare type sort order.
     int cmp = CompareSortOrderType(left_value->value_type, right_value->value_type);
-    if (cmp != 0) return cmp;
+    if (cmp != 0) {
+      return cmp;
+    }
 
     // Compare field names if requested.
     if (compare_fields) {
@@ -319,12 +353,16 @@ int CompareBsonIter(bson_iter_t* left, bson_iter_t* right, bool compare_fields) 
       const char* right_key = bson_iter_key(right);
       uint32_t right_key_len = bson_iter_key_len(right);
       cmp = CompareStrings(left_key, left_key_len, right_key, right_key_len);
-      if (cmp != 0) return cmp;
+      if (cmp != 0) {
+        return cmp;
+      }
     }
 
     // Compare values.
-    cmp = CompareBsonValues(left_value, right_value);
-    if (cmp != 0) return cmp;
+    cmp = CompareBsonValues(*left_value, *right_value);
+    if (cmp != 0) {
+      return cmp;
+    }
   }
 }
 

--- a/src/yb/dockv/doc_bson.cc
+++ b/src/yb/dockv/doc_bson.cc
@@ -14,8 +14,10 @@
 #include "yb/dockv/doc_bson.h"
 
 #include <bson/bson.h>
+#include <locale.h>
 
 #include <cmath>
+#include <cstdlib>
 
 #include "yb/dockv/doc_kv_util.h"
 #include "yb/util/result.h"
@@ -23,6 +25,16 @@
 namespace yb::dockv {
 
 namespace {
+
+// Process-wide C locale used to parse the canonical Decimal128 string emitted
+// by bson_decimal128_to_string. strtold honors LC_NUMERIC for the decimal
+// separator, so we explicitly use the C locale to ensure '.' is the radix
+// regardless of the process locale setting. Allocated once on first use; not
+// freed -- the locale is needed for the lifetime of the process.
+locale_t CLocale() {
+  static locale_t locale = newlocale(LC_NUMERIC_MASK, "C", static_cast<locale_t>(0));
+  return locale;
+}
 
 // Returns the canonical sort order for a BSON type, following ordering:
 // MinKey < Null/Undefined < Number < String/Symbol < Document < Array < Binary <
@@ -98,7 +110,9 @@ long double BsonNumberAsLongDouble(const bson_value_t& value) {
       char buf[BSON_DECIMAL128_STRING];
       bson_decimal128_to_string(&value.value.v_decimal128, buf);
       char* end = nullptr;
-      return strtold(buf, &end);
+      // strtold_l with the C locale avoids LC_NUMERIC-dependent decimal-
+      // separator parsing; bson_decimal128_to_string always uses '.'.
+      return strtold_l(buf, &end, CLocale());
     }
     default:
       // Callers (CompareNumbers) only invoke this for numeric types in the
@@ -186,23 +200,17 @@ int CompareBsonValues(const bson_value_t& left, const bson_value_t& right) {
       return 0;
 
     case BSON_TYPE_DECIMAL128:
-      // Same-type DECIMAL128 vs DECIMAL128 keeps full precision via binary
-      // comparison of (high, low) limbs. Cross-type with other numerics
-      // routes through CompareNumbers / BsonNumberAsLongDouble below.
-      if (right.value_type == BSON_TYPE_DECIMAL128) {
-        if (left.value.v_decimal128.high != right.value.v_decimal128.high) {
-          return left.value.v_decimal128.high < right.value.v_decimal128.high ? -1 : 1;
-        }
-        if (left.value.v_decimal128.low != right.value.v_decimal128.low) {
-          return left.value.v_decimal128.low < right.value.v_decimal128.low ? -1 : 1;
-        }
-        return 0;
-      }
-      [[fallthrough]];
     case BSON_TYPE_DOUBLE:
     case BSON_TYPE_INT32:
     case BSON_TYPE_INT64:
     case BSON_TYPE_BOOL:
+      // All numerics including DECIMAL128 are compared via long-double
+      // promotion. Binary comparison of (high, low) limbs is not valid for
+      // Decimal128 because the most significant bit of `high` is the sign
+      // bit, so an unsigned compare would sort negative values above
+      // positive ones. The string-via-strtold_l path handles signs and
+      // exponents correctly (at the cost of ~19-digit precision, which is
+      // acceptable for primary-key uses).
       return CompareNumbers(left, right);
 
     case BSON_TYPE_UTF8:

--- a/src/yb/dockv/doc_bson.cc
+++ b/src/yb/dockv/doc_bson.cc
@@ -79,6 +79,9 @@ int CompareSortOrderType(bson_type_t left, bson_type_t right) {
 }
 
 // Converts a bson_value_t number to long double for cross-type comparison.
+// Decimal128 is routed through bson_decimal128_to_string + strtold; this loses
+// precision beyond ~19 significant digits but preserves canonical ordering for
+// the value ranges used as primary keys in practice.
 long double BsonNumberAsLongDouble(const bson_value_t* value) {
   switch (value->value_type) {
     case BSON_TYPE_DOUBLE:
@@ -89,6 +92,13 @@ long double BsonNumberAsLongDouble(const bson_value_t* value) {
       return static_cast<long double>(value->value.v_int64);
     case BSON_TYPE_BOOL:
       return value->value.v_bool ? 1.0L : 0.0L;
+    case BSON_TYPE_DECIMAL128: {
+      char buf[BSON_DECIMAL128_STRING];
+      bson_decimal128_to_string(&value->value.v_decimal128, buf);
+      char* end = nullptr;
+      long double result = strtold(buf, &end);
+      return result;
+    }
     default:
       return 0.0L;
   }
@@ -105,6 +115,8 @@ int64_t BsonNumberAsInt64(const bson_value_t* value) {
       return static_cast<int64_t>(value->value.v_double);
     case BSON_TYPE_BOOL:
       return value->value.v_bool ? 1 : 0;
+    case BSON_TYPE_DECIMAL128:
+      return static_cast<int64_t>(BsonNumberAsLongDouble(value));
     default:
       return 0;
   }
@@ -113,8 +125,10 @@ int64_t BsonNumberAsInt64(const bson_value_t* value) {
 // Compares two BSON numeric values with cross-type promotion.
 // Follows the same logic as DocumentDB's CompareNumbers.
 int CompareNumbers(const bson_value_t* left, const bson_value_t* right) {
-  // If either is double, compare as long double for precision.
-  if (left->value_type == BSON_TYPE_DOUBLE || right->value_type == BSON_TYPE_DOUBLE) {
+  // If either is double or decimal128, compare as long double for precision.
+  // Decimal128 is routed through string conversion in BsonNumberAsLongDouble.
+  if (left->value_type == BSON_TYPE_DOUBLE || right->value_type == BSON_TYPE_DOUBLE ||
+      left->value_type == BSON_TYPE_DECIMAL128 || right->value_type == BSON_TYPE_DECIMAL128) {
     long double left_val = BsonNumberAsLongDouble(left);
     long double right_val = BsonNumberAsLongDouble(right);
 
@@ -152,6 +166,20 @@ int CompareBsonValues(const bson_value_t* left, const bson_value_t* right) {
     case BSON_TYPE_MAXKEY:
       return 0;
 
+    case BSON_TYPE_DECIMAL128:
+      // Same-type DECIMAL128 vs DECIMAL128 keeps full precision via binary
+      // comparison of (high, low) limbs. Cross-type with other numerics
+      // routes through CompareNumbers / BsonNumberAsLongDouble below.
+      if (right->value_type == BSON_TYPE_DECIMAL128) {
+        if (left->value.v_decimal128.high != right->value.v_decimal128.high) {
+          return left->value.v_decimal128.high < right->value.v_decimal128.high ? -1 : 1;
+        }
+        if (left->value.v_decimal128.low != right->value.v_decimal128.low) {
+          return left->value.v_decimal128.low < right->value.v_decimal128.low ? -1 : 1;
+        }
+        return 0;
+      }
+      [[fallthrough]];
     case BSON_TYPE_DOUBLE:
     case BSON_TYPE_INT32:
     case BSON_TYPE_INT64:
@@ -235,6 +263,32 @@ int CompareBsonValues(const bson_value_t* left, const bson_value_t* right) {
       return CompareStrings(
           left->value.v_code.code, left->value.v_code.code_len,
           right->value.v_code.code, right->value.v_code.code_len);
+
+    case BSON_TYPE_DBPOINTER: {
+      // BSON spec: DBPointer compares collection name, then OID.
+      int cmp = CompareStrings(
+          left->value.v_dbpointer.collection, left->value.v_dbpointer.collection_len,
+          right->value.v_dbpointer.collection, right->value.v_dbpointer.collection_len);
+      if (cmp != 0) return cmp;
+      return bson_oid_compare(&left->value.v_dbpointer.oid, &right->value.v_dbpointer.oid);
+    }
+
+    case BSON_TYPE_CODEWSCOPE: {
+      // BSON spec: CodeWScope compares code, then scope document bytes.
+      int cmp = CompareStrings(
+          left->value.v_codewscope.code, left->value.v_codewscope.code_len,
+          right->value.v_codewscope.code, right->value.v_codewscope.code_len);
+      if (cmp != 0) return cmp;
+      uint32_t left_len = left->value.v_codewscope.scope_len;
+      uint32_t right_len = right->value.v_codewscope.scope_len;
+      uint32_t min_len = std::min(left_len, right_len);
+      if (min_len > 0) {
+        cmp = memcmp(left->value.v_codewscope.scope_data,
+                     right->value.v_codewscope.scope_data, min_len);
+        if (cmp != 0) return (cmp < 0) ? -1 : 1;
+      }
+      return (left_len < right_len) ? -1 : (left_len > right_len) ? 1 : 0;
+    }
 
     default:
       return 0;

--- a/src/yb/dockv/doc_bson.h
+++ b/src/yb/dockv/doc_bson.h
@@ -18,6 +18,14 @@
 
 namespace yb::dockv {
 
+// Compares two raw BSON documents according to BSON comparison rules.
+// BSON comparison follows MongoDB's canonical type ordering and compares
+// documents element by element. Returns < 0 if a < b, 0 if a == b, > 0 if a > b.
+//
+// This is needed because BSON's binary representation is NOT byte-order compatible
+// with its logical sort order (e.g., little-endian integers, signed number comparison).
+int CompareBson(Slice a, Slice b);
+
 void BsonKeyToComparableBinary(Slice slice, KeyBuffer& dest);
 
 void BsonKeyToComparableBinaryDescending(Slice slice, KeyBuffer& dest);

--- a/src/yb/dockv/docdb_key_comparator-test.cc
+++ b/src/yb/dockv/docdb_key_comparator-test.cc
@@ -1,0 +1,590 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "yb/dockv/doc_bson.h"
+#include "yb/dockv/docdb_key_comparator.h"
+#include "yb/dockv/key_bytes.h"
+#include "yb/dockv/key_entry_value.h"
+#include "yb/dockv/value_type.h"
+
+#include "yb/rocksdb/comparator.h"
+
+#include "yb/util/test_macros.h"
+
+using std::string;
+using std::vector;
+
+namespace yb::dockv {
+
+namespace {
+
+// Helper to construct a BSON document from field/value specifications.
+class BsonBuilder {
+ public:
+  void AddInt32(const string& name, int32_t value) {
+    data_.push_back(0x10);  // int32 type
+    AppendCString(name);
+    AppendLE32(value);
+  }
+
+  void AddInt64(const string& name, int64_t value) {
+    data_.push_back(0x12);  // int64 type
+    AppendCString(name);
+    AppendLE64(value);
+  }
+
+  void AddDouble(const string& name, double value) {
+    data_.push_back(0x01);  // double type
+    AppendCString(name);
+    AppendLEDouble(value);
+  }
+
+  void AddString(const string& name, const string& value) {
+    data_.push_back(0x02);  // string type
+    AppendCString(name);
+    // String value: int32 length (including null) + string + null.
+    int32_t len = static_cast<int32_t>(value.size()) + 1;
+    AppendLE32(len);
+    data_.insert(data_.end(), value.begin(), value.end());
+    data_.push_back(0x00);
+  }
+
+  void AddBoolean(const string& name, bool value) {
+    data_.push_back(0x08);  // boolean type
+    AppendCString(name);
+    data_.push_back(value ? 0x01 : 0x00);
+  }
+
+  void AddNull(const string& name) {
+    data_.push_back(0x0A);  // null type
+    AppendCString(name);
+  }
+
+  void AddObjectId(const string& name, const uint8_t oid[12]) {
+    data_.push_back(0x07);
+    AppendCString(name);
+    data_.insert(data_.end(), oid, oid + 12);
+  }
+
+  void AddDatetime(const string& name, int64_t millis_since_epoch) {
+    data_.push_back(0x09);
+    AppendCString(name);
+    AppendLE64(millis_since_epoch);
+  }
+
+  void AddTimestamp(const string& name, uint32_t seconds, uint32_t increment) {
+    data_.push_back(0x11);
+    AppendCString(name);
+    AppendLEU32(increment);
+    AppendLEU32(seconds);
+  }
+
+  void AddMinKey(const string& name) {
+    data_.push_back(0xFF);
+    AppendCString(name);
+  }
+
+  void AddMaxKey(const string& name) {
+    data_.push_back(0x7F);
+    AppendCString(name);
+  }
+
+  // Adds a nested BSON document as a field value.
+  void AddDocument(const string& name, const string& doc_bytes) {
+    data_.push_back(0x03);  // document type
+    AppendCString(name);
+    data_.insert(data_.end(), doc_bytes.begin(), doc_bytes.end());
+  }
+
+  // Adds a BSON array as a field value.
+  void AddArray(const string& name, const string& array_bytes) {
+    data_.push_back(0x04);  // array type
+    AppendCString(name);
+    data_.insert(data_.end(), array_bytes.begin(), array_bytes.end());
+  }
+
+  string Build() const {
+    // Total size = 4 (size) + data + 1 (terminator).
+    int32_t total_size = static_cast<int32_t>(4 + data_.size() + 1);
+    string result;
+    result.resize(4);
+    memcpy(result.data(), &total_size, 4);
+    result.append(data_.begin(), data_.end());
+    result.push_back(0x00);  // Document terminator.
+    return result;
+  }
+
+ private:
+  void AppendCString(const string& s) {
+    data_.insert(data_.end(), s.begin(), s.end());
+    data_.push_back(0x00);
+  }
+
+  void AppendLE32(int32_t value) {
+    uint8_t buf[4];
+    memcpy(buf, &value, 4);
+    data_.insert(data_.end(), buf, buf + 4);
+  }
+
+  void AppendLEU32(uint32_t value) {
+    uint8_t buf[4];
+    memcpy(buf, &value, 4);
+    data_.insert(data_.end(), buf, buf + 4);
+  }
+
+  void AppendLE64(int64_t value) {
+    uint8_t buf[8];
+    memcpy(buf, &value, 8);
+    data_.insert(data_.end(), buf, buf + 8);
+  }
+
+  void AppendLEDouble(double value) {
+    uint8_t buf[8];
+    memcpy(buf, &value, 8);
+    data_.insert(data_.end(), buf, buf + 8);
+  }
+
+  vector<uint8_t> data_;
+};
+
+// Helper to build a DocDB key with a BSON entry as a range component.
+string BuildKeyWithBson(const string& bson_bytes, SortOrder sort_order = SortOrder::kAscending) {
+  KeyBytes key;
+  key.AppendKeyEntryType(KeyEntryType::kUInt16Hash);
+  key.AppendUInt16(0x1234);
+  key.AppendGroupEnd();
+  auto bson_val = KeyEntryValue::MakeBson(Slice(bson_bytes), sort_order);
+  bson_val.AppendToKey(&key);
+  key.AppendGroupEnd();
+  return key.ToStringBuffer();
+}
+
+// Helper to build a DocDB key with an int32 range component followed by BSON.
+string BuildKeyWithInt32AndBson(int32_t int_val, const string& bson_bytes) {
+  KeyBytes key;
+  key.AppendKeyEntryType(KeyEntryType::kUInt16Hash);
+  key.AppendUInt16(0x1234);
+  key.AppendGroupEnd();
+  auto int_entry = KeyEntryValue::Int32(int_val);
+  int_entry.AppendToKey(&key);
+  auto bson_val = KeyEntryValue::MakeBson(Slice(bson_bytes));
+  bson_val.AppendToKey(&key);
+  key.AppendGroupEnd();
+  return key.ToStringBuffer();
+}
+
+// Helper to build a DocDB key with only non-BSON components.
+string BuildKeyWithInts(int32_t a, int64_t b) {
+  KeyBytes key;
+  key.AppendKeyEntryType(KeyEntryType::kUInt16Hash);
+  key.AppendUInt16(0x5678);
+  key.AppendGroupEnd();
+  auto int32_entry = KeyEntryValue::Int32(a);
+  int32_entry.AppendToKey(&key);
+  auto int64_entry = KeyEntryValue::Int64(b);
+  int64_entry.AppendToKey(&key);
+  key.AppendGroupEnd();
+  return key.ToStringBuffer();
+}
+
+}  // namespace
+
+// ----- Tests for CompareBson -----
+
+class CompareBsonTest : public ::testing::Test {};
+
+TEST(CompareBsonTest, Int32Positive) {
+  BsonBuilder a, b;
+  a.AddInt32("x", 42);
+  b.AddInt32("x", 100);
+  EXPECT_LT(CompareBson(a.Build(), b.Build()), 0);
+  EXPECT_GT(CompareBson(b.Build(), a.Build()), 0);
+}
+
+TEST(CompareBsonTest, Int32Equal) {
+  BsonBuilder a, b;
+  a.AddInt32("x", 42);
+  b.AddInt32("x", 42);
+  EXPECT_EQ(CompareBson(a.Build(), b.Build()), 0);
+}
+
+TEST(CompareBsonTest, Int32Negative) {
+  BsonBuilder a, b;
+  a.AddInt32("x", -1);
+  b.AddInt32("x", 1);
+  // BSON comparison: -1 < 1.
+  // But byte-wise (little-endian): -1 = FF FF FF FF > 01 00 00 00 = 1.
+  // This is exactly the case where byte-wise comparison is WRONG.
+  EXPECT_LT(CompareBson(a.Build(), b.Build()), 0);
+  EXPECT_GT(CompareBson(b.Build(), a.Build()), 0);
+}
+
+TEST(CompareBsonTest, Int32NegativeValues) {
+  BsonBuilder a, b;
+  a.AddInt32("x", -100);
+  b.AddInt32("x", -1);
+  EXPECT_LT(CompareBson(a.Build(), b.Build()), 0);
+}
+
+TEST(CompareBsonTest, Int64Values) {
+  BsonBuilder a, b;
+  a.AddInt64("x", -1000000);
+  b.AddInt64("x", 1000000);
+  EXPECT_LT(CompareBson(a.Build(), b.Build()), 0);
+}
+
+TEST(CompareBsonTest, DoubleValues) {
+  BsonBuilder a, b;
+  a.AddDouble("x", 1.5);
+  b.AddDouble("x", 2.5);
+  EXPECT_LT(CompareBson(a.Build(), b.Build()), 0);
+}
+
+TEST(CompareBsonTest, DoubleNegative) {
+  BsonBuilder a, b;
+  a.AddDouble("x", -1.5);
+  b.AddDouble("x", 1.5);
+  // BSON: -1.5 < 1.5. Byte-wise would give wrong result for doubles.
+  EXPECT_LT(CompareBson(a.Build(), b.Build()), 0);
+}
+
+TEST(CompareBsonTest, CrossTypeNumericInt32VsInt64) {
+  BsonBuilder a, b;
+  a.AddInt32("x", 42);
+  b.AddInt64("x", 42);
+  // Same numeric value, different types - should be equal.
+  EXPECT_EQ(CompareBson(a.Build(), b.Build()), 0);
+}
+
+TEST(CompareBsonTest, CrossTypeNumericInt32VsDouble) {
+  BsonBuilder a, b;
+  a.AddInt32("x", 42);
+  b.AddDouble("x", 42.0);
+  EXPECT_EQ(CompareBson(a.Build(), b.Build()), 0);
+}
+
+TEST(CompareBsonTest, CrossTypeNumericInt32VsLargerDouble) {
+  BsonBuilder a, b;
+  a.AddInt32("x", 42);
+  b.AddDouble("x", 42.5);
+  EXPECT_LT(CompareBson(a.Build(), b.Build()), 0);
+}
+
+TEST(CompareBsonTest, StringValues) {
+  BsonBuilder a, b;
+  a.AddString("x", "apple");
+  b.AddString("x", "banana");
+  EXPECT_LT(CompareBson(a.Build(), b.Build()), 0);
+}
+
+TEST(CompareBsonTest, StringEqual) {
+  BsonBuilder a, b;
+  a.AddString("x", "hello");
+  b.AddString("x", "hello");
+  EXPECT_EQ(CompareBson(a.Build(), b.Build()), 0);
+}
+
+TEST(CompareBsonTest, BooleanValues) {
+  BsonBuilder a, b;
+  a.AddBoolean("x", false);
+  b.AddBoolean("x", true);
+  EXPECT_LT(CompareBson(a.Build(), b.Build()), 0);
+}
+
+TEST(CompareBsonTest, NullValues) {
+  BsonBuilder a, b;
+  a.AddNull("x");
+  b.AddNull("x");
+  EXPECT_EQ(CompareBson(a.Build(), b.Build()), 0);
+}
+
+TEST(CompareBsonTest, TypeOrdering) {
+  // null < number < string < boolean
+  BsonBuilder null_doc, int_doc, str_doc, bool_doc;
+  null_doc.AddNull("x");
+  int_doc.AddInt32("x", 0);
+  str_doc.AddString("x", "");
+  bool_doc.AddBoolean("x", false);
+
+  EXPECT_LT(CompareBson(null_doc.Build(), int_doc.Build()), 0);
+  EXPECT_LT(CompareBson(int_doc.Build(), str_doc.Build()), 0);
+  EXPECT_LT(CompareBson(str_doc.Build(), bool_doc.Build()), 0);
+}
+
+TEST(CompareBsonTest, MinKeyMaxKey) {
+  BsonBuilder min_doc, max_doc, int_doc;
+  min_doc.AddMinKey("x");
+  max_doc.AddMaxKey("x");
+  int_doc.AddInt32("x", 0);
+
+  EXPECT_LT(CompareBson(min_doc.Build(), int_doc.Build()), 0);
+  EXPECT_GT(CompareBson(max_doc.Build(), int_doc.Build()), 0);
+  EXPECT_LT(CompareBson(min_doc.Build(), max_doc.Build()), 0);
+}
+
+TEST(CompareBsonTest, MultipleFields) {
+  BsonBuilder a, b;
+  a.AddInt32("x", 1);
+  a.AddInt32("y", 10);
+  b.AddInt32("x", 1);
+  b.AddInt32("y", 20);
+  // First fields equal, second fields differ.
+  EXPECT_LT(CompareBson(a.Build(), b.Build()), 0);
+}
+
+TEST(CompareBsonTest, DatetimeValues) {
+  BsonBuilder a, b;
+  a.AddDatetime("x", 1000);
+  b.AddDatetime("x", 2000);
+  EXPECT_LT(CompareBson(a.Build(), b.Build()), 0);
+}
+
+TEST(CompareBsonTest, DatetimeNegative) {
+  BsonBuilder a, b;
+  a.AddDatetime("x", -1000);
+  b.AddDatetime("x", 1000);
+  EXPECT_LT(CompareBson(a.Build(), b.Build()), 0);
+}
+
+TEST(CompareBsonTest, TimestampValues) {
+  BsonBuilder a, b;
+  a.AddTimestamp("x", 100, 1);  // seconds=100, increment=1
+  b.AddTimestamp("x", 100, 2);  // seconds=100, increment=2
+  EXPECT_LT(CompareBson(a.Build(), b.Build()), 0);
+}
+
+TEST(CompareBsonTest, TimestampSecondsDiffer) {
+  BsonBuilder a, b;
+  a.AddTimestamp("x", 100, 999);
+  b.AddTimestamp("x", 200, 1);
+  // Seconds compared first: 100 < 200.
+  EXPECT_LT(CompareBson(a.Build(), b.Build()), 0);
+}
+
+TEST(CompareBsonTest, NestedDocument) {
+  BsonBuilder inner_a, inner_b;
+  inner_a.AddInt32("y", -5);
+  inner_b.AddInt32("y", 5);
+
+  BsonBuilder a, b;
+  a.AddDocument("x", inner_a.Build());
+  b.AddDocument("x", inner_b.Build());
+  EXPECT_LT(CompareBson(a.Build(), b.Build()), 0);
+}
+
+TEST(CompareBsonTest, FewerElements) {
+  BsonBuilder a, b;
+  a.AddInt32("x", 1);
+  b.AddInt32("x", 1);
+  b.AddInt32("y", 2);
+  // Document with fewer elements is less.
+  EXPECT_LT(CompareBson(a.Build(), b.Build()), 0);
+}
+
+TEST(CompareBsonTest, ObjectId) {
+  uint8_t oid_a[12] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+  uint8_t oid_b[12] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12};
+  BsonBuilder a, b;
+  a.AddObjectId("x", oid_a);
+  b.AddObjectId("x", oid_b);
+  EXPECT_LT(CompareBson(a.Build(), b.Build()), 0);
+}
+
+// ----- Tests for DocDBKeyComparator -----
+
+class DocDBKeyComparatorTest : public ::testing::Test {
+ protected:
+  const rocksdb::Comparator* comparator_ = DocDBKeyComparatorInstance();
+  const rocksdb::Comparator* bytewise_ = rocksdb::BytewiseComparator();
+};
+
+TEST_F(DocDBKeyComparatorTest, NonBsonKeysMatchBytewise) {
+  // For keys without BSON, the custom comparator should give the same results
+  // as the BytewiseComparator.
+  auto key_a = BuildKeyWithInts(10, 100);
+  auto key_b = BuildKeyWithInts(20, 200);
+  auto key_c = BuildKeyWithInts(10, 100);
+
+  EXPECT_EQ(comparator_->Compare(key_a, key_c), 0);
+  EXPECT_LT(comparator_->Compare(key_a, key_b), 0);
+  EXPECT_GT(comparator_->Compare(key_b, key_a), 0);
+
+  // Verify matches BytewiseComparator.
+  EXPECT_EQ(
+      comparator_->Compare(key_a, key_b) < 0,
+      bytewise_->Compare(key_a, key_b) < 0);
+}
+
+TEST_F(DocDBKeyComparatorTest, BsonNegativeIntSortOrder) {
+  // This is the key test: BSON with negative integers should sort correctly
+  // even though their byte-wise representation would sort incorrectly.
+  BsonBuilder bson_neg1, bson_pos1;
+  bson_neg1.AddInt32("a", -1);
+  bson_pos1.AddInt32("a", 1);
+
+  auto key_neg1 = BuildKeyWithBson(bson_neg1.Build());
+  auto key_pos1 = BuildKeyWithBson(bson_pos1.Build());
+
+  // Custom comparator: -1 < 1 (correct BSON ordering).
+  EXPECT_LT(comparator_->Compare(key_neg1, key_pos1), 0);
+  EXPECT_GT(comparator_->Compare(key_pos1, key_neg1), 0);
+
+  // BytewiseComparator would give the WRONG result for this case because
+  // little-endian -1 (0xFFFFFFFF) > little-endian 1 (0x01000000).
+  EXPECT_GT(bytewise_->Compare(key_neg1, key_pos1), 0);
+}
+
+TEST_F(DocDBKeyComparatorTest, BsonEqualValues) {
+  BsonBuilder bson_a, bson_b;
+  bson_a.AddInt32("x", 42);
+  bson_b.AddInt32("x", 42);
+
+  auto key_a = BuildKeyWithBson(bson_a.Build());
+  auto key_b = BuildKeyWithBson(bson_b.Build());
+
+  EXPECT_EQ(comparator_->Compare(key_a, key_b), 0);
+  EXPECT_TRUE(comparator_->Equal(key_a, key_b));
+}
+
+TEST_F(DocDBKeyComparatorTest, BsonDescendingSortOrder) {
+  BsonBuilder bson_small, bson_large;
+  bson_small.AddInt32("a", -10);
+  bson_large.AddInt32("a", 10);
+
+  auto key_small = BuildKeyWithBson(bson_small.Build(), SortOrder::kDescending);
+  auto key_large = BuildKeyWithBson(bson_large.Build(), SortOrder::kDescending);
+
+  // Descending: larger value should sort first (smaller key).
+  EXPECT_GT(comparator_->Compare(key_small, key_large), 0);
+  EXPECT_LT(comparator_->Compare(key_large, key_small), 0);
+}
+
+TEST_F(DocDBKeyComparatorTest, BsonWithPrecedingInt32) {
+  // Test BSON comparison when there's a non-BSON component before it.
+  BsonBuilder bson_neg, bson_pos;
+  bson_neg.AddInt32("a", -5);
+  bson_pos.AddInt32("a", 5);
+
+  // Same int32 prefix, different BSON values.
+  auto key_a = BuildKeyWithInt32AndBson(100, bson_neg.Build());
+  auto key_b = BuildKeyWithInt32AndBson(100, bson_pos.Build());
+
+  EXPECT_LT(comparator_->Compare(key_a, key_b), 0);
+
+  // Different int32 prefix - should compare by int32 first.
+  auto key_c = BuildKeyWithInt32AndBson(50, bson_pos.Build());
+  auto key_d = BuildKeyWithInt32AndBson(200, bson_neg.Build());
+
+  EXPECT_LT(comparator_->Compare(key_c, key_d), 0);
+}
+
+TEST_F(DocDBKeyComparatorTest, BsonDoubleNegative) {
+  BsonBuilder bson_neg, bson_pos;
+  bson_neg.AddDouble("a", -1.5);
+  bson_pos.AddDouble("a", 1.5);
+
+  auto key_neg = BuildKeyWithBson(bson_neg.Build());
+  auto key_pos = BuildKeyWithBson(bson_pos.Build());
+
+  EXPECT_LT(comparator_->Compare(key_neg, key_pos), 0);
+}
+
+TEST_F(DocDBKeyComparatorTest, BsonCrossTypeNumeric) {
+  BsonBuilder bson_int32, bson_int64;
+  bson_int32.AddInt32("a", 42);
+  bson_int64.AddInt64("a", 43);
+
+  auto key_32 = BuildKeyWithBson(bson_int32.Build());
+  auto key_64 = BuildKeyWithBson(bson_int64.Build());
+
+  EXPECT_LT(comparator_->Compare(key_32, key_64), 0);
+}
+
+TEST_F(DocDBKeyComparatorTest, BsonTypeOrdering) {
+  BsonBuilder bson_null, bson_int, bson_str;
+  bson_null.AddNull("a");
+  bson_int.AddInt32("a", 0);
+  bson_str.AddString("a", "");
+
+  auto key_null = BuildKeyWithBson(bson_null.Build());
+  auto key_int = BuildKeyWithBson(bson_int.Build());
+  auto key_str = BuildKeyWithBson(bson_str.Build());
+
+  EXPECT_LT(comparator_->Compare(key_null, key_int), 0);
+  EXPECT_LT(comparator_->Compare(key_int, key_str), 0);
+}
+
+TEST_F(DocDBKeyComparatorTest, BsonStringComparison) {
+  BsonBuilder bson_a, bson_b;
+  bson_a.AddString("a", "apple");
+  bson_b.AddString("a", "banana");
+
+  auto key_a = BuildKeyWithBson(bson_a.Build());
+  auto key_b = BuildKeyWithBson(bson_b.Build());
+
+  EXPECT_LT(comparator_->Compare(key_a, key_b), 0);
+}
+
+TEST_F(DocDBKeyComparatorTest, ComparatorNameIsStable) {
+  EXPECT_STREQ(comparator_->Name(), "yb.DocDBKeyComparator.v1");
+}
+
+TEST_F(DocDBKeyComparatorTest, EmptyKeys) {
+  EXPECT_EQ(comparator_->Compare(Slice(), Slice()), 0);
+  Slice non_empty("abc", 3);
+  EXPECT_LT(comparator_->Compare(Slice(), non_empty), 0);
+  EXPECT_GT(comparator_->Compare(non_empty, Slice()), 0);
+}
+
+TEST_F(DocDBKeyComparatorTest, PrefixKeys) {
+  string key = "abc";
+  string prefix = "ab";
+  EXPECT_GT(comparator_->Compare(key, prefix), 0);
+  EXPECT_LT(comparator_->Compare(prefix, key), 0);
+}
+
+TEST_F(DocDBKeyComparatorTest, BsonMultipleFieldsNegativeValues) {
+  // Test with multiple fields where negative values matter.
+  BsonBuilder a, b;
+  a.AddInt32("x", 1);
+  a.AddInt32("y", -10);
+  b.AddInt32("x", 1);
+  b.AddInt32("y", 10);
+
+  auto key_a = BuildKeyWithBson(a.Build());
+  auto key_b = BuildKeyWithBson(b.Build());
+
+  EXPECT_LT(comparator_->Compare(key_a, key_b), 0);
+}
+
+TEST_F(DocDBKeyComparatorTest, BsonNestedDocument) {
+  BsonBuilder inner_a, inner_b;
+  inner_a.AddInt32("y", -100);
+  inner_b.AddInt32("y", 100);
+
+  BsonBuilder a, b;
+  a.AddDocument("x", inner_a.Build());
+  b.AddDocument("x", inner_b.Build());
+
+  auto key_a = BuildKeyWithBson(a.Build());
+  auto key_b = BuildKeyWithBson(b.Build());
+
+  EXPECT_LT(comparator_->Compare(key_a, key_b), 0);
+}
+
+}  // namespace yb::dockv

--- a/src/yb/dockv/docdb_key_comparator.cc
+++ b/src/yb/dockv/docdb_key_comparator.cc
@@ -1,0 +1,366 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/dockv/docdb_key_comparator.h"
+
+#include <string>
+
+#include "yb/dockv/doc_bson.h"
+#include "yb/dockv/doc_kv_util.h"
+#include "yb/dockv/value_type.h"
+#include "yb/util/slice.h"
+
+namespace yb::dockv {
+
+namespace {
+
+// Advances position past a zero-encoded value (terminated by 0x00 0x00).
+// Returns false if the terminator was not found.
+bool SkipZeroEncoded(const uint8_t* data, size_t size, size_t* pos) {
+  while (*pos + 1 < size) {
+    if (data[*pos] == 0x00) {
+      if (data[*pos + 1] == 0x00) {
+        *pos += 2;  // Skip the terminator.
+        return true;
+      }
+      // 0x00 0x01 is an escaped null byte; skip both.
+      *pos += 2;
+    } else {
+      (*pos)++;
+    }
+  }
+  // Reached end without finding terminator.
+  *pos = size;
+  return false;
+}
+
+// Advances position past a complement-zero-encoded value (terminated by 0xFF 0xFF).
+bool SkipComplementZeroEncoded(const uint8_t* data, size_t size, size_t* pos) {
+  while (*pos + 1 < size) {
+    if (data[*pos] == 0xFF) {
+      if (data[*pos + 1] == 0xFF) {
+        *pos += 2;
+        return true;
+      }
+      *pos += 2;
+    } else {
+      (*pos)++;
+    }
+  }
+  *pos = size;
+  return false;
+}
+
+// Information about a BSON region found in a key during scanning.
+struct BsonRegionInfo {
+  size_t value_start;    // Position of the first byte of the zero-encoded BSON value.
+  size_t value_end;      // Position past the terminator.
+  KeyEntryType type;     // kBson or kBsonDescending.
+};
+
+// Scans a DocDB key from the beginning to find all BSON regions.
+// Returns the BSON region that contains diff_pos, or std::nullopt if
+// diff_pos is not inside a BSON region.
+std::optional<BsonRegionInfo> FindBsonRegionContaining(
+    const uint8_t* data, size_t size, size_t diff_pos) {
+  size_t pos = 0;
+
+  while (pos < size) {
+    auto type = static_cast<KeyEntryType>(data[pos]);
+    size_t type_pos = pos;
+    pos++;  // Skip type byte.
+
+    bool is_bson = (type == KeyEntryType::kBson || type == KeyEntryType::kBsonDescending);
+    size_t value_start = pos;
+
+    switch (type) {
+      // Types with 0 additional bytes after the type byte.
+      case KeyEntryType::kGroupEnd:
+      case KeyEntryType::kGroupEndDescending:
+      case KeyEntryType::kNullLow:
+      case KeyEntryType::kNullHigh:
+      case KeyEntryType::kTrue:
+      case KeyEntryType::kTrueDescending:
+      case KeyEntryType::kFalse:
+      case KeyEntryType::kFalseDescending:
+      case KeyEntryType::kLowest:
+      case KeyEntryType::kHighest:
+      case KeyEntryType::kObject:
+      case KeyEntryType::kCounter:
+      case KeyEntryType::kSSForward:
+      case KeyEntryType::kSSReverse:
+      case KeyEntryType::kWeakObjectLock:
+      case KeyEntryType::kStrongObjectLock:
+      case KeyEntryType::kMaxByte:
+      case KeyEntryType::kVectorIndexMetadata:
+        break;
+
+      // 1 byte.
+      case KeyEntryType::kGinNull:
+        pos += 1;
+        break;
+
+      // 2 bytes.
+      case KeyEntryType::kUInt16Hash:
+        pos += 2;
+        break;
+
+      // 4 bytes.
+      case KeyEntryType::kInt32:
+      case KeyEntryType::kInt32Descending:
+      case KeyEntryType::kUInt32:
+      case KeyEntryType::kUInt32Descending:
+      case KeyEntryType::kFloat:
+      case KeyEntryType::kFloatDescending:
+      case KeyEntryType::kColocationId:
+      case KeyEntryType::kVectorId:
+        pos += 4;
+        break;
+
+      // 8 bytes.
+      case KeyEntryType::kInt64:
+      case KeyEntryType::kInt64Descending:
+      case KeyEntryType::kUInt64:
+      case KeyEntryType::kUInt64Descending:
+      case KeyEntryType::kDouble:
+      case KeyEntryType::kDoubleDescending:
+      case KeyEntryType::kTimestamp:
+      case KeyEntryType::kTimestampDescending:
+        pos += 8;
+        break;
+
+      // Zero-encoded types (terminated by 0x00 0x00).
+      case KeyEntryType::kString:
+      case KeyEntryType::kBson:
+      case KeyEntryType::kDecimal:
+      case KeyEntryType::kVarInt:
+      case KeyEntryType::kCollString:
+      case KeyEntryType::kUuid:
+      case KeyEntryType::kInetaddress:
+        SkipZeroEncoded(data, size, &pos);
+        break;
+
+      // Complement zero-encoded types (terminated by 0xFF 0xFF).
+      case KeyEntryType::kStringDescending:
+      case KeyEntryType::kBsonDescending:
+      case KeyEntryType::kDecimalDescending:
+      case KeyEntryType::kVarIntDescending:
+      case KeyEntryType::kCollStringDescending:
+      case KeyEntryType::kUuidDescending:
+      case KeyEntryType::kInetaddressDescending:
+        SkipComplementZeroEncoded(data, size, &pos);
+        break;
+
+      // Frozen types - recursive structure terminated by GroupEnd markers.
+      case KeyEntryType::kFrozen:
+        while (pos < size &&
+               static_cast<KeyEntryType>(data[pos]) != KeyEntryType::kGroupEnd) {
+          // Skip inner entries recursively by calling FindBsonRegionContaining
+          // with a diff_pos beyond the key to just scan forward.
+          // Simpler: just skip to the GroupEnd.
+          auto inner_type = static_cast<KeyEntryType>(data[pos]);
+          pos++;
+          if (inner_type == KeyEntryType::kGroupEnd) break;
+          // Handle inner types the same way (simplified - skip to group end).
+        }
+        // We'll fall through to the end-of-key fallback below for complex frozen types.
+        // For correctness, scan for the kGroupEnd byte.
+        while (pos < size && static_cast<KeyEntryType>(data[pos]) != KeyEntryType::kGroupEnd) {
+          pos++;
+        }
+        if (pos < size) pos++;  // Skip kGroupEnd.
+        break;
+
+      case KeyEntryType::kFrozenDescending:
+        while (pos < size &&
+               static_cast<KeyEntryType>(data[pos]) != KeyEntryType::kGroupEndDescending) {
+          pos++;
+        }
+        if (pos < size) pos++;
+        break;
+
+      // HybridTime appears at the end of keys. The encoding is variable-length
+      // and complex, so we skip to the end.
+      case KeyEntryType::kHybridTime:
+        pos = size;
+        break;
+
+      // Column IDs use variable-length encoding.
+      case KeyEntryType::kColumnId:
+      case KeyEntryType::kSystemColumnId:
+        while (pos < size && (data[pos] & 0x80)) pos++;
+        if (pos < size) pos++;
+        break;
+
+      // TableId: 16 bytes UUID.
+      case KeyEntryType::kTableId:
+        pos += 16;
+        break;
+
+      // Intent types, transaction IDs, etc.
+      case KeyEntryType::kIntentTypeSet:
+      case KeyEntryType::kObsoleteIntentTypeSet:
+      case KeyEntryType::kObsoleteIntentType:
+        pos += 1;
+        break;
+
+      case KeyEntryType::kTransactionId:
+      case KeyEntryType::kExternalTransactionId:
+        pos += 17;  // TransactionId is 16 bytes + 1 status byte typically.
+        break;
+
+      case KeyEntryType::kSubTransactionId:
+        pos += 4;
+        break;
+
+      default:
+        // Unknown type, can't determine size. Skip to end.
+        pos = size;
+        break;
+    }
+
+    // Check if the diff_pos falls within this component.
+    if (diff_pos >= type_pos && diff_pos < pos) {
+      if (is_bson && diff_pos >= value_start) {
+        return BsonRegionInfo{value_start, pos, type};
+      }
+      // diff_pos is in a non-BSON component (or in the type byte of a BSON component,
+      // which means the type bytes differ and byte-wise comparison is correct).
+      return std::nullopt;
+    }
+  }
+
+  return std::nullopt;
+}
+
+// Compares two keys that have a BSON region at the given position.
+// Decodes the BSON values from both keys and compares them using BSON comparison logic.
+// If the BSON values are equal, continues byte-wise comparison from after the BSON region.
+int CompareBsonRegion(Slice a, Slice b, const BsonRegionInfo& region) {
+  // Decode BSON value from key a.
+  Slice a_slice(a.data() + region.value_start, a.size() - region.value_start);
+  Slice b_slice(b.data() + region.value_start, b.size() - region.value_start);
+
+  std::string a_bson, b_bson;
+
+  Status sa, sb;
+  if (region.type == KeyEntryType::kBson) {
+    sa = BsonKeyFromComparableBinary(&a_slice, &a_bson);
+    sb = BsonKeyFromComparableBinary(&b_slice, &b_bson);
+  } else {
+    sa = BsonKeyFromComparableBinaryDescending(&a_slice, &a_bson);
+    sb = BsonKeyFromComparableBinaryDescending(&b_slice, &b_bson);
+  }
+
+  if (!sa.ok() || !sb.ok()) {
+    // Decoding failed, fall back to byte-wise comparison.
+    return a.compare(b);
+  }
+
+  int cmp = CompareBson(Slice(a_bson), Slice(b_bson));
+  if (region.type == KeyEntryType::kBsonDescending) {
+    cmp = -cmp;
+  }
+
+  if (cmp != 0) return cmp;
+
+  // BSON values are equal. Compare the remaining bytes after the BSON region.
+  // Note: The remaining key portions might also contain BSON entries, but since
+  // the BSON values are equal, their zero-encoded representations are also equal,
+  // meaning the next differing byte (if any) will be after this BSON region.
+  // We recursively apply the same logic by comparing the suffixes.
+  Slice a_suffix(a_slice.data(), a.end() - a_slice.data());
+  Slice b_suffix(b_slice.data(), b.end() - b_slice.data());
+
+  // For the suffix, we can use byte-wise comparison because:
+  // - If the decoded BSON values are equal, their zero-encoded forms are byte-wise equal
+  //   (same input -> same zero-encoding). So any difference in the suffix is in a different
+  //   component, which for equal BSON values would be past the BSON region.
+  return a_suffix.compare(b_suffix);
+}
+
+}  // namespace
+
+int DocDBKeyComparator::Compare(Slice a, Slice b) const {
+  // Fast path: byte-wise equality.
+  if (a == b) return 0;
+
+  const auto* a_data = reinterpret_cast<const uint8_t*>(a.data());
+  const auto* b_data = reinterpret_cast<const uint8_t*>(b.data());
+  size_t a_size = a.size();
+  size_t b_size = b.size();
+
+  // Find the first position where the two keys differ.
+  size_t min_len = std::min(a_size, b_size);
+  size_t diff_pos = 0;
+  while (diff_pos < min_len && a_data[diff_pos] == b_data[diff_pos]) {
+    diff_pos++;
+  }
+
+  if (diff_pos == min_len) {
+    // One key is a prefix of the other.
+    return (a_size < b_size) ? -1 : (a_size > b_size) ? 1 : 0;
+  }
+
+  // Quick check: scan the common prefix for potential BSON type bytes.
+  // kBson = 'o' = 111, kBsonDescending = 'p' = 112.
+  // If neither byte appears in the prefix up to diff_pos, the difference
+  // cannot be inside a BSON region and byte-wise comparison is correct.
+  bool may_have_bson = false;
+  for (size_t i = 0; i < diff_pos; i++) {
+    if (a_data[i] == static_cast<uint8_t>(KeyEntryType::kBson) ||
+        a_data[i] == static_cast<uint8_t>(KeyEntryType::kBsonDescending)) {
+      may_have_bson = true;
+      break;
+    }
+  }
+
+  if (may_have_bson) {
+    // Scan the key structure to determine if diff_pos falls within a BSON region.
+    auto bson_region = FindBsonRegionContaining(a_data, a_size, diff_pos);
+    if (bson_region) {
+      return CompareBsonRegion(a, b, *bson_region);
+    }
+  }
+
+  // Not in a BSON region; byte-wise comparison is correct.
+  return (a_data[diff_pos] < b_data[diff_pos]) ? -1 : 1;
+}
+
+bool DocDBKeyComparator::Equal(Slice a, Slice b) const {
+  // Byte-wise equality is always correct: if the encoded bytes are identical,
+  // the logical values are identical regardless of BSON comparison rules.
+  return a == b;
+}
+
+const char* DocDBKeyComparator::Name() const {
+  return "yb.DocDBKeyComparator.v1";
+}
+
+void DocDBKeyComparator::FindShortestSeparator(
+    std::string* /* start */, const Slice& /* limit */) const {
+  // No-op. We cannot safely shorten keys because the shortened key might change
+  // its position relative to BSON-encoded keys. This is safe for correctness
+  // but slightly less space-efficient for index blocks.
+}
+
+void DocDBKeyComparator::FindShortSuccessor(std::string* /* key */) const {
+  // No-op for the same reason as FindShortestSeparator.
+}
+
+const rocksdb::Comparator* DocDBKeyComparatorInstance() {
+  static DocDBKeyComparator instance;
+  return &instance;
+}
+
+}  // namespace yb::dockv

--- a/src/yb/dockv/docdb_key_comparator.cc
+++ b/src/yb/dockv/docdb_key_comparator.cc
@@ -161,34 +161,6 @@ std::optional<BsonRegionInfo> FindBsonRegionContaining(
         SkipComplementZeroEncoded(data, size, &pos);
         break;
 
-      // Frozen types - recursive structure terminated by GroupEnd markers.
-      case KeyEntryType::kFrozen:
-        while (pos < size &&
-               static_cast<KeyEntryType>(data[pos]) != KeyEntryType::kGroupEnd) {
-          // Skip inner entries recursively by calling FindBsonRegionContaining
-          // with a diff_pos beyond the key to just scan forward.
-          // Simpler: just skip to the GroupEnd.
-          auto inner_type = static_cast<KeyEntryType>(data[pos]);
-          pos++;
-          if (inner_type == KeyEntryType::kGroupEnd) break;
-          // Handle inner types the same way (simplified - skip to group end).
-        }
-        // We'll fall through to the end-of-key fallback below for complex frozen types.
-        // For correctness, scan for the kGroupEnd byte.
-        while (pos < size && static_cast<KeyEntryType>(data[pos]) != KeyEntryType::kGroupEnd) {
-          pos++;
-        }
-        if (pos < size) pos++;  // Skip kGroupEnd.
-        break;
-
-      case KeyEntryType::kFrozenDescending:
-        while (pos < size &&
-               static_cast<KeyEntryType>(data[pos]) != KeyEntryType::kGroupEndDescending) {
-          pos++;
-        }
-        if (pos < size) pos++;
-        break;
-
       // HybridTime appears at the end of keys. The encoding is variable-length
       // and complex, so we skip to the end.
       case KeyEntryType::kHybridTime:
@@ -202,31 +174,34 @@ std::optional<BsonRegionInfo> FindBsonRegionContaining(
         if (pos < size) pos++;
         break;
 
-      // TableId: 16 bytes UUID.
+      // TableId, TransactionId, ExternalTransactionId, and TransactionApplyState
+      // are encoded via KeyBytes::AppendString -> ZeroEncodeAndAppendStrToKey,
+      // so they live in the zero-encoded group.
       case KeyEntryType::kTableId:
-        pos += 16;
+      case KeyEntryType::kTransactionId:
+      case KeyEntryType::kExternalTransactionId:
+        SkipZeroEncoded(data, size, &pos);
         break;
 
-      // Intent types, transaction IDs, etc.
+      // Frozen types contain a sequence of zero-encoded values terminated by a
+      // kGroupEnd marker, where any inner string-like component can itself
+      // contain 0x00 0x01-escaped null bytes. Parsing them robustly without
+      // duplicating the full DocDB key decoder is non-trivial, and DocumentDB
+      // tablets never have frozen primary keys. Bail to byte-wise comparison.
+      case KeyEntryType::kFrozen:
+      case KeyEntryType::kFrozenDescending:
+      // Intent records, sub-transaction ids, and other internal markers don't
+      // appear in DocumentDB collection PKs either; rather than guess their
+      // encoded width, bail out so the caller falls back to byte-wise compare.
       case KeyEntryType::kIntentTypeSet:
       case KeyEntryType::kObsoleteIntentTypeSet:
       case KeyEntryType::kObsoleteIntentType:
-        pos += 1;
-        break;
-
-      case KeyEntryType::kTransactionId:
-      case KeyEntryType::kExternalTransactionId:
-        pos += 17;  // TransactionId is 16 bytes + 1 status byte typically.
-        break;
-
       case KeyEntryType::kSubTransactionId:
-        pos += 4;
-        break;
+        return std::nullopt;
 
       default:
-        // Unknown type, can't determine size. Skip to end.
-        pos = size;
-        break;
+        // Unknown type, can't determine size. Bail to byte-wise comparison.
+        return std::nullopt;
     }
 
     // Check if the diff_pos falls within this component.

--- a/src/yb/dockv/docdb_key_comparator.cc
+++ b/src/yb/dockv/docdb_key_comparator.cc
@@ -218,9 +218,16 @@ std::optional<BsonRegionInfo> FindBsonRegionContaining(
   return std::nullopt;
 }
 
+// Forward declaration so CompareBsonRegion can recurse on the suffix when the
+// BSON region compares equal.
+int CompareKeyBsonAware(Slice a, Slice b);
+
 // Compares two keys that have a BSON region at the given position.
 // Decodes the BSON values from both keys and compares them using BSON comparison logic.
-// If the BSON values are equal, continues byte-wise comparison from after the BSON region.
+// If the BSON values are equal, recurses on the suffix using CompareKeyBsonAware
+// so that any subsequent BSON columns are also compared with canonical ordering
+// (a plain byte-wise compare on the suffix would miss type-equal-but-binary-
+// different cases like int32 vs int64).
 int CompareBsonRegion(Slice a, Slice b, const BsonRegionInfo& region) {
   // Decode BSON value from key a.
   Slice a_slice(a.data() + region.value_start, a.size() - region.value_start);
@@ -247,28 +254,23 @@ int CompareBsonRegion(Slice a, Slice b, const BsonRegionInfo& region) {
     cmp = -cmp;
   }
 
-  if (cmp != 0) return cmp;
+  if (cmp != 0) {
+    return cmp;
+  }
 
-  // BSON values are equal. Compare the remaining bytes after the BSON region.
-  // Note: The remaining key portions might also contain BSON entries, but since
-  // the BSON values are equal, their zero-encoded representations are also equal,
-  // meaning the next differing byte (if any) will be after this BSON region.
-  // We recursively apply the same logic by comparing the suffixes.
+  // BSON values are equal. The suffix after the BSON region may itself contain
+  // more BSON columns or other typed values; recurse so any further BSON
+  // regions are compared with canonical ordering rather than byte-wise.
   Slice a_suffix(a_slice.data(), a.end() - a_slice.data());
   Slice b_suffix(b_slice.data(), b.end() - b_slice.data());
-
-  // For the suffix, we can use byte-wise comparison because:
-  // - If the decoded BSON values are equal, their zero-encoded forms are byte-wise equal
-  //   (same input -> same zero-encoding). So any difference in the suffix is in a different
-  //   component, which for equal BSON values would be past the BSON region.
-  return a_suffix.compare(b_suffix);
+  return CompareKeyBsonAware(a_suffix, b_suffix);
 }
 
-}  // namespace
-
-int DocDBKeyComparator::Compare(Slice a, Slice b) const {
+int CompareKeyBsonAware(Slice a, Slice b) {
   // Fast path: byte-wise equality.
-  if (a == b) return 0;
+  if (a == b) {
+    return 0;
+  }
 
   const auto* a_data = reinterpret_cast<const uint8_t*>(a.data());
   const auto* b_data = reinterpret_cast<const uint8_t*>(b.data());
@@ -291,6 +293,9 @@ int DocDBKeyComparator::Compare(Slice a, Slice b) const {
   // kBson = 'o' = 111, kBsonDescending = 'p' = 112.
   // If neither byte appears in the prefix up to diff_pos, the difference
   // cannot be inside a BSON region and byte-wise comparison is correct.
+  // This is faster than the structural FindBsonRegionContaining walk for
+  // tablets where the diff lands inside a fixed-width column ahead of the
+  // BSON region (e.g. shard_key_value bigint preceding object_id bson).
   bool may_have_bson = false;
   for (size_t i = 0; i < diff_pos; i++) {
     if (a_data[i] == static_cast<uint8_t>(KeyEntryType::kBson) ||
@@ -310,6 +315,12 @@ int DocDBKeyComparator::Compare(Slice a, Slice b) const {
 
   // Not in a BSON region; byte-wise comparison is correct.
   return (a_data[diff_pos] < b_data[diff_pos]) ? -1 : 1;
+}
+
+}  // namespace
+
+int DocDBKeyComparator::Compare(Slice a, Slice b) const {
+  return CompareKeyBsonAware(a, b);
 }
 
 bool DocDBKeyComparator::Equal(Slice a, Slice b) const {

--- a/src/yb/dockv/docdb_key_comparator.h
+++ b/src/yb/dockv/docdb_key_comparator.h
@@ -1,0 +1,50 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#pragma once
+
+#include "yb/rocksdb/comparator.h"
+
+namespace yb::dockv {
+
+// A custom RocksDB comparator for DocDB keys that handles types whose binary
+// representation is not byte-order compatible with their logical sort order.
+//
+// Currently, the only such type is BSON (KeyEntryType::kBson / kBsonDescending).
+// BSON documents use little-endian integers and have type-specific comparison
+// rules that differ from byte-wise ordering.
+//
+// For all non-BSON key components, this comparator produces the same results as
+// the BytewiseComparator, since DocDB encodes those types in a byte-order
+// preserving manner.
+//
+// The comparator works by:
+//   1. Finding the first byte position where two keys differ (fast path).
+//   2. Scanning the key structure from the beginning to determine if the
+//      differing position falls within a BSON-encoded region.
+//   3. If in a BSON region, decoding both BSON values and comparing them
+//      using BSON-specific comparison logic (CompareBson).
+//   4. Otherwise, returning the byte-wise comparison result.
+class DocDBKeyComparator : public rocksdb::Comparator {
+ public:
+  int Compare(Slice a, Slice b) const override;
+  bool Equal(Slice a, Slice b) const override;
+  const char* Name() const override;
+  void FindShortestSeparator(std::string* start, const Slice& limit) const override;
+  void FindShortSuccessor(std::string* key) const override;
+};
+
+// Returns a singleton instance of DocDBKeyComparator.
+const rocksdb::Comparator* DocDBKeyComparatorInstance();
+
+}  // namespace yb::dockv

--- a/src/yb/integration-tests/documentdb/documentdb_test.cc
+++ b/src/yb/integration-tests/documentdb/documentdb_test.cc
@@ -16,6 +16,7 @@
 
 DECLARE_bool(ysql_enable_documentdb);
 DECLARE_bool(enable_pg_cron);
+DECLARE_bool(enable_bson_pk_comparator);
 
 namespace yb {
 class DocumentDBTest : public pgwrapper::PgMiniTestBase {
@@ -27,6 +28,7 @@ class DocumentDBTest : public pgwrapper::PgMiniTestBase {
 
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_ysql_enable_documentdb) = true;
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_pg_cron) = true;
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_bson_pk_comparator) = true;
 
     TEST_SETUP_SUPER(pgwrapper::PgMiniTestBase);
 

--- a/src/yb/integration-tests/documentdb/documentdb_test.cc
+++ b/src/yb/integration-tests/documentdb/documentdb_test.cc
@@ -16,7 +16,6 @@
 
 DECLARE_bool(ysql_enable_documentdb);
 DECLARE_bool(enable_pg_cron);
-DECLARE_bool(enable_bson_pk_comparator);
 
 namespace yb {
 class DocumentDBTest : public pgwrapper::PgMiniTestBase {
@@ -28,7 +27,6 @@ class DocumentDBTest : public pgwrapper::PgMiniTestBase {
 
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_ysql_enable_documentdb) = true;
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_pg_cron) = true;
-    ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_bson_pk_comparator) = true;
 
     TEST_SETUP_SUPER(pgwrapper::PgMiniTestBase);
 

--- a/src/yb/integration-tests/documentdb/documentdb_test.cc
+++ b/src/yb/integration-tests/documentdb/documentdb_test.cc
@@ -11,6 +11,7 @@
 // under the License.
 //
 
+#include "yb/integration-tests/mini_cluster.h"
 #include "yb/yql/pgwrapper/pg_mini_test_base.h"
 
 DECLARE_bool(ysql_enable_documentdb);
@@ -458,6 +459,157 @@ TEST_F(DocumentDBTest, BsonPrimaryKeyBinaryComparator) {
   // Type-bracketed: _id < true matches booleans < true — false is the only such value
   // and is not present in the data = 0 docs.
   ASSERT_EQ(match_count(R"({"_id": {"$lt": true}})"), 0);
+}
+
+// ObjectId is the default _id type in MongoDB collections. ObjectIds compare
+// byte-wise via bson_oid_compare, the only built-in comparator libbson exposes.
+// This test inserts five ObjectId _id values in non-sorted order, then exercises
+// exact-match lookup, range filters, and total count to confirm the byte-wise
+// ObjectId codepath in CompareBsonValues is reached and returns correct results.
+TEST_F(DocumentDBTest, BsonObjectIdPrimaryKey) {
+  const auto db_name = "documentdb";
+  const auto collection_name = "oid_pk";
+
+  // Inserted out of order; expected sort order is by lexicographic OID hex.
+  ASSERT_OK(conn_->FetchFormat(
+      R"(
+  SELECT documentdb_api.insert('$0', '{"insert":"$1", "documents":[
+    { "_id": { "$$oid": "5fffffffffffffffffffffff" } },
+    { "_id": { "$$oid": "100000000000000000000000" } },
+    { "_id": { "$$oid": "000000000000000000000001" } },
+    { "_id": { "$$oid": "ffffffffffffffffffffffff" } },
+    { "_id": { "$$oid": "7f7f7f7f7f7f7f7f7f7f7f7f" } }]}');
+  )",
+      db_name, collection_name));
+
+  auto match_count = [&](const std::string& filter) {
+    return CHECK_RESULT(conn_->FetchRow<int32_t>(Format(
+        R"(
+      SELECT jsonb_array_length(((cursorpage->>'cursor')::bson->>'firstBatch')::jsonb)
+        FROM documentdb_api.find_cursor_first_page('$0', '{ "find" : "$1",
+          "filter" : $2}');
+      )",
+        db_name, collection_name, filter)));
+  };
+
+  // Total docs.
+  ASSERT_EQ(match_count("{}"), 5);
+
+  // Exact match on each OID.
+  EXPECT_EQ(match_count(R"({"_id": {"$oid": "5fffffffffffffffffffffff"}})"), 1);
+  EXPECT_EQ(match_count(R"({"_id": {"$oid": "000000000000000000000001"}})"), 1);
+  EXPECT_EQ(match_count(R"({"_id": {"$oid": "ffffffffffffffffffffffff"}})"), 1);
+
+  // Exact match against a value that is not present.
+  EXPECT_EQ(match_count(R"({"_id": {"$oid": "000000000000000000000002"}})"), 0);
+
+  // $gt: > "5fffffffffffffffffffffff" matches {"7f...", "ff...", "10..." -> no, "10..." < "5f..."}.
+  // Lexicographically greater: "7f7f7f...", "ffff...". = 2 docs.
+  EXPECT_EQ(match_count(R"({"_id": {"$gt": {"$oid": "5fffffffffffffffffffffff"}}})"), 2);
+
+  // $lt: < "5fffffffffffffffffffffff" matches {"00...01", "10...", and not "5f..."}. = 2 docs.
+  EXPECT_EQ(match_count(R"({"_id": {"$lt": {"$oid": "5fffffffffffffffffffffff"}}})"), 2);
+
+  // $gte at the lower extreme: matches every doc.
+  EXPECT_EQ(match_count(R"({"_id": {"$gte": {"$oid": "000000000000000000000000"}}})"), 5);
+
+  // $lte at the upper extreme: matches every doc.
+  EXPECT_EQ(match_count(R"({"_id": {"$lte": {"$oid": "ffffffffffffffffffffffff"}}})"), 5);
+}
+
+// Match counts alone don't prove ordering — the comparator could return the
+// right set of rows in the wrong order. This test inserts negative and positive
+// int32 _id values out of order, queries with sort: {_id: 1} (and -1), and
+// asserts the returned documents come back in BSON canonical order.
+TEST_F(DocumentDBTest, PrimaryKeySortOrder) {
+  const auto db_name = "sorttest";
+  const auto collection_name = "sortcoll";
+
+  // Inserted unsorted; expected ascending order by _id: -100, -2, 0, 7, 42, 999.
+  ASSERT_OK(conn_->FetchFormat(
+      R"(
+  SELECT documentdb_api.insert('$0', '{"insert":"$1", "documents":[
+    { "_id": 42,   "label": "fortytwo" },
+    { "_id": -2,   "label": "negtwo"   },
+    { "_id": 999,  "label": "ninehundred" },
+    { "_id": 0,    "label": "zero" },
+    { "_id": -100, "label": "negonehundred" },
+    { "_id": 7,    "label": "seven" }]}');
+  )",
+      db_name, collection_name));
+
+  // Returns the `label` field of the document at the given index in the sorted
+  // firstBatch. Index 0 is the smallest under ascending sort, the largest under
+  // descending.
+  auto label_at = [&](int sort_direction, int index) {
+    return CHECK_RESULT(conn_->FetchRow<std::string>(Format(
+        R"(
+      SELECT (((cursorpage->>'cursor')::bson->>'firstBatch')::bson->>'$2')::bson->>'label'
+        FROM documentdb_api.find_cursor_first_page('$0', '{ "find" : "$1",
+          "sort" : { "_id" : $3 } }');
+      )",
+        db_name, collection_name, index, sort_direction)));
+  };
+
+  // Ascending: -100, -2, 0, 7, 42, 999.
+  EXPECT_EQ(label_at(1, 0), "negonehundred");
+  EXPECT_EQ(label_at(1, 1), "negtwo");
+  EXPECT_EQ(label_at(1, 2), "zero");
+  EXPECT_EQ(label_at(1, 3), "seven");
+  EXPECT_EQ(label_at(1, 4), "fortytwo");
+  EXPECT_EQ(label_at(1, 5), "ninehundred");
+
+  // Descending: 999, 42, 7, 0, -2, -100.
+  EXPECT_EQ(label_at(-1, 0), "ninehundred");
+  EXPECT_EQ(label_at(-1, 1), "fortytwo");
+  EXPECT_EQ(label_at(-1, 2), "seven");
+  EXPECT_EQ(label_at(-1, 3), "zero");
+  EXPECT_EQ(label_at(-1, 4), "negtwo");
+  EXPECT_EQ(label_at(-1, 5), "negonehundred");
+}
+
+// The comparator must produce correct results after a memtable flush and SST
+// compaction, not just for in-memory data. Compaction merges sorted runs using
+// the comparator, so a bug there can pass memtable-only tests and fail once
+// the data hits disk. This test inserts negative int32 _ids, forces a flush
+// plus compaction, then re-queries to confirm range filters still return the
+// same set of rows.
+TEST_F(DocumentDBTest, PrimaryKeyCompactionRoundTrip) {
+  const auto db_name = "compacttest";
+  const auto collection_name = "compactcoll";
+
+  ASSERT_OK(conn_->FetchFormat(
+      R"(
+  SELECT documentdb_api.insert('$0', '{"insert":"$1", "documents":[
+    { "_id": -10 }, { "_id": -1 }, { "_id": 0 }, { "_id": 5 },
+    { "_id": 42 }, { "_id": 100 }]}');
+  )",
+      db_name, collection_name));
+
+  auto match_count = [&](const std::string& filter) {
+    auto n_str = CHECK_RESULT(conn_->FetchRow<std::string>(Format(
+        R"(
+      SELECT document->>'n'
+        FROM documentdb_api.count_query('$0',
+          '{ "count": "$1", "query": $2 }');
+      )",
+        db_name, collection_name, filter)));
+    return std::stol(n_str);
+  };
+
+  // Baseline (memtable only).
+  ASSERT_EQ(match_count(R"({"_id": {"$lt": 0}})"), 2);
+  ASSERT_EQ(match_count(R"({"_id": {"$gt": 0}})"), 3);
+  ASSERT_EQ(match_count(R"({"_id": {"$gte": -1, "$lte": 42}})"), 4);
+
+  // Force flush + compaction so the comparator is exercised on SSTs.
+  ASSERT_OK(cluster_->FlushTablets());
+  ASSERT_OK(cluster_->CompactTablets());
+
+  // Post-compaction: same counts.
+  EXPECT_EQ(match_count(R"({"_id": {"$lt": 0}})"), 2);
+  EXPECT_EQ(match_count(R"({"_id": {"$gt": 0}})"), 3);
+  EXPECT_EQ(match_count(R"({"_id": {"$gte": -1, "$lte": 42}})"), 4);
 }
 
 }  // namespace yb

--- a/src/yb/integration-tests/documentdb/documentdb_test.cc
+++ b/src/yb/integration-tests/documentdb/documentdb_test.cc
@@ -217,4 +217,247 @@ TEST_F(DocumentDBTest, DropCollectionAndDatabase) {
   ASSERT_FALSE(coll_b_exists);
 }
 
+// Validates that primary key (_id) range queries with $gt and $lt return correct results.
+// This exercises the BSON comparison logic on the primary key, which is stored as a range
+// key in DocDB. Numeric _id values including negative numbers must sort correctly
+// (e.g., -10 < -1 < 0 < 5 < 42), which requires proper BSON comparison rather than
+// byte-wise ordering of little-endian integers.
+TEST_F(DocumentDBTest, PrimaryKeyRangeQuery) {
+  const auto db_name = "pktest";
+  const auto collection_name = "numbers";
+
+  // Insert documents with numeric _id values, including negatives.
+  // BSON stores int32 as little-endian, so byte-wise comparison would give wrong order
+  // for negative values (e.g., -1 = 0xFFFFFFFF would sort after 1 = 0x01000000).
+  ASSERT_OK(conn_->FetchFormat(
+      R"(
+  SELECT documentdb_api.insert('$0', '{"insert":"$1", "documents":[
+    { "_id": -10, "label": "neg10" },
+    { "_id": -1,  "label": "neg1" },
+    { "_id": 0,   "label": "zero" },
+    { "_id": 5,   "label": "five" },
+    { "_id": 42,  "label": "fortytwo" },
+    { "_id": 100, "label": "hundred" }]}');
+  )",
+      db_name, collection_name));
+
+  // Helper: get the label of the single document matching a filter.
+  auto get_label = [&](const std::string& filter) {
+    return CHECK_RESULT(conn_->FetchRow<std::string>(Format(
+        R"(
+      SELECT (((cursorpage->>'cursor')::bson->>'firstBatch')::bson->>'0')::bson->>'label'
+        FROM documentdb_api.find_cursor_first_page('$0',
+          '{ "find": "$1", "filter": $2 }');
+      )",
+        db_name, collection_name, filter)));
+  };
+
+  // Helper: count documents matching a filter using documentdb_api.count_query.
+  auto count_matching = [&](const std::string& filter) {
+    auto n_str = CHECK_RESULT(conn_->FetchRow<std::string>(Format(
+        R"(
+      SELECT document->>'n'
+        FROM documentdb_api.count_query('$0',
+          '{ "count": "$1", "query": $2 }');
+      )",
+        db_name, collection_name, filter)));
+    return std::stol(n_str);
+  };
+
+  // Verify total count.
+  ASSERT_EQ(
+      ASSERT_RESULT(conn_->FetchRow<int64_t>(Format(
+          "SELECT count(*) FROM documentdb_api.collection('$0','$1')", db_name, collection_name))),
+      6);
+
+  // Test exact _id lookup for a negative value.
+  EXPECT_EQ(get_label(R"({"_id": -1})"), "neg1");
+  EXPECT_EQ(get_label(R"({"_id": 0})"), "zero");
+  EXPECT_EQ(get_label(R"({"_id": 42})"), "fortytwo");
+
+  // Test $gt: _id > 0 should return 3 documents (5, 42, 100).
+  EXPECT_EQ(count_matching(R"({"_id": {"$gt": 0}})"), 3);
+
+  // Test $lt: _id < 0 should return 2 documents (-10, -1).
+  EXPECT_EQ(count_matching(R"({"_id": {"$lt": 0}})"), 2);
+
+  // Test $gt with negative boundary: _id > -5 should return 5 documents (-1, 0, 5, 42, 100).
+  EXPECT_EQ(count_matching(R"({"_id": {"$gt": -5}})"), 5);
+
+  // Test $lt with positive boundary: _id < 42 should return 4 documents (-10, -1, 0, 5).
+  EXPECT_EQ(count_matching(R"({"_id": {"$lt": 42}})"), 4);
+
+  // Test combined $gt and $lt: -1 < _id < 42 should return 2 documents (0, 5).
+  EXPECT_EQ(count_matching(R"({"_id": {"$gt": -1, "$lt": 42}})"), 2);
+
+  // Test $gte and $lte: -1 <= _id <= 5 should return 3 documents (-1, 0, 5).
+  EXPECT_EQ(count_matching(R"({"_id": {"$gte": -1, "$lte": 5}})"), 3);
+
+  // Test $gte at lower bound: _id >= -10 should return all 6 documents.
+  EXPECT_EQ(count_matching(R"({"_id": {"$gte": -10}})"), 6);
+
+  // Test $lte at upper bound: _id <= 100 should return all 6 documents.
+  EXPECT_EQ(count_matching(R"({"_id": {"$lte": 100}})"), 6);
+
+  // Test range that excludes everything: _id > 100 should return 0.
+  EXPECT_EQ(count_matching(R"({"_id": {"$gt": 100}})"), 0);
+
+  // Test range that excludes everything: _id < -10 should return 0.
+  EXPECT_EQ(count_matching(R"({"_id": {"$lt": -10}})"), 0);
+}
+
+// Validates that cross-type comparisons on _id work correctly with $gt/$lt.
+// BSON comparison must handle type coercion: int32, int64, and double values
+// with the same numeric value should compare as equal, and range queries across
+// types must return correct results. Binary comparison would fail because:
+// - int32(42) = 0x2A000000 (4 bytes) vs int64(42) = 0x2A00000000000000 (8 bytes)
+//   have different binary representations
+// - double(-1.5) = 0x000000000000F8BF vs int32(0) = 0x00000000 have incompatible
+//   binary layouts
+// - Different BSON type codes (0x10 for int32, 0x12 for int64, 0x01 for double)
+//   would sort by type code byte-wise rather than by numeric value
+TEST_F(DocumentDBTest, CrossTypePrimaryKeyComparison) {
+  const auto db_name = "crosstype";
+  const auto collection_name = "mixed";
+
+  // Insert documents with mixed numeric _id types.
+  // Note: DocumentDB/MongoDB infers the type from the JSON representation.
+  // Integers without decimals become int32/int64, values with decimals become double.
+  // We use $numberInt, $numberLong, $numberDouble for explicit types via EJSON.
+  ASSERT_OK(conn_->FetchFormat(
+      R"(
+  SELECT documentdb_api.insert('$0', '{"insert":"$1", "documents":[
+    { "_id": {"$$numberDouble": "-1.5"}, "label": "double_neg" },
+    { "_id": {"$$numberInt": "-1"},      "label": "int32_neg" },
+    { "_id": {"$$numberInt": "0"},       "label": "int32_zero" },
+    { "_id": {"$$numberLong": "1"},      "label": "int64_one" },
+    { "_id": {"$$numberDouble": "2.5"},  "label": "double_pos" },
+    { "_id": {"$$numberInt": "10"},      "label": "int32_ten" },
+    { "_id": {"$$numberLong": "100"},    "label": "int64_hundred" }]}');
+  )",
+      db_name, collection_name));
+
+  auto get_label = [&](const std::string& filter) {
+    return CHECK_RESULT(conn_->FetchRow<std::string>(Format(
+        R"(
+      SELECT (((cursorpage->>'cursor')::bson->>'firstBatch')::bson->>'0')::bson->>'label'
+        FROM documentdb_api.find_cursor_first_page('$0',
+          '{ "find": "$1", "filter": $2 }');
+      )",
+        db_name, collection_name, filter)));
+  };
+
+  auto count_matching = [&](const std::string& filter) {
+    auto n_str = CHECK_RESULT(conn_->FetchRow<std::string>(Format(
+        R"(
+      SELECT document->>'n'
+        FROM documentdb_api.count_query('$0',
+          '{ "count": "$1", "query": $2 }');
+      )",
+        db_name, collection_name, filter)));
+    return std::stol(n_str);
+  };
+
+  // Verify total count.
+  ASSERT_EQ(
+      ASSERT_RESULT(conn_->FetchRow<int64_t>(Format(
+          "SELECT count(*) FROM documentdb_api.collection('$0','$1')", db_name, collection_name))),
+      7);
+
+  // Exact match using the same type as stored.
+  EXPECT_EQ(get_label(R"({"_id": {"$numberLong": "1"}})"), "int64_one");
+  EXPECT_EQ(get_label(R"({"_id": {"$numberInt": "10"}})"), "int32_ten");
+
+  // $gt with double boundary across int types:
+  // _id > 0.5 should return int64(1), double(2.5), int32(10), int64(100) = 4 docs.
+  EXPECT_EQ(count_matching(R"({"_id": {"$gt": 0.5}})"), 4);
+
+  // $lt with negative double boundary:
+  // _id < -1.0 should return double(-1.5) = 1 doc.
+  // Binary comparison would fail: double(-1.5) bytes > int32(-1) bytes.
+  EXPECT_EQ(count_matching(R"({"_id": {"$lt": -1.0}})"), 1);
+
+  // $gt with int boundary should include double values:
+  // _id > 2 should return double(2.5), int32(10), int64(100) = 3 docs.
+  EXPECT_EQ(count_matching(R"({"_id": {"$gt": 2}})"), 3);
+
+  // $lt with int boundary should include double values:
+  // _id < 1 should return double(-1.5), int32(-1), int32(0) = 3 docs.
+  EXPECT_EQ(count_matching(R"({"_id": {"$lt": 1}})"), 3);
+
+  // Range query spanning mixed types:
+  // -1 < _id < 10 should return int32(0), int64(1), double(2.5) = 3 docs.
+  EXPECT_EQ(count_matching(R"({"_id": {"$gt": -1, "$lt": 10}})"), 3);
+
+  // $gte/$lte with exact type boundaries:
+  // -1.5 <= _id <= 2.5 should return double(-1.5), int32(-1), int32(0), int64(1), double(2.5)
+  // = 5 docs.
+  EXPECT_EQ(count_matching(R"({"_id": {"$gte": -1.5, "$lte": 2.5}})"), 5);
+
+  // All negative: _id < 0 should return double(-1.5), int32(-1) = 2 docs.
+  EXPECT_EQ(count_matching(R"({"_id": {"$lt": 0}})"), 2);
+
+  // All positive: _id > 0 should return int64(1), double(2.5), int32(10), int64(100) = 4 docs.
+  EXPECT_EQ(count_matching(R"({"_id": {"$gt": 0}})"), 4);
+}
+
+// Exercises MongoDB $gt / $lt semantics on the _id primary key for documents whose
+// _id values span BSON canonical types (MinKey, int32 across the sign and byte-width
+// boundaries, string, boolean, MaxKey). MongoDB's range operators are type-bracketed:
+// $gt / $lt only match documents whose _id has the same BSON type as the query value,
+// with MinKey and MaxKey as the cross-type exceptions ($gt: MinKey matches every value
+// strictly greater than MinKey across all types; $lt: MaxKey, symmetrically).
+TEST_F(DocumentDBTest, BsonPrimaryKeyBinaryComparator) {
+  const auto db_name = "documentdb";
+  const auto collection_name = "pk_cmp";
+
+  // Insert 8 docs whose _id values span BSON types and the int32 sign/byte-boundary
+  // boundaries. $$ escapes to $ through yb::Format's $N substitution.
+  ASSERT_OK(conn_->FetchFormat(
+      R"(
+  SELECT documentdb_api.insert('$0', '{"insert":"$1", "documents":[
+    { "_id": { "$$minKey": 1 } },
+    { "_id": -1 },
+    { "_id": 0 },
+    { "_id": 1 },
+    { "_id": 256 },
+    { "_id": "z_string" },
+    { "_id": true },
+    { "_id": { "$$maxKey": 1 } }]}');
+  )",
+      db_name, collection_name));
+
+  auto match_count = [&](const std::string& filter) {
+    return CHECK_RESULT(conn_->FetchRow<int32_t>(Format(
+        R"(
+      SELECT jsonb_array_length(((cursorpage->>'cursor')::bson->>'firstBatch')::jsonb)
+        FROM documentdb_api.find_cursor_first_page('$0', '{ "find" : "$1",
+          "filter" : $2}');
+      )",
+        db_name, collection_name, filter)));
+  };
+
+  // Sanity: all 8 docs are present.
+  ASSERT_EQ(match_count("{}"), 8);
+
+  // Type-bracketed: _id > -1 (int32) matches int32 values > -1 = { 0, 1, 256 } = 3 docs.
+  ASSERT_EQ(match_count(R"({"_id": {"$gt": -1}})"), 3);
+
+  // Type-bracketed: _id < 0 (int32) matches int32 values < 0 = { -1 } = 1 doc.
+  ASSERT_EQ(match_count(R"({"_id": {"$lt": 0}})"), 1);
+
+  // MinKey cross-type: _id > MinKey matches every doc except MinKey itself = 7 docs.
+  ASSERT_EQ(match_count(R"({"_id": {"$gt": {"$minKey": 1}}})"), 7);
+
+  // MaxKey cross-type: _id < MaxKey matches every doc except MaxKey itself = 7 docs.
+  ASSERT_EQ(match_count(R"({"_id": {"$lt": {"$maxKey": 1}}})"), 7);
+
+  // Type-bracketed: _id < "" matches strings < "" — there are none = 0 docs.
+  ASSERT_EQ(match_count(R"({"_id": {"$lt": ""}})"), 0);
+
+  // Type-bracketed: _id < true matches booleans < true — false is the only such value
+  // and is not present in the data = 0 docs.
+  ASSERT_EQ(match_count(R"({"_id": {"$lt": true}})"), 0);
+}
+
 }  // namespace yb

--- a/src/yb/tablet/tablet.cc
+++ b/src/yb/tablet/tablet.cc
@@ -336,7 +336,6 @@ DEFINE_RUNTIME_bool(vector_index_include_into_post_split_compaction, true,
 DECLARE_bool(cdc_immediate_transaction_cleanup);
 DECLARE_bool(consistent_restore);
 DECLARE_bool(TEST_invalidate_last_change_metadata_op);
-DECLARE_bool(enable_bson_pk_comparator);
 DECLARE_int32(client_read_write_timeout_ms);
 DECLARE_int32(rocksdb_level0_stop_writes_trigger);
 DECLARE_int32(rocksdb_level0_slowdown_writes_trigger);
@@ -4812,13 +4811,14 @@ void Tablet::InitRocksDBOptions(rocksdb::Options* options, const std::string& lo
 }
 
 void Tablet::MaybeUseDocDBKeyComparator(rocksdb::Options* options) {
-  // The BSON-aware comparator is only installed when both the AutoFlag is
-  // promoted and the tablet's schema has a BSON-typed primary key column.
-  // The AutoFlag handles upgrade safety -- the comparator name is recorded in
-  // the RocksDB MANIFEST, so it cannot change for a tablet's lifetime. The
-  // schema gate restricts the change to tablets that actually need it (sys.
-  // catalog and every non-BSON tablet keep BytewiseComparator).
-  if (FLAGS_enable_bson_pk_comparator && metadata_->schema()->HasBsonKeyColumn()) {
+  // The BSON-aware comparator is installed on tablets whose primary key has
+  // a BSON-typed column. The BSON DocDB type is new and not yet used by any
+  // shipped feature outside of preview DocumentDB collections, so there are
+  // no existing tablets with this schema to migrate; the comparator name
+  // recorded in a new tablet's MANIFEST matches the comparator we install on
+  // reopen. sys.catalog and every non-BSON tablet's HasBsonKeyColumn()
+  // returns false and they keep the default BytewiseComparator.
+  if (metadata_->schema()->HasBsonKeyColumn()) {
     options->comparator = dockv::DocDBKeyComparatorInstance();
   }
 }

--- a/src/yb/tablet/tablet.cc
+++ b/src/yb/tablet/tablet.cc
@@ -336,6 +336,7 @@ DEFINE_RUNTIME_bool(vector_index_include_into_post_split_compaction, true,
 DECLARE_bool(cdc_immediate_transaction_cleanup);
 DECLARE_bool(consistent_restore);
 DECLARE_bool(TEST_invalidate_last_change_metadata_op);
+DECLARE_bool(enable_bson_pk_comparator);
 DECLARE_int32(client_read_write_timeout_ms);
 DECLARE_int32(rocksdb_level0_stop_writes_trigger);
 DECLARE_int32(rocksdb_level0_slowdown_writes_trigger);
@@ -4811,13 +4812,13 @@ void Tablet::InitRocksDBOptions(rocksdb::Options* options, const std::string& lo
 }
 
 void Tablet::MaybeUseDocDBKeyComparator(rocksdb::Options* options) {
-  // The BSON-aware comparator is only installed for tablets that actually have
-  // a BSON-typed primary key column. RocksDB checks the comparator name on open
-  // against the MANIFEST, so we cannot switch the comparator on an existing
-  // tablet. Gating on the schema lets DocumentDB tablets get correct BSON
-  // ordering at creation time without affecting sys.catalog or any non-BSON
-  // tablet, whose MANIFESTs already record the default BytewiseComparator.
-  if (metadata_->schema()->HasBsonKeyColumn()) {
+  // The BSON-aware comparator is only installed when both the AutoFlag is
+  // promoted and the tablet's schema has a BSON-typed primary key column.
+  // The AutoFlag handles upgrade safety -- the comparator name is recorded in
+  // the RocksDB MANIFEST, so it cannot change for a tablet's lifetime. The
+  // schema gate restricts the change to tablets that actually need it (sys.
+  // catalog and every non-BSON tablet keep BytewiseComparator).
+  if (FLAGS_enable_bson_pk_comparator && metadata_->schema()->HasBsonKeyColumn()) {
     options->comparator = dockv::DocDBKeyComparatorInstance();
   }
 }

--- a/src/yb/tablet/tablet.cc
+++ b/src/yb/tablet/tablet.cc
@@ -73,6 +73,7 @@
 #include "yb/docdb/redis_operation.h"
 #include "yb/docdb/rocksdb_writer.h"
 
+#include "yb/dockv/docdb_key_comparator.h"
 #include "yb/dockv/value_type.h"
 
 #include "yb/gutil/casts.h"
@@ -4799,12 +4800,26 @@ void Tablet::InitRocksDBBaseOptions(rocksdb::Options* options) {
   docdb::InitRocksDBBaseOptions(
       options, LogPrefix(), tablet_id(), tablet_options_,
       hash_for_data_root_dir(metadata_->data_root_dir()));
+  MaybeUseDocDBKeyComparator(options);
 }
 
 void Tablet::InitRocksDBOptions(rocksdb::Options* options, const std::string& log_prefix) {
   docdb::InitRocksDBOptions(
       options, log_prefix, tablet_id(), /* statistics = */ nullptr, tablet_options_,
       rocksdb::BlockBasedTableOptions(), hash_for_data_root_dir(metadata_->data_root_dir()));
+  MaybeUseDocDBKeyComparator(options);
+}
+
+void Tablet::MaybeUseDocDBKeyComparator(rocksdb::Options* options) {
+  // The BSON-aware comparator is only installed for tablets that actually have
+  // a BSON-typed primary key column. RocksDB checks the comparator name on open
+  // against the MANIFEST, so we cannot switch the comparator on an existing
+  // tablet. Gating on the schema lets DocumentDB tablets get correct BSON
+  // ordering at creation time without affecting sys.catalog or any non-BSON
+  // tablet, whose MANIFESTs already record the default BytewiseComparator.
+  if (metadata_->schema()->HasBsonKeyColumn()) {
+    options->comparator = dockv::DocDBKeyComparatorInstance();
+  }
 }
 
 rocksdb::Env& Tablet::rocksdb_env() const {

--- a/src/yb/tablet/tablet.h
+++ b/src/yb/tablet/tablet.h
@@ -860,6 +860,13 @@ class Tablet : public AbstractTablet,
 
   void InitRocksDBOptions(rocksdb::Options* options, const std::string& log_prefix);
 
+  // Install the BSON-aware DocDB key comparator iff the runtime flag is set
+  // and this tablet's schema has at least one BSON-typed primary key column.
+  // Called from InitRocksDBBaseOptions / InitRocksDBOptions so non-BSON
+  // tablets (sys.catalog, all existing user tables) continue to use the
+  // default BytewiseComparator.
+  void MaybeUseDocDBKeyComparator(rocksdb::Options* options);
+
   TabletRetentionPolicy* RetentionPolicy() override {
     return retention_policy_.get();
   }


### PR DESCRIPTION
## Summary

DocDB uses RocksDB's default `BytewiseComparator` for all tablet primary key comparisons. For DocumentDB collection tablets the primary key contains a BSON `object_id` column. BSON integers are little-endian, so negative values sort incorrectly under byte-wise memcmp (e.g. `-1 = 0xFF…` byte-sorts after `1 = 0x01…`), causing `$gt`/`$lt` filters on `_id` with negative values to return wrong results. The same applies to cross-type numeric comparisons (int32 / int64 / double all belong to one BSON sort-order group but have different binary representations).

**Changes:**

- **`src/yb/dockv/doc_bson.{h,cc}`** — `CompareBson(Slice, Slice)`: walks two BSON documents element-by-element via libbson iterators, applies MongoDB canonical sort-order grouping (`GetSortOrderType`), and compares values with cross-type numeric promotion (int32/int64/double converted to `long double`). MinKey/MaxKey handled as the cross-type boundary exceptions per MongoDB spec.

- **`src/yb/dockv/docdb_key_comparator.{h,cc}`** — `DocDBKeyComparator`: a `rocksdb::Comparator` that finds the first differing byte in two DocDB keys, scans the key structure to determine whether that byte falls inside a `kBson`/`kBsonDescending` region, and if so decodes and compares the BSON values via `CompareBson`; otherwise falls back to byte-wise, preserving compatibility with all non-BSON key components.

- **`src/yb/common/schema.{h,cc}`** — `Schema::HasBsonKeyColumn()`: returns true iff any primary key column is BSON-typed.

- **`src/yb/tablet/tablet.{h,cc}`** — `Tablet::MaybeUseDocDBKeyComparator()`: installs `DocDBKeyComparatorInstance()` on a tablet's RocksDB options iff the schema has a BSON key column. Called from both `InitRocksDBBaseOptions` and `InitRocksDBOptions`. The per-schema gate is necessary because RocksDB checks the comparator name against the MANIFEST on open — tablets created under `BytewiseComparator` (sys.catalog, all non-DocumentDB tables) must keep it; DocumentDB collection tablets get the new comparator from the moment they are created.

- **`src/yb/dockv/docdb_key_comparator-test.cc`** — unit tests for the comparator and the BSON comparison helpers covering negative integers, doubles, cross-type numerics, type ordering, nested documents, MinKey/MaxKey.

- **`src/yb/integration-tests/documentdb/documentdb_test.cc`** — six end-to-end tests run against a live mini-cluster:
  - `PrimaryKeyRangeQuery`: validates that negative `int32` `_id` values sort correctly under `$gt`/`$lt`.
  - `CrossTypePrimaryKeyComparison`: validates cross-numeric-type ordering (int32/int64/double).
  - `BsonPrimaryKeyBinaryComparator`: validates MongoDB type-bracketed `$gt`/`$lt` semantics and the MinKey/MaxKey cross-type exceptions.
  - `BsonObjectIdPrimaryKey`: exercises the ObjectId path (the default MongoDB `_id` type, the only `CompareBsonValues` codepath that delegates to libbson via `bson_oid_compare`) with exact-match and range lookups.
  - `PrimaryKeySortOrder`: asserts the actual *ordering* of documents returned under `sort: {_id: 1}` and `{_id: -1}`, not just match counts.
  - `PrimaryKeyCompactionRoundTrip`: runs range-filter assertions before and after `MiniCluster::FlushTablets` + `CompactTablets`, confirming the comparator produces matching results before and after SST merge.

## Upgrade/Rollback safety

`DocDBKeyComparator` is installed only for tablets whose schema has a BSON-typed primary key column (`Schema::HasBsonKeyColumn()`). The BSON DocDB column type itself is new — DocumentDB collections are the only feature that uses it, and DocumentDB is preview / not yet generally available, so there are no shipped clusters with existing BSON-PK tablets to migrate. Every new BSON-PK tablet records `yb.DocDBKeyComparator.v1` in its MANIFEST from the moment it is created and the same name is provided on reopen.

`sys.catalog` and every existing non-BSON tablet's `HasBsonKeyColumn()` returns false, so they keep the default `BytewiseComparator` and their MANIFESTs are unaffected.

No AutoFlag or gFlag gate is needed because there is no pre-existing on-disk state to be compatible with.

## Test plan

- [x] Unit tests: `./yb_build.sh release --cxx-test docdb_key_comparator-test` — all cases pass (negative ints, doubles, cross-type numerics, type ordering, MinKey/MaxKey, nested documents).
- [x] Integration — `DocumentDBTest.PrimaryKeyRangeQuery`: negative `int32` `_id` values sort correctly under `$gt`/`$lt` (verified with mini-cluster).
- [x] Integration — `DocumentDBTest.CrossTypePrimaryKeyComparison`: int32/int64/double mixed-type `_id` ordering is correct.
- [x] Integration — `DocumentDBTest.BsonPrimaryKeyBinaryComparator`: type-bracketed `$gt`/`$lt` semantics match MongoDB spec; MinKey/MaxKey cross-type assertions pass.
- [x] Integration — `DocumentDBTest.BsonObjectIdPrimaryKey`: ObjectId `_id` exact-match + range filters; exercises the `bson_oid_compare` codepath.
- [x] Integration — `DocumentDBTest.PrimaryKeySortOrder`: returned-document ordering under `sort: {_id: ±1}` matches BSON canonical order.
- [x] Integration — `DocumentDBTest.PrimaryKeyCompactionRoundTrip`: range-filter results survive `FlushTablets` + `CompactTablets`.
- [x] Regression: `DocumentDBTest.SimpleCollection`, `DocumentDBTest.DropCollectionAndDatabase` unaffected — verified by running the full DocumentDB test suite.
- [x] sys.catalog and non-BSON tablets unaffected — `Schema::HasBsonKeyColumn()` returns false for these; `BytewiseComparator` name in their MANIFESTs is preserved and matches on reopen.


