### PR TITLE
Claude Skill: backport-commit improvements (cleanup, Phorge body format, conflict annotation)

### DIFF
--- a/.agents/scripts/backport-commit.py
+++ b/.agents/scripts/backport-commit.py
@@ -397,21 +397,24 @@ def amend_message(commit: str, branch: str, pr_url: Optional[str]) -> None:
     def is_test_plan_heading(line: str) -> bool:
         return line.startswith("## Test plan") or line.startswith("Test Plan:")
 
-    if any(is_test_plan_heading(line) for line in body_lines):
-        new_body_lines: list[str] = []
-        inserted = False
-        for line in body_lines:
-            if not inserted and is_test_plan_heading(line):
-                new_body_lines.append(original_line)
-                new_body_lines.append("")
-                inserted = True
-            new_body_lines.append(line)
-        new_body = "\n".join(new_body_lines)
-    else:
-        # If body_lines is empty (rare: original commit had no body beyond
-        # the prior footers we just stripped), avoid a leading blank line.
-        prefix = "\n".join(body_lines).rstrip()
-        new_body = (prefix + "\n\n" if prefix else "") + original_line
+    # Single pass: insert above the first test-plan heading. If none is
+    # found (rare -- nearly every commit body has one), fall through to
+    # the append-at-end branch.
+    new_body_lines: list[str] = []
+    inserted = False
+    for line in body_lines:
+        if not inserted and is_test_plan_heading(line):
+            new_body_lines.append(original_line)
+            new_body_lines.append("")
+            inserted = True
+        new_body_lines.append(line)
+    if not inserted:
+        while new_body_lines and not new_body_lines[-1].strip():
+            new_body_lines.pop()
+        if new_body_lines:
+            new_body_lines.append("")
+        new_body_lines.append(original_line)
+    new_body = "\n".join(new_body_lines)
 
     run(["git", "commit", "--amend", "--cleanup=verbatim",
          "-m", new_subject, "-m", new_body])

--- a/.agents/scripts/backport-commit.py
+++ b/.agents/scripts/backport-commit.py
@@ -371,8 +371,10 @@ def amend_message(commit: str, branch: str, pr_url: Optional[str]) -> None:
     new_subject = f"[BACKPORT {branch}]{sep}{subject}"
 
     # Body: original commit's body, minus any prior Backport-of / Original-commit
-    # footers, with `Original commit: <SHA> / #<PR>` inserted above the `## Test plan`
-    # heading (if present) or appended at the end.
+    # footers, with `Original commit: <SHA> / #<PR>` (GitHub-merged) or
+    # `Original commit: <SHA> / D<diff>` (Phorge-merged) inserted above the
+    # test-plan heading -- either Markdown `## Test plan` or Phorge
+    # `Test Plan:` -- or appended at the end if no heading exists.
     raw_body = git("log", "-n1", "--format=%b", commit)
     body_lines = [
         line for line in raw_body.splitlines()
@@ -381,15 +383,25 @@ def amend_message(commit: str, branch: str, pr_url: Optional[str]) -> None:
                 or line.startswith("Original commit:"))
     ]
     pr_num_match = re.search(r"/pull/(\d+)", pr_url) if pr_url else None
+    # Phorge-landed commits leave `Differential Revision: <url>/D<num>` in the
+    # body. Use the diff number when no GitHub PR was found.
+    phorge_match = (re.search(r"Differential Revision:\s*\S*?/D(\d+)", raw_body)
+                    if not pr_num_match else None)
     if pr_num_match:
         original_line = f"Original commit: {commit} / #{pr_num_match.group(1)}"
+    elif phorge_match:
+        original_line = f"Original commit: {commit} / D{phorge_match.group(1)}"
     else:
         original_line = f"Original commit: {commit}"
-    if any(line.startswith("## Test plan") for line in body_lines):
+
+    def is_test_plan_heading(line: str) -> bool:
+        return line.startswith("## Test plan") or line.startswith("Test Plan:")
+
+    if any(is_test_plan_heading(line) for line in body_lines):
         new_body_lines: list[str] = []
         inserted = False
         for line in body_lines:
-            if not inserted and line.startswith("## Test plan"):
+            if not inserted and is_test_plan_heading(line):
                 new_body_lines.append(original_line)
                 new_body_lines.append("")
                 inserted = True

--- a/.agents/scripts/backport-commit.py
+++ b/.agents/scripts/backport-commit.py
@@ -124,6 +124,9 @@ def parse_args(argv):
                    help="Backport to all stable branches >= this branch.")
     p.add_argument("-x", "--accept-branch", action="append", default=[],
                    help="Skip cherry-pick on the given branch (already resolved).")
+    p.add_argument("--keep-workspace", action="store_true",
+                   help="On success, don't delete local task branches or remove "
+                        "the worktree (default cleans up after PRs are created).")
     p.add_argument("commit", help="Commit SHA (>=7 hex chars).")
     p.add_argument("branches", nargs="*", help="Destination branches.")
     args = p.parse_args(argv)
@@ -149,7 +152,7 @@ def normalize_reviewers(s: Optional[str]) -> Optional[str]:
 
 # --- Workspace + remote detection -------------------------------------------
 
-def setup_workspace(workspace: Path, use_local: bool) -> None:
+def setup_workspace(workspace: Path, use_local: bool) -> bool:
     """Set up workspace and cd into it.
 
     For a fresh path, creates a git worktree off SCRIPT_REPO_ROOT (the
@@ -158,7 +161,11 @@ def setup_workspace(workspace: Path, use_local: bool) -> None:
     refs are visible across worktrees. An existing path is reused
     as-is, whether it's a worktree, a clone, or a plain checkout --
     we trust it as long as it's a valid git working directory.
+
+    Returns True iff this call created the worktree (so post-run cleanup
+    can safely remove it without clobbering a pre-existing checkout).
     """
+    created = False
     if use_local:
         info(f"Using current workspace: {workspace}")
     elif workspace.exists():
@@ -172,8 +179,10 @@ def setup_workspace(workspace: Path, use_local: bool) -> None:
         workspace.parent.mkdir(parents=True, exist_ok=True)
         run(["git", "-C", str(SCRIPT_REPO_ROOT), "worktree", "add",
              "--detach", str(workspace)])
+        created = True
 
     os.chdir(workspace)
+    return created
 
 
 def detect_upstream_remote(gh_repo: str) -> str:
@@ -500,6 +509,50 @@ def request_reviewers(gh_repo: str, pr_num: int, reviewers: str) -> None:
         warn(f"failed to add reviewers to PR #{pr_num} (continuing): {reviewers}")
 
 
+# --- Post-run cleanup -------------------------------------------------------
+
+def cleanup_after_success(workspace: Path, source_repo: Path,
+                          task_branches: list[str],
+                          try_remove_worktree: bool) -> None:
+    """Delete local task branches and (optionally) remove the worktree.
+
+    Called only on the success path (return 0 from main). Task branches
+    are no longer needed locally once their PRs are open -- the fork
+    holds the canonical copies. The worktree is only removed if we
+    created it this run AND it's still a linked worktree of source_repo;
+    that protects a plain checkout someone aimed YB_BACKPORT at.
+    """
+    if task_branches:
+        info(f"Deleting local task branches: {', '.join(task_branches)}")
+        # If HEAD points at one of the branches we're about to delete,
+        # detach so `git branch -D` doesn't refuse on "checked out here".
+        current = git("symbolic-ref", "--short", "HEAD", check=False)
+        if current in task_branches:
+            run(["git", "checkout", "--detach"], check=False)
+        for task in task_branches:
+            proc = run(["git", "branch", "-D", task], check=False)
+            if proc.returncode != 0:
+                warn(f"failed to delete local branch {task}: "
+                     f"{(proc.stderr or proc.stdout).strip()}")
+
+    if not try_remove_worktree:
+        return
+    # A linked worktree has `.git` as a file pointing at the source repo's
+    # .git/worktrees/<name> dir; a plain clone has `.git` as a directory.
+    # Refuse to remove the latter -- the user pointed YB_BACKPORT at it.
+    if not (workspace / ".git").is_file():
+        info(f"Workspace is not a linked worktree; leaving in place: {workspace}")
+        return
+    info(f"Removing worktree: {workspace}")
+    # cd out of the worktree before asking git to remove it.
+    os.chdir(source_repo)
+    proc = run(["git", "-C", str(source_repo), "worktree", "remove",
+                "--force", str(workspace)], check=False)
+    if proc.returncode != 0:
+        warn(f"failed to remove worktree {workspace}: "
+             f"{(proc.stderr or proc.stdout).strip()}")
+
+
 # --- Main -------------------------------------------------------------------
 
 def detect_stable_branches(upstream_remote: str, stable_limit: Optional[str]) -> list[str]:
@@ -573,7 +626,7 @@ def main(argv: list[str]) -> int:
              "Pass branches explicitly to skip auto-discovery entirely.")
 
     # Workspace + clean check.
-    setup_workspace(workspace, args.local)
+    worktree_created = setup_workspace(workspace, args.local)
     upstream_remote = detect_upstream_remote(gh_repo)
     info(f"Fetching latest code from {upstream_remote}")
     run(["git", "fetch", upstream_remote])
@@ -634,6 +687,9 @@ def main(argv: list[str]) -> int:
     # one cherry-picks from the previous task branch's tip (so any conflict
     # resolution carries forward).
     port_cmd = base_port_cmd
+    # Task branches that have a published (or pre-existing) backport PR --
+    # candidates for local cleanup on success.
+    published_tasks: list[str] = []
     rerun_args = []
     if args.preview:    rerun_args.append("-n")
     if args.local:      rerun_args.append("-l")
@@ -675,6 +731,7 @@ def main(argv: list[str]) -> int:
             existing = None
         if existing:
             info(f"Existing backport PR found: {existing} -- skipping")
+            published_tasks.append(task)
             # The chain logic below cherry-picks from $task onto the next
             # branch; ensure $task is present locally and current with the
             # fork. Force-fetch (`+task:task`) so a stale local task ref
@@ -765,9 +822,18 @@ def main(argv: list[str]) -> int:
             new_pr_num_match = re.search(r"/pull/(\d+)$", new_url)
             if new_pr_num_match and final_reviewers:
                 request_reviewers(gh_repo, int(new_pr_num_match.group(1)), final_reviewers)
+            published_tasks.append(task)
 
         # Chain: next branch cherry-picks from this task branch's tip.
         port_cmd = ["git", "cherry-pick", "--allow-empty", task]
+
+    if not args.preview and not args.keep_workspace:
+        cleanup_after_success(
+            workspace=workspace,
+            source_repo=SCRIPT_REPO_ROOT,
+            task_branches=published_tasks,
+            try_remove_worktree=worktree_created and not args.local,
+        )
 
     return 0
 

--- a/.claude/commands/backport-commit.md
+++ b/.claude/commands/backport-commit.md
@@ -73,12 +73,15 @@ Once **all** conflicts are resolved (and only then):
 
 2. `git cherry-pick --continue --no-edit` to land the resolved commit. Use `--no-edit` so the original commit message is preserved verbatim — the script re-derives the subject/body from `$commitid` on rerun, so anything you type here gets discarded anyway. If the resolved diff is empty, run `git cherry-pick --skip` instead.
 
-3. **Track the resolution.** If you resolved any **non-trivial** conflict (i.e., anything not pure-whitespace), record `<path>:<line>` and a short summary of how you resolved it. May be multiple lines per file when the resolution touches several hunks. You will use this in Step 4. Also remember **which branch** the resolution was on. Example:
+3. **Track every resolution, trivial or not.** Any conflict you touched by hand needs a paper trail in Step 4 so a reviewer can see what was changed vs. the original commit. Record `<path>:<line>` and a short summary of the resolution. For trivial cases a one-liner is fine ("accepted cherry-pick's added block; branch had no code at that location"); for non-trivial cases, expand to one line per hunk you reasoned about. May be multiple lines per file. Also remember **which branch** the resolution was on. Example:
    ```
-   2024.2:
+   2024.2 (non-trivial):
      src/yb/master/catalog_manager.cc:1843 — kept master's call signature; release branch lost the `epoch` arg
      src/yb/master/catalog_manager.cc:2017 — re-applied the cherry-picked guard around the older AddTask path
      src/yb/master/catalog_manager.h:412 — moved the new method below the existing private block
+
+   2025.2 (trivial):
+     src/yb/master/master-path-handlers.cc:1015 — accepted cherry-pick's added block; branch had no code at that location
    ```
 
 4. **Run the linter** from the repo root and confirm it is clean before re-running:
@@ -99,9 +102,11 @@ If a *later* branch in the same run also hits conflicts, repeat this step for th
 
 Extract every `https://github.com/...` URL printed by `gh pr create` from the (possibly multi-run) script output. Each successfully backported branch produces one PR.
 
-### Step 4: Annotate the PR body for branches where non-trivial conflicts were resolved
+### Step 4: Annotate the PR body for every branch where a conflict was resolved by hand
 
-Only the branch(es) you actually resolved by hand need annotation — branches that picked up the resolved diff via chaining did not require manual conflict resolution.
+Any branch where you ran `git cherry-pick --continue` (vs. it auto-applying cleanly) needs an annotation, **regardless of whether the resolution was trivial or non-trivial**. Reviewers shouldn't have to diff the backport against the original commit to discover there was a manual step. "Trivial" describes how easy the resolution was, not whether it warrants disclosure.
+
+Branches that picked up a resolved diff via chaining don't need annotation — that's already implicit in the upstream branch they chained from.
 
 For each such PR:
 


### PR DESCRIPTION
## Summary

Three related improvements to the `/backport-commit` workflow.

### 1. Clean up local task branches and worktree after success

`backport-commit.py` previously left behind every local `backport-<sha>-<branch>` task branch plus the backport worktree (`$HOME/code/backport-ybdb` by default) after a successful run. Both are dead weight once the PRs are open — the fork holds the canonical task-branch copies that the PRs reference, and the worktree is just the scratch area used to assemble them.

- After the per-branch loop completes successfully, delete each local task branch whose PR was created (or was detected as pre-existing).
- Remove the backport worktree, but only when (a) **this run** created it and (b) it's still a linked worktree of the source repo (i.e. `workspace/.git` is a file pointer, not a real `.git/` directory). This protects a plain checkout someone aimed `YB_BACKPORT` at.
- Skip cleanup on the preview path (`-n`) and on the exit-2 conflict path so the user can still inspect / `cd` in / resume.
- New `--keep-workspace` flag to opt out entirely (debugging).

Implementation notes:
- `setup_workspace()` now returns a `worktree_created` flag.
- Task-branch deletion detaches HEAD first if it points at one of the branches about to be deleted, so `git branch -D` doesn't refuse on "checked out here".
- Failures (e.g. `worktree remove` refused) are warned but don't fail the script — the PRs are already created at that point.

### 2. Handle Phorge-style commit bodies in `amend_message`

For commits landed via Phorge, the body uses `Test Plan:` (Phorge convention) instead of `## Test plan` (GitHub PR convention) and ends with a `Differential Revision: https://phorge.../D<num>` footer. Previously the script only recognized the Markdown heading, so:

- the `Original commit:` footer was appended at the very end of the body (below the Phorge footers) instead of above `Test Plan:`, and
- it used only the SHA with no reference, since no GitHub PR matched the commit.

Now the script matches either heading for the insertion position, and when no GitHub PR is found it parses the `Differential Revision: ...D<num>` footer to produce `Original commit: <SHA> / D<num>` (mirroring the `<SHA> / #<PR>` form used for GitHub-merged commits).

The insertion logic was also collapsed into a single pass per review feedback — the previous `if any(is_test_plan_heading(line) ...)` guard was redundant since the heading is virtually always present, and the parallel else-branch is now just a fallback append-at-end when no heading is found.

### 3. Annotate **every** manual conflict resolution in the PR body (skill update)

`.claude/commands/backport-commit.md` Step 4 previously gated PR-body annotation on "non-trivial" conflicts. That's the wrong gate — "trivial" describes how easy the resolution was, not whether it warrants disclosure to a reviewer. Reviewers shouldn't have to diff the backport against the original commit to discover the agent took a manual step.

New policy: any branch where the agent ran `git cherry-pick --continue` (vs. it applying cleanly) gets an entry in the PR body, with a trivial/non-trivial label and a short summary. Step 2 (substep 3) now asks the agent to track every resolution, not just non-trivial ones, and the Step 4 example shows both styles.

## Test plan

- [x] `python3 -m py_compile .agents/scripts/backport-commit.py` — clean.
- [x] `python3 .agents/scripts/backport-commit.py --help` — shows the new `--keep-workspace` flag.
- [x] Standalone smoke-test of the `amend_message` body-rewriting block against five synthetic inputs (Phorge body, GitHub-PR body, no-heading, empty, and "both heading + Phorge footer with GH PR URL — GH PR wins"). All passed.
- [x] End-to-end: ran a real backport with this version of the script (commit `5fc0505f` → 2026.1, then → 2025.2) — confirmed the local `backport-*` task branches were deleted on success, and the chained-run flow worked through a conflict resolution.