### PR TITLE
[BACKPORT 2026.1][#31332] docdb: Unmark tserver's has_faulty_drive upon reregistering

### DIFF
--- a/src/yb/integration-tests/faulty_drive-itest.cc
+++ b/src/yb/integration-tests/faulty_drive-itest.cc
@@ -14,13 +14,24 @@
 
 #include <gtest/gtest.h>
 
+#include "yb/integration-tests/mini_cluster.h"
 #include "yb/integration-tests/yb_table_test_base.h"
+
+#include "yb/master/master.h"
+#include "yb/master/mini_master.h"
+#include "yb/master/ts_descriptor.h"
+#include "yb/master/ts_manager.h"
 
 #include "yb/rocksdb/util/multi_drive_test_env.h"
 
 #include "yb/tserver/mini_tablet_server.h"
+#include "yb/tserver/tablet_server.h"
 
+#include "yb/util/backoff_waiter.h"
+#include "yb/util/curl_util.h"
+#include "yb/util/faststring.h"
 #include "yb/util/multi_drive_test_env.h"
+#include "yb/util/result.h"
 
 namespace yb {
 namespace integration_tests {
@@ -76,6 +87,92 @@ TEST_F(FaultyDriveTest, FixFaultyDriveAndRestartTS) {
   ASSERT_OK(ts->Restart());
   ASSERT_OK(ts->WaitStarted());
   ASSERT_FALSE(ts->fs_manager().has_faulty_drive());
+}
+
+// Validates the master-side cached has_faulty_drive_ state on TSDescriptor.
+// It must stay set across a TServer restart that did NOT fix the drive, and
+// must clear on a TServer restart that DID fix the drive.
+TEST_F(FaultyDriveTest, MasterClearsFaultyDriveOnTServerRestartAfterFix) {
+  ASSERT_OK(WaitAllReplicasReady(mini_cluster(), kDefaultTimeout));
+
+  auto* ts = mini_cluster()->mini_tablet_server(0);
+  const auto ts_uuid = ts->server()->permanent_uuid();
+
+  auto master_sees_faulty = [&]() -> Result<bool> {
+    auto* mini_master = VERIFY_RESULT(mini_cluster()->GetLeaderMiniMaster());
+    auto desc = VERIFY_RESULT(mini_master->master()->ts_manager()->LookupTSByUUID(ts_uuid));
+    return desc->has_faulty_drive();
+  };
+
+  auto fetch_master_url = [&](const std::string& path) -> Result<std::string> {
+    auto* mini_master = VERIFY_RESULT(mini_cluster()->GetLeaderMiniMaster());
+    const auto url = Format("http://$0$1", mini_master->bound_http_addr(), path);
+    EasyCurl curl;
+    faststring body;
+    RETURN_NOT_OK(curl.FetchURL(url, &body));
+    return body.ToString();
+  };
+
+  // Baseline: master sees the TS as healthy.
+  ASSERT_FALSE(ASSERT_RESULT(master_sees_faulty()));
+
+  auto* env = dynamic_cast<MultiDriveTestEnv*>(ts_env_.get());
+  auto* renv = dynamic_cast<rocksdb::MultiDriveTestEnv*>(ts_rocksdb_env_.get());
+  auto ts0_drive1 = mini_cluster()->GetTabletServerDrive(0, 1);
+
+  // (1) Inject the fault and restart so FSManager flips on bootstrap.
+  env->AddFailedPath(ts0_drive1);
+  renv->AddFailedPath(ts0_drive1);
+  ASSERT_OK(ts->Restart());
+  ASSERT_OK(ts->WaitStarted());
+  ASSERT_TRUE(ts->fs_manager().has_faulty_drive());
+  ASSERT_OK(WaitFor(
+      [&]() -> Result<bool> { return master_sees_faulty(); }, kDefaultTimeout,
+      "Master to observe faulty_drive=true"));
+
+  // /tablet-servers HTML and /api/v1/tablet-servers JSON should both surface the faulty drive.
+  {
+    const auto html = ASSERT_RESULT(fetch_master_url("/tablet-servers"));
+    ASSERT_NE(html.find("Faulty Drive"), std::string::npos)
+        << "Expected '/tablet-servers' HTML to contain 'Faulty Drive'";
+    const auto json = ASSERT_RESULT(fetch_master_url("/api/v1/tablet-servers"));
+    ASSERT_NE(json.find("\"has_faulty_drive\":true"), std::string::npos)
+        << "Expected '/api/v1/tablet-servers' JSON to report has_faulty_drive=true";
+  }
+
+  // (2) Restart again WITHOUT fixing the drive. The master  must continue to see the TServer as
+  // faulty after the restart settles.
+  ASSERT_OK(ts->Restart());
+  ASSERT_OK(ts->WaitStarted());
+  ASSERT_TRUE(ts->fs_manager().has_faulty_drive());
+  ASSERT_OK(WaitFor(
+      [&]() -> Result<bool> { return master_sees_faulty(); }, kDefaultTimeout,
+      "Master to re-observe faulty_drive=true after restart"));
+  // Hold the assertion across multiple heartbeat intervals to confirm it
+  // does not flap back to false.
+  std::this_thread::sleep_for(2s);
+  ASSERT_TRUE(ASSERT_RESULT(master_sees_faulty()));
+
+  // (3) Fix the drive and restart. Master must clear its cached state on
+  // the registration that follows the restart, without a master restart.
+  env->RemoveFailedPath(ts0_drive1);
+  renv->RemoveFailedPath(ts0_drive1);
+  ASSERT_OK(ts->Restart());
+  ASSERT_OK(ts->WaitStarted());
+  ASSERT_FALSE(ts->fs_manager().has_faulty_drive());
+  ASSERT_OK(WaitFor(
+      [&]() -> Result<bool> { return !VERIFY_RESULT(master_sees_faulty()); }, kDefaultTimeout,
+      "Master to clear faulty_drive after TServer restart with fixed drive"));
+
+  // After recovery the indicator must disappear from both the HTML and JSON endpoints.
+  {
+    const auto html = ASSERT_RESULT(fetch_master_url("/tablet-servers"));
+    ASSERT_EQ(html.find("Faulty Drive"), std::string::npos)
+        << "Expected '/tablet-servers' HTML to no longer contain 'Faulty Drive'";
+    const auto json = ASSERT_RESULT(fetch_master_url("/api/v1/tablet-servers"));
+    ASSERT_EQ(json.find("\"has_faulty_drive\":true"), std::string::npos)
+        << "Expected '/api/v1/tablet-servers' JSON to no longer report has_faulty_drive=true";
+  }
 }
 
 } // namespace integration_tests

--- a/src/yb/master/master-path-handlers.cc
+++ b/src/yb/master/master-path-handlers.cc
@@ -607,6 +607,10 @@ void MasterPathHandlers::TServerDisplay(
       tserver_info.color = tserver_info.color == "Green" ? kYBOrange : tserver_info.color;
       tserver_info.status += "</br>Leader Blacklisted";
     }
+    if (desc->has_faulty_drive()) {
+      tserver_info.color = tserver_info.color == "Green" ? kYBOrange : tserver_info.color;
+      tserver_info.status += "</br>Faulty Drive";
+    }
 
     html_row.AddColumn(
         Format("<font color=\"$0\">$1</font>", tserver_info.color, tserver_info.status));
@@ -1007,6 +1011,9 @@ void MasterPathHandlers::HandleGetTserverStatus(const Webserver::WebRequest& req
           jw.String("uptime_seconds");
           jw.Uint(0);
         }
+
+        jw.String("has_faulty_drive");
+        jw.Bool(desc->has_faulty_drive());
 
         jw.String("start_time_us");
         jw.Uint64(desc->start_time_us());

--- a/src/yb/master/ts_descriptor.cc
+++ b/src/yb/master/ts_descriptor.cc
@@ -155,6 +155,9 @@ Result<TSDescriptor::WriteLock> TSDescriptor::UpdateRegistration(
   latest_report_seqno_ = std::numeric_limits<int32_t>::min();
   placement_id_ = generate_placement_id(registration.common().cloud_info());
   proxies_.reset();
+  // Once a tserver is marked as faulty it remains that way until it reregisters here.
+  // If it is still faulty, then it will be marked again as part of UpdateFromHeartbeat afterwards.
+  has_faulty_drive_ = false;
   return std::move(l);
 }
 


### PR DESCRIPTION
Summary:
Clearing the has_fault_drive_ field when a tserver reregisters with the master. This makes it so
that the master does not have to be stepped down after fixing a faulty drive tserver.

Also updating the tablet-servers page to show faulty drives (similar to blacklisted nodes):
{F485968}

Original commit: 5fc0505f2327dbe15c45788bc2d3605e3e193469 / D52825

Test Plan:
FaultyDriveTest.MasterClearsFaultyDriveOnTServerRestartAfterFix

manual test
```
./bin/yb-ctl create --rf 3 --num_drives 2
./bin/yb-ctl stop_node 1
chmod 555 ~/yugabyte-data/node-1/disk-2
./bin/yb-ctl restart_node 1
# look at http://127.0.0.1:7000/tablet-servers

# fix:
chmod 755 ~/yugabyte-data/node-1/disk-2
./bin/yb-ctl restart_node 1
# look at http://127.0.0.1:7000/tablet-servers
```

Reviewers: bkolagani

Reviewed By: bkolagani

Subscribers: ybase

Differential Revision: https://phorge.dev.yugabyte.com/D52825

---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31678/>)