### PR TITLE
[#31681] Tserver: Drain pending requests on RequestSequencer shutdown

### DIFF
--- a/src/yb/tserver/pg_client_service.cc
+++ b/src/yb/tserver/pg_client_service.cc
@@ -284,11 +284,18 @@ class RequestSequencer {
     return Status::OK();
   }
 
-  void Shutdown() {
-    DEBUG_ONLY(DCHECK(DEBUG_IsMutexLocked()));
+  // Stops accepting new requests and wakes any cond_var waiters. Safe to call
+  // without holding mutex_. Must be paired with CompleteShutdown (which drains
+  // parked callbacks under the mutex) so that parked InboundCall references are
+  // released and the reactor can exit.
+  void StartShutdown() {
     is_active_.store(false, std::memory_order_release);
-    impl_.RejectPendingRequests();
     cond_.notify_all();
+  }
+
+  void CompleteShutdown() {
+    DEBUG_ONLY(DCHECK(DEBUG_IsMutexLocked()));
+    impl_.RejectPendingRequests();
   }
 
  private:
@@ -453,9 +460,27 @@ class LockablePgClientSession {
   }
 
   void StartShutdown(bool pg_service_shutting_down) {
-    {
+    request_sequencer_.StartShutdown();
+    if (pg_service_shutting_down) {
+      // Service is going down. Drain synchronously: the messenger thread pool
+      // is about to shut down, so a deferred drain may never run, leaving
+      // parked InboundCall references that prevent the reactor from exiting.
+      // mutex_ is normally uncontended on this path.
       std::lock_guard lock(mutex_);
-      request_sequencer_.Shutdown();
+      request_sequencer_.CompleteShutdown();
+    } else {
+      // Session expired (e.g., backend killed). An in-flight Perform RPC
+      // (e.g., slow BackfillIndex) may hold mutex_ for an unbounded time.
+      // Defer the drain to the messenger thread pool so session_.StartShutdown()
+      // — which aborts the session's transactions — is not gated on that RPC.
+      messenger_.ThreadPool().EnqueueFunctor([shared_this = shared_this_] {
+        auto obj = shared_this.lock();
+        if (!obj) {
+          return;
+        }
+        std::lock_guard lock(obj->mutex_);
+        obj->request_sequencer_.CompleteShutdown();
+      });
     }
     if (exchange_runnable_) {
       exchange_runnable_->StartShutdown();

--- a/src/yb/tserver/pg_client_service.cc
+++ b/src/yb/tserver/pg_client_service.cc
@@ -285,7 +285,9 @@ class RequestSequencer {
   }
 
   void Shutdown() {
+    DEBUG_ONLY(DCHECK(DEBUG_IsMutexLocked()));
     is_active_.store(false, std::memory_order_release);
+    impl_.RejectPendingRequests();
     cond_.notify_all();
   }
 
@@ -451,7 +453,10 @@ class LockablePgClientSession {
   }
 
   void StartShutdown(bool pg_service_shutting_down) {
-    request_sequencer_.Shutdown();
+    {
+      std::lock_guard lock(mutex_);
+      request_sequencer_.Shutdown();
+    }
     if (exchange_runnable_) {
       exchange_runnable_->StartShutdown();
     }


### PR DESCRIPTION
## Summary

`PgOpProcessingOrderTest.ShutdownTimeWithLostOp` and `PgOpProcessingOrderTest.BackendTerminationTimeWithLostOp` both hang on macOS for the full reactor-join timeout (90 s+) and fail the `< 0.8 * pg_client_session_expiration_ms` deadline. The same tests pass on Linux in ~7 s.

The divergence comes from the gflag default:

```cpp
DEFINE_RUNTIME_bool(pg_client_use_shared_memory, !yb::kIsMac, ...)
```

On Linux, PG client requests reach the tserver via the shared-memory exchange. A `SharedExchangeRunnable` thread enforces request ordering by calling `RequestSequencer::RegisterForProcessing`, which blocks on `cond_.wait_until` when the request's `serial_no` is ahead of `next_expected_serial_no_`. The `TEST_emulate_op_lost_on_write` flag creates such a gap, so the worker thread parks on the cond_var. `RequestSequencer::Shutdown` wakes it via `cond_.notify_all`; the predicate re-runs `TryRegisterForProcessing`, hits `EnsureIsActive` which observes `is_active_ == false`, and as a side effect calls `impl_.RejectPendingRequests`. The waiter unwinds with `ShutdownInProgress` and the request is responded to.

On macOS the same request flows through the regular Perform RPC instead. `PerformQuery::RunImpl` uses `GetSessionNoWait + Enqueue`, parking the response callback inside `RequestSequencer::impl_.pending_requests_` rather than a cond_var. Nothing wakes the `Enqueue` path on shutdown: `Shutdown` only flips `is_active_` and notifies the (non-existent) cond_var waiter, so the parked callback is never invoked, the `InboundCall` it captures stays alive, the connection's `calls_being_handled_` map stays non-empty, `Connection::Idle()` returns false, and `Reactor::CheckReadyToStop` never lets the reactor thread exit.

Fix `RequestSequencer::Shutdown` to drain `pending_requests_` itself rather than relying on the cond_var predicate's `EnsureIsActive` side effect. `LockablePgClientSession::StartShutdown` now acquires the session mutex around the call so the drain satisfies the same locking invariant the other `RequestSequencer` methods already enforce.

## Test plan

- [x] `PgOpProcessingOrderTest.ShutdownTimeWithLostOp` passes on macOS arm64 (completes well under the `0.8 * pg_client_session_expiration_ms` deadline).
- [x] `PgOpProcessingOrderTest.BackendTerminationTimeWithLostOp` passes on macOS arm64.
- [x] Both tests continue to pass on Linux (shared-memory path unchanged).
