### PR TITLE
[#31701] tserver: Fix kNormal pool self-deadlock in SyncClientMasterRpc

### DIFF
--- a/src/yb/client/client-internal.cc
+++ b/src/yb/client/client-internal.cc
@@ -146,7 +146,10 @@ class SyncClientMasterRpc : public internal::ClientMasterRpcBase {
       ClientData* client, CoarseTimePoint deadline, RespClass* resp,
       const std::string& name, const SyncLeaderMasterFunc& func)
       : ClientMasterRpcBase(client, deadline),
-        resp_(resp), name_(name), func_(func) {}
+        resp_(resp), name_(name), func_(func) {
+    this->mutable_retrier()->mutable_controller()->set_invoke_callback_mode(
+      rpc::InvokeCallbackMode::kReactorThread);
+  }
 
   void CallRemoteMethod() override {
     auto master_proxy = this->template master_proxy<ProxyClass>();


### PR DESCRIPTION
## Summary

Resolves #31701.

`PgSingleTServerTest.ManyYsqlConnections` (which runs under `PgSmallRpcWorkersTest` with `FLAGS_rpc_workers_limit = 32` and spawns 64 concurrent connections) deadlocks the tserver on both Linux and macOS. All 32 workers in the `kNormal` RPC pool end up stuck:

```
pthread_cond_wait
std::condition_variable::wait
Synchronizer::WaitUntil
YBClient::Data::SyncLeaderMasterRpc<>
YBClient::GetNamespaceInfo
PgClientServiceImpl::Impl::GetDatabaseInfo
PgClientServiceImpl::GetDatabaseInfo
PgClientServiceIf::Handle
ServicePoolImpl::Handle
InboundCall::InboundCallTask::Run
Worker::Execute
```

Each worker is dispatching an inbound `Perform` RPC that synchronously calls into master via `SyncLeaderMasterRpc` and blocks on the `Synchronizer` set by the master RPC's response callback. With the default `kThreadPool` callback mode, that callback is posted back to the same `kNormal` pool that is running the blocked caller. With every worker parked on its own `Synchronizer`, no worker is free to run the callback that would release it. The pool starves itself.

### Fix

Switch `SyncClientMasterRpc` to invoke its callback on the reactor thread (`kReactorThread`). The callback only signals the `Synchronizer`, so it is cheap and reactor-safe, and it no longer competes with the inbound RPC handlers for `kNormal` pool capacity.

## Test plan

- [x] `PgSingleTServerTest.ManyYsqlConnections` under `PgSmallRpcWorkersTest` (`FLAGS_rpc_workers_limit=32`, 64 concurrent connections) — previously deadlocked the tserver on both Linux and macOS, now completes.
