### PR TITLE
[#31467] DocDB: Fix ClockSynchronizationTest.TestClockSkewError flake under ASAN

### DIFF
--- a/src/yb/integration-tests/clock_synchronization-itest.cc
+++ b/src/yb/integration-tests/clock_synchronization-itest.cc
@@ -116,17 +116,15 @@ class ClockSynchronizationTest : public YBMiniClusterTestBase<MiniCluster> {
 
   virtual void SetupFlags() {
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_time_source) = "mock";
-    // MockClock returns a frozen physical time, so the HybridClock's logical component is the only
-    // thing advancing across Now() calls. After 4096 calls within the same physical microsecond,
-    // HandleLogicalComponentOverflow() bumps last_usec by 1, which then trips the
-    // "clock went backwards" branch in NowWithError and triggers a FATAL when
-    // fail_on_out_of_range_clock_skew is true (the default) and clock_skew_control is enabled by
-    // any transactional tablet in the mini-cluster. Under ASAN the slower test execution gives
-    // background pollers enough wall-clock time to reach the 4096-call threshold before the test
-    // body completes, causing ~97% flakiness on alma9-clang21-asan (issue #31467). This crash is
-    // an artifact of the mock clock interacting with the skew detector and is not the behavior
-    // this test is designed to exercise, so disable the FATAL the same way transaction-test.cc and
-    // snapshot-txn-test.cc do.
+    // MockClock returns a frozen physical time, so each call to HybridClock::NowWithError()
+    // (driven by background pollers in transactional tablets) advances only HybridClock's
+    // internal logical counter -- MockClock itself never moves.  After 4096 such calls the
+    // overflow handler bumps last_usec by 1; the next read then sees the (still-frozen)
+    // physical time as 1us behind last_usec and trips a FATAL when
+    // fail_on_out_of_range_clock_skew is true (the default).  Under ASAN the slower run
+    // gives pollers enough wall-clock time to reach the 4096-call threshold before
+    // TestClockSkewError's body finishes (#31467, ~97% flake rate on alma9-clang21-asan).
+    // Disable the FATAL the same way transaction-test.cc and snapshot-txn-test.cc do.
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_fail_on_out_of_range_clock_skew) = false;
   }
 
@@ -141,6 +139,11 @@ class ClockSynchronizationTest : public YBMiniClusterTestBase<MiniCluster> {
   constexpr static const char* const kTableName = "my_table";
 };
 
+// Verifies the cluster keeps serving DDL + writes when the (mocked) physical clock reports an
+// NTP max_error above FLAGS_max_clock_sync_error_usec.  This exercises the
+// disable_clock_sync_error=true path (the default) added by ENG-2012 (commit 577b0cbcf2, 2017):
+// with that flag set, CheckClockSyncError swallows the high max_error instead of returning
+// ServiceUnavailable, so CreateTable and PerformOps below should both succeed.
 TEST_F(ClockSynchronizationTest, TestClockSkewError) {
   mock_clock_.Set({0, FLAGS_max_clock_sync_error_usec + 1});
 

--- a/src/yb/integration-tests/clock_synchronization-itest.cc
+++ b/src/yb/integration-tests/clock_synchronization-itest.cc
@@ -37,6 +37,7 @@
 
 DECLARE_uint64(max_clock_sync_error_usec);
 DECLARE_bool(disable_clock_sync_error);
+DECLARE_bool(fail_on_out_of_range_clock_skew);
 DECLARE_int32(ht_lease_duration_ms);
 DECLARE_string(time_source);
 
@@ -115,6 +116,18 @@ class ClockSynchronizationTest : public YBMiniClusterTestBase<MiniCluster> {
 
   virtual void SetupFlags() {
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_time_source) = "mock";
+    // MockClock returns a frozen physical time, so the HybridClock's logical component is the only
+    // thing advancing across Now() calls. After 4096 calls within the same physical microsecond,
+    // HandleLogicalComponentOverflow() bumps last_usec by 1, which then trips the
+    // "clock went backwards" branch in NowWithError and triggers a FATAL when
+    // fail_on_out_of_range_clock_skew is true (the default) and clock_skew_control is enabled by
+    // any transactional tablet in the mini-cluster. Under ASAN the slower test execution gives
+    // background pollers enough wall-clock time to reach the 4096-call threshold before the test
+    // body completes, causing ~97% flakiness on alma9-clang21-asan (issue #31467). This crash is
+    // an artifact of the mock clock interacting with the skew detector and is not the behavior
+    // this test is designed to exercise, so disable the FATAL the same way transaction-test.cc and
+    // snapshot-txn-test.cc do.
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_fail_on_out_of_range_clock_skew) = false;
   }
 
   std::unique_ptr<client::YBClient> client_;


### PR DESCRIPTION
## Summary

Fixes #31467.

Fixes the ASAN flake of `ClockSynchronizationTest.TestClockSkewError` (>97% failure rate on `alma9-clang21-asan`).

### Root cause

`MockClock::Now()` returns a frozen physical time (`time_point = 0`). Transactional system tablets created by the mini-cluster (master metadata, transaction-status table) flip `clock_skew_control_enabled` to `true` at startup. Background pollers (`wait_queue_poller`, transaction pollers, etc.) keep calling `HybridClock::Now()` / `NowRange()`. With no physical-time advance, the logical component of the hybrid timestamp is the only thing that increments — after 4096 calls inside the same physical microsecond, `HandleLogicalComponentOverflow()` bumps `last_usec` from `0` → `1`.

The next `Now()` then sees `now->time_point (0) < last_usec (1)`, takes the "clock went backwards" branch in `NowWithError`, computes `delta = 1µs > max_allowed = 0µs`, and — because `FLAGS_fail_on_out_of_range_clock_skew` defaults to `true` — calls `LOG(FATAL) << "Too big clock skew is detected"`. Crash signature:

```
W hybrid_clock.cc:329] Logical component overflow: last_usec=0, logical=4096
F hybrid_clock.cc:203] Too big clock skew is detected: 0.000s, while max allowed is: 0.000s
```

Under ASAN the test runtime is slow enough (~22 s vs ~3 s release) that the background pollers reach the 4096-call threshold *before* `CreateTable() + PerformOps(100)` finishes, which is why the failure rate hits ~97% on `alma9-clang21-asan`. On faster builds the workload completes first and the test passes — which is why the symptom looks like a flake rather than a hard failure.

### Fix

Disable `FLAGS_fail_on_out_of_range_clock_skew` in `ClockSynchronizationTest::SetupFlags()` — the same pattern `transaction-test.cc` and `snapshot-txn-test.cc` already use for the same mock-clock / skew-detector interaction. The crash this guard triggers is not the behavior `TestClockSkewError` is designed to exercise (which is the `max_clock_sync_error_usec` path, set via `mock_clock_.Set({0, FLAGS_max_clock_sync_error_usec + 1})`).

## Test plan

- [x] Local repro on `asan/clang21`: with `YB_EXTRA_GTEST_FLAGS="--wait_queue_poll_interval_ms=1"` (a 100× poll-rate amplifier needed because this workstation is significantly faster than the alma9-asan CI workers, where the bug reproduces at the default poll rate), 6/30 iterations FATAL with the exact same `Too big clock skew is detected: 0.000s, while max allowed is: 0.000s` signature as the CI failure log.
- [x] Fix validation: 30/30 pass under the same amplifier, no FATAL in any iteration log.
- [x] False-negative check (per @mdbridge review): with the fix applied, ran the test binary directly with `--disable_clock_sync_error=false` (no source change) and confirmed it still FATALs — at `hybrid_clock.cc:178`, the *unconditional* `Couldn't get the current time: Clock unsynchronized. ... Error: Clock error was too high (10000001 us), max allowed (10000000 us)` branch, which is the code path `TestClockSkewError` is designed to exercise. That FATAL is independent of `FLAGS_fail_on_out_of_range_clock_skew` (which my fix toggles at `hybrid_clock.cc:203`), so the test still detects a real `max_clock_sync_error_usec` violation.
- [x] `alma9-clang21-asan` CI on this PR: green (3/3 ASAN runs).


---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31713/>)

