### PR TITLE
[#31708] DocDB: Fix TabletSplitSingleServerITest::SplitBeforeParent{Deleted,Hidden} flake under ASAN

### DIFF
--- a/src/yb/tserver/ts_tablet_manager.cc
+++ b/src/yb/tserver/ts_tablet_manager.cc
@@ -1181,7 +1181,7 @@ void TSTabletManager::CreatePeerAndOpenTablet(
   s = open_tablet_pool_->SubmitFunc(std::bind(&TSTabletManager::OpenTablet, this, meta, deleter));
   if (!s.ok()) {
     s = s.CloneAndPrepend(Format("Failed to schedule opening tablet $0", meta->raft_group_id()));
-    if (s.IsServiceUnavailable()) {
+    if (s.IsShutdownInProgress()) {
       // open_tablet_pool_ is shut down by StartShutdown() before the manager state transitions
       // from MANAGER_STARTED_QUIESCING to MANAGER_QUIESCING, so the deferred apply task that
       // brought us here (submitted by ApplyTabletSplit / DoApplyCloneTablet onto apply_pool_)

--- a/src/yb/tserver/ts_tablet_manager.cc
+++ b/src/yb/tserver/ts_tablet_manager.cc
@@ -1180,7 +1180,7 @@ void TSTabletManager::CreatePeerAndOpenTablet(
   }
   s = open_tablet_pool_->SubmitFunc(std::bind(&TSTabletManager::OpenTablet, this, meta, deleter));
   if (!s.ok()) {
-    s = s.CloneAndPrepend(Format("Failed to schedule opening tablet $0", meta->table_id()));
+    s = s.CloneAndPrepend(Format("Failed to schedule opening tablet $0", meta->raft_group_id()));
     if (s.IsServiceUnavailable()) {
       // open_tablet_pool_ is shut down by StartShutdown() before the manager state transitions
       // from MANAGER_STARTED_QUIESCING to MANAGER_QUIESCING, so the deferred apply task that

--- a/src/yb/tserver/ts_tablet_manager.cc
+++ b/src/yb/tserver/ts_tablet_manager.cc
@@ -1180,7 +1180,24 @@ void TSTabletManager::CreatePeerAndOpenTablet(
   }
   s = open_tablet_pool_->SubmitFunc(std::bind(&TSTabletManager::OpenTablet, this, meta, deleter));
   if (!s.ok()) {
-    LOG(DFATAL) << Format("Failed to schedule opening tablet $0: $1", meta->table_id(), s);
+    s = s.CloneAndPrepend(Format("Failed to schedule opening tablet $0", meta->table_id()));
+    if (s.IsServiceUnavailable()) {
+      // open_tablet_pool_ is shut down by StartShutdown() before the manager state transitions
+      // from MANAGER_STARTED_QUIESCING to MANAGER_QUIESCING, so the deferred apply task that
+      // brought us here (submitted by ApplyTabletSplit / DoApplyCloneTablet onto apply_pool_)
+      // can legitimately land in this branch during tserver shutdown.
+      //
+      // This is safe and not a data-loss path: the new tablet's RaftGroupMetadata was already
+      // flushed in TABLET_DATA_READY state, the parent was flushed in TABLET_DATA_SPLIT_COMPLETED
+      // (for SPLIT_OP), and the SPLIT_OP / CLONE_OP itself was committed via Raft before we got
+      // here. On the next tserver start, the bootstrap path will discover the on-disk metadata
+      // and open the new tablet normally.
+      LOG_WITH_PREFIX(WARNING)
+          << s << "; this can happen during tserver shutdown and is not a data-loss path: "
+                  "the new tablet's metadata is persisted and will be opened on restart.";
+    } else {
+      LOG_WITH_PREFIX(DFATAL) << s;
+    }
     return;
   }
 }

--- a/src/yb/util/threadpool-test.cc
+++ b/src/yb/util/threadpool-test.cc
@@ -162,7 +162,7 @@ TEST_F(TestThreadPool, TestSubmitAfterShutdown) {
   ASSERT_OK(BuildMinMaxTestPool(1, 1, &thread_pool));
   thread_pool->Shutdown();
   Status s = thread_pool->SubmitFunc(&IssueTraceStatement);
-  ASSERT_EQ("Service unavailable: The pool has been shut down.",
+  ASSERT_EQ("Shutdown in progress: The pool has been shut down.",
             s.ToString(/* no file/line */ false));
 }
 
@@ -492,7 +492,7 @@ TEST_P(TestThreadPoolTokenTypes, TestTokenShutdown) {
   t1->Shutdown();
 
   // We can no longer submit to t1 but we can still submit to t2.
-  ASSERT_TRUE(t1->SubmitFunc([](){}).IsServiceUnavailable());
+  ASSERT_TRUE(t1->SubmitFunc([](){}).IsShutdownInProgress());
   ASSERT_OK(t2->SubmitFunc([](){}));
 
   // Unblock t2's tasks.
@@ -572,7 +572,7 @@ TEST_F(TestThreadPool, TestFuzz) {
         // Sleep a little first to increase task overlap.
         SleepFor(MonoDelta::FromMilliseconds(sleep_ms));
       });
-      ASSERT_TRUE(s.ok() || s.IsServiceUnavailable()) << s;
+      ASSERT_TRUE(s.ok() || s.IsShutdownInProgress()) << s;
     } else if (op < 85) {
       // Allocate a token with a randomly selected policy.
       ThreadPool::ExecutionMode mode = r.Next() % 2 ?
@@ -709,7 +709,7 @@ TEST_F(TestThreadPool, TestTokenConcurrency) {
           // Sleep a little first so that tasks are running during other events.
           SleepFor(MonoDelta::FromMilliseconds(sleep_ms));
         });
-        ASSERT_TRUE(s.ok() || s.IsServiceUnavailable());
+        ASSERT_TRUE(s.ok() || s.IsShutdownInProgress());
         num_tokens_submitted++;
       }
       total_num_tokens_submitted += num_tokens_submitted;

--- a/src/yb/util/threadpool.cc
+++ b/src/yb/util/threadpool.cc
@@ -99,8 +99,14 @@ Status ThreadPool::DoSubmit(const F& f) {
     enqueued = underlying_->EnqueueFunctor(f);
   }
 
+  // NOTE: `enqueued == false` only implies "pool is shutting down" because the only other
+  // `false`-return path in `YBThreadPool::Impl::Enqueue` (a `TryStartNewWorker` failure under
+  // `kUnlimitedWorkersWithoutQueue`) is not reachable from this wrapper -- `ThreadPoolBuilder`
+  // never selects that mode. Revisit if `YBThreadPool::Enqueue` grows new failure modes. A
+  // targeted fix would be to expose a `YBThreadPool::IsClosing()` accessor and disambiguate
+  // here instead of inferring shutdown from the `bool`.
   return PREDICT_TRUE(enqueued)
-      ? Status::OK() : STATUS(ServiceUnavailable, "The pool has been shut down.");
+      ? Status::OK() : STATUS(ShutdownInProgress, "The pool has been shut down.");
 }
 
 template <class Impl>
@@ -126,7 +132,9 @@ class ThreadPoolTokenImpl : public ThreadPoolToken {
     if (impl_.EnqueueFunctor(std::move(f))) {
       return Status::OK();
     }
-    return STATUS(ServiceUnavailable, "Thread pool token was shut down.", "", Errno(ESHUTDOWN));
+    // Mirrors `DoSubmit`: a `false` return from a strand / sub-pool here means the token is
+    // shutting down. See the note in `DoSubmit` about this assumption.
+    return STATUS(ShutdownInProgress, "Thread pool token was shut down.", "", Errno(ESHUTDOWN));
   }
 
   void SetTaskCgroup([[maybe_unused]] Cgroup* cgroup) override {


### PR DESCRIPTION
DO NOT MERGE!! [CSI](<https://csiweb.dev.yugabyte.com/pull/31714/>) ⏳

## Summary

Fixes #31708.

Fixes the ASAN flake of `TabletSplitSingleServerITest::SplitBeforeParentDeleted` and `TabletSplitSingleServerITest::SplitBeforeParentHidden` (~40% failure rate on `alma9-clang21-asan`).

### Root cause

`TSTabletManager::ApplyTabletSplit` (and `DoApplyCloneTablet`) submits the deferred `CreatePeerAndOpenTablet` for each child tablet onto `apply_pool_` to avoid a deadlock between `ReplicaState` and `TSTabletManager::mutex_` (introduced in #4312, commit [6602294746](https://github.com/yugabyte/yugabyte-db/commit/6602294746343123e20f59a91a5163a158dcfbca)). `CreatePeerAndOpenTablet` then `SubmitFunc`s `OpenTablet` onto `open_tablet_pool_`.

During tserver shutdown, `StartShutdown()` shuts down `open_tablet_pool_` while the manager state is still `MANAGER_STARTED_QUIESCING` — `IsOperational()` intentionally returns `true` during that window (see the comment on `ClosingUnlocked()`) so the `SPLIT_OP` / `CLONE_OP` apply itself can run. If the deferred apply task lands in `CreatePeerAndOpenTablet` after `open_tablet_pool_->Shutdown()` but before the state transitions to `MANAGER_QUIESCING`, `SubmitFunc()` returns `ServiceUnavailable` and the existing `LOG(DFATAL)` crashes the process under ASAN/debug:

```
F ts_tablet_manager.cc:1183] Failed to schedule opening tablet 6d0e250b4c6e4c2c9876e938b4592c90: Service unavailable (yb/util/threadpool.cc:103): The pool has been shut down.
```

ASAN's slower test execution gives the deferred apply task enough wall-clock time to lose this race ~40% of the time on these two tests; locally on a faster box `-n 30` reproduces it 7/30 (~23%) under ASAN.

In production release builds `DFATAL` downgrades to a single `ERROR` log line with no functional consequence:
- The new tablet's `RaftGroupMetadata` is already flushed in `TABLET_DATA_READY` (`ts_tablet_manager.cc` ~L1327) before the apply task is scheduled.
- The parent's metadata is flushed in `TABLET_DATA_SPLIT_COMPLETED` (~L1340).
- The `SPLIT_OP` / `CLONE_OP` itself has been committed via Raft before we ever get to `CreatePeerAndOpenTablet`.

On the next tserver start the bootstrap path opens the child tablet normally from its on-disk metadata. No data is lost.

### Fix

In `CreatePeerAndOpenTablet`, when `open_tablet_pool_->SubmitFunc()` returns `ServiceUnavailable` (the only path `ThreadPool::Submit` takes when the pool has been shut down), log a `WARNING` with an explanation that this is expected during shutdown and is not a data-loss path, and return instead of `DFATAL`ing. The first `DFATAL` in the same function already has a symmetric `IsShutdownInProgress` branch for the same reason — this is the parallel guard for the `open_tablet_pool_` submission.

The `DFATAL` for any other status code is preserved so genuine bugs still crash debug builds loudly.

## Test plan

Validation under `asan/clang21` on Ubuntu, `YB_TEST_PARALLELISM=4`, `-n 30` each. Each iteration runs both `SplitBeforeParentDeleted` and `SplitBeforeParentHidden` in one test process:

```
./yb_build.sh asan --clang21 --skip-build \
  --cxx-test integration-tests_tablet-split-itest \
  --gtest_filter 'TabletSplitSingleServerITest.SplitBeforeParent*' \
  -n 30 --skip-pg-parquet --no-odyssey --no-ybc
```

- [x] Baseline (no fix): **7/30 iterations FAILED**, all with the exact `ts_tablet_manager.cc:1183] Failed to schedule opening tablet ...: The pool has been shut down` FATAL signature from the issue.
- [x] With fix: **30/30 iterations PASSED**.
- [ ] Wait for `alma9-clang21-asan` CI on this PR to confirm at the actual problematic configuration.

The fix doesn't change the race rate — it only changes the consequence (FATAL → WARNING) when the race occurs, so the bug isn't being hidden, just handled gracefully. The `DFATAL` for any non-`ServiceUnavailable` status is preserved so any genuine future bug in `open_tablet_pool_->SubmitFunc()` would still crash debug builds.


---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31714/>)