### PR TITLE
[#31707] YCQL: Lower TestTransaction.testReadRestarts read-restart threshold on ASAN

### DIFF
--- a/java/yb-cql/src/test/java/org/yb/cql/TestTransaction.java
+++ b/java/yb-cql/src/test/java/org/yb/cql/TestTransaction.java
@@ -664,8 +664,16 @@ public class TestTransaction extends BaseCQLTest {
           // (1) have the desired number of restart requests and retries.
           // (2) have run for 100 seconds but still don't have the desired number of restart
           //     requests. We still assert finally for atleast 1 restart and retry to have occurred.
-          final int TOTAL_RESTARTS = BuildTypeUtil.nonTsanVsTsan(10, 5);
-          final int TOTAL_RETRIES = BuildTypeUtil.nonTsanVsTsan(10, 5);
+          //
+          // ASAN gets the same lower thresholds as TSAN (issue #31707):
+          // runTestWithBothSkipPrefixLockSettings (added by commit c405be2e) runs this body twice
+          // with a cluster restart in between, doubling the wall-clock cost. Under ASAN the
+          // concurrent writer thread is slow enough that reaching 10 read restarts can blow past
+          // the 250s loop cap, and the wrapped body then exceeds the 450s test timeout. Lowering
+          // ASAN to the existing TSAN value of 5 lets the early-exit branch fire well before the
+          // cap on CI hardware while still exercising the read-restart code path.
+          final int TOTAL_RESTARTS = BuildTypeUtil.nonSanitizerVsSanitizer(10, 5);
+          final int TOTAL_RETRIES = BuildTypeUtil.nonSanitizerVsSanitizer(10, 5);
           int i = 0;
           int currentRestarts = 0;
           int currentRetries = 0;


### PR DESCRIPTION
## Summary

`testReadRestarts` spins concurrent reads and writes until either it sees `TOTAL_RESTARTS` read-restart errors and `TOTAL_RETRIES` retries, or it hits a 250-second loop budget. These were lowered from 10 → 5 for TSAN long ago, but ASAN was left at 10.

Commit c405be2eaa (#28674, "DocDB: Skip prefix locks at docdb layer") wrapped this test body in `runTestWithBothSkipPrefixLockSettings`, which now runs the body **twice** with a cluster restart in between, roughly doubling the wall-clock cost. Under ASAN this doubling exceeds the test timeout (300s × 1.5 ASAN multiplier = 450s), and the test has been failing **17/25 runs** on `master-alma9-clang21-asan` (issue #31707, DB-21448).

Reproduced locally under `taskset -c 0` + asan/clang21 — same `TestTimedOutException: test timed out after 450 seconds` stack as CI:

```
org.junit.runners.model.TestTimedOutException: test timed out after 450 seconds
    at org.yb.cql.TestTransaction.lambda$13(TestTransaction.java:680)
    at org.yb.cql.TestTransaction.runTestWithBothSkipPrefixLockSettings(TestTransaction.java:75)
    at org.yb.cql.TestTransaction.testReadRestarts(TestTransaction.java:625)
```

**Fix:** change `BuildTypeUtil.nonTsanVsTsan(10, 5)` → `BuildTypeUtil.nonSanitizerVsSanitizer(10, 5)` so ASAN gets the same lower thresholds as TSAN. The early-exit branch fires well before the 250s cap on CI hardware. The post-loop asserts still require ≥1 restart and ≥1 retry, so the test continues to validate the read-restart code path. TSAN behavior is unchanged.

Closes #31707.

## Test plan

- [x] Reproduced the timeout locally with `taskset -c 0` (simulates a heavily loaded CI worker) — baseline run timed out at 450s, matching the CI signature.
- [x] Validated the fix on 2 cores (matches real CI worker characteristics):

  | Config | Total time | Margin to 450s timeout |
  |---|---|---|
  | Baseline (no fix), 2 cores | 369s | 81s |
  | With fix, 2 cores | **145s** | **305s** |

  Phase breakdown with fix on 2 cores:
  - Phase 1 (`skip_prefix_locks=false`): 67s, exits at 7 restarts / 5 retries
  - Cluster restart: 8s
  - Phase 2 (`skip_prefix_locks=true`): 58s, exits at 7 restarts / 5 retries

- [ ] Jenkins: `.*testReadRestart.*`

---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31722/>)