### PR TITLE
[#31709] YSQL: Fix PgLibPqPgssQtextLeakTest false positive under ASAN

### DIFF
--- a/src/yb/yql/pgwrapper/pg_libpq-test.cc
+++ b/src/yb/yql/pgwrapper/pg_libpq-test.cc
@@ -3474,7 +3474,16 @@ TEST_F(PgLibPqPgssQtextLeakTest, TestNoMemoryLeakOnCorruptedPgssQtext) {
   constexpr int kNumPopulateQueries = 500;
   constexpr int kPgMaxIdentifierLen = 63;  // NAMEDATALEN - 1
   const int kLeakIterations = RegularBuildVsSanitizers(2000, 500);
-  const int64_t kMaxRssGrowthKb = RegularBuildVsSanitizers(50, 200) * 1024;
+  // The sanitizer threshold is set well above the ASAN baseline overhead (issue #31709):
+  // 500 iterations of the error path accumulate ~200 MB of RSS from ASAN's shadow memory,
+  // redzones, allocator metadata, and per-error ereport/longjmp cleanup state -- not from
+  // the leak this test guards against. Before bumping to 400 MB, runs consistently landed
+  // at ~203 MB and tipped over the previous 200 MB threshold ~28% of the time. A real
+  // regression of the qtext-buffer leak would add file_size * iterations of growth (with
+  // ASAN's per-allocation overhead on top -- empirically ~4x), so a threshold of 400 MB
+  // still detects an unfixed leak comfortably while leaving room for ASAN measurement
+  // noise. The non-sanitizer threshold (50 MB) is unchanged.
+  const int64_t kMaxRssGrowthKb = RegularBuildVsSanitizers(50, 400) * 1024;
   constexpr size_t kCorruptOffset = 500;
 
   auto conn = ASSERT_RESULT(Connect());


### PR DESCRIPTION
## Summary

Fixes #31709.

`PgLibPqPgssQtextLeakTest.TestNoMemoryLeakOnCorruptedPgssQtext` was failing ~28% (7/25) of runs in `master-alma9-clang21-asan` jobs. The assertion under test is:

> 500 iterations of the corrupted-qtext error path must grow RSS by at most `kMaxRssGrowthKb`.

The non-sanitizer budget is **50 MB** (very tight, intentional). Sanitizer builds were given **200 MB** to absorb ASAN's instrumentation overhead. Looking at the failing CI logs (e.g. runs #452 and #459), ASAN actually accumulates **~203 MB** of RSS across these iterations even without a leak:

- ASAN shadow memory (1 byte per 8 bytes of allocator state)
- redzones around every allocation
- allocator metadata for thousands of short-lived backend allocations
- per-error `ereport` / `longjmp` cleanup bookkeeping

That left the threshold flush against the noise floor and produced the flake.

## Fix

Raise the sanitizer threshold from **200 MB to 400 MB** (one constant change in the test). The non-sanitizer threshold and the iteration count are unchanged.

A real regression of the `pg_stat_statements` qtext-buffer leak fixed by `0ad22136ff` (commit that introduced this test) would add `file_size * iterations` of growth (with ASAN's per-allocation overhead on top -- empirically ~4x), well above 400 MB. So the test still detects an unfixed leak comfortably while leaving room for ASAN measurement noise.

## Test plan

The change is confined to a single constant in a C++ test. Inspection only locally because master HEAD currently has an **unrelated** regression that prevents `PgWrapperTestBase::SetUp()` from completing initdb (reproducible without this change for all `pg_libpq-test` tests, on a clean origin/master checkout):

```
FATAL: Invalid table definition: Error creating table template1.pg_proc on the master:
Error while creating transaction status table: Not enough live tablet servers to create
table with replication factor 3. Need at least 2 tablet servers whereas 0 are alive.
```

Will leave that to whoever owns the master bootstrap path; CI will exercise the actual leak test on a clean build.

## Jenkins

test regex: `.*PgLibPq.*`

---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31723/>)