### PR TITLE
[#31706] CDC: Fix TestDropSchemaHidesAssociatedTables flake under TSAN

### DIFF
--- a/src/yb/integration-tests/cdcsdk_consumption_consistent_changes-test.cc
+++ b/src/yb/integration-tests/cdcsdk_consumption_consistent_changes-test.cc
@@ -5462,7 +5462,7 @@ TEST_F(CDCSDKConsumptionConsistentChangesTest, TestDropSchemaHidesAssociatedTabl
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_table_rewrite_for_cdcsdk_table) = true;
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdcsdk_update_restart_time_when_nothing_to_stream) = false;
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdc_parent_tablet_deletion_task_retry_secs) = 1;
-  ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdc_intent_retention_ms) = 5 * 1000;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdc_intent_retention_ms) = 5 * 1000 * kTimeMultiplier;
 
   ASSERT_OK(SetUpWithParams(
       1 /* rf */, 1 /* num_masters */, false /* colocated */,
@@ -5511,7 +5511,8 @@ TEST_F(CDCSDKConsumptionConsistentChangesTest, TestDropSchemaHidesAssociatedTabl
         }
         return result;
       },
-      MonoDelta::FromSeconds(60), "Timed out waiting for hidden tables to be deleted"));
+      MonoDelta::FromSeconds(60) * kTimeMultiplier,
+      "Timed out waiting for hidden tables to be deleted"));
   CheckTabletsInCDCStateTable(
     {kCDCSDKSlotEntryTabletId}, test_client(), stream_id, {} /* expected_colocated_table_ids */,
     "Tablets in cdc_state for the stream doesnt match the expected set" /* timeout_msg */,


### PR DESCRIPTION
## Summary

`CDCSDKConsumptionConsistentChangesTest.TestDropSchemaHidesAssociatedTables` hardcodes two TSAN-sensitive durations that don't scale with `kTimeMultiplier`:

1. **`FLAGS_cdc_intent_retention_ms = 5 * 1000`** (line 5465) — the test relies on the CDC stream remaining valid through 5 table-DROP cycles plus virtual-WAL setup. Under TSAN's ~5x slowdown, the 5-second retention window expires before the test reaches `GetConsistentChangesFromCDC`, after which the test surfaces a `Stream ID is expired` error in CSI logs.

2. **`MonoDelta::FromSeconds(60)` in the terminal `WaitFor(...)`** (line 5514) — waits for the background tablet-deletion task to remove hidden tablets. That background task runs every `FLAGS_cdc_parent_tablet_deletion_task_retry_secs * kTimeMultiplier` seconds, so its wait budget needs the same multiplier to stay aligned.

Both fixes follow the established pattern in this file — see `924-925` (`50 / kTimeMultiplier`), `1263` (`10 * 1000 * kTimeMultiplier`), `3329` (`MonoDelta::FromSeconds(20 * kTimeMultiplier)`), `3387` (`FLAGS_cdcsdk_publication_list_refresh_interval_secs * kTimeMultiplier`).

No production-code change. The fix is two test-only scaling adjustments.

Diagnosis source: ReportPortal CSI logs for the failing TSAN runs (~32% baseline flake rate per the issue) showed `Stream ID is expired` as the failure pattern.

Fixes #31706.

## Test plan

- [ ] CI: `cdcsdk_consumption_consistent_changes-test` passes under TSAN (Jenkins).
- [ ] Local TSAN reproduction was not run for this change (agent sandbox blocked the build); the diagnosis is from CSI log analysis (`Stream ID is expired` failure pattern) and the established `kTimeMultiplier` pattern already used at 8+ other call sites in this file. Pre-merge Jenkins TSAN run is the verifying oracle.
- [ ] No runtime behavior change for non-TSAN builds (`kTimeMultiplier` is `1` outside sanitizer builds).


---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31727/>)