### PR TITLE
[#31704] YSQL: Fix PgDdlAtomicitySnapshotTest.SnapshotTest flake under TSAN

### DIFF
--- a/src/yb/yql/pgwrapper/pg_ddl_atomicity-test.cc
+++ b/src/yb/yql/pgwrapper/pg_ddl_atomicity-test.cc
@@ -1370,7 +1370,7 @@ TEST_F(PgDdlAtomicitySnapshotTest, SnapshotTest) {
   HybridTime hybrid_time_before_rollback = HybridTime::FromMicros(current_time.ToInt64());
 
   // Ensure that at least one snapshot is taken.
-  SleepFor(snapshot_interval_secs * 5s);
+  SleepFor(snapshot_interval_secs * 5s * kTimeMultiplier);
 
   // Verify that rollback for Alter and Create has indeed not happened yet.
   VerifyTableExists(client.get(), kDatabase, kCreateTable, 10);
@@ -1423,7 +1423,7 @@ Status PgDdlAtomicitySnapshotTest::ListSnapshotTest(DdlErrorInjection inject_err
   Timestamp current_time(VERIFY_RESULT(WallClock()->Now()).time_point);
   HybridTime hybrid_time_before_rollback = HybridTime::FromMicros(current_time.ToInt64());
 
-  SleepFor(snapshot_interval_secs * 5s);
+  SleepFor(snapshot_interval_secs * 5s * kTimeMultiplier);
   auto snapshot_id =
       VERIFY_RESULT(snapshot_util_->PickSuitableSnapshot(schedule_id, hybrid_time_before_rollback));
 


### PR DESCRIPTION
## Summary

`PgDdlAtomicitySnapshotTest.SnapshotTest` (and the `ListSnapshotTest` helper that drives several parameterized snapshot tests) sleeps for `snapshot_interval_secs * 5s` to give the snapshot schedule a chance to take at least one snapshot before `PickSuitableSnapshot` is invoked. With `snapshot_interval_secs = 1` that's 5 seconds, which is enough on fastdebug/release but not under TSAN where snapshot creation itself takes several extra seconds. When the sleep elapses before the first snapshot is committed, the subsequent `PickSuitableSnapshot` / `VerifyTableExists` / `VerifyTableNotExists` calls retry-loop until they hit their own per-call deadlines, blowing the cumulative test budget. CSI logs for the failing runs show the test being externally SIGKILL'd after exceeding its wall budget.

This file already uses `kTimeMultiplier` (lines 2110, 2133), so this PR just propagates the same pattern to the two `SleepFor(snapshot_interval_secs * 5s)` sites that drive the snapshot-test scenarios.

No production-code change. The fix is two test-only scaling adjustments.

Diagnosis source: ReportPortal CSI logs for the failing TSAN runs (~40% baseline flake rate per the issue) showed external SIGKILL after exceeding the test wall budget.

Fixes #31704.

## Test plan

- [ ] CI: `pg_ddl_atomicity-test` (`PgDdlAtomicitySnapshotTest.SnapshotTest` and the `ListSnapshot*` derivatives) passes under TSAN (Jenkins).
- [ ] Local TSAN reproduction was not run for this change (agent sandbox blocked the build); the diagnosis is from CSI log analysis (external SIGKILL after cumulative-timeout overrun) and the established `kTimeMultiplier` pattern already used at 2 other call sites in this file. Pre-merge Jenkins TSAN run is the verifying oracle.
- [ ] No runtime behavior change for non-TSAN builds (`kTimeMultiplier` is `1` outside sanitizer builds).


---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31728/>)