### PR TITLE
[#31729] Cursor: Document Cursor agent sandbox + CARGO_TARGET_DIR workarounds for yb_build.sh

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -133,6 +133,30 @@ sudo dpkg -i gettext-base.deb gettext.deb libpopt0.deb rsync.deb
 popd
 ```
 
+## Build Prerequisites for Cursor agents
+
+When invoking `yb_build.sh` (or any long subprocess pipeline that includes `build_postgres` / `rsync` / postgres `initdb`) via the Cursor agent's `Shell` tool, two quirks of the agent's environment break the build and must be worked around together — fixing only one still fails further along.
+
+1. **Pass `required_permissions: ["all"]` on the `Shell` call.**
+
+   Without it, the command runs inside the `cursor_sandbox` AppArmor profile (the default for `Shell`). The postgres-source mirror step (`rsync -avz` in `python/yugabyte/build_postgres.py`) deadlocks deterministically inside the profile: all three rsync workers go to sleep in `pselect6`, `postgres_build/` stays at 2 files indefinitely, and ninja halts the moment a target needs the postgres step. The profile also blocks signal delivery from outside the sandbox (`sudo kill` returns `EACCES`), so the only ways to clean up wedged processes are `sudo nsenter -t <pid> -a kill -9 -1` (entering the sandbox's user namespace) or a reboot. With `required_permissions: ["all"]`, the entire spawned tree (`bash` → `ninja` → `python3` → `rsync`) inherits `unconfined`, and the same rsync completes in ~300 ms.
+
+2. **Unset `CARGO_TARGET_DIR` for the `yb_build.sh` invocation** — e.g. `env -u CARGO_TARGET_DIR ./yb_build.sh ...`.
+
+   The Cursor agent shell exports `CARGO_TARGET_DIR=/tmp/cursor-sandbox-cache/<hash>/cargo-target` so cargo's build cache is shared across sessions. The third-party DocumentDB extension's pgrx setup runs `cargo build --package cargo-pgrx --release && target/release/cargo-pgrx pgrx init ...`: cargo writes the binary to `$CARGO_TARGET_DIR/release/cargo-pgrx`, but the very next shell step looks for `target/release/cargo-pgrx` relative to the pgrx source dir. The build fails with `/bin/sh: ...: target/release/cargo-pgrx: not found` → `make[2]: *** [cargo-pgrx-exists] Error 127` → `install-documentdb Error 2`. Unsetting the var makes cargo write to the relative path the Makefile expects. Each new `Shell` call inherits the parent env fresh, so `unset CARGO_TARGET_DIR` typed in an earlier `Shell` call does not persist — the unset (or `env -u`) must be on the same call that spawns `yb_build.sh`.
+
+After spawning the build, sanity-check that the build process is unconfined and free of `CARGO_TARGET_DIR` so future regressions surface immediately instead of after 25 minutes:
+```bash
+build_pid=$(pgrep -f '[y]b_build.sh|[n]inja -j' | head -1)
+if [ -n "$build_pid" ]; then
+  cat /proc/$build_pid/attr/current                                # expect: unconfined
+  readlink /proc/$build_pid/ns/user                                # expect: user:[4026531837] (host)
+  tr '\0' '\n' < /proc/$build_pid/environ | grep CARGO_TARGET_DIR  # expect: no output
+fi
+```
+
+This only affects how the agent invokes the build via `Shell` — humans running `./yb_build.sh` from their own terminal are already unconfined and typically don't have `CARGO_TARGET_DIR` set.
+
 ## Build System
 
 The primary build entry point is `yb_build.sh` at the repository root.


### PR DESCRIPTION
## Summary

When the Cursor agent invokes `./yb_build.sh` via its built-in `Shell` tool, two independent quirks of the agent's shell environment deterministically break the build. Each one wedges/fails at a different step, so fixing only one still leaves the build broken further along. Both were hit during this session before I figured out the second one.

### Pitfall 1 — `cursor_sandbox` AppArmor profile

Without `required_permissions: ["all"]`, the `Shell` call runs inside the `cursor_sandbox (enforce)` AppArmor profile. The postgres-source mirror step (`rsync -avz` in `python/yugabyte/build_postgres.py`) then deadlocks deterministically:

* All three rsync worker processes go to sleep in `pselect6` and accumulate ~3 s of CPU over 30+ min of wall time.
* `postgres_build/` stays at exactly 2 files (`GNUmakefile.in`, `Makefile`) indefinitely.
* ninja halts the moment a target depends on the postgres step.
* The profile also blocks signal delivery from outside the sandbox, so even `sudo kill -9` returns `EACCES`. The only ways to clean up wedged processes are `sudo nsenter -t <pid> -a kill -9 -1` (entering the sandbox's user namespace) or a reboot.

Fix: pass `required_permissions: ["all"]` on the `Shell` call. The whole spawned tree (`bash` → `ninja` → `python3` → `rsync`) then inherits `unconfined` and the same rsync completes in ~300 ms.

### Pitfall 2 — `CARGO_TARGET_DIR` exported by the Cursor agent shell

The Cursor agent's shell environment exports `CARGO_TARGET_DIR=/tmp/cursor-sandbox-cache/<hash>/cargo-target` so cargo's build cache is shared across sessions. This breaks the third-party DocumentDB extension's pgrx setup, which runs:

```
cd ../../pgrx
cargo build --package cargo-pgrx --release
target/release/cargo-pgrx pgrx init --pg15 ...
```

cargo writes the binary to `$CARGO_TARGET_DIR/release/cargo-pgrx`, but the next line of the same `&&`-chained shell command looks for `target/release/cargo-pgrx` relative to the pgrx source dir. Result: `/bin/sh: ...: target/release/cargo-pgrx: not found` → `make[2]: *** [cargo-pgrx-exists] Error 127` → `install-documentdb Error 2`, ~15 min into a TSAN build. The whole spawned tree is `unconfined` and otherwise healthy at this point, so it took a while to recognise this is a separate, env-var-driven issue and not a re-emergence of pitfall 1.

Fix: `env -u CARGO_TARGET_DIR ./yb_build.sh ...` on the launching `Shell` call. cargo then writes to the relative path the Makefile expects.

(`unset CARGO_TARGET_DIR` typed in an earlier `Shell` call does **not** persist — each `Shell` call inherits the parent env fresh — so it has to be on the same call that spawns the build.)

### What this PR adds

A short **"Build Prerequisites for Cursor agents"** section in `src/AGENTS.md` (parallel to the existing "Build Prerequisites for Claude Code" section), documenting both workarounds with the minimal background on why each is needed. It also includes a small post-spawn verification snippet that confirms the build process is unconfined **and** has no `CARGO_TARGET_DIR` in its environ, so any future regression of either pitfall surfaces immediately instead of after 25 minutes of waiting.

The verification snippet incorporates [gemini-code-assist's review suggestion](https://github.com/yugabyte/yugabyte-db/pull/31730#discussion_r2218279234) (`pgrep -f 'yb_build.sh|ninja -j'` + `if [ -n "$build_pid" ]` guard) so it works correctly while the build is still in the cmake-configure phase (before ninja has spawned), and extends it to also probe `/proc/<pid>/environ` for `CARGO_TARGET_DIR`.

### Empirical verification

End-to-end on a clean build dir:

* With **only** `required_permissions: ["all"]`: rsync runs fine (12 026 files synced in <1 min vs stuck at 2 files indefinitely), postgres compiles fine, ~1000 C++ objects build fine, then the documentdb extension fails at `cargo-pgrx-exists` after ~15 min — exit code 1.
* With `required_permissions: ["all"]` **and** `env -u CARGO_TARGET_DIR`: the same `yb_build.sh tsan daemons initdb --skip-pg-parquet --no-odyssey --no-ybc` invocation runs cleanly from configure through `initial_sys_catalog_snapshot` generation (the very last step under TSAN). **Exit code 0 in 20m41s**.

Documentation-only; no production code or build behavior affected. Humans running `./yb_build.sh` from their own terminal are unaffected — their terminals are already unconfined and don't typically have `CARGO_TARGET_DIR` set.

Fixes #31729.

## Test plan

- [x] No runtime / build / test behavior change — this is a documentation-only addition to `src/AGENTS.md`.
- [x] Both pitfalls reproduced independently in this session before the doc was written (sandbox deadlock at the rsync step; cargo-pgrx-exists Error 127 at the documentdb step).
- [x] Combined fix empirically verified end-to-end: `yb_build.sh tsan daemons initdb` exits 0 in 20m41s with both workarounds applied (`required_permissions: ["all"]` + `env -u CARGO_TARGET_DIR`).
- [x] The verification snippet was sanity-checked against the running build: `cat /proc/$build_pid/attr/current` → `unconfined`, `readlink /proc/$build_pid/ns/user` → `user:[4026531837]`, `grep CARGO_TARGET_DIR < environ` → no output.
- [x] CI: GitHub Actions `pr-title` / `pr-lint` on this PR.

---
_automated · Cursor (Opus 4.7)_
