### PR TITLE
[BACKPORT 2026.1][#31716] Build: Fix lint.py to use merge-base diff so CI lints only the PR's own changed files (#31717)

### DIFF
--- a/build-support/lint.py
+++ b/build-support/lint.py
@@ -110,7 +110,7 @@ def _changed_files(base: str | None = None) -> list[str]:
                      "pass --rev <base> explicitly")
     resolved = _git("rev-parse", "--symbolic-full-name", base)
     print(f"[lint] comparing against {base} ({resolved})", file=sys.stderr)
-    committed = set(_git("diff", "--name-only", "--diff-filter=d", base).splitlines())
+    committed = set(_git("diff", "--name-only", "--diff-filter=d", f"{base}...HEAD").splitlines())
     uncommitted = set(_git("diff", "--name-only", "--diff-filter=d", "HEAD").splitlines())
     untracked = set(_git("ls-files", "--others", "--exclude-standard").splitlines())
     return sorted(p for p in (committed | uncommitted | untracked) if p)


### PR DESCRIPTION
## Summary

`build-support/lint.py::_changed_files()` computed the committed-file
set with a two-dot diff against the base ref:

```python
committed = set(_git("diff", "--name-only", "--diff-filter=d", base).splitlines())
```

`git diff <base>` compares the working tree against `<base>` directly.
When `origin/master` advances past the commit a PR was rebased onto —
i.e. any commit lands in master between `git push` and the GitHub
Actions PR Static Checks job actually starting — the two-dot diff
enumerates every file changed in those intervening master commits **in
addition to** the PR's own changes. The lint then runs
`postgres`/`cpplint`/`pep8` against the unrelated files and surfaces
their pre-existing violations as PR failures.

### Local reproduction

```
git diff --name-only upstream/master HEAD       # 213 files  ← two-dot, current bug
git diff --name-only upstream/master...HEAD     #   4 files  ← three-dot, just the PR
```

The 209 extra files are exactly the unrelated content CI lints today.

### Why local `lint.sh` passes

`build-support/lint.sh --rev upstream/master` ends up computing
`upstream/master..HEAD` (the `git log` two-dot range form), which
already excludes work from intervening master commits, so local runs
don't reproduce the bug. `lint.py` is the script CI invokes, and it is
the one with the issue.

### Fix

Switch the committed-file enumeration to a three-dot diff:

```python
committed = set(_git("diff", "--name-only", "--diff-filter=d", f"{base}...HEAD").splitlines())
```

`<base>...HEAD` expands to `$(git merge-base <base> HEAD)..HEAD` — "the
files this branch has changed since diverging from base" — independent
of how far `<base>` has moved forward in the meantime. The `uncommitted`
and `untracked` lines stay as they are; they pick up working-tree state,
which the new `committed` query intentionally skips.

Fixes #31716.

Original commit: 9abe0ab56ca5fa383a8e94d613e7230ebbf5f158 / #31717

## Test plan

- [x] On a branch whose HEAD equals the current `upstream/master`, with
a synthetic edit applied to `build-support/lint.py`, verified that the
new three-dot enumeration reports `0` committed files while the old
two-dot form reports `1`, and the uncommitted set still captures the
working-tree edit:
      ```
git diff --name-only --diff-filter=d upstream/master # 1 (old, buggy)
git diff --name-only --diff-filter=d upstream/master...HEAD # 0 (new,
fix)
git diff --name-only --diff-filter=d HEAD # build-support/lint.py
      ```

---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31735/>)