### PR TITLE
[#31737] CDC: Fix TestLogRetentionByOpId_MinSpace timing race on fast hardware

### DIFF
--- a/src/yb/integration-tests/cdc_service-int-test.cc
+++ b/src/yb/integration-tests/cdc_service-int-test.cc
@@ -2335,7 +2335,7 @@ TEST_F(CDCServiceTestMinSpace, TestLogRetentionByOpId_MinSpace) {
   // ApplyTimeRetentionPolicy doesn't truncate them out of the GC list. On fast hardware the
   // write loop above can complete in well under a second, making every closed segment too
   // young to be eligible for GC.
-  SleepFor(MonoDelta::FromSeconds(2) * kTimeMultiplier);
+  SleepFor(MonoDelta::FromSeconds(2));
 
   log::SegmentSequence segment_sequence;
   ASSERT_OK(tablet_peer->log()->TEST_GetSegmentsToGC(

--- a/src/yb/integration-tests/cdc_service-int-test.cc
+++ b/src/yb/integration-tests/cdc_service-int-test.cc
@@ -2331,6 +2331,12 @@ TEST_F(CDCServiceTestMinSpace, TestLogRetentionByOpId_MinSpace) {
     WriteTestRow(i, kRowCount + i, "key" + std::to_string(i), tablet_id, proxy);
   }
 
+  // Ensure closed segments age past FLAGS_log_min_seconds_to_retain (1s) so that
+  // ApplyTimeRetentionPolicy doesn't truncate them out of the GC list. On fast hardware the
+  // write loop above can complete in well under a second, making every closed segment too
+  // young to be eligible for GC.
+  SleepFor(MonoDelta::FromSeconds(2) * kTimeMultiplier);
+
   log::SegmentSequence segment_sequence;
   ASSERT_OK(tablet_peer->log()->TEST_GetSegmentsToGC(
       std::numeric_limits<int64_t>::max(), &segment_sequence));


### PR DESCRIPTION
## Summary

`CDCServiceTestMinSpace.TestLogRetentionByOpId_MinSpace` writes 5000 rows then asserts that `GetSegmentsToGC` returns a non-empty list under simulated low disk space. On fast hardware (e.g. macOS arm64) the write loop completes in ~780 ms, so every closed WAL segment is still younger than `FLAGS_log_min_seconds_to_retain` (1 s, set in `SetUp`). `ApplyTimeRetentionPolicy` then truncates the entire candidate GC list and the assertion fires.

Sleep for `2s * kTimeMultiplier` after the write loop so the oldest closed segments age past the retention threshold before `GetSegmentsToGC` is called.

## Test plan

- [x] Ran `CDCServiceTestMinSpace.TestLogRetentionByOpId_MinSpace` locally on macOS arm64; passes consistently with the sleep.
- [x] CI on Linux (test was previously passing there; sleep is bounded by `kTimeMultiplier` so no meaningful runtime regression).
