### PR TITLE
[#31029] YSQL: Avoid mini-cluster master/tserver startup race in initdb

### DIFF
--- a/java/yb-client/src/test/java/org/yb/minicluster/MiniYBCluster.java
+++ b/java/yb-client/src/test/java/org/yb/minicluster/MiniYBCluster.java
@@ -902,6 +902,15 @@ public class MiniYBCluster implements AutoCloseable {
       }
       if (clusterParameters.startYsqlProxy) {
         masterCmdLine.add("--master_auto_run_initdb");
+        // Avoid GitHub #31029 startup race: initdb's postgres bootstrap calls CreateTable on the
+        // master (to create the global transaction status table) and fails with "Not enough live
+        // tablet servers ..." if no tservers have registered yet. Have the master wait for our
+        // tservers to register before launching initdb. numTservers is the right ceiling because
+        // (a) we are about to start exactly that many tservers immediately after, and (b) the
+        // master's own RF requirement is min(numTservers, FLAGS_replication_factor), so any test
+        // that survives the bootstrap eventually needs all numTservers to come up anyway.
+        masterCmdLine.add(
+            "--TEST_master_min_live_tservers_before_initdb=" + clusterParameters.numTservers);
       }
       final HostAndPort masterHostAndPort = HostAndPort.fromParts(masterBindAddress, masterRpcPort);
       masterProcesses.put(masterHostAndPort,

--- a/src/yb/integration-tests/external_mini_cluster.cc
+++ b/src/yb/integration-tests/external_mini_cluster.cc
@@ -406,6 +406,13 @@ Status ExternalMiniCluster::Start(rpc::Messenger* messenger) {
   } else {
     LOG(INFO) << "No need to start tablet servers";
   }
+  // WaitForInitDb is called here, after tservers have launched, rather than inside
+  // StartMasters(). The master gates initdb on the TEST_master_min_live_tservers_before_initdb
+  // flag set in StartMaster(), so initdb only completes after the tservers above register.
+  // StartMasters() is only called from this method, so the deferral is safe.
+  if (opts_.enable_ysql) {
+    RETURN_NOT_OK(WaitForInitDb());
+  }
   if (opts_.enable_ysql && opts_.wait_for_tservers_to_accept_ysql_connections) {
     RETURN_NOT_OK(WaitForTabletServersToAcceptYSQLConnection(
         MonoTime::Now() + kTabletServerRegistrationTimeout));
@@ -563,6 +570,16 @@ Result<ExternalMasterPtr> ExternalMiniCluster::StartMaster(
   if (opts_.enable_ysql) {
     flags.push_back("--enable_ysql=true");
     flags.push_back("--master_auto_run_initdb");
+    // Avoid GitHub #31029 startup race: initdb's postgres bootstrap calls CreateTable on the
+    // master (to create the global transaction status table) and fails with "Not enough live
+    // tablet servers ..." if no tservers have registered yet. Have the master wait for the
+    // tservers we are about to start before launching initdb. Mirrors the Java-side fix in
+    // MiniYBCluster.java. num_tablet_servers is the right ceiling because (a) we are about
+    // to start exactly that many tservers immediately after, and (b) the master's RF
+    // requirement is min(num_tablet_servers, FLAGS_replication_factor), so any test that
+    // survives the bootstrap eventually needs all of them anyway.
+    flags.push_back(Format(
+        "--TEST_master_min_live_tservers_before_initdb=$0", opts_.num_tablet_servers));
     if (opts_.enable_ysql_auth) {
       flags.push_back("--ysql_enable_auth=true");
     }
@@ -1281,9 +1298,10 @@ Status ExternalMiniCluster::StartMasters() {
     masters_.push_back(master);
   }
 
-  if (opts_.enable_ysql) {
-    RETURN_NOT_OK(WaitForInitDb());
-  }
+  // Note: WaitForInitDb() is intentionally not called here. It is called from Start() after
+  // tservers have launched, so that the master's wait on
+  // TEST_master_min_live_tservers_before_initdb does not deadlock against tservers that
+  // haven't been started yet. See the comment block in Start() for details.
 
   // Trigger an election to avoid an unnecessary 3s wait on every cluster startup.
   if (!masters_.empty()) {

--- a/src/yb/integration-tests/external_mini_cluster.cc
+++ b/src/yb/integration-tests/external_mini_cluster.cc
@@ -578,6 +578,12 @@ Result<ExternalMasterPtr> ExternalMiniCluster::StartMaster(
     // to start exactly that many tservers immediately after, and (b) the master's RF
     // requirement is min(num_tablet_servers, FLAGS_replication_factor), so any test that
     // survives the bootstrap eventually needs all of them anyway.
+    //
+    // Add the flag to --undefok so that upgrade tests (which boot older yb-master binaries
+    // from build/db-upgrade/) silently ignore it. Older masters never had this race in
+    // upgrade scenarios -- they load a pre-baked sys-catalog snapshot and bypass initdb
+    // altogether -- so being able to skip the flag is safe.
+    AppendCsvFlagValue(flags, "undefok", "TEST_master_min_live_tservers_before_initdb");
     flags.push_back(Format(
         "--TEST_master_min_live_tservers_before_initdb=$0", opts_.num_tablet_servers));
     if (opts_.enable_ysql_auth) {

--- a/src/yb/master/ysql/ysql_initdb_major_upgrade_handler.cc
+++ b/src/yb/master/ysql/ysql_initdb_major_upgrade_handler.cc
@@ -340,12 +340,33 @@ Status YsqlInitDBAndMajorUpgradeHandler::RunOperationAsync(std::function<void()>
 
 void YsqlInitDBAndMajorUpgradeHandler::RunNewClusterGlobalInitDB(const LeaderEpoch& epoch) {
   if (FLAGS_TEST_master_min_live_tservers_before_initdb > 0) {
+    // Generous upper bound on how long to spin waiting for tservers. MiniYBCluster tservers
+    // normally register within a few seconds (~10-20s under ASAN). 60s leaves plenty of headroom
+    // for slow builds while still letting test teardown make progress if a tserver crashes or
+    // otherwise fails to come up -- on timeout we fall through to the regular initdb-failure
+    // path rather than hanging the master thread pool indefinitely.
+    const auto kTserverRegisterWaitTimeout = MonoDelta::FromSeconds(60);
+    // Polling interval for the wait loop below. 100ms is fine-grained enough that the master
+    // proceeds promptly once tservers register, while keeping CPU cost negligible.
+    const auto kTserverRegisterPollInterval = MonoDelta::FromMilliseconds(100);
+
     const size_t required =
         static_cast<size_t>(FLAGS_TEST_master_min_live_tservers_before_initdb);
+    const auto deadline = MonoTime::Now() + kTserverRegisterWaitTimeout;
     LOG(INFO) << "TEST_master_min_live_tservers_before_initdb=" << required
               << ": waiting for tablet servers to register before running initdb";
     while (master_.ts_manager()->NumLiveDescriptors() < required) {
-      SleepFor(MonoDelta::FromMilliseconds(100));
+      if (MonoTime::Now() > deadline) {
+        LOG(WARNING) << "Timed out after " << kTserverRegisterWaitTimeout << " waiting for "
+                     << required << " tablet servers to register (only "
+                     << master_.ts_manager()->NumLiveDescriptors()
+                     << " registered); proceeding with initdb anyway. "
+                     << "It will likely fail with \"Not enough live tablet servers ...\". "
+                     << "Falling through avoids hanging the master thread pool during test "
+                     << "teardown if a tserver fails to come up.";
+        break;
+      }
+      SleepFor(kTserverRegisterPollInterval);
     }
     LOG(INFO) << master_.ts_manager()->NumLiveDescriptors()
               << " live tablet servers registered, proceeding with initdb";

--- a/src/yb/master/ysql/ysql_initdb_major_upgrade_handler.cc
+++ b/src/yb/master/ysql/ysql_initdb_major_upgrade_handler.cc
@@ -48,6 +48,15 @@ DECLARE_string(rpc_bind_addresses);
 DECLARE_bool(ysql_enable_auth);
 DECLARE_int32(master_ts_rpc_timeout_ms);
 
+DEFINE_test_flag(int32, master_min_live_tservers_before_initdb, 0,
+    "If positive, the master waits for at least this many tablet servers to "
+    "register before launching initdb in RunNewClusterGlobalInitDB. Used by "
+    "MiniYBCluster to avoid a startup race in which the postgres bootstrap "
+    "inside initdb calls CreateTable on the master before any tablet servers "
+    "are registered, which causes the bootstrap to fail with "
+    "\"Not enough live tablet servers ...\" and the master to LOG(FATAL) in "
+    "SetInitDbDone. Production code path is unchanged at the default value 0.");
+
 DEFINE_RUNTIME_uint32(ysql_upgrade_postgres_port, 5434,
   "Port used to start the postgres process for ysql upgrade");
 
@@ -330,6 +339,18 @@ Status YsqlInitDBAndMajorUpgradeHandler::RunOperationAsync(std::function<void()>
 }
 
 void YsqlInitDBAndMajorUpgradeHandler::RunNewClusterGlobalInitDB(const LeaderEpoch& epoch) {
+  if (FLAGS_TEST_master_min_live_tservers_before_initdb > 0) {
+    const size_t required =
+        static_cast<size_t>(FLAGS_TEST_master_min_live_tservers_before_initdb);
+    LOG(INFO) << "TEST_master_min_live_tservers_before_initdb=" << required
+              << ": waiting for tablet servers to register before running initdb";
+    while (master_.ts_manager()->NumLiveDescriptors() < required) {
+      SleepFor(MonoDelta::FromMilliseconds(100));
+    }
+    LOG(INFO) << master_.ts_manager()->NumLiveDescriptors()
+              << " live tablet servers registered, proceeding with initdb";
+  }
+
   auto status =
       InitDBAndSnapshotSysCatalog(/*db_name_to_oid_list=*/{}, /*is_major_upgrade=*/false, epoch);
   ERROR_NOT_OK(


### PR DESCRIPTION
## Summary

`MiniYBCluster` (Java) and `ExternalMiniCluster` (C++) both start the
master ahead of the tservers and pass `--master_auto_run_initdb` so the
master launches `initdb` as soon as it becomes the leader. `initdb`'s
postgres bootstrap then calls `CreateTable` on the master (to create
the global transaction status table). If no tservers have registered
yet, the `CreateTable` RPC returns "Not enough live tablet servers ..."
(the master needs at least `replication_factor` tservers to place the
system table). `initdb` exits 1 and the master hits an unconditional
`LOG(FATAL)` in `YsqlCatalogConfig::SetInitDbDone`, taking the leader
down before the test gets to execute a single DDL.

The race window is short under fast (debug/release) builds, but
`asan-clang21` is slow enough on master/tserver startup that the window
is hit reliably. Symptoms observed locally:

* Java side: `TestDdlSavepoints#yb_ddl_savepoint_tests` (issue #31029)
  fails essentially every iteration under ASAN.
* C++ side: every `LibPqTestBase` test that enables YSQL fails during
  cluster bootstrap. This masked the ASAN LSan leak fix
  (`45086aab3f`) for the `PgObjectLocksTest` family (issue #30090).

This change is **test-only**:

* Add a `DEFINE_test_flag(int32, master_min_live_tservers_before_initdb)`.
  When positive, `RunNewClusterGlobalInitDB` spins on
  `TSManager::NumLiveDescriptors()` with a 100ms sleep until at least
  N tservers have registered, or until a 60s deadline elapses (at which
  point it logs a warning and falls through to the regular initdb path
  rather than hanging the master thread pool during test teardown).
  Default `0` keeps the production code path untouched (the wait loop
  is short-circuited by the `> 0` guard).

* Java: in `MiniYBCluster`, set
  `--TEST_master_min_live_tservers_before_initdb=numTservers` right next
  to the existing `--master_auto_run_initdb` flag.

* C++: in `ExternalMiniCluster::StartMaster`, set the same flag with
  `opts_.num_tablet_servers`. Additionally, move the `WaitForInitDb()`
  call out of `StartMasters()` and into `Start()` after tservers have
  been launched -- otherwise the new flag would deadlock against
  tservers that haven't been started yet. `StartMasters()` has no
  callers outside `Start()`, so this deferral is safe.

For both harnesses, the N value passed matches the number of tservers
the harness is about to start, which is always `>=` the cluster's
effective replication factor, so the wait completes as soon as the
last tserver registers.

No production-side fix is needed. `FLAGS_master_auto_run_initdb`
defaults to `false` (`ysql_manager.cc`), and production clusters load
the pre-baked initial sys-catalog snapshot bundled at build time
(`share/initial_sys_catalog_snapshot/`, auto-detected at master
startup in `sys_catalog_initialization.cc`). The bootstrap-initdb path
in `RunNewClusterGlobalInitDB` is therefore reachable only from test
harnesses (this PR fixes both) and from the build-time
`create_initial_sys_catalog_snapshot` tool, which configures 0
tservers and short-circuits the new wait loop via the `> 0` guard.

## Test plan

- [x] `asan-clang21` local, 5 iterations of `TestDdlSavepoints` (Java):
      `./yb_build.sh asan --java-test 'org.yb.pgsql.TestDdlSavepoints#yb_ddl_savepoint_tests' --skip-cxx-build -n 5 --tp 1`
      -> 5/5 PASSED. Without this change, 5/5 fail with "Master config
      ... has no leader" after the master FATALs on `initdb` exit code
      256 in the bootstrap phase.
- [x] `asan-clang21` local, C++ tests from #30090:
      `PgObjectLocksTest.VerifyLockTimeout` (5/5),
      `PgObjectLocksTestMixModeDuringPromotion.TestMixModeDuringPromotion` (3/3),
      `PgObjectLocksTestMixModeDuringPromotion.TestLocksTakenAfterPromotionWithExistingConnections` (3/3),
      `PgObjectLocksTestRF1.TestShutdownWithWaiters` (3/3),
      `PgObjectLocksTestRF1.TestDisableReuseAbortedPlainTxn` (3/3).
      The first three are `LibPqTestBase`-based and required this fix.
      The last two are `PgMiniTestBase`-based (in-process MiniCluster)
      and pass with or without the C++ harness change -- included to
      cover the full sibling list Sergei flagged in #30090 and confirm
      no regression.
- [ ] CI on `asan-clang21` (primary signal: `TestDdlSavepoints` no
      longer flakes during cluster startup, and the `PgObjectLocksTest`
      family no longer fails during bootstrap).
- [ ] CI on `debug-clang21` / `release-clang21` (no regression -- the
      production code path is gated behind `FLAGS_TEST_... > 0`,
      default `0`).


---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31753/>)
