### PR TITLE
[#31755] Build: Preserve caller's YB_EXTRA_GTEST_FLAGS

### DIFF
--- a/build-support/yb_build_cmd_line.sh
+++ b/build-support/yb_build_cmd_line.sh
@@ -388,7 +388,12 @@ set_default_yb_build_args() {
   export YB_DOWNLOAD_THIRDPARTY=${YB_DOWNLOAD_THIRDPARTY:-1}
   export YB_HOST_FOR_RUNNING_TESTS=${YB_HOST_FOR_RUNNING_TESTS:-}
 
-  export YB_EXTRA_GTEST_FLAGS=""
+  # Honor any value the caller has already exported (e.g. from a wrapper script or interactive
+  # shell). The downstream consumers in common-test-env.sh and bin/repeat_unit_test.sh all
+  # dereference YB_EXTRA_GTEST_FLAGS as ${YB_EXTRA_GTEST_FLAGS:-}, and --test-args (below)
+  # appends with +=, so preserving the caller's value is safe and lets people prefix gtest
+  # flags onto the command without having to discover --test-args.
+  export YB_EXTRA_GTEST_FLAGS="${YB_EXTRA_GTEST_FLAGS:-}"
   unset BUILD_ROOT
 
   if [[ ${YB_RECREATE_INITIAL_SYS_CATALOG_SNAPSHOT:-} == "1" ]]; then


### PR DESCRIPTION
## Summary

`set_default_yb_build_args()` in `build-support/yb_build_cmd_line.sh` previously did

```bash
export YB_EXTRA_GTEST_FLAGS=""
```

unconditionally, silently dropping any value the caller had already exported in their environment. All downstream consumers (`common-test-env.sh:483`, `bin/repeat_unit_test.sh:286` and `:405-408`) dereference the variable as `${YB_EXTRA_GTEST_FLAGS:-}` and explicitly log when it is or isn't set — i.e. the rest of the system is structured to honor the caller's value, only this line fights that.

The result is that a perfectly reasonable invocation like

```bash
YB_EXTRA_GTEST_FLAGS=--gtest_repeat=5 ./yb_build.sh --cxx-test foo
```

silently has no effect, and you only notice if you happen to read the run log carefully. The only working entry point for ad-hoc gtest flags ends up being `./yb_build.sh ... --test-args "<flags>"` (line 558, which appends via `+=` to the same variable).

Per Slack discussion with @svarnau on the build team, change the line to preserve the caller's value:

```bash
export YB_EXTRA_GTEST_FLAGS="${YB_EXTRA_GTEST_FLAGS:-}"
```

A 5-line comment is added explaining why preserving is safe (so a future reader doesn't revert it back to the unconditional clear).

History: this line dates to 2016 (originally in `yb_build.sh`, moved to `yb_build_cmd_line.sh` by commit `7b67f9ce82`). Steve confirmed the CI Jenkins jobs never set `YB_EXTRA_GTEST_FLAGS` explicitly, so preserving the caller's value won't affect CI reproducibility.

Tracked in #31755.

## Test plan

- [x] Static read of all `YB_EXTRA_GTEST_FLAGS` consumers in the repo
      (`rg YB_EXTRA_GTEST_FLAGS`): all use `${YB_EXTRA_GTEST_FLAGS:-}`,
      i.e. default-empty when unset, so preserving the caller's value
      cannot break them.
- [x] Manual repro of the original bug before the fix:
      `YB_EXTRA_GTEST_FLAGS=--gtest_repeat=5 ./yb_build.sh --cxx-test foo`
      silently drops the flag; with the fix, the flag is honored
      (verified via `repeat_unit_test.sh`'s log line
      "Extra test flags from YB_EXTRA_GTEST_FLAGS: ...").
- [ ] CI green (shellcheck + any build-support tests).
- [ ] CI confirms no Jenkins job depends on the variable being cleared
      to empty (Steve confirmed via Slack that no CI job sets
      `YB_EXTRA_GTEST_FLAGS` explicitly).


---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31756/>)