### PR TITLE
[#31763] lint: Exclude tools from std::thread lint check

### DIFF
--- a/src/lint/cpplint.py
+++ b/src/lint/cpplint.py
@@ -5971,7 +5971,7 @@ def CheckStdThread(filename, clean_lines, linenum, error):
     linenum: The number of the line to check.
     error: The function to call with any errors found.
   """
-  if "thread" not in filename and "test" not in filename:
+  if "thread" not in filename and "test" not in filename and "tool" not in filename:
     line = clean_lines.elided[linenum]
     match = _RE_PATTERN_STD_THREAD.search(line)
     if match:

--- a/src/lint/cpplint.py
+++ b/src/lint/cpplint.py
@@ -5971,7 +5971,7 @@ def CheckStdThread(filename, clean_lines, linenum, error):
     linenum: The number of the line to check.
     error: The function to call with any errors found.
   """
-  if "thread" not in filename and "test" not in filename and "tool" not in filename:
+  if "thread" not in filename and "test" not in filename and "/tools/" not in filename:
     line = clean_lines.elided[linenum]
     match = _RE_PATTERN_STD_THREAD.search(line)
     if match:


### PR DESCRIPTION
Ran `src/lint/cpplint.py src/yb/rocksdb/tools/write_stress.cc` and made sure std::thread error no longer appears.