### PR TITLE
[BACKPORT 2026.1][#31676] YSQL: Remove ybhnsw.ef_search GUC (#31677)

### DIFF
--- a/src/postgres/third-party-extensions/pgvector/src/ybvector/ybhnsw.c
+++ b/src/postgres/third-party-extensions/pgvector/src/ybvector/ybhnsw.c
@@ -82,34 +82,17 @@ YbHnswInit(void)
 					  AccessExclusiveLock);
 	/* YB: needed so ysql_dump's WITH (colocation_id=...) parses on restore. */
 	YbAddColocationIdReloption(ybhnsw_relopt_kind);
-	/*
-	 * Notes:
-	 * - Both hnsw.ef_search and ybhnsw.ef_search map to the same underlying
-	 *   variable. This allows both GUCs to have the same value irrespective of
-	 *   which one is used.
-	 * - If both GUCs are set via 'ysql_pg_conf_csv', the value of ybhnsw.ef_search
-	 *   will override the value of hnsw.ef_search. This is because the new
-	 *   values of the GUCs are applied in the order in which the GUCs are
-	 *   defined in the extension init function (which invokes this function).
-	 * - A caveat of this mechanism is that if both of these GUCs are set via
-	 *   'ysql_pg_conf_csv', and the user runs a 'SHOW <guc-name>' query before
-	 *   the extension is init'ed, the GUCs will display different values. This
-	 *   is harmless (as one can't use the GUC meaningfully without the
-	 *   extension) and will get reconciled automatically upon running a query
-	 *   that causes the extension to initialize.
-	 */
 	DefineCustomIntVariable("hnsw.ef_search", "Sets the size of the dynamic candidate list for search",
-							"Valid range is 1..1000. This parameter automatically maintains the "
-							"same value as ybhnsw.ef_search. If both are set at startup, the value "
-							"of ybhnsw.ef_search is prioritized over the value of hnsw.ef_search. ",
+							"Valid range is 1..1000.",
 							&ybhnsw_ef_search,
 							YBHNSW_DEFAULT_EF_SEARCH, YBHNSW_MIN_EF_SEARCH, YBHNSW_MAX_EF_SEARCH, PGC_USERSET, 0, NULL, NULL, NULL);
 	MarkGUCPrefixReserved("hnsw");
-
-	DefineCustomIntVariable("ybhnsw.ef_search", "Sets the size of the dynamic candidate list for search",
-							"Valid range is 1..1000. This parameter automatically maintains the "
-							"same value as hnsw.ef_search.", &ybhnsw_ef_search,
-							YBHNSW_DEFAULT_EF_SEARCH, YBHNSW_MIN_EF_SEARCH, YBHNSW_MAX_EF_SEARCH, PGC_USERSET, 0, NULL, NULL, NULL);
+	/*
+	 * YB: Keep the ybhnsw prefix reserved (even though we no longer define any
+	 * ybhnsw.* GUCs) so that lingering 'SET ybhnsw.ef_search = ...' or
+	 * ysql_pg_conf_csv entries from before the removal produce a clear error
+	 * / startup warning instead of silently being accepted as no-op placeholders.
+	 */
 	MarkGUCPrefixReserved("ybhnsw");
 }
 

--- a/src/postgres/third-party-extensions/pgvector/test/expected/yb.orig.index.out
+++ b/src/postgres/third-party-extensions/pgvector/test/expected/yb.orig.index.out
@@ -389,7 +389,6 @@ DROP TABLE vec2;
 DROP TABLE vec1;
 CREATE TABLE vec1 (embedding vector(3));
 CREATE INDEX vec1_idx ON vec1 USING hnsw (embedding vector_l2_ops);
-SET ybhnsw.ef_search = 100;
 SET hnsw.ef_search = 100;
 \d vec1
                   Table "public.vec1"
@@ -400,45 +399,6 @@ Indexes:
     "vec1_idx" ybhnsw (embedding)
 
 DROP TABLE vec1;
--- Test to validate that both GUCs ybhnsw.ef_search and hnsw.ef_search are in sync.
-SHOW ybhnsw.ef_search;
- ybhnsw.ef_search 
-------------------
- 100
-(1 row)
-
-SHOW hnsw.ef_search;
- hnsw.ef_search 
-----------------
- 100
-(1 row)
-
-SET ybhnsw.ef_search = 200;
-SHOW ybhnsw.ef_search;
- ybhnsw.ef_search 
-------------------
- 200
-(1 row)
-
-SHOW hnsw.ef_search;
- hnsw.ef_search 
-----------------
- 200
-(1 row)
-
-RESET hnsw.ef_search;
-SHOW ybhnsw.ef_search;
- ybhnsw.ef_search 
-------------------
- 40
-(1 row)
-
-SHOW hnsw.ef_search;
- hnsw.ef_search 
-----------------
- 40
-(1 row)
-
 -- ANALYZE should not produce any warnings on tables with ybhnsw indexes.
 CREATE TABLE vec_analyze (id serial PRIMARY KEY, embedding vector(3)) SPLIT INTO 1 TABLETS;
 CREATE INDEX ON vec_analyze USING ybhnsw (embedding vector_l2_ops);

--- a/src/postgres/third-party-extensions/pgvector/test/sql/yb.orig.index.sql
+++ b/src/postgres/third-party-extensions/pgvector/test/sql/yb.orig.index.sql
@@ -122,22 +122,9 @@ DROP TABLE vec1;
 
 CREATE TABLE vec1 (embedding vector(3));
 CREATE INDEX vec1_idx ON vec1 USING hnsw (embedding vector_l2_ops);
-SET ybhnsw.ef_search = 100;
 SET hnsw.ef_search = 100;
 \d vec1
 DROP TABLE vec1;
-
--- Test to validate that both GUCs ybhnsw.ef_search and hnsw.ef_search are in sync.
-SHOW ybhnsw.ef_search;
-SHOW hnsw.ef_search;
-
-SET ybhnsw.ef_search = 200;
-SHOW ybhnsw.ef_search;
-SHOW hnsw.ef_search;
-
-RESET hnsw.ef_search;
-SHOW ybhnsw.ef_search;
-SHOW hnsw.ef_search;
 
 -- ANALYZE should not produce any warnings on tables with ybhnsw indexes.
 CREATE TABLE vec_analyze (id serial PRIMARY KEY, embedding vector(3)) SPLIT INTO 1 TABLETS;

--- a/src/yb/yql/pgwrapper/pg_vector_index-test.cc
+++ b/src/yb/yql/pgwrapper/pg_vector_index-test.cc
@@ -1108,7 +1108,7 @@ TEST_P(PgVectorIndexTest, EfSearch) {
 
   for (int i = 0; i != kIterations; ++i) {
     for (int ef : {kSmallEf, kBigEf}) {
-      ASSERT_OK(conn.ExecuteFormat("SET ybhnsw.ef_search = $0", ef));
+      ASSERT_OK(conn.ExecuteFormat("SET hnsw.ef_search = $0", ef));
       ANNOTATE_UNPROTECTED_WRITE(docdb::TEST_vector_index_max_checked_entries) = ef * 100;
       auto valid = RowsMatch(conn, "", ExpectedRows(1));
       ASSERT_TRUE(valid || ef == kSmallEf);


### PR DESCRIPTION
## Summary

Remove the `ybhnsw.ef_search` GUC, which was a YugabyteDB-specific alias
for the standard `hnsw.ef_search` GUC. Both mapped to the same
underlying C variable, keeping them permanently in sync.
`hnsw.ef_search` is the canonical Postgres-compatible name and is
sufficient on its own.

Having 2 separate GUCs resulted in issues when set before the extension
is loaded. The pgvector extension library is not in
`shared_preload_libraries`. It's loaded lazily the first time a query
touches a vector index in a session. When two GUCs share the same
`valueAddr` and the extension loads lazily, the second
`DefineCustomIntVariable` call always clobbers whatever the first one
absorbed from a placeholder.

Changes:
- Remove `DefineCustomIntVariable("ybhnsw.ef_search", ...)` from
`ybhnsw.c`. Keep `MarkGUCPrefixReserved("ybhnsw")` so that stale
`ybhnsw.*` configuration produces a visible error/warning instead of
being silently accepted as a no-op placeholder GUC.
- Update `yb.orig.index` regression test to remove `ybhnsw.ef_search`
SET/SHOW/RESET cases.
- Update `pg_vector_index-test.cc` `EfSearch` test to use `SET
hnsw.ef_search`.

## Upgrade/Rollback safety

This is a breaking change to the public SQL configuration surface: the
`ybhnsw.ef_search` GUC is removed. Because the `ybhnsw` prefix is still
reserved, any cluster that has `ybhnsw.ef_search` set will surface the
breakage clearly:
- `ysql_pg_conf_csv` containing `ybhnsw.ef_search=...`: the server
starts, but the pgvector extension load logs `WARNING: invalidated
custom configuration parameter "ybhnsw.ef_search"` and discards the
value.
- Interactive `SET ybhnsw.ef_search = ...`: fails with `ERROR:
unrecognized configuration parameter "ybhnsw.ef_search"`.

Migrate to the equivalent `hnsw.ef_search` GUC before upgrading.

Rollback is safe — restoring a previous build re-introduces the GUC.

Original commit: aca4759ad4979a4abf0e09833e3f38b19e465fdc / #31677

## Test plan

- [x] Built the pgvector extension (`vector.so`) with the updated
`ybhnsw.c`.
- [x] Ran `pg_vector_index-test --gtest_filter=*EfSearch*`: all 24
parameterized variants **PASSED** (305s).
- [x] Ran `TestPgRegressThirdPartyExtensionsPgvector#schedule` (includes
`yb.orig.index`): **PASSED** (30s).



---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31764/>)