### PR TITLE
[BACKPORT 2026.1][#30018] YSQL: Fix flaky test PgDDLConcurrencyTest.IndexCreation

### DIFF
--- a/src/yb/yql/pgwrapper/pg_ddl_concurrency-test.cc
+++ b/src/yb/yql/pgwrapper/pg_ddl_concurrency-test.cc
@@ -34,8 +34,12 @@ Status SuppressAllowedErrors(const Status& s) {
   // Catalog Version Mismatch: A DDL occurred while processing this query. Try again.
   // The "Try again" will be detected by IsRetryable(s) as true. But in uncommon
   // cases, PG backend will not append this line, for this test we still want to
-  // suppress this error.
-  if (s.message().Contains("waiting for postgres backends to catch up")) {
+  // suppress this error. The wait can time out either inside PG (after
+  // ysql_yb_wait_for_backends_catalog_version_timeout) or at the master RPC layer (after
+  // wait_for_ysql_backends_catalog_version_client_master_rpc_timeout_ms), so allow both
+  // flavors of message.
+  if (s.message().Contains("waiting for postgres backends to catch up") ||
+      s.message().Contains("WaitForBackendsCatalogVersion RPC")) {
     return Status::OK();
   }
   return s;
@@ -47,23 +51,32 @@ Status RunIndexCreationQueries(PGConn* conn, const std::string& table_name) {
       "CREATE TABLE IF NOT EXISTS $0(k int PRIMARY KEY, v int)",
       "CREATE INDEX IF NOT EXISTS $0_v ON $0(v)",
   };
-  while (true) {
+  // Cap retries. Every DDL bumps the catalog version (#28253), so with 4 threads cycling
+  // DROP -> CREATE TABLE -> CREATE INDEX, a CREATE INDEX -- which internally waits for backends
+  // to catch up to multiple catalog versions, governed by
+  // ysql_yb_wait_for_backends_catalog_version_timeout (30s) -- is very likely to be invalidated
+  // by a peer's DDL and time out. An unbounded retry then livelocks the test past the 10-minute
+  // gtest timeout. The test only needs to verify that no unexpected errors are produced; it does
+  // not require CREATE INDEX to actually succeed.
+  constexpr int kMaxAttempts = 10;
+  for (int attempt = 0; attempt < kMaxAttempts; ++attempt) {
     RETURN_NOT_OK(SuppressAllowedErrors(conn->ExecuteFormat(kQueries[0], table_name)));
 
     // CREATE TABLE may fail due to catalog version mismatch.
-    // If it fails, skip creating the index on it.
+    // If it fails, retry from DROP so that CREATE INDEX is not attempted against a missing
+    // relation (which would surface as a non-suppressible error).
     auto create_status = conn->ExecuteFormat(kQueries[1], table_name);
     RETURN_NOT_OK(SuppressAllowedErrors(create_status));
     if (!create_status.ok()) {
       continue;
     }
 
-    auto index_status = conn->ExecuteFormat(kQueries[2], table_name);
-    RETURN_NOT_OK(SuppressAllowedErrors(index_status));
-    if (index_status.ok()) {
-      return Status::OK();
-    }
+    // The code path under test (DDL transaction commit in the middle of CREATE INDEX) has been
+    // exercised. A suppressed error here is an acceptable outcome.
+    RETURN_NOT_OK(SuppressAllowedErrors(conn->ExecuteFormat(kQueries[2], table_name)));
+    return Status::OK();
   }
+  return Status::OK();
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
PgDDLConcurrencyTest.IndexCreation flakes in master (~14% failure rate
across recent builds). Two related issues:

1: Livelock from unbounded retry. After D47116 every DDL bumps the
catalog version, including DROP TABLE and CREATE TABLE. The
RunIndexCreationQueries inner loop was unbounded -- it only exited when
CREATE INDEX itself succeeded. With 4 threads (3 workers + 1 main)
cycling DROP -> CREATE TABLE -> CREATE INDEX as fast as possible, the
probability of CREATE INDEX (which internally waits for backends to
catch up to multiple catalog versions, governed by the 30s
ysql_yb_wait_for_backends_catalog_version_timeout) finishing without
being invalidated by a peer's DDL is very low. This causes the CREATE INDEX
to fail—but the test simply retries until it succeeds. This retry loop livelocked for long
stretches, pushing the test from ~3 min to the 10 min gtest timeout
and producing flaky failures with no useful log content.

2: Missing suppression for the master-side RPC timeout. When the wait
times out at the master RPC layer (governed by
wait_for_ysql_backends_catalog_version_client_master_rpc_timeout_ms,
5s in this test) rather than inside PG, the error message is
"WaitForBackendsCatalogVersion RPC ... timed out" rather than
"waiting for postgres backends to catch up". Only the latter was being
suppressed, so the RPC-layer timeout reached the test as an
unrecognized error and failed it.

Fix:

- Cap the inner retry loop at 10 attempts and treat exhaustion as
  success. The test only verifies that no unexpected errors are
  produced under concurrent DDL; it does not require CREATE INDEX to
  actually succeed.
- Add "WaitForBackendsCatalogVersion RPC" to the suppression list
  alongside "waiting for postgres backends to catch up".

Original commit: 0efde867a5e7fd77b7c48a4c7c88019bcd882b71 / D53345

Test Plan:
```
./yb_build.sh release --cxx-test pg_ddl_concurrency-test \
  --gtest_filter PgDDLConcurrencyTest.IndexCreation -n 50 \
  --test-parallelism 6
```

70/70 iterations pass locally across two stress runs (20 at -p 4, 50
at -p 6); each iteration finishes in 33-60s. Before the fix one run
reproduced the "WaitForBackendsCatalogVersion RPC ... timed out after
10.000s" failure in 34s.

Reviewers: myang

Reviewed By: myang

Subscribers: yql

Differential Revision: https://phorge.dev.yugabyte.com/D53345

---

[CSI](<https://csiweb.dev.yugabyte.com/pull/31766/>)