### PR TITLE
[BACKPORT 2026.1][#28098] YSQL: Bump BasePgSQLTest cluster-startup wait to 30s to fix multi-test flake

### DIFF
--- a/java/yb-pgsql/src/test/java/org/yb/pgsql/BasePgSQLTest.java
+++ b/java/yb-pgsql/src/test/java/org/yb/pgsql/BasePgSQLTest.java
@@ -104,7 +104,7 @@ public class BasePgSQLTest extends BaseMiniClusterTest {
   /** Matches Postgres' FirstNormalObjectId */
   protected final long FIRST_NORMAL_OID = 16384;
 
-  protected final long WAIT_FOR_PG_AFTER_CLUSTER_START_TIMEOUT_MS = 10000;
+  protected final long WAIT_FOR_PG_AFTER_CLUSTER_START_TIMEOUT_MS = 30000;
 
   private boolean pg_connection_check_after_startup = true;
 


### PR DESCRIPTION
Summary:
`waitForAllTServerPgWebservers`, added in cbb4a09da7b ("[#16814] YSQL: Fix TestYsqlMetrics flake by waiting for all PG webservers"), reused the existing `WAIT_FOR_PG_AFTER_CLUSTER_START_TIMEOUT_MS = 10s`. That budget worked for the prior caller, `verifyClusterAcceptsPGConnections`, because it races the fastest tserver in round-robin and returns as soon as one accepts a PG connection. The new helper, by contrast, waits on **all** tservers' `pgsql_proxy_webserver_port` binds and is bottlenecked by the slowest. Under load on release builds (sanitizer builds already get 30-90s headroom from `BuildTypeUtil`), a single tserver's webserver bind can exceed 10s and trip the timeout.

`initPostgresBefore` runs on the `@Before` of every `BasePgSQLTest`-derived test and again on every `restartCluster*` call, so the tight timeout is a latent flake risk across hundreds of PG Java tests. Tests that restart the cluster multiple times in a single method (e.g. `searchBindModeWithSearchWithEnvVarDefined` does it twice) are disproportionately exposed.

The tests below show fast-fail (~13-15s) signatures on `master` since the 2026-04-17 introduction of `waitForAllTServerPgWebservers`:

- [TestLDAPAuth.searchBindModeWithSearchWithEnvVarDefined[0]](https://detective.dev.yugabyte.com/stability/old/test?branch=master&class=org.yb.pgsql.TestLDAPAuth&name=searchBindModeWithSearchWithEnvVarDefined%5B0%5D) -- the test in #28098.
- [TestLDAPAuth.searchBindModeWithSearchWithEnvVarDefined[1]](https://detective.dev.yugabyte.com/stability/old/test?branch=master&class=org.yb.pgsql.TestLDAPAuth&name=searchBindModeWithSearchWithEnvVarDefined%5B1%5D) -- same test, YSQL_CONN_MGR variant.
- [TestYsqlMetrics.testMetricRows](https://detective.dev.yugabyte.com/stability/old/test?branch=master&class=org.yb.pgsql.TestYsqlMetrics&name=testMetricRows) and [TestYsqlMetrics.testStatementStats](https://detective.dev.yugabyte.com/stability/old/test?branch=master&class=org.yb.pgsql.TestYsqlMetrics&name=testStatementStats) -- the tests #16814 was meant to fix. They continue to flake because the new wait it introduced has the same tight 10s budget.
- [TestPgIndexSelectiveUpdate.testUpdateTableIndexWrites](https://detective.dev.yugabyte.com/stability/old/test?branch=master&class=org.yb.pgsql.TestPgIndexSelectiveUpdate&name=testUpdateTableIndexWrites) and [TestPgIndexSelectiveUpdate.testUpdateTableIndexWritesNoPushdown](https://detective.dev.yugabyte.com/stability/old/test?branch=master&class=org.yb.pgsql.TestPgIndexSelectiveUpdate&name=testUpdateTableIndexWritesNoPushdown).

Bump the timeout to 30s. For comparison, `MiniYBCluster` already gives tserver startup 60s and master startup 120s; 30s for the PG/webserver bind is in the same order of magnitude. Healthy startups still complete in 1-2s; a real bind failure still surfaces as a timeout, just after 30s instead of 10s. No passing case can regress -- this only relaxes an existing wait.

Note that #16814 was auto-closed when cbb4a09da7b landed; it should be reopened (or this diff should claim it) since the tests it tracked are still flaking for the same root cause class.

Original commit: 5c6b2085ef024a0214eb2f629239b7d3f5a1f70e / D53415

Test Plan:
```
  ./yb_build.sh release --java-test 'org.yb.pgsql.TestLDAPAuth#searchBindModeWithSearchWithEnvVarDefined[0]' -n 25 --tp 1
```

Reviewers: jason, hsunder

Reviewed By: jason

Subscribers: ybase

Differential Revision: https://phorge.dev.yugabyte.com/D53415