### PR TITLE
[BACKPORT 2024.2][#31704] YSQL: Fix PgDdlAtomicitySnapshotTest.SnapshotTest flake under TSAN

### DIFF
--- a/src/yb/yql/pgwrapper/pg_ddl_atomicity-test.cc
+++ b/src/yb/yql/pgwrapper/pg_ddl_atomicity-test.cc
@@ -1317,7 +1317,7 @@ TEST_F(PgDdlAtomicitySnapshotTest, SnapshotTest) {
   HybridTime hybrid_time_before_rollback = HybridTime::FromMicros(current_time.ToInt64());
 
   // Ensure that at least one snapshot is taken.
-  SleepFor(snapshot_interval_secs * 5s);
+  SleepFor(snapshot_interval_secs * 5s * kTimeMultiplier);
 
   // Verify that rollback for Alter and Create has indeed not happened yet.
   VerifyTableExists(client.get(), kDatabase, kCreateTable, 10);
@@ -1370,7 +1370,7 @@ Status PgDdlAtomicitySnapshotTest::ListSnapshotTest(DdlErrorInjection inject_err
   Timestamp current_time(VERIFY_RESULT(WallClock()->Now()).time_point);
   HybridTime hybrid_time_before_rollback = HybridTime::FromMicros(current_time.ToInt64());
 
-  SleepFor(snapshot_interval_secs * 5s);
+  SleepFor(snapshot_interval_secs * 5s * kTimeMultiplier);
   auto snapshot_id =
       VERIFY_RESULT(snapshot_util_->PickSuitableSnapshot(schedule_id, hybrid_time_before_rollback));
 


### PR DESCRIPTION
DO NOT MERGE!! [CSI](<https://csiweb.dev.yugabyte.com/pull/31793/>) ⏳

Summary:
`PgDdlAtomicitySnapshotTest.SnapshotTest` (and the `ListSnapshotTest` helper that drives several parameterized snapshot tests) sleeps for `snapshot_interval_secs * 5s` after recording `hybrid_time_before_rollback`, expecting at least one fresh snapshot to land before the subsequent `PickSuitableSnapshot(schedule_id, hybrid_time_before_rollback)`. With `snapshot_interval_secs = 1` that's 5 seconds, which is enough on fastdebug/release but not under TSAN where snapshot creation itself takes several extra seconds. When the sleep elapses before any snapshot with `cur_ht >= hybrid_time_before_rollback` is committed, every snapshot in the schedule is `<invalid>-{old_ht}`-bounded and `PickSuitableSnapshot` returns `NotFound`, which propagates through `ASSERT_RESULT` and fails the test. The `VerifyTableExists` / `VerifyTableNotExists` calls in this test also rely on similar wall-clock budgets and stack additional flakiness on top.

Local TSAN repro confirms the symptom exactly (see Test Plan): `snapshot_test_util.cc:437] PickSuitableSnapshot rejected <id> (<invalid>-{ ... }] for { ... }` followed by `[  FAILED  ] PgDdlAtomicitySnapshotTest.SnapshotTest`. CSI ReportPortal logs for the original failing runs (~40 % flake rate per the issue) show the same shape, sometimes followed by external SIGKILL when the cumulative retry-loop blows the test wall budget.

This file already uses `kTimeMultiplier` (lines 2110, 2133), so this diff just propagates the same pattern to the two `SleepFor(snapshot_interval_secs * 5s)` sites that drive the snapshot-test scenarios.

No production-code change. The fix is two test-only scaling adjustments.

Reference: https://github.com/yugabyte/yugabyte-db/issues/31704

Original commit: 1cd4c0c476aa951d921b9d0be2a7e511ceb83b60 / D53380

Test Plan:
**Local TSAN verification (idle 8-CPU desktop):**

`./yb_build.sh tsan --cxx-test pg_ddl_atomicity-test --gtest_filter PgDdlAtomicitySnapshotTest.SnapshotTest -n 30 --test-parallelism 4`

| Branch | Iters | Harness FAIL | gtest assertion FAIL (this diff's target) | TSAN-race FAIL (unrelated, see below) |
| --- | --- | --- | --- | --- |
| `master` (681310b12b) | 30 | 12 | **0** | 12 |
| fix branch (4d71b15ff4) | 30 | 13 | **1** (iter 30) | 12 |

(At parallelism = 1 on idle hardware, 10/10 PASS on both branches; the flake doesn't surface without CPU pressure.)

Failure signature on the targeted iter (fix branch, iter 30, 113 878 ms):

```
snapshot_test_util.cc:437] PickSuitableSnapshot rejected <snapshot-id>
  (<invalid>-{ days: 20592 time: 06:02:24.238852 }] for { days: 20592 time: 06:02:25.388299 }
[  FAILED  ] PgDdlAtomicitySnapshotTest.SnapshotTest (113878 ms)
```

This is exactly the failure mode this diff targets — the only snapshot in the schedule covers a time **before** `hybrid_time_before_rollback`, so `ASSERT_RESULT(PickSuitableSnapshot(...))` returns `NotFound`. The iter took 114 s vs the normal 50–60 s, i.e. master stalled long enough that no new snapshot was captured during the (5 s × kTimeMultiplier = 15 s) sleep. `kTimeMultiplier = 3` is enough for the common-case lag but not the worst-case stall under heavy concurrent TSAN load.

The other 12 + 12 "harness FAIL"s on both branches are an independent flake: `WARNING: ThreadSanitizer: data race` inside postgres signal-handling code during tserver/postgres teardown (`timeout.c:handle_sig_alarm` racing with `proc.c:LockErrorCleanup` / `postgres.c:die`, and `latch.c:SetLatch` racing with itself). They trigger when 4 tservers shut down concurrently on an 8-CPU box and aren't reachable from the test body or from this diff's `SleepFor` scaling. Same failure shape and rate on both branches (~40 %), so they're orthogonal to this fix and won't surface on Jenkins TSAN (which uses parallelism = 1 per test binary).

**Conclusion**
- Local repro confirms this diff exercises the right failure mode (`PickSuitableSnapshot` returning `NotFound`).
- The 3× scaling is enough for normal CI conditions; the one fix-branch failure happened under load conditions worse than CI sees. If Jenkins still shows the flake materially, the next step is to bump the multiplier further (e.g. `... * 10`) or replace the `SleepFor` with a `WaitForScheduleSnapshot`-style poll that explicitly waits for a snapshot whose hybrid time exceeds `hybrid_time_before_rollback`.
- `kTimeMultiplier = 1` outside sanitizer builds, so non-TSAN configurations are unaffected. Pre-merge Jenkins TSAN remains the final verifying oracle.

Reviewers: myang

Reviewed By: myang

Subscribers: ybase, yql

Differential Revision: https://phorge.dev.yugabyte.com/D53380