### PR TITLE
[#31771] Docs: Document hnsw.ef_search GUC and USING hnsw alias in pgvector extension docs

### DIFF
--- a/docs/content/stable/additional-features/pg-extensions/extension-pgvector.md
+++ b/docs/content/stable/additional-features/pg-extensions/extension-pgvector.md
@@ -180,6 +180,12 @@ To use the L2 distance function:
 CREATE INDEX NONCONCURRENTLY ON items USING ybhnsw (embedding vector_l2_ops);
 ```
 
+For PostgreSQL backwards compatibility, `USING hnsw` is also supported and is internally mapped to the `ybhnsw` index access method. For example, the following statement is equivalent to the one above:
+
+```sql
+CREATE INDEX NONCONCURRENTLY ON items USING hnsw (embedding vector_l2_ops);
+```
+
 To use the inner product function:
 
 ```sql
@@ -211,12 +217,26 @@ CREATE INDEX NONCONCURRENTLY ON items USING ybhnsw (embedding vector_l2_ops) WIT
 
 A higher `ef_construction` value provides faster recall at the cost of index build time / insert speed.
 
+#### Query-time tuning
+
+You can tune query-time behavior of HNSW search using the following GUC:
+
+| GUC | Description | Default |
+| :--- | :--- | :--- |
+| hnsw.ef_search | Size of the dynamic candidate list for search. Valid range: 1–1000. Higher values improve recall at the cost of query latency. | 40 |
+
+For example, to increase recall for the current session:
+
+```sql
+SET hnsw.ef_search = 100;
+```
+
 ### Limitations
 
 - Concurrent index creation is not currently supported. For example, the following syntax falls back to non-concurrent implementation:
 
     ```sql
-    CREATE INDEX CONCURRENLTY on <table> USING ybhnsq (vec vector_l2_ops);
+    CREATE INDEX CONCURRENTLY on <table> USING ybhnsw (vec vector_l2_ops);
     ```
 
     Unlike concurrent index creation on non-vector data types, the index backfill will take an exclusive lock (ACCESS_EXCLUSIVE) on the table, and writes to the table are blocked while index backfill is in progress. {{<issue 26402>}}


### PR DESCRIPTION
## Summary

Updates the stable pgvector extension documentation:

- Document the `hnsw.ef_search` GUC under a new "Query-time tuning" subsection — default `40`, valid range `1–1000`, with an example `SET` statement.
- Note that `USING hnsw` is also supported for PostgreSQL backwards compatibility and is internally mapped to the `ybhnsw` index access method, with an equivalent example.
- Fix typos `ybhnsq` → `ybhnsw` and `CONCURRENLTY` → `CONCURRENTLY` in the Limitations example.

## Test plan

- [ ] No runtime behavior change; docs-only edit. Visually inspect the rendered page on docs preview to confirm the new "Query-time tuning" table, the `USING hnsw` backwards-compatibility callout, and the corrected example in Limitations all render correctly.
