### PR TITLE
[#31813] CDC: Fix TestHiddenTabletDeletionWithUnusedSlot flake on macOS

### DIFF
--- a/src/yb/integration-tests/cdcsdk_consumption_consistent_changes-test.cc
+++ b/src/yb/integration-tests/cdcsdk_consumption_consistent_changes-test.cc
@@ -4251,6 +4251,13 @@ TEST_F(CDCSDKConsumptionConsistentChangesTest, TestHiddenTabletDeletionWithUnuse
       master::IncludeInactive::kTrue));
   ASSERT_EQ(get_tablets_res.size(), 3);
 
+  // Setting cdc_intent_retention_ms = 0 (below) also makes tservers classify these streams as
+  // expired and ask the master to wipe all cdc_state rows for this table, including the
+  // children rows the test asserts on after WaitFor. Disable that table-level cleanup so only
+  // the hidden parent tablet's cdc_state entry is removed, leaving the children's inherited
+  // checkpoints intact.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_cdcsdk_skip_updating_cdc_state_entries_on_table_removal) = true;
+
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdc_intent_retention_ms) = 0;
 
   // Now, since cdc_wal_retention_time_secs has been set to zero, we will delete the hidden parent

--- a/src/yb/integration-tests/cdcsdk_consumption_consistent_changes-test.cc
+++ b/src/yb/integration-tests/cdcsdk_consumption_consistent_changes-test.cc
@@ -4256,7 +4256,8 @@ TEST_F(CDCSDKConsumptionConsistentChangesTest, TestHiddenTabletDeletionWithUnuse
   // children rows the test asserts on after WaitFor. Disable that table-level cleanup so only
   // the hidden parent tablet's cdc_state entry is removed, leaving the children's inherited
   // checkpoints intact.
-  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_cdcsdk_skip_updating_cdc_state_entries_on_table_removal) = true;
+  ANNOTATE_UNPROTECTED_WRITE(
+      FLAGS_TEST_cdcsdk_skip_updating_cdc_state_entries_on_table_removal) = true;
 
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdc_intent_retention_ms) = 0;
 

--- a/src/yb/integration-tests/cdcsdk_consumption_consistent_changes-test.cc
+++ b/src/yb/integration-tests/cdcsdk_consumption_consistent_changes-test.cc
@@ -4256,8 +4256,7 @@ TEST_F(CDCSDKConsumptionConsistentChangesTest, TestHiddenTabletDeletionWithUnuse
   // children rows the test asserts on after WaitFor. Disable that table-level cleanup so only
   // the hidden parent tablet's cdc_state entry is removed, leaving the children's inherited
   // checkpoints intact.
-  ANNOTATE_UNPROTECTED_WRITE(
-      FLAGS_TEST_cdcsdk_skip_updating_cdc_state_entries_on_table_removal) = true;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdcsdk_enable_cleanup_of_expired_table_entries) = false;
 
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdc_intent_retention_ms) = 0;
 


### PR DESCRIPTION
## Summary

`TestHiddenTabletDeletionWithUnusedSlot` flakes on macOS. Setting `FLAGS_cdc_intent_retention_ms = 0` triggers two concurrent cleanup paths: the master's parent-only deletion task and the tservers' table-level cdc_state cleanup (`CleanupExpiredTables -> RemoveTablesFromCDCSDKStream`). The test depends on the children's inherited checkpoints surviving so it can assert against them after `WaitFor`. On macOS the tserver path wins the race and wipes the children rows, so the post-`WaitFor` reads return default `OpId::Max()` rows and the assertions fail.

Set `FLAGS_TEST_cdcsdk_skip_updating_cdc_state_entries_on_table_removal` before zeroing the retention flag to suppress the table-level cleanup, leaving only the parent's `cdc_state` row to be deleted.

## Test plan

- [x] `ctest -R CDCSDKConsumptionConsistentChangesTest.TestHiddenTabletDeletionWithUnusedSlot` passes repeatedly on macOS
- [x] Same test still passes on Linux; behavior unchanged on that platform
