### PR TITLE
[#31046] DocDB: Fix CheckTserverTabletHealth FATAL when consensus is unavailable

### DIFF
--- a/src/yb/tablet/tablet_peer.cc
+++ b/src/yb/tablet/tablet_peer.cc
@@ -103,6 +103,11 @@ using std::vector;
 DEFINE_test_flag(int32, delay_init_tablet_peer_ms, 0,
                  "Wait before executing init tablet peer for specified amount of milliseconds.");
 
+DEFINE_test_flag(bool, tablet_peer_force_get_raft_consensus_failure, false,
+                 "If set, TabletPeer::GetRaftConsensus returns IllegalState immediately. "
+                 "Used to deterministically exercise error paths in callers that handle "
+                 "transient consensus unavailability.");
+
 DEFINE_UNKNOWN_int32(cdc_min_replicated_index_considered_stale_secs, 1800,
     "If cdc_min_replicated_index hasn't been replicated in this amount of time, we reset its"
     "value to max int64 to avoid retaining any logs");
@@ -1546,6 +1551,11 @@ Result<std::shared_ptr<consensus::Consensus>> TabletPeer::GetConsensus() const {
 
 Result<shared_ptr<consensus::RaftConsensus>> TabletPeer::GetRaftConsensus() const {
   std::lock_guard lock(lock_);
+  if (PREDICT_FALSE(FLAGS_TEST_tablet_peer_force_get_raft_consensus_failure)) {
+    return STATUS_FORMAT(
+        IllegalState, "$0FLAGS_TEST_tablet_peer_force_get_raft_consensus_failure is set",
+        LogPrefix());
+  }
   // Cannot use NotFound status for the shutting down case as later the status may be extended with
   // TabletServerErrorPB::TABLET_NOT_RUNNING error code, and this combination of the status and
   // the code is not expected and is not considered as a retryable operation at least by yb-client.

--- a/src/yb/tserver/tablet_server-test.cc
+++ b/src/yb/tserver/tablet_server-test.cc
@@ -67,7 +67,6 @@
 #include "yb/util/curl_util.h"
 #include "yb/util/metrics.h"
 #include "yb/util/monotime.h"
-#include "yb/util/scope_exit.h"
 #include "yb/util/size_literals.h"
 #include "yb/util/status_log.h"
 
@@ -730,10 +729,8 @@ TEST_F(TabletServerTest, TestDeleteTablet_TabletNotCreated) {
 // the peer as RUNNING, but GetRaftConsensus returns IllegalState.
 // The RPC must complete without crashing the process.
 TEST_F(TabletServerTest, CheckTserverTabletHealthDoesNotCrashWhenConsensusUnavailable) {
+  // YBTest::flag_saver_ restores all gflags on fixture teardown, so no manual reset needed.
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_tablet_peer_force_get_raft_consensus_failure) = true;
-  auto reset = ScopeExit([] {
-    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_tablet_peer_force_get_raft_consensus_failure) = false;
-  });
 
   CheckTserverTabletHealthRequestPB req;
   req.add_tablet_ids(kTabletId);

--- a/src/yb/tserver/tablet_server-test.cc
+++ b/src/yb/tserver/tablet_server-test.cc
@@ -67,6 +67,7 @@
 #include "yb/util/curl_util.h"
 #include "yb/util/metrics.h"
 #include "yb/util/monotime.h"
+#include "yb/util/scope_exit.h"
 #include "yb/util/size_literals.h"
 #include "yb/util/status_log.h"
 
@@ -89,6 +90,7 @@ DECLARE_string(block_manager);
 DECLARE_string(rpc_bind_addresses);
 DECLARE_bool(disable_clock_sync_error);
 DECLARE_string(metric_node_name);
+DECLARE_bool(TEST_tablet_peer_force_get_raft_consensus_failure);
 
 // Declare these metrics prototypes for simpler unit testing of their behavior.
 METRIC_DECLARE_counter(rows_inserted);
@@ -717,22 +719,28 @@ TEST_F(TabletServerTest, TestDeleteTablet_TabletNotCreated) {
   ASSERT_TRUE(s.IsNotFound()) << s.ToString();
 }
 
-// Regression test for #31046. The 3-arg GetConsensusOrRespond helper used to
-// fall through and call Result::get() on a non-OK Result when GetRaftConsensus
-// failed, FATALing the tserver with "Check failed: value" at status.cc:657
-// inside CheckTserverTabletHealth. Starting tablet-peer shutdown is enough to
-// make GetRaftConsensus return IllegalState; the RPC must now respond with an
-// error instead of crashing the process.
+// Regression test for #31046. CheckTserverTabletHealth used to call
+// GetConsensusOrRespond inside its per-tablet loop, which (a) FATALed via
+// Result::get() on a non-OK Result before the 3-arg overload was fixed,
+// and (b) consumed the RpcContext on the first failing tablet, leading
+// the trailing context.RespondSuccess() to double-respond.
+// Production hits this when the RUNNING-state check in LookupTabletPeer
+// races with consensus transitioning to non-OK. We use a TEST flag to
+// force that condition deterministically: LookupTabletPeer still sees
+// the peer as RUNNING, but GetRaftConsensus returns IllegalState.
+// The RPC must complete without crashing the process.
 TEST_F(TabletServerTest, CheckTserverTabletHealthDoesNotCrashWhenConsensusUnavailable) {
-  ASSERT_TRUE(tablet_peer_->StartShutdown());
-  ASSERT_TRUE(tablet_peer_->IsShutdownStarted());
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_tablet_peer_force_get_raft_consensus_failure) = true;
+  auto reset = ScopeExit([] {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_tablet_peer_force_get_raft_consensus_failure) = false;
+  });
 
   CheckTserverTabletHealthRequestPB req;
   req.add_tablet_ids(kTabletId);
   CheckTserverTabletHealthResponsePB resp;
   RpcController controller;
   ASSERT_OK(proxy_->CheckTserverTabletHealth(req, &resp, &controller));
-  ASSERT_TRUE(resp.has_error());
+  EXPECT_FALSE(resp.has_error());
   EXPECT_EQ(0, resp.tablet_healths_size());
 }
 

--- a/src/yb/tserver/tablet_server-test.cc
+++ b/src/yb/tserver/tablet_server-test.cc
@@ -717,6 +717,25 @@ TEST_F(TabletServerTest, TestDeleteTablet_TabletNotCreated) {
   ASSERT_TRUE(s.IsNotFound()) << s.ToString();
 }
 
+// Regression test for #31046. The 3-arg GetConsensusOrRespond helper used to
+// fall through and call Result::get() on a non-OK Result when GetRaftConsensus
+// failed, FATALing the tserver with "Check failed: value" at status.cc:657
+// inside CheckTserverTabletHealth. Starting tablet-peer shutdown is enough to
+// make GetRaftConsensus return IllegalState; the RPC must now respond with an
+// error instead of crashing the process.
+TEST_F(TabletServerTest, CheckTserverTabletHealthDoesNotCrashWhenConsensusUnavailable) {
+  ASSERT_TRUE(tablet_peer_->StartShutdown());
+  ASSERT_TRUE(tablet_peer_->IsShutdownStarted());
+
+  CheckTserverTabletHealthRequestPB req;
+  req.add_tablet_ids(kTabletId);
+  CheckTserverTabletHealthResponsePB resp;
+  RpcController controller;
+  ASSERT_OK(proxy_->CheckTserverTabletHealth(req, &resp, &controller));
+  ASSERT_TRUE(resp.has_error());
+  EXPECT_EQ(0, resp.tablet_healths_size());
+}
+
 // Test that with concurrent requests to delete the same tablet, one wins and
 // the other fails, with no assertion failures. Regression test for KUDU-345.
 TEST_F(TabletServerTest, TestConcurrentDeleteTablet) {

--- a/src/yb/tserver/tablet_service.cc
+++ b/src/yb/tserver/tablet_service.cc
@@ -396,6 +396,7 @@ std::shared_ptr<consensus::RaftConsensus> GetConsensusOrRespond(const TabletPeer
   auto result = GetConsensus(tablet_peer);
   if (!result.ok()) {
     SetupErrorAndRespond(resp->mutable_error(), result.status(), context);
+    return nullptr;
   }
   return result.get();
 }

--- a/src/yb/tserver/tablet_service.cc
+++ b/src/yb/tserver/tablet_service.cc
@@ -3494,9 +3494,6 @@ void TabletServiceImpl::CheckTserverTabletHealth(const CheckTserverTabletHealthR
       continue;
     }
 
-    // Skip per-tablet without consuming the RPC context. Using GetConsensusOrRespond here
-    // would respond on the first failure and then the trailing context.RespondSuccess()
-    // would double-respond.
     auto consensus_result = GetConsensus(res->tablet_peer);
     if (!consensus_result.ok()) {
       LOG_WITH_FUNC(INFO) << "Could not find consensus for tablet " << tablet_id

--- a/src/yb/tserver/tablet_service.cc
+++ b/src/yb/tserver/tablet_service.cc
@@ -3494,11 +3494,16 @@ void TabletServiceImpl::CheckTserverTabletHealth(const CheckTserverTabletHealthR
       continue;
     }
 
-    auto consensus = GetConsensusOrRespond(res->tablet_peer, resp, &context);
-    if (!consensus) {
-      LOG_WITH_FUNC(INFO) << "Could not find consensus for tablet " << tablet_id;
+    // Skip per-tablet without consuming the RPC context. Using GetConsensusOrRespond here
+    // would respond on the first failure and then the trailing context.RespondSuccess()
+    // would double-respond.
+    auto consensus_result = GetConsensus(res->tablet_peer);
+    if (!consensus_result.ok()) {
+      LOG_WITH_FUNC(INFO) << "Could not find consensus for tablet " << tablet_id
+                          << ": " << consensus_result.status();
       continue;
     }
+    auto consensus = *consensus_result;
 
     auto* tablet_health = resp->add_tablet_healths();
     tablet_health->set_tablet_id(tablet_id);


### PR DESCRIPTION
## Summary

Fixes #31046.

`TabletServiceImpl::CheckTserverTabletHealth` had two related defects on the path where consensus is unavailable for a tablet:

1. **`GetConsensusOrRespond` 3-arg overload FATALed.** The helper called `SetupErrorAndRespond` on a non-OK `Result` and then fell through to `return result.get();` — `Result::get()` on a non-OK Result invokes `StatusCheck(false)` (the `CHECK(value)` at `src/yb/util/status.cc`), crashing the tserver with `F status.cc Check failed: value` inside `TabletServiceImpl::CheckTserverTabletHealth`.
2. **Double-respond from the loop.** Even after the helper bailed out cleanly, `CheckTserverTabletHealth`'s per-tablet loop did `if (!consensus) continue;`. `GetConsensusOrRespond` already consumed the `RpcContext` via `SetupErrorAndRespond`, so the trailing `context.RespondSuccess()` fired a `CHECK` in `InboundCall::RecordHandlingCompleted`.

Production hits this on a race between the `RUNNING`-state check in `LookupTabletPeer` and the consensus lookup — typically when YBA's `CheckTserverTabletHealth` probe lands on a peer mid-restart during a rolling gflag update.

**Fix:**

- Add early `return nullptr;` to the 3-arg `GetConsensusOrRespond` after `SetupErrorAndRespond`, matching the 4-arg overload's early-return pattern. This makes the helper safe for any future caller.
- Inside `CheckTserverTabletHealth`, call `GetConsensus` directly (returns `Result`, no `RpcContext` side-effect) so the per-tablet skip leaves the context intact for the trailing `RespondSuccess()`.

## Test plan

Deterministic regression test added: `tablet_server-test.cc :: TabletServerTest.CheckTserverTabletHealthDoesNotCrashWhenConsensusUnavailable`.

To deterministically reproduce the race in a unit test, a new TEST flag `FLAGS_TEST_tablet_peer_force_get_raft_consensus_failure` is added to `TabletPeer::GetRaftConsensus`. When set, it returns `IllegalState` immediately, so `LookupTabletPeer` still sees the peer as `RUNNING` but the consensus lookup fails — the exact production race condition.

Verified locally on macOS arm64 debug:
- [x] **Without the production fix** in `tablet_service.cc` → tserver FATALs (`status.cc Check failed: value`) in `TabletServiceImpl::CheckTserverTabletHealth`; child process killed by signal 6; ctest reports `1 FAILED TEST`.
- [x] **With the fix** → `[  PASSED  ] 1 test.` (~230 ms).
