### PR TITLE
[BACKPORT 2025.2][#31705] DocDB: Fix VectorLSMTest.EstimateNumVectorsForBytes/kHnswlib flake under TSAN

### DIFF
--- a/src/yb/ann_methods/vector_lsm-test.cc
+++ b/src/yb/ann_methods/vector_lsm-test.cc
@@ -370,13 +370,13 @@ Status VectorLSMTest::InsertRandomAndFlush(
 
 Status VectorLSMTest::WaitForBackgroundInsertsDone(const FloatVectorLSM& lsm, MonoDelta timeout) {
   return LoggedWaitFor(
-      [&lsm] { return !lsm.TEST_HasBackgroundInserts(); }, timeout,
+      [&lsm] { return !lsm.TEST_HasBackgroundInserts(); }, timeout * kTimeMultiplier,
       "Background inserts done", MonoDelta::FromMilliseconds(100), /* delay_multiplier = */ 1.0);
 }
 
 Status VectorLSMTest::WaitForCompactionsDone(const FloatVectorLSM& lsm, MonoDelta timeout) {
   return LoggedWaitFor(
-      [&lsm] { return !lsm.TEST_HasCompactions(); }, timeout,
+      [&lsm] { return !lsm.TEST_HasCompactions(); }, timeout * kTimeMultiplier,
       "Compactions done", MonoDelta::FromMilliseconds(100), /* delay_multiplier = */ 1.0);
 }
 


### PR DESCRIPTION
DO NOT MERGE!! [CSI](<https://csiweb.dev.yugabyte.com/pull/31832/>) ⏳

Summary:
`VectorLSMTest.EstimateNumVectorsForBytes/kHnswlib` calls `WaitForBackgroundInsertsDone(lsm)` with no timeout argument, which falls back to the helper's 20-second default. The test inserts as many vectors as fit inside a ~32 MiB budget — ~10K HNSW vectors — and the background insert pipeline takes longer than 20s to drain under TSAN's ~5× slowdown. CSI logs for the failing runs show the test failing with `LoggedWaitFor("Background inserts done") timed out` at the call site on line 1076.

Every other heavy wait in this test already scales by `kTimeMultiplier` (e.g. `merge_timeout = 5s * kTimeMultiplier` on line 922, the `1000 * kTimeMultiplier` budget on line 1035, etc.). The call on line 1076 was missed.

This diff (per @sergei's review):

- bumps the nominal base timeout at the call site from `20s` to `120s` (the background-insert work takes ~60s under TSAN on a developer laptop, so 20s is well below the noise floor),
- and moves the `* kTimeMultiplier` scaling **inside** the `WaitForBackgroundInsertsDone` and `WaitForCompactionsDone` helpers themselves rather than the call site.

The internal-scaling shape (a) keeps every caller TSAN-agnostic — they pass a nominal wall-clock budget and the helper takes care of the sanitizer scale-up, and (b) matches the convention used elsewhere in the codebase (e.g. `load_balancer_mini_cluster-test.cc`, `external_mini_cluster.cc`, `pg_wait_on_conflict-test.cc`). It also implicitly covers the existing default-timeout callers (line 928, 1097, 1100) for free, with no change in behavior on non-sanitizer builds.

No production-code change. The fix is a test-only wait-budget scaling.

Reference: https://github.com/yugabyte/yugabyte-db/issues/31705

Original commit: 39e11f310e10b3e9d3e2e2f5b8f80679fa533da7 / D53378

Test Plan:
Local TSAN verification on a developer laptop (`tsan-clang21-dynamic-ninja`), filter `VectorLSMTest.EstimateNumVectorsForBytes/kHnswlib`:

| Variant | Iters | Result | Per-iter | Failure |
|---|---|---|---|---|
| origin/master (no fix, default 20s timeout) | 20 | **20 / 20 FAILED** | ~67s | `Bad status: Timed out (...): Operation 'Background inserts done' didn't complete within 20000ms` at `vector_lsm-test.cc:1076` |
| first attempt — `20s * kTimeMultiplier` (= 60s under TSAN) | 20 | **20 / 20 FAILED** | ~67s | same line, `... didn't complete within 60000ms`. The background-insert work itself takes ~60s under TSAN on this host, so a 60s timeout was right at the edge |
| original fix — `120s * kTimeMultiplier` at call site (= 360s under TSAN) | 20 | **20 / 20 PASSED** | 65–67s | — |
| **this diff ** — `120s` at call site, `* kTimeMultiplier` inside helper (= 360s under TSAN) | 10 | **10 / 10 PASSED** | ~67s | — (re-verification of the refactor; identical effective behavior to the original fix) |

Failure-mode reproduction matched the CSI logs in #31705 exactly. The 360s effective budget gives ~5× headroom over the observed ~67s of real work without affecting healthy runs (the timeout is only consumed on a failure path). Other callers of `WaitForBackgroundInsertsDone` / `WaitForCompactionsDone` that previously relied on the 20s default now effectively get 60s under TSAN — strictly safer; no test ever fails by waiting longer for an `ASSERT_OK`.

Reviewers: sergei

Reviewed By: sergei

Subscribers: ybase

Differential Revision: https://phorge.dev.yugabyte.com/D53378