### PR TITLE
[#31840] CDC: Stabilize TestOldColocatedTableDeletedAfterExpiry

### DIFF
--- a/src/yb/integration-tests/cdcsdk_consumption_consistent_changes-test.cc
+++ b/src/yb/integration-tests/cdcsdk_consumption_consistent_changes-test.cc
@@ -6225,6 +6225,12 @@ TEST_F(CDCSDKConsumptionConsistentChangesTest, TestOldColocatedTableDeletedAfter
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_ysql_yb_enable_implicit_dynamic_tables_logical_replication) =
       true;
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdc_intent_retention_ms) = 0;
+  // With cdc_intent_retention_ms = 0 the tserver classifies every colocated table on the tablet
+  // (including pg_class and pg_publication_rel) as expired and asks the master to drop them from
+  // the stream's qualified list. The hidden OLD table is still removed via the dropped-table
+  // cleanup path after CleanupHiddenTablets fully deletes it, so disabling expired-table cleanup
+  // keeps the catalog tables in place without affecting the assertion below.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdcsdk_enable_cleanup_of_expired_table_entries) = false;
   // These will increase the frequency of bg task which cleans up hidden tables.
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_snapshot_coordinator_poll_interval_ms) = 1;
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdc_parent_tablet_deletion_task_retry_secs) = 1;


### PR DESCRIPTION
## Summary

Disable expired-table cleanup in `TestOldColocatedTableDeletedAfterExpiry` to keep the catalog tables (`pg_class`, `pg_publication_rel`) in the stream's qualified list while the OLD hidden table is being cleaned up.

### Motivation

The test sets `cdc_intent_retention_ms = 0` so the OLD hidden table becomes eligible for cleanup immediately after `TRUNCATE`. With that retention, however, `CheckStreamActive` in `PopulateTabletCheckPointInfo` fails for every tablet on every `UpdatePeersAndMetrics` tick — its active-time check trivially fails against 0ms. Failing tablets are passed to `AddTableToExpiredTablesMap`, which for a colocated tablet walks `GetAllColocatedTables()` and marks the user table together with `pg_class` and `pg_publication_rel` as expired. `CleanupExpiredTables` then issues `RemoveTablesFromCDCSDKStream` RPCs, and the master's bg task strips all three tables from the stream's qualified list.

If the tserver tick lands between stream creation and the helper's first poll — which happens reliably on macOS — the catalog tables are gone before the helper runs, and `VerifyTablesInStreamMetadata(..., include_catalog_tables=true)` times out after 60s waiting for `pg_class` / `pg_publication_rel` to reappear.

### Changes

`src/yb/integration-tests/cdcsdk_consumption_consistent_changes-test.cc`

Set `FLAGS_cdcsdk_enable_cleanup_of_expired_table_entries = false` in `TestOldColocatedTableDeletedAfterExpiry`. This gates both `CleanupExpiredTables` callsites in `cdc_service.cc:UpdatePeersAndMetrics` and `cdc_service.cc:CDCMasterBgTask`, so the catalog tables are never queued for removal.

The OLD `test_table` is still removed from the qualified list via the dropped-table cleanup path (independent of the disabled flag): `DoProcessCDCSDKColocatedTableDeletion` marks the hidden table free for deletion → `CleanupHiddenTablets` fully drops it → `CleanupCDCSDKDroppedTablesFromStreamInfo` removes it from the stream's qualified list.

`TestReleaseResourcesOnUnpolledTablets` in `cdcsdk_consistent_snapshot-test.cc` uses the same flag for the same reason — aggressive retention combined with assertions that require state-table / metadata preservation.

## Test plan

- [x] 100 iterations of `TestOldColocatedTableDeletedAfterExpiry` pass on macOS arm64 (release/clang21)
- [x] Test passes on Linux
