### PR TITLE
[#31845] YSQL: Avoid excessive read restarts in InconsistentIndexRead test

### DIFF
--- a/src/yb/yql/pgwrapper/pg_libpq-test.cc
+++ b/src/yb/yql/pgwrapper/pg_libpq-test.cc
@@ -5455,7 +5455,7 @@ TEST_F(PgLibPqTest, InconsistentIndexRead) {
   // Assert that the balance is always 10k.
   thread_holder.AddThreadFunctor([this, &stop = thread_holder.stop_flag(), initial_sum]() {
     auto reader_conn = ASSERT_RESULT(Connect());
-    ASSERT_OK(reader_conn.Execute("SET yb_max_query_layer_retries=120"));
+    ASSERT_OK(reader_conn.Execute("SET yb_parallel_range_rows = 0"));
     while (!stop.load(std::memory_order_acquire)) {
       auto sum_balance = ASSERT_RESULT(reader_conn.FetchRow<int64_t>(
           "/*+ IndexScan(bank) */ SELECT SUM(balance) FROM bank WHERE id >= 0"));

--- a/src/yb/yql/pgwrapper/pg_libpq-test.cc
+++ b/src/yb/yql/pgwrapper/pg_libpq-test.cc
@@ -5455,6 +5455,7 @@ TEST_F(PgLibPqTest, InconsistentIndexRead) {
   // Assert that the balance is always 10k.
   thread_holder.AddThreadFunctor([this, &stop = thread_holder.stop_flag(), initial_sum]() {
     auto reader_conn = ASSERT_RESULT(Connect());
+    ASSERT_OK(reader_conn.Execute("SET yb_max_query_layer_retries=120"));
     while (!stop.load(std::memory_order_acquire)) {
       auto sum_balance = ASSERT_RESULT(reader_conn.FetchRow<int64_t>(
           "/*+ IndexScan(bank) */ SELECT SUM(balance) FROM bank WHERE id >= 0"));


### PR DESCRIPTION
## Summary

PgLibPqTest.InconsistentIndexRead is flaky on macOS, failing with:

```
Restart read required (yb_max_query_layer_retries set to 60 are exhausted)
```

The test runs reliably on Linux.

The reader runs /*+ IndexScan(bank) */ SELECT SUM(balance) FROM bank WHERE id >= 0
in autocommit (READ COMMITTED) while a writer commits DELETE+INSERT transactions in
a tight loop. Parallel query is enabled on master, and with the scan being large, a parallel scan is planned.

Parallel scans do not perform efficient read restarts. For a usual scan, a read
restart advances the read point to the accumulated restart_read_ht while
preserving global_limit, which monotonically
shrinks the uncertainty window so restarts converge quickly. For a
parallel scan the global_limit and per-tablet local_limits are not preserved
across the parallel execution and the subsequent query-layer retry, so each retry
re-reads with a full-width uncertainty window. Under steady writer load the retries
do not accumulate progress and blow up, occasionally exhausting
yb_max_query_layer_retries on macOS.

Force the reader onto the non-parallel path with SET yb_parallel_range_rows = 0 so the
test exercises efficient read restarts and stays well under the default retry
budget. The underlying parallel-scan read-restart inefficiency is tracked by https://github.com/yugabyte/yugabyte-db/issues/32009.

## Test plan

- [x] `PgLibPqTest.InconsistentIndexRead` passes repeatedly on macOS (previously flaky)
- [x] `PgLibPqTest.InconsistentIndexRead` still passes on Linux
