### PR TITLE
Improve backend startup logging

### DIFF
--- a/src/postgres/src/backend/access/transam/parallel.c
+++ b/src/postgres/src/backend/access/transam/parallel.c
@@ -135,6 +135,12 @@ static dlist_head pcxt_list = DLIST_STATIC_INIT(pcxt_list);
 /* Backend-local copy of data from FixedParallelState. */
 static pid_t ParallelLeaderPid;
 
+pid_t
+GetParallelLeaderPid(void)
+{
+	return ParallelLeaderPid;
+}
+
 /*
  * List of internal parallel worker entry points.  We need this for
  * reasons explained in LookupParallelWorkerFunction(), below.

--- a/src/postgres/src/backend/postmaster/postmaster.c
+++ b/src/postgres/src/backend/postmaster/postmaster.c
@@ -93,6 +93,7 @@
 #include <pthread.h>
 #endif
 
+#include "access/parallel.h"
 #include "access/transam.h"
 #include "access/xlog.h"
 #include "access/xlogrecovery.h"
@@ -5036,12 +5037,33 @@ BackendInitialize(Port *port)
 		else
 			snprintf(remote_ps_data, sizeof(remote_ps_data), "%s(%s)", remote_host, remote_port);
 
-		YBC_LOG_INFO("Started %s backend with pid: %d, user_name: %s, "
-					 "remote_ps_data: %s",
-					 (am_walsender ?
-					  "walsender" :
-					  (yb_is_auth_backend ? "auth" : "regular")),
-					 getpid(), port->user_name, remote_ps_data);
+		StringInfoData logmsg;
+		const char *database_name =
+			(port->database_name && port->database_name[0] != '\0') ? port->database_name : "<unset>";
+		const char *application_name =
+			(port->application_name && port->application_name[0] != '\0') ? port->application_name : "<unset>";
+
+		initStringInfo(&logmsg);
+		appendStringInfo(&logmsg,
+						 "Started %s backend with pid: %d, user_name: %s, database_name: %s",
+						 (am_walsender ?
+						  "walsender" :
+						  (yb_is_auth_backend ? "auth" : "regular")),
+						 getpid(), port->user_name, database_name);
+		appendStringInfo(&logmsg, ", application_name: %s", application_name);
+		appendStringInfo(&logmsg, ", backend_type: %s", GetBackendTypeDesc(MyBackendType));
+		appendStringInfo(&logmsg, ", remote_ps_data: %s", remote_ps_data);
+		if (IsParallelWorker())
+		{
+			pid_t		leader_pid = GetParallelLeaderPid();
+
+			if (leader_pid > 0)
+				appendStringInfo(&logmsg, ", parallel_leader_pid: %d", leader_pid);
+			else
+				appendStringInfoString(&logmsg, ", parallel_leader_pid: <unknown>");
+		}
+		YBC_LOG_INFO("%s", logmsg.data);
+		pfree(logmsg.data);
 	}
 }
 

--- a/src/postgres/src/include/access/parallel.h
+++ b/src/postgres/src/include/access/parallel.h
@@ -60,6 +60,8 @@ extern PGDLLIMPORT bool InitializingParallelWorker;
 
 #define		IsParallelWorker()		(ParallelWorkerNumber >= 0)
 
+extern pid_t GetParallelLeaderPid(void);
+
 extern ParallelContext *CreateParallelContext(const char *library_name,
 											  const char *function_name, int nworkers);
 extern void InitializeParallelDSM(ParallelContext *pcxt);

--- a/src/yb/yql/pggate/pggate.cc
+++ b/src/yb/yql/pggate/pggate.cc
@@ -523,7 +523,6 @@ PgClient::ProxyInitInfo MakeProxyInitInfo(
                           tserver_shared_data.endpoint().port());
     result.resolve_cache_timeout = MonoDelta::kMax;
   }
-  LOG(INFO) << "Using TServer host_port: " << result.host_port;
   return result;
 }
 


### PR DESCRIPTION
## Summary
- remove redundant pggate log line for TServer host_port
- enrich backend startup log with database, application, backend type, and parallel leader pid when applicable

## Testing
- ./yb_build.sh release --cxx-test pggate_test

Fixes #31833