### PR TITLE
[#28866] DocDB: Add pgschema_name label to PGSQL table and tablet metrics

### DIFF
--- a/cloud/grafana/YugabyteDB.json
+++ b/cloud/grafana/YugabyteDB.json
@@ -1881,39 +1881,39 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(log_sync_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(log_sync_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
           "interval": "",
           "legendFormat": "Total Avg - Sync",
           "refId": "D"
         },
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(log_group_commit_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(log_group_commit_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
           "interval": "",
           "legendFormat": "Total Avg - Commit",
           "refId": "E"
         },
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(log_append_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(log_append_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
           "interval": "",
           "legendFormat": "Total Avg  - Append",
           "refId": "F"
         },
         {
-          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (rate(log_sync_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name, pgschema_name) (rate(log_sync_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
           "hide": false,
           "interval": "",
           "legendFormat": "{{exported_instance}} - Sync",
           "refId": "A"
         },
         {
-          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (rate(log_group_commit_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name, pgschema_name) (rate(log_group_commit_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
           "hide": false,
           "interval": "",
           "legendFormat": "{{exported_instance}} - Commit",
           "refId": "B"
         },
         {
-          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (rate(log_append_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name, pgschema_name) (rate(log_append_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
           "hide": false,
           "interval": "",
           "legendFormat": "{{exported_instance}} - Append",
@@ -2120,28 +2120,28 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (log_reader_bytes_read{node_prefix=\"$dbcluster\",export_type=\"master_export\"})) / 1024",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (log_reader_bytes_read{node_prefix=\"$dbcluster\",export_type=\"master_export\"})) / 1024",
           "hide": false,
           "interval": "",
           "legendFormat": "Total Avg - Log Bytes Read",
           "refId": "D"
         },
         {
-          "expr": "avg(sum without (table_id, table_name) (log_cache_size{node_prefix=\"$dbcluster\",export_type=\"master_export\"})) / 1024",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (log_cache_size{node_prefix=\"$dbcluster\",export_type=\"master_export\"})) / 1024",
           "hide": false,
           "interval": "",
           "legendFormat": "Total Avg - Log Cache Size",
           "refId": "E"
         },
         {
-          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (log_reader_bytes_read{node_prefix=\"$dbcluster\",export_type=\"master_export\"})) / 1024",
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name, pgschema_name) (log_reader_bytes_read{node_prefix=\"$dbcluster\",export_type=\"master_export\"})) / 1024",
           "hide": false,
           "interval": "",
           "legendFormat": "{{exported_instance}} - Log Bytes Read",
           "refId": "A"
         },
         {
-          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (log_cache_size{node_prefix=\"$dbcluster\",export_type=\"master_export\"})) / 1024",
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name, pgschema_name) (log_cache_size{node_prefix=\"$dbcluster\",export_type=\"master_export\"})) / 1024",
           "hide": false,
           "interval": "",
           "legendFormat": "{{exported_instance}} - Log Cache Size",
@@ -2238,14 +2238,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(log_bytes_logged{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(log_bytes_logged{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Total Avg - Log Bytes Logged",
           "refId": "B"
         },
         {
-          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (rate(log_bytes_logged{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name, pgschema_name) (rate(log_bytes_logged{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
           "hide": false,
           "interval": "",
           "legendFormat": "{{exported_instance}} - Log Bytes Logged",
@@ -2451,13 +2451,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(log_reader_bytes_read{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(log_reader_bytes_read{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
           "interval": "",
           "legendFormat": "Total Avg - Log Bytes Read",
           "refId": "B"
         },
         {
-          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (rate(log_reader_bytes_read{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name, pgschema_name) (rate(log_reader_bytes_read{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
           "hide": false,
           "interval": "",
           "legendFormat": "{{exported_instance}} - Log Bytes Read",
@@ -2651,14 +2651,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (log_cache_num_ops{node_prefix=\"$dbcluster\",export_type=\"master_export\"}))",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (log_cache_num_ops{node_prefix=\"$dbcluster\",export_type=\"master_export\"}))",
           "hide": false,
           "interval": "",
           "legendFormat": "Total Avg - Num Ops",
           "refId": "D"
         },
         {
-          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (log_cache_num_ops{node_prefix=\"$dbcluster\",export_type=\"master_export\"})) / 1024",
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name, pgschema_name) (log_cache_num_ops{node_prefix=\"$dbcluster\",export_type=\"master_export\"})) / 1024",
           "hide": false,
           "interval": "",
           "legendFormat": "{{exported_instance}} - Num Ops",
@@ -6751,13 +6751,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(log_bytes_logged{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(log_bytes_logged{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
           "interval": "",
           "legendFormat": "Total Avg - Log Bytes Logged",
           "refId": "B"
         },
         {
-          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (rate(log_bytes_logged{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name, pgschema_name) (rate(log_bytes_logged{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
           "hide": false,
           "interval": "",
           "legendFormat": "{{exported_instance}} - Log Bytes Logged",
@@ -6854,13 +6854,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(log_reader_bytes_read{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(log_reader_bytes_read{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
           "interval": "",
           "legendFormat": "Total Avg - Log Bytes Read",
           "refId": "B"
         },
         {
-          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (rate(log_reader_bytes_read{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name, pgschema_name) (rate(log_reader_bytes_read{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
           "hide": false,
           "interval": "",
           "legendFormat": "{{exported_instance}} - Log Bytes Read",
@@ -6958,39 +6958,39 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(log_sync_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(log_sync_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
           "interval": "",
           "legendFormat": "Total Avg - Sync",
           "refId": "D"
         },
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(log_group_commit_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(log_group_commit_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
           "interval": "",
           "legendFormat": "Total Avg - Commit",
           "refId": "E"
         },
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(log_append_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(log_append_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
           "interval": "",
           "legendFormat": "Total Avg  - Append",
           "refId": "F"
         },
         {
-          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (rate(log_sync_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name, pgschema_name) (rate(log_sync_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
           "hide": false,
           "interval": "",
           "legendFormat": "{{exported_instance}} - Sync",
           "refId": "A"
         },
         {
-          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (rate(log_group_commit_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name, pgschema_name) (rate(log_group_commit_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
           "hide": false,
           "interval": "",
           "legendFormat": "{{exported_instance}} - Commit",
           "refId": "B"
         },
         {
-          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (rate(log_append_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name, pgschema_name) (rate(log_append_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
           "hide": false,
           "interval": "",
           "legendFormat": "{{exported_instance}} - Append",
@@ -7191,28 +7191,28 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (log_reader_bytes_read{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"})) / 1024",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (log_reader_bytes_read{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"})) / 1024",
           "hide": false,
           "interval": "",
           "legendFormat": "Total Avg - Log Bytes Read",
           "refId": "D"
         },
         {
-          "expr": "avg(sum without (table_id, table_name) (log_cache_size{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"})) / 1024",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (log_cache_size{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"})) / 1024",
           "hide": false,
           "interval": "",
           "legendFormat": "Total Avg - Log Cache Size",
           "refId": "E"
         },
         {
-          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (log_reader_bytes_read{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"})) / 1024",
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name, pgschema_name) (log_reader_bytes_read{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"})) / 1024",
           "hide": false,
           "interval": "",
           "legendFormat": "{{exported_instance}} - Log Bytes Read",
           "refId": "A"
         },
         {
-          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (log_cache_size{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"})) / 1024",
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name, pgschema_name) (log_cache_size{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"})) / 1024",
           "hide": false,
           "interval": "",
           "legendFormat": "{{exported_instance}} - Log Cache Size",
@@ -7310,14 +7310,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (log_cache_num_ops{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}))",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (log_cache_num_ops{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}))",
           "hide": false,
           "interval": "",
           "legendFormat": "Total Avg - Num Ops",
           "refId": "D"
         },
         {
-          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (log_cache_num_ops{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"})) / 1024",
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name, pgschema_name) (log_cache_num_ops{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"})) / 1024",
           "hide": false,
           "interval": "",
           "legendFormat": "{{exported_instance}} - Num Ops",
@@ -7669,13 +7669,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_number_db_seek{node_prefix=\"$dbcluster\"}[5m])))",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(rocksdb_number_db_seek{node_prefix=\"$dbcluster\"}[5m])))",
           "interval": "",
           "legendFormat": "Seek",
           "refId": "A"
         },
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_number_db_next{node_prefix=\"$dbcluster\"}[5m])))",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(rocksdb_number_db_next{node_prefix=\"$dbcluster\"}[5m])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Next",
@@ -7772,7 +7772,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_number_db_seek{node_prefix=\"$dbcluster\"}[5m])))",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(rocksdb_number_db_seek{node_prefix=\"$dbcluster\"}[5m])))",
           "interval": "",
           "legendFormat": "Seek",
           "refId": "A"
@@ -7868,7 +7868,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (rocksdb_current_version_sst_files_size{node_prefix=\"$dbcluster\"})) / 1073741824",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rocksdb_current_version_sst_files_size{node_prefix=\"$dbcluster\"})) / 1073741824",
           "hide": false,
           "interval": "",
           "legendFormat": "Size of SSTables",
@@ -7966,7 +7966,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (rocksdb_current_version_num_sst_files{node_prefix=\"$dbcluster\"}))",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rocksdb_current_version_num_sst_files{node_prefix=\"$dbcluster\"}))",
           "hide": false,
           "interval": "",
           "legendFormat": "Average SSTables / Node",
@@ -8063,14 +8063,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_bloom_filter_checked{node_prefix=\"$dbcluster\"}[5m])))",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(rocksdb_bloom_filter_checked{node_prefix=\"$dbcluster\"}[5m])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Blooms checked",
           "refId": "A"
         },
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_bloom_filter_useful{node_prefix=\"$dbcluster\"}[5m]))) ",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(rocksdb_bloom_filter_useful{node_prefix=\"$dbcluster\"}[5m]))) ",
           "hide": false,
           "interval": "",
           "legendFormat": "Blooms useful",
@@ -8167,7 +8167,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_db_get_micros_sum{node_prefix=\"$dbcluster\"}[5m]))) / avg(sum without (table_id, table_name) (rate(rocksdb_db_get_micros_count{node_prefix=\"$dbcluster\"}[5m]))\r)",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(rocksdb_db_get_micros_sum{node_prefix=\"$dbcluster\"}[5m]))) / avg(sum without (table_id, table_name, pgschema_name) (rate(rocksdb_db_get_micros_count{node_prefix=\"$dbcluster\"}[5m]))\r)",
           "hide": false,
           "interval": "",
           "legendFormat": "Get",
@@ -8263,7 +8263,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_db_write_micros_sum{node_prefix=\"$dbcluster\"}[5m]))) / avg(sum without (table_id, table_name) (rate(rocksdb_db_write_micros_count{node_prefix=\"$dbcluster\"}[5m]))\r)",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(rocksdb_db_write_micros_sum{node_prefix=\"$dbcluster\"}[5m]))) / avg(sum without (table_id, table_name, pgschema_name) (rate(rocksdb_db_write_micros_count{node_prefix=\"$dbcluster\"}[5m]))\r)",
           "hide": false,
           "interval": "",
           "legendFormat": "Write",
@@ -8359,7 +8359,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_db_seek_micros_sum{node_prefix=\"$dbcluster\"}[5m]))) / avg(sum without (table_id, table_name) (rate(rocksdb_db_seek_micros_count{node_prefix=\"$dbcluster\"}[5m]))\r)",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(rocksdb_db_seek_micros_sum{node_prefix=\"$dbcluster\"}[5m]))) / avg(sum without (table_id, table_name, pgschema_name) (rate(rocksdb_db_seek_micros_count{node_prefix=\"$dbcluster\"}[5m]))\r)",
           "hide": false,
           "interval": "",
           "legendFormat": "Seek ",
@@ -8455,7 +8455,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_db_mutex_wait_micros{node_prefix=\"$dbcluster\"}[5m])))",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(rocksdb_db_mutex_wait_micros{node_prefix=\"$dbcluster\"}[5m])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Mutex",
@@ -8551,13 +8551,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_block_cache_hit{node_prefix=\"$dbcluster\"}[5m])))",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(rocksdb_block_cache_hit{node_prefix=\"$dbcluster\"}[5m])))",
           "interval": "",
           "legendFormat": "Hit",
           "refId": "A"
         },
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_block_cache_miss{node_prefix=\"$dbcluster\"}[5m])))",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(rocksdb_block_cache_miss{node_prefix=\"$dbcluster\"}[5m])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Miss",
@@ -8757,20 +8757,20 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_block_cache_add{node_prefix=\"$dbcluster\"}[5m])))",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(rocksdb_block_cache_add{node_prefix=\"$dbcluster\"}[5m])))",
           "interval": "",
           "legendFormat": "Add",
           "refId": "A"
         },
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_block_cache_single_touch_add{node_prefix=\"$dbcluster\"}[5m])))",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(rocksdb_block_cache_single_touch_add{node_prefix=\"$dbcluster\"}[5m])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Single Touch Add",
           "refId": "B"
         },
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_block_cache_multi_touch_add{node_prefix=\"$dbcluster\"}[5m])))",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(rocksdb_block_cache_multi_touch_add{node_prefix=\"$dbcluster\"}[5m])))",
           "interval": "",
           "legendFormat": "Multi Touch Add",
           "refId": "C"
@@ -8866,7 +8866,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_stall_micros{node_prefix=\"$dbcluster\"}[5m])))",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(rocksdb_stall_micros{node_prefix=\"$dbcluster\"}[5m])))",
           "interval": "",
           "legendFormat": "Stalls",
           "refId": "A"
@@ -8962,7 +8962,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(majority_sst_files_rejections{node_prefix=\"$dbcluster\"}[5m])))",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(majority_sst_files_rejections{node_prefix=\"$dbcluster\"}[5m])))",
           "interval": "",
           "legendFormat": "Rejections",
           "refId": "A"
@@ -9058,7 +9058,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_flush_write_bytes{node_prefix=\"$dbcluster\"}[5m]))) / 1048576",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(rocksdb_flush_write_bytes{node_prefix=\"$dbcluster\"}[5m]))) / 1048576",
           "hide": false,
           "interval": "",
           "legendFormat": "Flush",
@@ -9155,14 +9155,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_compact_read_bytes{node_prefix=\"$dbcluster\"}[5m]))) / 1048576",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(rocksdb_compact_read_bytes{node_prefix=\"$dbcluster\"}[5m]))) / 1048576",
           "hide": false,
           "interval": "",
           "legendFormat": "Bytes Read",
           "refId": "A"
         },
         {
-          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_compact_write_bytes{node_prefix=\"$dbcluster\"}[5m]))) / 1048576",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (rate(rocksdb_compact_write_bytes{node_prefix=\"$dbcluster\"}[5m]))) / 1048576",
           "interval": "",
           "legendFormat": "Bytes Written",
           "refId": "B"
@@ -9258,7 +9258,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (irate(rocksdb_numfiles_in_singlecompaction_sum{node_prefix=\"$dbcluster\"}[5m]))) / avg(sum without (table_id, table_name) (irate(rocksdb_numfiles_in_singlecompaction_count{node_prefix=\"$dbcluster\"}[5m]))\r)",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (irate(rocksdb_numfiles_in_singlecompaction_sum{node_prefix=\"$dbcluster\"}[5m]))) / avg(sum without (table_id, table_name, pgschema_name) (irate(rocksdb_numfiles_in_singlecompaction_count{node_prefix=\"$dbcluster\"}[5m]))\r)",
           "hide": false,
           "interval": "",
           "legendFormat": "Avg",
@@ -9354,7 +9354,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum without (table_id, table_name) (irate(rocksdb_compaction_times_micros_sum{node_prefix=\"$dbcluster\"}[5m]))) / avg(sum without (table_id, table_name) (irate(rocksdb_compaction_times_micros_count{node_prefix=\"$dbcluster\"}[5m]))\r)",
+          "expr": "avg(sum without (table_id, table_name, pgschema_name) (irate(rocksdb_compaction_times_micros_sum{node_prefix=\"$dbcluster\"}[5m]))) / avg(sum without (table_id, table_name, pgschema_name) (irate(rocksdb_compaction_times_micros_count{node_prefix=\"$dbcluster\"}[5m]))\r)",
           "hide": false,
           "interval": "",
           "legendFormat": "Avg",

--- a/managed/src/main/resources/metric/Dashboard.json
+++ b/managed/src/main/resources/metric/Dashboard.json
@@ -5136,12 +5136,12 @@
     "targets" : [ {
       "hide" : false,
       "legendFormat" : "Hit",
-      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"rocksdb_block_cache_hit\"}[300s]))) by (saved_name)",
+      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"rocksdb_block_cache_hit\"}[300s]))) by (saved_name)",
       "refId" : "A"
     }, {
       "hide" : false,
       "legendFormat" : "Miss",
-      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"rocksdb_block_cache_miss\"}[300s]))) by (saved_name)",
+      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"rocksdb_block_cache_miss\"}[300s]))) by (saved_name)",
       "refId" : "B"
     } ],
     "gridPos" : {
@@ -5233,12 +5233,12 @@
     "targets" : [ {
       "hide" : false,
       "legendFormat" : "Written",
-      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"rocksdb_compact_write_bytes\"}[300s]))) by (saved_name) / 1048576",
+      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"rocksdb_compact_write_bytes\"}[300s]))) by (saved_name) / 1048576",
       "refId" : "A"
     }, {
       "hide" : false,
       "legendFormat" : "Read",
-      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"rocksdb_compact_read_bytes\"}[300s]))) by (saved_name) / 1048576",
+      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"rocksdb_compact_read_bytes\"}[300s]))) by (saved_name) / 1048576",
       "refId" : "B"
     } ],
     "gridPos" : {
@@ -5330,7 +5330,7 @@
     "targets" : [ {
       "hide" : false,
       "legendFormat" : "Written",
-      "expr" : "sum(sum by (namespace_name, table_id, table_name)(rate(log_bytes_logged{table_id=~\".+\", node_prefix=~\"$dbcluster\", export_type=\"tserver_export\"}[300s])))",
+      "expr" : "sum(sum by (namespace_name, table_id, table_name, pgschema_name)(rate(log_bytes_logged{table_id=~\".+\", node_prefix=~\"$dbcluster\", export_type=\"tserver_export\"}[300s])))",
       "refId" : "A"
     } ],
     "gridPos" : {
@@ -5524,17 +5524,17 @@
     "targets" : [ {
       "hide" : false,
       "legendFormat" : "Sync",
-      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"log_sync_latency_count\"}[300s]))) by (saved_name)",
+      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"log_sync_latency_count\"}[300s]))) by (saved_name)",
       "refId" : "A"
     }, {
       "hide" : false,
       "legendFormat" : "Append",
-      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"log_append_latency_count\"}[300s]))) by (saved_name)",
+      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"log_append_latency_count\"}[300s]))) by (saved_name)",
       "refId" : "B"
     }, {
       "hide" : false,
       "legendFormat" : "Commit",
-      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"log_group_commit_latency_count\"}[300s]))) by (saved_name)",
+      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"log_group_commit_latency_count\"}[300s]))) by (saved_name)",
       "refId" : "C"
     } ],
     "gridPos" : {
@@ -5626,32 +5626,32 @@
     "targets" : [ {
       "hide" : false,
       "legendFormat" : "IntentsDB",
-      "expr" : "avg(sum by (saved_name, namespace_name, table_id, table_name)(avg_over_time({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"mem_tracker_IntentsDB_MemTable\"}[300s]))) by (saved_name)",
+      "expr" : "avg(sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)(avg_over_time({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"mem_tracker_IntentsDB_MemTable\"}[300s]))) by (saved_name)",
       "refId" : "A"
     }, {
       "hide" : false,
       "legendFormat" : "IntentsDB",
-      "expr" : "avg(sum by (saved_name, namespace_name, table_id, table_name)(avg_over_time({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"mem_tracker_server_Tablets_overhead_PerTablet_IntentsDB_MemTable\"}[300s]))) by (saved_name)",
+      "expr" : "avg(sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)(avg_over_time({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"mem_tracker_server_Tablets_overhead_PerTablet_IntentsDB_MemTable\"}[300s]))) by (saved_name)",
       "refId" : "B"
     }, {
       "hide" : false,
       "legendFormat" : "IntentsDB",
-      "expr" : "avg(sum by (saved_name, namespace_name, table_id, table_name)(avg_over_time({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"mem_tracker_server_PerTablet_IntentsDB_MemTable\"}[300s]))) by (saved_name)",
+      "expr" : "avg(sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)(avg_over_time({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"mem_tracker_server_PerTablet_IntentsDB_MemTable\"}[300s]))) by (saved_name)",
       "refId" : "C"
     }, {
       "hide" : false,
       "legendFormat" : "RegularDB",
-      "expr" : "avg(sum by (saved_name, namespace_name, table_id, table_name)(avg_over_time({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"mem_tracker_server_Tablets_overhead_PerTablet_RegularDB_MemTable\"}[300s]))) by (saved_name)",
+      "expr" : "avg(sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)(avg_over_time({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"mem_tracker_server_Tablets_overhead_PerTablet_RegularDB_MemTable\"}[300s]))) by (saved_name)",
       "refId" : "D"
     }, {
       "hide" : false,
       "legendFormat" : "RegularDB",
-      "expr" : "avg(sum by (saved_name, namespace_name, table_id, table_name)(avg_over_time({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"mem_tracker_server_PerTablet_RegularDB_MemTable\"}[300s]))) by (saved_name)",
+      "expr" : "avg(sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)(avg_over_time({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"mem_tracker_server_PerTablet_RegularDB_MemTable\"}[300s]))) by (saved_name)",
       "refId" : "E"
     }, {
       "hide" : false,
       "legendFormat" : "RegularDB",
-      "expr" : "avg(sum by (saved_name, namespace_name, table_id, table_name)(avg_over_time({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"mem_tracker_RegularDB_MemTable\"}[300s]))) by (saved_name)",
+      "expr" : "avg(sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)(avg_over_time({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"mem_tracker_RegularDB_MemTable\"}[300s]))) by (saved_name)",
       "refId" : "F"
     } ],
     "gridPos" : {
@@ -5743,22 +5743,22 @@
     "targets" : [ {
       "hide" : false,
       "legendFormat" : "Leader",
-      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"leader_memory_pressure_rejections\"}[300s]))) by (saved_name)",
+      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"leader_memory_pressure_rejections\"}[300s]))) by (saved_name)",
       "refId" : "A"
     }, {
       "hide" : false,
       "legendFormat" : "Follower",
-      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"follower_memory_pressure_rejections\"}[300s]))) by (saved_name)",
+      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"follower_memory_pressure_rejections\"}[300s]))) by (saved_name)",
       "refId" : "B"
     }, {
       "hide" : false,
       "legendFormat" : "Operations",
-      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"operation_memory_pressure_rejections\"}[300s]))) by (saved_name)",
+      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"operation_memory_pressure_rejections\"}[300s]))) by (saved_name)",
       "refId" : "C"
     }, {
       "hide" : false,
       "legendFormat" : "RPCs",
-      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"rpc_inbound_calls_rejected_because_memory_pressure\"}[300s]))) by (saved_name)",
+      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"rpc_inbound_calls_rejected_because_memory_pressure\"}[300s]))) by (saved_name)",
       "refId" : "D"
     } ],
     "gridPos" : {
@@ -5850,12 +5850,12 @@
     "targets" : [ {
       "hide" : false,
       "legendFormat" : "Write",
-      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name)(avg_over_time({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"write_operations_inflight\"}[300s]))) by (saved_name)",
+      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)(avg_over_time({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"write_operations_inflight\"}[300s]))) by (saved_name)",
       "refId" : "A"
     }, {
       "hide" : false,
       "legendFormat" : "All",
-      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name)(avg_over_time({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"all_operations_inflight\"}[300s]))) by (saved_name)",
+      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)(avg_over_time({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"all_operations_inflight\"}[300s]))) by (saved_name)",
       "refId" : "B"
     } ],
     "gridPos" : {
@@ -6039,7 +6039,7 @@
     "targets" : [ {
       "hide" : false,
       "legendFormat" : "Read",
-      "expr" : "sum(sum by (namespace_name, table_id, table_name)(rate(ql_read_latency_count{table_id=~\".+\", node_prefix=~\"$dbcluster\", export_type=\"tserver_export\"}[300s])))",
+      "expr" : "sum(sum by (namespace_name, table_id, table_name, pgschema_name)(rate(ql_read_latency_count{table_id=~\".+\", node_prefix=~\"$dbcluster\", export_type=\"tserver_export\"}[300s])))",
       "refId" : "A"
     } ],
     "gridPos" : {
@@ -6131,12 +6131,12 @@
     "targets" : [ {
       "hide" : false,
       "legendFormat" : "Blooms Useful",
-      "expr" : "avg(sum by (saved_name, namespace_name, table_id, table_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"rocksdb_bloom_filter_useful\"}[300s]))) by (saved_name)",
+      "expr" : "avg(sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"rocksdb_bloom_filter_useful\"}[300s]))) by (saved_name)",
       "refId" : "A"
     }, {
       "hide" : false,
       "legendFormat" : "Blooms Checked",
-      "expr" : "avg(sum by (saved_name, namespace_name, table_id, table_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"rocksdb_bloom_filter_checked\"}[300s]))) by (saved_name)",
+      "expr" : "avg(sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"rocksdb_bloom_filter_checked\"}[300s]))) by (saved_name)",
       "refId" : "B"
     } ],
     "gridPos" : {
@@ -6228,17 +6228,17 @@
     "targets" : [ {
       "hide" : false,
       "legendFormat" : "Seek",
-      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"rocksdb_number_db_seek\"}[300s]))) by (saved_name)",
+      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"rocksdb_number_db_seek\"}[300s]))) by (saved_name)",
       "refId" : "A"
     }, {
       "hide" : false,
       "legendFormat" : "Prev",
-      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"rocksdb_number_db_prev\"}[300s]))) by (saved_name)",
+      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"rocksdb_number_db_prev\"}[300s]))) by (saved_name)",
       "refId" : "B"
     }, {
       "hide" : false,
       "legendFormat" : "Next",
-      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"rocksdb_number_db_next\"}[300s]))) by (saved_name)",
+      "expr" : "sum(sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)(rate({export_type=\"tserver_export\", table_id=~\".+\", node_prefix=~\"$dbcluster\", saved_name=\"rocksdb_number_db_next\"}[300s]))) by (saved_name)",
       "refId" : "C"
     } ],
     "gridPos" : {
@@ -6514,7 +6514,7 @@
     "targets" : [ {
       "hide" : false,
       "legendFormat" : "Rejections",
-      "expr" : "sum(sum by (namespace_name, table_id, table_name)(rate(majority_sst_files_rejections{table_id=~\".+\", node_prefix=~\"$dbcluster\", export_type=\"tserver_export\"}[300s])))",
+      "expr" : "sum(sum by (namespace_name, table_id, table_name, pgschema_name)(rate(majority_sst_files_rejections{table_id=~\".+\", node_prefix=~\"$dbcluster\", export_type=\"tserver_export\"}[300s])))",
       "refId" : "A"
     } ],
     "gridPos" : {
@@ -6606,7 +6606,7 @@
     "targets" : [ {
       "hide" : false,
       "legendFormat" : "Write",
-      "expr" : "sum(sum by (namespace_name, table_id, table_name)(rate(ql_write_latency_count{table_id=~\".+\", node_prefix=~\"$dbcluster\", export_type=\"tserver_export\"}[300s])))",
+      "expr" : "sum(sum by (namespace_name, table_id, table_name, pgschema_name)(rate(ql_write_latency_count{table_id=~\".+\", node_prefix=~\"$dbcluster\", export_type=\"tserver_export\"}[300s])))",
       "refId" : "A"
     } ],
     "gridPos" : {
@@ -12889,7 +12889,7 @@
     "targets" : [ {
       "hide" : false,
       "legendFormat" : "Size",
-      "expr" : "avg(sum by (saved_name, namespace_name, table_id, table_name)(rocksdb_current_version_sst_files_size{node_prefix=~\"$dbcluster\", export_type=\"tserver_export\"})) / 1073741824",
+      "expr" : "avg(sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)(rocksdb_current_version_sst_files_size{node_prefix=~\"$dbcluster\", export_type=\"tserver_export\"})) / 1073741824",
       "refId" : "A"
     } ],
     "gridPos" : {

--- a/managed/src/main/resources/metric/metrics.yml
+++ b/managed/src/main/resources/metric/metrics.yml
@@ -3381,7 +3381,7 @@ table_write_latency:
 
 table_write_rps:
   metric: "ql_write_latency_count"
-  function: "rate|sum by (namespace_name, table_id, table_name)|sum"
+  function: "rate|sum by (namespace_name, table_id, table_name, pgschema_name)|sum"
   range: true
   filters:
     export_type: "tserver_export"
@@ -3412,7 +3412,7 @@ table_read_latency:
 
 table_read_rps:
   metric: "ql_read_latency_count"
-  function: "rate|sum by (namespace_name, table_id, table_name)|sum"
+  function: "rate|sum by (namespace_name, table_id, table_name, pgschema_name)|sum"
   range: true
   filters:
     export_type: "tserver_export"
@@ -3443,7 +3443,7 @@ table_write_lock_latency:
 
 table_mem_tracker_db_memtable:
   metric: ""
-  function: "avg_over_time|sum by (saved_name, namespace_name, table_id, table_name)|avg"
+  function: "avg_over_time|sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)|avg"
   range: true
   filters:
     export_type: "tserver_export"
@@ -3522,7 +3522,7 @@ table_wal_size:
 
 table_log_ops_second:
   metric: ""
-  function: "rate|sum by (saved_name, namespace_name, table_id, table_name)|sum"
+  function: "rate|sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)|sum"
   range: true
   filters:
     export_type: "tserver_export"
@@ -3541,7 +3541,7 @@ table_log_ops_second:
 
 table_log_bytes_written:
   metric: "log_bytes_logged"
-  function: "rate|sum by (namespace_name, table_id, table_name)|sum"
+  function: "rate|sum by (namespace_name, table_id, table_name, pgschema_name)|sum"
   range: true
   filters:
     export_type: "tserver_export"
@@ -3556,7 +3556,7 @@ table_log_bytes_written:
 
 table_seek_next_prev:
   metric: ""
-  function: "rate|sum by (saved_name, namespace_name, table_id, table_name)|sum"
+  function: "rate|sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)|sum"
   range: true
   filters:
     export_type: "tserver_export"
@@ -3575,7 +3575,7 @@ table_seek_next_prev:
 
 table_ops_in_flight:
   metric: ""
-  function: "avg_over_time|sum by (saved_name, namespace_name, table_id, table_name)|sum"
+  function: "avg_over_time|sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)|sum"
   range: true
   filters:
     export_type: "tserver_export"
@@ -3593,7 +3593,7 @@ table_ops_in_flight:
 
 table_write_rejections:
   metric: "majority_sst_files_rejections"
-  function: "rate|sum by (namespace_name, table_id, table_name)|sum"
+  function: "rate|sum by (namespace_name, table_id, table_name, pgschema_name)|sum"
   range: true
   filters:
     export_type: "tserver_export"
@@ -3608,7 +3608,7 @@ table_write_rejections:
 
 table_memory_rejections:
   metric: ""
-  function: "rate|sum by (saved_name, namespace_name, table_id, table_name)|sum"
+  function: "rate|sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)|sum"
   range: true
   filters:
     export_type: "tserver_export"
@@ -3628,7 +3628,7 @@ table_memory_rejections:
 
 table_compaction:
   metric: ""
-  function: "rate|sum by (saved_name, namespace_name, table_id, table_name)|sum"
+  function: "rate|sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)|sum"
   range: true
   operator: "/ 1048576"
   filters:
@@ -3648,7 +3648,7 @@ table_compaction:
 
 table_block_cache_hit_miss:
   metric: ""
-  function: "rate|sum by (saved_name, namespace_name, table_id, table_name)|sum"
+  function: "rate|sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)|sum"
   range: true
   filters:
     saved_name: "rocksdb_block_cache_hit|rocksdb_block_cache_miss"
@@ -3666,7 +3666,7 @@ table_block_cache_hit_miss:
 
 table_rocksdb_blooms_checked_and_useful:
   metric: ""
-  function: "rate|sum by (saved_name, namespace_name, table_id, table_name)|avg"
+  function: "rate|sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)|avg"
   range: true
   filters:
     export_type: "tserver_export"
@@ -3684,7 +3684,7 @@ table_rocksdb_blooms_checked_and_useful:
 
 table_rocksdb_total_sst_per_node:
   metric: "rocksdb_current_version_sst_files_size"
-  function: "sum by (saved_name, namespace_name, table_id, table_name)|avg"
+  function: "sum by (saved_name, namespace_name, table_id, table_name, pgschema_name)|avg"
   operator: "/ 1073741824"
   filters:
     export_type: "tserver_export"

--- a/src/yb/cdc/cdc_service.cc
+++ b/src/yb/cdc/cdc_service.cc
@@ -400,6 +400,11 @@ Result<std::shared_ptr<T>> GetOrCreateXreplTabletMetrics(
       attrs["namespace_name"] = raft_group_metadata->namespace_name();
       attrs["table_name"] = raft_group_metadata->table_name();
       attrs["table_type"] = TableType_Name(raft_group_metadata->table_type());
+      auto table_info = raft_group_metadata->primary_table_info();
+      if (source_type == XCLUSTER && table_info->table_type == PGSQL_TABLE_TYPE &&
+          table_info->schema().has_pgschema_name()) {
+        attrs["pgschema_name"] = table_info->schema().SchemaName();
+      }
       attrs["stream_id"] = stream_id.ToString();
       if (slot_name.has_value()) {
         attrs["slot_name"] = slot_name.value();

--- a/src/yb/tablet/tablet-metadata-test.cc
+++ b/src/yb/tablet/tablet-metadata-test.cc
@@ -123,6 +123,34 @@ TEST_F(TestRaftGroupMetadata, TestLoadFromSuperBlock) {
             << superblock_pb_1.DebugString();
 }
 
+TEST(TableInfoTest, PgSchemaNameInMetricAttributeMap) {
+  auto pgsql_schema = GetSimpleTestSchema();
+  pgsql_schema.InitColumnIdsByDefault();
+  pgsql_schema.SetSchemaName("test_schema");
+  auto pgsql_table_info = TableInfo::TEST_Create(
+      "table_id", "test_db", "test_table", TableType::PGSQL_TABLE_TYPE, pgsql_schema,
+      dockv::PartitionSchema());
+  auto pgsql_attrs = pgsql_table_info->CreateMetricAttributeMap();
+  ASSERT_EQ(pgsql_attrs["pgschema_name"], "test_schema");
+
+  auto empty_pgsql_schema = GetSimpleTestSchema();
+  empty_pgsql_schema.InitColumnIdsByDefault();
+  auto empty_pgsql_table_info = TableInfo::TEST_Create(
+      "table_id", "test_db", "test_table", TableType::PGSQL_TABLE_TYPE, empty_pgsql_schema,
+      dockv::PartitionSchema());
+  auto empty_pgsql_attrs = empty_pgsql_table_info->CreateMetricAttributeMap();
+  ASSERT_FALSE(empty_pgsql_attrs.contains("pgschema_name"));
+
+  auto ycql_schema = GetSimpleTestSchema();
+  ycql_schema.InitColumnIdsByDefault();
+  ycql_schema.SetSchemaName("test_schema");
+  auto ycql_table_info = TableInfo::TEST_Create(
+      "table_id", "test_keyspace", "test_table", TableType::YQL_TABLE_TYPE, ycql_schema,
+      dockv::PartitionSchema());
+  auto ycql_attrs = ycql_table_info->CreateMetricAttributeMap();
+  ASSERT_FALSE(ycql_attrs.contains("pgschema_name"));
+}
+
 TEST_F(TestRaftGroupMetadata, TestDeleteTabletDataClearsDisk) {
   auto tablet = harness_->tablet();
 

--- a/src/yb/tablet/tablet.cc
+++ b/src/yb/tablet/tablet.cc
@@ -3019,18 +3019,6 @@ Status Tablet::AlterSchema(ChangeMetadataOperation* operation) {
         operation->new_table_name().ToBuffer(),
         operation->op_id(),
         current_table_info->table_id);
-    // We shouldn't update the attributes of the colocation parent table's metrics when we alter
-    // a colocated table.
-    if (!metadata_->colocated()) {
-      if (table_metrics_entity_) {
-        table_metrics_entity_->SetAttribute("table_name", operation->new_table_name().ToBuffer());
-        table_metrics_entity_->SetAttribute("namespace_name", current_table_info->namespace_name);
-      }
-      if (tablet_metrics_entity_) {
-        tablet_metrics_entity_->SetAttribute("table_name", operation->new_table_name().ToBuffer());
-        tablet_metrics_entity_->SetAttribute("namespace_name", current_table_info->namespace_name);
-      }
-    }
   } else {
     metadata_->SetSchema(
         *operation->schema(), operation->index_map(), deleted_cols,
@@ -3038,6 +3026,7 @@ Status Tablet::AlterSchema(ChangeMetadataOperation* operation) {
         operation->op_id(),
         current_table_info->table_id);
   }
+  RefreshMetricsAttributes();
 
   // Cleanup the index from cache which are deleted or updated.
   if (current_table_info->index_map && !current_table_info->index_map->empty()) {
@@ -3054,6 +3043,22 @@ Status Tablet::AlterSchema(ChangeMetadataOperation* operation) {
 
   // Flush the updated schema metadata to disk.
   return metadata_->Flush();
+}
+
+void Tablet::RefreshMetricsAttributes() {
+  // We shouldn't update the attributes of the colocation parent table's metrics when we alter
+  // a colocated table.
+  if (metadata_->colocated()) {
+    return;
+  }
+
+  const auto attrs = metadata_->primary_table_info()->CreateMetricAttributeMap();
+  if (table_metrics_entity_) {
+    table_metrics_entity_->SetAttributes(attrs);
+  }
+  if (tablet_metrics_entity_) {
+    tablet_metrics_entity_->SetAttributes(attrs);
+  }
 }
 
 Status Tablet::InsertPackedSchemaForXClusterTarget(

--- a/src/yb/tablet/tablet.h
+++ b/src/yb/tablet/tablet.h
@@ -1184,6 +1184,8 @@ class Tablet : public AbstractTablet,
   void TEST_DocDBDumpToContainerImpl(
       Out& out, docdb::IncludeIntents include_intents, docdb::IncludeWriteTime include_write_time);
 
+  void RefreshMetricsAttributes();
+
   std::unique_ptr<const Schema> key_schema_;
 
   RaftGroupMetadataPtr metadata_;

--- a/src/yb/tablet/tablet_metadata.cc
+++ b/src/yb/tablet/tablet_metadata.cc
@@ -535,6 +535,9 @@ MetricAttributeMap TableInfo::CreateMetricAttributeMap() const {
   attrs["table_name"] = table_name;
   attrs["table_type"] = TableType_Name(table_type);
   attrs["namespace_name"] = namespace_name;
+  if (table_type == PGSQL_TABLE_TYPE && schema().has_pgschema_name()) {
+    attrs["pgschema_name"] = schema().SchemaName();
+  }
   if (table_type == PGSQL_TABLE_TYPE && !namespace_id.empty()) {
     auto db_oid = GetPgsqlDatabaseOid(namespace_id);
     if (db_oid.ok()) {

--- a/src/yb/util/metric_entity.cc
+++ b/src/yb/util/metric_entity.cc
@@ -206,6 +206,12 @@ AggregationLevels MetricEntity::ReconstructPrometheusAttributesUnlocked() {
     prometheus_attributes_["namespace_name"] =
         EscapePrometheusLabelValue(attributes_["namespace_name"]);
     {
+      auto it = attributes_.find("pgschema_name");
+      if (it != attributes_.end() && !it->second.empty()) {
+        prometheus_attributes_["pgschema_name"] = EscapePrometheusLabelValue(it->second);
+      }
+    }
+    {
       auto it = attributes_.find("database_oid");
       if (it != attributes_.end() && !it->second.empty()) {
         prometheus_attributes_["database_oid"] = it->second;
@@ -223,6 +229,12 @@ AggregationLevels MetricEntity::ReconstructPrometheusAttributesUnlocked() {
     prometheus_attributes_["table_type"] = attributes_["table_type"];
     prometheus_attributes_["namespace_name"] =
         EscapePrometheusLabelValue(attributes_["namespace_name"]);
+    {
+      auto it = attributes_.find("pgschema_name");
+      if (it != attributes_.end() && !it->second.empty()) {
+        prometheus_attributes_["pgschema_name"] = EscapePrometheusLabelValue(it->second);
+      }
+    }
     prometheus_attributes_["stream_id"] = aggregation_id_for_pre_aggregation_;
     default_aggregation_level = kStreamLevel;
   } else if (prototype_type == kCdcsdkMetricEntityName) {
@@ -468,6 +480,8 @@ std::string MetricEntity::LogPrefix() const {
 
 void MetricEntity::SetAttributes(const AttributeMap& attrs) {
   std::lock_guard l(lock_);
+  // Replaces the full attribute map. Callers must include every attribute that should be preserved;
+  // out-of-band attributes added after construction will be dropped.
   attributes_ = attrs;
   ReconstructPrometheusAttributesUnlocked();
   auto s = metrics_aggregator_->ReplaceAttributes(
@@ -499,6 +513,7 @@ void ConvertToServerLevelAttributes(MetricEntity::AttributeMap* non_server_level
   non_server_level_attributes->erase("table_name");
   non_server_level_attributes->erase("table_type");
   non_server_level_attributes->erase("namespace_name");
+  non_server_level_attributes->erase("pgschema_name");
 }
 
 void AssertAttributesMatchExpectation(

--- a/src/yb/util/metrics-test.cc
+++ b/src/yb/util/metrics-test.cc
@@ -254,6 +254,7 @@ TEST_F(MetricsTest, AggregationTest) {
     entity_attr["tablet_id"] = tablet_id + "_id";
     entity_attr["table_name"] = table_id;
     entity_attr["table_id"] = table_id + "_id";
+    entity_attr["pgschema_name"] = table_id + "_schema";
     auto entity = METRIC_ENTITY_tablet.Instantiate(&registry_, tablet_id, entity_attr);
 
     // Test SUM aggregation
@@ -327,6 +328,7 @@ TEST_F(MetricsTest, AggregationTest) {
     attributes["metric_type"] = "tablet";
     attributes["table_id"] = "table_1_id";
     attributes["table_name"] = "table_1";
+    attributes["pgschema_name"] = "table_1_schema";
     CheckPreStoredAndScrapeTimeAttributes(writer, "table_1_id", attributes, attributes);
 
     CheckPreAggreatedAndScrapeTimeValues(writer, kSumGaugeName, "table_2_id", 15, std::nullopt);
@@ -334,6 +336,7 @@ TEST_F(MetricsTest, AggregationTest) {
     CheckPreAggreatedAndScrapeTimeValues(writer, kSumCounterName, "table_2_id", 15, std::nullopt);
     attributes["table_id"] = "table_2_id";
     attributes["table_name"] = "table_2";
+    attributes["pgschema_name"] = "table_2_schema";
     CheckPreStoredAndScrapeTimeAttributes(writer, "table_2_id", attributes, attributes);
   }
   {
@@ -371,6 +374,7 @@ TEST_F(MetricsTest, AggregationTest) {
     attributes["metric_type"] = "tablet";
     attributes["table_id"] = "table_1_id";
     attributes["table_name"] = "table_1";
+    attributes["pgschema_name"] = "table_1_schema";
     CheckPreStoredAndScrapeTimeAttributes(writer, "table_1_id", attributes, attributes);
 
     // Simulate adding a tablet metric entity.
@@ -741,6 +745,9 @@ TEST_F(MetricsTest, VerifyHelpAndTypeTags) {
   auto tablet_entity =
       METRIC_ENTITY_tablet.Instantiate(&registry_, "tablet_entity_id_44", entity_attr);
   auto server_entity = METRIC_ENTITY_server.Instantiate(&registry_, "server_entity_id_45");
+  entity_attr["namespace_name"] = "test_namespace";
+  entity_attr["table_type"] = "PGSQL_TABLE_TYPE";
+  entity_attr["pgschema_name"] = "test_schema";
   entity_attr["stream_id"] = "stream_id_46";
   auto xcluster_entity =
       METRIC_ENTITY_xcluster.Instantiate(&registry_, "xcluster_entity_id_47", entity_attr);
@@ -783,6 +790,7 @@ TEST_F(MetricsTest, VerifyHelpAndTypeTags) {
   // Check lag output.
   EXPECT_EQ(1, StringOccurence(output_str,
       "# HELP t_lag Test lag description\n# TYPE t_lag gauge"));
+  ASSERT_STR_CONTAINS(output_str, "pgschema_name=\"test_schema\"");
 }
 
 TEST_F(MetricsTest, SimulateMetricDeletionBeforeFlush) {
@@ -855,6 +863,7 @@ TEST_F(MetricsTest, VerifyLabelValueEscaping) {
   entity_attr1["tablet_id"] = "tablet_id_52";
   entity_attr1["table_name"] = "\"yo\".\"name_split\"";
   entity_attr1["table_id"] = "table_id_53";
+  entity_attr1["pgschema_name"] = "\"yo\"";
   auto tablet_entity1 =
       METRIC_ENTITY_tablet.Instantiate(&registry_, "tablet_entity_id_54", entity_attr1);
   scoped_refptr<Counter> counter1 = METRIC_t_counter.Instantiate(tablet_entity1);
@@ -864,6 +873,7 @@ TEST_F(MetricsTest, VerifyLabelValueEscaping) {
   entity_attr2["tablet_id"] = "tablet_id_55";
   entity_attr2["table_name"] = "path\\to\\table";
   entity_attr2["table_id"] = "table_id_56";
+  entity_attr2["pgschema_name"] = "path\\to\\schema";
   auto tablet_entity2 =
       METRIC_ENTITY_tablet.Instantiate(&registry_, "tablet_entity_id_57", entity_attr2);
   scoped_refptr<Counter> counter2 = METRIC_t_counter.Instantiate(tablet_entity2);
@@ -873,9 +883,22 @@ TEST_F(MetricsTest, VerifyLabelValueEscaping) {
   entity_attr3["tablet_id"] = "tablet_id_58";
   entity_attr3["table_name"] = "line1\nline2";
   entity_attr3["table_id"] = "table_id_59";
+  entity_attr3["pgschema_name"] = "schema_line1\nschema_line2";
   auto tablet_entity3 =
       METRIC_ENTITY_tablet.Instantiate(&registry_, "tablet_entity_id_60", entity_attr3);
   scoped_refptr<Counter> counter3 = METRIC_t_counter.Instantiate(tablet_entity3);
+
+  MetricEntity::AttributeMap xcluster_entity_attr;
+  xcluster_entity_attr["stream_id"] = "stream_id_61";
+  xcluster_entity_attr["table_id"] = "table_id_62";
+  xcluster_entity_attr["table_name"] = "xcluster_table";
+  xcluster_entity_attr["table_type"] = "PGSQL_TABLE_TYPE";
+  xcluster_entity_attr["namespace_name"] = "xcluster_namespace";
+  xcluster_entity_attr["pgschema_name"] = "\"xcluster_schema\"";
+  auto xcluster_entity =
+      METRIC_ENTITY_xcluster.Instantiate(&registry_, "xcluster_entity_id_63", xcluster_entity_attr);
+  scoped_refptr<EventStats> event_stats = METRIC_t_event_stats.Instantiate(xcluster_entity);
+  event_stats->Increment(1);
 
   MetricPrometheusOptions opts;
   std::stringstream output;
@@ -886,13 +909,17 @@ TEST_F(MetricsTest, VerifyLabelValueEscaping) {
 
   // Quotes should be escaped
   ASSERT_STR_CONTAINS(output_str, "table_name=\"\\\"yo\\\".\\\"name_split\\\"\"");
+  ASSERT_STR_CONTAINS(output_str, "pgschema_name=\"\\\"yo\\\"\"");
+  ASSERT_STR_CONTAINS(output_str, "pgschema_name=\"\\\"xcluster_schema\\\"\"");
   ASSERT_STR_NOT_CONTAINS(output_str, "table_name=\"\"yo\".\"name_split\"\"");
 
   // Backslashes should be escaped
   ASSERT_STR_CONTAINS(output_str, "table_name=\"path\\\\to\\\\table\"");
+  ASSERT_STR_CONTAINS(output_str, "pgschema_name=\"path\\\\to\\\\schema\"");
 
   // Newlines should be escaped
   ASSERT_STR_CONTAINS(output_str, "table_name=\"line1\\nline2\"");
+  ASSERT_STR_CONTAINS(output_str, "pgschema_name=\"schema_line1\\nschema_line2\"");
 }
 
 // Regression test for a dangling-reference bug in


### PR DESCRIPTION
## Summary

Adds the PG schema name as a Prometheus label (`pgschema_name`) on
PGSQL table, tablet, and xCluster metric entities so metrics can be
filtered and grouped by schema.

Changes:

- `TableInfo::CreateMetricAttributeMap` sets `pgschema_name` when the
  table is PGSQL and the schema has a `pgschema_name`.
- `MetricEntity::ReconstructPrometheusAttributesUnlocked` propagates
  `pgschema_name` for tablet/table and xCluster entities, applying
  Prometheus label-value escaping.
- `ConvertToServerLevelAttributes` strips `pgschema_name` so
  server-level rollups don't carry the per-table label.
- `Tablet::AlterSchema` is refactored to refresh the full metric
  attribute map on every schema change (previously only on renames)
  via a new `RefreshMetricsAttributes()` helper. This is required so
  `ALTER TABLE ... SET SCHEMA` doesn't leave stale `pgschema_name`
  labels on the in-memory metric entities. Behavior for the
  colocation parent is preserved (skipped).
- A doc comment on `MetricEntity::SetAttributes` records that the
  call replaces the full attribute map (out-of-band attributes are
  dropped).
- The xCluster CDC metric-entity creation path sets `pgschema_name`
  when the source table is PGSQL (gated on `source_type == XCLUSTER`
  since the CDCSDK branch does not propagate the label).
- `metrics.yml` and the Grafana dashboards (`Dashboard.json`,
  `cloud/grafana/YugabyteDB.json`) include `pgschema_name` in inner
  `sum by(...)` clauses so the label survives aggregation when YBA
  filters by schema.

No on-disk format, RPC, gflag default, or wire-format change. The
new label is additive in Prometheus output; existing scrapers/
dashboards are unaffected.

## Test plan

- [ ] `ctest -R tablet-metadata-test` — covers the new
  `TableInfoTest.PgSchemaNameInMetricAttributeMap` (PGSQL with
  schema set, PGSQL without, YCQL).
- [ ] `ctest -R metrics-test` — covers the updated
  `AggregationTest`, `VerifyHelpAndTypeTags` (asserts
  `pgschema_name` in Prometheus output for the xCluster entity), and
  `VerifyLabelValueEscaping` (quote / backslash / newline escaping
  for `pgschema_name` on both tablet and xCluster entities).
- [ ] Manual: bring up a PGSQL cluster, create tables in multiple
  schemas, scrape `/prometheus-metrics` on a tserver, and confirm
  `pgschema_name="..."` appears on table and tablet metric series.
- [ ] Manual: run `ALTER TABLE foo SET SCHEMA newschema` and
  confirm the metric series for the affected tablet now reports the
  new `pgschema_name` (regression check for the
  `RefreshMetricsAttributes` change).
- [ ] Manual: confirm YBA dashboards still render with the updated
  `sum by(...)` clauses (no broken queries due to label changes).
