### PR TITLE
[BACKPORT 2026.1][#31345] YSQL: Fix PgLibPqCreateSequenceNamespaceRaceTest

### DIFF
--- a/src/yb/yql/pgwrapper/pg_libpq-test.cc
+++ b/src/yb/yql/pgwrapper/pg_libpq-test.cc
@@ -4866,30 +4866,36 @@ TEST_F(PgLibPqCreateSequenceNamespaceRaceTest, CreateSequenceNamespaceRaceTest) 
   pg_ts = cluster_->tablet_server(2);
   auto conn2 = ASSERT_RESULT(Connect());
   TestThreadHolder thread_holder;
-  thread_holder.AddThreadFunctor([&conn1]() -> void {
-    // Retry on 40001 (serialization failure) which can occur due to
-    // running CREATE TABLE concurrently with the other thread.
-    //
-    // In debug builds, Read Committed is on by default. This results
-    // in an internal DB-side retry of the operation on a conflict error. The retry
-    // can fail with a duplicate table error because the rollback of the previous
-    // transaction is async and might still be in flight.
-    Status s;
-    do {
-      s = conn1.Execute("CREATE TABLE t1(k SERIAL, v INT)");
-    } while (!s.ok() && (HasTransactionError(s) ||
-          PgsqlError(s) == YBPgErrorCode::YB_PG_DUPLICATE_TABLE));
-    ASSERT_OK(s);
-    ASSERT_OK(conn1.Execute("INSERT INTO t1(v) VALUES(1)"));
+  // The concurrent CREATE TABLEs bump the catalog version and can race with each other.
+  // When transactional DDL is disabled (--ysql_yb_ddl_transaction_block_enabled=false),
+  // a catalog-version-mismatch abort does not roll back the table that the first attempt
+  // already wrote to DocDB; instead the master's DDL atomicity infrastructure cleans it up
+  // asynchronously. That cleanup can land between a successful CREATE TABLE IF NOT EXISTS
+  // (which no-ops on the still-cached pg_class entry) and the INSERT, leaving the INSERT to
+  // fail with "relation does not exist". Wrap the whole create+insert in a retry loop so we
+  // recover from each of these transient outcomes.
+  auto create_and_insert = [](PGConn* conn, const std::string& table) {
+    while (true) {
+      auto create_status = conn->ExecuteFormat(
+          "CREATE TABLE IF NOT EXISTS $0(k SERIAL, v INT)", table);
+      ASSERT_TRUE(create_status.ok() ||
+                  HasTransactionError(create_status) || IsRetryable(create_status))
+          << create_status;
+      auto insert_status = conn->ExecuteFormat("INSERT INTO $0(v) VALUES(1)", table);
+      if (insert_status.ok()) return;
+      // The table may have been removed by the master's DDL atomicity cleanup after a
+      // catalog-mismatch abort of a concurrent CREATE TABLE; that surfaces as "relation
+      // does not exist" on the INSERT and is also retryable.
+      ASSERT_TRUE(HasTransactionError(insert_status) || IsRetryable(insert_status) ||
+                  insert_status.message().ToBuffer().find("does not exist") != std::string::npos)
+          << insert_status;
+    }
+  };
+  thread_holder.AddThreadFunctor([&conn1, &create_and_insert]() -> void {
+    create_and_insert(&conn1, "t1");
   });
-  thread_holder.AddThreadFunctor([&conn2]() -> void {
-    Status s;
-    do {
-      s = conn2.Execute("CREATE TABLE t2(k SERIAL, v INT)");
-    } while (!s.ok() && (HasTransactionError(s) ||
-          PgsqlError(s) == YBPgErrorCode::YB_PG_DUPLICATE_TABLE));
-    ASSERT_OK(s);
-    ASSERT_OK(conn2.Execute("INSERT INTO t2(v) VALUES(2)"));
+  thread_holder.AddThreadFunctor([&conn2, &create_and_insert]() -> void {
+    create_and_insert(&conn2, "t2");
   });
   thread_holder.WaitAndStop(10s * kTimeMultiplier);
 }


### PR DESCRIPTION
Summary:
After D47116 (#28253), every successful DDL increments the catalog
version. Two concurrent `CREATE TABLE`s now race on the catalog
version, and the catalog-version-mismatch detected at the end of one
backend's statement aborts that backend's PG transaction. When
transactional DDL is disabled
(`--ysql_yb_ddl_transaction_block_enabled=false`), aborting the PG
transaction does not roll back the table that has already been written
to DocDB; instead the master's DDL atomicity infrastructure cleans it
up asynchronously.

That leaves two failure modes that the test was not handling:

1. PG's transparent cache-refresh retry re-issues `CREATE TABLE`,
   which fails with `relation "<t>" already exists` (pgsql error
   42P07). The original retry predicate (`HasTransactionError`,
   matching only 40001/40P01) does not cover this.

2. With `IF NOT EXISTS`, the transparent retry no-ops on the still-
   present pg_class entry, but the master cleanup can land in the
   window between that successful CREATE and the follow-up `INSERT`,
   so the INSERT fails with `relation "<t>" does not exist`
   (pgsql error 42P01).

Both modes were observed in reproducer runs with
`enable_object_locking_for_table_locks=false` and
`ysql_yb_ddl_transaction_block_enabled=false`: every iteration failed
with one of the two errors above.

Wrap the whole create-then-insert sequence in a single retry loop:
- `CREATE TABLE IF NOT EXISTS` is retried on `HasTransactionError` or
  `IsRetryable` (which catches "Catalog Version Mismatch" surfaced when
  the transparent retry is unavailable);
- `INSERT` is retried on the same predicates, plus the specific
  "does not exist" message that indicates the table was cleaned up by
  the DDL atomicity worker after the transparent retry no-op.

Original commit: 63670582fcdd23a7ddcc6c43f469c48a4f1d6f73 / D53337

Test Plan:
Reproduced the failure (10/10 iterations) and validated the fix
(20/20 iterations) in the failing configuration by temporarily adding

```
--enable_object_locking_for_table_locks=false
--ysql_yb_ddl_transaction_block_enabled=false
```

to the test class's `UpdateMiniClusterOptions`, and reverting before
the diff:

```
./yb_build.sh release --cxx-test pg_libpq-test \
  --gtest_filter PgLibPqCreateSequenceNamespaceRaceTest.CreateSequenceNamespaceRaceTest \
  -n 20
```

Also re-ran 10x with the default release flags to confirm no regression.

Reviewers: bkolagani

Reviewed By: bkolagani

Subscribers: yql

Differential Revision: https://phorge.dev.yugabyte.com/D53337