### PR TITLE
[BACKPORT 2025.2][#31325] YSQL: Fix ASH query_id leakage in extended protocol

### DIFF
--- a/java/yb-pgsql/src/test/java/org/yb/pgsql/TestYbAsh.java
+++ b/java/yb-pgsql/src/test/java/org/yb/pgsql/TestYbAsh.java
@@ -29,6 +29,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import org.junit.Test;
@@ -429,5 +432,71 @@ public class TestYbAsh extends BasePgSQLTest {
 
     assertEquals(
         getSingleRow(stmt, storageFlushQueryId).getLong(0).intValue(), 0);
+  }
+
+  @Test
+  public void testExtendedProtocolDoesNotLeakQueryId() throws Exception {
+    setAshConfigAndRestartCluster(50, ASH_SAMPLE_SIZE);
+
+    try (Statement stmt = connection.createStatement()) {
+      final int numTables = 8;
+      for (int i = 0; i < numTables; ++i) {
+        stmt.execute(String.format(
+            "CREATE TABLE t%d(id INT PRIMARY KEY, val TEXT, num NUMERIC(12,2), ref_id INT)", i));
+        stmt.execute(String.format(
+            "INSERT INTO t%d(id, val, num, ref_id) " +
+            "SELECT g, 'row-' || g, (random()*1000)::numeric(12,2), g " +
+            "FROM generate_series(1, 200) g", i));
+      }
+    }
+
+    final String complexQuery =
+        "SELECT t0.id, t1.id, t2.id, t3.id, t4.id, t5.id, t6.id, t7.id " +
+        "FROM t0 " +
+        "JOIN t1 ON t1.ref_id = t0.id " +
+        "JOIN t2 ON t2.ref_id = t1.id " +
+        "JOIN t3 ON t3.ref_id = t2.id " +
+        "JOIN t4 ON t4.ref_id = t3.id " +
+        "JOIN t5 ON t5.ref_id = t4.id " +
+        "JOIN t6 ON t6.ref_id = t5.id " +
+        "JOIN t7 ON t7.ref_id = t6.id " +
+        "WHERE t0.num > ? LIMIT 10";
+
+    final int NUM_ITERATIONS = 10;
+    int executedTxns = 0;
+
+    // Do 10 iterations so that ASH has enough samples
+    // Create a new connection everytime to do catalog calls
+    for (int it = 0; it < NUM_ITERATIONS; ++it) {
+        try (Connection conn = getConnectionBuilder()
+                .withPreferQueryMode("extended").connect()) {
+                conn.setAutoCommit(false);
+                conn.setReadOnly(true);
+            try (PreparedStatement sel = conn.prepareStatement(complexQuery)) {
+                final int PARAM_CYCLE = 500;
+                sel.setInt(1, (int) ((++executedTxns) % PARAM_CYCLE));
+                // drain the result set
+                try (ResultSet rs = sel.executeQuery()) {
+                    while (rs.next()) ;
+                }
+                conn.commit();
+            } catch (Exception e) {
+                conn.rollback();
+            }
+        } catch (Exception e) {
+            fail("Workload connection failed: " + e.getMessage());
+        }
+    }
+
+    try (Statement stmt = connection.createStatement()) {
+      long leakedSamples = getSingleRow(stmt, String.format(
+          "SELECT COUNT(*) FROM %s AS ash " +
+          "JOIN pg_stat_statements AS pgss ON ash.query_id = pgss.queryid " +
+          "WHERE pgss.query ILIKE '%%BEGIN%%READ%%ONLY%%' " +
+          "AND ash.wait_event = 'CatalogRead'", ASH_VIEW)).getLong(0);
+      assertEquals(
+          "BEGIN READ ONLY's query_id should not be attached to CatalogRead samples",
+          0L, leakedSamples);
+    }
   }
 }

--- a/src/postgres/src/backend/tcop/postgres.c
+++ b/src/postgres/src/backend/tcop/postgres.c
@@ -1627,6 +1627,8 @@ exec_parse_message(const char *query_string,	/* string to execute */
 	const char *redacted_query_string;
 	CommandTag	command_tag;
 
+	uint64		yb_msg_query_id = YbAshGetConstQueryId();
+
 	/*
 	 * Report query to various monitoring facilities.
 	 */
@@ -1636,6 +1638,13 @@ exec_parse_message(const char *query_string,	/* string to execute */
 	command_tag = YbParseCommandTag(query_string);
 	redacted_query_string = YbRedactPasswordIfExists(query_string, command_tag);
 	pgstat_report_activity(STATE_RUNNING, redacted_query_string);
+
+	/*
+	 * YB: Drain any deferred query_id from the previous message so it is not
+	 * attributed to the catalog reads in pg_analyze_and_rewrite below. The
+	 * real query_id is pushed later by yb_ash's post_parse_analyze hook.
+	 */
+	YbAshSetQueryPlanPairForMessage(yb_msg_query_id);
 
 	set_ps_display("PARSE");
 
@@ -1849,6 +1858,8 @@ exec_parse_message(const char *query_string,	/* string to execute */
 	if (save_log_statement_stats)
 		ShowUsage("PARSE MESSAGE STATISTICS");
 
+	YbAshResetQueryPlanPairForMessage(yb_msg_query_id);
+
 	debug_query_string = NULL;
 }
 
@@ -1883,6 +1894,7 @@ exec_bind_message(StringInfo input_message)
 
 	const char *redacted_query_string;
 	CommandTag	command_tag;
+	uint64		yb_msg_query_id = YbAshGetConstQueryId();
 
 	/* Get the fixed part of the message */
 	portal_name = pq_getmsgstring(input_message);
@@ -1928,9 +1940,13 @@ exec_bind_message(StringInfo input_message)
 		if (query->queryId != UINT64CONST(0))
 		{
 			pgstat_report_query_id(query->queryId, false);
+			yb_msg_query_id = query->queryId;
 			break;
 		}
 	}
+
+	/* YB: Drain any deferred query_id and push this Bind's cached id. */
+	YbAshSetQueryPlanPairForMessage(yb_msg_query_id);
 
 	set_ps_display("BIND");
 
@@ -2280,6 +2296,14 @@ exec_bind_message(StringInfo input_message)
 	/* Done with the snapshot used for parameter I/O and parsing/planning */
 	if (snapshot_set)
 		PopActiveSnapshot();
+
+	/*
+	 * YB: Pop the Bind-phase query_id before PortalStart so that
+	 * ExecutorStart (called inside PortalStart) correctly picks up the
+	 * deferred-pop mechanism and stores the resolved plan_id rather than
+	 * the placeholder 0 that was pushed at the top of exec_bind_message.
+	 */
+	YbAshResetQueryPlanPairForMessage(yb_msg_query_id);
 
 	/*
 	 * And we're ready to start portal execution.
@@ -2856,6 +2880,7 @@ static void
 exec_describe_statement_message(const char *stmt_name)
 {
 	CachedPlanSource *psrc;
+	uint64		yb_msg_query_id = YbAshGetConstQueryId();
 
 	/*
 	 * Start up a transaction command. (Note that this will normally change
@@ -2907,6 +2932,24 @@ exec_describe_statement_message(const char *stmt_name)
 	if (whereToSendOutput != DestRemote)
 		return;					/* can't actually do anything... */
 
+	{
+		ListCell   *lc;
+
+		foreach(lc, psrc->query_list)
+		{
+			Query	   *query = lfirst_node(Query, lc);
+
+			if (query->queryId != UINT64CONST(0))
+			{
+				yb_msg_query_id = query->queryId;
+				break;
+			}
+		}
+	}
+
+	/* YB: Drain any deferred query_id and push this Describe's cached id. */
+	YbAshSetQueryPlanPairForMessage(yb_msg_query_id);
+
 	/*
 	 * First describe the parameters...
 	 */
@@ -2939,6 +2982,8 @@ exec_describe_statement_message(const char *stmt_name)
 	}
 	else
 		pq_putemptymessage('n');	/* NoData */
+
+	YbAshResetQueryPlanPairForMessage(yb_msg_query_id);
 }
 
 /*
@@ -2950,6 +2995,7 @@ static void
 exec_describe_portal_message(const char *portal_name)
 {
 	Portal		portal;
+	uint64		yb_msg_query_id = YbAshGetConstQueryId();
 
 	/*
 	 * Start up a transaction command. (Note that this will normally change
@@ -2985,6 +3031,24 @@ exec_describe_portal_message(const char *portal_name)
 	if (whereToSendOutput != DestRemote)
 		return;					/* can't actually do anything... */
 
+	{
+		ListCell   *lc;
+
+		foreach(lc, portal->stmts)
+		{
+			PlannedStmt *stmt = lfirst_node(PlannedStmt, lc);
+
+			if (stmt->queryId != UINT64CONST(0))
+			{
+				yb_msg_query_id = stmt->queryId;
+				break;
+			}
+		}
+	}
+
+	/* YB: Drain any deferred query_id and push this Describe's cached id. */
+	YbAshSetQueryPlanPairForMessage(yb_msg_query_id);
+
 	if (portal->tupDesc)
 		SendRowDescriptionMessage(&row_description_buf,
 								  portal->tupDesc,
@@ -2992,6 +3056,8 @@ exec_describe_portal_message(const char *portal_name)
 								  portal->formats);
 	else
 		pq_putemptymessage('n');	/* NoData */
+
+	YbAshResetQueryPlanPairForMessage(yb_msg_query_id);
 }
 
 

--- a/src/postgres/src/backend/utils/misc/yb_ash.c
+++ b/src/postgres/src/backend/utils/misc/yb_ash.c
@@ -35,6 +35,7 @@
 #include "libpq/libpq-be.h"
 #include "miscadmin.h"
 #include "optimizer/planner.h"
+#include "parser/analyze.h"
 #include "parser/scansup.h"
 #include "pg_yb_utils.h"
 #include "pgstat.h"
@@ -84,6 +85,7 @@ static ExecutorRun_hook_type prev_ExecutorRun = NULL;
 static ExecutorFinish_hook_type prev_ExecutorFinish = NULL;
 static ExecutorEnd_hook_type prev_ExecutorEnd = NULL;
 static ProcessUtility_hook_type prev_ProcessUtility = NULL;
+static post_parse_analyze_hook_type prev_post_parse_analyze_hook = NULL;
 
 YbAshTrackNestedQueries yb_ash_track_nested_queries = NULL;
 
@@ -108,6 +110,28 @@ static YbAshQueryPlanPairStack qp_pair_stack;
 static int	nested_level = 0;
 static bool pop_qp_pair_before_push = false;
 static YbcAshQueryPlanPair qp_pair_to_be_popped_before_push =
+	{YB_ASH_INVALID_QUERY_ID, YB_ASH_DEFAULT_PLAN_ID};
+
+/*
+ * Coordinate query_id tracking between exec_parse_message and the
+ * post_parse_analyze hook.  Parse cannot push the queryid at entry because
+ * the id is not yet known; the hook pushes it once JumbleQuery runs, and
+ * exec_parse_message pops it on exit using yb_ash_parse_qp_pair.
+ *
+ * Bind and Execute do not need this mechanism: their query_id is available
+ * at message entry, so a straightforward push/pop in the message handler
+ * suffices.
+ *
+ * yb_ash_in_parse_message – true while exec_parse_message is on the call
+ *   stack; guards the hook from pushing a query_id outside a Parse context.
+ * yb_ash_parse_qp_pushed  – true if the hook successfully pushed a qp_pair;
+ *   tells exec_parse_message whether to pop on exit.
+ * yb_ash_parse_qp_pair    – the qp_pair saved by the hook so that
+ *   exec_parse_message can pop it on exit.
+ */
+static bool yb_ash_in_parse_message = false;
+static bool yb_ash_parse_qp_pushed = false;
+static YbcAshQueryPlanPair yb_ash_parse_qp_pair =
 	{YB_ASH_INVALID_QUERY_ID, YB_ASH_DEFAULT_PLAN_ID};
 
 /*
@@ -149,6 +173,7 @@ static void YbAshInstallHooks(void);
 static int	yb_ash_cb_max_entries(void);
 static void YbAshSetQueryPlanPair(YbcAshQueryPlanPair qp_pair);
 static void YbAshResetQueryPlanPair(YbcAshQueryPlanPair qp_pair);
+static void YbAshFlushDeferredPop(void);
 static uint64 yb_ash_utility_query_id(const char *query, int query_len,
 									  int query_location,
 									  bool is_sensitive_stmt);
@@ -168,6 +193,8 @@ static void yb_ash_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 								  ProcessUtilityContext context, ParamListInfo params,
 								  QueryEnvironment *queryEnv, DestReceiver *dest,
 								  QueryCompletion *qc);
+static void yb_ash_post_parse_analyze(ParseState *pstate, Query *query,
+									  JumbleState *jstate);
 
 static const unsigned char *get_top_level_node_id();
 static void YbAshMaybeReplaceSample(PGPROC *proc, int num_procs, TimestampTz sample_time,
@@ -231,6 +258,9 @@ YbAshInit(void)
 void
 YbAshInstallHooks(void)
 {
+	prev_post_parse_analyze_hook = post_parse_analyze_hook;
+	post_parse_analyze_hook = yb_ash_post_parse_analyze;
+
 	prev_ExecutorStart = ExecutorStart_hook;
 	ExecutorStart_hook = yb_ash_ExecutorStart;
 
@@ -378,6 +408,43 @@ ybAshGetQpPair(QueryDesc *queryDesc)
 	if (ShouldResolvePlanId())
 		qp_pair.plan_id = ybGetPlanId(queryDesc->plannedstmt);
 	return qp_pair;
+}
+
+/*
+ * post_parse_analyze hook. When called from exec_parse_message, pushes the
+ * just-computed query_id so post-analysis work (rewriting, plan caching)
+ * attributes correctly. The push is paired with the pop in
+ * YbAshResetQueryPlanPairForMessage at exec_parse_message exit.
+ *
+ * Skips other call sites (exec_simple_query, SPI sub-parse, nested contexts)
+ * because they manage query_id via executor/utility hooks and an unmatched
+ * push here would leak onto the stack.
+ * TODO(#31445): Extend to exec_simple_query and SPI sub-parse by
+ * detecting the call context and issuing a matched push/pop, so Parse-phase
+ * catalog reads are correctly attributed in all code paths.
+ */
+static void
+yb_ash_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate)
+{
+	if (prev_post_parse_analyze_hook)
+		prev_post_parse_analyze_hook(pstate, query, jstate);
+
+	if (!yb_enable_ash)
+		return;
+
+	if (!yb_ash_in_parse_message || yb_ash_parse_qp_pushed)
+		return;
+
+	if (nested_level > 0)
+		return;
+
+	if (query->queryId == YB_ASH_INVALID_QUERY_ID)
+		return;
+
+	yb_ash_parse_qp_pair =
+		(YbcAshQueryPlanPair){query->queryId, YB_ASH_DEFAULT_PLAN_ID};
+	YbAshSetQueryPlanPair(yb_ash_parse_qp_pair);
+	yb_ash_parse_qp_pushed = true;
 }
 
 static void
@@ -645,6 +712,33 @@ YbAshSetMetadata(void)
 	MyProc->yb_ash_metadata.user_id = GetUserId();
 }
 
+/*
+ * Drain a pending deferred pop. Used by YbAshUnsetMetadata and by the
+ * per-message helpers to evict a previous statement's query_id before a new
+ * extended-protocol message starts.
+ */
+static void
+YbAshFlushDeferredPop(void)
+{
+	if (!pop_qp_pair_before_push)
+		return;
+
+	YbcAshQueryPlanPair prev_qp_pair =
+		YbAshQueryPlanPairStackPop(qp_pair_to_be_popped_before_push);
+
+	pop_qp_pair_before_push = false;
+	qp_pair_to_be_popped_before_push =
+		(YbcAshQueryPlanPair){YB_ASH_INVALID_QUERY_ID,
+		YB_ASH_DEFAULT_PLAN_ID};
+
+	if (!YbAshIsInvalidQpPair(prev_qp_pair))
+	{
+		LWLockAcquire(&MyProc->yb_ash_metadata_lock, LW_EXCLUSIVE);
+		MyProc->yb_ash_metadata.qp = prev_qp_pair;
+		LWLockRelease(&MyProc->yb_ash_metadata_lock);
+	}
+}
+
 void
 YbAshUnsetMetadata(void)
 {
@@ -653,31 +747,82 @@ YbAshUnsetMetadata(void)
 	 * returns an error. Reset the stack here. We can remove this if we
 	 * make query_id atomic
 	 */
-	if (pop_qp_pair_before_push)
-	{
-		YbcAshQueryPlanPair prev_qp_pair =
-			YbAshQueryPlanPairStackPop(qp_pair_to_be_popped_before_push);
-
-		pop_qp_pair_before_push = false;
-		qp_pair_to_be_popped_before_push =
-			(YbcAshQueryPlanPair){YB_ASH_INVALID_QUERY_ID,
-			YB_ASH_DEFAULT_PLAN_ID};
-
-		if (!YbAshIsInvalidQpPair(prev_qp_pair))
-		{
-			LWLockAcquire(&MyProc->yb_ash_metadata_lock, LW_EXCLUSIVE);
-			MyProc->yb_ash_metadata.qp = prev_qp_pair;
-			LWLockRelease(&MyProc->yb_ash_metadata_lock);
-		}
-	}
+	YbAshFlushDeferredPop();
 
 	qp_pair_stack.top_index = 0;
 	qp_pair_stack.num_entries_not_pushed = 0;
 
+	/* Reset parse-message state in case an error skipped the matching reset. */
+	yb_ash_in_parse_message = false;
+	yb_ash_parse_qp_pushed = false;
+	yb_ash_parse_qp_pair =
+		(YbcAshQueryPlanPair){YB_ASH_INVALID_QUERY_ID,
+		YB_ASH_DEFAULT_PLAN_ID};
+
 	LWLockAcquire(&MyProc->yb_ash_metadata_lock, LW_EXCLUSIVE);
 	MemSet(MyProc->yb_ash_metadata.root_request_id, 0,
 		   sizeof(MyProc->yb_ash_metadata.root_request_id));
+	MyProc->yb_ash_metadata.qp.query_id = YbAshGetConstQueryId();
 	LWLockRelease(&MyProc->yb_ash_metadata_lock);
+}
+
+/*
+ * Begin handling an extended-protocol message: drain any deferred pop and
+ * push the message's query_id if known. Parse callers pass the default
+ * sentinel (YbAshGetConstQueryId()); the post_parse_analyze hook pushes
+ * the real id later. Bind/Describe/Execute pass the cached query_id.
+ */
+void
+YbAshSetQueryPlanPairForMessage(uint64 query_id)
+{
+	if (!yb_enable_ash)
+		return;
+
+	YbAshFlushDeferredPop();
+
+	if (query_id != YbAshGetConstQueryId())
+	{
+		YbcAshQueryPlanPair qp_pair = {query_id, YB_ASH_DEFAULT_PLAN_ID};
+		YbAshSetQueryPlanPair(qp_pair);
+	}
+	else
+	{
+		yb_ash_in_parse_message = true;
+		yb_ash_parse_qp_pushed = false;
+		yb_ash_parse_qp_pair =
+			(YbcAshQueryPlanPair){YB_ASH_INVALID_QUERY_ID, YB_ASH_DEFAULT_PLAN_ID};
+	}
+}
+
+/*
+ * Symmetric counterpart of YbAshSetQueryPlanPairForMessage. For Parse
+ * (query_id == YbAshGetConstQueryId()), pops whatever the
+ * post_parse_analyze hook pushed (if anything); safe to call when the hook
+ * never fired.
+ */
+void
+YbAshResetQueryPlanPairForMessage(uint64 query_id)
+{
+	if (!yb_enable_ash)
+		return;
+
+	if (query_id == YbAshGetConstQueryId())
+	{
+		yb_ash_in_parse_message = false;
+		if (yb_ash_parse_qp_pushed)
+		{
+			YbAshResetQueryPlanPair(yb_ash_parse_qp_pair);
+			yb_ash_parse_qp_pushed = false;
+			yb_ash_parse_qp_pair =
+				(YbcAshQueryPlanPair){YB_ASH_INVALID_QUERY_ID,
+				YB_ASH_DEFAULT_PLAN_ID};
+		}
+		return;
+	}
+
+	YbcAshQueryPlanPair qp_pair = {query_id, YB_ASH_DEFAULT_PLAN_ID};
+
+	YbAshResetQueryPlanPair(qp_pair);
 }
 
 /*

--- a/src/postgres/src/include/yb_ash.h
+++ b/src/postgres/src/include/yb_ash.h
@@ -85,6 +85,13 @@ extern bool yb_ash_circular_buffer_size_check_hook(int *newval,
 extern void YbAshSetMetadata(void);
 extern void YbAshUnsetMetadata(void);
 
+/*
+ * Per extended-protocol message helpers wrapping Parse/Bind/Execute
+ * so a previous statement's query_id does not leak into the next message
+ */
+extern void YbAshSetQueryPlanPairForMessage(uint64 query_id);
+extern void YbAshResetQueryPlanPairForMessage(uint64 query_id);
+
 extern void YbAshSetOneTimeMetadata(void);
 extern void YbAshSetMetadataForBgworkers(void);
 extern uint64 YbAshGetConstQueryId(void);


### PR DESCRIPTION
Summary:
When using extended query protocol, ASH samples for catalog reads during
Parse are incorrectly attributed to the previous statement. This happens because
the driver can send multiple messages in one batch without an intermediate Sync,
so ASH’s “current query_id” from the prior statement remains active while the next
statement is being parsed/analyzed.

The result is that yb_active_session_history misleadingly shows the previous statement
as doing large amounts of CatalogRead, even though the catalog reads belong to the
subsequent query’s parse/analyze work.

The fix ensures query_id does not leak across extended-protocol messages and
that Parse-phase work isn’t incorrectly attributed to the previous statement.
Per-message ASH helpers are added/used around each extended-protocol message
(Parse, Bind, Execute) to drain any deferred prior query_id before the next
message begins, and to push/pop the message’s query_id when it’s known.

For Parse, since the real queryId is only known after query analysis/jumbling,
the fix coordinates Parse with a post_parse_analyze hook:
- At Parse entry: clear out any prior deferred query_id so Parse-phase catalog reads are no longer mislabeled as the previous statement.
- In post_parse_analyze: once the real queryId exists, push it so any subsequent Parse-adjacent work is attributed correctly.
- At Parse exit: pop/reset the pushed pair so it doesn’t persist into later messages.

Test Plan:
./yb_build.sh release --java-test TestYbAsh#testExtendedProtocolDoesNotLeakQueryId

Made sure the test fails without the fix

Reviewers: ishan.chhangani, aman.mangal, hbhanawat, cagrawal, gaurav.singh, jason

Reviewed By: ishan.chhangani

Subscribers: svc_phabricator, yql

Differential Revision: https://phorge.dev.yugabyte.com/D52788

Original commit: e55ee8774a5ff7780ff783d65184c84c062c27a6