### PR TITLE
[BACKPORT 2026.1][#31706] CDC: Fix TestDropSchemaHidesAssociatedTables flake under TSAN

### DIFF
--- a/src/yb/integration-tests/cdcsdk_consumption_consistent_changes-test.cc
+++ b/src/yb/integration-tests/cdcsdk_consumption_consistent_changes-test.cc
@@ -5462,7 +5462,6 @@ TEST_F(CDCSDKConsumptionConsistentChangesTest, TestDropSchemaHidesAssociatedTabl
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_table_rewrite_for_cdcsdk_table) = true;
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdcsdk_update_restart_time_when_nothing_to_stream) = false;
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdc_parent_tablet_deletion_task_retry_secs) = 1;
-  ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdc_intent_retention_ms) = 5 * 1000;
 
   ASSERT_OK(SetUpWithParams(
       1 /* rf */, 1 /* num_masters */, false /* colocated */,
@@ -5499,6 +5498,12 @@ TEST_F(CDCSDKConsumptionConsistentChangesTest, TestDropSchemaHidesAssociatedTabl
     auto change_resp = ASSERT_RESULT(GetConsistentChangesFromCDC(stream_id));
     ASSERT_EQ(change_resp.cdc_sdk_proto_records_size(), 3);  // BEGIN, INSERT, COMMIT
   }
+
+  // Force-expire the stream so the XReplParentTabletDeletionTask is unblocked from cleaning up the
+  // tablets dropped above. The retention check is `last_active_time + retention < now`, so 0 makes
+  // the stream expire on the next background-task tick. This decouples the wait below from any
+  // TSAN-sensitive retention timing.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdc_intent_retention_ms) = 0;
 
   ASSERT_OK(WaitFor(
       [&]() -> Result<bool> {


### PR DESCRIPTION
DO NOT MERGE!! [CSI](<https://csiweb.dev.yugabyte.com/pull/31900/>) ⏳

Summary:
`CDCSDKConsumptionConsistentChangesTest.TestDropSchemaHidesAssociatedTables` fails under TSAN with a `Stream ID is expired` error (~32% baseline flake rate per the issue). The root cause: the test hardcodes `FLAGS_cdc_intent_retention_ms = 5 * 1000` (5 s) on line 5465, and under TSAN's ~5x slowdown the 5 s retention window can lapse before the test reaches `GetConsistentChangesFromCDC` for all five table DROPs, after which the stream-validity check at `xrepl_catalog_manager.cc:5400` (`last_active_time + retention < now`) flips to expired.

This diff (per @devansh.singhal's review) avoids any TSAN-vs-production timing alignment by removing the override entirely and instead force-expiring the stream once we're done with it:

- **Remove the L5465 override**: the production default for `FLAGS_cdc_intent_retention_ms` is 8 hours (see `consensus/log.cc:236`), which is comfortably longer than the consumption loop regardless of TSAN slowdown, so the stream stays alive for the whole `GetConsistentChangesFromCDC` sequence.
- **Force-expire after the consumption loop (L5501)**: set `FLAGS_cdc_intent_retention_ms = 0` once we've consumed the changes. The `last_active_time + 0 < now` check then returns "expired" on the next background-task tick.

The `WaitFor(60s)` at L5514 then only needs to wait for one or two ticks of the `XReplParentTabletDeletionTask` (which runs every `FLAGS_cdc_parent_tablet_deletion_task_retry_secs = 1 s` per the L5464 override) to clean up the now-orphaned tablets — well under 60 s even on TSAN.

No production-code change. The fix is a test-only restructuring with no `kTimeMultiplier` dependency.

Reference: https://github.com/yugabyte/yugabyte-db/issues/31706

Original commit: 3dad0dd61c72bbe6d5228a555daf2855b042fa85 / D53379

Test Plan: Local TSAN verification: 20 / 20 iterations of `CDCSDKConsumptionConsistentChangesTest.TestDropSchemaHidesAssociatedTables` passed (~72-77 s each, `--test-parallelism 4`) on top of current `origin/master`. Pre-merge CSI to follow.

Reviewers: devansh.singhal

Reviewed By: devansh.singhal

Subscribers: ybase

Differential Revision: https://phorge.dev.yugabyte.com/D53379