### PR TITLE
[#22900] Docs: Fix async xCluster deployment doc examples

### DIFF
--- a/docs/content/stable/deploy/multi-dc/async-replication/async-deployment.md
+++ b/docs/content/stable/deploy/multi-dc/async-replication/async-deployment.md
@@ -34,7 +34,7 @@ Before setting up xCluster replication, ensure you have reviewed the [Prerequisi
 
 After you created the required tables, you can set up unidirectional replication as follows:
 
-- Look up the source universe UUID and the table IDs for the two tables and the index table:
+- Look up the source universe UUID and the table IDs for the tables you want to replicate (including any associated index tables):
 
   - To find a universe's UUID, check `http://yb-master-ip:7000/varz` for `--cluster_uuid`. If it is not available in this location, check the same field in the universe configuration.
 
@@ -112,19 +112,24 @@ When completed, proceed to [Verify replication](#verify-replication).
 
 ## Verify replication
 
-You can verify replication by stopping the workload and then using the `COUNT(*)` function on the target to source match.
+You can verify replication by stopping the workload and comparing row counts (or sample records) between the source and target universes.
 
 ### Unidirectional replication
 
-For unidirectional replication, connect to the target universe using the YSQL shell (ysqlsh) or the YCQL shell (ycqlsh), and confirm that you can see the expected records.
+For unidirectional replication, connect to the target universe using the YSQL shell (ysqlsh) or the YCQL shell (ycqlsh), and confirm that you can see the expected records. For example, using YSQL:
+
+```sql
+SELECT COUNT(*) FROM <table_name>;
+```
+
+Run the same query on the source universe and confirm the counts match.
 
 ### Bidirectional replication
 
-For bidirectional replication, repeat the procedure described in [Unidirectional replication](#unidirectional-replication), but reverse the source and destination information, as follows:
+For bidirectional replication, verify each direction independently after loading data into both universes (as described in [Load data into the source universe](#load-data-into-the-source-universe)):
 
-1. Run `yb-admin setup_universe_replication` on the target universe, pointing to source.
-2. Use the workload generator to start loading data into the target universe.
-3. Verify replication from target to source.
+1. Compare row counts on the target against the source to confirm source-to-target replication.
+1. Compare row counts on the source against the target to confirm target-to-source replication.
 
 To avoid primary key conflict errors, keep the key ranges for the two universes separate. This is done automatically by the applications included in the `yb-sample-apps.jar`.
 
@@ -258,7 +263,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
   - Execute the following commands for the source universe:
 
       ```sh
-    kubectl exec -it -n <source_universe_namespace> -t <source_universe_master_leader> -c <source_universe_container> -- bash
+    kubectl exec -it -n <source_universe_namespace> <source_universe_master_leader> -c <source_universe_container> -- bash
       /home/yugabyte/bin/ysqlsh -h <source_universe_yqlserver>
       create table query
     ```
@@ -266,7 +271,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
     Consider the following example:
 
       ```sh
-    kubectl exec -it -n xcluster-source -t yb-master-2 -c yb-master -- bash
+    kubectl exec -it -n xcluster-source yb-master-2 -c yb-master -- bash
       /home/yugabyte/bin/ysqlsh -h yb-tserver-1.yb-tservers.xcluster-source
       create table employees(id int primary key, name text);
       ```
@@ -274,7 +279,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
   - Execute the following commands for the target universe:
 
       ```sh
-    kubectl exec -it -n <target_universe_namespace> -t <target_universe_master_leader> -c <target_universe_container> -- bash
+    kubectl exec -it -n <target_universe_namespace> <target_universe_master_leader> -c <target_universe_container> -- bash
       /home/yugabyte/bin/ysqlsh -h <target_universe_yqlserver>
       create table query
     ```
@@ -282,7 +287,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
     Consider the following example:
 
       ```sh
-    kubectl exec -it -n xcluster-target -t yb-master-2 -c yb-master -- bash
+    kubectl exec -it -n xcluster-target yb-master-2 -c yb-master -- bash
       /home/yugabyte/bin/ysqlsh -h yb-tserver-1.yb-tservers.xcluster-target
       create table employees(id int primary key, name text);
       ```
@@ -291,7 +296,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
 - Set up replication from the source universe by executing the following command on the source universe:
 
   ```sh
-  kubectl exec -it -n <source_universe_namespace> -t <source_universe_master_leader> -c \
+  kubectl exec -it -n <source_universe_namespace> <source_universe_master_leader> -c \
     <source_universe_container> -- bash -c "/home/yugabyte/bin/yb-admin --master_addresses \
     <target_universe_master_addresses> setup_universe_replication \
     <source_universe_UUID>_<replication_stream_name> <source_universe_master_addresses> \
@@ -301,7 +306,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
   Consider the following example:
 
   ```sh
-  kubectl exec -it -n xcluster-source -t yb-master-2 -c yb-master -- bash -c \
+  kubectl exec -it -n xcluster-source yb-master-2 -c yb-master -- bash -c \
     "/home/yugabyte/bin/yb-admin --master_addresses yb-master-2.yb-masters.xcluster-target.svc.cluster.local, \
     yb-master-1.yb-masters.xcluster-target.svc.cluster.local,yb-master-0.yb-masters.xcluster-target.svc.cluster.local \
     setup_universe_replication ac39666d-c183-45d3-945a-475452deac9f_xCluster_1 \
@@ -312,7 +317,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
 - Perform the following on the source universe and then observe replication on the target universe:
 
   ```sh
-  kubectl exec -it -n <source_universe_namespace> -t <source_universe_master_leader> -c <source_universe_container> -- bash
+  kubectl exec -it -n <source_universe_namespace> <source_universe_master_leader> -c <source_universe_container> -- bash
     /home/yugabyte/bin/ysqlsh -h <source_universe_yqlserver>
     insert query
     select query
@@ -321,7 +326,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
   Consider the following example:
 
   ```sh
-  kubectl exec -it -n xcluster-source -t yb-master-2 -c yb-master -- bash
+  kubectl exec -it -n xcluster-source yb-master-2 -c yb-master -- bash
     /home/yugabyte/bin/ysqlsh -h yb-tserver-1.yb-tservers.xcluster-source
     INSERT INTO employees VALUES(1, 'name');
     SELECT * FROM employees;
@@ -330,7 +335,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
 - Perform the following on the target universe:
 
   ```sh
-  kubectl exec -it -n <target_universe_namespace> -t <target_universe_master_leader> -c <target_universe_container> -- bash
+  kubectl exec -it -n <target_universe_namespace> <target_universe_master_leader> -c <target_universe_container> -- bash
     /home/yugabyte/bin/ysqlsh -h <target_universe_yqlserver>
     select query
   ```
@@ -338,7 +343,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
   Consider the following example:
 
   ```sh
-  kubectl exec -it -n xcluster-target -t yb-master-2 -c yb-master -- bash
+  kubectl exec -it -n xcluster-target yb-master-2 -c yb-master -- bash
     /home/yugabyte/bin/ysqlsh -h yb-tserver-1.yb-tservers.xcluster-target
     SELECT * FROM employees;
   ```
@@ -376,7 +381,7 @@ Proceed as follows:
     table id: 000033e1000030008000000000004006, CDC bootstrap id: c967967523eb4e03bcc201bb464e0679
     ```
 
-1. Take the backup of the tables on the source universe and restore at the target universe by following instructions from [Backup and restore](../../../../manage/backup-restore/snapshot-ysql/).
+1. Take the backup of the tables on the source universe and restore at the target universe by following instructions from [Backup and restore](../../../../manage/backup-restore/snapshot-ysql/).
 1. Execute the following command to set up the replication stream using the bootstrap IDs generated in step 1. Ensure that the bootstrap IDs are in the same order as their corresponding table IDs.
 
     ```sh
@@ -399,7 +404,7 @@ Proceed as follows:
 You can modify the bootstrap as follows:
 
 - To wipe the test setup, use the `delete_universe_replication` command.
-- After running the `bootstrap_cdc_producer` command on the source universe, you can verify that it work as expected by running the `list_cdc_streams` command to view the associated entries: the bootstrap IDs generated by the `bootstrap_cdc_producer` command should match the `stream_id` values you see after executing the `list_cdc_streams` command.
+- After running the `bootstrap_cdc_producer` command on the source universe, you can verify that it works as expected by running the `list_cdc_streams` command to view the associated entries: the bootstrap IDs generated by the `bootstrap_cdc_producer` command should match the `stream_id` values you see after executing the `list_cdc_streams` command.
 
 You can also perform the following modifications:
 
@@ -410,7 +415,7 @@ You can also perform the following modifications:
 
 ## Handling DDL changes
 
-You can execute DDL operations after replication has been already been configured. Depending on the type of DDL operations, additional considerations are required.
+You can execute DDL operations after replication has already been configured. Depending on the type of DDL operations, additional considerations are required.
 
 ### Add new objects (Tables, Partitions, Indexes)
 
@@ -439,7 +444,7 @@ When new tables (or partitions) are created, to ensure that all changes from the
 
 1. Get table IDs of the new partition from the source as follows:
 
-    ```sql
+    ```sh
     yb-admin --master_addresses <source_master_ips> \
     --certs_dir_name <cert_dir> \
     list_tables include_table_id|grep 'order_changes_2023_01'
@@ -448,12 +453,12 @@ When new tables (or partitions) are created, to ensure that all changes from the
     You should see output similar to the following:
 
     ```output
-    yugabyte.order_changes_2021_01 000033e8000030008000000000004106
+    yugabyte.order_changes_2023_01 000033e8000030008000000000004106
     ```
 
 1. Add the new table (or partition) to replication.
 
-   ```sql
+   ```sh
    yb-admin --master_addresses <target_master_ips> \
    --certs_dir_name <cert_dir> \
    alter_universe_replication <replication_group_name> \
@@ -476,7 +481,7 @@ However, to add a new index to a table that already has data, the following addi
 1. Wait for index backfill to finish. For more details, refer to YugabyteDB tips on [monitor backfill progress](https://yugabytedb.tips/?p=2215).
 1. Determine the table ID for `my_new_index`.
 
-   ```sql
+   ```sh
    yb-admin
    --master_addresses <source_master_ips> \
    --certs_dir_name <cert_dir> \
@@ -491,7 +496,7 @@ However, to add a new index to a table that already has data, the following addi
 
 1. Bootstrap the replication stream on the source using the `bootstrap_cdc_producer` API and provide the table ID of the new index as follows:
 
-   ```sql
+   ```sh
    yb-admin
    --master_addresses <source_master_ips> \
    --certs_dir_name <cert_dir> \
@@ -509,7 +514,7 @@ However, to add a new index to a table that already has data, the following addi
 1. Wait for index backfill to finish. For more details, refer to YugabyteDB tips on [monitor backfill progress](https://yugabytedb.tips/?p=2215).
 1. Add the index to replication with the bootstrap ID from Step 4.
 
-    ```sql
+    ```sh
     yb-admin
     --master_addresses <target_master_ips> \
     --certs_dir_name <cert_dir> \
@@ -546,7 +551,7 @@ Objects (tables, indexes, partitions) need to be removed from replication before
 
 1. Get the table ID for the object to be removed from the source.
 
-    ```sql
+    ```sh
     yb-admin --master_addresses <source_master_ips> \
     --certs_dir_name <cert_dir> \
     list_tables include_table_id |grep '<partition_name>'
@@ -554,7 +559,7 @@ Objects (tables, indexes, partitions) need to be removed from replication before
 
 1. Remove the table from replication on the target.
 
-    ```sql
+    ```sh
     yb-admin --master_addresses <target_master_ips> \
     --certs_dir_name <cert_dir> \
     alter_universe_replication <replication_group_name> \
@@ -567,12 +572,14 @@ Alters involving adding/removing columns or modifying data types require replica
 
 1. Pause replication on both sides.
 
-    ```sql
-    yb-admin
-    --master_addresses <target_master_ips>
+    ```sh
+    yb-admin \
+    --master_addresses <target_master_ips> \
     --certs_dir_name <cert_dir> \
     set_universe_replication_enabled <replication_group_name> 0
     ```
+
+   For unidirectional replication, run this on the target (consumer) universe. For bidirectional replication, run it on each universe using that universe's master addresses and the replication group that consumes from the other universe.
 
    You should see output similar to the following:
 
@@ -583,12 +590,14 @@ Alters involving adding/removing columns or modifying data types require replica
 1. Perform the schema modification.
 1. Resume replication as follows:
 
-    ```sql
-    yb-admin
-    --master_addresses <target_master_ips>
+    ```sh
+    yb-admin \
+    --master_addresses <target_master_ips> \
     --certs_dir_name <cert_dir> \
-    set_universe_replication_enabled <replication_group_name> 0
+    set_universe_replication_enabled <replication_group_name> 1
     ```
+
+   Repeat on each universe for bidirectional replication.
 
     ```output
     Replication enabled successfully
@@ -614,7 +623,7 @@ For example, say you have a replicated table `test_table`.
       Example:
 
       ```sql
-      SELECT attmissingval FROM pg_attribute WHERE attrelid='test'::regclass AND attname='test_column';
+      SELECT attmissingval FROM pg_attribute WHERE attrelid='test_table'::regclass AND attname='test_column';
       ```
 
       ```output
@@ -627,5 +636,5 @@ For example, say you have a replicated table `test_table`.
     - Execute the `ADD COLUMN` command on the target with the computed default value.
 
       ```sql
-      ALTER TABLE test ADD COLUMN test_column TIMESTAMP DEFAULT "2024-01-09 12:29:11.88894"
+      ALTER TABLE test_table ADD COLUMN test_column TIMESTAMP DEFAULT '2024-01-09 12:29:11.88894'
       ```

--- a/docs/content/stable/deploy/multi-dc/async-replication/async-deployment.md
+++ b/docs/content/stable/deploy/multi-dc/async-replication/async-deployment.md
@@ -237,17 +237,17 @@ To create unidirectional replication, perform the following:
 
     ```sh
     ./bin/yb-admin --master_addresses <target_master_addresses> \
-    setup_universe_replication <source_universe_UUID>_<replication_stream_name> \
-    <source_master_addresses> <comma_separated_table_ids>
+      setup_universe_replication <source_universe_UUID>_<replication_stream_name> \
+      <source_master_addresses> <comma_separated_table_ids>
     ```
 
     Consider the following example:
 
     ```sh
     ./bin/yb-admin --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
-    setup_universe_replication 00000000-1111-2222-3333-444444444444_xClusterSetup1 \
-    127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
-    000033e1000030008000000000004007,000033e100003000800000000000400d,000033e1000030008000000000004013
+      setup_universe_replication 00000000-1111-2222-3333-444444444444_xClusterSetup1 \
+      127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+      000033e1000030008000000000004007,000033e100003000800000000000400d,000033e1000030008000000000004013
     ```
 
 1. Optionally, if you have access to YugabyteDB Anywhere, you can observe the replication setup (`xClusterSetup1`) by navigating to **Replication** on the source and target universe.
@@ -262,7 +262,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
 
   - Execute the following commands for the source universe:
 
-      ```sh
+    ```sh
     kubectl exec -it -n <source_universe_namespace> <source_universe_master_leader> -c <source_universe_container> -- bash
       /home/yugabyte/bin/ysqlsh -h <source_universe_yqlserver>
       create table query
@@ -270,15 +270,15 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
 
     Consider the following example:
 
-      ```sh
+    ```sh
     kubectl exec -it -n xcluster-source yb-master-2 -c yb-master -- bash
       /home/yugabyte/bin/ysqlsh -h yb-tserver-1.yb-tservers.xcluster-source
       create table employees(id int primary key, name text);
-      ```
+    ```
 
   - Execute the following commands for the target universe:
 
-      ```sh
+    ```sh
     kubectl exec -it -n <target_universe_namespace> <target_universe_master_leader> -c <target_universe_container> -- bash
       /home/yugabyte/bin/ysqlsh -h <target_universe_yqlserver>
       create table query
@@ -286,11 +286,11 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
 
     Consider the following example:
 
-      ```sh
+    ```sh
     kubectl exec -it -n xcluster-target yb-master-2 -c yb-master -- bash
       /home/yugabyte/bin/ysqlsh -h yb-tserver-1.yb-tservers.xcluster-target
       create table employees(id int primary key, name text);
-      ```
+    ```
 
 - Collect table UUIDs by navigating to **Tables** in the Admin UI available at 127.0.0.1:7000. These UUIDs are to be used while setting up replication.
 - Set up replication from the source universe by executing the following command on the source universe:
@@ -363,14 +363,14 @@ Proceed as follows:
 
     ```sh
     ./bin/yb-admin --master_addresses <source_universe_master_addresses> \
-    bootstrap_cdc_producer <comma_separated_source_universe_table_ids>
+      bootstrap_cdc_producer <comma_separated_source_universe_table_ids>
     ```
 
     Consider the following example:
 
     ```sh
     ./bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
-    bootstrap_cdc_producer 000033e1000030008000000000004000,000033e1000030008000000000004003,000033e1000030008000000000004006
+      bootstrap_cdc_producer 000033e1000030008000000000004000,000033e1000030008000000000004003,000033e1000030008000000000004006
     ```
 
     The following output is a list of bootstrap IDs, one per table ID:
@@ -446,8 +446,8 @@ When new tables (or partitions) are created, to ensure that all changes from the
 
     ```sh
     yb-admin --master_addresses <source_master_ips> \
-    --certs_dir_name <cert_dir> \
-    list_tables include_table_id|grep 'order_changes_2023_01'
+      --certs_dir_name <cert_dir> \
+      list_tables include_table_id|grep 'order_changes_2023_01'
     ```
 
     You should see output similar to the following:
@@ -458,18 +458,18 @@ When new tables (or partitions) are created, to ensure that all changes from the
 
 1. Add the new table (or partition) to replication.
 
-   ```sh
-   yb-admin --master_addresses <target_master_ips> \
-   --certs_dir_name <cert_dir> \
-   alter_universe_replication <replication_group_name> \
-   add_table  000033e800003000800000000000410b
-   ```
+    ```sh
+    yb-admin --master_addresses <target_master_ips> \
+      --certs_dir_name <cert_dir> \
+      alter_universe_replication <replication_group_name> \
+      add_table  000033e800003000800000000000410b
+    ```
 
-   You should see output similar to the following:
+    You should see output similar to the following:
 
-   ```output
+    ```output
     Replication altered successfully
-   ```
+    ```
 
 #### Add indexes in unidirectional replication
 
@@ -481,33 +481,31 @@ However, to add a new index to a table that already has data, the following addi
 1. Wait for index backfill to finish. For more details, refer to YugabyteDB tips on [monitor backfill progress](https://yugabytedb.tips/?p=2215).
 1. Determine the table ID for `my_new_index`.
 
-   ```sh
-   yb-admin
-   --master_addresses <source_master_ips> \
-   --certs_dir_name <cert_dir> \
-   list_tables include_table_id|grep 'my_new_index'
-   ```
+    ```sh
+    yb-admin --master_addresses <source_master_ips> \
+      --certs_dir_name <cert_dir> \
+      list_tables include_table_id|grep 'my_new_index'
+    ```
 
-   You should see output similar to the following:
+    You should see output similar to the following:
 
-   ```output
-   000033e8000030008000000000004028
-   ```
+    ```output
+    000033e8000030008000000000004028
+    ```
 
 1. Bootstrap the replication stream on the source using the `bootstrap_cdc_producer` API and provide the table ID of the new index as follows:
 
-   ```sh
-   yb-admin
-   --master_addresses <source_master_ips> \
-   --certs_dir_name <cert_dir> \
-   bootstrap_cdc_producer 000033e8000030008000000000004028
-   ```
+    ```sh
+    yb-admin --master_addresses <source_master_ips> \
+      --certs_dir_name <cert_dir> \
+      bootstrap_cdc_producer 000033e8000030008000000000004028
+    ```
 
-   You should see output similar to the following:
+    You should see output similar to the following:
 
-   ```output
-   table id: 000033e8000030008000000000004028, CDC bootstrap id: c8cba563e39c43feb66689514488591c
-   ```
+    ```output
+    table id: 000033e8000030008000000000004028, CDC bootstrap id: c8cba563e39c43feb66689514488591c
+    ```
 
 1. Wait for replication lag to be 0 on the main table using the replication lag metrics described in [Replication lag](#replication-lag).
 1. Create the same [index](../../../../api/ysql/the-sql-language/statements/ddl_create_index/) on the target.
@@ -515,14 +513,13 @@ However, to add a new index to a table that already has data, the following addi
 1. Add the index to replication with the bootstrap ID from Step 4.
 
     ```sh
-    yb-admin
-    --master_addresses <target_master_ips> \
-    --certs_dir_name <cert_dir> \
-    alter_universe_replication 59e58153-eec6-4cb5-a858-bf685df52316_east-west \
-    add_table  000033e8000030008000000000004028 c8cba563e39c43feb66689514488591c
+    yb-admin --master_addresses <target_master_ips> \
+      --certs_dir_name <cert_dir> \
+      alter_universe_replication 59e58153-eec6-4cb5-a858-bf685df52316_east-west \
+      add_table  000033e8000030008000000000004028 c8cba563e39c43feb66689514488591c
     ```
 
-   You should see output similar to the following:
+    You should see output similar to the following:
 
     ```output
     Replication altered successfully
@@ -553,17 +550,17 @@ Objects (tables, indexes, partitions) need to be removed from replication before
 
     ```sh
     yb-admin --master_addresses <source_master_ips> \
-    --certs_dir_name <cert_dir> \
-    list_tables include_table_id |grep '<partition_name>'
+      --certs_dir_name <cert_dir> \
+      list_tables include_table_id |grep '<partition_name>'
     ```
 
 1. Remove the table from replication on the target.
 
     ```sh
     yb-admin --master_addresses <target_master_ips> \
-    --certs_dir_name <cert_dir> \
-    alter_universe_replication <replication_group_name> \
-    remove_table  000033e800003000800000000000410b
+      --certs_dir_name <cert_dir> \
+      alter_universe_replication <replication_group_name> \
+      remove_table  000033e800003000800000000000410b
     ```
 
 ### Alters
@@ -573,15 +570,14 @@ Alters involving adding/removing columns or modifying data types require replica
 1. Pause replication on both sides.
 
     ```sh
-    yb-admin \
-    --master_addresses <target_master_ips> \
-    --certs_dir_name <cert_dir> \
-    set_universe_replication_enabled <replication_group_name> 0
+    yb-admin --master_addresses <target_master_ips> \
+      --certs_dir_name <cert_dir> \
+      set_universe_replication_enabled <replication_group_name> 0
     ```
 
-   For unidirectional replication, run this on the target (consumer) universe. For bidirectional replication, run it on each universe using that universe's master addresses and the replication group that consumes from the other universe.
+    For unidirectional replication, run this on the target (consumer) universe. For bidirectional replication, run it on each universe using that universe's master addresses and the replication group that consumes from the other universe.
 
-   You should see output similar to the following:
+    You should see output similar to the following:
 
     ```output
     Replication disabled successfully
@@ -591,13 +587,12 @@ Alters involving adding/removing columns or modifying data types require replica
 1. Resume replication as follows:
 
     ```sh
-    yb-admin \
-    --master_addresses <target_master_ips> \
-    --certs_dir_name <cert_dir> \
-    set_universe_replication_enabled <replication_group_name> 1
+    yb-admin --master_addresses <target_master_ips> \
+      --certs_dir_name <cert_dir> \
+      set_universe_replication_enabled <replication_group_name> 1
     ```
 
-   Repeat on each universe for bidirectional replication.
+    Repeat on each universe for bidirectional replication.
 
     ```output
     Replication enabled successfully
@@ -612,9 +607,9 @@ For example, say you have a replicated table `test_table`.
 1. Pause replication on both sides.
 1. Execute add column command on the source:
 
-   ```sql
-   ALTER TABLE test_table ADD COLUMN test_column TIMESTAMP DEFAULT NOW()
-   ```
+    ```sql
+    ALTER TABLE test_table ADD COLUMN test_column TIMESTAMP DEFAULT NOW()
+    ```
 
 1. Run the preceding `ALTER TABLE` command with the computed default value on the target as follows:
 

--- a/docs/content/v2.20/deploy/multi-dc/async-replication/async-deployment.md
+++ b/docs/content/v2.20/deploy/multi-dc/async-replication/async-deployment.md
@@ -28,7 +28,7 @@ If you already have existing data in your tables, follow the bootstrap process d
 
 After you created the required tables, you can set up unidirectional replication as follows:
 
-- Look up the source universe UUID and the table IDs for the two tables and the index table:
+- Look up the source universe UUID and the table IDs for the tables you want to replicate (including any associated index tables):
 
   - To find a universe's UUID, check `http://yb-master-ip:7000/varz` for `--cluster_uuid`. If it is not available in this location, check the same field in the universe configuration.
 
@@ -102,19 +102,24 @@ When completed, proceed to [Verify replication](#verify-replication).
 
 ## Verify replication
 
-You can verify replication by stopping the workload and then using the `COUNT(*)` function on the target to source match.
+You can verify replication by stopping the workload and comparing row counts (or sample records) between the source and target universes.
 
 ### Unidirectional replication
 
-For unidirectional replication, connect to the target universe using the YSQL shell (`ysqlsh`) or the YCQL shell (`ycqlsh`), and confirm that you can see the expected records.
+For unidirectional replication, connect to the target universe using the YSQL shell (`ysqlsh`) or the YCQL shell (`ycqlsh`), and confirm that you can see the expected records. For example, using YSQL:
+
+```sql
+SELECT COUNT(*) FROM <table_name>;
+```
+
+Run the same query on the source universe and confirm the counts match.
 
 ### Bidirectional replication
 
-For bidirectional replication, repeat the procedure described in [Unidirectional replication](#unidirectional-replication), but reverse the source and destination information, as follows:
+For bidirectional replication, verify each direction independently after loading data into both universes (as described in [Load data into the source universe](#load-data-into-the-source-universe)):
 
-1. Run `yb-admin setup_universe_replication` on the target universe, pointing to source.
-2. Use the workload generator to start loading data into the target universe.
-3. Verify replication from target to source.
+1. Compare row counts on the target against the source to confirm source-to-target replication.
+1. Compare row counts on the source against the target to confirm target-to-source replication.
 
 To avoid primary key conflict errors, keep the key ranges for the two universes separate. This is done automatically by the applications included in the `yb-sample-apps.jar`.
 
@@ -288,7 +293,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
   - Execute the following commands for the source universe:
 
       ```sh
-    kubectl exec -it -n <source_universe_namespace> -t <source_universe_master_leader> -c <source_universe_container> -- bash
+    kubectl exec -it -n <source_universe_namespace> <source_universe_master_leader> -c <source_universe_container> -- bash
       /home/yugabyte/bin/ysqlsh -h <source_universe_yqlserver>
       create table query
     ```
@@ -296,7 +301,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
     Consider the following example:
 
       ```sh
-    kubectl exec -it -n xcluster-source -t yb-master-2 -c yb-master -- bash
+    kubectl exec -it -n xcluster-source yb-master-2 -c yb-master -- bash
       /home/yugabyte/bin/ysqlsh -h yb-tserver-1.yb-tservers.xcluster-source
       create table employees(id int primary key, name text);
       ```
@@ -304,7 +309,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
   - Execute the following commands for the target universe:
 
       ```sh
-    kubectl exec -it -n <target_universe_namespace> -t <target_universe_master_leader> -c <target_universe_container> -- bash
+    kubectl exec -it -n <target_universe_namespace> <target_universe_master_leader> -c <target_universe_container> -- bash
       /home/yugabyte/bin/ysqlsh -h <target_universe_yqlserver>
       create table query
     ```
@@ -312,7 +317,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
     Consider the following example:
 
       ```sh
-    kubectl exec -it -n xcluster-target -t yb-master-2 -c yb-master -- bash
+    kubectl exec -it -n xcluster-target yb-master-2 -c yb-master -- bash
       /home/yugabyte/bin/ysqlsh -h yb-tserver-1.yb-tservers.xcluster-target
       create table employees(id int primary key, name text);
       ```
@@ -321,7 +326,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
 - Set up replication from the source universe by executing the following command on the source universe:
 
   ```sh
-  kubectl exec -it -n <source_universe_namespace> -t <source_universe_master_leader> -c \
+  kubectl exec -it -n <source_universe_namespace> <source_universe_master_leader> -c \
     <source_universe_container> -- bash -c "/home/yugabyte/bin/yb-admin --master_addresses \
     <target_universe_master_addresses> setup_universe_replication \
     <source_universe_UUID>_<replication_stream_name> <source_universe_master_addresses> \
@@ -331,7 +336,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
   Consider the following example:
 
   ```sh
-  kubectl exec -it -n xcluster-source -t yb-master-2 -c yb-master -- bash -c \
+  kubectl exec -it -n xcluster-source yb-master-2 -c yb-master -- bash -c \
     "/home/yugabyte/bin/yb-admin --master_addresses yb-master-2.yb-masters.xcluster-target.svc.cluster.local, \
     yb-master-1.yb-masters.xcluster-target.svc.cluster.local,yb-master-0.yb-masters.xcluster-target.svc.cluster.local \
     setup_universe_replication ac39666d-c183-45d3-945a-475452deac9f_xCluster_1 \
@@ -342,7 +347,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
 - Perform the following on the source universe and then observe replication on the target universe:
 
   ```sh
-  kubectl exec -it -n <source_universe_namespace> -t <source_universe_master_leader> -c <source_universe_container> -- bash
+  kubectl exec -it -n <source_universe_namespace> <source_universe_master_leader> -c <source_universe_container> -- bash
     /home/yugabyte/bin/ysqlsh -h <source_universe_yqlserver>
     insert query
     select query
@@ -351,7 +356,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
   Consider the following example:
 
   ```sh
-  kubectl exec -it -n xcluster-source -t yb-master-2 -c yb-master -- bash
+  kubectl exec -it -n xcluster-source yb-master-2 -c yb-master -- bash
     /home/yugabyte/bin/ysqlsh -h yb-tserver-1.yb-tservers.xcluster-source
     INSERT INTO employees VALUES(1, 'name');
     SELECT * FROM employees;
@@ -360,7 +365,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
 - Perform the following on the target universe:
 
   ```sh
-  kubectl exec -it -n <target_universe_namespace> -t <target_universe_master_leader> -c <target_universe_container> -- bash
+  kubectl exec -it -n <target_universe_namespace> <target_universe_master_leader> -c <target_universe_container> -- bash
     /home/yugabyte/bin/ysqlsh -h <target_universe_yqlserver>
     select query
   ```
@@ -368,7 +373,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
   Consider the following example:
 
   ```sh
-  kubectl exec -it -n xcluster-target -t yb-master-2 -c yb-master -- bash
+  kubectl exec -it -n xcluster-target yb-master-2 -c yb-master -- bash
     /home/yugabyte/bin/ysqlsh -h yb-tserver-1.yb-tservers.xcluster-target
     SELECT * FROM employees;
   ```
@@ -406,7 +411,7 @@ Proceed as follows:
     table id: 000033e1000030008000000000004006, CDC bootstrap id: c967967523eb4e03bcc201bb464e0679
     ```
 
-1. Take the backup of the tables on the source universe and restore at the target universe by following instructions from [Backup and restore](../../../../manage/backup-restore/snapshot-ysql/).
+1. Take the backup of the tables on the source universe and restore at the target universe by following instructions from [Backup and restore](../../../../manage/backup-restore/snapshot-ysql/).
 1. Execute the following command to set up the replication stream using the bootstrap IDs generated in step 1. Ensure that the bootstrap IDs are in the same order as their corresponding table IDs.
 
     ```sh
@@ -429,7 +434,7 @@ Proceed as follows:
 You can modify the bootstrap as follows:
 
 - To wipe the test setup, use the `delete_universe_replication` command.
-- After running the `bootstrap_cdc_producer` command on the source universe, you can verify that it work as expected by running the `list_cdc_streams` command to view the associated entries: the bootstrap IDs generated by the `bootstrap_cdc_producer` command should match the `stream_id` values you see after executing the `list_cdc_streams` command.
+- After running the `bootstrap_cdc_producer` command on the source universe, you can verify that it works as expected by running the `list_cdc_streams` command to view the associated entries: the bootstrap IDs generated by the `bootstrap_cdc_producer` command should match the `stream_id` values you see after executing the `list_cdc_streams` command.
 
 You can also perform the following modifications:
 
@@ -440,7 +445,7 @@ You can also perform the following modifications:
 
 ## Handling DDL changes
 
-You can execute DDL operations after replication has been already been configured. Depending on the type of DDL operations, additional considerations are required.
+You can execute DDL operations after replication has already been configured. Depending on the type of DDL operations, additional considerations are required.
 
 ### Add new objects (Tables, Partitions, Indexes)
 
@@ -469,7 +474,7 @@ When new tables (or partitions) are created, to ensure that all changes from the
 
 1. Get table IDs of the new partition from the source as follows:
 
-    ```sql
+    ```sh
     yb-admin --master_addresses <source_master_ips> \
     --certs_dir_name <cert_dir> \
     list_tables include_table_id|grep 'order_changes_2023_01'
@@ -478,12 +483,12 @@ When new tables (or partitions) are created, to ensure that all changes from the
     You should see output similar to the following:
 
     ```output
-    yugabyte.order_changes_2021_01 000033e8000030008000000000004106
+    yugabyte.order_changes_2023_01 000033e8000030008000000000004106
     ```
 
 1. Add the new table (or partition) to replication.
 
-   ```sql
+   ```sh
    yb-admin --master_addresses <target_master_ips> \
    --certs_dir_name <cert_dir> \
    alter_universe_replication <replication_group_name> \
@@ -506,7 +511,7 @@ However, to add a new index to a table that already has data, the following addi
 1. Wait for index backfill to finish. For more details, refer to YugabyteDB tips on [monitor backfill progress](https://yugabytedb.tips/?p=2215).
 1. Determine the table ID for `my_new_index`.
 
-   ```sql
+   ```sh
    yb-admin
    --master_addresses <source_master_ips> \
    --certs_dir_name <cert_dir> \
@@ -521,7 +526,7 @@ However, to add a new index to a table that already has data, the following addi
 
 1. Bootstrap the replication stream on the source using the `bootstrap_cdc_producer` API and provide the table ID of the new index as follows:
 
-   ```sql
+   ```sh
    yb-admin
    --master_addresses <source_master_ips> \
    --certs_dir_name <cert_dir> \
@@ -539,7 +544,7 @@ However, to add a new index to a table that already has data, the following addi
 1. Wait for index backfill to finish. For more details, refer to YugabyteDB tips on [monitor backfill progress](https://yugabytedb.tips/?p=2215).
 1. Add the index to replication with the bootstrap ID from Step 4.
 
-    ```sql
+    ```sh
     yb-admin
     --master_addresses <target_master_ips> \
     --certs_dir_name <cert_dir> \
@@ -547,7 +552,7 @@ However, to add a new index to a table that already has data, the following addi
     add_table  000033e8000030008000000000004028 c8cba563e39c43feb66689514488591c
     ```
 
-   You should see output similar to the following:
+    You should see output similar to the following:
 
     ```output
     Replication altered successfully
@@ -565,7 +570,7 @@ Objects (tables, indexes, partitions) need to be removed from replication before
 
 1. Get the table ID for the object to be removed from the source.
 
-    ```sql
+    ```sh
     yb-admin --master_addresses <source_master_ips> \
     --certs_dir_name <cert_dir> \
     list_tables include_table_id |grep '<partition_name>'
@@ -573,7 +578,7 @@ Objects (tables, indexes, partitions) need to be removed from replication before
 
 1. Remove the table from replication on the target.
 
-    ```sql
+    ```sh
     yb-admin --master_addresses <target_master_ips> \
     --certs_dir_name <cert_dir> \
     alter_universe_replication <replication_group_name> \
@@ -586,14 +591,16 @@ Alters involving adding/removing columns or modifying data types require replica
 
 1. Pause replication on both sides.
 
-    ```sql
-    yb-admin
-    --master_addresses <target_master_ips>
+    ```sh
+    yb-admin \
+    --master_addresses <target_master_ips> \
     --certs_dir_name <cert_dir> \
     set_universe_replication_enabled <replication_group_name> 0
     ```
 
-   You should see output similar to the following:
+    For unidirectional replication, run this on the target (consumer) universe. For bidirectional replication, run it on each universe using that universe's master addresses and the replication group that consumes from the other universe.
+
+    You should see output similar to the following:
 
     ```output
     Replication disabled successfully
@@ -602,12 +609,14 @@ Alters involving adding/removing columns or modifying data types require replica
 1. Perform the schema modification.
 1. Resume replication as follows:
 
-    ```sql
-    yb-admin
-    --master_addresses <target_master_ips>
+    ```sh
+    yb-admin \
+    --master_addresses <target_master_ips> \
     --certs_dir_name <cert_dir> \
-    set_universe_replication_enabled <replication_group_name> 0
+    set_universe_replication_enabled <replication_group_name> 1
     ```
+
+    Repeat on each universe for bidirectional replication.
 
     ```output
     Replication enabled successfully
@@ -633,7 +642,7 @@ For example, say you have a replicated table `test_table`.
       Example:
 
       ```sql
-      SELECT attmissingval FROM pg_attribute WHERE attrelid='test'::regclass AND attname='test_column';
+      SELECT attmissingval FROM pg_attribute WHERE attrelid='test_table'::regclass AND attname='test_column';
       ```
 
       ```output
@@ -646,5 +655,5 @@ For example, say you have a replicated table `test_table`.
     - Execute the `ADD COLUMN` command on the target with the computed default value.
 
       ```sql
-      ALTER TABLE test ADD COLUMN test_column TIMESTAMP DEFAULT "2024-01-09 12:29:11.88894"
+      ALTER TABLE test_table ADD COLUMN test_column TIMESTAMP DEFAULT '2024-01-09 12:29:11.88894'
       ```

--- a/docs/content/v2024.2/deploy/multi-dc/async-replication/async-deployment.md
+++ b/docs/content/v2024.2/deploy/multi-dc/async-replication/async-deployment.md
@@ -1,9 +1,9 @@
 ---
-title: Deploy to two universes with xCluster replication
+title: Deploy non-transactional xCluster replication
 headerTitle: Non-transactional xCluster
 linkTitle: Non-transactional
 description: Deploy using non-transactional unidirectional (master-follower) or bidirectional (multi-master) replication between universes
-headContent: Non-transactional uni- (master-follower) and bi- (multi-master) directional replication
+headContent: Deploy non-transactional uni- (master-follower) and bi- (multi-master) directional replication
 menu:
   v2024.2:
     parent: async-replication
@@ -32,7 +32,7 @@ Before setting up xCluster replication, ensure you have reviewed the [Prerequisi
 
 After you created the required tables, you can set up unidirectional replication as follows:
 
-- Look up the source universe UUID and the table IDs for the two tables and the index table:
+- Look up the source universe UUID and the table IDs for the tables you want to replicate (including any associated index tables):
 
   - To find a universe's UUID, check `http://yb-master-ip:7000/varz` for `--cluster_uuid`. If it is not available in this location, check the same field in the universe configuration.
 
@@ -110,19 +110,24 @@ When completed, proceed to [Verify replication](#verify-replication).
 
 ## Verify replication
 
-You can verify replication by stopping the workload and then using the `COUNT(*)` function on the target to source match.
+You can verify replication by stopping the workload and comparing row counts (or sample records) between the source and target universes.
 
 ### Unidirectional replication
 
-For unidirectional replication, connect to the target universe using the YSQL shell (`ysqlsh`) or the YCQL shell (`ycqlsh`), and confirm that you can see the expected records.
+For unidirectional replication, connect to the target universe using the YSQL shell (`ysqlsh`) or the YCQL shell (`ycqlsh`), and confirm that you can see the expected records. For example, using YSQL:
+
+```sql
+SELECT COUNT(*) FROM <table_name>;
+```
+
+Run the same query on the source universe and confirm the counts match.
 
 ### Bidirectional replication
 
-For bidirectional replication, repeat the procedure described in [Unidirectional replication](#unidirectional-replication), but reverse the source and destination information, as follows:
+For bidirectional replication, verify each direction independently after loading data into both universes (as described in [Load data into the source universe](#load-data-into-the-source-universe)):
 
-1. Run `yb-admin setup_universe_replication` on the target universe, pointing to source.
-2. Use the workload generator to start loading data into the target universe.
-3. Verify replication from target to source.
+1. Compare row counts on the target against the source to confirm source-to-target replication.
+1. Compare row counts on the source against the target to confirm target-to-source replication.
 
 To avoid primary key conflict errors, keep the key ranges for the two universes separate. This is done automatically by the applications included in the `yb-sample-apps.jar`.
 
@@ -230,17 +235,17 @@ To create unidirectional replication, perform the following:
 
     ```sh
     ./bin/yb-admin --master_addresses <target_master_addresses> \
-    setup_universe_replication <source_universe_UUID>_<replication_stream_name> \
-    <source_master_addresses> <comma_separated_table_ids>
+      setup_universe_replication <source_universe_UUID>_<replication_stream_name> \
+      <source_master_addresses> <comma_separated_table_ids>
     ```
 
     Consider the following example:
 
     ```sh
     ./bin/yb-admin --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
-    setup_universe_replication 00000000-1111-2222-3333-444444444444_xClusterSetup1 \
-    127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
-    000033e1000030008000000000004007,000033e100003000800000000000400d,000033e1000030008000000000004013
+      setup_universe_replication 00000000-1111-2222-3333-444444444444_xClusterSetup1 \
+      127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+      000033e1000030008000000000004007,000033e100003000800000000000400d,000033e1000030008000000000004013
     ```
 
 1. Optionally, if you have access to YugabyteDB Anywhere, you can observe the replication setup (`xClusterSetup1`) by navigating to **Replication** on the source and target universe.
@@ -255,41 +260,41 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
 
   - Execute the following commands for the source universe:
 
-      ```sh
-    kubectl exec -it -n <source_universe_namespace> -t <source_universe_master_leader> -c <source_universe_container> -- bash
+    ```sh
+    kubectl exec -it -n <source_universe_namespace> <source_universe_master_leader> -c <source_universe_container> -- bash
       /home/yugabyte/bin/ysqlsh -h <source_universe_yqlserver>
       create table query
     ```
 
     Consider the following example:
 
-      ```sh
-    kubectl exec -it -n xcluster-source -t yb-master-2 -c yb-master -- bash
+    ```sh
+    kubectl exec -it -n xcluster-source yb-master-2 -c yb-master -- bash
       /home/yugabyte/bin/ysqlsh -h yb-tserver-1.yb-tservers.xcluster-source
       create table employees(id int primary key, name text);
-      ```
+    ```
 
   - Execute the following commands for the target universe:
 
-      ```sh
-    kubectl exec -it -n <target_universe_namespace> -t <target_universe_master_leader> -c <target_universe_container> -- bash
+    ```sh
+    kubectl exec -it -n <target_universe_namespace> <target_universe_master_leader> -c <target_universe_container> -- bash
       /home/yugabyte/bin/ysqlsh -h <target_universe_yqlserver>
       create table query
     ```
 
     Consider the following example:
 
-      ```sh
-    kubectl exec -it -n xcluster-target -t yb-master-2 -c yb-master -- bash
+    ```sh
+    kubectl exec -it -n xcluster-target yb-master-2 -c yb-master -- bash
       /home/yugabyte/bin/ysqlsh -h yb-tserver-1.yb-tservers.xcluster-target
       create table employees(id int primary key, name text);
-      ```
+    ```
 
 - Collect table UUIDs by navigating to **Tables** in the Admin UI available at 127.0.0.1:7000. These UUIDs are to be used while setting up replication.
 - Set up replication from the source universe by executing the following command on the source universe:
 
   ```sh
-  kubectl exec -it -n <source_universe_namespace> -t <source_universe_master_leader> -c \
+  kubectl exec -it -n <source_universe_namespace> <source_universe_master_leader> -c \
     <source_universe_container> -- bash -c "/home/yugabyte/bin/yb-admin --master_addresses \
     <target_universe_master_addresses> setup_universe_replication \
     <source_universe_UUID>_<replication_stream_name> <source_universe_master_addresses> \
@@ -299,18 +304,18 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
   Consider the following example:
 
   ```sh
-  kubectl exec -it -n xcluster-source -t yb-master-2 -c yb-master -- bash -c \
+  kubectl exec -it -n xcluster-source yb-master-2 -c yb-master -- bash -c \
     "/home/yugabyte/bin/yb-admin --master_addresses yb-master-2.yb-masters.xcluster-target.svc.cluster.local, \
     yb-master-1.yb-masters.xcluster-target.svc.cluster.local,yb-master-0.yb-masters.xcluster-target.svc.cluster.local \
     setup_universe_replication ac39666d-c183-45d3-945a-475452deac9f_xCluster_1 \
     yb-master-2.yb-masters.xcluster-source.svc.cluster.local,yb-master-1.yb-masters.xcluster-source.svc.cluster.local, \
     yb-master-0.yb-masters.xcluster-source.svc.cluster.local 00004000000030008000000000004001"
-    ```
+  ```
 
 - Perform the following on the source universe and then observe replication on the target universe:
 
   ```sh
-  kubectl exec -it -n <source_universe_namespace> -t <source_universe_master_leader> -c <source_universe_container> -- bash
+  kubectl exec -it -n <source_universe_namespace> <source_universe_master_leader> -c <source_universe_container> -- bash
     /home/yugabyte/bin/ysqlsh -h <source_universe_yqlserver>
     insert query
     select query
@@ -319,7 +324,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
   Consider the following example:
 
   ```sh
-  kubectl exec -it -n xcluster-source -t yb-master-2 -c yb-master -- bash
+  kubectl exec -it -n xcluster-source yb-master-2 -c yb-master -- bash
     /home/yugabyte/bin/ysqlsh -h yb-tserver-1.yb-tservers.xcluster-source
     INSERT INTO employees VALUES(1, 'name');
     SELECT * FROM employees;
@@ -328,7 +333,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
 - Perform the following on the target universe:
 
   ```sh
-  kubectl exec -it -n <target_universe_namespace> -t <target_universe_master_leader> -c <target_universe_container> -- bash
+  kubectl exec -it -n <target_universe_namespace> <target_universe_master_leader> -c <target_universe_container> -- bash
     /home/yugabyte/bin/ysqlsh -h <target_universe_yqlserver>
     select query
   ```
@@ -336,7 +341,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
   Consider the following example:
 
   ```sh
-  kubectl exec -it -n xcluster-target -t yb-master-2 -c yb-master -- bash
+  kubectl exec -it -n xcluster-target yb-master-2 -c yb-master -- bash
     /home/yugabyte/bin/ysqlsh -h yb-tserver-1.yb-tservers.xcluster-target
     SELECT * FROM employees;
   ```
@@ -356,14 +361,14 @@ Proceed as follows:
 
     ```sh
     ./bin/yb-admin --master_addresses <source_universe_master_addresses> \
-    bootstrap_cdc_producer <comma_separated_source_universe_table_ids>
+      bootstrap_cdc_producer <comma_separated_source_universe_table_ids>
     ```
 
     Consider the following example:
 
     ```sh
     ./bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
-    bootstrap_cdc_producer 000033e1000030008000000000004000,000033e1000030008000000000004003,000033e1000030008000000000004006
+      bootstrap_cdc_producer 000033e1000030008000000000004000,000033e1000030008000000000004003,000033e1000030008000000000004006
     ```
 
     The following output is a list of bootstrap IDs, one per table ID:
@@ -374,7 +379,7 @@ Proceed as follows:
     table id: 000033e1000030008000000000004006, CDC bootstrap id: c967967523eb4e03bcc201bb464e0679
     ```
 
-1. Take the backup of the tables on the source universe and restore at the target universe by following instructions from [Backup and restore](../../../../manage/backup-restore/snapshot-ysql/).
+1. Take the backup of the tables on the source universe and restore at the target universe by following instructions from [Backup and restore](../../../../manage/backup-restore/snapshot-ysql/).
 1. Execute the following command to set up the replication stream using the bootstrap IDs generated in step 1. Ensure that the bootstrap IDs are in the same order as their corresponding table IDs.
 
     ```sh
@@ -397,7 +402,7 @@ Proceed as follows:
 You can modify the bootstrap as follows:
 
 - To wipe the test setup, use the `delete_universe_replication` command.
-- After running the `bootstrap_cdc_producer` command on the source universe, you can verify that it work as expected by running the `list_cdc_streams` command to view the associated entries: the bootstrap IDs generated by the `bootstrap_cdc_producer` command should match the `stream_id` values you see after executing the `list_cdc_streams` command.
+- After running the `bootstrap_cdc_producer` command on the source universe, you can verify that it works as expected by running the `list_cdc_streams` command to view the associated entries: the bootstrap IDs generated by the `bootstrap_cdc_producer` command should match the `stream_id` values you see after executing the `list_cdc_streams` command.
 
 You can also perform the following modifications:
 
@@ -408,7 +413,7 @@ You can also perform the following modifications:
 
 ## Handling DDL changes
 
-You can execute DDL operations after replication has been already been configured. Depending on the type of DDL operations, additional considerations are required.
+You can execute DDL operations after replication has already been configured. Depending on the type of DDL operations, additional considerations are required.
 
 ### Add new objects (Tables, Partitions, Indexes)
 
@@ -437,32 +442,32 @@ When new tables (or partitions) are created, to ensure that all changes from the
 
 1. Get table IDs of the new partition from the source as follows:
 
-    ```sql
+    ```sh
     yb-admin --master_addresses <source_master_ips> \
-    --certs_dir_name <cert_dir> \
-    list_tables include_table_id|grep 'order_changes_2023_01'
+      --certs_dir_name <cert_dir> \
+      list_tables include_table_id|grep 'order_changes_2023_01'
     ```
 
     You should see output similar to the following:
 
     ```output
-    yugabyte.order_changes_2021_01 000033e8000030008000000000004106
+    yugabyte.order_changes_2023_01 000033e8000030008000000000004106
     ```
 
 1. Add the new table (or partition) to replication.
 
-   ```sql
-   yb-admin --master_addresses <target_master_ips> \
-   --certs_dir_name <cert_dir> \
-   alter_universe_replication <replication_group_name> \
-   add_table  000033e800003000800000000000410b
-   ```
+    ```sh
+    yb-admin --master_addresses <target_master_ips> \
+      --certs_dir_name <cert_dir> \
+      alter_universe_replication <replication_group_name> \
+      add_table  000033e800003000800000000000410b
+    ```
 
-   You should see output similar to the following:
+    You should see output similar to the following:
 
-   ```output
+    ```output
     Replication altered successfully
-   ```
+    ```
 
 #### Add indexes in unidirectional replication
 
@@ -474,48 +479,45 @@ However, to add a new index to a table that already has data, the following addi
 1. Wait for index backfill to finish. For more details, refer to YugabyteDB tips on [monitor backfill progress](https://yugabytedb.tips/?p=2215).
 1. Determine the table ID for `my_new_index`.
 
-   ```sql
-   yb-admin
-   --master_addresses <source_master_ips> \
-   --certs_dir_name <cert_dir> \
-   list_tables include_table_id|grep 'my_new_index'
-   ```
+    ```sh
+    yb-admin --master_addresses <source_master_ips> \
+      --certs_dir_name <cert_dir> \
+      list_tables include_table_id|grep 'my_new_index'
+    ```
 
-   You should see output similar to the following:
+    You should see output similar to the following:
 
-   ```output
-   000033e8000030008000000000004028
-   ```
+    ```output
+    000033e8000030008000000000004028
+    ```
 
 1. Bootstrap the replication stream on the source using the `bootstrap_cdc_producer` API and provide the table ID of the new index as follows:
 
-   ```sql
-   yb-admin
-   --master_addresses <source_master_ips> \
-   --certs_dir_name <cert_dir> \
-   bootstrap_cdc_producer 000033e8000030008000000000004028
-   ```
+    ```sh
+    yb-admin --master_addresses <source_master_ips> \
+      --certs_dir_name <cert_dir> \
+      bootstrap_cdc_producer 000033e8000030008000000000004028
+    ```
 
-   You should see output similar to the following:
+    You should see output similar to the following:
 
-   ```output
-   table id: 000033e8000030008000000000004028, CDC bootstrap id: c8cba563e39c43feb66689514488591c
-   ```
+    ```output
+    table id: 000033e8000030008000000000004028, CDC bootstrap id: c8cba563e39c43feb66689514488591c
+    ```
 
 1. Wait for replication lag to be 0 on the main table using the replication lag metrics described in [Replication lag](#replication-lag).
 1. Create the same [index](../../../../api/ysql/the-sql-language/statements/ddl_create_index/) on the target.
 1. Wait for index backfill to finish. For more details, refer to YugabyteDB tips on [monitor backfill progress](https://yugabytedb.tips/?p=2215).
 1. Add the index to replication with the bootstrap ID from Step 4.
 
-    ```sql
-    yb-admin
-    --master_addresses <target_master_ips> \
-    --certs_dir_name <cert_dir> \
-    alter_universe_replication 59e58153-eec6-4cb5-a858-bf685df52316_east-west \
-    add_table  000033e8000030008000000000004028 c8cba563e39c43feb66689514488591c
+    ```sh
+    yb-admin --master_addresses <target_master_ips> \
+      --certs_dir_name <cert_dir> \
+      alter_universe_replication 59e58153-eec6-4cb5-a858-bf685df52316_east-west \
+      add_table  000033e8000030008000000000004028 c8cba563e39c43feb66689514488591c
     ```
 
-   You should see output similar to the following:
+    You should see output similar to the following:
 
     ```output
     Replication altered successfully
@@ -548,19 +550,19 @@ Objects (tables, indexes, partitions) need to be removed from replication before
 
 1. Get the table ID for the object to be removed from the source.
 
-    ```sql
+    ```sh
     yb-admin --master_addresses <source_master_ips> \
-    --certs_dir_name <cert_dir> \
-    list_tables include_table_id |grep '<partition_name>'
+      --certs_dir_name <cert_dir> \
+      list_tables include_table_id |grep '<partition_name>'
     ```
 
 1. Remove the table from replication on the target.
 
-    ```sql
+    ```sh
     yb-admin --master_addresses <target_master_ips> \
-    --certs_dir_name <cert_dir> \
-    alter_universe_replication <replication_group_name> \
-    remove_table  000033e800003000800000000000410b
+      --certs_dir_name <cert_dir> \
+      alter_universe_replication <replication_group_name> \
+      remove_table  000033e800003000800000000000410b
     ```
 
 ### Alters
@@ -569,14 +571,15 @@ Alters involving adding/removing columns or modifying data types require replica
 
 1. Pause replication on both sides.
 
-    ```sql
-    yb-admin
-    --master_addresses <target_master_ips>
-    --certs_dir_name <cert_dir> \
-    set_universe_replication_enabled <replication_group_name> 0
+    ```sh
+    yb-admin --master_addresses <target_master_ips> \
+      --certs_dir_name <cert_dir> \
+      set_universe_replication_enabled <replication_group_name> 0
     ```
 
-   You should see output similar to the following:
+    For unidirectional replication, run this on the target (consumer) universe. For bidirectional replication, run it on each universe using that universe's master addresses and the replication group that consumes from the other universe.
+
+    You should see output similar to the following:
 
     ```output
     Replication disabled successfully
@@ -585,12 +588,13 @@ Alters involving adding/removing columns or modifying data types require replica
 1. Perform the schema modification.
 1. Resume replication as follows:
 
-    ```sql
-    yb-admin
-    --master_addresses <target_master_ips>
-    --certs_dir_name <cert_dir> \
-    set_universe_replication_enabled <replication_group_name> 0
+    ```sh
+    yb-admin --master_addresses <target_master_ips> \
+      --certs_dir_name <cert_dir> \
+      set_universe_replication_enabled <replication_group_name> 1
     ```
+
+    Repeat on each universe for bidirectional replication.
 
     ```output
     Replication enabled successfully
@@ -616,7 +620,7 @@ For example, say you have a replicated table `test_table`.
       Example:
 
       ```sql
-      SELECT attmissingval FROM pg_attribute WHERE attrelid='test'::regclass AND attname='test_column';
+      SELECT attmissingval FROM pg_attribute WHERE attrelid='test_table'::regclass AND attname='test_column';
       ```
 
       ```output
@@ -629,5 +633,5 @@ For example, say you have a replicated table `test_table`.
     - Execute the `ADD COLUMN` command on the target with the computed default value.
 
       ```sql
-      ALTER TABLE test ADD COLUMN test_column TIMESTAMP DEFAULT "2024-01-09 12:29:11.88894"
+      ALTER TABLE test_table ADD COLUMN test_column TIMESTAMP DEFAULT '2024-01-09 12:29:11.88894'
       ```

--- a/docs/content/v2025.1/deploy/multi-dc/async-replication/async-deployment.md
+++ b/docs/content/v2025.1/deploy/multi-dc/async-replication/async-deployment.md
@@ -32,7 +32,7 @@ Before setting up xCluster replication, ensure you have reviewed the [Prerequisi
 
 After you created the required tables, you can set up unidirectional replication as follows:
 
-- Look up the source universe UUID and the table IDs for the two tables and the index table:
+- Look up the source universe UUID and the table IDs for the tables you want to replicate (including any associated index tables):
 
   - To find a universe's UUID, check `http://yb-master-ip:7000/varz` for `--cluster_uuid`. If it is not available in this location, check the same field in the universe configuration.
 
@@ -110,19 +110,24 @@ When completed, proceed to [Verify replication](#verify-replication).
 
 ## Verify replication
 
-You can verify replication by stopping the workload and then using the `COUNT(*)` function on the target to source match.
+You can verify replication by stopping the workload and comparing row counts (or sample records) between the source and target universes.
 
 ### Unidirectional replication
 
-For unidirectional replication, connect to the target universe using the YSQL shell (ysqlsh) or the YCQL shell (ycqlsh), and confirm that you can see the expected records.
+For unidirectional replication, connect to the target universe using the YSQL shell (ysqlsh) or the YCQL shell (ycqlsh), and confirm that you can see the expected records. For example, using YSQL:
+
+```sql
+SELECT COUNT(*) FROM <table_name>;
+```
+
+Run the same query on the source universe and confirm the counts match.
 
 ### Bidirectional replication
 
-For bidirectional replication, repeat the procedure described in [Unidirectional replication](#unidirectional-replication), but reverse the source and destination information, as follows:
+For bidirectional replication, verify each direction independently after loading data into both universes (as described in [Load data into the source universe](#load-data-into-the-source-universe)):
 
-1. Run `yb-admin setup_universe_replication` on the target universe, pointing to source.
-2. Use the workload generator to start loading data into the target universe.
-3. Verify replication from target to source.
+1. Compare row counts on the target against the source to confirm source-to-target replication.
+1. Compare row counts on the source against the target to confirm target-to-source replication.
 
 To avoid primary key conflict errors, keep the key ranges for the two universes separate. This is done automatically by the applications included in the `yb-sample-apps.jar`.
 
@@ -230,17 +235,17 @@ To create unidirectional replication, perform the following:
 
     ```sh
     ./bin/yb-admin --master_addresses <target_master_addresses> \
-    setup_universe_replication <source_universe_UUID>_<replication_stream_name> \
-    <source_master_addresses> <comma_separated_table_ids>
+      setup_universe_replication <source_universe_UUID>_<replication_stream_name> \
+      <source_master_addresses> <comma_separated_table_ids>
     ```
 
     Consider the following example:
 
     ```sh
     ./bin/yb-admin --master_addresses 127.0.0.11:7100,127.0.0.12:7100,127.0.0.13:7100 \
-    setup_universe_replication 00000000-1111-2222-3333-444444444444_xClusterSetup1 \
-    127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
-    000033e1000030008000000000004007,000033e100003000800000000000400d,000033e1000030008000000000004013
+      setup_universe_replication 00000000-1111-2222-3333-444444444444_xClusterSetup1 \
+      127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
+      000033e1000030008000000000004007,000033e100003000800000000000400d,000033e1000030008000000000004013
     ```
 
 1. Optionally, if you have access to YugabyteDB Anywhere, you can observe the replication setup (`xClusterSetup1`) by navigating to **Replication** on the source and target universe.
@@ -255,41 +260,41 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
 
   - Execute the following commands for the source universe:
 
-      ```sh
-    kubectl exec -it -n <source_universe_namespace> -t <source_universe_master_leader> -c <source_universe_container> -- bash
+    ```sh
+    kubectl exec -it -n <source_universe_namespace> <source_universe_master_leader> -c <source_universe_container> -- bash
       /home/yugabyte/bin/ysqlsh -h <source_universe_yqlserver>
       create table query
     ```
 
     Consider the following example:
 
-      ```sh
-    kubectl exec -it -n xcluster-source -t yb-master-2 -c yb-master -- bash
+    ```sh
+    kubectl exec -it -n xcluster-source yb-master-2 -c yb-master -- bash
       /home/yugabyte/bin/ysqlsh -h yb-tserver-1.yb-tservers.xcluster-source
       create table employees(id int primary key, name text);
-      ```
+    ```
 
   - Execute the following commands for the target universe:
 
-      ```sh
-    kubectl exec -it -n <target_universe_namespace> -t <target_universe_master_leader> -c <target_universe_container> -- bash
+    ```sh
+    kubectl exec -it -n <target_universe_namespace> <target_universe_master_leader> -c <target_universe_container> -- bash
       /home/yugabyte/bin/ysqlsh -h <target_universe_yqlserver>
       create table query
     ```
 
     Consider the following example:
 
-      ```sh
-    kubectl exec -it -n xcluster-target -t yb-master-2 -c yb-master -- bash
+    ```sh
+    kubectl exec -it -n xcluster-target yb-master-2 -c yb-master -- bash
       /home/yugabyte/bin/ysqlsh -h yb-tserver-1.yb-tservers.xcluster-target
       create table employees(id int primary key, name text);
-      ```
+    ```
 
 - Collect table UUIDs by navigating to **Tables** in the Admin UI available at 127.0.0.1:7000. These UUIDs are to be used while setting up replication.
 - Set up replication from the source universe by executing the following command on the source universe:
 
   ```sh
-  kubectl exec -it -n <source_universe_namespace> -t <source_universe_master_leader> -c \
+  kubectl exec -it -n <source_universe_namespace> <source_universe_master_leader> -c \
     <source_universe_container> -- bash -c "/home/yugabyte/bin/yb-admin --master_addresses \
     <target_universe_master_addresses> setup_universe_replication \
     <source_universe_UUID>_<replication_stream_name> <source_universe_master_addresses> \
@@ -299,7 +304,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
   Consider the following example:
 
   ```sh
-  kubectl exec -it -n xcluster-source -t yb-master-2 -c yb-master -- bash -c \
+  kubectl exec -it -n xcluster-source yb-master-2 -c yb-master -- bash -c \
     "/home/yugabyte/bin/yb-admin --master_addresses yb-master-2.yb-masters.xcluster-target.svc.cluster.local, \
     yb-master-1.yb-masters.xcluster-target.svc.cluster.local,yb-master-0.yb-masters.xcluster-target.svc.cluster.local \
     setup_universe_replication ac39666d-c183-45d3-945a-475452deac9f_xCluster_1 \
@@ -310,7 +315,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
 - Perform the following on the source universe and then observe replication on the target universe:
 
   ```sh
-  kubectl exec -it -n <source_universe_namespace> -t <source_universe_master_leader> -c <source_universe_container> -- bash
+  kubectl exec -it -n <source_universe_namespace> <source_universe_master_leader> -c <source_universe_container> -- bash
     /home/yugabyte/bin/ysqlsh -h <source_universe_yqlserver>
     insert query
     select query
@@ -319,7 +324,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
   Consider the following example:
 
   ```sh
-  kubectl exec -it -n xcluster-source -t yb-master-2 -c yb-master -- bash
+  kubectl exec -it -n xcluster-source yb-master-2 -c yb-master -- bash
     /home/yugabyte/bin/ysqlsh -h yb-tserver-1.yb-tservers.xcluster-source
     INSERT INTO employees VALUES(1, 'name');
     SELECT * FROM employees;
@@ -328,7 +333,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
 - Perform the following on the target universe:
 
   ```sh
-  kubectl exec -it -n <target_universe_namespace> -t <target_universe_master_leader> -c <target_universe_container> -- bash
+  kubectl exec -it -n <target_universe_namespace> <target_universe_master_leader> -c <target_universe_container> -- bash
     /home/yugabyte/bin/ysqlsh -h <target_universe_yqlserver>
     select query
   ```
@@ -336,7 +341,7 @@ In the Kubernetes environment, you can set up a pod to pod connectivity, as foll
   Consider the following example:
 
   ```sh
-  kubectl exec -it -n xcluster-target -t yb-master-2 -c yb-master -- bash
+  kubectl exec -it -n xcluster-target yb-master-2 -c yb-master -- bash
     /home/yugabyte/bin/ysqlsh -h yb-tserver-1.yb-tservers.xcluster-target
     SELECT * FROM employees;
   ```
@@ -356,14 +361,14 @@ Proceed as follows:
 
     ```sh
     ./bin/yb-admin --master_addresses <source_universe_master_addresses> \
-    bootstrap_cdc_producer <comma_separated_source_universe_table_ids>
+      bootstrap_cdc_producer <comma_separated_source_universe_table_ids>
     ```
 
     Consider the following example:
 
     ```sh
     ./bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 \
-    bootstrap_cdc_producer 000033e1000030008000000000004000,000033e1000030008000000000004003,000033e1000030008000000000004006
+      bootstrap_cdc_producer 000033e1000030008000000000004000,000033e1000030008000000000004003,000033e1000030008000000000004006
     ```
 
     The following output is a list of bootstrap IDs, one per table ID:
@@ -374,7 +379,7 @@ Proceed as follows:
     table id: 000033e1000030008000000000004006, CDC bootstrap id: c967967523eb4e03bcc201bb464e0679
     ```
 
-1. Take the backup of the tables on the source universe and restore at the target universe by following instructions from [Backup and restore](../../../../manage/backup-restore/snapshot-ysql/).
+1. Take the backup of the tables on the source universe and restore at the target universe by following instructions from [Backup and restore](../../../../manage/backup-restore/snapshot-ysql/).
 1. Execute the following command to set up the replication stream using the bootstrap IDs generated in step 1. Ensure that the bootstrap IDs are in the same order as their corresponding table IDs.
 
     ```sh
@@ -397,7 +402,7 @@ Proceed as follows:
 You can modify the bootstrap as follows:
 
 - To wipe the test setup, use the `delete_universe_replication` command.
-- After running the `bootstrap_cdc_producer` command on the source universe, you can verify that it work as expected by running the `list_cdc_streams` command to view the associated entries: the bootstrap IDs generated by the `bootstrap_cdc_producer` command should match the `stream_id` values you see after executing the `list_cdc_streams` command.
+- After running the `bootstrap_cdc_producer` command on the source universe, you can verify that it works as expected by running the `list_cdc_streams` command to view the associated entries: the bootstrap IDs generated by the `bootstrap_cdc_producer` command should match the `stream_id` values you see after executing the `list_cdc_streams` command.
 
 You can also perform the following modifications:
 
@@ -408,7 +413,7 @@ You can also perform the following modifications:
 
 ## Handling DDL changes
 
-You can execute DDL operations after replication has been already been configured. Depending on the type of DDL operations, additional considerations are required.
+You can execute DDL operations after replication has already been configured. Depending on the type of DDL operations, additional considerations are required.
 
 ### Add new objects (Tables, Partitions, Indexes)
 
@@ -437,32 +442,32 @@ When new tables (or partitions) are created, to ensure that all changes from the
 
 1. Get table IDs of the new partition from the source as follows:
 
-    ```sql
+    ```sh
     yb-admin --master_addresses <source_master_ips> \
-    --certs_dir_name <cert_dir> \
-    list_tables include_table_id|grep 'order_changes_2023_01'
+      --certs_dir_name <cert_dir> \
+      list_tables include_table_id|grep 'order_changes_2023_01'
     ```
 
     You should see output similar to the following:
 
     ```output
-    yugabyte.order_changes_2021_01 000033e8000030008000000000004106
+    yugabyte.order_changes_2023_01 000033e8000030008000000000004106
     ```
 
 1. Add the new table (or partition) to replication.
 
-   ```sql
-   yb-admin --master_addresses <target_master_ips> \
-   --certs_dir_name <cert_dir> \
-   alter_universe_replication <replication_group_name> \
-   add_table  000033e800003000800000000000410b
-   ```
+    ```sh
+    yb-admin --master_addresses <target_master_ips> \
+      --certs_dir_name <cert_dir> \
+      alter_universe_replication <replication_group_name> \
+      add_table  000033e800003000800000000000410b
+    ```
 
-   You should see output similar to the following:
+    You should see output similar to the following:
 
-   ```output
+    ```output
     Replication altered successfully
-   ```
+    ```
 
 #### Add indexes in unidirectional replication
 
@@ -474,48 +479,45 @@ However, to add a new index to a table that already has data, the following addi
 1. Wait for index backfill to finish. For more details, refer to YugabyteDB tips on [monitor backfill progress](https://yugabytedb.tips/?p=2215).
 1. Determine the table ID for `my_new_index`.
 
-   ```sql
-   yb-admin
-   --master_addresses <source_master_ips> \
-   --certs_dir_name <cert_dir> \
-   list_tables include_table_id|grep 'my_new_index'
-   ```
+    ```sh
+    yb-admin --master_addresses <source_master_ips> \
+      --certs_dir_name <cert_dir> \
+      list_tables include_table_id|grep 'my_new_index'
+    ```
 
-   You should see output similar to the following:
+    You should see output similar to the following:
 
-   ```output
-   000033e8000030008000000000004028
-   ```
+    ```output
+    000033e8000030008000000000004028
+    ```
 
 1. Bootstrap the replication stream on the source using the `bootstrap_cdc_producer` API and provide the table ID of the new index as follows:
 
-   ```sql
-   yb-admin
-   --master_addresses <source_master_ips> \
-   --certs_dir_name <cert_dir> \
-   bootstrap_cdc_producer 000033e8000030008000000000004028
-   ```
+    ```sh
+    yb-admin --master_addresses <source_master_ips> \
+      --certs_dir_name <cert_dir> \
+      bootstrap_cdc_producer 000033e8000030008000000000004028
+    ```
 
-   You should see output similar to the following:
+    You should see output similar to the following:
 
-   ```output
-   table id: 000033e8000030008000000000004028, CDC bootstrap id: c8cba563e39c43feb66689514488591c
-   ```
+    ```output
+    table id: 000033e8000030008000000000004028, CDC bootstrap id: c8cba563e39c43feb66689514488591c
+    ```
 
 1. Wait for replication lag to be 0 on the main table using the replication lag metrics described in [Replication lag](#replication-lag).
 1. Create the same [index](../../../../api/ysql/the-sql-language/statements/ddl_create_index/) on the target.
 1. Wait for index backfill to finish. For more details, refer to YugabyteDB tips on [monitor backfill progress](https://yugabytedb.tips/?p=2215).
 1. Add the index to replication with the bootstrap ID from Step 4.
 
-    ```sql
-    yb-admin
-    --master_addresses <target_master_ips> \
-    --certs_dir_name <cert_dir> \
-    alter_universe_replication 59e58153-eec6-4cb5-a858-bf685df52316_east-west \
-    add_table  000033e8000030008000000000004028 c8cba563e39c43feb66689514488591c
+    ```sh
+    yb-admin --master_addresses <target_master_ips> \
+      --certs_dir_name <cert_dir> \
+      alter_universe_replication 59e58153-eec6-4cb5-a858-bf685df52316_east-west \
+      add_table  000033e8000030008000000000004028 c8cba563e39c43feb66689514488591c
     ```
 
-   You should see output similar to the following:
+    You should see output similar to the following:
 
     ```output
     Replication altered successfully
@@ -544,19 +546,19 @@ Objects (tables, indexes, partitions) need to be removed from replication before
 
 1. Get the table ID for the object to be removed from the source.
 
-    ```sql
+    ```sh
     yb-admin --master_addresses <source_master_ips> \
-    --certs_dir_name <cert_dir> \
-    list_tables include_table_id |grep '<partition_name>'
+      --certs_dir_name <cert_dir> \
+      list_tables include_table_id |grep '<partition_name>'
     ```
 
 1. Remove the table from replication on the target.
 
-    ```sql
+    ```sh
     yb-admin --master_addresses <target_master_ips> \
-    --certs_dir_name <cert_dir> \
-    alter_universe_replication <replication_group_name> \
-    remove_table  000033e800003000800000000000410b
+      --certs_dir_name <cert_dir> \
+      alter_universe_replication <replication_group_name> \
+      remove_table  000033e800003000800000000000410b
     ```
 
 ### Alters
@@ -565,14 +567,15 @@ Alters involving adding/removing columns or modifying data types require replica
 
 1. Pause replication on both sides.
 
-    ```sql
-    yb-admin
-    --master_addresses <target_master_ips>
-    --certs_dir_name <cert_dir> \
-    set_universe_replication_enabled <replication_group_name> 0
+    ```sh
+    yb-admin --master_addresses <target_master_ips> \
+      --certs_dir_name <cert_dir> \
+      set_universe_replication_enabled <replication_group_name> 0
     ```
 
-   You should see output similar to the following:
+    For unidirectional replication, run this on the target (consumer) universe. For bidirectional replication, run it on each universe using that universe's master addresses and the replication group that consumes from the other universe.
+
+    You should see output similar to the following:
 
     ```output
     Replication disabled successfully
@@ -581,12 +584,13 @@ Alters involving adding/removing columns or modifying data types require replica
 1. Perform the schema modification.
 1. Resume replication as follows:
 
-    ```sql
-    yb-admin
-    --master_addresses <target_master_ips>
-    --certs_dir_name <cert_dir> \
-    set_universe_replication_enabled <replication_group_name> 0
+    ```sh
+    yb-admin --master_addresses <target_master_ips> \
+      --certs_dir_name <cert_dir> \
+      set_universe_replication_enabled <replication_group_name> 1
     ```
+
+    Repeat on each universe for bidirectional replication.
 
     ```output
     Replication enabled successfully
@@ -612,7 +616,7 @@ For example, say you have a replicated table `test_table`.
       Example:
 
       ```sql
-      SELECT attmissingval FROM pg_attribute WHERE attrelid='test'::regclass AND attname='test_column';
+      SELECT attmissingval FROM pg_attribute WHERE attrelid='test_table'::regclass AND attname='test_column';
       ```
 
       ```output
@@ -625,5 +629,5 @@ For example, say you have a replicated table `test_table`.
     - Execute the `ADD COLUMN` command on the target with the computed default value.
 
       ```sql
-      ALTER TABLE test ADD COLUMN test_column TIMESTAMP DEFAULT "2024-01-09 12:29:11.88894"
+      ALTER TABLE test_table ADD COLUMN test_column TIMESTAMP DEFAULT '2024-01-09 12:29:11.88894'
       ```


### PR DESCRIPTION
DB-11808
Clarify the attrelid regclass example for adding a column with a non-volatile default, and correct related inconsistencies found during a full-page review of async-deployment.md.

Fixes #22900

The "Add a column with a non-volatile default value" example in the non-transactional xCluster deployment doc used inconsistent table names (`test` vs `test_table`), which made `attrelid='test'::regclass` unclear.

This change aligns the example with `test_table` throughout, uses a valid timestamp literal for the computed default, and fixes other issues found during a full-page review (resume-replication flag, partition name typo, verify-replication steps, kubectl syntax, and yb-admin code fences).

## Test plan

- [ ] Reviewed rendered doc changes for the add-column example and related fixes
- [ ] Confirmed `attrelid='test_table'::regclass` matches the surrounding `test_table` example
- [ ] No runtime or build impact (docs-only change)
