### PR TITLE
Add ENABLE_FINETUNING markdown whole-file chunker

### DIFF
--- a/python/ai/rag_agent/embeddings/embed.py
+++ b/python/ai/rag_agent/embeddings/embed.py
@@ -9,7 +9,8 @@ import psycopg
 import os
 import mimetypes
 
-
+from rag_pipeline.markdown_finetuning_chunker import is_markdown_finetuning_enabled
+from rag_pipeline.markdown_finetuning_chunker import chunk_markdown_whole_file
 AI_PROVIDER_OPENAI = "OPENAI"
 AI_PROVIDER_AWS_BEDROCK = "AWS_BEDROCK"
 
@@ -157,6 +158,73 @@ class EmbeddingsGenerator:
             f"empty/whitespace chunks, {yielded_count} embeddings yielded"
         )
 
+    def _generate_embeddings_for_markdown_finetuning(
+        self,
+        pipeline_id: int,
+        file_location: str,
+        chunk_args=None,
+    ):
+        yielded_count = 0
+        chunk_count = 0
+        empty_chunk_count = 0
+        batch_texts = []
+        for chunk_text in chunk_markdown_whole_file(file_location, chunk_args):
+            chunk_count += 1
+            if chunk_text.strip():
+                batch_texts.append(chunk_text)
+
+                if len(batch_texts) >= self.batch_size:
+                    try:
+                        vectors = self.embedder.embed_documents(batch_texts)
+                        for text, vec in zip(batch_texts, vectors):
+                            yielded_count += 1
+                            yield text, vec
+                    except Exception as e:
+                        logging.error(
+                            f"Failed to generate embeddings for batch "
+                            f"ending at chunk {chunk_count} in file "
+                            f"{file_location}: {str(e)}"
+                        )
+                    batch_texts = []
+
+                    try:
+                        self.pipeline_tracking.update_chunks_processed(
+                            pipeline_id=pipeline_id,
+                            chunks_count=chunk_count
+                        )
+                    except Exception as e:
+                        logging.error(
+                            f"Failed to update embeddings generated: {str(e)}"
+                        )
+            else:
+                empty_chunk_count += 1
+
+        if batch_texts:
+            try:
+                vectors = self.embedder.embed_documents(batch_texts)
+                for text, vec in zip(batch_texts, vectors):
+                    yielded_count += 1
+                    yield text, vec
+            except Exception as e:
+                logging.error(
+                    f"Failed to generate embeddings for final batch "
+                    f"in file {file_location}: {str(e)}"
+                )
+
+        try:
+            self.pipeline_tracking.update_chunks_processed(
+                pipeline_id=pipeline_id, chunks_count=chunk_count
+            )
+        except Exception as e:
+            logging.error(f"Failed to update embeddings generated: {str(e)}")
+
+        logging.info(
+            f"Finished generating embeddings for markdown fine-tuning "
+            f"{file_location}: {chunk_count} total chunks, "
+            f"{empty_chunk_count} empty/whitespace chunks, "
+            f"{yielded_count} embeddings yielded"
+        )
+
     @meko_observe(
         name="Generate Embeddings for PDF Files / EmbeddingsGenerator",
         as_type="embedding",
@@ -300,8 +368,12 @@ class EmbeddingsGenerator:
             return self._generate_embeddings_for_html_file(
                 pipeline_id, file_location, chunk_args
             )
-
         file_type, _ = mimetypes.guess_type(file_location)
+        if is_markdown_finetuning_enabled(file_type):
+            return self._generate_embeddings_for_markdown_finetuning(
+                pipeline_id, file_location, chunk_args
+            )
+
         if file_type in (
             'text/plain',
             'application/json',

--- a/python/ai/rag_agent/rag_pipeline/__init__.py
+++ b/python/ai/rag_agent/rag_pipeline/__init__.py
@@ -31,6 +31,19 @@ _LAZY_EXPORTS = {
         "rag_pipeline.partition_chunk_pipeline",
         "stream_partition_and_chunk",
     ),
+    "chunk_markdown_whole_file": (
+        "rag_pipeline.markdown_finetuning_chunker",
+        "chunk_markdown_whole_file",
+    ),
+    "is_markdown_finetuning_enabled": (
+        "rag_pipeline.markdown_finetuning_chunker",
+        "is_markdown_finetuning_enabled",
+    ),
+    "MekoMarkdownParser": ("rag_pipeline.md_parser", "MekoMarkdownParser"),
+    "parse_markdown": ("rag_pipeline.md_parser", "parse_markdown"),
+    "parse_file": ("rag_pipeline.md_parser", "parse_file"),
+    "ParsedDocument": ("rag_pipeline.md_parser", "ParsedDocument"),
+    "ParsedChunk": ("rag_pipeline.md_parser", "ParsedChunk"),
     "chunk": ("rag_pipeline.chunk", "chunk"),
     "chunk_langchain_docs": (
         "rag_pipeline.chunk", "chunk_langchain_docs",

--- a/python/ai/rag_agent/rag_pipeline/markdown_finetuning_chunker.py
+++ b/python/ai/rag_agent/rag_pipeline/markdown_finetuning_chunker.py
@@ -1,0 +1,40 @@
+import logging
+import os
+from typing import Any, Dict, Generator, Optional
+
+from rag_pipeline.md_parser import parse_markdown
+from rag_pipeline.partition_chunk_pipeline import read_whole_file
+from observability import meko_observe
+
+
+MARKDOWN_MIME_TYPES = frozenset({"text/markdown", "text/x-markdown"})
+_ENV_FLAG = "ENABLE_FINETUNING"
+MAX_MARKDOWN_FILE_SIZE_BYTES = 5 * 1024 * 1024  # 5 MiB
+
+
+def is_markdown_finetuning_enabled(file_type: Optional[str]) -> bool:
+    if file_type not in MARKDOWN_MIME_TYPES:
+        return False
+    return os.getenv(_ENV_FLAG, "false").strip().lower() == "true"
+
+
+@meko_observe(name="Markdown Whole-File Chunking", as_type="span")
+def chunk_markdown_whole_file(
+    file_location: str,
+    chunk_args: Optional[Dict[str, Any]] = None,
+) -> Generator[str, None, None]:
+    # del chunk_args
+
+    full_text = read_whole_file(
+        file_location, max_size_bytes=MAX_MARKDOWN_FILE_SIZE_BYTES
+    )
+
+    doc = parse_markdown(full_text, source_file=file_location)
+    logging.info(
+        f"Markdown fine-tuning chunker: file={file_location}, "
+        f"length={len(full_text)} chars, "
+        f"title={doc.title!r}, chunks={doc.total_chunks}"
+    )
+
+    for chunk in doc.chunks:
+        yield chunk.to_embed_text(doc.title)

--- a/python/ai/rag_agent/rag_pipeline/md_parser.py
+++ b/python/ai/rag_agent/rag_pipeline/md_parser.py
@@ -1,0 +1,466 @@
+from __future__ import annotations
+
+import re
+import hashlib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+import frontmatter
+import mistune
+from langchain_core.documents import Document
+
+@dataclass
+class CodeBlock:
+    language: str
+    code: str
+
+
+@dataclass
+class TableBlock:
+    headers: list[str]
+    rows: list[list[str]]
+
+    def to_prose(self) -> str:
+        """Convert table to key: value prose — embeds cleanly vs raw markdown."""
+        lines = []
+        for row in self.rows:
+            parts = [f"{h}: {v}" for h, v in zip(self.headers, row)]
+            lines.append("; ".join(parts))
+        return "\n".join(lines)
+
+
+@dataclass
+class ParsedChunk:
+    heading_path:  list[str]
+    heading_depth: int
+    text:          str
+    code_blocks:   list[CodeBlock] = field(default_factory=list)
+    tables:        list[TableBlock] = field(default_factory=list)
+    links:         list[str]       = field(default_factory=list)
+    chunk_index:   int = 0
+
+    def to_embed_text(self, doc_title: str = "") -> str:
+        breadcrumb = " > ".join(self.heading_path)
+        lines = []
+        if doc_title:
+            lines.append(f"Document: {doc_title}")
+        lines.append(f"Section: {breadcrumb}")
+        lines.append("")
+        lines.append(self.text)
+        for cb in self.code_blocks:
+            lang = cb.language or "code"
+            lines.append(f"\n[{lang} example]\n{cb.code[:300]}")
+        return "\n".join(lines).strip()
+
+    def to_metadata(self, doc: "ParsedDocument") -> dict[str, Any]:
+        return {
+            "chunk_id":      self._chunk_id(doc.slug),
+            "doc_id":        doc.slug,
+            "source_file":   doc.source_file,
+            "title":         doc.title,
+            "section_title": self.heading_path[-1] if self.heading_path else "",
+            "heading_path":  self.heading_path,
+            "heading_depth": self.heading_depth,
+            "chunk_index":   self.chunk_index,
+            "doc_length":    doc.total_chunks,
+            "tags":          doc.tags,
+            "author":        doc.author,
+            "date":          doc.date,
+            "has_code":      bool(self.code_blocks),
+            "code_langs":    list({cb.language for cb in self.code_blocks if cb.language}),
+            "has_table":     bool(self.tables),
+            "links":         self.links,
+            "token_estimate": len(self.text.split()),   # rough; swap in tiktoken
+            "content_hash":  self._content_hash(),
+        }
+
+    def _chunk_id(self, doc_slug: str) -> str:
+        slug = re.sub(r"[^a-z0-9]+", "-", self.heading_path[-1].lower()).strip("-")
+        return f"{doc_slug}__{slug}__{self.chunk_index}"
+
+    def _content_hash(self) -> str:
+        return hashlib.sha256(self.text.encode()).hexdigest()[:16]
+
+
+@dataclass
+class ParsedDocument:
+    title:           str
+    tags:            list[str]
+    author:          str
+    date:            str
+    slug:            str
+    source_file:     str
+    raw_frontmatter: dict[str, Any] 
+    chunks:          list[ParsedChunk] = field(default_factory=list)
+
+    @property
+    def total_chunks(self) -> int:
+        return len(self.chunks)
+
+def _extract_text(node: dict) -> str:
+    if node.get("type") == "text":
+        return node.get("raw", "")
+    if node.get("type") == "softbreak":
+        return " "
+    if node.get("type") == "linebreak":
+        return "\n"
+    text = ""
+    for child in node.get("children") or []:
+        text += _extract_text(child)
+    return text
+
+
+def _extract_links(node: dict) -> list[str]:
+    links = []
+    if node.get("type") == "link":
+        href = (node.get("attrs") or {}).get("url", "")
+        if href:
+            links.append(href)
+    for child in node.get("children") or []:
+        links.extend(_extract_links(child))
+    return links
+
+
+def _table_to_block(node: dict) -> TableBlock:
+    headers: list[str] = []
+    rows: list[list[str]] = []
+    for child in node.get("children") or []:
+        if child["type"] == "table_head":
+            for cell in child.get("children") or []:
+                headers.append(_extract_text(cell).strip())
+        elif child["type"] == "table_body":
+            for row_node in child.get("children") or []:
+                row = [
+                    _extract_text(cell).strip()
+                    for cell in row_node.get("children") or []
+                ]
+                rows.append(row)
+    return TableBlock(headers=headers, rows=rows)
+
+_MD_PARSER = mistune.create_markdown(renderer=None, plugins=["table"])
+
+
+def parse_markdown(content: str, source_file: str = "") -> ParsedDocument:
+    # ── Step 1: split frontmatter from body ───────────────────────────────────
+    post = frontmatter.loads(content)
+    meta: dict[str, Any] = post.metadata
+    body: str = post.content
+
+    raw_title = str(meta.get("title", ""))
+    slug = str(meta.get(
+        "slug",
+        re.sub(r"[^a-z0-9]+", "-", raw_title.lower()).strip("-") or "doc"
+    ))
+
+    doc = ParsedDocument(
+        title           = raw_title,
+        tags            = list(meta.get("tags") or []),
+        author          = str(meta.get("author", "")),
+        date            = str(meta.get("date", "")),
+        slug            = slug,
+        source_file     = source_file,
+        raw_frontmatter = dict(meta),
+    )
+
+    # ── Step 2: parse body to AST ─────────────────────────────────────────────
+    ast: list[dict] = _MD_PARSER(body) or []
+
+    # ── Step 3: walk AST, split on headings ───────────────────────────────────
+    heading_stack:    list[str] = []
+    current_depth:    int = 0
+    current_text:     list[str] = []
+    current_codes:    list[CodeBlock] = []
+    current_tables:   list[TableBlock] = []
+    current_links:    list[str] = []
+
+    def flush() -> None:
+        if not heading_stack:
+            return
+        # Inline table prose into the text block so it's searchable
+        table_prose = "\n\n".join(t.to_prose() for t in current_tables)
+        full_text = "\n\n".join(filter(None, [
+            "\n\n".join(p for p in current_text if p.strip()),
+            table_prose,
+        ])).strip()
+
+        if full_text or current_codes:
+            chunk = ParsedChunk(
+                heading_path  = list(heading_stack),
+                heading_depth = current_depth,
+                text          = full_text,
+                code_blocks   = list(current_codes),
+                tables        = list(current_tables),
+                links         = list(current_links),
+                chunk_index   = len(doc.chunks),
+            )
+            doc.chunks.append(chunk)
+
+        current_text.clear()
+        current_codes.clear()
+        current_tables.clear()
+        current_links.clear()
+
+    for node in ast:
+        ntype = node.get("type")
+
+        if ntype == "blank_line":
+            continue
+
+        elif ntype == "heading":
+            flush()
+            depth = node["attrs"]["level"]
+            title = _extract_text(node).strip()
+            heading_stack = heading_stack[:depth - 1]
+            heading_stack.append(title)
+            current_depth = depth
+
+        elif ntype == "block_code":
+            lang = (node.get("attrs") or {}).get("info") or ""
+            code = node.get("raw", "").rstrip()
+            current_codes.append(CodeBlock(language=lang, code=code))
+
+        elif ntype == "table":
+            current_tables.append(_table_to_block(node))
+
+        elif ntype in ("paragraph", "block_quote", "list"):
+            current_text.append(_extract_text(node).strip())
+            current_links.extend(_extract_links(node))
+
+    flush()
+    return doc
+
+
+def parse_file(path: str | Path) -> ParsedDocument:
+    p = Path(path)
+    return parse_markdown(p.read_text(encoding="utf-8"), source_file=str(p))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# LangChain-compatible wrapper
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+PAGE_CONTENT_EMBED = "embed"
+PAGE_CONTENT_RAW = "raw"
+_VALID_PAGE_CONTENT_FORMATS = frozenset({PAGE_CONTENT_EMBED, PAGE_CONTENT_RAW})
+
+
+class MekoMarkdownParser:
+    """Markdown parser/splitter compatible with the LangChain text-splitter API.
+
+    Wraps :func:`parse_markdown` so its rich, structure-aware chunks can flow
+    into any LangChain pipeline that expects ``langchain_core.documents.Document``
+    objects (vector stores, retrievers, ``BaseDocumentTransformer`` chains, etc.).
+
+    Each emitted ``Document`` corresponds to one heading-scoped section of the
+    source markdown. Frontmatter, code blocks, tables (rendered as prose), and
+    links are all preserved either inside ``page_content`` (when
+    ``page_content_format="embed"``) or in the metadata.
+
+    The class mirrors the public surface of LangChain splitters so it can be
+    used as a drop-in alternative to ``MarkdownHeaderTextSplitter`` /
+    ``ExperimentalMarkdownSyntaxTextSplitter``:
+
+    * ``split_text(text) -> list[Document]``
+    * ``create_documents(texts, metadatas=None) -> list[Document]``
+    * ``split_documents(documents) -> list[Document]``
+    * ``transform_documents(documents, **kwargs) -> Sequence[Document]``
+    * ``atransform_documents(documents, **kwargs) -> Sequence[Document]``
+
+    Example:
+        ```python
+        parser = MekoMarkdownParser()
+        docs = parser.split_text(open("README.md").read())
+        # docs is list[langchain_core.documents.Document]
+        ```
+    """
+
+    def __init__(
+        self,
+        *,
+        page_content_format: str = PAGE_CONTENT_EMBED,
+        source_metadata_key: str = "source",
+        return_each_line: bool = False,
+        include_raw_frontmatter: bool = False,
+        extra_metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Configure the parser.
+
+        Args:
+            page_content_format: ``"embed"`` (default) emits the full
+                embedding-ready text produced by :meth:`ParsedChunk.to_embed_text`
+                (document title + heading breadcrumb + body + code previews).
+                ``"raw"`` emits only the chunk body text — closer to what the
+                stock LangChain ``MarkdownHeaderTextSplitter`` produces.
+            source_metadata_key: When consuming existing ``Document`` objects via
+                :meth:`split_documents`, the value at this metadata key is used
+                as the ``source_file`` for parsing. Defaults to ``"source"``,
+                which matches the convention used by LangChain document
+                loaders.
+            return_each_line: If ``True``, each non-empty line of a chunk is
+                emitted as its own ``Document`` (sharing the chunk's metadata).
+                Provided for parity with LangChain's
+                ``MarkdownHeaderTextSplitter``.
+            include_raw_frontmatter: If ``True``, attach the parsed YAML
+                frontmatter dict under the ``raw_frontmatter`` metadata key.
+                Off by default since the flat fields (``title``, ``tags``,
+                ``author``, ``date``) are already promoted into metadata.
+            extra_metadata: Optional dict merged into every emitted
+                ``Document``'s metadata. Useful for run-level fields such as
+                ``tenant_id`` or ``ingest_run_id``. Per-chunk keys take
+                precedence on collision.
+        """
+        if page_content_format not in _VALID_PAGE_CONTENT_FORMATS:
+            raise ValueError(
+                f"page_content_format must be one of "
+                f"{sorted(_VALID_PAGE_CONTENT_FORMATS)}, "
+                f"got {page_content_format!r}"
+            )
+        self.page_content_format = page_content_format
+        self.source_metadata_key = source_metadata_key
+        self.return_each_line = return_each_line
+        self.include_raw_frontmatter = include_raw_frontmatter
+        self.extra_metadata: dict[str, Any] = dict(extra_metadata or {})
+
+    # ── Pass-throughs to the underlying parser ───────────────────────────────
+
+    def parse(self, text: str, source_file: str = "") -> ParsedDocument:
+        """Parse markdown into the rich :class:`ParsedDocument` representation."""
+        return parse_markdown(text, source_file=source_file)
+
+    def parse_file(self, path: str | Path) -> ParsedDocument:
+        """Read and parse a markdown file from disk."""
+        return parse_file(path)
+
+    # ── LangChain-compatible API ─────────────────────────────────────────────
+
+    def split_text(self, text: str, source_file: str = "") -> list[Document]:
+        """Split markdown text into a list of LangChain ``Document`` objects.
+
+        Args:
+            text: The full markdown text (frontmatter optional).
+            source_file: Optional path of the source file. Recorded in each
+                emitted ``Document``'s metadata as ``source_file``. The base
+                LangChain ``split_text`` signature is ``(self, text)``; this
+                extra positional argument is keyword-defaulted so calling code
+                that targets the LangChain contract works unchanged.
+
+        Returns:
+            One ``Document`` per heading-scoped chunk produced by
+            :func:`parse_markdown`. When ``return_each_line=True`` is set, each
+            non-empty line of a chunk is emitted as its own ``Document``.
+        """
+        parsed = self.parse(text, source_file=source_file)
+        return self._documents_from_parsed(parsed, base_metadata=None)
+
+    def create_documents(
+        self,
+        texts: list[str],
+        metadatas: list[dict[str, Any]] | None = None,
+    ) -> list[Document]:
+        """Create ``Document`` objects from a list of markdown texts.
+
+        Mirrors :meth:`langchain_text_splitters.TextSplitter.create_documents`.
+        Per-input metadata is merged into every chunk produced from that input;
+        chunk-level metadata wins on key collisions so the structural fields
+        (``heading_path``, ``content_hash``, ...) are never overwritten.
+        """
+        if metadatas is not None and len(metadatas) != len(texts):
+            raise ValueError(
+                f"metadatas length ({len(metadatas)}) must match texts length "
+                f"({len(texts)})"
+            )
+        meta_iter: list[dict[str, Any]] = (
+            list(metadatas) if metadatas is not None else [{} for _ in texts]
+        )
+
+        documents: list[Document] = []
+        for text, meta in zip(texts, meta_iter):
+            base_metadata = dict(meta or {})
+            source_file = str(base_metadata.get(self.source_metadata_key, "") or "")
+            parsed = self.parse(text, source_file=source_file)
+            documents.extend(
+                self._documents_from_parsed(parsed, base_metadata=base_metadata)
+            )
+        return documents
+
+    def split_documents(
+        self, documents: Iterable[Document]
+    ) -> list[Document]:
+        """Split each input ``Document``'s ``page_content`` as markdown.
+
+        Mirrors :meth:`langchain_text_splitters.TextSplitter.split_documents`.
+        The input documents' metadata is propagated onto every output document
+        produced from them.
+        """
+        texts: list[str] = []
+        metadatas: list[dict[str, Any]] = []
+        for doc in documents:
+            texts.append(doc.page_content)
+            metadatas.append(dict(doc.metadata or {}))
+        return self.create_documents(texts, metadatas=metadatas)
+
+    # ── BaseDocumentTransformer-compatible API ───────────────────────────────
+
+    def transform_documents(
+        self, documents: Sequence[Document], **kwargs: Any
+    ) -> Sequence[Document]:
+        """``BaseDocumentTransformer.transform_documents`` shim."""
+        del kwargs
+        return self.split_documents(documents)
+
+    async def atransform_documents(
+        self, documents: Sequence[Document], **kwargs: Any
+    ) -> Sequence[Document]:
+        """Async variant of :meth:`transform_documents` (no real async work)."""
+        del kwargs
+        return self.split_documents(documents)
+
+    # ── Internals ────────────────────────────────────────────────────────────
+
+    def _documents_from_parsed(
+        self,
+        parsed: ParsedDocument,
+        base_metadata: dict[str, Any] | None,
+    ) -> list[Document]:
+        out: list[Document] = []
+        for chunk in parsed.chunks:
+            page_content = self._render_page_content(parsed, chunk)
+            metadata = self._build_metadata(parsed, chunk, base_metadata)
+
+            if self.return_each_line:
+                for line in page_content.splitlines():
+                    if line.strip():
+                        out.append(
+                            Document(page_content=line, metadata=dict(metadata))
+                        )
+            else:
+                out.append(Document(page_content=page_content, metadata=metadata))
+        return out
+
+    def _render_page_content(
+        self, parsed: ParsedDocument, chunk: ParsedChunk
+    ) -> str:
+        if self.page_content_format == PAGE_CONTENT_EMBED:
+            return chunk.to_embed_text(parsed.title)
+        return chunk.text
+
+    def _build_metadata(
+        self,
+        parsed: ParsedDocument,
+        chunk: ParsedChunk,
+        base_metadata: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        metadata: dict[str, Any] = {}
+        if self.extra_metadata:
+            metadata.update(self.extra_metadata)
+        if base_metadata:
+            metadata.update(base_metadata)
+        # Chunk metadata is authoritative — its structural keys
+        # (chunk_id, content_hash, heading_path, ...) must not be overwritten
+        # by upstream metadata blobs.
+        metadata.update(chunk.to_metadata(parsed))
+        if self.include_raw_frontmatter:
+            metadata["raw_frontmatter"] = dict(parsed.raw_frontmatter)
+        return metadata

--- a/python/ai/rag_agent/rag_pipeline/partition_chunk_pipeline.py
+++ b/python/ai/rag_agent/rag_pipeline/partition_chunk_pipeline.py
@@ -1,4 +1,4 @@
-from typing import Generator, Any, Dict
+from typing import Generator, Any, Dict, Optional
 import os
 import boto3
 import logging
@@ -129,3 +129,102 @@ def stream_partition_and_chunk(
     for paragraph in paragraph_stream(lines_iter):
         for chunked_text in chunk(splitter, paragraph, args):
             yield chunked_text
+
+def enforce_size_limit(
+    file_location: str,
+    size_bytes: Optional[int],
+    max_size_bytes: Optional[int],
+) -> None:
+    if size_bytes is None or max_size_bytes is None:
+        return
+    if size_bytes > max_size_bytes:
+        raise ValueError(
+            f"File {file_location} is {size_bytes} bytes which exceeds "
+            f"the {max_size_bytes}-byte "
+            f"({max_size_bytes // (1024 * 1024)} MiB) size limit; "
+            f"rejecting."
+        )
+
+
+def read_whole_file(
+    file_location: str,
+    max_size_bytes: Optional[int] = None,
+) -> str:
+    if file_location.startswith("s3://"):
+        return _read_s3_whole(file_location, max_size_bytes)
+
+    size_bytes = os.path.getsize(file_location)
+    enforce_size_limit(file_location, size_bytes, max_size_bytes)
+    logging.debug(
+        f"Reading file from local: {file_location} ({size_bytes} bytes)"
+    )
+    with open(file_location, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def _read_s3_whole(
+    file_location: str,
+    max_size_bytes: Optional[int],
+) -> str:
+    path = file_location[5:]
+    bucket, key = path.split("/", 1)
+
+    logging.debug(f"Reading file from S3: {file_location}")
+    try:
+        s3 = boto3.client("s3")
+        obj = s3.get_object(Bucket=bucket, Key=key)
+        enforce_size_limit(
+            file_location, obj.get("ContentLength"), max_size_bytes
+        )
+        return obj["Body"].read().decode("utf-8")
+    except ValueError:
+        raise
+    except Exception as e:
+        no_credentials = (
+            "NoCredentialsError" in str(type(e).__name__)
+            or "Unable to locate credentials" in str(e)
+        )
+        if not no_credentials:
+            logging.error(f"Error accessing S3 file {file_location}: {e}")
+            raise RuntimeError(
+                f"Failed to access S3 file {file_location}: {e}"
+            )
+
+        public_url = f"https://{bucket}.s3.amazonaws.com/{key}"
+        logging.warning(
+            f"S3 credentials not found, falling back to public URL for "
+            f"{file_location}: {public_url}"
+        )
+        try:
+            with requests.get(public_url, stream=True) as response:
+                response.raise_for_status()
+                content_length_header = response.headers.get("Content-Length")
+                if content_length_header is not None:
+                    enforce_size_limit(
+                        file_location,
+                        int(content_length_header),
+                        max_size_bytes,
+                    )
+                return response.content.decode("utf-8")
+        except ValueError:
+            raise
+        except requests.exceptions.RequestException as req_e:
+            logging.error(
+                f"Failed to download S3 file using public URL "
+                f"{public_url}: {req_e}"
+            )
+            raise RuntimeError(
+                f"S3 file {file_location} is not accessible via boto3 "
+                f"(no credentials) or as a public URL. Please ensure "
+                f"the S3 object has public read permissions or "
+                f"configure AWS credentials."
+            )
+        except Exception as alt_e:
+            logging.error(
+                f"Unexpected error with alternative S3 download method: "
+                f"{alt_e}"
+            )
+            raise RuntimeError(
+                f"Failed to access S3 file {file_location} using both "
+                f"boto3 and public URL methods: {alt_e}"
+            )

--- a/python/ai/rag_agent/requirements.txt
+++ b/python/ai/rag_agent/requirements.txt
@@ -41,3 +41,8 @@ boto3==1.34.81  # AWS SDK for Python (latest as of 2024-06)
 
 # Langfuse
 langfuse>=3.0.0
+
+# Markdown parsing for ENABLE_FINETUNING whole-file chunker
+# (rag_pipeline/md_parser.py)
+mistune
+python-frontmatter


### PR DESCRIPTION
Optional, env-gated path for embedding markdown files as structured, heading-scoped chunks instead of running them through the generic paragraph/recursive splitter. Off by default — existing behavior for all file types is unchanged unless ENABLE_FINETUNING=true.

- rag_pipeline/md_parser.py: mistune + python-frontmatter parser that emits ParsedDocument / ParsedChunk preserving heading_path, code blocks (with language), tables (rendered as "key: value" prose), and links. Chunks carry rich metadata (chunk_id, doc_id, source_file, heading_path, has_code/code_langs, has_table, content_hash, etc.) and a LangChain-compatible split_text / create_documents / split_documents / transform_documents surface.
- rag_pipeline/markdown_finetuning_chunker.py: is_markdown_finetuning_ enabled() flag + chunk_markdown_whole_file() that reads the file whole (capped at 5 MiB), parses it, and yields one embed-ready string per chunkith a "Document / Section" breadcrumb.
- rag_pipeline/partition_chunk_pipeline.py: new read_whole_file() with size-limit enforcement; supports local paths and s3:// URIs with a public-URL fallback when boto3 has no credentials.
- embeddings/embed.py: route markdown files through the new chunker when the flag is on, batching through embed_documents() at self.batch_size and updating pipeline_tracking per batch.
- rag_pipeline/__init__.py: lazy-export the new symbols.
- requirements.txt: add mistune and python-frontmatter.