### PR TITLE
[DOC-1334] Doc: Clarify advanced restore directory structure and NFS prerequisites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ managed/src/main/java/com/yugabyte/yw/common/operator/io/*
 # AI assistant configuration (local only)
 CLAUDE.local.md
 .claude/scheduled_tasks.lock
+.claude/

--- a/docs/content/stable/releases/yba-releases/v2024.2.md
+++ b/docs/content/stable/releases/yba-releases/v2024.2.md
@@ -91,7 +91,7 @@ Before upgrading, review the information in [Prepare to upgrade YugabyteDB Anywh
 ### Improvements
 
 * Introduces a runtime configuration (enabled by default) to allow local user login even when single sign-on (SSO) is enabled. PLAT-19204
-* Enables Azure Managed Identity for VM-based backups. When taking backups of a VM-based universe to Azure Blob Storage, instead of using an SAS token, you can use the Azure IAM roles assigned to YugabyteDB Anywhere and database nodes to authenticate. PLAT-8708
+* {{<tags/feature/ea idea="986">}}Enables Azure Managed Identity for VM-based backups. When taking backups of a VM-based universe to Azure Blob Storage, instead of using an SAS token, you can use the Azure IAM roles assigned to YugabyteDB Anywhere and database nodes to authenticate. PLAT-8708
 
 ### Bug fixes
 

--- a/docs/content/stable/yugabyte-platform/back-up-restore-universes/back-up-universe-data.md
+++ b/docs/content/stable/yugabyte-platform/back-up-restore-universes/back-up-universe-data.md
@@ -116,7 +116,7 @@ The copied location provides the full path to the backup.
 YugabyteDB Anywhere universe backups are stored using the following folder structure:
 
 ```output
-<storage-address>/sub-directories
+<storage-address>
   /yugabyte_backup    [NFS backups only]
     /univ-<universe-name>-<universe-uuid>
       /<database-name>

--- a/docs/content/stable/yugabyte-platform/back-up-restore-universes/back-up-universe-data.md
+++ b/docs/content/stable/yugabyte-platform/back-up-restore-universes/back-up-universe-data.md
@@ -118,7 +118,7 @@ YugabyteDB Anywhere universe backups are stored using the following folder struc
 ```output
 <storage-address>/sub-directories
   /yugabyte_backup    [NFS backups only]
-    /<univ_name>_<universe-uuid>
+    /univ-<universe-name>-<universe-uuid>
       /<database-name>
         /<backup-series-name>-<backup-series-uuid>
           /<backup-type>
@@ -130,19 +130,19 @@ For example, an S3 backup address would be similar to the following:
 
 ```output
 s3://user_bucket/some/sub/folders
-  /universe-name_a85b5b01-6e0b-4a24-b088-478dafff94e4
+  /univ-myuniverse-a85b5b01-6e0b-4a24-b088-478dafff94e4
     /database1_name
       /ybc_backup-92317948b8e444ba150616bf182a061
         /incremental
-          /20204-01-04T12: 11: 03
+          /2024-01-04T12:11:03
             /multi-table-postgres_40522fc46c69404893392b7d92039b9e
 ```
 
 | Component | Description |
 | :-------- | :---------- |
 | Storage address | The name of the bucket as specified in the [storage configuration](../configure-backup-storage/) that was used for the backup. This can include the path of the sub-folders (if any) in a bucket. For NFS, this will consist only of a path of subfolders. |
-| yugabyte_backup | NFS backups are stored under this directory. The directory is not present for S3, GCS, or Azure storage. |
-| Universe name and UUID | The name of the universe and UUID that was backed up. You can move this folder to a different location, but to successfully restore, do not modify this folder, or any of its contents. |
+| yugabyte_backup | NFS backups are stored under this directory (YugabyteDB Anywhere automatically adds this directory). The directory _is not present_ for S3, GCS, or Azure storage. For NFS storage, you can move this folder to a different location, but to successfully restore, do not modify this folder, or any of its contents. |
+| Universe name and UUID | The name of the universe and UUID that was backed up (prefixed with `univ-`). For cloud storage (not NFS), you can move this folder to a different location, but to successfully restore, do not modify this folder, or any of its contents. |
 | Database or Keyspace name | The name of the Database or Keyspace that was backed up. |
 | Backup series name and UUID | The name of the backup series and YBA-generated UUID. The UUID ensures that YBA can correctly identify the appropriate folder. |
 | Backup type | `full` or `incremental`. Indicates whether the subfolders contain full or incremental backups. |
@@ -182,7 +182,7 @@ Sun, 29 Jun 2025 20:27:05 +0000   Sun, 29 Jun 2025 20:27:11 +0000
 Keyspace Details
 Keyspace 1 Details
 Keyspace   Backup size   Default Location
-yugabyte   63.95 MB      s3://yb-emea-poc-backups/univ-2341a0b9-7b60-4a21-b6f6-6b557e5df036/ybc_backup-b924cda07330487089848e31b61007c4/full/2025-06-29T20:27:05/multi-table-yugabyte_6e7945f5b3e84a7a97eb3d8033b92f9c
+yugabyte   63.95 MB      s3://yb-emea-poc-backups/univ-test-2341a0b9-7b60-4a21-b6f6-6b557e5df036/ybc_backup-b924cda07330487089848e31b61007c4/full/2025-06-29T20:27:05/multi-table-yugabyte_6e7945f5b3e84a7a97eb3d8033b92f9c
 
 Table UUID list
 []
@@ -203,22 +203,34 @@ When moving a backup (for example, for long term storage), be sure to include al
 
 For a successful restore at a later date, none of the sub-components and folder names can be modified (from the sub-directories on down) in the address - only the storage address.
 
-For example, if you have a backup as follows:
+For example, if you have an S3 backup with a storage address of `s3://test_bucket` and the following path:
 
 ```output
-s3://test_bucket/test/univ-xyz
+s3://test_bucket/test/univ-xyz/...
 ```
 
 You can move the backup to a location similar to the following:
 
 ```output
-s3://user_bucket/test/univ-xyz
+s3://user_bucket/test/univ-xyz/...
 ```
 
 However, you can't move it to a different sub-directory inside the bucket such as the following:
 
 ```output
-s3://user_bucket/new-test/univ-xyz
+s3://user_bucket/new-test/univ-xyz/...
+```
+
+If you have an NFS backup with a storage address of `/mnt/backups/test/` and the following path:
+
+```output
+/mnt/backups/test/yugabyte_backup/univ-xyz/...
+```
+
+You can move the backup to a location similar to the following:
+
+```output
+/yb-backups/yugabyte_backup/univ-xyz/...
 ```
 
 To restore from a backup that has been moved, you need to use the [Advanced restore procedure](../restore-universe-data/#advanced-restore-procedure).

--- a/docs/content/stable/yugabyte-platform/back-up-restore-universes/back-up-universe-data.md
+++ b/docs/content/stable/yugabyte-platform/back-up-restore-universes/back-up-universe-data.md
@@ -116,23 +116,22 @@ The copied location provides the full path to the backup.
 YugabyteDB Anywhere universe backups are stored using the following folder structure:
 
 ```output
-<storage-address>
-  /sub-directories
+<storage-address>/sub-directories
+  /yugabyte_backup    [NFS backups only]
     /<univ_name>_<universe-uuid>
-     /<database-name>
-      /<backup-series-name>-<backup-series-uuid>
-        /<backup-type>
-          /<creation-time>
-            /<backup-name>_<uuid>
+      /<database-name>
+        /<backup-series-name>-<backup-series-uuid>
+          /<backup-type>
+            /<creation-time>
+              /<backup-name>_<uuid>
 ```
 
-For example:
+For example, an S3 backup address would be similar to the following:
 
 ```output
-s3://user_bucket
-  /some/sub/folders
-    /universe-name_a85b5b01-6e0b-4a24-b088-478dafff94e4
-     /database1_name
+s3://user_bucket/some/sub/folders
+  /universe-name_a85b5b01-6e0b-4a24-b088-478dafff94e4
+    /database1_name
       /ybc_backup-92317948b8e444ba150616bf182a061
         /incremental
           /20204-01-04T12: 11: 03
@@ -141,8 +140,8 @@ s3://user_bucket
 
 | Component | Description |
 | :-------- | :---------- |
-| Storage address | The name of the bucket as specified in the [storage configuration](../configure-backup-storage/) that was used for the backup. |
-| Sub-directories | The path of the sub-folders (if any) in a bucket. |
+| Storage address | The name of the bucket as specified in the [storage configuration](../configure-backup-storage/) that was used for the backup. This can include the path of the sub-folders (if any) in a bucket. For NFS, this will consist only of a path of subfolders. |
+| yugabyte_backup | NFS backups are stored under this directory. The directory is not present for S3, GCS, or Azure storage. |
 | Universe name and UUID | The name of the universe and UUID that was backed up. You can move this folder to a different location, but to successfully restore, do not modify this folder, or any of its contents. |
 | Database or Keyspace name | The name of the Database or Keyspace that was backed up. |
 | Backup series name and UUID | The name of the backup series and YBA-generated UUID. The UUID ensures that YBA can correctly identify the appropriate folder. |

--- a/docs/content/stable/yugabyte-platform/back-up-restore-universes/back-up-universe-data.md
+++ b/docs/content/stable/yugabyte-platform/back-up-restore-universes/back-up-universe-data.md
@@ -215,7 +215,7 @@ You can move the backup to a location similar to the following:
 s3://user_bucket/new-test/univ-xyz/...
 ```
 
-SImilarly, if you have an NFS backup with a storage address of `/mnt/backups/test/` and the following path:
+Similarly, if you have an NFS backup with a storage address of `/mnt/backups/test/` and the following path:
 
 ```output
 /mnt/backups/test/yugabyte_backup/univ-xyz/...

--- a/docs/content/stable/yugabyte-platform/back-up-restore-universes/back-up-universe-data.md
+++ b/docs/content/stable/yugabyte-platform/back-up-restore-universes/back-up-universe-data.md
@@ -203,7 +203,7 @@ When moving a backup (for example, for long term storage), be sure to include al
 
 For a successful restore at a later date, none of the sub-components and folder names can be modified (from the sub-directories on down) in the address - only the storage address.
 
-For example, if you have an S3 backup with a storage address of `s3://test_bucket` and the following path:
+For example, if you have an S3 backup with a storage address of `s3://test_bucket/test` and the following path:
 
 ```output
 s3://test_bucket/test/univ-xyz/...
@@ -212,16 +212,10 @@ s3://test_bucket/test/univ-xyz/...
 You can move the backup to a location similar to the following:
 
 ```output
-s3://user_bucket/test/univ-xyz/...
-```
-
-However, you can't move it to a different sub-directory inside the bucket such as the following:
-
-```output
 s3://user_bucket/new-test/univ-xyz/...
 ```
 
-If you have an NFS backup with a storage address of `/mnt/backups/test/` and the following path:
+SImilarly, if you have an NFS backup with a storage address of `/mnt/backups/test/` and the following path:
 
 ```output
 /mnt/backups/test/yugabyte_backup/univ-xyz/...

--- a/docs/content/stable/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
+++ b/docs/content/stable/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
@@ -161,8 +161,6 @@ You can configure Azure as your backup target.
 - [Blob container](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal#create-a-container).
 - [SAS Token](https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview?toc=/azure/storage/blobs/toc.json&bc=/azure/storage/blobs/breadcrumb/toc.json) or [Managed identity (IAM)](#azure-managed-identity-authentication).
 
-    Note that you must generate the SAS Token on the Storage Account, not the Container.
-
 ### Create an Azure storage configuration
 
 In YugabyteDB Anywhere:

--- a/docs/content/stable/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
+++ b/docs/content/stable/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
@@ -199,18 +199,13 @@ Before configuring Azure IAM authentication, ensure the following:
 
 - **YugabyteDB Anywhere VM**. Ensure the YugabyteDB Anywhere VM has _one_ of the following:
 
-  - Managed Identity enabled:
-    - In the Azure Portal, navigate to your YugabyteDB Anywhere VM.
-    - Go to **Identity** in the left menu.
-    - Under **System assigned**, set **Status** to **On** and save.
+  - Managed Identity enabled. YugabyteDB Anywhere supports system- and user-assigned managed identity.
 
-    For detailed steps, see [Configure managed identities on Azure virtual machines](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/qs-configure-portal-windows-vm) in the Azure documentation.
+    For more information, refer to [Configure managed identities on Azure virtual machines](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/qs-configure-portal-windows-vm) in the Azure documentation.
 
-  - App registration (Service Principal) configured:
-    - In Azure Portal, navigate to **Azure Active Directory > App registrations**.
-    - Create a new app registration or use an existing one.
-    - Note the **Application (client) ID**, **Directory (tenant) ID**, and create a **Client secret**.
-    - Set the following environment variables on the YugabyteDB Anywhere VM:
+  - App registration (Service Principal) configured.
+
+    Ensure the following environment variables are set on the YugabyteDB Anywhere VM:
 
       ```sh
       AZURE_TENANT_ID=<tenant-id>
@@ -218,13 +213,13 @@ Before configuring Azure IAM authentication, ensure the following:
       AZURE_CLIENT_SECRET=<client-secret>
       ```
 
-    For detailed steps, see [Register a Microsoft Entra app and create a service principal](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal) in the Azure documentation.
+    For more information, refer to [Register a Microsoft Entra app and create a service principal](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal) in the Azure documentation.
 
 - **Database nodes**. Ensure your database nodes are hosted on Azure VMs with one of the following:
 
   - Managed Identity enabled.
 
-    For each database node VM, follow the same steps as for the YugabyteDB Anywhere VM to enable system-assigned managed identity.
+    For each database node VM, enable system- or user-assigned managed identity.
 
     This is the recommended approach as it requires no additional credentials.
 
@@ -238,18 +233,9 @@ Before configuring Azure IAM authentication, ensure the following:
       AZURE_CLIENT_SECRET=<client-secret>
       ```
 
-- **Azure IAM role and permissions**. Assign the **Storage Blob Data Contributor** role (or a stricter role) on the target storage account/container to the Managed Identity or Service Principal:
+- **Azure IAM role and permissions**. Assign the **Storage Blob Data Contributor** role (or a stricter role) on the target storage account/container to the Managed Identity or Service Principal.
 
-  - In Azure Portal, navigate to your **Storage account**.
-  - Go to **Access control (IAM)**.
-  - Click **Add > Add role assignment**.
-  - Select **Storage Blob Data Contributor** role.
-  - Assign access to either:
-    - **Managed Identity**: Select the VM(s) or the system-assigned managed identity.
-    - **Service Principal**: Select the app registration (Service Principal) you created.
-  - Click **Save**.
-
-  For detailed steps, see [Assign Azure roles using the Azure portal](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-portal) in the Azure documentation.
+  For more information, refer to [Assign Azure roles using the Azure portal](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-portal) in the Azure documentation.
 
 #### Configure Azure storage with IAM using the API
 

--- a/docs/content/stable/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
+++ b/docs/content/stable/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
@@ -149,26 +149,6 @@ To create a GCP backup configuration, do the following:
 
 1. Click **Save**.
 
-## Network File System
-
-You can configure Network File System (NFS) as your backup target, as follows:
-
-1. Navigate to **Integrations > Backup > Network File System**.
-
-1. Click **Create NFS Backup** to access the configuration form shown in the following illustration:
-
-    ![NFS Configuration](/images/yp/cloud-provider-configuration-backup-nfs.png)
-
-1. Use the **Configuration Name** field to provide a meaningful name for your storage configuration.
-
-1. Complete the **NFS Storage Path** field by entering `/backup` or another directory that provides read, write, and access permissions to the SSH user of the YugabyteDB Anywhere instance.
-
-1. Click **Save**.
-
-{{< warning title="Prevent back up failure due to NFS unmount on cloud VM restart" >}}
-To avoid potential backup and restore errors, add the NFS mount to `/etc/fstab` on the nodes of universes using the backup configuration. When a cloud VM is restarted, the NFS mount may get unmounted if its entry is not in `/etc/fstab`. This can lead to backup failures, and errors during [backup](../back-up-universe-data/) or [restore](../restore-universe-data/).
-{{< /warning >}}
-
 ## Azure Storage
 
 You can configure Azure as your backup target.
@@ -393,6 +373,26 @@ For multi-region backup configurations with IAM enabled, you do not need to prov
    - No SAS tokens are required for any region when IAM is enabled.
 
 1. Click **Save**. -->
+
+## Network File System
+
+You can configure Network File System (NFS) as your backup target, as follows:
+
+1. Navigate to **Integrations > Backup > Network File System**.
+
+1. Click **Create NFS Backup** to access the configuration form shown in the following illustration:
+
+    ![NFS Configuration](/images/yp/cloud-provider-configuration-backup-nfs.png)
+
+1. Use the **Configuration Name** field to provide a meaningful name for your storage configuration.
+
+1. Complete the **NFS Storage Path** field by entering `/backup` or another directory that provides read, write, and access permissions to the SSH user of the YugabyteDB Anywhere instance.
+
+1. Click **Save**.
+
+{{< warning title="Prevent back up failure due to NFS unmount on cloud VM restart" >}}
+To avoid potential backup and restore errors, add the NFS mount to `/etc/fstab` on the nodes of universes using the backup configuration. When a cloud VM is restarted, the NFS mount may get unmounted if its entry is not in `/etc/fstab`. This can lead to backup failures, and errors during [backup](../back-up-universe-data/) or [restore](../restore-universe-data/).
+{{< /warning >}}
 
 ## Local storage
 

--- a/docs/content/stable/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
+++ b/docs/content/stable/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
@@ -183,7 +183,7 @@ In YugabyteDB Anywhere:
 
 ### Azure Managed Identity authentication
 
-{{<tags/feature/ea idea="986">}}YugabyteDB Anywhere supports Azure Managed Identity (IAM) authentication for backup storage configurations, providing an alternative to SAS tokens.
+{{<tags/feature/ea idea="986">}}YugabyteDB Anywhere supports Azure Managed Identity (IAM) authentication for backup storage configurations, providing an alternative to SAS tokens. (Available in v2025.2.1.0 and later.)
 
 Note that this feature is currently supported only for VM-based universes and via API.
 

--- a/docs/content/stable/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
+++ b/docs/content/stable/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
@@ -161,6 +161,8 @@ You can configure Azure as your backup target.
 - [Blob container](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal#create-a-container).
 - [SAS Token](https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview?toc=/azure/storage/blobs/toc.json&bc=/azure/storage/blobs/breadcrumb/toc.json) or [Managed identity (IAM)](#azure-managed-identity-authentication).
 
+    Note that you must generate the SAS Token on the Storage Account, not the Container.
+
 ### Create an Azure storage configuration
 
 In YugabyteDB Anywhere:

--- a/docs/content/stable/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
+++ b/docs/content/stable/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
@@ -11,6 +11,8 @@ menu:
     parent: back-up-restore-universes
     identifier: configure-backup-storage
     weight: 10
+rightNav:
+  hideH4: true
 type: docs
 ---
 
@@ -153,30 +155,11 @@ To create a GCP backup configuration, do the following:
 
 You can configure Azure as your backup target.
 
-### Configure storage on Azure
+### Prerequisites
 
-1. Create a storage account in Azure, as follows:
-
-    - Navigate to **Portal > Storage Account** and click **Add** (+).
-    - Complete the mandatory fields, such as **Resource group**, **Storage account name**, and **Location**, as per the following illustration:
-
-        ![Azure storage account creation](/images/yp/cloud-provider-configuration-backup-azure-account.png)
-
-1. Create a blob container, as follows:
-
-    - Open the storage account (for example, **storagetestazure**, as shown in the following illustration).
-    - Navigate to **Blob service > Containers > + Container** and then click **Create**.
-
-        ![Azure blob container creation](/images/yp/cloud-provider-configuration-backup-azure-blob-container.png)
-
-1. Generate an SAS Token, as follows:
-
-    - Navigate to **Storage account > Shared access signature**, as shown in the following illustration. (Note that you must generate the SAS Token on the Storage Account, not the Container. Generating the SAS Token on the container will prevent the configuration from being applied.)
-    - Under **Allowed resource types**, select **Container** and **Object**.
-    - Under **Allowed permissions**, select all options as shown.
-    - Click **Generate SAS and connection string** and copy the SAS token.
-
-        ![Azure Shared Access Signature page](/images/yp/cloud-provider-configuration-backup-azure-generate-token.png)
+- Azure storage account.
+- [Blob container](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal#create-a-container).
+- [SAS Token](https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview?toc=/azure/storage/blobs/toc.json&bc=/azure/storage/blobs/breadcrumb/toc.json) or [Managed identity (IAM)](#azure-managed-identity-authentication).
 
 ### Create an Azure storage configuration
 
@@ -190,9 +173,7 @@ In YugabyteDB Anywhere:
 
 1. Use the **Configuration Name** field to provide a meaningful name for your storage configuration.
 
-1. Enter the **Container URL** of the container you created. You can obtain the container URL in Azure by navigating to **Container > Properties**, as shown in the following illustration:
-
-    ![Azure container properties](/images/yp/cloud-provider-configuration-backup-azure-container-properties.png)
+1. Enter the **Container URL** of the container you created. You can obtain the container URL in Azure by navigating to **Container > Properties**.
 
 1. Provide the **SAS Token** you generated. You can copy the SAS Token directly from **Shared access signature** page in Azure.
 

--- a/docs/content/stable/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
+++ b/docs/content/stable/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
@@ -255,24 +255,50 @@ For information regarding components of a backup, refer to [Access backups in st
 
 ### Prerequisites
 
-To perform an advanced restore, you need the following:
+To perform an advanced restore, you need the following.
 
-- If the backup had [encryption at rest enabled](../../security/enable-encryption-at-rest), a matching KMS configuration in the target YugabyteDB Anywhere installation so that the backup can be decrypted.
-- A matching [storage configuration](../configure-backup-storage/) in the target YugabyteDB Anywhere installation with credentials to access the storage where the backup is located.
+#### KMS configuration
 
-    If you are restoring from a backup that was moved to another location, copy the backup to a location with a corresponding storage configuration in YugabyteDB Anywhere.
+If the backup had [encryption at rest enabled](../../security/enable-encryption-at-rest), you need a matching KMS configuration in the target YugabyteDB Anywhere installation so that the backup can be decrypted.
 
-- The storage address of the database or keyspace backup you want to restore.
+#### Storage configuration
 
-    If the backup is on a different YugabyteDB Anywhere installation, you can obtain the location address as follows:
+A matching [storage configuration](../configure-backup-storage/) in the target YugabyteDB Anywhere installation with credentials to access the storage where the backup is located.
 
-    1. In the **Backups** list, click the backup (row) to display the **Backup Details**.
+If you are restoring from a backup that was moved to another location, copy the backup to a location with a corresponding storage configuration in YugabyteDB Anywhere.
 
-    1. In the list of databases (YSQL) or keyspaces (YCQL), click **Copy Location** for the database or keyspace you want to restore. If your backup includes incremental backups, to display the databases or keyspaces, click the down arrow for the increment at which you want to restore.
+#### Backup location
 
-    1. Note the **Storage Config** used by the backup, along with the database or keyspace name.
+The full backup location of the database or keyspace backup you want to restore.
 
-    To determine the address from the backup folder structure, refer to [Access backups in storage](../back-up-universe-data/#access-backups-in-storage).
+You can obtain the address of the backup location as follows:
+
+1. Navigate to **Backups** and click the backup (row) to display the **Backup Details**.
+
+1. In the list of databases (YSQL) or keyspaces (YCQL), click **Copy Location** for the database or keyspace you want to restore. (If your backup includes incremental backups, to display the databases or keyspaces, click the down arrow for the increment at which you want to restore.)
+
+1. Note the **Storage Config** used by the backup, along with the database or keyspace name.
+
+The directory structure of the **Backup location** matters. For a restore to succeed, the YugabyteDB Anywhere requires the full path.
+
+For NFS storage configurations, the configuration path also includes a `yugabyte_backup` directory, which YugabyteDB Anywhere adds automatically when writing backups. The **Backup location** must include this directory. (S3, GCS, and Azure storage configurations do not have this extra directory; the bucket is part of the storage configuration's path itself.)
+
+For example, for an NFS storage configuration with the path `/backup`, a valid location is the following:
+
+```output
+/backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+```
+
+Similarly, for an NFS storage configuration with the path `/mnt/backup/`, a valid location is the following:
+
+```output
+/mnt/backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+```
+
+Everything from the `yugabyte_backup` folder down (or, for cloud storage, everything after the configured bucket and path prefix) must be left unchanged; only the leading storage address can differ, and only if it matches the selected storage configuration and the backup data actually resides there. If you moved or copied the backup to a new folder, please ensure the storage config with the correct path prefix is used to match where the backup data now resides.
+
+For more information on the folder structure of YugabyteDB Anywhere backups, refer to [Access backups in storage](../back-up-universe-data/#access-backups-in-storage).
+
 
 ### Perform an advanced restore
 
@@ -307,22 +333,6 @@ To perform an advanced restore, on the YugabyteDB Anywhere installation where yo
     ```
 
     YugabyteDB Anywhere looks for the backup in `test_bucket/test`, not `user_bucket/test`.
-
-    The directory structure of the **Backup location** matters. YugabyteDB Anywhere determines the location of the backup files by removing the storage configuration's path from the start of the **Backup location** you provide, and then appending whatever remains to the storage configuration's path. As a result, the **Backup location** must begin with the path defined in the selected storage configuration. If it doesn't, the path is constructed incorrectly and the restore fails immediately.
-
-    For NFS storage configurations, the configuration path also includes a `yugabyte_backup` directory, which YugabyteDB Anywhere adds automatically when writing backups. The **Backup location** must include this directory. (S3, GCS, and Azure storage configurations do not have this extra directory; the bucket is part of the storage configuration's path itself.) For example, for an NFS storage configuration with the path `/backup`, a valid location is the following:
-
-    ```output
-    /backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
-    ```
-
-    Similarly, for an NFS storage configuration with the path `/mnt/backup/`, a valid location is the following:
-
-    ```output
-    /mnt/backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
-    ```
-
-    Everything from the `yugabyte_backup` folder down (or, for cloud storage, everything after the configured bucket and path prefix) must be left unchanged; only the leading storage address can differ, and only if it matches the selected storage configuration and the backup data actually resides there. If you moved or copied the backup to a new folder, please ensure the storage config with the correct path prefix is used to match where the backup data now resides.
 
 1. Specify the name of the database or keyspace from which you are performing a restore.
 

--- a/docs/content/stable/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
+++ b/docs/content/stable/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
@@ -33,6 +33,12 @@ Backups from a stable track universe can only be restored to a higher version st
 
     If the topology of the target universe does not match, none of the tablespaces are preserved and all their data is written to the primary region. After the restore, you will have to re-add all the tablespaces. For more information on specifying data placement for tables and indexes, refer to [Tablespaces](../../../explore/going-beyond-sql/tablespaces/).
 
+- If you are restoring from a Network File System (NFS) storage configuration, the entire backup must be readable by the `yugabyte` user. If `yugabyte` does not have read access, it is possible for restores to fail with a "file does not exist" error message.
+
+- If a universe that spans multiple regions is backed up to NFS using a different volume for each region, all the NFS volumes must be synced to contain the full backup. Each node will require access to the full backup.
+
+    - There is a caveat where a node will not require access to backed up tablets if that tablet is pinned to another region using [tablespaces](../../../explore/going-beyond-sql/tablespaces/).
+
 ## Restore an entire or incremental backup
 
 You can restore YugabyteDB universe data from a backup as follows:
@@ -301,6 +307,22 @@ To perform an advanced restore, on the YugabyteDB Anywhere installation where yo
     ```
 
     YugabyteDB Anywhere looks for the backup in `test_bucket/test`, not `user_bucket/test`.
+
+    The directory structure of the **Backup location** matters. YugabyteDB Anywhere determines the location of the backup files by removing the storage configuration's path from the start of the **Backup location** you provide, and then appending whatever remains to the storage configuration's path. As a result, the **Backup location** must begin with the path defined in the selected storage configuration. If it doesn't, the path is constructed incorrectly and the restore fails immediately.
+
+    The configuration path also includes a `yugabyte_backup` directory, which YugabyteDB Anywhere adds automatically when writing backups. The **Backup location** must include this directory. For example, for a storage configuration with the path `/backup`, a valid location is the following:
+
+    ```output
+    /backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+    ```
+
+    Similarly, for a storage configuration with the path `/mnt/backup/`, a valid location is the following:
+
+    ```output
+    /mnt/backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+    ```
+
+    Everything from the `yugabyte_backup` folder down must be left unchanged; only the leading storage address can differ, and only if it matches the selected storage configuration and the backup data actually resides there. If you moved or copied the backup to a new folder, please ensure the storage config with the correct path prefix is used to match where the backup data now resides.
 
 1. Specify the name of the database or keyspace from which you are performing a restore.
 

--- a/docs/content/stable/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
+++ b/docs/content/stable/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
@@ -287,13 +287,13 @@ Everything from the `yugabyte_backup` folder down is required.
 
 If you moved or copied the backup to a new location, make sure the storage configuration has the correct storage address to match the location where the backup data now resides. YugabyteDB Anywhere automatically replaces the storage address of the backup location you provide with the storage address of the storage configuration you select.
 
-For example, if you provide a storage configuration with an address of `s3://newbucket/backups` and the following backup location:
+For example, if you provide a _storage configuration_ with an address of `s3://newbucket/backups` and the following _backup location_:
 
 ```output
 s3://mybucket/yb-backups/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
 ```
 
-YugabyteDB will look in the following location for the backup:
+YugabyteDB Anywhere will look in the following location for the backup:
 
 ```output
 s3://newbucket/backups/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
@@ -311,7 +311,7 @@ If the backup is still being managed by YugabyteDB Anywhere, you can obtain the 
 
 #### KMS configuration
 
-If the backup had [encryption at rest enabled](../../security/enable-encryption-at-rest), you need a matching KMS configuration in the target YugabyteDB Anywhere installation so that the backup can be decrypted.
+If the backup had [encryption at rest enabled](../../security/enable-encryption-at-rest), you need a matching [KMS configuration](../../security/create-kms-config/aws-kms/) in the target YugabyteDB Anywhere installation so that the backup can be decrypted.
 
 ### Perform an advanced restore
 

--- a/docs/content/stable/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
+++ b/docs/content/stable/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
@@ -37,7 +37,7 @@ Backups from a stable track universe can only be restored to a higher version st
 
 - If a universe that spans multiple regions is backed up to NFS using a different volume for each region, all the NFS volumes must be synced to contain the full backup. Each node will require access to the full backup.
 
-    - There is a caveat where a node will not require access to backed up tablets if that tablet is pinned to another region using [tablespaces](../../../explore/going-beyond-sql/tablespaces/).
+    [Tablespaces](../../../explore/going-beyond-sql/tablespaces/) are an exception. A node doesn't require access to backed up tablets if that tablet is pinned to another region using a tablespace.
 
 ## Restore an entire or incremental backup
 

--- a/docs/content/stable/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
+++ b/docs/content/stable/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
@@ -310,19 +310,19 @@ To perform an advanced restore, on the YugabyteDB Anywhere installation where yo
 
     The directory structure of the **Backup location** matters. YugabyteDB Anywhere determines the location of the backup files by removing the storage configuration's path from the start of the **Backup location** you provide, and then appending whatever remains to the storage configuration's path. As a result, the **Backup location** must begin with the path defined in the selected storage configuration. If it doesn't, the path is constructed incorrectly and the restore fails immediately.
 
-    The configuration path also includes a `yugabyte_backup` directory, which YugabyteDB Anywhere adds automatically when writing backups. The **Backup location** must include this directory. For example, for a storage configuration with the path `/backup`, a valid location is the following:
+    For NFS storage configurations, the configuration path also includes a `yugabyte_backup` directory, which YugabyteDB Anywhere adds automatically when writing backups. The **Backup location** must include this directory. (S3, GCS, and Azure storage configurations do not have this extra directory; the bucket is part of the storage configuration's path itself.) For example, for an NFS storage configuration with the path `/backup`, a valid location is the following:
 
     ```output
     /backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
     ```
 
-    Similarly, for a storage configuration with the path `/mnt/backup/`, a valid location is the following:
+    Similarly, for an NFS storage configuration with the path `/mnt/backup/`, a valid location is the following:
 
     ```output
     /mnt/backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
     ```
 
-    Everything from the `yugabyte_backup` folder down must be left unchanged; only the leading storage address can differ, and only if it matches the selected storage configuration and the backup data actually resides there. If you moved or copied the backup to a new folder, please ensure the storage config with the correct path prefix is used to match where the backup data now resides.
+    Everything from the `yugabyte_backup` folder down (or, for cloud storage, everything after the configured bucket and path prefix) must be left unchanged; only the leading storage address can differ, and only if it matches the selected storage configuration and the backup data actually resides there. If you moved or copied the backup to a new folder, please ensure the storage config with the correct path prefix is used to match where the backup data now resides.
 
 1. Specify the name of the database or keyspace from which you are performing a restore.
 

--- a/docs/content/stable/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
+++ b/docs/content/stable/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
@@ -257,10 +257,6 @@ For information regarding components of a backup, refer to [Access backups in st
 
 To perform an advanced restore, you need the following.
 
-#### KMS configuration
-
-If the backup had [encryption at rest enabled](../../security/enable-encryption-at-rest), you need a matching KMS configuration in the target YugabyteDB Anywhere installation so that the backup can be decrypted.
-
 #### Storage configuration
 
 A matching [storage configuration](../configure-backup-storage/) in the target YugabyteDB Anywhere installation with credentials to access the storage where the backup is located.
@@ -269,36 +265,53 @@ If you are restoring from a backup that was moved to another location, copy the 
 
 #### Backup location
 
-The full backup location of the database or keyspace backup you want to restore.
+The backup location of the database or keyspace backup you want to restore.
 
-You can obtain the address of the backup location as follows:
+The directory structure of the backup location matters. For a restore to succeed, the YugabyteDB Anywhere requires the full path; that includes everything after the storage address. For NFS storage configurations, the path must also include the `yugabyte_backup` directory.
 
-1. Navigate to **Backups** and click the backup (row) to display the **Backup Details**.
-
-1. In the list of databases (YSQL) or keyspaces (YCQL), click **Copy Location** for the database or keyspace you want to restore. (If your backup includes incremental backups, to display the databases or keyspaces, click the down arrow for the increment at which you want to restore.)
-
-1. Note the **Storage Config** used by the backup, along with the database or keyspace name.
-
-The directory structure of the **Backup location** matters. For a restore to succeed, the YugabyteDB Anywhere requires the full path.
-
-For NFS storage configurations, the configuration path also includes a `yugabyte_backup` directory, which YugabyteDB Anywhere adds automatically when writing backups. The **Backup location** must include this directory. (S3, GCS, and Azure storage configurations do not have this extra directory; the bucket is part of the storage configuration's path itself.)
-
-For example, for an NFS storage configuration with the path `/backup`, a valid location is the following:
+For example, for an S3 storage configuration with the storage address `s3://mybucket/yb-backups/`, a valid location is the following:
 
 ```output
-/backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+s3://mybucket/yb-backups/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
 ```
 
-Similarly, for an NFS storage configuration with the path `/mnt/backup/`, a valid location is the following:
+Everything after the address (`s3://mybucket/yb-backups`) is required.
+
+For an NFS storage configuration with the address `/mnt/backup/`, a valid location is the following:
 
 ```output
 /mnt/backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
 ```
 
-Everything from the `yugabyte_backup` folder down (or, for cloud storage, everything after the configured bucket and path prefix) must be left unchanged; only the leading storage address can differ, and only if it matches the selected storage configuration and the backup data actually resides there. If you moved or copied the backup to a new folder, please ensure the storage config with the correct path prefix is used to match where the backup data now resides.
+Everything from the `yugabyte_backup` folder down is required.
+
+If you moved or copied the backup to a new location, make sure the storage configuration has the correct storage address to match the location where the backup data now resides. YugabyteDB Anywhere automatically replaces the storage address of the backup location you provide with the storage address of the storage configuration you select.
+
+For example, if you provide a storage configuration with an address of `s3://newbucket/backups` and the following backup location:
+
+```output
+s3://mybucket/yb-backups/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+```
+
+YugabyteDB will look in the following location for the backup:
+
+```output
+s3://newbucket/backups/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+```
 
 For more information on the folder structure of YugabyteDB Anywhere backups, refer to [Access backups in storage](../back-up-universe-data/#access-backups-in-storage).
 
+If the backup is still being managed by YugabyteDB Anywhere, you can obtain the address of the backup location, along with the storage configuration and database name, as follows:
+
+1. In the YugabyteDB Anywhere where you are performing the restore, navigate to **Backups** and click the backup (row) to display the **Backup Details**.
+
+1. In the list of databases (YSQL) or keyspaces (YCQL), click **Copy Location** for the database or keyspace you want to restore. (If your backup includes incremental backups, to display the databases or keyspaces, click the down arrow for the increment at which you want to restore.)
+
+1. Note the **Storage Config** used by the backup, along with the database or keyspace name.
+
+#### KMS configuration
+
+If the backup had [encryption at rest enabled](../../security/enable-encryption-at-rest), you need a matching KMS configuration in the target YugabyteDB Anywhere installation so that the backup can be decrypted.
 
 ### Perform an advanced restore
 
@@ -310,17 +323,19 @@ To perform an advanced restore, on the YugabyteDB Anywhere installation where yo
 
 1. Choose the type of API.
 
-1. In the **Backup location** field, paste the location of the backup you are restoring. For example:
+1. In the **Backup location** field, paste the [backup location](#backup-location) of the backup you are restoring.
+
+    For example:
 
     ```output
     s3://user_bucket/some/sub/folders/univ-a85b5b01-6e0b-4a24-b088-478dafff94e4/ybc_backup-92317948b8e444ba150616bf182a061/incremental/20204-01-04T12: 11: 03/multi-table-postgres_40522fc46c69404893392b7d92039b9e
     ```
 
-1. Select the **Backup config** that corresponds to the storage configuration that was used for the backup. The storage could be on Google Cloud, Amazon S3, Azure, or Network File System.
+1. Select the **Backup config** that corresponds to the [storage configuration](#storage-configuration) that was used for the backup. The storage could be on Google Cloud, Amazon S3, Azure, or Network File System.
 
-    Note that the storage configuration bucket takes precedence over the bucket specified in the backup location.
+    The storage configuration bucket takes precedence over the bucket specified in the backup location.
 
-    For example, if the storage configuration you select is for the following S3 Bucket:
+    For example, if the storage configuration you select is for the following S3 bucket:
 
     ```output
     s3://test_bucket/test

--- a/docs/content/stable/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
+++ b/docs/content/stable/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
@@ -37,7 +37,7 @@ Backups from a stable track universe can only be restored to a higher version st
 
 - If a universe that spans multiple regions is backed up to NFS using a different volume for each region, all the NFS volumes must be synced to contain the full backup. Each node will require access to the full backup.
 
-    [Tablespaces](../../../explore/going-beyond-sql/tablespaces/) are an exception. A node doesn't require access to backed up tablets if that tablet is pinned to another region using a tablespace.
+    [Tablespaces](../../../explore/going-beyond-sql/tablespaces/) are an exception. A node doesn't require access to backed up tablets if they are pinned to another region using a tablespace.
 
 ## Restore an entire or incremental backup
 

--- a/docs/content/stable/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
+++ b/docs/content/stable/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
@@ -53,7 +53,7 @@ You can restore YugabyteDB universe data from a backup as follows:
 
 1. To rename databases (YSQL) or keyspaces (YCQL), select the **Rename** option.
 
-    If you are restoring a backup to a universe with an existing databases of the same name, you must rename the database.
+    If you are restoring a backup to a universe with an existing database of the same name, you must rename the database.
 
 1. If you are restoring data from a universe that has tablespaces, select the **Restore tablespaces and data to their respective regions** option.
 
@@ -95,7 +95,7 @@ To restore, do the following:
 
 1. In the **Restore Backup** dialog, select the universe (target) to which you want to restore the backup.
 
-    Note that the Creation time shown in the dialog indicates the backup job start time, _not_ the time that the particular database was actually snapshotted and backed up. When multiple databases are included in a backup job, each databases is snapshotted and backed up in serial order; thus, each individual database's actual snapshot and backup time is not the same as the backup job start time. To restore a database to a specific point in time, use [Point-in-time recovery](../pitr/).
+    Note that the Creation time shown in the dialog indicates the backup job start time, _not_ the time that the particular database was actually snapshotted and backed up. When multiple databases are included in a backup job, each database is snapshotted and backed up in serial order; thus, each individual database's actual snapshot and backup time is not the same as the backup job start time. To restore a database to a specific point in time, use [Point-in-time recovery](../pitr/).
 
 1. If you are restoring data from a universe that has, or previously had, [encryption at rest enabled](../../security/enable-encryption-at-rest), then you must select the KMS configuration to use so that the master keys referenced in the metadata file can be retrieved.
 
@@ -267,12 +267,12 @@ If you are restoring from a backup that was moved to another location, copy the 
 
 The backup location of the database or keyspace backup you want to restore.
 
-The directory structure of the backup location matters. For a restore to succeed, the YugabyteDB Anywhere requires the full path; that includes everything after the storage address. For NFS storage configurations, the path must also include the `yugabyte_backup` directory.
+The directory structure of the backup location matters. For a restore to succeed, YugabyteDB Anywhere requires the full path; that includes everything after the storage address. For NFS backups, YugabyteDB Anywhere automatically adds the `yugabyte_backup` directory; the backup location path you provide must also include the `yugabyte_backup` directory.
 
 For example, for an S3 storage configuration with the storage address `s3://mybucket/yb-backups/`, a valid location is the following:
 
 ```output
-s3://mybucket/yb-backups/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+s3://mybucket/yb-backups/univ-<universe-name>-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
 ```
 
 Everything after the address (`s3://mybucket/yb-backups`) is required.
@@ -280,7 +280,7 @@ Everything after the address (`s3://mybucket/yb-backups`) is required.
 For an NFS storage configuration with the address `/mnt/backup/`, a valid location is the following:
 
 ```output
-/mnt/backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+/mnt/backup/yugabyte_backup/univ-<universe-name>-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
 ```
 
 Everything from the `yugabyte_backup` folder down is required.
@@ -290,20 +290,20 @@ If you moved or copied the backup to a new location, make sure the storage confi
 For example, if you provide a _storage configuration_ with an address of `s3://newbucket/backups` and the following _backup location_:
 
 ```output
-s3://mybucket/yb-backups/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+s3://mybucket/yb-backups/univ-<universe-name>-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
 ```
 
 YugabyteDB Anywhere will look in the following location for the backup:
 
 ```output
-s3://newbucket/backups/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+s3://newbucket/backups/univ-<universe-name>-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
 ```
 
 For more information on the folder structure of YugabyteDB Anywhere backups, refer to [Access backups in storage](../back-up-universe-data/#access-backups-in-storage).
 
 If the backup is still being managed by YugabyteDB Anywhere, you can obtain the address of the backup location, along with the storage configuration and database name, as follows:
 
-1. In the YugabyteDB Anywhere where you are performing the restore, navigate to **Backups** and click the backup (row) to display the **Backup Details**.
+1. On the YugabyteDB Anywhere installation where the backup is registered (which may differ from where you are performing the restore), navigate to **Backups** and click the backup (row) to display the **Backup Details**.
 
 1. In the list of databases (YSQL) or keyspaces (YCQL), click **Copy Location** for the database or keyspace you want to restore. (If your backup includes incremental backups, to display the databases or keyspaces, click the down arrow for the increment at which you want to restore.)
 
@@ -328,7 +328,7 @@ To perform an advanced restore, on the YugabyteDB Anywhere installation where yo
     For example:
 
     ```output
-    s3://user_bucket/some/sub/folders/univ-a85b5b01-6e0b-4a24-b088-478dafff94e4/ybc_backup-92317948b8e444ba150616bf182a061/incremental/20204-01-04T12: 11: 03/multi-table-postgres_40522fc46c69404893392b7d92039b9e
+    s3://user_bucket/some/sub/folders/univ-myuniverse-a85b5b01-6e0b-4a24-b088-478dafff94e4/ybc_backup-92317948b8e444ba150616bf182a061/incremental/2024-01-04T12:11:03/multi-table-postgres_40522fc46c69404893392b7d92039b9e
     ```
 
 1. Select the **Backup config** that corresponds to the [storage configuration](#storage-configuration) that was used for the backup. The storage could be on Google Cloud, Amazon S3, Azure, or Network File System.

--- a/docs/content/v2.20/yugabyte-platform/back-up-restore-universes/back-up-universe-data.md
+++ b/docs/content/v2.20/yugabyte-platform/back-up-restore-universes/back-up-universe-data.md
@@ -112,31 +112,33 @@ YugabyteDB Anywhere universe backups are stored using the following folder struc
 
 ```output
 <storage-address>
-  /sub-directories
-    /<universe-uuid>
-      /<backup-series-name>-<backup-series-uuid>
-        /<backup-type>
-          /<creation-time>
-            /<backup-name>_<uuid>
+  /yugabyte_backup    [NFS backups only]
+    /univ-<universe-name>-<universe-uuid>
+      /<database-name>
+        /<backup-series-name>-<backup-series-uuid>
+          /<backup-type>
+            /<creation-time>
+              /<backup-name>_<uuid>
 ```
 
-For example:
+For example, an S3 backup address would be similar to the following:
 
 ```output
-s3://user_bucket
-  /some/sub/folders
-    /univ-a85b5b01-6e0b-4a24-b088-478dafff94e4
+s3://user_bucket/some/sub/folders
+  /univ-myuniverse-a85b5b01-6e0b-4a24-b088-478dafff94e4
+    /database1_name
       /ybc_backup-92317948b8e444ba150616bf182a061
         /incremental
-          /20204-01-04T12: 11: 03
+          /2024-01-04T12:11:03
             /multi-table-postgres_40522fc46c69404893392b7d92039b9e
 ```
 
 | Component | Description |
 | :-------- | :---------- |
-| Storage address | The name of the bucket as specified in the [backup configuration](../configure-backup-storage/) that was used for the backup. |
-| Sub-directories | The path of the sub-folders (if any) in a bucket. |
-| Universe UUID | The UUID of the universe that was backed up. You can move this folder to different a location, but to successfully restore, do not modify this folder or any of its contents. |
+| Storage address | The name of the bucket as specified in the [backup configuration](../configure-backup-storage/) that was used for the backup. This can include the path of the sub-folders (if any) in a bucket. For NFS, this will consist only of a path of subfolders. |
+| yugabyte_backup | NFS backups are stored under this directory (YugabyteDB Anywhere automatically adds this directory). The directory _is not present_ for S3, GCS, or Azure storage. For NFS storage, you can move this folder to a different location, but to successfully restore, do not modify this folder, or any of its contents. |
+| Universe name and UUID | The name of the universe and UUID that was backed up (prefixed with `univ-`). For cloud storage (not NFS), you can move this folder to a different location, but to successfully restore, do not modify this folder, or any of its contents. |
+| Database or Keyspace name | The name of the Database or Keyspace that was backed up. |
 | Backup series name and UUID | The name of the backup series and YBA-generated UUID. The UUID ensures that YBA can correctly identify the appropriate folder. |
 | Backup type | `full` or `incremental`. Indicates whether the subfolders contain full or incremental backups. |
 | Creation time | The time the backup was started. |
@@ -154,22 +156,28 @@ When moving a backup (for example, for long term storage), be sure to include al
 
 For a successful restore at a later date, none of the sub-components and folder names can be modified (from the sub-directories on down) in the address - only the storage address.
 
-For example, if you have a backup as follows:
+For example, if you have an S3 backup with a storage address of `s3://test_bucket/test` and the following path:
 
 ```output
-s3://test_bucket/test/univ-xyz
+s3://test_bucket/test/univ-xyz/...
 ```
 
 You can move the backup to a location similar to the following:
 
 ```output
-s3://user_bucket/test/univ-xyz
+s3://user_bucket/new-test/univ-xyz/...
 ```
 
-However, you can't move it to a different sub-directory inside the bucket such as the following:
+Similarly, if you have an NFS backup with a storage address of `/mnt/backups/test/` and the following path:
 
 ```output
-s3://user_bucket/new-test/univ-xyz
+/mnt/backups/test/yugabyte_backup/univ-xyz/...
+```
+
+You can move the backup to a location similar to the following:
+
+```output
+/yb-backups/yugabyte_backup/univ-xyz/...
 ```
 
 To restore from a backup that has been moved, you need to use the [Advanced restore procedure](../restore-universe-data/#advanced-restore-procedure).

--- a/docs/content/v2.20/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
+++ b/docs/content/v2.20/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
@@ -146,8 +146,6 @@ You can configure Azure as your backup target.
 - [Blob container](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal#create-a-container).
 - [SAS Token](https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview?toc=/azure/storage/blobs/toc.json&bc=/azure/storage/blobs/breadcrumb/toc.json).
 
-    Note that you must generate the SAS Token on the Storage Account, not the Container.
-
 ### Create an Azure storage configuration
 
 In YugabyteDB Anywhere:

--- a/docs/content/v2.20/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
+++ b/docs/content/v2.20/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
@@ -71,26 +71,6 @@ The following S3 IAM permissions are required:
 "s3:GetBucketLocation"
 ```
 
-## Network File System
-
-You can configure Network File System (NFS) as your backup target, as follows:
-
-1. Navigate to **Configs > Backup > Network File System**.
-
-1. Click **Create NFS Backup** to access the configuration form shown in the following illustration:
-
-    ![NFS Configuration](/images/yp/cloud-provider-configuration-backup-nfs.png)
-
-1. Use the **Configuration Name** field to provide a meaningful name for your backup configuration.
-
-1. Complete the **NFS Storage Path** field by entering `/backup` or another directory that provides read, write, and access permissions to the SSH user of the YugabyteDB Anywhere instance.
-
-1. Click **Save**.
-
-{{< warning title="Prevent back up failure due to NFS unmount on cloud VM restart" >}}
-To avoid potential backup and restore errors, add the NFS mount to `/etc/fstab` on the nodes of universes using the backup configuration. When a cloud VM is restarted, the NFS mount may get unmounted if its entry is not in `/etc/fstab`. This can lead to backup failures, and errors during [backup](../back-up-universe-data/) or [restore](../restore-universe-data/).
-{{< /warning >}}
-
 ## Google Cloud Storage
 
 You can configure Google Cloud Storage (GCS) as your backup target.
@@ -160,30 +140,13 @@ For instructions on setting up Workload Identity, see [Use Workload Identity](ht
 
 You can configure Azure as your backup target.
 
-### Configure storage on Azure
+### Prerequisites
 
-1. Create a storage account in Azure, as follows:
+- Azure storage account.
+- [Blob container](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal#create-a-container).
+- [SAS Token](https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview?toc=/azure/storage/blobs/toc.json&bc=/azure/storage/blobs/breadcrumb/toc.json).
 
-    - Navigate to **Portal > Storage Account** and click **Add** (+).
-    - Complete the mandatory fields, such as **Resource group**, **Storage account name**, and **Location**, as per the following illustration:
-
-        ![Azure storage account creation](/images/yp/cloud-provider-configuration-backup-azure-account.png)
-
-1. Create a blob container, as follows:
-
-    - Open the storage account (for example, **storagetestazure**, as shown in the following illustration).
-    - Navigate to **Blob service > Containers > + Container** and then click **Create**.
-
-        ![Azure blob container creation](/images/yp/cloud-provider-configuration-backup-azure-blob-container.png)
-
-1. Generate an SAS Token, as follows:
-
-    - Navigate to **Storage account > Shared access signature**, as shown in the following illustration. (Note that you must generate the SAS Token on the Storage Account, not the Container. Generating the SAS Token on the container will prevent the configuration from being applied.)
-    - Under **Allowed resource types**, select **Container** and **Object**.
-    - Under **Allowed permissions**, select all options as shown.
-    - Click **Generate SAS and connection string** and copy the SAS token.
-
-        ![Azure Shared Access Signature page](/images/yp/cloud-provider-configuration-backup-azure-generate-token.png)
+    Note that you must generate the SAS Token on the Storage Account, not the Container.
 
 ### Create an Azure storage configuration
 
@@ -197,13 +160,31 @@ In YugabyteDB Anywhere:
 
 1. Use the **Configuration Name** field to provide a meaningful name for your storage configuration.
 
-1. Enter the **Container URL** of the container you created. You can obtain the container URL in Azure by navigating to **Container > Properties**, as shown in the following illustration:
-
-    ![Azure container properties](/images/yp/cloud-provider-configuration-backup-azure-container-properties.png)
+1. Enter the **Container URL** of the container you created. You can obtain the container URL in Azure by navigating to **Container > Properties**.
 
 1. Provide the **SAS Token** you generated. You can copy the SAS Token directly from **Shared access signature** page in Azure.
 
 1. Click **Save**.
+
+## Network File System
+
+You can configure Network File System (NFS) as your backup target, as follows:
+
+1. Navigate to **Configs > Backup > Network File System**.
+
+1. Click **Create NFS Backup** to access the configuration form shown in the following illustration:
+
+    ![NFS Configuration](/images/yp/cloud-provider-configuration-backup-nfs.png)
+
+1. Use the **Configuration Name** field to provide a meaningful name for your backup configuration.
+
+1. Complete the **NFS Storage Path** field by entering `/backup` or another directory that provides read, write, and access permissions to the SSH user of the YugabyteDB Anywhere instance.
+
+1. Click **Save**.
+
+{{< warning title="Prevent back up failure due to NFS unmount on cloud VM restart" >}}
+To avoid potential backup and restore errors, add the NFS mount to `/etc/fstab` on the nodes of universes using the backup configuration. When a cloud VM is restarted, the NFS mount may get unmounted if its entry is not in `/etc/fstab`. This can lead to backup failures, and errors during [backup](../back-up-universe-data/) or [restore](../restore-universe-data/).
+{{< /warning >}}
 
 ## Local storage
 

--- a/docs/content/v2.20/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
+++ b/docs/content/v2.20/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
@@ -175,19 +175,19 @@ To perform an advanced restore, on the YugabyteDB Anywhere installation where yo
 
     The directory structure of the **Backup location** matters. YBA determines the location of the backup files by removing the backup config's path from the start of the **Backup location** you provide, and then appending whatever remains to the backup config's path. As a result, the **Backup location** must begin with the path defined in the selected backup config. If it doesn't, the path is constructed incorrectly and the restore fails immediately.
 
-    The backup config path also includes a `yugabyte_backup` directory, which YBA adds automatically when writing backups. The **Backup location** must include this directory. For example, for a backup config with the path `/backup`, a valid location is the following:
+    For NFS backup configs, the backup config path also includes a `yugabyte_backup` directory, which YBA adds automatically when writing backups. The **Backup location** must include this directory. (S3, GCS, and Azure backup configs do not have this extra directory; the bucket is part of the backup config's path itself.) For example, for an NFS backup config with the path `/backup`, a valid location is the following:
 
     ```output
     /backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
     ```
 
-    Similarly, for a backup config with the path `/mnt/backup/`, a valid location is the following:
+    Similarly, for an NFS backup config with the path `/mnt/backup/`, a valid location is the following:
 
     ```output
     /mnt/backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
     ```
 
-    Everything from the `yugabyte_backup` folder down must be left unchanged; only the leading storage address can differ, and only if it matches the selected backup config and the backup data actually resides there. If you moved or copied the backup to a new folder, please ensure the backup config with the correct path prefix is used to match where the backup data now resides.
+    Everything from the `yugabyte_backup` folder down (or, for cloud storage, everything after the configured bucket and path prefix) must be left unchanged; only the leading storage address can differ, and only if it matches the selected backup config and the backup data actually resides there. If you moved or copied the backup to a new folder, please ensure the backup config with the correct path prefix is used to match where the backup data now resides.
 
 1. Specify the name of the database or keyspace from which you are performing a restore.
 

--- a/docs/content/v2.20/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
+++ b/docs/content/v2.20/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
@@ -28,7 +28,7 @@ To access all universe backups, navigate to **Backups**.
 
 - If a universe that spans multiple regions is backed up to NFS using a different volume for each region, all the NFS volumes must be synced to contain the full backup. Each node will require access to the full backup.
 
-    - There is a caveat where a node will not require access to backed up tablets if that tablet is pinned to another region using [tablespaces](../../../explore/going-beyond-sql/tablespaces/).
+    - There is a caveat where a node will not require access to backed up tablets if that tablet is pinned to another region using [tablespaces](../../../explore/ysql-language-features/going-beyond-sql/tablespaces/).
 
 ## Restore an entire or incremental backup
 

--- a/docs/content/v2.20/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
+++ b/docs/content/v2.20/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
@@ -28,7 +28,7 @@ To access all universe backups, navigate to **Backups**.
 
 - If a universe that spans multiple regions is backed up to NFS using a different volume for each region, all the NFS volumes must be synced to contain the full backup. Each node will require access to the full backup.
 
-    [Tablespaces](../../../explore/ysql-language-features/going-beyond-sql/tablespaces/) are an exception. A node doesn't require access to backed up tablets if that tablet is pinned to another region using a tablespace.
+    [Tablespaces](../../../explore/ysql-language-features/going-beyond-sql/tablespaces/) are an exception. A node doesn't require access to backed up tablets if they are pinned to another region using a tablespace.
 
 ## Restore an entire or incremental backup
 

--- a/docs/content/v2.20/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
+++ b/docs/content/v2.20/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
@@ -28,7 +28,7 @@ To access all universe backups, navigate to **Backups**.
 
 - If a universe that spans multiple regions is backed up to NFS using a different volume for each region, all the NFS volumes must be synced to contain the full backup. Each node will require access to the full backup.
 
-    - There is a caveat where a node will not require access to backed up tablets if that tablet is pinned to another region using [tablespaces](../../../explore/ysql-language-features/going-beyond-sql/tablespaces/).
+    [Tablespaces](../../../explore/ysql-language-features/going-beyond-sql/tablespaces/) are an exception. A node doesn't require access to backed up tablets if that tablet is pinned to another region using a tablespace.
 
 ## Restore an entire or incremental backup
 
@@ -48,7 +48,7 @@ You can restore YugabyteDB universe data from a backup as follows:
 
 1. To rename databases (YSQL) or keyspaces (YCQL), select the **Rename** option.
 
-    If you are restoring a backup to a universe with an existing databases of the same name, you must rename the database.
+    If you are restoring a backup to a universe with an existing database of the same name, you must rename the database.
 
 1. If you are restoring data from a universe that has tablespaces, select the **Restore tablespaces and data to their respective regions** option.
 
@@ -82,7 +82,7 @@ To restore, do the following:
 
 1. In the **Restore Backup** dialog, select the universe (target) to which you want to restore the backup.
 
-    Note that the Creation time shown in the dialog indicates the backup job start time, _not_ the time that the particular database was actually snapshotted and backed up. When multiple databases are included in a backup job, each databases is snapshotted and backed up in serial order; thus, each individual database's actual snapshot and backup time is not the same as the backup job start time. To restore a database to a specific point in time, use [Point-in-time recovery](../pitr/).
+    Note that the Creation time shown in the dialog indicates the backup job start time, _not_ the time that the particular database was actually snapshotted and backed up. When multiple databases are included in a backup job, each database is snapshotted and backed up in serial order; thus, each individual database's actual snapshot and backup time is not the same as the backup job start time. To restore a database to a specific point in time, use [Point-in-time recovery](../pitr/).
 
 1. If you are restoring data from a universe that has, or previously had, [encryption at rest enabled](../../security/enable-encryption-at-rest), then you must select the KMS configuration to use so that the master keys referenced in the metadata file can be retrieved.
 
@@ -120,24 +120,63 @@ For information regarding components of a backup, refer to [Access backups in st
 
 ### Prerequisites
 
-To perform an advanced restore, you need the following:
+To perform an advanced restore, you need the following.
 
-- If the backup had [encryption at rest enabled](../../security/enable-encryption-at-rest), a matching KMS configuration in the target YBA installation so that the backup can be decrypted.
-- A matching [storage configuration](../configure-backup-storage/) in the target YBA installation with credentials to access the storage where the backup is located.
+#### Storage configuration
 
-    If you are restoring from a backup that was moved to another location, copy the backup to a location with a corresponding storage configuration in YBA.
+A matching [storage configuration](../configure-backup-storage/) in the target YBA installation with credentials to access the storage where the backup is located.
 
-- The storage address of the database or keyspace backup you want to restore.
+If you are restoring from a backup that was moved to another location, copy the backup to a location with a corresponding storage configuration in YBA.
 
-    If the backup is on a different YugabyteDB Anywhere installation, you can obtain the location address as follows:
+#### Backup location
 
-    1. In the **Backups** list, click the backup (row) to display the **Backup Details**.
+The backup location of the database or keyspace backup you want to restore.
 
-    1. In the list of databases (YSQL) or keyspaces (YCQL), click **Copy Location** for the database or keyspace you want to restore. If your backup includes incremental backups, to display the databases or keyspaces, click the down arrow for the increment at which you want to restore.
+The directory structure of the backup location matters. For a restore to succeed, YBA requires the full path; that includes everything after the storage address. For NFS backups, YBA automatically adds the `yugabyte_backup` directory; the backup location path you provide must also include the `yugabyte_backup` directory.
 
-    1. Note the **Storage Config** used by the backup, along with the database or keyspace name.
+For example, for an S3 storage configuration with the storage address `s3://mybucket/yb-backups/`, a valid location is the following:
 
-    To determine the address from the backup folder structure, refer to [Access backups in storage](../back-up-universe-data/#access-backups-in-storage).
+```output
+s3://mybucket/yb-backups/univ-<universe-name>-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+```
+
+Everything after the address (`s3://mybucket/yb-backups`) is required.
+
+For an NFS storage configuration with the address `/mnt/backup/`, a valid location is the following:
+
+```output
+/mnt/backup/yugabyte_backup/univ-<universe-name>-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+```
+
+Everything from the `yugabyte_backup` folder down is required.
+
+If you moved or copied the backup to a new location, make sure the storage configuration has the correct storage address to match the location where the backup data now resides. YBA automatically replaces the storage address of the backup location you provide with the storage address of the storage configuration you select.
+
+For example, if you provide a _storage configuration_ with an address of `s3://newbucket/backups` and the following _backup location_:
+
+```output
+s3://mybucket/yb-backups/univ-<universe-name>-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+```
+
+YBA will look in the following location for the backup:
+
+```output
+s3://newbucket/backups/univ-<universe-name>-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+```
+
+For more information on the folder structure of YugabyteDB Anywhere backups, refer to [Access backups in storage](../back-up-universe-data/#access-backups-in-storage).
+
+If the backup is still being managed by YBA, you can obtain the address of the backup location, along with the storage configuration and database name, as follows:
+
+1. On the YBA installation where the backup is registered (which may differ from where you are performing the restore), navigate to **Backups** and click the backup (row) to display the **Backup Details**.
+
+1. In the list of databases (YSQL) or keyspaces (YCQL), click **Copy Location** for the database or keyspace you want to restore. (If your backup includes incremental backups, to display the databases or keyspaces, click the down arrow for the increment at which you want to restore.)
+
+1. Note the **Storage Config** used by the backup, along with the database or keyspace name.
+
+#### KMS configuration
+
+If the backup had [encryption at rest enabled](../../security/enable-encryption-at-rest), you need a matching KMS configuration in the target YBA installation so that the backup can be decrypted.
 
 ### Perform an advanced restore
 
@@ -149,17 +188,19 @@ To perform an advanced restore, on the YugabyteDB Anywhere installation where yo
 
 1. Choose the type of API.
 
-1. In the **Backup location** field, paste the location of the backup you are restoring. For example:
+1. In the **Backup location** field, paste the [backup location](#backup-location) of the backup you are restoring.
+
+    For example:
 
     ```output
-    s3://user_bucket/some/sub/folders/univ-a85b5b01-6e0b-4a24-b088-478dafff94e4/ybc_backup-92317948b8e444ba150616bf182a061/incremental/20204-01-04T12: 11: 03/multi-table-postgres_40522fc46c69404893392b7d92039b9e
+    s3://user_bucket/some/sub/folders/univ-myuniverse-a85b5b01-6e0b-4a24-b088-478dafff94e4/ybc_backup-92317948b8e444ba150616bf182a061/incremental/2024-01-04T12:11:03/multi-table-postgres_40522fc46c69404893392b7d92039b9e
     ```
 
-1. Select the **Backup config** that corresponds to the location of the backup. The storage could be on Google Cloud, Amazon S3, Azure, or Network File System.
+1. Select the **Backup config** that corresponds to the [storage configuration](#storage-configuration) that was used for the backup. The storage could be on Google Cloud, Amazon S3, Azure, or Network File System.
 
-    Note that the backup config bucket takes precedence over the bucket specified in the backup location.
+    The backup config bucket takes precedence over the bucket specified in the backup location.
 
-    For example, if the backup config you provide is for the following S3 Bucket:
+    For example, if the backup config you select is for the following S3 bucket:
 
     ```output
     s3://test_bucket/test
@@ -172,22 +213,6 @@ To perform an advanced restore, on the YugabyteDB Anywhere installation where yo
     ```
 
     YBA looks for the backup in `test_bucket/test`, not `user_bucket/test`.
-
-    The directory structure of the **Backup location** matters. YBA determines the location of the backup files by removing the backup config's path from the start of the **Backup location** you provide, and then appending whatever remains to the backup config's path. As a result, the **Backup location** must begin with the path defined in the selected backup config. If it doesn't, the path is constructed incorrectly and the restore fails immediately.
-
-    For NFS backup configs, the backup config path also includes a `yugabyte_backup` directory, which YBA adds automatically when writing backups. The **Backup location** must include this directory. (S3, GCS, and Azure backup configs do not have this extra directory; the bucket is part of the backup config's path itself.) For example, for an NFS backup config with the path `/backup`, a valid location is the following:
-
-    ```output
-    /backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
-    ```
-
-    Similarly, for an NFS backup config with the path `/mnt/backup/`, a valid location is the following:
-
-    ```output
-    /mnt/backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
-    ```
-
-    Everything from the `yugabyte_backup` folder down (or, for cloud storage, everything after the configured bucket and path prefix) must be left unchanged; only the leading storage address can differ, and only if it matches the selected backup config and the backup data actually resides there. If you moved or copied the backup to a new folder, please ensure the backup config with the correct path prefix is used to match where the backup data now resides.
 
 1. Specify the name of the database or keyspace from which you are performing a restore.
 

--- a/docs/content/v2.20/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
+++ b/docs/content/v2.20/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
@@ -24,6 +24,12 @@ To access all universe backups, navigate to **Backups**.
 
     If the topology of the target universe does not match, none of the tablespaces are preserved and all their data is written to the primary region. After the restore, you will have to re-add all the tablespaces. For more information on specifying data placement for tables and indexes, refer to [Tablespaces](../../../explore/ysql-language-features/going-beyond-sql/tablespaces/).
 
+- If you are restoring from a Network File System (NFS) storage configuration, the entire backup must be readable by the `yugabyte` user. If `yugabyte` does not have read access, it is possible for restores to fail with a "file does not exist" error message.
+
+- If a universe that spans multiple regions is backed up to NFS using a different volume for each region, all the NFS volumes must be synced to contain the full backup. Each node will require access to the full backup.
+
+    - There is a caveat where a node will not require access to backed up tablets if that tablet is pinned to another region using [tablespaces](../../../explore/going-beyond-sql/tablespaces/).
+
 ## Restore an entire or incremental backup
 
 You can restore YugabyteDB universe data from a backup as follows:
@@ -166,6 +172,22 @@ To perform an advanced restore, on the YugabyteDB Anywhere installation where yo
     ```
 
     YBA looks for the backup in `test_bucket/test`, not `user_bucket/test`.
+
+    The directory structure of the **Backup location** matters. YBA determines the location of the backup files by removing the backup config's path from the start of the **Backup location** you provide, and then appending whatever remains to the backup config's path. As a result, the **Backup location** must begin with the path defined in the selected backup config. If it doesn't, the path is constructed incorrectly and the restore fails immediately.
+
+    The backup config path also includes a `yugabyte_backup` directory, which YBA adds automatically when writing backups. The **Backup location** must include this directory. For example, for a backup config with the path `/backup`, a valid location is the following:
+
+    ```output
+    /backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+    ```
+
+    Similarly, for a backup config with the path `/mnt/backup/`, a valid location is the following:
+
+    ```output
+    /mnt/backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+    ```
+
+    Everything from the `yugabyte_backup` folder down must be left unchanged; only the leading storage address can differ, and only if it matches the selected backup config and the backup data actually resides there. If you moved or copied the backup to a new folder, please ensure the backup config with the correct path prefix is used to match where the backup data now resides.
 
 1. Specify the name of the database or keyspace from which you are performing a restore.
 

--- a/docs/content/v2024.2/yugabyte-platform/back-up-restore-universes/back-up-universe-data.md
+++ b/docs/content/v2024.2/yugabyte-platform/back-up-restore-universes/back-up-universe-data.md
@@ -106,31 +106,33 @@ YugabyteDB Anywhere universe backups are stored using the following folder struc
 
 ```output
 <storage-address>
-  /sub-directories
-    /<universe-uuid>
-      /<backup-series-name>-<backup-series-uuid>
-        /<backup-type>
-          /<creation-time>
-            /<backup-name>_<uuid>
+  /yugabyte_backup    [NFS backups only]
+    /univ-<universe-name>-<universe-uuid>
+      /<database-name>
+        /<backup-series-name>-<backup-series-uuid>
+          /<backup-type>
+            /<creation-time>
+              /<backup-name>_<uuid>
 ```
 
-For example:
+For example, an S3 backup address would be similar to the following:
 
 ```output
-s3://user_bucket
-  /some/sub/folders
-    /univ-a85b5b01-6e0b-4a24-b088-478dafff94e4
+s3://user_bucket/some/sub/folders
+  /univ-myuniverse-a85b5b01-6e0b-4a24-b088-478dafff94e4
+    /database1_name
       /ybc_backup-92317948b8e444ba150616bf182a061
         /incremental
-          /20204-01-04T12: 11: 03
+          /2024-01-04T12:11:03
             /multi-table-postgres_40522fc46c69404893392b7d92039b9e
 ```
 
 | Component | Description |
 | :-------- | :---------- |
-| Storage address | The name of the bucket as specified in the [storage configuration](../configure-backup-storage/) that was used for the backup. |
-| Sub-directories | The path of the sub-folders (if any) in a bucket. |
-| Universe UUID | The UUID of the universe that was backed up. You can move this folder to different a location, but to successfully restore, do not modify this folder, or any of its contents. |
+| Storage address | The name of the bucket as specified in the [storage configuration](../configure-backup-storage/) that was used for the backup. This can include the path of the sub-folders (if any) in a bucket. For NFS, this will consist only of a path of subfolders. |
+| yugabyte_backup | NFS backups are stored under this directory (YugabyteDB Anywhere automatically adds this directory). The directory _is not present_ for S3, GCS, or Azure storage. For NFS storage, you can move this folder to a different location, but to successfully restore, do not modify this folder, or any of its contents. |
+| Universe name and UUID | The name of the universe and UUID that was backed up (prefixed with `univ-`). For cloud storage (not NFS), you can move this folder to a different location, but to successfully restore, do not modify this folder, or any of its contents. |
+| Database or Keyspace name | The name of the Database or Keyspace that was backed up. |
 | Backup series name and UUID | The name of the backup series and YBA-generated UUID. The UUID ensures that YBA can correctly identify the appropriate folder. |
 | Backup type | `full` or `incremental`. Indicates whether the subfolders contain full or incremental backups. |
 | Creation time | The time the backup was started. |
@@ -169,7 +171,7 @@ Sun, 29 Jun 2025 20:27:05 +0000   Sun, 29 Jun 2025 20:27:11 +0000
 Keyspace Details
 Keyspace 1 Details
 Keyspace   Backup size   Default Location
-yugabyte   63.95 MB      s3://yb-emea-poc-backups/univ-2341a0b9-7b60-4a21-b6f6-6b557e5df036/ybc_backup-b924cda07330487089848e31b61007c4/full/2025-06-29T20:27:05/multi-table-yugabyte_6e7945f5b3e84a7a97eb3d8033b92f9c
+yugabyte   63.95 MB      s3://yb-emea-poc-backups/univ-test-2341a0b9-7b60-4a21-b6f6-6b557e5df036/ybc_backup-b924cda07330487089848e31b61007c4/full/2025-06-29T20:27:05/multi-table-yugabyte_6e7945f5b3e84a7a97eb3d8033b92f9c
 
 Table UUID list
 []
@@ -190,22 +192,28 @@ When moving a backup (for example, for long term storage), be sure to include al
 
 For a successful restore at a later date, none of the sub-components and folder names can be modified (from the sub-directories on down) in the address - only the storage address.
 
-For example, if you have a backup as follows:
+For example, if you have an S3 backup with a storage address of `s3://test_bucket/test` and the following path:
 
 ```output
-s3://test_bucket/test/univ-xyz
+s3://test_bucket/test/univ-xyz/...
 ```
 
 You can move the backup to a location similar to the following:
 
 ```output
-s3://user_bucket/test/univ-xyz
+s3://user_bucket/new-test/univ-xyz/...
 ```
 
-However, you can't move it to a different sub-directory inside the bucket such as the following:
+Similarly, if you have an NFS backup with a storage address of `/mnt/backups/test/` and the following path:
 
 ```output
-s3://user_bucket/new-test/univ-xyz
+/mnt/backups/test/yugabyte_backup/univ-xyz/...
+```
+
+You can move the backup to a location similar to the following:
+
+```output
+/yb-backups/yugabyte_backup/univ-xyz/...
 ```
 
 To restore from a backup that has been moved, you need to use the [Advanced restore procedure](../restore-universe-data/#advanced-restore-procedure).

--- a/docs/content/v2024.2/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
+++ b/docs/content/v2024.2/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
@@ -9,6 +9,8 @@ menu:
     parent: back-up-restore-universes
     identifier: configure-backup-storage
     weight: 10
+rightNav:
+  hideH4: true
 type: docs
 ---
 
@@ -124,54 +126,17 @@ To create a GCP backup configuration, do the following:
 
 1. Click **Save**.
 
-## Network File System
-
-You can configure Network File System (NFS) as your backup target, as follows:
-
-1. Navigate to **Integrations > Backup > Network File System**.
-
-1. Click **Create NFS Backup** to access the configuration form shown in the following illustration:
-
-    ![NFS Configuration](/images/yp/cloud-provider-configuration-backup-nfs.png)
-
-1. Use the **Configuration Name** field to provide a meaningful name for your storage configuration.
-
-1. Complete the **NFS Storage Path** field by entering `/backup` or another directory that provides read, write, and access permissions to the SSH user of the YugabyteDB Anywhere instance.
-
-1. Click **Save**.
-
-{{< warning title="Prevent back up failure due to NFS unmount on cloud VM restart" >}}
-To avoid potential backup and restore errors, add the NFS mount to `/etc/fstab` on the nodes of universes using the backup configuration. When a cloud VM is restarted, the NFS mount may get unmounted if its entry is not in `/etc/fstab`. This can lead to backup failures, and errors during [backup](../back-up-universe-data/) or [restore](../restore-universe-data/).
-{{< /warning >}}
-
 ## Azure Storage
 
 You can configure Azure as your backup target.
 
-### Configure storage on Azure
+### Prerequisites
 
-1. Create a storage account in Azure, as follows:
+- Azure storage account.
+- [Blob container](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal#create-a-container).
+- [SAS Token](https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview?toc=/azure/storage/blobs/toc.json&bc=/azure/storage/blobs/breadcrumb/toc.json) or [Managed identity (IAM)](#azure-managed-identity-authentication).
 
-    - Navigate to **Portal > Storage Account** and click **Add** (+).
-    - Complete the mandatory fields, such as **Resource group**, **Storage account name**, and **Location**, as per the following illustration:
-
-        ![Azure storage account creation](/images/yp/cloud-provider-configuration-backup-azure-account.png)
-
-1. Create a blob container, as follows:
-
-    - Open the storage account (for example, **storagetestazure**, as shown in the following illustration).
-    - Navigate to **Blob service > Containers > + Container** and then click **Create**.
-
-        ![Azure blob container creation](/images/yp/cloud-provider-configuration-backup-azure-blob-container.png)
-
-1. Generate an SAS Token, as follows:
-
-    - Navigate to **Storage account > Shared access signature**, as shown in the following illustration. (Note that you must generate the SAS Token on the Storage Account, not the Container. Generating the SAS Token on the container will prevent the configuration from being applied.)
-    - Under **Allowed resource types**, select **Container** and **Object**.
-    - Under **Allowed permissions**, select all options as shown.
-    - Click **Generate SAS and connection string** and copy the SAS token.
-
-        ![Azure Shared Access Signature page](/images/yp/cloud-provider-configuration-backup-azure-generate-token.png)
+    Note that you must generate the SAS Token on the Storage Account, not the Container.
 
 ### Create an Azure storage configuration
 
@@ -185,9 +150,7 @@ In YugabyteDB Anywhere:
 
 1. Use the **Configuration Name** field to provide a meaningful name for your storage configuration.
 
-1. Enter the **Container URL** of the container you created. You can obtain the container URL in Azure by navigating to **Container > Properties**, as shown in the following illustration:
-
-    ![Azure container properties](/images/yp/cloud-provider-configuration-backup-azure-container-properties.png)
+1. Enter the **Container URL** of the container you created. You can obtain the container URL in Azure by navigating to **Container > Properties**.
 
 1. Provide the **SAS Token** you generated. You can copy the SAS Token directly from **Shared access signature** page in Azure.
 
@@ -327,6 +290,26 @@ Use the following configuration parameters:
 {{< note title="Mutually exclusive authentication" >}}
 You cannot use both SAS token and Azure IAM authentication in the same configuration. When `USE_AZURE_IAM` is `true`, do not include SAS token credentials in the request.
 {{< /note >}}
+
+## Network File System
+
+You can configure Network File System (NFS) as your backup target, as follows:
+
+1. Navigate to **Integrations > Backup > Network File System**.
+
+1. Click **Create NFS Backup** to access the configuration form shown in the following illustration:
+
+    ![NFS Configuration](/images/yp/cloud-provider-configuration-backup-nfs.png)
+
+1. Use the **Configuration Name** field to provide a meaningful name for your storage configuration.
+
+1. Complete the **NFS Storage Path** field by entering `/backup` or another directory that provides read, write, and access permissions to the SSH user of the YugabyteDB Anywhere instance.
+
+1. Click **Save**.
+
+{{< warning title="Prevent back up failure due to NFS unmount on cloud VM restart" >}}
+To avoid potential backup and restore errors, add the NFS mount to `/etc/fstab` on the nodes of universes using the backup configuration. When a cloud VM is restarted, the NFS mount may get unmounted if its entry is not in `/etc/fstab`. This can lead to backup failures, and errors during [backup](../back-up-universe-data/) or [restore](../restore-universe-data/).
+{{< /warning >}}
 
 ## Local storage
 

--- a/docs/content/v2024.2/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
+++ b/docs/content/v2024.2/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
@@ -174,18 +174,13 @@ Before configuring Azure IAM authentication, ensure the following:
 
 - **YugabyteDB Anywhere VM**. Ensure the YugabyteDB Anywhere VM has _one_ of the following:
 
-  - Managed Identity enabled:
-    - In the Azure Portal, navigate to your YugabyteDB Anywhere VM.
-    - Go to **Identity** in the left menu.
-    - Under **System assigned**, set **Status** to **On** and save.
+  - Managed Identity enabled. YugabyteDB Anywhere supports system- and user-assigned managed identity.
 
-    For detailed steps, see [Configure managed identities on Azure virtual machines](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/qs-configure-portal-windows-vm) in the Azure documentation.
+    For more information, refer to [Configure managed identities on Azure virtual machines](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/qs-configure-portal-windows-vm) in the Azure documentation.
 
-  - App registration (Service Principal) configured:
-    - In Azure Portal, navigate to **Azure Active Directory > App registrations**.
-    - Create a new app registration or use an existing one.
-    - Note the **Application (client) ID**, **Directory (tenant) ID**, and create a **Client secret**.
-    - Set the following environment variables on the YugabyteDB Anywhere VM:
+  - App registration (Service Principal) configured.
+
+    Ensure the following environment variables are set on the YugabyteDB Anywhere VM:
 
       ```sh
       AZURE_TENANT_ID=<tenant-id>
@@ -193,13 +188,13 @@ Before configuring Azure IAM authentication, ensure the following:
       AZURE_CLIENT_SECRET=<client-secret>
       ```
 
-    For detailed steps, see [Register a Microsoft Entra app and create a service principal](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal) in the Azure documentation.
+    For more information, refer to [Register a Microsoft Entra app and create a service principal](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal) in the Azure documentation.
 
 - **Database nodes**. Ensure your database nodes are hosted on Azure VMs with one of the following:
 
   - Managed Identity enabled.
 
-    For each database node VM, follow the same steps as for the YugabyteDB Anywhere VM to enable system-assigned managed identity.
+    For each database node VM, enable system- or user-assigned managed identity.
 
     This is the recommended approach as it requires no additional credentials.
 
@@ -213,18 +208,9 @@ Before configuring Azure IAM authentication, ensure the following:
       AZURE_CLIENT_SECRET=<client-secret>
       ```
 
-- **Azure IAM role and permissions**. Assign the **Storage Blob Data Contributor** role (or a stricter role) on the target storage account/container to the Managed Identity or Service Principal:
+- **Azure IAM role and permissions**. Assign the **Storage Blob Data Contributor** role (or a stricter role) on the target storage account/container to the Managed Identity or Service Principal.
 
-  - In Azure Portal, navigate to your **Storage account**.
-  - Go to **Access control (IAM)**.
-  - Click **Add > Add role assignment**.
-  - Select **Storage Blob Data Contributor** role.
-  - Assign access to either:
-    - **Managed Identity**: Select the VM(s) or the system-assigned managed identity.
-    - **Service Principal**: Select the app registration (Service Principal) you created.
-  - Click **Save**.
-
-  For detailed steps, see [Assign Azure roles using the Azure portal](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-portal) in the Azure documentation.
+  For more information, refer to [Assign Azure roles using the Azure portal](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-portal) in the Azure documentation.
 
 #### Configure Azure storage with IAM using the API
 

--- a/docs/content/v2024.2/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
+++ b/docs/content/v2024.2/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
@@ -136,8 +136,6 @@ You can configure Azure as your backup target.
 - [Blob container](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal#create-a-container).
 - [SAS Token](https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview?toc=/azure/storage/blobs/toc.json&bc=/azure/storage/blobs/breadcrumb/toc.json) or [Managed identity (IAM)](#azure-managed-identity-authentication).
 
-    Note that you must generate the SAS Token on the Storage Account, not the Container.
-
 ### Create an Azure storage configuration
 
 In YugabyteDB Anywhere:

--- a/docs/content/v2024.2/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
+++ b/docs/content/v2024.2/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
@@ -34,7 +34,7 @@ Backups from a stable track universe can only be restored to a higher version st
 
 - If a universe that spans multiple regions is backed up to NFS using a different volume for each region, all the NFS volumes must be synced to contain the full backup. Each node will require access to the full backup.
 
-    - There is a caveat where a node will not require access to backed up tablets if that tablet is pinned to another region using [tablespaces](../../../explore/going-beyond-sql/tablespaces/).
+    [Tablespaces](../../../explore/going-beyond-sql/tablespaces/) are an exception. A node doesn't require access to backed up tablets if that tablet is pinned to another region using a tablespace.
 
 ## Restore an entire or incremental backup
 
@@ -54,7 +54,7 @@ You can restore YugabyteDB universe data from a backup as follows:
 
 1. To rename databases (YSQL) or keyspaces (YCQL), select the **Rename** option.
 
-    If you are restoring a backup to a universe with an existing databases of the same name, you must rename the database.
+    If you are restoring a backup to a universe with an existing database of the same name, you must rename the database.
 
 1. If you are restoring data from a universe that has tablespaces, select the **Restore tablespaces and data to their respective regions** option.
 
@@ -88,7 +88,7 @@ To restore, do the following:
 
 1. In the **Restore Backup** dialog, select the universe (target) to which you want to restore the backup.
 
-    Note that the Creation time shown in the dialog indicates the backup job start time, _not_ the time that the particular database was actually snapshotted and backed up. When multiple databases are included in a backup job, each databases is snapshotted and backed up in serial order; thus, each individual database's actual snapshot and backup time is not the same as the backup job start time. To restore a database to a specific point in time, use [Point-in-time recovery](../pitr/).
+    Note that the Creation time shown in the dialog indicates the backup job start time, _not_ the time that the particular database was actually snapshotted and backed up. When multiple databases are included in a backup job, each database is snapshotted and backed up in serial order; thus, each individual database's actual snapshot and backup time is not the same as the backup job start time. To restore a database to a specific point in time, use [Point-in-time recovery](../pitr/).
 
 1. If you are restoring data from a universe that has, or previously had, [encryption at rest enabled](../../security/enable-encryption-at-rest), then you must select the KMS configuration to use so that the master keys referenced in the metadata file can be retrieved.
 
@@ -248,24 +248,63 @@ For information regarding components of a backup, refer to [Access backups in st
 
 ### Prerequisites
 
-To perform an advanced restore, you need the following:
+To perform an advanced restore, you need the following.
 
-- If the backup had [encryption at rest enabled](../../security/enable-encryption-at-rest), a matching KMS configuration in the target YugabyteDB Anywhere installation so that the backup can be decrypted.
-- A matching [storage configuration](../configure-backup-storage/) in the target YugabyteDB Anywhere installation with credentials to access the storage where the backup is located.
+#### Storage configuration
 
-    If you are restoring from a backup that was moved to another location, copy the backup to a location with a corresponding storage configuration in YugabyteDB Anywhere.
+A matching [storage configuration](../configure-backup-storage/) in the target YugabyteDB Anywhere installation with credentials to access the storage where the backup is located.
 
-- The storage address of the database or keyspace backup you want to restore.
+If you are restoring from a backup that was moved to another location, copy the backup to a location with a corresponding storage configuration in YugabyteDB Anywhere.
 
-    If the backup is on a different YugabyteDB Anywhere installation, you can obtain the location address as follows:
+#### Backup location
 
-    1. In the **Backups** list, click the backup (row) to display the **Backup Details**.
+The backup location of the database or keyspace backup you want to restore.
 
-    1. In the list of databases (YSQL) or keyspaces (YCQL), click **Copy Location** for the database or keyspace you want to restore. If your backup includes incremental backups, to display the databases or keyspaces, click the down arrow for the increment at which you want to restore.
+The directory structure of the backup location matters. For a restore to succeed, YugabyteDB Anywhere requires the full path; that includes everything after the storage address. For NFS backups, YugabyteDB Anywhere automatically adds the `yugabyte_backup` directory; the backup location path you provide must also include the `yugabyte_backup` directory.
 
-    1. Note the **Storage Config** used by the backup, along with the database or keyspace name.
+For example, for an S3 storage configuration with the storage address `s3://mybucket/yb-backups/`, a valid location is the following:
 
-    To determine the address from the backup folder structure, refer to [Access backups in storage](../back-up-universe-data/#access-backups-in-storage).
+```output
+s3://mybucket/yb-backups/univ-<universe-name>-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+```
+
+Everything after the address (`s3://mybucket/yb-backups`) is required.
+
+For an NFS storage configuration with the address `/mnt/backup/`, a valid location is the following:
+
+```output
+/mnt/backup/yugabyte_backup/univ-<universe-name>-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+```
+
+Everything from the `yugabyte_backup` folder down is required.
+
+If you moved or copied the backup to a new location, make sure the storage configuration has the correct storage address to match the location where the backup data now resides. YugabyteDB Anywhere automatically replaces the storage address of the backup location you provide with the storage address of the storage configuration you select.
+
+For example, if you provide a _storage configuration_ with an address of `s3://newbucket/backups` and the following _backup location_:
+
+```output
+s3://mybucket/yb-backups/univ-<universe-name>-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+```
+
+YugabyteDB Anywhere will look in the following location for the backup:
+
+```output
+s3://newbucket/backups/univ-<universe-name>-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+```
+
+For more information on the folder structure of YugabyteDB Anywhere backups, refer to [Access backups in storage](../back-up-universe-data/#access-backups-in-storage).
+
+If the backup is still being managed by YugabyteDB Anywhere, you can obtain the address of the backup location, along with the storage configuration and database name, as follows:
+
+1. On the YugabyteDB Anywhere installation where the backup is registered (which may differ from where you are performing the restore), navigate to **Backups** and click the backup (row) to display the **Backup Details**.
+
+1. In the list of databases (YSQL) or keyspaces (YCQL), click **Copy Location** for the database or keyspace you want to restore. (If your backup includes incremental backups, to display the databases or keyspaces, click the down arrow for the increment at which you want to restore.)
+
+1. Note the **Storage Config** used by the backup, along with the database or keyspace name.
+
+#### KMS configuration
+
+If the backup had [encryption at rest enabled](../../security/enable-encryption-at-rest), you need a matching [KMS configuration](../../security/create-kms-config/aws-kms/) in the target YugabyteDB Anywhere installation so that the backup can be decrypted.
 
 ### Perform an advanced restore
 
@@ -277,17 +316,19 @@ To perform an advanced restore, on the YugabyteDB Anywhere installation where yo
 
 1. Choose the type of API.
 
-1. In the **Backup location** field, paste the location of the backup you are restoring. For example:
+1. In the **Backup location** field, paste the [backup location](#backup-location) of the backup you are restoring.
+
+    For example:
 
     ```output
-    s3://user_bucket/some/sub/folders/univ-a85b5b01-6e0b-4a24-b088-478dafff94e4/ybc_backup-92317948b8e444ba150616bf182a061/incremental/20204-01-04T12: 11: 03/multi-table-postgres_40522fc46c69404893392b7d92039b9e
+    s3://user_bucket/some/sub/folders/univ-myuniverse-a85b5b01-6e0b-4a24-b088-478dafff94e4/ybc_backup-92317948b8e444ba150616bf182a061/incremental/2024-01-04T12:11:03/multi-table-postgres_40522fc46c69404893392b7d92039b9e
     ```
 
-1. Select the **Backup config** that corresponds to the storage configuration that was used for the backup. The storage could be on Google Cloud, Amazon S3, Azure, or Network File System.
+1. Select the **Backup config** that corresponds to the [storage configuration](#storage-configuration) that was used for the backup. The storage could be on Google Cloud, Amazon S3, Azure, or Network File System.
 
-    Note that the storage configuration bucket takes precedence over the bucket specified in the backup location.
+    The storage configuration bucket takes precedence over the bucket specified in the backup location.
 
-    For example, if the storage configuration you select is for the following S3 Bucket:
+    For example, if the storage configuration you select is for the following S3 bucket:
 
     ```output
     s3://test_bucket/test
@@ -300,22 +341,6 @@ To perform an advanced restore, on the YugabyteDB Anywhere installation where yo
     ```
 
     YugabyteDB Anywhere looks for the backup in `test_bucket/test`, not `user_bucket/test`.
-
-    The directory structure of the **Backup location** matters. YugabyteDB Anywhere determines the location of the backup files by removing the storage configuration's path from the start of the **Backup location** you provide, and then appending whatever remains to the storage configuration's path. As a result, the **Backup location** must begin with the path defined in the selected storage configuration. If it doesn't, the path is constructed incorrectly and the restore fails immediately.
-
-    For NFS storage configurations, the configuration path also includes a `yugabyte_backup` directory, which YugabyteDB Anywhere adds automatically when writing backups. The **Backup location** must include this directory. (S3, GCS, and Azure storage configurations do not have this extra directory; the bucket is part of the storage configuration's path itself.) For example, for an NFS storage configuration with the path `/backup`, a valid location is the following:
-
-    ```output
-    /backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
-    ```
-
-    Similarly, for an NFS storage configuration with the path `/mnt/backup/`, a valid location is the following:
-
-    ```output
-    /mnt/backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
-    ```
-
-    Everything from the `yugabyte_backup` folder down (or, for cloud storage, everything after the configured bucket and path prefix) must be left unchanged; only the leading storage address can differ, and only if it matches the selected storage configuration and the backup data actually resides there. If you moved or copied the backup to a new folder, please ensure the storage config with the correct path prefix is used to match where the backup data now resides.
 
 1. Specify the name of the database or keyspace from which you are performing a restore.
 

--- a/docs/content/v2024.2/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
+++ b/docs/content/v2024.2/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
@@ -303,19 +303,19 @@ To perform an advanced restore, on the YugabyteDB Anywhere installation where yo
 
     The directory structure of the **Backup location** matters. YugabyteDB Anywhere determines the location of the backup files by removing the storage configuration's path from the start of the **Backup location** you provide, and then appending whatever remains to the storage configuration's path. As a result, the **Backup location** must begin with the path defined in the selected storage configuration. If it doesn't, the path is constructed incorrectly and the restore fails immediately.
 
-    The configuration path also includes a `yugabyte_backup` directory, which YugabyteDB Anywhere adds automatically when writing backups. The **Backup location** must include this directory. For example, for a storage configuration with the path `/backup`, a valid location is the following:
+    For NFS storage configurations, the configuration path also includes a `yugabyte_backup` directory, which YugabyteDB Anywhere adds automatically when writing backups. The **Backup location** must include this directory. (S3, GCS, and Azure storage configurations do not have this extra directory; the bucket is part of the storage configuration's path itself.) For example, for an NFS storage configuration with the path `/backup`, a valid location is the following:
 
     ```output
     /backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
     ```
 
-    Similarly, for a storage configuration with the path `/mnt/backup/`, a valid location is the following:
+    Similarly, for an NFS storage configuration with the path `/mnt/backup/`, a valid location is the following:
 
     ```output
     /mnt/backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
     ```
 
-    Everything from the `yugabyte_backup` folder down must be left unchanged; only the leading storage address can differ, and only if it matches the selected storage configuration and the backup data actually resides there. If you moved or copied the backup to a new folder, please ensure the storage config with the correct path prefix is used to match where the backup data now resides.
+    Everything from the `yugabyte_backup` folder down (or, for cloud storage, everything after the configured bucket and path prefix) must be left unchanged; only the leading storage address can differ, and only if it matches the selected storage configuration and the backup data actually resides there. If you moved or copied the backup to a new folder, please ensure the storage config with the correct path prefix is used to match where the backup data now resides.
 
 1. Specify the name of the database or keyspace from which you are performing a restore.
 

--- a/docs/content/v2024.2/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
+++ b/docs/content/v2024.2/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
@@ -34,7 +34,7 @@ Backups from a stable track universe can only be restored to a higher version st
 
 - If a universe that spans multiple regions is backed up to NFS using a different volume for each region, all the NFS volumes must be synced to contain the full backup. Each node will require access to the full backup.
 
-    [Tablespaces](../../../explore/going-beyond-sql/tablespaces/) are an exception. A node doesn't require access to backed up tablets if that tablet is pinned to another region using a tablespace.
+    [Tablespaces](../../../explore/going-beyond-sql/tablespaces/) are an exception. A node doesn't require access to backed up tablets if they are pinned to another region using a tablespace.
 
 ## Restore an entire or incremental backup
 

--- a/docs/content/v2024.2/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
+++ b/docs/content/v2024.2/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
@@ -30,6 +30,12 @@ Backups from a stable track universe can only be restored to a higher version st
 
     If the topology of the target universe does not match, none of the tablespaces are preserved and all their data is written to the primary region. After the restore, you will have to re-add all the tablespaces. For more information on specifying data placement for tables and indexes, refer to [Tablespaces](../../../explore/going-beyond-sql/tablespaces/).
 
+- If you are restoring from a Network File System (NFS) storage configuration, the entire backup must be readable by the `yugabyte` user. If `yugabyte` does not have read access, it is possible for restores to fail with a "file does not exist" error message.
+
+- If a universe that spans multiple regions is backed up to NFS using a different volume for each region, all the NFS volumes must be synced to contain the full backup. Each node will require access to the full backup.
+
+    - There is a caveat where a node will not require access to backed up tablets if that tablet is pinned to another region using [tablespaces](../../../explore/going-beyond-sql/tablespaces/).
+
 ## Restore an entire or incremental backup
 
 You can restore YugabyteDB universe data from a backup as follows:
@@ -294,6 +300,22 @@ To perform an advanced restore, on the YugabyteDB Anywhere installation where yo
     ```
 
     YugabyteDB Anywhere looks for the backup in `test_bucket/test`, not `user_bucket/test`.
+
+    The directory structure of the **Backup location** matters. YugabyteDB Anywhere determines the location of the backup files by removing the storage configuration's path from the start of the **Backup location** you provide, and then appending whatever remains to the storage configuration's path. As a result, the **Backup location** must begin with the path defined in the selected storage configuration. If it doesn't, the path is constructed incorrectly and the restore fails immediately.
+
+    The configuration path also includes a `yugabyte_backup` directory, which YugabyteDB Anywhere adds automatically when writing backups. The **Backup location** must include this directory. For example, for a storage configuration with the path `/backup`, a valid location is the following:
+
+    ```output
+    /backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+    ```
+
+    Similarly, for a storage configuration with the path `/mnt/backup/`, a valid location is the following:
+
+    ```output
+    /mnt/backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+    ```
+
+    Everything from the `yugabyte_backup` folder down must be left unchanged; only the leading storage address can differ, and only if it matches the selected storage configuration and the backup data actually resides there. If you moved or copied the backup to a new folder, please ensure the storage config with the correct path prefix is used to match where the backup data now resides.
 
 1. Specify the name of the database or keyspace from which you are performing a restore.
 

--- a/docs/content/v2025.1/yugabyte-platform/back-up-restore-universes/back-up-universe-data.md
+++ b/docs/content/v2025.1/yugabyte-platform/back-up-restore-universes/back-up-universe-data.md
@@ -111,31 +111,33 @@ YugabyteDB Anywhere universe backups are stored using the following folder struc
 
 ```output
 <storage-address>
-  /sub-directories
-    /<universe-uuid>
-      /<backup-series-name>-<backup-series-uuid>
-        /<backup-type>
-          /<creation-time>
-            /<backup-name>_<uuid>
+  /yugabyte_backup    [NFS backups only]
+    /univ-<universe-name>-<universe-uuid>
+      /<database-name>
+        /<backup-series-name>-<backup-series-uuid>
+          /<backup-type>
+            /<creation-time>
+              /<backup-name>_<uuid>
 ```
 
-For example:
+For example, an S3 backup address would be similar to the following:
 
 ```output
-s3://user_bucket
-  /some/sub/folders
-    /univ-a85b5b01-6e0b-4a24-b088-478dafff94e4
+s3://user_bucket/some/sub/folders
+  /univ-myuniverse-a85b5b01-6e0b-4a24-b088-478dafff94e4
+    /database1_name
       /ybc_backup-92317948b8e444ba150616bf182a061
         /incremental
-          /20204-01-04T12: 11: 03
+          /2024-01-04T12:11:03
             /multi-table-postgres_40522fc46c69404893392b7d92039b9e
 ```
 
 | Component | Description |
 | :-------- | :---------- |
-| Storage address | The name of the bucket as specified in the [storage configuration](../configure-backup-storage/) that was used for the backup. |
-| Sub-directories | The path of the sub-folders (if any) in a bucket. |
-| Universe UUID | The UUID of the universe that was backed up. You can move this folder to different a location, but to successfully restore, do not modify this folder, or any of its contents. |
+| Storage address | The name of the bucket as specified in the [storage configuration](../configure-backup-storage/) that was used for the backup. This can include the path of the sub-folders (if any) in a bucket. For NFS, this will consist only of a path of subfolders. |
+| yugabyte_backup | NFS backups are stored under this directory (YugabyteDB Anywhere automatically adds this directory). The directory _is not present_ for S3, GCS, or Azure storage. For NFS storage, you can move this folder to a different location, but to successfully restore, do not modify this folder, or any of its contents. |
+| Universe name and UUID | The name of the universe and UUID that was backed up (prefixed with `univ-`). For cloud storage (not NFS), you can move this folder to a different location, but to successfully restore, do not modify this folder, or any of its contents. |
+| Database or Keyspace name | The name of the Database or Keyspace that was backed up. |
 | Backup series name and UUID | The name of the backup series and YBA-generated UUID. The UUID ensures that YBA can correctly identify the appropriate folder. |
 | Backup type | `full` or `incremental`. Indicates whether the subfolders contain full or incremental backups. |
 | Creation time | The time the backup was started. |
@@ -174,7 +176,7 @@ Sun, 29 Jun 2025 20:27:05 +0000   Sun, 29 Jun 2025 20:27:11 +0000
 Keyspace Details
 Keyspace 1 Details
 Keyspace   Backup size   Default Location
-yugabyte   63.95 MB      s3://yb-emea-poc-backups/univ-2341a0b9-7b60-4a21-b6f6-6b557e5df036/ybc_backup-b924cda07330487089848e31b61007c4/full/2025-06-29T20:27:05/multi-table-yugabyte_6e7945f5b3e84a7a97eb3d8033b92f9c
+yugabyte   63.95 MB      s3://yb-emea-poc-backups/univ-test-2341a0b9-7b60-4a21-b6f6-6b557e5df036/ybc_backup-b924cda07330487089848e31b61007c4/full/2025-06-29T20:27:05/multi-table-yugabyte_6e7945f5b3e84a7a97eb3d8033b92f9c
 
 Table UUID list
 []
@@ -195,22 +197,28 @@ When moving a backup (for example, for long term storage), be sure to include al
 
 For a successful restore at a later date, none of the sub-components and folder names can be modified (from the sub-directories on down) in the address - only the storage address.
 
-For example, if you have a backup as follows:
+For example, if you have an S3 backup with a storage address of `s3://test_bucket/test` and the following path:
 
 ```output
-s3://test_bucket/test/univ-xyz
+s3://test_bucket/test/univ-xyz/...
 ```
 
 You can move the backup to a location similar to the following:
 
 ```output
-s3://user_bucket/test/univ-xyz
+s3://user_bucket/new-test/univ-xyz/...
 ```
 
-However, you can't move it to a different sub-directory inside the bucket such as the following:
+Similarly, if you have an NFS backup with a storage address of `/mnt/backups/test/` and the following path:
 
 ```output
-s3://user_bucket/new-test/univ-xyz
+/mnt/backups/test/yugabyte_backup/univ-xyz/...
+```
+
+You can move the backup to a location similar to the following:
+
+```output
+/yb-backups/yugabyte_backup/univ-xyz/...
 ```
 
 To restore from a backup that has been moved, you need to use the [Advanced restore procedure](../restore-universe-data/#advanced-restore-procedure).

--- a/docs/content/v2025.1/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
+++ b/docs/content/v2025.1/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
@@ -9,6 +9,8 @@ menu:
     parent: back-up-restore-universes
     identifier: configure-backup-storage
     weight: 10
+rightNav:
+  hideH4: true
 type: docs
 ---
 
@@ -128,6 +130,36 @@ To create a GCP backup configuration, do the following:
 
 1. Click **Save**.
 
+## Azure Storage
+
+You can configure Azure as your backup target.
+
+### Prerequisites
+
+- Azure storage account.
+- [Blob container](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal#create-a-container).
+- [SAS Token](https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview?toc=/azure/storage/blobs/toc.json&bc=/azure/storage/blobs/breadcrumb/toc.json).
+
+    Note that you must generate the SAS Token on the Storage Account, not the Container.
+
+### Create an Azure storage configuration
+
+In YugabyteDB Anywhere:
+
+1. Navigate to **Integrations > Backup > Azure Storage**.
+
+1. Click **Create AZ Backup**.
+
+    ![Azure Configuration](/images/yp/cloud-provider-configuration-backup-azure.png)
+
+1. Use the **Configuration Name** field to provide a meaningful name for your storage configuration.
+
+1. Enter the **Container URL** of the container you created. You can obtain the container URL in Azure by navigating to **Container > Properties**.
+
+1. Provide the **SAS Token** you generated. You can copy the SAS Token directly from **Shared access signature** page in Azure.
+
+1. Click **Save**.
+
 ## Network File System
 
 You can configure Network File System (NFS) as your backup target, as follows:
@@ -147,55 +179,6 @@ You can configure Network File System (NFS) as your backup target, as follows:
 {{< warning title="Prevent back up failure due to NFS unmount on cloud VM restart" >}}
 To avoid potential backup and restore errors, add the NFS mount to `/etc/fstab` on the nodes of universes using the backup configuration. When a cloud VM is restarted, the NFS mount may get unmounted if its entry is not in `/etc/fstab`. This can lead to backup failures, and errors during [backup](../back-up-universe-data/) or [restore](../restore-universe-data/).
 {{< /warning >}}
-
-## Azure Storage
-
-You can configure Azure as your backup target.
-
-### Configure storage on Azure
-
-1. Create a storage account in Azure, as follows:
-
-    - Navigate to **Portal > Storage Account** and click **Add** (+).
-    - Complete the mandatory fields, such as **Resource group**, **Storage account name**, and **Location**, as per the following illustration:
-
-        ![Azure storage account creation](/images/yp/cloud-provider-configuration-backup-azure-account.png)
-
-1. Create a blob container, as follows:
-
-    - Open the storage account (for example, **storagetestazure**, as shown in the following illustration).
-    - Navigate to **Blob service > Containers > + Container** and then click **Create**.
-
-        ![Azure blob container creation](/images/yp/cloud-provider-configuration-backup-azure-blob-container.png)
-
-1. Generate an SAS Token, as follows:
-
-    - Navigate to **Storage account > Shared access signature**, as shown in the following illustration. (Note that you must generate the SAS Token on the Storage Account, not the Container. Generating the SAS Token on the container will prevent the configuration from being applied.)
-    - Under **Allowed resource types**, select **Container** and **Object**.
-    - Under **Allowed permissions**, select all options as shown.
-    - Click **Generate SAS and connection string** and copy the SAS token.
-
-        ![Azure Shared Access Signature page](/images/yp/cloud-provider-configuration-backup-azure-generate-token.png)
-
-### Create an Azure storage configuration
-
-In YugabyteDB Anywhere:
-
-1. Navigate to **Integrations > Backup > Azure Storage**.
-
-1. Click **Create AZ Backup**.
-
-    ![Azure Configuration](/images/yp/cloud-provider-configuration-backup-azure.png)
-
-1. Use the **Configuration Name** field to provide a meaningful name for your storage configuration.
-
-1. Enter the **Container URL** of the container you created. You can obtain the container URL in Azure by navigating to **Container > Properties**, as shown in the following illustration:
-
-    ![Azure container properties](/images/yp/cloud-provider-configuration-backup-azure-container-properties.png)
-
-1. Provide the **SAS Token** you generated. You can copy the SAS Token directly from **Shared access signature** page in Azure.
-
-1. Click **Save**.
 
 ## Local storage
 

--- a/docs/content/v2025.1/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
+++ b/docs/content/v2025.1/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
@@ -140,8 +140,6 @@ You can configure Azure as your backup target.
 - [Blob container](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal#create-a-container).
 - [SAS Token](https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview?toc=/azure/storage/blobs/toc.json&bc=/azure/storage/blobs/breadcrumb/toc.json).
 
-    Note that you must generate the SAS Token on the Storage Account, not the Container.
-
 ### Create an Azure storage configuration
 
 In YugabyteDB Anywhere:

--- a/docs/content/v2025.1/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
+++ b/docs/content/v2025.1/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
@@ -34,7 +34,7 @@ Backups from a stable track universe can only be restored to a higher version st
 
 - If a universe that spans multiple regions is backed up to NFS using a different volume for each region, all the NFS volumes must be synced to contain the full backup. Each node will require access to the full backup.
 
-    - There is a caveat where a node will not require access to backed up tablets if that tablet is pinned to another region using [tablespaces](../../../explore/going-beyond-sql/tablespaces/).
+    [Tablespaces](../../../explore/going-beyond-sql/tablespaces/) are an exception. A node doesn't require access to backed up tablets if that tablet is pinned to another region using a tablespace.
 
 ## Restore an entire or incremental backup
 
@@ -54,7 +54,7 @@ You can restore YugabyteDB universe data from a backup as follows:
 
 1. To rename databases (YSQL) or keyspaces (YCQL), select the **Rename** option.
 
-    If you are restoring a backup to a universe with an existing databases of the same name, you must rename the database.
+    If you are restoring a backup to a universe with an existing database of the same name, you must rename the database.
 
 1. If you are restoring data from a universe that has tablespaces, select the **Restore tablespaces and data to their respective regions** option.
 
@@ -88,7 +88,7 @@ To restore, do the following:
 
 1. In the **Restore Backup** dialog, select the universe (target) to which you want to restore the backup.
 
-    Note that the Creation time shown in the dialog indicates the backup job start time, _not_ the time that the particular database was actually snapshotted and backed up. When multiple databases are included in a backup job, each databases is snapshotted and backed up in serial order; thus, each individual database's actual snapshot and backup time is not the same as the backup job start time. To restore a database to a specific point in time, use [Point-in-time recovery](../pitr/).
+    Note that the Creation time shown in the dialog indicates the backup job start time, _not_ the time that the particular database was actually snapshotted and backed up. When multiple databases are included in a backup job, each database is snapshotted and backed up in serial order; thus, each individual database's actual snapshot and backup time is not the same as the backup job start time. To restore a database to a specific point in time, use [Point-in-time recovery](../pitr/).
 
 1. If you are restoring data from a universe that has, or previously had, [encryption at rest enabled](../../security/enable-encryption-at-rest), then you must select the KMS configuration to use so that the master keys referenced in the metadata file can be retrieved.
 
@@ -248,24 +248,63 @@ For information regarding components of a backup, refer to [Access backups in st
 
 ### Prerequisites
 
-To perform an advanced restore, you need the following:
+To perform an advanced restore, you need the following.
 
-- If the backup had [encryption at rest enabled](../../security/enable-encryption-at-rest), a matching KMS configuration in the target YugabyteDB Anywhere installation so that the backup can be decrypted.
-- A matching [storage configuration](../configure-backup-storage/) in the target YugabyteDB Anywhere installation with credentials to access the storage where the backup is located.
+#### Storage configuration
 
-    If you are restoring from a backup that was moved to another location, copy the backup to a location with a corresponding storage configuration in YugabyteDB Anywhere.
+A matching [storage configuration](../configure-backup-storage/) in the target YugabyteDB Anywhere installation with credentials to access the storage where the backup is located.
 
-- The storage address of the database or keyspace backup you want to restore.
+If you are restoring from a backup that was moved to another location, copy the backup to a location with a corresponding storage configuration in YugabyteDB Anywhere.
 
-    If the backup is on a different YugabyteDB Anywhere installation, you can obtain the location address as follows:
+#### Backup location
 
-    1. In the **Backups** list, click the backup (row) to display the **Backup Details**.
+The backup location of the database or keyspace backup you want to restore.
 
-    1. In the list of databases (YSQL) or keyspaces (YCQL), click **Copy Location** for the database or keyspace you want to restore. If your backup includes incremental backups, to display the databases or keyspaces, click the down arrow for the increment at which you want to restore.
+The directory structure of the backup location matters. For a restore to succeed, YugabyteDB Anywhere requires the full path; that includes everything after the storage address. For NFS backups, YugabyteDB Anywhere automatically adds the `yugabyte_backup` directory; the backup location path you provide must also include the `yugabyte_backup` directory.
 
-    1. Note the **Storage Config** used by the backup, along with the database or keyspace name.
+For example, for an S3 storage configuration with the storage address `s3://mybucket/yb-backups/`, a valid location is the following:
 
-    To determine the address from the backup folder structure, refer to [Access backups in storage](../back-up-universe-data/#access-backups-in-storage).
+```output
+s3://mybucket/yb-backups/univ-<universe-name>-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+```
+
+Everything after the address (`s3://mybucket/yb-backups`) is required.
+
+For an NFS storage configuration with the address `/mnt/backup/`, a valid location is the following:
+
+```output
+/mnt/backup/yugabyte_backup/univ-<universe-name>-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+```
+
+Everything from the `yugabyte_backup` folder down is required.
+
+If you moved or copied the backup to a new location, make sure the storage configuration has the correct storage address to match the location where the backup data now resides. YugabyteDB Anywhere automatically replaces the storage address of the backup location you provide with the storage address of the storage configuration you select.
+
+For example, if you provide a _storage configuration_ with an address of `s3://newbucket/backups` and the following _backup location_:
+
+```output
+s3://mybucket/yb-backups/univ-<universe-name>-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+```
+
+YugabyteDB Anywhere will look in the following location for the backup:
+
+```output
+s3://newbucket/backups/univ-<universe-name>-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+```
+
+For more information on the folder structure of YugabyteDB Anywhere backups, refer to [Access backups in storage](../back-up-universe-data/#access-backups-in-storage).
+
+If the backup is still being managed by YugabyteDB Anywhere, you can obtain the address of the backup location, along with the storage configuration and database name, as follows:
+
+1. On the YugabyteDB Anywhere installation where the backup is registered (which may differ from where you are performing the restore), navigate to **Backups** and click the backup (row) to display the **Backup Details**.
+
+1. In the list of databases (YSQL) or keyspaces (YCQL), click **Copy Location** for the database or keyspace you want to restore. (If your backup includes incremental backups, to display the databases or keyspaces, click the down arrow for the increment at which you want to restore.)
+
+1. Note the **Storage Config** used by the backup, along with the database or keyspace name.
+
+#### KMS configuration
+
+If the backup had [encryption at rest enabled](../../security/enable-encryption-at-rest), you need a matching [KMS configuration](../../security/create-kms-config/aws-kms/) in the target YugabyteDB Anywhere installation so that the backup can be decrypted.
 
 ### Perform an advanced restore
 
@@ -277,17 +316,19 @@ To perform an advanced restore, on the YugabyteDB Anywhere installation where yo
 
 1. Choose the type of API.
 
-1. In the **Backup location** field, paste the location of the backup you are restoring. For example:
+1. In the **Backup location** field, paste the [backup location](#backup-location) of the backup you are restoring.
+
+    For example:
 
     ```output
-    s3://user_bucket/some/sub/folders/univ-a85b5b01-6e0b-4a24-b088-478dafff94e4/ybc_backup-92317948b8e444ba150616bf182a061/incremental/20204-01-04T12: 11: 03/multi-table-postgres_40522fc46c69404893392b7d92039b9e
+    s3://user_bucket/some/sub/folders/univ-myuniverse-a85b5b01-6e0b-4a24-b088-478dafff94e4/ybc_backup-92317948b8e444ba150616bf182a061/incremental/2024-01-04T12:11:03/multi-table-postgres_40522fc46c69404893392b7d92039b9e
     ```
 
-1. Select the **Backup config** that corresponds to the storage configuration that was used for the backup. The storage could be on Google Cloud, Amazon S3, Azure, or Network File System.
+1. Select the **Backup config** that corresponds to the [storage configuration](#storage-configuration) that was used for the backup. The storage could be on Google Cloud, Amazon S3, Azure, or Network File System.
 
-    Note that the storage configuration bucket takes precedence over the bucket specified in the backup location.
+    The storage configuration bucket takes precedence over the bucket specified in the backup location.
 
-    For example, if the storage configuration you select is for the following S3 Bucket:
+    For example, if the storage configuration you select is for the following S3 bucket:
 
     ```output
     s3://test_bucket/test
@@ -300,22 +341,6 @@ To perform an advanced restore, on the YugabyteDB Anywhere installation where yo
     ```
 
     YugabyteDB Anywhere looks for the backup in `test_bucket/test`, not `user_bucket/test`.
-
-    The directory structure of the **Backup location** matters. YugabyteDB Anywhere determines the location of the backup files by removing the storage configuration's path from the start of the **Backup location** you provide, and then appending whatever remains to the storage configuration's path. As a result, the **Backup location** must begin with the path defined in the selected storage configuration. If it doesn't, the path is constructed incorrectly and the restore fails immediately.
-
-    For NFS storage configurations, the configuration path also includes a `yugabyte_backup` directory, which YugabyteDB Anywhere adds automatically when writing backups. The **Backup location** must include this directory. (S3, GCS, and Azure storage configurations do not have this extra directory; the bucket is part of the storage configuration's path itself.) For example, for an NFS storage configuration with the path `/backup`, a valid location is the following:
-
-    ```output
-    /backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
-    ```
-
-    Similarly, for an NFS storage configuration with the path `/mnt/backup/`, a valid location is the following:
-
-    ```output
-    /mnt/backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
-    ```
-
-    Everything from the `yugabyte_backup` folder down (or, for cloud storage, everything after the configured bucket and path prefix) must be left unchanged; only the leading storage address can differ, and only if it matches the selected storage configuration and the backup data actually resides there. If you moved or copied the backup to a new folder, please ensure the storage config with the correct path prefix is used to match where the backup data now resides.
 
 1. Specify the name of the database or keyspace from which you are performing a restore.
 

--- a/docs/content/v2025.1/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
+++ b/docs/content/v2025.1/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
@@ -303,19 +303,19 @@ To perform an advanced restore, on the YugabyteDB Anywhere installation where yo
 
     The directory structure of the **Backup location** matters. YugabyteDB Anywhere determines the location of the backup files by removing the storage configuration's path from the start of the **Backup location** you provide, and then appending whatever remains to the storage configuration's path. As a result, the **Backup location** must begin with the path defined in the selected storage configuration. If it doesn't, the path is constructed incorrectly and the restore fails immediately.
 
-    The configuration path also includes a `yugabyte_backup` directory, which YugabyteDB Anywhere adds automatically when writing backups. The **Backup location** must include this directory. For example, for a storage configuration with the path `/backup`, a valid location is the following:
+    For NFS storage configurations, the configuration path also includes a `yugabyte_backup` directory, which YugabyteDB Anywhere adds automatically when writing backups. The **Backup location** must include this directory. (S3, GCS, and Azure storage configurations do not have this extra directory; the bucket is part of the storage configuration's path itself.) For example, for an NFS storage configuration with the path `/backup`, a valid location is the following:
 
     ```output
     /backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
     ```
 
-    Similarly, for a storage configuration with the path `/mnt/backup/`, a valid location is the following:
+    Similarly, for an NFS storage configuration with the path `/mnt/backup/`, a valid location is the following:
 
     ```output
     /mnt/backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
     ```
 
-    Everything from the `yugabyte_backup` folder down must be left unchanged; only the leading storage address can differ, and only if it matches the selected storage configuration and the backup data actually resides there. If you moved or copied the backup to a new folder, please ensure the storage config with the correct path prefix is used to match where the backup data now resides.
+    Everything from the `yugabyte_backup` folder down (or, for cloud storage, everything after the configured bucket and path prefix) must be left unchanged; only the leading storage address can differ, and only if it matches the selected storage configuration and the backup data actually resides there. If you moved or copied the backup to a new folder, please ensure the storage config with the correct path prefix is used to match where the backup data now resides.
 
 1. Specify the name of the database or keyspace from which you are performing a restore.
 

--- a/docs/content/v2025.1/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
+++ b/docs/content/v2025.1/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
@@ -34,7 +34,7 @@ Backups from a stable track universe can only be restored to a higher version st
 
 - If a universe that spans multiple regions is backed up to NFS using a different volume for each region, all the NFS volumes must be synced to contain the full backup. Each node will require access to the full backup.
 
-    [Tablespaces](../../../explore/going-beyond-sql/tablespaces/) are an exception. A node doesn't require access to backed up tablets if that tablet is pinned to another region using a tablespace.
+    [Tablespaces](../../../explore/going-beyond-sql/tablespaces/) are an exception. A node doesn't require access to backed up tablets if they are pinned to another region using a tablespace.
 
 ## Restore an entire or incremental backup
 

--- a/docs/content/v2025.1/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
+++ b/docs/content/v2025.1/yugabyte-platform/back-up-restore-universes/restore-universe-data.md
@@ -30,6 +30,12 @@ Backups from a stable track universe can only be restored to a higher version st
 
     If the topology of the target universe does not match, none of the tablespaces are preserved and all their data is written to the primary region. After the restore, you will have to re-add all the tablespaces. For more information on specifying data placement for tables and indexes, refer to [Tablespaces](../../../explore/going-beyond-sql/tablespaces/).
 
+- If you are restoring from a Network File System (NFS) storage configuration, the entire backup must be readable by the `yugabyte` user. If `yugabyte` does not have read access, it is possible for restores to fail with a "file does not exist" error message.
+
+- If a universe that spans multiple regions is backed up to NFS using a different volume for each region, all the NFS volumes must be synced to contain the full backup. Each node will require access to the full backup.
+
+    - There is a caveat where a node will not require access to backed up tablets if that tablet is pinned to another region using [tablespaces](../../../explore/going-beyond-sql/tablespaces/).
+
 ## Restore an entire or incremental backup
 
 You can restore YugabyteDB universe data from a backup as follows:
@@ -294,6 +300,22 @@ To perform an advanced restore, on the YugabyteDB Anywhere installation where yo
     ```
 
     YugabyteDB Anywhere looks for the backup in `test_bucket/test`, not `user_bucket/test`.
+
+    The directory structure of the **Backup location** matters. YugabyteDB Anywhere determines the location of the backup files by removing the storage configuration's path from the start of the **Backup location** you provide, and then appending whatever remains to the storage configuration's path. As a result, the **Backup location** must begin with the path defined in the selected storage configuration. If it doesn't, the path is constructed incorrectly and the restore fails immediately.
+
+    The configuration path also includes a `yugabyte_backup` directory, which YugabyteDB Anywhere adds automatically when writing backups. The **Backup location** must include this directory. For example, for a storage configuration with the path `/backup`, a valid location is the following:
+
+    ```output
+    /backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+    ```
+
+    Similarly, for a storage configuration with the path `/mnt/backup/`, a valid location is the following:
+
+    ```output
+    /mnt/backup/yugabyte_backup/univ-<universe-uuid>/<database>/ybc_backup-<uuid>/full/<timestamp>/multi-table-<keyspace>_<uuid>
+    ```
+
+    Everything from the `yugabyte_backup` folder down must be left unchanged; only the leading storage address can differ, and only if it matches the selected storage configuration and the backup data actually resides there. If you moved or copied the backup to a new folder, please ensure the storage config with the correct path prefix is used to match where the backup data now resides.
 
 1. Specify the name of the database or keyspace from which you are performing a restore.
 


### PR DESCRIPTION
Document that the advanced restore Backup location must begin with the storage configuration path (including the auto-added yugabyte_backup directory for NFS), and add prerequisites covering NFS file readability by the yugabyte user and multi-region NFS replication (rsync). Applied to stable, v2025.1, v2024.2, and v2.20.

DOC-1294