### PR TITLE
[Docs] Add Source Group for Kapa MCP integration

### DIFF
--- a/docs/layouts/_partials/hooks/body-end.html
+++ b/docs/layouts/_partials/hooks/body-end.html
@@ -43,6 +43,7 @@ if (typeof detectExternalLink === 'function') {
   data-project-name="Yugabyte"
   data-project-color="rgb(120, 121, 241)"
   data-project-logo="/icons/yugabyte.svg"
+  data-source-group-ids-include="b7e416bc-0ead-40ac-a708-182c2a72ee6e"
   data-user-analytics-fingerprint-enabled="true"
   data-font-family="Inter,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji;"
   data-font-size-xs="13px"


### PR DESCRIPTION
Updates the Kapa widget integration to pass `source_group_ids_include` so queries are scoped to the YugabyteDB source group instead of using Global sources.