### PR TITLE
[#31938] YSQL: MAGE extension does work in backup/restore scenarios

### DIFF
--- a/java/yb-pgsql/src/test/java/org/yb/pgsql/TestYbBackup.java
+++ b/java/yb-pgsql/src/test/java/org/yb/pgsql/TestYbBackup.java
@@ -118,6 +118,15 @@ public class TestYbBackup extends BasePgSQLTest {
   }
 
   @Override
+  protected Map<String, String> getTServerFlags() {
+    Map<String, String> flagMap = super.getTServerFlags();
+    // Gates `CREATE EXTENSION mage` -- required by testMageBackupRestore and
+    // harmless to the other tests in this class (they do not touch mage).
+    flagMap.put("ysql_yb_enable_mage", "true");
+    return flagMap;
+  }
+
+  @Override
   protected void customizeMiniClusterBuilder(MiniYBClusterBuilder builder) {
     super.customizeMiniClusterBuilder(builder);
 
@@ -2183,6 +2192,64 @@ public class TestYbBackup extends BasePgSQLTest {
       assertQuery(stmt, "SELECT EXISTS(SELECT 1 FROM pg_class " +
                   "WHERE relname = 'hints_norm_and_app')", new Row(false));
 
+    }
+
+    // Cleanup.
+    try (Statement stmt = connection.createStatement()) {
+      if (isTestRunningWithConnectionManager())
+        waitForStatsToGetUpdated();
+      stmt.execute("DROP DATABASE yb2");
+    }
+  }
+
+  @Test
+  public void testMageBasicBackupRestore() throws Exception {
+    // End-to-end coverage for backup/restore of a database with the `mage`
+    // (Apache AGE) extension installed.
+    //
+    // The restore generates a ysql_dump in binary-upgrade mode that emits
+    // `DROP EXTENSION IF EXISTS mage;` before recreating an empty extension
+    // shell. Before the is_age_drop() fix in
+    // src/postgres/third-party-extensions/mage/src/backend/catalog/ag_catalog.c
+    // that DROP errored with `table "ag_graph" does not exist` and aborted
+    // the entire restore -- so any backup of a database using mage was
+    // effectively unrestorable.
+    //
+    // The test deliberately installs the extension *without* creating a graph.
+    // create_graph() materializes per-graph vertex/edge tables whose snapshot
+    // import currently hits an orthogonal issue at the master metadata stage;
+    // covering the extension itself is enough to exercise the failing DROP
+    // EXTENSION IF EXISTS mage path in ysql_dump that this fix targets.
+    String backupDir = null;
+    try (Statement stmt = connection.createStatement()) {
+      stmt.execute("CREATE EXTENSION mage");
+
+      backupDir = YBBackupUtil.getTempBackupDir();
+      String output = YBBackupUtil.runYbBackupCreate("--backup_location", backupDir,
+          "--keyspace", "ysql.yugabyte");
+      if (!TestUtils.useYbController()) {
+        backupDir = new JSONObject(output).getString("snapshot_url");
+      }
+    }
+
+    YBBackupUtil.runYbBackupRestore(backupDir, "--keyspace", "ysql.yb2");
+
+    try (Connection connection2 = getConnectionBuilder().withDatabase("yb2").connect();
+         Statement stmt = connection2.createStatement()) {
+      // mage is installed in the restored DB at the expected version.
+      assertQuery(stmt,
+          "SELECT extname, extversion FROM pg_extension WHERE extname = 'mage'",
+          new Row("mage", "1.6.0"));
+      // Catalog tables are member objects of the extension and were restored.
+      assertQuery(stmt,
+          "SELECT count(*) FROM mag_catalog.ag_graph",
+          new Row(0L));
+      // Dropping the restored extension must also work -- this exercises the
+      // AGE drop path on the restored side.
+      stmt.execute("DROP EXTENSION mage");
+      assertQuery(stmt,
+          "SELECT count(*) FROM pg_extension WHERE extname = 'mage'",
+          new Row(0L));
     }
 
     // Cleanup.

--- a/java/yb-pgsql/src/test/java/org/yb/pgsql/TestYbBackup.java
+++ b/java/yb-pgsql/src/test/java/org/yb/pgsql/TestYbBackup.java
@@ -2209,17 +2209,14 @@ public class TestYbBackup extends BasePgSQLTest {
     //
     // The restore generates a ysql_dump in binary-upgrade mode that emits
     // `DROP EXTENSION IF EXISTS mage;` before recreating an empty extension
-    // shell. Before the is_age_drop() fix in
-    // src/postgres/third-party-extensions/mage/src/backend/catalog/ag_catalog.c
-    // that DROP errored with `table "ag_graph" does not exist` and aborted
-    // the entire restore -- so any backup of a database using mage was
-    // effectively unrestorable.
+    // shell. 
     //
     // The test deliberately installs the extension *without* creating a graph.
     // create_graph() materializes per-graph vertex/edge tables whose snapshot
     // import currently hits an orthogonal issue at the master metadata stage;
     // covering the extension itself is enough to exercise the failing DROP
     // EXTENSION IF EXISTS mage path in ysql_dump that this fix targets.
+    // DB-21840
     String backupDir = null;
     try (Statement stmt = connection.createStatement()) {
       stmt.execute("CREATE EXTENSION mage");

--- a/src/postgres/third-party-extensions/mage/regress/expected/yb.orig.basic.out
+++ b/src/postgres/third-party-extensions/mage/regress/expected/yb.orig.basic.out
@@ -147,3 +147,28 @@ SELECT count(*) FROM pg_namespace WHERE nspname = 'basic';
      0
 (1 row)
 
+-- The extension is now gone. mag_catalog.ag_graph no longer exists (the
+-- mag_catalog schema itself can linger after the DROP above, but ag_graph does
+-- not). `DROP EXTENSION IF EXISTS mage` must be a clean no-op. Before the fix,
+-- is_age_drop() unconditionally routed this to drop_age_extension(), which
+-- enumerates graphs from mag_catalog.ag_graph and errored with
+-- `table "ag_graph" does not exist`. This is exactly the statement ysql_dump
+-- emits before recreating the empty extension in a binary-upgrade restore, so the
+-- failure broke backup/restore on databases using mage.
+DROP EXTENSION IF EXISTS mage;
+NOTICE:  extension "mage" does not exist, skipping
+-- Without IF EXISTS, dropping the absent extension must raise the standard
+-- "extension does not exist" error -- not the ag_graph/mag_catalog error.
+DROP EXTENSION mage;
+ERROR:  extension "mage" does not exist
+-- When the extension *is* installed, DROP EXTENSION IF EXISTS must still run the
+-- AGE-specific cleanup hook (is_age_drop() returns true and drop_age_extension()
+-- tears down the per-graph schemas).
+CREATE EXTENSION mage;
+DROP EXTENSION IF EXISTS mage;
+SELECT count(*) FROM pg_extension WHERE extname = 'mage';
+ count 
+-------
+     0
+(1 row)
+

--- a/src/postgres/third-party-extensions/mage/regress/sql/yb.orig.basic.sql
+++ b/src/postgres/third-party-extensions/mage/regress/sql/yb.orig.basic.sql
@@ -51,3 +51,21 @@ RESET search_path;
 DROP EXTENSION mage;
 SELECT count(*) FROM pg_extension WHERE extname = 'mage';
 SELECT count(*) FROM pg_namespace WHERE nspname = 'basic';
+-- The extension is now gone. mag_catalog.ag_graph no longer exists (the
+-- mag_catalog schema itself can linger after the DROP above, but ag_graph does
+-- not). `DROP EXTENSION IF EXISTS mage` must be a clean no-op. Before the fix,
+-- is_age_drop() unconditionally routed this to drop_age_extension(), which
+-- enumerates graphs from mag_catalog.ag_graph and errored with
+-- `table "ag_graph" does not exist`. This is exactly the statement ysql_dump
+-- emits before recreating the empty extension in a binary-upgrade restore, so the
+-- failure broke backup/restore on databases using mage.
+DROP EXTENSION IF EXISTS mage;
+-- Without IF EXISTS, dropping the absent extension must raise the standard
+-- "extension does not exist" error -- not the ag_graph/mag_catalog error.
+DROP EXTENSION mage;
+-- When the extension *is* installed, DROP EXTENSION IF EXISTS must still run the
+-- AGE-specific cleanup hook (is_age_drop() returns true and drop_age_extension()
+-- tears down the per-graph schemas).
+CREATE EXTENSION mage;
+DROP EXTENSION IF EXISTS mage;
+SELECT count(*) FROM pg_extension WHERE extname = 'mage';

--- a/src/postgres/third-party-extensions/mage/src/backend/catalog/ag_catalog.c
+++ b/src/postgres/third-party-extensions/mage/src/backend/catalog/ag_catalog.c
@@ -25,7 +25,6 @@
 #include "catalog/pg_class_d.h"
 #include "catalog/pg_namespace_d.h"
 #include "commands/defrem.h"
-#include "commands/extension.h" /* YB: get_extension_oid() */
 #include "tcop/utility.h"
 #include "utils/lsyscache.h"
 
@@ -36,6 +35,7 @@
 #include "utils/ag_cache.h"
 
 /* YB includes */
+#include "commands/extension.h" /* YB: get_extension_oid() */
 #include "commands/graph_commands.h"
 
 static object_access_hook_type prev_object_access_hook;
@@ -158,7 +158,7 @@ static bool is_age_drop(PlannedStmt *pstmt)
                     return false;
 
                 return true;
-            }
+            } /* YB */
         }
     }
 

--- a/src/postgres/third-party-extensions/mage/src/backend/catalog/ag_catalog.c
+++ b/src/postgres/third-party-extensions/mage/src/backend/catalog/ag_catalog.c
@@ -25,6 +25,7 @@
 #include "catalog/pg_class_d.h"
 #include "catalog/pg_namespace_d.h"
 #include "commands/defrem.h"
+#include "commands/extension.h" /* YB: get_extension_oid() */
 #include "tcop/utility.h"
 #include "utils/lsyscache.h"
 
@@ -147,7 +148,17 @@ static bool is_age_drop(PlannedStmt *pstmt)
             char *str = val->sval;
 
             if (!pg_strcasecmp(str, "mage")) /* YB */
+            {
+                /*
+                 * YB: The AGE-specific drop path (drop_age_extension) enumerates
+                 * graphs from the mag_catalog.ag_graph table. When the mage
+                 * extension is not installed, that lookup errors out.
+                 */
+                if (!OidIsValid(get_extension_oid("mage", true)))
+                    return false;
+
                 return true;
+            }
         }
     }
 

--- a/src/postgres/third-party-extensions/mage/src/backend/catalog/ag_catalog.c
+++ b/src/postgres/third-party-extensions/mage/src/backend/catalog/ag_catalog.c
@@ -35,7 +35,7 @@
 #include "utils/ag_cache.h"
 
 /* YB includes */
-#include "commands/extension.h" /* YB: get_extension_oid() */
+#include "commands/extension.h"
 #include "commands/graph_commands.h"
 
 static object_access_hook_type prev_object_access_hook;

--- a/src/postgres/third-party-extensions/mage/src/backend/catalog/ag_catalog.c
+++ b/src/postgres/third-party-extensions/mage/src/backend/catalog/ag_catalog.c
@@ -154,7 +154,7 @@ static bool is_age_drop(PlannedStmt *pstmt)
                  * graphs from the mag_catalog.ag_graph table. When the mage
                  * extension is not installed, that lookup errors out.
                  */
-                if (!OidIsValid(get_extension_oid("mage", true)))
+                if (!OidIsValid(get_extension_oid("mage", true /* missing_ok */ )))
                     return false;
 
                 return true;


### PR DESCRIPTION
DO NOT MERGE!! [CSI](<https://csiweb.dev.yugabyte.com/pull/31981/>) ❌. Once CSI passes, comment `trigger jenkins` to clear this warning.

sql_dump in binary-upgrade mode emits

    DROP EXTENSION IF EXISTS mage;

before recreating an empty extension shell, so any backup/restore of a database that uses the mage (Apache AGE) extension hits this statement during restore. The mage ProcessUtility hook intercepts every DROP that mentions "mage" via is_age_drop() and unconditionally routes it through drop_age_extension(), which enumerates graphs from mag_catalog.ag_graph. When the extension is not (yet) installed on the restore target, that lookup errors out with

    ERROR:  table "ag_graph" does not exist

and the whole restore aborts, so a backup of a mage-using database was effectively unrestorable.

Fix: guard is_age_drop() with get_extension_oid("mage", true). When the extension is not installed, defer to standard ProcessUtility, which correctly performs the IF EXISTS no-op (or raises the standard "extension does not exist" error for a bare DROP EXTENSION mage). get_extension_oid is preferred over checking the mag_catalog schema: the schema can linger after a prior DROP EXTENSION (so a schema-based guard still ran the AGE drop path and still hit the ag_graph lookup).

Tests:

  * src/postgres/third-party-extensions/mage/regress/{sql,expected}/ yb.orig.basic.{sql,out}: three direct regress cases appended at the end of the existing yb.orig.basic test: - DROP EXTENSION IF EXISTS mage; when not installed -> NOTICE skip
      - DROP EXTENSION mage; when not installed           -> proper
        "extension does not exist" error, not the ag_graph one
      - CREATE EXTENSION mage; then DROP EXTENSION IF EXISTS mage;
        confirms the AGE cleanup path still runs when installed

  * java/yb-pgsql/src/test/java/org/yb/pgsql/TestYbBackup.java: testMageBackupRestore does an end-to-end YBC backup/restore round trip on a database with mage installed Adds a class-level ysql_yb_enable_mage=true tserver flag; harmless to the other tests in the class, which never CREATE EXTENSION mage.

Verified locally on a 3-node mini-cluster:
  * mage regress (TestPgRegressThirdPartyExtensionsMage): 1/1 pass.
  * TestYbBackup#testMageBackupRestore under YB_TEST_YB_CONTROLLER=1: