### PR TITLE
[Doc] Use partition_key for CREATE TABLE PARTITION BY syntax

### DIFF
--- a/docs/content/stable/api/ysql/syntax_resources/ysql_grammar.ebnf
+++ b/docs/content/stable/api/ysql/syntax_resources/ysql_grammar.ebnf
@@ -768,11 +768,13 @@ drop_tablespace = 'DROP' 'TABLESPACE' [ 'IF' 'EXISTS' ] tablespace_name;
 
 
 
+partition_key = ( column_name | '(' expression ')' ) [ operator_class_name ] ;
+
 (* 'CREATE' 'TABLE' *)
 create_table = 'CREATE' [ 'TEMPORARY' | 'TEMP' | 'UNLOGGED' ] 'TABLE'
                  [ 'IF' 'NOT' 'EXISTS' ] table_name
                  '(' [ table_elem { ',' table_elem } ] ')' \
-                 [ 'PARTITION' 'BY' ( 'RANGE' | 'LIST' | 'HASH' ) '(' index_elem { ',' index_elem } ')' ] \
+                 [ 'PARTITION' 'BY' ( 'RANGE' | 'LIST' | 'HASH' ) '(' partition_key { ',' partition_key } ')' ] \
                  [ 'WITH' '(' ( 'COLOCATION' '=' ('true' | 'false') | 'COLOCATION_ID' '=' int_literal | storage_parameters ) ')'
                       | 'WITHOUT' 'OIDS' ] \
                  [ 'TABLESPACE' tablespace_name ] \

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_table.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_create_table.md
@@ -23,6 +23,7 @@ Use the CREATE TABLE statement to create a table in a database. It defines the t
   table_constraint,
   key_columns,
   hash_columns,
+  partition_key,
   range_columns,
   storage_parameters,
   storage_parameter,

--- a/docs/content/v2024.2/api/ysql/syntax_resources/ysql_grammar.ebnf
+++ b/docs/content/v2024.2/api/ysql/syntax_resources/ysql_grammar.ebnf
@@ -764,11 +764,13 @@ drop_tablespace = 'DROP' 'TABLESPACE' [ 'IF' 'EXISTS' ] tablespace_name;
 
 
 
+partition_key = ( column_name | '(' expression ')' ) [ operator_class_name ] ;
+
 (* 'CREATE' 'TABLE' *)
 create_table = 'CREATE' [ 'TEMPORARY' | 'TEMP' | 'UNLOGGED' ] 'TABLE'
                  [ 'IF' 'NOT' 'EXISTS' ] table_name
                  '(' [ table_elem { ',' table_elem } ] ')' \
-                 [ 'PARTITION' 'BY' ( 'RANGE' | 'LIST' | 'HASH' ) '(' index_elem { ',' index_elem } ')' ] \
+                 [ 'PARTITION' 'BY' ( 'RANGE' | 'LIST' | 'HASH' ) '(' partition_key { ',' partition_key } ')' ] \
                  [ 'WITH' '(' ( 'COLOCATION' '=' ('true' | 'false') | 'COLOCATION_ID' '=' int_literal | storage_parameters ) ')'
                       | 'WITHOUT' 'OIDS' ] \
                  [ 'TABLESPACE' tablespace_name ]

--- a/docs/content/v2024.2/api/ysql/the-sql-language/statements/ddl_create_table.md
+++ b/docs/content/v2024.2/api/ysql/the-sql-language/statements/ddl_create_table.md
@@ -23,6 +23,7 @@ Use the `CREATE TABLE` statement to create a table in a database. It defines the
   table_constraint,
   key_columns,
   hash_columns,
+  partition_key,
   range_columns,
   storage_parameters,
   storage_parameter,

--- a/docs/content/v2025.1/api/ysql/syntax_resources/ysql_grammar.ebnf
+++ b/docs/content/v2025.1/api/ysql/syntax_resources/ysql_grammar.ebnf
@@ -768,11 +768,13 @@ drop_tablespace = 'DROP' 'TABLESPACE' [ 'IF' 'EXISTS' ] tablespace_name;
 
 
 
+partition_key = ( column_name | '(' expression ')' ) [ operator_class_name ] ;
+
 (* 'CREATE' 'TABLE' *)
 create_table = 'CREATE' [ 'TEMPORARY' | 'TEMP' | 'UNLOGGED' ] 'TABLE'
                  [ 'IF' 'NOT' 'EXISTS' ] table_name
                  '(' [ table_elem { ',' table_elem } ] ')' \
-                 [ 'PARTITION' 'BY' ( 'RANGE' | 'LIST' | 'HASH' ) '(' index_elem { ',' index_elem } ')' ] \
+                 [ 'PARTITION' 'BY' ( 'RANGE' | 'LIST' | 'HASH' ) '(' partition_key { ',' partition_key } ')' ] \
                  [ 'WITH' '(' ( 'COLOCATION' '=' ('true' | 'false') | 'COLOCATION_ID' '=' int_literal | storage_parameters ) ')'
                       | 'WITHOUT' 'OIDS' ] \
                  [ 'TABLESPACE' tablespace_name ]

--- a/docs/content/v2025.1/api/ysql/the-sql-language/statements/ddl_create_table.md
+++ b/docs/content/v2025.1/api/ysql/the-sql-language/statements/ddl_create_table.md
@@ -23,6 +23,7 @@ Use the CREATE TABLE statement to create a table in a database. It defines the t
   table_constraint,
   key_columns,
   hash_columns,
+  partition_key,
   range_columns,
   storage_parameters,
   storage_parameter,


### PR DESCRIPTION
Add a dedicated partition_key rule instead of reusing index_elem, so syntax diagrams do not show index-only HASH/ASC/DESC/NULLS options on partition columns.