### PR TITLE
[DOC-1348] TA: Potential for missing or spurious rows with multikey lookups larger than 64 bytes

### DIFF
--- a/docs/content/stable/releases/techadvisories/_index.md
+++ b/docs/content/stable/releases/techadvisories/_index.md
@@ -25,7 +25,7 @@ For an RSS feed of all technical advisories, point your feed reader to the [RSS 
 | Potential for missing or spurious rows with multikey lookups larger than 64 bytes
 | {{<product "ysql">}}
 | {{<release "2025.2.0.0">}} to {{<release "2025.2.3.0">}}
-| {{<nobreak "4 June 2026">}}
+| {{<nobreak "5 June 2026">}}
 |
 | {{<ta 31533>}}
 | An xCluster target universe's YB-Master may crash when certain types of schema changes are applied after database upgrade

--- a/docs/content/stable/releases/techadvisories/_index.md
+++ b/docs/content/stable/releases/techadvisories/_index.md
@@ -21,6 +21,12 @@ For an RSS feed of all technical advisories, point your feed reader to the [RSS 
 {{%table%}}
 | Advisory&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Synopsis | Product | Affected Versions | Date |
 | :------------------------------- | :------- | :-----: | :---------------: | :--- |
+| {{<ta 31688>}}
+| Potential for missing or spurious rows with multikey lookups larger than 64 bytes
+| {{<product "ysql">}}
+| {{<release "2025.2.0.0">}} to {{<release "2025.2.3.0">}}
+| {{<nobreak "4 June 2026">}}
+|
 | {{<ta 31533>}}
 | An xCluster target universe's YB-Master may crash when certain types of schema changes are applied after database upgrade
 | {{<product "ybdb">}}

--- a/docs/content/stable/releases/techadvisories/ta-31688.md
+++ b/docs/content/stable/releases/techadvisories/ta-31688.md
@@ -1,0 +1,59 @@
+---
+title: TA-31688
+headerTitle: Potential for missing or spurious rows with multikey lookups larger than 64 bytes
+description: Batched multi-key lookups on the leading column of an index may return incorrect results on affected 2025.2 releases when key lengths cross the 64-byte inline buffer threshold.
+headcontent: 4 June 2026
+type: docs
+showRightNav: true
+cascade:
+  unversioned: true
+menu:
+  stable_releases:
+    identifier: ta-31688
+    weight: 1
+rightNav:
+  hideH2: true
+---
+
+|          Product           |  Affected Versions  |  Related Issues   | Fixed In |
+| :------------------------- | :------------------ | :---------------- | :------- |
+| {{<product "ysql">}}       | {{<release "2025.2.0.0">}} to {{<release "2025.2.3.0">}} | {{<issue 31688>}} | {{<release "2025.2.3.1">}}, <br> Upcoming releases: {{<release "2025.2.4.0">}}, {{<release "2026.1.0.0">}} |
+
+## Description
+
+On affected versions, a query that performs a batched lookup of multiple key values on the leading column of an index may return an incorrect result set: rows that exist on disk can be silently omitted, and rows that were deleted (or older versions of updated rows) can silently reappear.
+
+This issue is a highly specific edge case involving memory optimization and pointer tracking during batched multi-key lookups at query time. Triggering this issue requires a particular sequence and combination of key lengths, as described in the [details](#details).
+
+## Mitigation
+
+Upgrade to a release that contains the fix (see the above table).
+
+If an immediate upgrade is not possible, disable the variable [bloom filter](../../../architecture/docdb/performance/#data-model-aware-bloom-filters) optimization by setting the following YB-TServer flags and restarting the YB-TServer processes:
+
+```text
+--enable_scan_choices_variable_bloom_filter=false
+--disable_last_seen_ht_rollback=true
+```
+
+Disabling these flags avoids the incorrect-results path. Scans that previously benefited from the optimization may perform additional SST reads, but correctness is restored.
+
+## Details
+
+The bug was introduced by the variable bloom filter support added in {{<issue 28439>}}, first released in {{<release "2025.2.0.0">}}.
+
+YugabyteDB uses [bloom filters](../../../architecture/docdb/performance/#data-model-aware-bloom-filters) to avoid unnecessary SST file reads during key lookups. Each SST file has an associated bloom filter; before reading a file to check whether it contains a target key, [RocksDB](https://rocksdb.org/) consults the filter. If the filter reports the key is definitely absent, the file is skipped entirely.
+
+YugabyteDB optimizes these scans by pointing directly to an internal memory buffer rather than repeatedly copying key data by value. The issue manifests as a highly specific edge case under a precise sequence of events:
+
+1. A query is performing a batched multi-key lookup, in which there are several discrete target keys for the same scan. The common ways a query produces one are:
+    - an `IN` / `ANY` list on a key column
+    - a [batched nested loop join](../../../reference/configuration/postgresql-compatibility/#batched-nested-loop-join)
+    - the read-ahead probe performed by `INSERT ON CONFLICT`
+1. The scan begins processing a batch of small keys, which safely fit into a fast, default inline memory buffer (under 64 bytes).
+1. A subsequent key within the same query batch exceeds 64 bytes, forcing the database to dynamically reallocate and move the buffer to a larger space in memory.
+1. Because the logical data has not changed, optimization paths intentionally skip refreshing the underlying iterator. However, because the physical buffer was moved, the iterator is left tracking a stale pointer to an old, deallocated memory address.
+
+This memory mismatch changes the [bloom filter](../../../architecture/docdb/performance/#data-model-aware-bloom-filters) evaluations for the remainder of the scan, resulting in missing or spurious rows in the query output.
+
+This issue does not cause any direct change to the data on disk: data in the SST files remains intact. However, a DML query affected by this issue may make unintended changes.

--- a/docs/content/stable/releases/techadvisories/ta-31688.md
+++ b/docs/content/stable/releases/techadvisories/ta-31688.md
@@ -2,7 +2,7 @@
 title: TA-31688
 headerTitle: Potential for missing or spurious rows with multikey lookups larger than 64 bytes
 description: Batched multi-key lookups on the leading column of an index may return incorrect results on affected 2025.2 releases when key lengths cross the 64-byte inline buffer threshold.
-headcontent: 4 June 2026
+headcontent: 5 June 2026
 type: docs
 showRightNav: true
 cascade:


### PR DESCRIPTION
Deploy preview:https://deploy-preview-32040--infallible-bardeen-164bc9.netlify.app/stable/releases/techadvisories/ta-31688/