### PR TITLE
[#32043] CDC: Fix TestCDCSDKCacheWithLeaderReElect to pass leader index to StepDownLeader

### DIFF
--- a/src/yb/integration-tests/cdcsdk_ysql-test.cc
+++ b/src/yb/integration-tests/cdcsdk_ysql-test.cc
@@ -3674,7 +3674,7 @@ TEST_F(CDCSDKYsqlTest, YB_DISABLE_TEST_IN_TSAN(TestCDCSDKCacheWithLeaderReElect)
             << correct_expiry_time.time_since_epoch().count();
 
   // we need to ensure the initial leader get's back leadership
-  ASSERT_OK(StepDownLeader(first_follower_index, tablets[0].tablet_id()));
+  ASSERT_OK(StepDownLeader(first_leader_index, tablets[0].tablet_id()));
   LOG(INFO) << "Changed leadership back to the first leader TServer";
 
   // Call the test RPC to get last active time of the current leader (original), and it should


### PR DESCRIPTION
## Summary

`TestCDCSDKCacheWithLeaderReElect` passed `first_follower_index` to `StepDownLeader`, asking a follower to step down — a no-op, since only the leader can step down. Use `first_leader_index` so the leader actually steps down and a real re-election occurs, which is what the test is meant to exercise.

On Linux this happened to pass: the no-op self-stepdown still triggered a full pre-election + election cycle, and the 1s background task refreshed the follower's `cdc_sdk_min_checkpoint_op_id_expiration` within the test's 500ms `StepDownLeader` sleep, so `CompareExpirationTime` saw a fresh value. On macOS the timing didn't line up, no fresh expiration update reached the follower, and the test hung in `CompareExpirationTime` until the 10-minute test timeout killed it.

## Test plan

- [x] `TestCDCSDKCacheWithLeaderReElect` passes on macOS
- [x] `TestCDCSDKCacheWithLeaderReElect` continues to pass on Linux
