### PR TITLE
[BACKPORT 2026.1][#31870] DocDB: PgResponseCache entries become invalid after the originating RPC's deadline

### DIFF
--- a/src/yb/tserver/pg_response_cache.cc
+++ b/src/yb/tserver/pg_response_cache.cc
@@ -33,6 +33,7 @@
 #include "yb/tserver/pg_client.messages.h"
 
 #include "yb/util/async_util.h"
+#include "yb/util/enums.h"
 #include "yb/util/flags.h"
 #include "yb/util/flags/flag_tags.h"
 #include "yb/util/logging.h"
@@ -175,6 +176,8 @@ class MetricUpdater {
   DISALLOW_COPY_AND_ASSIGN(MetricUpdater);
 };
 
+YB_DEFINE_ENUM(DataState, (kNotReady)(kReadyOK)(kReadyFailure));
+
 class Data {
  public:
   Data(uint64_t version,
@@ -194,23 +197,24 @@ class Data {
           ReadHybridTime::SingleTime(HybridTime::FromMicros(
               FLAGS_TEST_pg_response_cache_catalog_read_time_usec)));
     }
-    auto failed = !IsOk(value);
+    auto new_state = DataState::kReadyFailure;
     size_t sz = 0;
-    if (!failed) {
+    if (IsOk(value)) {
       for (const auto& data : value.rows_data) {
         sz += data.size();
       }
+      new_state = DataState::kReadyOK;
     }
     decltype(waiters_) waiters;
     // Since response_ is not changed after assignment, we could store pointer to it to make
     // thread safety analysis happy, and then use it.
-    const PgResponseCache::Response* response;
+    const PgResponseCache::Response* response = nullptr;
     {
       std::lock_guard lock(mutex_);
       response_ = std::move(value);
       waiters.swap(waiters_);
       response = &*response_;
-      failed_ = failed;
+      state_.store(new_state, std::memory_order_release);
     }
     for (auto waiter : waiters) {
       waiter->Apply(*response);
@@ -223,8 +227,20 @@ class Data {
     }
   }
 
-  [[nodiscard]] bool IsValid(CoarseTimePoint now, uint64_t version) {
-    return version == version_ && now < readiness_deadline_ && !failed_;
+  [[nodiscard]] bool IsValid(CoarseTimePoint now, uint64_t version) const {
+    if (PREDICT_FALSE(version != version_)) {
+      return false;
+    }
+    const auto state = state_.load(std::memory_order_acquire);
+    switch (state) {
+      case DataState::kNotReady:
+        return now < readiness_deadline_;
+      case DataState::kReadyOK:
+        return true;
+      case DataState::kReadyFailure:
+        return false;
+    }
+    FATAL_INVALID_ENUM_VALUE(DataState, state);
   }
 
   [[nodiscard]] std::optional<const PgResponseCache::Response*> RegisterWaiter(
@@ -251,7 +267,7 @@ class Data {
   const CoarseTimePoint creation_time_;
   const CoarseTimePoint readiness_deadline_;
   std::mutex mutex_;
-  std::atomic<bool> failed_{false};
+  std::atomic<DataState> state_{DataState::kNotReady};
   bool running_ GUARDED_BY(mutex_) = false;
   std::optional<PgResponseCache::Response> response_ GUARDED_BY(mutex_);
   std::vector<PgResponseCacheWaiterPtr> waiters_ GUARDED_BY(mutex_);

--- a/src/yb/yql/pgwrapper/pg_catalog_perf-test.cc
+++ b/src/yb/yql/pgwrapper/pg_catalog_perf-test.cc
@@ -63,6 +63,8 @@ DECLARE_uint64(pg_response_cache_size_bytes);
 DECLARE_uint32(pg_response_cache_size_percentage);
 DECLARE_int32(pgsql_proxy_webserver_port);
 DECLARE_bool(ysql_enable_relcache_init_optimization);
+DECLARE_int32(ysql_client_read_write_timeout_ms);
+DECLARE_int32(pg_client_extra_timeout_ms);
 
 using namespace std::literals;
 
@@ -552,6 +554,40 @@ TEST_F_EX(PgCatalogPerfTest,
   }));
   ASSERT_EQ(metrics.cache.queries, 5);
   ASSERT_EQ(metrics.cache.hits, 5);
+}
+
+class PgCatalogShortRpcDeadlineTest : public PgCatalogWithUnlimitedCachePerfTest {
+ protected:
+  static constexpr int kRpcDeadlineMs = 2000;
+  static constexpr int kPgClientExtraTimeoutMs = 1000;
+
+  void SetUp() override {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_ysql_client_read_write_timeout_ms) = kRpcDeadlineMs;
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_pg_client_extra_timeout_ms) = kPgClientExtraTimeoutMs;
+    PgCatalogWithUnlimitedCachePerfTest::SetUp();
+  }
+};
+
+// Test that the response cache is used even after the RPC deadline has passed.
+TEST_F_EX(PgCatalogPerfTest,
+          ResponseCacheValidPastReadinessDeadline,
+          PgCatalogShortRpcDeadlineTest) {
+  // Warm up catalog's response cache.
+  ASSERT_RESULT(Connect());
+
+  const auto total_deadline_ms =
+      PgCatalogShortRpcDeadlineTest::kRpcDeadlineMs +
+      PgCatalogShortRpcDeadlineTest::kPgClientExtraTimeoutMs;
+  std::this_thread::sleep_for(std::chrono::milliseconds(
+      total_deadline_ms + ReleaseVsDebugVsAsanVsTsan(4000, 8000, 10000, 16000)));
+
+  // Ensure new connections use the response cache.
+  auto metrics = ASSERT_RESULT(metrics_->Delta([this] {
+    RETURN_NOT_OK(Connect());
+    return static_cast<Status>(Status::OK());
+  }));
+  ASSERT_GT(metrics.cache.queries, 0);
+  ASSERT_EQ(metrics.cache.queries, metrics.cache.hits);
 }
 
 // The test checks response cache renewing process in case of 'Snapshot too old' error.


### PR DESCRIPTION
DO NOT MERGE!! [CSI](<https://csiweb.dev.yugabyte.com/pull/32072/>) ❌. Once CSI passes, comment `trigger jenkins` to clear this warning.

Summary:
`PgResponseCache::Data::IsValid` unconditionally checked
`now < readiness_deadline_`, where `readiness_deadline_` is set once at
entry creation from the originating RPC's wall-clock deadline (the YSQL
client RW timeout, ~10 min by default). This caused every cache entry --
even one with a successful, populated, version-current response --
to become "invalid" once wall-clock crossed that deadline, forcing a
full rebuild every few minutes. The rebuilt RPC's response carries a fresh
`catalog_read_time` that propagates into subsequent paged RPCs' cache
keys, so one expiry cascades into ~5 misses per preload sequence on
every new connection's prefetch.

This was a regression introduced by #27412 (commit f960a4a1c7f, "Async
wait on pg response cache"). Pre-refactor, the deadline was only
consulted while the response was still in-flight:

  return version == version_ &&
         (IsReady(future_) ? IsOk(future_.get()) : now < readiness_deadline_);

Restore the pre-refactor semantics: the deadline remains a watchdog on
a stalled fetch, but a populated successful response stays valid until
catalog-version invalidation or LRU eviction supersedes it. The same
change was reverted on the 2024.2.4 backport branch (commit
413142ade11); this fix restores correct behavior on master.

Original commit: 36b344fe395d7b17c3152bf420f4bf05651fe084 / D53645

Test Plan:
New test:
  ./yb_build.sh release --cxx-test pg_catalog_perf-test \
    --gtest_filter PgCatalogPerfTest.ResponseCacheValidPastReadinessDeadline

Regression check (all response-cache tests):
  ./yb_build.sh release --cxx-test pg_catalog_perf-test \
    --gtest_filter '*ResponseCache*'

Verified locally that:
  - The new test fails before the IsValid fix (cache.hits = 0 instead of 5)
    when the warm-up entry's readiness_deadline has elapsed.
  - The new test passes with the fix.
  - All 10 existing *ResponseCache* tests still pass.

Reviewers: dmitry

Reviewed By: dmitry

Subscribers: svc_phabricator, yql, ybase

Differential Revision: https://phorge.dev.yugabyte.com/D53645