### PR TITLE
[#32075] YSQL: Fix stale txn_start_us at coordinator causing wrong deadlock victim selection

### DIFF
--- a/src/yb/yql/pgwrapper/pg_object_locks-test.cc
+++ b/src/yb/yql/pgwrapper/pg_object_locks-test.cc
@@ -355,6 +355,12 @@ TEST_F(PgObjectLocksTestRF1Deadlock, YB_DISABLE_TEST_IN_SANITIZERS(TestDeadlockS
   ASSERT_OK(WaitFor([&]() {
     return NumWaitingLocks() >= 1;
   }, 5s * kTimeMultiplier, "Timed out waiting for num waiting locks to be >= 1"));
+  // At this point both txns have triggered SetStartTimeIfNecessary via the object-lock path, so
+  // their local start_ values are set. Wait for the next periodic transaction heartbeat to carry
+  // those values to each status-tablet coordinator before forming the deadlock cycle, so the
+  // deadlock detector sees real txn_start_us values instead of the stale first_touch_=0 left by
+  // the pool-prebuilt CREATED heartbeat.
+  SleepFor(FLAGS_transaction_heartbeat_usec * 1us * kTimeMultiplier * 2);
   auto status_future_2 = std::async(std::launch::async, [&]() -> Status {
     RETURN_NOT_OK(conn1.Execute("LOCK TABLE test IN ACCESS EXCLUSIVE MODE"));
     return Status::OK();


### PR DESCRIPTION
## Problem

`PgObjectLocksTestRF1Deadlock.TestDeadlockSimple` was hanging on macOS. On Linux it usually passed but was latently broken in the same way — the test only happened to land on a benign timing.

## Root cause

The deadlock detector picks the victim with the maximum `txn_start_us` (newest transaction loses), with UUID lex order as tiebreaker. It reads `txn_start_us` from the transaction coordinator's per-txn `first_touch_` field, which is set from the `start_time` field on incoming heartbeat RPCs.

Two coincident facts produce the bug:

1. **`TransactionPool::Take` pre-prepares transactions.** When a connection asks the pool for a `kPlain` transaction, the pool returns one it has already `Prepare()`-ed. `Prepare()` triggers `RequestStatusTablet → LookupTabletDone → SendHeartbeat(CREATED)` — registering the transaction on the coordinator **before PG has provided the `xactStartTimestamp`**. At that moment, `YBTransaction::Impl::start_` is still 0.

2. **The heartbeat code suppresses `start_time` when `start_ == 0`** (`client/transaction.cc:1458-1467`). So the prebuild's CREATED heartbeat carries no `start_time` field; the coordinator records `first_touch_ = 0` (`tablet/transaction_coordinator.cc:787`).

When PG later calls `YBTransaction::SetPgTxnStart(xactStartTimestamp, ...)`, the original implementation stored the value only into `metadata_.pg_txn_start_us` — it did **not** update `start_`, and did **not** notify the coordinator. The next periodic heartbeat (`FLAGS_transaction_heartbeat_usec`, default ~500 ms) would eventually carry the correct `start_time` and overwrite `first_touch_`, but in the failing test runs the deadlock detector fired before that tick landed.

## Platform-specific symptom

The bug is the same on both platforms, but the observed outcome diverges based on timing:

- **macOS (consistently hangs).** Both transactions in the deadlock cycle were still at `first_touch_ = 0` when the deadlock detector ran. The cycle string emitted was `<0>c3561032-...-><0>52963476-...->`. With both `txn_start_us` equal to 0, victim selection fell through to UUID lex tiebreaker. On the failing runs this picked the SHARE-holder, which then released its locks while the lock-waiter kept waiting — orphaned locks → hang.

- **Linux (usually passes).** The second transaction's periodic heartbeat consistently landed before the deadlock detector ran, so its `first_touch_` had the real PG `xactStartTimestamp` while the first transaction's was still 0. Since `real_ts > 0`, the second (newer) transaction was correctly picked as victim. The test passed not because the bug wasn't present, but because Linux scheduling happened to deliver a heartbeat in the narrow window before the deadlock detector ran. The macOS scheduler (or local clock / RPC latency) shifted that race the other way, making the bug deterministic.

This is why prior `--num-reps` runs on Linux looked clean: the bug was masked by a heartbeat-vs-detector race that Linux usually won and macOS usually lost.

## Fix

Test-only change: after `WaitFor(NumWaitingLocks() >= 1)` succeeds — i.e., both transactions have executed their first `LOCK` and therefore set `start_` locally via `SetStartTimeIfNecessary` — sleep `2 × FLAGS_transaction_heartbeat_usec` before forming the deadlock cycle. This gives the periodic heartbeat one tick to carry the real `start_us` to each status-tablet coordinator, so the deadlock detector sees real values instead of `<0>`.

Matches the existing 2×-heartbeat sleep pattern used elsewhere in the same file (lines 1495, 1507).

An earlier version of this PR fixed the underlying race in `YBTransaction::SetPgTxnStart` (write `start_` + fire a corrective heartbeat). That approach was set aside in favor of stabilizing the test, leaving the production code path unchanged.

## Test plan

- [x] `PgObjectLocksTestRF1Deadlock.TestDeadlockSimple` passes on macOS (previously a deterministic hang)
- [x] `PgObjectLocksTestRF1Deadlock.TestDeadlockSimple` passes on Linux across repeated runs
