### PR TITLE
[doc] Removed Set schema entry from ysql_grammar file

### DIFF
--- a/docs/content/stable/api/ysql/syntax_resources/ysql_grammar.ebnf
+++ b/docs/content/stable/api/ysql/syntax_resources/ysql_grammar.ebnf
@@ -963,8 +963,7 @@ alter_aggregate = 'ALTER' 'AGGREGATE' aggregate_name '(' aggregate_signature ')'
 
 alter_aggregate_action =
   'RENAME' 'TO' new_name |
-  'OWNER' 'TO' ( new_owner | 'CURRENT_ROLE' | 'CURRENT_USER' | 'SESSION_USER' ) |
-  'SET' 'SCHEMA' schema_name ;
+  'OWNER' 'TO' ( new_owner | 'CURRENT_ROLE' | 'CURRENT_USER' | 'SESSION_USER' ) ;
 
 (* 'DROP' 'AGGREGATE' *)
 drop_aggregate = 'DROP' 'AGGREGATE' [ 'IF' 'EXISTS' ] ( aggregate_name '(' aggregate_signature ')' )


### PR DESCRIPTION
It should be added from 2026.1. Got missed in a previous PR - https://github.com/yugabyte/yugabyte-db/pull/31582/