### PR TITLE
[BACKPORT 2026.1][#31670] YSQL: Disable parallel query for CTAS and REFRESH MATERIALIZED VIEW

### DIFF
--- a/src/postgres/src/backend/commands/copyto.c
+++ b/src/postgres/src/backend/commands/copyto.c
@@ -515,9 +515,11 @@ BeginCopyTo(ParseState *pstate,
 					 errmsg("COPY query must have a RETURNING clause")));
 		}
 
-		/* plan the query */
+		/* plan the query. YB: parallel query is disabled for DDLs by default. */
 		plan = pg_plan_query(query, pstate->p_sourcetext,
-							 CURSOR_OPT_PARALLEL_OK, NULL);
+							 (IsYugaByteEnabled() && yb_disable_parallel_query_in_ddl) ?
+							 0 : CURSOR_OPT_PARALLEL_OK,
+							 NULL);
 
 		/*
 		 * With row-level security and a user using "COPY relation TO", we

--- a/src/postgres/src/backend/commands/createas.c
+++ b/src/postgres/src/backend/commands/createas.c
@@ -330,9 +330,11 @@ ExecCreateTableAs(ParseState *pstate, CreateTableAsStmt *stmt,
 		query = linitial_node(Query, rewritten);
 		Assert(query->commandType == CMD_SELECT);
 
-		/* plan the query */
+		/* plan the query. YB: parallel query is disabled for DDLs by default. */
 		plan = pg_plan_query(query, pstate->p_sourcetext,
-							 CURSOR_OPT_PARALLEL_OK, params);
+							 (IsYugaByteEnabled() && yb_disable_parallel_query_in_ddl) ?
+							 0 : CURSOR_OPT_PARALLEL_OK,
+							 params);
 
 		/*
 		 * Use a snapshot with an updated command ID to ensure this query sees

--- a/src/postgres/src/backend/commands/explain.c
+++ b/src/postgres/src/backend/commands/explain.c
@@ -1465,8 +1465,11 @@ ExplainOneUtility(Node *utilityStmt, IntoClause *into, ExplainState *es,
 
 		rewritten = QueryRewrite(castNode(Query, copyObject(ctas->query)));
 		Assert(list_length(rewritten) == 1);
+		/* YB: parallel query is disabled for DDLs by default. */
 		ExplainOneQuery(linitial_node(Query, rewritten),
-						CURSOR_OPT_PARALLEL_OK, ctas->into, es,
+						(IsYugaByteEnabled() && yb_disable_parallel_query_in_ddl) ?
+						0 : CURSOR_OPT_PARALLEL_OK,
+						ctas->into, es,
 						queryString, params, queryEnv);
 	}
 	else if (IsA(utilityStmt, DeclareCursorStmt))

--- a/src/postgres/src/backend/commands/matview.c
+++ b/src/postgres/src/backend/commands/matview.c
@@ -438,8 +438,14 @@ refresh_matview_datafill(DestReceiver *dest, Query *query,
 	/* Check for user-requested abort. */
 	CHECK_FOR_INTERRUPTS();
 
-	/* Plan the query which will generate data for the refresh. */
-	plan = pg_plan_query(query, queryString, CURSOR_OPT_PARALLEL_OK, NULL);
+	/*
+	 * Plan the query which will generate data for the refresh.
+	 * YB: parallel query is disabled for DDLs by default.
+	 */
+	plan = pg_plan_query(query, queryString,
+						 (IsYugaByteEnabled() && yb_disable_parallel_query_in_ddl) ?
+						 0 : CURSOR_OPT_PARALLEL_OK,
+						 NULL);
 
 	/*
 	 * Use a snapshot with an updated command ID to ensure this query sees

--- a/src/postgres/src/backend/utils/misc/guc.c
+++ b/src/postgres/src/backend/utils/misc/guc.c
@@ -3103,6 +3103,22 @@ static struct config_bool ConfigureNamesBool[] =
 	},
 
 	{
+		{"yb_disable_parallel_query_in_ddl", PGC_USERSET, QUERY_TUNING_METHOD,
+			gettext_noop("Disables parallel query for the SELECT planned by DDLs "
+						 "such as CREATE TABLE AS, SELECT INTO, CREATE/REFRESH "
+						 "MATERIALIZED VIEW, COPY (query) TO, and EXPLAIN "
+						 "[ANALYZE] CREATE TABLE AS."),
+			gettext_noop("Enabled by default because parallel query in these "
+						 "DDLs has not been QA tested in YugabyteDB. Set to off "
+						 "as an escape hatch to restore upstream PostgreSQL "
+						 "behavior for workloads that rely on it.")
+		},
+		&yb_disable_parallel_query_in_ddl,
+		true,
+		NULL, NULL, NULL
+	},
+
+	{
 		{"yb_test_skip_binding_scan_keys", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("For YB scans, skip binding scan keys to pggate. "
 						 "ybgin and internal scans are not affected."),

--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -2210,6 +2210,7 @@ bool		yb_enable_saop_pushdown = true;
 int			yb_toast_catcache_threshold = 2048; /* 2 KB */
 int			yb_catcache_list_from_preloaded_limit = 100000;
 int			yb_parallel_range_size = 1024 * 1024;
+bool		yb_disable_parallel_query_in_ddl = true;
 int			yb_insert_on_conflict_read_batch_size = 1024;
 bool		yb_enable_fkey_catcache = true;
 bool		yb_enable_fkey_batched_docdb_lookup_when_types_mismatch = false;

--- a/src/postgres/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/postgres/src/backend/utils/misc/postgresql.conf.sample
@@ -390,6 +390,7 @@
 #enable_tidscan = on
 #yb_enable_geolocation_costing = on
 #yb_enable_parallel_append = off
+#yb_disable_parallel_query_in_ddl = on
 #yb_enable_expression_pushdown = off
 #yb_enable_sequence_pushdown = on
 #yb_enable_distinct_pushdown = on

--- a/src/postgres/src/include/pg_yb_utils.h
+++ b/src/postgres/src/include/pg_yb_utils.h
@@ -629,6 +629,15 @@ extern int	yb_catcache_list_from_preloaded_limit;
 extern int	yb_parallel_range_size;
 
 /*
+ * Disables parallel query for the SELECT planned by DDLs (CREATE TABLE AS,
+ * SELECT INTO, CREATE/REFRESH MATERIALIZED VIEW, COPY (query) TO, and
+ * EXPLAIN [ANALYZE] CREATE TABLE AS). Enabled by default because parallel
+ * query in these DDLs has not been QA tested in YugabyteDB; set to off as an
+ * escape hatch to restore upstream PostgreSQL behavior.
+ */
+extern bool yb_disable_parallel_query_in_ddl;
+
+/*
  * INSERT ON CONFLICT batching read batch size.
  */
 extern int	yb_insert_on_conflict_read_batch_size;


### PR DESCRIPTION
DO NOT MERGE!! [CSI](<https://csiweb.dev.yugabyte.com/pull/32099/>) ⏳

Summary:
Upstream PostgreSQL passes CURSOR_OPT_PARALLEL_OK to pg_plan_query when
planning the underlying SELECT of CREATE TABLE AS / SELECT INTO / CREATE
MATERIALIZED VIEW (added in PG 11) and REFRESH MATERIALIZED VIEW (added
in PG 14), which lets the planner emit a Gather node and launch parallel
workers at execution time.

This change passes 0 instead of CURSOR_OPT_PARALLEL_OK at those two call
sites when IsYugaByteEnabled() is true. It mirrors upstream's pre-PG-11
and pre-PG-14 behavior: standard_planner marks the plan parallel-unsafe,
no Gather node is created, and no parallel workers are launched.

**Rationale:** Parallel query for the SELECT executed by these DDLs (CTAS / SELECT INTO / CREATE & REFRESH MATERIALIZED VIEW, plus COPY (query) TO and EXPLAIN [ANALYZE] CREATE TABLE AS) has not been QA tested in YugabyteDB.

**Escape hatch GUC:**

Add GUC yb_disable_parallel_query_in_ddl (default true). User who rely on parallel query in these DDLs can `SET yb_disable_parallel_query_in_ddl = off` to enable parallel query in DDLs.

Make yb_disable_parallel_query_in_ddl default to false after the above DDLs are QA tested with parallel queries.

Original commit: 89916d20b5dba5097661ea5c0bb02a88271aa631 / D53247

Test Plan:
Jenkins

Manually ran the following diff

```
diff --git a/src/postgres/src/backend/access/transam/parallel.c b/src/postgres/src/backend/access/transam/parallel.c
index cc9400ba65..93d9952b87 100644
--- a/src/postgres/src/backend/access/transam/parallel.c
+++ b/src/postgres/src/backend/access/transam/parallel.c
@@ -598,6 +598,10 @@ LaunchParallelWorkers(ParallelContext *pcxt)
        if (pcxt->nworkers == 0 || pcxt->nworkers_to_launch == 0)
                return;

+       /* YB MANUAL-TEST INSTRUMENTATION — revert before commit. */
+       elog(LOG, "YB: LaunchParallelWorkers entered; nworkers=%d nworkers_to_launch=%d",
+                pcxt->nworkers, pcxt->nworkers_to_launch);
+
        if (IsYugaByteEnabled())
        {
                /*
```

with

  1. CREATE TABLE AS — createas.c
  2. SELECT INTO — createas.c
  3. CREATE MATERIALIZED VIEW — createas.c
  4. REFRESH MATERIALIZED VIEW — matview.c
  5. COPY (query) TO — copyto.c
  6. EXPLAIN [ANALYZE] CREATE TABLE AS — explain.c

none of them launched parallel workers.

Fixes #31670

Backport-through: 2026.1

Reviewers: pjain, amartsinchyk

Reviewed By: pjain, amartsinchyk

Subscribers: svc_phabricator, ybase, yql

Differential Revision: https://phorge.dev.yugabyte.com/D53247