### PR TITLE
[docs] Correct YSQL UPDATE index key support

### DIFF
--- a/docs/content/stable/api/ysql/the-sql-language/statements/dml_update.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/dml_update.md
@@ -34,7 +34,7 @@ See the section [The WITH clause and common table expressions](../../with-clause
 
 ## Semantics
 
-Updating columns that are part of an index key including PRIMARY KEY is not yet supported.
+You can update columns that are part of an index key, including `PRIMARY KEY` columns. The updated values must still satisfy all applicable constraints, such as primary key and unique index constraints.
 
 - While the `WHERE` clause allows a wide range of operators, the exact conditions used in the where clause have significant performance considerations (especially for large datasets). For the best performance, use a `WHERE` clause that provides values for all columns in `PRIMARY KEY` or `INDEX KEY`.
 
@@ -115,7 +115,7 @@ yugabyte=# SELECT * FROM sample ORDER BY k1;
   1 |  2 |  3 | a
   2 |  3 |  7 | 7
   3 |  4 |  5 | c
-(2 rows)
+(3 rows)
 ```
 
 ## See also

--- a/docs/content/v2.20/api/ysql/the-sql-language/statements/dml_update.md
+++ b/docs/content/v2.20/api/ysql/the-sql-language/statements/dml_update.md
@@ -32,7 +32,7 @@ See the section [The WITH clause and common table expressions](../../with-clause
 
 ## Semantics
 
-Updating columns that are part of an index key including PRIMARY KEY is not yet supported.
+You can update columns that are part of an index key, including `PRIMARY KEY` columns. The updated values must still satisfy all applicable constraints, such as primary key and unique index constraints.
 
 - While the `WHERE` clause allows a wide range of operators, the exact conditions used in the where clause have significant performance considerations (especially for large datasets). For the best performance, use a `WHERE` clause that provides values for all columns in `PRIMARY KEY` or `INDEX KEY`.
 
@@ -113,7 +113,7 @@ yugabyte=# SELECT * FROM sample ORDER BY k1;
   1 |  2 |  3 | a
   2 |  3 |  7 | 7
   3 |  4 |  5 | c
-(2 rows)
+(3 rows)
 ```
 
 ## See also

--- a/docs/content/v2024.2/api/ysql/the-sql-language/statements/dml_update.md
+++ b/docs/content/v2024.2/api/ysql/the-sql-language/statements/dml_update.md
@@ -32,7 +32,7 @@ See the section [The WITH clause and common table expressions](../../with-clause
 
 ## Semantics
 
-Updating columns that are part of an index key including PRIMARY KEY is not yet supported.
+You can update columns that are part of an index key, including `PRIMARY KEY` columns. The updated values must still satisfy all applicable constraints, such as primary key and unique index constraints.
 
 - While the `WHERE` clause allows a wide range of operators, the exact conditions used in the where clause have significant performance considerations (especially for large datasets). For the best performance, use a `WHERE` clause that provides values for all columns in `PRIMARY KEY` or `INDEX KEY`.
 
@@ -113,7 +113,7 @@ yugabyte=# SELECT * FROM sample ORDER BY k1;
   1 |  2 |  3 | a
   2 |  3 |  7 | 7
   3 |  4 |  5 | c
-(2 rows)
+(3 rows)
 ```
 
 ## See also

--- a/docs/content/v2025.1/api/ysql/the-sql-language/statements/dml_update.md
+++ b/docs/content/v2025.1/api/ysql/the-sql-language/statements/dml_update.md
@@ -32,7 +32,7 @@ See the section [The WITH clause and common table expressions](../../with-clause
 
 ## Semantics
 
-Updating columns that are part of an index key including PRIMARY KEY is not yet supported.
+You can update columns that are part of an index key, including `PRIMARY KEY` columns. The updated values must still satisfy all applicable constraints, such as primary key and unique index constraints.
 
 - While the `WHERE` clause allows a wide range of operators, the exact conditions used in the where clause have significant performance considerations (especially for large datasets). For the best performance, use a `WHERE` clause that provides values for all columns in `PRIMARY KEY` or `INDEX KEY`.
 
@@ -113,7 +113,7 @@ yugabyte=# SELECT * FROM sample ORDER BY k1;
   1 |  2 |  3 | a
   2 |  3 |  7 | 7
   3 |  4 |  5 | c
-(2 rows)
+(3 rows)
 ```
 
 ## See also


### PR DESCRIPTION
## Summary

- Update YSQL `UPDATE` semantics to remove the obsolete statement that index-key and primary-key column updates are unsupported.
- Clarify that YSQL supports updating columns that are part of an index key, including `PRIMARY KEY` columns, subject to applicable constraints.
- Apply the correction to stable, v2025.1, v2024.2, and v2.20 docs.
- Fix the sample query output row count from `(2 rows)` to `(3 rows)`.

## Validation

- Confirmed release notes document support for primary-key updates:
  - `docs/content/stable/releases/ybdb-releases/end-of-life/v2.3.md`
- Confirmed existing regression coverage for index-key and primary-key updates:
  - `src/postgres/src/test/regress/sql/yb.orig.update_optimize_index_updates.sql`
- Confirmed source support via `YBCExecuteUpdateReplace` comment:
  - `src/postgres/src/include/executor/ybModifyTable.h`
- Ran `git diff --check`
