### PR TITLE
[#32074] DocDB: Fix webserver auth failing to start with --webserver_password_file

### DIFF
--- a/src/yb/server/webserver-test.cc
+++ b/src/yb/server/webserver-test.cc
@@ -287,6 +287,57 @@ TEST_F(WebserverTest, TestStaticFiles) {
   ASSERT_EQ("Remote error: HTTP 403", s.ToString(/* no file/line */ false));
 }
 
+// Tests that enabling password authentication (--webserver_password_file /
+// --webserver_authentication_domain) works end-to-end.
+class WebserverAuthTest : public WebserverTest {
+ public:
+  WebserverAuthTest() {
+    password_file_ = GetTestPath("webserver-htpasswd");
+  }
+
+  WebserverOptions ServerOptions() override {
+    auto opts = WebserverTest::ServerOptions();
+    opts.authentication_domain = kAuthDomain;
+    opts.password_file = password_file_;
+    return opts;
+  }
+
+  void SetUp() override {
+    // The password file must exist before the webserver starts. squeasel uses HTTP Digest
+    // auth, so each line is "user:realm:HA1" where HA1 = md5(user:realm:password). Here:
+    // md5("yugabyte:YugabyteDB:yugabyte").
+    ASSERT_OK(WriteStringToFile(
+        env_.get(),
+        Format("$0:$1:0fbdc56fb215d4d2e29ff88863aa2da5\n", kUser, kAuthDomain),
+        password_file_));
+    // WebserverTest::SetUp() starts the server. Before the global_passwords_file ->
+    // global_auth_file fix, squeasel rejected the option and Start() failed here.
+    WebserverTest::SetUp();
+  }
+
+ protected:
+  static constexpr const char* kAuthDomain = "YugabyteDB";
+  static constexpr const char* kUser = "yugabyte";
+  static constexpr const char* kPassword = "yugabyte";
+  string password_file_;
+};
+
+// Regression test for the squeasel option-name mismatch (global_passwords_file vs.
+// global_auth_file) that prevented the webserver from starting whenever a password file was
+// set. The server must start (asserted in SetUp) and must actually enforce auth: a request
+// without credentials is rejected with HTTP 401.
+TEST_F(WebserverAuthTest, TestUnauthenticatedRequestRejected) {
+  Status s = curl_.FetchURL(url_, &buf_);
+  ASSERT_EQ("Remote error: HTTP 401", s.ToString(/* no file/line */ false));
+}
+
+// Companion to the above: a request carrying valid credentials must succeed, confirming the
+// password file is actually wired to squeasel's HTTP Digest auth (not merely that auth is on).
+TEST_F(WebserverAuthTest, TestAuthenticatedRequestSucceeds) {
+  curl_.set_auth_creds(kUser, kPassword);
+  ASSERT_OK(curl_.FetchURL(url_, &buf_));
+}
+
 class WebserverSecureTest : public WebserverTest {
  public:
   WebserverOptions ServerOptions() override {

--- a/src/yb/server/webserver.cc
+++ b/src/yb/server/webserver.cc
@@ -422,7 +422,11 @@ Status Webserver::Impl::Start() {
       return STATUS(InvalidArgument, ss.str());
     }
     LOG(INFO) << "Webserver: Password file is " << opts_.password_file;
-    options.push_back("global_passwords_file");
+    // The bundled squeasel registers this config option under the name "global_auth_file"
+    // (the GLOBAL_PASSWORDS_FILE enum is only the internal index). Passing the old Mongoose/Kudu
+    // name "global_passwords_file" makes sq_start() reject it as an invalid option and refuse to
+    // start the webserver, breaking --webserver_password_file authentication entirely.
+    options.push_back("global_auth_file");
     options.push_back(opts_.password_file.c_str());
   }
 

--- a/src/yb/util/curl_util.cc
+++ b/src/yb/util/curl_util.cc
@@ -151,6 +151,12 @@ Status EasyCurl::DoRequest(
     RETURN_NOT_OK(
         TranslateError(curl_easy_setopt(curl_, CURLOPT_SSL_CIPHER_LIST, cipher_list_.c_str())));
   }
+  if (!auth_creds_.empty()) {
+    // CURLAUTH_ANY lets curl pick whatever scheme the server advertises in its 401
+    // challenge (the embedded webserver uses Digest).
+    RETURN_NOT_OK(TranslateError(curl_easy_setopt(curl_, CURLOPT_HTTPAUTH, CURLAUTH_ANY)));
+    RETURN_NOT_OK(TranslateError(curl_easy_setopt(curl_, CURLOPT_USERPWD, auth_creds_.c_str())));
+  }
 
   typedef std::unique_ptr<curl_slist, std::function<void(curl_slist*)>> CurlSlistPtr;
   CurlSlistPtr http_header_list;

--- a/src/yb/util/curl_util.h
+++ b/src/yb/util/curl_util.h
@@ -111,6 +111,13 @@ class EasyCurl {
     cipher_list_ = cipher_list;
   }
 
+  // Sets the HTTP authentication credentials. When set, curl answers the server's
+  // auth challenge (e.g. HTTP Digest, as used by the embedded webserver). Pass empty
+  // strings to disable.
+  void set_auth_creds(const std::string& user, const std::string& password) {
+    auth_creds_ = user.empty() && password.empty() ? "" : user + ":" + password;
+  }
+
  private:
   // Do a request. If 'post_data' is non-NULL, does a POST.
   // Otherwise, does a GET.
@@ -130,6 +137,8 @@ class EasyCurl {
   int64 ssl_version_ = 0;
   // The allowed SSL ciphers to use. Defaults to system default.
   std::string cipher_list_;
+  // HTTP auth credentials in "user:password" form. Empty means no authentication.
+  std::string auth_creds_;
   DISALLOW_COPY_AND_ASSIGN(EasyCurl);
 };
 


### PR DESCRIPTION
Fixes #32074

## Summary

Enabling Web UI authentication with `--webserver_password_file` (together with
`--webserver_authentication_domain`) caused yb-master / yb-tserver to fail at
startup:

```
Webserver: Invalid option: global_passwords_file
Webserver: Could not start on address 0.0.0.0:7000
```

The embedded webserver passed the password-file path to squeasel under the
option name `global_passwords_file`, but the bundled squeasel registers that
config option as `global_auth_file` (`GLOBAL_PASSWORDS_FILE` is only the
internal enum index, not the option string). `sq_start()` did not recognize the
name, logged `Invalid option`, and returned `NULL`, so the webserver — and
therefore the whole process — never started, making the documented webserver
authentication flags unusable.

This passes the correct `global_auth_file` option name so the password file is
wired to squeasel's HTTP Digest auth.

## Test plan

Added `WebserverAuthTest` (in `webserver-test.cc`) with two cases:

- [x] `TestUnauthenticatedRequestRejected` — a request with no credentials is
  rejected with HTTP 401. Fails before the fix because the server refuses to
  start.
- [x] `TestAuthenticatedRequestSucceeds` — a request carrying valid credentials
  succeeds (HTTP 200), confirming the password file is actually wired to
  squeasel's HTTP Digest auth, not merely that auth is enabled.

To send Digest credentials from the test, `EasyCurl` gains a small
`set_auth_creds()` helper that sets `CURLOPT_HTTPAUTH`/`CURLOPT_USERPWD`.

```
./yb_build.sh release --cxx-test webserver-test --gtest_filter 'WebserverAuthTest.*'
```

Both cases pass with the fix. Reverting the option name to
`global_passwords_file` reproduces the original failure
(`Invalid option: global_passwords_file` / `Could not start on address`).
