### PR TITLE
[BACKPORT 2025.2][#26952] YSQL: Log call stacks in PG on SIGSEGV, SIGABRT, LOG(FATAL)

### DIFF
--- a/java/yb-pgsql/src/test/java/org/yb/pgsql/TestPgYbStat.java
+++ b/java/yb-pgsql/src/test/java/org/yb/pgsql/TestPgYbStat.java
@@ -73,6 +73,7 @@ public class TestPgYbStat extends BasePgSQLTest {
         startSignal.countDown();
         startSignal.await();
         try {
+          LOG.info("Executing query: {}", query);
           statement.execute(query);
         } catch (Throwable throwable) {
           if(isTestRunningWithConnectionManager())
@@ -86,6 +87,7 @@ public class TestPgYbStat extends BasePgSQLTest {
         startSignal.countDown();
         startSignal.await();
         Thread.sleep(100); // Allow the query execution a headstart before killing
+        LOG.info("Sending signal {} to backend pid {}", signal, pid);
         ProcessUtil.signalProcess(pid, signal);
       });
       MiscUtil.runInParallel(cmds, startSignal, 60);

--- a/java/yb-pgsql/src/test/java/org/yb/pgsql/TestYsqlUpgrade.java
+++ b/java/yb-pgsql/src/test/java/org/yb/pgsql/TestYsqlUpgrade.java
@@ -559,7 +559,7 @@ public class TestYsqlUpgrade extends BasePgSQLTest {
           + ", row_type_oid = " + newSysOid()
           + ")";
 
-      stmt.execute("SET yb_test_fail_next_ddl TO true");
+      stmt.execute("SET yb_test_fail_next_ddl TO 1");
       runInvalidQuery(stmt, ddlSql, "Failed DDL operation as requested");
 
       // Letting CatalogManagerBgTasks do the cleanup.

--- a/src/postgres/src/backend/postmaster/bgworker.c
+++ b/src/postgres/src/backend/postmaster/bgworker.c
@@ -786,6 +786,8 @@ StartBackgroundWorker(void)
 		pqsignal(SIGINT, StatementCancelHandler);
 		pqsignal(SIGUSR1, procsignal_sigusr1_handler);
 		pqsignal(SIGFPE, FloatExceptionHandler);
+		pqsignal(SIGSEGV, YbCriticalSignalHandler);
+		pqsignal(SIGABRT, YbCriticalSignalHandler);
 
 		/* XXX Any other handlers needed here? */
 	}

--- a/src/postgres/src/backend/tcop/postgres.c
+++ b/src/postgres/src/backend/tcop/postgres.c
@@ -3547,10 +3547,27 @@ FloatExceptionHandler(SIGNAL_ARGS)
 	/* We're not returning, so no need to save errno */
 	ereport(ERROR,
 			(errcode(ERRCODE_FLOATING_POINT_EXCEPTION),
-			 errmsg("floating-point exception"),
-			 errdetail("An invalid floating-point operation was signaled. "
-					   "This probably means an out-of-range result or an "
-					   "invalid operation, such as division by zero.")));
+				errmsg("floating-point exception"),
+				errdetail("An invalid floating-point operation was signaled. "
+						"This probably means an out-of-range result or an "
+						"invalid operation, such as division by zero."),
+				errbacktrace()));
+}
+
+void
+YbCriticalSignalHandler(SIGNAL_ARGS)
+{
+	/* reset to default handler */
+	pqsignal(postgres_signal_arg, SIG_DFL);
+
+	ereport(LOG,
+			(errcode(ERRCODE_INTERNAL_ERROR),
+				errmsg("received critical signal %d", postgres_signal_arg),
+				errdetail("The backend received signal %d.", postgres_signal_arg),
+				errbacktrace()));
+
+	/* route to default handler */
+	raise(postgres_signal_arg);
 }
 
 /*
@@ -6427,7 +6444,8 @@ PostgresMain(const char *dbname, const char *username)
 		pqsignal(SIGUSR1, procsignal_sigusr1_handler);
 		pqsignal(SIGUSR2, SIG_IGN);
 		pqsignal(SIGFPE, FloatExceptionHandler);
-
+		pqsignal(SIGSEGV, YbCriticalSignalHandler);
+		pqsignal(SIGABRT, YbCriticalSignalHandler);
 		/*
 		 * Reset some signals that are accepted by postmaster but not by
 		 * backend

--- a/src/postgres/src/backend/utils/error/elog.c
+++ b/src/postgres/src/backend/utils/error/elog.c
@@ -840,9 +840,10 @@ errfinish(const char *filename, int lineno, const char *funcname)
 	oldcontext = MemoryContextSwitchTo(ErrorContext);
 
 	if (!edata->backtrace &&
-		edata->funcname &&
-		backtrace_functions &&
-		matches_backtrace_functions(edata->funcname))
+		((edata->funcname &&
+		  backtrace_functions &&
+		  matches_backtrace_functions(edata->funcname)) ||
+		 (IsYugaByteEnabled() && elevel >= FATAL)))
 		set_backtrace(edata, 2);
 
 	/*

--- a/src/postgres/src/backend/utils/misc/guc.c
+++ b/src/postgres/src/backend/utils/misc/guc.c
@@ -2840,18 +2840,6 @@ static struct config_bool ConfigureNamesBool[] =
 	},
 
 	{
-		{"yb_test_fail_next_ddl", PGC_USERSET, DEVELOPER_OPTIONS,
-			gettext_noop("When set, the next DDL will fail right before "
-						 "commit."),
-			NULL,
-			GUC_NOT_IN_SAMPLE
-		},
-		&yb_test_fail_next_ddl,
-		false,
-		NULL, NULL, NULL
-	},
-
-	{
 		{"yb_xcluster_automatic_mode_target_ddl", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Used to identify DDLs executed in Automatic xCluster mode target "
 						 "universe. For example, DDL operations will skip the data loading "
@@ -4029,6 +4017,17 @@ static struct config_int ConfigureNamesInt[] =
 		},
 		&PostAuthDelay,
 		0, 0, INT_MAX / 1000000,
+		NULL, NULL, NULL
+	},
+	{
+		{"yb_test_fail_next_ddl", PGC_SUSET, DEVELOPER_OPTIONS,
+			gettext_noop("When set to non-zero, the next DDL will fail: "
+						 "1=ERROR, 2=FATAL, 3=PANIC, 4=crash."),
+			NULL,
+			GUC_NOT_IN_SAMPLE
+		},
+		&yb_test_fail_next_ddl,
+		0, 0, 4,
 		NULL, NULL, NULL
 	},
 	{

--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -154,6 +154,8 @@ static int YbGetNumCreateFunctionStmts();
 static int YbGetNumRollbackToSavepointStmts();
 static bool YBIsCurrentStmtCreateFunction();
 
+static void yb_maybe_test_fail_ddl(void);
+
 uint64_t
 YBGetActiveCatalogCacheVersion()
 {
@@ -2457,7 +2459,7 @@ bool	   *yb_extra_commands_to_retry_in_proc = NULL;
 
 bool		yb_test_system_catalogs_creation = false;
 
-bool		yb_test_fail_next_ddl = false;
+int			yb_test_fail_next_ddl = 0;
 
 int			yb_test_sleep_before_executor_start_ms = 0;
 
@@ -3287,13 +3289,7 @@ YBCommitTransactionContainingDDL()
 									has_change);
 
 	Assert(ddl_transaction_state.nesting_level == 0);
-	if (yb_test_fail_next_ddl)
-	{
-		yb_test_fail_next_ddl = false;
-		if (YbIsClientYsqlConnMgr())
-			YbSendParameterStatusForConnectionManager("yb_test_fail_next_ddl", "false");
-		elog(ERROR, "Failed DDL operation as requested");
-	}
+	yb_maybe_test_fail_ddl();
 
 	if (yb_test_delay_next_ddl > 0)
 	{
@@ -8913,5 +8909,43 @@ YbInvalidatePlannerRelcache(PlannerInfo *root)
 
 			RelationCacheInvalidateEntry(idx->indexoid);
 		}
+	}
+}
+
+/*
+ * Check yb_test_fail_next_ddl and trigger the appropriate error if set.
+ * 0 = disabled, 1 = ERROR, 2 = FATAL, 3 = PANIC, 4 = crash.
+ * Resets to 0 after triggering.
+ */
+static void
+yb_maybe_test_fail_ddl(void)
+{
+	int fail_mode = yb_test_fail_next_ddl;
+	if (fail_mode == 0)
+		return;
+	yb_test_fail_next_ddl = 0;
+	if (YbIsClientYsqlConnMgr())
+		YbSendParameterStatusForConnectionManager("yb_test_fail_next_ddl", "0");
+
+	switch (fail_mode)
+	{
+		case 1:
+			elog(ERROR, "Failed DDL operation as requested");
+			break;
+		case 2:
+			elog(FATAL, "FATAL on DDL as requested");
+			break;
+		case 3:
+			elog(PANIC, "PANIC on DDL as requested");
+			break;
+		case 4:
+			{
+				/* Intentional null pointer dereference for crash testing */
+				volatile int *null_ptr = NULL;
+				*null_ptr = 0;
+				break;
+			}
+		default:
+			break;
 	}
 }

--- a/src/postgres/src/include/pg_yb_utils.h
+++ b/src/postgres/src/include/pg_yb_utils.h
@@ -722,11 +722,11 @@ extern bool *yb_extra_commands_to_retry_in_proc;
 extern bool yb_test_system_catalogs_creation;
 
 /*
- * If set to true, next DDL operation (only creating a relation for now) will fail,
- * resetting this back to false.
+ * If set to non-zero, next DDL operation will fail with the specified error level:
+ * 0 = disabled (default), 1 = ERROR, 2 = FATAL, 3 = PANIC, 4 = crash.
+ * Resets to 0 after triggering.
  */
-extern bool yb_test_fail_next_ddl;
-
+extern int yb_test_fail_next_ddl;
 /*
  * Sleep before executing a statement.
  * Can be used to simulate race conditions where catalog is updated between

--- a/src/postgres/src/include/tcop/tcopprot.h
+++ b/src/postgres/src/include/tcop/tcopprot.h
@@ -82,6 +82,7 @@ extern void die(SIGNAL_ARGS);
 extern void quickdie(SIGNAL_ARGS) pg_attribute_noreturn();
 extern void StatementCancelHandler(SIGNAL_ARGS);
 extern void FloatExceptionHandler(SIGNAL_ARGS) pg_attribute_noreturn();
+extern void YbCriticalSignalHandler(SIGNAL_ARGS);
 extern void RecoveryConflictInterrupt(ProcSignalReason reason); /* called from SIGUSR1
 																 * handler */
 extern void ProcessClientReadInterrupt(bool blocked);

--- a/src/postgres/src/test/regress/expected/yb.orig.alter_table.out
+++ b/src/postgres/src/test/regress/expected/yb.orig.alter_table.out
@@ -120,7 +120,7 @@ Indexes:
 DROP TABLE pk_tbl;
 -- Verify cache cleanup of table names when TABLE RENAME fails.
 CREATE TABLE rename_test (id int);
-SET yb_test_fail_next_ddl TO true;
+SET yb_test_fail_next_ddl TO 1;
 ALTER TABLE rename_test RENAME TO foobar;
 ERROR:  Failed DDL operation as requested
 -- The table name must be unchanged.

--- a/src/postgres/src/test/regress/sql/yb.orig.alter_table.sql
+++ b/src/postgres/src/test/regress/sql/yb.orig.alter_table.sql
@@ -63,7 +63,7 @@ DROP TABLE pk_tbl;
 
 -- Verify cache cleanup of table names when TABLE RENAME fails.
 CREATE TABLE rename_test (id int);
-SET yb_test_fail_next_ddl TO true;
+SET yb_test_fail_next_ddl TO 1;
 ALTER TABLE rename_test RENAME TO foobar;
 -- The table name must be unchanged.
 SELECT * FROM rename_test;

--- a/src/yb/integration-tests/cdcsdk_ysql-test.cc
+++ b/src/yb/integration-tests/cdcsdk_ysql-test.cc
@@ -7750,7 +7750,7 @@ TEST_F(CDCSDKYsqlTest, YB_DISABLE_TEST_IN_TSAN(TestAtomicDDLRollback)) {
   auto conn = ASSERT_RESULT(test_cluster_.ConnectToDB(test_namespace_name));
 
   // Fail the alter table ADD column, this will give us two CHANGE_METADATA_OPs
-  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl=true"));
+  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl=1"));
   ASSERT_NOK(AddColumn(&test_cluster_, test_namespace_name, kTableName, kValue2ColumnName, &conn));
 
   // Perform a multi shard transaction, so that we get DMLs in between the two CHANGE_METADATA_OPs
@@ -7939,7 +7939,7 @@ TEST_F(CDCSDKYsqlTest, YB_DISABLE_TEST_IN_TSAN(TestAtomicDDLDropColumn)) {
   auto conn = ASSERT_RESULT(test_cluster_.ConnectToDB(test_namespace_name));
 
   // Fail the ALTER TABLE DROP column
-  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl=true"));
+  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl=1"));
   ASSERT_NOK(DropColumn(&test_cluster_, test_namespace_name, kTableName, kValueColumnName, &conn));
 
   // Sleep to ensure that rollback has taken place

--- a/src/yb/integration-tests/system_table_delete-test.cc
+++ b/src/yb/integration-tests/system_table_delete-test.cc
@@ -46,7 +46,7 @@ TEST_F(SystemTableDelete, DeleteSysTableWithFixedOid) {
   ASSERT_OK(conn.Execute("SET ysql_upgrade_mode TO true"));
 
   // Force the table crete to fail.
-  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl TO true"));
+  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl TO 1"));
   ASSERT_NOK_STR_CONTAINS(conn.Execute(create_table_stmt), "Failed DDL operation as requested ");
 
   auto& catalog_manager = ASSERT_RESULT(cluster_->GetLeaderMiniMaster())->catalog_manager_impl();

--- a/src/yb/integration-tests/xcluster/xcluster_ddl_replication-test.cc
+++ b/src/yb/integration-tests/xcluster/xcluster_ddl_replication-test.cc
@@ -3149,9 +3149,9 @@ TEST_F(XClusterDDLReplicationTest, FailedSchemaChangeOnSource) {
   ASSERT_OK(conn.Execute("CREATE TABLE my_table (x INT);"));
 
   // Do a few failing ADD COLUMN DDLs, which might bump the next DocDB column ID.
-  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl=true;"));
+  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl=1;"));
   ASSERT_NOK(conn.Execute("ALTER TABLE my_table ADD COLUMN y TEXT;"));
-  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl=true;"));
+  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl=1;"));
   ASSERT_NOK(conn.Execute("ALTER TABLE my_table ADD COLUMN y TEXT;"));
 
   // In the absence of rollback of the next DocDB column ID counter,
@@ -3181,9 +3181,9 @@ TEST_F(XClusterDDLReplicationTest, FailedSchemaChangeOnSourceWithPartitioning) {
       "CREATE TABLE my_table_1 PARTITION OF my_table FOR VALUES FROM (1) TO (100000);"));
 
   // Do a few failing ADD COLUMN DDLs, which might bump the next DocDB column ID.
-  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl=true;"));
+  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl=1;"));
   ASSERT_NOK(conn.Execute("ALTER TABLE my_table ADD COLUMN y INT;"));
-  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl=true;"));
+  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl=1;"));
   ASSERT_NOK(conn.Execute("ALTER TABLE my_table ADD COLUMN y INT;"));
 
   // In the absence of rollback of the next DocDB column ID counter,
@@ -3292,7 +3292,7 @@ TEST_F(XClusterDDLReplicationTest, RollbackPreservesDeletedColumns) {
 
   auto conn = ASSERT_RESULT(producer_cluster_.ConnectToDB(namespace_name));
   ASSERT_OK(conn.Execute("CREATE TABLE my_table (x INT);"));
-  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl=true;"));
+  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl=1;"));
   ASSERT_NOK(conn.Execute("ALTER TABLE my_table ADD COLUMN y INT;"));
   ASSERT_OK(conn.Execute("ALTER TABLE my_table ADD COLUMN y INT;"));
 

--- a/src/yb/integration-tests/xcluster/xcluster_outbound_replication_group-itest.cc
+++ b/src/yb/integration-tests/xcluster/xcluster_outbound_replication_group-itest.cc
@@ -702,7 +702,7 @@ TEST_P(XClusterOutboundReplicationGroupParameterized, CleanupStreamsOfFailedTabl
   auto conn = ASSERT_RESULT(producer_cluster_.ConnectToDB(kNamespaceName));
 
   // This fails due to GUC yb_test_fail_next_ddl.
-  ASSERT_NOK(conn.Execute("SET yb_test_fail_next_ddl=true; CREATE TABLE tbl1 (a int)"));
+  ASSERT_NOK(conn.Execute("SET yb_test_fail_next_ddl=1; CREATE TABLE tbl1 (a int)"));
   ASSERT_OK(check_streams());
 
   ASSERT_OK(conn.Execute("CREATE TABLE moneyp (a money) PARTITION BY LIST (a);"));

--- a/src/yb/tools/yb-backup/yb-backup-cross-feature-test.cc
+++ b/src/yb/tools/yb-backup/yb-backup-cross-feature-test.cc
@@ -3371,7 +3371,7 @@ TEST_F(YBBackupTest, YB_DISABLE_TEST_IN_SANITIZERS(TestBackupWithFailedLegacyRew
   ASSERT_NO_FATALS(CreateIndex(Format("CREATE INDEX idx1 ON $0 (b DESC)", table_name)));
   // Perform a failed ADD PKEY operation.
   ASSERT_NO_FATALS(RunPsqlCommand(
-      Format("SET yb_test_fail_next_ddl = true;"
+      Format("SET yb_test_fail_next_ddl = 1;"
              "ALTER TABLE $0 ADD PRIMARY KEY (a ASC)", table_name), "SET"));
   // Verify the original table and the orphaned table exist.
   ASSERT_EQ(ASSERT_RESULT(client_->ListTables(table_name)).size(), 2);
@@ -3691,7 +3691,7 @@ TEST_F(
   // Perform some failed rewrite operations.
   ASSERT_NO_FATALS(RunPsqlCommand("SET yb_test_fail_table_rewrite_after_creation = true;"
       "ALTER TABLE table_1 ADD COLUMN d SERIAL", "SET"));
-  ASSERT_NO_FATALS(RunPsqlCommand("SET yb_test_fail_next_ddl = true;"
+  ASSERT_NO_FATALS(RunPsqlCommand("SET yb_test_fail_next_ddl = 1;"
       "ALTER TABLE table_1 DROP CONSTRAINT table_1_pkey", "SET"));
   // Backup then restore to a new database.
   const string backup_dir = GetTempDir("backup");

--- a/src/yb/tserver/xcluster_ddl_queue_handler.cc
+++ b/src/yb/tserver/xcluster_ddl_queue_handler.cc
@@ -507,7 +507,7 @@ Status XClusterDDLQueueHandler::ProcessDDLQuery(const XClusterDDLQueryInfo& quer
   }
 
   if (FLAGS_TEST_xcluster_ddl_queue_handler_fail_ddl) {
-    setup_query << "SET yb_test_fail_next_ddl TO true;";
+    setup_query << "SET yb_test_fail_next_ddl TO 1;";
   }
 
   setup_query << Format(

--- a/src/yb/yql/pgwrapper/libpq_utils.cc
+++ b/src/yb/yql/pgwrapper/libpq_utils.cc
@@ -765,7 +765,7 @@ Status PGConn::RollbackTransaction() {
 }
 
 Status PGConn::TestFailDdl(const std::string& ddl_to_fail) {
-  RETURN_NOT_OK(Execute("SET yb_test_fail_next_ddl=true"));
+  RETURN_NOT_OK(Execute("SET yb_test_fail_next_ddl=1"));
   Status s = Execute(ddl_to_fail);
   if (s.ok()) {
     return STATUS_FORMAT(InternalError,

--- a/src/yb/yql/pgwrapper/pg_catalog_perf-test.cc
+++ b/src/yb/yql/pgwrapper/pg_catalog_perf-test.cc
@@ -640,7 +640,7 @@ TEST_F(PgCatalogPerfTest, RPCCountAfterDdlFailure) {
     return conn->Execute("CREATE TABLE mytable1 (id int)");
   }));
   auto rpc_count_for_ddl_failure = ASSERT_RESULT(RPCCountAfterCacheRefresh([](PGConn* conn) {
-    RETURN_NOT_OK(conn->Execute("SET yb_test_fail_next_ddl=true"));
+    RETURN_NOT_OK(conn->Execute("SET yb_test_fail_next_ddl=1"));
     if (conn->Execute("CREATE TABLE mytable (id int)").ok()) {
       return STATUS(RuntimeError, "Expected to fail Ddl");
     }

--- a/src/yb/yql/pgwrapper/pg_ddl_atomicity-test.cc
+++ b/src/yb/yql/pgwrapper/pg_ddl_atomicity-test.cc
@@ -1928,7 +1928,7 @@ TEST_F(PgDdlAtomicityTest, TestPartitionedTableSchemaVerification) {
   // Perform an unsuccessful alter table operation.
   ASSERT_OK(conn.TestFailDdl("ALTER TABLE test_parent DROP COLUMN value"));
   ASSERT_OK(cluster_->SetFlagOnMasters("TEST_pause_ddl_rollback", "true"));
-  ASSERT_OK(conn.ExecuteFormat("SET yb_test_fail_next_ddl=true"));
+  ASSERT_OK(conn.ExecuteFormat("SET yb_test_fail_next_ddl=1"));
   // Perform an unsuccessful alter table rewrite operation.
   ASSERT_NOK(conn.ExecuteFormat("ALTER TABLE test_parent ADD PRIMARY KEY (key)"));
 
@@ -1979,7 +1979,7 @@ TEST_F(PgDdlAtomicityTest, TestAlterTableAddUniqueConstraint) {
 
   ASSERT_OK(conn.Execute("CREATE TABLE bar (y character varying(20))"));
   ASSERT_EQ(ASSERT_RESULT(client->ListTables("y_unique")).size(), 0);
-  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl=true"));
+  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl=1"));
   // As of 2024-09-17, the aborted ALTER TABLE bar statement leaves an orphan index
   // inside DocDB that is not garbage collected. But its existence will not prevent
   // a retry of the same statement to succeed, which will create another index with
@@ -2007,7 +2007,7 @@ TEST_F(PgDdlAtomicityTest, TestAlterTableAddCheckConstraint) {
   ASSERT_EQ(foo_table_info->schema.version(), 1);
 
   ASSERT_OK(conn.Execute("CREATE TABLE bar(id int)"));
-  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl=true"));
+  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl=1"));
   ASSERT_NOK(conn.Execute("ALTER TABLE bar ADD CONSTRAINT bar_id_check CHECK (id > 5)"));
   auto bar_table_id = ASSERT_RESULT(GetTableIdByTableName(client.get(), "yugabyte", "bar"));
   std::shared_ptr<client::YBTableInfo> bar_table_info = std::make_shared<client::YBTableInfo>();

--- a/src/yb/yql/pgwrapper/pg_libpq-test.cc
+++ b/src/yb/yql/pgwrapper/pg_libpq-test.cc
@@ -4124,18 +4124,18 @@ TEST_F(PgLibPqTest, DropSequenceTest) {
 
   // Verify that if DROP SEQUENCE fails, the sequence is actually not
   // dropped.
-  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl=true"));
+  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl=1"));
   ASSERT_NOK(conn.Execute("DROP SEQUENCE foo"));
   ASSERT_EQ(ASSERT_RESULT(conn.FetchRow<int64_t>("SELECT nextval('foo')")), 1);
 
   // Verify same behavior for sequences created using CREATE TABLE.
   ASSERT_OK(conn.Execute("CREATE TABLE t (k SERIAL)"));
-  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl=true"));
+  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl=1"));
   ASSERT_NOK(conn.Execute("DROP SEQUENCE t_k_seq CASCADE"));
   ASSERT_EQ(ASSERT_RESULT(conn.FetchRow<int64_t>("SELECT nextval('t_k_seq')")), 1);
 
   // Verify same behavior is seen while trying to drop the table.
-  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl=true"));
+  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl=1"));
   ASSERT_NOK(conn.Execute("DROP TABLE t"));
   ASSERT_EQ(ASSERT_RESULT(conn.FetchRow<int64_t>("SELECT nextval('t_k_seq')")), 2);
 

--- a/src/yb/yql/pgwrapper/pg_libpq_err-test.cc
+++ b/src/yb/yql/pgwrapper/pg_libpq_err-test.cc
@@ -10,6 +10,8 @@
 // or implied.  See the License for the specific language governing permissions and limitations
 // under the License.
 
+#include "yb/integration-tests/external_mini_cluster.h"
+
 #include "yb/yql/pgwrapper/libpq_test_base.h"
 #include "yb/yql/pgwrapper/libpq_utils.h"
 #include "yb/yql/pgwrapper/pg_test_utils.h"
@@ -411,6 +413,44 @@ TEST_F(PgLibPqErrTest, InsertTransactionAborted) {
       continue;
     }
   }
+}
+
+// Test that backtrace is printed to logs on FATAL and PANIC errors.
+TEST_F(PgLibPqErrTest, YbTestBacktraceOnFatal) {
+  auto conn = ASSERT_RESULT(Connect());
+
+  ASSERT_OK(conn.Execute("CREATE TABLE test_fail_ddl (k INT PRIMARY KEY, v INT)"));
+
+  // Test ERROR
+  ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl = 1"));
+  auto status = conn.Execute("ALTER TABLE test_fail_ddl ADD COLUMN v2 INT");
+  ASSERT_NOK(status);
+  ASSERT_STR_CONTAINS(status.ToString(), "Failed DDL operation as requested");
+  // Connection should still be good after ERROR
+  ASSERT_RESULT(conn.FetchRow<int32_t>("SELECT 1"));
+
+  auto* ts = cluster_->tablet_server(0);
+  {
+    // Verify backtrace is printed to logs on FATAL
+    LogWaiter log_waiter(ts, "BACKTRACE");
+    ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl = 2"));
+    status = conn.Execute("ALTER TABLE test_fail_ddl ADD COLUMN v3 INT");
+    ASSERT_NOK(status);
+    ASSERT_OK(log_waiter.WaitFor(MonoDelta::FromSeconds(10 * kTimeMultiplier)));
+  }
+  ASSERT_EQ(conn.ConnStatus(), CONNECTION_BAD);
+
+  conn = ASSERT_RESULT(Connect());
+  {
+    // Verify backtrace is printed to logs on PANIC
+    LogWaiter log_waiter(ts, "BACKTRACE");
+    ASSERT_OK(conn.Execute("SET yb_test_fail_next_ddl = 3"));
+    status = conn.Execute("ALTER TABLE test_fail_ddl ADD COLUMN v4 INT");
+    ASSERT_NOK(status);
+    ASSERT_OK(log_waiter.WaitFor(MonoDelta::FromSeconds(10 * kTimeMultiplier)));
+  }
+  ASSERT_EQ(conn.ConnStatus(), CONNECTION_BAD);
+
 }
 
 } // namespace pgwrapper


### PR DESCRIPTION
DO NOT MERGE!! [CSI](<https://csiweb.dev.yugabyte.com/pull/32147/>) ❌. Once CSI passes, comment `trigger jenkins` to clear this warning.

Summary:
Currently, when a backend exits in these unrecoverable error paths, we have to analyze a core dump to understand what happened. Logging the backtrace helps us understand the problem directly from logs. This is similar to what we do in tserver/master today.

Backtrace is printed through normal PG elog functions for
- SIGSEGV
- SIGABRT
- SIGFPE
- LOG(FATAL)
- LOG(PANIC)

Original commit: ca25fb9eb52b8bdbdc66987edcf5596ad61b7da9 / D50263

Test Plan:
`ybd release --cxx-test 'TEST_F(PgLibPqErrTest, YbTestBacktraceOnFatal)'` tests this flow for FATAL/PANIC logs.

Verified manually verify that sending a SIGABRT/SIGSEGV to a pg_sleep backend results in a log like below.

```
2026-02-07 09:45:34.310 PST [3035361] LOG:  received critical signal 6
2026-02-07 09:45:34.310 PST [3035361] DETAIL:  The backend received signal 6.
2026-02-07 09:45:34.310 PST [3035361] BACKTRACE:
            @     0x55b2a43495bf  YbCriticalSignalHandler
            @     0x7f6accebb990  (unknown)
            @     0x7f6accc123b7  epoll_wait
            @     0x55b2a431af81  WaitEventSetWait
            @     0x55b2a431ac9c  WaitLatch
            @     0x55b2a4400b32  pg_sleep
            @     0x55b2a414032c  ExecInterpExpr
            @     0x55b2a4189322  ExecResult
            @     0x55b2a414b0ad  standard_ExecutorRun
            @     0x7f6abaade13e  pgss_ExecutorRun
            @     0x7f6aba973905  ybpgm_ExecutorRun
            @     0x7f6aba96967a  pgaudit_ExecutorRun_hook
            @     0x55b2a4503e45  yb_ash_ExecutorRun
            @     0x55b2a4355788  PortalRunSelect
            @     0x55b2a43552af  PortalRun
            @     0x55b2a4351dcd  yb_exec_simple_query_impl
            @     0x55b2a4352403  yb_exec_query_wrapper_one_attempt
            @     0x55b2a434ea7b  PostgresMain
            @     0x55b2a42919bb  BackendRun
            @     0x55b2a428f682  ServerLoop
            @     0x55b2a428b626  PostmasterMain
            @     0x55b2a41c17fb  PostgresServerProcessMain
            @     0x55b2a41c14f2  main
            @     0x7f6accb0d865  __libc_start_main
            @     0x55b2a3ec106e  _start
```

Reviewers: kfranz, amartsinchyk, xCluster, hsunder, jason

Reviewed By: kfranz, amartsinchyk

Subscribers: jason, svc_phabricator, ybase, hsunder, yql, smishra

Differential Revision: https://phorge.dev.yugabyte.com/D50263

## Merge conflicts

- `src/yb/integration-tests/cdcsdk_ysql-test.cc:7754` — took the commit's `SET yb_test_fail_next_ddl=1` (GUC changed from bool to int) while keeping the branch's `test_namespace_name` argument in the adjacent `AddColumn` call (master renamed it to `kNamespaceName` independently of this commit)
- `src/yb/integration-tests/cdcsdk_ysql-test.cc:7945` — same resolution for the `DropColumn` hunk in `TestAtomicDDLDropColumn`
- `src/yb/yql/pgwrapper/pg_libpq_err-test.cc:419` — kept only the commit's new `YbTestBacktraceOnFatal` test; dropped the surrounding `InsertPerf` test that git pulled in as context (it exists on master but not on 2025.2 and is unrelated to this commit)
