### PR TITLE
[BACKPORT 2025.2][#32128] YSQL: Batch pg_statistic lookups during planning

### DIFF
--- a/java/yb-pgsql/src/test/java/org/yb/pgsql/TestPgPrefetchColumnStatistics.java
+++ b/java/yb-pgsql/src/test/java/org/yb/pgsql/TestPgPrefetchColumnStatistics.java
@@ -1,0 +1,223 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+package org.yb.pgsql;
+
+import static org.yb.AssertionWrappers.assertEquals;
+import static org.yb.AssertionWrappers.assertGreaterThanOrEqualTo;
+import static org.yb.AssertionWrappers.assertLessThan;
+import static org.yb.AssertionWrappers.assertLessThanOrEqualTo;
+import static org.yb.AssertionWrappers.assertTrue;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import org.json.JSONArray;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.yb.YBTestRunner;
+
+/**
+ * Tests for the yb_prefetch_column_statistics GUC.
+ *
+ * On a cold backend, planning any query that scans a wide table reads
+ * pg_statistic one column at a time: to cost the scan the planner estimates the
+ * relation's full-row width, calling get_attavgwidth() for every column --
+ * regardless of how many columns the query selects -- and each miss is an
+ * individual one-row catalog read (one RPC per column). With the prefetch
+ * enabled, get_relation_info() instead warms the catalog cache with all of the
+ * relation's pg_statistic rows in a single batched list lookup, so the
+ * subsequent per-column point lookups hit warm cache.
+ *
+ * These tests verify the observable contract of the feature: it issues
+ * strictly fewer catalog read requests, the saving scales with the column
+ * count, it is gated on the cost model, and -- crucially -- it changes neither
+ * the chosen plan nor the cost estimates.
+ */
+@RunWith(value = YBTestRunner.class)
+public class TestPgPrefetchColumnStatistics extends BasePgSQLTest {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestPgPrefetchColumnStatistics.class);
+
+  /** Number of non-key columns in the wide test table. */
+  private static final int NUM_COLUMNS = 50;
+
+  /**
+   * Create a wide, fully-analyzed table so that ANALYZE records a pg_statistic
+   * row for every column. With the cost model on, the planner reads every one
+   * of those rows when it estimates the relation's full-row width to cost a
+   * scan -- regardless of how many columns a query projects.
+   */
+  private void createWideTable(Statement stmt, String name) throws Exception {
+    StringBuilder cols = new StringBuilder("id int PRIMARY KEY");
+    StringBuilder vals = new StringBuilder("i");
+    for (int i = 1; i <= NUM_COLUMNS; i++) {
+      cols.append(", c").append(i).append(" int");
+      vals.append(", i * ").append(i + 1);
+    }
+    stmt.execute("CREATE TABLE " + name + " (" + cols + ")");
+    stmt.execute("INSERT INTO " + name + " SELECT " + vals +
+                 " FROM generate_series(1, 1000) i");
+    stmt.execute("ANALYZE " + name);
+  }
+
+  /**
+   * Returns the number of catalog read requests reported by EXPLAIN's DIST
+   * instrumentation when a brand-new (cold-cache) backend plans
+   * "SELECT * FROM &lt;table&gt;" for the first time. YB's "Catalog Read
+   * Requests" counter includes reads performed during planning, which is
+   * exactly where the pg_statistic lookups happen.
+   *
+   * Each call opens a fresh connection, so the catalog cache starts cold.
+   */
+  private int catalogReadsForFirstPlan(String table, boolean costModel,
+                                       boolean prefetch) throws Exception {
+    try (Connection conn = getConnectionBuilder().connect();
+         Statement stmt = conn.createStatement()) {
+      stmt.execute("SET yb_enable_base_scans_cost_model = " +
+                   (costModel ? "on" : "off"));
+      stmt.execute("SET yb_prefetch_column_statistics = " +
+                   (prefetch ? "on" : "off"));
+
+      String query =
+          "EXPLAIN (ANALYZE, DIST, FORMAT JSON) SELECT * FROM " + table;
+      try (ResultSet rs = stmt.executeQuery(query)) {
+        assertTrue("EXPLAIN returned no rows", rs.next());
+        String json = rs.getString(1);
+        LOG.info("costModel={} prefetch={} EXPLAIN: {}", costModel, prefetch,
+                 json);
+        return new JSONArray(json).getJSONObject(0)
+            .getInt("Catalog Read Requests");
+      }
+    }
+  }
+
+  /** Collect the full EXPLAIN output (plan shape AND cost estimates) as text. */
+  private String explainText(Statement stmt, String query) throws Exception {
+    StringBuilder sb = new StringBuilder();
+    try (ResultSet rs = stmt.executeQuery("EXPLAIN " + query)) {
+      while (rs.next()) {
+        sb.append(rs.getString(1)).append('\n');
+      }
+    }
+    return sb.toString();
+  }
+
+  /**
+   * The core of the feature: on a cold backend, prefetching collapses the burst
+   * of one-RPC-per-column pg_statistic point lookups into a single batched list
+   * lookup. The burst is the same for any query that scans the table -- the
+   * cost model reads every column's stats to estimate the full row width,
+   * regardless of projection -- so we use SELECT * here as a representative wide
+   * read. Planning it on a wide analyzed table for the first time must
+   * therefore issue strictly fewer catalog read requests with the prefetch on,
+   * and the saving must scale with the column count.
+   *
+   * If the list lookup failed to populate the per-tuple catcache entries that
+   * the later point lookups need, the prefetch-on path would do one extra list
+   * read on top of the per-column reads and this test would fail -- so it is a
+   * genuine check that the batching mechanism works.
+   */
+  @Test
+  @BypassConnMgr(reason = CATALOG_CACHE_MISS_NEED_UNIQUE_PHYSICAL_CONN)
+  public void testPrefetchReducesCatalogReadRequests() throws Exception {
+    try (Statement stmt = connection.createStatement()) {
+      createWideTable(stmt, "wide_reads");
+    }
+
+    int readsOff = catalogReadsForFirstPlan("wide_reads", true, false);
+    int readsOn = catalogReadsForFirstPlan("wide_reads", true, true);
+    LOG.info("Catalog read requests: prefetch off={}, on={}", readsOff, readsOn);
+
+    assertLessThan(
+        String.format("Prefetch should reduce catalog read requests "
+                      + "(off=%d, on=%d)", readsOff, readsOn),
+        readsOn, readsOff);
+
+    // Off issues roughly one read per analyzed column; on collapses them into a
+    // single list read. Require the saving to be a large fraction of the column
+    // count so this is a real batch effect rather than off-by-one noise.
+    assertGreaterThanOrEqualTo(
+        String.format("Expected the prefetch to save close to one read per "
+                      + "column (off=%d, on=%d, columns=%d)",
+                      readsOff, readsOn, NUM_COLUMNS),
+        readsOff - readsOn, NUM_COLUMNS / 2);
+  }
+
+  /**
+   * The prefetch is gated on the cost model: when it is off, get_attavgwidth()
+   * returns immediately without reading pg_statistic and the prefetch is not
+   * invoked, so toggling the GUC must not change the catalog read count. With
+   * the cost model on the same toggle yields the large saving above. We assert
+   * the saving is large with the cost model and negligible without it.
+   */
+  @Test
+  @BypassConnMgr(reason = CATALOG_CACHE_MISS_NEED_UNIQUE_PHYSICAL_CONN)
+  public void testNoEffectWhenCostModelDisabled() throws Exception {
+    try (Statement stmt = connection.createStatement()) {
+      createWideTable(stmt, "wide_gate");
+    }
+
+    int savingWithCostModel =
+        catalogReadsForFirstPlan("wide_gate", true, false)
+        - catalogReadsForFirstPlan("wide_gate", true, true);
+    int savingWithoutCostModel =
+        catalogReadsForFirstPlan("wide_gate", false, false)
+        - catalogReadsForFirstPlan("wide_gate", false, true);
+    LOG.info("Prefetch saving: withCostModel={}, withoutCostModel={}",
+             savingWithCostModel, savingWithoutCostModel);
+
+    assertGreaterThanOrEqualTo(
+        "Prefetch should save many reads when the cost model is enabled",
+        savingWithCostModel, NUM_COLUMNS / 2);
+    assertLessThanOrEqualTo(
+        String.format("Prefetch should have no real effect with the cost model "
+                      + "off (saving=%d)", savingWithoutCostModel),
+        savingWithoutCostModel, NUM_COLUMNS / 4);
+  }
+
+  /**
+   * The feature must change only the number and shape of catalog reads, never
+   * the resulting plan or cost estimates. We compare the full EXPLAIN output
+   * (which includes the cost/row/width estimates) with the prefetch on vs off
+   * and require it to be byte-identical for a variety of query shapes.
+   */
+  @Test
+  public void testPlansAndCostsUnchanged() throws Exception {
+    String[] queries = {
+        "SELECT * FROM wide_plan",
+        "SELECT * FROM wide_plan WHERE c1 > 100",
+        "SELECT c1, c25, c50 FROM wide_plan WHERE c2 < 50",
+        "SELECT c1, count(*) FROM wide_plan GROUP BY c1 ORDER BY c1",
+    };
+    try (Statement stmt = connection.createStatement()) {
+      createWideTable(stmt, "wide_plan");
+      stmt.execute("SET yb_enable_base_scans_cost_model = on");
+
+      for (String query : queries) {
+        stmt.execute("SET yb_prefetch_column_statistics = on");
+        String planOn = explainText(stmt, query);
+        stmt.execute("SET yb_prefetch_column_statistics = off");
+        String planOff = explainText(stmt, query);
+        assertEquals(
+            "Plan and cost estimates must be identical with the prefetch on vs "
+                + "off for query: " + query,
+            planOff, planOn);
+      }
+    }
+  }
+}

--- a/src/postgres/src/backend/optimizer/util/plancat.c
+++ b/src/postgres/src/backend/optimizer/util/plancat.c
@@ -85,6 +85,7 @@ static void set_baserel_partition_key_exprs(Relation relation,
 											RelOptInfo *rel);
 static void set_baserel_partition_constraint(Relation relation,
 											 RelOptInfo *rel);
+static void yb_prefetch_column_stats(Relation relation);
 
 
 /*
@@ -164,6 +165,17 @@ get_relation_info(PlannerInfo *root, Oid relationObjectId, bool inhparent,
 		palloc0((rel->max_attr - rel->min_attr + 1) * sizeof(Relids));
 	rel->attr_widths = (int32 *)
 		palloc0((rel->max_attr - rel->min_attr + 1) * sizeof(int32));
+
+	/*
+	 * YB: When the cost model (CBO) is enabled, costing a scan reads one
+	 * pg_statistic row per column on a cold backend -- get_attavgwidth() is
+	 * called over the relation's full-row width -- so a wide table is a burst of
+	 * one catalog RPC per column.  Warm them all with a single batched list
+	 * lookup first so those per-column lookups hit cache.
+	 */
+	if (IsYugaByteEnabled() && yb_prefetch_column_statistics &&
+		yb_enable_base_scans_cost_model)
+		yb_prefetch_column_stats(relation);
 
 	/*
 	 * Estimate relation size --- unless it's an inheritance parent, in which
@@ -1229,6 +1241,39 @@ get_relation_data_width(Oid relid, int32 *attr_widths)
 	table_close(relation, NoLock);
 
 	return result;
+}
+
+/*
+ * yb_prefetch_column_stats
+ *		Warm the catalog cache with all of a relation's pg_statistic rows in one
+ *		batched list lookup, so the planner's per-column get_attavgwidth() calls
+ *		hit warm cache instead of issuing a catalog RPC each.
+ */
+static void
+yb_prefetch_column_stats(Relation relation)
+{
+	CatCList   *list;
+
+	switch (relation->rd_rel->relkind)
+	{
+		case RELKIND_RELATION:
+		case RELKIND_MATVIEW:
+		case RELKIND_PARTITIONED_TABLE:
+		case RELKIND_FOREIGN_TABLE:
+			break;
+		default:
+			/* No column statistics to prefetch for this relation kind. */
+			return;
+	}
+
+	/*
+	 * Prefix scan on the leading key (starelid).  Releasing the list keeps the
+	 * per-tuple member entries cached for the upcoming point lookups; we only
+	 * want the side effect of populating the cache, not the list itself.
+	 */
+	list = SearchSysCacheList1(STATRELATTINH,
+							   ObjectIdGetDatum(RelationGetRelid(relation)));
+	ReleaseSysCacheList(list);
 }
 
 

--- a/src/postgres/src/backend/utils/misc/guc.c
+++ b/src/postgres/src/backend/utils/misc/guc.c
@@ -3263,6 +3263,17 @@ static struct config_bool ConfigureNamesBool[] =
 	},
 
 	{
+		{"yb_prefetch_column_statistics", PGC_USERSET, QUERY_TUNING_METHOD,
+			gettext_noop("Prefetch a relation's column statistics in one catalog "
+						 "read during planning."),
+			NULL
+		},
+		&yb_prefetch_column_statistics,
+		true,
+		NULL, NULL, NULL
+	},
+
+	{
 		{"yb_enable_update_reltuples_after_create_index", PGC_USERSET,
 			QUERY_TUNING_OTHER,
 			gettext_noop("Enables update of reltuples in pg_class for the base "

--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -2379,6 +2379,7 @@ bool		yb_plpgsql_disable_prefetch_in_for_query = false;
 bool		yb_enable_sequence_pushdown = true;
 bool		yb_disable_wait_for_backends_catalog_version = false;
 bool		yb_enable_base_scans_cost_model = false;
+bool		yb_prefetch_column_statistics = true;
 bool		yb_enable_update_reltuples_after_create_index = false;
 int			yb_wait_for_backends_catalog_version_timeout = 15 * 60 * 1000;	/* 15 min */
 bool		yb_prefer_bnl = false;

--- a/src/postgres/src/include/pg_yb_utils.h
+++ b/src/postgres/src/include/pg_yb_utils.h
@@ -589,6 +589,13 @@ extern bool yb_disable_wait_for_backends_catalog_version;
 extern bool yb_enable_base_scans_cost_model;
 
 /*
+ * When enabled, the planner warms the catalog cache with all of a relation's
+ * pg_statistic rows in a single batched RPC (instead of one point lookup per
+ * column) the first time the relation is planned in a backend.
+ */
+extern bool yb_prefetch_column_statistics;
+
+/*
  * Enables update of reltuples in pg_class for the base table and index after
  * creating the index.
  */


### PR DESCRIPTION
DO NOT MERGE!! [CSI](<https://csiweb.dev.yugabyte.com/pull/32158/>) ❌. Once CSI passes, comment `trigger jenkins` to clear this warning.

Summary:
On a cold YSQL backend with the cost model enabled
(`yb_enable_base_scans_cost_model`), planning any query that scans a wide table
reads one `pg_statistic` row per *table* column -- not per selected column. The
scan cost functions (e.g. `yb_cost_seqscan()`) need the relation's full-row
width to size the storage read: they estimate the number of DocDB blocks
scanned as `tuples * width / block_size`, the YB analog of PostgreSQL's
`seq_page_cost * relpages`, and a scan reads every row's on-disk bytes out of
RocksDB regardless of what the query projects. That width comes from
`yb_get_relation_data_width()` -> `get_rel_data_width()`, which calls
`get_attavgwidth()` for *every* attribute. Each `SearchSysCache3(STATRELATTINH,
...)` miss is an individual one-row scan -- one RPC per column -- so an N-column
table costs ~N separate catalog RPCs the first time a freshly connected backend
plans it, regardless of how many columns the query projects. (Projection is not
ignored: it feeds a separate, projected-only result width that drives the
DocDB->Postgres transfer cost; the per-column statistics are read either way.)

This is projection-independent. Measured on a fresh backend against a
50-column analyzed table, counting "Catalog Read Requests" from
EXPLAIN (ANALYZE, DIST) with the prefetch off then on (the difference is the
pg_statistic reads the prefetch collapses into one list read):

    query                    reads off -> on   pg_statistic reads
    SELECT *                  83 -> 33          50
    SELECT c1, c2             83 -> 33          50
    SELECT c1                 83 -> 33          50
    SELECT count(*)           88 -> 38          50
    SELECT c1 WHERE c2 > 5    88 -> 38          50

Even a single-column SELECT -- or count(*), which references no column at
all -- reads all 50 rows, because the scan's estimated cost depends on the
full row width either way. This burst is repaid by every freshly connected
backend under connection churn.

Warm the cache for the whole relation in one prefix scan instead. Since
`STATRELATTINH` is keyed (`starelid`, `staattnum`, `stainherit`), a list search on
the leading key returns all of the relation's stat rows in a single RPC and
instantiates each as an individual positive catcache entry, so the
subsequent per-column point lookups hit warm cache with no further RPCs.
This mirrors how `RelationBuildTupleDesc()` already bulk-loads `pg_attribute`.

The new helper `yb_prefetch_column_stats()` is invoked once per base
relation in get_relation_info(), gated on the new GUC
`yb_prefetch_column_statistics` (default true) and on
`yb_enable_base_scans_cost_model` (the all-column width lookups, which are the
source of the burst, only occur when the cost model is enabled). Only
relation kinds that can carry column statistics are prefetched.

Plans and cost estimates are unchanged; only the number and shape of
catalog reads differ. On a never-analyzed relation no stat rows exist, so
the list lookup simply misses once and the per-column lookups fall back to
type-based widths -- a bounded one-extra-RPC cost versus the large win on
analyzed tables.

Original commit: 211a32f56b6fa6295b8a15ba357fd1c378ebe7ed / D54378

Test Plan:
Built fastdebug and ran the new test class against a mini-cluster; all green:

  ./yb_build.sh fastdebug --java-test \
      'org.yb.pgsql.TestPgPrefetchColumnStatistics'
  Tests run: 3, Failures: 0, Errors: 0.
  - testPrefetchReducesCatalogReadRequests: the first cold-backend plan of
    "SELECT *" on a 50-column analyzed table reports 83 Catalog Read Requests
    (EXPLAIN ANALYZE DIST) with the GUC off vs 33 with it on -- the per-column
    pg_statistic point lookups collapse into a single list read.
  - testNoEffectWhenCostModelDisabled: the prefetch saves 50 reads with the
    cost model on and 0 with it off (it is gated on the cost model).
  - testPlansAndCostsUnchanged: the full EXPLAIN output is byte-identical with
    the GUC on vs off across several query shapes.

Reviewers: mtakahara

Reviewed By: mtakahara

Subscribers: yql, smishra

Differential Revision: https://phorge.dev.yugabyte.com/D54378