### PR TITLE
[#30110] DocDB: Add is_yb_managed gflag to master and TServers

### DIFF
--- a/src/yb/common/common_flags.cc
+++ b/src/yb/common/common_flags.cc
@@ -368,6 +368,7 @@ DEFINE_RUNTIME_bool(ysql_enable_auto_analyze, false,
     "which have changed more than a configurable threshold.");
 
 DEFINE_NON_RUNTIME_bool(enable_qos, false, "Enable the QoS feature.");
+
 DEFINE_NON_RUNTIME_bool(is_yb_managed, false,
   "If true instance is running in a YugabyteDB managed environment (YBM)");
 

--- a/src/yb/common/common_flags.cc
+++ b/src/yb/common/common_flags.cc
@@ -368,6 +368,8 @@ DEFINE_RUNTIME_bool(ysql_enable_auto_analyze, false,
     "which have changed more than a configurable threshold.");
 
 DEFINE_NON_RUNTIME_bool(enable_qos, false, "Enable the QoS feature.");
+DEFINE_NON_RUNTIME_bool(is_yb_managed, false,
+  "If true instance is running in a YugabyteDB managed environment (YBM)");
 
 namespace yb {
 

--- a/src/yb/common/common_flags.h
+++ b/src/yb/common/common_flags.h
@@ -33,6 +33,7 @@ DECLARE_int32(master_ts_rpc_timeout_ms);
 DECLARE_bool(enable_object_locking_for_table_locks);
 DECLARE_bool(ysql_yb_enable_invalidation_messages);
 DECLARE_bool(enable_qos);
+DECLARE_bool(is_yb_managed);
 
 namespace yb {
 


### PR DESCRIPTION
### Description

 Added is_yb_managed gflag to master and TServers


### Testing

1. Ran - ./yb_build.sh release - Build succeeded

2.  using --help command, printed the flag in both Tserver and master binaries, was able to see the flag
```
./build/release-clang21-dynamic-arm64-ninja/bin/yb-tserver --help | grep -C 3 is_yb_managed                                                                      1|0 ✔  03:51:53 
      default: true
    -enable_xcluster_auto_flag_validation (Enables validation of AutoFlags
      between the xcluster universes) type: bool default: false
    -is_yb_managed (If true instance is running in a YugabyteDB managed
      environment (YBM)) type: bool default: false
    -log_ysql_catalog_versions (Log YSQL catalog events. For debugging
      purposes.) type: bool default: false
```

```
./build/release-clang21-dynamic-arm64-ninja/bin/yb-master --help | grep -C 3 is_yb_managed                                                                              ✔  03:53:59 
      default: true
    -enable_xcluster_auto_flag_validation (Enables validation of AutoFlags
      between the xcluster universes) type: bool default: false
    -is_yb_managed (If true instance is running in a YugabyteDB managed
      environment (YBM)) type: bool default: false
    -log_ysql_catalog_versions (Log YSQL catalog events. For debugging
      purposes.) type: bool default: false
```

### Issue 

https://github.com/yugabyte/yugabyte-db/issues/30110
