### PR TITLE
[BACKPORT 2025.2][#32017] YSQL: Add a preflight check for orphaned grants

### DIFF
--- a/src/postgres/src/bin/pg_upgrade/check.c
+++ b/src/postgres/src/bin/pg_upgrade/check.c
@@ -52,6 +52,7 @@ static void yb_check_invalid_indexes();
 static void yb_check_installed_extensions();
 static void yb_check_pgcrypto_schema();
 static void yb_check_yb_role_prefix();
+static void yb_check_stale_acl_grantors();
 
 #define YB_SUPERUSER  "yb_superuser"
 
@@ -236,6 +237,7 @@ check_and_dump_old_cluster(bool live_check)
 	yb_check_installed_extensions();
 	yb_check_pgcrypto_schema();
 	yb_check_yb_role_prefix();
+	yb_check_stale_acl_grantors();
 
 	if (yb_has_check_fatal)
 		pg_fatal("\n");
@@ -2108,4 +2110,128 @@ yb_check_yb_role_prefix()
 	}
 	else
 		check_ok();
+}
+
+/*
+ * yb_check_stale_acl_grantors()
+ *
+ * Check for ACL entries whose grantor is not the current object owner.
+ */
+static void
+yb_check_stale_acl_grantors()
+{
+	int			dbnum;
+	bool		found = false;
+	char		output_path[MAXPGPATH];
+	FILE	   *script = NULL;
+
+	snprintf(output_path, sizeof(output_path), "%s/%s",
+			 log_opts.basedir,
+			 "stale_acl_grantors.txt");
+
+	prep_status("Checking for privileges with stale grantors");
+
+	for (dbnum = 0; dbnum < old_cluster.dbarr.ndbs; dbnum++)
+	{
+		PGresult   *res;
+		int			ntups;
+		int			rowno;
+		int			i_script;
+		DbInfo	   *active_db = &old_cluster.dbarr.dbs[dbnum];
+		PGconn	   *conn = connectToServer(&old_cluster, active_db->db_name);
+
+		res = executeQueryOrDie(conn,
+			"WITH stale AS ( "
+			"  SELECT p.oid AS oid, "
+			"         '\"' || replace(n.nspname, '\"', '\"\"') || '\".\"' || "
+			"         replace(p.proname, '\"', '\"\"') || '\"(' || "
+			"         pg_get_function_identity_arguments(p.oid) || ')' AS func, "
+			"         '\"' || replace(pg_get_userbyid(p.proowner), '\"', '\"\"') || '\"' AS owner, "
+			"         '\"' || replace(pg_get_userbyid(a.grantor), '\"', '\"\"') || '\"' AS grantor, "
+			"         CASE WHEN a.grantee = 0 THEN 'PUBLIC' "
+			"              ELSE '\"' || replace(pg_get_userbyid(a.grantee), '\"', '\"\"') || '\"' "
+			"         END AS grantee, "
+			"         a.privilege_type AS priv "
+			"  FROM pg_proc p "
+			"  JOIN pg_namespace n ON n.oid = p.pronamespace "
+			"  CROSS JOIN LATERAL aclexplode(p.proacl) a "
+			"  WHERE n.nspname NOT IN ('pg_catalog', 'information_schema') "
+			"    AND a.grantor <> p.proowner "
+			"), "
+			"steps AS ( "
+
+			/* stage 1a: become each stale grantor so we can revoke its grants */
+			"  SELECT oid, func, 1 AS stage, grantor AS grp, 0 AS seq, grantor AS tie, "
+			"         'ALTER FUNCTION ' || func || ' OWNER TO ' || grantor || ';' AS stmt "
+			"    FROM stale GROUP BY oid, func, grantor "
+
+			"  UNION ALL "
+
+			/* stage 1b: revoke what that grantor granted (owner is now the grantor) */
+			"  SELECT oid, func, 1, grantor, 1, grantee, "
+			"         'REVOKE ALL ON FUNCTION ' || func || ' FROM ' || grantee || ';' "
+			"    FROM stale GROUP BY oid, func, grantor, grantee "
+
+			"  UNION ALL "
+
+			/* stage 2: restore the real owner */
+			"  SELECT DISTINCT oid, func, 2, '', 0, '', "
+			"         'ALTER FUNCTION ' || func || ' OWNER TO ' || owner || ';' "
+			"    FROM stale "
+
+			"  UNION ALL "
+
+			/* stage 3: re-grant the preserved privileges from the real owner */
+			"  SELECT oid, func, 3, '', 1, grantee || ' ' || priv, "
+			"         'GRANT ' || priv || ' ON FUNCTION ' || func || ' TO ' || grantee || ';' "
+			"    FROM stale GROUP BY oid, func, grantee, priv "
+			") "
+
+			"SELECT string_agg('    ' || stmt, E'\\n' "
+			"                  ORDER BY stage, grp, seq, tie) AS script "
+			"  FROM steps "
+			" GROUP BY oid, func "
+			" ORDER BY func"
+		);
+		ntups = PQntuples(res);
+		if (ntups > 0)
+		{
+			found = true;
+			if (script == NULL && (script = fopen_priv(output_path, "w")) == NULL)
+				pg_fatal("could not open file \"%s\": %s\n", output_path,
+						strerror(errno));
+
+			i_script = PQfnumber(res, "script");
+
+			yb_fprintf_and_log(script, "In database: %s\n", active_db->db_name);
+			yb_fprintf_and_log(script, "    \\c %s\n", active_db->db_name);
+
+			for (rowno = 0; rowno < ntups; rowno++)
+				yb_fprintf_and_log(script, "%s\n\n",
+								PQgetvalue(res, rowno, i_script));
+
+		}
+		PQclear(res);
+		PQfinish(conn);
+	}
+
+	if (script)
+		fclose(script);
+
+	if (found)
+	{
+		yb_fatal("Your installation contains function privileges whose grantor is not\n"
+				 "the current owner. This can happen when function ownership is changed\n"
+				 "after privileges were granted (for example, ALTER FUNCTION ... OWNER\n"
+				 "TO). These stale ACL entries cause major version upgrade to fail.\n"
+				 "To fix, connect to each database listed below and run the commands\n"
+				 "printed for each affected function.\n"
+				 "A list of affected functions and fix commands is printed above and in\n"
+				 "the file:\n"
+				 "    %s\n\n", output_path);
+	}
+	else
+	{
+		check_ok();
+	}
 }

--- a/src/yb/integration-tests/upgrade-tests/ysql_major_upgrade_check-test.cc
+++ b/src/yb/integration-tests/upgrade-tests/ysql_major_upgrade_check-test.cc
@@ -401,4 +401,244 @@ TEST_F(YsqlMajorUpgradeCheckTest, YbPrefixRoles) {
   // Verify that validation now succeeds
   ASSERT_OK(ValidateUpgradeCompatibility());
 }
+
+TEST_F(YsqlMajorUpgradeCheckTest, StaleFunctionAclGrantors) {
+  auto conn = ASSERT_RESULT(cluster_->ConnectToDB());
+
+  auto phase1_single_function = [this, &conn]() {
+    // Phase 1: single function with stale grantor after ALTER FUNCTION OWNER TO.
+    ASSERT_OK(conn.Execute("CREATE ROLE test_role1"));
+    ASSERT_OK(conn.Execute("CREATE ROLE test_role2"));
+    ASSERT_OK(conn.Execute("GRANT CREATE ON SCHEMA public TO test_role1"));
+
+    ASSERT_OK(conn.Execute("SET SESSION AUTHORIZATION test_role1"));
+    ASSERT_OK(conn.Execute(
+        "CREATE FUNCTION public.test_func1(text) RETURNS bool "
+        "AS 'SELECT true' LANGUAGE sql"));
+    ASSERT_OK(conn.Execute("GRANT EXECUTE ON FUNCTION public.test_func1(text) TO PUBLIC"));
+    ASSERT_OK(conn.Execute("GRANT EXECUTE ON FUNCTION public.test_func1(text) TO test_role2"));
+    ASSERT_OK(conn.Execute("RESET SESSION AUTHORIZATION"));
+    ASSERT_OK(conn.Execute("ALTER FUNCTION public.test_func1(text) OWNER TO test_role2"));
+
+    // Verify pg_upgrade suggests the full repair script for the function.
+    ASSERT_OK(ValidateUpgradeCompatibilityFailure(std::vector<std::string>{
+        // test_func1(text)
+        "ALTER FUNCTION \"public\".\"test_func1\"(text) OWNER TO \"test_role1\";",
+        "REVOKE ALL ON FUNCTION \"public\".\"test_func1\"(text) FROM PUBLIC;",
+        "REVOKE ALL ON FUNCTION \"public\".\"test_func1\"(text) FROM \"test_role1\";",
+        "REVOKE ALL ON FUNCTION \"public\".\"test_func1\"(text) FROM \"test_role2\";",
+        "ALTER FUNCTION \"public\".\"test_func1\"(text) OWNER TO \"test_role2\";",
+        "GRANT EXECUTE ON FUNCTION \"public\".\"test_func1\"(text) TO PUBLIC;",
+        "GRANT EXECUTE ON FUNCTION \"public\".\"test_func1\"(text) TO \"test_role1\";",
+        "GRANT EXECUTE ON FUNCTION \"public\".\"test_func1\"(text) TO \"test_role2\";",
+    }));
+
+    // Mitigate the function and confirm check passes.
+    ASSERT_OK(conn.Execute("ALTER FUNCTION public.test_func1(text) OWNER TO test_role1"));
+    ASSERT_OK(conn.Execute("REVOKE ALL ON FUNCTION public.test_func1(text) FROM PUBLIC"));
+    ASSERT_OK(conn.Execute("REVOKE ALL ON FUNCTION public.test_func1(text) FROM test_role1"));
+    ASSERT_OK(conn.Execute("REVOKE ALL ON FUNCTION public.test_func1(text) FROM test_role2"));
+    ASSERT_OK(conn.Execute("ALTER FUNCTION public.test_func1(text) OWNER TO test_role2"));
+    ASSERT_OK(conn.Execute("GRANT EXECUTE ON FUNCTION public.test_func1(text) TO PUBLIC"));
+    ASSERT_OK(conn.Execute("GRANT EXECUTE ON FUNCTION public.test_func1(text) TO test_role1"));
+    ASSERT_OK(conn.Execute("GRANT EXECUTE ON FUNCTION public.test_func1(text) TO test_role2"));
+    ASSERT_OK(ValidateUpgradeCompatibility());
+  };
+
+  auto phase2_overloaded_functions = [this, &conn]() {
+    // Phase 2: overloaded functions with stale grantor after ALTER FUNCTION OWNER TO.
+    ASSERT_OK(conn.Execute("CREATE ROLE test_role3"));
+    ASSERT_OK(conn.Execute("CREATE ROLE test_role4"));
+    ASSERT_OK(conn.Execute("GRANT CREATE ON SCHEMA public TO test_role3"));
+
+    ASSERT_OK(conn.Execute("SET SESSION AUTHORIZATION test_role3"));
+    ASSERT_OK(conn.Execute(
+        "CREATE FUNCTION public.test_func2(text) RETURNS bool "
+        "AS 'SELECT true' LANGUAGE sql"));
+    ASSERT_OK(conn.Execute(
+        "CREATE FUNCTION public.test_func2(int) RETURNS bool "
+        "AS 'SELECT true' LANGUAGE sql"));
+    ASSERT_OK(conn.Execute("GRANT EXECUTE ON FUNCTION public.test_func2(text) TO PUBLIC"));
+    ASSERT_OK(conn.Execute("GRANT EXECUTE ON FUNCTION public.test_func2(int) TO test_role4"));
+    ASSERT_OK(conn.Execute("RESET SESSION AUTHORIZATION"));
+    ASSERT_OK(conn.Execute("ALTER FUNCTION public.test_func2(text) OWNER TO test_role4"));
+    ASSERT_OK(conn.Execute("ALTER FUNCTION public.test_func2(int) OWNER TO test_role4"));
+
+    // Verify pg_upgrade suggests per-signature repair scripts for each overload.
+    ASSERT_OK(ValidateUpgradeCompatibilityFailure(std::vector<std::string>{
+        // test_func2(integer)
+        "ALTER FUNCTION \"public\".\"test_func2\"(integer) OWNER TO \"test_role3\";",
+        "REVOKE ALL ON FUNCTION \"public\".\"test_func2\"(integer) FROM PUBLIC;",
+        "REVOKE ALL ON FUNCTION \"public\".\"test_func2\"(integer) FROM \"test_role3\";",
+        "REVOKE ALL ON FUNCTION \"public\".\"test_func2\"(integer) FROM \"test_role4\";",
+        "ALTER FUNCTION \"public\".\"test_func2\"(integer) OWNER TO \"test_role4\";",
+        "GRANT EXECUTE ON FUNCTION \"public\".\"test_func2\"(integer) TO PUBLIC;",
+        "GRANT EXECUTE ON FUNCTION \"public\".\"test_func2\"(integer) TO \"test_role3\";",
+
+        // test_func2(text)
+        "ALTER FUNCTION \"public\".\"test_func2\"(text) OWNER TO \"test_role3\";",
+        "REVOKE ALL ON FUNCTION \"public\".\"test_func2\"(text) FROM PUBLIC;",
+        "REVOKE ALL ON FUNCTION \"public\".\"test_func2\"(text) FROM \"test_role3\";",
+        "ALTER FUNCTION \"public\".\"test_func2\"(text) OWNER TO \"test_role4\";",
+        "GRANT EXECUTE ON FUNCTION \"public\".\"test_func2\"(text) TO PUBLIC;",
+        "GRANT EXECUTE ON FUNCTION \"public\".\"test_func2\"(text) TO \"test_role3\";",
+    }));
+
+    // Mitigate both overloads and confirm check passes.
+    ASSERT_OK(conn.Execute("ALTER FUNCTION public.test_func2(integer) OWNER TO test_role3"));
+    ASSERT_OK(conn.Execute("REVOKE ALL ON FUNCTION public.test_func2(integer) FROM PUBLIC"));
+    ASSERT_OK(conn.Execute("REVOKE ALL ON FUNCTION public.test_func2(integer) FROM test_role3"));
+    ASSERT_OK(conn.Execute("REVOKE ALL ON FUNCTION public.test_func2(integer) FROM test_role4"));
+    ASSERT_OK(conn.Execute("ALTER FUNCTION public.test_func2(integer) OWNER TO test_role4"));
+    ASSERT_OK(conn.Execute("GRANT EXECUTE ON FUNCTION public.test_func2(integer) TO PUBLIC"));
+    ASSERT_OK(conn.Execute("GRANT EXECUTE ON FUNCTION public.test_func2(integer) TO test_role3"));
+
+    ASSERT_OK(conn.Execute("ALTER FUNCTION public.test_func2(text) OWNER TO test_role3"));
+    ASSERT_OK(conn.Execute("REVOKE ALL ON FUNCTION public.test_func2(text) FROM PUBLIC"));
+    ASSERT_OK(conn.Execute("REVOKE ALL ON FUNCTION public.test_func2(text) FROM test_role3"));
+    ASSERT_OK(conn.Execute("ALTER FUNCTION public.test_func2(text) OWNER TO test_role4"));
+    ASSERT_OK(conn.Execute("GRANT EXECUTE ON FUNCTION public.test_func2(text) TO PUBLIC"));
+    ASSERT_OK(conn.Execute("GRANT EXECUTE ON FUNCTION public.test_func2(text) TO test_role3"));
+    ASSERT_OK(ValidateUpgradeCompatibility());
+  };
+
+  auto phase3_custom_schema = [this, &conn]() {
+    // Phase 3: stale function in a custom schema.
+    ASSERT_OK(conn.Execute("CREATE SCHEMA test_schema"));
+    ASSERT_OK(conn.Execute("CREATE ROLE test_role5"));
+    ASSERT_OK(conn.Execute("CREATE ROLE test_role6"));
+    ASSERT_OK(conn.Execute("GRANT USAGE, CREATE ON SCHEMA test_schema TO test_role5"));
+
+    ASSERT_OK(conn.Execute("SET SESSION AUTHORIZATION test_role5"));
+    ASSERT_OK(conn.Execute(
+        "CREATE FUNCTION test_schema.test_func3(text) RETURNS bool "
+        "AS 'SELECT true' LANGUAGE sql"));
+    ASSERT_OK(conn.Execute("GRANT EXECUTE ON FUNCTION test_schema.test_func3(text) TO PUBLIC"));
+    ASSERT_OK(conn.Execute(
+        "GRANT EXECUTE ON FUNCTION test_schema.test_func3(text) TO test_role6"));
+    ASSERT_OK(conn.Execute("RESET SESSION AUTHORIZATION"));
+    ASSERT_OK(conn.Execute(
+        "ALTER FUNCTION test_schema.test_func3(text) OWNER TO test_role6"));
+
+    // Verify pg_upgrade suggests the full repair script with schema quoting.
+    ASSERT_OK(ValidateUpgradeCompatibilityFailure(std::vector<std::string>{
+        // test_func3(text) in test_schema
+        "ALTER FUNCTION \"test_schema\".\"test_func3\"(text) OWNER TO \"test_role5\";",
+        "REVOKE ALL ON FUNCTION \"test_schema\".\"test_func3\"(text) FROM PUBLIC;",
+        "REVOKE ALL ON FUNCTION \"test_schema\".\"test_func3\"(text) FROM \"test_role5\";",
+        "REVOKE ALL ON FUNCTION \"test_schema\".\"test_func3\"(text) FROM \"test_role6\";",
+        "ALTER FUNCTION \"test_schema\".\"test_func3\"(text) OWNER TO \"test_role6\";",
+        "GRANT EXECUTE ON FUNCTION \"test_schema\".\"test_func3\"(text) TO PUBLIC;",
+        "GRANT EXECUTE ON FUNCTION \"test_schema\".\"test_func3\"(text) TO \"test_role5\";",
+        "GRANT EXECUTE ON FUNCTION \"test_schema\".\"test_func3\"(text) TO \"test_role6\";",
+    }));
+
+    // Mitigate the function and confirm check passes.
+    ASSERT_OK(conn.Execute("ALTER FUNCTION test_schema.test_func3(text) OWNER TO test_role5"));
+    ASSERT_OK(conn.Execute("REVOKE ALL ON FUNCTION test_schema.test_func3(text) FROM PUBLIC"));
+    ASSERT_OK(conn.Execute("REVOKE ALL ON FUNCTION test_schema.test_func3(text) FROM test_role5"));
+    ASSERT_OK(conn.Execute("REVOKE ALL ON FUNCTION test_schema.test_func3(text) FROM test_role6"));
+    ASSERT_OK(conn.Execute("ALTER FUNCTION test_schema.test_func3(text) OWNER TO test_role6"));
+    ASSERT_OK(conn.Execute("GRANT EXECUTE ON FUNCTION test_schema.test_func3(text) TO PUBLIC"));
+    ASSERT_OK(conn.Execute("GRANT EXECUTE ON FUNCTION test_schema.test_func3(text) TO test_role5"));
+    ASSERT_OK(conn.Execute("GRANT EXECUTE ON FUNCTION test_schema.test_func3(text) TO test_role6"));
+    ASSERT_OK(ValidateUpgradeCompatibility());
+
+    ASSERT_OK(conn.Execute("DROP FUNCTION test_schema.test_func3(text)"));
+    ASSERT_OK(conn.Execute("REVOKE USAGE, CREATE ON SCHEMA test_schema FROM test_role5"));
+    ASSERT_OK(conn.Execute("DROP SCHEMA test_schema"));
+  };
+
+  auto phase4_multiple_databases = [this, &conn]() {
+    // Phase 4: stale functions in two databases sharing the same roles.
+    constexpr const char* kTestDb1 = "test_db1";
+    constexpr const char* kTestDb2 = "test_db2";
+
+    ASSERT_OK(conn.Execute("CREATE DATABASE test_db1"));
+    ASSERT_OK(conn.Execute("CREATE DATABASE test_db2"));
+    ASSERT_OK(conn.Execute("CREATE ROLE test_role7"));
+    ASSERT_OK(conn.Execute("CREATE ROLE test_role8"));
+
+    auto setup_stale_function = [](pgwrapper::PGConn& conn_db) {
+      ASSERT_OK(conn_db.Execute("GRANT CREATE ON SCHEMA public TO test_role7"));
+      ASSERT_OK(conn_db.Execute("SET SESSION AUTHORIZATION test_role7"));
+      ASSERT_OK(conn_db.Execute(
+          "CREATE FUNCTION public.test_func4(text) RETURNS bool "
+          "AS 'SELECT true' LANGUAGE sql"));
+      ASSERT_OK(conn_db.Execute("GRANT EXECUTE ON FUNCTION public.test_func4(text) TO PUBLIC"));
+      ASSERT_OK(conn_db.Execute("GRANT EXECUTE ON FUNCTION public.test_func4(text) TO test_role8"));
+      ASSERT_OK(conn_db.Execute("RESET SESSION AUTHORIZATION"));
+      ASSERT_OK(conn_db.Execute("ALTER FUNCTION public.test_func4(text) OWNER TO test_role8"));
+    };
+
+    auto conn_db1 = ASSERT_RESULT(cluster_->ConnectToDB(kTestDb1));
+    setup_stale_function(conn_db1);
+
+    auto conn_db2 = ASSERT_RESULT(cluster_->ConnectToDB(kTestDb2));
+    setup_stale_function(conn_db2);
+
+    // Verify pg_upgrade suggests the full repair script in each database.
+    ASSERT_OK(ValidateUpgradeCompatibilityFailure(std::vector<std::string>{
+        // test_db1
+        "In database: test_db1",
+        "ALTER FUNCTION \"public\".\"test_func4\"(text) OWNER TO \"test_role7\";",
+        "REVOKE ALL ON FUNCTION \"public\".\"test_func4\"(text) FROM PUBLIC;",
+        "REVOKE ALL ON FUNCTION \"public\".\"test_func4\"(text) FROM \"test_role7\";",
+        "REVOKE ALL ON FUNCTION \"public\".\"test_func4\"(text) FROM \"test_role8\";",
+        "ALTER FUNCTION \"public\".\"test_func4\"(text) OWNER TO \"test_role8\";",
+        "GRANT EXECUTE ON FUNCTION \"public\".\"test_func4\"(text) TO PUBLIC;",
+        "GRANT EXECUTE ON FUNCTION \"public\".\"test_func4\"(text) TO \"test_role7\";",
+        "GRANT EXECUTE ON FUNCTION \"public\".\"test_func4\"(text) TO \"test_role8\";",
+
+        // test_db2
+        "In database: test_db2",
+        "ALTER FUNCTION \"public\".\"test_func4\"(text) OWNER TO \"test_role7\";",
+        "REVOKE ALL ON FUNCTION \"public\".\"test_func4\"(text) FROM PUBLIC;",
+        "REVOKE ALL ON FUNCTION \"public\".\"test_func4\"(text) FROM \"test_role7\";",
+        "REVOKE ALL ON FUNCTION \"public\".\"test_func4\"(text) FROM \"test_role8\";",
+        "ALTER FUNCTION \"public\".\"test_func4\"(text) OWNER TO \"test_role8\";",
+        "GRANT EXECUTE ON FUNCTION \"public\".\"test_func4\"(text) TO PUBLIC;",
+        "GRANT EXECUTE ON FUNCTION \"public\".\"test_func4\"(text) TO \"test_role7\";",
+        "GRANT EXECUTE ON FUNCTION \"public\".\"test_func4\"(text) TO \"test_role8\";",
+    }));
+
+    auto mitigate_stale_function = [](pgwrapper::PGConn& conn_db) {
+      ASSERT_OK(conn_db.Execute("ALTER FUNCTION public.test_func4(text) OWNER TO test_role7"));
+      ASSERT_OK(conn_db.Execute("REVOKE ALL ON FUNCTION public.test_func4(text) FROM PUBLIC"));
+      ASSERT_OK(conn_db.Execute("REVOKE ALL ON FUNCTION public.test_func4(text) FROM test_role7"));
+      ASSERT_OK(conn_db.Execute("REVOKE ALL ON FUNCTION public.test_func4(text) FROM test_role8"));
+      ASSERT_OK(conn_db.Execute("ALTER FUNCTION public.test_func4(text) OWNER TO test_role8"));
+      ASSERT_OK(conn_db.Execute("GRANT EXECUTE ON FUNCTION public.test_func4(text) TO PUBLIC"));
+      ASSERT_OK(conn_db.Execute("GRANT EXECUTE ON FUNCTION public.test_func4(text) TO test_role7"));
+      ASSERT_OK(conn_db.Execute("GRANT EXECUTE ON FUNCTION public.test_func4(text) TO test_role8"));
+    };
+
+    mitigate_stale_function(conn_db1);
+    mitigate_stale_function(conn_db2);
+    ASSERT_OK(ValidateUpgradeCompatibility());
+
+    ASSERT_OK(conn_db1.Execute("DROP FUNCTION public.test_func4(text)"));
+    ASSERT_OK(conn_db2.Execute("DROP FUNCTION public.test_func4(text)"));
+  };
+
+  auto cleanup = [&conn]() {
+    ASSERT_OK(conn.Execute("DROP FUNCTION public.test_func1(text), "
+      "public.test_func2(text), public.test_func2(int)"));
+    ASSERT_OK(conn.Execute("DROP DATABASE test_db1"));
+    ASSERT_OK(conn.Execute("DROP DATABASE test_db2"));
+    ASSERT_OK(conn.Execute("REVOKE CREATE ON SCHEMA public FROM test_role1"));
+    ASSERT_OK(conn.Execute("REVOKE CREATE ON SCHEMA public FROM test_role3"));
+    ASSERT_OK(conn.Execute("DROP ROLE test_role1, test_role2, test_role3, test_role4"));
+    ASSERT_OK(conn.Execute("DROP ROLE test_role5, test_role6"));
+    ASSERT_OK(conn.Execute("DROP ROLE test_role7, test_role8"));
+  };
+
+  ASSERT_NO_FATALS(phase1_single_function());
+  ASSERT_NO_FATALS(phase2_overloaded_functions());
+  ASSERT_NO_FATALS(phase3_custom_schema());
+  ASSERT_NO_FATALS(phase4_multiple_databases());
+
+  // Cleanup functions, schema grants, roles, and the extra databases.
+  ASSERT_NO_FATALS(cleanup());
+}
 }  // namespace yb


### PR DESCRIPTION
DO NOT MERGE!! [CSI](<https://csiweb.dev.yugabyte.com/pull/32194/>) ❌. Once CSI passes, comment `trigger jenkins` to clear this warning.

Summary:
When function privileges are granted and the function owner is later changed (with ALTER FUNCTION ... OWNER TO), the ACL can still list the original grantor instead of the current owner.

These stale grantors block YSQL major version upgrade because pg_upgrade fails on the inconsistent catalog state.
This revision adds a new pg_upgrade --check validation (yb_check_stale_acl_grantors) that detects affected functions, fails the check with a clear error, and prints a per-function repair script (temporarily change owner, revoke stale grants, restore owner, re-grant privileges).
It also adds YsqlMajorUpgradeCheckTest.StaleFunctionAclGrantors to cover single functions, overloaded functions, custom schemas, and multiple databases.

Jira: [[ https://yugabyte.atlassian.net/browse/DB-21709 | DB-21709 ]]

Original commit: 467873afb0ddfbb72a6d73989fa858550bdf7e32 / D54376

Test Plan:
**Automated:**
```
./yb_build.sh release --cxx-test integration-tests_ysql_major_upgrade_check-test \
  --gtest_filter YsqlMajorUpgradeCheckTest.StaleFunctionAclGrantors
...
[       OK ] YsqlMajorUpgradeCheckTest.StaleFunctionAclGrantors (30923 ms)
[  PASSED  ] 1 test.
100% tests passed, 0 tests failed out of 1
Total Test time (real) = 32.29 sec
```

**Manual:**

Create stale grantor state
```
ysqlsh (11.2-YB-2024.2.7.3-b0)
Type "help" for help.

yugabyte=# CREATE ROLE test_role1;
CREATE ROLE
yugabyte=# CREATE ROLE test_role2;
CREATE ROLE
yugabyte=# GRANT CREATE ON SCHEMA public TO test_role1;
GRANT
yugabyte=# SET SESSION AUTHORIZATION test_role1;
SET
yugabyte=> CREATE FUNCTION public.test_func1(text) RETURNS bool AS 'SELECT true' LANGUAGE sql;
CREATE FUNCTION
yugabyte=> GRANT EXECUTE ON FUNCTION public.test_func1(text) TO PUBLIC;
GRANT
yugabyte=> GRANT EXECUTE ON FUNCTION public.test_func1(text) TO test_role2;
GRANT
yugabyte=> RESET SESSION AUTHORIZATION;
RESET
yugabyte=# ALTER FUNCTION public.test_func1(text) OWNER TO test_role2;
ALTER FUNCTION
```

Run check — failed
```
./build/latest/postgres_build/src/bin/pg_upgrade/pg_upgrade --check -U yugabyte --old-host 127.0.0.1 --old-port 5433 --old-datadir ~/yugabyte-data/data/pg_data_11

Performing Consistency Checks on Old Live Server
------------------------------------------------
Checking cluster versions                                   ok
Checking attributes of the 'yugabyte' user                  ok
Checking for all 3 system databases                         ok
Checking database connection settings                       ok
Checking for system-defined composite types in user tables  ok
Checking for reg* data types in user tables                 ok
Checking for removed "abstime" data type in user tables     ok
Checking for removed "reltime" data type in user tables     ok
Checking for removed "tinterval" data type in user tables   ok
Checking for user-defined postfix operators                 ok
Checking for incompatible polymorphic functions             ok
Checking for invalid "sql_identifier" user columns          ok
Checking for invalid indexes                                ok
Checking installed extensions                               ok
Checking for extensions in conflicting schemas              ok
Checking for roles starting with "yb_"                      ok
Checking for privileges with stale grantors                 fatal

In database: yugabyte
    \c yugabyte
    ALTER FUNCTION "public"."test_func1"(text) OWNER TO "test_role1";
    REVOKE ALL ON FUNCTION "public"."test_func1"(text) FROM "test_role1";
    REVOKE ALL ON FUNCTION "public"."test_func1"(text) FROM "test_role2";
    REVOKE ALL ON FUNCTION "public"."test_func1"(text) FROM PUBLIC;
    ALTER FUNCTION "public"."test_func1"(text) OWNER TO "test_role2";
    GRANT EXECUTE ON FUNCTION "public"."test_func1"(text) TO "test_role1";
    GRANT EXECUTE ON FUNCTION "public"."test_func1"(text) TO "test_role2";
    GRANT EXECUTE ON FUNCTION "public"."test_func1"(text) TO PUBLIC;

Your installation contains function privileges whose grantor is not
the current owner. This can happen when function ownership is changed
after privileges were granted (for example, ALTER FUNCTION ... OWNER
TO). These stale ACL entries cause major version upgrade to fail.
To fix, connect to each database listed below and run the commands
printed for each affected function.
A list of affected functions and fix commands is printed above and in
the file:
    /Users/nikhillondhe/yugabyte-data/data/pg_data_11/pg_upgrade_output.d/20260609T180358.914/stale_acl_grantors.txt

Failure, exiting
```

Apply fix
```
ALTER FUNCTION "public"."test_func1"(text) OWNER TO "test_role1";
ALTER FUNCTION
yugabyte=#     REVOKE ALL ON FUNCTION "public"."test_func1"(text) FROM "test_role1";
REVOKE
yugabyte=#     REVOKE ALL ON FUNCTION "public"."test_func1"(text) FROM "test_role2";
REVOKE
yugabyte=#     REVOKE ALL ON FUNCTION "public"."test_func1"(text) FROM PUBLIC;
REVOKE
yugabyte=#     ALTER FUNCTION "public"."test_func1"(text) OWNER TO "test_role2";
ALTER FUNCTION
yugabyte=#     GRANT EXECUTE ON FUNCTION "public"."test_func1"(text) TO "test_role1";
GRANT
yugabyte=#     GRANT EXECUTE ON FUNCTION "public"."test_func1"(text) TO "test_role2";
GRANT
yugabyte=#     GRANT EXECUTE ON FUNCTION "public"."test_func1"(text) TO PUBLIC;
GRANT
```

Run check again — passed
```
./build/latest/postgres_build/src/bin/pg_upgrade/pg_upgrade --check -U yugabyte --old-host 127.0.0.1 --old-port 5433 --old-datadir ~/yugabyte-data/data/pg_data_11

Performing Consistency Checks on Old Live Server
------------------------------------------------
Checking cluster versions                                   ok
Checking attributes of the 'yugabyte' user                  ok
Checking for all 3 system databases                         ok
Checking database connection settings                       ok
Checking for system-defined composite types in user tables  ok
Checking for reg* data types in user tables                 ok
Checking for removed "abstime" data type in user tables     ok
Checking for removed "reltime" data type in user tables     ok
Checking for removed "tinterval" data type in user tables   ok
Checking for user-defined postfix operators                 ok
Checking for incompatible polymorphic functions             ok
Checking for invalid "sql_identifier" user columns          ok
Checking for invalid indexes                                ok
Checking installed extensions                               ok
Checking for extensions in conflicting schemas              ok
Checking for roles starting with "yb_"                      ok
Checking for privileges with stale grantors                 ok

*Clusters are compatible*
```

Reviewers: fizaa

Reviewed By: fizaa

Subscribers: yql

Differential Revision: https://phorge.dev.yugabyte.com/D54376