### PR TITLE
[BACKPORT 2025.1][#6640] YSQL: Support ALTER TABLESPACE SET/RESET for placement options (#31948)

### DIFF
--- a/docs/content/stable/api/ysql/the-sql-language/statements/_index.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/_index.md
@@ -30,6 +30,7 @@ The YSQL statements are compatible with the SQL dialect that PostgreSQL supports
 | [`ALTER SERVER`](ddl_alter_server) | Change foreign server definition |
 | [`ALTER SCHEMA`](ddl_alter_schema) | Change schema definition |
 | [`ALTER TABLE`](ddl_alter_table) | Change table definition |
+| [`ALTER TABLESPACE`](ddl_alter_tablespace) | Change tablespace placement options |
 | [`COMMENT`](ddl_comment) | Set, update, or remove a comment on a database object |
 | [`CREATE AGGREGATE`](ddl_create_aggregate) | Create an aggregate |
 | [`CREATE CAST`](ddl_create_cast) | Create a cast |

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_alter_tablespace.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_alter_tablespace.md
@@ -1,0 +1,79 @@
+---
+title: ALTER TABLESPACE [YSQL]
+headerTitle: ALTER TABLESPACE
+linkTitle: ALTER TABLESPACE
+description: Use the ALTER TABLESPACE statement to change tablespace placement options.
+menu:
+  stable_api:
+    identifier: ddl_alter_tablespace
+    parent: statements
+type: docs
+---
+
+## Synopsis
+
+Use the `ALTER TABLESPACE` statement to change the placement options of an existing tablespace.
+
+Changing YugabyteDB placement options affects all YSQL tables, indexes, materialized views, and tablegroups that use the tablespace. The catalog change is applied immediately, but tablet replica movement is asynchronous and is performed by the load balancer.
+
+## Syntax
+
+```sql
+ALTER TABLESPACE tablespace_name SET ( tablespace_option = value [, ...] );
+ALTER TABLESPACE tablespace_name RESET ( tablespace_option [, ...] );
+```
+
+## Semantics
+
+### tablespace_name
+
+Specify the name of the tablespace to alter.
+
+### tablespace_option
+
+Can be one of `replica_placement` or `read_replica_placement`.
+
+- Use `replica_placement` to specify the number of live replicas and how they are distributed across clouds, regions, and zones.
+- Use `read_replica_placement` to specify read replica placement. `read_replica_placement` requires `replica_placement` to be set.
+
+When a tablespace is already used by existing database objects, the new placement must be satisfiable by the currently available tablet servers. If the tablespace is unused, you can define placement before adding the corresponding tablet servers, matching `CREATE TABLESPACE` behavior.
+
+## Examples
+
+Change the live replica placement for a tablespace:
+
+```sql
+ALTER TABLESPACE us_west_tablespace SET (
+  replica_placement = '{"num_replicas":3,
+    "placement_blocks":[
+      {"cloud":"cloud1","region":"us-west","zone":"us-west-1a","min_num_replicas":1},
+      {"cloud":"cloud1","region":"us-west","zone":"us-west-1b","min_num_replicas":1},
+      {"cloud":"cloud1","region":"us-west","zone":"us-west-1c","min_num_replicas":1}
+    ]}'
+);
+```
+
+Remove custom read replica placement:
+
+```sql
+ALTER TABLESPACE us_west_tablespace RESET (read_replica_placement);
+```
+
+Remove all custom placement options so objects using the tablespace fall back to the cluster placement policy:
+
+```sql
+ALTER TABLESPACE us_west_tablespace RESET (replica_placement, read_replica_placement);
+```
+
+## Notes
+
+- Data movement is asynchronous. Monitor tablet placement from the YB-Master UI at `http://<YB-Master-host>:7000/tables`.
+- The command updates the tablespace definition. You don't need to run `ALTER TABLE ... SET TABLESPACE` for each object already using the tablespace.
+- Tablespaces are global objects. In xCluster or backup/restore workflows, ensure the expected tablespace definitions exist where they are needed.
+
+## See also
+
+- [CREATE TABLESPACE](../ddl_create_tablespace)
+- [DROP TABLESPACE](../ddl_drop_tablespace)
+- [ALTER TABLE](../ddl_alter_table)
+- [ALTER INDEX](../ddl_alter_index)

--- a/java/yb-pgsql/src/test/java/org/yb/pgsql/BaseTablespaceTest.java
+++ b/java/yb-pgsql/src/test/java/org/yb/pgsql/BaseTablespaceTest.java
@@ -71,6 +71,7 @@ public abstract class BaseTablespaceTest extends BasePgSQLTest {
                           Integer.toString(MASTER_REFRESH_TABLESPACE_INFO_SECS));
     builder.addMasterFlag("auto_create_local_transaction_tables", "true");
     builder.addMasterFlag("TEST_name_transaction_tables_with_tablespace_id", "true");
+    builder.addMasterFlag("catalog_manager_check_ts_count_for_create_table", "false");
 
     // We wait for the load balancer whenever it gets triggered anyways, so there's
     // no concerns about the load balancer taking too many resources.

--- a/java/yb-pgsql/src/test/java/org/yb/pgsql/TestTablespaceProperties.java
+++ b/java/yb-pgsql/src/test/java/org/yb/pgsql/TestTablespaceProperties.java
@@ -100,6 +100,82 @@ public class TestTablespaceProperties extends BaseTablespaceTest {
   }
 
   @Test
+  public void testAlterTablespacePlacementMovesExistingObjects() throws Exception {
+    Tablespace alteredTablespace = new Tablespace(tablespaceName, Arrays.asList(2, 3));
+    String tableName = "alter_tsp_base";
+    String indexName = "alter_tsp_idx";
+    String matViewName = "alter_tsp_mv";
+    String tablegroupName = "alter_tsp_tgroup";
+    String tablegroupTableName = "alter_tsp_tgroup_tbl";
+    String partitionedTableName = "alter_tsp_part";
+    String partitionName1 = "alter_tsp_part_p1";
+    String partitionName2 = "alter_tsp_part_p2";
+    // The partitioned parent does not own tablets, so verify its partitions.
+    List<String> relations = Arrays.asList(
+        tableName, indexName, matViewName, tablegroupTableName, partitionName1, partitionName2);
+
+    try (Statement setupStatement = connection.createStatement()) {
+      setupStatement.execute(String.format(
+          "CREATE TABLE %s (a int) TABLESPACE %s", tableName, tablespaceName));
+      setupStatement.execute(String.format(
+          "CREATE INDEX %s ON %s(a) TABLESPACE %s", indexName, tableName, tablespaceName));
+      setupStatement.execute(String.format(
+          "CREATE MATERIALIZED VIEW %s TABLESPACE %s AS SELECT * FROM %s",
+          matViewName, tablespaceName, tableName));
+      setupStatement.execute(String.format(
+          "CREATE TABLEGROUP %s TABLESPACE %s", tablegroupName, tablespaceName));
+      setupStatement.execute(String.format(
+          "CREATE TABLE %s (a int) TABLEGROUP %s", tablegroupTableName, tablegroupName));
+      setupStatement.execute(String.format(
+          "CREATE TABLE %s (a int) PARTITION BY RANGE (a) TABLESPACE %s",
+          partitionedTableName, tablespaceName));
+      setupStatement.execute(String.format(
+          "CREATE TABLE %s PARTITION OF %s FOR VALUES FROM (0) TO (100) TABLESPACE %s",
+          partitionName1, partitionedTableName, tablespaceName));
+      setupStatement.execute(String.format(
+          "CREATE TABLE %s PARTITION OF %s FOR VALUES FROM (100) TO (200) TABLESPACE %s",
+          partitionName2, partitionedTableName, tablespaceName));
+    }
+
+    try {
+      verifyPlacement(relations, customTablespace);
+
+      try (Statement alterStatement = connection.createStatement()) {
+        alterStatement.execute(String.format(
+            "ALTER TABLESPACE %s SET (replica_placement='%s')",
+            tablespaceName, alteredTablespace.toJson()));
+      }
+
+      Thread.sleep(2 * 1000 * MASTER_REFRESH_TABLESPACE_INFO_SECS);
+      assertTrue(miniCluster.getClient().waitForLoadBalance(
+          MASTER_LOAD_BALANCER_WAIT_TIME_MS, miniCluster.getTabletServers().size()));
+      verifyPlacement(relations, alteredTablespace);
+
+      try (Statement resetStatement = connection.createStatement()) {
+        resetStatement.execute(String.format(
+            "ALTER TABLESPACE %s RESET (replica_placement)", tablespaceName));
+      }
+
+      Thread.sleep(2 * 1000 * MASTER_REFRESH_TABLESPACE_INFO_SECS);
+      assertTrue(miniCluster.getClient().waitForLoadBalance(
+          MASTER_LOAD_BALANCER_WAIT_TIME_MS, miniCluster.getTabletServers().size()));
+      verifyPlacement(relations, defaultTablespace);
+    } finally {
+      try (Statement cleanupStatement = connection.createStatement()) {
+        cleanupStatement.execute(String.format("DROP TABLE IF EXISTS %s", tablegroupTableName));
+        cleanupStatement.execute(String.format("DROP TABLEGROUP IF EXISTS %s", tablegroupName));
+        cleanupStatement.execute(String.format("DROP MATERIALIZED VIEW IF EXISTS %s", matViewName));
+        cleanupStatement.execute(String.format(
+            "DROP TABLE IF EXISTS %s CASCADE", partitionedTableName));
+        cleanupStatement.execute(String.format("DROP TABLE IF EXISTS %s CASCADE", tableName));
+        cleanupStatement.execute(String.format(
+            "ALTER TABLESPACE %s SET (replica_placement='%s')",
+            tablespaceName, customTablespace.toJson()));
+      }
+    }
+  }
+
+  @Test
   public void testDisabledTablespaces() throws Exception {
     markClusterNeedsRecreation();
     // Create some tables with custom and default placements.
@@ -264,6 +340,45 @@ public class TestTablespaceProperties extends BaseTablespaceTest {
     executeAndAssertErrorThrown(
         "ALTER MATERIALIZED VIEW validPlacementMv SET TABLESPACE insufficient_rf_tblspc",
         not_enough_tservers_msg);
+
+    Tablespace invalidAlterPlacement = new Tablespace(
+        "invalid_alter_tblspc",
+        2,
+        Arrays.asList(new PlacementBlock(2), new PlacementBlock("cloud3", "region1", "zone1", 1)));
+    executeAndAssertErrorThrown(
+        String.format(
+            "ALTER TABLESPACE valid_tblspc SET (replica_placement='%s')",
+            invalidAlterPlacement.toJson()),
+        not_enough_tservers_msg);
+
+    try (Statement setupStatement = connection.createStatement()) {
+      setupStatement.execute("CREATE TABLESPACE alter_validation_tblspc LOCATION '/data'");
+    }
+    executeAndAssertErrorThrown(
+        "ALTER TABLESPACE alter_validation_tblspc "
+            + "SET (replica_placement='[{\"cloud\"}]')",
+        "JSON parsing of live placement option failed");
+    Tablespace readReplicaAlterTblspc =
+        new Tablespace("read_replica_alter_tblspc", Collections.singletonList(1));
+    executeAndAssertErrorThrown(
+        String.format(
+            "ALTER TABLESPACE alter_validation_tblspc SET (read_replica_placement='%s')",
+            readReplicaAlterTblspc.toJson()),
+        "read_replica_placement option requires replica_placement to be set");
+    Tablespace validAlterValidationTblspc =
+        new Tablespace("valid_alter_validation_tblspc", Arrays.asList(1, 2));
+    try (Statement setupStatement = connection.createStatement()) {
+      setupStatement.execute(String.format(
+          "ALTER TABLESPACE alter_validation_tblspc SET (replica_placement='%s', " +
+              "read_replica_placement='%s')",
+          validAlterValidationTblspc.toJson(), readReplicaAlterTblspc.toJson()));
+    }
+    executeAndAssertErrorThrown(
+        "ALTER TABLESPACE alter_validation_tblspc RESET (replica_placement)",
+        "read_replica_placement option requires replica_placement to be set");
+    try (Statement cleanupStatement = connection.createStatement()) {
+      cleanupStatement.execute("DROP TABLESPACE alter_validation_tblspc");
+    }
   }
 
   /*
@@ -502,6 +617,27 @@ public class TestTablespaceProperties extends BaseTablespaceTest {
 
     verifyPlacement(tablesWithCustomPlacement, customTablespace);
 
+    try (Statement alterStatement = connection.createStatement()) {
+      alterStatement.execute(String.format(
+          "ALTER TABLESPACE %s SET (read_replica_placement='%s')",
+          tablespaceName, new Tablespace(
+              "read_replica_tablespace", Collections.singletonList(1)).toJson()));
+    }
+    waitForLoadBalancer(expectedTServers);
+    List<String> customTablesWithoutTransactionTable = tablesWithCustomPlacement.stream()
+        .filter(table -> !table.contains("transaction"))
+        .collect(Collectors.toList());
+    for (final String table : customTablesWithoutTransactionTable) {
+      verifyPlacementForReadReplica(table, customTablespace.numReplicas, 1);
+    }
+
+    try (Statement alterStatement = connection.createStatement()) {
+      alterStatement.execute(String.format(
+          "ALTER TABLESPACE %s RESET (read_replica_placement)", tablespaceName));
+    }
+    waitForLoadBalancer(expectedTServers);
+    verifyPlacement(tablesWithCustomPlacement, customTablespace);
+
     // Alter tables with custom tablespaces to move to pg_default.
     List<String> movedTables = moveCreatedTestDataToDefaultTablespace("read_replica");
 
@@ -512,9 +648,16 @@ public class TestTablespaceProperties extends BaseTablespaceTest {
   }
 
   void verifyPlacementForReadReplica(final String table) throws Exception {
+    verifyPlacementForReadReplica(table, 1 /* expectedLiveReplicas */,
+        1 /* expectedReadReplicas */);
+  }
+
+  void verifyPlacementForReadReplica(
+      final String table, int expectedLiveReplicas, int expectedReadReplicas) throws Exception {
     LOG.info("Verifying placement for read replica for table " + table);
     final YBClient client = miniCluster.getClient();
-    client.waitForReplicaCount(getTableFromName(table), 2, DEFAULT_TIMEOUT_MS);
+    client.waitForReplicaCount(
+        getTableFromName(table), expectedLiveReplicas + expectedReadReplicas, DEFAULT_TIMEOUT_MS);
 
     List<LocatedTablet> tabletLocations =
         getTableFromName(table).getTabletsLocations(DEFAULT_TIMEOUT_MS);
@@ -528,11 +671,8 @@ public class TestTablespaceProperties extends BaseTablespaceTest {
 
       long liveReplicas = replicas.size() - readReplicas;
 
-      // A live replica must be found.
-      assertEquals(1, liveReplicas);
-
-      // A read-only replica must be found.
-      assertEquals(1, readReplicas);
+      assertEquals(expectedLiveReplicas, liveReplicas);
+      assertEquals(expectedReadReplicas, readReplicas);
     }
   }
 

--- a/src/postgres/src/backend/commands/tablecmds.c
+++ b/src/postgres/src/backend/commands/tablecmds.c
@@ -16215,71 +16215,8 @@ ATExecSetTableSpaceNoStorage(Relation rel, Oid newTableSpace)
 	}
 
 	if (IsYBRelation(rel))
-	{
-		Datum	   *options;
-		int			num_options;
-
-		yb_get_tablespace_options(&options, &num_options, newTableSpace);
-		/*
-		 * Validation should only happen on tablespaces that have a defined
-		 * replica placement
-		 */
-		const char *placement_prefix = "replica_placement=";
-		const char *read_prefix = "read_replica_placement=";
-		const int	placement_prefix_len = strlen(placement_prefix);
-		const int	read_prefix_len = strlen(read_prefix);
-
-		char	   *live_option = NULL;
-		char	   *read_option = NULL;
-
-		for (int i = 0; i < num_options; i++)
-		{
-			char	   *option = text_to_cstring(DatumGetTextP(options[i]));
-
-			if (strncmp(option, placement_prefix, placement_prefix_len) == 0)
-			{
-				if (live_option != NULL)
-					ereport(ERROR,
-							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-							 errmsg("duplicate replica_placement option found")));
-				live_option = option;
-				continue;
-			}
-			else if (strncmp(option, read_prefix, read_prefix_len) == 0)
-			{
-				if (read_option != NULL)
-					ereport(ERROR,
-							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-							 errmsg("duplicate read_replica_placement option found."
-									"Only one read_replica_placement option is supported via "
-									"tablespaces.")));
-				read_option = option;
-				continue;
-			}
-			else
-			{
-				ereport(ERROR,
-						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-						 errmsg("expected replica_placement or read_replica_placement "
-								"option. Got %s", option)));
-			}
-
-			pfree(option);
-		}
-
-		const char *live_value = live_option ?
-			live_option + placement_prefix_len : NULL;
-		const char *read_value = read_option ?
-			read_option + read_prefix_len : NULL;
-
-		YBCValidatePlacements(live_value, read_value,
-								true /* check_satisfiable */ );
-
-		if (live_option)
-			pfree(live_option);
-		if (read_option)
-			pfree(read_option);
-	}
+		yb_validate_tablespace_placement_by_oid(newTableSpace,
+											true /* check_satisfiable */ );
 
 	/* Update can be done, so change reltablespace */
 	SetRelationTableSpace(rel, newTableSpace, InvalidOid);

--- a/src/postgres/src/backend/commands/tablespace.c
+++ b/src/postgres/src/backend/commands/tablespace.c
@@ -1118,6 +1118,28 @@ RenameTableSpace(const char *oldname, const char *newname)
 	return address;
 }
 
+static bool
+yb_tablespace_has_dependencies(Oid tablespaceoid)
+{
+	char	   *detail = NULL;
+	char	   *detail_log = NULL;
+	bool		has_dependencies;
+
+	if (IsPinnedObject(TableSpaceRelationId, tablespaceoid))
+		return true;
+
+	has_dependencies = checkSharedDependencies(TableSpaceRelationId, tablespaceoid,
+										  &detail, &detail_log);
+
+	if (detail)
+		pfree(detail);
+	if (detail_log)
+		pfree(detail_log);
+
+	return has_dependencies;
+}
+
+
 /*
  * Alter table space options
  */
@@ -1135,6 +1157,7 @@ AlterTableSpaceOptions(AlterTableSpaceOptionsStmt *stmt)
 	bool		isnull;
 	bool		repl_null[Natts_pg_tablespace];
 	bool		repl_repl[Natts_pg_tablespace];
+	bool		yb_tablespace_in_use = false;
 	HeapTuple	newtuple;
 
 	/* Search pg_tablespace */
@@ -1167,7 +1190,18 @@ AlterTableSpaceOptions(AlterTableSpaceOptionsStmt *stmt)
 									 stmt->isReset);
 
 	if (IsYugaByteEnabled())
+	{
+		/*
+		 * Validate syntax for all ALTER TABLESPACE changes.  When the
+		 * tablespace already has dependent objects, also verify that the new
+		 * placement is satisfiable because existing tablets may be moved by the
+		 * load balancer after this catalog update commits.
+		 */
 		(void) yb_tablespace_reloptions(newOptions, true);
+		yb_tablespace_in_use = yb_tablespace_has_dependencies(tablespaceoid);
+		yb_validate_tablespace_placement_options(newOptions,
+										   yb_tablespace_in_use);
+	}
 	else
 		(void) tablespace_reloptions(newOptions, true);
 
@@ -1186,6 +1220,14 @@ AlterTableSpaceOptions(AlterTableSpaceOptionsStmt *stmt)
 	CatalogTupleUpdate(rel, &newtuple->t_self, newtuple);
 
 	InvokeObjectPostAlterHook(TableSpaceRelationId, tablespaceoid, 0);
+
+	if (IsYugaByteEnabled() && yb_tablespace_in_use)
+		ereport(NOTICE,
+				(errmsg("data movement for tablespace %s is successfully initiated",
+						stmt->tablespacename),
+				 errdetail("Data movement is a long running asynchronous process "
+						   "and can be monitored by checking the tablet placement "
+						   "in http://<YB-Master-host>:7000/tables.")));
 
 	heap_freetuple(newtuple);
 
@@ -1682,6 +1724,119 @@ yb_get_tablespace_options(Datum **options, int *num_options, Oid spc_oid)
 						spc_oid)));
 
 	ReleaseSysCache(tuple);
+}
+
+/*
+ * yb_extract_tablespace_placement_options - extract Yugabyte placement
+ * options from a pg_tablespace spcoptions text array.
+ *
+ * live_placement and read_replica_placement are returned as palloc'd strings
+ * without their reloption name prefixes, or NULL if absent.
+ */
+static void
+yb_extract_tablespace_placement_options(Datum *options, int num_options,
+									   char **live_placement,
+									   char **read_replica_placement)
+{
+	const char *placement_prefix = "replica_placement=";
+	const char *read_prefix = "read_replica_placement=";
+	const int	placement_prefix_len = strlen(placement_prefix);
+	const int	read_prefix_len = strlen(read_prefix);
+
+	*live_placement = NULL;
+	*read_replica_placement = NULL;
+
+	if (options == NULL || num_options <= 0)
+		return;
+
+	for (int i = 0; i < num_options; i++)
+	{
+		char	   *option = text_to_cstring(DatumGetTextP(options[i]));
+
+		if (strncmp(option, placement_prefix, placement_prefix_len) == 0)
+		{
+			if (*live_placement != NULL)
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						 errmsg("duplicate replica_placement option found")));
+			*live_placement = pstrdup(option + placement_prefix_len);
+		}
+		else if (strncmp(option, read_prefix, read_prefix_len) == 0)
+		{
+			if (*read_replica_placement != NULL)
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						 errmsg("duplicate read_replica_placement option found."
+								"Only one read_replica_placement option is supported via "
+								"tablespaces.")));
+			*read_replica_placement = pstrdup(option + read_prefix_len);
+		}
+		else
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("expected replica_placement or read_replica_placement "
+							"option. Got %s", option)));
+		}
+
+		pfree(option);
+	}
+}
+
+void
+yb_validate_tablespace_placement_options(Datum reloptions, bool check_satisfiable)
+{
+	Datum	   *options = NULL;
+	int			num_options = 0;
+	char	   *live_placement = NULL;
+	char	   *read_replica_placement = NULL;
+
+	if (reloptions != (Datum) 0)
+	{
+		ArrayType  *array = DatumGetArrayTypeP(reloptions);
+
+		deconstruct_array(array, TEXTOID, -1, false, 'i',
+						  &options, NULL, &num_options);
+	}
+
+	yb_extract_tablespace_placement_options(options, num_options,
+									   &live_placement, &read_replica_placement);
+
+	YBCValidatePlacements(live_placement, read_replica_placement,
+						  check_satisfiable);
+
+	if (live_placement)
+		pfree(live_placement);
+	if (read_replica_placement)
+		pfree(read_replica_placement);
+	if (options)
+		pfree(options);
+}
+
+void
+yb_validate_tablespace_placement_by_oid(Oid spc_oid, bool check_satisfiable)
+{
+	Datum	   *options;
+	int			num_options;
+	char	   *live_placement = NULL;
+	char	   *read_replica_placement = NULL;
+
+	if (!OidIsValid(spc_oid))
+		return;
+
+	yb_get_tablespace_options(&options, &num_options, spc_oid);
+	yb_extract_tablespace_placement_options(options, num_options,
+									   &live_placement, &read_replica_placement);
+
+	YBCValidatePlacements(live_placement, read_replica_placement,
+						  check_satisfiable);
+
+	if (live_placement)
+		pfree(live_placement);
+	if (read_replica_placement)
+		pfree(read_replica_placement);
+	if (options)
+		pfree(options);
 }
 
 /*

--- a/src/postgres/src/backend/parser/gram.y
+++ b/src/postgres/src/backend/parser/gram.y
@@ -1056,7 +1056,7 @@ stmt:
 			| AlterSeqStmt
 			| AlterSystemStmt { parser_ybc_not_support(@1, "This statement"); }
 			| AlterTableStmt
-			| AlterTblSpcStmt { parser_ybc_signal_unsupported(@1, "This statement", 1153); }
+			| AlterTblSpcStmt
 			| AlterCompositeTypeStmt { parser_ybc_not_support(@1, "This statement"); }
 			| AlterPublicationStmt
 			| AlterRoleSetStmt
@@ -9967,7 +9967,6 @@ reindex_target_multitable:
 AlterTblSpcStmt:
 			ALTER TABLESPACE name SET reloptions
 				{
-					parser_ybc_signal_unsupported(@1, "ALTER TABLESPACE", 1153);
 					AlterTableSpaceOptionsStmt *n =
 						makeNode(AlterTableSpaceOptionsStmt);
 
@@ -9978,7 +9977,6 @@ AlterTblSpcStmt:
 				}
 			| ALTER TABLESPACE name RESET reloptions
 				{
-					parser_ybc_signal_unsupported(@1, "ALTER TABLESPACE", 1153);
 					AlterTableSpaceOptionsStmt *n =
 						makeNode(AlterTableSpaceOptionsStmt);
 

--- a/src/postgres/src/include/commands/tablespace.h
+++ b/src/postgres/src/include/commands/tablespace.h
@@ -78,5 +78,9 @@ extern void validatePlacementConfigurations(const char *live_placement,
 											const char *read_replica_placement);
 extern void yb_get_tablespace_options(Datum **options, int *num_options,
 									  Oid spc_oid);
+extern void yb_validate_tablespace_placement_options(Datum reloptions,
+												 bool check_satisfiable);
+extern void yb_validate_tablespace_placement_by_oid(Oid spc_oid,
+											 bool check_satisfiable);
 
 #endif							/* TABLESPACE_H */

--- a/src/postgres/src/test/regress/expected/yb.orig.tablespaces.out
+++ b/src/postgres/src/test/regress/expected/yb.orig.tablespaces.out
@@ -114,17 +114,27 @@ LINE 1: CREATE TABLESPACE regress_tblspace_2 LOCATION '/data';
                                              ^
 HINT:  See https://github.com/yugabyte/yugabyte-db/issues/6569. React with thumbs up to raise its priority
 -- try setting and resetting some properties for the new tablespace
-ALTER TABLESPACE regress_tblspace SET (random_page_cost = 1.0, seq_page_cost = 1.1);
-ERROR:  ALTER TABLESPACE not supported yet
-LINE 1: ALTER TABLESPACE regress_tblspace SET (random_page_cost = 1....
-        ^
-HINT:  See https://github.com/yugabyte/yugabyte-db/issues/1153. React with thumbs up to raise its priority
--- Enable these tests after ALTER is supported.
-/*
+ALTER TABLESPACE regress_tblspace SET (random_page_cost = 1.0, seq_page_cost = 1.1); -- fail
+ERROR:  unrecognized parameter "random_page_cost"
+ALTER TABLESPACE regress_tblspace SET (replica_placement='{"num_replicas":1, "placement_blocks":[{"cloud":"cloud1","region":"region1","zone":"zone1","min_num_replicas":1}]}'); -- ok
+SELECT spcoptions IS NOT NULL FROM pg_tablespace WHERE spcname = 'regress_tblspace';
+ ?column? 
+----------
+ t
+(1 row)
+
 ALTER TABLESPACE regress_tblspace SET (some_nonexistent_parameter = true);  -- fail
+ERROR:  unrecognized parameter "some_nonexistent_parameter"
 ALTER TABLESPACE regress_tblspace RESET (random_page_cost = 2.0); -- fail
+ERROR:  RESET must not include values for parameters
 ALTER TABLESPACE regress_tblspace RESET (random_page_cost, effective_io_concurrency); -- ok
-*/
+ALTER TABLESPACE regress_tblspace RESET (replica_placement); -- ok
+SELECT spcoptions IS NULL FROM pg_tablespace WHERE spcname = 'regress_tblspace';
+ ?column? 
+----------
+ t
+(1 row)
+
 -- create a schema we can use
 CREATE SCHEMA testschema;
 -- create a tablespace not satisfied by the cluster
@@ -691,6 +701,8 @@ CREATE TABLE tbl_other(x int, y int);
 SET SESSION ROLE yb_db_admin;
 -- Verify yb_db_admin role can CREATE tablespace
 CREATE TABLESPACE tblspace WITH (replica_placement='{"num_replicas": 1, "placement_blocks": [{"cloud":"cloud1","region":"region1","zone":"zone1","min_num_replicas":1}]}');
+-- Verify yb_db_admin role can ALTER tablespace
+ALTER TABLESPACE tblspace SET (replica_placement='{"num_replicas": 1, "placement_blocks": [{"cloud":"cloud1","region":"region1","zone":"zone1","min_num_replicas":1}]}');
 -- Verify yb_db_admin role can CREATE table with tablespace
 CREATE TABLE tbl (x int, y int) TABLESPACE tblspace;
 DROP TABLE tbl;
@@ -707,12 +719,6 @@ DROP TABLE tbl;
 CREATE TABLE tbl(x int, y int);
 CREATE INDEX idx ON tbl(x) TABLESPACE tblspace;
 CREATE INDEX idx2 ON tbl_other(x) TABLESPACE tblspace;
--- Verify yb_db_admin role cannot ALTER tablespace
-ALTER TABLESPACE tblspace SET (random_page_cost = 1.0, seq_page_cost = 1.1);
-ERROR:  ALTER TABLESPACE not supported yet
-LINE 1: ALTER TABLESPACE tblspace SET (random_page_cost = 1.0, seq_p...
-        ^
-HINT:  See https://github.com/yugabyte/yugabyte-db/issues/1153. React with thumbs up to raise its priority
 -- Verify yb_db_admin role can DROP tablespace
 DROP TABLE tbl;
 DROP TABLE tbl_other;

--- a/src/postgres/src/test/regress/sql/yb.orig.tablespaces.sql
+++ b/src/postgres/src/test/regress/sql/yb.orig.tablespaces.sql
@@ -84,14 +84,14 @@ CREATE TABLESPACE regress_tblspace LOCATION '/data';
 CREATE TABLESPACE regress_tblspace_2 LOCATION '/data';
 
 -- try setting and resetting some properties for the new tablespace
-ALTER TABLESPACE regress_tblspace SET (random_page_cost = 1.0, seq_page_cost = 1.1);
-
--- Enable these tests after ALTER is supported.
-/*
+ALTER TABLESPACE regress_tblspace SET (random_page_cost = 1.0, seq_page_cost = 1.1); -- fail
+ALTER TABLESPACE regress_tblspace SET (replica_placement='{"num_replicas":1, "placement_blocks":[{"cloud":"cloud1","region":"region1","zone":"zone1","min_num_replicas":1}]}'); -- ok
+SELECT spcoptions IS NOT NULL FROM pg_tablespace WHERE spcname = 'regress_tblspace';
 ALTER TABLESPACE regress_tblspace SET (some_nonexistent_parameter = true);  -- fail
 ALTER TABLESPACE regress_tblspace RESET (random_page_cost = 2.0); -- fail
 ALTER TABLESPACE regress_tblspace RESET (random_page_cost, effective_io_concurrency); -- ok
-*/
+ALTER TABLESPACE regress_tblspace RESET (replica_placement); -- ok
+SELECT spcoptions IS NULL FROM pg_tablespace WHERE spcname = 'regress_tblspace';
 
 -- create a schema we can use
 CREATE SCHEMA testschema;
@@ -374,6 +374,8 @@ CREATE TABLE tbl_other(x int, y int);
 SET SESSION ROLE yb_db_admin;
 -- Verify yb_db_admin role can CREATE tablespace
 CREATE TABLESPACE tblspace WITH (replica_placement='{"num_replicas": 1, "placement_blocks": [{"cloud":"cloud1","region":"region1","zone":"zone1","min_num_replicas":1}]}');
+-- Verify yb_db_admin role can ALTER tablespace
+ALTER TABLESPACE tblspace SET (replica_placement='{"num_replicas": 1, "placement_blocks": [{"cloud":"cloud1","region":"region1","zone":"zone1","min_num_replicas":1}]}');
 -- Verify yb_db_admin role can CREATE table with tablespace
 CREATE TABLE tbl (x int, y int) TABLESPACE tblspace;
 DROP TABLE tbl;
@@ -386,8 +388,6 @@ DROP TABLE tbl;
 CREATE TABLE tbl(x int, y int);
 CREATE INDEX idx ON tbl(x) TABLESPACE tblspace;
 CREATE INDEX idx2 ON tbl_other(x) TABLESPACE tblspace;
--- Verify yb_db_admin role cannot ALTER tablespace
-ALTER TABLESPACE tblspace SET (random_page_cost = 1.0, seq_page_cost = 1.1);
 -- Verify yb_db_admin role can DROP tablespace
 DROP TABLE tbl;
 DROP TABLE tbl_other;


### PR DESCRIPTION
DO NOT MERGE!! [CSI](<https://csiweb.dev.yugabyte.com/pull/32226/>) ❌. Once CSI passes, comment `trigger jenkins` to clear this warning.

This patch makes `ALTER TABLESPACE ... SET/RESET` work for the YB
placement options (`replica_placement` and `read_replica_placement`), so
an existing tablespace can be updated in place. This avoids the awkward
evolution of tablespace definitions which require creating new ts,
altering all relations that use it, and then deleting the old ts.

tracking issue: #6640 

Some details:

- `ALTER TABLESPACE` validates the final `spcoptions` the same way we
validate `ALTER TABLE/INDEX/MATERIALIZED VIEW ... SET TABLESPACE`.
- If the tablespace is already in use, the new placement has to be
satisfiable
- Existing objects are not moved synchronously. We keep using the
current master tablespace refresh + load balancer path, so movement
happens asynchronously after the new tablespace options are picked up
- `read_replica_placement` still requires `replica_placement`, so `RESET
(replica_placement)` fails if `read_replica_placement` is still set.

Test coverage added for:

- `ALTER TABLESPACE ... SET/RESET` regression cases
- movement for tables, indexes, materialized views, and tablegroups
- reset behavior
- invalid placement / invalid JSON cases
- read replica validation, including the `RESET (replica_placement)`
case above

Also includes YSQL docs for `ALTER TABLESPACE`.

Tested successfully with:

- `./yb_build.sh release --target postgres --skip-java --no-odyssey`
- `JAVA_TOOL_OPTIONS='--add-opens=java.base/java.lang=ALL-UNNAMED'
./yb_build.sh release --java-test org.yb.pgsql.TestPgRegressTablespaces`
- `JAVA_TOOL_OPTIONS='--add-opens=java.base/java.lang=ALL-UNNAMED'
./yb_build.sh release --java-test
'org.yb.pgsql.TestTablespaceProperties#testAlterTablespacePlacementMovesExistingObjects'`
- `JAVA_TOOL_OPTIONS='--add-opens=java.base/java.lang=ALL-UNNAMED'
./yb_build.sh release --java-test
'org.yb.pgsql.TestTablespaceProperties#negativeTest'`
- `JAVA_TOOL_OPTIONS='--add-opens=java.base/java.lang=ALL-UNNAMED'
./yb_build.sh release --java-test
'org.yb.pgsql.TestTablespaceProperties#readReplicaWithTablespaces'`

Practical testing with `ysqlsh`:

```sql
yugabyte=# select spcname, spcoptions from pg_tablespace where spcname = 'ats_unused';
  spcname   | spcoptions
------------+------------
 ats_unused |
(1 row)

yugabyte=# \set valid_placement '{"num_replicas":1,"placement_blocks":[{"cloud":"cloud1","region":"datacenter1","zone":"rack1","min_num_replicas":1}]}'

yugabyte=# \echo :valid_placement
{"num_replicas":1,"placement_blocks":[{"cloud":"cloud1","region":"datacenter1","zone":"rack1","min_num_replicas":1}]}

yugabyte=# ALTER TABLESPACE ats_unused SET (
  replica_placement=:'valid_placement',
  read_replica_placement=:'valid_placement'
);
ALTER TABLESPACE

yugabyte=# select spcname, spcoptions from pg_tablespace where spcname = 'ats_unused';
  spcname   |                                                                                                                                                           spcoptions
------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 ats_unused | {"replica_placement={\"num_replicas\":1,\"placement_blocks\":[{\"cloud\":\"cloud1\",\"region\":\"datacenter1\",\"zone\":\"rack1\",\"min_num_replicas\":1}]}","read_replica_placement={\"num_replicas\":1,\"placement_blocks\":[{\"cloud\":\"cloud1\",\"region\":\"datacenter1\",\"zone\":\"rack1\",\"min_num_replicas\":1}]}"}
(1 row)

yugabyte=# ALTER TABLESPACE ats_unused RESET (replica_placement);
ERROR:  read_replica_placement option requires replica_placement to be set

yugabyte=# ALTER TABLESPACE ats_unused RESET (read_replica_placement);
ALTER TABLESPACE

yugabyte=# select spcname, spcoptions from pg_tablespace where spcname = 'ats_unused';
  spcname   |                                                                          spcoptions
------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------
 ats_unused | {"replica_placement={\"num_replicas\":1,\"placement_blocks\":[{\"cloud\":\"cloud1\",\"region\":\"datacenter1\",\"zone\":\"rack1\",\"min_num_replicas\":1}]}"}
(1 row)

yugabyte=# ALTER TABLESPACE ats_unused RESET (replica_placement);
ALTER TABLESPACE

yugabyte=# select spcname, spcoptions from pg_tablespace where spcname = 'ats_unused';
  spcname   | spcoptions                                                                                                                                                                                                        ------------+------------
 ats_unused |
(1 row)
```

Original commit: 0af82c65c1a6e5487e50e6fa80059c58436646d2 / #31948

## Merge conflict resolutions

The cherry-pick applied **cleanly onto 2025.1** (chained from the 2025.2 backport #32113), so no conflicts were resolved by hand on this branch. The resulting diff is identical to the master commit (`0af82c65c1a` / #31948) **except for one docs line**, which was adapted to this branch's existing convention:

- **`docs/content/stable/api/ysql/the-sql-language/statements/_index.md`** — the new `ALTER TABLESPACE` row in the statements table follows the release-branch style (backticked statement name, no trailing slash on the link — `` [`ALTER TABLESPACE`](ddl_alter_tablespace) ``) rather than master's plain-name + trailing-slash style (`[ALTER TABLESPACE](ddl_alter_tablespace/)`), matching every other row in the table on this branch. The adaptation originated in the 2025.2 backport (#32113) and was carried in via the clean chain.

All code changes (`tablespace.c`, `tablecmds.c`, `gram.y`, `tablespace.h`), the test changes, and the `ddl_alter_tablespace.md` doc page are byte-identical to the master commit.
