### PR TITLE
most xCluster replication requires no rewrite of associated indexes

### DIFF
--- a/docs/content/stable/architecture/docdb-replication/async-replication.md
+++ b/docs/content/stable/architecture/docdb-replication/async-replication.md
@@ -322,7 +322,7 @@ Improper use can compromise replication consistency and lead to data divergence.
 
   An exception are DDLs related to PUBLICATION and SUBSCRIPTION, which should only be used on the source universe.
 
-- `ALTER TABLE` DDLs that involve table rewrites (including just of the associated indexes; see [Alter table operations that involve a table rewrite](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-table-operations-that-involve-a-table-rewrite)) may not be performed while replication is running; you will need to drop replication, perform those DDL(s) on the source universe, then create replication again.
+- You cannot run [ALTER TABLE DDLs that involve table rewrites](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-table-operations-that-involve-a-table-rewrite) (including those that rewrite only the associated indexes, or both the table and associated indexes) while replication is running. You will need to drop replication, perform those DDL(s) on the source universe, then create replication again.
 
 - The `TRUNCATE` command is not supported.
 
@@ -348,7 +348,7 @@ Improper use can compromise replication consistency and lead to data divergence.
 
 - Table rewrites
 
-  `ALTER TABLE` DDLs that involve table rewrites (including just of the associated indexes; see [Alter table operations that involve a table rewrite](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-table-operations-that-involve-a-table-rewrite)) may not be performed while replication is running; you will need to drop replication, perform those DDL(s) on the source universe, then create replication again.
+  You cannot run [ALTER TABLE DDLs that involve table rewrites](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-table-operations-that-involve-a-table-rewrite) (including those that rewrite only the associated indexes, or both the table and associated indexes) while replication is running. You will need to drop replication, perform those DDL(s) on the source universe, then create replication again.
 
 - Composite, enum, and range (array) types
 

--- a/docs/content/stable/architecture/docdb-replication/async-replication.md
+++ b/docs/content/stable/architecture/docdb-replication/async-replication.md
@@ -322,7 +322,7 @@ Improper use can compromise replication consistency and lead to data divergence.
 
   An exception are DDLs related to PUBLICATION and SUBSCRIPTION, which should only be used on the source universe.
 
-- `ALTER TABLE` DDLs that involve table rewrites (see [Alter table operations that involve a table rewrite](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-table-operations-that-involve-a-table-rewrite)) may not be performed while replication is running; you will need to drop replication, perform those DDL(s) on the source universe, then create replication again.
+- `ALTER TABLE` DDLs that involve table rewrites (including just of the associated indexes; see [Alter table operations that involve a table rewrite](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-table-operations-that-involve-a-table-rewrite)) may not be performed while replication is running; you will need to drop replication, perform those DDL(s) on the source universe, then create replication again.
 
 - The `TRUNCATE` command is not supported.
 
@@ -348,7 +348,7 @@ Improper use can compromise replication consistency and lead to data divergence.
 
 - Table rewrites
 
-  `ALTER TABLE` DDLs that involve table rewrites (see [Alter table operations that involve a table rewrite](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-table-operations-that-involve-a-table-rewrite)) may not be performed while replication is running; you will need to drop replication, perform those DDL(s) on the source universe, then create replication again.
+  `ALTER TABLE` DDLs that involve table rewrites (including just of the associated indexes; see [Alter table operations that involve a table rewrite](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-table-operations-that-involve-a-table-rewrite)) may not be performed while replication is running; you will need to drop replication, perform those DDL(s) on the source universe, then create replication again.
 
 - Composite, enum, and range (array) types
 

--- a/docs/content/v2024.2/architecture/docdb-replication/async-replication.md
+++ b/docs/content/v2024.2/architecture/docdb-replication/async-replication.md
@@ -244,7 +244,7 @@ The following limitations apply to all xCluster modes and deployment scenarios:
 
 - Table rewrites
 
-  `ALTER TABLE` DDLs that involve table rewrites (including just of the associated indexes; see [Alter table operations that involve a table rewrite](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-table-operations-that-involve-a-table-rewrite)) may not be performed while replication is running; you will need to drop replication, perform those DDL(s) on the source universe, then create replication again.
+  You cannot run [ALTER TABLE DDLs that involve table rewrites](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-table-operations-that-involve-a-table-rewrite) (including those that rewrite only the associated indexes, or both the table and associated indexes) while replication is running. You will need to drop replication, perform those DDL(s) on the source universe, then create replication again.
 
 Limitations specific to each scenario and mode are listed below:
 

--- a/docs/content/v2024.2/architecture/docdb-replication/async-replication.md
+++ b/docs/content/v2024.2/architecture/docdb-replication/async-replication.md
@@ -244,7 +244,7 @@ The following limitations apply to all xCluster modes and deployment scenarios:
 
 - Table rewrites
 
-  `ALTER TABLE` DDLs that involve table rewrites (see [Alter table operations that involve a table rewrite](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-table-operations-that-involve-a-table-rewrite)) may not be performed while replication is running; you will need to drop replication, perform those DDL(s) on the source universe, then create replication again.
+  `ALTER TABLE` DDLs that involve table rewrites (including just of the associated indexes; see [Alter table operations that involve a table rewrite](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-table-operations-that-involve-a-table-rewrite)) may not be performed while replication is running; you will need to drop replication, perform those DDL(s) on the source universe, then create replication again.
 
 Limitations specific to each scenario and mode are listed below:
 

--- a/docs/content/v2025.1/architecture/docdb-replication/async-replication.md
+++ b/docs/content/v2025.1/architecture/docdb-replication/async-replication.md
@@ -328,7 +328,7 @@ Improper use can compromise replication consistency and lead to data divergence.
 
   An exception are DDLs related to PUBLICATION and SUBSCRIPTION, which should only be used on the source universe.
 
-- `ALTER TABLE` DDLs that involve table rewrites (see [Alter table operations that involve a table rewrite](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-table-operations-that-involve-a-table-rewrite)) may not be performed while replication is running; you will need to drop replication, perform those DDL(s) on the source universe, then create replication again.
+- `ALTER TABLE` DDLs that involve table rewrites (including just of the associated indexes; see [Alter table operations that involve a table rewrite](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-table-operations-that-involve-a-table-rewrite)) may not be performed while replication is running; you will need to drop replication, perform those DDL(s) on the source universe, then create replication again.
 
 - The `TRUNCATE` command is not supported.
 
@@ -350,7 +350,7 @@ Improper use can compromise replication consistency and lead to data divergence.
 
 - Table rewrites
 
-  `ALTER TABLE` DDLs that involve table rewrites (see [Alter table operations that involve a table rewrite](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-table-operations-that-involve-a-table-rewrite)) may not be performed while replication is running; you will need to drop replication, perform those DDL(s) on the source universe, then create replication again.
+  `ALTER TABLE` DDLs that involve table rewrites (including just of the associated indexes; see [Alter table operations that involve a table rewrite](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-table-operations-that-involve-a-table-rewrite)) may not be performed while replication is running; you will need to drop replication, perform those DDL(s) on the source universe, then create replication again.
 
 - Composite, enum, and range (array) types
 

--- a/docs/content/v2025.1/architecture/docdb-replication/async-replication.md
+++ b/docs/content/v2025.1/architecture/docdb-replication/async-replication.md
@@ -328,7 +328,7 @@ Improper use can compromise replication consistency and lead to data divergence.
 
   An exception are DDLs related to PUBLICATION and SUBSCRIPTION, which should only be used on the source universe.
 
-- `ALTER TABLE` DDLs that involve table rewrites (including just of the associated indexes; see [Alter table operations that involve a table rewrite](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-table-operations-that-involve-a-table-rewrite)) may not be performed while replication is running; you will need to drop replication, perform those DDL(s) on the source universe, then create replication again.
+- You cannot run [ALTER TABLE DDLs that involve table rewrites](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-table-operations-that-involve-a-table-rewrite) (including those that rewrite only the associated indexes, or both the table and associated indexes) while replication is running. You will need to drop replication, perform those DDL(s) on the source universe, then create replication again.
 
 - The `TRUNCATE` command is not supported.
 
@@ -350,7 +350,7 @@ Improper use can compromise replication consistency and lead to data divergence.
 
 - Table rewrites
 
-  `ALTER TABLE` DDLs that involve table rewrites (including just of the associated indexes; see [Alter table operations that involve a table rewrite](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-table-operations-that-involve-a-table-rewrite)) may not be performed while replication is running; you will need to drop replication, perform those DDL(s) on the source universe, then create replication again.
+  You cannot run [ALTER TABLE DDLs that involve table rewrites](../../../api/ysql/the-sql-language/statements/ddl_alter_table/#alter-table-operations-that-involve-a-table-rewrite) (including those that rewrite only the associated indexes, or both the table and associated indexes) while replication is running. You will need to drop replication, perform those DDL(s) on the source universe, then create replication again.
 
 - Composite, enum, and range (array) types
 


### PR DESCRIPTION
 A recent customer incident may have been partially caused by the customer not realizing that just because a DDL doesn't rewrite the main table doesn't mean it doesn't rewrite the associated index as well, which we forbid in most modes of access to replication.

Here we make the documentation a little bit more specific in hopes of avoiding this in the future.