### PR TITLE
[#30723] DistributedTracing: Route OpenTelemetry internal logs to YugabyteDB logging

### DIFF
--- a/src/yb/util/CMakeLists.txt
+++ b/src/yb/util/CMakeLists.txt
@@ -257,6 +257,7 @@ set(OPENTELEMETRY_LIBRARIES
   opentelemetry_trace
   opentelemetry_exporter_otlp_http
   opentelemetry_resources
+  opentelemetry_common
   opentelemetry_proto)
 
 set(UTIL_LIBS

--- a/src/yb/util/dist_trace.cc
+++ b/src/yb/util/dist_trace.cc
@@ -55,8 +55,15 @@ DEFINE_NON_RUNTIME_uint32(otel_batch_max_export_batch_size, 512,
     "Maximum number of spans exported in a single batch. Must be greater than 0 and no "
     "larger than otel_batch_max_queue_size.");
 
+DEFINE_NON_RUNTIME_string(otel_internal_log_level, "info",
+    "Minimum OpenTelemetry SDK internal log level forwarded to YugabyteDB logging. Allowed "
+    "values are debug, info, warning, error, and none.");
+
 DEFINE_validator(otel_batch_max_queue_size,
     FLAG_GE_FLAG_VALIDATOR(otel_batch_max_export_batch_size));
+
+DEFINE_validator(otel_internal_log_level,
+    FLAG_IN_SET_VALIDATOR("debug", "info", "warning", "error", "none"));
 
 namespace yb::dist_trace {
 
@@ -101,6 +108,27 @@ class RpcSpanAttrs {
 
 thread_local RpcSpanAttrs pending_rpc_attrs;
 
+internal_log::LogLevel GetOtelInternalLogLevel() {
+  const auto& flag_value = FLAGS_otel_internal_log_level;
+  if (flag_value == "debug") {
+    return internal_log::LogLevel::Debug;
+  }
+  if (flag_value == "info") {
+    return internal_log::LogLevel::Info;
+  }
+  if (flag_value == "warning") {
+    return internal_log::LogLevel::Warning;
+  }
+  if (flag_value == "error") {
+    return internal_log::LogLevel::Error;
+  }
+  if (flag_value == "none") {
+    return internal_log::LogLevel::None;
+  }
+  LOG(DFATAL) << "Unknown otel_internal_log_level: " << flag_value;
+  return internal_log::LogLevel::Info;
+}
+
 class YbOtelLogHandler : public internal_log::LogHandler {
  public:
   void Handle(
@@ -122,7 +150,7 @@ class YbOtelLogHandler : public internal_log::LogHandler {
         LOG(INFO) << "[" << safe_file << ":" << line << "]: " << safe_msg;
         break;
       case internal_log::LogLevel::Debug:
-        VLOG(1) << "[" << safe_file << ":" << line << "] Debug: " << safe_msg;
+        LOG(INFO) << "[" << safe_file << ":" << line << "] Debug: " << safe_msg;
         break;
       case internal_log::LogLevel::None:
         break;
@@ -207,11 +235,9 @@ void InitDistTrace(int64_t process_pid, nostd::string_view node_uuid) {
   internal_log::GlobalLogHandler::SetLogHandler(
       opentelemetry::nostd::shared_ptr<internal_log::LogHandler>(new YbOtelLogHandler()));
 
-  // OTel applies this threshold before calling the global handler. Keep it at the most
-  // permissive runtime level so every SDK-internal message that was compiled in reaches
-  // YbOtelLogHandler; the LOG(...) call in the handler then lets the YB process logging
-  // configuration make the final filtering/routing decision.
-  internal_log::GlobalLogHandler::SetLogLevel(internal_log::LogLevel::Debug);
+  // OTel macros filter first using GlobalLogHandler::GetLogLevel(). Accepted messages
+  // are mapped to LOG(...), where YB logging applies its own routing.
+  internal_log::GlobalLogHandler::SetLogLevel(GetOtelInternalLogLevel());
 
   auto resource_attrs = CreateResource(process_pid, node_uuid);
   const auto status = InitDistTraceProvider(resource_attrs);

--- a/src/yb/util/dist_trace.cc
+++ b/src/yb/util/dist_trace.cc
@@ -21,6 +21,7 @@
 #include "opentelemetry/context/runtime_context.h"
 #include "opentelemetry/exporters/otlp/otlp_http_exporter_factory.h"
 #include "opentelemetry/exporters/otlp/otlp_http_exporter_options.h"
+#include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/sdk/trace/batch_span_processor_factory.h"
 #include "opentelemetry/sdk/trace/batch_span_processor_options.h"
 #include "opentelemetry/sdk/trace/tracer_provider.h"
@@ -62,6 +63,7 @@ namespace yb::dist_trace {
 namespace trace_sdk = opentelemetry::sdk::trace;
 namespace resource_sdk = opentelemetry::sdk::resource;
 namespace otlp_exporter = opentelemetry::exporter::otlp;
+namespace internal_log = opentelemetry::sdk::common::internal_log;
 namespace context = opentelemetry::context;
 
 namespace {
@@ -98,6 +100,33 @@ class RpcSpanAttrs {
 };
 
 thread_local RpcSpanAttrs pending_rpc_attrs;
+
+class YbOtelLogHandler : public internal_log::LogHandler {
+ public:
+  void Handle(
+      internal_log::LogLevel level, const char* file, int line, const char* msg,
+      const opentelemetry::sdk::common::AttributeMap& attributes) noexcept override {
+    (void)attributes;
+
+    switch (level) {
+      case internal_log::LogLevel::Error:
+        LOG(ERROR) << "[" << file << ":" << line << "]: " << msg;
+        break;
+      case internal_log::LogLevel::Warning:
+        LOG(WARNING) << "[" << file << ":" << line << "]: " << msg;
+        break;
+      case internal_log::LogLevel::Info:
+        LOG(INFO) << "[" << file << ":" << line << "]: " << msg;
+        break;
+      case internal_log::LogLevel::Debug:
+        VLOG(1) << "[" << file << ":" << line << "] Debug: " << msg;
+        break;
+      case internal_log::LogLevel::None:
+        LOG(INFO) << "[" << file << ":" << line << "] None: " << msg;
+        break;
+    }
+  }
+};
 
 resource_sdk::Resource CreateResource(int64_t process_pid, nostd::string_view node_uuid) {
   resource_sdk::ResourceAttributes attrs;
@@ -173,6 +202,15 @@ bool IsDistTraceEnabled() {
 void InitDistTrace(int64_t process_pid, nostd::string_view node_uuid) {
   DCHECK(IsDistTraceEnabled());
 
+  internal_log::GlobalLogHandler::SetLogHandler(
+      opentelemetry::nostd::shared_ptr<internal_log::LogHandler>(new YbOtelLogHandler()));
+
+  // OTel applies this threshold before calling the global handler. Keep it at the most
+  // permissive runtime level so every SDK-internal message that was compiled in reaches
+  // YbOtelLogHandler; the LOG(...) call in the handler then lets the YB process logging
+  // configuration make the final filtering/routing decision.
+  internal_log::GlobalLogHandler::SetLogLevel(internal_log::LogLevel::Debug);
+
   auto resource_attrs = CreateResource(process_pid, node_uuid);
   const auto status = InitDistTraceProvider(resource_attrs);
   if (!status.ok()) {
@@ -184,7 +222,6 @@ void InitDistTrace(int64_t process_pid, nostd::string_view node_uuid) {
       nostd::shared_ptr<context::propagation::TextMapPropagator>(
           new trace::propagation::HttpTraceContext()));
 
-  // TODO(#30723): Integrate Otel logs with Yugabyte logs.
   LOG(INFO) << "OTEL: Initialized tracing for service: " << ysql_resource_name
             << "\nBatchSpanProcessor config: max_queue_size=" << FLAGS_otel_batch_max_queue_size
             << ", schedule_delay_ms=" << FLAGS_otel_batch_schedule_delay_ms

--- a/src/yb/util/dist_trace.cc
+++ b/src/yb/util/dist_trace.cc
@@ -108,21 +108,23 @@ class YbOtelLogHandler : public internal_log::LogHandler {
       const opentelemetry::sdk::common::AttributeMap& attributes) noexcept override {
     (void)attributes;
 
+    const char* safe_file = file ? file : "unknown";
+    const char* safe_msg = msg ? msg : "";
+
     switch (level) {
       case internal_log::LogLevel::Error:
-        LOG(ERROR) << "[" << file << ":" << line << "]: " << msg;
+        LOG(ERROR) << "[" << safe_file << ":" << line << "]: " << safe_msg;
         break;
       case internal_log::LogLevel::Warning:
-        LOG(WARNING) << "[" << file << ":" << line << "]: " << msg;
+        LOG(WARNING) << "[" << safe_file << ":" << line << "]: " << safe_msg;
         break;
       case internal_log::LogLevel::Info:
-        LOG(INFO) << "[" << file << ":" << line << "]: " << msg;
+        LOG(INFO) << "[" << safe_file << ":" << line << "]: " << safe_msg;
         break;
       case internal_log::LogLevel::Debug:
-        VLOG(1) << "[" << file << ":" << line << "] Debug: " << msg;
+        VLOG(1) << "[" << safe_file << ":" << line << "] Debug: " << safe_msg;
         break;
       case internal_log::LogLevel::None:
-        LOG(INFO) << "[" << file << ":" << line << "] None: " << msg;
         break;
     }
   }

--- a/src/yb/yql/pgwrapper/dist_trace-test.cc
+++ b/src/yb/yql/pgwrapper/dist_trace-test.cc
@@ -1750,6 +1750,37 @@ TEST_F(DistTraceRpcTest, TestOtelInternalLogLevelGFlagControlsSdkFiltering) {
   ASSERT_EQ(debug_waiter.GetEventCount(), 0);
 }
 
+TEST_F(DistTraceRpcTest, TestOtelInternalLogLevelNoneSuppressesAllMessages) {
+  google::FlagSaver flag_saver;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_otel_collector_traces_endpoint) = collector_.Url();
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_otel_internal_log_level) = "none";
+
+  static constexpr auto kError = "otel none threshold internal error";
+  static constexpr auto kWarning = "otel none threshold internal warning";
+  static constexpr auto kInfo = "otel none threshold internal info";
+  static constexpr auto kDebug = "otel none threshold internal debug";
+
+  RegexWaiterLogSink error_waiter(Format("E.*$0.*", kError));
+  RegexWaiterLogSink warning_waiter(Format("W.*$0.*", kWarning));
+  RegexWaiterLogSink info_waiter(Format("I.*$0.*", kInfo));
+  RegexWaiterLogSink debug_waiter(Format("I.*$0.*", kDebug));
+
+  dist_trace::InitDistTrace(0 /* process_pid */, "dist-trace-otel-none-log-level-test");
+  auto cleanup = ScopeExit([] {
+    dist_trace::CleanupDistTrace();
+  });
+
+  OTEL_INTERNAL_LOG_ERROR(kError);
+  OTEL_INTERNAL_LOG_WARN(kWarning);
+  OTEL_INTERNAL_LOG_INFO(kInfo);
+  OTEL_INTERNAL_LOG_DEBUG(kDebug);
+
+  ASSERT_EQ(error_waiter.GetEventCount(), 0);
+  ASSERT_EQ(warning_waiter.GetEventCount(), 0);
+  ASSERT_EQ(info_waiter.GetEventCount(), 0);
+  ASSERT_EQ(debug_waiter.GetEventCount(), 0);
+}
+
 TEST_F(DistTraceRpcTest, TestErroredRpcSpanStatus) {
   google::FlagSaver flag_saver;
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_otel_collector_traces_endpoint) = collector_.Url();

--- a/src/yb/yql/pgwrapper/dist_trace-test.cc
+++ b/src/yb/yql/pgwrapper/dist_trace-test.cc
@@ -24,6 +24,7 @@
 #include <google/protobuf/empty.pb.h>
 #include <gtest/gtest.h>
 
+#include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/trace/scope.h"
 #include "opentelemetry/trace/tracer.h"
 #include "opentelemetry/proto/collector/trace/v1/trace_service.pb.h"
@@ -39,6 +40,7 @@
 #include "yb/util/enums.h"
 #include "yb/util/format.h"
 #include "yb/util/flags.h"
+#include "yb/util/logging_test_util.h"
 #include "yb/util/net/sockaddr.h"
 #include "yb/util/random_util.h"
 #include "yb/util/scope_exit.h"
@@ -1657,6 +1659,37 @@ TEST_F(DistTraceRpcTest, TestRpcSpans) {
       },
       kOtelBatchScheduleDelayMs * kTimeMultiplier * 50ms,
       "RPC span to appear in trace"));
+}
+
+TEST_F(DistTraceRpcTest, TestOtelInternalMessagesAreLogged) {
+  google::FlagSaver flag_saver;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_otel_collector_traces_endpoint) = collector_.Url();
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_v) = 1;
+
+  static constexpr auto kError = "otel internal error";
+  static constexpr auto kWarning = "otel internal warning";
+  static constexpr auto kInfo = "otel internal info";
+  static constexpr auto kDebug = "otel internal debug";
+
+  StringWaiterLogSink error_waiter(kError);
+  StringWaiterLogSink warning_waiter(kWarning);
+  StringWaiterLogSink info_waiter(kInfo);
+  StringWaiterLogSink debug_waiter(kDebug);
+
+  dist_trace::InitDistTrace(0 /* process_pid */, "dist-trace-otel-log-test");
+  auto cleanup = ScopeExit([] {
+    dist_trace::CleanupDistTrace();
+  });
+
+  OTEL_INTERNAL_LOG_ERROR(kError);
+  OTEL_INTERNAL_LOG_WARN(kWarning);
+  OTEL_INTERNAL_LOG_INFO(kInfo);
+  OTEL_INTERNAL_LOG_DEBUG(kDebug);
+
+  ASSERT_OK(error_waiter.WaitFor(5s * kTimeMultiplier));
+  ASSERT_OK(warning_waiter.WaitFor(5s * kTimeMultiplier));
+  ASSERT_OK(info_waiter.WaitFor(5s * kTimeMultiplier));
+  ASSERT_OK(debug_waiter.WaitFor(5s * kTimeMultiplier));
 }
 
 TEST_F(DistTraceRpcTest, TestErroredRpcSpanStatus) {

--- a/src/yb/yql/pgwrapper/dist_trace-test.cc
+++ b/src/yb/yql/pgwrapper/dist_trace-test.cc
@@ -54,6 +54,7 @@
 #include "yb/yql/pgwrapper/pg_test_utils.h"
 
 DECLARE_string(otel_collector_traces_endpoint);
+DECLARE_string(otel_internal_log_level);
 DECLARE_uint32(otel_batch_max_queue_size);
 DECLARE_uint32(otel_batch_schedule_delay_ms);
 DECLARE_uint32(otel_batch_max_export_batch_size);
@@ -1664,17 +1665,17 @@ TEST_F(DistTraceRpcTest, TestRpcSpans) {
 TEST_F(DistTraceRpcTest, TestOtelInternalMessagesAreLogged) {
   google::FlagSaver flag_saver;
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_otel_collector_traces_endpoint) = collector_.Url();
-  ANNOTATE_UNPROTECTED_WRITE(FLAGS_v) = 1;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_otel_internal_log_level) = "debug";
 
   static constexpr auto kError = "otel internal error";
   static constexpr auto kWarning = "otel internal warning";
   static constexpr auto kInfo = "otel internal info";
   static constexpr auto kDebug = "otel internal debug";
 
-  StringWaiterLogSink error_waiter(kError);
-  StringWaiterLogSink warning_waiter(kWarning);
-  StringWaiterLogSink info_waiter(kInfo);
-  StringWaiterLogSink debug_waiter(kDebug);
+  RegexWaiterLogSink error_waiter(Format("E.*$0.*", kError));
+  RegexWaiterLogSink warning_waiter(Format("W.*$0.*", kWarning));
+  RegexWaiterLogSink info_waiter(Format("I.*$0.*", kInfo));
+  RegexWaiterLogSink debug_waiter(Format("I.*$0.*", kDebug));
 
   dist_trace::InitDistTrace(0 /* process_pid */, "dist-trace-otel-log-test");
   auto cleanup = ScopeExit([] {
@@ -1690,6 +1691,63 @@ TEST_F(DistTraceRpcTest, TestOtelInternalMessagesAreLogged) {
   ASSERT_OK(warning_waiter.WaitFor(5s * kTimeMultiplier));
   ASSERT_OK(info_waiter.WaitFor(5s * kTimeMultiplier));
   ASSERT_OK(debug_waiter.WaitFor(5s * kTimeMultiplier));
+}
+
+TEST_F(DistTraceRpcTest, TestOtelInternalLogLevelDefaultsToInfo) {
+  google::FlagSaver flag_saver;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_otel_collector_traces_endpoint) = collector_.Url();
+
+  static constexpr auto kError = "otel default internal error";
+  static constexpr auto kInfo = "otel default internal info";
+  static constexpr auto kDebug = "otel default internal debug";
+
+  RegexWaiterLogSink error_waiter(Format("E.*$0.*", kError));
+  RegexWaiterLogSink info_waiter(Format("I.*$0.*", kInfo));
+  RegexWaiterLogSink debug_waiter(Format("I.*$0.*", kDebug));
+
+  dist_trace::InitDistTrace(0 /* process_pid */, "dist-trace-otel-default-log-level-test");
+  auto cleanup = ScopeExit([] {
+    dist_trace::CleanupDistTrace();
+  });
+
+  OTEL_INTERNAL_LOG_ERROR(kError);
+  OTEL_INTERNAL_LOG_INFO(kInfo);
+  OTEL_INTERNAL_LOG_DEBUG(kDebug);
+
+  ASSERT_OK(error_waiter.WaitFor(5s * kTimeMultiplier));
+  ASSERT_OK(info_waiter.WaitFor(5s * kTimeMultiplier));
+  ASSERT_EQ(debug_waiter.GetEventCount(), 0);
+}
+
+TEST_F(DistTraceRpcTest, TestOtelInternalLogLevelGFlagControlsSdkFiltering) {
+  google::FlagSaver flag_saver;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_otel_collector_traces_endpoint) = collector_.Url();
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_otel_internal_log_level) = "error";
+
+  static constexpr auto kError = "otel error threshold internal error";
+  static constexpr auto kWarning = "otel error threshold internal warning";
+  static constexpr auto kInfo = "otel error threshold internal info";
+  static constexpr auto kDebug = "otel error threshold internal debug";
+
+  RegexWaiterLogSink error_waiter(Format("E.*$0.*", kError));
+  RegexWaiterLogSink warning_waiter(Format("W.*$0.*", kWarning));
+  RegexWaiterLogSink info_waiter(Format("I.*$0.*", kInfo));
+  RegexWaiterLogSink debug_waiter(Format("I.*$0.*", kDebug));
+
+  dist_trace::InitDistTrace(0 /* process_pid */, "dist-trace-otel-error-log-level-test");
+  auto cleanup = ScopeExit([] {
+    dist_trace::CleanupDistTrace();
+  });
+
+  OTEL_INTERNAL_LOG_ERROR(kError);
+  OTEL_INTERNAL_LOG_WARN(kWarning);
+  OTEL_INTERNAL_LOG_INFO(kInfo);
+  OTEL_INTERNAL_LOG_DEBUG(kDebug);
+
+  ASSERT_OK(error_waiter.WaitFor(5s * kTimeMultiplier));
+  ASSERT_EQ(warning_waiter.GetEventCount(), 0);
+  ASSERT_EQ(info_waiter.GetEventCount(), 0);
+  ASSERT_EQ(debug_waiter.GetEventCount(), 0);
 }
 
 TEST_F(DistTraceRpcTest, TestErroredRpcSpanStatus) {


### PR DESCRIPTION
## Summary

Previously, OpenTelemetry SDK-internal log messages (connection failures to the collector, export errors, etc.) were discarded because no global log handler was registered. This made it hard to diagnose distributed-tracing problems from the YugabyteDB logs.

This change adds `YbOtelLogHandler`, which implements the OTel SDK `LogHandler` interface. Adds `--otel_internal_log_level` to control the OpenTelemetry SDK internal logging threshold. It defaults to `info`,
  supports `debug`, `info`, `warning`, `error`, and `none`, and is applied before the SDK calls the YB log handler. Accepted OTel internal messages are then mapped to YB `LOG(...)` severities:

- `Error` -> `LOG(ERROR)`
- `Warning` -> `LOG(WARNING)`
- `Info`/`Debug` -> `LOG(INFO)`

The handler is registered as the global OTel log handler during `InitDistTrace()`. The SDK-side log level is set to the most permissive runtime level (`Debug`) so that every compiled-in message reaches the handler; the `LOG(...)`/`VLOG(...)` calls then let the YugabyteDB process logging configuration make the final filtering and routing decision.

This also removes the now-resolved `TODO(#30723)` placeholder.

## Test plan

- [ ] New unit test `DistTraceRpcTest.TestOtelInternalMessagesAreLogged` verifies that OTel internal messages at Error, Warning, Info, and Debug levels are routed to the YugabyteDB log sink.
- [ ]  - Added coverage for `--otel_internal_log_level`, including the default `info` behavior, `error` filtering, and `none` suppressing all OTel internal messages.
