### PR TITLE
[#31297] DocDB: Add logic to compact tablets based on schema packing count

### DIFF
--- a/src/yb/tablet/tablet-metadata-test.cc
+++ b/src/yb/tablet/tablet-metadata-test.cc
@@ -206,5 +206,27 @@ TEST_F(TestRaftGroupMetadata, IndexMapReturnsNotFoundForMissingTable) {
   ASSERT_TRUE(missing_result.status().IsNotFound()) << missing_result.status();
 }
 
+TEST_F(TestRaftGroupMetadata, SchemaPackingCountReport) {
+  auto* meta = harness_->tablet()->metadata();
+
+  size_t initial_schema_packing_count = meta->GetTotalSchemaPackingCount();
+  ASSERT_GE(initial_schema_packing_count, 1);
+  LOG(INFO) << "Initial schema packing count " << initial_schema_packing_count;
+
+  auto initial_table_info = meta->primary_table_info();
+  const Schema initial_schema = initial_table_info->schema();
+  const auto initial_version = initial_table_info->schema_version;
+  const qlexpr::IndexMap& index_map = *initial_table_info->index_map;
+  const TableId& table_id = initial_table_info->table_id;
+
+  // Perform schema changes 
+  meta->SetSchema(
+      initial_schema, index_map, /* deleted_cols */ {}, initial_version + 1, OpId() /* op_id */,
+      table_id);
+  
+  size_t updated_schema_packing_count = meta->GetTotalSchemaPackingCount();
+  ASSERT_EQ(updated_schema_packing_count, initial_schema_packing_count + 1);
+}
+
 } // namespace tablet
 } // namespace yb

--- a/src/yb/tablet/tablet_metadata.cc
+++ b/src/yb/tablet/tablet_metadata.cc
@@ -2526,4 +2526,17 @@ Result<docdb::EncodedPartitionBounds> RaftGroupMetadata::MakeEncodedPartitionBou
   };
 }
 
+size_t RaftGroupMetadata::GetTotalSchemaPackingCount() const {
+  std::lock_guard lock(data_mutex_);
+
+  size_t total_count = 0;
+  for (const auto& [table_id, table_info]: kv_store_.tables) {
+    if (!table_info || !table_info->doc_read_context) {
+      continue;
+    }
+    total_count += table_info->doc_read_context->schema_packing_storage.SchemaCount();
+  }
+  return total_count;
+}
+
 } // namespace yb::tablet

--- a/src/yb/tablet/tablet_metadata.h
+++ b/src/yb/tablet/tablet_metadata.h
@@ -764,6 +764,8 @@ class RaftGroupMetadata : public RefCountedThreadSafe<RaftGroupMetadata>,
   // if any field has been updated and a flush may be required.
   bool OnPostSplitCompactionDone();
 
+  size_t GetTotalSchemaPackingCount() const;
+
  private:
   using MutexType = simple_spinlock;
 

--- a/src/yb/tserver/full_compaction_manager.cc
+++ b/src/yb/tserver/full_compaction_manager.cc
@@ -84,7 +84,8 @@ DEFINE_RUNTIME_int32(auto_compact_memory_cleanup_interval_sec, 3600,
               "full compaction manager. -1 indicates we should disable clean up.");
 
 DEFINE_RUNTIME_uint32(full_compaction_schema_packing_count_threshold, 1000,
-              "Schema packing count threshold at which, full compaction will be done.");
+              "Schema packing count threshold at which, full compaction will be done. "
+              "A value of 0 disables this check.");
 
 using namespace std::literals;
 
@@ -390,13 +391,18 @@ bool FullCompactionManager::ShouldCompactBasedOnMetadata(
   if (!tablet_metadata) {
     return false;
   }
-
+  
+  const auto threshold = ANNOTATE_UNPROTECTED_READ(FLAGS_full_compaction_schema_packing_count_threshold);
+  if (threshold == 0) {
+    return false;
+  }
+  
   size_t schema_packing_count = tablet_metadata->GetTotalSchemaPackingCount();
-  if (schema_packing_count > ANNOTATE_UNPROTECTED_READ(FLAGS_full_compaction_schema_packing_count_threshold)) {
+  if (schema_packing_count > threshold) {
       LOG(INFO) << Format("TabletId $0 is eligible for compaction because schema packing count $1 exceeded threshold $2",
                           tablet_id, 
-                          schema_packing_count, 
-                          ANNOTATE_UNPROTECTED_READ(FLAGS_full_compaction_schema_packing_count_threshold));
+                          schema_packing_count,
+                          threshold);
     return true;
   }
   return false;

--- a/src/yb/tserver/full_compaction_manager.cc
+++ b/src/yb/tserver/full_compaction_manager.cc
@@ -83,6 +83,9 @@ DEFINE_RUNTIME_int32(auto_compact_memory_cleanup_interval_sec, 3600,
               "The frequency with which we should check whether cleanup is needed in the "
               "full compaction manager. -1 indicates we should disable clean up.");
 
+DEFINE_RUNTIME_uint32(full_compaction_schema_packing_count_threshold, 1000,
+              "Schema packing count threshold at which, full compaction will be done.");
+
 using namespace std::literals;
 
 namespace yb {
@@ -260,6 +263,7 @@ PeerNextCompactList FullCompactionManager::GetPeersEligibleForCompaction(
   for (const auto& peer : peers) {
     const auto tablet_id = peer->tablet_id();
     const auto tablet = peer->shared_tablet_maybe_null();
+    const auto tablet_metadata = peer->tablet_metadata();
     // If the tablet isn't eligible for compaction, remove it from our stored compaction
     // times and skip it.
     if (!tablet || !tablet->IsEligibleForFullCompaction()) {
@@ -274,6 +278,8 @@ PeerNextCompactList FullCompactionManager::GetPeersEligibleForCompaction(
     HybridTime next_compact_time;
     // Check if we should schedule a compaction based on stats collected.
     if (ShouldCompactBasedOnStats(tablet_id)) {
+      next_compact_time = now;
+    } else if (ShouldCompactBasedOnMetadata(tablet_id, tablet_metadata)) {
       next_compact_time = now;
     } else if (compaction_frequency_ != MonoDelta::kZero) {
       // If the next compaction time is pre-calculated, use that. Otherwise, calculate
@@ -376,6 +382,24 @@ MonoDelta FullCompactionManager::CalculateJitter(
   const auto small_hash =
       hash_value_for_jitter(tablet_id, last_compact_time) % kMaxSmallHash;
   return max_jitter_ / kMaxSmallHash * small_hash;
+}
+
+bool FullCompactionManager::ShouldCompactBasedOnMetadata(
+    const TabletId& tablet_id,
+    const tablet::RaftGroupMetadataPtr& tablet_metadata) {
+  if (!tablet_metadata) {
+    return false;
+  }
+
+  size_t schema_packing_count = tablet_metadata->GetTotalSchemaPackingCount();
+  if (schema_packing_count > ANNOTATE_UNPROTECTED_READ(FLAGS_full_compaction_schema_packing_count_threshold)) {
+      LOG(INFO) << Format("TabletId $0 is eligible for compaction because schema packing count $1 exceeded threshold $2",
+                          tablet_id, 
+                          schema_packing_count, 
+                          ANNOTATE_UNPROTECTED_READ(FLAGS_full_compaction_schema_packing_count_threshold));
+    return true;
+  }
+  return false;
 }
 
 KeyStatsSlidingWindow::KeyStatsSlidingWindow(int32_t check_interval_sec)

--- a/src/yb/tserver/full_compaction_manager.cc
+++ b/src/yb/tserver/full_compaction_manager.cc
@@ -396,10 +396,10 @@ bool FullCompactionManager::ShouldCompactBasedOnMetadata(
   if (threshold == 0) {
     return false;
   }
-  
+
   size_t schema_packing_count = tablet_metadata->GetTotalSchemaPackingCount();
   if (schema_packing_count > threshold) {
-      LOG(INFO) << Format("TabletId $0 is eligible for compaction because schema packing count $1 exceeded threshold $2",
+    LOG(INFO) << Format("TabletId $0 is eligible for compaction because schema packing count $1 exceeded threshold $2",
                           tablet_id, 
                           schema_packing_count,
                           threshold);

--- a/src/yb/tserver/full_compaction_manager.h
+++ b/src/yb/tserver/full_compaction_manager.h
@@ -156,6 +156,9 @@ class FullCompactionManager {
     return tablet_stats_window_.find(tablet_id) != tablet_stats_window_.end();
   }
 
+  bool ShouldCompactBasedOnMetadata(
+    const TabletId& tablet_id, const tablet::RaftGroupMetadataPtr& tablet_metadata);
+
  private:
   FRIEND_TEST(TsTabletManagerTest, FullCompactionCalculateNextCompaction);
   FRIEND_TEST(TsTabletManagerTest, CompactionsEvenlySpreadByJitter);


### PR DESCRIPTION
### Summary

Added logic to compact tablets based on schema packing count. This is needed when there is schema bloat due to multiple DDL commands.


### Testing

1. Added UTs for testing schema count method
2. Manually tested by running the server (both master, tablet server). Performed below to test it.

a. Ran the server with `full_compaction_schema_packing_count_threshold`, `auto_compact_check_interval_sec`, `ysql_enable_packed_row` flags

```
./bin/yugabyted start \
--tserver_flags="full_compaction_schema_packing_count_threshold=5,auto_compact_check_interval_sec=10,ysql_enable_packed_row=true" \
--master_flags="ysql_enable_packed_row=true" 
```

b. Created a test table and ran bunch of alter schema commands and inserted some values

```
CREATE TABLE test (
  id INT PRIMARY KEY
);

INSERT INTO test
SELECT generate_series(1,10000);
	
INSERT INTO test
SELECT generate_series(10001,20000);

ALTER TABLE test ADD COLUMN c1 INT;
UPDATE test SET c1 = 1;

ALTER TABLE test ADD COLUMN c2 INT;
UPDATE test SET c2 = 2;

ALTER TABLE test ADD COLUMN c3 INT;
UPDATE test SET c3 = 3;

ALTER TABLE test ADD COLUMN c4 INT;
UPDATE test SET c4 = 4;
```

c. Checked logs of yb-tserver.INFO logs for compaction related logs, added a dummy debug log to verify the current packing schema count as well. 

```
I0622 02:22:25.370625 1862381568 full_compaction_manager.cc:393] [debug] inside should compact based on metadata - 35 --> dummy log added, printed the packing schema count

I0622 02:22:35.376046 1862381568 full_compaction_manager.cc:396] TabletId 7abd39bf3e4a48018943a2ef95b4a2e9 is eligible for compaction because schema packing count 35 exceeded threshold 5

// Sample compaction logs
I0622 02:23:35.634306 1888759808 compaction_job.cc:628] T 7abd39bf3e4a48018943a2ef95b4a2e9 P 33edebcefeba45928bead958b5d44024 [R]: [default] compacted to: files[1] max score 0.20, MB/sec: 27.9 rd, 18.7 wr, level 0, files in(0, 1) out(1) MB in(0.0, 6.0) out(4.0), read-write-amplify(10559183.0) write-amplify(4242266.0) OK, records in: 510000, records dropped: 170000
I0622 02:23:35.634315 1888759808 event_logger.cc:87] T 7abd39bf3e4a48018943a2ef95b4a2e9 P 33edebcefeba45928bead958b5d44024 [R]: EVENT_LOG_v1 {"time_micros": 1782075215631658, "job": 84, "event": "compaction_finished", "compaction_time_micros": 226460, "output_level": 0, "num_output_files": 1, "total_output_size": 4242266, "num_input_records": 510000, "num_output_records": 340000, "num_subcompactions": 1, "is_full_compaction": 1, "lsm_state": [1]}
I0622 02:23:35.634485 1888759808 db_impl.cc:1389] T 7abd39bf3e4a48018943a2ef95b4a2e9 P 33edebcefeba45928bead958b5d44024 [R]: [JOB 84] Delete /Users/rajamanickam/var/data/yb-data/tserver/data/rocksdb/table-000034e1000030008000000000004500/tablet-7abd39bf3e4a48018943a2ef95b4a2e9/000092.sst type=2 #92 -- OK
I0622 02:23:35.634492 1888759808 event_logger.cc:70] T 7abd39bf3e4a48018943a2ef95b4a2e9 P 33edebcefeba45928bead958b5d44024 [R]: EVENT_LOG_v1 {"time_micros": 1782075215634492, "job": 84, "event": "table_file_deletion", "file_number": 92}
I0622 02:23:35.634517 1854926848 db_impl.cc:3074] T 7abd39bf3e4a48018943a2ef95b4a2e9 P 33edebcefeba45928bead958b5d44024 [I]: [default] Manual compaction starting, reason: kScheduledFullCompaction
I0622 02:23:35.634533 1854926848 db_impl.cc:3133] T 7abd39bf3e4a48018943a2ef95b4a2e9 P 33edebcefeba45928bead958b5d44024 [I]: [default] Manual compaction completed with no op, reason: kScheduledFullCompaction
I0622 02:23:55.414721 1888759808 event_logger.cc:70] T 7abd39bf3e4a48018943a2ef95b4a2e9 P 33edebcefeba45928bead958b5d44024 [R]: EVENT_LOG_v1 {"time_micros": 1782075235414697, "job": 86, "event": "compaction_started", "files_L0": [94], "score": -1, "input_data_size": 4242266, "is_full_compaction": 1}
I0622 02:23:55.565187 1888759808 event_logger.cc:70] T 7abd39bf3e4a48018943a2ef95b4a2e9 P 33edebcefeba45928bead958b5d44024 [R]: EVENT_LOG_v1 {"time_micros": 1782075235565183, "cf_name": "default", "job": 86, "event": "table_file_creation", "file_number": 95, "file_size": 4242266, "table_properties": {"data_size": 4165005, "data_index_size": 15797, "filter_size": 65482, "filter_index_size": 22, "raw_key_size": 11573248, "raw_average_key_size": 34, "raw_value_size": 7100128, "raw_average_value_size": 20, "num_data_blocks": 503, "num_entries": 340000, "num_filter_blocks": 1, "num_data_index_blocks": 1, "filter_policy_name": "DocKeyV3Filter", "kDeletedKeys": "0"}}
I0622 02:23:55.567219 1888759808 event_logger.cc:87] T 7abd39bf3e4a48018943a2ef95b4a2e9 P 33edebcefeba45928bead958b5d44024 [R]: EVENT_LOG_v1 {"time_micros": 1782075235566065, "job": 86, "event": "compaction_finished", "compaction_time_micros": 150460, "output_level": 0, "num_output_files": 1, "total_output_size": 4242266, "num_input_records": 340000, "num_output_records": 340000, "num_subcompactions": 1, "is_full_compaction": 1, "lsm_state": [1]}
I0622 02:23:55.567355 1888759808 event_logger.cc:70] T 7abd39bf3e4a48018943a2ef95b4a2e9 P 33edebcefeba45928bead958b5d44024 [R]: EVENT_LOG_v1 {"time_micros": 1782075235567354, "job": 86, "event": "table_file_deletion", "file_number": 94}
I0622 02:24:15.426635 1888759808 db_impl.cc:3792] T 7abd39bf3e4a48018943a2ef95b4a2e9 P 33edebcefeba45928bead958b5d44024 [R]: [default] Manual compaction from level-0 to level-0 from (begin) .. (end); will stop at (end)
I0622 02:24:15.607358 1858367488 db_impl.cc:3133] T 7abd39bf3e4a48018943a2ef95b4a2e9 P 33edebcefeba45928bead958b5d44024 [I]: [default] Manual compaction completed with no op, reason: kScheduledFullCompaction
```


d. Verified after sometime, schema count was back to 1







### Issue

https://github.com/yugabyte/yugabyte-db/issues/31297