### PR TITLE
[BACKPORT 2025.2][#32220] YSQL: Fixes unique index consistency bug when rows have NULL key columns (#32126)

### DIFF
--- a/src/postgres/src/backend/executor/execIndexing.c
+++ b/src/postgres/src/backend/executor/execIndexing.c
@@ -756,6 +756,53 @@ YbExecDoUpdateIndexTuple(ResultRelInfo *resultRelInfo,
 	MemoryContextSwitchTo(oldContext);
 }
 
+static bool
+YbIndexKeyColumnsModifiedByPkeyUpdate(Relation indexRelation,
+									 TupleTableSlot *slot,
+									 bool is_pk_updated)
+{
+	Form_pg_index indexData = indexRelation->rd_index;
+
+	if (!is_pk_updated)
+		return false;
+
+	/*
+	 * In non-unique indexes, ybidxbasectid is part of the index row key and
+	 * changes whenever the base table primary key changes.
+	 */
+	if (!indexData->indisunique)
+		return true;
+
+	/*
+	 * In unique indexes with NULLS NOT DISTINCT, ybuniqueidxkeysuffix is
+	 * always NULL, so a base table primary key update does not change the
+	 * index row key.
+	 */
+	if (indexData->indnullsnotdistinct)
+		return false;
+
+	for (int i = 0; i < indexData->indnkeyatts; i++)
+	{
+		AttrNumber	attnum = indexData->indkey.values[i];
+
+		/*
+		 * Expression key columns have attnum 0. Avoid evaluating the
+		 * expression here; conservatively assume that it can be NULL.
+		 * This consequently leads to a less optimized scenario where
+		 * we do a DELETE+INSERT unnecessarily, but this favors safety
+		 * over speed. It would be possible to use something like
+		 * FormIndexDatum to look up the actual values, but that's an
+		 * expensive operation since it needs to compute the actual expression
+		 * that would need to be optimized itself if we were to call it
+		 * very frequently.
+		 */
+		if (attnum <= 0 || slot_attisnull(slot, attnum))
+			return true;
+	}
+
+	return false;
+}
+
 List *
 YbExecUpdateIndexTuples(ResultRelInfo *resultRelInfo,
 						TupleTableSlot *slot,
@@ -953,15 +1000,13 @@ YbExecUpdateIndexTuples(ResultRelInfo *resultRelInfo,
 		}
 
 		/*
-		 * In the following scenarios, the index tuple can be modified (updated)
-		 * in-place, without the need to delete and reinsert the tuple:
-		 * - The index is a covering index (number of key columns < number of columns in the index),
-		 *   only the non-key columns need to be updated, and the primary key is not updated.
-		 * - The index is a unique index and only the non-key columns of the index need to be
-		 *   updated (irrespective of whether the primary key is updated).
+		 * In-place index tuple updates are possible only when the index tuple has
+		 * non-key columns to update, or when a unique index needs only its
+		 * ybbasectid value updated. Non-unique indexes without non-key columns
+		 * have no value columns to update in-place.
 		 */
-		if ((indexData->indnkeyatts == indexData->indnatts || is_pk_updated) &&
-			(!indexData->indisunique))
+		if (indexData->indnkeyatts == indexData->indnatts &&
+			!indexData->indisunique)
 		{
 			deleteIndexes = lappend_int(deleteIndexes, i);
 			insertIndexes = lappend_int(insertIndexes, i);
@@ -1012,6 +1057,21 @@ YbExecUpdateIndexTuples(ResultRelInfo *resultRelInfo,
 		}
 
 		if (j < indexRelation->rd_index->indnkeyatts)
+		{
+			deleteIndexes = lappend_int(deleteIndexes, i);
+			insertIndexes = lappend_int(insertIndexes, i);
+			continue;
+		}
+
+		/*
+		 * A base table primary key update can modify system-defined index key columns
+		 * even when the user-defined index key columns are unchanged. Non-unique
+		 * indexes use ybidxbasectid as part of the index row key. Unique indexes
+		 * that use NULLS DISTINCT semantics store ybuniqueidxkeysuffix as the base
+		 * table ybctid whenever any key column is NULL.
+		 */
+		if (YbIndexKeyColumnsModifiedByPkeyUpdate(indexRelation, slot,
+												 is_pk_updated))
 		{
 			deleteIndexes = lappend_int(deleteIndexes, i);
 			insertIndexes = lappend_int(insertIndexes, i);

--- a/src/postgres/src/test/regress/expected/yb.orig.update_optimize_index_updates.out
+++ b/src/postgres/src/test/regress/expected/yb.orig.update_optimize_index_updates.out
@@ -1572,11 +1572,11 @@ EXPLAIN (ANALYZE, DIST, COSTS OFF) UPDATE t_simple SET k2 = k2 + 1 WHERE k1 = 2;
          Storage Table Read Ops: 1
          Storage Table Rows Scanned: 1
          Storage Table Write Requests: 2
-         Storage Index Write Requests: 1
+         Storage Index Write Requests: 2
  Storage Read Requests: 1
  Storage Read Ops: 1
  Storage Rows Scanned: 1
- Storage Write Requests: 3
+ Storage Write Requests: 4
  Storage Flush Requests: 1
 (13 rows)
 
@@ -1590,11 +1590,11 @@ EXPLAIN (ANALYZE, DIST, COSTS OFF) UPDATE t_simple SET k1 = k1 + 10 WHERE k1 = 3
          Storage Table Read Ops: 1
          Storage Table Rows Scanned: 1
          Storage Table Write Requests: 2
-         Storage Index Write Requests: 1
+         Storage Index Write Requests: 2
  Storage Read Requests: 1
  Storage Read Ops: 1
  Storage Rows Scanned: 1
- Storage Write Requests: 3
+ Storage Write Requests: 4
  Storage Flush Requests: 1
 (13 rows)
 
@@ -1608,11 +1608,11 @@ EXPLAIN (ANALYZE, DIST, COSTS OFF) UPDATE t_simple SET k2 = k2 + 5, v3 = v3 + 5 
          Storage Table Read Ops: 1
          Storage Table Rows Scanned: 1
          Storage Table Write Requests: 2
-         Storage Index Write Requests: 1
+         Storage Index Write Requests: 2
  Storage Read Requests: 1
  Storage Read Ops: 1
  Storage Rows Scanned: 1
- Storage Write Requests: 3
+ Storage Write Requests: 4
  Storage Flush Requests: 1
 (13 rows)
 
@@ -1772,11 +1772,11 @@ EXPLAIN (ANALYZE, DIST, COSTS OFF) UPDATE t_simple SET k1 = k1 + 10, k2 = k2 + 1
          Storage Table Read Ops: 1
          Storage Table Rows Scanned: 1
          Storage Table Write Requests: 2
-         Storage Index Write Requests: 2
+         Storage Index Write Requests: 3
  Storage Read Requests: 1
  Storage Read Ops: 1
  Storage Rows Scanned: 1
- Storage Write Requests: 4
+ Storage Write Requests: 5
  Storage Flush Requests: 1
 (13 rows)
 
@@ -1790,11 +1790,11 @@ EXPLAIN (ANALYZE, DIST, COSTS OFF) UPDATE t_simple SET k1 = k1 + 10, k2 = k2 + 1
          Storage Table Read Ops: 1
          Storage Table Rows Scanned: 1
          Storage Table Write Requests: 2
-         Storage Index Write Requests: 2
+         Storage Index Write Requests: 3
  Storage Read Requests: 1
  Storage Read Ops: 1
  Storage Rows Scanned: 1
- Storage Write Requests: 4
+ Storage Write Requests: 5
  Storage Flush Requests: 1
 (13 rows)
 
@@ -1863,3 +1863,605 @@ SELECT * FROM t_simple;
   3 |  3 | 13 |  4 |  3 |  3
 (10 rows)
 
+--
+-- Additional coverage for hidden unique index key suffix changes.
+--
+SET yb_enable_inplace_index_update TO on;
+DROP TABLE IF EXISTS t_unique_key_update;
+NOTICE:  table "t_unique_key_update" does not exist, skipping
+CREATE TABLE t_unique_key_update (
+  h INT,
+  r INT,
+  k INT,
+  a INT,
+  b INT,
+  active BOOLEAN DEFAULT true,
+  PRIMARY KEY ((h) HASH, r ASC, k ASC)
+);
+CREATE UNIQUE INDEX NONCONCURRENTLY t_unique_key_update_uq
+ON t_unique_key_update (a ASC, b ASC);
+INSERT INTO t_unique_key_update (h, r, k, a, b) VALUES
+  (1, 1, 0, NULL, 10),
+  (1, 2, 0, 20, 20),
+  (1, 3, 0, NULL, 30),
+  (1, 4, 0, NULL, 40);
+-- Non-expression unique index: key changes from NULL to not-NULL.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_key_update SET a = 10 WHERE h = 1 AND r = 1;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Update on t_unique_key_update (actual rows=0 loops=1)
+   ->  Index Scan using t_unique_key_update_pkey on t_unique_key_update (actual rows=1 loops=1)
+         Index Cond: ((h = 1) AND (r = 1))
+         Storage Table Read Requests: 1
+         Storage Table Read Ops: 1
+         Storage Table Rows Scanned: 1
+         Storage Table Write Requests: 1
+         Storage Index Write Requests: 2
+ Storage Read Requests: 1
+ Storage Read Ops: 1
+ Storage Rows Scanned: 1
+ Storage Write Requests: 3
+ Storage Flush Requests: 1
+(13 rows)
+
+-- Non-expression unique index: key changes from not-NULL to NULL.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_key_update SET a = NULL WHERE h = 1 AND r = 2;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Update on t_unique_key_update (actual rows=0 loops=1)
+   ->  Index Scan using t_unique_key_update_pkey on t_unique_key_update (actual rows=1 loops=1)
+         Index Cond: ((h = 1) AND (r = 2))
+         Storage Table Read Requests: 1
+         Storage Table Read Ops: 1
+         Storage Table Rows Scanned: 1
+         Storage Table Write Requests: 1
+         Storage Index Write Requests: 2
+ Storage Read Requests: 1
+ Storage Read Ops: 1
+ Storage Rows Scanned: 1
+ Storage Write Requests: 3
+ Storage Flush Requests: 1
+(13 rows)
+
+-- Non-expression unique index: key is NULL; primary key update.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_key_update SET k = 1 WHERE h = 1 AND r = 3 AND k = 0;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Update on t_unique_key_update (actual rows=0 loops=1)
+   ->  Index Scan using t_unique_key_update_pkey on t_unique_key_update (actual rows=1 loops=1)
+         Index Cond: ((h = 1) AND (r = 3) AND (k = 0))
+         Storage Table Read Requests: 1
+         Storage Table Read Ops: 1
+         Storage Table Rows Scanned: 1
+         Storage Table Write Requests: 2
+         Storage Index Write Requests: 2
+ Storage Read Requests: 1
+ Storage Read Ops: 1
+ Storage Rows Scanned: 1
+ Storage Write Requests: 4
+ Storage Flush Requests: 1
+(13 rows)
+
+-- Non-expression unique index: some keys are NULL; another key becomes NULL.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_key_update SET b = NULL WHERE h = 1 AND r = 4;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Update on t_unique_key_update (actual rows=0 loops=1)
+   ->  Index Scan using t_unique_key_update_pkey on t_unique_key_update (actual rows=1 loops=1)
+         Index Cond: ((h = 1) AND (r = 4))
+         Storage Table Read Requests: 1
+         Storage Table Read Ops: 1
+         Storage Table Rows Scanned: 1
+         Storage Table Write Requests: 1
+         Storage Index Write Requests: 2
+ Storage Read Requests: 1
+ Storage Read Ops: 1
+ Storage Rows Scanned: 1
+ Storage Write Requests: 3
+ Storage Flush Requests: 1
+(13 rows)
+
+SELECT yb_index_check('t_unique_key_update_uq'::regclass);
+ yb_index_check 
+----------------
+ 
+(1 row)
+
+SELECT * FROM t_unique_key_update ORDER BY h, r, k;
+ h | r | k | a  | b  | active 
+---+---+---+----+----+--------
+ 1 | 1 | 0 | 10 | 10 | t
+ 1 | 2 | 0 |    | 20 | t
+ 1 | 3 | 1 |    | 30 | t
+ 1 | 4 | 0 |    |    | t
+(4 rows)
+
+DROP TABLE t_unique_key_update;
+DROP TABLE IF EXISTS t_unique_key_update_nnd;
+NOTICE:  table "t_unique_key_update_nnd" does not exist, skipping
+CREATE TABLE t_unique_key_update_nnd (
+  h INT,
+  r INT,
+  k INT,
+  a INT,
+  b INT,
+  active BOOLEAN DEFAULT true,
+  PRIMARY KEY ((h) HASH, r ASC, k ASC)
+);
+CREATE UNIQUE INDEX NONCONCURRENTLY t_unique_key_update_nnd_uq
+ON t_unique_key_update_nnd (a ASC, b ASC) NULLS NOT DISTINCT;
+INSERT INTO t_unique_key_update_nnd (h, r, k, a, b) VALUES
+  (2, 1, 0, NULL, 10),
+  (2, 2, 0, 20, 20),
+  (2, 3, 0, NULL, 30),
+  (2, 4, 0, NULL, 40);
+-- Non-expression unique NULLS NOT DISTINCT index: key changes from NULL to not-NULL.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_key_update_nnd SET a = 10 WHERE h = 2 AND r = 1;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Update on t_unique_key_update_nnd (actual rows=0 loops=1)
+   ->  Index Scan using t_unique_key_update_nnd_pkey on t_unique_key_update_nnd (actual rows=1 loops=1)
+         Index Cond: ((h = 2) AND (r = 1))
+         Storage Table Read Requests: 1
+         Storage Table Read Ops: 1
+         Storage Table Rows Scanned: 1
+         Storage Table Write Requests: 1
+         Storage Index Write Requests: 2
+ Storage Read Requests: 1
+ Storage Read Ops: 1
+ Storage Rows Scanned: 1
+ Storage Write Requests: 3
+ Storage Flush Requests: 1
+(13 rows)
+
+-- Non-expression unique NULLS NOT DISTINCT index: key changes from not-NULL to NULL.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_key_update_nnd SET a = NULL WHERE h = 2 AND r = 2;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Update on t_unique_key_update_nnd (actual rows=0 loops=1)
+   ->  Index Scan using t_unique_key_update_nnd_pkey on t_unique_key_update_nnd (actual rows=1 loops=1)
+         Index Cond: ((h = 2) AND (r = 2))
+         Storage Table Read Requests: 1
+         Storage Table Read Ops: 1
+         Storage Table Rows Scanned: 1
+         Storage Table Write Requests: 1
+         Storage Index Write Requests: 2
+ Storage Read Requests: 1
+ Storage Read Ops: 1
+ Storage Rows Scanned: 1
+ Storage Write Requests: 3
+ Storage Flush Requests: 1
+(13 rows)
+
+-- Non-expression unique NULLS NOT DISTINCT index: key is NULL; primary key update.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_key_update_nnd SET k = 1 WHERE h = 2 AND r = 3 AND k = 0;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Update on t_unique_key_update_nnd (actual rows=0 loops=1)
+   ->  Index Scan using t_unique_key_update_nnd_pkey on t_unique_key_update_nnd (actual rows=1 loops=1)
+         Index Cond: ((h = 2) AND (r = 3) AND (k = 0))
+         Storage Table Read Requests: 1
+         Storage Table Read Ops: 1
+         Storage Table Rows Scanned: 1
+         Storage Table Write Requests: 2
+         Storage Index Write Requests: 1
+ Storage Read Requests: 1
+ Storage Read Ops: 1
+ Storage Rows Scanned: 1
+ Storage Write Requests: 3
+ Storage Flush Requests: 1
+(13 rows)
+
+-- Non-expression unique NULLS NOT DISTINCT index: some keys are NULL; another key becomes NULL.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_key_update_nnd SET b = NULL WHERE h = 2 AND r = 4;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Update on t_unique_key_update_nnd (actual rows=0 loops=1)
+   ->  Index Scan using t_unique_key_update_nnd_pkey on t_unique_key_update_nnd (actual rows=1 loops=1)
+         Index Cond: ((h = 2) AND (r = 4))
+         Storage Table Read Requests: 1
+         Storage Table Read Ops: 1
+         Storage Table Rows Scanned: 1
+         Storage Table Write Requests: 1
+         Storage Index Write Requests: 2
+ Storage Read Requests: 1
+ Storage Read Ops: 1
+ Storage Rows Scanned: 1
+ Storage Write Requests: 3
+ Storage Flush Requests: 1
+(13 rows)
+
+SELECT yb_index_check('t_unique_key_update_nnd_uq'::regclass);
+ yb_index_check 
+----------------
+ 
+(1 row)
+
+SELECT * FROM t_unique_key_update_nnd ORDER BY h, r, k;
+ h | r | k | a  | b  | active 
+---+---+---+----+----+--------
+ 2 | 1 | 0 | 10 | 10 | t
+ 2 | 2 | 0 |    | 20 | t
+ 2 | 3 | 1 |    | 30 | t
+ 2 | 4 | 0 |    |    | t
+(4 rows)
+
+DROP TABLE t_unique_key_update_nnd;
+DROP TABLE IF EXISTS t_unique_expr_update;
+NOTICE:  table "t_unique_expr_update" does not exist, skipping
+CREATE TABLE t_unique_expr_update (
+  h INT,
+  r INT,
+  k INT,
+  a INT,
+  b INT,
+  c INT,
+  d INT,
+  active BOOLEAN DEFAULT true,
+  PRIMARY KEY ((h) HASH, r ASC, k ASC)
+);
+CREATE UNIQUE INDEX NONCONCURRENTLY t_unique_expr_update_uq
+ON t_unique_expr_update ((a + b), (c + d));
+INSERT INTO t_unique_expr_update (h, r, k, a, b, c, d) VALUES
+  (3, 1, 0, NULL, 10, 1, 1),
+  (3, 2, 0, 20, 20, 2, 2),
+  (3, 3, 0, NULL, 30, 3, 3),
+  (3, 4, 0, NULL, 40, 4, 4);
+-- Expression unique index: key changes from NULL to not-NULL.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_expr_update SET a = 10 WHERE h = 3 AND r = 1;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Update on t_unique_expr_update (actual rows=0 loops=1)
+   ->  Index Scan using t_unique_expr_update_pkey on t_unique_expr_update (actual rows=1 loops=1)
+         Index Cond: ((h = 3) AND (r = 1))
+         Storage Table Read Requests: 1
+         Storage Table Read Ops: 1
+         Storage Table Rows Scanned: 1
+         Storage Table Write Requests: 1
+         Storage Index Write Requests: 2
+ Storage Read Requests: 1
+ Storage Read Ops: 1
+ Storage Rows Scanned: 1
+ Storage Write Requests: 3
+ Storage Flush Requests: 1
+(13 rows)
+
+-- Expression unique index: key changes from not-NULL to NULL.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_expr_update SET a = NULL WHERE h = 3 AND r = 2;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Update on t_unique_expr_update (actual rows=0 loops=1)
+   ->  Index Scan using t_unique_expr_update_pkey on t_unique_expr_update (actual rows=1 loops=1)
+         Index Cond: ((h = 3) AND (r = 2))
+         Storage Table Read Requests: 1
+         Storage Table Read Ops: 1
+         Storage Table Rows Scanned: 1
+         Storage Table Write Requests: 1
+         Storage Index Write Requests: 2
+ Storage Read Requests: 1
+ Storage Read Ops: 1
+ Storage Rows Scanned: 1
+ Storage Write Requests: 3
+ Storage Flush Requests: 1
+(13 rows)
+
+-- Expression unique index: key is NULL; primary key update.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_expr_update SET k = 1 WHERE h = 3 AND r = 3 AND k = 0;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Update on t_unique_expr_update (actual rows=0 loops=1)
+   ->  Index Scan using t_unique_expr_update_pkey on t_unique_expr_update (actual rows=1 loops=1)
+         Index Cond: ((h = 3) AND (r = 3) AND (k = 0))
+         Storage Table Read Requests: 1
+         Storage Table Read Ops: 1
+         Storage Table Rows Scanned: 1
+         Storage Table Write Requests: 2
+         Storage Index Write Requests: 2
+ Storage Read Requests: 1
+ Storage Read Ops: 1
+ Storage Rows Scanned: 1
+ Storage Write Requests: 4
+ Storage Flush Requests: 1
+(13 rows)
+
+-- Expression unique index: some keys are NULL; another key becomes NULL.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_expr_update SET c = NULL WHERE h = 3 AND r = 4;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Update on t_unique_expr_update (actual rows=0 loops=1)
+   ->  Index Scan using t_unique_expr_update_pkey on t_unique_expr_update (actual rows=1 loops=1)
+         Index Cond: ((h = 3) AND (r = 4))
+         Storage Table Read Requests: 1
+         Storage Table Read Ops: 1
+         Storage Table Rows Scanned: 1
+         Storage Table Write Requests: 1
+         Storage Index Write Requests: 2
+ Storage Read Requests: 1
+ Storage Read Ops: 1
+ Storage Rows Scanned: 1
+ Storage Write Requests: 3
+ Storage Flush Requests: 1
+(13 rows)
+
+SELECT yb_index_check('t_unique_expr_update_uq'::regclass);
+ yb_index_check 
+----------------
+ 
+(1 row)
+
+SELECT * FROM t_unique_expr_update ORDER BY h, r, k;
+ h | r | k | a  | b  | c | d | active 
+---+---+---+----+----+---+---+--------
+ 3 | 1 | 0 | 10 | 10 | 1 | 1 | t
+ 3 | 2 | 0 |    | 20 | 2 | 2 | t
+ 3 | 3 | 1 |    | 30 | 3 | 3 | t
+ 3 | 4 | 0 |    | 40 |   | 4 | t
+(4 rows)
+
+DROP TABLE t_unique_expr_update;
+DROP TABLE IF EXISTS t_unique_expr_update_nnd;
+NOTICE:  table "t_unique_expr_update_nnd" does not exist, skipping
+CREATE TABLE t_unique_expr_update_nnd (
+  h INT,
+  r INT,
+  k INT,
+  a INT,
+  b INT,
+  c INT,
+  d INT,
+  active BOOLEAN DEFAULT true,
+  PRIMARY KEY ((h) HASH, r ASC, k ASC)
+);
+CREATE UNIQUE INDEX NONCONCURRENTLY t_unique_expr_update_nnd_uq
+ON t_unique_expr_update_nnd ((a + b), (c + d)) NULLS NOT DISTINCT;
+INSERT INTO t_unique_expr_update_nnd (h, r, k, a, b, c, d) VALUES
+  (4, 1, 0, NULL, 10, 1, 1),
+  (4, 2, 0, 20, 20, 2, 2),
+  (4, 3, 0, NULL, 30, 3, 3),
+  (4, 4, 0, NULL, 40, 4, 4);
+-- Expression unique NULLS NOT DISTINCT index: key changes from NULL to not-NULL.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_expr_update_nnd SET a = 10 WHERE h = 4 AND r = 1;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Update on t_unique_expr_update_nnd (actual rows=0 loops=1)
+   ->  Index Scan using t_unique_expr_update_nnd_pkey on t_unique_expr_update_nnd (actual rows=1 loops=1)
+         Index Cond: ((h = 4) AND (r = 1))
+         Storage Table Read Requests: 1
+         Storage Table Read Ops: 1
+         Storage Table Rows Scanned: 1
+         Storage Table Write Requests: 1
+         Storage Index Write Requests: 2
+ Storage Read Requests: 1
+ Storage Read Ops: 1
+ Storage Rows Scanned: 1
+ Storage Write Requests: 3
+ Storage Flush Requests: 1
+(13 rows)
+
+-- Expression unique NULLS NOT DISTINCT index: key changes from not-NULL to NULL.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_expr_update_nnd SET a = NULL WHERE h = 4 AND r = 2;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Update on t_unique_expr_update_nnd (actual rows=0 loops=1)
+   ->  Index Scan using t_unique_expr_update_nnd_pkey on t_unique_expr_update_nnd (actual rows=1 loops=1)
+         Index Cond: ((h = 4) AND (r = 2))
+         Storage Table Read Requests: 1
+         Storage Table Read Ops: 1
+         Storage Table Rows Scanned: 1
+         Storage Table Write Requests: 1
+         Storage Index Write Requests: 2
+ Storage Read Requests: 1
+ Storage Read Ops: 1
+ Storage Rows Scanned: 1
+ Storage Write Requests: 3
+ Storage Flush Requests: 1
+(13 rows)
+
+-- Expression unique NULLS NOT DISTINCT index: key is NULL; primary key update.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_expr_update_nnd SET k = 1 WHERE h = 4 AND r = 3 AND k = 0;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Update on t_unique_expr_update_nnd (actual rows=0 loops=1)
+   ->  Index Scan using t_unique_expr_update_nnd_pkey on t_unique_expr_update_nnd (actual rows=1 loops=1)
+         Index Cond: ((h = 4) AND (r = 3) AND (k = 0))
+         Storage Table Read Requests: 1
+         Storage Table Read Ops: 1
+         Storage Table Rows Scanned: 1
+         Storage Table Write Requests: 2
+         Storage Index Write Requests: 1
+ Storage Read Requests: 1
+ Storage Read Ops: 1
+ Storage Rows Scanned: 1
+ Storage Write Requests: 3
+ Storage Flush Requests: 1
+(13 rows)
+
+-- Expression unique NULLS NOT DISTINCT index: some keys are NULL; another key becomes NULL.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_expr_update_nnd SET c = NULL WHERE h = 4 AND r = 4;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Update on t_unique_expr_update_nnd (actual rows=0 loops=1)
+   ->  Index Scan using t_unique_expr_update_nnd_pkey on t_unique_expr_update_nnd (actual rows=1 loops=1)
+         Index Cond: ((h = 4) AND (r = 4))
+         Storage Table Read Requests: 1
+         Storage Table Read Ops: 1
+         Storage Table Rows Scanned: 1
+         Storage Table Write Requests: 1
+         Storage Index Write Requests: 2
+ Storage Read Requests: 1
+ Storage Read Ops: 1
+ Storage Rows Scanned: 1
+ Storage Write Requests: 3
+ Storage Flush Requests: 1
+(13 rows)
+
+SELECT yb_index_check('t_unique_expr_update_nnd_uq'::regclass);
+ yb_index_check 
+----------------
+ 
+(1 row)
+
+SELECT * FROM t_unique_expr_update_nnd ORDER BY h, r, k;
+ h | r | k | a  | b  | c | d | active 
+---+---+---+----+----+---+---+--------
+ 4 | 1 | 0 | 10 | 10 | 1 | 1 | t
+ 4 | 2 | 0 |    | 20 | 2 | 2 | t
+ 4 | 3 | 1 |    | 30 | 3 | 3 | t
+ 4 | 4 | 0 |    | 40 |   | 4 | t
+(4 rows)
+
+DROP TABLE t_unique_expr_update_nnd;
+DROP TABLE IF EXISTS t_partial_unique_expr_update;
+NOTICE:  table "t_partial_unique_expr_update" does not exist, skipping
+CREATE TABLE t_partial_unique_expr_update (
+  h INT,
+  r INT,
+  k INT,
+  a INT,
+  b INT,
+  c INT,
+  d INT,
+  active BOOLEAN,
+  PRIMARY KEY ((h) HASH, r ASC, k ASC)
+);
+CREATE UNIQUE INDEX NONCONCURRENTLY t_partial_unique_expr_update_uq
+ON t_partial_unique_expr_update ((a + b), (c + d)) WHERE active;
+INSERT INTO t_partial_unique_expr_update VALUES
+  (5, 1, 0, NULL, 10, 1, 1, true),
+  (5, 2, 0, 20, 20, 2, 2, false),
+  (5, 3, 0, NULL, 30, 3, 3, true),
+  (5, 4, 0, NULL, 40, 4, 4, false),
+  (5, 5, 0, NULL, 50, 5, 5, false);
+-- Partial expression unique index: NULL to not-NULL and exits the index.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_partial_unique_expr_update SET a = 10, active = false WHERE h = 5 AND r = 1;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Update on t_partial_unique_expr_update (actual rows=0 loops=1)
+   ->  Index Scan using t_partial_unique_expr_update_pkey on t_partial_unique_expr_update (actual rows=1 loops=1)
+         Index Cond: ((h = 5) AND (r = 1))
+         Storage Table Read Requests: 1
+         Storage Table Read Ops: 1
+         Storage Table Rows Scanned: 1
+         Storage Table Write Requests: 1
+         Storage Index Write Requests: 1
+ Storage Read Requests: 1
+ Storage Read Ops: 1
+ Storage Rows Scanned: 1
+ Storage Write Requests: 2
+ Storage Flush Requests: 1
+(13 rows)
+
+-- Partial expression unique index: not-NULL to NULL and enters the index.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_partial_unique_expr_update SET a = NULL, active = true WHERE h = 5 AND r = 2;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Update on t_partial_unique_expr_update (actual rows=0 loops=1)
+   ->  Index Scan using t_partial_unique_expr_update_pkey on t_partial_unique_expr_update (actual rows=1 loops=1)
+         Index Cond: ((h = 5) AND (r = 2))
+         Storage Table Read Requests: 1
+         Storage Table Read Ops: 1
+         Storage Table Rows Scanned: 1
+         Storage Table Write Requests: 1
+         Storage Index Write Requests: 1
+ Storage Read Requests: 1
+ Storage Read Ops: 1
+ Storage Rows Scanned: 1
+ Storage Write Requests: 2
+ Storage Flush Requests: 1
+(13 rows)
+
+-- Partial expression unique index: key is NULL, primary key update, and exits the index.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_partial_unique_expr_update SET k = 1, active = false WHERE h = 5 AND r = 3 AND k = 0;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Update on t_partial_unique_expr_update (actual rows=0 loops=1)
+   ->  Index Scan using t_partial_unique_expr_update_pkey on t_partial_unique_expr_update (actual rows=1 loops=1)
+         Index Cond: ((h = 5) AND (r = 3) AND (k = 0))
+         Storage Table Read Requests: 1
+         Storage Table Read Ops: 1
+         Storage Table Rows Scanned: 1
+         Storage Table Write Requests: 2
+         Storage Index Write Requests: 1
+ Storage Read Requests: 1
+ Storage Read Ops: 1
+ Storage Rows Scanned: 1
+ Storage Write Requests: 3
+ Storage Flush Requests: 1
+(13 rows)
+
+-- Partial expression unique index: some keys are NULL, another key becomes NULL, and enters the index.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_partial_unique_expr_update SET c = NULL, active = true WHERE h = 5 AND r = 4;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Update on t_partial_unique_expr_update (actual rows=0 loops=1)
+   ->  Index Scan using t_partial_unique_expr_update_pkey on t_partial_unique_expr_update (actual rows=1 loops=1)
+         Index Cond: ((h = 5) AND (r = 4))
+         Storage Table Read Requests: 1
+         Storage Table Read Ops: 1
+         Storage Table Rows Scanned: 1
+         Storage Table Write Requests: 1
+         Storage Index Write Requests: 1
+ Storage Read Requests: 1
+ Storage Read Ops: 1
+ Storage Rows Scanned: 1
+ Storage Write Requests: 2
+ Storage Flush Requests: 1
+(13 rows)
+
+-- Partial expression unique index: key is NULL, primary key update, and enters the index.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_partial_unique_expr_update SET k = 1, active = true WHERE h = 5 AND r = 5 AND k = 0;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Update on t_partial_unique_expr_update (actual rows=0 loops=1)
+   ->  Index Scan using t_partial_unique_expr_update_pkey on t_partial_unique_expr_update (actual rows=1 loops=1)
+         Index Cond: ((h = 5) AND (r = 5) AND (k = 0))
+         Storage Table Read Requests: 1
+         Storage Table Read Ops: 1
+         Storage Table Rows Scanned: 1
+         Storage Table Write Requests: 2
+         Storage Index Write Requests: 1
+ Storage Read Requests: 1
+ Storage Read Ops: 1
+ Storage Rows Scanned: 1
+ Storage Write Requests: 3
+ Storage Flush Requests: 1
+(13 rows)
+
+SELECT yb_index_check('t_partial_unique_expr_update_uq'::regclass);
+ yb_index_check 
+----------------
+ 
+(1 row)
+
+SELECT * FROM t_partial_unique_expr_update ORDER BY h, r, k;
+ h | r | k | a  | b  | c | d | active 
+---+---+---+----+----+---+---+--------
+ 5 | 1 | 0 | 10 | 10 | 1 | 1 | f
+ 5 | 2 | 0 |    | 20 | 2 | 2 | t
+ 5 | 3 | 1 |    | 30 | 3 | 3 | f
+ 5 | 4 | 0 |    | 40 |   | 4 | t
+ 5 | 5 | 1 |    | 50 | 5 | 5 | t
+(5 rows)
+
+DROP TABLE t_partial_unique_expr_update;

--- a/src/postgres/src/test/regress/sql/yb.orig.update_optimize_index_updates.sql
+++ b/src/postgres/src/test/regress/sql/yb.orig.update_optimize_index_updates.sql
@@ -260,3 +260,183 @@ EXPLAIN (VERBOSE) /*+ IndexOnlyScan(t_simple multi_include) */ SELECT v1, v2, v3
 EXPLAIN (VERBOSE) /*+ IndexScan(multi_include) */ SELECT * FROM t_simple ORDER BY (v1, v2);
 /*+ IndexScan(multi_include) */ SELECT * FROM t_simple ORDER BY (v1, v2);
 SELECT * FROM t_simple;
+
+--
+-- Additional coverage for hidden unique index key suffix changes.
+--
+SET yb_enable_inplace_index_update TO on;
+
+DROP TABLE IF EXISTS t_unique_key_update;
+CREATE TABLE t_unique_key_update (
+  h INT,
+  r INT,
+  k INT,
+  a INT,
+  b INT,
+  active BOOLEAN DEFAULT true,
+  PRIMARY KEY ((h) HASH, r ASC, k ASC)
+);
+CREATE UNIQUE INDEX NONCONCURRENTLY t_unique_key_update_uq
+ON t_unique_key_update (a ASC, b ASC);
+INSERT INTO t_unique_key_update (h, r, k, a, b) VALUES
+  (1, 1, 0, NULL, 10),
+  (1, 2, 0, 20, 20),
+  (1, 3, 0, NULL, 30),
+  (1, 4, 0, NULL, 40);
+-- Non-expression unique index: key changes from NULL to not-NULL.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_key_update SET a = 10 WHERE h = 1 AND r = 1;
+-- Non-expression unique index: key changes from not-NULL to NULL.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_key_update SET a = NULL WHERE h = 1 AND r = 2;
+-- Non-expression unique index: key is NULL; primary key update.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_key_update SET k = 1 WHERE h = 1 AND r = 3 AND k = 0;
+-- Non-expression unique index: some keys are NULL; another key becomes NULL.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_key_update SET b = NULL WHERE h = 1 AND r = 4;
+SELECT yb_index_check('t_unique_key_update_uq'::regclass);
+SELECT * FROM t_unique_key_update ORDER BY h, r, k;
+DROP TABLE t_unique_key_update;
+
+DROP TABLE IF EXISTS t_unique_key_update_nnd;
+CREATE TABLE t_unique_key_update_nnd (
+  h INT,
+  r INT,
+  k INT,
+  a INT,
+  b INT,
+  active BOOLEAN DEFAULT true,
+  PRIMARY KEY ((h) HASH, r ASC, k ASC)
+);
+CREATE UNIQUE INDEX NONCONCURRENTLY t_unique_key_update_nnd_uq
+ON t_unique_key_update_nnd (a ASC, b ASC) NULLS NOT DISTINCT;
+INSERT INTO t_unique_key_update_nnd (h, r, k, a, b) VALUES
+  (2, 1, 0, NULL, 10),
+  (2, 2, 0, 20, 20),
+  (2, 3, 0, NULL, 30),
+  (2, 4, 0, NULL, 40);
+-- Non-expression unique NULLS NOT DISTINCT index: key changes from NULL to not-NULL.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_key_update_nnd SET a = 10 WHERE h = 2 AND r = 1;
+-- Non-expression unique NULLS NOT DISTINCT index: key changes from not-NULL to NULL.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_key_update_nnd SET a = NULL WHERE h = 2 AND r = 2;
+-- Non-expression unique NULLS NOT DISTINCT index: key is NULL; primary key update.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_key_update_nnd SET k = 1 WHERE h = 2 AND r = 3 AND k = 0;
+-- Non-expression unique NULLS NOT DISTINCT index: some keys are NULL; another key becomes NULL.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_key_update_nnd SET b = NULL WHERE h = 2 AND r = 4;
+SELECT yb_index_check('t_unique_key_update_nnd_uq'::regclass);
+SELECT * FROM t_unique_key_update_nnd ORDER BY h, r, k;
+DROP TABLE t_unique_key_update_nnd;
+
+DROP TABLE IF EXISTS t_unique_expr_update;
+CREATE TABLE t_unique_expr_update (
+  h INT,
+  r INT,
+  k INT,
+  a INT,
+  b INT,
+  c INT,
+  d INT,
+  active BOOLEAN DEFAULT true,
+  PRIMARY KEY ((h) HASH, r ASC, k ASC)
+);
+CREATE UNIQUE INDEX NONCONCURRENTLY t_unique_expr_update_uq
+ON t_unique_expr_update ((a + b), (c + d));
+INSERT INTO t_unique_expr_update (h, r, k, a, b, c, d) VALUES
+  (3, 1, 0, NULL, 10, 1, 1),
+  (3, 2, 0, 20, 20, 2, 2),
+  (3, 3, 0, NULL, 30, 3, 3),
+  (3, 4, 0, NULL, 40, 4, 4);
+-- Expression unique index: key changes from NULL to not-NULL.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_expr_update SET a = 10 WHERE h = 3 AND r = 1;
+-- Expression unique index: key changes from not-NULL to NULL.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_expr_update SET a = NULL WHERE h = 3 AND r = 2;
+-- Expression unique index: key is NULL; primary key update.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_expr_update SET k = 1 WHERE h = 3 AND r = 3 AND k = 0;
+-- Expression unique index: some keys are NULL; another key becomes NULL.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_expr_update SET c = NULL WHERE h = 3 AND r = 4;
+SELECT yb_index_check('t_unique_expr_update_uq'::regclass);
+SELECT * FROM t_unique_expr_update ORDER BY h, r, k;
+DROP TABLE t_unique_expr_update;
+
+DROP TABLE IF EXISTS t_unique_expr_update_nnd;
+CREATE TABLE t_unique_expr_update_nnd (
+  h INT,
+  r INT,
+  k INT,
+  a INT,
+  b INT,
+  c INT,
+  d INT,
+  active BOOLEAN DEFAULT true,
+  PRIMARY KEY ((h) HASH, r ASC, k ASC)
+);
+CREATE UNIQUE INDEX NONCONCURRENTLY t_unique_expr_update_nnd_uq
+ON t_unique_expr_update_nnd ((a + b), (c + d)) NULLS NOT DISTINCT;
+INSERT INTO t_unique_expr_update_nnd (h, r, k, a, b, c, d) VALUES
+  (4, 1, 0, NULL, 10, 1, 1),
+  (4, 2, 0, 20, 20, 2, 2),
+  (4, 3, 0, NULL, 30, 3, 3),
+  (4, 4, 0, NULL, 40, 4, 4);
+-- Expression unique NULLS NOT DISTINCT index: key changes from NULL to not-NULL.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_expr_update_nnd SET a = 10 WHERE h = 4 AND r = 1;
+-- Expression unique NULLS NOT DISTINCT index: key changes from not-NULL to NULL.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_expr_update_nnd SET a = NULL WHERE h = 4 AND r = 2;
+-- Expression unique NULLS NOT DISTINCT index: key is NULL; primary key update.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_expr_update_nnd SET k = 1 WHERE h = 4 AND r = 3 AND k = 0;
+-- Expression unique NULLS NOT DISTINCT index: some keys are NULL; another key becomes NULL.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_unique_expr_update_nnd SET c = NULL WHERE h = 4 AND r = 4;
+SELECT yb_index_check('t_unique_expr_update_nnd_uq'::regclass);
+SELECT * FROM t_unique_expr_update_nnd ORDER BY h, r, k;
+DROP TABLE t_unique_expr_update_nnd;
+
+DROP TABLE IF EXISTS t_partial_unique_expr_update;
+CREATE TABLE t_partial_unique_expr_update (
+  h INT,
+  r INT,
+  k INT,
+  a INT,
+  b INT,
+  c INT,
+  d INT,
+  active BOOLEAN,
+  PRIMARY KEY ((h) HASH, r ASC, k ASC)
+);
+CREATE UNIQUE INDEX NONCONCURRENTLY t_partial_unique_expr_update_uq
+ON t_partial_unique_expr_update ((a + b), (c + d)) WHERE active;
+INSERT INTO t_partial_unique_expr_update VALUES
+  (5, 1, 0, NULL, 10, 1, 1, true),
+  (5, 2, 0, 20, 20, 2, 2, false),
+  (5, 3, 0, NULL, 30, 3, 3, true),
+  (5, 4, 0, NULL, 40, 4, 4, false),
+  (5, 5, 0, NULL, 50, 5, 5, false);
+-- Partial expression unique index: NULL to not-NULL and exits the index.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_partial_unique_expr_update SET a = 10, active = false WHERE h = 5 AND r = 1;
+-- Partial expression unique index: not-NULL to NULL and enters the index.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_partial_unique_expr_update SET a = NULL, active = true WHERE h = 5 AND r = 2;
+-- Partial expression unique index: key is NULL, primary key update, and exits the index.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_partial_unique_expr_update SET k = 1, active = false WHERE h = 5 AND r = 3 AND k = 0;
+-- Partial expression unique index: some keys are NULL, another key becomes NULL, and enters the index.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_partial_unique_expr_update SET c = NULL, active = true WHERE h = 5 AND r = 4;
+-- Partial expression unique index: key is NULL, primary key update, and enters the index.
+EXPLAIN (ANALYZE, DIST, COSTS OFF)
+UPDATE t_partial_unique_expr_update SET k = 1, active = true WHERE h = 5 AND r = 5 AND k = 0;
+SELECT yb_index_check('t_partial_unique_expr_update_uq'::regclass);
+SELECT * FROM t_partial_unique_expr_update ORDER BY h, r, k;
+DROP TABLE t_partial_unique_expr_update;


### PR DESCRIPTION
Original commit: b6ae5f320f91a08de42f609eab97e44ba7ea5f46 / #32126

`yb_enable_inplace_index_update` incorrectly treats primary-key updates on unique secondary indexes as safe for in-place index-row updates. This is false when the unique index uses NULLs-distinct semantics and any unique-index key column is NULL, because the hidden `ybuniqueidxkeysuffix` is part of the index row key and is derived from the base row `ybctid`.  A base table PK update changes the base row ybctid, so the hidden unique suffix changes too.

fixes: https://github.com/yugabyte/yugabyte-db/issues/32220

Reproducible example:

 ```sql
SET yb_enable_inplace_index_update = on;

CREATE TABLE idx_test (
  c1 bigint,
  id bigint,
  foo smallint DEFAULT 0 NOT NULL,
  some_hash bytea,
  is_not_deleted boolean,
  PRIMARY KEY ((c1) HASH, id ASC, foo ASC)
);

CREATE UNIQUE INDEX idx_test_uq
ON idx_test USING lsm (c1 HASH, some_hash ASC)
WHERE is_not_deleted;

INSERT INTO idx_test (c1, id, foo, some_hash, is_not_deleted)
VALUES (1, 1, 0, NULL, true);

UPDATE idx_test SET foo = 1
WHERE c1 = 1 AND id = 1 AND foo = 0;

SELECT yb_index_check('idx_test_uq'::regclass);
```

Consistency check immediately fails

```sql
yugabyte=# SELECT yb_index_check('idx_test_uq'::regclass);
ERROR:  ybuniqueidxkeysuffix and ybbasectid mismatch
DETAIL:  index: 'idx_test_uq', ybbasectid: '\x47eda949800000000000000121498000000000000001488000000121'
```

The fix is to essentially force the `DELETE+INSERT` for this scenario.

With `yb_enable_inplace_index_update = off` the issue is not reproducible with the above example.
