### PR TITLE
[BACKPORT 2025.2][#30141] DocDB: Remove unused read replicas in cluster balancer

### DIFF
--- a/src/yb/integration-tests/load_balancer_placement_policy-test.cc
+++ b/src/yb/integration-tests/load_balancer_placement_policy-test.cc
@@ -1266,6 +1266,56 @@ TEST_P(TablespaceReadReplicaUuidTest, TestTablespaceReadReplicaAlter) {
   ASSERT_VECTORS_EQ(expected_counts_per_ts, counts_per_ts);
 }
 
+// Test that when a table with read replicas is altered to use a tablespace without read replicas,
+// the read replicas are removed.
+TEST_F(TablespaceReadReplicaTest, TestAlterTableToTablespaceWithoutReadReplica) {
+  const auto kTablespaceNoReadReplica = "ts_no_rr";
+  const auto kDatabaseName = "yugabyte";
+  const auto kPgTableName = "test_pg_table";
+
+  ASSERT_OK(yb_admin_client_->ModifyPlacementInfo(
+      "c.r.z0,c.r.z1,c.r.z2", 3 /* replication_factor */, ""));
+
+  size_t num_tservers = num_tablet_servers();
+  AddNewTserverToZone("z3", ++num_tservers, kReadReplicaPlacementUuid);
+  AddNewTserverToZone("z4", ++num_tservers, kReadReplicaPlacementUuid);
+  ASSERT_OK(yb_admin_client_->AddReadReplicaPlacementInfo(
+      "c.r.z3,c.r.z4", 2 /* replication_factor */, kReadReplicaPlacementUuid));
+
+  DeleteTable();
+  auto pg_conn = ASSERT_RESULT(external_mini_cluster()->ConnectToDB());
+
+  // Create a table in the default tablespace. This table will inherit read replicas
+  // from the cluster-level configuration.
+  ASSERT_OK(pg_conn.ExecuteFormat(
+      "CREATE TABLE $0 (k INT PRIMARY KEY) SPLIT INTO 1 TABLETS", kPgTableName));
+
+  WaitForLoadBalancerToBeIdle();
+
+  const TableId table_id = ASSERT_RESULT(FindYsqlTableId(kDatabaseName, kPgTableName));
+
+  vector<int> counts_per_ts = ASSERT_RESULT(GetLoadOnTserversByTableId(table_id, num_tservers));
+  vector<int> expected_counts_per_ts = {1, 1, 1, 1, 1};
+  ASSERT_VECTORS_EQ(expected_counts_per_ts, counts_per_ts);
+
+  // Create a tablespace without read replicas
+  const test::Tablespace tablespace_no_read_replica(
+      kTablespaceNoReadReplica,
+      /* numReplicas = */ 3,
+      {test::PlacementBlock("c", "r", "z0", 1), test::PlacementBlock("c", "r", "z1", 1),
+       test::PlacementBlock("c", "r", "z2", 1)});
+
+  ASSERT_OK(pg_conn.Execute(tablespace_no_read_replica.CreateCmd()));
+
+  ASSERT_OK(pg_conn.ExecuteFormat(
+      "ALTER TABLE $0 SET TABLESPACE $1", kPgTableName, tablespace_no_read_replica.name));
+  WaitForLoadBalancer();
+
+  counts_per_ts = ASSERT_RESULT(GetLoadOnTserversByTableId(table_id, num_tservers));
+  expected_counts_per_ts = {1, 1, 1, 0, 0};
+  ASSERT_VECTORS_EQ(expected_counts_per_ts, counts_per_ts);
+}
+
 // Test creating a table in a tablespace that has a read replica using a wildcard placement
 // block. The tablespace either embeds an explicit placement_uuid or omits it (and the master
 // auto-populates it from the cluster config), depending on the test parameter.

--- a/src/yb/master/cluster_balance.cc
+++ b/src/yb/master/cluster_balance.cc
@@ -256,19 +256,24 @@ void ClusterLoadBalancer::InitTablespaceManager() {
 Status ClusterLoadBalancer::PopulateReplicationInfo(
     const scoped_refptr<TableInfo>& table, const ReplicationInfoPB& replication_info) {
 
+  bool has_read_replicas = true;
   if (state_->options_->type == ReplicaType::kLive) {
     state_->placement_.CopyFrom(replication_info.live_replicas());
   } else if (state_->options_->type == ReplicaType::kReadOnly) {
     if (replication_info.read_replicas_size() == 0) {
-      // Should not reach here as tables that should not have read replicas should
-      // have already been skipped before reaching here.
-      return STATUS_FORMAT(
-          IllegalState, "Encountered a table $0 with no read replicas. Placement info $1",
-          table->id(), replication_info);
+      // The table has no read replicas configured. Set num_replicas to 0 so that any existing
+      // read replicas are detected as over-replicated and removed. This handles the case where
+      // a table is moved to a tablespace without read replica placement.
+      has_read_replicas = false;
+      state_->placement_.Clear();
+      state_->placement_.set_num_replicas(0);
+    } else {
+      state_->placement_.CopyFrom(GetReadOnlyPlacementFromUuid(replication_info));
     }
-    state_->placement_.CopyFrom(GetReadOnlyPlacementFromUuid(replication_info));
   }
-  if (state_->placement_.num_replicas() == 0) {
+  // Apply default replication factor if not set, but only if the table has read replicas
+  // configured (i.e., we don't want to override an explicit 0 setting).
+  if (state_->placement_.num_replicas() == 0 && has_read_replicas) {
     state_->placement_.set_num_replicas(FLAGS_replication_factor);
   }
   if (state_->placement_.placement_blocks().empty()) {
@@ -431,17 +436,6 @@ void ClusterLoadBalancer::RunLoadBalancerWithOptions(
     const auto replication_info = GetTableReplicationInfo(table);
     VLOG(2) << Format("Replication info for table $0: $1", table_id,
         replication_info.ShortDebugString());
-
-    if (options->type == ReplicaType::kReadOnly) {
-      if (replication_info.read_replicas_size() == 0) {
-        // The table has a replication policy without any read replicas present.
-        // The LoadBalancer is handling read replicas in this run, so this
-        // table can be skipped.
-        VLOG(2) << Format("Skipping table $0 with no read replicas configured in read replica run",
-            table_id);
-        continue;
-      }
-    }
 
     ResetTableStatePtr(table_id, options);
 

--- a/src/yb/master/cluster_balance_util.cc
+++ b/src/yb/master/cluster_balance_util.cc
@@ -341,10 +341,6 @@ Status PerTableLoadState::UpdateTablet(TabletInfo *tablet) {
     }
   }
 
-  // Only set the over-replication section if we need to.
-  if (placement_.num_replicas() == 0) {
-    placement_.set_num_replicas(FLAGS_replication_factor);
-  }
   tablet_meta.is_over_replicated = placement_.num_replicas() < static_cast<int32_t>(replica_count);
   tablet_meta.is_under_replicated = placement_.num_replicas() > static_cast<int32_t>(replica_count);
   if (VLOG_IS_ON(3)) {


### PR DESCRIPTION
DO NOT MERGE!! [CSI](<https://csiweb.dev.yugabyte.com/pull/32351/>) ⏳

Summary:
Currently, the load balancer completely skips over load balancing read replicas for tablets that don't have any read replicas configured.

This causes a bug in the case where a tablet is originally in a tablespace that has read replicas, but then it is moved into a tablespace without read replicas. After the move, the load balancer skips over this tablet during the read replica balancing phase. As a result, the old read replicas are never removed.

This diff still lets the load balancer run in the case that it is in a tablespace with zero read replicas, allowing it to detect that the read replicas are overreplicated and remove the old read replicas.

Original commit: ee3585f3a265f02d82684b562db6edc246272a59 / D49971

Test Plan:
```
./yb_build.sh release --cxx-test load_balancer_placement_policy-test --gtest-filter "*TestAlterTableToTablespaceWithoutReadReplica*"

Reviewers: asrivastava

Reviewed By: asrivastava

Subscribers: ybase

Differential Revision: https://phorge.dev.yugabyte.com/D49971