### PR TITLE
fix: output COMMIT/ROLLBACK result in isolation tester

### DIFF
--- a/src/postgres/src/test/isolation/isolationtester.c
+++ b/src/postgres/src/test/isolation/isolationtester.c
@@ -1079,6 +1079,8 @@ try_complete_step(TestSpec *testspec, PermutationStep *pstep, int flags)
 		switch (PQresultStatus(res))
 		{
 			case PGRES_COMMAND_OK:
+				printf("%s\n", PQcmdStatus(res));
+				break;
 			case PGRES_EMPTY_QUERY:
 				break;
 			case PGRES_TUPLES_OK:


### PR DESCRIPTION
## Summary

Print the command status after PGRES_COMMAND_OK so that the result of COMMIT or ROLLBACK is displayed instead of repeating the command.

## Changes

- Added printf and break after case PGRES_COMMAND_OK in isolationtester.c

## Testing

Tested with isolation test suite.

Fixes #29929