### PR TITLE
fix: clear buffered operations before AtSubAbort_Snapshot

### DIFF
--- a/src/postgres/src/backend/access/transam/xact.c
+++ b/src/postgres/src/backend/access/transam/xact.c
@@ -5736,6 +5736,12 @@ AbortSubTransaction(void)
 	}
 
 	/*
+	 * YB: Clear buffered operations before AtSubAbort_Snapshot to avoid
+	 * flushing operations that will be rolled back anyway.
+	 */
+	YBCRollbackToSubTransaction(s->subTransactionId);
+
+	/*
 	 * We can skip all this stuff if the subxact failed before creating a
 	 * ResourceOwner...
 	 */
@@ -5786,8 +5792,6 @@ AbortSubTransaction(void)
 		AtEOSubXact_PgStat(false, s->nestingLevel);
 		AtSubAbort_Snapshot(s->nestingLevel);
 	}
-
-	YBCRollbackToSubTransaction(s->subTransactionId);
 
 	/*
 	 * Restore the upper transaction's read-only state, too.  This should be


### PR DESCRIPTION
## Summary

Move YBCRollbackToSubTransaction() call to before the if (s->curTransactionOwner) block in AbortSubTransaction().

## Problem

In AbortSubTransaction(), the call chain on subtransaction abort flushes buffered operations to the tserver before clearing them, instead of just dropping them. Since the subtransaction is being aborted, the buffered operations are going to be rolled back anyway. Flushing them to the tserver first is wasted work and can also cause spurious errors.

## Fix

By moving YBCRollbackToSubTransaction() before AtSubAbort_Snapshot(), the buffer is cleared (via buffer_.Clear()) before RestoreReadPoint triggers FlushBufferedOperations(). This gives the intended drop, not flush behavior on subtransaction abort.

Fixes #31655