### PR TITLE
fix: add warning when tablet starts with no RocksDB data

### DIFF
--- a/src/yb/tablet/tablet_bootstrap.cc
+++ b/src/yb/tablet/tablet_bootstrap.cc
@@ -559,9 +559,8 @@ class TabletBootstrap {
 
     // This is a new tablet, nothing left to do.
     if (!has_blocks && !needs_recovery) {
-      LOG_WITH_PREFIX(WARNING) << "No blocks or log segments found for tablet "
-                               << meta_->tablet_id()
-                               << ". This may indicate that RocksDB data was deleted "
+      LOG_WITH_PREFIX(WARNING) << "No blocks or log segments found. "
+                               << "This may indicate that RocksDB data was deleted "
                                << "or never existed. Creating new log.";
       RETURN_NOT_OK_PREPEND(OpenLog(CreateNewSegment::kTrue), "Failed to open new log");
       RETURN_NOT_OK(FinishBootstrap("No bootstrap required, opened a new log",

--- a/src/yb/tablet/tablet_bootstrap.cc
+++ b/src/yb/tablet/tablet_bootstrap.cc
@@ -559,7 +559,10 @@ class TabletBootstrap {
 
     // This is a new tablet, nothing left to do.
     if (!has_blocks && !needs_recovery) {
-      LOG_WITH_PREFIX(INFO) << "No blocks or log segments found. Creating new log.";
+      LOG_WITH_PREFIX(WARNING) << "No blocks or log segments found for tablet "
+                               << meta_->tablet_id()
+                               << ". This may indicate that RocksDB data was deleted "
+                               << "or never existed. Creating new log.";
       RETURN_NOT_OK_PREPEND(OpenLog(CreateNewSegment::kTrue), "Failed to open new log");
       RETURN_NOT_OK(FinishBootstrap("No bootstrap required, opened a new log",
                                     rebuilt_log,


### PR DESCRIPTION
## Summary

Add a WARNING log when a tablet peer has no blocks or log segments and starts fresh from OpId::Min() (0.0).

## Problem

In one customer setup, RocksDBs for all peers hosted by a node were deleted after OS patching activity. The peers started off fresh from op 0.0 and recovered automatically, but there was no warning to flag this unusual situation.

## Fix

Changed the INFO log to WARNING and added tablet_id to help operators detect and investigate when RocksDB data is missing.

Fixes #32114