### PR TITLE
fix: add is_clamped to docdb request debug log

### DIFF
--- a/src/yb/yql/pggate/pg_session.cc
+++ b/src/yb/yql/pggate/pg_session.cc
@@ -481,6 +481,7 @@ class PgSession::RunHelper {
           << table.table_name().table_name()
           << ", txn_serial_no: " << rp.txn
           << ", read_time_serial_no: " << rp.read_time_serial_no
+          << ", is_clamped: " << rp.is_clamped
           << ": " << op->ToString();
     }
 


### PR DESCRIPTION
## Summary

Include the is_clamped flag from TxnReadPoint in the debug log output when yb_debug_log_docdb_requests is enabled.

## Problem

The docdb request debug log shows txn_serial_no and read_time_serial_no but does not indicate whether the uncertainty window is clamped. This information is useful for debugging read time issues.

## Fix

Added is_clamped field to the log output to provide additional context about the uncertainty window state.

Fixes #29940