### PR TITLE
[#28251] DocDB: Document --flagfile in yb-admin usage text

### DIFF
--- a/src/yb/tools/yb-admin_cli.cc
+++ b/src/yb/tools/yb-admin_cli.cc
@@ -501,7 +501,15 @@ void ClusterAdminCli::SetUsage(const string& prog_name) {
   ostringstream str;
 
   str << prog_name << " [--master_addresses server1:port,server2:port,server3:port,...] "
-      << " [--timeout_ms <millisec>] [--certs_dir_name <dir_name>] <operation>" << endl
+      << " [--timeout_ms <millisec>] [--certs_dir_name <dir_name>]" << endl
+      << "  [--flagfile <path/to/master/conf/server.conf>]" << endl
+      << "  <operation>" << endl
+      << endl
+      << "Tip: Use --flagfile with the master's server.conf to automatically pick up" << endl
+      << "master_addresses and certs_dir, avoiding manual flag entry." << endl
+      << "Example: " << prog_name
+      << " --flagfile master/conf/server.conf list_all_masters" << endl
+      << endl
       << "<operation> must be one of:" << endl;
 
   for (size_t i = 0; i < commands_.size(); ++i) {


### PR DESCRIPTION
## Summary

Historically, we’ve had the `-flagfile` option for the `yb-admin` command. While it used to be a bit **buggy[1]**, it now works perfectly, even with TLS enabled.

Typically, yb-admin is the only command that requires a long string of all the master_addresses. With the --flagfile option working smoothly, it can now automatically load those certificates and configs for you. 

Additionally, while yb-ts-cli is usually run per server (meaning we can just pass a single host like `hostname -i`), the --flagfile option can be used there too to handle certs automatically.
See it in action below:

```
[yugabyte@yb-node-1 ~]$ tserver/bin/yb-admin --flagfile master/conf/server.conf list_all_masters
Master UUID                      	RPC Host/Port        	State    	Role 	Broadcast Host/Port
fdf80dffa0a54a94a8de9e606e0fbd82 	192.0.2.11:7100     	ALIVE    	LEADER 	N/A

[yugabyte@yb-node-1 ~]$ tserver/bin/yb-ts-cli -server_address `hostname -i` list_master_servers --flagfile tserver/conf/server.conf
RPC Host/Port		Role
192.0.2.11:7100		Leader

# ============

[yugabyte@yb-node-1 ~]$ cp master/conf/server.conf /tmp/

[yugabyte@yb-node-1 ~]$ tserver/bin/yb-admin --flagfile /tmp/server.conf list_all_masters
Master UUID                      	RPC Host/Port        	State    	Role 	Broadcast Host/Port
fdf80dffa0a54a94a8de9e606e0fbd82 	192.0.2.11:7100     	ALIVE    	LEADER 	N/A
```

Notice I am not providing --certs_dir_name anywhere.

#### So the only action items remains is: 
 
- Documents the existing `--flagfile` option in yb-admin's usage/help text
- Operators can use `--flagfile master/conf/server.conf` to automatically load `master_addresses` and `certs_dir`, avoiding manual flag entry and syntax errors
- Adds a concrete usage example to the help output

Jira: [DB-17917](https://yugabyte.atlassian.net/browse/DB-17917)

## Testing done.

- [x] The flag itself works as pointed above in example.
- [x] Build yb-admin and verify `yb-admin --help` shows the new `--flagfile` documentation

```
./build/latest/bin/yb-admin 2>&1 | head -15
yb-admin: ./build/latest/bin/yb-admin [--master_addresses server1:port,server2:port,server3:port,...]  [--timeout_ms <millisec>] [--certs_dir_name <dir_name>]
  [--flagfile <path/to/master/conf/server.conf>]
  <operation>

Tip: Use --flagfile with the master's server.conf to automatically pick up
master_addresses and certs_dir, avoiding manual flag entry.
Example: ./build/latest/bin/yb-admin --flagfile master/conf/server.conf list_all_masters

<operation> must be one of:
 1. change_config <tablet_id> <ADD_SERVER|REMOVE_SERVER> <peer_uuid> [PRE_VOTER|PRE_OBSERVER]
 2. list_tablet_servers <tablet_id>
 3. backfill_indexes_for_table <table>
 4. list_tables [include_db_type] [include_table_id] [include_table_type]
 5. list_tables_with_db_types
 6. list_tablets <table> [<max_tablets>] (default 10, set 0 for max) [JSON] [include_followers]
```
- [x] Verify `yb-admin --flagfile master/conf/server.conf list_all_masters` works on a TLS-enabled cluster



---
**[1] Why this was buggy in previous versions**

This is a **TLS flag mismatch**, not a master-discovery or connectivity bug.

command:

```sh
tserver/bin/yb-admin --flagfile master/conf/server.conf list_all_masters
```

loads `master/conf/server.conf`, which sets the **server** flag:

```sh
--certs_dir=/home/yugabyte/yugabyte-tls-config
--use_client_to_server_encryption=true
--use_node_to_node_encryption=true
```

But in **2024.2**, `yb-admin` only enables TLS when **`--certs_dir_name`** is set, it does **not** read `--certs_dir` from the flagfile.

### 2024.2 code (only checks `certs_dir_name`)

```617:622:src/yb/tools/yb-admin_client.cc
  if (!FLAGS_certs_dir_name.empty()) {
  ...
    secure_context_ = VERIFY_RESULT(rpc::CreateSecureContext(
        FLAGS_certs_dir_name, rpc::UseClientCerts(!cert_name.empty()), cert_name));
```

`--certs_dir` is a different gflag (defined in `src/yb/rpc/secure.cc` for servers). Gflags will parse it from the flagfile, but `yb-admin` ignores it for client TLS setup.

### What happens at runtime

1. `master_addresses` from the flagfile **does** work — you can see it trying all three masters.
2. `certs_dir` is parsed into `FLAGS_certs_dir`, but **not used** for the client secure context.
3. `yb-admin` connects **without TLS**.
4. Masters have `use_client_to_server_encryption=true` → they drop the plain connection during handshake.
5. Result: `recvmsg got EOF from remote` and the misleading hint about `--certs_dir_name`.

---

## The fix (2025.2+)

**[[DB-17900](https://yugabyte.atlassian.net/browse/DB-17900)]** — commit [c0b84c779a](https://github.com/yugabyte/yugabyte-db/commit/c0b84c779aad8aa8caad835da79a338a2c3cc872) (Phorge [D45974](https://phorge.dev.yugabyte.com/D45974)), merged Aug 2025:

> *"yb-admin and yb-ts-cli can only specify the certs directory with certs_dir_name, but certs_dir shows up in the help text and could also be used."*

New shared helper in `src/yb/tools/tools_utils.cc`:

```31:36:src/yb/tools/tools_utils.cc
  auto certs_dir_name = FLAGS_certs_dir_name;
  if (certs_dir_name.empty()) {
    certs_dir_name = FLAGS_certs_dir;
  }
  if (certs_dir_name.empty()) {
    return nullptr;
```

So when you pass `--flagfile master/conf/server.conf`, `--certs_dir` is picked up and TLS works.

### Release branch presence

| Branch | Has fix? |
|--------|----------|
| `2024.2.x` | **No** |
| `2025.1.x` | **No** |
| `2025.2.0+` | **Yes** |
| `2026.1` | **Yes** |

If you tested **2025.1** and it still failed, that matches the code as the fix landed in **2025.2.0**, not 2025.1.

---

## Workaround on 2024.2

Pass `--certs_dir_name` explicitly (this is what the docs and YBA use):

```sh
tserver/bin/yb-admin \
  --flagfile master/conf/server.conf \
  --certs_dir_name /home/yugabyte/yugabyte-tls-config \
  list_all_masters
```

Or the documented form:

```sh
~/master/bin/yb-admin \
  --master_addresses <master1:7100,master2:7100,master3:7100> \
  --certs_dir_name ~/yugabyte-tls-config \
  list_all_masters
```

[DB-17900]: https://yugabyte.atlassian.net/browse/DB-17900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DB-17917]: https://yugabyte.atlassian.net/browse/DB-17917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
