### PR TITLE
[BACKPORT 2026.1][#32161] CDCSDK: Allow concurrent sessions to tag writes with same origin  (#30907)

### DIFF
--- a/java/yb-pgsql/src/test/java/org/yb/pgsql/TestPgReplicationSlot.java
+++ b/java/yb-pgsql/src/test/java/org/yb/pgsql/TestPgReplicationSlot.java
@@ -5052,6 +5052,133 @@ public class TestPgReplicationSlot extends BasePgSQLTest {
   }
 
   @Test
+  public void testPgoutputWithSharedOriginId() throws Exception {
+    final String slotName = "test_replication_with_shared_origin_id";
+    final String originId1 = "shared_origin1";
+    final String originId2 = "shared_origin2";
+
+    Connection replConn = getConnectionBuilder().withTServer(0).replicationConnect();
+    PGReplicationConnection replConnection =
+        replConn.unwrap(PGConnection.class).getReplicationAPI();
+    Connection conn2 = getConnectionBuilder().withTServer(1).connect();
+
+    try (Statement stmt1 = connection.createStatement();
+         Statement stmt2 = conn2.createStatement()) {
+      stmt1.execute("DROP TABLE IF EXISTS shared_origin_tbl1");
+      stmt1.execute("DROP TABLE IF EXISTS shared_origin_tbl2");
+      stmt1.execute("CREATE TABLE shared_origin_tbl1 (a INT PRIMARY KEY, b TEXT)");
+      stmt1.execute("ALTER TABLE shared_origin_tbl1 REPLICA IDENTITY DEFAULT");
+      stmt1.execute("CREATE TABLE shared_origin_tbl2 (a INT PRIMARY KEY, b TEXT)");
+      stmt1.execute("ALTER TABLE shared_origin_tbl2 REPLICA IDENTITY DEFAULT");
+      stmt1.execute("CREATE PUBLICATION shared_origin_pub FOR ALL TABLES");
+
+      stmt1.execute("SELECT pg_replication_origin_create('" + originId1 + "')");
+      stmt1.execute("SELECT pg_replication_origin_create('" + originId2 + "')");
+      stmt1.execute("CREATE ROLE shared_origin_non_su LOGIN PASSWORD 'pwd'");
+      createSlot(replConnection, slotName, PG_OUTPUT_PLUGIN_NAME);
+
+      try (Connection nonSuConn = getConnectionBuilder()
+               .withUser("shared_origin_non_su").withPassword("pwd").connect();
+           Statement nonSuStmt = nonSuConn.createStatement()) {
+        runInvalidQuery(
+            nonSuStmt,
+            "SELECT yb_replication_origin_session_setup_shared('" + originId1 + "')",
+            "permission denied for function yb_replication_origin_session_setup_shared");
+        runInvalidQuery(
+            nonSuStmt,
+            "SELECT yb_replication_origin_session_reset_shared()",
+            "permission denied for function yb_replication_origin_session_reset_shared");
+      }
+
+      stmt1.execute("SELECT yb_replication_origin_session_setup_shared('" + originId1 + "')");
+      stmt2.execute("SELECT yb_replication_origin_session_setup_shared('" + originId2 + "')");
+
+      runInvalidQuery(
+          stmt1,
+          "SELECT pg_replication_origin_session_setup('" + originId2 + "')",
+          "replication origin session already setup");
+      runInvalidQuery(
+          stmt1,
+          "SELECT yb_replication_origin_session_setup_shared('" + originId2 + "')",
+          "replication origin session already setup");
+
+      stmt1.execute("CREATE TEMP TABLE shared_origin_temp(i int)");
+      stmt1.execute("INSERT INTO shared_origin_temp VALUES (1)");
+      stmt1.execute("DROP TABLE shared_origin_temp");
+      stmt1.execute("INSERT INTO shared_origin_tbl1 values (1, 'from_origin1')");
+      stmt2.execute("INSERT INTO shared_origin_tbl2 values (2, 'from_origin2')");
+
+      stmt1.execute("SELECT yb_replication_origin_session_reset_shared()");
+      stmt2.execute("SELECT yb_replication_origin_session_reset_shared()");
+      stmt1.execute("INSERT INTO shared_origin_tbl1 values (3, 'local_after_reset')");
+
+      stmt1.execute("SELECT pg_replication_origin_session_setup('" + originId1 + "')");
+      runInvalidQuery(
+          stmt1,
+          "SELECT yb_replication_origin_session_setup_shared('" + originId2 + "')",
+          "cannot use shared replication origin session while an exclusive one is active");
+      runInvalidQuery(
+          stmt1,
+          "SELECT yb_replication_origin_session_reset_shared()",
+          "cannot reset shared replication origin session while an exclusive one is active");
+      stmt1.execute("SELECT pg_replication_origin_session_reset()");
+
+    }
+
+    PGReplicationStream stream = replConnection.replicationStream()
+                                     .logical()
+                                     .withSlotName(slotName)
+                                     .withStartPosition(LogSequenceNumber.valueOf(0L))
+                                     .withSlotOption("proto_version", 1)
+                                     .withSlotOption("publication_names", "shared_origin_pub")
+                                     .start();
+
+    List<PgOutputMessage> result = receiveMessage(stream, 13);
+    int originMessages = 0;
+    int origin1Messages = 0;
+    int origin2Messages = 0;
+    for (PgOutputMessage message : result) {
+      if (message.messageType() == PgOutputMessageType.ORIGIN) {
+        originMessages++;
+      }
+      if (message.equals(PgOutputOriginMessage.Create(originId1))) {
+        origin1Messages++;
+      }
+      if (message.equals(PgOutputOriginMessage.Create(originId2))) {
+        origin2Messages++;
+      }
+    }
+    assertEquals(2, originMessages);
+    assertEquals(1, origin1Messages);
+    assertEquals(1, origin2Messages);
+
+    stream.close();
+    conn2.close();
+    replConn.close();
+  }
+
+  @Test
+  public void testSharedOriginIdDisabled() throws Exception {
+    Map<String, String> tserverFlags = getTServerFlags();
+    appendToYsqlPgConf(tserverFlags, "yb_enable_replication_origin_shared=false");
+    restartClusterWithFlags(getMasterFlags(), tserverFlags);
+
+    try (Statement stmt = connection.createStatement()) {
+      stmt.execute("SELECT pg_replication_origin_create('disabled_shared_origin')");
+      runInvalidQuery(
+          stmt,
+          "SELECT yb_replication_origin_session_setup_shared('disabled_shared_origin')",
+          "yb_replication_origin_session_setup_shared requires "
+              + "yb_enable_replication_origin_shared to be enabled");
+      runInvalidQuery(
+          stmt,
+          "SELECT yb_replication_origin_session_reset_shared()",
+          "yb_replication_origin_session_reset_shared requires "
+              + "yb_enable_replication_origin_shared to be enabled");
+    }
+  }
+
+  @Test
   public void testYboutputWithOriginIdCreatedAfterSlot() throws Exception {
     final String slotName = "test_replication_with_origin_id_post_slot";
     final String originId1 = "origin1_post";

--- a/src/postgres/src/backend/catalog/system_functions.sql
+++ b/src/postgres/src/backend/catalog/system_functions.sql
@@ -687,7 +687,11 @@ REVOKE EXECUTE ON FUNCTION pg_replication_origin_session_progress(boolean) FROM 
 
 REVOKE EXECUTE ON FUNCTION pg_replication_origin_session_reset() FROM public;
 
+REVOKE EXECUTE ON FUNCTION yb_replication_origin_session_reset_shared() FROM public;
+
 REVOKE EXECUTE ON FUNCTION pg_replication_origin_session_setup(text) FROM public;
+
+REVOKE EXECUTE ON FUNCTION yb_replication_origin_session_setup_shared(text) FROM public;
 
 REVOKE EXECUTE ON FUNCTION pg_replication_origin_xact_reset() FROM public;
 

--- a/src/postgres/src/backend/replication/logical/origin.c
+++ b/src/postgres/src/backend/replication/logical/origin.c
@@ -1233,6 +1233,10 @@ replorigin_session_reset(void)
 void
 replorigin_session_advance(XLogRecPtr remote_commit, XLogRecPtr local_commit)
 {
+	/* Shared origin sessions only tag writes and do not track progress. */
+	if (yb_enable_replication_origin_shared && session_replication_state == NULL)
+		return;
+
 	Assert(session_replication_state != NULL);
 	Assert(session_replication_state->roident != InvalidRepOriginId);
 
@@ -1364,12 +1368,62 @@ pg_replication_origin_session_setup(PG_FUNCTION_ARGS)
 	RepOriginId origin;
 
 	replorigin_check_prerequisites(true, false);
+	if (yb_enable_replication_origin_shared &&
+		session_replication_state == NULL &&
+		replorigin_session_origin != InvalidRepOriginId)
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_IN_USE),
+				 errmsg("replication origin session already setup")));
 
 	name = text_to_cstring((text *) DatumGetPointer(PG_GETARG_DATUM(0)));
 	origin = replorigin_by_name(name, false);
 	replorigin_session_setup(origin);
 
 	replorigin_session_origin = origin;
+
+	pfree(name);
+
+	PG_RETURN_VOID();
+}
+
+/*
+ * Setup a replication origin for this session without acquiring an exclusive
+ * slot. This allows multiple sessions to tag their writes with the same
+ * xrepl_origin_id concurrently. No progress tracking is performed. This is
+ * only suitable for write tagging (e.g., CDC origin filtering).
+ */
+Datum
+yb_replication_origin_session_setup_shared(PG_FUNCTION_ARGS)
+{
+	char	   *name;
+	RepOriginId origin;
+
+	if (!yb_enable_replication_origin_shared)
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("yb_replication_origin_session_setup_shared requires yb_enable_replication_origin_shared to be enabled")));
+
+	replorigin_check_prerequisites(true, false);
+
+	if (session_replication_state != NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_IN_USE),
+				 errmsg("cannot use shared replication origin session while an exclusive one is active")));
+
+	if (replorigin_session_origin != InvalidRepOriginId)
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_IN_USE),
+				 errmsg("replication origin session already setup")));
+
+	name = text_to_cstring((text *) DatumGetPointer(PG_GETARG_DATUM(0)));
+	origin = replorigin_by_name(name, false);
+
+	replorigin_session_origin = origin;
+	if (YbIsClientYsqlConnMgr())
+	{
+		elog(LOG, "Incrementing sticky object count for setting shared replication origin in session");
+		increment_sticky_object_count();
+	}
 
 	pfree(name);
 
@@ -1385,6 +1439,37 @@ pg_replication_origin_session_reset(PG_FUNCTION_ARGS)
 	replorigin_check_prerequisites(true, false);
 
 	replorigin_session_reset();
+
+	replorigin_session_origin = InvalidRepOriginId;
+	replorigin_session_origin_lsn = InvalidXLogRecPtr;
+	replorigin_session_origin_timestamp = 0;
+
+	PG_RETURN_VOID();
+}
+
+/*
+ * Reset a shared replication origin previously set with
+ * yb_replication_origin_session_setup_shared(). Simply clears the
+ * session variable without touching shared-memory slots.
+ */
+Datum
+yb_replication_origin_session_reset_shared(PG_FUNCTION_ARGS)
+{
+	if (!yb_enable_replication_origin_shared)
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("yb_replication_origin_session_reset_shared requires yb_enable_replication_origin_shared to be enabled")));
+
+	if (session_replication_state != NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_IN_USE),
+				 errmsg("cannot reset shared replication origin session while an exclusive one is active"),
+				 errhint("Use pg_replication_origin_session_reset() instead.")));
+
+	if (replorigin_session_origin == InvalidRepOriginId)
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("no replication origin is setup for this session")));
 
 	replorigin_session_origin = InvalidRepOriginId;
 	replorigin_session_origin_lsn = InvalidXLogRecPtr;

--- a/src/postgres/src/backend/utils/misc/guc.c
+++ b/src/postgres/src/backend/utils/misc/guc.c
@@ -3359,6 +3359,17 @@ static struct config_bool ConfigureNamesBool[] =
 	},
 
 	{
+		{"yb_enable_replication_origin_shared", PGC_POSTMASTER, DEVELOPER_OPTIONS,
+			gettext_noop("Enable shared replication origin write tagging."),
+			NULL,
+			GUC_NOT_IN_SAMPLE
+		},
+		&yb_enable_replication_origin_shared,
+		true,
+		NULL, NULL, NULL
+	},
+
+	{
 		{"yb_ddl_transaction_block_enabled", PGC_POSTMASTER, DEVELOPER_OPTIONS,
 			gettext_noop("If true, DDL operations in YSQL will execute within "
 						 "the active transaction block instead of their "

--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -2336,6 +2336,8 @@ int			yb_test_reset_retry_counts = -1;
 bool		yb_enable_ddl_atomicity_infra = true;
 bool		yb_ddl_rollback_enabled = false;
 
+bool		yb_enable_replication_origin_shared = true;
+
 bool		yb_use_hash_splitting_by_default = true;
 
 bool		yb_xcluster_automatic_mode_target_ddl = false;

--- a/src/postgres/src/include/catalog/pg_proc.dat
+++ b/src/postgres/src/include/catalog/pg_proc.dat
@@ -11602,6 +11602,18 @@
   proparallel => 'u', prorettype => 'void', proargtypes => 'text',
   prosrc => 'pg_replication_origin_session_setup' },
 
+{ oid => '8894',
+  descr => 'set session replication origin without exclusive lock (for concurrent write tagging)',
+  proname => 'yb_replication_origin_session_setup_shared', provolatile => 'v',
+  proparallel => 'u', prorettype => 'void', proargtypes => 'text',
+  prosrc => 'yb_replication_origin_session_setup_shared' },
+
+{ oid => '8895',
+  descr => 'reset shared replication origin set by yb_replication_origin_session_setup_shared',
+  proname => 'yb_replication_origin_session_reset_shared', provolatile => 'v',
+  proparallel => 'u', prorettype => 'void', proargtypes => '',
+  prosrc => 'yb_replication_origin_session_reset_shared' },
+
 { oid => '6007', descr => 'teardown configured replication progress tracking',
   proname => 'pg_replication_origin_session_reset', provolatile => 'v',
   proparallel => 'u', prorettype => 'void', proargtypes => '',

--- a/src/postgres/src/include/catalog/pg_yb_migration.dat
+++ b/src/postgres/src/include/catalog/pg_yb_migration.dat
@@ -12,6 +12,7 @@
 [
 
 # For better version control conflict detection, list latest migration filename
-# here: V101.2__30642__update_yb_tablet_metadata.sql
-{ major => '101', minor => '2', name => '<baseline>', time_applied => '_null_' }
+# here: V102__30907__pg_replication_origin_shared.sql
+{ major => '102', minor => '0', name => '<baseline>', time_applied => '_null_' }
+
 ]

--- a/src/postgres/src/include/pg_yb_utils.h
+++ b/src/postgres/src/include/pg_yb_utils.h
@@ -865,6 +865,9 @@ extern int	yb_test_reset_retry_counts;
 */
 extern bool yb_enable_ddl_atomicity_infra;
 
+/* Enable shared replication origin write tagging. */
+extern bool yb_enable_replication_origin_shared;
+
 /*
  * Allow to return to the client SQL status codes defined by YugabyteDB (YBxxx).
  * Those codes are used internally to determine if transparent retry is

--- a/src/yb/integration-tests/cdcsdk_ysql-test.cc
+++ b/src/yb/integration-tests/cdcsdk_ysql-test.cc
@@ -13196,6 +13196,46 @@ TEST_F(CDCSDKYsqlTest, TestOriginId) {
   cdc_sdk_checkpoint = change_resp.cdc_sdk_checkpoint();
 }
 
+TEST_F(CDCSDKYsqlTest, TestSharedOriginIdFromConcurrentSessions) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_yb_enable_cdc_consistent_snapshot_streams) = true;
+  ASSERT_OK(SetUpWithParams(1 /* rf */, 1 /* num_masters*/));
+  const auto kOrigin = "shared_origin";
+  auto conn1 = ASSERT_RESULT(test_cluster_.ConnectToDB(test_namespace_name));
+
+  ASSERT_OK(conn1.FetchFormat("SELECT pg_replication_origin_create('$0');", kOrigin));
+  auto conn2 = ASSERT_RESULT(test_cluster_.ConnectToDB(test_namespace_name));
+
+  auto table = ASSERT_RESULT(CreateTable(&test_cluster_, test_namespace_name, kTableName));
+  google::protobuf::RepeatedPtrField<master::TabletLocationsPB> tablets;
+  ASSERT_OK(test_client()->GetTablets(table, 0, &tablets, nullptr));
+  ASSERT_EQ(tablets.size(), 1);
+  auto stream_id = ASSERT_RESULT(CreateConsistentSnapshotStream());
+
+  ASSERT_OK(conn1.FetchFormat("SELECT yb_replication_origin_session_setup_shared('$0');", kOrigin));
+  ASSERT_OK(conn2.FetchFormat("SELECT yb_replication_origin_session_setup_shared('$0');", kOrigin));
+  ASSERT_OK(conn1.Execute("CREATE TEMP TABLE shared_origin_temp(i int)"));
+  ASSERT_OK(conn1.Execute("INSERT INTO shared_origin_temp VALUES (1)"));
+  ASSERT_OK(conn1.Execute("DROP TABLE shared_origin_temp"));
+  ASSERT_OK(conn1.ExecuteFormat("INSERT INTO $0 VALUES (1, 100)", kTableName));
+  ASSERT_OK(conn2.ExecuteFormat("INSERT INTO $0 VALUES (2, 200)", kTableName));
+  ASSERT_OK(conn1.Fetch("SELECT yb_replication_origin_session_reset_shared()"));
+  ASSERT_OK(conn2.Fetch("SELECT yb_replication_origin_session_reset_shared()"));
+
+  auto change_resp = ASSERT_RESULT(GetChangesFromCDC(stream_id, tablets));
+  LOG(INFO) << "CDC response: " << change_resp.ShortDebugString();
+  auto seen_inserts = 0;
+  for (const auto& record : change_resp.cdc_sdk_proto_records()) {
+    if (record.row_message().op() != RowMessage::INSERT) {
+      continue;
+    }
+
+    ASSERT_TRUE(record.row_message().has_xrepl_origin_id());
+    ASSERT_EQ(record.row_message().xrepl_origin_id(), 1);
+    seen_inserts++;
+  }
+  ASSERT_EQ(seen_inserts, 2);
+}
+
 TEST_F(CDCSDKYsqlTest, TestOriginIdOnDMLRecords) {
   ASSERT_OK(SetUpWithParams(1 /* rf */, 1 /* num_masters*/));
   const auto kOrigin1 = "origin1";

--- a/src/yb/yql/pgwrapper/ysql_migrations/V102__30907__pg_replication_origin_shared.sql
+++ b/src/yb/yql/pgwrapper/ysql_migrations/V102__30907__pg_replication_origin_shared.sql
@@ -1,0 +1,33 @@
+BEGIN;
+  SET LOCAL yb_non_ddl_txn_for_sys_tables_allowed TO true;
+
+  INSERT INTO pg_catalog.pg_proc (
+    oid, proname, pronamespace, proowner, prolang, procost, prorows, provariadic,
+    prosupport, prokind, prosecdef, proleakproof, proisstrict, proretset,
+    provolatile, proparallel, pronargs, pronargdefaults, prorettype, proargtypes,
+    proallargtypes, proargmodes, proargnames, proargdefaults, protrftypes,
+    prosrc, probin, prosqlbody, proconfig, proacl) VALUES
+    (8894, 'yb_replication_origin_session_setup_shared', 11, 10, 12, 1, 0, 0,
+     '-', 'f', false, false, true, false, 'v', 'u', 1, 0, 2278, '25',
+     NULL, NULL, NULL, NULL, NULL,
+     'yb_replication_origin_session_setup_shared', NULL, NULL, NULL, '{postgres=X/postgres}'),
+    (8895, 'yb_replication_origin_session_reset_shared', 11, 10, 12, 1, 0, 0,
+     '-', 'f', false, false, true, false, 'v', 'u', 0, 0, 2278, '',
+     NULL, NULL, NULL, NULL, NULL,
+     'yb_replication_origin_session_reset_shared', NULL, NULL, NULL, '{postgres=X/postgres}')
+  ON CONFLICT DO NOTHING;
+
+  INSERT INTO pg_catalog.pg_description (
+    objoid, classoid, objsubid, description
+  ) VALUES
+    (8894, 1255, 0, 'set session replication origin without exclusive lock (for concurrent write tagging)'),
+    (8895, 1255, 0, 'reset shared replication origin set by yb_replication_origin_session_setup_shared')
+  ON CONFLICT DO NOTHING;
+
+  INSERT INTO pg_catalog.pg_init_privs (
+    objoid, classoid, objsubid, privtype, initprivs
+  ) VALUES
+    (8894, 1255, 0, 'i', '{postgres=X/postgres}'),
+    (8895, 1255, 0, 'i', '{postgres=X/postgres}')
+  ON CONFLICT DO NOTHING;
+COMMIT;


### PR DESCRIPTION
## Summary

Adds YB-specific shared replication-origin session helpers for CDCSDK
write tagging:

- `yb_replication_origin_session_setup_shared(text)`
- `yb_replication_origin_session_reset_shared()`

These functions let multiple sessions tag writes with replication
origins concurrently without acquiring exclusive replication-origin
progress slots. The tagged writes carry `xrepl_origin_id` in CDC
records, while replication-origin progress tracking remains
exclusive-session behavior.

Fixes #32161.

## Problem

`pg_replication_origin_session_setup(text)` acquires an exclusive
replication-origin progress slot in shared memory. That is required for
logical-replication replay because the session advances replay progress,
but it is too restrictive for CDCSDK write tagging.

For CDC origin filtering, multiple writer sessions may need to tag their
writes with the same origin ID so downstream CDC consumers can identify
and filter those writes. They do not need to own or advance the origin's
replication progress.

With the existing exclusive setup path, only one session can use a given
origin at a time. Other sessions fail with:

```text
ERROR: replication origin with ID <origin_id> is already active for PID <other_pid> (SQLSTATE 55006)
```

## Solution

Add shared-origin session helpers for the write-tagging use case:

### `yb_replication_origin_session_setup_shared(text)`

Sets the current session's replication origin for CDC write tagging
without acquiring an exclusive progress slot.

Behavior:

- Validates that the origin exists.
- Sets the backend-local `replorigin_session_origin` used to stamp
`xrepl_origin_id` on writes.
- Does not call `replorigin_session_setup()` and does not acquire a
shared-memory progress slot.
- Allows multiple sessions to use the same origin concurrently.
- Rejects duplicate setup in the same session.
- Rejects setup if an exclusive replication-origin session is already
active.
- Keeps YSQL connection-manager sessions sticky while shared-origin
state is active.

### `yb_replication_origin_session_reset_shared()`

Clears shared-origin state for the current session without touching
shared-memory progress slots.

Behavior:

- Rejects reset if no replication origin is active in the session.
- Rejects reset if an exclusive replication-origin session is active;
callers must use `pg_replication_origin_session_reset()` for that case.
- Clears origin LSN/timestamp session state along with the origin ID.

## Guardrails

- Shared-origin behavior is gated by default-on GUC
`yb_enable_replication_origin_shared`.
- When the GUC is disabled, both shared setup/reset functions error
without changing session state.
- Existing `pg_replication_origin_session_setup()` /
`pg_replication_origin_session_reset()` remain the exclusive
progress-tracking APIs.
- Shared-to-exclusive, exclusive-to-shared, shared-to-shared, and reset
mismatch cases fail cleanly instead of silently clobbering session
state.

## Catalog And Upgrade

- Adds catalog entries for OIDs `8894` and `8895`.
- Adds `REVOKE EXECUTE` entries so the new functions are not executable
by `PUBLIC`, matching existing `pg_replication_origin_*` functions.
- Adds YSQL migration `V104__30907__pg_replication_origin_shared.sql` so
upgraded clusters get the new functions, descriptions, and initial
privileges.
- Migration rows set `proisstrict = true`, matching fresh initdb catalog
behavior.

## Usage

```sql
-- Create the origin once.
SELECT pg_replication_origin_create('my_origin');

-- On each writer session. Safe for multiple sessions concurrently.
SELECT yb_replication_origin_session_setup_shared('my_origin');

-- Subsequent writes on this session carry xrepl_origin_id.
INSERT INTO ...;

-- Clear the origin for this session.
SELECT yb_replication_origin_session_reset_shared();
```

Original commit: 9b08b0010cf1c911b2e25367c955c7af5babd0e2 / #30907