### PR TITLE
[#32296] YSQL: Fix TestConnectionManagerBoundedStaleness expected RPC count

### DIFF
--- a/src/yb/yql/pgwrapper/pg_catalog_version-test.cc
+++ b/src/yb/yql/pgwrapper/pg_catalog_version-test.cc
@@ -3373,11 +3373,15 @@ TEST_P(PgCatalogVersionConnManagerTest,
             << ", master_read_count_after: " << master_read_count_after;
 
   if (enable_ysql_conn_mgr) {
-    // CM auth-passthrough serves auth from the cache and does no relcache rebuild
-    // during auth, so the loop's master reads come only from rebuilding the
-    // expired auth-phase cache entry: 0 when object locking already warmed it at
-    // v_new before the loop, else 1.
-    const int num_rebuild_rpcs = IsObjectLockingEnabled() ? 0 : 1;
+    // CM auth-passthrough serves auth from the cache and does no relcache
+    // rebuild during auth. With object locking the relcache init file is already
+    // warm at v_new before the loop, so the loop sees no master reads (0).
+    // Without object locking the init file is stale when the loop runs and --
+    // via the #31844 yb_internal_conn routing -- a single dedicated
+    // relcache-init connection rebuilds it once for all conn-mgr backends rather
+    // than each rebuilding it inline; that rebuild (1 master RPC) plus the
+    // auth-phase pg_authid read (1) give 2.
+    const int num_rebuild_rpcs = IsObjectLockingEnabled() ? 0 : 2;
     ASSERT_EQ(master_read_count_before + num_rebuild_rpcs,
               master_read_count_after);
   }


### PR DESCRIPTION
## Summary

`PgCatalogVersionConnManagerTest.TestConnectionManagerBoundedStaleness/1`
(connection manager enabled) fails consistently in the non-object-locking
configs (release / fastdebug / arm-release), tracked as #32296.

It is a stale **test expectation**, not a product bug. The yb_internal_conn
relcache-init routing added in #31844 (D53799) changed how a connection-manager
backend handles a stale relcache init file during the verify loop: instead of
every conn-mgr backend rebuilding the init file inline, a single dedicated
relcache-init connection rebuilds it once for all of them. In the
non-object-locking case that adds exactly one master read inside the measured
window (the dedicated rebuild) on top of the auth-phase `pg_authid` read, so the
loop now observes 2 master RPCs instead of 1.

This is the intended, strictly-better behavior (one builder vs. a thundering
herd of simultaneous inline rebuilds), so this change updates the assertion's
expected count from 1 to 2 (and the accompanying comment) rather than touching
the production path. The extra read is deterministic: verified `116 -> 117`
(+1) across release, fastdebug, and arm-release, all 11 retries. The
object-locking case is unchanged at 0 (the init file is force-refreshed warm
before the loop, so no rebuild happens inside the measured window).

## Test plan

- [ ] `./yb_build.sh release --cxx-test pg_catalog_version-test --gtest_filter 'PgCatalogVersionConnManagerTest.TestConnectionManagerBoundedStaleness*'`
- [ ] `./yb_build.sh fastdebug --cxx-test pg_catalog_version-test --gtest_filter 'PgCatalogVersionConnManagerTest.TestConnectionManagerBoundedStaleness*'`
- [ ] Confirm the `/1` variant (connection manager enabled) passes — this was the consistent failure in #32296.
