### PR TITLE
[#32461] CDC: Support transactional DDL via pg_attribute streaming

### DIFF
--- a/src/yb/cdc/cdc_service.cc
+++ b/src/yb/cdc/cdc_service.cc
@@ -2860,9 +2860,9 @@ Result<bool> CDCServiceImpl::CheckBeforeImageActive(
     // - If the tablet is colocated, we check the replica identities of this tablet's tables which
     // are present in the stream metadata's replica identity map.
     // - If the tablet is sys catalog, we check the replica identities of only tables
-    // 'pg_publication_rel', 'pg_class' & 'pg_replication_origin' residing in it (This is because
-    // currently only these sys catalog tables are part of publication's table list).
-    // If before image is active for any such tables then we should return true.
+    // 'pg_publication_rel', 'pg_class', 'pg_replication_origin' & 'pg_attribute' residing in it
+    // (This is because currently only these sys catalog tables are part of publication's table
+    // list). If before image is active for any such tables then we should return true.
     if (is_colocated_tablet || is_sys_catalog_tablet) {
       auto table_ids = tablet_peer->tablet_metadata()->GetAllColocatedTables();
       bool replica_identity_found_for_any_table = false;
@@ -4876,6 +4876,7 @@ Result<std::vector<TableId>> CDCServiceImpl::GetStreamableCatalogTables(
   table_ids.push_back(GetPgsqlTableId(pg_database_oid, kPgPublicationRelOid));
   table_ids.push_back(GetPgsqlTableId(kTemplate1Oid, kPgReplicationOriginOid));
   table_ids.push_back(GetPgsqlTableId(pg_database_oid, kPgPublicationOid));
+  table_ids.push_back(GetPgsqlTableId(pg_database_oid, kPgAttributeTableOid));
   return table_ids;
 }
 

--- a/src/yb/cdc/cdc_service.h
+++ b/src/yb/cdc/cdc_service.h
@@ -305,8 +305,9 @@ class CDCServiceImpl : public CDCServiceIf {
 
   static bool IsCDCSDKSnapshotBootstrapRequest(const CDCSDKCheckpointPB& req_checkpoint);
 
-  // Returns a list of catalog tables which gets streamed. (Currently 'pg_publication_rel' &
-  // 'pg_class' are the only catalog tables which gets streamed).
+  // Returns a list of catalog tables which gets streamed. (Currently 'pg_publication_rel',
+  // 'pg_class', 'pg_replication_origin', 'pg_publication' & 'pg_attribute' are the catalog tables
+  // which get streamed).
   // 'namespace_id' is the id of namespace on which stream was created.
   static Result<std::vector<TableId>> GetStreamableCatalogTables(const NamespaceId& namespace_id);
 

--- a/src/yb/cdc/cdcsdk_unique_record_id.cc
+++ b/src/yb/cdc/cdcsdk_unique_record_id.cc
@@ -44,10 +44,21 @@ CDCSDKUniqueRecordID::CDCSDKUniqueRecordID(
     this->docdb_txn_id_ = "";
   }
   switch (this->vwal_record_type_) {
-    case VWALRecordType::PUBLICATION_REFRESH: FALLTHROUGH_INTENDED;
-    case VWALRecordType::DDL:
+    case VWALRecordType::PUBLICATION_REFRESH:
       this->record_time_ = 0;
       this->write_id_ = 0;
+      this->table_id_ = record->row_message().table_id();
+      this->primary_key_ = "";
+      break;
+    case VWALRecordType::DDL:
+      // Transactional DDLs constructed from pg_attribute DMLs carry record_time for correct
+      // ordering (commit_time, then record_time). Legacy CHANGE_METADATA DDLs may omit it.
+      this->record_time_ = record->row_message().has_record_time()
+                               ? record->row_message().record_time()
+                               : 0;
+      this->write_id_ = record->has_cdc_sdk_op_id() && record->cdc_sdk_op_id().has_write_id()
+                            ? record->cdc_sdk_op_id().write_id()
+                            : 0;
       this->table_id_ = record->row_message().table_id();
       this->primary_key_ = "";
       break;
@@ -190,16 +201,22 @@ bool CDCSDKUniqueRecordID::HasHigherPriorityThan(
     return this->commit_time_ < other_unique_record_id->commit_time_;
   }
 
-  // DDL records should get the highest priority.
-  if (IsDDLRecordType(this->vwal_record_type_) ||
-      IsDDLRecordType(other_unique_record_id->vwal_record_type_)) {
+  // Transactional DDLs are ordered like DMLs: commit_time then record_time. Only fall back to
+  // the legacy DDL-first tie-break when neither side has a record_time (CHANGE_METADATA DDLs).
+  const bool this_is_ddl = IsDDLRecordType(this->vwal_record_type_);
+  const bool other_is_ddl = IsDDLRecordType(other_unique_record_id->vwal_record_type_);
+  if ((this_is_ddl || other_is_ddl) && this->record_time_ == 0 &&
+      other_unique_record_id->record_time_ == 0) {
     return CompareDDLOrder(other_unique_record_id);
   }
 
-  // If either one of the records being compared is not a BEGIN/COMMIT/DML record then use
+  // If either one of the records being compared is not a BEGIN/COMMIT/DML/DDL record then use
   // vwal_record_type to break the tie.
-  if (!IsBeginOrCommitOrDMLType(this->vwal_record_type_) ||
-      !IsBeginOrCommitOrDMLType(other_unique_record_id->vwal_record_type_)) {
+  const bool this_is_begin_commit_dml_or_ddl =
+      IsBeginOrCommitOrDMLType(this->vwal_record_type_) || this_is_ddl;
+  const bool other_is_begin_commit_dml_or_ddl =
+      IsBeginOrCommitOrDMLType(other_unique_record_id->vwal_record_type_) || other_is_ddl;
+  if (!this_is_begin_commit_dml_or_ddl || !other_is_begin_commit_dml_or_ddl) {
     if (this->vwal_record_type_ != other_unique_record_id->vwal_record_type_) {
       return this->vwal_record_type_ < other_unique_record_id->vwal_record_type_;
     }

--- a/src/yb/cdc/cdcsdk_virtual_wal.cc
+++ b/src/yb/cdc/cdcsdk_virtual_wal.cc
@@ -15,7 +15,9 @@
 #include "yb/cdc/xrepl_stream_metadata.h"
 
 #include "yb/client/client.h"
+#include "yb/client/table_info.h"
 #include "yb/common/entity_ids.h"
+#include "yb/common/schema_pbutil.h"
 
 #include "yb/master/sys_catalog_constants.h"
 
@@ -61,6 +63,10 @@
 
 #define GET_OID_FROM_PG_PUBLICATION_RECORD(record) \
   record->row_message().new_tuple().Get(0).pg_catalog_value().uint32_value()
+
+// attrelid is the first column of pg_attribute (see pg_attribute.h).
+#define GET_ATTRELID_FROM_PG_ATTRIBUTE_TUPLE(tuple) \
+  (tuple).Get(0).pg_catalog_value().uint32_value()
 
 DEFINE_RUNTIME_uint32(cdcsdk_vwal_tablets_to_poll_batch_size, 200,
     "The maximum number of tablets to poll in a single GetConsistentChanges call. If there are "
@@ -242,19 +248,24 @@ Status CDCSDKVirtualWAL::InitVirtualWALInternal(
     pub_all_tables_ = pub_all_tables;
     publications_list_ = std::move(publications_list);
 
-    // Add the PG catalog tables to the table_list.
+    // Add the PG catalog tables to the table_list. pg_attribute is streamed so transactional DDLs
+    // can be detected from catalog DMLs. The other catalog tables are used for publication /
+    // replication-origin change detection.
     auto namespace_id = stream->GetNamespaceId();
     auto pg_database_oid = VERIFY_RESULT(GetPgsqlDatabaseOid(namespace_id));
     pg_class_table_id_ = GetPgsqlTableId(pg_database_oid, kPgClassTableOid);
     pg_publication_rel_table_id_ = GetPgsqlTableId(pg_database_oid, kPgPublicationRelOid);
     pg_replication_origin_table_id_ = GetPgsqlTableId(kTemplate1Oid, kPgReplicationOriginOid);
     pg_publication_table_id_ = GetPgsqlTableId(pg_database_oid, kPgPublicationOid);
+    pg_attribute_table_id_ = GetPgsqlTableId(pg_database_oid, kPgAttributeTableOid);
     table_list.emplace(pg_class_table_id_);
     table_list.emplace(pg_publication_rel_table_id_);
     table_list.emplace(pg_replication_origin_table_id_);
     table_list.emplace(pg_publication_table_id_);
+    table_list.emplace(pg_attribute_table_id_);
     VLOG_WITH_PREFIX(1) << "Successfully added the catalog tables pg_class, pg_publication_rel, "
-                           "pg_replication_origin and pg_publication to the polling list.";
+                           "pg_replication_origin, pg_publication and pg_attribute to the polling "
+                           "list.";
   }
 
   if (FLAGS_enable_table_rewrite_for_cdcsdk_table) {
@@ -637,6 +648,27 @@ Status CDCSDKVirtualWAL::GetConsistentChangesInternal(
     auto record = tablet_record_info_pair.second.second;
 
     if (tablet_id == master::kSysCatalogTabletId) {
+      // Convert DMLs on pg_attribute into DDL records for transactional DDL support.
+      if (!pg_attribute_table_id_.empty() &&
+          record->row_message().table_id() == pg_attribute_table_id_) {
+        auto ddl_record_result = ConstructDDLRecordFromPgAttributeDML(record);
+        if (!ddl_record_result.ok()) {
+          VLOG_WITH_PREFIX(2) << "Failed to construct DDL from pg_attribute DML: "
+                              << ddl_record_result.status()
+                              << ", record: " << record->ShortDebugString();
+          continue;
+        }
+        if (*ddl_record_result) {
+          auto records = resp->add_cdc_sdk_proto_records();
+          VLOG_WITH_PREFIX(1) << "Shipping transactional DDL record constructed from pg_attribute: "
+                              << (*ddl_record_result)->ShortDebugString();
+          last_seen_ddl_commit_time_ = HybridTime((*ddl_record_result)->row_message().commit_time());
+          records->CopyFrom(**ddl_record_result);
+          metadata.ddl_records++;
+        }
+        continue;
+      }
+
       bool explicit_alter_pub_detected;
       auto pub_refresh_required = DeterminePubRefreshFromMasterRecord(
           tablet_record_info_pair.second, &explicit_alter_pub_detected);
@@ -662,8 +694,15 @@ Status CDCSDKVirtualWAL::GetConsistentChangesInternal(
       continue;
     }
 
-    // Skip generating LSN & txnID for a DDL record and directly add it to the response.
+    // When streaming pg_attribute (transactional DDL mode), DDLs from GetChanges
+    // (CHANGE_METADATA_OP) are not relevant; transactional DDLs are constructed from pg_attribute
+    // DMLs above. Otherwise ship GetChanges DDLs as before.
     if (record->row_message().op() == RowMessage_Op_DDL) {
+      if (!pg_attribute_table_id_.empty()) {
+        VLOG_WITH_PREFIX(2) << "Ignoring DDL record from GetChanges (transactional DDL mode): "
+                            << record->ShortDebugString();
+        continue;
+      }
       auto records = resp->add_cdc_sdk_proto_records();
       VLOG_WITH_PREFIX(1) << "Shipping DDL record: " << record->ShortDebugString();
       last_seen_ddl_commit_time_ = HybridTime(record->row_message().commit_time());
@@ -1049,10 +1088,15 @@ Status CDCSDKVirtualWAL::AddRecordsToTabletQueue(
   std::queue<std::shared_ptr<CDCSDKProtoRecordPB>>& tablet_queue = tablet_queues_[tablet_id];
   if (resp->cdc_sdk_proto_records_size() > 0) {
     for (const auto& record : resp->cdc_sdk_proto_records()) {
-      // cdc_service sends artificially generated DDL records whenever it has a cache miss while
-      // checking for table schema. These DDL records do not have a commit_time value as they does
-      // not correspond to an actual WAL entry. Hence, it is safe to skip them from adding into the
-      // tablet queue.
+      // With transactional DDL (pg_attribute streaming), DDLs are derived from pg_attribute DMLs
+      // in the virtual WAL. Ignore DDL records from GetChanges (schema-cache-miss and
+      // CHANGE_METADATA_OP). Without pg_attribute streaming, only skip artificial DDLs that lack
+      // commit_time.
+      if (record.row_message().op() == RowMessage_Op_DDL && !pg_attribute_table_id_.empty()) {
+        VLOG_WITH_PREFIX(3) << "Filtered DDL record from GetChanges (transactional DDL mode): "
+                            << record.ShortDebugString();
+        continue;
+      }
       if (record.row_message().has_commit_time()) {
         tablet_queue.push(std::make_shared<CDCSDKProtoRecordPB>(record));
       } else {
@@ -1794,7 +1838,116 @@ std::vector<TabletId> CDCSDKVirtualWAL::GetTabletIdsFromVirtualWAL() {
 
 bool CDCSDKVirtualWAL::IsCatalogTableEligibleForCDC(const TableId& table_id) const {
   return table_id == pg_class_table_id_ || table_id == pg_publication_rel_table_id_ ||
-         table_id == pg_replication_origin_table_id_ || table_id == pg_publication_table_id_;
+         table_id == pg_replication_origin_table_id_ || table_id == pg_publication_table_id_ ||
+         table_id == pg_attribute_table_id_;
+}
+
+Result<std::shared_ptr<CDCSDKProtoRecordPB>>
+CDCSDKVirtualWAL::ConstructDDLRecordFromPgAttributeDML(
+    const std::shared_ptr<CDCSDKProtoRecordPB>& attribute_record) {
+  const auto& row_message = attribute_record->row_message();
+  const auto op = row_message.op();
+  if (op != RowMessage_Op_INSERT && op != RowMessage_Op_UPDATE && op != RowMessage_Op_DELETE) {
+    return nullptr;
+  }
+
+  // attrelid is the first column of pg_attribute. Prefer new_tuple for INSERT/UPDATE and
+  // old_tuple for DELETE.
+  const auto& tuple =
+      (op == RowMessage_Op_DELETE) ? row_message.old_tuple() : row_message.new_tuple();
+  if (tuple.empty()) {
+    return STATUS(InvalidArgument, "pg_attribute change record missing tuple data");
+  }
+  const uint32_t attrelid = GET_ATTRELID_FROM_PG_ATTRIBUTE_TUPLE(tuple);
+  if (attrelid == 0) {
+    return nullptr;
+  }
+
+  auto stream = VERIFY_RESULT(cdc_service_->GetStream(stream_id_));
+  const auto namespace_id = stream->GetNamespaceId();
+  const auto pg_database_oid = VERIFY_RESULT(GetPgsqlDatabaseOid(namespace_id));
+  const TableId table_id = GetPgsqlTableId(pg_database_oid, attrelid);
+
+  // Only ship DDLs for tables that are part of the publication (exclude catalog tables).
+  if (!publication_table_list_.contains(table_id) || IsCatalogTableEligibleForCDC(table_id)) {
+    VLOG_WITH_PREFIX(3) << "Skipping pg_attribute DML for table_id not in publication: "
+                        << table_id;
+    return nullptr;
+  }
+
+  // One DDL per (commit_time, table_id); later pg_attribute rows for the same table/txn share
+  // the same commit-time schema.
+  const std::string ddl_key = Format("$0:$1", row_message.commit_time(), table_id);
+  if (shipped_transactional_ddl_keys_.contains(ddl_key)) {
+    return nullptr;
+  }
+
+  auto schema_result =
+      cdc_service_->client()->GetTableSchemaFromSysCatalog(table_id, row_message.commit_time());
+  if (!schema_result.ok()) {
+    // Table may not exist in DocDB yet (e.g. not committed / not a user table).
+    VLOG_WITH_PREFIX(2) << "Could not get schema for table_id " << table_id
+                        << " at commit_time " << row_message.commit_time() << ": "
+                        << schema_result.status();
+    return nullptr;
+  }
+  const Schema& schema = schema_result->first;
+  const uint32_t schema_version = schema_result->second;
+
+  auto table_info_result = cdc_service_->client()->GetYBTableInfoById(table_id, false);
+  TableName table_name;
+  if (table_info_result.ok()) {
+    table_name = table_info_result->table_name.table_name();
+  } else {
+    // Fall back to an empty name if the table metadata is unavailable.
+    VLOG_WITH_PREFIX(2) << "Could not get table name for table_id " << table_id << ": "
+                        << table_info_result.status();
+  }
+
+  auto ddl_record = std::make_shared<CDCSDKProtoRecordPB>();
+  RowMessage* ddl_row_message = ddl_record->mutable_row_message();
+  ddl_row_message->set_op(RowMessage_Op_DDL);
+  ddl_row_message->set_table(table_name);
+  ddl_row_message->set_table_id(table_id);
+  ddl_row_message->set_commit_time(row_message.commit_time());
+  // Preserve record_time from the pg_attribute DML so ordering vs other records is
+  // commit_time then record_time.
+  if (row_message.has_record_time()) {
+    ddl_row_message->set_record_time(row_message.record_time());
+  }
+  if (row_message.has_transaction_id()) {
+    ddl_row_message->set_transaction_id(row_message.transaction_id());
+  }
+  ddl_row_message->set_schema_version(schema_version);
+  const auto& pgschema_name = schema.SchemaName();
+  if (!pgschema_name.empty()) {
+    ddl_row_message->set_pgschema_name(pgschema_name);
+  }
+
+  SchemaPB schema_pb;
+  SchemaToPB(schema, &schema_pb);
+  for (const auto& column : schema_pb.columns()) {
+    CDCSDKColumnInfoPB* column_info = ddl_row_message->mutable_schema()->add_column_info();
+    column_info->set_name(column.name());
+    column_info->mutable_type()->CopyFrom(column.type());
+    column_info->set_is_key(column.is_key());
+    column_info->set_is_hash_key(column.is_hash_key());
+    column_info->set_is_nullable(column.is_nullable());
+    column_info->set_oid(column.pg_type_oid());
+  }
+  CDCSDKTablePropertiesPB* table_properties_pb =
+      ddl_row_message->mutable_schema()->mutable_tab_info();
+  table_properties_pb->set_default_time_to_live(schema_pb.table_properties().default_time_to_live());
+  table_properties_pb->set_num_tablets(schema_pb.table_properties().num_tablets());
+  table_properties_pb->set_is_ysql_catalog_table(
+      schema_pb.table_properties().is_ysql_catalog_table());
+
+  if (attribute_record->has_cdc_sdk_op_id()) {
+    ddl_record->mutable_cdc_sdk_op_id()->CopyFrom(attribute_record->cdc_sdk_op_id());
+  }
+
+  shipped_transactional_ddl_keys_.insert(ddl_key);
+  return ddl_record;
 }
 
 bool CDCSDKVirtualWAL::DeterminePubRefreshFromMasterRecord(
@@ -1857,19 +2010,25 @@ bool CDCSDKVirtualWAL::DeterminePubRefreshFromMasterRecord(
 
     *explicit_alter_publication_detected = true;
     return true;
+  } else if (table_id == pg_attribute_table_id_) {
+    // pg_attribute DMLs are handled separately as transactional DDLs and do not trigger a
+    // publication refresh by themselves.
+    return false;
   }
 
   // We should only receive records corresponding to pg_class, pg_publication_rel,
-  // pg_replication_origin and pg_publication tables. Only possibility of reaching here is when a
-  // DDL record is sent from sys catalog tablet, for ex: when a new slot is created, the existing
-  // slot sees the CHANGE_METADATA_OP used for setting retention barriers and sends a DDL record.
+  // pg_replication_origin, pg_publication and pg_attribute tables. Only possibility of reaching
+  // here is when a DDL record is sent from sys catalog tablet, for ex: when a new slot is created,
+  // the existing slot sees the CHANGE_METADATA_OP used for setting retention barriers and sends a
+  // DDL record.
   LOG_IF(DFATAL, record->row_message().op() != RowMessage_Op_DDL)
       << "Records from an unexpected table: " << table_id
       << " received from sys catalog tablet in virtual WAL."
       << " pg_class_table_id_ = " << pg_class_table_id_
       << " pg_publication_rel_table_id_ = " << pg_publication_rel_table_id_
       << " pg_replication_origin_table_id_ = " << pg_replication_origin_table_id_
-      << " pg_publication_table_id_ = " << pg_publication_table_id_;
+      << " pg_publication_table_id_ = " << pg_publication_table_id_
+      << " pg_attribute_table_id_ = " << pg_attribute_table_id_;
   return false;
 }
 

--- a/src/yb/cdc/cdcsdk_virtual_wal.h
+++ b/src/yb/cdc/cdcsdk_virtual_wal.h
@@ -220,6 +220,12 @@ class CDCSDKVirtualWAL {
 
   bool IsCatalogTableEligibleForCDC(const TableId& table_id) const;
 
+  // Constructs a DDL CDC record from a DML change on pg_attribute for transactional DDL support.
+  // Returns nullptr if the record should be ignored (e.g. non-publication table, duplicate for
+  // the same commit_time/table).
+  Result<std::shared_ptr<CDCSDKProtoRecordPB>> ConstructDDLRecordFromPgAttributeDML(
+      const std::shared_ptr<CDCSDKProtoRecordPB>& attribute_record);
+
   bool ShouldPopulateExplicitCheckpoint();
 
   bool CheckForTableRewriteOrDrop(std::shared_ptr<CDCSDKProtoRecordPB> record);
@@ -370,6 +376,14 @@ class CDCSDKVirtualWAL {
 
   // The table ID of pg_publication catalog table for the database on which virtual WAL is polling.
   TableId pg_publication_table_id_;
+
+  // The table ID of pg_attribute catalog table for the database on which virtual WAL is polling.
+  // Used to detect transactional DDLs.
+  TableId pg_attribute_table_id_;
+
+  // Tracks (commit_time, table_id) pairs for which a transactional DDL record has already been
+  // shipped, so multiple pg_attribute DML rows for the same table/txn only produce one DDL.
+  std::unordered_set<std::string> shipped_transactional_ddl_keys_;
 
   // The list of publication OIDs that are being polled by the virtual WAL.
   std::unordered_set<uint32_t> publications_list_;

--- a/src/yb/integration-tests/cdcsdk_stream-test.cc
+++ b/src/yb/integration-tests/cdcsdk_stream-test.cc
@@ -149,6 +149,7 @@ class CDCSDKStreamTest : public CDCSDKTestBase {
     table_ids.insert(GetPgsqlTableId(pg_database_oid, kPgPublicationRelOid));
     table_ids.insert(GetPgsqlTableId(kTemplate1Oid, kPgReplicationOriginOid));
     table_ids.insert(GetPgsqlTableId(pg_database_oid, kPgPublicationOid));
+    table_ids.insert(GetPgsqlTableId(pg_database_oid, kPgAttributeTableOid));
 
     if (with_table) {
       auto table =
@@ -172,7 +173,7 @@ class CDCSDKStreamTest : public CDCSDKTestBase {
     std::vector<xrepl::StreamId> resp_stream_ids;
     for (uint32_t i = 0; i < num_streams; ++i) {
       if (with_table) {
-        // Since there are four tables (1 user + 3 catalog), all the streams would contain four
+        // Since there are six tables (1 user + 5 catalog), all the streams would contain six
         // table_ids in their response.
         ASSERT_EQ(1 + kNumberOfCatalogTablesBeingPolledByCDC, list_streams.Get(i).table_id_size());
 
@@ -183,7 +184,7 @@ class CDCSDKStreamTest : public CDCSDKTestBase {
           ASSERT_TRUE(table_ids.contains(table_id_in_resp));
         }
       } else {
-        // Since there are no user tables in DB, there would be 3 table_ids (catalog tables) in the
+        // Since there are no user tables in DB, there would be 5 table_ids (catalog tables) in the
         // response.
         ASSERT_EQ(kNumberOfCatalogTablesBeingPolledByCDC, list_streams.Get(i).table_id_size());
       }
@@ -235,6 +236,8 @@ class CDCSDKStreamTest : public CDCSDKTestBase {
         GetPgsqlTableId(kTemplate1Oid, kPgReplicationOriginOid));
     tables_expected_in_stream_metadata.insert(
         GetPgsqlTableId(pg_database_oid, kPgPublicationOid));
+    tables_expected_in_stream_metadata.insert(
+        GetPgsqlTableId(pg_database_oid, kPgAttributeTableOid));
 
     auto db_stream_id = ASSERT_RESULT(CreateDBStreamWithReplicationSlot());
 
@@ -526,7 +529,7 @@ TEST_F(CDCSDKStreamTest, TestPgReplicationSlotCreateWithDropTable) {
           LOG(INFO) << "GetDBStreamInfo response = " << resp.ToString();
           RETURN_NOT_OK(StatusFromPB(resp->error().status()));
         }
-        // We will have 3 pg_catalog tables in the stream metadata.
+        // We will have 5 pg_catalog tables in the stream metadata.
         return (resp->table_info_size() == kNumberOfCatalogTablesBeingPolledByCDC);
       },
       MonoDelta::FromSeconds(60),

--- a/src/yb/integration-tests/cdcsdk_test_base.h
+++ b/src/yb/integration-tests/cdcsdk_test_base.h
@@ -77,7 +77,7 @@ namespace cdc {
 
 constexpr int kRpcTimeout = 60 * kTimeMultiplier;
 constexpr int kFlushTimeoutSecs = 60 * kTimeMultiplier;
-constexpr int kNumberOfCatalogTablesBeingPolledByCDC = 4;
+constexpr int kNumberOfCatalogTablesBeingPolledByCDC = 5;
 // Number of cdc_state entries a logical replication stream creates by default when the database has
 // no user tables: one for the sys_catalog tablet-stream entry and one slot entry for the stream.
 constexpr int kNumberOfBaseCdcStateEntriesForLogicalStream = 2;

--- a/src/yb/integration-tests/cdcsdk_ysql-test.cc
+++ b/src/yb/integration-tests/cdcsdk_ysql-test.cc
@@ -12449,34 +12449,38 @@ TEST_F(CDCSDKYsqlTest, TestPollingPgCatalogTables) {
   // 0=DDL, 1=INSERT, 2=UPDATE, 3=DELETE, 4=READ, 5=TRUNCATE, 6=BEGIN, 7=COMMIT
   int record_count[] = {0, 0, 0, 0, 0, 0, 0, 0};
 
-  // We will receive 4 DDLs, one each for pg_class, pg_publication_rel, pg_publication and
-  // pg_replication_origin.
-  // Each CREATE TABLE will give 2 inserts and an update to pg_class in debug builds. In release
-  // build we get 3 inserts.
-  // Creation of pub_1 will result into one insert to pg_publication_rel and one insert to
-  // pg_publication. Creation of pub_2 (FOR ALL TABLES) will result into one insert to
-  // pg_publication (no pg_publication_rel entry for all-tables publications).
-  // ALTER PUB ADD TABLE will give one insert and ALTER PUB DROP TABLE will give one delete to
-  // pg_publication_rel.
-  // ALTER TABLE will give one update to pg_class in debug builds and one insert in release builds.
-  // Creation of 2 replication origins gives 2 inserts to pg_replication_origin and dropping one
-  // gives 1 delete.
-  // We will not receive any record corresponding to the addition of column in other catalog tables
-  // such as pg_attribute.
-  const int expected_count_without_packed_row[] = {4, 12, 4, 2, 0, 0, 11, 11};
-  const int expected_count_with_packed_row[] = {4, 16, 0, 2, 0, 0, 11, 11};
+  // We will receive at least 5 DDLs (one each for pg_class, pg_publication_rel, pg_publication,
+  // pg_replication_origin and pg_attribute from schema-cache / CHANGE_METADATA when polling the
+  // sys catalog tablet via GetChanges directly in this test).
+  // Streaming pg_attribute also yields INSERT/UPDATE/DELETE records for column changes, so DML
+  // counts are asserted as lower bounds relative to the pre-pg_attribute expectations.
+  const int min_ddl = 5;
+  const int min_insert_without_packed_row = 12;
+  const int min_insert_with_packed_row = 16;
+  const int min_update_without_packed_row = 4;
+  const int min_delete = 2;
+
+  bool saw_pg_attribute_record = false;
+  auto namespace_id = ASSERT_RESULT(GetNamespaceId(test_namespace_name));
+  auto pg_database_oid = ASSERT_RESULT(GetPgsqlDatabaseOid(namespace_id));
+  const auto pg_attribute_table_id = GetPgsqlTableId(pg_database_oid, kPgAttributeTableOid);
 
   for (auto record : change_resp.cdc_sdk_proto_records()) {
     UpdateRecordCount(record, record_count);
-  }
-
-  for (int i = 0; i < 8; i++) {
-    if (FLAGS_ysql_enable_packed_row) {
-      ASSERT_EQ(record_count[i], expected_count_with_packed_row[i]);
-    } else {
-      ASSERT_EQ(record_count[i], expected_count_without_packed_row[i]);
+    if (record.row_message().table_id() == pg_attribute_table_id) {
+      saw_pg_attribute_record = true;
     }
   }
+
+  ASSERT_TRUE(saw_pg_attribute_record) << "Expected to receive records for pg_attribute";
+  ASSERT_GE(record_count[0], min_ddl);
+  if (FLAGS_ysql_enable_packed_row) {
+    ASSERT_GE(record_count[1], min_insert_with_packed_row);
+  } else {
+    ASSERT_GE(record_count[1], min_insert_without_packed_row);
+    ASSERT_GE(record_count[2], min_update_without_packed_row);
+  }
+  ASSERT_GE(record_count[3], min_delete);
 }
 
 TEST_F(CDCSDKYsqlTest, TestStreamIndependenceWhilePollingCatalogTablet) {

--- a/src/yb/integration-tests/cdcsdk_ysql_test_base.cc
+++ b/src/yb/integration-tests/cdcsdk_ysql_test_base.cc
@@ -2605,6 +2605,7 @@ void CDCSDKYsqlTest::VerifyTablesInStreamMetadata(
             all_expected_table_ids.insert(GetPgsqlTableId(pg_database_oid, kPgPublicationRelOid));
             all_expected_table_ids.insert(GetPgsqlTableId(kTemplate1Oid, kPgReplicationOriginOid));
             all_expected_table_ids.insert(GetPgsqlTableId(pg_database_oid, kPgPublicationOid));
+            all_expected_table_ids.insert(GetPgsqlTableId(pg_database_oid, kPgAttributeTableOid));
           }
           const uint64_t table_info_size = get_resp->table_info_size();
 
@@ -2664,6 +2665,7 @@ void CDCSDKYsqlTest::VerifyTablesAndStateInStreamMetadata(
           all_expected_table_ids.insert(GetPgsqlTableId(pg_database_oid, kPgPublicationRelOid));
           all_expected_table_ids.insert(GetPgsqlTableId(kTemplate1Oid, kPgReplicationOriginOid));
           all_expected_table_ids.insert(GetPgsqlTableId(pg_database_oid, kPgPublicationOid));
+          all_expected_table_ids.insert(GetPgsqlTableId(pg_database_oid, kPgAttributeTableOid));
         }
 
         if (static_cast<size_t>(stream_lock->pb.table_id_size()) != all_expected_table_ids.size()) {

--- a/src/yb/master/xrepl_catalog_manager.cc
+++ b/src/yb/master/xrepl_catalog_manager.cc
@@ -649,7 +649,8 @@ std::string CDCStreamInfosAsString(const std::vector<CDCStreamInfoPointer>& cdc_
 
 bool IsCatalogTableEligibleForCDC(uint32_t table_oid) {
   return table_oid == kPgClassTableOid || table_oid == kPgPublicationRelOid ||
-         table_oid == kPgReplicationOriginOid || table_oid == kPgPublicationOid;
+         table_oid == kPgReplicationOriginOid || table_oid == kPgPublicationOid ||
+         table_oid == kPgAttributeTableOid;
 }
 
 }  // namespace
@@ -1143,9 +1144,10 @@ Status CatalogManager::CreateNewCDCStreamForNamespace(
     table_ids.push_back(table->id());
   }
 
-  // We add the pg_class, pg_publication_rel, pg_replication_origin and pg_publication catalog
-  // tables to the stream metadata as we will poll them to figure out changes to the publications
-  // and replication origins. This will not be done for gRPC streams.
+  // We add the pg_class, pg_publication_rel, pg_replication_origin, pg_publication and pg_attribute
+  // catalog tables to the stream metadata. We poll the first four to figure out changes to the
+  // publications and replication origins, and pg_attribute to detect transactional DDLs. This will
+  // not be done for gRPC streams.
   if (FLAGS_ysql_yb_enable_implicit_dynamic_tables_logical_replication &&
       FLAGS_cdc_enable_dynamic_schema_changes && req.has_cdcsdk_ysql_replication_slot_name()) {
     auto database_oid = VERIFY_RESULT(GetPgsqlDatabaseOid(namespace_id));
@@ -1153,9 +1155,10 @@ Status CatalogManager::CreateNewCDCStreamForNamespace(
     table_ids.push_back(GetPgsqlTableId(database_oid, kPgPublicationRelOid));
     table_ids.push_back(GetPgsqlTableId(kTemplate1Oid, kPgReplicationOriginOid));
     table_ids.push_back(GetPgsqlTableId(database_oid, kPgPublicationOid));
+    table_ids.push_back(GetPgsqlTableId(database_oid, kPgAttributeTableOid));
     VLOG_WITH_FUNC(1) << "Added the catalog tables pg_class, pg_publication_rel, "
-                      << "pg_replication_origin and pg_publication to the stream metadata tables "
-                      << "list.";
+                      << "pg_replication_origin, pg_publication and pg_attribute to the stream "
+                      << "metadata tables list.";
   }
 
   VLOG_WITH_FUNC(1) << Format("Creating CDCSDK stream for $0 tables", table_ids.size());


### PR DESCRIPTION
## Summary

**Closed — opened against upstream by mistake.**

This draft PR should not have been filed on `yugabyte/yugabyte-db`. Work was only meant to live on the personal fork. Closing to clear the noise; please ignore.

---

Original body (for reference):

Adds transactional DDL support for YSQL CDC logical replication via `pg_attribute` streaming in the virtual WAL. See personal fork PR instead.