### PR TITLE
[#26039] YSQL: Port intarray gin__int_ops to ybgin

### DIFF
--- a/src/postgres/contrib/intarray/Makefile
+++ b/src/postgres/contrib/intarray/Makefile
@@ -12,7 +12,8 @@ OBJS = \
 	_intbig_gist.o
 
 EXTENSION = intarray
-DATA = intarray--1.4--1.5.sql intarray--1.3--1.4.sql intarray--1.2--1.3.sql \
+DATA = intarray--1.5--1.5-yb-1.0.sql intarray--1.4--1.5.sql \
+	intarray--1.3--1.4.sql intarray--1.2--1.3.sql \
 	intarray--1.2.sql intarray--1.1--1.2.sql \
 	intarray--1.0--1.1.sql
 PGFILEDESC = "intarray - functions and operators for arrays of integers"

--- a/src/postgres/contrib/intarray/expected/yb.port._int.out
+++ b/src/postgres/contrib/intarray/expected/yb.port._int.out
@@ -479,11 +479,17 @@ ERROR:  index method "gist" not supported yet
 HINT:  See https://github.com/yugabyte/yugabyte-db/issues/1337. React with thumbs up to raise its priority
 CREATE INDEX text_idx on test__int using gin ( a gin__int_ops );
 SELECT count(*) from test__int WHERE a && '{23,50}';
-ERROR:  unsupported ybgin index scan
-DETAIL:  ybgin index method cannot use more than one required scan entry: got 2.
+ count 
+-------
+   403
+(1 row)
+
 SELECT count(*) from test__int WHERE a @@ '23|50';
-ERROR:  unsupported ybgin index scan
-DETAIL:  ybgin index method cannot use more than one required scan entry: got 2.
+ count 
+-------
+   403
+(1 row)
+
 SELECT count(*) from test__int WHERE a @> '{23,50}';
  count 
 -------
@@ -527,8 +533,11 @@ SELECT count(*) from test__int WHERE a @> '{20,23}' or a @> '{50,68}';
 (1 row)
 
 SELECT count(*) from test__int WHERE a @@ '(20&23)|(50&68)';
-ERROR:  unsupported ybgin index scan
-DETAIL:  ybgin index method cannot use more than one required scan entry: got 3.
+ count 
+-------
+    21
+(1 row)
+
 SELECT count(*) from test__int WHERE a @@ '20 | !21';
  count 
 -------

--- a/src/postgres/contrib/intarray/expected/yb.port._int.out
+++ b/src/postgres/contrib/intarray/expected/yb.port._int.out
@@ -478,5 +478,67 @@ CREATE INDEX text_idx on test__int using gist ( a gist__intbig_ops );
 ERROR:  index method "gist" not supported yet
 HINT:  See https://github.com/yugabyte/yugabyte-db/issues/1337. React with thumbs up to raise its priority
 CREATE INDEX text_idx on test__int using gin ( a gin__int_ops );
-ERROR:  operator class "gin__int_ops" does not exist for access method "ybgin"
+SELECT count(*) from test__int WHERE a && '{23,50}';
+ERROR:  unsupported ybgin index scan
+DETAIL:  ybgin index method cannot use more than one required scan entry: got 2.
+SELECT count(*) from test__int WHERE a @@ '23|50';
+ERROR:  unsupported ybgin index scan
+DETAIL:  ybgin index method cannot use more than one required scan entry: got 2.
+SELECT count(*) from test__int WHERE a @> '{23,50}';
+ count 
+-------
+    12
+(1 row)
+
+SELECT count(*) from test__int WHERE a @@ '23&50';
+ count 
+-------
+    12
+(1 row)
+
+SELECT count(*) from test__int WHERE a @> '{20,23}';
+ count 
+-------
+    12
+(1 row)
+
+SELECT count(*) from test__int WHERE a <@ '{73,23,20}';
+ count 
+-------
+    10
+(1 row)
+
+SELECT count(*) from test__int WHERE a = '{73,23,20}';
+ count 
+-------
+     1
+(1 row)
+
+SELECT count(*) from test__int WHERE a @@ '50&68';
+ count 
+-------
+     9
+(1 row)
+
+SELECT count(*) from test__int WHERE a @> '{20,23}' or a @> '{50,68}';
+ count 
+-------
+    21
+(1 row)
+
+SELECT count(*) from test__int WHERE a @@ '(20&23)|(50&68)';
+ERROR:  unsupported ybgin index scan
+DETAIL:  ybgin index method cannot use more than one required scan entry: got 3.
+SELECT count(*) from test__int WHERE a @@ '20 | !21';
+ count 
+-------
+  6567
+(1 row)
+
+SELECT count(*) from test__int WHERE a @@ '!20 & !21';
+ count 
+-------
+  6344
+(1 row)
+
 RESET enable_seqscan;

--- a/src/postgres/contrib/intarray/intarray--1.5--1.5-yb-1.0.sql
+++ b/src/postgres/contrib/intarray/intarray--1.5--1.5-yb-1.0.sql
@@ -1,0 +1,29 @@
+/* contrib/intarray/intarray--1.5--1.5-yb-1.0.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION intarray UPDATE TO '1.5-yb-1.0'" to load this file. \quit
+
+/*
+ * Translate gin operator class to ybgin operator class.  Ignore gist because
+ * the ybgist index access method does not exist, yet.
+ */
+
+/*
+ * Adopted from contrib/intarray/intarray--1.2.sql, reflecting the state of
+ * gin__int_ops at version 1.5: the deprecated @ and ~ operators (strategies 13
+ * and 14) were dropped in intarray--1.4--1.5.sql, so they are omitted here.
+ */
+
+CREATE OPERATOR CLASS gin__int_ops
+FOR TYPE _int4 USING ybgin
+AS
+	OPERATOR	3	&&,
+	OPERATOR	6	= (anyarray, anyarray),
+	OPERATOR	7	@>,
+	OPERATOR	8	<@,
+	OPERATOR	20	@@ (_int4, query_int),
+	FUNCTION	1	btint4cmp (int4, int4),
+	FUNCTION	2	ginarrayextract (anyarray, internal, internal),
+	FUNCTION	3	ginint4_queryextract (_int4, internal, int2, internal, internal, internal, internal),
+	FUNCTION	4	ginint4_consistent (internal, int2, _int4, int4, internal, internal, internal, internal),
+	STORAGE		int4;

--- a/src/postgres/contrib/intarray/intarray.control
+++ b/src/postgres/contrib/intarray/intarray.control
@@ -1,6 +1,6 @@
 # intarray extension
 comment = 'functions, operators, and index support for 1-D arrays of integers'
-default_version = '1.5'
+default_version = '1.5-yb-1.0'
 module_pathname = '$libdir/_int'
 relocatable = true
 trusted = true

--- a/src/postgres/contrib/intarray/sql/yb.port._int.sql
+++ b/src/postgres/contrib/intarray/sql/yb.port._int.sql
@@ -100,4 +100,18 @@ CREATE INDEX text_idx on test__int using gist ( a gist__int_ops );
 CREATE INDEX text_idx on test__int using gist ( a gist__intbig_ops );
 
 CREATE INDEX text_idx on test__int using gin ( a gin__int_ops );
+
+SELECT count(*) from test__int WHERE a && '{23,50}';
+SELECT count(*) from test__int WHERE a @@ '23|50';
+SELECT count(*) from test__int WHERE a @> '{23,50}';
+SELECT count(*) from test__int WHERE a @@ '23&50';
+SELECT count(*) from test__int WHERE a @> '{20,23}';
+SELECT count(*) from test__int WHERE a <@ '{73,23,20}';
+SELECT count(*) from test__int WHERE a = '{73,23,20}';
+SELECT count(*) from test__int WHERE a @@ '50&68';
+SELECT count(*) from test__int WHERE a @> '{20,23}' or a @> '{50,68}';
+SELECT count(*) from test__int WHERE a @@ '(20&23)|(50&68)';
+SELECT count(*) from test__int WHERE a @@ '20 | !21';
+SELECT count(*) from test__int WHERE a @@ '!20 & !21';
+
 RESET enable_seqscan;

--- a/src/postgres/src/backend/utils/adt/selfuncs.c
+++ b/src/postgres/src/backend/utils/adt/selfuncs.c
@@ -7573,6 +7573,30 @@ gincost_pattern(IndexOptInfo *index, int indexcol,
 		return true;
 	}
 
+	if (IsYugaByteEnabled() && index->relam == YBGIN_AM_OID &&
+		index->opcintype[indexcol] == INT4ARRAYOID && nentries > 1)
+	{
+		/*
+		 * TODO(#7850): ybgin cannot execute a scan key that expands to more
+		 * than one required entry -- for example intarray's array-overlap "&&"
+		 * or a query_int OR such as "1 | 2" -- so the executor errors out at
+		 * run time with "unsupported ybgin index scan".  Until ybgin supports
+		 * multi-entry scans, steer such a query to a sequential scan instead of
+		 * a runtime error by piggybacking on attHasFullScan (which the caller
+		 * translates to disable_cost).
+		 *
+		 * This is intentionally scoped to intarray's gin__int_ops opclass,
+		 * identified by its _int4 (int[]) input type -- the only ybgin opclass
+		 * over int arrays.  The same executor limitation applies to the other
+		 * ybgin opclasses (array_ops, tsvector, jsonb, pg_trgm, hstore), but we
+		 * deliberately leave their behavior unchanged here to keep the blast
+		 * radius small; the general fix belongs in the executor.  See
+		 * https://github.com/yugabyte/yugabyte-db/issues/7850.
+		 */
+		counts->attHasFullScan[indexcol] = true;
+		return true;
+	}
+
 	for (i = 0; i < nentries; i++)
 	{
 		/*


### PR DESCRIPTION
## Summary

Ports the `intarray` extension's `gin__int_ops` operator class to YugabyteDB's `ybgin` access method, mirroring the existing `pg_trgm` and `hstore` ports.

### Problem

`intarray` defines `gin__int_ops` only for the upstream `gin` access method. YugabyteDB transparently routes `USING gin` index creation to `ybgin`, but no `ybgin` operator class existed for `int[]`, so:

```sql
CREATE INDEX ON t USING gin (col gin__int_ops);
-- ERROR:  operator class "gin__int_ops" does not exist for access method "ybgin"
```

Users had to drop the explicit opclass and fall back to the built-in `array_ops`, which does not support intarray's `@@` (`query_int`) operator.

### Change

- **`intarray--1.5--1.5-yb-1.0.sql`** (new): creates `gin__int_ops FOR TYPE _int4 USING ybgin` with the version-1.5 operator set (`&&`, `=`, `@>`, `<@`, `@@`) and the standard support functions (`btint4cmp`, `ginarrayextract`, `ginint4_queryextract`, `ginint4_consistent`). The deprecated `@`/`~` operators dropped in `intarray--1.4--1.5.sql` are omitted. Not marked `DEFAULT` — `array_ops` remains the default opclass for `_int4`.
- **`intarray.control`**: `default_version` `1.5` -> `1.5-yb-1.0`, so `CREATE EXTENSION intarray` installs the ybgin opclass automatically.
- **`Makefile`**: adds the new script to `DATA`.
- **`sql/yb.port._int.sql` / `expected/yb.port._int.out`**: re-enables the index-scan verification queries that were removed while the ybgin index could not be built.

A **second commit** adds a small cost-model change so multi-entry queries fall back to a sequential scan instead of erroring at run time (details below).

### Behavior on ybgin

Single-entry queries (`col && '{x}'`, `col @> '{x}'`, `col @@ 'x'`, `=`) use the ybgin index. Queries whose scan key expands to **more than one required entry** — overlap `&&` with 2+ elements, or a `query_int` OR such as `1 | 2` / `(20&23)|(50&68)` — cannot be executed by ybgin; the executor raises `unsupported ybgin index scan` (the same limitation `array_ops`, `tsvector`, `jsonb`, `pg_trgm`, and `hstore` already have — see #7850).

The second commit costs such multi-entry scans as disabled **for `gin__int_ops`** in the GIN cost estimator, so the planner falls back to a sequential scan (correct results, no error) rather than choosing the index and failing. It is deliberately **scoped to `gin__int_ops`** (identified by its `_int4` input type — the only ybgin opclass over int arrays) so the other ybgin opclasses are left unchanged; the general fix belongs in the executor and is tracked in #7850.

## Test plan

Built from source (`release`) and ran locally:

- [x] `./yb_build.sh release --java-test 'org.yb.pgsql.TestPgRegressContribIntarray'` — **PASS**. The `yb.port._int` schedule builds the `gin__int_ops` ybgin index; single-entry queries use the index and multi-entry queries fall back to a sequential scan, all returning counts matching the sequential-scan reference (no `unsupported ybgin index scan` errors).
- [x] `./yb_build.sh release --java-test 'org.yb.pgsql.TestPgRegressGin'` — **PASS**, all 9 tests unchanged (`yb.orig.ybgin`, `ybgin_search_modes`, `ybgin_operators`, `ybgin_nulls`, `ybgin_misc`, `ybgin_cost_estimate`, `ybgin_pushdown`, `yb.port.gin`, `yb.orig.gin`) — confirms the scoped cost-model change leaves other ybgin opclasses untouched.
- [x] `./yb_build.sh release --java-test 'org.yb.pgsql.TestPgRegressContribPgTrgm'` — **PASS** (unchanged) — additional confirmation the scoping does not affect `gin_trgm_ops`.
- [x] `TestPgRegressContribHstore`, `TestPgRegressArrays`, `TestPgRegressJson` — **PASS** (unchanged).

