### PR TITLE
[BACKPORT 2026.1][#28251] DocDB: Document --flagfile in yb-admin usage text

### DIFF
--- a/src/yb/tools/yb-admin_cli.cc
+++ b/src/yb/tools/yb-admin_cli.cc
@@ -503,7 +503,15 @@ void ClusterAdminCli::SetUsage(const string& prog_name) {
   ostringstream str;
 
   str << prog_name << " [--master_addresses server1:port,server2:port,server3:port,...] "
-      << " [--timeout_ms <millisec>] [--certs_dir_name <dir_name>] <operation>" << endl
+      << " [--timeout_ms <millisec>] [--certs_dir_name <dir_name>]" << endl
+      << "  [--flagfile <path/to/master/conf/server.conf>]" << endl
+      << "  <operation>" << endl
+      << endl
+      << "Tip: Use --flagfile with the master's server.conf to automatically pick up" << endl
+      << "master_addresses and certs_dir, avoiding manual flag entry." << endl
+      << "Example: " << prog_name
+      << " --flagfile master/conf/server.conf list_all_masters" << endl
+      << endl
       << "<operation> must be one of:" << endl;
 
   for (size_t i = 0; i < commands_.size(); ++i) {


### PR DESCRIPTION
Operators often manually pass --master_addresses and --certs_dir_name
to yb-admin, unaware that the gflags built-in --flagfile option can
load these automatically from the master's server.conf. Update the
usage/help text to document --flagfile with a concrete example.


Original commit: 5c8957ca821a3af544ca823700e96172bbd04be2 / #32408