### PR TITLE
[Docs] Mark transactional ddl as EA in 2025.2 and 2026.1

### DIFF
--- a/docs/content/stable/explore/transactions/transactional-ddl.md
+++ b/docs/content/stable/explore/transactions/transactional-ddl.md
@@ -5,7 +5,7 @@ linkTitle: Transactional DDL
 description: Learn how YugabyteDB handles DDLs in a transaction
 headcontent: Learn how YugabyteDB handles DDLs in a transaction
 tags:
-   feature: tech-preview
+   feature: early-access
 menu:
   stable:
     identifier: transactional-ddl
@@ -20,9 +20,7 @@ YugabyteDB's transactional DDL provides similar guarantees for rolling back DDL 
 
 ## Enable transactional DDL
 
-{{<tags/feature/tp idea="1677">}} Support for transactional DDL is disabled by default, and to enable the feature, set the [yb-tserver](../../../reference/configuration/yb-tserver/) flag `ysql_yb_ddl_transaction_block_enabled` to true.
-
-Because `ysql_yb_ddl_transaction_block_enabled` is a preview flag, to use it, add the flag to the [allowed_preview_flags_csv](../../../reference/configuration/yb-tserver/#allowed-preview-flags-csv) list (that is, `allowed_preview_flags_csv=ysql_yb_ddl_transaction_block_enabled`).
+{{<tags/feature/ea idea="1677">}} Support for transactional DDL is disabled by default, and to enable the feature, set the [yb-tserver](../../../reference/configuration/yb-tserver/) flag `ysql_yb_ddl_transaction_block_enabled` to true.
 
 ## Rollback capabilities
 

--- a/docs/content/v2025.2/explore/transactions/transactional-ddl.md
+++ b/docs/content/v2025.2/explore/transactions/transactional-ddl.md
@@ -5,7 +5,7 @@ linkTitle: Transactional DDL
 description: Learn how YugabyteDB handles DDLs in a transaction
 headcontent: Learn how YugabyteDB handles DDLs in a transaction
 tags:
-   feature: tech-preview
+   feature: early-access
 menu:
   v2025.2:
     identifier: transactional-ddl
@@ -20,9 +20,7 @@ YugabyteDB's transactional DDL provides similar guarantees for rolling back DDL 
 
 ## Enable transactional DDL
 
-{{<tags/feature/tp idea="1677">}} Support for transactional DDL is disabled by default, and to enable the feature, set the [yb-tserver](../../../reference/configuration/yb-tserver/) flag `ysql_yb_ddl_transaction_block_enabled` to true.
-
-Because `ysql_yb_ddl_transaction_block_enabled` is a preview flag, to use it, add the flag to the [allowed_preview_flags_csv](../../../reference/configuration/yb-tserver/#allowed-preview-flags-csv) list (that is, `allowed_preview_flags_csv=ysql_yb_ddl_transaction_block_enabled`).
+{{<tags/feature/ea idea="1677">}} Support for transactional DDL is disabled by default, and to enable the feature, set the [yb-tserver](../../../reference/configuration/yb-tserver/) flag `ysql_yb_ddl_transaction_block_enabled` to true.
 
 ## Rollback capabilities
 


### PR DESCRIPTION
Transactional DDL is TP in 2025.1 and EA in 2025.2 and 2026.1. Presently, docs show it as TP in all 3 versions. Therefore, this PR updates the docs accordingly.