### PR TITLE
[#17797] YSQL: Support SPLIT INTO syntax for matviews

### DIFF
--- a/src/postgres/src/backend/commands/createas.c
+++ b/src/postgres/src/backend/commands/createas.c
@@ -114,6 +114,8 @@ create_ctas_internal(List *attrList, IntoClause *into)
 	create->tablespacename = into->tableSpaceName;
 	create->if_not_exists = false;
 	create->accessMethod = into->accessMethod;
+	/* YB: forward the SPLIT clause so the relation is pre-split at creation */
+	create->split_options = into->split_options;
 
 	/*
 	 * Create the relation.  (This will error out if there's an existing view,

--- a/src/postgres/src/backend/commands/matview.c
+++ b/src/postgres/src/backend/commands/matview.c
@@ -336,11 +336,21 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 	 * Create the transient table that will receive the regenerated data. Lock
 	 * it against access by any other process until commit (by which time it
 	 * will be gone).
+	 *
+	 * YB: Preserve the matview's tablet split when it is swapped in for the
+	 * old storage (non-concurrent refresh).  Without this the new heap would
+	 * be created with default splitting (a single tablet), silently discarding
+	 * the pre-split requested at CREATE MATERIALIZED VIEW ... SPLIT INTO time
+	 * (and any subsequent auto-splitting), even though yb_presplit remains in
+	 * reloptions.  This mirrors the table-rewrite path in ATRewriteTables.
+	 * (The concurrent and in-place refresh paths use a temporary transient
+	 * relation and merge into the existing matview, so their splits are
+	 * unaffected by this flag.)
 	 */
 	OIDNewHeap = make_new_heap(matviewOid, tableSpace,
 							   matviewRel->rd_rel->relam,
 							   relpersistence, ExclusiveLock,
-							   false /* yb_copy_split_options */ );
+							   true /* yb_copy_split_options */ );
 	LockRelationOid(OIDNewHeap, AccessExclusiveLock);
 	dest = CreateTransientRelDestReceiver(OIDNewHeap);
 

--- a/src/postgres/src/backend/nodes/copyfuncs.c
+++ b/src/postgres/src/backend/nodes/copyfuncs.c
@@ -1600,6 +1600,7 @@ _copyIntoClause(const IntoClause *from)
 	COPY_STRING_FIELD(tableSpaceName);
 	COPY_NODE_FIELD(viewQuery);
 	COPY_SCALAR_FIELD(skipData);
+	COPY_NODE_FIELD(split_options);
 
 	return newnode;
 }

--- a/src/postgres/src/backend/nodes/equalfuncs.c
+++ b/src/postgres/src/backend/nodes/equalfuncs.c
@@ -155,6 +155,7 @@ _equalIntoClause(const IntoClause *a, const IntoClause *b)
 	COMPARE_STRING_FIELD(tableSpaceName);
 	COMPARE_NODE_FIELD(viewQuery);
 	COMPARE_SCALAR_FIELD(skipData);
+	COMPARE_NODE_FIELD(split_options);
 
 	return true;
 }

--- a/src/postgres/src/backend/nodes/outfuncs.c
+++ b/src/postgres/src/backend/nodes/outfuncs.c
@@ -1281,6 +1281,7 @@ _outIntoClause(StringInfo str, const IntoClause *node)
 	WRITE_STRING_FIELD(tableSpaceName);
 	WRITE_NODE_FIELD(viewQuery);
 	WRITE_BOOL_FIELD(skipData);
+	WRITE_NODE_FIELD(split_options);
 }
 
 static void

--- a/src/postgres/src/backend/nodes/readfuncs.c
+++ b/src/postgres/src/backend/nodes/readfuncs.c
@@ -601,6 +601,7 @@ _readIntoClause(void)
 	READ_STRING_FIELD(tableSpaceName);
 	READ_NODE_FIELD(viewQuery);
 	READ_BOOL_FIELD(skipData);
+	READ_NODE_FIELD(split_options);
 
 	READ_DONE();
 }

--- a/src/postgres/src/backend/parser/gram.y
+++ b/src/postgres/src/backend/parser/gram.y
@@ -5099,7 +5099,7 @@ CreateMatViewStmt:
 		;
 
 create_mv_target:
-			qualified_name opt_column_list table_access_method_clause opt_reloptions OptTableSpace
+			qualified_name opt_column_list table_access_method_clause opt_reloptions OptTableSpace YbOptSplit
 				{
 					$$ = makeNode(IntoClause);
 					$$->rel = $1;
@@ -5110,6 +5110,7 @@ create_mv_target:
 					$$->tableSpaceName = $5;
 					$$->viewQuery = NULL;		/* filled at analysis time */
 					$$->skipData = false;		/* might get changed later */
+					$$->split_options = $6;		/* YB: SPLIT clause */
 				}
 		;
 

--- a/src/postgres/src/include/nodes/primnodes.h
+++ b/src/postgres/src/include/nodes/primnodes.h
@@ -117,6 +117,7 @@ typedef struct IntoClause
 	char	   *tableSpaceName; /* table space to use, or NULL */
 	Node	   *viewQuery;		/* materialized view's SELECT query */
 	bool		skipData;		/* true for WITH NO DATA */
+	struct YbOptSplit *split_options;	/* YB: SPLIT statement options */
 } IntoClause;
 
 

--- a/src/postgres/src/test/regress/expected/yb.orig.split_options.out
+++ b/src/postgres/src/test/regress/expected/yb.orig.split_options.out
@@ -104,6 +104,76 @@ SELECT * FROM test_mv_split ORDER BY k;
 
 DROP MATERIALIZED VIEW test_mv_split;
 DROP TABLE test_mv_source;
+-- Test CREATE MATERIALIZED VIEW with SPLIT INTO N TABLETS
+CREATE TABLE test_mv_split_into_source (k int, v int);
+INSERT INTO test_mv_split_into_source VALUES (1, 10), (2, 20), (3, 30);
+CREATE MATERIALIZED VIEW test_mv_split_into SPLIT INTO 3 TABLETS AS
+    SELECT * FROM test_mv_split_into_source;
+-- Verify tablet count
+SELECT num_tablets FROM yb_table_properties('test_mv_split_into'::regclass);
+ num_tablets 
+-------------
+           3
+(1 row)
+
+-- Verify yb_presplit is stored in reloptions
+SELECT reloptions FROM pg_class WHERE relname = 'test_mv_split_into';
+   reloptions    
+-----------------
+ {yb_presplit=3}
+(1 row)
+
+-- Verify data
+SELECT * FROM test_mv_split_into ORDER BY k;
+ k | v  
+---+----
+ 1 | 10
+ 2 | 20
+ 3 | 30
+(3 rows)
+
+DROP MATERIALIZED VIEW test_mv_split_into;
+-- Test CREATE MATERIALIZED VIEW ... SPLIT INTO ... WITH NO DATA
+CREATE MATERIALIZED VIEW test_mv_split_nodata SPLIT INTO 5 TABLETS AS
+    SELECT * FROM test_mv_split_into_source WITH NO DATA;
+SELECT num_tablets FROM yb_table_properties('test_mv_split_nodata'::regclass);
+ num_tablets 
+-------------
+           5
+(1 row)
+
+SELECT reloptions FROM pg_class WHERE relname = 'test_mv_split_nodata';
+   reloptions    
+-----------------
+ {yb_presplit=5}
+(1 row)
+
+DROP MATERIALIZED VIEW test_mv_split_nodata;
+-- Test SPLIT INTO and WITH (yb_presplit=...) together on a matview: the SPLIT
+-- clause governs the initial layout, the yb_presplit reloption is recorded
+-- as-is (they are allowed to disagree), mirroring the CREATE TABLE behavior.
+CREATE MATERIALIZED VIEW test_mv_split_both WITH (yb_presplit='5') SPLIT INTO 3 TABLETS AS
+    SELECT * FROM test_mv_split_into_source;
+SELECT num_tablets FROM yb_table_properties('test_mv_split_both'::regclass);
+ num_tablets 
+-------------
+           3
+(1 row)
+
+SELECT reloptions FROM pg_class WHERE relname = 'test_mv_split_both';
+   reloptions    
+-----------------
+ {yb_presplit=5}
+(1 row)
+
+DROP MATERIALIZED VIEW test_mv_split_both;
+-- Test SPLIT AT VALUES on a matview: the grammar accepts the clause, but a
+-- matview built from a SELECT has no range primary key, so creation fails
+-- with a clear error (mirrors the same restriction on hash-partitioned tables).
+CREATE MATERIALIZED VIEW test_mv_split_at SPLIT AT VALUES ((100), (200)) AS
+    SELECT * FROM test_mv_split_into_source;
+ERROR:  cannot split table that does not have primary key
+DROP TABLE test_mv_split_into_source;
 -- Test that SPLIT INTO and WITH (yb_presplit=...) are equivalent
 CREATE TABLE test_split_syntax1 (k int PRIMARY KEY, v int) SPLIT INTO 7 TABLETS;
 CREATE TABLE test_split_syntax2 (k int PRIMARY KEY, v int) WITH (yb_presplit=7);

--- a/src/postgres/src/test/regress/expected/yb.orig.split_options.out
+++ b/src/postgres/src/test/regress/expected/yb.orig.split_options.out
@@ -132,6 +132,20 @@ SELECT * FROM test_mv_split_into ORDER BY k;
  3 | 30
 (3 rows)
 
+-- REFRESH (non-concurrent) must preserve the pre-split tablet count
+REFRESH MATERIALIZED VIEW test_mv_split_into;
+SELECT num_tablets FROM yb_table_properties('test_mv_split_into'::regclass);
+ num_tablets 
+-------------
+           3
+(1 row)
+
+SELECT reloptions FROM pg_class WHERE relname = 'test_mv_split_into';
+   reloptions    
+-----------------
+ {yb_presplit=3}
+(1 row)
+
 DROP MATERIALIZED VIEW test_mv_split_into;
 -- Test CREATE MATERIALIZED VIEW ... SPLIT INTO ... WITH NO DATA
 CREATE MATERIALIZED VIEW test_mv_split_nodata SPLIT INTO 5 TABLETS AS

--- a/src/postgres/src/test/regress/sql/yb.orig.split_options.sql
+++ b/src/postgres/src/test/regress/sql/yb.orig.split_options.sql
@@ -51,6 +51,42 @@ SELECT * FROM test_mv_split ORDER BY k;
 DROP MATERIALIZED VIEW test_mv_split;
 DROP TABLE test_mv_source;
 
+-- Test CREATE MATERIALIZED VIEW with SPLIT INTO N TABLETS
+CREATE TABLE test_mv_split_into_source (k int, v int);
+INSERT INTO test_mv_split_into_source VALUES (1, 10), (2, 20), (3, 30);
+CREATE MATERIALIZED VIEW test_mv_split_into SPLIT INTO 3 TABLETS AS
+    SELECT * FROM test_mv_split_into_source;
+-- Verify tablet count
+SELECT num_tablets FROM yb_table_properties('test_mv_split_into'::regclass);
+-- Verify yb_presplit is stored in reloptions
+SELECT reloptions FROM pg_class WHERE relname = 'test_mv_split_into';
+-- Verify data
+SELECT * FROM test_mv_split_into ORDER BY k;
+DROP MATERIALIZED VIEW test_mv_split_into;
+
+-- Test CREATE MATERIALIZED VIEW ... SPLIT INTO ... WITH NO DATA
+CREATE MATERIALIZED VIEW test_mv_split_nodata SPLIT INTO 5 TABLETS AS
+    SELECT * FROM test_mv_split_into_source WITH NO DATA;
+SELECT num_tablets FROM yb_table_properties('test_mv_split_nodata'::regclass);
+SELECT reloptions FROM pg_class WHERE relname = 'test_mv_split_nodata';
+DROP MATERIALIZED VIEW test_mv_split_nodata;
+
+-- Test SPLIT INTO and WITH (yb_presplit=...) together on a matview: the SPLIT
+-- clause governs the initial layout, the yb_presplit reloption is recorded
+-- as-is (they are allowed to disagree), mirroring the CREATE TABLE behavior.
+CREATE MATERIALIZED VIEW test_mv_split_both WITH (yb_presplit='5') SPLIT INTO 3 TABLETS AS
+    SELECT * FROM test_mv_split_into_source;
+SELECT num_tablets FROM yb_table_properties('test_mv_split_both'::regclass);
+SELECT reloptions FROM pg_class WHERE relname = 'test_mv_split_both';
+DROP MATERIALIZED VIEW test_mv_split_both;
+
+-- Test SPLIT AT VALUES on a matview: the grammar accepts the clause, but a
+-- matview built from a SELECT has no range primary key, so creation fails
+-- with a clear error (mirrors the same restriction on hash-partitioned tables).
+CREATE MATERIALIZED VIEW test_mv_split_at SPLIT AT VALUES ((100), (200)) AS
+    SELECT * FROM test_mv_split_into_source;
+DROP TABLE test_mv_split_into_source;
+
 -- Test that SPLIT INTO and WITH (yb_presplit=...) are equivalent
 CREATE TABLE test_split_syntax1 (k int PRIMARY KEY, v int) SPLIT INTO 7 TABLETS;
 CREATE TABLE test_split_syntax2 (k int PRIMARY KEY, v int) WITH (yb_presplit=7);

--- a/src/postgres/src/test/regress/sql/yb.orig.split_options.sql
+++ b/src/postgres/src/test/regress/sql/yb.orig.split_options.sql
@@ -62,6 +62,10 @@ SELECT num_tablets FROM yb_table_properties('test_mv_split_into'::regclass);
 SELECT reloptions FROM pg_class WHERE relname = 'test_mv_split_into';
 -- Verify data
 SELECT * FROM test_mv_split_into ORDER BY k;
+-- REFRESH (non-concurrent) must preserve the pre-split tablet count
+REFRESH MATERIALIZED VIEW test_mv_split_into;
+SELECT num_tablets FROM yb_table_properties('test_mv_split_into'::regclass);
+SELECT reloptions FROM pg_class WHERE relname = 'test_mv_split_into';
 DROP MATERIALIZED VIEW test_mv_split_into;
 
 -- Test CREATE MATERIALIZED VIEW ... SPLIT INTO ... WITH NO DATA


### PR DESCRIPTION
## Summary

Allow tablet-splitting properties to be set on a materialized view at creation time, e.g.:

```sql
CREATE MATERIALIZED VIEW mv SPLIT INTO 3 TABLETS AS SELECT ...;
```

Previously `SPLIT INTO N TABLETS` / `SPLIT AT VALUES` were only accepted for `CREATE TABLE` and `CREATE INDEX`. Materialized views are created through the `CREATE TABLE AS` path (`CreateTableAsStmt` -> `IntoClause`), which had no field to carry the SPLIT clause.

### Creation support (commit 1)

- Add `split_options` to `IntoClause` and wire `YbOptSplit` into the `create_mv_target` grammar rule.
- Forward `into->split_options` into the synthesized `CreateStmt` in `create_ctas_internal`, so `DefineRelation` applies it and reconciles it with the `yb_presplit` reloption (exactly as for regular tables).
- Register the new field in the copy/equal/out/read node functions.

`SPLIT INTO N TABLETS` pre-splits the matview into N hash tablets and records `yb_presplit=N` in reloptions. `SPLIT AT VALUES` is accepted by the grammar but rejected at creation for a matview built from a `SELECT` (no range primary key), matching the existing restriction on hash-partitioned tables.

### Preserve the split across REFRESH (commit 2)

A non-concurrent `REFRESH MATERIALIZED VIEW` rebuilds the matview into a new heap via `make_new_heap()`, which was called with `yb_copy_split_options=false` -- so the refreshed matview silently dropped back to a single tablet even though `yb_presplit` remained in reloptions. This pre-existing gap affected matviews pre-split via either the new `SPLIT INTO` syntax or the existing `WITH (yb_presplit=N)` reloption.

The refresh now passes `yb_copy_split_options=true`, preserving the matview's current split (the requested pre-split plus any subsequent auto-splitting), mirroring the `ALTER TABLE` rewrite path in `ATRewriteTables`. The concurrent and in-place refresh paths merge into the existing matview via a temporary transient relation and were already unaffected.

## Upgrade/Rollback safety

No wire-format (`.proto`), catalog-schema, on-disk-format, or gflag-default changes. The new `IntoClause.split_options` is an in-memory parse-node field only -- never persisted or sent over the wire -- so it carries no mixed-version concern.

The only behavior change is on non-concurrent `REFRESH MATERIALIZED VIEW`: the new binary preserves the matview's tablet split, the old binary drops it to a single tablet. On a mixed-version cluster the outcome of a given REFRESH depends only on the version of the query-layer node that runs it; both outcomes are valid matview refreshes (the difference is solely the tablet count of the rebuilt storage). The `yb_presplit` reloption remains intact in either direction, so rollback to the prior version simply reverts to the old drop-to-one-tablet behavior with no cleanup or migration required.

## Test plan

- [ ] Extended the `yb.orig.split_options` regress test with materialized-view cases: `SPLIT INTO N TABLETS` (plain, `WITH NO DATA`, and combined with `WITH (yb_presplit=N)`), a `SPLIT AT VALUES` negative case, and a non-concurrent `REFRESH` that verifies the tablet count is preserved.
- [ ] `./yb_build.sh release --java-test org.yb.pgsql.TestPgRegressSplitOptions`
- [ ] Manually verified on a single-node cluster: `SPLIT INTO N` yields N tablets and `{yb_presplit=N}` in reloptions; `SPLIT AT VALUES` on a matview errors cleanly (no range PK); `REFRESH` (non-concurrent, `CONCURRENTLY`, and for `WITH (yb_presplit=N)` matviews) preserves the tablet count; a default no-split matview still refreshes to a single tablet (no regression).
