### PR TITLE
[BACKPORT 2026.1][#18983] DocDB: Sort yb-admin list_all_tablet_servers by status then host (#32476)

### DIFF
--- a/src/yb/tools/yb-admin_client-test.cc
+++ b/src/yb/tools/yb-admin_client-test.cc
@@ -17,6 +17,7 @@
 #include "yb/master/master_ddl.pb.h"
 #include "yb/master/catalog_manager_util.h"
 #include "yb/tools/yb-admin_client.h"
+#include "yb/tools/yb-admin_util.h"
 #include "yb/util/backoff_waiter.h"
 #include "yb/util/pb_util.h"
 #include "yb/util/test_thread_holder.h"
@@ -278,6 +279,39 @@ TEST_F(
   };
   ASSERT_OK(cluster_admin_client_->CreateNamespaceSnapshot(
       database, 0 /* retention_duration_hours */));
+}
+
+namespace {
+
+master::ListTabletServersResponsePB::Entry MakeTabletServerEntry(
+    const std::string& uuid, const std::string& host, uint16_t port, bool alive) {
+  master::ListTabletServersResponsePB::Entry entry;
+  entry.mutable_instance_id()->set_permanent_uuid(uuid);
+  HostPortToPB(
+      HostPort(host, port),
+      entry.mutable_registration()->mutable_common()->add_private_rpc_addresses());
+  entry.set_alive(alive);
+  return entry;
+}
+
+}  // namespace
+
+TEST(ListTabletServerSortTest, AliveBeforeDeadThenHost) {
+  google::protobuf::RepeatedPtrField<master::ListTabletServersResponsePB::Entry> servers;
+  *servers.Add() = MakeTabletServerEntry("uuid-dead-10", "10.0.0.10", 9100, false);
+  *servers.Add() = MakeTabletServerEntry("uuid-alive-30-b", "10.0.0.30", 9100, true);
+  *servers.Add() = MakeTabletServerEntry("uuid-alive-30-a", "10.0.0.30", 9100, true);
+  *servers.Add() = MakeTabletServerEntry("uuid-dead-20", "10.0.0.20", 9100, false);
+  *servers.Add() = MakeTabletServerEntry("uuid-alive-15", "10.0.0.15", 9100, true);
+
+  SortListTabletServerEntries(servers);
+
+  ASSERT_EQ(5, servers.size());
+  EXPECT_EQ("uuid-alive-15", servers.Get(0).instance_id().permanent_uuid());
+  EXPECT_EQ("uuid-alive-30-a", servers.Get(1).instance_id().permanent_uuid());
+  EXPECT_EQ("uuid-alive-30-b", servers.Get(2).instance_id().permanent_uuid());
+  EXPECT_EQ("uuid-dead-10", servers.Get(3).instance_id().permanent_uuid());
+  EXPECT_EQ("uuid-dead-20", servers.Get(4).instance_id().permanent_uuid());
 }
 
 }  // namespace tools

--- a/src/yb/tools/yb-admin_client.cc
+++ b/src/yb/tools/yb-admin_client.cc
@@ -31,13 +31,14 @@
 //
 
 #include "yb/tools/yb-admin_client.h"
+#include "yb/tools/yb-admin_util.h"
 
+#include <iomanip>
 #include <sstream>
 #include <string>
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
-#include <iomanip>
 
 #include <boost/multi_index/composite_key.hpp>
 #include <boost/multi_index/global_fun.hpp>
@@ -90,7 +91,6 @@
 #include "yb/rpc/secure_stream.h"
 
 #include "yb/tools/tools_utils.h"
-#include "yb/tools/yb-admin_util.h"
 
 #include "yb/tserver/tserver_admin.proxy.h"
 #include "yb/tserver/tserver_service.proxy.h"
@@ -1353,6 +1353,7 @@ Result<HostPort> ClusterAdminClient::GetFirstRpcAddressForTS(const PeerId& uuid)
 Status ClusterAdminClient::ListAllTabletServers(bool exclude_dead) {
   RepeatedPtrField<ListTabletServersResponsePB::Entry> servers;
   RETURN_NOT_OK(ListTabletServers(&servers));
+  SortListTabletServerEntries(servers);
   char kSpaceSep = ' ';
 
   cout << RightPadToUuidWidth("Tablet Server UUID") << kSpaceSep

--- a/src/yb/tools/yb-admin_util.cc
+++ b/src/yb/tools/yb-admin_util.cc
@@ -12,6 +12,9 @@
 
 #include "yb/tools/yb-admin_util.h"
 
+#include <algorithm>
+#include <string_view>
+
 #include "yb/common/snapshot.h"
 
 #include "yb/util/result.h"
@@ -20,6 +23,47 @@ namespace yb {
 namespace tools {
 
 using std::string;
+using master::ListTabletServersResponsePB;
+
+namespace {
+
+int GetTabletServerAliveRank(const ListTabletServersResponsePB::Entry& server) {
+  if (!server.has_alive()) {
+    return 2;
+  }
+  return server.alive() ? 0 : 1;
+}
+
+bool CompareListTabletServersEntries(
+    const ListTabletServersResponsePB::Entry& a,
+    const ListTabletServersResponsePB::Entry& b) {
+  const int a_alive_rank = GetTabletServerAliveRank(a);
+  const int b_alive_rank = GetTabletServerAliveRank(b);
+  if (a_alive_rank != b_alive_rank) {
+    return a_alive_rank < b_alive_rank;
+  }
+
+  const auto& a_addresses = a.registration().common().private_rpc_addresses();
+  const auto& b_addresses = b.registration().common().private_rpc_addresses();
+
+  const std::string_view a_host =
+      a_addresses.empty() ? std::string_view() : a_addresses.Get(0).host();
+  const std::string_view b_host =
+      b_addresses.empty() ? std::string_view() : b_addresses.Get(0).host();
+  if (a_host != b_host) {
+    return a_host < b_host;
+  }
+
+  const uint32_t a_port = a_addresses.empty() ? 0 : a_addresses.Get(0).port();
+  const uint32_t b_port = b_addresses.empty() ? 0 : b_addresses.Get(0).port();
+  if (a_port != b_port) {
+    return a_port < b_port;
+  }
+
+  return a.instance_id().permanent_uuid() < b.instance_id().permanent_uuid();
+}
+
+}  // namespace
 
 string SnapshotIdToString(const SnapshotId& snapshot_id) {
   auto txn_snapshot_id = TryFullyDecodeTxnSnapshotId(snapshot_id);
@@ -35,6 +79,11 @@ SnapshotId StringToSnapshotId(const string& str) {
   }
   // If conversion into TxnSnapshotId failed.
   return SnapshotId(str);
+}
+
+void SortListTabletServerEntries(
+    google::protobuf::RepeatedPtrField<ListTabletServersResponsePB::Entry>& servers) {
+  std::sort(servers.begin(), servers.end(), CompareListTabletServersEntries);
 }
 
 }  // namespace tools

--- a/src/yb/tools/yb-admin_util.h
+++ b/src/yb/tools/yb-admin_util.h
@@ -16,6 +16,7 @@
 #include <utility>
 
 #include "yb/common/entity_ids_types.h"
+#include "yb/master/master_cluster.pb.h"
 
 namespace yb {
 namespace tools {
@@ -23,6 +24,9 @@ namespace tools {
 std::string SnapshotIdToString(const SnapshotId& snapshot_id);
 
 SnapshotId StringToSnapshotId(const std::string& str);
+
+void SortListTabletServerEntries(
+    google::protobuf::RepeatedPtrField<master::ListTabletServersResponsePB::Entry>& servers);
 
 }  // namespace tools
 }  // namespace yb


### PR DESCRIPTION
## Summary

Sort `yb-admin list_all_tablet_servers` output for easier operator
scanning at scale.

- Primary sort: ALIVE tablet servers before DEAD ones
- Secondary sort: RPC host (alphabetical string compare), with UUID as
tie-breaker
- Sorting is implemented in `SortListTabletServerEntries()` and covered
by a unit test

Fixes https://github.com/yugabyte/yugabyte-db/issues/18983

## Testing Done:

- [x] `./yb_build.sh release --cxx-test yb-admin_client-test
--gtest_filter ListTabletServerSortTest.AliveBeforeDeadThenHost --sj
--skip-pg-parquet --no-odyssey --no-ybc`
- [x] Manually verified
`build/release-clang21-dynamic-arm64-ninja/bin/yb-admin
list_all_tablet_servers` shows alive hosts first, then dead hosts, each
group sorted by hostname

### With this change

```
build/release-clang21-dynamic-arm64-ninja/bin/yb-admin -master_addresses 127.0.0.1:7100,127.0.0.1:7110,127.0.0.1:7120 list_all_tablet_servers
Tablet Server UUID               RPC Host/Port Heartbeat delay Status   Reads/s  Writes/s Uptime   SST total size  SST uncomp size SST #files      Memory   Broadcast Host/Port
a3b423b811f04c819fd0bccabccadd9f yb-bignode-node1:9100 0.79s           ALIVE    0.20     0.00     8552     257.43 KB       964.62 KB       3               93.81 MB yb-bignode-node1:9100
1e70b965485a402f8555c961e92b8ed5 yb-bignode-node2:9100 0.78s           ALIVE    0.00     0.00     8543     103.68 KB       551.67 KB       1               75.74 MB yb-bignode-node2:9100
137117e25f094bda9c91a75ccf121a6e yb-bignode-node3:9100 0.95s           ALIVE    0.00     0.00     8515     0 B             0 B             0               41.17 MB yb-bignode-node3:9100
9cc7f27663cd4bbe81869a990cc01100 yb-bignode-node4:9100 0.76s           ALIVE    0.00     0.00     8535     257.43 KB       964.62 KB       3               76.44 MB yb-bignode-node4:9100
693f5820f2f74dd1a55936b9b9ed2ff0 yb-bignode-node5:9100 0.53s           ALIVE    0.00     0.00     8534     0 B             0 B             0               43.22 MB yb-bignode-node5:9100
70f50b8d894547beaa2a698ba6f2ce4e yb-bignode-node6:9100 0.65s           ALIVE    0.00     0.00     8533     0 B             0 B             0               63.91 MB yb-bignode-node6:9100
d726e87208c449198dbd76f58942b7e5 yb-bignode-node7:9100 0.85s           ALIVE    0.00     0.00     8531     0 B             0 B             0               58.38 MB yb-bignode-node7:9100
79ea0d242cc445b79a7296818b240a99 yb-bignode-node8:9100 0.44s           ALIVE    0.00     0.00     8534     0 B             0 B             0               44.23 MB yb-bignode-node8:9100
f99c37be78234103ae89fa4356d4ae8e yb-bignode-node10:9100 8149.29s        DEAD     0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node10:9100
e050458be63441a294d583b3eb703aff yb-bignode-node11:9100 8125.11s        DEAD     0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node11:9100
807bcd5a3f314ff8af5f1b24cde2aef1 yb-bignode-node12:9100 8108.61s        DEAD     0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node12:9100
ff8a67d84fa6447c90a19e325c6012e7 yb-bignode-node13:9100 8107.54s        DEAD     0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node13:9100
9ac59894d8814e97a9e0bd3f05b85eeb yb-bignode-node14:9100 8106.29s        DEAD     0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node14:9100
6e2661e85242440487e626d043729ee4 yb-bignode-node15:9100 8105.47s        DEAD     0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node15:9100
54072ccf9a7b4b0586f2cfaf36b2ceb4 yb-bignode-node9:9100 8175.09s        DEAD     0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node9:9100
```

### Without this change

```
 yb-admin -master_addresses 127.0.0.1:7100,127.0.0.1:7110,127.0.0.1:7120 list_all_tablet_servers
Tablet Server UUID               RPC Host/Port Heartbeat delay Status   Reads/s  Writes/s Uptime   SST total size  SST uncomp size SST #files      Memory   Broadcast Host/Port
137117e25f094bda9c91a75ccf121a6e yb-bignode-node3:9100 0.34s           ALIVE    0.00     0.00     8660     0 B             0 B             0               40.30 MB yb-bignode-node3:9100
1e70b965485a402f8555c961e92b8ed5 yb-bignode-node2:9100 0.17s           ALIVE    0.00     0.40     8683     103.68 KB       551.67 KB       1               74.67 MB yb-bignode-node2:9100
54072ccf9a7b4b0586f2cfaf36b2ceb4 yb-bignode-node9:9100 8316.63s        DEAD     0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node9:9100
693f5820f2f74dd1a55936b9b9ed2ff0 yb-bignode-node5:9100 0.91s           ALIVE    0.00     0.00     8674     0 B             0 B             0               43.79 MB yb-bignode-node5:9100
6e2661e85242440487e626d043729ee4 yb-bignode-node15:9100 8247.01s        DEAD     0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node15:9100
70f50b8d894547beaa2a698ba6f2ce4e yb-bignode-node6:9100 0.04s           ALIVE    0.00     0.00     8678     0 B             0 B             0               63.03 MB yb-bignode-node6:9100
79ea0d242cc445b79a7296818b240a99 yb-bignode-node8:9100 0.83s           ALIVE    0.00     0.00     8674     0 B             0 B             0               44.25 MB yb-bignode-node8:9100
807bcd5a3f314ff8af5f1b24cde2aef1 yb-bignode-node12:9100 8250.15s        DEAD     0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node12:9100
9ac59894d8814e97a9e0bd3f05b85eeb yb-bignode-node14:9100 8247.83s        DEAD     0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node14:9100
9cc7f27663cd4bbe81869a990cc01100 yb-bignode-node4:9100 0.14s           ALIVE    0.00     0.00     8675     257.43 KB       964.62 KB       3               75.63 MB yb-bignode-node4:9100
a3b423b811f04c819fd0bccabccadd9f yb-bignode-node1:9100 0.18s           ALIVE    0.20     0.00     8692     257.43 KB       964.62 KB       3               94.02 MB yb-bignode-node1:9100
d726e87208c449198dbd76f58942b7e5 yb-bignode-node7:9100 0.24s           ALIVE    0.00     0.00     8677     0 B             0 B             0               58.54 MB yb-bignode-node7:9100
e050458be63441a294d583b3eb703aff yb-bignode-node11:9100 8266.65s        DEAD     0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node11:9100
f99c37be78234103ae89fa4356d4ae8e yb-bignode-node10:9100 8290.83s        DEAD     0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node10:9100
ff8a67d84fa6447c90a19e325c6012e7 yb-bignode-node13:9100 8249.08s        DEAD     0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node13:9100
```


### With this change (Only ALIVE nodes)

```
build/release-clang21-dynamic-arm64-ninja/bin/yb-admin -master_addresses yb-bignode-node1:7100,yb-bignode-node2:7100,yb-bignode-node4:7100 list_all_tablet_servers
Tablet Server UUID               RPC Host/Port Heartbeat delay Status   Reads/s  Writes/s Uptime   SST total size  SST uncomp size SST #files      Memory   Broadcast Host/Port
a3b423b811f04c819fd0bccabccadd9f yb-bignode-node1:9100 16.64s          ALIVE    0.00     1.57     712      257.43 KB       964.62 KB       3               97.71 MB yb-bignode-node1:9100
f99c37be78234103ae89fa4356d4ae8e yb-bignode-node10:9100 25.01s          ALIVE    0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node10:9100
e050458be63441a294d583b3eb703aff yb-bignode-node11:9100 16.71s          ALIVE    0.00     0.00     891      0 B             0 B             0               75.22 MB yb-bignode-node11:9100
807bcd5a3f314ff8af5f1b24cde2aef1 yb-bignode-node12:9100 0.00s           ALIVE    0.00     0.00     728      0 B             0 B             0               73.61 MB yb-bignode-node12:9100
ff8a67d84fa6447c90a19e325c6012e7 yb-bignode-node13:9100 25.01s          ALIVE    0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node13:9100
9ac59894d8814e97a9e0bd3f05b85eeb yb-bignode-node14:9100 16.70s          ALIVE    0.00     0.00     712      0 B             0 B             0               70.15 MB yb-bignode-node14:9100
6e2661e85242440487e626d043729ee4 yb-bignode-node15:9100 0.04s           ALIVE    0.00     0.00     906      0 B             0 B             0               36.68 MB yb-bignode-node15:9100
1e70b965485a402f8555c961e92b8ed5 yb-bignode-node2:9100 0.00s           ALIVE    0.00     0.00     729      103.68 KB       551.67 KB       1               85.68 MB yb-bignode-node2:9100
137117e25f094bda9c91a75ccf121a6e yb-bignode-node3:9100 17.03s          ALIVE    0.00     0.00     9662     0 B             0 B             0               39.40 MB yb-bignode-node3:9100
9cc7f27663cd4bbe81869a990cc01100 yb-bignode-node4:9100 16.64s          ALIVE    0.00     0.00     712      257.43 KB       964.62 KB       3               88.60 MB yb-bignode-node4:9100
693f5820f2f74dd1a55936b9b9ed2ff0 yb-bignode-node5:9100 0.00s           ALIVE    0.00     0.00     9697     0 B             0 B             0               40.04 MB yb-bignode-node5:9100
70f50b8d894547beaa2a698ba6f2ce4e yb-bignode-node6:9100 16.66s          ALIVE    0.00     0.00     712      0 B             0 B             0               77.66 MB yb-bignode-node6:9100
d726e87208c449198dbd76f58942b7e5 yb-bignode-node7:9100 16.66s          ALIVE    0.00     0.00     712      0 B             0 B             0               74.03 MB yb-bignode-node7:9100
79ea0d242cc445b79a7296818b240a99 yb-bignode-node8:9100 17.03s          ALIVE    0.00     0.00     9680     0 B             0 B             0               42.83 MB yb-bignode-node8:9100
54072ccf9a7b4b0586f2cfaf36b2ceb4 yb-bignode-node9:9100 16.66s          ALIVE    0.00     0.00     712      0 B             0 B             0               72.46 MB yb-bignode-node9:9100
```


### Without this change (Only ALIVE nodes)

```
yb-admin -master_addresses yb-bignode-node1:7100,yb-bignode-node2:7100,yb-bignode-node4:7100 list_all_tablet_servers
Tablet Server UUID               RPC Host/Port Heartbeat delay Status   Reads/s  Writes/s Uptime   SST total size  SST uncomp size SST #files      Memory   Broadcast Host/Port
137117e25f094bda9c91a75ccf121a6e yb-bignode-node3:9100 0.01s           ALIVE    0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node3:9100
1e70b965485a402f8555c961e92b8ed5 yb-bignode-node2:9100 0.01s           ALIVE    0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node2:9100
54072ccf9a7b4b0586f2cfaf36b2ceb4 yb-bignode-node9:9100 0.01s           ALIVE    0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node9:9100
693f5820f2f74dd1a55936b9b9ed2ff0 yb-bignode-node5:9100 0.01s           ALIVE    0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node5:9100
6e2661e85242440487e626d043729ee4 yb-bignode-node15:9100 0.01s           ALIVE    0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node15:9100
70f50b8d894547beaa2a698ba6f2ce4e yb-bignode-node6:9100 0.01s           ALIVE    0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node6:9100
79ea0d242cc445b79a7296818b240a99 yb-bignode-node8:9100 0.01s           ALIVE    0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node8:9100
807bcd5a3f314ff8af5f1b24cde2aef1 yb-bignode-node12:9100 0.01s           ALIVE    0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node12:9100
9ac59894d8814e97a9e0bd3f05b85eeb yb-bignode-node14:9100 0.01s           ALIVE    0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node14:9100
9cc7f27663cd4bbe81869a990cc01100 yb-bignode-node4:9100 0.01s           ALIVE    0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node4:9100
a3b423b811f04c819fd0bccabccadd9f yb-bignode-node1:9100 0.01s           ALIVE    0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node1:9100
d726e87208c449198dbd76f58942b7e5 yb-bignode-node7:9100 0.01s           ALIVE    0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node7:9100
e050458be63441a294d583b3eb703aff yb-bignode-node11:9100 0.01s           ALIVE    0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node11:9100
f99c37be78234103ae89fa4356d4ae8e yb-bignode-node10:9100 0.01s           ALIVE    0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node10:9100
ff8a67d84fa6447c90a19e325c6012e7 yb-bignode-node13:9100 0.01s           ALIVE    0.00     0.00     0        0 B             0 B             0               0 B      yb-bignode-node13:9100
```


### Hostname sort note (all-ALIVE cluster)

When every node is ALIVE, ordering is purely by hostname string compare.
In the mixed ALIVE/DEAD example above, positions 2–7 are `node2`–`node7`
(alive group sorted by host). In the all-ALIVE example, positions 2–7
are `node10`–`node15` because string compare treats `node10` as coming
before `node2` (`'1' < '2'` at the first differing character). This is
expected lexicographic behavior, not a comparator bug.

In production, hostnames typically include AZ/region prefixes (e.g.
`useast1a-1`, `useast1b-2`) which sort in a more human-readable order.

---------

Original commit: d3cca658195a46562824906fb845bf49bc911d58 / #32476