### PR TITLE
node-agent: Add CheckYugabyteDbStatus RPC to detect running YugabyteDB processes

### DIFF
--- a/managed/node-agent/app/server/rpc.go
+++ b/managed/node-agent/app/server/rpc.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"node-agent/app/task"
+	"node-agent/app/ybdb"
 	pb "node-agent/generated/service"
 	"node-agent/metric"
 	"node-agent/model"
@@ -687,6 +688,21 @@ func (server *RPCServer) Update(
 	}
 	res := &pb.UpdateResponse{Home: util.MustGetHomeDirectory()}
 	return res, err
+}
+
+// CheckYugabyteDbStatus detects the running YugabyteDB related processes on the
+// node, the ports they listen on and the configuration they were started with.
+func (server *RPCServer) CheckYugabyteDbStatus(
+	ctx context.Context,
+	in *pb.CheckYugabyteDbStatusRequest,
+) (*pb.CheckYugabyteDbStatusResponse, error) {
+	util.FileLogger().Debugf(ctx, "Received check YugabyteDB status")
+	res, err := ybdb.NewDetector().Detect(ctx)
+	if err != nil {
+		util.FileLogger().Errorf(ctx, "Error in detecting YugabyteDB status - %s", err.Error())
+		return nil, toGrpcErrorIfNeeded(codes.Internal, err)
+	}
+	return res, nil
 }
 
 /* End of gRPC methods. */

--- a/managed/node-agent/app/server/rpc_test.go
+++ b/managed/node-agent/app/server/rpc_test.go
@@ -102,6 +102,42 @@ func TestPing(t *testing.T) {
 	}
 }
 
+func TestCheckYugabyteDbStatus(t *testing.T) {
+	conn, err := grpc.Dial(serverAddr, dialOpts...)
+	if err != nil {
+		t.Fatalf("Failed to dial: %v", err)
+	}
+	defer conn.Close()
+	client := pb.NewNodeAgentClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	res, err := client.CheckYugabyteDbStatus(ctx, &pb.CheckYugabyteDbStatusRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The test host is not expected to run YugabyteDB, so only the shape of the
+	// response is validated: one status entry per known role.
+	if len(res.GetProcesses()) == 0 {
+		t.Fatalf("Expected a status entry per role")
+	}
+	roles := map[pb.YugabyteProcessRole]bool{}
+	for _, status := range res.GetProcesses() {
+		roles[status.GetRole()] = true
+	}
+	expectedRoles := []pb.YugabyteProcessRole{
+		pb.YugabyteProcessRole_YB_ROLE_MASTER,
+		pb.YugabyteProcessRole_YB_ROLE_TSERVER,
+		pb.YugabyteProcessRole_YB_ROLE_CONTROLLER,
+		pb.YugabyteProcessRole_YB_ROLE_POSTGRES,
+		pb.YugabyteProcessRole_YB_ROLE_NODE_EXPORTER,
+	}
+	for _, role := range expectedRoles {
+		if !roles[role] {
+			t.Errorf("Expected status entry for role %s", role)
+		}
+	}
+}
+
 func TestExecuteInvalidCommand(t *testing.T) {
 	conn, err := grpc.Dial(serverAddr, dialOpts...)
 	if err != nil {

--- a/managed/node-agent/app/ybdb/config.go
+++ b/managed/node-agent/app/ybdb/config.go
@@ -1,0 +1,137 @@
+// Copyright (c) YugabyteDB, Inc.
+
+package ybdb
+
+import (
+	pb "node-agent/generated/service"
+	"sort"
+	"strings"
+)
+
+const (
+	// maxFlagfileBytes caps the number of bytes read from a flagfile.
+	maxFlagfileBytes = 256 * 1024
+	// maxConfigKeys caps the number of arguments returned per source to avoid
+	// excessively large responses.
+	maxConfigKeys = 500
+	// redactedValue replaces the value of sensitive arguments.
+	redactedValue = "REDACTED"
+	// flagfileKey is the argument key that points to the flagfile itself.
+	flagfileKey = "flagfile"
+)
+
+// argKV is an intermediate key-value representation of a process argument.
+type argKV struct {
+	key   string
+	value string
+}
+
+// sensitiveKeySubstrings are matched (case-insensitively) against argument keys
+// to decide whether the value must be redacted.
+var sensitiveKeySubstrings = []string{
+	"password",
+	"secret",
+	"token",
+	"jwt",
+	"credential",
+	"passphrase",
+}
+
+// isSensitiveKey returns true when the value for the key must be redacted.
+func isSensitiveKey(key string) bool {
+	lower := strings.ToLower(key)
+	for _, substr := range sensitiveKeySubstrings {
+		if strings.Contains(lower, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// mergeArgs overlays the command line arguments on top of the flagfile
+// arguments, matching gflags precedence where the command line wins. The
+// flagfile pointer itself is excluded from the effective set.
+func mergeArgs(flagfileArgs, cmdArgs []argKV) []argKV {
+	merged := make(map[string]string)
+	for _, arg := range flagfileArgs {
+		merged[arg.key] = arg.value
+	}
+	for _, arg := range cmdArgs {
+		if arg.key == flagfileKey {
+			continue
+		}
+		merged[arg.key] = arg.value
+	}
+	return sortedArgs(merged)
+}
+
+// sortedArgs returns the map as a slice sorted by key for deterministic output.
+func sortedArgs(m map[string]string) []argKV {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	args := make([]argKV, 0, len(keys))
+	for _, k := range keys {
+		args = append(args, argKV{key: k, value: m[k]})
+	}
+	return args
+}
+
+// toProtoArgs converts the arguments to their proto form, capping the count and
+// redacting sensitive values.
+func toProtoArgs(args []argKV, source string) []*pb.ProcessArg {
+	if len(args) > maxConfigKeys {
+		args = args[:maxConfigKeys]
+	}
+	result := make([]*pb.ProcessArg, 0, len(args))
+	for _, arg := range args {
+		value := arg.value
+		if isSensitiveKey(arg.key) {
+			value = redactedValue
+		}
+		result = append(result, &pb.ProcessArg{
+			Key:    arg.key,
+			Value:  value,
+			Source: source,
+		})
+	}
+	return result
+}
+
+// buildConfig assembles the ProcessConfig from the parsed command line and the
+// flagfile content when it is readable.
+func buildConfig(
+	flagfilePath string,
+	flagfileExists bool,
+	flagfileReadable bool,
+	cmdArgs []argKV,
+	flagfileContent []byte,
+) *pb.ProcessConfig {
+	sortedCmdArgs := sortArgSlice(cmdArgs)
+	var flagfileArgs []argKV
+	if flagfileReadable {
+		flagfileArgs = parseFlagfile(flagfileContent)
+	}
+	sortedFlagfileArgs := sortArgSlice(flagfileArgs)
+	mergedArgs := mergeArgs(sortedFlagfileArgs, sortedCmdArgs)
+	return &pb.ProcessConfig{
+		FlagfilePath:     flagfilePath,
+		FlagfileExists:   flagfileExists,
+		FlagfileReadable: flagfileReadable,
+		CmdlineArgs:      toProtoArgs(sortedCmdArgs, "cmdline"),
+		FlagfileArgs:     toProtoArgs(sortedFlagfileArgs, "flagfile"),
+		Args:             toProtoArgs(mergedArgs, "merged"),
+	}
+}
+
+// sortArgSlice returns a copy of the argument slice sorted by key.
+func sortArgSlice(args []argKV) []argKV {
+	sorted := make([]argKV, len(args))
+	copy(sorted, args)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return sorted[i].key < sorted[j].key
+	})
+	return sorted
+}

--- a/managed/node-agent/app/ybdb/config_test.go
+++ b/managed/node-agent/app/ybdb/config_test.go
@@ -82,7 +82,13 @@ func TestBuildConfigRedactsAllSources(t *testing.T) {
 
 func TestBuildConfigUnreadableFlagfile(t *testing.T) {
 	cmdArgs := []argKV{{key: "flagfile", value: "/conf/server.conf"}}
-	config := buildConfig("/conf/server.conf", true /* exists */, false /* readable */, cmdArgs, nil)
+	config := buildConfig(
+		"/conf/server.conf",
+		true,  /* exists */
+		false, /* readable */
+		cmdArgs,
+		nil,
+	)
 	if len(config.GetFlagfileArgs()) != 0 {
 		t.Errorf("expected no flagfile args when unreadable, got %+v", config.GetFlagfileArgs())
 	}

--- a/managed/node-agent/app/ybdb/config_test.go
+++ b/managed/node-agent/app/ybdb/config_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) YugabyteDB, Inc.
+
+package ybdb
+
+import (
+	pb "node-agent/generated/service"
+	"testing"
+)
+
+func TestIsSensitiveKey(t *testing.T) {
+	sensitive := []string{
+		"ysql_hba_conf_csv_password",
+		"webserver_password",
+		"my_secret",
+		"api_token",
+		"jwt",
+		"ldap_bind_credential",
+		"tls_passphrase",
+	}
+	for _, key := range sensitive {
+		if !isSensitiveKey(key) {
+			t.Errorf("isSensitiveKey(%q) = false, want true", key)
+		}
+	}
+	nonSensitive := []string{"rpc_bind_addresses", "webserver_port", "placement_cloud"}
+	for _, key := range nonSensitive {
+		if isSensitiveKey(key) {
+			t.Errorf("isSensitiveKey(%q) = true, want false", key)
+		}
+	}
+}
+
+func TestMergeArgs(t *testing.T) {
+	flagfileArgs := []argKV{
+		{key: "webserver_port", value: "7000"},
+		{key: "rpc_bind_addresses", value: "10.0.0.1:7100"},
+	}
+	cmdArgs := []argKV{
+		{key: "flagfile", value: "/conf/server.conf"},
+		{key: "webserver_port", value: "7001"},
+	}
+	got := mergeArgs(flagfileArgs, cmdArgs)
+	want := []argKV{
+		{key: "rpc_bind_addresses", value: "10.0.0.1:7100"},
+		// Command line wins over the flagfile value.
+		{key: "webserver_port", value: "7001"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("mergeArgs() len = %d, want %d (%+v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("mergeArgs()[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestBuildConfigRedactsAllSources(t *testing.T) {
+	cmdArgs := []argKV{
+		{key: "flagfile", value: "/conf/server.conf"},
+		{key: "ysql_password", value: "supersecret"},
+	}
+	flagfileContent := []byte("--webserver_port=7000\n--ldap_bind_password=topsecret\n")
+	config := buildConfig(
+		"/conf/server.conf",
+		true, /* exists */
+		true, /* readable */
+		cmdArgs,
+		flagfileContent,
+	)
+	if config.GetFlagfilePath() != "/conf/server.conf" {
+		t.Errorf("flagfile path = %q", config.GetFlagfilePath())
+	}
+	if !config.GetFlagfileExists() || !config.GetFlagfileReadable() {
+		t.Errorf("expected flagfile to exist and be readable")
+	}
+	assertRedacted(t, config.GetCmdlineArgs(), "ysql_password")
+	assertRedacted(t, config.GetFlagfileArgs(), "ldap_bind_password")
+	assertRedacted(t, config.GetArgs(), "ysql_password")
+	assertRedacted(t, config.GetArgs(), "ldap_bind_password")
+}
+
+func TestBuildConfigUnreadableFlagfile(t *testing.T) {
+	cmdArgs := []argKV{{key: "flagfile", value: "/conf/server.conf"}}
+	config := buildConfig("/conf/server.conf", true /* exists */, false /* readable */, cmdArgs, nil)
+	if len(config.GetFlagfileArgs()) != 0 {
+		t.Errorf("expected no flagfile args when unreadable, got %+v", config.GetFlagfileArgs())
+	}
+	if config.GetFlagfileReadable() {
+		t.Errorf("expected flagfile readable to be false")
+	}
+}
+
+func assertRedacted(t *testing.T, args []*pb.ProcessArg, key string) {
+	t.Helper()
+	for _, arg := range args {
+		if arg.GetKey() == key {
+			if arg.GetValue() != redactedValue {
+				t.Errorf("expected key %q to be redacted, got %q", key, arg.GetValue())
+			}
+			return
+		}
+	}
+	t.Errorf("key %q not found in args", key)
+}

--- a/managed/node-agent/app/ybdb/detector.go
+++ b/managed/node-agent/app/ybdb/detector.go
@@ -1,0 +1,297 @@
+// Copyright (c) YugabyteDB, Inc.
+
+package ybdb
+
+import (
+	"context"
+	pb "node-agent/generated/service"
+	"node-agent/util"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// DetectTimeout is the maximum time allowed for a full detection sweep.
+const DetectTimeout = 5 * time.Second
+
+// Detector detects running YugabyteDB related processes on the node.
+type Detector struct {
+	sys System
+}
+
+// NewDetector returns a Detector backed by the local operating system.
+func NewDetector() *Detector {
+	return &Detector{sys: newOsSystem()}
+}
+
+// NewDetectorWithSystem returns a Detector backed by the given System. It is
+// primarily used for testing.
+func NewDetectorWithSystem(sys System) *Detector {
+	return &Detector{sys: sys}
+}
+
+// allDefaultPorts maps every known default port to its role.
+var allDefaultPorts = func() map[uint32]pb.YugabyteProcessRole {
+	ports := make(map[uint32]pb.YugabyteProcessRole)
+	for _, def := range roleDefs {
+		for _, port := range def.defaultPorts {
+			ports[port] = def.role
+		}
+	}
+	return ports
+}()
+
+// roleState is the intermediate detection state for a single role.
+type roleState struct {
+	def         roleDef
+	pids        []int
+	primaryArgs []string
+	listeners   []ssListener
+	ports       map[uint32]bool
+}
+
+// Detect performs a read-only detection sweep and returns the status of each
+// known role.
+func (d *Detector) Detect(ctx context.Context) (*pb.CheckYugabyteDbStatusResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, DetectTimeout)
+	defer cancel()
+
+	selfPid := d.sys.SelfPid()
+	states := make(map[pb.YugabyteProcessRole]*roleState, len(roleDefs))
+	pidRole := make(map[int]pb.YugabyteProcessRole)
+	for _, def := range roleDefs {
+		state := &roleState{def: def, ports: make(map[uint32]bool)}
+		pids := d.verifiedPids(ctx, def, selfPid)
+		state.pids = pids
+		if len(pids) > 0 {
+			// The primary pid is the lowest pid.
+			primary := pids[0]
+			for _, pid := range pids {
+				if pid < primary {
+					primary = pid
+				}
+				pidRole[pid] = def.role
+			}
+			if args, err := d.sys.ReadCmdline(primary); err == nil {
+				state.primaryArgs = args
+			}
+		}
+		states[def.role] = state
+	}
+
+	listeners := d.listeners(ctx)
+	listenedPorts := make(map[uint32]bool)
+	for _, listener := range listeners {
+		listenedPorts[listener.port] = true
+	}
+
+	otherListeners := make([]*pb.ProcessListener, 0)
+	for _, listener := range listeners {
+		role := d.classifyListener(listener, pidRole)
+		if role == pb.YugabyteProcessRole_YB_ROLE_UNKNOWN {
+			continue
+		}
+		if _, isDefault := allDefaultPorts[listener.port]; !isDefault {
+			// A YugabyteDB process listening on a non-default port.
+			otherListeners = append(otherListeners, toProtoListener(listener, role))
+		}
+	}
+
+	// Attribute default ports that are actually being listened on to their role.
+	for _, listener := range listeners {
+		if role, isDefault := allDefaultPorts[listener.port]; isDefault {
+			state := states[role]
+			state.ports[listener.port] = true
+			state.listeners = append(state.listeners, listener)
+		}
+	}
+
+	response := &pb.CheckYugabyteDbStatusResponse{
+		OtherListeners: otherListeners,
+	}
+	for _, def := range roleDefs {
+		state := states[def.role]
+		processStatus := d.buildProcessStatus(ctx, state)
+		response.Processes = append(response.Processes, processStatus)
+		if processStatus.GetRunning() {
+			switch def.role {
+			case pb.YugabyteProcessRole_YB_ROLE_MASTER:
+				response.MasterPresent = true
+			case pb.YugabyteProcessRole_YB_ROLE_TSERVER:
+				response.TserverPresent = true
+			case pb.YugabyteProcessRole_YB_ROLE_CONTROLLER:
+				response.ControllerPresent = true
+			case pb.YugabyteProcessRole_YB_ROLE_POSTGRES:
+				response.PostgresPresent = true
+			case pb.YugabyteProcessRole_YB_ROLE_NODE_EXPORTER:
+				response.NodeExporterPresent = true
+			}
+		}
+	}
+	return response, nil
+}
+
+// verifiedPids returns the pids for the role after confirming each candidate by
+// classifying its command line. The current process is always excluded.
+func (d *Detector) verifiedPids(
+	ctx context.Context,
+	def roleDef,
+	selfPid int,
+) []int {
+	candidates, err := d.sys.Pgrep(ctx, def.pgrepPattern)
+	if err != nil {
+		util.FileLogger().Warnf(ctx, "Failed to pgrep for %s: %s", def.name, err.Error())
+		return nil
+	}
+	pids := make([]int, 0, len(candidates))
+	for _, pid := range candidates {
+		if pid == selfPid {
+			continue
+		}
+		args, err := d.sys.ReadCmdline(pid)
+		if err != nil {
+			continue
+		}
+		if classifyRole(strings.Join(args, " ")) == def.role {
+			pids = append(pids, pid)
+		}
+	}
+	return pids
+}
+
+// listeners returns the parsed listening sockets. A failure to run the sweep is
+// logged and treated as an empty result so that process based detection can
+// still succeed.
+func (d *Detector) listeners(ctx context.Context) []ssListener {
+	out, err := d.sys.SsListeners(ctx)
+	if err != nil {
+		util.FileLogger().Warnf(ctx, "Failed to list listening sockets: %s", err.Error())
+		return nil
+	}
+	return parseSsListeners(out)
+}
+
+// classifyListener determines the role of a listening socket using the pid to
+// role map, then the process command line and finally the process name.
+func (d *Detector) classifyListener(
+	listener ssListener,
+	pidRole map[int]pb.YugabyteProcessRole,
+) pb.YugabyteProcessRole {
+	if listener.pid == 0 {
+		return pb.YugabyteProcessRole_YB_ROLE_UNKNOWN
+	}
+	if role, ok := pidRole[listener.pid]; ok {
+		return role
+	}
+	if args, err := d.sys.ReadCmdline(listener.pid); err == nil {
+		if role := classifyRole(strings.Join(args, " ")); role != pb.YugabyteProcessRole_YB_ROLE_UNKNOWN {
+			return role
+		}
+	}
+	return classifyProcessName(listener.processName)
+}
+
+// buildProcessStatus assembles the status for a single role, including the
+// configuration when applicable.
+func (d *Detector) buildProcessStatus(
+	ctx context.Context,
+	state *roleState,
+) *pb.ProcessStatus {
+	running := len(state.pids) > 0 || len(state.ports) > 0
+	status := &pb.ProcessStatus{
+		Role:    state.def.role,
+		Running: running,
+	}
+	if len(state.pids) > 0 {
+		status.Pid = int32(state.pids[0])
+	}
+	ports := make([]uint32, 0, len(state.ports))
+	for port := range state.ports {
+		ports = append(ports, port)
+	}
+	sort.Slice(ports, func(i, j int) bool { return ports[i] < ports[j] })
+	status.ListenPorts = ports
+	for _, listener := range state.listeners {
+		status.Listeners = append(status.Listeners, toProtoListener(listener, state.def.role))
+	}
+	if state.def.hasConfig && running && len(state.primaryArgs) > 0 {
+		status.Config = d.buildConfigForProcess(ctx, state)
+	}
+	return status
+}
+
+// buildConfigForProcess extracts the flagfile path and arguments for a running
+// process from its command line and flagfile.
+func (d *Detector) buildConfigForProcess(
+	ctx context.Context,
+	state *roleState,
+) *pb.ProcessConfig {
+	flagfilePath, cmdArgs := parseCmdline(state.primaryArgs)
+	if flagfilePath == "" {
+		flagfilePath = deriveFlagfilePath(state.primaryArgs[0])
+	}
+	var exists, readable bool
+	var content []byte
+	if flagfilePath != "" {
+		exists, readable = d.sys.StatFile(flagfilePath)
+		if readable {
+			data, err := d.sys.ReadFileLimit(flagfilePath, maxFlagfileBytes)
+			if err != nil {
+				util.FileLogger().
+					Warnf(ctx, "Failed to read flagfile %s: %s", flagfilePath, err.Error())
+				readable = false
+			} else {
+				content = data
+			}
+		}
+	}
+	return buildConfig(flagfilePath, exists, readable, cmdArgs, content)
+}
+
+// deriveFlagfilePath returns the conventional flagfile path for a YugabyteDB
+// binary, e.g. ".../master/bin/yb-master" resolves to
+// ".../master/conf/server.conf".
+func deriveFlagfilePath(binaryPath string) string {
+	if binaryPath == "" {
+		return ""
+	}
+	binDir := filepath.Dir(binaryPath)
+	serverHome := filepath.Dir(binDir)
+	if serverHome == "" || serverHome == "." || serverHome == "/" {
+		return ""
+	}
+	return filepath.Join(serverHome, "conf", "server.conf")
+}
+
+// classifyProcessName classifies a listening socket by its process name, which
+// may be truncated to the kernel comm length.
+func classifyProcessName(name string) pb.YugabyteProcessRole {
+	if name == "" {
+		return pb.YugabyteProcessRole_YB_ROLE_UNKNOWN
+	}
+	switch {
+	case strings.HasPrefix(name, "yb-master"):
+		return pb.YugabyteProcessRole_YB_ROLE_MASTER
+	case strings.HasPrefix(name, "yb-tserver"):
+		return pb.YugabyteProcessRole_YB_ROLE_TSERVER
+	case strings.HasPrefix(name, "yb-controller"):
+		return pb.YugabyteProcessRole_YB_ROLE_CONTROLLER
+	case strings.Contains(name, "postgres") || strings.Contains(name, "postmaster"):
+		return pb.YugabyteProcessRole_YB_ROLE_POSTGRES
+	case strings.Contains(name, "node_exporter"):
+		return pb.YugabyteProcessRole_YB_ROLE_NODE_EXPORTER
+	}
+	return pb.YugabyteProcessRole_YB_ROLE_UNKNOWN
+}
+
+// toProtoListener converts an internal listener to its proto form.
+func toProtoListener(listener ssListener, role pb.YugabyteProcessRole) *pb.ProcessListener {
+	return &pb.ProcessListener{
+		Port:        listener.port,
+		Protocol:    listener.protocol,
+		Pid:         int32(listener.pid),
+		Role:        role,
+		ProcessName: listener.processName,
+	}
+}

--- a/managed/node-agent/app/ybdb/detector.go
+++ b/managed/node-agent/app/ybdb/detector.go
@@ -153,7 +153,7 @@ func (d *Detector) verifiedPids(
 		if err != nil {
 			continue
 		}
-		if classifyRole(strings.Join(args, " ")) == def.role {
+		if classifyRole(args) == def.role {
 			pids = append(pids, pid)
 		}
 	}
@@ -185,7 +185,7 @@ func (d *Detector) classifyListener(
 		return role
 	}
 	if args, err := d.sys.ReadCmdline(listener.pid); err == nil {
-		if role := classifyRole(strings.Join(args, " ")); role != pb.YugabyteProcessRole_YB_ROLE_UNKNOWN {
+		if role := classifyRole(args); role != pb.YugabyteProcessRole_YB_ROLE_UNKNOWN {
 			return role
 		}
 	}

--- a/managed/node-agent/app/ybdb/detector.go
+++ b/managed/node-agent/app/ybdb/detector.go
@@ -63,17 +63,15 @@ func (d *Detector) Detect(ctx context.Context) (*pb.CheckYugabyteDbStatusRespons
 	for _, def := range roleDefs {
 		state := &roleState{def: def, ports: make(map[uint32]bool)}
 		pids := d.verifiedPids(ctx, def, selfPid)
+		sort.Ints(pids)
 		state.pids = pids
 		if len(pids) > 0 {
-			// The primary pid is the lowest pid.
-			primary := pids[0]
+			// The primary pid is the lowest pid and is always pids[0]
+			// after sorting, so reported Pid and config stay aligned.
 			for _, pid := range pids {
-				if pid < primary {
-					primary = pid
-				}
 				pidRole[pid] = def.role
 			}
-			if args, err := d.sys.ReadCmdline(primary); err == nil {
+			if args, err := d.sys.ReadCmdline(pids[0]); err == nil {
 				state.primaryArgs = args
 			}
 		}
@@ -81,31 +79,7 @@ func (d *Detector) Detect(ctx context.Context) (*pb.CheckYugabyteDbStatusRespons
 	}
 
 	listeners := d.listeners(ctx)
-	listenedPorts := make(map[uint32]bool)
-	for _, listener := range listeners {
-		listenedPorts[listener.port] = true
-	}
-
-	otherListeners := make([]*pb.ProcessListener, 0)
-	for _, listener := range listeners {
-		role := d.classifyListener(listener, pidRole)
-		if role == pb.YugabyteProcessRole_YB_ROLE_UNKNOWN {
-			continue
-		}
-		if _, isDefault := allDefaultPorts[listener.port]; !isDefault {
-			// A YugabyteDB process listening on a non-default port.
-			otherListeners = append(otherListeners, toProtoListener(listener, role))
-		}
-	}
-
-	// Attribute default ports that are actually being listened on to their role.
-	for _, listener := range listeners {
-		if role, isDefault := allDefaultPorts[listener.port]; isDefault {
-			state := states[role]
-			state.ports[listener.port] = true
-			state.listeners = append(state.listeners, listener)
-		}
-	}
+	otherListeners := d.attributeListeners(states, pidRole, listeners)
 
 	response := &pb.CheckYugabyteDbStatusResponse{
 		OtherListeners: otherListeners,
@@ -172,6 +146,52 @@ func (d *Detector) listeners(ctx context.Context) []ssListener {
 	return parseSsListeners(out)
 }
 
+// attributeListeners assigns listening sockets to roles. A listener is only
+// credited to a role when classifyListener agrees, so an unrelated process on
+// a default YB port (9000, 5433, …) cannot mark that role present. The
+// exception is a pid-less default-port listener (ss -p unavailable) when the
+// role was already confirmed via pgrep.
+func (d *Detector) attributeListeners(
+	states map[pb.YugabyteProcessRole]*roleState,
+	pidRole map[int]pb.YugabyteProcessRole,
+	listeners []ssListener,
+) []*pb.ProcessListener {
+	otherListeners := make([]*pb.ProcessListener, 0)
+	for _, listener := range listeners {
+		classified := d.classifyListener(listener, pidRole)
+		if classified != pb.YugabyteProcessRole_YB_ROLE_UNKNOWN {
+			appendListener(states[classified], listener, classified, &otherListeners)
+			continue
+		}
+		if listener.pid != 0 {
+			continue
+		}
+		role, isDefault := allDefaultPorts[listener.port]
+		if !isDefault || len(states[role].pids) == 0 {
+			continue
+		}
+		appendListener(states[role], listener, role, &otherListeners)
+	}
+	return otherListeners
+}
+
+// appendListener records a listener on its classified role. Default ports for
+// that role are kept on the process status; any other port is also reported in
+// otherListeners.
+func appendListener(
+	state *roleState,
+	listener ssListener,
+	role pb.YugabyteProcessRole,
+	otherListeners *[]*pb.ProcessListener,
+) {
+	if owner, isDefault := allDefaultPorts[listener.port]; isDefault && owner == role {
+		state.ports[listener.port] = true
+		state.listeners = append(state.listeners, listener)
+		return
+	}
+	*otherListeners = append(*otherListeners, toProtoListener(listener, role))
+}
+
 // classifyListener determines the role of a listening socket using the pid to
 // role map, then the process command line and finally the process name.
 func (d *Detector) classifyListener(
@@ -185,9 +205,9 @@ func (d *Detector) classifyListener(
 		return role
 	}
 	if args, err := d.sys.ReadCmdline(listener.pid); err == nil {
-		if role := classifyRole(args); role != pb.YugabyteProcessRole_YB_ROLE_UNKNOWN {
-			return role
-		}
+		// Trust the executable path over the kernel comm, including a
+		// definitive UNKNOWN (e.g. system postgres vs yb-postmaster).
+		return classifyRole(args)
 	}
 	return classifyProcessName(listener.processName)
 }
@@ -198,6 +218,8 @@ func (d *Detector) buildProcessStatus(
 	ctx context.Context,
 	state *roleState,
 ) *pb.ProcessStatus {
+	// Ports are only populated from classified (or pgrep-backed pid-less)
+	// listeners, so a foreign process on a default YB port cannot flip this.
 	running := len(state.pids) > 0 || len(state.ports) > 0
 	status := &pb.ProcessStatus{
 		Role:    state.def.role,

--- a/managed/node-agent/app/ybdb/detector_test.go
+++ b/managed/node-agent/app/ybdb/detector_test.go
@@ -1,0 +1,239 @@
+// Copyright (c) YugabyteDB, Inc.
+
+package ybdb
+
+import (
+	"context"
+	pb "node-agent/generated/service"
+	"testing"
+)
+
+// fakeSystem is an in-memory System used to drive the detector in tests.
+type fakeSystem struct {
+	pgrep    map[string][]int
+	cmdlines map[int][]string
+	ssOutput string
+	files    map[string][]byte
+	selfPid  int
+}
+
+func (f *fakeSystem) Pgrep(ctx context.Context, pattern string) ([]int, error) {
+	return f.pgrep[pattern], nil
+}
+
+func (f *fakeSystem) ReadCmdline(pid int) ([]string, error) {
+	if args, ok := f.cmdlines[pid]; ok {
+		return args, nil
+	}
+	return nil, context.Canceled
+}
+
+func (f *fakeSystem) SsListeners(ctx context.Context) (string, error) {
+	return f.ssOutput, nil
+}
+
+func (f *fakeSystem) StatFile(path string) (bool, bool) {
+	_, ok := f.files[path]
+	return ok, ok
+}
+
+func (f *fakeSystem) ReadFileLimit(path string, max int64) ([]byte, error) {
+	if data, ok := f.files[path]; ok {
+		return data, nil
+	}
+	return nil, context.Canceled
+}
+
+func (f *fakeSystem) SelfPid() int {
+	return f.selfPid
+}
+
+func fullDeploymentSystem() *fakeSystem {
+	return &fakeSystem{
+		selfPid: 999,
+		pgrep: map[string][]int{
+			"bin/yb-master":            {1001},
+			"bin/yb-tserver":           {1002},
+			"bin/yb-controller-server": {1003},
+			"postgres/bin/postgres":    {1004},
+			"node_exporter":            {1005},
+		},
+		cmdlines: map[int][]string{
+			1001: {
+				"/home/yugabyte/master/bin/yb-master",
+				"--flagfile",
+				"/home/yugabyte/master/conf/server.conf",
+			},
+			1002: {
+				"/home/yugabyte/tserver/bin/yb-tserver",
+				"--flagfile",
+				"/home/yugabyte/tserver/conf/server.conf",
+			},
+			1003: {
+				"/home/yugabyte/controller/bin/yb-controller-server",
+				"--flagfile",
+				"/home/yugabyte/controller/conf/server.conf",
+			},
+			1004: {"/home/yugabyte/tserver/postgres/bin/postgres", "-D", "/home/yugabyte/pgdata"},
+			1005: {"/home/yugabyte/node_exporter/bin/node_exporter"},
+		},
+		ssOutput: `LISTEN 0 4096 0.0.0.0:7000 0.0.0.0:* users:(("yb-master",pid=1001,fd=1))
+LISTEN 0 4096 0.0.0.0:7100 0.0.0.0:* users:(("yb-master",pid=1001,fd=2))
+LISTEN 0 4096 0.0.0.0:9000 0.0.0.0:* users:(("yb-tserver",pid=1002,fd=1))
+LISTEN 0 4096 0.0.0.0:9100 0.0.0.0:* users:(("yb-tserver",pid=1002,fd=2))
+LISTEN 0 4096 0.0.0.0:14000 0.0.0.0:* users:(("yb-controller-s",pid=1003,fd=1))
+LISTEN 0 4096 0.0.0.0:18018 0.0.0.0:* users:(("yb-controller-s",pid=1003,fd=2))
+LISTEN 0 128 127.0.0.1:5433 0.0.0.0:* users:(("postgres",pid=1004,fd=1))
+LISTEN 0 128 0.0.0.0:9300 0.0.0.0:* users:(("node_exporter",pid=1005,fd=1))
+LISTEN 0 128 0.0.0.0:9042 0.0.0.0:* users:(("yb-tserver",pid=1002,fd=9))
+`,
+		files: map[string][]byte{
+			"/home/yugabyte/master/conf/server.conf": []byte(
+				"--rpc_bind_addresses=10.0.0.1:7100\n--webserver_port=7000\n",
+			),
+			"/home/yugabyte/tserver/conf/server.conf": []byte(
+				"--rpc_bind_addresses=10.0.0.1:9100\n--webserver_port=9000\n",
+			),
+			"/home/yugabyte/controller/conf/server.conf": []byte("--server_address=10.0.0.1\n"),
+		},
+	}
+}
+
+func statusForRole(
+	res *pb.CheckYugabyteDbStatusResponse,
+	role pb.YugabyteProcessRole,
+) *pb.ProcessStatus {
+	for _, status := range res.GetProcesses() {
+		if status.GetRole() == role {
+			return status
+		}
+	}
+	return nil
+}
+
+func TestDetectFullDeployment(t *testing.T) {
+	detector := NewDetectorWithSystem(fullDeploymentSystem())
+	res, err := detector.Detect(context.Background())
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	if !res.GetMasterPresent() || !res.GetTserverPresent() || !res.GetControllerPresent() ||
+		!res.GetPostgresPresent() || !res.GetNodeExporterPresent() {
+		t.Fatalf("expected all roles present, got %+v", res)
+	}
+
+	master := statusForRole(res, pb.YugabyteProcessRole_YB_ROLE_MASTER)
+	if master == nil || !master.GetRunning() || master.GetPid() != 1001 {
+		t.Fatalf("unexpected master status %+v", master)
+	}
+	if !equalPorts(master.GetListenPorts(), []uint32{7000, 7100}) {
+		t.Errorf("master listen ports = %v, want [7000 7100]", master.GetListenPorts())
+	}
+	if master.GetConfig() == nil ||
+		master.GetConfig().GetFlagfilePath() != "/home/yugabyte/master/conf/server.conf" {
+		t.Errorf("unexpected master config %+v", master.GetConfig())
+	}
+	if !hasArg(master.GetConfig().GetFlagfileArgs(), "rpc_bind_addresses", "10.0.0.1:7100") {
+		t.Errorf("master flagfile args missing rpc_bind_addresses: %+v",
+			master.GetConfig().GetFlagfileArgs())
+	}
+
+	postgres := statusForRole(res, pb.YugabyteProcessRole_YB_ROLE_POSTGRES)
+	if postgres == nil || !postgres.GetRunning() || postgres.GetPid() != 1004 {
+		t.Fatalf("unexpected postgres status %+v", postgres)
+	}
+	if postgres.GetConfig() != nil {
+		t.Errorf("postgres should not have config, got %+v", postgres.GetConfig())
+	}
+	if !equalPorts(postgres.GetListenPorts(), []uint32{5433}) {
+		t.Errorf("postgres listen ports = %v, want [5433]", postgres.GetListenPorts())
+	}
+
+	// The non-default tserver port must appear in otherListeners.
+	if !hasListenerPort(res.GetOtherListeners(), 9042, pb.YugabyteProcessRole_YB_ROLE_TSERVER) {
+		t.Errorf("expected other listener on 9042 for tserver, got %+v", res.GetOtherListeners())
+	}
+}
+
+func TestDetectNothingRunning(t *testing.T) {
+	detector := NewDetectorWithSystem(&fakeSystem{selfPid: 999, pgrep: map[string][]int{}})
+	res, err := detector.Detect(context.Background())
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	if res.GetMasterPresent() || res.GetTserverPresent() || res.GetControllerPresent() ||
+		res.GetPostgresPresent() || res.GetNodeExporterPresent() {
+		t.Fatalf("expected no roles present, got %+v", res)
+	}
+	for _, status := range res.GetProcesses() {
+		if status.GetRunning() {
+			t.Errorf("role %s should not be running", status.GetRole())
+		}
+		if status.GetConfig() != nil {
+			t.Errorf("role %s should not have config", status.GetRole())
+		}
+	}
+}
+
+func TestDetectExcludesSelfPid(t *testing.T) {
+	sys := &fakeSystem{
+		selfPid: 1001,
+		pgrep:   map[string][]int{"bin/yb-master": {1001}},
+		cmdlines: map[int][]string{
+			1001: {"/home/yugabyte/master/bin/yb-master", "--flagfile", "/conf/server.conf"},
+		},
+	}
+	detector := NewDetectorWithSystem(sys)
+	res, err := detector.Detect(context.Background())
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	if res.GetMasterPresent() {
+		t.Errorf("self pid must be excluded from detection")
+	}
+}
+
+func TestDeriveFlagfilePath(t *testing.T) {
+	got := deriveFlagfilePath("/home/yugabyte/master/bin/yb-master")
+	want := "/home/yugabyte/master/conf/server.conf"
+	if got != want {
+		t.Errorf("deriveFlagfilePath() = %q, want %q", got, want)
+	}
+	if deriveFlagfilePath("") != "" {
+		t.Errorf("deriveFlagfilePath(\"\") should be empty")
+	}
+}
+
+func equalPorts(got, want []uint32) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func hasArg(args []*pb.ProcessArg, key, value string) bool {
+	for _, arg := range args {
+		if arg.GetKey() == key && arg.GetValue() == value {
+			return true
+		}
+	}
+	return false
+}
+
+func hasListenerPort(
+	listeners []*pb.ProcessListener,
+	port uint32,
+	role pb.YugabyteProcessRole,
+) bool {
+	for _, listener := range listeners {
+		if listener.GetPort() == port && listener.GetRole() == role {
+			return true
+		}
+	}
+	return false
+}

--- a/managed/node-agent/app/ybdb/detector_test.go
+++ b/managed/node-agent/app/ybdb/detector_test.go
@@ -193,6 +193,118 @@ func TestDetectExcludesSelfPid(t *testing.T) {
 	}
 }
 
+func TestDetectIgnoresUnrelatedProcessOnDefaultPort(t *testing.T) {
+	sys := &fakeSystem{
+		selfPid: 999,
+		pgrep:   map[string][]int{},
+		cmdlines: map[int][]string{
+			2001: {"/usr/sbin/nginx"},
+			2002: {"/usr/lib/postgresql/16/bin/postgres", "-D", "/var/lib/postgresql/data"},
+		},
+		ssOutput: `LISTEN 0 4096 0.0.0.0:9000 0.0.0.0:* users:(("nginx",pid=2001,fd=1))
+LISTEN 0 128 127.0.0.1:5433 0.0.0.0:* users:(("postgres",pid=2002,fd=1))
+`,
+	}
+	detector := NewDetectorWithSystem(sys)
+	res, err := detector.Detect(context.Background())
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	if res.GetTserverPresent() {
+		t.Errorf("unrelated process on 9000 must not mark tserver present")
+	}
+	if res.GetPostgresPresent() {
+		t.Errorf("system postgres on 5433 must not mark YB postgres present")
+	}
+	tserver := statusForRole(res, pb.YugabyteProcessRole_YB_ROLE_TSERVER)
+	if tserver != nil && len(tserver.GetListeners()) > 0 {
+		t.Errorf("tserver must not inherit foreign listeners, got %+v", tserver.GetListeners())
+	}
+}
+
+func TestDetectPidMatchesPrimaryConfig(t *testing.T) {
+	sys := &fakeSystem{
+		selfPid: 999,
+		pgrep:   map[string][]int{"bin/yb-master": {2002, 1001}},
+		cmdlines: map[int][]string{
+			2002: {
+				"/home/yugabyte/master/bin/yb-master",
+				"--flagfile",
+				"/home/yugabyte/master/conf/newer.conf",
+			},
+			1001: {
+				"/home/yugabyte/master/bin/yb-master",
+				"--flagfile",
+				"/home/yugabyte/master/conf/server.conf",
+			},
+		},
+		files: map[string][]byte{
+			"/home/yugabyte/master/conf/server.conf": []byte("--webserver_port=7000\n"),
+			"/home/yugabyte/master/conf/newer.conf":  []byte("--webserver_port=7001\n"),
+		},
+	}
+	detector := NewDetectorWithSystem(sys)
+	res, err := detector.Detect(context.Background())
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	master := statusForRole(res, pb.YugabyteProcessRole_YB_ROLE_MASTER)
+	if master == nil || !master.GetRunning() {
+		t.Fatalf("expected running master, got %+v", master)
+	}
+	if master.GetPid() != 1001 {
+		t.Errorf("Pid = %d, want primary pid 1001", master.GetPid())
+	}
+	if master.GetConfig() == nil ||
+		master.GetConfig().GetFlagfilePath() != "/home/yugabyte/master/conf/server.conf" {
+		t.Errorf("config must come from primary pid, got %+v", master.GetConfig())
+	}
+}
+
+func TestDetectPidlessDefaultPortRequiresVerifiedProcess(t *testing.T) {
+	// ss without -p (pid=0) on a default port must not claim the role unless
+	// pgrep already confirmed a matching process.
+	unrelated := &fakeSystem{
+		selfPid:  999,
+		pgrep:    map[string][]int{},
+		ssOutput: "LISTEN 0 4096 0.0.0.0:9000 0.0.0.0:*\n",
+	}
+	res, err := NewDetectorWithSystem(unrelated).Detect(context.Background())
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	if res.GetTserverPresent() {
+		t.Errorf("pid-less listener on 9000 must not mark tserver present")
+	}
+
+	confirmed := &fakeSystem{
+		selfPid: 999,
+		pgrep:   map[string][]int{"bin/yb-tserver": {1002}},
+		cmdlines: map[int][]string{
+			1002: {
+				"/home/yugabyte/tserver/bin/yb-tserver",
+				"--flagfile",
+				"/home/yugabyte/tserver/conf/server.conf",
+			},
+		},
+		ssOutput: "LISTEN 0 4096 0.0.0.0:9000 0.0.0.0:*\n",
+		files: map[string][]byte{
+			"/home/yugabyte/tserver/conf/server.conf": []byte("--webserver_port=9000\n"),
+		},
+	}
+	res, err = NewDetectorWithSystem(confirmed).Detect(context.Background())
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	if !res.GetTserverPresent() {
+		t.Fatalf("verified tserver must still be present without ss -p")
+	}
+	tserver := statusForRole(res, pb.YugabyteProcessRole_YB_ROLE_TSERVER)
+	if tserver == nil || !equalPorts(tserver.GetListenPorts(), []uint32{9000}) {
+		t.Errorf("tserver listen ports = %v, want [9000]", tserver.GetListenPorts())
+	}
+}
+
 func TestDeriveFlagfilePath(t *testing.T) {
 	got := deriveFlagfilePath("/home/yugabyte/master/bin/yb-master")
 	want := "/home/yugabyte/master/conf/server.conf"

--- a/managed/node-agent/app/ybdb/parse.go
+++ b/managed/node-agent/app/ybdb/parse.go
@@ -120,13 +120,13 @@ func parseCmdline(args []string) (flagfilePath string, cmdArgs []argKV) {
 }
 
 // parseFlagfile parses a gflags file into key-value pairs. Blank lines and
-// comment lines (starting with '#') are ignored. Each flag may be written as
+// comment lines (starting with '#' or '//') are ignored. Each flag may be written as
 // "--key=value", "key=value" or "--key" (boolean).
 func parseFlagfile(content []byte) []argKV {
 	args := make([]argKV, 0)
 	for _, line := range strings.Split(string(content), "\n") {
 		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "#") {
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "//") {
 			continue
 		}
 		key := strings.TrimLeft(line, "-")

--- a/managed/node-agent/app/ybdb/parse.go
+++ b/managed/node-agent/app/ybdb/parse.go
@@ -1,0 +1,147 @@
+// Copyright (c) YugabyteDB, Inc.
+
+package ybdb
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// ssListener is a single listening socket parsed from ss output.
+type ssListener struct {
+	port        uint32
+	protocol    string
+	pid         int
+	processName string
+}
+
+var (
+	// ssProcessPidRegex extracts the pid from an ss users:(("name",pid=123,fd=4)) column.
+	ssProcessPidRegex = regexp.MustCompile(`pid=(\d+)`)
+	// ssProcessNameRegex extracts the process name from the same column.
+	ssProcessNameRegex = regexp.MustCompile(`\("([^"]+)"`)
+)
+
+// parseSsListeners parses the output of "ss -H -O -lntp". Lines that cannot be
+// parsed are skipped. The process column is optional as it is only present when
+// the caller has sufficient privilege.
+func parseSsListeners(output string) []ssListener {
+	listeners := make([]ssListener, 0)
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		// State Recv-Q Send-Q Local-Address:Port Peer-Address:Port [Process]
+		if len(fields) < 4 {
+			continue
+		}
+		localAddr := fields[3]
+		port, ok := portFromAddress(localAddr)
+		if !ok {
+			continue
+		}
+		listener := ssListener{
+			port:     port,
+			protocol: protocolFromAddress(localAddr),
+		}
+		// The process column, when present, is the remaining text after the peer.
+		if len(fields) >= 6 {
+			processCol := strings.Join(fields[5:], " ")
+			if match := ssProcessPidRegex.FindStringSubmatch(processCol); match != nil {
+				if pid, err := strconv.Atoi(match[1]); err == nil {
+					listener.pid = pid
+				}
+			}
+			if match := ssProcessNameRegex.FindStringSubmatch(processCol); match != nil {
+				listener.processName = match[1]
+			}
+		}
+		listeners = append(listeners, listener)
+	}
+	return listeners
+}
+
+// portFromAddress returns the port from an ss local address such as
+// "0.0.0.0:7000", "[::]:7100", "*:9300" or "127.0.0.1:5433".
+func portFromAddress(addr string) (uint32, bool) {
+	idx := strings.LastIndex(addr, ":")
+	if idx < 0 || idx == len(addr)-1 {
+		return 0, false
+	}
+	port, err := strconv.ParseUint(addr[idx+1:], 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	return uint32(port), true
+}
+
+// protocolFromAddress returns "tcp6" for IPv6 style addresses and "tcp" otherwise.
+func protocolFromAddress(addr string) string {
+	if strings.Contains(addr, "[") || strings.Contains(addr, "::") {
+		return "tcp6"
+	}
+	return "tcp"
+}
+
+// parseCmdline parses the arguments of a process command line (excluding the
+// binary path in args[0]). It returns the resolved --flagfile path and the list
+// of remaining arguments as key-value pairs. Both "--key=value" and
+// "--key value" forms are supported.
+func parseCmdline(args []string) (flagfilePath string, cmdArgs []argKV) {
+	cmdArgs = make([]argKV, 0)
+	// Skip args[0] which is the binary path.
+	for i := 1; i < len(args); i++ {
+		token := args[i]
+		if !strings.HasPrefix(token, "-") {
+			continue
+		}
+		key := strings.TrimLeft(token, "-")
+		if key == "" {
+			continue
+		}
+		var value string
+		if eq := strings.Index(key, "="); eq >= 0 {
+			value = key[eq+1:]
+			key = key[:eq]
+		} else if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+			// Space separated value, e.g. "--flagfile /path".
+			value = args[i+1]
+			i++
+		}
+		if key == "flagfile" {
+			flagfilePath = value
+		}
+		cmdArgs = append(cmdArgs, argKV{key: key, value: value})
+	}
+	return flagfilePath, cmdArgs
+}
+
+// parseFlagfile parses a gflags file into key-value pairs. Blank lines and
+// comment lines (starting with '#') are ignored. Each flag may be written as
+// "--key=value", "key=value" or "--key" (boolean).
+func parseFlagfile(content []byte) []argKV {
+	args := make([]argKV, 0)
+	for _, line := range strings.Split(string(content), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key := strings.TrimLeft(line, "-")
+		if key == "" {
+			continue
+		}
+		var value string
+		if eq := strings.Index(key, "="); eq >= 0 {
+			value = strings.TrimSpace(key[eq+1:])
+			key = strings.TrimSpace(key[:eq])
+		}
+		if key == "" {
+			continue
+		}
+		args = append(args, argKV{key: key, value: value})
+	}
+	return args
+}

--- a/managed/node-agent/app/ybdb/parse_test.go
+++ b/managed/node-agent/app/ybdb/parse_test.go
@@ -1,0 +1,123 @@
+// Copyright (c) YugabyteDB, Inc.
+
+package ybdb
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseSsListeners(t *testing.T) {
+	output := `LISTEN 0 4096 0.0.0.0:7000 0.0.0.0:* users:(("yb-master",pid=1001,fd=370))
+LISTEN 0 4096 [::]:7100 [::]:* users:(("yb-master",pid=1001,fd=12))
+LISTEN 0 128 127.0.0.1:5433 0.0.0.0:*
+LISTEN 0 128 *:9300 *:*
+garbage line
+`
+	got := parseSsListeners(output)
+	want := []ssListener{
+		{port: 7000, protocol: "tcp", pid: 1001, processName: "yb-master"},
+		{port: 7100, protocol: "tcp6", pid: 1001, processName: "yb-master"},
+		{port: 5433, protocol: "tcp"},
+		{port: 9300, protocol: "tcp"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseSsListeners() = %+v, want %+v", got, want)
+	}
+}
+
+func TestPortFromAddress(t *testing.T) {
+	tests := []struct {
+		addr string
+		port uint32
+		ok   bool
+	}{
+		{"0.0.0.0:7000", 7000, true},
+		{"[::]:7100", 7100, true},
+		{"*:9300", 9300, true},
+		{"127.0.0.1:5433", 5433, true},
+		{"no-port", 0, false},
+		{"trailing:", 0, false},
+	}
+	for _, tt := range tests {
+		port, ok := portFromAddress(tt.addr)
+		if port != tt.port || ok != tt.ok {
+			t.Errorf("portFromAddress(%q) = (%d, %t), want (%d, %t)",
+				tt.addr, port, ok, tt.port, tt.ok)
+		}
+	}
+}
+
+func TestParseCmdline(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		wantFlagfile string
+		wantArgs     []argKV
+	}{
+		{
+			name: "flagfile space separated",
+			args: []string{
+				"/home/yugabyte/tserver/bin/yb-tserver",
+				"--flagfile",
+				"/home/yugabyte/tserver/conf/server.conf",
+			},
+			wantFlagfile: "/home/yugabyte/tserver/conf/server.conf",
+			wantArgs: []argKV{
+				{key: "flagfile", value: "/home/yugabyte/tserver/conf/server.conf"},
+			},
+		},
+		{
+			name: "flagfile equals and extra flags",
+			args: []string{
+				"/bin/yb-master",
+				"--flagfile=/conf/server.conf",
+				"--webserver_port=7000",
+				"--use_client_to_server_encryption",
+			},
+			wantFlagfile: "/conf/server.conf",
+			wantArgs: []argKV{
+				{key: "flagfile", value: "/conf/server.conf"},
+				{key: "webserver_port", value: "7000"},
+				{key: "use_client_to_server_encryption", value: ""},
+			},
+		},
+		{
+			name:         "no flagfile",
+			args:         []string{"/bin/yb-tserver", "--rpc_bind_addresses", "10.0.0.1:9100"},
+			wantFlagfile: "",
+			wantArgs:     []argKV{{key: "rpc_bind_addresses", value: "10.0.0.1:9100"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flagfile, args := parseCmdline(tt.args)
+			if flagfile != tt.wantFlagfile {
+				t.Errorf("flagfile = %q, want %q", flagfile, tt.wantFlagfile)
+			}
+			if !reflect.DeepEqual(args, tt.wantArgs) {
+				t.Errorf("args = %+v, want %+v", args, tt.wantArgs)
+			}
+		})
+	}
+}
+
+func TestParseFlagfile(t *testing.T) {
+	content := []byte(`# This is a comment
+
+--rpc_bind_addresses=10.0.0.1:7100
+--webserver_port=7000
+placement_cloud=aws
+--use_node_to_node_encryption
+`)
+	got := parseFlagfile(content)
+	want := []argKV{
+		{key: "rpc_bind_addresses", value: "10.0.0.1:7100"},
+		{key: "webserver_port", value: "7000"},
+		{key: "placement_cloud", value: "aws"},
+		{key: "use_node_to_node_encryption", value: ""},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseFlagfile() = %+v, want %+v", got, want)
+	}
+}

--- a/managed/node-agent/app/ybdb/roles.go
+++ b/managed/node-agent/app/ybdb/roles.go
@@ -1,0 +1,87 @@
+// Copyright (c) YugabyteDB, Inc.
+
+// Package ybdb provides read-only detection of running YugabyteDB related
+// processes on a node, the ports they listen on and the configuration
+// (flagfile and command line arguments) they were started with.
+package ybdb
+
+import (
+	pb "node-agent/generated/service"
+	"strings"
+)
+
+// roleDef describes how a YugabyteDB related process is detected.
+type roleDef struct {
+	role pb.YugabyteProcessRole
+	// name is a short human readable name used in logs.
+	name string
+	// pgrepPattern is passed to "pgrep -f" to find candidate pids.
+	pgrepPattern string
+	// classifiers are substrings matched against a process command line to
+	// confirm the role. The first matching role wins.
+	classifiers []string
+	// defaultPorts are the well known ports for the role.
+	defaultPorts []uint32
+	// hasConfig indicates whether the flagfile and arguments are extracted.
+	hasConfig bool
+}
+
+// roleDefs is the ordered list of roles that are detected in v1. The order is
+// significant because it is used to classify a process by its command line and
+// the first match wins (for example, yb-tserver is matched before postgres so
+// that the tserver process is not misclassified).
+var roleDefs = []roleDef{
+	{
+		role:         pb.YugabyteProcessRole_YB_ROLE_MASTER,
+		name:         "master",
+		pgrepPattern: "bin/yb-master",
+		classifiers:  []string{"/bin/yb-master"},
+		defaultPorts: []uint32{7000, 7100},
+		hasConfig:    true,
+	},
+	{
+		role:         pb.YugabyteProcessRole_YB_ROLE_TSERVER,
+		name:         "tserver",
+		pgrepPattern: "bin/yb-tserver",
+		classifiers:  []string{"/bin/yb-tserver"},
+		defaultPorts: []uint32{9000, 9100},
+		hasConfig:    true,
+	},
+	{
+		role:         pb.YugabyteProcessRole_YB_ROLE_CONTROLLER,
+		name:         "controller",
+		pgrepPattern: "bin/yb-controller-server",
+		classifiers:  []string{"yb-controller-server"},
+		defaultPorts: []uint32{14000, 18018},
+		hasConfig:    true,
+	},
+	{
+		role:         pb.YugabyteProcessRole_YB_ROLE_POSTGRES,
+		name:         "postgres",
+		pgrepPattern: "postgres/bin/postgres",
+		classifiers:  []string{"postgres/bin/postgres", "yb-postmaster"},
+		defaultPorts: []uint32{5433, 13000},
+		hasConfig:    false,
+	},
+	{
+		role:         pb.YugabyteProcessRole_YB_ROLE_NODE_EXPORTER,
+		name:         "node_exporter",
+		pgrepPattern: "node_exporter",
+		classifiers:  []string{"node_exporter"},
+		defaultPorts: []uint32{9300},
+		hasConfig:    false,
+	},
+}
+
+// classifyRole returns the role for the given process command line, or
+// YB_ROLE_UNKNOWN when it does not match any known YugabyteDB process.
+func classifyRole(cmdline string) pb.YugabyteProcessRole {
+	for _, def := range roleDefs {
+		for _, classifier := range def.classifiers {
+			if strings.Contains(cmdline, classifier) {
+				return def.role
+			}
+		}
+	}
+	return pb.YugabyteProcessRole_YB_ROLE_UNKNOWN
+}

--- a/managed/node-agent/app/ybdb/roles.go
+++ b/managed/node-agent/app/ybdb/roles.go
@@ -75,10 +75,17 @@ var roleDefs = []roleDef{
 
 // classifyRole returns the role for the given process command line, or
 // YB_ROLE_UNKNOWN when it does not match any known YugabyteDB process.
-func classifyRole(cmdline string) pb.YugabyteProcessRole {
+func classifyRole(args []string) pb.YugabyteProcessRole {
+	if len(args) == 0 {
+		return pb.YugabyteProcessRole_YB_ROLE_UNKNOWN
+	}
+	exe := args[0]
 	for _, def := range roleDefs {
 		for _, classifier := range def.classifiers {
-			if strings.Contains(cmdline, classifier) {
+			if strings.Contains(exe, classifier) {
+				return def.role
+			}
+			if strings.HasPrefix(classifier, "/") && strings.Contains(exe, classifier[1:]) {
 				return def.role
 			}
 		}

--- a/managed/node-agent/app/ybdb/system.go
+++ b/managed/node-agent/app/ybdb/system.go
@@ -115,14 +115,11 @@ func (s *osSystem) ReadCmdline(pid int) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	parts := strings.Split(string(data), "\x00")
-	args := make([]string, 0, len(parts))
-	for _, part := range parts {
-		if part != "" {
-			args = append(args, part)
-		}
+	if len(data) == 0 {
+		return nil, nil
 	}
-	return args, nil
+	trimmed := strings.TrimSuffix(string(data), "\x00")
+	return strings.Split(trimmed, "\x00"), nil
 }
 
 func (s *osSystem) SsListeners(ctx context.Context) (string, error) {

--- a/managed/node-agent/app/ybdb/system.go
+++ b/managed/node-agent/app/ybdb/system.go
@@ -1,0 +1,110 @@
+// Copyright (c) YugabyteDB, Inc.
+
+package ybdb
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// System abstracts the operating system interactions needed for detection so
+// that the detector can be unit tested with fixtures.
+type System interface {
+	// Pgrep returns the pids whose full command line matches the pattern. No
+	// match is not an error and returns an empty slice.
+	Pgrep(ctx context.Context, pattern string) ([]int, error)
+	// ReadCmdline returns the NUL separated arguments of a process.
+	ReadCmdline(pid int) ([]string, error)
+	// SsListeners returns the raw output of the listening socket sweep.
+	SsListeners(ctx context.Context) (string, error)
+	// StatFile reports whether the path exists and is readable.
+	StatFile(path string) (exists bool, readable bool)
+	// ReadFileLimit reads up to max bytes from the path.
+	ReadFileLimit(path string, max int64) ([]byte, error)
+	// SelfPid returns the pid of the current process.
+	SelfPid() int
+}
+
+// osSystem is the production System backed by the local operating system.
+type osSystem struct{}
+
+func newOsSystem() System {
+	return &osSystem{}
+}
+
+func (s *osSystem) Pgrep(ctx context.Context, pattern string) ([]int, error) {
+	cmd := exec.CommandContext(ctx, "pgrep", "-f", pattern)
+	out, err := cmd.Output()
+	if err != nil {
+		// pgrep exits with 1 when there is no match, which is not an error here.
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return nil, nil
+		}
+		return nil, err
+	}
+	pids := make([]int, 0)
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if pid, err := strconv.Atoi(line); err == nil {
+			pids = append(pids, pid)
+		}
+	}
+	return pids, nil
+}
+
+func (s *osSystem) ReadCmdline(pid int) ([]string, error) {
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/cmdline")
+	if err != nil {
+		return nil, err
+	}
+	parts := strings.Split(string(data), "\x00")
+	args := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part != "" {
+			args = append(args, part)
+		}
+	}
+	return args, nil
+}
+
+func (s *osSystem) SsListeners(ctx context.Context) (string, error) {
+	cmd := exec.CommandContext(ctx, "ss", "-H", "-O", "-lntp")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func (s *osSystem) StatFile(path string) (bool, bool) {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return false, false
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return true, false
+	}
+	file.Close()
+	return true, true
+}
+
+func (s *osSystem) ReadFileLimit(path string, max int64) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return io.ReadAll(io.LimitReader(file, max))
+}
+
+func (s *osSystem) SelfPid() int {
+	return os.Getpid()
+}

--- a/managed/node-agent/app/ybdb/system.go
+++ b/managed/node-agent/app/ybdb/system.go
@@ -7,9 +7,59 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
+
+// hardenedPath lists the standard directories where ss and pgrep are installed
+// across RHEL and Debian based distributions. It is used to resolve the tools
+// and is placed on the command environment so that detection works even when
+// the node-agent process runs with a minimal PATH (for example under systemd).
+const hardenedPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+// resolveTool returns an absolute path to the given tool. It first honors the
+// process PATH and falls back to the hardened directories. Go resolves the
+// binary at command construction time using the process PATH, so an explicit
+// lookup is required for the hardened directories to take effect. The bare name
+// is returned when the tool cannot be found so that exec surfaces a clear error.
+func resolveTool(name string) string {
+	if path, err := exec.LookPath(name); err == nil {
+		return path
+	}
+	for _, dir := range filepath.SplitList(hardenedPath) {
+		candidate := filepath.Join(dir, name)
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() &&
+			info.Mode()&0111 != 0 {
+			return candidate
+		}
+	}
+	return name
+}
+
+// commandEnv returns the process environment with the hardened directories
+// ensured on PATH without changing the precedence of the existing PATH.
+func commandEnv() []string {
+	merged := hardenedPath
+	if existing := os.Getenv("PATH"); existing != "" {
+		merged = existing + string(os.PathListSeparator) + hardenedPath
+	}
+	env := os.Environ()
+	result := make([]string, 0, len(env)+1)
+	replaced := false
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "PATH=") {
+			result = append(result, "PATH="+merged)
+			replaced = true
+			continue
+		}
+		result = append(result, kv)
+	}
+	if !replaced {
+		result = append(result, "PATH="+merged)
+	}
+	return result
+}
 
 // System abstracts the operating system interactions needed for detection so
 // that the detector can be unit tested with fixtures.
@@ -37,7 +87,8 @@ func newOsSystem() System {
 }
 
 func (s *osSystem) Pgrep(ctx context.Context, pattern string) ([]int, error) {
-	cmd := exec.CommandContext(ctx, "pgrep", "-f", pattern)
+	cmd := exec.CommandContext(ctx, resolveTool("pgrep"), "-f", pattern)
+	cmd.Env = commandEnv()
 	out, err := cmd.Output()
 	if err != nil {
 		// pgrep exits with 1 when there is no match, which is not an error here.
@@ -75,7 +126,8 @@ func (s *osSystem) ReadCmdline(pid int) ([]string, error) {
 }
 
 func (s *osSystem) SsListeners(ctx context.Context) (string, error) {
-	cmd := exec.CommandContext(ctx, "ss", "-H", "-O", "-lntp")
+	cmd := exec.CommandContext(ctx, resolveTool("ss"), "-H", "-O", "-lntp")
+	cmd.Env = commandEnv()
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err

--- a/managed/node-agent/app/ybdb/system_test.go
+++ b/managed/node-agent/app/ybdb/system_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) YugabyteDB, Inc.
+
+package ybdb
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestResolveToolFallsBackToHardenedPath(t *testing.T) {
+	// A tool that is very unlikely to be on PATH resolves to the bare name.
+	if got := resolveTool("definitely-not-a-real-tool-xyz"); got != "definitely-not-a-real-tool-xyz" {
+		t.Errorf("resolveTool() = %q, want bare name", got)
+	}
+	// A tool that exists in a hardened directory resolves to an absolute path.
+	// "sh" is present in /bin on both RHEL and Debian based systems.
+	if got := resolveTool("sh"); !strings.HasPrefix(got, "/") {
+		t.Errorf("resolveTool(\"sh\") = %q, want an absolute path", got)
+	}
+}
+
+func TestCommandEnvEnsuresHardenedPath(t *testing.T) {
+	env := commandEnv()
+	var pathValue string
+	pathCount := 0
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "PATH=") {
+			pathValue = strings.TrimPrefix(kv, "PATH=")
+			pathCount++
+		}
+	}
+	if pathCount != 1 {
+		t.Fatalf("commandEnv() has %d PATH entries, want exactly 1", pathCount)
+	}
+	for _, dir := range strings.Split(hardenedPath, string(os.PathListSeparator)) {
+		if !strings.Contains(pathValue, dir) {
+			t.Errorf("commandEnv() PATH %q missing hardened dir %q", pathValue, dir)
+		}
+	}
+}

--- a/managed/node-agent/build.sh
+++ b/managed/node-agent/build.sh
@@ -191,7 +191,7 @@ clean_build() {
 
 format() {
     pushd "$project_dir"
-    go install github.com/segmentio/golines@v0.12.2
+    go install github.com/segmentio/golines@v0.13.0
     go install golang.org/x/tools/cmd/goimports@v0.24.0
     for dir in */ ; do
         # Remove trailing slash.

--- a/managed/node-agent/proto/server.proto
+++ b/managed/node-agent/proto/server.proto
@@ -17,6 +17,8 @@ service NodeAgent {
     rpc UploadFile(stream UploadFileRequest) returns (UploadFileResponse);
     rpc DownloadFile(DownloadFileRequest) returns (stream DownloadFileResponse);
     rpc Update(UpdateRequest) returns (UpdateResponse);
+    rpc CheckYugabyteDbStatus(CheckYugabyteDbStatusRequest)
+        returns (CheckYugabyteDbStatusResponse);
 }
 
 message ServerInfo {

--- a/managed/node-agent/proto/yb.proto
+++ b/managed/node-agent/proto/yb.proto
@@ -220,3 +220,67 @@ message RotateSshKeyInput {
 
 message RotateSshKeyOutput {
 }
+
+// YugabyteProcessRole identifies a YugabyteDB related process on the node.
+enum YugabyteProcessRole {
+    YB_ROLE_UNKNOWN = 0;
+    YB_ROLE_MASTER = 1;
+    YB_ROLE_TSERVER = 2;
+    YB_ROLE_CONTROLLER = 3;
+    YB_ROLE_POSTGRES = 4;
+    YB_ROLE_NODE_EXPORTER = 5;
+}
+
+// ProcessListener is a single listening socket classified to a role when known.
+message ProcessListener {
+    uint32 port = 1;
+    string protocol = 2;
+    int32 pid = 3;
+    YugabyteProcessRole role = 4;
+    string processName = 5;
+}
+
+// ProcessArg is a single key-value argument. Sensitive values are redacted.
+message ProcessArg {
+    string key = 1;
+    string value = 2;
+    // Source is one of "cmdline", "flagfile" or "merged".
+    string source = 3;
+}
+
+// ProcessConfig carries the flagfile and parsed arguments for a process. It is
+// only populated for master, tserver and controller when the process is running.
+message ProcessConfig {
+    string flagfilePath = 1;
+    bool flagfileExists = 2;
+    bool flagfileReadable = 3;
+    repeated ProcessArg cmdlineArgs = 4;
+    repeated ProcessArg flagfileArgs = 5;
+    // Merged effective arguments (flagfile overlaid by cmdline).
+    repeated ProcessArg args = 6;
+}
+
+// ProcessStatus is the detected status of a single role.
+message ProcessStatus {
+    YugabyteProcessRole role = 1;
+    bool running = 2;
+    // Primary pid when multiple processes match the role.
+    int32 pid = 3;
+    repeated uint32 listenPorts = 4;
+    repeated ProcessListener listeners = 5;
+    ProcessConfig config = 6;
+}
+
+message CheckYugabyteDbStatusRequest {
+}
+
+message CheckYugabyteDbStatusResponse {
+    bool masterPresent = 1;
+    bool tserverPresent = 2;
+    bool controllerPresent = 3;
+    bool postgresPresent = 4;
+    bool nodeExporterPresent = 5;
+    repeated ProcessStatus processes = 6;
+    // Listeners classified as YugabyteDB processes on non-default ports.
+    repeated ProcessListener otherListeners = 7;
+}

--- a/managed/src/main/java/com/yugabyte/yw/common/NodeAgentClient.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/NodeAgentClient.java
@@ -27,6 +27,8 @@ import com.yugabyte.yw.models.Provider;
 import com.yugabyte.yw.models.Universe;
 import com.yugabyte.yw.models.helpers.YBAError;
 import com.yugabyte.yw.nodeagent.AbortTaskRequest;
+import com.yugabyte.yw.nodeagent.CheckYugabyteDbStatusRequest;
+import com.yugabyte.yw.nodeagent.CheckYugabyteDbStatusResponse;
 import com.yugabyte.yw.nodeagent.ConfigureServerInput;
 import com.yugabyte.yw.nodeagent.ConfigureServerOutput;
 import com.yugabyte.yw.nodeagent.ConfigureServiceInput;
@@ -870,6 +872,19 @@ public class NodeAgentClient {
     ManagedChannel channel = getManagedChannel(nodeAgent, enableTls);
     NodeAgentBlockingStub stub = NodeAgentGrpc.newBlockingStub(channel);
     return stub.ping(PingRequest.newBuilder().build());
+  }
+
+  /**
+   * Detects the running YugabyteDB related processes on the node, the ports they listen on and the
+   * configuration they were started with. This is a synchronous, read-only call.
+   *
+   * @param nodeAgent the node agent to query.
+   * @return the detected status of each known role.
+   */
+  public CheckYugabyteDbStatusResponse checkYugabyteDbStatus(NodeAgent nodeAgent) {
+    ManagedChannel channel = getManagedChannel(nodeAgent, true);
+    NodeAgentBlockingStub stub = NodeAgentGrpc.newBlockingStub(channel);
+    return stub.checkYugabyteDbStatus(CheckYugabyteDbStatusRequest.newBuilder().build());
   }
 
   public PingResponse waitForServerReady(NodeAgent nodeAgent, Duration timeout) {

--- a/managed/src/test/java/com/yugabyte/yw/common/NodeAgentClientTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/common/NodeAgentClientTest.java
@@ -25,6 +25,8 @@ import com.yugabyte.yw.models.Customer;
 import com.yugabyte.yw.models.NodeAgent;
 import com.yugabyte.yw.models.NodeAgent.ArchType;
 import com.yugabyte.yw.models.NodeAgent.OSType;
+import com.yugabyte.yw.nodeagent.CheckYugabyteDbStatusRequest;
+import com.yugabyte.yw.nodeagent.CheckYugabyteDbStatusResponse;
 import com.yugabyte.yw.nodeagent.DescribeTaskRequest;
 import com.yugabyte.yw.nodeagent.DescribeTaskResponse;
 import com.yugabyte.yw.nodeagent.DownloadFileRequest;
@@ -37,12 +39,14 @@ import com.yugabyte.yw.nodeagent.PingRequest;
 import com.yugabyte.yw.nodeagent.PingResponse;
 import com.yugabyte.yw.nodeagent.PreflightCheckInput;
 import com.yugabyte.yw.nodeagent.PreflightCheckOutput;
+import com.yugabyte.yw.nodeagent.ProcessStatus;
 import com.yugabyte.yw.nodeagent.SubmitTaskRequest;
 import com.yugabyte.yw.nodeagent.SubmitTaskResponse;
 import com.yugabyte.yw.nodeagent.UpdateRequest;
 import com.yugabyte.yw.nodeagent.UpdateResponse;
 import com.yugabyte.yw.nodeagent.UploadFileRequest;
 import com.yugabyte.yw.nodeagent.UploadFileResponse;
+import com.yugabyte.yw.nodeagent.YugabyteProcessRole;
 import io.grpc.ConnectivityState;
 import io.grpc.ManagedChannel;
 import io.grpc.Status;
@@ -155,6 +159,25 @@ public class NodeAgentClientTest extends FakeDBApplication {
           public void update(
               UpdateRequest request, StreamObserver<UpdateResponse> responseObserver) {
             responseObserver.onNext(UpdateResponse.newBuilder().build());
+            responseObserver.onCompleted();
+          }
+
+          @Override
+          public void checkYugabyteDbStatus(
+              CheckYugabyteDbStatusRequest request,
+              StreamObserver<CheckYugabyteDbStatusResponse> responseObserver) {
+            responseObserver.onNext(
+                CheckYugabyteDbStatusResponse.newBuilder()
+                    .setMasterPresent(true)
+                    .setTserverPresent(true)
+                    .addProcesses(
+                        ProcessStatus.newBuilder()
+                            .setRole(YugabyteProcessRole.YB_ROLE_MASTER)
+                            .setRunning(true)
+                            .setPid(1001)
+                            .addListenPorts(7000)
+                            .build())
+                    .build());
             responseObserver.onCompleted();
           }
 
@@ -330,6 +353,18 @@ public class NodeAgentClientTest extends FakeDBApplication {
     clientWithStaleChannel.ping(nodeAgent);
     assertEquals(2, channelLoads.get());
     verify(unhealthyChannel).shutdown();
+  }
+
+  @Test
+  public void testCheckYugabyteDbStatus() {
+    CheckYugabyteDbStatusResponse response = nodeAgentClient.checkYugabyteDbStatus(nodeAgent);
+    assertNotNull("CheckYugabyteDbStatusResponse must be set", response);
+    assertEquals(true, response.getMasterPresent());
+    assertEquals(true, response.getTserverPresent());
+    ProcessStatus master = Iterables.getOnlyElement(response.getProcessesList());
+    assertEquals(YugabyteProcessRole.YB_ROLE_MASTER, master.getRole());
+    assertEquals(true, master.getRunning());
+    assertEquals(1001, master.getPid());
   }
 
   @Test


### PR DESCRIPTION
There are two purposes for this feature:

1. Use `node-agent` to detect existing yugabyteDB processes running on a node that is potentially being added to inventory in YBA. This could be either a negative test to prevent addition or a positive test to enable import of an existing cluster.
2. A health check for configuration drift between YBA and the downstream node.

It adds a synchronous, read-only gRPC method on node-agent that reports which YugabyteDB related processes are running on the node (master, tserver, yb-controller, postgres, node_exporter), the ports they listen on, and, for master/tserver/controller, the flagfile path and effective configuration parsed from the process command line and server.conf.

Detection is layered over pgrep and an "ss -H -O -lntp" listener sweep, with the primary pid verified via /proc/<pid>/cmdline.
Sensitive argument values (password, secret, token, etc.) are redacted in all returned argument lists.


| Role | Process match | Default ports (HTTP / RPC or listen) |
|------|---------------|--------------------------------------|
| Master | `bin/yb-master` | 7000 / 7100 |
| TServer | `bin/yb-tserver` (incl. cgroup wrapper) | 9000 / 9100 |
| YB-Controller | `yb-controller-server` | 14000 / 18018 |
| Postgres (YSQL) | `postgres` / `yb-postmaster` under tserver | 5433 (RPC), 13000 (YSQL HTTP) |
| Node exporter | `node_exporter` | 9300 |

## Architecture

```mermaid
sequenceDiagram
    participant Caller as YBA_NodeAgentClient
    participant NA as NodeAgent_RPCServer
    participant Det as ybdb_Detector
    participant OS as Linux_ss_pgrep_proc

    Caller->>NA: CheckYugabyteDbStatus(empty request)
    NA->>Det: Detect(ctx)
    Det->>OS: pgrep per role
    Det->>OS: ss -H -O -lnt + BPF sport filters
    Det->>OS: /proc/cmdline classify listeners
    Det->>OS: parse --flagfile + read server.conf
    Det-->>NA: CheckYugabyteDbStatusResponse
    NA-->>Caller: response
```

## Example response shape

```json
{
  "master_present": true,
  "tserver_present": true,
  "controller_present": true,
  "postgres_present": true,
  "node_exporter_present": true,
  "processes": [
    {
      "role": "YB_ROLE_MASTER",
      "running": true,
      "pid": 1001,
      "listen_ports": [7000, 7100],
      "config": {
        "flagfile_path": "/home/yugabyte/master/conf/server.conf",
        "flagfile_exists": true,
        "flagfile_readable": true,
        "cmdline_args": [{ "key": "flagfile", "value": "/home/yugabyte/master/conf/server.conf", "source": "cmdline" }],
        "flagfile_args": [
          { "key": "rpc_bind_addresses", "value": "10.0.0.1:7100", "source": "flagfile" },
          { "key": "webserver_port", "value": "7000", "source": "flagfile" }
        ],
        "args": [
          { "key": "rpc_bind_addresses", "value": "10.0.0.1:7100", "source": "merged" },
          { "key": "webserver_port", "value": "7000", "source": "merged" },
          { "key": "flagfile", "value": "/home/yugabyte/master/conf/server.conf", "source": "merged" }
        ]
      }
    },
    {
      "role": "YB_ROLE_TSERVER",
      "running": true,
      "pid": 1002,
      "listen_ports": [9000, 9100],
      "config": {
        "flagfile_path": "/home/yugabyte/tserver/conf/server.conf",
        "flagfile_exists": true,
        "flagfile_readable": true,
        "args": [{ "key": "webserver_port", "value": "9000", "source": "merged" }]
      }
    },
    {
      "role": "YB_ROLE_CONTROLLER",
      "running": true,
      "pid": 1003,
      "listen_ports": [14000, 18018],
      "config": {
        "flagfile_path": "/home/yugabyte/controller/conf/server.conf",
        "flagfile_exists": true,
        "flagfile_readable": true,
        "args": [{ "key": "yb_controller_rpc_port", "value": "18018", "source": "merged" }]
      }
    },
    { "role": "YB_ROLE_POSTGRES", "running": true, "pid": 1004, "listen_ports": [5433] },
    { "role": "YB_ROLE_NODE_EXPORTER", "running": true, "pid": 1005, "listen_ports": [9300] }
  ],
  "other_listeners": []
}
```

## Upgrade/Rollback safety

This change adds a new unary RPC (`CheckYugabyteDbStatus`) and new proto messages/fields. It does not change existing RPCs, on-disk layout, catalog schema, or gflag defaults.

- **Forward (old caller, new node-agent):** Safe. The new method is unused until a caller is deployed. Existing RPCs are unchanged.
- **Backward (new caller, old node-agent):** The new RPC is absent, so the gRPC client receives `UNIMPLEMENTED`. Callers must treat that as "status unknown" and must not infer that YugabyteDB is absent. YBA does not expose this RPC over REST in v1, so mixed-version YBA/node-agent pairs are unaffected until a caller is added.
- **Rollback:** Revert the caller first (if any), then the node-agent binary. Proto field numbers are additive only; rolling back node-agent simply stops advertising the new method. No AutoFlag/gFlag gate is required because the new behavior cannot execute until a client invokes the new RPC.
