### PR TITLE
[#32549] DocDB: Fix yb-master startup crash in negative half-hour timezones

### DIFF
--- a/src/yb/util/date_time-test.cc
+++ b/src/yb/util/date_time-test.cc
@@ -13,6 +13,10 @@
 
 #include "yb/util/date_time.h"
 
+#include <cstdlib>
+#include <ctime>
+#include <string>
+
 #include <boost/date_time/local_time/local_time.hpp>
 #include <boost/smart_ptr/make_shared.hpp>
 
@@ -102,6 +106,76 @@ TEST_F(DateTimeTest, InvalidBoostTimeZoneFromString) {
   ASSERT_TRUE(exception_caught);
   ASSERT_EQ("bad lexical cast: source type value could not be interpreted as target",
             exception_msg);
+}
+
+namespace {
+
+// Sets TZ for the scope and restores it on exit, so the GetSystemTimezone() path (which reads TZ
+// via the C library) can be exercised hermetically. POSIX offsets need no tzdata and have no DST.
+// The POSIX sign is inverted from the ISO output: a positive POSIX offset is west of UTC, so
+// "XYZ3:30" is UTC-03:30.
+class ScopedTz {
+ public:
+  explicit ScopedTz(const char* tz) {
+    if (const char* old = getenv("TZ")) {
+      had_old_ = true;
+      old_tz_ = old;
+    }
+    CHECK_EQ(0, setenv("TZ", tz, /* overwrite */ 1));
+    tzset();
+  }
+
+  ~ScopedTz() {
+    if (had_old_) {
+      CHECK_EQ(0, setenv("TZ", old_tz_.c_str(), /* overwrite */ 1));
+    } else {
+      CHECK_EQ(0, unsetenv("TZ"));
+    }
+    tzset();
+  }
+
+ private:
+  bool had_old_ = false;
+  std::string old_tz_;
+};
+
+void ExpectSystemTimezone(const char* posix_tz, const std::string& expected) {
+  ScopedTz tz(posix_tz);
+  ASSERT_EQ(expected, DateTime::SystemTimezone()) << "POSIX TZ " << posix_tz;
+}
+
+// A named zone must resolve (via GetTimezone) to the same instant as its numeric standard-time
+// offset; GetTimezone uses the DST-independent raw offset.
+void ExpectNamedZoneMatchesOffset(const std::string& zone, const std::string& offset) {
+  const std::string base = "2021-01-01 12:00:00";
+  const auto from_named = ASSERT_RESULT(DateTime::TimestampFromString(base + " " + zone));
+  const auto from_offset = ASSERT_RESULT(DateTime::TimestampFromString(base + offset));
+  ASSERT_EQ(from_named, from_offset) << zone << " should resolve to offset " << offset;
+}
+
+} // namespace
+
+// Regression test for #32549: GetSystemTimezone() (via SystemTimezone()) must format a negative
+// fractional-hour offset as "-HH:MM", not "-HH:-MM" (7 chars), which overflowed buffer[7] and
+// aborted the process via a CHECK.
+TEST_F(DateTimeTest, SystemTimezoneFormatsNegativeHalfHourOffset) {
+  ExpectSystemTimezone("XYZ3:30", "-03:30");   // UTC-03:30, negative half-hour
+  ExpectSystemTimezone("XYZ9:30", "-09:30");   // UTC-09:30, negative half-hour
+  ExpectSystemTimezone("XYZ0:30", "-00:30");   // UTC-00:30, negative sub-hour (hours == 0)
+  ExpectSystemTimezone("XYZ-5:30", "+05:30");  // UTC+05:30, positive half-hour
+  ExpectSystemTimezone("XYZ-0:30", "+00:30");  // UTC+00:30, positive sub-hour (hours == 0)
+  ExpectSystemTimezone("XYZ5", "-05:00");      // UTC-05:00, negative whole-hour
+  ExpectSystemTimezone("XYZ0", "+00:00");      // UTC
+}
+
+// Companion for the sibling formatter GetTimezone() (reached via TimestampFromString with a named
+// zone), which already uses abs() but must not regress.
+TEST_F(DateTimeTest, GetTimezoneFormatsNamedZoneOffset) {
+  ExpectNamedZoneMatchesOffset("America/St_Johns", "-03:30");   // negative half-hour
+  ExpectNamedZoneMatchesOffset("Pacific/Marquesas", "-09:30");  // negative half-hour
+  ExpectNamedZoneMatchesOffset("America/New_York", "-05:00");   // negative whole-hour
+  ExpectNamedZoneMatchesOffset("Asia/Kolkata", "+05:30");       // positive half-hour
+  ExpectNamedZoneMatchesOffset("Asia/Kathmandu", "+05:45");     // positive 45-minute
 }
 
 } // namespace util

--- a/src/yb/util/date_time.cc
+++ b/src/yb/util/date_time.cc
@@ -97,19 +97,24 @@ Result<GregorianCalendar> CreateCalendar() {
   return cal;
 }
 
+// Format a UTC offset as "+HH:MM" or "-HH:MM"; the sign is taken from the whole offset.
+string FormatUtcOffset(const time_duration& offset) {
+  const char sign = offset.is_negative() ? '-' : '+';
+  const int hours = abs(narrow_cast<int>(offset.hours()));
+  const int minutes = abs(narrow_cast<int>(offset.minutes()));
+  char buffer[7]; // "+HH:MM" or "-HH:MM"
+  const size_t result = snprintf(buffer, sizeof(buffer), "%c%2.2d:%2.2d", sign, hours, minutes);
+  CHECK(result > 0 && result < sizeof(buffer)) << "Unexpected snprintf result: " << result;
+  return buffer;
+}
+
 // Get system (local) time zone.
 string GetSystemTimezone() {
   // Get system timezone by getting current UTC time, converting to local time and computing the
   // offset.
   const ptime utc_time = microsec_clock::universal_time();
   const ptime local_time = boost::date_time::c_local_adjustor<ptime>::utc_to_local(utc_time);
-  const time_duration offset = local_time - utc_time;
-  const int hours = narrow_cast<int>(offset.hours());
-  const int minutes = narrow_cast<int>(offset.minutes());
-  char buffer[7]; // "+HH:MM" or "-HH:MM"
-  const size_t result = snprintf(buffer, sizeof(buffer), "%+2.2d:%2.2d", hours, minutes);
-  CHECK(result > 0 && result < sizeof(buffer)) << "Unexpected snprintf result: " << result;
-  return buffer;
+  return FormatUtcOffset(local_time - utc_time);
 }
 
 /* Subset of supported Timezone formats https://docs.oracle.com/cd/E51711_01/DR/ICU_Time_Zones.html
@@ -145,15 +150,7 @@ Result<string> GetTimezone(string timezoneID) {
     return STATUS(InvalidArgument, "Invalid Timezone: " + timezoneID +
         "\nUse standardized timezone such as \"America/New_York\" or offset such as UTC-07:00.");
   }
-  time_duration td = milliseconds(tzone->getRawOffset());
-  const int hours = narrow_cast<int>(td.hours());
-  const int minutes = narrow_cast<int>(td.minutes());
-  char buffer[7]; // "+HH:MM" or "-HH:MM"
-  const size_t result = snprintf(buffer, sizeof(buffer), "%+2.2d:%2.2d", hours, abs(minutes));
-  if (result <= 0 || result >= sizeof(buffer)) {
-    return STATUS(Corruption, "Parsing timezone into timezone offset string failed");
-  }
-  return buffer;
+  return FormatUtcOffset(milliseconds(tzone->getRawOffset()));
 }
 
 Result<time_zone_ptr> StringToTimezone(const string& tz, bool use_utc) {


### PR DESCRIPTION
## Summary

`GetSystemTimezone()` in `src/yb/util/date_time.cc` formats the system UTC
offset with `snprintf(buffer /* char[7] */, "%+2.2d:%2.2d", hours, minutes)`.
`boost::time_duration` carries the sign on every component, so in a negative
fractional-hour timezone such as UTC-02:30 both `hours` and `minutes` are
negative and the result is `"-02:-30"`, which is 7 characters. That overruns
the 7-byte buffer, `snprintf` returns 7, and the following
`CHECK(result < sizeof(buffer))` fails, aborting `yb-master` (and
`yb-tserver`) at startup through the `FooterHtml` -> `TimestampToString` path.

Derive the sign from `offset.is_negative()` and format the absolute hours and
minutes (`"%c%2.2d:%2.2d"`). The offset now renders as `"-02:30"` and fits the
buffer; this also fixes negative sub-hour offsets (e.g. UTC-00:30, where the
hour component is 0) that a `%+` on the hours field would sign incorrectly.
The same change is applied to the sibling `GetTimezone()` for consistency;
positive and whole-hour offsets are unchanged.

Closes #32549.

## Test plan

Automated (new regression tests in `src/yb/util/date_time-test.cc`):

- [ ] `./yb_build.sh release --cxx-test date_time-test --gtest_filter '*Timezone*'`
  - `SystemTimezoneFormatsNegativeHalfHourOffset` exercises `GetSystemTimezone()`
    via the public `DateTime::SystemTimezone()` wrapper, driving negative
    half-hour, negative sub-hour (hours == 0), positive half-hour, whole-hour,
    and UTC offsets through `TZ` (hermetic POSIX offsets; no tzdata or DST
    dependence).
  - `GetTimezoneFormatsNamedZoneOffset` exercises `GetTimezone()` via
    `TimestampFromString` with named zones (`America/St_Johns` -03:30,
    `Pacific/Marquesas` -09:30, plus positive and whole-hour controls).
- [ ] Full `date_time-test` passes (pre-existing cases unaffected).

Manual (reproduction from #32549):

- [ ] `yb-master` starts under `TZ=America/St_Johns` instead of aborting at
      `date_time.cc:111`; the `TZ=UTC` control still starts.