### PR TITLE
[#16670] DocDB: add TraceContextPB and RequestHeader.trace_context

### DIFF
--- a/src/yb/rpc/rpc_header.proto
+++ b/src/yb/rpc/rpc_header.proto
@@ -54,6 +54,21 @@ message RemoteMethodPB {
   required string method_name = 2;
 };
 
+// Distributed-trace context (W3C trace-context; https://www.w3.org/TR/trace-context/) propagated
+// across a process boundary. Defined here so a single message and wire format serves both
+// transports: it is carried in the RPC RequestHeader below (alongside AshMetadataPB), and as an
+// independent length-prefixed slot in the shared-memory PG<->tserver exchange.
+message TraceContextPB {
+  // 8 bytes (high 64 bits of trace_id)
+  optional fixed64 trace_id_hi = 1;
+  // 8 bytes (low 64 bits of trace_id)
+  optional fixed64 trace_id_lo = 2;
+  // 8 bytes
+  optional fixed64 span_id = 3;
+  // Low byte: flags, High byte: version (1-2 bytes on wire)
+  optional uint32 version_and_flags = 4;
+}
+
 // The header for the RPC request frame.
 message RequestHeader {
   reserved 6;
@@ -81,6 +96,9 @@ message RequestHeader {
   optional AshMetadataPB metadata = 5;
 
   optional uint64 pool_tag = 7;
+
+  // Distributed-trace context, propagating the trace from caller to the server handling this RPC.
+  optional TraceContextPB trace_context = 8;
 
   // CRC32C for message body and header without CRC field. Use 15 as max 1 byte tag.
   optional fixed32 crc = 15;


### PR DESCRIPTION
## Summary

Define `TraceContextPB` (W3C trace-context, https://www.w3.org/TR/trace-context/) in `common.proto` and add the `trace_context` field to the RPC `RequestHeader`. This is the wire type shared by the RPC-header and shared-memory trace-propagation transports; no code references it yet.

## Upgrade/Rollback safety

Purely additive and wire-compatible in both directions:

- `TraceContextPB` is a brand-new message; `RequestHeader.trace_context` uses the previously-unused field tag `8` (the next tag after `pool_tag = 7`; `crc` remains `15`). Both fields are `optional`.
- On a mixed-version cluster: an older server that predates this change ignores the unknown field `8` on incoming `RequestHeader`s; a newer server treats an absent `trace_context` as "no trace context".
- Rollback is safe because nothing reads or writes the field yet — it is a schema-only addition.

## Test plan

- [x] Proto-only change with no references yet; there is no runtime behavior to exercise.
- [x] Verified the protobufs compile as part of the build.
