### PR TITLE
[#16670] DocDB: Distributed-trace propagation for query RPCs

### DIFF
--- a/src/postgres/src/backend/postmaster/postmaster.c
+++ b/src/postgres/src/backend/postmaster/postmaster.c
@@ -2489,6 +2489,15 @@ retry1:
 							 errhint("Value must be one of the registered "
 									 "YbInternalConnKind wire names.")));
 			}
+			else if (YBIsEnabledInPostgresEnvVar()
+					 && strcmp(nameptr, "yb_dist_traceparent") == 0)
+			{
+				/*
+				 * Stash traceparent for InitPostgres's backend-init span;
+				 * consumed here, turned into a corresponding GUC.
+				 */
+				port->yb_dist_traceparent = pstrdup(valptr);
+			}
 			else if (strncmp(nameptr, "_pq_.", 5) == 0)
 			{
 				/*

--- a/src/postgres/src/backend/utils/init/postinit.c
+++ b/src/postgres/src/backend/utils/init/postinit.c
@@ -1130,6 +1130,18 @@ InitPostgresImpl(const char *in_dbname, Oid dboid,
 	/* Connect to YugaByte cluster. */
 	YBInitPostgresBackend("postgres", yb_init_info);
 
+	if (IsYugaByteEnabled() && !bootstrap && MyProcPort != NULL &&
+		MyProcPort->yb_dist_traceparent != NULL &&
+		MyProcPort->yb_dist_traceparent[0] != '\0')
+	{
+		char		tracecontext[128];
+
+		snprintf(tracecontext, sizeof(tracecontext), "traceparent='%s'",
+				 MyProcPort->yb_dist_traceparent);
+		SetConfigOption("yb_dist_tracecontext", tracecontext,
+						PGC_BACKEND, PGC_S_CLIENT);
+	}
+
 	if (IsYugaByteEnabled() && !bootstrap)
 	{
 		HandleYBStatus(YBCPgTableExists(Template1DbOid,

--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -1206,7 +1206,7 @@ YBInitPostgresBackend(const char *program_name, const YbcPgInitPostgresInfo *ini
 			hex_encode((const char *) YbGetLocalTServerUuid(), UUID_LEN, hex_uuid);
 			hex_uuid[2 * UUID_LEN] = '\0';
 
-			YBCInitDistTrace(MyProcPid, hex_uuid);
+			YBCInitDistTrace(hex_uuid);
 		}
 	}
 }
@@ -1217,7 +1217,7 @@ YBOnPostgresBackendShutdown()
 	YBCDestroyPgGate();
 
 	if (YBCIsDistTraceEnabled())
-		YBCCleanupDistTrace();
+		YBCShutdownDistTrace();
 }
 
 void

--- a/src/postgres/src/include/libpq/libpq-be.h
+++ b/src/postgres/src/include/libpq/libpq-be.h
@@ -188,6 +188,13 @@ typedef struct Port
 	bool		yb_is_ssl_enabled_in_logical_conn;
 
 	/*
+	 * YB: W3C traceparent from the "yb_dist_traceparent" startup-packet param
+	 * (set by the tserver). Root span for backend init; read in InitPostgres.
+	 * NULL when absent.
+	 */
+	char	   *yb_dist_traceparent;
+
+	/*
 	 * Authenticated identity.  The meaning of this identifier is dependent on
 	 * hba->auth_method; it is the identity (if any) that the user presented
 	 * during the authentication cycle, before they were assigned a database

--- a/src/postgres/src/interfaces/libpq/fe-connect.c
+++ b/src/postgres/src/interfaces/libpq/fe-connect.c
@@ -355,6 +355,14 @@ static const internalPQconninfoOption PQconninfoOptions[] = {
 		"YB-Internal-Conn-Kind", "", 32,
 	offsetof(struct pg_conn, yb_internal_conn_kind)},
 
+	/*
+	 * W3C traceparent set on any connection that carries a trace context, used
+	 * as the root span for backend init and queries.
+	 */
+	{"yb_dist_traceparent", NULL, NULL, NULL,
+		"YB-Dist-Traceparent", "", 64,
+	offsetof(struct pg_conn, yb_dist_traceparent)},
+
 	/* Terminating entry --- MUST BE LAST */
 	{NULL, NULL, NULL, NULL,
 	NULL, NULL, 0}
@@ -4193,6 +4201,8 @@ freePGconn(PGconn *conn)
 		free(conn->target_session_attrs);
 	if (conn->yb_internal_conn_kind)
 		free(conn->yb_internal_conn_kind);
+	if (conn->yb_dist_traceparent)
+		free(conn->yb_dist_traceparent);
 	termPQExpBuffer(&conn->errorMessage);
 	termPQExpBuffer(&conn->workBuffer);
 

--- a/src/postgres/src/interfaces/libpq/fe-protocol3.c
+++ b/src/postgres/src/interfaces/libpq/fe-protocol3.c
@@ -2239,6 +2239,9 @@ build_startup_packet(const PGconn *conn, char *packet,
 	if (conn->yb_internal_conn_kind && conn->yb_internal_conn_kind[0])
 		ADD_STARTUP_OPTION("yb_internal_conn_kind",
 						   conn->yb_internal_conn_kind);
+	if (conn->yb_dist_traceparent && conn->yb_dist_traceparent[0])
+		ADD_STARTUP_OPTION("yb_dist_traceparent",
+						   conn->yb_dist_traceparent);
 	if (conn->send_appname)
 	{
 		/* Use appname if present, otherwise use fallback */

--- a/src/postgres/src/interfaces/libpq/libpq-int.h
+++ b/src/postgres/src/interfaces/libpq/libpq-int.h
@@ -400,6 +400,9 @@ struct pg_conn
 										 * names (see yb_internal_conn.h);
 										 * NULL/empty for a regular client
 										 * connection */
+	char	   *yb_dist_traceparent;	/* W3C traceparent for the backend's
+										  root trace span and query tracing from
+										  tserver; NULL when not tracing */
 
 	/* Optional file to write trace info to */
 	FILE	   *Pfdebug;

--- a/src/yb/ash/rpc_wait_state.cc
+++ b/src/yb/ash/rpc_wait_state.cc
@@ -12,6 +12,8 @@
 //
 #include "yb/ash/rpc_wait_state.h"
 
+#include "yb/gutil/endian.h"
+
 #include "yb/rpc/inbound_call.h"
 #include "yb/rpc/lightweight_message.h"
 
@@ -129,6 +131,36 @@ uint8_t* MetadataSerializer::SerializeToArray(uint8_t* out) {
   }
 
   return metadata_.SerializeWithCachedSizesToArray(out);
+}
+
+void TraceContextSerializer::SetTraceContext(
+    const opentelemetry::trace::SpanContext& span_context) {
+  if (!span_context.IsValid()) {
+    return;
+  }
+  const auto trace_id = span_context.trace_id();
+  const auto span_id = span_context.span_id();
+  // Split the 16-byte trace id into two big-endian 64-bit halves; the span id is one big-endian
+  // 64-bit value -- the layout rpc::ToSpanContext reads back on the tserver.
+  trace_context_.set_trace_id_hi(BigEndian::Load64(trace_id.Id().data()));
+  trace_context_.set_trace_id_lo(BigEndian::Load64(trace_id.Id().data() + 8));
+  trace_context_.set_span_id(BigEndian::Load64(span_id.Id().data()));
+  // Low byte: flags; high byte: the (currently unused) version.
+  constexpr uint32_t kVersion = 0;
+  trace_context_.set_version_and_flags((kVersion << 8) | span_context.trace_flags().flags());
+  serialized_size_ = trace_context_.ByteSizeLong();
+}
+
+size_t TraceContextSerializer::SerializedSize() const {
+  return Output::VarintSize32(static_cast<uint32_t>(serialized_size_)) + serialized_size_;
+}
+
+uint8_t* TraceContextSerializer::SerializeToArray(uint8_t* out) const {
+  out = Output::WriteVarint32ToArray(static_cast<uint32_t>(serialized_size_), out);
+  if (serialized_size_ == 0) {
+    return out;
+  }
+  return trace_context_.SerializeWithCachedSizesToArray(out);
 }
 
 } // namespace yb::ash

--- a/src/yb/ash/rpc_wait_state.h
+++ b/src/yb/ash/rpc_wait_state.h
@@ -12,10 +12,13 @@
 //
 #pragma once
 
+#include "opentelemetry/trace/span_context.h"
+
 #include "yb/ash/wait_state.h"
 
 #include "yb/common/common.pb.h"
 
+#include "yb/rpc/rpc_header.pb.h"
 #include "yb/rpc/wait_state_if.h"
 
 namespace yb::ash {
@@ -57,6 +60,21 @@ class MetadataSerializerFactory : public rpc::MetadataSerializerFactory {
   std::unique_ptr<rpc::MetadataSerializer> Create(rpc::MetadataSerializationMode mode) override {
     return std::make_unique<ash::MetadataSerializer>(mode);
   }
+};
+
+// Serializes a distributed-trace SpanContext as a standalone length-prefixed TraceContextPB blob
+// for the shared-memory PG<->tserver exchange, independent of the ASH metadata blob. Always emits
+// the length prefix (zero when no context is set) so the exchange framing stays parseable.
+class TraceContextSerializer {
+ public:
+  // Encodes span_context into the trace-context blob; a no-op when the context is invalid.
+  void SetTraceContext(const opentelemetry::trace::SpanContext& span_context);
+  size_t SerializedSize() const;
+  uint8_t* SerializeToArray(uint8_t* out) const;
+
+ private:
+  rpc::TraceContextPB trace_context_;
+  size_t serialized_size_ = 0;
 };
 
 } // namespace yb::ash

--- a/src/yb/master/async_rpc_tasks_base.cc
+++ b/src/yb/master/async_rpc_tasks_base.cc
@@ -114,7 +114,9 @@ RetryingRpcTask::RetryingRpcTask(
     : master_(master),
       callback_pool_(callback_pool),
       async_task_throttler_(async_task_throttler),
-      deadline_(UnresponsiveDeadline()) {}
+      deadline_(UnresponsiveDeadline()),
+      // Snapshot the active trace context on the creating thread.
+      trace_parent_(dist_trace::GetActiveSpanContext()) {}
 
 RetryingRpcTask::~RetryingRpcTask() {
   auto state = state_.load(std::memory_order_acquire);
@@ -130,6 +132,9 @@ std::string RetryingRpcTask::LogPrefix() const {
 // Send the subclass RPC request.
 Status RetryingRpcTask::Run() {
   VLOG_WITH_PREFIX(1) << "Start Running";
+  // Re-establish the creating thread's trace context.
+  auto trace_scope = dist_trace::ActivateParentScope(trace_parent_);
+
   attempt_start_ts_ = MonoTime::Now();
   ++attempt_;
   VLOG_WITH_PREFIX(1) << "Start Running, attempt: " << attempt_;

--- a/src/yb/master/async_rpc_tasks_base.h
+++ b/src/yb/master/async_rpc_tasks_base.h
@@ -25,6 +25,7 @@
 #include "yb/tserver/backup.proxy.h"
 
 #include "yb/util/async_task_util.h"
+#include "yb/util/dist_trace.h"
 #include "yb/util/memory/memory.h"
 #include "yb/util/metrics_fwd.h"
 #include "yb/util/result.h"
@@ -245,6 +246,10 @@ class RetryingRpcTask : public server::RunnableMonitoredTask {
 
   virtual int num_max_retries();
   virtual int max_delay_ms();
+
+  // Trace context active when this task was created, re-activated at the top of Run() so the task's
+  // RPCs nest under it. Invalid (no-op) when created outside a traced origin.
+  dist_trace::trace::SpanContext trace_parent_ = dist_trace::trace::SpanContext::GetInvalid();
 };
 
 // A background task which continuously retries sending an RPC to master server.

--- a/src/yb/master/multi_step_monitored_task.cc
+++ b/src/yb/master/multi_step_monitored_task.cc
@@ -25,7 +25,9 @@ namespace yb::master {
 
 MultiStepMonitoredTask::MultiStepMonitoredTask(
     ThreadPool& async_task_pool, rpc::Messenger& messenger)
-    : messenger_(messenger), async_task_pool_(async_task_pool) {}
+    : messenger_(messenger),
+      async_task_pool_(async_task_pool),
+      trace_parent_(dist_trace::GetActiveSpanContext()) {}
 
 void MultiStepMonitoredTask::Start() {
   LOG_WITH_PREFIX(INFO) << "Starting task";
@@ -206,6 +208,9 @@ Status MultiStepMonitoredTask::RunInternal() {
 
   RETURN_NOT_OK(ValidateRunnable());
 
+  // Re-activate the triggering trace on this worker/reactor thread so RPCs the step issues nest
+  // under it. No-op when trace_parent_ is invalid.
+  auto parent_scope = dist_trace::ActivateParentScope(trace_parent_);
   return step();
 }
 

--- a/src/yb/master/multi_step_monitored_task.h
+++ b/src/yb/master/multi_step_monitored_task.h
@@ -20,6 +20,7 @@
 #include "yb/master/leader_epoch.h"
 #include "yb/rpc/rpc_fwd.h"
 #include "yb/server/monitored_task.h"
+#include "yb/util/dist_trace.h"
 #include "yb/util/status.h"
 #include "yb/util/status_callback.h"
 
@@ -142,6 +143,12 @@ class MultiStepMonitoredTask : public server::RunnableMonitoredTask {
 
   std::string next_step_description_ GUARDED_BY(schedule_task_mutex_);
   std::function<Status()> next_step_ GUARDED_BY(schedule_task_mutex_) = nullptr;
+
+  // Trace context of the operation that created this task, captured at construction and
+  // re-activated around each step so the step's RPCs nest under the triggering trace -- steps run
+  // on async-pool/reactor threads, so the context must ride on the task. No-op when unset or
+  // tracing is off.
+  dist_trace::trace::SpanContext trace_parent_ = dist_trace::trace::SpanContext::GetInvalid();
 };
 
 // A MultiStepMonitoredTask that is tied to a single CatalogEntity object (ex: Table) and the master

--- a/src/yb/rpc/local_call.cc
+++ b/src/yb/rpc/local_call.cc
@@ -20,6 +20,7 @@
 #include "yb/rpc/rpc_controller.h"
 #include "yb/rpc/rpc_header.messages.h"
 
+#include "yb/util/dist_trace.h"
 #include "yb/util/format.h"
 #include "yb/util/memory/memory.h"
 #include "yb/util/result.h"
@@ -40,6 +41,12 @@ LocalOutboundCall::LocalOutboundCall(
                    response_storage, controller, std::move(rpc_metrics), std::move(callback),
                    callback_thread_pool, /* metadata_serializer_factory= */ nullptr) {
   TRACE_TO(trace_, "LocalOutboundCall");
+  if (otel_span()) {
+    otel_span()->SetAttribute("rpc.local_call", true);
+    // The OutboundCall ctor left the client span's scope on this thread; a local call never drops
+    // it. Drop it here or it re-parents later work. The span stays alive via GetContext().
+    otel_span()->DropScope();
+  }
 }
 
 Status LocalOutboundCall::SetRequestParam(

--- a/src/yb/rpc/local_call.h
+++ b/src/yb/rpc/local_call.h
@@ -50,6 +50,16 @@ class LocalOutboundCall : public OutboundCall {
     return req_;
   }
 
+  // Span context of this outbound call's trace span, to parent the matching local inbound span
+  // (local calls carry no wire header). nullopt when tracing is off. Safe after the scope is
+  // dropped.
+  std::optional<opentelemetry::trace::SpanContext> otel_span_context() const {
+    if (const auto& span = otel_span(); span) {
+      return span->GetContext();
+    }
+    return std::nullopt;
+  }
+
   bool is_local() const override { return true; }
 
   ThreadPoolTag pool_tag() const;
@@ -134,6 +144,7 @@ auto HandleCall(InboundCallPtr call, F f) {
       f(req, resp, std::move(rpc_context));
     }
   }
+  yb_call->DropServerSpanScope();
 }
 
 class LocalYBInboundCallTracker : public InboundCall::CallProcessedListener {

--- a/src/yb/rpc/outbound_call.cc
+++ b/src/yb/rpc/outbound_call.cc
@@ -151,13 +151,11 @@ bool FinishedState(RpcCallState state) {
   return false;
 }
 
-void SetSpanStatus(opentelemetry::trace::Span& span, RpcCallState state) {
+void SetSpanStatus(opentelemetry::trace::Span& span, RpcCallState state, const Status& status) {
   switch (state) {
     case TIMED_OUT:
-      span.SetStatus(opentelemetry::trace::StatusCode::kError, "Call TimedOut");
-      return;
     case FINISHED_ERROR:
-      span.SetStatus(opentelemetry::trace::StatusCode::kError, "Call ErroredOut");
+      span.SetStatus(opentelemetry::trace::StatusCode::kError, status.ToUserMessage());
       return;
     case FINISHED_SUCCESS:
       span.SetStatus(opentelemetry::trace::StatusCode::kOk);
@@ -279,9 +277,16 @@ OutboundCall::OutboundCall(const RemoteMethod& remote_method,
   IncrementCounter(rpc_metrics_->outbound_calls_created);
   IncrementGauge(rpc_metrics_->outbound_calls_alive);
 
-  if (dist_trace::HasActiveContext()) {
-    otel_span_ = dist_trace::StartSpan(
-        Format("rpc $0", remote_method_.ToString()), dist_trace::GetPendingRpcAttrPairs());
+  // Capture this call's parent before StartClientSpanWithScope makes otel_span_ current;
+  // InvokeCallbackSync restores it around the callback so its follow-on work nests as a sibling.
+  trace_parent_ = dist_trace::GetActiveSpanContext();
+
+  otel_span_ = dist_trace::StartClientSpanWithScope(Format("rpc $0", remote_method_.ToString()));
+  if (otel_span_) {
+    otel_span_->SetAttribute("rpc.system", "outbound_rpc");
+    otel_span_->SetAttribute("rpc.service", remote_method_.service_name());
+    otel_span_->SetAttribute("rpc.method", remote_method_.method_name());
+    otel_span_->SetAttribute("rpc.call_id", call_id_);
   }
 }
 
@@ -372,6 +377,33 @@ Status OutboundCall::SetRequestParam(
     metadata_size += 1; // add tag size of RequestHeader::kMetadataFieldNumber
   }
 
+  // Distributed-trace context: extract the outbound span's SpanContext (if any) and pre-compute the
+  // serialized size of the TraceContextPB submessage so it can be folded into the header length.
+  size_t trace_context_size = 0;
+  size_t trace_context_message_size = 0;
+  uint32_t version_and_flags = 0;
+  opentelemetry::trace::TraceId trace_id;
+  opentelemetry::trace::SpanId span_id;
+  if (otel_span_) {
+    auto span_context = otel_span_->GetContext();
+    if (span_context.IsValid()) {
+      trace_id = span_context.trace_id();
+      span_id = span_context.span_id();
+      auto trace_flags = span_context.trace_flags();
+      // TraceContextPB submessage layout:
+      // - trace_id_hi: 1 byte tag + 8 bytes fixed64
+      // - trace_id_lo: 1 byte tag + 8 bytes fixed64
+      // - span_id:     1 byte tag + 8 bytes fixed64
+      // - version_and_flags: 1 byte tag + varint (size depends on the combined value)
+      constexpr uint32_t kVersion = 0;
+      version_and_flags = (kVersion << 8) | trace_flags.flags();
+      size_t version_and_flags_varint_size = Output::VarintSize32(version_and_flags);
+      trace_context_message_size = 3 * 9 + 1 + version_and_flags_varint_size;
+      trace_context_size =
+          1 + Output::VarintSize64(trace_context_message_size) + trace_context_message_size;
+    }
+  }
+
   auto use_crc = FLAGS_rpc_enable_crc;
   size_t header_pb_len = 1 + call_id_size + // int32 call_id = 1
                          serialized_remote_method.size() + // RemoteMethodPB remote_method = 2
@@ -380,6 +412,7 @@ Status OutboundCall::SetRequestParam(
   if (pool_tag) {
     header_pb_len += 1 + Output::VarintSize64(pool_tag); // uint64 pool_tag = 7
   }
+  header_pb_len += trace_context_size; // TraceContext trace_context = 8
   if (use_crc) {
     header_pb_len += 1 + sizeof(uint32_t); // fixed32 crc = 15
   }
@@ -431,6 +464,31 @@ Status OutboundCall::SetRequestParam(
     dst = Output::WriteVarint64ToArray(pool_tag, dst);
   }
 
+  if (trace_context_size > 0) {
+    // Write the TraceContextPB submessage. Field numbers match yb.TraceContextPB in common.proto.
+    // The 16-byte trace id splits into two big-endian 64-bit halves; the span id is one big-endian
+    // 64-bit.
+    dst = Output::WriteTagToArray(
+        (RequestHeader::kTraceContextFieldNumber << 3) | WireFormatLite::WIRETYPE_LENGTH_DELIMITED,
+        dst);
+    dst = Output::WriteVarint32ToArray(narrow_cast<uint32_t>(trace_context_message_size), dst);
+
+    dst = Output::WriteTagToArray(
+        (TraceContextPB::kTraceIdHiFieldNumber << 3) | WireFormatLite::WIRETYPE_FIXED64, dst);
+    dst = Output::WriteLittleEndian64ToArray(BigEndian::Load64(trace_id.Id().data()), dst);
+
+    dst = Output::WriteTagToArray(
+        (TraceContextPB::kTraceIdLoFieldNumber << 3) | WireFormatLite::WIRETYPE_FIXED64, dst);
+    dst = Output::WriteLittleEndian64ToArray(BigEndian::Load64(trace_id.Id().data() + 8), dst);
+
+    dst = Output::WriteTagToArray(
+        (TraceContextPB::kSpanIdFieldNumber << 3) | WireFormatLite::WIRETYPE_FIXED64, dst);
+    dst = Output::WriteLittleEndian64ToArray(BigEndian::Load64(span_id.Id().data()), dst);
+
+    dst = Output::WriteTagToArray(TraceContextPB::kVersionAndFlagsFieldNumber << 3, dst);
+    dst = Output::WriteVarint32ToArray(version_and_flags, dst);
+  }
+
   // CRC should be at the end of header, otherwise adjust CRC filling logic below.
   if (use_crc) {
     dst = Output::WriteTagToArray(
@@ -472,7 +530,7 @@ OutboundCall::State OutboundCall::state() const {
   return state_.load(std::memory_order_acquire);
 }
 
-bool OutboundCall::SetState(State new_state) {
+bool OutboundCall::SetState(State new_state, const Status& status) {
   auto old_state = state();
   // Sanity check state transitions.
   DVLOG(3) << "OutboundCall " << this << " (" << ToString() << ") switching from "
@@ -487,7 +545,8 @@ bool OutboundCall::SetState(State new_state) {
     }
     if (state_.compare_exchange_weak(old_state, new_state, std::memory_order_acq_rel)) {
       if (otel_span_ && FinishedState(new_state)) {
-        SetSpanStatus(*otel_span_, new_state);
+        DCHECK(otel_span_->span);
+        SetSpanStatus(*otel_span_->span, new_state, status);
         otel_span_->End();
       }
       return true;
@@ -557,7 +616,13 @@ void OutboundCall::InvokeCallbackSync(std::optional<CoarseTimePoint> now_optiona
   // TODO: consider removing the cycle-based mechanism of reporting slow callbacks below.
 
   int64_t start_cycles = CycleClock::Now();
-  callback_();
+  // Re-activate the call's parent context so RPCs the callback issues nest as siblings, not
+  // parentless roots. No-op when trace_parent_ is invalid; parent_scope drops at block end so it
+  // can't leak.
+  {
+    auto parent_scope = dist_trace::ActivateParentScope(trace_parent_);
+    callback_();
+  }
   // Clear the callback, since it may be holding onto reference counts
   // via bound parameters. We do this inside the timer because it's possible
   // the user has naughty destructors that block, and we want to account for that
@@ -692,7 +757,7 @@ void OutboundCall::SetFailed(const Status &status, std::unique_ptr<ErrorStatusPB
   bool invoke_callback;
   {
     std::lock_guard l(mtx_);
-    invoke_callback = SetState(RpcCallState::FINISHED_ERROR);
+    invoke_callback = SetState(RpcCallState::FINISHED_ERROR, status);
     if (invoke_callback) {
       status_ = status;
       if (status_.IsRemoteError()) {
@@ -731,7 +796,7 @@ void OutboundCall::SetTimedOut() {
         call_id_);
     std::lock_guard l(mtx_);
     status_ = std::move(status);
-    invoke_callback = SetState(RpcCallState::TIMED_OUT);
+    invoke_callback = SetState(RpcCallState::TIMED_OUT, status_);
   }
   if (invoke_callback) {
     InvokeCallback();

--- a/src/yb/rpc/outbound_call.cc
+++ b/src/yb/rpc/outbound_call.cc
@@ -465,7 +465,8 @@ Status OutboundCall::SetRequestParam(
   }
 
   if (trace_context_size > 0) {
-    // Write the TraceContextPB submessage. Field numbers match yb.TraceContextPB in common.proto.
+    // Write the TraceContextPB submessage. Field numbers match yb.rpc.TraceContextPB in
+    // rpc_header.proto.
     // The 16-byte trace id splits into two big-endian 64-bit halves; the span id is one big-endian
     // 64-bit.
     dst = Output::WriteTagToArray(
@@ -485,7 +486,8 @@ Status OutboundCall::SetRequestParam(
         (TraceContextPB::kSpanIdFieldNumber << 3) | WireFormatLite::WIRETYPE_FIXED64, dst);
     dst = Output::WriteLittleEndian64ToArray(BigEndian::Load64(span_id.Id().data()), dst);
 
-    dst = Output::WriteTagToArray(TraceContextPB::kVersionAndFlagsFieldNumber << 3, dst);
+    dst = Output::WriteTagToArray(
+        (TraceContextPB::kVersionAndFlagsFieldNumber << 3) | WireFormatLite::WIRETYPE_VARINT, dst);
     dst = Output::WriteVarint32ToArray(version_and_flags, dst);
   }
 

--- a/src/yb/rpc/outbound_call.h
+++ b/src/yb/rpc/outbound_call.h
@@ -72,12 +72,11 @@
 #include "yb/util/memory/memory_usage.h"
 #include "yb/util/monotime.h"
 #include "yb/util/net/sockaddr.h"
-#include "yb/util/dist_trace_fwd.h"
+#include "yb/util/dist_trace.h"
 #include "yb/util/object_pool.h"
 #include "yb/util/ref_cnt_buffer.h"
 #include "yb/util/shared_lock.h"
 #include "yb/util/slice.h"
-#include "yb/util/status_fwd.h"
 #include "yb/util/trace.h"
 
 using namespace std::literals;
@@ -349,6 +348,16 @@ class OutboundCall : public RpcCall {
   void SetConnectionId(const ConnectionId& value, const std::string* hostname) {
     conn_id_ = value;
     hostname_ = hostname;
+    if (otel_span_) {
+      if (hostname) {
+        otel_span_->SetAttribute("network.peer.name", *hostname);
+      }
+      otel_span_->SetAttribute("network.peer.address", yb::ToString(value.remote()));
+      // Drop the OTEL span's scope here, on the calling thread, before the call is queued to the
+      // reactor. The span ends later, but the scope must be released on the thread that installed
+      // it.
+      otel_span_->DropScope();
+    }
   }
 
   void SetThreadPoolFailure(const Status& status) EXCLUDES(mtx_) {
@@ -453,6 +462,10 @@ class OutboundCall : public RpcCall {
   virtual size_t GetSidecarsCount() const;
   virtual size_t TransferSidecars(Sidecars* dest);
 
+  // Distributed-trace span for this call; LocalOutboundCall reads its context to parent the local
+  // inbound span.
+  const dist_trace::SpanWithScopePtr& otel_span() const { return otel_span_; }
+
   // ----------------------------------------------------------------------------------------------
   // Protected fields set in constructor or during initialization
   // ----------------------------------------------------------------------------------------------
@@ -481,7 +494,7 @@ class OutboundCall : public RpcCall {
 
   void NotifyTransferred(const Status& status, const ConnectionPtr& conn) override;
 
-  MUST_USE_RESULT bool SetState(State new_state);
+  MUST_USE_RESULT bool SetState(State new_state, const Status& status = Status::OK());
   State state() const;
 
   // return current status
@@ -595,9 +608,13 @@ class OutboundCall : public RpcCall {
 
   std::unique_ptr<MetadataSerializer> metadata_serializer_;
 
-  // OpenTelemetry span for distributed tracing. Created when the call starts if there is an
-  // active trace context, ended when the call completes (success, failure, or timeout).
-  opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> otel_span_;
+  // OpenTelemetry span for this call, created at start (if a trace context is active) and ended at
+  // completion.
+  dist_trace::SpanWithScopePtr otel_span_;
+
+  // The trace context active when this call was constructed -- its PARENT, re-activated around the
+  // completion callback so follow-on RPCs nest as SIBLINGS of this call.
+  dist_trace::trace::SpanContext trace_parent_ = dist_trace::trace::SpanContext::GetInvalid();
 
   // InvokeCallbackTask should be able to call InvokeCallbackSync and we don't want other that
   // method to be public.

--- a/src/yb/rpc/periodic.cc
+++ b/src/yb/rpc/periodic.cc
@@ -56,6 +56,7 @@ PeriodicTimer::PeriodicTimer(
     Messenger* messenger, RunTaskFunctor functor, MonoDelta period, Options options)
     : messenger_(messenger),
       functor_(std::move(functor)),
+      trace_parent_(dist_trace::GetActiveSpanContext()),
       period_(period),
       options_(std::move(options)),
       rng_(GetRandomSeed32()),
@@ -194,6 +195,8 @@ void PeriodicTimer::Callback(int64_t my_callback_generation) {
   }
 
   if (run_task) {
+    // Re-activate the context captured at construction so the task's RPCs nest under it.
+    auto parent_scope = dist_trace::ActivateParentScope(trace_parent_);
     functor_();
 
     if (options_.one_shot) {

--- a/src/yb/rpc/periodic.h
+++ b/src/yb/rpc/periodic.h
@@ -24,6 +24,7 @@
 #include <gtest/gtest_prod.h>
 
 #include "yb/gutil/macros.h"
+#include "yb/util/dist_trace.h"
 #include "yb/util/locks.h"
 #include "yb/util/monotime.h"
 #include "yb/util/random.h"
@@ -171,6 +172,9 @@ class PeriodicTimer : public std::enable_shared_from_this<PeriodicTimer> {
 
   // User-defined task functor.
   RunTaskFunctor functor_;
+
+  // Trace context captured at construction
+  const dist_trace::trace::SpanContext trace_parent_;
 
   // User-specified task period.
   const MonoDelta period_;

--- a/src/yb/rpc/rpc.cc
+++ b/src/yb/rpc/rpc.cc
@@ -92,7 +92,8 @@ RpcRetrier::RpcRetrier(CoarseTimePoint deadline, Messenger* messenger, ProxyCach
     : start_(CoarseMonoClock::now()),
       deadline_(deadline),
       messenger_(messenger),
-      proxy_cache_(*proxy_cache) {
+      proxy_cache_(*proxy_cache),
+      trace_parent_(dist_trace::GetActiveSpanContext()) {
   DCHECK(deadline != CoarseTimePoint());
 }
 
@@ -228,6 +229,10 @@ void RpcRetrier::DoRetry(RpcCommand* rpc, const Status& status) {
   if (new_status.ok()) {
     controller_.Reset();
     VTRACE_TO(1, rpc->trace(), "Sending Rpc");
+    // DoRetry runs on a scope-less reactor thread; re-establish the caller's parent (captured in
+    // the ctor) so the OutboundCall rebuilt in SendRpc captures it. No-op when trace_parent_ is
+    // invalid.
+    auto parent_scope = dist_trace::ActivateParentScope(trace_parent_);
     rpc->SendRpc();
   } else {
     // Service unavailable here means that we failed to schedule delayed task, i.e. reactor

--- a/src/yb/rpc/rpc.h
+++ b/src/yb/rpc/rpc.h
@@ -40,6 +40,7 @@
 
 #include "yb/rpc/rpc_controller.h"
 
+#include "yb/util/dist_trace.h"
 #include "yb/util/enums.h"
 #include "yb/util/monotime.h"
 
@@ -189,6 +190,9 @@ class RpcRetrier {
   std::atomic<ScheduledTaskId> task_id_{kInvalidTaskId};
 
   std::atomic<RpcRetrierState> state_{RpcRetrierState::kIdle};
+
+  // Trace context active when this retrier was constructed -- the caller's parent span.
+  dist_trace::trace::SpanContext trace_parent_ = dist_trace::trace::SpanContext::GetInvalid();
 
   DISALLOW_COPY_AND_ASSIGN(RpcRetrier);
 };

--- a/src/yb/rpc/rpc_context.cc
+++ b/src/yb/rpc/rpc_context.cc
@@ -147,11 +147,16 @@ RpcContext::RpcContext(std::shared_ptr<YBInboundCall> call,
     RespondRpcFailure(ErrorStatusPB::ERROR_INVALID_REQUEST, s);
     return;
   }
+  call_->CreateServerSpan();
   TRACE_EVENT_ASYNC_BEGIN1("rpc_call", "RPC", this, "call", call_->ToString());
 }
 
 RpcContext::RpcContext(std::shared_ptr<LocalYBInboundCall> call)
     : call_(call), params_(call.get(), boost::null_deleter()) {
+  // Inbound (server-side) span for this local call.
+  if (auto outbound_call = call->outbound_call(); outbound_call) {
+    call_->CreateServerSpan(outbound_call->otel_span_context());
+  }
   TRACE_EVENT_ASYNC_BEGIN1("rpc_call", "RPC", this, "call", call_->ToString());
 }
 

--- a/src/yb/rpc/rpc_header.proto
+++ b/src/yb/rpc/rpc_header.proto
@@ -54,6 +54,21 @@ message RemoteMethodPB {
   required string method_name = 2;
 };
 
+// Distributed-trace context (W3C trace-context; https://www.w3.org/TR/trace-context/) propagated
+// across a process boundary. Defined here so a single message and wire format serves both
+// transports: it is carried in the RPC RequestHeader below (alongside AshMetadataPB), and as an
+// independent length-prefixed slot in the shared-memory PG<->tserver exchange.
+message TraceContextPB {
+  // 8 bytes (high 64 bits of trace_id)
+  optional fixed64 trace_id_hi = 1;
+  // 8 bytes (low 64 bits of trace_id)
+  optional fixed64 trace_id_lo = 2;
+  // 8 bytes
+  optional fixed64 span_id = 3;
+  // Low byte: flags, High byte: version (1-2 bytes on wire)
+  optional uint32 version_and_flags = 4;
+}
+
 // The header for the RPC request frame.
 message RequestHeader {
   reserved 6;
@@ -81,6 +96,9 @@ message RequestHeader {
   optional AshMetadataPB metadata = 5;
 
   optional uint64 pool_tag = 7;
+
+  // Distributed-trace context, propagating the trace from caller to the server handling this RPC.
+  optional TraceContextPB trace_context = 8;
 
   // CRC32C for message body and header without CRC field. Use 15 as max 1 byte tag.
   optional fixed32 crc = 15;

--- a/src/yb/rpc/scheduler.h
+++ b/src/yb/rpc/scheduler.h
@@ -17,6 +17,7 @@
 
 #include "yb/rpc/rpc_fwd.h"
 
+#include "yb/util/dist_trace.h"
 #include "yb/util/net/net_fwd.h"
 #include "yb/util/status.h"
 #include "yb/util/logging.h"
@@ -31,10 +32,11 @@ constexpr ScheduledTaskId kUninitializedScheduledTaskId = 0;
 class ScheduledTaskBase {
  public:
   explicit ScheduledTaskBase(ScheduledTaskId id, const SteadyTimePoint& time)
-      : id_(id), time_(time) {}
+      : id_(id), time_(time), trace_parent_(dist_trace::GetActiveSpanContext()) {}
 
   ScheduledTaskId id() const { return id_; }
   SteadyTimePoint time() const { return time_; }
+  const dist_trace::trace::SpanContext& trace_parent() const { return trace_parent_; }
 
   virtual ~ScheduledTaskBase() {}
   virtual void Run(const Status& status) = 0;
@@ -42,6 +44,7 @@ class ScheduledTaskBase {
  private:
   ScheduledTaskId id_;
   SteadyTimePoint time_;
+  dist_trace::trace::SpanContext trace_parent_;
 };
 
 template<class F>
@@ -51,6 +54,7 @@ class ScheduledTask : public ScheduledTaskBase {
       : ScheduledTaskBase(id, time), f_(f) {}
 
   void Run(const Status& status) override {
+    auto scope = dist_trace::ActivateParentScope(trace_parent());
     f_(status);
   }
  private:
@@ -64,6 +68,7 @@ class ScheduledTaskWithId : public ScheduledTaskBase {
       : ScheduledTaskBase(id, time), f_(f) {}
 
   void Run(const Status& status) override {
+    auto scope = dist_trace::ActivateParentScope(trace_parent());
     f_(id(), status);
   }
 

--- a/src/yb/rpc/serialization.cc
+++ b/src/yb/rpc/serialization.cc
@@ -229,6 +229,9 @@ Status ParseHeader(
       case RequestHeader::kMetadataFieldNumber:
         parsed_header->metadata = VERIFY_RESULT(ParseString(buf, "metadata", in));
         break;
+      case RequestHeader::kTraceContextFieldNumber:
+        parsed_header->trace_context = VERIFY_RESULT(ParseString(buf, "trace_context", in));
+        break;
       default: {
         if (!SkipField(tag & 7, in)) {
           return STATUS_FORMAT(Corruption, "Unable to skip: $0", tag);
@@ -372,6 +375,93 @@ Result<ParsedRemoteMethod> ParseRemoteMethod(const Slice& buf) {
     }
   }
   return result;
+}
+
+namespace {
+
+// Rebuilds a remote SpanContext from the wire fields. Fails if the trace/span ids are zero.
+Result<opentelemetry::trace::SpanContext> BuildSpanContext(
+    uint64_t trace_id_hi, uint64_t trace_id_lo, uint64_t span_id, uint32_t version_and_flags) {
+  // 16-byte trace id from its high/low 64-bit halves; 8-byte span id (big-endian on the wire).
+  uint8_t trace_id_bytes[16];
+  BigEndian::Store64(trace_id_bytes, trace_id_hi);
+  BigEndian::Store64(trace_id_bytes + 8, trace_id_lo);
+  uint8_t span_id_bytes[8];
+  BigEndian::Store64(span_id_bytes, span_id);
+
+  // Flags are the low byte; the high byte is the (currently unused) version.
+  uint8_t flags = version_and_flags & 0xFF;
+
+  auto span_context = opentelemetry::trace::SpanContext(
+      opentelemetry::trace::TraceId(trace_id_bytes),
+      opentelemetry::trace::SpanId(span_id_bytes),
+      opentelemetry::trace::TraceFlags(flags),
+      /* is_remote= */ true);
+
+  if (!span_context.IsValid()) {
+    return STATUS(Corruption, "Invalid trace context: trace_id_hi/lo or span_id is zero");
+  }
+  return span_context;
+}
+
+}  // namespace
+
+Result<opentelemetry::trace::SpanContext> ParseTraceContext(const Slice& buf) {
+  CodedInputStream in(buf.data(), narrow_cast<int>(buf.size()));
+  in.PushLimit(narrow_cast<int>(buf.size()));
+  uint64_t trace_id_hi = 0, trace_id_lo = 0, span_id = 0;
+  uint32_t version_and_flags = 0;
+  bool has_trace_id_hi = false, has_trace_id_lo = false, has_span_id = false,
+       has_version_and_flags = false;
+  while (in.BytesUntilLimit() > 0) {
+    auto tag = in.ReadTag();
+    auto field = tag >> 3;
+    switch (field) {
+      case TraceContextPB::kTraceIdHiFieldNumber:
+        if (!in.ReadLittleEndian64(&trace_id_hi)) {
+          return STATUS(Corruption, "Unable to decode trace_id_hi");
+        }
+        has_trace_id_hi = true;
+        break;
+      case TraceContextPB::kTraceIdLoFieldNumber:
+        if (!in.ReadLittleEndian64(&trace_id_lo)) {
+          return STATUS(Corruption, "Unable to decode trace_id_lo");
+        }
+        has_trace_id_lo = true;
+        break;
+      case TraceContextPB::kSpanIdFieldNumber:
+        if (!in.ReadLittleEndian64(&span_id)) {
+          return STATUS(Corruption, "Unable to decode span_id");
+        }
+        has_span_id = true;
+        break;
+      case TraceContextPB::kVersionAndFlagsFieldNumber:
+        if (!in.ReadVarint32(&version_and_flags)) {
+          return STATUS(Corruption, "Unable to decode version_and_flags");
+        }
+        has_version_and_flags = true;
+        break;
+      default: {
+        if (!SkipField(tag & 7, &in)) {
+          return STATUS_FORMAT(Corruption, "Unable to skip: $0", tag);
+        }
+      }
+    }
+  }
+  if (!has_trace_id_hi || !has_trace_id_lo || !has_span_id || !has_version_and_flags) {
+    return STATUS(Corruption, "Incomplete trace context: missing field");
+  }
+  return BuildSpanContext(trace_id_hi, trace_id_lo, span_id, version_and_flags);
+}
+
+Result<opentelemetry::trace::SpanContext> ToSpanContext(const TraceContextPB& trace_context) {
+  if (!trace_context.has_trace_id_hi() || !trace_context.has_trace_id_lo() ||
+      !trace_context.has_span_id() || !trace_context.has_version_and_flags()) {
+    return STATUS(Corruption, "Incomplete trace context: missing field");
+  }
+  return BuildSpanContext(
+      trace_context.trace_id_hi(), trace_context.trace_id_lo(), trace_context.span_id(),
+      trace_context.version_and_flags());
 }
 
 std::string ParsedRequestHeader::RemoteMethodAsString() const {

--- a/src/yb/rpc/serialization.h
+++ b/src/yb/rpc/serialization.h
@@ -42,6 +42,8 @@
 #include <google/protobuf/message.h>
 #include <google/protobuf/repeated_field.h>
 
+#include "opentelemetry/trace/span_context.h"
+
 #include "yb/rpc/rpc_fwd.h"
 
 #include "yb/util/result.h"
@@ -62,6 +64,8 @@ class Status;
 
 namespace rpc {
 
+class TraceContextPB;
+
 Result<std::pair<RefCntBuffer, size_t>> SerializeResponse(
     size_t body_size, size_t additional_size, const google::protobuf::Message& header,
     AnyMessageConstPtr body);
@@ -79,6 +83,7 @@ struct ParsedRequestHeader {
   boost::iterator_range<const uint32_t*> sidecar_offsets;
   Slice metadata;
   ThreadPoolTag pool_tag = 0;
+  Slice trace_context;
   std::optional<uint32_t> crc;
 
   std::string RemoteMethodAsString() const;
@@ -104,7 +109,15 @@ struct ParsedRemoteMethod {
   Slice method;
 };
 
+// Builds a SpanContext from a TraceContextPB (shared-memory path). Fails if any field is missing or
+// the trace/span ids are zero.
+Result<opentelemetry::trace::SpanContext> ToSpanContext(const TraceContextPB& trace_context);
+
 Result<ParsedRemoteMethod> ParseRemoteMethod(const Slice& buf);
+
+// Parses a RequestHeader.trace_context wire slice into a SpanContext (RPC path). Fails if any field
+// is missing or the trace/span ids are zero.
+Result<opentelemetry::trace::SpanContext> ParseTraceContext(const Slice& buf);
 Status ParseMetadata(Slice buf, AnyMessagePtr out);
 Status ParseMetadataFromSharedMemory(uint8_t** input, size_t length, AnyMessagePtr out);
 

--- a/src/yb/rpc/yb_rpc.cc
+++ b/src/yb/rpc/yb_rpc.cc
@@ -29,7 +29,9 @@
 #include "yb/rpc/serialization.h"
 
 #include "yb/util/debug/trace_event.h"
+#include "yb/util/dist_trace.h"
 #include "yb/util/format.h"
+#include "yb/util/logging.h"
 #include "yb/util/result.h"
 #include "yb/util/status_format.h"
 
@@ -305,6 +307,18 @@ Status YBInboundCall::ParseFrom(const MemTrackerPtr& mem_tracker, CallData* call
   DVLOG(4) << "Parsed YBInboundCall header: " << header_.call_id;
   UpdateWaitStateInfo();
 
+  // Extract the propagated distributed-trace parent from the header, if present. The span itself is
+  // created later (CreateServerSpan) once the request params have been parsed. Tracing is
+  // best-effort: a malformed context is logged and dropped, never fails the RPC.
+  if (dist_trace::IsDistTraceEnabled() && !header_.trace_context.empty()) {
+    auto parsed = ParseTraceContext(header_.trace_context);
+    if (parsed.ok()) {
+      parent_span_context_ = std::move(*parsed);
+    } else {
+      YB_LOG_EVERY_N_SECS(WARNING, 5) << "Failed to parse RPC trace context: " << parsed.status();
+    }
+  }
+
   consumption_ = ScopedTrackedConsumption(mem_tracker, call_data->size());
   request_data_ = std::move(*call_data);
 
@@ -314,6 +328,27 @@ Status YBInboundCall::ParseFrom(const MemTrackerPtr& mem_tracker, CallData* call
   }
 
   return Status::OK();
+}
+
+void YBInboundCall::CreateServerSpan(std::optional<opentelemetry::trace::SpanContext> parent) {
+  // Remote calls supply no `parent` and fall back to the context parsed from the wire header; local
+  // calls pass the originating outbound span's context explicitly (there is no wire header).
+  const auto& parent_context = parent ? parent : parent_span_context_;
+  if (!parent_context) {
+    return;
+  }
+  auto parsed_method = ParseRemoteMethod(header_.remote_method);
+  if (!parsed_method.ok()) {
+    return;
+  }
+  auto span_name = Format("rpc $0.$1", parsed_method->service, parsed_method->method);
+  span_ = dist_trace::StartServerSpanWithScope(span_name, *parent_context);
+  if (span_) {
+    span_->SetAttribute("rpc.system", "inbound_rpc");
+    span_->SetAttribute("rpc.service", parsed_method->service.ToBuffer());
+    span_->SetAttribute("rpc.method", parsed_method->method.ToBuffer());
+    span_->SetAttribute("rpc.call_id", header_.call_id);
+  }
 }
 
 Status YBInboundCall::SerializeResponseBuffer(AnyMessageConstPtr response, bool is_success) {
@@ -425,12 +460,23 @@ Status YBInboundCall::ParseParam(RpcCallParams* params) {
 
 void YBInboundCall::RespondSuccess(AnyMessageConstPtr response) {
   TRACE_EVENT0("rpc", "InboundCall::RespondSuccess");
+  if (span_) {
+    span_->SetStatus(opentelemetry::trace::StatusCode::kOk);
+    span_->End();
+    span_.reset();
+  }
   Respond(response, /*is_success=*/true);
 }
 
 void YBInboundCall::RespondFailure(ErrorStatusPB::RpcErrorCodePB error_code,
                                    const Status& status) {
   TRACE_EVENT0("rpc", "InboundCall::RespondFailure");
+
+  if (span_) {
+    span_->SetStatus(opentelemetry::trace::StatusCode::kError, status.ToUserMessage());
+    span_->End();
+    span_.reset();
+  }
 
   // Release memory early and prevent building an oversized error response.
   sidecars_.Reset();

--- a/src/yb/rpc/yb_rpc.h
+++ b/src/yb/rpc/yb_rpc.h
@@ -34,6 +34,7 @@
 #include "yb/rpc/serialization.h"
 #include "yb/rpc/sidecars.h"
 
+#include "yb/util/dist_trace.h"
 #include "yb/util/ev_util.h"
 #include "yb/util/net/net_fwd.h"
 #include "yb/util/size_literals.h"
@@ -199,6 +200,19 @@ class YBInboundCall : public InboundCall {
 
   virtual Status ParseParam(RpcCallParams* params);
 
+  // Creates a server-side trace span, from the inbound RequestHeader's trace_context (remote)
+  // or the outbound call's context via `parent` (local). No-op when no parent or tracing is off.
+  void CreateServerSpan(
+      std::optional<opentelemetry::trace::SpanContext> parent = std::nullopt);
+
+  // Releases the server span's thread-local scope on the handler thread once synchronous handling
+  // is done. The span itself ends later (RespondSuccess/Failure), possibly on another thread.
+  void DropServerSpanScope() {
+    if (span_) {
+      span_->DropScope();
+    }
+  }
+
   size_t ObjectSize() const override { return sizeof(*this); }
 
   Result<RefCntSlice> ExtractSidecar(size_t idx) const;
@@ -230,6 +244,12 @@ class YBInboundCall : public InboundCall {
 
   // The header of the incoming call. Set by ParseFrom()
   ParsedRequestHeader header_;
+
+  // Parent span context parsed from the inbound trace_context header field, if present.
+  std::optional<opentelemetry::trace::SpanContext> parent_span_context_;
+
+  // Server-side distributed-trace span (with activated scope) for this call.
+  dist_trace::SpanWithScopePtr span_;
 
   // The buffers for serialized response. Set by SerializeResponseBuffer().
   RefCntBuffer response_buf_;

--- a/src/yb/tablet/operations/operation_driver.cc
+++ b/src/yb/tablet/operations/operation_driver.cc
@@ -96,6 +96,7 @@ OperationDriver::OperationDriver(OperationTracker *operation_tracker,
       preparer_(preparer),
       trace_(Trace::MaybeGetNewTraceForParent(Trace::CurrentTrace())),
       wait_state_(ash::WaitStateInfo::CurrentWaitState()),
+      otel_parent_(dist_trace::GetActiveSpanContext()),
       start_time_(MonoTime::Now()),
       replication_state_(NOT_REPLICATING),
       prepare_state_(NOT_PREPARED) {
@@ -406,6 +407,10 @@ void OperationDriver::ApplyTask(int64_t leader_term, OpIds* applied_op_ids) {
   ADOPT_TRACE(trace());
   ADOPT_WAIT_STATE(wait_state());
   SCOPED_WAIT_STATUS(OnCpu_Active);
+
+  // Re-activate the submitting thread's trace on this apply thread so RPCs the operation issues
+  // during apply (e.g. APPLYING/APPLIED UpdateTransaction RPCs) nest under it.
+  auto otel_scope = dist_trace::ActivateParentScope(otel_parent_);
 
 #ifndef NDEBUG
   {

--- a/src/yb/tablet/operations/operation_driver.h
+++ b/src/yb/tablet/operations/operation_driver.h
@@ -51,6 +51,7 @@
 
 #include "yb/tablet/operations/operation.h"
 
+#include "yb/util/dist_trace.h"
 #include "yb/util/status_fwd.h"
 #include "yb/util/lockfree.h"
 #include "yb/util/trace.h"
@@ -268,6 +269,9 @@ class OperationDriver : public RefCountedThreadSafe<OperationDriver>,
   // Trace object for tracing any operations started by this driver.
   scoped_refptr<Trace> trace_;
   const ash::WaitStateInfoPtr wait_state_;
+
+  // OpenTelemetry trace context of the submitting thread
+  const dist_trace::trace::SpanContext otel_parent_ = dist_trace::trace::SpanContext::GetInvalid();
 
   const MonoTime start_time_;
 

--- a/src/yb/tserver/db_server_base.cc
+++ b/src/yb/tserver/db_server_base.cc
@@ -28,6 +28,7 @@
 #include "yb/tserver/tserver_util_fwd.h"
 #include "yb/tserver/tserver_shared_mem.h"
 
+#include "yb/util/dist_trace.h"
 #include "yb/util/jsonwriter.h"
 #include "yb/util/metrics.h"
 #include "yb/util/mem_tracker.h"
@@ -50,6 +51,11 @@ DbServerBase::~DbServerBase() {
 
 Status DbServerBase::Init() {
   RETURN_NOT_OK(RpcAndWebServerBase::Init());
+
+  // Initialize distributed tracing once per process here
+  if (dist_trace::IsDistTraceEnabled()) {
+    dist_trace::InitDistTrace(name_, permanent_uuid());
+  }
 
   async_client_init_ = std::make_unique<client::AsyncClientInitializer>(
       "server_client", default_client_timeout(), permanent_uuid(), &options(), metric_entity(),
@@ -117,6 +123,10 @@ void DbServerBase::Shutdown() {
     txn_manager->Shutdown();
   }
   async_client_init_->Shutdown();
+
+  if (dist_trace::IsDistTraceEnabled()) {
+    dist_trace::ShutdownDistTrace();
+  }
 }
 
 const std::shared_future<client::YBClient*>& DbServerBase::client_future() const {

--- a/src/yb/tserver/pg_client_session.cc
+++ b/src/yb/tserver/pg_client_session.cc
@@ -58,6 +58,8 @@
 
 #include "yb/rpc/lightweight_message.h"
 #include "yb/rpc/rpc_context.h"
+#include "yb/rpc/rpc_header.pb.h"
+#include "yb/rpc/serialization.h"
 #include "yb/rpc/sidecars.h"
 #include "yb/rpc/scheduler.h"
 
@@ -81,6 +83,7 @@
 #include "yb/util/cast.h"
 #include "yb/util/cgroups.h"
 #include "yb/util/debug-util.h"
+#include "yb/util/dist_trace.h"
 #include "yb/util/enums.h"
 #include "yb/util/logging.h"
 #include "yb/util/lw_function.h"
@@ -836,6 +839,30 @@ using PerformQueryTraits = QueryTraits<PgPerformRequestMsg, PgPerformResponseMsg
 using ObjectLockQueryTraits =
     QueryTraits<const PgAcquireObjectLockRequestMsg, PgAcquireObjectLockResponseMsg>;
 
+// Name of the inbound shared-memory span.
+template <QueryTraitsType T>
+std::string_view SharedMemHandlerSpanName();
+template <>
+std::string_view SharedMemHandlerSpanName<PerformQueryTraits>() {
+  return "shmem yb.tserver.PgClientService.Perform";
+}
+template <>
+std::string_view SharedMemHandlerSpanName<ObjectLockQueryTraits>() {
+  return "shmem yb.tserver.PgClientService.AcquireObjectLock";
+}
+
+// Method name attribute for the inbound shared-memory span.
+template <QueryTraitsType T>
+const char* SharedMemMethodName();
+template <>
+const char* SharedMemMethodName<PerformQueryTraits>() {
+  return "Perform";
+}
+template <>
+const char* SharedMemMethodName<ObjectLockQueryTraits>() {
+  return "AcquireObjectLock";
+}
+
 using ResponseSender = std::function<void()>;
 
 template <QueryTraitsType T>
@@ -1113,6 +1140,8 @@ class SharedExchangeQuery : public std::enable_shared_from_this<SharedExchangeQu
   // 8 bytes - timeout in milliseconds.
   // next - size of serialized AshMetadataPB protobuf (say 'x').
   // next 'x' bytes - serialized AshMetadataPB protobuf.
+  // next - size of serialized TraceContextPB protobuf (say 'y').
+  // next 'y' bytes - serialized TraceContextPB protobuf.
   // remaining bytes - serialized PgPerformRequestPB protobuf.
   template <class... Args>
   Result<RequestInfo> ParseRequest(
@@ -1124,6 +1153,8 @@ class SharedExchangeQuery : public std::enable_shared_from_this<SharedExchangeQu
     input += sizeof(uint64_t);
     RETURN_NOT_OK(rpc::ParseMetadataFromSharedMemory(
         &input, end - input, rpc::AnyMessagePtr(&ash_metadata_)));
+    RETURN_NOT_OK(rpc::ParseMetadataFromSharedMemory(
+        &input, end - input, rpc::AnyMessagePtr(&trace_context_)));
     RETURN_NOT_OK(req_.ParseFromSlice(Slice(input, end)));
     data_.emplace(
         std::forward<Args>(args)..., session_id, arena_, req_, resp_, sidecars_,
@@ -1144,6 +1175,7 @@ class SharedExchangeQuery : public std::enable_shared_from_this<SharedExchangeQu
   }
 
   const AshMetadataPB& ash_metadata() const { return ash_metadata_; }
+  const rpc::TraceContextPB& trace_context() const { return trace_context_; }
 
  private:
   void SendResponse() {
@@ -1210,6 +1242,7 @@ class SharedExchangeQuery : public std::enable_shared_from_this<SharedExchangeQu
   std::remove_const_t<typename T::ReqPB> req_;
   typename T::RespPB resp_;
   AshMetadataPB ash_metadata_;
+  rpc::TraceContextPB trace_context_;
   rpc::Sidecars sidecars_;
   std::weak_ptr<PgClientSession> session_;
   SharedExchange& exchange_;
@@ -2769,7 +2802,34 @@ class PgClientSession::Impl {
     auto track_guard = wait_state
         ? TrackSharedMemoryPgMethodExecution<T>(wait_state, query.ash_metadata())
         : std::nullopt;
-    return DoHandleSharedExchangeQuery(precondition_waiter, std::move(data), deadline);
+
+    // Fix span attibutes for shared memory exchange.
+    dist_trace::SpanWithScopePtr trace_scope;
+    const auto& trace_context = query.trace_context();
+    if (dist_trace::IsDistTraceEnabled() && trace_context.has_span_id()) {
+      auto parent_context = rpc::ToSpanContext(trace_context);
+      if (parent_context.ok()) {
+        trace_scope = dist_trace::StartServerSpanWithScope(
+            SharedMemHandlerSpanName<T>(), *parent_context);
+        if (trace_scope) {
+          // Mirror the attributes the RPC inbound span carries (yb_rpc.cc), minus the ones with no
+          // shared-memory analog (rpc.call_id).
+          trace_scope->SetAttribute("rpc.system", "inbound_shmem");
+          trace_scope->SetAttribute("rpc.service", "yb.tserver.PgClientService");
+          trace_scope->SetAttribute("rpc.method", SharedMemMethodName<T>());
+        }
+      }
+    }
+
+    const auto status = DoHandleSharedExchangeQuery(precondition_waiter, std::move(data), deadline);
+    if (trace_scope) {
+      if (status.ok()) {
+        trace_scope->SetStatus(opentelemetry::trace::StatusCode::kOk);
+      } else {
+        trace_scope->SetStatus(opentelemetry::trace::StatusCode::kError, status.ToUserMessage());
+      }
+    }
+    return status;
   }
 
   template <QueryTraitsType T, class... Args>

--- a/src/yb/tserver/tablet_validator.cc
+++ b/src/yb/tserver/tablet_validator.cc
@@ -45,6 +45,7 @@
 
 #include "yb/util/background_task.h"
 #include "yb/util/compare_util.h"
+#include "yb/util/dist_trace.h"
 #include "yb/util/flags.h"
 #include "yb/util/logging.h"
 #include "yb/util/monotime.h"
@@ -90,6 +91,10 @@ struct IndexTableInfo {
   TabletId index_tablet_id;
   TableId  index_table_id;
   TableId  group_id; // Generally contains indexed_table_id.
+
+  // OTel context active when this index was scheduled (the CreateTablet RPC's trace, carried into
+  // OpenTablet by the threadpool). Used to nest the later GetBackfillStatus poll under that trace.
+  dist_trace::trace::SpanContext trace_parent = dist_trace::trace::SpanContext::GetInvalid();
 
   std::string ToString() const {
     return YB_STRUCT_TO_STRING(index_tablet_id, index_table_id, group_id);
@@ -399,10 +404,16 @@ bool TabletMetadataValidator::Impl::ScheduleTabletPropertiesValidation(
     return false;
   }
 
+  // Active OTel context, live here because the threadpool carries it from the CreateTablet RPC into
+  // OpenTablet. Stored per index so the later GetBackfillStatus poll nests under the triggering
+  // trace.
+  const auto trace_parent = dist_trace::GetActiveSpanContext();
+
   // Pick all index tables with retain_delete_markers set to true.
   std::vector<IndexTableInfo> candidates;
   candidates.reserve(meta.GetColocatedTablesCount()); // Let's try to predict the size.
-  meta.IterateColocatedTables([this, &meta, &candidates](const yb::tablet::TableInfo& info){
+  meta.IterateColocatedTables(
+      [this, &meta, &candidates, &trace_parent](const yb::tablet::TableInfo& info){
     VLOG_WITH_PREFIX(4) << "Candidate: " << info.ToString();
     if (info.schema().table_properties().retain_delete_markers()) {
       // For colocation tables info.index_info may not be set and thus it's not possible
@@ -410,7 +421,7 @@ bool TabletMetadataValidator::Impl::ScheduleTabletPropertiesValidation(
       // index table id instead of indexed table id to reuse the same structures.
       auto group_id = info.index_info ? info.index_info->indexed_table_id() : info.table_id;
       candidates.emplace_back(IndexTableInfo{
-          meta.raft_group_id(), info.table_id, std::move(group_id) });
+          meta.raft_group_id(), info.table_id, std::move(group_id), trace_parent });
     }
   });
   if (candidates.empty()) {
@@ -487,6 +498,13 @@ Result<master::GetBackfillStatusResponsePB> TabletMetadataValidator::Impl::SyncW
        to_sync.size() < batch_size && it != index_tablets_to_sync_.end(); ++it) {
     to_sync.emplace(it->index_table_id);
   }
+
+  // First entry wins: one RPC batches many index tables (possibly from different DDLs), but a span
+  // has a single parent. Nest the RPC under the first batched index's captured trace context.
+  const auto trace_parent = index_tablets_to_sync_.empty()
+      ? dist_trace::trace::SpanContext::GetInvalid()
+      : index_tablets_to_sync_.begin()->trace_parent;
+  auto otel_scope = dist_trace::ActivateParentScope(trace_parent);
 
   // Only backfilling status is being synced with the master at the moment.
   VLOG_WITH_PREFIX(1) << "Requesting backfill status for " << yb::ToString(to_sync);

--- a/src/yb/util/dist_trace.cc
+++ b/src/yb/util/dist_trace.cc
@@ -11,43 +11,35 @@
 // under the License.
 //
 
-#include "yb/util/dist_trace.h"
-
-#include <deque>
-#include <memory>
-
 #include "opentelemetry/context/propagation/global_propagator.h"
-#include "opentelemetry/context/propagation/text_map_propagator.h"
-#include "opentelemetry/context/runtime_context.h"
 #include "opentelemetry/exporters/otlp/otlp_http_exporter_factory.h"
 #include "opentelemetry/exporters/otlp/otlp_http_exporter_options.h"
 #include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/sdk/trace/batch_span_processor_factory.h"
-#include "opentelemetry/sdk/trace/batch_span_processor_options.h"
-#include "opentelemetry/sdk/trace/tracer_provider.h"
 #include "opentelemetry/sdk/trace/tracer_provider_factory.h"
 #include "opentelemetry/sdk/trace/provider.h"
-#include "opentelemetry/trace/context.h"
 #include "opentelemetry/trace/propagation/http_trace_context.h"
 #include "opentelemetry/trace/provider.h"
-#include "opentelemetry/trace/span.h"
-#include "opentelemetry/trace/span_metadata.h"
-#include "opentelemetry/trace/tracer.h"
 
+#include "yb/util/dist_trace.h"
 #include "yb/util/flag_validators.h"
-#include "yb/util/flags.h"
 #include "yb/util/signal_util.h"
 
 DEFINE_NON_RUNTIME_PREVIEW_string(otel_collector_traces_endpoint, "",
     "OTLP HTTP endpoint for the OpenTelemetry collector. When set, distributed tracing is "
     "enabled and spans are exported to this endpoint on each query execution.");
 
-DEFINE_NON_RUNTIME_uint32(otel_batch_max_queue_size, 2048,
+DEFINE_NON_RUNTIME_uint32(otel_batch_max_queue_size, 16384,
     "Maximum number of spans that can be buffered in the batch span processor queue. "
     "Spans arriving after this limit are dropped. Must be greater than 0 and at least as "
     "large as otel_batch_max_export_batch_size.");
 
-DEFINE_NON_RUNTIME_uint32(otel_batch_schedule_delay_ms, 5000,
+DEFINE_NON_RUNTIME_uint32(otel_ysql_batch_max_queue_size, 2048,
+    "Like otel_batch_max_queue_size, but used only by the ysql (postgres backend) process, which "
+    "runs one batch span processor per connection. Must be greater than 0 and at least as large as "
+    "otel_batch_max_export_batch_size.");
+
+DEFINE_NON_RUNTIME_uint32(otel_batch_schedule_delay_ms, 500,
     "Time interval in milliseconds between two consecutive batch exports of spans to the "
     "OpenTelemetry collector. Lower values reduce latency but increase export frequency.");
 
@@ -60,6 +52,9 @@ DEFINE_NON_RUNTIME_string(otel_internal_log_level, "info",
     "values are debug, info, warning, error, and none.");
 
 DEFINE_validator(otel_batch_max_queue_size,
+    FLAG_GE_FLAG_VALIDATOR(otel_batch_max_export_batch_size));
+
+DEFINE_validator(otel_ysql_batch_max_queue_size,
     FLAG_GE_FLAG_VALIDATOR(otel_batch_max_export_batch_size));
 
 DEFINE_validator(otel_internal_log_level,
@@ -75,38 +70,39 @@ namespace context = opentelemetry::context;
 
 namespace {
 
-const nostd::string_view ysql_resource_name = "ysql";
+// Service name for the tracing resource and tracer (e.g. "ysql", "Master", "TabletServer").
+static std::string g_service_name;
 
-// Owns string attribute data and maintains a parallel vector of string_view/AttributeValue pairs
-// that can be passed directly to the OTel Tracer::StartSpan API. Uses std::deque for pointer
-// stability -- unlike std::vector, deque does not relocate existing elements on insertion, so
-// string_views into earlier entries remain valid.
-class RpcSpanAttrs {
- public:
-  void AddStringAttr(std::string key, std::string value) {
-    auto& owned_key = owned_keys_.emplace_back(std::move(key));
-    auto& owned_val = owned_values_.emplace_back(std::move(value));
-    attrs_.emplace_back(owned_key, owned_val);
+// The ysql process gets its own queue-size flag; tserver/master share otel_batch_max_queue_size.
+static uint32_t EffectiveBatchMaxQueueSize() {
+  return g_service_name == kYsqlServiceName ? FLAGS_otel_ysql_batch_max_queue_size
+                                            : FLAGS_otel_batch_max_queue_size;
+}
+
+// A batch of pending RPC span attributes, owned as plain (key, value) strings.
+using PendingRpcSpanAttrs = std::vector<std::pair<std::string, std::string>>;
+
+thread_local PendingRpcSpanAttrs pending_rpc_attrs;
+
+// Moves the pending attributes out of the thread-local buffer, leaving it empty. The returned batch
+// owns the strings.
+static PendingRpcSpanAttrs ConsumePendingRpcAttrs() {
+  PendingRpcSpanAttrs consumed = std::move(pending_rpc_attrs);
+  // std::move leaves the source unspecified; force it empty.
+  pending_rpc_attrs.clear();
+  return consumed;
+}
+
+// Builds the OTel-API attribute vector (string_view/AttributeValue pairs) viewing into `attrs`.
+std::vector<std::pair<nostd::string_view, opentelemetry::common::AttributeValue>> SpanAttrsView(
+    const PendingRpcSpanAttrs& attrs) {
+  std::vector<std::pair<nostd::string_view, opentelemetry::common::AttributeValue>> view;
+  view.reserve(attrs.size());
+  for (const auto& [key, value] : attrs) {
+    view.emplace_back(key, value);
   }
-
-  const std::vector<std::pair<nostd::string_view, opentelemetry::common::AttributeValue>>& attrs()
-      const {
-    return attrs_;
-  }
-
-  void clear() {
-    attrs_.clear();
-    owned_keys_.clear();
-    owned_values_.clear();
-  }
-
- private:
-  std::deque<std::string> owned_keys_;
-  std::deque<std::string> owned_values_;
-  std::vector<std::pair<nostd::string_view, opentelemetry::common::AttributeValue>> attrs_;
-};
-
-thread_local RpcSpanAttrs pending_rpc_attrs;
+  return view;
+}
 
 internal_log::LogLevel GetOtelInternalLogLevel() {
   const auto& flag_value = FLAGS_otel_internal_log_level;
@@ -158,10 +154,11 @@ class YbOtelLogHandler : public internal_log::LogHandler {
   }
 };
 
-resource_sdk::Resource CreateResource(int64_t process_pid, nostd::string_view node_uuid) {
+resource_sdk::Resource CreateResource(
+    nostd::string_view service_name, nostd::string_view node_uuid) {
   resource_sdk::ResourceAttributes attrs;
-  attrs.SetAttribute("service.name", ysql_resource_name);
-  attrs.SetAttribute("process.pid", process_pid);
+  attrs.SetAttribute("service.name", service_name);
+  attrs.SetAttribute("process.pid", static_cast<int64_t>(getpid()));
   attrs.SetAttribute("service.instance.id", node_uuid);
 
   return resource_sdk::Resource::Create(attrs);
@@ -177,7 +174,7 @@ auto CreateExporter() {
 
 trace_sdk::BatchSpanProcessorOptions MakeBatchProcessorOptions() {
   trace_sdk::BatchSpanProcessorOptions batching_opts;
-  batching_opts.max_queue_size = static_cast<size_t>(FLAGS_otel_batch_max_queue_size);
+  batching_opts.max_queue_size = static_cast<size_t>(EffectiveBatchMaxQueueSize());
   batching_opts.schedule_delay_millis =
       std::chrono::milliseconds(FLAGS_otel_batch_schedule_delay_ms);
   batching_opts.max_export_batch_size = static_cast<size_t>(FLAGS_otel_batch_max_export_batch_size);
@@ -207,8 +204,8 @@ Status InitDistTraceProvider(const resource_sdk::Resource& resource_attrs) {
 // supplied (through GUC or comment) traceparent header.
 class TraceparentCarrier : public context::propagation::TextMapCarrier {
  public:
-  explicit TraceparentCarrier(nostd::string_view traceparent)
-      : traceparent_(traceparent) {}
+  explicit TraceparentCarrier(nostd::string_view traceparent = {})
+      : traceparent_(traceparent.data(), traceparent.size()) {}
 
   nostd::string_view Get(nostd::string_view key) const noexcept override {
     if (key == trace::propagation::kTraceParent) {
@@ -217,10 +214,16 @@ class TraceparentCarrier : public context::propagation::TextMapCarrier {
     return {};
   }
 
-  void Set(nostd::string_view, nostd::string_view) noexcept override {}
+  void Set(nostd::string_view key, nostd::string_view value) noexcept override {
+    if (key == trace::propagation::kTraceParent) {
+      traceparent_.assign(value.data(), value.size());
+    }
+  }
+
+  const std::string& traceparent() const { return traceparent_; }
 
  private:
-  nostd::string_view traceparent_;
+  std::string traceparent_;
 };
 
 }  // namespace
@@ -229,7 +232,7 @@ bool IsDistTraceEnabled() {
   return !FLAGS_otel_collector_traces_endpoint.empty();
 }
 
-void InitDistTrace(int64_t process_pid, nostd::string_view node_uuid) {
+void InitDistTrace(nostd::string_view service_name, nostd::string_view node_uuid) {
   DCHECK(IsDistTraceEnabled());
 
   internal_log::GlobalLogHandler::SetLogHandler(
@@ -239,7 +242,8 @@ void InitDistTrace(int64_t process_pid, nostd::string_view node_uuid) {
   // are mapped to LOG(...), where YB logging applies its own routing.
   internal_log::GlobalLogHandler::SetLogLevel(GetOtelInternalLogLevel());
 
-  auto resource_attrs = CreateResource(process_pid, node_uuid);
+  g_service_name = std::string(service_name);
+  auto resource_attrs = CreateResource(service_name, node_uuid);
   const auto status = InitDistTraceProvider(resource_attrs);
   if (!status.ok()) {
     LOG(DFATAL) << "Failed to initialize OpenTelemetry tracing: " << status;
@@ -250,13 +254,13 @@ void InitDistTrace(int64_t process_pid, nostd::string_view node_uuid) {
       nostd::shared_ptr<context::propagation::TextMapPropagator>(
           new trace::propagation::HttpTraceContext()));
 
-  LOG(INFO) << "OTEL: Initialized tracing for service: " << ysql_resource_name
-            << "\nBatchSpanProcessor config: max_queue_size=" << FLAGS_otel_batch_max_queue_size
+  LOG(INFO) << "OTEL: Initialized tracing for service: " << g_service_name
+            << "\nBatchSpanProcessor config: max_queue_size=" << EffectiveBatchMaxQueueSize()
             << ", schedule_delay_ms=" << FLAGS_otel_batch_schedule_delay_ms
             << ", max_export_batch_size=" << FLAGS_otel_batch_max_export_batch_size;
 }
 
-void CleanupDistTrace() {
+void ShutdownDistTrace() {
   DCHECK(IsDistTraceEnabled());
 
   std::shared_ptr<trace::TracerProvider> none;
@@ -267,7 +271,7 @@ void CleanupDistTrace() {
 
 nostd::shared_ptr<opentelemetry::trace::Tracer> GetDistTracer() {
   DCHECK(IsDistTraceEnabled());
-  return DCHECK_NOTNULL(trace::Provider::GetTracerProvider()->GetTracer(ysql_resource_name));
+  return DCHECK_NOTNULL(trace::Provider::GetTracerProvider()->GetTracer(g_service_name));
 }
 
 // A SpanContext is not valid when either its trace ID or span ID is all zeros.
@@ -292,12 +296,30 @@ trace::SpanContext GetTraceparentSpanContext(const char* traceparent) {
   return trace::GetSpan(parent_context)->GetContext();
 }
 
+std::string GetActiveTraceparent() {
+  if (!HasActiveContext()) {
+    return {};
+  }
+  TraceparentCarrier carrier;
+  static const auto propagator =
+      context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
+  propagator->Inject(carrier, context::RuntimeContext::GetCurrent());
+  return carrier.traceparent();
+}
+
 bool HasActiveContext() {
   if (!IsDistTraceEnabled()) {
     return false;
   }
   auto current_span = trace::Tracer::GetCurrentSpan();
   return current_span && current_span->GetContext().IsValid();
+}
+
+trace::SpanContext GetActiveSpanContext() {
+  if (!HasActiveContext()) {
+    return trace::SpanContext::GetInvalid();
+  }
+  return trace::Tracer::GetCurrentSpan()->GetContext();
 }
 
 nostd::shared_ptr<trace::Span> StartSpan(
@@ -321,17 +343,68 @@ nostd::shared_ptr<trace::Span> StartSpan(std::string_view op_name) {
   return StartSpan(op_name, {});
 }
 
+SpanWithScopePtr StartSpanWithScope(
+    std::string_view op_name,
+    const std::vector<std::pair<nostd::string_view, opentelemetry::common::AttributeValue>>& attrs,
+    trace::SpanKind kind) {
+  if (!HasActiveContext()) {
+    return nullptr;
+  }
+  trace::StartSpanOptions options;
+  options.kind = kind;
+  return std::make_shared<SpanWithScope>(StartSpan(op_name, attrs, options));
+}
+
+SpanWithScopePtr StartSpanWithScope(std::string_view op_name, trace::SpanKind kind) {
+  return StartSpanWithScope(op_name, {}, kind);
+}
+
+SpanWithScopePtr StartClientSpanWithScope(std::string_view op_name) {
+  const auto pending = ConsumePendingRpcAttrs();
+
+  if (!IsDistTraceEnabled()) {
+    return nullptr;
+  }
+
+  auto current_span = trace::Tracer::GetCurrentSpan();
+  if (current_span && current_span->GetContext().IsValid()) {
+    return StartSpanWithScope(op_name, SpanAttrsView(pending), trace::SpanKind::kClient);
+  }
+
+  return nullptr;
+}
+
+SpanWithScopePtr StartServerSpanWithScope(
+    std::string_view op_name,
+    const trace::SpanContext& parent_context,
+    const std::vector<std::pair<nostd::string_view, opentelemetry::common::AttributeValue>>&
+        attrs) {
+  if (!IsDistTraceEnabled()) {
+    return nullptr;
+  }
+  trace::StartSpanOptions options;
+  options.kind = trace::SpanKind::kServer;
+  options.parent = parent_context;
+  return std::make_shared<SpanWithScope>(GetDistTracer()->StartSpan(
+      nostd::string_view(op_name.data(), op_name.size()), attrs, options));
+}
+
+SpanWithScopePtr StartServerSpanWithScope(
+    std::string_view op_name, const trace::SpanContext& parent_context) {
+  return StartServerSpanWithScope(op_name, parent_context, {});
+}
+
+SpanWithScopePtr ActivateParentScope(const trace::SpanContext& parent_context) {
+  if (!IsDistTraceEnabled() || !parent_context.IsValid()) {
+    return nullptr;
+  }
+  // A non-recording span that merely carries parent_context.
+  return std::make_shared<SpanWithScope>(
+      nostd::shared_ptr<trace::Span>(new trace::DefaultSpan(parent_context)));
+}
+
 void AddPendingRpcStringAttr(std::string key, std::string value) {
-  pending_rpc_attrs.AddStringAttr(std::move(key), std::move(value));
-}
-
-const std::vector<std::pair<nostd::string_view,
-                            opentelemetry::common::AttributeValue>>& GetPendingRpcAttrPairs() {
-  return pending_rpc_attrs.attrs();
-}
-
-void ClearPendingRpcAttrs() {
-  pending_rpc_attrs.clear();
+  pending_rpc_attrs.emplace_back(std::move(key), std::move(value));
 }
 
 }  // namespace yb::dist_trace

--- a/src/yb/util/dist_trace.h
+++ b/src/yb/util/dist_trace.h
@@ -13,28 +13,89 @@
 
 #pragma once
 
-#include <cstdint>
-#include <string>
-#include <string_view>
-#include <utility>
-#include <vector>
+#include <thread>
 
-#include "opentelemetry/common/attribute_value.h"
-#include "opentelemetry/trace/span_metadata.h"
+#include "opentelemetry/trace/scope.h"
 #include "opentelemetry/trace/span_startoptions.h"
 
 #include "yb/util/dist_trace_fwd.h"
+#include "yb/util/logging.h"
 
 namespace yb::dist_trace {
 
 namespace nostd = opentelemetry::nostd;
 namespace trace = opentelemetry::trace;
 
-void InitDistTrace(int64_t process_pid, opentelemetry::nostd::string_view node_uuid);
-void CleanupDistTrace();
+// Bundles a span with an activated (thread-local) scope so work started after it inherits it as
+// parent; DropScope on the constructing thread before hopping threads. End() is safe from any
+// thread.
+struct SpanWithScope {
+  explicit SpanWithScope(nostd::shared_ptr<trace::Span> s)
+      : span(std::move(s)), scope(span) {}
+
+  ~SpanWithScope() { End(); }
+
+  SpanWithScope(SpanWithScope&&) = default;
+  SpanWithScope& operator=(SpanWithScope&&) = default;
+  SpanWithScope(const SpanWithScope&) = delete;
+  SpanWithScope& operator=(const SpanWithScope&) = delete;
+
+  void SetAttribute(nostd::string_view key, const opentelemetry::common::AttributeValue& value) {
+    if (span) {
+      span->SetAttribute(key, value);
+    }
+  }
+
+  void SetStatus(trace::StatusCode code, nostd::string_view description = "") {
+    if (span) {
+      span->SetStatus(code, description);
+    }
+  }
+
+  trace::SpanContext GetContext() const {
+    return span ? span->GetContext() : trace::SpanContext::GetInvalid();
+  }
+
+  // Releases the thread-local scope. Must be called on the thread that constructed this object.
+  void DropScope() {
+    scope.reset();
+    owner_thread = {};
+  }
+
+  void End() {
+    if (span && span->IsRecording()) {
+      // The scope must be dropped on its creating thread; catch an unintended thread hop.
+      DCHECK(owner_thread == std::thread::id() || std::this_thread::get_id() == owner_thread)
+          << "SpanWithScope scope released off its creating thread";
+      scope.reset();
+      span->End();
+    }
+  }
+
+  nostd::shared_ptr<trace::Span> span;
+  std::optional<trace::Scope> scope;
+  std::thread::id owner_thread = std::this_thread::get_id();
+};
+
+using SpanWithScopePtr = std::shared_ptr<SpanWithScope>;
+
+// OTel service.name for the ysql (postgres backend) process, passed to InitDistTrace at startup.
+inline const std::string kYsqlServiceName = "ysql";
+
+void InitDistTrace(
+    opentelemetry::nostd::string_view service_name, opentelemetry::nostd::string_view node_uuid);
+void ShutdownDistTrace();
 nostd::shared_ptr<opentelemetry::trace::Tracer> GetDistTracer();
 bool IsDistTraceEnabled();
 trace::SpanContext GetTraceparentSpanContext(const char* traceparent);
+
+// Serializes the active span into a W3C traceparent string via the global propagator (inverse of
+// GetTraceparentSpanContext); hands the context to another process. Empty when disabled/no context.
+std::string GetActiveTraceparent();
+
+// Get SpanContext of the active span
+trace::SpanContext GetActiveSpanContext();
+
 bool IsSpanContextValidAndRemote(const trace::SpanContext& span_context);
 
 // Returns true if distributed tracing is enabled and there is an active span in the OTEL context.
@@ -48,11 +109,34 @@ nostd::shared_ptr<trace::Span> StartSpan(
     const std::vector<std::pair<nostd::string_view, opentelemetry::common::AttributeValue>>& attrs);
 nostd::shared_ptr<trace::Span> StartSpan(std::string_view op_name);
 
+// Starts a child span of the active context, bundled with an activated scope so it
+// becomes current; nullptr when no active context.
+SpanWithScopePtr StartSpanWithScope(
+    std::string_view op_name,
+    const std::vector<std::pair<nostd::string_view, opentelemetry::common::AttributeValue>>& attrs,
+    trace::SpanKind kind = trace::SpanKind::kInternal);
+SpanWithScopePtr StartSpanWithScope(
+    std::string_view op_name, trace::SpanKind kind = trace::SpanKind::kInternal);
+
+// Client span for an outbound RPC; drains pending thread-local attrs onto it.
+// Child of active context, else an optional root gated by otel_rpc_sampling_ratio.
+SpanWithScopePtr StartClientSpanWithScope(std::string_view op_name);
+
+// Span as a remote child of parent_context (from an inbound request) + activated scope --
+// the server end of a propagated trace; needs no local active context.
+SpanWithScopePtr StartServerSpanWithScope(
+    std::string_view op_name,
+    const trace::SpanContext& parent_context,
+    const std::vector<std::pair<nostd::string_view, opentelemetry::common::AttributeValue>>& attrs);
+SpanWithScopePtr StartServerSpanWithScope(
+    std::string_view op_name, const trace::SpanContext& parent_context);
+
+// Re-establishes parent_context as this thread's active context WITHOUT a new span, so RPCs built
+// here nest under it -- for RPCs issued off the origin's thread.
+SpanWithScopePtr ActivateParentScope(const trace::SpanContext& parent_context);
+
 // Thread-local attribute buffer for the next RPC span. Producers (e.g. PgSession) add
-// attributes here; the OutboundCall constructor consumes them when starting a span.
+// attributes here; the OutboundCall Span consumes them when started.
 void AddPendingRpcStringAttr(std::string key, std::string value);
-const std::vector<std::pair<nostd::string_view, opentelemetry::common::AttributeValue>>&
-    GetPendingRpcAttrPairs();
-void ClearPendingRpcAttrs();
 
 }  // namespace yb::dist_trace

--- a/src/yb/util/strand.cc
+++ b/src/yb/util/strand.cc
@@ -14,6 +14,7 @@
 
 #include <thread>
 
+#include "yb/util/dist_trace.h"
 #include "yb/util/flags.h"
 #include "yb/util/scope_exit.h"
 #include "yb/util/status.h"
@@ -121,6 +122,9 @@ Strand::~Strand() {
 }
 
 bool Strand::Enqueue(StrandTask* task) {
+  // Capture the active trace context; Strand::Task::Done re-activates it around task->Run() so the
+  // task's RPCs nest under the triggering trace. No-op if no scope/off.
+  task->set_trace_parent(dist_trace::GetActiveSpanContext());
   return EnqueueHelper([this, task](bool ok) {
     if (ok) {
       if (task_->Enqueue(task)) {
@@ -153,6 +157,10 @@ void Strand::Task::Done(const Status& status) {
 
       auto running = active_enqueues_.load(std::memory_order_acquire) < Strand::kStopMark;
       const auto& actual_status = running ? status : StrandAbortedStatus();
+      // Re-activate the context captured at Enqueue for this task only, so its RPCs nest under the
+      // triggering trace.
+      auto parent_scope =
+        dist_trace::ActivateParentScope(task->trace_parent());
       if (actual_status.ok()) {
         task->Run();
       }

--- a/src/yb/util/strand.h
+++ b/src/yb/util/strand.h
@@ -27,6 +27,14 @@ class StrandTask : public MPSCQueueEntry<StrandTask> {
   // When the thread pool done with a task, i.e. it completed or failed, it invokes Done.
   virtual void Done(const Status& status) = 0;
 
+  const dist_trace::trace::SpanContext& trace_parent() const {
+    return trace_parent_;
+  }
+
+  void set_trace_parent(dist_trace::trace::SpanContext trace_parent) {
+    trace_parent_ = std::move(trace_parent);
+  }
+
   virtual ~StrandTask() = default;
 
  private:
@@ -39,6 +47,7 @@ class StrandTask : public MPSCQueueEntry<StrandTask> {
   }
 
   StrandTask* next_ = nullptr;
+  dist_trace::trace::SpanContext trace_parent_ = dist_trace::trace::SpanContext::GetInvalid();
 };
 
 template <class F>

--- a/src/yb/util/thread_pool.cc
+++ b/src/yb/util/thread_pool.cc
@@ -23,7 +23,6 @@
 #include <boost/intrusive/list.hpp>
 
 #include "yb/util/cgroups.h"
-#include "yb/util/debug-util.h"
 #include "yb/util/flags.h"
 #include "yb/util/lockfree.h"
 #include "yb/util/scope_exit.h"
@@ -213,6 +212,8 @@ class Worker : public boost::intrusive::list_base_hook<> {
       }
 #endif
       auto start = MonoTime::NowIf(has_run_metrics);
+      // Re-activate the Enqueue-captured scope. No-op when trace_parent is invalid.
+      auto parent_scope = dist_trace::ActivateParentScope(task->trace_parent());
       if (!task->run_token()) {
         task->Run();
         task->Done(Status::OK());
@@ -648,6 +649,8 @@ YBThreadPool::~YBThreadPool() {
 }
 
 bool YBThreadPool::Enqueue(ThreadPoolTask* task) {
+  // Capture the active trace scope here, on the submitting thread, where it is still live.
+  task->set_trace_parent(dist_trace::GetActiveSpanContext());
   return impl_->Enqueue(task);
 }
 

--- a/src/yb/util/thread_pool.h
+++ b/src/yb/util/thread_pool.h
@@ -22,6 +22,7 @@
 #include "yb/gutil/port.h"
 
 #include "yb/util/debug/leakcheck_disabler.h"
+#include "yb/util/dist_trace.h"
 #include "yb/util/metrics.h"
 #include "yb/util/lockfree.h"
 #include "yb/util/scope_exit.h"
@@ -54,6 +55,16 @@ class ThreadPoolTask {
     run_token_ = std::move(run_token);
   }
 
+  // Trace context captured at Enqueue (on the submitting thread, where it is still live) and
+  // re-activated around Run() on the worker thread.
+  const dist_trace::trace::SpanContext& trace_parent() const {
+    return trace_parent_;
+  }
+
+  void set_trace_parent(dist_trace::trace::SpanContext trace_parent) {
+    trace_parent_ = std::move(trace_parent);
+  }
+
   void set_submit_time(MonoTime value) {
     submit_time_ = value;
   }
@@ -81,6 +92,7 @@ class ThreadPoolTask {
   // the task completion.
   ThreadPoolTask* next_ = nullptr;
   std::optional<std::weak_ptr<void>> run_token_;
+  dist_trace::trace::SpanContext trace_parent_ = dist_trace::trace::SpanContext::GetInvalid();
   MonoTime submit_time_;
   [[maybe_unused]] Cgroup* task_cgroup_ = nullptr;
 };
@@ -100,6 +112,8 @@ class FunctorThreadPoolTask : public Base {
 
  private:
   void Run() override {
+    // Re-activate the trace context captured at Enqueue
+    auto trace_scope = dist_trace::ActivateParentScope(this->trace_parent());
     f_();
   }
 
@@ -176,18 +190,26 @@ class TaskRecipient {
 
   template <NonReferenceType F>
   bool EnqueueFunctor(const F& f) {
-    return Enqueue(MakeFunctorThreadPoolTask<F, TaskType>(f));
+    return Enqueue(StampTraceContext(MakeFunctorThreadPoolTask<F, TaskType>(f)));
   }
 
   template <NonReferenceType F>
   bool EnqueueFunctor(F&& f) {
-    return Enqueue(MakeFunctorThreadPoolTask<F, TaskType>(std::move(f)));
+    return Enqueue(StampTraceContext(MakeFunctorThreadPoolTask<F, TaskType>(std::move(f))));
   }
 
   // Matches the interface of yb::ThreadPool::Submit.
   template <NonReferenceType F>
   Status Submit(const F& f) {
-    return EnqueueWithStatus(MakeFunctorThreadPoolTask<F, TaskType>(f));
+    return EnqueueWithStatus(StampTraceContext(MakeFunctorThreadPoolTask<F, TaskType>(f)));
+  }
+
+ private:
+  // Sets trace context to carry it across the threads: stamp the active context onto the task
+  template <class Task>
+  Task* StampTraceContext(Task* task) {
+    task->set_trace_parent(dist_trace::GetActiveSpanContext());
+    return task;
   }
 };
 

--- a/src/yb/yql/pggate/pg_client.cc
+++ b/src/yb/yql/pggate/pg_client.cc
@@ -282,9 +282,23 @@ struct ResponseReadyTraits;
 std::string_view GetSharedMemSpanName(tserver::PgSharedExchangeReqType req_type) {
   switch (req_type) {
     case tserver::PgSharedExchangeReqType::PERFORM:
-      return "shmem req yb.tserver.PgClientService.Perform";
+      return "shmem yb.tserver.PgClientService.Perform";
     case tserver::PgSharedExchangeReqType::ACQUIRE_OBJECT_LOCK:
-      return "shmem req yb.tserver.PgClientService.AcquireObjectLock";
+      return "shmem yb.tserver.PgClientService.AcquireObjectLock";
+    case tserver::PgSharedExchangeReqType_INT_MIN_SENTINEL_DO_NOT_USE_: [[fallthrough]];
+    case tserver::PgSharedExchangeReqType_INT_MAX_SENTINEL_DO_NOT_USE_: break;
+  }
+  FATAL_INVALID_ENUM_VALUE(tserver::PgSharedExchangeReqType, req_type);
+}
+
+// Method name attribute for the outbound shared-memory span, mirroring rpc.method on RPC spans (the
+// service is always PgClientService). Paired with the tserver's SharedMemMethodName.
+const char* GetSharedMemMethodName(tserver::PgSharedExchangeReqType req_type) {
+  switch (req_type) {
+    case tserver::PgSharedExchangeReqType::PERFORM:
+      return "Perform";
+    case tserver::PgSharedExchangeReqType::ACQUIRE_OBJECT_LOCK:
+      return "AcquireObjectLock";
     case tserver::PgSharedExchangeReqType_INT_MIN_SENTINEL_DO_NOT_USE_: [[fallthrough]];
     case tserver::PgSharedExchangeReqType_INT_MAX_SENTINEL_DO_NOT_USE_: break;
   }
@@ -428,14 +442,19 @@ struct PgClientData : public FetchBigDataCallback {
   rpc::CallData big_call_data GUARDED_BY(exchange_mutex);
   // Only the owning future accesses this span while starting or finishing the shared-memory
   // request. Exchange callbacks do not touch it, so it does not need exchange_mutex protection.
-  opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> otel_span;
+  dist_trace::SpanWithScopePtr otel_span;
 
   PgClientData(const LWReqPB& req_, ThreadSafeArena* arena_) : req(req_), resp(arena_) {}
 
   void StartSharedMemorySpan() {
-    if (dist_trace::HasActiveContext()) {
-      otel_span = dist_trace::StartSpan(
-          GetSharedMemSpanName(kSharedExchangeRequestType), dist_trace::GetPendingRpcAttrPairs());
+    otel_span = dist_trace::StartClientSpanWithScope(
+        GetSharedMemSpanName(kSharedExchangeRequestType));
+    if (otel_span) {
+      // Mirror the attributes the RPC outbound span carries (outbound_call.cc).
+      otel_span->SetAttribute("rpc.system", "outbound_shmem");
+      otel_span->SetAttribute("rpc.service", "yb.tserver.PgClientService");
+      otel_span->SetAttribute("rpc.method", GetSharedMemMethodName(kSharedExchangeRequestType));
+      otel_span->DropScope();
     }
   }
 
@@ -1197,8 +1216,30 @@ class PgClient::Impl : public BigDataFetcher {
     if (tablespace_oid) {
       lock_oid.set_tablespace_oid(*tablespace_oid);
     }
-    req.set_lock_type(static_cast<tserver::ObjectLockMode>(mode));
+    const auto lock_type = static_cast<tserver::ObjectLockMode>(mode);
+    req.set_lock_type(lock_type);
     req.set_is_session_lock(is_session_lock);
+
+    // Publish the details of AcquireObjectLock.
+    if (dist_trace::HasActiveContext()) {
+      dist_trace::AddPendingRpcStringAttr(
+          "rpc.object_lock.database_oid", std::to_string(lock_id.db_oid));
+      dist_trace::AddPendingRpcStringAttr(
+          "rpc.object_lock.relation_oid", std::to_string(lock_id.relation_oid));
+      dist_trace::AddPendingRpcStringAttr(
+          "rpc.object_lock.object_oid", std::to_string(lock_id.object_oid));
+      dist_trace::AddPendingRpcStringAttr(
+          "rpc.object_lock.object_sub_oid", std::to_string(lock_id.object_sub_oid));
+      dist_trace::AddPendingRpcStringAttr(
+          "rpc.object_lock.lock_mode", tserver::ObjectLockMode_Name(lock_type));
+      dist_trace::AddPendingRpcStringAttr(
+          "rpc.object_lock.is_session_lock", is_session_lock ? "true" : "false");
+      if (tablespace_oid) {
+        dist_trace::AddPendingRpcStringAttr(
+            "rpc.object_lock.tablespace_oid", std::to_string(*tablespace_oid));
+      }
+    }
+
     auto method = [](auto* proxy, const auto& req, auto* resp, auto* controller, auto callback) {
       proxy->AcquireObjectLockAsync(req, resp, controller, std::move(callback));
     };

--- a/src/yb/yql/pggate/pg_client.cc
+++ b/src/yb/yql/pggate/pg_client.cc
@@ -1125,9 +1125,16 @@ class PgClient::Impl : public BigDataFetcher {
   ResultFuture<Data> PrepareAndSend(Method method, Args&&... args) {
     auto data = std::make_shared<Data>(std::forward<Args>(args)...);
     if (session_shared_mem_ && session_shared_mem_->exchange().ReadyToSend()) {
+      // Start the outbound shared-memory span before sizing the request.
+      data->StartSharedMemorySpan();
       ash::MetadataSerializer metadata(rpc::MetadataSerializationMode::kWriteOnZero);
+      ash::TraceContextSerializer trace_context;
+      if (data->otel_span) {
+        trace_context.SetTraceContext(data->otel_span->GetContext());
+      }
       constexpr size_t kHeaderSize = sizeof(uint8_t) + sizeof(uint64_t);
       const size_t kMetadataSize = metadata.SerializedSize();
+      const size_t kTraceContextSize = trace_context.SerializedSize();
       auto& exchange = session_shared_mem_->exchange();
       // Sanity check: the exchange must not be reused while a big shared memory response from a
       // previous request has been announced but not yet loaded and released. Otherwise the tserver
@@ -1135,9 +1142,9 @@ class PgClient::Impl : public BigDataFetcher {
       // still intend to load it (see PgClientSession::ReleaseAbandonedBigSharedMemSegment).
       LOG_IF(DFATAL, big_shared_memory_response_pending_)
           << "Reusing shared exchange while a big shared memory response is still pending";
-      auto out = exchange.Obtain(kHeaderSize + kMetadataSize + data->req.SerializedSize());
+      auto out = exchange.Obtain(
+          kHeaderSize + kMetadataSize + kTraceContextSize + data->req.SerializedSize());
       if (out) {
-        data->StartSharedMemorySpan();
         const auto [rpc_deadline, rpc_timeout] =
             timeouts_.GetDeadlineAndTimeoutForRPC<typename Data::RequestType>();
         *reinterpret_cast<uint8_t *>(out) = Data::kSharedExchangeRequestType;
@@ -1145,6 +1152,7 @@ class PgClient::Impl : public BigDataFetcher {
         LittleEndian::Store64(out, rpc_timeout.ToMilliseconds());
         out += sizeof(uint64_t);
         out = pointer_cast<std::byte*>(metadata.SerializeToArray(to_uchar_ptr(out)));
+        out = pointer_cast<std::byte*>(trace_context.SerializeToArray(to_uchar_ptr(out)));
         const auto size = data->req.SerializedSize();
         auto* end = pointer_cast<std::byte*>(
             data->req.SerializeToArray(pointer_cast<uint8_t*>(out)));
@@ -1164,6 +1172,8 @@ class PgClient::Impl : public BigDataFetcher {
         data->SetupExchange(&exchange, this, rpc_deadline);
         return ExchangeFuture<Data>(std::move(data));
       }
+      // End the shared-memory span started above so it is not leaked.
+      data->EndSharedMemorySpan(Status::OK());
     }
     data->controller.set_invoke_callback_mode(rpc::InvokeCallbackMode::kReactorThread);
     method(

--- a/src/yb/yql/pggate/pg_session.cc
+++ b/src/yb/yql/pggate/pg_session.cc
@@ -109,12 +109,23 @@ void Erase(Container* container, const Key& key) {
 }
 
 void PublishPendingRpcTableInfo(
+    const PgsqlOps& operations,
     const std::vector<yb::PgObjectId>& relations,
     const std::unordered_map<yb::PgObjectId, PgTableDescPtr, yb::PgObjectIdHash>& table_cache) {
   if (!dist_trace::HasActiveContext() || relations.empty()) {
     return;
   }
-  dist_trace::ClearPendingRpcAttrs();
+
+  // Publish the details of Perform RPC.
+  size_t reads = 0;
+  size_t writes = 0;
+  for (const auto& op : operations) {
+    (op->is_read() ? reads : writes)++;
+  }
+  dist_trace::AddPendingRpcStringAttr("rpc.perform.op_count", std::to_string(operations.size()));
+  dist_trace::AddPendingRpcStringAttr("rpc.perform.reads", std::to_string(reads));
+  dist_trace::AddPendingRpcStringAttr("rpc.perform.writes", std::to_string(writes));
+
   std::set<PgObjectId> unique_relations(relations.begin(), relations.end());
   std::string joined_names;
   for (const auto& relation : unique_relations) {
@@ -993,7 +1004,7 @@ Result<PerformFuture> PgSession::Perform(BufferableOperations&& ops, PerformOpti
   std::move(ops).MoveTo(operations, relations);
   // Must run before `relations` is moved into PerformFuture below; otherwise the vector is
   // empty and no table info gets published for the upcoming RPC client span.
-  PublishPendingRpcTableInfo(relations, table_cache_);
+  PublishPendingRpcTableInfo(operations, relations, table_cache_);
   return PerformFuture(
       pg_client_.PerformAsync(&options, std::move(operations), metrics_),
       std::move(relations));

--- a/src/yb/yql/pggate/ybc_dist_trace.cc
+++ b/src/yb/yql/pggate/ybc_dist_trace.cc
@@ -21,6 +21,7 @@
 #include "opentelemetry/trace/tracer.h"
 
 #include "yb/util/dist_trace.h"
+#include "yb/util/flags.h"
 #include "yb/util/logging.h"
 
 #include "yb/yql/pggate/pg_memctx.h"
@@ -96,14 +97,12 @@ void YBCDestroySpanContext(YbcOtelSpanContext span_ctx) {
   PgMemctx::Destroy(span_ctx);
 }
 
-void YBCInitDistTrace(int64_t process_pid, const char* node_uuid) {
-  DCHECK_GT(process_pid, 0);
-
-  dist_trace::InitDistTrace(process_pid, DCHECK_NOTNULL(node_uuid));
+void YBCInitDistTrace(const char* node_uuid) {
+  dist_trace::InitDistTrace(dist_trace::kYsqlServiceName, DCHECK_NOTNULL(node_uuid));
 }
 
-void YBCCleanupDistTrace() {
-  dist_trace::CleanupDistTrace();
+void YBCShutdownDistTrace() {
+  dist_trace::ShutdownDistTrace();
 }
 
 void YBCDistTraceClearStack() {

--- a/src/yb/yql/pggate/ybc_dist_trace.h
+++ b/src/yb/yql/pggate/ybc_dist_trace.h
@@ -60,8 +60,8 @@ extern "C" {
   } while (0)
 
 bool YBCIsOtelScopeStackEmpty();
-void YBCInitDistTrace(int64_t process_pid, const char* node_uuid);
-void YBCCleanupDistTrace();
+void YBCInitDistTrace(const char* node_uuid);
+void YBCShutdownDistTrace();
 bool YBCIsDistTraceEnabled();
 bool YBCIsDistTraceActive();
 bool YBCIsTraceParentValidAndRemote(const char* traceparent);

--- a/src/yb/yql/pgwrapper/dist_trace-test.cc
+++ b/src/yb/yql/pgwrapper/dist_trace-test.cc
@@ -1677,9 +1677,9 @@ TEST_F(DistTraceRpcTest, TestOtelInternalMessagesAreLogged) {
   RegexWaiterLogSink info_waiter(Format("I.*$0.*", kInfo));
   RegexWaiterLogSink debug_waiter(Format("I.*$0.*", kDebug));
 
-  dist_trace::InitDistTrace(0 /* process_pid */, "dist-trace-otel-log-test");
+  dist_trace::InitDistTrace("ysql" /* service_name */, "dist-trace-otel-log-test");
   auto cleanup = ScopeExit([] {
-    dist_trace::CleanupDistTrace();
+    dist_trace::ShutdownDistTrace();
   });
 
   OTEL_INTERNAL_LOG_ERROR(kError);
@@ -1705,9 +1705,9 @@ TEST_F(DistTraceRpcTest, TestOtelInternalLogLevelDefaultsToInfo) {
   RegexWaiterLogSink info_waiter(Format("I.*$0.*", kInfo));
   RegexWaiterLogSink debug_waiter(Format("I.*$0.*", kDebug));
 
-  dist_trace::InitDistTrace(0 /* process_pid */, "dist-trace-otel-default-log-level-test");
+  dist_trace::InitDistTrace("ysql" /* service_name */, "dist-trace-otel-default-log-level-test");
   auto cleanup = ScopeExit([] {
-    dist_trace::CleanupDistTrace();
+    dist_trace::ShutdownDistTrace();
   });
 
   OTEL_INTERNAL_LOG_ERROR(kError);
@@ -1734,9 +1734,9 @@ TEST_F(DistTraceRpcTest, TestOtelInternalLogLevelGFlagControlsSdkFiltering) {
   RegexWaiterLogSink info_waiter(Format("I.*$0.*", kInfo));
   RegexWaiterLogSink debug_waiter(Format("I.*$0.*", kDebug));
 
-  dist_trace::InitDistTrace(0 /* process_pid */, "dist-trace-otel-error-log-level-test");
+  dist_trace::InitDistTrace("ysql" /* service_name */, "dist-trace-otel-error-log-level-test");
   auto cleanup = ScopeExit([] {
-    dist_trace::CleanupDistTrace();
+    dist_trace::ShutdownDistTrace();
   });
 
   OTEL_INTERNAL_LOG_ERROR(kError);
@@ -1765,9 +1765,9 @@ TEST_F(DistTraceRpcTest, TestOtelInternalLogLevelNoneSuppressesAllMessages) {
   RegexWaiterLogSink info_waiter(Format("I.*$0.*", kInfo));
   RegexWaiterLogSink debug_waiter(Format("I.*$0.*", kDebug));
 
-  dist_trace::InitDistTrace(0 /* process_pid */, "dist-trace-otel-none-log-level-test");
+  dist_trace::InitDistTrace("ysql" /* service_name */, "dist-trace-otel-none-log-level-test");
   auto cleanup = ScopeExit([] {
-    dist_trace::CleanupDistTrace();
+    dist_trace::ShutdownDistTrace();
   });
 
   OTEL_INTERNAL_LOG_ERROR(kError);
@@ -1789,9 +1789,9 @@ TEST_F(DistTraceRpcTest, TestErroredRpcSpanStatus) {
       kOtelBatchMaxExportBatchSize;
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_otel_batch_max_queue_size) = kOtelBatchMaxQueueSize;
 
-  dist_trace::InitDistTrace(0 /* process_pid */, "dist-trace-rpc-error-test");
+  dist_trace::InitDistTrace("ysql" /* service_name */, "dist-trace-rpc-error-test");
   auto cleanup = ScopeExit([] {
-    dist_trace::CleanupDistTrace();
+    dist_trace::ShutdownDistTrace();
   });
 
   auto root_span = dist_trace::GetDistTracer()->StartSpan("rpc-error-test");

--- a/src/yb/yql/pgwrapper/dist_trace-test.cc
+++ b/src/yb/yql/pgwrapper/dist_trace-test.cc
@@ -39,7 +39,6 @@
 #include "yb/util/dist_trace.h"
 #include "yb/util/enums.h"
 #include "yb/util/format.h"
-#include "yb/util/flags.h"
 #include "yb/util/logging_test_util.h"
 #include "yb/util/net/sockaddr.h"
 #include "yb/util/random_util.h"
@@ -71,7 +70,7 @@ static constexpr auto kOtelBatchMaxQueueSize = 4096;
 static constexpr auto kOtelBatchMaxExportBatchSize = 512;
 static constexpr auto kOtelBatchScheduleDelayMs = 100;
 static constexpr auto kSharedMemoryPerformSpanName =
-    "shmem req yb.tserver.PgClientService.Perform";
+    "shmem yb.tserver.PgClientService.Perform";
 
 YB_DEFINE_ENUM(QueryExecMode, (kFetch)(kExecute));
 YB_STRONGLY_TYPED_BOOL(IsUtility);
@@ -190,7 +189,7 @@ class OtlpHttpCollector {
 
   static bool ShouldIgnoreForQuerySpanComparison(const Span& span) {
     return kExecutorNodeSpanNames.contains(span.op_name) ||
-           span.op_name.starts_with("shmem req ") ||
+           span.op_name.starts_with("shmem ") ||
            span.op_name.starts_with("rpc ");
   }
 
@@ -349,7 +348,8 @@ class OtlpHttpCollector {
     std::lock_guard lock(mutex_);
     for (const auto& [_, trace] : traces_) {
       for (const auto& span : trace.spans) {
-        if (span.op_name.starts_with(prefix) && span.status_message == status_message) {
+        if (span.op_name.starts_with(prefix) &&
+            span.status_message.find(status_message) != std::string_view::npos) {
           return true;
         }
       }
@@ -486,6 +486,49 @@ class OtlpHttpCollector {
         Format("Child spans of '$0' in trace '$1'", parent_op_name, trace_id));
   }
 
+  // Waits for a cross-boundary pairing in trace_id: a server span (service_name == server_service,
+  // op name starting with op_prefix, rpc.system == expected_rpc_system) whose parent_span_id is the
+  // span_id of a client span (service_name == client_service, same op_prefix). This proves the
+  // query's trace propagated from caller to callee. Returns the server span on success.
+  Result<Span> WaitForRemoteChildSpan(
+      std::string_view trace_id, std::string_view op_prefix,
+      std::string_view client_service, std::string_view server_service,
+      std::string_view expected_rpc_system) const EXCLUDES(mutex_) {
+    Span server_span;
+    RETURN_NOT_OK(WaitFor(
+        [&]() -> Result<bool> {
+          std::lock_guard lock(mutex_);
+          auto it = traces_.find(std::string(trace_id));
+          if (it == traces_.end()) return false;
+          const auto& spans = it->second.spans;
+          for (const auto& server : spans) {
+            if (server.service_name != server_service ||
+                !server.op_name.starts_with(op_prefix) ||
+                server.parent_span_id.empty()) {
+              continue;
+            }
+            auto sys_it = server.str_attrs.find("rpc.system");
+            if (sys_it == server.str_attrs.end() || sys_it->second != expected_rpc_system) {
+              continue;
+            }
+            // The server span's parent must be a client span in the same trace.
+            for (const auto& client : spans) {
+              if (client.service_name == client_service &&
+                  client.op_name.starts_with(op_prefix) &&
+                  client.span_id == server.parent_span_id) {
+                server_span = server;
+                return true;
+              }
+            }
+          }
+          return false;
+        },
+        kOtelBatchScheduleDelayMs * kTimeMultiplier * 50ms,
+        Format("Remote child span '$0*' on '$1' linked to '$2' in trace '$3'",
+               op_prefix, server_service, client_service, trace_id)));
+    return server_span;
+  }
+
  private:
   void HandleTraceRequest(const Webserver::WebRequest& req, Webserver::WebResponse* resp) {
     if (req.request_method != "POST") {
@@ -585,16 +628,16 @@ class DistTraceTest : public LibPqTestBase {
   }
 
   virtual void ConfigureDistTraceOptions(ExternalMiniClusterOptions* options) {
-    AppendFlagToAllowedPreviewFlagsCsv(options->extra_tserver_flags,
-        "otel_collector_traces_endpoint");
-    options->extra_tserver_flags.push_back(
-        Format("--otel_collector_traces_endpoint=$0", collector_.Url()));
-    options->extra_tserver_flags.push_back(
-        Format("--otel_batch_schedule_delay_ms=$0", kOtelBatchScheduleDelayMs));
-    options->extra_tserver_flags.push_back(
-        Format("--otel_batch_max_export_batch_size=$0", kOtelBatchMaxExportBatchSize));
-    options->extra_tserver_flags.push_back(
-        Format("--otel_batch_max_queue_size=$0", kOtelBatchMaxQueueSize));
+    // Export OTEL traces from both tservers and masters so cross-boundary DDL spans (which land on
+    // the master) reach the collector.
+    for (auto* flags : {&options->extra_tserver_flags, &options->extra_master_flags}) {
+      AppendFlagToAllowedPreviewFlagsCsv(*flags, "otel_collector_traces_endpoint");
+      flags->push_back(Format("--otel_collector_traces_endpoint=$0", collector_.Url()));
+      flags->push_back(Format("--otel_batch_schedule_delay_ms=$0", kOtelBatchScheduleDelayMs));
+      flags->push_back(
+          Format("--otel_batch_max_export_batch_size=$0", kOtelBatchMaxExportBatchSize));
+      flags->push_back(Format("--otel_batch_max_queue_size=$0", kOtelBatchMaxQueueSize));
+    }
   }
 
   int GetNumTabletServers() const override {
@@ -1662,6 +1705,63 @@ TEST_F(DistTraceRpcTest, TestRpcSpans) {
       "RPC span to appear in trace"));
 }
 
+// Cross-boundary: the Perform RPC's trace must reach the tserver. The inbound server span on
+// TabletServer should be a child of the PG backend's (ysql) outbound client span.
+TEST_F(DistTraceRpcTest, TestRpcSpanReachesTabletServer) {
+  ASSERT_OK(CreateTable("rpc_crossing_test", 5));
+
+  auto tp = GenerateTraceparent();
+  ASSERT_OK(conn_->ExecuteFormat(
+      "SET yb_dist_tracecontext = 'traceparent=''$0'''", tp.full));
+  ASSERT_OK(conn_->Fetch("SELECT * FROM rpc_crossing_test"));
+
+  auto server_span = ASSERT_RESULT(collector_.WaitForRemoteChildSpan(
+      tp.trace_id, "rpc yb.tserver.PgClientService.Perform",
+      "ysql" /* client_service */, "TabletServer" /* server_service */,
+      "inbound_rpc" /* expected_rpc_system */));
+
+  ASSERT_EQ(server_span.str_attrs["rpc.service"], "yb.tserver.PgClientService");
+  ASSERT_EQ(server_span.str_attrs["rpc.method"], "Perform");
+}
+
+// Cross-boundary over shared memory: the Perform shmem exchange's trace must reach the tserver.
+// The inbound server span on TabletServer should be a child of the ysql outbound client span.
+TEST_F(DistTraceTest, TestSharedMemoryPerformReachesTabletServer) {
+  ASSERT_OK(CreateTable("shmem_crossing_test", 5));
+
+  auto tp = GenerateTraceparent();
+  ASSERT_OK(conn_->ExecuteFormat(
+      "SET yb_dist_tracecontext = 'traceparent=''$0'''", tp.full));
+  ASSERT_OK(conn_->Fetch("SELECT * FROM shmem_crossing_test"));
+
+  auto server_span = ASSERT_RESULT(collector_.WaitForRemoteChildSpan(
+      tp.trace_id, "shmem yb.tserver.PgClientService.Perform",
+      "ysql" /* client_service */, "TabletServer" /* server_service */,
+      "inbound_shmem" /* expected_rpc_system */));
+
+  ASSERT_EQ(server_span.str_attrs["rpc.service"], "yb.tserver.PgClientService");
+  ASSERT_EQ(server_span.str_attrs["rpc.method"], "Perform");
+}
+
+// Cross-boundary to master: a DDL fans out from the tserver to the master. A master inbound RPC
+// span should join the query's trace as a child of a tserver outbound span -- proving the trace
+// propagated the full PG -> tserver -> master chain. Any master method suffices, so match on the
+// "rpc " prefix and distinguish the boundary by service_name (TabletServer -> Master).
+TEST_F(DistTraceTest, TestDdlRpcReachesMaster) {
+  auto tp = GenerateTraceparent();
+  ASSERT_OK(conn_->ExecuteFormat(
+      "SET yb_dist_tracecontext = 'traceparent=''$0'''", tp.full));
+  ASSERT_OK(conn_->Execute(
+      "CREATE TABLE master_crossing_test (id int PRIMARY KEY, val text)"));
+
+  auto server_span = ASSERT_RESULT(collector_.WaitForRemoteChildSpan(
+      tp.trace_id, "rpc ",
+      "TabletServer" /* client_service */, "Master" /* server_service */,
+      "inbound_rpc" /* expected_rpc_system */));
+
+  ASSERT_STR_CONTAINS(server_span.str_attrs["rpc.service"], "yb.master.");
+}
+
 TEST_F(DistTraceRpcTest, TestOtelInternalMessagesAreLogged) {
   google::FlagSaver flag_saver;
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_otel_collector_traces_endpoint) = collector_.Url();
@@ -1815,7 +1915,8 @@ TEST_F(DistTraceRpcTest, TestErroredRpcSpanStatus) {
   ASSERT_OK(WaitFor(
       [&]() -> Result<bool> {
         return collector_.HasSpanWithNamePrefixAndStatusMessage(
-            "rpc WrongServiceName.ThisMethodDoesNotExist", "Call ErroredOut");
+            "rpc WrongServiceName.ThisMethodDoesNotExist",
+            "Service WrongServiceName not registered on TabletServer");
       },
       kOtelBatchScheduleDelayMs * kTimeMultiplier * 50ms,
       "Errored RPC span to appear in trace"));
@@ -1844,7 +1945,7 @@ TEST_F(DistTraceRpcTimeoutTest, TestTimedOutRpcSpanStatus) {
         auto rpc_spans = collector_.FindSpansByNamePrefix(tp.trace_id, "rpc ");
         return std::any_of(rpc_spans.begin(), rpc_spans.end(), [](const Span& span) {
           return span.op_name.starts_with("rpc yb.tserver.PgClientService.GetLockStatus") &&
-                 span.status_message == "Call TimedOut";
+                 span.status_message.find("timed out after") != std::string::npos;
         });
       },
       kOtelBatchScheduleDelayMs * kTimeMultiplier * 50ms,

--- a/src/yb/yql/pgwrapper/libpq_utils.cc
+++ b/src/yb/yql/pgwrapper/libpq_utils.cc
@@ -28,6 +28,7 @@
 #include "yb/gutil/endian.h"
 
 #include "yb/util/backoff_waiter.h"
+#include "yb/util/dist_trace.h"
 #include "yb/util/endian_util.h"
 #include "yb/util/enums.h"
 #include "yb/util/format.h"
@@ -139,6 +140,9 @@ std::string BuildConnectionString(const PGConnSettings& settings, bool mask_pass
   if (!settings.yb_internal_conn_kind.empty()) {
     result += Format(
         " yb_internal_conn_kind=$0", PqEscapeStringConn(settings.yb_internal_conn_kind));
+  }
+  if (!settings.traceparent.empty()) {
+    result += Format(" yb_dist_traceparent=$0", PqEscapeStringConn(settings.traceparent));
   }
   return result;
 }
@@ -1030,7 +1034,8 @@ PGConnBuilder CreateInternalPGConnBuilder(
        .password = UInt64ToString(postgres_auth_key),
        .connect_timeout = connect_timeout,
        .yb_internal_conn_kind = std::string(yb_internal_conn_kind),
-       .should_stop = std::move(should_stop)});
+       .should_stop = std::move(should_stop),
+       .traceparent = dist_trace::GetActiveTraceparent()});
 }
 
 } // namespace yb::pgwrapper

--- a/src/yb/yql/pgwrapper/libpq_utils.h
+++ b/src/yb/yql/pgwrapper/libpq_utils.h
@@ -468,6 +468,9 @@ struct PGConnSettings {
   // shutting down). Checked between connection attempts, not during one. Carried by the builder, so
   // it also applies to any later reconnect made from a stored builder.
   std::function<bool()> should_stop = {};
+  // W3C traceparent for the distributed-trace root span the backend should
+  // activate intializing connection.
+  std::string traceparent = {};
 };
 
 class PGConnBuilder {


### PR DESCRIPTION
## Summary

Distributed-trace (W3C trace-context) propagation for query RPCs across YugabyteDB. A `traceparent` originating at the tserver is carried end to end — over the RPC wire header, the PG↔tserver shared-memory exchange, async thread hops, and the PG backend startup packet — so spans on downstream servers and the PG backend nest under the originating trace. Every path is gated by `IsDistTraceEnabled` and is a no-op when tracing is off.

This is a large change, so it is organized as **9 self-contained commits in dependency order** — each builds the tree and is meant to be reviewed on its own. (They were prepared as a 9-PR stack; since a chained stack can't target intermediate branches that live on our fork, they are submitted here as one PR preserving the same commit boundaries.)

**Commit-by-commit:**

1. **add TraceContextPB and RequestHeader.trace_context** — Define `TraceContextPB` (W3C trace-context) and the `trace_context` field (tag 8) on the RPC `RequestHeader`, both in `rpc_header.proto`. The shared wire type for the RPC-header and shared-memory transports; no code references it yet.
2. **span/scope API and its direct callers** — Rework the `dist_trace` library into the span+scope API the rest of the stack builds on (`SpanWithScope`, `Start{Client,Server}SpanWithScope`, `ActivateParentScope`, `GetActiveSpanContext`/`GetActiveTraceparent`), and update every in-tree caller in lockstep so the tree keeps building.
3. **async scope-carry across thread hops** — Carry the active trace context across thread boundaries (thread pools, strands, scheduler, periodic timers, RPC retries) so work resumed on a worker/reactor thread nests under the submitting trace. Purely additive; a no-op on an invalid context.
4. **RPC trace-context propagation (wire codec + client/server spans)** — Decode the context off the wire, create the server span on the callee, and hand a local call's client span to its in-process inbound span (`serialization`, `yb_rpc`, `local_call`, `rpc_context`). A bad context is logged, never fails the RPC.
5. **carry trace context across task and Raft-apply thread hops** — Same capture/re-activate pattern applied to higher-level task types (operation driver's apply task, master async RPC tasks, multi-step monitored tasks, tablet validator) so their RPCs nest under the triggering trace.
6. **propagate trace context over the PG↔tserver shared-memory exchange** — Add the write side (`TraceContextSerializer`) and wire both ends of the shared-memory Perform / AcquireObjectLock fast path, mirroring the RPC-header path; the server span is tagged `rpc.system=inbound_shmem`.
7. **initialize distributed tracing in the master/tserver process** — Initialize the process-wide tracer once in `DbServerBase::Init` (service name = server name, node id = permanent uuid) for master, tserver, and the PG backend's server; torn down in `Shutdown`. Gated by `IsDistTraceEnabled`.
8. **propagate traceparent to the PG backend via the startup packet** — Carry a W3C `traceparent` from the tserver into the PG backend over the connection startup packet (new `yb_dist_traceparent` conninfo option → `yb_dist_tracecontext` GUC), so backend init and subsequent queries root under the originating trace.
9. **end-to-end distributed-tracing tests** — `pgwrapper/dist_trace-test.cc` exercises the full path (process init, RPC-header and shared-memory propagation, span parent/child nesting, startup-packet traceparent), asserting the expected trace/span relationships end to end.

## Upgrade/Rollback safety

Wire-compatible in both directions.

- `TraceContextPB` is a brand-new message; `RequestHeader.trace_context` uses the previously-unused field tag `8` (the next tag after `pool_tag = 7`; `crc` remains `15`). Both fields are `optional`.
- On a mixed-version cluster: an older server that predates this change ignores the unknown field `8` on incoming `RequestHeader`s; a newer server treats an absent `trace_context` as "no trace context".
- The shared-memory exchange always emits a length prefix for the trace-context blob (zero when unset), so the framing stays parseable regardless of whether the peer populates it.
- All propagation is gated by `IsDistTraceEnabled`, so with tracing off there is no observable behavior change on the wire or in the shared-memory exchange.
- Rollback is safe: reverting stops reading/writing the field; the unused proto tag and GUC leave no persistent state behind.

## Test plan

- [x] `dist_trace-test` passes — end-to-end propagation across process init, RPC header, shared-memory exchange, and startup-packet traceparent, with the expected span parent/child nesting.
- [x] Existing RPC and `pg_client_session` tests pass with tracing disabled (no behavior change when `IsDistTraceEnabled` is false).
- [x] Protobufs compile (`rpc_header.proto` changes).
