### PR TITLE
[BACKPORT 2025.2][#9624] DocDB: Suggest closest matches for misspelled yb-admin commands (#32513)

### DIFF
--- a/src/yb/tools/yb-admin-test.cc
+++ b/src/yb/tools/yb-admin-test.cc
@@ -213,6 +213,69 @@ class AdminCliTest : public AdminTestBase {
   TmpDirProvider tmp_dir_;
 };
 
+// Verify the "did you mean" help for a misspelled operation, none of which needs a running
+// cluster (the operation is checked before yb-admin connects to the master): prefix matches,
+// fuzzy (edit-distance) matches, and that an invalid operation no longer dumps the full command
+// list (the original complaint in the issue) while running with no operation still prints the
+// full usage as help.
+TEST_F(AdminCliTest, InvalidOperationSuggestsClosestCommands) {
+  const auto exe_path = GetAdminToolPath();
+  constexpr auto kUnusedMasterAddress = "127.0.0.1:0";
+  // This marker only appears in the full usage/command listing (which is printed to stdout).
+  constexpr auto kFullUsageMarker = "<operation> must be one of";
+  std::string output;
+  std::string error;
+
+  // Prefix match: an unambiguous typo suggests the single command it is a prefix of.
+  ASSERT_NOK(Subprocess::Call(
+      ToStringVector(
+          exe_path, "--master_addresses", kUnusedMasterAddress, "list_snapshot_schedule"),
+      /* output */ nullptr, &error));
+  ASSERT_STR_CONTAINS(error, "Did you mean one of these?");
+  ASSERT_STR_CONTAINS(error, "list_snapshot_schedules");
+
+  // Prefix match: a prefix of several commands lists every candidate and a hint, and must not dump
+  // the full command list on either stream.
+  ASSERT_NOK(Subprocess::Call(
+      ToStringVector(exe_path, "--master_addresses", kUnusedMasterAddress, "list_table"), &output,
+      &error));
+  ASSERT_STR_CONTAINS(error, "Did you mean one of these?");
+  ASSERT_STR_CONTAINS(error, "list_tables");
+  ASSERT_STR_CONTAINS(error, "list_tablets");
+  ASSERT_STR_CONTAINS(error, "to see all available operations");
+  ASSERT_STR_NOT_CONTAINS(output, kFullUsageMarker);
+  ASSERT_STR_NOT_CONTAINS(error, kFullUsageMarker);
+
+  // Fuzzy match: a transposition ("tabels" instead of "tables") is not a prefix but is close.
+  ASSERT_NOK(Subprocess::Call(
+      ToStringVector(exe_path, "--master_addresses", kUnusedMasterAddress, "list_tabels"), nullptr,
+      &error));
+  ASSERT_STR_CONTAINS(error, "Did you mean one of these?");
+  ASSERT_STR_CONTAINS(error, "list_tables");
+
+  // Fuzzy match: a missing leading character ("ist_tables") is one edit away from "list_tables".
+  ASSERT_NOK(Subprocess::Call(
+      ToStringVector(exe_path, "--master_addresses", kUnusedMasterAddress, "ist_tables"), nullptr,
+      &error));
+  ASSERT_STR_CONTAINS(error, "list_tables");
+
+  // An empty operation is a prefix of every command, but should not list all of them.
+  ASSERT_NOK(Subprocess::Call(
+      ToStringVector(exe_path, "--master_addresses", kUnusedMasterAddress, ""), nullptr, &error));
+  ASSERT_STR_NOT_CONTAINS(error, "Did you mean one of these?");
+
+  // A far-off garbage string is beyond the edit-distance tolerance, so nothing is suggested.
+  ASSERT_NOK(Subprocess::Call(
+      ToStringVector(exe_path, "--master_addresses", kUnusedMasterAddress, "zzzzzzzzzzzzzzzzzz"),
+      nullptr, &error));
+  ASSERT_STR_NOT_CONTAINS(error, "Did you mean one of these?");
+
+  // Running with no operation at all should still print the full usage as help on stdout.
+  ASSERT_NOK(Subprocess::Call(
+      ToStringVector(exe_path, "--master_addresses", kUnusedMasterAddress), &output, &error));
+  ASSERT_STR_CONTAINS(output, kFullUsageMarker);
+}
+
 // Test yb-admin config change while running a workload.
 // 1. Instantiate external mini cluster with 3 TS.
 // 2. Create table with 2 replicas.

--- a/src/yb/tools/yb-admin_cli.cc
+++ b/src/yb/tools/yb-admin_cli.cc
@@ -32,6 +32,8 @@
 
 #include "yb/tools/yb-admin_cli.h"
 
+#include <algorithm>
+#include <limits>
 #include <memory>
 #include <unordered_set>
 #include <utility>
@@ -396,6 +398,30 @@ Status PrintJsonResult(Result<rapidjson::Document>&& action_result) {
   return Status::OK();
 }
 
+// Levenshtein edit distance between two strings, used to suggest the closest command names when
+// the operation the user typed is not a prefix of any registered command. Uses two rolling rows
+// instead of the full matrix since only the previous row is needed.
+size_t EditDistance(const string& lhs, const string& rhs) {
+  vector<size_t> prev(rhs.size() + 1);
+  vector<size_t> curr(rhs.size() + 1);
+  for (size_t j = 0; j <= rhs.size(); ++j) {
+    prev[j] = j;
+  }
+  for (size_t i = 1; i <= lhs.size(); ++i) {
+    curr[0] = i;
+    for (size_t j = 1; j <= rhs.size(); ++j) {
+      const size_t substitution_cost = (lhs[i - 1] == rhs[j - 1]) ? 0 : 1;
+      curr[j] = std::min({
+          prev[j] + 1,                     // deletion
+          curr[j - 1] + 1,                 // insertion
+          prev[j - 1] + substitution_cost  // substitution
+      });
+    }
+    prev.swap(curr);
+  }
+  return prev[rhs.size()];
+}
+
 }  // namespace
 
 std::string ClusterAdminCli::GetArgumentExpressions(const std::string& usage_arguments) {
@@ -412,6 +438,60 @@ std::string ClusterAdminCli::GetArgumentExpressions(const std::string& usage_arg
     }
   }
   return expressions.empty() ? "" : "Definitions: " + expressions;
+}
+
+std::vector<std::string> ClusterAdminCli::GetSuggestedCommands(const std::string& op) const {
+  if (op.empty()) {
+    return {};
+  }
+
+  // Prefer commands that the typed operation is a prefix of, e.g. "list_snapshot_schedule" points
+  // the user at "list_snapshot_schedules". command_indexes_ is sorted, so the prefix matches form
+  // a contiguous range starting at lower_bound(op).
+  std::vector<std::string> candidates;
+  for (auto it = command_indexes_.lower_bound(op); it != command_indexes_.end(); ++it) {
+    if (!boost::starts_with(it->first, op)) {
+      break;
+    }
+    if (!commands_[it->second].hidden_) {
+      candidates.push_back(it->first);
+    }
+  }
+  if (!candidates.empty()) {
+    return candidates;
+  }
+
+  // Otherwise fall back to fuzzy matching so that a typo anywhere in the name - a transposition or
+  // a wrong or missing leading character - still resolves to the closest command(s), e.g.
+  // "list_tabels" -> "list_tables". Scale the tolerance with the length of the operation so that
+  // short names don't match everything, and keep only the commands tied for the smallest distance
+  // so the suggestion list stays short.
+  const size_t max_distance = std::max<size_t>(2, op.size() / 3);
+  size_t best_distance = std::numeric_limits<size_t>::max();
+  for (const auto& [name, index] : command_indexes_) {
+    if (commands_[index].hidden_) {
+      continue;
+    }
+    // The edit distance is at least the difference in lengths, so skip the full computation for
+    // commands that cannot possibly be within the tolerance.
+    const size_t len_diff =
+        op.size() > name.size() ? op.size() - name.size() : name.size() - op.size();
+    if (len_diff > max_distance) {
+      continue;
+    }
+    const size_t distance = EditDistance(op, name);
+    if (distance > max_distance) {
+      continue;
+    }
+    if (distance < best_distance) {
+      best_distance = distance;
+      candidates.clear();
+    }
+    if (distance == best_distance) {
+      candidates.push_back(name);
+    }
+  }
+  return candidates;
 }
 
 Status ClusterAdminCli::RunCommand(
@@ -471,7 +551,19 @@ Status ClusterAdminCli::Run(int argc, char** argv) {
 
   if (cmd == command_indexes_.end()) {
     cerr << "Invalid operation: " << op << endl;
-    return ClusterAdminCli::kInvalidArguments;
+
+    const auto suggestions = GetSuggestedCommands(op);
+    if (!suggestions.empty()) {
+      cerr << "Did you mean one of these?" << endl;
+      for (const auto& suggestion : suggestions) {
+        cerr << "  " << suggestion << endl;
+      }
+    }
+    cerr << "Run '" << prog_name << "' with no operation to see all available operations." << endl;
+
+    // The targeted error and suggestions above are more helpful than the full command list, so
+    // return a non-InvalidArgument status to keep main() from additionally dumping the usage.
+    return STATUS_FORMAT(RuntimeError, "Invalid operation: $0", op);
   }
 
   // Init client.

--- a/src/yb/tools/yb-admin_cli.h
+++ b/src/yb/tools/yb-admin_cli.h
@@ -82,6 +82,10 @@ class ClusterAdminCli {
   Status RunCommand(
       const Command& command, const CLIArguments& command_args, const std::string& program_name);
   std::string GetArgumentExpressions(const std::string& usage_arguments);
+  // Returns the command names to suggest for an operation that did not match any registered
+  // command, or an empty vector when there is no good suggestion. Commands that the operation is a
+  // prefix of are preferred; otherwise the closest commands by edit distance are returned.
+  std::vector<std::string> GetSuggestedCommands(const std::string& op) const;
   std::vector<Command> commands_;
   std::map<std::string, size_t> command_indexes_;
   std::unique_ptr<ClusterAdminClient> client_;


### PR DESCRIPTION
## Summary

`yb-admin` looks up the operation name given on the command line with an
exact match against the
list of registered commands. If the operation is slightly misspelled
(e.g.
`list_snapshot_schedule` instead of `list_snapshot_schedules`), the user
was shown the
`Invalid operation` error followed by the entire list of ~130 supported
commands, with no hint
about what they may have meant.

This PR makes that error helpful in two ways:

**1. Suggest the closest commands.**
- Prefix match first: registered (non-hidden) commands that have the
typed operation as a prefix
  are suggested.
- Edit-distance fallback: if nothing is a prefix, fall back to
Levenshtein (fuzzy) matching so a
typo anywhere in the name - a transposition, or a wrong or missing
leading character - still
resolves to the closest command(s). The tolerance scales with the length
of the operation, and
  only the closest-scoring tier is shown to keep the list short.

```
$ yb-admin --master_addresses ... list_snapshot_schedule    # prefix
Invalid operation: list_snapshot_schedule
Did you mean one of these?
  list_snapshot_schedules

$ yb-admin --master_addresses ... ist_tables                # missing leading char (fuzzy)
Invalid operation: ist_tables
Did you mean one of these?
  list_tables

$ yb-admin --master_addresses ... list_tabels               # transposition (fuzzy)
Invalid operation: list_tabels
Did you mean one of these?
  list_tables
  list_tablets
```

**2. Stop dumping the full command list on an invalid operation.** That
wall of ~130 commands was
the original complaint in the issue. The invalid-operation path now
shows only the targeted
suggestions plus a one-line hint, and returns a non-`InvalidArgument`
status so `main()` no longer
appends the full usage. Running `yb-admin` with no operation at all
still prints the full usage as
help.

The command is never run automatically based on a match, even an
unambiguous prefix, to avoid
surprising behavior for scripts that pass an already-invalid command
(per maintainer guidance on
the issue).

Fixes #9624. Subsumes #32516 (fuzzy / nearest-neighbor matching), which
is closed as folded in
here.

Original commit: d8f71119fa9a4cc761ae43705082db7907132d71 / #32513

## Test plan

- [x] `AdminCliTest.InvalidOperationSuggestsClosestCommands` - one test
covering the whole
  "did you mean" help path:
- prefix matches: an unambiguous single-command prefix, and an ambiguous
prefix that lists
    every candidate;
- fuzzy / edit-distance matches: a transposition (`list_tabels`) and a
missing leading
    character (`ist_tables`);
- that an empty operation and a far-off garbage string suggest nothing;
and
- that an invalid operation no longer prints the full command list on
either stream, while
    running with no operation at all still does.
- [x] Built `yb-admin` and `yb-admin-test` (release) locally; the test
passes, and manually
verified the examples above. The test needs no running cluster since the
check happens before
  `yb-admin` connects to the master.

---------