### PR TITLE
[#31530] YSQL: Stop object-lock RPCs from leaking read-time state into fast-path DML

### DIFF
--- a/src/yb/yql/pggate/pg_txn_manager.cc
+++ b/src/yb/yql/pggate/pg_txn_manager.cc
@@ -884,7 +884,8 @@ Status PgTxnManager::SetupReadTimeOptions(
 Status PgTxnManager::SetupPerformOptions(
     SetupPerformOptionsAccessorTag, tserver::PgPerformOptionsPB& options,
     NonTransactionalWrites ops_has_non_transactional_writes,
-    std::optional<ReadTimeAction> read_time_action) {
+    std::optional<ReadTimeAction> read_time_action,
+    IsLocalObjectLockOp is_local_object_lock_op) {
   if (!IsDdlModeWithSeparateTransaction() && !txn_in_progress_) {
     IncTxnSerialNo();
   }
@@ -906,8 +907,15 @@ Status PgTxnManager::SetupPerformOptions(
     options.set_priority(*priority_);
   }
 
-  RETURN_NOT_OK(SetupReadTimeOptions(
-      *options.mutable_read_time_options(), read_time_action, ops_has_non_transactional_writes));
+  // Object-lock RPCs must not carry read-time manipulations; keep only the serial numbers.
+  if (is_local_object_lock_op) {
+    auto& read_time_options = *options.mutable_read_time_options();
+    read_time_options.set_read_time_serial_no(serial_no_.read_time());
+    read_time_options.set_read_time_serial_no_history_min(serial_no_.min_read_time());
+  } else {
+    RETURN_NOT_OK(SetupReadTimeOptions(
+        *options.mutable_read_time_options(), read_time_action, ops_has_non_transactional_writes));
+  }
 
   options.set_force_global_transaction(yb_force_global_transaction);
   options.set_force_tablespace_locality(yb_force_tablespace_locality);
@@ -1132,12 +1140,16 @@ Status PgTxnManager::AcquireObjectLock(
     const YbcObjectLockId& lock_id, YbcObjectLockMode mode,
     bool is_session_lock,
     std::optional<PgTablespaceOid> tablespace_oid) {
+  const auto is_local_object_lock_op =
+      IsLocalObjectLockOp(mode <= YbcObjectLockMode::YB_OBJECT_ROW_EXCLUSIVE_LOCK);
   RETURN_NOT_OK(CalculateIsolation(
       false /* read_only, doesn't matter */,
       GetTxnPriorityRequirement(RowMarkType::ROW_MARK_ABSENT),
-      IsLocalObjectLockOp(mode <= YbcObjectLockMode::YB_OBJECT_ROW_EXCLUSIVE_LOCK)));
+      is_local_object_lock_op));
   tserver::PgPerformOptionsPB options;
-  RETURN_NOT_OK(SetupPerformOptions(tag, options, NonTransactionalWrites::kFalse));
+  RETURN_NOT_OK(SetupPerformOptions(
+      tag, options, NonTransactionalWrites::kFalse, {} /* read_time_action */,
+      is_local_object_lock_op));
   RETURN_NOT_OK(client_->AcquireObjectLock(
       &options, lock_id, mode, is_session_lock, tablespace_oid));
   DEBUG_ONLY(DEBUG_UpdateLastObjectLockingInfo());

--- a/src/yb/yql/pggate/pg_txn_manager.h
+++ b/src/yb/yql/pggate/pg_txn_manager.h
@@ -126,7 +126,8 @@ class PgTxnManager : public RefCountedThreadSafe<PgTxnManager> {
 
   Status SetupPerformOptions(SetupPerformOptionsAccessorTag tag,
       tserver::PgPerformOptionsPB& options, NonTransactionalWrites ops_has_non_transactional_writes,
-      std::optional<ReadTimeAction> read_time_action = {});
+      std::optional<ReadTimeAction> read_time_action = {},
+      IsLocalObjectLockOp is_local_object_lock_op = IsLocalObjectLockOp::kFalse);
 
   double GetTransactionPriority() const;
   YbcTxnPriorityRequirement GetTransactionPriorityType() const;


### PR DESCRIPTION
## Summary

For fastpath-eligible object locks (mode <= ROW EXCLUSIVE), pggate takes a shared-memory IPC fast path when it is healthy and falls back to an RPC to the local tserver's `PgClientService` otherwise. When the RPC path is taken (e.g. shared-memory IPC is unavailable, as it currently is on macOS), `PgTxnManager::AcquireObjectLock` reused `SetupPerformOptions`, which called `SetupReadTimeOptions` and set read-time manipulations (`defer_read_point` / `clamp_uncertainty_window` / `ENSURE_READ_TIME_IS_SET`) derived from `yb_read_after_commit_visibility` onto the **lock RPC's** options.

The tserver, processing the lock RPC, then pre-picked a deferred/clamped read time during lock acquisition and stored it in the session read point. The fast-path DML that immediately followed inherited that stale snapshot instead of asking the storage layer to pick its own — silently violating the read-after-commit visibility the session requested. The visible symptom is `picked_read_time_on_docdb` (incremented when the storage layer picks the read time) staying at 0, which fails these tests on macOS:

- `PgReadTimeTest.CheckDeferredReadAfterCommitVisibility`
- `PgReadTimeTest.CheckRelaxedReadAfterCommitVisibility`

Linux passes only because shared-memory acquisition succeeds — the RPC path, and therefore `SetupPerformOptions`, is never invoked during lock acquisition. The bug is latent there and would surface the moment the shared-memory channel is unavailable.

**Fix:** thread `IsLocalObjectLockOp` (`mode <= ROW EXCLUSIVE`) into `SetupPerformOptions` and skip `SetupReadTimeOptions` for local object-lock RPCs, setting only the read-time serial numbers so the lock RPC still lines up with the subsequent statement. Higher-mode locks keep `is_local_object_lock_op = false`, so the heavyweight DDL/DML that follows them still runs `SetupReadTimeOptions` exactly as before.

This supersedes #31531 (re-derived as a minimal change against current master, where `SetupReadTimeOptions` is already extracted and `CalculateIsolation` already takes `IsLocalObjectLockOp`).

## Test plan

- [x] `./yb_build.sh release --cxx-test pg_read_time-test` — full `pg_read_time-test` suite green on macOS (43 passed, 0 failed)
- [x] `PgReadTimeTest.CheckDeferredReadAfterCommitVisibility` passes on macOS (was failing)
- [x] `PgReadTimeTest.CheckRelaxedReadAfterCommitVisibility` passes on macOS (was failing)
- [x] No change on the Linux shared-memory fast path — `SetupReadTimeOptions` is still invoked for all non-local-object-lock ops and for higher-mode locks
