### PR TITLE
Guard ExecutorCheckPerms hook when audit stack is absent

### DIFF
--- a/src/postgres/third-party-extensions/pgaudit/pgaudit.c
+++ b/src/postgres/third-party-extensions/pgaudit/pgaudit.c
@@ -1367,6 +1367,15 @@ pgaudit_ExecutorCheckPerms_hook(List *rangeTabls, bool abort)
 {
   Oid auditOid = InvalidOid;
 
+    if (auditEventStack == NULL)
+    {
+        if (next_ExecutorCheckPerms_hook &&
+            !(*next_ExecutorCheckPerms_hook) (rangeTabls, abort))
+            return false;
+
+        return true;
+    }
+
     /* Get the audit oid if the role exists */
   if (auditRole != NULL && auditRole[0] != '\0') {
     auditOid = get_role_oid(auditRole, true);
@@ -1377,7 +1386,7 @@ pgaudit_ExecutorCheckPerms_hook(List *rangeTabls, bool abort)
         !IsAbortedTransactionBlockState())
     {
         /* If auditLogRows is on, wait for rows processed to be set */
-        if (auditLogRows && auditEventStack != NULL)
+        if (auditLogRows)
         {
             /* Check if the top item is SELECT/INSERT for CREATE TABLE AS */
             if (auditEventStack->auditEvent.commandTag == T_SelectStmt &&


### PR DESCRIPTION
Fixes #32512 

This change adds a defensive NULL check for auditEventStack in pgaudit_ExecutorCheckPerms_hook(). ExecCheckRTPerms() can be invoked outside ExecutorStart(), before the audit event stack has been established. In that case, skip audit logging and continue the hook chain instead of dereferencing a NULL auditEventStack, preventing backend crashes while preserving the existing behavior during normal executor execution.