### PR TITLE
[#32681] DocDB: Skip DEAD tservers in list_tablet_server_log_locations

### DIFF
--- a/src/yb/tools/yb-admin_client.cc
+++ b/src/yb/tools/yb-admin_client.cc
@@ -1481,16 +1481,40 @@ Status ClusterAdminClient::ListTabletServersLogLocations() {
 
   for (const ListTabletServersResponsePB::Entry& server : servers) {
     auto ts_uuid = server.instance_id().permanent_uuid();
+    const auto rpc_addr_str = FormatFirstHostPort(
+        server.registration().common().private_rpc_addresses());
 
-    HostPort ts_addr = VERIFY_RESULT(GetFirstRpcAddressForTS(ts_uuid));
+    // Skip RPCs to dead tservers; connecting would time out and abort the whole command.
+    if (server.has_alive() && !server.alive()) {
+      cout << ts_uuid << kColumnSep
+           << rpc_addr_str << kColumnSep
+           << "N/A (DEAD)" << endl;
+      continue;
+    }
 
+    if (!server.has_registration() ||
+        server.registration().common().private_rpc_addresses().empty()) {
+      cout << ts_uuid << kColumnSep
+           << rpc_addr_str << kColumnSep
+           << "N/A (no RPC address)" << endl;
+      continue;
+    }
+
+    HostPort ts_addr = HostPortFromPB(server.registration().common().private_rpc_addresses(0));
     TabletServerServiceProxy ts_proxy(proxy_cache_.get(), ts_addr);
 
-    const auto resp = VERIFY_RESULT(InvokeRpc(
-        &TabletServerServiceProxy::GetLogLocation, ts_proxy, tserver::GetLogLocationRequestPB()));
+    // Soft-fail per-server errors so one unreachable tserver does not hide the rest.
+    const auto resp = InvokeRpc(
+        &TabletServerServiceProxy::GetLogLocation, ts_proxy, tserver::GetLogLocationRequestPB());
+    if (!resp.ok()) {
+      cout << ts_uuid << kColumnSep
+           << ts_addr << kColumnSep
+           << "ERROR: " << resp.status() << endl;
+      continue;
+    }
     cout << ts_uuid << kColumnSep
          << ts_addr << kColumnSep
-         << resp.log_location() << endl;
+         << resp->log_location() << endl;
   }
 
   return Status::OK();


### PR DESCRIPTION
## Summary

`yb-admin list_tablet_server_log_locations` previously issued a `GetLogLocation` RPC to every tablet server in the master's registry, including DEAD ones. A connect timeout to the first unreachable DEAD node aborted the command via `VERIFY_RESULT`, even after live servers had already been printed.

This change:
- Skips RPCs to DEAD tservers and prints `N/A (DEAD)` instead
- Soft-fails per-server RPC errors so one unreachable node does not hide results for the rest
- Uses the RPC address from the existing list entry (avoids a redundant `ListTabletServers` call per node)

## Test plan

- [ ] On a cluster with at least one DEAD tserver visible in `list_all_tablet_servers`, run `yb-admin list_tablet_server_log_locations`
- [ ] Confirm the command exits successfully and prints log locations for ALIVE tservers
- [ ] Confirm DEAD tservers appear as `N/A (DEAD)` rather than causing a connect timeout
- [ ] On a healthy all-ALIVE cluster, confirm log locations still print as before
