### PR TITLE
[#3235] DocDB: Test read replica count in tablet locations

### DIFF
--- a/src/yb/integration-tests/cluster_itest_util.cc
+++ b/src/yb/integration-tests/cluster_itest_util.cc
@@ -1299,7 +1299,7 @@ Status GetTabletLocations(ExternalMiniCluster* cluster,
   *req.add_tablet_ids() = tablet_id;
   rpc::RpcController rpc;
   rpc.set_timeout(timeout);
-  RETURN_NOT_OK(cluster->GetMasterProxy<master::MasterClientProxy>().GetTabletLocations(
+  RETURN_NOT_OK(cluster->GetLeaderMasterProxy<master::MasterClientProxy>().GetTabletLocations(
       req, &resp, &rpc));
   if (resp.has_error()) {
     return StatusFromPB(resp.error().status());

--- a/src/yb/integration-tests/master_failover-itest.cc
+++ b/src/yb/integration-tests/master_failover-itest.cc
@@ -54,6 +54,7 @@
 
 #include "yb/gutil/strings/substitute.h"
 
+#include "yb/integration-tests/cluster_itest_util.h"
 #include "yb/integration-tests/external_mini_cluster.h"
 #include "yb/integration-tests/mini_cluster.h"
 #include "yb/integration-tests/yb_mini_cluster_test_base.h"
@@ -650,8 +651,10 @@ class MasterFailoverTestWithPlacement : public MasterFailoverTest {
 };
 
 TEST_F_EX(MasterFailoverTest, TestFailoverWithReadReplicas, MasterFailoverTestWithPlacement) {
+  constexpr int kNumReadReplicas = 1;
+  constexpr int kNumReplicas = kNumTabletServerReplicas + kNumReadReplicas;
   ASSERT_OK(yb_admin_client_->AddReadReplicaPlacementInfo(
-      "c.r.z0:1", 1, kReadReplicaPlacementUuid));
+      "c.r.z0:1", kNumReadReplicas, kReadReplicaPlacementUuid));
 
   // Add a new read replica tserver to the cluster with a matching cloud info to a live placement,
   // to test that we distinguish not just by cloud info but also by peer role.
@@ -664,6 +667,37 @@ TEST_F_EX(MasterFailoverTest, TestFailoverWithReadReplicas, MasterFailoverTestWi
 
   YBTableName table_name(YQL_DATABASE_CQL, "test", "testFailoverWithReadReplicas");
   ASSERT_OK(CreateTable(table_name, kWaitForCreate));
+
+  master::GetTableLocationsResponsePB table_locations;
+  ASSERT_OK(WaitFor([&]() -> Result<bool> {
+    table_locations.Clear();
+    RETURN_NOT_OK(itest::GetTableLocations(
+        cluster_.get(), table_name, MonoDelta::FromSeconds(10), RequireTabletsRunning::kTrue,
+        &table_locations));
+    if (table_locations.tablet_locations().empty()) {
+      return false;
+    }
+    for (const auto& tablet : table_locations.tablet_locations()) {
+      if (tablet.replicas_size() != kNumReplicas) {
+        return false;
+      }
+    }
+    return true;
+  }, MonoDelta::FromSeconds(30), "Wait for read replicas"));
+
+  {
+    auto unexpected_replica_count_log = cluster_->GetMasterLogWaiter(
+        Format("Expected replicas $0 but found $1", kNumTabletServerReplicas, kNumReplicas));
+    for (const auto& tablet : table_locations.tablet_locations()) {
+      master::TabletLocationsPB tablet_locations;
+      ASSERT_OK(itest::GetTabletLocations(
+          cluster_.get(), tablet.tablet_id(), MonoDelta::FromSeconds(10), &tablet_locations));
+      ASSERT_EQ(tablet_locations.expected_live_replicas(), kNumTabletServerReplicas);
+      ASSERT_EQ(tablet_locations.expected_read_replicas(), kNumReadReplicas);
+      ASSERT_EQ(tablet_locations.replicas_size(), kNumReplicas);
+    }
+    ASSERT_FALSE(unexpected_replica_count_log.IsEventOccurred());
+  }
 
   // Shutdown the live ts in c.r.z0
   auto live_ts_uuid = cluster_->tablet_server(0)->instance_id().permanent_uuid();

--- a/src/yb/integration-tests/master_failover-itest.cc
+++ b/src/yb/integration-tests/master_failover-itest.cc
@@ -671,9 +671,12 @@ TEST_F_EX(MasterFailoverTest, TestFailoverWithReadReplicas, MasterFailoverTestWi
   master::GetTableLocationsResponsePB table_locations;
   ASSERT_OK(WaitFor([&]() -> Result<bool> {
     table_locations.Clear();
-    RETURN_NOT_OK(itest::GetTableLocations(
+    auto status = itest::GetTableLocations(
         cluster_.get(), table_name, MonoDelta::FromSeconds(10), RequireTabletsRunning::kTrue,
-        &table_locations));
+        &table_locations);
+    if (!status.ok()) {
+      return false;
+    }
     if (table_locations.tablet_locations().empty()) {
       return false;
     }

--- a/src/yb/integration-tests/master_failover-itest.cc
+++ b/src/yb/integration-tests/master_failover-itest.cc
@@ -689,12 +689,12 @@ TEST_F_EX(MasterFailoverTest, TestFailoverWithReadReplicas, MasterFailoverTestWi
     auto unexpected_replica_count_log = cluster_->GetMasterLogWaiter(
         Format("Expected replicas $0 but found $1", kNumTabletServerReplicas, kNumReplicas));
     for (const auto& tablet : table_locations.tablet_locations()) {
-      master::TabletLocationsPB tablet_locations;
+      master::TabletLocationsPB tablet_details;
       ASSERT_OK(itest::GetTabletLocations(
-          cluster_.get(), tablet.tablet_id(), MonoDelta::FromSeconds(10), &tablet_locations));
-      ASSERT_EQ(tablet_locations.expected_live_replicas(), kNumTabletServerReplicas);
-      ASSERT_EQ(tablet_locations.expected_read_replicas(), kNumReadReplicas);
-      ASSERT_EQ(tablet_locations.replicas_size(), kNumReplicas);
+          cluster_.get(), tablet.tablet_id(), MonoDelta::FromSeconds(10), &tablet_details));
+      ASSERT_EQ(tablet_details.expected_live_replicas(), kNumTabletServerReplicas);
+      ASSERT_EQ(tablet_details.expected_read_replicas(), kNumReadReplicas);
+      ASSERT_EQ(tablet_details.replicas_size(), kNumReplicas);
     }
     ASSERT_FALSE(unexpected_replica_count_log.IsEventOccurred());
   }


### PR DESCRIPTION
## Summary

- Add regression coverage for the read-replica tablet count returned by `GetTabletLocations`.
- Verify mixed live/read placements do not emit the spurious replica-count warning.
- Allow the shared tablet-location helper to target the leader in multi-master tests.

Closes #3235

## Test plan

- [x] `./yb_build.sh debug --cxx-test master_failover-itest --gtest_filter MasterFailoverTest.TestFailoverWithReadReplicas -n 3`
- [x] Mutation check: a live-only expected count reproduces `Expected replicas 3 but found 4` and fails the new assertion.
- [x] `build-support/lint.sh --rev upstream/master`