### PR TITLE
[#32722] Build: Include ysql_dump in standalone client package

### DIFF
--- a/yb_release_manifest.json
+++ b/yb_release_manifest.json
@@ -102,10 +102,12 @@
   },
   "yugabyte-client": {
     "%symlinks%": {
+      "bin/ysql_dump": "../postgres/bin/ysql_dump",
       "bin/ysqlsh": "../postgres/bin/ysqlsh"
     },
     ".": ["$BUILD_ROOT/version_metadata.json"],
     "bin": [
+      "$BUILD_ROOT/postgres/bin/ysql_dump",
       "$BUILD_ROOT/postgres/bin/ysqlsh",
       "build-support/post_install.sh",
       "scripts/installation/bin/fips_install.sh",

--- a/yb_release_manifest.json
+++ b/yb_release_manifest.json
@@ -103,11 +103,13 @@
   "yugabyte-client": {
     "%symlinks%": {
       "bin/ysql_dump": "../postgres/bin/ysql_dump",
+      "bin/ysql_dumpall": "../postgres/bin/ysql_dumpall",
       "bin/ysqlsh": "../postgres/bin/ysqlsh"
     },
     ".": ["$BUILD_ROOT/version_metadata.json"],
     "bin": [
       "$BUILD_ROOT/postgres/bin/ysql_dump",
+      "$BUILD_ROOT/postgres/bin/ysql_dumpall",
       "$BUILD_ROOT/postgres/bin/ysqlsh",
       "build-support/post_install.sh",
       "scripts/installation/bin/fips_install.sh",


### PR DESCRIPTION
## Summary

Include `ysql_dump` in the standalone YugabyteDB client distribution and expose it through `bin/ysql_dump`, following the existing `ysqlsh` layout.

This provides a version-matched dump utility without requiring users to download the full server distribution.

Closes https://github.com/yugabyte/yugabyte-db/issues/32722 and https://github.com/yugabyte/yugabyte-db/issues/1477

## Test plan

- [x] `python3 -m json.tool yb_release_manifest.json`
- [x] Verified the manifest packages `postgres/bin/ysql_dump` and that `bin/ysql_dump` resolves to it.
- [x] `./build-support/lint.sh --rev upstream/master`
