### PR TITLE
[#32697] DocDB: Skip copying parent retryable requests when split child has persisted state

### DIFF
--- a/src/yb/integration-tests/tablet-split-itest.cc
+++ b/src/yb/integration-tests/tablet-split-itest.cc
@@ -3057,6 +3057,91 @@ TEST_F(TabletSplitSingleServerITest, TestRetryableWriteWithPersistedStructure) {
   TestRetryableWrite();
 }
 
+TEST_F(TabletSplitSingleServerITest, RetryableWriteAfterSplitChildRestart) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_skip_deleting_split_tablets) = true;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_copy_retryable_requests_from_parent) = true;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_flush_retryable_requests) = true;
+
+  constexpr int kNumRows = 2;
+  CreateSingleTablet();
+  const auto split_hash_code = ASSERT_RESULT(WriteRowsAndGetMiddleHashCode(kNumRows));
+  const auto parent_peer = ASSERT_RESULT(GetSingleTabletLeaderPeer());
+  const auto parent_tablet_id = parent_peer->tablet_id();
+
+  ASSERT_OK(SplitSingleTablet(split_hash_code));
+  ASSERT_OK(WaitForTabletSplitCompletion(2, 1, 1));
+  const auto child_peers = ListTableActiveTabletLeadersPeers(cluster_.get(), table_->id());
+  ASSERT_EQ(child_peers.size(), 2);
+  ASSERT_OK(WriteRow(NewSession(), kNumRows + 1, 0));
+  std::vector<OpId> child_committed_op_ids;
+  for (const auto& child_peer : child_peers) {
+    child_committed_op_ids.push_back(
+        ASSERT_RESULT(child_peer->GetRaftConsensus())->GetLastCommittedOpId());
+  }
+
+#ifndef NDEBUG
+  SyncPoint::GetInstance()->LoadDependency({
+      {"AsyncRpc::Finished:SetTimedOut:1",
+       "TabletSplitSingleServerITest::RetryableWriteAfterSplitChildRestart:WriteTimedOut"},
+      {"TabletSplitSingleServerITest::RetryableWriteAfterSplitChildRestart:RetryWrite",
+       "AsyncRpc::Finished:SetTimedOut:2"},
+  });
+  SyncPoint::GetInstance()->EnableProcessing();
+#endif
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_asyncrpc_finished_set_timedout) = true;
+  std::thread write_thread([&] {
+    CHECK_OK(WriteRow(NewSession(), kNumRows + 1, kNumRows + 1));
+  });
+
+  ASSERT_OK(WaitFor(
+      [&]() -> Result<bool> {
+        for (size_t i = 0; i != child_peers.size(); ++i) {
+          if (VERIFY_RESULT(child_peers[i]->GetRaftConsensus())->GetLastCommittedOpId() >
+              child_committed_op_ids[i]) {
+            return true;
+          }
+        }
+        return false;
+      },
+      10s, "post-split update is applied"));
+  TEST_SYNC_POINT(
+      "TabletSplitSingleServerITest::RetryableWriteAfterSplitChildRestart:WriteTimedOut");
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_asyncrpc_finished_set_timedout) = false;
+
+  for (const auto& child_peer : child_peers) {
+    ASSERT_OK(child_peer->log()->AllocateSegmentAndRollOver());
+    ASSERT_OK(WaitFor([&] { return child_peer->TEST_HasBootstrapStateOnDisk(); },
+                      10s, "child retryable requests flushed to disk"));
+    ASSERT_OK(ASSERT_RESULT(child_peer->shared_tablet())->Flush(
+        tablet::FlushMode::kSync, rocksdb::FlushReason::kTestOnly));
+  }
+
+  auto* tablet_server = cluster_->mini_tablet_server(0);
+  ASSERT_OK(tablet_server->Restart());
+  ASSERT_OK(WaitFor(
+      [&]() -> Result<bool> {
+        auto peer = tablet_server->server()->tablet_manager()->GetTablet(parent_tablet_id);
+        return peer.ok() && (*peer)->state() == tablet::RaftGroupStatePB::RUNNING;
+      },
+      10s, "split parent is running"));
+  ASSERT_OK(WaitFor(
+      [&] { return ListTableActiveTabletLeadersPeers(cluster_.get(), table_->id()).size() == 2; },
+      10s, "split children are running after restart"));
+
+  ASSERT_OK(DeleteRow(NewSession(), kNumRows + 1));
+  TEST_SYNC_POINT(
+      "TabletSplitSingleServerITest::RetryableWriteAfterSplitChildRestart:RetryWrite");
+  write_thread.join();
+
+  ASSERT_OK(CheckRowsCount(kNumRows));
+
+#ifndef NDEBUG
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearTrace();
+#endif
+}
+
 TEST_F(TabletSplitExternalMiniClusterITest, Simple) {
   CreateSingleTablet();
   CHECK_OK(WriteRowsAndFlush());

--- a/src/yb/integration-tests/tablet-split-itest.cc
+++ b/src/yb/integration-tests/tablet-split-itest.cc
@@ -3135,6 +3135,7 @@ TEST_F(TabletSplitSingleServerITest, RetryableWriteAfterSplitChildRestart) {
   write_thread.join();
 
   ASSERT_OK(CheckRowsCount(kNumRows));
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_skip_deleting_split_tablets) = false;
 
 #ifndef NDEBUG
   SyncPoint::GetInstance()->DisableProcessing();

--- a/src/yb/tserver/ts_tablet_manager.cc
+++ b/src/yb/tserver/ts_tablet_manager.cc
@@ -2224,7 +2224,7 @@ void TSTabletManager::OpenTablet(const RaftGroupMetadataPtr& meta,
   retryable_requests.SetRequestTimeout(FLAGS_retryable_request_timeout_secs);
 
   if (FLAGS_enable_copy_retryable_requests_from_parent &&
-          cmeta->has_split_parent_tablet_id()) {
+      cmeta->has_split_parent_tablet_id() && !bootstrap_state_manager->has_file_on_disk()) {
     auto parent_tablet_requests = GetTabletRetryableRequests(cmeta->split_parent_tablet_id());
     if (parent_tablet_requests.ok()) {
       retryable_requests.CopyFrom(*parent_tablet_requests);


### PR DESCRIPTION
## Summary

When a split child tablet is opened on tserver restart, `TSTabletManager::OpenTablet` copies retryable requests from the split parent tablet when `enable_copy_retryable_requests_from_parent` is set. This copy happened whenever the tablet had a split parent, even when the child had already flushed its own retryable requests bootstrap state to disk.

Overwriting the child's persisted state with the parent's state regresses retryable-request tracking, so an already-applied retried write can be applied a second time after restart.

This change only copies retryable requests from the parent when the child has no bootstrap state file of its own (`!bootstrap_state_manager->has_file_on_disk()`). When the child has persisted state, that state is authoritative: it is loaded during bootstrap and WAL replay re-registers any newer requests.

## Test plan

- [x] New regression test `TabletSplitSingleServerITest.RetryableWriteAfterSplitChildRestart` passes with the fix (run in a debug build, where the test's sync points are active):

```
./yb_build.sh debug --cxx-test tablet-split-itest \
  --gtest_filter TabletSplitSingleServerITest.RetryableWriteAfterSplitChildRestart
```
