### PR TITLE
[#32468] DocDB: Fix typo in require_tablets_running variable name

### DIFF
--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -12873,7 +12873,7 @@ Status CatalogManager::GetTableLocations(
 
   std::vector<TabletInfoPtr> tablets = VERIFY_RESULT(table->GetTabletsInRange(req));
   PartitionsOnly partitions_only(req->partitions_only());
-  bool require_tablets_runnings = req->require_tablets_running();
+  bool require_tablets_running = req->require_tablets_running();
 
   int expected_live_replicas = 0;
   int expected_read_replicas = 0;
@@ -12889,7 +12889,7 @@ Status CatalogManager::GetTableLocations(
         tablet, locs_pb, IncludeHidden::kTrue, partitions_only);
     if (!status.ok()) {
       // Not running.
-      if (require_tablets_runnings) {
+      if (require_tablets_running) {
         resp->mutable_tablet_locations()->Clear();
         return SetupError(resp->mutable_error(), MasterErrorPB::OBJECT_NOT_FOUND, status);
       }


### PR DESCRIPTION
## Summary

Rename the `CatalogManager::GetTableLocations` local variable from `require_tablets_runnings` to `require_tablets_running` to match the request field. No behavior change.

Closes #32468

## Test plan

- [x] `build-support/lint.sh --rev upstream/master`
- [x] Verified the diff contains only the local identifier rename
