### PR TITLE
[#32412] YSQL: Increase terminated query text length

### DIFF
--- a/docs/content/stable/explore/observability/yb-pg-stat-get-queries.md
+++ b/docs/content/stable/explore/observability/yb-pg-stat-get-queries.md
@@ -51,7 +51,7 @@ The following table describes the fields and their values:
 | :---- | :--- | :---------- |
 | databasename | Name | Name of the database to which the backend was connected when the query was terminated. |
 | backend_pid | Integer | Backend process ID. |
-| query_text | Text | The query that was executed, up to a maximum of 256 characters. |
+| query_text | Text | The query that was executed, up to a maximum of 1,023 bytes. The captured text can be shorter if `track_activity_query_size` is lower. |
 | termination_reason | Text | An explanation of why the query was terminated. One of:<br/>Terminated by SIGKILL<br/>Terminated by SIGSEGV<br/>temporary file size exceeds temp_file_limit (xxx kB)
 | query_start_time | Timestampz | Time at which the query started. |
 | query_end_time | Timestampz | Time at which the query was terminated. |

--- a/src/postgres/src/backend/utils/activity/yb_terminated_queries.c
+++ b/src/postgres/src/backend/utils/activity/yb_terminated_queries.c
@@ -46,10 +46,10 @@
 /* Caps the number of queries which can be stored in the array. */
 #define YB_TERMINATED_QUERIES_SIZE 1000
 
-#define YB_QUERY_TEXT_SIZE 256
+#define YB_QUERY_TEXT_SIZE 1024
 #define YB_QUERY_TERMINATION_SIZE 256
 
-#define YB_TERMINATED_QUERIES_FILE_FORMAT_ID	0x20250401
+#define YB_TERMINATED_QUERIES_FILE_FORMAT_ID	0x20260717
 #define YB_TERMINATED_QUERIES_FILENAME		"pg_stat/yb_terminated_queries.stat"
 #define YB_TERMINATED_QUERIES_TMPFILE		"pg_stat/yb_terminated_queries.tmp"
 
@@ -154,10 +154,10 @@ yb_report_query_termination(char *message, int pid)
 			SUB_SET(userid, beentry->st_userid);
 #undef SUB_SET
 
-#define SUB_MOVE(shfld, befld) strncpy(curr_entry->shfld, befld, sizeof(curr_entry->shfld)-1)
-			SUB_MOVE(query_string, beentry->st_activity_raw);
-			SUB_MOVE(termination_reason, message);
-#undef SUB_MOVE
+			strlcpy(curr_entry->query_string, beentry->st_activity_raw,
+					sizeof(curr_entry->query_string));
+			strlcpy(curr_entry->termination_reason, message,
+					sizeof(curr_entry->termination_reason));
 
 			yb_terminated_queries->curr++;
 			LWLockRelease(yb_terminated_queries_lock);

--- a/src/postgres/src/backend/utils/activity/yb_terminated_queries.c
+++ b/src/postgres/src/backend/utils/activity/yb_terminated_queries.c
@@ -154,9 +154,10 @@ yb_report_query_termination(char *message, int pid)
 			SUB_SET(userid, beentry->st_userid);
 #undef SUB_SET
 
-			strlcpy(curr_entry->query_string, beentry->st_activity_raw,
+			strlcpy(curr_entry->query_string,
+					beentry->st_activity_raw ? beentry->st_activity_raw : "",
 					sizeof(curr_entry->query_string));
-			strlcpy(curr_entry->termination_reason, message,
+			strlcpy(curr_entry->termination_reason, message ? message : "",
 					sizeof(curr_entry->termination_reason));
 
 			yb_terminated_queries->curr++;

--- a/src/postgres/src/test/regress/expected/yb.orig.stat.out
+++ b/src/postgres/src/test/regress/expected/yb.orig.stat.out
@@ -72,67 +72,15 @@ SELECT databasename, termination_reason, query_text FROM yb_terminated_queries;
  db2          | temporary file size exceeds temp_file_limit (0kB) | SELECT * FROM generate_series(0, 1000001);
 (3 rows)
 
-SELECT 'We were taught in this modern age that science and mathematics is the pinnacle of human achievement.'
-'Yet, in our complacency, we began to neglect the very thing which our ancestors had once done: to challenge the process.'
-'We need to stand back and critically analyze what we do and doing so would allow us to become better and so much more.'
-FROM generate_series(0, 1000000);
-ERROR:  temporary file size exceeds temp_file_limit (0kB)
-SELECT pg_sleep(1);
- pg_sleep 
-----------
- 
-(1 row)
-
+-- Test permissions for different roles
+\c yugabyte
 SELECT databasename, termination_reason, query_text FROM yb_terminated_queries;
- databasename |                termination_reason                 |                                                         query_text                                                         
---------------+---------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------
- yugabyte     | temporary file size exceeds temp_file_limit (0kB) | SELECT * FROM generate_series(0, 1000000);
- yugabyte     | temporary file size exceeds temp_file_limit (0kB) | SELECT 'bob' FROM generate_series(0, 1000000);
- db2          | temporary file size exceeds temp_file_limit (0kB) | SELECT * FROM generate_series(0, 1000001);
- db2          | temporary file size exceeds temp_file_limit (0kB) | SELECT 'We were taught in this modern age that science and mathematics is the pinnacle of human achievement.'             +
-              |                                                   | 'Yet, in our complacency, we began to neglect the very thing which our ancestors had once done: to challenge the process.'+
-              |                                                   | 'We need to stand back
-(4 rows)
-
-SELECT databasename, termination_reason, query_text FROM yb_terminated_queries WHERE databasename = 'yugabyte';
  databasename |                termination_reason                 |                   query_text                   
 --------------+---------------------------------------------------+------------------------------------------------
  yugabyte     | temporary file size exceeds temp_file_limit (0kB) | SELECT * FROM generate_series(0, 1000000);
  yugabyte     | temporary file size exceeds temp_file_limit (0kB) | SELECT 'bob' FROM generate_series(0, 1000000);
-(2 rows)
-
-SELECT databasename, termination_reason, query_text FROM yb_terminated_queries WHERE databasename = 'db2';
- databasename |                termination_reason                 |                                                         query_text                                                         
---------------+---------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------
  db2          | temporary file size exceeds temp_file_limit (0kB) | SELECT * FROM generate_series(0, 1000001);
- db2          | temporary file size exceeds temp_file_limit (0kB) | SELECT 'We were taught in this modern age that science and mathematics is the pinnacle of human achievement.'             +
-              |                                                   | 'Yet, in our complacency, we began to neglect the very thing which our ancestors had once done: to challenge the process.'+
-              |                                                   | 'We need to stand back
-(2 rows)
-
-SELECT query_text, length(query_text) AS query_length FROM yb_terminated_queries;
-                                                         query_text                                                         | query_length 
-----------------------------------------------------------------------------------------------------------------------------+--------------
- SELECT * FROM generate_series(0, 1000000);                                                                                 |           42
- SELECT 'bob' FROM generate_series(0, 1000000);                                                                             |           46
- SELECT * FROM generate_series(0, 1000001);                                                                                 |           42
- SELECT 'We were taught in this modern age that science and mathematics is the pinnacle of human achievement.'             +|          255
- 'Yet, in our complacency, we began to neglect the very thing which our ancestors had once done: to challenge the process.'+| 
- 'We need to stand back                                                                                                     | 
-(4 rows)
-
--- Test permissions for different roles
-\c yugabyte
-SELECT databasename, termination_reason, query_text FROM yb_terminated_queries;
- databasename |                termination_reason                 |                                                         query_text                                                         
---------------+---------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------
- yugabyte     | temporary file size exceeds temp_file_limit (0kB) | SELECT * FROM generate_series(0, 1000000);
- yugabyte     | temporary file size exceeds temp_file_limit (0kB) | SELECT 'bob' FROM generate_series(0, 1000000);
- db2          | temporary file size exceeds temp_file_limit (0kB) | SELECT * FROM generate_series(0, 1000001);
- db2          | temporary file size exceeds temp_file_limit (0kB) | SELECT 'We were taught in this modern age that science and mathematics is the pinnacle of human achievement.'             +
-              |                                                   | 'Yet, in our complacency, we began to neglect the very thing which our ancestors had once done: to challenge the process.'+
-              |                                                   | 'We need to stand back
-(4 rows)
+(3 rows)
 
 CREATE ROLE test_user WITH login;
 \c yugabyte test_user
@@ -162,16 +110,13 @@ SELECT
     S.query_text AS query_text
 FROM yb_pg_stat_get_queries(null) AS S
 LEFT JOIN pg_database AS D ON (S.db_oid = D.oid) ORDER BY S.db_oid;
- databasename |                                                         query_text                                                         
---------------+----------------------------------------------------------------------------------------------------------------------------
+ databasename |                  query_text                  
+--------------+----------------------------------------------
  yugabyte     | SELECT * FROM generate_series(0, 1000000);
  yugabyte     | SELECT 'bob' FROM generate_series(0, 1000000);
  yugabyte     | SELECT * FROM generate_series(0, 100000002);
  db2          | SELECT * FROM generate_series(0, 1000001);
- db2          | SELECT 'We were taught in this modern age that science and mathematics is the pinnacle of human achievement.'             +
-              | 'Yet, in our complacency, we began to neglect the very thing which our ancestors had once done: to challenge the process.'+
-              | 'We need to stand back
-(5 rows)
+(4 rows)
 
 \c yugabyte yugabyte
 REVOKE pg_read_all_stats FROM test_user;
@@ -182,16 +127,13 @@ SELECT
     S.query_text AS query_text
 FROM yb_pg_stat_get_queries(null) AS S
 LEFT JOIN pg_database AS D ON (S.db_oid = D.oid) ORDER BY S.db_oid;
- databasename |                                                         query_text                                                         
---------------+----------------------------------------------------------------------------------------------------------------------------
+ databasename |                  query_text                  
+--------------+----------------------------------------------
  yugabyte     | SELECT * FROM generate_series(0, 1000000);
  yugabyte     | SELECT 'bob' FROM generate_series(0, 1000000);
  yugabyte     | SELECT * FROM generate_series(0, 100000002);
  db2          | SELECT * FROM generate_series(0, 1000001);
- db2          | SELECT 'We were taught in this modern age that science and mathematics is the pinnacle of human achievement.'             +
-              | 'Yet, in our complacency, we began to neglect the very thing which our ancestors had once done: to challenge the process.'+
-              | 'We need to stand back
-(5 rows)
+(4 rows)
 
 \c yugabyte yugabyte
 REVOKE yb_db_admin FROM test_user;
@@ -213,17 +155,14 @@ show temp_file_limit;
 SELECT * FROM generate_series(0, 1234567);
 ERROR:  temporary file size exceeds temp_file_limit (0kB)
 SELECT databasename, termination_reason, query_text FROM yb_terminated_queries ORDER BY databasename;
-    databasename    |                   termination_reason                    |                                                         query_text                                                         
---------------------+---------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------
+    databasename    |                   termination_reason                    |                  query_text                  
+--------------------+---------------------------------------------------------+----------------------------------------------
  db2                | temporary file size exceeds temp_file_limit (0kB)       | SELECT * FROM generate_series(0, 1000001);
- db2                | temporary file size exceeds temp_file_limit (0kB)       | SELECT 'We were taught in this modern age that science and mathematics is the pinnacle of human achievement.'             +
-                    |                                                         | 'Yet, in our complacency, we began to neglect the very thing which our ancestors had once done: to challenge the process.'+
-                    |                                                         | 'We need to stand back
  test_user_database | temporary file size exceeds temp_file_limit (0kB)       | SELECT * FROM generate_series(0, 1234567);
  yugabyte           | temporary file size exceeds temp_file_limit (0kB)       | SELECT * FROM generate_series(0, 1000000);
  yugabyte           | temporary file size exceeds temp_file_limit (0kB)       | SELECT 'bob' FROM generate_series(0, 1000000);
  yugabyte           | temporary file size exceeds temp_file_limit (1048576kB) | SELECT * FROM generate_series(0, 100000002);
-(6 rows)
+(5 rows)
 
 -- Drop the superuser privilege as we want to see if we would only see the terminated query
 -- of our created database only.
@@ -241,3 +180,23 @@ SELECT databasename, termination_reason, query_text FROM yb_terminated_queries;
  test_user_database | temporary file size exceeds temp_file_limit (0kB)       | SELECT * FROM generate_series(0, 1234567);
 (2 rows)
 
+SET work_mem TO 64;
+SELECT 'We were taught in this modern age that science and mathematics is the pinnacle of human achievement.'
+'Yet, in our complacency, we began to neglect the very thing which our ancestors had once done: to challenge the process.'
+'We need to stand back and critically analyze what we do and doing so would allow us to become better and so much more.'
+FROM generate_series(0, 1000000);
+ERROR:  temporary file size exceeds temp_file_limit (0kB)
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT length(query_text) > 255 AS query_text_exceeds_255,
+       query_text LIKE '%FROM generate_series(0, 1000000);' AS query_text_is_complete
+FROM yb_terminated_queries
+WHERE query_text LIKE 'SELECT ''We were taught%';
+ query_text_exceeds_255 | query_text_is_complete 
+------------------------+------------------------
+ t                      | t
+(1 row)

--- a/src/postgres/src/test/regress/sql/yb.orig.stat.sql
+++ b/src/postgres/src/test/regress/sql/yb.orig.stat.sql
@@ -30,17 +30,6 @@ SELECT * FROM generate_series(0, 1000001);
 SELECT pg_sleep(1);
 SELECT databasename, termination_reason, query_text FROM yb_terminated_queries;
 
-SELECT 'We were taught in this modern age that science and mathematics is the pinnacle of human achievement.'
-'Yet, in our complacency, we began to neglect the very thing which our ancestors had once done: to challenge the process.'
-'We need to stand back and critically analyze what we do and doing so would allow us to become better and so much more.'
-FROM generate_series(0, 1000000);
-
-SELECT pg_sleep(1);
-SELECT databasename, termination_reason, query_text FROM yb_terminated_queries;
-SELECT databasename, termination_reason, query_text FROM yb_terminated_queries WHERE databasename = 'yugabyte';
-SELECT databasename, termination_reason, query_text FROM yb_terminated_queries WHERE databasename = 'db2';
-SELECT query_text, length(query_text) AS query_length FROM yb_terminated_queries;
-
 -- Test permissions for different roles
 \c yugabyte
 SELECT databasename, termination_reason, query_text FROM yb_terminated_queries;
@@ -100,3 +89,15 @@ ALTER user test_user WITH nosuperuser;
 
 SELECT pg_sleep(1);
 SELECT databasename, termination_reason, query_text FROM yb_terminated_queries;
+
+SET work_mem TO 64;
+SELECT 'We were taught in this modern age that science and mathematics is the pinnacle of human achievement.'
+'Yet, in our complacency, we began to neglect the very thing which our ancestors had once done: to challenge the process.'
+'We need to stand back and critically analyze what we do and doing so would allow us to become better and so much more.'
+FROM generate_series(0, 1000000);
+
+SELECT pg_sleep(1);
+SELECT length(query_text) > 255 AS query_text_exceeds_255,
+       query_text LIKE '%FROM generate_series(0, 1000000);' AS query_text_is_complete
+FROM yb_terminated_queries
+WHERE query_text LIKE 'SELECT ''We were taught%';


### PR DESCRIPTION
## Summary

Increase the `yb_terminated_queries` query buffer from 256 to 1,024 bytes, matching the default `track_activity_query_size` and retaining up to 1,023 bytes of query text.

Use bounded string copies, update the persisted format identifier and documentation, and add regression coverage that verifies queries longer than 255 bytes remain complete.

Closes #32412

## Upgrade/Rollback safety

The persisted `yb_terminated_queries` raw structure format changes. On the first postmaster restart after upgrade or rollback, incompatible saved terminated-query telemetry is discarded and collection resumes in the current format. This affects only local terminated-query statistics; there are no catalog, wire, or database data format changes, and mixed-version nodes operate independently.

## Test plan

- [x] `src/tools/pgindent/yb_pgindent src/backend/utils/activity/yb_terminated_queries.c`
- [x] `./yb_build.sh debug postgres --sj --skip-pg-parquet --no-odyssey --no-ybc`
- [x] `build-support/lint.sh --rev upstream/master`
- [ ] `./yb_build.sh debug --skip-pg-parquet --no-odyssey --no-ybc --java-test 'org.yb.pgsql.TestPgRegressYbStat'` (the local sandbox blocks POSIX shared-memory creation during `initdb`; CI coverage is required)
