### PR TITLE
[#31574] YSQL: Support DROP INDEX CONCURRENTLY

### DIFF
--- a/docs/content/stable/api/ysql/syntax_resources/ysql_grammar.ebnf
+++ b/docs/content/stable/api/ysql/syntax_resources/ysql_grammar.ebnf
@@ -1073,7 +1073,7 @@ drop_table = 'DROP' 'TABLE' [ 'IF' 'EXISTS' ] table_name { ',' table_name}
                   [ 'CASCADE' | 'RESTRICT' ] ;
 
 (* 'DROP' 'INDEX' *)
-drop_index = 'DROP' 'INDEX' [ 'IF' 'EXISTS' ] index_name [ 'CASCADE' | 'RESTRICT' ] ;
+drop_index = 'DROP' 'INDEX' [ 'CONCURRENTLY' ] [ 'IF' 'EXISTS' ] index_name [ 'CASCADE' | 'RESTRICT' ] ;
 
 index_name = name ;
 

--- a/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_index.md
+++ b/docs/content/stable/api/ysql/the-sql-language/statements/ddl_drop_index.md
@@ -24,6 +24,10 @@ Use the `DROP INDEX` statement to remove an index from the database.
 
 ## Semantics
 
+#### CONCURRENTLY
+
+Drop the index without blocking concurrent reads and writes on its table. Only one index can be specified, `CASCADE` is not supported, and the statement cannot run inside a transaction block. Indexes on partitioned tables cannot be dropped concurrently.
+
 #### *if_exists*
 
 Under normal operation, an error is raised if the index does not exist.  Adding `IF EXISTS` will quietly ignore any non-existent indexes specified.

--- a/src/postgres/src/backend/catalog/dependency.c
+++ b/src/postgres/src/backend/catalog/dependency.c
@@ -1465,7 +1465,8 @@ doDeletion(const ObjectAddress *object, int flags, bool ybOriginalObject)
 
 					if (yb_index)
 					{
-						if (IsYBRelation(yb_index) && !yb_index->rd_index->indisprimary)
+						if (IsYBRelation(yb_index) &&
+							!yb_index->rd_index->indisprimary && !concurrent)
 							YBCDropIndex(yb_index);
 
 						RelationClose(yb_index);

--- a/src/postgres/src/backend/catalog/index.c
+++ b/src/postgres/src/backend/catalog/index.c
@@ -113,6 +113,7 @@ typedef struct
 
 /* non-export function prototypes */
 static bool relationHasPrimaryKey(Relation rel);
+static void YbCommitIndexDropStateChange(const char *phase);
 static TupleDesc ConstructTupleDescriptor(Relation heapRelation,
 										  IndexInfo *indexInfo,
 										  List *indexColNames,
@@ -2308,6 +2309,8 @@ index_drop(Oid indexId, bool concurrent, bool concurrent_lock_mode)
 				indexrelid;
 	LOCKTAG		heaplocktag;
 	LOCKMODE	lockmode;
+	volatile BackendType old_type = MyBackendType;
+	volatile bool yb_type_changed = false;
 
 	/*
 	 * A temporary relation uses a non-concurrent DROP.  Other backends can't
@@ -2384,113 +2387,149 @@ index_drop(Oid indexId, bool concurrent, bool concurrent_lock_mode)
 	 */
 	if (concurrent)
 	{
-		/*
-		 * We must commit our transaction in order to make the first pg_index
-		 * state update visible to other sessions.  If the DROP machinery has
-		 * already performed any other actions (removal of other objects,
-		 * pg_depend entries, etc), the commit would make those actions
-		 * permanent, which would leave us with inconsistent catalog state if
-		 * we fail partway through the following sequence.  Since DROP INDEX
-		 * CONCURRENTLY is restricted to dropping just one index that has no
-		 * dependencies, we should get here before anything's been done ---
-		 * but let's check that to be sure.  We can verify that the current
-		 * transaction has not executed any transactional updates by checking
-		 * that no XID has been assigned.
-		 */
-		if (GetTopTransactionIdIfAny() != InvalidTransactionId)
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("DROP INDEX CONCURRENTLY must be first action in transaction")));
+		if (IsYugaByteEnabled() &&
+			(MyBackendType == B_BACKEND || MyBackendType == YB_YSQL_CONN_MGR))
+		{
+			MyBackendType = YB_INDEX_BACKFILL_DDL;
+			if (MyBEEntry)
+				MyBEEntry->st_backendType = MyBackendType;
+			yb_type_changed = true;
+		}
 
-		/*
-		 * Mark index invalid by updating its pg_index entry
-		 */
-		index_set_state_flags(indexId, INDEX_DROP_CLEAR_VALID);
+		PG_TRY();
+		{
+			/*
+			 * We must commit our transaction in order to make the first pg_index
+			 * state update visible to other sessions.  If the DROP machinery has
+			 * already performed any other actions (removal of other objects,
+			 * pg_depend entries, etc), the commit would make those actions
+			 * permanent, which would leave us with inconsistent catalog state if
+			 * we fail partway through the following sequence.  Since DROP INDEX
+			 * CONCURRENTLY is restricted to dropping just one index that has no
+			 * dependencies, we should get here before anything's been done ---
+			 * but let's check that to be sure.  We can verify that the current
+			 * transaction has not executed any transactional updates by checking
+			 * that no XID has been assigned.
+			 */
+			if (GetTopTransactionIdIfAny() != InvalidTransactionId)
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("DROP INDEX CONCURRENTLY must be first action in transaction")));
 
-		/*
-		 * Invalidate the relcache for the table, so that after this commit
-		 * all sessions will refresh any cached plans that might reference the
-		 * index.
-		 */
-		CacheInvalidateRelcache(userHeapRelation);
+			/*
+			 * Mark index invalid by updating its pg_index entry
+			 */
+			index_set_state_flags(indexId, INDEX_DROP_CLEAR_VALID);
 
-		/* save lockrelid and locktag for below, then close but keep locks */
-		heaprelid = userHeapRelation->rd_lockInfo.lockRelId;
-		SET_LOCKTAG_RELATION(heaplocktag, heaprelid.dbId, heaprelid.relId);
-		indexrelid = userIndexRelation->rd_lockInfo.lockRelId;
+			/*
+			 * Invalidate the relcache for the table, so that after this commit
+			 * all sessions will refresh any cached plans that might reference the
+			 * index.
+			 */
+			CacheInvalidateRelcache(userHeapRelation);
 
-		table_close(userHeapRelation, NoLock);
-		index_close(userIndexRelation, NoLock);
+			/* save lockrelid and locktag for below, then close but keep locks */
+			heaprelid = userHeapRelation->rd_lockInfo.lockRelId;
+			SET_LOCKTAG_RELATION(heaplocktag, heaprelid.dbId, heaprelid.relId);
+			indexrelid = userIndexRelation->rd_lockInfo.lockRelId;
 
-		/*
-		 * We must commit our current transaction so that the indisvalid
-		 * update becomes visible to other transactions; then start another.
-		 * Note that any previously-built data structures are lost in the
-		 * commit.  The only data we keep past here are the relation IDs.
-		 *
-		 * Before committing, get a session-level lock on the table, to ensure
-		 * that neither it nor the index can be dropped before we finish. This
-		 * cannot block, even if someone else is waiting for access, because
-		 * we already have the same lock within our transaction.
-		 */
-		LockRelationIdForSession(&heaprelid, ShareUpdateExclusiveLock);
-		LockRelationIdForSession(&indexrelid, ShareUpdateExclusiveLock);
+			table_close(userHeapRelation, NoLock);
+			index_close(userIndexRelation, NoLock);
 
-		PopActiveSnapshot();
-		CommitTransactionCommand();
-		StartTransactionCommand();
+			/*
+			 * We must commit our current transaction so that the indisvalid
+			 * update becomes visible to other transactions; then start another.
+			 * Note that any previously-built data structures are lost in the
+			 * commit.  The only data we keep past here are the relation IDs.
+			 *
+			 * Before committing, get a session-level lock on the table, to ensure
+			 * that neither it nor the index can be dropped before we finish. This
+			 * cannot block, even if someone else is waiting for access, because
+			 * we already have the same lock within our transaction.
+			 */
+			LockRelationIdForSession(&heaprelid, ShareUpdateExclusiveLock);
+			LockRelationIdForSession(&indexrelid, ShareUpdateExclusiveLock);
 
-		/*
-		 * Now we must wait until no running transaction could be using the
-		 * index for a query.  Use AccessExclusiveLock here to check for
-		 * running transactions that hold locks of any kind on the table. Note
-		 * we do not need to worry about xacts that open the table for reading
-		 * after this point; they will see the index as invalid when they open
-		 * the relation.
-		 *
-		 * Note: the reason we use actual lock acquisition here, rather than
-		 * just checking the ProcArray and sleeping, is that deadlock is
-		 * possible if one of the transactions in question is blocked trying
-		 * to acquire an exclusive lock on our table.  The lock code will
-		 * detect deadlock and error out properly.
-		 *
-		 * Note: we report progress through WaitForLockers() unconditionally
-		 * here, even though it will only be used when we're called by REINDEX
-		 * CONCURRENTLY and not when called by DROP INDEX CONCURRENTLY.
-		 */
-		WaitForLockers(heaplocktag, AccessExclusiveLock, true);
+			PopActiveSnapshot();
+			if (IsYugaByteEnabled())
+				YbCommitIndexDropStateChange("drop_indisvalid");
+			else
+			{
+				CommitTransactionCommand();
+				StartTransactionCommand();
+			}
 
-		/* Finish invalidation of index and mark it as dead */
-		index_concurrently_set_dead(heapId, indexId);
+			/*
+			 * Now we must wait until no running transaction could be using the
+			 * index for a query.  Use AccessExclusiveLock here to check for
+			 * running transactions that hold locks of any kind on the table. Note
+			 * we do not need to worry about xacts that open the table for reading
+			 * after this point; they will see the index as invalid when they open
+			 * the relation.
+			 *
+			 * Note: the reason we use actual lock acquisition here, rather than
+			 * just checking the ProcArray and sleeping, is that deadlock is
+			 * possible if one of the transactions in question is blocked trying
+			 * to acquire an exclusive lock on our table.  The lock code will
+			 * detect deadlock and error out properly.
+			 *
+			 * Note: we report progress through WaitForLockers() unconditionally
+			 * here, even though it will only be used when we're called by REINDEX
+			 * CONCURRENTLY and not when called by DROP INDEX CONCURRENTLY.
+			 */
+			WaitForLockers(heaplocktag, AccessExclusiveLock, true);
 
-		/*
-		 * Again, commit the transaction to make the pg_index update visible
-		 * to other sessions.
-		 */
-		CommitTransactionCommand();
-		StartTransactionCommand();
+			/* Finish invalidation of index and mark it as dead */
+			index_concurrently_set_dead(heapId, indexId);
 
-		/*
-		 * Wait till every transaction that saw the old index state has
-		 * finished.  See above about progress reporting.
-		 */
-		WaitForLockers(heaplocktag, AccessExclusiveLock, true);
+			/*
+			 * Again, commit the transaction to make the pg_index update visible
+			 * to other sessions.
+			 */
+			if (IsYugaByteEnabled())
+				YbCommitIndexDropStateChange("drop_indislive");
+			else
+			{
+				CommitTransactionCommand();
+				StartTransactionCommand();
+			}
 
-		/*
-		 * Re-open relations to allow us to complete our actions.
-		 *
-		 * At this point, nothing should be accessing the index, but lets
-		 * leave nothing to chance and grab AccessExclusiveLock on the index
-		 * before the physical deletion.
-		 */
-		userHeapRelation = table_open(heapId, ShareUpdateExclusiveLock);
-		userIndexRelation = index_open(indexId, AccessExclusiveLock);
+			/*
+			 * Wait till every transaction that saw the old index state has
+			 * finished.  See above about progress reporting.
+			 */
+			WaitForLockers(heaplocktag, AccessExclusiveLock, true);
+
+			/*
+			 * Re-open relations to allow us to complete our actions.
+			 *
+			 * At this point, nothing should be accessing the index, but lets
+			 * leave nothing to chance and grab AccessExclusiveLock on the index
+			 * before the physical deletion.
+			 */
+			userHeapRelation = table_open(heapId, ShareUpdateExclusiveLock);
+			userIndexRelation = index_open(indexId, AccessExclusiveLock);
+		}
+		PG_FINALLY();
+		{
+			if (yb_type_changed)
+			{
+				MyBackendType = old_type;
+				if (MyBEEntry)
+					MyBEEntry->st_backendType = old_type;
+			}
+		}
+		PG_END_TRY();
 	}
 	else
 	{
 		/* Not concurrent, so just transfer predicate locks and we're good */
 		TransferPredicateLocksToHeapRelation(userIndexRelation);
 	}
+
+	if (concurrent && IsYBRelation(userIndexRelation) &&
+		!userIndexRelation->rd_index->indisprimary)
+		YBCDropIndex(userIndexRelation);
 
 	/*
 	 * Schedule physical removal of the files (if any)
@@ -2575,6 +2614,32 @@ index_drop(Oid indexId, bool concurrent, bool concurrent_lock_mode)
 		UnlockRelationIdForSession(&heaprelid, ShareUpdateExclusiveLock);
 		UnlockRelationIdForSession(&indexrelid, ShareUpdateExclusiveLock);
 	}
+}
+
+static void
+YbCommitIndexDropStateChange(const char *phase)
+{
+	if (YBCIsLegacyModeForCatalogOps())
+	{
+		YbDdlOriginalStmtState ddl_stmt_state;
+		YbDdlMode	ddl_mode = YBGetCurrentDdlMode();
+
+		YBGetDdlOriginalStmtState(&ddl_stmt_state);
+		YBDecrementDdlNestingLevel();
+		CommitTransactionCommand();
+		StartTransactionCommand();
+		YBIncrementDdlNestingLevel(ddl_mode);
+		YBSetDdlOriginalStmtState(&ddl_stmt_state);
+	}
+	else
+		YbCommitTransactionCommandIntermediate();
+
+	YbTestGucFailIfStrEqual(yb_test_fail_index_state_change, phase);
+	if (yb_test_block_index_phase[0] != '\0')
+		YbTestGucBlockWhileStrEqual(&yb_test_block_index_phase,
+									phase, "concurrent index drop state change");
+
+	YbWaitForBackendsCatalogVersion();
 }
 
 /* ----------------------------------------------------------------

--- a/src/postgres/src/backend/catalog/index.c
+++ b/src/postgres/src/backend/catalog/index.c
@@ -2309,8 +2309,6 @@ index_drop(Oid indexId, bool concurrent, bool concurrent_lock_mode)
 				indexrelid;
 	LOCKTAG		heaplocktag;
 	LOCKMODE	lockmode;
-	volatile BackendType old_type = MyBackendType;
-	volatile bool yb_type_changed = false;
 
 	/*
 	 * A temporary relation uses a non-concurrent DROP.  Other backends can't
@@ -2387,6 +2385,23 @@ index_drop(Oid indexId, bool concurrent, bool concurrent_lock_mode)
 	 */
 	if (concurrent)
 	{
+		/*
+		 * YB: Change the backend type to YB_INDEX_BACKFILL_DDL for the
+		 * duration of the two WaitForLockers calls below.  A
+		 * YB_INDEX_BACKFILL_DDL backend is ignored by the
+		 * WaitForYsqlBackendsCatalogVersion query logic, so a DROP INDEX
+		 * CONCURRENTLY blocked on old transactions does not appear as a
+		 * lagging backend and time out other concurrent index DDLs (see the
+		 * corresponding logic for CREATE INDEX CONCURRENTLY in DefineIndex).
+		 * Unlike CREATE INDEX CONCURRENTLY, this applies in legacy mode for
+		 * catalog ops too because YbCommitIndexDropStateChange waits for
+		 * backend catalog-version convergence in both modes.
+		 */
+
+		/* Use volatile to ensure variables survive a siglongjmp */
+		volatile BackendType old_type = MyBackendType;
+		volatile bool yb_type_changed = false;
+
 		if (IsYugaByteEnabled() &&
 			(MyBackendType == B_BACKEND || MyBackendType == YB_YSQL_CONN_MGR))
 		{
@@ -2616,6 +2631,22 @@ index_drop(Oid indexId, bool concurrent, bool concurrent_lock_mode)
 	}
 }
 
+/*
+ * YB: Commit a pg_index state-change transaction of DROP INDEX CONCURRENTLY
+ * and wait until every backend in the cluster has caught up to the resulting
+ * catalog version, so that no backend can still be planning or executing
+ * queries against the old index state when the caller proceeds.
+ *
+ * The commit must preserve the YB DDL state of the overall DROP INDEX
+ * statement across the intermediate transaction boundary.  In legacy mode
+ * for catalog ops, YbCommitTransactionCommandIntermediate does not restore
+ * that state (it only does so when DDL transaction block support is
+ * enabled), so explicitly re-wind and re-establish the DDL nesting level and
+ * original-statement state around the commit, mirroring YbDefineIndexHelper.
+ *
+ * "phase" identifies the just-committed pg_index transition for the
+ * yb_test_fail_index_state_change and yb_test_block_index_phase test hooks.
+ */
 static void
 YbCommitIndexDropStateChange(const char *phase)
 {

--- a/src/postgres/src/backend/commands/indexcmds.c
+++ b/src/postgres/src/backend/commands/indexcmds.c
@@ -127,7 +127,6 @@ static void update_relispartition(Oid relationId, bool newval);
 static inline void set_indexsafe_procflags(void);
 
 /* YB function declarations. */
-static void YbWaitForBackendsCatalogVersion();
 static void YbDefineIndexHelper(Oid relationId, Oid indexRelationId, Oid databaseId);
 
 /*
@@ -5311,7 +5310,7 @@ set_indexsafe_procflags(void)
 	LWLockRelease(ProcArrayLock);
 }
 
-static void
+void
 YbWaitForBackendsCatalogVersion()
 {
 	if (yb_disable_wait_for_backends_catalog_version)

--- a/src/postgres/src/backend/parser/gram.y
+++ b/src/postgres/src/backend/parser/gram.y
@@ -7368,7 +7368,6 @@ DropStmt:	DROP object_type_any_name IF_P EXISTS any_name_list opt_drop_behavior
 				}
 			| DROP INDEX CONCURRENTLY any_name_list opt_drop_behavior
 				{
-					parser_ybc_not_support(@1, "DROP INDEX CONCURRENTLY");
 					DropStmt *n = makeNode(DropStmt);
 
 					n->removeType = OBJECT_INDEX;
@@ -7380,7 +7379,6 @@ DropStmt:	DROP object_type_any_name IF_P EXISTS any_name_list opt_drop_behavior
 				}
 			| DROP INDEX CONCURRENTLY IF_P EXISTS any_name_list opt_drop_behavior
 				{
-					parser_ybc_not_support(@1, "DROP INDEX CONCURRENTLY");
 					DropStmt *n = makeNode(DropStmt);
 
 					n->removeType = OBJECT_INDEX;

--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -3862,6 +3862,8 @@ YbGetDdlMode(PlannedStmt *pstmt, ProcessUtilityContext context,
 
 		case T_DropStmt:
 			{
+				DropStmt   *stmt = castNode(DropStmt, parsetree);
+
 				/*
 				 * If this is a DROP statement that is being executed as part of
 				 * REFRESH MATVIEW (CONCURRENTLY), we are only dropping temporary
@@ -3875,8 +3877,6 @@ YbGetDdlMode(PlannedStmt *pstmt, ProcessUtilityContext context,
 					 * If all dropped objects are temporary, we do not need to
 					 * bump the catalog version.
 					 */
-					DropStmt   *stmt = castNode(DropStmt, parsetree);
-
 				if (stmt->removeType == OBJECT_INDEX ||
 					stmt->removeType == OBJECT_TABLE ||
 					stmt->removeType == OBJECT_VIEW)
@@ -3905,6 +3905,10 @@ YbGetDdlMode(PlannedStmt *pstmt, ProcessUtilityContext context,
 							is_altering_existing_data = true;
 					}
 				}
+				if (stmt->removeType == OBJECT_INDEX && stmt->concurrent)
+					should_run_in_autonomous_transaction =
+						!IsInTransactionBlock(is_top_level) &&
+						YBCIsLegacyModeForCatalogOps();
 				is_breaking_change = false;
 				break;
 			}

--- a/src/postgres/src/include/commands/defrem.h
+++ b/src/postgres/src/include/commands/defrem.h
@@ -47,6 +47,7 @@ extern bool CheckIndexCompatible(Oid oldId,
 extern Oid	GetDefaultOpClass(Oid type_id, Oid am_id);
 extern Oid	ResolveOpClass(List *opclass, Oid attrType,
 						   const char *accessMethodName, Oid accessMethodId);
+extern void YbWaitForBackendsCatalogVersion(void);
 
 /* commands/functioncmds.c */
 extern ObjectAddress CreateFunction(ParseState *pstate, CreateFunctionStmt *stmt);

--- a/src/postgres/src/test/isolation/expected/yb.port.drop-index-concurrently-1.out
+++ b/src/postgres/src/test/isolation/expected/yb.port.drop-index-concurrently-1.out
@@ -1,0 +1,52 @@
+Parsed test spec with 3 sessions
+
+starting permutation: prepi preps begin disableseq explaini enableseq disableindex explains select2 drop insert2 end2 selecti selects end
+step prepi: PREPARE getrow_idxscan AS SELECT * FROM test_dc WHERE data = 34 ORDER BY id,data;
+step preps: PREPARE getrow_seqscan AS SELECT * FROM test_dc WHERE data = 34 ORDER BY id,data;
+step begin: BEGIN;
+step disableseq: SET enable_seqscan = false;
+step explaini: EXPLAIN (COSTS OFF) EXECUTE getrow_idxscan;
+QUERY PLAN                                    
+----------------------------------------------
+Sort                                          
+  Sort Key: id                                
+  ->  Index Scan using test_dc_data on test_dc
+        Index Cond: (data = 34)               
+(4 rows)
+
+step enableseq: SET enable_seqscan = true;
+step disableindex: SET enable_indexscan = false;
+step explains: EXPLAIN (COSTS OFF) EXECUTE getrow_seqscan;
+QUERY PLAN                         
+-----------------------------------
+Sort                               
+  Sort Key: id                     
+  ->  Seq Scan on test_dc          
+        Storage Filter: (data = 34)
+(4 rows)
+
+step select2: SELECT * FROM test_dc WHERE data = 34 ORDER BY id,data;
+id|data
+--+----
+34|  34
+(1 row)
+
+step drop: DROP INDEX CONCURRENTLY test_dc_data; <waiting ...>
+step insert2: INSERT INTO test_dc(data) SELECT * FROM generate_series(1, 100);
+step end2: COMMIT;
+step selecti: EXECUTE getrow_idxscan;
+ id|data
+---+----
+ 34|  34
+134|  34
+(2 rows)
+
+step selects: EXECUTE getrow_seqscan;
+ id|data
+---+----
+ 34|  34
+134|  34
+(2 rows)
+
+step end: COMMIT;
+step drop: <... completed>

--- a/src/postgres/src/test/isolation/specs/yb.port.drop-index-concurrently-1.spec
+++ b/src/postgres/src/test/isolation/specs/yb.port.drop-index-concurrently-1.spec
@@ -1,0 +1,40 @@
+# DROP INDEX CONCURRENTLY
+#
+# Verify that an index remains usable and maintained by transactions that
+# observed it before a concurrent drop started.
+
+setup
+{
+	CREATE TABLE test_dc(id serial primary key, data int);
+	INSERT INTO test_dc(data) SELECT * FROM generate_series(1, 100);
+	CREATE INDEX test_dc_data ON test_dc(data);
+}
+
+teardown
+{
+	DROP TABLE test_dc;
+}
+
+session s1
+step prepi { PREPARE getrow_idxscan AS SELECT * FROM test_dc WHERE data = 34 ORDER BY id,data; }
+step preps { PREPARE getrow_seqscan AS SELECT * FROM test_dc WHERE data = 34 ORDER BY id,data; }
+step begin { BEGIN; }
+step disableseq { SET enable_seqscan = false; }
+step explaini { EXPLAIN (COSTS OFF) EXECUTE getrow_idxscan; }
+step enableseq { SET enable_seqscan = true; }
+step disableindex { SET enable_indexscan = false; }
+step explains { EXPLAIN (COSTS OFF) EXECUTE getrow_seqscan; }
+step selecti { EXECUTE getrow_idxscan; }
+step selects { EXECUTE getrow_seqscan; }
+step end { COMMIT; }
+
+session s2
+setup { BEGIN; }
+step select2 { SELECT * FROM test_dc WHERE data = 34 ORDER BY id,data; }
+step insert2 { INSERT INTO test_dc(data) SELECT * FROM generate_series(1, 100); }
+step end2 { COMMIT; }
+
+session s3
+step drop { DROP INDEX CONCURRENTLY test_dc_data; }
+
+permutation prepi preps begin disableseq explaini enableseq disableindex explains select2 drop insert2 end2 selecti selects end

--- a/src/postgres/src/test/isolation/yb_pg_isolation_object_locking_schedule
+++ b/src/postgres/src/test/isolation/yb_pg_isolation_object_locking_schedule
@@ -1,10 +1,10 @@
 test: fk-partitioned-1
 test: propagate-lock-delete
+test: yb.port.drop-index-concurrently-1
 test: multiple-cic
 test: alter-table-2
 test: alter-table-3
 test: alter-table-4
-test: yb.port.drop-index-concurrently-1
 test: yb.port.sequence-ddl
 test: yb.port.vacuum-concurrent-drop
 test: partition-concurrent-attach

--- a/src/postgres/src/test/isolation/yb_pg_isolation_object_locking_schedule
+++ b/src/postgres/src/test/isolation/yb_pg_isolation_object_locking_schedule
@@ -4,6 +4,7 @@ test: multiple-cic
 test: alter-table-2
 test: alter-table-3
 test: alter-table-4
+test: yb.port.drop-index-concurrently-1
 test: yb.port.sequence-ddl
 test: yb.port.vacuum-concurrent-drop
 test: partition-concurrent-attach

--- a/src/postgres/src/test/regress/expected/yb.port.create_index.out
+++ b/src/postgres/src/test/regress/expected/yb.port.create_index.out
@@ -229,6 +229,43 @@ NOTICE:  making create index for table "concur_heap" nonconcurrent
 DETAIL:  Create index in transaction block cannot be concurrent.
 HINT:  Consider running it outside of a transaction block. See https://github.com/yugabyte/yugabyte-db/issues/6240.
 COMMIT;
+-- Temporary indexes use the non-concurrent drop path.
+CREATE TEMP TABLE concur_temp (f1 int, f2 text) ON COMMIT PRESERVE ROWS;
+CREATE INDEX CONCURRENTLY concur_temp_ind ON concur_temp(f1);
+DROP INDEX CONCURRENTLY concur_temp_ind;
+SELECT to_regclass('pg_temp.concur_temp_ind') IS NULL AS dropped;
+ dropped 
+---------
+ t
+(1 row)
+
+DROP TABLE concur_temp;
+-- Try some concurrent index drops.
+DROP INDEX CONCURRENTLY "concur_index2";
+DROP INDEX CONCURRENTLY IF EXISTS "concur_index2";
+NOTICE:  index "concur_index2" does not exist, skipping
+-- failures
+DROP INDEX CONCURRENTLY "concur_index2", "concur_index3";
+ERROR:  DROP INDEX CONCURRENTLY does not support dropping multiple objects
+DROP INDEX CONCURRENTLY "concur_index5" CASCADE;
+ERROR:  DROP INDEX CONCURRENTLY does not support CASCADE
+BEGIN;
+DROP INDEX CONCURRENTLY "concur_index5";
+ERROR:  DROP INDEX CONCURRENTLY cannot run inside a transaction block
+ROLLBACK;
+-- successes
+DROP INDEX CONCURRENTLY IF EXISTS "concur_index3";
+DROP INDEX CONCURRENTLY "concur_index4";
+DROP INDEX CONCURRENTLY "concur_index5";
+DROP INDEX CONCURRENTLY "concur_index1";
+DROP INDEX CONCURRENTLY "concur_heap_expr_idx";
+SELECT indexname FROM pg_indexes
+  WHERE tablename = 'concur_heap' ORDER BY indexname;
+ indexname 
+-----------
+ std_index
+(1 row)
+
 -- Failed builds are left invalid by VACUUM FULL, fixed by REINDEX
 -- YB note: VACUUM and REINDEX TABLE are not yet supported
 VACUUM FULL concur_heap;
@@ -238,6 +275,7 @@ ERROR:  REINDEX TABLE not supported yet
 LINE 1: REINDEX TABLE concur_heap;
                 ^
 HINT:  Please report the issue on https://github.com/YugaByte/yugabyte-db/issues
+DROP TABLE concur_heap;
 --
 -- Test ADD CONSTRAINT USING INDEX
 --

--- a/src/postgres/src/test/regress/expected/yb.port.indexing.out
+++ b/src/postgres/src/test/regress/expected/yb.port.indexing.out
@@ -139,6 +139,8 @@ create table idxpart1 partition of idxpart for values from (0) to (10);
 -- depends on the partition table itself and on the index created on the parent
 -- table, and either of the two error messages are possible.
 -- drop index idxpart1_a_idx;	-- no way
+drop index concurrently idxpart_a_idx;	-- unsupported
+ERROR:  cannot drop partitioned index "idxpart_a_idx" concurrently
 drop index idxpart_a_idx;	-- both indexes go away
 select relname, relkind from pg_class
   where relname like 'idxpart%' order by relname;

--- a/src/postgres/src/test/regress/sql/yb.port.create_index.sql
+++ b/src/postgres/src/test/regress/sql/yb.port.create_index.sql
@@ -205,10 +205,38 @@ BEGIN;
 CREATE INDEX std_index on concur_heap(f2);
 COMMIT;
 
+-- Temporary indexes use the non-concurrent drop path.
+CREATE TEMP TABLE concur_temp (f1 int, f2 text) ON COMMIT PRESERVE ROWS;
+CREATE INDEX CONCURRENTLY concur_temp_ind ON concur_temp(f1);
+DROP INDEX CONCURRENTLY concur_temp_ind;
+SELECT to_regclass('pg_temp.concur_temp_ind') IS NULL AS dropped;
+DROP TABLE concur_temp;
+
+-- Try some concurrent index drops.
+DROP INDEX CONCURRENTLY "concur_index2";
+DROP INDEX CONCURRENTLY IF EXISTS "concur_index2";
+
+-- failures
+DROP INDEX CONCURRENTLY "concur_index2", "concur_index3";
+DROP INDEX CONCURRENTLY "concur_index5" CASCADE;
+BEGIN;
+DROP INDEX CONCURRENTLY "concur_index5";
+ROLLBACK;
+
+-- successes
+DROP INDEX CONCURRENTLY IF EXISTS "concur_index3";
+DROP INDEX CONCURRENTLY "concur_index4";
+DROP INDEX CONCURRENTLY "concur_index5";
+DROP INDEX CONCURRENTLY "concur_index1";
+DROP INDEX CONCURRENTLY "concur_heap_expr_idx";
+SELECT indexname FROM pg_indexes
+  WHERE tablename = 'concur_heap' ORDER BY indexname;
+
 -- Failed builds are left invalid by VACUUM FULL, fixed by REINDEX
 -- YB note: VACUUM and REINDEX TABLE are not yet supported
 VACUUM FULL concur_heap;
 REINDEX TABLE concur_heap;
+DROP TABLE concur_heap;
 
 --
 -- Test ADD CONSTRAINT USING INDEX

--- a/src/postgres/src/test/regress/sql/yb.port.indexing.sql
+++ b/src/postgres/src/test/regress/sql/yb.port.indexing.sql
@@ -70,6 +70,7 @@ create table idxpart1 partition of idxpart for values from (0) to (10);
 -- depends on the partition table itself and on the index created on the parent
 -- table, and either of the two error messages are possible.
 -- drop index idxpart1_a_idx;	-- no way
+drop index concurrently idxpart_a_idx;	-- unsupported
 drop index idxpart_a_idx;	-- both indexes go away
 select relname, relkind from pg_class
   where relname like 'idxpart%' order by relname;

--- a/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
+++ b/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
@@ -563,6 +563,38 @@ TEST_P(PgIndexBackfillTest, Drop) {
   ASSERT_FALSE(ASSERT_RESULT(conn_->HasIndexScan(query)));
 }
 
+TEST_P(PgIndexBackfillTest, DropConcurrentlyRetry) {
+  ASSERT_OK(conn_->ExecuteFormat("CREATE TABLE $0 (i int PRIMARY KEY, j int)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat("CREATE INDEX $0 ON $1 (j ASC)", kIndexName, kTableName));
+  auto client = ASSERT_RESULT(cluster_->CreateClient());
+
+  ASSERT_OK(conn_->Execute("SET yb_test_fail_index_state_change = 'drop_indisvalid'"));
+  ASSERT_NOK_STR_CONTAINS(
+      conn_->ExecuteFormat("DROP INDEX CONCURRENTLY $0", kIndexName),
+      "TEST injected failure at stage drop_indisvalid");
+  ASSERT_OK(WaitForIndexStateFlags(
+      IndexStateFlags{IndexStateFlag::kIndIsLive, IndexStateFlag::kIndIsReady}));
+  ASSERT_EQ(ASSERT_RESULT(client->ListTables(kIndexName)).size(), 1);
+
+  ASSERT_OK(conn_->Execute("SET yb_test_fail_index_state_change = 'drop_indislive'"));
+  ASSERT_NOK_STR_CONTAINS(
+      conn_->ExecuteFormat("DROP INDEX CONCURRENTLY $0", kIndexName),
+      "TEST injected failure at stage drop_indislive");
+  ASSERT_OK(WaitForIndexStateFlags(IndexStateFlags{}));
+  ASSERT_EQ(ASSERT_RESULT(client->ListTables(kIndexName)).size(), 1);
+
+  ASSERT_OK(conn_->Execute("RESET yb_test_fail_index_state_change"));
+  ASSERT_OK(conn_->ExecuteFormat("DROP INDEX CONCURRENTLY $0", kIndexName));
+  ASSERT_TRUE(ASSERT_RESULT(conn_->FetchRow<bool>(
+      Format("SELECT to_regclass('$0') IS NULL", kIndexName))));
+  ASSERT_OK(WaitFor(
+      [&]() -> Result<bool> {
+        return VERIFY_RESULT(client->ListTables(kIndexName)).empty();
+      },
+      30s,
+      "wait for dropped DocDB index"));
+}
+
 // Make sure deletes to nonexistent rows look like noops to clients.  This may seem too obvious to
 // necessitate a test, but logic for backfill is special in that it wants nonexistent index deletes
 // to be applied for the backfill process to use them.  This test guards against that logic being


### PR DESCRIPTION
## Summary

- Enable PostgreSQL-compatible `DROP INDEX CONCURRENTLY` in YSQL.
- Preserve YB DDL state and wait for distributed catalog convergence across both index-state transitions.
- Delay DocDB index deletion until readers and writers can no longer use the index.
- Add regression, isolation, retry, cleanup, and documentation coverage.

Closes #31574

## Test plan

- [x] `./yb_build.sh debug --target pgwrapper_pg_index_backfill-test`
- [x] `./yb_build.sh debug --cxx-test pgwrapper_pg_index_backfill-test --gtest_filter 'PgIndexBackfillTest.DropConcurrentlyRetry/0'`
- [x] `./yb_build.sh debug --cxx-test pgwrapper_pg_index_backfill-test --gtest_filter 'PgIndexBackfillTest.DropConcurrentlyRetry/1'`
- [x] Focused `yb.port.drop-index-concurrently-1` run through `org.yb.pgsql.TestPgRegressIsolationObjectLockingPorted#testPgRegress`
- [x] `./yb_build.sh debug --java-test 'org.yb.pgsql.TestPgRegressPgIndex#schedule'`
- [x] `build-support/lint.sh --rev upstream/master` (0 errors)
