### PR TITLE
[#32543] YSQL: Generate valid partial indexes in ysql_dump

### DIFF
--- a/java/yb-pgsql/src/test/java/org/yb/pgsql/TestYsqlDumpSplitOptions.java
+++ b/java/yb-pgsql/src/test/java/org/yb/pgsql/TestYsqlDumpSplitOptions.java
@@ -403,17 +403,17 @@ public class TestYsqlDumpSplitOptions extends BasePgSQLTest {
   }
 
   /**
-   * Regression test: a table created without SPLIT INTO should not gain a
-   * yb_presplit reloption after dump+restore.  Pg_dump's --include-yb-metadata
-   * always emits SPLIT INTO N TABLETS for hash tables to preserve the current
-   * tablet count, and DefineRelation auto-derives yb_presplit from that
-   * clause.  To keep the restored relation aligned with the source the dump
-   * folds an empty-string yb_presplit sentinel into the CREATE statement's
-   * WITH clause, which DefineRelation/DefineIndex recognise as
-   * "suppress auto-derive" and strip before persistence.
+   * Regression test: dump+restore should preserve whether yb_presplit is
+   * absent or explicitly set.  Pg_dump's --include-yb-metadata always emits
+   * SPLIT INTO N TABLETS for hash tables to preserve the current tablet count,
+   * and DefineRelation auto-derives yb_presplit from that clause.  To keep the
+   * restored relation aligned with the source the dump folds an empty-string
+   * yb_presplit sentinel into the CREATE statement's WITH clause, which
+   * DefineRelation/DefineIndex recognise as "suppress auto-derive" and strip
+   * before persistence.
    */
   @Test
-  public void testRestorePreservesAbsenceOfPresplit() throws Exception {
+  public void testRestorePreservesPresplitState() throws Exception {
     final String sourceDb = "no_presplit_src_db";
     final String targetDb = "no_presplit_tgt_db";
     int tserverIndex = 0;
@@ -423,13 +423,18 @@ public class TestYsqlDumpSplitOptions extends BasePgSQLTest {
       stmt.executeUpdate("CREATE DATABASE " + targetDb);
     }
 
-    // Create a hash-PK table and a hash secondary index without SPLIT clauses.
+    // Create a hash-PK table and secondary indexes with different presplit states.
     try (Connection conn = getConnectionBuilder().withDatabase(sourceDb).connect();
          Statement stmt = conn.createStatement()) {
       stmt.executeUpdate(
-          "CREATE TABLE no_presplit_tbl (k INT, v INT, PRIMARY KEY (k HASH))");
+          "CREATE TABLE no_presplit_tbl "
+              + "(k INT, v INT, \"contains WITH (\" INT, PRIMARY KEY (k HASH))");
       stmt.executeUpdate(
           "CREATE INDEX no_presplit_idx ON no_presplit_tbl (v HASH) SPLIT INTO 3 TABLETS");
+      stmt.executeUpdate(
+          "CREATE INDEX partial_presplit_idx "
+              + "ON no_presplit_tbl (\"contains WITH (\" HASH) "
+              + "WITH (yb_presplit='1') WHERE k > 0");
 
       String tableRel = getReloptions(stmt, "no_presplit_tbl");
       assertTrue("Source table should not have yb_presplit in reloptions",
@@ -445,6 +450,11 @@ public class TestYsqlDumpSplitOptions extends BasePgSQLTest {
       idxRel = getReloptions(stmt, "no_presplit_idx");
       assertTrue("Index reloptions should be empty after RESET",
           idxRel == null || !idxRel.contains("yb_presplit"));
+
+      String partialIdxRel = getReloptions(stmt, "partial_presplit_idx");
+      assertNotNull("Partial index should have reloptions", partialIdxRel);
+      assertTrue("Partial index should have yb_presplit",
+          partialIdxRel.contains("yb_presplit=1"));
     }
 
     // Dump the source with --include-yb-metadata.
@@ -476,6 +486,16 @@ public class TestYsqlDumpSplitOptions extends BasePgSQLTest {
         sentinelCount >= 2);
     assertFalse("Dump should not emit ALTER TABLE RESET (yb_presplit)",
         dumpContent.contains("RESET (yb_presplit)"));
+    int partialIndexPos = dumpContent.indexOf(
+        "CREATE INDEX NONCONCURRENTLY partial_presplit_idx ");
+    int partialIndexPresplitPos = dumpContent.indexOf(
+        " WITH (yb_presplit='1')", partialIndexPos);
+    int partialIndexPredicatePos = dumpContent.indexOf(" WHERE ", partialIndexPos);
+    assertTrue("Dump should place yb_presplit before the partial-index predicate; dump=\n"
+            + dumpContent,
+        partialIndexPos >= 0
+            && partialIndexPresplitPos > partialIndexPos
+            && partialIndexPredicatePos > partialIndexPresplitPos);
 
     // Restore the dump into the target database.
     List<String> restoreArgs = new ArrayList<>(Arrays.asList(
@@ -488,7 +508,7 @@ public class TestYsqlDumpSplitOptions extends BasePgSQLTest {
         "-v", "ON_ERROR_STOP=1"));
     ProcessUtil.executeSimple(restoreArgs, "ysqlsh (restore)");
 
-    // Neither the restored table nor the restored index should have yb_presplit.
+    // Verify that each restored relation retained its source reloption state.
     try (Connection conn = getConnectionBuilder().withDatabase(targetDb).connect();
          Statement stmt = conn.createStatement()) {
       String tableRel = getReloptions(stmt, "no_presplit_tbl");
@@ -497,6 +517,10 @@ public class TestYsqlDumpSplitOptions extends BasePgSQLTest {
       String idxRel = getReloptions(stmt, "no_presplit_idx");
       assertTrue("Restored index should not have yb_presplit; got: " + idxRel,
           idxRel == null || !idxRel.contains("yb_presplit"));
+      String partialIdxRel = getReloptions(stmt, "partial_presplit_idx");
+      assertNotNull("Restored partial index should have reloptions", partialIdxRel);
+      assertTrue("Restored partial index should retain yb_presplit; got: " + partialIdxRel,
+          partialIdxRel.contains("yb_presplit=1"));
     }
 
     try (Statement stmt = connection.createStatement()) {

--- a/java/yb-pgsql/src/test/java/org/yb/pgsql/TestYsqlDumpSplitOptions.java
+++ b/java/yb-pgsql/src/test/java/org/yb/pgsql/TestYsqlDumpSplitOptions.java
@@ -486,15 +486,21 @@ public class TestYsqlDumpSplitOptions extends BasePgSQLTest {
         sentinelCount >= 2);
     assertFalse("Dump should not emit ALTER TABLE RESET (yb_presplit)",
         dumpContent.contains("RESET (yb_presplit)"));
+    // Scope the ordering assertions to the partial index's own CREATE INDEX
+    // statement so matches elsewhere in the dump cannot satisfy them.
     int partialIndexPos = dumpContent.indexOf(
         "CREATE INDEX NONCONCURRENTLY partial_presplit_idx ");
-    int partialIndexPresplitPos = dumpContent.indexOf(
-        " WITH (yb_presplit='1')", partialIndexPos);
-    int partialIndexPredicatePos = dumpContent.indexOf(" WHERE ", partialIndexPos);
-    assertTrue("Dump should place yb_presplit before the partial-index predicate; dump=\n"
-            + dumpContent,
-        partialIndexPos >= 0
-            && partialIndexPresplitPos > partialIndexPos
+    assertTrue("Dump should contain the partial-index CREATE INDEX; dump=\n" + dumpContent,
+        partialIndexPos >= 0);
+    int partialIndexEnd = dumpContent.indexOf(';', partialIndexPos);
+    assertTrue("Partial-index CREATE INDEX should be terminated; dump=\n" + dumpContent,
+        partialIndexEnd >= 0);
+    String partialIndexStmt = dumpContent.substring(partialIndexPos, partialIndexEnd);
+    int partialIndexPresplitPos = partialIndexStmt.indexOf(" WITH (yb_presplit='1')");
+    int partialIndexPredicatePos = partialIndexStmt.indexOf(" WHERE ");
+    assertTrue("Partial index should place yb_presplit before its predicate; statement=\n"
+            + partialIndexStmt,
+        partialIndexPresplitPos >= 0
             && partialIndexPredicatePos > partialIndexPresplitPos);
 
     // Restore the dump into the target database.

--- a/src/postgres/src/bin/pg_dump/pg_dump.c
+++ b/src/postgres/src/bin/pg_dump/pg_dump.c
@@ -20555,6 +20555,9 @@ ybFindIndexdefClause(const char *indexdef, const char *clause)
  * first.  If neither is present, we append it at the end of the indexdef
  * (e.g. for a single-tablet index that still has an explicit reloption to
  * preserve).
+ *
+ * The SQL pg_get_indexdef() used by getIndexes() intentionally omits
+ * TABLESPACE; pg_dump carries it separately in the archive entry metadata.
  */
 static char *
 ybInjectPresplitIntoIndexdef(Archive *fout, const char *indexdef,

--- a/src/postgres/src/bin/pg_dump/pg_dump.c
+++ b/src/postgres/src/bin/pg_dump/pg_dump.c
@@ -380,6 +380,8 @@ static void isDatabaseColocated(Archive *fout);
 static char *extractYbPresplitFromReloptions(const char *reloptions);
 static char *removeYbPresplitFromReloptions(const char *reloptions);
 static bool ybDumpPresplitInCreate(Archive *fout);
+static const char *ybFindIndexdefClause(const char *indexdef,
+										const char *clause);
 static char *ybInjectPresplitIntoIndexdef(Archive *fout, const char *indexdef,
 										  const char *value);
 static char *getYbSplitClause(Archive *fout, const TableInfo *tbinfo);
@@ -20490,6 +20492,52 @@ extractYbPresplitFromReloptions(const char *reloptions)
 	return result;
 }
 
+/* Find a top-level clause, ignoring quoted text and parenthesized expressions. */
+static const char *
+ybFindIndexdefClause(const char *indexdef, const char *clause)
+{
+	const size_t clause_len = strlen(clause);
+	int			paren_depth = 0;
+	char		quote = '\0';
+
+	for (const char *p = indexdef; *p != '\0'; p++)
+	{
+		if (quote != '\0')
+		{
+			if (*p == quote)
+			{
+				if (p[1] == quote)
+					p++;
+				else
+					quote = '\0';
+			}
+			continue;
+		}
+
+		if (*p == '\'' || *p == '"')
+		{
+			quote = *p;
+			continue;
+		}
+		if (*p == '(')
+		{
+			paren_depth++;
+			continue;
+		}
+		if (*p == ')')
+		{
+			if (paren_depth > 0)
+				paren_depth--;
+			continue;
+		}
+
+		if (paren_depth == 0 && strncmp(p, clause, clause_len) == 0)
+			return p;
+	}
+
+	return NULL;
+}
+
 /*
  * YB: Return a newly-allocated copy of `indexdef` with a yb_presplit=<value>
  * entry folded into the WITH clause.
@@ -20501,11 +20549,12 @@ extractYbPresplitFromReloptions(const char *reloptions)
  *
  * `indexdef` is the string produced by pg_get_indexdef(), shaped roughly
  * as "CREATE [UNIQUE] INDEX ... ON tbl USING am (cols) [WITH (opts)]
- * [SPLIT ...]".  We splice the new option into the existing WITH clause
- * if present; otherwise we insert a fresh `WITH (yb_presplit='<value>')`
- * before the SPLIT keyword if present; otherwise we append it at the end
- * of the indexdef (e.g. for a single-tablet index that still has an
- * explicit reloption to preserve).
+ * [SPLIT ...] [WHERE ...]".  We splice the new option into the existing
+ * WITH clause if present; otherwise we insert a fresh
+ * `WITH (yb_presplit='<value>')` before SPLIT or WHERE, whichever comes
+ * first.  If neither is present, we append it at the end of the indexdef
+ * (e.g. for a single-tablet index that still has an explicit reloption to
+ * preserve).
  */
 static char *
 ybInjectPresplitIntoIndexdef(Archive *fout, const char *indexdef,
@@ -20514,6 +20563,8 @@ ybInjectPresplitIntoIndexdef(Archive *fout, const char *indexdef,
 	const char *with_start;
 	const char *with_close;
 	const char *split_start;
+	const char *where_start;
+	const char *insert_start;
 	PQExpBuffer buf;
 	char	   *result;
 
@@ -20522,7 +20573,7 @@ ybInjectPresplitIntoIndexdef(Archive *fout, const char *indexdef,
 	if (!value)
 		value = "";
 
-	with_start = strstr(indexdef, " WITH (");
+	with_start = ybFindIndexdefClause(indexdef, " WITH (");
 	if (with_start != NULL)
 	{
 		/* Find the matching ')' after WITH ( -- the first ')'. */
@@ -20545,19 +20596,24 @@ ybInjectPresplitIntoIndexdef(Archive *fout, const char *indexdef,
 
 	/*
 	 * No existing WITH clause.  Insert a fresh `WITH (yb_presplit='...')`
-	 * before the SPLIT keyword if there is one, otherwise at the end of
-	 * the indexdef.
+	 * before the first SPLIT or WHERE clause, otherwise at the end of the
+	 * indexdef.
 	 */
-	split_start = strstr(indexdef, " SPLIT ");
-	if (split_start == NULL)
-		split_start = indexdef + strlen(indexdef);
+	split_start = ybFindIndexdefClause(indexdef, " SPLIT ");
+	where_start = ybFindIndexdefClause(indexdef, " WHERE ");
+	insert_start = split_start;
+	if (where_start != NULL &&
+		(insert_start == NULL || where_start < insert_start))
+		insert_start = where_start;
+	if (insert_start == NULL)
+		insert_start = indexdef + strlen(indexdef);
 
 	buf = createPQExpBuffer();
-	appendBinaryPQExpBuffer(buf, indexdef, split_start - indexdef);
+	appendBinaryPQExpBuffer(buf, indexdef, insert_start - indexdef);
 	appendPQExpBufferStr(buf, " WITH (yb_presplit=");
 	appendStringLiteralAH(buf, value, fout);
 	appendPQExpBufferChar(buf, ')');
-	appendPQExpBufferStr(buf, split_start);
+	appendPQExpBufferStr(buf, insert_start);
 	result = pg_strdup(buf->data);
 	destroyPQExpBuffer(buf);
 	return result;

--- a/src/postgres/src/bin/pg_dump/pg_dump.c
+++ b/src/postgres/src/bin/pg_dump/pg_dump.c
@@ -380,6 +380,8 @@ static void isDatabaseColocated(Archive *fout);
 static char *extractYbPresplitFromReloptions(const char *reloptions);
 static char *removeYbPresplitFromReloptions(const char *reloptions);
 static bool ybDumpPresplitInCreate(Archive *fout);
+static const char *ybFindIndexdefClause(const char *indexdef,
+										const char *clause);
 static char *ybInjectPresplitIntoIndexdef(Archive *fout, const char *indexdef,
 										  const char *value);
 static char *getYbSplitClause(Archive *fout, const TableInfo *tbinfo);
@@ -20531,6 +20533,52 @@ extractYbPresplitFromReloptions(const char *reloptions)
 	return result;
 }
 
+/* Find a top-level clause, ignoring quoted text and parenthesized expressions. */
+static const char *
+ybFindIndexdefClause(const char *indexdef, const char *clause)
+{
+	const size_t clause_len = strlen(clause);
+	int			paren_depth = 0;
+	char		quote = '\0';
+
+	for (const char *p = indexdef; *p != '\0'; p++)
+	{
+		if (quote != '\0')
+		{
+			if (*p == quote)
+			{
+				if (p[1] == quote)
+					p++;
+				else
+					quote = '\0';
+			}
+			continue;
+		}
+
+		if (*p == '\'' || *p == '"')
+		{
+			quote = *p;
+			continue;
+		}
+		if (*p == '(')
+		{
+			paren_depth++;
+			continue;
+		}
+		if (*p == ')')
+		{
+			if (paren_depth > 0)
+				paren_depth--;
+			continue;
+		}
+
+		if (paren_depth == 0 && strncmp(p, clause, clause_len) == 0)
+			return p;
+	}
+
+	return NULL;
+}
+
 /*
  * YB: Return a newly-allocated copy of `indexdef` with a yb_presplit=<value>
  * entry folded into the WITH clause.
@@ -20542,11 +20590,12 @@ extractYbPresplitFromReloptions(const char *reloptions)
  *
  * `indexdef` is the string produced by pg_get_indexdef(), shaped roughly
  * as "CREATE [UNIQUE] INDEX ... ON tbl USING am (cols) [WITH (opts)]
- * [SPLIT ...]".  We splice the new option into the existing WITH clause
- * if present; otherwise we insert a fresh `WITH (yb_presplit='<value>')`
- * before the SPLIT keyword if present; otherwise we append it at the end
- * of the indexdef (e.g. for a single-tablet index that still has an
- * explicit reloption to preserve).
+ * [SPLIT ...] [WHERE ...]".  We splice the new option into the existing
+ * WITH clause if present; otherwise we insert a fresh
+ * `WITH (yb_presplit='<value>')` before SPLIT or WHERE, whichever comes
+ * first.  If neither is present, we append it at the end of the indexdef
+ * (e.g. for a single-tablet index that still has an explicit reloption to
+ * preserve).
  */
 static char *
 ybInjectPresplitIntoIndexdef(Archive *fout, const char *indexdef,
@@ -20555,6 +20604,8 @@ ybInjectPresplitIntoIndexdef(Archive *fout, const char *indexdef,
 	const char *with_start;
 	const char *with_close;
 	const char *split_start;
+	const char *where_start;
+	const char *insert_start;
 	PQExpBuffer buf;
 	char	   *result;
 
@@ -20563,7 +20614,7 @@ ybInjectPresplitIntoIndexdef(Archive *fout, const char *indexdef,
 	if (!value)
 		value = "";
 
-	with_start = strstr(indexdef, " WITH (");
+	with_start = ybFindIndexdefClause(indexdef, " WITH (");
 	if (with_start != NULL)
 	{
 		/* Find the matching ')' after WITH ( -- the first ')'. */
@@ -20586,19 +20637,24 @@ ybInjectPresplitIntoIndexdef(Archive *fout, const char *indexdef,
 
 	/*
 	 * No existing WITH clause.  Insert a fresh `WITH (yb_presplit='...')`
-	 * before the SPLIT keyword if there is one, otherwise at the end of
-	 * the indexdef.
+	 * before the first SPLIT or WHERE clause, otherwise at the end of the
+	 * indexdef.
 	 */
-	split_start = strstr(indexdef, " SPLIT ");
-	if (split_start == NULL)
-		split_start = indexdef + strlen(indexdef);
+	split_start = ybFindIndexdefClause(indexdef, " SPLIT ");
+	where_start = ybFindIndexdefClause(indexdef, " WHERE ");
+	insert_start = split_start;
+	if (where_start != NULL &&
+		(insert_start == NULL || where_start < insert_start))
+		insert_start = where_start;
+	if (insert_start == NULL)
+		insert_start = indexdef + strlen(indexdef);
 
 	buf = createPQExpBuffer();
-	appendBinaryPQExpBuffer(buf, indexdef, split_start - indexdef);
+	appendBinaryPQExpBuffer(buf, indexdef, insert_start - indexdef);
 	appendPQExpBufferStr(buf, " WITH (yb_presplit=");
 	appendStringLiteralAH(buf, value, fout);
 	appendPQExpBufferChar(buf, ')');
-	appendPQExpBufferStr(buf, split_start);
+	appendPQExpBufferStr(buf, insert_start);
 	result = pg_strdup(buf->data);
 	destroyPQExpBuffer(buf);
 	return result;

--- a/src/postgres/src/bin/pg_dump/pg_dump.c
+++ b/src/postgres/src/bin/pg_dump/pg_dump.c
@@ -20596,6 +20596,9 @@ ybFindIndexdefClause(const char *indexdef, const char *clause)
  * first.  If neither is present, we append it at the end of the indexdef
  * (e.g. for a single-tablet index that still has an explicit reloption to
  * preserve).
+ *
+ * The SQL pg_get_indexdef() used by getIndexes() intentionally omits
+ * TABLESPACE; pg_dump carries it separately in the archive entry metadata.
  */
 static char *
 ybInjectPresplitIntoIndexdef(Archive *fout, const char *indexdef,

--- a/src/postgres/src/bin/pg_dump/pg_dump.c
+++ b/src/postgres/src/bin/pg_dump/pg_dump.c
@@ -20555,6 +20555,14 @@ ybFindIndexdefClause(const char *indexdef, const char *clause)
 			continue;
 		}
 
+		/*
+		 * Check for the clause before consuming *p as a quote or
+		 * parenthesis so a clause that begins with one of those
+		 * characters can still match at top level.
+		 */
+		if (paren_depth == 0 && strncmp(p, clause, clause_len) == 0)
+			return p;
+
 		if (*p == '\'' || *p == '"')
 		{
 			quote = *p;
@@ -20571,9 +20579,6 @@ ybFindIndexdefClause(const char *indexdef, const char *clause)
 				paren_depth--;
 			continue;
 		}
-
-		if (paren_depth == 0 && strncmp(p, clause, clause_len) == 0)
-			return p;
 	}
 
 	return NULL;


### PR DESCRIPTION
## Summary

- preserve `CREATE INDEX` grammar ordering when `ysql_dump` reinserts `yb_presplit` for partial indexes
- ignore clause-like text inside quoted identifiers and parenthesized index expressions when locating insertion points
- add dump-and-restore coverage for a one-tablet partial index with an explicit `yb_presplit` value

Closes #32543

## Upgrade/Rollback safety

No catalog, wire-format, or flag changes. The unpromoted `yb_dump_presplit_in_create=false` path is unchanged. The promoted path only moves the existing `yb_presplit` reloption before a partial-index predicate, using syntax already supported by versions that accept the folded CREATE form.

## Test plan

- [x] `build-support/lint.sh --rev upstream/master` (0 errors)
- [x] Native/PostgreSQL build and `TestYsqlDumpSplitOptions` test-source compilation through `yb_build.sh release`
- [ ] `./yb_build.sh release --java-test 'org.yb.pgsql.TestYsqlDumpSplitOptions#testRestorePreservesPresplitState'` reached mini-cluster setup, but the local sandbox rejected every available loopback bind address before the test method ran