### PR TITLE
[BACKPORT 2025.2][#32550] YSQL: Fix wrong results from DISTINCT pushdown through subquery scan (#32571)

### DIFF
--- a/src/postgres/src/backend/optimizer/path/pathkeys.c
+++ b/src/postgres/src/backend/optimizer/path/pathkeys.c
@@ -2075,3 +2075,48 @@ yb_get_ecs_for_query_uniqkeys(PlannerInfo *root)
 
 	return ecs;
 }
+
+/*
+ * Convert a subquery's uniqkeys into the terms of the outer query.
+ */
+List *
+yb_convert_subquery_uniqkeys(RelOptInfo *rel, List *subquery_uniqkeys,
+							 List *subquery_tlist)
+{
+	List	   *retval = NIL;
+	ListCell   *i;
+
+	foreach(i, subquery_uniqkeys)
+	{
+		Expr	   *uniqkey = (Expr *) lfirst(i);
+		Var		   *outer_var = NULL;
+		ListCell   *j;
+
+		foreach(j, subquery_tlist)
+		{
+			TargetEntry *tle = (TargetEntry *) lfirst(j);
+			Expr	   *tle_expr;
+
+			tle_expr = canonicalize_ec_expression(tle->expr,
+												  exprType((Node *) uniqkey),
+												  exprCollation((Node *) uniqkey));
+			if (!equal(tle_expr, uniqkey))
+				continue;
+
+			outer_var = find_var_for_subquery_tle(rel, tle);
+			if (outer_var)
+				break;
+		}
+
+		/*
+		 * DISTINCT on {a, b} does not imply DISTINCT on {a}.  Therefore,
+		 * if one uniqkey cannot be translated, the whole set must be dropped.
+		 */
+		if (!outer_var)
+			return NIL;
+
+		retval = lappend(retval, outer_var);
+	}
+
+	return retval;
+}

--- a/src/postgres/src/backend/optimizer/util/pathnode.c
+++ b/src/postgres/src/backend/optimizer/util/pathnode.c
@@ -68,6 +68,9 @@ static bool contain_references_to(PlannerInfo *root, Node *clause,
 								  Relids relids);
 static bool ris_contain_references_to(PlannerInfo *root, List *rinfos,
 									  Relids relids);
+/* YB declarations */
+static void yb_propagate_subqueryscan_fields(YbPathInfo *parent_fields,
+											 RelOptInfo *rel, Path *subpath);
 
 
 /*****************************************************************************
@@ -2527,8 +2530,8 @@ create_subqueryscan_path(PlannerInfo *root, RelOptInfo *rel, Path *subpath,
 		subpath->parallel_safe;
 	pathnode->path.parallel_workers = subpath->parallel_workers;
 	pathnode->path.pathkeys = pathkeys;
-	yb_propagate_fields(&pathnode->path.yb_path_info,
-						&subpath->yb_path_info);
+	yb_propagate_subqueryscan_fields(&pathnode->path.yb_path_info, rel,
+									 subpath);
 	pathnode->subpath = subpath;
 
 	cost_subqueryscan(pathnode, root, rel, pathnode->path.param_info);
@@ -5592,4 +5595,27 @@ yb_assign_unique_path_node_id(PlannerInfo *root, Path *path)
 			path->ybHasHintedUid = true;
 		}
 	}
+}
+
+/*
+ * Propagate YugabyteDB fields through a SubqueryScanPath.
+ *
+ * SubqueryScanPath crosses a namespace boundary:
+ * fields represented in the subquery's terms must be translated to
+ * the outer query.
+ */
+static void
+yb_propagate_subqueryscan_fields(YbPathInfo *parent_fields, RelOptInfo *rel,
+								 Path *subpath)
+{
+	if (!IsYugaByteEnabled())
+		return;
+
+	if (subpath->yb_path_info.yb_uniqkeys == NIL)
+		return;
+
+	parent_fields->yb_uniqkeys =
+		yb_convert_subquery_uniqkeys(rel,
+									 subpath->yb_path_info.yb_uniqkeys,
+									 make_tlist_from_pathtarget(subpath->pathtarget));
 }

--- a/src/postgres/src/include/optimizer/paths.h
+++ b/src/postgres/src/include/optimizer/paths.h
@@ -288,5 +288,8 @@ extern int	yb_calculate_distinct_prefixlen(PlannerInfo *root,
 extern bool yb_has_sufficient_uniqkeys(PlannerInfo *root, Path *pathnode);
 extern List *yb_get_ecs_for_query_uniqkeys(PlannerInfo *root);
 extern Path *get_singleton_append_subpath(Path *path);
+extern List *yb_convert_subquery_uniqkeys(RelOptInfo *rel,
+										  List *subquery_uniqkeys,
+										  List *subquery_tlist);
 
 #endif							/* PATHS_H */

--- a/src/postgres/src/test/regress/expected/yb.orig.distinct_pushdown_join.out
+++ b/src/postgres/src/test/regress/expected/yb.orig.distinct_pushdown_join.out
@@ -683,7 +683,343 @@ EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT v FROM t t
 (10 rows)
 
 DROP INDEX irv;
+-- Do not partially translate uniqkeys through a subquery scan.
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT s.r1 FROM (SELECT DISTINCT r1 FROM t WHERE r1 = r2) s;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Unique (actual rows=1 loops=1)
+         ->  Distinct Index Scan using t_pkey on t (actual rows=2 loops=1)
+               Distinct Keys: t.r1, t.r2
+               Storage Filter: (r1 = r2)
+(5 rows)
+
+SELECT DISTINCT s.r1 FROM (SELECT DISTINCT r1 FROM t WHERE r1 = r2) s;
+ r1 
+----
+  1
+(1 row)
+
+-- Retain the outer distinct when the subquery has additional distinct keys.
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT s.r1 FROM (SELECT DISTINCT r1, r2 FROM t) s;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Unique (actual rows=2 loops=1)
+   ->  Subquery Scan on s (actual rows=6 loops=1)
+         ->  Unique (actual rows=6 loops=1)
+               ->  Distinct Index Scan using t_pkey on t (actual rows=7 loops=1)
+                     Distinct Keys: t.r1, t.r2
+(5 rows)
+
+SELECT DISTINCT s.r1 FROM (SELECT DISTINCT r1, r2 FROM t) s;
+ r1 
+----
+  1
+ 10
+(2 rows)
+
 DROP TABLE t;
+CREATE TABLE distinct_expr (a INT);
+INSERT INTO distinct_expr
+  SELECT i % 5 FROM GENERATE_SERIES(1, 1000) AS i;
+ANALYZE distinct_expr;
+-- Do not propagate uniqkeys when the subquery has no distinct pushdown.
+CREATE INDEX distinct_expr_a_idx ON distinct_expr (a ASC);
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT s.a FROM (SELECT DISTINCT a, a + 1 FROM distinct_expr) s ORDER BY 1;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on s (actual rows=5 loops=1)
+   ->  Unique (actual rows=5 loops=1)
+         ->  Sort (actual rows=5 loops=1)
+               Sort Key: distinct_expr.a, ((distinct_expr.a + 1))
+               Sort Method: quicksort
+               ->  Result distinct_expr (actual rows=5 loops=1)
+                     ->  Unique (actual rows=5 loops=1)
+                           ->  Distinct Index Only Scan using distinct_expr_a_idx on distinct_expr (actual rows=5 loops=1)
+                                 Distinct Keys: distinct_expr.a
+                                 Heap Fetches: 0
+(10 rows)
+
+SELECT DISTINCT s.a FROM (SELECT DISTINCT a, a + 1 FROM distinct_expr) s ORDER BY 1;
+ a 
+---
+ 0
+ 1
+ 2
+ 3
+ 4
+(5 rows)
+
+-- Preserve distinct pushdown through a subquery without DISTINCT.
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT s.a FROM (SELECT a FROM distinct_expr) s ORDER BY 1;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Distinct Index Only Scan using distinct_expr_a_idx on distinct_expr (actual rows=5 loops=1)
+         Distinct Keys: distinct_expr.a
+         Heap Fetches: 0
+(4 rows)
+
+SELECT DISTINCT s.a FROM (SELECT a FROM distinct_expr) s ORDER BY 1;
+ a 
+---
+ 0
+ 1
+ 2
+ 3
+ 4
+(5 rows)
+
+-- Translate uniqkeys through nested subquery scans.
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT s2.a FROM (SELECT DISTINCT s1.a FROM (SELECT DISTINCT a FROM distinct_expr) s1) s2 ORDER BY 1;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Distinct Index Only Scan using distinct_expr_a_idx on distinct_expr (actual rows=5 loops=1)
+         Distinct Keys: distinct_expr.a
+         Heap Fetches: 0
+(4 rows)
+
+SELECT DISTINCT s2.a FROM (SELECT DISTINCT s1.a FROM (SELECT DISTINCT a FROM distinct_expr) s1) s2 ORDER BY 1;
+ a 
+---
+ 0
+ 1
+ 2
+ 3
+ 4
+(5 rows)
+
+DROP INDEX distinct_expr_a_idx;
+-- Drop uniqkeys when one key is not exposed by the subquery scan.
+CREATE INDEX distinct_expr_a_expr_idx
+  ON distinct_expr (a ASC, (a + 1) ASC);
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT s.a FROM (SELECT DISTINCT a, a + 1 FROM distinct_expr) s ORDER BY 1;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on s (actual rows=5 loops=1)
+   ->  Unique (actual rows=5 loops=1)
+         ->  Result distinct_expr (actual rows=5 loops=1)
+               ->  Unique (actual rows=5 loops=1)
+                     ->  Distinct Index Only Scan using distinct_expr_a_expr_idx on distinct_expr (actual rows=5 loops=1)
+                           Distinct Keys: distinct_expr.a
+                           Heap Fetches: 0
+(7 rows)
+
+SELECT DISTINCT s.a FROM (SELECT DISTINCT a, a + 1 FROM distinct_expr) s ORDER BY 1;
+ a 
+---
+ 0
+ 1
+ 2
+ 3
+ 4
+(5 rows)
+
+DROP TABLE distinct_expr;
+CREATE DOMAIN dint AS INT4;
+CREATE TABLE td (x dint);
+CREATE INDEX td_x_idx ON td (x ASC);
+INSERT INTO td
+  SELECT (i % 5)::dint FROM GENERATE_SERIES(1, 1000) AS i;
+ANALYZE td;
+-- Translate a domain-to-base relabel through a subquery scan.
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT s.a FROM (SELECT DISTINCT x::INT4 AS a FROM td) s ORDER BY 1;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Result td (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Distinct Index Only Scan using td_x_idx on td (actual rows=5 loops=1)
+                     Distinct Keys: td.x
+                     Heap Fetches: 0
+(6 rows)
+
+SELECT DISTINCT s.a FROM (SELECT DISTINCT x::INT4 AS a FROM td) s ORDER BY 1;
+ a 
+---
+ 0
+ 1
+ 2
+ 3
+ 4
+(5 rows)
+
+DROP TABLE td;
+DROP DOMAIN dint;
+-- Do not translate uniqkeys when collations do not match.
+CREATE TABLE distinct_collate (a TEXT);
+CREATE INDEX distinct_collate_c_idx ON distinct_collate (a COLLATE "C" ASC);
+INSERT INTO distinct_collate
+  SELECT (i % 5)::TEXT FROM GENERATE_SERIES(1, 1000) AS i;
+ANALYZE distinct_collate;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT s.x FROM (SELECT DISTINCT a COLLATE "C" AS x FROM distinct_collate) s ORDER BY 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Result distinct_collate (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Distinct Index Only Scan using distinct_collate_c_idx on distinct_collate (actual rows=5 loops=1)
+                     Distinct Keys: distinct_collate.a
+                     Heap Fetches: 0
+(6 rows)
+
+SELECT DISTINCT s.x FROM (SELECT DISTINCT a COLLATE "C" AS x FROM distinct_collate) s ORDER BY 1;
+ x 
+---
+ 0
+ 1
+ 2
+ 3
+ 4
+(5 rows)
+
+DROP TABLE distinct_collate;
+-- Regression test for untranslated uniqkeys leaking from subquery paths.
+CREATE TABLE distinct_outer(k INT);
+CREATE TABLE distinct_inner(a INT);
+CREATE INDEX distinct_outer_k_idx ON distinct_outer(k ASC);
+CREATE INDEX distinct_inner_a_idx ON distinct_inner(a ASC);
+INSERT INTO distinct_outer
+  SELECT CASE WHEN i <= 500 THEN 1 ELSE 2 END
+  FROM GENERATE_SERIES(1, 1000) AS i;
+INSERT INTO distinct_inner
+  SELECT i % 3
+  FROM GENERATE_SERIES(1, 1000) AS i;
+ANALYZE distinct_outer;
+ANALYZE distinct_inner;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT o.k FROM distinct_outer o, (SELECT DISTINCT a FROM distinct_inner) s ORDER BY 1;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=2 loops=1)
+   ->  Nested Loop (actual rows=6 loops=1)
+         ->  Unique (actual rows=2 loops=1)
+               ->  Distinct Index Only Scan using distinct_outer_k_idx on distinct_outer o (actual rows=2 loops=1)
+                     Distinct Keys: o.k
+                     Heap Fetches: 0
+         ->  Materialize (actual rows=3 loops=2)
+               ->  Subquery Scan on s (actual rows=3 loops=1)
+                     ->  Unique (actual rows=3 loops=1)
+                           ->  Distinct Index Only Scan using distinct_inner_a_idx on distinct_inner (actual rows=3 loops=1)
+                                 Distinct Keys: distinct_inner.a
+                                 Heap Fetches: 0
+(12 rows)
+
+SELECT DISTINCT o.k FROM distinct_outer o, (SELECT DISTINCT a FROM distinct_inner) s ORDER BY 1;
+ k 
+---
+ 1
+ 2
+(2 rows)
+
+-- Propagate uniqkeys from a subquery through a cross join.
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT o.k, s.a FROM distinct_outer o, (SELECT DISTINCT a FROM distinct_inner) s ORDER BY 1, 2;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=6 loops=1)
+   Sort Key: o.k, distinct_inner.a
+   Sort Method: quicksort
+   ->  Nested Loop (actual rows=6 loops=1)
+         ->  Unique (actual rows=2 loops=1)
+               ->  Distinct Index Only Scan using distinct_outer_k_idx on distinct_outer o (actual rows=2 loops=1)
+                     Distinct Keys: o.k
+                     Heap Fetches: 0
+         ->  Materialize (actual rows=3 loops=2)
+               ->  Unique (actual rows=3 loops=1)
+                     ->  Distinct Index Only Scan using distinct_inner_a_idx on distinct_inner (actual rows=3 loops=1)
+                           Distinct Keys: distinct_inner.a
+                           Heap Fetches: 0
+(13 rows)
+
+SELECT DISTINCT o.k, s.a FROM distinct_outer o, (SELECT DISTINCT a FROM distinct_inner) s ORDER BY 1, 2;
+ k | a 
+---+---
+ 1 | 0
+ 1 | 1
+ 1 | 2
+ 2 | 0
+ 2 | 1
+ 2 | 2
+(6 rows)
+
+-- Propagate uniqkeys from a subquery through an inner join.
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT o.k, s.a FROM distinct_outer o, (SELECT DISTINCT a FROM distinct_inner) s WHERE o.k = s.a ORDER BY 1, 2;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Merge Join (actual rows=2 loops=1)
+   Merge Cond: (o.k = distinct_inner.a)
+   ->  Unique (actual rows=2 loops=1)
+         ->  Distinct Index Only Scan using distinct_outer_k_idx on distinct_outer o (actual rows=2 loops=1)
+               Distinct Keys: o.k
+               Heap Fetches: 0
+   ->  Unique (actual rows=3 loops=1)
+         ->  Distinct Index Only Scan using distinct_inner_a_idx on distinct_inner (actual rows=3 loops=1)
+               Distinct Keys: distinct_inner.a
+               Heap Fetches: 0
+(10 rows)
+
+SELECT DISTINCT o.k, s.a FROM distinct_outer o, (SELECT DISTINCT a FROM distinct_inner) s WHERE o.k = s.a ORDER BY 1, 2;
+ k | a 
+---+---
+ 1 | 1
+ 2 | 2
+(2 rows)
+
+-- Handle propagated uniqkeys from the nullable side of a left join.
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT o.k, s.a FROM distinct_outer o LEFT JOIN (SELECT DISTINCT a FROM distinct_inner) s ON o.k = s.a AND s.a = 1 ORDER BY 1, 2;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=2 loops=1)
+   Sort Key: o.k, distinct_inner.a
+   Sort Method: quicksort
+   ->  Hash Right Join (actual rows=2 loops=1)
+         Hash Cond: (distinct_inner.a = o.k)
+         ->  Unique (actual rows=1 loops=1)
+               ->  Distinct Index Only Scan using distinct_inner_a_idx on distinct_inner (actual rows=1 loops=1)
+                     Index Cond: (a = 1)
+                     Distinct Keys: distinct_inner.a
+                     Heap Fetches: 0
+         ->  Hash (actual rows=2 loops=1)
+               Buckets: 1024 (originally 1024)  Original Batches: 1
+               ->  Unique (actual rows=2 loops=1)
+                     ->  Distinct Index Only Scan using distinct_outer_k_idx on distinct_outer o (actual rows=2 loops=1)
+                           Distinct Keys: o.k
+                           Heap Fetches: 0
+(16 rows)
+
+SELECT DISTINCT o.k, s.a FROM distinct_outer o LEFT JOIN (SELECT DISTINCT a FROM distinct_inner) s ON o.k = s.a AND s.a = 1 ORDER BY 1, 2;
+ k | a 
+---+---
+ 1 | 1
+ 2 |  
+(2 rows)
+
+-- Preserve correct results through a UNION subquery.
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT s.x FROM (SELECT k FROM distinct_outer UNION SELECT a FROM distinct_inner) s(x) ORDER BY 1;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Sort (actual rows=3 loops=1)
+   Sort Key: distinct_outer.k
+   Sort Method: quicksort
+   ->  HashAggregate (actual rows=3 loops=1)
+         Group Key: distinct_outer.k
+         ->  HashAggregate (actual rows=3 loops=1)
+               Group Key: distinct_outer.k
+               ->  Append (actual rows=2000 loops=1)
+                     ->  Seq Scan on distinct_outer (actual rows=1000 loops=1)
+                     ->  Seq Scan on distinct_inner (actual rows=1000 loops=1)
+(10 rows)
+
+SELECT DISTINCT s.x FROM (SELECT k FROM distinct_outer UNION SELECT a FROM distinct_inner) s(x) ORDER BY 1;
+ x 
+---
+ 0
+ 1
+ 2
+(3 rows)
+
+DROP TABLE distinct_outer;
+DROP TABLE distinct_inner;
 -- Regression test case for GitHub issue #20827
 CREATE TABLE t1 (col_int_key int, pad int, primary key(col_int_key asc, pad asc));
 INSERT INTO t1 (select 3, i from generate_series(1, 1000) i);

--- a/src/postgres/src/test/regress/sql/yb.orig.distinct_pushdown_join.sql
+++ b/src/postgres/src/test/regress/sql/yb.orig.distinct_pushdown_join.sql
@@ -107,7 +107,106 @@ EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT v FROM t t
 
 DROP INDEX irv;
 
+-- Do not partially translate uniqkeys through a subquery scan.
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT s.r1 FROM (SELECT DISTINCT r1 FROM t WHERE r1 = r2) s;
+SELECT DISTINCT s.r1 FROM (SELECT DISTINCT r1 FROM t WHERE r1 = r2) s;
+
+-- Retain the outer distinct when the subquery has additional distinct keys.
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT s.r1 FROM (SELECT DISTINCT r1, r2 FROM t) s;
+SELECT DISTINCT s.r1 FROM (SELECT DISTINCT r1, r2 FROM t) s;
+
 DROP TABLE t;
+
+CREATE TABLE distinct_expr (a INT);
+INSERT INTO distinct_expr
+  SELECT i % 5 FROM GENERATE_SERIES(1, 1000) AS i;
+ANALYZE distinct_expr;
+
+-- Do not propagate uniqkeys when the subquery has no distinct pushdown.
+CREATE INDEX distinct_expr_a_idx ON distinct_expr (a ASC);
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT s.a FROM (SELECT DISTINCT a, a + 1 FROM distinct_expr) s ORDER BY 1;
+SELECT DISTINCT s.a FROM (SELECT DISTINCT a, a + 1 FROM distinct_expr) s ORDER BY 1;
+
+-- Preserve distinct pushdown through a subquery without DISTINCT.
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT s.a FROM (SELECT a FROM distinct_expr) s ORDER BY 1;
+SELECT DISTINCT s.a FROM (SELECT a FROM distinct_expr) s ORDER BY 1;
+
+-- Translate uniqkeys through nested subquery scans.
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT s2.a FROM (SELECT DISTINCT s1.a FROM (SELECT DISTINCT a FROM distinct_expr) s1) s2 ORDER BY 1;
+SELECT DISTINCT s2.a FROM (SELECT DISTINCT s1.a FROM (SELECT DISTINCT a FROM distinct_expr) s1) s2 ORDER BY 1;
+
+DROP INDEX distinct_expr_a_idx;
+
+-- Drop uniqkeys when one key is not exposed by the subquery scan.
+CREATE INDEX distinct_expr_a_expr_idx
+  ON distinct_expr (a ASC, (a + 1) ASC);
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT s.a FROM (SELECT DISTINCT a, a + 1 FROM distinct_expr) s ORDER BY 1;
+SELECT DISTINCT s.a FROM (SELECT DISTINCT a, a + 1 FROM distinct_expr) s ORDER BY 1;
+
+DROP TABLE distinct_expr;
+
+CREATE DOMAIN dint AS INT4;
+CREATE TABLE td (x dint);
+CREATE INDEX td_x_idx ON td (x ASC);
+INSERT INTO td
+  SELECT (i % 5)::dint FROM GENERATE_SERIES(1, 1000) AS i;
+ANALYZE td;
+
+-- Translate a domain-to-base relabel through a subquery scan.
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT s.a FROM (SELECT DISTINCT x::INT4 AS a FROM td) s ORDER BY 1;
+SELECT DISTINCT s.a FROM (SELECT DISTINCT x::INT4 AS a FROM td) s ORDER BY 1;
+
+DROP TABLE td;
+DROP DOMAIN dint;
+
+-- Do not translate uniqkeys when collations do not match.
+CREATE TABLE distinct_collate (a TEXT);
+CREATE INDEX distinct_collate_c_idx ON distinct_collate (a COLLATE "C" ASC);
+INSERT INTO distinct_collate
+  SELECT (i % 5)::TEXT FROM GENERATE_SERIES(1, 1000) AS i;
+ANALYZE distinct_collate;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT s.x FROM (SELECT DISTINCT a COLLATE "C" AS x FROM distinct_collate) s ORDER BY 1;
+SELECT DISTINCT s.x FROM (SELECT DISTINCT a COLLATE "C" AS x FROM distinct_collate) s ORDER BY 1;
+
+DROP TABLE distinct_collate;
+
+-- Regression test for untranslated uniqkeys leaking from subquery paths.
+CREATE TABLE distinct_outer(k INT);
+CREATE TABLE distinct_inner(a INT);
+CREATE INDEX distinct_outer_k_idx ON distinct_outer(k ASC);
+CREATE INDEX distinct_inner_a_idx ON distinct_inner(a ASC);
+
+INSERT INTO distinct_outer
+  SELECT CASE WHEN i <= 500 THEN 1 ELSE 2 END
+  FROM GENERATE_SERIES(1, 1000) AS i;
+INSERT INTO distinct_inner
+  SELECT i % 3
+  FROM GENERATE_SERIES(1, 1000) AS i;
+ANALYZE distinct_outer;
+ANALYZE distinct_inner;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT o.k FROM distinct_outer o, (SELECT DISTINCT a FROM distinct_inner) s ORDER BY 1;
+SELECT DISTINCT o.k FROM distinct_outer o, (SELECT DISTINCT a FROM distinct_inner) s ORDER BY 1;
+
+-- Propagate uniqkeys from a subquery through a cross join.
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT o.k, s.a FROM distinct_outer o, (SELECT DISTINCT a FROM distinct_inner) s ORDER BY 1, 2;
+SELECT DISTINCT o.k, s.a FROM distinct_outer o, (SELECT DISTINCT a FROM distinct_inner) s ORDER BY 1, 2;
+
+-- Propagate uniqkeys from a subquery through an inner join.
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT o.k, s.a FROM distinct_outer o, (SELECT DISTINCT a FROM distinct_inner) s WHERE o.k = s.a ORDER BY 1, 2;
+SELECT DISTINCT o.k, s.a FROM distinct_outer o, (SELECT DISTINCT a FROM distinct_inner) s WHERE o.k = s.a ORDER BY 1, 2;
+
+-- Handle propagated uniqkeys from the nullable side of a left join.
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT o.k, s.a FROM distinct_outer o LEFT JOIN (SELECT DISTINCT a FROM distinct_inner) s ON o.k = s.a AND s.a = 1 ORDER BY 1, 2;
+SELECT DISTINCT o.k, s.a FROM distinct_outer o LEFT JOIN (SELECT DISTINCT a FROM distinct_inner) s ON o.k = s.a AND s.a = 1 ORDER BY 1, 2;
+
+-- Preserve correct results through a UNION subquery.
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT s.x FROM (SELECT k FROM distinct_outer UNION SELECT a FROM distinct_inner) s(x) ORDER BY 1;
+SELECT DISTINCT s.x FROM (SELECT k FROM distinct_outer UNION SELECT a FROM distinct_inner) s(x) ORDER BY 1;
+
+DROP TABLE distinct_outer;
+DROP TABLE distinct_inner;
 
 -- Regression test case for GitHub issue #20827
 


### PR DESCRIPTION
## Summary

When distinct pushdown is enabled (`yb_enable_distinct_pushdown`),
`create_subqueryscan_path` propagated the subpath's `yb_uniqkeys` (a
distinctness proof) into the outer query verbatim. Those keys are
expressed in the subquery's namespace, so carrying them unchanged let
the outer query treat its rows as already-distinct when they were not
producing duplicate rows despite `SELECT DISTINCT`.

Example of the wrong result:

```sql
SELECT DISTINCT u.k FROM u, (SELECT DISTINCT a FROM t) s ORDER BY u.k;
```

returned duplicate `k` values instead of the distinct set.

This change adds `yb_convert_subquery_uniqkeys`, which translates each
inner uniqkey into the outer query's namespace:

- Match the inner uniqkey against the subquery's target list.
- Map the matched target entry to the `Var` that the subquery scan
actually emits (via `reltarget`).
- If any uniqkey cannot be translated, drop the entire proof
(`yb_uniqkeys = NIL`) so the outer `DISTINCT` remains responsible for
deduplication.

Original commit: ee367279a3e9a333544e9870603df84e64fa9f15 / #32571

## Test plan

Jenkins

Add regression and coverage cases to the yb.orig.distinct_pushdown_join
YSQL regress test:

- Correctness: DISTINCT over a join with a DISTINCT subquery (the
reported
bug) now returns the distinct set instead of duplicate rows; also
covered
through cross join, inner join, the nullable side of a left join, and a
  UNION subquery.
- Translation retained: nested subquery scans, and a domain-to-base
(RelabelType) relabel, keep distinct pushdown and elide the outer
Unique.
- Proof dropped correctly: subquery with extra distinct keys, a key not
  exposed by the subquery scan, an expression index, and a collation
  mismatch all retain the outer Unique.
- Each case asserts both the EXPLAIN plan and the result rows.

## Backport notes

The original commit wrote the new cases using the `parameterized_query` /
`run_query` psql test framework (`\i :run_query`), which does not exist on
2025.2 — that branch still uses the older explicit-`EXPLAIN`/`SELECT` idiom.
Backporting the framework (#30901 + #32688, ~211 files) into a stable branch
is out of scope here, so the added cases were rewritten to the explicit idiom
already used throughout this file on 2025.2. The queries, expected plans, and
result rows are unchanged from the original; only the harness wrapper differs.
