### PR TITLE
[#32681] DocDB: Soft-fail list_tablet_server_log_locations on DEAD tservers

### DIFF
--- a/src/yb/tools/yb-admin-test.cc
+++ b/src/yb/tools/yb-admin-test.cc
@@ -2590,6 +2590,12 @@ TEST_F(AdminCliTest, TestListTabletServerLogLocationsWithDeadTServer) {
   auto output_dead = ASSERT_RESULT(CallAdmin("list_tablet_server_log_locations"));
   ASSERT_STR_CONTAINS(output_dead, ts_uuid);
   ASSERT_STR_CONTAINS(output_dead, "N/A");
+
+  // Dead tserver should sort to the end.
+  const auto dead_row_pos = output_dead.find(ts_uuid);
+  ASSERT_NE(dead_row_pos, std::string::npos);
+  ASSERT_EQ(output_dead.find(ts_uuid, dead_row_pos + 1), std::string::npos);
+  ASSERT_EQ(output_dead.find('\n', dead_row_pos), output_dead.rfind('\n'));
 }
 
 TEST_F(AdminCliTest, TestDisallowImplicitStreamCreation) {

--- a/src/yb/tools/yb-admin-test.cc
+++ b/src/yb/tools/yb-admin-test.cc
@@ -2564,38 +2564,62 @@ TEST_F(AdminCliTest, TestRemoveTabletServer) {
 }
 
 // Regression test for https://github.com/yugabyte/yugabyte-db/issues/32681:
-// list_tablet_server_log_locations must not abort on DEAD tservers.
+// list_tablet_server_log_locations must not abort on DEAD tservers, and must
+// sort alive tservers ahead of dead ones.
 TEST_F(AdminCliTest, TestListTabletServerLogLocationsWithDeadTServer) {
-  ANNOTATE_UNPROTECTED_WRITE(FLAGS_num_tablet_servers) = 1;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_num_tablet_servers) = 2;
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_num_replicas) = 1;
   BuildAndStart({}, {"--enable_load_balancing=false", "--tserver_unresponsive_timeout_ms=5000"});
 
-  const auto ts_uuid = cluster_->tablet_server(0)->uuid();
+  // Kill tserver 0 (the one that sorts first by host/port) and keep tserver 1
+  // alive, so alive-first ordering must actively reorder the two entries rather
+  // than coincidentally matching the host/port tie-break.
+  auto* dead_ts = cluster_->tablet_server(0);
+  auto* alive_ts = cluster_->tablet_server(1);
+  const auto dead_uuid = dead_ts->uuid();
+  const auto alive_uuid = alive_ts->uuid();
 
+  // Helper: extract the LogLocation column for a given tserver UUID.
+  auto log_location_for = [](const std::string& output, const std::string& uuid) -> std::string {
+    std::smatch match;
+    if (!std::regex_search(output, match, std::regex(uuid + R"(\s+\S+\s+(\S+))"))) {
+      return "";
+    }
+    return match[1].str();
+  };
+
+  // While both are alive, both report a real log directory (no N/A).
   auto output_alive = ASSERT_RESULT(CallAdmin("list_tablet_server_log_locations"));
-  ASSERT_STR_CONTAINS(output_alive, ts_uuid);
+  ASSERT_STR_CONTAINS(output_alive, dead_uuid);
+  ASSERT_STR_CONTAINS(output_alive, alive_uuid);
   ASSERT_STR_NOT_CONTAINS(output_alive, "N/A");
 
-  cluster_->tablet_server(0)->Shutdown();
+  dead_ts->Shutdown();
   auto cluster_client =
       master::MasterClusterClient(cluster_->GetLeaderMasterProxy<master::MasterClusterProxy>());
   ASSERT_OK(WaitFor(
-      [&cluster_client, &ts_uuid]() -> Result<bool> {
-        auto tserver = VERIFY_RESULT(cluster_client.GetTabletServer(ts_uuid));
+      [&cluster_client, &dead_uuid]() -> Result<bool> {
+        auto tserver = VERIFY_RESULT(cluster_client.GetTabletServer(dead_uuid));
         return tserver && !tserver->alive();
       },
       30s, "tserver not marked dead"));
 
-  // Must succeed (not connect-timeout abort) and report N/A for the dead tserver.
-  auto output_dead = ASSERT_RESULT(CallAdmin("list_tablet_server_log_locations"));
-  ASSERT_STR_CONTAINS(output_dead, ts_uuid);
-  ASSERT_STR_CONTAINS(output_dead, "N/A");
+  // Must succeed (not connect-timeout abort) and list both tservers.
+  auto output = ASSERT_RESULT(CallAdmin("list_tablet_server_log_locations"));
+  ASSERT_STR_CONTAINS(output, dead_uuid);
+  ASSERT_STR_CONTAINS(output, alive_uuid);
 
-  // Dead tserver should sort to the end.
-  const auto dead_row_pos = output_dead.find(ts_uuid);
-  ASSERT_NE(dead_row_pos, std::string::npos);
-  ASSERT_EQ(output_dead.find(ts_uuid, dead_row_pos + 1), std::string::npos);
-  ASSERT_EQ(output_dead.find('\n', dead_row_pos), output_dead.rfind('\n'));
+  // Alive tserver reports a real log location; dead tserver reports N/A.
+  ASSERT_NE(log_location_for(output, alive_uuid), "N/A");
+  ASSERT_NE(log_location_for(output, alive_uuid), "");
+  ASSERT_EQ(log_location_for(output, dead_uuid), "N/A");
+
+  // Alive tserver sorts ahead of the dead one.
+  const auto alive_pos = output.find(alive_uuid);
+  const auto dead_pos = output.find(dead_uuid);
+  ASSERT_NE(alive_pos, std::string::npos);
+  ASSERT_NE(dead_pos, std::string::npos);
+  ASSERT_LT(alive_pos, dead_pos);
 }
 
 TEST_F(AdminCliTest, TestDisallowImplicitStreamCreation) {

--- a/src/yb/tools/yb-admin-test.cc
+++ b/src/yb/tools/yb-admin-test.cc
@@ -2563,6 +2563,35 @@ TEST_F(AdminCliTest, TestRemoveTabletServer) {
   EXPECT_EQ(find_tserver_result, std::nullopt);
 }
 
+// Regression test for https://github.com/yugabyte/yugabyte-db/issues/32681:
+// list_tablet_server_log_locations must not abort on DEAD tservers.
+TEST_F(AdminCliTest, TestListTabletServerLogLocationsWithDeadTServer) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_num_tablet_servers) = 1;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_num_replicas) = 1;
+  BuildAndStart({}, {"--enable_load_balancing=false", "--tserver_unresponsive_timeout_ms=5000"});
+
+  const auto ts_uuid = cluster_->tablet_server(0)->uuid();
+
+  auto output_alive = ASSERT_RESULT(CallAdmin("list_tablet_server_log_locations"));
+  ASSERT_STR_CONTAINS(output_alive, ts_uuid);
+  ASSERT_STR_NOT_CONTAINS(output_alive, "N/A");
+
+  cluster_->tablet_server(0)->Shutdown();
+  auto cluster_client =
+      master::MasterClusterClient(cluster_->GetLeaderMasterProxy<master::MasterClusterProxy>());
+  ASSERT_OK(WaitFor(
+      [&cluster_client, &ts_uuid]() -> Result<bool> {
+        auto tserver = VERIFY_RESULT(cluster_client.GetTabletServer(ts_uuid));
+        return tserver && !tserver->alive();
+      },
+      30s, "tserver not marked dead"));
+
+  // Must succeed (not connect-timeout abort) and report N/A for the dead tserver.
+  auto output_dead = ASSERT_RESULT(CallAdmin("list_tablet_server_log_locations"));
+  ASSERT_STR_CONTAINS(output_dead, ts_uuid);
+  ASSERT_STR_CONTAINS(output_dead, "N/A");
+}
+
 TEST_F(AdminCliTest, TestDisallowImplicitStreamCreation) {
   std::string test_namespace = "pg_namespace_cdc";
   BuildAndStart();

--- a/src/yb/tools/yb-admin_client.cc
+++ b/src/yb/tools/yb-admin_client.cc
@@ -1480,17 +1480,38 @@ Status ClusterAdminClient::ListTabletServersLogLocations() {
   }
 
   for (const ListTabletServersResponsePB::Entry& server : servers) {
-    auto ts_uuid = server.instance_id().permanent_uuid();
+    const auto& ts_uuid = server.instance_id().permanent_uuid();
+    const auto ts_addr_str = FormatFirstHostPort(
+        server.registration().common().private_rpc_addresses());
 
-    HostPort ts_addr = VERIFY_RESULT(GetFirstRpcAddressForTS(ts_uuid));
+    // Skip RPCs to known-dead tservers and report them as unavailable so one
+    // unreachable node does not abort listing for the rest of the cluster.
+    if (server.has_alive() && !server.alive()) {
+      cout << ts_uuid << kColumnSep << ts_addr_str << kColumnSep << "N/A" << endl;
+      continue;
+    }
 
+    if (!server.has_registration() ||
+        server.registration().common().private_rpc_addresses().empty()) {
+      LOG(WARNING) << "Tablet server " << ts_uuid << " has no RPC address registered";
+      cout << ts_uuid << kColumnSep << ts_addr_str << kColumnSep << "N/A" << endl;
+      continue;
+    }
+
+    HostPort ts_addr = HostPortFromPB(server.registration().common().private_rpc_addresses(0));
     TabletServerServiceProxy ts_proxy(proxy_cache_.get(), ts_addr);
 
-    const auto resp = VERIFY_RESULT(InvokeRpc(
-        &TabletServerServiceProxy::GetLogLocation, ts_proxy, tserver::GetLogLocationRequestPB()));
+    auto resp = InvokeRpc(
+        &TabletServerServiceProxy::GetLogLocation, ts_proxy, tserver::GetLogLocationRequestPB());
+    if (!resp.ok()) {
+      LOG(WARNING) << "Unable to get log location from tablet server " << ts_uuid
+                   << " at " << ts_addr << ": " << resp.status();
+      cout << ts_uuid << kColumnSep << ts_addr_str << kColumnSep << "N/A" << endl;
+      continue;
+    }
     cout << ts_uuid << kColumnSep
-         << ts_addr << kColumnSep
-         << resp.log_location() << endl;
+         << ts_addr_str << kColumnSep
+         << resp->log_location() << endl;
   }
 
   return Status::OK();

--- a/src/yb/tools/yb-admin_client.cc
+++ b/src/yb/tools/yb-admin_client.cc
@@ -1471,6 +1471,9 @@ Status ClusterAdminClient::ListAllMasters() {
 Status ClusterAdminClient::ListTabletServersLogLocations() {
   RepeatedPtrField<ListTabletServersResponsePB::Entry> servers;
   RETURN_NOT_OK(ListTabletServers(&servers));
+  // Sort alive tservers first so unreachable (DEAD/unknown) nodes appear last,
+  // matching the ordering of list_all_tablet_servers.
+  SortListTabletServerEntries(servers);
 
   if (!servers.empty()) {
     cout << RightPadToUuidWidth("TS UUID") << kColumnSep


### PR DESCRIPTION
## Summary

`yb-admin list_tablet_server_log_locations` aborted with a connect timeout when the master's tablet-server registry still contained DEAD entries. The command issued `GetLogLocation` to every registered tserver and failed the whole listing on the first `VERIFY_RESULT` error.

This change:
- Skips RPCs to known-DEAD tservers and reports their log location as `N/A`
- Soft-fails per-server RPC / missing-address errors so live tservers still list
- Uses the RPC address from the already-fetched `ListTabletServers` entry (avoids re-listing per server)
- Sorts tservers alive-first (reusing `SortListTabletServerEntries`) so unreachable nodes appear last, matching `list_all_tablet_servers`

## Example

Cluster with 6 tservers where `192.0.2.5` and `192.0.2.6` are DEAD.

Server list:

```
yb-admin --master_addresses 192.0.2.159,192.0.2.114 list_all_tablet_servers
    Tablet Server UUID               RPC Host/Port     Heartbeat delay Status   Reads/s  Writes/s Uptime   SST total size  SST uncomp size SST #files      Memory   Broadcast Host/Port
    02bb1fd6c6fa4d418448524aa00ee691 192.0.2.106:9100  0.59s           ALIVE    0.00     0.00     8351     0 B             0 B             0               62.99 MB N/A
    338e9dee7ab84560a8cd53dc7dc89ef4 192.0.2.114:9100  0.44s           ALIVE    0.00     0.00     6198     0 B             0 B             0               57.34 MB N/A
    cd3105d3bd5540d899d2a0f073c2105a 192.0.2.144:9100  0.86s           ALIVE    0.00     0.00     2855     333.44 KB       337.00 KB       5               54.91 MB N/A
    ee6a69e00dc04a14a0f70be7927a9cc4 192.0.2.159:9100  0.66s           ALIVE    0.00     0.00     6067     133.81 KB       136.44 KB       2               61.48 MB N/A
    1fb95dd124e54edb858c71fa6e06ea1b 192.0.2.111:9100  5783.08s        DEAD     0.00     0.00     0        0 B             0 B             0               0 B      N/A
    8a301f6b02af46c8a5d7c85ab4bdfdcf 192.0.2.182:9100  5770.50s        DEAD     0.00     0.00     0        0 B             0 B             0               0 B      N/A
```

**Without this fix** : aborts on the first unreachable tserver, hiding the rest:

    $ yb-admin --master_addresses 192.0.2.1,192.0.2.2 list_tablet_server_log_locations
    TS UUID                            RPC Host/Port    LogLocation
    0000000000000000000000000000aaaa   192.0.2.1:9100   /mnt/d0/yb-data/tserver/logs
    Error running list_tablet_server_log_locations: Network error (yb/rpc/connection.cc:268): Unable to list tablet server log locations: Connect timeout ... => 192.0.2.5:9100, passed: 14.987s, timeout: 15.000s: kConnectFailed (network error 1)

**With this fix** : lists every tserver, DEAD nodes show `N/A` and sort last:

    $ yb-admin --master_addresses 192.0.2.1,192.0.2.2 list_tablet_server_log_locations
    TS UUID                            RPC Host/Port    LogLocation
    0000000000000000000000000000aaaa   192.0.2.1:9100   /mnt/d0/yb-data/tserver/logs
    0000000000000000000000000000bbbb   192.0.2.2:9100   /mnt/d0/yb-data/tserver/logs
    0000000000000000000000000000cccc   192.0.2.3:9100   /mnt/d0/yb-data/tserver/logs
    0000000000000000000000000000dddd   192.0.2.4:9100   /mnt/d0/yb-data/tserver/logs
    0000000000000000000000000000eeee   192.0.2.5:9100   N/A
    0000000000000000000000000000ffff   192.0.2.6:9100   N/A

## Test plan

- [x] `./yb_build.sh release --cxx-test yb-admin-test --gtest_filter AdminCliTest.TestListTabletServerLogLocationsWithDeadTServer`
- [x] Manually ran `yb-admin list_tablet_server_log_locations` against a cluster with DEAD tservers: exits 0, live nodes show log dirs, dead nodes show `N/A`
