### PR TITLE
[#32240] YSQL: Preserve setseed semantics for random filters

### DIFF
--- a/src/postgres/src/backend/executor/ybExpr.c
+++ b/src/postgres/src/backend/executor/ybExpr.c
@@ -302,16 +302,6 @@ yb_can_pushdown_func(Oid funcid)
 
 	/*
 	 * Check whether this function is on a list of hand-picked functions
-	 * safe for pushdown.
-	 */
-	for (int i = 0; i < yb_funcs_safe_for_pushdown_count; ++i)
-	{
-		if (funcid == yb_funcs_safe_for_pushdown[i])
-			return true;
-	}
-
-	/*
-	 * Check whether this function is on a list of hand-picked functions
 	 * that cannot be pushed down.
 	 */
 	for (int i = 0; i < yb_funcs_unsafe_for_pushdown_count; ++i)

--- a/src/postgres/src/backend/utils/misc/yb_exceptions_for_func_pushdown.c
+++ b/src/postgres/src/backend/utils/misc/yb_exceptions_for_func_pushdown.c
@@ -1,8 +1,7 @@
 /*-------------------------------------------------------------------------
  *
  * yb_exceptions_for_func_pushdown.c
- *    List of non-immutable functions that do not perform any accesses to
- *    the database.
+ *    Lists of exceptions for function pushdown.
  *
  * Copyright (c) YugabyteDB, Inc.
  *
@@ -29,10 +28,6 @@
 #include "catalog/pg_operator_d.h"
 #include "nodes/primnodes.h"
 #include "utils/fmgroids.h"
-
-const uint32 yb_funcs_safe_for_pushdown[] = {
-	F_RANDOM
-};
 
 const uint32 yb_funcs_unsafe_for_pushdown[] = {
 	/* to_tsany.c */
@@ -245,7 +240,6 @@ const SQLValueFunctionOp yb_pushdown_sqlvaluefunctions[] = {
 
 #define DEFINE_ARRAY_SIZE(array) const int array##_count = lengthof(array)
 
-DEFINE_ARRAY_SIZE(yb_funcs_safe_for_pushdown);
 DEFINE_ARRAY_SIZE(yb_funcs_unsafe_for_pushdown);
 DEFINE_ARRAY_SIZE(yb_funcs_safe_for_mixed_mode_pushdown);
 DEFINE_ARRAY_SIZE(yb_pushdown_funcs_to_constify);

--- a/src/postgres/src/include/pg_yb_utils.h
+++ b/src/postgres/src/include/pg_yb_utils.h
@@ -1250,14 +1250,6 @@ bool		IsYbExtensionUser(Oid member);
 bool		IsYbFdwUser(Oid member);
 
 /*
- * Array of IDs of non-immutable functions that do not perform any database
- * lookups or writes. When these functions are used in an INSERT/UPDATE/DELETE
- * statement, they will not cause the actual modify statement to become a
- * cross shard operation.
- */
-extern const uint32 yb_funcs_safe_for_pushdown[];
-
-/*
  * These functions are unsafe to run in a multi-threaded environment. There is
  * no specific attribute that identifies them as such, so we have to manually
  * identify them.
@@ -1286,7 +1278,6 @@ extern const SQLValueFunctionOp yb_pushdown_sqlvaluefunctions[];
 /*
  * Number of functions in the lists above.
  */
-extern const int yb_funcs_safe_for_pushdown_count;
 extern const int yb_funcs_unsafe_for_pushdown_count;
 extern const int yb_funcs_safe_for_mixed_mode_pushdown_count;
 extern const int yb_pushdown_funcs_to_constify_count;

--- a/src/postgres/src/test/regress/expected/yb.orig.distinct_pushdown_join.out
+++ b/src/postgres/src/test/regress/expected/yb.orig.distinct_pushdown_join.out
@@ -363,19 +363,20 @@ EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) /*+Nestloop(t1 t2)*/ SELEC
 \set _echo_run_query :ECHO
 \set ECHO none
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT t1.r1 FROM t t1 JOIN t t2 ON t1.r1 = t2.r2 WHERE t1.r1 + RANDOM() < 5;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
  HashAggregate (actual rows=1 loops=1)
    Group Key: t1.r1
    ->  Hash Join (actual rows=3000 loops=1)
          Hash Cond: (t1.r1 = t2.r2)
          ->  Seq Scan on t t1 (actual rows=1000 loops=1)
-               Storage Filter: (((r1)::double precision + random()) < '5'::double precision)
+               Filter: (((r1)::double precision + random()) < '5'::double precision)
+               Rows Removed by Filter: 1000
          ->  Hash (actual rows=7 loops=1)
                Buckets: 1024 (originally 1024)  Original Batches: 1
                ->  Distinct Index Scan using t_pkey on t t2 (actual rows=7 loops=1)
                      Distinct Keys: t2.r1, t2.r2
-(10 rows)
+(11 rows)
 
 SELECT DISTINCT t1.r1 FROM t t1 JOIN t t2 ON t1.r1 = t2.r2 WHERE t1.r1 + RANDOM() < 5;
  r1 
@@ -388,8 +389,8 @@ SELECT DISTINCT t1.r1 FROM t t1 JOIN t t2 ON t1.r1 = t2.r2 WHERE t1.r1 + RANDOM(
 \set _echo_run_query :ECHO
 \set ECHO none
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT t1.r1 FROM t t1 JOIN t t2 USING (r1) JOIN t t3 USING (r1) WHERE t3.r1 + RANDOM() < 5;
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
  Unique (actual rows=1 loops=1)
    ->  Merge Join (actual rows=1000 loops=1)
          Merge Cond: (t2.r1 = t1.r1)
@@ -404,8 +405,9 @@ EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT t1.r1 FROM
                                  Distinct Keys: t1.r1
                      ->  Materialize (actual rows=1000 loops=1)
                            ->  Index Scan using t_pkey on t t3 (actual rows=1000 loops=1)
-                                 Storage Filter: (((r1)::double precision + random()) < '5'::double precision)
-(15 rows)
+                                 Filter: (((r1)::double precision + random()) < '5'::double precision)
+                                 Rows Removed by Filter: 1000
+(16 rows)
 
 SELECT DISTINCT t1.r1 FROM t t1 JOIN t t2 USING (r1) JOIN t t3 USING (r1) WHERE t3.r1 + RANDOM() < 5;
  r1 

--- a/src/postgres/src/test/regress/expected/yb.orig.distinct_pushdown_pred.out
+++ b/src/postgres/src/test/regress/expected/yb.orig.distinct_pushdown_pred.out
@@ -326,12 +326,12 @@ SELECT DISTINCT 0 * r1 AS r FROM t;
 -- In general, volatile expressions may have side effects, so they need to be run
 -- for each tuple. Cannot use a distinct index scan in that case.
 EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT r1 FROM t WHERE r1 * RANDOM() > 1;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
  HashAggregate
    Group Key: r1
    ->  Seq Scan on t
-         Storage Filter: (((r1)::double precision * random()) > '1'::double precision)
+         Filter: (((r1)::double precision * random()) > '1'::double precision)
 (4 rows)
 
 EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT r1 * RANDOM() AS r FROM t;

--- a/src/postgres/src/test/regress/expected/yb.orig.dml_pushdown.out
+++ b/src/postgres/src/test/regress/expected/yb.orig.dml_pushdown.out
@@ -931,8 +931,7 @@ EXPLAIN (COSTS OFF) UPDATE single_row_function_test SET v=getpgusername() WHERE 
    ->  Result single_row_function_test
 (2 rows)
 
--- Verify that using supported non-immutable functions (like random(), NOW(), timestamp, timestampz etc) which do not perform reads or writes to the database
--- to assign values/WHERE clause does not prevent the use of fast-path.
+-- Verify that locally evaluable non-immutable assignment expressions do not prevent the use of fast-path.
 EXPLAIN (COSTS OFF) UPDATE single_row_function_test SET created_at = '2022-01-01 00:00:00'::TIMESTAMP WITH TIME ZONE, random_field = ceil(random())::int  WHERE date_pk = NOW() AND k = 1;
               QUERY PLAN               
 ---------------------------------------
@@ -940,14 +939,15 @@ EXPLAIN (COSTS OFF) UPDATE single_row_function_test SET created_at = '2022-01-01
    ->  Result single_row_function_test
 (2 rows)
 
--- Verify that even if the function used in the WHERE clause is a supported but volatile function, the fast path is still disabled.
+-- Verify that a volatile function in the WHERE clause disables fast-path and remains a local filter.
 EXPLAIN (COSTS OFF) UPDATE single_row_function_test SET created_at = '2022-01-01 00:00:00'::TIMESTAMP WITH TIME ZONE, random_field = ceil(random())::int  WHERE date_pk = NOW() AND k = random()::int;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                 QUERY PLAN                 
+--------------------------------------------
  Update on single_row_function_test
    ->  Seq Scan on single_row_function_test
-         Storage Filter: ((date_pk = now()) AND (k = (random())::integer))
-(3 rows)
+         Storage Filter: (date_pk = now())
+         Filter: (k = (random())::integer)
+(4 rows)
 
 DROP TABLE single_row_function_test;
 -- Test execution.

--- a/src/postgres/src/test/regress/expected/yb.orig.dml_single_row.out
+++ b/src/postgres/src/test/regress/expected/yb.orig.dml_single_row.out
@@ -858,8 +858,7 @@ EXPLAIN (COSTS OFF) UPDATE single_row_function_test SET v=getpgusername() WHERE 
    ->  Result single_row_function_test
 (2 rows)
 
--- Verify that using supported non-immutable functions (like random(), NOW(), timestamp, timestampz etc) which do not perform reads or writes to the database
--- to assign values/WHERE clause does not prevent the use of fast-path.
+-- Verify that locally evaluable non-immutable assignment expressions do not prevent the use of fast-path.
 EXPLAIN (COSTS OFF) UPDATE single_row_function_test SET created_at = '2022-01-01 00:00:00'::TIMESTAMP WITH TIME ZONE, random_field = ceil(random())::int  WHERE date_pk = NOW() AND k = 1;
               QUERY PLAN               
 ---------------------------------------
@@ -867,7 +866,7 @@ EXPLAIN (COSTS OFF) UPDATE single_row_function_test SET created_at = '2022-01-01
    ->  Result single_row_function_test
 (2 rows)
 
--- Verify that even if the function used in the WHERE clause is a supported but volatile function, the fast path is still disabled.
+-- Verify that a volatile function in the WHERE clause disables fast-path and remains a local filter.
 EXPLAIN (COSTS OFF) UPDATE single_row_function_test SET created_at = '2022-01-01 00:00:00'::TIMESTAMP WITH TIME ZONE, random_field = ceil(random())::int  WHERE date_pk = NOW() AND k = random()::int;
                             QUERY PLAN                             
 -------------------------------------------------------------------

--- a/src/postgres/src/test/regress/expected/yb.orig.select_no_pushdown.out
+++ b/src/postgres/src/test/regress/expected/yb.orig.select_no_pushdown.out
@@ -87,7 +87,7 @@ SELECT * FROM pushdown_test WHERE left(t1, i1) = 'v';
  1 |  1 | value1 | Thu Nov 11 11:11:11 2021 | Thu Nov 11 10:11:11 2021 UTC | empty | {1,NULL,42}
 (1 row)
 
--- Functions safe for pushdown (yb_safe_funcs_for_pushdown.c)
+-- Volatile function
 EXPLAIN (COSTS FALSE) SELECT * FROM pushdown_test WHERE i1 < 10 + random() * 90;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
@@ -101,6 +101,38 @@ SELECT * FROM pushdown_test WHERE i1 < 10 + random() * 90;
  1 |  1 | value1 | Thu Nov 11 11:11:11 2021 | Thu Nov 11 10:11:11 2021 UTC | empty | {1,NULL,42}
 (1 row)
 
+-- random() uses backend-local state controlled by setseed(), so it must remain
+-- a local filter even when expression pushdown is enabled.
+SET yb_enable_expression_pushdown to on;
+EXPLAIN (COSTS FALSE) SELECT count(*) FROM pushdown_test WHERE random() < 0.5;
+                      QUERY PLAN                      
+------------------------------------------------------
+ Aggregate
+   ->  Seq Scan on pushdown_test
+         Filter: (random() < '0.5'::double precision)
+(3 rows)
+
+SELECT setseed(0.41);
+ setseed 
+---------
+ 
+(1 row)
+
+SELECT count(*) AS seeded_count FROM pushdown_test WHERE random() < 0.5 \gset
+SELECT setseed(0.41);
+ setseed 
+---------
+ 
+(1 row)
+
+SELECT count(*) = :seeded_count AS seeded_random_repeats
+  FROM pushdown_test WHERE random() < 0.5;
+ seeded_random_repeats 
+-----------------------
+ t
+(1 row)
+
+SET yb_enable_expression_pushdown to off;
 -- Null test
 EXPLAIN (COSTS FALSE) SELECT * FROM pushdown_test WHERE ts1 IS NULL;
         QUERY PLAN         

--- a/src/postgres/src/test/regress/expected/yb.orig.ybgin_pushdown.out
+++ b/src/postgres/src/test/regress/expected/yb.orig.ybgin_pushdown.out
@@ -125,7 +125,7 @@ SELECT * FROM gin_pushdown WHERE json_content @> '{"refs": [{"val":"9"}]}' AND j
  9  | 9    | 9      | {"refs": [{"val": "9"}, {"val": "10"}]}
 (1 row)
 
--- Expression that does not refer any columns can go to the index.
+-- Volatile expressions cannot be pushed to the index.
 SELECT $$
 :P SELECT * FROM gin_pushdown WHERE json_content @> '{"refs": [{"val":"9"}]}' AND random() > 2.0;
 $$ AS query \gset
@@ -137,7 +137,7 @@ EXPLAIN (costs off) SELECT * FROM gin_pushdown WHERE json_content @> '{"refs": [
 -------------------------------------------------------------------
  Index Scan using gin_pushdown_json_content_idx on gin_pushdown
    Index Cond: (json_content @> '{"refs": [{"val": "9"}]}'::jsonb)
-   Storage Index Filter: (random() > '2'::double precision)
+   Filter: (random() > '2'::double precision)
 (3 rows)
 
 SELECT * FROM gin_pushdown WHERE json_content @> '{"refs": [{"val":"9"}]}' AND random() > 2.0;
@@ -156,7 +156,7 @@ EXPLAIN (costs off) SELECT * FROM gin_pushdown WHERE json_content @> '{"refs": [
 -------------------------------------------------------------------
  Index Scan using gin_pushdown_json_content_idx on gin_pushdown
    Index Cond: (json_content @> '{"refs": [{"val": "9"}]}'::jsonb)
-   Storage Index Filter: (random() < '2'::double precision)
+   Filter: (random() < '2'::double precision)
 (3 rows)
 
 SELECT * FROM gin_pushdown WHERE json_content @> '{"refs": [{"val":"9"}]}' AND random() < 2.0;
@@ -266,7 +266,7 @@ SELECT * FROM gin_pushdown WHERE guid = '9' AND json_content->'refs'->0->'val' =
  9  | 9    | 9      | {"refs": [{"val": "9"}, {"val": "10"}]}
 (1 row)
 
--- Expression that does not refer any columns can go to the index.
+-- Volatile expressions cannot be pushed to the index.
 SELECT $$
 :P SELECT * FROM gin_pushdown WHERE guid = '9' AND random() > 2.0;
 $$ AS query \gset
@@ -274,11 +274,11 @@ $$ AS query \gset
 \set _echo_run_query :ECHO
 \set ECHO none
 EXPLAIN (costs off) SELECT * FROM gin_pushdown WHERE guid = '9' AND random() > 2.0;
-                         QUERY PLAN                         
-------------------------------------------------------------
+                       QUERY PLAN                       
+--------------------------------------------------------
  Index Scan using gin_pushdown_guid_key on gin_pushdown
    Index Cond: ((guid)::text = '9'::text)
-   Storage Index Filter: (random() > '2'::double precision)
+   Filter: (random() > '2'::double precision)
 (3 rows)
 
 SELECT * FROM gin_pushdown WHERE guid = '9' AND random() > 2.0;
@@ -293,11 +293,11 @@ $$ AS query \gset
 \set _echo_run_query :ECHO
 \set ECHO none
 EXPLAIN (costs off) SELECT * FROM gin_pushdown WHERE guid = '9' AND random() < 2.0;
-                         QUERY PLAN                         
-------------------------------------------------------------
+                       QUERY PLAN                       
+--------------------------------------------------------
  Index Scan using gin_pushdown_guid_key on gin_pushdown
    Index Cond: ((guid)::text = '9'::text)
-   Storage Index Filter: (random() < '2'::double precision)
+   Filter: (random() < '2'::double precision)
 (3 rows)
 
 SELECT * FROM gin_pushdown WHERE guid = '9' AND random() < 2.0;

--- a/src/postgres/src/test/regress/sql/yb.orig.dml_pushdown.sql
+++ b/src/postgres/src/test/regress/sql/yb.orig.dml_pushdown.sql
@@ -284,11 +284,10 @@ EXPLAIN (COSTS OFF) UPDATE single_row_function_test SET random_field = 2 WHERE k
 -- Verify that using unsupported non-immutable functions to assign values does not disable the use of fast path.
 EXPLAIN (COSTS OFF) UPDATE single_row_function_test SET v=getpgusername() WHERE k = 1 AND date_pk = NOW();
 
--- Verify that using supported non-immutable functions (like random(), NOW(), timestamp, timestampz etc) which do not perform reads or writes to the database
--- to assign values/WHERE clause does not prevent the use of fast-path.
+-- Verify that locally evaluable non-immutable assignment expressions do not prevent the use of fast-path.
 EXPLAIN (COSTS OFF) UPDATE single_row_function_test SET created_at = '2022-01-01 00:00:00'::TIMESTAMP WITH TIME ZONE, random_field = ceil(random())::int  WHERE date_pk = NOW() AND k = 1;
 
--- Verify that even if the function used in the WHERE clause is a supported but volatile function, the fast path is still disabled.
+-- Verify that a volatile function in the WHERE clause disables fast-path and remains a local filter.
 EXPLAIN (COSTS OFF) UPDATE single_row_function_test SET created_at = '2022-01-01 00:00:00'::TIMESTAMP WITH TIME ZONE, random_field = ceil(random())::int  WHERE date_pk = NOW() AND k = random()::int;
 DROP TABLE single_row_function_test;
 

--- a/src/postgres/src/test/regress/sql/yb.orig.dml_single_row.sql
+++ b/src/postgres/src/test/regress/sql/yb.orig.dml_single_row.sql
@@ -254,11 +254,10 @@ EXPLAIN (COSTS OFF) UPDATE single_row_function_test SET random_field = 2 WHERE k
 -- Verify that using unsupported non-immutable functions to assign values does not disable the use of fast path.
 EXPLAIN (COSTS OFF) UPDATE single_row_function_test SET v=getpgusername() WHERE k = 1 AND date_pk = NOW();
 
--- Verify that using supported non-immutable functions (like random(), NOW(), timestamp, timestampz etc) which do not perform reads or writes to the database
--- to assign values/WHERE clause does not prevent the use of fast-path.
+-- Verify that locally evaluable non-immutable assignment expressions do not prevent the use of fast-path.
 EXPLAIN (COSTS OFF) UPDATE single_row_function_test SET created_at = '2022-01-01 00:00:00'::TIMESTAMP WITH TIME ZONE, random_field = ceil(random())::int  WHERE date_pk = NOW() AND k = 1;
 
--- Verify that even if the function used in the WHERE clause is a supported but volatile function, the fast path is still disabled.
+-- Verify that a volatile function in the WHERE clause disables fast-path and remains a local filter.
 EXPLAIN (COSTS OFF) UPDATE single_row_function_test SET created_at = '2022-01-01 00:00:00'::TIMESTAMP WITH TIME ZONE, random_field = ceil(random())::int  WHERE date_pk = NOW() AND k = random()::int;
 DROP TABLE single_row_function_test;
 

--- a/src/postgres/src/test/regress/sql/yb.orig.select_no_pushdown.sql
+++ b/src/postgres/src/test/regress/sql/yb.orig.select_no_pushdown.sql
@@ -28,10 +28,22 @@ EXPLAIN (COSTS FALSE) SELECT * FROM pushdown_test WHERE left(t1, i1) = 'v';
 
 SELECT * FROM pushdown_test WHERE left(t1, i1) = 'v';
 
--- Functions safe for pushdown (yb_safe_funcs_for_pushdown.c)
+-- Volatile function
 EXPLAIN (COSTS FALSE) SELECT * FROM pushdown_test WHERE i1 < 10 + random() * 90;
 
 SELECT * FROM pushdown_test WHERE i1 < 10 + random() * 90;
+
+-- random() uses backend-local state controlled by setseed(), so it must remain
+-- a local filter even when expression pushdown is enabled.
+SET yb_enable_expression_pushdown to on;
+EXPLAIN (COSTS FALSE) SELECT count(*) FROM pushdown_test WHERE random() < 0.5;
+
+SELECT setseed(0.41);
+SELECT count(*) AS seeded_count FROM pushdown_test WHERE random() < 0.5 \gset
+SELECT setseed(0.41);
+SELECT count(*) = :seeded_count AS seeded_random_repeats
+  FROM pushdown_test WHERE random() < 0.5;
+SET yb_enable_expression_pushdown to off;
 
 -- Null test
 EXPLAIN (COSTS FALSE) SELECT * FROM pushdown_test WHERE ts1 IS NULL;

--- a/src/postgres/src/test/regress/sql/yb.orig.ybgin_pushdown.sql
+++ b/src/postgres/src/test/regress/sql/yb.orig.ybgin_pushdown.sql
@@ -51,7 +51,7 @@ SELECT $$
 $$ AS query \gset
 \i :run_query
 
--- Expression that does not refer any columns can go to the index.
+-- Volatile expressions cannot be pushed to the index.
 SELECT $$
 :P SELECT * FROM gin_pushdown WHERE json_content @> '{"refs": [{"val":"9"}]}' AND random() > 2.0;
 $$ AS query \gset
@@ -87,7 +87,7 @@ SELECT $$
 $$ AS query \gset
 \i :run_query
 
--- Expression that does not refer any columns can go to the index.
+-- Volatile expressions cannot be pushed to the index.
 SELECT $$
 :P SELECT * FROM gin_pushdown WHERE guid = '9' AND random() > 2.0;
 $$ AS query \gset


### PR DESCRIPTION
## Summary

`random()` is volatile and uses session-local PRNG state, but YSQL treated it as
the sole non-immutable function safe for DocDB expression pushdown. As a result,
`setseed()` seeded the YSQL backend while pushed filters consumed unrelated
TServer PRNG state.

Remove the obsolete non-immutable safe-function allowlist so the existing
immutability check keeps `random()` in YSQL. Update affected plans and add a
regression proving identically seeded scans repeat with expression pushdown
enabled.

Closes https://github.com/yugabyte/yugabyte-db/issues/32240

## Test plan

- [x] `./yb_build.sh release daemons initdb --sj --skip-pg-parquet --no-odyssey --no-ybc`
- [x] `./yb_build.sh release --java-test 'org.yb.pgsql.TestPgRegressDml#schedule'`
- [x] `./yb_build.sh release --java-test 'org.yb.pgsql.TestPgRegressDistinctPushdown#testPgRegressDistinctPushdown'`
- [x] `./yb_build.sh release --java-test 'org.yb.pgsql.TestPgRegressGin#testPgRegressGin'`
- [x] Reproduced the original 100,000-row query with pushdown enabled; `EXPLAIN` uses a local `Filter` and three runs after `setseed(0.41)` each returned `50027`.
- [x] `./yb_build.sh release --java-test 'org.yb.pgsql.TestPgRegressPushdown#testPgRegressPushdown'` — the new `yb.orig.select_no_pushdown` regression passes; the containing suite remains red only because unrelated `yb.orig.dml_single_row` `Storage Flush Requests` counters differ from its existing golden output.
