### PR TITLE
[BACKPORT 2025.2][#28753] DocDB: Use uniform base-1000 (GB/MB/KB) disk size units in Master and T-Server UIs (#32591)

### DIFF
--- a/src/yb/gutil/strings/numbers.cc
+++ b/src/yb/gutil/strings/numbers.cc
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <cmath>
 #include <iomanip>
 #include <limits>
 #include <sstream>
@@ -1522,23 +1523,41 @@ string UInt64ToString(uint64 ui64, const char* format) {
   return StringPrintf(format, ui64);
 }
 
-namespace {
-  constexpr int64_t kBytesPerGB = 1000000000;
-  constexpr int64_t kBytesPerMB = 1000000;
-  constexpr int64_t kBytesPerKB = 1000;
-}
-
 string HumanizeBytes(uint64_t bytes, int precision) {
+  // Decimal (base 1000) units with explicit labels, scaling all the way up to
+  // exabytes so that large sizes (multi-TB/PB tablets and tables) don't render
+  // as unwieldy GB values (e.g. "10000.00 GB").
+  static const char* const kUnits[] = {"B", "KB", "MB", "GB", "TB", "PB", "EB"};
+  static const size_t kNumUnits = sizeof(kUnits) / sizeof(kUnits[0]);
+
   std::ostringstream op_stream;
-  op_stream << std::fixed << std::setprecision(precision);
-  if (bytes >= kBytesPerGB) {
-    op_stream << static_cast<double> (bytes)/kBytesPerGB << " GB";
-  } else if (bytes >= kBytesPerMB) {
-    op_stream << static_cast<double> (bytes)/kBytesPerMB << " MB";
-  } else if (bytes >= kBytesPerKB) {
-    op_stream << static_cast<double> (bytes)/kBytesPerKB << " KB";
-  } else {
+  // Print exact whole bytes below 1 KB (no fractional part for raw byte counts).
+  if (bytes < 1000) {
     op_stream << bytes << " B";
+    return op_stream.str();
   }
+
+  double value = static_cast<double>(bytes);
+  size_t unit = 0;
+  while (value >= 1000.0 && unit + 1 < kNumUnits) {
+    value /= 1000.0;
+    ++unit;
+  }
+
+  // Round to the requested precision BEFORE settling on the unit. Otherwise a
+  // value such as 999.999999 MB would be rendered as "1000.00 MB" (the display
+  // rounding pushes it to 1000) instead of being promoted to "1.00 GB". After
+  // rounding, if it lands on 1000 we bump to the next unit (unless we are
+  // already at the largest one). The stream then prints this already-rounded
+  // value, so there is no second, inconsistent rounding step.
+  const double scale = std::pow(10.0, precision);
+  value = std::round(value * scale) / scale;
+  while (value >= 1000.0 && unit + 1 < kNumUnits) {
+    value /= 1000.0;
+    value = std::round(value * scale) / scale;
+    ++unit;
+  }
+
+  op_stream << std::fixed << std::setprecision(precision) << value << " " << kUnits[unit];
   return op_stream.str();
 }

--- a/src/yb/gutil/strings/string_util-test.cc
+++ b/src/yb/gutil/strings/string_util-test.cc
@@ -32,6 +32,7 @@
 // Some portions Copyright 2013 The Chromium Authors. All rights reserved.
 
 #include "yb/gutil/strings/join.h"
+#include "yb/gutil/strings/numbers.h"
 #include "yb/gutil/strings/util.h"
 #include "yb/util/string_util.h"
 #include "yb/util/test_util.h"
@@ -229,6 +230,45 @@ TEST_F(StringUtilTest, JoinStringsLimitCount) {
   std::string result = "test";
   JoinStringsLimitCount(std::vector<std::string>{"foo"}, ",", 1, &result);
   ASSERT_EQ(result, "foo");
+}
+
+TEST_F(StringUtilTest, TestHumanizeBytes) {
+  // Below 1 KB the raw byte count is printed with no fractional part.
+  ASSERT_EQ("0 B", HumanizeBytes(0));
+  ASSERT_EQ("1 B", HumanizeBytes(1));
+  ASSERT_EQ("999 B", HumanizeBytes(999));
+
+  // Decimal (base 1000) scaling with explicit labels.
+  ASSERT_EQ("1.00 KB", HumanizeBytes(1000));
+  ASSERT_EQ("1.00 MB", HumanizeBytes(1000000));
+  ASSERT_EQ("1.00 GB", HumanizeBytes(1000000000));
+
+  // A binary "1 MiB" (1048576 bytes) is 1.05 MB in base 1000.
+  ASSERT_EQ("1.05 MB", HumanizeBytes(1048576));
+  // Example from GitHub issue #28753: 6,347,254,071 bytes -> 6.35 GB.
+  ASSERT_EQ("6.35 GB", HumanizeBytes(6347254071ULL));
+
+  // Large sizes must keep scaling past GB instead of showing "10000.00 GB".
+  ASSERT_EQ("10.00 TB", HumanizeBytes(10000000000000ULL));
+  ASSERT_EQ("2.50 PB", HumanizeBytes(2500000000000000ULL));
+  ASSERT_EQ("1.00 EB", HumanizeBytes(1000000000000000000ULL));
+  // EB is the largest unit; values beyond it stay in EB.
+  ASSERT_EQ("5.00 EB", HumanizeBytes(5000000000000000000ULL));
+
+  // The precision argument controls the number of fractional digits.
+  ASSERT_EQ("1.234 KB", HumanizeBytes(1234, 3));
+  ASSERT_EQ("1.2 KB", HumanizeBytes(1234, 1));
+
+  // Rounding boundary: a value just under the next unit must be promoted once
+  // display rounding pushes it to 1000, rather than rendering "1000.00 <unit>".
+  ASSERT_EQ("1.00 GB", HumanizeBytes(999999999ULL));       // 999.999999 MB -> 1.00 GB
+  ASSERT_EQ("1.00 MB", HumanizeBytes(999999ULL));          // 999.999 KB    -> 1.00 MB
+  ASSERT_EQ("1.00 PB", HumanizeBytes(999999999999999ULL)); // 999.999... TB -> 1.00 PB
+  // Promotion must also respect the precision argument.
+  ASSERT_EQ("1 GB", HumanizeBytes(999999999ULL, 0));       // 999.99... MB -> 1 GB
+  // Values that round up but stay within the same unit must NOT be promoted.
+  ASSERT_EQ("999.50 MB", HumanizeBytes(999499999ULL));
+  ASSERT_EQ("999.99 MB", HumanizeBytes(999994999ULL));
 }
 
 } // namespace yb

--- a/src/yb/master/master-path-handlers.cc
+++ b/src/yb/master/master-path-handlers.cc
@@ -1281,17 +1281,17 @@ string GetOnDiskSizeInHtml(const TabletReplicaDriveInfo &info) {
   std::ostringstream disk_size_html;
   disk_size_html << "<ul>"
                  << "<li>" << "Total: "
-                 << HumanReadableNumBytes::ToString(
+                 << HumanizeBytes(
                         info.sst_files_size + info.wal_files_size + info.vector_index_size)
                  << "<li>" << "WAL Files: "
-                 << HumanReadableNumBytes::ToString(info.wal_files_size)
+                 << HumanizeBytes(info.wal_files_size)
                  << "<li>" << "SST Files: "
-                 << HumanReadableNumBytes::ToString(info.sst_files_size)
+                 << HumanizeBytes(info.sst_files_size)
                  << "<li>" << "SST Files Uncompressed: "
-                 << HumanReadableNumBytes::ToString(info.uncompressed_sst_file_size);
+                 << HumanizeBytes(info.uncompressed_sst_file_size);
   if (info.vector_index_size > 0) {
     disk_size_html << "<li>" << "Vector Indexes: "
-                   << HumanReadableNumBytes::ToString(info.vector_index_size);
+                   << HumanizeBytes(info.vector_index_size);
   }
   disk_size_html << "</ul>";
 
@@ -1638,20 +1638,20 @@ void MasterPathHandlers::HandleAllTablesJSON(
         jw.String("on_disk_size");
         jw.StartObject();
         jw.String("wal_files_size");
-        jw.String(HumanReadableNumBytes::ToString(table.second.on_disk_size.wal_files_size));
+        jw.String(HumanizeBytes(table.second.on_disk_size.wal_files_size));
         jw.String("wal_files_size_bytes");
         jw.Uint64(table.second.on_disk_size.wal_files_size);
         jw.String("sst_files_size");
-        jw.String(HumanReadableNumBytes::ToString(table.second.on_disk_size.sst_files_size));
+        jw.String(HumanizeBytes(table.second.on_disk_size.sst_files_size));
         jw.String("sst_files_size_bytes");
         jw.Uint64(table.second.on_disk_size.sst_files_size);
         jw.String("uncompressed_sst_file_size");
         jw.String(
-            HumanReadableNumBytes::ToString(table.second.on_disk_size.uncompressed_sst_file_size));
+            HumanizeBytes(table.second.on_disk_size.uncompressed_sst_file_size));
         jw.String("uncompressed_sst_file_size_bytes");
         jw.Uint64(table.second.on_disk_size.uncompressed_sst_file_size);
         jw.String("vector_index_size");
-        jw.String(HumanReadableNumBytes::ToString(table.second.on_disk_size.vector_index_size));
+        jw.String(HumanizeBytes(table.second.on_disk_size.vector_index_size));
         jw.String("vector_index_size_bytes");
         jw.Uint64(table.second.on_disk_size.vector_index_size);
         jw.String("has_missing_size");
@@ -3757,9 +3757,9 @@ string MasterPathHandlers::ReplicaInfoToHtml(
     html << Format("UUID: $0<br/>", ts_uuid);
     html << Format(
         "Active SSTs size: $0<br/>",
-        HumanReadableNumBytes::ToString(replica.drive_info.sst_files_size));
+        HumanizeBytes(replica.drive_info.sst_files_size));
     html << Format(
-        "WALs size: $0\n", HumanReadableNumBytes::ToString(replica.drive_info.wal_files_size));
+        "WALs size: $0\n", HumanizeBytes(replica.drive_info.wal_files_size));
   }
   html << "</ul>\n";
   return html.str();

--- a/src/yb/tserver/tserver-path-handlers.cc
+++ b/src/yb/tserver/tserver-path-handlers.cc
@@ -669,17 +669,17 @@ string GetOnDiskSizeInHtml(const yb::tablet::TabletOnDiskSizeInfo& info) {
   disk_size_html << "<ul>"
                  << "<li>" << "Total (may be stale): "
                  << (info.total_on_disk_size > 0 ?
-                        HumanReadableNumBytes::ToString(info.total_on_disk_size) : "N/A")
+                        HumanizeBytes(info.total_on_disk_size) : "N/A")
                  << "<ul>"
                  << "<li>" << "SST Files: "
-                 << HumanReadableNumBytes::ToString(info.sst_files_disk_size)
+                 << HumanizeBytes(info.sst_files_disk_size)
                  << "<li>" << "WAL Files: "
-                 << HumanReadableNumBytes::ToString(info.wal_files_disk_size)
+                 << HumanizeBytes(info.wal_files_disk_size)
                  << "<li>" << "Consensus Metadata: "
-                 << HumanReadableNumBytes::ToString(info.consensus_metadata_disk_size);
+                 << HumanizeBytes(info.consensus_metadata_disk_size);
   if (info.vector_index_disk_size > 0) {
     disk_size_html << "<li>" << "Vector Indexes: "
-                   << HumanReadableNumBytes::ToString(info.vector_index_disk_size);
+                   << HumanizeBytes(info.vector_index_disk_size);
   }
   disk_size_html << "</ul>"
                  << "</ul>";
@@ -1055,8 +1055,8 @@ void TabletServerPathHandlers::HandleMaintenanceManagerPage(const Webserver::Web
       *output << Substitute(
           "<tr><td>$0</td><td>$1</td><td>$2</td><td>$3</td><td>$4</td><td>$5</td></tr>\n",
           EscapeForHtmlToString(op_pb.name()), op_pb.runnable(),
-          HumanReadableNumBytes::ToString(op_pb.ram_anchored_bytes()),
-          HumanReadableNumBytes::ToString(op_pb.logs_retained_bytes()), op_pb.perf_improvement(),
+          HumanizeBytes(op_pb.ram_anchored_bytes()),
+          HumanizeBytes(op_pb.logs_retained_bytes()), op_pb.perf_improvement(),
           op_pb.cdcsdk_reset_stale_retention_barrier() ? "Yes" : "No");
     }
   }
@@ -1338,31 +1338,31 @@ void TabletServerPathHandlers::HandleTabletsJSON(const Webserver::WebRequest& re
     jw.StartObject();
     const yb::tablet::TabletOnDiskSizeInfo& info = yb::tablet::TabletOnDiskSizeInfo::FromPB(status);
     jw.String("total_size");
-    jw.String(HumanReadableNumBytes::ToString(info.active_on_disk_size));
+    jw.String(HumanizeBytes(info.active_on_disk_size));
     jw.String("total_size_bytes");
     jw.Uint64(info.active_on_disk_size);
     jw.String("total_size_including_snapshots");
-    jw.String(HumanReadableNumBytes::ToString(info.total_on_disk_size));
+    jw.String(HumanizeBytes(info.total_on_disk_size));
     jw.String("total_size_including_snapshots_bytes");
     jw.Uint64(info.total_on_disk_size);
     jw.String("consensus_metadata_size");
-    jw.String(HumanReadableNumBytes::ToString(info.consensus_metadata_disk_size));
+    jw.String(HumanizeBytes(info.consensus_metadata_disk_size));
     jw.String("consensus_metadata_size_bytes");
     jw.Uint64(info.consensus_metadata_disk_size);
     jw.String("wal_files_size");
-    jw.String(HumanReadableNumBytes::ToString(info.wal_files_disk_size));
+    jw.String(HumanizeBytes(info.wal_files_disk_size));
     jw.String("wal_files_size_bytes");
     jw.Uint64(info.wal_files_disk_size);
     jw.String("sst_files_size");
-    jw.String(HumanReadableNumBytes::ToString(info.sst_files_disk_size));
+    jw.String(HumanizeBytes(info.sst_files_disk_size));
     jw.String("sst_files_size_bytes");
     jw.Uint64(info.sst_files_disk_size);
     jw.String("uncompressed_sst_files_size");
-    jw.String(HumanReadableNumBytes::ToString(info.uncompressed_sst_files_disk_size));
+    jw.String(HumanizeBytes(info.uncompressed_sst_files_disk_size));
     jw.String("uncompressed_sst_files_size_bytes");
     jw.Uint64(info.uncompressed_sst_files_disk_size);
     jw.String("vector_index_size");
-    jw.String(HumanReadableNumBytes::ToString(info.vector_index_disk_size));
+    jw.String(HumanizeBytes(info.vector_index_disk_size));
     jw.String("vector_index_size_bytes");
     jw.Uint64(info.vector_index_disk_size);
     jw.EndObject();


### PR DESCRIPTION
## Summary

Disk sizes were reported with inconsistent units across YugabyteDB
surfaces (GitHub issue #28753). The Platform (YBA) UI was standardized
on **base 1000 with explicit `GB`/`MB`/`KB` labels**, and this change
brings the DB-side Master and T-Server web UIs in line with that
standard.

### Problem

The Master and T-Server web UIs formatted SST/WAL/disk sizes with
`HumanReadableNumBytes::ToString`, which computes in **base 1024** but
labels the value with a bare `K`/`M`/`G` — so a value that is really
`41.46 MiB` was rendered as `41.46M`. The Master "Tablet Servers" table,
however, already used `HumanizeBytes`, which formats in **base 1000**
with explicit `" GB"`/`" MB"`/`" KB"` labels. As a result the same
underlying metric could appear to disagree between pages (e.g. `6.3 GB`
on one page and `5.9 GiB` on another).

### Change

Switch the on-disk-size displays to the existing `HumanizeBytes` helper
(already `#include`d via `yb/gutil/strings/numbers.h`) so all size
output uses base 1000 with explicit `GB`/`MB`/`KB` labels:

- **`src/yb/master/master-path-handlers.cc`** — the per-tablet
on-disk-size HTML breakdown (Total / WAL / SST / Uncompressed / Vector
index), the per-table JSON `on_disk_size` string fields, and the
per-replica "Active SSTs size / WALs size" HTML.
- **`src/yb/tserver/tserver-path-handlers.cc`** — the per-tablet
on-disk-size HTML breakdown, the maintenance-ops "RAM anchored / Logs
retained" columns, and the tablet JSON size string fields.

Notes:
- The raw `*_bytes` JSON fields are left unchanged — they carry exact
byte counts, not human-readable strings.
- The shared `HumanReadableNumBytes` utility is intentionally **not**
modified, since it is also used for log output and parse round-trips
elsewhere in the codebase; scoping the change to the UI path handlers
avoids unrelated risk.

## Demo

Built the daemons from this branch and loaded three tables on a local
`yb-ctl` (RF=1) cluster — one sized to land in each unit — then flushed
them so real SST files exist. The Master UI `/tables` on-disk-size
column now renders each in the correct base-1000 unit (`KB` / `MB` /
`GB`):

| Table | SST Files | Total |
|---|---|---|
| `demo_kb` | 131.44 KB | 1.18 MB |
| `demo_mb` | 8.52 MB | 21.02 MB |
| `demo_gb` | 1.41 GB | 2.84 GB |

![Master UI /tables showing KB, MB, and GB
units](https://raw.githubusercontent.com/ag26jan/yugabyte-db/pr-assets/pr-32591/demo-units-master-tables.png)

Original commit: 7db97a75eee0ce0706f5ae2a917fbaf96699c49c / #32591

## Test plan

- [x] `./yb_build.sh release daemons` builds `yb-master` and
`yb-tserver` cleanly with the changes.
- [x] On a local `yb-ctl` (RF=1) cluster, loaded a ~572 MB table and
flushed it; the Master UI `/tables` on-disk-size column renders `Total:
673.71 MB`, `WAL Files: 634.90 MB`, `SST Files: 38.81 MB`, `SST Files
Uncompressed: 616.93 MB`, and the per-replica table page renders `Active
SSTs size: 38.81 MB` / `WALs size: 634.90 MB` (base 1000).
- [x] The T-Server UI `/tablets` page renders `Total (may be stale):
674.17 MB`, `SST Files: 38.81 MB`, `WAL Files: 634.90 MB`, `Consensus
Metadata: 1.96 KB` (base 1000).
- [x] The JSON endpoints (`/api/v1/tablets`, tables JSON) report
human-readable size strings in `GB`/`MB`/`KB` (e.g. `"sst_files_size":
"38.81 MB"` for `sst_files_size_bytes: 38809852`) while the `*_bytes`
fields still carry raw byte counts. Confirmed `1048576` bytes now
renders `1.05 MB` (base 1000) rather than the previous `1.00M` (base
1024).

---------