### PR TITLE
Add intents_min_seconds_to_retain

### DIFF
--- a/docs/content/v2025.1/reference/configuration/yb-tserver.md
+++ b/docs/content/v2025.1/reference/configuration/yb-tserver.md
@@ -1249,6 +1249,19 @@ Default: `28800000` (8 hours)
 
 The time period, in milliseconds, after which the intents will be cleaned up if there is no client polling for the change records.
 
+##### --intents_min_seconds_to_retain
+
+{{% tags/wrap %}}
+{{<tags/feature/t-server>}}
+Default: `0`
+{{% /tags/wrap %}}
+
+Minimum duration, in seconds, to retain a committed transaction's on-disk intents after the transaction has been applied. When set to a non-zero value, every intent-cleanup path treats it as a "CDC active" signal: the immediate post-apply intent removal is deferred, and the transaction's intents are reclaimed only after the wall-clock age of its commit hybrid time exceeds this threshold. At apply time a `PostApplyTransactionMetadata` record (carrying the commit hybrid time) is persisted so the IntentsDB compaction-filter garbage-collection path can make the wall-clock retention decision without any in-memory state.
+
+Serves as a time-based parallel to [--log_min_seconds_to_retain](#log-min-seconds-to-retain) (which governs WAL segment retention) for the IntentsDB. The default of `0` preserves the historical behavior of cleaning up intents as soon as a transaction's APPLYING record is replicated, when no CDC consumer is pinning a checkpoint barrier via `UpdateCdcReplicatedIndex`.
+
+Intended for CDC consumers that rely on wall-clock retention instead of per-stream lease-based barriers. Operationally, pair with `--log_min_seconds_to_retain` (set both to the same value so the WAL and IntentsDB stay in sync for any consumer that may need to read either). You do not need to also raise `--aborted_intent_cleanup_ms`: the retention window is enforced by the wall-clock gate in the compaction garbage-collection path, so a committed transaction's intents are retained for the full window regardless of how soon the compaction filter surfaces the transaction.
+
 ##### --cdc_wal_retention_time_secs
 
 {{% tags/wrap %}}

--- a/src/yb/client/ql-transaction-test.cc
+++ b/src/yb/client/ql-transaction-test.cc
@@ -84,6 +84,7 @@ DECLARE_int32(TEST_inject_load_transaction_delay_ms);
 DECLARE_int64(db_block_cache_size_bytes);
 DECLARE_int64(db_write_buffer_size);
 DECLARE_int64(transaction_rpc_timeout_ms);
+DECLARE_uint32(intents_min_seconds_to_retain);
 DECLARE_uint64(aborted_intent_cleanup_ms);
 DECLARE_uint64(log_segment_size_bytes);
 DECLARE_uint64(max_clock_skew_usec);
@@ -910,6 +911,62 @@ TEST_F(QLTransactionTest, CheckCompactionAbortCleanup) {
   ASSERT_OK(WaitIntentsCleaned());
 
   ASSERT_OK(cluster_->RestartSync());
+}
+
+// Baseline for --intents_min_seconds_to_retain: with the flag disabled (default 0), a committed
+// transaction's provisional records are reclaimed shortly after apply (HandleTransactionCleanup
+// schedules their removal), even when the compaction filter is told to surface the transaction
+// immediately (aborted_intent_cleanup_ms == 0). This is the behavior the retention flag overrides,
+// and it anchors the positive test below.
+TEST_F(QLTransactionTest, CommittedIntentsCleanedWithoutRetentionWindow) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_intents_min_seconds_to_retain) = 0;
+  // Surface committed transactions to the intents compaction filter immediately.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_aborted_intent_cleanup_ms) = 0;
+
+  ASSERT_NO_FATALS(WriteData());
+  ASSERT_OK(WaitTransactionsCleaned());
+
+  // Committed intents are reclaimed as usual -- nothing is pinning them.
+  ASSERT_OK(WaitIntentsCleaned());
+}
+
+// Positive test for --intents_min_seconds_to_retain: with a large retention window a committed
+// transaction's provisional records survive apply, in-memory eviction, and repeated IntentsDB
+// flush + compaction, even with aborted_intent_cleanup_ms == 0 (so the compaction filter surfaces
+// the transaction on every pass and only the wall-clock window protects the intents). This mirrors
+// a CDC consumer that relies on wall-clock retention instead of a per-stream checkpoint barrier.
+TEST_F(QLTransactionTest, CommittedIntentsSurviveWithinRetentionWindow) {
+  // 1 hour: comfortably larger than the test runtime, so the window never elapses here.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_intents_min_seconds_to_retain) = 3600;
+  // Force the compaction filter to consider the committed txn for cleanup on every pass; only the
+  // retention window should keep its intents alive.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_aborted_intent_cleanup_ms) = 0;
+
+  ASSERT_NO_FATALS(WriteData());
+
+  // The transaction is still evicted from memory: the retention window only defers intent GC, it
+  // does not pin the transaction in `transactions_`.
+  ASSERT_OK(WaitTransactionsCleaned());
+
+  const auto intents_after_apply = CountIntents(cluster_.get());
+  ASSERT_GE(intents_after_apply, kNumRows)
+      << "committed provisional records should still be present after apply within the window";
+
+  // Flush the IntentsDB (so the post-apply metadata carrying commit_ht is on disk) and compact
+  // repeatedly. Pre-fix the immediate post-apply removal / compaction GC would have reclaimed the
+  // committed intents here; with the wall-clock gate they must survive because commit_ht is inside
+  // the retention window.
+  for (int i = 0; i < 3; ++i) {
+    ASSERT_OK(cluster_->FlushTablets(tablet::FlushMode::kSync, tablet::FlushFlags::kIntents));
+    ASSERT_OK(cluster_->CompactTablets());
+  }
+
+  ASSERT_GE(CountIntents(cluster_.get()), kNumRows)
+      << "committed intents were GC'd inside the --intents_min_seconds_to_retain window";
+
+  // The window did not leave the transaction stuck as pending: the data is committed and readable.
+  ASSERT_FALSE(HasTransactions());
+  ASSERT_NO_FATALS(VerifyData());
 }
 
 class QLTransactionTestWithDisabledCompactions : public QLTransactionTest {

--- a/src/yb/common/transaction.h
+++ b/src/yb/common/transaction.h
@@ -44,7 +44,20 @@ namespace yb {
 
 YB_STRONGLY_TYPED_UUID_DECL(TransactionId);
 using TransactionIdSet = std::unordered_set<TransactionId, TransactionIdHash>;
-using TransactionIdApplyOpIdMap = std::unordered_map<TransactionId, OpId, TransactionIdHash>;
+
+// Per-transaction cleanup info surfaced by the IntentsDB compaction filter and consumed by
+// TransactionParticipant::Cleanup. `apply_op_id` is the transaction's apply record OpId (used by
+// the lease-based CDC checkpoint barrier). `commit_ht` is the transaction's commit hybrid time,
+// read from the on-disk PostApplyTransactionMetadata; it is the wall-clock reference used by the
+// time-based intent-retention path (--intents_min_seconds_to_retain). It is
+// HybridTime::kInvalid when no post-apply metadata was seen for the transaction (e.g. an aborted
+// transaction, or a committed transaction that predates post-apply metadata being written).
+struct TransactionApplyOpIdInfo {
+  OpId apply_op_id = OpId::Invalid();
+  HybridTime commit_ht = HybridTime::kInvalid;
+};
+using TransactionIdApplyOpIdMap =
+    std::unordered_map<TransactionId, TransactionApplyOpIdInfo, TransactionIdHash>;
 using SubTransactionId = uint32_t;
 // When session level advisory locks are enabled, we created a docdb transaction for a pg session
 // on a session advisory lock request, if one doesn't already exist. This transaction lives for the

--- a/src/yb/docdb/docdb_compaction_filter_intents.cc
+++ b/src/yb/docdb/docdb_compaction_filter_intents.cc
@@ -14,6 +14,7 @@
 #include "yb/docdb/docdb_compaction_filter_intents.h"
 
 #include <memory>
+#include <tuple>
 
 #include <boost/multi_index/member.hpp>
 
@@ -84,12 +85,13 @@ class DocDBIntentsCompactionFilter : public rocksdb::CompactionFilter {
 
   Result<std::optional<TransactionId>> FilterExternalIntent(const Slice& key);
 
-  Result<std::pair<TransactionId, OpId>> ParsePostApplyTransactionMetadata(
+  Result<std::tuple<TransactionId, OpId, HybridTime>> ParsePostApplyTransactionMetadata(
       const Slice& key, const Slice& existing_value);
 
   void AddTransactionToCleanup(const TransactionId& transaction_id);
 
-  void SetTransactionApplyOpId(const TransactionId& transaction_id, const OpId& apply_op_id);
+  void SetTransactionApplyMetadata(
+      const TransactionId& transaction_id, const OpId& apply_op_id, HybridTime commit_ht);
 
   tablet::Tablet* const tablet_;
   const MicrosTime compaction_start_time_;
@@ -162,8 +164,8 @@ rocksdb::FilterDecision DocDBIntentsCompactionFilter::Filter(
   if (key_type == KeyType::kPostApplyTransactionMetadata) {
     auto result = ParsePostApplyTransactionMetadata(key, existing_value);
     MAYBE_LOG_ERROR_AND_RETURN_KEEP(result);
-    const auto& [transaction_id, apply_op_id] = *result;
-    SetTransactionApplyOpId(transaction_id, apply_op_id);
+    const auto& [transaction_id, apply_op_id, commit_ht] = *result;
+    SetTransactionApplyMetadata(transaction_id, apply_op_id, commit_ht);
   }
 
   // TODO(dtxn): If/when we add processing of reverse index or intents here - we will need to
@@ -200,7 +202,7 @@ Result<std::optional<TransactionId>> DocDBIntentsCompactionFilter::FilterTransac
       "Could not decode Transaction metadata");
 }
 
-Result<std::pair<TransactionId, OpId>>
+Result<std::tuple<TransactionId, OpId, HybridTime>>
 DocDBIntentsCompactionFilter::ParsePostApplyTransactionMetadata(
     const Slice& key, const Slice& existing_value) {
   PostApplyTransactionMetadataPB metadata_pb;
@@ -211,13 +213,18 @@ DocDBIntentsCompactionFilter::ParsePostApplyTransactionMetadata(
 
   OpId apply_op_id = metadata_pb.has_apply_op_id() ? OpId::FromPB(metadata_pb.apply_op_id())
                                                    : OpId::Invalid();
+  // commit_ht is the wall-clock reference used by the time-based intent-retention path
+  // (--intents_min_seconds_to_retain). Surfaced here so TransactionParticipant::Cleanup can decide
+  // whether a committed transaction's intents are still within the retention window.
+  HybridTime commit_ht = metadata_pb.has_commit_ht() ? HybridTime(metadata_pb.commit_ht())
+                                                     : HybridTime::kInvalid;
 
   Slice key_slice = key;
   TransactionId transaction_id = VERIFY_RESULT_PREPEND(
       dockv::DecodeTransactionIdFromIntentValue(&key_slice),
       "Could not decode post-apply transaction metadata");
 
-  return std::make_pair(transaction_id, apply_op_id);
+  return std::make_tuple(transaction_id, apply_op_id, commit_ht);
 }
 
 Result<std::optional<TransactionId>> DocDBIntentsCompactionFilter::FilterExternalIntent(
@@ -252,17 +259,18 @@ void DocDBIntentsCompactionFilter::CompactionFinished() {
 
 void DocDBIntentsCompactionFilter::AddTransactionToCleanup(const TransactionId& transaction_id) {
   if (transactions_to_cleanup_.size() <= FLAGS_aborted_intent_cleanup_max_batch_size) {
-    transactions_to_cleanup_.emplace(transaction_id, OpId::Invalid());
+    transactions_to_cleanup_.emplace(transaction_id, TransactionApplyOpIdInfo{});
   } else {
     rejected_transactions_++;
   }
 }
 
-void DocDBIntentsCompactionFilter::SetTransactionApplyOpId(
-    const TransactionId& transaction_id, const OpId& apply_op_id) {
+void DocDBIntentsCompactionFilter::SetTransactionApplyMetadata(
+    const TransactionId& transaction_id, const OpId& apply_op_id, HybridTime commit_ht) {
   auto itr = transactions_to_cleanup_.find(transaction_id);
   if (itr != transactions_to_cleanup_.end()) {
-    itr->second = apply_op_id;
+    itr->second.apply_op_id = apply_op_id;
+    itr->second.commit_ht = commit_ht;
   }
 }
 

--- a/src/yb/tablet/running_transaction.cc
+++ b/src/yb/tablet/running_transaction.cc
@@ -668,6 +668,18 @@ void RunningTransaction::SetApplyOpId(const OpId& op_id) {
   apply_record_op_id_ = op_id;
 }
 
+void RunningTransaction::SetApplyHybridTimes(HybridTime commit_ht, HybridTime log_ht) {
+  // Single-batch applies bypass SetApplyData (it's only called when apply_state.active()),
+  // which means apply_data_.log_ht stays at the default-constructed invalid HT. The CDC
+  // intent-retention check in HandleTransactionCleanup reads exactly that field, so without
+  // an explicit stamp here it always sees an invalid HT and refuses to honour
+  // --intents_min_seconds_to_retain. This setter is the minimum we need to stamp the times
+  // from the inbound TransactionApplyData onto the running transaction so the retention
+  // gating works for the common case.
+  apply_data_.commit_ht = commit_ht;
+  apply_data_.log_ht = log_ht;
+}
+
 bool RunningTransaction::ProcessingApply() const {
   return processing_apply_.load(std::memory_order_acquire);
 }

--- a/src/yb/tablet/running_transaction.h
+++ b/src/yb/tablet/running_transaction.h
@@ -135,6 +135,17 @@ class RunningTransaction : public std::enable_shared_from_this<RunningTransactio
 
   void SetApplyOpId(const OpId& id);
 
+  // Stamp the commit / apply (log_ht) hybrid times that came with the APPLYING op onto the
+  // transaction's apply_data_ slot. Used so that callers reading {@link GetApplyHybridTime}
+  // / {@link GetCommitHybridTime} get a real value even when SetApplyData() is never invoked
+  // (the case for transactions whose apply fits in a single batch -- the common case for
+  // YSQL inserts touching a primary table plus a unique index). Without this, the
+  // ScheduleRemoveIntents gating in `intents_min_seconds_to_retain` runs against an invalid
+  // HybridTime and trips its `!apply_ht.is_valid() => return false` short-circuit, causing
+  // intents to be GC'd despite the retention window. See the comment block at the call site
+  // for the full diagnosis.
+  void SetApplyHybridTimes(HybridTime commit_ht, HybridTime log_ht);
+
   const OpId& GetApplyOpId() const {
     return apply_record_op_id_;
   }

--- a/src/yb/tablet/tablet.cc
+++ b/src/yb/tablet/tablet.cc
@@ -357,6 +357,7 @@ DECLARE_int64(apply_intents_task_injected_delay_ms);
 DECLARE_int64(db_block_size_bytes);
 DECLARE_int64(rocksdb_compact_flush_rate_limit_bytes_per_sec);
 DECLARE_uint64(cdc_intent_retention_ms);
+DECLARE_uint32(intents_min_seconds_to_retain);
 DECLARE_uint64(rocksdb_max_file_size_for_compaction);
 DECLARE_string(regular_tablets_data_block_key_value_encoding);
 
@@ -1535,6 +1536,31 @@ void Tablet::DoCleanupIntentFiles() {
         break;
       }
     }
+
+    // Wall-clock intent retention (--intents_min_seconds_to_retain). When no CDC SDK stream is
+    // registered (is_under_cdc_sdk_replication() is false), the stream barrier above does not
+    // engage. DoCleanupIntentFiles deletes whole intents SST files based only on
+    // MinRunningHybridTime, which advances past committed-and-applied transactions -- so without
+    // this gate it reclaims committed intents inside the retention window, bypassing the per-txn
+    // gating in transaction_participant.cc. Retain any intents SST file whose newest write is
+    // still inside the --intents_min_seconds_to_retain wall-clock window so a CDC consumer relying
+    // on wall-clock retention can read the committed intents at APPLYING time. best_file is the
+    // oldest live intents file, so once it is within the window every newer file is too: break.
+    const auto cdc_intents_retain_secs = FLAGS_intents_min_seconds_to_retain;
+    if (cdc_intents_retain_secs > 0 && best_file_max_ht.is_valid() &&
+        best_file_max_ht != HybridTime::kMax) {
+      const auto now_micros = clock_->Now().GetPhysicalValueMicros();
+      const auto file_micros = best_file_max_ht.GetPhysicalValueMicros();
+      const auto window_micros = static_cast<uint64_t>(
+          MonoDelta::FromSeconds(cdc_intents_retain_secs).ToMicroseconds());
+      if (now_micros <= file_micros || (now_micros - file_micros) < window_micros) {
+        VLOG_WITH_PREFIX_AND_FUNC(4)
+            << "Cannot delete intents SST file: within --intents_min_seconds_to_retain window, "
+            << "best file max ht: " << best_file_max_ht;
+        break;
+      }
+    }
+
     if (best_file->name_id == previous_name_id) {
       LOG_WITH_PREFIX_AND_FUNC(INFO)
           << "Attempt to delete same file: " << previous_name_id << ", stopping cleanup";

--- a/src/yb/tablet/transaction_participant.cc
+++ b/src/yb/tablet/transaction_participant.cc
@@ -117,6 +117,14 @@ DEFINE_RUNTIME_AUTO_bool(cdc_write_post_apply_metadata, kLocalPersisted, false, 
 DEFINE_RUNTIME_bool(cdc_immediate_transaction_cleanup, true,
     "Clean up transactions from memory after apply, even if its changes have not yet been "
     "streamed by CDC.");
+
+DEFINE_RUNTIME_uint32(intents_min_seconds_to_retain, 0,
+    "If > 0, post-apply intent cleanup for a committed transaction is deferred until the "
+    "wall-clock age of the transaction's apply hybrid time exceeds this many seconds. Acts as "
+    "a time-based parallel to --log_min_seconds_to_retain (which governs WAL segment retention) "
+    "for the IntentsDB. Default 0 preserves existing behavior (intents cleaned up immediately "
+    "post-apply when no CDC consumer is pinning a checkpoint barrier via UpdateCdcReplicatedIndex). "
+    "Intended for CDC consumers that rely on wall-clock retention instead of per-stream barriers.");
 DEFINE_test_flag(int32, stopactivetxns_sleep_in_abort_cb_ms, 0,
     "Delays the abort callback in StopActiveTxns to repro GitHub #23399.");
 
@@ -910,12 +918,33 @@ class TransactionParticipant::Impl
     TransactionIdSet set;
     {
       std::lock_guard lock(mutex_);
+      const bool cdc_wall_clock_retention =
+          FLAGS_intents_min_seconds_to_retain > 0;
       const OpId& cdcsdk_checkpoint_op_id = GetLatestCheckPointUnlocked();
 
-      if (cdcsdk_checkpoint_op_id != OpId::Max()) {
-        for (const auto& [transaction_id, apply_op_id] : txns) {
-          const OpId* apply_record_op_id = &apply_op_id;
-          if (!apply_op_id.valid()) {
+      if (cdc_wall_clock_retention) {
+        // Wall-clock intent retention (--intents_min_seconds_to_retain). Retention is time-based
+        // rather than tied to a CDC checkpoint barrier: a committed transaction's intents must
+        // survive --intents_min_seconds_to_retain seconds past its commit_ht. commit_ht is
+        // surfaced from the on-disk PostApplyTransactionMetadata by the IntentsDB compaction
+        // filter. A transaction with an invalid commit_ht (no post-apply metadata was seen: an
+        // aborted transaction, or a committed one predating this feature) falls through to
+        // CleanupAbortsTask, which independently verifies abort status against the coordinator
+        // before removing any intents -- so committed-but-still-known transactions are not
+        // over-cleaned.
+        for (const auto& [transaction_id, info] : txns) {
+          if (info.commit_ht.is_valid() && IsWithinIntentsRetentionWindow(info.commit_ht)) {
+            VLOG_WITH_PREFIX(2)
+                << "Transaction within intent-retention window, should not cleanup. "
+                << "TransactionId: " << transaction_id << ", commit_ht: " << info.commit_ht;
+            continue;
+          }
+          set.insert(transaction_id);
+        }
+      } else if (cdcsdk_checkpoint_op_id != OpId::Max()) {
+        for (const auto& [transaction_id, info] : txns) {
+          const OpId* apply_record_op_id = &info.apply_op_id;
+          if (!info.apply_op_id.valid()) {
             // Apply op id is unknown -- may be from before upgrade to version that writes
             // apply op id to metadata. If cdc_immediate_transaction_cleanup is not false, it has
             // been removed from memory already, but we don't know if CDC still needs it, so we
@@ -1051,6 +1080,14 @@ class TransactionParticipant::Impl
         data.transaction_id, "apply"s, TransactionLoadFlags{TransactionLoadFlag::kMustExist}));
     if (lock_and_iterator.found()) {
       lock_and_iterator.transaction().SetApplyOpId(data.op_id);
+      // Stamp the apply's hybrid times onto the txn BEFORE the (possibly imminent)
+      // RemoveUnlocked call. The single-batch apply path below jumps straight to
+      // RemoveUnlocked without going through SetApplyData, so apply_data_.log_ht / commit_ht
+      // would otherwise be invalid HTs by the time HandleTransactionCleanup checks the
+      // --intents_min_seconds_to_retain window. SetApplyData (called in the active() branch)
+      // already populates these via apply_data_ = *data, so this stamp is the parallel for
+      // the inactive branch.
+      lock_and_iterator.transaction().SetApplyHybridTimes(data.commit_ht, data.log_ht);
       if (!apply_state.active()) {
         RemoveUnlocked(
             lock_and_iterator.iterator, RemoveReason::kApplied, &min_running_notifier);
@@ -1145,6 +1182,10 @@ class TransactionParticipant::Impl
       }
       CHECK(transactions_.modify(it, [&data](auto& txn) {
         txn->SetApplyOpId(data.op_id);
+        // Mirror UpdateAppliedTransaction: stamp HTs alongside the op_id so that any path
+        // that subsequently leads to RemoveUnlocked sees a valid apply_data_.log_ht and the
+        // intents-retention window is honoured.
+        txn->SetApplyHybridTimes(data.commit_ht, data.log_ht);
       }));
 
       if ((**it).ProcessingApply()) {
@@ -2025,6 +2066,28 @@ class TransactionParticipant::Impl
     std::optional<PostApplyTransactionMetadata> post_apply_metadata_entry;
   };
 
+  // Returns true iff --intents_min_seconds_to_retain is set and the wall-clock age of `ht`
+  // (a transaction's commit / apply hybrid time) is below the configured threshold. When true,
+  // the transaction's intents are still inside the CDC retention window and must not be garbage
+  // collected, so a stream-id-less CDC consumer can still read them at APPLYING time. Used both
+  // by the IntentsDB compaction GC path (Cleanup) and to reason about the retention window in
+  // general. A return of false (the default when the flag is 0) preserves the historical
+  // "clean up intents immediately post-apply" behavior.
+  bool IsWithinIntentsRetentionWindow(HybridTime ht) const {
+    const auto retention_secs = FLAGS_intents_min_seconds_to_retain;
+    if (retention_secs == 0 || !ht.is_valid()) {
+      return false;
+    }
+    const auto now_micros = participant_context_.Now().GetPhysicalValueMicros();
+    const auto ht_micros = ht.GetPhysicalValueMicros();
+    if (now_micros <= ht_micros) {
+      // HT is in the (logical) future of our clock; treat as within window.
+      return true;
+    }
+    const auto age_micros = now_micros - ht_micros;
+    return age_micros < static_cast<uint64_t>(MonoDelta::FromSeconds(retention_secs).ToMicroseconds());
+  }
+
   TransactionMetaCleanupResult HandleTransactionCleanup(
       const Transactions::iterator& it, RemoveReason reason, const OpId& checkpoint_op_id)
       REQUIRES(mutex_) {
@@ -2040,6 +2103,35 @@ class TransactionParticipant::Impl
 
     const TransactionId& txn_id = (**it).id();
     const OpId& op_id = (**it).GetApplyOpId();
+
+    // Wall-clock intent retention (--intents_min_seconds_to_retain). When the flag is set a
+    // committed transaction's intents must survive a wall-clock window instead of being removed as
+    // soon as they are applied. Rather than removing intents eagerly at apply, persist a
+    // PostApplyTransactionMetadata record carrying commit_ht so the IntentsDB compaction-filter GC
+    // path (Cleanup) can decide, purely from wall-clock age, when the retention window has
+    // elapsed. This reuses the SAME mechanism lease-based CDC uses to evict a txn from memory
+    // while deferring intent GC -- we just gate the deferral on a wall-clock window rather than an
+    // op_id checkpoint barrier. The transaction is still evicted from `transactions_`
+    // (should_remove_transaction stays true; no in-memory growth).
+    //
+    // Only committed (applied) transactions qualify: an invalid commit_ht means the txn was not
+    // applied (e.g. aborted), in which case there is nothing to retain and we fall through to the
+    // normal cleanup path below. Loaded-with-CDC txns short-circuit earlier (see above) and rely
+    // on the post-apply metadata persisted before restart.
+    //
+    // The post-apply metadata is the retention mechanism here, so we write it unconditionally (it
+    // does not depend on --cdc_write_post_apply_metadata, which gates the lease-based CDC path).
+    if (FLAGS_intents_min_seconds_to_retain > 0 &&
+        (**it).GetCommitHybridTime().is_valid()) {
+      post_apply_metadata_entry = PostApplyTransactionMetadata{
+          .transaction_id = txn_id,
+          .apply_op_id = op_id,
+          .commit_ht = (**it).GetCommitHybridTime(),
+          .log_ht = (**it).GetApplyHybridTime(),
+      };
+      return {should_remove_transaction, post_apply_metadata_entry};
+    }
+
     if (op_id <= checkpoint_op_id) {
       if (PREDICT_TRUE(!FLAGS_TEST_no_schedule_remove_intents)) {
         (**it).ScheduleRemoveIntents(*it, reason);
@@ -2177,8 +2269,19 @@ class TransactionParticipant::Impl
     }
     // Skip this cleanup if CDC is active on this tablet; we defer to full SST file deletion
     // triggered when CDC checkpoint moves.
-    if (!FLAGS_cdc_immediate_transaction_cleanup ||
-        latest_checkpoint == OpId::Max()) {
+    //
+    // Wall-clock intent retention: --intents_min_seconds_to_retain is a first-class "retain
+    // intents" signal. Without it, a committed-but-evicted transaction surfaced by a
+    // read-path / conflict-resolution status lookup (with kCleanup) after its 15s
+    // recently_removed_transactions_ TTL expires would have its intents deleted here, inside
+    // the retention window. This is a purely eager defense-in-depth path: deferring it is
+    // safe because the wall-clock-gated compaction GC path (Cleanup) still reclaims the intents
+    // once the window elapses.
+    const bool cdc_wall_clock_retention =
+        FLAGS_intents_min_seconds_to_retain > 0;
+    if (!cdc_wall_clock_retention &&
+        (!FLAGS_cdc_immediate_transaction_cleanup ||
+         latest_checkpoint == OpId::Max())) {
       if (flags.Test(TransactionLoadFlag::kCleanup)) {
         VLOG_WITH_PREFIX(2) << "Schedule cleanup for: " << id;
         auto cleanup_task = std::make_shared<CleanupIntentsTask>(
@@ -2225,7 +2328,17 @@ class TransactionParticipant::Impl
     // be checked when we remove the txn from 'transactions_' and trigger cleanup of intents. Once
     // CDC stream these txns, their intents will be cleaned up by the intent SST file cleanup
     // codepath.
-    if (GetLatestCheckPointUnlocked() != OpId::Max()) {
+    //
+    // Wall-clock intent retention: when --intents_min_seconds_to_retain > 0 but no CDC SDK stream
+    // is registered (GetLatestCheckPoint() == OpId::Max()), the check above would not set the
+    // marker, and a committed transaction replayed after a restart / leader change would have its
+    // intents deleted eagerly on eviction (HandleTransactionCleanup) inside the retention window
+    // -- loaded txns have no in-memory commit_ht, so the wall-clock window gate there cannot
+    // protect them. Treat --intents_min_seconds_to_retain > 0 as an additional "retain intents"
+    // signal. Their intents are reclaimed later by the wall-clock-gated compaction GC path using
+    // the commit_ht persisted in PostApplyTransactionMetadata before the restart.
+    if (GetLatestCheckPointUnlocked() != OpId::Max() ||
+        FLAGS_intents_min_seconds_to_retain > 0) {
       txn->SetTxnLoadedWithCDC();
     }
     if (last_batch_data.hybrid_time) {


### PR DESCRIPTION
 ### What

Add `--intents_min_seconds_to_retain`: wall-clock-based IntentsDB intent retention

Introduces a new tserver flag `--intents_min_seconds_to_retain` (default 0, runtime-changeable). When set to a non-zero value, a committed transaction's on-disk intents are retained for a wall-clock window past their commit hybrid time, instead of being cleaned up immediately after apply.

It's the IntentsDB parallel to `--log_min_seconds_to_retain` (which governs WAL segment retention). Default 0 fully preserves today's behavior.

 ### Why

Enables CDC consumers to rely on time-based intent retention rather than pinning a per-stream, lease-based checkpoint barrier (UpdateCdcReplicatedIndex). This removes the need to track the slowest consumer's checkpoint to decide when intents can be reclaimed, and lets retention be reasoned about purely from wall-clock age.

 ### How

 - At apply, instead of eagerly removing intents, persists a PostApplyTransactionMetadata record carrying commit_ht (reusing the same evict-from-memory / defer-GC mechanism lease-based CDC already uses). The transaction is still evicted from memory
 - Threads commit_ht through the IntentsDB compaction filter so the compaction GC path can make the retention decision from disk alone.
 - Gates every intent-cleanup path on the window: the compaction-filter Cleanup, the whole-SST-file DoCleanupIntentFiles, the LockAndFind defense-in-depth cleanup, and the loaded-txn (post-restart) marker.
 - Adds SetApplyHybridTimes() so single-batch applies stamp a valid commit_ht/log_ht.

 ### Testing

 Two new tests in ql-transaction-test.cc:
 - Control — flag off: committed intents are cleaned promptly after apply.
 - Positive — flag on (with aborted_intent_cleanup_ms = 0 to force the compaction filter to surface the txn every pass): committed intents survive apply, in-memory eviction, and repeated IntentsDB flush + compaction, while the transaction is still evicted from memory and the data stays readable.

 ### Notes

 - Strictly additive; behavior is unchanged when the flag is left at its 0 default.
 - Operationally, pair with --log_min_seconds_to_retain (same value) to keep WAL and IntentsDB retention in sync.