### PR TITLE
[IDEA-2151] DocDB: Filter Prometheus metrics using active-table lists

### DIFF
--- a/src/yb/master/master_tserver.h
+++ b/src/yb/master/master_tserver.h
@@ -141,6 +141,10 @@ class MasterTabletServer : public tserver::TabletServerIf,
 
   virtual Result<std::vector<TserverMetricsInfoPB>> GetMetrics() const override;
 
+  Status SetActiveTableMetrics(std::unordered_set<std::string> /* table_ids */) override {
+    return STATUS(NotSupported, "SetActiveTableMetrics is not supported on masters");
+  }
+
   bool SkipCatalogVersionChecks() override;
 
   void SetYsqlDBCatalogVersions(

--- a/src/yb/master/master_tserver.h
+++ b/src/yb/master/master_tserver.h
@@ -141,8 +141,8 @@ class MasterTabletServer : public tserver::TabletServerIf,
 
   virtual Result<std::vector<TserverMetricsInfoPB>> GetMetrics() const override;
 
-  Status SetActiveTableMetrics(std::unordered_set<std::string> /* table_ids */) override {
-    return STATUS(NotSupported, "SetActiveTableMetrics is not supported on masters");
+  Status SetActiveTableIdsForMetrics(std::unordered_set<std::string> /* table_ids */) override {
+    return STATUS(NotSupported, "SetActiveTableIdsForMetrics is not supported on masters");
   }
 
   bool SkipCatalogVersionChecks() override;

--- a/src/yb/server/default-path-handlers.cc
+++ b/src/yb/server/default-path-handlers.cc
@@ -478,11 +478,16 @@ static void WriteMetricsAsJson(const MetricRegistry* const metrics,
 
 static void WriteMetricsForPrometheus(const MetricRegistry* const metrics,
                                       const Webserver::WebRequest& req,
-                                      Webserver::WebResponse* resp) {
+                                      Webserver::WebResponse* resp,
+                                      const std::function<void(MetricPrometheusOptions*)>&
+                                          configure_prometheus_options) {
   MetricPrometheusOptions opts;
   opts.export_help_and_type = ExportHelpAndType(FLAGS_export_help_and_type_in_prometheus_metrics);
   opts.max_metric_entries = FLAGS_max_prometheus_metric_entries;
   ParseRequestOptions(req, &opts);
+  if (configure_prometheus_options) {
+    configure_prometheus_options(&opts);
+  }
 
   std::stringstream* output = &resp->output;
 
@@ -786,10 +791,12 @@ void AddDefaultPathHandlers(Webserver* webserver) {
   AddPprofPathHandlers(webserver);
 }
 
-void RegisterMetricsJsonHandler(Webserver* webserver, const MetricRegistry* const metrics) {
+void RegisterMetricsJsonHandler(
+    Webserver* webserver, const MetricRegistry* const metrics,
+    std::function<void(MetricPrometheusOptions*)> configure_prometheus_options) {
   Webserver::PathHandlerCallback callback = std::bind(WriteMetricsAsJson, metrics, _1, _2);
   Webserver::PathHandlerCallback prometheus_callback = std::bind(
-      WriteMetricsForPrometheus, metrics, _1, _2);
+      WriteMetricsForPrometheus, metrics, _1, _2, std::move(configure_prometheus_options));
   bool not_styled = false;
   bool not_on_nav_bar = false;
   webserver->RegisterPathHandler("/metrics", "Metrics", callback, not_styled, not_on_nav_bar);

--- a/src/yb/server/default-path-handlers.cc
+++ b/src/yb/server/default-path-handlers.cc
@@ -702,6 +702,11 @@ void ParseRequestOptions(
       }
     }
 
+    // Parsed argument names are lower cased by the webserver, so callers may spell this parameter
+    // with any casing.
+    arg = FindWithDefault(req.parsed_args, "apply_table_ids_filter", "false");
+    prometheus_opts->apply_table_ids_filter = ParseLeadingBoolValue(arg.c_str(), false);
+
     prometheus_opts->version = FindWithDefault(req.parsed_args, "version", kFilterVersionOne);
 
     if (prometheus_opts->version == kFilterVersionTwo) {

--- a/src/yb/server/default-path-handlers.h
+++ b/src/yb/server/default-path-handlers.h
@@ -43,6 +43,8 @@
 
 #pragma once
 
+#include <functional>
+
 #include "yb/server/webserver.h"
 #include "yb/util/metric_entity.h"
 #include "yb/util/jsonwriter.h"
@@ -65,7 +67,9 @@ void AddDefaultPathHandlers(Webserver* webserver);
 void MemUsageHandler(const Webserver::WebRequest& req, Webserver::WebResponse* resp);
 
 // Adds an endpoint to get metrics in JSON format.
-void RegisterMetricsJsonHandler(Webserver* webserver, const MetricRegistry* const metrics);
+void RegisterMetricsJsonHandler(
+    Webserver* webserver, const MetricRegistry* const metrics,
+    std::function<void(MetricPrometheusOptions*)> configure_prometheus_options = {});
 
 // Adds an endpoint to display path usage.
 void RegisterPathUsageHandler(Webserver* webserver, FsManager* fsmanager);

--- a/src/yb/server/server_base.cc
+++ b/src/yb/server/server_base.cc
@@ -737,7 +737,9 @@ Status RpcAndWebServerBase::Start() {
 
   AddDefaultPathHandlers(web_server_.get());
   AddRpczPathHandlers(messenger_.get(), ShouldExportLocalCalls(), web_server_.get());
-  RegisterMetricsJsonHandler(web_server_.get(), metric_registry_.get());
+  RegisterMetricsJsonHandler(
+      web_server_.get(), metric_registry_.get(),
+      [this](MetricPrometheusOptions* options) { ConfigurePrometheusMetricsOptions(options); });
   RegisterPathUsageHandler(web_server_.get(), fs_manager_.get());
   RegisterTlsHandler(web_server_.get(), this);
   TracingPathHandlers::RegisterHandlers(web_server_.get());

--- a/src/yb/server/server_base.cc
+++ b/src/yb/server/server_base.cc
@@ -739,7 +739,9 @@ Status RpcAndWebServerBase::Start() {
 
   AddDefaultPathHandlers(web_server_.get());
   AddRpczPathHandlers(messenger_.get(), ShouldExportLocalCalls(), web_server_.get());
-  RegisterMetricsJsonHandler(web_server_.get(), metric_registry_.get());
+  RegisterMetricsJsonHandler(
+      web_server_.get(), metric_registry_.get(),
+      [this](MetricPrometheusOptions* options) { ConfigurePrometheusMetricsOptions(options); });
   RegisterPathUsageHandler(web_server_.get(), fs_manager_.get());
   RegisterTlsHandler(web_server_.get(), this);
   TracingPathHandlers::RegisterHandlers(web_server_.get());

--- a/src/yb/server/server_base.h
+++ b/src/yb/server/server_base.h
@@ -224,6 +224,8 @@ class RpcAndWebServerBase : public RpcServerBase {
     return false;
   }
 
+  virtual void ConfigurePrometheusMetricsOptions(MetricPrometheusOptions* options) const {}
+
   static void DisplayIconTile(std::stringstream* output, const std::string icon,
                               const std::string caption, const std::string url);
 

--- a/src/yb/tserver/tablet_server-test.cc
+++ b/src/yb/tserver/tablet_server-test.cc
@@ -34,6 +34,8 @@
 #include "yb/common/schema_pbutil.h"
 #include "yb/consensus/log-test-base.h"
 
+#include "yb/client/yb_table_name.h"
+
 #include "yb/dockv/partition.h"
 
 #include "yb/gutil/strings/escaping.h"
@@ -88,6 +90,7 @@ DECLARE_int32(metrics_retirement_age_ms);
 DECLARE_string(block_manager);
 DECLARE_string(rpc_bind_addresses);
 DECLARE_bool(disable_clock_sync_error);
+DECLARE_bool(enable_active_table_metrics_filtering);
 DECLARE_string(metric_node_name);
 
 // Declare these metrics prototypes for simpler unit testing of their behavior.
@@ -141,6 +144,63 @@ TEST_F(TabletServerTest, TestPingServer) {
   server::PingResponsePB resp;
   RpcController controller;
   ASSERT_OK(generic_proxy_->Ping(req, &resp, &controller));
+}
+
+TEST_F(TabletServerTest, ActiveTableMetricsLease) {
+  EasyCurl curl;
+  const auto url = Format(
+      "http://$0/prometheus-metrics?show_help=false",
+      yb::ToString(mini_server_->bound_http_addr()));
+  auto Scrape = [&]() {
+    faststring buffer;
+    CHECK_OK(curl.FetchURL(url, &buffer));
+    return buffer.ToString();
+  };
+  const auto table_label = Format(R"#(table_id="$0")#", kTableName.table_name());
+
+  // The default behavior is unchanged before the first lease, even after filtering is enabled.
+  ASSERT_STR_CONTAINS(Scrape(), table_label);
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_active_table_metrics_filtering) = true;
+  ASSERT_STR_CONTAINS(Scrape(), table_label);
+
+  SetActiveTableMetricsRequestPB req;
+  SetActiveTableMetricsResponsePB resp;
+  req.set_lease_duration_ms(10'000);
+  req.add_table_ids("another-table");
+  RpcController controller;
+  ASSERT_OK(proxy_->SetActiveTableMetrics(req, &resp, &controller));
+  ASSERT_FALSE(resp.has_error()) << resp.error().DebugString();
+  ASSERT_STR_NOT_CONTAINS(Scrape(), table_label);
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_active_table_metrics_filtering) = false;
+  ASSERT_STR_CONTAINS(Scrape(), table_label);
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_active_table_metrics_filtering) = true;
+  ASSERT_STR_NOT_CONTAINS(Scrape(), table_label);
+
+  req.clear_table_ids();
+  req.add_table_ids(kTableName.table_name());
+  resp.Clear();
+  controller.Reset();
+  ASSERT_OK(proxy_->SetActiveTableMetrics(req, &resp, &controller));
+  ASSERT_FALSE(resp.has_error()) << resp.error().DebugString();
+  ASSERT_STR_CONTAINS(Scrape(), table_label);
+
+  req.clear_table_ids();
+  req.set_lease_duration_ms(10'000);
+  resp.Clear();
+  controller.Reset();
+  ASSERT_OK(proxy_->SetActiveTableMetrics(req, &resp, &controller));
+  ASSERT_FALSE(resp.has_error()) << resp.error().DebugString();
+  ASSERT_STR_NOT_CONTAINS(Scrape(), table_label);
+
+  req.set_lease_duration_ms(20);
+  resp.Clear();
+  controller.Reset();
+  ASSERT_OK(proxy_->SetActiveTableMetrics(req, &resp, &controller));
+  ASSERT_FALSE(resp.has_error()) << resp.error().DebugString();
+  SleepFor(MonoDelta::FromMilliseconds(100 * kTimeMultiplier));
+  // Expired leases also restore the existing export-all behavior.
+  ASSERT_STR_CONTAINS(Scrape(), table_label);
 }
 
 TEST_F(TabletServerTest, TestServerClock) {

--- a/src/yb/tserver/tablet_server-test.cc
+++ b/src/yb/tserver/tablet_server-test.cc
@@ -195,6 +195,7 @@ TEST_F(TabletServerTest, ActiveTableMetricsFiltering) {
   RpcController controller;
   ASSERT_OK(proxy_->SetActiveTableIdsForMetrics(req, &resp, &controller));
   ASSERT_FALSE(resp.has_error()) << resp.error().DebugString();
+  ASSERT_TRUE(resp.filtering_enabled());
   const auto first_update_time =
       ASSERT_RESULT(LastUpdateTime(FilteredScrape()));
   ASSERT_GT(first_update_time, 0);
@@ -266,6 +267,30 @@ TEST_F(TabletServerTest, ActiveTableMetricsFiltering) {
   ASSERT_OK(proxy_->SetActiveTableIdsForMetrics(req, &resp, &controller));
   ASSERT_TRUE(resp.has_error());
   ASSERT_TRUE(StatusFromPB(resp.error().status()).IsInvalidArgument());
+  ASSERT_STR_NOT_CONTAINS(FilteredScrape(), table_label);
+  ASSERT_TRUE(resp.filtering_enabled());
+
+  // A list sent while filtering is disabled is still accepted, and the response tells the caller
+  // that no scrape is using it.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_active_table_metrics_filtering) = false;
+  req.clear_table_ids();
+  req.add_table_ids(kTableName.table_name());
+  resp.Clear();
+  controller.Reset();
+  ASSERT_OK(proxy_->SetActiveTableIdsForMetrics(req, &resp, &controller));
+  ASSERT_FALSE(resp.has_error()) << resp.error().DebugString();
+  ASSERT_FALSE(resp.filtering_enabled());
+  ASSERT_STR_CONTAINS(FilteredScrape(), table_label);
+
+  // Once filtering is enabled again, the list stored while it was off takes effect immediately.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_active_table_metrics_filtering) = true;
+  ASSERT_STR_CONTAINS(FilteredScrape(), table_label);
+  req.clear_table_ids();
+  req.add_table_ids("another-table");
+  resp.Clear();
+  controller.Reset();
+  ASSERT_OK(proxy_->SetActiveTableIdsForMetrics(req, &resp, &controller));
+  ASSERT_FALSE(resp.has_error()) << resp.error().DebugString();
   ASSERT_STR_NOT_CONTAINS(FilteredScrape(), table_label);
 }
 

--- a/src/yb/tserver/tablet_server-test.cc
+++ b/src/yb/tserver/tablet_server-test.cc
@@ -189,11 +189,11 @@ TEST_F(TabletServerTest, ActiveTableMetricsFiltering) {
   ASSERT_STR_CONTAINS(Scrape("&apply_table_IDs_filter=false"), table_label);
   ASSERT_STR_NOT_CONTAINS(FilteredScrape(), table_label);
 
-  SetActiveTableMetricsRequestPB req;
-  SetActiveTableMetricsResponsePB resp;
+  SetActiveTableIdsForMetricsRequestPB req;
+  SetActiveTableIdsForMetricsResponsePB resp;
   req.add_table_ids("another-table");
   RpcController controller;
-  ASSERT_OK(proxy_->SetActiveTableMetrics(req, &resp, &controller));
+  ASSERT_OK(proxy_->SetActiveTableIdsForMetrics(req, &resp, &controller));
   ASSERT_FALSE(resp.has_error()) << resp.error().DebugString();
   const auto first_update_time =
       ASSERT_RESULT(LastUpdateTime(FilteredScrape()));
@@ -211,7 +211,7 @@ TEST_F(TabletServerTest, ActiveTableMetricsFiltering) {
   req.add_table_ids(kTableName.table_name());
   resp.Clear();
   controller.Reset();
-  ASSERT_OK(proxy_->SetActiveTableMetrics(req, &resp, &controller));
+  ASSERT_OK(proxy_->SetActiveTableIdsForMetrics(req, &resp, &controller));
   ASSERT_FALSE(resp.has_error()) << resp.error().DebugString();
   const auto second_update_time =
       ASSERT_RESULT(LastUpdateTime(FilteredScrape()));
@@ -226,7 +226,7 @@ TEST_F(TabletServerTest, ActiveTableMetricsFiltering) {
   req.add_table_ids("another-table");
   resp.Clear();
   controller.Reset();
-  ASSERT_OK(proxy_->SetActiveTableMetrics(req, &resp, &controller));
+  ASSERT_OK(proxy_->SetActiveTableIdsForMetrics(req, &resp, &controller));
   ASSERT_TRUE(resp.has_error());
   ASSERT_TRUE(StatusFromPB(resp.error().status()).IsInvalidArgument());
   ASSERT_EQ(
@@ -241,7 +241,7 @@ TEST_F(TabletServerTest, ActiveTableMetricsFiltering) {
   req.add_table_ids(kTableName.table_name());
   resp.Clear();
   controller.Reset();
-  ASSERT_OK(proxy_->SetActiveTableMetrics(req, &resp, &controller));
+  ASSERT_OK(proxy_->SetActiveTableIdsForMetrics(req, &resp, &controller));
   ASSERT_FALSE(resp.has_error()) << resp.error().DebugString();
   ASSERT_STR_CONTAINS(FilteredScrape(), table_label);
 
@@ -249,7 +249,7 @@ TEST_F(TabletServerTest, ActiveTableMetricsFiltering) {
   req.clear_table_ids();
   resp.Clear();
   controller.Reset();
-  ASSERT_OK(proxy_->SetActiveTableMetrics(req, &resp, &controller));
+  ASSERT_OK(proxy_->SetActiveTableIdsForMetrics(req, &resp, &controller));
   ASSERT_FALSE(resp.has_error()) << resp.error().DebugString();
   ASSERT_GT(
       ASSERT_RESULT(LastUpdateTime(FilteredScrape())),
@@ -263,7 +263,7 @@ TEST_F(TabletServerTest, ActiveTableMetricsFiltering) {
   req.add_table_ids("");
   resp.Clear();
   controller.Reset();
-  ASSERT_OK(proxy_->SetActiveTableMetrics(req, &resp, &controller));
+  ASSERT_OK(proxy_->SetActiveTableIdsForMetrics(req, &resp, &controller));
   ASSERT_TRUE(resp.has_error());
   ASSERT_TRUE(StatusFromPB(resp.error().status()).IsInvalidArgument());
   ASSERT_STR_NOT_CONTAINS(FilteredScrape(), table_label);

--- a/src/yb/tserver/tablet_server-test.cc
+++ b/src/yb/tserver/tablet_server-test.cc
@@ -235,6 +235,16 @@ TEST_F(TabletServerTest, ActiveTableMetricsFiltering) {
   // Rejected updates leave the previously accepted list active.
   ASSERT_STR_CONTAINS(FilteredScrape(), table_label);
 
+  // The limit counts distinct table IDs, so repeating one does not consume the budget twice.
+  req.clear_table_ids();
+  req.add_table_ids(kTableName.table_name());
+  req.add_table_ids(kTableName.table_name());
+  resp.Clear();
+  controller.Reset();
+  ASSERT_OK(proxy_->SetActiveTableMetrics(req, &resp, &controller));
+  ASSERT_FALSE(resp.has_error()) << resp.error().DebugString();
+  ASSERT_STR_CONTAINS(FilteredScrape(), table_label);
+
   SleepFor(MonoDelta::FromMilliseconds(1));
   req.clear_table_ids();
   resp.Clear();
@@ -245,6 +255,17 @@ TEST_F(TabletServerTest, ActiveTableMetricsFiltering) {
       ASSERT_RESULT(LastUpdateTime(FilteredScrape())),
       second_update_time);
   ASSERT_STR_CONTAINS(Scrape(), table_label);
+  ASSERT_STR_NOT_CONTAINS(FilteredScrape(), table_label);
+
+  // An empty table ID rejects the whole request, leaving the previously accepted list active.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_max_active_table_metrics_table_count) = 1000;
+  req.add_table_ids(kTableName.table_name());
+  req.add_table_ids("");
+  resp.Clear();
+  controller.Reset();
+  ASSERT_OK(proxy_->SetActiveTableMetrics(req, &resp, &controller));
+  ASSERT_TRUE(resp.has_error());
+  ASSERT_TRUE(StatusFromPB(resp.error().status()).IsInvalidArgument());
   ASSERT_STR_NOT_CONTAINS(FilteredScrape(), table_label);
 }
 

--- a/src/yb/tserver/tablet_server-test.cc
+++ b/src/yb/tserver/tablet_server-test.cc
@@ -153,11 +153,12 @@ TEST_F(TabletServerTest, ActiveTableMetricsFiltering) {
   const auto url = Format(
       "http://$0/prometheus-metrics?show_help=false",
       yb::ToString(mini_server_->bound_http_addr()));
-  auto Scrape = [&]() {
+  auto Scrape = [&](const std::string& extra_args = "") {
     faststring buffer;
-    CHECK_OK(curl.FetchURL(url, &buffer));
+    CHECK_OK(curl.FetchURL(url + extra_args, &buffer));
     return buffer.ToString();
   };
+  auto FilteredScrape = [&]() { return Scrape("&apply_table_IDs_filter=true"); };
   const auto table_label = Format(R"#(table_id="$0")#", kTableName.table_name());
   auto LastUpdateTime = [](const std::string& scrape) -> Result<uint64_t> {
     constexpr std::string_view kMetricName = "active_table_metrics_last_update_time";
@@ -176,13 +177,17 @@ TEST_F(TabletServerTest, ActiveTableMetricsFiltering) {
     return CheckedStoull(scrape.substr(value_pos + 1, value_end - value_pos - 1));
   };
 
-  // Filtering is opt-in. A fresh process exports all table metrics while the flag is disabled.
+  // Both the runtime flag and the scrape URL parameter must opt in to filtering.
   auto scrape = Scrape();
   ASSERT_STR_CONTAINS(scrape, table_label);
+  ASSERT_STR_CONTAINS(FilteredScrape(), table_label);
   ASSERT_EQ(0, ASSERT_RESULT(LastUpdateTime(scrape)));
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_active_table_metrics_filtering) = true;
-  // Once enabled, a fresh process exports no table metrics until it receives its first list.
-  ASSERT_STR_NOT_CONTAINS(Scrape(), table_label);
+  // Existing scrape URLs retain their behavior, while opted-in scrapes emit no table metrics
+  // until the process receives its first list.
+  ASSERT_STR_CONTAINS(Scrape(), table_label);
+  ASSERT_STR_CONTAINS(Scrape("&apply_table_IDs_filter=false"), table_label);
+  ASSERT_STR_NOT_CONTAINS(FilteredScrape(), table_label);
 
   SetActiveTableMetricsRequestPB req;
   SetActiveTableMetricsResponsePB resp;
@@ -190,14 +195,16 @@ TEST_F(TabletServerTest, ActiveTableMetricsFiltering) {
   RpcController controller;
   ASSERT_OK(proxy_->SetActiveTableMetrics(req, &resp, &controller));
   ASSERT_FALSE(resp.has_error()) << resp.error().DebugString();
-  const auto first_update_time = ASSERT_RESULT(LastUpdateTime(Scrape()));
+  const auto first_update_time =
+      ASSERT_RESULT(LastUpdateTime(FilteredScrape()));
   ASSERT_GT(first_update_time, 0);
-  ASSERT_STR_NOT_CONTAINS(Scrape(), table_label);
+  ASSERT_STR_CONTAINS(Scrape(), table_label);
+  ASSERT_STR_NOT_CONTAINS(FilteredScrape(), table_label);
 
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_active_table_metrics_filtering) = false;
-  ASSERT_STR_CONTAINS(Scrape(), table_label);
+  ASSERT_STR_CONTAINS(FilteredScrape(), table_label);
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_active_table_metrics_filtering) = true;
-  ASSERT_STR_NOT_CONTAINS(Scrape(), table_label);
+  ASSERT_STR_NOT_CONTAINS(FilteredScrape(), table_label);
 
   SleepFor(MonoDelta::FromMilliseconds(1));
   req.clear_table_ids();
@@ -206,13 +213,14 @@ TEST_F(TabletServerTest, ActiveTableMetricsFiltering) {
   controller.Reset();
   ASSERT_OK(proxy_->SetActiveTableMetrics(req, &resp, &controller));
   ASSERT_FALSE(resp.has_error()) << resp.error().DebugString();
-  const auto second_update_time = ASSERT_RESULT(LastUpdateTime(Scrape()));
+  const auto second_update_time =
+      ASSERT_RESULT(LastUpdateTime(FilteredScrape()));
   ASSERT_GT(second_update_time, first_update_time);
-  ASSERT_STR_CONTAINS(Scrape(), table_label);
+  ASSERT_STR_CONTAINS(FilteredScrape(), table_label);
 
   // The most recently received list remains active indefinitely.
   SleepFor(MonoDelta::FromMilliseconds(100 * kTimeMultiplier));
-  ASSERT_STR_CONTAINS(Scrape(), table_label);
+  ASSERT_STR_CONTAINS(FilteredScrape(), table_label);
 
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_max_active_table_metrics_table_count) = 1;
   req.add_table_ids("another-table");
@@ -221,9 +229,11 @@ TEST_F(TabletServerTest, ActiveTableMetricsFiltering) {
   ASSERT_OK(proxy_->SetActiveTableMetrics(req, &resp, &controller));
   ASSERT_TRUE(resp.has_error());
   ASSERT_TRUE(StatusFromPB(resp.error().status()).IsInvalidArgument());
-  ASSERT_EQ(ASSERT_RESULT(LastUpdateTime(Scrape())), second_update_time);
+  ASSERT_EQ(
+      ASSERT_RESULT(LastUpdateTime(FilteredScrape())),
+      second_update_time);
   // Rejected updates leave the previously accepted list active.
-  ASSERT_STR_CONTAINS(Scrape(), table_label);
+  ASSERT_STR_CONTAINS(FilteredScrape(), table_label);
 
   SleepFor(MonoDelta::FromMilliseconds(1));
   req.clear_table_ids();
@@ -231,8 +241,11 @@ TEST_F(TabletServerTest, ActiveTableMetricsFiltering) {
   controller.Reset();
   ASSERT_OK(proxy_->SetActiveTableMetrics(req, &resp, &controller));
   ASSERT_FALSE(resp.has_error()) << resp.error().DebugString();
-  ASSERT_GT(ASSERT_RESULT(LastUpdateTime(Scrape())), second_update_time);
-  ASSERT_STR_NOT_CONTAINS(Scrape(), table_label);
+  ASSERT_GT(
+      ASSERT_RESULT(LastUpdateTime(FilteredScrape())),
+      second_update_time);
+  ASSERT_STR_CONTAINS(Scrape(), table_label);
+  ASSERT_STR_NOT_CONTAINS(FilteredScrape(), table_label);
 }
 
 TEST_F(TabletServerTest, TestServerClock) {

--- a/src/yb/tserver/tablet_server-test.cc
+++ b/src/yb/tserver/tablet_server-test.cc
@@ -71,6 +71,7 @@
 #include "yb/util/monotime.h"
 #include "yb/util/size_literals.h"
 #include "yb/util/status_log.h"
+#include "yb/util/stol_utils.h"
 
 using yb::rpc::MessengerBuilder;
 using yb::rpc::RpcController;
@@ -91,6 +92,7 @@ DECLARE_string(block_manager);
 DECLARE_string(rpc_bind_addresses);
 DECLARE_bool(disable_clock_sync_error);
 DECLARE_bool(enable_active_table_metrics_filtering);
+DECLARE_uint32(max_active_table_metrics_table_count);
 DECLARE_string(metric_node_name);
 
 // Declare these metrics prototypes for simpler unit testing of their behavior.
@@ -146,7 +148,7 @@ TEST_F(TabletServerTest, TestPingServer) {
   ASSERT_OK(generic_proxy_->Ping(req, &resp, &controller));
 }
 
-TEST_F(TabletServerTest, ActiveTableMetricsLease) {
+TEST_F(TabletServerTest, ActiveTableMetricsFiltering) {
   EasyCurl curl;
   const auto url = Format(
       "http://$0/prometheus-metrics?show_help=false",
@@ -157,19 +159,39 @@ TEST_F(TabletServerTest, ActiveTableMetricsLease) {
     return buffer.ToString();
   };
   const auto table_label = Format(R"#(table_id="$0")#", kTableName.table_name());
+  auto LastUpdateTime = [](const std::string& scrape) -> Result<uint64_t> {
+    constexpr std::string_view kMetricName = "active_table_metrics_last_update_time";
+    const auto metric_pos = scrape.find(kMetricName);
+    if (metric_pos == std::string::npos) {
+      return STATUS(NotFound, "Active table metrics last update time not found");
+    }
+    const auto value_pos = scrape.find(' ', metric_pos + kMetricName.size());
+    if (value_pos == std::string::npos) {
+      return STATUS(Corruption, "Malformed active table metrics last update time");
+    }
+    const auto value_end = scrape.find_first_of(" \n", value_pos + 1);
+    if (value_end == std::string::npos) {
+      return STATUS(Corruption, "Malformed active table metrics last update time");
+    }
+    return CheckedStoull(scrape.substr(value_pos + 1, value_end - value_pos - 1));
+  };
 
-  // The default behavior is unchanged before the first lease, even after filtering is enabled.
-  ASSERT_STR_CONTAINS(Scrape(), table_label);
+  // Filtering is opt-in. A fresh process exports all table metrics while the flag is disabled.
+  auto scrape = Scrape();
+  ASSERT_STR_CONTAINS(scrape, table_label);
+  ASSERT_EQ(0, ASSERT_RESULT(LastUpdateTime(scrape)));
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_active_table_metrics_filtering) = true;
-  ASSERT_STR_CONTAINS(Scrape(), table_label);
+  // Once enabled, a fresh process exports no table metrics until it receives its first list.
+  ASSERT_STR_NOT_CONTAINS(Scrape(), table_label);
 
   SetActiveTableMetricsRequestPB req;
   SetActiveTableMetricsResponsePB resp;
-  req.set_lease_duration_ms(10'000);
   req.add_table_ids("another-table");
   RpcController controller;
   ASSERT_OK(proxy_->SetActiveTableMetrics(req, &resp, &controller));
   ASSERT_FALSE(resp.has_error()) << resp.error().DebugString();
+  const auto first_update_time = ASSERT_RESULT(LastUpdateTime(Scrape()));
+  ASSERT_GT(first_update_time, 0);
   ASSERT_STR_NOT_CONTAINS(Scrape(), table_label);
 
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_active_table_metrics_filtering) = false;
@@ -177,30 +199,40 @@ TEST_F(TabletServerTest, ActiveTableMetricsLease) {
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_active_table_metrics_filtering) = true;
   ASSERT_STR_NOT_CONTAINS(Scrape(), table_label);
 
+  SleepFor(MonoDelta::FromMilliseconds(1));
   req.clear_table_ids();
   req.add_table_ids(kTableName.table_name());
   resp.Clear();
   controller.Reset();
   ASSERT_OK(proxy_->SetActiveTableMetrics(req, &resp, &controller));
   ASSERT_FALSE(resp.has_error()) << resp.error().DebugString();
+  const auto second_update_time = ASSERT_RESULT(LastUpdateTime(Scrape()));
+  ASSERT_GT(second_update_time, first_update_time);
   ASSERT_STR_CONTAINS(Scrape(), table_label);
 
-  req.clear_table_ids();
-  req.set_lease_duration_ms(10'000);
-  resp.Clear();
-  controller.Reset();
-  ASSERT_OK(proxy_->SetActiveTableMetrics(req, &resp, &controller));
-  ASSERT_FALSE(resp.has_error()) << resp.error().DebugString();
-  ASSERT_STR_NOT_CONTAINS(Scrape(), table_label);
-
-  req.set_lease_duration_ms(20);
-  resp.Clear();
-  controller.Reset();
-  ASSERT_OK(proxy_->SetActiveTableMetrics(req, &resp, &controller));
-  ASSERT_FALSE(resp.has_error()) << resp.error().DebugString();
+  // The most recently received list remains active indefinitely.
   SleepFor(MonoDelta::FromMilliseconds(100 * kTimeMultiplier));
-  // Expired leases also restore the existing export-all behavior.
   ASSERT_STR_CONTAINS(Scrape(), table_label);
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_max_active_table_metrics_table_count) = 1;
+  req.add_table_ids("another-table");
+  resp.Clear();
+  controller.Reset();
+  ASSERT_OK(proxy_->SetActiveTableMetrics(req, &resp, &controller));
+  ASSERT_TRUE(resp.has_error());
+  ASSERT_TRUE(StatusFromPB(resp.error().status()).IsInvalidArgument());
+  ASSERT_EQ(ASSERT_RESULT(LastUpdateTime(Scrape())), second_update_time);
+  // Rejected updates leave the previously accepted list active.
+  ASSERT_STR_CONTAINS(Scrape(), table_label);
+
+  SleepFor(MonoDelta::FromMilliseconds(1));
+  req.clear_table_ids();
+  resp.Clear();
+  controller.Reset();
+  ASSERT_OK(proxy_->SetActiveTableMetrics(req, &resp, &controller));
+  ASSERT_FALSE(resp.has_error()) << resp.error().DebugString();
+  ASSERT_GT(ASSERT_RESULT(LastUpdateTime(Scrape())), second_update_time);
+  ASSERT_STR_NOT_CONTAINS(Scrape(), table_label);
 }
 
 TEST_F(TabletServerTest, TestServerClock) {

--- a/src/yb/tserver/tablet_server.cc
+++ b/src/yb/tserver/tablet_server.cc
@@ -105,6 +105,7 @@
 #include "yb/util/cgroups.h"
 #include "yb/util/flags.h"
 #include "yb/util/logging.h"
+#include "yb/util/metric_entity.h"
 #include "yb/util/net/net_util.h"
 #include "yb/util/net/sockaddr.h"
 #include "yb/util/ntp_clock.h"
@@ -187,6 +188,10 @@ DEFINE_NON_RUNTIME_int64(inbound_rpc_memory_limit, 0, "Inbound RPC memory limit"
 
 DEFINE_NON_RUNTIME_bool(tserver_enable_metrics_snapshotter, false,
     "Should metrics snapshotter be enabled");
+
+DEFINE_RUNTIME_bool(enable_active_table_metrics_filtering, false,
+    "Filter table-level Prometheus metrics using active table leases supplied through "
+    "SetActiveTableMetrics. When disabled, all table metrics are exported.");
 
 DEFINE_test_flag(uint64, pg_auth_key, 0, "Forces an auth key for the postgres user when non-zero");
 
@@ -428,6 +433,25 @@ std::string TabletServer::ToString() const {
   return strings::Substitute("TabletServer : rpc=$0, uuid=$1",
                              yb::ToString(first_rpc_address()),
                              fs_manager_->uuid());
+}
+
+void TabletServer::SetActiveTableMetrics(
+    std::unordered_set<std::string> table_ids, MonoDelta lease_duration) {
+  std::lock_guard lock(active_table_metrics_mutex_);
+  active_table_ids_ =
+      std::make_shared<const std::unordered_set<std::string>>(std::move(table_ids));
+  active_table_metrics_lease_expiration_ = CoarseMonoClock::Now() + lease_duration;
+}
+
+void TabletServer::ConfigurePrometheusMetricsOptions(MetricPrometheusOptions* options) const {
+  if (!FLAGS_enable_active_table_metrics_filtering) {
+    return;
+  }
+  std::lock_guard lock(active_table_metrics_mutex_);
+  if (active_table_ids_ &&
+      CoarseMonoClock::Now() < active_table_metrics_lease_expiration_) {
+    options->active_table_ids = active_table_ids_;
+  }
 }
 
 MonoDelta TabletServer::default_client_timeout() {

--- a/src/yb/tserver/tablet_server.cc
+++ b/src/yb/tserver/tablet_server.cc
@@ -474,7 +474,7 @@ Status TabletServer::SetActiveTableMetrics(std::unordered_set<std::string> table
 }
 
 void TabletServer::ConfigurePrometheusMetricsOptions(MetricPrometheusOptions* options) const {
-  if (!FLAGS_enable_active_table_metrics_filtering) {
+  if (!FLAGS_enable_active_table_metrics_filtering || !options->apply_table_ids_filter) {
     return;
   }
   static const auto kNoActiveTables =

--- a/src/yb/tserver/tablet_server.cc
+++ b/src/yb/tserver/tablet_server.cc
@@ -60,6 +60,7 @@
 #include "yb/fs/fs_manager.h"
 
 #include "yb/gutil/strings/substitute.h"
+#include "yb/gutil/walltime.h"
 
 #include "yb/master/master_ddl.pb.h"
 #include "yb/master/master_heartbeat.pb.h"
@@ -106,6 +107,7 @@
 #include "yb/util/flags.h"
 #include "yb/util/logging.h"
 #include "yb/util/metric_entity.h"
+#include "yb/util/metrics.h"
 #include "yb/util/net/net_util.h"
 #include "yb/util/net/sockaddr.h"
 #include "yb/util/ntp_clock.h"
@@ -190,8 +192,14 @@ DEFINE_NON_RUNTIME_bool(tserver_enable_metrics_snapshotter, false,
     "Should metrics snapshotter be enabled");
 
 DEFINE_RUNTIME_bool(enable_active_table_metrics_filtering, false,
-    "Filter table-level Prometheus metrics using active table leases supplied through "
-    "SetActiveTableMetrics. When disabled, all table metrics are exported.");
+    "Filter table-level Prometheus metrics using the latest active table list supplied through "
+    "SetActiveTableMetrics. When enabled, table metrics are not exported until the first list is "
+    "received. When disabled, all table metrics are exported.");
+
+DEFINE_RUNTIME_uint32(max_active_table_metrics_table_count, 1000,
+    "Maximum number of table IDs accepted by SetActiveTableMetrics. Requests exceeding this limit "
+    "are rejected and the previously accepted list remains active. Zero allows only an empty "
+    "list.");
 
 DEFINE_test_flag(uint64, pg_auth_key, 0, "Forces an auth key for the postgres user when non-zero");
 
@@ -286,6 +294,12 @@ DECLARE_string(ysql_ident_conf_csv);
 DECLARE_string(tmp_dir);
 
 namespace yb::tserver {
+
+METRIC_DEFINE_gauge_uint64(
+    server, active_table_metrics_last_update_time, "Active Table Metrics Last Update Time",
+    MetricUnit::kMicroseconds,
+    "Physical time of the last SetActiveTableMetrics request received by this tablet server. "
+    "Zero means no request has been received since process start.");
 
 constexpr auto kYsqlPgConfCsvFlag = "ysql_pg_conf_csv";
 constexpr auto kYsqlHbaConfCsvFlag = "ysql_hba_conf_csv";
@@ -422,6 +436,8 @@ TabletServer::TabletServer(const TabletServerOptions& opts)
       cgroup_manager_(FLAGS_enable_qos ? new TServerCgroupManager() : nullptr)
 #endif
       {
+  active_table_metrics_last_update_time_ =
+      METRIC_active_table_metrics_last_update_time.Instantiate(metric_entity(), 0);
   SetConnectionContextFactory(rpc::CreateConnectionContextFactory<rpc::YBInboundConnectionContext>(
       FLAGS_inbound_rpc_memory_limit, mem_tracker()));
   ysql_db_catalog_version_index_used_ =
@@ -441,23 +457,30 @@ std::string TabletServer::ToString() const {
                              fs_manager_->uuid());
 }
 
-void TabletServer::SetActiveTableMetrics(
-    std::unordered_set<std::string> table_ids, MonoDelta lease_duration) {
-  std::lock_guard lock(active_table_metrics_mutex_);
-  active_table_ids_ =
-      std::make_shared<const std::unordered_set<std::string>>(std::move(table_ids));
-  active_table_metrics_lease_expiration_ = CoarseMonoClock::Now() + lease_duration;
+Status TabletServer::SetActiveTableMetrics(std::unordered_set<std::string> table_ids) {
+  if (table_ids.size() > FLAGS_max_active_table_metrics_table_count) {
+    return STATUS_FORMAT(
+        InvalidArgument, "Active table list contains $0 tables, exceeding the limit of $1",
+        table_ids.size(), FLAGS_max_active_table_metrics_table_count);
+  }
+  {
+    std::lock_guard lock(active_table_metrics_mutex_);
+    active_table_ids_ =
+        std::make_shared<const std::unordered_set<std::string>>(std::move(table_ids));
+  }
+  active_table_metrics_last_update_time_->set_value(
+      static_cast<uint64_t>(GetCurrentTimeMicros()));
+  return Status::OK();
 }
 
 void TabletServer::ConfigurePrometheusMetricsOptions(MetricPrometheusOptions* options) const {
   if (!FLAGS_enable_active_table_metrics_filtering) {
     return;
   }
+  static const auto kNoActiveTables =
+      std::make_shared<const std::unordered_set<std::string>>();
   std::lock_guard lock(active_table_metrics_mutex_);
-  if (active_table_ids_ &&
-      CoarseMonoClock::Now() < active_table_metrics_lease_expiration_) {
-    options->active_table_ids = active_table_ids_;
-  }
+  options->active_table_ids = active_table_ids_ ? active_table_ids_ : kNoActiveTables;
 }
 
 MonoDelta TabletServer::default_client_timeout() {

--- a/src/yb/tserver/tablet_server.cc
+++ b/src/yb/tserver/tablet_server.cc
@@ -192,14 +192,16 @@ DEFINE_NON_RUNTIME_bool(tserver_enable_metrics_snapshotter, false,
     "Should metrics snapshotter be enabled");
 
 DEFINE_RUNTIME_bool(enable_active_table_metrics_filtering, false,
-    "Filter table-level Prometheus metrics using the latest active table list supplied through "
-    "SetActiveTableMetrics. When enabled, table metrics are not exported until the first list is "
-    "received. When disabled, all table metrics are exported.");
+    "Allow scrapes of /prometheus-metrics to filter table-level metrics using the latest active "
+    "table list supplied through SetActiveTableIdsForMetrics. A scrape is filtered only if it also "
+    "passes apply_table_IDs_filter=true; such a scrape exports no table metrics until the first "
+    "list is received. When this flag is disabled, all table metrics are exported regardless of "
+    "the URL parameter.");
 
 DEFINE_RUNTIME_uint32(max_active_table_metrics_table_count, 1000,
-    "Maximum number of table IDs accepted by SetActiveTableMetrics. Requests exceeding this limit "
-    "are rejected and the previously accepted list remains active. Zero allows only an empty "
-    "list.");
+    "Maximum number of table IDs accepted by SetActiveTableIdsForMetrics. Requests exceeding this "
+    "limit are rejected and the previously accepted list remains active. Zero allows only an "
+    "empty list.");
 
 DEFINE_test_flag(uint64, pg_auth_key, 0, "Forces an auth key for the postgres user when non-zero");
 
@@ -298,7 +300,7 @@ namespace yb::tserver {
 METRIC_DEFINE_gauge_uint64(
     server, active_table_metrics_last_update_time, "Active Table Metrics Last Update Time",
     MetricUnit::kMicroseconds,
-    "Physical time of the last SetActiveTableMetrics request received by this tablet server. "
+    "Physical time of the last SetActiveTableIdsForMetrics request received by this tablet server. "
     "Zero means no request has been received since process start.");
 
 constexpr auto kYsqlPgConfCsvFlag = "ysql_pg_conf_csv";
@@ -457,7 +459,10 @@ std::string TabletServer::ToString() const {
                              fs_manager_->uuid());
 }
 
-Status TabletServer::SetActiveTableMetrics(std::unordered_set<std::string> table_ids) {
+// The list is accepted and stored regardless of enable_active_table_metrics_filtering. The flag
+// only gates whether scrapes may use the list, so an operator turning it on takes effect
+// immediately instead of waiting for the caller's next push.
+Status TabletServer::SetActiveTableIdsForMetrics(std::unordered_set<std::string> table_ids) {
   if (table_ids.size() > FLAGS_max_active_table_metrics_table_count) {
     return STATUS_FORMAT(
         InvalidArgument, "Active table list contains $0 tables, exceeding the limit of $1",

--- a/src/yb/tserver/tablet_server.cc
+++ b/src/yb/tserver/tablet_server.cc
@@ -105,6 +105,7 @@
 #include "yb/util/cgroups.h"
 #include "yb/util/flags.h"
 #include "yb/util/logging.h"
+#include "yb/util/metric_entity.h"
 #include "yb/util/net/net_util.h"
 #include "yb/util/net/sockaddr.h"
 #include "yb/util/ntp_clock.h"
@@ -187,6 +188,10 @@ DEFINE_NON_RUNTIME_int64(inbound_rpc_memory_limit, 0, "Inbound RPC memory limit"
 
 DEFINE_NON_RUNTIME_bool(tserver_enable_metrics_snapshotter, false,
     "Should metrics snapshotter be enabled");
+
+DEFINE_RUNTIME_bool(enable_active_table_metrics_filtering, false,
+    "Filter table-level Prometheus metrics using active table leases supplied through "
+    "SetActiveTableMetrics. When disabled, all table metrics are exported.");
 
 DEFINE_test_flag(uint64, pg_auth_key, 0, "Forces an auth key for the postgres user when non-zero");
 
@@ -434,6 +439,25 @@ std::string TabletServer::ToString() const {
   return strings::Substitute("TabletServer : rpc=$0, uuid=$1",
                              yb::ToString(first_rpc_address()),
                              fs_manager_->uuid());
+}
+
+void TabletServer::SetActiveTableMetrics(
+    std::unordered_set<std::string> table_ids, MonoDelta lease_duration) {
+  std::lock_guard lock(active_table_metrics_mutex_);
+  active_table_ids_ =
+      std::make_shared<const std::unordered_set<std::string>>(std::move(table_ids));
+  active_table_metrics_lease_expiration_ = CoarseMonoClock::Now() + lease_duration;
+}
+
+void TabletServer::ConfigurePrometheusMetricsOptions(MetricPrometheusOptions* options) const {
+  if (!FLAGS_enable_active_table_metrics_filtering) {
+    return;
+  }
+  std::lock_guard lock(active_table_metrics_mutex_);
+  if (active_table_ids_ &&
+      CoarseMonoClock::Now() < active_table_metrics_lease_expiration_) {
+    options->active_table_ids = active_table_ids_;
+  }
 }
 
 MonoDelta TabletServer::default_client_timeout() {

--- a/src/yb/tserver/tablet_server.h
+++ b/src/yb/tserver/tablet_server.h
@@ -178,6 +178,11 @@ class TabletServer : public DbServerBase, public TabletServerIf {
 
   AutoFlagsConfigPB TEST_GetAutoFlagConfig() const;
 
+  void SetActiveTableMetrics(
+      std::unordered_set<std::string> table_ids, MonoDelta lease_duration) override;
+
+  void ConfigurePrometheusMetricsOptions(MetricPrometheusOptions* options) const override;
+
   TSTabletManager* tablet_manager() const override { return tablet_manager_.get(); }
   TabletPeerLookupIf* tablet_peer_lookup() override;
 
@@ -638,6 +643,12 @@ class TabletServer : public DbServerBase, public TabletServerIf {
   };
 
   ClusterConfig cluster_config_;
+
+  mutable std::mutex active_table_metrics_mutex_;
+  std::shared_ptr<const std::unordered_set<std::string>> active_table_ids_
+      GUARDED_BY(active_table_metrics_mutex_);
+  CoarseTimePoint active_table_metrics_lease_expiration_
+      GUARDED_BY(active_table_metrics_mutex_) = CoarseTimePoint::min();
 
   // Auto initialize some of the service flags that are defaulted to -1.
   void AutoInitServiceFlags();

--- a/src/yb/tserver/tablet_server.h
+++ b/src/yb/tserver/tablet_server.h
@@ -180,7 +180,7 @@ class TabletServer : public DbServerBase, public TabletServerIf {
 
   AutoFlagsConfigPB TEST_GetAutoFlagConfig() const;
 
-  Status SetActiveTableMetrics(std::unordered_set<std::string> table_ids) override;
+  Status SetActiveTableIdsForMetrics(std::unordered_set<std::string> table_ids) override;
 
   void ConfigurePrometheusMetricsOptions(MetricPrometheusOptions* options) const override;
 

--- a/src/yb/tserver/tablet_server.h
+++ b/src/yb/tserver/tablet_server.h
@@ -78,6 +78,7 @@
 
 #include "yb/util/atomic.h"
 #include "yb/util/locks.h"
+#include "yb/util/metrics_fwd.h"
 #include "yb/util/net/net_util.h"
 #include "yb/util/net/sockaddr.h"
 #include "yb/util/one_time_bool.h"
@@ -179,8 +180,7 @@ class TabletServer : public DbServerBase, public TabletServerIf {
 
   AutoFlagsConfigPB TEST_GetAutoFlagConfig() const;
 
-  void SetActiveTableMetrics(
-      std::unordered_set<std::string> table_ids, MonoDelta lease_duration) override;
+  Status SetActiveTableMetrics(std::unordered_set<std::string> table_ids) override;
 
   void ConfigurePrometheusMetricsOptions(MetricPrometheusOptions* options) const override;
 
@@ -674,8 +674,7 @@ class TabletServer : public DbServerBase, public TabletServerIf {
   mutable std::mutex active_table_metrics_mutex_;
   std::shared_ptr<const std::unordered_set<std::string>> active_table_ids_
       GUARDED_BY(active_table_metrics_mutex_);
-  CoarseTimePoint active_table_metrics_lease_expiration_
-      GUARDED_BY(active_table_metrics_mutex_) = CoarseTimePoint::min();
+  scoped_refptr<AtomicGauge<uint64_t>> active_table_metrics_last_update_time_;
 
   // Auto initialize some of the service flags that are defaulted to -1.
   void AutoInitServiceFlags();

--- a/src/yb/tserver/tablet_server.h
+++ b/src/yb/tserver/tablet_server.h
@@ -179,6 +179,11 @@ class TabletServer : public DbServerBase, public TabletServerIf {
 
   AutoFlagsConfigPB TEST_GetAutoFlagConfig() const;
 
+  void SetActiveTableMetrics(
+      std::unordered_set<std::string> table_ids, MonoDelta lease_duration) override;
+
+  void ConfigurePrometheusMetricsOptions(MetricPrometheusOptions* options) const override;
+
   TSTabletManager* tablet_manager() const override { return tablet_manager_.get(); }
   TabletPeerLookupIf* tablet_peer_lookup() override;
 
@@ -665,6 +670,12 @@ class TabletServer : public DbServerBase, public TabletServerIf {
   };
 
   ClusterConfig cluster_config_;
+
+  mutable std::mutex active_table_metrics_mutex_;
+  std::shared_ptr<const std::unordered_set<std::string>> active_table_ids_
+      GUARDED_BY(active_table_metrics_mutex_);
+  CoarseTimePoint active_table_metrics_lease_expiration_
+      GUARDED_BY(active_table_metrics_mutex_) = CoarseTimePoint::min();
 
   // Auto initialize some of the service flags that are defaulted to -1.
   void AutoInitServiceFlags();

--- a/src/yb/tserver/tablet_server_interface.h
+++ b/src/yb/tserver/tablet_server_interface.h
@@ -14,7 +14,9 @@
 #pragma once
 
 #include <future>
+#include <string>
 #include <string_view>
+#include <unordered_set>
 
 #include "yb/ash/wait_state.h"
 
@@ -162,6 +164,9 @@ class TabletServerIf : public LocalTabletServer {
 
   virtual Result<std::vector<tablet::TabletStatusPB>> GetLocalTabletsMetadata() const = 0;
   virtual Result<std::vector<TserverMetricsInfoPB>> GetMetrics() const = 0;
+
+  virtual void SetActiveTableMetrics(
+      std::unordered_set<std::string> table_ids, MonoDelta lease_duration) = 0;
 
   virtual Result<pgwrapper::PGConn> CreateInternalPGConn(
       const std::string& database_name, std::string_view user = kDefaultInternalPgUser,

--- a/src/yb/tserver/tablet_server_interface.h
+++ b/src/yb/tserver/tablet_server_interface.h
@@ -165,7 +165,9 @@ class TabletServerIf : public LocalTabletServer {
   virtual Result<std::vector<tablet::TabletStatusPB>> GetLocalTabletsMetadata() const = 0;
   virtual Result<std::vector<TserverMetricsInfoPB>> GetMetrics() const = 0;
 
-  virtual Status SetActiveTableMetrics(std::unordered_set<std::string> table_ids) = 0;
+  // Replaces the set of table IDs whose table-level metrics are exported by scrapes that opt into
+  // active-table filtering.
+  virtual Status SetActiveTableIdsForMetrics(std::unordered_set<std::string> table_ids) = 0;
 
   virtual Result<pgwrapper::PGConn> CreateInternalPGConn(
       const std::string& database_name, std::string_view user = kDefaultInternalPgUser,

--- a/src/yb/tserver/tablet_server_interface.h
+++ b/src/yb/tserver/tablet_server_interface.h
@@ -165,8 +165,7 @@ class TabletServerIf : public LocalTabletServer {
   virtual Result<std::vector<tablet::TabletStatusPB>> GetLocalTabletsMetadata() const = 0;
   virtual Result<std::vector<TserverMetricsInfoPB>> GetMetrics() const = 0;
 
-  virtual void SetActiveTableMetrics(
-      std::unordered_set<std::string> table_ids, MonoDelta lease_duration) = 0;
+  virtual Status SetActiveTableMetrics(std::unordered_set<std::string> table_ids) = 0;
 
   virtual Result<pgwrapper::PGConn> CreateInternalPGConn(
       const std::string& database_name, std::string_view user = kDefaultInternalPgUser,

--- a/src/yb/tserver/tablet_service.cc
+++ b/src/yb/tserver/tablet_service.cc
@@ -33,8 +33,10 @@
 #include "yb/tserver/tablet_service.h"
 
 #include <algorithm>
+#include <limits>
 #include <memory>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include <boost/algorithm/string/replace.hpp>
@@ -3559,6 +3561,36 @@ void TabletServiceImpl::GetMetrics(const GetMetricsRequestPB* req,
   }
   vector<TserverMetricsInfoPB> metrics = result.get();
   *resp->mutable_metrics() = {metrics.begin(), metrics.end()};
+  context.RespondSuccess();
+}
+
+void TabletServiceImpl::SetActiveTableMetrics(
+    const SetActiveTableMetricsRequestPB* req, SetActiveTableMetricsResponsePB* resp,
+    rpc::RpcContext context) {
+  if (!req->has_lease_duration_ms() || req->lease_duration_ms() == 0 ||
+      req->lease_duration_ms() > std::numeric_limits<int64_t>::max()) {
+    SetupErrorAndRespond(
+        resp->mutable_error(),
+        STATUS(InvalidArgument, "lease_duration_ms must be between 1 and INT64_MAX"),
+        &context);
+    return;
+  }
+
+  std::unordered_set<std::string> table_ids;
+  table_ids.reserve(req->table_ids_size());
+  for (const auto& table_id : req->table_ids()) {
+    if (table_id.empty()) {
+      SetupErrorAndRespond(
+          resp->mutable_error(), STATUS(InvalidArgument, "table_ids must not contain empty IDs"),
+          &context);
+      return;
+    }
+    table_ids.insert(table_id);
+  }
+
+  server_->SetActiveTableMetrics(
+      std::move(table_ids),
+      MonoDelta::FromMilliseconds(static_cast<int64_t>(req->lease_duration_ms())));
   context.RespondSuccess();
 }
 

--- a/src/yb/tserver/tablet_service.cc
+++ b/src/yb/tserver/tablet_service.cc
@@ -33,7 +33,6 @@
 #include "yb/tserver/tablet_service.h"
 
 #include <algorithm>
-#include <limits>
 #include <memory>
 #include <string>
 #include <unordered_set>
@@ -3560,15 +3559,6 @@ void TabletServiceImpl::GetMetrics(const GetMetricsRequestPB* req,
 void TabletServiceImpl::SetActiveTableMetrics(
     const SetActiveTableMetricsRequestPB* req, SetActiveTableMetricsResponsePB* resp,
     rpc::RpcContext context) {
-  if (!req->has_lease_duration_ms() || req->lease_duration_ms() == 0 ||
-      req->lease_duration_ms() > std::numeric_limits<int64_t>::max()) {
-    SetupErrorAndRespond(
-        resp->mutable_error(),
-        STATUS(InvalidArgument, "lease_duration_ms must be between 1 and INT64_MAX"),
-        &context);
-    return;
-  }
-
   std::unordered_set<std::string> table_ids;
   table_ids.reserve(req->table_ids_size());
   for (const auto& table_id : req->table_ids()) {
@@ -3581,9 +3571,11 @@ void TabletServiceImpl::SetActiveTableMetrics(
     table_ids.insert(table_id);
   }
 
-  server_->SetActiveTableMetrics(
-      std::move(table_ids),
-      MonoDelta::FromMilliseconds(static_cast<int64_t>(req->lease_duration_ms())));
+  const auto status = server_->SetActiveTableMetrics(std::move(table_ids));
+  if (!status.ok()) {
+    SetupErrorAndRespond(resp->mutable_error(), status, &context);
+    return;
+  }
   context.RespondSuccess();
 }
 

--- a/src/yb/tserver/tablet_service.cc
+++ b/src/yb/tserver/tablet_service.cc
@@ -327,6 +327,7 @@ DEFINE_RUNTIME_bool(reject_writes_when_disk_full, kRejectWritesWhenDiskFullDefau
 
 DECLARE_bool(enable_object_locking_for_table_locks);
 DECLARE_bool(ysql_enable_object_locking_infra);
+DECLARE_bool(enable_active_table_metrics_filtering);
 
 METRIC_DEFINE_gauge_uint64(server, ts_split_op_added, "Split OPs Added to Leader",
     yb::MetricUnit::kOperations, "Number of split operations added to the leader's Raft log.");
@@ -3559,6 +3560,10 @@ void TabletServiceImpl::GetMetrics(const GetMetricsRequestPB* req,
 void TabletServiceImpl::SetActiveTableIdsForMetrics(
     const SetActiveTableIdsForMetricsRequestPB* req, SetActiveTableIdsForMetricsResponsePB* resp,
     rpc::RpcContext context) {
+  // Reported on every response, including rejections, so the caller always learns whether any
+  // scrape can use the list it just sent.
+  resp->set_filtering_enabled(FLAGS_enable_active_table_metrics_filtering);
+
   std::unordered_set<std::string> table_ids;
   table_ids.reserve(req->table_ids_size());
   for (const auto& table_id : req->table_ids()) {

--- a/src/yb/tserver/tablet_service.cc
+++ b/src/yb/tserver/tablet_service.cc
@@ -33,8 +33,10 @@
 #include "yb/tserver/tablet_service.h"
 
 #include <algorithm>
+#include <limits>
 #include <memory>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include <boost/algorithm/string/replace.hpp>
@@ -3552,6 +3554,36 @@ void TabletServiceImpl::GetMetrics(const GetMetricsRequestPB* req,
   }
   vector<TserverMetricsInfoPB> metrics = result.get();
   *resp->mutable_metrics() = {metrics.begin(), metrics.end()};
+  context.RespondSuccess();
+}
+
+void TabletServiceImpl::SetActiveTableMetrics(
+    const SetActiveTableMetricsRequestPB* req, SetActiveTableMetricsResponsePB* resp,
+    rpc::RpcContext context) {
+  if (!req->has_lease_duration_ms() || req->lease_duration_ms() == 0 ||
+      req->lease_duration_ms() > std::numeric_limits<int64_t>::max()) {
+    SetupErrorAndRespond(
+        resp->mutable_error(),
+        STATUS(InvalidArgument, "lease_duration_ms must be between 1 and INT64_MAX"),
+        &context);
+    return;
+  }
+
+  std::unordered_set<std::string> table_ids;
+  table_ids.reserve(req->table_ids_size());
+  for (const auto& table_id : req->table_ids()) {
+    if (table_id.empty()) {
+      SetupErrorAndRespond(
+          resp->mutable_error(), STATUS(InvalidArgument, "table_ids must not contain empty IDs"),
+          &context);
+      return;
+    }
+    table_ids.insert(table_id);
+  }
+
+  server_->SetActiveTableMetrics(
+      std::move(table_ids),
+      MonoDelta::FromMilliseconds(static_cast<int64_t>(req->lease_duration_ms())));
   context.RespondSuccess();
 }
 

--- a/src/yb/tserver/tablet_service.cc
+++ b/src/yb/tserver/tablet_service.cc
@@ -3556,8 +3556,8 @@ void TabletServiceImpl::GetMetrics(const GetMetricsRequestPB* req,
   context.RespondSuccess();
 }
 
-void TabletServiceImpl::SetActiveTableMetrics(
-    const SetActiveTableMetricsRequestPB* req, SetActiveTableMetricsResponsePB* resp,
+void TabletServiceImpl::SetActiveTableIdsForMetrics(
+    const SetActiveTableIdsForMetricsRequestPB* req, SetActiveTableIdsForMetricsResponsePB* resp,
     rpc::RpcContext context) {
   std::unordered_set<std::string> table_ids;
   table_ids.reserve(req->table_ids_size());
@@ -3571,7 +3571,7 @@ void TabletServiceImpl::SetActiveTableMetrics(
     table_ids.insert(table_id);
   }
 
-  const auto status = server_->SetActiveTableMetrics(std::move(table_ids));
+  const auto status = server_->SetActiveTableIdsForMetrics(std::move(table_ids));
   if (!status.ok()) {
     SetupErrorAndRespond(resp->mutable_error(), status, &context);
     return;

--- a/src/yb/tserver/tablet_service.h
+++ b/src/yb/tserver/tablet_service.h
@@ -205,6 +205,10 @@ class TabletServiceImpl : public TabletServerServiceIf, public ReadTabletProvide
                   GetMetricsResponsePB* resp,
                   rpc::RpcContext context) override;
 
+  void SetActiveTableMetrics(
+      const SetActiveTableMetricsRequestPB* req, SetActiveTableMetricsResponsePB* resp,
+      rpc::RpcContext context) override;
+
   void PgRemoteExec(const PgRemoteExecRequestPB* req,
                     PgRemoteExecResponsePB* resp,
                     rpc::RpcContext context) override;

--- a/src/yb/tserver/tablet_service.h
+++ b/src/yb/tserver/tablet_service.h
@@ -205,8 +205,8 @@ class TabletServiceImpl : public TabletServerServiceIf, public ReadTabletProvide
                   GetMetricsResponsePB* resp,
                   rpc::RpcContext context) override;
 
-  void SetActiveTableMetrics(
-      const SetActiveTableMetricsRequestPB* req, SetActiveTableMetricsResponsePB* resp,
+  void SetActiveTableIdsForMetrics(
+      const SetActiveTableIdsForMetricsRequestPB* req, SetActiveTableIdsForMetricsResponsePB* resp,
       rpc::RpcContext context) override;
 
   void PgRemoteExec(const PgRemoteExecRequestPB* req,

--- a/src/yb/tserver/tserver_service.proto
+++ b/src/yb/tserver/tserver_service.proto
@@ -164,6 +164,9 @@ service TabletServerService {
 
   rpc GetMetrics(GetMetricsRequestPB) returns (GetMetricsResponsePB);
 
+  rpc SetActiveTableMetrics(SetActiveTableMetricsRequestPB)
+      returns (SetActiveTableMetricsResponsePB);
+
   rpc AdminExecutePgsql(AdminExecutePgsqlRequestPB)
       returns (AdminExecutePgsqlResponsePB);
 
@@ -265,6 +268,17 @@ message GetMetricsRequestPB {
 message GetMetricsResponsePB {
   repeated TserverMetricsInfoPB metrics  = 1;
   optional TabletServerErrorPB error = 2;
+}
+
+message SetActiveTableMetricsRequestPB {
+  // The complete set of tables whose table-level metrics should be exported by
+  // /prometheus-metrics while this lease is valid.
+  repeated string table_ids = 1;
+  optional uint64 lease_duration_ms = 2;
+}
+
+message SetActiveTableMetricsResponsePB {
+  optional TabletServerErrorPB error = 1;
 }
 
 message GetLogLocationRequestPB {

--- a/src/yb/tserver/tserver_service.proto
+++ b/src/yb/tserver/tserver_service.proto
@@ -166,6 +166,9 @@ service TabletServerService {
 
   rpc GetMetrics(GetMetricsRequestPB) returns (GetMetricsResponsePB);
 
+  rpc SetActiveTableMetrics(SetActiveTableMetricsRequestPB)
+      returns (SetActiveTableMetricsResponsePB);
+
   rpc AdminExecutePgsql(AdminExecutePgsqlRequestPB)
       returns (AdminExecutePgsqlResponsePB);
 
@@ -267,6 +270,17 @@ message GetMetricsRequestPB {
 message GetMetricsResponsePB {
   repeated TserverMetricsInfoPB metrics  = 1;
   optional TabletServerErrorPB error = 2;
+}
+
+message SetActiveTableMetricsRequestPB {
+  // The complete set of tables whose table-level metrics should be exported by
+  // /prometheus-metrics while this lease is valid.
+  repeated string table_ids = 1;
+  optional uint64 lease_duration_ms = 2;
+}
+
+message SetActiveTableMetricsResponsePB {
+  optional TabletServerErrorPB error = 1;
 }
 
 message GetLogLocationRequestPB {

--- a/src/yb/tserver/tserver_service.proto
+++ b/src/yb/tserver/tserver_service.proto
@@ -274,9 +274,8 @@ message GetMetricsResponsePB {
 
 message SetActiveTableMetricsRequestPB {
   // The complete set of tables whose table-level metrics should be exported by
-  // /prometheus-metrics while this lease is valid.
+  // /prometheus-metrics. Each request replaces the previous set.
   repeated string table_ids = 1;
-  optional uint64 lease_duration_ms = 2;
 }
 
 message SetActiveTableMetricsResponsePB {

--- a/src/yb/tserver/tserver_service.proto
+++ b/src/yb/tserver/tserver_service.proto
@@ -166,8 +166,8 @@ service TabletServerService {
 
   rpc GetMetrics(GetMetricsRequestPB) returns (GetMetricsResponsePB);
 
-  rpc SetActiveTableMetrics(SetActiveTableMetricsRequestPB)
-      returns (SetActiveTableMetricsResponsePB);
+  rpc SetActiveTableIdsForMetrics(SetActiveTableIdsForMetricsRequestPB)
+      returns (SetActiveTableIdsForMetricsResponsePB);
 
   rpc AdminExecutePgsql(AdminExecutePgsqlRequestPB)
       returns (AdminExecutePgsqlResponsePB);
@@ -272,13 +272,13 @@ message GetMetricsResponsePB {
   optional TabletServerErrorPB error = 2;
 }
 
-message SetActiveTableMetricsRequestPB {
+message SetActiveTableIdsForMetricsRequestPB {
   // The complete set of tables whose table-level metrics should be exported by
   // /prometheus-metrics. Each request replaces the previous set.
   repeated string table_ids = 1;
 }
 
-message SetActiveTableMetricsResponsePB {
+message SetActiveTableIdsForMetricsResponsePB {
   optional TabletServerErrorPB error = 1;
 }
 

--- a/src/yb/tserver/tserver_service.proto
+++ b/src/yb/tserver/tserver_service.proto
@@ -280,6 +280,11 @@ message SetActiveTableIdsForMetricsRequestPB {
 
 message SetActiveTableIdsForMetricsResponsePB {
   optional TabletServerErrorPB error = 1;
+
+  // State of enable_active_table_metrics_filtering on this tablet server. The list is stored
+  // either way, but no scrape uses it while this is false, so the caller can surface that its
+  // list is not being applied.
+  optional bool filtering_enabled = 2;
 }
 
 message GetLogLocationRequestPB {

--- a/src/yb/util/metric_entity.h
+++ b/src/yb/util/metric_entity.h
@@ -18,6 +18,7 @@
 #include <functional>
 #include <map>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "yb/gutil/callback_forward.h"
 #include "yb/gutil/map-util.h"
@@ -112,6 +113,10 @@ struct MetricPrometheusOptions : public MetricOptions {
 
   std::string server_allowlist_string = ".*";
   std::string server_blocklist_string = "";
+
+  // Missing means all tables. A present, possibly empty set limits table-level
+  // metrics to the listed table IDs.
+  std::shared_ptr<const std::unordered_set<std::string>> active_table_ids;
 };
 
 struct MetricHelpAndType {

--- a/src/yb/util/metric_entity.h
+++ b/src/yb/util/metric_entity.h
@@ -114,6 +114,9 @@ struct MetricPrometheusOptions : public MetricOptions {
   std::string server_allowlist_string = ".*";
   std::string server_blocklist_string = "";
 
+  // Whether this scrape should use the active table IDs stored by the server.
+  bool apply_table_ids_filter = false;
+
   // Missing means all tables. A present, possibly empty set limits table-level
   // metrics to the listed table IDs.
   std::shared_ptr<const std::unordered_set<std::string>> active_table_ids;

--- a/src/yb/util/metrics-test.cc
+++ b/src/yb/util/metrics-test.cc
@@ -337,6 +337,22 @@ TEST_F(MetricsTest, AggregationTest) {
     CheckPreStoredAndScrapeTimeAttributes(writer, "table_2_id", attributes, attributes);
   }
   {
+    opts.active_table_ids = std::make_shared<std::unordered_set<std::string>>(
+        std::initializer_list<std::string>{"table_1_id"});
+    std::stringstream filtered_output;
+    PrometheusWriter writer(&filtered_output, opts);
+    ASSERT_OK(registry_.WriteForPrometheus(&writer, opts));
+    ASSERT_STR_CONTAINS(filtered_output.str(), R"#(table_id="table_1_id")#");
+    ASSERT_STR_NOT_CONTAINS(filtered_output.str(), R"#(table_id="table_2_id")#");
+
+    opts.active_table_ids = std::make_shared<std::unordered_set<std::string>>();
+    std::stringstream empty_output;
+    PrometheusWriter empty_writer(&empty_output, opts);
+    ASSERT_OK(registry_.WriteForPrometheus(&empty_writer, opts));
+    ASSERT_STR_NOT_CONTAINS(empty_output.str(), "table_id=");
+    opts.active_table_ids.reset();
+  }
+  {
     // Check server level aggregation
     opts.priority_regex_string = "";
     PrometheusWriter writer(&output, opts);

--- a/src/yb/util/metrics-test.cc
+++ b/src/yb/util/metrics-test.cc
@@ -337,6 +337,7 @@ TEST_F(MetricsTest, AggregationTest) {
     CheckPreStoredAndScrapeTimeAttributes(writer, "table_2_id", attributes, attributes);
   }
   {
+    // An active-table list restricts table level aggregation to the listed tables.
     opts.active_table_ids = std::make_shared<std::unordered_set<std::string>>(
         std::initializer_list<std::string>{"table_1_id"});
     std::stringstream filtered_output;
@@ -350,6 +351,21 @@ TEST_F(MetricsTest, AggregationTest) {
     PrometheusWriter empty_writer(&empty_output, opts);
     ASSERT_OK(registry_.WriteForPrometheus(&empty_writer, opts));
     ASSERT_STR_NOT_CONTAINS(empty_output.str(), "table_id=");
+
+    // Server level aggregation still covers every table, including the filtered out ones.
+    opts.priority_regex_string = "";
+    std::stringstream server_level_output;
+    PrometheusWriter server_level_writer(&server_level_output, opts);
+    ASSERT_OK(registry_.WriteForPrometheus(&server_level_writer, opts));
+    CheckPreAggreatedAndScrapeTimeValues(
+        server_level_writer, kSumGaugeName, kServerLevelAggregationId, 34, std::nullopt);
+    CheckPreAggreatedAndScrapeTimeValues(
+        server_level_writer, kMaxGaugeName, kServerLevelAggregationId, std::nullopt, 10);
+    CheckPreAggreatedAndScrapeTimeValues(
+        server_level_writer, kSumCounterName, kServerLevelAggregationId, 34, std::nullopt);
+    ASSERT_STR_NOT_CONTAINS(server_level_output.str(), "table_id=");
+
+    opts.priority_regex_string = ".*";
     opts.active_table_ids.reset();
   }
   {
@@ -741,6 +757,8 @@ METRIC_DEFINE_histogram(server, t_hist, "Test Histogram Label",
     MetricUnit::kMilliseconds, "Test histogram description", 100000000L, 2);
 METRIC_DEFINE_event_stats(xcluster, t_event_stats, "Test EventStats Label",
     MetricUnit::kMilliseconds, "Test event stats description");
+METRIC_DEFINE_counter(xcluster, t_xcluster_counter, "Test xCluster Counter Label",
+    MetricUnit::kMilliseconds, "Test xCluster counter description");
 METRIC_DEFINE_counter(tablet, t_counter, "Test Counter Label", MetricUnit::kMilliseconds,
     "Test counter description");
 METRIC_DEFINE_gauge_int32(tablet, t_gauge, "Test Gauge Label", MetricUnit::kMilliseconds,
@@ -799,6 +817,36 @@ TEST_F(MetricsTest, VerifyHelpAndTypeTags) {
   // Check lag output.
   EXPECT_EQ(1, StringOccurence(output_str,
       "# HELP t_lag Test lag description\n# TYPE t_lag gauge"));
+}
+
+// The active-table list restricts table-level series only. xCluster series are aggregated per
+// stream but carry a table id as well, so they must survive the filter.
+TEST_F(MetricsTest, ActiveTableIdsDoNotFilterStreamLevelMetrics) {
+  MetricEntity::AttributeMap entity_attr;
+  entity_attr["tablet_id"] = "tablet_id_60";
+  entity_attr["table_name"] = "test_table";
+  entity_attr["table_id"] = "table_id_61";
+  auto tablet_entity =
+      METRIC_ENTITY_tablet.Instantiate(&registry_, "tablet_entity_id_62", entity_attr);
+  entity_attr["stream_id"] = "stream_id_63";
+  auto xcluster_entity =
+      METRIC_ENTITY_xcluster.Instantiate(&registry_, "xcluster_entity_id_64", entity_attr);
+
+  scoped_refptr<Counter> tablet_counter = METRIC_t_counter.Instantiate(tablet_entity);
+  scoped_refptr<Counter> xcluster_counter = METRIC_t_xcluster_counter.Instantiate(xcluster_entity);
+  tablet_counter->Increment();
+  xcluster_counter->Increment();
+
+  MetricPrometheusOptions opts;
+  opts.active_table_ids = std::make_shared<std::unordered_set<std::string>>();
+  std::stringstream output;
+  PrometheusWriter writer(&output, opts);
+  ASSERT_OK(registry_.WriteForPrometheus(&writer, opts));
+
+  const auto output_str = output.str();
+  ASSERT_STR_NOT_CONTAINS(output_str, METRIC_t_counter.name());
+  ASSERT_STR_CONTAINS(output_str, METRIC_t_xcluster_counter.name());
+  ASSERT_STR_CONTAINS(output_str, R"#(stream_id="stream_id_63")#");
 }
 
 TEST_F(MetricsTest, SimulateMetricDeletionBeforeFlush) {

--- a/src/yb/util/metrics_writer.cc
+++ b/src/yb/util/metrics_writer.cc
@@ -33,6 +33,7 @@ PrometheusWriter::PrometheusWriter(std::stringstream* output,
           std::chrono::system_clock::now().time_since_epoch()).count()),
       export_help_and_type_(opts.export_help_and_type),
       prometheus_metric_filter_(CreatePrometheusMetricFilter(opts)),
+      active_table_ids_(opts.active_table_ids),
       remaining_allowed_entries_(opts.max_metric_entries) {}
 
 PrometheusWriter::~PrometheusWriter() {}
@@ -45,12 +46,6 @@ Status PrometheusWriter::FlushScrapeTimeAggregatedValues() {
       continue;
     }
     auto& aggregated_values = metric_info.scrape_time_aggregated_values_;
-    if (remaining_allowed_entries_ < aggregated_values.size()) {
-      num_of_entries_cut_off_ += aggregated_values.size();
-      continue;
-    }
-    remaining_allowed_entries_ -= aggregated_values.size();
-
     const auto& metric_entity_type = metric_info.metric_entity_type_;
     auto attributes_by_aggregation_id_it =
         attributes_by_metric_entity_type_and_aggregation_id_.find(metric_entity_type);
@@ -63,6 +58,20 @@ Status PrometheusWriter::FlushScrapeTimeAggregatedValues() {
 
     const auto& metric_help = metric_info.help_and_type_.help;
     const auto& metric_type = metric_info.help_and_type_.type;
+    size_t num_output_entries = 0;
+    for (const auto& [aggregation_id, value] : aggregated_values) {
+      auto attributes_it = attributes_by_aggregation_id.find(aggregation_id);
+      if (attributes_it != attributes_by_aggregation_id.end() &&
+          ShouldExportTableMetrics(attributes_it->second)) {
+        ++num_output_entries;
+      }
+    }
+    if (remaining_allowed_entries_ < num_output_entries) {
+      num_of_entries_cut_off_ += num_output_entries;
+      continue;
+    }
+    remaining_allowed_entries_ -= num_output_entries;
+
     for (const auto& [aggregation_id, value] : aggregated_values) {
       auto attributes_it = attributes_by_aggregation_id.find(aggregation_id);
       if (attributes_it == attributes_by_aggregation_id.end()) {
@@ -70,11 +79,23 @@ Status PrometheusWriter::FlushScrapeTimeAggregatedValues() {
             Format("No attributes stored for metric with entity type $0 and aggregation id $1",
                 metric_entity_type, aggregation_id));
       }
+      if (!ShouldExportTableMetrics(attributes_it->second)) {
+        continue;
+      }
       FlushHelpAndTypeIfRequested(metric_name, metric_help, metric_type);
       RETURN_NOT_OK(FlushSingleEntry(attributes_it->second, metric_name, value));
     }
   }
   return Status::OK();
+}
+
+bool PrometheusWriter::ShouldExportTableMetrics(
+    const MetricEntity::AttributeMap& attributes) const {
+  if (!active_table_ids_) {
+    return true;
+  }
+  const auto table_id = attributes.find("table_id");
+  return table_id == attributes.end() || active_table_ids_->contains(table_id->second);
 }
 
 Status PrometheusWriter::Finish(const MetricsAggregator& metrics_aggregator) {
@@ -207,9 +228,11 @@ Status PrometheusWriter::WriteSingleEntry(
 
   if (aggregation_levels & kTableLevel) {
     DCHECK(table_id_it != attributes.end());
-    AddScrapeTimeAggregatedEntry(
-        table_id_it->second, type, description, attributes, name, value,
-        aggregation_function, metric_entity_type, metric_prototype_holder);
+    if (ShouldExportTableMetrics(attributes)) {
+      AddScrapeTimeAggregatedEntry(
+          table_id_it->second, type, description, attributes, name, value,
+          aggregation_function, metric_entity_type, metric_prototype_holder);
+    }
   }
 
   if (aggregation_levels & kServerLevel) {
@@ -273,17 +296,6 @@ Status PrometheusWriter::FlushPreAggregatedValues(
     bool need_table_or_stream_level_values = aggregation_levels & kTableLevel ||
                                              aggregation_levels & kStreamLevel;
 
-    // Make sure we have enough space to write all the entries.
-    auto num_output_entries = (need_table_or_stream_level_values)
-                              ? metric_info.num_aggregated_value_holders()
-                              : 0;
-    num_output_entries += (need_server_level_values) ? 1 : 0;
-    if (remaining_allowed_entries_ < num_output_entries) {
-      num_of_entries_cut_off_ += num_output_entries;
-      continue;
-    }
-    remaining_allowed_entries_ -= num_output_entries;
-
     // Retrieve attributes_ptr_by_aggregation_id map.
     auto attributes_ptr_by_aggregation_id_it =
         attributes_ptr_by_metric_entity_type_and_aggregation_id.find(
@@ -300,6 +312,20 @@ Status PrometheusWriter::FlushPreAggregatedValues(
     const auto& metric_type = metric_info.help_and_type_.type;
     const auto pre_aggregated_values = metric_info.GetPreAggregatedValues(
         need_server_level_values, need_table_or_stream_level_values);
+    size_t num_output_entries = 0;
+    for (const auto& [aggregation_id, value] : pre_aggregated_values) {
+      auto attributes_ptr_it = attributes_ptr_by_aggregation_id.find(aggregation_id);
+      if (attributes_ptr_it != attributes_ptr_by_aggregation_id.end() &&
+          ShouldExportTableMetrics(*attributes_ptr_it->second)) {
+        ++num_output_entries;
+      }
+    }
+    if (remaining_allowed_entries_ < num_output_entries) {
+      num_of_entries_cut_off_ += num_output_entries;
+      continue;
+    }
+    remaining_allowed_entries_ -= num_output_entries;
+
     for (const auto& [aggregation_id, value] : pre_aggregated_values) {
       auto attributes_ptr_it = attributes_ptr_by_aggregation_id.find(aggregation_id);
       if (attributes_ptr_it == attributes_ptr_by_aggregation_id.end()) {
@@ -307,6 +333,9 @@ Status PrometheusWriter::FlushPreAggregatedValues(
             "No server-level attributes stored for metric with entity type $0, aggregation id $1",
             metric_info.metric_entity_type_, aggregation_id));
         // This can happen when a new tablet is added during the flush.
+        continue;
+      }
+      if (!ShouldExportTableMetrics(*attributes_ptr_it->second)) {
         continue;
       }
 

--- a/src/yb/util/metrics_writer.cc
+++ b/src/yb/util/metrics_writer.cc
@@ -264,6 +264,9 @@ Status PrometheusWriter::FlushPreAggregatedValues(
   const auto& pre_aggregated_metric_info_by_metric_name =
       metrics_aggregator.pre_aggregated_metric_info_by_metric_name();
 
+  // Reused across metrics to avoid reallocating for every metric name.
+  std::vector<std::pair<const MetricEntity::AttributeMap*, int64_t>> entries_to_flush;
+
   for (const auto& [name, metric_info_ptr] : pre_aggregated_metric_info_by_metric_name) {
     const auto& metric_info = *metric_info_ptr;
 
@@ -288,26 +291,12 @@ Status PrometheusWriter::FlushPreAggregatedValues(
     }
     const auto& attributes_ptr_by_aggregation_id = attributes_ptr_by_aggregation_id_it->second;
 
-    // Begin flushing the metric.
-    const auto& metric_help = metric_info.help_and_type_.help;
-    const auto& metric_type = metric_info.help_and_type_.type;
+    // Collect the entries to flush, so that the entry budget below only accounts for entries
+    // that are actually exported.
     const auto pre_aggregated_values = metric_info.GetPreAggregatedValues(
         need_server_level_values, need_table_or_stream_level_values);
-    size_t num_output_entries = 0;
-    for (const auto& [aggregation_id, value] : pre_aggregated_values) {
-      auto attributes_ptr_it = attributes_ptr_by_aggregation_id.find(aggregation_id);
-      if (attributes_ptr_it != attributes_ptr_by_aggregation_id.end() &&
-          prometheus_metric_filter_->ShouldExportTableMetrics(
-              *attributes_ptr_it->second, metric_info.metric_entity_type_)) {
-        ++num_output_entries;
-      }
-    }
-    if (remaining_allowed_entries_ < num_output_entries) {
-      num_of_entries_cut_off_ += num_output_entries;
-      continue;
-    }
-    remaining_allowed_entries_ -= num_output_entries;
-
+    entries_to_flush.clear();
+    entries_to_flush.reserve(pre_aggregated_values.size());
     for (const auto& [aggregation_id, value] : pre_aggregated_values) {
       auto attributes_ptr_it = attributes_ptr_by_aggregation_id.find(aggregation_id);
       if (attributes_ptr_it == attributes_ptr_by_aggregation_id.end()) {
@@ -321,9 +310,21 @@ Status PrometheusWriter::FlushPreAggregatedValues(
               *attributes_ptr_it->second, metric_info.metric_entity_type_)) {
         continue;
       }
+      entries_to_flush.emplace_back(attributes_ptr_it->second.get(), value);
+    }
 
+    if (remaining_allowed_entries_ < entries_to_flush.size()) {
+      num_of_entries_cut_off_ += entries_to_flush.size();
+      continue;
+    }
+    remaining_allowed_entries_ -= entries_to_flush.size();
+
+    // Begin flushing the metric.
+    const auto& metric_help = metric_info.help_and_type_.help;
+    const auto& metric_type = metric_info.help_and_type_.type;
+    for (const auto& [attributes_ptr, value] : entries_to_flush) {
       FlushHelpAndTypeIfRequested(name, metric_help, metric_type);
-      RETURN_NOT_OK(FlushSingleEntry(*attributes_ptr_it->second, name, value));
+      RETURN_NOT_OK(FlushSingleEntry(*attributes_ptr, name, value));
     }
   }
 

--- a/src/yb/util/metrics_writer.cc
+++ b/src/yb/util/metrics_writer.cc
@@ -33,7 +33,6 @@ PrometheusWriter::PrometheusWriter(std::stringstream* output,
           std::chrono::system_clock::now().time_since_epoch()).count()),
       export_help_and_type_(opts.export_help_and_type),
       prometheus_metric_filter_(CreatePrometheusMetricFilter(opts)),
-      active_table_ids_(opts.active_table_ids),
       remaining_allowed_entries_(opts.max_metric_entries) {}
 
 PrometheusWriter::~PrometheusWriter() {}
@@ -45,7 +44,15 @@ Status PrometheusWriter::FlushScrapeTimeAggregatedValues() {
       // This metric has been removed, so we don't need to output it.
       continue;
     }
+    // Entries excluded by the active-table list are never aggregated, so the budget below only
+    // accounts for entries that will be flushed.
     auto& aggregated_values = metric_info.scrape_time_aggregated_values_;
+    if (remaining_allowed_entries_ < aggregated_values.size()) {
+      num_of_entries_cut_off_ += aggregated_values.size();
+      continue;
+    }
+    remaining_allowed_entries_ -= aggregated_values.size();
+
     const auto& metric_entity_type = metric_info.metric_entity_type_;
     auto attributes_by_aggregation_id_it =
         attributes_by_metric_entity_type_and_aggregation_id_.find(metric_entity_type);
@@ -58,20 +65,6 @@ Status PrometheusWriter::FlushScrapeTimeAggregatedValues() {
 
     const auto& metric_help = metric_info.help_and_type_.help;
     const auto& metric_type = metric_info.help_and_type_.type;
-    size_t num_output_entries = 0;
-    for (const auto& [aggregation_id, value] : aggregated_values) {
-      auto attributes_it = attributes_by_aggregation_id.find(aggregation_id);
-      if (attributes_it != attributes_by_aggregation_id.end() &&
-          ShouldExportTableMetrics(attributes_it->second)) {
-        ++num_output_entries;
-      }
-    }
-    if (remaining_allowed_entries_ < num_output_entries) {
-      num_of_entries_cut_off_ += num_output_entries;
-      continue;
-    }
-    remaining_allowed_entries_ -= num_output_entries;
-
     for (const auto& [aggregation_id, value] : aggregated_values) {
       auto attributes_it = attributes_by_aggregation_id.find(aggregation_id);
       if (attributes_it == attributes_by_aggregation_id.end()) {
@@ -79,23 +72,11 @@ Status PrometheusWriter::FlushScrapeTimeAggregatedValues() {
             Format("No attributes stored for metric with entity type $0 and aggregation id $1",
                 metric_entity_type, aggregation_id));
       }
-      if (!ShouldExportTableMetrics(attributes_it->second)) {
-        continue;
-      }
       FlushHelpAndTypeIfRequested(metric_name, metric_help, metric_type);
       RETURN_NOT_OK(FlushSingleEntry(attributes_it->second, metric_name, value));
     }
   }
   return Status::OK();
-}
-
-bool PrometheusWriter::ShouldExportTableMetrics(
-    const MetricEntity::AttributeMap& attributes) const {
-  if (!active_table_ids_) {
-    return true;
-  }
-  const auto table_id = attributes.find("table_id");
-  return table_id == attributes.end() || active_table_ids_->contains(table_id->second);
 }
 
 Status PrometheusWriter::Finish(const MetricsAggregator& metrics_aggregator) {
@@ -228,7 +209,7 @@ Status PrometheusWriter::WriteSingleEntry(
 
   if (aggregation_levels & kTableLevel) {
     DCHECK(table_id_it != attributes.end());
-    if (ShouldExportTableMetrics(attributes)) {
+    if (prometheus_metric_filter_->ShouldExportTableMetrics(attributes, metric_entity_type)) {
       AddScrapeTimeAggregatedEntry(
           table_id_it->second, type, description, attributes, name, value,
           aggregation_function, metric_entity_type, metric_prototype_holder);
@@ -316,7 +297,8 @@ Status PrometheusWriter::FlushPreAggregatedValues(
     for (const auto& [aggregation_id, value] : pre_aggregated_values) {
       auto attributes_ptr_it = attributes_ptr_by_aggregation_id.find(aggregation_id);
       if (attributes_ptr_it != attributes_ptr_by_aggregation_id.end() &&
-          ShouldExportTableMetrics(*attributes_ptr_it->second)) {
+          prometheus_metric_filter_->ShouldExportTableMetrics(
+              *attributes_ptr_it->second, metric_info.metric_entity_type_)) {
         ++num_output_entries;
       }
     }
@@ -335,7 +317,8 @@ Status PrometheusWriter::FlushPreAggregatedValues(
         // This can happen when a new tablet is added during the flush.
         continue;
       }
-      if (!ShouldExportTableMetrics(*attributes_ptr_it->second)) {
+      if (!prometheus_metric_filter_->ShouldExportTableMetrics(
+              *attributes_ptr_it->second, metric_info.metric_entity_type_)) {
         continue;
       }
 

--- a/src/yb/util/metrics_writer.h
+++ b/src/yb/util/metrics_writer.h
@@ -115,6 +115,8 @@ class PrometheusWriter {
 
   void InvalidAggregationFunction(AggregationFunction aggregation_function);
 
+  bool ShouldExportTableMetrics(const MetricEntity::AttributeMap& attributes) const;
+
   void AddScrapeTimeAggregatedEntry(const std::string& key,
                           const char* type, const char* description,
                           const MetricEntity::AttributeMap& attributes,
@@ -142,6 +144,8 @@ class PrometheusWriter {
   ExportHelpAndType export_help_and_type_ = ExportHelpAndType::kFalse;
 
   std::unique_ptr<PrometheusMetricFilter> prometheus_metric_filter_;
+
+  const std::shared_ptr<const std::unordered_set<std::string>> active_table_ids_;
 
   uint32_t remaining_allowed_entries_;
 

--- a/src/yb/util/metrics_writer.h
+++ b/src/yb/util/metrics_writer.h
@@ -115,8 +115,6 @@ class PrometheusWriter {
 
   void InvalidAggregationFunction(AggregationFunction aggregation_function);
 
-  bool ShouldExportTableMetrics(const MetricEntity::AttributeMap& attributes) const;
-
   void AddScrapeTimeAggregatedEntry(const std::string& key,
                           const char* type, const char* description,
                           const MetricEntity::AttributeMap& attributes,
@@ -144,8 +142,6 @@ class PrometheusWriter {
   ExportHelpAndType export_help_and_type_ = ExportHelpAndType::kFalse;
 
   std::unique_ptr<PrometheusMetricFilter> prometheus_metric_filter_;
-
-  const std::shared_ptr<const std::unordered_set<std::string>> active_table_ids_;
 
   uint32_t remaining_allowed_entries_;
 

--- a/src/yb/util/prometheus_metric_filter-test.cc
+++ b/src/yb/util/prometheus_metric_filter-test.cc
@@ -33,6 +33,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 #include <gtest/gtest.h>
 
@@ -291,6 +292,66 @@ TEST_F(PrometheusMetricFilterTest, TestV2ServerLevel) {
   ASSERT_EQ(kTableLevel, names_to_levels[kTabletMetricName2]);
   ASSERT_EQ(kTableLevel, names_to_levels[kTableMetricName]);
   ASSERT_EQ(kNoLevel, names_to_levels[kServerMetricName]);
+}
+
+TEST_F(PrometheusMetricFilterTest, TestActiveTableIds) {
+  auto GetOutput = [this](const MetricPrometheusOptions& opts) -> Result<std::string> {
+    std::stringstream output;
+    PrometheusWriter writer(&output, opts);
+    RETURN_NOT_OK(registry_.WriteForPrometheus(&writer, opts));
+    return output.str();
+  };
+
+  static const auto kTableIdLabel1 = R"#(table_id="table_id_1")#";
+  static const auto kTableIdLabel2 = R"#(table_id="table_id_2")#";
+
+  for (const auto& version : {kFilterVersionOne, kFilterVersionTwo}) {
+    SCOPED_TRACE(version);
+    MetricPrometheusOptions opts;
+    opts.version = version;
+
+    // Without an active-table list, every table is exported.
+    auto output = ASSERT_RESULT(GetOutput(opts));
+    ASSERT_STR_CONTAINS(output, kTableIdLabel1);
+    ASSERT_STR_CONTAINS(output, kTableIdLabel2);
+    ASSERT_STR_CONTAINS(output, kServerMetricName);
+
+    // A list drops the table level series of every table outside of it.
+    opts.active_table_ids = std::make_shared<std::unordered_set<std::string>>(
+        std::initializer_list<std::string>{"table_id_1"});
+    output = ASSERT_RESULT(GetOutput(opts));
+    ASSERT_STR_CONTAINS(output, kTableIdLabel1);
+    ASSERT_STR_NOT_CONTAINS(output, kTableIdLabel2);
+    ASSERT_STR_CONTAINS(output, kServerMetricName);
+
+    // An empty list drops all of them, while metrics without a table id are untouched.
+    opts.active_table_ids = std::make_shared<std::unordered_set<std::string>>();
+    output = ASSERT_RESULT(GetOutput(opts));
+    ASSERT_STR_NOT_CONTAINS(output, "table_id=");
+    ASSERT_STR_CONTAINS(output, kServerMetricName);
+  }
+}
+
+TEST_F(PrometheusMetricFilterTest, TestActiveTableIdsWithMaxMetricEntries) {
+  MetricPrometheusOptions opts;
+  opts.version = kFilterVersionTwo;
+  opts.table_allowlist_string = kTableMetricName;
+  opts.server_allowlist_string = kServerMetricName;
+  // Only table_id_1 and the server metric are left to export, so the two entries fit into the
+  // budget and nothing is reported as cut off.
+  opts.active_table_ids = std::make_shared<std::unordered_set<std::string>>(
+      std::initializer_list<std::string>{"table_id_1"});
+  opts.max_metric_entries = 2;
+
+  NMSWriter::EntityMetricsMap table_metrics;
+  NMSWriter::MetricsMap server_metrics;
+  NMSWriter writer(&table_metrics, &server_metrics, opts);
+  ASSERT_OK(registry_.WriteForPrometheus(&writer, opts));
+
+  ASSERT_EQ(1, table_metrics.size());
+  ASSERT_TRUE(table_metrics.contains("table_id_1"));
+  ASSERT_EQ(1, server_metrics.size());
+  ASSERT_EQ(0, writer.TEST_GetNumberOfEntriesCutOff());
 }
 
 TEST_F(PrometheusMetricFilterTest, TestLimitMaxMetricEntries) {

--- a/src/yb/util/prometheus_metric_filter.cc
+++ b/src/yb/util/prometheus_metric_filter.cc
@@ -19,6 +19,24 @@
 
 namespace yb {
 
+PrometheusMetricFilter::PrometheusMetricFilter(const MetricPrometheusOptions& opts)
+    : active_table_ids_(opts.active_table_ids) {}
+
+bool PrometheusMetricFilter::ShouldExportTableMetrics(
+    const MetricEntity::AttributeMap& attributes, const std::string& metric_entity_type) const {
+  if (!active_table_ids_) {
+    return true;
+  }
+  // xCluster series carry a table id but are aggregated per stream, so they are not part of the
+  // table-level metrics the active-table list controls.
+  if (metric_entity_type == kXClusterMetricEntityName ||
+      metric_entity_type == kCdcsdkMetricEntityName) {
+    return true;
+  }
+  const auto table_id = attributes.find("table_id");
+  return table_id == attributes.end() || active_table_ids_->contains(table_id->second);
+}
+
 namespace {
 
 class PrometheusMetricFilterV1 : public PrometheusMetricFilter {
@@ -39,7 +57,8 @@ class PrometheusMetricFilterV1 : public PrometheusMetricFilter {
 };
 
 PrometheusMetricFilterV1::PrometheusMetricFilterV1(const MetricPrometheusOptions& opts)
-    : priority_regex_(opts.priority_regex_string),
+    : PrometheusMetricFilter(opts),
+      priority_regex_(opts.priority_regex_string),
       general_metrics_allowlist_(opts.general_metrics_allowlist) {}
 
 bool PrometheusMetricFilterV1::ShouldCollectMetric(const std::string& metric_name) const {
@@ -101,7 +120,8 @@ class PrometheusMetricFilterV2 : public PrometheusMetricFilter {
 };
 
 PrometheusMetricFilterV2::PrometheusMetricFilterV2(const MetricPrometheusOptions& opts)
-    : table_allowlist_(opts.table_allowlist_string),
+    : PrometheusMetricFilter(opts),
+      table_allowlist_(opts.table_allowlist_string),
       table_blocklist_(opts.table_blocklist_string),
       server_allowlist_(opts.server_allowlist_string),
       server_blocklist_(opts.server_blocklist_string) {}

--- a/src/yb/util/prometheus_metric_filter.h
+++ b/src/yb/util/prometheus_metric_filter.h
@@ -21,8 +21,15 @@ namespace yb {
 
 class PrometheusMetricFilter {
  public:
+  explicit PrometheusMetricFilter(const MetricPrometheusOptions& opts);
+
   virtual AggregationLevels GetAggregationLevels(
       const std::string& metric_name, AggregationLevels default_aggregation_levels) = 0;
+
+  // Returns whether an entry with the given attributes passes the active-table list, if one was
+  // supplied. Entries without a table id, and entries of stream-level entities, always pass.
+  bool ShouldExportTableMetrics(
+      const MetricEntity::AttributeMap& attributes, const std::string& metric_entity_type) const;
 
   virtual std::string Version() const = 0;
 
@@ -34,6 +41,9 @@ class PrometheusMetricFilter {
 
  protected:
   MetricAggregationMap metric_filter_;
+
+ private:
+  const std::shared_ptr<const std::unordered_set<std::string>> active_table_ids_;
 };
 
 std::unique_ptr<PrometheusMetricFilter> CreatePrometheusMetricFilter(


### PR DESCRIPTION
## Summary

Add a `SetActiveTableMetrics` tablet-server RPC that lets an external metrics collector replace the complete set of active table IDs.

The runtime `enable_active_table_metrics_filtering` gflag defaults to disabled. When disabled, `/prometheus-metrics` exports all table metrics. When enabled, a fresh or restarted tablet server exports no table-level metrics until it receives its first list, then continues using the latest accepted list until it is replaced. An empty list suppresses all table-level series while retaining non-table metrics.

The `max_active_table_metrics_table_count` runtime gflag defaults to 1000. Requests above that limit are rejected without changing the current list. The server-level `active_table_metrics_last_update_time` gauge records the physical time of each accepted update so monitoring can alert when the control plane has not refreshed a tablet server.

Filtering is intentionally applied during the Prometheus scrape to both pre-aggregated and scrape-time aggregated values, including metric-entry limit accounting. Counters, gauges, histograms, and pre-aggregated values continue to be maintained for all tables. This preserves cumulative metric semantics and server-level aggregates while avoiding synchronization in metric-update hot paths. The change reduces exported series cardinality and scrape work, but does not reduce internal metric collection overhead.

## Upgrade/Rollback safety

The protobuf change is additive. Older tablet servers do not expose `SetActiveTableMetrics`, so the collector must tolerate `UNIMPLEMENTED` during a mixed-version upgrade. New tablet servers retain export-all behavior by default because `enable_active_table_metrics_filtering` is disabled.

Enable filtering only after the collector can publish active-table lists to upgraded tablet servers. Once enabled, a restarted tablet server intentionally suppresses table metrics until it receives a list. Rolling back removes the RPC and returns nodes to the existing export-all behavior; active-table state is process-local and is not persisted.

## Test plan

- [x] `./yb_build.sh debug --cxx-test metrics-test --gtest_filter MetricsTest.AggregationTest`
- [x] `./yb_build.sh debug --cxx-test tablet_server-test --gtest_filter TabletServerTest.ActiveTableMetricsFiltering`
- [x] `./yb_build.sh debug --target tablet_server-test --sj --skip-pg-parquet --no-odyssey --no-ybc`
- [x] Scoped lint for all modified files
