### PR TITLE
[BACKPORT 2026.1][#32681] DocDB: Soft-fail list_tablet_server_log_locations on DEAD tservers (#32787)

### DIFF
--- a/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/ReplaceNodeInUniverse.java
+++ b/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/ReplaceNodeInUniverse.java
@@ -55,7 +55,7 @@ public class ReplaceNodeInUniverse extends EditUniverseTaskBase {
           false);
 
       // Generate new nodeDetails from existing node.
-      NodeDetails newNode = PlacementInfoUtil.createToBeAddedNode(currentNode);
+      NodeDetails newNode = PlacementInfoUtil.createToBeAddedNode(universe, currentNode);
       // Set the replacement node to toBeRemoved state.
       setToBeRemovedState(currentNode);
 

--- a/managed/src/main/java/com/yugabyte/yw/common/PlacementInfoUtil.java
+++ b/managed/src/main/java/com/yugabyte/yw/common/PlacementInfoUtil.java
@@ -2182,7 +2182,7 @@ public class PlacementInfoUtil {
     return result;
   }
 
-  public static NodeDetails createToBeAddedNode(NodeDetails templateNode) {
+  public static NodeDetails createToBeAddedNode(Universe universe, NodeDetails templateNode) {
     NodeDetails newNode = new NodeDetails();
     newNode.cloudInfo = new CloudSpecificInfo();
     newNode.ybPrebuiltAmi = templateNode.ybPrebuiltAmi;
@@ -2191,10 +2191,28 @@ public class PlacementInfoUtil {
 
     newNode.disksAreMountedByUUID = true;
     newNode.isMaster = templateNode.isMaster;
+    newNode.isTserver = templateNode.isTserver;
+
+    if (!newNode.isMaster && !newNode.isTserver) {
+      Cluster cluster = universe.getCluster(templateNode.placementUuid);
+      if (cluster == null) {
+        throw new IllegalStateException(
+            "Cluster for " + templateNode.nodeName + " node is not found");
+      }
+      if (templateNode.dedicatedTo != null && cluster.userIntent.dedicatedNodes) {
+        if (templateNode.dedicatedTo == ServerType.TSERVER) {
+          newNode.isTserver = true;
+        } else if (templateNode.dedicatedTo == ServerType.MASTER) {
+          newNode.isMaster = true;
+        }
+      } else {
+        newNode.isTserver = true;
+      }
+    }
     if (newNode.isMaster) {
       newNode.masterState = NodeDetails.MasterState.ToStart;
     }
-    newNode.isTserver = templateNode.isTserver;
+
     newNode.state = NodeDetails.NodeState.ToBeAdded;
 
     if (templateNode.cloudInfo == null) {

--- a/managed/src/test/java/com/yugabyte/yw/commissioner/tasks/local/NodeOperationsLocalTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/commissioner/tasks/local/NodeOperationsLocalTest.java
@@ -195,6 +195,39 @@ public class NodeOperationsLocalTest extends LocalProviderUniverseTestBase {
   }
 
   @Test
+  public void testReplaceStoppedNodeInUniverse() throws InterruptedException {
+    UniverseDefinitionTaskParams.UserIntent userIntent = getDefaultUserIntent();
+    userIntent.specificGFlags = getGFlags();
+    Universe universe = createUniverse(userIntent);
+    NodeDetails nodeDetails = universe.getUniverseDetails().nodeDetailsSet.iterator().next();
+    verifyUniverseState(universe);
+
+    String nodeName = nodeDetails.nodeName;
+    NodeActionFormData formData = new NodeActionFormData();
+    formData.nodeAction = NodeActionType.STOP;
+    Result result = nodeOperationInUniverse(universe.getUniverseUUID(), nodeName, formData);
+    checkAndWaitForTask(result);
+    universe = Universe.getOrBadRequest(universe.getUniverseUUID());
+
+    for (NodeDetails details : universe.getUniverseDetails().nodeDetailsSet) {
+      if (details.nodeName.equals(nodeName)) {
+        assertEquals(NodeDetails.NodeState.Stopped, details.state);
+      } else {
+        assertEquals(NodeDetails.NodeState.Live, details.state);
+      }
+    }
+
+    formData.nodeAction = NodeActionType.REPLACE;
+    result = nodeOperationInUniverse(universe.getUniverseUUID(), nodeName, formData);
+    checkAndWaitForTask(result);
+    universe = Universe.getOrBadRequest(universe.getUniverseUUID());
+    for (NodeDetails details : universe.getUniverseDetails().nodeDetailsSet) {
+      assertEquals(NodeDetails.NodeState.Live, details.state);
+    }
+    verifyUniverseState(universe);
+  }
+
+  @Test
   public void testRemoveNodeFromUniverseGeoFAIL() throws InterruptedException {
     UniverseDefinitionTaskParams taskParams = new UniverseDefinitionTaskParams();
 


### PR DESCRIPTION
## Summary

`yb-admin list_tablet_server_log_locations` aborted with a connect
timeout when the master's tablet-server registry still contained DEAD
entries. The command issued `GetLogLocation` to every registered tserver
and failed the whole listing on the first `VERIFY_RESULT` error.

This change:
- Skips RPCs to known-DEAD tservers and reports their log location as
`N/A`
- Soft-fails per-server RPC / missing-address errors so live tservers
still list
- Uses the RPC address from the already-fetched `ListTabletServers`
entry (avoids re-listing per server)
- Sorts tservers alive-first (reusing `SortListTabletServerEntries`) so
unreachable nodes appear last, matching `list_all_tablet_servers`

## Example

Cluster with 6 tservers where `192.0.2.5` and `192.0.2.6` are DEAD.

Server list:

```
yb-admin --master_addresses 192.0.2.159,192.0.2.114 list_all_tablet_servers
    Tablet Server UUID               RPC Host/Port     Heartbeat delay Status   Reads/s  Writes/s Uptime   SST total size  SST uncomp size SST #files      Memory   Broadcast Host/Port
    02bb1fd6c6fa4d418448524aa00ee691 192.0.2.106:9100  0.59s           ALIVE    0.00     0.00     8351     0 B             0 B             0               62.99 MB N/A
    338e9dee7ab84560a8cd53dc7dc89ef4 192.0.2.114:9100  0.44s           ALIVE    0.00     0.00     6198     0 B             0 B             0               57.34 MB N/A
    cd3105d3bd5540d899d2a0f073c2105a 192.0.2.144:9100  0.86s           ALIVE    0.00     0.00     2855     333.44 KB       337.00 KB       5               54.91 MB N/A
    ee6a69e00dc04a14a0f70be7927a9cc4 192.0.2.159:9100  0.66s           ALIVE    0.00     0.00     6067     133.81 KB       136.44 KB       2               61.48 MB N/A
    1fb95dd124e54edb858c71fa6e06ea1b 192.0.2.111:9100  5783.08s        DEAD     0.00     0.00     0        0 B             0 B             0               0 B      N/A
    8a301f6b02af46c8a5d7c85ab4bdfdcf 192.0.2.182:9100  5770.50s        DEAD     0.00     0.00     0        0 B             0 B             0               0 B      N/A
```

**Without this fix** : aborts on the first unreachable tserver, hiding
the rest:

$ yb-admin --master_addresses 192.0.2.1,192.0.2.2
list_tablet_server_log_locations
    TS UUID                            RPC Host/Port    LogLocation
0000000000000000000000000000aaaa 192.0.2.1:9100
/mnt/d0/yb-data/tserver/logs
Error running list_tablet_server_log_locations: Network error
(yb/rpc/connection.cc:268): Unable to list tablet server log locations:
Connect timeout ... => 192.0.2.5:9100, passed: 14.987s, timeout:
15.000s: kConnectFailed (network error 1)

**With this fix** : lists every tserver, DEAD nodes show `N/A` and sort
last:

$ yb-admin --master_addresses 192.0.2.1,192.0.2.2
list_tablet_server_log_locations
    TS UUID                            RPC Host/Port    LogLocation
0000000000000000000000000000aaaa 192.0.2.1:9100
/mnt/d0/yb-data/tserver/logs
0000000000000000000000000000bbbb 192.0.2.2:9100
/mnt/d0/yb-data/tserver/logs
0000000000000000000000000000cccc 192.0.2.3:9100
/mnt/d0/yb-data/tserver/logs
0000000000000000000000000000dddd 192.0.2.4:9100
/mnt/d0/yb-data/tserver/logs
    0000000000000000000000000000eeee   192.0.2.5:9100   N/A
    0000000000000000000000000000ffff   192.0.2.6:9100   N/A

Original commit: ae915b2567d7241700b2dda321bf2f0fa470b824 / #32787

## Test plan

- [x] `./yb_build.sh release --cxx-test yb-admin-test --gtest_filter
AdminCliTest.TestListTabletServerLogLocationsWithDeadTServer`
- [x] Manually ran `yb-admin list_tablet_server_log_locations` against a
cluster with DEAD tservers: exits 0, live nodes show log dirs, dead
nodes show `N/A`

---------