### PR TITLE
[BACKPORT 2025.2][#32681] DocDB: Soft-fail list_tablet_server_log_locations on DEAD tservers (#32787)

### DIFF
--- a/build-support/generate_test_certificates.sh
+++ b/build-support/generate_test_certificates.sh
@@ -45,6 +45,7 @@ policy = yugabyte_policy
 
 unique_subject = no
 copy_extensions = copy
+x509_extensions = my_extensions
 
 [ yugabyte_policy ]
 commonName = supplied
@@ -55,6 +56,10 @@ distinguished_name = yugabyte_distinguished_name
 
 [ yugabyte_distinguished_name ]
 commonName = $common_name
+
+[ my_extensions ]
+basicConstraints = critical, CA:true
+keyUsage = critical, keyCertSign, cRLSign
 EOT
 
   cat > "$dir/ca.conf" <<-EOT

--- a/build-support/thirdparty_archives.yml
+++ b/build-support/thirdparty_archives.yml
@@ -1,126 +1,126 @@
-sha: d2c1bf5b659d9d598de0054bf465e1cd033fb77b
+sha: 0ea2a0241e58a6ba9a290af37263dad01f365da5
 archives:
 
   - os_type: almalinux8
     architecture: aarch64
     compiler_type: clang19
-    tag: v20260429072932-d2c1bf5b65-almalinux8-aarch64-clang19
+    tag: v2025.2-20260709154541-0ea2a0241e-almalinux8-aarch64-clang19
 
   - os_type: almalinux8
     architecture: aarch64
     compiler_type: clang19
     lto_type: full
-    tag: v20260429072958-d2c1bf5b65-almalinux8-aarch64-clang19-full-lto
+    tag: v2025.2-20260709154547-0ea2a0241e-almalinux8-aarch64-clang19-full-lto
 
   - os_type: almalinux8
     architecture: aarch64
     compiler_type: clang21
-    tag: v20260429073015-d2c1bf5b65-almalinux8-aarch64-clang21
+    tag: v2025.2-20260709155142-0ea2a0241e-almalinux8-aarch64-clang21
 
   - os_type: almalinux8
     architecture: aarch64
     compiler_type: clang21
     lto_type: full
-    tag: v20260429072838-d2c1bf5b65-almalinux8-aarch64-clang21-full-lto
+    tag: v2025.2-20260709155139-0ea2a0241e-almalinux8-aarch64-clang21-full-lto
 
   - os_type: almalinux8
     architecture: x86_64
     compiler_type: clang19
-    tag: v20260429072827-d2c1bf5b65-almalinux8-x86_64-clang19
+    tag: v2025.2-20260709154551-0ea2a0241e-almalinux8-x86_64-clang19
 
   - os_type: almalinux8
     architecture: x86_64
     compiler_type: clang19
     lto_type: full
-    tag: v20260429072755-d2c1bf5b65-almalinux8-x86_64-clang19-full-lto
+    tag: v2025.2-20260709154521-0ea2a0241e-almalinux8-x86_64-clang19-full-lto
 
   - os_type: almalinux8
     architecture: x86_64
     compiler_type: clang21
-    tag: v20260429073041-d2c1bf5b65-almalinux8-x86_64-clang21
+    tag: v2025.2-20260709154532-0ea2a0241e-almalinux8-x86_64-clang21
 
   - os_type: almalinux8
     architecture: x86_64
     compiler_type: clang21
     lto_type: full
-    tag: v20260429072849-d2c1bf5b65-almalinux8-x86_64-clang21-full-lto
+    tag: v2025.2-20260709154555-0ea2a0241e-almalinux8-x86_64-clang21-full-lto
 
   - os_type: almalinux8
     architecture: x86_64
     compiler_type: gcc12
-    tag: v20260429072901-d2c1bf5b65-almalinux8-x86_64-gcc12
+    tag: v2025.2-20260721161537-0ea2a0241e-almalinux8-x86_64-gcc12
 
   - os_type: almalinux8
     architecture: x86_64
     compiler_type: gcc13
-    tag: v20260429072818-d2c1bf5b65-almalinux8-x86_64-gcc13
+    tag: v2025.2-20260709154528-0ea2a0241e-almalinux8-x86_64-gcc13
 
   - os_type: almalinux9
     architecture: x86_64
     compiler_type: clang19
-    tag: v20260430050334-d2c1bf5b65-almalinux9-x86_64-clang19
+    tag: v2025.2-20260709154555-0ea2a0241e-almalinux9-x86_64-clang19
 
   - os_type: almalinux9
     architecture: x86_64
     compiler_type: clang21
-    tag: v20260429072841-d2c1bf5b65-almalinux9-x86_64-clang21
+    tag: v2025.2-20260709154611-0ea2a0241e-almalinux9-x86_64-clang21
 
   - os_type: almalinux9
     architecture: x86_64
     compiler_type: gcc12
-    tag: v20260429072827-d2c1bf5b65-almalinux9-x86_64-gcc12
+    tag: v2025.2-20260709154642-0ea2a0241e-almalinux9-x86_64-gcc12
 
   - os_type: almalinux9
     architecture: x86_64
     compiler_type: gcc13
-    tag: v20260429072833-d2c1bf5b65-almalinux9-x86_64-gcc13
+    tag: v2025.2-20260709154653-0ea2a0241e-almalinux9-x86_64-gcc13
 
   - os_type: macos
     architecture: arm64
     compiler_type: clang
-    tag: v20260429072638-d2c1bf5b65-macos-arm64
+    tag: v2025.2-20260709154411-0ea2a0241e-macos-arm64
 
   - os_type: macos
     architecture: arm64
     compiler_type: clang21
-    tag: v20260429072645-d2c1bf5b65-macos-arm64-clang21
+    tag: v2025.2-20260709154344-0ea2a0241e-macos-arm64-clang21
 
   - os_type: macos
     architecture: x86_64
     compiler_type: clang
-    tag: v20260429135133-d2c1bf5b65-macos-x86_64
+    tag: v2025.2-20260721161452-0ea2a0241e-macos-x86_64
 
   - os_type: macos
     architecture: x86_64
     compiler_type: clang21
-    tag: v20260429072823-d2c1bf5b65-macos-x86_64-clang21
+    tag: v2025.2-20260721161501-0ea2a0241e-macos-x86_64-clang21
 
   - os_type: ubuntu22.04
     architecture: x86_64
     compiler_type: clang19
-    tag: v20260429072829-d2c1bf5b65-ubuntu2204-x86_64-clang19
+    tag: v2025.2-20260709154456-0ea2a0241e-ubuntu2204-x86_64-clang19
 
   - os_type: ubuntu22.04
     architecture: x86_64
     compiler_type: clang21
-    tag: v20260429072848-d2c1bf5b65-ubuntu2204-x86_64-clang21
+    tag: v2025.2-20260709154511-0ea2a0241e-ubuntu2204-x86_64-clang21
 
   - os_type: ubuntu22.04
     architecture: x86_64
     compiler_type: gcc12
-    tag: v20260429072833-d2c1bf5b65-ubuntu2204-x86_64-gcc12
+    tag: v2025.2-20260709154535-0ea2a0241e-ubuntu2204-x86_64-gcc12
 
   - os_type: ubuntu24.04
     architecture: x86_64
     compiler_type: clang19
-    tag: v20260429072809-d2c1bf5b65-ubuntu2404-x86_64-clang19
+    tag: v2025.2-20260709154611-0ea2a0241e-ubuntu2404-x86_64-clang19
 
   - os_type: ubuntu24.04
     architecture: x86_64
     compiler_type: clang21
-    tag: v20260429072812-d2c1bf5b65-ubuntu2404-x86_64-clang21
+    tag: v2025.2-20260709154613-0ea2a0241e-ubuntu2404-x86_64-clang21
 
   - os_type: ubuntu24.04
     architecture: x86_64
     compiler_type: gcc13
-    tag: v20260429072945-d2c1bf5b65-ubuntu2404-x86_64-gcc13
+    tag: v2025.2-20260709154559-0ea2a0241e-ubuntu2404-x86_64-gcc13

--- a/build-support/tsan-suppressions.txt
+++ b/build-support/tsan-suppressions.txt
@@ -186,3 +186,6 @@ race:k5_once
 race:od_logger_format
 race:od_stat_query_end
 race:od_route_pool_stat
+
+# False positive because we compile OpenSSL without TSAN instrumentation (#32121).
+race:libcrypto.so.3

--- a/src/yb/integration-tests/secure_connection_test.cc
+++ b/src/yb/integration-tests/secure_connection_test.cc
@@ -221,7 +221,7 @@ TEST_F_EX(SecureConnectionTest, CipherList, SecureConnectionCipherListTest) {
 
 class SecureConnectionCipherSuitesTest : public SecureConnectionTest {
   void SetUp() override {
-    ANNOTATE_UNPROTECTED_WRITE(FLAGS_ciphersuites) = "TLS_AES_128_CCM_8_SHA256";
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_ciphersuites) = "TLS_AES_128_CCM_SHA256";
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_ssl_protocols) = "tls13";
     SecureConnectionTest::SetUp();
   }


### PR DESCRIPTION
## Summary

`yb-admin list_tablet_server_log_locations` aborted with a connect
timeout when the master's tablet-server registry still contained DEAD
entries. The command issued `GetLogLocation` to every registered tserver
and failed the whole listing on the first `VERIFY_RESULT` error.

This change:
- Skips RPCs to known-DEAD tservers and reports their log location as
`N/A`
- Soft-fails per-server RPC / missing-address errors so live tservers
still list
- Uses the RPC address from the already-fetched `ListTabletServers`
entry (avoids re-listing per server)
- Sorts tservers alive-first (reusing `SortListTabletServerEntries`) so
unreachable nodes appear last, matching `list_all_tablet_servers`

## Example

Cluster with 6 tservers where `192.0.2.5` and `192.0.2.6` are DEAD.

Server list:

```
yb-admin --master_addresses 192.0.2.159,192.0.2.114 list_all_tablet_servers
    Tablet Server UUID               RPC Host/Port     Heartbeat delay Status   Reads/s  Writes/s Uptime   SST total size  SST uncomp size SST #files      Memory   Broadcast Host/Port
    02bb1fd6c6fa4d418448524aa00ee691 192.0.2.106:9100  0.59s           ALIVE    0.00     0.00     8351     0 B             0 B             0               62.99 MB N/A
    338e9dee7ab84560a8cd53dc7dc89ef4 192.0.2.114:9100  0.44s           ALIVE    0.00     0.00     6198     0 B             0 B             0               57.34 MB N/A
    cd3105d3bd5540d899d2a0f073c2105a 192.0.2.144:9100  0.86s           ALIVE    0.00     0.00     2855     333.44 KB       337.00 KB       5               54.91 MB N/A
    ee6a69e00dc04a14a0f70be7927a9cc4 192.0.2.159:9100  0.66s           ALIVE    0.00     0.00     6067     133.81 KB       136.44 KB       2               61.48 MB N/A
    1fb95dd124e54edb858c71fa6e06ea1b 192.0.2.111:9100  5783.08s        DEAD     0.00     0.00     0        0 B             0 B             0               0 B      N/A
    8a301f6b02af46c8a5d7c85ab4bdfdcf 192.0.2.182:9100  5770.50s        DEAD     0.00     0.00     0        0 B             0 B             0               0 B      N/A
```

**Without this fix** : aborts on the first unreachable tserver, hiding
the rest:

$ yb-admin --master_addresses 192.0.2.1,192.0.2.2
list_tablet_server_log_locations
    TS UUID                            RPC Host/Port    LogLocation
0000000000000000000000000000aaaa 192.0.2.1:9100
/mnt/d0/yb-data/tserver/logs
Error running list_tablet_server_log_locations: Network error
(yb/rpc/connection.cc:268): Unable to list tablet server log locations:
Connect timeout ... => 192.0.2.5:9100, passed: 14.987s, timeout:
15.000s: kConnectFailed (network error 1)

**With this fix** : lists every tserver, DEAD nodes show `N/A` and sort
last:

$ yb-admin --master_addresses 192.0.2.1,192.0.2.2
list_tablet_server_log_locations
    TS UUID                            RPC Host/Port    LogLocation
0000000000000000000000000000aaaa 192.0.2.1:9100
/mnt/d0/yb-data/tserver/logs
0000000000000000000000000000bbbb 192.0.2.2:9100
/mnt/d0/yb-data/tserver/logs
0000000000000000000000000000cccc 192.0.2.3:9100
/mnt/d0/yb-data/tserver/logs
0000000000000000000000000000dddd 192.0.2.4:9100
/mnt/d0/yb-data/tserver/logs
    0000000000000000000000000000eeee   192.0.2.5:9100   N/A
    0000000000000000000000000000ffff   192.0.2.6:9100   N/A

Original commit: ae915b2567d7241700b2dda321bf2f0fa470b824 / #32787

## Test plan

- [x] `./yb_build.sh release --cxx-test yb-admin-test --gtest_filter
AdminCliTest.TestListTabletServerLogLocationsWithDeadTServer`
- [x] Manually ran `yb-admin list_tablet_server_log_locations` against a
cluster with DEAD tservers: exits 0, live nodes show log dirs, dead
nodes show `N/A`

---------