### PR TITLE
[DOC-1421] Clarify and refresh CDC known limitations

### DIFF
--- a/docs/content/stable/additional-features/change-data-capture/using-logical-replication/_index.md
+++ b/docs/content/stable/additional-features/change-data-capture/using-logical-replication/_index.md
@@ -118,19 +118,15 @@ For reference documentation, see [YugabyteDB Connector](./yugabytedb-connector/)
 
 - YCQL tables aren't currently supported. Issue {{<issue 11320>}}.
 
-- Transaction savepoints are supported starting from v2025.2.2.0. Issue {{<issue 10936>}}.
+- Transaction savepoints are not supported in versions earlier than v2025.2.2.0. Issue {{<issue 10936>}}.
 
 - Support for enabling CDC on Read Replicas is tracked in issue {{<issue 11116>}}.
-
-- Support for tablet splitting with logical replication is disabled from v2024.1.4 and v2024.2.1. Tracked in issue {{<issue 24918>}}.
 
 - A replication slot should be consumed by at most one consumer at a time. However, there is currently no locking mechanism to enforce this. As a result, you should ensure that multiple consumers do not consume from a slot simultaneously. Tracked in issue {{<issue 20755>}}.
 
 - If a row is updated or deleted in the same transaction in which it was inserted, CDC cannot retrieve the before-image values for the UPDATE / DELETE event unless the YB-TServer flag [cdc_enable_intra_transactional_before_image](../../../reference/configuration/yb-tserver/#cdc-enable-intra-transactional-before-image) is enabled (v2025.2.4.0+). With that flag enabled, CDC returns the row state immediately before each intra-transactional operation. If the replica identity is not CHANGE and a before image still cannot be found, CDC throws an error while processing the event.
 
     To handle updates/deletes with a non-CHANGE replica identity when no before image is available, set the YB-TServer flag [cdc_send_null_before_image_if_not_exists](../../../reference/configuration/yb-tserver/#cdc-send-null-before-image-if-not-exists) to true. With this flag enabled, CDC sends a null before-image instead of failing with an error.
-
-- Currently, to use [replication origins](./advanced-topic/#replication-origins), you must create the replication origin before you start streaming changes from a replication slot. Tracked in issue {{<issue 30068>}}.
 
 - Adding an expired or not-of-interest table to a publication renders the replication slot associated with this publication unusable. In such a scenario, the slot must be dropped and a new slot must be created to proceed. Tracked in issue {{<issue 28310>}}.
 

--- a/docs/content/stable/additional-features/change-data-capture/using-logical-replication/advanced-topic.md
+++ b/docs/content/stable/additional-features/change-data-capture/using-logical-replication/advanced-topic.md
@@ -305,8 +305,6 @@ In a bi-directional replication setup where two databases replicate changes to e
 
 This ensures that changes only flow in one direction.
 
-Note that, currently, you must create the replication origin before you start streaming changes from a replication slot. (Tracked in issue {{<issue 30068>}}.)
-
 The YugabyteDB implementation of replication origins mimics that of PostgreSQL; refer to [Replication Progress Tracking](https://www.postgresql.org/docs/15/replication-origins.html) in the PostgreSQL documentation.
 
 ### Properties
@@ -369,7 +367,3 @@ The PostgreSQL logical replication protocol streams transactions with origin inf
 - Implement different processing logic based on the transaction origin
 
 When a session has a replication origin configured using `pg_replication_origin_session_setup()`, the origin information is included in the WAL records and streamed as part of the logical replication protocol. This enables output plugins and replication clients to detect the origin of events and avoid loops in bi-directional replication setups.
-
-### Limitations
-
-- Currently, you must create the replication origin before you start streaming changes from a replication slot. Tracked in issue {{<issue 30068>}}.

--- a/docs/content/stable/additional-features/change-data-capture/using-yugabytedb-grpc-replication/_index.md
+++ b/docs/content/stable/additional-features/change-data-capture/using-yugabytedb-grpc-replication/_index.md
@@ -73,7 +73,7 @@ For reference documentation, see [YugabyteDB gRPC Connector](./debezium-connecto
 
 In addition, CDC support for the following features will be added in upcoming releases:
 
-* Transaction savepoints are supported starting from v2025.2.2.0. Issue {{<issue 10936>}}.
+* Transaction savepoints are not supported in versions earlier than v2025.2.2.0. Issue {{<issue 10936>}}.
 * Support for enabling CDC on Read Replicas is tracked in issue {{<issue 11116>}}.
 * Support for schema evolution with before image is tracked in issue {{<issue 15197>}}.
 

--- a/docs/content/v2024.2/additional-features/change-data-capture/using-logical-replication/_index.md
+++ b/docs/content/v2024.2/additional-features/change-data-capture/using-logical-replication/_index.md
@@ -112,11 +112,11 @@ For reference documentation, see [YugabyteDB Connector](./yugabytedb-connector/)
 
 - Support for point-in-time recovery (PITR) is tracked in issue {{<issue 10938>}}.
 
-- Transaction savepoints are supported starting from v2024.2.8.0. Issue {{<issue 10936>}}.
+- Transaction savepoints are not supported in versions earlier than v2024.2.8.0. Issue {{<issue 10936>}}.
 
 - Support for enabling CDC on Read Replicas is tracked in issue {{<issue 11116>}}.
 
-- Support for tablet splitting with logical replication is disabled from v2024.1.4 and v2024.2.1. Tracked in issue {{<issue 24918>}}.
+- Support for tablet splitting with logical replication is disabled from v2024.2.1 and re-enabled from v2024.2.2.0. Tracked in issue {{<issue 24918>}}.
 
 - A replication slot should be consumed by at most one consumer at a time. However, there is currently no locking mechanism to enforce this. As a result, you should ensure that multiple consumers do not consume from a slot simultaneously. Tracked in issue {{<issue 20755>}}.
 

--- a/docs/content/v2024.2/additional-features/change-data-capture/using-yugabytedb-grpc-replication/_index.md
+++ b/docs/content/v2024.2/additional-features/change-data-capture/using-yugabytedb-grpc-replication/_index.md
@@ -66,7 +66,7 @@ For reference documentation, see [YugabyteDB gRPC Connector](./debezium-connecto
 In addition, CDC support for the following features will be added in upcoming releases:
 
 * Support for point-in-time recovery (PITR) is tracked in issue {{<issue 10938>}}.
-* Transaction savepoints are supported starting from v2024.2.8.0. Issue {{<issue 10936>}}.
+* Transaction savepoints are not supported in versions earlier than v2024.2.8.0. Issue {{<issue 10936>}}.
 * Support for enabling CDC on Read Replicas is tracked in issue {{<issue 11116>}}.
 * Support for schema evolution with before image is tracked in issue {{<issue 15197>}}.
 

--- a/docs/content/v2025.1/additional-features/change-data-capture/using-logical-replication/_index.md
+++ b/docs/content/v2025.1/additional-features/change-data-capture/using-logical-replication/_index.md
@@ -110,11 +110,9 @@ For reference documentation, see [YugabyteDB Connector](./yugabytedb-connector/)
 
 - YCQL tables aren't currently supported. Issue {{<issue 11320>}}.
 
-- Transaction savepoints are supported starting from v2025.1.4.0. Issue {{<issue 10936>}}.
+- Transaction savepoints are not supported in versions earlier than v2025.1.4.0. Issue {{<issue 10936>}}.
 
 - Support for enabling CDC on Read Replicas is tracked in issue {{<issue 11116>}}.
-
-- Support for tablet splitting with logical replication is disabled from v2024.1.4 and v2024.2.1. Tracked in issue {{<issue 24918>}}.
 
 - A replication slot should be consumed by at most one consumer at a time. However, there is currently no locking mechanism to enforce this. As a result, you should ensure that multiple consumers do not consume from a slot simultaneously. Tracked in issue {{<issue 20755>}}.
 

--- a/docs/content/v2025.1/additional-features/change-data-capture/using-yugabytedb-grpc-replication/_index.md
+++ b/docs/content/v2025.1/additional-features/change-data-capture/using-yugabytedb-grpc-replication/_index.md
@@ -70,7 +70,7 @@ For reference documentation, see [YugabyteDB gRPC Connector](./debezium-connecto
 
 In addition, CDC support for the following features will be added in upcoming releases:
 
-* Transaction savepoints are supported starting from v2025.1.4.0. Issue {{<issue 10936>}}.
+* Transaction savepoints are not supported in versions earlier than v2025.1.4.0. Issue {{<issue 10936>}}.
 * Support for enabling CDC on Read Replicas is tracked in issue {{<issue 11116>}}.
 * Support for schema evolution with before image is tracked in issue {{<issue 15197>}}.
 

--- a/docs/content/v2025.2/additional-features/change-data-capture/using-logical-replication/_index.md
+++ b/docs/content/v2025.2/additional-features/change-data-capture/using-logical-replication/_index.md
@@ -112,11 +112,9 @@ For reference documentation, see [YugabyteDB Connector](./yugabytedb-connector/)
 
 - YCQL tables aren't currently supported. Issue {{<issue 11320>}}.
 
-- Transaction savepoints are supported starting from v2025.2.2.0. Issue {{<issue 10936>}}.
+- Transaction savepoints are not supported in versions earlier than v2025.2.2.0. Issue {{<issue 10936>}}.
 
 - Support for enabling CDC on Read Replicas is tracked in issue {{<issue 11116>}}.
-
-- Support for tablet splitting with logical replication is disabled from v2024.1.4 and v2024.2.1. Tracked in issue {{<issue 24918>}}.
 
 - A replication slot should be consumed by at most one consumer at a time. However, there is currently no locking mechanism to enforce this. As a result, you should ensure that multiple consumers do not consume from a slot simultaneously. Tracked in issue {{<issue 20755>}}.
 

--- a/docs/content/v2025.2/additional-features/change-data-capture/using-yugabytedb-grpc-replication/_index.md
+++ b/docs/content/v2025.2/additional-features/change-data-capture/using-yugabytedb-grpc-replication/_index.md
@@ -70,7 +70,7 @@ For reference documentation, see [YugabyteDB gRPC Connector](./debezium-connecto
 
 In addition, CDC support for the following features will be added in upcoming releases:
 
-* Transaction savepoints are supported starting from v2025.2.2.0. Issue {{<issue 10936>}}.
+* Transaction savepoints are not supported in versions earlier than v2025.2.2.0. Issue {{<issue 10936>}}.
 * Support for enabling CDC on Read Replicas is tracked in issue {{<issue 11116>}}.
 * Support for schema evolution with before image is tracked in issue {{<issue 15197>}}.
 


### PR DESCRIPTION
Reword savepoint bullets as earlier-version limitations, update tablet splitting status for v2024.2, and drop the fixed replication-origins restriction from stable.