### PR TITLE
[#31078] YSQL: Make `pg_stat_statements.track = all` the default

### DIFF
--- a/src/postgres/contrib/pg_stat_statements/expected/yb.orig.pg_stat_statements.out
+++ b/src/postgres/contrib/pg_stat_statements/expected/yb.orig.pg_stat_statements.out
@@ -4,6 +4,16 @@ CREATE EXTENSION pg_stat_statements;
 --
 SET pg_stat_statements.track_utility = TRUE;
 SET pg_stat_statements.track_planning = TRUE;
+-- YB: the default of pg_stat_statements.track is 'all' in YugabyteDB
+-- (upstream default: 'top').  Assert it, then pin 'top' so the rest of
+-- this test does not depend on the default.
+SELECT current_setting('pg_stat_statements.track') AS track;
+ track 
+-------
+ all
+(1 row)
+
+SET pg_stat_statements.track = 'top';
 --
 -- create / alter user
 --

--- a/src/postgres/contrib/pg_stat_statements/pg_stat_statements.c
+++ b/src/postgres/contrib/pg_stat_statements/pg_stat_statements.c
@@ -603,7 +603,7 @@ _PG_init(void)
 							 "Selects which statements are tracked by pg_stat_statements.",
 							 NULL,
 							 &pgss_track,
-							 PGSS_TRACK_TOP,
+							 PGSS_TRACK_ALL,	/* YB: change default */
 							 track_options,
 							 PGC_SUSET,
 							 0,
@@ -829,6 +829,7 @@ getYsqlStatementStats(void *cb_arg)
 
 			WriteIntToJson(cb_arg, "userid", entry->key.userid);
 			WriteIntToJson(cb_arg, "dbid", entry->key.dbid);
+			WriteBoolToJson(cb_arg, "toplevel", entry->key.toplevel);
 			WriteIntToJson(cb_arg, "query_id", entry->key.queryid);
 			WriteStringToJson(cb_arg, "query", qry);
 			WriteIntToJson(cb_arg, "calls", entry->counters.calls[PGSS_EXEC]);

--- a/src/postgres/contrib/pg_stat_statements/sql/yb.orig.pg_stat_statements.sql
+++ b/src/postgres/contrib/pg_stat_statements/sql/yb.orig.pg_stat_statements.sql
@@ -5,6 +5,11 @@ CREATE EXTENSION pg_stat_statements;
 --
 SET pg_stat_statements.track_utility = TRUE;
 SET pg_stat_statements.track_planning = TRUE;
+-- YB: the default of pg_stat_statements.track is 'all' in YugabyteDB
+-- (upstream default: 'top').  Assert it, then pin 'top' so the rest of
+-- this test does not depend on the default.
+SELECT current_setting('pg_stat_statements.track') AS track;
+SET pg_stat_statements.track = 'top';
 
 --
 -- create / alter user

--- a/src/yb/yql/pggate/webserver/ybc_pg_webserver_wrapper.cc
+++ b/src/yb/yql/pggate/webserver/ybc_pg_webserver_wrapper.cc
@@ -661,6 +661,12 @@ void WriteDoubleToJson(void *p1, const char* key, const double value) {
   writer->Double(value);
 }
 
+void WriteBoolToJson(void *p1, const char* key, const bool value) {
+  JsonWriter *writer = static_cast<JsonWriter *>(p1);
+  writer->String(key);
+  writer->Bool(value);
+}
+
 void WriteIntArrayToJson(void *p1, const char *key, const int64 *values, const size_t size) {
   JsonWriter *writer = static_cast<JsonWriter *>(p1);
   writer->String(key);

--- a/src/yb/yql/pggate/webserver/ybc_pg_webserver_wrapper.h
+++ b/src/yb/yql/pggate/webserver/ybc_pg_webserver_wrapper.h
@@ -123,6 +123,7 @@ void WriteStringToJson(void *p1, const char* key, const char* value);
 // required for current usecase and writing arrays of primitive types.
 void WriteIntToJson(void *p1, const char* key, const int64_t value);
 void WriteDoubleToJson(void *p1, const char* key, const double value);
+void WriteBoolToJson(void *p1, const char* key, const bool value);
 void WriteIntArrayToJson(void *p1, const char *key, const int64 *values, const size_t size);
 void WriteDoubleArrayToJson(void *p1, const char *key, const double *values, const size_t size);
 


### PR DESCRIPTION
DO NOT MERGE!! [CSI](<https://csiweb.dev.yugabyte.com/pull/32862/>) ❌. Once CSI passes, comment `trigger jenkins` to clear this warning.

## Summary

Fixes #31078 (DB-20958).

The upstream default of `pg_stat_statements.track` is `top`, which hides statements nested inside functions, procedures, triggers, and DO blocks. Those nested statements are frequently the ones doing the actual reads and writes, so hiding them makes latency triage with pg_stat_statements harder than it needs to be. ASH follows this GUC to decide whether nested queries are tracked (`yb_track_nested_queries`), so it also gains nested-query visibility by default.

Changes:

- **Default `pg_stat_statements.track` to `all`** in `pg_stat_statements.c` (`/* YB: change default */`, same pattern as the existing YB default change for `pg_stat_statements.track_planning`).
- **Emit `toplevel` on the tserver `13000/statements` endpoint.** With `track = all`, a query can have two entries with the same queryid (one top-level, one nested); the JSON previously omitted the `toplevel` hash-key dimension, making those rows indistinguishable. The field mirrors the `pg_stat_statements` view column and is emitted via a new `WriteBoolToJson` helper in the pggate webserver wrapper.
- **Regress coverage for the new default**: `yb.orig.pg_stat_statements` now asserts `current_setting('pg_stat_statements.track') = 'all'`, then pins `top` so the rest of the test (which runs a plpgsql function under the session default) stays independent of the compiled default. `yb.port.pg_stat_statements` needs no changes: every section exercising nested statements already sets the GUC explicitly, and sections running under the compiled default contain only top-level statements (PREPARE/EXECUTE are special-cased by pgss and not counted as nested).

Behavioral notes for reviewers:

- Nested statements now appear in `pg_stat_statements`, the `13000/statements` JSON, and ASH samples by default. Anything counting rows in these surfaces will see more entries.
- More entries increases pressure on `pg_stat_statements.max` (default 5000), so eviction (`dealloc` in `pg_stat_statements_info`) can start sooner on plpgsql-heavy workloads. Shared-memory size is governed by `pg_stat_statements.max`, not by `track`, so memory consumption is unchanged.
- `pg_stat_statements_reset(userid, dbid, queryid)` already removes both toplevel variants of a key; `yb_get_histogram()` already takes an explicit `top_level` argument. No other key-probing paths needed changes.
- The new JSON field is additive. YBA slow queries reads the `pg_stat_statements` view over SQL rather than this endpoint, and yugabyted-ui does not parse `/statements`.

Follow-up (not in this change): `docs/content/*/launch-and-manage/monitor-and-alert/query-tuning/pg-stat-statements.md` documents upstream defaults (it already lists `track_planning = off`, which YB ships as `on`); the docs table should be updated to the YB defaults in a docs change.

## Upgrade/Rollback safety

- No wire-format (`.proto`), catalog, RPC-versioning, or on-disk format changes.
- The GUC default is compiled into the `pg_stat_statements` extension library and takes effect on each node as it restarts onto the new binary. In a mixed-version cluster, nodes simply differ in whether nested statements are collected locally; there is no cross-node coordination on this GUC. Statistics remain per-node and ephemeral (the pgss stat file is only persisted across graceful restarts, and its entry key layout, which already includes `toplevel`, is unchanged).
- Explicit user settings win over the default at every level (`ysql_pg_conf_csv`, `ALTER SYSTEM`, `ALTER DATABASE/ROLE ... SET`, session `SET`), so users who have pinned `track` see no change.
- Rollback: the old binary reverts to the `top` default and simply stops creating nested entries; existing entries (including `toplevel = false` ones persisted by the new binary across a graceful restart) are read fine by the old binary since the key layout is unchanged.
- The `13000/statements` JSON change is additive (new `toplevel` field); JSON consumers that ignore unknown fields are unaffected.

## Test Plan

Build:

```
./yb_build.sh release daemons initdb --sj --skip-pg-parquet --no-odyssey --no-ybc
```

Regress and targeted tests:

```
./yb_build.sh release --java-test org.yb.pgsql.TestPgRegressPgStatStatements
./yb_build.sh release --java-test 'org.yb.pgsql.TestYbAsh#testNestedQueriesWithAsh'
./yb_build.sh release --java-test 'org.yb.pgsql.TestPgStatStatements#testNestedExecutionAttributesMetricsToTopLevelQuery'
./yb_build.sh release --cxx-test pg_stat_statements-test
./yb_build.sh release --cxx-test pg_ash-test --gtest_filter PgAshNestedQueryTracking.TestNestedQueryTrackingConfigs
```

Manual verification on a running cluster:

- `SHOW pg_stat_statements.track;` returns `all`.
- Run a plpgsql function wrapping a DML statement; the inner statement appears in `pg_stat_statements` with `toplevel = false`.
- `curl -s http://127.0.0.1:13000/statements | jq '.statements[0]'` shows a boolean `toplevel` on every entry, with both `true` and `false` present after the function call above.

Jenkins: full run (default-behavior change; watch suites that assert on pg_stat_statements contents or ASH sample sets).
