### PR TITLE
[#32865] ClaudeCode: Replace Gemini review config with REVIEW.md

### DIFF
--- a/.agents/scripts/git-push.sh
+++ b/.agents/scripts/git-push.sh
@@ -210,14 +210,6 @@ if [[ -n "$pre_push_sha" ]] && command -v gh >/dev/null 2>&1; then
       echo ">>> new commits in this push:"
       echo "$new_subjects"
 
-      # Re-trigger Gemini Code Assist on the new commits.
-      if gh pr comment "$pr_num" -R "$GH_REPO" --body "/gemini review" \
-            >/dev/null 2>&1; then
-        echo ">>> requested Gemini review (/gemini review)"
-      else
-        echo "warn: failed to post '/gemini review' on PR #${pr_num}" >&2
-      fi
-
       echo ""
       echo ">>> Review the PR title and summary. Update either if these commits"
       echo "    significantly shift scope, approach, or component. Leave them"

--- a/.claude/skills/review-backport/SKILL.md
+++ b/.claude/skills/review-backport/SKILL.md
@@ -11,7 +11,7 @@ description: >-
 
 Review a YugabyteDB backport diff by comparing it to the original commit/diff and identifying any differences.
 
-For the review *policy* (what counts as a backport, what to flag vs. ignore, byte-identical-hunk handling, and the `## Merge conflicts` convention), see the **Backport PRs** section of `@../../../.gemini/styleguide.md`. This skill covers the *mechanics* of fetching and comparing Phorge diffs and tracing unexplained code back to its origin on master.
+For the review *policy* (what counts as a backport, what to flag vs. ignore, byte-identical-hunk handling, and the `## Merge conflicts` convention), see the **Backport PRs** section of `@../../../REVIEW.md`. This skill covers the *mechanics* of fetching and comparing Phorge diffs and tracing unexplained code back to its origin on master.
 
 ## Prerequisites
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,6 +1,6 @@
 # YugabyteDB Code Review Style Guide
 
-This document configures AI code-review agents' automated review for PRs in this repository. It scopes what to flag, what to skip, and how to handle a few PR types (especially backports) where the default review behavior produces noise.
+This document is the review guide for anyone — human or AI agent — reviewing PRs in this repository. It scopes what to flag, what to skip, and how to handle a few PR types (especially backports) where the default review behavior produces noise.
 
 ## General review guidance
 
@@ -27,7 +27,7 @@ Default comment severity threshold: **MEDIUM**. Suppress LOW-severity nits unles
 
 **When you have no actionable feedback, say so in one line.** Do not write a `## Code Review` summary paragraph that paraphrases the diff and then ends with "I have no feedback to provide." — that's review noise the author has to read and dismiss. Just leave a single comment of the form `LGTM` (optionally with a one-line caveat, e.g. `LGTM — please verify the test plan covers <X>`). Skip the diff recap entirely; the author already knows what they wrote.
 
-**Do not repeatedly re-flag the same issue across review rounds.** A `/gemini review` retrigger after a follow-up commit must respect the prior round's resolution:
+**Do not repeatedly re-flag the same issue across review rounds.** A re-review after a follow-up commit must respect the prior round's resolution:
 
 - If a thread on the same line / same issue was **resolved** (via the GitHub UI or `resolveReviewThread`), do not raise it again. The resolve carries the human/agent decision and re-flagging adds review noise.
 - If a thread has a **reply** explaining why the suggestion was declined (e.g. "the script already has `set -euo pipefail` at line 17") or applied differently from the literal suggestion, accept the explanation and skip the issue on the next pass.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -81,7 +81,7 @@ Substitute `<agent>` with the most specific identifier you have (model name + ha
 
 ## Reviewing commits
 
-When reviewing a PR, a backport diff, or any commit on this repo, follow the guidance in `.gemini/styleguide.md`. It scopes which issues are worth flagging (correctness, memory safety, security, concurrency, performance, breaking-change risk) versus which to skip (lint-owned style, naming nits, repeat-flags across rounds), spells out the **backport-mode** rules for cherry-pick PRs (compare against the originating commit; don't re-flag byte-identical hunks), and lists the areas (`src/yb/master/`, `src/yb/tablet/`, `src/yb/cdc/`, `src/postgres/`, `managed/`) that warrant deeper attention. Read it before forming review comments.
+When reviewing a PR, a backport diff, or any commit on this repo, follow the guidance in the repo-root `REVIEW.md`. It scopes which issues are worth flagging (correctness, memory safety, security, concurrency, performance, breaking-change risk) versus which to skip (lint-owned style, naming nits, repeat-flags across rounds), spells out the **backport-mode** rules for cherry-pick PRs (compare against the originating commit; don't re-flag byte-identical hunks), and lists the areas (`src/yb/master/`, `src/yb/tablet/`, `src/yb/cdc/`, `src/postgres/`, `managed/`) that warrant deeper attention. Read it before forming review comments.
 
 ## Replying to PR review comments
 


### PR DESCRIPTION
## Summary

The AI code-review policy lived at `.gemini/styleguide.md`, a path owned by one vendor tool
(Gemini Code Assist), even though the content is tool-agnostic and was already consumed by other
agents via `src/AGENTS.md` § Reviewing commits and the `review-backport` Claude skill.

**`.gemini/styleguide.md` → `REVIEW.md`** — move the review policy to a neutral repo-root path
(tracked as a rename; the now-empty `.gemini/` directory is removed). Two in-file rewordings drop
the vendor-specific framing:

- The intro now describes the document as the review guide for anyone — human or AI agent —
  reviewing PRs, rather than as configuration for one review bot.
- The don't-re-flag-across-review-rounds rule now says "a re-review after a follow-up commit"
  instead of "a `/gemini review` retrigger". The rule itself is unchanged.

Everything else in the document — what to flag vs. skip, the MEDIUM severity threshold, the
backport-mode rules, the deeper-review areas, the ignore list — carries over verbatim.

**`src/AGENTS.md`** and **`.claude/skills/review-backport/SKILL.md`** — update the two inbound
references. `src/AGENTS.md` points at "the repo-root `REVIEW.md`" (spelled out, since a bare
`REVIEW.md` read from `src/` would resolve as `src/REVIEW.md`); the skill's `@`-reference becomes
`@../../../REVIEW.md`.

**`.agents/scripts/git-push.sh`** — drop the automatic `/gemini review` comment that was posted on
every push landing on an open PR, so the shared push workflow no longer hard-codes one review bot.
The rest of the post-push reporting — the new-commit list and the PR title/summary sync reminder —
is unchanged.

No runtime behavior change: this touches agent instructions and one push helper only.

## Test plan

No runtime code is touched — the change is agent instructions plus one push-helper script.

- [x] `bash -n .agents/scripts/git-push.sh` passes after removing the retrigger block.
- [x] Repo-wide `grep -ri 'gemini\|styleguide'` finds no remaining references to the old path
      outside unrelated pre-existing hits (Vale style-rule comments, `src/lint/cpplint.py` URLs,
      and place names in `src/postgres/` test data).
- [x] `git status` confirms the move is tracked as a rename (`R095 .gemini/styleguide.md →
      REVIEW.md`), so the policy's history is preserved.
- [x] Both inbound links resolve: `REVIEW.md` exists at the repo root, and
      `.claude/skills/review-backport/SKILL.md`'s `@../../../REVIEW.md` resolves from
      `.claude/skills/review-backport/` to the repo root.
- [x] `lint.sh --rev upstream/master` clean (enforced by `create-pr.sh` before push).
