### PR TITLE
[#28579] DocDB: Add unit tests for compact_table and compact_table_by_id output

### DIFF
--- a/src/yb/tools/yb-admin-test.cc
+++ b/src/yb/tools/yb-admin-test.cc
@@ -2229,6 +2229,65 @@ TEST_F(AdminCliTest, TestCompactionStatusAfterCompactionFinishes) {
   ASSERT_GT(last_request_time, time_before_compaction);
 }
 
+TEST_F(AdminCliTest, TestCompactTableOutputFormat) {
+  BuildAndStart();
+  const string output = ASSERT_RESULT(CallAdmin(
+      "compact_table", kTableName.namespace_name(), kTableName.table_name(), "30" /* timeout */));
+  const string expected_table_name =
+      Format("$0.$1", kTableName.namespace_name(), kTableName.table_name());
+  const std::regex regex(Format(R"(Compacted \[$0.*\] tables\.)", expected_table_name));
+  ASSERT_TRUE(std::regex_search(output, regex)) << "Unexpected output format: " << output;
+}
+
+TEST_F(AdminCliTest, TestCompactTableWithMissingTable) {
+  BuildAndStart();
+  const auto result = CallAdmin("compact_table");
+  ASSERT_FALSE(result.ok());
+  ASSERT_STR_CONTAINS(result.status().ToString(), "Empty list of tables");
+  ASSERT_STR_CONTAINS(result.status().ToString(), "Usage:");
+}
+
+TEST_F(AdminCliTest, TestCompactTableWithInvalidTable) {
+  BuildAndStart();
+  const auto result = CallAdmin(
+      "compact_table", "ycql.nonexistent_namespace", "nonexistent_table");
+  ASSERT_FALSE(result.ok());
+  ASSERT_STR_CONTAINS(result.status().ToString(), "not found");
+}
+
+TEST_F(AdminCliTest, TestCompactTableById) {
+  BuildAndStart();
+  const string master_address = ToString(cluster_->master()->bound_rpc_addr());
+  auto client = ASSERT_RESULT(YBClientBuilder().add_master_server_addr(master_address).Build());
+
+  auto tables = ASSERT_RESULT(client->ListTables(/* filter */ kTableName.table_name(),
+                                                  /* exclude_ysql */ true));
+  ASSERT_EQ(1, tables.size());
+  const auto table_id = tables.front().table_id();
+
+  const string output = ASSERT_RESULT(
+      CallAdmin("compact_table_by_id", table_id, /* timeout */ "30"));
+  const string expected_table_name =
+      Format("$0.$1", kTableName.namespace_name(), kTableName.table_name());
+  const std::regex regex(Format(R"(Compacted \[$0.*\] tables\.)", expected_table_name));
+  ASSERT_TRUE(std::regex_search(output, regex)) << "Unexpected output format: " << output;
+}
+
+TEST_F(AdminCliTest, TestCompactTableByIdWithMissingTableId) {
+  BuildAndStart();
+  const auto result = CallAdmin("compact_table_by_id");
+  ASSERT_FALSE(result.ok());
+  ASSERT_STR_CONTAINS(result.status().ToString(), "Usage:");
+}
+
+TEST_F(AdminCliTest, TestCompactTableByIdWithInvalidTableId) {
+  BuildAndStart();
+  const auto result = CallAdmin(
+      "compact_table_by_id", "nonexistent_table_id", /* timeout */ "30");
+  ASSERT_FALSE(result.ok());
+  ASSERT_STR_CONTAINS(result.status().ToString(), "not found");
+}
+
 // Covers https://github.com/yugabyte/yugabyte-db/issues/19957
 TEST_F(AdminCliTest, TestAdminCommandTimeout) {
   // The test checks that an admin command timeout for compactions and flushes is honored by


### PR DESCRIPTION
## Summary

Adds `AdminCliTest` coverage for the `compact_table` and `compact_table_by_id` yb-admin commands:

- `TestCompactTableOutputFormat` — verifies the `Compacted [<table>] tables.` success output format.
- `TestCompactTableWithMissingTable` — verifies the error/usage output when no table is supplied.
- `TestCompactTableWithInvalidTable` — verifies the error output for a nonexistent table.
- `TestCompactTableById` — verifies the success output format via `compact_table_by_id`.
- `TestCompactTableByIdWithMissingTableId` — verifies usage output when no table id is supplied.
- `TestCompactTableByIdWithInvalidTableId` — verifies the error output for a nonexistent table id.

This covers the `compact_table`/`compact_table_by_id` half of #28579; #28804 already covers the `flush_table`/`flush_table_by_id` half.

## Test plan

- [ ] CI: `yb-admin-test` — `AdminCliTest.TestCompactTableOutputFormat`
- [ ] CI: `yb-admin-test` — `AdminCliTest.TestCompactTableWithMissingTable`
- [ ] CI: `yb-admin-test` — `AdminCliTest.TestCompactTableWithInvalidTable`
- [ ] CI: `yb-admin-test` — `AdminCliTest.TestCompactTableById`
- [ ] CI: `yb-admin-test` — `AdminCliTest.TestCompactTableByIdWithMissingTableId`
- [ ] CI: `yb-admin-test` — `AdminCliTest.TestCompactTableByIdWithInvalidTableId`

Not run locally (dev machine has insufficient RAM for a full build); relying on GitHub CI to build and execute these tests.
