### PR TITLE
[#32345] YSQL: Fix missing yb_stat_auto_analyze entry after relfilenode changes

### DIFF
--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -9427,19 +9427,33 @@ yb_stat_auto_analyze(PG_FUNCTION_ARGS)
 	for (i = 0; i < num_rows; ++i)
 	{
 		YbcAutoAnalyzeInfo *row_info = (YbcAutoAnalyzeInfo *) auto_analyze_info + i;
+		YbcPgTableDesc ybc_tabledesc;
+		YbcPgOid 	ybc_tableoid;
 		Datum		values[YB_AUTO_ANALYZE_TABLE_COLS];
 		bool		nulls[YB_AUTO_ANALYZE_TABLE_COLS];
 
 		memset(values, 0, sizeof(values));
 		memset(nulls, 0, sizeof(nulls));
-		Relation rel = RelationIdGetRelation(row_info->table_oid);
+		
+		YbcStatus status = YBCPgGetTableDesc(MyDatabaseId,
+						 					 row_info->table_oid,
+						 					 &ybc_tabledesc);
+		if(status)
+		{
+			YBCFreeStatus(status);
+			continue;
+		}
+
+		HandleYBStatus(YBCPgGetTableOid(ybc_tabledesc, &ybc_tableoid));
+
+		Relation rel = RelationIdGetRelation(ybc_tableoid);
 		/*
 		 * A table could be deleted, but auto analyze hasn't cleaned up its
 		 * entry from its service table yet.
 		 */
 		if (!RelationIsValid(rel))
 			continue;
-		values[0] = ObjectIdGetDatum(row_info->table_oid);
+		values[0] = ObjectIdGetDatum(ybc_tableoid);
 		values[1] = CStringGetTextDatum(get_namespace_name(RelationGetNamespace(rel)));
 		values[2] = CStringGetTextDatum(RelationGetRelationName(rel));
 		values[3] = UInt64GetDatum(row_info->mutations);

--- a/src/yb/yql/pggate/ybc_pggate.cc
+++ b/src/yb/yql/pggate/ybc_pggate.cc
@@ -1253,6 +1253,15 @@ YbcStatus YBCPgGetTableProperties(YbcPgTableDesc table_desc,
   return YBCStatusOK();
 }
 
+YbcStatus YBCPgGetTableOid(YbcPgTableDesc desc,
+                           YbcPgOid *YbcPgTableoid){
+  if (!desc || !YbcPgTableoid) {
+    return YBCStatusOK();
+  }
+  *YbcPgTableoid = desc->pg_table_id().object_oid;
+  return YBCStatusOK();
+}
+
 // table_desc is expected to be a PgTableDesc of a range-partitioned table.
 // split_datums are expected to have an allocated size:
 // num_splits * num_range_key_columns, and it is used to

--- a/src/yb/yql/pggate/ybc_pggate.h
+++ b/src/yb/yql/pggate/ybc_pggate.h
@@ -402,6 +402,9 @@ YbcStatus YBCPgGetColumnInfo(YbcPgTableDesc table_desc,
 YbcStatus YBCPgGetTableProperties(YbcPgTableDesc table_desc,
                                   YbcTableProperties properties);
 
+YbcStatus YBCPgGetTableOid(YbcPgTableDesc desc,
+                           YbcPgOid *YbcPgTableoid);
+
 YbcStatus YBCPgDmlModifiesRow(YbcPgStatement handle, bool *modifies_row);
 
 YbcStatus YBCPgSetIsSysCatalogVersionChange(YbcPgStatement handle);

--- a/src/yb/yql/pgwrapper/pg_auto_analyze-test.cc
+++ b/src/yb/yql/pgwrapper/pg_auto_analyze-test.cc
@@ -1602,6 +1602,11 @@ TEST_F(PgAutoAnalyzeTest, AutoAnalyzeObservability) {
   ASSERT_EQ(num_rows, mutations);
   ASSERT_TRUE(!last_analyze_info.has_value());
 
+  // Regression test for a case where the table entry was missing from
+  // yb_stat_auto_analyze after ALTER TABLE.
+  ASSERT_OK(conn.ExecuteFormat("ALTER TABLE $0.$1 ALTER COLUMN k TYPE bigint",
+                               schema_name,table_name));
+
   auto start_time = GetCurrentTimeMicros();
   // Trigger ANALYZE
   ASSERT_OK(conn.ExecuteFormat("INSERT INTO $0.$1 SELECT generate_series(1, $2)",


### PR DESCRIPTION
**Summary:**
Fixes #32345 
Fix an issue where a table could disappear from
`yb_stat_auto_analyze` after its `relfilenode` changes.

**Root Cause:**
`yb_stat_auto_analyze` performed relation lookup using `relfilenode`. Operations such as `ALTER TABLE` can rewrite a table and assign it a new `relfilenode`. As a result, the previous `relfilenode` no longer mapped to a valid relation, causing the lookup to fail and the corresponding entry to be omitted from the output.

**Fix:**
Perform relation lookup using the stable relation OID obtained from the Yugabyte table descriptor instead of `relfilenode`. This ensures that tables continue to be reported correctly in
`yb_stat_auto_analyze` even after operations that change their `relfilenode`.

**Test Plan:**
Extend `PgAutoAnalyzeTest.AutoAnalyzeObservability` with a regression scenario that performs an `ALTER TABLE` before triggering auto analyze. The new test reproduces the issue on the original implementation and passes with this fix.