### PR TITLE
Eventual near-local index

### DIFF
--- a/src/postgres/src/backend/commands/indexcmds.c
+++ b/src/postgres/src/backend/commands/indexcmds.c
@@ -1256,6 +1256,21 @@ DefineIndex(Oid relationId,
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
 						 errmsg("cannot use TABLEGROUP with SPLIT")));
+
+			/*
+			 * YB: 'SPLIT FOLLOWING TABLE' is a prototype feature gated by the
+			 * yb_enable_follow_table_index GUC (mirrors the master gflag
+			 * --ysql_yb_enable_follow_table_index). Reject early with a friendly
+			 * error when the feature is disabled; the master enforces this
+			 * authoritatively as well.
+			 */
+			if (stmt->split_options->split_type == FOLLOW_TABLE &&
+				!yb_enable_follow_table_index)
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("SPLIT FOLLOWING TABLE is not enabled"),
+						 errhint("Set yb_enable_follow_table_index to true to use "
+								 "follow-table indexes.")));
 		}
 
 		colocation_id = YbGetColocationIdFromRelOptions(stmt->options);
@@ -1424,8 +1439,14 @@ DefineIndex(Oid relationId,
 	 * YB: Keep the SPLIT clause and the yb_presplit reloption in sync so that
 	 * the index is created with the right pre-split values and yb_presplit is
 	 * persisted for REINDEX and dump/restore.
+	 *
+	 * SPLIT FOLLOWING TABLE carries no num_tablets/split_points to synchronize
+	 * (the index derives its partitioning from the base table at the master),
+	 * so it is excluded here and rides the split_options plumbing untouched.
 	 */
-	if (IsYugaByteEnabled())
+	if (IsYugaByteEnabled() &&
+		!(stmt->split_options &&
+		  stmt->split_options->split_type == FOLLOW_TABLE))
 		YbSyncSplitOptionsAndPresplit(&stmt->split_options, &stmt->options);
 
 	/*

--- a/src/postgres/src/backend/commands/indexcmds.c
+++ b/src/postgres/src/backend/commands/indexcmds.c
@@ -1256,21 +1256,6 @@ DefineIndex(Oid relationId,
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
 						 errmsg("cannot use TABLEGROUP with SPLIT")));
-
-			/*
-			 * YB: 'SPLIT FOLLOWING TABLE' is a prototype feature gated by the
-			 * yb_enable_follow_table_index GUC (mirrors the master gflag
-			 * --ysql_yb_enable_follow_table_index). Reject early with a friendly
-			 * error when the feature is disabled; the master enforces this
-			 * authoritatively as well.
-			 */
-			if (stmt->split_options->split_type == FOLLOW_TABLE &&
-				!yb_enable_follow_table_index)
-				ereport(ERROR,
-						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg("SPLIT FOLLOWING TABLE is not enabled"),
-						 errhint("Set yb_enable_follow_table_index to true to use "
-								 "follow-table indexes.")));
 		}
 
 		colocation_id = YbGetColocationIdFromRelOptions(stmt->options);
@@ -1438,16 +1423,30 @@ DefineIndex(Oid relationId,
 	/*
 	 * YB: Keep the SPLIT clause and the yb_presplit reloption in sync so that
 	 * the index is created with the right pre-split values and yb_presplit is
-	 * persisted for REINDEX and dump/restore.
-	 *
-	 * SPLIT FOLLOWING TABLE carries no num_tablets/split_points to synchronize
-	 * (the index derives its partitioning from the base table at the master),
-	 * so it is excluded here and rides the split_options plumbing untouched.
+	 * persisted for REINDEX and dump/restore.  This covers SPLIT FOLLOWING
+	 * TABLE too: it serializes to the operand-less "FOLLOWING TABLE", which is
+	 * what lets pg_get_indexdef re-emit the clause instead of falling back to
+	 * the index's current tablet count.
 	 */
-	if (IsYugaByteEnabled() &&
-		!(stmt->split_options &&
-		  stmt->split_options->split_type == FOLLOW_TABLE))
+	if (IsYugaByteEnabled())
 		YbSyncSplitOptionsAndPresplit(&stmt->split_options, &stmt->options);
+
+	/*
+	 * YB: 'SPLIT FOLLOWING TABLE' is a prototype feature gated by the
+	 * yb_enable_follow_table_index GUC (mirrors the master gflag
+	 * --ysql_yb_enable_follow_table_index).  The check lives here, after the
+	 * sync above, so that it also covers a split_options derived from a
+	 * yb_presplit reloption rather than from an explicit SPLIT clause.  The
+	 * master enforces this authoritatively as well.
+	 */
+	if (stmt->split_options &&
+		stmt->split_options->split_type == FOLLOW_TABLE &&
+		!yb_enable_follow_table_index)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("SPLIT FOLLOWING TABLE is not enabled"),
+				 errhint("Set yb_enable_follow_table_index to true to use "
+						 "follow-table indexes.")));
 
 	/*
 	 * Parse AM-specific options, convert to text array form, validate.

--- a/src/postgres/src/backend/commands/yb_cmds.c
+++ b/src/postgres/src/backend/commands/yb_cmds.c
@@ -23,6 +23,7 @@
 
 #include "postgres.h"
 
+#include "access/genam.h"
 #include "access/heapam.h"
 #include "access/htup_details.h"
 #include "access/nbtree.h"
@@ -553,6 +554,18 @@ CreateTableHandleSplitOptions(YbcPgStatement handle, TupleDesc desc,
 				YBTransformPartitionSplitPoints(handle, split_options->split_points, attrs, attr_count);
 				break;
 			}
+
+		case FOLLOW_TABLE:
+			/*
+			 * YB: The SPLIT clause grammar is shared between CREATE TABLE and
+			 * CREATE INDEX, so SPLIT FOLLOWING TABLE parses here too. There is
+			 * no table for a table to follow, though: the clause only means
+			 * something for a secondary index.
+			 */
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
+					 errmsg("SPLIT FOLLOWING TABLE is only valid for a secondary index")));
+			break;
 
 		default:
 			ereport(ERROR,
@@ -1132,9 +1145,86 @@ YbUnsafeTruncate(Relation rel)
 	list_free(indexlist);
 }
 
+/*
+ * YB: Check that a SPLIT FOLLOWING TABLE index hashes the same way as the
+ * table it follows.
+ *
+ * DocDB assigns a row to a tablet by hashing the encoded values of the
+ * relation's leading HASH key columns, so an index row only lands in the
+ * partition range that holds its base row when the index's HASH key is the
+ * base table's HASH key -- same columns, same order.  An index that hashes on
+ * anything else would still inherit the base table's partition boundaries but
+ * would scatter its rows across them arbitrarily, quietly delivering none of
+ * the co-location the clause asks for.  Reject that up front instead.
+ *
+ * The master cannot make this check on YSQL's behalf.  For a YSQL index it
+ * receives only the base table's id, not the index's column mapping (see
+ * IndexInfoBuilder::ApplyColumnMapping, which the PGSQL path skips), so its
+ * own eligibility check degrades to comparing HASH column counts.
+ *
+ * A YB table's HASH key is the leading HASH portion of its primary key; a
+ * table without a primary key is distributed on an internal row identifier
+ * that no secondary index can reproduce.
+ */
+static void
+YbValidateFollowTableHashKey(Relation rel, IndexInfo *indexInfo,
+							 int16 *coloptions, int numIndexKeyAttrs)
+{
+	Oid			pkIndexOid = RelationGetPrimaryKeyIndex(rel);
+	Relation	pkRel;
+	int			numIndexHashAttrs;
+	int			numBaseHashAttrs;
+	bool		matches;
+
+	if (!OidIsValid(pkIndexOid))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
+				 errmsg("cannot use SPLIT FOLLOWING TABLE on an index of table \"%s\"",
+						RelationGetRelationName(rel)),
+				 errdetail("Table \"%s\" has no primary key, so its rows are distributed by an internal identifier that an index cannot reproduce.",
+						   RelationGetRelationName(rel))));
+
+	/* Count the leading HASH key columns of the new index. */
+	numIndexHashAttrs = 0;
+	while (numIndexHashAttrs < numIndexKeyAttrs &&
+		   (coloptions[numIndexHashAttrs] & INDOPTION_HASH))
+		numIndexHashAttrs++;
+
+	pkRel = index_open(pkIndexOid, AccessShareLock);
+
+	/* Count the leading HASH key columns of the base table's primary key. */
+	numBaseHashAttrs = 0;
+	while (numBaseHashAttrs < IndexRelationGetNumberOfKeyAttributes(pkRel) &&
+		   (pkRel->rd_indoption[numBaseHashAttrs] & INDOPTION_HASH))
+		numBaseHashAttrs++;
+
+	matches = (numIndexHashAttrs == numBaseHashAttrs);
+	for (int i = 0; matches && i < numBaseHashAttrs; i++)
+	{
+		AttrNumber	indexAttno = indexInfo->ii_IndexAttrNumbers[i];
+
+		/* An expression column (attnum 0) can never match a base column. */
+		if (indexAttno == InvalidAttrNumber ||
+			indexAttno != pkRel->rd_index->indkey.values[i])
+			matches = false;
+	}
+
+	index_close(pkRel, AccessShareLock);
+
+	if (!matches)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
+				 errmsg("SPLIT FOLLOWING TABLE requires the index HASH key to match the HASH key of table \"%s\"",
+						RelationGetRelationName(rel)),
+				 errdetail("The index must be hashed on the same columns, in the same order, as the leading HASH columns of the table's primary key."),
+				 errhint("Reorder the index columns so that the table's HASH key comes first, or omit SPLIT FOLLOWING TABLE.")));
+}
+
 /* Utility function to handle split points */
 static void
 CreateIndexHandleSplitOptions(YbcPgStatement handle,
+							  Relation rel,
+							  IndexInfo *indexInfo,
 							  TupleDesc desc,
 							  YbOptSplit *split_options,
 							  int16 *coloptions,
@@ -1174,13 +1264,16 @@ CreateIndexHandleSplitOptions(YbcPgStatement handle,
 			 * YB: SPLIT FOLLOWING TABLE. The index derives its partitioning and
 			 * placement from the base table at the master. Require HASH columns
 			 * (following is only meaningful for a hash-partitioned index) and
-			 * mark the create request as a follow-table request. Eligibility
-			 * (matching the base table's hash key) is validated at the master.
+			 * that they be the base table's HASH key, then mark the create
+			 * request as a follow-table request.
 			 */
 			if (!(coloptions[0] & INDOPTION_HASH))
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
 						 errmsg("HASH columns must be present to follow the base table's split")));
+
+			YbValidateFollowTableHashKey(rel, indexInfo, coloptions,
+										 numIndexKeyAttrs);
 
 			HandleYBStatus(YBCPgCreateIndexSetFollowTable(handle));
 			break;
@@ -1304,7 +1397,8 @@ YBCCreateIndex(const char *indexName,
 
 	/* Handle SPLIT statement, if present */
 	if (split_options)
-		CreateIndexHandleSplitOptions(handle, indexTupleDesc, split_options, coloptions,
+		CreateIndexHandleSplitOptions(handle, rel, indexInfo, indexTupleDesc,
+									  split_options, coloptions,
 									  indexInfo->ii_NumIndexKeyAttrs);
 
 	/* Create the index. */

--- a/src/postgres/src/backend/commands/yb_cmds.c
+++ b/src/postgres/src/backend/commands/yb_cmds.c
@@ -1169,6 +1169,22 @@ CreateIndexHandleSplitOptions(YbcPgStatement handle,
 				break;
 			}
 
+		case FOLLOW_TABLE:
+			/*
+			 * YB: SPLIT FOLLOWING TABLE. The index derives its partitioning and
+			 * placement from the base table at the master. Require HASH columns
+			 * (following is only meaningful for a hash-partitioned index) and
+			 * mark the create request as a follow-table request. Eligibility
+			 * (matching the base table's hash key) is validated at the master.
+			 */
+			if (!(coloptions[0] & INDOPTION_HASH))
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
+						 errmsg("HASH columns must be present to follow the base table's split")));
+
+			HandleYBStatus(YBCPgCreateIndexSetFollowTable(handle));
+			break;
+
 		default:
 			ereport(ERROR, (errmsg("illegal memory state for SPLIT options")));
 			break;

--- a/src/postgres/src/backend/parser/gram.y
+++ b/src/postgres/src/backend/parser/gram.y
@@ -4882,6 +4882,14 @@ SplitClause:
       	  $$->num_tablets = -1;
       	  $$->split_points = $4;
         }
+      | FOLLOWING TABLE
+        {
+      	  /* YB: index follows its base table's split mapping (SPLIT FOLLOWING TABLE). */
+      	  $$ = makeNode(YbOptSplit);
+      	  $$->split_type = FOLLOW_TABLE;
+      	  $$->num_tablets = -1;
+      	  $$->split_points = NULL;
+        }
       ;
 
 yb_split_points:

--- a/src/postgres/src/backend/utils/adt/ruleutils.c
+++ b/src/postgres/src/backend/utils/adt/ruleutils.c
@@ -1672,30 +1672,41 @@ pg_get_indexdef_worker(Oid indexrelid, int colno,
 
 		/*
 		 * YB: Emit split clause based on the current configuration.
-		 * - Hash indexes: SPLIT INTO N TABLETS (current tablet count).
+		 * - Follow-table indexes: SPLIT FOLLOWING TABLE, recovered from the
+		 *   yb_presplit reloption.  This is a declarative property rather than
+		 *   a tablet count, so it is emitted whatever the index's current
+		 *   tablet count is; emitting SPLIT INTO N TABLETS here instead would
+		 *   silently downgrade the index to an ordinary hash index on restore.
+		 * - Other hash indexes: SPLIT INTO N TABLETS (current tablet count).
 		 * - Range indexes: SPLIT AT VALUES (...) from yb_presplit, since
 		 *   SPLIT INTO N TABLETS is not valid for range-partitioned indexes.
 		 */
-		if (includeYbMetadata && indexrel->yb_table_properties &&
-			indexrel->yb_table_properties->num_tablets > 1)
+		if (includeYbMetadata && indexrel->yb_table_properties)
 		{
-			if (indexrel->yb_table_properties->num_hash_key_columns > 0)
-			{
-				appendStringInfo(&buf, " SPLIT INTO %" PRIu64 " TABLETS",
-								 indexrel->yb_table_properties->num_tablets);
-			}
-			else if (!amroutine->yb_amiscopartitioned)
-			{
-				/* Skip range SPLIT for copartitioned AMs (e.g. ybhnsw); not valid on vector index. */
-				char	   *presplit = yb_extract_reloption_value(indexrelid,
-																  "yb_presplit");
+			char	   *presplit = yb_extract_reloption_value(indexrelid,
+															  "yb_presplit");
 
-				if (presplit && presplit[0] == '(')
+			if (presplit && pg_strcasecmp(presplit, "FOLLOWING TABLE") == 0)
+			{
+				appendStringInfoString(&buf, " SPLIT FOLLOWING TABLE");
+			}
+			else if (indexrel->yb_table_properties->num_tablets > 1)
+			{
+				if (indexrel->yb_table_properties->num_hash_key_columns > 0)
+				{
+					appendStringInfo(&buf, " SPLIT INTO %" PRIu64 " TABLETS",
+									 indexrel->yb_table_properties->num_tablets);
+				}
+				/* Skip range SPLIT for copartitioned AMs (e.g. ybhnsw); not valid on vector index. */
+				else if (!amroutine->yb_amiscopartitioned &&
+						 presplit && presplit[0] == '(')
 				{
 					appendStringInfo(&buf, " SPLIT AT VALUES %s", presplit);
-					pfree(presplit);
 				}
 			}
+
+			if (presplit)
+				pfree(presplit);
 		}
 
 		/*

--- a/src/postgres/src/backend/utils/misc/guc.c
+++ b/src/postgres/src/backend/utils/misc/guc.c
@@ -1407,6 +1407,20 @@ static struct config_bool ConfigureNamesBool[] =
 		NULL, NULL, NULL
 	},
 	{
+		{"yb_enable_follow_table_index", PGC_SUSET, DEVELOPER_OPTIONS,
+			gettext_noop("Prototype: enables 'CREATE INDEX ... SPLIT FOLLOWING TABLE'."),
+			gettext_noop("When true, a hash-partitioned secondary index whose hash key "
+						 "matches its base table's may be created with SPLIT FOLLOWING "
+						 "TABLE, making the index eventually track the base table's tablet "
+						 "split boundaries and placement. When false, that syntax is "
+						 "rejected."),
+			GUC_NOT_IN_SAMPLE
+		},
+		&yb_enable_follow_table_index,
+		false,
+		NULL, NULL, NULL
+	},
+	{
 		{"yb_prefer_bnl", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("If enabled, planner will force a preference of batched"
 						 " nested loop join plans over classic nested loop"

--- a/src/postgres/src/backend/utils/misc/guc.c
+++ b/src/postgres/src/backend/utils/misc/guc.c
@@ -1411,8 +1411,14 @@ static struct config_bool ConfigureNamesBool[] =
 			gettext_noop("Prototype: enables 'CREATE INDEX ... SPLIT FOLLOWING TABLE'."),
 			gettext_noop("When true, a hash-partitioned secondary index whose hash key "
 						 "matches its base table's may be created with SPLIT FOLLOWING "
-						 "TABLE, making the index eventually track the base table's tablet "
-						 "split boundaries and placement. When false, that syntax is "
+						 "TABLE. Split boundaries are then actively kept in step: the index "
+						 "is split to match new boundaries in the base table. Placement is "
+						 "only a best-effort preference: the cluster balancer steers replica "
+						 "and leader moves toward the matching base tablet when it can do so "
+						 "without disturbing load balance, and never at the cost of it. "
+						 "Co-location is therefore not guaranteed, and in a settled cluster "
+						 "an index tablet's leader will frequently sit on a different node "
+						 "than its base tablet's leader. When false, that syntax is "
 						 "rejected."),
 			GUC_NOT_IN_SAMPLE
 		},

--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -2299,6 +2299,12 @@ bool		yb_enable_replication_origin_shared = true;
 
 bool		yb_use_hash_splitting_by_default = true;
 
+/*
+ * Prototype: gates the 'SPLIT FOLLOWING TABLE' CREATE INDEX syntax. Mirrors the gflag
+ * --ysql_yb_enable_follow_table_index in common_flags.cc.
+ */
+bool		yb_enable_follow_table_index = false;
+
 bool		yb_xcluster_automatic_mode_target_ddl = false;
 
 bool		yb_enable_extended_sql_codes = false;

--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -7539,6 +7539,25 @@ YbGetSplitOptions(Relation rel)
 	YbOptSplit *split_options = makeNode(YbOptSplit);
 
 	/*
+	 * YB: A follow-table index's split is a declarative property, not a tablet
+	 * count or a set of split points, so it cannot be recovered from the
+	 * relation's live tablet layout.  Recover it from the persisted
+	 * yb_presplit reloption instead.  Without this, operations that rebuild
+	 * the DocDB relation while preserving split options -- REINDEX, ALTER
+	 * TABLE rewrites, TRUNCATE -- would silently recreate the index as an
+	 * ordinary hash index with whatever tablet count it happened to have.
+	 */
+	{
+		const char *presplit = YbRelationGetPresplit(rel);
+
+		if (presplit && pg_strcasecmp(presplit, "FOLLOWING TABLE") == 0)
+		{
+			split_options->split_type = FOLLOW_TABLE;
+			return split_options;
+		}
+	}
+
+	/*
 	 * The split type is NUM_TABLETS when the relation has hash key columns
 	 * OR if the relation's range key is currently being dropped. Otherwise,
 	 * the split type is SPLIT_POINTS.
@@ -7869,6 +7888,7 @@ YbRelationIsHashPartitioned(Relation rel)
  *
  * - SPLIT INTO N TABLETS  requires a hash-partitioned relation
  * - SPLIT AT VALUES (...) requires a range-partitioned relation
+ * - SPLIT FOLLOWING TABLE requires a hash-partitioned index (YB)
  */
 void
 YbValidatePresplitForRelation(Relation rel, const char *presplit_str)
@@ -7889,14 +7909,29 @@ YbValidatePresplitForRelation(Relation rel, const char *presplit_str)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("yb_presplit with split points is not yet supported for hash partitioned tables")));
+
+	if (split->split_type == FOLLOW_TABLE)
+	{
+		if (rel->rd_rel->relkind != RELKIND_INDEX &&
+			rel->rd_rel->relkind != RELKIND_PARTITIONED_INDEX)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
+					 errmsg("SPLIT FOLLOWING TABLE is only valid for a secondary index")));
+
+		if (!is_hash)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
+					 errmsg("HASH columns must be present to follow the base table's split")));
+	}
 }
 
 /*
  * Parse a yb_presplit reloption value into a YbOptSplit node.
  *
- * The persisted value comes in three flavors, all of which are accepted:
+ * The persisted value comes in four flavors, all of which are accepted:
  *   - A bare positive integer: "5"               (SPLIT INTO N TABLETS)
  *   - A bare split-point list: "((100),(200))"   (SPLIT AT VALUES (...))
+ *   - A bare follow clause:    "FOLLOWING TABLE" (SPLIT FOLLOWING TABLE)
  *   - A full clause:           "SPLIT INTO 5 TABLETS" or
  *                              "SPLIT AT VALUES ((100),(200))"
  *
@@ -7925,7 +7960,8 @@ YbParsePresplitString(const char *presplit_str)
 		query = prefixed = psprintf("AT VALUES %s", presplit_str);
 	else if (pg_strncasecmp(presplit_str, "SPLIT", 5) == 0 ||
 			 pg_strncasecmp(presplit_str, "INTO", 4) == 0 ||
-			 pg_strncasecmp(presplit_str, "AT", 2) == 0)
+			 pg_strncasecmp(presplit_str, "AT", 2) == 0 ||
+			 pg_strncasecmp(presplit_str, "FOLLOWING", 9) == 0)
 		query = presplit_str;
 	else
 		/* Treat anything else as the operand of SPLIT INTO N TABLETS. */
@@ -7957,6 +7993,17 @@ YbSplitOptionsToPresplitString(YbOptSplit *split_options)
 	{
 		/* Format: ((val1), (val2), ...) */
 		return YbSplitPointsToString(split_options->split_points);
+	}
+	else if (split_options->split_type == FOLLOW_TABLE)
+	{
+		/*
+		 * YB: SPLIT FOLLOWING TABLE carries no operand.  Persisting it as a
+		 * yb_presplit reloption is what makes the property survive
+		 * dump/restore and REINDEX: without it, pg_get_indexdef would fall
+		 * back to emitting the index's current tablet count and the index
+		 * would silently be recreated as an ordinary hash index.
+		 */
+		return pstrdup("FOLLOWING TABLE");
 	}
 
 	return NULL;

--- a/src/postgres/src/include/nodes/parsenodes.h
+++ b/src/postgres/src/include/nodes/parsenodes.h
@@ -2426,7 +2426,8 @@ typedef struct Constraint
 typedef enum
 {
 	NUM_TABLETS = 0,
-	SPLIT_POINTS = 1
+	SPLIT_POINTS = 1,
+	FOLLOW_TABLE = 2			/* YB: index follows its base table's split mapping */
 } YbSplitType;
 
 typedef struct YbOptSplit

--- a/src/postgres/src/include/pg_yb_utils.h
+++ b/src/postgres/src/include/pg_yb_utils.h
@@ -905,6 +905,12 @@ YbDdlRollbackEnabled()
 extern bool yb_use_hash_splitting_by_default;
 
 /*
+ * Prototype: when true, allows 'CREATE INDEX ... SPLIT FOLLOWING TABLE' for a
+ * hash-partitioned secondary index whose hash key matches its base table.
+ */
+extern bool yb_enable_follow_table_index;
+
+/*
  * If set to true, non-key columns of secondary indexes are updated in-place
  * when no key columns are modified.
  */

--- a/src/postgres/src/include/utils/rel.h
+++ b/src/postgres/src/include/utils/rel.h
@@ -773,8 +773,9 @@ typedef struct YbParitionedTableOptions
 /*
  * YbRelationGetPresplit
  *		Returns the relation's yb_presplit reloption setting, or NULL if
- *		unset.  The string is either a number (for SPLIT INTO N TABLETS)
- *		or a split-point list (for SPLIT AT VALUES ((...),...)).
+ *		unset.  The string is either a number (for SPLIT INTO N TABLETS),
+ *		a split-point list (for SPLIT AT VALUES ((...),...)), or the literal
+ *		"FOLLOWING TABLE" (for SPLIT FOLLOWING TABLE).
  *
  *		For RELKIND_PARTITIONED_TABLE, rd_options is a YbParitionedTableOptions;
  *		for everything else (heap, matview, index, partitioned index) it is a

--- a/src/yb/client/table_creator.cc
+++ b/src/yb/client/table_creator.cc
@@ -244,6 +244,11 @@ YBTableCreator& YBTableCreator::skip_index_backfill(const bool skip_index_backfi
   return *this;
 }
 
+YBTableCreator& YBTableCreator::follow_table_mode(master::YbFollowTableMode mode) {
+  follow_table_mode_ = mode;
+  return *this;
+}
+
 YBTableCreator& YBTableCreator::use_mangled_column_name(bool value) {
   index_info_->set_use_mangled_column_name(value);
   return *this;
@@ -414,6 +419,11 @@ Status YBTableCreator::Create() {
     req.set_is_unique_index(index_info_->is_unique());
     req.set_skip_index_backfill(skip_index_backfill_);
     req.set_is_backfill_deferred(index_info_->is_backfill_deferred());
+
+    // Prototype: forward follow-table mode (SPLIT FOLLOWING TABLE) to the master.
+    if (follow_table_mode_ != master::FOLLOW_TABLE_NONE) {
+      req.set_follow_table_mode(follow_table_mode_);
+    }
   }
 
   auto deadline = CoarseMonoClock::Now() +

--- a/src/yb/client/table_creator.h
+++ b/src/yb/client/table_creator.h
@@ -148,6 +148,10 @@ class YBTableCreator {
   // For index table: sets whether to do online schema migration when creating index.
   YBTableCreator& skip_index_backfill(const bool skip_index_backfill);
 
+  // Prototype: for index table, sets whether the index follows its base table's
+  // tablet split mapping and placement (SPLIT FOLLOWING TABLE).
+  YBTableCreator& follow_table_mode(master::YbFollowTableMode mode);
+
   // For vector index table: adds vector index-specific options.
   YBTableCreator& add_vector_options(const PgVectorIdxOptionsPB& vec_options);
 
@@ -224,6 +228,9 @@ class YBTableCreator {
   std::unique_ptr<IndexInfoPB> index_info_;
 
   bool skip_index_backfill_ = false;
+
+  // Prototype: follow-table mode for a secondary index (SPLIT FOLLOWING TABLE).
+  master::YbFollowTableMode follow_table_mode_ = master::FOLLOW_TABLE_NONE;
 
   bool TEST_use_old_style_create_request_ = false;
 

--- a/src/yb/common/common_flags.cc
+++ b/src/yb/common/common_flags.cc
@@ -377,9 +377,13 @@ DEFINE_RUNTIME_bool(ysql_enable_auto_analyze, false,
 DEFINE_RUNTIME_PG_FLAG(bool, yb_enable_follow_table_index, false,
     "Prototype: enable follow-table secondary indexes. When true, a hash-partitioned "
     "secondary index whose hash key matches its base table's may be created with "
-    "'CREATE INDEX ... SPLIT FOLLOWING TABLE', which makes the index eventually track the "
-    "base table's tablet split boundaries and placement. When false, that syntax is "
-    "rejected. Defaults to false.");
+    "'CREATE INDEX ... SPLIT FOLLOWING TABLE'. Split boundaries are then actively kept in step: "
+    "the index is split to match new boundaries in the base table. Placement is only a "
+    "best-effort preference: the cluster balancer steers replica and leader moves toward the "
+    "matching base tablet when it can do so without disturbing load balance, and never at the "
+    "cost of it. Co-location is therefore not guaranteed, and in a settled cluster an index "
+    "tablet's leader will frequently sit on a different node than its base tablet's leader. "
+    "When false, the syntax is rejected. Defaults to false.");
 
 DEFINE_NON_RUNTIME_bool(enable_qos, false, "Enable the QoS feature.");
 

--- a/src/yb/common/common_flags.cc
+++ b/src/yb/common/common_flags.cc
@@ -374,6 +374,13 @@ DEFINE_RUNTIME_bool(ysql_enable_auto_analyze, false,
     "Enable Auto Analyze to automatically trigger ANALYZE for updating table statistics of tables "
     "which have changed more than a configurable threshold.");
 
+DEFINE_RUNTIME_PG_FLAG(bool, yb_enable_follow_table_index, false,
+    "Prototype: enable follow-table secondary indexes. When true, a hash-partitioned "
+    "secondary index whose hash key matches its base table's may be created with "
+    "'CREATE INDEX ... SPLIT FOLLOWING TABLE', which makes the index eventually track the "
+    "base table's tablet split boundaries and placement. When false, that syntax is "
+    "rejected. Defaults to false.");
+
 DEFINE_NON_RUNTIME_bool(enable_qos, false, "Enable the QoS feature.");
 
 DEFINE_NON_RUNTIME_bool(is_yb_managed, false,

--- a/src/yb/common/common_flags.h
+++ b/src/yb/common/common_flags.h
@@ -32,6 +32,7 @@ DECLARE_int32(ysql_clone_pg_schema_rpc_timeout_ms);
 DECLARE_int32(master_ts_rpc_timeout_ms);
 DECLARE_bool(enable_object_locking_for_table_locks);
 DECLARE_bool(ysql_yb_enable_invalidation_messages);
+DECLARE_bool(ysql_yb_enable_follow_table_index);
 DECLARE_bool(enable_qos);
 DECLARE_bool(is_yb_managed);
 

--- a/src/yb/master/catalog_entity_info.cc
+++ b/src/yb/master/catalog_entity_info.cc
@@ -551,10 +551,6 @@ bool TableInfo::is_vector_index() const {
   return l->is_vector_index();
 }
 
-YbFollowTableMode TableInfo::follow_table_mode() const {
-  return LockForRead()->pb.follow_table_mode();
-}
-
 Result<uint32_t> TableInfo::GetPgRelfilenodeOid() const {
   return GetPgsqlTableOid(id());
 }

--- a/src/yb/master/catalog_entity_info.cc
+++ b/src/yb/master/catalog_entity_info.cc
@@ -551,6 +551,10 @@ bool TableInfo::is_vector_index() const {
   return l->is_vector_index();
 }
 
+YbFollowTableMode TableInfo::follow_table_mode() const {
+  return LockForRead()->pb.follow_table_mode();
+}
+
 Result<uint32_t> TableInfo::GetPgRelfilenodeOid() const {
   return GetPgsqlTableOid(id());
 }

--- a/src/yb/master/catalog_entity_info.h
+++ b/src/yb/master/catalog_entity_info.h
@@ -523,6 +523,12 @@ struct PersistentTableInfo : public Persistent<SysTablesEntryPB> {
   bool is_index() const;
   bool is_vector_index() const;
 
+  // Prototype: whether this is a follow-table index (SPLIT FOLLOWING TABLE). Lives on the
+  // persistent state rather than on TableInfo so that callers use the lock they already
+  // hold instead of taking a second read lock.
+  YbFollowTableMode follow_table_mode() const { return pb.follow_table_mode(); }
+  bool follows_table() const { return follow_table_mode() != FOLLOW_TABLE_NONE; }
+
   SchemaPB* mutable_schema() {
     return pb.mutable_schema();
   }
@@ -730,11 +736,6 @@ class TableInfo : public RefCountedThreadSafe<TableInfo>,
   bool is_local_index() const;
   bool is_unique_index() const;
   bool is_vector_index() const;
-
-  // Prototype: how this index follows its base table's tablet split mapping and
-  // placement (SPLIT FOLLOWING TABLE). FOLLOW_TABLE_NONE for a normal index/table.
-  YbFollowTableMode follow_table_mode() const;
-  bool follows_table() const { return follow_table_mode() != FOLLOW_TABLE_NONE; }
 
   void set_is_system() { is_system_ = true; }
   bool is_system() const { return is_system_; }

--- a/src/yb/master/catalog_entity_info.h
+++ b/src/yb/master/catalog_entity_info.h
@@ -731,6 +731,11 @@ class TableInfo : public RefCountedThreadSafe<TableInfo>,
   bool is_unique_index() const;
   bool is_vector_index() const;
 
+  // Prototype: how this index follows its base table's tablet split mapping and
+  // placement (SPLIT FOLLOWING TABLE). FOLLOW_TABLE_NONE for a normal index/table.
+  YbFollowTableMode follow_table_mode() const;
+  bool follows_table() const { return follow_table_mode() != FOLLOW_TABLE_NONE; }
+
   void set_is_system() { is_system_ = true; }
   bool is_system() const { return is_system_; }
 

--- a/src/yb/master/catalog_entity_info.proto
+++ b/src/yb/master/catalog_entity_info.proto
@@ -29,6 +29,14 @@ import "yb/dockv/dockv.proto";
 import "yb/master/master_types.proto";
 import "yb/tserver/tserver.proto";
 
+// Prototype: how a secondary index tracks its base table's tablet split
+// mapping and placement (SPLIT FOLLOWING TABLE). Gated by the master gflag
+// --ysql_yb_enable_follow_table_index.
+enum YbFollowTableMode {
+  FOLLOW_TABLE_NONE = 0;      // Normal, independent index (default).
+  FOLLOW_TABLE_EVENTUAL = 1;  // Index eventually converges to the base table's mapping.
+}
+
 message BackfillJobPB {
   repeated IndexInfoPB indexes = 1;
 
@@ -230,6 +238,10 @@ message SysTablesEntryPB {
   }
 
   optional XClusterTableInfo xcluster_table_info = 42;
+
+  // Prototype: for a secondary index, the mode by which it follows its base
+  // table's tablet split mapping and placement (SPLIT FOLLOWING TABLE).
+  optional YbFollowTableMode follow_table_mode = 43 [ default = FOLLOW_TABLE_NONE ];
 }
 
 // The on-disk entry in the sys.catalog table ("metadata" column) for

--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -60,6 +60,7 @@
 #include <atomic>
 #include <chrono>
 #include <functional>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -3755,10 +3756,13 @@ Status CatalogManager::ReconcileFollowTableIndexSplits(
     const auto& index_tablets = *index_tablets_res;
     const auto& base_tablets = *base_tablets_res;
 
-    // Boundaries (partition_key_start) the index tablets already have.
-    std::set<std::string> index_starts;
+    // Index tablets keyed by partition_key_start. Built once per index, because it answers both
+    // questions the loop below asks: whether the index already has a given boundary, and which
+    // index tablet covers a given hash range. Doing the latter with a scan per base boundary
+    // would be quadratic and would re-lock every index tablet each time.
+    std::map<std::string, TabletInfoPtr> index_by_start;
     for (const auto& t : index_tablets) {
-      index_starts.insert(t->LockForRead()->pb.partition().partition_key_start());
+      index_by_start.emplace(t->LockForRead()->pb.partition().partition_key_start(), t);
     }
 
     // For each interior base boundary the index still lacks, force a matching 2-way split
@@ -3770,27 +3774,53 @@ Status CatalogManager::ReconcileFollowTableIndexSplits(
         break;
       }
       std::string boundary = base_tablet->LockForRead()->pb.partition().partition_key_start();
-      if (boundary.empty() || index_starts.count(boundary)) {
+      if (boundary.empty() || index_by_start.count(boundary)) {
         continue;  // first tablet (no interior boundary) or index already split here.
       }
 
-      // Find the index tablet whose range [start, end) covers 'boundary'. Locks are taken
-      // and released per tablet: we must not hold any tablet lock across DoSplitTablet, which
-      // acquires mutex_ (the required lock order is mutex_ -> table -> tablet).
-      TabletInfoPtr covering;
-      for (const auto& it : index_tablets) {
-        std::string s, e;
+      // The index tablet covering 'boundary' is the one with the greatest start <= boundary:
+      // index tablets tile the hash key space contiguously, so that tablet's range necessarily
+      // contains the boundary and its end need not be consulted. upper_bound cannot return
+      // begin() here, since the first index tablet's start is empty and sorts before every
+      // boundary, but treat it as "no covering tablet" rather than rely on that.
+      auto covering_it = index_by_start.upper_bound(boundary);
+      if (covering_it == index_by_start.begin()) {
+        continue;
+      }
+      --covering_it;
+      const TabletInfoPtr& covering = covering_it->second;
+      // One split per index tablet per pass. A tablet that fails validation below is left in
+      // this set deliberately, so a covering tablet that cannot be split is not re-checked once
+      // per base boundary it covers.
+      if (!queued_index_tablets.insert(covering->tablet_id()).second) {
+        continue;
+      }
+
+      // DoSplitTablet below passes ManualSplit::kTrue, which waives the per-tablet disabled list
+      // and the TTL check in addition to the table-level lists pre-checked above. Following the
+      // base table is not a reason to override those either, so run the tablet-level validation
+      // explicitly. The tablet read lock is scoped tightly: it must not be held across
+      // GetTabletInfo, which takes mutex_ (required order is mutex_ -> table -> tablet).
+      TabletInfoPtr split_parent;
+      {
+        TabletId parent_id;
         {
-          auto il = it->LockForRead();
-          s = il->pb.partition().partition_key_start();
-          e = il->pb.partition().partition_key_end();
+          auto cl = covering->LockForRead();
+          parent_id = cl->pb.split_parent_tablet_id();
         }
-        if (s <= boundary && (e.empty() || boundary < e)) {
-          covering = it;
-          break;
+        if (!parent_id.empty()) {
+          auto parent_res = GetTabletInfo(parent_id);
+          if (parent_res.ok()) {
+            split_parent = *parent_res;
+          }
         }
       }
-      if (!covering || !queued_index_tablets.insert(covering->tablet_id()).second) {
+      auto tablet_validation = master_->tablet_split_manager().ValidateSplitCandidateTablet(
+          *covering, split_parent, IgnoreTtlValidation::kFalse, IgnoreDisabledList::kFalse);
+      if (!tablet_validation.ok()) {
+        YB_LOG_EVERY_N_SECS(INFO, 300)
+            << "Follow-table reconciler: skipping index tablet " << covering->tablet_id()
+            << " (index " << table->id() << "): " << tablet_validation;
         continue;
       }
 
@@ -12244,7 +12274,7 @@ Status CatalogManager::ProcessPendingAssignmentsPerTable(
   // Prototype (follow-table index): if this table follows a base table, precompute for each
   // tablet the tservers hosting the matching base tablet, to use as a soft placement
   // preference below. Do this BEFORE taking tablet write locks so the catalog mutex (acquired
-  // by GetTableInfo/GetFollowTableReplicasByPartitionKey) is taken in the documented order
+  // by GetTableInfo/GetFollowTableBasePlacements) is taken in the documented order
   // (mutex_ -> table -> tablet). Empty for non-following tables.
   std::unordered_map<TabletId, std::set<TabletServerId>> follow_preferred_by_tablet;
   if (FLAGS_ysql_yb_enable_follow_table_index) {
@@ -12257,13 +12287,13 @@ Status CatalogManager::ProcessPendingAssignmentsPerTable(
     }
     if (!base_table_id.empty()) {
       // Best-effort: any lookup failure just leaves the preferences empty.
-      auto base_replicas = GetFollowTableReplicasByPartitionKey(base_table_id);
-      if (base_replicas.ok()) {
+      auto base_placements = GetFollowTableBasePlacements(base_table_id);
+      if (base_placements.ok()) {
         for (const TabletInfoPtr& tablet : tablets) {
-          auto it = base_replicas->find(
+          auto it = base_placements->find(
               tablet->LockForRead()->pb.partition().partition_key_start());
-          if (it != base_replicas->end() && !it->second.empty()) {
-            follow_preferred_by_tablet[tablet->tablet_id()] = it->second;
+          if (it != base_placements->end() && !it->second.replicas.empty()) {
+            follow_preferred_by_tablet[tablet->tablet_id()] = it->second.replicas;
           }
         }
       }
@@ -12823,15 +12853,15 @@ shared_ptr<TSDescriptor> CatalogManager::SelectReplica(
   return found_ts;
 }
 
-Result<std::unordered_map<std::string, std::set<TabletServerId>>>
-CatalogManager::GetFollowTableReplicasByPartitionKey(const TableId& base_table_id) {
-  std::unordered_map<std::string, std::set<TabletServerId>> replicas_by_partition_key;
+Result<std::unordered_map<std::string, CatalogManager::FollowTableBasePlacement>>
+CatalogManager::GetFollowTableBasePlacements(const TableId& base_table_id) {
+  std::unordered_map<std::string, FollowTableBasePlacement> placements;
   if (base_table_id.empty()) {
-    return replicas_by_partition_key;
+    return placements;
   }
   auto base_table = GetTableInfo(base_table_id);
   if (!base_table) {
-    return replicas_by_partition_key;
+    return placements;
   }
   auto base_tablets = VERIFY_RESULT(base_table->GetTablets());
   for (const auto& base_tablet : base_tablets) {
@@ -12839,13 +12869,16 @@ CatalogManager::GetFollowTableReplicasByPartitionKey(const TableId& base_table_i
     if (!replicas) {
       continue;
     }
-    auto& preferred =
-        replicas_by_partition_key[base_tablet->LockForRead()->pb.partition().partition_key_start()];
-    for (const auto& entry : *replicas) {
-      preferred.insert(entry.first);
+    auto& placement =
+        placements[base_tablet->LockForRead()->pb.partition().partition_key_start()];
+    for (const auto& [ts_uuid, replica] : *replicas) {
+      placement.replicas.insert(ts_uuid);
+      if (replica.role == PeerRole::LEADER) {
+        placement.leader = ts_uuid;
+      }
     }
   }
-  return replicas_by_partition_key;
+  return placements;
 }
 
 void CatalogManager::SelectReplicas(

--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -3691,6 +3691,101 @@ Status CatalogManager::SplitTablet(
   return SplitTablet(tablet, is_manual_split, split_factor, epoch);
 }
 
+Status CatalogManager::ReconcileFollowTableIndexSplits(
+    const std::vector<TableInfoPtr>& tables, const LeaderEpoch& epoch) {
+  if (!FLAGS_ysql_yb_enable_follow_table_index) {
+    return Status::OK();
+  }
+  for (const auto& table : tables) {
+    TableId base_table_id;
+    PartitionSchemaPB index_partition_schema_pb;
+    {
+      auto l = table->LockForRead();
+      if (l->pb.follow_table_mode() == FOLLOW_TABLE_NONE || !l->is_running()) {
+        continue;
+      }
+      base_table_id = l->indexed_table_id();
+      index_partition_schema_pb = l->pb.partition_schema();
+    }
+    if (base_table_id.empty()) {
+      continue;
+    }
+    auto base_table = GetTableInfo(base_table_id);
+    if (!base_table) {
+      continue;
+    }
+
+    auto index_tablets_res = table->GetTablets(GetTabletsMode::kOrderByPartitions);
+    auto base_tablets_res = base_table->GetTablets(GetTabletsMode::kOrderByPartitions);
+    if (!index_tablets_res.ok() || !base_tablets_res.ok()) {
+      continue;
+    }
+    const auto& index_tablets = *index_tablets_res;
+    const auto& base_tablets = *base_tablets_res;
+
+    // Boundaries (partition_key_start) the index tablets already have.
+    std::set<std::string> index_starts;
+    for (const auto& t : index_tablets) {
+      index_starts.insert(t->LockForRead()->pb.partition().partition_key_start());
+    }
+
+    // For each interior base boundary the index still lacks, force a matching 2-way split
+    // on the index tablet covering that hash range. At most one split per index tablet per
+    // pass keeps this idempotent and eventually convergent across passes.
+    std::set<std::string> queued_index_tablets;
+    for (const auto& base_tablet : base_tablets) {
+      std::string boundary = base_tablet->LockForRead()->pb.partition().partition_key_start();
+      if (boundary.empty() || index_starts.count(boundary)) {
+        continue;  // first tablet (no interior boundary) or index already split here.
+      }
+
+      // Find the index tablet whose range [start, end) covers 'boundary'. Locks are taken
+      // and released per tablet: we must not hold any tablet lock across DoSplitTablet, which
+      // acquires mutex_ (the required lock order is mutex_ -> table -> tablet).
+      TabletInfoPtr covering;
+      for (const auto& it : index_tablets) {
+        std::string s, e;
+        {
+          auto il = it->LockForRead();
+          s = il->pb.partition().partition_key_start();
+          e = il->pb.partition().partition_key_end();
+        }
+        if (s <= boundary && (e.empty() || boundary < e)) {
+          covering = it;
+          break;
+        }
+      }
+      if (!covering || !queued_index_tablets.insert(covering->tablet_id()).second) {
+        continue;
+      }
+
+      auto encoded = PartitionSchema::GetEncodedPartitionKey(boundary, index_partition_schema_pb);
+      if (!encoded.ok()) {
+        LOG(WARNING) << "Follow-table reconciler: failed to encode split key for index "
+                     << table->id() << ": " << encoded.status();
+        continue;
+      }
+      std::vector<std::string> split_partition_keys{boundary};
+      std::vector<std::string> split_encoded_keys{*encoded};
+      // Forced (manual) split so it is not rejected by the follow-table exclusion in
+      // ValidateSplitCandidateTable, and split at the base's exact boundary rather than the
+      // index tablet's own mid-point so boundaries converge to match the base.
+      auto s = DoSplitTablet(
+          covering, split_encoded_keys, split_partition_keys, ManualSplit::kTrue, epoch);
+      if (s.ok()) {
+        LOG(INFO) << "Follow-table reconciler: queued split of index tablet "
+                  << covering->tablet_id() << " (index " << table->id()
+                  << ") to match base table " << base_table_id << " boundary.";
+      } else {
+        WARN_NOT_OK(s, Format("Follow-table reconciler: split of index tablet $0 (index $1) "
+                              "to match base boundary failed",
+                              covering->tablet_id(), table->id()));
+      }
+    }
+  }
+  return Status::OK();
+}
+
 Status CatalogManager::XReplValidateSplitCandidateTable(const TableId& table_id) const {
   SharedLock lock(mutex_);
   return XReplValidateSplitCandidateTableUnlocked(table_id);
@@ -12096,6 +12191,32 @@ Status CatalogManager::ProcessPendingAssignmentsPerTable(
   RETURN_NOT_OK(InitializeTableLoadState(table_id, ts_descs, &table_load_state));
   table_load_state.SortLoad();
 
+  // Prototype (follow-table index): if this table follows a base table, precompute for each
+  // tablet the tservers hosting the matching base tablet, to use as a soft placement
+  // preference below. Do this BEFORE taking tablet write locks so the catalog mutex (acquired
+  // by GetTableInfo/GetFollowTablePreferredReplicas) is taken in the documented order
+  // (mutex_ -> table -> tablet). Empty for non-following tables.
+  std::unordered_map<TabletId, std::set<TabletServerId>> follow_preferred_by_tablet;
+  if (FLAGS_ysql_yb_enable_follow_table_index) {
+    TableId base_table_id;
+    if (auto index_table = GetTableInfo(table_id)) {
+      auto l = index_table->LockForRead();
+      if (l->pb.follow_table_mode() != FOLLOW_TABLE_NONE) {
+        base_table_id = l->indexed_table_id();
+      }
+    }
+    if (!base_table_id.empty()) {
+      for (const TabletInfoPtr& tablet : tablets) {
+        std::string partition_key_start =
+            tablet->LockForRead()->pb.partition().partition_key_start();
+        auto pref = GetFollowTablePreferredReplicas(base_table_id, partition_key_start);
+        if (pref.ok() && !pref->empty()) {
+          follow_preferred_by_tablet[tablet->tablet_id()] = std::move(*pref);
+        }
+      }
+    }
+  }
+
   // Take write locks on all tablets to be processed, and ensure that they are
   // unlocked at the end of this scope.
   for (const TabletInfoPtr& tablet : tablets) {
@@ -12147,7 +12268,8 @@ Status CatalogManager::ProcessPendingAssignmentsPerTable(
     // NOTE: if we fail to select replicas on the first pass (due to
     // insufficient Tablet Servers being online), we will still try
     // again unless the tablet/table creation is cancelled.
-    s = SelectReplicasForTablet(ts_descs, tablet, &table_load_state, global_load_state);
+    s = SelectReplicasForTablet(
+        ts_descs, tablet, &table_load_state, global_load_state, follow_preferred_by_tablet);
     if (!s.ok()) {
       LOG_WITH_FUNC(INFO) << "Select replicas for tablet " << tablet->id() << " failed: " << s;
       s = s.CloneAndPrepend(Substitute(
@@ -12267,7 +12389,8 @@ Status CatalogManager::SelectProtegeForTablet(
 
 Status CatalogManager::SelectReplicasForTablet(
     const TSDescriptorVector& ts_descs, const TabletInfoPtr& tablet,
-    CMPerTableLoadState* per_table_state, CMGlobalLoadState* global_state) {
+    CMPerTableLoadState* per_table_state, CMGlobalLoadState* global_state,
+    const std::unordered_map<TabletId, std::set<TabletServerId>>& follow_preferred_by_tablet) {
   auto table_guard = tablet->table()->LockForRead();
 
   if (!table_guard->pb.IsInitialized()) {
@@ -12284,8 +12407,19 @@ Status CatalogManager::SelectReplicasForTablet(
   VLOG_WITH_FUNC(3) << "Committed consensus state: " << AsString(cstate);
   consensus::RaftConfigPB* config = cstate->mutable_config();
 
+  // Prototype (follow-table index): if the caller precomputed a base-tablet host set for this
+  // tablet (done before tablet locks are held, so the catalog mutex was taken in the correct
+  // order), use it as a soft co-placement preference. Absent/empty => normal placement.
+  const std::set<TabletServerId>* preferred_replicas = nullptr;
+  auto pref_it = follow_preferred_by_tablet.find(tablet->tablet_id());
+  if (pref_it != follow_preferred_by_tablet.end()) {
+    preferred_replicas = &pref_it->second;
+  }
+  static const std::set<TabletServerId> kNoPreference;
+
   RETURN_NOT_OK(HandlePlacementUsingReplicationInfo(
-      replication_info, ts_descs, config, per_table_state, global_state));
+      replication_info, ts_descs, config, per_table_state, global_state,
+      preferred_replicas ? *preferred_replicas : kNoPreference));
 
   LOG_WITH_FUNC(INFO)
       << "Initial tserver uuids for tablet " << tablet->tablet_id() << " [table_id="
@@ -12327,7 +12461,8 @@ Status CatalogManager::HandlePlacementUsingReplicationInfo(
     const TSDescriptorVector& all_ts_descs,
     consensus::RaftConfigPB* config,
     CMPerTableLoadState* per_table_state,
-    CMGlobalLoadState* global_state) {
+    CMGlobalLoadState* global_state,
+    const set<TabletServerId>& preferred_replicas) {
   // Validate if we have enough tservers to put the replicas.
   ValidateReplicationInfoRequestPB req;
   req.mutable_replication_info()->CopyFrom(replication_info);
@@ -12336,9 +12471,11 @@ Status CatalogManager::HandlePlacementUsingReplicationInfo(
 
   TSDescriptorVector ts_descs;
   GetTsDescsFromPlacementInfo(replication_info.live_replicas(), all_ts_descs, &ts_descs);
+  // Prototype (follow-table index): the base-tablet co-placement preference applies only
+  // to the live (VOTER) replicas; read replicas keep normal placement.
   RETURN_NOT_OK(HandlePlacementUsingPlacementInfo(
       replication_info.live_replicas(), ts_descs, PeerMemberType::VOTER,
-      config, per_table_state, global_state));
+      config, per_table_state, global_state, preferred_replicas));
   for (int i = 0; i < replication_info.read_replicas_size(); i++) {
     GetTsDescsFromPlacementInfo(replication_info.read_replicas(i), all_ts_descs, &ts_descs);
     RETURN_NOT_OK(HandlePlacementUsingPlacementInfo(
@@ -12353,7 +12490,9 @@ Status CatalogManager::HandlePlacementUsingPlacementInfo(const PlacementInfoPB& 
                                                          PeerMemberType member_type,
                                                          consensus::RaftConfigPB* config,
                                                          CMPerTableLoadState* per_table_state,
-                                                         CMGlobalLoadState* global_state) {
+                                                         CMGlobalLoadState* global_state,
+                                                         const set<TabletServerId>&
+                                                             preferred_replicas) {
   size_t nreplicas = GetNumReplicasOrGlobalReplicationFactor(placement_info);
   size_t ntservers = ts_descs.size();
   // Keep track of servers we've already selected, so that we don't attempt to
@@ -12365,7 +12504,7 @@ Status CatalogManager::HandlePlacementUsingPlacementInfo(const PlacementInfoPB& 
     // We cannot put more than ntservers replicas.
     nreplicas = min(nreplicas, ntservers);
     SelectReplicas(ts_descs, nreplicas, config, &already_selected_ts, member_type,
-                   per_table_state, global_state);
+                   per_table_state, global_state, preferred_replicas);
   } else {
     // TODO(bogdan): move to separate function
     //
@@ -12386,7 +12525,7 @@ Status CatalogManager::HandlePlacementUsingPlacementInfo(const PlacementInfoPB& 
       size_t num_replicas = min(min_num_replicas, available_ts_descs_size);
       min_replica_count_sum += min_num_replicas;
       SelectReplicas(available_ts_descs, num_replicas, config, &already_selected_ts, member_type,
-                     per_table_state, global_state);
+                     per_table_state, global_state, preferred_replicas);
     }
 
     size_t replicas_left = nreplicas - min_replica_count_sum;
@@ -12399,7 +12538,7 @@ Status CatalogManager::HandlePlacementUsingPlacementInfo(const PlacementInfoPB& 
       // requested placements and checked individually per placement info, if we could cover the
       // minimums.
       SelectReplicas(all_allowed_ts, replicas_left, config, &already_selected_ts, member_type,
-                     per_table_state, global_state);
+                     per_table_state, global_state, preferred_replicas);
     }
   }
   return Status::OK();
@@ -12597,7 +12736,20 @@ void CatalogManager::StartElectionIfReady(
 shared_ptr<TSDescriptor> CatalogManager::SelectReplica(
     const TSDescriptorVector& ts_descs,
     set<TabletServerId>* excluded,
-    CMPerTableLoadState* per_table_state, CMGlobalLoadState* global_state) {
+    CMPerTableLoadState* per_table_state, CMGlobalLoadState* global_state,
+    const set<TabletServerId>& preferred_replicas) {
+  // Prototype (follow-table index): soft co-placement. If any preferred tserver (a host
+  // of the matching base tablet) is allowed for this tablet and not already chosen, pick
+  // it before considering load. This is a preference, not a constraint: when no preferred
+  // tserver qualifies we fall through to normal load-based selection below.
+  if (!preferred_replicas.empty()) {
+    for (const auto& ts : ts_descs) {
+      const auto& uuid = ts->permanent_uuid();
+      if (preferred_replicas.count(uuid) && !excluded->count(uuid)) {
+        return ts;
+      }
+    }
+  }
   shared_ptr<TSDescriptor> found_ts;
   for (const auto& sorted_load : per_table_state->sorted_replica_load_) {
     // Don't consider a tserver that has already been considered for this tablet.
@@ -12618,15 +12770,44 @@ shared_ptr<TSDescriptor> CatalogManager::SelectReplica(
   return found_ts;
 }
 
+Result<std::set<TabletServerId>> CatalogManager::GetFollowTablePreferredReplicas(
+    const TableId& base_table_id, const std::string& partition_key_start) {
+  std::set<TabletServerId> preferred;
+  if (base_table_id.empty()) {
+    return preferred;
+  }
+  auto base_table = GetTableInfo(base_table_id);
+  if (!base_table) {
+    return preferred;
+  }
+  // Identical hash key => identical encoded partition-key space, so the base tablet that
+  // starts at the same partition_key_start covers exactly this index tablet's hash range.
+  auto base_tablets = VERIFY_RESULT(base_table->GetTablets(GetTabletsMode::kOrderByPartitions));
+  for (const auto& base_tablet : base_tablets) {
+    if (base_tablet->LockForRead()->pb.partition().partition_key_start() != partition_key_start) {
+      continue;
+    }
+    auto replicas = base_tablet->GetReplicaLocations();
+    if (replicas) {
+      for (const auto& entry : *replicas) {
+        preferred.insert(entry.first);
+      }
+    }
+    break;
+  }
+  return preferred;
+}
+
 void CatalogManager::SelectReplicas(
     const TSDescriptorVector& ts_descs, size_t nreplicas, consensus::RaftConfigPB* config,
     set<TabletServerId>* already_selected_ts, PeerMemberType member_type,
-    CMPerTableLoadState* per_table_state, CMGlobalLoadState* global_state) {
+    CMPerTableLoadState* per_table_state, CMGlobalLoadState* global_state,
+    const set<TabletServerId>& preferred_replicas) {
   DCHECK_LE(nreplicas, ts_descs.size());
 
   for (size_t i = 0; i < nreplicas; ++i) {
     shared_ptr<TSDescriptor> ts = SelectReplica(
-        ts_descs, already_selected_ts, per_table_state, global_state);
+        ts_descs, already_selected_ts, per_table_state, global_state, preferred_replicas);
     InsertOrDie(already_selected_ts, ts->permanent_uuid());
     // Update the load state at global and table level.
     per_table_state->per_ts_replica_load_[ts->permanent_uuid()]++;

--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -4437,6 +4437,50 @@ bool EnableTableOwnedVectorReverseMapping() {
       : FLAGS_enable_table_owned_vector_reverse_mapping;
 }
 
+// Prototype: an index is eligible to follow its base table (SPLIT FOLLOWING TABLE)
+// only when it shares the base table's HASH key. Both must be hash-partitioned with
+// the same number of hash key columns; that guarantees a compatible (uint16) encoded
+// partition-key space, so a base split key can be reused verbatim on the index -- the
+// property every later following phase relies on.
+//
+// The stronger semantic property (each index hash column is exactly the base table's
+// corresponding hash key column, in order, so a row and its index entry hash into the
+// same bucket) is checked here only for YCQL, where IndexInfoPB.indexed_hash_column_ids
+// is populated. For YSQL that field is not populated at the master (index maintenance
+// lives in the PG layer), so exact column identity is trusted from the user's explicit
+// opt-in for now and re-verified when partition following compares live ranges in a
+// later phase. Returns OK when eligible, else InvalidArgument explaining why.
+Status ValidateFollowTableEligibility(
+    const IndexInfoPB& index_info, const Schema& index_schema, const Schema& base_schema) {
+  const size_t base_hash_count = base_schema.num_hash_key_columns();
+  const size_t index_hash_count = index_schema.num_hash_key_columns();
+  SCHECK_GT(
+      base_hash_count, 0U, InvalidArgument,
+      "SPLIT FOLLOWING TABLE requires a hash-partitioned base table");
+  SCHECK_GT(
+      index_hash_count, 0U, InvalidArgument,
+      "SPLIT FOLLOWING TABLE requires a hash-partitioned index");
+  SCHECK_EQ(
+      index_hash_count, base_hash_count, InvalidArgument,
+      "SPLIT FOLLOWING TABLE requires the index and base table to have the same number of "
+      "HASH key columns");
+
+  // YCQL: strict column-identity check when the base column mapping is available.
+  if (static_cast<size_t>(index_info.indexed_hash_column_ids_size()) == base_hash_count) {
+    for (size_t i = 0; i < base_hash_count; ++i) {
+      if (ColumnId(static_cast<ColumnIdRep>(
+              index_info.indexed_hash_column_ids(narrow_cast<int>(i)))) !=
+          base_schema.column_id(i)) {
+        return STATUS(
+            InvalidArgument,
+            "SPLIT FOLLOWING TABLE requires the index HASH key to match the base table's HASH "
+            "key in order");
+      }
+    }
+  }
+  return Status::OK();
+}
+
 } // namespace
 
 // Create a new table.
@@ -4525,6 +4569,22 @@ Status CatalogManager::CreateTable(const CreateTableRequestPB* orig_req,
   Schema schema;
   RETURN_NOT_OK(SchemaFromPB(req.schema(), &schema));
   RETURN_NOT_OK(ValidateCreateTableSchema(schema, resp));
+
+  // Prototype: validate a follow-table index (SPLIT FOLLOWING TABLE). This is the
+  // authoritative gate; PostgreSQL also rejects early when the GUC is off. The index
+  // must share its base table's HASH key (see ValidateFollowTableEligibility). Later
+  // phases (partition/placement/split following) key off the persisted mode.
+  if (req.follow_table_mode() != FOLLOW_TABLE_NONE) {
+    SCHECK(
+        FLAGS_ysql_yb_enable_follow_table_index, InvalidArgument,
+        "SPLIT FOLLOWING TABLE is not enabled "
+        "(set --ysql_yb_enable_follow_table_index=true)");
+    SCHECK(
+        IsIndex(req), InvalidArgument,
+        "SPLIT FOLLOWING TABLE is only valid for a secondary index");
+    auto base_schema = VERIFY_RESULT(indexed_table->GetSchema());
+    RETURN_NOT_OK(ValidateFollowTableEligibility(req.index_info(), schema, base_schema));
+  }
 
   // Pre-colocation GA colocated tables in a legacy colocated database are colocated via database,
   // but after GA, colocated tables are colocated via tablegroups.
@@ -4633,6 +4693,26 @@ Status CatalogManager::CreateTable(const CreateTableRequestPB* orig_req,
   // non-parent table. Such tables will reuse tablets of their respective colocation group.
   bool joining_colocation_group =
       colocated && !IsColocationParentTableId(req.table_id());
+
+  // Prototype: creation-time partition following. When this index follows its base table
+  // (SPLIT FOLLOWING TABLE), inherit the base table's current tablet split boundaries 1:1
+  // instead of synthesizing new ones. The index keeps its own hash partition_schema (which
+  // matches the base's by the eligibility check), so the base's encoded partition ranges
+  // apply verbatim. Populating CreateTableRequestPB.partitions routes creation through the
+  // existing explicit-partitions branch of CreatePartitions (the same path backup/restore
+  // uses to reproduce a table's partitioning) -- no colocation machinery involved.
+  if (req.follow_table_mode() != FOLLOW_TABLE_NONE) {
+    auto base_tablets =
+        VERIFY_RESULT(indexed_table->GetTablets(GetTabletsMode::kOrderByPartitions));
+    req.clear_partitions();
+    for (const auto& base_tablet : base_tablets) {
+      *req.add_partitions() = base_tablet->LockForRead()->pb.partition();
+    }
+    req.set_num_tablets(req.partitions_size());
+    LOG(INFO) << "Follow-table index " << req.name() << " inheriting "
+              << req.partitions_size() << " partition(s) from base table "
+              << req.indexed_table_id();
+  }
 
   int num_tablets = VERIFY_RESULT(
       CalculateNumTabletsForTableCreation(req, schema, replication_info.live_replicas()));
@@ -4805,6 +4885,13 @@ Status CatalogManager::CreateTable(const CreateTableRequestPB* orig_req,
         req, schema, partition_schema, namespace_id, namespace_name, partitions, colocated,
         IsSystemObject::kFalse, &index_info, joining_colocation_group ? nullptr : &tablets, resp,
         &table, &indexed_table));
+
+    // Prototype: persist the follow-table mode on the index's metadata so later phases
+    // (partition/placement/split following) can identify follower indexes.
+    if (req.follow_table_mode() != FOLLOW_TABLE_NONE) {
+      table->mutable_metadata()->mutable_dirty()->pb.set_follow_table_mode(
+          req.follow_table_mode());
+    }
 
     // Section is executed when a table is either the parent table or a user table in a colocation
     // group.

--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -450,6 +450,13 @@ DEFINE_RUNTIME_int64(tablet_force_split_threshold_bytes, 100_GB,
     "tablets from forming in your cluster even if both automatic splitting phases have "
     "been finished.");
 
+DEFINE_RUNTIME_uint32(follow_table_index_max_splits_per_pass, 8,
+    "Maximum number of tablet splits the follow-table index reconciler may issue in one "
+    "background pass, across all follow-table indexes. These are forced splits, so they "
+    "are not covered by outstanding_tablet_split_limit; this bounds how much split work a "
+    "single pass can queue when an index is far behind its base table. Convergence "
+    "continues on later passes. 0 disables the reconciler's splitting.");
+
 DEFINE_test_flag(bool, crash_server_on_sys_catalog_leader_affinity_move, false,
     "When set, crash the master process if it performs a sys catalog leader affinity "
     "move.");
@@ -3696,22 +3703,47 @@ Status CatalogManager::ReconcileFollowTableIndexSplits(
   if (!FLAGS_ysql_yb_enable_follow_table_index) {
     return Status::OK();
   }
+  uint32_t splits_remaining = FLAGS_follow_table_index_max_splits_per_pass;
   for (const auto& table : tables) {
+    if (splits_remaining == 0) {
+      break;
+    }
     TableId base_table_id;
     PartitionSchemaPB index_partition_schema_pb;
     {
       auto l = table->LockForRead();
-      if (l->pb.follow_table_mode() == FOLLOW_TABLE_NONE || !l->is_running()) {
+      if (!l->follows_table() || !l->is_running()) {
         continue;
       }
       base_table_id = l->indexed_table_id();
       index_partition_schema_pb = l->pb.partition_schema();
     }
-    if (base_table_id.empty()) {
+    // A colocated index has no tablets of its own; it shares its colocation parent's
+    // tablet, which must never be split on this index's behalf. CreateTable rejects the
+    // combination, so this only guards against catalog entries that predate that check.
+    if (base_table_id.empty() || table->colocated()) {
       continue;
     }
     auto base_table = GetTableInfo(base_table_id);
     if (!base_table) {
+      continue;
+    }
+
+    // The splits below are issued as manual/forced splits, which waive the disabled lists,
+    // PITR coverage, TTL and tablet-replica-limit protections. Following the base table is
+    // not a good enough reason to override an operator who has disabled splitting or a
+    // restore that is in flight, so ask here whether the index would be splittable on all
+    // those other grounds -- suppressing only the follow-table exclusion itself, which
+    // exists precisely to route these splits through this reconciler.
+    auto validation = master_->tablet_split_manager().ValidateSplitCandidateTable(
+        table, IgnoreDisabledList::kFalse, IgnoreVectorIndexesValidation::kFalse,
+        IgnoreFollowTableExclusion::kTrue);
+    if (!validation.ok()) {
+      YB_LOG_EVERY_N_SECS(INFO, 300)
+          << "Follow-table reconciler: skipping index " << table->id() << ": " << validation;
+      continue;
+    }
+    if (!XReplValidateSplitCandidateTable(table->id()).ok()) {
       continue;
     }
 
@@ -3734,6 +3766,9 @@ Status CatalogManager::ReconcileFollowTableIndexSplits(
     // pass keeps this idempotent and eventually convergent across passes.
     std::set<std::string> queued_index_tablets;
     for (const auto& base_tablet : base_tablets) {
+      if (splits_remaining == 0) {
+        break;
+      }
       std::string boundary = base_tablet->LockForRead()->pb.partition().partition_key_start();
       if (boundary.empty() || index_starts.count(boundary)) {
         continue;  // first tablet (no interior boundary) or index already split here.
@@ -3761,8 +3796,11 @@ Status CatalogManager::ReconcileFollowTableIndexSplits(
 
       auto encoded = PartitionSchema::GetEncodedPartitionKey(boundary, index_partition_schema_pb);
       if (!encoded.ok()) {
-        LOG(WARNING) << "Follow-table reconciler: failed to encode split key for index "
-                     << table->id() << ": " << encoded.status();
+        // Rate-limited: this runs on every background pass, and a partition schema that
+        // cannot encode one boundary generally cannot encode any of them.
+        YB_LOG_EVERY_N_SECS(WARNING, 300)
+            << "Follow-table reconciler: failed to encode split key for index "
+            << table->id() << ": " << encoded.status();
         continue;
       }
       std::vector<std::string> split_partition_keys{boundary};
@@ -3772,14 +3810,15 @@ Status CatalogManager::ReconcileFollowTableIndexSplits(
       // index tablet's own mid-point so boundaries converge to match the base.
       auto s = DoSplitTablet(
           covering, split_encoded_keys, split_partition_keys, ManualSplit::kTrue, epoch);
+      --splits_remaining;
       if (s.ok()) {
         LOG(INFO) << "Follow-table reconciler: queued split of index tablet "
                   << covering->tablet_id() << " (index " << table->id()
                   << ") to match base table " << base_table_id << " boundary.";
       } else {
-        WARN_NOT_OK(s, Format("Follow-table reconciler: split of index tablet $0 (index $1) "
-                              "to match base boundary failed",
-                              covering->tablet_id(), table->id()));
+        YB_LOG_EVERY_N_SECS(WARNING, 300)
+            << "Follow-table reconciler: split of index tablet " << covering->tablet_id()
+            << " (index " << table->id() << ") to match base boundary failed: " << s;
       }
     }
   }
@@ -4541,10 +4580,12 @@ bool EnableTableOwnedVectorReverseMapping() {
 // The stronger semantic property (each index hash column is exactly the base table's
 // corresponding hash key column, in order, so a row and its index entry hash into the
 // same bucket) is checked here only for YCQL, where IndexInfoPB.indexed_hash_column_ids
-// is populated. For YSQL that field is not populated at the master (index maintenance
-// lives in the PG layer), so exact column identity is trusted from the user's explicit
-// opt-in for now and re-verified when partition following compares live ranges in a
-// later phase. Returns OK when eligible, else InvalidArgument explaining why.
+// is populated. For YSQL that field is not populated at the master -- the PGSQL create
+// path supplies only the base table's id, not a column mapping (see
+// IndexInfoBuilder::ApplyColumnMapping, which it skips) -- so column identity is checked
+// in the PG layer instead, by YbValidateFollowTableHashKey in yb_cmds.c. The count checks
+// below are the master's authoritative backstop for both languages.
+// Returns OK when eligible, else InvalidArgument explaining why.
 Status ValidateFollowTableEligibility(
     const IndexInfoPB& index_info, const Schema& index_schema, const Schema& base_schema) {
   const size_t base_hash_count = base_schema.num_hash_key_columns();
@@ -4710,6 +4751,15 @@ Status CatalogManager::CreateTable(const CreateTableRequestPB* orig_req,
   SCHECK(
       !colocated || req.has_table_id(), InvalidArgument,
       "Colocated table should specify a table ID");
+
+  // Prototype: a colocated index has no tablets of its own -- it shares its colocation
+  // parent's single tablet -- so there is nothing to follow, and the split reconciler
+  // must never be pointed at that shared tablet. The same is true of a vector index,
+  // which is copartitioned with the indexed table. Reject rather than silently persist a
+  // mode nothing will act on. (This check needs `colocated`, which is only known here.)
+  SCHECK(
+      req.follow_table_mode() == FOLLOW_TABLE_NONE || !colocated, InvalidArgument,
+      "SPLIT FOLLOWING TABLE is not supported for colocated or vector indexes");
 
   // If ysql_enable_colocated_tables_with_tablespaces is not enabled then tablespaces cannot be
   // specified for indexes on colocated tables. Vector indexes are exempt: they are copartitioned
@@ -12194,24 +12244,27 @@ Status CatalogManager::ProcessPendingAssignmentsPerTable(
   // Prototype (follow-table index): if this table follows a base table, precompute for each
   // tablet the tservers hosting the matching base tablet, to use as a soft placement
   // preference below. Do this BEFORE taking tablet write locks so the catalog mutex (acquired
-  // by GetTableInfo/GetFollowTablePreferredReplicas) is taken in the documented order
+  // by GetTableInfo/GetFollowTableReplicasByPartitionKey) is taken in the documented order
   // (mutex_ -> table -> tablet). Empty for non-following tables.
   std::unordered_map<TabletId, std::set<TabletServerId>> follow_preferred_by_tablet;
   if (FLAGS_ysql_yb_enable_follow_table_index) {
     TableId base_table_id;
     if (auto index_table = GetTableInfo(table_id)) {
       auto l = index_table->LockForRead();
-      if (l->pb.follow_table_mode() != FOLLOW_TABLE_NONE) {
+      if (l->follows_table()) {
         base_table_id = l->indexed_table_id();
       }
     }
     if (!base_table_id.empty()) {
-      for (const TabletInfoPtr& tablet : tablets) {
-        std::string partition_key_start =
-            tablet->LockForRead()->pb.partition().partition_key_start();
-        auto pref = GetFollowTablePreferredReplicas(base_table_id, partition_key_start);
-        if (pref.ok() && !pref->empty()) {
-          follow_preferred_by_tablet[tablet->tablet_id()] = std::move(*pref);
+      // Best-effort: any lookup failure just leaves the preferences empty.
+      auto base_replicas = GetFollowTableReplicasByPartitionKey(base_table_id);
+      if (base_replicas.ok()) {
+        for (const TabletInfoPtr& tablet : tablets) {
+          auto it = base_replicas->find(
+              tablet->LockForRead()->pb.partition().partition_key_start());
+          if (it != base_replicas->end() && !it->second.empty()) {
+            follow_preferred_by_tablet[tablet->tablet_id()] = it->second;
+          }
         }
       }
     }
@@ -12770,32 +12823,29 @@ shared_ptr<TSDescriptor> CatalogManager::SelectReplica(
   return found_ts;
 }
 
-Result<std::set<TabletServerId>> CatalogManager::GetFollowTablePreferredReplicas(
-    const TableId& base_table_id, const std::string& partition_key_start) {
-  std::set<TabletServerId> preferred;
+Result<std::unordered_map<std::string, std::set<TabletServerId>>>
+CatalogManager::GetFollowTableReplicasByPartitionKey(const TableId& base_table_id) {
+  std::unordered_map<std::string, std::set<TabletServerId>> replicas_by_partition_key;
   if (base_table_id.empty()) {
-    return preferred;
+    return replicas_by_partition_key;
   }
   auto base_table = GetTableInfo(base_table_id);
   if (!base_table) {
-    return preferred;
+    return replicas_by_partition_key;
   }
-  // Identical hash key => identical encoded partition-key space, so the base tablet that
-  // starts at the same partition_key_start covers exactly this index tablet's hash range.
-  auto base_tablets = VERIFY_RESULT(base_table->GetTablets(GetTabletsMode::kOrderByPartitions));
+  auto base_tablets = VERIFY_RESULT(base_table->GetTablets());
   for (const auto& base_tablet : base_tablets) {
-    if (base_tablet->LockForRead()->pb.partition().partition_key_start() != partition_key_start) {
+    auto replicas = base_tablet->GetReplicaLocations();
+    if (!replicas) {
       continue;
     }
-    auto replicas = base_tablet->GetReplicaLocations();
-    if (replicas) {
-      for (const auto& entry : *replicas) {
-        preferred.insert(entry.first);
-      }
+    auto& preferred =
+        replicas_by_partition_key[base_tablet->LockForRead()->pb.partition().partition_key_start()];
+    for (const auto& entry : *replicas) {
+      preferred.insert(entry.first);
     }
-    break;
   }
-  return preferred;
+  return replicas_by_partition_key;
 }
 
 void CatalogManager::SelectReplicas(

--- a/src/yb/master/catalog_manager.h
+++ b/src/yb/master/catalog_manager.h
@@ -2169,12 +2169,19 @@ class CatalogManager : public CatalogManagerIf, public SnapshotCoordinatorContex
       CMPerTableLoadState* per_table_state, CMGlobalLoadState* global_state,
       const std::set<TabletServerId>& preferred_replicas = {});
 
-  // Prototype (follow-table index): returns the set of tserver uuids currently hosting
-  // the base table's tablet whose hash partition range starts at 'partition_key_start'.
-  // Empty if the base table/tablet cannot be found or its replicas are unknown; used as
-  // a soft placement preference so a follower index tablet co-locates with its base.
-  Result<std::set<TabletServerId>> GetFollowTablePreferredReplicas(
-      const TableId& base_table_id, const std::string& partition_key_start);
+  // Prototype (follow-table index): maps each of the base table's hash partition range
+  // starts to the set of tserver uuids currently hosting that tablet. Because a follower
+  // index shares its base table's HASH key, the two have the same encoded partition-key
+  // space, so an index tablet's partition_key_start selects the base tablet covering
+  // exactly its hash range. Used as a soft placement preference so index tablets
+  // co-locate with their base tablets.
+  //
+  // Built once per table rather than looked up per tablet: callers iterate every tablet
+  // of the index, and a per-tablet scan of the base table's tablet list would be
+  // quadratic and would re-lock every base tablet each time. Empty if the base table
+  // cannot be found.
+  Result<std::unordered_map<std::string, std::set<TabletServerId>>>
+      GetFollowTableReplicasByPartitionKey(const TableId& base_table_id);
 
   // Select and assign a tablet server as the protege 'config'. This protege is selected from the
   // set of tservers in 'global_state' that have the lowest current protege load.

--- a/src/yb/master/catalog_manager.h
+++ b/src/yb/master/catalog_manager.h
@@ -1041,12 +1041,17 @@ class CatalogManager : public CatalogManagerIf, public SnapshotCoordinatorContex
 
   // Loops through the table's placement infos and populates the corresponding config from
   // each placement.
+  // Prototype (follow-table index): 'preferred_replicas', when non-empty, is a soft
+  // preference for tservers hosting the matching base tablet. Replica selection favors
+  // these tservers but falls back to normal load-based selection when they are
+  // unavailable or would violate placement constraints.
   Status HandlePlacementUsingReplicationInfo(
       const ReplicationInfoPB& replication_info,
       const TSDescriptorVector& all_ts_descs,
       consensus::RaftConfigPB* config,
       CMPerTableLoadState* per_table_state,
-      CMGlobalLoadState* global_state);
+      CMGlobalLoadState* global_state,
+      const std::set<TabletServerId>& preferred_replicas = {});
 
   // Handles the config creation for a given placement.
   Status HandlePlacementUsingPlacementInfo(const PlacementInfoPB& placement_info,
@@ -1054,7 +1059,8 @@ class CatalogManager : public CatalogManagerIf, public SnapshotCoordinatorContex
                                            consensus::PeerMemberType member_type,
                                            consensus::RaftConfigPB* config,
                                            CMPerTableLoadState* per_table_state,
-                                           CMGlobalLoadState* global_state);
+                                           CMGlobalLoadState* global_state,
+                                           const std::set<TabletServerId>& preferred_replicas = {});
 
   // Populates ts_descs with all tservers belonging to a certain placement.
   void GetTsDescsFromPlacementInfo(const PlacementInfoPB& placement_info,
@@ -2160,7 +2166,15 @@ class CatalogManager : public CatalogManagerIf, public SnapshotCoordinatorContex
   std::shared_ptr<TSDescriptor> SelectReplica(
       const TSDescriptorVector& ts_descs,
       std::set<TabletServerId>* excluded,
-      CMPerTableLoadState* per_table_state, CMGlobalLoadState* global_state);
+      CMPerTableLoadState* per_table_state, CMGlobalLoadState* global_state,
+      const std::set<TabletServerId>& preferred_replicas = {});
+
+  // Prototype (follow-table index): returns the set of tserver uuids currently hosting
+  // the base table's tablet whose hash partition range starts at 'partition_key_start'.
+  // Empty if the base table/tablet cannot be found or its replicas are unknown; used as
+  // a soft placement preference so a follower index tablet co-locates with its base.
+  Result<std::set<TabletServerId>> GetFollowTablePreferredReplicas(
+      const TableId& base_table_id, const std::string& partition_key_start);
 
   // Select and assign a tablet server as the protege 'config'. This protege is selected from the
   // set of tservers in 'global_state' that have the lowest current protege load.
@@ -2174,9 +2188,15 @@ class CatalogManager : public CatalogManagerIf, public SnapshotCoordinatorContex
   // servers to select the N replicas, return Status::InvalidArgument.
   //
   // This method is called by "ProcessPendingAssignmentsPerTable()".
+  // 'follow_preferred_by_tablet' (prototype, follow-table index) maps a tablet id to the
+  // tservers hosting the matching base tablet; it is precomputed by the caller before any
+  // tablet locks are taken (so the catalog mutex is acquired in the correct order) and used
+  // as a soft placement preference for that tablet's replicas.
   Status SelectReplicasForTablet(
       const TSDescriptorVector& ts_descs, const TabletInfoPtr& tablet,
-      CMPerTableLoadState* per_table_state, CMGlobalLoadState* global_state);
+      CMPerTableLoadState* per_table_state, CMGlobalLoadState* global_state,
+      const std::unordered_map<TabletId, std::set<TabletServerId>>& follow_preferred_by_tablet =
+          {});
 
   // Select N Replicas from the online tablet servers that have been chosen to respect the
   // placement information provided. Populate the consensus configuration object with choices and
@@ -2190,7 +2210,8 @@ class CatalogManager : public CatalogManagerIf, public SnapshotCoordinatorContex
       std::set<TabletServerId>* already_selected_ts,
       consensus::PeerMemberType member_type,
       CMPerTableLoadState* per_table_state,
-      CMGlobalLoadState* global_state);
+      CMGlobalLoadState* global_state,
+      const std::set<TabletServerId>& preferred_replicas = {});
 
   void HandleAssignPreparingTablet(const TabletInfoPtr& tablet,
                                    DeferredAssignmentActions* deferred);
@@ -2383,6 +2404,14 @@ class CatalogManager : public CatalogManagerIf, public SnapshotCoordinatorContex
       const TabletInfoPtr& source_tablet_info,
       const std::vector<docdb::DocKeyHash>& split_hash_codes, ManualSplit is_manual_split,
       const LeaderEpoch& epoch);
+
+  // Prototype (follow-table index): for each follow-table index in 'tables', diff its tablet
+  // partition boundaries against its base table's and force a matching split on the index
+  // tablet for each base boundary the index still lacks. Idempotent and eventually
+  // convergent (at most one split per index tablet per pass). Invoked from the background
+  // splitting loop. No-op unless the follow-table feature flag is enabled.
+  Status ReconcileFollowTableIndexSplits(
+      const std::vector<TableInfoPtr>& tables, const LeaderEpoch& epoch);
 
   int64_t leader_ready_term() const override {
     return leader_ready_term_.load();

--- a/src/yb/master/catalog_manager.h
+++ b/src/yb/master/catalog_manager.h
@@ -2169,19 +2169,30 @@ class CatalogManager : public CatalogManagerIf, public SnapshotCoordinatorContex
       CMPerTableLoadState* per_table_state, CMGlobalLoadState* global_state,
       const std::set<TabletServerId>& preferred_replicas = {});
 
+  // Prototype (follow-table index): where one tablet of a followed base table currently
+  // lives.
+  struct FollowTableBasePlacement {
+    // Tservers hosting any replica of the base tablet.
+    std::set<TabletServerId> replicas;
+    // Tserver hosting the base tablet's leader, or empty if it has no known leader.
+    // Reads of an index entry's base row go to the base leader, so this is the placement
+    // that actually determines whether the follow-up lookup stays on the same host.
+    TabletServerId leader;
+  };
+
   // Prototype (follow-table index): maps each of the base table's hash partition range
-  // starts to the set of tserver uuids currently hosting that tablet. Because a follower
-  // index shares its base table's HASH key, the two have the same encoded partition-key
-  // space, so an index tablet's partition_key_start selects the base tablet covering
-  // exactly its hash range. Used as a soft placement preference so index tablets
-  // co-locate with their base tablets.
+  // starts to where that tablet currently lives. Because a follower index shares its base
+  // table's HASH key, the two have the same encoded partition-key space, so an index
+  // tablet's partition_key_start selects the base tablet covering exactly its hash range.
+  // Used as a soft placement preference so index tablets co-locate with their base
+  // tablets, and their leaders with the base leaders.
   //
   // Built once per table rather than looked up per tablet: callers iterate every tablet
   // of the index, and a per-tablet scan of the base table's tablet list would be
   // quadratic and would re-lock every base tablet each time. Empty if the base table
   // cannot be found.
-  Result<std::unordered_map<std::string, std::set<TabletServerId>>>
-      GetFollowTableReplicasByPartitionKey(const TableId& base_table_id);
+  Result<std::unordered_map<std::string, FollowTableBasePlacement>>
+      GetFollowTableBasePlacements(const TableId& base_table_id);
 
   // Select and assign a tablet server as the protege 'config'. This protege is selected from the
   // set of tservers in 'global_state' that have the lowest current protege load.

--- a/src/yb/master/catalog_manager_bg_tasks.cc
+++ b/src/yb/master/catalog_manager_bg_tasks.cc
@@ -285,6 +285,11 @@ void CatalogManagerBgTasks::RunOnceAsLeader(const LeaderEpoch& epoch) {
   }
   master_->tablet_split_manager().MaybeDoSplitting(tables, tablet_info_map, epoch);
 
+  // Prototype (follow-table index): reconcile follow-table index tablet boundaries to match
+  // their base tables. No-op unless the follow-table feature flag is enabled.
+  WARN_NOT_OK(catalog_manager_->ReconcileFollowTableIndexSplits(tables, epoch),
+              "Failed to reconcile follow-table index splits");
+
   WARN_NOT_OK(master_->clone_state_manager().Run(), "Failed to run CloneStateManager: ");
 
   if (!to_delete.empty() || catalog_manager_->AreTablesDeletingOrHiding()) {

--- a/src/yb/master/cluster_balance.cc
+++ b/src/yb/master/cluster_balance.cc
@@ -127,6 +127,12 @@ DEFINE_test_flag(int32, load_balancer_wait_after_count_pending_tasks_ms, 0,
                  "For testing purposes, number of milliseconds to wait after counting and "
                  "finding pending tasks.");
 
+DEFINE_RUNTIME_bool(follow_table_index_leader_affinity, true,
+    "Prototype: for secondary indexes created with SPLIT FOLLOWING TABLE, let the cluster "
+    "balancer step an index tablet's leader onto the tserver already hosting the leader of the "
+    "matching base tablet, once leader load is otherwise balanced. Only has an effect when "
+    "ysql_yb_enable_follow_table_index is set.");
+
 DECLARE_int32(min_leader_stepdown_retry_interval_ms);
 DECLARE_bool(enable_ysql_tablespaces_for_placement);
 DECLARE_bool(ysql_yb_enable_follow_table_index);
@@ -911,9 +917,10 @@ Status ClusterLoadBalancer::AnalyzeTablets(const TableInfoPtr& table) {
   }
 
   // Prototype (follow-table index): if this table follows a base table, record for each index
-  // tablet the tservers that currently host the matching base tablet. GetTabletToMove uses this
-  // as a soft co-placement preference so index tablets drift toward their base tablet's nodes
-  // over successive balancer passes. Best-effort: any lookup failure just leaves the entry empty.
+  // tablet where the matching base tablet currently lives -- the tservers hosting its replicas
+  // (a soft co-placement preference for GetTabletToMove) and the tserver hosting its leader (the
+  // target for GetLeaderToMoveForFollowTable). Index tablets drift toward their base tablet's
+  // nodes over successive balancer passes. Best-effort: any lookup failure leaves both empty.
   if (FLAGS_ysql_yb_enable_follow_table_index) {
     TableId base_table_id;
     {
@@ -923,13 +930,19 @@ Status ClusterLoadBalancer::AnalyzeTablets(const TableInfoPtr& table) {
       }
     }
     if (!base_table_id.empty()) {
-      auto base_replicas = catalog_manager_->GetFollowTableReplicasByPartitionKey(base_table_id);
-      if (base_replicas.ok()) {
+      auto base_placements = catalog_manager_->GetFollowTableBasePlacements(base_table_id);
+      if (base_placements.ok()) {
         for (const auto& tablet : tablets) {
-          auto it = base_replicas->find(
+          auto it = base_placements->find(
               tablet->LockForRead()->pb.partition().partition_key_start());
-          if (it != base_replicas->end() && !it->second.empty()) {
-            state_->follow_table_preferred_ts_[tablet->id()] = it->second;
+          if (it == base_placements->end()) {
+            continue;
+          }
+          if (!it->second.replicas.empty()) {
+            state_->follow_table_preferred_ts_[tablet->id()] = it->second.replicas;
+          }
+          if (!it->second.leader.empty()) {
+            state_->follow_table_preferred_leader_ts_[tablet->id()] = it->second.leader;
           }
         }
       }
@@ -1473,15 +1486,47 @@ Result<std::optional<ClusterLoadBalancer::LeaderMoveDetails>>
       // Find the leaders on the higher loaded TS that have running peers on the lower loaded TS.
       // If there are, we have a candidate we want, so fill in the output params and return.
       const std::set<TabletId>& leaders = state_->per_ts_meta_[high_load_uuid].leaders;
-      for (const auto& [tablet_id, path] : GetLeadersOnTSToMove(
-               global_state_->drive_aware_, leaders, state_->per_ts_meta_[low_load_uuid])) {
+      auto candidates = GetLeadersOnTSToMove(
+          global_state_->drive_aware_, leaders, state_->per_ts_meta_[low_load_uuid]);
 
+      // Prototype (follow-table index): the move above is happening regardless; all that is left
+      // to decide is which of the candidates to move. Order them into three groups:
+      //   1. the base tablet's leader is on the destination -- moving this one co-locates it,
+      //   2. no opinion,
+      //   3. the base tablet's leader is on the source -- this one is already co-located, and
+      //      moving it would break that.
+      // Every candidate here produces the same load change, so none of this trades away balance.
+      // Group 3 is what makes co-placement accumulate instead of drifting: without it, ordinary
+      // churn is as likely to destroy co-location as to create it.
+      if (FLAGS_ysql_yb_enable_follow_table_index && FLAGS_follow_table_index_leader_affinity &&
+          !state_->follow_table_preferred_leader_ts_.empty()) {
+        auto base_leader_is_on = [this](const TabletId& tablet_id, const TabletServerId& ts_uuid) {
+          auto it = state_->follow_table_preferred_leader_ts_.find(tablet_id);
+          return it != state_->follow_table_preferred_leader_ts_.end() && it->second == ts_uuid;
+        };
+        // Sink the candidates that would break co-location behind everything else, then float the
+        // ones that would gain it to the front of what is left.
+        auto keep_end = std::stable_partition(
+            candidates.begin(), candidates.end(),
+            [&](const std::pair<TabletId, std::string>& candidate) {
+              return !base_leader_is_on(candidate.first, high_load_uuid);
+            });
+        std::stable_partition(
+            candidates.begin(), keep_end,
+            [&](const std::pair<TabletId, std::string>& candidate) {
+              return base_leader_is_on(candidate.first, low_load_uuid);
+            });
+      }
+
+      for (const auto& [tablet_id, path] : candidates) {
         auto move_details = LeaderMoveDetails {
           .tablet_id = tablet_id,
           .from_ts = high_load_uuid,
           .to_ts = low_load_uuid,
           .to_ts_path = path,
-          .reason = std::move(reason),
+          // Copied, not moved: a later candidate may be reached via the stepdown-backoff
+          // `continue` below and would otherwise get an empty reason.
+          .reason = reason,
         };
 
         VLOG(3) << "For leader balancing found tablet " << tablet_id << " to move from "
@@ -1668,6 +1713,117 @@ Result<std::optional<ClusterLoadBalancer::LeaderMoveDetails>>
   return std::nullopt;
 }
 
+Result<std::optional<ClusterLoadBalancer::LeaderMoveDetails>>
+    ClusterLoadBalancer::GetLeaderToMoveForFollowTable() {
+  if (!FLAGS_ysql_yb_enable_follow_table_index ||
+      !FLAGS_follow_table_index_leader_affinity ||
+      state_->follow_table_preferred_leader_ts_.empty()) {
+    return std::nullopt;
+  }
+
+  // Index each tserver by its affinitized priority (its position in sorted_leader_load_). Moves
+  // are only considered within one priority: crossing priorities is the job of
+  // GetLeaderToMoveAcrossAffinitizedPriorities, which has already run and declined, so a move
+  // this pass made across priorities would be fighting the preferred-zone configuration.
+  std::unordered_map<TabletServerId, size_t> priority_by_ts;
+  for (size_t priority = 0; priority < state_->sorted_leader_load_.size(); ++priority) {
+    for (const auto& ts_uuid : state_->sorted_leader_load_[priority]) {
+      priority_by_ts[ts_uuid] = priority;
+    }
+  }
+
+  const auto current_time = MonoTime::Now();
+  std::optional<LeaderMoveDetails> best;
+  ssize_t best_gain = 0;
+
+  for (const auto& [tablet_id, want_ts] : state_->follow_table_preferred_leader_ts_) {
+    auto tablet_meta_it = state_->per_tablet_meta_.find(tablet_id);
+    if (tablet_meta_it == state_->per_tablet_meta_.end()) {
+      continue;
+    }
+    // Note this already accounts for in-flight stepdowns: AnalyzeTablets replays pending leader
+    // stepdown tasks into the state before we get here.
+    const TabletServerId& from_ts = tablet_meta_it->second.leader_uuid;
+    if (from_ts.empty() || from_ts == want_ts) {
+      // No leader to step down, or the leader is already where we want it.
+      continue;
+    }
+
+    // The destination must be a tserver this table's state knows about, and must be eligible to
+    // hold leaders at all.
+    auto want_meta_it = state_->per_ts_meta_.find(want_ts);
+    if (want_meta_it == state_->per_ts_meta_.end() ||
+        global_state_->leader_blacklisted_servers_.contains(want_ts)) {
+      continue;
+    }
+    auto want_priority = priority_by_ts.find(want_ts);
+    auto from_priority = priority_by_ts.find(from_ts);
+    if (want_priority == priority_by_ts.end() || from_priority == priority_by_ts.end() ||
+        want_priority->second != from_priority->second) {
+      continue;
+    }
+
+    // Never make the leader spread worse. A strictly lower destination load means that after the
+    // move (destination +1, source -1) the gap between the two is no wider than it was, so the
+    // load-driven passes have no reason to move this leader back.
+    ssize_t from_load = state_->GetLeaderLoad(from_ts);
+    ssize_t want_load = state_->GetLeaderLoad(want_ts);
+    if (want_load >= from_load) {
+      continue;
+    }
+
+    // Same requirement against the cluster-wide leader counts. Without this, a move that helps
+    // this table could widen the global spread enough for the global leader balancing branch of
+    // GetLeaderToMove to move the leader straight back, and the two passes would trade it back
+    // and forth.
+    if (global_state_->GetGlobalLeaderLoad(want_ts) >=
+        global_state_->GetGlobalLeaderLoad(from_ts)) {
+      continue;
+    }
+
+    // The destination must already host a running peer of this tablet. Reusing the leader-move
+    // helper with a singleton set gives us that check and the drive-aware path in one call.
+    auto peers = GetLeadersOnTSToMove(
+        global_state_->drive_aware_, {tablet_id}, want_meta_it->second);
+    if (peers.empty()) {
+      continue;
+    }
+
+    // Respect the stepdown backoff, so a tablet that keeps failing to step down onto want_ts is
+    // not retried on every pass.
+    const auto& stepdown_failures = tablet_meta_it->second.leader_stepdown_failures;
+    auto failure_it = stepdown_failures.find(want_ts);
+    if (failure_it != stepdown_failures.end() &&
+        (current_time - failure_it->second).ToMilliseconds() <
+            FLAGS_min_leader_stepdown_retry_interval_ms) {
+      continue;
+    }
+
+    // Iteration order over an unordered_map carries no meaning, so choose deterministically:
+    // the move that relieves the most leader load, ties broken by tablet id.
+    ssize_t gain = from_load - want_load;
+    if (best && (gain < best_gain || (gain == best_gain && tablet_id >= best->tablet_id))) {
+      continue;
+    }
+    best = LeaderMoveDetails {
+      .tablet_id = tablet_id,
+      .from_ts = from_ts,
+      .to_ts = want_ts,
+      .to_ts_path = peers.front().second,
+      .reason = Format(
+          "Destination hosts the leader of this follow-table index tablet's base tablet, and has "
+          "fewer leaders for this table than the source ($0 < $1)", want_load, from_load),
+    };
+    best_gain = gain;
+  }
+
+  if (best) {
+    VLOG(3) << "Follow-table leader affinity found tablet " << best->tablet_id << " to move from "
+            << best->from_ts << " to " << best->to_ts;
+  }
+  return best;
+}
+
 Result<bool> ClusterLoadBalancer::HandleLeaderMoves(
     TabletId* out_tablet_id, TabletServerId* out_from_ts, TabletServerId* out_to_ts) {
   // If the user sets 'transaction_tables_use_preferred_zones' gflag to 0 and the tablet
@@ -1679,6 +1835,13 @@ Result<bool> ClusterLoadBalancer::HandleLeaderMoves(
   }
   if (!move_details) {
     move_details = VERIFY_RESULT(GetLeaderToMoveWithinAffinitizedPriorities());
+  }
+  if (!move_details) {
+    // Prototype (follow-table index): leader load is balanced as far as the passes above care,
+    // so any remaining freedom in leader placement is free to spend on co-locating index leaders
+    // with their base tablet leaders. Deliberately last, so co-placement never delays a move
+    // that is actually correcting load.
+    move_details = VERIFY_RESULT(GetLeaderToMoveForFollowTable());
   }
   if (!move_details) {
     return false;

--- a/src/yb/master/cluster_balance.cc
+++ b/src/yb/master/cluster_balance.cc
@@ -918,18 +918,19 @@ Status ClusterLoadBalancer::AnalyzeTablets(const TableInfoPtr& table) {
     TableId base_table_id;
     {
       auto l = table->LockForRead();
-      if (l->pb.follow_table_mode() != FOLLOW_TABLE_NONE) {
+      if (l->follows_table()) {
         base_table_id = l->indexed_table_id();
       }
     }
     if (!base_table_id.empty()) {
-      for (const auto& tablet : tablets) {
-        std::string partition_key_start =
-            tablet->LockForRead()->pb.partition().partition_key_start();
-        auto preferred =
-            catalog_manager_->GetFollowTablePreferredReplicas(base_table_id, partition_key_start);
-        if (preferred.ok() && !preferred->empty()) {
-          state_->follow_table_preferred_ts_[tablet->id()] = std::move(*preferred);
+      auto base_replicas = catalog_manager_->GetFollowTableReplicasByPartitionKey(base_table_id);
+      if (base_replicas.ok()) {
+        for (const auto& tablet : tablets) {
+          auto it = base_replicas->find(
+              tablet->LockForRead()->pb.partition().partition_key_start());
+          if (it != base_replicas->end() && !it->second.empty()) {
+            state_->follow_table_preferred_ts_[tablet->id()] = it->second;
+          }
         }
       }
     }

--- a/src/yb/master/cluster_balance.cc
+++ b/src/yb/master/cluster_balance.cc
@@ -129,6 +129,7 @@ DEFINE_test_flag(int32, load_balancer_wait_after_count_pending_tasks_ms, 0,
 
 DECLARE_int32(min_leader_stepdown_retry_interval_ms);
 DECLARE_bool(enable_ysql_tablespaces_for_placement);
+DECLARE_bool(ysql_yb_enable_follow_table_index);
 
 DEPRECATE_FLAG(bool, load_balancer_count_move_as_add, "03_2025");
 
@@ -909,6 +910,31 @@ Status ClusterLoadBalancer::AnalyzeTablets(const TableInfoPtr& table) {
     }
   }
 
+  // Prototype (follow-table index): if this table follows a base table, record for each index
+  // tablet the tservers that currently host the matching base tablet. GetTabletToMove uses this
+  // as a soft co-placement preference so index tablets drift toward their base tablet's nodes
+  // over successive balancer passes. Best-effort: any lookup failure just leaves the entry empty.
+  if (FLAGS_ysql_yb_enable_follow_table_index) {
+    TableId base_table_id;
+    {
+      auto l = table->LockForRead();
+      if (l->pb.follow_table_mode() != FOLLOW_TABLE_NONE) {
+        base_table_id = l->indexed_table_id();
+      }
+    }
+    if (!base_table_id.empty()) {
+      for (const auto& tablet : tablets) {
+        std::string partition_key_start =
+            tablet->LockForRead()->pb.partition().partition_key_start();
+        auto preferred =
+            catalog_manager_->GetFollowTablePreferredReplicas(base_table_id, partition_key_start);
+        if (preferred.ok() && !preferred->empty()) {
+          state_->follow_table_preferred_ts_[tablet->id()] = std::move(*preferred);
+        }
+      }
+    }
+  }
+
   return Status::OK();
 }
 
@@ -1228,6 +1254,11 @@ Result<std::optional<TabletId>> ClusterLoadBalancer::GetTabletToMove(
 
     std::optional<TableId> result;
     auto chosen_tablet_ci_similarity = CatalogManagerUtil::NO_MATCH;
+    // Prototype (follow-table index): whether the currently-chosen tablet wants to be on to_ts
+    // because to_ts hosts its matching base tablet. This is the primary tiebreak (ahead of cloud
+    // info similarity) so a follower index tablet is preferred for a move that co-locates it with
+    // its base; it never forces a move or bypasses placement checks (soft preference).
+    bool chosen_prefers_to_ts = false;
     for (const TabletId& tablet_id : tablets) {
       // TODO(#15853): this should be augmented as well to allow dropping by one replica, if still
       // leaving us with more than the minimum.
@@ -1262,12 +1293,28 @@ Result<std::optional<TabletId>> ClusterLoadBalancer::GetTabletToMove(
         ci_similarity = CatalogManagerUtil::ComputeCloudInfoSimilarity(leader_ci, to_ts_ci);
       }
 
-      if (result && ci_similarity <= chosen_tablet_ci_similarity) {
-        continue;
+      // Prototype (follow-table index): does this tablet prefer to_ts for base co-placement?
+      bool prefers_to_ts = false;
+      {
+        auto ft_it = state_->follow_table_preferred_ts_.find(tablet_id);
+        if (ft_it != state_->follow_table_preferred_ts_.end() && ft_it->second.count(to_ts)) {
+          prefers_to_ts = true;
+        }
+      }
+
+      if (result) {
+        // Co-placement preference is the primary key; cloud info similarity is the tiebreak.
+        if (prefers_to_ts < chosen_prefers_to_ts) {
+          continue;
+        }
+        if (prefers_to_ts == chosen_prefers_to_ts && ci_similarity <= chosen_tablet_ci_similarity) {
+          continue;
+        }
       }
       // This is the best tablet to move, so far.
       result = tablet_id;
       chosen_tablet_ci_similarity = ci_similarity;
+      chosen_prefers_to_ts = prefers_to_ts;
     }
 
     // If there is any tablet we can move from this drive, choose it and return.

--- a/src/yb/master/cluster_balance.h
+++ b/src/yb/master/cluster_balance.h
@@ -261,6 +261,21 @@ class ClusterLoadBalancer {
   // Returns std::nullopt otherwise. If error is found, returns Status.
   Result<std::optional<LeaderMoveDetails>> GetLeaderToMoveWithinAffinitizedPriorities();
 
+  // Prototype (follow-table index): step an index tablet's leader onto the tserver that already
+  // hosts the leader of its base tablet, so the index lookup and the base-row read it feeds stay
+  // on one host. Runs only after the load-driven leader passes have declined to move anything.
+  //
+  // A move is only taken when the destination has strictly fewer leaders than the source, both
+  // for this table and cluster-wide. That makes it impossible for the load-driven passes to have
+  // a reason to move the leader back, so the two can never trade a leader back and forth. The
+  // price is that this pass is inert once leader load is exactly even: co-placement then requires
+  // swapping two leaders, which the one-move-at-a-time interface here cannot express. So this
+  // steers leader moves toward co-placement while the cluster is converging (after index
+  // creation, a split, or a tserver restart) rather than guaranteeing co-placement at rest.
+  //
+  // Returns the move if one was found, std::nullopt otherwise.
+  Result<std::optional<LeaderMoveDetails>> GetLeaderToMoveForFollowTable();
+
   // Go through sorted_load_ and figure out which tablet to rebalance and from which TS that is
   // serving it to which other TS.
   //

--- a/src/yb/master/cluster_balance_util.h
+++ b/src/yb/master/cluster_balance_util.h
@@ -532,6 +532,12 @@ class PerTableLoadState {
   // List of tablet ids that have been added to a new tablet server.
   std::set<TabletId> tablets_added_;
 
+  // Prototype (follow-table index): for a follow-table index table, maps each index tablet id
+  // to the set of tservers currently hosting the matching base tablet. Used as a soft
+  // co-placement preference when choosing replica moves (see GetTabletToMove). Empty for
+  // tables that do not follow a base table.
+  std::unordered_map<TabletId, std::set<TabletServerId>> follow_table_preferred_ts_;
+
   // Number of leaders per each tablet server to balance below.
   const int leader_balance_threshold_ = 0;
 

--- a/src/yb/master/cluster_balance_util.h
+++ b/src/yb/master/cluster_balance_util.h
@@ -538,6 +538,14 @@ class PerTableLoadState {
   // tables that do not follow a base table.
   std::unordered_map<TabletId, std::set<TabletServerId>> follow_table_preferred_ts_;
 
+  // Prototype (follow-table index): for a follow-table index table, maps each index tablet id
+  // to the tserver currently hosting the leader of the matching base tablet. This is the
+  // placement that matters for latency -- an index entry's base-row lookup is served by the
+  // base leader. Read by GetLeaderToMove, to order otherwise-equivalent move candidates, and by
+  // GetLeaderToMoveForFollowTable, to propose moves of its own. Only populated when the base
+  // tablet has a known leader; empty for non-following tables.
+  std::unordered_map<TabletId, TabletServerId> follow_table_preferred_leader_ts_;
+
   // Number of leaders per each tablet server to balance below.
   const int leader_balance_threshold_ = 0;
 

--- a/src/yb/master/master_ddl.proto
+++ b/src/yb/master/master_ddl.proto
@@ -152,6 +152,10 @@ message CreateTableRequestPB {
 
   // For YSQL tables, the sub-transaction used by this DDL. If aborted, table will be removed.
   optional uint32 sub_transaction_id = 35;
+
+  // Prototype: when set to a non-NONE mode, this index follows its base table's
+  // tablet split mapping and placement (SPLIT FOLLOWING TABLE).
+  optional YbFollowTableMode follow_table_mode = 36 [ default = FOLLOW_TABLE_NONE ];
 }
 
 message CreateTableResponsePB {

--- a/src/yb/master/tablet_split_manager.cc
+++ b/src/yb/master/tablet_split_manager.cc
@@ -67,6 +67,8 @@ DEFINE_RUNTIME_uint64(outstanding_tablet_split_limit_per_tserver, 3,
 
 DECLARE_bool(TEST_validate_all_tablet_candidates);
 
+DECLARE_bool(ysql_yb_enable_follow_table_index);
+
 DEFINE_RUNTIME_bool(enable_tablet_split_of_pitr_tables, true,
     "When set, it enables automatic tablet splitting of tables covered by "
     "Point In Time Restore schedules.");
@@ -241,7 +243,8 @@ Status TabletSplitManager::ValidatePartitioningVersion(const TableInfo& table) {
 Status TabletSplitManager::ValidateSplitCandidateTable(
     const TableInfoPtr& table,
     const IgnoreDisabledList ignore_disabled_lists,
-    const IgnoreVectorIndexesValidation ignore_vector_indexes_validation) {
+    const IgnoreVectorIndexesValidation ignore_vector_indexes_validation,
+    const IgnoreFollowTableExclusion ignore_follow_table_exclusion) {
   if (PREDICT_FALSE(FLAGS_TEST_validate_all_tablet_candidates)) {
     return Status::OK();
   }
@@ -270,7 +273,17 @@ Status TabletSplitManager::ValidateSplitCandidateTable(
   // split reconciler, which issues them as manual/forced splits. ignore_disabled_lists is
   // set exactly for such forced splits, so we exclude the follow-table index only from the
   // automatic (non-forced) candidate path and let the reconciler's forced split through.
-  if (!ignore_disabled_lists && table_lock->pb.follow_table_mode() != FOLLOW_TABLE_NONE) {
+  //
+  // The reconciler also calls this as a pre-check, to confirm the index would be splittable
+  // on every other ground before it forces a split; that call passes
+  // IgnoreFollowTableExclusion::kTrue to suppress just this check.
+  //
+  // This is gated on the same flag as the reconciler (ReconcileFollowTableIndexSplits).
+  // Otherwise turning the feature off would leave already-created follow-table indexes
+  // frozen: no reconciler to split them to match the base, and no automatic splitting
+  // either. With the gate, disabling the flag makes them behave as ordinary indexes.
+  if (!ignore_disabled_lists && !ignore_follow_table_exclusion &&
+      FLAGS_ysql_yb_enable_follow_table_index && table_lock->follows_table()) {
     return STATUS_FORMAT(
         NotSupported,
         "Independent tablet splitting is disabled for follow-table indexes, table: $0",

--- a/src/yb/master/tablet_split_manager.cc
+++ b/src/yb/master/tablet_split_manager.cc
@@ -265,6 +265,18 @@ Status TabletSplitManager::ValidateSplitCandidateTable(
         *table);
   }
 
+  // Prototype: a follow-table index (SPLIT FOLLOWING TABLE) never splits on its own
+  // SST size. Its tablet splits are driven to match the base table by the follow-table
+  // split reconciler, which issues them as manual/forced splits. ignore_disabled_lists is
+  // set exactly for such forced splits, so we exclude the follow-table index only from the
+  // automatic (non-forced) candidate path and let the reconciler's forced split through.
+  if (!ignore_disabled_lists && table_lock->pb.follow_table_mode() != FOLLOW_TABLE_NONE) {
+    return STATUS_FORMAT(
+        NotSupported,
+        "Independent tablet splitting is disabled for follow-table indexes, table: $0",
+        *table);
+  }
+
   if (!ignore_vector_indexes_validation &&
       !FLAGS_enable_tablet_split_of_tables_with_vector_index) {
     for (const auto& index : table_lock->pb.indexes()) {

--- a/src/yb/master/tablet_split_manager.h
+++ b/src/yb/master/tablet_split_manager.h
@@ -27,6 +27,12 @@ namespace master {
 YB_STRONGLY_TYPED_BOOL(IgnoreTtlValidation);
 YB_STRONGLY_TYPED_BOOL(IgnoreDisabledList);
 YB_STRONGLY_TYPED_BOOL(IgnoreVectorIndexesValidation);
+// Prototype (follow-table index): suppresses only the "follow-table indexes do not split
+// independently" check, leaving every other table-level check in force. Set by the
+// follow-table split reconciler so it can ask "would this table be splittable if it were
+// an ordinary index?" without having to claim a manual split, which would waive the
+// disabled lists, PITR and replica-limit protections along with it.
+YB_STRONGLY_TYPED_BOOL(IgnoreFollowTableExclusion);
 
 Status CheckLiveReplicasForSplit(
     const TabletId& tablet_id, const TabletReplicaMap& replicas, size_t rf);
@@ -65,7 +71,9 @@ class TabletSplitManager {
       const TableInfoPtr& table,
       IgnoreDisabledList ignore_disabled_list = IgnoreDisabledList::kFalse,
       IgnoreVectorIndexesValidation ignore_vector_indexes_validation =
-          IgnoreVectorIndexesValidation::kFalse);
+          IgnoreVectorIndexesValidation::kFalse,
+      IgnoreFollowTableExclusion ignore_follow_table_exclusion =
+          IgnoreFollowTableExclusion::kFalse);
 
   // Tablet-level checks for splitting that are checked not only as a best-effort
   // filter, but also after acquiring the table/tablet locks in CatalogManager::DoSplit.

--- a/src/yb/tserver/pg_client.proto
+++ b/src/yb/tserver/pg_client.proto
@@ -476,6 +476,19 @@ message PgCreateTableRequestPB {
   // Used to setup the session in case the table is being created in a
   // transaction block with transactional ddl enabled i.e. use_regular_transaction_block is true.
   PgPerformOptionsPB options = 27;
+
+  // Prototype: when set to a non-NONE mode, this index follows its base table's
+  // tablet split mapping and placement (SPLIT FOLLOWING TABLE). This is a proto3
+  // mirror of master.YbFollowTableMode (a proto2 enum, which a proto3 message may
+  // not reference directly); the integer values are kept in sync and mapped in
+  // pg_create_table.cc.
+  YbFollowTableMode follow_table_mode = 28;
+}
+
+// Proto3 mirror of master.YbFollowTableMode; values must match.
+enum YbFollowTableMode {
+  FOLLOW_TABLE_NONE = 0;
+  FOLLOW_TABLE_EVENTUAL = 1;
 }
 
 message PgCreateTableResponsePB {

--- a/src/yb/tserver/pg_create_table.cc
+++ b/src/yb/tserver/pg_create_table.cc
@@ -212,8 +212,25 @@ Status PgCreateTable::Exec(
     }
     // Prototype: forward the follow-table mode (SPLIT FOLLOWING TABLE) to the master.
     // req_ carries a proto3 mirror enum (tserver::YbFollowTableMode); map it to the
-    // proto2 master::YbFollowTableMode expected by the master. Integer values match.
+    // proto2 master::YbFollowTableMode expected by the master. A proto3 message may not
+    // reference a proto2 enum, so the two definitions are kept in sync by hand; these
+    // assertions fail the build if one is changed without the other.
+    static_assert(
+        static_cast<int>(YbFollowTableMode::FOLLOW_TABLE_NONE) ==
+            static_cast<int>(master::YbFollowTableMode::FOLLOW_TABLE_NONE),
+        "tserver and master YbFollowTableMode enums have diverged");
+    static_assert(
+        static_cast<int>(YbFollowTableMode::FOLLOW_TABLE_EVENTUAL) ==
+            static_cast<int>(master::YbFollowTableMode::FOLLOW_TABLE_EVENTUAL),
+        "tserver and master YbFollowTableMode enums have diverged");
+
     if (req_.follow_table_mode() != YbFollowTableMode::FOLLOW_TABLE_NONE) {
+      // proto3 enums are open: a newer or mismatched client can send a value this build
+      // does not know. Reject it rather than static_cast-ing it into a master enum that
+      // has no such value, which would be undefined behavior downstream.
+      SCHECK(
+          master::YbFollowTableMode_IsValid(req_.follow_table_mode()), InvalidArgument,
+          Format("Unknown follow_table_mode: $0", req_.follow_table_mode()));
       table_creator->follow_table_mode(
           static_cast<master::YbFollowTableMode>(req_.follow_table_mode()));
     }

--- a/src/yb/tserver/pg_create_table.cc
+++ b/src/yb/tserver/pg_create_table.cc
@@ -210,6 +210,13 @@ Status PgCreateTable::Exec(
     if (req_.skip_index_backfill()) {
       table_creator->skip_index_backfill(true);
     }
+    // Prototype: forward the follow-table mode (SPLIT FOLLOWING TABLE) to the master.
+    // req_ carries a proto3 mirror enum (tserver::YbFollowTableMode); map it to the
+    // proto2 master::YbFollowTableMode expected by the master. Integer values match.
+    if (req_.follow_table_mode() != YbFollowTableMode::FOLLOW_TABLE_NONE) {
+      table_creator->follow_table_mode(
+          static_cast<master::YbFollowTableMode>(req_.follow_table_mode()));
+    }
   }
 
   // If the table was created in the xCluster DDL replication extension.

--- a/src/yb/yql/pggate/pg_ddl.cc
+++ b/src/yb/yql/pggate/pg_ddl.cc
@@ -254,6 +254,11 @@ Status PgCreateTableBase::SetNumTablets(int32_t num_tablets) {
   return Status::OK();
 }
 
+Status PgCreateTableBase::SetFollowTable() {
+  req_.set_follow_table_mode(tserver::FOLLOW_TABLE_EVENTUAL);
+  return Status::OK();
+}
+
 Status PgCreateTableBase::SetVectorOptions(YbcPgVectorIdxOptions* options) {
   auto options_pb = req_.mutable_vector_idx_options();
   options_pb->set_dist_type(static_cast<PgVectorDistanceType>(options->dist_type));

--- a/src/yb/yql/pggate/pg_ddl.h
+++ b/src/yb/yql/pggate/pg_ddl.h
@@ -114,6 +114,10 @@ class PgCreateTableBase : public PgDdl {
 
   Status SetNumTablets(int32_t num_tablets);
 
+  // Prototype: mark this table (index) to follow its base table's split mapping
+  // and placement (SPLIT FOLLOWING TABLE).
+  Status SetFollowTable();
+
   Status SetHnswOptions(int m, int m0, int ef_construction);
 
   Status SetVectorOptions(YbcPgVectorIdxOptions* options);

--- a/src/yb/yql/pggate/pggate.cc
+++ b/src/yb/yql/pggate/pggate.cc
@@ -1352,6 +1352,10 @@ Status PgApiImpl::CreateIndexSetNumTablets(PgStatement* handle, int32_t num_tabl
   return VERIFY_RESULT_REF(GetStatementAs<PgCreateIndex>(handle)).SetNumTablets(num_tablets);
 }
 
+Status PgApiImpl::CreateIndexSetFollowTable(PgStatement* handle) {
+  return VERIFY_RESULT_REF(GetStatementAs<PgCreateIndex>(handle)).SetFollowTable();
+}
+
 Status PgApiImpl::CreateIndexSetVectorOptions(PgStatement* handle, YbcPgVectorIdxOptions* options) {
   return VERIFY_RESULT_REF(GetStatementAs<PgCreateIndex>(handle)).SetVectorOptions(options);
 }

--- a/src/yb/yql/pggate/pggate.h
+++ b/src/yb/yql/pggate/pggate.h
@@ -412,6 +412,8 @@ class PgApiImpl {
 
   Status CreateIndexSetNumTablets(PgStatement *handle, int32_t num_tablets);
 
+  Status CreateIndexSetFollowTable(PgStatement *handle);
+
   Status CreateIndexSetVectorOptions(PgStatement *handle, YbcPgVectorIdxOptions *options);
 
   Status CreateIndexSetHnswOptions(PgStatement *handle, int m, int m0, int ef_construction);

--- a/src/yb/yql/pggate/ybc_pggate.cc
+++ b/src/yb/yql/pggate/ybc_pggate.cc
@@ -1340,6 +1340,10 @@ YbcStatus YBCPgCreateIndexSetNumTablets(YbcPgStatement handle, int32_t num_table
   return ToYBCStatus(pgapi->CreateIndexSetNumTablets(handle, num_tablets));
 }
 
+YbcStatus YBCPgCreateIndexSetFollowTable(YbcPgStatement handle) {
+  return ToYBCStatus(pgapi->CreateIndexSetFollowTable(handle));
+}
+
 YbcStatus YBCPgCreateIndexSetVectorOptions(YbcPgStatement handle, YbcPgVectorIdxOptions *options) {
   return ToYBCStatus(pgapi->CreateIndexSetVectorOptions(handle, options));
 }

--- a/src/yb/yql/pggate/ybc_pggate.h
+++ b/src/yb/yql/pggate/ybc_pggate.h
@@ -457,6 +457,10 @@ YbcStatus YBCPgCreateIndexAddColumn(YbcPgStatement handle, const char *attr_name
 
 YbcStatus YBCPgCreateIndexSetNumTablets(YbcPgStatement handle, int32_t num_tablets);
 
+// Prototype: mark this index to follow its base table's split mapping and placement
+// (SPLIT FOLLOWING TABLE).
+YbcStatus YBCPgCreateIndexSetFollowTable(YbcPgStatement handle);
+
 YbcStatus YBCPgCreateIndexSetVectorOptions(YbcPgStatement handle, YbcPgVectorIdxOptions *options);
 
 YbcStatus YBCPgCreateIndexSetHnswOptions(


### PR DESCRIPTION
This PR is to chip-away at issue https://github.com/yugabyte/yugabyte-db/issues/25 (Support local indexes)

That PR hasn't had much progress as it is a very large ask that affects many and deep parts of the system.

This PR aims to make the implementation closer to the goal of https://github.com/yugabyte/yugabyte-db/issues/25 without actually solving it. Specifically this PR:
- introduces new syntax `SPLIT FOLLOWING TABLE` for an index to specify best effort locating a secondary index with the same HASH as the PK to balance to the same node(s)
- the feature (`yb_enable_follow_table_index`) must be enabled before use
- it does this by setting desired balance targets matching current PK's
- these targets may never be realized as there could be constraints on the index which have very different data distributions than the PK, but that's ok there's still much potential benefit here

So with the above limitations the most we can expect from this PR is:
- network communications on same host more often where both PK and index operations are involved _(significant only if inter-node network is saturated or in different availability zone/region/cloud-provider)_

#### With performance benefits being marginal, why this PR?

Issue https://github.com/yugabyte/yugabyte-db/issues/25 is asking for 100% transactional index balancing tracking PK which I believe to be too high a bar (at least at present). I also don't believe that's really what users of YugabyteDB always want--they want to have good P95/P99 etc latencies, which we could possibly get by **mostly** _(rather than absolutely)_ locating indexes with PK. Further limiting this to when the index and PK share same HASH parts should make it more likely in practice than not.

The hope/expectation is that after this PR is in the main line, that someone who is specifically interested in the distributed transaction aspects may carry it forward to **optimistically** combine operations when conditions are met.

The PR comment below has a **review of the initial 2 commits**, along with descriptions of the **3rd** and **4th commits that address them**.