### PR TITLE
[#32883] DocDB: Add yb_thin_client, a thin Perform-based tserver client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -902,6 +902,7 @@ set(YB_SUBDIR_NAMES
     server
     storage
     tablet
+    thin_client
     tools
     tserver
     util

--- a/python/yugabyte/lto.py
+++ b/python/yugabyte/lto.py
@@ -676,7 +676,10 @@ def link_whole_program(
                          'have been invoked. Perhaps yb_build.sh should be invoked with '
                          'the --force-run-cmake argument.')
 
-    wait_for_free_memory(required_mem_gib=13, timeout_minutes=20)
+    # Only the actual link consumes the large amount of memory LTO requires; merely emitting the
+    # link command (run_linker=False) does not, so don't gate that on free memory.
+    if run_linker:
+        wait_for_free_memory(required_mem_gib=13, timeout_minutes=20)
 
     initial_node_list = list(initial_nodes)
     if len(initial_node_list) != 1:

--- a/src/yb/client/yb_op.cc
+++ b/src/yb/client/yb_op.cc
@@ -86,32 +86,6 @@ using std::string;
 
 namespace {
 
-void SetPartitionKey(const Slice& value, LWPgsqlReadRequestPB* request) {
-  request->dup_partition_key(value);
-}
-
-void SetPartitionKey(const Slice& value, LWPgsqlWriteRequestPB* request) {
-  request->dup_partition_key(value);
-}
-
-void SetHashCodePartitionKey(uint16_t hash_code, LWPgsqlReadRequestPB* request) {
-  if (request->is_forward_scan()) {
-    if (hash_code == 0) {
-      request->clear_partition_key();
-    } else {
-      auto partition_key = dockv::PartitionSchema::EncodeMultiColumnHashValue(hash_code);
-      SetPartitionKey(partition_key, request);
-    }
-  } else {
-    if (hash_code == dockv::PartitionSchema::kMaxPartitionKey) {
-      request->clear_partition_key();
-    } else {
-      auto partition_key = dockv::PartitionSchema::EncodeMultiColumnHashValue(hash_code + 1);
-      SetPartitionKey(partition_key, request);
-    }
-  }
-}
-
 template <typename Req>
 void GetPartitionKey(const Req& request, std::string* partition_key) {
   if (request.has_partition_key()) {
@@ -121,211 +95,9 @@ void GetPartitionKey(const Req& request, std::string* partition_key) {
   }
 }
 
-template<class Req>
-auto* GetPagingState(const Req& request) {
-  if (request.has_index_request()) {
-    return request.index_request().has_paging_state()
-        ? &request.index_request().paging_state() : nullptr;
-  }
-  return request.has_paging_state() ? &request.paging_state() : nullptr;
-}
-
-Result<uint16_t> GetHashCodeFromBound(const Slice& key) {
-  uint16_t hash_code;
-  if (dockv::PartitionSchema::IsValidHashPartitionKeyBound(key)) {
-    DCHECK(!yb_allow_dockey_bounds) << "Invalid request bound: " << key.ToDebugHexString();
-    hash_code = dockv::PartitionSchema::DecodeMultiColumnHashValue(key);
-  } else {
-    DCHECK(yb_allow_dockey_bounds) << "Invalid request bound: " << key.ToDebugHexString();
-    hash_code = VERIFY_RESULT(dockv::DocKey::DecodeHash(key));
-  }
-  return hash_code;
-}
-
-template<class Req>
-Status InitHashPartitionKey(
-    const Schema& schema, const dockv::PartitionSchema& partition_schema, Req* request) {
-  // Seek a specific partition_key from read_request, also set the hash_code/max_hash_code bounds.
-  // 1. paging_state -- Use the partition key provided by the server. It is a follow-up request, so
-  //    the hash code bounds are already set.
-  // 2. hash column values -- Full set of hash values allow to calculate the hash code, which sets
-  //    the partition key, and the both hash code bounds.
-  // 3. lower and upper bound -- If set, provide the value for the hash_code and the max_hash_code
-  //    respectively. Depending on the scan direction, one of them provides the partition key value.
-  if (auto* paging_state = GetPagingState(*request); paging_state) {
-    // TODO: DocDB used to set the next partition key as the hash code of the next row (see
-    // PgsqlReadOperation::SetPagingState) regardless of the scan direction. That is inconsistent
-    // with the current semantics of the partition key, which is exclusive in the backward scan.
-    // While we have fixed it in DocDB, there is a backward compatibility problem, at the time of
-    // upgrade there may be nodes still sending the inclusive hash code.
-    // So for now we extract the hash code from the next row key, later on, when we don't have to
-    // maintain backward compatibility with older versions, we can use the partition key from the
-    // paging state unconditionally.
-    if (paging_state->has_next_row_key()) {
-      auto hash_code = VERIFY_RESULT(dockv::DocKey::DecodeHash(paging_state->next_row_key()));
-      SetHashCodePartitionKey(hash_code, request);
-    } else {
-      SetPartitionKey(paging_state->next_partition_key(), request);
-    }
-    return Status::OK();
-  }
-  if (!request->partition_column_values().empty()) {
-    // If hashed columns are set, use them to compute the exact key and set the bounds
-    auto hash_code = VERIFY_RESULT(partition_schema.PgsqlHashColumnCompoundValue(
-        request->partition_column_values()));
-    request->set_hash_code(hash_code);
-    request->set_max_hash_code(hash_code);
-    SetHashCodePartitionKey(hash_code, request);
-    return Status::OK();
-  }
-  request->clear_partition_key();
-  if (request->has_lower_bound()) {
-    auto hash_code = VERIFY_RESULT(GetHashCodeFromBound(request->lower_bound().key()));
-    request->set_hash_code(hash_code);
-    if (request->is_forward_scan()) {
-      SetHashCodePartitionKey(hash_code, request);
-    }
-  }
-  if (request->has_upper_bound()) {
-    auto max_hash_code = VERIFY_RESULT(GetHashCodeFromBound(request->upper_bound().key()));
-    request->set_max_hash_code(max_hash_code);
-    if (!request->is_forward_scan()) {
-      SetHashCodePartitionKey(max_hash_code, request);
-    }
-  }
-  return Status::OK();
-}
-
-template<class Req>
-Status InitRangePartitionKey(const Schema& schema, Req* request) {
-  // Seek a specific partition_key from read_request
-  // 1. paging_state -- Use the partition key provided by the server.
-  // 2. upper or lower bound -- If the scan direction is forward, the lower bound is the
-  //    partition key. For the backward scan the partition key is implicitly exclusive, so if the
-  //    upper bound is set and is inclusive, the partition key should be set strictly greater than
-  //    the upper bound.
-  if (auto *paging_state = GetPagingState(*request); paging_state) {
-    SetPartitionKey(paging_state->next_partition_key(), request);
-    return Status::OK();
-  }
-  request->clear_partition_key();
-  if (request->has_lower_bound() && request->is_forward_scan()) {
-    SetPartitionKey(request->lower_bound().key(), request);
-  }
-  if (request->has_upper_bound() && !request->is_forward_scan()) {
-    if (request->upper_bound().is_inclusive()) {
-      // Partition key is exclusive, so we add +inf to include the upper bound value itself.
-      dockv::DocKey doc_key;
-      VERIFY_RESULT(doc_key.DecodeFrom(
-          request->upper_bound().key(),
-          dockv::DocKeyPart::kWholeDocKey,
-          dockv::AllowSpecial::kTrue));
-      doc_key.AddRangeComponent(dockv::KeyEntryValue(dockv::KeyEntryType::kHighest));
-      SetPartitionKey(doc_key.Encode(), request);
-    } else {
-      SetPartitionKey(request->upper_bound().key(), request);
-    }
-  }
-  return Status::OK();
-}
-
-template <class Col>
-Result<std::vector<dockv::KeyEntryValue>> GetRangeComponents(
-    const Schema& schema, const Col& range_cols, const bool lower_bound) {
-  size_t column_idx = 0;
-  auto range_cols_it = range_cols.begin();
-  const auto num_range_key_columns = schema.num_range_key_columns();
-  dockv::KeyEntryValues result;
-  for (const auto& col_id : schema.column_ids()) {
-    if (!schema.is_range_column(col_id)) {
-      continue;
-    }
-
-    const ColumnSchema& column_schema = VERIFY_RESULT(schema.column_by_id(col_id));
-
-    if (schema.table_properties().partitioning_version() > 0) {
-      if (column_idx < static_cast<size_t>(range_cols.size())) {
-        result.push_back(dockv::KeyEntryValue::FromQLValuePBForKey(
-            range_cols_it->value(), column_schema.sorting_type()));
-      } else {
-        result.emplace_back(
-            lower_bound ? dockv::KeyEntryType::kLowest : dockv::KeyEntryType::kHighest);
-      }
-    } else {
-      if (column_idx >= static_cast<size_t>(range_cols.size()) ||
-          range_cols_it->value().value_case() == QLValuePB::VALUE_NOT_SET) {
-        result.emplace_back(
-            lower_bound ? dockv::KeyEntryType::kLowest : dockv::KeyEntryType::kHighest);
-      } else {
-        result.push_back(dockv::KeyEntryValue::FromQLValuePB(
-            range_cols_it->value(), column_schema.sorting_type()));
-      }
-    }
-
-    ++range_cols_it;
-    if (++column_idx == num_range_key_columns) {
-      break;
-    }
-  }
-
-  if (!lower_bound) {
-    result.emplace_back(dockv::KeyEntryType::kHighest);
-  }
-  return result;
-}
-
-template <class Col>
-Result<std::string> GetRangePartitionKey(
-    const Schema& schema, const Col& range_cols) {
-  RSTATUS_DCHECK(!schema.num_hash_key_columns(), IllegalState,
-      "Cannot get range partition key for hash partitioned table");
-
-  auto range_components = VERIFY_RESULT(GetRangeComponents(schema, range_cols, true));
-  return dockv::DocKey(std::move(range_components)).Encode().ToStringBuffer();
-}
-
-template<class Req>
-Status InitReadPartitionKey(
-    const Schema& schema, const dockv::PartitionSchema& partition_schema, Req* request) {
-  if (schema.num_hash_key_columns() > 0) {
-    return InitHashPartitionKey(schema, partition_schema, request);
-  }
-
-  return InitRangePartitionKey(schema, request);
-}
-
-template<class Req>
-Status InitWritePartitionKey(
-    const Schema& schema, const dockv::PartitionSchema& partition_schema, Req* request) {
-  const auto& ybctid = request->ybctid_column_value().value();
-  if (schema.num_hash_key_columns() > 0) {
-    if (!IsNull(ybctid)) {
-      const uint16 hash_code = VERIFY_RESULT(dockv::DocKey::DecodeHash(ybctid.binary_value()));
-      request->set_hash_code(hash_code);
-      SetPartitionKey(dockv::PartitionSchema::EncodeMultiColumnHashValue(hash_code), request);
-      return Status::OK();
-    }
-
-    // Computing the partition_key.
-    auto partition_key = VERIFY_RESULT(partition_schema.EncodePgsqlHash(
-        request->partition_column_values()));
-    request->set_hash_code(dockv::PartitionSchema::DecodeMultiColumnHashValue(partition_key));
-    SetPartitionKey(partition_key, request);
-    return Status::OK();
-  } else {
-    // Range partitioned table
-    if (!IsNull(ybctid)) {
-      SetPartitionKey(ybctid.binary_value(), request);
-      return Status::OK();
-    }
-
-    // Computing the range key.
-    SetPartitionKey(
-        VERIFY_RESULT(GetRangePartitionKey(schema, request->range_column_values())),
-        request);
-    return Status::OK();
-  }
-}
+// Partition-key computation lives in yb_dockv so callers that must not link yb_client can route.
+using dockv::GetRangeComponents;
+using dockv::GetRangePartitionKey;
 
 template <class Req>
 Status DoGetRangePartitionBounds(const Schema& schema,
@@ -884,7 +656,7 @@ Status YBPgsqlWriteOp::GetPartitionKey(std::string* partition_key) const {
     client::GetPartitionKey(*request_, partition_key);
     return Status::OK();
   }
-  RETURN_NOT_OK(InitWritePartitionKey(
+  RETURN_NOT_OK(dockv::InitPartitionKey(
       table_->InternalSchema(), table_->partition_schema(), request_));
   *partition_key = std::move(*request_->mutable_partition_key());
   return Status::OK();
@@ -957,7 +729,7 @@ Status YBPgsqlReadOp::GetPartitionKey(std::string* partition_key) const {
     return Status::OK();
   }
 
-  RETURN_NOT_OK(InitReadPartitionKey(
+  RETURN_NOT_OK(dockv::InitPartitionKey(
       table_->InternalSchema(), table_->partition_schema(), request_));
   *partition_key = std::move(*request_->mutable_partition_key());
   if (!request_->is_forward_scan()) {
@@ -1106,13 +878,13 @@ bool YBPgsqlReadOp::should_apply_intents(IsolationLevel isolation_level) {
 Status InitPartitionKey(
     const Schema& schema, const dockv::PartitionSchema& partition_schema,
     LWPgsqlReadRequestPB* request) {
-  return InitReadPartitionKey(schema, partition_schema, request);
+  return dockv::InitPartitionKey(schema, partition_schema, request);
 }
 
 Status InitPartitionKey(
     const Schema& schema, const dockv::PartitionSchema& partition_schema,
     LWPgsqlWriteRequestPB* request) {
-  return InitWritePartitionKey(schema, partition_schema, request);
+  return dockv::InitPartitionKey(schema, partition_schema, request);
 }
 
 Status GetRangePartitionBounds(const Schema& schema,

--- a/src/yb/dockv/partition.cc
+++ b/src/yb/dockv/partition.cc
@@ -49,6 +49,10 @@
 #include "yb/common/schema.h"
 
 #include "yb/dockv/doc_key.h"
+#include "yb/dockv/key_entry_value.h"
+#include "yb/dockv/value_type.h"
+
+#include "yb/yql/pggate/util/ybc_guc.h"
 
 #include "yb/gutil/hash/hash.h"
 #include "yb/gutil/map-util.h"
@@ -1542,6 +1546,272 @@ void PartitionSchema::ProcessHashKeyEntry(const LWPgsqlExpressionPB& expr, std::
 
 void PartitionSchema::ProcessHashKeyEntry(const PgsqlExpressionPB& expr, std::string* out) {
   AppendToKey(expr.value(), out);
+}
+
+template <class Col>
+Result<KeyEntryValues> GetRangeComponents(
+    const Schema& schema, const Col& range_cols, const bool lower_bound) {
+  size_t column_idx = 0;
+  auto range_cols_it = range_cols.begin();
+  const auto num_range_key_columns = schema.num_range_key_columns();
+  KeyEntryValues result;
+  for (const auto& col_id : schema.column_ids()) {
+    if (!schema.is_range_column(col_id)) {
+      continue;
+    }
+
+    const ColumnSchema& column_schema = VERIFY_RESULT(schema.column_by_id(col_id));
+
+    if (schema.table_properties().partitioning_version() > 0) {
+      if (column_idx < static_cast<size_t>(range_cols.size())) {
+        result.push_back(KeyEntryValue::FromQLValuePBForKey(
+            range_cols_it->value(), column_schema.sorting_type()));
+      } else {
+        result.emplace_back(lower_bound ? KeyEntryType::kLowest : KeyEntryType::kHighest);
+      }
+    } else {
+      if (column_idx >= static_cast<size_t>(range_cols.size()) ||
+          range_cols_it->value().value_case() == QLValuePB::VALUE_NOT_SET) {
+        result.emplace_back(lower_bound ? KeyEntryType::kLowest : KeyEntryType::kHighest);
+      } else {
+        result.push_back(KeyEntryValue::FromQLValuePB(
+            range_cols_it->value(), column_schema.sorting_type()));
+      }
+    }
+
+    ++range_cols_it;
+    if (++column_idx == num_range_key_columns) {
+      break;
+    }
+  }
+
+  if (!lower_bound) {
+    result.emplace_back(KeyEntryType::kHighest);
+  }
+  return result;
+}
+
+template <class Col>
+Result<std::string> GetRangePartitionKey(const Schema& schema, const Col& range_cols) {
+  RSTATUS_DCHECK(!schema.num_hash_key_columns(), IllegalState,
+      "Cannot get range partition key for hash partitioned table");
+
+  auto range_components = VERIFY_RESULT(GetRangeComponents(schema, range_cols, true));
+  return DocKey(std::move(range_components)).Encode().ToStringBuffer();
+}
+
+#define YB_INSTANTIATE_RANGE_KEY_FUNCS(Col) \
+    template Result<KeyEntryValues> GetRangeComponents<Col>(const Schema&, const Col&, bool); \
+    template Result<std::string> GetRangePartitionKey<Col>(const Schema&, const Col&);
+
+YB_INSTANTIATE_RANGE_KEY_FUNCS(google::protobuf::RepeatedPtrField<PgsqlExpressionPB>)
+YB_INSTANTIATE_RANGE_KEY_FUNCS(ArenaList<LWPgsqlExpressionPB>)
+
+#undef YB_INSTANTIATE_RANGE_KEY_FUNCS
+
+namespace {
+
+void SetPartitionKey(const Slice& value, LWPgsqlReadRequestPB* request) {
+  request->dup_partition_key(value);
+}
+
+void SetPartitionKey(const Slice& value, LWPgsqlWriteRequestPB* request) {
+  request->dup_partition_key(value);
+}
+
+void SetPartitionKey(const Slice& value, PgsqlReadRequestPB* request) {
+  request->set_partition_key(value.cdata(), value.size());
+}
+
+void SetPartitionKey(const Slice& value, PgsqlWriteRequestPB* request) {
+  request->set_partition_key(value.cdata(), value.size());
+}
+
+template <class Req>
+void SetHashCodePartitionKey(uint16_t hash_code, Req* request) {
+  if (request->is_forward_scan()) {
+    if (hash_code == 0) {
+      request->clear_partition_key();
+    } else {
+      SetPartitionKey(PartitionSchema::EncodeMultiColumnHashValue(hash_code), request);
+    }
+  } else {
+    if (hash_code == PartitionSchema::kMaxPartitionKey) {
+      request->clear_partition_key();
+    } else {
+      SetPartitionKey(PartitionSchema::EncodeMultiColumnHashValue(hash_code + 1), request);
+    }
+  }
+}
+
+template<class Req>
+auto* GetPagingState(const Req& request) {
+  if (request.has_index_request()) {
+    return request.index_request().has_paging_state()
+        ? &request.index_request().paging_state() : nullptr;
+  }
+  return request.has_paging_state() ? &request.paging_state() : nullptr;
+}
+
+Result<uint16_t> GetHashCodeFromBound(const Slice& key) {
+  uint16_t hash_code;
+  if (PartitionSchema::IsValidHashPartitionKeyBound(key)) {
+    DCHECK(!yb_allow_dockey_bounds) << "Invalid request bound: " << key.ToDebugHexString();
+    hash_code = PartitionSchema::DecodeMultiColumnHashValue(key);
+  } else {
+    DCHECK(yb_allow_dockey_bounds) << "Invalid request bound: " << key.ToDebugHexString();
+    hash_code = VERIFY_RESULT(DocKey::DecodeHash(key));
+  }
+  return hash_code;
+}
+
+template<class Req>
+Status InitHashPartitionKey(
+    const Schema& schema, const PartitionSchema& partition_schema, Req* request) {
+  // Seek a specific partition_key from read_request, also set the hash_code/max_hash_code bounds.
+  // 1. paging_state -- Use the partition key provided by the server. It is a follow-up request, so
+  //    the hash code bounds are already set.
+  // 2. hash column values -- Full set of hash values allow to calculate the hash code, which sets
+  //    the partition key, and the both hash code bounds.
+  // 3. lower and upper bound -- If set, provide the value for the hash_code and the max_hash_code
+  //    respectively. Depending on the scan direction, one of them provides the partition key value.
+  if (auto* paging_state = GetPagingState(*request); paging_state) {
+    // TODO: DocDB used to set the next partition key as the hash code of the next row (see
+    // PgsqlReadOperation::SetPagingState) regardless of the scan direction. That is inconsistent
+    // with the current semantics of the partition key, which is exclusive in the backward scan.
+    // While we have fixed it in DocDB, there is a backward compatibility problem, at the time of
+    // upgrade there may be nodes still sending the inclusive hash code.
+    // So for now we extract the hash code from the next row key, later on, when we don't have to
+    // maintain backward compatibility with older versions, we can use the partition key from the
+    // paging state unconditionally.
+    if (paging_state->has_next_row_key()) {
+      auto hash_code = VERIFY_RESULT(DocKey::DecodeHash(paging_state->next_row_key()));
+      SetHashCodePartitionKey(hash_code, request);
+    } else {
+      SetPartitionKey(paging_state->next_partition_key(), request);
+    }
+    return Status::OK();
+  }
+  if (!request->partition_column_values().empty()) {
+    // If hashed columns are set, use them to compute the exact key and set the bounds
+    auto hash_code = VERIFY_RESULT(partition_schema.PgsqlHashColumnCompoundValue(
+        request->partition_column_values()));
+    request->set_hash_code(hash_code);
+    request->set_max_hash_code(hash_code);
+    SetHashCodePartitionKey(hash_code, request);
+    return Status::OK();
+  }
+  request->clear_partition_key();
+  if (request->has_lower_bound()) {
+    auto hash_code = VERIFY_RESULT(GetHashCodeFromBound(request->lower_bound().key()));
+    request->set_hash_code(hash_code);
+    if (request->is_forward_scan()) {
+      SetHashCodePartitionKey(hash_code, request);
+    }
+  }
+  if (request->has_upper_bound()) {
+    auto max_hash_code = VERIFY_RESULT(GetHashCodeFromBound(request->upper_bound().key()));
+    request->set_max_hash_code(max_hash_code);
+    if (!request->is_forward_scan()) {
+      SetHashCodePartitionKey(max_hash_code, request);
+    }
+  }
+  return Status::OK();
+}
+
+template<class Req>
+Status InitRangePartitionKey(const Schema& schema, Req* request) {
+  // Seek a specific partition_key from read_request
+  // 1. paging_state -- Use the partition key provided by the server.
+  // 2. upper or lower bound -- If the scan direction is forward, the lower bound is the
+  //    partition key. For the backward scan the partition key is implicitly exclusive, so if the
+  //    upper bound is set and is inclusive, the partition key should be set strictly greater than
+  //    the upper bound.
+  if (auto *paging_state = GetPagingState(*request); paging_state) {
+    SetPartitionKey(paging_state->next_partition_key(), request);
+    return Status::OK();
+  }
+  request->clear_partition_key();
+  if (request->has_lower_bound() && request->is_forward_scan()) {
+    SetPartitionKey(request->lower_bound().key(), request);
+  }
+  if (request->has_upper_bound() && !request->is_forward_scan()) {
+    if (request->upper_bound().is_inclusive()) {
+      // Partition key is exclusive, so we add +inf to include the upper bound value itself.
+      DocKey doc_key;
+      VERIFY_RESULT(doc_key.DecodeFrom(
+          request->upper_bound().key(), DocKeyPart::kWholeDocKey, AllowSpecial::kTrue));
+      doc_key.AddRangeComponent(KeyEntryValue(KeyEntryType::kHighest));
+      SetPartitionKey(doc_key.Encode(), request);
+    } else {
+      SetPartitionKey(request->upper_bound().key(), request);
+    }
+  }
+  return Status::OK();
+}
+
+template<class Req>
+Status InitReadPartitionKeyImpl(
+    const Schema& schema, const PartitionSchema& partition_schema, Req* request) {
+  if (schema.num_hash_key_columns() > 0) {
+    return InitHashPartitionKey(schema, partition_schema, request);
+  }
+
+  return InitRangePartitionKey(schema, request);
+}
+
+template<class Req>
+Status InitWritePartitionKeyImpl(
+    const Schema& schema, const PartitionSchema& partition_schema, Req* request) {
+  const auto& ybctid = request->ybctid_column_value().value();
+  if (schema.num_hash_key_columns() > 0) {
+    if (!IsNull(ybctid)) {
+      const uint16 hash_code = VERIFY_RESULT(DocKey::DecodeHash(ybctid.binary_value()));
+      request->set_hash_code(hash_code);
+      SetPartitionKey(PartitionSchema::EncodeMultiColumnHashValue(hash_code), request);
+      return Status::OK();
+    }
+
+    // Computing the partition_key.
+    auto partition_key = VERIFY_RESULT(partition_schema.EncodePgsqlHash(
+        request->partition_column_values()));
+    request->set_hash_code(PartitionSchema::DecodeMultiColumnHashValue(partition_key));
+    SetPartitionKey(partition_key, request);
+    return Status::OK();
+  } else {
+    // Range partitioned table
+    if (!IsNull(ybctid)) {
+      SetPartitionKey(ybctid.binary_value(), request);
+      return Status::OK();
+    }
+
+    // Computing the range key.
+    SetPartitionKey(
+        VERIFY_RESULT(GetRangePartitionKey(schema, request->range_column_values())), request);
+    return Status::OK();
+  }
+}
+
+}  // namespace
+
+Status InitPartitionKey(
+    const Schema& schema, const PartitionSchema& partition_schema, PgsqlReadRequestPB* request) {
+  return InitReadPartitionKeyImpl(schema, partition_schema, request);
+}
+
+Status InitPartitionKey(
+    const Schema& schema, const PartitionSchema& partition_schema, PgsqlWriteRequestPB* request) {
+  return InitWritePartitionKeyImpl(schema, partition_schema, request);
+}
+
+Status InitPartitionKey(
+    const Schema& schema, const PartitionSchema& partition_schema, LWPgsqlReadRequestPB* request) {
+  return InitReadPartitionKeyImpl(schema, partition_schema, request);
+}
+
+Status InitPartitionKey(
+    const Schema& schema, const PartitionSchema& partition_schema, LWPgsqlWriteRequestPB* request) {
+  return InitWritePartitionKeyImpl(schema, partition_schema, request);
 }
 
 }  // namespace yb::dockv

--- a/src/yb/dockv/partition.h
+++ b/src/yb/dockv/partition.h
@@ -40,6 +40,7 @@
 
 #include "yb/common/common_fwd.h"
 #include "yb/common/column_id.h"
+#include "yb/dockv/dockv_fwd.h"
 #include "yb/dockv/partial_row.h"
 
 #include "yb/util/enums.h"
@@ -535,5 +536,28 @@ class PartitionSchema {
   RangeSchema range_schema_;
   std::optional<YBHashSchema> hash_schema_;  // Defined only for table that is hash-partitioned.
 };
+
+// DocKey range components for a possibly PARTIAL list of range column values; columns that were
+// not supplied become -Inf (`lower_bound`) or +Inf, so a leading prefix addresses its whole range.
+template <class Col>
+Result<KeyEntryValues> GetRangeComponents(
+    const Schema& schema, const Col& range_cols, bool lower_bound);
+
+// Partition key of the row (or range prefix) named by `range_cols`; the range-sharded counterpart
+// of PartitionSchema::EncodePgsqlHash. Fails for a hash-sharded table.
+template <class Col>
+Result<std::string> GetRangePartitionKey(const Schema& schema, const Col& range_cols);
+
+// Sets request->partition_key (plus hash code bounds when hash-sharded) so the op can be routed,
+// resuming on the tablet the paging state names. Callers must do this themselves: the tserver only
+// reads the field back, and an unset key routes to the first tablet.
+Status InitPartitionKey(
+    const Schema& schema, const PartitionSchema& partition_schema, PgsqlReadRequestPB* request);
+Status InitPartitionKey(
+    const Schema& schema, const PartitionSchema& partition_schema, PgsqlWriteRequestPB* request);
+Status InitPartitionKey(
+    const Schema& schema, const PartitionSchema& partition_schema, LWPgsqlReadRequestPB* request);
+Status InitPartitionKey(
+    const Schema& schema, const PartitionSchema& partition_schema, LWPgsqlWriteRequestPB* request);
 
 }  // namespace yb::dockv

--- a/src/yb/thin_client/CMakeLists.txt
+++ b/src/yb/thin_client/CMakeLists.txt
@@ -1,0 +1,53 @@
+# Copyright (c) YugabyteDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations
+# under the License.
+#
+
+#######################################
+# yb_thin_client
+#
+# A thin, Perform-based tserver client (C ABI in yb_thin_client.h). It links only the
+# PgClientServiceProxy closure -- deliberately NOT yb_client / master / consensus / docdb / tablet.
+#######################################
+
+set(THIN_CLIENT_SRCS
+  yb_thin_client.cc
+  )
+
+set(THIN_CLIENT_LIBS
+  pg_client_proto
+  yb_common
+  yb_common_proto
+  yb_dockv
+  yb_pggate_util  # pg_doc_data / pg_wire: the pg_doc_data row-sidecar decoder
+  yrpc
+  yb_util
+  )
+
+ADD_YB_LIBRARY(yb_thin_client
+    SRCS ${THIN_CLIENT_SRCS}
+    DEPS ${THIN_CLIENT_LIBS})
+
+#######################################
+# yb_thin_client-itest
+#
+# Live smoke test driven through a pgwrapper mini cluster; links the shim under test plus the
+# pgwrapper test-base closure. This directory is processed after yql (see top-level CMakeLists) so
+# those targets are already defined.
+#######################################
+
+set(YB_TEST_LINK_LIBS
+    yb_thin_client
+    yb_pgwrapper
+    yb_pggate_util
+    pg_wrapper_test_base
+    ${YB_MIN_TEST_LIBS})
+ADD_YB_TEST(yb_thin_client-itest)

--- a/src/yb/thin_client/README.md
+++ b/src/yb/thin_client/README.md
@@ -1,0 +1,84 @@
+# yb_thin_client — a thin, Perform-based tserver client
+
+`yb_thin_client` is a small C-ABI library that talks directly to a
+`yb-tserver`'s `yb.tserver.PgClientService.Perform` RPC via
+`PgClientServiceProxy`. It is meant to be built here, shipped as a shared
+object, and linked by a foreign (e.g. non-C++) caller that needs YugabyteDB's
+hot read/write paths without embedding a full client.
+
+## Design
+
+- **Server-side routing only.** Each op carries its own partition routing info
+  (`hash_code` + `partition_key`, computed from the hash columns), and the
+  tserver routes it to the right tablet — exactly as it does for pggate. There
+  is deliberately **no** `YBClient` / `YBSession` / `Batcher` / metacache /
+  `TabletInvoker` on the client side.
+- **No master dependency.** The client connects to tserver RPC endpoints only.
+- **Thin C ABI.** Everything YugabyteDB-specific lives behind
+  `yb_thin_client.h`. The caller marshals POD structs, bridges the async
+  callbacks to its runtime, and maps status codes — it does not build requests,
+  manage sessions, compute partition keys, or frame RPCs.
+- **Non-goals:** no distributed transactions (ops are single-shard /
+  non-transactional), no DDL, no catalog-version checks, no shared-memory
+  (`SharedExchange`) Perform — it uses the plain RPC `PerformAsync` because the
+  caller is typically on a different host than the tserver.
+
+## API (see `yb_thin_client.h` for the authoritative contract)
+
+- `ybthin_client_create` / `ybthin_client_destroy` — connect and open a pool of
+  `PgClientService` sessions (Heartbeat) across one or more connections, with a
+  keepalive; optional TLS (server-auth or mTLS) via `SecureContext`. A single
+  session serializes its Performs server-side, so concurrency comes from having
+  many sessions; `ybthin_pool_opts` sizes the pool (read/write sessions packed
+  onto connections). Reads round-robin the read sessions; upserts round-robin the
+  write sessions.
+- `ybthin_table_open` / `ybthin_table_close` / `ybthin_columns_free` — resolve a
+  table by `(db_oid, table_oid)` and fetch its schema (columns in schema order:
+  hash, then range, then value). Also the startup health check.
+- `ybthin_read_page_async` — one page of a read; delivers the `pg_doc_data` row
+  sidecar + opaque `paging_state` + `used_read_time_ht`.
+- `ybthin_upsert_batch_async` — N `PGSQL_UPSERT` rows as the ops of one Perform.
+- `ybthin_read_result_free` / `ybthin_string_free` — free shim-owned buffers.
+
+Status codes: `OK / INVALID / NETWORK / TRY_AGAIN / READ_RESTART / SCHEMA /
+OTHER`. Callbacks may fire on a YB reactor thread, so they must be cheap and
+non-blocking (signal a channel and return).
+
+## Versioning / backward compatibility
+
+This library is **upgraded before the tserver**, so a given build must keep
+working against an **older** tserver than it was compiled against. Keep the wire
+usage backward-compatible: only send request fields / rely on RPCs and semantics
+the oldest supported tserver understands, and tolerate responses that lack fields
+a newer server would set. The C ABI is additive-only (new functions; new struct
+fields / enum values appended at the end; never renumber, reorder, or remove).
+
+## Build
+
+```
+./yb_build.sh release --target yb_thin_client
+```
+
+produces `build/<build-root>/lib/libyb_thin_client.so`. The transitive `.so`
+closure it links (the deploy set) is the `PgClientServiceProxy` closure
+(`pg_client_proto`, `yb_common`, `yb_dockv`, `yrpc`, `yb_util` + transitive proto
+libs) and deliberately excludes the engine libs (`yb_client`, `master`,
+`consensus`, `docdb`, `tablet`). The exact, versioned list is documented at the
+top of `yb_thin_client.cc`; regenerate it with `ldd` against the built `.so`.
+
+Deploy model: ship the `.so` with its runtime closure (or a single self-contained
+object) and **version-pair it with the tserver** it talks to.
+
+## Test
+
+`yb_thin_client-itest` drives the whole C ABI against a pgwrapper mini cluster:
+
+```
+./yb_build.sh release --cxx-test yb_thin_client-itest
+```
+
+- `PgThinClientTest.OpenUpsertReadPaged` — open table (schema asserted), upsert
+  rows (cross-checked via SQL), and page a bounded scan.
+- `PgThinClientTlsTest.ClientCreateOverTls` — under node-to-node +
+  client-to-server encryption, a plaintext client is rejected by the TLS-only
+  endpoint and a TLS `client_create` (test CA) succeeds.

--- a/src/yb/thin_client/yb_release
+++ b/src/yb/thin_client/yb_release
@@ -111,8 +111,29 @@ grep -qE 'postgres_build/src/common/' "$link_args_file" && \
 grep -qE 'postgres_build/src/port/' "$link_args_file" && \
   pg_targets+=( "postgres_build/src/port/libpgport.a" )
 log "Closure: ${#closure_objs[@]} objects + ${#pg_targets[@]} PostgreSQL static lib(s)"
-( cd "$build_root" && ninja -k 0 "${closure_objs[@]}" "${pg_targets[@]}" ) || \
+# YB_BUILD_ROOT must be exported for ninja: several closure objects order-only-depend on
+# configure_postgres/genbki (via the yb_pggate_util dep), and build_postgres aborts without it. If it
+# is unset, those postgres steps fail, ninja SKIPS the dependent objects (e.g. yb_thin_client.cc.o),
+# and the link silently reuses a STALE object -- shipping a .so that doesn't match the source.
+#
+# Build the shim's OWN object on its own first. In the batched closure build below, ninja's -k 0
+# tolerates unrelated intermediate .so link failures (--no-undefined) -- but it can also skip
+# yb_thin_client.cc.o in the same run, silently leaving it stale. Building it alone (its only
+# prereqs are the postgres configure/genbki steps) guarantees it is regenerated from current source.
+shim_obj_target="src/yb/thin_client/CMakeFiles/yb_thin_client.dir/yb_thin_client.cc.o"
+( cd "$build_root" && YB_BUILD_ROOT="$build_root" ninja "$shim_obj_target" ) \
+  || fatal "failed to compile $shim_obj_target -- see ninja output above"
+( cd "$build_root" && YB_BUILD_ROOT="$build_root" ninja -k 0 "${closure_objs[@]}" "${pg_targets[@]}" ) || \
   log "note: a non-closure byproduct failed to link (expected with --no-tcmalloc); continuing"
+
+# Guard against the stale-object trap above: the shim's own object (the one that regressed) must be
+# newer than its source. If it's stale, the postgres prereqs likely failed and ninja skipped it --
+# abort rather than link and ship a .so that doesn't match the source.
+shim_obj="$build_root/src/yb/thin_client/CMakeFiles/yb_thin_client.dir/yb_thin_client.cc.o"
+if [[ ! -f "$shim_obj" || "$shim_obj" -ot "$script_dir/yb_thin_client.cc" ]]; then
+  fatal "stale/missing yb_thin_client.cc.o (older than its source) -- postgres prereqs likely \
+failed; the link would ship a mismatched .so. Check the ninja output above."
+fi
 
 # Export only the ybthin_* ABI; everything else (protobuf/absl/OpenSSL/... symbols) is localized so
 # the shim never interposes or collides with symbols in the host process.

--- a/src/yb/thin_client/yb_release
+++ b/src/yb/thin_client/yb_release
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) YugabyteDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations
+# under the License.
+#
+# yb_release for the yb_thin_client library.
+#
+# Builds a SINGLE self-contained libyb_thin_client.so via full-LTO whole-program linking -- the same
+# mechanism yb_release uses to produce the self-contained server binaries -- then packages it, the
+# C ABI header, and the version file into a tarball placed next to yb_release's release tarballs
+# ($YB_SRC_ROOT/build), named with the version/commit/architecture. Tarball layout:
+#   libyb_thin_client-<version>-<commit>-<build_type>-<system>-<arch>/
+#     lib/libyb_thin_client.so    include/yb_thin_client.h    version.txt
+#
+# The .so statically links the entire PgClientServiceProxy closure and depends only on system
+# libraries (libc, libpthread, ...); it exports only the ybthin_* C ABI and uses the standard C
+# library allocator (tcmalloc is disabled -- see --no-tcmalloc below) so it does not interpose the
+# allocator of the process that loads it.
+#
+# Note: the whole-program LTO link requires ~13 GiB of free RAM (same gate as yb_release's server
+# link); the script waits for it before linking.
+#
+# usage: src/yb/thin_client/yb_release [build_type]     (build_type defaults to "release")
+#        --destination <dir>   also copy the tarball into <dir> (like yb_release --destination)
+
+set -euo pipefail
+
+script_dir=$( cd "${BASH_SOURCE%/*}" && pwd )
+yb_src_root=$( cd "$script_dir/../../.." && pwd )
+# shellcheck source=build-support/common-build-env.sh
+. "$yb_src_root/build-support/common-build-env.sh"
+
+build_type="release"
+destination=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --destination) destination=$2; shift 2 ;;
+    --destination=*) destination=${1#*=}; shift ;;
+    -h|--help) grep '^#' "$BASH_SOURCE" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) build_type=$1; shift ;;
+  esac
+done
+validate_build_type "$build_type"
+
+activate_virtualenv
+set_pythonpath
+
+readonly lib_name="libyb_thin_client.so"
+readonly cmake_target="yb_thin_client"
+
+# Configure the full-LTO tree, then build and link ONLY the client's real link closure. We do NOT
+# build the yb_thin_client .so *target*: in ninja that target carries order-only edges onto the
+# whole YugabyteDB server (master/tablet/docdb) and the PostgreSQL backend, which drags in ~14000
+# files never linked into the client. Instead we ask the whole-program linker which object files
+# the client actually links, and compile just those (compiling an object never triggers the
+# order-only .so edges), cutting the build to a few hundred objects plus PostgreSQL's libpgcommon.
+#
+# --no-tcmalloc: YugabyteDB servers link Google tcmalloc as the process allocator, but this .so is
+# loaded into a foreign process (which owns its allocator), so we build the closure with tcmalloc
+# disabled -- the code is #ifdef-guarded to fall back to the standard C library malloc/free.
+# --force-run-cmake so --no-tcmalloc is (re)applied even if the tree was configured with it enabled.
+# --cmake-only: just configure here; we compile the closure below.
+log "Configuring the full-LTO tree (no tcmalloc, $build_type)"
+build_log=$( mktemp )
+YB_LINKING_TYPE=full-lto YB_BUILD_TESTS=false \
+  "$yb_src_root/yb_build.sh" "$build_type" --no-tcmalloc --force-run-cmake --cmake-only \
+  --skip-java 2>&1 | tee "$build_log"
+build_root=$( grep -E '^Build directory' "$build_log" | tail -1 | sed -E 's/^[^:]*:[[:space:]]*//' )
+[[ -d "$build_root" ]] || fatal "Could not determine the full-LTO build root from the build output"
+log "Full-LTO build root: $build_root"
+
+lto_out="$build_root/lib/$lib_name"
+
+# Emit the whole-program link command (bitcode objects + static libraries, engine libs excluded)
+# without running the linker. This needs only the configured build graph, not built objects
+# (--incomplete-build), and its output names every object the client links -- our build work-list.
+log "Computing the whole-program link command (and the real object closure) for $lib_name"
+"$YB_SCRIPT_PATH_DEPENDENCY_GRAPH" \
+  --build-root="$build_root" \
+  --file-regex="^.*/libyb_thin_client[.]so\$" \
+  --incomplete-build \
+  --never-run-build \
+  --run-linker=false \
+  --lto-output-path="$lto_out" \
+  link-whole-program
+
+link_args_file="${lto_out}_lto_link_cmd_args.txt"
+[[ -f "$link_args_file" ]] || fatal "Whole-program link did not emit args file: $link_args_file"
+
+# Compile just the closure: every object named in the link command, plus the PostgreSQL static libs
+# whose members the client links (libpgcommon/libpgport are byproducts of the monolithic postgres
+# target, so we request the archives, not the individual objects). -k 0 keeps going if a non-closure
+# byproduct trips the --no-undefined check that --no-tcmalloc turns on.
+log "Building the client's real link closure only (not the full server/PG tree)"
+mapfile -t closure_objs < <(
+  grep -oE '[^ ]+\.cc\.o' "$link_args_file" | grep -F "$build_root/" |
+    sed "s#${build_root}/##" | sort -u )
+[[ ${#closure_objs[@]} -gt 0 ]] || fatal "Could not extract the object closure from $link_args_file"
+pg_targets=()
+grep -qE 'postgres_build/src/common/' "$link_args_file" && \
+  pg_targets+=( "postgres_build/src/common/libpgcommon.a" )
+grep -qE 'postgres_build/src/port/' "$link_args_file" && \
+  pg_targets+=( "postgres_build/src/port/libpgport.a" )
+log "Closure: ${#closure_objs[@]} objects + ${#pg_targets[@]} PostgreSQL static lib(s)"
+( cd "$build_root" && ninja -k 0 "${closure_objs[@]}" "${pg_targets[@]}" ) || \
+  log "note: a non-closure byproduct failed to link (expected with --no-tcmalloc); continuing"
+
+# Export only the ybthin_* ABI; everything else (protobuf/absl/OpenSSL/... symbols) is localized so
+# the shim never interposes or collides with symbols in the host process.
+version_script=$( mktemp )
+cat >"$version_script" <<'VS'
+YBTHIN {
+  global:
+    ybthin_*;
+  local:
+    *;
+};
+VS
+
+log "Linking $lib_name (single self-contained object)"
+# The link args use paths relative to the build root, so run from there.
+mapfile -t link_args < "$link_args_file"
+( cd "$build_root" &&
+  "${link_args[@]}" -Wl,--gc-sections -Wl,--version-script="$version_script" -o "$lto_out" )
+strip --strip-all "$lto_out"
+
+# Package the .so, the C ABI header, and the version file into a tarball named like a yb_release
+# tar, and drop it where yb_release drops its tars ($YB_SRC_ROOT/build).
+version=$( tr -d '[:space:]' < "$yb_src_root/version.txt" 2>/dev/null || echo "0.0.0.0" )
+commit=$( cd "$yb_src_root" && git rev-parse --short HEAD 2>/dev/null || echo unknown )
+arch=$( uname -m )
+system=$( uname -s | tr '[:upper:]' '[:lower:]' )
+pkg_name="libyb_thin_client-${version}-${commit}-${build_type}-${system}-${arch}"
+
+stage=$( mktemp -d )
+pkg_dir="$stage/$pkg_name"
+mkdir -p "$pkg_dir/lib" "$pkg_dir/include"
+cp "$lto_out" "$pkg_dir/lib/$lib_name"
+cp "$script_dir/yb_thin_client.h" "$pkg_dir/include/yb_thin_client.h"
+cp "$yb_src_root/version.txt" "$pkg_dir/version.txt"
+
+release_dir="$yb_src_root/build"
+mkdir -p "$release_dir"
+tarball="$release_dir/${pkg_name}.tar.gz"
+tar -czf "$tarball" -C "$stage" "$pkg_name"
+rm -rf "$stage"
+log "Packaged: $tarball ($( du -h "$tarball" | cut -f1 ))"
+
+if [[ -n "$destination" ]]; then
+  [[ -d "$destination" ]] || fatal "Destination $destination is not a directory"
+  cp "$tarball" "$destination/"
+  log "Copied to $destination/${pkg_name}.tar.gz"
+fi

--- a/src/yb/thin_client/yb_release
+++ b/src/yb/thin_client/yb_release
@@ -18,7 +18,7 @@
 # mechanism yb_release uses to produce the self-contained server binaries -- then packages it, the
 # C ABI header, and the version file into a tarball placed next to yb_release's release tarballs
 # ($YB_SRC_ROOT/build), named with the version/commit/architecture. Tarball layout:
-#   libyb_thin_client-<version>-<commit>-<build_type>-<system>-<arch>/
+#   yb_thin_client-<version>-<commit>-<build_type>-<system>-<arch>/
 #     lib/libyb_thin_client.so    include/yb_thin_client.h    version.txt
 #
 # The .so statically links the entire PgClientServiceProxy closure and depends only on system
@@ -160,7 +160,7 @@ version=$( tr -d '[:space:]' < "$yb_src_root/version.txt" 2>/dev/null || echo "0
 commit=$( cd "$yb_src_root" && git rev-parse --short HEAD 2>/dev/null || echo unknown )
 arch=$( uname -m )
 system=$( uname -s | tr '[:upper:]' '[:lower:]' )
-pkg_name="libyb_thin_client-${version}-${commit}-${build_type}-${system}-${arch}"
+pkg_name="yb_thin_client-${version}-${commit}-${build_type}-${system}-${arch}"
 
 stage=$( mktemp -d )
 pkg_dir="$stage/$pkg_name"

--- a/src/yb/thin_client/yb_thin_client-itest.cc
+++ b/src/yb/thin_client/yb_thin_client-itest.cc
@@ -1,0 +1,338 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+// Live smoke test for the Perform-based tserver client (src/yb/thin_client/yb_thin_client.h) driven
+// against a single mini tserver's PgClientService. Exercises the whole C ABI: client_create ->
+// table_open (schema check) -> upsert_batch -> paged read, and cross-checks the shim's writes and
+// reads against ordinary SQL through the same tserver.
+
+#include <array>
+#include <future>
+#include <string>
+#include <vector>
+
+#include "yb/thin_client/yb_thin_client.h"
+
+#include "yb/integration-tests/mini_cluster.h"
+#include "yb/tserver/mini_tablet_server.h"
+
+#include "yb/util/format.h"
+#include "yb/util/net/net_util.h"
+#include "yb/util/path_util.h"
+#include "yb/util/result.h"
+#include "yb/util/slice.h"
+#include "yb/util/test_macros.h"
+#include "yb/util/test_util.h"
+
+#include "yb/yql/pgwrapper/libpq_utils.h"
+#include "yb/yql/pgwrapper/pg_mini_test_base.h"
+
+DECLARE_bool(use_node_to_node_encryption);
+DECLARE_bool(use_client_to_server_encryption);
+DECLARE_bool(allow_insecure_connections);
+DECLARE_bool(TEST_private_broadcast_address);
+DECLARE_string(certs_dir);
+DECLARE_string(TEST_public_hostname_suffix);
+
+namespace yb::pgwrapper {
+
+namespace {
+
+// A decoded cell, deep-copied so it outlives ybthin_read_result_free.
+struct DecodedCell {
+  ybthin_bind_tag tag = YBTHIN_BIND_NULL;
+  int64_t i = 0;
+  std::string bytes;
+};
+
+// Bridges an async shim read to a future. `cells` is row-major (n_rows * n_cols).
+struct ReadOutcome {
+  ybthin_status_code code = YBTHIN_OTHER;
+  std::string message;
+  size_t n_rows = 0;
+  size_t n_cols = 0;
+  std::vector<DecodedCell> cells;
+  std::vector<uint8_t> paging_state;
+  uint64_t used_read_time_ht = 0;
+};
+
+void OnReadDone(void* ctx, ybthin_status status, ybthin_read_result* result) {
+  auto* promise = static_cast<std::promise<ReadOutcome>*>(ctx);
+  ReadOutcome out;
+  out.code = status.code;
+  if (status.message) {
+    out.message = status.message;
+    ybthin_string_free(status.message);
+  }
+  if (result) {
+    out.used_read_time_ht = result->used_read_time_ht;
+    // This test drives a single-op batch, so read results[0].
+    if (result->n_ops > 0) {
+      const ybthin_read_op_result& op = result->results[0];
+      out.n_rows = op.n_rows;
+      out.n_cols = op.n_cols;
+      out.cells.resize(op.n_rows * op.n_cols);
+      for (size_t idx = 0; idx < out.cells.size(); ++idx) {
+        const ybthin_cell& src = op.cells[idx];
+        DecodedCell& dst = out.cells[idx];
+        dst.tag = src.tag;
+        dst.i = src.i;
+        if (src.bytes && src.bytes_len) {
+          dst.bytes.assign(reinterpret_cast<const char*>(src.bytes), src.bytes_len);
+        }
+      }
+      if (op.paging_state) {
+        out.paging_state.assign(op.paging_state, op.paging_state + op.paging_state_len);
+      }
+    }
+    ybthin_read_result_free(result);
+  }
+  promise->set_value(std::move(out));
+}
+
+struct WriteOutcome {
+  ybthin_status_code code = YBTHIN_OTHER;
+  std::string message;
+};
+
+void OnWriteDone(void* ctx, ybthin_status status) {
+  auto* promise = static_cast<std::promise<WriteOutcome>*>(ctx);
+  WriteOutcome out;
+  out.code = status.code;
+  if (status.message) {
+    out.message = status.message;
+    ybthin_string_free(status.message);
+  }
+  promise->set_value(std::move(out));
+}
+
+ybthin_bind I32(int32_t v) { return ybthin_bind{YBTHIN_BIND_I32, v, nullptr, 0}; }
+
+ybthin_bind Bytea(const std::string& s) {
+  return ybthin_bind{
+      YBTHIN_BIND_BYTEA, 0, reinterpret_cast<const uint8_t*>(s.data()), s.size()};
+}
+
+}  // namespace
+
+class PgThinClientTest : public PgMiniTestBase {
+ protected:
+  // These tests exercise single-shard ops against one hash key; a single tserver keeps the
+  // in-process cluster small enough that running the plaintext and TLS cases back-to-back in one
+  // test binary does not exhaust memory when initdb forks postgres.
+  size_t NumTabletServers() override { return 1; }
+
+  std::string TServerAddr() const {
+    return cluster_->mini_tablet_server(0)->bound_rpc_addr_str();
+  }
+
+  Result<uint32_t> FetchOid(PGConn* conn, const std::string& query) {
+    auto value = VERIFY_RESULT(conn->FetchRowAsString(query));
+    return static_cast<uint32_t>(std::stoul(value));
+  }
+
+  // Drives the full C ABI end-to-end (open table, upsert, paged read) against the mini tserver,
+  // connecting with `tls` (nullptr => plaintext) and cross-checking writes and reads via SQL.
+  void RunOpenUpsertReadPaged(const ybthin_tls_opts* tls) {
+    constexpr int kHashKey = 1;
+    constexpr int kOtherHashKey = 2;
+    constexpr int kNumRows = 250;
+    constexpr int kUpperBound = 199;      // read v <= 199
+    constexpr int kExpectedRead = 200;    // v in [0, 199]
+    constexpr uint64_t kPageLimit = 64;
+
+    // Create the table and populate a decoy hash key via SQL so we can cross-check the shim.
+    auto conn = ASSERT_RESULT(Connect());
+    ASSERT_OK(conn.Execute(
+        "CREATE TABLE t (k int, v int, payload bytea, PRIMARY KEY((k) HASH, v))"));
+    ASSERT_OK(conn.ExecuteFormat(
+        "INSERT INTO t SELECT $0, gs, '\\xdead'::bytea FROM generate_series(0, 9) gs",
+        kOtherHashKey));
+
+    const auto db_oid = ASSERT_RESULT(FetchOid(&conn, "SELECT oid FROM pg_database "
+                                                       "WHERE datname = current_database()"));
+    const auto table_oid = ASSERT_RESULT(FetchOid(&conn, "SELECT 't'::regclass::oid"));
+
+    // ---- client_create ------------------------------------------------------
+    const auto addr = TServerAddr();
+    const char* addrs[] = {addr.c_str()};
+    ybthin_client* client = nullptr;
+    {
+      auto st = ybthin_client_create(
+          addrs, 1, tls, /* pool= */ nullptr, /* rpc_timeout_ms= */ 60000, /* num_reactors= */ 0,
+          &client);
+      ASSERT_EQ(st.code, YBTHIN_OK) << (st.message ? st.message : "");
+    }
+
+    // ---- table_open + schema check -----------------------------------------
+    ybthin_table* table = nullptr;
+    ybthin_table_info info = {};
+    {
+      auto st = ybthin_table_open(client, db_oid, table_oid, &table, &info);
+      ASSERT_EQ(st.code, YBTHIN_OK) << (st.message ? st.message : "");
+    }
+    ASSERT_EQ(info.n_columns, 3);
+    ASSERT_EQ(std::string(info.columns[0].name), "k");
+    ASSERT_EQ(info.columns[0].kind, YBTHIN_COL_HASH);
+    ASSERT_EQ(info.columns[0].type, YBTHIN_T_I32);
+    ASSERT_EQ(std::string(info.columns[1].name), "v");
+    ASSERT_EQ(info.columns[1].kind, YBTHIN_COL_RANGE);
+    ASSERT_EQ(info.columns[1].type, YBTHIN_T_I32);
+    ASSERT_EQ(std::string(info.columns[2].name), "payload");
+    ASSERT_EQ(info.columns[2].kind, YBTHIN_COL_VALUE);
+    ASSERT_EQ(info.columns[2].type, YBTHIN_T_BYTEA);
+
+    const int32_t v_id = info.columns[1].id;
+    const int32_t payload_id = info.columns[2].id;
+
+    // ---- upsert_batch -------------------------------------------------------
+    const std::string payload = "hello";
+    std::vector<std::array<ybthin_bind, 2>> keys(kNumRows);
+    std::vector<ybthin_bind> values(kNumRows);
+    std::vector<int32_t> value_ids(kNumRows, payload_id);
+    std::vector<ybthin_upsert_row> rows(kNumRows);
+    for (int i = 0; i < kNumRows; ++i) {
+      keys[i] = {I32(kHashKey), I32(i)};      // (k HASH, v RANGE) in schema order
+      values[i] = Bytea(payload);
+      rows[i] = ybthin_upsert_row{table, keys[i].data(), 2, &value_ids[i], &values[i], 1};
+    }
+    {
+      std::promise<WriteOutcome> promise;
+      auto future = promise.get_future();
+      ybthin_upsert_batch_async(client, rows.data(), rows.size(), &OnWriteDone, &promise);
+      auto out = future.get();
+      ASSERT_EQ(out.code, YBTHIN_OK) << out.message;
+    }
+
+    // Cross-check the shim's writes via SQL through the same tserver.
+    ASSERT_EQ(kNumRows, ASSERT_RESULT(conn.FetchRow<PGUint64>(
+                            Format("SELECT count(*) FROM t WHERE k = $0", kHashKey))));
+    ASSERT_EQ(
+        kExpectedRead,
+        ASSERT_RESULT(conn.FetchRow<PGUint64>(Format(
+            "SELECT count(*) FROM t WHERE k = $0 AND v <= $1", kHashKey, kUpperBound))));
+
+    // ---- paged read ---------------------------------------------------------
+    ybthin_bind hash_values[] = {I32(kHashKey)};
+    ybthin_cond conds[] = {{v_id, YBTHIN_LE, I32(kUpperBound)}};
+    int32_t target_ids[] = {v_id, payload_id};
+    ybthin_read_spec spec = {};
+    spec.hash_values = hash_values;
+    spec.n_hash = 1;
+    spec.conds = conds;
+    spec.n_conds = 1;
+    spec.target_ids = target_ids;
+    spec.n_targets = 2;
+    spec.limit = kPageLimit;
+    spec.is_forward_scan = 1;
+
+    int64_t total = 0;
+    int pages = 0;
+    std::vector<uint8_t> paging_state;
+    do {
+      std::promise<ReadOutcome> promise;
+      auto future = promise.get_future();
+      // Single-op batch, paging this op's scan across calls (the batch snapshot is per-call here).
+      ybthin_read_op op = {};
+      op.table = table;
+      op.spec = spec;
+      op.paging_state_in = paging_state.empty() ? nullptr : paging_state.data();
+      op.paging_state_in_len = paging_state.size();
+      ybthin_read_async(client, &op, 1, /* read_time_ht= */ 0, &OnReadDone, &promise);
+      auto out = future.get();
+      ASSERT_EQ(out.code, YBTHIN_OK) << out.message;
+      // The shim decoded the sidecar into typed cells: 2 targets (v INT4, payload BYTEA).
+      ASSERT_EQ(out.n_cols, 2u);
+      ASSERT_EQ(out.cells.size(), out.n_rows * out.n_cols);
+      for (size_t r = 0; r < out.n_rows; ++r) {
+        const DecodedCell& v_cell = out.cells[r * out.n_cols + 0];
+        const DecodedCell& payload_cell = out.cells[r * out.n_cols + 1];
+        ASSERT_EQ(v_cell.tag, YBTHIN_BIND_I32);
+        EXPECT_LE(v_cell.i, kUpperBound);  // the range bound we scanned under
+        ASSERT_EQ(payload_cell.tag, YBTHIN_BIND_BYTEA);
+        EXPECT_EQ(payload_cell.bytes, payload);
+      }
+      total += static_cast<int64_t>(out.n_rows);
+      paging_state = std::move(out.paging_state);
+      ++pages;
+      ASSERT_LT(pages, 100) << "paging did not terminate";
+    } while (!paging_state.empty());
+
+    ASSERT_EQ(total, kExpectedRead);
+    ASSERT_GT(pages, 1) << "expected the scan to span multiple pages at limit " << kPageLimit;
+
+    ybthin_columns_free(info.columns, info.n_columns);
+    ybthin_table_close(table);
+    ybthin_client_destroy(client);
+  }
+};
+
+TEST_F(PgThinClientTest, OpenUpsertReadPaged) {
+  RunOpenUpsertReadPaged(/* tls= */ nullptr);
+}
+
+// TLS variant: the cluster runs with node-to-node encryption, and the thin client connects over TLS
+// authenticating the server against the test CA. Also asserts the TLS-only endpoint rejects a
+// plaintext client.
+class PgThinClientTlsTest : public PgThinClientTest {
+ protected:
+  void SetUp() override {
+    // Encrypt both the internal RPC path (which the thin client speaks to) and the client-to-server
+    // path; enabling only node-to-node leaves the in-process postgres cert setup half-configured.
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_use_node_to_node_encryption) = true;
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_use_client_to_server_encryption) = true;
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_allow_insecure_connections) = false;
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_certs_dir) = GetCertsDir();
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_public_hostname_suffix) = ".ip.yugabyte";
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_private_broadcast_address) = true;
+    PgThinClientTest::SetUp();
+  }
+
+  std::string CaCertPath() const { return JoinPathSegments(GetCertsDir(), "ca.crt"); }
+};
+
+// Exercises the thin client's TLS path against the encrypted tserver RPC endpoint. client_create
+// opens a session via a Heartbeat RPC, so a success proves the full TLS handshake plus an encrypted
+// RPC round-trip; Perform ops reuse the same TLS stream. The plaintext/Perform coverage lives in
+// the non-TLS test above, so this focuses on transport security only.
+TEST_F(PgThinClientTlsTest, ClientCreateOverTls) {
+  const auto addr = TServerAddr();
+  const char* addrs[] = {addr.c_str()};
+
+  // The TLS-only RPC endpoint must reject a plaintext client.
+  {
+    ybthin_client* insecure = nullptr;
+    auto st = ybthin_client_create(
+        addrs, 1, /* tls= */ nullptr, /* pool= */ nullptr, /* rpc_timeout_ms= */ 10000,
+        /* num_reactors= */ 0, &insecure);
+    ASSERT_NE(st.code, YBTHIN_OK) << "plaintext client unexpectedly reached a TLS-only endpoint";
+    if (st.message) {
+      ybthin_string_free(st.message);
+    }
+    if (insecure) {
+      ybthin_client_destroy(insecure);
+    }
+  }
+
+  // Server-authenticated TLS using the test CA (no client cert required by default).
+  const auto ca = CaCertPath();
+  ybthin_tls_opts tls = {};
+  tls.ca_cert_path = ca.c_str();
+  ybthin_client* client = nullptr;
+  auto st = ybthin_client_create(
+      addrs, 1, &tls, /* pool= */ nullptr, /* rpc_timeout_ms= */ 60000, /* num_reactors= */ 0,
+      &client);
+  ASSERT_EQ(st.code, YBTHIN_OK) << (st.message ? st.message : "");
+  ybthin_client_destroy(client);
+}
+
+}  // namespace yb::pgwrapper

--- a/src/yb/thin_client/yb_thin_client-itest.cc
+++ b/src/yb/thin_client/yb_thin_client-itest.cc
@@ -388,6 +388,174 @@ TEST_F(PgThinClientTest, PagedReadHoldsSnapshotAcrossPages) {
   ybthin_client_destroy(client);
 }
 
+// Range-sharded tables. Routing is the client's job on the Perform path (PgClientSession never
+// derives a partition key), and a range table has no hash columns to derive one from, so the shim
+// builds it from the range key. The table is split into 4 tablets so anything that mis-routes --
+// or that fails to follow the paging state onto the next tablet -- loses rows instead of quietly
+// passing on a single-tablet table.
+TEST_F(PgThinClientTest, RangeShardedTable) {
+  constexpr int kNumRows = 200;         // r in [0, 199], split across 4 tablets
+  constexpr uint64_t kPageLimit = 32;   // several pages per tablet
+
+  auto conn = ASSERT_RESULT(Connect());
+  ASSERT_OK(conn.Execute(
+      "CREATE TABLE rs (r int, payload bytea, PRIMARY KEY(r ASC)) "
+      "SPLIT AT VALUES ((50), (100), (150))"));
+
+  const auto db_oid = ASSERT_RESULT(FetchOid(&conn, "SELECT oid FROM pg_database "
+                                                     "WHERE datname = current_database()"));
+  const auto table_oid = ASSERT_RESULT(FetchOid(&conn, "SELECT 'rs'::regclass::oid"));
+
+  const auto addr = TServerAddr();
+  const char* addrs[] = {addr.c_str()};
+  ybthin_client* client = nullptr;
+  {
+    auto st = ybthin_client_create(
+        addrs, 1, /* tls= */ nullptr, /* pool= */ nullptr, /* rpc_timeout_ms= */ 60000,
+        /* num_reactors= */ 0, &client);
+    ASSERT_EQ(st.code, YBTHIN_OK) << (st.message ? st.message : "");
+  }
+  ybthin_table* table = nullptr;
+  ybthin_table_info info = {};
+  {
+    auto st = ybthin_table_open(client, db_oid, table_oid, &table, &info);
+    ASSERT_EQ(st.code, YBTHIN_OK) << (st.message ? st.message : "");
+  }
+  // No hash columns: the key column is RANGE.
+  ASSERT_EQ(info.n_columns, 2);
+  ASSERT_EQ(std::string(info.columns[0].name), "r");
+  ASSERT_EQ(info.columns[0].kind, YBTHIN_COL_RANGE);
+  const int32_t r_id = info.columns[0].id;
+  const int32_t payload_id = info.columns[1].id;
+
+  // ---- upserts spanning every tablet --------------------------------------
+  const std::string payload = "rangeval";
+  std::vector<std::array<ybthin_bind, 1>> keys(kNumRows);
+  std::vector<ybthin_bind> values(kNumRows);
+  std::vector<int32_t> value_ids(kNumRows, payload_id);
+  std::vector<ybthin_upsert_row> rows(kNumRows);
+  for (int i = 0; i < kNumRows; ++i) {
+    keys[i] = {I32(i)};
+    values[i] = Bytea(payload);
+    rows[i] = ybthin_upsert_row{table, keys[i].data(), 1, &value_ids[i], &values[i], 1};
+  }
+  {
+    std::promise<WriteOutcome> promise;
+    auto future = promise.get_future();
+    ybthin_upsert_batch_async(client, rows.data(), rows.size(), &OnWriteDone, &promise);
+    auto out = future.get();
+    ASSERT_EQ(out.code, YBTHIN_OK) << out.message;
+  }
+  // Cross-check via SQL: every row landed, and on the right tablet (a mis-routed write would be
+  // rejected or land under a different key).
+  ASSERT_EQ(kNumRows, ASSERT_RESULT(conn.FetchRow<PGUint64>("SELECT count(*) FROM rs")));
+  ASSERT_EQ(kNumRows, ASSERT_RESULT(conn.FetchRow<PGUint64>(
+                          Format("SELECT count(*) FROM rs WHERE payload = '$0'::bytea",
+                                 payload))));
+
+  // ---- point read: exact range key routes to one tablet --------------------
+  {
+    ybthin_bind range_values[] = {I32(137)};  // in the 4th tablet
+    int32_t target_ids[] = {r_id};
+    ybthin_read_spec spec = {};
+    spec.range_values = range_values;
+    spec.n_range = 1;
+    spec.target_ids = target_ids;
+    spec.n_targets = 1;
+    spec.is_forward_scan = 1;
+
+    std::promise<ReadOutcome> promise;
+    auto future = promise.get_future();
+    ybthin_read_op op = {};
+    op.table = table;
+    op.spec = spec;
+    ybthin_read_async(client, &op, 1, /* read_time_ht= */ 0, &OnReadDone, &promise);
+    auto out = future.get();
+    ASSERT_EQ(out.code, YBTHIN_OK) << out.message;
+    ASSERT_EQ(out.n_rows, 1u);
+    ASSERT_EQ(out.cells[0].tag, YBTHIN_BIND_I32);
+    EXPECT_EQ(out.cells[0].i, 137);
+  }
+
+  // ---- full paged scan must cross every tablet boundary --------------------
+  {
+    int32_t target_ids[] = {r_id};
+    ybthin_read_spec spec = {};
+    spec.target_ids = target_ids;   // no range_values: scan from the start of the table
+    spec.n_targets = 1;
+    spec.limit = kPageLimit;
+    spec.is_forward_scan = 1;
+
+    std::vector<int32_t> seen;
+    std::vector<uint8_t> paging_state;
+    int pages = 0;
+    do {
+      std::promise<ReadOutcome> promise;
+      auto future = promise.get_future();
+      ybthin_read_op op = {};
+      op.table = table;
+      op.spec = spec;
+      op.paging_state_in = paging_state.empty() ? nullptr : paging_state.data();
+      op.paging_state_in_len = paging_state.size();
+      ybthin_read_async(client, &op, 1, /* read_time_ht= */ 0, &OnReadDone, &promise);
+      auto out = future.get();
+      ASSERT_EQ(out.code, YBTHIN_OK) << out.message;
+      for (size_t i = 0; i < out.n_rows; ++i) {
+        ASSERT_EQ(out.cells[i].tag, YBTHIN_BIND_I32);
+        seen.push_back(static_cast<int32_t>(out.cells[i].i));
+      }
+      paging_state = std::move(out.paging_state);
+      ++pages;
+      ASSERT_LT(pages, 100) << "paging did not terminate";
+    } while (!paging_state.empty());
+
+    std::sort(seen.begin(), seen.end());
+    seen.erase(std::unique(seen.begin(), seen.end()), seen.end());
+    ASSERT_EQ(seen.size(), static_cast<size_t>(kNumRows))
+        << "scan did not cover every tablet: an unset/stale partition key routes the continuation "
+           "back to the first tablet, so the scan stops at that tablet's last row";
+    EXPECT_EQ(seen.front(), 0);
+    EXPECT_EQ(seen.back(), kNumRows - 1);
+  }
+
+  // ---- fail fast: hash values on a range-sharded table ---------------------
+  {
+    ybthin_bind hash_values[] = {I32(1)};
+    int32_t target_ids[] = {r_id};
+    ybthin_read_spec spec = {};
+    spec.hash_values = hash_values;
+    spec.n_hash = 1;
+    spec.target_ids = target_ids;
+    spec.n_targets = 1;
+
+    std::promise<ReadOutcome> promise;
+    auto future = promise.get_future();
+    ybthin_read_op op = {};
+    op.table = table;
+    op.spec = spec;
+    ybthin_read_async(client, &op, 1, /* read_time_ht= */ 0, &OnReadDone, &promise);
+    auto out = future.get();
+    ASSERT_EQ(out.code, YBTHIN_INVALID) << "expected hash_values on a range table to be rejected";
+  }
+
+  // ---- fail fast: an upsert that does not bind the whole primary key -------
+  {
+    ybthin_bind no_keys[] = {I32(0)};
+    int32_t vid = payload_id;
+    ybthin_bind val = Bytea(payload);
+    ybthin_upsert_row bad = {table, no_keys, 0, &vid, &val, 1};  // n_keys == 0
+    std::promise<WriteOutcome> promise;
+    auto future = promise.get_future();
+    ybthin_upsert_batch_async(client, &bad, 1, &OnWriteDone, &promise);
+    auto out = future.get();
+    ASSERT_EQ(out.code, YBTHIN_INVALID) << "expected a partial primary key to be rejected";
+  }
+
+  ybthin_columns_free(info.columns, info.n_columns);
+  ybthin_table_close(table);
+  ybthin_client_destroy(client);
+}
+
 // TLS variant: the cluster runs with node-to-node encryption, and the thin client connects over TLS
 // authenticating the server against the test CA. Also asserts the TLS-only endpoint rejects a
 // plaintext client.

--- a/src/yb/thin_client/yb_thin_client-itest.cc
+++ b/src/yb/thin_client/yb_thin_client-itest.cc
@@ -17,6 +17,8 @@
 
 #include <algorithm>
 #include <functional>
+#include <tuple>
+#include <utility>
 #include <array>
 #include <future>
 #include <string>
@@ -596,6 +598,336 @@ TEST_F(PgThinClientTest, RangeShardedTable) {
     ybthin_upsert_batch_async(client, &bad, 1, &OnWriteDone, &promise);
     auto out = future.get();
     ASSERT_EQ(out.code, YBTHIN_INVALID) << "expected a partial primary key to be rejected";
+  }
+
+  ybthin_columns_free(info.columns, info.n_columns);
+  ybthin_table_close(table);
+  ybthin_client_destroy(client);
+}
+
+// A range-sharded table with a FOUR column key, matching the shape a caller reported problems on:
+// (a, b, segno, chunk_offset). Two independent things are checked here.
+//
+// 1. A range key PREFIX must bound the scan the same way in both directions. Encoding the prefix
+//    into scan bounds is what routes a range scan, and the upper bound of a prefix has to cover
+//    every key under it -- get that wrong and a reverse scan silently returns nothing while the
+//    identical forward scan returns rows.
+// 2. A condition on a key column must be evaluated even when that column is not among the targets.
+//    DocDB builds both the projection and the filter from col_refs (docdb/pgsql_operation.cc), so a
+//    condition column missing from col_refs is filtered against a column that was never read, and
+//    matches nothing.
+TEST_F(PgThinClientTest, RangeKeyPrefixesAndKeyColumnConditions) {
+  constexpr int kA = 1;
+  constexpr int kNumB = 3, kNumSeg = 3, kNumChunk = 4;   // 36 rows under a = 1
+
+  auto conn = ASSERT_RESULT(Connect());
+  ASSERT_OK(conn.Execute(
+      "CREATE TABLE k (a int, b int, segno int, chunk_offset int, v bytea, "
+      "PRIMARY KEY (a ASC, b ASC, segno ASC, chunk_offset ASC)) "
+      // Split on THREE column tuples, as a reporting caller's table does. That is what makes the
+      // prefix depth matter: a 1-2 column prefix spans tablets while a 3-4 column one targets
+      // exactly one, and a scan that starts on the wrong tablet returns nothing.
+      "SPLIT AT VALUES ((1, 1, 0), (1, 2, 0), (2, 0, 0), (2, 1, 2))"));
+  ASSERT_OK(conn.ExecuteFormat(
+      "INSERT INTO k SELECT $0, b, s, c, '\\xfeed'::bytea "
+      "FROM generate_series(0, $1) b, generate_series(0, $2) s, generate_series(0, $3) c",
+      kA, kNumB - 1, kNumSeg - 1, kNumChunk - 1));
+  // A second value of `a`, so a prefix scan that ignores its bounds would over-return.
+  ASSERT_OK(conn.ExecuteFormat(
+      "INSERT INTO k SELECT $0, b, s, c, '\\xfeed'::bytea "
+      "FROM generate_series(0, $1) b, generate_series(0, $2) s, generate_series(0, $3) c",
+      kA + 1, kNumB - 1, kNumSeg - 1, kNumChunk - 1));
+
+  const auto db_oid = ASSERT_RESULT(FetchOid(&conn, "SELECT oid FROM pg_database "
+                                                     "WHERE datname = current_database()"));
+  const auto table_oid = ASSERT_RESULT(FetchOid(&conn, "SELECT 'k'::regclass::oid"));
+
+  const auto addr = TServerAddr();
+  const char* addrs[] = {addr.c_str()};
+  ybthin_client* client = nullptr;
+  {
+    auto st = ybthin_client_create(
+        addrs, 1, /* tls= */ nullptr, /* pool= */ nullptr, /* rpc_timeout_ms= */ 60000,
+        /* num_reactors= */ 0, &client);
+    ASSERT_EQ(st.code, YBTHIN_OK) << (st.message ? st.message : "");
+  }
+  ybthin_table* table = nullptr;
+  ybthin_table_info info = {};
+  {
+    auto st = ybthin_table_open(client, db_oid, table_oid, &table, &info);
+    ASSERT_EQ(st.code, YBTHIN_OK) << (st.message ? st.message : "");
+  }
+  ASSERT_EQ(info.n_columns, 5);
+  const int32_t b_id = info.columns[1].id;
+  const int32_t segno_id = info.columns[2].id, chunk_id = info.columns[3].id;
+  ASSERT_EQ(info.columns[2].kind, YBTHIN_COL_RANGE);
+  ASSERT_EQ(info.columns[3].kind, YBTHIN_COL_RANGE);
+
+  // Pages a scan to completion and returns the values of the single target column.
+  auto scan = [&](const ybthin_read_spec& spec) -> Result<std::vector<int32_t>> {
+    std::vector<int32_t> seen;
+    std::vector<uint8_t> paging_state;
+    int pages = 0;
+    do {
+      std::promise<ReadOutcome> promise;
+      auto future = promise.get_future();
+      ybthin_read_op op = {};
+      op.table = table;
+      op.spec = spec;
+      op.paging_state_in = paging_state.empty() ? nullptr : paging_state.data();
+      op.paging_state_in_len = paging_state.size();
+      ybthin_read_async(client, &op, 1, /* read_time_ht= */ 0, &OnReadDone, &promise);
+      auto out = future.get();
+      SCHECK_EQ(out.code, YBTHIN_OK, IllegalState, out.message);
+      for (size_t i = 0; i < out.n_rows; ++i) {
+        seen.push_back(static_cast<int32_t>(out.cells[i * out.n_cols].i));
+      }
+      paging_state = std::move(out.paging_state);
+      SCHECK_LT(++pages, 100, IllegalState, "paging did not terminate");
+    } while (!paging_state.empty());
+    return seen;
+  };
+
+  // ---- (1) a range key prefix must behave identically forward and reverse ----
+  // Prefix lengths 1..4: (a), (a,b), (a,b,segno), (a,b,segno,chunk_offset).
+  const ybthin_bind prefix[] = {I32(kA), I32(1), I32(2), I32(3)};
+  const int expected_rows[] = {kNumB * kNumSeg * kNumChunk, kNumSeg * kNumChunk, kNumChunk, 1};
+  int32_t target_ids[] = {chunk_id};
+  for (size_t n = 1; n <= 4; ++n) {
+    ybthin_read_spec spec = {};
+    spec.range_values = prefix;
+    spec.n_range = n;
+    spec.target_ids = target_ids;
+    spec.n_targets = 1;
+
+    spec.is_forward_scan = 1;
+    auto fwd = ASSERT_RESULT(scan(spec));
+    spec.is_forward_scan = 0;
+    auto rev = ASSERT_RESULT(scan(spec));
+
+    ASSERT_EQ(fwd.size(), static_cast<size_t>(expected_rows[n - 1]))
+        << "forward scan on a " << n << "-column range prefix";
+    ASSERT_EQ(rev.size(), fwd.size())
+        << "reverse scan on a " << n << "-column range prefix returned " << rev.size()
+        << " rows but forward returned " << fwd.size();
+    std::sort(fwd.begin(), fwd.end());
+    std::sort(rev.begin(), rev.end());
+    ASSERT_EQ(fwd, rev) << "forward and reverse disagree on a " << n << "-column prefix";
+  }
+
+  // ---- (2) a condition on a key column that is NOT a target ----
+  // segno is the 3rd key column, chunk_offset the 4th; neither is the target here, so both rely on
+  // the condition column reaching col_refs.
+  int32_t only_b[] = {b_id};
+  for (const auto& [cond_col, cond_val, expected, name] :
+       std::vector<std::tuple<int32_t, int32_t, int, const char*>>{
+           {segno_id, 1, kNumB * kNumChunk, "segno (3rd key column)"},
+           {chunk_id, 2, kNumB * kNumSeg, "chunk_offset (4th key column)"}}) {
+    ybthin_bind a_only[] = {I32(kA)};
+    ybthin_cond conds[] = {{cond_col, YBTHIN_EQ, I32(cond_val)}};
+    ybthin_read_spec spec = {};
+    spec.range_values = a_only;
+    spec.n_range = 1;
+    spec.conds = conds;
+    spec.n_conds = 1;
+    spec.target_ids = only_b;
+    spec.n_targets = 1;
+
+    spec.is_forward_scan = 1;
+    auto fwd = ASSERT_RESULT(scan(spec));
+    spec.is_forward_scan = 0;
+    auto rev = ASSERT_RESULT(scan(spec));
+    ASSERT_EQ(fwd.size(), static_cast<size_t>(expected)) << "forward Eq cond on " << name;
+    ASSERT_EQ(rev.size(), static_cast<size_t>(expected)) << "reverse Eq cond on " << name;
+  }
+
+  ybthin_columns_free(info.columns, info.n_columns);
+  ybthin_table_close(table);
+  ybthin_client_destroy(client);
+}
+
+// Reported by a caller migrating amp_storage.wals from hash to range partitioning. Mirrors their
+// repro table exactly, including the column types and the 3-column split points, and -- crucially
+// -- reads a SINGLE page with limit 1 rather than paging to exhaustion, which is how the caller
+// issues its "covering chunk" lookup. A fan-out that starts a reverse scan on the wrong tablet
+// hands back an empty first page, which such a caller reports as "no rows".
+TEST_F(PgThinClientTest, RangeShardedDescendingPrefixSinglePage) {
+  auto conn = ASSERT_RESULT(Connect());
+  ASSERT_OK(conn.Execute(
+      "CREATE TABLE wals_range_repro ("
+      "  branch_id TEXT NOT NULL, bucket_id SMALLINT NOT NULL, segno BIGINT NOT NULL,"
+      "  chunk_offset BIGINT NOT NULL, chunk_size INTEGER NOT NULL, data BYTEA NOT NULL,"
+      "  PRIMARY KEY (branch_id ASC, bucket_id ASC, segno ASC, chunk_offset ASC))"
+      " SPLIT AT VALUES (('b', 0, 2), ('b', 0, 4))"));
+  ASSERT_OK(conn.Execute(
+      "INSERT INTO wals_range_repro "
+      "SELECT 'b', 0, s, o*100, 100, '\\x02'::bytea "
+      "FROM generate_series(1,5) s, generate_series(0,3) o"));
+  // Bracket rows, so a read that loses its bounds is caught rather than passing.
+  ASSERT_OK(conn.Execute(
+      "INSERT INTO wals_range_repro VALUES "
+      "('a', 0, 9, 0, 100, '\\x0a'::bytea), ('c', 0, 9, 0, 100, '\\x0c'::bytea)"));
+
+  const auto db_oid = ASSERT_RESULT(FetchOid(&conn, "SELECT oid FROM pg_database "
+                                                     "WHERE datname = current_database()"));
+  const auto table_oid = ASSERT_RESULT(
+      FetchOid(&conn, "SELECT 'wals_range_repro'::regclass::oid"));
+
+  const auto addr = TServerAddr();
+  const char* addrs[] = {addr.c_str()};
+  ybthin_client* client = nullptr;
+  {
+    auto st = ybthin_client_create(
+        addrs, 1, /* tls= */ nullptr, /* pool= */ nullptr, /* rpc_timeout_ms= */ 60000,
+        /* num_reactors= */ 0, &client);
+    ASSERT_EQ(st.code, YBTHIN_OK) << (st.message ? st.message : "");
+  }
+  ybthin_table* table = nullptr;
+  ybthin_table_info info = {};
+  {
+    auto st = ybthin_table_open(client, db_oid, table_oid, &table, &info);
+    ASSERT_EQ(st.code, YBTHIN_OK) << (st.message ? st.message : "");
+  }
+  ASSERT_EQ(info.n_columns, 6);
+  for (int i = 0; i < 4; ++i) {
+    ASSERT_EQ(info.columns[i].kind, YBTHIN_COL_RANGE) << "key column " << i;
+  }
+  const int32_t segno_id = info.columns[2].id, chunk_id = info.columns[3].id;
+
+  const std::string branch = "b";
+  auto text_b = [&] {
+    return ybthin_bind{YBTHIN_BIND_TEXT, 0,
+                       reinterpret_cast<const uint8_t*>(branch.data()), branch.size()};
+  };
+  auto i16 = [](int64_t v) { return ybthin_bind{YBTHIN_BIND_I16, v, nullptr, 0}; };
+  auto i64 = [](int64_t v) { return ybthin_bind{YBTHIN_BIND_I64, v, nullptr, 0}; };
+
+  int32_t targets[] = {segno_id, chunk_id};
+  // ONE page only, exactly as the caller issues it -- no paging loop to paper over an empty page.
+  auto first_page = [&](const ybthin_read_spec& spec) -> Result<std::vector<std::pair<int64_t,
+                                                                                      int64_t>>> {
+    std::promise<ReadOutcome> promise;
+    auto future = promise.get_future();
+    ybthin_read_op op = {};
+    op.table = table;
+    op.spec = spec;
+    ybthin_read_async(client, &op, 1, /* read_time_ht= */ 0, &OnReadDone, &promise);
+    auto out = future.get();
+    SCHECK_EQ(out.code, YBTHIN_OK, IllegalState, out.message);
+    std::vector<std::pair<int64_t, int64_t>> rows;
+    for (size_t r = 0; r < out.n_rows; ++r) {
+      rows.emplace_back(out.cells[r * out.n_cols].i, out.cells[r * out.n_cols + 1].i);
+    }
+    return rows;
+  };
+
+  // ---- Bug 1: descending, limit 1, one page, at every prefix depth ----------
+  const ybthin_bind prefix[] = {text_b(), i16(0), i64(3), i64(200)};
+  struct Probe { size_t n; int64_t want_segno, want_offset; const char* id; };
+  for (const auto& p : {Probe{1, 5, 300, "L2 ['b']"},
+                        Probe{2, 5, 300, "L3 ['b',0]"},
+                        Probe{3, 3, 300, "L4 ['b',0,3]"},
+                        Probe{4, 3, 200, "L5 ['b',0,3,200] (full key)"}}) {
+    ybthin_read_spec spec = {};
+    spec.range_values = prefix;
+    spec.n_range = p.n;
+    spec.target_ids = targets;
+    spec.n_targets = 2;
+    spec.limit = 1;
+    spec.is_forward_scan = 0;
+    auto rows = ASSERT_RESULT(first_page(spec));
+    ASSERT_EQ(rows.size(), 1u) << p.id << ": descending limit 1 returned " << rows.size()
+                               << " rows on the first page";
+    EXPECT_EQ(rows[0].first, p.want_segno) << p.id;
+    EXPECT_EQ(rows[0].second, p.want_offset) << p.id;
+  }
+
+  // ---- Bug 2: an Eq/Lt cond on segno, the key column after the prefix -------
+  const ybthin_bind pfx2[] = {text_b(), i16(0)};
+  {
+    ybthin_cond eq[] = {{segno_id, YBTHIN_EQ, i64(3)}};
+    ybthin_read_spec spec = {};
+    spec.range_values = pfx2;
+    spec.n_range = 2;
+    spec.conds = eq;
+    spec.n_conds = 1;
+    spec.target_ids = targets;
+    spec.n_targets = 2;
+    spec.limit = 10;
+    spec.is_forward_scan = 1;
+    auto fwd = ASSERT_RESULT(first_page(spec));
+    ASSERT_EQ(fwd.size(), 4u) << "L6: forward Eq cond on segno (3rd key column)";
+
+    spec.limit = 1;
+    spec.is_forward_scan = 0;
+    auto rev = ASSERT_RESULT(first_page(spec));
+    ASSERT_EQ(rev.size(), 1u) << "D: descending Eq cond on segno";
+    EXPECT_EQ(rev[0].first, 3);
+    EXPECT_EQ(rev[0].second, 300);
+  }
+  {
+    // Cond on the LAST key column already works; lock it in.
+    ybthin_cond lt[] = {{chunk_id, YBTHIN_LT, i64(250)}};
+    ybthin_read_spec spec = {};
+    spec.range_values = pfx2;
+    spec.n_range = 2;
+    spec.conds = lt;
+    spec.n_conds = 1;
+    spec.target_ids = targets;
+    spec.n_targets = 2;
+    spec.limit = 1;
+    spec.is_forward_scan = 0;
+    auto rows = ASSERT_RESULT(first_page(spec));
+    ASSERT_EQ(rows.size(), 1u) << "I: descending cond on chunk_offset";
+    EXPECT_EQ(rows[0].first, 5);
+    EXPECT_EQ(rows[0].second, 200);
+  }
+
+  // ---- L7: is the short first page just a tablet boundary, or a lost scan? --
+  // Reported as inconclusive: `segno < 4` forward returned 4 rows, which is exactly tablet 1's
+  // contribution, so it is a legitimate first page IF the scan continues. Page it out and count.
+  // This also separates Bug 2 from a paging artefact: Lt gets rows through where Eq returns none.
+  {
+    ybthin_cond lt[] = {{segno_id, YBTHIN_LT, i64(4)}};
+    ybthin_read_spec spec = {};
+    spec.range_values = pfx2;
+    spec.n_range = 2;
+    spec.conds = lt;
+    spec.n_conds = 1;
+    spec.target_ids = targets;
+    spec.n_targets = 2;
+    spec.limit = 10;
+    spec.is_forward_scan = 1;
+
+    std::vector<std::pair<int64_t, int64_t>> all;
+    std::vector<uint8_t> ps;
+    int pages = 0;
+    do {
+      std::promise<ReadOutcome> promise;
+      auto future = promise.get_future();
+      ybthin_read_op op = {};
+      op.table = table;
+      op.spec = spec;
+      op.paging_state_in = ps.empty() ? nullptr : ps.data();
+      op.paging_state_in_len = ps.size();
+      ybthin_read_async(client, &op, 1, /* read_time_ht= */ 0, &OnReadDone, &promise);
+      auto out = future.get();
+      ASSERT_EQ(out.code, YBTHIN_OK) << out.message;
+      for (size_t r = 0; r < out.n_rows; ++r) {
+        all.emplace_back(out.cells[r * out.n_cols].i, out.cells[r * out.n_cols + 1].i);
+      }
+      ps = std::move(out.paging_state);
+      ASSERT_LT(++pages, 20) << "L7 paging did not terminate";
+    } while (!ps.empty());
+
+    // segno 1,2,3 x chunk_offset 0,100,200,300, and nothing from branch 'a' or 'c'.
+    ASSERT_EQ(all.size(), 12u)
+        << "L7: `segno < 4` paged to exhaustion returned " << all.size() << " rows over " << pages
+        << " pages; a short FIRST page is only a tablet boundary if the scan then continues";
+    for (const auto& [segno, offset] : all) {
+      EXPECT_LT(segno, 4);
+      EXPECT_GE(segno, 1);
+    }
   }
 
   ybthin_columns_free(info.columns, info.n_columns);

--- a/src/yb/thin_client/yb_thin_client-itest.cc
+++ b/src/yb/thin_client/yb_thin_client-itest.cc
@@ -935,6 +935,112 @@ TEST_F(PgThinClientTest, RangeShardedDescendingPrefixSinglePage) {
   ybthin_client_destroy(client);
 }
 
+// Deep range keys. Range-partitioning the wider tables would need prefixes 7-8 columns deep --
+// amp_storage.pages is 5 hash + 3 range, pending_gc 2 hash + 5 range -- well past the 4 columns the
+// other tests cover. Nothing in the routing is depth-limited, so this pins that down. Also asserts
+// the null-key guard, since DocDB forbids nulls in the range key prefix.
+TEST_F(PgThinClientTest, DeepRangeKeyPrefixes) {
+  auto conn = ASSERT_RESULT(Connect());
+  ASSERT_OK(conn.Execute(
+      "CREATE TABLE deep (k1 TEXT, k2 SMALLINT, k3 BIGINT, k4 BIGINT, k5 INT, k6 INT, k7 INT,"
+      "  k8 INT, v BYTEA, PRIMARY KEY (k1 ASC, k2 ASC, k3 ASC, k4 ASC, k5 ASC, k6 ASC, k7 ASC,"
+      "  k8 ASC)) SPLIT AT VALUES (('b', 0, 2), ('b', 0, 4))"));
+  // k3 varies 1..5 across the split points, k8 varies 0..3 within each; k4..k7 are fixed at 7 so a
+  // deep prefix has to carry them to reach a row.
+  ASSERT_OK(conn.Execute(
+      "INSERT INTO deep SELECT 'b', 0, s, 7, 7, 7, 7, o, '\\x07'::bytea "
+      "FROM generate_series(1,5) s, generate_series(0,3) o"));
+  ASSERT_OK(conn.Execute(
+      "INSERT INTO deep VALUES ('a',0,9,7,7,7,7,0,'\\x0a'::bytea),"
+      " ('c',0,9,7,7,7,7,0,'\\x0c'::bytea)"));
+
+  const auto db_oid = ASSERT_RESULT(FetchOid(&conn, "SELECT oid FROM pg_database "
+                                                     "WHERE datname = current_database()"));
+  const auto table_oid = ASSERT_RESULT(FetchOid(&conn, "SELECT 'deep'::regclass::oid"));
+  const auto addr = TServerAddr();
+  const char* addrs[] = {addr.c_str()};
+  ybthin_client* client = nullptr;
+  {
+    auto st = ybthin_client_create(
+        addrs, 1, nullptr, nullptr, 60000, 0, &client);
+    ASSERT_EQ(st.code, YBTHIN_OK) << (st.message ? st.message : "");
+  }
+  ybthin_table* table = nullptr;
+  ybthin_table_info info = {};
+  {
+    auto st = ybthin_table_open(client, db_oid, table_oid, &table, &info);
+    ASSERT_EQ(st.code, YBTHIN_OK) << (st.message ? st.message : "");
+  }
+  ASSERT_EQ(info.n_columns, 9);
+  for (int i = 0; i < 8; ++i) {
+    ASSERT_EQ(info.columns[i].kind, YBTHIN_COL_RANGE) << "key column " << i;
+  }
+  const int32_t k3_id = info.columns[2].id, k8_id = info.columns[7].id;
+
+  const std::string branch = "b";
+  const ybthin_bind prefix[] = {
+      {YBTHIN_BIND_TEXT, 0, reinterpret_cast<const uint8_t*>(branch.data()), branch.size()},
+      {YBTHIN_BIND_I16, 0, nullptr, 0},   // k2 = 0
+      {YBTHIN_BIND_I64, 3, nullptr, 0},   // k3 = 3
+      {YBTHIN_BIND_I64, 7, nullptr, 0},   // k4
+      {YBTHIN_BIND_I32, 7, nullptr, 0},   // k5
+      {YBTHIN_BIND_I32, 7, nullptr, 0},   // k6
+      {YBTHIN_BIND_I32, 7, nullptr, 0},   // k7
+      {YBTHIN_BIND_I32, 2, nullptr, 0}};  // k8 = 2 -> the full key
+  int32_t targets[] = {k3_id, k8_id};
+
+  auto one_page = [&](size_t n_range, int forward) -> Result<size_t> {
+    ybthin_read_spec spec = {};
+    spec.range_values = prefix;
+    spec.n_range = n_range;
+    spec.target_ids = targets;
+    spec.n_targets = 2;
+    spec.limit = 10;
+    spec.is_forward_scan = forward;
+    std::promise<ReadOutcome> promise;
+    auto future = promise.get_future();
+    ybthin_read_op op = {};
+    op.table = table;
+    op.spec = spec;
+    ybthin_read_async(client, &op, 1, 0, &OnReadDone, &promise);
+    auto out = future.get();
+    SCHECK_EQ(out.code, YBTHIN_OK, IllegalState, out.message);
+    return out.n_rows;
+  };
+
+  // Depths 3..8 all address the same 4 rows (k3=3, k8=0..3) until the full key narrows to 1.
+  for (size_t n = 3; n <= 8; ++n) {
+    const size_t want = (n == 8) ? 1 : 4;
+    auto fwd = ASSERT_RESULT(one_page(n, 1));
+    auto rev = ASSERT_RESULT(one_page(n, 0));
+    ASSERT_EQ(fwd, want) << "forward, " << n << "-column prefix";
+    ASSERT_EQ(rev, want) << "reverse, " << n << "-column prefix returned " << rev
+                         << " on the first page";
+  }
+
+  // Null in the key prefix is rejected, not bound.
+  {
+    ybthin_bind with_null[] = {prefix[0], {YBTHIN_BIND_NULL, 0, nullptr, 0}};
+    ybthin_read_spec spec = {};
+    spec.range_values = with_null;
+    spec.n_range = 2;
+    spec.target_ids = targets;
+    spec.n_targets = 2;
+    std::promise<ReadOutcome> promise;
+    auto future = promise.get_future();
+    ybthin_read_op op = {};
+    op.table = table;
+    op.spec = spec;
+    ybthin_read_async(client, &op, 1, 0, &OnReadDone, &promise);
+    auto out = future.get();
+    ASSERT_EQ(out.code, YBTHIN_INVALID) << "a null range key value must be rejected";
+  }
+
+  ybthin_columns_free(info.columns, info.n_columns);
+  ybthin_table_close(table);
+  ybthin_client_destroy(client);
+}
+
 // TLS variant: the cluster runs with node-to-node encryption, and the thin client connects over TLS
 // authenticating the server against the test CA. Also asserts the TLS-only endpoint rejects a
 // plaintext client.

--- a/src/yb/thin_client/yb_thin_client-itest.cc
+++ b/src/yb/thin_client/yb_thin_client-itest.cc
@@ -16,6 +16,7 @@
 // reads against ordinary SQL through the same tserver.
 
 #include <algorithm>
+#include <functional>
 #include <array>
 #include <future>
 #include <string>
@@ -514,6 +515,52 @@ TEST_F(PgThinClientTest, RangeShardedTable) {
     ASSERT_EQ(seen.size(), static_cast<size_t>(kNumRows))
         << "scan did not cover every tablet: an unset/stale partition key routes the continuation "
            "back to the first tablet, so the scan stops at that tablet's last row";
+    EXPECT_EQ(seen.front(), 0);
+    EXPECT_EQ(seen.back(), kNumRows - 1);
+  }
+
+  // ---- backward paged scan must also cross every tablet, in reverse --------
+  // A backward scan starts at the LAST tablet, so its partition key needs the extra adjustment
+  // GetPartitionKeyForBackwardScan makes; without it the scan starts at the first tablet and
+  // returns only that tablet's rows.
+  {
+    int32_t target_ids[] = {r_id};
+    ybthin_read_spec spec = {};
+    spec.target_ids = target_ids;
+    spec.n_targets = 1;
+    spec.limit = kPageLimit;
+    spec.is_forward_scan = 0;
+
+    std::vector<int32_t> seen;
+    std::vector<uint8_t> paging_state;
+    int pages = 0;
+    do {
+      std::promise<ReadOutcome> promise;
+      auto future = promise.get_future();
+      ybthin_read_op op = {};
+      op.table = table;
+      op.spec = spec;
+      op.paging_state_in = paging_state.empty() ? nullptr : paging_state.data();
+      op.paging_state_in_len = paging_state.size();
+      ybthin_read_async(client, &op, 1, /* read_time_ht= */ 0, &OnReadDone, &promise);
+      auto out = future.get();
+      ASSERT_EQ(out.code, YBTHIN_OK) << out.message;
+      for (size_t i = 0; i < out.n_rows; ++i) {
+        ASSERT_EQ(out.cells[i].tag, YBTHIN_BIND_I32);
+        seen.push_back(static_cast<int32_t>(out.cells[i].i));
+      }
+      paging_state = std::move(out.paging_state);
+      ++pages;
+      ASSERT_LT(pages, 100) << "backward paging did not terminate";
+    } while (!paging_state.empty());
+
+    // Rows must arrive descending, and the scan must have covered the whole table.
+    ASSERT_TRUE(std::is_sorted(seen.begin(), seen.end(), std::greater<int32_t>()))
+        << "backward scan did not return rows in descending order";
+    std::sort(seen.begin(), seen.end());
+    seen.erase(std::unique(seen.begin(), seen.end()), seen.end());
+    ASSERT_EQ(seen.size(), static_cast<size_t>(kNumRows))
+        << "backward scan did not cover every tablet";
     EXPECT_EQ(seen.front(), 0);
     EXPECT_EQ(seen.back(), kNumRows - 1);
   }

--- a/src/yb/thin_client/yb_thin_client-itest.cc
+++ b/src/yb/thin_client/yb_thin_client-itest.cc
@@ -15,6 +15,7 @@
 // table_open (schema check) -> upsert_batch -> paged read, and cross-checks the shim's writes and
 // reads against ordinary SQL through the same tserver.
 
+#include <algorithm>
 #include <array>
 #include <future>
 #include <string>
@@ -278,6 +279,113 @@ class PgThinClientTest : public PgMiniTestBase {
 
 TEST_F(PgThinClientTest, OpenUpsertReadPaged) {
   RunOpenUpsertReadPaged(/* tls= */ nullptr);
+}
+
+// Regression test for row drops across page boundaries.
+//
+// A paged scan must observe ONE consistent snapshot for its whole duration -- every row that
+// existed when the scan started must be returned, even if it is deleted while the scan is still
+// paging. This test starts a scan, then commits a DELETE of the not-yet-scanned tail between the
+// first and second pages; a snapshot-consistent scan must still return those rows (the delete is
+// after the scan's snapshot), so nothing is dropped mid-scan.
+//
+// It continues the scan by only passing the server's paging_state back (read_time_ht == 0 on every
+// call -- the natural "just keep paging" usage, and exactly what OpenUpsertReadPaged above does).
+// The shim advances its per-session read_time_serial on every Perform, including continuations,
+// which makes the server's ENSURE_READ_TIME_IS_SET pick a FRESH (current) read time for each page
+// (pg_client_session.cc ProcessReadTimeManipulation) instead of restoring page 1's; that fresh time
+// is forwarded to the tablet as an explicit read time, so DocDB ignores the read time embedded in
+// the paging_state (pgsql_operation.cc, guarded by !is_explicit_request_read_time) and continues
+// the scan at the newer snapshot. Rows deleted between pages therefore vanish from the result --
+// the "paged scan drops rows across a page boundary" failure this guards against.
+TEST_F(PgThinClientTest, PagedReadHoldsSnapshotAcrossPages) {
+  constexpr int kHashKey = 7;
+  constexpr int kNumRows = 200;          // v in [0, 199]
+  constexpr int kDeleteFrom = 100;       // rows v in [100, 199] deleted after page 1
+  constexpr uint64_t kPageLimit = 50;    // forces several pages (first page returns v in [0, 49])
+
+  auto conn = ASSERT_RESULT(Connect());
+  ASSERT_OK(conn.Execute("CREATE TABLE p (k int, v int, PRIMARY KEY((k) HASH, v))"));
+  ASSERT_OK(conn.ExecuteFormat(
+      "INSERT INTO p SELECT $0, gs FROM generate_series(0, $1) gs", kHashKey, kNumRows - 1));
+
+  const auto db_oid = ASSERT_RESULT(FetchOid(&conn, "SELECT oid FROM pg_database "
+                                                     "WHERE datname = current_database()"));
+  const auto table_oid = ASSERT_RESULT(FetchOid(&conn, "SELECT 'p'::regclass::oid"));
+
+  const auto addr = TServerAddr();
+  const char* addrs[] = {addr.c_str()};
+  ybthin_client* client = nullptr;
+  {
+    auto st = ybthin_client_create(
+        addrs, 1, /* tls= */ nullptr, /* pool= */ nullptr, /* rpc_timeout_ms= */ 60000,
+        /* num_reactors= */ 0, &client);
+    ASSERT_EQ(st.code, YBTHIN_OK) << (st.message ? st.message : "");
+  }
+  ybthin_table* table = nullptr;
+  ybthin_table_info info = {};
+  {
+    auto st = ybthin_table_open(client, db_oid, table_oid, &table, &info);
+    ASSERT_EQ(st.code, YBTHIN_OK) << (st.message ? st.message : "");
+  }
+  const int32_t v_id = info.columns[1].id;
+
+  ybthin_bind hash_values[] = {I32(kHashKey)};
+  int32_t target_ids[] = {v_id};
+  ybthin_read_spec spec = {};
+  spec.hash_values = hash_values;
+  spec.n_hash = 1;
+  spec.target_ids = target_ids;
+  spec.n_targets = 1;
+  spec.limit = kPageLimit;
+  spec.is_forward_scan = 1;
+
+  std::vector<int32_t> seen;
+  std::vector<uint8_t> paging_state;
+  int pages = 0;
+  bool deleted = false;
+  do {
+    std::promise<ReadOutcome> promise;
+    auto future = promise.get_future();
+    ybthin_read_op op = {};
+    op.table = table;
+    op.spec = spec;
+    op.paging_state_in = paging_state.empty() ? nullptr : paging_state.data();
+    op.paging_state_in_len = paging_state.size();
+    // Continue the scan with just the paging_state (read_time_ht == 0): the scan must stay on its
+    // original snapshot on its own, not silently jump to a newer one on each page.
+    ybthin_read_async(client, &op, 1, /* read_time_ht= */ 0, &OnReadDone, &promise);
+    auto out = future.get();
+    ASSERT_EQ(out.code, YBTHIN_OK) << out.message;
+    for (size_t r = 0; r < out.n_rows; ++r) {
+      const DecodedCell& v_cell = out.cells[r * out.n_cols + 0];
+      ASSERT_EQ(v_cell.tag, YBTHIN_BIND_I32);
+      seen.push_back(static_cast<int32_t>(v_cell.i));
+    }
+    paging_state = std::move(out.paging_state);
+    ++pages;
+    // After the first page, commit a delete of the not-yet-scanned tail. A scan that holds its
+    // snapshot must still return these rows on later pages.
+    if (!deleted) {
+      ASSERT_OK(conn.ExecuteFormat(
+          "DELETE FROM p WHERE k = $0 AND v >= $1", kHashKey, kDeleteFrom));
+      deleted = true;
+    }
+    ASSERT_LT(pages, 100) << "paging did not terminate";
+  } while (!paging_state.empty());
+
+  std::sort(seen.begin(), seen.end());
+  seen.erase(std::unique(seen.begin(), seen.end()), seen.end());
+  ASSERT_GT(pages, 1) << "expected the scan to span multiple pages at limit " << kPageLimit;
+  ASSERT_EQ(seen.size(), static_cast<size_t>(kNumRows))
+      << "paged scan dropped rows across a page boundary: the concurrent delete of v >= "
+      << kDeleteFrom << " became visible mid-scan, so the scan did not hold its snapshot";
+  EXPECT_EQ(seen.front(), 0);
+  EXPECT_EQ(seen.back(), kNumRows - 1);
+
+  ybthin_columns_free(info.columns, info.n_columns);
+  ybthin_table_close(table);
+  ybthin_client_destroy(client);
 }
 
 // TLS variant: the cluster runs with node-to-node encryption, and the thin client connects over TLS

--- a/src/yb/thin_client/yb_thin_client.cc
+++ b/src/yb/thin_client/yb_thin_client.cc
@@ -139,6 +139,12 @@ struct ybthin_client {
   std::vector<std::unique_ptr<ybthin_session>> write_sessions;
   std::atomic<size_t> read_rr{0};   // round-robin cursor for read-session selection
   std::atomic<size_t> write_rr{0};  // round-robin cursor for write-session selection
+  // A fresh txn_serial_no is stamped on every Perform. The server keeps a plain session's read
+  // point (and transaction) alive across Performs that carry the SAME txn_serial_no, so a constant
+  // would freeze the read point at the first read -- reads would never see later commits. Advancing
+  // it per Perform makes each one a fresh logical transaction that picks a new read point (this is
+  // what pggate/yb_tsclient do; see pg_client_session.cc gating on txn_serial_no_).
+  std::atomic<uint64_t> txn_serial{1};
   std::vector<HostPort> hosts;
   MonoDelta timeout;
   int num_reactors = kDefaultNumReactors;
@@ -601,9 +607,14 @@ void FinishRead(ReadCall* raw) {
 
   auto* result = static_cast<ybthin_read_result*>(calloc(1, sizeof(ybthin_read_result)));
   result->n_ops = n_ops;
-  result->used_read_time_ht = call->used_read_time_ht;
   result->results = static_cast<ybthin_read_op_result*>(
       calloc(n_ops ? n_ops : 1, sizeof(ybthin_read_op_result)));
+
+  // The hybrid time the batch actually ran at (all ops share one snapshot). For a pinned batch it
+  // is the caller's read_time_ht; for a fresh (read_time_ht == 0) batch the server picks it and
+  // reports it in the paging state -- surface it so the caller can pin follow-up pages/batches to
+  // the same snapshot.
+  uint64_t picked_read_ht = 0;
 
   for (size_t i = 0; i < n_ops; ++i) {
     const auto& op = call->resp.responses(static_cast<int>(i));
@@ -631,6 +642,11 @@ void FinishRead(ReadCall* raw) {
     // A missing paging_state means this op's scan is exhausted; otherwise wrap the server's paging
     // state with the pinning header so a continuation returns to this batch's session.
     if (op.has_paging_state()) {
+      // The server stamps the snapshot it chose into the paging state; capture it as the batch's
+      // used read time (all ops ran at one snapshot).
+      if (op.paging_state().read_time().has_read_ht()) {
+        picked_read_ht = op.paging_state().read_time().read_ht();
+      }
       std::string srv;
       op.paging_state().SerializeToString(&srv);
       std::string wrapped = WrapPagingState(call->session_index, call->generation, srv);
@@ -638,6 +654,9 @@ void FinishRead(ReadCall* raw) {
       op_result.paging_state_len = wrapped.size();
     }
   }
+  // Pinned batch: echo the caller's read_time_ht. Fresh batch: report the server-picked time.
+  result->used_read_time_ht =
+      call->used_read_time_ht != 0 ? call->used_read_time_ht : picked_read_ht;
   call->cb(call->ctx, OkStatus(), result);
 }
 
@@ -1008,13 +1027,17 @@ void ybthin_read_async(
     }
   }
 
-  // One snapshot for the whole batch: read_time_ht == 0 lets the server set a clamped read point
-  // (relaxed read-after-commit); otherwise pin read == global_limit so all ops see one snapshot.
+  // One snapshot for the whole batch.
   auto* rto = req.mutable_options()->mutable_read_time_options();
   if (read_time_ht == 0) {
+    // Fresh read point for this batch: ensure a read time is set (the fresh txn_serial_no stamped
+    // at dispatch already dropped any prior read point, so the server picks a current one here).
+    // This mirrors yb_tsclient's plain-read path. Read-after-write correctness comes from the fresh
+    // txn_serial_no, not from this manipulation alone.
     rto->set_read_time_manipulation(tserver::ENSURE_READ_TIME_IS_SET);
-    rto->set_clamp_uncertainty_window(true);
   } else {
+    // Pin the batch to an explicit snapshot (e.g. paged-scan continuation, or a second batch that
+    // must observe the same snapshot as a prior one via its used_read_time_ht).
     auto* rt = rto->mutable_read_time();
     rt->set_read_ht(read_time_ht);
     rt->set_global_limit_ht(read_time_ht);
@@ -1042,6 +1065,8 @@ void ybthin_read_async(
       for (auto& op : *raw->req.mutable_ops()) {
         op.mutable_read()->set_stmt_id(s->stmt_id++);
       }
+      // Fresh transaction per Perform so the server does not reuse this session's prior read point.
+      raw->req.mutable_options()->set_txn_serial_no(client->txn_serial.fetch_add(1));
       raw->req.set_session_id(s->session_id);
       raw->req.set_serial_no(s->serial_no++);
       dispatch = true;
@@ -1137,6 +1162,8 @@ void ybthin_upsert_batch_async(
       const uint64_t serial = s->read_time_serial++;
       rto->set_read_time_serial_no(serial);
       rto->set_read_time_serial_no_history_min(serial);
+      // Fresh transaction per Perform (stateless writes), matching the read path and yb_tsclient.
+      raw->req.mutable_options()->set_txn_serial_no(client->txn_serial.fetch_add(1));
       raw->req.set_session_id(s->session_id);
       raw->req.set_serial_no(s->serial_no++);
       dispatch = true;

--- a/src/yb/thin_client/yb_thin_client.cc
+++ b/src/yb/thin_client/yb_thin_client.cc
@@ -1,0 +1,1157 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+// yb_thin_client.cc — a thin, Perform-based YugabyteDB tserver client.
+//
+// Implements the C ABI in yb_thin_client.h by speaking yb.tserver.PgClientService.Perform
+// directly to a tserver RPC endpoint via PgClientServiceProxy. There is deliberately NO YBClient /
+// YBSession / Batcher / metacache / TabletInvoker: each op carries its own partition routing info
+// (hash_code + partition_key) and the tserver routes it, exactly as it does for pggate.
+//
+// BACKWARD COMPATIBILITY: this library is shipped and consumed outside the YugabyteDB build and is
+// upgraded before the tserver, so it must keep working against an OLDER tserver than it was
+// compiled against. Keep the wire usage backward-compatible: only send request fields / rely on
+// RPCs and semantics the oldest supported tserver understands, and tolerate responses that lack
+// fields a newer server would set. Keep the C ABI (see yb_thin_client.h) additive-only.
+//
+
+#include "yb/thin_client/yb_thin_client.h"
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <memory>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "yb/common/common.pb.h"
+#include "yb/common/common_types.pb.h"
+#include "yb/common/entity_ids.h"
+#include "yb/common/pgsql_protocol.pb.h"
+#include "yb/common/ql_type.h"
+#include "yb/common/schema.h"
+#include "yb/common/schema_pbutil.h"
+#include "yb/common/value.pb.h"
+#include "yb/common/wire_protocol.h"
+
+#include "yb/dockv/partition.h"
+
+#include "yb/master/master_ddl.pb.h"
+
+#include "yb/rpc/messenger.h"
+#include "yb/rpc/proxy.h"
+#include "yb/rpc/rpc_controller.h"
+#include "yb/rpc/secure.h"
+#include "yb/rpc/secure_stream.h"
+
+#include "yb/tserver/pg_client.pb.h"
+#include "yb/tserver/pg_client.proxy.h"
+
+#include "yb/yql/pggate/util/pg_doc_data.h"
+#include "yb/yql/pggate/util/pg_wire.h"
+
+#include "yb/util/monotime.h"
+#include "yb/util/net/net_util.h"
+#include "yb/util/ref_cnt_buffer.h"
+#include "yb/util/result.h"
+#include "yb/util/slice.h"
+#include "yb/util/status.h"
+#include "yb/util/status_format.h"
+
+using yb::DataType;
+using yb::HostPort;
+using yb::MonoDelta;
+using yb::RefCntSlice;
+using yb::Result;
+using yb::Schema;
+using yb::Slice;
+using yb::Status;
+using yb::dockv::PartitionSchema;
+
+namespace tserver = yb::tserver;
+namespace rpc = yb::rpc;
+namespace pggate = yb::pggate;
+
+// Default tserver RPC port used when a "host" is passed without ":port".
+static constexpr uint16_t kDefaultTserverRpcPort = 9100;
+// Session keepalive cadence — well inside the server's default expiry window.
+static constexpr int kKeepaliveIntervalMs = 10000;
+static constexpr int kDefaultRpcTimeoutMs = 60000;
+static constexpr int kDefaultNumReactors = 4;
+// Default pool shape (see ybthin_pool_opts): concurrency from multiple sessions, packed 4 per
+// connection so a small pool opens a single connection.
+static constexpr uint32_t kDefaultReadSessions = 4;
+static constexpr uint32_t kDefaultWriteSessions = 1;
+static constexpr uint32_t kDefaultSessionsPerConn = 4;
+
+// ---- opaque handles -------------------------------------------------------
+
+// One connection to a tserver: its own messenger (hence its own socket, so N connections spread
+// across tserver nodes behind a ClusterIP VIP) and a PgClientServiceProxy. Sessions are packed onto
+// connections.
+struct ybthin_connection {
+  std::unique_ptr<rpc::Messenger> messenger;
+  std::unique_ptr<rpc::ProxyCache> proxy_cache;
+  std::unique_ptr<tserver::PgClientServiceProxy> proxy;
+  HostPort host;
+};
+
+// One PgClientService session. The server serializes a session's Performs by a contiguous serial
+// starting at 0 (pg_client_service.cc next_expected_serial_no_), so serial_no / read_time_serial /
+// stmt_id are per-session and serial_no MUST start at 0 and be allocated only for dispatched
+// Performs (a gap stalls later Performs until their deadline). `generation` identifies this
+// incarnation: a paged scan pinned to (session, generation) becomes invalid once the session is
+// reopened with a fresh session_id (serials reset), so continuations on a stale generation are
+// reported as YBTHIN_READ_RESTART.
+struct ybthin_session {
+  size_t conn_index = 0;
+  std::mutex mu;  // guards {open, session_id, serial_no, read_time_serial, stmt_id, generation}
+  bool open = false;
+  uint32_t generation = 0;
+  uint64_t session_id = 0;
+  uint64_t serial_no = 0;
+  uint64_t read_time_serial = 1;
+  uint64_t stmt_id = 1;
+};
+
+struct ybthin_client {
+  std::unique_ptr<rpc::SecureContext> secure_context;  // null for plaintext; shared by all conns
+  std::vector<std::unique_ptr<ybthin_connection>> connections;
+  std::vector<std::unique_ptr<ybthin_session>> read_sessions;
+  std::vector<std::unique_ptr<ybthin_session>> write_sessions;
+  std::atomic<size_t> read_rr{0};   // round-robin cursor for read-session selection
+  std::atomic<size_t> write_rr{0};  // round-robin cursor for write-session selection
+  std::vector<HostPort> hosts;
+  MonoDelta timeout;
+  int num_reactors = kDefaultNumReactors;
+
+  // Keepalive. Deliberately std::thread, not yb::Thread: this .so is self-contained and must not
+  // pull in YB's global thread registry / tracking machinery for a single background heartbeat.
+  std::thread keepalive_thread;  // NOLINT(build/std_thread)
+  std::mutex mu;
+  std::condition_variable cv;
+  bool stop = false;
+};
+
+struct ybthin_table {
+  struct ColInfo {
+    std::string name;
+    int32_t id;
+    ybthin_col_kind kind;
+    ybthin_value_type type;
+  };
+  std::string table_id;
+  uint32_t schema_version = 0;
+  size_t num_hash_key_columns = 0;
+  size_t num_key_columns = 0;
+  Schema schema;
+  PartitionSchema partition_schema;
+  std::vector<ColInfo> columns;  // owns the name strings referenced by ybthin_column
+};
+
+namespace {
+
+// ---- allocation helpers (all shim-returned buffers use malloc/free) --------
+
+char* DupCString(const std::string& s) {
+  char* p = static_cast<char*>(malloc(s.size() + 1));
+  if (p) {
+    memcpy(p, s.data(), s.size());
+    p[s.size()] = '\0';
+  }
+  return p;
+}
+
+uint8_t* DupBytes(const void* data, size_t len) {
+  if (len == 0) {
+    return nullptr;
+  }
+  uint8_t* p = static_cast<uint8_t*>(malloc(len));
+  if (p) {
+    memcpy(p, data, len);
+  }
+  return p;
+}
+
+// ---- status helpers -------------------------------------------------------
+
+ybthin_status OkStatus() { return ybthin_status{YBTHIN_OK, nullptr}; }
+
+ybthin_status MakeStatus(ybthin_status_code code, const std::string& msg) {
+  return ybthin_status{code, code == YBTHIN_OK ? nullptr : DupCString(msg)};
+}
+
+ybthin_status_code ClassifyStatus(const Status& s) {
+  if (s.ok()) return YBTHIN_OK;
+  if (s.IsTimedOut() || s.IsNetworkError() || s.IsRemoteError()) return YBTHIN_NETWORK;
+  if (s.IsTryAgain() || s.IsServiceUnavailable() || s.IsBusy()) return YBTHIN_TRY_AGAIN;
+  if (s.IsInvalidArgument() || s.IsNotSupported()) return YBTHIN_INVALID;
+  return YBTHIN_OTHER;
+}
+
+ybthin_status FromStatus(const Status& s) {
+  if (s.ok()) return OkStatus();
+  auto code = ClassifyStatus(s);
+  const auto msg = s.ToString();
+  // A dropped/expired session surfaces as an app error; steer the caller to reconnect.
+  if (code == YBTHIN_OTHER || code == YBTHIN_INVALID) {
+    if (msg.find("ession") != std::string::npos &&
+        (msg.find("nknown") != std::string::npos || msg.find("xpired") != std::string::npos)) {
+      code = YBTHIN_NETWORK;
+    }
+  }
+  return MakeStatus(code, msg);
+}
+
+// ---- value / condition encoding -------------------------------------------
+
+Status BindToQLValue(const ybthin_bind& b, yb::QLValuePB* out) {
+  switch (b.tag) {
+    case YBTHIN_BIND_NULL:
+      return Status::OK();  // absent oneof == SQL NULL
+    case YBTHIN_BIND_BOOL:
+      out->set_bool_value(b.i != 0);
+      return Status::OK();
+    case YBTHIN_BIND_I16:
+      out->set_int16_value(static_cast<int32_t>(b.i));
+      return Status::OK();
+    case YBTHIN_BIND_I32:
+      out->set_int32_value(static_cast<int32_t>(b.i));
+      return Status::OK();
+    case YBTHIN_BIND_I64:
+      out->set_int64_value(b.i);
+      return Status::OK();
+    case YBTHIN_BIND_TEXT:
+      out->set_string_value(b.bytes, b.bytes_len);
+      return Status::OK();
+    case YBTHIN_BIND_BYTEA:
+      out->set_binary_value(b.bytes, b.bytes_len);
+      return Status::OK();
+  }
+  return STATUS_FORMAT(InvalidArgument, "bad bind tag $0", static_cast<int>(b.tag));
+}
+
+Result<yb::QLOperator> MapCondOp(ybthin_cond_op op) {
+  switch (op) {
+    case YBTHIN_EQ: return yb::QL_OP_EQUAL;
+    case YBTHIN_LE: return yb::QL_OP_LESS_THAN_EQUAL;
+    case YBTHIN_GE: return yb::QL_OP_GREATER_THAN_EQUAL;
+    case YBTHIN_LT: return yb::QL_OP_LESS_THAN;
+    case YBTHIN_GT: return yb::QL_OP_GREATER_THAN;
+  }
+  return STATUS_FORMAT(InvalidArgument, "bad cond op $0", static_cast<int>(op));
+}
+
+// Builds a single "<column> <op> <value>" comparison into `out`.
+Status BuildComparison(const ybthin_cond& c, yb::PgsqlExpressionPB* out) {
+  auto* cond = out->mutable_condition();
+  cond->set_op(VERIFY_RESULT(MapCondOp(c.op)));
+  cond->add_operands()->set_column_id(c.column_id);
+  return BindToQLValue(c.value, cond->add_operands()->mutable_value());
+}
+
+// Sets hash_code + partition_key from already-populated partition_column_values so the tserver can
+// route the op without a scan. No-op for a table with no hash columns.
+template <class ReqPB>
+Status SetPartitionRouting(const ybthin_table& table, ReqPB* req) {
+  if (req->partition_column_values().empty()) {
+    return Status::OK();
+  }
+  auto partition_key = VERIFY_RESULT(
+      table.partition_schema.EncodePgsqlHash(req->partition_column_values()));
+  req->set_hash_code(PartitionSchema::DecodeMultiColumnHashValue(partition_key));
+  req->set_partition_key(std::move(partition_key));
+  return Status::OK();
+}
+
+Result<ybthin_value_type> MapDataType(DataType dt) {
+  switch (dt) {
+    case DataType::BOOL: return YBTHIN_T_BOOL;
+    case DataType::INT16: return YBTHIN_T_I16;
+    case DataType::INT32: return YBTHIN_T_I32;
+    case DataType::INT64: return YBTHIN_T_I64;
+    case DataType::STRING: return YBTHIN_T_TEXT;
+    case DataType::BINARY: return YBTHIN_T_BYTEA;
+    default:
+      return STATUS_FORMAT(NotSupported, "unsupported column data type $0", dt);
+  }
+}
+
+Result<std::string> ReadFile(const char* path) {
+  std::ifstream f(path, std::ios::binary);
+  if (!f) {
+    return STATUS_FORMAT(IOError, "cannot open $0", path);
+  }
+  std::stringstream ss;
+  ss << f.rdbuf();
+  return ss.str();
+}
+
+// Sends one Heartbeat. `create` true opens a new session (send pid); false keeps `session_id_`
+// alive. On success the assigned/echoed session id is returned.
+Result<uint64_t> DoHeartbeat(
+    const tserver::PgClientServiceProxy& proxy, const MonoDelta& timeout, bool create,
+    uint64_t session_id) {
+  tserver::PgHeartbeatRequestPB req;
+  if (create) {
+    req.set_pid(static_cast<uint32_t>(getpid()));
+  } else {
+    req.set_session_id(session_id);
+  }
+  tserver::PgHeartbeatResponsePB resp;
+  rpc::RpcController controller;
+  controller.set_timeout(timeout);
+  RETURN_NOT_OK(proxy.Heartbeat(req, &resp, &controller));
+  RETURN_NOT_OK(yb::ResponseStatus(resp));
+  return resp.session_id();
+}
+
+// ---- session pool ---------------------------------------------------------
+
+// (Re)opens a session on its connection: mints a fresh server session_id, resets the per-session
+// serial to 0, and bumps the generation so any scan pinned to the old incarnation is invalidated.
+// Caller must hold s->mu.
+Status OpenSession(ybthin_client* client, ybthin_session* s) {
+  auto& conn = *client->connections[s->conn_index];
+  auto sid = DoHeartbeat(*conn.proxy, client->timeout, /* create= */ true, /* session_id= */ 0);
+  RETURN_NOT_OK(sid);
+  s->session_id = *sid;
+  s->serial_no = 0;
+  ++s->generation;
+  s->open = true;
+  return Status::OK();
+}
+
+// Lazily reopens a session that was torn down by a prior network failure. Caller holds s->mu.
+Status EnsureSessionOpen(ybthin_client* client, ybthin_session* s) {
+  return s->open ? Status::OK() : OpenSession(client, s);
+}
+
+// A network-class failure means the server may have dropped the session; drop it so the next use
+// reopens with a fresh id (serials reset to 0).
+void MaybeMarkSessionDead(ybthin_session* s, const ybthin_status& st) {
+  if (st.code == YBTHIN_NETWORK) {
+    std::lock_guard<std::mutex> lock(s->mu);
+    s->open = false;
+  }
+}
+
+size_t NextReadIndex(ybthin_client* client) {
+  return client->read_rr.fetch_add(1, std::memory_order_relaxed) % client->read_sessions.size();
+}
+
+// Round-robins a write session; falls back to read sessions when there are none.
+ybthin_session* NextWriteSession(ybthin_client* client) {
+  auto& pool = client->write_sessions.empty() ? client->read_sessions : client->write_sessions;
+  return pool[client->write_rr.fetch_add(1, std::memory_order_relaxed) % pool.size()].get();
+}
+
+// Wrapped paging state = [magic][version][u32 read-session index][u32 generation] + the server's
+// paging state. The caller passes this back opaquely; on continuation the shim routes to the same
+// session (generation-checked), which is where the server's read point for the scan lives.
+constexpr uint8_t kPagingMagic = 0xB1;
+constexpr uint8_t kPagingVersion = 1;
+constexpr size_t kPagingHeaderLen = 2 + 4 + 4;
+
+void PutU32LE(std::string* s, uint32_t v) {
+  for (int i = 0; i < 4; ++i) s->push_back(static_cast<char>((v >> (8 * i)) & 0xff));
+}
+uint32_t GetU32LE(const uint8_t* p) {
+  uint32_t v = 0;
+  for (int i = 0; i < 4; ++i) v |= static_cast<uint32_t>(p[i]) << (8 * i);
+  return v;
+}
+
+std::string WrapPagingState(uint32_t session_index, uint32_t generation, const std::string& srv) {
+  std::string out;
+  out.reserve(kPagingHeaderLen + srv.size());
+  out.push_back(static_cast<char>(kPagingMagic));
+  out.push_back(static_cast<char>(kPagingVersion));
+  PutU32LE(&out, session_index);
+  PutU32LE(&out, generation);
+  out.append(srv);
+  return out;
+}
+
+struct PinInfo {
+  uint32_t session_index;
+  uint32_t generation;
+  Slice server_paging_state;
+};
+Result<PinInfo> UnwrapPagingState(const uint8_t* data, size_t len) {
+  if (len < kPagingHeaderLen || data[0] != kPagingMagic || data[1] != kPagingVersion) {
+    return STATUS(InvalidArgument, "malformed wrapped paging state");
+  }
+  return PinInfo{
+      GetU32LE(data + 2), GetU32LE(data + 6),
+      Slice(data + kPagingHeaderLen, len - kPagingHeaderLen)};
+}
+
+// Extracts the best human-readable message from a per-op response.
+std::string PgsqlResponseMessage(const yb::PgsqlResponsePB& r) {
+  if (r.error_status_size() > 0) {
+    return yb::StatusFromPB(r.error_status(0)).ToString();
+  }
+  if (r.has_error_message()) {
+    return r.error_message();
+  }
+  return "pgsql op failed";
+}
+
+// Maps a non-OK per-op response to a shim status.
+ybthin_status PgsqlResponseError(const yb::PgsqlResponsePB& r) {
+  switch (r.status()) {
+    case yb::PgsqlResponsePB::PGSQL_STATUS_RESTART_REQUIRED_ERROR:
+      return MakeStatus(YBTHIN_READ_RESTART, PgsqlResponseMessage(r));
+    case yb::PgsqlResponsePB::PGSQL_STATUS_SCHEMA_VERSION_MISMATCH:
+      return MakeStatus(YBTHIN_SCHEMA, PgsqlResponseMessage(r));
+    default:
+      if (r.error_status_size() > 0) {
+        return FromStatus(yb::StatusFromPB(r.error_status(0)));
+      }
+      return MakeStatus(YBTHIN_OTHER, PgsqlResponseMessage(r));
+  }
+}
+
+// ---- async call contexts --------------------------------------------------
+
+struct ReadCall {
+  ybthin_session* session;      // the one session this batch runs on
+  uint32_t session_index;       // its index into client->read_sessions (for wrapping)
+  uint32_t generation;          // session incarnation this batch ran at (for wrapping)
+  bool has_continuation;        // any op is a continuation -> its pinned session must still match
+  uint32_t pinned_generation;   // generation the continuation ops were pinned to
+  tserver::PgPerformRequestPB req;
+  tserver::PgPerformResponsePB resp;
+  rpc::RpcController controller;
+  ybthin_read_cb cb;
+  void* ctx;
+  uint64_t used_read_time_ht;
+  // Per-op target column value types, in target (== response cell) order. The
+  // row sidecar isn't self-describing, so decoding each op's response needs
+  // these; the shim has them from the opened tables' schemas.
+  std::vector<std::vector<ybthin_value_type>> op_target_types;
+};
+
+struct WriteCall {
+  ybthin_session* session;
+  tserver::PgPerformRequestPB req;
+  tserver::PgPerformResponsePB resp;
+  rpc::RpcController controller;
+  ybthin_write_cb cb;
+  void* ctx;
+};
+
+// Decodes the pg_doc_data row sidecar into a flat, row-major array of
+// (n_rows * target_types.size()) cells using YugabyteDB's own PgWire/PgDocData
+// readers (the single source of truth for the wire format). The cells and the
+// TEXT/BYTEA byte payloads they point into are returned as ONE malloc'd block
+// (the byte arena trails the cell array), so the caller frees it with a single
+// free(*out_cells). `target_types` gives each target column's type in target
+// (== cell) order, since the sidecar is not self-describing.
+Status DecodeReadRows(
+    Slice sidecar, const std::vector<ybthin_value_type>& target_types,
+    ybthin_cell** out_cells, size_t* out_n_rows) {
+  int64_t row_count = 0;
+  Slice cursor;
+  pggate::PgDocData::LoadCache(sidecar, &row_count, &cursor);
+  if (row_count < 0) {
+    return STATUS_FORMAT(Corruption, "negative row count $0", row_count);
+  }
+  const size_t n_cols = target_types.size();
+  const size_t n_cells = static_cast<size_t>(row_count) * n_cols;
+
+  std::vector<ybthin_cell> cells(n_cells);  // value-initialized: tag 0 == NULL, bytes null
+  std::string arena;                        // TEXT/BYTEA payloads, concatenated
+  struct ByteRef { size_t cell_idx; size_t off; size_t len; };
+  std::vector<ByteRef> byte_refs;
+
+  for (int64_t r = 0; r < row_count; ++r) {
+    for (size_t c = 0; c < n_cols; ++c) {
+      const size_t idx = static_cast<size_t>(r) * n_cols + c;
+      ybthin_cell& cell = cells[idx];
+      if (VERIFY_RESULT(pggate::PgDocData::CheckedReadHeaderIsNull(&cursor))) {
+        cell.tag = YBTHIN_BIND_NULL;
+        continue;
+      }
+      switch (target_types[c]) {
+        case YBTHIN_T_BOOL:
+          cell.tag = YBTHIN_BIND_BOOL;
+          cell.i = VERIFY_RESULT(pggate::PgWire::CheckedReadNumber<uint8_t>(&cursor));
+          break;
+        case YBTHIN_T_I16:
+          cell.tag = YBTHIN_BIND_I16;
+          cell.i = VERIFY_RESULT(pggate::PgWire::CheckedReadNumber<int16_t>(&cursor));
+          break;
+        case YBTHIN_T_I32:
+          cell.tag = YBTHIN_BIND_I32;
+          cell.i = VERIFY_RESULT(pggate::PgWire::CheckedReadNumber<int32_t>(&cursor));
+          break;
+        case YBTHIN_T_I64:
+          cell.tag = YBTHIN_BIND_I64;
+          cell.i = VERIFY_RESULT(pggate::PgWire::CheckedReadNumber<int64_t>(&cursor));
+          break;
+        case YBTHIN_T_TEXT: {
+          // Length-prefixed and NUL-terminated: len counts the trailing NUL.
+          const uint64_t len = VERIFY_RESULT(pggate::PgWire::CheckedReadNumber<uint64_t>(&cursor));
+          if (len == 0) {
+            return STATUS(Corruption, "TEXT cell with zero length (missing NUL)");
+          }
+          if (cursor.size() < len) {
+            return STATUS(Corruption, "TEXT cell truncated");
+          }
+          cell.tag = YBTHIN_BIND_TEXT;
+          byte_refs.push_back({idx, arena.size(), len - 1});
+          arena.append(cursor.cdata(), len - 1);  // value bytes, excluding the trailing NUL
+          cursor.remove_prefix(len);               // consume value + NUL
+          break;
+        }
+        case YBTHIN_T_BYTEA: {
+          const uint64_t len = VERIFY_RESULT(pggate::PgWire::CheckedReadNumber<uint64_t>(&cursor));
+          if (cursor.size() < len) {
+            return STATUS(Corruption, "BYTEA cell truncated");
+          }
+          cell.tag = YBTHIN_BIND_BYTEA;
+          byte_refs.push_back({idx, arena.size(), len});
+          arena.append(cursor.cdata(), len);
+          cursor.remove_prefix(len);
+          break;
+        }
+      }
+    }
+  }
+  if (!cursor.empty()) {
+    return STATUS_FORMAT(Corruption, "trailing garbage: $0 bytes after $1 rows",
+                         cursor.size(), row_count);
+  }
+
+  // One block: the cell array followed by the byte arena the TEXT/BYTEA cells point into.
+  const size_t cells_bytes = n_cells * sizeof(ybthin_cell);
+  const size_t total = cells_bytes + arena.size();
+  auto* block = static_cast<uint8_t*>(malloc(total ? total : 1));
+  if (!block) {
+    return STATUS(RuntimeError, "out of memory decoding read rows");
+  }
+  auto* out = reinterpret_cast<ybthin_cell*>(block);
+  if (cells_bytes) {
+    memcpy(out, cells.data(), cells_bytes);
+  }
+  uint8_t* arena_base = block + cells_bytes;
+  if (!arena.empty()) {
+    memcpy(arena_base, arena.data(), arena.size());
+  }
+  for (const auto& ref : byte_refs) {
+    out[ref.cell_idx].bytes = arena_base + ref.off;
+    out[ref.cell_idx].bytes_len = ref.len;
+  }
+  *out_cells = out;
+  *out_n_rows = static_cast<size_t>(row_count);
+  return Status::OK();
+}
+
+void FinishRead(ReadCall* raw) {
+  std::unique_ptr<ReadCall> call(raw);
+
+  Status rpc_status = call->controller.status();
+  if (!rpc_status.ok()) {
+    auto st = FromStatus(rpc_status);
+    MaybeMarkSessionDead(call->session, st);
+    call->cb(call->ctx, st, nullptr);
+    return;
+  }
+  Status app_status = yb::ResponseStatus(call->resp);
+  if (!app_status.ok()) {
+    auto st = FromStatus(app_status);
+    MaybeMarkSessionDead(call->session, st);
+    call->cb(call->ctx, st, nullptr);
+    return;
+  }
+  const size_t n_ops = call->op_target_types.size();
+  if (static_cast<size_t>(call->resp.responses_size()) != n_ops) {
+    call->cb(call->ctx, MakeStatus(YBTHIN_OTHER, "Perform op-response count mismatch"), nullptr);
+    return;
+  }
+  // Batch-level status: a Perform fails/read-restarts as a unit, so any op error fails the whole
+  // call with no partial results.
+  for (size_t i = 0; i < n_ops; ++i) {
+    const auto& op = call->resp.responses(static_cast<int>(i));
+    if (op.status() != yb::PgsqlResponsePB::PGSQL_STATUS_OK) {
+      call->cb(call->ctx, PgsqlResponseError(op), nullptr);
+      return;
+    }
+  }
+
+  auto* result = static_cast<ybthin_read_result*>(calloc(1, sizeof(ybthin_read_result)));
+  result->n_ops = n_ops;
+  result->used_read_time_ht = call->used_read_time_ht;
+  result->results = static_cast<ybthin_read_op_result*>(
+      calloc(n_ops ? n_ops : 1, sizeof(ybthin_read_op_result)));
+
+  for (size_t i = 0; i < n_ops; ++i) {
+    const auto& op = call->resp.responses(static_cast<int>(i));
+    auto& op_result = result->results[i];
+    op_result.n_cols = call->op_target_types[i].size();
+    if (op.has_rows_data_sidecar()) {
+      auto sidecar = call->controller.ExtractSidecar(op.rows_data_sidecar());
+      if (!sidecar.ok()) {
+        ybthin_read_result_free(result);
+        call->cb(call->ctx, FromStatus(sidecar.status()), nullptr);
+        return;
+      }
+      ybthin_cell* cells = nullptr;
+      size_t n_rows = 0;
+      Status decoded =
+          DecodeReadRows(sidecar->AsSlice(), call->op_target_types[i], &cells, &n_rows);
+      if (!decoded.ok()) {
+        ybthin_read_result_free(result);
+        call->cb(call->ctx, FromStatus(decoded), nullptr);
+        return;
+      }
+      op_result.cells = cells;
+      op_result.n_rows = n_rows;
+    }
+    // A missing paging_state means this op's scan is exhausted; otherwise wrap the server's paging
+    // state with the pinning header so a continuation returns to this batch's session.
+    if (op.has_paging_state()) {
+      std::string srv;
+      op.paging_state().SerializeToString(&srv);
+      std::string wrapped = WrapPagingState(call->session_index, call->generation, srv);
+      op_result.paging_state = DupBytes(wrapped.data(), wrapped.size());
+      op_result.paging_state_len = wrapped.size();
+    }
+  }
+  call->cb(call->ctx, OkStatus(), result);
+}
+
+void FinishWrite(WriteCall* raw) {
+  std::unique_ptr<WriteCall> call(raw);
+
+  Status rpc_status = call->controller.status();
+  if (!rpc_status.ok()) {
+    auto st = FromStatus(rpc_status);
+    MaybeMarkSessionDead(call->session, st);
+    call->cb(call->ctx, st);
+    return;
+  }
+  Status app_status = yb::ResponseStatus(call->resp);
+  if (!app_status.ok()) {
+    auto st = FromStatus(app_status);
+    MaybeMarkSessionDead(call->session, st);
+    call->cb(call->ctx, st);
+    return;
+  }
+  // Every per-row op must have succeeded — a dropped row is an error, never a silent short write.
+  for (const auto& op : call->resp.responses()) {
+    if (op.status() != yb::PgsqlResponsePB::PGSQL_STATUS_OK) {
+      call->cb(call->ctx, PgsqlResponseError(op));
+      return;
+    }
+  }
+  call->cb(call->ctx, OkStatus());
+}
+
+}  // namespace
+
+// ===========================================================================
+// C ABI
+// ===========================================================================
+
+extern "C" {
+
+ybthin_status ybthin_client_create(
+    const char* const* tserver_addrs, size_t n_addrs, const ybthin_tls_opts* tls,
+    const ybthin_pool_opts* pool, uint32_t rpc_timeout_ms, uint32_t num_reactors,
+    ybthin_client** out) {
+  if (!tserver_addrs || n_addrs == 0 || !out) {
+    return MakeStatus(YBTHIN_INVALID, "tserver_addrs and out are required");
+  }
+
+  const uint32_t read_n =
+      (pool && pool->read_sessions) ? pool->read_sessions : kDefaultReadSessions;
+  const uint32_t write_n =
+      (pool && pool->write_sessions) ? pool->write_sessions : kDefaultWriteSessions;
+  const uint32_t spc =
+      (pool && pool->sessions_per_conn) ? pool->sessions_per_conn : kDefaultSessionsPerConn;
+  if (read_n == 0) {
+    return MakeStatus(YBTHIN_INVALID, "read_sessions must be >= 1");
+  }
+  const uint32_t num_conns = (read_n + write_n + spc - 1) / spc;
+
+  auto client = std::make_unique<ybthin_client>();
+  client->timeout =
+      MonoDelta::FromMilliseconds(rpc_timeout_ms ? rpc_timeout_ms : kDefaultRpcTimeoutMs);
+  client->num_reactors = num_reactors ? static_cast<int>(num_reactors) : kDefaultNumReactors;
+
+  for (size_t i = 0; i < n_addrs; ++i) {
+    auto hp = HostPort::FromString(tserver_addrs[i], kDefaultTserverRpcPort);
+    if (hp.ok()) client->hosts.push_back(*hp);
+  }
+  if (client->hosts.empty()) {
+    return MakeStatus(YBTHIN_INVALID, "no valid tserver addresses");
+  }
+
+  // Secure context (shared by every connection's messenger).
+  if (tls && tls->ca_cert_path) {
+    const bool mtls = tls->cert_path && tls->key_path;
+    auto secure_context = std::make_unique<rpc::SecureContext>(
+        rpc::RequireClientCertificate::kFalse, rpc::UseClientCertificate(mtls));
+    if (mtls) {
+      auto cert = ReadFile(tls->cert_path);
+      if (!cert.ok()) return FromStatus(cert.status());
+      auto key = ReadFile(tls->key_path);
+      if (!key.ok()) return FromStatus(key.status());
+      Status s = secure_context->UseCertificates(tls->ca_cert_path, Slice(*cert), Slice(*key));
+      if (!s.ok()) return FromStatus(s);
+    } else {
+      Status s = secure_context->AddCertificateAuthorityFile(tls->ca_cert_path);
+      if (!s.ok()) return FromStatus(s);
+    }
+    client->secure_context = std::move(secure_context);
+  }
+
+  auto shutdown_all = [&client] {
+    for (auto& c : client->connections) {
+      if (c->messenger) c->messenger->Shutdown();
+    }
+  };
+
+  // One messenger (hence one socket) per connection, so connections spread across tserver nodes.
+  for (uint32_t c = 0; c < num_conns; ++c) {
+    auto conn = std::make_unique<ybthin_connection>();
+    rpc::MessengerBuilder builder("yb_thin_client");
+    builder.set_num_reactors(client->num_reactors);
+    builder.UseDefaultConnectionContextFactory();
+    if (client->secure_context) {
+      rpc::ApplySecureContext(client->secure_context.get(), &builder);
+    }
+    auto messenger = builder.Build();
+    if (!messenger.ok()) {
+      shutdown_all();
+      return FromStatus(messenger.status());
+    }
+    conn->messenger = std::move(*messenger);
+    conn->proxy_cache = std::make_unique<rpc::ProxyCache>(conn->messenger.get());
+    conn->host = client->hosts[c % client->hosts.size()];
+    conn->proxy =
+        std::make_unique<tserver::PgClientServiceProxy>(conn->proxy_cache.get(), conn->host);
+    client->connections.push_back(std::move(conn));
+  }
+
+  // Create and open sessions, packing `spc` per connection: global index g -> connection g / spc.
+  uint32_t g = 0;
+  auto add_session = [&](std::vector<std::unique_ptr<ybthin_session>>* dst) -> Status {
+    auto s = std::make_unique<ybthin_session>();
+    s->conn_index = g / spc;
+    std::lock_guard<std::mutex> lock(s->mu);
+    RETURN_NOT_OK(OpenSession(client.get(), s.get()));
+    dst->push_back(std::move(s));
+    ++g;
+    return Status::OK();
+  };
+  for (uint32_t i = 0; i < read_n; ++i) {
+    Status s = add_session(&client->read_sessions);
+    if (!s.ok()) { shutdown_all(); return FromStatus(s); }
+  }
+  for (uint32_t i = 0; i < write_n; ++i) {
+    Status s = add_session(&client->write_sessions);
+    if (!s.ok()) { shutdown_all(); return FromStatus(s); }
+  }
+
+  // Keepalive: re-heartbeat every open session well inside the server's expiry window; a failed
+  // heartbeat drops the session so the next use reopens it.
+  ybthin_client* raw = client.get();
+  raw->keepalive_thread = std::thread([raw] {  // NOLINT(build/std_thread)
+    std::unique_lock<std::mutex> lock(raw->mu);
+    while (!raw->stop) {
+      if (raw->cv.wait_for(lock, std::chrono::milliseconds(kKeepaliveIntervalMs),
+                           [raw] { return raw->stop; })) {
+        break;
+      }
+      lock.unlock();
+      const auto hb_timeout = std::min(raw->timeout, MonoDelta::FromSeconds(5));
+      auto ping = [raw, hb_timeout](ybthin_session* s) {
+        std::lock_guard<std::mutex> slock(s->mu);
+        if (!s->open) return;
+        auto r = DoHeartbeat(*raw->connections[s->conn_index]->proxy, hb_timeout,
+                             /* create= */ false, s->session_id);
+        if (!r.ok()) s->open = false;
+      };
+      for (auto& s : raw->read_sessions) ping(s.get());
+      for (auto& s : raw->write_sessions) ping(s.get());
+      lock.lock();
+    }
+  });
+
+  *out = client.release();
+  return OkStatus();
+}
+
+void ybthin_client_destroy(ybthin_client* client) {
+  if (!client) {
+    return;
+  }
+  {
+    std::lock_guard<std::mutex> lock(client->mu);
+    client->stop = true;
+  }
+  client->cv.notify_all();
+  if (client->keepalive_thread.joinable()) {
+    client->keepalive_thread.join();
+  }
+  for (auto& conn : client->connections) {
+    if (conn->messenger) conn->messenger->Shutdown();
+  }
+  delete client;
+}
+
+ybthin_status ybthin_table_open(
+    ybthin_client* client, uint32_t db_oid, uint32_t table_oid, ybthin_table** out,
+    ybthin_table_info* info_out) {
+  if (!client || !out || !info_out) {
+    return MakeStatus(YBTHIN_INVALID, "client, out and info_out are required");
+  }
+  auto table = std::make_unique<ybthin_table>();
+  table->table_id = yb::GetPgsqlTableId(db_oid, table_oid);
+
+  tserver::PgOpenTableRequestPB req;
+  req.set_table_id(table->table_id);
+  tserver::PgOpenTableResponsePB resp;
+  rpc::RpcController controller;
+  controller.set_timeout(client->timeout);
+
+  // OpenTable is session-less; any connection serves it.
+  Status s = client->connections.front()->proxy->OpenTable(req, &resp, &controller);
+  if (!s.ok()) return FromStatus(s);
+  s = yb::ResponseStatus(resp);
+  if (!s.ok()) return FromStatus(s);
+
+  const auto& info = resp.info();
+  table->schema_version = info.version();
+  s = yb::SchemaFromPB(info.schema(), &table->schema);
+  if (!s.ok()) return FromStatus(s);
+  s = PartitionSchema::FromPB(info.partition_schema(), table->schema, &table->partition_schema);
+  if (!s.ok()) return FromStatus(s);
+
+  table->num_hash_key_columns = table->schema.num_hash_key_columns();
+  table->num_key_columns = table->schema.num_key_columns();
+
+  const size_t n = table->schema.num_columns();
+  table->columns.reserve(n);
+  for (size_t i = 0; i < n; ++i) {
+    const auto& col = table->schema.column(i);
+    auto type = MapDataType(col.type()->main());
+    if (!type.ok()) return FromStatus(type.status());
+    ybthin_col_kind kind = i < table->num_hash_key_columns ? YBTHIN_COL_HASH
+                           : i < table->num_key_columns    ? YBTHIN_COL_RANGE
+                                                           : YBTHIN_COL_VALUE;
+    table->columns.push_back(
+        {col.name(), table->schema.column_id(i).rep(), kind, *type});
+  }
+
+  auto* out_cols = static_cast<ybthin_column*>(malloc(n * sizeof(ybthin_column)));
+  for (size_t i = 0; i < n; ++i) {
+    const auto& ci = table->columns[i];
+    out_cols[i] = ybthin_column{ci.name.c_str(), ci.id, ci.kind, ci.type};
+  }
+  info_out->columns = out_cols;
+  info_out->n_columns = n;
+
+  *out = table.release();
+  return OkStatus();
+}
+
+void ybthin_table_close(ybthin_table* table) { delete table; }
+
+void ybthin_columns_free(ybthin_column* columns, size_t /* n */) {
+  // Only the array is shim-heap; the name strings are owned by the ybthin_table handle.
+  free(columns);
+}
+
+void ybthin_read_async(
+    ybthin_client* client, const ybthin_read_op* ops, size_t n_ops, uint64_t read_time_ht,
+    ybthin_read_cb cb, void* ctx) {
+  if (n_ops == 0) {
+    cb(ctx, MakeStatus(YBTHIN_INVALID, "read batch has no ops"), nullptr);
+    return;
+  }
+  auto call = std::make_unique<ReadCall>();
+  call->cb = cb;
+  call->ctx = ctx;
+  call->used_read_time_ht = read_time_ht;
+
+  // Select the batch's session. Continuation ops (paging_state_in set) return to the session that
+  // issued them, so all continuations in a batch must pin the SAME session; a batch with no
+  // continuations round-robins the read pool. Fresh ops ride whichever session is chosen.
+  bool have_pinned = false;
+  size_t session_index = 0;
+  uint32_t pinned_generation = 0;
+  std::vector<Slice> server_paging_states(n_ops);  // empty entry => fresh op
+  for (size_t i = 0; i < n_ops; ++i) {
+    const auto& op = ops[i];
+    if (!(op.paging_state_in && op.paging_state_in_len > 0)) {
+      continue;
+    }
+    auto pin = UnwrapPagingState(op.paging_state_in, op.paging_state_in_len);
+    if (!pin.ok()) {
+      cb(ctx, MakeStatus(YBTHIN_INVALID, "could not parse paging_state_in"), nullptr);
+      return;
+    }
+    if (pin->session_index >= client->read_sessions.size()) {
+      cb(ctx, MakeStatus(YBTHIN_READ_RESTART, "pinned read session no longer exists"), nullptr);
+      return;
+    }
+    if (!have_pinned) {
+      have_pinned = true;
+      session_index = pin->session_index;
+      pinned_generation = pin->generation;
+    } else if (pin->session_index != session_index || pin->generation != pinned_generation) {
+      cb(ctx, MakeStatus(
+             YBTHIN_INVALID, "all continuation ops in a batch must share the paging session"),
+         nullptr);
+      return;
+    }
+    server_paging_states[i] = pin->server_paging_state;
+  }
+  if (!have_pinned) {
+    session_index = NextReadIndex(client);
+  }
+  call->session = client->read_sessions[session_index].get();
+  call->session_index = static_cast<uint32_t>(session_index);
+  call->has_continuation = have_pinned;
+  call->pinned_generation = pinned_generation;
+
+  // Build one Perform with n_ops read requests, in caller order (results map back by index).
+  auto& req = call->req;
+  call->op_target_types.resize(n_ops);
+  Status build = Status::OK();
+  for (size_t i = 0; i < n_ops; ++i) {
+    const ybthin_table* table = ops[i].table;
+    const ybthin_read_spec* spec = &ops[i].spec;
+    auto* read = req.add_ops()->mutable_read();
+    read->set_client(yb::YQL_CLIENT_PGSQL);
+    read->set_table_id(table->table_id);
+    read->set_schema_version(table->schema_version);
+
+    for (size_t h = 0; h < spec->n_hash && build.ok(); ++h) {
+      build = BindToQLValue(
+          spec->hash_values[h], read->add_partition_column_values()->mutable_value());
+    }
+    if (build.ok()) {
+      build = SetPartitionRouting(*table, read);
+    }
+    if (build.ok() && spec->n_conds > 0) {
+      if (spec->n_conds == 1) {
+        build = BuildComparison(spec->conds[0], read->mutable_condition_expr());
+      } else {
+        auto* cond = read->mutable_condition_expr()->mutable_condition();
+        cond->set_op(yb::QL_OP_AND);
+        for (size_t c = 0; c < spec->n_conds && build.ok(); ++c) {
+          build = BuildComparison(spec->conds[c], cond->add_operands());
+        }
+      }
+    }
+    if (!build.ok()) {
+      cb(ctx, FromStatus(build), nullptr);
+      return;
+    }
+
+    auto& types = call->op_target_types[i];
+    types.reserve(spec->n_targets);
+    for (size_t t = 0; t < spec->n_targets; ++t) {
+      read->add_targets()->set_column_id(spec->target_ids[t]);
+      read->add_col_refs()->set_column_id(spec->target_ids[t]);
+      // Resolve the target column's type (from the opened schema) so the response sidecar can be
+      // decoded; the sidecar carries values but no types.
+      const ybthin_value_type* type = nullptr;
+      for (const auto& col : table->columns) {
+        if (col.id == spec->target_ids[t]) {
+          type = &col.type;
+          break;
+        }
+      }
+      if (!type) {
+        cb(ctx, MakeStatus(YBTHIN_INVALID, "read target column id is not in the table"), nullptr);
+        return;
+      }
+      types.push_back(*type);
+    }
+    read->set_is_forward_scan(spec->is_forward_scan != 0);
+    if (spec->limit) {
+      read->set_limit(spec->limit);
+    }
+    read->set_return_paging_state(true);
+    if (!server_paging_states[i].empty()) {
+      const Slice& ps = server_paging_states[i];
+      if (!read->mutable_paging_state()->ParseFromArray(
+              ps.data(), static_cast<int>(ps.size()))) {
+        cb(ctx, MakeStatus(YBTHIN_INVALID, "could not parse paging_state_in"), nullptr);
+        return;
+      }
+    }
+  }
+
+  // One snapshot for the whole batch: read_time_ht == 0 lets the server set a clamped read point
+  // (relaxed read-after-commit); otherwise pin read == global_limit so all ops see one snapshot.
+  auto* rto = req.mutable_options()->mutable_read_time_options();
+  if (read_time_ht == 0) {
+    rto->set_read_time_manipulation(tserver::ENSURE_READ_TIME_IS_SET);
+    rto->set_clamp_uncertainty_window(true);
+  } else {
+    auto* rt = rto->mutable_read_time();
+    rt->set_read_ht(read_time_ht);
+    rt->set_global_limit_ht(read_time_ht);
+  }
+
+  // Bind the session identity and dispatch under the session lock: reopen the session if a prior
+  // failure dropped it; a continuation whose session was reopened can no longer be served, so
+  // report READ_RESTART. The Perform serial is allocated last so a failed build never leaves a gap.
+  ReadCall* raw = call.release();
+  auto* s = raw->session;
+  ybthin_status early = OkStatus();
+  bool dispatch = false;
+  {
+    std::lock_guard<std::mutex> lock(s->mu);
+    Status open = EnsureSessionOpen(client, s);
+    if (!open.ok()) {
+      early = FromStatus(open);
+    } else if (raw->has_continuation && s->generation != raw->pinned_generation) {
+      early = MakeStatus(YBTHIN_READ_RESTART, "pinned read session was reopened");
+    } else {
+      raw->generation = s->generation;
+      const uint64_t read_serial = s->read_time_serial++;
+      rto->set_read_time_serial_no(read_serial);
+      rto->set_read_time_serial_no_history_min(read_serial);
+      for (auto& op : *raw->req.mutable_ops()) {
+        op.mutable_read()->set_stmt_id(s->stmt_id++);
+      }
+      raw->req.set_session_id(s->session_id);
+      raw->req.set_serial_no(s->serial_no++);
+      dispatch = true;
+    }
+  }
+  if (!dispatch) {
+    std::unique_ptr<ReadCall> deleter(raw);
+    cb(ctx, early, nullptr);
+    return;
+  }
+  raw->controller.set_timeout(client->timeout);
+  client->connections[s->conn_index]->proxy->PerformAsync(
+      raw->req, &raw->resp, &raw->controller, [raw] { FinishRead(raw); });
+}
+
+void ybthin_read_result_free(ybthin_read_result* result) {
+  if (!result) {
+    return;
+  }
+  if (result->results) {
+    for (size_t i = 0; i < result->n_ops; ++i) {
+      // Each op's `cells` is a single block (cell array + trailing TEXT/BYTEA byte arena).
+      free(result->results[i].cells);
+      free(result->results[i].paging_state);
+    }
+    free(result->results);
+  }
+  free(result);
+}
+
+void ybthin_upsert_batch_async(
+    ybthin_client* client, const ybthin_upsert_row* rows, size_t n_rows,
+    ybthin_write_cb cb, void* ctx) {
+  if (n_rows == 0) {
+    cb(ctx, MakeStatus(YBTHIN_INVALID, "upsert batch has no rows"));
+    return;
+  }
+  auto call = std::make_unique<WriteCall>();
+  call->cb = cb;
+  call->ctx = ctx;
+  call->session = NextWriteSession(client);
+
+  auto& req = call->req;
+
+  Status build = Status::OK();
+  for (size_t r = 0; r < n_rows && build.ok(); ++r) {
+    const auto& row = rows[r];
+    const ybthin_table* table = row.table;
+    auto* write = req.add_ops()->mutable_write();
+    write->set_client(yb::YQL_CLIENT_PGSQL);
+    write->set_stmt_type(yb::PgsqlWriteRequestPB::PGSQL_UPSERT);
+    write->set_table_id(table->table_id);
+    write->set_schema_version(table->schema_version);
+
+    // Primary-key columns are supplied in schema order: hash columns first, then range columns.
+    for (size_t i = 0; i < row.n_keys && build.ok(); ++i) {
+      auto* expr = i < table->num_hash_key_columns ? write->add_partition_column_values()
+                                                   : write->add_range_column_values();
+      build = BindToQLValue(row.key_values[i], expr->mutable_value());
+    }
+    if (build.ok()) {
+      build = SetPartitionRouting(*table, write);
+    }
+    for (size_t i = 0; i < row.n_values && build.ok(); ++i) {
+      auto* cv = write->add_column_values();
+      cv->set_column_id(row.value_ids[i]);
+      build = BindToQLValue(row.values[i], cv->mutable_expr()->mutable_value());
+    }
+  }
+  if (!build.ok()) {
+    cb(ctx, FromStatus(build));
+    return;
+  }
+
+  // Bind the session identity and dispatch under the session lock. A non-transactional write
+  // carries a read-time serial (+ history min) and lets the storage layer pick the read time for
+  // conflict resolution (pg_txn_manager.cc SetupReadTimeOptions). The Perform serial is allocated
+  // last so a failed build never leaves a gap in the session's contiguous serial sequence.
+  WriteCall* raw = call.release();
+  auto* s = raw->session;
+  ybthin_status early = OkStatus();
+  bool dispatch = false;
+  {
+    std::lock_guard<std::mutex> lock(s->mu);
+    Status open = EnsureSessionOpen(client, s);
+    if (!open.ok()) {
+      early = FromStatus(open);
+    } else {
+      for (auto& op : *raw->req.mutable_ops()) {
+        op.mutable_write()->set_stmt_id(s->stmt_id++);
+      }
+      auto* rto = raw->req.mutable_options()->mutable_read_time_options();
+      const uint64_t serial = s->read_time_serial++;
+      rto->set_read_time_serial_no(serial);
+      rto->set_read_time_serial_no_history_min(serial);
+      raw->req.set_session_id(s->session_id);
+      raw->req.set_serial_no(s->serial_no++);
+      dispatch = true;
+    }
+  }
+  if (!dispatch) {
+    std::unique_ptr<WriteCall> deleter(raw);
+    cb(ctx, early);
+    return;
+  }
+  raw->controller.set_timeout(client->timeout);
+  client->connections[s->conn_index]->proxy->PerformAsync(
+      raw->req, &raw->resp, &raw->controller, [raw] { FinishWrite(raw); });
+}
+
+void ybthin_string_free(char* s) { free(s); }
+
+}  // extern "C"

--- a/src/yb/thin_client/yb_thin_client.cc
+++ b/src/yb/thin_client/yb_thin_client.cc
@@ -54,6 +54,8 @@
 
 #include "yb/dockv/partition.h"
 
+#include "yb/gutil/endian.h"
+
 #include "yb/master/master_ddl.pb.h"
 
 #include "yb/rpc/messenger.h"
@@ -171,9 +173,7 @@ struct ybthin_table {
   };
   std::string table_id;
   uint32_t schema_version = 0;
-  size_t num_hash_key_columns = 0;
-  size_t num_key_columns = 0;
-  Schema schema;
+  Schema schema;  // num_hash_key_columns() / num_key_columns() are read directly off this
   PartitionSchema partition_schema;
   std::vector<ColInfo> columns;  // owns the name strings referenced by ybthin_column
 };
@@ -388,22 +388,20 @@ constexpr uint8_t kPagingMagic = 0xB1;
 constexpr uint8_t kPagingVersion = 2;
 constexpr size_t kPagingHeaderLen = 2 + 4 + 4 + 8 + 8;
 
+// Little-endian pack/unpack via gutil's tested primitives (LittleEndian::{Store,Load}{32,64}),
+// wrapped so the append-to-string / read-from-pointer call sites stay compact.
 void PutU32LE(std::string* s, uint32_t v) {
-  for (int i = 0; i < 4; ++i) s->push_back(static_cast<char>((v >> (8 * i)) & 0xff));
+  char buf[sizeof(v)];
+  LittleEndian::Store32(buf, v);
+  s->append(buf, sizeof(buf));
 }
-uint32_t GetU32LE(const uint8_t* p) {
-  uint32_t v = 0;
-  for (int i = 0; i < 4; ++i) v |= static_cast<uint32_t>(p[i]) << (8 * i);
-  return v;
-}
+uint32_t GetU32LE(const uint8_t* p) { return LittleEndian::Load32(p); }
 void PutU64LE(std::string* s, uint64_t v) {
-  for (int i = 0; i < 8; ++i) s->push_back(static_cast<char>((v >> (8 * i)) & 0xff));
+  char buf[sizeof(v)];
+  LittleEndian::Store64(buf, v);
+  s->append(buf, sizeof(buf));
 }
-uint64_t GetU64LE(const uint8_t* p) {
-  uint64_t v = 0;
-  for (int i = 0; i < 8; ++i) v |= static_cast<uint64_t>(p[i]) << (8 * i);
-  return v;
-}
+uint64_t GetU64LE(const uint8_t* p) { return LittleEndian::Load64(p); }
 
 std::string WrapPagingState(
     uint32_t session_index, uint32_t generation, uint64_t read_time_serial, uint64_t txn_serial,
@@ -434,6 +432,17 @@ Result<PinInfo> UnwrapPagingState(const uint8_t* data, size_t len) {
   return PinInfo{
       GetU32LE(data + 2), GetU32LE(data + 6), GetU64LE(data + 10), GetU64LE(data + 18),
       Slice(data + kPagingHeaderLen, len - kPagingHeaderLen)};
+}
+
+// Stamps a Perform's read serial and the matching windowed history_min. The server keeps the read
+// points of serials in [serial - kReadSerialHistoryWindow, serial] so paged scans / continuations
+// can restore their snapshot; setting history_min == serial would prune them. The read and write
+// dispatch paths both call this so the window (a non-obvious server coupling) lives in one place.
+template <class ReadTimeOptionsPB>
+void SetReadTimeSerial(ReadTimeOptionsPB* rto, uint64_t serial) {
+  rto->set_read_time_serial_no(serial);
+  rto->set_read_time_serial_no_history_min(
+      serial > kReadSerialHistoryWindow ? serial - kReadSerialHistoryWindow : 0);
 }
 
 // Extracts the best human-readable message from a per-op response.
@@ -899,18 +908,17 @@ ybthin_status ybthin_table_open(
   s = PartitionSchema::FromPB(info.partition_schema(), table->schema, &table->partition_schema);
   if (!s.ok()) return FromStatus(s);
 
-  table->num_hash_key_columns = table->schema.num_hash_key_columns();
-  table->num_key_columns = table->schema.num_key_columns();
-
+  const size_t num_hash_key_columns = table->schema.num_hash_key_columns();
+  const size_t num_key_columns = table->schema.num_key_columns();
   const size_t n = table->schema.num_columns();
   table->columns.reserve(n);
   for (size_t i = 0; i < n; ++i) {
     const auto& col = table->schema.column(i);
     auto type = MapDataType(col.type()->main());
     if (!type.ok()) return FromStatus(type.status());
-    ybthin_col_kind kind = i < table->num_hash_key_columns ? YBTHIN_COL_HASH
-                           : i < table->num_key_columns    ? YBTHIN_COL_RANGE
-                                                           : YBTHIN_COL_VALUE;
+    ybthin_col_kind kind = i < num_hash_key_columns ? YBTHIN_COL_HASH
+                           : i < num_key_columns    ? YBTHIN_COL_RANGE
+                                                    : YBTHIN_COL_VALUE;
     table->columns.push_back(
         {col.name(), table->schema.column_id(i).rep(), kind, *type});
   }
@@ -1118,9 +1126,7 @@ void ybthin_read_async(
         read_serial = s->read_time_serial++;
         txn_serial = client->txn_serial.fetch_add(1);
       }
-      rto->set_read_time_serial_no(read_serial);
-      rto->set_read_time_serial_no_history_min(
-          read_serial > kReadSerialHistoryWindow ? read_serial - kReadSerialHistoryWindow : 0);
+      SetReadTimeSerial(rto, read_serial);
       for (auto& op : *raw->req.mutable_ops()) {
         op.mutable_read()->set_stmt_id(s->stmt_id++);
       }
@@ -1184,9 +1190,10 @@ void ybthin_upsert_batch_async(
     write->set_schema_version(table->schema_version);
 
     // Primary-key columns are supplied in schema order: hash columns first, then range columns.
+    const size_t num_hash_key_columns = table->schema.num_hash_key_columns();
     for (size_t i = 0; i < row.n_keys && build.ok(); ++i) {
-      auto* expr = i < table->num_hash_key_columns ? write->add_partition_column_values()
-                                                   : write->add_range_column_values();
+      auto* expr = i < num_hash_key_columns ? write->add_partition_column_values()
+                                            : write->add_range_column_values();
       build = BindToQLValue(row.key_values[i], expr->mutable_value());
     }
     if (build.ok()) {
@@ -1220,11 +1227,8 @@ void ybthin_upsert_batch_async(
       for (auto& op : *raw->req.mutable_ops()) {
         op.mutable_write()->set_stmt_id(s->stmt_id++);
       }
-      auto* rto = raw->req.mutable_options()->mutable_read_time_options();
-      const uint64_t serial = s->read_time_serial++;
-      rto->set_read_time_serial_no(serial);
-      rto->set_read_time_serial_no_history_min(
-          serial > kReadSerialHistoryWindow ? serial - kReadSerialHistoryWindow : 0);
+      SetReadTimeSerial(raw->req.mutable_options()->mutable_read_time_options(),
+                        s->read_time_serial++);
       // Fresh transaction per Perform (stateless writes), matching the read path and yb_tsclient.
       raw->req.mutable_options()->set_txn_serial_no(client->txn_serial.fetch_add(1));
       raw->req.set_session_id(s->session_id);

--- a/src/yb/thin_client/yb_thin_client.cc
+++ b/src/yb/thin_client/yb_thin_client.cc
@@ -101,6 +101,11 @@ static constexpr int kDefaultNumReactors = 4;
 static constexpr uint32_t kDefaultReadSessions = 4;
 static constexpr uint32_t kDefaultWriteSessions = 1;
 static constexpr uint32_t kDefaultSessionsPerConn = 4;
+// read_time_serial_no_history_min is set this far BELOW the current read serial (matching
+// yb_tsclient): the server keeps the read points of that many recent serials so paged scans /
+// continuations can restore their snapshot, while older ones are pruned. Setting it EQUAL to the
+// serial prunes everything and is part of what left the shim's read point sticky.
+static constexpr uint64_t kReadSerialHistoryWindow = 65536;
 
 // ---- opaque handles -------------------------------------------------------
 
@@ -370,12 +375,18 @@ ybthin_session* NextWriteSession(ybthin_client* client) {
   return pool[client->write_rr.fetch_add(1, std::memory_order_relaxed) % pool.size()].get();
 }
 
-// Wrapped paging state = [magic][version][u32 read-session index][u32 generation] + the server's
-// paging state. The caller passes this back opaquely; on continuation the shim routes to the same
-// session (generation-checked), which is where the server's read point for the scan lives.
+// Wrapped paging state =
+//   [magic][version][u32 read-session index][u32 generation][u64 read_time_serial][u64 txn_serial]
+//   + the server's paging state.
+// The caller passes this back opaquely. On continuation the shim routes to the same session
+// (generation-checked) AND replays the scan's original read_time_serial / txn_serial rather than
+// allocating new ones -- keeping read_time_serial_no constant across a scan's pages, exactly as
+// pggate does within a single statement, so the server restores this scan's read point and every
+// page observes ONE snapshot. (Advancing the serial per page made the server's
+// ENSURE_READ_TIME_IS_SET pick a fresh, later read time each page, dropping rows deleted mid-scan.)
 constexpr uint8_t kPagingMagic = 0xB1;
-constexpr uint8_t kPagingVersion = 1;
-constexpr size_t kPagingHeaderLen = 2 + 4 + 4;
+constexpr uint8_t kPagingVersion = 2;
+constexpr size_t kPagingHeaderLen = 2 + 4 + 4 + 8 + 8;
 
 void PutU32LE(std::string* s, uint32_t v) {
   for (int i = 0; i < 4; ++i) s->push_back(static_cast<char>((v >> (8 * i)) & 0xff));
@@ -385,14 +396,26 @@ uint32_t GetU32LE(const uint8_t* p) {
   for (int i = 0; i < 4; ++i) v |= static_cast<uint32_t>(p[i]) << (8 * i);
   return v;
 }
+void PutU64LE(std::string* s, uint64_t v) {
+  for (int i = 0; i < 8; ++i) s->push_back(static_cast<char>((v >> (8 * i)) & 0xff));
+}
+uint64_t GetU64LE(const uint8_t* p) {
+  uint64_t v = 0;
+  for (int i = 0; i < 8; ++i) v |= static_cast<uint64_t>(p[i]) << (8 * i);
+  return v;
+}
 
-std::string WrapPagingState(uint32_t session_index, uint32_t generation, const std::string& srv) {
+std::string WrapPagingState(
+    uint32_t session_index, uint32_t generation, uint64_t read_time_serial, uint64_t txn_serial,
+    const std::string& srv) {
   std::string out;
   out.reserve(kPagingHeaderLen + srv.size());
   out.push_back(static_cast<char>(kPagingMagic));
   out.push_back(static_cast<char>(kPagingVersion));
   PutU32LE(&out, session_index);
   PutU32LE(&out, generation);
+  PutU64LE(&out, read_time_serial);
+  PutU64LE(&out, txn_serial);
   out.append(srv);
   return out;
 }
@@ -400,6 +423,8 @@ std::string WrapPagingState(uint32_t session_index, uint32_t generation, const s
 struct PinInfo {
   uint32_t session_index;
   uint32_t generation;
+  uint64_t read_time_serial;  // the scan's original serials; a continuation replays them so the
+  uint64_t txn_serial;        // server restores this scan's read point instead of picking a new one
   Slice server_paging_state;
 };
 Result<PinInfo> UnwrapPagingState(const uint8_t* data, size_t len) {
@@ -407,7 +432,7 @@ Result<PinInfo> UnwrapPagingState(const uint8_t* data, size_t len) {
     return STATUS(InvalidArgument, "malformed wrapped paging state");
   }
   return PinInfo{
-      GetU32LE(data + 2), GetU32LE(data + 6),
+      GetU32LE(data + 2), GetU32LE(data + 6), GetU64LE(data + 10), GetU64LE(data + 18),
       Slice(data + kPagingHeaderLen, len - kPagingHeaderLen)};
 }
 
@@ -445,6 +470,10 @@ struct ReadCall {
   uint32_t generation;          // session incarnation this batch ran at (for wrapping)
   bool has_continuation;        // any op is a continuation -> its pinned session must still match
   uint32_t pinned_generation;   // generation the continuation ops were pinned to
+  uint64_t pinned_read_time_serial;  // a continuation replays the scan's original serials (below)
+  uint64_t pinned_txn_serial;        // instead of advancing, so the server restores its read point
+  uint64_t read_time_serial;    // serials actually used for THIS Perform; wrapped into the response
+  uint64_t txn_serial;          // paging state so the next page replays them
   tserver::PgPerformRequestPB req;
   tserver::PgPerformResponsePB resp;
   rpc::RpcController controller;
@@ -649,7 +678,8 @@ void FinishRead(ReadCall* raw) {
       }
       std::string srv;
       op.paging_state().SerializeToString(&srv);
-      std::string wrapped = WrapPagingState(call->session_index, call->generation, srv);
+      std::string wrapped = WrapPagingState(
+          call->session_index, call->generation, call->read_time_serial, call->txn_serial, srv);
       op_result.paging_state = DupBytes(wrapped.data(), wrapped.size());
       op_result.paging_state_len = wrapped.size();
     }
@@ -922,6 +952,8 @@ void ybthin_read_async(
   bool have_pinned = false;
   size_t session_index = 0;
   uint32_t pinned_generation = 0;
+  uint64_t pinned_read_time_serial = 0;
+  uint64_t pinned_txn_serial = 0;
   std::vector<Slice> server_paging_states(n_ops);  // empty entry => fresh op
   for (size_t i = 0; i < n_ops; ++i) {
     const auto& op = ops[i];
@@ -941,7 +973,13 @@ void ybthin_read_async(
       have_pinned = true;
       session_index = pin->session_index;
       pinned_generation = pin->generation;
-    } else if (pin->session_index != session_index || pin->generation != pinned_generation) {
+      pinned_read_time_serial = pin->read_time_serial;
+      pinned_txn_serial = pin->txn_serial;
+    } else if (pin->session_index != session_index || pin->generation != pinned_generation ||
+               pin->read_time_serial != pinned_read_time_serial ||
+               pin->txn_serial != pinned_txn_serial) {
+      // One Perform carries one snapshot (one read_time_serial_no), so continuation ops batched
+      // together must all belong to the same scan/snapshot -- i.e. share the session and serials.
       cb(ctx, MakeStatus(
              YBTHIN_INVALID, "all continuation ops in a batch must share the paging session"),
          nullptr);
@@ -956,6 +994,8 @@ void ybthin_read_async(
   call->session_index = static_cast<uint32_t>(session_index);
   call->has_continuation = have_pinned;
   call->pinned_generation = pinned_generation;
+  call->pinned_read_time_serial = pinned_read_time_serial;
+  call->pinned_txn_serial = pinned_txn_serial;
 
   // Build one Perform with n_ops read requests, in caller order (results map back by index).
   auto& req = call->req;
@@ -1030,11 +1070,14 @@ void ybthin_read_async(
   // One snapshot for the whole batch.
   auto* rto = req.mutable_options()->mutable_read_time_options();
   if (read_time_ht == 0) {
-    // Fresh read point for this batch: ensure a read time is set (the fresh txn_serial_no stamped
-    // at dispatch already dropped any prior read point, so the server picks a current one here).
-    // This mirrors yb_tsclient's plain-read path. Read-after-write correctness comes from the fresh
-    // txn_serial_no, not from this manipulation alone.
+    // Let the server pick the read point. ENSURE + clamp + the read serial (set at dispatch) drive
+    // it: for a FRESH scan the serial advances, so the server picks a new clamped read time (a new
+    // snapshot that observes the latest commits -- read-after-write). For a CONTINUATION the serial
+    // is REPLAYED (unchanged), so the server restores the scan's read point and ENSURE is a no-op
+    // -- every page reads at one snapshot. This mirrors pggate: advance read_time_serial_no per
+    // statement, hold it constant across that statement's pages.
     rto->set_read_time_manipulation(tserver::ENSURE_READ_TIME_IS_SET);
+    rto->set_clamp_uncertainty_window(true);
   } else {
     // Pin the batch to an explicit snapshot (e.g. paged-scan continuation, or a second batch that
     // must observe the same snapshot as a prior one via its used_read_time_ht).
@@ -1059,16 +1102,35 @@ void ybthin_read_async(
       early = MakeStatus(YBTHIN_READ_RESTART, "pinned read session was reopened");
     } else {
       raw->generation = s->generation;
-      const uint64_t read_serial = s->read_time_serial++;
+      uint64_t read_serial;
+      uint64_t txn_serial;
+      if (raw->has_continuation) {
+        // Continue the scan on its ORIGINAL serials (carried in the paging state) instead of
+        // allocating new ones. With read_time_serial_no unchanged, the server restores this scan's
+        // read point (pg_client_session.cc read_point_history_) and every page reads at one
+        // snapshot -- the way pggate keeps read_time_serial_no constant across a statement's pages.
+        read_serial = raw->pinned_read_time_serial;
+        txn_serial = raw->pinned_txn_serial;
+      } else {
+        // Fresh scan == a new statement: advance to a new read point so it observes the latest
+        // committed data (read-after-write), and a fresh transaction serial so the server does not
+        // reuse this session's prior read point.
+        read_serial = s->read_time_serial++;
+        txn_serial = client->txn_serial.fetch_add(1);
+      }
       rto->set_read_time_serial_no(read_serial);
-      rto->set_read_time_serial_no_history_min(read_serial);
+      rto->set_read_time_serial_no_history_min(
+          read_serial > kReadSerialHistoryWindow ? read_serial - kReadSerialHistoryWindow : 0);
       for (auto& op : *raw->req.mutable_ops()) {
         op.mutable_read()->set_stmt_id(s->stmt_id++);
       }
-      // Fresh transaction per Perform so the server does not reuse this session's prior read point.
-      raw->req.mutable_options()->set_txn_serial_no(client->txn_serial.fetch_add(1));
+      raw->req.mutable_options()->set_txn_serial_no(txn_serial);
       raw->req.set_session_id(s->session_id);
       raw->req.set_serial_no(s->serial_no++);
+      // Remember the serials this Perform ran at so FinishRead can wrap them into the response
+      // paging state for the next page to replay.
+      raw->read_time_serial = read_serial;
+      raw->txn_serial = txn_serial;
       dispatch = true;
     }
   }
@@ -1161,7 +1223,8 @@ void ybthin_upsert_batch_async(
       auto* rto = raw->req.mutable_options()->mutable_read_time_options();
       const uint64_t serial = s->read_time_serial++;
       rto->set_read_time_serial_no(serial);
-      rto->set_read_time_serial_no_history_min(serial);
+      rto->set_read_time_serial_no_history_min(
+          serial > kReadSerialHistoryWindow ? serial - kReadSerialHistoryWindow : 0);
       // Fresh transaction per Perform (stateless writes), matching the read path and yb_tsclient.
       raw->req.mutable_options()->set_txn_serial_no(client->txn_serial.fetch_add(1));
       raw->req.set_session_id(s->session_id);

--- a/src/yb/thin_client/yb_thin_client.cc
+++ b/src/yb/thin_client/yb_thin_client.cc
@@ -32,10 +32,8 @@
 #include <condition_variable>
 #include <cstdlib>
 #include <cstring>
-#include <fstream>
 #include <memory>
 #include <mutex>
-#include <sstream>
 #include <string>
 #include <thread>
 #include <vector>
@@ -50,7 +48,10 @@
 #include "yb/common/value.pb.h"
 #include "yb/common/wire_protocol.h"
 
+#include "yb/dockv/doc_key.h"
+#include "yb/dockv/key_entry_value.h"
 #include "yb/dockv/partition.h"
+#include "yb/dockv/value_type.h"
 
 #include "yb/gutil/endian.h"
 
@@ -68,6 +69,8 @@
 #include "yb/yql/pggate/util/pg_doc_data.h"
 #include "yb/yql/pggate/util/pg_wire.h"
 
+#include "yb/util/env.h"
+#include "yb/util/faststring.h"
 #include "yb/util/monotime.h"
 #include "yb/util/net/net_util.h"
 #include "yb/util/ref_cnt_buffer.h"
@@ -77,6 +80,7 @@
 #include "yb/util/status_format.h"
 
 using yb::DataType;
+using yb::faststring;
 using yb::HostPort;
 using yb::MonoDelta;
 using yb::RefCntSlice;
@@ -89,6 +93,7 @@ using yb::dockv::PartitionSchema;
 namespace tserver = yb::tserver;
 namespace rpc = yb::rpc;
 namespace pggate = yb::pggate;
+namespace dockv = yb::dockv;
 
 // Default tserver RPC port used when a "host" is passed without ":port".
 static constexpr uint16_t kDefaultTserverRpcPort = 9100;
@@ -270,20 +275,6 @@ Status BuildComparison(const ybthin_cond& c, yb::PgsqlExpressionPB* out) {
   return BindToQLValue(c.value, cond->add_operands()->mutable_value());
 }
 
-// Sets hash_code + partition_key from already-populated partition_column_values so the tserver can
-// route the op without a scan. No-op for a table with no hash columns.
-template <class ReqPB>
-Status SetPartitionRouting(const ybthin_table& table, ReqPB* req) {
-  if (req->partition_column_values().empty()) {
-    return Status::OK();
-  }
-  auto partition_key = VERIFY_RESULT(
-      table.partition_schema.EncodePgsqlHash(req->partition_column_values()));
-  req->set_hash_code(PartitionSchema::DecodeMultiColumnHashValue(partition_key));
-  req->set_partition_key(std::move(partition_key));
-  return Status::OK();
-}
-
 Result<ybthin_value_type> MapDataType(DataType dt) {
   switch (dt) {
     case DataType::BOOL: return YBTHIN_T_BOOL;
@@ -298,13 +289,9 @@ Result<ybthin_value_type> MapDataType(DataType dt) {
 }
 
 Result<std::string> ReadFile(const char* path) {
-  std::ifstream f(path, std::ios::binary);
-  if (!f) {
-    return STATUS_FORMAT(IOError, "cannot open $0", path);
-  }
-  std::stringstream ss;
-  ss << f.rdbuf();
-  return ss.str();
+  faststring data;
+  RETURN_NOT_OK(yb::ReadFileToString(yb::Env::Default(), path, &data));
+  return data.ToString();
 }
 
 // Sends one Heartbeat. `create` true opens a new session (send pid); false keeps `session_id_`
@@ -990,6 +977,27 @@ void ybthin_read_async(
   for (size_t i = 0; i < n_ops; ++i) {
     const ybthin_table* table = ops[i].table;
     const ybthin_read_spec* spec = &ops[i].spec;
+    // Binding the wrong kind of key would leave the partition key unset and quietly read only the
+    // first tablet, so reject it instead.
+    const bool range_sharded = table->schema.num_hash_key_columns() == 0;
+    if (range_sharded && spec->n_hash > 0) {
+      cb(ctx, MakeStatus(
+             YBTHIN_INVALID, "table is range-sharded: use spec.range_values, not hash_values"),
+         nullptr);
+      return;
+    }
+    if (!range_sharded && spec->n_range > 0) {
+      cb(ctx, MakeStatus(
+             YBTHIN_INVALID, "table is hash-sharded: use spec.hash_values, not range_values"),
+         nullptr);
+      return;
+    }
+    if (spec->n_hash > table->schema.num_hash_key_columns() ||
+        spec->n_range > table->schema.num_range_key_columns()) {
+      cb(ctx, MakeStatus(YBTHIN_INVALID, "more key values than key columns"), nullptr);
+      return;
+    }
+
     auto* read = req.add_ops()->mutable_read();
     read->set_client(yb::YQL_CLIENT_PGSQL);
     read->set_table_id(table->table_id);
@@ -999,8 +1007,31 @@ void ybthin_read_async(
       build = BindToQLValue(
           spec->hash_values[h], read->add_partition_column_values()->mutable_value());
     }
+    for (size_t r = 0; r < spec->n_range && build.ok(); ++r) {
+      build = BindToQLValue(
+          spec->range_values[r], read->add_range_column_values()->mutable_value());
+    }
+    // A read is routed off its scan bounds, not its range_column_values (only writes use those --
+    // see InitRange/WritePartitionKey), so turn the supplied key prefix into encoded bounds. A
+    // partial prefix widens to its whole range: -Inf on the lower side, +Inf on the upper.
+    if (build.ok() && spec->n_range > 0) {
+      auto lower = dockv::GetRangeComponents(
+          table->schema, read->range_column_values(), /* lower_bound= */ true);
+      auto upper = dockv::GetRangeComponents(
+          table->schema, read->range_column_values(), /* lower_bound= */ false);
+      if (!lower.ok() || !upper.ok()) {
+        cb(ctx, FromStatus(lower.ok() ? upper.status() : lower.status()), nullptr);
+        return;
+      }
+      auto* lb = read->mutable_lower_bound();
+      lb->set_key(dockv::DocKey(std::move(*lower)).Encode().ToStringBuffer());
+      lb->set_is_inclusive(true);
+      auto* ub = read->mutable_upper_bound();
+      ub->set_key(dockv::DocKey(std::move(*upper)).Encode().ToStringBuffer());
+      ub->set_is_inclusive(true);
+    }
     if (build.ok()) {
-      build = SetPartitionRouting(*table, read);
+      build = dockv::InitPartitionKey(table->schema, table->partition_schema, read);
     }
     if (build.ok() && spec->n_conds > 0) {
       if (spec->n_conds == 1) {
@@ -1048,6 +1079,13 @@ void ybthin_read_async(
       if (!read->mutable_paging_state()->ParseFromArray(
               ps.data(), static_cast<int>(ps.size()))) {
         cb(ctx, MakeStatus(YBTHIN_INVALID, "could not parse paging_state_in"), nullptr);
+        return;
+      }
+      // Re-route: InitPartitionKey resumes on whichever tablet the paging state names, which
+      // for a scan crossing a boundary is a different one.
+      build = dockv::InitPartitionKey(table->schema, table->partition_schema, read);
+      if (!build.ok()) {
+        cb(ctx, FromStatus(build), nullptr);
         return;
       }
     }
@@ -1153,6 +1191,11 @@ void ybthin_upsert_batch_async(
   for (size_t r = 0; r < n_rows && build.ok(); ++r) {
     const auto& row = rows[r];
     const ybthin_table* table = row.table;
+    // A write needs the whole primary key; a short one is padded out and hits a different row.
+    if (row.n_keys != table->schema.num_key_columns()) {
+      cb(ctx, MakeStatus(YBTHIN_INVALID, "upsert row must bind every primary key column"));
+      return;
+    }
     auto* write = req.add_ops()->mutable_write();
     write->set_client(yb::YQL_CLIENT_PGSQL);
     write->set_stmt_type(yb::PgsqlWriteRequestPB::PGSQL_UPSERT);
@@ -1167,7 +1210,7 @@ void ybthin_upsert_batch_async(
       build = BindToQLValue(row.key_values[i], expr->mutable_value());
     }
     if (build.ok()) {
-      build = SetPartitionRouting(*table, write);
+      build = dockv::InitPartitionKey(table->schema, table->partition_schema, write);
     }
     for (size_t i = 0; i < row.n_values && build.ok(); ++i) {
       auto* cv = write->add_column_values();

--- a/src/yb/thin_client/yb_thin_client.cc
+++ b/src/yb/thin_client/yb_thin_client.cc
@@ -417,6 +417,38 @@ void SetReadTimeSerial(ReadTimeOptionsPB* rto, uint64_t serial) {
       serial > kReadSerialHistoryWindow ? serial - kReadSerialHistoryWindow : 0);
 }
 
+// Derives a read's partition key. A read is routed off its scan bounds rather than its
+// range_column_values (only writes use those), so a supplied range key prefix is first encoded
+// into bounds; a partial prefix widens to its whole range. A backward scan then walks the key to
+// the tablet it actually starts in, mirroring what YBPgsqlReadOp::GetPartitionKey does.
+Status RouteRead(const ybthin_table& table, bool has_range_values, yb::PgsqlReadRequestPB* read) {
+  if (has_range_values) {
+    auto lower = VERIFY_RESULT(dockv::GetRangeComponents(
+        table.schema, read->range_column_values(), /* lower_bound= */ true));
+    auto upper = VERIFY_RESULT(dockv::GetRangeComponents(
+        table.schema, read->range_column_values(), /* lower_bound= */ false));
+    auto* lb = read->mutable_lower_bound();
+    lb->set_key(dockv::DocKey(std::move(lower)).Encode().ToStringBuffer());
+    lb->set_is_inclusive(true);
+    auto* ub = read->mutable_upper_bound();
+    ub->set_key(dockv::DocKey(std::move(upper)).Encode().ToStringBuffer());
+    ub->set_is_inclusive(true);
+  }
+  // InitHashPartitionKey's paging branch assumes the hash code bounds are already set, because
+  // pggate reuses one request object for every page of a scan. The shim builds a fresh request per
+  // page, so set them here or a continuation would scan unbounded and re-read the first page.
+  if (!read->partition_column_values().empty()) {
+    const auto hash_code = VERIFY_RESULT(
+        table.partition_schema.PgsqlHashColumnCompoundValue(read->partition_column_values()));
+    read->set_hash_code(hash_code);
+    read->set_max_hash_code(hash_code);
+  }
+  // No backward-scan adjustment here: the tserver already applies GetPartitionKeyForBackwardScan
+  // to our (non-owning) ops, using its own fresh tablet list -- doing it again would walk the key
+  // back one tablet too far.
+  return dockv::InitPartitionKey(table.schema, table.partition_schema, read);
+}
+
 // Extracts the best human-readable message from a per-op response.
 std::string PgsqlResponseMessage(const yb::PgsqlResponsePB& r) {
   if (r.error_status_size() > 0) {
@@ -1011,28 +1043,6 @@ void ybthin_read_async(
       build = BindToQLValue(
           spec->range_values[r], read->add_range_column_values()->mutable_value());
     }
-    // A read is routed off its scan bounds, not its range_column_values (only writes use those --
-    // see InitRange/WritePartitionKey), so turn the supplied key prefix into encoded bounds. A
-    // partial prefix widens to its whole range: -Inf on the lower side, +Inf on the upper.
-    if (build.ok() && spec->n_range > 0) {
-      auto lower = dockv::GetRangeComponents(
-          table->schema, read->range_column_values(), /* lower_bound= */ true);
-      auto upper = dockv::GetRangeComponents(
-          table->schema, read->range_column_values(), /* lower_bound= */ false);
-      if (!lower.ok() || !upper.ok()) {
-        cb(ctx, FromStatus(lower.ok() ? upper.status() : lower.status()), nullptr);
-        return;
-      }
-      auto* lb = read->mutable_lower_bound();
-      lb->set_key(dockv::DocKey(std::move(*lower)).Encode().ToStringBuffer());
-      lb->set_is_inclusive(true);
-      auto* ub = read->mutable_upper_bound();
-      ub->set_key(dockv::DocKey(std::move(*upper)).Encode().ToStringBuffer());
-      ub->set_is_inclusive(true);
-    }
-    if (build.ok()) {
-      build = dockv::InitPartitionKey(table->schema, table->partition_schema, read);
-    }
     if (build.ok() && spec->n_conds > 0) {
       if (spec->n_conds == 1) {
         build = BuildComparison(spec->conds[0], read->mutable_condition_expr());
@@ -1081,13 +1091,13 @@ void ybthin_read_async(
         cb(ctx, MakeStatus(YBTHIN_INVALID, "could not parse paging_state_in"), nullptr);
         return;
       }
-      // Re-route: InitPartitionKey resumes on whichever tablet the paging state names, which
-      // for a scan crossing a boundary is a different one.
-      build = dockv::InitPartitionKey(table->schema, table->partition_schema, read);
-      if (!build.ok()) {
-        cb(ctx, FromStatus(build), nullptr);
-        return;
-      }
+    }
+    // Route last: the partition key depends on the scan direction, the bounds and the paging
+    // state, so every one of them has to be set by now.
+    build = RouteRead(*table, spec->n_range > 0, read);
+    if (!build.ok()) {
+      cb(ctx, FromStatus(build), nullptr);
+      return;
     }
   }
 

--- a/src/yb/thin_client/yb_thin_client.cc
+++ b/src/yb/thin_client/yb_thin_client.cc
@@ -1029,6 +1029,15 @@ void ybthin_read_async(
       cb(ctx, MakeStatus(YBTHIN_INVALID, "more key values than key columns"), nullptr);
       return;
     }
+    // DocDB takes range_column_values as the range key prefix and forbids nulls in it. Reject
+    // rather than bind one: a null would make the prefix mean something the caller did not ask
+    // for, and the scan would quietly return the wrong rows.
+    for (size_t r = 0; r < spec->n_range; ++r) {
+      if (spec->range_values[r].tag == YBTHIN_BIND_NULL) {
+        cb(ctx, MakeStatus(YBTHIN_INVALID, "range key values may not be null"), nullptr);
+        return;
+      }
+    }
 
     auto* read = req.add_ops()->mutable_read();
     read->set_client(yb::YQL_CLIENT_PGSQL);

--- a/src/yb/thin_client/yb_thin_client.cc
+++ b/src/yb/thin_client/yb_thin_client.cc
@@ -1043,14 +1043,51 @@ void ybthin_read_async(
       build = BindToQLValue(
           spec->range_values[r], read->add_range_column_values()->mutable_value());
     }
-    if (build.ok() && spec->n_conds > 0) {
-      if (spec->n_conds == 1) {
-        build = BuildComparison(spec->conds[0], read->mutable_condition_expr());
+    // An Eq on the key column right after the prefix EXTENDS the prefix; it is not a filter.
+    // DocDB reads range_column_values as the range key prefix and derives the scan range from it,
+    // so a bound key column has to be part of that prefix -- left in condition_expr it contradicts
+    // the derived range and the scan returns nothing. pggate normalises the same way
+    // (PgDmlRead::ProcessEmptyKeyBinds: conditions move to condition_expr only once a PRECEDING
+    // key column is unbound). Non-Eq conditions, and anything past the first unbound column, stay
+    // filters.
+    std::vector<bool> cond_folded(spec->n_conds, false);
+    if (table->schema.num_hash_key_columns() == 0) {
+      for (size_t k = spec->n_range; build.ok() && k < table->schema.num_key_columns(); ++k) {
+        const int32_t key_col_id = table->columns[k].id;
+        size_t match = spec->n_conds;
+        for (size_t c = 0; c < spec->n_conds; ++c) {
+          if (!cond_folded[c] && spec->conds[c].column_id == key_col_id &&
+              spec->conds[c].op == YBTHIN_EQ && spec->conds[c].value.tag != YBTHIN_BIND_NULL) {
+            match = c;
+            break;
+          }
+        }
+        if (match == spec->n_conds) {
+          break;  // gap in the key prefix: everything from here on stays a filter
+        }
+        build = BindToQLValue(
+            spec->conds[match].value, read->add_range_column_values()->mutable_value());
+        cond_folded[match] = true;
+      }
+    }
+    size_t n_filters = 0;
+    for (size_t c = 0; c < spec->n_conds; ++c) {
+      if (!cond_folded[c]) ++n_filters;
+    }
+    if (build.ok() && n_filters > 0) {
+      if (n_filters == 1) {
+        for (size_t c = 0; c < spec->n_conds && build.ok(); ++c) {
+          if (!cond_folded[c]) {
+            build = BuildComparison(spec->conds[c], read->mutable_condition_expr());
+          }
+        }
       } else {
         auto* cond = read->mutable_condition_expr()->mutable_condition();
         cond->set_op(yb::QL_OP_AND);
         for (size_t c = 0; c < spec->n_conds && build.ok(); ++c) {
-          build = BuildComparison(spec->conds[c], cond->add_operands());
+          if (!cond_folded[c]) {
+            build = BuildComparison(spec->conds[c], cond->add_operands());
+          }
         }
       }
     }

--- a/src/yb/thin_client/yb_thin_client.cc
+++ b/src/yb/thin_client/yb_thin_client.cc
@@ -17,11 +17,9 @@
 // YBSession / Batcher / metacache / TabletInvoker: each op carries its own partition routing info
 // (hash_code + partition_key) and the tserver routes it, exactly as it does for pggate.
 //
-// BACKWARD COMPATIBILITY: this library is shipped and consumed outside the YugabyteDB build and is
-// upgraded before the tserver, so it must keep working against an OLDER tserver than it was
-// compiled against. Keep the wire usage backward-compatible: only send request fields / rely on
-// RPCs and semantics the oldest supported tserver understands, and tolerate responses that lack
-// fields a newer server would set. Keep the C ABI (see yb_thin_client.h) additive-only.
+// BACKWARD COMPATIBILITY: this library is upgraded before the tserver, so it must keep working
+// against an OLDER one -- only rely on request fields and semantics the oldest supported tserver
+// understands, and tolerate responses missing newer fields. See yb_thin_client.h for the full rule.
 //
 
 #include "yb/thin_client/yb_thin_client.h"
@@ -103,10 +101,8 @@ static constexpr int kDefaultNumReactors = 4;
 static constexpr uint32_t kDefaultReadSessions = 4;
 static constexpr uint32_t kDefaultWriteSessions = 1;
 static constexpr uint32_t kDefaultSessionsPerConn = 4;
-// read_time_serial_no_history_min is set this far BELOW the current read serial (matching
-// yb_tsclient): the server keeps the read points of that many recent serials so paged scans /
-// continuations can restore their snapshot, while older ones are pruned. Setting it EQUAL to the
-// serial prunes everything and is part of what left the shim's read point sticky.
+// How far below the current read serial to set read_time_serial_no_history_min: the server keeps
+// the read points of that many recent serials, so continuations can restore their snapshot.
 static constexpr uint64_t kReadSerialHistoryWindow = 65536;
 
 // ---- opaque handles -------------------------------------------------------
@@ -122,12 +118,10 @@ struct ybthin_connection {
 };
 
 // One PgClientService session. The server serializes a session's Performs by a contiguous serial
-// starting at 0 (pg_client_service.cc next_expected_serial_no_), so serial_no / read_time_serial /
-// stmt_id are per-session and serial_no MUST start at 0 and be allocated only for dispatched
-// Performs (a gap stalls later Performs until their deadline). `generation` identifies this
-// incarnation: a paged scan pinned to (session, generation) becomes invalid once the session is
-// reopened with a fresh session_id (serials reset), so continuations on a stale generation are
-// reported as YBTHIN_READ_RESTART.
+// starting at 0 (pg_client_service.cc next_expected_serial_no_), so serial_no must start at 0 and
+// be allocated only for dispatched Performs -- a gap stalls later ones until their deadline.
+// Reopening the session resets the serials and bumps `generation`, invalidating scans pinned to
+// the old incarnation (reported as YBTHIN_READ_RESTART).
 struct ybthin_session {
   size_t conn_index = 0;
   std::mutex mu;  // guards {open, session_id, serial_no, read_time_serial, stmt_id, generation}
@@ -146,18 +140,15 @@ struct ybthin_client {
   std::vector<std::unique_ptr<ybthin_session>> write_sessions;
   std::atomic<size_t> read_rr{0};   // round-robin cursor for read-session selection
   std::atomic<size_t> write_rr{0};  // round-robin cursor for write-session selection
-  // A fresh txn_serial_no is stamped on every Perform. The server keeps a plain session's read
-  // point (and transaction) alive across Performs that carry the SAME txn_serial_no, so a constant
-  // would freeze the read point at the first read -- reads would never see later commits. Advancing
-  // it per Perform makes each one a fresh logical transaction that picks a new read point (this is
-  // what pggate/yb_tsclient do; see pg_client_session.cc gating on txn_serial_no_).
+  // The server keeps a plain session's read point alive across Performs carrying the SAME
+  // txn_serial_no, so a fresh one per Perform makes each a new logical transaction that picks a
+  // new read point (see pg_client_session.cc gating on txn_serial_no_).
   std::atomic<uint64_t> txn_serial{1};
   std::vector<HostPort> hosts;
   MonoDelta timeout;
   int num_reactors = kDefaultNumReactors;
 
-  // Keepalive. Deliberately std::thread, not yb::Thread: this .so is self-contained and must not
-  // pull in YB's global thread registry / tracking machinery for a single background heartbeat.
+  // std::thread, not yb::Thread: a self-contained .so must not pull in YB's global thread registry.
   std::thread keepalive_thread;  // NOLINT(build/std_thread)
   std::mutex mu;
   std::condition_variable cv;
@@ -173,7 +164,7 @@ struct ybthin_table {
   };
   std::string table_id;
   uint32_t schema_version = 0;
-  Schema schema;  // num_hash_key_columns() / num_key_columns() are read directly off this
+  Schema schema;
   PartitionSchema partition_schema;
   std::vector<ColInfo> columns;  // owns the name strings referenced by ybthin_column
 };
@@ -375,21 +366,15 @@ ybthin_session* NextWriteSession(ybthin_client* client) {
   return pool[client->write_rr.fetch_add(1, std::memory_order_relaxed) % pool.size()].get();
 }
 
-// Wrapped paging state =
+// Wrapped paging state, passed back opaquely by the caller:
 //   [magic][version][u32 read-session index][u32 generation][u64 read_time_serial][u64 txn_serial]
 //   + the server's paging state.
-// The caller passes this back opaquely. On continuation the shim routes to the same session
-// (generation-checked) AND replays the scan's original read_time_serial / txn_serial rather than
-// allocating new ones -- keeping read_time_serial_no constant across a scan's pages, exactly as
-// pggate does within a single statement, so the server restores this scan's read point and every
-// page observes ONE snapshot. (Advancing the serial per page made the server's
-// ENSURE_READ_TIME_IS_SET pick a fresh, later read time each page, dropping rows deleted mid-scan.)
+// A continuation routes back to the same session (generation-checked) and replays the scan's
+// original serials, so every page of a scan reads at one snapshot (see SetReadTimeSerial).
 constexpr uint8_t kPagingMagic = 0xB1;
 constexpr uint8_t kPagingVersion = 2;
 constexpr size_t kPagingHeaderLen = 2 + 4 + 4 + 8 + 8;
 
-// Little-endian pack/unpack via gutil's tested primitives (LittleEndian::{Store,Load}{32,64}),
-// wrapped so the append-to-string / read-from-pointer call sites stay compact.
 void PutU32LE(std::string* s, uint32_t v) {
   char buf[sizeof(v)];
   LittleEndian::Store32(buf, v);
@@ -421,8 +406,9 @@ std::string WrapPagingState(
 struct PinInfo {
   uint32_t session_index;
   uint32_t generation;
-  uint64_t read_time_serial;  // the scan's original serials; a continuation replays them so the
-  uint64_t txn_serial;        // server restores this scan's read point instead of picking a new one
+  // The scan's original serials, replayed by a continuation so the server restores its read point.
+  uint64_t read_time_serial;
+  uint64_t txn_serial;
   Slice server_paging_state;
 };
 Result<PinInfo> UnwrapPagingState(const uint8_t* data, size_t len) {
@@ -435,9 +421,8 @@ Result<PinInfo> UnwrapPagingState(const uint8_t* data, size_t len) {
 }
 
 // Stamps a Perform's read serial and the matching windowed history_min. The server keeps the read
-// points of serials in [serial - kReadSerialHistoryWindow, serial] so paged scans / continuations
-// can restore their snapshot; setting history_min == serial would prune them. The read and write
-// dispatch paths both call this so the window (a non-obvious server coupling) lives in one place.
+// points of serials in [serial - kReadSerialHistoryWindow, serial] so continuations can restore
+// their snapshot; setting history_min == serial would prune them.
 template <class ReadTimeOptionsPB>
 void SetReadTimeSerial(ReadTimeOptionsPB* rto, uint64_t serial) {
   rto->set_read_time_serial_no(serial);
@@ -474,24 +459,25 @@ ybthin_status PgsqlResponseError(const yb::PgsqlResponsePB& r) {
 // ---- async call contexts --------------------------------------------------
 
 struct ReadCall {
-  ybthin_session* session;      // the one session this batch runs on
-  uint32_t session_index;       // its index into client->read_sessions (for wrapping)
-  uint32_t generation;          // session incarnation this batch ran at (for wrapping)
-  bool has_continuation;        // any op is a continuation -> its pinned session must still match
-  uint32_t pinned_generation;   // generation the continuation ops were pinned to
-  uint64_t pinned_read_time_serial;  // a continuation replays the scan's original serials (below)
-  uint64_t pinned_txn_serial;        // instead of advancing, so the server restores its read point
-  uint64_t read_time_serial;    // serials actually used for THIS Perform; wrapped into the response
-  uint64_t txn_serial;          // paging state so the next page replays them
+  ybthin_session* session;     // the one session this batch runs on
+  uint32_t session_index;      // its index into client->read_sessions (for wrapping)
+  uint32_t generation;         // session incarnation this batch ran at (for wrapping)
+  bool has_continuation;       // any op is a continuation -> its pinned session must still match
+  // What the continuation ops were pinned to, and what this Perform actually ran at. The latter is
+  // wrapped into the response paging state for the next page to replay.
+  uint32_t pinned_generation;
+  uint64_t pinned_read_time_serial;
+  uint64_t pinned_txn_serial;
+  uint64_t read_time_serial;
+  uint64_t txn_serial;
   tserver::PgPerformRequestPB req;
   tserver::PgPerformResponsePB resp;
   rpc::RpcController controller;
   ybthin_read_cb cb;
   void* ctx;
   uint64_t used_read_time_ht;
-  // Per-op target column value types, in target (== response cell) order. The
-  // row sidecar isn't self-describing, so decoding each op's response needs
-  // these; the shim has them from the opened tables' schemas.
+  // Per-op target column types, in target (== response cell) order: the row sidecar is not
+  // self-describing, so decoding needs the types from the opened table's schema.
   std::vector<std::vector<ybthin_value_type>> op_target_types;
 };
 
@@ -504,13 +490,10 @@ struct WriteCall {
   void* ctx;
 };
 
-// Decodes the pg_doc_data row sidecar into a flat, row-major array of
-// (n_rows * target_types.size()) cells using YugabyteDB's own PgWire/PgDocData
-// readers (the single source of truth for the wire format). The cells and the
-// TEXT/BYTEA byte payloads they point into are returned as ONE malloc'd block
-// (the byte arena trails the cell array), so the caller frees it with a single
-// free(*out_cells). `target_types` gives each target column's type in target
-// (== cell) order, since the sidecar is not self-describing.
+// Decodes the pg_doc_data row sidecar into a row-major array of (n_rows * target_types.size())
+// cells, using YugabyteDB's own PgWire/PgDocData readers for the wire format. The cells and the
+// TEXT/BYTEA payloads they point into are returned as ONE malloc'd block (the byte arena trails
+// the cell array), so the caller frees it with a single free(*out_cells).
 Status DecodeReadRows(
     Slice sidecar, const std::vector<ybthin_value_type>& target_types,
     ybthin_cell** out_cells, size_t* out_n_rows) {
@@ -648,10 +631,8 @@ void FinishRead(ReadCall* raw) {
   result->results = static_cast<ybthin_read_op_result*>(
       calloc(n_ops ? n_ops : 1, sizeof(ybthin_read_op_result)));
 
-  // The hybrid time the batch actually ran at (all ops share one snapshot). For a pinned batch it
-  // is the caller's read_time_ht; for a fresh (read_time_ht == 0) batch the server picks it and
-  // reports it in the paging state -- surface it so the caller can pin follow-up pages/batches to
-  // the same snapshot.
+  // For a fresh batch the server picks the snapshot and reports it in the paging state; surface it
+  // so the caller can pin follow-up batches to the same one.
   uint64_t picked_read_ht = 0;
 
   for (size_t i = 0; i < n_ops; ++i) {
@@ -680,8 +661,6 @@ void FinishRead(ReadCall* raw) {
     // A missing paging_state means this op's scan is exhausted; otherwise wrap the server's paging
     // state with the pinning header so a continuation returns to this batch's session.
     if (op.has_paging_state()) {
-      // The server stamps the snapshot it chose into the paging state; capture it as the batch's
-      // used read time (all ops ran at one snapshot).
       if (op.paging_state().read_time().has_read_ht()) {
         picked_read_ht = op.paging_state().read_time().read_ht();
       }
@@ -954,9 +933,8 @@ void ybthin_read_async(
   call->ctx = ctx;
   call->used_read_time_ht = read_time_ht;
 
-  // Select the batch's session. Continuation ops (paging_state_in set) return to the session that
-  // issued them, so all continuations in a batch must pin the SAME session; a batch with no
-  // continuations round-robins the read pool. Fresh ops ride whichever session is chosen.
+  // Continuation ops must return to the session that issued them, so all of them in a batch must
+  // pin the same one; a batch with no continuations round-robins the read pool.
   bool have_pinned = false;
   size_t session_index = 0;
   uint32_t pinned_generation = 0;
@@ -1078,25 +1056,20 @@ void ybthin_read_async(
   // One snapshot for the whole batch.
   auto* rto = req.mutable_options()->mutable_read_time_options();
   if (read_time_ht == 0) {
-    // Let the server pick the read point. ENSURE + clamp + the read serial (set at dispatch) drive
-    // it: for a FRESH scan the serial advances, so the server picks a new clamped read time (a new
-    // snapshot that observes the latest commits -- read-after-write). For a CONTINUATION the serial
-    // is REPLAYED (unchanged), so the server restores the scan's read point and ENSURE is a no-op
-    // -- every page reads at one snapshot. This mirrors pggate: advance read_time_serial_no per
-    // statement, hold it constant across that statement's pages.
+    // Let the server pick the read point; the read serial set at dispatch decides which one -- a
+    // fresh serial gets a new snapshot, a replayed one restores the scan's (ENSURE then no-ops).
     rto->set_read_time_manipulation(tserver::ENSURE_READ_TIME_IS_SET);
     rto->set_clamp_uncertainty_window(true);
   } else {
-    // Pin the batch to an explicit snapshot (e.g. paged-scan continuation, or a second batch that
-    // must observe the same snapshot as a prior one via its used_read_time_ht).
+    // Pin the batch to an explicit snapshot, e.g. a prior batch's used_read_time_ht.
     auto* rt = rto->mutable_read_time();
     rt->set_read_ht(read_time_ht);
     rt->set_global_limit_ht(read_time_ht);
   }
 
-  // Bind the session identity and dispatch under the session lock: reopen the session if a prior
-  // failure dropped it; a continuation whose session was reopened can no longer be served, so
-  // report READ_RESTART. The Perform serial is allocated last so a failed build never leaves a gap.
+  // Dispatch under the session lock, reopening the session if a prior failure dropped it. A
+  // continuation whose session was reopened can no longer be served, so report READ_RESTART.
+  // The Perform serial is allocated last so a failed build leaves no gap.
   ReadCall* raw = call.release();
   auto* s = raw->session;
   ybthin_status early = OkStatus();
@@ -1113,16 +1086,14 @@ void ybthin_read_async(
       uint64_t read_serial;
       uint64_t txn_serial;
       if (raw->has_continuation) {
-        // Continue the scan on its ORIGINAL serials (carried in the paging state) instead of
-        // allocating new ones. With read_time_serial_no unchanged, the server restores this scan's
-        // read point (pg_client_session.cc read_point_history_) and every page reads at one
-        // snapshot -- the way pggate keeps read_time_serial_no constant across a statement's pages.
+        // Replay the scan's original serials: with read_time_serial_no unchanged the server
+        // restores its read point (pg_client_session.cc read_point_history_), so every page of the
+        // scan reads at one snapshot. This is how pggate holds a statement's pages together.
         read_serial = raw->pinned_read_time_serial;
         txn_serial = raw->pinned_txn_serial;
       } else {
-        // Fresh scan == a new statement: advance to a new read point so it observes the latest
-        // committed data (read-after-write), and a fresh transaction serial so the server does not
-        // reuse this session's prior read point.
+        // A fresh scan is a new statement: advance both serials so it gets a new read point and
+        // observes the latest committed data.
         read_serial = s->read_time_serial++;
         txn_serial = client->txn_serial.fetch_add(1);
       }
@@ -1133,8 +1104,7 @@ void ybthin_read_async(
       raw->req.mutable_options()->set_txn_serial_no(txn_serial);
       raw->req.set_session_id(s->session_id);
       raw->req.set_serial_no(s->serial_no++);
-      // Remember the serials this Perform ran at so FinishRead can wrap them into the response
-      // paging state for the next page to replay.
+      // FinishRead wraps these into the response paging state for the next page to replay.
       raw->read_time_serial = read_serial;
       raw->txn_serial = txn_serial;
       dispatch = true;
@@ -1210,10 +1180,9 @@ void ybthin_upsert_batch_async(
     return;
   }
 
-  // Bind the session identity and dispatch under the session lock. A non-transactional write
-  // carries a read-time serial (+ history min) and lets the storage layer pick the read time for
-  // conflict resolution (pg_txn_manager.cc SetupReadTimeOptions). The Perform serial is allocated
-  // last so a failed build never leaves a gap in the session's contiguous serial sequence.
+  // Dispatch under the session lock. A non-transactional write still carries a read-time serial and
+  // lets the storage layer pick the read time for conflict resolution (pg_txn_manager.cc
+  // SetupReadTimeOptions). The Perform serial is allocated last so a failed build leaves no gap.
   WriteCall* raw = call.release();
   auto* s = raw->session;
   ybthin_status early = OkStatus();

--- a/src/yb/thin_client/yb_thin_client.h
+++ b/src/yb/thin_client/yb_thin_client.h
@@ -1,0 +1,304 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+
+/* yb_thin_client.h — C ABI for a thin, Perform-based YugabyteDB tserver client.
+ *
+ * This header is the ONLY contract between the (foreign) caller and the C++
+ * implementation (`yb_thin_client.cc`, built against the YugabyteDB tree). The
+ * client speaks `yb.tserver.PgClientService.Perform` directly to a tserver
+ * RPC endpoint and lets the tserver route each op to the right tablet —
+ * there is deliberately NO client-side metacache, batcher, or tablet
+ * invoker on the caller's side.
+ *
+ * VERSIONING / BACKWARD COMPATIBILITY: this library is built, shipped and
+ * consumed OUTSIDE the YugabyteDB build tree, and it is upgraded BEFORE the
+ * tserver — so a given build of it must keep working against an OLDER tserver
+ * than the one it was compiled against. Keep its on-the-wire usage
+ * BACKWARD-COMPATIBLE with older servers:
+ *   - Only send Perform requests / set protobuf fields / rely on RPCs and
+ *     semantics that the OLDEST supported tserver already understands. Never
+ *     require a request field, op, or behavior that only a newer tserver added
+ *     — an older server will ignore or reject it.
+ *   - Tolerate responses from an older server that lack fields a newer server
+ *     would set; never depend on such a field being present.
+ * The C ABI below is likewise a stable contract: make only ADDITIVE changes
+ * (new functions; new fields appended to the END of structs; new enum values
+ * appended at the END). Never renumber/repurpose an existing enum value,
+ * reorder or remove a struct field, or change a function signature in place.
+ *
+ * Ownership: every out-pointer the library fills is owned by it and freed
+ * with the matching `*_free`/`*_destroy` below. Input arrays and strings are
+ * borrowed for the duration of the call only. All strings are UTF-8,
+ * NUL-terminated. The header is C (extern "C"); it must compile under a plain
+ * C compiler and expose no C++ types.
+ */
+#ifndef YB_THIN_CLIENT_YB_THIN_CLIENT_H
+#define YB_THIN_CLIENT_YB_THIN_CLIENT_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ---- status --------------------------------------------------------- */
+
+typedef enum {
+  YBTHIN_OK = 0,
+  YBTHIN_INVALID = 1,      /* bad arguments / misuse — never retry        */
+  YBTHIN_NETWORK = 2,      /* transport loss, timeout, or lost session    */
+  YBTHIN_TRY_AGAIN = 3,    /* transient server state (leader not ready…)  */
+  YBTHIN_READ_RESTART = 4, /* restart_read_time: caller restarts the scan */
+  YBTHIN_SCHEMA = 5,       /* schema-version mismatch — reopen the table  */
+  YBTHIN_OTHER = 6,        /* anything else — fatal                       */
+} ybthin_status_code;
+
+/* Returned by fallible calls. `message` is owned (free with
+ * ybthin_string_free) and NULL when code == YBTHIN_OK. */
+typedef struct {
+  ybthin_status_code code;
+  char* message;
+} ybthin_status;
+
+/* ---- handles -------------------------------------------------------- */
+
+typedef struct ybthin_client ybthin_client; /* one per process component  */
+typedef struct ybthin_table ybthin_table;   /* an opened table handle      */
+
+/* ---- client lifecycle ----------------------------------------------- */
+
+typedef struct {
+  const char* ca_cert_path; /* NULL => plaintext (no TLS)                 */
+  const char* cert_path;    /* client cert; NULL if not using mTLS        */
+  const char* key_path;     /* client key;  NULL if not using mTLS        */
+} ybthin_tls_opts;
+
+/* Session/connection pool sizing. A single PgClientService session serializes
+ * its Performs by serial number server-side, so concurrency comes from having
+ * many sessions; connections spread those sessions across tserver nodes (behind
+ * a ClusterIP VIP, each new connection may land on a different tserver).
+ * `sessions_per_conn` sessions are packed onto each connection; the client opens
+ * ceil((read_sessions + write_sessions) / sessions_per_conn) connections.
+ * Reads round-robin the read sessions; upserts round-robin the write sessions
+ * (falling back to read sessions when write_sessions == 0). A field of 0 (or a
+ * NULL ybthin_pool_opts) selects the default for that field. */
+typedef struct {
+  uint32_t read_sessions;      /* 0 => default (4)                          */
+  uint32_t write_sessions;     /* 0 => default (1)                          */
+  uint32_t sessions_per_conn;  /* 0 => default (4)                          */
+} ybthin_pool_opts;
+
+/* Connect to one or more tserver RPC endpoints ("host:port", default port
+ * 9100). Opens a pool of PgClientService sessions (Heartbeat) across one or
+ * more connections and starts their keepalive. No master addresses are needed —
+ * routing is server-side. */
+ybthin_status ybthin_client_create(const char* const* tserver_addrs,
+                                   size_t n_addrs,
+                                   const ybthin_tls_opts* tls,   /* nullable */
+                                   const ybthin_pool_opts* pool, /* nullable */
+                                   uint32_t rpc_timeout_ms,
+                                   uint32_t num_reactors, /* 0 => default   */
+                                   ybthin_client** out);
+
+void ybthin_client_destroy(ybthin_client*);
+
+/* ---- table open + schema -------------------------------------------- */
+
+typedef enum {
+  YBTHIN_COL_HASH = 0,
+  YBTHIN_COL_RANGE = 1,
+  YBTHIN_COL_VALUE = 2,
+} ybthin_col_kind;
+
+typedef enum {
+  YBTHIN_T_BOOL = 0,
+  YBTHIN_T_I16 = 1,
+  YBTHIN_T_I32 = 2,
+  YBTHIN_T_I64 = 3,
+  YBTHIN_T_TEXT = 4,
+  YBTHIN_T_BYTEA = 5,
+} ybthin_value_type;
+
+typedef struct {
+  const char* name; /* owned by the table handle (valid until close)      */
+  int32_t id;       /* DocDB column id                                    */
+  ybthin_col_kind kind;
+  ybthin_value_type type;
+} ybthin_column;
+
+/* Filled by ybthin_table_open. `columns` is owned by the shim; free with
+ * ybthin_columns_free. Kept in schema order (hash, then range, then
+ * value), so the caller can bind hash/key values positionally. */
+typedef struct {
+  ybthin_column* columns;
+  size_t n_columns;
+} ybthin_table_info;
+
+/* Resolve a table by (db_oid, table_oid): computes its pgsql table id and
+ * fetches its schema. Fails fast if the tserver/table is unreachable —
+ * used as the startup health check. */
+ybthin_status ybthin_table_open(ybthin_client*, uint32_t db_oid,
+                                uint32_t table_oid, ybthin_table** out,
+                                ybthin_table_info* info_out);
+
+void ybthin_table_close(ybthin_table*);
+void ybthin_columns_free(ybthin_column*, size_t n);
+
+/* ---- values, conditions, read spec ---------------------------------- */
+
+typedef enum {
+  YBTHIN_BIND_NULL = 0,
+  YBTHIN_BIND_BOOL = 1,
+  YBTHIN_BIND_I16 = 2,
+  YBTHIN_BIND_I32 = 3,
+  YBTHIN_BIND_I64 = 4,
+  YBTHIN_BIND_TEXT = 5,
+  YBTHIN_BIND_BYTEA = 6,
+} ybthin_bind_tag;
+
+/* A bound value. For BOOL/I16/I32/I64 read `i`; for TEXT/BYTEA read
+ * (`bytes`, `bytes_len`). The shim encodes each per its column's DocDB
+ * type (raw big-endian ints, raw bytes for text/binary). */
+typedef struct {
+  ybthin_bind_tag tag;
+  int64_t i;
+  const uint8_t* bytes;
+  size_t bytes_len;
+} ybthin_bind;
+
+typedef enum {
+  YBTHIN_EQ = 0,
+  YBTHIN_LE = 1,
+  YBTHIN_GE = 2,
+  YBTHIN_LT = 3,
+  YBTHIN_GT = 4,
+} ybthin_cond_op;
+
+typedef struct {
+  int32_t column_id;
+  ybthin_cond_op op;
+  ybthin_bind value;
+} ybthin_cond;
+
+typedef struct {
+  const ybthin_bind* hash_values; /* hash cols in schema order            */
+  size_t n_hash;
+  const ybthin_cond* conds; /* range/lsn bounds (AND-combined)            */
+  size_t n_conds;
+  const int32_t* target_ids; /* column ids to return, in order            */
+  size_t n_targets;
+  uint64_t limit;      /* rows per page; 0 => server default              */
+  int is_forward_scan; /* bool: PK stores lsn DESC, so forward == desc    */
+} ybthin_read_spec;
+
+/* A decoded cell of a read result. NULL is a tag (tag == YBTHIN_BIND_NULL);
+ * BOOL/I16/I32/I64 read `i`; TEXT/BYTEA read (`bytes`, `bytes_len`). `bytes`
+ * point into result-owned storage, valid until ybthin_read_result_free.
+ * Mirrors ybthin_bind (the write side) so the value model is symmetric. */
+typedef struct {
+  ybthin_bind_tag tag;
+  int64_t i;
+  const uint8_t* bytes;
+  size_t bytes_len;
+} ybthin_cell;
+
+/* One read op in a batch. Each op names its own table (a batch may mix
+ * tables). `paging_state_in`==NULL (len 0) starts this op's scan; a prior
+ * page's paging_state continues it. Note: the read snapshot is a batch
+ * property (ybthin_read_async's read_time_ht), NOT part of the spec. */
+typedef struct {
+  ybthin_table* table;
+  ybthin_read_spec spec;
+  const uint8_t* paging_state_in;
+  size_t paging_state_in_len;
+} ybthin_read_op;
+
+/* Per-op slice of a batch result, decoded by the shim (using YugabyteDB's own
+ * pg_doc_data codec) into a row-major array of typed cells: the cell at row r,
+ * column c is `cells[r * n_cols + c]`, and `n_cols == the op's spec.n_targets`
+ * (cells follow target order). `paging_state` is NULL/0 when this op's scan is
+ * exhausted; otherwise pass it back verbatim as a later op's `paging_state_in`
+ * to continue. */
+typedef struct {
+  ybthin_cell* cells;
+  size_t n_rows;
+  size_t n_cols;
+  uint8_t* paging_state;
+  size_t paging_state_len;
+} ybthin_read_op_result;
+
+/* Whole-batch result: `results[i]` corresponds to the i-th op passed to
+ * ybthin_read_async. `used_read_time_ht` is the hybrid time the WHOLE batch
+ * ran at (one snapshot per Perform; 0 if the server did not report one).
+ * Owned by the shim; free once with ybthin_read_result_free. */
+typedef struct {
+  ybthin_read_op_result* results;
+  size_t n_ops;
+  uint64_t used_read_time_ht;
+} ybthin_read_result;
+
+void ybthin_read_result_free(ybthin_read_result*);
+
+/* ---- upsert (write) rows -------------------------------------------- */
+
+/* One PGSQL_UPSERT row: its table, PK columns (schema order), plus non-key
+ * cells as parallel (id, value) arrays. Each row names its table, so a write
+ * batch may span tables (all rows still ride ONE Perform). */
+typedef struct {
+  ybthin_table* table;
+  const ybthin_bind* key_values;
+  size_t n_keys;
+  const int32_t* value_ids;
+  const ybthin_bind* values;
+  size_t n_values;
+} ybthin_upsert_row;
+
+/* ---- async execution ------------------------------------------------ */
+
+/* Completion callbacks. They may run on a YB reactor thread, so they MUST
+ * be cheap and non-blocking (signal a channel and return). `ctx` is the
+ * opaque pointer handed to the call. `status`/`result` are owned by the
+ * callback: copy what you need, then free them (ybthin_string_free /
+ * ybthin_read_result_free) before returning. */
+typedef void (*ybthin_read_cb)(void* ctx, ybthin_status status,
+                               ybthin_read_result* result);
+typedef void (*ybthin_write_cb)(void* ctx, ybthin_status status);
+
+/* Run a batch of read ops as the ops of ONE Perform: one RPC, one read
+ * session, one snapshot. `results[i]` in the delivered ybthin_read_result
+ * corresponds to `ops[i]`. `read_time_ht` pins the batch snapshot (0 => the
+ * server picks a clamped read point); pass a prior batch's `used_read_time_ht`
+ * to continue its scans under the same snapshot. An op with `paging_state_in`
+ * set continues that op's scan; mixed fresh/continuation batches are legal, but
+ * all continuation ops must share the paging session that issued them.
+ * Status is batch-level: any op failure fails the whole call (no partial
+ * results) — on YBTHIN_READ_RESTART the caller re-issues from fresh pages. */
+void ybthin_read_async(ybthin_client*, const ybthin_read_op* ops, size_t n_ops,
+                       uint64_t read_time_ht, ybthin_read_cb cb, void* ctx);
+
+/* Apply N upserts as the ops of ONE Perform (one write batch on one write
+ * session). Each row names its own table, so the batch may span tables. The
+ * shim verifies every op's per-row response status; any failure surfaces via
+ * `status`. */
+void ybthin_upsert_batch_async(ybthin_client*, const ybthin_upsert_row* rows,
+                               size_t n_rows, ybthin_write_cb cb, void* ctx);
+
+/* ---- misc ----------------------------------------------------------- */
+
+void ybthin_string_free(char*);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif  // YB_THIN_CLIENT_YB_THIN_CLIENT_H

--- a/src/yb/thin_client/yb_thin_client.h
+++ b/src/yb/thin_client/yb_thin_client.h
@@ -192,6 +192,11 @@ typedef struct {
   size_t n_targets;
   uint64_t limit;      /* rows per page; 0 => server default              */
   int is_forward_scan; /* bool: PK stores lsn DESC, so forward == desc    */
+  /* Range key cols in schema order, for a RANGE-sharded table: a full key
+   * targets one row, a prefix that prefix's range, NULL/0 the whole table.
+   * Mixing these with hash_values returns YBTHIN_INVALID. */
+  const ybthin_bind* range_values;
+  size_t n_range;
 } ybthin_read_spec;
 
 /* A decoded cell of a read result. NULL is a tag (tag == YBTHIN_BIND_NULL);

--- a/src/yb/thin_client/yb_thin_client.h
+++ b/src/yb/thin_client/yb_thin_client.h
@@ -19,21 +19,15 @@
  * there is deliberately NO client-side metacache, batcher, or tablet
  * invoker on the caller's side.
  *
- * VERSIONING / BACKWARD COMPATIBILITY: this library is built, shipped and
- * consumed OUTSIDE the YugabyteDB build tree, and it is upgraded BEFORE the
- * tserver — so a given build of it must keep working against an OLDER tserver
- * than the one it was compiled against. Keep its on-the-wire usage
- * BACKWARD-COMPATIBLE with older servers:
- *   - Only send Perform requests / set protobuf fields / rely on RPCs and
- *     semantics that the OLDEST supported tserver already understands. Never
- *     require a request field, op, or behavior that only a newer tserver added
- *     — an older server will ignore or reject it.
- *   - Tolerate responses from an older server that lack fields a newer server
- *     would set; never depend on such a field being present.
- * The C ABI below is likewise a stable contract: make only ADDITIVE changes
- * (new functions; new fields appended to the END of structs; new enum values
- * appended at the END). Never renumber/repurpose an existing enum value,
- * reorder or remove a struct field, or change a function signature in place.
+ * VERSIONING / BACKWARD COMPATIBILITY: this library is built and shipped
+ * OUTSIDE the YugabyteDB tree and upgraded BEFORE the tserver, so a given build
+ * must keep working against an OLDER tserver. On the wire: only rely on request
+ * fields, RPCs and semantics the OLDEST supported tserver understands, and
+ * tolerate responses missing fields a newer server would set.
+ * The C ABI below is likewise stable — make only ADDITIVE changes (new
+ * functions; fields appended to the END of structs; enum values appended at the
+ * END). Never renumber an enum value, reorder or remove a struct field, or
+ * change a function signature in place.
  *
  * Ownership: every out-pointer the library fills is owned by it and freed
  * with the matching `*_free`/`*_destroy` below. Input arrays and strings are
@@ -83,15 +77,14 @@ typedef struct {
   const char* key_path;     /* client key;  NULL if not using mTLS        */
 } ybthin_tls_opts;
 
-/* Session/connection pool sizing. A single PgClientService session serializes
- * its Performs by serial number server-side, so concurrency comes from having
- * many sessions; connections spread those sessions across tserver nodes (behind
- * a ClusterIP VIP, each new connection may land on a different tserver).
- * `sessions_per_conn` sessions are packed onto each connection; the client opens
- * ceil((read_sessions + write_sessions) / sessions_per_conn) connections.
- * Reads round-robin the read sessions; upserts round-robin the write sessions
- * (falling back to read sessions when write_sessions == 0). A field of 0 (or a
- * NULL ybthin_pool_opts) selects the default for that field. */
+/* Session/connection pool sizing. The server serializes a single session's
+ * Performs by serial number, so concurrency comes from having many sessions;
+ * connections spread them across tserver nodes (behind a ClusterIP VIP, each
+ * new connection may land on a different one). `sessions_per_conn` sessions are
+ * packed per connection, so the client opens
+ * ceil((read_sessions + write_sessions) / sessions_per_conn) of them. Reads and
+ * upserts each round-robin their pool (upserts fall back to the read sessions
+ * when write_sessions == 0). A 0 field (or NULL opts) takes the default. */
 typedef struct {
   uint32_t read_sessions;      /* 0 => default (4)                          */
   uint32_t write_sessions;     /* 0 => default (1)                          */
@@ -275,18 +268,15 @@ typedef void (*ybthin_read_cb)(void* ctx, ybthin_status status,
 typedef void (*ybthin_write_cb)(void* ctx, ybthin_status status);
 
 /* Run a batch of read ops as the ops of ONE Perform: one RPC, one read
- * session, one snapshot. `results[i]` in the delivered ybthin_read_result
- * corresponds to `ops[i]`. `read_time_ht` pins the batch snapshot (0 => the
- * server picks a clamped read point). An op with `paging_state_in` set continues
- * that op's scan; a continuation automatically stays on the scan's ORIGINAL
- * snapshot (the paging_state carries it), so paging a scan with `read_time_ht`
- * left 0 on every page is snapshot-consistent — no rows are dropped even if data
- * changes mid-scan. Passing a prior batch's `used_read_time_ht` as `read_time_ht`
- * is only needed to force a NEW batch of scans onto an existing snapshot. Mixed
- * fresh/continuation batches are legal, but all continuation ops must share the
- * paging session (and snapshot) that issued them.
- * Status is batch-level: any op failure fails the whole call (no partial
- * results) — on YBTHIN_READ_RESTART the caller re-issues from fresh pages. */
+ * session, one snapshot. `results[i]` corresponds to `ops[i]`.
+ * `read_time_ht` pins the batch snapshot (0 => the server picks one); pass a
+ * prior batch's `used_read_time_ht` only to force a NEW batch onto an existing
+ * snapshot. An op with `paging_state_in` set continues that op's scan and stays
+ * on the scan's original snapshot automatically, so paging with `read_time_ht`
+ * left 0 throughout is still consistent — no rows are dropped mid-scan.
+ * Continuation ops in one batch must all share the paging session that issued
+ * them. Status is batch-level: any op failure fails the whole call with no
+ * partial results; on YBTHIN_READ_RESTART re-issue the scan from a fresh page. */
 void ybthin_read_async(ybthin_client*, const ybthin_read_op* ops, size_t n_ops,
                        uint64_t read_time_ht, ybthin_read_cb cb, void* ctx);
 

--- a/src/yb/thin_client/yb_thin_client.h
+++ b/src/yb/thin_client/yb_thin_client.h
@@ -277,10 +277,14 @@ typedef void (*ybthin_write_cb)(void* ctx, ybthin_status status);
 /* Run a batch of read ops as the ops of ONE Perform: one RPC, one read
  * session, one snapshot. `results[i]` in the delivered ybthin_read_result
  * corresponds to `ops[i]`. `read_time_ht` pins the batch snapshot (0 => the
- * server picks a clamped read point); pass a prior batch's `used_read_time_ht`
- * to continue its scans under the same snapshot. An op with `paging_state_in`
- * set continues that op's scan; mixed fresh/continuation batches are legal, but
- * all continuation ops must share the paging session that issued them.
+ * server picks a clamped read point). An op with `paging_state_in` set continues
+ * that op's scan; a continuation automatically stays on the scan's ORIGINAL
+ * snapshot (the paging_state carries it), so paging a scan with `read_time_ht`
+ * left 0 on every page is snapshot-consistent — no rows are dropped even if data
+ * changes mid-scan. Passing a prior batch's `used_read_time_ht` as `read_time_ht`
+ * is only needed to force a NEW batch of scans onto an existing snapshot. Mixed
+ * fresh/continuation batches are legal, but all continuation ops must share the
+ * paging session (and snapshot) that issued them.
  * Status is batch-level: any op failure fails the whole call (no partial
  * results) — on YBTHIN_READ_RESTART the caller re-issues from fresh pages. */
 void ybthin_read_async(ybthin_client*, const ybthin_read_op* ops, size_t n_ops,


### PR DESCRIPTION
## Summary

Adds **`yb_thin_client`** — a thin, self-contained shared library (stable C ABI in `yb_thin_client.h`) that speaks `yb.tserver.PgClientService.Perform` directly to a tserver RPC endpoint. There is deliberately **no** `YBClient` / `YBSession` / batcher / metacache / tablet invoker: each op carries its own partition routing (`hash_code` + `partition_key`) and the tserver routes it, exactly as it does for pggate. It is meant to be built, shipped, and consumed **outside** the YugabyteDB build by a foreign process.

What's included:
- **C ABI** (`yb_thin_client.h`): client/table lifecycle, batch-first async read (`ybthin_read_async`) and async upsert (`ybthin_upsert_batch_async`), typed value/cell model, TLS/mTLS options, and a session/connection pool with keepalive.
- **Implementation** (`yb_thin_client.cc`): session pool over `PgClientServiceProxy`, table-open + schema resolution, `pg_doc_data` row-sidecar decoding via YugabyteDB's own `PgWire`/`PgDocData` readers, and server-side-routed reads/writes.
- **Snapshot-consistent paged scans**: a scan holds one read snapshot across all its pages, mirroring pggate — a fresh scan advances the session's read-time serial (a new snapshot, so read-after-write holds), while a continuation replays the scan's original `read_time_serial_no`/`txn_serial_no` (carried in the wrapped paging state) so the tserver restores the scan's read point instead of picking a newer one. This prevents rows deleted mid-scan from being dropped across a page boundary.
- **Packaging** (`yb_release`, `CMakeLists.txt`, `lto.py`): a lean release script that produces a single self-contained `libyb_thin_client.so` via full-LTO whole-program linking of only the client's real link closure (not the whole server/PG tree), with tcmalloc disabled so the `.so` does not interpose the host process's allocator, and exporting only the `ybthin_*` symbols. The `lto.py` change gates the 13 GiB link memory wait behind `run_linker` so the emit-only path doesn't block.

Backward compatibility: the library is upgraded ahead of the tserver, so it only relies on request fields / RPCs / semantics the oldest supported tserver already understands, and tolerates responses missing fields a newer server would set. The C ABI is additive-only.

## Test plan

New integration test `yb_thin_client-itest` (driven through a `PgMiniTestBase` single-tserver mini cluster, cross-checking the shim's reads/writes against ordinary SQL on the same tserver):

- [x] `PgThinClientTest.OpenUpsertReadPaged` — full C ABI end-to-end: `client_create` → `table_open` (schema check) → `upsert_batch` → paged read, cross-checked via SQL. **Passed locally** (release).
- [x] `PgThinClientTest.PagedReadHoldsSnapshotAcrossPages` — pages a scan while a committed `DELETE` of the not-yet-scanned tail lands between pages, and asserts the full original row set is still returned (snapshot held across page boundaries; no rows dropped). **Passed locally** (release).
- [ ] `PgThinClientTlsTest.ClientCreateOverTls` — TLS handshake + encrypted RPC round trip, and asserts a TLS-only endpoint rejects a plaintext client. (Covered by the test binary; validated via CI.)

All test data uses generic identifiers (tables `t`/`p`, columns `k`/`v`/`payload`); no external addresses or fixtures.
