### PR TITLE
[#32235] YSQL: Detect and stop creating stale index opclasses that break major upgrades

### DIFF
--- a/src/postgres/src/backend/commands/tablecmds.c
+++ b/src/postgres/src/backend/commands/tablecmds.c
@@ -5610,12 +5610,21 @@ ATRewriteCatalogs(List **wqueue, LOCKMODE lockmode,
 			 * ATExecAlterColumnType since it should be done only once if
 			 * multiple columns of a table are altered).
 			 *
-			 * Do not perform this work if it is a YB relation because we will
-			 * have created an entirely new table, so there is no need for
-			 * cleanup.
+			 * YB Note: skip the cleanup when the legacy ALTER TYPE flow
+			 * (yb_enable_alter_table_rewrite disabled) cloned the table onto
+			 * an entirely new relation, which recreated all dependent
+			 * objects. The clone only happens when the type change requires
+			 * a rewrite (see yb_clone_table in ATExecAlterColumnType). If no
+			 * rewrite was required (tab->rewrite == 0), the column type was
+			 * updated in place and the cleanup must still run to re-resolve
+			 * dependent indexes and constraints: skipping it used to leave
+			 * indexes with a stale operator class, making the dumped index
+			 * DDL fail to restore during a YSQL major version upgrade
+			 * (GH issue #32235).
 			 */
 			if (pass == AT_PASS_ALTER_TYPE &&
-				(!IsYBRelation(tab->rel) || yb_enable_alter_table_rewrite))
+				(!IsYBRelation(tab->rel) || yb_enable_alter_table_rewrite ||
+				 tab->rewrite == 0))
 				ATPostAlterTypeCleanup(wqueue, tab, lockmode);
 
 			if (tab->rel)

--- a/src/postgres/src/bin/pg_upgrade/check.c
+++ b/src/postgres/src/bin/pg_upgrade/check.c
@@ -49,6 +49,7 @@ static void yb_check_user_attributes(PGconn *old_cluster_conn,
 static void yb_check_yugabyte_user(PGconn *old_cluster_conn);
 static void yb_check_old_cluster_user(PGconn *old_cluster_conn);
 static void yb_check_invalid_indexes();
+static void yb_check_index_opclass_consistency();
 static void yb_check_installed_extensions();
 static void yb_check_pgcrypto_schema();
 static void yb_check_yb_role_prefix();
@@ -235,6 +236,7 @@ check_and_dump_old_cluster(bool live_check)
 		old_9_3_check_for_line_data_type_usage(&old_cluster);
 
 	yb_check_invalid_indexes();
+	yb_check_index_opclass_consistency();
 	yb_check_installed_extensions();
 	yb_check_pgcrypto_schema();
 	yb_check_yb_role_prefix();
@@ -1881,6 +1883,154 @@ yb_check_invalid_indexes()
 	{
 		check_ok();
 	}
+}
+
+/*
+ * yb_check_index_opclass_consistency()
+ *
+ * Find indexes whose recorded operator class (pg_index.indclass) no longer
+ * accepts the data type of the indexed table column.  Older versions of
+ * YugabyteDB could leave such stale entries behind when ALTER TABLE ...
+ * ALTER COLUMN ... TYPE ran with yb_enable_alter_table_rewrite disabled and
+ * the type change did not require a table rewrite (GH issue #32235).
+ * pg_dump emits an explicit operator class for these indexes, which the new
+ * PostgreSQL version then refuses to restore.
+ */
+static void
+yb_check_index_opclass_consistency()
+{
+	int			dbnum;
+	bool		found = false;
+	char		output_path[MAXPGPATH];
+	FILE	   *script = NULL;
+
+	snprintf(output_path, sizeof(output_path), "%s/%s",
+			 log_opts.basedir,
+			 "index_opclass_mismatch.txt");
+
+	prep_status("Checking for indexes with mismatched operator classes");
+
+	for (dbnum = 0; dbnum < old_cluster.dbarr.ndbs; dbnum++)
+	{
+		PGresult   *res;
+		int			ntups;
+		int			rowno;
+		int			i_schemaname;
+		int			i_indexname;
+		int			i_indexrelid;
+		int			i_colname;
+		int			i_opcname;
+		int			i_opcintype;
+		int			i_coltype;
+		bool		db_used = false;
+		DbInfo	   *active_db = &old_cluster.dbarr.dbs[dbnum];
+		PGconn	   *conn = connectToServer(&old_cluster, active_db->db_name);
+
+		/*
+		 * Find index key columns whose operator class input type no longer
+		 * accepts the table column's data type, mirroring the validation
+		 * ResolveOpClass performs when the dumped index DDL is restored: the
+		 * column type must match the operator class input type or be
+		 * binary-coercible to it.  Domains are reduced to their base type
+		 * first (like GetDefaultOpClass does).  Operator classes with a
+		 * polymorphic/pseudo-type input (e.g. anyarray, anyenum) are skipped:
+		 * they were validated at index creation and accept every type of
+		 * their type class.  Expression columns (indkey entry 0) have no
+		 * table column to compare against.  Temporary relations are skipped
+		 * because pg_dump does not dump them.
+		 */
+		res = executeQueryOrDie(conn,
+								"WITH RECURSIVE resolved AS ( "
+								"  SELECT oid AS typid, oid AS base, typbasetype "
+								"  FROM pg_catalog.pg_type "
+								"  UNION ALL "
+								"  SELECT r.typid, t.oid, t.typbasetype "
+								"  FROM resolved r "
+								"  JOIN pg_catalog.pg_type t ON t.oid = r.typbasetype "
+								"), base_type AS ( "
+								"  SELECT typid, base FROM resolved WHERE typbasetype = 0 "
+								") "
+								"SELECT n.nspname AS schemaname, "
+								"       ic.relname AS indexname, "
+								"       i.indexrelid AS indexrelid, "
+								"       ta.attname AS colname, "
+								"       oc.opcname AS opcname, "
+								"       pg_catalog.format_type(oc.opcintype, NULL) AS opcintype, "
+								"       pg_catalog.format_type(ta.atttypid, ta.atttypmod) AS coltype "
+								"FROM pg_catalog.pg_index i "
+								"JOIN pg_catalog.pg_class ic ON ic.oid = i.indexrelid "
+								"JOIN pg_catalog.pg_class tc ON tc.oid = i.indrelid "
+								"JOIN pg_catalog.pg_namespace n ON n.oid = ic.relnamespace "
+								"CROSS JOIN LATERAL pg_catalog.generate_series(0, i.indnkeyatts - 1) AS k(k) "
+								"JOIN pg_catalog.pg_attribute ta "
+								"  ON ta.attrelid = i.indrelid AND ta.attnum = i.indkey[k.k] "
+								"JOIN pg_catalog.pg_opclass oc ON oc.oid = i.indclass[k.k] "
+								"JOIN pg_catalog.pg_type ot ON ot.oid = oc.opcintype "
+								"JOIN base_type bt ON bt.typid = ta.atttypid "
+								"WHERE i.indkey[k.k] != 0 "
+								"  AND tc.relpersistence != 't' "
+								"  AND ta.atttypid != oc.opcintype "
+								"  AND bt.base != oc.opcintype "
+								"  AND ot.typtype != 'p' "
+								"  AND NOT EXISTS ( "
+								"    SELECT 1 FROM pg_catalog.pg_cast c "
+								"    WHERE c.castsource = bt.base "
+								"      AND c.casttarget = oc.opcintype "
+								"      AND c.castmethod = 'b' "
+								"      AND c.castcontext = 'i') "
+								"ORDER BY n.nspname, ic.relname, k.k");
+
+		ntups = PQntuples(res);
+		i_schemaname = PQfnumber(res, "schemaname");
+		i_indexname = PQfnumber(res, "indexname");
+		i_indexrelid = PQfnumber(res, "indexrelid");
+		i_colname = PQfnumber(res, "colname");
+		i_opcname = PQfnumber(res, "opcname");
+		i_opcintype = PQfnumber(res, "opcintype");
+		i_coltype = PQfnumber(res, "coltype");
+
+		for (rowno = 0; rowno < ntups; rowno++)
+		{
+			found = true;
+			if (script == NULL && (script = fopen_priv(output_path, "w")) == NULL)
+				pg_fatal("could not open file \"%s\": %s\n", output_path,
+						 strerror(errno));
+			if (!db_used)
+			{
+				yb_fprintf_and_log(script, "In database: %s\n",
+								   active_db->db_name);
+				db_used = true;
+			}
+			yb_fprintf_and_log(script,
+							   "  %s.%s (oid=%s) column \"%s\": operator class \"%s\" accepts type %s, but the column is of type %s\n",
+							   PQgetvalue(res, rowno, i_schemaname),
+							   PQgetvalue(res, rowno, i_indexname),
+							   PQgetvalue(res, rowno, i_indexrelid),
+							   PQgetvalue(res, rowno, i_colname),
+							   PQgetvalue(res, rowno, i_opcname),
+							   PQgetvalue(res, rowno, i_opcintype),
+							   PQgetvalue(res, rowno, i_coltype));
+		}
+
+		PQclear(res);
+		PQfinish(conn);
+	}
+
+	if (found)
+	{
+		yb_fatal("Your installation contains indexes whose operator class does not accept\n"
+				 "the data type of the indexed table column. Older versions of YugabyteDB\n"
+				 "could leave indexes in this state when ALTER TABLE ... ALTER COLUMN ...\n"
+				 "TYPE was run with yb_enable_alter_table_rewrite disabled. pg_dump emits\n"
+				 "an explicit operator class for such indexes, and the new PostgreSQL\n"
+				 "version fails to restore them. You can fix this by dropping and\n"
+				 "recreating the affected indexes (for indexes backing constraints, drop\n"
+				 "and re-add the constraint).\n"
+				 "A list of the affected indexes is printed above and in the file:\n"
+				 "    %s\n\n", output_path);
+	}
+	else
+		check_ok();
 }
 
 static void

--- a/src/postgres/src/test/regress/expected/yb.orig.alter_table_rewrite.out
+++ b/src/postgres/src/test/regress/expected/yb.orig.alter_table_rewrite.out
@@ -1486,3 +1486,131 @@ ORDER BY m.relname;
  idx_inh_parent | relfilenode reused | OID reused
 (2 rows)
 
+--
+-- Test ALTER TYPE with yb_enable_alter_table_rewrite = OFF when no table
+-- rewrite is required (issue #32235). The legacy path used to skip
+-- ATPostAlterTypeCleanup entirely, leaving dependent indexes pointing at the
+-- old type's operator class; the stale operator class then made the YSQL
+-- major version upgrade's pg_restore fail with "operator class ... does not
+-- accept data type ...".
+--
+SET yb_enable_alter_table_rewrite = OFF;
+-- timestamp -> timestamptz requires no table rewrite only under UTC.
+SET timezone = 'UTC';
+CREATE TABLE legacy_alter_type_test (id int, id2 int, created_at timestamp,
+    PRIMARY KEY (id ASC));
+CREATE INDEX legacy_alter_type_idx ON legacy_alter_type_test (id2 ASC, created_at DESC);
+INSERT INTO legacy_alter_type_test
+    SELECT g, g, '2024-01-01 00:00:00'::timestamp + make_interval(mins => g)
+    FROM generate_series(1, 5) g;
+CREATE TEMP TABLE legacy_alter_type_info AS
+    SELECT oid, relfilenode FROM pg_class WHERE relname = 'legacy_alter_type_test';
+ALTER TABLE legacy_alter_type_test ALTER COLUMN created_at TYPE timestamptz;
+-- the no-rewrite type change must not have rewritten the table.
+SELECT CASE WHEN old.oid = new.oid AND old.relfilenode = new.relfilenode
+        THEN 'table not rewritten' ELSE 'table rewritten' END AS result
+    FROM legacy_alter_type_info old, pg_class new
+    WHERE new.relname = 'legacy_alter_type_test';
+       result        
+---------------------
+ table not rewritten
+(1 row)
+
+-- the index must use the new type's default operator class, so
+-- pg_get_indexdef must not print an explicit operator class.
+SELECT pg_get_indexdef('legacy_alter_type_idx'::regclass);
+                                             pg_get_indexdef                                              
+----------------------------------------------------------------------------------------------------------
+ CREATE INDEX legacy_alter_type_idx ON public.legacy_alter_type_test USING lsm (id2 ASC, created_at DESC)
+(1 row)
+
+-- indclass and the index's pg_attribute rows must match the new column type.
+SELECT a.attname, format_type(a.atttypid, a.atttypmod) AS attr_type, opc.opcname
+    FROM pg_index i
+    JOIN pg_attribute a ON a.attrelid = i.indexrelid
+    JOIN pg_opclass opc ON opc.oid = i.indclass[a.attnum - 1]
+    WHERE i.indexrelid = 'legacy_alter_type_idx'::regclass
+    ORDER BY a.attnum;
+  attname   |        attr_type         |     opcname     
+------------+--------------------------+-----------------
+ id2        | integer                  | int4_ops
+ created_at | timestamp with time zone | timestamptz_ops
+(2 rows)
+
+-- the rebuilt index is consistent with the base table and serves reads.
+SELECT yb_index_check('legacy_alter_type_idx'::regclass);
+ yb_index_check 
+----------------
+ 
+(1 row)
+
+/*+ IndexScan(legacy_alter_type_test legacy_alter_type_idx) */ EXPLAIN (COSTS OFF)
+SELECT id, id2 FROM legacy_alter_type_test
+    WHERE id2 > 3 AND created_at > '2024-01-01 00:00:00+00' ORDER BY id;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: id
+   ->  Index Scan using legacy_alter_type_idx on legacy_alter_type_test
+         Index Cond: ((id2 > 3) AND (created_at > 'Mon Jan 01 00:00:00 2024 UTC'::timestamp with time zone))
+(4 rows)
+
+/*+ IndexScan(legacy_alter_type_test legacy_alter_type_idx) */
+SELECT id, id2 FROM legacy_alter_type_test
+    WHERE id2 > 3 AND created_at > '2024-01-01 00:00:00+00' ORDER BY id;
+ id | id2 
+----+-----
+  4 |   4
+  5 |   5
+(2 rows)
+
+-- an index backing a UNIQUE constraint is fixed up through the same path.
+CREATE TABLE legacy_alter_type_unique_test (created_at timestamp UNIQUE);
+INSERT INTO legacy_alter_type_unique_test VALUES ('2024-01-01 00:00:00');
+ALTER TABLE legacy_alter_type_unique_test ALTER COLUMN created_at TYPE timestamptz;
+SELECT format_type(a.atttypid, a.atttypmod) AS attr_type, opc.opcname
+    FROM pg_index i
+    JOIN pg_attribute a ON a.attrelid = i.indexrelid
+    JOIN pg_opclass opc ON opc.oid = i.indclass[a.attnum - 1]
+    WHERE i.indexrelid = 'legacy_alter_type_unique_test_created_at_key'::regclass;
+        attr_type         |     opcname     
+--------------------------+-----------------
+ timestamp with time zone | timestamptz_ops
+(1 row)
+
+SELECT yb_index_check('legacy_alter_type_unique_test_created_at_key'::regclass);
+ yb_index_check 
+----------------
+ 
+(1 row)
+
+INSERT INTO legacy_alter_type_unique_test VALUES ('2024-01-01 00:00:00+00'); -- should fail.
+ERROR:  duplicate key value violates unique constraint "legacy_alter_type_unique_test_created_at_key"
+-- a compatible no-rewrite change under the legacy path reuses the index in
+-- place and updates its attribute metadata.
+CREATE TABLE legacy_alter_compat_test (a varchar(10));
+CREATE INDEX legacy_alter_compat_idx ON legacy_alter_compat_test (a);
+CREATE TEMP TABLE legacy_alter_compat_info AS
+    SELECT c.oid, c.relfilenode, a.atttypmod FROM pg_class c, pg_attribute a
+    WHERE c.relname = 'legacy_alter_compat_idx' AND a.attrelid = c.oid AND a.attnum = 1;
+ALTER TABLE legacy_alter_compat_test ALTER COLUMN a TYPE varchar(100);
+SELECT CASE WHEN old.oid = new.oid THEN 'OID reused' ELSE 'OID changed' END,
+        CASE WHEN old.relfilenode = new.relfilenode
+            THEN 'relfilenode reused' ELSE 'relfilenode changed' END,
+        CASE WHEN old.atttypmod <> a.atttypmod
+            THEN 'atttypmod updated' ELSE 'atttypmod unchanged' END
+    FROM legacy_alter_compat_info old, pg_class new, pg_attribute a
+    WHERE new.relname = 'legacy_alter_compat_idx'
+        AND a.attrelid = new.oid AND a.attnum = 1;
+    case    |        case        |       case        
+------------+--------------------+-------------------
+ OID reused | relfilenode reused | atttypmod updated
+(1 row)
+
+RESET yb_enable_alter_table_rewrite;
+RESET timezone;
+-- the restore-side failure that stale operator classes previously caused: an
+-- explicit operator class that does not accept the column type is rejected.
+CREATE TABLE restore_shape_test (id int, created_at timestamptz);
+CREATE INDEX ON restore_shape_test (created_at timestamp_ops DESC); -- should fail.
+ERROR:  operator class "timestamp_ops" does not accept data type timestamp with time zone

--- a/src/postgres/src/test/regress/sql/yb.orig.alter_table_rewrite.sql
+++ b/src/postgres/src/test/regress/sql/yb.orig.alter_table_rewrite.sql
@@ -713,3 +713,80 @@ SELECT m.relname,
 FROM inh_idx_info m
 JOIN pg_class new ON new.relname = m.relname
 ORDER BY m.relname;
+
+--
+-- Test ALTER TYPE with yb_enable_alter_table_rewrite = OFF when no table
+-- rewrite is required (issue #32235). The legacy path used to skip
+-- ATPostAlterTypeCleanup entirely, leaving dependent indexes pointing at the
+-- old type's operator class; the stale operator class then made the YSQL
+-- major version upgrade's pg_restore fail with "operator class ... does not
+-- accept data type ...".
+--
+SET yb_enable_alter_table_rewrite = OFF;
+-- timestamp -> timestamptz requires no table rewrite only under UTC.
+SET timezone = 'UTC';
+CREATE TABLE legacy_alter_type_test (id int, id2 int, created_at timestamp,
+    PRIMARY KEY (id ASC));
+CREATE INDEX legacy_alter_type_idx ON legacy_alter_type_test (id2 ASC, created_at DESC);
+INSERT INTO legacy_alter_type_test
+    SELECT g, g, '2024-01-01 00:00:00'::timestamp + make_interval(mins => g)
+    FROM generate_series(1, 5) g;
+CREATE TEMP TABLE legacy_alter_type_info AS
+    SELECT oid, relfilenode FROM pg_class WHERE relname = 'legacy_alter_type_test';
+ALTER TABLE legacy_alter_type_test ALTER COLUMN created_at TYPE timestamptz;
+-- the no-rewrite type change must not have rewritten the table.
+SELECT CASE WHEN old.oid = new.oid AND old.relfilenode = new.relfilenode
+        THEN 'table not rewritten' ELSE 'table rewritten' END AS result
+    FROM legacy_alter_type_info old, pg_class new
+    WHERE new.relname = 'legacy_alter_type_test';
+-- the index must use the new type's default operator class, so
+-- pg_get_indexdef must not print an explicit operator class.
+SELECT pg_get_indexdef('legacy_alter_type_idx'::regclass);
+-- indclass and the index's pg_attribute rows must match the new column type.
+SELECT a.attname, format_type(a.atttypid, a.atttypmod) AS attr_type, opc.opcname
+    FROM pg_index i
+    JOIN pg_attribute a ON a.attrelid = i.indexrelid
+    JOIN pg_opclass opc ON opc.oid = i.indclass[a.attnum - 1]
+    WHERE i.indexrelid = 'legacy_alter_type_idx'::regclass
+    ORDER BY a.attnum;
+-- the rebuilt index is consistent with the base table and serves reads.
+SELECT yb_index_check('legacy_alter_type_idx'::regclass);
+/*+ IndexScan(legacy_alter_type_test legacy_alter_type_idx) */ EXPLAIN (COSTS OFF)
+SELECT id, id2 FROM legacy_alter_type_test
+    WHERE id2 > 3 AND created_at > '2024-01-01 00:00:00+00' ORDER BY id;
+/*+ IndexScan(legacy_alter_type_test legacy_alter_type_idx) */
+SELECT id, id2 FROM legacy_alter_type_test
+    WHERE id2 > 3 AND created_at > '2024-01-01 00:00:00+00' ORDER BY id;
+-- an index backing a UNIQUE constraint is fixed up through the same path.
+CREATE TABLE legacy_alter_type_unique_test (created_at timestamp UNIQUE);
+INSERT INTO legacy_alter_type_unique_test VALUES ('2024-01-01 00:00:00');
+ALTER TABLE legacy_alter_type_unique_test ALTER COLUMN created_at TYPE timestamptz;
+SELECT format_type(a.atttypid, a.atttypmod) AS attr_type, opc.opcname
+    FROM pg_index i
+    JOIN pg_attribute a ON a.attrelid = i.indexrelid
+    JOIN pg_opclass opc ON opc.oid = i.indclass[a.attnum - 1]
+    WHERE i.indexrelid = 'legacy_alter_type_unique_test_created_at_key'::regclass;
+SELECT yb_index_check('legacy_alter_type_unique_test_created_at_key'::regclass);
+INSERT INTO legacy_alter_type_unique_test VALUES ('2024-01-01 00:00:00+00'); -- should fail.
+-- a compatible no-rewrite change under the legacy path reuses the index in
+-- place and updates its attribute metadata.
+CREATE TABLE legacy_alter_compat_test (a varchar(10));
+CREATE INDEX legacy_alter_compat_idx ON legacy_alter_compat_test (a);
+CREATE TEMP TABLE legacy_alter_compat_info AS
+    SELECT c.oid, c.relfilenode, a.atttypmod FROM pg_class c, pg_attribute a
+    WHERE c.relname = 'legacy_alter_compat_idx' AND a.attrelid = c.oid AND a.attnum = 1;
+ALTER TABLE legacy_alter_compat_test ALTER COLUMN a TYPE varchar(100);
+SELECT CASE WHEN old.oid = new.oid THEN 'OID reused' ELSE 'OID changed' END,
+        CASE WHEN old.relfilenode = new.relfilenode
+            THEN 'relfilenode reused' ELSE 'relfilenode changed' END,
+        CASE WHEN old.atttypmod <> a.atttypmod
+            THEN 'atttypmod updated' ELSE 'atttypmod unchanged' END
+    FROM legacy_alter_compat_info old, pg_class new, pg_attribute a
+    WHERE new.relname = 'legacy_alter_compat_idx'
+        AND a.attrelid = new.oid AND a.attnum = 1;
+RESET yb_enable_alter_table_rewrite;
+RESET timezone;
+-- the restore-side failure that stale operator classes previously caused: an
+-- explicit operator class that does not accept the column type is rejected.
+CREATE TABLE restore_shape_test (id int, created_at timestamptz);
+CREATE INDEX ON restore_shape_test (created_at timestamp_ops DESC); -- should fail.

--- a/src/yb/integration-tests/upgrade-tests/ysql_major_upgrade_check-test.cc
+++ b/src/yb/integration-tests/upgrade-tests/ysql_major_upgrade_check-test.cc
@@ -402,6 +402,54 @@ TEST_F(YsqlMajorUpgradeCheckTest, YbPrefixRoles) {
   ASSERT_OK(ValidateUpgradeCompatibility());
 }
 
+TEST_F(YsqlMajorUpgradeCheckTest, IndexOpclassMismatch) {
+  auto conn = ASSERT_RESULT(cluster_->ConnectToDB());
+
+  // Indexes whose operator class input type differs from the column type but
+  // is legitimately accepted must NOT be flagged: domains (opclass is on the
+  // base type), enums (polymorphic anyenum opclass), and binary-coercible
+  // types (varchar column with the text opclass).
+  ASSERT_OK(conn.Execute("CREATE DOMAIN posint AS int CHECK (VALUE > 0)"));
+  ASSERT_OK(conn.Execute("CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')"));
+  ASSERT_OK(conn.Execute(
+      "CREATE TABLE opclass_ok_test (id int, d posint, m mood, v varchar(10), "
+      "PRIMARY KEY (id ASC))"));
+  ASSERT_OK(conn.Execute("CREATE INDEX idx_ok_domain ON opclass_ok_test (d)"));
+  ASSERT_OK(conn.Execute("CREATE INDEX idx_ok_enum ON opclass_ok_test (m)"));
+  ASSERT_OK(conn.Execute("CREATE INDEX idx_ok_coercible ON opclass_ok_test (v text_ops)"));
+  ASSERT_OK(ValidateUpgradeCompatibility());
+
+  // Simulate the stale state left behind by the legacy (rewrite disabled)
+  // ALTER TYPE path on older versions (GH #32235): the table column was
+  // changed from timestamp to timestamptz in place, but the dependent index
+  // kept the timestamp operator class in pg_index.indclass. The PG15 restore
+  // would reject the dumped index DDL with "operator class \"timestamp_ops\"
+  // does not accept data type timestamp with time zone".
+  ASSERT_OK(conn.Execute(
+      "CREATE TABLE opclass_test (id int, id2 int, created_at timestamptz, "
+      "PRIMARY KEY (id ASC))"));
+  ASSERT_OK(conn.Execute("CREATE INDEX idx_opclass_stale ON opclass_test (created_at DESC)"));
+  ASSERT_OK(conn.Execute("SET yb_non_ddl_txn_for_sys_tables_allowed TO on"));
+  ASSERT_OK(conn.Execute(
+      "UPDATE pg_index SET indclass = ("
+      "SELECT oid::text::oidvector FROM pg_opclass WHERE opcname = 'timestamp_ops' "
+      "AND opcmethod = (SELECT oid FROM pg_am WHERE amname = 'lsm')) "
+      "WHERE indexrelid = 'idx_opclass_stale'::regclass"));
+  ASSERT_OK(conn.Execute("RESET yb_non_ddl_txn_for_sys_tables_allowed"));
+
+  ASSERT_OK(ValidateUpgradeCompatibilityFailure(std::vector<std::string>{
+      "public.idx_opclass_stale",
+      "operator class \"timestamp_ops\" accepts type timestamp without time zone",
+      "column is of type timestamp with time zone",
+      "Your installation contains indexes whose operator class does not accept"}));
+
+  // Recovery: drop and recreate the index, which re-resolves the operator
+  // class from the current column type.
+  ASSERT_OK(conn.Execute("DROP INDEX idx_opclass_stale"));
+  ASSERT_OK(conn.Execute("CREATE INDEX idx_opclass_stale ON opclass_test (created_at DESC)"));
+  ASSERT_OK(ValidateUpgradeCompatibility());
+}
+
 TEST_F(YsqlMajorUpgradeCheckTest, StaleFunctionAclGrantors) {
   auto conn = ASSERT_RESULT(cluster_->ConnectToDB());
 


### PR DESCRIPTION
## Summary

Fixes #32235 (Jira: DB-21918)

`pg_restore` fails with `ERROR: operator class "timestamp_ops" does not accept data type timestamp with time zone` during the PG11 -> PG15 YSQL major version upgrade (`upgrade_ysql_major_version_catalog`), aborting the upgrade mid-restore.

**Root cause.** With `yb_enable_alter_table_rewrite = false` (legacy ALTER flow), `ALTER TABLE ... ALTER COLUMN ... TYPE` skips `ATPostAlterTypeCleanup` for YB relations, assuming the table clone recreated all dependent indexes. The clone, however, only runs when the type change requires a rewrite (`tab->rewrite > 0`). For a no-rewrite change (e.g. `timestamp -> timestamptz` under UTC), the column type is updated in place and dependent indexes keep the old type's operator class in `pg_index.indclass`. PG11 tolerates this at runtime, but `pg_get_indexdef` prints the now non-default opclass explicitly in dumps, and PG15's `ResolveOpClass` (no legacy-name shim since upstream PG12) rejects the dumped `CREATE INDEX` during the upgrade's pg_restore.

**Fixes (two independent layers):**

1. **Pre-flight check** - new `yb_check_index_opclass_consistency()` in the pg_upgrade YB check battery (`src/postgres/src/bin/pg_upgrade/check.c`). Flags index key columns whose operator class input type no longer accepts the table column's type, mirroring `ResolveOpClass` acceptance rules (exact match, binary-coercible cast, domain base type, polymorphic/pseudo-type opclasses). Existing stale state now fails `pg_upgrade --check` with a per-index report and remediation instead of aborting mid-upgrade.
2. **Creation-side fix** - `src/postgres/src/backend/commands/tablecmds.c`: under the legacy flow, run `ATPostAlterTypeCleanup` when no clone actually happened (`tab->rewrite == 0`). Dependent indexes/constraints are then re-resolved exactly as the default rewrite flow already does: incompatible indexes are rebuilt with the new type's default operator class; compatible ones take the existing in-place `YbATExecAlterIndexAttributeType` route (metadata-only update, relfilenode preserved).

The restore-side option (reinstating the pre-PG12 legacy-name shim under binary upgrade) was deliberately not taken: it would silently mask genuine mismatches during upgrade.

## Upgrade/Rollback safety

- The new pre-flight check only affects `pg_upgrade --check` / the check phase of the YSQL major version upgrade. It reads catalog state and reports; it performs no writes. Clusters without stale index opclasses see no behavior change. Clusters with stale state now fail fast in `--check` (previously they failed mid-restore with a rollback) - strictly better operator experience, no new failure class.
- The creation-side fix changes no catalog schema, no on-disk format, and no wire format. It only makes the legacy (`yb_enable_alter_table_rewrite = false`) no-rewrite ALTER TYPE path perform the same dependent-object cleanup the default path already performs, so newly-altered indexes carry correct metadata going forward. Existing stale metadata is not rewritten by this change (that is what the pre-flight check plus drop/recreate remediation is for).
- Rollback: reverting the commit restores prior behavior with no migration needed in either direction.

## Test plan

- [x] `./yb_build.sh release --cxx-test ysql_major_upgrade_check-test --gtest_filter 'YsqlMajorUpgradeCheckTest.IndexOpclassMismatch'` - new upgrade-check test (old version 2024.2.4.0/PG11): manufactures the stale `indclass` state via a catalog update under `yb_non_ddl_txn_for_sys_tables_allowed` (simulating pre-fix clusters), asserts `pg_upgrade --check` fails naming the index and the type mismatch, asserts drop/recreate recovery passes, and asserts legitimate opclass/type differences (domains, enums, binary-coercible varchar/text) are not flagged. Red run (without the check.c fix): `pg_upgrade --check` reported `*Clusters are compatible*` against the stale cluster and the test failed with `Expected pg_upgrade to fail with error(s)`. Green run (with the fix): passed.
- [x] `./yb_build.sh release --java-test 'org.yb.pgsql.TestPgRegressTable'` - extended `yb.orig.alter_table_rewrite` regress test: with `yb_enable_alter_table_rewrite = OFF`, a no-rewrite `timestamp -> timestamptz` leaves no explicit opclass in `pg_get_indexdef`, `indclass`/index `pg_attribute` match the new type, `yb_index_check` passes on the rebuilt indexes, a hinted index scan returns correct rows, the UNIQUE-backing index is rebuilt and still enforced, and a compatible `varchar` widening takes the in-place route (OID/relfilenode reused, `atttypmod` updated). Red run (without the tablecmds.c fix): `pg_get_indexdef` printed `created_at timestamp_ops DESC` and index attrs stayed `timestamp without time zone`/`timestamp_ops`. Green run (with the fix): passed.
- [x] `./build-support/lint.sh --rev origin/master` - 0 errors (20 warnings, all pre-existing unmarked-YB-hunk/style findings in untouched regions of the modified upstream-owned files).
