### PR TITLE
[#16670] dist-trace: async scope-carry across thread hops

### DIFF
--- a/src/yb/rpc/periodic.cc
+++ b/src/yb/rpc/periodic.cc
@@ -56,6 +56,7 @@ PeriodicTimer::PeriodicTimer(
     Messenger* messenger, RunTaskFunctor functor, MonoDelta period, Options options)
     : messenger_(messenger),
       functor_(std::move(functor)),
+      trace_parent_(dist_trace::GetActiveSpanContext()),
       period_(period),
       options_(std::move(options)),
       rng_(GetRandomSeed32()),
@@ -194,6 +195,8 @@ void PeriodicTimer::Callback(int64_t my_callback_generation) {
   }
 
   if (run_task) {
+    // Re-activate the context captured at construction so the task's RPCs nest under it.
+    auto parent_scope = dist_trace::ActivateParentScope(trace_parent_);
     functor_();
 
     if (options_.one_shot) {

--- a/src/yb/rpc/periodic.h
+++ b/src/yb/rpc/periodic.h
@@ -24,6 +24,7 @@
 #include <gtest/gtest_prod.h>
 
 #include "yb/gutil/macros.h"
+#include "yb/util/dist_trace.h"
 #include "yb/util/locks.h"
 #include "yb/util/monotime.h"
 #include "yb/util/random.h"
@@ -171,6 +172,9 @@ class PeriodicTimer : public std::enable_shared_from_this<PeriodicTimer> {
 
   // User-defined task functor.
   RunTaskFunctor functor_;
+
+  // Trace context captured at construction
+  const dist_trace::trace::SpanContext trace_parent_;
 
   // User-specified task period.
   const MonoDelta period_;

--- a/src/yb/rpc/rpc.cc
+++ b/src/yb/rpc/rpc.cc
@@ -92,7 +92,8 @@ RpcRetrier::RpcRetrier(CoarseTimePoint deadline, Messenger* messenger, ProxyCach
     : start_(CoarseMonoClock::now()),
       deadline_(deadline),
       messenger_(messenger),
-      proxy_cache_(*proxy_cache) {
+      proxy_cache_(*proxy_cache),
+      trace_parent_(dist_trace::GetActiveSpanContext()) {
   DCHECK(deadline != CoarseTimePoint());
 }
 
@@ -228,6 +229,10 @@ void RpcRetrier::DoRetry(RpcCommand* rpc, const Status& status) {
   if (new_status.ok()) {
     controller_.Reset();
     VTRACE_TO(1, rpc->trace(), "Sending Rpc");
+    // DoRetry runs on a scope-less reactor thread; re-establish the caller's parent (captured in
+    // the ctor) so the OutboundCall rebuilt in SendRpc captures it. No-op when trace_parent_ is
+    // invalid.
+    auto parent_scope = dist_trace::ActivateParentScope(trace_parent_);
     rpc->SendRpc();
   } else {
     // Service unavailable here means that we failed to schedule delayed task, i.e. reactor

--- a/src/yb/rpc/rpc.h
+++ b/src/yb/rpc/rpc.h
@@ -40,6 +40,7 @@
 
 #include "yb/rpc/rpc_controller.h"
 
+#include "yb/util/dist_trace.h"
 #include "yb/util/enums.h"
 #include "yb/util/monotime.h"
 
@@ -189,6 +190,9 @@ class RpcRetrier {
   std::atomic<ScheduledTaskId> task_id_{kInvalidTaskId};
 
   std::atomic<RpcRetrierState> state_{RpcRetrierState::kIdle};
+
+  // Trace context active when this retrier was constructed -- the caller's parent span.
+  dist_trace::trace::SpanContext trace_parent_ = dist_trace::trace::SpanContext::GetInvalid();
 
   DISALLOW_COPY_AND_ASSIGN(RpcRetrier);
 };

--- a/src/yb/rpc/scheduler.h
+++ b/src/yb/rpc/scheduler.h
@@ -17,6 +17,7 @@
 
 #include "yb/rpc/rpc_fwd.h"
 
+#include "yb/util/dist_trace.h"
 #include "yb/util/net/net_fwd.h"
 #include "yb/util/status.h"
 #include "yb/util/logging.h"
@@ -31,10 +32,11 @@ constexpr ScheduledTaskId kUninitializedScheduledTaskId = 0;
 class ScheduledTaskBase {
  public:
   explicit ScheduledTaskBase(ScheduledTaskId id, const SteadyTimePoint& time)
-      : id_(id), time_(time) {}
+      : id_(id), time_(time), trace_parent_(dist_trace::GetActiveSpanContext()) {}
 
   ScheduledTaskId id() const { return id_; }
   SteadyTimePoint time() const { return time_; }
+  const dist_trace::trace::SpanContext& trace_parent() const { return trace_parent_; }
 
   virtual ~ScheduledTaskBase() {}
   virtual void Run(const Status& status) = 0;
@@ -42,6 +44,7 @@ class ScheduledTaskBase {
  private:
   ScheduledTaskId id_;
   SteadyTimePoint time_;
+  dist_trace::trace::SpanContext trace_parent_;
 };
 
 template<class F>
@@ -51,6 +54,7 @@ class ScheduledTask : public ScheduledTaskBase {
       : ScheduledTaskBase(id, time), f_(f) {}
 
   void Run(const Status& status) override {
+    auto scope = dist_trace::ActivateParentScope(trace_parent());
     f_(status);
   }
  private:
@@ -64,6 +68,7 @@ class ScheduledTaskWithId : public ScheduledTaskBase {
       : ScheduledTaskBase(id, time), f_(f) {}
 
   void Run(const Status& status) override {
+    auto scope = dist_trace::ActivateParentScope(trace_parent());
     f_(id(), status);
   }
 

--- a/src/yb/util/strand.cc
+++ b/src/yb/util/strand.cc
@@ -14,6 +14,7 @@
 
 #include <thread>
 
+#include "yb/util/dist_trace.h"
 #include "yb/util/flags.h"
 #include "yb/util/scope_exit.h"
 #include "yb/util/status.h"
@@ -121,6 +122,9 @@ Strand::~Strand() {
 }
 
 bool Strand::Enqueue(StrandTask* task) {
+  // Capture the active trace context; Strand::Task::Done re-activates it around task->Run() so the
+  // task's RPCs nest under the triggering trace. No-op if no scope/off.
+  task->set_trace_parent(dist_trace::GetActiveSpanContext());
   return EnqueueHelper([this, task](bool ok) {
     if (ok) {
       if (task_->Enqueue(task)) {
@@ -153,6 +157,10 @@ void Strand::Task::Done(const Status& status) {
 
       auto running = active_enqueues_.load(std::memory_order_acquire) < Strand::kStopMark;
       const auto& actual_status = running ? status : StrandAbortedStatus();
+      // Re-activate the context captured at Enqueue for this task only, so its RPCs nest under the
+      // triggering trace.
+      auto parent_scope =
+        dist_trace::ActivateParentScope(task->trace_parent());
       if (actual_status.ok()) {
         task->Run();
       }

--- a/src/yb/util/strand.h
+++ b/src/yb/util/strand.h
@@ -27,6 +27,14 @@ class StrandTask : public MPSCQueueEntry<StrandTask> {
   // When the thread pool done with a task, i.e. it completed or failed, it invokes Done.
   virtual void Done(const Status& status) = 0;
 
+  const dist_trace::trace::SpanContext& trace_parent() const {
+    return trace_parent_;
+  }
+
+  void set_trace_parent(dist_trace::trace::SpanContext trace_parent) {
+    trace_parent_ = std::move(trace_parent);
+  }
+
   virtual ~StrandTask() = default;
 
  private:
@@ -39,6 +47,7 @@ class StrandTask : public MPSCQueueEntry<StrandTask> {
   }
 
   StrandTask* next_ = nullptr;
+  dist_trace::trace::SpanContext trace_parent_ = dist_trace::trace::SpanContext::GetInvalid();
 };
 
 template <class F>

--- a/src/yb/util/thread_pool.cc
+++ b/src/yb/util/thread_pool.cc
@@ -23,7 +23,6 @@
 #include <boost/intrusive/list.hpp>
 
 #include "yb/util/cgroups.h"
-#include "yb/util/debug-util.h"
 #include "yb/util/flags.h"
 #include "yb/util/lockfree.h"
 #include "yb/util/scope_exit.h"
@@ -213,6 +212,8 @@ class Worker : public boost::intrusive::list_base_hook<> {
       }
 #endif
       auto start = MonoTime::NowIf(has_run_metrics);
+      // Re-activate the Enqueue-captured scope. No-op when trace_parent is invalid.
+      auto parent_scope = dist_trace::ActivateParentScope(task->trace_parent());
       if (!task->run_token()) {
         task->Run();
         task->Done(Status::OK());
@@ -648,6 +649,8 @@ YBThreadPool::~YBThreadPool() {
 }
 
 bool YBThreadPool::Enqueue(ThreadPoolTask* task) {
+  // Capture the active trace scope here, on the submitting thread, where it is still live.
+  task->set_trace_parent(dist_trace::GetActiveSpanContext());
   return impl_->Enqueue(task);
 }
 

--- a/src/yb/util/thread_pool.h
+++ b/src/yb/util/thread_pool.h
@@ -22,6 +22,7 @@
 #include "yb/gutil/port.h"
 
 #include "yb/util/debug/leakcheck_disabler.h"
+#include "yb/util/dist_trace.h"
 #include "yb/util/metrics.h"
 #include "yb/util/lockfree.h"
 #include "yb/util/scope_exit.h"
@@ -54,6 +55,16 @@ class ThreadPoolTask {
     run_token_ = std::move(run_token);
   }
 
+  // Trace context captured at Enqueue (on the submitting thread, where it is still live) and
+  // re-activated around Run() on the worker thread.
+  const dist_trace::trace::SpanContext& trace_parent() const {
+    return trace_parent_;
+  }
+
+  void set_trace_parent(dist_trace::trace::SpanContext trace_parent) {
+    trace_parent_ = std::move(trace_parent);
+  }
+
   void set_submit_time(MonoTime value) {
     submit_time_ = value;
   }
@@ -81,6 +92,7 @@ class ThreadPoolTask {
   // the task completion.
   ThreadPoolTask* next_ = nullptr;
   std::optional<std::weak_ptr<void>> run_token_;
+  dist_trace::trace::SpanContext trace_parent_ = dist_trace::trace::SpanContext::GetInvalid();
   MonoTime submit_time_;
   [[maybe_unused]] Cgroup* task_cgroup_ = nullptr;
 };
@@ -100,6 +112,8 @@ class FunctorThreadPoolTask : public Base {
 
  private:
   void Run() override {
+    // Re-activate the trace context captured at Enqueue
+    auto trace_scope = dist_trace::ActivateParentScope(this->trace_parent());
     f_();
   }
 
@@ -176,18 +190,26 @@ class TaskRecipient {
 
   template <NonReferenceType F>
   bool EnqueueFunctor(const F& f) {
-    return Enqueue(MakeFunctorThreadPoolTask<F, TaskType>(f));
+    return Enqueue(StampTraceContext(MakeFunctorThreadPoolTask<F, TaskType>(f)));
   }
 
   template <NonReferenceType F>
   bool EnqueueFunctor(F&& f) {
-    return Enqueue(MakeFunctorThreadPoolTask<F, TaskType>(std::move(f)));
+    return Enqueue(StampTraceContext(MakeFunctorThreadPoolTask<F, TaskType>(std::move(f))));
   }
 
   // Matches the interface of yb::ThreadPool::Submit.
   template <NonReferenceType F>
   Status Submit(const F& f) {
-    return EnqueueWithStatus(MakeFunctorThreadPoolTask<F, TaskType>(f));
+    return EnqueueWithStatus(StampTraceContext(MakeFunctorThreadPoolTask<F, TaskType>(f)));
+  }
+
+ private:
+  // Sets trace context to carry it across the threads: stamp the active context onto the task
+  template <class Task>
+  Task* StampTraceContext(Task* task) {
+    task->set_trace_parent(dist_trace::GetActiveSpanContext());
+    return task;
   }
 };
 


### PR DESCRIPTION
Carry the active OTel trace context across thread boundaries so work
resumed on a worker/reactor thread nests under the trace that submitted
it. Each carrier captures dist_trace::GetActiveSpanContext() where the
scope is still live (Enqueue / construction) and re-establishes it with
dist_trace::ActivateParentScope() around the deferred callback.

- util/thread_pool: ThreadPoolTask carries trace_parent_; captured in
  YBThreadPool::Enqueue and TaskRecipient::StampTraceContext, re-activated
  in the worker loop and FunctorThreadPoolTask::Run.
- util/strand: StrandTask carries trace_parent_; captured in
  Strand::Enqueue, re-activated in Strand::Task::Done.
- rpc/scheduler: ScheduledTaskBase captures at construction, re-activates
  in ScheduledTask{,WithId}::Run.
- rpc/periodic: PeriodicTimer captures at construction, re-activates in
  Callback before running the task.
- rpc/rpc: RpcRetrier captures at construction, re-activates in DoRetry
  before rebuilding the OutboundCall (carries the parent across retries).

Purely additive; all no-ops when the captured context is invalid.


