### PR TITLE
[#16670] dist-trace: RPC trace-context propagation (wire codec + client/server spans)

### DIFF
--- a/src/yb/rpc/local_call.cc
+++ b/src/yb/rpc/local_call.cc
@@ -20,6 +20,7 @@
 #include "yb/rpc/rpc_controller.h"
 #include "yb/rpc/rpc_header.messages.h"
 
+#include "yb/util/dist_trace.h"
 #include "yb/util/format.h"
 #include "yb/util/memory/memory.h"
 #include "yb/util/result.h"
@@ -40,6 +41,12 @@ LocalOutboundCall::LocalOutboundCall(
                    response_storage, controller, std::move(rpc_metrics), std::move(callback),
                    callback_thread_pool, /* metadata_serializer_factory= */ nullptr) {
   TRACE_TO(trace_, "LocalOutboundCall");
+  if (otel_span()) {
+    otel_span()->SetAttribute("rpc.local_call", true);
+    // The OutboundCall ctor left the client span's scope on this thread; a local call never drops
+    // it. Drop it here or it re-parents later work. The span stays alive via GetContext().
+    otel_span()->DropScope();
+  }
 }
 
 Status LocalOutboundCall::SetRequestParam(

--- a/src/yb/rpc/local_call.h
+++ b/src/yb/rpc/local_call.h
@@ -50,6 +50,16 @@ class LocalOutboundCall : public OutboundCall {
     return req_;
   }
 
+  // Span context of this outbound call's trace span, to parent the matching local inbound span
+  // (local calls carry no wire header). nullopt when tracing is off. Safe after the scope is
+  // dropped.
+  std::optional<opentelemetry::trace::SpanContext> otel_span_context() const {
+    if (const auto& span = otel_span(); span) {
+      return span->GetContext();
+    }
+    return std::nullopt;
+  }
+
   bool is_local() const override { return true; }
 
   ThreadPoolTag pool_tag() const;
@@ -134,6 +144,7 @@ auto HandleCall(InboundCallPtr call, F f) {
       f(req, resp, std::move(rpc_context));
     }
   }
+  yb_call->DropServerSpanScope();
 }
 
 class LocalYBInboundCallTracker : public InboundCall::CallProcessedListener {

--- a/src/yb/rpc/outbound_call.cc
+++ b/src/yb/rpc/outbound_call.cc
@@ -465,7 +465,8 @@ Status OutboundCall::SetRequestParam(
   }
 
   if (trace_context_size > 0) {
-    // Write the TraceContextPB submessage. Field numbers match yb.TraceContextPB in common.proto.
+    // Write the TraceContextPB submessage. Field numbers match yb.rpc.TraceContextPB in
+    // rpc_header.proto.
     // The 16-byte trace id splits into two big-endian 64-bit halves; the span id is one big-endian
     // 64-bit.
     dst = Output::WriteTagToArray(
@@ -485,7 +486,8 @@ Status OutboundCall::SetRequestParam(
         (TraceContextPB::kSpanIdFieldNumber << 3) | WireFormatLite::WIRETYPE_FIXED64, dst);
     dst = Output::WriteLittleEndian64ToArray(BigEndian::Load64(span_id.Id().data()), dst);
 
-    dst = Output::WriteTagToArray(TraceContextPB::kVersionAndFlagsFieldNumber << 3, dst);
+    dst = Output::WriteTagToArray(
+        (TraceContextPB::kVersionAndFlagsFieldNumber << 3) | WireFormatLite::WIRETYPE_VARINT, dst);
     dst = Output::WriteVarint32ToArray(version_and_flags, dst);
   }
 

--- a/src/yb/rpc/rpc_context.cc
+++ b/src/yb/rpc/rpc_context.cc
@@ -147,11 +147,16 @@ RpcContext::RpcContext(std::shared_ptr<YBInboundCall> call,
     RespondRpcFailure(ErrorStatusPB::ERROR_INVALID_REQUEST, s);
     return;
   }
+  call_->CreateServerSpan();
   TRACE_EVENT_ASYNC_BEGIN1("rpc_call", "RPC", this, "call", call_->ToString());
 }
 
 RpcContext::RpcContext(std::shared_ptr<LocalYBInboundCall> call)
     : call_(call), params_(call.get(), boost::null_deleter()) {
+  // Inbound (server-side) span for this local call.
+  if (auto outbound_call = call->outbound_call(); outbound_call) {
+    call_->CreateServerSpan(outbound_call->otel_span_context());
+  }
   TRACE_EVENT_ASYNC_BEGIN1("rpc_call", "RPC", this, "call", call_->ToString());
 }
 

--- a/src/yb/rpc/serialization.cc
+++ b/src/yb/rpc/serialization.cc
@@ -229,6 +229,9 @@ Status ParseHeader(
       case RequestHeader::kMetadataFieldNumber:
         parsed_header->metadata = VERIFY_RESULT(ParseString(buf, "metadata", in));
         break;
+      case RequestHeader::kTraceContextFieldNumber:
+        parsed_header->trace_context = VERIFY_RESULT(ParseString(buf, "trace_context", in));
+        break;
       default: {
         if (!SkipField(tag & 7, in)) {
           return STATUS_FORMAT(Corruption, "Unable to skip: $0", tag);
@@ -372,6 +375,93 @@ Result<ParsedRemoteMethod> ParseRemoteMethod(const Slice& buf) {
     }
   }
   return result;
+}
+
+namespace {
+
+// Rebuilds a remote SpanContext from the wire fields. Fails if the trace/span ids are zero.
+Result<opentelemetry::trace::SpanContext> BuildSpanContext(
+    uint64_t trace_id_hi, uint64_t trace_id_lo, uint64_t span_id, uint32_t version_and_flags) {
+  // 16-byte trace id from its high/low 64-bit halves; 8-byte span id (big-endian on the wire).
+  uint8_t trace_id_bytes[16];
+  BigEndian::Store64(trace_id_bytes, trace_id_hi);
+  BigEndian::Store64(trace_id_bytes + 8, trace_id_lo);
+  uint8_t span_id_bytes[8];
+  BigEndian::Store64(span_id_bytes, span_id);
+
+  // Flags are the low byte; the high byte is the (currently unused) version.
+  uint8_t flags = version_and_flags & 0xFF;
+
+  auto span_context = opentelemetry::trace::SpanContext(
+      opentelemetry::trace::TraceId(trace_id_bytes),
+      opentelemetry::trace::SpanId(span_id_bytes),
+      opentelemetry::trace::TraceFlags(flags),
+      /* is_remote= */ true);
+
+  if (!span_context.IsValid()) {
+    return STATUS(Corruption, "Invalid trace context: trace_id_hi/lo or span_id is zero");
+  }
+  return span_context;
+}
+
+}  // namespace
+
+Result<opentelemetry::trace::SpanContext> ParseTraceContext(const Slice& buf) {
+  CodedInputStream in(buf.data(), narrow_cast<int>(buf.size()));
+  in.PushLimit(narrow_cast<int>(buf.size()));
+  uint64_t trace_id_hi = 0, trace_id_lo = 0, span_id = 0;
+  uint32_t version_and_flags = 0;
+  bool has_trace_id_hi = false, has_trace_id_lo = false, has_span_id = false,
+       has_version_and_flags = false;
+  while (in.BytesUntilLimit() > 0) {
+    auto tag = in.ReadTag();
+    auto field = tag >> 3;
+    switch (field) {
+      case TraceContextPB::kTraceIdHiFieldNumber:
+        if (!in.ReadLittleEndian64(&trace_id_hi)) {
+          return STATUS(Corruption, "Unable to decode trace_id_hi");
+        }
+        has_trace_id_hi = true;
+        break;
+      case TraceContextPB::kTraceIdLoFieldNumber:
+        if (!in.ReadLittleEndian64(&trace_id_lo)) {
+          return STATUS(Corruption, "Unable to decode trace_id_lo");
+        }
+        has_trace_id_lo = true;
+        break;
+      case TraceContextPB::kSpanIdFieldNumber:
+        if (!in.ReadLittleEndian64(&span_id)) {
+          return STATUS(Corruption, "Unable to decode span_id");
+        }
+        has_span_id = true;
+        break;
+      case TraceContextPB::kVersionAndFlagsFieldNumber:
+        if (!in.ReadVarint32(&version_and_flags)) {
+          return STATUS(Corruption, "Unable to decode version_and_flags");
+        }
+        has_version_and_flags = true;
+        break;
+      default: {
+        if (!SkipField(tag & 7, &in)) {
+          return STATUS_FORMAT(Corruption, "Unable to skip: $0", tag);
+        }
+      }
+    }
+  }
+  if (!has_trace_id_hi || !has_trace_id_lo || !has_span_id || !has_version_and_flags) {
+    return STATUS(Corruption, "Incomplete trace context: missing field");
+  }
+  return BuildSpanContext(trace_id_hi, trace_id_lo, span_id, version_and_flags);
+}
+
+Result<opentelemetry::trace::SpanContext> ToSpanContext(const TraceContextPB& trace_context) {
+  if (!trace_context.has_trace_id_hi() || !trace_context.has_trace_id_lo() ||
+      !trace_context.has_span_id() || !trace_context.has_version_and_flags()) {
+    return STATUS(Corruption, "Incomplete trace context: missing field");
+  }
+  return BuildSpanContext(
+      trace_context.trace_id_hi(), trace_context.trace_id_lo(), trace_context.span_id(),
+      trace_context.version_and_flags());
 }
 
 std::string ParsedRequestHeader::RemoteMethodAsString() const {

--- a/src/yb/rpc/serialization.h
+++ b/src/yb/rpc/serialization.h
@@ -42,6 +42,8 @@
 #include <google/protobuf/message.h>
 #include <google/protobuf/repeated_field.h>
 
+#include "opentelemetry/trace/span_context.h"
+
 #include "yb/rpc/rpc_fwd.h"
 
 #include "yb/util/result.h"
@@ -62,6 +64,8 @@ class Status;
 
 namespace rpc {
 
+class TraceContextPB;
+
 Result<std::pair<RefCntBuffer, size_t>> SerializeResponse(
     size_t body_size, size_t additional_size, const google::protobuf::Message& header,
     AnyMessageConstPtr body);
@@ -79,6 +83,7 @@ struct ParsedRequestHeader {
   boost::iterator_range<const uint32_t*> sidecar_offsets;
   Slice metadata;
   ThreadPoolTag pool_tag = 0;
+  Slice trace_context;
   std::optional<uint32_t> crc;
 
   std::string RemoteMethodAsString() const;
@@ -104,7 +109,15 @@ struct ParsedRemoteMethod {
   Slice method;
 };
 
+// Builds a SpanContext from a TraceContextPB (shared-memory path). Fails if any field is missing or
+// the trace/span ids are zero.
+Result<opentelemetry::trace::SpanContext> ToSpanContext(const TraceContextPB& trace_context);
+
 Result<ParsedRemoteMethod> ParseRemoteMethod(const Slice& buf);
+
+// Parses a RequestHeader.trace_context wire slice into a SpanContext (RPC path). Fails if any field
+// is missing or the trace/span ids are zero.
+Result<opentelemetry::trace::SpanContext> ParseTraceContext(const Slice& buf);
 Status ParseMetadata(Slice buf, AnyMessagePtr out);
 Status ParseMetadataFromSharedMemory(uint8_t** input, size_t length, AnyMessagePtr out);
 

--- a/src/yb/rpc/yb_rpc.cc
+++ b/src/yb/rpc/yb_rpc.cc
@@ -29,7 +29,9 @@
 #include "yb/rpc/serialization.h"
 
 #include "yb/util/debug/trace_event.h"
+#include "yb/util/dist_trace.h"
 #include "yb/util/format.h"
+#include "yb/util/logging.h"
 #include "yb/util/result.h"
 #include "yb/util/status_format.h"
 
@@ -305,6 +307,18 @@ Status YBInboundCall::ParseFrom(const MemTrackerPtr& mem_tracker, CallData* call
   DVLOG(4) << "Parsed YBInboundCall header: " << header_.call_id;
   UpdateWaitStateInfo();
 
+  // Extract the propagated distributed-trace parent from the header, if present. The span itself is
+  // created later (CreateServerSpan) once the request params have been parsed. Tracing is
+  // best-effort: a malformed context is logged and dropped, never fails the RPC.
+  if (dist_trace::IsDistTraceEnabled() && !header_.trace_context.empty()) {
+    auto parsed = ParseTraceContext(header_.trace_context);
+    if (parsed.ok()) {
+      parent_span_context_ = std::move(*parsed);
+    } else {
+      YB_LOG_EVERY_N_SECS(WARNING, 5) << "Failed to parse RPC trace context: " << parsed.status();
+    }
+  }
+
   consumption_ = ScopedTrackedConsumption(mem_tracker, call_data->size());
   request_data_ = std::move(*call_data);
 
@@ -314,6 +328,27 @@ Status YBInboundCall::ParseFrom(const MemTrackerPtr& mem_tracker, CallData* call
   }
 
   return Status::OK();
+}
+
+void YBInboundCall::CreateServerSpan(std::optional<opentelemetry::trace::SpanContext> parent) {
+  // Remote calls supply no `parent` and fall back to the context parsed from the wire header; local
+  // calls pass the originating outbound span's context explicitly (there is no wire header).
+  const auto& parent_context = parent ? parent : parent_span_context_;
+  if (!parent_context) {
+    return;
+  }
+  auto parsed_method = ParseRemoteMethod(header_.remote_method);
+  if (!parsed_method.ok()) {
+    return;
+  }
+  auto span_name = Format("rpc $0.$1", parsed_method->service, parsed_method->method);
+  span_ = dist_trace::StartServerSpanWithScope(span_name, *parent_context);
+  if (span_) {
+    span_->SetAttribute("rpc.system", "inbound_rpc");
+    span_->SetAttribute("rpc.service", parsed_method->service.ToBuffer());
+    span_->SetAttribute("rpc.method", parsed_method->method.ToBuffer());
+    span_->SetAttribute("rpc.call_id", header_.call_id);
+  }
 }
 
 Status YBInboundCall::SerializeResponseBuffer(AnyMessageConstPtr response, bool is_success) {
@@ -425,12 +460,23 @@ Status YBInboundCall::ParseParam(RpcCallParams* params) {
 
 void YBInboundCall::RespondSuccess(AnyMessageConstPtr response) {
   TRACE_EVENT0("rpc", "InboundCall::RespondSuccess");
+  if (span_) {
+    span_->SetStatus(opentelemetry::trace::StatusCode::kOk);
+    span_->End();
+    span_.reset();
+  }
   Respond(response, /*is_success=*/true);
 }
 
 void YBInboundCall::RespondFailure(ErrorStatusPB::RpcErrorCodePB error_code,
                                    const Status& status) {
   TRACE_EVENT0("rpc", "InboundCall::RespondFailure");
+
+  if (span_) {
+    span_->SetStatus(opentelemetry::trace::StatusCode::kError, status.ToUserMessage());
+    span_->End();
+    span_.reset();
+  }
 
   // Release memory early and prevent building an oversized error response.
   sidecars_.Reset();

--- a/src/yb/rpc/yb_rpc.h
+++ b/src/yb/rpc/yb_rpc.h
@@ -34,6 +34,7 @@
 #include "yb/rpc/serialization.h"
 #include "yb/rpc/sidecars.h"
 
+#include "yb/util/dist_trace.h"
 #include "yb/util/ev_util.h"
 #include "yb/util/net/net_fwd.h"
 #include "yb/util/size_literals.h"
@@ -199,6 +200,19 @@ class YBInboundCall : public InboundCall {
 
   virtual Status ParseParam(RpcCallParams* params);
 
+  // Creates a server-side trace span, from the inbound RequestHeader's trace_context (remote)
+  // or the outbound call's context via `parent` (local). No-op when no parent or tracing is off.
+  void CreateServerSpan(
+      std::optional<opentelemetry::trace::SpanContext> parent = std::nullopt);
+
+  // Releases the server span's thread-local scope on the handler thread once synchronous handling
+  // is done. The span itself ends later (RespondSuccess/Failure), possibly on another thread.
+  void DropServerSpanScope() {
+    if (span_) {
+      span_->DropScope();
+    }
+  }
+
   size_t ObjectSize() const override { return sizeof(*this); }
 
   Result<RefCntSlice> ExtractSidecar(size_t idx) const;
@@ -230,6 +244,12 @@ class YBInboundCall : public InboundCall {
 
   // The header of the incoming call. Set by ParseFrom()
   ParsedRequestHeader header_;
+
+  // Parent span context parsed from the inbound trace_context header field, if present.
+  std::optional<opentelemetry::trace::SpanContext> parent_span_context_;
+
+  // Server-side distributed-trace span (with activated scope) for this call.
+  dist_trace::SpanWithScopePtr span_;
 
   // The buffers for serialized response. Set by SerializeResponseBuffer().
   RefCntBuffer response_buf_;


### PR DESCRIPTION
End-to-end propagation of a distributed trace across the RPC transport:
decode the context off the wire, create the server span on the callee,
and hand a local call's client span to its in-process inbound span. The
client and server halves reference each other's context accessors, so
they ship together.

Wire codec (serialization.{cc,h}):
- ParseTraceContext(Slice): decode the RequestHeader.trace_context wire
  field; ToSpanContext(TraceContextPB): the shared-memory equivalent;
  both via BuildSpanContext, failing on a zero/invalid context.
- ParseHeader captures RequestHeader.trace_context into ParsedRequestHeader.

Server / inbound span (yb_rpc.{cc,h}):
- YBInboundCall::ParseFrom parses the header trace_context into
  parent_span_context_ (best-effort: a bad context is logged, never fails
  the RPC).
- CreateServerSpan starts a StartServerSpanWithScope child of that parent
  (remote) or of an explicitly passed context (local); RespondSuccess/
  Failure set status and end it; DropServerSpanScope releases the scope on
  the handler thread while the span ends later.

Client local-call handoff (local_call.{cc,h}, rpc_context.cc):
- LocalOutboundCall tags rpc.local_call and drops its client-span scope in
  the ctor (a local call never hops threads to drop it later).
- otel_span_context() exposes the outbound span's context so the local
  inbound span can parent under it (no wire header exists locally).
- RpcContext creates the server span: from the wire header for remote
  calls, from the outbound call's context for local calls.


