### PR TITLE
[#16670] dist-trace: carry trace context across task and Raft-apply thread hops

### DIFF
--- a/src/yb/master/async_rpc_tasks_base.cc
+++ b/src/yb/master/async_rpc_tasks_base.cc
@@ -116,7 +116,9 @@ RetryingRpcTask::RetryingRpcTask(
     : master_(master),
       callback_pool_(callback_pool),
       async_task_throttler_(async_task_throttler),
-      deadline_(UnresponsiveDeadline()) {}
+      deadline_(UnresponsiveDeadline()),
+      // Snapshot the active trace context on the creating thread.
+      trace_parent_(dist_trace::GetActiveSpanContext()) {}
 
 RetryingRpcTask::~RetryingRpcTask() {
   auto state = state_.load(std::memory_order_acquire);
@@ -132,6 +134,9 @@ std::string RetryingRpcTask::LogPrefix() const {
 // Send the subclass RPC request.
 Status RetryingRpcTask::Run() {
   VLOG_WITH_PREFIX(1) << "Start Running";
+  // Re-establish the creating thread's trace context.
+  auto trace_scope = dist_trace::ActivateParentScope(trace_parent_);
+
   attempt_start_ts_ = MonoTime::Now();
   ++attempt_;
   VLOG_WITH_PREFIX(1) << "Start Running, attempt: " << attempt_;

--- a/src/yb/master/async_rpc_tasks_base.h
+++ b/src/yb/master/async_rpc_tasks_base.h
@@ -25,6 +25,7 @@
 #include "yb/tserver/backup.proxy.h"
 
 #include "yb/util/async_task_util.h"
+#include "yb/util/dist_trace.h"
 #include "yb/util/memory/memory.h"
 #include "yb/util/metrics_fwd.h"
 #include "yb/util/result.h"
@@ -245,6 +246,10 @@ class RetryingRpcTask : public server::RunnableMonitoredTask {
 
   virtual int num_max_retries();
   virtual int max_delay_ms();
+
+  // Trace context active when this task was created, re-activated at the top of Run() so the task's
+  // RPCs nest under it. Invalid (no-op) when created outside a traced origin.
+  dist_trace::trace::SpanContext trace_parent_ = dist_trace::trace::SpanContext::GetInvalid();
 };
 
 // A background task which continuously retries sending an RPC to master server.

--- a/src/yb/master/multi_step_monitored_task.cc
+++ b/src/yb/master/multi_step_monitored_task.cc
@@ -26,7 +26,9 @@ namespace yb::master {
 
 MultiStepMonitoredTask::MultiStepMonitoredTask(
     ThreadPool& async_task_pool, rpc::Messenger& messenger)
-    : messenger_(messenger), async_task_pool_(async_task_pool) {}
+    : messenger_(messenger),
+      async_task_pool_(async_task_pool),
+      trace_parent_(dist_trace::GetActiveSpanContext()) {}
 
 void MultiStepMonitoredTask::Start() {
   LOG_WITH_PREFIX(INFO) << "Starting task";
@@ -207,6 +209,9 @@ Status MultiStepMonitoredTask::RunInternal() {
 
   RETURN_NOT_OK(ValidateRunnable());
 
+  // Re-activate the triggering trace on this worker/reactor thread so RPCs the step issues nest
+  // under it. No-op when trace_parent_ is invalid.
+  auto parent_scope = dist_trace::ActivateParentScope(trace_parent_);
   return step();
 }
 

--- a/src/yb/master/multi_step_monitored_task.h
+++ b/src/yb/master/multi_step_monitored_task.h
@@ -20,6 +20,7 @@
 #include "yb/master/leader_epoch.h"
 #include "yb/rpc/rpc_fwd.h"
 #include "yb/server/monitored_task.h"
+#include "yb/util/dist_trace.h"
 #include "yb/util/status.h"
 #include "yb/util/status_callback.h"
 
@@ -142,6 +143,12 @@ class MultiStepMonitoredTask : public server::RunnableMonitoredTask {
 
   std::string next_step_description_ GUARDED_BY(schedule_task_mutex_);
   std::function<Status()> next_step_ GUARDED_BY(schedule_task_mutex_) = nullptr;
+
+  // Trace context of the operation that created this task, captured at construction and
+  // re-activated around each step so the step's RPCs nest under the triggering trace -- steps run
+  // on async-pool/reactor threads, so the context must ride on the task. No-op when unset or
+  // tracing is off.
+  dist_trace::trace::SpanContext trace_parent_ = dist_trace::trace::SpanContext::GetInvalid();
 };
 
 // A MultiStepMonitoredTask that is tied to a single CatalogEntity object (ex: Table) and the master

--- a/src/yb/tablet/operations/operation_driver.cc
+++ b/src/yb/tablet/operations/operation_driver.cc
@@ -96,6 +96,7 @@ OperationDriver::OperationDriver(OperationTracker *operation_tracker,
       preparer_(preparer),
       trace_(Trace::MaybeGetNewTraceForParent(Trace::CurrentTrace())),
       wait_state_(ash::WaitStateInfo::CurrentWaitState()),
+      otel_parent_(dist_trace::GetActiveSpanContext()),
       start_time_(MonoTime::Now()),
       replication_state_(NOT_REPLICATING),
       prepare_state_(NOT_PREPARED) {
@@ -406,6 +407,10 @@ void OperationDriver::ApplyTask(int64_t leader_term, OpIds* applied_op_ids) {
   ADOPT_TRACE(trace());
   ADOPT_WAIT_STATE(wait_state());
   SCOPED_WAIT_STATUS(OnCpu_Active);
+
+  // Re-activate the submitting thread's trace on this apply thread so RPCs the operation issues
+  // during apply (e.g. APPLYING/APPLIED UpdateTransaction RPCs) nest under it.
+  auto otel_scope = dist_trace::ActivateParentScope(otel_parent_);
 
 #ifndef NDEBUG
   {

--- a/src/yb/tablet/operations/operation_driver.h
+++ b/src/yb/tablet/operations/operation_driver.h
@@ -51,6 +51,7 @@
 
 #include "yb/tablet/operations/operation.h"
 
+#include "yb/util/dist_trace.h"
 #include "yb/util/status_fwd.h"
 #include "yb/util/lockfree.h"
 #include "yb/util/trace.h"
@@ -268,6 +269,9 @@ class OperationDriver : public RefCountedThreadSafe<OperationDriver>,
   // Trace object for tracing any operations started by this driver.
   scoped_refptr<Trace> trace_;
   const ash::WaitStateInfoPtr wait_state_;
+
+  // OpenTelemetry trace context of the submitting thread
+  const dist_trace::trace::SpanContext otel_parent_ = dist_trace::trace::SpanContext::GetInvalid();
 
   const MonoTime start_time_;
 

--- a/src/yb/tserver/tablet_validator.cc
+++ b/src/yb/tserver/tablet_validator.cc
@@ -45,6 +45,7 @@
 
 #include "yb/util/background_task.h"
 #include "yb/util/compare_util.h"
+#include "yb/util/dist_trace.h"
 #include "yb/util/flags.h"
 #include "yb/util/logging.h"
 #include "yb/util/monotime.h"
@@ -90,6 +91,10 @@ struct IndexTableInfo {
   TabletId index_tablet_id;
   TableId  index_table_id;
   TableId  group_id; // Generally contains indexed_table_id.
+
+  // OTel context active when this index was scheduled (the CreateTablet RPC's trace, carried into
+  // OpenTablet by the threadpool). Used to nest the later GetBackfillStatus poll under that trace.
+  dist_trace::trace::SpanContext trace_parent = dist_trace::trace::SpanContext::GetInvalid();
 
   std::string ToString() const {
     return YB_STRUCT_TO_STRING(index_tablet_id, index_table_id, group_id);
@@ -399,10 +404,16 @@ bool TabletMetadataValidator::Impl::ScheduleTabletPropertiesValidation(
     return false;
   }
 
+  // Active OTel context, live here because the threadpool carries it from the CreateTablet RPC into
+  // OpenTablet. Stored per index so the later GetBackfillStatus poll nests under the triggering
+  // trace.
+  const auto trace_parent = dist_trace::GetActiveSpanContext();
+
   // Pick all index tables with retain_delete_markers set to true.
   std::vector<IndexTableInfo> candidates;
   candidates.reserve(meta.GetColocatedTablesCount()); // Let's try to predict the size.
-  meta.IterateColocatedTables([this, &meta, &candidates](const yb::tablet::TableInfo& info){
+  meta.IterateColocatedTables(
+      [this, &meta, &candidates, &trace_parent](const yb::tablet::TableInfo& info){
     VLOG_WITH_PREFIX(4) << "Candidate: " << info.ToString();
     if (info.schema().table_properties().retain_delete_markers()) {
       // For colocation tables info.index_info may not be set and thus it's not possible
@@ -410,7 +421,7 @@ bool TabletMetadataValidator::Impl::ScheduleTabletPropertiesValidation(
       // index table id instead of indexed table id to reuse the same structures.
       auto group_id = info.index_info ? info.index_info->indexed_table_id() : info.table_id;
       candidates.emplace_back(IndexTableInfo{
-          meta.raft_group_id(), info.table_id, std::move(group_id) });
+          meta.raft_group_id(), info.table_id, std::move(group_id), trace_parent });
     }
   });
   if (candidates.empty()) {
@@ -487,6 +498,13 @@ Result<master::GetBackfillStatusResponsePB> TabletMetadataValidator::Impl::SyncW
        to_sync.size() < batch_size && it != index_tablets_to_sync_.end(); ++it) {
     to_sync.emplace(it->index_table_id);
   }
+
+  // First entry wins: one RPC batches many index tables (possibly from different DDLs), but a span
+  // has a single parent. Nest the RPC under the first batched index's captured trace context.
+  const auto trace_parent = index_tablets_to_sync_.empty()
+      ? dist_trace::trace::SpanContext::GetInvalid()
+      : index_tablets_to_sync_.begin()->trace_parent;
+  auto otel_scope = dist_trace::ActivateParentScope(trace_parent);
 
   // Only backfilling status is being synced with the master at the moment.
   VLOG_WITH_PREFIX(1) << "Requesting backfill status for " << yb::ToString(to_sync);


### PR DESCRIPTION
Same capture/re-activate pattern as the async scope-carry infra, applied
to the higher-level task types whose work runs on a different thread than
the one that triggered it. Each snapshots dist_trace::GetActiveSpanContext()
where the scope is still live and re-establishes it with ActivateParentScope
around the deferred run, so the work's RPCs nest under the triggering trace.

- tablet/operation_driver: OperationDriver captures at construction,
  re-activates in ApplyTask (APPLYING/APPLIED UpdateTransaction RPCs on
  the Raft apply thread).
- master/async_rpc_tasks_base: RetryingRpcTask captures at construction,
  re-activates at the top of Run().
- master/multi_step_monitored_task: captures at construction, re-activates
  in RunInternal before each step.
- tserver/tablet_validator: captures per scheduled index (carried from the
  CreateTablet RPC into OpenTablet), re-activates the first batched index's
  context around the GetBackfillStatus poll.

Purely additive; all no-ops when the captured context is invalid.


