### PR TITLE
[#16670] dist-trace: propagate trace context over the PG<->tserver shared memory exchange

### DIFF
--- a/src/yb/ash/rpc_wait_state.cc
+++ b/src/yb/ash/rpc_wait_state.cc
@@ -12,6 +12,8 @@
 //
 #include "yb/ash/rpc_wait_state.h"
 
+#include "yb/gutil/endian.h"
+
 #include "yb/rpc/inbound_call.h"
 #include "yb/rpc/lightweight_message.h"
 
@@ -129,6 +131,36 @@ uint8_t* MetadataSerializer::SerializeToArray(uint8_t* out) {
   }
 
   return metadata_.SerializeWithCachedSizesToArray(out);
+}
+
+void TraceContextSerializer::SetTraceContext(
+    const opentelemetry::trace::SpanContext& span_context) {
+  if (!span_context.IsValid()) {
+    return;
+  }
+  const auto trace_id = span_context.trace_id();
+  const auto span_id = span_context.span_id();
+  // Split the 16-byte trace id into two big-endian 64-bit halves; the span id is one big-endian
+  // 64-bit value -- the layout rpc::ToSpanContext reads back on the tserver.
+  trace_context_.set_trace_id_hi(BigEndian::Load64(trace_id.Id().data()));
+  trace_context_.set_trace_id_lo(BigEndian::Load64(trace_id.Id().data() + 8));
+  trace_context_.set_span_id(BigEndian::Load64(span_id.Id().data()));
+  // Low byte: flags; high byte: the (currently unused) version.
+  constexpr uint32_t kVersion = 0;
+  trace_context_.set_version_and_flags((kVersion << 8) | span_context.trace_flags().flags());
+  serialized_size_ = trace_context_.ByteSizeLong();
+}
+
+size_t TraceContextSerializer::SerializedSize() const {
+  return Output::VarintSize32(static_cast<uint32_t>(serialized_size_)) + serialized_size_;
+}
+
+uint8_t* TraceContextSerializer::SerializeToArray(uint8_t* out) const {
+  out = Output::WriteVarint32ToArray(static_cast<uint32_t>(serialized_size_), out);
+  if (serialized_size_ == 0) {
+    return out;
+  }
+  return trace_context_.SerializeWithCachedSizesToArray(out);
 }
 
 } // namespace yb::ash

--- a/src/yb/ash/rpc_wait_state.h
+++ b/src/yb/ash/rpc_wait_state.h
@@ -12,10 +12,13 @@
 //
 #pragma once
 
+#include "opentelemetry/trace/span_context.h"
+
 #include "yb/ash/wait_state.h"
 
 #include "yb/common/common.pb.h"
 
+#include "yb/rpc/rpc_header.pb.h"
 #include "yb/rpc/wait_state_if.h"
 
 namespace yb::ash {
@@ -57,6 +60,21 @@ class MetadataSerializerFactory : public rpc::MetadataSerializerFactory {
   std::unique_ptr<rpc::MetadataSerializer> Create(rpc::MetadataSerializationMode mode) override {
     return std::make_unique<ash::MetadataSerializer>(mode);
   }
+};
+
+// Serializes a distributed-trace SpanContext as a standalone length-prefixed TraceContextPB blob
+// for the shared-memory PG<->tserver exchange, independent of the ASH metadata blob. Always emits
+// the length prefix (zero when no context is set) so the exchange framing stays parseable.
+class TraceContextSerializer {
+ public:
+  // Encodes span_context into the trace-context blob; a no-op when the context is invalid.
+  void SetTraceContext(const opentelemetry::trace::SpanContext& span_context);
+  size_t SerializedSize() const;
+  uint8_t* SerializeToArray(uint8_t* out) const;
+
+ private:
+  rpc::TraceContextPB trace_context_;
+  size_t serialized_size_ = 0;
 };
 
 } // namespace yb::ash

--- a/src/yb/tserver/pg_client_session.cc
+++ b/src/yb/tserver/pg_client_session.cc
@@ -58,6 +58,8 @@
 
 #include "yb/rpc/lightweight_message.h"
 #include "yb/rpc/rpc_context.h"
+#include "yb/rpc/rpc_header.pb.h"
+#include "yb/rpc/serialization.h"
 #include "yb/rpc/sidecars.h"
 #include "yb/rpc/scheduler.h"
 
@@ -81,6 +83,7 @@
 #include "yb/util/cast.h"
 #include "yb/util/cgroups.h"
 #include "yb/util/debug-util.h"
+#include "yb/util/dist_trace.h"
 #include "yb/util/enums.h"
 #include "yb/util/logging.h"
 #include "yb/util/lw_function.h"
@@ -837,6 +840,30 @@ using PerformQueryTraits = QueryTraits<PgPerformRequestMsg, PgPerformResponseMsg
 using ObjectLockQueryTraits =
     QueryTraits<const PgAcquireObjectLockRequestMsg, PgAcquireObjectLockResponseMsg>;
 
+// Name of the inbound shared-memory span.
+template <QueryTraitsType T>
+std::string_view SharedMemHandlerSpanName();
+template <>
+std::string_view SharedMemHandlerSpanName<PerformQueryTraits>() {
+  return "shmem yb.tserver.PgClientService.Perform";
+}
+template <>
+std::string_view SharedMemHandlerSpanName<ObjectLockQueryTraits>() {
+  return "shmem yb.tserver.PgClientService.AcquireObjectLock";
+}
+
+// Method name attribute for the inbound shared-memory span.
+template <QueryTraitsType T>
+const char* SharedMemMethodName();
+template <>
+const char* SharedMemMethodName<PerformQueryTraits>() {
+  return "Perform";
+}
+template <>
+const char* SharedMemMethodName<ObjectLockQueryTraits>() {
+  return "AcquireObjectLock";
+}
+
 using ResponseSender = std::function<void()>;
 
 template <QueryTraitsType T>
@@ -1114,6 +1141,8 @@ class SharedExchangeQuery : public std::enable_shared_from_this<SharedExchangeQu
   // 8 bytes - timeout in milliseconds.
   // next - size of serialized AshMetadataPB protobuf (say 'x').
   // next 'x' bytes - serialized AshMetadataPB protobuf.
+  // next - size of serialized TraceContextPB protobuf (say 'y').
+  // next 'y' bytes - serialized TraceContextPB protobuf.
   // remaining bytes - serialized PgPerformRequestPB protobuf.
   template <class... Args>
   Result<RequestInfo> ParseRequest(
@@ -1125,6 +1154,8 @@ class SharedExchangeQuery : public std::enable_shared_from_this<SharedExchangeQu
     input += sizeof(uint64_t);
     RETURN_NOT_OK(rpc::ParseMetadataFromSharedMemory(
         &input, end - input, rpc::AnyMessagePtr(&ash_metadata_)));
+    RETURN_NOT_OK(rpc::ParseMetadataFromSharedMemory(
+        &input, end - input, rpc::AnyMessagePtr(&trace_context_)));
     RETURN_NOT_OK(req_.ParseFromSlice(Slice(input, end)));
     data_.emplace(
         std::forward<Args>(args)..., session_id, arena_, req_, resp_, sidecars_,
@@ -1145,6 +1176,7 @@ class SharedExchangeQuery : public std::enable_shared_from_this<SharedExchangeQu
   }
 
   const AshMetadataPB& ash_metadata() const { return ash_metadata_; }
+  const rpc::TraceContextPB& trace_context() const { return trace_context_; }
 
  private:
   void SendResponse() {
@@ -1211,6 +1243,7 @@ class SharedExchangeQuery : public std::enable_shared_from_this<SharedExchangeQu
   std::remove_const_t<typename T::ReqPB> req_;
   typename T::RespPB resp_;
   AshMetadataPB ash_metadata_;
+  rpc::TraceContextPB trace_context_;
   rpc::Sidecars sidecars_;
   std::weak_ptr<PgClientSession> session_;
   SharedExchange& exchange_;
@@ -2790,7 +2823,34 @@ class PgClientSession::Impl {
     auto track_guard = wait_state
         ? TrackSharedMemoryPgMethodExecution<T>(wait_state, query.ash_metadata())
         : std::nullopt;
-    return DoHandleSharedExchangeQuery(precondition_waiter, std::move(data), deadline);
+
+    // Fix span attibutes for shared memory exchange.
+    dist_trace::SpanWithScopePtr trace_scope;
+    const auto& trace_context = query.trace_context();
+    if (dist_trace::IsDistTraceEnabled() && trace_context.has_span_id()) {
+      auto parent_context = rpc::ToSpanContext(trace_context);
+      if (parent_context.ok()) {
+        trace_scope = dist_trace::StartServerSpanWithScope(
+            SharedMemHandlerSpanName<T>(), *parent_context);
+        if (trace_scope) {
+          // Mirror the attributes the RPC inbound span carries (yb_rpc.cc), minus the ones with no
+          // shared-memory analog (rpc.call_id).
+          trace_scope->SetAttribute("rpc.system", "inbound_shmem");
+          trace_scope->SetAttribute("rpc.service", "yb.tserver.PgClientService");
+          trace_scope->SetAttribute("rpc.method", SharedMemMethodName<T>());
+        }
+      }
+    }
+
+    const auto status = DoHandleSharedExchangeQuery(precondition_waiter, std::move(data), deadline);
+    if (trace_scope) {
+      if (status.ok()) {
+        trace_scope->SetStatus(opentelemetry::trace::StatusCode::kOk);
+      } else {
+        trace_scope->SetStatus(opentelemetry::trace::StatusCode::kError, status.ToUserMessage());
+      }
+    }
+    return status;
   }
 
   template <QueryTraitsType T, class... Args>

--- a/src/yb/yql/pggate/pg_client.cc
+++ b/src/yb/yql/pggate/pg_client.cc
@@ -1126,9 +1126,16 @@ class PgClient::Impl : public BigDataFetcher {
   ResultFuture<Data> PrepareAndSend(Method method, Args&&... args) {
     auto data = std::make_shared<Data>(std::forward<Args>(args)...);
     if (session_shared_mem_ && session_shared_mem_->exchange().ReadyToSend()) {
+      // Start the outbound shared-memory span before sizing the request.
+      data->StartSharedMemorySpan();
       ash::MetadataSerializer metadata(rpc::MetadataSerializationMode::kWriteOnZero);
+      ash::TraceContextSerializer trace_context;
+      if (data->otel_span) {
+        trace_context.SetTraceContext(data->otel_span->GetContext());
+      }
       constexpr size_t kHeaderSize = sizeof(uint8_t) + sizeof(uint64_t);
       const size_t kMetadataSize = metadata.SerializedSize();
+      const size_t kTraceContextSize = trace_context.SerializedSize();
       auto& exchange = session_shared_mem_->exchange();
       // Sanity check: the exchange must not be reused while a big shared memory response from a
       // previous request has been announced but not yet loaded and released. Otherwise the tserver
@@ -1136,9 +1143,9 @@ class PgClient::Impl : public BigDataFetcher {
       // still intend to load it (see PgClientSession::ReleaseAbandonedBigSharedMemSegment).
       LOG_IF(DFATAL, big_shared_memory_response_pending_)
           << "Reusing shared exchange while a big shared memory response is still pending";
-      auto out = exchange.Obtain(kHeaderSize + kMetadataSize + data->req.SerializedSize());
+      auto out = exchange.Obtain(
+          kHeaderSize + kMetadataSize + kTraceContextSize + data->req.SerializedSize());
       if (out) {
-        data->StartSharedMemorySpan();
         const auto [rpc_deadline, rpc_timeout] =
             timeouts_.GetDeadlineAndTimeoutForRPC<typename Data::RequestType>();
         *reinterpret_cast<uint8_t *>(out) = Data::kSharedExchangeRequestType;
@@ -1146,6 +1153,7 @@ class PgClient::Impl : public BigDataFetcher {
         LittleEndian::Store64(out, rpc_timeout.ToMilliseconds());
         out += sizeof(uint64_t);
         out = pointer_cast<std::byte*>(metadata.SerializeToArray(to_uchar_ptr(out)));
+        out = pointer_cast<std::byte*>(trace_context.SerializeToArray(to_uchar_ptr(out)));
         const auto size = data->req.SerializedSize();
         auto* end = pointer_cast<std::byte*>(
             data->req.SerializeToArray(pointer_cast<uint8_t*>(out)));
@@ -1165,6 +1173,8 @@ class PgClient::Impl : public BigDataFetcher {
         data->SetupExchange(&exchange, this, rpc_deadline);
         return ExchangeFuture<Data>(std::move(data));
       }
+      // End the shared-memory span started above so it is not leaked.
+      data->EndSharedMemorySpan(Status::OK());
     }
     data->controller.set_invoke_callback_mode(rpc::InvokeCallbackMode::kReactorThread);
     method(


### PR DESCRIPTION
Carry the distributed-trace parent across the shared-memory Perform /
AcquireObjectLock fast path, mirroring what the RPC header path already
does. The read-side codec (rpc::ToSpanContext) shipped earlier; this adds
the write side and wires both ends of the exchange.

- ash/rpc_wait_state: TraceContextSerializer encodes the active span's
  SpanContext as a standalone length-prefixed TraceContextPB blob (always
  emits the length prefix, zero when unset, so the framing stays
  parseable). Big-endian layout matches what rpc::ToSpanContext reads back.
- pggate/pg_client (PrepareAndSend): start the outbound shared-memory span,
  serialize the trace_context blob into the exchange buffer after the ASH
  metadata, size the obtain accordingly, and end the span on the early-exit
  path so it is not leaked.
- tserver/pg_client_session: parse the trace_context blob out of the
  exchange, and when present start a server span (StartServerSpanWithScope)
  as a child of the propagated context, with rpc.system=inbound_shmem and
  matching service/method attributes; set Ok/Error status around the
  handler.


