### PR TITLE
[DOC-1425] Change table column name to SQL standard

### DIFF
--- a/docs/content/stable/explore/transactions/isolation-levels.md
+++ b/docs/content/stable/explore/transactions/isolation-levels.md
@@ -55,10 +55,10 @@ To set the transaction isolation level of a transaction, use the command `SET TR
 
 PostgreSQL (and the SQL standard) has four isolation levels: Serializable, Repeatable read, Read Committed, and Read Uncommitted.
 
-The following table shows the mapping between the PostgreSQL isolation levels in YSQL, along with transaction anomalies that can occur at each isolation level:
+The following table shows the mapping between SQL standard isolation levels in YSQL, along with transaction anomalies that can occur at each isolation level:
 
-| PostgreSQL Isolation | YugabyteDB Equivalent     | Dirty Read | Non-repeatable Read | Phantom Read | Serialization Anomaly |
-| :------------------- | :------------------------ | :--------- | :------------------ | :----------- | :-------------------- |
+| SQL Standard Isolation | YugabyteDB Equivalent     | Dirty Read | Non-repeatable Read | Phantom Read | Serialization Anomaly |
+| :--------------------- | :------------------------ | :--------- | :------------------ | :----------- | :-------------------- |
 | Read Uncommitted | Read Committed | Allowed, but not in YSQL |  Possible | Possible | Possible |
 | Read Committed   | Read Committed | Not possible | Possible     | Possible | Possible |
 | Repeatable read  | Snapshot                      | Not possible | Not possible | Allowed, but not in YSQL | Possible |

--- a/docs/content/v2.20/explore/transactions/isolation-levels.md
+++ b/docs/content/v2.20/explore/transactions/isolation-levels.md
@@ -53,10 +53,10 @@ To set the transaction isolation level of a transaction, use the command `SET TR
 
 PostgreSQL (and the SQL standard) has four isolation levels: Serializable, Repeatable read, Read Committed, and Read Uncommitted.
 
-The following table shows the mapping between the PostgreSQL isolation levels in YSQL, along with transaction anomalies that can occur at each isolation level:
+The following table shows the mapping between SQL standard isolation levels in YSQL, along with transaction anomalies that can occur at each isolation level:
 
-| PostgreSQL Isolation | YugabyteDB Equivalent     | Dirty Read | Non-repeatable Read | Phantom Read | Serialization Anomaly |
-| :------------------- | :------------------------ | :--------- | :------------------ | :----------- | :-------------------- |
+| SQL Standard Isolation | YugabyteDB Equivalent     | Dirty Read | Non-repeatable Read | Phantom Read | Serialization Anomaly |
+| :--------------------- | :------------------------ | :--------- | :------------------ | :----------- | :-------------------- |
 | Read Uncommitted | Read Committed {{<tags/feature/ea>}} | Allowed, but not in YSQL |  Possible | Possible | Possible |
 | Read Committed   | Read Committed {{<tags/feature/ea idea="1099">}} | Not possible | Possible     | Possible | Possible |
 | Repeatable read  | Snapshot                      | Not possible | Not possible | Allowed, but not in YSQL | Possible |

--- a/docs/content/v2024.2/explore/transactions/isolation-levels.md
+++ b/docs/content/v2024.2/explore/transactions/isolation-levels.md
@@ -53,10 +53,10 @@ To set the transaction isolation level of a transaction, use the command `SET TR
 
 PostgreSQL (and the SQL standard) has four isolation levels: Serializable, Repeatable read, Read Committed, and Read Uncommitted.
 
-The following table shows the mapping between the PostgreSQL isolation levels in YSQL, along with transaction anomalies that can occur at each isolation level:
+The following table shows the mapping between SQL standard isolation levels in YSQL, along with transaction anomalies that can occur at each isolation level:
 
-| PostgreSQL Isolation | YugabyteDB Equivalent     | Dirty Read | Non-repeatable Read | Phantom Read | Serialization Anomaly |
-| :------------------- | :------------------------ | :--------- | :------------------ | :----------- | :-------------------- |
+| SQL Standard Isolation | YugabyteDB Equivalent     | Dirty Read | Non-repeatable Read | Phantom Read | Serialization Anomaly |
+| :--------------------- | :------------------------ | :--------- | :------------------ | :----------- | :-------------------- |
 | Read Uncommitted | Read Committed | Allowed, but not in YSQL |  Possible | Possible | Possible |
 | Read Committed   | Read Committed | Not possible | Possible     | Possible | Possible |
 | Repeatable read  | Snapshot                      | Not possible | Not possible | Allowed, but not in YSQL | Possible |

--- a/docs/content/v2025.1/explore/transactions/isolation-levels.md
+++ b/docs/content/v2025.1/explore/transactions/isolation-levels.md
@@ -53,10 +53,10 @@ To set the transaction isolation level of a transaction, use the command `SET TR
 
 PostgreSQL (and the SQL standard) has four isolation levels: Serializable, Repeatable read, Read Committed, and Read Uncommitted.
 
-The following table shows the mapping between the PostgreSQL isolation levels in YSQL, along with transaction anomalies that can occur at each isolation level:
+The following table shows the mapping between SQL standard isolation levels in YSQL, along with transaction anomalies that can occur at each isolation level:
 
-| PostgreSQL Isolation | YugabyteDB Equivalent     | Dirty Read | Non-repeatable Read | Phantom Read | Serialization Anomaly |
-| :------------------- | :------------------------ | :--------- | :------------------ | :----------- | :-------------------- |
+| SQL Standard Isolation | YugabyteDB Equivalent     | Dirty Read | Non-repeatable Read | Phantom Read | Serialization Anomaly |
+| :--------------------- | :------------------------ | :--------- | :------------------ | :----------- | :-------------------- |
 | Read Uncommitted | Read Committed | Allowed, but not in YSQL |  Possible | Possible | Possible |
 | Read Committed   | Read Committed | Not possible | Possible     | Possible | Possible |
 | Repeatable read  | Snapshot                      | Not possible | Not possible | Allowed, but not in YSQL | Possible |

--- a/docs/content/v2025.2/explore/transactions/isolation-levels.md
+++ b/docs/content/v2025.2/explore/transactions/isolation-levels.md
@@ -55,10 +55,10 @@ To set the transaction isolation level of a transaction, use the command `SET TR
 
 PostgreSQL (and the SQL standard) has four isolation levels: Serializable, Repeatable read, Read Committed, and Read Uncommitted.
 
-The following table shows the mapping between the PostgreSQL isolation levels in YSQL, along with transaction anomalies that can occur at each isolation level:
+The following table shows the mapping between SQL standard isolation levels in YSQL, along with transaction anomalies that can occur at each isolation level:
 
-| PostgreSQL Isolation | YugabyteDB Equivalent     | Dirty Read | Non-repeatable Read | Phantom Read | Serialization Anomaly |
-| :------------------- | :------------------------ | :--------- | :------------------ | :----------- | :-------------------- |
+| SQL Standard Isolation | YugabyteDB Equivalent     | Dirty Read | Non-repeatable Read | Phantom Read | Serialization Anomaly |
+| :--------------------- | :------------------------ | :--------- | :------------------ | :----------- | :-------------------- |
 | Read Uncommitted | Read Committed | Allowed, but not in YSQL |  Possible | Possible | Possible |
 | Read Committed   | Read Committed | Not possible | Possible     | Possible | Possible |
 | Repeatable read  | Snapshot                      | Not possible | Not possible | Allowed, but not in YSQL | Possible |


### PR DESCRIPTION
Change table column name to SQL standard from Postrgresql isolation

@netlify /stable/explore/transactions/isolation-levels/#isolation-levels-in-postgresql-and-ysql