### PR TITLE
[#32941] DocDB: Fix use-after-free in QLWriteOperation::UpdateIndexes

### DIFF
--- a/src/yb/docdb/cql_operation.cc
+++ b/src/yb/docdb/cql_operation.cc
@@ -979,6 +979,10 @@ Status QLWriteOperation::ApplyForRegularColumns(const QLColumnValueMsg& column_v
 }
 
 Status QLWriteOperation::Apply(const DocOperationApplyData& data) {
+  // Anything a previous attempt accumulated is abandoned.
+  index_requests_.clear();
+  index_arena_.reset();
+
   data.doc_write_batch->SetDocReadContext(doc_read_context_);
 
   QLTableRow existing_row;
@@ -1468,8 +1472,12 @@ Status QLWriteOperation::UpdateIndexes(const QLTableRow& existing_row, const QLT
   VLOG(2) << "Updating indexes, existing: " << existing_row.ToString() << ", new: "
           << new_row.ToString();
   const auto& index_ids = request_.update_index_ids();
-  index_arena_ = SharedThreadSafeArena();
-  index_requests_.reserve(index_ids.size() * 2);
+  // index_requests_ holds raw pointers into index_arena_, so the arena has to outlive every call
+  // made within one apply attempt. Apply() resets both when a new attempt starts.
+  if (!index_arena_) {
+    index_arena_ = SharedThreadSafeArena();
+    index_requests_.reserve(index_ids.size() * 2);
+  }
   for (const auto& index_id : index_ids) {
     const auto* index = VERIFY_RESULT(index_map_.FindIndex(index_id));
     bool index_key_changed = false;

--- a/src/yb/integration-tests/cql-index-test.cc
+++ b/src/yb/integration-tests/cql-index-test.cc
@@ -548,6 +548,35 @@ TEST_F(CqlIndexTest, ConcurrentUpdate2Columns) {
   TestConcurrentModify2Columns("UPDATE t SET $0 = ? WHERE key = ?");
 }
 
+// Deletes a whole partition of an indexed table with a single range delete (hash key given, range
+// key omitted), and checks that all the rows and all their index entries are gone.
+TEST_F(CqlIndexTest, RangeDeleteWithIndex) {
+  constexpr auto kNumRows = 16;
+  constexpr auto kNamespace = "test";
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_allow_index_table_read_write) = true;
+
+  auto session = ASSERT_RESULT(EstablishSession(driver_.get()));
+  ASSERT_OK(session.ExecuteQuery(
+      "CREATE TABLE t (h INT, r INT, value INT, PRIMARY KEY ((h), r)) WITH "
+      "transactions = { 'enabled' : true }"));
+  ASSERT_OK(session.ExecuteQuery("CREATE INDEX idx ON t (value)"));
+  ASSERT_OK(client_->WaitUntilIndexPermissionsAtLeast(
+      client::YBTableName(YQL_DATABASE_CQL, kNamespace, "t"),
+      client::YBTableName(YQL_DATABASE_CQL, kNamespace, "idx"),
+      IndexPermissions::INDEX_PERM_READ_WRITE_AND_DELETE));
+
+  for (int r = 1; r <= kNumRows; ++r) {
+    ASSERT_OK(session.ExecuteQuery(Format("INSERT INTO t (h, r, value) VALUES (1, $0, $0)", r)));
+  }
+  ASSERT_EQ(ASSERT_RESULT(session.FetchValue<int64_t>("SELECT COUNT(*) FROM idx")), kNumRows);
+
+  ASSERT_OK(session.ExecuteQuery("DELETE FROM t WHERE h = 1"));
+
+  ASSERT_EQ(ASSERT_RESULT(session.FetchValue<int64_t>("SELECT COUNT(*) FROM t")), 0);
+  ASSERT_EQ(ASSERT_RESULT(session.FetchValue<int64_t>("SELECT COUNT(*) FROM idx")), 0);
+}
+
 TEST_F(CqlIndexTest, SlowIndexResponse) {
   constexpr auto kNumKeys = NonTsanVsTsan(3000, 1500);
   constexpr auto kWriteBatchSize = NonTsanVsTsan(100, 30);


### PR DESCRIPTION
## Summary

Fixes #32941.

`QLWriteOperation::UpdateIndexes()` unconditionally assigned a fresh arena to `index_arena_` on every call:

```c++
  const auto& index_ids = request_.update_index_ids();
  index_arena_ = SharedThreadSafeArena();
  index_requests_.reserve(index_ids.size() * 2);
```

`index_requests_` holds raw `QLWriteRequestMsg*` pointers to requests allocated from that arena, it is a member of the operation, and it is only appended to -- never cleared. It is consumed later, after the whole operation has been applied, by `WriteQuery::UpdateQLIndexes()`, which iterates every entry and dereferences it.

`SharedThreadSafeArena()` performs a single allocation holding the control block, the arena object and the first block of arena storage (`kStartBlockSize = 4 * 1024`), so assigning a new arena drops the last reference to the previous one and frees every request allocated from it.

There are two ways to call `UpdateIndexes()` more than once for the same operation:

- A YCQL `DELETE` that supplies the hash key but omits the range key removes the whole partition within one write operation. `QLWriteOperation::ApplyDelete()` takes the `IsRangeOperation()` branch and calls `UpdateIndexes()` once per deleted row, so for a partition of N rows, N-1 of the N accumulated index requests pointed into freed memory by the time they were read. With 2 rows this surfaced as a garbage schema version in the error returned to the client (`expected 0, got 148098936`); with more rows the tablet server crashed.
- `WriteQuery::DoCompleteExecute()` re-applies the same `doc_ops_` in place when a local read restart is needed, so a second attempt frees the first attempt's requests. This needs no range delete -- a single row write is enough. This path is currently unreachable for YCQL writes, since `allow_immediate_read_restart_` is `!read_time_`, which is false for them.

### The fix

Create the arena on the first call within an apply attempt and reuse it for the rest of that attempt, so it outlives every request accumulated in `index_requests_`. The `reserve()` moves with it: calling it once per row with an exact size would defeat the vector's geometric growth. Reset both members at the top of `Apply()`, so a retried attempt starts clean instead of inheriting the abandoned attempt's requests.

The index backfill path already handles this correctly -- `Tablet::FlushWriteIndexBatchIfRequired()` only replaces the arena after `FlushWriteIndexBatch()` has synchronously flushed the batch and cleared `index_requests`.

### Origin

This is a regression, introduced in two stages:

- 69e7f2a1ae2 "[#29705] DocDB: Temporary typedefs for lightweight protobufs migration" added the per-call `index_arena_` assignment. Before it, `IndexRequests` held `QLWriteRequestPB` by value, so the vector owned each request and nothing could dangle.
- 9f0f237e1df "[#29787] DocDB: Use lightweight protobufs for read and write requests" changed `IndexRequests` to hold `QLWriteRequestMsg*`, putting the request object itself, and not only its contents, in the freed arena.

### Scope

YSQL is not affected: `PgsqlWriteOperation` does not use this path. Reaching the bug also requires the YCQL query layer to populate `update_index_ids`, which only happens for a non-primary-key-only secondary index.

## Test plan

Added `CqlIndexTest.RangeDeleteWithIndex`, which deletes a whole partition of an indexed table with a single range delete and checks that all the rows and all their index entries are gone. It dies on SIGILL without this change.

```
ybd release --cxx-test integration-tests_cql-index-test \
  --gtest_filter CqlIndexTest.RangeDeleteWithIndex -n 5
```

- [x] `CqlIndexTest.RangeDeleteWithIndex` fails without the fix (child process terminated due to signal 4) and passes 5/5 with it
- [x] `CqlIndexTest.Simple`
- [x] `CqlIndexTest.MultipleIndex`
- [x] `CqlIndexTest.ConcurrentInsert2Columns`
- [x] `CqlIndexTest.ConcurrentUpdate2Columns`
