### PR TITLE
[DOC-1427][ybm] Clarify Metrics Exporter OTLP ports and ybdb prefix

### DIFF
--- a/docs/content/stable/yugabyte-cloud/cloud-monitor/managed-integrations.md
+++ b/docs/content/stable/yugabyte-cloud/cloud-monitor/managed-integrations.md
@@ -14,6 +14,8 @@ type: docs
 
 You can export cluster metrics and logs to third-party tools for analysis and customization.
 
+All metrics exported from a cluster are prefixed with `ybdb`.
+
 To export either metrics or logs from a cluster:
 
 1. [Create an export configuration](#configure-integrations) for the integration you want to use. A configuration defines the sign in credentials and settings for the tool that you want to export to.
@@ -142,6 +144,10 @@ The [Prometheus](https://prometheus.io/docs/introduction/overview/) integration 
 
     Note that the Prometheus instance itself should not be publicly accessible, but must be reachable from your YugabyteDB Aeon cluster via VPC peering (see YugabyteDB Aeon requirements below).
 
+  - Prometheus listening on the HTTP or HTTPS port that matches the endpoint URL you provide.
+
+    The Metrics Exporter connects using the port implied by the URL scheme: port 80 for `http://` and port 443 for `https://`. The default Prometheus listen port (9090) is not used and export fails if Prometheus is only reachable on 9090. Configure Prometheus to listen on port 80 or 443, or place a reverse proxy such as nginx in front of Prometheus to terminate HTTP/HTTPS on 80 or 443 and forward traffic to Prometheus.
+
   - [OTLP Receiver](https://prometheus.io/docs/prometheus/latest/querying/api/#otlp-receiver) feature flag enabled.
   {{< note title="Note" >}}
 How you enable the OTLP Receiver feature flag differs between Prometheus versions. Be sure to check the appropriate documentation for your version of Prometheus.
@@ -171,6 +177,14 @@ To create an export configuration, do the following:
     http://<prometheus-endpoint-host-address>/api/v1/otlp
     ```
 
+    or, for HTTPS,
+
+    ```sh
+    https://<prometheus-endpoint-host-address>/api/v1/otlp
+    ```
+
+    Omit a custom port from the URL. The exporter targets port 80 for HTTP and port 443 for HTTPS. Do not use Prometheus's default port 9090.
+
 1. Click **Create Configuration**.
 
 ### VictoriaMetrics
@@ -193,6 +207,10 @@ The [VictoriaMetrics](https://docs.victoriametrics.com/) integration requires th
 
     See [Control traffic to your AWS resources using security groups](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-groups.html) in the AWS documentation, or [VPC firewall rules](https://cloud.google.com/firewall/docs/firewalls) in the Google Cloud documentation.
 
+  - VictoriaMetrics listening on the HTTP or HTTPS port that matches the endpoint URL you provide.
+
+    The Metrics Exporter connects using the port implied by the URL scheme: port 80 for `http://` and port 443 for `https://`. The default VictoriaMetrics listen port is not used and export fails if VictoriaMetrics is only reachable on a non-standard port such as 8428. Configure VictoriaMetrics to listen on port 80 or 443, or place a reverse proxy such as nginx in front of VictoriaMetrics to terminate HTTP/HTTPS on 80 or 443 and forward traffic to VictoriaMetrics.
+
 - YugabyteDB Aeon cluster from which you want to export metrics
   - Cluster deployed in VPCs on AWS, or a VPC in GCP. See [VPCs](../../cloud-basics/cloud-vpcs/cloud-add-vpc/).
   - VPCs are peered with the VPC hosting VictoriaMetrics. See [Peer VPCs](../../cloud-basics/cloud-vpcs/cloud-add-vpc-aws/).
@@ -212,6 +230,14 @@ To create an export configuration, do the following:
     ```sh
     http://<victoria-metrics-endpoint-host-address>/opentelemetry
     ```
+
+    or, for HTTPS,
+
+    ```sh
+    https://<victoria-metrics-endpoint-host-address>/opentelemetry
+    ```
+
+    Omit a custom port from the URL. The exporter targets port 80 for HTTP and port 443 for HTTPS. Do not use VictoriaMetrics's default listen port.
 
 1. Click **Create Configuration**.
 

--- a/docs/content/stable/yugabyte-cloud/cloud-monitor/metrics-export.md
+++ b/docs/content/stable/yugabyte-cloud/cloud-monitor/metrics-export.md
@@ -16,6 +16,8 @@ You can export [cluster metrics](../monitor-metrics/) to third-party tools for a
 
 Metrics export is not available for Sandbox clusters.
 
+All metrics exported from a cluster are prefixed with `ybdb`.
+
 Exporting metrics may incur costs for network transfer, especially for cross-region and internet-based transfers. Refer to [Data transfer costs](../../cloud-admin/cloud-billing-costs/#data-transfer-costs).
 
 ## Prerequisites

--- a/docs/content/stable/yugabyte-cloud/cloud-monitor/metrics-export.md
+++ b/docs/content/stable/yugabyte-cloud/cloud-monitor/metrics-export.md
@@ -38,3 +38,11 @@ To modify the metrics export configuration, on the cluster **Settings** tab, sel
 To pause or resume metrics export from a cluster, on the cluster **Settings** tab, select **Edit Metrics Export Configuration** and choose **Pause Metrics Export** or **Resume Metrics Export**.
 
 To remove metrics export from a cluster, on the cluster **Settings** tab, select **Edit Metrics Export Configuration** and choose **Disable Metrics Export**.
+
+## Troubleshooting
+
+If metrics aren't being exported, verify the following:
+
+- Prometheus/VictoriaMetrics is listening on port 80 or 443.
+- Firewall rules allow traffic from your cluster to the listening port.
+- The URL scheme (http vs https) matches the configured port.


### PR DESCRIPTION
Document that Prometheus and VictoriaMetrics must listen on port 80/443 (or sit behind a reverse proxy), not their defaults, and that exported metrics are prefixed with ybdb.