### PR TITLE
[#29306] DocDB: Release CatalogManager::mutex_ before AlterTable sys-catalog write

### DIFF
--- a/src/yb/integration-tests/alter_table-test.cc
+++ b/src/yb/integration-tests/alter_table-test.cc
@@ -76,6 +76,7 @@
 #include "yb/tserver/ts_tablet_manager.h"
 
 #include "yb/util/atomic.h"
+#include "yb/util/backoff_waiter.h"
 #include "yb/util/faststring.h"
 #include "yb/util/logging_test_util.h"
 #include "yb/util/metrics.h"
@@ -101,6 +102,7 @@ DECLARE_int32(replication_factor);
 DECLARE_int32(log_min_seconds_to_retain);
 DECLARE_int32(catalog_manager_report_batch_size);
 DECLARE_string(TEST_block_alter_table);
+DECLARE_bool(TEST_fail_alter_table_after_commit);
 DECLARE_bool(TEST_fail_alter_table_sys_catalog_write);
 
 METRIC_DECLARE_counter(sys_catalog_peer_write_count);
@@ -334,8 +336,9 @@ class ReplicatedAlterTableTest : public AlterTableTest {
   virtual int num_replicas() const override { return 3; }
 };
 
-// Subclass for the tests that target the sys-catalog write step of an alter. The tablet-report
-// batch size that parameterizes AlterTableTest does not affect these tests, so they run at a
+// Subclass for the tests that target the master-side windows of an alter, from the name
+// reservation through the sys-catalog write and the in-memory commit. The tablet-report batch
+// size that parameterizes AlterTableTest does not affect these tests, so they run at a
 // single value.
 class AlterTableSysCatalogWriteTest : public AlterTableTest {};
 
@@ -687,6 +690,9 @@ TEST_P(AlterTableSysCatalogWriteTest, TestRenameSysCatalogWriteFailureDoesNotDea
 
   ASSERT_TRUE(ASSERT_RESULT(TableNameResolves(kTableName)));
   ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(new_name)));
+
+  // The rolled-back name is free for a fresh table.
+  ASSERT_OK(CreateTable(new_name));
 }
 
 // The non-rename variant of the sys-catalog write-failure test above. A column add reserves no
@@ -706,11 +712,13 @@ TEST_P(AlterTableSysCatalogWriteTest, TestAddColumnSysCatalogWriteFailureKeepsNa
   ASSERT_OK(AddNewI32Column(kTableName, "added-after-add-failure"));
 }
 
-// The three tests below open the window that the sys-catalog write for an alter runs in.
-// FLAGS_TEST_block_alter_table = "sys_catalog_write" parks the alter after it has released
-// CatalogManager::mutex_ and before it starts the write, holding the table's COW write lock.
-// That is the exact state a concurrent RPC observes while a real write is in flight. Each test
-// drives client operations through the open window and asserts what they see.
+// The window tests below park an alter mid-flight with FLAGS_TEST_block_alter_table and drive
+// concurrent client operations through the open window. "sys_catalog_write" parks the alter
+// after it has released CatalogManager::mutex_ and before it starts the sys-catalog write,
+// holding the table's COW write lock. That is the exact state a concurrent RPC observes while a
+// real write is in flight. "post_name_reservation" parks a rename after it has reserved its new
+// name and released mutex_, before it takes the COW write lock. That is the state a concurrent
+// RPC observes between the reservation and the lock, when the rename holds no lock at all.
 
 // Catalog operations must not block while an alter's sys-catalog write is in flight, because
 // mutex_ is released across the write. While the alter is parked, a schema read of the altering
@@ -882,6 +890,340 @@ TEST_P(AlterTableSysCatalogWriteTest, TestDropByOldNameWaitsForRenameCommit) {
   // succeeding proves the rename erased the old name and the drop erased the new one.
   ASSERT_OK(CreateTable(kTableName));
   ASSERT_OK(CreateTable(new_name));
+}
+
+// Two renames of the same table can be in flight at once. The first rename holds the table's
+// COW write lock across its sys-catalog write. The second rename reserves its own new name
+// under mutex_ and then waits for the COW lock with no lock held, so catalog operations proceed
+// while it waits and its reserved name resolves. Once the first rename commits, the second
+// rename applies on top of it. Each rename erases the name that was committed when it acquired
+// the lock, so every name the table passed through frees up for reuse.
+TEST_P(AlterTableSysCatalogWriteTest, TestQueuedRenameWaitsWithoutBlockingCatalogOps) {
+  YBTableName first_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "renamed-once");
+  YBTableName second_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "renamed-twice");
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "sys_catalog_write";
+  StringWaiterLogSink parked_sink("Blocking AlterTableWithBatchTracker");
+
+  // Declared before the holder. Its destructor joins the threads, which write these values, so
+  // the values must outlive the holder on every return path.
+  Status first_rename_status;
+  Status second_rename_status;
+  TestThreadHolder threads;
+  auto release_alter = ScopeExit([] {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  });
+  threads.AddThreadFunctor([&] {
+    std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+    // The second rename changes the name again before the tablets report, so polling for this
+    // alter to finish by name cannot succeed. Return once the master has committed the rename.
+    first_rename_status = table_alterer->RenameTo(first_name)->wait(false)->Alter();
+  });
+  ASSERT_OK(parked_sink.WaitFor(30s * kTimeMultiplier));
+
+  threads.AddThreadFunctor([&] {
+    std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+    second_rename_status = table_alterer->RenameTo(second_name)->wait(false)->Alter();
+  });
+
+  // The second rename reserves its new name under mutex_ and then waits for the COW write lock
+  // that the parked rename holds. The reservation resolving proves the second rename is past
+  // its mutex_ scope. If the second rename held mutex_ while waiting for the COW lock, this
+  // schema read would block behind it and the wait would time out.
+  ASSERT_OK(WaitFor([&]() -> Result<bool> {
+    return TableNameResolves(second_name);
+  }, 30s * kTimeMultiplier, "second rename reserves its new name"));
+
+  // The committed name and both reservations point at the same table.
+  auto info_committed = ASSERT_RESULT(client_->GetYBTableInfo(kTableName));
+  auto info_first = ASSERT_RESULT(client_->GetYBTableInfo(first_name));
+  auto info_second = ASSERT_RESULT(client_->GetYBTableInfo(second_name));
+  ASSERT_EQ(info_committed.table_id, info_first.table_id);
+  ASSERT_EQ(info_committed.table_id, info_second.table_id);
+
+  // Catalog operations proceed while the second rename waits. A listing shows the table exactly
+  // once, under its committed name, and a CREATE of an unrelated table completes. Both acquire
+  // mutex_, so they would block if either in-flight rename held it.
+  auto tables = ASSERT_RESULT(client_->ListTables());
+  ASSERT_EQ(1, std::ranges::count_if(tables, [](const YBTableName& name) {
+    return name.table_name() == kTableName.table_name();
+  }));
+  YBTableName other_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "created-during-queued-rename");
+  ASSERT_OK(CreateTable(other_name));
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  threads.JoinAll();
+  ASSERT_OK(first_rename_status);
+  ASSERT_OK(second_rename_status);
+
+  // The first rename erased the original name. The second rename erased the first new name,
+  // which was the committed name when it acquired the lock. Only the final name resolves, and
+  // both earlier names are free for fresh tables. A rename that erased the name its request
+  // carried instead of the committed name would leave the first new name behind.
+  ASSERT_TRUE(ASSERT_RESULT(TableNameResolves(second_name)));
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(kTableName)));
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(first_name)));
+  ASSERT_OK(CreateTable(kTableName));
+  ASSERT_OK(CreateTable(first_name));
+
+  // The renamed table is fully usable. This alter waits for the tablets to apply the schema, so
+  // the cluster is settled before teardown.
+  ASSERT_OK(AddNewI32Column(second_name, "added-after-queued-renames"));
+}
+
+// An alter that carries both a rename and a failing option must not leak the reserved new name.
+// wal_retention_secs cannot be combined with other changes, so a request that carries both a
+// rename and wal_retention_secs fails validation after the new name is reserved in the by-name
+// map. The failure must erase the reservation. A leaked entry would keep the new name resolving
+// to this table and would fail any CREATE targeting the name with AlreadyPresent until a leader
+// change rebuilds the map.
+TEST_P(AlterTableSysCatalogWriteTest, TestFailedRenameDoesNotLeakReservedName) {
+  YBTableName new_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "never-renamed-to");
+
+  std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+  Status s = table_alterer->RenameTo(new_name)->SetWalRetentionSecs(3600)->Alter();
+  ASSERT_THAT(s, EqualsCode(STATUS(InvalidArgument, "")));
+
+  // The old name stays live and the reservation is rolled back.
+  ASSERT_TRUE(ASSERT_RESULT(TableNameResolves(kTableName)));
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(new_name)));
+
+  // The rolled-back name is free for a fresh table.
+  ASSERT_OK(CreateTable(new_name));
+}
+
+// The alter-step variant of the leak test above. The rename target is free, so the reservation
+// succeeds, and the invalid alter step fails the request after it, inside the schema-change
+// application rather than in option validation. The failure must erase the reservation.
+TEST_P(AlterTableSysCatalogWriteTest, TestFailedAlterStepReleasesReservedName) {
+  YBTableName new_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "never-renamed-either");
+
+  // Dropping a column that does not exist fails schema-change application.
+  std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+  table_alterer->DropColumn("no-such-column");
+  Status s = table_alterer->RenameTo(new_name)->Alter();
+  ASSERT_THAT(s, EqualsCode(STATUS(NotFound, "")));
+
+  // The old name stays live and the reservation is rolled back.
+  ASSERT_TRUE(ASSERT_RESULT(TableNameResolves(kTableName)));
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(new_name)));
+
+  // The rolled-back name is free for a fresh table.
+  ASSERT_OK(CreateTable(new_name));
+}
+
+// A rename checks its target name for collisions and reserves it before the table's COW write
+// lock is taken, so the collision check runs before the request's alter steps are validated. A
+// request that combines a rename to a taken name with an invalid alter step reports the
+// collision. This pins that order deliberately. The collision cannot be checked later than the
+// reservation, and the reservation precedes the COW lock so that mutex_ and that lock are never
+// held together.
+TEST_P(AlterTableSysCatalogWriteTest, TestRenameCollisionCheckedBeforeAlterSteps) {
+  YBTableName taken_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "taken-name");
+  ASSERT_OK(CreateTable(taken_name));
+
+  // Dropping a column that does not exist is an invalid step. The collision must win.
+  std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+  table_alterer->DropColumn("no-such-column");
+  Status s = table_alterer->RenameTo(taken_name)->Alter();
+  ASSERT_THAT(s, EqualsCode(STATUS(AlreadyPresent, "")));
+
+  // Nothing changed. Each name still resolves to its own table.
+  auto info_original = ASSERT_RESULT(client_->GetYBTableInfo(kTableName));
+  auto info_taken = ASSERT_RESULT(client_->GetYBTableInfo(taken_name));
+  ASSERT_NE(info_original.table_id, info_taken.table_id);
+}
+
+// A rename whose target is the table's own current name collides with the table itself in the
+// by-name map. The collision is reported before any reservation is made, so the failure path
+// has nothing to erase and must not touch the live entry. A rollback that erased the entry
+// anyway would drop the table's only name mapping.
+TEST_P(AlterTableSysCatalogWriteTest, TestRenameToSameNameKeepsTableReachable) {
+  std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+  Status s = table_alterer->RenameTo(kTableName)->Alter();
+  ASSERT_THAT(s, EqualsCode(STATUS(AlreadyPresent, "")));
+
+  // The table's one name mapping is intact. A lookup and a subsequent alter both succeed.
+  ASSERT_TRUE(ASSERT_RESULT(TableNameResolves(kTableName)));
+  ASSERT_OK(AddNewI32Column(kTableName, "added-after-self-rename"));
+}
+
+// The name reservation rejects a concurrent rename the same way it rejects a concurrent
+// CREATE. While one table's rename is parked before its sys-catalog write, holding the
+// reservation, a rename of a second table to the same name fails with AlreadyPresent against
+// the reservation. The check runs in the second rename's own mutex_ scope, so it completes
+// while the first rename is parked. Once the first rename commits, the name belongs to the
+// renamed table and its vacated old name is free.
+TEST_P(AlterTableSysCatalogWriteTest, TestRenameToReservedNameRejected) {
+  YBTableName contested_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "contested-name");
+  YBTableName other_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "other-renamer");
+  ASSERT_OK(CreateTable(other_name));
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "sys_catalog_write";
+  StringWaiterLogSink parked_sink("Blocking AlterTableWithBatchTracker");
+
+  // Declared before the holder. Its destructor joins the thread, which writes this status, so
+  // the status must outlive the holder on every return path.
+  Status rename_status;
+  TestThreadHolder threads;
+  auto release_alter = ScopeExit([] {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  });
+  threads.AddThreadFunctor([&] {
+    std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+    rename_status = table_alterer->RenameTo(contested_name)->Alter();
+  });
+  ASSERT_OK(parked_sink.WaitFor(30s * kTimeMultiplier));
+
+  // The second rename fails against the reservation, before it reaches its own park point, so
+  // this call returns while the first rename is still parked.
+  std::unique_ptr<YBTableAlterer> other_alterer(client_->NewTableAlterer(other_name));
+  Status s = other_alterer->RenameTo(contested_name)->Alter();
+  ASSERT_THAT(s, EqualsCode(STATUS(AlreadyPresent, "")));
+
+  // The failed rename changed nothing. The other table stays reachable by its own name, and the
+  // contested name still resolves to the renaming table.
+  auto info_other = ASSERT_RESULT(client_->GetYBTableInfo(other_name));
+  auto info_contested = ASSERT_RESULT(client_->GetYBTableInfo(contested_name));
+  auto info_renaming = ASSERT_RESULT(client_->GetYBTableInfo(kTableName));
+  ASSERT_EQ(info_contested.table_id, info_renaming.table_id);
+  ASSERT_NE(info_contested.table_id, info_other.table_id);
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  threads.JoinAll();
+  ASSERT_OK(rename_status);
+
+  // The parked rename committed. The contested name belongs to the renamed table and the old
+  // name is free for a fresh table.
+  ASSERT_TRUE(ASSERT_RESULT(TableNameResolves(contested_name)));
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(kTableName)));
+  ASSERT_OK(CreateTable(kTableName));
+}
+
+// A rename holds no lock between reserving its new name and taking the table's COW write lock.
+// A DROP of the table through its committed old name in that window runs to completion, because
+// nothing blocks it, and it erases only the committed name. The reservation stays behind,
+// pointing at the deleted table. The rename then finds the table deleted and fails, and the
+// failure must erase the reservation. A reservation left behind would fail every CREATE of that
+// name with AlreadyPresent even though the table is gone.
+TEST_P(AlterTableSysCatalogWriteTest, TestDropByOldNameDuringReservationWindow) {
+  YBTableName new_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "reserved-then-dropped");
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "post_name_reservation";
+  StringWaiterLogSink parked_sink("Blocking AlterTableWithBatchTracker");
+
+  // Declared before the holder. Its destructor joins the thread, which writes this status, so
+  // the status must outlive the holder on every return path.
+  Status rename_status;
+  TestThreadHolder threads;
+  auto release_alter = ScopeExit([] {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  });
+  threads.AddThreadFunctor([&] {
+    std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+    rename_status = table_alterer->RenameTo(new_name)->Alter();
+  });
+  ASSERT_OK(parked_sink.WaitFor(30s * kTimeMultiplier));
+
+  // The parked rename holds neither mutex_ nor the table's COW write lock, so the drop runs to
+  // completion while the rename is parked.
+  ASSERT_OK(client_->DeleteTable(kTableName));
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  threads.JoinAll();
+  // The rename finds the table deleted when it takes the lock.
+  ASSERT_THAT(rename_status, EqualsCode(STATUS(NotFound, "")));
+
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(kTableName)));
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(new_name)));
+
+  // The drop erased the committed name and the rename's failure erased the reservation. Both
+  // names are free for fresh tables.
+  ASSERT_OK(CreateTable(kTableName));
+  ASSERT_OK(CreateTable(new_name));
+}
+
+// The reservation-window variant where the DROP arrives through the reserved new name instead
+// of the committed old name. The delete path resolves the name before it takes any lock and
+// never revalidates it, so the drop resolves the reservation to the renaming table and deletes
+// it. The drop erases only the committed name, the rename fails against the deleted table, and
+// the failure must erase the reservation.
+//
+// TODO: A delete-path fix that revalidates the resolved name against the committed
+// name once the delete holds the table lock would reject a drop through an uncommitted reserved
+// name, and the drop assertions below should flip with it.
+TEST_P(AlterTableSysCatalogWriteTest, TestDropByReservedNameDuringReservationWindow) {
+  YBTableName new_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "reserved-name-dropped");
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "post_name_reservation";
+  StringWaiterLogSink parked_sink("Blocking AlterTableWithBatchTracker");
+
+  // Declared before the holder. Its destructor joins the thread, which writes this status, so
+  // the status must outlive the holder on every return path.
+  Status rename_status;
+  TestThreadHolder threads;
+  auto release_alter = ScopeExit([] {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  });
+  threads.AddThreadFunctor([&] {
+    std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+    rename_status = table_alterer->RenameTo(new_name)->Alter();
+  });
+  ASSERT_OK(parked_sink.WaitFor(30s * kTimeMultiplier));
+
+  // The reserved name resolves to the renaming table, and the parked rename holds no lock, so
+  // the drop resolves through the reservation and runs to completion.
+  ASSERT_OK(client_->DeleteTable(new_name));
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  threads.JoinAll();
+  // The rename finds the table deleted when it takes the lock.
+  ASSERT_THAT(rename_status, EqualsCode(STATUS(NotFound, "")));
+
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(kTableName)));
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(new_name)));
+
+  // The drop erased the committed name and the rename's failure erased the reservation. Both
+  // names are free for fresh tables.
+  ASSERT_OK(CreateTable(kTableName));
+  ASSERT_OK(CreateTable(new_name));
+}
+
+// An injected failure right after the in-memory commit exercises the alter's late failure path.
+// The rename is committed at that point, so the failure must not roll it back. The reservation
+// guard was dismissed at commit and the old name was already erased, so the new name keeps
+// resolving, the old name is free, and the error reaches the client. A guard that outlived the
+// commit would erase the table's live name.
+TEST_P(AlterTableSysCatalogWriteTest, TestFailureAfterCommitKeepsRename) {
+  YBTableName new_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "renamed-then-failed");
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_fail_alter_table_after_commit) = true;
+  std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+  Status s = table_alterer->RenameTo(new_name)->Alter();
+  ASSERT_NOK(s);
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_fail_alter_table_after_commit) = false;
+
+  // The rename committed before the injected failure. Only the new name resolves.
+  ASSERT_TRUE(ASSERT_RESULT(TableNameResolves(new_name)));
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(kTableName)));
+
+  // The commit erased the old name rather than leaking it, so it is free for a fresh table.
+  ASSERT_OK(CreateTable(kTableName));
+
+  // The renamed table accepts further schema changes. This alter waits for the tablets to apply
+  // the schema, so the cluster is settled before teardown.
+  ASSERT_OK(AddNewI32Column(new_name, "added-after-injected-failure"));
 }
 
 // Test restarting a tablet server several times after various

--- a/src/yb/integration-tests/alter_table-test.cc
+++ b/src/yb/integration-tests/alter_table-test.cc
@@ -76,6 +76,7 @@
 #include "yb/tserver/ts_tablet_manager.h"
 
 #include "yb/util/atomic.h"
+#include "yb/util/backoff_waiter.h"
 #include "yb/util/faststring.h"
 #include "yb/util/logging_test_util.h"
 #include "yb/util/metrics.h"
@@ -100,6 +101,7 @@ DECLARE_int32(replication_factor);
 DECLARE_int32(log_min_seconds_to_retain);
 DECLARE_int32(catalog_manager_report_batch_size);
 DECLARE_string(TEST_block_alter_table);
+DECLARE_bool(TEST_fail_alter_table_after_commit);
 DECLARE_bool(TEST_fail_alter_table_sys_catalog_write);
 
 METRIC_DECLARE_counter(sys_catalog_peer_write_count);
@@ -333,8 +335,9 @@ class ReplicatedAlterTableTest : public AlterTableTest {
   virtual int num_replicas() const override { return 3; }
 };
 
-// Subclass for the tests that target the sys-catalog write step of an alter. The tablet-report
-// batch size that parameterizes AlterTableTest does not affect these tests, so they run at a
+// Subclass for the tests that target the master-side windows of an alter, from the name
+// reservation through the sys-catalog write and the in-memory commit. The tablet-report batch
+// size that parameterizes AlterTableTest does not affect these tests, so they run at a
 // single value.
 class AlterTableSysCatalogWriteTest : public AlterTableTest {};
 
@@ -686,6 +689,9 @@ TEST_P(AlterTableSysCatalogWriteTest, TestRenameSysCatalogWriteFailureDoesNotDea
 
   ASSERT_TRUE(ASSERT_RESULT(TableNameResolves(kTableName)));
   ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(new_name)));
+
+  // The rolled-back name is free for a fresh table.
+  ASSERT_OK(CreateTable(new_name));
 }
 
 // The non-rename variant of the sys-catalog write-failure test above. A column add reserves no
@@ -705,11 +711,13 @@ TEST_P(AlterTableSysCatalogWriteTest, TestAddColumnSysCatalogWriteFailureKeepsNa
   ASSERT_OK(AddNewI32Column(kTableName, "added-after-add-failure"));
 }
 
-// The three tests below open the window that the sys-catalog write for an alter runs in.
-// FLAGS_TEST_block_alter_table = "sys_catalog_write" parks the alter after it has released
-// CatalogManager::mutex_ and before it starts the write, holding the table's COW write lock.
-// That is the exact state a concurrent RPC observes while a real write is in flight. Each test
-// drives client operations through the open window and asserts what they see.
+// The window tests below park an alter mid-flight with FLAGS_TEST_block_alter_table and drive
+// concurrent client operations through the open window. "sys_catalog_write" parks the alter
+// after it has released CatalogManager::mutex_ and before it starts the sys-catalog write,
+// holding the table's COW write lock. That is the exact state a concurrent RPC observes while a
+// real write is in flight. "post_name_reservation" parks a rename after it has reserved its new
+// name and released mutex_, before it takes the COW write lock. That is the state a concurrent
+// RPC observes between the reservation and the lock, when the rename holds no lock at all.
 
 // Catalog operations must not block while an alter's sys-catalog write is in flight, because
 // mutex_ is released across the write. While the alter is parked, a schema read of the altering
@@ -861,6 +869,320 @@ TEST_P(AlterTableSysCatalogWriteTest, TestDropByOldNameWaitsForRenameCommit) {
   // succeeding proves the rename erased the old name and the drop erased the new one.
   ASSERT_OK(CreateTable(kTableName));
   ASSERT_OK(CreateTable(new_name));
+}
+
+// Two renames of the same table can be in flight at once. The first rename holds the table's
+// COW write lock across its sys-catalog write. The second rename reserves its own new name
+// under mutex_ and then waits for the COW lock with no lock held, so catalog operations proceed
+// while it waits and its reserved name resolves. Once the first rename commits, the second
+// rename applies on top of it. Each rename erases the name that was committed when it acquired
+// the lock, so every name the table passed through frees up for reuse.
+TEST_P(AlterTableSysCatalogWriteTest, TestQueuedRenameWaitsWithoutBlockingCatalogOps) {
+  YBTableName first_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "renamed-once");
+  YBTableName second_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "renamed-twice");
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "sys_catalog_write";
+  StringWaiterLogSink parked_sink("Blocking AlterTableWithBatchTracker");
+
+  auto first_rename_future = std::async(std::launch::async, [&] {
+    std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+    // The second rename changes the name again before the tablets report, so polling for this
+    // alter to finish by name cannot succeed. Return once the master has committed the rename.
+    return table_alterer->RenameTo(first_name)->wait(false)->Alter();
+  });
+  std::future<Status> second_rename_future;  // Assigned once the first rename is parked.
+  auto release_alter = ScopeExit([] {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  });
+  ASSERT_OK(parked_sink.WaitFor(30s * kTimeMultiplier));
+
+  second_rename_future = std::async(std::launch::async, [&] {
+    std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+    return table_alterer->RenameTo(second_name)->wait(false)->Alter();
+  });
+
+  // The second rename reserves its new name under mutex_ and then waits for the COW write lock
+  // that the parked rename holds. The reservation resolving proves the second rename is past
+  // its mutex_ scope. If the second rename held mutex_ while waiting for the COW lock, this
+  // schema read would block behind it and the wait would time out.
+  ASSERT_OK(WaitFor([&]() -> Result<bool> {
+    return TableNameResolves(second_name);
+  }, 30s * kTimeMultiplier, "second rename reserves its new name"));
+
+  // The committed name and both reservations point at the same table.
+  auto info_committed = ASSERT_RESULT(client_->GetYBTableInfo(kTableName));
+  auto info_first = ASSERT_RESULT(client_->GetYBTableInfo(first_name));
+  auto info_second = ASSERT_RESULT(client_->GetYBTableInfo(second_name));
+  ASSERT_EQ(info_committed.table_id, info_first.table_id);
+  ASSERT_EQ(info_committed.table_id, info_second.table_id);
+
+  // Catalog operations proceed while the second rename waits. A listing shows the table exactly
+  // once, under its committed name, and a CREATE of an unrelated table completes. Both acquire
+  // mutex_, so they would block if either in-flight rename held it.
+  auto tables = ASSERT_RESULT(client_->ListTables());
+  ASSERT_EQ(1, std::ranges::count_if(tables, [](const YBTableName& name) {
+    return name.table_name() == kTableName.table_name();
+  }));
+  YBTableName other_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "created-during-queued-rename");
+  ASSERT_OK(CreateTable(other_name));
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  ASSERT_OK(first_rename_future.get());
+  ASSERT_OK(second_rename_future.get());
+
+  // The first rename erased the original name. The second rename erased the first new name,
+  // which was the committed name when it acquired the lock. Only the final name resolves, and
+  // both earlier names are free for fresh tables. A rename that erased the name its request
+  // carried instead of the committed name would leave the first new name behind.
+  ASSERT_TRUE(ASSERT_RESULT(TableNameResolves(second_name)));
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(kTableName)));
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(first_name)));
+  ASSERT_OK(CreateTable(kTableName));
+  ASSERT_OK(CreateTable(first_name));
+
+  // The renamed table is fully usable. This alter waits for the tablets to apply the schema, so
+  // the cluster is settled before teardown.
+  ASSERT_OK(AddNewI32Column(second_name, "added-after-queued-renames"));
+}
+
+// An alter that carries both a rename and a failing option must not leak the reserved new name.
+// wal_retention_secs cannot be combined with other changes, so a request that carries both a
+// rename and wal_retention_secs fails validation after the new name is reserved in the by-name
+// map. The failure must erase the reservation. A leaked entry would keep the new name resolving
+// to this table and would fail any CREATE targeting the name with AlreadyPresent until a leader
+// change rebuilds the map.
+TEST_P(AlterTableSysCatalogWriteTest, TestFailedRenameDoesNotLeakReservedName) {
+  YBTableName new_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "never-renamed-to");
+
+  std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+  Status s = table_alterer->RenameTo(new_name)->SetWalRetentionSecs(3600)->Alter();
+  ASSERT_THAT(s, EqualsCode(STATUS(InvalidArgument, "")));
+
+  // The old name stays live and the reservation is rolled back.
+  ASSERT_TRUE(ASSERT_RESULT(TableNameResolves(kTableName)));
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(new_name)));
+
+  // The rolled-back name is free for a fresh table.
+  ASSERT_OK(CreateTable(new_name));
+}
+
+// The alter-step variant of the leak test above. The rename target is free, so the reservation
+// succeeds, and the invalid alter step fails the request after it, inside the schema-change
+// application rather than in option validation. The failure must erase the reservation.
+TEST_P(AlterTableSysCatalogWriteTest, TestFailedAlterStepReleasesReservedName) {
+  YBTableName new_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "never-renamed-either");
+
+  // Dropping a column that does not exist fails schema-change application.
+  std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+  table_alterer->DropColumn("no-such-column");
+  Status s = table_alterer->RenameTo(new_name)->Alter();
+  ASSERT_THAT(s, EqualsCode(STATUS(NotFound, "")));
+
+  // The old name stays live and the reservation is rolled back.
+  ASSERT_TRUE(ASSERT_RESULT(TableNameResolves(kTableName)));
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(new_name)));
+
+  // The rolled-back name is free for a fresh table.
+  ASSERT_OK(CreateTable(new_name));
+}
+
+// A rename checks its target name for collisions and reserves it before the table's COW write
+// lock is taken, so the collision check runs before the request's alter steps are validated. A
+// request that combines a rename to a taken name with an invalid alter step reports the
+// collision. This pins that order deliberately. The collision cannot be checked later than the
+// reservation, and the reservation precedes the COW lock so that mutex_ and that lock are never
+// held together.
+TEST_P(AlterTableSysCatalogWriteTest, TestRenameCollisionCheckedBeforeAlterSteps) {
+  YBTableName taken_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "taken-name");
+  ASSERT_OK(CreateTable(taken_name));
+
+  // Dropping a column that does not exist is an invalid step. The collision must win.
+  std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+  table_alterer->DropColumn("no-such-column");
+  Status s = table_alterer->RenameTo(taken_name)->Alter();
+  ASSERT_THAT(s, EqualsCode(STATUS(AlreadyPresent, "")));
+
+  // Nothing changed. Each name still resolves to its own table.
+  auto info_original = ASSERT_RESULT(client_->GetYBTableInfo(kTableName));
+  auto info_taken = ASSERT_RESULT(client_->GetYBTableInfo(taken_name));
+  ASSERT_NE(info_original.table_id, info_taken.table_id);
+}
+
+// A rename whose target is the table's own current name collides with the table itself in the
+// by-name map. The collision is reported before any reservation is made, so the failure path
+// has nothing to erase and must not touch the live entry. A rollback that erased the entry
+// anyway would drop the table's only name mapping.
+TEST_P(AlterTableSysCatalogWriteTest, TestRenameToSameNameKeepsTableReachable) {
+  std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+  Status s = table_alterer->RenameTo(kTableName)->Alter();
+  ASSERT_THAT(s, EqualsCode(STATUS(AlreadyPresent, "")));
+
+  // The table's one name mapping is intact. A lookup and a subsequent alter both succeed.
+  ASSERT_TRUE(ASSERT_RESULT(TableNameResolves(kTableName)));
+  ASSERT_OK(AddNewI32Column(kTableName, "added-after-self-rename"));
+}
+
+// The name reservation rejects a concurrent rename the same way it rejects a concurrent
+// CREATE. While one table's rename is parked before its sys-catalog write, holding the
+// reservation, a rename of a second table to the same name fails with AlreadyPresent against
+// the reservation. The check runs in the second rename's own mutex_ scope, so it completes
+// while the first rename is parked. Once the first rename commits, the name belongs to the
+// renamed table and its vacated old name is free.
+TEST_P(AlterTableSysCatalogWriteTest, TestRenameToReservedNameRejected) {
+  YBTableName contested_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "contested-name");
+  YBTableName other_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "other-renamer");
+  ASSERT_OK(CreateTable(other_name));
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "sys_catalog_write";
+  StringWaiterLogSink parked_sink("Blocking AlterTableWithBatchTracker");
+
+  auto rename_future = std::async(std::launch::async, [&] {
+    std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+    return table_alterer->RenameTo(contested_name)->Alter();
+  });
+  auto release_alter = ScopeExit([] {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  });
+  ASSERT_OK(parked_sink.WaitFor(30s * kTimeMultiplier));
+
+  // The second rename fails against the reservation, before it reaches its own park point, so
+  // this call returns while the first rename is still parked.
+  std::unique_ptr<YBTableAlterer> other_alterer(client_->NewTableAlterer(other_name));
+  Status s = other_alterer->RenameTo(contested_name)->Alter();
+  ASSERT_THAT(s, EqualsCode(STATUS(AlreadyPresent, "")));
+
+  // The failed rename changed nothing. The other table stays reachable by its own name, and the
+  // contested name still resolves to the renaming table.
+  auto info_other = ASSERT_RESULT(client_->GetYBTableInfo(other_name));
+  auto info_contested = ASSERT_RESULT(client_->GetYBTableInfo(contested_name));
+  auto info_renaming = ASSERT_RESULT(client_->GetYBTableInfo(kTableName));
+  ASSERT_EQ(info_contested.table_id, info_renaming.table_id);
+  ASSERT_NE(info_contested.table_id, info_other.table_id);
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  ASSERT_OK(rename_future.get());
+
+  // The parked rename committed. The contested name belongs to the renamed table and the old
+  // name is free for a fresh table.
+  ASSERT_TRUE(ASSERT_RESULT(TableNameResolves(contested_name)));
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(kTableName)));
+  ASSERT_OK(CreateTable(kTableName));
+}
+
+// A rename holds no lock between reserving its new name and taking the table's COW write lock.
+// A DROP of the table through its committed old name in that window runs to completion, because
+// nothing blocks it, and it erases only the committed name. The reservation stays behind,
+// pointing at the deleted table. The rename then finds the table deleted and fails, and the
+// failure must erase the reservation. A reservation left behind would fail every CREATE of that
+// name with AlreadyPresent even though the table is gone.
+TEST_P(AlterTableSysCatalogWriteTest, TestDropByOldNameDuringReservationWindow) {
+  YBTableName new_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "reserved-then-dropped");
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "post_name_reservation";
+  StringWaiterLogSink parked_sink("Blocking AlterTableWithBatchTracker");
+
+  auto rename_future = std::async(std::launch::async, [&] {
+    std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+    return table_alterer->RenameTo(new_name)->Alter();
+  });
+  auto release_alter = ScopeExit([] {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  });
+  ASSERT_OK(parked_sink.WaitFor(30s * kTimeMultiplier));
+
+  // The parked rename holds neither mutex_ nor the table's COW write lock, so the drop runs to
+  // completion while the rename is parked.
+  ASSERT_OK(client_->DeleteTable(kTableName));
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  // The rename finds the table deleted when it takes the lock.
+  ASSERT_THAT(rename_future.get(), EqualsCode(STATUS(NotFound, "")));
+
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(kTableName)));
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(new_name)));
+
+  // The drop erased the committed name and the rename's failure erased the reservation. Both
+  // names are free for fresh tables.
+  ASSERT_OK(CreateTable(kTableName));
+  ASSERT_OK(CreateTable(new_name));
+}
+
+// The reservation-window variant where the DROP arrives through the reserved new name instead
+// of the committed old name. The delete path resolves the name before it takes any lock and
+// never revalidates it, so the drop resolves the reservation to the renaming table and deletes
+// it. The drop erases only the committed name, the rename fails against the deleted table, and
+// the failure must erase the reservation.
+//
+// TODO: A delete-path fix that revalidates the resolved name against the committed
+// name once the delete holds the table lock would reject a drop through an uncommitted reserved
+// name, and the drop assertions below should flip with it.
+TEST_P(AlterTableSysCatalogWriteTest, TestDropByReservedNameDuringReservationWindow) {
+  YBTableName new_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "reserved-name-dropped");
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "post_name_reservation";
+  StringWaiterLogSink parked_sink("Blocking AlterTableWithBatchTracker");
+
+  auto rename_future = std::async(std::launch::async, [&] {
+    std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+    return table_alterer->RenameTo(new_name)->Alter();
+  });
+  auto release_alter = ScopeExit([] {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  });
+  ASSERT_OK(parked_sink.WaitFor(30s * kTimeMultiplier));
+
+  // The reserved name resolves to the renaming table, and the parked rename holds no lock, so
+  // the drop resolves through the reservation and runs to completion.
+  ASSERT_OK(client_->DeleteTable(new_name));
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  // The rename finds the table deleted when it takes the lock.
+  ASSERT_THAT(rename_future.get(), EqualsCode(STATUS(NotFound, "")));
+
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(kTableName)));
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(new_name)));
+
+  // The drop erased the committed name and the rename's failure erased the reservation. Both
+  // names are free for fresh tables.
+  ASSERT_OK(CreateTable(kTableName));
+  ASSERT_OK(CreateTable(new_name));
+}
+
+// An injected failure right after the in-memory commit exercises the alter's late failure path.
+// The rename is committed at that point, so the failure must not roll it back. The reservation
+// guard was dismissed at commit and the old name was already erased, so the new name keeps
+// resolving, the old name is free, and the error reaches the client. A guard that outlived the
+// commit would erase the table's live name.
+TEST_P(AlterTableSysCatalogWriteTest, TestFailureAfterCommitKeepsRename) {
+  YBTableName new_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "renamed-then-failed");
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_fail_alter_table_after_commit) = true;
+  std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+  Status s = table_alterer->RenameTo(new_name)->Alter();
+  ASSERT_NOK(s);
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_fail_alter_table_after_commit) = false;
+
+  // The rename committed before the injected failure. Only the new name resolves.
+  ASSERT_TRUE(ASSERT_RESULT(TableNameResolves(new_name)));
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(kTableName)));
+
+  // The commit erased the old name rather than leaking it, so it is free for a fresh table.
+  ASSERT_OK(CreateTable(kTableName));
+
+  // The renamed table accepts further schema changes. This alter waits for the tablets to apply
+  // the schema, so the cluster is settled before teardown.
+  ASSERT_OK(AddNewI32Column(new_name, "added-after-injected-failure"));
 }
 
 // Test restarting a tablet server several times after various

--- a/src/yb/integration-tests/alter_table-test.cc
+++ b/src/yb/integration-tests/alter_table-test.cc
@@ -30,11 +30,14 @@
 // under the License.
 //
 
+#include <algorithm>
+#include <future>
 #include <map>
 #include <string>
 #include <utility>
 
 #include "yb/util/flags.h"
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "yb/client/client-test-util.h"
@@ -46,6 +49,7 @@
 #include "yb/client/table_alterer.h"
 #include "yb/client/table_creator.h"
 #include "yb/client/table_handle.h"
+#include "yb/client/table_info.h"
 #include "yb/client/yb_op.h"
 
 #include "yb/common/ql_value.h"
@@ -73,12 +77,15 @@
 
 #include "yb/util/atomic.h"
 #include "yb/util/faststring.h"
+#include "yb/util/logging_test_util.h"
 #include "yb/util/metrics.h"
 #include "yb/util/random.h"
 #include "yb/util/random_util.h"
+#include "yb/util/scope_exit.h"
 #include "yb/util/status_log.h"
 #include "yb/util/test_util.h"
 #include "yb/util/thread.h"
+#include "yb/util/tsan_util.h"
 
 using namespace std::literals;
 
@@ -92,6 +99,8 @@ DECLARE_int32(ht_lease_duration_ms);
 DECLARE_int32(replication_factor);
 DECLARE_int32(log_min_seconds_to_retain);
 DECLARE_int32(catalog_manager_report_batch_size);
+DECLARE_string(TEST_block_alter_table);
+DECLARE_bool(TEST_fail_alter_table_sys_catalog_write);
 
 METRIC_DECLARE_counter(sys_catalog_peer_write_count);
 
@@ -113,6 +122,10 @@ using std::vector;
 using std::string;
 using std::max;
 using tablet::TabletPeer;
+
+MATCHER_P(EqualsCode, expected_status, "") {
+  return arg.code() == expected_status.code();
+}
 
 class AlterTableTest : public YBMiniClusterTestBase<MiniCluster>,
                        public ::testing::WithParamInterface<int> {
@@ -273,6 +286,28 @@ class AlterTableTest : public YBMiniClusterTestBase<MiniCluster>,
     return GetSysCatalogMetric(METRIC_sys_catalog_peer_write_count);
   }
 
+  Result<bool> TableHasColumn(const YBTableName& table_name, const string& column_name) {
+    YBSchema schema;
+    dockv::PartitionSchema partition_schema;
+    RETURN_NOT_OK(client_->GetTableSchema(table_name, &schema, &partition_schema));
+    return std::ranges::any_of(schema.columns(), [&](const auto& column) {
+      return column.name() == column_name;
+    });
+  }
+
+  Result<bool> TableNameResolves(const YBTableName& table_name) {
+    YBSchema schema;
+    dockv::PartitionSchema partition_schema;
+    Status s = client_->GetTableSchema(table_name, &schema, &partition_schema);
+    if (s.ok()) {
+      return true;
+    }
+    if (s.IsNotFound()) {
+      return false;
+    }
+    return s;
+  }
+
  protected:
   virtual int num_replicas() const { return 1; }
 
@@ -298,10 +333,17 @@ class ReplicatedAlterTableTest : public AlterTableTest {
   virtual int num_replicas() const override { return 3; }
 };
 
+// Subclass for the tests that target the sys-catalog write step of an alter. The tablet-report
+// batch size that parameterizes AlterTableTest does not affect these tests, so they run at a
+// single value.
+class AlterTableSysCatalogWriteTest : public AlterTableTest {};
+
 const YBTableName AlterTableTest::kTableName(YQL_DATABASE_CQL, "my_keyspace", "fake-table");
 
 INSTANTIATE_TEST_CASE_P(BatchSize, AlterTableTest, ::testing::Values(1, 10));
 INSTANTIATE_TEST_CASE_P(BatchSize, ReplicatedAlterTableTest, ::testing::Values(1, 10));
+INSTANTIATE_TEST_CASE_P(
+    SingleBatchSize, AlterTableSysCatalogWriteTest, ::testing::Values(1));
 
 // Simple test to verify that the "alter table" command sent and executed
 // on the TS handling the tablet of the altered table.
@@ -613,7 +655,212 @@ TEST_P(AlterTableTest, TestRenameTableAndAdd) {
   ASSERT_OK(table_alterer->RenameTo(new_name)
             ->Alter());
 
+  // After a successful rename the old name must not resolve. The commit erased it.
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(kTableName)));
+
   ASSERT_OK(AddNewI32Column(new_name, "new"));
+}
+
+// An ALTER TABLE whose sys-catalog write fails must surface an error instead of wedging the
+// master. If AlterTable held CatalogManager::mutex_ across the write, the failure-path rollback
+// would re-acquire that same non-recursive mutex and self-deadlock, so the write must run with
+// mutex_ released.
+//
+// This is the rename variant. The new name is reserved under mutex_ before the write. After the
+// injected failure the reservation must be rolled back, and the old name must still resolve
+// because only a commit erases it.
+TEST_P(AlterTableSysCatalogWriteTest, TestRenameSysCatalogWriteFailureDoesNotDeadlock) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_fail_alter_table_sys_catalog_write) = true;
+
+  YBTableName new_name(kTableName.namespace_type(), kTableName.namespace_name(), "renamed-table");
+  std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+  Status s = table_alterer->RenameTo(new_name)->timeout(MonoDelta::FromSeconds(30))->Alter();
+  // The injected write failure must surface as an error instead of hanging.
+  ASSERT_NOK(s);
+
+  // Confirm mutex_ is not wedged. A subsequent alter acquires the same mutex and must complete.
+  // The old name must still resolve because a failure never erases it, and the reserved new name
+  // must be rolled back.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_fail_alter_table_sys_catalog_write) = false;
+  ASSERT_OK(AddNewI32Column(kTableName, "added-after-rename-failure"));
+
+  ASSERT_TRUE(ASSERT_RESULT(TableNameResolves(kTableName)));
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(new_name)));
+}
+
+// The non-rename variant of the sys-catalog write-failure test above. A column add reserves no
+// name, so its failure path must not touch the by-name map. A rollback that erases a name anyway
+// hits the table's live entry and drops its mapping. The test verifies that the table stays
+// reachable by its original name after an injected write failure.
+TEST_P(AlterTableSysCatalogWriteTest, TestAddColumnSysCatalogWriteFailureKeepsNameMapping) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_fail_alter_table_sys_catalog_write) = true;
+
+  Status s = AddNewI32Column(kTableName, "doomed-column", MonoDelta::FromSeconds(30));
+  ASSERT_NOK(s);
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_fail_alter_table_sys_catalog_write) = false;
+
+  // The live mapping must be intact. A name lookup and a subsequent alter both succeed.
+  ASSERT_TRUE(ASSERT_RESULT(TableNameResolves(kTableName)));
+  ASSERT_OK(AddNewI32Column(kTableName, "added-after-add-failure"));
+}
+
+// The three tests below open the window that the sys-catalog write for an alter runs in.
+// FLAGS_TEST_block_alter_table = "sys_catalog_write" parks the alter after it has released
+// CatalogManager::mutex_ and before it starts the write, holding the table's COW write lock.
+// That is the exact state a concurrent RPC observes while a real write is in flight. Each test
+// drives client operations through the open window and asserts what they see.
+
+// Catalog operations must not block while an alter's sys-catalog write is in flight, because
+// mutex_ is released across the write. While the alter is parked, a schema read of the altering
+// table returns its committed schema without the new column, a listing shows the table once, and
+// a CREATE of an unrelated table completes. Each of these operations acquires mutex_, so if an
+// alter ever again held mutex_ across the write, they would block behind the parked alter and
+// this test would time out.
+TEST_P(AlterTableSysCatalogWriteTest, TestCatalogOpsProceedWhileAlterWritesSysCatalog) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "sys_catalog_write";
+  StringWaiterLogSink parked_sink("Blocking AlterTableWithBatchTracker");
+
+  auto alter_future = std::async(std::launch::async, [&] {
+    return AddNewI32Column(kTableName, "column-added-during-park");
+  });
+  auto release_alter = ScopeExit([] {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  });
+  ASSERT_OK(parked_sink.WaitFor(30s * kTimeMultiplier));
+
+  ASSERT_FALSE(ASSERT_RESULT(TableHasColumn(kTableName, "column-added-during-park")));
+
+  auto tables = ASSERT_RESULT(client_->ListTables());
+  ASSERT_EQ(1, std::ranges::count_if(tables, [](const YBTableName& name) {
+    return name.table_name() == kTableName.table_name();
+  }));
+
+  YBTableName other_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "created-during-park");
+  ASSERT_OK(CreateTable(other_name));
+
+  // The alter is still parked, so the operations above overlapped its write window instead of
+  // running after it completed.
+  ASSERT_EQ(alter_future.wait_for(0s), std::future_status::timeout);
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  ASSERT_OK(alter_future.get());
+  ASSERT_TRUE(ASSERT_RESULT(TableHasColumn(kTableName, "column-added-during-park")));
+}
+
+// A YCQL rename reserves the new name in the by-name map before mutex_ is released and erases
+// the old name only after the in-memory commit. While the rename is parked before its write,
+// both names resolve to the same table, a CREATE targeting either name is rejected with
+// AlreadyPresent, and a listing shows the table exactly once, under its committed old name.
+// After the rename commits, the old name is free and a CREATE reusing it succeeds.
+TEST_P(AlterTableSysCatalogWriteTest, TestRenameWindowBothNamesResolve) {
+  YBTableName new_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "renamed-during-park");
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "sys_catalog_write";
+  StringWaiterLogSink parked_sink("Blocking AlterTableWithBatchTracker");
+
+  auto rename_future = std::async(std::launch::async, [&] {
+    std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+    return table_alterer->RenameTo(new_name)->Alter();
+  });
+  auto release_alter = ScopeExit([] {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  });
+  ASSERT_OK(parked_sink.WaitFor(30s * kTimeMultiplier));
+
+  // The reservation that blocks CREATE collisions is an ordinary by-name map entry, and name
+  // lookups read through it, so the new name resolves before the rename commits. If the rename
+  // fails, the rollback removes the reservation and the new name stops resolving.
+  auto info_by_old_name = ASSERT_RESULT(client_->GetYBTableInfo(kTableName));
+  auto info_by_new_name = ASSERT_RESULT(client_->GetYBTableInfo(new_name));
+  ASSERT_EQ(info_by_old_name.table_id, info_by_new_name.table_id);
+
+  // A lookup through the reservation returns committed table state. The returned identifier
+  // carries the committed old name, not the uncommitted new one.
+  ASSERT_EQ(kTableName.table_name(), info_by_new_name.table_name.table_name());
+
+  // The listing iterates the by-id map and reports committed names, so the renaming table shows
+  // up exactly once, under the old name.
+  auto tables = ASSERT_RESULT(client_->ListTables());
+  ASSERT_EQ(1, std::ranges::count_if(tables, [](const YBTableName& name) {
+    return name.table_name() == kTableName.table_name();
+  }));
+  ASSERT_EQ(0, std::ranges::count_if(tables, [&](const YBTableName& name) {
+    return name.table_name() == new_name.table_name();
+  }));
+
+  ASSERT_THAT(CreateTable(new_name), EqualsCode(STATUS(AlreadyPresent, "")));
+  ASSERT_THAT(CreateTable(kTableName), EqualsCode(STATUS(AlreadyPresent, "")));
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  ASSERT_OK(rename_future.get());
+
+  // The commit erased the old name and the table stays reachable under the new one, so the old
+  // name is free for a fresh table.
+  ASSERT_TRUE(ASSERT_RESULT(TableNameResolves(new_name)));
+  ASSERT_OK(CreateTable(kTableName));
+}
+
+// A DROP that arrives through the old name while the rename is parked resolves the table and
+// then waits on its COW write lock. The drop must not complete while the rename holds that
+// lock, and once the rename commits the drop deletes the renamed table, so afterwards neither
+// name resolves. The rename's post-commit erase removes the old name and the drop removes the
+// new name, so this interleaving leaves nothing behind in the by-name map.
+//
+// TODO: The delete path resolves the name before it takes any lock and never
+// revalidates it, so the drop deletes the renamed table through its stale old name. A fix that
+// revalidates the name once the delete holds the table lock would reject the stale old name,
+// and the assertions below should flip with it.
+TEST_P(AlterTableSysCatalogWriteTest, TestDropByOldNameWaitsForRenameCommit) {
+  YBTableName new_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "renamed-before-drop");
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "sys_catalog_write";
+  StringWaiterLogSink parked_sink("Blocking AlterTableWithBatchTracker");
+  StringWaiterLogSink drop_started_sink("Servicing DeleteTable request");
+
+  auto rename_future = std::async(std::launch::async, [&] {
+    std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+    // The drop deletes the table as soon as the rename commits, so waiting for the new schema to
+    // reach the tablets cannot succeed. Return once the master has committed the rename.
+    return table_alterer->RenameTo(new_name)->wait(false)->Alter();
+  });
+  std::future<Status> drop_future;  // Assigned once the rename is parked.
+  auto release_alter = ScopeExit([] {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  });
+  ASSERT_OK(parked_sink.WaitFor(30s * kTimeMultiplier));
+
+  drop_future = std::async(std::launch::async, [&] {
+    return client_->DeleteTable(kTableName);
+  });
+
+  // Once the master logs the drop it resolves the old name within the same handler, with mutex_
+  // free, and then waits on the COW write lock that the parked rename holds. Give it a moment to
+  // prove it stays blocked.
+  ASSERT_OK(drop_started_sink.WaitFor(30s * kTimeMultiplier));
+  ASSERT_EQ(drop_future.wait_for(1s * kTimeMultiplier), std::future_status::timeout);
+
+  // The drop waits on the COW write lock without holding mutex_. An unrelated CREATE acquires
+  // mutex_ and completes while the drop stays blocked.
+  YBTableName probe_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "created-during-blocked-drop");
+  ASSERT_OK(CreateTable(probe_name));
+  ASSERT_EQ(drop_future.wait_for(0s), std::future_status::timeout);
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  ASSERT_OK(rename_future.get());
+  ASSERT_OK(drop_future.get());
+
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(kTableName)));
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(new_name)));
+
+  // A leftover entry in the by-name map would fail a CREATE with AlreadyPresent. Both creates
+  // succeeding proves the rename erased the old name and the drop erased the new one.
+  ASSERT_OK(CreateTable(kTableName));
+  ASSERT_OK(CreateTable(new_name));
 }
 
 // Test restarting a tablet server several times after various

--- a/src/yb/integration-tests/alter_table-test.cc
+++ b/src/yb/integration-tests/alter_table-test.cc
@@ -30,11 +30,14 @@
 // under the License.
 //
 
+#include <algorithm>
+#include <atomic>
 #include <map>
 #include <string>
 #include <utility>
 
 #include "yb/util/flags.h"
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "yb/client/client-test-util.h"
@@ -46,6 +49,7 @@
 #include "yb/client/table_alterer.h"
 #include "yb/client/table_creator.h"
 #include "yb/client/table_handle.h"
+#include "yb/client/table_info.h"
 #include "yb/client/yb_op.h"
 
 #include "yb/common/ql_value.h"
@@ -73,12 +77,16 @@
 
 #include "yb/util/atomic.h"
 #include "yb/util/faststring.h"
+#include "yb/util/logging_test_util.h"
 #include "yb/util/metrics.h"
 #include "yb/util/random.h"
 #include "yb/util/random_util.h"
+#include "yb/util/scope_exit.h"
 #include "yb/util/status_log.h"
+#include "yb/util/test_thread_holder.h"
 #include "yb/util/test_util.h"
 #include "yb/util/thread.h"
+#include "yb/util/tsan_util.h"
 
 using namespace std::literals;
 
@@ -92,6 +100,8 @@ DECLARE_int32(ht_lease_duration_ms);
 DECLARE_int32(replication_factor);
 DECLARE_int32(log_min_seconds_to_retain);
 DECLARE_int32(catalog_manager_report_batch_size);
+DECLARE_string(TEST_block_alter_table);
+DECLARE_bool(TEST_fail_alter_table_sys_catalog_write);
 
 METRIC_DECLARE_counter(sys_catalog_peer_write_count);
 
@@ -113,6 +123,10 @@ using std::vector;
 using std::string;
 using std::max;
 using tablet::TabletPeer;
+
+MATCHER_P(EqualsCode, expected_status, "") {
+  return arg.code() == expected_status.code();
+}
 
 class AlterTableTest : public YBMiniClusterTestBase<MiniCluster>,
                        public ::testing::WithParamInterface<int> {
@@ -273,6 +287,28 @@ class AlterTableTest : public YBMiniClusterTestBase<MiniCluster>,
     return GetSysCatalogMetric(METRIC_sys_catalog_peer_write_count);
   }
 
+  Result<bool> TableHasColumn(const YBTableName& table_name, const string& column_name) {
+    YBSchema schema;
+    dockv::PartitionSchema partition_schema;
+    RETURN_NOT_OK(client_->GetTableSchema(table_name, &schema, &partition_schema));
+    return std::ranges::any_of(schema.columns(), [&](const auto& column) {
+      return column.name() == column_name;
+    });
+  }
+
+  Result<bool> TableNameResolves(const YBTableName& table_name) {
+    YBSchema schema;
+    dockv::PartitionSchema partition_schema;
+    Status s = client_->GetTableSchema(table_name, &schema, &partition_schema);
+    if (s.ok()) {
+      return true;
+    }
+    if (s.IsNotFound()) {
+      return false;
+    }
+    return s;
+  }
+
  protected:
   virtual int num_replicas() const { return 1; }
 
@@ -298,10 +334,17 @@ class ReplicatedAlterTableTest : public AlterTableTest {
   virtual int num_replicas() const override { return 3; }
 };
 
+// Subclass for the tests that target the sys-catalog write step of an alter. The tablet-report
+// batch size that parameterizes AlterTableTest does not affect these tests, so they run at a
+// single value.
+class AlterTableSysCatalogWriteTest : public AlterTableTest {};
+
 const YBTableName AlterTableTest::kTableName(YQL_DATABASE_CQL, "my_keyspace", "fake-table");
 
 INSTANTIATE_TEST_CASE_P(BatchSize, AlterTableTest, ::testing::Values(1, 10));
 INSTANTIATE_TEST_CASE_P(BatchSize, ReplicatedAlterTableTest, ::testing::Values(1, 10));
+INSTANTIATE_TEST_CASE_P(
+    SingleBatchSize, AlterTableSysCatalogWriteTest, ::testing::Values(1));
 
 // Simple test to verify that the "alter table" command sent and executed
 // on the TS handling the tablet of the altered table.
@@ -613,7 +656,232 @@ TEST_P(AlterTableTest, TestRenameTableAndAdd) {
   ASSERT_OK(table_alterer->RenameTo(new_name)
             ->Alter());
 
+  // After a successful rename the old name must not resolve. The commit erased it.
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(kTableName)));
+
   ASSERT_OK(AddNewI32Column(new_name, "new"));
+}
+
+// An ALTER TABLE whose sys-catalog write fails must surface an error instead of wedging the
+// master. If AlterTable held CatalogManager::mutex_ across the write, the failure-path rollback
+// would re-acquire that same non-recursive mutex and self-deadlock, so the write must run with
+// mutex_ released.
+//
+// This is the rename variant. The new name is reserved under mutex_ before the write. After the
+// injected failure the reservation must be rolled back, and the old name must still resolve
+// because only a commit erases it.
+TEST_P(AlterTableSysCatalogWriteTest, TestRenameSysCatalogWriteFailureDoesNotDeadlock) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_fail_alter_table_sys_catalog_write) = true;
+
+  YBTableName new_name(kTableName.namespace_type(), kTableName.namespace_name(), "renamed-table");
+  std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+  Status s = table_alterer->RenameTo(new_name)->timeout(MonoDelta::FromSeconds(30))->Alter();
+  // The injected write failure must surface as an error instead of hanging.
+  ASSERT_NOK(s);
+
+  // Confirm mutex_ is not wedged. A subsequent alter acquires the same mutex and must complete.
+  // The old name must still resolve because a failure never erases it, and the reserved new name
+  // must be rolled back.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_fail_alter_table_sys_catalog_write) = false;
+  ASSERT_OK(AddNewI32Column(kTableName, "added-after-rename-failure"));
+
+  ASSERT_TRUE(ASSERT_RESULT(TableNameResolves(kTableName)));
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(new_name)));
+}
+
+// The non-rename variant of the sys-catalog write-failure test above. A column add reserves no
+// name, so its failure path must not touch the by-name map. A rollback that erases a name anyway
+// hits the table's live entry and drops its mapping. The test verifies that the table stays
+// reachable by its original name after an injected write failure.
+TEST_P(AlterTableSysCatalogWriteTest, TestAddColumnSysCatalogWriteFailureKeepsNameMapping) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_fail_alter_table_sys_catalog_write) = true;
+
+  Status s = AddNewI32Column(kTableName, "doomed-column", MonoDelta::FromSeconds(30));
+  ASSERT_NOK(s);
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_fail_alter_table_sys_catalog_write) = false;
+
+  // The live mapping must be intact. A name lookup and a subsequent alter both succeed.
+  ASSERT_TRUE(ASSERT_RESULT(TableNameResolves(kTableName)));
+  ASSERT_OK(AddNewI32Column(kTableName, "added-after-add-failure"));
+}
+
+// The three tests below open the window that the sys-catalog write for an alter runs in.
+// FLAGS_TEST_block_alter_table = "sys_catalog_write" parks the alter after it has released
+// CatalogManager::mutex_ and before it starts the write, holding the table's COW write lock.
+// That is the exact state a concurrent RPC observes while a real write is in flight. Each test
+// drives client operations through the open window and asserts what they see.
+
+// Catalog operations must not block while an alter's sys-catalog write is in flight, because
+// mutex_ is released across the write. While the alter is parked, a schema read of the altering
+// table returns its committed schema without the new column, a listing shows the table once, and
+// a CREATE of an unrelated table completes. Each of these operations acquires mutex_, so if an
+// alter ever again held mutex_ across the write, they would block behind the parked alter and
+// this test would time out.
+TEST_P(AlterTableSysCatalogWriteTest, TestCatalogOpsProceedWhileAlterWritesSysCatalog) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "sys_catalog_write";
+  StringWaiterLogSink parked_sink("Blocking AlterTableWithBatchTracker");
+
+  // Declared before the holder. Its destructor joins the thread, which writes these values, so
+  // the values must outlive the holder on every return path.
+  Status alter_status;
+  std::atomic<bool> alter_done{false};
+  TestThreadHolder threads;
+  auto release_alter = ScopeExit([] {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  });
+  threads.AddThreadFunctor([&] {
+    alter_status = AddNewI32Column(kTableName, "column-added-during-park");
+    alter_done = true;
+  });
+  ASSERT_OK(parked_sink.WaitFor(30s * kTimeMultiplier));
+
+  ASSERT_FALSE(ASSERT_RESULT(TableHasColumn(kTableName, "column-added-during-park")));
+
+  auto tables = ASSERT_RESULT(client_->ListTables());
+  ASSERT_EQ(1, std::ranges::count_if(tables, [](const YBTableName& name) {
+    return name.table_name() == kTableName.table_name();
+  }));
+
+  YBTableName other_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "created-during-park");
+  ASSERT_OK(CreateTable(other_name));
+
+  // The alter is still parked, so the operations above overlapped its write window instead of
+  // running after it completed.
+  ASSERT_FALSE(alter_done.load());
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  threads.JoinAll();
+  ASSERT_OK(alter_status);
+  ASSERT_TRUE(ASSERT_RESULT(TableHasColumn(kTableName, "column-added-during-park")));
+}
+
+// A YCQL rename reserves the new name in the by-name map before mutex_ is released and erases
+// the old name only after the in-memory commit. While the rename is parked before its write,
+// both names resolve to the same table, a CREATE targeting either name is rejected with
+// AlreadyPresent, and a listing shows the table exactly once, under its committed old name.
+// After the rename commits, the old name is free and a CREATE reusing it succeeds.
+TEST_P(AlterTableSysCatalogWriteTest, TestRenameWindowBothNamesResolve) {
+  YBTableName new_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "renamed-during-park");
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "sys_catalog_write";
+  StringWaiterLogSink parked_sink("Blocking AlterTableWithBatchTracker");
+
+  // Declared before the holder. Its destructor joins the thread, which writes this status, so
+  // the status must outlive the holder on every return path.
+  Status rename_status;
+  TestThreadHolder threads;
+  auto release_alter = ScopeExit([] {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  });
+  threads.AddThreadFunctor([&] {
+    std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+    rename_status = table_alterer->RenameTo(new_name)->Alter();
+  });
+  ASSERT_OK(parked_sink.WaitFor(30s * kTimeMultiplier));
+
+  // The reservation that blocks CREATE collisions is an ordinary by-name map entry, and name
+  // lookups read through it, so the new name resolves before the rename commits. If the rename
+  // fails, the rollback removes the reservation and the new name stops resolving.
+  auto info_by_old_name = ASSERT_RESULT(client_->GetYBTableInfo(kTableName));
+  auto info_by_new_name = ASSERT_RESULT(client_->GetYBTableInfo(new_name));
+  ASSERT_EQ(info_by_old_name.table_id, info_by_new_name.table_id);
+
+  // A lookup through the reservation returns committed table state. The returned identifier
+  // carries the committed old name, not the uncommitted new one.
+  ASSERT_EQ(kTableName.table_name(), info_by_new_name.table_name.table_name());
+
+  // The listing iterates the by-id map and reports committed names, so the renaming table shows
+  // up exactly once, under the old name.
+  auto tables = ASSERT_RESULT(client_->ListTables());
+  ASSERT_EQ(1, std::ranges::count_if(tables, [](const YBTableName& name) {
+    return name.table_name() == kTableName.table_name();
+  }));
+  ASSERT_EQ(0, std::ranges::count_if(tables, [&](const YBTableName& name) {
+    return name.table_name() == new_name.table_name();
+  }));
+
+  ASSERT_THAT(CreateTable(new_name), EqualsCode(STATUS(AlreadyPresent, "")));
+  ASSERT_THAT(CreateTable(kTableName), EqualsCode(STATUS(AlreadyPresent, "")));
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  threads.JoinAll();
+  ASSERT_OK(rename_status);
+
+  // The commit erased the old name and the table stays reachable under the new one, so the old
+  // name is free for a fresh table.
+  ASSERT_TRUE(ASSERT_RESULT(TableNameResolves(new_name)));
+  ASSERT_OK(CreateTable(kTableName));
+}
+
+// A DROP that arrives through the old name while the rename is parked resolves the table and
+// then waits on its COW write lock. The drop must not complete while the rename holds that
+// lock, and once the rename commits the drop deletes the renamed table, so afterwards neither
+// name resolves. The rename's post-commit erase removes the old name and the drop removes the
+// new name, so this interleaving leaves nothing behind in the by-name map.
+//
+// TODO: The delete path resolves the name before it takes any lock and never
+// revalidates it, so the drop deletes the renamed table through its stale old name. A fix that
+// revalidates the name once the delete holds the table lock would reject the stale old name,
+// and the assertions below should flip with it.
+TEST_P(AlterTableSysCatalogWriteTest, TestDropByOldNameWaitsForRenameCommit) {
+  YBTableName new_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "renamed-before-drop");
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "sys_catalog_write";
+  StringWaiterLogSink parked_sink("Blocking AlterTableWithBatchTracker");
+  StringWaiterLogSink drop_started_sink("Servicing DeleteTable request");
+
+  // Declared before the holder. Its destructor joins the threads, which write these values, so
+  // the values must outlive the holder on every return path.
+  Status rename_status;
+  Status drop_status;
+  std::atomic<bool> drop_done{false};
+  TestThreadHolder threads;
+  auto release_alter = ScopeExit([] {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  });
+  threads.AddThreadFunctor([&] {
+    std::unique_ptr<YBTableAlterer> table_alterer(client_->NewTableAlterer(kTableName));
+    // The drop deletes the table as soon as the rename commits, so waiting for the new schema to
+    // reach the tablets cannot succeed. Return once the master has committed the rename.
+    rename_status = table_alterer->RenameTo(new_name)->wait(false)->Alter();
+  });
+  ASSERT_OK(parked_sink.WaitFor(30s * kTimeMultiplier));
+
+  threads.AddThreadFunctor([&] {
+    drop_status = client_->DeleteTable(kTableName);
+    drop_done = true;
+  });
+
+  // Once the master logs the drop it resolves the old name within the same handler, with mutex_
+  // free, and then waits on the COW write lock that the parked rename holds. Give it a moment to
+  // prove it stays blocked.
+  ASSERT_OK(drop_started_sink.WaitFor(30s * kTimeMultiplier));
+  SleepFor(1s * kTimeMultiplier);
+  ASSERT_FALSE(drop_done.load());
+
+  // The drop waits on the COW write lock without holding mutex_. An unrelated CREATE acquires
+  // mutex_ and completes while the drop stays blocked.
+  YBTableName probe_name(
+      kTableName.namespace_type(), kTableName.namespace_name(), "created-during-blocked-drop");
+  ASSERT_OK(CreateTable(probe_name));
+  ASSERT_FALSE(drop_done.load());
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_block_alter_table) = "";
+  threads.JoinAll();
+  ASSERT_OK(rename_status);
+  ASSERT_OK(drop_status);
+
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(kTableName)));
+  ASSERT_FALSE(ASSERT_RESULT(TableNameResolves(new_name)));
+
+  // A leftover entry in the by-name map would fail a CREATE with AlreadyPresent. Both creates
+  // succeeding proves the rename erased the old name and the drop erased the new one.
+  ASSERT_OK(CreateTable(kTableName));
+  ASSERT_OK(CreateTable(new_name));
 }
 
 // Test restarting a tablet server several times after various

--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -313,6 +313,10 @@ DEFINE_test_flag(bool, fail_alter_table_after_commit, false,
     "If true, return an error after in-memory commit of the ALTER TABLE operation."
     "Used to force ALTER to fail at a deterministic spot.");
 
+DEFINE_test_flag(bool, fail_alter_table_sys_catalog_write, false,
+    "If true, force the sys-catalog Upsert in UpdateSysCatalogWithNewSchema to fail. Exercises the "
+    "ALTER TABLE IO-failure rollback path.");
+
 DEFINE_test_flag(bool, pause_before_send_hinted_election, false,
     "Inside StartElectionIfReady, pause before sending request for hinted election");
 
@@ -587,7 +591,8 @@ DEFINE_NON_RUNTIME_bool(enable_heartbeat_pg_catalog_versions_cache, true,
 
 DEFINE_test_flag(string, block_alter_table, "",
     "If non-empty, the specified alter table step is blocked. Possible values are "
-    "\"alter_schema\" (blocks the schema from being altered) and \"completion\","
+    "\"alter_schema\" (blocks the schema from being altered), \"sys_catalog_write\" (blocks "
+    "after mutex_ is released and before the sys-catalog write starts), and \"completion\" "
     "(blocks the service completion of the alter table request)");
 
 DECLARE_bool(master_enable_universe_uuid_heartbeat_check);
@@ -8309,6 +8314,16 @@ Status CatalogManager::AlterTableWithBatchTracker(
     has_changes = true;
   }
 
+  // Release mutex_. The collision check and name reservation above are the last steps that need
+  // it. Everything below operates on the table's COW state or performs IO. The failure rollback
+  // and the deferred old-name erase below re-acquire mutex_ only after the COW lock is released,
+  // which preserves the lock order between mutex_ and the COW lock. While the sys-catalog write
+  // runs, a YCQL rename is visible to concurrent RPCs under both names. Anything that resolves
+  // the table still serializes on its COW lock and sees the outcome at commit or rollback.
+  // CreateTable already has the same uncommitted-name window. A follow-up is to revalidate the
+  // resolved name against the committed pb at the delete and lookup choke points.
+  lock.unlock();
+
   // Check if there has been any changes to the placement policies for this table.
   if (req->has_replication_info()) {
     if (table->GetTableType() == PGSQL_TABLE_TYPE) {
@@ -8377,13 +8392,6 @@ Status CatalogManager::AlterTableWithBatchTracker(
         Substitute("Alter table version=$0 ts=$1", table_pb.version(), LocalTimeAsString()));
   }
 
-  // Remove the old name. Not present if PGSQL.
-  if (table->GetTableType() != PGSQL_TABLE_TYPE && req->has_new_table_name()) {
-    TRACE("Removing (namespace, table) combination ($0, $1) from by-name map",
-          namespace_id, table_name);
-    table_names_map_.erase({namespace_id, table_name});
-  }
-
   // Update a task to rollback alter if the corresponding YSQL transaction
   // rolls back.
   TransactionMetadata txn;
@@ -8434,14 +8442,46 @@ Status CatalogManager::AlterTableWithBatchTracker(
     }
   }
 
-  RETURN_NOT_OK(UpdateSysCatalogWithNewSchema(
-      table, ddl_log_entries, namespace_id, new_table_name, epoch, resp));
+  while (FLAGS_TEST_block_alter_table == "sys_catalog_write") {
+    constexpr auto kSleepFor = 100ms;
+    LOG(INFO) << Format("Blocking $0 for $1ms", __func__, kSleepFor);
+    SleepFor(kSleepFor);
+  }
+
+  Status update_status = UpdateSysCatalogWithNewSchema(table, ddl_log_entries, epoch, resp);
+  if (!update_status.ok()) {
+    // The write failed. Discard the staged COW changes and drop the reserved new name. The old
+    // name was never erased, so the table stays reachable by it.
+    l.Unlock();
+    if (table->GetTableType() != PGSQL_TABLE_TYPE && req->has_new_table_name()) {
+      LockGuard map_lock(mutex_);
+      // Tolerate an entry that is already absent. Both mutex_ and the COW lock were released
+      // above, so a concurrent mutation could have removed it.
+      if (table_names_map_.erase({namespace_id, new_table_name}) != 1) {
+        LOG(WARNING) << "ALTER TABLE rollback: reserved new name " << namespace_id << "."
+                     << new_table_name << " was already absent from the by-name map";
+      }
+    }
+    return update_status;
+  }
+
   // Update the in-memory state.
   TRACE("Committing in-memory state");
   VLOG_WITH_FUNC(3) << "SysTablesEntryPB for " << table->id()
                     << " after the after table operation is: " << table_pb.DebugString();
   l.Commit();
-  lock.unlock();
+
+  // A committed rename erases its old name here rather than before the write, so that a failed
+  // write leaves the table reachable by the old name. Tolerate an entry that is already absent.
+  // Both mutex_ and the COW lock were released above, so a concurrent mutation could have
+  // removed it.
+  if (table->GetTableType() != PGSQL_TABLE_TYPE && req->has_new_table_name()) {
+    LockGuard map_lock(mutex_);
+    if (table_names_map_.erase({namespace_id, table_name}) != 1) {
+      LOG(WARNING) << "ALTER TABLE: old name " << namespace_id << "." << table_name
+                   << " was already absent from the by-name map when clearing it after a rename";
+    }
+  }
 
   TEST_SYNC_POINT("YBBackupTestWithColocationParam::AlterTableDocDBTableCommitted");
   TEST_SYNC_POINT("YBBackupTestWithColocationParam::ContinueAlterTable");
@@ -8480,8 +8520,6 @@ Status CatalogManager::AlterTableWithBatchTracker(
 Status CatalogManager::UpdateSysCatalogWithNewSchema(
     const scoped_refptr<TableInfo>& table,
     const std::vector<DdlLogEntry>& ddl_log_entries,
-    const string& new_namespace_id,
-    const string& new_table_name,
     const LeaderEpoch& epoch,
     AlterTableResponsePB* resp) {
   TRACE("Updating metadata on disk");
@@ -8490,18 +8528,17 @@ Status CatalogManager::UpdateSysCatalogWithNewSchema(
   for (const auto& entry : ddl_log_entries) {
     ddl_log_entry_pointers.push_back(&entry);
   }
-  Status s = sys_catalog_->Upsert(epoch, ddl_log_entry_pointers, table);
+  Status s;
+  if (PREDICT_FALSE(FLAGS_TEST_fail_alter_table_sys_catalog_write)) {
+    s = STATUS(IOError, "Injected sys-catalog write failure for ALTER TABLE");
+  } else {
+    s = sys_catalog_->Upsert(epoch, ddl_log_entry_pointers, table);
+  }
   if (!s.ok()) {
     s = s.CloneAndPrepend(
         Substitute("An error occurred while updating sys-catalog tables entry: $0",
                    s.ToString()));
     LOG(WARNING) << s.ToString();
-    if (table->GetTableType() != PGSQL_TABLE_TYPE &&
-        (!new_namespace_id.empty() || !new_table_name.empty())) {
-      LockGuard lock(mutex_);
-      VLOG_WITH_FUNC(3) << "Acquired the catalog manager lock";
-      CHECK_EQ(table_names_map_.erase({new_namespace_id, new_table_name}), 1);
-    }
     if (resp)
       return CheckIfNoLongerLeaderAndSetupError(s, resp);
 

--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -591,9 +591,11 @@ DEFINE_NON_RUNTIME_bool(enable_heartbeat_pg_catalog_versions_cache, true,
 
 DEFINE_test_flag(string, block_alter_table, "",
     "If non-empty, the specified alter table step is blocked. Possible values are "
-    "\"alter_schema\" (blocks the schema from being altered), \"sys_catalog_write\" (blocks "
-    "after mutex_ is released and before the sys-catalog write starts), and \"completion\" "
-    "(blocks the service completion of the alter table request)");
+    "\"alter_schema\" (blocks the schema from being altered), \"post_name_reservation\" (blocks "
+    "a rename after its new name is reserved and before the table's COW write lock is taken), "
+    "\"sys_catalog_write\" (blocks after the COW write lock is taken and before the sys-catalog "
+    "write starts), and \"completion\" (blocks the service completion of the alter table "
+    "request)");
 
 DECLARE_bool(master_enable_universe_uuid_heartbeat_check);
 
@@ -8213,7 +8215,7 @@ Status CatalogManager::AlterTableWithBatchTracker(
 
   while (FLAGS_TEST_block_alter_table == "alter_schema") {
     constexpr auto kSleepFor = 100ms;
-    LOG(INFO) << Format("Blocking $0 for $1ms", __func__, kSleepFor);
+    LOG(INFO) << Format("Blocking $0 at alter_schema for $1ms", __func__, kSleepFor);
     SleepFor(kSleepFor);
   }
 
@@ -8225,9 +8227,58 @@ Status CatalogManager::AlterTableWithBatchTracker(
         xcluster_manager_.get()->IsNamespaceInAutomaticDDLMode(table->namespace_id());
   }
 
-  // todo(GH29185): too much happens here under the cm mutex.
-  UniqueLock lock(mutex_);
-  VLOG_WITH_FUNC(3) << "Acquired the catalog manager lock";
+  // A rename acquires the new name in the by-name map here, before the table's COW write lock
+  // is taken, so mutex_ is never held together with that lock and never across IO. The entry
+  // points at this table, so a concurrent create or rename that targets the name fails against
+  // it, and lookups resolve through it. The table is visible under both names until the alter
+  // commits or rolls back. CreateTable has the same uncommitted-name window. A follow-up is to
+  // revalidate the resolved name against the committed pb at the delete and lookup choke points.
+  bool reserved_new_name = false;
+  // Postgres handles name uniqueness constraints in its own layer.
+  if (req->has_new_table_name() && table->GetTableType() != PGSQL_TABLE_TYPE) {
+    LockGuard map_lock(mutex_);
+    TRACE("Acquired catalog manager lock");
+    // Verify that the table does not exist.
+    scoped_refptr<TableInfo> other_table = FindPtrOrNull(
+        table_names_map_, {namespace_id, req->new_table_name()});
+    if (other_table != nullptr) {
+      Status s = STATUS_SUBSTITUTE(AlreadyPresent,
+          "Object '$0.$1' already exists",
+          GetNamespaceNameUnlocked(namespace_id), other_table->name());
+      LOG(WARNING) << "Found table: " << other_table->ToStringWithState()
+                   << ". Failed alterring table with error: "
+                   << s.ToString() << " Request:\n" << req->DebugString();
+      return SetupError(resp->mutable_error(), MasterErrorPB::OBJECT_ALREADY_PRESENT, s);
+    }
+
+    // Acquire the new table name (now we have 2 names for the same table).
+    table_names_map_[{namespace_id, req->new_table_name()}] = table;
+    reserved_new_name = true;
+  }
+
+  // Erase the reservation if the alter fails before its sys-catalog write commits the rename.
+  // The guard is declared before the COW write lock below is taken, so on any failure return it
+  // runs after that lock is released, which keeps mutex_ from being acquired while the COW lock
+  // is held.
+  auto name_reservation_guard = CancelableScopeExit(
+      [this, &namespace_id, req, reserved_new_name] {
+        if (!reserved_new_name) {
+          return;
+        }
+        LockGuard map_lock(mutex_);
+        // Tolerate an entry that is already absent. Neither mutex_ nor the COW lock is held for
+        // the whole span since the reservation, so a concurrent mutation could have removed it.
+        if (table_names_map_.erase({namespace_id, req->new_table_name()}) != 1) {
+          LOG(WARNING) << "ALTER TABLE rollback: reserved new name " << namespace_id << "."
+                       << req->new_table_name() << " was already absent from the by-name map";
+        }
+      });
+
+  while (FLAGS_TEST_block_alter_table == "post_name_reservation") {
+    constexpr auto kSleepFor = 100ms;
+    LOG(INFO) << Format("Blocking $0 at post_name_reservation for $1ms", __func__, kSleepFor);
+    SleepFor(kSleepFor);
+  }
 
   TRACE("Locking table");
   auto l = table->LockForWrite();
@@ -8288,41 +8339,10 @@ Status CatalogManager::AlterTableWithBatchTracker(
     has_changes = true;
   }
 
-  // Try to acquire the new table name.
   if (req->has_new_table_name()) {
-
-    // Postgres handles name uniqueness constraints in it's own layer.
-    if (l->table_type() != PGSQL_TABLE_TYPE) {
-      // Verify that the table does not exist.
-      scoped_refptr<TableInfo> other_table = FindPtrOrNull(
-          table_names_map_, {namespace_id, new_table_name});
-      if (other_table != nullptr) {
-        Status s = STATUS_SUBSTITUTE(AlreadyPresent,
-            "Object '$0.$1' already exists",
-            GetNamespaceNameUnlocked(namespace_id), other_table->name());
-        LOG(WARNING) << "Found table: " << other_table->ToStringWithState()
-                     << ". Failed alterring table with error: "
-                     << s.ToString() << " Request:\n" << req->DebugString();
-        return SetupError(resp->mutable_error(), MasterErrorPB::OBJECT_ALREADY_PRESENT, s);
-      }
-
-      // Acquire the new table name (now we have 2 name for the same table).
-      table_names_map_[{namespace_id, new_table_name}] = table;
-    }
-
     table_pb.set_name(new_table_name);
     has_changes = true;
   }
-
-  // Release mutex_. The collision check and name reservation above are the last steps that need
-  // it. Everything below operates on the table's COW state or performs IO. The failure rollback
-  // and the deferred old-name erase below re-acquire mutex_ only after the COW lock is released,
-  // which preserves the lock order between mutex_ and the COW lock. While the sys-catalog write
-  // runs, a YCQL rename is visible to concurrent RPCs under both names. Anything that resolves
-  // the table still serializes on its COW lock and sees the outcome at commit or rollback.
-  // CreateTable already has the same uncommitted-name window. A follow-up is to revalidate the
-  // resolved name against the committed pb at the delete and lookup choke points.
-  lock.unlock();
 
   // Check if there has been any changes to the placement policies for this table.
   if (req->has_replication_info()) {
@@ -8444,26 +8464,13 @@ Status CatalogManager::AlterTableWithBatchTracker(
 
   while (FLAGS_TEST_block_alter_table == "sys_catalog_write") {
     constexpr auto kSleepFor = 100ms;
-    LOG(INFO) << Format("Blocking $0 for $1ms", __func__, kSleepFor);
+    LOG(INFO) << Format("Blocking $0 at sys_catalog_write for $1ms", __func__, kSleepFor);
     SleepFor(kSleepFor);
   }
 
-  Status update_status = UpdateSysCatalogWithNewSchema(table, ddl_log_entries, epoch, resp);
-  if (!update_status.ok()) {
-    // The write failed. Discard the staged COW changes and drop the reserved new name. The old
-    // name was never erased, so the table stays reachable by it.
-    l.Unlock();
-    if (table->GetTableType() != PGSQL_TABLE_TYPE && req->has_new_table_name()) {
-      LockGuard map_lock(mutex_);
-      // Tolerate an entry that is already absent. Both mutex_ and the COW lock were released
-      // above, so a concurrent mutation could have removed it.
-      if (table_names_map_.erase({namespace_id, new_table_name}) != 1) {
-        LOG(WARNING) << "ALTER TABLE rollback: reserved new name " << namespace_id << "."
-                     << new_table_name << " was already absent from the by-name map";
-      }
-    }
-    return update_status;
-  }
+  // If the write fails, the WriteLock destructor will discard the staged COW changes and the
+  // CancelableScopeExit will remove the name reservation in table_names_map_ if necessary.
+  RETURN_NOT_OK(UpdateSysCatalogWithNewSchema(table, ddl_log_entries, epoch, resp));
 
   // Update the in-memory state.
   TRACE("Committing in-memory state");
@@ -8471,11 +8478,16 @@ Status CatalogManager::AlterTableWithBatchTracker(
                     << " after the after table operation is: " << table_pb.DebugString();
   l.Commit();
 
+  // The alter is committed. If a rename reserved a new name, that name is the table's live name
+  // now, so dismiss the guard that would erase it. The dismissal must stay directly after the
+  // commit. A failure return between the two would run the guard and erase the live name.
+  name_reservation_guard.Cancel();
+
   // A committed rename erases its old name here rather than before the write, so that a failed
   // write leaves the table reachable by the old name. Tolerate an entry that is already absent.
   // Both mutex_ and the COW lock were released above, so a concurrent mutation could have
   // removed it.
-  if (table->GetTableType() != PGSQL_TABLE_TYPE && req->has_new_table_name()) {
+  if (reserved_new_name) {
     LockGuard map_lock(mutex_);
     if (table_names_map_.erase({namespace_id, table_name}) != 1) {
       LOG(WARNING) << "ALTER TABLE: old name " << namespace_id << "." << table_name
@@ -8510,7 +8522,7 @@ Status CatalogManager::AlterTableWithBatchTracker(
 
   while (FLAGS_TEST_block_alter_table == "completion") {
     constexpr auto kSleepFor = 100ms;
-    LOG(INFO) << Format("Blocking $0 for $1ms", __func__, kSleepFor);
+    LOG(INFO) << Format("Blocking $0 at completion for $1ms", __func__, kSleepFor);
     SleepFor(kSleepFor);
   }
 

--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -591,9 +591,11 @@ DEFINE_NON_RUNTIME_bool(enable_heartbeat_pg_catalog_versions_cache, true,
 
 DEFINE_test_flag(string, block_alter_table, "",
     "If non-empty, the specified alter table step is blocked. Possible values are "
-    "\"alter_schema\" (blocks the schema from being altered), \"sys_catalog_write\" (blocks "
-    "after mutex_ is released and before the sys-catalog write starts), and \"completion\" "
-    "(blocks the service completion of the alter table request)");
+    "\"alter_schema\" (blocks the schema from being altered), \"post_name_reservation\" (blocks "
+    "a rename after its new name is reserved and before the table's COW write lock is taken), "
+    "\"sys_catalog_write\" (blocks after the COW write lock is taken and before the sys-catalog "
+    "write starts), and \"completion\" (blocks the service completion of the alter table "
+    "request)");
 
 DECLARE_bool(master_enable_universe_uuid_heartbeat_check);
 
@@ -8213,7 +8215,7 @@ Status CatalogManager::AlterTableWithBatchTracker(
 
   while (FLAGS_TEST_block_alter_table == "alter_schema") {
     constexpr auto kSleepFor = 100ms;
-    LOG(INFO) << Format("Blocking $0 for $1ms", __func__, kSleepFor);
+    LOG(INFO) << Format("Blocking $0 at alter_schema for $1ms", __func__, kSleepFor);
     SleepFor(kSleepFor);
   }
 
@@ -8225,9 +8227,58 @@ Status CatalogManager::AlterTableWithBatchTracker(
         xcluster_manager_.get()->IsNamespaceInAutomaticDDLMode(table->namespace_id());
   }
 
-  // todo(GH29185): too much happens here under the cm mutex.
-  UniqueLock lock(mutex_);
-  VLOG_WITH_FUNC(3) << "Acquired the catalog manager lock";
+  // A rename acquires the new name in the by-name map here, before the table's COW write lock
+  // is taken, so mutex_ is never held together with that lock and never across IO. The entry
+  // points at this table, so a concurrent create or rename that targets the name fails against
+  // it, and lookups resolve through it. The table is visible under both names until the alter
+  // commits or rolls back. CreateTable has the same uncommitted-name window. A follow-up is to
+  // revalidate the resolved name against the committed pb at the delete and lookup choke points.
+  bool reserved_new_name = false;
+  // Postgres handles name uniqueness constraints in its own layer.
+  if (req->has_new_table_name() && table->GetTableType() != PGSQL_TABLE_TYPE) {
+    LockGuard map_lock(mutex_);
+    TRACE("Acquired catalog manager lock");
+    // Verify that the table does not exist.
+    scoped_refptr<TableInfo> other_table = FindPtrOrNull(
+        table_names_map_, {namespace_id, req->new_table_name()});
+    if (other_table != nullptr) {
+      Status s = STATUS_SUBSTITUTE(AlreadyPresent,
+          "Object '$0.$1' already exists",
+          GetNamespaceNameUnlocked(namespace_id), other_table->name());
+      LOG(WARNING) << "Found table: " << other_table->ToStringWithState()
+                   << ". Failed alterring table with error: "
+                   << s.ToString() << " Request:\n" << req->DebugString();
+      return SetupError(resp->mutable_error(), MasterErrorPB::OBJECT_ALREADY_PRESENT, s);
+    }
+
+    // Acquire the new table name (now we have 2 names for the same table).
+    table_names_map_[{namespace_id, req->new_table_name()}] = table;
+    reserved_new_name = true;
+  }
+
+  // Erase the reservation if the alter fails before its sys-catalog write commits the rename.
+  // The guard is declared before the COW write lock below is taken, so on any failure return it
+  // runs after that lock is released, which keeps mutex_ from being acquired while the COW lock
+  // is held.
+  auto name_reservation_guard = CancelableScopeExit(
+      [this, &namespace_id, req, reserved_new_name] {
+        if (!reserved_new_name) {
+          return;
+        }
+        LockGuard map_lock(mutex_);
+        // Tolerate an entry that is already absent. Neither mutex_ nor the COW lock is held for
+        // the whole span since the reservation, so a concurrent mutation could have removed it.
+        if (table_names_map_.erase({namespace_id, req->new_table_name()}) != 1) {
+          LOG(WARNING) << "ALTER TABLE rollback: reserved new name " << namespace_id << "."
+                       << req->new_table_name() << " was already absent from the by-name map";
+        }
+      });
+
+  while (FLAGS_TEST_block_alter_table == "post_name_reservation") {
+    constexpr auto kSleepFor = 100ms;
+    LOG(INFO) << Format("Blocking $0 at post_name_reservation for $1ms", __func__, kSleepFor);
+    SleepFor(kSleepFor);
+  }
 
   TRACE("Locking table");
   auto l = table->LockForWrite();
@@ -8288,41 +8339,12 @@ Status CatalogManager::AlterTableWithBatchTracker(
     has_changes = true;
   }
 
-  // Try to acquire the new table name.
   if (req->has_new_table_name()) {
-
-    // Postgres handles name uniqueness constraints in it's own layer.
-    if (l->table_type() != PGSQL_TABLE_TYPE) {
-      // Verify that the table does not exist.
-      scoped_refptr<TableInfo> other_table = FindPtrOrNull(
-          table_names_map_, {namespace_id, new_table_name});
-      if (other_table != nullptr) {
-        Status s = STATUS_SUBSTITUTE(AlreadyPresent,
-            "Object '$0.$1' already exists",
-            GetNamespaceNameUnlocked(namespace_id), other_table->name());
-        LOG(WARNING) << "Found table: " << other_table->ToStringWithState()
-                     << ". Failed alterring table with error: "
-                     << s.ToString() << " Request:\n" << req->DebugString();
-        return SetupError(resp->mutable_error(), MasterErrorPB::OBJECT_ALREADY_PRESENT, s);
-      }
-
-      // Acquire the new table name (now we have 2 name for the same table).
-      table_names_map_[{namespace_id, new_table_name}] = table;
-    }
-
+    // The new name was checked for collisions and reserved in the by-name map before the COW
+    // write lock was taken. Stage the rename.
     table_pb.set_name(new_table_name);
     has_changes = true;
   }
-
-  // Release mutex_. The collision check and name reservation above are the last steps that need
-  // it. Everything below operates on the table's COW state or performs IO. The failure rollback
-  // and the deferred old-name erase below re-acquire mutex_ only after the COW lock is released,
-  // which preserves the lock order between mutex_ and the COW lock. While the sys-catalog write
-  // runs, a YCQL rename is visible to concurrent RPCs under both names. Anything that resolves
-  // the table still serializes on its COW lock and sees the outcome at commit or rollback.
-  // CreateTable already has the same uncommitted-name window. A follow-up is to revalidate the
-  // resolved name against the committed pb at the delete and lookup choke points.
-  lock.unlock();
 
   // Check if there has been any changes to the placement policies for this table.
   if (req->has_replication_info()) {
@@ -8444,24 +8466,15 @@ Status CatalogManager::AlterTableWithBatchTracker(
 
   while (FLAGS_TEST_block_alter_table == "sys_catalog_write") {
     constexpr auto kSleepFor = 100ms;
-    LOG(INFO) << Format("Blocking $0 for $1ms", __func__, kSleepFor);
+    LOG(INFO) << Format("Blocking $0 at sys_catalog_write for $1ms", __func__, kSleepFor);
     SleepFor(kSleepFor);
   }
 
   Status update_status = UpdateSysCatalogWithNewSchema(table, ddl_log_entries, epoch, resp);
   if (!update_status.ok()) {
-    // The write failed. Discard the staged COW changes and drop the reserved new name. The old
-    // name was never erased, so the table stays reachable by it.
-    l.Unlock();
-    if (table->GetTableType() != PGSQL_TABLE_TYPE && req->has_new_table_name()) {
-      LockGuard map_lock(mutex_);
-      // Tolerate an entry that is already absent. Both mutex_ and the COW lock were released
-      // above, so a concurrent mutation could have removed it.
-      if (table_names_map_.erase({namespace_id, new_table_name}) != 1) {
-        LOG(WARNING) << "ALTER TABLE rollback: reserved new name " << namespace_id << "."
-                     << new_table_name << " was already absent from the by-name map";
-      }
-    }
+    // The write failed. Discard the staged COW changes. The reservation guard erases the
+    // reserved new name once the COW lock is released. The old name was never erased, so the
+    // table stays reachable by it.
     return update_status;
   }
 
@@ -8470,6 +8483,11 @@ Status CatalogManager::AlterTableWithBatchTracker(
   VLOG_WITH_FUNC(3) << "SysTablesEntryPB for " << table->id()
                     << " after the after table operation is: " << table_pb.DebugString();
   l.Commit();
+
+  // The alter is committed. If a rename reserved a new name, that name is the table's live name
+  // now, so dismiss the guard that would erase it. The dismissal must stay directly after the
+  // commit. A failure return between the two would run the guard and erase the live name.
+  name_reservation_guard.Cancel();
 
   // A committed rename erases its old name here rather than before the write, so that a failed
   // write leaves the table reachable by the old name. Tolerate an entry that is already absent.
@@ -8510,7 +8528,7 @@ Status CatalogManager::AlterTableWithBatchTracker(
 
   while (FLAGS_TEST_block_alter_table == "completion") {
     constexpr auto kSleepFor = 100ms;
-    LOG(INFO) << Format("Blocking $0 for $1ms", __func__, kSleepFor);
+    LOG(INFO) << Format("Blocking $0 at completion for $1ms", __func__, kSleepFor);
     SleepFor(kSleepFor);
   }
 

--- a/src/yb/master/catalog_manager.h
+++ b/src/yb/master/catalog_manager.h
@@ -506,8 +506,6 @@ class CatalogManager : public CatalogManagerIf, public SnapshotCoordinatorContex
   Status UpdateSysCatalogWithNewSchema(
     const scoped_refptr<TableInfo>& table,
     const std::vector<DdlLogEntry>& ddl_log_entries,
-    const std::string& new_namespace_id,
-    const std::string& new_table_name,
     const LeaderEpoch& epoch,
     AlterTableResponsePB* resp);
 
@@ -588,7 +586,6 @@ class CatalogManager : public CatalogManagerIf, public SnapshotCoordinatorContex
 
   Status YsqlDdlTxnAlterTableHelper(const YsqlTableDdlTxnState txn_data,
                                     const std::vector<DdlLogEntry>& ddl_log_entries,
-                                    const std::string& new_table_name,
                                     bool success,
                                     int rollback_till_ddl_state_index = 0);
 

--- a/src/yb/master/ysql_ddl_handler.cc
+++ b/src/yb/master/ysql_ddl_handler.cc
@@ -482,7 +482,7 @@ Status CatalogManager::HandleSuccessfulYsqlDdlTxn(
   }
   SchemaToPB(builder.Build(), mutable_pb.mutable_schema());
   return YsqlDdlTxnAlterTableHelper(
-      txn_data, ddl_log_entries, /*new_table_name=*/"", /*success=*/true);
+      txn_data, ddl_log_entries, /*success=*/true);
 }
 
 Status CatalogManager::HandleAbortedYsqlDdlTxn(const YsqlTableDdlTxnState txn_data) {
@@ -558,7 +558,7 @@ Status CatalogManager::RollbackYsqlTxnDdlStates(
     mutable_pb.set_next_column_id(first_ddl_state.previous_next_column_id());
   }
   return YsqlDdlTxnAlterTableHelper(
-      txn_data, ddl_log_entries, new_table_name, /*success=*/false,
+      txn_data, ddl_log_entries, /*success=*/false,
       rollback_till_ddl_state_index);
 }
 
@@ -610,7 +610,6 @@ Status CatalogManager::ClearYsqlDdlTxnState(
 
 Status CatalogManager::YsqlDdlTxnAlterTableHelper(const YsqlTableDdlTxnState txn_data,
                                                   const std::vector<DdlLogEntry>& ddl_log_entries,
-                                                  const string& new_table_name,
                                                   bool success,
                                                   int rollback_till_ddl_state_index) {
   RSTATUS_DCHECK(
@@ -642,8 +641,6 @@ Status CatalogManager::YsqlDdlTxnAlterTableHelper(const YsqlTableDdlTxnState txn
   RETURN_NOT_OK(UpdateSysCatalogWithNewSchema(
         txn_data.table,
         ddl_log_entries,
-        "" /* new_namespace_id */,
-        new_table_name,
         txn_data.epoch,
         nullptr /* resp */));
 


### PR DESCRIPTION
## Summary

`CatalogManager::AlterTableWithBatchTracker` held `CatalogManager::mutex_` in exclusive mode across the sys-catalog Raft write that persists an altered table's schema. `mutex_` is a reader-writer spinlock, and nearly every master RPC takes it in shared mode, so each ALTER TABLE stalled the whole master for the length of a consensus commit. Issue #29306 calls out this exact site with "we should not do any IO while holding the CatalogManager::mutex_", and the code marks it with `// todo(GH29185): too much happens here under the cm mutex.` This change deletes that TODO.

This change takes `mutex_` in at most two short scopes, and never across the write or together with the table's copy-on-write lock. A rename checks its target name for collisions and reserves it before the copy-on-write lock is taken, then cleans up the old name after the alter commits. Only a YCQL rename needs those scopes. Every other alter, including every PGSQL alter and the CDC retention path, takes no exclusive `mutex_` at all. `CreateTable`, `CreateNamespace`, and `DoSplitTablet` already run their sys-catalog writes without holding `mutex_`. To measure the effect I swapped the master binary on a cluster with 7 masters and 280 tablet servers and created a CDCSDK stream over a 2000-table namespace, which issues one ALTER per table. During stream creation the control build logged over 8,000 slow-RPC warnings per run and the patched build logged 24, none of them from tserver heartbeats or catalog reads. Stream creation itself took the same time on both builds. The full numbers are in the table below. The new ordering also fixes a self-deadlock and two rollback bugs in the old failure path, and stops a failing rename from leaking its reserved name.

## Why it matters

CDCSDK stream creation calls AlterTable once per table in the namespace, through `SetAllCDCSDKRetentionBarriers`, to set `wal_retention_secs`. On a namespace with thousands of tables that means thousands of back-to-back exclusive holds of `mutex_`, each spanning a Raft commit. While each hold lasts, every shared acquirer waits. That includes catalog lookups, connection setup, and tserver heartbeat processing. Bulk ALTERs from any source create the same pattern. Stream creation is just the densest case I measured.

The cost only appears when exclusive holds arrive back to back. A single-ALTER micro-benchmark will not show it.

## What changed

`AlterTableWithBatchTracker` now takes `mutex_` in at most two short scopes, and the sys-catalog write runs with no catalog-wide lock held. `mutex_` is never held together with the table's copy-on-write lock, so no path through the function can invert the order of those two locks.

A YCQL rename checks its target name for collisions and reserves it in `table_names_map_` in one short exclusive scope before the table's copy-on-write lock is taken. The reservation points at the table, so a concurrent CREATE or rename aiming at the same name fails against it. A cleanup guard declared before the copy-on-write lock erases the reservation if the alter fails on any later step, and the declaration order makes the guard run only after that lock is released. If the write succeeds, the guard is dismissed, the new name is the table's live name, and the old name is removed in a second short scope after the in-memory commit. If the write fails, the staged schema changes are discarded and the guard drops the reserved name. The old name was never touched, so the table stays reachable under it and there is nothing else to roll back.

Every other alter has no name-map state to maintain and takes no exclusive `mutex_` at all. PGSQL alters are all in this group, including PGSQL renames, because PGSQL enforces name uniqueness in its own layer and its tables are not in the by-name map. The CDC `wal_retention_secs` path is in this group too.

## Latent bugs in the old failure path

Moving the rollback out of `UpdateSysCatalogWithNewSchema` also fixes three bugs in the old code.

The first is a self-deadlock. When the write failed, `UpdateSysCatalogWithNewSchema` re-acquired the non-recursive `mutex_` to clean up the name map, while its caller still held it. For a YCQL table the cleanup ran whenever a namespace id or a new table name was passed in, and the caller always passed the namespace id, so every failing YCQL alter hung the master, rename or not. The rollback now lives in the caller, runs after the COW lock is released, and takes `mutex_` fresh, the same way `AbortTableCreation` cleans up after a failed create.

The second bug was masked by the first. `new_table_name` defaults to the table's current name, so a failing alter that renamed nothing would have erased the table's live name entry, even though nothing had been reserved. The rollback is now gated exactly like the reservation, on a YCQL alter that actually carries a new name.

The failure path also never restored the old name, which the old code had already erased before the write. A failing rename would have left the table unreachable by either name until a leader change rebuilt the map. Deferring the erase to after the commit removes that state to roll back.

The old failure path ended in a `CHECK_EQ` that required the erase to remove exactly one entry. That assertion was unreachable, because the thread deadlocked on the lock acquisition two lines above it. Even if it had run, a failing alter with no rename would have passed the check by erasing the live name entry. The check could only fire when the entry was absent, and once `mutex_` is released across the write an absent entry is a legal state. A leader change rebuilds the by-name map from the sys-catalog, so a rollback that runs after the master loses and regains leadership can find the reservation already gone. Crashing the master over a stale entry in a map that self-heals is the wrong response, so the rollback and the post-commit erase log a warning and continue. The old code ignored the result of its pre-write old-name erase entirely. The delete path already logs a warning when an erase from this map finds nothing.

With the rollback moved, the `new_namespace_id` and `new_table_name` parameters of `UpdateSysCatalogWithNewSchema` are dead. They are removed here, along with the matching arguments in `YsqlDdlTxnAlterTableHelper`, whose PGSQL call sites could never reach the erased branch.

## Why releasing the lock is safe

The write itself touches nothing that `mutex_` protects. `mutex_` guards the catalog-wide lookup maps, and the only map mutations on this path are the name reservation and the old-name removal after commit. Each runs under its own short `mutex_` acquisition.

The table's own metadata is guarded by its copy-on-write lock, and that lock stays held across the write. Concurrent operations can still find the table through the maps, but they read its last committed state. Another writer to the same table blocks on the COW lock until this alter commits or rolls back. The newly observable rename window is described in the behavior change section below.

## Behavior change during YCQL rename

The old code erased the old name from the by-name map before the write and held `mutex_` until after the in-memory commit, so concurrent RPCs blocked and then saw only the final state. With the lock released during the write, the table resolves under both names until the rename settles. Only catalog operations on the master can observe this window. Row reads and writes route by table ID, never through the by-name map, so the data path does not change.

Operations that use the new name can resolve the table before the rename is durable. If the write then fails, a DROP or ALTER that used the new name has acted on a name that never committed. A CREATE or rename that targets either name fails with AlreadyPresent during the window. For the old name that used to block and then succeed once the rename was done. For the new name a failed write makes the rejection spurious, and a retry succeeds once the rollback drops the reservation.

Operations that use the old name keep resolving the table during the window instead of blocking. Metadata reads such as `GetTableSchema` return the last committed state, which is still correct because the rename is not durable yet. A DROP that resolves the old name during the window and then waits on the COW lock deletes the table after the rename commits. That race already exists on master for a DROP that resolves the name just before the alter takes `mutex_`, so the window widens rather than opens. After the rename commits, the old name is erased under a fresh `mutex_` acquisition, so it stays visible for a moment before it becomes free.

The window is narrow. Only YCQL renames are affected, because PGSQL tables are not in the by-name map and non-rename alters reserve nothing. An operation that wins the race still serializes on the table's COW write lock, so no inconsistent state is ever persisted, and the table stays reachable by its old name the whole time. `CreateTable` already has the same window today. It reserves a name, releases `mutex_`, and then writes the sys-catalog, and name lookups do not filter uncommitted entries. This change widens an existing hazard rather than introducing a new kind. YCQL table rename is also reachable only through the client API, not through CQL.

The collision check now runs before the table-state checks, which changes one error code. A rename that targets a taken name on a table that is not yet ready returns AlreadyPresent for the name instead of TryAgain for the table state. A rename that goes on to fail those state checks also holds its reservation until the cleanup guard drops it on the failure return, so a CREATE racing such a doomed alter can see a transient AlreadyPresent for the target name and succeeds on retry. `CreateTable`'s uncommitted reservations expose the same transient today.

The complete fix for this problem is to revalidate a name-resolved table against its committed metadata after taking the COW lock. That changes DROP semantics globally and covers the pre-existing races of the same shape, so it belongs in a follow-up.

## Measured impact

I swapped only the master binary on a test cluster with 7 masters and 280 tablet servers, kept the tservers and the master leader fixed, and created one CDCSDK stream over a namespace with 2000 tables. Both master binaries are built from the upstream 2025.2.5.0-b31 tag. Neither build contains the CDC stream-creation batching from #19066. That change landed after the b31 tag, so both arms dispatch the stream's ALTERs without pacing. The control is that source unmodified and the fix is the same source plus the first commit of this PR. The reservation rework in the second commit was not re-measured. For the non-rename alters driven here it removes the one remaining short `mutex_` hold. Three runs per arm. Every run reproduced its arm's result.

The master logs an `RPC took a long time` warning from `ScopedLeaderSharedLock` when handling an RPC takes longer than one second (`master_log_lock_warning_ms`). The warning rows in the table below count those log lines during stream creation, and the p99 figures come from the durations the warnings report.

Throughout each run, a loop on one of the cluster's nodes called `yb-admin list_tables` and `yb-admin list_namespaces` and recorded each call's latency. Every call is a fresh process, so nothing is cached and each call performs a full catalog read against the master leader. The idle baseline is the p99 of the same calls while no stream creation is running, roughly 130 to 170 ms across runs.

| signal during stream creation | control (n=3) | fix (n=3) |
|---|---|---|
| master slow-RPC warnings, all RPCs | 8,042-10,155 | 24 in every run (over 300x fewer) |
| slow-RPC warnings for catalog reads (ListTables/ListNamespaces/GetTableSchema) | 178-272 (p99 3.6-4.4 s) | 0 |
| slow-RPC warnings for tserver heartbeats | 3,791-4,128 (p99 82-98 s) | 0 |
| `yb-admin` catalog reads, p99 | 1.4-2.6 s (11-16x that run's idle baseline) | 133-173 ms (1.0-1.1x) |
| stream create duration | ~152-164 s | ~151-159 s (unchanged) |

When running against the first commit in this branch, the same 24 warnings appear in each run. Twenty-three come from the master's `catalog_manager_bg_tasks` loop and one is the CreateCDCStream call itself, which runs as long as the whole create and reports once on both builds. Each pass of the loop holds the leader lock in shared mode for about 12 seconds, and this change does not touch that code. So the two builds match whenever ALTERs are not running and the gains above are not a general speedup.

However, during stream creation, that background task loop queued behind the same back-to-back exclusive holds and took as long as 162 seconds to complete without this fix. It never took longer than 13 seconds when running against the first commit in this branch.

Stream create duration is unchanged. This fix removes the collateral blocking, not the create work itself.

## Pre-existing issues

Three issues here predate this change. The reservation rework fixes the first two.

1. Fixed here. On master, an error between the name reservation and the write leaks the reservation. A CREATE of that name then fails with AlreadyPresent until a leader change or a master restart rebuilds the by-name map, and dropping the table does not clear the entry. The cleanup guard now covers every failure return after the reservation. Tests pin the rollback for a failed option validation, a failed alter step, a table deleted in the reservation window, and a failed sys-catalog write.
2. Fixed here. On master, a second alter on the same table holds `mutex_` while it waits for the first alter's COW lock, so one slow alter can stall every master RPC through a queued neighbor. `mutex_` is no longer held when the COW lock is taken, so a queued alter blocks nothing else. A new test pins it.
3. Still present. The [`!has_changes && force_send_alter_request` branch](https://github.com/yugabyte/yugabyte-db/blob/3ca634624044b28f55b064ee3088a41d5f0f20b8/src/yb/master/catalog_manager.cc#L8315-L8321) runs `SendAlterTableRequest` while holding the table's copy-on-write lock, including a synchronous sys-catalog write for transactional PGSQL alters. No code in the repository sets that field.

## Testing

Two test flags inject failures. The new `TEST_fail_alter_table_sys_catalog_write` fails the sys-catalog write at the Upsert call. The existing `TEST_fail_alter_table_after_commit` fails the alter right after its in-memory commit. Two new stage values for the existing `TEST_block_alter_table` flag park an alter mid-flight. `sys_catalog_write` parks an alter just before the write starts, holding the table's copy-on-write lock, which is the state concurrent RPCs observe while a real write is in flight. `post_name_reservation` parks a rename after it reserves its new name and before it takes that lock, when it holds no lock at all.

- YCQL `alter_table-test`. The existing rename test now also asserts that the old name stops resolving after a successful rename. A new rename-failure test asserts that the alter returns an error instead of deadlocking, that the reserved new name is released and free for a fresh CREATE, and that the old name still resolves. A new add-column-failure test asserts that a failing non-rename alter leaves the live name mapping intact. The rename test runs under both of the suite's tablet-report batch-size parameterizations. The failure tests run once each, on a fixture instantiated at a single batch size, because the batch size does not affect them.
- Four tests cover the reservation rework's failure paths. The first combines a rename with a `wal_retention_secs` change. That combination fails validation after the new name is reserved, so the test pins the leak fix by asserting that the old name still resolves, that the target name does not, and that a CREATE of the target name then succeeds. The second fails inside schema-change application instead, by combining a rename to a free name with a drop of a column that does not exist, and asserts the same rollback. The third renames to a taken name while also carrying an invalid alter step and asserts that the collision is reported, which pins the new check order deliberately. The fourth renames a table to its own current name, which collides with the table itself before anything is reserved, and asserts that the table stays reachable and alterable afterwards, so a failure that reserved nothing never erases a live name. All four run on the single-batch-size fixture.
- One test injects a failure right after the alter's in-memory commit. The rename is committed at that point, so the failure must not roll it back. The alter returns the error to the client, the new name keeps resolving, the old name is free for a fresh CREATE, and the renamed table accepts a further alter. A rollback that outlived the commit would have erased the table's live name.
- Five tests park an alter at the `sys_catalog_write` stage and drive concurrent operations through the window. While an add-column alter is parked, a schema read of the altering table returns the committed schema without the new column, a listing shows the table once, and a CREATE of an unrelated table completes. The alter is still parked after those operations finish, so they overlapped the write window instead of following it. Each of these operations acquires `mutex_`, which the old code held across the write. While a rename is parked, both names resolve to the same table ID, a lookup through the reserved name returns the committed old name, a listing shows the table exactly once under the old name, a CREATE targeting either name fails with AlreadyPresent, and once the rename commits a CREATE reusing the old name succeeds. The third test sends a DROP through the old name while a rename is parked. The drop blocks on the table's copy-on-write lock, and an unrelated CREATE acquires `mutex_` and completes while the drop stays blocked, so the blocked drop is not holding `mutex_`. Once the rename commits, the drop deletes the renamed table, and afterwards neither name resolves and a CREATE of each name succeeds, so neither map entry leaked. The fourth queues a second rename behind a parked first rename. The queued rename reserves its own name and then waits for the table lock with no lock held, so its reserved name resolves, all three names resolve to the one table, a listing shows the table once, and an unrelated CREATE completes while it waits. Once both renames commit, only the final name resolves, both earlier names are free for fresh CREATEs, and a further alter succeeds. That pins the queued-alter fix, and it pins that a rename erases the name that was committed when it acquired the lock rather than the name its request carried. The fifth renames a second table to the name a parked rename has reserved. The second rename fails with AlreadyPresent while the first is still parked, so its collision check does not wait behind the parked rename, and the contested name resolves to the renaming table rather than the second table. Once the parked rename commits, the contested name belongs to the renamed table and its vacated old name is free for a fresh CREATE. These tests run on the same single-batch-size fixture.
- Two tests park a rename at the `post_name_reservation` stage and send a DROP through the open window, one through the committed old name and one through the reserved new name. The parked rename holds no lock, so both drops run to completion while it is parked. The rename then finds the table deleted and fails, and both tests assert that the failure releases the reservation and that a CREATE of each name succeeds, so a drop landing in the reservation window leaks nothing.
- The whole `alter_table-test` binary passes on this branch, all 50 runnable test instances across its parameterizations. The two instances of one upstream-disabled test are skipped.
- PGSQL coverage. The alter-related tests of `pg_ddl_atomicity-test`, including `AlterTableRollbackOnMasterCrash`, and the rename test of `pg_ddl_transaction-test` exercise the changed helper signature. All 27 runs across three sweeps pass.
- PGSQL concurrent DDL stress. I ran all 20 instances of `PgDdlAtomicityStressTest.Main` on this branch, covering plain, colocated, partitioned, and colocated partitioned tables. Each instance runs five threads against one table. Two threads alternate ALTER TABLE ADD COLUMN and DROP COLUMN, one of them with defaults. One thread creates and drops an index, one builds a concurrent index, and one updates rows throughout. Sixteen of the instances inject failures into the master's DDL verification and rollback paths at 10 percent probability. The same four `TEST_ysql_` flags repeat across each table shape. PGSQL alters flow through the same AlterTable path, which now takes no exclusive `mutex_` for them, and each DDL on a partitioned table expands into one statement per partition plus the parent, which multiplies the concurrent DDL through that path. All 20 pass.
- The failure-injection tests catch the old bug. I applied only the test flag and the injection to master and left the old locking in place. Both failure-injection tests deadlock the master there. The AlterTable worker spins in the failure path trying to re-acquire `mutex_`, heartbeats and catalog reads time out behind it, and the run has to be killed at the test timeout. On this branch the same tests pass in under a second each, and the injected failure surfaces as a clean error.