### PR TITLE
[#31135] YSQL: Fix segfault on query layer retry of EXPLAIN ANALYZE over a view

### DIFF
--- a/java/yb-pgsql/src/test/java/org/yb/pgsql/TestPgTransparentRestarts.java
+++ b/java/yb-pgsql/src/test/java/org/yb/pgsql/TestPgTransparentRestarts.java
@@ -41,6 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import static org.yb.util.BuildTypeUtil.getTimeoutMultiplier;
 
+import org.yb.client.TestUtils;
 import org.yb.client.YBClient;
 import org.yb.util.CatchingThread;
 import org.yb.util.RandomUtil;
@@ -349,6 +350,84 @@ public class TestPgTransparentRestarts extends BasePgSQLTest {
         return stmt;
       };
     }.runTest();
+  }
+
+  /**
+   * Regression test for #31135 (DB-21015): backend SIGSEGV on transparent query-layer retry of a
+   * simple-query-mode {@code EXPLAIN ANALYZE} over a view.
+   * <p>
+   * Under the simple query protocol a utility statement's contained query is one-shot, so the
+   * rewriter and planner scribble on it in place: {@code pull_up_simple_subquery} merges the
+   * view's subquery into the outer query and sets the view RTE's {@code rte->subquery} to NULL.
+   * When a conflicting committed write triggers YB's READ COMMITTED statement retry, re-acquiring
+   * executor locks used to re-walk that scribbled tree and crash on the NULL subquery in
+   * {@code ScanQueryForLocks}.
+   */
+  @Test
+  public void explainAnalyzeViewConflictRetry_simpleQueryMode() throws Exception {
+    try (Statement stmt = connection.createStatement()) {
+      stmt.execute("CREATE TABLE test_explain_restart (k INT PRIMARY KEY, v INT)");
+      stmt.execute("INSERT INTO test_explain_restart VALUES (1, 10)");
+      stmt.execute(
+          "CREATE VIEW test_explain_restart_view AS SELECT k, v FROM test_explain_restart");
+    }
+    try (Connection updateConn = getConnectionBuilder().connect();
+         Connection explainConn = getConnectionBuilder().withPreferQueryMode("simple").connect();
+         Statement updateStmt = updateConn.createStatement();
+         Statement explainStmt = explainConn.createStatement()) {
+      explainStmt.execute(LOG_RESTARTS_SQL);
+
+      // Hold a conflicting provisional write on the row so that the locking read below has to
+      // wait for it, then conflicts once it is committed.
+      updateStmt.execute("BEGIN");
+      updateStmt.execute("UPDATE test_explain_restart SET v = v + 1 WHERE k = 1");
+
+      CatchingThread explainThread = new CatchingThread("EXPLAIN ANALYZE", () -> {
+        List<String> planLines = new ArrayList<>();
+        try (ResultSet rs = explainStmt.executeQuery(
+            "EXPLAIN ANALYZE SELECT * FROM test_explain_restart_view WHERE k = 1 FOR UPDATE")) {
+          while (rs.next()) {
+            planLines.add(rs.getString(1));
+          }
+        }
+        assertFalse("EXPLAIN ANALYZE returned no plan output", planLines.isEmpty());
+        LOG.info("EXPLAIN ANALYZE completed, {} plan lines", planLines.size());
+      });
+      explainThread.start();
+
+      // Wait until the EXPLAIN ANALYZE is executing (i.e. blocked waiting on the held row lock),
+      // then commit to trigger the conflict retry.
+      TestUtils.waitFor(() -> {
+        try (Statement stmt = connection.createStatement();
+             ResultSet rs = stmt.executeQuery(
+                 "SELECT COUNT(*) FROM pg_stat_activity" +
+                 " WHERE state = 'active' AND query LIKE 'EXPLAIN ANALYZE%'")) {
+          return rs.next() && rs.getLong(1) > 0;
+        }
+      }, 30000L);
+      Thread.sleep(1000);
+      updateStmt.execute("COMMIT");
+
+      explainThread.join(60000);
+      assertFalse("EXPLAIN ANALYZE thread is still running", explainThread.isAlive());
+      explainThread.rethrowIfCaught();
+
+      // The backend must have survived the retried statement.
+      try (ResultSet rs =
+          explainStmt.executeQuery("SELECT COUNT(*) FROM test_explain_restart")) {
+        assertTrue(rs.next());
+        assertEquals(1, rs.getLong(1));
+      }
+    } finally {
+      // Best-effort cleanup: on unfixed code the backend crash takes down all connections, and
+      // that failure must not be masked by cleanup errors.
+      try (Statement stmt = connection.createStatement()) {
+        stmt.execute("DROP VIEW IF EXISTS test_explain_restart_view");
+        stmt.execute("DROP TABLE IF EXISTS test_explain_restart");
+      } catch (Exception e) {
+        LOG.warn("Cleanup failed (expected when the backend crashed)", e);
+      }
+    }
   }
 
   /**

--- a/src/postgres/src/backend/utils/cache/plancache.c
+++ b/src/postgres/src/backend/utils/cache/plancache.c
@@ -2037,8 +2037,22 @@ ScanQueryForLocks(Query *parsetree, bool acquire)
 				break;
 
 			case RTE_SUBQUERY:
-				/* Recurse into subquery-in-FROM */
-				ScanQueryForLocks(rte->subquery, acquire);
+
+				/*
+				 * YB: rte->subquery is NULL if the planner pulled up the
+				 * subquery (pull_up_simple_subquery) while scribbling on a
+				 * one-shot utility tree, e.g. a simple-query-protocol
+				 * EXPLAIN ANALYZE over a view.  YB's query-layer retry
+				 * re-walks such trees via AcquireExecutorLocks.  Lock
+				 * coverage is preserved: pull-up merged the subquery's
+				 * rtable into this query's rtable, so the pulled-up
+				 * relations are locked by this same walk.
+				 */
+				if (rte->subquery)
+				{
+					/* Recurse into subquery-in-FROM */
+					ScanQueryForLocks(rte->subquery, acquire);
+				}
 				break;
 
 			default:


### PR DESCRIPTION
## Summary

Fixes #31135 (Jira: DB-21015).

A `SIGSEGV` kills the backend when YB's query-layer retry re-walks the parse
tree of a simple-query-protocol `EXPLAIN ANALYZE` over a view:

1. Under the simple query protocol the utility statement's contained query is
   one-shot: `ExplainQuery` rewrites it in place (no `copyObject`), and the
   planner then scribbles on the same tree. `pull_up_simple_subquery` merges
   the view's subquery into the parent query and sets the view RTE's
   `rte->subquery = NULL` (`prepjointree.c`).
2. A retriable error (e.g. `kConflict` under READ COMMITTED, where any
   command tag is retried) triggers the query-layer retry:
   `yb_perform_retry_on_error` -> portal restart ->
   `YBAcquireExecutorLocksForRetry` -> `AcquireExecutorLocks` ->
   `UtilityContainsQuery` -> `ScanQueryForLocks`, which recursed into the
   now-NULL `rte->subquery` with no guard and crashed:

   ```
   ScanQueryForLocks
   ScanQueryForLocks
   YBAcquireExecutorLocksForRetry
   yb_perform_retry_on_error
   ```

Upstream PostgreSQL sanctions scribbling on one-shot utility trees because
nothing upstream re-reads them after planning; YB's retry path violates that
assumption. The extended query protocol is unaffected because
`standard_ProcessUtility` copies the tree when `readOnlyTree` is true
(`portal->cplan != NULL`).

**Fix:** NULL-guard the `RTE_SUBQUERY` arm of `ScanQueryForLocks`
(`src/postgres/src/backend/utils/cache/plancache.c`). Lock coverage is
preserved: pull-up concatenates the subquery's rtable into the parent rtable,
so the pulled-up relations are locked by the same walk.

## Test plan

New regression test `TestPgTransparentRestarts#explainAnalyzeViewConflictRetry_simpleQueryMode`:
tserver gflag `yb_enable_read_committed_isolation=true`, session A holds
`BEGIN; UPDATE t ...`, session B (JDBC `preferQueryMode=simple`) runs
`EXPLAIN ANALYZE SELECT * FROM v WHERE k = 1 FOR UPDATE`, A commits, the
statement retry walks the scribbled tree.

- [x] Red (test-only tree, unfixed): `./yb_build.sh release --java-test
  'org.yb.pgsql.TestPgTransparentRestarts#explainAnalyzeViewConflictRetry_simpleQueryMode'`
  fails; postgres log shows `Restarting portal  for retry` followed by
  `server process (PID n) was terminated by signal 11: Segmentation fault`
  with the `ScanQueryForLocks` backtrace above; client sees
  `PSQLException ... EOFException`.
- [x] Green (with fix): same command passes; log shows the same
  `performing query layer retry, attempt number 0` / `Restarting portal  for
  retry`, the statement completes and returns the plan, connection stays
  alive.
- [x] Green re-run after rebasing onto current master.
- [x] `./build-support/lint.sh --rev origin/master` exits 0 (one warning
  about a pre-existing unmarked YB hunk elsewhere in plancache.c; the new
  hunk carries a YB comment).

Standalone repro against released images (crashes on unfixed builds,
e.g. tags `2025.1.3.1-b2` and `2026.1.0.1-b1`):

```sh
IMG=docker.io/yugabytedb/yugabyte:<tag>
podman run -d --name yb31135 $IMG bash -c \
  '/home/yugabyte/bin/yugabyted start --advertise_address=127.0.0.1 --daemon=false \
   --tserver_flags=yb_enable_read_committed_isolation=true'
# wait until: podman exec yb31135 /home/yugabyte/bin/ysqlsh -h 127.0.0.1 -c 'SELECT 1'

podman exec yb31135 /home/yugabyte/bin/ysqlsh -h 127.0.0.1 \
  -c 'CREATE TABLE t (k int PRIMARY KEY, val int);' \
  -c 'INSERT INTO t VALUES (1, 10);' \
  -c 'CREATE VIEW v AS SELECT k, val FROM t;'

podman exec yb31135 /home/yugabyte/bin/ysqlsh -h 127.0.0.1 \
  -c 'BEGIN; UPDATE t SET val = val + 1 WHERE k = 1; SELECT pg_sleep(6); COMMIT;' &
sleep 2
podman exec -e PGOPTIONS='-c yb_debug_log_internal_restarts=true' yb31135 \
  /home/yugabyte/bin/ysqlsh -h 127.0.0.1 \
  -c 'EXPLAIN ANALYZE SELECT * FROM v WHERE k = 1 FOR UPDATE;'
# unfixed -> "server closed the connection unexpectedly";
# postgres log: "Restarting portal  for retry" then signal 11
```
