### PR TITLE
[#31258] DocDB: Fix heap-use-after-free in QLTransactionTest.WriteBatchDuringShutdown

### DIFF
--- a/src/yb/client/ql-transaction-test.cc
+++ b/src/yb/client/ql-transaction-test.cc
@@ -1967,25 +1967,33 @@ TEST_F_EX(QLTransactionTest, TransactionsEarlyLoadedTest, QLTransactionTestSingl
 
 TEST_F_EX(QLTransactionTest, YB_DEBUG_ONLY_TEST(WriteBatchDuringShutdown),
           QLTransactionTestSingleTablet) {
-  tablet::TabletPeer* follower;
+  std::string follower_uuid;
+  std::string tablet_id;
+  tablet::TransactionParticipantContext* follower_context = nullptr;
   {
     auto peers = ASSERT_RESULT(ListTabletPeersForTableName(
         cluster_.get(), table_->name().table_name(), ListPeersFilter::kNonLeaders));
     ASSERT_GE(peers.size(), 1);
-    follower = peers.front().get();
+    tablet::TabletPeer* follower = peers.front().get();
+    ASSERT_NE(follower, nullptr);
+    follower_uuid = follower->permanent_uuid();
+    tablet_id = follower->tablet_id();
+    // The raw TabletPeer must not escape this scope: its owning shared_ptr is
+    // released here, and the peer itself is destroyed by the tablet server
+    // shutdown below while the sync point callbacks can still fire. Callbacks
+    // may only capture values computed from the peer; the upcast pointer is
+    // used for identity comparison and never dereferenced.
+    follower_context = implicit_cast<tablet::TransactionParticipantContext*>(follower);
   }
-  ASSERT_NE(follower, nullptr);
-  auto follower_uuid = follower->permanent_uuid();
-  auto tablet_id = follower->tablet_id();
 
   auto& sync_point = *SyncPoint::GetInstance();
   CountDownLatch start_shutdown_latch(1);
   CountDownLatch write_batch_latch(1);
   sync_point.SetCallBack(
       "TransactionParticipant::Impl::StartShutdown",
-      [follower, &start_shutdown_latch](void* arg) {
+      [follower_context, &start_shutdown_latch](void* arg) {
     auto* context = static_cast<tablet::TransactionParticipantContext*>(arg);
-    if (implicit_cast<tablet::TransactionParticipantContext*>(follower) == context) {
+    if (follower_context == context) {
       LOG(INFO) << "TransactionParticipant::Impl::StartShutdown";
       start_shutdown_latch.CountDown();
     }
@@ -1993,10 +2001,10 @@ TEST_F_EX(QLTransactionTest, YB_DEBUG_ONLY_TEST(WriteBatchDuringShutdown),
   OpId apply_op_id;
   sync_point.SetCallBack(
       "RaftConsensus::UpdateReplica",
-      [follower, &write_batch_latch, &start_shutdown_latch, &apply_op_id](void* arg) {
+      [follower_uuid, tablet_id, &write_batch_latch, &start_shutdown_latch,
+       &apply_op_id](void* arg) {
     auto* request = static_cast<consensus::LWConsensusRequestPB*>(arg);
-    if (request->dest_uuid() != follower->permanent_uuid() ||
-        request->tablet_id() != follower->tablet_id()) {
+    if (request->dest_uuid() != follower_uuid || request->tablet_id() != tablet_id) {
       return;
     }
     LOG(INFO) << "RaftConsensus::UpdateReplica: " << request->ShortDebugString();
@@ -2034,7 +2042,10 @@ TEST_F_EX(QLTransactionTest, YB_DEBUG_ONLY_TEST(WriteBatchDuringShutdown),
   mini_tserver->Shutdown();
   LOG(INFO) << "RESTART MID";
   sync_point.DisableProcessing();
-  follower = nullptr;
+  // DisableProcessing() only stops new callback invocations. Also wait for
+  // in-flight callbacks to drain so no straggler can touch the latches on this
+  // test's stack after the test returns.
+  sync_point.ClearAllCallBacks();
   ASSERT_OK(mini_tserver->Start());
   LOG(INFO) << "RESTART END";
   latch.Wait();


### PR DESCRIPTION
## Summary

`QLTransactionTest.WriteBatchDuringShutdown` intermittently fails ASAN runs with a heap-use-after-free READ of size 8 on a `TabletServer-hi` RPC worker thread, inside the test's own `"RaftConsensus::UpdateReplica"` sync point callback.

Root cause (test code only): the callback captures a raw `TabletPeer* follower` whose owning `shared_ptr` is released immediately after lookup, and dereferences it (`follower->permanent_uuid()` / `follower->tablet_id()`) as its filter. The callback intentionally stays enabled across `mini_tserver->Shutdown()` -- the paired `"TransactionParticipant::Impl::StartShutdown"` callback must fire mid-shutdown -- but the shutdown destroys the follower's `TabletPeer` (`TSTabletManager::CompleteShutdown()` clears the tablet map), while the in-process MiniCluster's two surviving tablet servers keep sending UpdateConsensus RPCs that fire the process-global callback against the freed peer. `SyncPoint::DisableProcessing()` is only called after `Shutdown()` returns, and it does not drain in-flight callbacks.

The fix keeps the raw peer from escaping the lookup scope:

- The `"RaftConsensus::UpdateReplica"` callback now captures the follower's `permanent_uuid()` / `tablet_id()` strings by value and filters on those; no `TabletPeer` dereference remains.
- The `"TransactionParticipant::Impl::StartShutdown"` callback compares its argument against a pre-computed `TransactionParticipantContext*` upcast of the peer (pointer identity only, never dereferenced).
- `SyncPoint::ClearAllCallBacks()` is now called after `DisableProcessing()`: disabling only stops new invocations, while clearing also waits for in-flight callbacks to drain, so a straggler cannot touch the latches on the test's stack after the test returns (a sibling stack-use-after-scope hazard on `write_batch_latch` / `apply_op_id`).

Alternatives rejected: capturing a `shared_ptr<TabletPeer>` would keep the peer alive across the restart and change the lifetime the test exercises; moving `DisableProcessing()` before `Shutdown()` would break the mid-shutdown latch choreography.

The defect exists only in `!NDEBUG` test code (the test is `YB_DEBUG_ONLY_TEST`, and the sync point compiles out under `NDEBUG`), so release builds and shipped binaries are unaffected.

Note: #31258 groups two other ASAN use-after-free failures (`XClusterDBScopedTest.DeleteWhenSourceIsDown`, `PgObjectLocksTest.ExclusiveLockReleaseInvalidatesCatalogCache`) by error kind only; they use different fixtures and are almost certainly distinct defects, which this PR does not address.

Fixes #31258
Jira: DB-21123

## Test plan

- [x] Mechanism demo (macOS arm64, `clang++ -std=c++17 -g -O0 -fsanitize=address`): a standalone transliteration of the SyncPoint semantics reproduces the ASAN heap-use-after-free with the raw-pointer capture (exit 134) and runs clean with the value-capture pattern used by this fix.
- [x] `./yb_build.sh debug --cxx-test ql-transaction-test --gtest_filter QLTransactionTest.WriteBatchDuringShutdown` (macOS arm64) run before and after the fix: the latch choreography and shutdown interleaving still pass.
- [ ] CI / maintainer (Linux): `./yb_build.sh asan --cxx-test ql-transaction-test --gtest_filter QLTransactionTest.WriteBatchDuringShutdown -n 1000 -- -p 8` -- the failure is a roughly 1%-per-run race in ASAN builds; the loop is the deterministic wrapper.
