### PR TITLE
[#31805] DocDB: Fix 60s libpq connect block in CheckYsqlLaggingCatalogVersions

### DIFF
--- a/src/yb/tserver/tablet_server.cc
+++ b/src/yb/tserver/tablet_server.cc
@@ -118,6 +118,7 @@
 #include "yb/util/status_format.h"
 #include "yb/util/status_log.h"
 #include "yb/util/string_util.h"
+#include "yb/util/tsan_util.h"
 
 #include "yb/yql/pggate/util/ybc_util.h"
 #include "yb/yql/pgwrapper/libpq_utils.h"
@@ -938,6 +939,12 @@ void TabletServer::Shutdown() {
   }
   LOG(INFO) << "TabletServer shutting down...";
 
+  // Stop the periodic lagging-catalog-versions check from re-scheduling itself. An
+  // already-running check aborts quickly, because shutting_down_ is set: the callback checks it
+  // before connecting, and the libpq connect retry loop observes it through the should_stop
+  // predicate of CreateInternalPGConn.
+  check_lagging_catalog_versions_task_.StartShutdown();
+
   // Best effort to give up our ysql lease.
   // todo(zdrudi): there's lifetime issues trying to access the pg_supervisor here through
   // callbacks. Probably due to the way the MiniCluster sets up the PgSupervisor.
@@ -997,6 +1004,11 @@ void TabletServer::Shutdown() {
   // Unblock PG backends still waiting on a relcache-init connection before we join reactors below;
   // otherwise their orphaned RPCs keep their connections open and wedge reactor shutdown.
   AbortInFlightRelcacheInitConnections();
+
+  // Wait out any in-flight lagging-catalog-versions check and abort the pending one. This must
+  // happen while the messenger io_threads that run the check are still alive; the base class
+  // shutdowns below join them.
+  check_lagging_catalog_versions_task_.CompleteShutdown();
 
   DbServerBase::Shutdown();
   RpcAndWebServerBase::Shutdown();
@@ -2139,7 +2151,13 @@ void TabletServer::DoGarbageCollectionOfInvalidationMessages(
 }
 
 Status TabletServer::CheckYsqlLaggingCatalogVersions() {
-  auto deadline = CoarseMonoClock::Now() + default_client_timeout();
+  // This is a periodic best-effort check against the local postmaster: use a short connect
+  // budget instead of the general client timeout. When the postmaster is unreachable (e.g. it
+  // is already stopped while the process shuts down), the full 60s budget would pin a
+  // messenger io_thread in the connect retry loop for the whole minute per invocation
+  // (#31805). A missed cycle merely delays invalidation message garbage collection until the
+  // next interval.
+  auto deadline = CoarseMonoClock::Now() + 2s * kTimeMultiplier;
   auto pg_conn = VERIFY_RESULT(
       CreateInternalPGConn("template1", kDefaultInternalPgUser, false, deadline));
   const std::string query = "SELECT datid, local_catalog_version FROM "
@@ -2571,10 +2589,15 @@ TserverXClusterContextIf& TabletServer::GetXClusterContext() const {
 
 void TabletServer::ScheduleCheckLaggingCatalogVersions() {
   LOG(INFO) << __func__;
-  messenger()->scheduler().Schedule(
+  check_lagging_catalog_versions_task_.Bind(&messenger()->scheduler());
+  check_lagging_catalog_versions_task_.Schedule(
     [this](const Status& status) {
       if (!status.ok()) {
         LOG(INFO) << status;
+        return;
+      }
+      if (shutting_down_) {
+        LOG(INFO) << "Skipping the lagging catalog versions check: shutting down";
         return;
       }
       auto s = CheckYsqlLaggingCatalogVersions();

--- a/src/yb/tserver/tablet_server.h
+++ b/src/yb/tserver/tablet_server.h
@@ -60,6 +60,7 @@
 #include "yb/gutil/macros.h"
 
 #include "yb/rpc/rpc_fwd.h"
+#include "yb/rpc/scheduler.h"
 
 #include "yb/master/master_fwd.h"
 #include "yb/master/master_heartbeat.pb.h"
@@ -724,6 +725,11 @@ class TabletServer : public DbServerBase, public TabletServerIf {
   std::optional<ConnectivityPoller> connectivity_poller_;
 
   std::unique_ptr<docdb::ObjectLockSharedStateManager> object_lock_shared_state_manager_;
+
+  // Tracks the periodic CheckYsqlLaggingCatalogVersions task so that Shutdown() can stop the
+  // re-schedule loop and wait out an in-flight check before the messenger is shut down.
+  rpc::ScheduledTaskTracker check_lagging_catalog_versions_task_;
+
   OneTimeBool shutting_down_;
 
   // Per-database list of pending relcache-init callbacks. The first caller for a database creates

--- a/src/yb/yql/pgwrapper/pg_catalog_version-test.cc
+++ b/src/yb/yql/pgwrapper/pg_catalog_version-test.cc
@@ -15,7 +15,9 @@
 #include "yb/tserver/tserver_service.proxy.h"
 #include "yb/tserver/tserver_shared_mem.h"
 #include "yb/util/env_util.h"
+#include "yb/util/monotime.h"
 #include "yb/util/path_util.h"
+#include "yb/util/pg_util.h"
 #include "yb/util/scope_exit.h"
 #include "yb/util/status_log.h"
 #include "yb/util/string_util.h"
@@ -2937,6 +2939,47 @@ TEST_F(PgCatalogVersionTest, InvalMessageMinimalRetention) {
   VerifyCatCacheRefreshMetricsHelper(
       0 /* num_full_refreshes */, 1 /* num_delta_refreshes */,
       std::make_pair(false, true) /* at_least */);
+}
+
+// Regression test for https://github.com/yugabyte/yugabyte-db/issues/31805.
+// The periodic lagging-catalog-versions check opens a libpq connection to the
+// local postmaster. When the postmaster is unreachable (stopped, or its unix
+// socket directory removed), the connect used to retry until the general 60s
+// client deadline, pinning a messenger io_thread for the full 60s per
+// invocation, and the task re-scheduled itself unconditionally even while the
+// tablet server was shutting down. Verify that the check gives up quickly and
+// that tablet server shutdown is not delayed by the check.
+TEST_F(PgCatalogVersionTest, CheckLaggingCatalogVersionsPostmasterDown) {
+  RestartClusterWithInvalMessageEnabled(
+      { "--check_lagging_catalog_versions_interval_secs=1" });
+  auto* ts = cluster_->tablet_server(0);
+  // Ensure the postmaster on ts is up and accepting connections.
+  pg_ts = ts;
+  ASSERT_RESULT(Connect());
+
+  // Arm the log watcher before making the postmaster unreachable: LogWaiter is
+  // edge-triggered and only sees log lines emitted after it is armed.
+  LogWaiter log_waiter(ts, "Could not get the set of lagging catalog versions");
+
+  // Remove the postmaster's unix socket directory. Connection attempts fail
+  // immediately with "No such file or directory", exactly like they do after
+  // the postmaster has shut down.
+  const auto socket_dir =
+      PgDeriveSocketDir(HostPort(ts->bind_host(), ts->pgsql_rpc_port()));
+  LOG(INFO) << "Removing postmaster socket directory " << socket_dir;
+  ASSERT_OK(Env::Default()->DeleteRecursively(socket_dir));
+
+  // The check runs every second and must fail fast. Before the fix the first
+  // failure was logged only after the full 60s connect deadline expired.
+  ASSERT_OK(log_waiter.WaitFor(MonoDelta::FromSeconds(20 * kTimeMultiplier)));
+
+  // Graceful shutdown must not be blocked by an in-flight or re-scheduled
+  // check either.
+  const auto shutdown_start = MonoTime::Now();
+  ts->Shutdown(SafeShutdown::kTrue);
+  const auto shutdown_duration = MonoTime::Now() - shutdown_start;
+  LOG(INFO) << "Tablet server shutdown took " << shutdown_duration;
+  ASSERT_LT(shutdown_duration, MonoDelta::FromSeconds(30 * kTimeMultiplier));
 }
 
 // https://github.com/yugabyte/yugabyte-db/issues/27822


### PR DESCRIPTION
## Summary
Fixes #31805 (Jira: DB-21507).

`TabletServer::ScheduleCheckLaggingCatalogVersions()` scheduled the periodic lagging-catalog-versions check directly on the messenger scheduler with no `ScheduledTaskTracker`, and `CheckYsqlLaggingCatalogVersions()` opened its internal libpq connection with the general 60s client timeout (`tserver_yb_client_default_timeout_ms`). `PGConn::Connect` retries a failed connect until the deadline, so whenever the local postmaster is unreachable (stopped, restarting, or its unix socket removed) each invocation pinned a messenger io_thread for the full 60s, logged `Could not get the set of lagging catalog versions` only after a minute, and re-scheduled itself unconditionally - including during process shutdown, where the blocked io_thread stalls the `Messenger::Shutdown` reactor join: SIGTERM-to-exit took ~61s with a "dumping all thread stacks" report instead of ~1s. The `should_stop` predicate added by 2ef5075daa (#32293) only covers the window after `TabletServer::Shutdown()` has set `shutting_down_`; the runtime manifestation and the gap before `Shutdown()` remained.

This applies both fixes suggested in the issue:
- Use a short connect budget (`2s * kTimeMultiplier`) for this heartbeat-style check instead of `default_client_timeout()`. A missed cycle only delays invalidation-message garbage collection until the next interval. This also covers the non-shutdown manifestation, which the `should_stop` predicate cannot.
- Own the task with an `rpc::ScheduledTaskTracker` (`check_lagging_catalog_versions_task_`, the `PgClientServiceImpl` / `YsqlManager` pattern): the callback bails out once `shutting_down_` is set, `StartShutdown()` at the top of `TabletServer::Shutdown()` stops the re-schedule loop, and `CompleteShutdown()` runs before the base-class shutdowns join the messenger io_threads that execute the callback. The runtime re-read of `check_lagging_catalog_versions_interval_secs` on every cycle is preserved.

The new regression test drives the check at a 1s interval, removes the postmaster's unix socket directory (the exact post-postmaster-shutdown state), and asserts the check fails fast and that a subsequent graceful tserver shutdown is quick. On the unfixed tree the test fails: no check failure is logged within 20s of socket removal because the in-flight connect is still inside its 60s budget (`connect_timeout=59` visible in the conn string). With the fix, the failure is logged ~2.9s after socket removal and graceful tserver shutdown takes ~0.13s.

## Upgrade/Rollback safety
No wire-format, persisted-state, RPC-versioning, or flag-default changes. The change is node-local (an internal connect deadline for a periodic best-effort check, plus shutdown-path task tracking), so mixed-version clusters and rollback are unaffected.

## Test plan
- [x] `./yb_build.sh debug --cxx-test pg_catalog_version-test --gtest_filter PgCatalogVersionTest.CheckLaggingCatalogVersionsPostmasterDown` - new regression test; fails on the unfixed tree (log-waiter timeout after 20005ms), passes with the fix (failure logged 2.9s after socket removal; tserver shutdown 0.134s).
- [x] `./yb_build.sh debug --cxx-test pg_catalog_version-test --gtest_filter PgCatalogVersionTest.InvalMessageMinimalRetention` - the test from the issue report; passes with the fix.
- [x] `./build-support/lint.sh --rev origin/master` - 0 errors, 0 warnings.
