### PR TITLE
[#32966] DocDB: Do not GC a snapshot while a restoration is using it

### DIFF
--- a/src/yb/client/snapshot_schedule-test.cc
+++ b/src/yb/client/snapshot_schedule-test.cc
@@ -40,6 +40,7 @@
 #include "yb/tablet/tablet_retention_policy.h"
 
 #include "yb/util/backoff_waiter.h"
+#include "yb/util/logging_test_util.h"
 #include "yb/util/string_util.h"
 #include "yb/util/test_macros.h"
 
@@ -53,6 +54,7 @@ DECLARE_int32(timestamp_history_retention_interval_sec);
 DECLARE_int32(timestamp_syscatalog_history_retention_interval_sec);
 DECLARE_uint64(snapshot_coordinator_poll_interval_ms);
 DECLARE_uint64(snapshot_coordinator_cleanup_delay_ms);
+DECLARE_bool(TEST_pause_issuing_tserver_snapshot_requests);
 
 namespace yb {
 namespace client {
@@ -179,6 +181,78 @@ TEST_F(SnapshotScheduleTest, GC) {
 
     std::this_thread::sleep_for(100ms);
   }
+}
+
+// Deleting a snapshot schedule must not collect or retire it while an in-progress restoration is
+// using one of its snapshots. Retiring the schedule leaks the snapshot: nothing revisits it.
+TEST_F(SnapshotScheduleTest, DeleteScheduleDuringRestore) {
+  const auto kInterval = 5s * kTimeMultiplier;
+  constexpr int kRequiredPolls = 6;
+
+  // Retire the deleted schedule on the first poll, so the retirement races the paused restoration.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_snapshot_coordinator_cleanup_delay_ms) = 0;
+
+  google::SetVLOGLevel("master_snapshot_coordinator*", 4);
+
+  ASSERT_NO_FATALS(WriteData());
+  auto schedule_id = ASSERT_RESULT(snapshot_util_->CreateSchedule(
+      table_, kTableName.namespace_type(), kTableName.namespace_name(), WaitSnapshot::kTrue,
+      kInterval, kInterval * 100 /* retention */));
+  // Restore to a time after the schedule was created, so the sys catalog restore keeps it. This
+  // also picks the second snapshot, an interval later, so there is no race with the first.
+  auto restore_at = cluster_->mini_master(0)->Now();
+  ASSERT_OK(snapshot_util_->WaitScheduleSnapshot(schedule_id, restore_at));
+  auto snapshot_id = ASSERT_RESULT(snapshot_util_->PickSuitableSnapshot(schedule_id, restore_at));
+
+  StringWaiterLogSink coordinator_polls("Poll()");
+
+  // Hold the restoration in progress before the tablet phase.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_pause_issuing_tserver_snapshot_requests) = true;
+  auto restoration_id = ASSERT_RESULT(snapshot_util_->StartRestoration(snapshot_id, restore_at));
+
+  ASSERT_OK(snapshot_util_->WaitRestorationInState(
+      restoration_id, master::SysSnapshotEntryPB::RESTORING));
+
+  ASSERT_OK(snapshot_util_->DeleteSchedule(schedule_id));
+  const auto polls_before = coordinator_polls.GetEventCount();
+
+  // Keep these strings in sync with MasterSnapshotCoordinator and SnapshotScheduleState.
+  StringWaiterLogSink snapshot_delete_started(Format("Cleanup snapshot: $0", snapshot_id));
+  StringWaiterLogSink schedule_retired(Format("Snapshot Schedule $0 cleanup started", schedule_id));
+
+  ASSERT_OK(WaitFor(
+      [&]() -> Result<bool> {
+        SCHECK_EQ(
+            snapshot_delete_started.GetEventCount(), 0, IllegalState,
+            Format("Background deletion of snapshot $0 started while restoration $1 was using it",
+                   snapshot_id, restoration_id));
+        SCHECK_EQ(
+            schedule_retired.GetEventCount(), 0, IllegalState,
+            Format("Snapshot schedule $0 was retired while restoration $1 was still using its "
+                   "snapshot $2, which leaks the snapshot: nothing revisits a retired schedule",
+                   schedule_id, restoration_id, snapshot_id));
+        return coordinator_polls.GetEventCount() >= polls_before + kRequiredPolls;
+      },
+      60s * kTimeMultiplier,
+      Format("Coordinator to poll $0 times with deleted schedule $1 pinned by restoration $2",
+             kRequiredPolls, schedule_id, restoration_id),
+      MonoDelta::FromMilliseconds(50), 1.0));
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_pause_issuing_tserver_snapshot_requests) = false;
+  ASSERT_OK(snapshot_util_->WaitRestorationInState(
+      restoration_id, master::SysSnapshotEntryPB::RESTORED));
+
+  ASSERT_OK(snapshot_util_->WaitSnapshotCleaned(snapshot_id));
+  ASSERT_OK(WaitFor(
+      [&]() -> Result<bool> {
+        for (const auto& schedule : VERIFY_RESULT(snapshot_util_->ListSchedules())) {
+          if (TryFullyDecodeSnapshotScheduleId(schedule.id()) == schedule_id) {
+            return false;
+          }
+        }
+        return true;
+      },
+      60s * kTimeMultiplier, Format("Deleted schedule $0 to be retired", schedule_id)));
 }
 
 TEST_F(SnapshotScheduleTest, TablegroupGC) {

--- a/src/yb/client/snapshot_test_util.cc
+++ b/src/yb/client/snapshot_test_util.cc
@@ -421,6 +421,19 @@ Result<Schedules> SnapshotTestUtil::ListSchedules(const SnapshotScheduleId& id) 
   return std::move(resp.schedules());
 }
 
+Status SnapshotTestUtil::DeleteSchedule(const SnapshotScheduleId& id) {
+  master::DeleteSnapshotScheduleRequestPB req;
+  master::DeleteSnapshotScheduleResponsePB resp;
+
+  req.set_snapshot_schedule_id(id.data(), id.size());
+
+  rpc::RpcController controller;
+  controller.set_timeout(60s);
+  RETURN_NOT_OK(
+      VERIFY_RESULT(MakeBackupServiceProxy()).DeleteSnapshotSchedule(req, &resp, &controller));
+  return ResponseStatus(resp);
+}
+
 Result<TxnSnapshotId> SnapshotTestUtil::PickSuitableSnapshot(
       const SnapshotScheduleId& schedule_id, HybridTime hybrid_time) {
   auto schedules = VERIFY_RESULT(ListSchedules(schedule_id));

--- a/src/yb/client/snapshot_test_util.h
+++ b/src/yb/client/snapshot_test_util.h
@@ -135,6 +135,9 @@ class SnapshotTestUtil {
 
   Result<Schedules> ListSchedules(const SnapshotScheduleId& id = SnapshotScheduleId::Nil());
 
+  // Marks the schedule as deleted. Retirement and snapshot collection happen asynchronously.
+  Status DeleteSchedule(const SnapshotScheduleId& id);
+
   Result<TxnSnapshotId> PickSuitableSnapshot(
       const SnapshotScheduleId& schedule_id, HybridTime hybrid_time);
 

--- a/src/yb/integration-tests/snapshot-test.cc
+++ b/src/yb/integration-tests/snapshot-test.cc
@@ -57,6 +57,7 @@
 
 #include "yb/util/backoff_waiter.h"
 #include "yb/util/cast.h"
+#include "yb/util/logging_test_util.h"
 #include "yb/util/pb_util.h"
 #include "yb/util/scope_exit.h"
 #include "yb/util/status_format.h"
@@ -1000,18 +1001,85 @@ TEST_F(SnapshotTest, RescheduleOperationsForExpiredSnapshot) {
 
 class RestoreAndDeleteValidationTest : public SnapshotTest {
  public:
-  TxnSnapshotId CreateTableAndSnapshotDuringWrites(int insertions = 100) {
+  void SetUp() override {
+    // NON_RUNTIME, so it has to be set before the masters start.
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_snapshot_coordinator_poll_interval_ms) = 250;
+    google::SetVLOGLevel("master_snapshot_coordinator*", 1);
+    SnapshotTest::SetUp();
+  }
+
+  TxnSnapshotId CreateTableAndSnapshotDuringWrites(
+      int insertions = 100, std::optional<int32_t> retention_duration_hours = std::nullopt) {
     auto workload = CreateDefaultWorkload();
     workload.Setup();
     workload.Start();
     workload.WaitInserted(insertions);
-    const auto snapshot_id = CreateSnapshot();
+    const auto snapshot_id = CreateSnapshot(retention_duration_hours);
     int64_t max_inserted = workload.rows_inserted();
     workload.WaitInserted(max_inserted + insertions);
     workload.StopAndJoin();
     return snapshot_id;
   }
 };
+
+// Automatic snapshot GC must not delete a snapshot that an in-progress restoration is using.
+TEST_F(RestoreAndDeleteValidationTest, TtlExpiryDuringRestore) {
+  constexpr int kRequiredDeclinedCycles = 5;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_snapshot_coordinator_cleanup_delay_ms) = 500;
+
+  auto snapshot_id = CreateTableAndSnapshotDuringWrites(
+      100, 1 /* retention_duration_hours */);
+
+  // Hold the restoration in progress before the tablet phase.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_pause_issuing_tserver_snapshot_requests) = true;
+  auto restoration_id = ASSERT_RESULT(RestoreSnapshot(snapshot_id));
+
+  auto delete_status = DeleteSnapshot(snapshot_id);
+  ASSERT_TRUE(delete_status.IsInvalidArgument()) << delete_status;
+  ASSERT_STR_CONTAINS(
+      delete_status.ToString(), Format("restoration $0 is in progress", restoration_id));
+
+  // Expire the snapshot now that the restoration is in flight, by casting the 1 hour set
+  // before to 1ms.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_treat_hours_as_milliseconds_for_snapshot_expiry) = true;
+
+  // Keep these strings in sync with MasterSnapshotCoordinator.
+  StringWaiterLogSink expiry_considered(Format("Snapshot $0 has expired", snapshot_id));
+  StringWaiterLogSink delete_started(Format("Cleanup snapshot: $0", snapshot_id));
+
+  ASSERT_OK(WaitFor(
+      [this, &snapshot_id, &restoration_id, &expiry_considered, &delete_started]()
+          -> Result<bool> {
+        SCHECK_EQ(
+            delete_started.GetEventCount(), 0, IllegalState,
+            Format("Background deletion of snapshot $0 started while restoration $1 was using it",
+                   snapshot_id, restoration_id));
+        RETURN_NOT_OK_PREPEND(
+            CheckAllSnapshots({{snapshot_id, SysSnapshotEntryPB::COMPLETE}}),
+            Format("Snapshot $0 was GC'd while restoration $1 was using it",
+                   snapshot_id, restoration_id));
+        return expiry_considered.GetEventCount() >= kRequiredDeclinedCycles;
+      },
+      60s * kTimeMultiplier,
+      Format("Coordinator to decline deleting in-use snapshot $0 for $1 cycles",
+             snapshot_id, kRequiredDeclinedCycles),
+      MonoDelta::FromMilliseconds(50), 1.0));
+
+  // The restoration is still in progress here: the observation window above is ~1.5s.
+  // The first expiry consideration lands within one 250ms poll, then kRequiredDeclinedCycles - 1
+  // more, plus WaitFor's 50ms sampling: ~1.5s, well within the 60s timeout.
+  // Sanitizer builds stretch that timeout further via kTimeMultiplier.
+  delete_status = DeleteSnapshot(snapshot_id);
+  ASSERT_TRUE(delete_status.IsInvalidArgument()) << delete_status;
+  ASSERT_STR_CONTAINS(
+      delete_status.ToString(), Format("restoration $0 is in progress", restoration_id));
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_pause_issuing_tserver_snapshot_requests) = false;
+  ASSERT_OK(WaitForSnapshotRestorationDone(restoration_id));
+
+  // Deferred, not cancelled. Also proves the snapshot really was expirable above.
+  ASSERT_OK(WaitForSnapshotOpDone("IsSnapshotDeleted", snapshot_id));
+}
 
 TEST_F(RestoreAndDeleteValidationTest, DeleteDuringRestore) {
   auto snapshot_id = CreateTableAndSnapshotDuringWrites();

--- a/src/yb/master/master_snapshot_coordinator.cc
+++ b/src/yb/master/master_snapshot_coordinator.cc
@@ -1536,9 +1536,8 @@ class MasterSnapshotCoordinator::Impl {
           cleanup_snapshots.push_back(p->id());
         } else if (p->HasExpired(context_.Clock()->Now()) &&
                    p->initial_state() != SysSnapshotEntryPB::DELETING) {
-          // For expired snapshots that we have not already tried to delete, start the deletion
-          // workflow.
-          LOG(INFO) << "Snapshot " << p->id() << " has expired. Trying to delete it.";
+          // VLOG because TryDeleteSnapshot may decline, in which case this repeats every poll.
+          VLOG(1) << "Snapshot " << p->id() << " has expired. Trying to delete it.";
           TryDeleteSnapshot(p.get(), &schedules_data);
         } else {
           p->PrepareOperations(&operations);
@@ -1571,16 +1570,26 @@ class MasterSnapshotCoordinator::Impl {
     ScheduleOperations(restore_operations, leader_term);
   }
 
-  void TryDeleteSnapshot(SnapshotState* snapshot, PollSchedulesData* data) {
+  // Returns true if the snapshot is pinned by an in-progress restoration.
+  bool TryDeleteSnapshot(SnapshotState* snapshot, PollSchedulesData* data) REQUIRES(mutex_) {
+    auto restoration = FindInProgressRestorationUsingSnapshot(snapshot->id());
+    if (restoration) {
+      VLOG(1) << "Not deleting snapshot " << snapshot->id() << "/" << snapshot->schedule_id()
+              << ": restoration " << restoration->get().restoration_id()
+              << " is in progress and using it";
+      return true;
+    }
+
     auto delete_status = snapshot->TryStartDelete();
     if (!delete_status.ok()) {
       VLOG(1) << "Unable to delete snapshot " << snapshot->id() << "/" << snapshot->schedule_id()
               << ": " << delete_status << ", state: " << snapshot->ToString();
-      return;
+      return false;
     }
 
     VLOG(1) << "Cleanup snapshot: " << snapshot->id() << "/" << snapshot->schedule_id();
     data->delete_snapshots.push_back(snapshot->id());
+    return false;
   }
 
   void PollSchedulesPrepare(PollSchedulesData* data) REQUIRES(mutex_) {
@@ -1589,8 +1598,16 @@ class MasterSnapshotCoordinator::Impl {
       HybridTime last_snapshot_time;
       if (schedule->deleted()) {
         auto range = snapshots_.get<ScheduleTag>().equal_range(schedule->id());
+        bool pinned_by_restoration = false;
         for (const auto& snapshot : boost::make_iterator_range(range.first, range.second)) {
-          TryDeleteSnapshot(snapshot.get(), data);
+          if (TryDeleteSnapshot(snapshot.get(), data)) {
+            pinned_by_restoration = true;
+          }
+        }
+        if (pinned_by_restoration) {
+          VLOG(1) << "Not retiring deleted snapshot schedule " << schedule->id()
+                  << ": a restoration is in progress and using one of its snapshots";
+          continue;
         }
       } else {
         auto [begin, end] = snapshots_.get<ScheduleTag>().equal_range(schedule->id());


### PR DESCRIPTION
## Summary

`MasterSnapshotCoordinator::Delete()` -- the user-facing RPC path -- refuses to delete a snapshot
that an in-progress restoration is using, via `FindInProgressRestorationUsingSnapshot()`. The
background GC paths in `PollSchedules()` go through `TryDeleteSnapshot()`, which had no such guard,
so a snapshot could be deleted out from under a live restoration in two ways:

1. **TTL expiry** -- an expired snapshot was deleted even while a restoration was using it.
2. **Deleted snapshot schedule** -- deleting a schedule collects its snapshots and then retires the
   schedule. If a restoration was using one of those snapshots, the snapshot was deleted; and
   because nothing ever revisits a retired schedule, the snapshot was leaked.

This moves the in-progress-restoration guard into `TryDeleteSnapshot()` so both background paths
honor it, and has it report whether the snapshot is pinned, so the deleted-schedule path can defer
retiring the schedule until no restoration is using any of its snapshots.

The `Snapshot ... has expired. Trying to delete it.` line drops from `INFO` to `VLOG(1)`: now that
the delete can be declined, it would otherwise repeat on every coordinator poll.

## Upgrade/Rollback safety

No proto, on-disk format, catalog, or gflag-default changes. The change is confined to the master
leader's in-memory snapshot-GC scheduling decisions.

- **Upgrade:** a new master leader defers GC of a snapshot pinned by an in-progress restoration
  rather than deleting it. Nothing is persisted differently, so a mixed-version master quorum
  behaves according to whichever node currently holds leadership; there is no divergent state to
  reconcile.
- **Rollback:** an older master leader returns to the previous behavior, where background GC may
  delete a snapshot mid-restoration. No migration or cleanup is required, and the new code writes
  no state that older code would need to interpret.

## Test plan

- [x] `SnapshotScheduleTest.DeleteScheduleDuringRestore` (new) -- deleting a snapshot schedule while
      a restoration is using one of its snapshots neither collects the snapshot nor retires the
      schedule; both proceed once the restoration finishes.
- [x] `RestoreAndDeleteValidationTest.TtlExpiryDuringRestore` (new) -- a snapshot that reaches its
      TTL mid-restoration is not GC'd, and is deleted after the restoration completes (deferred,
      not cancelled).
- [ ] Existing neighbours in the same suites (`SnapshotScheduleTest.GC`,
      `RestoreAndDeleteValidationTest.DeleteDuringRestore`) -- to confirm no regression in the
      paths this touches.
