### PR TITLE
DocDB: Tombstone tablet snapshots before cleanup

### DIFF
--- a/src/yb/integration-tests/snapshot-test.cc
+++ b/src/yb/integration-tests/snapshot-test.cc
@@ -10,6 +10,8 @@
 // or implied.  See the License for the specific language governing permissions and limitations
 // under the License.
 
+#include <algorithm>
+
 #include <gtest/gtest.h>
 
 #include "yb/client/snapshot_test_util.h"
@@ -60,6 +62,7 @@
 #include "yb/util/pb_util.h"
 #include "yb/util/scope_exit.h"
 #include "yb/util/status_format.h"
+#include "yb/util/test_thread_holder.h"
 
 using namespace std::literals;
 
@@ -69,6 +72,7 @@ DECLARE_int32(log_min_seconds_to_retain);
 DECLARE_uint64(snapshot_coordinator_cleanup_delay_ms);
 DECLARE_uint64(snapshot_coordinator_poll_interval_ms);
 DECLARE_uint32(default_snapshot_retention_hours);
+DECLARE_bool(TEST_pause_after_tombstoning_snapshot);
 DECLARE_bool(TEST_tablet_verify_flushed_frontier_after_modifying);
 DECLARE_bool(TEST_treat_hours_as_milliseconds_for_snapshot_expiry);
 DECLARE_bool(TEST_fail_tserver_snapshot_op);
@@ -117,6 +121,21 @@ using master::SysSnapshotEntryPB;
 using master::TableIdentifierPB;
 
 const YBTableName kTableName(YQL_DATABASE_CQL, "my_keyspace", "snapshot_test_table");
+
+TEST(TabletSnapshotsTest, DeletedSnapshotDirectoryName) {
+  const std::string snapshot_dir = "/tmp/snapshots/snapshot.id";
+  const auto deleted_snapshot_dir =
+      tablet::TabletSnapshots::DeletedSnapshotDir(snapshot_dir, OpId(7, 1234));
+
+  ASSERT_EQ(deleted_snapshot_dir, snapshot_dir + ".7.1234.deleted.tmp");
+  ASSERT_TRUE(tablet::TabletSnapshots::IsTempSnapshotDir(deleted_snapshot_dir));
+  ASSERT_TRUE(tablet::TabletSnapshots::IsDeletedSnapshotDir(deleted_snapshot_dir));
+  ASSERT_TRUE(tablet::TabletSnapshots::IsDeletedSnapshotDir(
+      "/tmp/snapshots/snapshot.id.with.dots.7.1234.deleted.tmp"));
+  ASSERT_FALSE(tablet::TabletSnapshots::IsDeletedSnapshotDir(snapshot_dir + ".tmp"));
+  ASSERT_FALSE(tablet::TabletSnapshots::IsDeletedSnapshotDir(
+      snapshot_dir + ".invalid.1234.deleted.tmp"));
+}
 
 template <typename MiniClusterType>
 class SnapshotTestBase : public YBMiniClusterTestBase<MiniClusterType> {
@@ -560,9 +579,51 @@ TEST_F(SnapshotTest, CreateSnapshot) {
   ASSERT_OK(cluster_->RestartSync());
 }
 
+// Verifies that physical cleanup only starts after the snapshot directory is tombstoned.
+TEST_F(SnapshotTest, DeleteSnapshotTombstonesBeforePhysicalCleanup) {
+  SetupWorkload();
+  const auto snapshot_id = CreateSnapshot();
+  ASSERT_NO_FATALS(VerifySnapshotFiles(snapshot_id));
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_pause_after_tombstoning_snapshot) = true;
+  TestThreadHolder delete_thread_holder;
+  Status delete_status;
+  delete_thread_holder.AddThreadFunctor([&] {
+    delete_status = DeleteSnapshotAndWait(snapshot_id);
+  });
+  auto unblock_deletion = ScopeExit([&] {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_pause_after_tombstoning_snapshot) = false;
+    delete_thread_holder.JoinAll();
+  });
+
+  for (size_t i = 0; i < cluster_->num_tablet_servers(); ++i) {
+    MiniTabletServer* const ts = cluster_->mini_tablet_server(i);
+    for (const auto& tablet_peer : ts->server()->tablet_manager()->GetTabletPeers()) {
+      const auto top_snapshots_dir = tablet_peer->tablet_metadata()->snapshots_dir();
+      const auto snapshot_dir = JoinPathSegments(top_snapshots_dir, snapshot_id.ToString());
+      auto* const env = tablet_peer->tablet_metadata()->fs_manager()->env();
+      ASSERT_OK(WaitFor([&] {
+        if (env->FileExists(snapshot_dir)) {
+          return false;
+        }
+        const auto children = env->GetChildren(top_snapshots_dir, ExcludeDots::kTrue);
+        if (!children.ok()) {
+          return false;
+        }
+        return std::any_of(children->begin(), children->end(), [&](const auto& child) {
+          return child.starts_with(snapshot_id.ToString()) &&
+                 tablet::TabletSnapshots::IsDeletedSnapshotDir(child);
+        });
+      }, 15s, Format("Wait for snapshot $0 to be tombstoned", snapshot_id)));
+    }
+  }
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_pause_after_tombstoning_snapshot) = false;
+  delete_thread_holder.JoinAll();
+  ASSERT_OK(delete_status);
+}
+
 // Tests that a non-imported snapshot hides a table that is dropped subsequently.
-// Until the snapshot is deleted, the table is hidden and once the
-// snapshot gets deleted, the table is subsequently deleted.
 TEST_F(SnapshotTest, HideTablesCoveredBySnapshot) {
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_snapshot_coordinator_cleanup_delay_ms) = 500;
   auto workload = SetupWorkload(); // Used to create table

--- a/src/yb/tablet/tablet_bootstrap.cc
+++ b/src/yb/tablet/tablet_bootstrap.cc
@@ -1998,12 +1998,15 @@ class TabletBootstrap {
           const string snapshot_dir = JoinPathSegments(top_snapshots_dir, dir_name);
 
           if (TabletSnapshots::IsTempSnapshotDir(snapshot_dir)) {
-            LOG_WITH_PREFIX(INFO) << "Deleting old temporary snapshot directory " << snapshot_dir;
+            const auto snapshot_dir_type =
+                TabletSnapshots::IsDeletedSnapshotDir(snapshot_dir) ? "deleted" : "temporary";
+            LOG_WITH_PREFIX(INFO) << "Deleting old " << snapshot_dir_type
+                                  << " snapshot directory " << snapshot_dir;
 
             s = meta_->fs_manager()->env()->DeleteRecursively(snapshot_dir);
             if (!s.ok()) {
-              LOG_WITH_PREFIX(WARNING) << "Cannot delete old temporary snapshot directory "
-                                       << snapshot_dir << ": " << s;
+              LOG_WITH_PREFIX(WARNING) << "Cannot delete old " << snapshot_dir_type
+                                       << " snapshot directory " << snapshot_dir << ": " << s;
             }
 
             s = meta_->fs_manager()->env()->SyncDir(top_snapshots_dir);

--- a/src/yb/tablet/tablet_snapshots.cc
+++ b/src/yb/tablet/tablet_snapshots.cc
@@ -45,6 +45,7 @@
 #include "yb/util/format.h"
 #include "yb/util/logging.h"
 #include "yb/util/operation_counter.h"
+#include "yb/util/path_util.h"
 #include "yb/util/random_util.h"
 #include "yb/util/scope_exit.h"
 #include "yb/util/status_format.h"
@@ -71,6 +72,10 @@ DEFINE_test_flag(int32, delay_tablet_export_metadata_ms, 0,
 DEFINE_test_flag(double, delay_create_snapshot_probability, 0.0,
     "The probability to delay creating snapshot by 1 second");
 
+DEFINE_test_flag(bool, pause_after_tombstoning_snapshot, false,
+    "If true, pause snapshot deletion after tombstoning the snapshot directory "
+    "until the flag is reset.");
+
 DEFINE_test_flag(bool, pause_create_checkpoint, false,
     "If true, pause after acquiring checkpoint lock in CreateCheckpoint "
     "until the flag is reset.");
@@ -80,8 +85,23 @@ namespace yb::tablet {
 namespace {
 
 const std::string kTempSnapshotDirSuffix = ".tmp";
+const std::string kDeletedSnapshotDirSuffix = ".deleted.tmp";
 const std::string kTabletMetadataFile = "tablet.metadata";
 const std::string kLastSnapshotPrefix = "last_snapshot.";
+
+Result<bool> IsSnapshotDirectory(Env& env, const std::string& path) {
+  auto is_directory = env.IsDirectory(path);
+  if (!is_directory.ok()) {
+    if (is_directory.status().IsNotFound()) {
+      return false;
+    }
+    return is_directory.status();
+  }
+  if (!*is_directory) {
+    return STATUS_FORMAT(IllegalState, "Snapshot path $0 is not a directory", path);
+  }
+  return true;
+}
 
 std::string TabletMetadataFile(const std::string& dir) {
   return JoinPathSegments(dir, kTabletMetadataFile);
@@ -173,6 +193,35 @@ std::string TabletSnapshots::SnapshotsDirName(const std::string& rocksdb_dir) {
 
 bool TabletSnapshots::IsTempSnapshotDir(const std::string& dir) {
   return dir.ends_with(kTempSnapshotDirSuffix);
+}
+
+bool TabletSnapshots::IsDeletedSnapshotDir(const std::string& dir) {
+  const auto base_name = BaseName(dir);
+  if (!base_name.ends_with(kDeletedSnapshotDirSuffix)) {
+    return false;
+  }
+
+  const auto op_id_end = base_name.size() - kDeletedSnapshotDirSuffix.size();
+  if (op_id_end == 0) {
+    return false;
+  }
+  const auto index_separator = base_name.rfind('.', op_id_end - 1);
+  if (index_separator == std::string::npos || index_separator == 0) {
+    return false;
+  }
+  const auto term_separator = base_name.rfind('.', index_separator - 1);
+  if (term_separator == std::string::npos || term_separator == 0) {
+    return false;
+  }
+
+  const auto op_id = OpId::FromString(
+      base_name.substr(term_separator + 1, op_id_end - term_separator - 1));
+  return op_id.ok() && op_id->is_valid_not_empty();
+}
+
+std::string TabletSnapshots::DeletedSnapshotDir(
+    const std::string& snapshot_dir, const OpId& delete_op_id) {
+  return Format("$0.$1$2", snapshot_dir, delete_op_id, kDeletedSnapshotDirSuffix);
 }
 
 bool TabletSnapshots::IsLastSnapshotTimeFilePath(const std::string& dir) {
@@ -661,29 +710,81 @@ Result<std::string> TabletSnapshots::RestoreToTemporary(
 Status TabletSnapshots::Delete(const SnapshotOperation& operation) {
   const std::string top_snapshots_dir = metadata().snapshots_dir();
   const auto& snapshot_id = operation.request()->snapshot_id();
-  auto txn_snapshot_id = TryFullyDecodeTxnSnapshotId(snapshot_id);
+  const auto txn_snapshot_id = TryFullyDecodeTxnSnapshotId(snapshot_id);
   const std::string snapshot_dir = JoinPathSegments(
       top_snapshots_dir, !txn_snapshot_id ? snapshot_id.ToBuffer() : txn_snapshot_id.ToString());
+  const auto tombstone_dir = DeletedSnapshotDir(snapshot_dir, operation.op_id());
+  Env& env = this->env();
 
-  std::lock_guard lock(create_checkpoint_lock());
-  Env* const env = metadata().fs_manager()->env();
-
-  if (env->FileExists(snapshot_dir)) {
-    const Status deletion_status = env->DeleteRecursively(snapshot_dir);
-    if (PREDICT_FALSE(!deletion_status.ok())) {
-      LOG_WITH_PREFIX(WARNING) << "Cannot recursively delete snapshot dir " << snapshot_dir
-                               << ": " << deletion_status;
+  bool delete_tombstone = false;
+  {
+    std::lock_guard lock(create_checkpoint_lock());
+    const auto snapshot_dir_exists = IsSnapshotDirectory(env, snapshot_dir);
+    if (!snapshot_dir_exists.ok()) {
+      LOG_WITH_PREFIX(WARNING) << "Cannot check snapshot dir " << snapshot_dir
+                               << " while deleting it: " << snapshot_dir_exists.status();
+      return Status::OK();
+    }
+    const auto tombstone_dir_exists = IsSnapshotDirectory(env, tombstone_dir);
+    if (!tombstone_dir_exists.ok()) {
+      LOG_WITH_PREFIX(WARNING) << "Cannot check deleted snapshot dir " << tombstone_dir
+                               << " while deleting snapshot dir " << snapshot_dir
+                               << ": " << tombstone_dir_exists.status();
+      return Status::OK();
     }
 
-    const Status sync_status = env->SyncDir(top_snapshots_dir);
-    if (PREDICT_FALSE(!sync_status.ok())) {
-      LOG_WITH_PREFIX(WARNING) << "Cannot sync top snapshots dir " << top_snapshots_dir
-                               << ": " << sync_status;
+    if (*snapshot_dir_exists && *tombstone_dir_exists) {
+      LOG_WITH_PREFIX(WARNING) << "Both snapshot dir " << snapshot_dir
+                               << " and deleted snapshot dir " << tombstone_dir << " exist";
+      return Status::OK();
+    }
+
+    if (*snapshot_dir_exists) {
+      const Status rename_status = env.RenameFile(snapshot_dir, tombstone_dir);
+      if (PREDICT_FALSE(!rename_status.ok())) {
+        LOG_WITH_PREFIX(WARNING) << "Cannot tombstone snapshot dir " << snapshot_dir
+                                 << " as " << tombstone_dir << ": " << rename_status;
+        return Status::OK();
+      }
+      LOG_WITH_PREFIX(INFO) << "Tombstoned snapshot dir " << snapshot_dir
+                            << " as " << tombstone_dir;
+    }
+
+    if (*snapshot_dir_exists || *tombstone_dir_exists) {
+      const Status sync_status = env.SyncDir(top_snapshots_dir);
+      if (PREDICT_FALSE(!sync_status.ok())) {
+        LOG_WITH_PREFIX(WARNING) << "Cannot sync top snapshots dir " << top_snapshots_dir
+                                 << " after tombstoning snapshot dir " << snapshot_dir
+                                 << ": " << sync_status;
+      }
+      delete_tombstone = true;
     }
   }
 
-  LOG_WITH_PREFIX(INFO) << "Complete snapshot deletion on tablet in folder: " << snapshot_dir;
+  if (!delete_tombstone) {
+    LOG_WITH_PREFIX(INFO) << "Complete snapshot deletion on tablet in folder: " << snapshot_dir;
+    return Status::OK();
+  }
 
+  TEST_PAUSE_IF_FLAG(TEST_pause_after_tombstoning_snapshot);
+
+  {
+    SCOPED_WAIT_STATUS(Snapshot_CleanupSnapshotDir);
+    const Status deletion_status = env.DeleteRecursively(tombstone_dir);
+    if (PREDICT_FALSE(!deletion_status.ok())) {
+      LOG_WITH_PREFIX(WARNING) << "Cannot recursively delete tombstoned snapshot dir "
+                               << tombstone_dir << ": " << deletion_status;
+    }
+  }
+
+  const Status sync_status = env.SyncDir(top_snapshots_dir);
+  if (PREDICT_FALSE(!sync_status.ok())) {
+    LOG_WITH_PREFIX(WARNING) << "Cannot sync top snapshots dir " << top_snapshots_dir
+                             << " after deleting tombstoned snapshot dir " << tombstone_dir
+                             << ": " << sync_status;
+  }
+
+  LOG_WITH_PREFIX(INFO) << "Complete snapshot deletion on tablet in folder: " << snapshot_dir;
   return Status::OK();
 }
 

--- a/src/yb/tablet/tablet_snapshots.h
+++ b/src/yb/tablet/tablet_snapshots.h
@@ -104,6 +104,11 @@ class TabletSnapshots : public TabletComponent {
 
   static bool IsTempSnapshotDir(const std::string& dir);
 
+  static bool IsDeletedSnapshotDir(const std::string& dir);
+
+  static std::string DeletedSnapshotDir(
+      const std::string& snapshot_dir, const OpId& delete_op_id);
+
   static bool IsLastSnapshotTimeFilePath(const std::string& dir);
 
  private:

--- a/src/yb/tserver/remote_bootstrap_snapshots.cc
+++ b/src/yb/tserver/remote_bootstrap_snapshots.cc
@@ -184,6 +184,7 @@ Status RemoteBootstrapSnapshotsSource::Init() {
 
   for (const string& dir_name : snapshots) {
     const std::string snapshot_dir = JoinPathSegments(top_snapshots_dir, dir_name);
+    // Deleted snapshots use the .deleted.tmp suffix and must not be transferred.
     if (tablet::TabletSnapshots::IsTempSnapshotDir(snapshot_dir)) {
       continue;
     }

--- a/src/yb/tserver/ts_snapshots_page_handler.cc
+++ b/src/yb/tserver/ts_snapshots_page_handler.cc
@@ -115,7 +115,10 @@ Result<NamespaceToSnapshotToInodesMap> GetNamespaceToSnapshotToInodesMap(
     auto snapshot_dirs = VERIFY_RESULT(env->GetChildren(snapshots_dir, ExcludeDots::kTrue));
     for (const auto& snapshot_id : snapshot_dirs) {
       auto snapshot_dir = JoinPathSegments(snapshots_dir, snapshot_id);
-      if (!env->DirExists(snapshot_dir)) continue;
+      if (tablet::TabletSnapshots::IsTempSnapshotDir(snapshot_dir) ||
+          !env->DirExists(snapshot_dir)) {
+        continue;
+      }
 
       uint64_t snapshot_creation_time = 0;
       if (auto it = snapshot_metadata.find(snapshot_id); it != snapshot_metadata.end()) {


### PR DESCRIPTION
Rename deleted tablet snapshot directories to durable tombstones before physical cleanup. Keep recursive deletion outside the checkpoint lock, retain startup recovery through the existing temporary-directory path, and hide tombstones from snapshot consumers.