### PR TITLE
[#33009] DocDB: Roll back index backfill when the completion writes fail

### DIFF
--- a/src/yb/master/backfill_index.cc
+++ b/src/yb/master/backfill_index.cc
@@ -114,6 +114,10 @@ DEFINE_test_flag(int32, slowdown_backfill_alter_table_rpcs_ms, 0,
 DEFINE_test_flag(int32, slowdown_backfill_job_deletion_ms, 0,
     "Slows down backfill job deletion so that backfill job can be read by test.");
 
+DEFINE_test_flag(bool, fail_backfill_job_deletion_once, false,
+    "Fails the sys-catalog write that clears the backfill job, then resets itself. Simulates a "
+    "transient write failure on the last of the backfill completion writes.");
+
 DEFINE_test_flag(bool, skip_index_backfill, false,
     "Skips backfilling the data on tservers and leaves the index in inconsistent state.");
 
@@ -1016,9 +1020,20 @@ Status BackfillTable::Done(const Status& s, const std::unordered_set<TableId>& f
     }
     LOG_WITH_PREFIX(INFO) << "Completed backfilling the index table.";
     StopLivenessMonitor();
-    RETURN_NOT_OK_PREPEND(
-        MarkAllIndexesAsSuccess(), "Failed to mark indexes as successfully backfilled.");
-    RETURN_NOT_OK_PREPEND(UpdateIndexPermissionsForIndexes(), "Failed to complete backfill.");
+    const auto completion_status = [this]() -> Status {
+      RETURN_NOT_OK_PREPEND(
+          MarkAllIndexesAsSuccess(), "Failed to mark indexes as successfully backfilled.");
+      RETURN_NOT_OK_PREPEND(UpdateIndexPermissionsForIndexes(), "Failed to complete backfill.");
+      return Status::OK();
+    }();
+    if (!completion_status.ok()) {
+      LOG_WITH_PREFIX(WARNING) << "Failed to complete the backfill: " << completion_status;
+      RETURN_NOT_OK_PREPEND(
+          MarkIndexesAsFailed(requested_index_ids_, completion_status.message().ToBuffer()),
+          "Couldn't mark indexes as failed");
+      RETURN_NOT_OK(CheckIfDone());
+      return completion_status;
+    }
   } else {
     VLOG_WITH_PREFIX(1) << "Still backfilling " << tablets_pending_ << " more tablets.";
   }
@@ -1264,6 +1279,10 @@ Status BackfillTable::ClearCheckpointStateInTablets() {
     DCHECK_LE(l.data().pb.backfill_jobs_size(), 1) << "For now we only expect to have up to 1 "
                                                        "outstanding backfill job.";
     l.mutable_data()->pb.clear_backfill_jobs();
+    if (PREDICT_FALSE(FLAGS_TEST_fail_backfill_job_deletion_once)) {
+      ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_fail_backfill_job_deletion_once) = false;
+      return STATUS(InternalError, "TEST: could not clear backfilling timestamp.");
+    }
     RETURN_NOT_OK_PREPEND(
         master_->catalog_manager_impl()->sys_catalog_->Upsert(
             epoch_, indexed_table_),

--- a/src/yb/master/backfill_index.cc
+++ b/src/yb/master/backfill_index.cc
@@ -1027,6 +1027,7 @@ Status BackfillTable::Done(const Status& s, const std::unordered_set<TableId>& f
       return Status::OK();
     }();
     if (!completion_status.ok()) {
+      state_.store(State::kFailed, std::memory_order_release);
       LOG_WITH_PREFIX(WARNING) << "Failed to complete the backfill: " << completion_status;
       RETURN_NOT_OK_PREPEND(
           MarkIndexesAsFailed(requested_index_ids_, completion_status.message().ToBuffer()),

--- a/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
+++ b/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
@@ -183,6 +183,18 @@ class PgIndexBackfillTest : public LibPqTestBase, public ::testing::WithParamInt
         "Wait for IndexScan");
   }
 
+  Result<bool> IsBackfilling(const TableId& table_id) {
+    master::GetTableSchemaRequestPB req;
+    req.mutable_table()->set_table_id(table_id);
+    master::GetTableSchemaResponsePB resp;
+    rpc::RpcController rpc;
+    rpc.set_timeout(30s * kTimeMultiplier);
+    RETURN_NOT_OK(
+        cluster_->GetLeaderMasterProxy<master::MasterDdlProxy>().GetTableSchema(req, &resp, &rpc));
+    SCHECK(!resp.has_error(), IllegalState, resp.error().status().message());
+    return resp.is_backfilling();
+  }
+
   bool HasClientTimedOut(const Status& s);
   void TestSimpleBackfill(const std::string& table_create_suffix = "");
   void TestLargeBackfill(const int num_rows);
@@ -3986,6 +3998,28 @@ TEST_P(PgIndexBackfillCancellationWithoutFixTest, BackfillContinuesAfterBackendK
   thread_holder_.JoinAll();
   EXPECT_FALSE(create_index_completed_ok_.load())
       << "CREATE INDEX completed before pg_terminate_backend interrupted it";
+}
+
+// Fails the last completion write and checks the error reaches the requester and the latch clears.
+TEST_P(PgIndexBackfillTest, ReportsTransientSysCatalogWriteFailure) {
+  ASSERT_OK(conn_->ExecuteFormat("CREATE TABLE $0 (i int)", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat("INSERT INTO $0 VALUES (generate_series(1, 100))", kTableName));
+
+  auto client = ASSERT_RESULT(cluster_->CreateClient());
+  const auto table_id =
+      ASSERT_RESULT(GetTableIdByTableName(client.get(), kDatabaseName, kTableName));
+
+  ASSERT_OK(cluster_->SetFlagOnMasters("TEST_fail_backfill_job_deletion_once", "true"));
+
+  const auto status = conn_->ExecuteFormat("CREATE INDEX $0 ON $1 (i)", kIndexName, kTableName);
+  ASSERT_NOK(status);
+  ASSERT_STR_CONTAINS(status.ToString(), "Failed to complete backfill");
+  ASSERT_STR_CONTAINS(status.ToString(), "TEST: could not clear backfilling timestamp");
+
+  // The latch clears after the client sees the error.
+  ASSERT_OK(WaitFor(
+      [this, &table_id]() -> Result<bool> { return !VERIFY_RESULT(IsBackfilling(table_id)); },
+      60s * kTimeMultiplier, "the backfill latch to be released"));
 }
 
 } // namespace yb::pgwrapper


### PR DESCRIPTION
## Summary

`BackfillTable::Done()` CASes the backfill to the terminal `kSuccess` state **before** the durable
sys-catalog writes that finish the index build:

- **W2** `MarkAllIndexesAsSuccess()`
- **W3** `AllowCompactionsToGCDeleteMarkers`
- **W4** `MultiStageAlterTable::UpdateIndexPermission`
- **W5/W6** `ClearCheckpointStateInTablets`

then the non-write steps: `ClearIsBackfilling()`, `ReenableSplittingForBackfillingTable()`,
`SendAlterTableRequest()`.

If any of those writes fails transiently:

- `TableInfo::is_backfilling_` stays latched, so no new backfill can start on the table
- tablet splitting stays disabled for the table
- the backfill job is never cleared from the sys catalog
- the requester's `CREATE INDEX` waits out its own `backfill_index_client_rpc_timeout_ms`, 24h by
  default, with no indication of what went wrong

`is_backfilling_` is in-memory only, so today the sole recovery is a master restart.

## Fix

Treat a failure of the completion writes as a backfill failure and roll the index build back, rather
than leaving it in a state that can neither complete nor be retried.

On failure, `Done()` marks the requested indexes `FAILED` with the underlying error and re-runs
`CheckIfDone()`. The second pass through `UpdateIndexPermissionsForIndexes()` reads the persisted
`FAILED` `backfill_state`, so it targets `INDEX_PERM_WRITE_AND_DELETE_WHILE_REMOVING` (the rollback
ladder) instead of `INDEX_PERM_READ_WRITE_AND_DELETE`, skips the delete-marker GC write, and then
reaches `ClearIsBackfilling()`, re-enables splitting, and sends the alter -- unwedging the table.

The persisted `backfill_error_message` is copied into `fully_applied_indexes` by
`CopySchemaDetailsToFullyApplied`, so it reaches PGSQL clients through `GetTableSchema` without any
extra mirroring. `CREATE INDEX` now fails promptly, naming the real cause. That also covers #32976.

## Trade-offs

- **A backfill that actually succeeded is discarded.** If the sys-catalog write times out after hours
  of backfilling, `CREATE INDEX` now fails and the index rolls back, where before the data work was
  (invisibly) done. Failing in minutes and letting the user retry beats hanging for 24h and then
  failing anyway, but it is a real cost.
- **Not convergent.** The rollback itself needs two more sys-catalog writes to land. If one of those
  also fails, the table re-wedges exactly as before, still recoverable only by a master restart. This
  narrows the window substantially but does not close it; a completion-retry state machine would, and
  is a larger change.

## Test plan

New test `PgIndexBackfillTest.ReportsTransientSysCatalogWriteFailure` injects a one-shot failure into
the last completion write (`TEST_fail_backfill_job_deletion_once`, which resets itself so the
rollback's retry succeeds) and asserts that the requester's `CREATE INDEX` fails with both the stage
and the root cause, and that `is_backfilling_` clears afterwards.

- [x] `./yb_build.sh --no-ccache --cxx-test pgwrapper_pg_index_backfill-test --gtest_filter '*ReportsTransientSysCatalogWriteFailure*'` -- both parameterized instances pass (20.0s / 18.3s), debug clang21 arm64

The full `pgwrapper_pg_index_backfill-test` suite has not been run locally; leaving that to CI.
