### PR TITLE
[BACKPORT 2025.2][#27835] CDC: Dropping associated streams during a database drop

### DIFF
--- a/src/yb/integration-tests/cdcsdk_ysql-test.cc
+++ b/src/yb/integration-tests/cdcsdk_ysql-test.cc
@@ -10,6 +10,8 @@
 // or implied.  See the License for the specific language governing permissions and limitations
 // under the License.
 
+#include <atomic>
+
 #include <gtest/gtest.h>
 
 #include "yb/cdc/cdc_service.pb.h"
@@ -37,6 +39,7 @@
 #include "yb/util/logging_test_util.h"
 #include "yb/util/metrics.h"
 #include "yb/util/test_macros.h"
+#include "yb/util/test_thread_holder.h"
 #include "yb/util/tostring.h"
 
 DECLARE_uint32(wait_for_ysql_backends_catalog_version_client_master_rpc_timeout_ms);
@@ -12715,6 +12718,244 @@ TEST_F(CDCSDKYsqlTest, TestUPAMMovesRetentionBarriersForCatalogTablet) {
   auto tablet_peer_ptr = ASSERT_NOTNULL(test_cluster_.mini_cluster_->mini_master()->tablet_peer());
   // Checking that UpdatePeersAndMetrics has not expired the tablet checkpoint.
   ASSERT_NE(tablet_peer_ptr->GetLatestCheckPoint(), OpId::Max());
+}
+
+TEST_F(CDCSDKYsqlTest, TestUPAMMovesRetentionBarriersOnDBDropAndMasterRestart) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_yb_enable_cdc_consistent_snapshot_streams) = true;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_update_min_cdc_indices_interval_secs) = 1;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdc_state_checkpoint_update_interval_ms) = 0;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdcsdk_retention_barrier_no_revision_interval_secs) = 0;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdc_intent_retention_ms) = 60000;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_cdcsdk_disable_deleted_stream_cleanup) = true;
+
+  ASSERT_OK(SetUpWithParams(
+      1 /* rf */, 1 /* num_masters */, false /* colocated */,
+      true /* cdc_populate_safepoint_record */));
+  auto table1 = ASSERT_RESULT(CreateTable(&test_cluster_, kNamespaceName, kTableName));
+  google::protobuf::RepeatedPtrField<master::TabletLocationsPB> table1_tablets;
+  ASSERT_OK(test_client()->GetTablets(table1, 0, &table1_tablets, nullptr));
+  ASSERT_EQ(table1_tablets.size(), 1);
+
+  const std::string kNamespaceName2 = Format("$0_2", kNamespaceName);
+  const std::string kTableName2 = Format("$0_2", kTableName);
+  ASSERT_OK(CreateDatabase(&test_cluster_, kNamespaceName2));
+  auto table2 = ASSERT_RESULT(CreateTable(&test_cluster_, kNamespaceName2, kTableName2));
+  google::protobuf::RepeatedPtrField<master::TabletLocationsPB> table2_tablets;
+  ASSERT_OK(test_client()->GetTablets(table2, 0, &table2_tablets, nullptr));
+  ASSERT_EQ(table2_tablets.size(), 1);
+
+  auto stream_id1 = ASSERT_RESULT(CreateConsistentSnapshotStreamWithReplicationSlot(
+      "slot_1", CDCSDKSnapshotOption::EXPORT_SNAPSHOT, false, kNamespaceName));
+  auto stream_id2 = ASSERT_RESULT(CreateConsistentSnapshotStreamWithReplicationSlot(
+      "slot_2", CDCSDKSnapshotOption::EXPORT_SNAPSHOT, false, kNamespaceName2));
+
+  ASSERT_OK(DropDB(&test_cluster_));
+
+  auto master = test_cluster()->mini_master();
+  ASSERT_OK(master->Restart());
+  ASSERT_OK(test_cluster()->mini_tablet_server(0)->Restart());
+  SleepFor(MonoDelta::FromSeconds(5));
+
+  // Keep polling table2 using a thread to ensure that the stream_id2 doesn't expire.
+  std::atomic<bool> stop_get_changes_thread{false};
+  std::thread get_changes_thread([&stream_id2, &table2_tablets, &stop_get_changes_thread, this]() {
+    GetChangesResponsePB change_resp;
+    const CDCSDKCheckpointPB* explicit_checkpoint = &CDCSDKCheckpointPB::default_instance();
+    while (!stop_get_changes_thread.load()) {
+      change_resp = ASSERT_RESULT(GetChangesFromCDCWithExplictCheckpoint(
+          stream_id2, table2_tablets, explicit_checkpoint, explicit_checkpoint));
+      ASSERT_FALSE(change_resp.has_error());
+      explicit_checkpoint = &change_resp.cdc_sdk_checkpoint();
+      SleepFor(MonoDelta::FromSeconds(1));
+    }
+  });
+
+  // Checking that the stream is still present.
+  auto& cm = master->catalog_manager_impl();
+  auto stream_info = ASSERT_RESULT(cm.GetXReplStreamInfo(stream_id1));
+  ASSERT_TRUE(stream_info->LockForRead()->is_deleting());
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_cdcsdk_disable_deleted_stream_cleanup) = false;
+  // Waiting for catalog manager's background task to delete the stream_id1's related cdc state
+  // table entries.
+  auto cdc_state_table = MakeCDCStateTable(test_client());
+  ASSERT_OK(WaitFor(
+      [&]() -> Result<bool> {
+        auto stream_info = cm.GetXReplStreamInfo(stream_id1);
+        bool stream_deleted = !stream_info.ok() && stream_info.status().IsNotFound();
+        auto tablet_stream_entry = VERIFY_RESULT(
+            cdc_state_table.TryFetchEntry({table1_tablets[0].tablet_id(), stream_id1}));
+        auto slot_entry =
+            VERIFY_RESULT(cdc_state_table.TryFetchEntry({kCDCSDKSlotEntryTabletId, stream_id1}));
+
+        return stream_deleted && !tablet_stream_entry.has_value() && !slot_entry.has_value();
+      },
+      MonoDelta::FromSeconds(30), "Timed out waiting for stream ID 1 to be deleted"));
+
+  SleepFor(MonoDelta::FromMilliseconds(FLAGS_cdc_intent_retention_ms));
+  stop_get_changes_thread.store(true);
+  get_changes_thread.join();
+
+  // Since table2 was continuously getting polled, UPAM, in the meantime, should have kept moving
+  // forward the cdc_sdk_min_checkpoint_op_id_expiration time for tablets of table2. So, tablet
+  // checkpoint should be not Max().
+  auto tablet_peer =
+      ASSERT_RESULT(GetLeaderPeerForTablet(test_cluster(), table2_tablets[0].tablet_id()));
+  ASSERT_NE(tablet_peer->GetLatestCheckPoint(), OpId::Max());
+}
+
+void CDCSDKYsqlTest::TestStreamsDroppedOnDBDropAndMasterRestart(
+    const std::string& sync_point_name, bool use_logical_replication) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_yb_enable_cdc_consistent_snapshot_streams) = true;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_update_min_cdc_indices_interval_secs) = 1;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_catalog_manager_bg_task_wait_ms) = 10 * 1000;
+
+  ASSERT_OK(SetUpWithParams(
+      1 /* rf */, 1 /* num_masters */, false /* colocated */,
+      true /* cdc_populate_safepoint_record */));
+  auto table1 = ASSERT_RESULT(CreateTable(&test_cluster_, kNamespaceName, kTableName));
+  google::protobuf::RepeatedPtrField<master::TabletLocationsPB> table1_tablets;
+  ASSERT_OK(test_client()->GetTablets(table1, 0, &table1_tablets, nullptr));
+  ASSERT_EQ(table1_tablets.size(), 1);
+
+  xrepl::StreamId stream_id1, stream_id2;
+  if (use_logical_replication) {
+    stream_id1 = ASSERT_RESULT(CreateConsistentSnapshotStreamWithReplicationSlot("slot_1"));
+    stream_id2 = ASSERT_RESULT(CreateConsistentSnapshotStreamWithReplicationSlot("slot_2"));
+  } else {
+    stream_id1 = ASSERT_RESULT(CreateConsistentSnapshotStream());
+    stream_id2 = ASSERT_RESULT(CreateConsistentSnapshotStream());
+  }
+
+  // Crash the Master after table has been marked as dropped in sys catalog, but before tablets
+  // are dropped, or xCluster streams dropped.
+  auto* sync_point_instance = yb::SyncPoint::GetInstance();
+  Synchronizer sync;
+  sync_point_instance->SetCallBack(
+      sync_point_name, [sync_point_instance, callback = sync.AsStdStatusCallback()](void* arg) {
+        LOG(INFO) << "Forcing master failure";
+        *reinterpret_cast<bool*>(arg) = true;
+
+        sync_point_instance->DisableProcessing();
+        callback(Status::OK());
+      });
+  sync_point_instance->EnableProcessing();
+
+  auto test_thread_holder = TestThreadHolder();
+  test_thread_holder.AddThread([&]() { auto status = DropDB(&test_cluster_); });
+
+  ASSERT_OK(sync.Wait());
+  auto master = test_cluster()->mini_master();
+  ASSERT_OK(master->Restart());
+
+  test_thread_holder.JoinAll();
+
+  auto& cm = master->catalog_manager_impl();
+  auto cdc_state_table = MakeCDCStateTable(test_client());
+  ASSERT_OK(WaitFor(
+      [&]() -> Result<bool> {
+        // Check whether both streams are deleted and their related cdc state table entries are
+        // deleted. Also, check that the table in kNamespaceName is deleted.
+        bool checker = true;
+        for (const auto& stream_id : {stream_id1, stream_id2}) {
+          auto stream_info = cm.GetXReplStreamInfo(stream_id);
+          bool stream_deleted = !stream_info.ok() && stream_info.status().IsNotFound();
+          auto tablet_stream_entry = VERIFY_RESULT(
+              cdc_state_table.TryFetchEntry({table1_tablets[0].tablet_id(), stream_id}));
+          // For gRPC streams, we won't have corresponding 'slot_entry'. So, its value won't impact
+          // 'checker' value.
+          auto slot_entry =
+              VERIFY_RESULT(cdc_state_table.TryFetchEntry({kCDCSDKSlotEntryTabletId, stream_id}));
+          checker = checker && stream_deleted && !tablet_stream_entry.has_value() &&
+                    !slot_entry.has_value();
+        }
+
+        checker = checker && !GetTable(&test_cluster_, kNamespaceName, kTableName).ok();
+        return checker;
+      },
+      MonoDelta::FromSeconds(60), "Timed out waiting for all streams to be deleted"));
+}
+
+TEST_F(CDCSDKYsqlTest, TestLogicalStreamsDroppedWhenMasterRestartBeforeStreamsMarkingInDBDrop) {
+  TestStreamsDroppedOnDBDropAndMasterRestart(
+      "DropXReplStreams::FailBeforeStreamsStateChangesPersisted",
+      true /* use_logical_replication */);
+}
+
+TEST_F(CDCSDKYsqlTest, TestLogicalStreamsDroppedWhenMasterRestartBeforeStreamsDeletionInDBDrop) {
+  TestStreamsDroppedOnDBDropAndMasterRestart(
+      "CleanUpDeletedXReplStreams::FailBeforeStreamDeletion", true /* use_logical_replication */);
+}
+
+TEST_F(CDCSDKYsqlTest, TestGRPCStreamsDroppedWhenMasterRestartBeforeStreamsMarkingInDBDrop) {
+  TestStreamsDroppedOnDBDropAndMasterRestart(
+      "DropXReplStreams::FailBeforeStreamsStateChangesPersisted",
+      false /* use_logical_replication */);
+}
+
+TEST_F(CDCSDKYsqlTest, TestGRPCStreamsDroppedWhenMasterRestartBeforeStreamsDeletionInDBDrop) {
+  TestStreamsDroppedOnDBDropAndMasterRestart(
+      "CleanUpDeletedXReplStreams::FailBeforeStreamDeletion", false /* use_logical_replication */);
+}
+
+// This test mimics the following scenario:
+// - Dropping a namespace on an older version (where the streams are not dropped as part of
+// namespace drop). This leads to some stale streams lingering in the system.
+// - Upgrading to a version where dropping a namespace includes associated streams drop. The
+// upgraded system should delete the stale streams.
+TEST_F(CDCSDKYsqlTest, TestStreamWithoutNamespaceDrops) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_yb_enable_cdc_consistent_snapshot_streams) = true;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_update_min_cdc_indices_interval_secs) = 1;
+  // ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdc_state_checkpoint_update_interval_ms) = 0;
+  // ANNOTATE_UNPROTECTED_WRITE(FLAGS_cdcsdk_retention_barrier_no_revision_interval_secs) = 0;
+  // ANNOTATE_UNPROTECTED_WRITE(FLAGS_catalog_manager_bg_task_wait_ms) = 10 * 1000;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_cdcsdk_disable_deleted_stream_cleanup) = true;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_cdcsdk_disable_stream_drop_during_db_drop) = true;
+
+  ASSERT_OK(SetUpWithParams(
+      1 /* rf */, 1 /* num_masters */, false /* colocated */,
+      true /* cdc_populate_safepoint_record */));
+  auto table = ASSERT_RESULT(CreateTable(&test_cluster_, kNamespaceName, kTableName));
+  google::protobuf::RepeatedPtrField<master::TabletLocationsPB> tablets;
+  ASSERT_OK(test_client()->GetTablets(table, 0, &tablets, nullptr));
+  ASSERT_EQ(tablets.size(), 1);
+
+  auto stream_id = ASSERT_RESULT(CreateConsistentSnapshotStreamWithReplicationSlot());
+
+  ASSERT_OK(DropDB(&test_cluster_));
+  SleepFor(MonoDelta::FromSeconds(5));
+
+  // Asserting that the stream is not marked as DELETING and so slot entry is present in
+  // cdc_state_table.
+  auto master = test_cluster()->mini_master();
+  auto& cm = master->catalog_manager_impl();
+  auto stream_info = ASSERT_RESULT(cm.GetXReplStreamInfo(stream_id));
+  ASSERT_FALSE(stream_info->LockForRead()->started_deleting());
+  auto cdc_state_table = MakeCDCStateTable(test_client());
+  auto slot_entry =
+      ASSERT_RESULT(cdc_state_table.TryFetchEntry({kCDCSDKSlotEntryTabletId, stream_id}));
+  ASSERT_TRUE(slot_entry.has_value());
+
+  // Simulating cluster upgrade by restarting the master.
+  ASSERT_OK(master->Restart());
+  ASSERT_OK(test_cluster()->WaitForAllTabletServers());
+
+  // The stream should be marked as DELETING during its loading from sys catalog after restart.
+  auto& cm_after_restart = master->catalog_manager_impl();
+  stream_info = ASSERT_RESULT(cm_after_restart.GetXReplStreamInfo(stream_id));
+  ASSERT_TRUE(stream_info->LockForRead()->is_deleting());
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_cdcsdk_disable_deleted_stream_cleanup) = false;
+
+  ASSERT_OK(WaitFor(
+      [&]() -> Result<bool> {
+        auto stream_info = cm_after_restart.GetXReplStreamInfo(stream_id);
+        bool stream_deleted = !stream_info.ok() && stream_info.status().IsNotFound();
+        slot_entry =
+            VERIFY_RESULT(cdc_state_table.TryFetchEntry({kCDCSDKSlotEntryTabletId, stream_id}));
+        return stream_deleted && !slot_entry.has_value();
+      },
+      MonoDelta::FromSeconds(60), "Timed out waiting for stream ID 1 to be deleted"));
 }
 
 TEST_F(CDCSDKYsqlTest, TestOriginId) {

--- a/src/yb/integration-tests/cdcsdk_ysql_test_base.h
+++ b/src/yb/integration-tests/cdcsdk_ysql_test_base.h
@@ -156,6 +156,7 @@ DECLARE_int32(cdc_create_stream_alter_table_dispatch_batch_size);
 DECLARE_int32(cdc_create_stream_alter_table_dispatch_delay_ms);
 DECLARE_int32(max_concurrent_alter_table_rpcs);
 DECLARE_int32(ysql_ddl_rpc_timeout_sec);
+DECLARE_bool(TEST_cdcsdk_disable_stream_drop_during_db_drop);
 
 namespace yb {
 
@@ -927,6 +928,8 @@ class CDCSDKYsqlTest : public CDCSDKTestBase {
   void TestLagMetricWithConsistentSnapshotStream(bool expire_table);
 
   Status CdcReleaseBarriersOnTablet(const TabletId& tablet_id);
+  void TestStreamsDroppedOnDBDropAndMasterRestart(
+      const string& sync_point_name, bool use_logical_replication);
 };
 
 }  // namespace cdc

--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -653,6 +653,9 @@ DEFINE_test_flag(bool, fail_yugabyte_namespace_creation_on_second_attempt, false
 DEFINE_test_flag(int32, delay_at_start_of_schedule_post_tablet_create_tasks_ms, 0,
     "Sleep at the start of SchedulePostTabletCreationTasks.");
 
+DEFINE_test_flag(bool, cdcsdk_disable_stream_drop_during_db_drop, false,
+    "When enabled, the DeleteNamespace workflow won't mark associated CDCSDK streams as DELETING.");
+
 DECLARE_bool(create_initial_sys_catalog_snapshot);
 DECLARE_bool(enable_pg_cron);
 DECLARE_bool(enable_truncate_cdcsdk_table);
@@ -9983,10 +9986,31 @@ void CatalogManager::DeleteYsqlDatabaseAsync(
     }
   }
 
+  if (!is_ysql_major_upgrade &&
+      PREDICT_TRUE(!FLAGS_TEST_cdcsdk_disable_stream_drop_during_db_drop)) {
+    // Dropping all CDCSDK streams for the database.
+    TRACE("Dropping all CDCSDK streams for the YSQL database");
+    auto s = DropAllCDCSDKStreams(database->id());
+    WARN_NOT_OK(s, "DropAllCDCSDKStreams failed");
+
+    if (!s.ok()) {
+      if (s.IsIllegalState() && s.message().ToBuffer() == "Failing for TESTING") {
+        // Simulated failure injected by test. Return immediately.
+        return;
+      }
+      // Move to FAILED so DeleteNamespace can be reissued by the user.
+      auto l = database->LockForWrite();
+      SysNamespaceEntryPB& metadata = database->mutable_metadata()->mutable_dirty()->pb;
+      metadata.set_state(SysNamespaceEntryPB::FAILED);
+      l.Commit();
+      return;
+    }
+  }
+
   // Delete all tables in the database. If we're in a major YSQL upgrade, this will delete
   // only the new version's tables.
   TRACE("Delete all tables in YSQL database");
-  Status s = DeleteYsqlDBTables(database->id(), DeleteYsqlDBTablesType::kNormal, epoch);
+  auto s = DeleteYsqlDBTables(database->id(), DeleteYsqlDBTablesType::kNormal, epoch);
   WARN_NOT_OK(s, "DeleteYsqlDBTables failed");
 
   auto l = database->LockForWrite();

--- a/src/yb/master/catalog_manager.h
+++ b/src/yb/master/catalog_manager.h
@@ -828,6 +828,9 @@ class CatalogManager : public CatalogManagerIf, public SnapshotCoordinatorContex
   Status HandleDroppedTablesForCDCSDKStreams(const std::unordered_set<TableId>& table_ids)
       EXCLUDES(mutex_);
 
+  // Delete all the CDCSDK streams on a namespace.
+  Status DropAllCDCSDKStreams(const NamespaceId& ns_id) EXCLUDES(mutex_);
+
   // Add new table metadata to all CDCSDK streams of required namespace.
   Status AddNewTableToCDCDKStreamsMetadata(const TableId& table_id, const NamespaceId& ns_id)
       EXCLUDES(mutex_);

--- a/src/yb/master/xrepl_catalog_manager.cc
+++ b/src/yb/master/xrepl_catalog_manager.cc
@@ -266,16 +266,15 @@ class CDCStreamLoader : public Visitor<PersistentCDCStreamInfo> {
     scoped_refptr<NamespaceInfo> ns;
     scoped_refptr<TableInfo> table;
 
+    bool should_mark_cdcsdk_stream_as_deleting = false;
     if (metadata.has_namespace_id()) {
       ns = FindPtrOrNull(catalog_manager_->namespace_ids_map_, metadata.namespace_id());
 
+      // If the namespace is not found then ideally this CDCSDK stream should have been deleted. We
+      // will load such stream metadata and mark it as DELETING. The background task will then
+      // cleanup this stream.
       if (!ns) {
-        LOG(DFATAL) << "Invalid namespace ID " << metadata.namespace_id() << " for stream "
-                    << stream_id;
-        // TODO (#2059): Potentially signals a race condition that namesapce got deleted
-        // while stream was being created.
-        // Log error and continue without loading the stream.
-        return Status::OK();
+        should_mark_cdcsdk_stream_as_deleting = true;
       }
     } else {
       table = catalog_manager_->tables_->FindTableOrNull(
@@ -298,10 +297,16 @@ class CDCStreamLoader : public Visitor<PersistentCDCStreamInfo> {
     // a previous version where these options were not present.
     AddDefaultValuesIfMissing(metadata, &l);
 
-    // If the table has been deleted, then mark this stream as DELETING so it can be deleted by the
-    // catalog manager background thread. Otherwise if this stream is missing an entry
-    // for state, then mark its state as Active.
+    // No matter what the state of this CDCSDK stream is persisted in sys catalog, we will mark the
+    // stream as DELETING if its namespace is not found.
+    if (should_mark_cdcsdk_stream_as_deleting) {
+      l.mutable_data()->pb.set_state(SysCDCStreamEntryPB::DELETING);
+    }
 
+    // If the table asscoiated with this xcluster stream is in deleting state or the namespace
+    // associated with this CDCSDK stream is in deleting state, then mark this stream as DELETING so
+    // it can be deleted by the catalog manager background thread. Otherwise if this stream is
+    // missing an entry for state, then mark its state as Active.
     if (((table && table->LockForRead()->is_deleting()) ||
          (ns && ns->state() == SysNamespaceEntryPB::DELETING)) &&
         !l.data().is_deleting()) {
@@ -758,6 +763,30 @@ Status CatalogManager::DropCDCSDKStreams(const std::unordered_set<TableId>& tabl
   // Do not delete them here, just mark them as DELETING_METADATA and the catalog manager background
   // thread will handle the deletion.
   return DropXReplStreams(streams, SysCDCStreamEntryPB::DELETING_METADATA);
+}
+
+Status CatalogManager::DropAllCDCSDKStreams(const NamespaceId& ns_id) {
+  DCHECK(!ns_id.empty()) << "Namespace ID should not be empty for CDCSDK streams deletion";
+
+  std::vector<CDCStreamInfoPtr> streams;
+  {
+    SharedLock lock(mutex_);
+    for (const auto& entry : cdc_stream_map_) {
+      auto ltm = entry.second->LockForRead();
+      if (!ltm->namespace_id().empty() && ltm->namespace_id() == ns_id) {
+        streams.push_back(entry.second);
+      }
+    }
+  }
+
+  if (streams.empty()) {
+    return Status::OK();
+  }
+
+  LOG(INFO) << "Deleting all CDCSDK streams for namespace: " << ns_id;
+  // Do not delete them here, just mark them as DELETING and the catalog manager background thread
+  // will handle the deletion.
+  return DropXReplStreams(streams, SysCDCStreamEntryPB::DELETING);
 }
 
 Status CatalogManager::AddNewTableToCDCDKStreamsMetadata(
@@ -2106,6 +2135,15 @@ Status CatalogManager::DropXReplStreams(
   if (streams_to_mark.empty()) {
     return Status::OK();
   }
+
+  bool TEST_fail = false;
+  TEST_SYNC_POINT_CALLBACK("DropXReplStreams::FailBeforeStreamsStateChangesPersisted", &TEST_fail);
+  if (TEST_fail) {
+    LOG(INFO) << "Failed before streams " << CDCStreamInfosAsString(streams_to_mark)
+              << " states are persisted to " << SysCDCStreamEntryPB::State_Name(delete_state)
+              << " in sys catalog";
+  }
+  SCHECK(!TEST_fail, IllegalState, "Failing for TESTING");
 
   // The mutation will be aborted when 'l' exits the scope on early return.
   RETURN_NOT_OK(CheckStatus(
@@ -3468,6 +3506,14 @@ Status CatalogManager::CleanUpDeletedXReplStreams(const LeaderEpoch& epoch) {
   }
 
   RETURN_NOT_OK(xcluster_manager_->RemoveStreamsFromSysCatalog(epoch, streams_to_delete));
+
+  bool TEST_fail = false;
+  TEST_SYNC_POINT_CALLBACK("CleanUpDeletedXReplStreams::FailBeforeStreamDeletion", &TEST_fail);
+  if (TEST_fail) {
+    LOG(INFO) << "Failed before streams " << CDCStreamInfosAsString(streams_to_delete)
+              << " are deleted from sys catalog";
+  }
+  SCHECK(!TEST_fail, IllegalState, "Failing for TESTING");
 
   RETURN_NOT_OK_PREPEND(
       sys_catalog_->Delete(epoch, streams_to_delete),


### PR DESCRIPTION
DO NOT MERGE!! [CSI](<https://csiweb.dev.yugabyte.com/pull/33049/>) ⏳

Summary:
It is seen that when a database (having an active replication slot) is dropped and a node is restarted, then after `FLAGS_cdc_intent_retention_ms` time we start getting `Trying to fetch already GCed intents` error for every `GetChanges()` call.

The issue happens because:
* Currently the workflow of dropping the database don’t delete the associated streams and so such streams' metadata doesn’t get deleted.
* Now, when a master restarts, it tries to load all streams' metadata in the in-mem map `cdc_stream_map_` from the proto persisted on disk using its `CDCStreamLoader::Visit()` function. However, it is not able to do so since the underlying namespace for such stream is already deleted.
* Now, when UPAM tries to load the stream metadata (using `CDCServiceImpl::GetStream()` in `CDCServiceImpl::GetNamespaceMinRecordIdCommitTimeMap()`, it doesn’t find it and so `GetNamespaceMinRecordIdCommitTimeMap()` returns non-ok status.
* For CDC state table tablet-stream entries (unrelated to streams of dropped database), `CDCServiceImpl::PopulateTabletCheckPointInfo()` won’t be able to fill the `cdcsdk_min_checkpoint_map` because `GetNamespaceMinRecordIdCommitTimeMap()` had returned non-ok status. The `cdcsdk_min_checkpoint_map` is the important map taken into consideration for refreshing the retention barriers. If there  isn't an entry for a tablet in it, the UPAM can't refresh such tablet's retention barrier.
* Thus the retention barriers for such tablet eventually gets lifted (after `FLAGS_cdc_min_replicated_index_considered_stale_secs` as part of maintenance op `ResetStaleRetentionBarriersOp`) and we see `Trying to fetch already GCed intents` error.

To correct this:
* The diff adds the logic of marking the associated streams as `DELETING` in the workflow of namespace deletion.
* We let `CDCStreamLoader::Visit()` function to load the stream which don't have the valid namespace in `cdc_stream_map_` but rightaway mark them in `DELETING` state.
* This way Catalog manager's background task `CatalogManager::CleanUpDeletedXReplStreams()` eventually runs, deleting the stream metadata and entries associated with such stream from cdc state table.
* The UPAM will not see entries related to such stream and `CDCServiceImpl::GetNamespaceMinRecordIdCommitTimeMap()` will not return non-ok status. Thus UPAM won't stuck resolving GCed intents error.

**Upgrade/Rollback safety**
There can be scenario where a database was dropped on an older version where dropping of associated streams are not part of drop database workflow. That way such streams linger in the system (along with their slot entries in cdc_state table). Now when the cluster is upgraded to version which now supports streams drop in database drop workflow, the above mentioned solution approach takes care of loading such streams, marking them as `DELETING` and thus eventually clearing them from system.

Jira: DB-17444

Original commit: 58f9ec18f4be457983ecde08f0801df1d02e7c5e / D49225

Test Plan:
yb_build.sh --cxx-test cdcsdk_ysql-test --gtest_filter CDCSDKYsqlTest.TestUPAMMovesRetentionBarriersOnDBDropAndMasterRestart
yb_build.sh --cxx-test cdcsdk_ysql-test --gtest_filter CDCSDKYsqlTest.TestLogicalStreamsDroppedWhenMasterRestartBeforeStreamsMarkingInDBDrop
yb_build.sh --cxx-test cdcsdk_ysql-test --gtest_filter CDCSDKYsqlTest.TestLogicalStreamsDroppedWhenMasterRestartBeforeStreamsDeletionInDBDrop
yb_build.sh --cxx-test cdcsdk_ysql-test --gtest_filter CDCSDKYsqlTest.TestGRPCStreamsDroppedWhenMasterRestartBeforeStreamsMarkingInDBDrop
yb_build.sh --cxx-test cdcsdk_ysql-test --gtest_filter CDCSDKYsqlTest.TestGRPCStreamsDroppedWhenMasterRestartBeforeStreamsDeletionInDBDrop
yb_build.sh --cxx-test cdcsdk_ysql-test --gtest_filter CDCSDKYsqlTest.TestStreamWithoutNamespaceDrops

Reviewers: xCluster, hsunder, asrinivasan, sumukh.phalgaonkar, skumar, stiwary

Reviewed By: asrinivasan

Subscribers: ycdcxcluster, ybase

Tags: #jenkins-ready

Differential Revision: https://phorge.dev.yugabyte.com/D49225


## Merge conflicts

- `src/yb/integration-tests/cdcsdk_ysql-test.cc:30` — accepted cherry-pick's added includes (`master.h`, `master_replication.pb.h`, `master_replication.proxy.h`); branch had no code at that location.
- `src/yb/integration-tests/cdcsdk_ysql_test_base.h:159` — adjacent, non-overlapping flag declarations added by both sides; kept both.
- `src/yb/integration-tests/cdcsdk_ysql_test_base.h:930` — adjacent, non-overlapping method declarations added by both sides; kept both.
- `src/yb/master/catalog_manager.h:828` — adjacent, non-overlapping method declarations (`HandleDroppedTablesForCDCSDKStreams` pre-existing on branch, `DropAllCDCSDKStreams` newly cherry-picked); kept both.
