### PR TITLE
[#33075] DocDB: Validate the rpc handle in LocalProbeProcessor::AddBlocker

### DIFF
--- a/src/yb/docdb/deadlock_detector.cc
+++ b/src/yb/docdb/deadlock_detector.cc
@@ -245,8 +245,6 @@ class LocalProbeProcessor : public std::enable_shared_from_this<LocalProbeProces
     auto& blocking_subtxn_set = info.blocker_txn_info.blocking_subtxn_set;
     auto handle = rpcs_->Prepare();
     if (handle == rpcs_->InvalidHandle()) {
-      // Must not reach handles_: InvalidHandle() is calls_.end(), and Send() dereferences every
-      // element of handles_ unconditionally.
       LOG_WITH_PREFIX_AND_FUNC(WARNING) << "Shutting down. Cannot send probe.";
       return;
     }
@@ -1159,8 +1157,6 @@ class DeadlockDetector::Impl : public std::enable_shared_from_this<DeadlockDetec
         log_prefix_, detector_id, probe_num, req.min_probe_num(), probe_origin_txn_id, &rpcs_,
         &client(), nullptr /* probe_latency */);
 
-    // Lets tests shut the status tablet down while this handler is parked, so that AddBlocker below
-    // sees an already shut down rpcs_. The argument tells the test which tablet to shut down.
     TEST_SYNC_POINT_CALLBACK(
         "DeadlockDetector::GetProbesToForward:BeforeAddBlockers",
         const_cast<TabletId*>(&status_tablet_));

--- a/src/yb/docdb/deadlock_detector.cc
+++ b/src/yb/docdb/deadlock_detector.cc
@@ -45,6 +45,7 @@
 #include "yb/util/shared_lock.h"
 #include "yb/util/status_format.h"
 #include "yb/util/strongly_typed_uuid.h"
+#include "yb/util/sync_point.h"
 #include "yb/util/unique_lock.h"
 #include "yb/util/yb_pg_errcodes.h"
 
@@ -242,12 +243,14 @@ class LocalProbeProcessor : public std::enable_shared_from_this<LocalProbeProces
     auto& blocker_id = info.blocker_txn_info.id;
     auto& blocker_status_tablet = info.blocker_txn_info.status_tablet;
     auto& blocking_subtxn_set = info.blocker_txn_info.blocking_subtxn_set;
-    handles_.push_back(rpcs_->Prepare());
-    auto handle = handles_.back();
+    auto handle = rpcs_->Prepare();
     if (handle == rpcs_->InvalidHandle()) {
+      // Must not reach handles_: InvalidHandle() is calls_.end(), and Send() dereferences every
+      // element of handles_ unconditionally.
       LOG_WITH_PREFIX_AND_FUNC(WARNING) << "Shutting down. Cannot send probe.";
       return;
     }
+    handles_.push_back(handle);
 
     tserver::ProbeTransactionDeadlockRequestPB req;
     req.set_detector_id(origin_detector_id_.data(), origin_detector_id_.size());
@@ -1155,6 +1158,12 @@ class DeadlockDetector::Impl : public std::enable_shared_from_this<DeadlockDetec
     auto local_processor = std::make_shared<LocalProbeProcessor>(
         log_prefix_, detector_id, probe_num, req.min_probe_num(), probe_origin_txn_id, &rpcs_,
         &client(), nullptr /* probe_latency */);
+
+    // Lets tests shut the status tablet down while this handler is parked, so that AddBlocker below
+    // sees an already shut down rpcs_. The argument tells the test which tablet to shut down.
+    TEST_SYNC_POINT_CALLBACK(
+        "DeadlockDetector::GetProbesToForward:BeforeAddBlockers",
+        const_cast<TabletId*>(&status_tablet_));
 
     for (const auto& blockers : blockers_per_ts) {
       local_processor->CaptureSharedBlockingDataPtr(blockers);

--- a/src/yb/yql/pgwrapper/pg_wait_on_conflict-test.cc
+++ b/src/yb/yql/pgwrapper/pg_wait_on_conflict-test.cc
@@ -11,6 +11,8 @@
 // under the License.
 //
 
+#include <future>
+#include <mutex>
 #include <shared_mutex>
 #include <thread>
 
@@ -1049,6 +1051,115 @@ TEST_F(PgWaitQueuesTest, YB_DISABLE_TEST_IN_TSAN(TestDelayedProbeAnalysis)) {
   }
 
   thread_holder.WaitAndStop(25s * kTimeMultiplier);
+}
+
+// The poller reads this flag at tserver startup, so it has to be lowered before the cluster comes
+// up. At its 60s default the first forwarded probe can be a minute out.
+class PgWaitQueuesProbeForwardingTest : public PgWaitQueuesTest {
+ protected:
+  void SetUp() override {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_send_wait_for_report_interval_ms) = 100;
+    PgWaitQueuesTest::SetUp();
+  }
+};
+
+// Regression test for AddBlocker pushing Rpcs::Prepare()'s result into handles_ before checking it
+// against InvalidHandle(), leaving Send() to dereference calls_.end().
+TEST_F(PgWaitQueuesProbeForwardingTest, ForwardProbeDuringDetectorShutdown) {
+  constexpr auto kBeforeAddBlockers = "DeadlockDetector::GetProbesToForward:BeforeAddBlockers";
+  constexpr auto kShutdownDone =
+      "PgWaitQueuesProbeForwardingTest::ForwardProbeDuringDetectorShutdown:ShutdownDone";
+
+  // Park the probe handler at kBeforeAddBlockers until the test fires kShutdownDone.
+  auto* sync_point = yb::SyncPoint::GetInstance();
+  sync_point->LoadDependency({{kShutdownDone, kBeforeAddBlockers}});
+  sync_point->ClearTrace();
+  sync_point->DisableProcessing();
+
+  std::promise<TabletId> status_tablet_promise;
+  auto status_tablet_future = status_tablet_promise.get_future();
+  std::once_flag published;
+  sync_point->SetCallBack(kBeforeAddBlockers, [&](void* arg) {
+    // Runs once per forwarded probe; only the first arrival picks the tablet to shut down.
+    std::call_once(published, [&] {
+      status_tablet_promise.set_value(*static_cast<TabletId*>(arg));
+    });
+  });
+
+  // Declared after the state the callback captures, so the callback is unregistered before that
+  // state dies. DisableProcessing also releases any still-parked handler.
+  auto sync_point_cleanup = ScopeExit([sync_point] {
+    sync_point->DisableProcessing();
+    sync_point->ClearAllCallBacks();
+  });
+
+  auto setup_conn = ASSERT_RESULT(Connect());
+  ASSERT_OK(setup_conn.Execute("CREATE TABLE foo (k INT PRIMARY KEY, v INT)"));
+  ASSERT_OK(setup_conn.Execute("INSERT INTO foo SELECT generate_series(0, 5), 0"));
+
+  // Build a wait-for chain conn1 -> conn2 -> conn3. GetProbesToForward reaches the AddBlocker loop
+  // because the probed blocker, conn2, is itself blocked.
+  auto conn3 = ASSERT_RESULT(Connect());
+  ASSERT_OK(conn3.StartTransaction(IsolationLevel::SNAPSHOT_ISOLATION));
+  ASSERT_OK(conn3.Fetch("SELECT * FROM foo WHERE k=3 FOR UPDATE"));
+
+  auto conn2 = ASSERT_RESULT(Connect());
+  ASSERT_OK(conn2.StartTransaction(IsolationLevel::SNAPSHOT_ISOLATION));
+  ASSERT_OK(conn2.Fetch("SELECT * FROM foo WHERE k=2 FOR UPDATE"));
+
+  auto conn1 = ASSERT_RESULT(Connect());
+  ASSERT_OK(conn1.StartTransaction(IsolationLevel::SNAPSHOT_ISOLATION));
+  ASSERT_OK(conn1.Fetch("SELECT * FROM foo WHERE k=1 FOR UPDATE"));
+
+  sync_point->EnableProcessing();
+
+  // Killing a status tablet can leave a waiter blocked forever on an unresolvable transaction, and
+  // ExpectBlockedAsync's std::async future joins in its destructor. Bound it so the test fails.
+  for (auto* conn : {&conn1, &conn2, &conn3}) {
+    ASSERT_OK(conn->ExecuteFormat("SET statement_timeout=$0", 60000 * kTimeMultiplier));
+  }
+
+  auto future_2 = ASSERT_RESULT(ExpectBlockedAsync(&conn2, "UPDATE foo SET v=v+1 WHERE k=3"));
+  auto future_1 = ASSERT_RESULT(ExpectBlockedAsync(&conn1, "UPDATE foo SET v=v+1 WHERE k=2"));
+
+  // Require that a probe actually reached the sync point.
+  ASSERT_EQ(status_tablet_future.wait_for(60s * kTimeMultiplier), std::future_status::ready);
+  const auto status_tablet_id = status_tablet_future.get();
+  LOG(INFO) << "Probe handler parked at detector for status tablet " << status_tablet_id;
+
+  tablet::TabletPeerPtr victim;
+  for (const auto& peer :
+       ListTabletPeers(cluster_.get(), ListPeersFilter::kLeaders, UserTabletsOnly::kFalse)) {
+    if (peer->tablet_id() == status_tablet_id) {
+      victim = peer;
+      break;
+    }
+  }
+  ASSERT_NE(victim, nullptr);
+
+  // Own thread, so the test thread stays free to release the handler CompleteShutdown may drain on.
+  auto shutdown_future = std::async(std::launch::async, [&victim] {
+    return victim->TEST_Shutdown(
+        tablet::ShouldAbortActiveTransactions::kTrue, tablet::DisableFlushOnShutdown::kFalse);
+  });
+
+  // Either outcome means StartShutdown ran, so Prepare() now returns InvalidHandle.
+  shutdown_future.wait_for(5s * kTimeMultiplier);
+  TEST_SYNC_POINT(kShutdownDone);
+  ASSERT_EQ(shutdown_future.wait_for(60s * kTimeMultiplier), std::future_status::ready);
+  ASSERT_OK(shutdown_future.get());
+
+  // Unwind the transactions and log their outcomes, which vary with a status tablet destroyed
+  // underneath them. The pre-fix signal is the tserver dying in Send() just above.
+  LOG(INFO) << "conn3 commit: " << conn3.CommitTransaction();
+  LOG(INFO) << "conn2 blocked statement: " << future_2.get();
+  LOG(INFO) << "conn2 commit: " << conn2.CommitTransaction();
+  LOG(INFO) << "conn1 blocked statement: " << future_1.get();
+  LOG(INFO) << "conn1 commit: " << conn1.CommitTransaction();
+
+  // Safe to fail out now that both futures are joined. Checks the survivors still serve queries.
+  auto check_conn = ASSERT_RESULT(Connect());
+  ASSERT_EQ(ASSERT_RESULT(check_conn.FetchRow<int64_t>("SELECT COUNT(*) FROM foo")), 6);
 }
 
 class PgWaitQueuesDisableRowLocking : public PgWaitQueuesTest {


### PR DESCRIPTION
## Summary

`LocalProbeProcessor::AddBlocker` pushed the result of `Rpcs::Prepare()` into `handles_` before
checking it against `InvalidHandle()`. Once the deadlock detector's rpc registry is shut down,
`Prepare()` returns `InvalidHandle()`, which is `calls_.end()`. The early return then left that
past-the-end iterator in `handles_`, and `Send()` dereferences every element of `handles_` via
`(**handle).SendRpc()`, so the tserver crashed. The `handles_.size() == 0` check at the top of
`Send()` does not catch this, because `handles_` is not empty — it holds one entry that cannot be
used.

Only the `ProcessProbe` rpc path gets here. It holds no `ScopedRWOperation`, so a status tablet can
shut down while one of its probe handlers is still adding blockers. The poller-driven path does not
have this problem, because `Poller::Shutdown` waits for its callbacks to finish before the
coordinator shuts the detector down.

This checks the handle before pushing it, so an invalid handle never enters `handles_`. `Send()` then
takes its existing empty-`handles_` path and invokes the callback, so the probe rpc still gets an
answer instead of being dropped.

Also adds a regression test. It parks a probe handler at a new sync point in `GetProbesToForward` and
shuts that handler's status tablet down underneath it, so `AddBlocker` runs against an
already-shut-down `rpcs_`. The shutdown runs on its own thread, because if the parked handler is
serving a probe the detector sent to itself, `Rpcs::CompleteShutdown` waits for a call that only the
test thread can release.

## Test plan

New regression test, run in release on macOS arm64:

```
./yb_build.sh release --cxx-test pg_wait_on_conflict-test \
  --gtest-filter PgWaitQueuesProbeForwardingTest.ForwardProbeDuringDetectorShutdown -n 10
```

- [x] 10/10 iterations pass with the fix.
- [x] Every iteration logs `AddBlocker: Shutting down. Cannot send probe.` exactly once, confirming
      the guarded path is actually exercised rather than the test passing vacuously.
- [x] Without the fix, the same interleaving crashes the tserver in `Send()`.
- [x] Both shutdown orderings are covered across the 10 iterations: those where `TEST_Shutdown`
      drains immediately (<1ms), and the self-probe case where it blocks until the test releases the
      parked handler.
