### PR TITLE
[BACKPORT 2025.2][#31301] DistributedTracing: Emit one span per executor node instead of one per tuple

### DIFF
--- a/src/postgres/src/backend/commands/portalcmds.c
+++ b/src/postgres/src/backend/commands/portalcmds.c
@@ -36,6 +36,7 @@
 
 /* YB includes */
 #include "pg_yb_utils.h"
+#include "yb_dist_trace.h"
 
 
 /*
@@ -330,6 +331,15 @@ PortalCleanup(Portal portal)
 			PG_END_TRY();
 
 			CurrentResourceOwner = saveResourceOwner;
+		}
+		else if (YBCIsDistTraceEnabled())
+		{
+			/*
+			 * YB: executor shutdown is skipped for failed portals, so
+			 * ExecEndNode never runs and node spans left open by a suspended
+			 * portal would leak.
+			 */
+			YbDistTraceEndNodeSpans(queryDesc->planstate, /* errored */ true);
 		}
 	}
 }

--- a/src/postgres/src/backend/executor/execProcnode.c
+++ b/src/postgres/src/backend/executor/execProcnode.c
@@ -128,7 +128,7 @@
 
 static TupleTableSlot *ExecProcNodeFirst(PlanState *node);
 static TupleTableSlot *ExecProcNodeInstr(PlanState *node);
-static TupleTableSlot *ExecProcNodeYbDistTrace(PlanState *node);
+static TupleTableSlot *YbExecProcNodeTrace(PlanState *node);
 static const char *YbGetExecNodeSpanName(PlanState *node);
 static bool ExecShutdownNode_walker(PlanState *node, void *context);
 
@@ -485,15 +485,13 @@ ExecProcNodeFirst(PlanState *node)
 	 * does instrumentation.  Otherwise we can dispense with all wrappers and
 	 * have ExecProcNode() directly call the relevant function from now on.
 	 *
-	 * YB: When distributed tracing is active, ExecProcNodeInstr wraps spans
-	 * around ExecProcNodeReal internally so that span durations exclude
-	 * instrumentation overhead.  When there is no instrumentation but tracing
-	 * is enabled, ExecProcNodeYbDistTrace is installed instead.
+	 * YB: When distributed tracing is active but there is no instrumentation,
+	 * YbExecProcNodeTrace manages the node's span instead.
 	 */
 	if (node->instrument)
 		node->ExecProcNode = ExecProcNodeInstr;
 	else if (YBCIsDistTraceActive())
-		node->ExecProcNode = ExecProcNodeYbDistTrace;
+		node->ExecProcNode = YbExecProcNodeTrace;
 	else
 		node->ExecProcNode = node->ExecProcNodeReal;
 
@@ -1111,11 +1109,7 @@ ExecProcNodeInstr(PlanState *node)
 	InstrStartNode(node->instrument);
 
 	if (YBCIsDistTraceActive())
-	{
-		YB_DIST_TRACE_START_SPAN(YbGetExecNodeSpanName(node));
-		result = node->ExecProcNodeReal(node);
-		YB_DIST_TRACE_END_SPAN();
-	}
+		result = YbExecProcNodeTrace(node);
 	else
 		result = node->ExecProcNodeReal(node);
 
@@ -1127,22 +1121,43 @@ ExecProcNodeInstr(PlanState *node)
 
 
 /*
- * ExecProcNodeYbDistTrace
- *
- * ExecProcNode wrapper that starts/ends a distributed tracing span around
- * the real node execution.  Installed by ExecProcNodeFirst when distributed
- * tracing is enabled but no instrumentation is active.
+ * Create the node's span on its first call and make it current while
+ * ExecProcNodeReal runs, so child spans (RPC, shared-memory) nest under it.
+ * The span is ended at ExecEndNode, or earlier at the end of the protocol
+ * message when the portal suspends (cursors, extended-protocol row limits);
+ * a later resume then creates a fresh span under that message's root span.
  */
 static TupleTableSlot *
-ExecProcNodeYbDistTrace(PlanState *node)
+YbExecProcNodeTrace(PlanState *node)
 {
 	TupleTableSlot *result;
 
-	YB_DIST_TRACE_START_SPAN(YbGetExecNodeSpanName(node));
+	/*
+	 * This wrapper stays installed for the node's lifetime, but a suspended
+	 * portal can be resumed by a later message that carries no trace.
+	 */
+	if (!YBCIsDistTraceActive())
+		return node->ExecProcNodeReal(node);
 
+	if (!node->yb_dist_trace_node_span)
+	{
+		/*
+		 * Create in es_query_cxt so the span's YB-side handle is registered
+		 * in a memctx that lives exactly as long as the plan tree; the
+		 * current context here is typically a short-lived per-tuple context.
+		 */
+		MemoryContext oldcontext =
+			MemoryContextSwitchTo(node->state->es_query_cxt);
+
+		node->yb_dist_trace_node_span =
+			YBCDistTraceCreateNodeSpan(YbGetExecNodeSpanName(node));
+		MemoryContextSwitchTo(oldcontext);
+		node->state->yb_dist_trace_has_node_spans = true;
+	}
+
+	YBCDistTraceNodeSpanPushScope(node->yb_dist_trace_node_span);
 	result = node->ExecProcNodeReal(node);
-
-	YB_DIST_TRACE_END_SPAN();
+	YBCDistTraceNodeSpanPopScope(node->yb_dist_trace_node_span);
 
 	return result;
 }
@@ -1450,6 +1465,17 @@ ExecEndNode(PlanState *node)
 		default:
 			elog(ERROR, "unrecognized node type: %d", (int) nodeTag(node));
 			break;
+	}
+
+	/*
+	 * YB: end this node's distributed-tracing span.  Runs after the switch so
+	 * child spans close before their parent; on query abort the executor
+	 * hooks in yb_dist_trace.c close whatever is left open.
+	 */
+	if (node->yb_dist_trace_node_span)
+	{
+		YBCDistTraceEndNodeSpan(node->yb_dist_trace_node_span);
+		node->yb_dist_trace_node_span = NULL;
 	}
 }
 

--- a/src/postgres/src/backend/tcop/postgres.c
+++ b/src/postgres/src/backend/tcop/postgres.c
@@ -103,6 +103,7 @@
 #include "yb/yql/pggate/ybc_dist_trace.h"
 #include "yb/yql/pggate/ybc_gflags.h"
 #include "yb/yql/pggate/ybc_pggate.h"
+#include "yb_dist_trace.h"
 #include "yb_tcmalloc_utils.h"
 #include "yb_ysql_conn_mgr_helper.h"
 #include <arpa/inet.h>
@@ -1708,6 +1709,7 @@ exec_simple_query(const char *query_string)
 	if (save_log_statement_stats)
 		ShowUsage("QUERY STATISTICS");
 
+	YbDistTraceEndOpenNodeSpans();
 	YB_DIST_TRACE_END_SPAN();
 	TRACE_POSTGRESQL_QUERY_DONE(query_string);
 
@@ -2760,6 +2762,7 @@ exec_execute_message(const char *portal_name, long max_rows)
 	if (save_log_statement_stats)
 		ShowUsage("EXECUTE MESSAGE STATISTICS");
 
+	YbDistTraceEndOpenNodeSpans();
 	YB_DIST_TRACE_END_SPAN(); /* ext.execute */
 
 	debug_query_string = NULL;

--- a/src/postgres/src/backend/utils/misc/Makefile
+++ b/src/postgres/src/backend/utils/misc/Makefile
@@ -17,6 +17,7 @@ override CPPFLAGS := -I. -I$(srcdir) $(CPPFLAGS)
 OBJS = \
 	pg_yb_utils.o \
 	yb_ash.o \
+	yb_dist_trace.o \
 	yb_exceptions_for_func_pushdown.o \
 	yb_file_utils.o \
 	yb_index_check.o \

--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -142,6 +142,7 @@
 #include "yb/yql/pggate/ybc_gflags.h"
 #include "yb/yql/pggate/ybc_pggate.h"
 #include "yb_ash.h"
+#include "yb_dist_trace.h"
 #include "yb_internal_conn.h"
 #include "yb_qpm.h"
 #include "yb_query_diagnostics.h"
@@ -1341,6 +1342,9 @@ YBInitPostgresBackend(const char *program_name, const YbcPgInitPostgresInfo *ini
 			hex_uuid[2 * UUID_LEN] = '\0';
 
 			YBCInitDistTrace(MyProcPid, hex_uuid);
+
+			/* Hooks that close node spans left open by a query abort. */
+			YbDistTraceInstallExecutorHooks();
 		}
 	}
 }

--- a/src/postgres/src/backend/utils/misc/yb_dist_trace.c
+++ b/src/postgres/src/backend/utils/misc/yb_dist_trace.c
@@ -1,0 +1,160 @@
+/*-------------------------------------------------------------------------
+ *
+ * yb_dist_trace.c
+ *	  Distributed tracing/Yugabyte (Postgres layer) executor hooks.
+ *
+ * Copyright (c) YugabyteDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * IDENTIFICATION
+ *	  src/backend/utils/misc/yb_dist_trace.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "executor/executor.h"
+#include "miscadmin.h"
+#include "nodes/nodeFuncs.h"
+#include "pg_yb_utils.h"
+#include "utils/portal.h"
+#include "yb_dist_trace.h"
+
+static ExecutorRun_hook_type prev_ExecutorRun = NULL;
+static ExecutorFinish_hook_type prev_ExecutorFinish = NULL;
+static ExecutorEnd_hook_type prev_ExecutorEnd = NULL;
+
+static bool
+YbDistTraceEndNodeSpans_walker(PlanState *node, void *context)
+{
+	if (node == NULL)
+		return false;
+
+	check_stack_depth();
+
+	/* Post-order traversal to end child spans before the parent's. */
+	planstate_tree_walker(node, YbDistTraceEndNodeSpans_walker, context);
+
+	if (node->yb_dist_trace_node_span)
+	{
+		if (*(bool *) context)
+			YBCDistTraceEndNodeSpanOnError(node->yb_dist_trace_node_span);
+		else
+			YBCDistTraceEndNodeSpan(node->yb_dist_trace_node_span);
+		node->yb_dist_trace_node_span = NULL;
+	}
+
+	return false;
+}
+
+void
+YbDistTraceEndNodeSpans(struct PlanState *planstate, bool errored)
+{
+	YbDistTraceEndNodeSpans_walker((PlanState *) planstate, &errored);
+	Assert(planstate && planstate->state);
+	planstate->state->yb_dist_trace_has_node_spans = false;
+}
+
+static void
+YbDistTraceEndPortalNodeSpans(Portal portal)
+{
+	/* Skip the tree walk for portals that never opened a span this cycle. */
+	if (portal->queryDesc && portal->queryDesc->planstate &&
+		portal->queryDesc->estate->yb_dist_trace_has_node_spans)
+		YbDistTraceEndNodeSpans(portal->queryDesc->planstate, /* errored */ false);
+}
+
+/*
+ * End node spans still open in suspended portals (cursors, extended-protocol
+ * portals with a row limit). This ensures that at every message boundary,
+ * there are no exec node spans open. The next ExecProcNode call recreates
+ * the span under the new root.
+ */
+void
+YbDistTraceEndOpenNodeSpans(void)
+{
+	if (!YBCIsDistTraceActive())
+		return;
+
+	YbForEachPortal(YbDistTraceEndPortalNodeSpans);
+}
+
+static void
+YbDistTrace_ExecutorRun(QueryDesc *queryDesc, ScanDirection direction,
+					   uint64 count, bool execute_once)
+{
+	PG_TRY();
+	{
+		if (prev_ExecutorRun)
+			prev_ExecutorRun(queryDesc, direction, count, execute_once);
+		else
+			standard_ExecutorRun(queryDesc, direction, count, execute_once);
+	}
+	PG_CATCH();
+	{
+		YbDistTraceEndNodeSpans(queryDesc->planstate, /* errored */ true);
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+}
+
+static void
+YbDistTrace_ExecutorFinish(QueryDesc *queryDesc)
+{
+	PG_TRY();
+	{
+		if (prev_ExecutorFinish)
+			prev_ExecutorFinish(queryDesc);
+		else
+			standard_ExecutorFinish(queryDesc);
+	}
+	PG_CATCH();
+	{
+		YbDistTraceEndNodeSpans(queryDesc->planstate, /* errored */ true);
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+}
+
+static void
+YbDistTrace_ExecutorEnd(QueryDesc *queryDesc)
+{
+	PG_TRY();
+	{
+		if (prev_ExecutorEnd)
+			prev_ExecutorEnd(queryDesc);
+		else
+			standard_ExecutorEnd(queryDesc);
+	}
+	PG_CATCH();
+	{
+		YbDistTraceEndNodeSpans(queryDesc->planstate, /* errored */ true);
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+}
+
+void
+YbDistTraceInstallExecutorHooks(void)
+{
+	prev_ExecutorRun = ExecutorRun_hook;
+	ExecutorRun_hook = YbDistTrace_ExecutorRun;
+
+	prev_ExecutorFinish = ExecutorFinish_hook;
+	ExecutorFinish_hook = YbDistTrace_ExecutorFinish;
+
+	prev_ExecutorEnd = ExecutorEnd_hook;
+	ExecutorEnd_hook = YbDistTrace_ExecutorEnd;
+}

--- a/src/postgres/src/backend/utils/mmgr/portalmem.c
+++ b/src/postgres/src/backend/utils/mmgr/portalmem.c
@@ -1201,6 +1201,21 @@ ThereAreNoReadyPortals(void)
 }
 
 /*
+ * YB: invoke callback on every existing portal.
+ */
+void
+YbForEachPortal(void (*callback) (Portal portal))
+{
+	HASH_SEQ_STATUS status;
+	PortalHashEnt *hentry;
+
+	hash_seq_init(&status, PortalHashTable);
+
+	while ((hentry = (PortalHashEnt *) hash_seq_search(&status)) != NULL)
+		callback(hentry->portal);
+}
+
+/*
  * Hold all pinned portals.
  *
  * When initiating a COMMIT or ROLLBACK inside a procedure, this must be

--- a/src/postgres/src/include/nodes/execnodes.h
+++ b/src/postgres/src/include/nodes/execnodes.h
@@ -772,6 +772,8 @@ typedef struct EState
 	 * FK relation. Used by YBCBuildYBTupleIdDescriptor().
 	 */
 	List	   *yb_es_pk_proutes;
+
+	bool		yb_dist_trace_has_node_spans;
 } EState;
 
 /*
@@ -1213,6 +1215,12 @@ typedef struct PlanState
 	bool		outeropsset;
 	bool		inneropsset;
 	bool		resultopsset;
+
+	/*
+	 * YB : handle to this node's live span; kept across calls so scope can be
+	 * pushed/popped per call - one span per node, not per tuple
+	 */
+	YbcOtelNodeSpan yb_dist_trace_node_span;
 } PlanState;
 
 /* ----------------

--- a/src/postgres/src/include/utils/portal.h
+++ b/src/postgres/src/include/utils/portal.h
@@ -248,5 +248,6 @@ extern void PortalHashTableDeleteAll(void);
 extern bool ThereAreNoReadyPortals(void);
 extern void HoldPinnedPortals(void);
 extern void ForgetPortalSnapshots(void);
+extern void YbForEachPortal(void (*callback) (Portal portal));
 
 #endif							/* PORTAL_H */

--- a/src/postgres/src/include/yb_dist_trace.h
+++ b/src/postgres/src/include/yb_dist_trace.h
@@ -1,0 +1,33 @@
+/*-------------------------------------------------------------------------
+ *
+ * yb_dist_trace.h
+ *	  Distributed tracing/Yugabyte (Postgres layer) executor hooks.
+ *
+ * Copyright (c) YugabyteDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * src/include/yb_dist_trace.h
+ * ----------
+ */
+
+#ifndef YB_DIST_TRACE_H
+#define YB_DIST_TRACE_H
+
+struct PlanState;
+
+extern void YbDistTraceInstallExecutorHooks(void);
+extern void YbDistTraceEndNodeSpans(struct PlanState *planstate, bool errored);
+extern void YbDistTraceEndOpenNodeSpans(void);
+
+#endif							/* YB_DIST_TRACE_H */

--- a/src/postgres/src/tools/pgindent/yb_typedefs.list
+++ b/src/postgres/src/tools/pgindent/yb_typedefs.list
@@ -259,6 +259,7 @@ YbcMetricsInfo
 YbcObjectLockId
 YbcObjectLockMode
 YbcOrderingMode
+YbcOtelNodeSpan
 YbcOtelSpanContext
 YbcPallocFn
 YbcPgAshConfig

--- a/src/yb/yql/pggate/ybc_dist_trace.cc
+++ b/src/yb/yql/pggate/ybc_dist_trace.cc
@@ -13,6 +13,8 @@
 
 #include "yb/yql/pggate/ybc_dist_trace.h"
 
+#include <memory>
+#include <optional>
 #include <stack>
 
 #include "opentelemetry/common/attribute_value.h"
@@ -31,7 +33,6 @@ namespace yb::pggate {
 namespace {
 
 namespace context = opentelemetry::context;
-namespace common = opentelemetry::common;
 namespace trace = opentelemetry::trace;
 namespace nostd = opentelemetry::nostd;
 
@@ -59,6 +60,69 @@ class OtelSpanContext : public PgMemctx::Registrable {
 
  private:
   trace::SpanContext span_ctx_;
+};
+
+// PushScope() makes the executor plan node span, the current span during each
+// call so child spans (RPC, shared-memory) nest under it. This prevents creating
+// a node span on each tuple.
+class OtelNodeSpan : public PgMemctx::Registrable {
+ public:
+  explicit OtelNodeSpan(nostd::shared_ptr<trace::Span> span)
+      : span_(std::move(span)) {}
+
+  // Every node span is ended explicitly: at ExecEndNode, at the message
+  // boundary for a suspended portal, by the executor error hooks, or by
+  // PortalCleanup of a failed portal. Reaching teardown un-ended means one of
+  // those paths was missed, not a case to handle here: ~Span() ends the span
+  // (leaving its status unset) and ~Scope detaches, so nothing is lost but the
+  // status and an accurate end time.
+  ~OtelNodeSpan() override {
+    DCHECK(ended_) << "node span reached memctx teardown un-ended";
+  }
+
+  void PushScope() {
+    DCHECK(!scope_) << "node span scope already active";
+    scope_.emplace(span_);
+  }
+
+  void PopScope() {
+    DCHECK(scope_) << "node span scope not active";
+    scope_.reset();
+  }
+
+  void End() {
+    DCHECK(!scope_) << "node span ended while its scope is still current";
+    span_->SetStatus(trace::StatusCode::kOk);
+    FinishSpan();
+  }
+
+  // Error-path cleanup. A node whose scope is still attached was on the
+  // active ExecProcNode call chain when the error longjmp fired, so it (and
+  // its ancestors, whose scopes are also still attached) genuinely failed.
+  // An idle node's calls all returned normally before the failure: leave its
+  // status unset, ExecEndNode never confirmed completion, so kOk would
+  // overclaim and mark that error cleanup ended it.
+  void EndOnError() {
+    if (scope_) {
+      span_->SetStatus(trace::StatusCode::kError, "node interrupted by error");
+      // The longjmp skipped PopScope(); detach before ending so the
+      // RuntimeContext never holds an ended span as its current span.
+      scope_.reset();
+    } else {
+      span_->SetAttribute("yb.ended_by_error_cleanup", true);
+    }
+    FinishSpan();
+  }
+
+ private:
+  void FinishSpan() {
+    ended_ = true;
+    span_->End();
+  }
+
+  nostd::shared_ptr<trace::Span> span_;
+  std::optional<trace::Scope> scope_;
+  bool ended_ = false;
 };
 
 extern "C" {
@@ -145,14 +209,20 @@ void YBCDistTraceStartSpan(const char* op_name) {
   OtelScopeStack().emplace(trace::Scope(span), std::move(span));
 }
 
+// The attribute setters target the RuntimeContext's current span rather than
+// the scope-stack top: node spans are made current via OtelNodeSpan::PushScope
+// without going through the stack, so during ExecProcNode this is the only way
+// node-level attributes (e.g. sort.type) reach the node span instead of the
+// enclosing execute span. Stack spans install a trace::Scope too, so outside
+// node execution both notions of "current" coincide.
 void YBCDistTraceSetCurrSpanAttrUint64(const char* key, uint64_t value) {
   DCHECK(!YBCIsOtelScopeStackEmpty());
-  DCHECK_NOTNULL(OtelScopeStack().top().second)->SetAttribute(key, value);
+  trace::Tracer::GetCurrentSpan()->SetAttribute(key, value);
 }
 
 void YBCDistTraceSetCurrSpanAttrStr(const char* key, const char* value) {
   DCHECK(!YBCIsOtelScopeStackEmpty());
-  DCHECK_NOTNULL(OtelScopeStack().top().second)->SetAttribute(key, value);
+  trace::Tracer::GetCurrentSpan()->SetAttribute(key, value);
 }
 
 void YBCDistTraceEndSpan() {
@@ -167,6 +237,40 @@ bool YBCDistTraceIsRootSpan() {
 
 bool YBCIsOtelScopeStackEmpty() {
   return OtelScopeStack().empty();
+}
+
+// Executor plan-node spans (one span per node, not per tuple): created on the
+// node's first ExecProcNode call, current for the duration of each call, and
+// ended at ExecEndNode, at the end of the protocol message if the portal is
+// suspended (so a span never outlives its message's root span), or by the
+// executor hooks in yb_dist_trace.c on query abort.
+YbcOtelNodeSpan YBCDistTraceCreateNodeSpan(const char* op_name) {
+  DCHECK(YBCIsDistTraceActive());
+  // StartSpan inherits the implicit context (the parent node's span, or the
+  // enclosing execute span for the root node). Ownership lives in the current
+  // YB memctx (es_query_cxt); the End functions destroy it early.
+  auto node_span = std::make_unique<OtelNodeSpan>(dist_trace::StartSpan(op_name));
+  auto* raw = node_span.get();
+  YBCGetPgCallbacks()->GetCurrentYbMemctx()->Register(node_span.release());
+  return raw;
+}
+
+void YBCDistTraceNodeSpanPushScope(YbcOtelNodeSpan node_span) {
+  DCHECK_NOTNULL(node_span)->PushScope();
+}
+
+void YBCDistTraceNodeSpanPopScope(YbcOtelNodeSpan node_span) {
+  DCHECK_NOTNULL(node_span)->PopScope();
+}
+
+void YBCDistTraceEndNodeSpan(YbcOtelNodeSpan node_span) {
+  DCHECK_NOTNULL(node_span)->End();
+  PgMemctx::Destroy(node_span);
+}
+
+void YBCDistTraceEndNodeSpanOnError(YbcOtelNodeSpan node_span) {
+  DCHECK_NOTNULL(node_span)->EndOnError();
+  PgMemctx::Destroy(node_span);
 }
 
 } // extern "C"

--- a/src/yb/yql/pggate/ybc_dist_trace.h
+++ b/src/yb/yql/pggate/ybc_dist_trace.h
@@ -76,6 +76,12 @@ void YBCDistTraceEndSpan();
 bool YBCDistTraceIsRootSpan();
 void YBCDistTraceClearStack();
 
+YbcOtelNodeSpan YBCDistTraceCreateNodeSpan(const char* op_name);
+void YBCDistTraceNodeSpanPushScope(YbcOtelNodeSpan node_span);
+void YBCDistTraceNodeSpanPopScope(YbcOtelNodeSpan node_span);
+void YBCDistTraceEndNodeSpan(YbcOtelNodeSpan node_span);
+void YBCDistTraceEndNodeSpanOnError(YbcOtelNodeSpan node_span);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/src/yb/yql/pggate/ybc_pg_typedefs.h
+++ b/src/yb/yql/pggate/ybc_pg_typedefs.h
@@ -66,6 +66,9 @@ YB_DEFINE_HANDLE_TYPE(PgMemctx);
 // Handle to a distributed trace span context.
 YB_DEFINE_HANDLE_TYPE(OtelSpanContext);
 
+// Handle to a live distributed-trace span for a single executor plan node.
+YB_DEFINE_HANDLE_TYPE(OtelNodeSpan);
+
 // Represents STATUS_* definitions from src/postgres/src/include/c.h.
 #define YBC_STATUS_OK     (0)
 #define YBC_STATUS_ERROR  (-1)

--- a/src/yb/yql/pgwrapper/dist_trace-test.cc
+++ b/src/yb/yql/pgwrapper/dist_trace-test.cc
@@ -68,6 +68,7 @@ namespace {
 namespace otlp = opentelemetry::proto::collector::trace::v1;
 namespace otlp_common = opentelemetry::proto::common::v1;
 namespace otlp_resource = opentelemetry::proto::resource::v1;
+namespace otlp_trace = opentelemetry::proto::trace::v1;
 
 static constexpr auto kOtelBatchMaxQueueSize = 4096;
 static constexpr auto kOtelBatchMaxExportBatchSize = 512;
@@ -108,8 +109,12 @@ struct Span {
   int64_t db_id = 0;
   int64_t user_id = 0;
   std::string status_message;
+  int status_code = otlp_trace::Status::STATUS_CODE_UNSET;
   std::unordered_map<std::string, std::string> str_attrs;
   std::unordered_map<std::string, int64_t> int_attrs;
+  std::unordered_map<std::string, bool> bool_attrs;
+  uint64_t start_nanos = 0;
+  uint64_t end_nanos = 0;
 
   bool operator<(const Span& other) const {
     return std::tie(op_name, service_name, query_text, trace_id, db_id, user_id) <
@@ -534,14 +539,20 @@ class OtlpHttpCollector {
               .db_id = FindIntAttribute(span.attributes(), "db.id"),
               .user_id = FindIntAttribute(span.attributes(), "user.id"),
               .status_message = span.status().message(),
+              .status_code = span.status().code(),
               .str_attrs = {},
               .int_attrs = {},
+              .bool_attrs = {},
+              .start_nanos = span.start_time_unix_nano(),
+              .end_nanos = span.end_time_unix_nano(),
           };
           for (const auto& attr : span.attributes()) {
             if (attr.value().has_string_value()) {
               new_span.str_attrs[attr.key()] = attr.value().string_value();
             } else if (attr.value().has_int_value()) {
               new_span.int_attrs[attr.key()] = attr.value().int_value();
+            } else if (attr.value().has_bool_value()) {
+              new_span.bool_attrs[attr.key()] = attr.value().bool_value();
             }
           }
           trace.spans.push_back(std::move(new_span));
@@ -692,8 +703,10 @@ class DistTraceTest : public LibPqTestBase {
         .db_id = db_id,
         .user_id = user_id,
         .status_message = {},
+        .status_code = otlp_trace::Status::STATUS_CODE_UNSET,
         .str_attrs = {},
         .int_attrs = {},
+        .bool_attrs = {},
     };
   }
 
@@ -1405,6 +1418,104 @@ TEST_F(DistTraceTest, TestNodeSpans) {
   ASSERT_OK(conn_->Execute("RESET enable_material"));
 }
 
+// A query failing mid-execution longjmps past ExecEndNode, so the node span
+// must be closed with error status by the ExecutorRun hook's error cleanup.
+TEST_F(DistTraceTest, TestNodeSpanClosedOnMidExecutionError) {
+  ASSERT_OK(CreateTable("err_t", 5));
+
+  auto tp = GenerateTraceparent();
+  ASSERT_OK(conn_->ExecuteFormat(
+      "SET yb_dist_tracecontext = 'traceparent=''$0'''", tp.full));
+
+  // Fails inside the Seq Scan's ExecProcNode call, after its span is created.
+  ASSERT_NOK(conn_->Fetch("SELECT 1/(id-id) FROM err_t"));
+
+  ASSERT_OK(WaitFor(
+      [&]() -> Result<bool> {
+        auto scan_spans = collector_.FindSpansByNamePrefix(tp.trace_id, "Seq Scan");
+        return !scan_spans.empty() &&
+               scan_spans.front().status_message == "node interrupted by error";
+      },
+      kOtelBatchScheduleDelayMs * kTimeMultiplier * 50ms,
+      "errored Seq Scan node span to appear in trace"));
+
+  // Tracing must keep working on the same connection after the abort.
+  auto tp2 = GenerateTraceparent();
+  ASSERT_OK(conn_->ExecuteFormat(
+      "SET yb_dist_tracecontext = 'traceparent=''$0'''", tp2.full));
+  ASSERT_OK(conn_->Fetch("SELECT * FROM err_t"));
+  ASSERT_OK(collector_.VerifyTraceContainsOpName(tp2.trace_id, "query"));
+}
+
+// On a mid-execution error, only nodes on the active ExecProcNode call chain
+// are marked errored. A node span that is still open but idle (every call it
+// ran returned normally) belongs to a subtree that finished its work before
+// the failure; it must end with unset status plus a yb.ended_by_error_cleanup
+// marker so the trace pinpoints the failing node instead of painting the
+// whole plan tree as failed.
+TEST_F(DistTraceTest, TestCompletedNodeSpanNotErroredOnLaterError) {
+  ASSERT_OK(CreateTable("err_done_t", 5));
+
+  auto tp = GenerateTraceparent();
+  ASSERT_OK(conn_->ExecuteFormat(
+      "SET yb_dist_tracecontext = 'traceparent=''$0'''", tp.full));
+
+  // The Aggregate's first ExecProcNode call drains the Seq Scan to completion,
+  // then the division by zero fails in the Aggregate's own projection, so the
+  // Aggregate is the only node mid-call when the error fires.
+  ASSERT_NOK(conn_->Fetch("SELECT 1 / (sum(id) - sum(id)) FROM err_done_t"));
+
+  ASSERT_OK(WaitFor(
+      [&]() -> Result<bool> {
+        return !collector_.FindSpansByNamePrefix(tp.trace_id, "Aggregate").empty() &&
+               !collector_.FindSpansByNamePrefix(tp.trace_id, "Seq Scan").empty();
+      },
+      kOtelBatchScheduleDelayMs * kTimeMultiplier * 50ms,
+      "Aggregate and Seq Scan node spans to appear in trace"));
+
+  auto agg_spans = collector_.FindSpansByNamePrefix(tp.trace_id, "Aggregate");
+  ASSERT_EQ(agg_spans.size(), 1);
+  ASSERT_EQ(agg_spans.front().status_code, otlp_trace::Status::STATUS_CODE_ERROR);
+  ASSERT_EQ(agg_spans.front().status_message, "node interrupted by error");
+
+  auto scan_spans = collector_.FindSpansByNamePrefix(tp.trace_id, "Seq Scan");
+  ASSERT_EQ(scan_spans.size(), 1);
+  const auto& scan_span = scan_spans.front();
+  ASSERT_EQ(scan_span.status_code, otlp_trace::Status::STATUS_CODE_UNSET)
+      << "completed node span marked with status message: " << scan_span.status_message;
+  ASSERT_TRUE(scan_span.bool_attrs.contains("yb.ended_by_error_cleanup"))
+      << "yb.ended_by_error_cleanup attribute missing on span ended by error cleanup";
+}
+
+// Node-level attributes are set while the node span is current in the OTel
+// RuntimeContext (node spans never go through the scope stack), so sort.type
+// must land on the Sort node span, not the enclosing execute span.
+TEST_F(DistTraceTest, TestSortTypeAttributeOnSortNodeSpan) {
+  ASSERT_OK(CreateTable("sort_t", 20));
+
+  auto tp = GenerateTraceparent();
+  ASSERT_OK(conn_->ExecuteFormat(
+      "SET yb_dist_tracecontext = 'traceparent=''$0'''", tp.full));
+  ASSERT_OK(conn_->Fetch("SELECT * FROM sort_t ORDER BY val"));
+
+  ASSERT_OK(WaitFor(
+      [&]() -> Result<bool> {
+        return collector_.HasSpanWithName(tp.trace_id, "Sort");
+      },
+      kOtelBatchScheduleDelayMs * kTimeMultiplier * 30ms,
+      "Sort node span to appear in trace"));
+
+  auto sort_span = collector_.FindSpanByNamePrefix(tp.trace_id, "Sort");
+  ASSERT_TRUE(sort_span.has_value()) << "Sort span not found";
+  ASSERT_TRUE(sort_span->str_attrs.contains("sort.type"))
+      << "sort.type attribute missing on Sort node span";
+
+  auto execute_span = collector_.FindSpanByNamePrefix(tp.trace_id, "execute");
+  ASSERT_TRUE(execute_span.has_value()) << "execute span not found";
+  ASSERT_FALSE(execute_span->str_attrs.contains("sort.type"))
+      << "sort.type attribute leaked onto the execute span";
+}
+
 TEST_F(DistTraceTest, TestExtendedQueryProtocolComment) {
   auto ext_conn = ASSERT_RESULT(Connect(false /* simple_query_protocol */));
   auto tp = GenerateTraceparent();
@@ -1771,6 +1882,94 @@ TEST_F(DistTraceRpcTest, TestOtelInternalLogLevelNoneSuppressesAllMessages) {
   ASSERT_EQ(warning_waiter.GetEventCount(), 0);
   ASSERT_EQ(info_waiter.GetEventCount(), 0);
   ASSERT_EQ(debug_waiter.GetEventCount(), 0);
+}
+
+// A multi-row scan must emit exactly one executor-node span (not one per
+// tuple), with the scan's storage RPC nested under it.
+TEST_F(DistTraceRpcTest, TestNodeSpanPerNodeAndRpcNesting) {
+  constexpr int kNumRows = 50;
+  ASSERT_OK(CreateTable("node_span_test", kNumRows));
+
+  auto tp = GenerateTraceparent();
+  ASSERT_OK(conn_->ExecuteFormat(
+      "SET yb_dist_tracecontext = 'traceparent=''$0'''", tp.full));
+
+  ASSERT_OK(conn_->Fetch("SELECT * FROM node_span_test"));
+
+  // At least one RPC span must be a direct child of the Seq Scan node span.
+  ASSERT_OK(WaitFor(
+      [&]() -> Result<bool> {
+        auto scan_spans = collector_.FindSpansByNamePrefix(tp.trace_id, "Seq Scan");
+        if (scan_spans.empty()) return false;
+        auto rpc_spans = collector_.FindSpansByNamePrefix(tp.trace_id, "rpc ");
+        return std::any_of(rpc_spans.begin(), rpc_spans.end(), [&](const Span& rpc) {
+          return std::any_of(scan_spans.begin(), scan_spans.end(), [&](const Span& scan) {
+            return rpc.parent_span_id == scan.span_id;
+          });
+        });
+      },
+      kOtelBatchScheduleDelayMs * kTimeMultiplier * 50ms,
+      "Seq Scan node span with a child RPC span"));
+
+  // Exactly one Seq Scan span regardless of row count; settle first so any
+  // stray per-tuple spans would already have been exported.
+  SleepFor(kOtelBatchScheduleDelayMs * kTimeMultiplier * 4ms);
+  auto scan_spans = collector_.FindSpansByNamePrefix(tp.trace_id, "Seq Scan");
+  ASSERT_EQ(scan_spans.size(), 1)
+      << "expected exactly one Seq Scan node span, got " << scan_spans.size();
+
+  // The node span starts within its parent execute span. Its end is not
+  // asserted to be contained: node spans end at ExecEndNode (executor
+  // teardown), which runs after the execute span has closed, so a small
+  // overhang past the parent's end is expected.
+  const auto& scan = scan_spans.front();
+  auto parent = collector_.FindSpanBySpanId(tp.trace_id, scan.parent_span_id);
+  ASSERT_TRUE(parent.has_value()) << "Seq Scan parent span not found";
+  ASSERT_GE(scan.start_nanos, parent->start_nanos)
+      << "Seq Scan starts before its parent '" << parent->op_name << "'";
+}
+
+// A cursor scanned across multiple FETCH messages must emit one Seq Scan node
+// span per message. The node outlives each message (ExecEndNode only runs at
+// CLOSE), so a single live span would attribute the second FETCH's work to
+// the first message and leave the second FETCH's subtree empty.
+TEST_F(DistTraceRpcTest, TestCursorFetchEmitsNodeSpanPerMessage) {
+  constexpr int kNumRows = 50;
+  ASSERT_OK(CreateTable("cursor_test", kNumRows));
+
+  auto tp = GenerateTraceparent();
+  ASSERT_OK(conn_->ExecuteFormat(
+      "SET yb_dist_tracecontext = 'traceparent=''$0'''", tp.full));
+
+  ASSERT_OK(conn_->Execute("BEGIN"));
+  ASSERT_OK(conn_->Execute("DECLARE c CURSOR FOR SELECT * FROM cursor_test"));
+  ASSERT_OK(conn_->Fetch("FETCH 5 FROM c"));
+  ASSERT_OK(conn_->Fetch("FETCH 5 FROM c"));
+  ASSERT_OK(conn_->Execute("CLOSE c"));
+  ASSERT_OK(conn_->Execute("COMMIT"));
+
+  ASSERT_OK(WaitFor(
+      [&]() -> Result<bool> {
+        return collector_.FindSpansByNamePrefix(tp.trace_id, "Seq Scan").size() >= 2;
+      },
+      kOtelBatchScheduleDelayMs * kTimeMultiplier * 50ms,
+      "One Seq Scan node span per FETCH message"));
+
+  // Settle so any stray span (e.g. one ended only at CLOSE) gets exported.
+  SleepFor(kOtelBatchScheduleDelayMs * kTimeMultiplier * 4ms);
+  auto scan_spans = collector_.FindSpansByNamePrefix(tp.trace_id, "Seq Scan");
+  ASSERT_EQ(scan_spans.size(), 2)
+      << "expected one Seq Scan node span per FETCH, got " << scan_spans.size();
+
+  // Each FETCH's scan span must hang under its own message's spans, starting
+  // within its parent.
+  ASSERT_NE(scan_spans[0].parent_span_id, scan_spans[1].parent_span_id);
+  for (const auto& scan : scan_spans) {
+    auto parent = collector_.FindSpanBySpanId(tp.trace_id, scan.parent_span_id);
+    ASSERT_TRUE(parent.has_value()) << "Seq Scan parent span not found";
+    ASSERT_GE(scan.start_nanos, parent->start_nanos)
+        << "Seq Scan starts before its parent '" << parent->op_name << "'";
+  }
 }
 
 TEST_F(DistTraceRpcTest, TestErroredRpcSpanStatus) {


### PR DESCRIPTION
Summary:
The executor wrapped every ExecProcNode call in a distributed-tracing span,
producing one span per tuple (millions of spans for a large scan). This revision
changes the behaviour to emit exactly one span per executor plan node:

- Create the node's span on its first ExecProcNode call and keep it the current
  span for the duration of each call, so live RPC and shared-memory spans nest
  under the executor node that issued them.
- Since we cannot figure out if a particular RPC / row fetch is the last one for
  any execProcNode, we end all exec node spans together at ExecEndNode.
- Close any still-open node spans on query abort.

All previously emitted spans (root query, parse/rewrite/plan, the extended
protocol ext.* spans, RPC and shared-memory spans) are unchanged.

Original commit: 103f54edc9b5c2b86c5e55079c0ad6f9f89b9d2a / D54967

Test Plan:
./yb_build.sh --cxx-test dist_trace-test --gtest_filter DistTraceTest.TestNodeSpanPerNodeAndRpcNesting

Manual: ran traced Seq Scan, Nested Loop, and YB Batched Nested Loop queries on
a local cluster exporting to an OTLP collector + Jaeger. Confirmed exactly one
span per executor node regardless of row count , RPC spans
nested under the issuing node, and correct parent containment at every level.

Reviewers: asaha, aman.mangal

Reviewed By: asaha

Subscribers: swapnil.kasaliwal, jason, yql, ybase

Differential Revision: https://phorge.dev.yugabyte.com/D54967

## Merge conflicts

- src/postgres/src/include/nodes/execnodes.h:776 — this commit's own addition (bool yb_dist_trace_has_node_spans;) sits right after an unrelated field, yb_read_ahead_allowed, that exists on master (added separately by the SKIP LOCKED read-ahead-optimization work, #23584) but was never backported to 2025.2. Losing that anchor line made git dump both fields into the conflict. Resolved by keeping only yb_dist_trace_has_node_spans, matching this commit's actual diff; did not introduce the unrelated field.
