### PR TITLE
[#33103] DocDB: Copy the remote bootstrap source out of peers_map_ under queue_lock_

### DIFF
--- a/src/yb/consensus/consensus_queue-test.cc
+++ b/src/yb/consensus/consensus_queue-test.cc
@@ -1092,7 +1092,7 @@ TEST_F(ConsensusQueueTest, TestRemoteBootstrapSourceUntrackedAfterQueueLockRelea
   ASSERT_OK(queue_->RequestForPeer(kPeerUuid, &request, &refs, &needs_remote_bootstrap));
   ASSERT_TRUE(needs_remote_bootstrap);
 
-  // Delete peer-2 right after the queue lock is released, before its fields are read.
+  // Delete peer-2 as soon as the queue lock is released.
   auto* sync_point = SyncPoint::GetInstance();
   sync_point->SetCallBack(
       "PeerMessageQueue::GetRemoteBootstrapRequestForPeer:AfterQueueLockReleased",
@@ -1106,7 +1106,6 @@ TEST_F(ConsensusQueueTest, TestRemoteBootstrapSourceUntrackedAfterQueueLockRelea
   StartRemoteBootstrapRequestPB rb_req;
   ASSERT_OK(queue_->GetRemoteBootstrapRequestForPeer(kPeerUuid, &rb_req));
 
-  // Without the fix these read the freed TrackedPeer.
   ASSERT_TRUE(rb_req.IsInitialized()) << rb_req.ShortDebugString();
   ASSERT_EQ(kTestTablet, rb_req.tablet_id());
   ASSERT_EQ(kRbsSourceUuid, rb_req.bootstrap_source_peer_uuid());

--- a/src/yb/consensus/consensus_queue-test.cc
+++ b/src/yb/consensus/consensus_queue-test.cc
@@ -49,6 +49,7 @@
 #include "yb/server/hybrid_clock.h"
 
 #include "yb/util/metrics.h"
+#include "yb/util/sync_point.h"
 #include "yb/util/test_macros.h"
 #include "yb/util/test_util.h"
 #include "yb/util/threadpool.h"
@@ -56,6 +57,7 @@
 using std::string;
 
 DECLARE_bool(enable_data_block_fsync);
+DECLARE_bool(remote_bootstrap_from_leader_only);
 DECLARE_uint64(consensus_max_batch_size_bytes);
 
 METRIC_DECLARE_entity(tablet);
@@ -1022,6 +1024,97 @@ TEST_F(ConsensusQueueTest, TestTriggerRemoteBootstrapIfTabletNotFound) {
   ASSERT_EQ(kLeaderUuid, rb_req.bootstrap_source_peer_uuid());
   ASSERT_EQ(FakeRaftPeerPB(kLeaderUuid).last_known_private_addr()[0].ShortDebugString(),
             rb_req.bootstrap_source_private_addr()[0].ShortDebugString());
+}
+
+TEST_F(ConsensusQueueTest, TestRemoteBootstrapSourceUntrackedAfterQueueLockRelease) {
+  // Let a follower serve the bootstrap; otherwise the leader is always the source.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_remote_bootstrap_from_leader_only) = false;
+
+  constexpr auto kRbsSourceUuid = "peer-2";
+  constexpr auto kZone = "zone-1";
+
+  // Put both peers in one zone, so peer-2 is closer to peer-1 than the leader is.
+  auto peer_pb = [kZone](const std::string& uuid) {
+    RaftPeerPB peer_pb;
+    peer_pb.set_permanent_uuid(uuid);
+    auto* cloud_info = peer_pb.mutable_cloud_info();
+    cloud_info->set_placement_cloud("cloud-1");
+    cloud_info->set_placement_region("region-1");
+    cloud_info->set_placement_zone(kZone);
+    auto* addr = peer_pb.mutable_last_known_private_addr()->Add();
+    addr->set_host(uuid + ".fake-domain-for-tests");
+    addr->set_port(0);
+    return peer_pb;
+  };
+
+  queue_->Init(OpId::Min());
+  queue_->SetLeaderMode(
+      OpId::Min(), OpId::Min().term, OpId::Min(), OpId(), BuildRaftConfigPBForTests(3));
+  AppendReplicateMessagesToQueue(queue_.get(), clock_, 1, kNumMessages);
+
+  queue_->TrackPeer(peer_pb(kPeerUuid));
+  queue_->TrackPeer(peer_pb(kRbsSourceUuid));
+
+  ThreadSafeArena arena;
+  LWConsensusRequestPB request(&arena);
+  LWReplicateMsgsHolder refs;
+  bool needs_remote_bootstrap;
+
+  // Have peer-2 reply successfully, so it is caught up and can serve a remote bootstrap.
+  {
+    LWConsensusResponsePB response(&arena);
+    response.ref_responder_uuid(kRbsSourceUuid);
+    ASSERT_OK(queue_->RequestForPeer(kRbsSourceUuid, &request, &refs, &needs_remote_bootstrap));
+    ASSERT_FALSE(needs_remote_bootstrap);
+    SetLastReceivedAndLastCommitted(&response, MakeOpIdForIndex(kNumMessages));
+    queue_->ResponseFromPeer(kRbsSourceUuid, response);
+    request.Clear();
+    refs.Reset();
+  }
+  // Check the source qualifies before relying on it being picked.
+  const auto rbs_source = queue_->GetTrackedPeerForTests(kRbsSourceUuid);
+  ASSERT_TRUE(rbs_source.is_last_exchange_successful);
+  ASSERT_EQ(PeerMemberType::VOTER, rbs_source.member_type);
+  ASSERT_EQ(MakeOpIdForIndex(kNumMessages), rbs_source.last_received);
+
+  // Have peer-1 reply that it has no tablet, so the leader marks it for remote bootstrap.
+  {
+    LWConsensusResponsePB response(&arena);
+    response.ref_responder_uuid(kPeerUuid);
+    ASSERT_OK(queue_->RequestForPeer(kPeerUuid, &request, &refs, &needs_remote_bootstrap));
+    ASSERT_FALSE(needs_remote_bootstrap);
+    response.mutable_error()->set_code(tserver::TabletServerErrorPB::TABLET_NOT_FOUND);
+    StatusToPB(STATUS(NotFound, "No such tablet"), response.mutable_error()->mutable_status());
+    ASSERT_TRUE(queue_->ResponseFromPeer(kPeerUuid, response));
+    request.Clear();
+    refs.Reset();
+  }
+  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, &request, &refs, &needs_remote_bootstrap));
+  ASSERT_TRUE(needs_remote_bootstrap);
+
+  // Delete peer-2 right after the queue lock is released, before its fields are read.
+  auto* sync_point = SyncPoint::GetInstance();
+  sync_point->SetCallBack(
+      "PeerMessageQueue::GetRemoteBootstrapRequestForPeer:AfterQueueLockReleased",
+      [this](void*) { queue_->UntrackPeer(kRbsSourceUuid); });
+  sync_point->EnableProcessing();
+  auto se = ScopeExit([sync_point] {
+    sync_point->DisableProcessing();
+    sync_point->ClearAllCallBacks();
+  });
+
+  StartRemoteBootstrapRequestPB rb_req;
+  ASSERT_OK(queue_->GetRemoteBootstrapRequestForPeer(kPeerUuid, &rb_req));
+
+  // Without the fix these read the freed TrackedPeer.
+  ASSERT_TRUE(rb_req.IsInitialized()) << rb_req.ShortDebugString();
+  ASSERT_EQ(kTestTablet, rb_req.tablet_id());
+  ASSERT_EQ(kRbsSourceUuid, rb_req.bootstrap_source_peer_uuid());
+  ASSERT_FALSE(rb_req.is_served_by_tablet_leader());
+  ASSERT_EQ(1, rb_req.bootstrap_source_private_addr().size());
+  ASSERT_EQ(peer_pb(kRbsSourceUuid).last_known_private_addr()[0].ShortDebugString(),
+            rb_req.bootstrap_source_private_addr()[0].ShortDebugString());
+  ASSERT_EQ(kZone, rb_req.bootstrap_source_cloud_info().placement_zone());
 }
 
 // Tests that TestReadReplicatedMessagesForCDC() only reads messages until the last known

--- a/src/yb/consensus/consensus_queue-test.cc
+++ b/src/yb/consensus/consensus_queue-test.cc
@@ -49,7 +49,6 @@
 #include "yb/server/hybrid_clock.h"
 
 #include "yb/util/metrics.h"
-#include "yb/util/sync_point.h"
 #include "yb/util/test_macros.h"
 #include "yb/util/test_util.h"
 #include "yb/util/threadpool.h"
@@ -57,7 +56,6 @@
 using std::string;
 
 DECLARE_bool(enable_data_block_fsync);
-DECLARE_bool(remote_bootstrap_from_leader_only);
 DECLARE_uint64(consensus_max_batch_size_bytes);
 
 METRIC_DECLARE_entity(tablet);
@@ -1024,96 +1022,6 @@ TEST_F(ConsensusQueueTest, TestTriggerRemoteBootstrapIfTabletNotFound) {
   ASSERT_EQ(kLeaderUuid, rb_req.bootstrap_source_peer_uuid());
   ASSERT_EQ(FakeRaftPeerPB(kLeaderUuid).last_known_private_addr()[0].ShortDebugString(),
             rb_req.bootstrap_source_private_addr()[0].ShortDebugString());
-}
-
-TEST_F(ConsensusQueueTest, TestRemoteBootstrapSourceUntrackedAfterQueueLockRelease) {
-  // Let a follower serve the bootstrap; otherwise the leader is always the source.
-  ANNOTATE_UNPROTECTED_WRITE(FLAGS_remote_bootstrap_from_leader_only) = false;
-
-  constexpr auto kRbsSourceUuid = "peer-2";
-  constexpr auto kZone = "zone-1";
-
-  // Put both peers in one zone, so peer-2 is closer to peer-1 than the leader is.
-  auto peer_pb = [kZone](const std::string& uuid) {
-    RaftPeerPB peer_pb;
-    peer_pb.set_permanent_uuid(uuid);
-    auto* cloud_info = peer_pb.mutable_cloud_info();
-    cloud_info->set_placement_cloud("cloud-1");
-    cloud_info->set_placement_region("region-1");
-    cloud_info->set_placement_zone(kZone);
-    auto* addr = peer_pb.mutable_last_known_private_addr()->Add();
-    addr->set_host(uuid + ".fake-domain-for-tests");
-    addr->set_port(0);
-    return peer_pb;
-  };
-
-  queue_->Init(OpId::Min());
-  queue_->SetLeaderMode(
-      OpId::Min(), OpId::Min().term, OpId::Min(), OpId(), BuildRaftConfigPBForTests(3));
-  AppendReplicateMessagesToQueue(queue_.get(), clock_, 1, kNumMessages);
-
-  queue_->TrackPeer(peer_pb(kPeerUuid));
-  queue_->TrackPeer(peer_pb(kRbsSourceUuid));
-
-  ThreadSafeArena arena;
-  LWConsensusRequestPB request(&arena);
-  LWReplicateMsgsHolder refs;
-  bool needs_remote_bootstrap;
-
-  // Have peer-2 reply successfully, so it is caught up and can serve a remote bootstrap.
-  {
-    LWConsensusResponsePB response(&arena);
-    response.ref_responder_uuid(kRbsSourceUuid);
-    ASSERT_OK(queue_->RequestForPeer(kRbsSourceUuid, &request, &refs, &needs_remote_bootstrap));
-    ASSERT_FALSE(needs_remote_bootstrap);
-    SetLastReceivedAndLastCommitted(&response, MakeOpIdForIndex(kNumMessages));
-    queue_->ResponseFromPeer(kRbsSourceUuid, response);
-    request.Clear();
-    refs.Reset();
-  }
-  // Check the source qualifies before relying on it being picked.
-  const auto rbs_source = queue_->GetTrackedPeerForTests(kRbsSourceUuid);
-  ASSERT_TRUE(rbs_source.is_last_exchange_successful);
-  ASSERT_EQ(PeerMemberType::VOTER, rbs_source.member_type);
-  ASSERT_EQ(MakeOpIdForIndex(kNumMessages), rbs_source.last_received);
-
-  // Have peer-1 reply that it has no tablet, so the leader marks it for remote bootstrap.
-  {
-    LWConsensusResponsePB response(&arena);
-    response.ref_responder_uuid(kPeerUuid);
-    ASSERT_OK(queue_->RequestForPeer(kPeerUuid, &request, &refs, &needs_remote_bootstrap));
-    ASSERT_FALSE(needs_remote_bootstrap);
-    response.mutable_error()->set_code(tserver::TabletServerErrorPB::TABLET_NOT_FOUND);
-    StatusToPB(STATUS(NotFound, "No such tablet"), response.mutable_error()->mutable_status());
-    ASSERT_TRUE(queue_->ResponseFromPeer(kPeerUuid, response));
-    request.Clear();
-    refs.Reset();
-  }
-  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, &request, &refs, &needs_remote_bootstrap));
-  ASSERT_TRUE(needs_remote_bootstrap);
-
-  // Delete peer-2 as soon as the queue lock is released.
-  auto* sync_point = SyncPoint::GetInstance();
-  sync_point->SetCallBack(
-      "PeerMessageQueue::GetRemoteBootstrapRequestForPeer:AfterQueueLockReleased",
-      [this](void*) { queue_->UntrackPeer(kRbsSourceUuid); });
-  sync_point->EnableProcessing();
-  auto se = ScopeExit([sync_point] {
-    sync_point->DisableProcessing();
-    sync_point->ClearAllCallBacks();
-  });
-
-  StartRemoteBootstrapRequestPB rb_req;
-  ASSERT_OK(queue_->GetRemoteBootstrapRequestForPeer(kPeerUuid, &rb_req));
-
-  ASSERT_TRUE(rb_req.IsInitialized()) << rb_req.ShortDebugString();
-  ASSERT_EQ(kTestTablet, rb_req.tablet_id());
-  ASSERT_EQ(kRbsSourceUuid, rb_req.bootstrap_source_peer_uuid());
-  ASSERT_FALSE(rb_req.is_served_by_tablet_leader());
-  ASSERT_EQ(1, rb_req.bootstrap_source_private_addr().size());
-  ASSERT_EQ(peer_pb(kRbsSourceUuid).last_known_private_addr()[0].ShortDebugString(),
-            rb_req.bootstrap_source_private_addr()[0].ShortDebugString());
-  ASSERT_EQ(kZone, rb_req.bootstrap_source_cloud_info().placement_zone());
 }
 
 // Tests that TestReadReplicatedMessagesForCDC() only reads messages until the last known

--- a/src/yb/consensus/consensus_queue.cc
+++ b/src/yb/consensus/consensus_queue.cc
@@ -71,6 +71,7 @@
 #include "yb/util/status_log.h"
 #include "yb/util/sync_point.h"
 #include "yb/util/tostring.h"
+#include "yb/util/unique_lock.h"
 #include "yb/util/url-coding.h"
 
 using namespace std::literals;
@@ -1090,61 +1091,53 @@ Result<const PeerMessageQueue::TrackedPeer*> PeerMessageQueue::FindClosestPeerFo
 
 Status PeerMessageQueue::GetRemoteBootstrapRequestForPeer(const string& uuid,
                                                           StartRemoteBootstrapRequestPB* req) {
-  std::optional<TrackedPeer> rbs_source;
-  int64_t current_term;
-  OpId pending_config_op_id;
-  {
-    LockGuard lock(queue_lock_);
-    DCHECK_EQ(queue_state_.state, State::kQueueOpen);
-    DCHECK_NE(uuid, local_peer_uuid_);
-    TrackedPeer* peer = FindPtrOrNull(peers_map_, uuid);
-    if (PREDICT_FALSE(peer == nullptr || queue_state_.mode == Mode::NON_LEADER)) {
-      return STATUS(NotFound, "Peer not tracked or queue not in leader mode.");
-    }
-
-    if (PREDICT_FALSE(!peer->needs_remote_bootstrap)) {
-      return STATUS(IllegalState, "Peer does not need to remotely bootstrap", uuid);
-    }
-
-    if (peer->member_type == PeerMemberType::VOTER ||
-        peer->member_type == PeerMemberType::OBSERVER) {
-      LOG(INFO) << "Remote bootstrapping peer " << uuid << " with type "
-                << PeerMemberType_Name(peer->member_type);
-    }
-
-    // Check if a closest follower can serve as the RBS source.
-    auto rbs_from_leader_only =
-        FLAGS_remote_bootstrap_from_leader_only ||
-        !peer->cloud_info.has_value() ||
-        peer->failed_bootstrap_attempts_from_non_leader >=
-            FLAGS_max_remote_bootstrap_attempts_from_non_leader;
-
-    const TrackedPeer* rbs_source_ptr =
-        rbs_from_leader_only ? local_peer_ : VERIFY_RESULT(FindClosestPeerForBootstrap(peer));
-    rbs_source.emplace(*rbs_source_ptr);
-    current_term = queue_state_.current_term;
-    pending_config_op_id = queue_state_.pending_config_op_id;
-
-    // Acess/Edit peer's fields within queue_lock_'s scope to avoid race. For instance, this peer's
-    // information could be accessed while finding RBS source for another newly added peer.
-    peer->needs_remote_bootstrap = false;
-    if (PREDICT_FALSE(FLAGS_TEST_assert_remote_bootstrap_happens_from_same_zone)) {
-      CHECK_EQ(
-          TablespaceParser::GetLocalityLevel(
-              rbs_source->cloud_info.value(), peer->cloud_info.value()),
-          LocalityLevel::kZone)
-          << "Expected rbs source to be in same zone as new peer";
-    }
+  // The whole request is populated under queue_lock_: rbs_source points into peers_map_, and
+  // UntrackPeer deletes those objects under the same lock.
+  UniqueLock<LockType> lock(queue_lock_);
+  DCHECK_EQ(queue_state_.state, State::kQueueOpen);
+  DCHECK_NE(uuid, local_peer_uuid_);
+  TrackedPeer* peer = FindPtrOrNull(peers_map_, uuid);
+  if (PREDICT_FALSE(peer == nullptr || queue_state_.mode == Mode::NON_LEADER)) {
+    return STATUS(NotFound, "Peer not tracked or queue not in leader mode.");
   }
 
-  TEST_SYNC_POINT("PeerMessageQueue::GetRemoteBootstrapRequestForPeer:AfterQueueLockReleased");
+  if (PREDICT_FALSE(!peer->needs_remote_bootstrap)) {
+    return STATUS(IllegalState, "Peer does not need to remotely bootstrap", uuid);
+  }
+
+  if (peer->member_type == PeerMemberType::VOTER ||
+      peer->member_type == PeerMemberType::OBSERVER) {
+    LOG(INFO) << "Remote bootstrapping peer " << uuid << " with type "
+              << PeerMemberType_Name(peer->member_type);
+  }
+
+  // Check if a closest follower can serve as the RBS source.
+  auto rbs_from_leader_only =
+      FLAGS_remote_bootstrap_from_leader_only ||
+      !peer->cloud_info.has_value() ||
+      peer->failed_bootstrap_attempts_from_non_leader >=
+          FLAGS_max_remote_bootstrap_attempts_from_non_leader;
+
+  const TrackedPeer* rbs_source =
+      rbs_from_leader_only ? local_peer_ : VERIFY_RESULT(FindClosestPeerForBootstrap(peer));
+
+  // Acess/Edit peer's fields within queue_lock_'s scope to avoid race. For instance, this peer's
+  // information could be accessed while finding RBS source for another newly added peer.
+  peer->needs_remote_bootstrap = false;
+  if (PREDICT_FALSE(FLAGS_TEST_assert_remote_bootstrap_happens_from_same_zone)) {
+    CHECK_EQ(
+        TablespaceParser::GetLocalityLevel(
+            rbs_source->cloud_info.value(), peer->cloud_info.value()),
+        LocalityLevel::kZone)
+        << "Expected rbs source to be in same zone as new peer";
+  }
 
   req->Clear();
   req->set_dest_uuid(uuid);
   req->set_tablet_id(tablet_id_);
   // can use leader's current term as the bootstrap request is served by the leader or any other
   // closest peer that is in the same term (when FLAGS_remote_bootstrap_from_leader_only is false).
-  req->set_caller_term(current_term);
+  req->set_caller_term(queue_state_.current_term);
   // populate req with the closest peer's info for remote bootstrapping the tracked peer
   req->set_bootstrap_source_peer_uuid(rbs_source->uuid);
   *req->mutable_bootstrap_source_private_addr() = {
@@ -1154,8 +1147,8 @@ Status PeerMessageQueue::GetRemoteBootstrapRequestForPeer(const string& uuid,
   if (rbs_source->cloud_info.has_value()) {
     *req->mutable_bootstrap_source_cloud_info() = rbs_source->cloud_info.value();
   }
-  if (pending_config_op_id.is_valid_not_empty()) {
-    pending_config_op_id.ToPB(req->mutable_pending_config_op_id());
+  if (queue_state_.pending_config_op_id.is_valid_not_empty()) {
+    queue_state_.pending_config_op_id.ToPB(req->mutable_pending_config_op_id());
   }
 
   if (rbs_source->uuid != local_peer_uuid_) {
@@ -1168,6 +1161,9 @@ Status PeerMessageQueue::GetRemoteBootstrapRequestForPeer(const string& uuid,
   } else {
     req->set_is_served_by_tablet_leader(true);
   }
+
+  lock.unlock();
+  TEST_SYNC_POINT("PeerMessageQueue::GetRemoteBootstrapRequestForPeer:AfterQueueLockReleased");
 
   return Status::OK();
 }

--- a/src/yb/consensus/consensus_queue.cc
+++ b/src/yb/consensus/consensus_queue.cc
@@ -69,9 +69,7 @@
 #include "yb/util/shared_lock.h"
 #include "yb/util/size_literals.h"
 #include "yb/util/status_log.h"
-#include "yb/util/sync_point.h"
 #include "yb/util/tostring.h"
-#include "yb/util/unique_lock.h"
 #include "yb/util/url-coding.h"
 
 using namespace std::literals;
@@ -1093,7 +1091,7 @@ Status PeerMessageQueue::GetRemoteBootstrapRequestForPeer(const string& uuid,
                                                           StartRemoteBootstrapRequestPB* req) {
   // The whole request is populated under queue_lock_: rbs_source points into peers_map_, and
   // UntrackPeer deletes those objects under the same lock.
-  UniqueLock<LockType> lock(queue_lock_);
+  LockGuard lock(queue_lock_);
   DCHECK_EQ(queue_state_.state, State::kQueueOpen);
   DCHECK_NE(uuid, local_peer_uuid_);
   TrackedPeer* peer = FindPtrOrNull(peers_map_, uuid);
@@ -1121,8 +1119,6 @@ Status PeerMessageQueue::GetRemoteBootstrapRequestForPeer(const string& uuid,
   const TrackedPeer* rbs_source =
       rbs_from_leader_only ? local_peer_ : VERIFY_RESULT(FindClosestPeerForBootstrap(peer));
 
-  // Acess/Edit peer's fields within queue_lock_'s scope to avoid race. For instance, this peer's
-  // information could be accessed while finding RBS source for another newly added peer.
   peer->needs_remote_bootstrap = false;
   if (PREDICT_FALSE(FLAGS_TEST_assert_remote_bootstrap_happens_from_same_zone)) {
     CHECK_EQ(
@@ -1161,9 +1157,6 @@ Status PeerMessageQueue::GetRemoteBootstrapRequestForPeer(const string& uuid,
   } else {
     req->set_is_served_by_tablet_leader(true);
   }
-
-  lock.unlock();
-  TEST_SYNC_POINT("PeerMessageQueue::GetRemoteBootstrapRequestForPeer:AfterQueueLockReleased");
 
   return Status::OK();
 }

--- a/src/yb/consensus/consensus_queue.cc
+++ b/src/yb/consensus/consensus_queue.cc
@@ -69,6 +69,7 @@
 #include "yb/util/shared_lock.h"
 #include "yb/util/size_literals.h"
 #include "yb/util/status_log.h"
+#include "yb/util/sync_point.h"
 #include "yb/util/tostring.h"
 #include "yb/util/url-coding.h"
 
@@ -1089,15 +1090,14 @@ Result<const PeerMessageQueue::TrackedPeer*> PeerMessageQueue::FindClosestPeerFo
 
 Status PeerMessageQueue::GetRemoteBootstrapRequestForPeer(const string& uuid,
                                                           StartRemoteBootstrapRequestPB* req) {
-  TrackedPeer* peer = nullptr;
-  const TrackedPeer* rbs_source = nullptr;
+  std::optional<TrackedPeer> rbs_source;
   int64_t current_term;
   OpId pending_config_op_id;
   {
     LockGuard lock(queue_lock_);
     DCHECK_EQ(queue_state_.state, State::kQueueOpen);
     DCHECK_NE(uuid, local_peer_uuid_);
-    peer = FindPtrOrNull(peers_map_, uuid);
+    TrackedPeer* peer = FindPtrOrNull(peers_map_, uuid);
     if (PREDICT_FALSE(peer == nullptr || queue_state_.mode == Mode::NON_LEADER)) {
       return STATUS(NotFound, "Peer not tracked or queue not in leader mode.");
     }
@@ -1119,8 +1119,9 @@ Status PeerMessageQueue::GetRemoteBootstrapRequestForPeer(const string& uuid,
         peer->failed_bootstrap_attempts_from_non_leader >=
             FLAGS_max_remote_bootstrap_attempts_from_non_leader;
 
-    rbs_source = rbs_from_leader_only ? local_peer_
-                                      : VERIFY_RESULT(FindClosestPeerForBootstrap(peer));
+    const TrackedPeer* rbs_source_ptr =
+        rbs_from_leader_only ? local_peer_ : VERIFY_RESULT(FindClosestPeerForBootstrap(peer));
+    rbs_source.emplace(*rbs_source_ptr);
     current_term = queue_state_.current_term;
     pending_config_op_id = queue_state_.pending_config_op_id;
 
@@ -1135,6 +1136,8 @@ Status PeerMessageQueue::GetRemoteBootstrapRequestForPeer(const string& uuid,
           << "Expected rbs source to be in same zone as new peer";
     }
   }
+
+  TEST_SYNC_POINT("PeerMessageQueue::GetRemoteBootstrapRequestForPeer:AfterQueueLockReleased");
 
   req->Clear();
   req->set_dest_uuid(uuid);
@@ -1155,7 +1158,7 @@ Status PeerMessageQueue::GetRemoteBootstrapRequestForPeer(const string& uuid,
     pending_config_op_id.ToPB(req->mutable_pending_config_op_id());
   }
 
-  if (rbs_source->uuid != local_peer_->uuid) {
+  if (rbs_source->uuid != local_peer_uuid_) {
     // rbs source is not the leader, hence set the leader info.
     req->set_is_served_by_tablet_leader(false);
     req->set_tablet_leader_peer_uuid(uuid);


### PR DESCRIPTION
## Summary

`PeerMessageQueue::GetRemoteBootstrapRequestForPeer` looked the remote bootstrap source up in
`peers_map_` under `queue_lock_`, kept the raw `TrackedPeer*`, and then read its `uuid`,
`cloud_info`, `last_known_private_addr` and `last_known_broadcast_addr` after releasing the lock.

`UntrackPeer` is the only deleter of those objects and runs under the same lock, reached from
`Peer::Close()` on routine configuration change, step-down and replica-eviction paths. Nothing keeps
the peer alive across the unlock, so the request could be populated from freed memory — a garbage
UUID or addresses in the RBS request, a crash, or heap corruption once the block is reused.

`local_peer_` is never deleted while the queue is open, so this needs a remote-follower source, i.e.
`remote_bootstrap_from_leader_only == false` — the auto-promoted default on finalized clusters.

Fix: copy the selected source into a `std::optional<TrackedPeer>` while the lock is held and read
the copy afterwards. `TrackedPeer` is copy-constructible and small, and the tail of the function
only formats the request, so the copy is cheap and keeps the post-unlock region intact. The one
remaining raw dereference, `local_peer_->uuid`, is replaced with the `const local_peer_uuid_` member,
which is fixed at construction and needs no lock.

## Test plan

- [x] New regression test
      `ConsensusQueueTest.TestRemoteBootstrapSourceUntrackedAfterQueueLockRelease`: tracks two
      followers in the same zone, brings one up to date so it is chosen as the closest bootstrap
      source, drives the other into remote bootstrap with a `TABLET_NOT_FOUND` response, then
      untracks the source from a sync point placed immediately after `queue_lock_` is released and
      asserts the resulting request still carries the source's uuid, address and cloud info.
- [x] Test fails on master without the fix (release build, macOS arm64 — the freed `TrackedPeer`
      yields a corrupted `bootstrap_source_peer_uuid`) and passes with it.
- [x] Full `consensus_queue-test` binary (14 cases) passes with the fix.
