### PR TITLE
[#30180] YSQL: Expose colocated tablet disk size via tablet_attrs and introduce yb_tablegroup_size() function

### DIFF
--- a/docs/content/stable/additional-features/colocation.md
+++ b/docs/content/stable/additional-features/colocation.md
@@ -169,6 +169,22 @@ Changing table colocation requires some downtime during the creation of the new 
 
 To view metrics such as table size, use the name of the parent colocation table. The colocation table name is in the format `<colocation table object ID>.colocation.parent.tablename`. All the tables in a colocation share the same metric values and these show under the colocation table for each metric. Table and tablet metrics are available at the YB-TServer endpoint (`<node-ip>:9000`) as well as in YugabyteDB Anywhere in the Metrics section for each Universe.
 
+From YSQL, you can also inspect the shared parent tablet size:
+
+```sql
+-- Per-tablet sizes (including the colocation parent row)
+SELECT relname, tablet_id, tablet_attrs
+FROM yb_tablet_metadata
+WHERE db_name = current_database()
+  AND relname LIKE '%.colocation.parent.tablename';
+
+-- Tablegroup-level convenience (leader SST + WAL bytes)
+SELECT pg_size_pretty(yb_tablegroup_size(tablegroup_oid))
+FROM yb_table_properties('my_table'::regclass);
+```
+
+`pg_table_size()` remains empty for individual colocated tables because they share storage with the parent tablet. Values are leader-replica estimates (same semantics as `pg_table_size` for non-colocated tables); multiply by the replication factor for cluster-wide disk footprint.
+
 ## Limitations and considerations
 
 - Metrics for table metrics such as table size are available for the colocation tablet, not for individual colocated tables that are part of the colocation.

--- a/docs/content/stable/additional-features/colocation.md
+++ b/docs/content/stable/additional-features/colocation.md
@@ -183,7 +183,7 @@ SELECT pg_size_pretty(yb_tablegroup_size(tablegroup_oid))
 FROM yb_table_properties('my_table'::regclass);
 ```
 
-`pg_table_size()` remains empty for individual colocated tables because they share storage with the parent tablet. Values are leader-replica estimates (same semantics as `pg_table_size` for non-colocated tables); multiply by the replication factor for cluster-wide disk footprint.
+`pg_table_size()` remains empty for individual colocated tables because they share storage with the parent tablet. Values are tablet leader estimates (same semantics as `pg_table_size` for non-colocated tables); multiply by the replication factor for cluster-wide disk footprint.
 
 ## Limitations and considerations
 

--- a/docs/content/stable/explore/observability/yb-tablet-metadata.md
+++ b/docs/content/stable/explore/observability/yb-tablet-metadata.md
@@ -39,7 +39,7 @@ The following table describes the columns of the `yb_tablet_metadata` view.
 | replicas | text[] | A list of replica IP addresses and port (includes leader) associated with the tablet. |
 | start_range | text | Starting range key (inclusive) for the tablet. (NULL for hash-sharded tables.) |
 | end_range | text | Ending range key (exclusive) for the tablet. (NULL for hash-sharded tables.) |
-| tablet_attrs | json | Reserved for future use. Currently empty. |
+| tablet_attrs | json | Leader-replica disk size fields when available: `sst_bytes`, `wal_bytes`, `uncompressed_sst_bytes`, `total_bytes` (SST+WAL), and optionally `vector_index_bytes`. NULL when sizes are unavailable or the row is privilege-masked. |
 | tablet_state | text | Current state of the tablet. <br>Possible tablet states are `PREPARING`, `CREATING`, `RUNNING`, `REPLACED`, or `DELETED`. |
 
 The `relname`, `start_range`, and `end_range` columns are masked for unprivileged users (shown as `<insufficient privilege>`). Only superusers or users with the `yb_db_admin` role can see the entire unmasked view.

--- a/docs/content/stable/explore/observability/yb-tablet-metadata.md
+++ b/docs/content/stable/explore/observability/yb-tablet-metadata.md
@@ -37,6 +37,10 @@ The following table describes the columns of the `yb_tablet_metadata` view.
 | end_hash_code | int | Ending hash code (exclusive) for the tablet. (NULL for range-sharded tables.) |
 | leader | text | IP address, port of the leader node for the tablet. |
 | replicas | text[] | A list of replica IP addresses and port (includes leader) associated with the tablet. |
+| start_range | text | Decoded start key for range-sharded tablets. (NULL for hash-sharded tables.) |
+| end_range | text | Decoded end key for range-sharded tablets. (NULL for hash-sharded tables.) |
+| tablet_attrs | jsonb | Leader-replica disk size fields when available: `sst_bytes`, `wal_bytes`, `uncompressed_sst_bytes`, `total_bytes` (SST+WAL), and optionally `vector_index_bytes`. NULL when sizes are unavailable or the row is privilege-masked. |
+| tablet_state | text | Master-side tablet lifecycle state (for example, RUNNING). |
 
 ## Examples
 

--- a/docs/content/stable/explore/observability/yb-tablet-metadata.md
+++ b/docs/content/stable/explore/observability/yb-tablet-metadata.md
@@ -39,7 +39,7 @@ The following table describes the columns of the `yb_tablet_metadata` view.
 | replicas | text[] | A list of replica IP addresses and port (includes leader) associated with the tablet. |
 | start_range | text | Starting range key (inclusive) for the tablet. (NULL for hash-sharded tables.) |
 | end_range | text | Ending range key (exclusive) for the tablet. (NULL for hash-sharded tables.) |
-| tablet_attrs | json | Leader-replica disk size fields when available: `sst_bytes`, `wal_bytes`, `uncompressed_sst_bytes`, `total_bytes` (SST+WAL), and optionally `vector_index_bytes`. NULL when sizes are unavailable or the row is privilege-masked. |
+| tablet_attrs | json | Tablet leader disk size fields when available: `sst_bytes`, `wal_bytes`, `uncompressed_sst_bytes`, `total_bytes` (SST+WAL), and optionally `vector_index_bytes`. NULL when sizes are unavailable or the row is privilege-masked. |
 | tablet_state | text | Current state of the tablet. <br>Possible tablet states are `PREPARING`, `CREATING`, `RUNNING`, `REPLACED`, or `DELETED`. |
 
 The `relname`, `start_range`, and `end_range` columns are masked for unprivileged users (shown as `<insufficient privilege>`). Only superusers or users with the `yb_db_admin` role can see the entire unmasked view.

--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -86,6 +86,7 @@
 #include "catalog/pg_yb_logical_client_version.h"
 #include "catalog/pg_yb_profile.h"
 #include "catalog/pg_yb_role_profile.h"
+#include "catalog/pg_yb_tablegroup.h"
 #include "catalog/yb_catalog_version.h"
 #include "catalog/yb_logical_client_version.h"
 #include "catalog/yb_type.h"
@@ -5962,6 +5963,43 @@ yb_is_database_colocated(PG_FUNCTION_ARGS)
 }
 
 /*
+ * Return leader SST+WAL disk size in bytes for a tablegroup's colocation
+ * parent tablet. Matches GetTableDiskSize / pg_table_size semantics (RF=1
+ * leader footprint). Errors if the oid is not a pg_yb_tablegroup entry.
+ */
+Datum
+yb_tablegroup_size(PG_FUNCTION_ARGS)
+{
+	Oid			tablegroup_oid = PG_GETARG_OID(0);
+	int64_t		size = 0;
+	int32_t		num_missing_tablets = 0;
+	HeapTuple	tuple;
+
+	tuple = SearchSysCache1(YBTABLEGROUPOID, ObjectIdGetDatum(tablegroup_oid));
+	if (!HeapTupleIsValid(tuple))
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("tablegroup with OID %u does not exist", tablegroup_oid)));
+	ReleaseSysCache(tuple);
+
+	HandleYBStatus(YBCPgGetTablegroupDiskSize(tablegroup_oid,
+											  MyDatabaseId,
+											  MyDatabaseColocated,
+											  &size,
+											  &num_missing_tablets));
+	if (num_missing_tablets > 0)
+	{
+		elog(NOTICE,
+			 "%d tablets of tablegroup %u did not provide disk size "
+			 "estimates, and were not added to the displayed totals.",
+			 num_missing_tablets,
+			 tablegroup_oid);
+	}
+
+	PG_RETURN_INT64(size);
+}
+
+/*
  * This function serves mostly as a helper for YSQL migration to introduce
  * pg_yb_catalog_version table without breaking version continuity.
  */
@@ -9175,7 +9213,10 @@ string_list_compare(const ListCell *a, const ListCell *b)
  * NULL, and start_range/end_range contain the decoded range partition key
  * boundaries.
  * Leader is provided as a separate column for simpler querying.
- * tablet_attrs is reserved for future use and is currently always NULL.
+ * tablet_attrs is a jsonb object with leader-replica disk size fields when
+ * available: sst_bytes, wal_bytes, uncompressed_sst_bytes, total_bytes
+ * (sst+wal), and optionally vector_index_bytes. NULL when sizes are
+ * unavailable or the row is privilege-masked.
  */
 Datum
 yb_get_tablet_metadata(PG_FUNCTION_ARGS)
@@ -9396,8 +9437,42 @@ yb_get_tablet_metadata(PG_FUNCTION_ARGS)
 			nulls[9] = true;
 		}
 
-		/* TODO(#30180): Populate tablet_attrs. */
-		nulls[12] = true;
+		/*
+		 * tablet_attrs: leader SST/WAL sizes. Omit when privilege-masked or
+		 * when master did not report drive info for the leader.
+		 */
+		if (show_real && tablet->has_disk_size)
+		{
+			char		attrs_buf[256];
+			int64		total_bytes =
+				tablet->sst_files_disk_size + tablet->wal_files_disk_size;
+
+			if (tablet->vector_index_disk_size > 0)
+			{
+				snprintf(attrs_buf, sizeof(attrs_buf),
+						 "{\"sst_bytes\":%lld,\"wal_bytes\":%lld,"
+						 "\"uncompressed_sst_bytes\":%lld,\"total_bytes\":%lld,"
+						 "\"vector_index_bytes\":%lld}",
+						 (long long) tablet->sst_files_disk_size,
+						 (long long) tablet->wal_files_disk_size,
+						 (long long) tablet->uncompressed_sst_files_disk_size,
+						 (long long) total_bytes,
+						 (long long) tablet->vector_index_disk_size);
+			}
+			else
+			{
+				snprintf(attrs_buf, sizeof(attrs_buf),
+						 "{\"sst_bytes\":%lld,\"wal_bytes\":%lld,"
+						 "\"uncompressed_sst_bytes\":%lld,\"total_bytes\":%lld}",
+						 (long long) tablet->sst_files_disk_size,
+						 (long long) tablet->wal_files_disk_size,
+						 (long long) tablet->uncompressed_sst_files_disk_size,
+						 (long long) total_bytes);
+			}
+			values[12] = DirectFunctionCall1(jsonb_in, CStringGetDatum(attrs_buf));
+		}
+		else
+			nulls[12] = true;
 
 		if (tablet->tablet_state)
 			values[13] = CStringGetTextDatum(tablet->tablet_state);

--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -6115,12 +6115,19 @@ yb_tablegroup_size(PG_FUNCTION_ARGS)
 	int64_t		size = 0;
 	int32_t		num_missing_tablets = 0;
 	HeapTuple	tuple;
+	char		grpname[NAMEDATALEN];
 
 	tuple = SearchSysCache1(YBTABLEGROUPOID, ObjectIdGetDatum(tablegroup_oid));
 	if (!HeapTupleIsValid(tuple))
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_OBJECT),
 				 errmsg("tablegroup with OID %u does not exist", tablegroup_oid)));
+
+	/* Copy the name and release before the RPC so we do not hold the cache pin. */
+	strlcpy(grpname,
+			NameStr(((Form_pg_yb_tablegroup) GETSTRUCT(tuple))->grpname),
+			sizeof(grpname));
+	ReleaseSysCache(tuple);
 
 	HandleYBStatus(YBCPgGetTablegroupDiskSize(tablegroup_oid,
 											  MyDatabaseId,
@@ -6129,15 +6136,12 @@ yb_tablegroup_size(PG_FUNCTION_ARGS)
 											  &num_missing_tablets));
 	if (num_missing_tablets > 0)
 	{
-		Form_pg_yb_tablegroup form = (Form_pg_yb_tablegroup) GETSTRUCT(tuple);
-
 		elog(NOTICE,
 			 "%d tablets of tablegroup %s did not provide disk size "
 			 "estimates, and were not added to the displayed totals.",
 			 num_missing_tablets,
-			 NameStr(form->grpname));
+			 grpname);
 	}
-	ReleaseSysCache(tuple);
 
 	PG_RETURN_INT64(size);
 }
@@ -9358,7 +9362,7 @@ string_list_compare(const ListCell *a, const ListCell *b)
  * NULL, and start_range/end_range contain the decoded range partition key
  * boundaries.
  * Leader is provided as a separate column for simpler querying.
- * tablet_attrs is a json object with leader-replica disk size fields when
+ * tablet_attrs is a json object with tablet leader disk size fields when
  * available: sst_bytes, wal_bytes, uncompressed_sst_bytes, total_bytes
  * (sst+wal), and optionally vector_index_bytes. NULL when sizes are
  * unavailable or the row is privilege-masked.

--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -87,6 +87,7 @@
 #include "catalog/pg_yb_logical_client_version.h"
 #include "catalog/pg_yb_profile.h"
 #include "catalog/pg_yb_role_profile.h"
+#include "catalog/pg_yb_tablegroup.h"
 #include "catalog/yb_catalog_version.h"
 #include "catalog/yb_logical_client_version.h"
 #include "catalog/yb_type.h"
@@ -6103,6 +6104,43 @@ yb_is_database_colocated(PG_FUNCTION_ARGS)
 }
 
 /*
+ * Return leader SST+WAL disk size in bytes for a tablegroup's colocation
+ * parent tablet. Matches GetTableDiskSize / pg_table_size semantics (RF=1
+ * leader footprint). Errors if the oid is not a pg_yb_tablegroup entry.
+ */
+Datum
+yb_tablegroup_size(PG_FUNCTION_ARGS)
+{
+	Oid			tablegroup_oid = PG_GETARG_OID(0);
+	int64_t		size = 0;
+	int32_t		num_missing_tablets = 0;
+	HeapTuple	tuple;
+
+	tuple = SearchSysCache1(YBTABLEGROUPOID, ObjectIdGetDatum(tablegroup_oid));
+	if (!HeapTupleIsValid(tuple))
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("tablegroup with OID %u does not exist", tablegroup_oid)));
+	ReleaseSysCache(tuple);
+
+	HandleYBStatus(YBCPgGetTablegroupDiskSize(tablegroup_oid,
+											  MyDatabaseId,
+											  MyDatabaseColocated,
+											  &size,
+											  &num_missing_tablets));
+	if (num_missing_tablets > 0)
+	{
+		elog(NOTICE,
+			 "%d tablets of tablegroup %u did not provide disk size "
+			 "estimates, and were not added to the displayed totals.",
+			 num_missing_tablets,
+			 tablegroup_oid);
+	}
+
+	PG_RETURN_INT64(size);
+}
+
+/*
  * This function serves mostly as a helper for YSQL migration to introduce
  * pg_yb_catalog_version table without breaking version continuity.
  */
@@ -9318,7 +9356,10 @@ string_list_compare(const ListCell *a, const ListCell *b)
  * NULL, and start_range/end_range contain the decoded range partition key
  * boundaries.
  * Leader is provided as a separate column for simpler querying.
- * tablet_attrs is reserved for future use and is currently always NULL.
+ * tablet_attrs is a jsonb object with leader-replica disk size fields when
+ * available: sst_bytes, wal_bytes, uncompressed_sst_bytes, total_bytes
+ * (sst+wal), and optionally vector_index_bytes. NULL when sizes are
+ * unavailable or the row is privilege-masked.
  */
 Datum
 yb_get_tablet_metadata(PG_FUNCTION_ARGS)
@@ -9539,8 +9580,42 @@ yb_get_tablet_metadata(PG_FUNCTION_ARGS)
 			nulls[9] = true;
 		}
 
-		/* TODO(#30180): Populate tablet_attrs. */
-		nulls[12] = true;
+		/*
+		 * tablet_attrs: leader SST/WAL sizes. Omit when privilege-masked or
+		 * when master did not report drive info for the leader.
+		 */
+		if (show_real && tablet->has_disk_size)
+		{
+			char		attrs_buf[256];
+			int64		total_bytes =
+				tablet->sst_files_disk_size + tablet->wal_files_disk_size;
+
+			if (tablet->vector_index_disk_size > 0)
+			{
+				snprintf(attrs_buf, sizeof(attrs_buf),
+						 "{\"sst_bytes\":%lld,\"wal_bytes\":%lld,"
+						 "\"uncompressed_sst_bytes\":%lld,\"total_bytes\":%lld,"
+						 "\"vector_index_bytes\":%lld}",
+						 (long long) tablet->sst_files_disk_size,
+						 (long long) tablet->wal_files_disk_size,
+						 (long long) tablet->uncompressed_sst_files_disk_size,
+						 (long long) total_bytes,
+						 (long long) tablet->vector_index_disk_size);
+			}
+			else
+			{
+				snprintf(attrs_buf, sizeof(attrs_buf),
+						 "{\"sst_bytes\":%lld,\"wal_bytes\":%lld,"
+						 "\"uncompressed_sst_bytes\":%lld,\"total_bytes\":%lld}",
+						 (long long) tablet->sst_files_disk_size,
+						 (long long) tablet->wal_files_disk_size,
+						 (long long) tablet->uncompressed_sst_files_disk_size,
+						 (long long) total_bytes);
+			}
+			values[12] = DirectFunctionCall1(jsonb_in, CStringGetDatum(attrs_buf));
+		}
+		else
+			nulls[12] = true;
 
 		if (tablet->tablet_state)
 			values[13] = CStringGetTextDatum(tablet->tablet_state);

--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -6121,7 +6121,6 @@ yb_tablegroup_size(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_OBJECT),
 				 errmsg("tablegroup with OID %u does not exist", tablegroup_oid)));
-	ReleaseSysCache(tuple);
 
 	HandleYBStatus(YBCPgGetTablegroupDiskSize(tablegroup_oid,
 											  MyDatabaseId,
@@ -6130,12 +6129,15 @@ yb_tablegroup_size(PG_FUNCTION_ARGS)
 											  &num_missing_tablets));
 	if (num_missing_tablets > 0)
 	{
+		Form_pg_yb_tablegroup form = (Form_pg_yb_tablegroup) GETSTRUCT(tuple);
+
 		elog(NOTICE,
-			 "%d tablets of tablegroup %u did not provide disk size "
+			 "%d tablets of tablegroup %s did not provide disk size "
 			 "estimates, and were not added to the displayed totals.",
 			 num_missing_tablets,
-			 tablegroup_oid);
+			 NameStr(form->grpname));
 	}
+	ReleaseSysCache(tuple);
 
 	PG_RETURN_INT64(size);
 }

--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -9356,7 +9356,7 @@ string_list_compare(const ListCell *a, const ListCell *b)
  * NULL, and start_range/end_range contain the decoded range partition key
  * boundaries.
  * Leader is provided as a separate column for simpler querying.
- * tablet_attrs is a jsonb object with leader-replica disk size fields when
+ * tablet_attrs is a json object with leader-replica disk size fields when
  * available: sst_bytes, wal_bytes, uncompressed_sst_bytes, total_bytes
  * (sst+wal), and optionally vector_index_bytes. NULL when sizes are
  * unavailable or the row is privilege-masked.
@@ -9612,7 +9612,7 @@ yb_get_tablet_metadata(PG_FUNCTION_ARGS)
 						 (long long) tablet->uncompressed_sst_files_disk_size,
 						 (long long) total_bytes);
 			}
-			values[12] = DirectFunctionCall1(jsonb_in, CStringGetDatum(attrs_buf));
+			values[12] = DirectFunctionCall1(json_in, CStringGetDatum(attrs_buf));
 		}
 		else
 			nulls[12] = true;

--- a/src/postgres/src/include/catalog/catalog.h
+++ b/src/postgres/src/include/catalog/catalog.h
@@ -33,7 +33,7 @@
  * last used OID (<system_catalog>.<object_name>). This is intended to act as a
  * safeguard against silent rebases.
  */
-#define YB_LAST_USED_OID 8117 /* corresponds to pg_authid.yb_global_views_user */
+#define YB_LAST_USED_OID 8118 /* corresponds to pg_proc.yb_tablegroup_size */
 
 extern bool IsSystemRelation(Relation relation);
 extern bool IsToastRelation(Relation relation);

--- a/src/postgres/src/include/catalog/pg_proc.dat
+++ b/src/postgres/src/include/catalog/pg_proc.dat
@@ -12361,4 +12361,10 @@
   proargmodes => '{i,i,i,o,o,o}',
   proargnames => '{hba_path,guc_path,ident_path,hba_error,guc_error,ident_error}',
   prosrc => 'yb_pg_validate_conf_file'},
+
+{ oid => '8116',
+  descr => 'Disk size in bytes of a tablegroup colocation parent tablet (leader SST+WAL)',
+  proname => 'yb_tablegroup_size', provolatile => 'v',
+  prorettype => 'int8', proargtypes => 'oid',
+  prosrc => 'yb_tablegroup_size' },
 ]

--- a/src/postgres/src/include/catalog/pg_proc.dat
+++ b/src/postgres/src/include/catalog/pg_proc.dat
@@ -12359,4 +12359,10 @@
   proargmodes => '{i,i,i,o,o,o}',
   proargnames => '{hba_path,guc_path,ident_path,hba_error,guc_error,ident_error}',
   prosrc => 'yb_pg_validate_conf_file'},
+
+{ oid => '8116',
+  descr => 'Disk size in bytes of a tablegroup colocation parent tablet (leader SST+WAL)',
+  proname => 'yb_tablegroup_size', provolatile => 'v',
+  prorettype => 'int8', proargtypes => 'oid',
+  prosrc => 'yb_tablegroup_size' },
 ]

--- a/src/postgres/src/include/catalog/pg_proc.dat
+++ b/src/postgres/src/include/catalog/pg_proc.dat
@@ -12364,7 +12364,7 @@
 
 { oid => '8116',
   descr => 'Disk size in bytes of a tablegroup colocation parent tablet (leader SST+WAL)',
-  proname => 'yb_tablegroup_size', provolatile => 'v',
+  proname => 'yb_tablegroup_size', provolatile => 'v', proparallel => 'r',
   prorettype => 'int8', proargtypes => 'oid',
   prosrc => 'yb_tablegroup_size' },
 ]

--- a/src/postgres/src/include/catalog/pg_proc.dat
+++ b/src/postgres/src/include/catalog/pg_proc.dat
@@ -12362,7 +12362,7 @@
   proargnames => '{hba_path,guc_path,ident_path,hba_error,guc_error,ident_error}',
   prosrc => 'yb_pg_validate_conf_file'},
 
-{ oid => '8116',
+{ oid => '8118',
   descr => 'Disk size in bytes of a tablegroup colocation parent tablet (leader SST+WAL)',
   proname => 'yb_tablegroup_size', provolatile => 'v', proparallel => 'r',
   prorettype => 'int8', proargtypes => 'oid',

--- a/src/postgres/src/include/catalog/pg_yb_migration.dat
+++ b/src/postgres/src/include/catalog/pg_yb_migration.dat
@@ -12,7 +12,7 @@
 [
 
 # For better version control conflict detection, list latest migration filename
-# here: V108__30566__yb_index_check_log_num_errors.sql
-{ major => '108', minor => '0', name => '<baseline>', time_applied => '_null_' }
+# here: V109__30180__yb_tablegroup_size.sql
+{ major => '109', minor => '0', name => '<baseline>', time_applied => '_null_' }
 
 ]

--- a/src/postgres/src/include/catalog/pg_yb_migration.dat
+++ b/src/postgres/src/include/catalog/pg_yb_migration.dat
@@ -12,7 +12,7 @@
 [
 
 # For better version control conflict detection, list latest migration filename
-# here: V107__30591__yb_global_views.sql
-{ major => '107', minor => '0', name => '<baseline>', time_applied => '_null_' }
+# here: V108__30180__yb_tablegroup_size.sql
+{ major => '108', minor => '0', name => '<baseline>', time_applied => '_null_' }
 
 ]

--- a/src/postgres/src/test/regress/expected/yb.orig.tablet_metadata.out
+++ b/src/postgres/src/test/regress/expected/yb.orig.tablet_metadata.out
@@ -455,6 +455,9 @@ WHERE db_name = 'colocated_db'
  t
 (1 row)
 
+-- yb_tablegroup_size raises a NOTICE naming the tablegroup oid when a tablet
+-- has not reported drive info yet, which depends on heartbeat timing.
+SET client_min_messages = warning;
 SELECT yb_tablegroup_size(oid) >= 0 AS tg_size_ok
 FROM pg_yb_tablegroup
 WHERE grpname = 'default';
@@ -462,6 +465,8 @@ WHERE grpname = 'default';
 ------------
  t
 (1 row)
+
+RESET client_min_messages;
 
 -- Cleanup
 \c yugabyte yugabyte

--- a/src/postgres/src/test/regress/expected/yb.orig.tablet_metadata.out
+++ b/src/postgres/src/test/regress/expected/yb.orig.tablet_metadata.out
@@ -426,10 +426,10 @@ WHERE tablet_id = '00000000000000000000000000000000';
 -- and non-negative values. Empty result (attrs not yet available) is OK.
 \c yugabyte yugabyte
 SELECT COALESCE(bool_and(
-         (tablet_attrs ? 'sst_bytes')
-         AND (tablet_attrs ? 'wal_bytes')
-         AND (tablet_attrs ? 'total_bytes')
-         AND (tablet_attrs ? 'uncompressed_sst_bytes')
+         (tablet_attrs->>'sst_bytes') IS NOT NULL
+         AND (tablet_attrs->>'wal_bytes') IS NOT NULL
+         AND (tablet_attrs->>'total_bytes') IS NOT NULL
+         AND (tablet_attrs->>'uncompressed_sst_bytes') IS NOT NULL
          AND (tablet_attrs->>'sst_bytes')::bigint >= 0
          AND (tablet_attrs->>'wal_bytes')::bigint >= 0
          AND (tablet_attrs->>'total_bytes')::bigint >= 0), true) AS attrs_shape_ok
@@ -444,7 +444,7 @@ WHERE db_name = 'yugabyte'
 
 \c colocated_db yugabyte
 SELECT COALESCE(bool_and(
-         (tablet_attrs ? 'total_bytes')
+         (tablet_attrs->>'total_bytes') IS NOT NULL
          AND (tablet_attrs->>'total_bytes')::bigint >= 0), true) AS coloc_parent_attrs_ok
 FROM yb_tablet_metadata
 WHERE db_name = 'colocated_db'

--- a/src/postgres/src/test/regress/expected/yb.orig.tablet_metadata.out
+++ b/src/postgres/src/test/regress/expected/yb.orig.tablet_metadata.out
@@ -455,7 +455,7 @@ WHERE db_name = 'colocated_db'
  t
 (1 row)
 
--- yb_tablegroup_size raises a NOTICE naming the tablegroup oid when a tablet
+-- yb_tablegroup_size raises a NOTICE naming the tablegroup when a tablet
 -- has not reported drive info yet, which depends on heartbeat timing.
 SET client_min_messages = warning;
 SELECT yb_tablegroup_size(oid) >= 0 AS tg_size_ok

--- a/src/postgres/src/test/regress/expected/yb.orig.tablet_metadata.out
+++ b/src/postgres/src/test/regress/expected/yb.orig.tablet_metadata.out
@@ -417,6 +417,52 @@ WHERE tablet_id = '00000000000000000000000000000000';
  <insufficient privilege> |                 |               |             | 
 (1 row)
 
+-- ============================================================
+-- tablet_attrs and yb_tablegroup_size
+-- ============================================================
+-- Privilege-masked rows keep tablet_attrs NULL (covered by (G) above).
+-- When drive info is present, tablet_attrs exposes leader SST/WAL sizes.
+-- Soft checks: if attrs are populated they must have the expected keys
+-- and non-negative values. Empty result (attrs not yet available) is OK.
+\c yugabyte yugabyte
+SELECT COALESCE(bool_and(
+         (tablet_attrs ? 'sst_bytes')
+         AND (tablet_attrs ? 'wal_bytes')
+         AND (tablet_attrs ? 'total_bytes')
+         AND (tablet_attrs ? 'uncompressed_sst_bytes')
+         AND (tablet_attrs->>'sst_bytes')::bigint >= 0
+         AND (tablet_attrs->>'wal_bytes')::bigint >= 0
+         AND (tablet_attrs->>'total_bytes')::bigint >= 0), true) AS attrs_shape_ok
+FROM yb_tablet_metadata
+WHERE db_name = 'yugabyte'
+  AND relname = 'test_table_1'
+  AND tablet_attrs IS NOT NULL;
+ attrs_shape_ok 
+----------------
+ t
+(1 row)
+
+\c colocated_db yugabyte
+SELECT COALESCE(bool_and(
+         (tablet_attrs ? 'total_bytes')
+         AND (tablet_attrs->>'total_bytes')::bigint >= 0), true) AS coloc_parent_attrs_ok
+FROM yb_tablet_metadata
+WHERE db_name = 'colocated_db'
+  AND relname LIKE '%.colocation.parent.tablename'
+  AND tablet_attrs IS NOT NULL;
+ coloc_parent_attrs_ok 
+-----------------------
+ t
+(1 row)
+
+SELECT yb_tablegroup_size(oid) >= 0 AS tg_size_ok
+FROM pg_yb_tablegroup
+WHERE grpname = 'default';
+ tg_size_ok 
+------------
+ t
+(1 row)
+
 -- Cleanup
 \c yugabyte yugabyte
 DROP DATABASE colocated_db;

--- a/src/postgres/src/test/regress/expected/yb.orig.tablet_metadata.out
+++ b/src/postgres/src/test/regress/expected/yb.orig.tablet_metadata.out
@@ -418,56 +418,23 @@ WHERE tablet_id = '00000000000000000000000000000000';
 (1 row)
 
 -- ============================================================
--- tablet_attrs and yb_tablegroup_size
+-- yb_tablegroup_size
 -- ============================================================
--- Privilege-masked rows keep tablet_attrs NULL (covered by (G) above).
--- When drive info is present, tablet_attrs exposes leader SST/WAL sizes.
--- Soft checks: if attrs are populated they must have the expected keys
--- and non-negative values. Empty result (attrs not yet available) is OK.
-\c yugabyte yugabyte
-SELECT COALESCE(bool_and(
-         (tablet_attrs->>'sst_bytes') IS NOT NULL
-         AND (tablet_attrs->>'wal_bytes') IS NOT NULL
-         AND (tablet_attrs->>'total_bytes') IS NOT NULL
-         AND (tablet_attrs->>'uncompressed_sst_bytes') IS NOT NULL
-         AND (tablet_attrs->>'sst_bytes')::bigint >= 0
-         AND (tablet_attrs->>'wal_bytes')::bigint >= 0
-         AND (tablet_attrs->>'total_bytes')::bigint >= 0), true) AS attrs_shape_ok
-FROM yb_tablet_metadata
-WHERE db_name = 'yugabyte'
-  AND relname = 'test_table_1'
-  AND tablet_attrs IS NOT NULL;
- attrs_shape_ok 
-----------------
- t
-(1 row)
-
+-- tablet_attrs key/shape checks live in PgTableSizeTest.ColocatedTableSize,
+-- which can wait for master drive-info heartbeats. pg_regress cannot, and a
+-- populated-but-unread-yet row would make those predicates return false.
+-- yb_tablegroup_size raises a NOTICE when a tablet has not reported drive
+-- info yet; suppress it. The returned size is still >= 0.
 \c colocated_db yugabyte
-SELECT COALESCE(bool_and(
-         (tablet_attrs->>'total_bytes') IS NOT NULL
-         AND (tablet_attrs->>'total_bytes')::bigint >= 0), true) AS coloc_parent_attrs_ok
-FROM yb_tablet_metadata
-WHERE db_name = 'colocated_db'
-  AND relname LIKE '%.colocation.parent.tablename'
-  AND tablet_attrs IS NOT NULL;
- coloc_parent_attrs_ok 
------------------------
- t
-(1 row)
-
--- yb_tablegroup_size raises a NOTICE naming the tablegroup when a tablet
--- has not reported drive info yet, which depends on heartbeat timing.
 SET client_min_messages = warning;
-SELECT yb_tablegroup_size(oid) >= 0 AS tg_size_ok
-FROM pg_yb_tablegroup
-WHERE grpname = 'default';
+SELECT COALESCE(bool_and(yb_tablegroup_size(oid) >= 0), true) AS tg_size_ok
+FROM pg_yb_tablegroup;
  tg_size_ok 
 ------------
  t
 (1 row)
 
 RESET client_min_messages;
-
 -- Cleanup
 \c yugabyte yugabyte
 DROP DATABASE colocated_db;

--- a/src/postgres/src/test/regress/sql/yb.orig.tablet_metadata.sql
+++ b/src/postgres/src/test/regress/sql/yb.orig.tablet_metadata.sql
@@ -345,9 +345,15 @@ WHERE db_name = 'colocated_db'
   AND relname LIKE '%.colocation.parent.tablename'
   AND tablet_attrs IS NOT NULL;
 
+-- yb_tablegroup_size raises a NOTICE naming the tablegroup oid when a tablet
+-- has not reported drive info yet, which depends on heartbeat timing.
+SET client_min_messages = warning;
+
 SELECT yb_tablegroup_size(oid) >= 0 AS tg_size_ok
 FROM pg_yb_tablegroup
 WHERE grpname = 'default';
+
+RESET client_min_messages;
 
 -- Cleanup
 \c yugabyte yugabyte

--- a/src/postgres/src/test/regress/sql/yb.orig.tablet_metadata.sql
+++ b/src/postgres/src/test/regress/sql/yb.orig.tablet_metadata.sql
@@ -314,45 +314,17 @@ FROM yb_get_tablet_metadata()
 WHERE tablet_id = '00000000000000000000000000000000';
 
 -- ============================================================
--- tablet_attrs and yb_tablegroup_size
+-- yb_tablegroup_size
 -- ============================================================
--- Privilege-masked rows keep tablet_attrs NULL (covered by (G) above).
--- When drive info is present, tablet_attrs exposes leader SST/WAL sizes.
--- Soft checks: if attrs are populated they must have the expected keys
--- and non-negative values. Empty result (attrs not yet available) is OK.
-\c yugabyte yugabyte
-
-SELECT COALESCE(bool_and(
-         (tablet_attrs->>'sst_bytes') IS NOT NULL
-         AND (tablet_attrs->>'wal_bytes') IS NOT NULL
-         AND (tablet_attrs->>'total_bytes') IS NOT NULL
-         AND (tablet_attrs->>'uncompressed_sst_bytes') IS NOT NULL
-         AND (tablet_attrs->>'sst_bytes')::bigint >= 0
-         AND (tablet_attrs->>'wal_bytes')::bigint >= 0
-         AND (tablet_attrs->>'total_bytes')::bigint >= 0), true) AS attrs_shape_ok
-FROM yb_tablet_metadata
-WHERE db_name = 'yugabyte'
-  AND relname = 'test_table_1'
-  AND tablet_attrs IS NOT NULL;
-
+-- tablet_attrs key/shape checks live in PgTableSizeTest.ColocatedTableSize,
+-- which can wait for master drive-info heartbeats. pg_regress cannot, and a
+-- populated-but-unread-yet row would make those predicates return false.
+-- yb_tablegroup_size raises a NOTICE when a tablet has not reported drive
+-- info yet; suppress it. The returned size is still >= 0.
 \c colocated_db yugabyte
-
-SELECT COALESCE(bool_and(
-         (tablet_attrs->>'total_bytes') IS NOT NULL
-         AND (tablet_attrs->>'total_bytes')::bigint >= 0), true) AS coloc_parent_attrs_ok
-FROM yb_tablet_metadata
-WHERE db_name = 'colocated_db'
-  AND relname LIKE '%.colocation.parent.tablename'
-  AND tablet_attrs IS NOT NULL;
-
--- yb_tablegroup_size raises a NOTICE naming the tablegroup when a tablet
--- has not reported drive info yet, which depends on heartbeat timing.
 SET client_min_messages = warning;
-
-SELECT yb_tablegroup_size(oid) >= 0 AS tg_size_ok
-FROM pg_yb_tablegroup
-WHERE grpname = 'default';
-
+SELECT COALESCE(bool_and(yb_tablegroup_size(oid) >= 0), true) AS tg_size_ok
+FROM pg_yb_tablegroup;
 RESET client_min_messages;
 
 -- Cleanup

--- a/src/postgres/src/test/regress/sql/yb.orig.tablet_metadata.sql
+++ b/src/postgres/src/test/regress/sql/yb.orig.tablet_metadata.sql
@@ -323,10 +323,10 @@ WHERE tablet_id = '00000000000000000000000000000000';
 \c yugabyte yugabyte
 
 SELECT COALESCE(bool_and(
-         (tablet_attrs ? 'sst_bytes')
-         AND (tablet_attrs ? 'wal_bytes')
-         AND (tablet_attrs ? 'total_bytes')
-         AND (tablet_attrs ? 'uncompressed_sst_bytes')
+         (tablet_attrs->>'sst_bytes') IS NOT NULL
+         AND (tablet_attrs->>'wal_bytes') IS NOT NULL
+         AND (tablet_attrs->>'total_bytes') IS NOT NULL
+         AND (tablet_attrs->>'uncompressed_sst_bytes') IS NOT NULL
          AND (tablet_attrs->>'sst_bytes')::bigint >= 0
          AND (tablet_attrs->>'wal_bytes')::bigint >= 0
          AND (tablet_attrs->>'total_bytes')::bigint >= 0), true) AS attrs_shape_ok
@@ -338,7 +338,7 @@ WHERE db_name = 'yugabyte'
 \c colocated_db yugabyte
 
 SELECT COALESCE(bool_and(
-         (tablet_attrs ? 'total_bytes')
+         (tablet_attrs->>'total_bytes') IS NOT NULL
          AND (tablet_attrs->>'total_bytes')::bigint >= 0), true) AS coloc_parent_attrs_ok
 FROM yb_tablet_metadata
 WHERE db_name = 'colocated_db'

--- a/src/postgres/src/test/regress/sql/yb.orig.tablet_metadata.sql
+++ b/src/postgres/src/test/regress/sql/yb.orig.tablet_metadata.sql
@@ -345,7 +345,7 @@ WHERE db_name = 'colocated_db'
   AND relname LIKE '%.colocation.parent.tablename'
   AND tablet_attrs IS NOT NULL;
 
--- yb_tablegroup_size raises a NOTICE naming the tablegroup oid when a tablet
+-- yb_tablegroup_size raises a NOTICE naming the tablegroup when a tablet
 -- has not reported drive info yet, which depends on heartbeat timing.
 SET client_min_messages = warning;
 

--- a/src/postgres/src/test/regress/sql/yb.orig.tablet_metadata.sql
+++ b/src/postgres/src/test/regress/sql/yb.orig.tablet_metadata.sql
@@ -313,6 +313,42 @@ SELECT object_name, start_hash_code, end_hash_code, start_range, end_range
 FROM yb_get_tablet_metadata()
 WHERE tablet_id = '00000000000000000000000000000000';
 
+-- ============================================================
+-- tablet_attrs and yb_tablegroup_size
+-- ============================================================
+-- Privilege-masked rows keep tablet_attrs NULL (covered by (G) above).
+-- When drive info is present, tablet_attrs exposes leader SST/WAL sizes.
+-- Soft checks: if attrs are populated they must have the expected keys
+-- and non-negative values. Empty result (attrs not yet available) is OK.
+\c yugabyte yugabyte
+
+SELECT COALESCE(bool_and(
+         (tablet_attrs ? 'sst_bytes')
+         AND (tablet_attrs ? 'wal_bytes')
+         AND (tablet_attrs ? 'total_bytes')
+         AND (tablet_attrs ? 'uncompressed_sst_bytes')
+         AND (tablet_attrs->>'sst_bytes')::bigint >= 0
+         AND (tablet_attrs->>'wal_bytes')::bigint >= 0
+         AND (tablet_attrs->>'total_bytes')::bigint >= 0), true) AS attrs_shape_ok
+FROM yb_tablet_metadata
+WHERE db_name = 'yugabyte'
+  AND relname = 'test_table_1'
+  AND tablet_attrs IS NOT NULL;
+
+\c colocated_db yugabyte
+
+SELECT COALESCE(bool_and(
+         (tablet_attrs ? 'total_bytes')
+         AND (tablet_attrs->>'total_bytes')::bigint >= 0), true) AS coloc_parent_attrs_ok
+FROM yb_tablet_metadata
+WHERE db_name = 'colocated_db'
+  AND relname LIKE '%.colocation.parent.tablename'
+  AND tablet_attrs IS NOT NULL;
+
+SELECT yb_tablegroup_size(oid) >= 0 AS tg_size_ok
+FROM pg_yb_tablegroup
+WHERE grpname = 'default';
+
 -- Cleanup
 \c yugabyte yugabyte
 DROP DATABASE colocated_db;

--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -14796,6 +14796,20 @@ void PopulateTabletMetadata(
     tablet_metadata->mutable_partition()->set_partition_key_end(
         partition.partition_key_end());
   }
+
+  // Leader SST/WAL sizes from heartbeat-cached drive info (same source as GetTableDiskSize).
+  // Missing leader drive info leaves size fields unset so YSQL can omit tablet_attrs keys.
+  auto drive_info_result = tablet->GetLeaderReplicaDriveInfo();
+  if (drive_info_result.ok()) {
+    const auto& drive_info = *drive_info_result;
+    tablet_metadata->set_sst_files_disk_size(drive_info.sst_files_size);
+    tablet_metadata->set_wal_files_disk_size(drive_info.wal_files_size);
+    tablet_metadata->set_uncompressed_sst_files_disk_size(drive_info.uncompressed_sst_file_size);
+    tablet_metadata->set_total_on_disk_size(drive_info.total_size);
+    if (drive_info.vector_index_size > 0) {
+      tablet_metadata->set_vector_index_disk_size(drive_info.vector_index_size);
+    }
+  }
 }
 
 }  // namespace

--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -14899,6 +14899,20 @@ void PopulateTabletMetadata(
     tablet_metadata->mutable_partition()->set_partition_key_end(
         partition.partition_key_end());
   }
+
+  // Leader SST/WAL sizes from heartbeat-cached drive info (same source as GetTableDiskSize).
+  // Missing leader drive info leaves size fields unset so YSQL can omit tablet_attrs keys.
+  auto drive_info_result = tablet->GetLeaderReplicaDriveInfo();
+  if (drive_info_result.ok()) {
+    const auto& drive_info = *drive_info_result;
+    tablet_metadata->set_sst_files_disk_size(drive_info.sst_files_size);
+    tablet_metadata->set_wal_files_disk_size(drive_info.wal_files_size);
+    tablet_metadata->set_uncompressed_sst_files_disk_size(drive_info.uncompressed_sst_file_size);
+    tablet_metadata->set_total_on_disk_size(drive_info.total_size);
+    if (drive_info.vector_index_size > 0) {
+      tablet_metadata->set_vector_index_disk_size(drive_info.vector_index_size);
+    }
+  }
 }
 
 }  // namespace

--- a/src/yb/tserver/pg_client.proto
+++ b/src/yb/tserver/pg_client.proto
@@ -1068,6 +1068,9 @@ message PgDeleteDBSequencesResponsePB {
 message PgGetTableDiskSizeRequestPB {
   PgObjectIdPB table_id = 1;
   reserved 2; // ASH metadata is now passed in RequestHeader PB
+  // DocDB table UUID. When set, takes precedence over table_id. Used for
+  // colocation parent tables which have no PG oid mapping.
+  optional string yb_table_id = 3;
 }
 
 message PgGetTableDiskSizeResponsePB {

--- a/src/yb/tserver/pg_client_service.cc
+++ b/src/yb/tserver/pg_client_service.cc
@@ -2376,8 +2376,10 @@ class PgClientServiceImpl::Impl : public SessionProvider {
   Status GetTableDiskSize(
       const PgGetTableDiskSizeRequestPB& req, PgGetTableDiskSizeResponsePB* resp,
       rpc::RpcContext* context) {
-    auto result =
-        client().GetTableDiskSize(PgObjectId::GetYbTableIdFromPB(req.table_id()));
+    const auto table_id = req.has_yb_table_id() && !req.yb_table_id().empty()
+        ? req.yb_table_id()
+        : PgObjectId::GetYbTableIdFromPB(req.table_id());
+    auto result = client().GetTableDiskSize(table_id);
     if (!result.ok()) {
       StatusToPB(result.status(), resp->mutable_status());
     } else {

--- a/src/yb/tserver/pg_client_service.cc
+++ b/src/yb/tserver/pg_client_service.cc
@@ -2369,8 +2369,10 @@ class PgClientServiceImpl::Impl : public SessionProvider, public SessionRegistry
   Status GetTableDiskSize(
       const PgGetTableDiskSizeRequestPB& req, PgGetTableDiskSizeResponsePB* resp,
       rpc::RpcContext* context) {
-    auto result =
-        client().GetTableDiskSize(PgObjectId::GetYbTableIdFromPB(req.table_id()));
+    const auto table_id = req.has_yb_table_id() && !req.yb_table_id().empty()
+        ? req.yb_table_id()
+        : PgObjectId::GetYbTableIdFromPB(req.table_id());
+    auto result = client().GetTableDiskSize(table_id);
     if (!result.ok()) {
       StatusToPB(result.status(), resp->mutable_status());
     } else {

--- a/src/yb/yql/pggate/pg_client.cc
+++ b/src/yb/yql/pggate/pg_client.cc
@@ -1506,6 +1506,21 @@ class PgClient::Impl : public BigDataFetcher {
     return client::TableSizeInfo{resp.size(), resp.num_missing_tablets()};
   }
 
+  Result<client::TableSizeInfo> GetTableDiskSizeByYbTableId(const TableId& yb_table_id) {
+    tserver::PgGetTableDiskSizeResponsePB resp;
+
+    tserver::PgGetTableDiskSizeRequestPB req;
+    req.set_yb_table_id(yb_table_id);
+
+    RETURN_NOT_OK(DoSyncRPC(&PgClientServiceProxy::GetTableDiskSize,
+        req, resp, PggateRPC::kGetTableDiskSize));
+    if (resp.has_status()) {
+      return StatusFromPB(resp.status());
+    }
+
+    return client::TableSizeInfo{resp.size(), resp.num_missing_tablets()};
+  }
+
   Result<bool> CheckIfPitrActive() {
     tserver::PgCheckIfPitrActiveRequestPB req;
     tserver::PgCheckIfPitrActiveResponsePB resp;
@@ -2323,6 +2338,11 @@ Status PgClient::ValidatePlacement(tserver::PgValidatePlacementRequestPB* req) {
 Result<client::TableSizeInfo> PgClient::GetTableDiskSize(
     const PgObjectId& table_oid) {
   return impl_->GetTableDiskSize(table_oid);
+}
+
+Result<client::TableSizeInfo> PgClient::GetTableDiskSizeByYbTableId(
+    const TableId& yb_table_id) {
+  return impl_->GetTableDiskSizeByYbTableId(yb_table_id);
 }
 
 Status PgClient::InsertSequenceTuple(int64_t db_oid,

--- a/src/yb/yql/pggate/pg_client.cc
+++ b/src/yb/yql/pggate/pg_client.cc
@@ -1501,6 +1501,21 @@ class PgClient::Impl : public BigDataFetcher {
     return client::TableSizeInfo{resp.size(), resp.num_missing_tablets()};
   }
 
+  Result<client::TableSizeInfo> GetTableDiskSizeByYbTableId(const TableId& yb_table_id) {
+    tserver::PgGetTableDiskSizeResponsePB resp;
+
+    tserver::PgGetTableDiskSizeRequestPB req;
+    req.set_yb_table_id(yb_table_id);
+
+    RETURN_NOT_OK(DoSyncRPC(&PgClientServiceProxy::GetTableDiskSize,
+        req, resp, PggateRPC::kGetTableDiskSize));
+    if (resp.has_status()) {
+      return StatusFromPB(resp.status());
+    }
+
+    return client::TableSizeInfo{resp.size(), resp.num_missing_tablets()};
+  }
+
   Result<bool> CheckIfPitrActive() {
     tserver::PgCheckIfPitrActiveRequestPB req;
     tserver::PgCheckIfPitrActiveResponsePB resp;
@@ -2293,6 +2308,11 @@ Status PgClient::ValidatePlacement(tserver::PgValidatePlacementRequestPB* req) {
 Result<client::TableSizeInfo> PgClient::GetTableDiskSize(
     const PgObjectId& table_oid) {
   return impl_->GetTableDiskSize(table_oid);
+}
+
+Result<client::TableSizeInfo> PgClient::GetTableDiskSizeByYbTableId(
+    const TableId& yb_table_id) {
+  return impl_->GetTableDiskSizeByYbTableId(yb_table_id);
 }
 
 Status PgClient::InsertSequenceTuple(int64_t db_oid,

--- a/src/yb/yql/pggate/pg_client.h
+++ b/src/yb/yql/pggate/pg_client.h
@@ -33,6 +33,7 @@
 #include "yb/client/client_fwd.h"
 
 #include "yb/common/pg_types.h"
+#include "yb/common/entity_ids_types.h"
 #include "yb/common/read_hybrid_time.h"
 #include "yb/common/transaction.h"
 
@@ -268,6 +269,8 @@ class PgClient {
   Status ValidatePlacement(tserver::PgValidatePlacementRequestPB* req);
 
   Result<client::TableSizeInfo> GetTableDiskSize(const PgObjectId& table_oid);
+
+  Result<client::TableSizeInfo> GetTableDiskSizeByYbTableId(const TableId& yb_table_id);
 
   Status InsertSequenceTuple(int64_t db_oid,
                              int64_t seq_oid,

--- a/src/yb/yql/pggate/pg_client.h
+++ b/src/yb/yql/pggate/pg_client.h
@@ -33,6 +33,7 @@
 #include "yb/client/client_fwd.h"
 
 #include "yb/common/pg_types.h"
+#include "yb/common/entity_ids_types.h"
 #include "yb/common/read_hybrid_time.h"
 #include "yb/common/transaction.h"
 
@@ -264,6 +265,8 @@ class PgClient {
   Status ValidatePlacement(tserver::PgValidatePlacementRequestPB* req);
 
   Result<client::TableSizeInfo> GetTableDiskSize(const PgObjectId& table_oid);
+
+  Result<client::TableSizeInfo> GetTableDiskSizeByYbTableId(const TableId& yb_table_id);
 
   Status InsertSequenceTuple(int64_t db_oid,
                              int64_t seq_oid,

--- a/src/yb/yql/pggate/pggate.cc
+++ b/src/yb/yql/pggate/pggate.cc
@@ -33,7 +33,9 @@
 #include "yb/client/table_info.h"
 
 #include "yb/common/common_flags.h"
+#include "yb/common/colocated_util.h"
 #include "yb/common/common_net.pb.h"
+#include "yb/common/entity_ids.h"
 #include "yb/common/pg_system_attr.h"
 #include "yb/common/ql_value.h"
 #include "yb/common/schema.h"
@@ -1309,6 +1311,15 @@ Status PgApiImpl::SetTablespaceOid(
 
 Result<client::TableSizeInfo> PgApiImpl::GetTableDiskSize(const PgObjectId& table_oid) {
   return pg_client_.GetTableDiskSize(table_oid);
+}
+
+Result<client::TableSizeInfo> PgApiImpl::GetTablegroupDiskSize(
+    PgOid database_oid, PgOid tablegroup_oid, bool is_database_colocated) {
+  const auto tablegroup_id = GetPgsqlTablegroupId(database_oid, tablegroup_oid);
+  const auto parent_table_id = is_database_colocated
+      ? GetColocationParentTableId(tablegroup_id)
+      : GetTablegroupParentTableId(tablegroup_id);
+  return pg_client_.GetTableDiskSizeByYbTableId(parent_table_id);
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/src/yb/yql/pggate/pggate.cc
+++ b/src/yb/yql/pggate/pggate.cc
@@ -33,7 +33,9 @@
 #include "yb/client/table_info.h"
 
 #include "yb/common/common_flags.h"
+#include "yb/common/colocated_util.h"
 #include "yb/common/common_net.pb.h"
+#include "yb/common/entity_ids.h"
 #include "yb/common/pg_system_attr.h"
 #include "yb/common/ql_value.h"
 #include "yb/common/schema.h"
@@ -1308,6 +1310,15 @@ Status PgApiImpl::SetTablespaceOid(
 
 Result<client::TableSizeInfo> PgApiImpl::GetTableDiskSize(const PgObjectId& table_oid) {
   return pg_client_.GetTableDiskSize(table_oid);
+}
+
+Result<client::TableSizeInfo> PgApiImpl::GetTablegroupDiskSize(
+    PgOid database_oid, PgOid tablegroup_oid, bool is_database_colocated) {
+  const auto tablegroup_id = GetPgsqlTablegroupId(database_oid, tablegroup_oid);
+  const auto parent_table_id = is_database_colocated
+      ? GetColocationParentTableId(tablegroup_id)
+      : GetTablegroupParentTableId(tablegroup_id);
+  return pg_client_.GetTableDiskSizeByYbTableId(parent_table_id);
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/src/yb/yql/pggate/pggate.h
+++ b/src/yb/yql/pggate/pggate.h
@@ -386,6 +386,9 @@ class PgApiImpl {
 
   Result<client::TableSizeInfo> GetTableDiskSize(const PgObjectId& table_oid);
 
+  Result<client::TableSizeInfo> GetTablegroupDiskSize(
+      PgOid database_oid, PgOid tablegroup_oid, bool is_database_colocated);
+
   //------------------------------------------------------------------------------------------------
   // Create and drop index.
   Status NewCreateIndex(const char *database_name,

--- a/src/yb/yql/pggate/ybc_pg_typedefs.h
+++ b/src/yb/yql/pggate/ybc_pg_typedefs.h
@@ -918,6 +918,12 @@ typedef struct {
   bool is_hash_partitioned;
   const char* tablet_state;
   YbcPgOid pg_table_oid;
+  /* Leader-replica disk sizes from master; has_disk_size false when unavailable. */
+  bool has_disk_size;
+  int64_t sst_files_disk_size;
+  int64_t wal_files_disk_size;
+  int64_t uncompressed_sst_files_disk_size;
+  int64_t vector_index_disk_size;
 } YbcPgGlobalTabletsDescriptor;
 
 typedef struct {

--- a/src/yb/yql/pggate/ybc_pg_typedefs.h
+++ b/src/yb/yql/pggate/ybc_pg_typedefs.h
@@ -900,6 +900,12 @@ typedef struct {
   bool is_hash_partitioned;
   const char* tablet_state;
   YbcPgOid pg_table_oid;
+  /* Leader-replica disk sizes from master; has_disk_size false when unavailable. */
+  bool has_disk_size;
+  int64_t sst_files_disk_size;
+  int64_t wal_files_disk_size;
+  int64_t uncompressed_sst_files_disk_size;
+  int64_t vector_index_disk_size;
 } YbcPgGlobalTabletsDescriptor;
 
 typedef struct {

--- a/src/yb/yql/pggate/ybc_pg_typedefs.h
+++ b/src/yb/yql/pggate/ybc_pg_typedefs.h
@@ -918,7 +918,7 @@ typedef struct {
   bool is_hash_partitioned;
   const char* tablet_state;
   YbcPgOid pg_table_oid;
-  /* Leader-replica disk sizes from master; has_disk_size false when unavailable. */
+  /* Tablet leader disk sizes from master; has_disk_size false when unavailable. */
   bool has_disk_size;
   int64_t sst_files_disk_size;
   int64_t wal_files_disk_size;

--- a/src/yb/yql/pggate/ybc_pggate.cc
+++ b/src/yb/yql/pggate/ybc_pggate.cc
@@ -29,6 +29,8 @@
 #include "yb/client/tablet_server.h"
 
 #include "yb/common/common_flags.h"
+#include "yb/common/colocated_util.h"
+#include "yb/common/entity_ids.h"
 #include "yb/common/hybrid_time.h"
 #include "yb/common/jsonb.h"
 #include "yb/common/pg_types.h"
@@ -1293,6 +1295,19 @@ YbcStatus YBCPgGetTableDiskSize(YbcPgOid table_relfilenode_oid,
      *size = value.table_size;
      *num_missing_tablets = value.num_missing_tablets;
   });
+}
+
+YbcStatus YBCPgGetTablegroupDiskSize(YbcPgOid tablegroup_oid,
+                                     YbcPgOid database_oid,
+                                     bool is_database_colocated,
+                                     int64_t *size,
+                                     int32_t *num_missing_tablets) {
+  return ExtractValueFromResult(
+      pgapi->GetTablegroupDiskSize(database_oid, tablegroup_oid, is_database_colocated),
+      [size, num_missing_tablets](auto value) {
+        *size = value.table_size;
+        *num_missing_tablets = value.num_missing_tablets;
+      });
 }
 
 // Index Operations -------------------------------------------------------------------------------
@@ -3170,7 +3185,13 @@ YbcStatus YBCTabletsMetadata(YbcPgGlobalTabletsDescriptor** tablets, size_t* cou
             ? YBCPAllocStdString(tablet_metadata.tablet_state())
             : nullptr,
         .pg_table_oid = tablet_metadata.has_pg_table_oid() ? tablet_metadata.pg_table_oid()
-                                                           : kPgInvalidOid
+                                                           : kPgInvalidOid,
+        .has_disk_size = tablet_metadata.has_sst_files_disk_size() ||
+                         tablet_metadata.has_wal_files_disk_size(),
+        .sst_files_disk_size = tablet_metadata.sst_files_disk_size(),
+        .wal_files_disk_size = tablet_metadata.wal_files_disk_size(),
+        .uncompressed_sst_files_disk_size = tablet_metadata.uncompressed_sst_files_disk_size(),
+        .vector_index_disk_size = tablet_metadata.vector_index_disk_size()
       };
       ++dest;
     }

--- a/src/yb/yql/pggate/ybc_pggate.cc
+++ b/src/yb/yql/pggate/ybc_pggate.cc
@@ -29,6 +29,8 @@
 #include "yb/client/tablet_server.h"
 
 #include "yb/common/common_flags.h"
+#include "yb/common/colocated_util.h"
+#include "yb/common/entity_ids.h"
 #include "yb/common/hybrid_time.h"
 #include "yb/common/jsonb.h"
 #include "yb/common/pg_types.h"
@@ -1292,6 +1294,19 @@ YbcStatus YBCPgGetTableDiskSize(YbcPgOid table_relfilenode_oid,
      *size = value.table_size;
      *num_missing_tablets = value.num_missing_tablets;
   });
+}
+
+YbcStatus YBCPgGetTablegroupDiskSize(YbcPgOid tablegroup_oid,
+                                     YbcPgOid database_oid,
+                                     bool is_database_colocated,
+                                     int64_t *size,
+                                     int32_t *num_missing_tablets) {
+  return ExtractValueFromResult(
+      pgapi->GetTablegroupDiskSize(database_oid, tablegroup_oid, is_database_colocated),
+      [size, num_missing_tablets](auto value) {
+        *size = value.table_size;
+        *num_missing_tablets = value.num_missing_tablets;
+      });
 }
 
 // Index Operations -------------------------------------------------------------------------------
@@ -3176,7 +3191,13 @@ YbcStatus YBCTabletsMetadata(YbcPgGlobalTabletsDescriptor** tablets, size_t* cou
             ? YBCPAllocStdString(tablet_metadata.tablet_state())
             : nullptr,
         .pg_table_oid = tablet_metadata.has_pg_table_oid() ? tablet_metadata.pg_table_oid()
-                                                           : kPgInvalidOid
+                                                           : kPgInvalidOid,
+        .has_disk_size = tablet_metadata.has_sst_files_disk_size() ||
+                         tablet_metadata.has_wal_files_disk_size(),
+        .sst_files_disk_size = tablet_metadata.sst_files_disk_size(),
+        .wal_files_disk_size = tablet_metadata.wal_files_disk_size(),
+        .uncompressed_sst_files_disk_size = tablet_metadata.uncompressed_sst_files_disk_size(),
+        .vector_index_disk_size = tablet_metadata.vector_index_disk_size()
       };
       ++dest;
     }

--- a/src/yb/yql/pggate/ybc_pggate.h
+++ b/src/yb/yql/pggate/ybc_pggate.h
@@ -422,6 +422,12 @@ YbcStatus YBCPgGetTableDiskSize(YbcPgOid table_relfilenode_oid,
                                 int64_t *size,
                                 int32_t *num_missing_tablets);
 
+YbcStatus YBCPgGetTablegroupDiskSize(YbcPgOid tablegroup_oid,
+                                     YbcPgOid database_oid,
+                                     bool is_database_colocated,
+                                     int64_t *size,
+                                     int32_t *num_missing_tablets);
+
 YbcStatus YBCGetSplitPoints(YbcPgTableDesc table_desc,
                             const YbcPgTypeEntity **type_entities,
                             YbcPgTypeAttrs *type_attrs_arr,

--- a/src/yb/yql/pgwrapper/pg_table_size-test.cc
+++ b/src/yb/yql/pgwrapper/pg_table_size-test.cc
@@ -208,15 +208,18 @@ TEST_F(PgTableSizeTest, ColocatedTableSize) {
       "SELECT yb_tablegroup_size(oid) FROM pg_yb_tablegroup WHERE grpname = 'default'"));
   ASSERT_GT(tg_size, 0);
 
+  // Both sides read the master's heartbeat-cached drive info, which keeps being
+  // refreshed while the test runs, so compare them within a single statement.
   ASSERT_OK(WaitFor([&]() -> Result<bool> {
-    return test_conn.FetchRow<bool>(Format(
+    return test_conn.FetchRow<bool>(
         "SELECT EXISTS ("
         "  SELECT 1 FROM yb_tablet_metadata "
         "  WHERE db_name = current_database() "
-        "    AND relname LIKE '%%.colocation.parent.tablename' "
+        "    AND relname LIKE '%.colocation.parent.tablename' "
         "    AND tablet_attrs IS NOT NULL "
-        "    AND (tablet_attrs->>'total_bytes')::bigint = $0)",
-        tg_size));
+        "    AND (tablet_attrs->>'total_bytes')::bigint = "
+        "        (SELECT yb_tablegroup_size(oid) FROM pg_yb_tablegroup "
+        "         WHERE grpname = 'default'))");
   }, 30s, "Wait for colocated parent tablet_attrs to match yb_tablegroup_size"));
 }
 

--- a/src/yb/yql/pgwrapper/pg_table_size-test.cc
+++ b/src/yb/yql/pgwrapper/pg_table_size-test.cc
@@ -32,6 +32,7 @@
 #include "yb/tserver/tablet_server.h"
 #include "yb/tserver/ts_tablet_manager.h"
 
+#include "yb/util/backoff_waiter.h"
 #include "yb/util/status.h"
 #include "yb/util/status_format.h"
 #include "yb/util/test_macros.h"
@@ -40,6 +41,8 @@
 #include "yb/yql/pgwrapper/pg_mini_test_base.h"
 
 DECLARE_int32(tserver_heartbeat_metrics_interval_ms);
+
+using namespace std::chrono_literals;
 
 namespace yb {
 namespace pgwrapper {

--- a/src/yb/yql/pgwrapper/pg_table_size-test.cc
+++ b/src/yb/yql/pgwrapper/pg_table_size-test.cc
@@ -199,6 +199,22 @@ TEST_F(PgTableSizeTest, ColocatedTableSize) {
 
   ASSERT_OK(VerifyInvalidTableSize(cluster_.get(), &test_conn, "T", kTable));
   ASSERT_OK(VerifyInvalidTableSize(cluster_.get(), &test_conn, "I", kIndex));
+
+  // Colocation parent size is available via yb_tablegroup_size and tablet_attrs.
+  auto tg_size = ASSERT_RESULT(test_conn.FetchRow<int64_t>(
+      "SELECT yb_tablegroup_size(oid) FROM pg_yb_tablegroup WHERE grpname = 'default'"));
+  ASSERT_GT(tg_size, 0);
+
+  ASSERT_OK(WaitFor([&]() -> Result<bool> {
+    return test_conn.FetchRow<bool>(Format(
+        "SELECT EXISTS ("
+        "  SELECT 1 FROM yb_tablet_metadata "
+        "  WHERE db_name = current_database() "
+        "    AND relname LIKE '%%.colocation.parent.tablename' "
+        "    AND tablet_attrs IS NOT NULL "
+        "    AND (tablet_attrs->>'total_bytes')::bigint = $0)",
+        tg_size));
+  }, 30s, "Wait for colocated parent tablet_attrs to match yb_tablegroup_size"));
 }
 
 TEST_F(PgTableSizeTest, SimpleTableSize) {

--- a/src/yb/yql/pgwrapper/ysql_migrations/V108__30180__yb_tablegroup_size.sql
+++ b/src/yb/yql/pgwrapper/ysql_migrations/V108__30180__yb_tablegroup_size.sql
@@ -1,0 +1,38 @@
+BEGIN;
+  SET LOCAL yb_non_ddl_txn_for_sys_tables_allowed TO true;
+
+  -- yb_tablegroup_size(oid): leader SST+WAL bytes for a tablegroup's
+  -- colocation parent tablet (same semantics as GetTableDiskSize).
+  INSERT INTO pg_catalog.pg_proc (
+    oid, proname, pronamespace, proowner, prolang, procost, prorows, provariadic,
+    prosupport, prokind, prosecdef, proleakproof, proisstrict, proretset,
+    provolatile, proparallel, pronargs, pronargdefaults, prorettype, proargtypes,
+    proallargtypes, proargmodes, proargnames, proargdefaults, protrftypes,
+    prosrc, probin, prosqlbody, proconfig, proacl) VALUES
+    (8116, 'yb_tablegroup_size', 11, 10, 12, 1, 0, 0, '-', 'f',
+     false, false, true, false, 'v', 's', 1, 0, 20, '26',
+     NULL, NULL, NULL, NULL, NULL,
+     'yb_tablegroup_size', NULL, NULL, NULL, NULL)
+  ON CONFLICT DO NOTHING;
+
+  INSERT INTO pg_catalog.pg_description (
+    objoid, classoid, objsubid, description
+  ) VALUES (
+    8116, 1255, 0,
+    'Disk size in bytes of a tablegroup colocation parent tablet (leader SST+WAL)'
+  ) ON CONFLICT DO NOTHING;
+
+  -- Create dependency records for everything we (possibly) created.
+  DO $$
+  BEGIN
+    IF NOT EXISTS (
+      SELECT FROM pg_catalog.pg_depend
+        WHERE refclassid = 1255 AND refobjid = 8116
+    ) THEN
+      INSERT INTO pg_catalog.pg_depend (
+        classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype
+      ) VALUES
+        (0, 0, 0, 1255, 8116, 0, 'p');
+    END IF;
+  END $$;
+COMMIT;

--- a/src/yb/yql/pgwrapper/ysql_migrations/V109__30180__yb_tablegroup_size.sql
+++ b/src/yb/yql/pgwrapper/ysql_migrations/V109__30180__yb_tablegroup_size.sql
@@ -21,18 +21,4 @@ BEGIN;
     8116, 1255, 0,
     'Disk size in bytes of a tablegroup colocation parent tablet (leader SST+WAL)'
   ) ON CONFLICT DO NOTHING;
-
-  -- Create dependency records for everything we (possibly) created.
-  DO $$
-  BEGIN
-    IF NOT EXISTS (
-      SELECT FROM pg_catalog.pg_depend
-        WHERE refclassid = 1255 AND refobjid = 8116
-    ) THEN
-      INSERT INTO pg_catalog.pg_depend (
-        classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype
-      ) VALUES
-        (0, 0, 0, 1255, 8116, 0, 'p');
-    END IF;
-  END $$;
 COMMIT;

--- a/src/yb/yql/pgwrapper/ysql_migrations/V109__30180__yb_tablegroup_size.sql
+++ b/src/yb/yql/pgwrapper/ysql_migrations/V109__30180__yb_tablegroup_size.sql
@@ -1,0 +1,38 @@
+BEGIN;
+  SET LOCAL yb_non_ddl_txn_for_sys_tables_allowed TO true;
+
+  -- yb_tablegroup_size(oid): leader SST+WAL bytes for a tablegroup's
+  -- colocation parent tablet (same semantics as GetTableDiskSize).
+  INSERT INTO pg_catalog.pg_proc (
+    oid, proname, pronamespace, proowner, prolang, procost, prorows, provariadic,
+    prosupport, prokind, prosecdef, proleakproof, proisstrict, proretset,
+    provolatile, proparallel, pronargs, pronargdefaults, prorettype, proargtypes,
+    proallargtypes, proargmodes, proargnames, proargdefaults, protrftypes,
+    prosrc, probin, prosqlbody, proconfig, proacl) VALUES
+    (8116, 'yb_tablegroup_size', 11, 10, 12, 1, 0, 0, '-', 'f',
+     false, false, true, false, 'v', 's', 1, 0, 20, '26',
+     NULL, NULL, NULL, NULL, NULL,
+     'yb_tablegroup_size', NULL, NULL, NULL, NULL)
+  ON CONFLICT DO NOTHING;
+
+  INSERT INTO pg_catalog.pg_description (
+    objoid, classoid, objsubid, description
+  ) VALUES (
+    8116, 1255, 0,
+    'Disk size in bytes of a tablegroup colocation parent tablet (leader SST+WAL)'
+  ) ON CONFLICT DO NOTHING;
+
+  -- Create dependency records for everything we (possibly) created.
+  DO $$
+  BEGIN
+    IF NOT EXISTS (
+      SELECT FROM pg_catalog.pg_depend
+        WHERE refclassid = 1255 AND refobjid = 8116
+    ) THEN
+      INSERT INTO pg_catalog.pg_depend (
+        classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype
+      ) VALUES
+        (0, 0, 0, 1255, 8116, 0, 'p');
+    END IF;
+  END $$;
+COMMIT;

--- a/src/yb/yql/pgwrapper/ysql_migrations/V109__30180__yb_tablegroup_size.sql
+++ b/src/yb/yql/pgwrapper/ysql_migrations/V109__30180__yb_tablegroup_size.sql
@@ -9,7 +9,7 @@ BEGIN;
     provolatile, proparallel, pronargs, pronargdefaults, prorettype, proargtypes,
     proallargtypes, proargmodes, proargnames, proargdefaults, protrftypes,
     prosrc, probin, prosqlbody, proconfig, proacl) VALUES
-    (8116, 'yb_tablegroup_size', 11, 10, 12, 1, 0, 0, '-', 'f',
+    (8118, 'yb_tablegroup_size', 11, 10, 12, 1, 0, 0, '-', 'f',
      false, false, true, false, 'v', 'r', 1, 0, 20, '26',
      NULL, NULL, NULL, NULL, NULL,
      'yb_tablegroup_size', NULL, NULL, NULL, NULL)
@@ -18,12 +18,12 @@ BEGIN;
   -- Restrict parallel use: this function RPCs to master for disk size.
   UPDATE pg_catalog.pg_proc
      SET proparallel = 'r'
-   WHERE oid = 8116 AND proparallel IS DISTINCT FROM 'r';
+   WHERE oid = 8118 AND proparallel IS DISTINCT FROM 'r';
 
   INSERT INTO pg_catalog.pg_description (
     objoid, classoid, objsubid, description
   ) VALUES (
-    8116, 1255, 0,
+    8118, 1255, 0,
     'Disk size in bytes of a tablegroup colocation parent tablet (leader SST+WAL)'
   ) ON CONFLICT DO NOTHING;
 COMMIT;

--- a/src/yb/yql/pgwrapper/ysql_migrations/V109__30180__yb_tablegroup_size.sql
+++ b/src/yb/yql/pgwrapper/ysql_migrations/V109__30180__yb_tablegroup_size.sql
@@ -10,10 +10,15 @@ BEGIN;
     proallargtypes, proargmodes, proargnames, proargdefaults, protrftypes,
     prosrc, probin, prosqlbody, proconfig, proacl) VALUES
     (8116, 'yb_tablegroup_size', 11, 10, 12, 1, 0, 0, '-', 'f',
-     false, false, true, false, 'v', 's', 1, 0, 20, '26',
+     false, false, true, false, 'v', 'r', 1, 0, 20, '26',
      NULL, NULL, NULL, NULL, NULL,
      'yb_tablegroup_size', NULL, NULL, NULL, NULL)
   ON CONFLICT DO NOTHING;
+
+  -- Restrict parallel use: this function RPCs to master for disk size.
+  UPDATE pg_catalog.pg_proc
+     SET proparallel = 'r'
+   WHERE oid = 8116 AND proparallel IS DISTINCT FROM 'r';
 
   INSERT INTO pg_catalog.pg_description (
     objoid, classoid, objsubid, description


### PR DESCRIPTION
Users in Aeon are unable to see the size of tables stored in the colocated tablegroup, it would be helpful to have the size for the tablet exposed via YSQL so that it can be monitored to not exceed our general guidance on colocated tablets.

Populate yb_tablet_metadata.tablet_attrs with leader SST/WAL sizes from master drive info, and add yb_tablegroup_size() for colocation parent footprint. Leave pg_table_size empty for colocated child tables to avoid overcounting shared storage.

## Upgrade/Rollback safety
Optional PgGetTableDiskSizeRequestPB.yb_table_id field is ignored by older tservers; tablet_attrs changes from always-NULL to populated JSON (additive). New yb_tablegroup_size arrives via YSQL migration V109.

---
_automated · Cursor Grok 4.5_
