### PR TITLE
[#16670] DocDB: dist-trace: Propagate trace context over the PG-tserver shared memory exchange

### DIFF
--- a/src/yb/ash/rpc_wait_state.cc
+++ b/src/yb/ash/rpc_wait_state.cc
@@ -12,6 +12,8 @@
 //
 #include "yb/ash/rpc_wait_state.h"
 
+#include "yb/gutil/endian.h"
+
 #include "yb/rpc/inbound_call.h"
 #include "yb/rpc/lightweight_message.h"
 
@@ -129,6 +131,36 @@ uint8_t* MetadataSerializer::SerializeToArray(uint8_t* out) {
   }
 
   return metadata_.SerializeWithCachedSizesToArray(out);
+}
+
+void TraceContextSerializer::SetTraceContext(
+    const opentelemetry::trace::SpanContext& span_context) {
+  if (!span_context.IsValid()) {
+    return;
+  }
+  const auto trace_id = span_context.trace_id();
+  const auto span_id = span_context.span_id();
+  // Split the 16-byte trace id into two big-endian 64-bit halves; the span id is one big-endian
+  // 64-bit value -- the layout rpc::ToSpanContext reads back on the tserver.
+  trace_context_.set_trace_id_hi(BigEndian::Load64(trace_id.Id().data()));
+  trace_context_.set_trace_id_lo(BigEndian::Load64(trace_id.Id().data() + 8));
+  trace_context_.set_span_id(BigEndian::Load64(span_id.Id().data()));
+  // Low byte: flags; high byte: the (currently unused) version.
+  constexpr uint32_t kVersion = 0;
+  trace_context_.set_version_and_flags((kVersion << 8) | span_context.trace_flags().flags());
+  serialized_size_ = trace_context_.ByteSizeLong();
+}
+
+size_t TraceContextSerializer::SerializedSize() const {
+  return Output::VarintSize32(static_cast<uint32_t>(serialized_size_)) + serialized_size_;
+}
+
+uint8_t* TraceContextSerializer::SerializeToArray(uint8_t* out) const {
+  out = Output::WriteVarint32ToArray(static_cast<uint32_t>(serialized_size_), out);
+  if (serialized_size_ == 0) {
+    return out;
+  }
+  return trace_context_.SerializeWithCachedSizesToArray(out);
 }
 
 } // namespace yb::ash

--- a/src/yb/ash/rpc_wait_state.h
+++ b/src/yb/ash/rpc_wait_state.h
@@ -12,10 +12,13 @@
 //
 #pragma once
 
+#include "opentelemetry/trace/span_context.h"
+
 #include "yb/ash/wait_state.h"
 
 #include "yb/common/common.pb.h"
 
+#include "yb/rpc/rpc_header.pb.h"
 #include "yb/rpc/wait_state_if.h"
 
 namespace yb::ash {
@@ -57,6 +60,21 @@ class MetadataSerializerFactory : public rpc::MetadataSerializerFactory {
   std::unique_ptr<rpc::MetadataSerializer> Create(rpc::MetadataSerializationMode mode) override {
     return std::make_unique<ash::MetadataSerializer>(mode);
   }
+};
+
+// Serializes a distributed-trace SpanContext as a standalone length-prefixed TraceContextPB blob
+// for the shared-memory PG<->tserver exchange, independent of the ASH metadata blob. Always emits
+// the length prefix (zero when no context is set) so the exchange framing stays parseable.
+class TraceContextSerializer {
+ public:
+  // Encodes span_context into the trace-context blob; a no-op when the context is invalid.
+  void SetTraceContext(const opentelemetry::trace::SpanContext& span_context);
+  size_t SerializedSize() const;
+  uint8_t* SerializeToArray(uint8_t* out) const;
+
+ private:
+  rpc::TraceContextPB trace_context_;
+  size_t serialized_size_ = 0;
 };
 
 } // namespace yb::ash

--- a/src/yb/tserver/pg_client_session.cc
+++ b/src/yb/tserver/pg_client_session.cc
@@ -58,6 +58,8 @@
 
 #include "yb/rpc/lightweight_message.h"
 #include "yb/rpc/rpc_context.h"
+#include "yb/rpc/rpc_header.pb.h"
+#include "yb/rpc/serialization.h"
 #include "yb/rpc/sidecars.h"
 #include "yb/rpc/scheduler.h"
 
@@ -81,6 +83,7 @@
 #include "yb/util/cast.h"
 #include "yb/util/cgroups.h"
 #include "yb/util/debug-util.h"
+#include "yb/util/dist_trace.h"
 #include "yb/util/enums.h"
 #include "yb/util/logging.h"
 #include "yb/util/lw_function.h"
@@ -841,6 +844,30 @@ using PerformQueryTraits = QueryTraits<PgPerformRequestMsg, PgPerformResponseMsg
 using ObjectLockQueryTraits =
     QueryTraits<const PgAcquireObjectLockRequestMsg, PgAcquireObjectLockResponseMsg>;
 
+// Name of the inbound shared-memory span.
+template <QueryTraitsType T>
+std::string_view SharedMemHandlerSpanName();
+template <>
+std::string_view SharedMemHandlerSpanName<PerformQueryTraits>() {
+  return "shmem yb.tserver.PgClientService.Perform";
+}
+template <>
+std::string_view SharedMemHandlerSpanName<ObjectLockQueryTraits>() {
+  return "shmem yb.tserver.PgClientService.AcquireObjectLock";
+}
+
+// Method name attribute for the inbound shared-memory span.
+template <QueryTraitsType T>
+const char* SharedMemMethodName();
+template <>
+const char* SharedMemMethodName<PerformQueryTraits>() {
+  return "Perform";
+}
+template <>
+const char* SharedMemMethodName<ObjectLockQueryTraits>() {
+  return "AcquireObjectLock";
+}
+
 using ResponseSender = std::function<void()>;
 
 template <QueryTraitsType T>
@@ -1118,6 +1145,8 @@ class SharedExchangeQuery : public std::enable_shared_from_this<SharedExchangeQu
   // 8 bytes - timeout in milliseconds.
   // next - size of serialized AshMetadataPB protobuf (say 'x').
   // next 'x' bytes - serialized AshMetadataPB protobuf.
+  // next - size of serialized TraceContextPB protobuf (say 'y').
+  // next 'y' bytes - serialized TraceContextPB protobuf.
   // remaining bytes - serialized PgPerformRequestPB protobuf.
   template <class... Args>
   Result<RequestInfo> ParseRequest(
@@ -1129,6 +1158,8 @@ class SharedExchangeQuery : public std::enable_shared_from_this<SharedExchangeQu
     input += sizeof(uint64_t);
     RETURN_NOT_OK(rpc::ParseMetadataFromSharedMemory(
         &input, end - input, rpc::AnyMessagePtr(&ash_metadata_)));
+    RETURN_NOT_OK(rpc::ParseMetadataFromSharedMemory(
+        &input, end - input, rpc::AnyMessagePtr(&trace_context_)));
     RETURN_NOT_OK(req_.ParseFromSlice(Slice(input, end)));
     data_.emplace(
         std::forward<Args>(args)..., session_id, arena_, req_, resp_, sidecars_,
@@ -1149,6 +1180,7 @@ class SharedExchangeQuery : public std::enable_shared_from_this<SharedExchangeQu
   }
 
   const AshMetadataPB& ash_metadata() const { return ash_metadata_; }
+  const rpc::TraceContextPB& trace_context() const { return trace_context_; }
 
  private:
   void SendResponse() {
@@ -1215,6 +1247,7 @@ class SharedExchangeQuery : public std::enable_shared_from_this<SharedExchangeQu
   std::remove_const_t<typename T::ReqPB> req_;
   typename T::RespPB resp_;
   AshMetadataPB ash_metadata_;
+  rpc::TraceContextPB trace_context_;
   rpc::Sidecars sidecars_;
   std::weak_ptr<PgClientSession> session_;
   SharedExchange& exchange_;
@@ -2817,7 +2850,34 @@ class PgClientSession::Impl {
     auto track_guard = wait_state
         ? TrackSharedMemoryPgMethodExecution<T>(wait_state, query.ash_metadata())
         : std::nullopt;
-    return DoHandleSharedExchangeQuery(precondition_waiter, std::move(data), deadline);
+
+    // Fix span attibutes for shared memory exchange.
+    dist_trace::SpanWithScopePtr trace_scope;
+    const auto& trace_context = query.trace_context();
+    if (dist_trace::IsDistTraceEnabled() && trace_context.has_span_id()) {
+      auto parent_context = rpc::ToSpanContext(trace_context);
+      if (parent_context.ok()) {
+        trace_scope = dist_trace::StartServerSpanWithScope(
+            SharedMemHandlerSpanName<T>(), *parent_context);
+        if (trace_scope) {
+          // Mirror the attributes the RPC inbound span carries (yb_rpc.cc), minus the ones with no
+          // shared-memory analog (rpc.call_id).
+          trace_scope->SetAttribute("rpc.system", "inbound_shmem");
+          trace_scope->SetAttribute("rpc.service", "yb.tserver.PgClientService");
+          trace_scope->SetAttribute("rpc.method", SharedMemMethodName<T>());
+        }
+      }
+    }
+
+    const auto status = DoHandleSharedExchangeQuery(precondition_waiter, std::move(data), deadline);
+    if (trace_scope) {
+      if (status.ok()) {
+        trace_scope->SetStatus(opentelemetry::trace::StatusCode::kOk);
+      } else {
+        trace_scope->SetStatus(opentelemetry::trace::StatusCode::kError, status.ToUserMessage());
+      }
+    }
+    return status;
   }
 
   template <QueryTraitsType T, class... Args>

--- a/src/yb/tserver/pg_client_session.cc
+++ b/src/yb/tserver/pg_client_session.cc
@@ -2851,7 +2851,7 @@ class PgClientSession::Impl {
         ? TrackSharedMemoryPgMethodExecution<T>(wait_state, query.ash_metadata())
         : std::nullopt;
 
-    // Fix span attibutes for shared memory exchange.
+    // Start the inbound span for this shared memory request, as a child of the propagated context.
     dist_trace::SpanWithScopePtr trace_scope;
     const auto& trace_context = query.trace_context();
     if (dist_trace::IsDistTraceEnabled() && trace_context.has_span_id()) {

--- a/src/yb/yql/pggate/pg_client.cc
+++ b/src/yb/yql/pggate/pg_client.cc
@@ -1130,9 +1130,16 @@ class PgClient::Impl : public BigDataFetcher {
   ResultFuture<Data> PrepareAndSend(Method method, Args&&... args) {
     auto data = std::make_shared<Data>(std::forward<Args>(args)...);
     if (session_shared_mem_ && session_shared_mem_->exchange().ReadyToSend()) {
+      // Start the outbound shared-memory span before sizing the request.
+      data->StartSharedMemorySpan();
       ash::MetadataSerializer metadata(rpc::MetadataSerializationMode::kWriteOnZero);
+      ash::TraceContextSerializer trace_context;
+      if (data->otel_span) {
+        trace_context.SetTraceContext(data->otel_span->GetContext());
+      }
       constexpr size_t kHeaderSize = sizeof(uint8_t) + sizeof(uint64_t);
       const size_t kMetadataSize = metadata.SerializedSize();
+      const size_t kTraceContextSize = trace_context.SerializedSize();
       auto& exchange = session_shared_mem_->exchange();
       // Sanity check: the exchange must not be reused while a big shared memory response from a
       // previous request has been announced but not yet loaded and released. Otherwise the tserver
@@ -1140,9 +1147,9 @@ class PgClient::Impl : public BigDataFetcher {
       // still intend to load it (see PgClientSession::ReleaseAbandonedBigSharedMemSegment).
       LOG_IF(DFATAL, big_shared_memory_response_pending_)
           << "Reusing shared exchange while a big shared memory response is still pending";
-      auto out = exchange.Obtain(kHeaderSize + kMetadataSize + data->req.SerializedSize());
+      auto out = exchange.Obtain(
+          kHeaderSize + kMetadataSize + kTraceContextSize + data->req.SerializedSize());
       if (out) {
-        data->StartSharedMemorySpan();
         const auto [rpc_deadline, rpc_timeout] =
             timeouts_.GetDeadlineAndTimeoutForRPC<typename Data::RequestType>();
         *reinterpret_cast<uint8_t *>(out) = Data::kSharedExchangeRequestType;
@@ -1150,6 +1157,7 @@ class PgClient::Impl : public BigDataFetcher {
         LittleEndian::Store64(out, rpc_timeout.ToMilliseconds());
         out += sizeof(uint64_t);
         out = pointer_cast<std::byte*>(metadata.SerializeToArray(to_uchar_ptr(out)));
+        out = pointer_cast<std::byte*>(trace_context.SerializeToArray(to_uchar_ptr(out)));
         const auto size = data->req.SerializedSize();
         auto* end = pointer_cast<std::byte*>(
             data->req.SerializeToArray(pointer_cast<uint8_t*>(out)));
@@ -1169,6 +1177,8 @@ class PgClient::Impl : public BigDataFetcher {
         data->SetupExchange(&exchange, this, rpc_deadline);
         return ExchangeFuture<Data>(std::move(data));
       }
+      // End the shared-memory span started above so it is not leaked.
+      data->EndSharedMemorySpan(Status::OK());
     }
     data->controller.set_invoke_callback_mode(rpc::InvokeCallbackMode::kReactorThread);
     method(

--- a/src/yb/yql/pgwrapper/dist_trace-test.cc
+++ b/src/yb/yql/pgwrapper/dist_trace-test.cc
@@ -1876,6 +1876,25 @@ TEST_F(DistTraceRpcTest, TestRpcPerformSpanReportsAsyncError) {
       "Perform server span reporting the injected error"));
 }
 
+// Cross-boundary over shared memory: the Perform shmem exchange's trace must reach the tserver.
+// The inbound server span on TabletServer should be a child of the ysql outbound client span.
+TEST_F(DistTraceTest, TestSharedMemoryPerformReachesTabletServer) {
+  ASSERT_OK(CreateTable("shmem_crossing_test", 5));
+
+  auto tp = GenerateTraceparent();
+  ASSERT_OK(conn_->ExecuteFormat(
+      "SET yb_dist_tracecontext = 'traceparent=''$0'''", tp.full));
+  ASSERT_OK(conn_->Fetch("SELECT * FROM shmem_crossing_test"));
+
+  auto server_span = ASSERT_RESULT(collector_.WaitForRemoteChildSpan(
+      tp.trace_id, "shmem yb.tserver.PgClientService.Perform",
+      "ysql" /* client_service */, "TabletServer" /* server_service */,
+      "inbound_shmem" /* expected_rpc_system */));
+
+  ASSERT_EQ(server_span.str_attrs["rpc.service"], "yb.tserver.PgClientService");
+  ASSERT_EQ(server_span.str_attrs["rpc.method"], "Perform");
+}
+
 TEST_F(DistTraceRpcTest, TestOtelInternalMessagesAreLogged) {
   google::FlagSaver flag_saver;
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_otel_collector_traces_endpoint) = collector_.Url();

--- a/src/yb/yql/pgwrapper/dist_trace-test.cc
+++ b/src/yb/yql/pgwrapper/dist_trace-test.cc
@@ -73,6 +73,8 @@ static constexpr auto kOtelBatchMaxExportBatchSize = 512;
 static constexpr auto kOtelBatchScheduleDelayMs = 100;
 static constexpr auto kSharedMemoryPerformSpanName =
     "shmem yb.tserver.PgClientService.Perform";
+static constexpr auto kSharedMemoryObjectLockSpanName =
+    "shmem yb.tserver.PgClientService.AcquireObjectLock";
 
 YB_DEFINE_ENUM(QueryExecMode, (kFetch)(kExecute));
 YB_STRONGLY_TYPED_BOOL(IsUtility);
@@ -393,6 +395,20 @@ class OtlpHttpCollector {
     return result;
   }
 
+  std::vector<Span> FindSpansByParent(
+      const std::string& trace_id, const std::string& parent_span_id) const EXCLUDES(mutex_) {
+    std::lock_guard lock(mutex_);
+    std::vector<Span> result;
+    auto it = traces_.find(trace_id);
+    if (it == traces_.end()) return result;
+    for (const auto& span : it->second.spans) {
+      if (span.parent_span_id == parent_span_id) {
+        result.push_back(span);
+      }
+    }
+    return result;
+  }
+
   std::optional<Span> FindRpcSpanWithTableName(
       const std::string& trace_id, std::string_view table_name) const EXCLUDES(mutex_) {
     return FindSpanWithNamePrefixAndTableName(trace_id, "rpc ", table_name);
@@ -637,6 +653,11 @@ class DistTraceTest : public LibPqTestBase {
         Format("--enable_object_lock_fastpath=$0", UsePgClientSharedMemory()));
     options->extra_tserver_flags.push_back(
         Format("--pg_client_use_shared_memory=$0", UsePgClientSharedMemory()));
+    if (UsePgClientSharedMemory()) {
+      // Object locking defaults off in debug builds; the AcquireObjectLock exchange needs it on.
+      options->extra_tserver_flags.push_back("--enable_object_locking_for_table_locks=true");
+      options->extra_tserver_flags.push_back("--ysql_yb_ddl_transaction_block_enabled=true");
+    }
   }
 
   virtual void ConfigureDistTraceOptions(ExternalMiniClusterOptions* options) {
@@ -1876,23 +1897,68 @@ TEST_F(DistTraceRpcTest, TestRpcPerformSpanReportsAsyncError) {
       "Perform server span reporting the injected error"));
 }
 
-// Cross-boundary over shared memory: the Perform shmem exchange's trace must reach the tserver.
-// The inbound server span on TabletServer should be a child of the ysql outbound client span.
-TEST_F(DistTraceTest, TestSharedMemoryPerformReachesTabletServer) {
-  ASSERT_OK(CreateTable("shmem_crossing_test", 5));
+// Cross-boundary over shared memory: both request types carried by the exchange must propagate the
+// trace to the tserver. Each inbound server span on TabletServer should be a child of the ysql
+// outbound client span.
+TEST_F(DistTraceTest, TestSharedMemorySpansReachTabletServer) {
+  static constexpr auto kTableName = "shmem_crossing_test";
+  ASSERT_OK(CreateTable(kTableName, 5));
 
   auto tp = GenerateTraceparent();
   ASSERT_OK(conn_->ExecuteFormat(
       "SET yb_dist_tracecontext = 'traceparent=''$0'''", tp.full));
-  ASSERT_OK(conn_->Fetch("SELECT * FROM shmem_crossing_test"));
+  ASSERT_OK(conn_->FetchFormat("SELECT * FROM $0", kTableName));
 
-  auto server_span = ASSERT_RESULT(collector_.WaitForRemoteChildSpan(
-      tp.trace_id, "shmem yb.tserver.PgClientService.Perform",
+  auto perform_span = ASSERT_RESULT(collector_.WaitForRemoteChildSpan(
+      tp.trace_id, kSharedMemoryPerformSpanName,
       "ysql" /* client_service */, "TabletServer" /* server_service */,
       "inbound_shmem" /* expected_rpc_system */));
 
+  ASSERT_EQ(perform_span.str_attrs["rpc.service"], "yb.tserver.PgClientService");
+  ASSERT_EQ(perform_span.str_attrs["rpc.method"], "Perform");
+
+  auto lock_span = ASSERT_RESULT(collector_.WaitForRemoteChildSpan(
+      tp.trace_id, kSharedMemoryObjectLockSpanName,
+      "ysql" /* client_service */, "TabletServer" /* server_service */,
+      "inbound_shmem" /* expected_rpc_system */));
+
+  ASSERT_EQ(lock_span.str_attrs["rpc.service"], "yb.tserver.PgClientService");
+  ASSERT_EQ(lock_span.str_attrs["rpc.method"], "AcquireObjectLock");
+}
+
+// Checks that a request too large for the exchange falls back to RPC, leaving a childless shared
+// memory span and an RPC span whose inbound counterpart on TabletServer is its remote child.
+TEST_F(DistTraceTest, TestSharedMemoryFallbackToRpc) {
+  static constexpr auto kTableName = "shmem_fallback_test";
+  ASSERT_OK(CreateTable(kTableName, 1));
+
+  // A value far larger than the exchange makes SharedExchange::Obtain fail.
+  auto tp = GenerateTraceparent();
+  ASSERT_OK(conn_->ExecuteFormat(
+      "INSERT INTO $0 VALUES (100, repeat('x', 1048576)) /*traceparent='$1'*/",
+      kTableName, tp.full));
+
+  auto server_span = ASSERT_RESULT(collector_.WaitForRemoteChildSpan(
+      tp.trace_id, "rpc yb.tserver.PgClientService.Perform",
+      "ysql" /* client_service */, "TabletServer" /* server_service */,
+      "inbound_rpc" /* expected_rpc_system */));
+
   ASSERT_EQ(server_span.str_attrs["rpc.service"], "yb.tserver.PgClientService");
   ASSERT_EQ(server_span.str_attrs["rpc.method"], "Perform");
+
+  ASSERT_OK(WaitFor(
+      [&]() -> Result<bool> {
+        for (const auto& span : collector_.FindSpansByNamePrefix(
+                 tp.trace_id, kSharedMemoryPerformSpanName)) {
+          if (span.service_name == "ysql" &&
+              collector_.FindSpansByParent(tp.trace_id, span.span_id).empty()) {
+            return true;
+          }
+        }
+        return false;
+      },
+      kOtelBatchScheduleDelayMs * kTimeMultiplier * 50ms,
+      "Childless shared memory Perform span for the abandoned attempt"));
 }
 
 TEST_F(DistTraceRpcTest, TestOtelInternalMessagesAreLogged) {


### PR DESCRIPTION
## Summary

Extend the same propagation to the shared-memory fast path between a PG backend and its
tserver, so requests that bypass the RPC stack still join the caller's trace. The backend
serializes its active span's context into the exchange alongside the ASH metadata it
already carries, and the tserver opens a server span under it. The encoding reuses the
wire type and decoder introduced for the RPC header rather than adding a second
representation of the same context.

## Test plan

- [x] `./yb_build.sh release --cxx-test dist_trace-test` — full binary, green on this
      commit, including the new `TestSharedMemorySpansReachTabletServer` and
      `TestSharedMemoryFallbackToRpc`.

`TestSharedMemorySpansReachTabletServer` covers both request types the exchange carries,
`Perform` and `AcquireObjectLock`: each inbound span on the tserver must join the query's
trace as a child of the ysql backend's outbound span, with `rpc.system=yb_shmem`.
`TestSharedMemoryFallbackToRpc` sends a request too large for the exchange, asserting the
shared-memory span is left childless and the RPC that replaces it has its own inbound span
on the far side.

### Stack

1. #33116 — span/scope API and its direct callers
2. #33112 — propagate trace context across the RPC boundary
3. #33113 — propagate trace context over the PG↔tserver shared memory exchange
4. #33114 — carry trace context across thread hops
5. #33115 — propagate traceparent to the PG backend via the startup packet
