### PR TITLE
[#16670] DocDB: dist-trace: Propagate traceparent to the PG backend via the startup packet

### DIFF
--- a/src/postgres/src/backend/postmaster/postmaster.c
+++ b/src/postgres/src/backend/postmaster/postmaster.c
@@ -2489,6 +2489,15 @@ retry1:
 							 errhint("Value must be one of the registered "
 									 "YbInternalConnKind wire names.")));
 			}
+			else if (YBIsEnabledInPostgresEnvVar()
+					 && strcmp(nameptr, "yb_dist_traceparent") == 0)
+			{
+				/*
+				 * Stash traceparent for InitPostgres's backend-init span;
+				 * consumed here, turned into a corresponding GUC.
+				 */
+				port->yb_dist_traceparent = pstrdup(valptr);
+			}
 			else if (strncmp(nameptr, "_pq_.", 5) == 0)
 			{
 				/*

--- a/src/postgres/src/backend/utils/init/postinit.c
+++ b/src/postgres/src/backend/utils/init/postinit.c
@@ -1130,6 +1130,22 @@ InitPostgresImpl(const char *in_dbname, Oid dboid,
 	/* Connect to YugaByte cluster. */
 	YBInitPostgresBackend("postgres", yb_init_info);
 
+	if (IsYugaByteEnabled() && !bootstrap && MyProcPort != NULL &&
+		MyProcPort->yb_dist_traceparent != NULL &&
+		MyProcPort->yb_dist_traceparent[0] != '\0')
+	{
+		char		tracecontext[128];
+
+		snprintf(tracecontext, sizeof(tracecontext), "traceparent='%s'",
+				 MyProcPort->yb_dist_traceparent);
+
+		/* Warn instead of failing the connection when the value is rejected. */
+		(void) set_config_option("yb_dist_tracecontext", tracecontext,
+								 PGC_BACKEND, PGC_S_CLIENT, GUC_ACTION_SET,
+								 true /* changeVal */, WARNING,
+								 false /* is_reload */);
+	}
+
 	if (IsYugaByteEnabled() && !bootstrap)
 	{
 		HandleYBStatus(YBCPgTableExists(Template1DbOid,

--- a/src/postgres/src/include/libpq/libpq-be.h
+++ b/src/postgres/src/include/libpq/libpq-be.h
@@ -188,6 +188,13 @@ typedef struct Port
 	bool		yb_is_ssl_enabled_in_logical_conn;
 
 	/*
+	 * YB: W3C traceparent from the "yb_dist_traceparent" startup-packet param
+	 * (set by the tserver). Root span for backend init; read in InitPostgres.
+	 * NULL when absent.
+	 */
+	char	   *yb_dist_traceparent;
+
+	/*
 	 * Authenticated identity.  The meaning of this identifier is dependent on
 	 * hba->auth_method; it is the identity (if any) that the user presented
 	 * during the authentication cycle, before they were assigned a database

--- a/src/postgres/src/interfaces/libpq/fe-connect.c
+++ b/src/postgres/src/interfaces/libpq/fe-connect.c
@@ -355,6 +355,14 @@ static const internalPQconninfoOption PQconninfoOptions[] = {
 		"YB-Internal-Conn-Kind", "", 32,
 	offsetof(struct pg_conn, yb_internal_conn_kind)},
 
+	/*
+	 * W3C traceparent set on any connection that carries a trace context, used
+	 * as the root span for backend init and queries.
+	 */
+	{"yb_dist_traceparent", NULL, NULL, NULL,
+		"YB-Dist-Traceparent", "", 64,
+	offsetof(struct pg_conn, yb_dist_traceparent)},
+
 	/* Terminating entry --- MUST BE LAST */
 	{NULL, NULL, NULL, NULL,
 	NULL, NULL, 0}
@@ -4193,6 +4201,8 @@ freePGconn(PGconn *conn)
 		free(conn->target_session_attrs);
 	if (conn->yb_internal_conn_kind)
 		free(conn->yb_internal_conn_kind);
+	if (conn->yb_dist_traceparent)
+		free(conn->yb_dist_traceparent);
 	termPQExpBuffer(&conn->errorMessage);
 	termPQExpBuffer(&conn->workBuffer);
 

--- a/src/postgres/src/interfaces/libpq/fe-protocol3.c
+++ b/src/postgres/src/interfaces/libpq/fe-protocol3.c
@@ -2239,6 +2239,9 @@ build_startup_packet(const PGconn *conn, char *packet,
 	if (conn->yb_internal_conn_kind && conn->yb_internal_conn_kind[0])
 		ADD_STARTUP_OPTION("yb_internal_conn_kind",
 						   conn->yb_internal_conn_kind);
+	if (conn->yb_dist_traceparent && conn->yb_dist_traceparent[0])
+		ADD_STARTUP_OPTION("yb_dist_traceparent",
+						   conn->yb_dist_traceparent);
 	if (conn->send_appname)
 	{
 		/* Use appname if present, otherwise use fallback */

--- a/src/postgres/src/interfaces/libpq/libpq-int.h
+++ b/src/postgres/src/interfaces/libpq/libpq-int.h
@@ -400,6 +400,9 @@ struct pg_conn
 										 * names (see yb_internal_conn.h);
 										 * NULL/empty for a regular client
 										 * connection */
+	char	   *yb_dist_traceparent;	/* W3C traceparent for the backend's
+										  root trace span and query tracing from
+										  tserver; NULL when not tracing */
 
 	/* Optional file to write trace info to */
 	FILE	   *Pfdebug;

--- a/src/yb/util/dist_trace.cc
+++ b/src/yb/util/dist_trace.cc
@@ -225,8 +225,8 @@ Status InitDistTraceProvider(const resource_sdk::Resource& resource_attrs) {
 // supplied (through GUC or comment) traceparent header.
 class TraceparentCarrier : public context::propagation::TextMapCarrier {
  public:
-  explicit TraceparentCarrier(nostd::string_view traceparent)
-      : traceparent_(traceparent) {}
+  explicit TraceparentCarrier(nostd::string_view traceparent = {})
+      : traceparent_(traceparent.data(), traceparent.size()) {}
 
   nostd::string_view Get(nostd::string_view key) const noexcept override {
     if (key == trace::propagation::kTraceParent) {
@@ -235,10 +235,16 @@ class TraceparentCarrier : public context::propagation::TextMapCarrier {
     return {};
   }
 
-  void Set(nostd::string_view, nostd::string_view) noexcept override {}
+  void Set(nostd::string_view key, nostd::string_view value) noexcept override {
+    if (key == trace::propagation::kTraceParent) {
+      traceparent_.assign(value.data(), value.size());
+    }
+  }
+
+  const std::string& traceparent() const { return traceparent_; }
 
  private:
-  nostd::string_view traceparent_;
+  std::string traceparent_;
 };
 
 }  // namespace
@@ -309,6 +315,17 @@ trace::SpanContext GetTraceparentSpanContext(const char* traceparent) {
 
   // Return the SpanContext from the parent context.
   return trace::GetSpan(parent_context)->GetContext();
+}
+
+std::string GetActiveTraceparent() {
+  if (!HasActiveContext()) {
+    return {};
+  }
+  TraceparentCarrier carrier;
+  static const auto propagator =
+      context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
+  propagator->Inject(carrier, context::RuntimeContext::GetCurrent());
+  return carrier.traceparent();
 }
 
 bool HasActiveContext() {

--- a/src/yb/util/dist_trace.h
+++ b/src/yb/util/dist_trace.h
@@ -102,6 +102,10 @@ nostd::shared_ptr<opentelemetry::trace::Tracer> GetDistTracer();
 bool IsDistTraceEnabled();
 trace::SpanContext GetTraceparentSpanContext(const char* traceparent);
 
+// Serializes the active span into a W3C traceparent string via the global propagator (inverse of
+// GetTraceparentSpanContext); hands the context to another process. Empty when disabled/no context.
+std::string GetActiveTraceparent();
+
 trace::SpanContext GetActiveSpanContext();
 
 bool IsSpanContextValidAndRemote(const trace::SpanContext& span_context);

--- a/src/yb/yql/pgwrapper/dist_trace-test.cc
+++ b/src/yb/yql/pgwrapper/dist_trace-test.cc
@@ -603,6 +603,42 @@ class OtlpHttpCollector {
     return downstream_span;
   }
 
+  // Waits for a span from child_service in trace_id whose query text starts with
+  // child_query_prefix and whose parent is a span from parent_service with an op name starting
+  // with parent_op_prefix. Returns the child span.
+  Result<Span> WaitForCrossServiceChildSpan(
+      std::string_view trace_id, std::string_view parent_service,
+      std::string_view parent_op_prefix, std::string_view child_service,
+      std::string_view child_query_prefix) const EXCLUDES(mutex_) {
+    Span child_span;
+    RETURN_NOT_OK(WaitFor(
+        [&]() -> Result<bool> {
+          std::lock_guard lock(mutex_);
+          auto it = traces_.find(std::string(trace_id));
+          if (it == traces_.end()) return false;
+          const auto& spans = it->second.spans;
+          for (const auto& child : spans) {
+            if (child.service_name != child_service || child.parent_span_id.empty() ||
+                !child.query_text.starts_with(child_query_prefix)) {
+              continue;
+            }
+            for (const auto& parent : spans) {
+              if (parent.service_name == parent_service &&
+                  parent.op_name.starts_with(parent_op_prefix) &&
+                  parent.span_id == child.parent_span_id) {
+                child_span = child;
+                return true;
+              }
+            }
+          }
+          return false;
+        },
+        kOtelBatchScheduleDelayMs * kTimeMultiplier * 50ms,
+        Format("Span on '$0' for '$1*' parented by a '$2' span '$3*' in trace '$4'",
+               child_service, child_query_prefix, parent_service, parent_op_prefix, trace_id)));
+    return child_span;
+  }
+
  private:
   void HandleTraceRequest(const Webserver::WebRequest& req, Webserver::WebResponse* resp) {
     if (req.request_method != "POST") {
@@ -2047,6 +2083,26 @@ TEST_F(DistTraceTest, TestApplyTaskCarriesTraceContextToMaster) {
 
   ASSERT_EQ(master_span.str_attrs["rpc.service"], "yb.tserver.TabletServerService");
   ASSERT_EQ(master_span.str_attrs["rpc.method"], "UpdateTransaction");
+}
+
+// Runs a CREATE INDEX under a known traceparent and asserts the trace contains the BACKFILL INDEX
+// statement run by the internal PG connection the tserver opens for the backfill, parented under
+// the tserver's BackfillIndex span.
+TEST_F(DistTraceTest, TestBackfillBackendJoinsQueryTrace) {
+  ASSERT_OK(CreateTable("backfill_trace_test", 10));
+
+  auto tp = GenerateTraceparent();
+  ASSERT_OK(conn_->ExecuteFormat(
+      "SET yb_dist_tracecontext = 'traceparent=''$0'''", tp.full));
+  ASSERT_OK(conn_->Execute("CREATE INDEX backfill_trace_test_idx ON backfill_trace_test (val)"));
+
+  auto backend_span = ASSERT_RESULT(collector_.WaitForCrossServiceChildSpan(
+      tp.trace_id, "TabletServer" /* parent_service */,
+      "rpc yb.tserver.TabletServerAdminService.BackfillIndex" /* parent_op_prefix */,
+      "ysql" /* child_service */, "BACKFILL INDEX " /* child_query_prefix */));
+
+  ASSERT_EQ(backend_span.trace_id, tp.trace_id);
+  ASSERT_EQ(backend_span.op_name, "query");
 }
 
 TEST_F(DistTraceRpcTest, TestOtelInternalMessagesAreLogged) {

--- a/src/yb/yql/pgwrapper/libpq_utils.cc
+++ b/src/yb/yql/pgwrapper/libpq_utils.cc
@@ -28,6 +28,7 @@
 #include "yb/gutil/endian.h"
 
 #include "yb/util/backoff_waiter.h"
+#include "yb/util/dist_trace.h"
 #include "yb/util/endian_util.h"
 #include "yb/util/enums.h"
 #include "yb/util/format.h"
@@ -139,6 +140,9 @@ std::string BuildConnectionString(const PGConnSettings& settings, bool mask_pass
   if (!settings.yb_internal_conn_kind.empty()) {
     result += Format(
         " yb_internal_conn_kind=$0", PqEscapeStringConn(settings.yb_internal_conn_kind));
+  }
+  if (!settings.traceparent.empty()) {
+    result += Format(" yb_dist_traceparent=$0", PqEscapeStringConn(settings.traceparent));
   }
   return result;
 }
@@ -1030,7 +1034,8 @@ PGConnBuilder CreateInternalPGConnBuilder(
        .password = UInt64ToString(postgres_auth_key),
        .connect_timeout = connect_timeout,
        .yb_internal_conn_kind = std::string(yb_internal_conn_kind),
-       .should_stop = std::move(should_stop)});
+       .should_stop = std::move(should_stop),
+       .traceparent = dist_trace::GetActiveTraceparent()});
 }
 
 } // namespace yb::pgwrapper

--- a/src/yb/yql/pgwrapper/libpq_utils.h
+++ b/src/yb/yql/pgwrapper/libpq_utils.h
@@ -469,6 +469,9 @@ struct PGConnSettings {
   // shutting down). Checked between connection attempts, not during one. Carried by the builder, so
   // it also applies to any later reconnect made from a stored builder.
   std::function<bool()> should_stop = {};
+  // W3C traceparent for the distributed-trace root span the backend should
+  // activate intializing connection.
+  std::string traceparent = {};
 };
 
 class PGConnBuilder {


### PR DESCRIPTION
## Summary

Carry the trace into PG backends the tserver spawns for internal connections, over the
connection startup packet, so a backend's initialization and the statements it runs root
under the originating trace instead of starting their own. A malformed value leaves the
backend untraced rather than failing the connection.

## Upgrade/Rollback safety

No proto, catalog, on-disk format, or gflag default changes, and nothing is persisted.

The one wire-visible change is a new startup-packet parameter, `yb_dist_traceparent`, which libpq
emits only when the matching conninfo option is set. PostgreSQL treats an unrecognized startup
parameter as a GUC name, so a backend built without this change would reject such a connection with
"unrecognized configuration parameter". That cannot arise here: the option is set only by
`BuildConnectionString` for internal connections, where a tserver connects to the postgres process
it spawned from its own binary, so client and backend are always the same build. With the option
unset the startup packet is byte-identical to today's, so external clients are unaffected.

Rollback is a plain binary swap — a node on an older build simply stops emitting and consuming the
parameter, and there is no state to migrate or clean up.

## Test plan

- [x] `./yb_build.sh release --cxx-test dist_trace-test`

`TestBackfillBackendJoinsQueryTrace` drives the production path that spawns a backend this
way: `CREATE INDEX` on a YSQL table, where `Tablet::BackfillIndexesForYsql` opens an internal
PG connection while the `BackfillIndex` server span is active. It asserts that the
`BACKFILL INDEX ...` statement the spawned backend runs appears in the statement's own trace,
as a `ysql` span parented under the tserver's `TabletServerAdminService.BackfillIndex` span.

The new `WaitForCrossServiceChildSpan` collector helper does the pairing, matching on the
parent's op name and the child's query text. Both are needed: `CREATE INDEX` opens a second
internal connection as well — the `pg_stat_activity` poll behind
`WaitForYsqlBackendsCatalogVersion` — and matching on services alone would be satisfied by
either, so the assertion has to name which one it means. `WaitForRemoteChildSpan` cannot be
reused here because the two sides share no op-name convention.

### Stack

1. #33116 — span/scope API and its direct callers
2. #33112 — propagate trace context across the RPC boundary
3. #33113 — propagate trace context over the PG↔tserver shared memory exchange
4. #33114 — carry trace context across thread hops
5. #33115 — propagate traceparent to the PG backend via the startup packet

