### PR TITLE
[#31461] YSQL: Honor deferred read point for DDLs in regular transaction blocks

### DIFF
--- a/src/yb/tserver/pg_client_session.cc
+++ b/src/yb/tserver/pg_client_session.cc
@@ -3908,9 +3908,10 @@ class PgClientSession::Impl {
     RETURN_NOT_OK(
         UpdateReadPointForXClusterConsistentReads(options, deadline, session.read_point()));
 
-    if (!options.ddl_mode() && !options.use_legacy_catalog_session() &&
-        read_time_options.defer_read_point()) {
-      // For DMLs, only fast path writes cannot be deferred.
+    if (!options.use_legacy_catalog_session() && read_time_options.defer_read_point()) {
+      // Among DMLs, only fast path writes cannot be deferred. DDLs can also request
+      // deferral, but only when they run in the regular transaction block (see
+      // PgTxnManager::CalculateIsolation).
       RETURN_NOT_OK(session.read_point()->TrySetDeferredCurrentReadTime());
       VLOG_WITH_PREFIX(3) << "Set current read time for deferred mode "
           << session.read_point()->GetReadTime();

--- a/src/yb/yql/pgwrapper/pg_read_after_commit_visibility-test.cc
+++ b/src/yb/yql/pgwrapper/pg_read_after_commit_visibility-test.cc
@@ -91,10 +91,11 @@ class PgReadAfterCommitVisibilityTest : public PgMiniTestBase {
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_yb_enable_read_committed_isolation) = true;
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_time_source) = server::SkewedClock::kName;
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_replication_factor) = 1;
-    // Support DDL concurrency with object locks.
+    // Run DDLs in the regular transaction block, optionally with DDL
+    // concurrency via object locks.
     ANNOTATE_UNPROTECTED_WRITE(FLAGS_ysql_yb_ddl_transaction_block_enabled) = true;
-    ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_object_locking_for_table_locks) = true;
-    ANNOTATE_UNPROTECTED_WRITE(FLAGS_ysql_enable_concurrent_ddl) = true;
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_object_locking_for_table_locks) = EnableTableLocks();
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_ysql_enable_concurrent_ddl) = EnableTableLocks();
     PgMiniTestBase::SetUp();
     SpawnSupervisors();
   }
@@ -114,6 +115,8 @@ class PgReadAfterCommitVisibilityTest : public PgMiniTestBase {
     // One server for a proxy and the other server to host the data.
     return 2;
   }
+
+  virtual bool EnableTableLocks() const { return true; }
 
   void BeforePgProcessStart() override {
     // Identify the tserver index that hosts the MiniCluster postmaster
@@ -539,6 +542,66 @@ TEST_F(PgReadAfterCommitVisibilityTest, DeferredModeHiddenDml) {
     "INSERT INTO kv(k) VALUES (1) RETURNING k"
     ") SELECT k FROM new_kv"
   );
+}
+
+// Fixture without table-level object locks: with them enabled, every DDL
+// statement starts with a lock acquisition request that is not in ddl mode and
+// picks (and defers) the statement read point before the DDL's own requests
+// arrive. Without them, the read point is picked by the DDL's own requests,
+// which exercises the deferral path for ddl mode requests.
+class PgReadAfterCommitVisibilityDdlTest : public PgReadAfterCommitVisibilityTest {
+ protected:
+  bool EnableTableLocks() const override { return false; }
+};
+
+// Deferred mode also applies to DDLs when DDL transaction blocks are enabled
+// (ysql_yb_ddl_transaction_block_enabled, set by this fixture): the DDL runs in
+// the regular transaction block, so pggate requests a deferred read point for
+// it just like for DMLs. The tserver must honor the deferral: a DDL that reads
+// user data picks the global limit as its read time, observes recent commits
+// despite clock skew, and cannot hit a read restart. Regression test for
+// #31461.
+TEST_F(PgReadAfterCommitVisibilityDdlTest, DeferredModeDdl) {
+  auto proxyConn = ASSERT_RESULT(ConnectToProxy());
+  auto hostConn = ASSERT_RESULT(ConnectToDataHost());
+
+  // Create the base table on the data node (the proxy is blacklisted).
+  ASSERT_OK(hostConn.Execute(
+    "CREATE TABLE kv (k INT, v INT, PRIMARY KEY(k HASH)) SPLIT INTO 1 TABLETS"));
+
+  // Populate the catalog cache on the proxy backend so that catalog cache
+  // misses do not interfere with hybrid time propagation.
+  ASSERT_RESULT(proxyConn.FetchRows<int32_t>("SELECT k FROM kv"));
+
+  ASSERT_OK(proxyConn.Execute("SET yb_read_after_commit_visibility = deferred"));
+
+  // Jump the clock of the data node hosting the table into the future.
+  auto skew = 100ms;
+  auto changers = JumpClockDataNodes(skew);
+
+  // Fast path insert via the host connection. The commit timestamp is picked
+  // on the data node whose clock is ahead of the proxy's.
+  ASSERT_OK(hostConn.Execute("INSERT INTO kv(k, v) VALUES (1, 1)"));
+
+  // The tserver logs the message below (pg_client_session.cc, VLOG level 3)
+  // whenever it defers the read point of a request. The tservers run
+  // in-process in this test, so the message is observable via a log sink.
+  // The DDL below is the only deferred-eligible statement until the sink is
+  // checked: the host connection does not use the deferred mode and the
+  // proxy connection issues no other statement in between.
+  google::SetVLOGLevel("pg_client_session*", 3);
+  StringWaiterLogSink log_waiter("Set current read time for deferred mode");
+
+  // Run a DDL that reads the user table from the proxy connection. With the
+  // deferred read point honored, it must observe the recent insert and must
+  // not surface a read restart error.
+  ASSERT_OK(proxyConn.Execute("CREATE TABLE kv_copy AS SELECT k, v FROM kv"));
+  ASSERT_TRUE(log_waiter.IsEventOccurred())
+      << "The DDL did not defer its read point despite "
+         "yb_read_after_commit_visibility = 'deferred'";
+
+  auto count = ASSERT_RESULT(proxyConn.FetchRow<int64_t>("SELECT COUNT(*) FROM kv_copy"));
+  ASSERT_EQ(count, 1);
 }
 
 } // namespace yb::pgwrapper


### PR DESCRIPTION
DO NOT MERGE!! [CSI](<https://csiweb.dev.yugabyte.com/pull/33118/>) ❌. Once CSI passes, comment `trigger jenkins` to clear this warning.

## Summary

Fixes #31461 (Jira: DB-21280).

When `yb_read_after_commit_visibility` is set to `'deferred'` (or a `READ ONLY DEFERRABLE` transaction is used), pggate requests a deferred read point via the `defer_read_point` option. `PgClientSessionImpl::UpdateReadTime` dropped that request for any perform RPC with `ddl_mode: true`, so DDL statements silently ran with a regular, restart-prone read time.

With `ysql_yb_ddl_transaction_block_enabled` (transactional DDL), DDLs run in the regular transaction block and pggate does request deferral for them; the tserver-side drop then causes `Restart read required` errors that the query layer cannot retry (DDL retries are unsupported in READ COMMITTED with transactional DDL), and violates pggate's "Deferred reads do not face read restart errors" invariant (`PgTxnManager::CheckConflictsAcrossReadTimeOptions`). With the flag disabled, pggate never requests deferral for DDLs (`PgTxnManager::CalculateIsolation` returns early before computing `need_defer_read_point_`), so this change is behavior-neutral in that mode.

This PR drops the `ddl_mode` conjunct from the deferral guard so that a requested deferral is honored for DDLs too. Reads on the legacy catalog session still cannot be deferred.

The new `PgReadAfterCommitVisibilityDdlTest.DeferredModeDdl` test reproduces the dropped deferral and verifies the fix. It runs with table-level object locks disabled because the lock acquisition request that otherwise precedes every DDL is not in ddl mode and picks (and defers) the statement read point itself, masking the bug. Without the fix the test fails deterministically:

```
ERROR:  Restart read required (query layer retry isn't possible because retrying DDL
statements are not supported in READ COMMITTED isolation level when transactional DDL
is enabled. If object locking is enabled, kConflict and kReadRestart errors won't occur.)
```

Note: the issue carries "2025.2 Backport Required" and "2026.1 Backport Required" labels; backport PRs are to follow separately (the guard exists in both branches with older field names).

## Upgrade/Rollback safety

No wire-format, catalog, or on-disk changes; no flag defaults change. The behavior change is confined to perform RPCs that carry both `ddl_mode: true` and `defer_read_point: true`, which pggate only sends when `ysql_yb_ddl_transaction_block_enabled` is set and the session opted into deferred visibility (`yb_read_after_commit_visibility = 'deferred'` or a deferrable read-only transaction). During a mixed-version window an un-upgraded tserver simply keeps the old behavior (deferral dropped for DDLs), which is safe; rollback restores it uniformly.

## Test plan

- [x] `./yb_build.sh debug --cxx-test pg_read_after_commit_visibility-test --gtest_filter PgReadAfterCommitVisibilityDdlTest.DeferredModeDdl` (new test; fails with `Restart read required` before the fix, passes after; the tserver log shows the deferral applied to the DDL's requests after the fix and never before)
- [x] `./yb_build.sh debug --cxx-test pg_read_after_commit_visibility-test --gtest_filter PgReadAfterCommitVisibilityTest.DifferentNodeDeferredRead` (existing deferred-mode DML regression control, passes)
- [x] `./build-support/lint.sh --rev origin/master` (0 errors, 0 warnings)
