### PR TITLE
[DOC-184][yba] Clarify namespace in k8s permissions

### DIFF
--- a/docs/content/stable/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-k8s.md
+++ b/docs/content/stable/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-k8s.md
@@ -27,26 +27,26 @@ type: docs
     </a>
   </li>
   <li>
-    <a href="../cloud-permissions-nodes-gcp" class="nav-link">
+    <a href="../cloud-permissions-nodes-gcp/" class="nav-link">
       <i class="fa-brands fa-google"></i>
       GCP
     </a>
   </li>
   <li>
-    <a href="../cloud-permissions-nodes-azure" class="nav-link">
+    <a href="../cloud-permissions-nodes-azure/" class="nav-link">
       <i class="fa-brands fa-microsoft"></i>
       Azure
     </a>
   </li>
   <li>
-    <a href="../cloud-permissions-nodes-k8s" class="nav-link active">
+    <a href="../cloud-permissions-nodes-k8s/" class="nav-link active">
       <i class="fa-regular fa-dharmachakra"></i>
       Kubernetes
     </a>
   </li>
 </ul>
 
-For YugabyteDB Anywhere (YBA) to be able to deploy and manage YugabyteDB clusters, you need to provide YBA with privileges on your cloud infrastructure to create, delete, and modify VMs, mount and unmount disk volumes, and so on. The more permissions that you can provide, the more YBA can automate.
+For YugabyteDB Anywhere (YBA) to deploy and manage YugabyteDB universes on Kubernetes, you need to provide YBA with a service account that can create and manage pods, services, StatefulSets, secrets, and related resources in the target namespaces. The more permissions that you can provide, the more YBA can automate.
 
 ## Kubernetes
 
@@ -56,17 +56,17 @@ Do one of the following:
 
 - Create a [`yugabyte-platform-universe-management` service account](#create-a-service-account) and a [`kubeconfig` file](#create-a-kubeconfig-file) directly.
 
-  Do this for each Kubernetes cluster if you are doing a multi-cluster setup.
+  Do this for each Kubernetes cluster if you are doing a multi-cluster setup. Prefer this approach when you need least-privilege access (for example, Namespace Restricted), because the YBA installation service account may not have the permissions required to manage universes.
 
-- If deploying into a single Kubernetes cluster, have YBA auto-fill these values using the existing service account and kubeconfig file used for your YBA installation.
+- If deploying into a single Kubernetes cluster **and** the service account used for your YBA installation already has sufficient permissions to manage universes, have YBA auto-fill these values using that service account and kubeconfig.
 
   See [Create a provider](../../../configure-yugabyte-platform/kubernetes/) for details.
 
 ### Create a service account
 
-The secret of a service account can be used to generate a `kubeconfig` file. This account should not be deleted once it is in use by YBA.
+YBA uses a kubeconfig generated for this service account to authenticate to the Kubernetes cluster. Do not delete the account after YBA starts using it.
 
-Set the `YBA_NAMESPACE` environment variable to the namespace where your YBA is installed, as follows:
+Set the `YBA_NAMESPACE` environment variable to the namespace where you will create the service account. This is commonly the namespace where YBA is installed, but it can be any namespace; later steps must use the same value for `<SA_NAMESPACE>`.
 
 ```sh
 export YBA_NAMESPACE="yb-platform"
@@ -88,74 +88,78 @@ Expect the following output:
 serviceaccount/yugabyte-platform-universe-management created
 ```
 
-The next step is to grant access to this service account using ClusterRoles and Roles, as well as ClusterRoleBindings and RoleBindings, thus allowing it to manage the YugabyteDB universe's resources for you.
+The next step is to grant access to this service account using ClusterRoles and Roles, as well as ClusterRoleBindings and RoleBindings, so it can manage YugabyteDB universe resources.
 
-The namespace in the following commands needs to be replaced with the correct namespace of the previously created service account.
+In the RBAC manifests, `<SA_NAMESPACE>` is the namespace where the service account lives (the value of `YBA_NAMESPACE`). For Namespace Admin and Namespace Restricted, that is separate from the *target* namespaces where you deploy universes; those are set with `kubectl apply -n`.
 
 The tasks you can perform depend on your access level.
 
-**Global Admin** can grant broad cluster level admin access by executing the following command:
+**Global Admin** can grant broad cluster-level admin access by executing the following command:
 
 ```sh
 export YBA_NAMESPACE="yb-platform"
 
 curl -s https://raw.githubusercontent.com/yugabyte/charts/master/rbac/platform-global-admin.yaml \
-  | sed "s/namespace: <SA_NAMESPACE>/namespace: ${YBA_NAMESPACE}"/g \
-  | kubectl apply -n ${YBA_NAMESPACE} -f -
+  | sed "s/namespace: <SA_NAMESPACE>/namespace: ${YBA_NAMESPACE}/g" \
+  | kubectl apply -f -
 ```
 
-**Global Restricted** can grant access to only the specific cluster roles to create and manage YugabyteDB universes across all the namespaces in a cluster using the following command:
+**Global Restricted** can grant access to only the specific cluster roles required to create and manage YugabyteDB universes across all namespaces in a cluster. Contains ClusterRoles and ClusterRoleBindings for the required set of permissions.
 
 ```sh
 export YBA_NAMESPACE="yb-platform"
 
 curl -s https://raw.githubusercontent.com/yugabyte/charts/master/rbac/platform-global.yaml \
-  | sed "s/namespace: <SA_NAMESPACE>/namespace: ${YBA_NAMESPACE}"/g \
-  | kubectl apply -n ${YBA_NAMESPACE} -f -
+  | sed "s/namespace: <SA_NAMESPACE>/namespace: ${YBA_NAMESPACE}/g" \
+  | kubectl apply -f -
 ```
 
-This contains ClusterRoles and ClusterRoleBindings for the required set of permissions.
+**Namespace Admin** can grant namespace-level admin access. Contains a RoleBinding that grants the `cluster-admin` ClusterRole to the service account in each target namespace.
 
-**Namespace Admin** can grant namespace-level admin access by using the following command:
+Apply the YAML in each target namespace where you want to deploy universes. For example, to grant namespace-level admin access in `yb-db-demo` and `yb-db-us-east4-a`:
 
 ```sh
 export YBA_NAMESPACE="yb-platform"
 
-curl -s https://raw.githubusercontent.com/yugabyte/charts/master/rbac/platform-namespaced-admin.yaml \
-  | sed "s/namespace: <SA_NAMESPACE>/namespace: ${YBA_NAMESPACE}"/g \
-  | kubectl apply -n ${<target_namespace>} -f -
+for ns in yb-db-demo yb-db-us-east4-a; do
+  curl -s https://raw.githubusercontent.com/yugabyte/charts/master/rbac/platform-namespaced-admin.yaml \
+    | sed "s/namespace: <SA_NAMESPACE>/namespace: ${YBA_NAMESPACE}/g" \
+    | kubectl apply -n "${ns}" -f -
+done
 ```
-
-If you have multiple target namespaces, then you have to apply the YAML in all of them.
 
 **Namespace Restricted** can grant access to only the specific roles required to create and manage YugabyteDB universes in a particular namespace. Contains Roles and RoleBindings for the required set of permissions.
 
-For example, if your goal is to allow YBA to manage YugabyteDB universes in the namespaces `yb-db-demo` and `yb-db-us-east4-a` (the target namespaces), then you need to apply in both the target namespaces, as follows:
+As with Namespace Admin, apply the YAML in each target namespace. For example, if your goal is to allow YBA to manage YugabyteDB universes in the namespaces `yb-db-demo` and `yb-db-us-east4-a`, apply in both target namespaces as follows:
 
 ```sh
 export YBA_NAMESPACE="yb-platform"
 
-curl -s https://raw.githubusercontent.com/yugabyte/charts/master/rbac/platform-namespaced.yaml \
-  | sed "s/namespace: <SA_NAMESPACE>/namespace: ${YBA_NAMESPACE}"/g \
-  | kubectl apply -n ${<target_namespace>} -f -
+for ns in yb-db-demo yb-db-us-east4-a; do
+  curl -s https://raw.githubusercontent.com/yugabyte/charts/master/rbac/platform-namespaced.yaml \
+    | sed "s/namespace: <SA_NAMESPACE>/namespace: ${YBA_NAMESPACE}/g" \
+    | kubectl apply -n "${ns}" -f -
+done
 ```
 
 ### Create a kubeconfig file
 
-You can create a `kubeconfig` file for the previously created `yugabyte-platform-universe-management` service account as follows:
+You can create a `kubeconfig` file for the previously created `yugabyte-platform-universe-management` service account as follows.
+
+The `-n` argument must be the namespace where the service account was created (`YBA_NAMESPACE`), not a target universe namespace.
 
 1. Run the following `wget` command to get the Python script for generating the `kubeconfig` file:
 
     ```sh
-    wget https://raw.githubusercontent.com/YugaByte/charts/master/stable/yugabyte/generate_kubeconfig.py
+    wget https://raw.githubusercontent.com/yugabyte/charts/master/stable/yugabyte/generate_kubeconfig.py
     ```
 
-1. Run the following command to generate the `kubeconfig` file:
+1. Run the following command to generate the `kubeconfig` file. The script creates a service account token secret (required on Kubernetes 1.24 and later) and writes a kubeconfig that uses that token:
 
     ```sh
     export YBA_NAMESPACE="yb-platform"
 
-    python generate_kubeconfig.py -s yugabyte-platform-universe-management -n ${YBA_NAMESPACE}
+    python3 generate_kubeconfig.py -s yugabyte-platform-universe-management -n ${YBA_NAMESPACE}
     ```
 
     Expect the following output:


### PR DESCRIPTION
Changes:

- Replaced invalid ${<target_namespace>} with a real for loop over the example target namespaces
- Clarified that <SA_NAMESPACE> / YBA_NAMESPACE is the SA namespace; -n is each universe namespace
- Applied the same pattern to Namespace Admin and Namespace Restricted
- Put /g inside the sed quotes (was previously concatenated outside)

Plus misc tidyups