### PR TITLE
[DOC-1402][yba] Add decision guidance for S3 backup IAM

### DIFF
--- a/docs/content/stable/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
+++ b/docs/content/stable/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
@@ -48,7 +48,7 @@ When you create an S3 backup configuration, choose how YugabyteDB Anywhere and t
 
 | Option | When to use | Prerequisites | Trade-offs |
 | :--- | :--- | :--- | :--- |
-| Universe node IAM role {{<tags/feature/ea>}} | Production backups on AWS VMs or Kubernetes (EKS IRSA). Recommended for new deployments. | Attach IAM roles (or annotated Kubernetes service accounts) with the [required S3 IAM permissions](#required-s3-iam-permissions) to each universe node or database pod.<br>Set the **Use S3 IAM roles attached to DB node for Backup/Restore** [Universe Configuration option](../../administer-yugabyte-platform/manage-runtime-config/) to true. Enable **IAM Role** on the storage configuration. For EKS setup, see [EKS service account](../../create-deployments/create-universe-multi-zone-kubernetes/#eks-service-account). | YB Controller on each node authenticates to S3 directly, so backups scale with cluster size. Requires a universe-level runtime configuration change. Preferred path going forward. |
+| Universe node IAM role {{<tags/feature/ea>}} | Production backups on AWS VMs or Kubernetes (EKS IRSA). Recommended for new deployments. | Attach IAM roles (or annotated Kubernetes service accounts) with the [required S3 IAM permissions](#required-s3-iam-permissions) to each universe node or database pod.<br>Set the **Use S3 IAM roles attached to DB node for Backup/Restore** [Universe Configuration option](../../administer-yugabyte-platform/manage-runtime-config/) to true. Enable **IAM Role** on the storage configuration. For EKS, see [Kubernetes backups (EKS)](#kubernetes-backups-eks). | YB Controller on each node authenticates to S3 directly, so backups scale with cluster size. Requires a universe-level runtime configuration change. Preferred path going forward. |
 | YBA instance IAM role (Legacy) {{<tags/feature/ga>}} | Existing setups that already use the IAM role attached to the YugabyteDB Anywhere VM or pod. | Attach an IAM role with the [required S3 IAM permissions](#required-s3-iam-permissions) to the YugabyteDB Anywhere host. Enable **IAM Role**. <br>Leave **Use S3 IAM roles attached to DB node for Backup/Restore** at the default (`false`). | YBA fetches temporary credentials from its own instance role and passes them to database nodes. This path does not scale well for large backups and is not recommended for new deployments. |
 | Access Key and Access Secret {{<tags/feature/ga>}} | Evaluation and proof-of-concept setups; environments where neither YBA nor universe nodes have IAM roles (including many S3-compatible targets). | An IAM user (or equivalent) with the [required S3 IAM permissions](#required-s3-iam-permissions). Leave **IAM Role** disabled and enter **Access Key** and **Access Secret**. | Simplest path to a first successful backup. Credentials are stored in YBA and must be rotated manually. Prefer IAM for production when available. |
 
@@ -58,7 +58,7 @@ When you create an S3 backup configuration, choose how YugabyteDB Anywhere and t
 - **New production AWS or EKS universe.** Attach instance profiles (or IRSA service accounts) to the database nodes, set **Use S3 IAM roles attached to DB node for Backup/Restore** (`yb.backup.s3.use_db_nodes_iam_role_for_backup`) to true for the universe, then enable **IAM Role** on the storage configuration.
 - **Existing YBA-role configuration.** Keep **IAM Role** enabled and leave `yb.backup.s3.use_db_nodes_iam_role_for_backup` at `false` until you can migrate nodes to their own IAM roles.
 
-For cloud permission setup details, refer to [Permissions to back up and restore](../../prepare/cloud-permissions/cloud-permissions-storage/).
+For cloud permission setup details, refer to [Permissions to back up and restore](../../prepare/cloud-permissions/cloud-permissions-storage/). On EKS, open the AWS **Kubernetes** tab on that page for IRSA setup.
 
 ### Create an AWS backup configuration
 
@@ -111,6 +111,80 @@ The following S3 IAM permissions are required:
 "s3:GetBucketLocation"
 ```
 
+### Kubernetes backups (EKS)
+
+{{<tags/feature/ea>}}On Amazon EKS, use IRSA so database pods can assume an IAM role for S3. Node instance profiles alone do **not** grant S3 access to pods.
+
+For IAM role trust policy, KSA annotations, and verification steps, refer to the AWS **Kubernetes** tab in [Permissions to back up and restore](../../prepare/cloud-permissions/cloud-permissions-storage/).
+
+To configure S3 backups with universe node IAM on EKS:
+
+1. Create an IRSA-enabled Kubernetes service account (KSA) with the [required S3 IAM permissions](#required-s3-iam-permissions), in each namespace where database pods run.
+
+1. Attach the KSA to database pods using provider or universe Helm overrides. For example:
+
+    ```yaml
+    tserver:
+      serviceAccount: <KSA_NAME>
+    ```
+
+    For details, see [EKS service account](../../create-deployments/create-universe-multi-zone-kubernetes/#eks-service-account). If you use the [YugabyteDB Kubernetes Operator](../../anywhere-automation/yb-kubernetes-operator/), set the same override under `spec.kubernetesOverrides`.
+
+1. Set the **Use S3 IAM roles attached to DB node for Backup/Restore** Universe Configuration option (config key `yb.backup.s3.use_db_nodes_iam_role_for_backup`) to true. Refer to [Manage runtime configuration settings](../../administer-yugabyte-platform/manage-runtime-config/).
+
+1. Create an S3 storage configuration with **IAM Role** enabled, as described in [Create an AWS backup configuration](#create-an-aws-backup-configuration).
+
+1. Verify credentials from a tserver pod (see the prepare page), then run a test backup.
+
+For which settings survive pod restarts and upgrades, see [Make backup settings persistent on Kubernetes](#make-backup-settings-persistent-on-kubernetes).
+
+### Make backup settings persistent on Kubernetes
+
+Settings you apply with `kubectl edit`, one-off interactive install prompts, or temporary pod changes are **not** durable. Use the following so backup IAM configuration survives restarts and upgrades:
+
+| Setting | Persistent if you… | Not persistent if you… |
+| :--- | :--- | :--- |
+| Storage configuration (**IAM Role**, Access Key / Secret, GCS credentials) | Create or update it in the YBA UI or API (stored in the YBA database). | — |
+| **Use S3 IAM roles attached to DB node for Backup/Restore** (`yb.backup.s3.use_db_nodes_iam_role_for_backup`) | Set it via YBA [runtime configuration](../../administer-yugabyte-platform/manage-runtime-config/) (UI or API). | — |
+| Database pod `serviceAccount` (and GKE `nodeSelector`) | Set provider or universe **Helm overrides** in YBA, or Operator `kubernetesOverrides`, then apply/upgrade the universe. | Edit the live Deployment or Pod with `kubectl`, or change the SA only in the cluster without updating overrides. |
+| YBA pod service account (legacy YBA IAM / GKE YBA Workload Identity) | Put `yugaware.serviceAccount` (and any required `nodeSelector`) in your Helm `values.yaml` and run `helm upgrade`. | Rely only on interactive install answers that were never written to `values.yaml`. |
+| IRSA / Workload Identity annotations on the KSA | Keep annotations in the KSA manifest you manage (GitOps, Helm chart for the SA, or `kubectl apply` of that manifest). | Recreate the KSA without annotations, or expect YBA to recreate IRSA bindings for you. |
+
+#### Universe pod overrides (recommended path)
+
+Set the database pod service account in YBA (provider- or universe-level overrides), for example:
+
+```yaml
+tserver:
+  serviceAccount: <KSA_NAME>
+```
+
+For GKE, also include:
+
+```yaml
+nodeSelector:
+  iam.gke.io/gke-metadata-server-enabled: "true"
+```
+
+Saving these overrides in YBA and applying them to the universe is what makes the pod identity persistent. See [Helm overrides](../../create-deployments/create-universe-multi-zone-kubernetes/#helm-overrides).
+
+#### YBA Helm values (YBA pod IAM)
+
+If the YBA pod itself must use a cloud IAM role (legacy S3 path, or GKE validation), set the service account in values and upgrade:
+
+```yaml
+yugaware:
+  serviceAccount: <KSA_NAME>
+nodeSelector:
+  iam.gke.io/gke-metadata-server-enabled: "true"   # GKE only
+```
+
+```sh
+helm upgrade <RELEASE_NAME> yugabytedb/yugaware -n <YBA_NAMESPACE> -f values.yaml
+```
+
+For GKE install-time guidance, see [Enable GKE service account-based IAM](../../install-yugabyte-platform/install-software/kubernetes/#enable-gke-service-account-based-iam).
+
 ### Specify signing region
 
 In some circumstances, you may need to additionally specify the signing region for the AWS backup configuration. For example:
@@ -146,12 +220,21 @@ To grant access to your bucket, create a GCP service account with [IAM roles for
 roles/storage.admin
 ```
 
-The credentials for this account (in JSON format) are used when creating the backup storage configuration. For information on how to obtain GCS credentials, see [Cloud Storage authentication](https://cloud.google.com/storage/docs/authentication).
+The credentials for this account (in JSON format) are used when creating the backup storage configuration with static credentials. For information on how to obtain GCS credentials, see [Cloud Storage authentication](https://cloud.google.com/storage/docs/authentication).
 
 You can configure access control for the GCS bucket as follows:
 
 - Provide the required access control list (ACL) and set it as either uniform or fine-grained (for object-level access).
 - Add permissions, such as roles and members.
+
+### Choose a GCS authentication method
+
+When you create a GCS backup configuration, choose how YugabyteDB Anywhere and the universe authenticate to the bucket:
+
+- **Use GCP IAM** — Use Workload Identity (GKE) or the IAM identity on the YBA / database host. On GKE, attach a Google IAM service account to the Kubernetes service account used by database pods (and typically the YBA pod). See [Kubernetes backups (GKE)](#kubernetes-backups-gke).
+- **GCS Credentials (JSON)** — Simplest path for evaluation setups, or when Workload Identity / host IAM is unavailable. Leave **Use GCP IAM** disabled and paste the service account JSON.
+
+For cloud permission setup, refer to the GCP tab in [Permissions to back up and restore](../../prepare/cloud-permissions/cloud-permissions-storage/) (use the **Kubernetes** sub-tab for GKE).
 
 ### Create a GCS backup configuration
 
@@ -167,11 +250,37 @@ To create a GCP backup configuration, do the following:
 
 1. Enter the URI of your GCS bucket in the **GCS Bucket** field. For example, `gs://gcp-bucket/test_backups`.
 
-1. Select **Use GCP IAM** to use the YugabyteDB Anywhere instance's Identity Access Management (IAM) role for the GCS backup.
+1. Choose authentication:
 
-1. If **Use GCP IAM** is disabled, enter the credentials for your account in JSON format in the **GCS Credentials** field.
+    - To use IAM (including GKE Workload Identity), select **Use GCP IAM**.
+    - Otherwise, leave **Use GCP IAM** disabled and enter the credentials for your account in JSON format in the **GCS Credentials** field.
 
 1. Click **Save**.
+
+### Kubernetes backups (GKE)
+
+On GKE, use [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) so database pods can access GCS. For KSA annotations, IAM bindings, and verification, refer to the GCP **Kubernetes** tab in [Permissions to back up and restore](../../prepare/cloud-permissions/cloud-permissions-storage/) and [GKE service account-based IAM](../../prepare/cloud-permissions/cloud-permissions-nodes-gcp/#gke-service-account-based-iam-gcp-iam).
+
+To configure GCS backups with Workload Identity:
+
+1. Create a Google IAM service account with the [required permissions](#required-gcp-service-account-permissions), and a Kubernetes service account (KSA) annotated for Workload Identity in each namespace where pods run.
+
+1. Attach the KSA to database pods using provider or universe Helm overrides:
+
+    ```yaml
+    tserver:
+      serviceAccount: <KSA_NAME>
+    nodeSelector:
+      iam.gke.io/gke-metadata-server-enabled: "true"
+    ```
+
+    For details, see [GKE service account](../../create-deployments/create-universe-multi-zone-kubernetes/#gke-service-account). To upgrade an existing universe, see [Upgrade universes for GKE service account-based IAM](../../manage-deployments/edit-helm-overrides/#upgrade-universes-for-gke-service-account-based-iam).
+
+1. If the YBA pod must also use Workload Identity (recommended so YBA can validate the bucket), set the YBA Helm service account as described in [Enable GKE service account-based IAM](../../install-yugabyte-platform/install-software/kubernetes/#enable-gke-service-account-based-iam), and persist it with `helm upgrade` — see [Make backup settings persistent on Kubernetes](#make-backup-settings-persistent-on-kubernetes).
+
+1. Create a GCS storage configuration with **Use GCP IAM** enabled, as described in [Create a GCS backup configuration](#create-a-gcs-backup-configuration).
+
+1. Verify the workload identity from a tserver pod, then run a test backup.
 
 ## Azure Storage
 

--- a/docs/content/stable/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
+++ b/docs/content/stable/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
@@ -37,8 +37,28 @@ You can configure AWS S3 and S3-compatible storage as your backup target.
     If you are using custom self-signed or CA certificates, to connect to your S3 storage, you must add the certificates to the YugabyteDB Anywhere Trust Store. Refer to [Add certificates to your trust store](../../security/enable-encryption-in-transit/trust-store/).
 
     {{< note title="Certificate validation can't be disabled" >}}
-If you set the **Server certificate verification for S3 backup/restore** (`yb.certVerifyBackupRestore.is_enforced`) Global Runtime Configuration option to False, the setting will be ignored.
+If you set the **Server certificate verification for S3 backup/restore** Global Runtime Configuration option (config key `yb.certVerifyBackupRestore.is_enforced`) to False, the setting will be ignored.
     {{< /note >}}
+
+### Choose an S3 authentication method
+
+When you create an S3 backup configuration, choose how YugabyteDB Anywhere and the universe authenticate to the bucket. Enable **IAM Role** for either IAM path, or leave it disabled and provide static credentials.
+
+**Recommended default:** For production universes on AWS (including EKS with IRSA), use universe node IAM roles. Use static **Access Key** and **Access Secret** credentials for evaluation setups, or when neither the YBA host nor the universe nodes can assume IAM roles. Treat YBA instance IAM as legacy, and keep it only for existing configurations that already depend on it.
+
+| Option | When to use | Prerequisites | Trade-offs |
+| :--- | :--- | :--- | :--- |
+| Universe node IAM role {{<tags/feature/ea>}} | Production backups on AWS VMs or Kubernetes (EKS IRSA). Recommended for new deployments. | Attach IAM roles (or annotated Kubernetes service accounts) with the [required S3 IAM permissions](#required-s3-iam-permissions) to each universe node or database pod.<br>Set the **Use S3 IAM roles attached to DB node for Backup/Restore** [Universe Configuration option](../../administer-yugabyte-platform/manage-runtime-config/) to true. Enable **IAM Role** on the storage configuration. For EKS setup, see [EKS service account](../../create-deployments/create-universe-multi-zone-kubernetes/#eks-service-account). | YB Controller on each node authenticates to S3 directly, so backups scale with cluster size. Requires a universe-level runtime configuration change. Preferred path going forward. |
+| YBA instance IAM role (Legacy) {{<tags/feature/ga>}} | Existing setups that already use the IAM role attached to the YugabyteDB Anywhere VM or pod. | Attach an IAM role with the [required S3 IAM permissions](#required-s3-iam-permissions) to the YugabyteDB Anywhere host. Enable **IAM Role**. <br>Leave **Use S3 IAM roles attached to DB node for Backup/Restore** at the default (`false`). | YBA fetches temporary credentials from its own instance role and passes them to database nodes. This path does not scale well for large backups and is not recommended for new deployments. |
+| Access Key and Access Secret {{<tags/feature/ga>}} | Evaluation and proof-of-concept setups; environments where neither YBA nor universe nodes have IAM roles (including many S3-compatible targets). | An IAM user (or equivalent) with the [required S3 IAM permissions](#required-s3-iam-permissions). Leave **IAM Role** disabled and enter **Access Key** and **Access Secret**. | Simplest path to a first successful backup. Credentials are stored in YBA and must be rotated manually. Prefer IAM for production when available. |
+
+#### Examples
+
+- **First backup / evaluation.** Leave **IAM Role** disabled. Enter an AWS access key and secret for a user that can read and write the backup bucket.
+- **New production AWS or EKS universe.** Attach instance profiles (or IRSA service accounts) to the database nodes, set **Use S3 IAM roles attached to DB node for Backup/Restore** (`yb.backup.s3.use_db_nodes_iam_role_for_backup`) to true for the universe, then enable **IAM Role** on the storage configuration.
+- **Existing YBA-role configuration.** Keep **IAM Role** enabled and leave `yb.backup.s3.use_db_nodes_iam_role_for_backup` at `false` until you can migrate nodes to their own IAM roles.
+
+For cloud permission setup details, refer to [Permissions to back up and restore](../../prepare/cloud-permissions/cloud-permissions-storage/).
 
 ### Create an AWS backup configuration
 
@@ -52,19 +72,21 @@ To configure S3 storage, do the following:
 
 1. Use the **Configuration Name** field to provide a meaningful name for your storage configuration.
 
-1. Enable **IAM Role** to use the YugabyteDB Anywhere instance's Identity Access Management (IAM) role or universe node IAM role for the S3 backup. See [Required S3 IAM permissions](#required-s3-iam-permissions).
+1. Choose authentication using the guidance in [Choose an S3 authentication method](#choose-an-s3-authentication-method):
 
-    To enable universe node IAM roles to access storage in S3, set the **Use S3 IAM roles attached to DB node for Backup/Restore** Universe Configuration option (config key `yb.backup.s3.use_db_nodes_iam_role_for_backup`) to true. Refer to [Manage runtime configuration settings](../../administer-yugabyte-platform/manage-runtime-config/).
+    - To use IAM (universe node IAM role or legacy YBA instance IAM role), enable **IAM Role**.
 
-1. If **IAM Role** is disabled, enter values for the **Access Key** and **Access Secret** fields.
+        For universe node IAM roles, also set the **Use S3 IAM roles attached to DB node for Backup/Restore** Universe Configuration option (config key `yb.backup.s3.use_db_nodes_iam_role_for_backup`) to true. Refer to [Manage runtime configuration settings](../../administer-yugabyte-platform/manage-runtime-config/).
 
-    For information on AWS access keys, see [Manage access keys for IAM users](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html).
+    - To use static credentials, leave **IAM Role** disabled and enter values for the **Access Key** and **Access Secret** fields.
+
+        For information on AWS access keys, see [Manage access keys for IAM users](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html).
 
 1. In the **S3 Bucket** field, enter the bucket name in the format `s3://bucket_name`, or `https://storage_vendor/s3-bucket-name` for S3-compatible storage.
 
 1. In the **S3 Bucket Host Base** field, enter the HTTP host header (endpoint URL) of the AWS S3 or S3-compatible storage, in the form `s3.amazonaws.com` or `my.storage.com`.
 
-1. If you are using S3-compatible storage, set the **S3 Path Style Access** option to true. (The option is only available if the **enablePathStyleAccess** feature is enabled.)
+1. If you are using S3-compatible storage, set the **S3 Path Style Access** option to true. (The option is only available after you enable the **Enable Path Access Style for Amazon S3** Global Runtime Configuration option, config key `yb.ui.feature_flags.enable_path_style_access`.)
 
 1. Click **Save**.
 

--- a/docs/content/stable/yugabyte-platform/create-deployments/create-universe-multi-zone-kubernetes.md
+++ b/docs/content/stable/yugabyte-platform/create-deployments/create-universe-multi-zone-kubernetes.md
@@ -170,6 +170,8 @@ nodeSelector:
   iam.gke.io/gke-metadata-server-enabled: "true"
 ```
 
+For end-to-end GCS backup setup on GKE (Workload Identity, storage configuration, and persistence), see [Kubernetes backups (GKE)](../../back-up-restore-universes/configure-backup-storage/#kubernetes-backups-gke) and the GCP **Kubernetes** tab in [Permissions to back up and restore](../../prepare/cloud-permissions/cloud-permissions-storage/).
+
 If you don't provide namespace names for each zone/region during [provider creation](../../configure-yugabyte-platform/kubernetes/), add the names using the following steps:
 
 1. Add the Kubernetes service account to the namespaces where the pods are created.
@@ -180,6 +182,10 @@ To enable the GKE service account service at the provider level, refer to [Overr
 #### EKS service account
 
 In AWS, you can attach a service account to database pods; the account can then be used to access storage. The service account used for the database pods should have annotations for the IAM role. The service account to be used can be applied to the DB pods as helm override with provider/universe level overrides. The IAM role used should be sufficient to access S3 storage.
+
+{{< note title="Node IAM is not pod IAM" >}}
+IAM roles on EKS worker nodes do not grant S3 access to pods. Use IRSA on the database pod service account. See [Kubernetes backups (EKS)](../../back-up-restore-universes/configure-backup-storage/#kubernetes-backups-eks) and the AWS **Kubernetes** tab in [Permissions to back up and restore](../../prepare/cloud-permissions/cloud-permissions-storage/).
+{{< /note >}}
 
 To enable IAM roles for S3, set the **Use S3 IAM roles attached to DB node for Backup/Restore** Universe Configuration option (config key `yb.backup.s3.use_db_nodes_iam_role_for_backup`) to true. Refer to [Manage runtime configuration settings](../../administer-yugabyte-platform/manage-runtime-config/).
 
@@ -193,6 +199,8 @@ tserver:
 ```
 
 To enable the EKS service account service at the provider level, refer to [Overrides](../../configure-yugabyte-platform/kubernetes/#overrides).
+
+Save these overrides in YBA (or Operator `kubernetesOverrides`) so they persist across upgrades — see [Make backup settings persistent on Kubernetes](../../back-up-restore-universes/configure-backup-storage/#make-backup-settings-persistent-on-kubernetes).
 
 #### Readiness probes
 

--- a/docs/content/stable/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-gcp.md
+++ b/docs/content/stable/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-gcp.md
@@ -99,9 +99,11 @@ By using Workload Identity, you avoid the need for manually managing service acc
 
 - To enable GCP IAM when installing YugabyteDB Anywhere on Kubernetes, refer to [Enable GKE service account-based IAM](../../../install-yugabyte-platform/install-software/kubernetes/#enable-gke-service-account-based-iam).
 
+- To prepare GCS permissions and Workload Identity for backups, refer to the GCP **Kubernetes** tab in [Permissions to back up and restore](../cloud-permissions-storage/).
+
 - To enable GCP IAM during universe creation on Kubernetes, refer to [Configure Helm overrides](../../../create-deployments/create-universe-multi-zone-kubernetes/#helm-overrides).
 
-- To enable GCP IAM for Google Cloud Storage backup configuration with Kubernetes, refer to [Configure backup storage](../../../back-up-restore-universes/configure-backup-storage/#google-cloud-storage).
+- To enable GCP IAM for Google Cloud Storage backup configuration with Kubernetes, refer to [Kubernetes backups (GKE)](../../../back-up-restore-universes/configure-backup-storage/#kubernetes-backups-gke).
 
 - To upgrade an existing universe with GCP IAM, refer to [Upgrade universes for GKE service account-based IAM support](../../../manage-deployments/edit-helm-overrides/#upgrade-universes-for-gke-service-account-based-iam).
 

--- a/docs/content/stable/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-k8s.md
+++ b/docs/content/stable/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-k8s.md
@@ -52,6 +52,8 @@ For YugabyteDB Anywhere (YBA) to be able to deploy and manage YugabyteDB cluster
 
 As a prerequisite for creating pods and deploying database clusters, YBA requires a service account in the Kubernetes cluster and a corresponding kubeconfig file.
 
+For S3 or GCS backup IAM on Kubernetes (which pods need roles, IRSA / Workload Identity, and how to make settings persistent), see [Permissions to back up and restore](../cloud-permissions-storage/) (AWS or GCP **Kubernetes** tab) and [Configure backup storage](../../../back-up-restore-universes/configure-backup-storage/#make-backup-settings-persistent-on-kubernetes).
+
 Do one of the following:
 
 - Create a [`yugabyte-platform-universe-management` service account](#create-a-service-account) and a [`kubeconfig` file](#create-a-kubeconfig-file) directly.

--- a/docs/content/stable/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-storage.md
+++ b/docs/content/stable/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-storage.md
@@ -61,12 +61,7 @@ When backing up to and/or restoring from NFS storage, the NFS storage system mus
 
   <div id="aws" class="tab-pane fade" role="tabpanel" aria-labelledby="aws-tab">
 
-When backing up to and/or restoring from AWS S3 or S3-compatible storage, YBA and DB nodes must be able to write to and read from the S3 storage bucket.
-
-To grant the required access, you can do one of the following:
-
-- Provide a service account with the following permissions.
-- Create the EC2 VM instances (for both the YBA VM and the DB nodes VMs) with an IAM role with the required permissions.
+When backing up to and/or restoring from AWS S3 or S3-compatible storage, YBA and database nodes (or pods) must be able to write to and read from the S3 storage bucket.
 
 The following permissions are required:
 
@@ -79,22 +74,111 @@ The following permissions are required:
 "s3:GetBucketLocation"
 ```
 
-The Access key ID and Secret Access Key for the service account are used when creating a backup [storage configuration](../../../back-up-restore-universes/configure-backup-storage/#amazon-s3) for S3.
+<ul class="nav nav-tabs-alt nav-tabs-yb custom-tabs">
+  <li>
+    <a href="#aws-vm" class="nav-link active" id="aws-vm-tab" data-bs-toggle="tab"
+      role="tab" aria-controls="aws-vm" aria-selected="true">
+      <i class="fa-solid fa-server"></i>
+      VM
+    </a>
+  </li>
+  <li>
+    <a href="#aws-k8s" class="nav-link" id="aws-k8s-tab" data-bs-toggle="tab"
+      role="tab" aria-controls="aws-k8s" aria-selected="false">
+      <i class="fa-regular fa-dharmachakra"></i>
+      Kubernetes
+    </a>
+  </li>
+</ul>
+
+<div class="tab-content">
+  <div id="aws-vm" class="tab-pane fade show active" role="tabpanel" aria-labelledby="aws-vm-tab">
+
+To grant the required access on VMs, do one of the following:
+
+- Provide an IAM user with the permissions listed above, and use its Access key ID and Secret Access Key when creating the backup storage configuration.
+- Create the EC2 VM instances (for both the YBA VM and the DB node VMs) with an IAM role that has the required permissions.
 
 | Save for later | To configure |
 | :--- | :--- |
-| Service account Access key ID and Secret Access Key | [Storage configuration](../../../back-up-restore-universes/configure-backup-storage/#amazon-s3) for S3 |
+| Service account Access key ID and Secret Access Key, or IAM roles on the VMs | [Storage configuration](../../../back-up-restore-universes/configure-backup-storage/#amazon-s3) for S3 |
+
+  </div>
+
+  <div id="aws-k8s" class="tab-pane fade" role="tabpanel" aria-labelledby="aws-k8s-tab">
+
+On Amazon EKS, IAM roles attached to worker **nodes** do not grant S3 access to **pods**. Use [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) so that a Kubernetes service account (KSA) can assume an IAM role.
+
+**Recommended:** Attach the IAM role to a KSA used by the **database (YBDB) pods** — the universe node IAM path. See [Choose an S3 authentication method](../../../back-up-restore-universes/configure-backup-storage/#choose-an-s3-authentication-method).
+
+| Auth option | Which service account needs the IAM role |
+| :--- | :--- |
+| Universe node IAM (recommended) | KSA on **YBDB** (tserver) pods. YBA pod IAM is not required for backup I/O. |
+| YBA instance IAM (legacy) | KSA on the **YBA** pod (or operator pod). |
+| Access Key and Access Secret | Neither. Provide static credentials in the storage configuration. |
+
+##### Create an IRSA-enabled service account
+
+1. Create an IAM role with the [S3 permissions](#aws) listed above, and a trust policy that allows your EKS OIDC provider to assume the role for the KSA. For example:
+
+    ```json
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "Federated": "arn:aws:iam::<ACCOUNT_ID>:oidc-provider/<OIDC_PROVIDER>"
+          },
+          "Action": "sts:AssumeRoleWithWebIdentity",
+          "Condition": {
+            "StringEquals": {
+              "<OIDC_PROVIDER>:sub": "system:serviceaccount:<NAMESPACE>:<KSA_NAME>",
+              "<OIDC_PROVIDER>:aud": "sts.amazonaws.com"
+            }
+          }
+        }
+      ]
+    }
+    ```
+
+1. Create the KSA in each namespace where database pods run, and annotate it with the role ARN:
+
+    ```yaml
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: <KSA_NAME>
+      namespace: <NAMESPACE>
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE_NAME>
+    ```
+
+1. Apply the KSA to database pods using provider or universe [Helm overrides](../../../create-deployments/create-universe-multi-zone-kubernetes/#eks-service-account) (or Operator `kubernetesOverrides`). Do not rely on one-off `kubectl edit` changes — those are lost on upgrade. See [Make backup settings persistent on Kubernetes](../../../back-up-restore-universes/configure-backup-storage/#make-backup-settings-persistent-on-kubernetes).
+
+##### Verify from a database pod
+
+After the universe is running with the annotated KSA:
+
+```sh
+kubectl exec -n <NAMESPACE> -it <TSERVER_POD> -- \
+  aws sts get-caller-identity
+```
+
+Confirm that the returned ARN matches the IRSA role you created.
+
+| Save for later | To configure |
+| :--- | :--- |
+| Annotated KSA name and IAM role | [Kubernetes backups (EKS)](../../../back-up-restore-universes/configure-backup-storage/#kubernetes-backups-eks) and [EKS service account](../../../create-deployments/create-universe-multi-zone-kubernetes/#eks-service-account) overrides |
+
+  </div>
+</div>
 
   </div>
 
   <div id="gcp" class="tab-pane fade" role="tabpanel" aria-labelledby="gcp-tab">
 
-When backing up to and/or restoring from GCP GCS, YBA and database nodes must be able to write to and read from the GCS storage bucket.
-
-To grant the required access, you can do one of the following:
-
-- Provide a GCP service account with [IAM roles for cloud storage](https://cloud.google.com/storage/docs/access-control/iam-roles) with the required permissions.
-- Create the VM instances (for both the YBA VM and the DB nodes VMs) with an IAM role that has the required permissions.
+When backing up to and/or restoring from GCP GCS, YBA and database nodes (or pods) must be able to write to and read from the GCS storage bucket.
 
 The following permissions are required:
 
@@ -102,11 +186,89 @@ The following permissions are required:
 roles/storage.admin
 ```
 
-The credentials for this account (in JSON format) are used when creating a backup [storage configuration](../../../back-up-restore-universes/configure-backup-storage/#google-cloud-storage) for GCS.
+<ul class="nav nav-tabs-alt nav-tabs-yb custom-tabs">
+  <li>
+    <a href="#gcp-vm" class="nav-link active" id="gcp-vm-tab" data-bs-toggle="tab"
+      role="tab" aria-controls="gcp-vm" aria-selected="true">
+      <i class="fa-solid fa-server"></i>
+      VM
+    </a>
+  </li>
+  <li>
+    <a href="#gcp-k8s" class="nav-link" id="gcp-k8s-tab" data-bs-toggle="tab"
+      role="tab" aria-controls="gcp-k8s" aria-selected="false">
+      <i class="fa-regular fa-dharmachakra"></i>
+      Kubernetes
+    </a>
+  </li>
+</ul>
+
+<div class="tab-content">
+  <div id="gcp-vm" class="tab-pane fade show active" role="tabpanel" aria-labelledby="gcp-vm-tab">
+
+To grant the required access on VMs, do one of the following:
+
+- Provide a GCP service account with [IAM roles for cloud storage](https://cloud.google.com/storage/docs/access-control/iam-roles) with the permissions listed above, and use its JSON credentials when creating the backup storage configuration.
+- Create the VM instances (for both the YBA VM and the DB node VMs) with an IAM role that has the required permissions.
 
 | Save for later | To configure |
 | :--- | :--- |
-| Service account JSON credentials | [Storage configuration](../../../back-up-restore-universes/configure-backup-storage/#google-cloud-storage) for GCS |
+| Service account JSON credentials, or IAM roles on the VMs | [Storage configuration](../../../back-up-restore-universes/configure-backup-storage/#google-cloud-storage) for GCS |
+
+  </div>
+
+  <div id="gcp-k8s" class="tab-pane fade" role="tabpanel" aria-labelledby="gcp-k8s-tab">
+
+On Google Kubernetes Engine (GKE), use [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) so that a Kubernetes service account (KSA) can act as a Google IAM service account. Node-level service accounts do not replace Workload Identity for pods.
+
+**Recommended:** Annotate a KSA used by the **database (YBDB) pods**, and enable **Use GCP IAM** on the storage configuration. For background, see [GKE service account-based IAM](../cloud-permissions-nodes-gcp/#gke-service-account-based-iam-gcp-iam).
+
+| Auth option | Which service account needs the IAM binding |
+| :--- | :--- |
+| Use GCP IAM with YBDB pods (recommended) | KSA on **YBDB** (tserver) pods, bound to a Google IAM service account with `roles/storage.admin` (or equivalent). |
+| Use GCP IAM on the YBA pod | KSA on the **YBA** pod (set via Helm at install/upgrade). Often used together with YBDB pod IAM so YBA can validate the bucket. |
+| GCS JSON credentials | Neither. Provide JSON credentials in the storage configuration. |
+
+##### Prerequisites
+
+- Workload Identity enabled on the GKE cluster; worker nodes have the GKE metadata server enabled.
+- A Google IAM service account with permission to read, write, list, and delete objects in GCS (`roles/storage.admin` or equivalent).
+- The annotated KSA present in every namespace where YBA and/or YBDB pods run.
+
+##### Annotate the Kubernetes service account
+
+Bind the KSA to the Google IAM service account:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: <KSA_NAME>
+  namespace: <NAMESPACE>
+  annotations:
+    iam.gke.io/gcp-service-account: <GSA_NAME>@<PROJECT_ID>.iam.gserviceaccount.com
+```
+
+Also grant the Google IAM service account permission for the KSA to impersonate it (see [Use Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) in the GKE documentation).
+
+Apply the KSA to database pods using provider or universe [Helm overrides](../../../create-deployments/create-universe-multi-zone-kubernetes/#gke-service-account), including the metadata-server nodeSelector. Persist YBA-pod IAM via Helm `values.yaml` — see [Enable GKE service account-based IAM](../../../install-yugabyte-platform/install-software/kubernetes/#enable-gke-service-account-based-iam) and [Make backup settings persistent on Kubernetes](../../../back-up-restore-universes/configure-backup-storage/#make-backup-settings-persistent-on-kubernetes).
+
+##### Verify from a database pod
+
+```sh
+kubectl exec -n <NAMESPACE> -it <TSERVER_POD> -- \
+  curl -s -H "Metadata-Flavor: Google" \
+  http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email
+```
+
+Confirm that the email matches the Google IAM service account bound to the KSA.
+
+| Save for later | To configure |
+| :--- | :--- |
+| Annotated KSA name and Google IAM service account | [Kubernetes backups (GKE)](../../../back-up-restore-universes/configure-backup-storage/#kubernetes-backups-gke) and [GKE service account](../../../create-deployments/create-universe-multi-zone-kubernetes/#gke-service-account) overrides |
+
+  </div>
+</div>
 
   </div>
 

--- a/docs/content/v2025.1/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
+++ b/docs/content/v2025.1/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
@@ -32,6 +32,26 @@ You can configure AWS S3 and S3-compatible storage as your backup target.
 
 - To validate connections to your S3 storage using custom self-signed or CA certificates, add the certificates to the YugabyteDB Anywhere Trust Store. Refer to [Add certificates to your trust store](../../security/enable-encryption-in-transit/trust-store/).
 
+### Choose an S3 authentication method
+
+When you create an S3 backup configuration, choose how YugabyteDB Anywhere and the universe authenticate to the bucket. Enable **IAM Role** for either IAM path, or leave it disabled and provide static credentials.
+
+**Recommended default:** For production universes on AWS (including EKS with IRSA), use universe node IAM roles. Use static **Access Key** and **Access Secret** credentials for evaluation setups, or when neither the YBA host nor the universe nodes can assume IAM roles. Treat YBA instance IAM as legacy, and keep it only for existing configurations that already depend on it.
+
+| Option | When to use | Prerequisites | Trade-offs |
+| :--- | :--- | :--- | :--- |
+| Universe node IAM role {{<tags/feature/ea>}} | Production backups on AWS VMs or Kubernetes (EKS IRSA). Recommended for new deployments. | Attach IAM roles (or annotated Kubernetes service accounts) with the [required S3 IAM permissions](#required-s3-iam-permissions) to each universe node or database pod.<br>Set the **Use S3 IAM roles attached to DB node for Backup/Restore** [Universe Configuration option](../../administer-yugabyte-platform/manage-runtime-config/) to true. Enable **IAM Role** on the storage configuration. For EKS setup, see [EKS service account](../../create-deployments/create-universe-multi-zone-kubernetes/#eks-service-account). | YB Controller on each node authenticates to S3 directly, so backups scale with cluster size. Requires a universe-level runtime configuration change. Preferred path going forward. |
+| YBA instance IAM role (Legacy) {{<tags/feature/ga>}} | Existing setups that already use the IAM role attached to the YugabyteDB Anywhere VM or pod. | Attach an IAM role with the [required S3 IAM permissions](#required-s3-iam-permissions) to the YugabyteDB Anywhere host. Enable **IAM Role**. <br>Leave **Use S3 IAM roles attached to DB node for Backup/Restore** at the default (`false`). | YBA fetches temporary credentials from its own instance role and passes them to database nodes. This path does not scale well for large backups and is not recommended for new deployments. |
+| Access Key and Access Secret {{<tags/feature/ga>}} | Evaluation and proof-of-concept setups; environments where neither YBA nor universe nodes have IAM roles (including many S3-compatible targets). | An IAM user (or equivalent) with the [required S3 IAM permissions](#required-s3-iam-permissions). Leave **IAM Role** disabled and enter **Access Key** and **Access Secret**. | Simplest path to a first successful backup. Credentials are stored in YBA and must be rotated manually. Prefer IAM for production when available. |
+
+#### Examples
+
+- **First backup / evaluation.** Leave **IAM Role** disabled. Enter an AWS access key and secret for a user that can read and write the backup bucket.
+- **New production AWS or EKS universe.** Attach instance profiles (or IRSA service accounts) to the database nodes, set **Use S3 IAM roles attached to DB node for Backup/Restore** (`yb.backup.s3.use_db_nodes_iam_role_for_backup`) to true for the universe, then enable **IAM Role** on the storage configuration.
+- **Existing YBA-role configuration.** Keep **IAM Role** enabled and leave `yb.backup.s3.use_db_nodes_iam_role_for_backup` at `false` until you can migrate nodes to their own IAM roles.
+
+For cloud permission setup details, refer to [Permissions to back up and restore](../../prepare/cloud-permissions/cloud-permissions-storage/).
+
 ### Create an AWS backup configuration
 
 To configure S3 storage, do the following:
@@ -44,19 +64,21 @@ To configure S3 storage, do the following:
 
 1. Use the **Configuration Name** field to provide a meaningful name for your storage configuration.
 
-1. Enable **IAM Role** to use the YugabyteDB Anywhere instance's Identity Access Management (IAM) role or universe node IAM role for the S3 backup. See [Required S3 IAM permissions](#required-s3-iam-permissions).
+1. Choose authentication using the guidance in [Choose an S3 authentication method](#choose-an-s3-authentication-method):
 
-    To enable universe node IAM roles to access storage in S3, set the **Use S3 IAM roles attached to DB node for Backup/Restore** Universe Configuration option (config key `yb.backup.s3.use_db_nodes_iam_role_for_backup`) to true. Refer to [Manage runtime configuration settings](../../administer-yugabyte-platform/manage-runtime-config/).
+    - To use IAM (universe node IAM role or legacy YBA instance IAM role), enable **IAM Role**.
 
-1. If **IAM Role** is disabled, enter values for the **Access Key** and **Access Secret** fields.
+        For universe node IAM roles, also set the **Use S3 IAM roles attached to DB node for Backup/Restore** Universe Configuration option (config key `yb.backup.s3.use_db_nodes_iam_role_for_backup`) to true. Refer to [Manage runtime configuration settings](../../administer-yugabyte-platform/manage-runtime-config/).
 
-    For information on AWS access keys, see [Manage access keys for IAM users](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html).
+    - To use static credentials, leave **IAM Role** disabled and enter values for the **Access Key** and **Access Secret** fields.
+
+        For information on AWS access keys, see [Manage access keys for IAM users](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html).
 
 1. In the **S3 Bucket** field, enter the bucket name in the format `s3://bucket_name`, or `https://storage_vendor/s3-bucket-name` for S3-compatible storage.
 
 1. In the **S3 Bucket Host Base** field, enter the HTTP host header (endpoint URL) of the AWS S3 or S3-compatible storage, in the form `s3.amazonaws.com` or `my.storage.com`.
 
-1. If you are using S3-compatible storage, set the **S3 Path Style Access** option to true. (The option is only available if the **enablePathStyleAccess** feature is enabled.)
+1. If you are using S3-compatible storage, set the **S3 Path Style Access** option to true. (The option is only available after you enable the **Enable Path Access Style for Amazon S3** Global Runtime Configuration option, config key `yb.ui.feature_flags.enable_path_style_access`.)
 
 1. Click **Save**.
 

--- a/docs/content/v2025.1/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
+++ b/docs/content/v2025.1/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
@@ -40,7 +40,7 @@ When you create an S3 backup configuration, choose how YugabyteDB Anywhere and t
 
 | Option | When to use | Prerequisites | Trade-offs |
 | :--- | :--- | :--- | :--- |
-| Universe node IAM role {{<tags/feature/ea>}} | Production backups on AWS VMs or Kubernetes (EKS IRSA). Recommended for new deployments. | Attach IAM roles (or annotated Kubernetes service accounts) with the [required S3 IAM permissions](#required-s3-iam-permissions) to each universe node or database pod.<br>Set the **Use S3 IAM roles attached to DB node for Backup/Restore** [Universe Configuration option](../../administer-yugabyte-platform/manage-runtime-config/) to true. Enable **IAM Role** on the storage configuration. For EKS setup, see [EKS service account](../../create-deployments/create-universe-multi-zone-kubernetes/#eks-service-account). | YB Controller on each node authenticates to S3 directly, so backups scale with cluster size. Requires a universe-level runtime configuration change. Preferred path going forward. |
+| Universe node IAM role {{<tags/feature/ea>}} | Production backups on AWS VMs or Kubernetes (EKS IRSA). Recommended for new deployments. | Attach IAM roles (or annotated Kubernetes service accounts) with the [required S3 IAM permissions](#required-s3-iam-permissions) to each universe node or database pod.<br>Set the **Use S3 IAM roles attached to DB node for Backup/Restore** [Universe Configuration option](../../administer-yugabyte-platform/manage-runtime-config/) to true. Enable **IAM Role** on the storage configuration. For EKS, see [Kubernetes backups (EKS)](#kubernetes-backups-eks). | YB Controller on each node authenticates to S3 directly, so backups scale with cluster size. Requires a universe-level runtime configuration change. Preferred path going forward. |
 | YBA instance IAM role (Legacy) {{<tags/feature/ga>}} | Existing setups that already use the IAM role attached to the YugabyteDB Anywhere VM or pod. | Attach an IAM role with the [required S3 IAM permissions](#required-s3-iam-permissions) to the YugabyteDB Anywhere host. Enable **IAM Role**. <br>Leave **Use S3 IAM roles attached to DB node for Backup/Restore** at the default (`false`). | YBA fetches temporary credentials from its own instance role and passes them to database nodes. This path does not scale well for large backups and is not recommended for new deployments. |
 | Access Key and Access Secret {{<tags/feature/ga>}} | Evaluation and proof-of-concept setups; environments where neither YBA nor universe nodes have IAM roles (including many S3-compatible targets). | An IAM user (or equivalent) with the [required S3 IAM permissions](#required-s3-iam-permissions). Leave **IAM Role** disabled and enter **Access Key** and **Access Secret**. | Simplest path to a first successful backup. Credentials are stored in YBA and must be rotated manually. Prefer IAM for production when available. |
 
@@ -50,7 +50,7 @@ When you create an S3 backup configuration, choose how YugabyteDB Anywhere and t
 - **New production AWS or EKS universe.** Attach instance profiles (or IRSA service accounts) to the database nodes, set **Use S3 IAM roles attached to DB node for Backup/Restore** (`yb.backup.s3.use_db_nodes_iam_role_for_backup`) to true for the universe, then enable **IAM Role** on the storage configuration.
 - **Existing YBA-role configuration.** Keep **IAM Role** enabled and leave `yb.backup.s3.use_db_nodes_iam_role_for_backup` at `false` until you can migrate nodes to their own IAM roles.
 
-For cloud permission setup details, refer to [Permissions to back up and restore](../../prepare/cloud-permissions/cloud-permissions-storage/).
+For cloud permission setup details, refer to [Permissions to back up and restore](../../prepare/cloud-permissions/cloud-permissions-storage/). On EKS, open the AWS **Kubernetes** tab on that page for IRSA setup.
 
 ### Create an AWS backup configuration
 
@@ -103,6 +103,80 @@ The following S3 IAM permissions are required:
 "s3:GetBucketLocation"
 ```
 
+### Kubernetes backups (EKS)
+
+{{<tags/feature/ea>}}On Amazon EKS, use IRSA so database pods can assume an IAM role for S3. Node instance profiles alone do **not** grant S3 access to pods.
+
+For IAM role trust policy, KSA annotations, and verification steps, refer to the AWS **Kubernetes** tab in [Permissions to back up and restore](../../prepare/cloud-permissions/cloud-permissions-storage/).
+
+To configure S3 backups with universe node IAM on EKS:
+
+1. Create an IRSA-enabled Kubernetes service account (KSA) with the [required S3 IAM permissions](#required-s3-iam-permissions), in each namespace where database pods run.
+
+1. Attach the KSA to database pods using provider or universe Helm overrides. For example:
+
+    ```yaml
+    tserver:
+      serviceAccount: <KSA_NAME>
+    ```
+
+    For details, see [EKS service account](../../create-deployments/create-universe-multi-zone-kubernetes/#eks-service-account). If you use the [YugabyteDB Kubernetes Operator](../../anywhere-automation/yb-kubernetes-operator/), set the same override under `spec.kubernetesOverrides`.
+
+1. Set the **Use S3 IAM roles attached to DB node for Backup/Restore** Universe Configuration option (config key `yb.backup.s3.use_db_nodes_iam_role_for_backup`) to true. Refer to [Manage runtime configuration settings](../../administer-yugabyte-platform/manage-runtime-config/).
+
+1. Create an S3 storage configuration with **IAM Role** enabled, as described in [Create an AWS backup configuration](#create-an-aws-backup-configuration).
+
+1. Verify credentials from a tserver pod (see the prepare page), then run a test backup.
+
+For which settings survive pod restarts and upgrades, see [Make backup settings persistent on Kubernetes](#make-backup-settings-persistent-on-kubernetes).
+
+### Make backup settings persistent on Kubernetes
+
+Settings you apply with `kubectl edit`, one-off interactive install prompts, or temporary pod changes are **not** durable. Use the following so backup IAM configuration survives restarts and upgrades:
+
+| Setting | Persistent if you… | Not persistent if you… |
+| :--- | :--- | :--- |
+| Storage configuration (**IAM Role**, Access Key / Secret, GCS credentials) | Create or update it in the YBA UI or API (stored in the YBA database). | — |
+| **Use S3 IAM roles attached to DB node for Backup/Restore** (`yb.backup.s3.use_db_nodes_iam_role_for_backup`) | Set it via YBA [runtime configuration](../../administer-yugabyte-platform/manage-runtime-config/) (UI or API). | — |
+| Database pod `serviceAccount` (and GKE `nodeSelector`) | Set provider or universe **Helm overrides** in YBA, or Operator `kubernetesOverrides`, then apply/upgrade the universe. | Edit the live Deployment or Pod with `kubectl`, or change the SA only in the cluster without updating overrides. |
+| YBA pod service account (legacy YBA IAM / GKE YBA Workload Identity) | Put `yugaware.serviceAccount` (and any required `nodeSelector`) in your Helm `values.yaml` and run `helm upgrade`. | Rely only on interactive install answers that were never written to `values.yaml`. |
+| IRSA / Workload Identity annotations on the KSA | Keep annotations in the KSA manifest you manage (GitOps, Helm chart for the SA, or `kubectl apply` of that manifest). | Recreate the KSA without annotations, or expect YBA to recreate IRSA bindings for you. |
+
+#### Universe pod overrides (recommended path)
+
+Set the database pod service account in YBA (provider- or universe-level overrides), for example:
+
+```yaml
+tserver:
+  serviceAccount: <KSA_NAME>
+```
+
+For GKE, also include:
+
+```yaml
+nodeSelector:
+  iam.gke.io/gke-metadata-server-enabled: "true"
+```
+
+Saving these overrides in YBA and applying them to the universe is what makes the pod identity persistent. See [Helm overrides](../../create-deployments/create-universe-multi-zone-kubernetes/#helm-overrides).
+
+#### YBA Helm values (YBA pod IAM)
+
+If the YBA pod itself must use a cloud IAM role (legacy S3 path, or GKE validation), set the service account in values and upgrade:
+
+```yaml
+yugaware:
+  serviceAccount: <KSA_NAME>
+nodeSelector:
+  iam.gke.io/gke-metadata-server-enabled: "true"   # GKE only
+```
+
+```sh
+helm upgrade <RELEASE_NAME> yugabytedb/yugaware -n <YBA_NAMESPACE> -f values.yaml
+```
+
+For GKE install-time guidance, see [Enable GKE service account-based IAM](../../install-yugabyte-platform/install-software/kubernetes/#enable-gke-service-account-based-iam).
+
 ### Using a proxy
 
 By default, **Proxy Configuration** for S3 storage is not available in the UI. To make it available, navigate to `https://<my-yugabytedb-anywhere-ip>/features` and enable the **enableS3BackupProxy** option.
@@ -125,12 +199,21 @@ To grant access to your bucket, create a GCP service account with [IAM roles for
 roles/storage.admin
 ```
 
-The credentials for this account (in JSON format) are used when creating the backup storage configuration. For information on how to obtain GCS credentials, see [Cloud Storage authentication](https://cloud.google.com/storage/docs/authentication).
+The credentials for this account (in JSON format) are used when creating the backup storage configuration with static credentials. For information on how to obtain GCS credentials, see [Cloud Storage authentication](https://cloud.google.com/storage/docs/authentication).
 
 You can configure access control for the GCS bucket as follows:
 
 - Provide the required access control list (ACL) and set it as either uniform or fine-grained (for object-level access).
 - Add permissions, such as roles and members.
+
+### Choose a GCS authentication method
+
+When you create a GCS backup configuration, choose how YugabyteDB Anywhere and the universe authenticate to the bucket:
+
+- **Use GCP IAM** — Use Workload Identity (GKE) or the IAM identity on the YBA / database host. On GKE, attach a Google IAM service account to the Kubernetes service account used by database pods (and typically the YBA pod). See [Kubernetes backups (GKE)](#kubernetes-backups-gke).
+- **GCS Credentials (JSON)** — Simplest path for evaluation setups, or when Workload Identity / host IAM is unavailable. Leave **Use GCP IAM** disabled and paste the service account JSON.
+
+For cloud permission setup, refer to the GCP tab in [Permissions to back up and restore](../../prepare/cloud-permissions/cloud-permissions-storage/) (use the **Kubernetes** sub-tab for GKE).
 
 ### Create a GCS backup configuration
 
@@ -146,11 +229,37 @@ To create a GCP backup configuration, do the following:
 
 1. Enter the URI of your GCS bucket in the **GCS Bucket** field. For example, `gs://gcp-bucket/test_backups`.
 
-1. Select **Use GCP IAM** to use the YugabyteDB Anywhere instance's Identity Access Management (IAM) role for the GCS backup.
+1. Choose authentication:
 
-1. If **Use GCP IAM** is disabled, enter the credentials for your account in JSON format in the **GCS Credentials** field.
+    - To use IAM (including GKE Workload Identity), select **Use GCP IAM**.
+    - Otherwise, leave **Use GCP IAM** disabled and enter the credentials for your account in JSON format in the **GCS Credentials** field.
 
 1. Click **Save**.
+
+### Kubernetes backups (GKE)
+
+On GKE, use [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) so database pods can access GCS. For KSA annotations, IAM bindings, and verification, refer to the GCP **Kubernetes** tab in [Permissions to back up and restore](../../prepare/cloud-permissions/cloud-permissions-storage/) and [GKE service account-based IAM](../../prepare/cloud-permissions/cloud-permissions-nodes-gcp/#gke-service-account-based-iam-gcp-iam).
+
+To configure GCS backups with Workload Identity:
+
+1. Create a Google IAM service account with the [required permissions](#required-gcp-service-account-permissions), and a Kubernetes service account (KSA) annotated for Workload Identity in each namespace where pods run.
+
+1. Attach the KSA to database pods using provider or universe Helm overrides:
+
+    ```yaml
+    tserver:
+      serviceAccount: <KSA_NAME>
+    nodeSelector:
+      iam.gke.io/gke-metadata-server-enabled: "true"
+    ```
+
+    For details, see [GKE service account](../../create-deployments/create-universe-multi-zone-kubernetes/#gke-service-account). To upgrade an existing universe, see [Upgrade universes for GKE service account-based IAM](../../manage-deployments/edit-helm-overrides/#upgrade-universes-for-gke-service-account-based-iam).
+
+1. If the YBA pod must also use Workload Identity (recommended so YBA can validate the bucket), set the YBA Helm service account as described in [Enable GKE service account-based IAM](../../install-yugabyte-platform/install-software/kubernetes/#enable-gke-service-account-based-iam), and persist it with `helm upgrade` — see [Make backup settings persistent on Kubernetes](#make-backup-settings-persistent-on-kubernetes).
+
+1. Create a GCS storage configuration with **Use GCP IAM** enabled, as described in [Create a GCS backup configuration](#create-a-gcs-backup-configuration).
+
+1. Verify the workload identity from a tserver pod, then run a test backup.
 
 ## Azure Storage
 

--- a/docs/content/v2025.1/yugabyte-platform/create-deployments/create-universe-multi-zone-kubernetes.md
+++ b/docs/content/v2025.1/yugabyte-platform/create-deployments/create-universe-multi-zone-kubernetes.md
@@ -168,6 +168,8 @@ nodeSelector:
   iam.gke.io/gke-metadata-server-enabled: "true"
 ```
 
+For end-to-end GCS backup setup on GKE (Workload Identity, storage configuration, and persistence), see [Kubernetes backups (GKE)](../../back-up-restore-universes/configure-backup-storage/#kubernetes-backups-gke) and the GCP **Kubernetes** tab in [Permissions to back up and restore](../../prepare/cloud-permissions/cloud-permissions-storage/).
+
 If you don't provide namespace names for each zone/region during [provider creation](../../configure-yugabyte-platform/kubernetes/), add the names using the following steps:
 
 1. Add the Kubernetes service account to the namespaces where the pods are created.
@@ -178,6 +180,10 @@ To enable the GKE service account service at the provider level, refer to [Overr
 #### EKS service account
 
 In AWS, you can attach a service account to database pods; the account can then be used to access storage. The service account used for the database pods should have annotations for the IAM role. The service account to be used can be applied to the DB pods as helm override with provider/universe level overrides. The IAM role used should be sufficient to access S3 storage.
+
+{{< note title="Node IAM is not pod IAM" >}}
+IAM roles on EKS worker nodes do not grant S3 access to pods. Use IRSA on the database pod service account. See [Kubernetes backups (EKS)](../../back-up-restore-universes/configure-backup-storage/#kubernetes-backups-eks) and the AWS **Kubernetes** tab in [Permissions to back up and restore](../../prepare/cloud-permissions/cloud-permissions-storage/).
+{{< /note >}}
 
 To enable IAM roles for S3, set the **Use S3 IAM roles attached to DB node for Backup/Restore** Universe Configuration option (config key `yb.backup.s3.use_db_nodes_iam_role_for_backup`) to true. Refer to [Manage runtime configuration settings](../../administer-yugabyte-platform/manage-runtime-config/).
 
@@ -191,6 +197,8 @@ tserver:
 ```
 
 To enable the EKS service account service at the provider level, refer to [Overrides](../../configure-yugabyte-platform/kubernetes/#overrides).
+
+Save these overrides in YBA (or Operator `kubernetesOverrides`) so they persist across upgrades — see [Make backup settings persistent on Kubernetes](../../back-up-restore-universes/configure-backup-storage/#make-backup-settings-persistent-on-kubernetes).
 
 #### Readiness probes
 

--- a/docs/content/v2025.1/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-gcp.md
+++ b/docs/content/v2025.1/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-gcp.md
@@ -99,9 +99,11 @@ By using Workload Identity, you avoid the need for manually managing service acc
 
 - To enable GCP IAM when installing YugabyteDB Anywhere on Kubernetes, refer to [Enable GKE service account-based IAM](../../../install-yugabyte-platform/install-software/kubernetes/#enable-gke-service-account-based-iam).
 
+- To prepare GCS permissions and Workload Identity for backups, refer to the GCP **Kubernetes** tab in [Permissions to back up and restore](../cloud-permissions-storage/).
+
 - To enable GCP IAM during universe creation on Kubernetes, refer to [Configure Helm overrides](../../../create-deployments/create-universe-multi-zone-kubernetes/#helm-overrides).
 
-- To enable GCP IAM for Google Cloud Storage backup configuration with Kubernetes, refer to [Configure backup storage](../../../back-up-restore-universes/configure-backup-storage/#google-cloud-storage).
+- To enable GCP IAM for Google Cloud Storage backup configuration with Kubernetes, refer to [Kubernetes backups (GKE)](../../../back-up-restore-universes/configure-backup-storage/#kubernetes-backups-gke).
 
 - To upgrade an existing universe with GCP IAM, refer to [Upgrade universes for GKE service account-based IAM support](../../../manage-deployments/edit-helm-overrides/#upgrade-universes-for-gke-service-account-based-iam).
 

--- a/docs/content/v2025.1/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-k8s.md
+++ b/docs/content/v2025.1/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-k8s.md
@@ -52,6 +52,8 @@ For YugabyteDB Anywhere (YBA) to be able to deploy and manage YugabyteDB cluster
 
 As a prerequisite for creating pods and deploying database clusters, YBA requires a service account in the Kubernetes cluster and a corresponding kubeconfig file.
 
+For S3 or GCS backup IAM on Kubernetes (which pods need roles, IRSA / Workload Identity, and how to make settings persistent), see [Permissions to back up and restore](../cloud-permissions-storage/) (AWS or GCP **Kubernetes** tab) and [Configure backup storage](../../../back-up-restore-universes/configure-backup-storage/#make-backup-settings-persistent-on-kubernetes).
+
 Do one of the following:
 
 - Create a [`yugabyte-platform-universe-management` service account](#create-a-service-account) and a [`kubeconfig` file](#create-a-kubeconfig-file) directly.

--- a/docs/content/v2025.1/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-storage.md
+++ b/docs/content/v2025.1/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-storage.md
@@ -61,12 +61,7 @@ When backing up to and/or restoring from NFS storage, the NFS storage system mus
 
   <div id="aws" class="tab-pane fade" role="tabpanel" aria-labelledby="aws-tab">
 
-When backing up to and/or restoring from AWS S3 or S3-compatible storage, YBA and DB nodes must be able to write to and read from the S3 storage bucket.
-
-To grant the required access, you can do one of the following:
-
-- Provide a service account with the following permissions.
-- Create the EC2 VM instances (for both the YBA VM and the DB nodes VMs) with an IAM role with the required permissions.
+When backing up to and/or restoring from AWS S3 or S3-compatible storage, YBA and database nodes (or pods) must be able to write to and read from the S3 storage bucket.
 
 The following permissions are required:
 
@@ -79,22 +74,111 @@ The following permissions are required:
 "s3:GetBucketLocation"
 ```
 
-The Access key ID and Secret Access Key for the service account are used when creating a backup [storage configuration](../../../back-up-restore-universes/configure-backup-storage/#amazon-s3) for S3.
+<ul class="nav nav-tabs-alt nav-tabs-yb custom-tabs">
+  <li>
+    <a href="#aws-vm" class="nav-link active" id="aws-vm-tab" data-bs-toggle="tab"
+      role="tab" aria-controls="aws-vm" aria-selected="true">
+      <i class="fa-solid fa-server"></i>
+      VM
+    </a>
+  </li>
+  <li>
+    <a href="#aws-k8s" class="nav-link" id="aws-k8s-tab" data-bs-toggle="tab"
+      role="tab" aria-controls="aws-k8s" aria-selected="false">
+      <i class="fa-regular fa-dharmachakra"></i>
+      Kubernetes
+    </a>
+  </li>
+</ul>
+
+<div class="tab-content">
+  <div id="aws-vm" class="tab-pane fade show active" role="tabpanel" aria-labelledby="aws-vm-tab">
+
+To grant the required access on VMs, do one of the following:
+
+- Provide an IAM user with the permissions listed above, and use its Access key ID and Secret Access Key when creating the backup storage configuration.
+- Create the EC2 VM instances (for both the YBA VM and the DB node VMs) with an IAM role that has the required permissions.
 
 | Save for later | To configure |
 | :--- | :--- |
-| Service account Access key ID and Secret Access Key | [Storage configuration](../../../back-up-restore-universes/configure-backup-storage/#amazon-s3) for S3 |
+| Service account Access key ID and Secret Access Key, or IAM roles on the VMs | [Storage configuration](../../../back-up-restore-universes/configure-backup-storage/#amazon-s3) for S3 |
+
+  </div>
+
+  <div id="aws-k8s" class="tab-pane fade" role="tabpanel" aria-labelledby="aws-k8s-tab">
+
+On Amazon EKS, IAM roles attached to worker **nodes** do not grant S3 access to **pods**. Use [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) so that a Kubernetes service account (KSA) can assume an IAM role.
+
+**Recommended:** Attach the IAM role to a KSA used by the **database (YBDB) pods** — the universe node IAM path. See [Choose an S3 authentication method](../../../back-up-restore-universes/configure-backup-storage/#choose-an-s3-authentication-method).
+
+| Auth option | Which service account needs the IAM role |
+| :--- | :--- |
+| Universe node IAM (recommended) | KSA on **YBDB** (tserver) pods. YBA pod IAM is not required for backup I/O. |
+| YBA instance IAM (legacy) | KSA on the **YBA** pod (or operator pod). |
+| Access Key and Access Secret | Neither. Provide static credentials in the storage configuration. |
+
+##### Create an IRSA-enabled service account
+
+1. Create an IAM role with the [S3 permissions](#aws) listed above, and a trust policy that allows your EKS OIDC provider to assume the role for the KSA. For example:
+
+    ```json
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "Federated": "arn:aws:iam::<ACCOUNT_ID>:oidc-provider/<OIDC_PROVIDER>"
+          },
+          "Action": "sts:AssumeRoleWithWebIdentity",
+          "Condition": {
+            "StringEquals": {
+              "<OIDC_PROVIDER>:sub": "system:serviceaccount:<NAMESPACE>:<KSA_NAME>",
+              "<OIDC_PROVIDER>:aud": "sts.amazonaws.com"
+            }
+          }
+        }
+      ]
+    }
+    ```
+
+1. Create the KSA in each namespace where database pods run, and annotate it with the role ARN:
+
+    ```yaml
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: <KSA_NAME>
+      namespace: <NAMESPACE>
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE_NAME>
+    ```
+
+1. Apply the KSA to database pods using provider or universe [Helm overrides](../../../create-deployments/create-universe-multi-zone-kubernetes/#eks-service-account) (or Operator `kubernetesOverrides`). Do not rely on one-off `kubectl edit` changes — those are lost on upgrade. See [Make backup settings persistent on Kubernetes](../../../back-up-restore-universes/configure-backup-storage/#make-backup-settings-persistent-on-kubernetes).
+
+##### Verify from a database pod
+
+After the universe is running with the annotated KSA:
+
+```sh
+kubectl exec -n <NAMESPACE> -it <TSERVER_POD> -- \
+  aws sts get-caller-identity
+```
+
+Confirm that the returned ARN matches the IRSA role you created.
+
+| Save for later | To configure |
+| :--- | :--- |
+| Annotated KSA name and IAM role | [Kubernetes backups (EKS)](../../../back-up-restore-universes/configure-backup-storage/#kubernetes-backups-eks) and [EKS service account](../../../create-deployments/create-universe-multi-zone-kubernetes/#eks-service-account) overrides |
+
+  </div>
+</div>
 
   </div>
 
   <div id="gcp" class="tab-pane fade" role="tabpanel" aria-labelledby="gcp-tab">
 
-When backing up to and/or restoring from GCP GCS, YBA and database nodes must be able to write to and read from the GCS storage bucket.
-
-To grant the required access, you can do one of the following:
-
-- Provide a GCP service account with [IAM roles for cloud storage](https://cloud.google.com/storage/docs/access-control/iam-roles) with the required permissions.
-- Create the VM instances (for both the YBA VM and the DB nodes VMs) with an IAM role that has the required permissions.
+When backing up to and/or restoring from GCP GCS, YBA and database nodes (or pods) must be able to write to and read from the GCS storage bucket.
 
 The following permissions are required:
 
@@ -102,11 +186,89 @@ The following permissions are required:
 roles/storage.admin
 ```
 
-The credentials for this account (in JSON format) are used when creating a backup [storage configuration](../../../back-up-restore-universes/configure-backup-storage/#google-cloud-storage) for GCS.
+<ul class="nav nav-tabs-alt nav-tabs-yb custom-tabs">
+  <li>
+    <a href="#gcp-vm" class="nav-link active" id="gcp-vm-tab" data-bs-toggle="tab"
+      role="tab" aria-controls="gcp-vm" aria-selected="true">
+      <i class="fa-solid fa-server"></i>
+      VM
+    </a>
+  </li>
+  <li>
+    <a href="#gcp-k8s" class="nav-link" id="gcp-k8s-tab" data-bs-toggle="tab"
+      role="tab" aria-controls="gcp-k8s" aria-selected="false">
+      <i class="fa-regular fa-dharmachakra"></i>
+      Kubernetes
+    </a>
+  </li>
+</ul>
+
+<div class="tab-content">
+  <div id="gcp-vm" class="tab-pane fade show active" role="tabpanel" aria-labelledby="gcp-vm-tab">
+
+To grant the required access on VMs, do one of the following:
+
+- Provide a GCP service account with [IAM roles for cloud storage](https://cloud.google.com/storage/docs/access-control/iam-roles) with the permissions listed above, and use its JSON credentials when creating the backup storage configuration.
+- Create the VM instances (for both the YBA VM and the DB node VMs) with an IAM role that has the required permissions.
 
 | Save for later | To configure |
 | :--- | :--- |
-| Service account JSON credentials | [Storage configuration](../../../back-up-restore-universes/configure-backup-storage/#google-cloud-storage) for GCS |
+| Service account JSON credentials, or IAM roles on the VMs | [Storage configuration](../../../back-up-restore-universes/configure-backup-storage/#google-cloud-storage) for GCS |
+
+  </div>
+
+  <div id="gcp-k8s" class="tab-pane fade" role="tabpanel" aria-labelledby="gcp-k8s-tab">
+
+On Google Kubernetes Engine (GKE), use [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) so that a Kubernetes service account (KSA) can act as a Google IAM service account. Node-level service accounts do not replace Workload Identity for pods.
+
+**Recommended:** Annotate a KSA used by the **database (YBDB) pods**, and enable **Use GCP IAM** on the storage configuration. For background, see [GKE service account-based IAM](../cloud-permissions-nodes-gcp/#gke-service-account-based-iam-gcp-iam).
+
+| Auth option | Which service account needs the IAM binding |
+| :--- | :--- |
+| Use GCP IAM with YBDB pods (recommended) | KSA on **YBDB** (tserver) pods, bound to a Google IAM service account with `roles/storage.admin` (or equivalent). |
+| Use GCP IAM on the YBA pod | KSA on the **YBA** pod (set via Helm at install/upgrade). Often used together with YBDB pod IAM so YBA can validate the bucket. |
+| GCS JSON credentials | Neither. Provide JSON credentials in the storage configuration. |
+
+##### Prerequisites
+
+- Workload Identity enabled on the GKE cluster; worker nodes have the GKE metadata server enabled.
+- A Google IAM service account with permission to read, write, list, and delete objects in GCS (`roles/storage.admin` or equivalent).
+- The annotated KSA present in every namespace where YBA and/or YBDB pods run.
+
+##### Annotate the Kubernetes service account
+
+Bind the KSA to the Google IAM service account:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: <KSA_NAME>
+  namespace: <NAMESPACE>
+  annotations:
+    iam.gke.io/gcp-service-account: <GSA_NAME>@<PROJECT_ID>.iam.gserviceaccount.com
+```
+
+Also grant the Google IAM service account permission for the KSA to impersonate it (see [Use Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) in the GKE documentation).
+
+Apply the KSA to database pods using provider or universe [Helm overrides](../../../create-deployments/create-universe-multi-zone-kubernetes/#gke-service-account), including the metadata-server nodeSelector. Persist YBA-pod IAM via Helm `values.yaml` — see [Enable GKE service account-based IAM](../../../install-yugabyte-platform/install-software/kubernetes/#enable-gke-service-account-based-iam) and [Make backup settings persistent on Kubernetes](../../../back-up-restore-universes/configure-backup-storage/#make-backup-settings-persistent-on-kubernetes).
+
+##### Verify from a database pod
+
+```sh
+kubectl exec -n <NAMESPACE> -it <TSERVER_POD> -- \
+  curl -s -H "Metadata-Flavor: Google" \
+  http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email
+```
+
+Confirm that the email matches the Google IAM service account bound to the KSA.
+
+| Save for later | To configure |
+| :--- | :--- |
+| Annotated KSA name and Google IAM service account | [Kubernetes backups (GKE)](../../../back-up-restore-universes/configure-backup-storage/#kubernetes-backups-gke) and [GKE service account](../../../create-deployments/create-universe-multi-zone-kubernetes/#gke-service-account) overrides |
+
+  </div>
+</div>
 
   </div>
 

--- a/docs/content/v2025.2/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
+++ b/docs/content/v2025.2/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
@@ -35,8 +35,28 @@ You can configure AWS S3 and S3-compatible storage as your backup target.
     If you are using custom self-signed or CA certificates, to connect to your S3 storage, you must add the certificates to the YugabyteDB Anywhere Trust Store. Refer to [Add certificates to your trust store](../../security/enable-encryption-in-transit/trust-store/).
 
     {{< note title="Certificate validation can't be disabled" >}}
-If you set the **Server certificate verification for S3 backup/restore** (`yb.certVerifyBackupRestore.is_enforced`) Global Runtime Configuration option to False, the setting will be ignored.
+If you set the **Server certificate verification for S3 backup/restore** Global Runtime Configuration option (config key `yb.certVerifyBackupRestore.is_enforced`) to False, the setting will be ignored.
     {{< /note >}}
+
+### Choose an S3 authentication method
+
+When you create an S3 backup configuration, choose how YugabyteDB Anywhere and the universe authenticate to the bucket. Enable **IAM Role** for either IAM path, or leave it disabled and provide static credentials.
+
+**Recommended default:** For production universes on AWS (including EKS with IRSA), use universe node IAM roles. Use static **Access Key** and **Access Secret** credentials for evaluation setups, or when neither the YBA host nor the universe nodes can assume IAM roles. Treat YBA instance IAM as legacy, and keep it only for existing configurations that already depend on it.
+
+| Option | When to use | Prerequisites | Trade-offs |
+| :--- | :--- | :--- | :--- |
+| Universe node IAM role {{<tags/feature/ea>}} | Production backups on AWS VMs or Kubernetes (EKS IRSA). Recommended for new deployments. | Attach IAM roles (or annotated Kubernetes service accounts) with the [required S3 IAM permissions](#required-s3-iam-permissions) to each universe node or database pod.<br>Set the **Use S3 IAM roles attached to DB node for Backup/Restore** [Universe Configuration option](../../administer-yugabyte-platform/manage-runtime-config/) to true. Enable **IAM Role** on the storage configuration. For EKS setup, see [EKS service account](../../create-deployments/create-universe-multi-zone-kubernetes/#eks-service-account). | YB Controller on each node authenticates to S3 directly, so backups scale with cluster size. Requires a universe-level runtime configuration change. Preferred path going forward. |
+| YBA instance IAM role (Legacy) {{<tags/feature/ga>}} | Existing setups that already use the IAM role attached to the YugabyteDB Anywhere VM or pod. | Attach an IAM role with the [required S3 IAM permissions](#required-s3-iam-permissions) to the YugabyteDB Anywhere host. Enable **IAM Role**. <br>Leave **Use S3 IAM roles attached to DB node for Backup/Restore** at the default (`false`). | YBA fetches temporary credentials from its own instance role and passes them to database nodes. This path does not scale well for large backups and is not recommended for new deployments. |
+| Access Key and Access Secret {{<tags/feature/ga>}} | Evaluation and proof-of-concept setups; environments where neither YBA nor universe nodes have IAM roles (including many S3-compatible targets). | An IAM user (or equivalent) with the [required S3 IAM permissions](#required-s3-iam-permissions). Leave **IAM Role** disabled and enter **Access Key** and **Access Secret**. | Simplest path to a first successful backup. Credentials are stored in YBA and must be rotated manually. Prefer IAM for production when available. |
+
+#### Examples
+
+- **First backup / evaluation.** Leave **IAM Role** disabled. Enter an AWS access key and secret for a user that can read and write the backup bucket.
+- **New production AWS or EKS universe.** Attach instance profiles (or IRSA service accounts) to the database nodes, set **Use S3 IAM roles attached to DB node for Backup/Restore** (`yb.backup.s3.use_db_nodes_iam_role_for_backup`) to true for the universe, then enable **IAM Role** on the storage configuration.
+- **Existing YBA-role configuration.** Keep **IAM Role** enabled and leave `yb.backup.s3.use_db_nodes_iam_role_for_backup` at `false` until you can migrate nodes to their own IAM roles.
+
+For cloud permission setup details, refer to [Permissions to back up and restore](../../prepare/cloud-permissions/cloud-permissions-storage/).
 
 ### Create an AWS backup configuration
 
@@ -50,19 +70,21 @@ To configure S3 storage, do the following:
 
 1. Use the **Configuration Name** field to provide a meaningful name for your storage configuration.
 
-1. Enable **IAM Role** to use the YugabyteDB Anywhere instance's Identity Access Management (IAM) role or universe node IAM role for the S3 backup. See [Required S3 IAM permissions](#required-s3-iam-permissions).
+1. Choose authentication using the guidance in [Choose an S3 authentication method](#choose-an-s3-authentication-method):
 
-    To enable universe node IAM roles to access storage in S3, set the **Use S3 IAM roles attached to DB node for Backup/Restore** Universe Configuration option (config key `yb.backup.s3.use_db_nodes_iam_role_for_backup`) to true. Refer to [Manage runtime configuration settings](../../administer-yugabyte-platform/manage-runtime-config/).
+    - To use IAM (universe node IAM role or legacy YBA instance IAM role), enable **IAM Role**.
 
-1. If **IAM Role** is disabled, enter values for the **Access Key** and **Access Secret** fields.
+        For universe node IAM roles, also set the **Use S3 IAM roles attached to DB node for Backup/Restore** Universe Configuration option (config key `yb.backup.s3.use_db_nodes_iam_role_for_backup`) to true. Refer to [Manage runtime configuration settings](../../administer-yugabyte-platform/manage-runtime-config/).
 
-    For information on AWS access keys, see [Manage access keys for IAM users](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html).
+    - To use static credentials, leave **IAM Role** disabled and enter values for the **Access Key** and **Access Secret** fields.
+
+        For information on AWS access keys, see [Manage access keys for IAM users](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html).
 
 1. In the **S3 Bucket** field, enter the bucket name in the format `s3://bucket_name`, or `https://storage_vendor/s3-bucket-name` for S3-compatible storage.
 
 1. In the **S3 Bucket Host Base** field, enter the HTTP host header (endpoint URL) of the AWS S3 or S3-compatible storage, in the form `s3.amazonaws.com` or `my.storage.com`.
 
-1. If you are using S3-compatible storage, set the **S3 Path Style Access** option to true. (The option is only available if the **enablePathStyleAccess** feature is enabled.)
+1. If you are using S3-compatible storage, set the **S3 Path Style Access** option to true. (The option is only available after you enable the **Enable Path Access Style for Amazon S3** Global Runtime Configuration option, config key `yb.ui.feature_flags.enable_path_style_access`.)
 
 1. Click **Save**.
 

--- a/docs/content/v2025.2/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
+++ b/docs/content/v2025.2/yugabyte-platform/back-up-restore-universes/configure-backup-storage.md
@@ -46,7 +46,7 @@ When you create an S3 backup configuration, choose how YugabyteDB Anywhere and t
 
 | Option | When to use | Prerequisites | Trade-offs |
 | :--- | :--- | :--- | :--- |
-| Universe node IAM role {{<tags/feature/ea>}} | Production backups on AWS VMs or Kubernetes (EKS IRSA). Recommended for new deployments. | Attach IAM roles (or annotated Kubernetes service accounts) with the [required S3 IAM permissions](#required-s3-iam-permissions) to each universe node or database pod.<br>Set the **Use S3 IAM roles attached to DB node for Backup/Restore** [Universe Configuration option](../../administer-yugabyte-platform/manage-runtime-config/) to true. Enable **IAM Role** on the storage configuration. For EKS setup, see [EKS service account](../../create-deployments/create-universe-multi-zone-kubernetes/#eks-service-account). | YB Controller on each node authenticates to S3 directly, so backups scale with cluster size. Requires a universe-level runtime configuration change. Preferred path going forward. |
+| Universe node IAM role {{<tags/feature/ea>}} | Production backups on AWS VMs or Kubernetes (EKS IRSA). Recommended for new deployments. | Attach IAM roles (or annotated Kubernetes service accounts) with the [required S3 IAM permissions](#required-s3-iam-permissions) to each universe node or database pod.<br>Set the **Use S3 IAM roles attached to DB node for Backup/Restore** [Universe Configuration option](../../administer-yugabyte-platform/manage-runtime-config/) to true. Enable **IAM Role** on the storage configuration. For EKS, see [Kubernetes backups (EKS)](#kubernetes-backups-eks). | YB Controller on each node authenticates to S3 directly, so backups scale with cluster size. Requires a universe-level runtime configuration change. Preferred path going forward. |
 | YBA instance IAM role (Legacy) {{<tags/feature/ga>}} | Existing setups that already use the IAM role attached to the YugabyteDB Anywhere VM or pod. | Attach an IAM role with the [required S3 IAM permissions](#required-s3-iam-permissions) to the YugabyteDB Anywhere host. Enable **IAM Role**. <br>Leave **Use S3 IAM roles attached to DB node for Backup/Restore** at the default (`false`). | YBA fetches temporary credentials from its own instance role and passes them to database nodes. This path does not scale well for large backups and is not recommended for new deployments. |
 | Access Key and Access Secret {{<tags/feature/ga>}} | Evaluation and proof-of-concept setups; environments where neither YBA nor universe nodes have IAM roles (including many S3-compatible targets). | An IAM user (or equivalent) with the [required S3 IAM permissions](#required-s3-iam-permissions). Leave **IAM Role** disabled and enter **Access Key** and **Access Secret**. | Simplest path to a first successful backup. Credentials are stored in YBA and must be rotated manually. Prefer IAM for production when available. |
 
@@ -56,7 +56,7 @@ When you create an S3 backup configuration, choose how YugabyteDB Anywhere and t
 - **New production AWS or EKS universe.** Attach instance profiles (or IRSA service accounts) to the database nodes, set **Use S3 IAM roles attached to DB node for Backup/Restore** (`yb.backup.s3.use_db_nodes_iam_role_for_backup`) to true for the universe, then enable **IAM Role** on the storage configuration.
 - **Existing YBA-role configuration.** Keep **IAM Role** enabled and leave `yb.backup.s3.use_db_nodes_iam_role_for_backup` at `false` until you can migrate nodes to their own IAM roles.
 
-For cloud permission setup details, refer to [Permissions to back up and restore](../../prepare/cloud-permissions/cloud-permissions-storage/).
+For cloud permission setup details, refer to [Permissions to back up and restore](../../prepare/cloud-permissions/cloud-permissions-storage/). On EKS, open the AWS **Kubernetes** tab on that page for IRSA setup.
 
 ### Create an AWS backup configuration
 
@@ -109,6 +109,80 @@ The following S3 IAM permissions are required:
 "s3:GetBucketLocation"
 ```
 
+### Kubernetes backups (EKS)
+
+{{<tags/feature/ea>}}On Amazon EKS, use IRSA so database pods can assume an IAM role for S3. Node instance profiles alone do **not** grant S3 access to pods.
+
+For IAM role trust policy, KSA annotations, and verification steps, refer to the AWS **Kubernetes** tab in [Permissions to back up and restore](../../prepare/cloud-permissions/cloud-permissions-storage/).
+
+To configure S3 backups with universe node IAM on EKS:
+
+1. Create an IRSA-enabled Kubernetes service account (KSA) with the [required S3 IAM permissions](#required-s3-iam-permissions), in each namespace where database pods run.
+
+1. Attach the KSA to database pods using provider or universe Helm overrides. For example:
+
+    ```yaml
+    tserver:
+      serviceAccount: <KSA_NAME>
+    ```
+
+    For details, see [EKS service account](../../create-deployments/create-universe-multi-zone-kubernetes/#eks-service-account). If you use the [YugabyteDB Kubernetes Operator](../../anywhere-automation/yb-kubernetes-operator/), set the same override under `spec.kubernetesOverrides`.
+
+1. Set the **Use S3 IAM roles attached to DB node for Backup/Restore** Universe Configuration option (config key `yb.backup.s3.use_db_nodes_iam_role_for_backup`) to true. Refer to [Manage runtime configuration settings](../../administer-yugabyte-platform/manage-runtime-config/).
+
+1. Create an S3 storage configuration with **IAM Role** enabled, as described in [Create an AWS backup configuration](#create-an-aws-backup-configuration).
+
+1. Verify credentials from a tserver pod (see the prepare page), then run a test backup.
+
+For which settings survive pod restarts and upgrades, see [Make backup settings persistent on Kubernetes](#make-backup-settings-persistent-on-kubernetes).
+
+### Make backup settings persistent on Kubernetes
+
+Settings you apply with `kubectl edit`, one-off interactive install prompts, or temporary pod changes are **not** durable. Use the following so backup IAM configuration survives restarts and upgrades:
+
+| Setting | Persistent if you… | Not persistent if you… |
+| :--- | :--- | :--- |
+| Storage configuration (**IAM Role**, Access Key / Secret, GCS credentials) | Create or update it in the YBA UI or API (stored in the YBA database). | — |
+| **Use S3 IAM roles attached to DB node for Backup/Restore** (`yb.backup.s3.use_db_nodes_iam_role_for_backup`) | Set it via YBA [runtime configuration](../../administer-yugabyte-platform/manage-runtime-config/) (UI or API). | — |
+| Database pod `serviceAccount` (and GKE `nodeSelector`) | Set provider or universe **Helm overrides** in YBA, or Operator `kubernetesOverrides`, then apply/upgrade the universe. | Edit the live Deployment or Pod with `kubectl`, or change the SA only in the cluster without updating overrides. |
+| YBA pod service account (legacy YBA IAM / GKE YBA Workload Identity) | Put `yugaware.serviceAccount` (and any required `nodeSelector`) in your Helm `values.yaml` and run `helm upgrade`. | Rely only on interactive install answers that were never written to `values.yaml`. |
+| IRSA / Workload Identity annotations on the KSA | Keep annotations in the KSA manifest you manage (GitOps, Helm chart for the SA, or `kubectl apply` of that manifest). | Recreate the KSA without annotations, or expect YBA to recreate IRSA bindings for you. |
+
+#### Universe pod overrides (recommended path)
+
+Set the database pod service account in YBA (provider- or universe-level overrides), for example:
+
+```yaml
+tserver:
+  serviceAccount: <KSA_NAME>
+```
+
+For GKE, also include:
+
+```yaml
+nodeSelector:
+  iam.gke.io/gke-metadata-server-enabled: "true"
+```
+
+Saving these overrides in YBA and applying them to the universe is what makes the pod identity persistent. See [Helm overrides](../../create-deployments/create-universe-multi-zone-kubernetes/#helm-overrides).
+
+#### YBA Helm values (YBA pod IAM)
+
+If the YBA pod itself must use a cloud IAM role (legacy S3 path, or GKE validation), set the service account in values and upgrade:
+
+```yaml
+yugaware:
+  serviceAccount: <KSA_NAME>
+nodeSelector:
+  iam.gke.io/gke-metadata-server-enabled: "true"   # GKE only
+```
+
+```sh
+helm upgrade <RELEASE_NAME> yugabytedb/yugaware -n <YBA_NAMESPACE> -f values.yaml
+```
+
+For GKE install-time guidance, see [Enable GKE service account-based IAM](../../install-yugabyte-platform/install-software/kubernetes/#enable-gke-service-account-based-iam).
+
 ### Specify signing region
 
 In some circumstances, you may need to additionally specify the signing region for the AWS backup configuration. For example:
@@ -144,12 +218,21 @@ To grant access to your bucket, create a GCP service account with [IAM roles for
 roles/storage.admin
 ```
 
-The credentials for this account (in JSON format) are used when creating the backup storage configuration. For information on how to obtain GCS credentials, see [Cloud Storage authentication](https://cloud.google.com/storage/docs/authentication).
+The credentials for this account (in JSON format) are used when creating the backup storage configuration with static credentials. For information on how to obtain GCS credentials, see [Cloud Storage authentication](https://cloud.google.com/storage/docs/authentication).
 
 You can configure access control for the GCS bucket as follows:
 
 - Provide the required access control list (ACL) and set it as either uniform or fine-grained (for object-level access).
 - Add permissions, such as roles and members.
+
+### Choose a GCS authentication method
+
+When you create a GCS backup configuration, choose how YugabyteDB Anywhere and the universe authenticate to the bucket:
+
+- **Use GCP IAM** — Use Workload Identity (GKE) or the IAM identity on the YBA / database host. On GKE, attach a Google IAM service account to the Kubernetes service account used by database pods (and typically the YBA pod). See [Kubernetes backups (GKE)](#kubernetes-backups-gke).
+- **GCS Credentials (JSON)** — Simplest path for evaluation setups, or when Workload Identity / host IAM is unavailable. Leave **Use GCP IAM** disabled and paste the service account JSON.
+
+For cloud permission setup, refer to the GCP tab in [Permissions to back up and restore](../../prepare/cloud-permissions/cloud-permissions-storage/) (use the **Kubernetes** sub-tab for GKE).
 
 ### Create a GCS backup configuration
 
@@ -165,11 +248,37 @@ To create a GCP backup configuration, do the following:
 
 1. Enter the URI of your GCS bucket in the **GCS Bucket** field. For example, `gs://gcp-bucket/test_backups`.
 
-1. Select **Use GCP IAM** to use the YugabyteDB Anywhere instance's Identity Access Management (IAM) role for the GCS backup.
+1. Choose authentication:
 
-1. If **Use GCP IAM** is disabled, enter the credentials for your account in JSON format in the **GCS Credentials** field.
+    - To use IAM (including GKE Workload Identity), select **Use GCP IAM**.
+    - Otherwise, leave **Use GCP IAM** disabled and enter the credentials for your account in JSON format in the **GCS Credentials** field.
 
 1. Click **Save**.
+
+### Kubernetes backups (GKE)
+
+On GKE, use [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) so database pods can access GCS. For KSA annotations, IAM bindings, and verification, refer to the GCP **Kubernetes** tab in [Permissions to back up and restore](../../prepare/cloud-permissions/cloud-permissions-storage/) and [GKE service account-based IAM](../../prepare/cloud-permissions/cloud-permissions-nodes-gcp/#gke-service-account-based-iam-gcp-iam).
+
+To configure GCS backups with Workload Identity:
+
+1. Create a Google IAM service account with the [required permissions](#required-gcp-service-account-permissions), and a Kubernetes service account (KSA) annotated for Workload Identity in each namespace where pods run.
+
+1. Attach the KSA to database pods using provider or universe Helm overrides:
+
+    ```yaml
+    tserver:
+      serviceAccount: <KSA_NAME>
+    nodeSelector:
+      iam.gke.io/gke-metadata-server-enabled: "true"
+    ```
+
+    For details, see [GKE service account](../../create-deployments/create-universe-multi-zone-kubernetes/#gke-service-account). To upgrade an existing universe, see [Upgrade universes for GKE service account-based IAM](../../manage-deployments/edit-helm-overrides/#upgrade-universes-for-gke-service-account-based-iam).
+
+1. If the YBA pod must also use Workload Identity (recommended so YBA can validate the bucket), set the YBA Helm service account as described in [Enable GKE service account-based IAM](../../install-yugabyte-platform/install-software/kubernetes/#enable-gke-service-account-based-iam), and persist it with `helm upgrade` — see [Make backup settings persistent on Kubernetes](#make-backup-settings-persistent-on-kubernetes).
+
+1. Create a GCS storage configuration with **Use GCP IAM** enabled, as described in [Create a GCS backup configuration](#create-a-gcs-backup-configuration).
+
+1. Verify the workload identity from a tserver pod, then run a test backup.
 
 ## Azure Storage
 

--- a/docs/content/v2025.2/yugabyte-platform/create-deployments/create-universe-multi-zone-kubernetes.md
+++ b/docs/content/v2025.2/yugabyte-platform/create-deployments/create-universe-multi-zone-kubernetes.md
@@ -168,6 +168,8 @@ nodeSelector:
   iam.gke.io/gke-metadata-server-enabled: "true"
 ```
 
+For end-to-end GCS backup setup on GKE (Workload Identity, storage configuration, and persistence), see [Kubernetes backups (GKE)](../../back-up-restore-universes/configure-backup-storage/#kubernetes-backups-gke) and the GCP **Kubernetes** tab in [Permissions to back up and restore](../../prepare/cloud-permissions/cloud-permissions-storage/).
+
 If you don't provide namespace names for each zone/region during [provider creation](../../configure-yugabyte-platform/kubernetes/), add the names using the following steps:
 
 1. Add the Kubernetes service account to the namespaces where the pods are created.
@@ -178,6 +180,10 @@ To enable the GKE service account service at the provider level, refer to [Overr
 #### EKS service account
 
 In AWS, you can attach a service account to database pods; the account can then be used to access storage. The service account used for the database pods should have annotations for the IAM role. The service account to be used can be applied to the DB pods as helm override with provider/universe level overrides. The IAM role used should be sufficient to access S3 storage.
+
+{{< note title="Node IAM is not pod IAM" >}}
+IAM roles on EKS worker nodes do not grant S3 access to pods. Use IRSA on the database pod service account. See [Kubernetes backups (EKS)](../../back-up-restore-universes/configure-backup-storage/#kubernetes-backups-eks) and the AWS **Kubernetes** tab in [Permissions to back up and restore](../../prepare/cloud-permissions/cloud-permissions-storage/).
+{{< /note >}}
 
 To enable IAM roles for S3, set the **Use S3 IAM roles attached to DB node for Backup/Restore** Universe Configuration option (config key `yb.backup.s3.use_db_nodes_iam_role_for_backup`) to true. Refer to [Manage runtime configuration settings](../../administer-yugabyte-platform/manage-runtime-config/).
 
@@ -191,6 +197,8 @@ tserver:
 ```
 
 To enable the EKS service account service at the provider level, refer to [Overrides](../../configure-yugabyte-platform/kubernetes/#overrides).
+
+Save these overrides in YBA (or Operator `kubernetesOverrides`) so they persist across upgrades — see [Make backup settings persistent on Kubernetes](../../back-up-restore-universes/configure-backup-storage/#make-backup-settings-persistent-on-kubernetes).
 
 #### Readiness probes
 

--- a/docs/content/v2025.2/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-gcp.md
+++ b/docs/content/v2025.2/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-gcp.md
@@ -99,9 +99,11 @@ By using Workload Identity, you avoid the need for manually managing service acc
 
 - To enable GCP IAM when installing YugabyteDB Anywhere on Kubernetes, refer to [Enable GKE service account-based IAM](../../../install-yugabyte-platform/install-software/kubernetes/#enable-gke-service-account-based-iam).
 
+- To prepare GCS permissions and Workload Identity for backups, refer to the GCP **Kubernetes** tab in [Permissions to back up and restore](../cloud-permissions-storage/).
+
 - To enable GCP IAM during universe creation on Kubernetes, refer to [Configure Helm overrides](../../../create-deployments/create-universe-multi-zone-kubernetes/#helm-overrides).
 
-- To enable GCP IAM for Google Cloud Storage backup configuration with Kubernetes, refer to [Configure backup storage](../../../back-up-restore-universes/configure-backup-storage/#google-cloud-storage).
+- To enable GCP IAM for Google Cloud Storage backup configuration with Kubernetes, refer to [Kubernetes backups (GKE)](../../../back-up-restore-universes/configure-backup-storage/#kubernetes-backups-gke).
 
 - To upgrade an existing universe with GCP IAM, refer to [Upgrade universes for GKE service account-based IAM support](../../../manage-deployments/edit-helm-overrides/#upgrade-universes-for-gke-service-account-based-iam).
 

--- a/docs/content/v2025.2/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-k8s.md
+++ b/docs/content/v2025.2/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-nodes-k8s.md
@@ -52,6 +52,8 @@ For YugabyteDB Anywhere (YBA) to be able to deploy and manage YugabyteDB cluster
 
 As a prerequisite for creating pods and deploying database clusters, YBA requires a service account in the Kubernetes cluster and a corresponding kubeconfig file.
 
+For S3 or GCS backup IAM on Kubernetes (which pods need roles, IRSA / Workload Identity, and how to make settings persistent), see [Permissions to back up and restore](../cloud-permissions-storage/) (AWS or GCP **Kubernetes** tab) and [Configure backup storage](../../../back-up-restore-universes/configure-backup-storage/#make-backup-settings-persistent-on-kubernetes).
+
 Do one of the following:
 
 - Create a [`yugabyte-platform-universe-management` service account](#create-a-service-account) and a [`kubeconfig` file](#create-a-kubeconfig-file) directly.

--- a/docs/content/v2025.2/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-storage.md
+++ b/docs/content/v2025.2/yugabyte-platform/prepare/cloud-permissions/cloud-permissions-storage.md
@@ -61,12 +61,7 @@ When backing up to and/or restoring from NFS storage, the NFS storage system mus
 
   <div id="aws" class="tab-pane fade" role="tabpanel" aria-labelledby="aws-tab">
 
-When backing up to and/or restoring from AWS S3 or S3-compatible storage, YBA and DB nodes must be able to write to and read from the S3 storage bucket.
-
-To grant the required access, you can do one of the following:
-
-- Provide a service account with the following permissions.
-- Create the EC2 VM instances (for both the YBA VM and the DB nodes VMs) with an IAM role with the required permissions.
+When backing up to and/or restoring from AWS S3 or S3-compatible storage, YBA and database nodes (or pods) must be able to write to and read from the S3 storage bucket.
 
 The following permissions are required:
 
@@ -79,22 +74,111 @@ The following permissions are required:
 "s3:GetBucketLocation"
 ```
 
-The Access key ID and Secret Access Key for the service account are used when creating a backup [storage configuration](../../../back-up-restore-universes/configure-backup-storage/#amazon-s3) for S3.
+<ul class="nav nav-tabs-alt nav-tabs-yb custom-tabs">
+  <li>
+    <a href="#aws-vm" class="nav-link active" id="aws-vm-tab" data-bs-toggle="tab"
+      role="tab" aria-controls="aws-vm" aria-selected="true">
+      <i class="fa-solid fa-server"></i>
+      VM
+    </a>
+  </li>
+  <li>
+    <a href="#aws-k8s" class="nav-link" id="aws-k8s-tab" data-bs-toggle="tab"
+      role="tab" aria-controls="aws-k8s" aria-selected="false">
+      <i class="fa-regular fa-dharmachakra"></i>
+      Kubernetes
+    </a>
+  </li>
+</ul>
+
+<div class="tab-content">
+  <div id="aws-vm" class="tab-pane fade show active" role="tabpanel" aria-labelledby="aws-vm-tab">
+
+To grant the required access on VMs, do one of the following:
+
+- Provide an IAM user with the permissions listed above, and use its Access key ID and Secret Access Key when creating the backup storage configuration.
+- Create the EC2 VM instances (for both the YBA VM and the DB node VMs) with an IAM role that has the required permissions.
 
 | Save for later | To configure |
 | :--- | :--- |
-| Service account Access key ID and Secret Access Key | [Storage configuration](../../../back-up-restore-universes/configure-backup-storage/#amazon-s3) for S3 |
+| Service account Access key ID and Secret Access Key, or IAM roles on the VMs | [Storage configuration](../../../back-up-restore-universes/configure-backup-storage/#amazon-s3) for S3 |
+
+  </div>
+
+  <div id="aws-k8s" class="tab-pane fade" role="tabpanel" aria-labelledby="aws-k8s-tab">
+
+On Amazon EKS, IAM roles attached to worker **nodes** do not grant S3 access to **pods**. Use [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) so that a Kubernetes service account (KSA) can assume an IAM role.
+
+**Recommended:** Attach the IAM role to a KSA used by the **database (YBDB) pods** — the universe node IAM path. See [Choose an S3 authentication method](../../../back-up-restore-universes/configure-backup-storage/#choose-an-s3-authentication-method).
+
+| Auth option | Which service account needs the IAM role |
+| :--- | :--- |
+| Universe node IAM (recommended) | KSA on **YBDB** (tserver) pods. YBA pod IAM is not required for backup I/O. |
+| YBA instance IAM (legacy) | KSA on the **YBA** pod (or operator pod). |
+| Access Key and Access Secret | Neither. Provide static credentials in the storage configuration. |
+
+##### Create an IRSA-enabled service account
+
+1. Create an IAM role with the [S3 permissions](#aws) listed above, and a trust policy that allows your EKS OIDC provider to assume the role for the KSA. For example:
+
+    ```json
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "Federated": "arn:aws:iam::<ACCOUNT_ID>:oidc-provider/<OIDC_PROVIDER>"
+          },
+          "Action": "sts:AssumeRoleWithWebIdentity",
+          "Condition": {
+            "StringEquals": {
+              "<OIDC_PROVIDER>:sub": "system:serviceaccount:<NAMESPACE>:<KSA_NAME>",
+              "<OIDC_PROVIDER>:aud": "sts.amazonaws.com"
+            }
+          }
+        }
+      ]
+    }
+    ```
+
+1. Create the KSA in each namespace where database pods run, and annotate it with the role ARN:
+
+    ```yaml
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: <KSA_NAME>
+      namespace: <NAMESPACE>
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE_NAME>
+    ```
+
+1. Apply the KSA to database pods using provider or universe [Helm overrides](../../../create-deployments/create-universe-multi-zone-kubernetes/#eks-service-account) (or Operator `kubernetesOverrides`). Do not rely on one-off `kubectl edit` changes — those are lost on upgrade. See [Make backup settings persistent on Kubernetes](../../../back-up-restore-universes/configure-backup-storage/#make-backup-settings-persistent-on-kubernetes).
+
+##### Verify from a database pod
+
+After the universe is running with the annotated KSA:
+
+```sh
+kubectl exec -n <NAMESPACE> -it <TSERVER_POD> -- \
+  aws sts get-caller-identity
+```
+
+Confirm that the returned ARN matches the IRSA role you created.
+
+| Save for later | To configure |
+| :--- | :--- |
+| Annotated KSA name and IAM role | [Kubernetes backups (EKS)](../../../back-up-restore-universes/configure-backup-storage/#kubernetes-backups-eks) and [EKS service account](../../../create-deployments/create-universe-multi-zone-kubernetes/#eks-service-account) overrides |
+
+  </div>
+</div>
 
   </div>
 
   <div id="gcp" class="tab-pane fade" role="tabpanel" aria-labelledby="gcp-tab">
 
-When backing up to and/or restoring from GCP GCS, YBA and database nodes must be able to write to and read from the GCS storage bucket.
-
-To grant the required access, you can do one of the following:
-
-- Provide a GCP service account with [IAM roles for cloud storage](https://cloud.google.com/storage/docs/access-control/iam-roles) with the required permissions.
-- Create the VM instances (for both the YBA VM and the DB nodes VMs) with an IAM role that has the required permissions.
+When backing up to and/or restoring from GCP GCS, YBA and database nodes (or pods) must be able to write to and read from the GCS storage bucket.
 
 The following permissions are required:
 
@@ -102,11 +186,89 @@ The following permissions are required:
 roles/storage.admin
 ```
 
-The credentials for this account (in JSON format) are used when creating a backup [storage configuration](../../../back-up-restore-universes/configure-backup-storage/#google-cloud-storage) for GCS.
+<ul class="nav nav-tabs-alt nav-tabs-yb custom-tabs">
+  <li>
+    <a href="#gcp-vm" class="nav-link active" id="gcp-vm-tab" data-bs-toggle="tab"
+      role="tab" aria-controls="gcp-vm" aria-selected="true">
+      <i class="fa-solid fa-server"></i>
+      VM
+    </a>
+  </li>
+  <li>
+    <a href="#gcp-k8s" class="nav-link" id="gcp-k8s-tab" data-bs-toggle="tab"
+      role="tab" aria-controls="gcp-k8s" aria-selected="false">
+      <i class="fa-regular fa-dharmachakra"></i>
+      Kubernetes
+    </a>
+  </li>
+</ul>
+
+<div class="tab-content">
+  <div id="gcp-vm" class="tab-pane fade show active" role="tabpanel" aria-labelledby="gcp-vm-tab">
+
+To grant the required access on VMs, do one of the following:
+
+- Provide a GCP service account with [IAM roles for cloud storage](https://cloud.google.com/storage/docs/access-control/iam-roles) with the permissions listed above, and use its JSON credentials when creating the backup storage configuration.
+- Create the VM instances (for both the YBA VM and the DB node VMs) with an IAM role that has the required permissions.
 
 | Save for later | To configure |
 | :--- | :--- |
-| Service account JSON credentials | [Storage configuration](../../../back-up-restore-universes/configure-backup-storage/#google-cloud-storage) for GCS |
+| Service account JSON credentials, or IAM roles on the VMs | [Storage configuration](../../../back-up-restore-universes/configure-backup-storage/#google-cloud-storage) for GCS |
+
+  </div>
+
+  <div id="gcp-k8s" class="tab-pane fade" role="tabpanel" aria-labelledby="gcp-k8s-tab">
+
+On Google Kubernetes Engine (GKE), use [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) so that a Kubernetes service account (KSA) can act as a Google IAM service account. Node-level service accounts do not replace Workload Identity for pods.
+
+**Recommended:** Annotate a KSA used by the **database (YBDB) pods**, and enable **Use GCP IAM** on the storage configuration. For background, see [GKE service account-based IAM](../cloud-permissions-nodes-gcp/#gke-service-account-based-iam-gcp-iam).
+
+| Auth option | Which service account needs the IAM binding |
+| :--- | :--- |
+| Use GCP IAM with YBDB pods (recommended) | KSA on **YBDB** (tserver) pods, bound to a Google IAM service account with `roles/storage.admin` (or equivalent). |
+| Use GCP IAM on the YBA pod | KSA on the **YBA** pod (set via Helm at install/upgrade). Often used together with YBDB pod IAM so YBA can validate the bucket. |
+| GCS JSON credentials | Neither. Provide JSON credentials in the storage configuration. |
+
+##### Prerequisites
+
+- Workload Identity enabled on the GKE cluster; worker nodes have the GKE metadata server enabled.
+- A Google IAM service account with permission to read, write, list, and delete objects in GCS (`roles/storage.admin` or equivalent).
+- The annotated KSA present in every namespace where YBA and/or YBDB pods run.
+
+##### Annotate the Kubernetes service account
+
+Bind the KSA to the Google IAM service account:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: <KSA_NAME>
+  namespace: <NAMESPACE>
+  annotations:
+    iam.gke.io/gcp-service-account: <GSA_NAME>@<PROJECT_ID>.iam.gserviceaccount.com
+```
+
+Also grant the Google IAM service account permission for the KSA to impersonate it (see [Use Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) in the GKE documentation).
+
+Apply the KSA to database pods using provider or universe [Helm overrides](../../../create-deployments/create-universe-multi-zone-kubernetes/#gke-service-account), including the metadata-server nodeSelector. Persist YBA-pod IAM via Helm `values.yaml` — see [Enable GKE service account-based IAM](../../../install-yugabyte-platform/install-software/kubernetes/#enable-gke-service-account-based-iam) and [Make backup settings persistent on Kubernetes](../../../back-up-restore-universes/configure-backup-storage/#make-backup-settings-persistent-on-kubernetes).
+
+##### Verify from a database pod
+
+```sh
+kubectl exec -n <NAMESPACE> -it <TSERVER_POD> -- \
+  curl -s -H "Metadata-Flavor: Google" \
+  http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email
+```
+
+Confirm that the email matches the Google IAM service account bound to the KSA.
+
+| Save for later | To configure |
+| :--- | :--- |
+| Annotated KSA name and Google IAM service account | [Kubernetes backups (GKE)](../../../back-up-restore-universes/configure-backup-storage/#kubernetes-backups-gke) and [GKE service account](../../../create-deployments/create-universe-multi-zone-kubernetes/#gke-service-account) overrides |
+
+  </div>
+</div>
 
   </div>
 


### PR DESCRIPTION
Added a Choose an S3 authentication method section to the configure-backup-storage page

DOC-1403 Kubernetes-specific IAM setup for backup storage

@netlify /stable/yugabyte-platform/back-up-restore-universes/configure-backup-storage/