### PR TITLE
[#33125] DocDB: Dump thread stacks to the log when RPC service queues stay full

### DIFF
--- a/src/yb/rpc/CMakeLists.txt
+++ b/src/yb/rpc/CMakeLists.txt
@@ -103,6 +103,7 @@ set(YRPC_SRCS
     serialization.cc
     service_if.cc
     service_pool.cc
+    service_queue_monitor.cc
     sidecars.cc
     stream.cc
     tcp_stream.cc

--- a/src/yb/rpc/messenger.cc
+++ b/src/yb/rpc/messenger.cc
@@ -57,6 +57,7 @@
 #include "yb/rpc/rpc_metrics.h"
 #include "yb/rpc/rpc_service.h"
 #include "yb/rpc/rpc_util.h"
+#include "yb/rpc/service_queue_monitor.h"
 #include "yb/rpc/tcp_stream.h"
 #include "yb/rpc/yb_rpc.h"
 
@@ -206,12 +207,15 @@ void Messenger::Shutdown() {
   std::vector<Reactor*> reactors;
   std::unique_ptr<Acceptor> acceptor;
   std::unique_ptr<ReactorMonitor> reactor_monitor;
+  std::unique_ptr<ServiceQueueMonitor> service_queue_monitor;
   {
     std::lock_guard guard(lock_);
 
     acceptor.swap(acceptor_);
 
     reactor_monitor.swap(reactor_monitor_);
+
+    service_queue_monitor.swap(service_queue_monitor_);
 
     for (const auto& reactor : reactors_) {
       reactors.push_back(reactor.get());
@@ -225,6 +229,11 @@ void Messenger::Shutdown() {
   if (reactor_monitor) {
     reactor_monitor->Shutdown();
     reactor_monitor.reset();
+  }
+
+  if (service_queue_monitor) {
+    service_queue_monitor->Shutdown();
+    service_queue_monitor.reset();
   }
 
   for (auto* reactor : reactors) {
@@ -448,6 +457,13 @@ Status Messenger::RegisterService(
     const std::string& service_name, const scoped_refptr<RpcService>& service) {
   DCHECK(service);
   rpc_services_.emplace(service_name, service);
+  {
+    std::lock_guard guard(lock_);
+    if (!service_queue_monitor_) {
+      service_queue_monitor_ = std::make_unique<ServiceQueueMonitor>(name_);
+    }
+    service_queue_monitor_->Track(service_name, service);
+  }
   return Status::OK();
 }
 

--- a/src/yb/rpc/messenger.cc
+++ b/src/yb/rpc/messenger.cc
@@ -197,25 +197,32 @@ void Messenger::Shutdown() {
   }
   VLOG_WITH_PREFIX(1) << "shutting down messenger";
 
+  // Since we're shutting down, it's OK to block.
+  ThreadRestrictions::ScopedAllowWait allow_wait;
+
+  std::unique_ptr<ServiceQueueMonitor> service_queue_monitor;
+  {
+    std::lock_guard guard(lock_);
+    service_queue_monitor.swap(service_queue_monitor_);
+  }
+  if (service_queue_monitor) {
+    service_queue_monitor->Shutdown();
+    service_queue_monitor.reset();
+  }
+
   ShutdownThreadPools();
   ShutdownAcceptor();
   UnregisterAllServices();
 
-  // Since we're shutting down, it's OK to block.
-  ThreadRestrictions::ScopedAllowWait allow_wait;
-
   std::vector<Reactor*> reactors;
   std::unique_ptr<Acceptor> acceptor;
   std::unique_ptr<ReactorMonitor> reactor_monitor;
-  std::unique_ptr<ServiceQueueMonitor> service_queue_monitor;
   {
     std::lock_guard guard(lock_);
 
     acceptor.swap(acceptor_);
 
     reactor_monitor.swap(reactor_monitor_);
-
-    service_queue_monitor.swap(service_queue_monitor_);
 
     for (const auto& reactor : reactors_) {
       reactors.push_back(reactor.get());
@@ -229,11 +236,6 @@ void Messenger::Shutdown() {
   if (reactor_monitor) {
     reactor_monitor->Shutdown();
     reactor_monitor.reset();
-  }
-
-  if (service_queue_monitor) {
-    service_queue_monitor->Shutdown();
-    service_queue_monitor.reset();
   }
 
   for (auto* reactor : reactors) {
@@ -455,6 +457,12 @@ Result<ThreadPoolPtr> Messenger::TaggedThreadPool(TaggedThreadPools::Tag tag) {
 // Register a new RpcService to handle inbound requests.
 Status Messenger::RegisterService(
     const std::string& service_name, const scoped_refptr<RpcService>& service) {
+  return RegisterService(service_name, service, ServicePriority::kNormal);
+}
+
+Status Messenger::RegisterService(
+    const std::string& service_name, const scoped_refptr<RpcService>& service,
+    ServicePriority priority) {
   DCHECK(service);
   rpc_services_.emplace(service_name, service);
   {
@@ -462,7 +470,7 @@ Status Messenger::RegisterService(
     if (!service_queue_monitor_) {
       service_queue_monitor_ = std::make_unique<ServiceQueueMonitor>(name_);
     }
-    service_queue_monitor_->Track(service_name, service);
+    service_queue_monitor_->Track(service_name, service, priority);
   }
   return Status::OK();
 }

--- a/src/yb/rpc/messenger.h
+++ b/src/yb/rpc/messenger.h
@@ -246,6 +246,9 @@ class Messenger : public ProxyContext {
 
   // Register a new RpcService to handle inbound requests.
   Status RegisterService(const std::string& service_name, const RpcServicePtr& service);
+  Status RegisterService(
+      const std::string& service_name, const RpcServicePtr& service,
+      ServicePriority priority);
 
   void UnregisterAllServices();
 

--- a/src/yb/rpc/messenger.h
+++ b/src/yb/rpc/messenger.h
@@ -474,6 +474,10 @@ class Messenger : public ProxyContext {
 
   std::unique_ptr<ReactorMonitor> reactor_monitor_ GUARDED_BY(lock_);
 
+  // Watchdog that dumps thread stacks to the log when the queue of a registered RPC service
+  // stays at or above a configured threshold. See service_queue_monitor.h.
+  std::unique_ptr<ServiceQueueMonitor> service_queue_monitor_ GUARDED_BY(lock_);
+
   std::unique_ptr<CallStateListenerFactory> call_state_listener_factory_;
   std::unique_ptr<MetadataSerializerFactory> metadata_serializer_factory_;
 

--- a/src/yb/rpc/mt-rpc-test.cc
+++ b/src/yb/rpc/mt-rpc-test.cc
@@ -43,12 +43,17 @@
 #include "yb/rpc/yb_rpc.h"
 
 #include "yb/util/countdown_latch.h"
+#include "yb/util/logging_test_util.h"
 #include "yb/util/metrics.h"
 #include "yb/util/net/net_util.h"
 #include "yb/util/status_log.h"
 #include "yb/util/test_macros.h"
 #include "yb/util/test_util.h"
 #include "yb/util/thread.h"
+
+DECLARE_int32(rpc_queue_stack_dump_min_polls);
+DECLARE_int32(rpc_queue_stack_dump_poll_interval_ms);
+DECLARE_int64(rpc_queue_stack_dump_threshold);
 
 METRIC_DECLARE_counter(rpc_connections_accepted);
 METRIC_DECLARE_counter(rpcs_queue_overflow);
@@ -96,7 +101,106 @@ class MultiThreadedRpcTest : public RpcTestBase {
       }
     }
   }
+
+  // Starts a server whose only service has a tiny queue served by a worker pool with no workers,
+  // then saturates it so that the service queue depth stays at its maximum until shutdown. When
+  // enabled is true, verifies that the RPC queue depth monitor dumps thread stacks to the log
+  // and that repeated dumps are suppressed with an exponentially growing backoff. When enabled
+  // is false, verifies that no dump is produced while the queue stays full.
+  void VerifyQueueStackDump(bool enabled);
 };
+
+void MultiThreadedRpcTest::VerifyQueueStackDump(bool enabled) {
+  const size_t kMaxConcurrency = 2;
+
+  // Register the log sinks before the monitor has any chance to log.
+  StringWaiterLogSink dump_sink("Dumping thread stacks");
+  StringWaiterLogSink stacks_sink("thread(s) with stack");
+  // With a 100 ms poll interval and 2 consecutive polls required, the suppression interval is
+  // 200 ms after the first dump and doubles to 400 ms after the second one.
+  StringWaiterLogSink first_dump_sink("Suppressing further dumps for 200 ms.");
+  StringWaiterLogSink second_dump_sink("Suppressing further dumps for 400 ms.");
+
+  // The monitor thread starts when the service is registered below, so it is safe to assign
+  // the flags directly here.
+  FLAGS_rpc_queue_stack_dump_poll_interval_ms = 100;
+  FLAGS_rpc_queue_stack_dump_min_polls = 2;
+  if (enabled) {
+    FLAGS_rpc_queue_stack_dump_threshold = 1;
+  }
+
+  MessengerBuilder bld("messenger1");
+  bld.set_num_reactors(kMaxConcurrency);
+  bld.set_metric_entity(metric_entity());
+  std::unique_ptr<Messenger> server_messenger = ASSERT_RESULT(bld.Build());
+
+  Endpoint server_addr;
+  ASSERT_OK(server_messenger->ListenAddress(
+      CreateConnectionContextFactory<YBInboundConnectionContext>(),
+      Endpoint(), &server_addr));
+
+  std::unique_ptr<ServiceIf> service(new GenericCalculatorService());
+  auto service_name = service->service_name();
+  ThreadPoolPtr thread_pool = std::make_shared<ThreadPool>(
+      ThreadPoolOptions {
+        .name = "bogus_pool",
+        .max_workers = 0
+      });
+  scoped_refptr<ServicePool> service_pool(new ServicePool(
+      kMaxConcurrency, [thread_pool](auto) { return thread_pool; },
+      &server_messenger->scheduler(), std::move(service), metric_entity()));
+  ASSERT_OK(server_messenger->RegisterService(service_name, service_pool));
+  ASSERT_OK(server_messenger->StartAcceptor());
+
+  // Two calls get stuck in the service queue forever because the worker pool has no workers,
+  // and the third one fails immediately due to queue overflow, which counts down the latch.
+  // From that point the service queue depth stays at kMaxConcurrency until shutdown.
+  scoped_refptr<yb::Thread> threads[3];
+  Status status[3];
+  CountDownLatch latch(1);
+  for (int i = 0; i < 3; i++) {
+    ASSERT_OK(yb::Thread::Create("test", strings::Substitute("t$0", i),
+      &MultiThreadedRpcTest::SingleCall, this, HostPort::FromBoundEndpoint(server_addr),
+      CalculatorServiceMethods::AddMethod(), &status[i], &latch, &threads[i]));
+  }
+  latch.Wait();
+
+  if (enabled) {
+    ASSERT_OK(first_dump_sink.WaitFor(MonoDelta::FromSeconds(60)));
+    ASSERT_OK(stacks_sink.WaitFor(MonoDelta::FromSeconds(60)));
+    // The queue stays over the threshold, so the monitor keeps dumping, with a doubled
+    // suppression interval.
+    ASSERT_OK(second_dump_sink.WaitFor(MonoDelta::FromSeconds(60)));
+    ASSERT_GE(dump_sink.GetEventCount(), 2);
+  } else {
+    // Give the monitor ample time to poll the full queue.
+    SleepFor(MonoDelta::FromSeconds(2));
+    ASSERT_EQ(dump_sink.GetEventCount(), 0);
+    ASSERT_EQ(stacks_sink.GetEventCount(), 0);
+  }
+
+  server_messenger->UnregisterAllServices();
+  service_pool->Shutdown();
+  thread_pool->Shutdown();
+  server_messenger->Shutdown();
+
+  for (const auto& thread : threads) {
+    ASSERT_OK(ThreadJoiner(thread.get()).warn_every(500ms).Join());
+  }
+}
+
+// Test that sustained RPC service queue buildup triggers a thread stack dump in the log when
+// rpc_queue_stack_dump_threshold is set, and that repeated dumps are suppressed with an
+// exponential backoff.
+TEST_F(MultiThreadedRpcTest, QueueStackDumpOnSustainedQueueBuildup) {
+  VerifyQueueStackDump(/* enabled= */ true);
+}
+
+// Test that no thread stack dump is produced on sustained RPC service queue buildup while
+// rpc_queue_stack_dump_threshold is left at its default of 0 (disabled).
+TEST_F(MultiThreadedRpcTest, NoQueueStackDumpWhenDisabled) {
+  VerifyQueueStackDump(/* enabled= */ false);
+}
 
 static void AssertShutdown(yb::Thread* thread, const Status* status) {
   ASSERT_OK(ThreadJoiner(thread).warn_every(500ms).Join());

--- a/src/yb/rpc/mt-rpc-test.cc
+++ b/src/yb/rpc/mt-rpc-test.cc
@@ -30,6 +30,7 @@
 // under the License.
 //
 
+#include <algorithm>
 #include <string>
 
 #include <gtest/gtest.h>
@@ -42,16 +43,21 @@
 #include "yb/rpc/rpc_controller.h"
 #include "yb/rpc/yb_rpc.h"
 
+#include "yb/util/backoff_waiter.h"
 #include "yb/util/countdown_latch.h"
+#include "yb/util/flags.h"
 #include "yb/util/logging_test_util.h"
 #include "yb/util/metrics.h"
 #include "yb/util/net/net_util.h"
+#include "yb/util/scope_exit.h"
 #include "yb/util/status_log.h"
 #include "yb/util/test_macros.h"
+#include "yb/util/test_thread_holder.h"
 #include "yb/util/test_util.h"
 #include "yb/util/thread.h"
 
-DECLARE_int32(rpc_queue_stack_dump_min_polls);
+DECLARE_int32(rpc_queue_stack_dump_max_interval_ms);
+DECLARE_int32(rpc_queue_stack_dump_min_interval_ms);
 DECLARE_int32(rpc_queue_stack_dump_poll_interval_ms);
 DECLARE_int64(rpc_queue_stack_dump_threshold);
 
@@ -64,6 +70,37 @@ using namespace std::literals;
 
 namespace yb {
 namespace rpc {
+
+class BlockingCalculatorService : public GenericCalculatorService {
+ public:
+  explicit BlockingCalculatorService(size_t num_workers) : workers_blocked_(num_workers) {}
+
+  void Handle(InboundCallPtr incoming) override {
+    workers_blocked_.CountDown();
+    release_workers_.Wait();
+    GenericCalculatorService::Handle(std::move(incoming));
+  }
+
+  bool WaitForWorkers(MonoDelta timeout) const {
+    return workers_blocked_.WaitFor(timeout);
+  }
+
+  void ReleaseWorkers() {
+    release_workers_.CountDown();
+  }
+
+ private:
+  CountDownLatch workers_blocked_;
+  CountDownLatch release_workers_{1};
+};
+
+class QueueSizeRpcService : public RpcService {
+ public:
+  void FillEndpoints(RpcEndpointMap*) override {}
+  void Process(InboundCallPtr, Queue) override {}
+  void StartShutdown() override {}
+  void CompleteShutdown() override {}
+};
 
 class MultiThreadedRpcTest : public RpcTestBase {
  public:
@@ -102,36 +139,39 @@ class MultiThreadedRpcTest : public RpcTestBase {
     }
   }
 
-  // Starts a server whose only service has a tiny queue served by a worker pool with no workers,
-  // then saturates it so that the service queue depth stays at its maximum until shutdown. When
-  // enabled is true, verifies that the RPC queue depth monitor dumps thread stacks to the log
-  // and that repeated dumps are suppressed with an exponentially growing backoff. When enabled
-  // is false, verifies that no dump is produced while the queue stays full.
-  void VerifyQueueStackDump(bool enabled);
+  // Blocks all RPC workers, fills the service queue, and verifies the queue monitor behavior.
+  void VerifyQueueStackDump(bool enabled, bool enable_after_queue_buildup = false);
 };
 
-void MultiThreadedRpcTest::VerifyQueueStackDump(bool enabled) {
-  const size_t kMaxConcurrency = 2;
+void MultiThreadedRpcTest::VerifyQueueStackDump(bool enabled, bool enable_after_queue_buildup) {
+  constexpr size_t kNumWorkers = 2;
+  constexpr size_t kQueueSize = 2;
+  constexpr size_t kNumCalls = kNumWorkers + kQueueSize;
 
   // Register the log sinks before the monitor has any chance to log.
   StringWaiterLogSink dump_sink("Dumping thread stacks");
+  StringWaiterLogSink fallback_sink("falling back to all managed threads");
   StringWaiterLogSink stacks_sink("thread(s) with stack");
-  // With a 100 ms poll interval and 2 consecutive polls required, the suppression interval is
-  // 200 ms after the first dump and doubles to 400 ms after the second one.
-  StringWaiterLogSink first_dump_sink("Suppressing further dumps for 200 ms.");
-  StringWaiterLogSink second_dump_sink("Suppressing further dumps for 400 ms.");
+  RegexWaiterLogSink worker_stacks_sink(
+      "[\\s\\S]*2 thread\\(s\\) with stack \\["
+      "(messenger1_1_worker-[0-9]+, messenger1_2_worker-[0-9]+|"
+      "messenger1_2_worker-[0-9]+, messenger1_1_worker-[0-9]+)"
+      "\\]:[\\s\\S]*");
+  RegexWaiterLogSink first_dump_sink(
+      "[\\s\\S]*Suppressing further dumps for (2[0-4][0-9]|250) ms\\.[\\s\\S]*");
+  RegexWaiterLogSink second_dump_sink(
+      "[\\s\\S]*Suppressing further dumps for (4[0-4][0-9]|450) ms\\.[\\s\\S]*");
 
-  // The monitor thread starts when the service is registered below, so it is safe to assign
-  // the flags directly here.
-  FLAGS_rpc_queue_stack_dump_poll_interval_ms = 100;
-  FLAGS_rpc_queue_stack_dump_min_polls = 2;
-  if (enabled) {
-    FLAGS_rpc_queue_stack_dump_threshold = 1;
-  }
+  FLAGS_rpc_queue_stack_dump_max_interval_ms = 1000;
+  FLAGS_rpc_queue_stack_dump_min_interval_ms = 200;
+  FLAGS_rpc_queue_stack_dump_poll_interval_ms = 50;
+  FLAGS_rpc_queue_stack_dump_threshold =
+      enabled && !enable_after_queue_buildup ? kQueueSize : 0;
 
   MessengerBuilder bld("messenger1");
-  bld.set_num_reactors(kMaxConcurrency);
+  bld.set_num_reactors(1);
   bld.set_metric_entity(metric_entity());
+  bld.set_thread_pool_options(kNumWorkers);
   std::unique_ptr<Messenger> server_messenger = ASSERT_RESULT(bld.Build());
 
   Endpoint server_addr;
@@ -139,39 +179,51 @@ void MultiThreadedRpcTest::VerifyQueueStackDump(bool enabled) {
       CreateConnectionContextFactory<YBInboundConnectionContext>(),
       Endpoint(), &server_addr));
 
-  std::unique_ptr<ServiceIf> service(new GenericCalculatorService());
+  std::unique_ptr<ServiceIf> service(new BlockingCalculatorService(kNumWorkers));
+  auto* blocking_service = down_cast<BlockingCalculatorService*>(service.get());
   auto service_name = service->service_name();
-  ThreadPoolPtr thread_pool = std::make_shared<ThreadPool>(
-      ThreadPoolOptions {
-        .name = "bogus_pool",
-        .max_workers = 0
-      });
   scoped_refptr<ServicePool> service_pool(new ServicePool(
-      kMaxConcurrency, [thread_pool](auto) { return thread_pool; },
+      kQueueSize,
+      [messenger = server_messenger.get()](auto) {
+        return messenger->ThreadPoolPtr(ServicePriority::kNormal);
+      },
       &server_messenger->scheduler(), std::move(service), metric_entity()));
   ASSERT_OK(server_messenger->RegisterService(service_name, service_pool));
   ASSERT_OK(server_messenger->StartAcceptor());
 
-  // Two calls get stuck in the service queue forever because the worker pool has no workers,
-  // and the third one fails immediately due to queue overflow, which counts down the latch.
-  // From that point the service queue depth stays at kMaxConcurrency until shutdown.
-  scoped_refptr<yb::Thread> threads[3];
-  Status status[3];
-  CountDownLatch latch(1);
-  for (int i = 0; i < 3; i++) {
-    ASSERT_OK(yb::Thread::Create("test", strings::Substitute("t$0", i),
-      &MultiThreadedRpcTest::SingleCall, this, HostPort::FromBoundEndpoint(server_addr),
-      CalculatorServiceMethods::AddMethod(), &status[i], &latch, &threads[i]));
+  TestThreadHolder call_threads;
+  auto release_workers = ScopeExit([blocking_service] { blocking_service->ReleaseWorkers(); });
+  Status statuses[kNumCalls];
+  CountDownLatch calls_done(kNumCalls);
+  const auto host_port = HostPort::FromBoundEndpoint(server_addr);
+  auto start_call = [&](size_t index) {
+    call_threads.AddThread([&, index] {
+      SingleCall(
+          host_port, CalculatorServiceMethods::AddMethod(), &statuses[index], &calls_done);
+    });
+  };
+
+  for (size_t i = 0; i != kNumWorkers; ++i) {
+    start_call(i);
   }
-  latch.Wait();
+  ASSERT_TRUE(blocking_service->WaitForWorkers(MonoDelta::FromSeconds(60)));
+  for (size_t i = kNumWorkers; i != kNumCalls; ++i) {
+    start_call(i);
+  }
+  ASSERT_OK(WaitFor(
+      [&] { return service_pool->QueueSize() == kQueueSize; }, MonoDelta::FromSeconds(60),
+      "RPC service queue to fill"));
+
+  if (enable_after_queue_buildup) {
+    ASSERT_OK(SET_FLAG(rpc_queue_stack_dump_threshold, static_cast<int64_t>(kQueueSize)));
+  }
 
   if (enabled) {
     ASSERT_OK(first_dump_sink.WaitFor(MonoDelta::FromSeconds(60)));
-    ASSERT_OK(stacks_sink.WaitFor(MonoDelta::FromSeconds(60)));
-    // The queue stays over the threshold, so the monitor keeps dumping, with a doubled
-    // suppression interval.
+    ASSERT_OK(worker_stacks_sink.WaitFor(MonoDelta::FromSeconds(60)));
     ASSERT_OK(second_dump_sink.WaitFor(MonoDelta::FromSeconds(60)));
     ASSERT_GE(dump_sink.GetEventCount(), 2);
+    ASSERT_EQ(fallback_sink.GetEventCount(), 0);
   } else {
     // Give the monitor ample time to poll the full queue.
     SleepFor(MonoDelta::FromSeconds(2));
@@ -179,14 +231,13 @@ void MultiThreadedRpcTest::VerifyQueueStackDump(bool enabled) {
     ASSERT_EQ(stacks_sink.GetEventCount(), 0);
   }
 
-  server_messenger->UnregisterAllServices();
-  service_pool->Shutdown();
-  thread_pool->Shutdown();
-  server_messenger->Shutdown();
-
-  for (const auto& thread : threads) {
-    ASSERT_OK(ThreadJoiner(thread.get()).warn_every(500ms).Join());
+  blocking_service->ReleaseWorkers();
+  ASSERT_TRUE(calls_done.WaitFor(MonoDelta::FromSeconds(60)));
+  call_threads.JoinAll();
+  for (const auto& status : statuses) {
+    ASSERT_OK(status);
   }
+  server_messenger->Shutdown();
 }
 
 // Test that sustained RPC service queue buildup triggers a thread stack dump in the log when
@@ -200,6 +251,30 @@ TEST_F(MultiThreadedRpcTest, QueueStackDumpOnSustainedQueueBuildup) {
 // rpc_queue_stack_dump_threshold is left at its default of 0 (disabled).
 TEST_F(MultiThreadedRpcTest, NoQueueStackDumpWhenDisabled) {
   VerifyQueueStackDump(/* enabled= */ false);
+}
+
+TEST_F(MultiThreadedRpcTest, QueueStackDumpCanBeEnabledAtRuntime) {
+  VerifyQueueStackDump(/* enabled= */ true, /* enable_after_queue_buildup= */ true);
+}
+
+TEST_F(MultiThreadedRpcTest, QueueStackDumpUsesOneProcessGlobalMonitor) {
+  std::unique_ptr<Messenger> messenger1 = ASSERT_RESULT(MessengerBuilder("messenger1").Build());
+  std::unique_ptr<Messenger> messenger2 = ASSERT_RESULT(MessengerBuilder("messenger2").Build());
+  auto shutdown = ScopeExit([&] {
+    messenger1->Shutdown();
+    messenger2->Shutdown();
+  });
+
+  ASSERT_OK(messenger1->RegisterService("service1", RpcServicePtr(new QueueSizeRpcService)));
+  ASSERT_OK(messenger2->RegisterService("service2", RpcServicePtr(new QueueSizeRpcService)));
+  ASSERT_OK(WaitFor(
+      [] {
+        const auto threads = ListThreadsForStackTrace();
+        return std::count_if(threads.begin(), threads.end(), [](const auto& thread) {
+          return thread.category == "rpc_queue";
+        }) == 1;
+      },
+      MonoDelta::FromSeconds(60), "single process-wide RPC queue monitor"));
 }
 
 static void AssertShutdown(yb::Thread* thread, const Status* status) {

--- a/src/yb/rpc/rpc_fwd.h
+++ b/src/yb/rpc/rpc_fwd.h
@@ -83,6 +83,7 @@ class Rpcs;
 class Scheduler;
 class SecureContext;
 class ServicePoolImpl;
+class ServiceQueueMonitor;
 class Sidecars;
 class Stream;
 class StreamReadBuffer;

--- a/src/yb/rpc/rpc_service.h
+++ b/src/yb/rpc/rpc_service.h
@@ -58,9 +58,9 @@ class RpcService : public RefCountedThreadSafe<RpcService> {
   // Wait until RPC sevrice shutdown completes.
   virtual void CompleteShutdown() = 0;
 
-  // Returns the number of calls currently queued for processing by this service.
-  // Services that do not maintain a queue report 0.
-  virtual size_t QueuedCalls() const { return 0; }
+  // Returns a best-effort snapshot of calls admitted to this service whose processing has not
+  // started. Actively executing calls are excluded. Services that do not maintain a queue report 0.
+  virtual size_t QueueSize() const { return 0; }
 
   void Shutdown() {
     StartShutdown();

--- a/src/yb/rpc/rpc_service.h
+++ b/src/yb/rpc/rpc_service.h
@@ -31,6 +31,8 @@
 //
 #pragma once
 
+#include <stddef.h>
+
 #include "yb/rpc/rpc_fwd.h"
 
 namespace yb {
@@ -55,6 +57,10 @@ class RpcService : public RefCountedThreadSafe<RpcService> {
 
   // Wait until RPC sevrice shutdown completes.
   virtual void CompleteShutdown() = 0;
+
+  // Returns the number of calls currently queued for processing by this service.
+  // Services that do not maintain a queue report 0.
+  virtual size_t QueuedCalls() const { return 0; }
 
   void Shutdown() {
     StartShutdown();

--- a/src/yb/rpc/service_pool.cc
+++ b/src/yb/rpc/service_pool.cc
@@ -206,7 +206,7 @@ class ServicePoolImpl final : public InboundCallHandler {
     thread_pool->Enqueue(task);
   }
 
-  size_t QueuedCalls() const {
+  size_t QueueSize() const {
     return static_cast<size_t>(
         std::max<int64_t>(queued_calls_.load(std::memory_order_relaxed), 0));
   }
@@ -505,8 +505,8 @@ void ServicePool::FillEndpoints(RpcEndpointMap* map) {
   impl_->FillEndpoints(RpcServicePtr(this), map);
 }
 
-size_t ServicePool::QueuedCalls() const {
-  return impl_->QueuedCalls();
+size_t ServicePool::QueueSize() const {
+  return impl_->QueueSize();
 }
 
 const Counter* ServicePool::RpcsTimedOutInQueueMetricForTests() const {

--- a/src/yb/rpc/service_pool.cc
+++ b/src/yb/rpc/service_pool.cc
@@ -35,6 +35,7 @@
 #include <pthread.h>
 #include <sys/types.h>
 
+#include <algorithm>
 #include <functional>
 #include <memory>
 #include <queue>
@@ -203,6 +204,11 @@ class ServicePoolImpl final : public InboundCallHandler {
     }
 
     thread_pool->Enqueue(task);
+  }
+
+  size_t QueuedCalls() const {
+    return static_cast<size_t>(
+        std::max<int64_t>(queued_calls_.load(std::memory_order_relaxed), 0));
   }
 
   const Counter* RpcsTimedOutInQueueMetricForTests() const {
@@ -497,6 +503,10 @@ void ServicePool::Process(InboundCallPtr call, Queue queue) {
 
 void ServicePool::FillEndpoints(RpcEndpointMap* map) {
   impl_->FillEndpoints(RpcServicePtr(this), map);
+}
+
+size_t ServicePool::QueuedCalls() const {
+  return impl_->QueuedCalls();
 }
 
 const Counter* ServicePool::RpcsTimedOutInQueueMetricForTests() const {

--- a/src/yb/rpc/service_pool.h
+++ b/src/yb/rpc/service_pool.h
@@ -79,6 +79,7 @@ class ServicePool : public RpcService {
 
   void FillEndpoints(RpcEndpointMap* map) override;
   void Process(InboundCallPtr call, Queue queue) override;
+  size_t QueuedCalls() const override;
   const Counter* RpcsTimedOutInQueueMetricForTests() const;
   const Counter* RpcsQueueOverflowMetric() const;
   std::string service_name() const;

--- a/src/yb/rpc/service_pool.h
+++ b/src/yb/rpc/service_pool.h
@@ -79,7 +79,7 @@ class ServicePool : public RpcService {
 
   void FillEndpoints(RpcEndpointMap* map) override;
   void Process(InboundCallPtr call, Queue queue) override;
-  size_t QueuedCalls() const override;
+  size_t QueueSize() const override;
   const Counter* RpcsTimedOutInQueueMetricForTests() const;
   const Counter* RpcsQueueOverflowMetric() const;
   std::string service_name() const;

--- a/src/yb/rpc/service_queue_monitor.cc
+++ b/src/yb/rpc/service_queue_monitor.cc
@@ -18,8 +18,11 @@
 #include <chrono>
 #include <condition_variable>
 #include <map>
+#include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -27,20 +30,22 @@
 
 #include "yb/rpc/rpc_service.h"
 
+#include "yb/util/backoff_waiter.h"
 #include "yb/util/flags.h"
+#include "yb/util/format.h"
 #include "yb/util/logging.h"
 #include "yb/util/monotime.h"
+#include "yb/util/scope_exit.h"
 #include "yb/util/stack_trace.h"
-#include "yb/util/status_log.h"
 #include "yb/util/thread.h"
 
 using namespace std::literals;
 
 DEFINE_RUNTIME_int64(rpc_queue_stack_dump_threshold, 0,
-    "If greater than 0, dump the stacks of all threads to the log when the queue of any RPC "
-    "service stays at or above this many calls for rpc_queue_stack_dump_min_polls consecutive "
-    "polls. Helps diagnosing why RPC worker threads are not draining the service queues. "
-    "0 disables the RPC queue depth monitor.");
+    "If greater than 0, dump RPC worker thread stacks to the log when the queue of any RPC "
+    "service stays at or above this many calls for rpc_queue_stack_dump_min_interval_ms. Helps "
+    "diagnosing why RPC worker threads are not draining the service queues. 0 disables the RPC "
+    "queue depth monitor.");
 TAG_FLAG(rpc_queue_stack_dump_threshold, advanced);
 
 DEFINE_RUNTIME_int32(rpc_queue_stack_dump_poll_interval_ms, 1000,
@@ -48,147 +53,336 @@ DEFINE_RUNTIME_int32(rpc_queue_stack_dump_poll_interval_ms, 1000,
     "is enabled via rpc_queue_stack_dump_threshold.");
 TAG_FLAG(rpc_queue_stack_dump_poll_interval_ms, advanced);
 
-DEFINE_RUNTIME_int32(rpc_queue_stack_dump_min_polls, 3,
-    "Number of consecutive polls for which an RPC service queue has to stay at or above "
-    "rpc_queue_stack_dump_threshold before thread stacks are dumped to the log.");
-TAG_FLAG(rpc_queue_stack_dump_min_polls, advanced);
+DEFINE_RUNTIME_int32(rpc_queue_stack_dump_min_interval_ms, 10000,
+    "Minimum time (in ms) for which an RPC service queue has to stay at or above "
+    "rpc_queue_stack_dump_threshold before thread stacks are dumped. This is also the initial "
+    "interval between repeated dumps while the condition persists.");
+TAG_FLAG(rpc_queue_stack_dump_min_interval_ms, advanced);
 
-DEFINE_RUNTIME_int32(rpc_queue_stack_dump_max_backoff_ms, 300000,
+DEFINE_RUNTIME_int32(rpc_queue_stack_dump_max_interval_ms, 300000,
     "Maximum interval (in ms) between consecutive thread stack dumps while an RPC service "
     "queue stays at or above rpc_queue_stack_dump_threshold. Repeated dumps are suppressed "
     "with an exponential backoff capped at this interval; the backoff resets once the queue "
     "drains below the threshold.");
-TAG_FLAG(rpc_queue_stack_dump_max_backoff_ms, advanced);
+TAG_FLAG(rpc_queue_stack_dump_max_interval_ms, advanced);
 
 namespace yb::rpc {
 
 namespace {
 
 constexpr int32_t kMinPollIntervalMs = 10;
-
-// Maximum number of thread names listed per group of threads sharing the same stack.
 constexpr size_t kMaxThreadNamesPerGroup = 10;
+constexpr size_t kMaxServicesInSummary = 10;
 
-// Guards against multiple messengers in the same process (e.g. a tablet server and its CQL
-// proxy) dumping thread stacks back to back for the same overload event.
-std::mutex global_dump_time_mutex;
-CoarseTimePoint global_last_dump_time;
-
-bool ShouldSkipDumpGlobally(CoarseTimePoint now, CoarseMonoClock::Duration min_gap) {
-  std::lock_guard lock(global_dump_time_mutex);
-  if (global_last_dump_time != CoarseTimePoint() && now < global_last_dump_time + min_gap) {
-    return true;
-  }
-  global_last_dump_time = now;
-  return false;
-}
+std::atomic<uint64_t> next_monitor_owner_id{1};
 
 }  // namespace
 
 class ServiceQueueMonitor::Impl {
  public:
-  explicit Impl(const std::string& name) : name_(name) {}
+  ~Impl() {
+    Shutdown();
+  }
+
+  void Track(
+      uint64_t owner_id, const std::string& messenger_name, const std::string& service_name,
+      const RpcServicePtr& service, ServicePriority priority) {
+    std::lock_guard lock(mutex_);
+    if (stop_.load(std::memory_order_acquire)) {
+      return;
+    }
+    services_.push_back(TrackedService {
+      .owner_id = owner_id,
+      .messenger_name = messenger_name,
+      .service_name = service_name,
+      .priority = priority,
+      .service = service,
+      .above_threshold_since = CoarseTimePoint(),
+    });
+    if (!thread_) {
+      auto thread = Thread::Make(
+          "rpc_queue", "rpc_queue_monitor", [this] { Execute(); });
+      if (!thread.ok()) {
+        YB_LOG_EVERY_N_SECS(WARNING, 30)
+            << "Failed to start RPC service queue monitor: " << thread.status();
+        return;
+      }
+      thread_ = *thread;
+    }
+    cond_.notify_one();
+  }
+
+  void Untrack(uint64_t owner_id) {
+    std::lock_guard lock(mutex_);
+    std::erase_if(services_, [owner_id](const auto& service) {
+      return service.owner_id == owner_id;
+    });
+    const auto active_owner =
+        std::find(active_dump_owner_ids_.begin(), active_dump_owner_ids_.end(), owner_id);
+    if (active_owner != active_dump_owner_ids_.end()) {
+      active_dump_owner_ids_.erase(active_owner);
+      if (active_dump_owner_ids_.empty()) {
+        cancel_dump_.store(true, std::memory_order_release);
+      }
+    }
+    cond_.notify_one();
+  }
+
+ private:
+  struct TrackedService {
+    uint64_t owner_id;
+    std::string messenger_name;
+    std::string service_name;
+    ServicePriority priority;
+    RpcServicePtr service;
+    CoarseTimePoint above_threshold_since;
+  };
+
+  struct AffectedService {
+    uint64_t owner_id;
+    std::string messenger_name;
+    std::string service_name;
+    ServicePriority priority;
+    size_t depth;
+    CoarseDuration above_threshold_for;
+    bool triggers_dump;
+  };
+
+  struct TriggerEvaluation {
+    std::vector<AffectedService> affected_services;
+    bool should_dump = false;
+  };
 
   void Shutdown() {
     ThreadPtr thread;
     {
       std::lock_guard lock(mutex_);
       stop_.store(true, std::memory_order_release);
+      cancel_dump_.store(true, std::memory_order_release);
       cond_.notify_one();
-      if (!thread_) {
-        return;
-      }
-      thread = thread_;
+      thread = std::exchange(thread_, ThreadPtr());
     }
-    thread->Join();
-  }
-
-  void Track(const std::string& service_name, const RpcServicePtr& service) {
-    std::lock_guard lock(mutex_);
-    if (stop_.load(std::memory_order_acquire)) {
-      return;
-    }
-    services_.emplace_back(service_name, service);
-    if (!thread_) {
-      thread_ = CHECK_RESULT(Thread::Make(
-          name_ + "_rpc_queue", name_ + "_rpc_queue_monitor", [this] { Execute(); }));
+    if (thread) {
+      thread->Join();
     }
   }
 
- private:
   void Execute() {
     std::unique_lock lock(mutex_);
     while (!stop_.load(std::memory_order_acquire)) {
-      auto poll_interval_ms = std::max(
-          FLAGS_rpc_queue_stack_dump_poll_interval_ms, kMinPollIntervalMs);
-      cond_.wait_for(lock, std::chrono::milliseconds(poll_interval_ms));
+      const auto poll_interval = std::chrono::milliseconds(
+          std::max(FLAGS_rpc_queue_stack_dump_poll_interval_ms, kMinPollIntervalMs));
+      auto wait_duration = CoarseDuration(poll_interval);
+      if (next_dump_time_ != CoarseTimePoint()) {
+        const auto now = CoarseMonoClock::Now();
+        wait_duration = next_dump_time_ <= now
+            ? CoarseDuration::zero()
+            : std::min(wait_duration, next_dump_time_ - now);
+      }
+      if (wait_duration > CoarseDuration::zero()) {
+        cond_.wait_for(lock, wait_duration);
+      }
       if (stop_.load(std::memory_order_acquire)) {
         break;
       }
-      auto threshold = FLAGS_rpc_queue_stack_dump_threshold;
+
+      const auto threshold = FLAGS_rpc_queue_stack_dump_threshold;
       if (threshold <= 0) {
-        ResetPollState();
+        ResetTriggerState();
+        ResetDumpState();
+        last_threshold_ = threshold;
         continue;
       }
-      size_t max_depth = 0;
-      const std::string* worst_service = nullptr;
-      for (const auto& [service_name, service] : services_) {
-        auto depth = service->QueuedCalls();
-        if (worst_service == nullptr || depth > max_depth) {
-          max_depth = depth;
-          worst_service = &service_name;
-        }
+
+      if (threshold != last_threshold_) {
+        ResetTriggerState();
+        ResetDumpState();
+        last_threshold_ = threshold;
       }
-      if (worst_service == nullptr || max_depth < static_cast<size_t>(threshold)) {
-        ResetPollState();
+
+      const auto min_interval = CoarseDuration(std::chrono::milliseconds(
+          std::max(FLAGS_rpc_queue_stack_dump_min_interval_ms, 1)));
+      const auto max_interval = std::max(
+          CoarseDuration(std::chrono::milliseconds(
+              std::max(FLAGS_rpc_queue_stack_dump_max_interval_ms, 1))),
+          min_interval);
+      const auto now = CoarseMonoClock::Now();
+      auto evaluation = CheckTriggersForDump(now, threshold, min_interval);
+      if (!evaluation.should_dump) {
+        ResetDumpState();
         continue;
       }
-      if (++consecutive_polls_over_threshold_ <
-              std::max(FLAGS_rpc_queue_stack_dump_min_polls, 1)) {
-        continue;
-      }
-      auto now = CoarseMonoClock::Now();
-      if (next_dump_time_ != CoarseTimePoint() && now < next_dump_time_) {
-        continue;
-      }
-      if (ShouldSkipDumpGlobally(now, poll_interval_ms * 1ms)) {
-        continue;
-      }
-      auto max_backoff_ms = std::max<int64_t>(
-          FLAGS_rpc_queue_stack_dump_max_backoff_ms, poll_interval_ms);
-      suppress_ms_ = suppress_ms_ == 0
-          ? static_cast<int64_t>(poll_interval_ms) *
-                std::max(FLAGS_rpc_queue_stack_dump_min_polls, 1)
-          : std::min(suppress_ms_ * 2, max_backoff_ms);
-      next_dump_time_ = now + suppress_ms_ * 1ms;
-      // Copy what the dump needs, then release the lock so that Track and Shutdown are not
-      // blocked while stacks are being collected.
-      auto service_name = *worst_service;
-      auto consecutive_polls = consecutive_polls_over_threshold_;
-      auto suppress_ms = suppress_ms_;
-      lock.unlock();
-      DumpThreadStacks(service_name, max_depth, threshold, consecutive_polls, suppress_ms);
-      lock.lock();
+      MaybeDump(lock, now, threshold, min_interval, max_interval, std::move(evaluation));
     }
   }
 
-  void ResetPollState() {
-    consecutive_polls_over_threshold_ = 0;
-    suppress_ms_ = 0;
+  TriggerEvaluation CheckTriggersForDump(
+      CoarseTimePoint now, int64_t threshold, CoarseDuration min_interval) {
+    TriggerEvaluation result;
+    result.affected_services.reserve(services_.size());
+    for (auto& service : services_) {
+      const auto depth = service.service->QueueSize();
+      if (depth < static_cast<size_t>(threshold)) {
+        service.above_threshold_since = CoarseTimePoint();
+        continue;
+      }
+      if (service.above_threshold_since == CoarseTimePoint()) {
+        service.above_threshold_since = now;
+      }
+      const auto above_threshold_for = now - service.above_threshold_since;
+      const auto triggers_dump = above_threshold_for >= min_interval;
+      result.should_dump = result.should_dump || triggers_dump;
+      result.affected_services.push_back(AffectedService {
+        .owner_id = service.owner_id,
+        .messenger_name = service.messenger_name,
+        .service_name = service.service_name,
+        .priority = service.priority,
+        .depth = depth,
+        .above_threshold_for = above_threshold_for,
+        .triggers_dump = triggers_dump,
+      });
+    }
+    std::sort(
+        result.affected_services.begin(), result.affected_services.end(),
+        [](const auto& lhs, const auto& rhs) {
+          if (lhs.triggers_dump != rhs.triggers_dump) {
+            return lhs.triggers_dump > rhs.triggers_dump;
+          }
+          if (lhs.depth != rhs.depth) {
+            return lhs.depth > rhs.depth;
+          }
+          return std::tie(lhs.messenger_name, lhs.service_name) <
+                 std::tie(rhs.messenger_name, rhs.service_name);
+        });
+    return result;
+  }
+
+  void MaybeDump(
+      std::unique_lock<std::mutex>& lock, CoarseTimePoint now, int64_t threshold,
+      CoarseDuration min_interval, CoarseDuration max_interval,
+      TriggerEvaluation evaluation) {
+    if (!backoff_) {
+      backoff_.emplace(
+          CoarseTimePoint::max(), max_interval, min_interval,
+          CoarseBackoffWaiter::kDefaultMaxJitterMs, /* init_exponent= */ 1);
+      next_dump_time_ = CoarseTimePoint();
+    }
+    if (next_dump_time_ != CoarseTimePoint() && now < next_dump_time_) {
+      return;
+    }
+
+    const auto suppress_for = backoff_->DelayForTime(now);
+    if (suppress_for < max_interval) {
+      backoff_->NextAttempt();
+    }
+    next_dump_time_ = now + suppress_for;
+    const auto dump_id = next_dump_id_++;
+    active_dump_owner_ids_.clear();
+    for (const auto& service : evaluation.affected_services) {
+      if (service.triggers_dump &&
+          std::find(
+              active_dump_owner_ids_.begin(), active_dump_owner_ids_.end(), service.owner_id) ==
+              active_dump_owner_ids_.end()) {
+        active_dump_owner_ids_.push_back(service.owner_id);
+      }
+    }
+    cancel_dump_.store(false, std::memory_order_release);
+    lock.unlock();
+    const auto dump_completed = DumpThreadStacks(dump_id, threshold, suppress_for, evaluation);
+    lock.lock();
+    active_dump_owner_ids_.clear();
+    if (!dump_completed) {
+      ResetDumpState();
+    }
+  }
+
+  void ResetTriggerState() {
+    for (auto& service : services_) {
+      service.above_threshold_since = CoarseTimePoint();
+    }
+  }
+
+  void ResetDumpState() {
+    backoff_.reset();
     next_dump_time_ = CoarseTimePoint();
   }
 
-  void DumpThreadStacks(
-      const std::string& service_name, size_t depth, int64_t threshold, int32_t consecutive_polls,
-      int64_t suppress_ms) {
-    LOG(WARNING) << name_ << ": RPC service queue for " << service_name << " has " << depth
-                 << " queued calls, at or above threshold " << threshold << " for "
-                 << consecutive_polls << " consecutive polls. Dumping thread stacks. "
-                 << "Suppressing further dumps for " << suppress_ms << " ms.";
-    auto threads = ListThreadsForStackTrace();
-    if (threads.empty()) {
-      return;
+  bool DumpCancelled() const {
+    return stop_.load(std::memory_order_acquire) ||
+           cancel_dump_.load(std::memory_order_acquire);
+  }
+
+  bool IsRelevantThreadCategory(
+      const std::string& category, const TriggerEvaluation& evaluation) const {
+    for (const auto& service : evaluation.affected_services) {
+      if (service.priority == ServicePriority::kHigh) {
+        if (category == service.messenger_name + "-high-pri") {
+          return true;
+        }
+      } else if (category == service.messenger_name ||
+                 category.starts_with(service.messenger_name + "_pool_")) {
+        return true;
+      }
     }
+    return false;
+  }
+
+  bool DumpThreadStacks(
+      uint64_t dump_id, int64_t threshold, CoarseDuration suppress_for,
+      const TriggerEvaluation& evaluation) {
+    const auto start = MonoTime::Now();
+    size_t thread_count = 0;
+    size_t group_count = 0;
+    const char* outcome = "completed";
+    auto log_completion = ScopeExit([&] {
+      LOG(WARNING) << "RPC queue stack dump " << dump_id << " " << outcome << " in "
+                   << (MonoTime::Now() - start).ToMilliseconds() << " ms; threads=" << thread_count
+                   << ", groups=" << group_count << ".";
+    });
+    if (DumpCancelled()) {
+      outcome = "cancelled";
+      return false;
+    }
+
+    std::vector<std::string> service_summaries;
+    service_summaries.reserve(std::min(evaluation.affected_services.size(), kMaxServicesInSummary));
+    for (size_t i = 0;
+         i != std::min(evaluation.affected_services.size(), kMaxServicesInSummary); ++i) {
+      const auto& service = evaluation.affected_services[i];
+      service_summaries.push_back(Format(
+          "$0/$1 depth=$2 duration_ms=$3$4", service.messenger_name, service.service_name,
+          service.depth, ToMilliseconds(service.above_threshold_for),
+          service.triggers_dump ? " (triggered)" : ""));
+    }
+    const auto omitted = evaluation.affected_services.size() - service_summaries.size();
+    LOG(WARNING) << "RPC queue stack dump " << dump_id << ": "
+                 << evaluation.affected_services.size()
+                 << " service queue(s) at or above threshold " << threshold << " ["
+                 << JoinStrings(service_summaries, ", ") << "]"
+                 << (omitted ? Format("; $0 additional service(s) omitted", omitted) : "")
+                 << ". Dumping thread stacks. Suppressing further dumps for "
+                 << ToMilliseconds(suppress_for) << " ms.";
+
+    auto all_threads = ListThreadsForStackTrace();
+    std::vector<ThreadIdAndName> threads;
+    threads.reserve(all_threads.size());
+    for (auto& thread : all_threads) {
+      if (IsRelevantThreadCategory(thread.category, evaluation)) {
+        threads.push_back(std::move(thread));
+      }
+    }
+    if (threads.empty() && !all_threads.empty()) {
+      LOG(WARNING) << "RPC queue stack dump " << dump_id
+                   << ": no matching RPC worker thread categories; falling back to all managed "
+                      "threads.";
+      threads = std::move(all_threads);
+    }
+    thread_count = threads.size();
+    if (threads.empty() || DumpCancelled()) {
+      outcome = DumpCancelled() ? "cancelled" : "completed";
+      return !DumpCancelled();
+    }
+
     std::sort(threads.begin(), threads.end(), [](const auto& lhs, const auto& rhs) {
       return lhs.tid_for_stack < rhs.tid_for_stack;
     });
@@ -197,7 +391,15 @@ class ServiceQueueMonitor::Impl {
     for (const auto& thread : threads) {
       tids.push_back(thread.tid_for_stack);
     }
+    if (DumpCancelled()) {
+      outcome = "cancelled";
+      return false;
+    }
     auto stacks = ThreadStacks(tids);
+    if (DumpCancelled()) {
+      outcome = "cancelled";
+      return false;
+    }
     // Group threads that share the same stack (or the same collection failure), so that each
     // stack is symbolized and logged only once.
     struct Group {
@@ -209,7 +411,13 @@ class ServiceQueueMonitor::Impl {
                                 : "!" + stacks[i].status().ToString();
       groups[std::move(key)].thread_indexes.push_back(i);
     }
+    group_count = groups.size();
+    size_t group_index = 0;
     for (const auto& [_, group] : groups) {
+      if (DumpCancelled()) {
+        outcome = "cancelled";
+        return false;
+      }
       const auto& stack = stacks[group.thread_indexes.front()];
       std::vector<std::string> names;
       names.reserve(std::min(group.thread_indexes.size(), kMaxThreadNamesPerGroup + 1));
@@ -220,44 +428,65 @@ class ServiceQueueMonitor::Impl {
         }
         names.push_back(threads[index].name);
       }
-      LOG(WARNING) << name_ << ": " << group.thread_indexes.size() << " thread(s) with stack ["
-                   << JoinStrings(names, ", ") << "]:\n"
+      LOG(WARNING) << "RPC queue stack dump " << dump_id << ", group " << ++group_index << "/"
+                   << groups.size() << ": " << group.thread_indexes.size()
+                   << " thread(s) with stack [" << JoinStrings(names, ", ") << "]:\n"
                    << (stack.ok() ? stack->Symbolize()
                                   : "Failed to collect stack: " + stack.status().ToString());
     }
+    return true;
   }
 
-  const std::string name_;
   std::mutex mutex_;
   std::condition_variable cond_;
   ThreadPtr thread_ GUARDED_BY(mutex_);
   std::atomic<bool> stop_{false};
+  std::atomic<bool> cancel_dump_{false};
   // Guarded by mutex_. Not annotated because Execute accesses it under std::unique_lock, which
   // the thread safety analysis does not track.
-  std::vector<std::pair<std::string, RpcServicePtr>> services_;
+  std::vector<TrackedService> services_;
+  std::vector<uint64_t> active_dump_owner_ids_;
 
   // Poll state below is only accessed by the monitor thread.
-  int32_t consecutive_polls_over_threshold_ = 0;
-  // Interval used to suppress dumps after the most recent one, doubling on every dump up to
-  // FLAGS_rpc_queue_stack_dump_max_backoff_ms. 0 means no dump happened since the monitored
-  // queues were last below the threshold.
-  int64_t suppress_ms_ = 0;
+  int64_t last_threshold_ = 0;
+  std::optional<CoarseBackoffWaiter> backoff_;
   CoarseTimePoint next_dump_time_;
+  uint64_t next_dump_id_ = 1;
 };
 
+std::shared_ptr<ServiceQueueMonitor::Impl> ServiceQueueMonitor::SharedImpl() {
+  static std::mutex mutex;
+  static std::weak_ptr<Impl> weak_impl;
+  std::lock_guard lock(mutex);
+  auto result = weak_impl.lock();
+  if (!result) {
+    result = std::make_shared<Impl>();
+    weak_impl = result;
+  }
+  return result;
+}
+
 ServiceQueueMonitor::ServiceQueueMonitor(const std::string& name)
-    : impl_(std::make_unique<Impl>(name)) {}
+    : name_(name),
+      impl_(SharedImpl()),
+      owner_id_(next_monitor_owner_id.fetch_add(1, std::memory_order_relaxed)) {}
 
 ServiceQueueMonitor::~ServiceQueueMonitor() {
   Shutdown();
 }
 
 void ServiceQueueMonitor::Shutdown() {
-  impl_->Shutdown();
+  if (impl_) {
+    impl_->Untrack(owner_id_);
+    impl_.reset();
+  }
 }
 
-void ServiceQueueMonitor::Track(const std::string& service_name, const RpcServicePtr& service) {
-  impl_->Track(service_name, service);
+void ServiceQueueMonitor::Track(
+    const std::string& service_name, const RpcServicePtr& service, ServicePriority priority) {
+  if (impl_) {
+    impl_->Track(owner_id_, name_, service_name, service, priority);
+  }
 }
 
 }  // namespace yb::rpc

--- a/src/yb/rpc/service_queue_monitor.cc
+++ b/src/yb/rpc/service_queue_monitor.cc
@@ -1,0 +1,263 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/rpc/service_queue_monitor.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <map>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "yb/gutil/strings/join.h"
+
+#include "yb/rpc/rpc_service.h"
+
+#include "yb/util/flags.h"
+#include "yb/util/logging.h"
+#include "yb/util/monotime.h"
+#include "yb/util/stack_trace.h"
+#include "yb/util/status_log.h"
+#include "yb/util/thread.h"
+
+using namespace std::literals;
+
+DEFINE_RUNTIME_int64(rpc_queue_stack_dump_threshold, 0,
+    "If greater than 0, dump the stacks of all threads to the log when the queue of any RPC "
+    "service stays at or above this many calls for rpc_queue_stack_dump_min_polls consecutive "
+    "polls. Helps diagnosing why RPC worker threads are not draining the service queues. "
+    "0 disables the RPC queue depth monitor.");
+TAG_FLAG(rpc_queue_stack_dump_threshold, advanced);
+
+DEFINE_RUNTIME_int32(rpc_queue_stack_dump_poll_interval_ms, 1000,
+    "Interval (in ms) between RPC service queue depth polls, when the RPC queue depth monitor "
+    "is enabled via rpc_queue_stack_dump_threshold.");
+TAG_FLAG(rpc_queue_stack_dump_poll_interval_ms, advanced);
+
+DEFINE_RUNTIME_int32(rpc_queue_stack_dump_min_polls, 3,
+    "Number of consecutive polls for which an RPC service queue has to stay at or above "
+    "rpc_queue_stack_dump_threshold before thread stacks are dumped to the log.");
+TAG_FLAG(rpc_queue_stack_dump_min_polls, advanced);
+
+DEFINE_RUNTIME_int32(rpc_queue_stack_dump_max_backoff_ms, 300000,
+    "Maximum interval (in ms) between consecutive thread stack dumps while an RPC service "
+    "queue stays at or above rpc_queue_stack_dump_threshold. Repeated dumps are suppressed "
+    "with an exponential backoff capped at this interval; the backoff resets once the queue "
+    "drains below the threshold.");
+TAG_FLAG(rpc_queue_stack_dump_max_backoff_ms, advanced);
+
+namespace yb::rpc {
+
+namespace {
+
+constexpr int32_t kMinPollIntervalMs = 10;
+
+// Maximum number of thread names listed per group of threads sharing the same stack.
+constexpr size_t kMaxThreadNamesPerGroup = 10;
+
+// Guards against multiple messengers in the same process (e.g. a tablet server and its CQL
+// proxy) dumping thread stacks back to back for the same overload event.
+std::mutex global_dump_time_mutex;
+CoarseTimePoint global_last_dump_time;
+
+bool ShouldSkipDumpGlobally(CoarseTimePoint now, CoarseMonoClock::Duration min_gap) {
+  std::lock_guard lock(global_dump_time_mutex);
+  if (global_last_dump_time != CoarseTimePoint() && now < global_last_dump_time + min_gap) {
+    return true;
+  }
+  global_last_dump_time = now;
+  return false;
+}
+
+}  // namespace
+
+class ServiceQueueMonitor::Impl {
+ public:
+  explicit Impl(const std::string& name) : name_(name) {}
+
+  void Shutdown() {
+    ThreadPtr thread;
+    {
+      std::lock_guard lock(mutex_);
+      stop_.store(true, std::memory_order_release);
+      cond_.notify_one();
+      if (!thread_) {
+        return;
+      }
+      thread = thread_;
+    }
+    thread->Join();
+  }
+
+  void Track(const std::string& service_name, const RpcServicePtr& service) {
+    std::lock_guard lock(mutex_);
+    if (stop_.load(std::memory_order_acquire)) {
+      return;
+    }
+    services_.emplace_back(service_name, service);
+    if (!thread_) {
+      thread_ = CHECK_RESULT(Thread::Make(
+          name_ + "_rpc_queue", name_ + "_rpc_queue_monitor", [this] { Execute(); }));
+    }
+  }
+
+ private:
+  void Execute() {
+    std::unique_lock lock(mutex_);
+    while (!stop_.load(std::memory_order_acquire)) {
+      auto poll_interval_ms = std::max(
+          FLAGS_rpc_queue_stack_dump_poll_interval_ms, kMinPollIntervalMs);
+      cond_.wait_for(lock, std::chrono::milliseconds(poll_interval_ms));
+      if (stop_.load(std::memory_order_acquire)) {
+        break;
+      }
+      auto threshold = FLAGS_rpc_queue_stack_dump_threshold;
+      if (threshold <= 0) {
+        ResetPollState();
+        continue;
+      }
+      size_t max_depth = 0;
+      const std::string* worst_service = nullptr;
+      for (const auto& [service_name, service] : services_) {
+        auto depth = service->QueuedCalls();
+        if (worst_service == nullptr || depth > max_depth) {
+          max_depth = depth;
+          worst_service = &service_name;
+        }
+      }
+      if (worst_service == nullptr || max_depth < static_cast<size_t>(threshold)) {
+        ResetPollState();
+        continue;
+      }
+      if (++consecutive_polls_over_threshold_ <
+              std::max(FLAGS_rpc_queue_stack_dump_min_polls, 1)) {
+        continue;
+      }
+      auto now = CoarseMonoClock::Now();
+      if (next_dump_time_ != CoarseTimePoint() && now < next_dump_time_) {
+        continue;
+      }
+      if (ShouldSkipDumpGlobally(now, poll_interval_ms * 1ms)) {
+        continue;
+      }
+      auto max_backoff_ms = std::max<int64_t>(
+          FLAGS_rpc_queue_stack_dump_max_backoff_ms, poll_interval_ms);
+      suppress_ms_ = suppress_ms_ == 0
+          ? static_cast<int64_t>(poll_interval_ms) *
+                std::max(FLAGS_rpc_queue_stack_dump_min_polls, 1)
+          : std::min(suppress_ms_ * 2, max_backoff_ms);
+      next_dump_time_ = now + suppress_ms_ * 1ms;
+      // Copy what the dump needs, then release the lock so that Track and Shutdown are not
+      // blocked while stacks are being collected.
+      auto service_name = *worst_service;
+      auto consecutive_polls = consecutive_polls_over_threshold_;
+      auto suppress_ms = suppress_ms_;
+      lock.unlock();
+      DumpThreadStacks(service_name, max_depth, threshold, consecutive_polls, suppress_ms);
+      lock.lock();
+    }
+  }
+
+  void ResetPollState() {
+    consecutive_polls_over_threshold_ = 0;
+    suppress_ms_ = 0;
+    next_dump_time_ = CoarseTimePoint();
+  }
+
+  void DumpThreadStacks(
+      const std::string& service_name, size_t depth, int64_t threshold, int32_t consecutive_polls,
+      int64_t suppress_ms) {
+    LOG(WARNING) << name_ << ": RPC service queue for " << service_name << " has " << depth
+                 << " queued calls, at or above threshold " << threshold << " for "
+                 << consecutive_polls << " consecutive polls. Dumping thread stacks. "
+                 << "Suppressing further dumps for " << suppress_ms << " ms.";
+    auto threads = ListThreadsForStackTrace();
+    if (threads.empty()) {
+      return;
+    }
+    std::sort(threads.begin(), threads.end(), [](const auto& lhs, const auto& rhs) {
+      return lhs.tid_for_stack < rhs.tid_for_stack;
+    });
+    std::vector<ThreadIdForStack> tids;
+    tids.reserve(threads.size());
+    for (const auto& thread : threads) {
+      tids.push_back(thread.tid_for_stack);
+    }
+    auto stacks = ThreadStacks(tids);
+    // Group threads that share the same stack (or the same collection failure), so that each
+    // stack is symbolized and logged only once.
+    struct Group {
+      std::vector<size_t> thread_indexes;
+    };
+    std::map<std::string, Group> groups;
+    for (size_t i = 0; i != stacks.size(); ++i) {
+      auto key = stacks[i].ok() ? std::string(stacks[i]->as_string_view())
+                                : "!" + stacks[i].status().ToString();
+      groups[std::move(key)].thread_indexes.push_back(i);
+    }
+    for (const auto& [_, group] : groups) {
+      const auto& stack = stacks[group.thread_indexes.front()];
+      std::vector<std::string> names;
+      names.reserve(std::min(group.thread_indexes.size(), kMaxThreadNamesPerGroup + 1));
+      for (auto index : group.thread_indexes) {
+        if (names.size() == kMaxThreadNamesPerGroup) {
+          names.push_back("...");
+          break;
+        }
+        names.push_back(threads[index].name);
+      }
+      LOG(WARNING) << name_ << ": " << group.thread_indexes.size() << " thread(s) with stack ["
+                   << JoinStrings(names, ", ") << "]:\n"
+                   << (stack.ok() ? stack->Symbolize()
+                                  : "Failed to collect stack: " + stack.status().ToString());
+    }
+  }
+
+  const std::string name_;
+  std::mutex mutex_;
+  std::condition_variable cond_;
+  ThreadPtr thread_ GUARDED_BY(mutex_);
+  std::atomic<bool> stop_{false};
+  // Guarded by mutex_. Not annotated because Execute accesses it under std::unique_lock, which
+  // the thread safety analysis does not track.
+  std::vector<std::pair<std::string, RpcServicePtr>> services_;
+
+  // Poll state below is only accessed by the monitor thread.
+  int32_t consecutive_polls_over_threshold_ = 0;
+  // Interval used to suppress dumps after the most recent one, doubling on every dump up to
+  // FLAGS_rpc_queue_stack_dump_max_backoff_ms. 0 means no dump happened since the monitored
+  // queues were last below the threshold.
+  int64_t suppress_ms_ = 0;
+  CoarseTimePoint next_dump_time_;
+};
+
+ServiceQueueMonitor::ServiceQueueMonitor(const std::string& name)
+    : impl_(std::make_unique<Impl>(name)) {}
+
+ServiceQueueMonitor::~ServiceQueueMonitor() {
+  Shutdown();
+}
+
+void ServiceQueueMonitor::Shutdown() {
+  impl_->Shutdown();
+}
+
+void ServiceQueueMonitor::Track(const std::string& service_name, const RpcServicePtr& service) {
+  impl_->Track(service_name, service);
+}
+
+}  // namespace yb::rpc

--- a/src/yb/rpc/service_queue_monitor.h
+++ b/src/yb/rpc/service_queue_monitor.h
@@ -1,0 +1,46 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "yb/rpc/rpc_fwd.h"
+
+namespace yb::rpc {
+
+// Watchdog that polls the queue depth of the RPC services registered with a messenger and, when
+// any queue stays at or above a configured threshold for several consecutive polls, dumps the
+// stacks of all threads to the log. This automates the manual /threadz capture that is otherwise
+// needed to diagnose why RPC worker threads are not draining the service queues.
+//
+// Disabled unless FLAGS_rpc_queue_stack_dump_threshold > 0. All controlling flags are runtime
+// flags defined in service_queue_monitor.cc, so the watchdog can be enabled on a live server.
+// While the condition persists, subsequent dumps are suppressed with an exponential backoff.
+class ServiceQueueMonitor {
+ public:
+  explicit ServiceQueueMonitor(const std::string& name);
+  ~ServiceQueueMonitor();
+
+  void Shutdown();
+
+  // Starts monitoring the queue of the given service. The monitor thread is started on first use.
+  void Track(const std::string& service_name, const RpcServicePtr& service);
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace yb::rpc

--- a/src/yb/rpc/service_queue_monitor.h
+++ b/src/yb/rpc/service_queue_monitor.h
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -20,27 +21,37 @@
 
 namespace yb::rpc {
 
-// Watchdog that polls the queue depth of the RPC services registered with a messenger and, when
-// any queue stays at or above a configured threshold for several consecutive polls, dumps the
-// stacks of all threads to the log. This automates the manual /threadz capture that is otherwise
-// needed to diagnose why RPC worker threads are not draining the service queues.
+// Process-wide watchdog that polls RPC service queue depths and, when any queue stays at or above
+// a configured threshold, dumps the stacks of the affected RPC worker threads to the log. This
+// automates the manual /threadz capture otherwise needed to diagnose why workers are not draining
+// service queues.
 //
 // Disabled unless FLAGS_rpc_queue_stack_dump_threshold > 0. All controlling flags are runtime
 // flags defined in service_queue_monitor.cc, so the watchdog can be enabled on a live server.
 // While the condition persists, subsequent dumps are suppressed with an exponential backoff.
+// Each instance is a lightweight registration for one messenger; all instances share one worker.
 class ServiceQueueMonitor {
  public:
   explicit ServiceQueueMonitor(const std::string& name);
   ~ServiceQueueMonitor();
 
+  ServiceQueueMonitor(const ServiceQueueMonitor&) = delete;
+  ServiceQueueMonitor& operator=(const ServiceQueueMonitor&) = delete;
+
   void Shutdown();
 
-  // Starts monitoring the queue of the given service. The monitor thread is started on first use.
-  void Track(const std::string& service_name, const RpcServicePtr& service);
+  // Starts monitoring the queue of the given service. The process-wide worker starts on first use.
+  void Track(
+      const std::string& service_name, const RpcServicePtr& service,
+      ServicePriority priority = ServicePriority::kNormal);
 
  private:
   class Impl;
-  std::unique_ptr<Impl> impl_;
+  static std::shared_ptr<Impl> SharedImpl();
+
+  const std::string name_;
+  std::shared_ptr<Impl> impl_;
+  const uint64_t owner_id_;
 };
 
 }  // namespace yb::rpc

--- a/src/yb/server/rpc_server.cc
+++ b/src/yb/server/rpc_server.cc
@@ -146,7 +146,7 @@ Status RpcServer::RegisterService(size_t queue_limit,
         return messenger_->ThreadPoolPtr(priority);
       },
       &messenger_->scheduler(), std::move(service), metric_entity));
-  RETURN_NOT_OK(messenger_->RegisterService(service_name, service_pool));
+  RETURN_NOT_OK(messenger_->RegisterService(service_name, service_pool, priority));
   return Status::OK();
 }
 

--- a/src/yb/util/thread.cc
+++ b/src/yb/util/thread.cc
@@ -284,6 +284,7 @@ class ThreadMgr {
   void RemoveThread(ThreadDescriptor* descriptor);
 
   void RenderThreadGroup(const std::string& group, std::ostream& output) EXCLUDES(mutex_);
+  std::vector<ThreadIdAndName> ListThreads() EXCLUDES(mutex_);
   uint64_t ReadThreadsRunning();
   uint64_t ReadThreadsStarted();
 
@@ -624,6 +625,22 @@ void ThreadMgr::RenderThreadCategoryRows(
 void ThreadMgr::RenderThreadGroup(const std::string& group, std::ostream& output) {
   std::lock_guard lock(mutex_);
   RenderThreadGroupUnlocked(group, output);
+}
+
+std::vector<ThreadIdAndName> ThreadMgr::ListThreads() {
+  std::vector<ThreadIdAndName> result;
+  std::lock_guard lock(mutex_);
+  for (const auto& [_, category] : thread_categories_) {
+    for (const auto& descriptor : category) {
+#if defined(__linux__)
+      auto tid_for_stack = descriptor.thread_id;
+#else
+      auto tid_for_stack = descriptor.pthread_id;
+#endif
+      result.push_back(ThreadIdAndName{tid_for_stack, descriptor.name});
+    }
+  }
+  return result;
 }
 
 void ThreadMgr::RenderThreadGroupUnlocked(const std::string& group, std::ostream& output) {
@@ -1088,6 +1105,10 @@ Result<std::string> Thread::ThreadName(int64_t thread_id) {
 
 void RenderAllThreadStacks(std::ostream& output) {
   thread_manager->RenderThreadGroup(kAllGroups, output);
+}
+
+std::vector<ThreadIdAndName> ListThreadsForStackTrace() {
+  return thread_manager->ListThreads();
 }
 
 size_t CountManagedThreads() {

--- a/src/yb/util/thread.cc
+++ b/src/yb/util/thread.cc
@@ -630,14 +630,15 @@ void ThreadMgr::RenderThreadGroup(const std::string& group, std::ostream& output
 std::vector<ThreadIdAndName> ThreadMgr::ListThreads() {
   std::vector<ThreadIdAndName> result;
   std::lock_guard lock(mutex_);
-  for (const auto& [_, category] : thread_categories_) {
+  result.reserve(descriptors_by_id_.size());
+  for (const auto& [category_name, category] : thread_categories_) {
     for (const auto& descriptor : category) {
 #if defined(__linux__)
       auto tid_for_stack = descriptor.thread_id;
 #else
       auto tid_for_stack = descriptor.pthread_id;
 #endif
-      result.push_back(ThreadIdAndName{tid_for_stack, descriptor.name});
+      result.push_back(ThreadIdAndName{tid_for_stack, descriptor.name, category_name});
     }
   }
   return result;

--- a/src/yb/util/thread.h
+++ b/src/yb/util/thread.h
@@ -429,4 +429,14 @@ void RenderAllThreadStacks(std::ostream& output);
 size_t CountManagedThreads();
 size_t CountStartedThreads();
 
+// Identifies a live thread registered with the global thread manager, in a form suitable for
+// collecting its stack via ThreadStacks() and attributing it in diagnostic output.
+struct ThreadIdAndName {
+  ThreadIdForStack tid_for_stack;
+  std::string name;
+};
+
+// Lists all live threads registered with the global thread manager.
+std::vector<ThreadIdAndName> ListThreadsForStackTrace();
+
 } // namespace yb

--- a/src/yb/util/thread.h
+++ b/src/yb/util/thread.h
@@ -434,6 +434,7 @@ size_t CountStartedThreads();
 struct ThreadIdAndName {
   ThreadIdForStack tid_for_stack;
   std::string name;
+  std::string category;
 };
 
 // Lists all live threads registered with the global thread manager.


### PR DESCRIPTION
DO NOT MERGE!! [CSI]() ❌. Once CSI passes, comment `trigger jenkins` to clear this warning.

## Summary

Fixes #33125 (Jira: DB-22832)

Currently, when an RPC service queue overflows, the server only logs a rate-limited backpressure warning in `ServicePoolImpl::Overflow` and increments the `rpcs_queue_overflow` counter. Nothing captures what the RPC worker threads are doing, so diagnosing why the workers are not draining the queue requires manually hitting the `/threadz` endpoint while the incident is in progress.

This change adds an opt-in queue depth watchdog to the shared `src/yb/rpc/` code, so it works for both `yb-master` and `yb-tserver`:

- Lightweight per-`Messenger` registrations share one process-wide `ServiceQueueMonitor` worker and one dump backoff sequence. Services expose a best-effort queue snapshot through `RpcService::QueueSize()`, and registrations are removed before Messenger shutdown starts.
- Queue persistence is tracked independently per service. A dump becomes eligible after any queue remains at or above `rpc_queue_stack_dump_threshold` for `rpc_queue_stack_dump_min_interval_ms`; the warning summarizes up to ten affected services.
- Automatic captures are limited to the normal, tagged-normal, or high-priority RPC worker categories associated with affected services. If no expected worker category exists, collection falls back to all managed threads rather than producing an empty diagnostic.
- Threads sharing an identical stack are grouped and logged once. Every record carries a process-wide dump ID, and a completion record reports elapsed time, thread count, and group count.
- Repeated dumps use `CoarseBackoffWaiter` exponential backoff with jitter, starting at `rpc_queue_stack_dump_min_interval_ms` and capped by `rpc_queue_stack_dump_max_interval_ms` (default 5 minutes). The backoff resets after the sustained overload clears.

The single process-wide monitor thread starts when the first server Messenger registers a service. While `rpc_queue_stack_dump_threshold` is 0, it sleeps on a condition variable and continues to support enabling the feature on a live server.

## Upgrade/Rollback safety

Safe in both directions:

- The four new runtime flags (`rpc_queue_stack_dump_threshold`, `rpc_queue_stack_dump_poll_interval_ms`, `rpc_queue_stack_dump_min_interval_ms`, `rpc_queue_stack_dump_max_interval_ms`) default to the feature being disabled (`rpc_queue_stack_dump_threshold = 0`). Support can enable the watchdog on a live cluster without a restart.
- No wire-format, RPC-versioning, catalog, or on-disk format changes; the change is process-local diagnostics consisting of one background monitor thread per server process and opt-in log output.
- Rollback removes the flags and leaves no persistent state.
- Existing `NON_RUNTIME` queue-length flags such as `master_svc_queue_length` are unchanged.

## Test plan

- [x] `./yb_build.sh release --cxx-test mt-rpc-test --gtest_filter MultiThreadedRpcTest.QueueStackDumpOnSustainedQueueBuildup`: blocks two real RPC workers, fills the service queue, verifies both worker names appear in one grouped stack, and verifies jittered 200 ms then 400 ms backoff ranges.
- [x] `./yb_build.sh release --cxx-test mt-rpc-test --gtest_filter MultiThreadedRpcTest.NoQueueStackDumpWhenDisabled`: applies the same worker and queue pressure with the feature disabled and verifies no dump.
- [x] `./yb_build.sh release --cxx-test mt-rpc-test --gtest_filter MultiThreadedRpcTest.QueueStackDumpCanBeEnabledAtRuntime`: registers services while disabled, enables the runtime threshold after the queue fills, and verifies capture.
- [x] `./yb_build.sh release --cxx-test mt-rpc-test --gtest_filter MultiThreadedRpcTest.QueueStackDumpUsesOneProcessGlobalMonitor`: registers services with two Messengers and verifies one process-wide monitor thread.
- [x] `./yb_build.sh release --cxx-test mt-rpc-test --gtest_filter MultiThreadedRpcTest.TestBlowOutServiceQueue`: existing queue-overflow coverage still passes.
- [x] `./yb_build.sh release daemons --sj --skip-pg-parquet --no-odyssey --no-ybc`: clean compile of `yb-master`, `yb-tserver`, PostgreSQL, AutoFlags generation, and `yb-admin`.
- [x] `./build-support/lint.sh --rev origin/master`: 0 errors, 0 warnings.
