### PR TITLE
[#33152] DocDB: Preserve split parent consensus metadata when applying a tablet split

### DIFF
--- a/src/yb/consensus/consensus_meta.cc
+++ b/src/yb/consensus/consensus_meta.cc
@@ -90,7 +90,8 @@ PeerRole UnpackRole(ConsensusMetadata::PackedRoleAndTerm role_and_term) {
 
 } // anonymous namespace
 
-Result<std::unique_ptr<ConsensusMetadata>> ConsensusMetadata::Create(FsManager* fs_manager,
+std::unique_ptr<ConsensusMetadata> ConsensusMetadata::CreateUnflushedInternal(
+                                 FsManager* fs_manager,
                                  const string& tablet_id,
                                  const std::string& peer_uuid,
                                  const RaftConfigPB& config,
@@ -98,6 +99,22 @@ Result<std::unique_ptr<ConsensusMetadata>> ConsensusMetadata::Create(FsManager* 
   std::unique_ptr<ConsensusMetadata> cmeta(new ConsensusMetadata(fs_manager, tablet_id, peer_uuid));
   cmeta->set_committed_config(config);
   cmeta->set_current_term(current_term);
+  return cmeta;
+}
+
+std::unique_ptr<ConsensusMetadata> ConsensusMetadata::CreateUnflushed(FsManager* fs_manager,
+                                 const std::string& peer_uuid,
+                                 const RaftConfigPB& config,
+                                 int64_t current_term) {
+  return CreateUnflushedInternal(fs_manager, {}, peer_uuid, config, current_term);
+}
+
+Result<std::unique_ptr<ConsensusMetadata>> ConsensusMetadata::Create(FsManager* fs_manager,
+                                 const string& tablet_id,
+                                 const std::string& peer_uuid,
+                                 const RaftConfigPB& config,
+                                 int64_t current_term) {
+  auto cmeta = CreateUnflushedInternal(fs_manager, tablet_id, peer_uuid, config, current_term);
   RETURN_NOT_OK(cmeta->Flush());
   return cmeta;
 }
@@ -329,6 +346,8 @@ void ConsensusMetadata::MergeCommittedConsensusStatePB(const ConsensusStatePB& c
 }
 
 Status ConsensusMetadata::Flush() {
+  SCHECK(!tablet_id_.empty(), IllegalState,
+         "Cannot flush consensus metadata with no tablet id, peer $0", peer_uuid_);
   MAYBE_FAULT(FLAGS_TEST_fault_crash_before_cmeta_flush);
   if (PREDICT_FALSE(FLAGS_TEST_error_before_flushing_consensus_metadata)) {
     return STATUS(
@@ -365,7 +384,8 @@ ConsensusMetadata::ConsensusMetadata(FsManager* fs_manager,
 }
 
 std::string ConsensusMetadata::LogPrefix() const {
-  return MakeTabletLogPrefix(tablet_id_, peer_uuid_);
+  return tablet_id_.empty() ? Format("P $0: ", peer_uuid_)
+                            : MakeTabletLogPrefix(tablet_id_, peer_uuid_);
 }
 
 void ConsensusMetadata::UpdateActiveRole() {

--- a/src/yb/consensus/consensus_meta.h
+++ b/src/yb/consensus/consensus_meta.h
@@ -139,6 +139,13 @@ class ConsensusMetadata {
                                const RaftConfigPB& config,
                                int64_t current_term);
 
+  // Same as Create, but does not touch disk and leaves the tablet id unset. The caller must
+  // set_tablet_id() before calling Flush().
+  static std::unique_ptr<ConsensusMetadata> CreateUnflushed(FsManager* fs_manager,
+                               const std::string& peer_uuid,
+                               const RaftConfigPB& config,
+                               int64_t current_term);
+
   // Load a ConsensusMetadata object from disk.
   // Returns Status::NotFound if the file could not be found. May return other
   // Status codes if unable to read the file.
@@ -257,6 +264,12 @@ class ConsensusMetadata {
  private:
   ConsensusMetadata(FsManager* fs_manager, std::string tablet_id,
                     std::string peer_uuid);
+
+  static std::unique_ptr<ConsensusMetadata> CreateUnflushedInternal(FsManager* fs_manager,
+                               const std::string& tablet_id,
+                               const std::string& peer_uuid,
+                               const RaftConfigPB& config,
+                               int64_t current_term);
 
   std::string LogPrefix() const;
 

--- a/src/yb/integration-tests/tablet-split-itest.cc
+++ b/src/yb/integration-tests/tablet-split-itest.cc
@@ -295,9 +295,9 @@ TEST_F(TabletSplitITest, ParentTabletCleanup) {
 
 // Checks that applying a tablet split leaves the split parent's consensus metadata file alone.
 TEST_F(TabletSplitITest, ParentConsensusMetadataPreservedAcrossSplit) {
+  google::FlagSaver flag_saver;
   // Keep the parent around so its cmeta file is not deleted before we can re-read it.
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_skip_deleting_split_tablets) = true;
-
   CreateSingleTablet();
   const auto split_hash_code = ASSERT_RESULT(WriteRowsAndGetMiddleHashCode(kDefaultNumRows));
 

--- a/src/yb/integration-tests/tablet-split-itest.cc
+++ b/src/yb/integration-tests/tablet-split-itest.cc
@@ -11,8 +11,10 @@
 // under the License.
 //
 
+#include <algorithm>
 #include <chrono>
 #include <limits>
+#include <unordered_map>
 #include <thread>
 
 #include <gtest/gtest.h>
@@ -31,6 +33,7 @@
 #include "yb/consensus/consensus.h"
 #include "yb/consensus/consensus.pb.h"
 #include "yb/consensus/consensus.proxy.h"
+#include "yb/consensus/consensus_meta.h"
 #include "yb/consensus/consensus_util.h"
 #include "yb/consensus/log.h"
 #include "yb/consensus/log.messages.h"
@@ -288,6 +291,89 @@ TEST_F(TabletSplitITest, ParentTabletCleanup) {
 
   // This will make client first try to access deleted tablet and that should be handled correctly.
   ASSERT_OK(CheckRowsCount(kNumRows));
+}
+
+// Checks that applying a tablet split leaves the split parent's consensus metadata file alone.
+TEST_F(TabletSplitITest, ParentConsensusMetadataPreservedAcrossSplit) {
+  // Keep the parent around so its cmeta file is not deleted before we can re-read it.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_skip_deleting_split_tablets) = true;
+
+  CreateSingleTablet();
+  const auto split_hash_code = ASSERT_RESULT(WriteRowsAndGetMiddleHashCode(kDefaultNumRows));
+
+  const auto parent_tablet_id =
+      ASSERT_RESULT(GetSingleTestTabletInfo(ASSERT_RESULT(catalog_manager())))->id();
+
+  struct MetaSnapshot {
+    int64_t current_term;
+    bool has_voted_for;
+    std::string voted_for;
+
+    bool operator <=(const MetaSnapshot& other) const {
+      if (current_term != other.current_term) {
+        return current_term < other.current_term;
+      }
+      return !has_voted_for || (other.has_voted_for && voted_for == other.voted_for);
+    }
+
+    std::string ToString() const {
+      return Format("{ term: $0, voted_for: $1 }", current_term,
+                    has_voted_for ? voted_for : "<none>");
+    }
+  };
+
+  // Keyed by tserver uuid.
+  using MetaSnapshots = std::unordered_map<std::string, MetaSnapshot>;
+
+  // Reads the parent cmeta straight off disk on every tserver that has one. ConsensusMetadata is
+  // written via a temp file plus atomic rename, so this is safe to do while the peer is running.
+  auto read_parent_cmeta = [this, &parent_tablet_id]() -> Result<MetaSnapshots> {
+    MetaSnapshots result;
+    for (size_t i = 0; i < cluster_->num_tablet_servers(); ++i) {
+      auto& fs_manager = cluster_->mini_tablet_server(i)->fs_manager();
+      std::unique_ptr<consensus::ConsensusMetadata> cmeta;
+      auto status = consensus::ConsensusMetadata::Load(
+          &fs_manager, parent_tablet_id, fs_manager.uuid(), &cmeta);
+      if (status.IsNotFound()) {
+        // This tserver does not host a replica of the parent tablet.
+        continue;
+      }
+      RETURN_NOT_OK(status);
+      result.emplace(
+          fs_manager.uuid(),
+          MetaSnapshot{
+              .current_term = cmeta->current_term(),
+              .has_voted_for = cmeta->has_voted_for(),
+              .voted_for = cmeta->has_voted_for() ? cmeta->voted_for() : std::string(),
+          });
+    }
+    return result;
+  };
+
+  const auto before = ASSERT_RESULT(read_parent_cmeta());
+  ASSERT_FALSE(before.empty()) << "No parent cmeta found on disk on any tserver";
+
+  // At least one replica must have a recorded vote.
+  ASSERT_TRUE(std::any_of(before.begin(), before.end(), [](const auto& entry) {
+    return entry.second.has_voted_for;
+  })) << "No replica had voted_for set before the split; test would not be meaningful";
+
+  ASSERT_OK(SplitSingleTablet(split_hash_code));
+  ASSERT_OK(WaitForTabletSplitCompletion(
+      /* expected_non_split_tablets = */ 2, /* expected_split_tablets = */ 1));
+
+  const auto after = ASSERT_RESULT(read_parent_cmeta());
+
+  // Make sure that the parent cmeta is still consistent across all tservers.
+  for (const auto& [ts_uuid, before_snapshot] : before) {
+    auto it = after.find(ts_uuid);
+    ASSERT_NE(it, after.end()) << "Parent cmeta disappeared on TS " << ts_uuid;
+    const auto& after_snapshot = it->second;
+
+    ASSERT_TRUE(before_snapshot <= after_snapshot)
+        << "cmeta unexpected: parent " << parent_tablet_id << " TS: " << ts_uuid
+        << " before: " << before_snapshot.ToString() << " after: " << after_snapshot.ToString();
+  }
 }
 
 // Test for #31936, ensure that marking all_tablets as stale forces a full tablet lookup, even if

--- a/src/yb/tserver/ts_tablet_manager.cc
+++ b/src/yb/tserver/ts_tablet_manager.cc
@@ -1301,9 +1301,9 @@ Status TSTabletManager::ApplyTabletSplit(
       }
   }};
 
-  std::unique_ptr<ConsensusMetadata> cmeta = VERIFY_RESULT(ConsensusMetadata::Create(
-      fs_manager_, tablet_id, fs_manager_->uuid(), committed_raft_config.value(),
-      split_op_id.term));
+  // Children's cmeta template. The child tablet id is set and flushed later, in the loop below.
+  std::unique_ptr<ConsensusMetadata> cmeta = ConsensusMetadata::CreateUnflushed(
+      fs_manager_, fs_manager_->uuid(), committed_raft_config.value(), split_op_id.term);
   if (request->has_split_parent_leader_uuid()) {
     cmeta->set_leader_uuid(request->split_parent_leader_uuid().ToBuffer());
     LOG_WITH_PREFIX(INFO) << "Using Raft config: " << committed_raft_config->ShortDebugString();


### PR DESCRIPTION
## Summary

`TSTabletManager::ApplyTabletSplit` builds one `ConsensusMetadata` object as a template and
retargets it per child with `set_tablet_id()` before each `Flush()`. It obtained that object
from `ConsensusMetadata::Create()`, which flushes to disk before returning -- while the object
still carries the *parent's* tablet id. That flush lands in the split parent's cmeta file and
overwrites it with state computed for the children: `current_term` set to `split_op_id.term`,
and no `voted_for`.

A split does not modify the parent's Raft group. The parent keeps operating -- heartbeating,
standing for and voting in elections -- until the master deletes it, so this erases a live
replica's recorded vote, breaking two invariants for that replica: at most one vote per term,
and terms never move backwards. The damage is invisible while the process stays up, because
in-memory state is still correct and the next ordinary metadata write repairs the file. It has
consequences only if the replica restarts inside that window and bootstraps from the damaged
file.

Changes:

- Add `ConsensusMetadata::CreateUnflushed()`, which builds the object without touching disk and
  leaves the tablet id unset. `Create()` keeps its existing flush-on-construction behavior;
  both now share a private `CreateUnflushedInternal()`.
- `ApplyTabletSplit` uses `CreateUnflushed()`, so the first flush happens only after
  `set_tablet_id()` has named a child.
- `Flush()` fails if the tablet id is unset, so a future caller cannot reintroduce the same
  overwrite silently.
- `LogPrefix()` tolerates the window where the tablet id is not yet set.

Both entry points into `ApplyTabletSplit` are covered by the fix: the live apply path, and
replay during tablet bootstrap (`TabletBootstrap::PlaySplitOpRequest`). On the replay path the
split op's term can be older than the parent's current term, so there the parent's term can
move backwards as well as losing its vote.

## Upgrade/Rollback safety

No wire-format, on-disk-format, catalog, or gflag change. The consensus metadata schema is
untouched; this change only removes a spurious write to an existing file.

Upgrade: no ordering constraint. A mixed-version cluster is safe -- nodes carrying the fix stop
damaging their split parents' metadata, and nodes without it behave exactly as they do today.
Rollback: safe, and requires no cleanup. Files already damaged by an older binary are repaired
by the next ordinary metadata write on that replica, or on the next election.

## Test plan

- [x] New test `TabletSplitITest.ParentConsensusMetadataPreservedAcrossSplit` passes
      (release, clang21, arm64). It reads the split parent's cmeta off disk on every tserver
      before and after the split and asserts that no replica's term or recorded vote regresses.
- [x] Negative control: with the fix reverted and the test unchanged, the test fails with
      `before: { term: 1, voted_for: <uuid> } after: { term: 1, voted_for: <none> }` --
      i.e. it reproduces the reported defect and is not vacuously green.
- [ ] Full `integration-tests_tablet-split-itest` suite.
- [ ] Debug and TSAN builds.
