### PR TITLE
[#33173] ClaudeCode: Add prose discipline convention and pre-publish trim step

### DIFF
--- a/.claude/skills/create-diff/SKILL.md
+++ b/.claude/skills/create-diff/SKILL.md
@@ -176,6 +176,22 @@ Based on the files changed on the branch, decide the default subscriber:
 
 Confirm the subscriber list with the user before creating the diff.
 
+### Step 5.5: Cut the prose the branch added
+
+Re-read the **text** the branch adds — comments, `architecture/` docs,
+agent docs — and apply [`AGENTS.md` Prose
+discipline](../../../AGENTS.md#prose-discipline--write-for-the-reader-not-for-volume).
+It is a gate here because it is easy to hold at the start of a task and
+gone by the end of one, and this is the last point where cutting is
+free.
+
+```
+git diff <base>...HEAD -- '*.md'   # doc prose; also skim added comments in the code diff
+```
+
+Commit any resulting edits on the branch before Step 6, and re-run the
+linter (Step 2).
+
 ### Step 6: Create the diff with `arc diff --create`
 
 **Confidentiality — final scrub before publishing.** Phorge is treated
@@ -209,8 +225,15 @@ arc diff --create --message-file <path> --reviewers <reviewers> --cc <subscriber
 Pre-fill the message file with:
 
 - **Title**: the constructed title from step 4
-- **Summary**: a short description of the change (derive from branch commits)
-- **Test Plan**: ask the user for one if not obvious from the branch
+- **Summary**: derived from the branch commits.  Say **why**, always —
+  a reviewer who has to reverse-engineer the motivation is the
+  expensive case — then a summary sized to the change, roughly a line
+  per file, and whatever the reader must *act* on (new gflags,
+  upgrade/rollback consequences, migration steps).  Not a narration of
+  the diff.  See [`AGENTS.md` Prose
+  discipline](../../../AGENTS.md#prose-discipline--write-for-the-reader-not-for-volume).
+- **Test Plan**: ask the user for one if not obvious from the branch.
+  Keep it to what was actually run — it is not a place for prose.
 - **Reviewers**: (as provided)
 - **Subscribers**: `ybase` and/or `yugaware` per Step 4
 

--- a/.claude/skills/create-diff/SKILL.md
+++ b/.claude/skills/create-diff/SKILL.md
@@ -227,10 +227,9 @@ Pre-fill the message file with:
 - **Title**: the constructed title from step 4
 - **Summary**: derived from the branch commits.  Say **why**, always —
   a reviewer who has to reverse-engineer the motivation is the
-  expensive case — then a summary sized to the change, roughly a line
-  per file, and whatever the reader must *act* on (new gflags,
-  upgrade/rollback consequences, migration steps).  Not a narration of
-  the diff.  See [`AGENTS.md` Prose
+  expensive case — then what changed, and whatever the reader must *act*
+  on (new gflags, upgrade/rollback consequences, migration steps).  Not
+  a narration of the diff.  See [`AGENTS.md` Prose
   discipline](../../../AGENTS.md#prose-discipline--write-for-the-reader-not-for-volume).
 - **Test Plan**: ask the user for one if not obvious from the branch.
   Keep it to what was actually run — it is not a place for prose.

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -107,11 +107,28 @@ Examples:
 
 If the user supplies a title that already includes `[<issue>] ` or doesn't match the format, fix it before calling the script — don't rely on the script's auto-strip (it only handles the leading `[*] ` case) and don't surprise the user with an `exit 1` after they confirmed the metadata.
 
+### Step 4b: Cut the prose the branch added
+
+Re-read the **text** the branch adds — comments, `architecture/` docs, agent docs — and
+apply [`AGENTS.md` § Prose
+discipline](../../../AGENTS.md#prose-discipline--write-for-the-reader-not-for-volume). It
+is a gate here because it is easy to hold at the start of a task and gone by the end of
+one, and this is the last point where cutting is free.
+
+```
+git diff <upstream>/master...HEAD -- '*.md'   # doc prose; also skim added comments in the code diff
+```
+
+Land any resulting edits as a new commit before Step 5 — the script refuses to run against
+a dirty tree.
+
 ### Step 5: Run `create-pr.sh` to rebase, lint, push, and open the PR
 
 > **Confidentiality — final scrub before publishing.** The repo and every PR are public. Before invoking the script, re-read the description, test plan, upgrade-rollback notes, the commit messages on the branch, **the branch name itself** (it becomes the public PR head ref), **and the test code being added**, and confirm none of the following appear: customer names or identifiers (universe UUIDs, account IDs, support cases, environment names, region/zone names); PII (real names / emails / phone numbers / postal addresses / IP addresses — use RFC 5737/3849 documentation ranges in tests); unanonymized customer schemas (table / column / query text / query plans / sample rows from a real customer — reconstruct a synthetic reproducer); credentials, tokens, certificates, private keys, or license keys; internal-only hostnames, URLs, Grafana/Slack/Linear links, or vault paths; unreleased internal information (roadmap, SLAs, embargoed security findings, internal infra hostnames). See the top of this skill and `src/AGENTS.md` § Confidentiality for the full rule. If unsure whether a string is sensitive, don't write it down — ask the user.
 
-Once you have the issue (Step 3.1), title (Step 4), and reviewers (Step 3 if user-supplied), write the description and test plan to **separate** temp files and hand everything to the script:
+Once you have the issue (Step 3.1), title (Step 4), and reviewers (Step 3 if user-supplied), write the description and test plan to **separate** temp files and hand everything to the script.
+
+Say **why**, always — a reviewer who has to reverse-engineer the motivation is the expensive case — then a summary sized to the change, roughly a line per file, and whatever the reader must *act* on (new gflags, upgrade/rollback consequences, migration steps). Not a narration of the diff. Keep the test plan to what was actually run. See [`AGENTS.md` § Prose discipline](../../../AGENTS.md#prose-discipline--write-for-the-reader-not-for-volume).
 
 ```
 .agents/scripts/create-pr.sh \

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -128,7 +128,7 @@ a dirty tree.
 
 Once you have the issue (Step 3.1), title (Step 4), and reviewers (Step 3 if user-supplied), write the description and test plan to **separate** temp files and hand everything to the script.
 
-Say **why**, always — a reviewer who has to reverse-engineer the motivation is the expensive case — then a summary sized to the change, roughly a line per file, and whatever the reader must *act* on (new gflags, upgrade/rollback consequences, migration steps). Not a narration of the diff. Keep the test plan to what was actually run. See [`AGENTS.md` § Prose discipline](../../../AGENTS.md#prose-discipline--write-for-the-reader-not-for-volume).
+Say **why**, always — a reviewer who has to reverse-engineer the motivation is the expensive case — then what changed, and whatever the reader must *act* on (new gflags, upgrade/rollback consequences, migration steps). Not a narration of the diff. Keep the test plan to what was actually run. See [`AGENTS.md` § Prose discipline](../../../AGENTS.md#prose-discipline--write-for-the-reader-not-for-volume).
 
 ```
 .agents/scripts/create-pr.sh \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,22 +30,20 @@ When working on DB code (`src/`), refer to `src/AGENTS.md` for build and test gu
 
 AI-written text runs long: PR and diff descriptions that narrate the diff, comments that
 restate the line below them, design docs padded with editorial framing. It reads as
-thorough and costs real review time — reviewers spend their budget deleting it instead of
-checking the change. Every extra sentence is also one more claim that has to stay true as
-the code moves, which is why the long version is the *harder* one to maintain.
+thorough, but it costs review time, and every extra sentence is one more claim that has to
+stay true as the code moves.
 
-There are no word counts here. Judge each piece by what a reader who already knows this
+There are no hard limits here. Judge each piece by what a reader who already knows this
 repo needs:
 
-- **Code comments** — the *why*, when it isn't obvious from the code: an invariant, a
-  locking or ordering constraint, a workaround and the upstream bug behind it. Not a
-  restatement of the line below, not section captions, not narration of the change you
-  just made.
+- **Code comments** — don't restate the code. Comment the *why* when it isn't obvious: an
+  invariant, a cross-component contract, a locking or ordering constraint, a workaround and
+  the upstream bug behind it. Not a label for the block below it, not narration of the
+  change you just made.
 - **PR / Phorge diff descriptions** — the motivation (a reviewer who doesn't know why is
-  the expensive case), a summary sized to the change, roughly a line per file, and
-  whatever the reader must *act* on: new gflags, upgrade/rollback consequences, migration
-  steps. Not a paragraph per file, not a narration of the diff. The test plan is a
-  separate section — keep it to what was run.
+  the expensive case), what changed, and whatever the reader must *act* on: new gflags,
+  upgrade/rollback consequences, migration steps. Not a narration of the diff. The test
+  plan is a separate section — keep it to what was run.
 - **Design docs (`architecture/`) and agent docs (`AGENTS.md`, `.claude/skills/`)** — how
   the system is wired today, why it's built that way, and what the reader has to do. Cut
   restated context and the history of what the code used to do.
@@ -54,16 +52,15 @@ repo needs:
 The test for a sentence: would a reader who knows this repo do or believe anything
 differently without it? If not, cut it.
 
-Two guardrails. **Motivation is not filler** — why a design is the way it is is exactly
-what a reader can't recover from the code; what's being cut is text that says the same
-thing twice, not text that explains. And don't over-correct: the goal is *fewer,
-load-bearing* words, not stripped docs. Deleting a section that describes live behavior is
-a worse outcome than leaving it wordy, and this applies to your own diff, not a cleanup
-tour of files you didn't touch.
+**Motivation is not filler** — why a design is the way it is is exactly what a reader can't
+recover from the code; what's being cut is text that says the same thing twice, not text
+that explains. And don't over-correct: the goal is *fewer, load-bearing* words, not
+stripped docs. Deleting a section that describes live behavior is a worse outcome than
+leaving it wordy, and this applies to your own diff, not a cleanup tour of files you didn't
+touch.
 
 This does **not** apply to the user-facing docs website (`docs/`), which follows its own
 editorial style guide and is written for readers who do *not* know this repo.
 
 Trim before you publish, not in review: the `create-pr` and `create-diff` skills re-check
-this as a step, because guidance that lives only here is remembered at the start of a task
-and gone by the end of one.
+this as a step.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,3 +25,45 @@ For agents that want to deploy, configure and run YugabyteDB refer to instructio
 ### Coding and Development
 
 When working on DB code (`src/`), refer to `src/AGENTS.md` for build and test guidance
+
+### Prose discipline — write for the reader, not for volume
+
+AI-written text runs long: PR and diff descriptions that narrate the diff, comments that
+restate the line below them, design docs padded with editorial framing. It reads as
+thorough and costs real review time — reviewers spend their budget deleting it instead of
+checking the change. Every extra sentence is also one more claim that has to stay true as
+the code moves, which is why the long version is the *harder* one to maintain.
+
+There are no word counts here. Judge each piece by what a reader who already knows this
+repo needs:
+
+- **Code comments** — the *why*, when it isn't obvious from the code: an invariant, a
+  locking or ordering constraint, a workaround and the upstream bug behind it. Not a
+  restatement of the line below, not section captions, not narration of the change you
+  just made.
+- **PR / Phorge diff descriptions** — the motivation (a reviewer who doesn't know why is
+  the expensive case), a summary sized to the change, roughly a line per file, and
+  whatever the reader must *act* on: new gflags, upgrade/rollback consequences, migration
+  steps. Not a paragraph per file, not a narration of the diff. The test plan is a
+  separate section — keep it to what was run.
+- **Design docs (`architecture/`) and agent docs (`AGENTS.md`, `.claude/skills/`)** — how
+  the system is wired today, why it's built that way, and what the reader has to do. Cut
+  restated context and the history of what the code used to do.
+- **Commit messages** — subject, plus the why when the why isn't obvious.
+
+The test for a sentence: would a reader who knows this repo do or believe anything
+differently without it? If not, cut it.
+
+Two guardrails. **Motivation is not filler** — why a design is the way it is is exactly
+what a reader can't recover from the code; what's being cut is text that says the same
+thing twice, not text that explains. And don't over-correct: the goal is *fewer,
+load-bearing* words, not stripped docs. Deleting a section that describes live behavior is
+a worse outcome than leaving it wordy, and this applies to your own diff, not a cleanup
+tour of files you didn't touch.
+
+This does **not** apply to the user-facing docs website (`docs/`), which follows its own
+editorial style guide and is written for readers who do *not* know this repo.
+
+Trim before you publish, not in review: the `create-pr` and `create-diff` skills re-check
+this as a step, because guidance that lives only here is remembered at the start of a task
+and gone by the end of one.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -108,12 +108,27 @@ Write temporary files (PR bodies, commit messages, lint logs, etc.) to **`/tmp/c
 - Keep lists of `DECLARE_xxx(yyy)` flag declarations in alphabetical order.
 - Keep lists of forward declarations in alphabetical order.
 
+## Prose discipline
+
+Comment the *why* when it isn't obvious — an invariant, a locking or ordering constraint,
+a workaround and the upstream bug behind it. Don't restate the line below, caption an
+obvious block, or narrate the change you just made; `git log` and the diff already say
+that. The same applies to PR/diff descriptions and `architecture/` docs: give the reader
+the motivation and what they must act on, not a retelling of the diff. Padding costs
+reviewers real time and rots as the code moves. Full rule and reasoning:
+[`AGENTS.md` § Prose discipline](../AGENTS.md#prose-discipline--write-for-the-reader-not-for-volume);
+the `create-pr` and `create-diff` skills re-check it before publishing.
+
 ## Commit messages
 
 - Use backticks for method, class, and other code references.
 - Prefer `DocDB` over `docdb` as a component prefix.
 - When referencing other commits (for instance as the cause of a regression), use the form
   `<COMMIT_HASH>/<DIFF_ID>`.
+- The body carries the **why** — the constraint, the failure it fixes, the decision a
+  reader would otherwise have to reverse-engineer. Not a file-by-file retelling of the
+  diff (`git show` does that better). A commit whose reasoning is obvious from the subject
+  needs no body at all.
 
 ## Build System
 

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -110,12 +110,13 @@ Write temporary files (PR bodies, commit messages, lint logs, etc.) to **`/tmp/c
 
 ## Prose discipline
 
-Comment the *why* when it isn't obvious — an invariant, a locking or ordering constraint,
-a workaround and the upstream bug behind it. Don't restate the line below, caption an
-obvious block, or narrate the change you just made; `git log` and the diff already say
-that. The same applies to PR/diff descriptions and `architecture/` docs: give the reader
-the motivation and what they must act on, not a retelling of the diff. Padding costs
-reviewers real time and rots as the code moves. Full rule and reasoning:
+Comment the *why* when it isn't obvious: an invariant, a cross-component contract, a
+locking or ordering constraint, a workaround and the upstream bug behind it. Not a label
+for the block below it, not narration of the change you just made. Don't restate the code;
+`git log` and the diff already say that. The same applies to PR/diff descriptions and
+`architecture/` docs: give the reader the motivation and what they must act on, not a
+retelling of the diff. Padding costs reviewers real time and rots as the code moves. Full
+rule and reasoning:
 [`AGENTS.md` § Prose discipline](../AGENTS.md#prose-discipline--write-for-the-reader-not-for-volume);
 the `create-pr` and `create-diff` skills re-check it before publishing.
 


### PR DESCRIPTION
## Summary

Agents write too much prose — PR and Phorge diff descriptions that narrate the diff,
comments that restate the line below, design docs padded with editorial framing. Review
time goes into deleting it instead of checking the change, and every spare sentence is one
more claim that has to stay true as the code moves.

This states the rule as a repo convention and, more importantly, as a **step in the skills
that publish** — guidance that lives only in `AGENTS.md` is read at the start of a task and
gone by the end of one, so `create-pr` and `create-diff` are where the agent actually gets
reminded, and where cutting is still free.

Stated as **intent, not line counts** (no "max N lines for a comment"), so it can be
reasoned about per change rather than applied mechanically.

## Files changed

- **`AGENTS.md`** — new `Prose discipline` convention: the reason (review cost, and that
  the longer version is the harder one to keep true), then what each surface needs —
  comments, PR/diff descriptions, design and agent docs, commit messages — plus two
  guardrails: motivation is not filler, and don't over-correct into stripped docs.
  Explicitly scoped out is `docs/`, the user-facing docs website, which has its own
  editorial style guide.
- **`src/AGENTS.md`** — a pointer, because an agent working on DB code reads this file and
  may never open the root one. Also one bullet under `Commit messages`: the body carries
  the *why*, not a file-by-file retelling of the diff.
- **`.claude/skills/create-pr/SKILL.md`** — new Step 4b, "cut the prose the branch added",
  run before the publish step so any trim can land as a normal commit; plus description
  guidance in Step 5, the step that writes the PR body.
- **`.claude/skills/create-diff/SKILL.md`** — the same gate as Step 5.5, and a rewritten
  `Summary` / `Test Plan` bullet in the `arc diff` message-file spec.

The trim procedure itself lives in `AGENTS.md` only; both skills link to it rather than
restating it, so there is one copy to keep true.

## Test plan

Agent instructions and docs only — no code, so nothing to build or run.

- [x] Applied the new Step 4b to this branch's own diff before committing. It found the
      "cut / keep / don't over-correct" block duplicated near-verbatim across both skills,
      consolidated it into `AGENTS.md`, and left the skills pointing at it — 136 added
      lines down to 100.
- [x] Verified the relative links and the `AGENTS.md` heading anchor by inspection:
      `../AGENTS.md` from `src/`, `../../../AGENTS.md` from each `.claude/skills/*/`.
- [ ] `build-support/lint.sh --rev upstream/master` — run by `create-pr.sh` before it
      pushes; the PR is not opened unless it is clean.
