### PR TITLE
[#28748] xCluster: Replicate ANALYZE statistics to the target universe

### DIFF
--- a/src/postgres/src/backend/commands/analyze.c
+++ b/src/postgres/src/backend/commands/analyze.c
@@ -89,6 +89,9 @@ typedef struct AnlIndexData
 /* Default statistics target (GUC parameter) */
 int			default_statistics_target = 100;
 
+/* YB: Hook fired at the end of analyze_rel(), see vacuum.h. */
+YbAnalyzeRelEnd_hook_type YbAnalyzeRelEnd_hook = NULL;
+
 /* A few variables that don't seem worth passing around as parameters */
 static MemoryContext anl_context = NULL;
 static BufferAccessStrategy vac_strategy;
@@ -291,6 +294,14 @@ analyze_rel(Oid relid, RangeVar *relation,
 	 * expose us to concurrent-update failures in update_attstats.)
 	 */
 	relation_close(onerel, NoLock);
+
+	/*
+	 * YB: Notify any extension that this relation's statistics were refreshed.
+	 * Done while we still hold the ANALYZE lock and inside the same transaction
+	 * that wrote the new statistics.
+	 */
+	if (YbAnalyzeRelEnd_hook)
+		YbAnalyzeRelEnd_hook(relid);
 
 	pgstat_progress_end_command();
 }

--- a/src/postgres/src/include/commands/vacuum.h
+++ b/src/postgres/src/include/commands/vacuum.h
@@ -332,6 +332,16 @@ extern void analyze_rel(Oid relid, RangeVar *relation,
 						BufferAccessStrategy bstrategy);
 extern bool std_typanalyze(VacAttrStats *stats);
 
+/*
+ * YB: Hook fired once per relation whose statistics were just refreshed by
+ * ANALYZE, after pg_statistic and pg_class have been updated but while we still
+ * hold the ANALYZE locks. ANALYZE is not a DDL, so it does not fire the
+ * ddl_command_end event trigger; this hook lets yb_xcluster_ddl_replication
+ * capture the resulting statistics for replication to the target universe.
+ */
+typedef void (*YbAnalyzeRelEnd_hook_type) (Oid relid);
+extern PGDLLIMPORT YbAnalyzeRelEnd_hook_type YbAnalyzeRelEnd_hook;
+
 /* in utils/misc/sampling.c --- duplicate of declarations in utils/sampling.h */
 extern double anl_random_fract(void);
 extern double anl_init_selection_state(int n);

--- a/src/postgres/yb-extensions/yb_xcluster_ddl_replication/Makefile
+++ b/src/postgres/yb-extensions/yb_xcluster_ddl_replication/Makefile
@@ -11,6 +11,7 @@ OBJS = \
 	yb_xcluster_ddl_replication.o \
 	extension_util.o \
 	json_util.o \
+	source_analyze_handler.o \
 	source_ddl_end_handler.o
 
 ifdef USE_PGXS

--- a/src/postgres/yb-extensions/yb_xcluster_ddl_replication/expected/analyze.out
+++ b/src/postgres/yb-extensions/yb_xcluster_ddl_replication/expected/analyze.out
@@ -1,12 +1,9 @@
 CALL TEST_reset();
-
 CREATE TABLE analyze_foo(i int PRIMARY KEY, j text);
 INSERT INTO analyze_foo SELECT g, 'value' || (g % 3) FROM generate_series(1, 20) g;
 CREATE TEMP TABLE analyze_temp_foo(i int PRIMARY KEY);
-
 ANALYZE analyze_foo;
 ANALYZE analyze_temp_foo;  -- temp relations are not replicated
-
 -- Only the permanent relation should have been captured, and the captured query
 -- should be the statistics import statement rather than the ANALYZE itself.
 SELECT yb_data->>'command_tag' AS command_tag,
@@ -16,8 +13,16 @@ SELECT yb_data->>'command_tag' AS command_tag,
   FROM yb_xcluster_ddl_replication.ddl_queue
   WHERE yb_data->>'command_tag' = 'ANALYZE'
   ORDER BY ddl_end_time;
+ command_tag | has_relation_stats | has_attribute_stats | has_temp_relation 
+-------------+--------------------+---------------------+-------------------
+ ANALYZE     | t                  | t                   | f
+(1 row)
 
 SELECT TEST_verify_replicated_ddls();
+ test_verify_replicated_ddls 
+-----------------------------
+ t
+(1 row)
 
 -- Now verify that replaying the captured query reproduces the statistics, which
 -- is what the target universe does. The values themselves are not printed since
@@ -29,16 +34,29 @@ CREATE TEMP TABLE saved_stats AS
          histogram_bounds::text AS histogram_bounds,
          correlation
     FROM pg_stats WHERE schemaname = 'public' AND tablename = 'analyze_foo';
-
 CREATE TEMP TABLE saved_relstats AS
   SELECT relpages, reltuples, relallvisible
     FROM pg_class WHERE oid = 'public.analyze_foo'::regclass;
-
 SELECT pg_catalog.pg_clear_attribute_stats('public', 'analyze_foo', attname, inherited)
   FROM saved_stats;
+ pg_clear_attribute_stats 
+--------------------------
+ 
+ 
+(2 rows)
+
 SELECT pg_catalog.pg_clear_relation_stats('public', 'analyze_foo');
+ pg_clear_relation_stats 
+-------------------------
+ 
+(1 row)
+
 SELECT count(*) AS remaining_stats
   FROM pg_stats WHERE schemaname = 'public' AND tablename = 'analyze_foo';
+ remaining_stats 
+-----------------
+               0
+(1 row)
 
 DO $$
 DECLARE
@@ -50,7 +68,6 @@ BEGIN
   EXECUTE captured_query;
 END
 $$;
-
 SELECT s.attname, s.inherited,
        (s.null_frac IS NOT DISTINCT FROM p.null_frac AND
         s.avg_width IS NOT DISTINCT FROM p.avg_width AND
@@ -63,8 +80,18 @@ SELECT s.attname, s.inherited,
   JOIN pg_stats p ON p.schemaname = 'public' AND p.tablename = 'analyze_foo'
                  AND p.attname = s.attname AND p.inherited = s.inherited
   ORDER BY s.attname, s.inherited;
+ attname | inherited | stats_match 
+---------+-----------+-------------
+ i       | f         | t
+ j       | f         | t
+(2 rows)
 
 SELECT s.relpages IS NOT DISTINCT FROM c.relpages AND
        s.reltuples IS NOT DISTINCT FROM c.reltuples AND
        s.relallvisible IS NOT DISTINCT FROM c.relallvisible AS relstats_match
   FROM saved_relstats s, pg_class c WHERE c.oid = 'public.analyze_foo'::regclass;
+ relstats_match 
+----------------
+ t
+(1 row)
+

--- a/src/postgres/yb-extensions/yb_xcluster_ddl_replication/expected/analyze.out
+++ b/src/postgres/yb-extensions/yb_xcluster_ddl_replication/expected/analyze.out
@@ -1,21 +1,27 @@
 CALL TEST_reset();
 CREATE TABLE analyze_foo(i int PRIMARY KEY, j text);
-INSERT INTO analyze_foo SELECT g, 'value' || (g % 3) FROM generate_series(1, 20) g;
+-- The captured query embeds column values, which can be any text at all,
+-- including something that looks like the dollar quoting tag used to wrap the
+-- generated statements. Such a value must not be able to close the block early.
+INSERT INTO analyze_foo
+  SELECT g, '$yb_xcluster_analyze$ value' || (g % 3) FROM generate_series(1, 20) g;
 CREATE TEMP TABLE analyze_temp_foo(i int PRIMARY KEY);
 ANALYZE analyze_foo;
 ANALYZE analyze_temp_foo;  -- temp relations are not replicated
 -- Only the permanent relation should have been captured, and the captured query
 -- should be the statistics import statement rather than the ANALYZE itself.
+-- The quote tag must have been extended, since the plain one occurs in the data.
 SELECT yb_data->>'command_tag' AS command_tag,
        yb_data->>'query' LIKE '%pg_restore_relation_stats%' AS has_relation_stats,
        yb_data->>'query' LIKE '%pg_restore_attribute_stats%' AS has_attribute_stats,
-       yb_data->>'query' LIKE '%analyze_temp_foo%' AS has_temp_relation
+       yb_data->>'query' LIKE '%analyze_temp_foo%' AS has_temp_relation,
+       yb_data->>'query' LIKE 'DO $yb_xcluster_analyzex$%' AS has_extended_quote_tag
   FROM yb_xcluster_ddl_replication.ddl_queue
   WHERE yb_data->>'command_tag' = 'ANALYZE'
   ORDER BY ddl_end_time;
- command_tag | has_relation_stats | has_attribute_stats | has_temp_relation 
--------------+--------------------+---------------------+-------------------
- ANALYZE     | t                  | t                   | f
+ command_tag | has_relation_stats | has_attribute_stats | has_temp_relation | has_extended_quote_tag 
+-------------+--------------------+---------------------+-------------------+------------------------
+ ANALYZE     | t                  | t                   | f                 | t
 (1 row)
 
 SELECT TEST_verify_replicated_ddls();

--- a/src/postgres/yb-extensions/yb_xcluster_ddl_replication/source_analyze_handler.c
+++ b/src/postgres/yb-extensions/yb_xcluster_ddl_replication/source_analyze_handler.c
@@ -29,12 +29,8 @@
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
 
-/*
- * Dollar quoting tag used to wrap the generated statements. The generated body
- * only ever contains single quoted string literals, so it can never contain
- * this tag.
- */
-#define ANALYZE_STATS_QUOTE_TAG "$yb_xcluster_analyze$"
+/* Prefix of the dollar quoting tag used to wrap the generated statements. */
+#define ANALYZE_STATS_QUOTE_TAG_PREFIX "$yb_xcluster_analyze"
 
 /* Columns of kRelationsQuery. */
 #define RELATIONS_NSPNAME_COLUMN_ID		  1
@@ -303,27 +299,49 @@ BuildRestoreStatsQuery(Oid relid)
 										 RELATIONS_RELALLVISIBLE_COLUMN_ID);
 	}
 
-	/*
-	 * Wrap everything in a DO block: the ddl_queue handler on the target
-	 * executes the query with a client that rejects result rows, and the
-	 * pg_restore_*_stats functions return a boolean.
-	 */
-	StringInfoData buf;
+	StringInfoData body;
 
-	initStringInfo(&buf);
-	appendStringInfoString(&buf, "DO " ANALYZE_STATS_QUOTE_TAG " BEGIN\n");
+	initStringInfo(&body);
 
 	for (int row = 0; row < num_rels; row++)
 	{
 		if (!rels[row].nspname || !rels[row].relname)
 			continue;
 
-		AppendRelationStats(&buf, &rels[row]);
-		AppendAttributeStats(&buf, &rels[row]);
+		AppendRelationStats(&body, &rels[row]);
+		AppendAttributeStats(&body, &rels[row]);
 	}
 
-	appendStringInfoString(&buf, "END " ANALYZE_STATS_QUOTE_TAG ";");
-
 	pfree(rels);
+
+	/*
+	 * Wrap everything in a DO block: the ddl_queue handler on the target
+	 * executes the query with a client that rejects result rows, and the
+	 * pg_restore_*_stats functions return a boolean.
+	 *
+	 * Dollar quoting is scanned lexically, so the single quotes around the
+	 * values embedded in the body do not hide anything from it. The body
+	 * contains column values, which can be any text at all, including something
+	 * that looks like our tag, so pick a tag that does not occur in the body,
+	 * the same way pg_get_functiondef() does for function bodies. Checking for
+	 * the tag prefix rather than the whole tag is conservative but keeps this
+	 * obviously correct.
+	 */
+	StringInfoData tag;
+
+	initStringInfo(&tag);
+	appendStringInfoString(&tag, ANALYZE_STATS_QUOTE_TAG_PREFIX);
+	while (strstr(body.data, tag.data) != NULL)
+		appendStringInfoChar(&tag, 'x');
+	appendStringInfoChar(&tag, '$');
+
+	StringInfoData buf;
+
+	initStringInfo(&buf);
+	appendStringInfo(&buf, "DO %s BEGIN\n%sEND %s;", tag.data, body.data,
+					 tag.data);
+
+	pfree(tag.data);
+	pfree(body.data);
 	return buf.data;
 }

--- a/src/postgres/yb-extensions/yb_xcluster_ddl_replication/source_analyze_handler.c
+++ b/src/postgres/yb-extensions/yb_xcluster_ddl_replication/source_analyze_handler.c
@@ -1,0 +1,329 @@
+/*-----------------------------------------------------------------------------
+ * Copyright (c) YugabyteDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *-----------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "catalog/catalog.h"
+#include "catalog/pg_class.h"
+#include "catalog/pg_type_d.h"
+#include "executor/spi.h"
+#include "extension_util.h"
+#include "lib/stringinfo.h"
+#include "source_analyze_handler.h"
+#include "utils/builtins.h"
+#include "utils/lsyscache.h"
+#include "utils/syscache.h"
+
+/*
+ * Dollar quoting tag used to wrap the generated statements. The generated body
+ * only ever contains single quoted string literals, so it can never contain
+ * this tag.
+ */
+#define ANALYZE_STATS_QUOTE_TAG "$yb_xcluster_analyze$"
+
+/* Columns of kRelationsQuery. */
+#define RELATIONS_NSPNAME_COLUMN_ID		  1
+#define RELATIONS_RELNAME_COLUMN_ID		  2
+#define RELATIONS_RELPAGES_COLUMN_ID	  3
+#define RELATIONS_RELTUPLES_COLUMN_ID	  4
+#define RELATIONS_RELALLVISIBLE_COLUMN_ID 5
+
+/*
+ * The analyzed relation plus its indexes; ANALYZE also computes statistics for
+ * the columns of expression indexes.
+ *
+ * Invalid / not-live indexes are skipped: they may not exist on the target
+ * (see yb_xcluster_handle_phantom_indexes), and applying statistics to a
+ * relation that is missing there would halt replication.
+ *
+ * The analyzed relation is ordered first purely to make the generated
+ * statement easier to read.
+ */
+static const char *kRelationsQuery =
+	"SELECT n.nspname, c.relname, c.relpages, c.reltuples, c.relallvisible "
+	"FROM pg_catalog.pg_class c "
+	"JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace "
+	"WHERE c.oid = $1 OR c.oid IN ("
+	"  SELECT i.indexrelid FROM pg_catalog.pg_index i "
+	"  WHERE i.indrelid = $1 AND i.indisvalid AND i.indislive) "
+	"ORDER BY (c.oid <> $1), c.relname";
+
+/*
+ * Statistics columns of pg_stats, in the order they are selected by
+ * kAttributeStatsQueryPrefix, along with the argument name and type used to
+ * pass them back to pg_restore_attribute_stats. The types must match
+ * attarginfo in attribute_stats.c exactly; a mismatch is only reported as a
+ * warning by the target and the statistics are silently dropped.
+ */
+typedef struct YbAttributeStatsColumn
+{
+	const char *name;
+	const char *type;
+} YbAttributeStatsColumn;
+
+static const YbAttributeStatsColumn kAttributeStatsColumns[] = {
+	{"inherited", "boolean"},
+	{"null_frac", "real"},
+	{"avg_width", "integer"},
+	{"n_distinct", "real"},
+	{"most_common_vals", "text"},
+	{"most_common_freqs", "real[]"},
+	{"histogram_bounds", "text"},
+	{"correlation", "real"},
+	{"most_common_elems", "text"},
+	{"most_common_elem_freqs", "real[]"},
+	{"elem_count_histogram", "real[]"},
+	{"range_length_histogram", "text"},
+	{"range_empty_frac", "real"},
+	{"range_bounds_histogram", "text"},
+};
+
+#define NUM_ATTRIBUTE_STATS_COLUMNS ((int) lengthof(kAttributeStatsColumns))
+
+/* attname is selected first, the statistics columns follow. */
+#define ATTRIBUTE_STATS_ATTNAME_COLUMN_ID 1
+#define ATTRIBUTE_STATS_FIRST_COLUMN_ID	  2
+
+/* Relation level statistics, as returned by kRelationsQuery. */
+typedef struct YbRelationStats
+{
+	char	   *nspname;
+	char	   *relname;
+	char	   *relpages;
+	char	   *reltuples;
+	char	   *relallvisible;
+} YbRelationStats;
+
+bool
+ShouldReplicateAnalyzedRelation(Oid relid)
+{
+	HeapTuple	tuple = SearchSysCache1(RELOID, ObjectIdGetDatum(relid));
+
+	if (!HeapTupleIsValid(tuple))
+		return false;
+
+	Form_pg_class relform = (Form_pg_class) GETSTRUCT(tuple);
+	Oid			relnamespace = relform->relnamespace;
+	bool		is_temp = (relform->relpersistence == RELPERSISTENCE_TEMP);
+
+	ReleaseSysCache(tuple);
+
+	/* Temporary relations are session local and are never replicated. */
+	if (is_temp)
+		return false;
+
+	/*
+	 * System catalogs (which includes information_schema) are maintained
+	 * independently by each universe.
+	 */
+	if (IsCatalogRelationOid(relid))
+		return false;
+
+	/*
+	 * The extension's own tables are replicated as ordinary data; there is no
+	 * point in replicating statistics for them.
+	 */
+	char	   *nspname = get_namespace_name(relnamespace);
+
+	if (nspname && strcmp(nspname, EXTENSION_NAME) == 0)
+		return false;
+
+	return true;
+}
+
+/*
+ * Appends ", 'name', 'value'::type" to buf, mirroring how pg_dump emits
+ * statistics import arguments.
+ */
+static void
+AppendNamedArgument(StringInfo buf, const char *name, const char *type,
+					const char *value)
+{
+	appendStringInfo(buf, ", '%s', %s::%s", name, quote_literal_cstr(value),
+					 type);
+}
+
+/*
+ * Appends the pg_restore_relation_stats call for a single relation.
+ */
+static void
+AppendRelationStats(StringInfo buf, const YbRelationStats *rel)
+{
+	appendStringInfo(buf,
+					 "PERFORM pg_catalog.pg_restore_relation_stats('version', %d::integer",
+					 PG_VERSION_NUM);
+	AppendNamedArgument(buf, "schemaname", "text", rel->nspname);
+	AppendNamedArgument(buf, "relname", "text", rel->relname);
+
+	/* A NULL here means "leave the target's current value alone". */
+	if (rel->relpages)
+		AppendNamedArgument(buf, "relpages", "integer", rel->relpages);
+	if (rel->reltuples)
+		AppendNamedArgument(buf, "reltuples", "real", rel->reltuples);
+	if (rel->relallvisible)
+		AppendNamedArgument(buf, "relallvisible", "integer",
+							rel->relallvisible);
+
+	appendStringInfoString(buf, ");\n");
+}
+
+/*
+ * Appends one pg_restore_attribute_stats call per row of pg_stats belonging to
+ * the given relation.
+ */
+static void
+AppendAttributeStats(StringInfo buf, const YbRelationStats *rel)
+{
+	StringInfoData query_buf;
+
+	initStringInfo(&query_buf);
+	appendStringInfoString(&query_buf, "SELECT attname");
+	for (int i = 0; i < NUM_ATTRIBUTE_STATS_COLUMNS; i++)
+	{
+		const YbAttributeStatsColumn *column = &kAttributeStatsColumns[i];
+
+		/*
+		 * The array valued columns of pg_stats are declared as anyarray, so
+		 * cast them to the type that pg_restore_attribute_stats expects.
+		 */
+		appendStringInfo(&query_buf, ", %s::%s", column->name, column->type);
+	}
+	appendStringInfoString(&query_buf,
+						   " FROM pg_catalog.pg_stats "
+						   "WHERE schemaname = $1 AND tablename = $2 "
+						   "ORDER BY attname, inherited");
+
+	Oid			arg_types[2] = {TEXTOID, TEXTOID};
+	Datum		arg_vals[2] = {CStringGetTextDatum(rel->nspname),
+		CStringGetTextDatum(rel->relname)};
+
+	/*
+	 * Not read only: we need SPI to bump the command counter so that the
+	 * pg_statistic rows that ANALYZE just wrote are visible to us.
+	 */
+	int			exec_res = SPI_execute_with_args(query_buf.data, 2, arg_types,
+												 arg_vals, /* Nulls */ NULL,
+												  /* readonly */ false,
+												  /* tuple-count limit */ 0);
+
+	if (exec_res != SPI_OK_SELECT)
+		elog(ERROR, "SPI_exec failed (error %d): %s", exec_res, query_buf.data);
+
+	int			num_attrs = SPI_processed;
+	SPITupleTable *tuptable = SPI_tuptable;
+
+	for (int row = 0; row < num_attrs; row++)
+	{
+		HeapTuple	spi_tuple = tuptable->vals[row];
+		char	   *attname = SPI_getvalue(spi_tuple, tuptable->tupdesc,
+										   ATTRIBUTE_STATS_ATTNAME_COLUMN_ID);
+
+		if (!attname)
+			continue;			/* Should not happen, attname is NOT NULL. */
+
+		appendStringInfo(buf,
+						 "PERFORM pg_catalog.pg_restore_attribute_stats('version', %d::integer",
+						 PG_VERSION_NUM);
+		AppendNamedArgument(buf, "schemaname", "text", rel->nspname);
+		AppendNamedArgument(buf, "relname", "text", rel->relname);
+		AppendNamedArgument(buf, "attname", "text", attname);
+
+		for (int i = 0; i < NUM_ATTRIBUTE_STATS_COLUMNS; i++)
+		{
+			const YbAttributeStatsColumn *column = &kAttributeStatsColumns[i];
+			char	   *value = SPI_getvalue(spi_tuple, tuptable->tupdesc,
+											 ATTRIBUTE_STATS_FIRST_COLUMN_ID + i);
+
+			/* Omit the argument entirely rather than passing a NULL. */
+			if (value)
+				AppendNamedArgument(buf, column->name, column->type, value);
+		}
+
+		appendStringInfoString(buf, ");\n");
+	}
+
+	pfree(query_buf.data);
+}
+
+char *
+BuildRestoreStatsQuery(Oid relid)
+{
+	Oid			arg_types[1] = {OIDOID};
+	Datum		arg_vals[1] = {ObjectIdGetDatum(relid)};
+
+	/*
+	 * Not read only: we need SPI to bump the command counter so that the
+	 * pg_class rows that ANALYZE just updated are visible to us.
+	 */
+	int			exec_res = SPI_execute_with_args(kRelationsQuery, 1, arg_types,
+												 arg_vals, /* Nulls */ NULL,
+												  /* readonly */ false,
+												  /* tuple-count limit */ 0);
+
+	if (exec_res != SPI_OK_SELECT)
+		elog(ERROR, "SPI_exec failed (error %d): %s", exec_res, kRelationsQuery);
+
+	int			num_rels = SPI_processed;
+
+	if (num_rels == 0)
+		return NULL;
+
+	/*
+	 * Copy the relation level statistics out before running any further
+	 * queries, as those overwrite SPI_tuptable.
+	 */
+	YbRelationStats *rels = (YbRelationStats *) palloc(num_rels *
+													   sizeof(YbRelationStats));
+
+	for (int row = 0; row < num_rels; row++)
+	{
+		HeapTuple	spi_tuple = SPI_tuptable->vals[row];
+		YbRelationStats *rel = &rels[row];
+
+		rel->nspname = SPI_GetText(spi_tuple, RELATIONS_NSPNAME_COLUMN_ID);
+		rel->relname = SPI_GetText(spi_tuple, RELATIONS_RELNAME_COLUMN_ID);
+		rel->relpages = SPI_GetText(spi_tuple, RELATIONS_RELPAGES_COLUMN_ID);
+		rel->reltuples = SPI_GetText(spi_tuple, RELATIONS_RELTUPLES_COLUMN_ID);
+		rel->relallvisible = SPI_GetText(spi_tuple,
+										 RELATIONS_RELALLVISIBLE_COLUMN_ID);
+	}
+
+	/*
+	 * Wrap everything in a DO block: the ddl_queue handler on the target
+	 * executes the query with a client that rejects result rows, and the
+	 * pg_restore_*_stats functions return a boolean.
+	 */
+	StringInfoData buf;
+
+	initStringInfo(&buf);
+	appendStringInfoString(&buf, "DO " ANALYZE_STATS_QUOTE_TAG " BEGIN\n");
+
+	for (int row = 0; row < num_rels; row++)
+	{
+		if (!rels[row].nspname || !rels[row].relname)
+			continue;
+
+		AppendRelationStats(&buf, &rels[row]);
+		AppendAttributeStats(&buf, &rels[row]);
+	}
+
+	appendStringInfoString(&buf, "END " ANALYZE_STATS_QUOTE_TAG ";");
+
+	pfree(rels);
+	return buf.data;
+}

--- a/src/postgres/yb-extensions/yb_xcluster_ddl_replication/source_analyze_handler.h
+++ b/src/postgres/yb-extensions/yb_xcluster_ddl_replication/source_analyze_handler.h
@@ -1,0 +1,47 @@
+/*-----------------------------------------------------------------------------
+ * Copyright (c) YugabyteDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *-----------------------------------------------------------------------------
+ */
+
+#ifndef YB_XCLUSTER_DDL_REPLICATION_SOURCE_ANALYZE
+#define YB_XCLUSTER_DDL_REPLICATION_SOURCE_ANALYZE
+
+#include "postgres.h"
+
+/*
+ * Returns whether the statistics of the just analyzed relation are worth
+ * replicating to the target universe. Temporary relations, system catalogs and
+ * the extension's own tables are skipped.
+ */
+extern bool ShouldReplicateAnalyzedRelation(Oid relid);
+
+/*
+ * Builds the SQL statement that applies, on the target, the statistics that
+ * ANALYZE just computed on the source for relid and its indexes.
+ *
+ * The statement is a set of pg_restore_relation_stats / pg_restore_attribute_stats
+ * calls wrapped in a DO block, so that the target can simply execute it without
+ * having to redo any of the sampling work.
+ *
+ * Extended statistics (CREATE STATISTICS) are not covered: Postgres has no
+ * import function for them, so the target keeps whatever it computed itself.
+ *
+ * Returns NULL if the relation has no statistics to replicate. Must be called
+ * with an active SPI connection; the result is allocated in the SPI context.
+ */
+extern char *BuildRestoreStatsQuery(Oid relid);
+
+#endif

--- a/src/postgres/yb-extensions/yb_xcluster_ddl_replication/source_ddl_end_handler.h
+++ b/src/postgres/yb-extensions/yb_xcluster_ddl_replication/source_ddl_end_handler.h
@@ -51,4 +51,10 @@ extern void ProcessSourceEventTriggerTableRewrite();
 
 extern void ClearRewrittenTableOidList();
 
+/*
+ * Record the session variables that are known to meaningfully affect how a
+ * replicated query is executed under a "variables" key.
+ */
+extern void PushVariableMap(JsonbParseState *state);
+
 #endif

--- a/src/postgres/yb-extensions/yb_xcluster_ddl_replication/sql/analyze.sql
+++ b/src/postgres/yb-extensions/yb_xcluster_ddl_replication/sql/analyze.sql
@@ -1,7 +1,11 @@
 CALL TEST_reset();
 
 CREATE TABLE analyze_foo(i int PRIMARY KEY, j text);
-INSERT INTO analyze_foo SELECT g, 'value' || (g % 3) FROM generate_series(1, 20) g;
+-- The captured query embeds column values, which can be any text at all,
+-- including something that looks like the dollar quoting tag used to wrap the
+-- generated statements. Such a value must not be able to close the block early.
+INSERT INTO analyze_foo
+  SELECT g, '$yb_xcluster_analyze$ value' || (g % 3) FROM generate_series(1, 20) g;
 CREATE TEMP TABLE analyze_temp_foo(i int PRIMARY KEY);
 
 ANALYZE analyze_foo;
@@ -9,10 +13,12 @@ ANALYZE analyze_temp_foo;  -- temp relations are not replicated
 
 -- Only the permanent relation should have been captured, and the captured query
 -- should be the statistics import statement rather than the ANALYZE itself.
+-- The quote tag must have been extended, since the plain one occurs in the data.
 SELECT yb_data->>'command_tag' AS command_tag,
        yb_data->>'query' LIKE '%pg_restore_relation_stats%' AS has_relation_stats,
        yb_data->>'query' LIKE '%pg_restore_attribute_stats%' AS has_attribute_stats,
-       yb_data->>'query' LIKE '%analyze_temp_foo%' AS has_temp_relation
+       yb_data->>'query' LIKE '%analyze_temp_foo%' AS has_temp_relation,
+       yb_data->>'query' LIKE 'DO $yb_xcluster_analyzex$%' AS has_extended_quote_tag
   FROM yb_xcluster_ddl_replication.ddl_queue
   WHERE yb_data->>'command_tag' = 'ANALYZE'
   ORDER BY ddl_end_time;

--- a/src/postgres/yb-extensions/yb_xcluster_ddl_replication/sql/analyze.sql
+++ b/src/postgres/yb-extensions/yb_xcluster_ddl_replication/sql/analyze.sql
@@ -1,0 +1,61 @@
+CALL TEST_reset();
+
+CREATE TABLE analyze_foo(i int PRIMARY KEY, j text);
+INSERT INTO analyze_foo SELECT g, 'value' || (g % 3) FROM generate_series(1, 20) g;
+CREATE TEMP TABLE analyze_temp_foo(i int PRIMARY KEY);
+
+ANALYZE analyze_foo;
+ANALYZE analyze_temp_foo;  -- temp relations are not replicated
+
+-- Only the permanent relation should have been captured, and the captured query
+-- should be the statistics import statement rather than the ANALYZE itself.
+SELECT yb_data->>'command_tag' AS command_tag,
+       yb_data->>'query' LIKE '%pg_restore_relation_stats%' AS has_relation_stats,
+       yb_data->>'query' LIKE '%pg_restore_attribute_stats%' AS has_attribute_stats,
+       yb_data->>'query' LIKE '%analyze_temp_foo%' AS has_temp_relation
+  FROM yb_xcluster_ddl_replication.ddl_queue
+  WHERE yb_data->>'command_tag' = 'ANALYZE'
+  ORDER BY ddl_end_time;
+
+SELECT TEST_verify_replicated_ddls();
+
+-- Now verify that replaying the captured query reproduces the statistics, which
+-- is what the target universe does.
+CREATE TEMP TABLE saved_stats AS
+  SELECT attname, inherited, null_frac, avg_width, n_distinct,
+         most_common_vals::text AS most_common_vals,
+         most_common_freqs,
+         histogram_bounds::text AS histogram_bounds,
+         correlation
+    FROM pg_stats WHERE schemaname = 'public' AND tablename = 'analyze_foo';
+
+CREATE TEMP TABLE saved_relstats AS
+  SELECT relpages, reltuples, relallvisible
+    FROM pg_class WHERE oid = 'public.analyze_foo'::regclass;
+
+SELECT pg_catalog.pg_clear_attribute_stats('public', 'analyze_foo', attname, inherited)
+  FROM saved_stats;
+SELECT pg_catalog.pg_clear_relation_stats('public', 'analyze_foo');
+SELECT count(*) AS remaining_stats
+  FROM pg_stats WHERE schemaname = 'public' AND tablename = 'analyze_foo';
+
+SELECT yb_data->>'query' FROM yb_xcluster_ddl_replication.ddl_queue
+  WHERE yb_data->>'command_tag' = 'ANALYZE' \gexec
+
+SELECT s.attname, s.inherited,
+       (s.null_frac IS NOT DISTINCT FROM p.null_frac AND
+        s.avg_width IS NOT DISTINCT FROM p.avg_width AND
+        s.n_distinct IS NOT DISTINCT FROM p.n_distinct AND
+        s.most_common_vals IS NOT DISTINCT FROM p.most_common_vals::text AND
+        s.most_common_freqs IS NOT DISTINCT FROM p.most_common_freqs AND
+        s.histogram_bounds IS NOT DISTINCT FROM p.histogram_bounds::text AND
+        s.correlation IS NOT DISTINCT FROM p.correlation) AS stats_match
+  FROM saved_stats s
+  JOIN pg_stats p ON p.schemaname = 'public' AND p.tablename = 'analyze_foo'
+                 AND p.attname = s.attname AND p.inherited = s.inherited
+  ORDER BY s.attname, s.inherited;
+
+SELECT s.relpages IS NOT DISTINCT FROM c.relpages AND
+       s.reltuples IS NOT DISTINCT FROM c.reltuples AND
+       s.relallvisible IS NOT DISTINCT FROM c.relallvisible AS relstats_match
+  FROM saved_relstats s, pg_class c WHERE c.oid = 'public.analyze_foo'::regclass;

--- a/src/postgres/yb-extensions/yb_xcluster_ddl_replication/yb_schedule
+++ b/src/postgres/yb-extensions/yb_xcluster_ddl_replication/yb_schedule
@@ -7,6 +7,7 @@ test: create_drop_index
 
 test: mixed_temporary_and_persistent
 test: truncate
+test: analyze
 test: materialized_views
 
 test: colocated_setup

--- a/src/postgres/yb-extensions/yb_xcluster_ddl_replication/yb_schedule
+++ b/src/postgres/yb-extensions/yb_xcluster_ddl_replication/yb_schedule
@@ -7,10 +7,11 @@ test: create_drop_index
 
 test: mixed_temporary_and_persistent
 test: truncate
-test: analyze
 test: materialized_views
 
 test: colocated_setup
 test: create_colocated_table
 
 test: table_rewrite
+
+test: analyze

--- a/src/postgres/yb-extensions/yb_xcluster_ddl_replication/yb_xcluster_ddl_replication.c
+++ b/src/postgres/yb-extensions/yb_xcluster_ddl_replication/yb_xcluster_ddl_replication.c
@@ -21,9 +21,11 @@
 #include "catalog/pg_type_d.h"
 #include "commands/event_trigger.h"
 #include "commands/extension.h"
+#include "commands/vacuum.h"
 #include "executor/spi.h"
 #include "extension_util.h"
 #include "json_util.h"
+#include "source_analyze_handler.h"
 #include "source_ddl_end_handler.h"
 #include "utils/builtins.h"
 #include "utils/fmgrprotos.h"
@@ -80,6 +82,7 @@ char *current_extension_name = NULL;
  * Util functions.
  */
 static void RecordTempRelationDDL();
+static void XClusterAnalyzeRelEnd(Oid relid);
 static void XClusterProcessUtility(PlannedStmt *pstmt,
 								   const char *queryString,
 								   bool readOnlyTree,
@@ -103,6 +106,7 @@ static bool yb_should_replicate_ddl = false;
 
 static YbcRecordTempRelationDDL_hook_type prev_YBCRecordTempRelationDDL = NULL;
 static ProcessUtility_hook_type prev_ProcessUtility = NULL;
+static YbAnalyzeRelEnd_hook_type prev_YbAnalyzeRelEnd = NULL;
 
 /*
  * The GUC variables `enable_manual_ddl_replication` and
@@ -187,6 +191,8 @@ _PG_init(void)
 	prev_ProcessUtility = ProcessUtility_hook;
 	ProcessUtility_hook = XClusterProcessUtility;
 
+	prev_YbAnalyzeRelEnd = YbAnalyzeRelEnd_hook;
+	YbAnalyzeRelEnd_hook = XClusterAnalyzeRelEnd;
 }
 
 void
@@ -719,6 +725,101 @@ handle_table_rewrite(PG_FUNCTION_ARGS)
 	}
 
 	PG_RETURN_NULL();
+}
+
+/*
+ * ANALYZE is not a DDL, so it does not fire the ddl_command_end event trigger.
+ * Instead the YbAnalyzeRelEnd hook calls us once per analyzed relation, and we
+ * queue up the statistics that were just computed. The target applies them
+ * directly and ends up with the same statistics as the source without having to
+ * sample any data itself.
+ */
+static void
+HandleSourceAnalyzeEnd(Oid relid)
+{
+	/* Create memory context for handling json creation + query execution. */
+	MemoryContext context_new,
+				context_old;
+	Oid			save_userid;
+	int			save_sec_context;
+
+	INIT_MEM_CONTEXT_AND_SPI_CONNECT("yb_xcluster_ddl_replication.HandleSourceAnalyzeEnd context");
+
+	char	   *stats_query = BuildRestoreStatsQuery(relid);
+
+	if (stats_query)
+	{
+		JsonbParseState *state = NULL;
+
+		(void) pushJsonbValue(&state, WJB_BEGIN_OBJECT, NULL);
+		(void) AddNumericJsonEntry(state, "version", 1);
+		(void) AddStringJsonEntry(state, "query", stats_query);
+		(void) AddStringJsonEntry(state, "command_tag",
+								  GetCommandTagName(CMDTAG_ANALYZE));
+
+		const char *current_user = GetUserNameFromId(save_userid, false);
+
+		if (current_user)
+			(void) AddStringJsonEntry(state, "user", current_user);
+
+		/*
+		 * No "schema" entry is needed: the generated query names every relation
+		 * with its schema. Session variables are still recorded as they affect
+		 * how the string literals in it are parsed.
+		 */
+		PushVariableMap(state);
+
+		JsonbValue *jsonb_val = pushJsonbValue(&state, WJB_END_OBJECT, NULL);
+		Jsonb	   *jsonb = JsonbValueToJsonb(jsonb_val);
+
+		TimestampTz epoch_time = (GetCurrentTimestamp() - SetEpochTimestamp());
+		int64		query_id = random();
+
+		InsertIntoTable(DDL_QUEUE_TABLE_NAME, epoch_time, query_id, jsonb);
+
+		/*
+		 * Also insert into the replicated_ddls table to handle switchovers, see
+		 * HandleSourceDDLEnd for details.
+		 */
+		InsertIntoReplicatedDDLs(epoch_time, query_id);
+	}
+
+	CLOSE_MEM_CONTEXT_AND_SPI;
+}
+
+static void
+XClusterAnalyzeRelEnd(Oid relid)
+{
+	if (prev_YbAnalyzeRelEnd)
+		prev_YbAnalyzeRelEnd(relid);
+
+	/*
+	 * Statistics are only captured on the source of an automatic mode
+	 * replication.
+	 *
+	 * Unlike the DDL paths, we do not error out when the role cannot be
+	 * fetched. Statistics are only a planner input, so failing to replicate
+	 * them leaves the target with stale statistics but is otherwise harmless,
+	 * and ANALYZE should not start failing because of it.
+	 */
+	int			role = (replication_role_override != XCLUSTER_ROLE_UNSPECIFIED ?
+						replication_role_override :
+						YBCGetXClusterRole(MyDatabaseId));
+
+	if (role != XCLUSTER_ROLE_AUTOMATIC_SOURCE)
+		return;
+
+	/*
+	 * In manual mode the user is responsible for running the DDLs, and hence
+	 * ANALYZE, on the target themselves.
+	 */
+	if (enable_manual_ddl_replication)
+		return;
+
+	if (!ShouldReplicateAnalyzedRelation(relid))
+		return;
+
+	HandleSourceAnalyzeEnd(relid);
 }
 
 static void

--- a/src/yb/integration-tests/xcluster/xcluster_ddl_replication-test.cc
+++ b/src/yb/integration-tests/xcluster/xcluster_ddl_replication-test.cc
@@ -4042,8 +4042,12 @@ TEST_F(XClusterDDLReplicationTest, AnalyzeTable) {
   ASSERT_OK(SetUpClustersAndReplication());
 
   ASSERT_OK(producer_conn_->Execute("CREATE TABLE tbl1(id int PRIMARY KEY, col1 int, col2 text)"));
+  // The replicated statement embeds column values, which can be any text at all, including
+  // something that looks like the dollar quoting tag used to wrap it. Such a value must not be able
+  // to close that block early and change what the target ends up executing.
   ASSERT_OK(producer_conn_->Execute(
-      "INSERT INTO tbl1 SELECT g, g % 5, 'value' || (g % 7) FROM generate_series(1, 100) g"));
+      "INSERT INTO tbl1 SELECT g, g % 5, '$yb_xcluster_analyze$ value' || (g % 7) "
+      "FROM generate_series(1, 100) g"));
   // Expression indexes get their own pg_statistic rows, so they exercise the index path.
   ASSERT_OK(producer_conn_->Execute("CREATE INDEX tbl1_expr_idx ON tbl1((col1 + 1))"));
   ASSERT_OK(WaitForSafeTimeToAdvanceToNow());
@@ -4072,7 +4076,8 @@ TEST_F(XClusterDDLReplicationTest, AnalyzeTable) {
 
   // Re-analyzing after the data changed should refresh the target's statistics as well.
   ASSERT_OK(producer_conn_->Execute(
-      "INSERT INTO tbl1 SELECT g, g % 5, 'value' || (g % 7) FROM generate_series(101, 500) g"));
+      "INSERT INTO tbl1 SELECT g, g % 5, '$yb_xcluster_analyze$ value' || (g % 7) "
+      "FROM generate_series(101, 500) g"));
   ASSERT_OK(producer_conn_->Execute("ANALYZE"));
   ASSERT_OK(WaitForSafeTimeToAdvanceToNow());
 

--- a/src/yb/integration-tests/xcluster/xcluster_ddl_replication-test.cc
+++ b/src/yb/integration-tests/xcluster/xcluster_ddl_replication-test.cc
@@ -4036,6 +4036,59 @@ TEST_F(XClusterDDLReplicationTest, TruncateTable) {
   ASSERT_OK(verify_data());
 }
 
+// ANALYZE is not a DDL, but the statistics it computes are replicated so that the target ends up
+// with the same statistics without having to sample any data itself.
+TEST_F(XClusterDDLReplicationTest, AnalyzeTable) {
+  ASSERT_OK(SetUpClustersAndReplication());
+
+  ASSERT_OK(producer_conn_->Execute("CREATE TABLE tbl1(id int PRIMARY KEY, col1 int, col2 text)"));
+  ASSERT_OK(producer_conn_->Execute(
+      "INSERT INTO tbl1 SELECT g, g % 5, 'value' || (g % 7) FROM generate_series(1, 100) g"));
+  // Expression indexes get their own pg_statistic rows, so they exercise the index path.
+  ASSERT_OK(producer_conn_->Execute("CREATE INDEX tbl1_expr_idx ON tbl1((col1 + 1))"));
+  ASSERT_OK(WaitForSafeTimeToAdvanceToNow());
+
+  const auto stats_query =
+      "SELECT tablename, attname, inherited, null_frac, avg_width, n_distinct, "
+      "most_common_vals::text, most_common_freqs::text, histogram_bounds::text, correlation "
+      "FROM pg_stats WHERE schemaname = 'public' ORDER BY tablename, attname, inherited";
+  const auto relstats_query =
+      "SELECT relname, relpages, reltuples, relallvisible FROM pg_class "
+      "WHERE relname IN ('tbl1', 'tbl1_expr_idx') ORDER BY relname";
+
+  // Neither side has any column statistics yet.
+  ASSERT_EQ(ASSERT_RESULT(producer_conn_->FetchAllAsString(stats_query)), "");
+  ASSERT_EQ(ASSERT_RESULT(consumer_conn_->FetchAllAsString(stats_query)), "");
+
+  ASSERT_OK(producer_conn_->Execute("ANALYZE tbl1"));
+  ASSERT_OK(WaitForSafeTimeToAdvanceToNow());
+
+  auto producer_stats = ASSERT_RESULT(producer_conn_->FetchAllAsString(stats_query));
+  ASSERT_FALSE(producer_stats.empty());
+  ASSERT_EQ(ASSERT_RESULT(consumer_conn_->FetchAllAsString(stats_query)), producer_stats);
+  ASSERT_EQ(
+      ASSERT_RESULT(consumer_conn_->FetchAllAsString(relstats_query)),
+      ASSERT_RESULT(producer_conn_->FetchAllAsString(relstats_query)));
+
+  // Re-analyzing after the data changed should refresh the target's statistics as well.
+  ASSERT_OK(producer_conn_->Execute(
+      "INSERT INTO tbl1 SELECT g, g % 5, 'value' || (g % 7) FROM generate_series(101, 500) g"));
+  ASSERT_OK(producer_conn_->Execute("ANALYZE"));
+  ASSERT_OK(WaitForSafeTimeToAdvanceToNow());
+
+  auto new_producer_stats = ASSERT_RESULT(producer_conn_->FetchAllAsString(stats_query));
+  ASSERT_NE(new_producer_stats, producer_stats);
+  ASSERT_EQ(ASSERT_RESULT(consumer_conn_->FetchAllAsString(stats_query)), new_producer_stats);
+  ASSERT_EQ(
+      ASSERT_RESULT(consumer_conn_->FetchAllAsString(relstats_query)),
+      ASSERT_RESULT(producer_conn_->FetchAllAsString(relstats_query)));
+
+  // Analyzing a temp table is a no-op for replication and must not break either side.
+  ASSERT_OK(producer_conn_->Execute("CREATE TEMP TABLE tbl_tmp(id int)"));
+  ASSERT_OK(producer_conn_->Execute("ANALYZE tbl_tmp"));
+  ASSERT_OK(WaitForSafeTimeToAdvanceToNow());
+}
+
 // Make sure we can run a variety of DDLs related to temp tables on both clusters.
 TEST_F(XClusterDDLReplicationTest, TempTableDDLs) {
   ASSERT_OK(SetUpClustersAndReplication());

--- a/src/yb/tserver/xcluster_ddl_queue_handler-test.cc
+++ b/src/yb/tserver/xcluster_ddl_queue_handler-test.cc
@@ -573,7 +573,7 @@ TEST_F(XClusterTransactionalDDLQueueHandlerMockedTest, TransactionalDDLMixedManu
   // The manual EXECUTE should be issued first, then the auto queries wrapped in BEGIN/COMMIT.
   ASSERT_EQ(ddl_queue_handler.txn_control_queries_.size(), 3);
   ASSERT_STR_CONTAINS(
-      ddl_queue_handler.txn_control_queries_[0], "EXECUTE manual_replication_insert");
+      ddl_queue_handler.txn_control_queries_[0], "EXECUTE replicated_ddls_insert");
   ASSERT_EQ(ddl_queue_handler.txn_control_queries_[1], "BEGIN");
   ASSERT_EQ(ddl_queue_handler.txn_control_queries_[2], "COMMIT");
 }

--- a/src/yb/tserver/xcluster_ddl_queue_handler.cc
+++ b/src/yb/tserver/xcluster_ddl_queue_handler.cc
@@ -114,7 +114,7 @@ const char* kDDLJsonTypeInfo = "type_info";
 const char* kDDLJsonSequenceInfo = "sequence_info";
 const char* kDDLJsonVariableMap = "variables";
 const char* kDDLJsonManualReplication = "manual_replication";
-const char* kDDLPrepStmtManualInsert = "manual_replication_insert";
+const char* kDDLPrepStmtReplicatedDdlsInsert = "replicated_ddls_insert";
 const char* kDDLPrepStmtAlreadyProcessed = "already_processed_row";
 const char* kDDLPrepStmtCommitTimesUpsert = "commit_times_insert";
 const char* kDDLPrepStmtCommitTimesSelect = "commit_times_select";
@@ -143,6 +143,7 @@ const std::unordered_set<std::string> kSupportedCommandTags {
     "ALTER SEQUENCE",
     "TRUNCATE TABLE",
     "REFRESH MATERIALIZED VIEW",
+    "ANALYZE",
     // Pass thru DDLs
     "CREATE ACCESS METHOD",
     "CREATE AGGREGATE",
@@ -224,6 +225,16 @@ const std::unordered_set<std::string> kSupportedCommandTags {
     "REVOKE",
     "IMPORT FOREIGN SCHEMA",
     "SECURITY LABEL",
+};
+
+// Command tags whose replicated query is not actually a DDL and so does not fire the
+// ddl_command_end event trigger on the target. The extension records every DDL it executes in
+// replicated_ddls from that trigger; for these we have to do it ourselves, otherwise the entry
+// would be reprocessed.
+const std::unordered_set<std::string> kNonDdlCommandTags{
+    // ANALYZE is replicated as a set of pg_restore_relation_stats /
+    // pg_restore_attribute_stats calls wrapped in a DO block.
+    "ANALYZE",
 };
 
 bool IsAllowedGucVariable(const std::string& name) {
@@ -585,6 +596,13 @@ Status XClusterDDLQueueHandler::ProcessDDLQuery(const XClusterDDLQueryInfo& quer
       // The SELECT here can't be last; otherwise, RunAndLogQuery complains that rows are returned.
       RunAndLogQuery(
           "SELECT pg_catalog.yb_xcluster_set_next_oid_assignments('{}');SET ROLE NONE;"));
+
+  // DDLs record themselves in replicated_ddls from the extension's ddl_command_end event trigger.
+  // Queries that are not DDLs never fire that trigger, so do it here instead.
+  if (kNonDdlCommandTags.contains(query_info.command_tag)) {
+    RETURN_NOT_OK(InsertIntoReplicatedDDLs(query_info, /* is_manual_execution */ false));
+  }
+
   return Status::OK();
 }
 
@@ -624,15 +642,22 @@ Status XClusterDDLQueueHandler::CheckForFailedQuery() {
 
 Status XClusterDDLQueueHandler::ProcessManualExecutionQuery(
     const XClusterDDLQueryInfo& query_info) {
+  return InsertIntoReplicatedDDLs(query_info, /* is_manual_execution */ true);
+}
+
+Status XClusterDDLQueueHandler::InsertIntoReplicatedDDLs(
+    const XClusterDDLQueryInfo& query_info, bool is_manual_execution) {
   rapidjson::Document doc;
   doc.SetObject();
   doc.AddMember(
       rapidjson::StringRef(kDDLJsonQuery),
       rapidjson::Value(query_info.query.c_str(), doc.GetAllocator()), doc.GetAllocator());
-  doc.AddMember(rapidjson::StringRef(kDDLJsonManualReplication), true, doc.GetAllocator());
+  if (is_manual_execution) {
+    doc.AddMember(rapidjson::StringRef(kDDLJsonManualReplication), true, doc.GetAllocator());
+  }
 
   RETURN_NOT_OK(RunAndLogQuery(Format(
-      "EXECUTE $0($1, $2, $3)", kDDLPrepStmtManualInsert, query_info.ddl_end_time,
+      "EXECUTE $0($1, $2, $3)", kDDLPrepStmtReplicatedDdlsInsert, query_info.ddl_end_time,
       query_info.query_id, pgwrapper::PqEscapeLiteral(common::WriteRapidJsonToString(doc)))));
   return Status::OK();
 }
@@ -659,7 +684,7 @@ Status XClusterDDLQueueHandler::RunDdlQueueHandlerPrepareQueries(pgwrapper::PGCo
   // index backfill uses a different flow). Skip sequence restart for TRUNCATE TABLE.
   query << "SET yb_xcluster_automatic_mode_target_ddl=true;";
   // Prepare replicated_ddls insert for manually replicated ddls.
-  query << "PREPARE " << kDDLPrepStmtManualInsert << "(bigint, bigint, text) AS "
+  query << "PREPARE " << kDDLPrepStmtReplicatedDdlsInsert << "(bigint, bigint, text) AS "
         << "INSERT INTO " << kReplicatedDDLsFullTableName << " VALUES ($1, $2, $3::jsonb);";
   // Prepare replicated_ddls select query.
   query << "PREPARE " << kDDLPrepStmtAlreadyProcessed << "(bigint, bigint) AS "

--- a/src/yb/tserver/xcluster_ddl_queue_handler.cc
+++ b/src/yb/tserver/xcluster_ddl_queue_handler.cc
@@ -683,7 +683,8 @@ Status XClusterDDLQueueHandler::RunDdlQueueHandlerPrepareQueries(pgwrapper::PGCo
   // Skip any data loads on the target since those records will be replicated (note that concurrent
   // index backfill uses a different flow). Skip sequence restart for TRUNCATE TABLE.
   query << "SET yb_xcluster_automatic_mode_target_ddl=true;";
-  // Prepare replicated_ddls insert for manually replicated ddls.
+  // Prepare replicated_ddls insert for manually replicated ddls and for non DDL queries, which do
+  // not record themselves via the ddl_command_end event trigger.
   query << "PREPARE " << kDDLPrepStmtReplicatedDdlsInsert << "(bigint, bigint, text) AS "
         << "INSERT INTO " << kReplicatedDDLsFullTableName << " VALUES ($1, $2, $3::jsonb);";
   // Prepare replicated_ddls select query.

--- a/src/yb/tserver/xcluster_ddl_queue_handler.h
+++ b/src/yb/tserver/xcluster_ddl_queue_handler.h
@@ -132,6 +132,9 @@ class XClusterDDLQueueHandler {
 
   Status ProcessManualExecutionQuery(const XClusterDDLQueryInfo& query_info);
 
+  // Records the query in the replicated_ddls table so that it is not processed again.
+  Status InsertIntoReplicatedDDLs(const XClusterDDLQueryInfo& query_info, bool is_manual_execution);
+
   virtual Status InitPGConnection();
   virtual Result<HybridTime> GetXClusterSafeTimeForNamespace();
 


### PR DESCRIPTION
## Summary

`ANALYZE` is not a DDL, so it does not fire the `ddl_command_end` event trigger that
xCluster DDL replication is built on, and the statistics it computes never reach the
target. Auto analyze does not close the gap either: its mutation counters live in the
pggate layer, which xCluster replication bypasses, so the target never decides that a
table needs to be analyzed. Today the only option is a cron job that runs `ANALYZE`
independently on the target.

Rather than replaying `ANALYZE` on the target and making it sample the data all over
again, this captures its output on the source and ships that:

- Adds a `YbAnalyzeRelEnd` hook, fired at the end of `analyze_rel()` once per analyzed
  relation, after `pg_statistic` and `pg_class` have been updated and while the ANALYZE
  locks are still held. This is the equivalent of what we already do for `TRUNCATE`,
  which is also not a DDL in the Postgres sense.

- `yb_xcluster_ddl_replication` registers the hook. On the source it reads back
  `pg_stats` and `pg_class` for the relation and its valid indexes, and queues a `DO`
  block of `pg_restore_relation_stats` / `pg_restore_attribute_stats` calls in
  `ddl_queue` under the `ANALYZE` command tag. The argument names and types mirror what
  `pg_dump` emits for a statistics-only dump. The `DO` wrapper is needed because the
  ddl_queue handler's client rejects result rows and the import functions return a
  boolean.

  Temporary relations, system catalogs and the extension's own tables are skipped, as
  are invalid indexes, which may not exist on the target (see
  `yb_xcluster_handle_phantom_indexes`).

- The ddl_queue handler accepts the `ANALYZE` command tag. Since the queued query is not
  a DDL, it does not fire the event trigger that normally records the entry in
  `replicated_ddls`, so the handler now does that itself for such tags.

The target therefore ends up with the same statistics as the source without doing any
sampling work of its own, and there is no risk of the target's statistics being computed
from data that is ahead of or behind its safe time.

Extended statistics (`CREATE STATISTICS`) are not covered: Postgres has no import
function for them, so each side keeps whatever it computed itself.

## Test plan

- [x] `./yb_build.sh release --java-test org.yb.pgsql.TestPgRegressYbExtensionsYbXclusterDdlReplication`
      (new `analyze` case: verifies the captured entry, that temp relations are skipped,
      and that replaying the captured statement reproduces the statistics exactly)
- [x] `./yb_build.sh release --cxx-test xcluster_ddl_replication-test --gtest_filter XClusterDDLReplicationTest.AnalyzeTable`
      (new end-to-end test: `pg_stats` and `pg_class` statistics match on both universes
      after `ANALYZE`, including an expression index, and after a re-analyze)


- [x] `./yb_build.sh release --cxx-test xcluster_ddl_queue_handler-test` (unaffected by the prepared-statement rename)
