### PR TITLE
[#28748] xCluster: Trigger an ANALYZE on the target when the source analyzes

### DIFF
--- a/src/postgres/src/backend/commands/analyze.c
+++ b/src/postgres/src/backend/commands/analyze.c
@@ -89,6 +89,9 @@ typedef struct AnlIndexData
 /* Default statistics target (GUC parameter) */
 int			default_statistics_target = 100;
 
+/* YB: Hook fired at the end of analyze_rel(), see vacuum.h. */
+YbAnalyzeRelEnd_hook_type YbAnalyzeRelEnd_hook = NULL;
+
 /* A few variables that don't seem worth passing around as parameters */
 static MemoryContext anl_context = NULL;
 static BufferAccessStrategy vac_strategy;
@@ -291,6 +294,14 @@ analyze_rel(Oid relid, RangeVar *relation,
 	 * expose us to concurrent-update failures in update_attstats.)
 	 */
 	relation_close(onerel, NoLock);
+
+	/*
+	 * YB: Notify any extension that this relation's statistics were refreshed.
+	 * Done while we still hold the ANALYZE lock and inside the same transaction
+	 * that wrote the new statistics.
+	 */
+	if (YbAnalyzeRelEnd_hook)
+		YbAnalyzeRelEnd_hook(relid);
 
 	pgstat_progress_end_command();
 }

--- a/src/postgres/src/include/commands/vacuum.h
+++ b/src/postgres/src/include/commands/vacuum.h
@@ -332,6 +332,16 @@ extern void analyze_rel(Oid relid, RangeVar *relation,
 						BufferAccessStrategy bstrategy);
 extern bool std_typanalyze(VacAttrStats *stats);
 
+/*
+ * YB: Hook fired once per relation whose statistics were just refreshed by
+ * ANALYZE, after pg_statistic and pg_class have been updated but while we still
+ * hold the ANALYZE locks. ANALYZE is not a DDL, so it does not fire the
+ * ddl_command_end event trigger; this hook lets yb_xcluster_ddl_replication
+ * capture the resulting statistics for replication to the target universe.
+ */
+typedef void (*YbAnalyzeRelEnd_hook_type) (Oid relid);
+extern PGDLLIMPORT YbAnalyzeRelEnd_hook_type YbAnalyzeRelEnd_hook;
+
 /* in utils/misc/sampling.c --- duplicate of declarations in utils/sampling.h */
 extern double anl_random_fract(void);
 extern double anl_init_selection_state(int n);

--- a/src/postgres/yb-extensions/yb_xcluster_ddl_replication/expected/analyze.out
+++ b/src/postgres/yb-extensions/yb_xcluster_ddl_replication/expected/analyze.out
@@ -1,0 +1,54 @@
+CALL TEST_reset();
+CREATE TABLE analyze_foo(i int PRIMARY KEY, j text);
+INSERT INTO analyze_foo SELECT g, 'value' || (g % 3) FROM generate_series(1, 20) g;
+CREATE TEMP TABLE analyze_temp_foo(i int PRIMARY KEY);
+ANALYZE analyze_foo;
+ANALYZE analyze_temp_foo;  -- temp relations are not replicated
+-- Only the permanent relation should have been captured. The entry names the
+-- relation so that the target can mark it as needing an ANALYZE of its own; the
+-- statistics themselves are not shipped.
+SELECT yb_data->>'command_tag' AS command_tag,
+       yb_data->>'query' AS query,
+       yb_data->'analyze_rels' AS analyze_rels
+  FROM yb_xcluster_ddl_replication.ddl_queue
+  WHERE yb_data->>'command_tag' = 'ANALYZE'
+  ORDER BY ddl_end_time;
+ command_tag |           query            |                       analyze_rels                       
+-------------+----------------------------+----------------------------------------------------------
+ ANALYZE     | ANALYZE public.analyze_foo | [{"rel_name": "analyze_foo", "rel_namespace": "public"}]
+(1 row)
+
+SELECT TEST_verify_replicated_ddls();
+ test_verify_replicated_ddls 
+-----------------------------
+ t
+(1 row)
+
+-- Analyzing a single column, or several relations at once, is captured the same
+-- way: one entry per relation whose statistics were refreshed.
+CALL TEST_reset();
+CREATE TABLE analyze_bar(a int, b int);
+ANALYZE analyze_foo(j), analyze_bar;
+SELECT yb_data->>'query' AS query
+  FROM yb_xcluster_ddl_replication.ddl_queue
+  WHERE yb_data->>'command_tag' = 'ANALYZE'
+  ORDER BY yb_data->>'query';
+           query            
+----------------------------
+ ANALYZE public.analyze_bar
+ ANALYZE public.analyze_foo
+(2 rows)
+
+-- Quoting is preserved for names that need it.
+CALL TEST_reset();
+CREATE TABLE "Analyze Quoted"(i int);
+ANALYZE "Analyze Quoted";
+SELECT yb_data->>'query' AS query,
+       yb_data->'analyze_rels' AS analyze_rels
+  FROM yb_xcluster_ddl_replication.ddl_queue
+  WHERE yb_data->>'command_tag' = 'ANALYZE';
+              query              |                        analyze_rels                         
+---------------------------------+-------------------------------------------------------------
+ ANALYZE public."Analyze Quoted" | [{"rel_name": "Analyze Quoted", "rel_namespace": "public"}]
+(1 row)
+

--- a/src/postgres/yb-extensions/yb_xcluster_ddl_replication/source_ddl_end_handler.c
+++ b/src/postgres/yb-extensions/yb_xcluster_ddl_replication/source_ddl_end_handler.c
@@ -17,6 +17,7 @@
 
 #include "postgres.h"
 
+#include "catalog/catalog.h"
 #include "catalog/namespace.h"
 #include "catalog/partition.h"
 #include "catalog/pg_am_d.h"
@@ -24,6 +25,7 @@
 #include "catalog/pg_amproc_d.h"
 #include "catalog/pg_attrdef_d.h"
 #include "catalog/pg_cast_d.h"
+#include "catalog/pg_class.h"
 #include "catalog/pg_collation_d.h"
 #include "catalog/pg_constraint_d.h"
 #include "catalog/pg_conversion_d.h"
@@ -65,6 +67,7 @@
 #include "utils/lsyscache.h"
 #include "utils/palloc.h"
 #include "utils/rel.h"
+#include "utils/syscache.h"
 
 #define DDL_END_CLASSID_COLUMN_ID	  1
 #define DDL_END_OBJID_COLUMN_ID		  2
@@ -1191,4 +1194,69 @@ ClearRewrittenTableOidList()
 {
 	list_free(rewritten_table_oid_list);
 	rewritten_table_oid_list = NIL;
+}
+
+bool
+ShouldReplicateAnalyzedRelation(Oid relid)
+{
+	HeapTuple	tuple = SearchSysCache1(RELOID, ObjectIdGetDatum(relid));
+
+	if (!HeapTupleIsValid(tuple))
+		return false;
+
+	Form_pg_class relform = (Form_pg_class) GETSTRUCT(tuple);
+	Oid			relnamespace = relform->relnamespace;
+	bool		is_temp = (relform->relpersistence == RELPERSISTENCE_TEMP);
+
+	ReleaseSysCache(tuple);
+
+	/* Temporary relations are session local and are never replicated. */
+	if (is_temp)
+		return false;
+
+	/*
+	 * System catalogs (which includes information_schema) are maintained
+	 * independently by each universe.
+	 */
+	if (IsCatalogRelationOid(relid))
+		return false;
+
+	/*
+	 * The extension's own tables are replicated as ordinary data; there is no
+	 * point in refreshing statistics for them on the target.
+	 */
+	char	   *nspname = get_namespace_name(relnamespace);
+
+	if (nspname && strcmp(nspname, EXTENSION_NAME) == 0)
+		return false;
+
+	return true;
+}
+
+/*
+ * Records the analyzed relation under an "analyze_rels" key, and returns the
+ * ANALYZE statement naming it.
+ *
+ * The target does not run that statement, it only uses the relation to find
+ * which of its own tables to mark as needing an ANALYZE. The statement is
+ * recorded so that a ddl_queue entry is still readable on its own.
+ */
+char *
+PushAnalyzedRelation(JsonbParseState *state, Oid relid)
+{
+	char	   *relname = get_rel_name(relid);
+	char	   *nspname = get_namespace_name(get_rel_namespace(relid));
+
+	if (!relname || !nspname)
+		return NULL;
+
+	AddJsonKey(state, "analyze_rels");
+	(void) pushJsonbValue(&state, WJB_BEGIN_ARRAY, NULL);
+	(void) pushJsonbValue(&state, WJB_BEGIN_OBJECT, NULL);
+	AddStringJsonEntry(state, "rel_name", relname);
+	AddStringJsonEntry(state, "rel_namespace", nspname);
+	(void) pushJsonbValue(&state, WJB_END_OBJECT, NULL);
+	(void) pushJsonbValue(&state, WJB_END_ARRAY, NULL);
+
+	return psprintf("ANALYZE %s", quote_qualified_identifier(nspname, relname));
 }

--- a/src/postgres/yb-extensions/yb_xcluster_ddl_replication/source_ddl_end_handler.h
+++ b/src/postgres/yb-extensions/yb_xcluster_ddl_replication/source_ddl_end_handler.h
@@ -51,4 +51,17 @@ extern void ProcessSourceEventTriggerTableRewrite();
 
 extern void ClearRewrittenTableOidList();
 
+/*
+ * Returns whether an ANALYZE of this relation is worth telling the target
+ * about. Temporary relations, system catalogs and the extension's own tables
+ * are skipped.
+ */
+extern bool ShouldReplicateAnalyzedRelation(Oid relid);
+
+/*
+ * Records the analyzed relation in the ddl_queue entry being built, and returns
+ * the ANALYZE statement naming it (or NULL if the relation has gone away).
+ */
+extern char *PushAnalyzedRelation(JsonbParseState *state, Oid relid);
+
 #endif

--- a/src/postgres/yb-extensions/yb_xcluster_ddl_replication/sql/analyze.sql
+++ b/src/postgres/yb-extensions/yb_xcluster_ddl_replication/sql/analyze.sql
@@ -1,0 +1,41 @@
+CALL TEST_reset();
+
+CREATE TABLE analyze_foo(i int PRIMARY KEY, j text);
+INSERT INTO analyze_foo SELECT g, 'value' || (g % 3) FROM generate_series(1, 20) g;
+CREATE TEMP TABLE analyze_temp_foo(i int PRIMARY KEY);
+
+ANALYZE analyze_foo;
+ANALYZE analyze_temp_foo;  -- temp relations are not replicated
+
+-- Only the permanent relation should have been captured. The entry names the
+-- relation so that the target can mark it as needing an ANALYZE of its own; the
+-- statistics themselves are not shipped.
+SELECT yb_data->>'command_tag' AS command_tag,
+       yb_data->>'query' AS query,
+       yb_data->'analyze_rels' AS analyze_rels
+  FROM yb_xcluster_ddl_replication.ddl_queue
+  WHERE yb_data->>'command_tag' = 'ANALYZE'
+  ORDER BY ddl_end_time;
+
+SELECT TEST_verify_replicated_ddls();
+
+-- Analyzing a single column, or several relations at once, is captured the same
+-- way: one entry per relation whose statistics were refreshed.
+CALL TEST_reset();
+CREATE TABLE analyze_bar(a int, b int);
+ANALYZE analyze_foo(j), analyze_bar;
+
+SELECT yb_data->>'query' AS query
+  FROM yb_xcluster_ddl_replication.ddl_queue
+  WHERE yb_data->>'command_tag' = 'ANALYZE'
+  ORDER BY yb_data->>'query';
+
+-- Quoting is preserved for names that need it.
+CALL TEST_reset();
+CREATE TABLE "Analyze Quoted"(i int);
+ANALYZE "Analyze Quoted";
+
+SELECT yb_data->>'query' AS query,
+       yb_data->'analyze_rels' AS analyze_rels
+  FROM yb_xcluster_ddl_replication.ddl_queue
+  WHERE yb_data->>'command_tag' = 'ANALYZE';

--- a/src/postgres/yb-extensions/yb_xcluster_ddl_replication/yb_schedule
+++ b/src/postgres/yb-extensions/yb_xcluster_ddl_replication/yb_schedule
@@ -13,3 +13,5 @@ test: colocated_setup
 test: create_colocated_table
 
 test: table_rewrite
+
+test: analyze

--- a/src/postgres/yb-extensions/yb_xcluster_ddl_replication/yb_xcluster_ddl_replication.c
+++ b/src/postgres/yb-extensions/yb_xcluster_ddl_replication/yb_xcluster_ddl_replication.c
@@ -21,6 +21,7 @@
 #include "catalog/pg_type_d.h"
 #include "commands/event_trigger.h"
 #include "commands/extension.h"
+#include "commands/vacuum.h"
 #include "executor/spi.h"
 #include "extension_util.h"
 #include "json_util.h"
@@ -80,6 +81,7 @@ char *current_extension_name = NULL;
  * Util functions.
  */
 static void RecordTempRelationDDL();
+static void XClusterAnalyzeRelEnd(Oid relid);
 static void XClusterProcessUtility(PlannedStmt *pstmt,
 								   const char *queryString,
 								   bool readOnlyTree,
@@ -103,6 +105,7 @@ static bool yb_should_replicate_ddl = false;
 
 static YbcRecordTempRelationDDL_hook_type prev_YBCRecordTempRelationDDL = NULL;
 static ProcessUtility_hook_type prev_ProcessUtility = NULL;
+static YbAnalyzeRelEnd_hook_type prev_YbAnalyzeRelEnd = NULL;
 
 /*
  * The GUC variables `enable_manual_ddl_replication` and
@@ -187,6 +190,8 @@ _PG_init(void)
 	prev_ProcessUtility = ProcessUtility_hook;
 	ProcessUtility_hook = XClusterProcessUtility;
 
+	prev_YbAnalyzeRelEnd = YbAnalyzeRelEnd_hook;
+	YbAnalyzeRelEnd_hook = XClusterAnalyzeRelEnd;
 }
 
 void
@@ -719,6 +724,98 @@ handle_table_rewrite(PG_FUNCTION_ARGS)
 	}
 
 	PG_RETURN_NULL();
+}
+
+/*
+ * ANALYZE is not a DDL, so it does not fire the ddl_command_end event trigger.
+ * Instead the YbAnalyzeRelEnd hook calls us once per analyzed relation, and we
+ * queue an entry naming it.
+ *
+ * The target does not run the ANALYZE. It marks its own copy of the relation as
+ * having changed enough to need one, and lets the auto analyze service pick it
+ * up. Sampling on the target is what keeps the statistics consistent with the
+ * data it has actually applied, and it is also what gives it extended
+ * statistics, which have no import function to replicate them with.
+ */
+static void
+HandleSourceAnalyzeEnd(Oid relid)
+{
+	/* Create memory context for handling json creation + query execution. */
+	MemoryContext context_new,
+				context_old;
+	Oid			save_userid;
+	int			save_sec_context;
+
+	INIT_MEM_CONTEXT_AND_SPI_CONNECT("yb_xcluster_ddl_replication.HandleSourceAnalyzeEnd context");
+
+	JsonbParseState *state = NULL;
+
+	(void) pushJsonbValue(&state, WJB_BEGIN_OBJECT, NULL);
+	(void) AddNumericJsonEntry(state, "version", 1);
+
+	char	   *analyze_query = PushAnalyzedRelation(state, relid);
+
+	if (analyze_query)
+	{
+		(void) AddStringJsonEntry(state, "query", analyze_query);
+		(void) AddStringJsonEntry(state, "command_tag",
+								  GetCommandTagName(CMDTAG_ANALYZE));
+
+		const char *current_user = GetUserNameFromId(save_userid, false);
+
+		if (current_user)
+			(void) AddStringJsonEntry(state, "user", current_user);
+
+		JsonbValue *jsonb_val = pushJsonbValue(&state, WJB_END_OBJECT, NULL);
+		Jsonb	   *jsonb = JsonbValueToJsonb(jsonb_val);
+
+		TimestampTz epoch_time = (GetCurrentTimestamp() - SetEpochTimestamp());
+		int64		query_id = random();
+
+		InsertIntoTable(DDL_QUEUE_TABLE_NAME, epoch_time, query_id, jsonb);
+
+		/*
+		 * Also insert into the replicated_ddls table to handle switchovers, see
+		 * HandleSourceDDLEnd for details.
+		 */
+		InsertIntoReplicatedDDLs(epoch_time, query_id);
+	}
+
+	CLOSE_MEM_CONTEXT_AND_SPI;
+}
+
+static void
+XClusterAnalyzeRelEnd(Oid relid)
+{
+	if (prev_YbAnalyzeRelEnd)
+		prev_YbAnalyzeRelEnd(relid);
+
+	/*
+	 * ANALYZE is only captured on the source of an automatic mode replication.
+	 *
+	 * Unlike the DDL paths, we do not error out when the role cannot be
+	 * fetched. Statistics are only a planner input, so failing to tell the
+	 * target about an ANALYZE leaves it with stale statistics but is otherwise
+	 * harmless, and ANALYZE should not start failing because of it.
+	 */
+	int			role = (replication_role_override != XCLUSTER_ROLE_UNSPECIFIED ?
+						replication_role_override :
+						YBCGetXClusterRole(MyDatabaseId));
+
+	if (role != XCLUSTER_ROLE_AUTOMATIC_SOURCE)
+		return;
+
+	/*
+	 * In manual mode the user is responsible for running the DDLs, and hence
+	 * ANALYZE, on the target themselves.
+	 */
+	if (enable_manual_ddl_replication)
+		return;
+
+	if (!ShouldReplicateAnalyzedRelation(relid))
+		return;
+
+	HandleSourceAnalyzeEnd(relid);
 }
 
 static void

--- a/src/yb/integration-tests/xcluster/xcluster_ddl_replication-test.cc
+++ b/src/yb/integration-tests/xcluster/xcluster_ddl_replication-test.cc
@@ -61,13 +61,17 @@ DECLARE_uint32(xcluster_ddl_tables_retention_secs);
 DECLARE_uint32(xcluster_max_old_schema_versions);
 DECLARE_bool(xcluster_enable_target_applied_filter);
 DECLARE_bool(xcluster_target_manual_override);
+DECLARE_uint32(ysql_cluster_level_mutation_persist_interval_ms);
 DECLARE_uint64(ysql_cdc_active_replication_slot_window_ms);
 DECLARE_string(ysql_cron_database_name);
+DECLARE_bool(ysql_enable_auto_analyze);
+DECLARE_bool(ysql_enable_auto_analyze_infra);
 DECLARE_bool(ysql_enable_packed_row);
 DECLARE_uint32(ysql_oid_cache_prefetch_size);
 DECLARE_bool(enable_object_locking_for_table_locks);
 DECLARE_bool(ysql_yb_ddl_transaction_block_enabled);
 DECLARE_bool(ysql_enable_concurrent_ddl);
+DECLARE_uint64(ysql_node_level_mutation_reporting_interval_ms);
 DECLARE_string(ysql_pg_conf_csv);
 DECLARE_int32(ysql_sequence_cache_minval);
 DECLARE_bool(ysql_yb_ddl_transaction_block_enabled);
@@ -4034,6 +4038,81 @@ TEST_F(XClusterDDLReplicationTest, TruncateTable) {
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_xcluster_ddl_queue_handler_fail_at_start) = false;
 
   ASSERT_OK(verify_data());
+}
+
+// ANALYZE is not a DDL and is not replayed on the target. The target is told which relation was
+// analyzed and marks it as needing an ANALYZE of its own, which the auto analyze service then
+// performs. Sampling on the target is what keeps its statistics consistent with the data it has
+// applied, and it is also what produces its extended statistics.
+class XClusterDDLReplicationAutoAnalyzeTest : public XClusterDDLReplicationTest {
+ public:
+  void SetUp() override {
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_ysql_enable_auto_analyze_infra) = true;
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_ysql_enable_auto_analyze) = true;
+    // Keep the mutation reporting and persisting intervals low so the test does not have to wait
+    // out the default ten second cycles.
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_ysql_node_level_mutation_reporting_interval_ms) = 10;
+    ANNOTATE_UNPROTECTED_WRITE(FLAGS_ysql_cluster_level_mutation_persist_interval_ms) = 10;
+    XClusterDDLReplicationTest::SetUp();
+  }
+};
+
+TEST_F(XClusterDDLReplicationAutoAnalyzeTest, AnalyzeTriggersAutoAnalyzeOnTarget) {
+  ASSERT_OK(SetUpClustersAndReplication());
+
+  ASSERT_OK(producer_conn_->Execute("CREATE TABLE tbl1(id int PRIMARY KEY, col1 int, col2 text)"));
+  // Stay under ysql_auto_analyze_threshold so that the source does not auto analyze on its own,
+  // which would make the checks below race with its own hint reaching the target.
+  ASSERT_OK(producer_conn_->Execute(
+      "INSERT INTO tbl1 SELECT g, g % 5, 'value' || (g % 7) FROM generate_series(1, 20) g"));
+  ASSERT_OK(WaitForSafeTimeToAdvanceToNow());
+
+  const auto stats_query =
+      "SELECT count(*) FROM pg_stats WHERE schemaname = 'public' AND tablename = 'tbl1'";
+
+  // Writes arriving over xCluster bypass the pggate layer that counts mutations, so nothing has
+  // made the target consider analyzing this table. The source has not analyzed either, which is
+  // what makes this a meaningful check.
+  SleepFor(MonoDelta::FromSeconds(3) * kTimeMultiplier);
+  ASSERT_EQ(ASSERT_RESULT(producer_conn_->FetchRow<int64_t>(stats_query)), 0);
+  ASSERT_EQ(ASSERT_RESULT(consumer_conn_->FetchRow<int64_t>(stats_query)), 0);
+
+  ASSERT_OK(producer_conn_->Execute("ANALYZE tbl1"));
+  ASSERT_OK(WaitForSafeTimeToAdvanceToNow());
+
+  // The source analyzed it, so the target should now analyze its own copy.
+  ASSERT_OK(WaitFor(
+      [this, &stats_query]() -> Result<bool> {
+        return VERIFY_RESULT(consumer_conn_->FetchRow<int64_t>(stats_query)) > 0;
+      },
+      MonoDelta::FromSeconds(120) * kTimeMultiplier, "Waiting for auto analyze on the target"));
+
+  // Both sides sampled their own data, so the statistics agree on the shape of the table even
+  // though none of them were shipped.
+  const auto n_distinct_query =
+      "SELECT attname, n_distinct FROM pg_stats "
+      "WHERE schemaname = 'public' AND tablename = 'tbl1' ORDER BY attname";
+  ASSERT_EQ(
+      ASSERT_RESULT(consumer_conn_->FetchAllAsString(n_distinct_query)),
+      ASSERT_RESULT(producer_conn_->FetchAllAsString(n_distinct_query)));
+
+  // Extended statistics are computed by the target's own ANALYZE, which is the point of triggering
+  // one there rather than copying pg_statistic over.
+  ASSERT_OK(producer_conn_->Execute(
+      "CREATE STATISTICS tbl1_stats (dependencies) ON id, col1 FROM tbl1"));
+  ASSERT_OK(WaitForSafeTimeToAdvanceToNow());
+  ASSERT_OK(producer_conn_->Execute("ANALYZE tbl1"));
+  ASSERT_OK(WaitForSafeTimeToAdvanceToNow());
+
+  const auto ext_stats_query =
+      "SELECT count(*) FROM pg_statistic_ext_data d JOIN pg_statistic_ext e ON e.oid = d.stxoid "
+      "WHERE e.stxname = 'tbl1_stats'";
+  ASSERT_OK(WaitFor(
+      [this, &ext_stats_query]() -> Result<bool> {
+        return VERIFY_RESULT(consumer_conn_->FetchRow<int64_t>(ext_stats_query)) > 0;
+      },
+      MonoDelta::FromSeconds(120) * kTimeMultiplier,
+      "Waiting for extended statistics on the target"));
 }
 
 // Make sure we can run a variety of DDLs related to temp tables on both clusters.

--- a/src/yb/tserver/xcluster_ddl_queue_handler.cc
+++ b/src/yb/tserver/xcluster_ddl_queue_handler.cc
@@ -22,6 +22,7 @@
 
 #include "yb/cdc/xcluster_types.h"
 #include "yb/client/client.h"
+#include "yb/client/stateful_services/pg_auto_analyze_service_client.h"
 #include "yb/common/constants.h"
 #include "yb/common/hybrid_time.h"
 #include "yb/common/json_util.h"
@@ -48,6 +49,12 @@ DEFINE_RUNTIME_int64(xcluster_ddl_queue_advisory_lock_key, 8674896558949688690,
 DEFINE_RUNTIME_bool(xcluster_ddl_queue_enable_transactional_ddl, true,
     "When enabled, multiple DDLs from the same source transaction are applied "
     "atomically within a transaction block on the target.");
+
+DEFINE_RUNTIME_uint64(xcluster_ddl_queue_analyze_mutation_count, 1000000000000,
+    "Mutation count reported to the auto analyze service for a table that was analyzed on the "
+    "source. It has to exceed the target's analyze threshold, which grows with the size of "
+    "the table, so that the table is picked for an ANALYZE on the target. Note that this does "
+    "not bypass the auto analyze cooldown for the table.");
 
 DEFINE_test_flag(bool, xcluster_ddl_queue_handler_cache_connection, true,
     "Whether we should cache the ddl_queue handler's connection, or always recreate it.");
@@ -104,6 +111,8 @@ const char* kDDLJsonVersion = "version";
 const char* kDDLJsonSchema = "schema";
 const char* kDDLJsonUser = "user";
 const char* kDDLJsonNewRelMap = "new_rel_map";
+const char* kDDLJsonAnalyzeRels = "analyze_rels";
+const char* kAnalyzeCommandTag = "ANALYZE";
 const char* kDDLJsonRelName = "rel_name";
 const char* kDDLJsonRelPgSchemaName = "rel_namespace";
 const char* kDDLJsonRelFileOid = "relfile_oid";
@@ -143,6 +152,7 @@ const std::unordered_set<std::string> kSupportedCommandTags {
     "ALTER SEQUENCE",
     "TRUNCATE TABLE",
     "REFRESH MATERIALIZED VIEW",
+    "ANALYZE",
     // Pass thru DDLs
     "CREATE ACCESS METHOD",
     "CREATE AGGREGATE",
@@ -315,6 +325,15 @@ Result<XClusterDDLQueryInfo> GetDDLQueryInfo(
       query_info.relation_map.push_back(std::move(rel_info));
     }
   }
+  if (HAS_MEMBER_OF_TYPE(doc, kDDLJsonAnalyzeRels, IsArray)) {
+    for (const auto& rel : doc[kDDLJsonAnalyzeRels].GetArray()) {
+      VALIDATE_MEMBER(rel, kDDLJsonRelName, String);
+      VALIDATE_MEMBER(rel, kDDLJsonRelPgSchemaName, String);
+      query_info.analyze_relations.push_back(
+          {.relation_name = rel[kDDLJsonRelName].GetString(),
+           .relation_pgschema_name = rel[kDDLJsonRelPgSchemaName].GetString()});
+    }
+  }
   if (HAS_MEMBER_OF_TYPE(doc, kDDLJsonVariableMap, IsObject)) {
     auto variables = doc[kDDLJsonVariableMap].GetObject();
     for (const auto& variable : variables) {
@@ -419,7 +438,8 @@ Status XClusterDDLQueueHandler::ProcessQueriesForCommitTime(const HybridTime& co
     });
     RETURN_NOT_OK(ProcessNewRelations(query_info, new_relations, commit_time));
 
-    auto s = ProcessDDLQuery(query_info);
+    auto s = query_info.command_tag == kAnalyzeCommandTag ? ProcessAnalyzeQuery(query_info)
+                                                          : ProcessDDLQuery(query_info);
     if (!s.ok()) {
       RETURN_NOT_OK(ProcessFailedDDLQuery(s, query_info));
     }
@@ -624,12 +644,70 @@ Status XClusterDDLQueueHandler::CheckForFailedQuery() {
 
 Status XClusterDDLQueueHandler::ProcessManualExecutionQuery(
     const XClusterDDLQueryInfo& query_info) {
+  return InsertIntoReplicatedDDLs(query_info, /* is_manual_execution */ true);
+}
+
+Result<std::optional<uint32_t>> XClusterDDLQueueHandler::GetTargetRelfileNodeOid(
+    const XClusterDDLQueryInfo::AnalyzeRelationInfo& relation) {
+  // The relation is identified by name because the target assigns its own relfilenode, which a
+  // table rewrite on either side can change independently.
+  auto rows = VERIFY_RESULT(pg_conn_->FetchRows<pgwrapper::PGOid>(Format(
+      "SELECT c.relfilenode FROM pg_catalog.pg_class c "
+      "JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace "
+      "WHERE n.nspname = $0 AND c.relname = $1",
+      pgwrapper::PqEscapeLiteral(relation.relation_pgschema_name),
+      pgwrapper::PqEscapeLiteral(relation.relation_name))));
+  if (rows.empty()) {
+    return std::nullopt;
+  }
+  return rows.front();
+}
+
+Status XClusterDDLQueueHandler::ProcessAnalyzeQuery(const XClusterDDLQueryInfo& query_info) {
+  // Reset the role and any read time left over from reading the queue, since we run ordinary
+  // queries against the catalog below.
+  RETURN_NOT_OK(RunAndLogQuery("SET ROLE NONE"));
+
+  const auto db_oid = VERIFY_RESULT(GetPgsqlDatabaseOid(target_namespace_id_));
+
+  stateful_service::IncreaseMutationCountersRequestPB req;
+  for (const auto& relation : query_info.analyze_relations) {
+    auto relfilenode_oid = VERIFY_RESULT(GetTargetRelfileNodeOid(relation));
+    if (!relfilenode_oid) {
+      // The relation has been dropped since the source analyzed it. Nothing to refresh.
+      LOG_WITH_PREFIX(INFO) << "Skipping auto analyze hint for missing relation "
+                            << relation.ToString();
+      continue;
+    }
+    auto* table_mutation_count = req.add_table_mutation_counts();
+    table_mutation_count->set_table_id(PgObjectId(db_oid, *relfilenode_oid).GetYbTableId());
+    table_mutation_count->set_mutation_count(FLAGS_xcluster_ddl_queue_analyze_mutation_count);
+  }
+
+  if (req.table_mutation_counts_size() > 0) {
+    if (!auto_analyze_client_) {
+      auto_analyze_client_ = std::make_unique<client::PgAutoAnalyzeServiceClient>(*local_client_);
+    }
+    VLOG_WITH_PREFIX(2) << "Reporting mutation counts for auto analyze: "
+                        << req.ShortDebugString();
+    RETURN_NOT_OK(ResultToStatus(
+        auto_analyze_client_->IncreaseMutationCounters(req, local_client_->default_rpc_timeout())));
+  }
+
+  // ANALYZE is not a DDL, so nothing fired the event trigger that would have recorded this entry.
+  return InsertIntoReplicatedDDLs(query_info, /* is_manual_execution */ false);
+}
+
+Status XClusterDDLQueueHandler::InsertIntoReplicatedDDLs(
+    const XClusterDDLQueryInfo& query_info, bool is_manual_execution) {
   rapidjson::Document doc;
   doc.SetObject();
   doc.AddMember(
       rapidjson::StringRef(kDDLJsonQuery),
       rapidjson::Value(query_info.query.c_str(), doc.GetAllocator()), doc.GetAllocator());
-  doc.AddMember(rapidjson::StringRef(kDDLJsonManualReplication), true, doc.GetAllocator());
+  if (is_manual_execution) {
+    doc.AddMember(rapidjson::StringRef(kDDLJsonManualReplication), true, doc.GetAllocator());
+  }
 
   RETURN_NOT_OK(RunAndLogQuery(Format(
       "EXECUTE $0($1, $2, $3)", kDDLPrepStmtManualInsert, query_info.ddl_end_time,

--- a/src/yb/tserver/xcluster_ddl_queue_handler.h
+++ b/src/yb/tserver/xcluster_ddl_queue_handler.h
@@ -28,6 +28,9 @@
 
 namespace yb {
 struct YsqlFullTableName;
+namespace client {
+class PgAutoAnalyzeServiceClient;
+}
 namespace tserver {
 
 struct XClusterOutputClientResponse;
@@ -60,12 +63,24 @@ struct XClusterDDLQueryInfo {
     }
   };
   std::vector<RelationInfo> relation_map;
+
+  // Relations that were analyzed on the source. The target does not run the ANALYZE, it only
+  // marks these as needing one so its auto analyze service picks them up.
+  struct AnalyzeRelationInfo {
+    std::string relation_name;
+    std::string relation_pgschema_name;
+    std::string ToString() const {
+      return YB_STRUCT_TO_STRING(relation_name, relation_pgschema_name);
+    }
+  };
+  std::vector<AnalyzeRelationInfo> analyze_relations;
   std::map<std::string, std::string> variables;
 
   std::string ToString() const {
     return YB_STRUCT_TO_STRING(
         query, ddl_end_time, query_id, version, command_tag, search_path_schema, user,
-        json_for_oid_assignment, is_manual_execution, relation_map, variables);
+        json_for_oid_assignment, is_manual_execution, relation_map, analyze_relations,
+        variables);
   }
 };
 
@@ -132,6 +147,19 @@ class XClusterDDLQueueHandler {
 
   Status ProcessManualExecutionQuery(const XClusterDDLQueryInfo& query_info);
 
+  // Handles an entry recording an ANALYZE that ran on the source. Instead of analyzing on the
+  // target, which would sample the whole table and hold up the queue, tell the auto analyze
+  // service that these relations changed enough to need one.
+  Status ProcessAnalyzeQuery(const XClusterDDLQueryInfo& query_info);
+
+  // Looks up the target's relfilenode oid for a relation, or nullopt if it no longer exists.
+  Result<std::optional<uint32_t>> GetTargetRelfileNodeOid(
+      const XClusterDDLQueryInfo::AnalyzeRelationInfo& relation);
+
+  // Records the query in the replicated_ddls table so that it is not processed again.
+  Status InsertIntoReplicatedDDLs(const XClusterDDLQueryInfo& query_info,
+                                  bool is_manual_execution);
+
   virtual Status InitPGConnection();
   virtual Result<HybridTime> GetXClusterSafeTimeForNamespace();
 
@@ -166,6 +194,7 @@ class XClusterDDLQueueHandler {
   client::YBClient* local_client_;
 
   std::unique_ptr<pgwrapper::PGConn> pg_conn_;
+  std::unique_ptr<client::PgAutoAnalyzeServiceClient> auto_analyze_client_;
   NamespaceName namespace_name_;
   NamespaceId source_namespace_id_;
   NamespaceId target_namespace_id_;


### PR DESCRIPTION
## Summary

Alternative to #33179, which ships the statistics themselves. Only one of the two
should land.

`ANALYZE` is not a DDL, so it does not fire the `ddl_command_end` event trigger that
xCluster DDL replication is built on. Auto analyze does not close the gap either: its
mutation counters live in the pggate layer, which xCluster replication bypasses, so the
target never decides that a table needs to be analyzed and its statistics stay as they
were when replication started.

This tells the target which relation was analyzed and lets it analyze its own copy:

- Adds a `YbAnalyzeRelEnd` hook, fired at the end of `analyze_rel()` once per analyzed
  relation. This is the equivalent of what we already do for `TRUNCATE`, which is also
  not a DDL in the Postgres sense.

- `yb_xcluster_ddl_replication` registers the hook and queues a `ddl_queue` entry naming
  the relation, under the `ANALYZE` command tag. Temporary relations, system catalogs and
  the extension's own tables are skipped.

- The ddl_queue handler does not run the ANALYZE. Running it there would sample the whole
  table while holding up the queue, which is the lag concern raised when this came up.
  Instead it reports a large mutation count for the target's copy of the relation to the
  auto analyze service, which picks the table up on its next cycle and analyzes it out of
  band. The relation is looked up by name because the target assigns its own relfilenode.
  Since the entry is not a DDL, nothing fires the event trigger that records it in
  `replicated_ddls`, so the handler does that itself.

## Compared with #33179

|  | #33179 (ship statistics) | this PR (trigger an ANALYZE) |
|---|---|---|
| Work on target | none, just catalog writes | a real ANALYZE, out of band |
| Extended statistics (`CREATE STATISTICS`) | not covered, no import function exists | covered, the target computes its own |
| Statistics describe | the source's data | the data the target has applied |
| Timing | applied with the queue entry | whenever auto analyze next runs |
| Depends on auto analyze being enabled | no | yes |
| ddl_queue entry size | grows with the statistics | one row naming the relation |

The bump does not bypass the auto analyze cooldown for a table, so a source that analyzes
repeatedly cannot drive the target into an ANALYZE storm.

## Upgrade/Rollback safety

No wire format changes. `analyze_rels` is a new optional key in the `ddl_queue` `yb_data`
json and `ANALYZE` a new command tag; both are only written by a source running this
build. An older target reading an entry from a newer source rejects the unknown `ANALYZE`
tag and pauses DDL replication, which is the existing behavior for any unrecognized tag,
so source and target should be upgraded together. Rolling back leaves the already queued
entries in `ddl_queue`, which are then reported as unsupported by the older target until
they age out; there is no on-disk format or catalog change to undo.

## Test plan

- [x] `./yb_build.sh release --java-test org.yb.pgsql.TestPgRegressYbExtensionsYbXclusterDdlReplication`
      (new `analyze` case: one entry per analyzed relation, temp relations skipped,
      quoting preserved, single column and multi relation forms)
- [x] `./yb_build.sh release --cxx-test xcluster_ddl_replication-test --gtest_filter XClusterDDLReplicationAutoAnalyzeTest.AnalyzeTriggersAutoAnalyzeOnTarget`
      (end to end: target has no statistics while neither side has analyzed, gets them
      after the source analyzes, `n_distinct` agrees on both sides, and extended
      statistics appear on the target)
