### PR TITLE
[#33068] DocDB: Fix random tserver SIGSEGV from out-of-bounds per-CPU pool indexing

### DIFF
--- a/src/yb/gutil/sysinfo.h
+++ b/src/yb/gutil/sysinfo.h
@@ -57,8 +57,8 @@ namespace base {
 // value of sched_getcpu().
 extern int NumCPUs();
 
-// Use the default value for when gflags are not initialized yet (i.e. spinlock.cc)
-// or if we need the actual number of CPUs (i.e. object_pool.h)
+// Return the number of online CPUs. Like NumCPUs(), but ignoring the --num_cpus flag override.
+// Use when gflags are not initialized yet (i.e. spinlock.cc).
 extern int RawNumCPUs();
 
 // Return the maximum CPU index that may be returned by sched_getcpu(). For example, on

--- a/src/yb/util/object_pool-test.cc
+++ b/src/yb/util/object_pool-test.cc
@@ -30,9 +30,16 @@
 // under the License.
 //
 
+#ifdef __linux__
+#include <sched.h>
+#endif
+
 #include "yb/util/logging.h"
 #include <gtest/gtest.h>
 
+#include "yb/gutil/sysinfo.h"
+
+#include "yb/util/errno.h"
 #include "yb/util/object_pool.h"
 
 namespace yb {
@@ -97,5 +104,57 @@ TEST(TestObjectPool, TestScopedPtr) {
   }
   ASSERT_EQ(0, MyClass::instance_count());
 }
+
+#ifdef __linux__
+
+namespace {
+
+// Restores the affinity mask of the calling thread on destruction, so pinning does not leak into
+// the rest of the test binary.
+struct ScopedThreadAffinity {
+  cpu_set_t original;
+
+  ScopedThreadAffinity() { PCHECK(sched_getaffinity(0, sizeof(original), &original) == 0); }
+  ~ScopedThreadAffinity() { PCHECK(sched_setaffinity(0, sizeof(original), &original) == 0); }
+};
+
+} // namespace
+
+// ThreadSafeObjectPool picks a pool using sched_getcpu(), so every CPU the process may be scheduled
+// on has to map to a pool. Pins the calling thread to each allowed CPU in turn and takes and
+// releases an object from there.
+TEST(TestThreadSafeObjectPool, TakeAndReleaseOnEveryCpu) {
+  MyClass::ResetCount();
+  {
+    ScopedThreadAffinity affinity;
+    ThreadSafeObjectPool<MyClass> pool;
+
+    int cpus_covered = 0;
+    for (int cpu = 0; cpu != CPU_SETSIZE; ++cpu) {
+      if (!CPU_ISSET(cpu, &affinity.original)) {
+        continue;
+      }
+
+      cpu_set_t single;
+      CPU_ZERO(&single);
+      CPU_SET(cpu, &single);
+      ASSERT_EQ(sched_setaffinity(0, sizeof(single), &single), 0) << ErrnoToString(errno);
+      ASSERT_EQ(sched_getcpu(), cpu) << "a single-CPU mask must leave the thread nowhere else";
+
+      auto* object = pool.Take();
+      ASSERT_NE(object, nullptr);
+      pool.Release(object);
+      ++cpus_covered;
+    }
+
+    LOG(INFO) << "Exercised the pool on " << cpus_covered << " CPUs, max CPU index "
+              << base::MaxCPUIndex() << ", online CPUs " << base::RawNumCPUs();
+    ASSERT_GT(cpus_covered, 0);
+  }
+
+  ASSERT_EQ(0, MyClass::instance_count()) << "pool destruction must free every pooled object";
+}
+
+#endif // __linux__
 
 } // namespace yb

--- a/src/yb/util/object_pool.h
+++ b/src/yb/util/object_pool.h
@@ -250,9 +250,8 @@ class ThreadSafeObjectPool {
     if (PREDICT_FALSE(cpu < 0)) {
       return PoolIndexForThread();
     }
-    auto index = static_cast<size_t>(cpu);
-    DCHECK_LT(index, pools_.size());
-    return index;
+    // Pools are thread-safe and interchangeable, so wrap a CPU id beyond the cached MaxCPUIndex().
+    return static_cast<size_t>(cpu) % pools_.size();
 #endif // defined(__APPLE__)
   }
 

--- a/src/yb/util/object_pool.h
+++ b/src/yb/util/object_pool.h
@@ -35,13 +35,12 @@
 
 #include <stdint.h>
 
-#include <functional>
-
-#if defined(__APPLE__)
-#include <thread>
-#else
+#if !defined(__APPLE__)
 #include <sched.h>
 #endif
+
+#include <functional>
+#include <thread>
 
 #include <boost/container/stable_vector.hpp>
 #include <boost/lockfree/stack.hpp>
@@ -203,10 +202,10 @@ class ThreadSafeObjectPool {
   explicit ThreadSafeObjectPool(Factory factory = DefaultFactory<T>(),
                                 Deleter deleter = std::default_delete<T>())
       : factory_(std::move(factory)), deleter_(std::move(deleter)) {
-    // Need the actual number of CPUs, so we do not use the Gflag value
-    size_t num_cpus = base::RawNumCPUs();
-    pools_.reserve(num_cpus);
-    while (pools_.size() != num_cpus) {
+    // Indexed by sched_getcpu(), so pools_ must cover the CPU id space, not the count of CPUs.
+    size_t num_pools = base::MaxCPUIndex() + 1;
+    pools_.reserve(num_pools);
+    while (pools_.size() != num_pools) {
       pools_.emplace_back(50);
     }
   }
@@ -237,14 +236,23 @@ class ThreadSafeObjectPool {
   }
 
  private:
+  // Picks a pool without knowing the current CPU, by spreading over the calling thread instead.
+  size_t PoolIndexForThread() const {
+    return std::hash<std::thread::id>()(std::this_thread::get_id()) % pools_.size();
+  }
+
   size_t GetCPU() const {
 #if defined(__APPLE__)
     // OSX doesn't have a way to get the CPU, so we'll pick a random one.
-    return std::hash<std::thread::id>()(std::this_thread::get_id()) % pools_.size();
+    return PoolIndexForThread();
 #else
-    size_t cpu = sched_getcpu();
-    DCHECK_LT(cpu, pools_.size());
-    return cpu;
+    auto cpu = sched_getcpu();
+    if (PREDICT_FALSE(cpu < 0)) {
+      return PoolIndexForThread();
+    }
+    auto index = static_cast<size_t>(cpu);
+    DCHECK_LT(index, pools_.size());
+    return index;
 #endif // defined(__APPLE__)
   }
 


### PR DESCRIPTION
## Summary

Issue: https://github.com/yugabyte/yugabyte-db/issues/33068

`ThreadSafeObjectPool` keeps one lock-free stack per CPU. It sizes that array from `base::RawNumCPUs()`, a count of online CPUs, and then indexes it with `sched_getcpu()`, an absolute CPU id. Those are different number spaces. Whenever a thread can be scheduled on a CPU whose id is greater than or equal to the number of online CPUs, `Take()` and `Release()` index past the end of `pools_` and the process dies with SIGSEGV. `DCHECK_LT` is compiled out in release builds, so nothing catches it.

The two numbers agree only when the online CPUs form a contiguous range starting at 0, which is the usual case and why this has gone unnoticed. They diverge in two situations:

- Some CPUs are offline. `/sys/devices/system/cpu/online` loses entries, so a thread can run on a CPU id above the online count. This is the case `MaxCPUIndex()` already documents in `src/yb/gutil/sysinfo.h:64`: "on an 8-core machine, this will return '7' even if some of the CPUs have been disabled".
- Something makes `/sys/devices/system/cpu/online` container aware. `lxcfs` has done this since 3.1.2. With a cpuset of `32-36` it reports 5 online CPUs while threads keep running on host CPU ids 32 through 36, and under `--enable-cfs` it instead renumbers the range to `0-4` from the CFS quota. Either way the count is 5 and `sched_getcpu()` returns up to 36.

Every user of the pool is exposed:

- `src/yb/util/trace.cc:293`, the arena pool behind tracing
- `src/yb/yql/cql/ql/ql_processor.cc:157` and `src/yb/yql/cql/cqlserver/cql_service.h:289`, the CQL parser pools

### Fix

Size `pools_` by `base::MaxCPUIndex() + 1`. `MaxCPUIndex()` reads `/sys/devices/system/cpu/present` and is the documented bound for anything indexed by `sched_getcpu()`. This matches the two per-CPU structures that already use it: `PerCpuRwMutex` (`src/yb/util/locks.h:179`) and `ClockboundClock` (`src/yb/server/clockbound_clock.cc:189`).

`GetCPU()` also converted a failed `sched_getcpu()` (it returns `int` and can return `-1`) into `SIZE_MAX` through `size_t cpu = sched_getcpu()`, an out of bounds index regardless of how `pools_` is sized. The negative case now falls back to the thread-id hash that macOS already used, extracted as `PoolIndexForThread()`.

`MaxCPUIndex()` is cached under `call_once`, so a CPU that comes online later would still fall outside `pools_`, guarded only by a `DCHECK` that release builds drop. `GetCPU()` therefore wraps with `% pools_.size()` and never indexes raw, following `ClockboundClock::Now()`, which does the same.

This is the same class of bug as #9619, where `PerCpuRwMutex` assumed `sched_getcpu()` stayed inside the online CPU range. `ThreadSafeObjectPool` was the last per-CPU structure in the tree sizing by a count while indexing by CPU id.

The remaining caller of `RawNumCPUs()` is `spinlock.cc`, so its doc comment in `sysinfo.h` no longer points readers at `object_pool.h` for "the actual number of CPUs".

## Test plan

- [x] `build-support/lint.sh --rev origin/master` reports 0 errors, 0 warnings
- [x] `object_pool-test`, covering the existing cases plus the new `TestThreadSafeObjectPool.TakeAndReleaseOnEveryCpu`

The new test pins the calling thread to each CPU in its affinity mask in turn, takes and releases an object from each, and restores the original mask on exit. It also asserts that pool destruction frees every pooled object.

Scope worth stating plainly: on a machine where `/sys/devices/system/cpu/online` matches `/sys/devices/system/cpu/present`, every CPU id is a valid index either way, so the test passes with and without the fix. Reproducing the SIGSEGV needs an environment where the online CPU count is lower than the highest CPU id a thread can be scheduled on, which is what LXC containers with a CPU quota and a wide cpuset produce.

