### PR TITLE
[#33207] DocDB: Resume a lost index backfill after the indexed table leaves ALTERING

### DIFF
--- a/src/yb/master/backfill_index.cc
+++ b/src/yb/master/backfill_index.cc
@@ -335,7 +335,7 @@ Status MultiStageAlterTable::StartBackfillingData(
     const std::vector<IndexInfoPB>& idx_infos,
     std::optional<uint32_t> current_version, const LeaderEpoch& epoch,
     std::optional<TransactionMetadata> requester_transaction) {
-  // We leave the table state as ALTERING so that a master failover can resume the backfill.
+  // Stay in ALTERING: IsAlterTableDone must not report done while the backfill is running.
   RETURN_NOT_OK(ClearFullyAppliedAndUpdateState(
       catalog_manager, indexed_table, current_version, /* change_state to RUNNING */ false, epoch));
 

--- a/src/yb/master/catalog_manager.cc
+++ b/src/yb/master/catalog_manager.cc
@@ -12054,7 +12054,9 @@ Status CatalogManager::HandleTabletSchemaVersionReport(
   // Verify if it's the last tablet report, and the alter completed.
   {
     auto l = table->LockForRead();
-    if (l->pb.state() != SysTablesEntryPB::ALTERING) {
+    // A recorded backfill job with no backfill running means the backfill was lost.
+    const bool resume_backfill = l->pb.backfill_jobs_size() > 0 && !table->IsBackfilling();
+    if (l->pb.state() != SysTablesEntryPB::ALTERING && !resume_backfill) {
       VLOG_WITH_PREFIX_AND_FUNC(2) << "Table " << table->ToString() << " is not altering";
       return Status::OK();
     }
@@ -14052,6 +14054,7 @@ void CatalogManager::SysCatalogLoaded(SysCatalogLoadingState&& state) {
       "Failed to backfill plugin name for notifications CDC streams");
 
   SchedulePostTabletCreationTasksForPendingTables(state.epoch);
+  EnqueuePendingBackfillsAfterLoad();
   restoring_sys_catalog_ = false;
 
   if (FLAGS_enable_ysql) {
@@ -14275,6 +14278,25 @@ void CatalogManager::SchedulePostTabletCreationTasksForPendingTables(const Leade
       continue;
     }
     SchedulePostTabletCreationTasks(*table_info_result, epoch);
+  }
+}
+
+void CatalogManager::EnqueuePendingBackfillsAfterLoad() {
+  std::vector<TableInfoPtr> tables;
+  {
+    SharedLock lock(mutex_);
+    tables.reserve(tables_->Size());
+    for (const auto& table_info : tables_->GetAllTables()) {
+      tables.push_back(table_info);
+    }
+  }
+
+  for (const auto& table_info : tables) {
+    if (table_info->LockForRead()->pb.backfill_jobs_size() == 0 || table_info->IsBackfilling()) {
+      continue;
+    }
+    LOG(INFO) << "Queueing " << table_info->ToString() << " for backfill resumption";
+    AddPendingBackFill(table_info->id());
   }
 }
 

--- a/src/yb/master/catalog_manager.h
+++ b/src/yb/master/catalog_manager.h
@@ -3286,6 +3286,10 @@ class CatalogManager : public CatalogManagerIf, public SnapshotCoordinatorContex
 
   void SchedulePostTabletCreationTasksForPendingTables(const LeaderEpoch& epoch) EXCLUDES(mutex_);
 
+  // Queues every table that has a backfill job recorded but no backfill running for resumption by
+  // CatalogManagerBgTasks.
+  void EnqueuePendingBackfillsAfterLoad() EXCLUDES(mutex_);
+
   Status BumpVersionAndStoreClusterConfig(
       ClusterConfigInfo* cluster_config, ClusterConfigInfo::WriteLock* l);
 

--- a/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
+++ b/src/yb/yql/pgwrapper/pg_index_backfill-test.cc
@@ -2261,6 +2261,81 @@ TEST_P(PgIndexBackfillMultiMaster, MasterLeaderStepdown) {
   thread_holder_.JoinAll();
 }
 
+// Make sure that a tablet schema version report arriving during backfill does not strand the
+// backfill across a master leader change.  The report moves the indexed table out of ALTERING, and
+// the new master leader has to resume the backfill anyway.  Simulate the following:
+//   Session A                                    Session B
+//   --------------------------                   ----------------------
+//   CREATE INDEX
+//   - indislive
+//   - indisready
+//   - backfill
+//     - get safe time for read
+//                                                tablet leader stepdown
+//                                                - new leader reports schema version
+//                                                master leader stepdown
+TEST_P(PgIndexBackfillMultiMaster, BackfillResumesAfterMasterFailover) {
+  auto client = ASSERT_RESULT(cluster_->CreateClient());
+
+  // 1. Create a single-tablet table and start CREATE INDEX on a separate thread.
+  ASSERT_OK(conn_->ExecuteFormat(
+      "CREATE TABLE $0 (i int, PRIMARY KEY (i)) SPLIT INTO 1 TABLETS", kTableName));
+  ASSERT_OK(conn_->ExecuteFormat("INSERT INTO $0 VALUES (1)", kTableName));
+
+  const auto table_id = ASSERT_RESULT(
+      GetTableIdByTableName(client.get(), kDatabaseName, kTableName));
+
+  // conn_ should be used by at most one thread for thread safety.
+  thread_holder_.AddThreadFunctor([this] {
+    LOG(INFO) << "Begin create thread";
+    PGConn create_conn = ASSERT_RESULT(ConnectToDB(kDatabaseName));
+    ASSERT_OK(create_conn.ExecuteFormat("CREATE INDEX $0 ON $1 (i ASC)", kIndexName, kTableName));
+    LOG(INFO) << "Done create thread";
+  });
+
+  // 2. Wait for backfill safe time, at which point the backfill is blocked by
+  //    TEST_block_do_backfill.
+  ASSERT_OK(WaitForBackfillSafeTime(kYBTableName));
+
+  // 3. Step down the tablet leader so the new leader reports its schema version to the master
+  //    while the backfill is in progress.
+  google::protobuf::RepeatedPtrField<master::TabletLocationsPB> tablets;
+  ASSERT_OK(client->GetTabletsFromTableId(table_id, 0, &tablets));
+  ASSERT_EQ(tablets.size(), 1);
+  const auto tablet_id = tablets[0].tablet_id();
+  const auto old_leader_idx = ASSERT_RESULT(cluster_->GetTabletLeaderIndex(tablet_id));
+  ASSERT_OK(cluster_->CallYbAdmin({"leader_stepdown", tablet_id}));
+  ASSERT_OK(WaitFor(
+      [this, &tablet_id, old_leader_idx]() -> Result<bool> {
+        auto leader_idx = cluster_->GetTabletLeaderIndex(tablet_id);
+        return leader_idx.ok() && *leader_idx != old_leader_idx;
+      },
+      30s * kTimeMultiplier, "Wait for tablet leader to change"));
+
+  // 4. Wait for the report to take the indexed table out of ALTERING.  This is the precondition
+  //    for the bug: the state that the resume path used to key off of is gone.
+  ASSERT_OK(WaitFor(
+      [&client, &table_id]() -> Result<bool> {
+        bool alter_in_progress = true;
+        RETURN_NOT_OK(client->IsAlterTableInProgress(kYBTableName, table_id, &alter_in_progress));
+        return !alter_in_progress;
+      },
+      60s * kTimeMultiplier, "Wait for indexed table to leave ALTERING"));
+
+  // 5. Fail the backfill over to a new master leader.
+  ASSERT_OK(cluster_->StepDownMasterLeaderAndWaitForNewLeader());
+
+  // 6. Unblock the backfill and join the create thread.  The new master leader has to resume the
+  //    backfill for CREATE INDEX to return.
+  ASSERT_OK(cluster_->SetFlagOnMasters("TEST_block_do_backfill", "false"));
+  thread_holder_.JoinAll();
+
+  // 7. The index is usable.
+  const std::string query = Format("SELECT i FROM $0 WHERE i = 1", kTableName);
+  ASSERT_TRUE(ASSERT_RESULT(conn_->HasIndexScan(query)));
+  ASSERT_EQ(ASSERT_RESULT(conn_->FetchRow<int32_t>(query)), 1);
+}
+
 // Override the index backfill test class to use colocated tables.
 class PgIndexBackfillColocated : public PgIndexBackfillTest {
  public:


### PR DESCRIPTION
DO NOT MERGE!! [CSI](<https://csiweb.dev.yugabyte.com/pull/33208/>) ❌. Once CSI passes, comment `trigger jenkins` to clear this warning.

## Summary

`MultiStageAlterTable::StartBackfillingData` leaves the indexed table persisted as `ALTERING` for the duration of an index backfill, records the work in the table's `backfill_jobs`, and tracks progress only through the in-memory `is_backfilling_` flag.

A tablet schema-version report arriving during that window re-enters `LaunchNextTableInfoVersionIfNecessary`. For a YSQL table at `INDEX_PERM_DO_BACKFILL` both `indexes_to_update` and `indexes_to_delete` are empty and `is_backfilling` short-circuits the remaining check, so the "not necessary to launch next version" guard is taken and `ClearFullyAppliedAndUpdateState(..., /* change state to RUNNING */ true, ...)` persists `RUNNING` while the backfill is still running.

Nothing goes visibly wrong until the master leader changes. The new leader has `is_backfilling_ == false` and reads a table in state `RUNNING`, so the recovery path that rebuilds `indexes_to_backfill` from `backfill_jobs` — guarded on `!is_backfilling` — never applies. The backfill is never resumed and the index is left at `INDEX_PERM_DO_BACKFILL`. The window lasts as long as the backfill itself, so it is wide on a large table, and any tablet leader election, tserver restart, or periodic full tablet report will produce the report that triggers it.

Persisting `RUNNING` mid-backfill is not itself the defect: concurrent DDL on the indexed table clears `ALTERING` the same way, so table state cannot be relied on to mean "a backfill is outstanding". What is missing is a resume path that does not depend on it. `HandleTabletSchemaVersionReport` early-returns unless the table is `ALTERING`, and it is the only entry point to the resume logic, so once the state is cleared the backfill becomes unreachable.

The fix relaxes that gate on durable evidence instead: the function also proceeds when the table has a recorded backfill job and no backfill running (`backfill_jobs_size() > 0 && !IsBackfilling()`), which is exactly the condition the recovery path in `LaunchNextTableInfoVersionIfNecessary` already looks for. The backfill is then relaunched from the persisted job regardless of whether the table is `ALTERING` or `RUNNING`. Keeping the resume behind this one function means PITR restores and post-failover resumption continue to share a single code path, including the `IsTableUndergoingPitrRestore` check and the DDL-verification cleanup.

Resumption otherwise depends on a tablet report arriving after the election, which is not guaranteed. `SysCatalogLoaded` therefore queues every table in that state with `CatalogManagerBgTasks` (`EnqueuePendingBackfillsAfterLoad`), reusing the `pending_backfill_tables_` queue that PITR already feeds, so a newly elected leader picks the job up on its own.

## Upgrade/Rollback safety

No wire-format, catalog-schema, on-disk-format, or gflag-default change. The fix only adds a resume path over state that is already persisted in `backfill_jobs`.

Mixed-version clusters are safe in both directions: masters do not coordinate on this path, and only the leader acts on it. During a rolling upgrade an unfixed master leader still fails to resume a backfill whose table has left `ALTERING`; a fixed leader resumes it, including for indexes stranded before the upgrade, since the decision is made from the persisted job.

Rollback is safe: reverting restores the previous behavior with no state to migrate. An index stranded while the unfixed code is in place is resumed as soon as a fixed master holds leadership.

## Test plan

New regression test `PgIndexBackfillMultiMaster.BackfillResumesAfterMasterFailover`: it holds the backfill with `TEST_block_do_backfill`, steps down the indexed table's tablet leader so the new leader reports its schema version to the master, waits for the indexed table to leave `ALTERING`, then fails the master leader over and unblocks the backfill. Without the fix the index never becomes valid.

- [x] `./yb_build.sh release --cxx-test pg_index_backfill-test --gtest_filter 'PgIndexBackfillMultiMaster.BackfillResumesAfterMasterFailover/*'` — fails on `/0` and `/1` before the change, passes on both after
- [x] `./yb_build.sh release --cxx-test pg_index_backfill-test --gtest_filter 'PgIndexBackfillMultiMaster.MasterLeaderStepdown/*'` — the existing master-failover coverage, passes on `/0` and `/1`
