### PR TITLE
[#33243] DocDB: Stripe the retryable request tracker to reduce request ID lock contention

### DIFF
--- a/src/yb/client/CMakeLists.txt
+++ b/src/yb/client/CMakeLists.txt
@@ -48,6 +48,7 @@ set(CLIENT_SRCS
   meta_data_cache.cc
   namespace_alterer.cc
   permissions.cc
+  retryable_request_tracker.cc
   session.cc
   schema.cc
   stateful_services/stateful_service_client_base.cc

--- a/src/yb/client/async_rpc.cc
+++ b/src/yb/client/async_rpc.cc
@@ -697,13 +697,14 @@ WriteRpc::WriteRpc(const AsyncRpcData& data, rpc::ThreadPoolTag pool_tag)
     // request ID and details (see https://github.com/yugabyte/yugabyte-db/issues/14005).
     if (first_yb_op->request_id()) {
       const auto& request_detail = batcher_->GetRequestDetails(*first_yb_op->request_id());
-      req_.set_request_id(*first_yb_op->request_id());
-      req_.set_min_running_request_id(request_detail.min_running_request_id);
+      req_.set_request_id(request_detail.registration.request_id());
+      req_.set_min_running_request_id(
+          request_detail.registration.min_running_request_id());
     } else {
-      const auto request_pair = batcher_->NextRequestIdAndMinRunningRequestId();
-      req_.set_request_id(request_pair.first);
-      req_.set_min_running_request_id(request_pair.second);
-      batcher_->RegisterRequest(request_pair.first, request_pair.second);
+      const auto& request_detail = batcher_->RegisterRequest();
+      req_.set_request_id(request_detail.registration.request_id());
+      req_.set_min_running_request_id(
+          request_detail.registration.min_running_request_id());
     }
     FillRequestIds(req_.request_id(), &ops_);
   }

--- a/src/yb/client/batcher.cc
+++ b/src/yb/client/batcher.cc
@@ -688,12 +688,22 @@ server::Clock* Batcher::Clock() const {
   return client_->Clock();
 }
 
-std::pair<RetryableRequestId, RetryableRequestId> Batcher::NextRequestIdAndMinRunningRequestId() {
-  return client_->NextRequestIdAndMinRunningRequestId();
+const RequestDetails& Batcher::RegisterRequest() {
+  auto registration = client_->data_->retryable_request_tracker_.Register();
+  const auto request_id = registration.request_id();
+  auto [it, inserted] = retryable_requests_.emplace(
+      request_id, RequestDetails(std::move(registration)));
+  CHECK(inserted) << "Duplicate retryable request ID: " << request_id;
+  return it->second;
 }
 
 void Batcher::RequestsFinished() {
-  client_->RequestsFinished(retryable_requests_ | boost::adaptors::map_keys);
+  std::vector<RetryableRequestTracker::Registration*> registrations;
+  registrations.reserve(retryable_requests_.size());
+  for (auto& entry : retryable_requests_) {
+    registrations.push_back(&entry.second.registration);
+  }
+  client_->data_->retryable_request_tracker_.Unregister(registrations);
 }
 
 void Batcher::MoveRequestDetailsFrom(const BatcherPtr& other, RetryableRequestId id) {

--- a/src/yb/client/batcher.h
+++ b/src/yb/client/batcher.h
@@ -38,6 +38,7 @@
 
 #include "yb/client/async_rpc.h"
 #include "yb/client/error_collector.h"
+#include "yb/client/retryable_request_tracker.h"
 #include "yb/client/transaction.h"
 
 #include "yb/common/consistent_read_point.h"
@@ -90,10 +91,10 @@ struct InFlightOpsGroupsWithMetadata {
 };
 
 struct RequestDetails {
-  RetryableRequestId min_running_request_id;
+  RetryableRequestTracker::Registration registration;
 
-  explicit RequestDetails(RetryableRequestId min_running_request_id_) :
-      min_running_request_id(min_running_request_id_) {}
+  explicit RequestDetails(RetryableRequestTracker::Registration registration_)
+      : registration(std::move(registration_)) {}
 };
 
 using BatcherRequestsMap = std::unordered_map<RetryableRequestId, RequestDetails>;
@@ -251,14 +252,9 @@ class Batcher : public Runnable, public std::enable_shared_from_this<Batcher> {
 
   server::Clock* Clock() const;
 
-  std::pair<RetryableRequestId, RetryableRequestId> NextRequestIdAndMinRunningRequestId();
-
   void RequestsFinished();
 
-  void RegisterRequest(
-      RetryableRequestId id, RetryableRequestId min_running_id) {
-    retryable_requests_.emplace(id, RequestDetails(min_running_id));
-  }
+  const RequestDetails& RegisterRequest();
 
   void MoveRequestDetailsFrom(const BatcherPtr& other, RetryableRequestId id);
 

--- a/src/yb/client/client-internal.h
+++ b/src/yb/client/client-internal.h
@@ -33,13 +33,13 @@
 
 #include <functional>
 #include <mutex>
-#include <set>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 #include "yb/client/client.h"
+#include "yb/client/retryable_request_tracker.h"
 
 #include "yb/common/common_net.pb.h"
 #include "yb/common/entity_ids.h"
@@ -642,15 +642,7 @@ class YBClient::Data {
   const ClientId id_;
   const std::string log_prefix_;
 
-  // Used to track requests that were sent to a particular tablet, so it could track different
-  // RPCs related to the same write operation and reject duplicates.
-  struct TabletRequests {
-    RetryableRequestId request_id_seq = 0;
-    std::set<RetryableRequestId> running_requests;
-  };
-
-  simple_spinlock tablet_requests_mutex_;
-  TabletRequests requests_;
+  internal::RetryableRequestTracker retryable_request_tracker_;
 
   std::array<std::atomic<int>, 2> tserver_count_cached_;
 

--- a/src/yb/client/client-unittest.cc
+++ b/src/yb/client/client-unittest.cc
@@ -34,6 +34,7 @@
 #include <array>
 #include <functional>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -110,7 +111,8 @@ TEST(ClientUnitTest, TestSchemaBuilder_SingleKey_GoodSchema) {
 }
 
 TEST(ClientUnitTest, RetryableRequestTrackerMaintainsMinimumActiveRequestId) {
-  internal::RetryableRequestTracker tracker;
+  // A single stripe preserves the dense, exact-minimum behavior.
+  internal::RetryableRequestTracker tracker(1);
   auto first = tracker.Register();
   auto second = tracker.Register();
   auto third = tracker.Register();
@@ -157,18 +159,101 @@ TEST(ClientUnitTest, RetryableRequestTrackerTransfersMovedRegistration) {
   ASSERT_EQ(tracker.TEST_ActiveRequestsCount(), 0);
 }
 
+TEST(ClientUnitTest, RetryableRequestTrackerStripeCountRoundsUpToPowerOfTwo) {
+  ASSERT_EQ(internal::RetryableRequestTracker(1).TEST_StripeCount(), 1);
+  ASSERT_EQ(internal::RetryableRequestTracker(3).TEST_StripeCount(), 4);
+  ASSERT_EQ(internal::RetryableRequestTracker(16).TEST_StripeCount(), 16);
+  // 0 selects the flag default (16).
+  ASSERT_EQ(internal::RetryableRequestTracker().TEST_StripeCount(), 16);
+}
+
+TEST(ClientUnitTest, RetryableRequestTrackerStripedIdsAreUniqueAndWatermarkConservative) {
+  internal::RetryableRequestTracker tracker(4);
+  const auto stripes = tracker.TEST_StripeCount();
+
+  auto pinned = tracker.Register();
+  std::vector<internal::RetryableRequestTracker::Registration> registrations;
+  registrations.reserve(4 * stripes);
+  std::unordered_set<RetryableRequestId> seen_ids = {pinned.request_id()};
+  for (size_t i = 0; i != 4 * stripes; ++i) {
+    auto registration = tracker.Register();
+    // IDs are globally unique across stripes.
+    ASSERT_TRUE(seen_ids.insert(registration.request_id()).second);
+    // The watermark never exceeds the registration's own ID, nor the ID of a
+    // request registered earlier and still active.
+    ASSERT_LE(registration.min_running_request_id(), registration.request_id());
+    ASSERT_LE(registration.min_running_request_id(), pinned.request_id());
+    registrations.push_back(std::move(registration));
+  }
+  ASSERT_EQ(tracker.TEST_ActiveRequestsCount(), 1 + 4 * stripes);
+
+  std::vector<internal::RetryableRequestTracker::Registration*> registration_ptrs;
+  registration_ptrs.reserve(registrations.size());
+  for (auto& registration : registrations) {
+    registration_ptrs.push_back(&registration);
+  }
+  tracker.Unregister(registration_ptrs);
+  std::array pinned_ptr = {&pinned};
+  tracker.Unregister(pinned_ptr);
+  ASSERT_EQ(tracker.TEST_ActiveRequestsCount(), 0);
+}
+
+TEST(ClientUnitTest, RetryableRequestTrackerWatermarkAdvancesAfterRetirement) {
+  internal::RetryableRequestTracker tracker(4);
+  const auto stripes = tracker.TEST_StripeCount();
+
+  // The very first registration draws a stripe's initial ID, which is below
+  // the stripe count.
+  auto first = tracker.Register();
+  ASSERT_LT(first.request_id(), static_cast<RetryableRequestId>(stripes));
+
+  // One full round-robin cycle touches every stripe, advancing each next-ID
+  // past its initial value.
+  std::vector<internal::RetryableRequestTracker::Registration> cycle;
+  cycle.reserve(stripes);
+  for (size_t i = 0; i != stripes; ++i) {
+    cycle.push_back(tracker.Register());
+  }
+  std::vector<internal::RetryableRequestTracker::Registration*> cycle_ptrs;
+  for (auto& registration : cycle) {
+    cycle_ptrs.push_back(&registration);
+  }
+  tracker.Unregister(cycle_ptrs);
+  std::array first_ptr = {&first};
+  tracker.Unregister(first_ptr);
+  ASSERT_EQ(tracker.TEST_ActiveRequestsCount(), 0);
+
+  // With every stripe used at least once and all requests retired, the
+  // watermark has moved past the first request's ID.
+  auto next = tracker.Register();
+  ASSERT_GT(next.min_running_request_id(), first.request_id());
+  ASSERT_GE(next.min_running_request_id(), static_cast<RetryableRequestId>(stripes));
+  std::array next_ptr = {&next};
+  tracker.Unregister(next_ptr);
+}
+
 TEST(ClientUnitTest, RetryableRequestTrackerConcurrentRegistrationAndRetirement) {
   constexpr size_t kNumThreads = 8;
   constexpr size_t kRequestsPerThread = 100;
 
   internal::RetryableRequestTracker tracker;
+  // Stays registered for the whole test: no concurrently computed watermark
+  // may ever exceed its ID.
+  auto pinned = tracker.Register();
+  const auto pinned_id = pinned.request_id();
+
+  std::array<std::vector<RetryableRequestId>, kNumThreads> ids_by_thread;
   TestThreadHolder thread_holder;
   for (size_t thread_idx = 0; thread_idx != kNumThreads; ++thread_idx) {
-    thread_holder.AddThreadFunctor([&tracker] {
+    thread_holder.AddThreadFunctor([&tracker, pinned_id, &ids = ids_by_thread[thread_idx]] {
       std::vector<internal::RetryableRequestTracker::Registration> registrations;
       registrations.reserve(kRequestsPerThread);
       for (size_t request_idx = 0; request_idx != kRequestsPerThread; ++request_idx) {
-        registrations.push_back(tracker.Register());
+        auto registration = tracker.Register();
+        ASSERT_LE(registration.min_running_request_id(), registration.request_id());
+        ASSERT_LE(registration.min_running_request_id(), pinned_id);
+        ids.push_back(registration.request_id());
+        registrations.push_back(std::move(registration));
       }
 
       std::vector<internal::RetryableRequestTracker::Registration*> registration_ptrs;
@@ -181,12 +266,18 @@ TEST(ClientUnitTest, RetryableRequestTrackerConcurrentRegistrationAndRetirement)
   }
   thread_holder.WaitAndStop(10s);
 
+  std::unordered_set<RetryableRequestId> unique_ids = {pinned_id};
+  for (const auto& ids : ids_by_thread) {
+    ASSERT_EQ(ids.size(), kRequestsPerThread);
+    for (const auto id : ids) {
+      ASSERT_TRUE(unique_ids.insert(id).second) << "duplicate request id " << id;
+    }
+  }
+
+  ASSERT_EQ(tracker.TEST_ActiveRequestsCount(), 1);
+  std::array pinned_ptr = {&pinned};
+  tracker.Unregister(pinned_ptr);
   ASSERT_EQ(tracker.TEST_ActiveRequestsCount(), 0);
-  auto registration = tracker.Register();
-  ASSERT_EQ(registration.request_id(), kNumThreads * kRequestsPerThread);
-  ASSERT_EQ(registration.min_running_request_id(), registration.request_id());
-  std::array registrations = {&registration};
-  tracker.Unregister(registrations);
 }
 
 } // namespace client

--- a/src/yb/client/client-unittest.cc
+++ b/src/yb/client/client-unittest.cc
@@ -31,6 +31,7 @@
 //
 // Tests for the client which are true unit tests and don't require a cluster, etc.
 
+#include <array>
 #include <functional>
 #include <string>
 #include <vector>
@@ -38,7 +39,10 @@
 #include <gtest/gtest.h>
 
 #include "yb/client/client-internal.h"
+#include "yb/client/retryable_request_tracker.h"
 #include "yb/client/schema.h"
+
+#include "yb/util/test_thread_holder.h"
 
 namespace yb {
 namespace client {
@@ -103,6 +107,86 @@ TEST(ClientUnitTest, TestSchemaBuilder_SingleKey_GoodSchema) {
   b.AddColumn("b")->Type(DataType::INT32);
   b.AddColumn("c")->Type(DataType::INT32)->NotNull();
   ASSERT_EQ("OK", b.Build(&s).ToString());
+}
+
+TEST(ClientUnitTest, RetryableRequestTrackerMaintainsMinimumActiveRequestId) {
+  internal::RetryableRequestTracker tracker;
+  auto first = tracker.Register();
+  auto second = tracker.Register();
+  auto third = tracker.Register();
+
+  ASSERT_EQ(first.request_id(), 0);
+  ASSERT_EQ(second.request_id(), 1);
+  ASSERT_EQ(third.request_id(), 2);
+  ASSERT_EQ(first.min_running_request_id(), 0);
+  ASSERT_EQ(second.min_running_request_id(), 0);
+  ASSERT_EQ(third.min_running_request_id(), 0);
+
+  std::array middle_registration = {&second};
+  tracker.Unregister(middle_registration);
+  ASSERT_EQ(tracker.TEST_ActiveRequestsCount(), 2);
+
+  auto fourth = tracker.Register();
+  ASSERT_EQ(fourth.request_id(), 3);
+  ASSERT_EQ(fourth.min_running_request_id(), 0);
+
+  std::array first_registration = {&first};
+  tracker.Unregister(first_registration);
+  auto fifth = tracker.Register();
+  ASSERT_EQ(fifth.request_id(), 4);
+  ASSERT_EQ(fifth.min_running_request_id(), 2);
+
+  std::array remaining_registrations = {&third, &fourth, &fifth};
+  tracker.Unregister(remaining_registrations);
+  ASSERT_EQ(tracker.TEST_ActiveRequestsCount(), 0);
+
+  auto sixth = tracker.Register();
+  ASSERT_EQ(sixth.request_id(), 5);
+  ASSERT_EQ(sixth.min_running_request_id(), 5);
+  std::array sixth_registration = {&sixth};
+  tracker.Unregister(sixth_registration);
+}
+
+TEST(ClientUnitTest, RetryableRequestTrackerTransfersMovedRegistration) {
+  internal::RetryableRequestTracker tracker;
+  auto registration = tracker.Register();
+  auto moved_registration = std::move(registration);
+
+  std::array registrations = {&moved_registration};
+  tracker.Unregister(registrations);
+  ASSERT_EQ(tracker.TEST_ActiveRequestsCount(), 0);
+}
+
+TEST(ClientUnitTest, RetryableRequestTrackerConcurrentRegistrationAndRetirement) {
+  constexpr size_t kNumThreads = 8;
+  constexpr size_t kRequestsPerThread = 100;
+
+  internal::RetryableRequestTracker tracker;
+  TestThreadHolder thread_holder;
+  for (size_t thread_idx = 0; thread_idx != kNumThreads; ++thread_idx) {
+    thread_holder.AddThreadFunctor([&tracker] {
+      std::vector<internal::RetryableRequestTracker::Registration> registrations;
+      registrations.reserve(kRequestsPerThread);
+      for (size_t request_idx = 0; request_idx != kRequestsPerThread; ++request_idx) {
+        registrations.push_back(tracker.Register());
+      }
+
+      std::vector<internal::RetryableRequestTracker::Registration*> registration_ptrs;
+      registration_ptrs.reserve(registrations.size());
+      for (auto& registration : registrations) {
+        registration_ptrs.push_back(&registration);
+      }
+      tracker.Unregister(registration_ptrs);
+    });
+  }
+  thread_holder.WaitAndStop(10s);
+
+  ASSERT_EQ(tracker.TEST_ActiveRequestsCount(), 0);
+  auto registration = tracker.Register();
+  ASSERT_EQ(registration.request_id(), kNumThreads * kRequestsPerThread);
+  ASSERT_EQ(registration.min_running_request_id(), registration.request_id());
+  std::array registrations = {&registration};
+  tracker.Unregister(registrations);
 }
 
 } // namespace client

--- a/src/yb/client/client.cc
+++ b/src/yb/client/client.cc
@@ -2625,33 +2625,8 @@ const CloudInfoPB& YBClient::cloud_info() const {
   return data_->cloud_info_pb_;
 }
 
-std::pair<RetryableRequestId, RetryableRequestId> YBClient::NextRequestIdAndMinRunningRequestId() {
-  std::lock_guard lock(data_->tablet_requests_mutex_);
-  auto& requests = data_->requests_;
-  auto id = requests.request_id_seq++;
-  requests.running_requests.insert(id);
-  return std::make_pair(id, *requests.running_requests.begin());
-}
-
 void YBClient::AddMetaCacheInfo(JsonWriter* writer) const {
   data_->meta_cache_->AddAllTabletInfo(writer);
-}
-
-void YBClient::RequestsFinished(const RetryableRequestIdRange& request_id_range) {
-  if (request_id_range.empty()) {
-    return;
-  }
-  std::lock_guard lock(data_->tablet_requests_mutex_);
-  for (const auto& id : request_id_range) {
-    auto& requests = data_->requests_.running_requests;
-    auto it = requests.find(id);
-    if (it != requests.end()) {
-      requests.erase(it);
-    } else {
-      LOG_WITH_PREFIX(DFATAL) << "RequestsFinished called for an unknown request: "
-                              << id;
-    }
-  }
 }
 
 void YBClient::LookupTabletByKey(

--- a/src/yb/client/client.h
+++ b/src/yb/client/client.h
@@ -1132,11 +1132,7 @@ class YBClient {
 
   const CloudInfoPB& cloud_info() const;
 
-  std::pair<RetryableRequestId, RetryableRequestId> NextRequestIdAndMinRunningRequestId();
-
   void AddMetaCacheInfo(JsonWriter* writer) const;
-
-  void RequestsFinished(const RetryableRequestIdRange& request_id_range);
 
   void Shutdown();
 

--- a/src/yb/client/retryable_request_tracker.cc
+++ b/src/yb/client/retryable_request_tracker.cc
@@ -28,27 +28,56 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied.  See the License for the specific language governing permissions and limitations
 // under the License.
+//
 
 #include "yb/client/retryable_request_tracker.h"
 
+#include <functional>
 #include <mutex>
+#include <thread>
 #include <utility>
 
+#include "yb/util/flags.h"
 #include "yb/util/logging.h"
+
+DEFINE_NON_RUNTIME_uint32(client_retryable_request_tracker_stripes, 16,
+    "Number of independently locked stripes used to track retryable request IDs in each "
+    "YB client. Values are rounded up to a power of two.");
 
 namespace yb::client::internal {
 
+namespace {
+
+constexpr size_t kMaxStripes = 1024;
+
+size_t EffectiveStripeCount(size_t requested) {
+  if (requested == 0) {
+    requested = FLAGS_client_retryable_request_tracker_stripes;
+  }
+  requested = std::clamp<size_t>(requested, 1, kMaxStripes);
+  size_t stripes = 1;
+  while (stripes < requested) {
+    stripes <<= 1;
+  }
+  return stripes;
+}
+
+}  // namespace
+
 RetryableRequestTracker::Registration::Registration(
     RetryableRequestId request_id, RetryableRequestId min_running_request_id,
-    ActiveRequests::iterator position)
+    Stripe* stripe, ActiveRequests::iterator position)
     : request_id_(request_id),
       min_running_request_id_(min_running_request_id),
+      stripe_(stripe),
       position_(position) {}
 
 RetryableRequestTracker::Registration::Registration(Registration&& other) noexcept
     : request_id_(other.request_id_),
       min_running_request_id_(other.min_running_request_id_),
+      stripe_(other.stripe_),
       position_(std::move(other.position_)) {
+  other.stripe_ = nullptr;
   other.position_.reset();
 }
 
@@ -58,44 +87,88 @@ RetryableRequestTracker::Registration& RetryableRequestTracker::Registration::op
     CHECK(!position_) << "Overwriting an active retryable request registration";
     request_id_ = other.request_id_;
     min_running_request_id_ = other.min_running_request_id_;
+    stripe_ = other.stripe_;
     position_ = std::move(other.position_);
+    other.stripe_ = nullptr;
     other.position_.reset();
   }
   return *this;
 }
 
+RetryableRequestTracker::RetryableRequestTracker(size_t stripe_count)
+    : stripe_count_(EffectiveStripeCount(stripe_count)),
+      stripes_(std::make_unique<Stripe[]>(stripe_count_)) {
+  for (size_t index = 0; index < stripe_count_; ++index) {
+    stripes_[index].next_id = index;
+    stripes_[index].lower_bound.store(index, std::memory_order_release);
+  }
+}
+
+size_t RetryableRequestTracker::NextStripeIndex() {
+  // Round-robin per thread: consecutive requests from one thread cycle through
+  // every stripe, so all lower bounds keep advancing on any active client. The
+  // hash seed spreads the starting stripe across threads.
+  static thread_local uint64_t counter =
+      std::hash<std::thread::id>()(std::this_thread::get_id());
+  return counter++ & (stripe_count_ - 1);
+}
+
+RetryableRequestId RetryableRequestTracker::ComputeWatermark() const {
+  auto watermark = stripes_[0].lower_bound.load(std::memory_order_acquire);
+  for (size_t index = 1; index < stripe_count_; ++index) {
+    watermark = std::min(watermark, stripes_[index].lower_bound.load(std::memory_order_acquire));
+  }
+  return watermark;
+}
+
 RetryableRequestTracker::Registration RetryableRequestTracker::Register() {
-  std::lock_guard lock(mutex_);
-  const auto request_id = next_request_id_++;
-  const auto position = active_requests_.emplace(active_requests_.end(), request_id);
-  return Registration(request_id, active_requests_.front(), position);
+  auto& stripe = stripes_[NextStripeIndex()];
+  RetryableRequestId request_id;
+  ActiveRequests::iterator position;
+  {
+    std::lock_guard lock(stripe.mutex);
+    request_id = stripe.next_id;
+    stripe.next_id += stripe_count_;
+    position = stripe.active_requests.emplace(stripe.active_requests.end(), request_id);
+    stripe.lower_bound.store(stripe.active_requests.front(), std::memory_order_release);
+  }
+  // Computed after this request is visible in its stripe, so the watermark is
+  // at most this stripe's lower bound and therefore at most request_id.
+  return Registration(request_id, ComputeWatermark(), &stripe, position);
 }
 
 void RetryableRequestTracker::Unregister(std::span<Registration*> registrations) {
-  if (registrations.empty()) {
-    return;
-  }
-
+  // Destroy retired list nodes after all locks are released.
   ActiveRequests retired_requests;
-  {
-    std::lock_guard lock(mutex_);
-    for (auto* registration : registrations) {
-      CHECK_NOTNULL(registration);
-      if (!registration->position_) {
-        LOG(DFATAL) << "Retryable request registration already retired: "
-                    << registration->request_id_;
-        continue;
-      }
-      DCHECK_EQ(**registration->position_, registration->request_id_);
-      retired_requests.splice(retired_requests.end(), active_requests_, *registration->position_);
-      registration->position_.reset();
+  for (auto* registration : registrations) {
+    CHECK_NOTNULL(registration);
+    if (!registration->position_) {
+      LOG(DFATAL) << "Retryable request registration already retired: "
+                  << registration->request_id_;
+      continue;
     }
+    auto* stripe = CHECK_NOTNULL(registration->stripe_);
+    {
+      std::lock_guard lock(stripe->mutex);
+      DCHECK_EQ(**registration->position_, registration->request_id_);
+      retired_requests.splice(
+          retired_requests.end(), stripe->active_requests, *registration->position_);
+      stripe->lower_bound.store(
+          stripe->active_requests.empty() ? stripe->next_id : stripe->active_requests.front(),
+          std::memory_order_release);
+    }
+    registration->stripe_ = nullptr;
+    registration->position_.reset();
   }
 }
 
 size_t RetryableRequestTracker::TEST_ActiveRequestsCount() const {
-  std::lock_guard lock(mutex_);
-  return active_requests_.size();
+  size_t count = 0;
+  for (size_t index = 0; index < stripe_count_; ++index) {
+    std::lock_guard lock(stripes_[index].mutex);
+    count += stripes_[index].active_requests.size();
+  }
+  return count;
 }
 
 }  // namespace yb::client::internal

--- a/src/yb/client/retryable_request_tracker.cc
+++ b/src/yb/client/retryable_request_tracker.cc
@@ -1,0 +1,101 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// The following only applies to changes made to this file as part of YugabyteDB development.
+//
+// Portions Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+
+#include "yb/client/retryable_request_tracker.h"
+
+#include <mutex>
+#include <utility>
+
+#include "yb/util/logging.h"
+
+namespace yb::client::internal {
+
+RetryableRequestTracker::Registration::Registration(
+    RetryableRequestId request_id, RetryableRequestId min_running_request_id,
+    ActiveRequests::iterator position)
+    : request_id_(request_id),
+      min_running_request_id_(min_running_request_id),
+      position_(position) {}
+
+RetryableRequestTracker::Registration::Registration(Registration&& other) noexcept
+    : request_id_(other.request_id_),
+      min_running_request_id_(other.min_running_request_id_),
+      position_(std::move(other.position_)) {
+  other.position_.reset();
+}
+
+RetryableRequestTracker::Registration& RetryableRequestTracker::Registration::operator=(
+    Registration&& other) noexcept {
+  if (this != &other) {
+    CHECK(!position_) << "Overwriting an active retryable request registration";
+    request_id_ = other.request_id_;
+    min_running_request_id_ = other.min_running_request_id_;
+    position_ = std::move(other.position_);
+    other.position_.reset();
+  }
+  return *this;
+}
+
+RetryableRequestTracker::Registration RetryableRequestTracker::Register() {
+  std::lock_guard lock(mutex_);
+  const auto request_id = next_request_id_++;
+  const auto position = active_requests_.emplace(active_requests_.end(), request_id);
+  return Registration(request_id, active_requests_.front(), position);
+}
+
+void RetryableRequestTracker::Unregister(std::span<Registration*> registrations) {
+  if (registrations.empty()) {
+    return;
+  }
+
+  ActiveRequests retired_requests;
+  {
+    std::lock_guard lock(mutex_);
+    for (auto* registration : registrations) {
+      CHECK_NOTNULL(registration);
+      if (!registration->position_) {
+        LOG(DFATAL) << "Retryable request registration already retired: "
+                    << registration->request_id_;
+        continue;
+      }
+      DCHECK_EQ(**registration->position_, registration->request_id_);
+      retired_requests.splice(retired_requests.end(), active_requests_, *registration->position_);
+      registration->position_.reset();
+    }
+  }
+}
+
+size_t RetryableRequestTracker::TEST_ActiveRequestsCount() const {
+  std::lock_guard lock(mutex_);
+  return active_requests_.size();
+}
+
+}  // namespace yb::client::internal

--- a/src/yb/client/retryable_request_tracker.h
+++ b/src/yb/client/retryable_request_tracker.h
@@ -1,0 +1,86 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// The following only applies to changes made to this file as part of YugabyteDB development.
+//
+// Portions Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+#pragma once
+
+#include <list>
+#include <optional>
+#include <span>
+
+#include "yb/common/retryable_request.h"
+#include "yb/gutil/macros.h"
+#include "yb/util/locks.h"
+
+namespace yb::client::internal {
+
+// Tracks retryable requests issued by one YBClient. Request IDs and active-list insertion are
+// serialized, so the list remains ordered by request ID and its front is the minimum active ID.
+class RetryableRequestTracker {
+ private:
+  using ActiveRequests = std::list<RetryableRequestId>;
+
+ public:
+  class Registration {
+   public:
+    Registration(Registration&& other) noexcept;
+    Registration& operator=(Registration&& other) noexcept;
+
+    Registration(const Registration&) = delete;
+    Registration& operator=(const Registration&) = delete;
+
+    RetryableRequestId request_id() const { return request_id_; }
+
+    RetryableRequestId min_running_request_id() const { return min_running_request_id_; }
+
+   private:
+    Registration(
+        RetryableRequestId request_id, RetryableRequestId min_running_request_id,
+        ActiveRequests::iterator position);
+
+    RetryableRequestId request_id_;
+    RetryableRequestId min_running_request_id_;
+    std::optional<ActiveRequests::iterator> position_;
+
+    friend class RetryableRequestTracker;
+  };
+
+  Registration Register();
+  void Unregister(std::span<Registration*> registrations);
+
+  size_t TEST_ActiveRequestsCount() const;
+
+ private:
+  mutable simple_spinlock mutex_;
+  RetryableRequestId next_request_id_ GUARDED_BY(mutex_) = 0;
+  ActiveRequests active_requests_ GUARDED_BY(mutex_);
+};
+
+}  // namespace yb::client::internal

--- a/src/yb/client/retryable_request_tracker.h
+++ b/src/yb/client/retryable_request_tracker.h
@@ -31,21 +31,47 @@
 //
 #pragma once
 
+#include <atomic>
 #include <list>
+#include <memory>
 #include <optional>
 #include <span>
 
 #include "yb/common/retryable_request.h"
 #include "yb/gutil/macros.h"
+#include "yb/gutil/port.h"
 #include "yb/util/locks.h"
 
 namespace yb::client::internal {
 
-// Tracks retryable requests issued by one YBClient. Request IDs and active-list insertion are
-// serialized, so the list remains ordered by request ID and its front is the minimum active ID.
+// Tracks retryable requests issued by one YBClient.
+//
+// Request IDs must be unique within a client, and every outgoing RPC carries a
+// min-running watermark. Tablet leaders reject request IDs below the watermark
+// they last saw and garbage-collect retry-deduplication state up to it, so a
+// watermark must never exceed the ID of any request that is registered but
+// unfinished when the watermark is computed, or that registers later. A
+// conservative (lagging) watermark is always safe: it only delays server-side
+// cleanup, which is additionally bounded by time-based expiry.
+//
+// To avoid serializing every registration behind one lock, state is striped.
+// Stripe s of S assigns IDs from the arithmetic sequence s, s+S, s+2S, ...
+// under its own lock, so ID assignment and active-list insertion remain atomic
+// per stripe, each stripe's active list stays in ascending ID order, and each
+// stripe maintains a monotonically non-decreasing lower bound on any ID it has
+// in flight or may still assign: the list front when non-empty, otherwise the
+// next unassigned ID. The watermark is the minimum of the per-stripe lower
+// bounds. Reading the bounds without a consistent snapshot is safe: a value
+// read from a stripe is a valid lower bound for every request that stripe had
+// registered at read time (it is at most the list front) and for every request
+// it registers later (IDs and bounds only grow).
+//
+// Stripes are selected by a per-thread round-robin counter, so any client that
+// keeps issuing requests keeps every stripe's lower bound advancing.
 class RetryableRequestTracker {
  private:
   using ActiveRequests = std::list<RetryableRequestId>;
+  struct Stripe;
 
  public:
   class Registration {
@@ -63,24 +89,41 @@ class RetryableRequestTracker {
    private:
     Registration(
         RetryableRequestId request_id, RetryableRequestId min_running_request_id,
-        ActiveRequests::iterator position);
+        Stripe* stripe, ActiveRequests::iterator position);
 
     RetryableRequestId request_id_;
     RetryableRequestId min_running_request_id_;
+    Stripe* stripe_;
     std::optional<ActiveRequests::iterator> position_;
 
     friend class RetryableRequestTracker;
   };
 
+  // stripe_count == 0 selects --client_retryable_request_tracker_stripes.
+  // Counts are rounded up to a power of two.
+  explicit RetryableRequestTracker(size_t stripe_count = 0);
+
   Registration Register();
   void Unregister(std::span<Registration*> registrations);
 
   size_t TEST_ActiveRequestsCount() const;
+  size_t TEST_StripeCount() const { return stripe_count_; }
 
  private:
-  mutable simple_spinlock mutex_;
-  RetryableRequestId next_request_id_ GUARDED_BY(mutex_) = 0;
-  ActiveRequests active_requests_ GUARDED_BY(mutex_);
+  struct alignas(CACHELINE_SIZE) Stripe {
+    mutable simple_spinlock mutex;
+    RetryableRequestId next_id GUARDED_BY(mutex) = 0;
+    ActiveRequests active_requests GUARDED_BY(mutex);
+    // active_requests.empty() ? next_id : active_requests.front().
+    // Monotonically non-decreasing; updated under mutex, read lock-free.
+    std::atomic<RetryableRequestId> lower_bound{0};
+  };
+
+  size_t NextStripeIndex();
+  RetryableRequestId ComputeWatermark() const;
+
+  size_t stripe_count_;
+  std::unique_ptr<Stripe[]> stripes_;
 };
 
 }  // namespace yb::client::internal


### PR DESCRIPTION
DO NOT MERGE!! [CSI](<https://csiweb.dev.yugabyte.com/pull/33244/>) ❌. Once CSI passes, comment `trigger jenkins` to clear this warning.

## Summary

At high connection counts on many-core hosts, every YBClient operation crosses one per-client lock twice: `YBClient::NextRequestIdAndMinRunningRequestId` takes it to allocate a request ID and register it in the running-requests set, and `RequestsFinished` takes it again to retire the ID. Lock-contention profiling on a 3-node cluster of large (hundreds of vCPUs) nodes under a single-row INSERT workload at 3,500-5,000 connections attributed ~90% of the embedded YSQL client's total lock wait time to this pair.

Two commits:

1. **Reduce work under the lock** on the ID-generation/retirement path (narrows the critical section without changing the data structure).
2. **Stripe the RetryableRequestTracker.** The tracker is partitioned into independently locked stripes; stripe `s` of `S` assigns request IDs `s, s+S, s+2S, ...` under its own lock, keeping ID assignment and active-list insertion atomic per stripe. Each stripe publishes a monotone lower bound (the front of its running list when non-empty, otherwise its next unassigned ID) in a lock-free atomic; `min_running_request_id` is the minimum across stripes. The watermark may lag but can never overshoot, regardless of read interleaving, so server-side dedup-state GC driven by the watermark remains correct. Stripes are chosen by a per-thread round-robin counter so every stripe keeps advancing on an active client. The stripe count comes from a new non-runtime flag `--client_retryable_request_tracker_stripes` (default 16, rounded up to a power of two; default preserves enough striping to remove the hot lock while keeping per-stripe ID-space fragmentation negligible).

With both changes (measured with 64 stripes), the register/unregister path dropped from ~90% of client lock wait to ~2%, contributing to a ~15% single-row write throughput improvement on the same hardware in combination with reactor/connection tuning.

Fixes #33243

## Test plan

- [x] `client-unittest` passes (12/12), including five new/extended tracker tests:
  - `RetryableRequestTrackerMaintainsMinimumActiveRequestId`
  - `RetryableRequestTrackerTransfersMovedRegistration`
  - `RetryableRequestTrackerStripeCountRoundsUpToPowerOfTwo`
  - `RetryableRequestTrackerStripedIdsAreUniqueAndWatermarkConservative`
  - `RetryableRequestTrackerWatermarkAdvancesAfterRetirement`
- [x] Built and tested on both x86_64/clang19 (release, full LTO) and aarch64/clang21 (release).
- [x] Backport of the same changes ran a multi-week write-scaling benchmark campaign on a 3-node cluster (RF3, single-row INSERT, up to 10,000 connections) with no consensus/dedup errors; contention profiles confirm the lock is no longer hot.
