### PR TITLE
[#32600] DocDB: Allocate retryable request ids in per-thread blocks

### DIFF
--- a/src/yb/client/CMakeLists.txt
+++ b/src/yb/client/CMakeLists.txt
@@ -48,6 +48,7 @@ set(CLIENT_SRCS
   meta_data_cache.cc
   namespace_alterer.cc
   permissions.cc
+  request_id_allocator.cc
   session.cc
   schema.cc
   stateful_services/stateful_service_client_base.cc
@@ -142,6 +143,7 @@ ADD_YB_TEST(ql-map-test)
 ADD_YB_TEST(ql-tablet-test)
 ADD_YB_TEST(ql-transaction-test)
 ADD_YB_TEST(ql-stress-test)
+ADD_YB_TEST(request_id_allocator-test)
 ADD_YB_TEST(seal-txn-test)
 ADD_YB_TEST(snapshot-txn-test)
 ADD_YB_TEST(snapshot_schedule-test)

--- a/src/yb/client/async_rpc.cc
+++ b/src/yb/client/async_rpc.cc
@@ -700,10 +700,10 @@ WriteRpc::WriteRpc(const AsyncRpcData& data, rpc::ThreadPoolTag pool_tag)
       req_.set_request_id(*first_yb_op->request_id());
       req_.set_min_running_request_id(request_detail.min_running_request_id);
     } else {
-      const auto request_pair = batcher_->NextRequestIdAndMinRunningRequestId();
-      req_.set_request_id(request_pair.first);
-      req_.set_min_running_request_id(request_pair.second);
-      batcher_->RegisterRequest(request_pair.first, request_pair.second);
+      const auto allocation = batcher_->NextRequestIdAndMinRunningRequestId();
+      req_.set_request_id(allocation.id);
+      req_.set_min_running_request_id(allocation.min_running);
+      batcher_->RegisterRequest(allocation);
     }
     FillRequestIds(req_.request_id(), &ops_);
   }

--- a/src/yb/client/batcher.cc
+++ b/src/yb/client/batcher.cc
@@ -41,7 +41,6 @@
 #include <utility>
 #include <vector>
 
-#include <boost/range/adaptors.hpp>
 
 #include "yb/ash/wait_state.h"
 
@@ -688,12 +687,14 @@ server::Clock* Batcher::Clock() const {
   return client_->Clock();
 }
 
-std::pair<RetryableRequestId, RetryableRequestId> Batcher::NextRequestIdAndMinRunningRequestId() {
+RequestIdAllocation Batcher::NextRequestIdAndMinRunningRequestId() {
   return client_->NextRequestIdAndMinRunningRequestId();
 }
 
 void Batcher::RequestsFinished() {
-  client_->RequestsFinished(retryable_requests_ | boost::adaptors::map_keys);
+  for (const auto& entry : retryable_requests_) {
+    RequestIdAllocator::Finished(entry.second.block);
+  }
 }
 
 void Batcher::MoveRequestDetailsFrom(const BatcherPtr& other, RetryableRequestId id) {

--- a/src/yb/client/batcher.h
+++ b/src/yb/client/batcher.h
@@ -38,6 +38,7 @@
 
 #include "yb/client/async_rpc.h"
 #include "yb/client/error_collector.h"
+#include "yb/client/request_id_allocator.h"
 #include "yb/client/transaction.h"
 
 #include "yb/common/consistent_read_point.h"
@@ -92,8 +93,11 @@ struct InFlightOpsGroupsWithMetadata {
 struct RequestDetails {
   RetryableRequestId min_running_request_id;
 
-  explicit RequestDetails(RetryableRequestId min_running_request_id_) :
-      min_running_request_id(min_running_request_id_) {}
+  // Keeps the id's block alive; used to report completion to the request id allocator.
+  RequestIdBlockPtr block;
+
+  explicit RequestDetails(const RequestIdAllocation& allocation) :
+      min_running_request_id(allocation.min_running), block(allocation.block) {}
 };
 
 using BatcherRequestsMap = std::unordered_map<RetryableRequestId, RequestDetails>;
@@ -251,13 +255,12 @@ class Batcher : public Runnable, public std::enable_shared_from_this<Batcher> {
 
   server::Clock* Clock() const;
 
-  std::pair<RetryableRequestId, RetryableRequestId> NextRequestIdAndMinRunningRequestId();
+  RequestIdAllocation NextRequestIdAndMinRunningRequestId();
 
   void RequestsFinished();
 
-  void RegisterRequest(
-      RetryableRequestId id, RetryableRequestId min_running_id) {
-    retryable_requests_.emplace(id, RequestDetails(min_running_id));
+  void RegisterRequest(const RequestIdAllocation& allocation) {
+    retryable_requests_.emplace(allocation.id, RequestDetails(allocation));
   }
 
   void MoveRequestDetailsFrom(const BatcherPtr& other, RetryableRequestId id);

--- a/src/yb/client/client-internal.h
+++ b/src/yb/client/client-internal.h
@@ -40,6 +40,7 @@
 #include <vector>
 
 #include "yb/client/client.h"
+#include "yb/client/request_id_allocator.h"
 
 #include "yb/common/common_net.pb.h"
 #include "yb/common/entity_ids.h"
@@ -642,15 +643,9 @@ class YBClient::Data {
   const ClientId id_;
   const std::string log_prefix_;
 
-  // Used to track requests that were sent to a particular tablet, so it could track different
-  // RPCs related to the same write operation and reject duplicates.
-  struct TabletRequests {
-    RetryableRequestId request_id_seq = 0;
-    std::set<RetryableRequestId> running_requests;
-  };
-
-  simple_spinlock tablet_requests_mutex_;
-  TabletRequests requests_;
+  // Allocates ids for retryable write requests, so the server can track different RPCs related
+  // to the same write operation and reject duplicates.
+  internal::RequestIdAllocator request_id_allocator_;
 
   std::array<std::atomic<int>, 2> tserver_count_cached_;
 

--- a/src/yb/client/client.cc
+++ b/src/yb/client/client.cc
@@ -2625,33 +2625,12 @@ const CloudInfoPB& YBClient::cloud_info() const {
   return data_->cloud_info_pb_;
 }
 
-std::pair<RetryableRequestId, RetryableRequestId> YBClient::NextRequestIdAndMinRunningRequestId() {
-  std::lock_guard lock(data_->tablet_requests_mutex_);
-  auto& requests = data_->requests_;
-  auto id = requests.request_id_seq++;
-  requests.running_requests.insert(id);
-  return std::make_pair(id, *requests.running_requests.begin());
+internal::RequestIdAllocation YBClient::NextRequestIdAndMinRunningRequestId() {
+  return data_->request_id_allocator_.Next();
 }
 
 void YBClient::AddMetaCacheInfo(JsonWriter* writer) const {
   data_->meta_cache_->AddAllTabletInfo(writer);
-}
-
-void YBClient::RequestsFinished(const RetryableRequestIdRange& request_id_range) {
-  if (request_id_range.empty()) {
-    return;
-  }
-  std::lock_guard lock(data_->tablet_requests_mutex_);
-  for (const auto& id : request_id_range) {
-    auto& requests = data_->requests_.running_requests;
-    auto it = requests.find(id);
-    if (it != requests.end()) {
-      requests.erase(it);
-    } else {
-      LOG_WITH_PREFIX(DFATAL) << "RequestsFinished called for an unknown request: "
-                              << id;
-    }
-  }
 }
 
 void YBClient::LookupTabletByKey(

--- a/src/yb/client/client.h
+++ b/src/yb/client/client.h
@@ -177,6 +177,7 @@ struct CDCSDKStreamInfo {
 
 namespace internal {
 class ClientMasterRpcBase;
+struct RequestIdAllocation;
 }
 
 using GetTableLocationsCallback =
@@ -1132,11 +1133,9 @@ class YBClient {
 
   const CloudInfoPB& cloud_info() const;
 
-  std::pair<RetryableRequestId, RetryableRequestId> NextRequestIdAndMinRunningRequestId();
+  internal::RequestIdAllocation NextRequestIdAndMinRunningRequestId();
 
   void AddMetaCacheInfo(JsonWriter* writer) const;
-
-  void RequestsFinished(const RetryableRequestIdRange& request_id_range);
 
   void Shutdown();
 

--- a/src/yb/client/request_id_allocator-test.cc
+++ b/src/yb/client/request_id_allocator-test.cc
@@ -1,0 +1,183 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include <atomic>
+#include <mutex>
+#include <random>
+#include <thread>
+#include <unordered_set>
+#include <vector>
+
+#include "yb/client/request_id_allocator.h"
+
+#include "yb/util/flags.h"
+#include "yb/util/test_util.h"
+
+DECLARE_uint32(client_request_id_block_size);
+DECLARE_uint32(client_request_id_block_idle_sec);
+
+namespace yb {
+namespace client {
+namespace internal {
+
+class RequestIdAllocatorTest : public YBTest {
+};
+
+TEST_F(RequestIdAllocatorTest, Basic) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_client_request_id_block_size) = 8;
+  RequestIdAllocator allocator;
+
+  std::unordered_set<RetryableRequestId> ids;
+  std::vector<RequestIdAllocation> allocations;
+  RetryableRequestId prev_min = 0;
+  for (int i = 0; i != 100; ++i) {
+    auto allocation = allocator.Next();
+    ASSERT_TRUE(ids.insert(allocation.id).second) << "Duplicate id: " << allocation.id;
+    ASSERT_LE(allocation.min_running, allocation.id);
+    ASSERT_GE(allocation.min_running, prev_min) << "min_running went backwards";
+    prev_min = allocation.min_running;
+    allocations.push_back(std::move(allocation));
+  }
+
+  for (const auto& allocation : allocations) {
+    RequestIdAllocator::Finished(allocation.block);
+  }
+  allocations.clear();
+
+  // After all requests finished and idle blocks sealed, min advances past every issued id.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_client_request_id_block_idle_sec) = 0;
+  SleepFor(MonoDelta::FromMilliseconds(50));
+  allocator.TEST_Sweep();
+  ASSERT_EQ(allocator.TEST_num_active_blocks(), 0);
+  for (auto id : ids) {
+    ASSERT_GT(allocator.TEST_min_running(), id);
+  }
+}
+
+TEST_F(RequestIdAllocatorTest, RetireOnBlockExhaustion) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_client_request_id_block_size) = 4;
+  RequestIdAllocator allocator;
+
+  // Consume and finish two full blocks; exhausted blocks retire without the idle sweep.
+  for (int i = 0; i != 9; ++i) {
+    auto allocation = allocator.Next();
+    RequestIdAllocator::Finished(allocation.block);
+  }
+  // Only the current (third) block may still be active.
+  ASSERT_LE(allocator.TEST_num_active_blocks(), 1);
+  ASSERT_GE(allocator.TEST_min_running(), 8);
+}
+
+TEST_F(RequestIdAllocatorTest, IdleBlockDoesNotPinMinForever) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_client_request_id_block_size) = 1024;
+  RequestIdAllocator allocator;
+
+  // A thread allocates once from a big block and goes idle.
+  auto idle_allocation = allocator.Next();
+  RequestIdAllocator::Finished(idle_allocation.block);
+  ASSERT_EQ(allocator.TEST_min_running(), 0);
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_client_request_id_block_idle_sec) = 0;
+  SleepFor(MonoDelta::FromMilliseconds(50));
+  allocator.TEST_Sweep();
+
+  // The idle block was sealed and retired; min moved past its floor.
+  ASSERT_EQ(allocator.TEST_num_active_blocks(), 0);
+  ASSERT_GT(allocator.TEST_min_running(), idle_allocation.id);
+}
+
+TEST_F(RequestIdAllocatorTest, SealedBlockStillTracksRunningRequests) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_client_request_id_block_size) = 1024;
+  RequestIdAllocator allocator;
+
+  auto running = allocator.Next();
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_client_request_id_block_idle_sec) = 0;
+  SleepFor(MonoDelta::FromMilliseconds(50));
+  allocator.TEST_Sweep();
+
+  // The block is sealed but the request is still running, so min must not pass its id.
+  ASSERT_EQ(allocator.TEST_num_active_blocks(), 1);
+  ASSERT_LE(allocator.TEST_min_running(), running.id);
+
+  RequestIdAllocator::Finished(running.block);
+  allocator.TEST_Sweep();
+  ASSERT_EQ(allocator.TEST_num_active_blocks(), 0);
+  ASSERT_GT(allocator.TEST_min_running(), running.id);
+}
+
+TEST_F(RequestIdAllocatorTest, ConcurrentHammer) {
+  constexpr int kThreads = 16;
+  constexpr int kIterations = 5000;
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_client_request_id_block_size) = 16;
+  RequestIdAllocator allocator;
+
+  // Max min_running ever advertised. The core safety invariant is that an id returned by
+  // Next() is never below a min_running advertised before that Next() call started.
+  std::atomic<RetryableRequestId> max_advertised_min{0};
+
+  std::mutex all_ids_mutex;
+  std::unordered_set<RetryableRequestId> all_ids;
+
+  std::vector<std::thread> threads;
+  for (int t = 0; t != kThreads; ++t) {
+    threads.emplace_back([&allocator, &max_advertised_min, &all_ids_mutex, &all_ids, t] {
+      std::mt19937 rng(t);
+      std::vector<RequestIdAllocation> outstanding;
+      std::vector<RetryableRequestId> my_ids;
+      for (int i = 0; i != kIterations; ++i) {
+        auto min_before = max_advertised_min.load();
+        auto allocation = allocator.Next();
+        ASSERT_GE(allocation.id, min_before)
+            << "Issued an id below a previously advertised min_running";
+        ASSERT_LE(allocation.min_running, allocation.id);
+        my_ids.push_back(allocation.id);
+
+        auto current = max_advertised_min.load();
+        while (current < allocation.min_running &&
+               !max_advertised_min.compare_exchange_weak(current, allocation.min_running)) {}
+
+        outstanding.push_back(std::move(allocation));
+        // Finish a random outstanding request about half the time.
+        if (!outstanding.empty() && rng() % 2 == 0) {
+          size_t idx = rng() % outstanding.size();
+          RequestIdAllocator::Finished(outstanding[idx].block);
+          outstanding[idx] = std::move(outstanding.back());
+          outstanding.pop_back();
+        }
+      }
+      for (const auto& allocation : outstanding) {
+        RequestIdAllocator::Finished(allocation.block);
+      }
+      std::lock_guard lock(all_ids_mutex);
+      for (auto id : my_ids) {
+        ASSERT_TRUE(all_ids.insert(id).second) << "Duplicate id: " << id;
+      }
+    });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  ASSERT_EQ(all_ids.size(), kThreads * kIterations);
+
+  // All requests finished; after the idle sweep the min passes everything issued.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_client_request_id_block_idle_sec) = 0;
+  SleepFor(MonoDelta::FromMilliseconds(50));
+  allocator.TEST_Sweep();
+  ASSERT_EQ(allocator.TEST_num_active_blocks(), 0);
+}
+
+} // namespace internal
+} // namespace client
+} // namespace yb

--- a/src/yb/client/request_id_allocator.cc
+++ b/src/yb/client/request_id_allocator.cc
@@ -1,0 +1,281 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/client/request_id_allocator.h"
+
+#include <atomic>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <unordered_map>
+
+#include "yb/util/flags.h"
+#include "yb/util/locks.h"
+#include "yb/util/monotime.h"
+
+DEFINE_RUNTIME_uint32(client_request_id_block_size, 256,
+    "Number of consecutive retryable request ids a client thread reserves at a time. Larger "
+    "values reduce contention on the shared request id registry, but increase how far the "
+    "min_running_request_id advertised to servers may lag behind, delaying server-side cleanup "
+    "of retryable request state.");
+
+DEFINE_RUNTIME_uint32(client_request_id_block_idle_sec, 30,
+    "Seal a thread's reserved block of retryable request ids after it has not been allocated "
+    "from for this long, so that an idle thread does not hold back min_running_request_id.");
+
+namespace yb {
+namespace client {
+namespace internal {
+
+namespace {
+
+// Entries cached per thread; above this, entries of destroyed allocators are purged.
+constexpr size_t kThreadLocalPurgeThreshold = 32;
+
+std::atomic<uint64_t> instance_id_seq{0};
+
+} // namespace
+
+// A contiguous range of ids [floor, floor + size) owned by a single allocating thread.
+// next_offset_ is bumped only by the owner thread; finished_ is bumped by whichever threads
+// complete the requests. Once sealed, no new ids are handed out; the block is retired when
+// every allocated id has finished.
+class RequestIdBlock {
+ public:
+  RequestIdBlock(
+      std::weak_ptr<RequestIdAllocatorImpl> impl, RetryableRequestId floor, uint32_t size,
+      CoarseTimePoint now)
+      : impl_(std::move(impl)), floor_(floor), size_(size),
+        last_alloc_nanos_(now.time_since_epoch().count()) {}
+
+  RetryableRequestId floor() const { return floor_; }
+
+  // Returns an allocated id, or nullopt if the block is exhausted or sealed.
+  // Must be called by the owner thread only.
+  std::optional<RetryableRequestId> TryAllocate() {
+    // The fetch_add and the sealed_ load below are both sequentially consistent, pairing with
+    // the sequentially consistent store in Seal(): for any concurrent seal, either we observe
+    // sealed_ == true here and discard the slot, or the sealer's subsequent reads observe our
+    // increment of next_offset_ and the block stays active until the matching MarkFinished().
+    auto offset = next_offset_.fetch_add(1);
+    if (offset >= size_) {
+      // Exhausted. This overshoot is not compensated; Quiescent() clamps next_offset_ to size_.
+      // Only the owner bumps next_offset_, and the owner drops the block after this, so the
+      // clamp discards at most this one overshoot.
+      Seal();
+      return std::nullopt;
+    }
+    if (sealed_.load()) {
+      // Sealed concurrently by the idle sweep. The slot at `offset` was still counted by the
+      // sealer, so return it as immediately finished.
+      MarkFinished();
+      return std::nullopt;
+    }
+    last_alloc_nanos_.store(
+        CoarseMonoClock::Now().time_since_epoch().count(), std::memory_order_relaxed);
+    return floor_ + offset;
+  }
+
+  void Seal() {
+    sealed_.store(true);
+  }
+
+  bool sealed() const {
+    return sealed_.load();
+  }
+
+  void MarkFinished() {
+    finished_.fetch_add(1);
+  }
+
+  // Whether the block can be retired: sealed, and every allocated id has finished.
+  // Every increment of next_offset_ (clamped to size_) is eventually matched by exactly one
+  // increment of finished_ - either the real completion of the request, or the discard
+  // compensation in TryAllocate - so equality means no id from this block is still running.
+  bool Quiescent() const {
+    if (!sealed_.load()) {
+      return false;
+    }
+    auto allocated = std::min<uint64_t>(next_offset_.load(), size_);
+    return finished_.load() == allocated;
+  }
+
+  CoarseTimePoint last_alloc() const {
+    return CoarseTimePoint(CoarseMonoClock::Duration(
+        last_alloc_nanos_.load(std::memory_order_relaxed)));
+  }
+
+  const std::weak_ptr<RequestIdAllocatorImpl>& impl() const { return impl_; }
+
+ private:
+  const std::weak_ptr<RequestIdAllocatorImpl> impl_;
+  const RetryableRequestId floor_;
+  const uint32_t size_;
+  std::atomic<uint64_t> next_offset_{0};
+  std::atomic<uint64_t> finished_{0};
+  std::atomic<bool> sealed_{false};
+  std::atomic<int64_t> last_alloc_nanos_;
+};
+
+class RequestIdAllocatorImpl {
+ public:
+  RequestIdBlockPtr AllocateBlock(const std::shared_ptr<RequestIdAllocatorImpl>& self) {
+    auto size = std::max<uint32_t>(1, FLAGS_client_request_id_block_size);
+    std::lock_guard lock(registry_lock_);
+    auto now = CoarseMonoClock::Now();
+    if (now >= last_sweep_ + kSweepInterval) {
+      last_sweep_ = now;
+      SweepUnlocked(now);
+    }
+    auto floor = id_seq_.fetch_add(size);
+    auto block = std::make_shared<RequestIdBlock>(self, floor, size, now);
+    active_blocks_.emplace(floor, block);
+    return block;
+  }
+
+  // Removes the block from the registry if it is quiescent, and advances the cached min.
+  void RetireIfQuiescent(RequestIdBlock* block) {
+    if (!block->Quiescent()) {
+      return;
+    }
+    std::lock_guard lock(registry_lock_);
+    auto it = active_blocks_.find(block->floor());
+    if (it == active_blocks_.end() || it->second.get() != block) {
+      return;
+    }
+    active_blocks_.erase(it);
+    RecomputeMinUnlocked();
+  }
+
+  RetryableRequestId min_running() const {
+    return cached_min_.load(std::memory_order_acquire);
+  }
+
+  size_t num_active_blocks() const {
+    std::lock_guard lock(registry_lock_);
+    return active_blocks_.size();
+  }
+
+  void Sweep() {
+    std::lock_guard lock(registry_lock_);
+    SweepUnlocked(CoarseMonoClock::Now());
+  }
+
+ private:
+  static constexpr auto kSweepInterval = std::chrono::seconds(1);
+
+  // Seals blocks that have not allocated for FLAGS_client_request_id_block_idle_sec, retires
+  // quiescent blocks, and advances the cached min.
+  void SweepUnlocked(CoarseTimePoint now) REQUIRES(registry_lock_) {
+    const auto idle_cutoff =
+        now - std::chrono::seconds(FLAGS_client_request_id_block_idle_sec);
+    for (auto it = active_blocks_.begin(); it != active_blocks_.end();) {
+      auto& block = *it->second;
+      if (!block.sealed() && block.last_alloc() < idle_cutoff) {
+        block.Seal();
+      }
+      if (block.Quiescent()) {
+        it = active_blocks_.erase(it);
+      } else {
+        ++it;
+      }
+    }
+    RecomputeMinUnlocked();
+  }
+
+  void RecomputeMinUnlocked() REQUIRES(registry_lock_) {
+    // With no active blocks there are no running requests and any future id is >= id_seq_.
+    // Otherwise no running or future id is below the smallest active floor. Both are computed
+    // under registry_lock_, which also serializes id_seq_ advancement, and the cached min only
+    // ratchets forward.
+    auto new_min = active_blocks_.empty() ? id_seq_.load() : active_blocks_.begin()->first;
+    if (new_min > cached_min_.load(std::memory_order_acquire)) {
+      cached_min_.store(new_min, std::memory_order_release);
+    }
+  }
+
+  std::atomic<RetryableRequestId> id_seq_{0};
+  std::atomic<RetryableRequestId> cached_min_{0};
+
+  mutable simple_spinlock registry_lock_;
+  // Active blocks by floor. Touched once per block lifecycle, not per request.
+  std::map<RetryableRequestId, RequestIdBlockPtr> active_blocks_ GUARDED_BY(registry_lock_);
+  CoarseTimePoint last_sweep_ GUARDED_BY(registry_lock_) = CoarseTimePoint::min();
+};
+
+namespace {
+
+// Per-thread current block, per allocator instance. Keyed by a never-reused instance id so a
+// destroyed allocator's entry cannot be confused with a new allocator at the same address.
+RequestIdBlockPtr& ThreadLocalSlot(uint64_t instance_id) {
+  thread_local std::unordered_map<uint64_t, RequestIdBlockPtr> slots;
+  if (slots.size() >= kThreadLocalPurgeThreshold) {
+    for (auto it = slots.begin(); it != slots.end();) {
+      if (it->first != instance_id && (!it->second || it->second->impl().expired())) {
+        it = slots.erase(it);
+      } else {
+        ++it;
+      }
+    }
+  }
+  return slots[instance_id];
+}
+
+} // namespace
+
+RequestIdAllocator::RequestIdAllocator()
+    : instance_id_(instance_id_seq.fetch_add(1)),
+      impl_(std::make_shared<RequestIdAllocatorImpl>()) {}
+
+RequestIdAllocator::~RequestIdAllocator() = default;
+
+RequestIdAllocation RequestIdAllocator::Next() {
+  auto& slot = ThreadLocalSlot(instance_id_);
+  for (;;) {
+    if (slot) {
+      auto id = slot->TryAllocate();
+      if (id) {
+        // min_running is loaded while our unsealed block is registered, so it cannot exceed
+        // our block's floor and therefore cannot exceed *id.
+        return RequestIdAllocation{*id, impl_->min_running(), slot};
+      }
+      impl_->RetireIfQuiescent(slot.get());
+      slot.reset();
+    }
+    slot = impl_->AllocateBlock(impl_);
+  }
+}
+
+void RequestIdAllocator::Finished(const RequestIdBlockPtr& block) {
+  block->MarkFinished();
+  auto impl = block->impl().lock();
+  if (impl) {
+    impl->RetireIfQuiescent(block.get());
+  }
+}
+
+RetryableRequestId RequestIdAllocator::TEST_min_running() const {
+  return impl_->min_running();
+}
+
+size_t RequestIdAllocator::TEST_num_active_blocks() const {
+  return impl_->num_active_blocks();
+}
+
+void RequestIdAllocator::TEST_Sweep() {
+  impl_->Sweep();
+}
+
+} // namespace internal
+} // namespace client
+} // namespace yb

--- a/src/yb/client/request_id_allocator.h
+++ b/src/yb/client/request_id_allocator.h
@@ -1,0 +1,96 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#pragma once
+
+#include <memory>
+
+#include "yb/common/retryable_request.h"
+
+namespace yb {
+namespace client {
+namespace internal {
+
+class RequestIdBlock;
+using RequestIdBlockPtr = std::shared_ptr<RequestIdBlock>;
+
+class RequestIdAllocatorImpl;
+
+// Result of allocating a retryable request id.
+struct RequestIdAllocation {
+  RetryableRequestId id;
+
+  // Safe lower bound for the ids of requests that are currently running or could still be
+  // issued by this client. Sent to the server as min_running_request_id, which the server uses
+  // to garbage-collect its retryable-request dedup state and to reject requests with smaller
+  // ids. It is always <= id, and it is monotonically non-decreasing across allocations, so it
+  // may lag the exact minimum of the running set. Lagging is safe: it only delays server-side
+  // cleanup.
+  RetryableRequestId min_running;
+
+  // Handle used to report completion of this request via RequestIdAllocator::Finished.
+  RequestIdBlockPtr block;
+};
+
+// Allocates retryable request ids for a YBClient.
+//
+// Replaces a single spinlock-guarded set of running request ids, which serialized every write
+// from every thread of the client process (profiled as the top contended lock under single-row
+// insert load on many-core hosts). Instead, each allocating thread holds a private block of
+// consecutive ids and hands them out with thread-local operations only; the shared registry
+// lock is taken once per block (FLAGS_client_request_id_block_size allocations), not once per
+// request.
+//
+// Invariants relied upon by the server (see consensus/retryable_requests.cc):
+// - Ids are unique per client.
+// - min_running advertised to the server never exceeds the id of any request that is still
+//   running or that the client may still issue. The server ratchets its per-client
+//   min_running_request_id up to the advertised value and rejects smaller request ids with
+//   an Expired error.
+// The allocator maintains the second invariant by tracking a floor per active block:
+// min_running is the minimum floor across active blocks, and a block stays active until it is
+// sealed (no further ids will be allocated from it) and all its allocated ids have finished.
+// Blocks left idle by threads that stopped allocating are sealed by a periodic sweep so they
+// do not pin min_running forever.
+class RequestIdAllocator {
+ public:
+  RequestIdAllocator();
+  ~RequestIdAllocator();
+
+  RequestIdAllocator(const RequestIdAllocator&) = delete;
+  void operator=(const RequestIdAllocator&) = delete;
+
+  // Allocates a new request id. Lock-free except once per block.
+  RequestIdAllocation Next();
+
+  // Reports that a request allocated from the given block has finished (i.e. it will never be
+  // retried with the same id). Must be called exactly once per successful Next().
+  static void Finished(const RequestIdBlockPtr& block);
+
+  // Current min-running lower bound, as would be advertised by the next allocation.
+  RetryableRequestId TEST_min_running() const;
+
+  // Number of active (not yet retired) blocks.
+  size_t TEST_num_active_blocks() const;
+
+  // Runs the idle-block sweep unconditionally, ignoring the time gate.
+  void TEST_Sweep();
+
+ private:
+  const uint64_t instance_id_;
+  const std::shared_ptr<RequestIdAllocatorImpl> impl_;
+};
+
+} // namespace internal
+} // namespace client
+} // namespace yb


### PR DESCRIPTION
## Summary

Every write RPC allocates a retryable request id at construction and retires it
at completion. Both operations took a single process-wide spinlock
(`YBClient::Data::tablet_requests_mutex_`) and mutated a `std::set` inside the
critical section. With `pg_client_use_shared_memory=true`, all PostgreSQL
backends on a node funnel their writes through the one shared pggate YBClient
inside the tserver process, so this lock was acquired twice per written row by
the entire node. Under single-row insert load on many-core hosts it shows up as
the dominant contended spinlock in the tserver process and caps per-node write
throughput while most cores stay idle.

Replace the lock with a block allocator (`RequestIdAllocator`):

- Each allocating thread reserves a block of consecutive ids
  (`client_request_id_block_size`, default 256) and hands them out with
  thread-local operations only. The shared registry spinlock is taken once per
  block lifecycle instead of twice per request.
- `min_running_request_id` is maintained at block granularity: the minimum
  floor across active blocks (or the sequence head when none are active),
  ratcheting forward only. It may lag the exact minimum of running requests,
  which merely delays server-side cleanup of retryable-request state; it never
  exceeds a running or still-issuable id, which is the invariant servers rely
  on when rejecting stale ids as Expired.
- A block is retired once it is sealed and every allocated id has finished. An
  idle sweep (`client_request_id_block_idle_sec`, default 30) seals blocks
  abandoned by idle threads so they cannot pin `min_running_request_id`
  forever. The seal-vs-allocate race is resolved with a sequentially consistent
  protocol plus discard compensation.
- Ids stay consecutive within a block, so the server-side dedup intervals
  (merged by adjacency in `retryable_requests.cc`) do not fragment.
- The Batcher's `RequestDetails` carries a handle to the id's block, so request
  completion is a counter bump instead of a global-lock `std::set` erase.

## Test plan

- [x] New unit test `request_id_allocator-test`, covering id uniqueness and min
      monotonicity, block-exhaustion retirement, idle-block sealing,
      sealed-block-with-running-request tracking, and a 16-thread hammer
      asserting no id is ever issued below a previously advertised
      `min_running_request_id`:

      ./yb_build.sh --cxx-test request_id_allocator-test

- [x] Sanity of the retryable-request machinery end to end:

      ./yb_build.sh --cxx-test ql-stress-test --gtest_filter QLStressTest.RetryWrites
      ./yb_build.sh --cxx-test ql-stress-test --gtest_filter QLStressTest.RetryWritesWithRestarts
      ./yb_build.sh --cxx-test retryable_request-test
