### PR TITLE
[#33253] Build: Report an unrelated --rev base instead of crashing

### DIFF
--- a/build-support/lint.py
+++ b/build-support/lint.py
@@ -179,6 +179,14 @@ def _changed_files(base: str | None = None) -> list[str]:
                          f"pointing at {_CANONICAL_REPO_HINT}; pass --rev <base> explicitly")
     resolved = _git("rev-parse", "--symbolic-full-name", base)
     print(f"[lint] comparing against {base} ({resolved})", file=sys.stderr)
+    # base...HEAD needs a merge base, and git refuses the whole diff when the two share no
+    # common ancestor -- an unrelated history, such as a vendored-upstream remote. Report
+    # that rather than letting the diff fail as an uncaught CalledProcessError.
+    try:
+        _git("merge-base", base, "HEAD")
+    except subprocess.CalledProcessError:
+        sys.exit(f"[lint] {base!r} has no common ancestor with HEAD -- unrelated histories. "
+                 "Pass --rev a ref on this branch's history.")
     committed = set(_git("diff", "--name-only", "--diff-filter=d", f"{base}...HEAD").splitlines())
     uncommitted = set(_git("diff", "--name-only", "--diff-filter=d", "HEAD").splitlines())
     untracked = set(_git("ls-files", "--others", "--exclude-standard").splitlines())


### PR DESCRIPTION
## Summary

`_changed_files()` validates the base ref with `rev-parse --verify`, then diffs
`base...HEAD`. The three-dot form requires a merge base and git refuses the whole diff when
there is none, so a ref that *exists* but shares no history with `HEAD` passes validation
and then dies as an uncaught traceback.

This repo already has such a remote — `pg`, tracking upstream PostgreSQL, which shares no
ancestry with the YugabyteDB history:

```
$ ./build-support/lint.py --rev pg/master
[lint] comparing against pg/master (refs/remotes/pg/master)
...
subprocess.CalledProcessError: Command '['git', 'diff', '--name-only',
  '--diff-filter=d', 'pg/master...HEAD']' returned non-zero exit status 128
```

Check for a merge base first, and exit with a message naming the problem — in the shape of
the neighboring bad-ref case, which already exits cleanly with
`[lint] --rev: unknown git ref 'no/such/ref'`:

```
$ ./build-support/lint.py --rev pg/master
[lint] 'pg/master' has no common ancestor with HEAD -- unrelated histories.
Pass --rev a ref on this branch's history.
```

### Why not match `src/lint/common.sh`

`set_merge_base()` handles the same condition for the shell rules by degrading to `HEAD`:

```bash
merge_base=$(git merge-base HEAD "${upstream}" || git rev-parse HEAD)
```

That leaves `merge_base` at `HEAD`, so the rules inspect an empty commit range and quietly
lint no committed changes. Copying it here would trade a loud crash for silent
under-checking. An unrelated base is a mistake worth reporting, not one worth quietly
checking less around, so this diverges on purpose.

### Scope

Reaching this requires deliberately naming an unrelated ref, so real-world impact is low.
It is worth closing because it is the same shape as #33249: a ref that passes validation
and then blows up further down.

Note for whoever lands second — this touches the same three lines of `_changed_files()`
that #33250 rewrites, so one of the two will need a trivial rebase. They are independent
fixes and neither depends on the other.

Fixes #33253.

## Test plan

- [x] **The bug** — `./build-support/lint.sh --rev pg/master` (a real remote in this repo
      with unrelated history): now prints
      `[lint] 'pg/master' has no common ancestor with HEAD -- unrelated histories.` and
      exits 1. Previously ended in an uncaught `CalledProcessError` traceback.
- [x] `--rev origin/master`: unchanged, diffs against it, exits 0.
- [x] `--rev no/such/ref`: unchanged, still exits with
      `[lint] --rev: unknown git ref 'no/such/ref'`.
- [x] `--rev origin/2024.2` — a legitimate base far from `HEAD`: still resolves a merge base
      and proceeds, confirming the new check keys on unrelated history rather than distance.
- [x] `build-support/lint.sh --rev origin/master` clean on this branch.
