### PR TITLE
[yugabyted] FIx TypeError due to missing pid parameter

### DIFF
--- a/bin/yugabyted
+++ b/bin/yugabyted
@@ -3764,11 +3764,11 @@ class ControlScript(object):
         self.set_signals(SIG_DFL)
 
         try:
-            for p in self.processes.values():
-                p.kill()
-
-            for p in self.processes.values():
-                p.wait_until_stop()
+            for name, p in self.processes.copy().items():
+                err, pid = p.kill()
+                if err:
+                    Output.log("There was an error trying to kill process of {} (PID: {}): {}".format(name, pid, err), logging.ERROR)
+                p.wait_until_stop(pid)
 
             self.script.delete_pidfile()
 


### PR DESCRIPTION
Currently yugabyted would error in a docker container whenever it would be shutdown, the process wouldn't die in time and when waiting for it you were missing the pid parameter so it instead crashed the script and the container would immediately shut down, not allowing tserver to have a graceful shutdown leading to database corruption repeatedly.

Having separate loops would mean that we first killed all processes and then waiting for them but the problem there was that inside ProcessManager.kill() we deleted the pid files and we wouldnt be able to access the pid in the second loop for waiting. Joining them in one loop ensures that processes are kileld gracefully and properly waited for shutdown.

Error for context:
```py
Shutting down...

    args.func()

  File "/usr/local/bin/yugabyted", line 780, in start

    self.start_processes()

  File "/usr/local/bin/yugabyted", line 4179, in start_processes

    time.sleep(int(self.configs.saved_data.get("polling_interval")))

  File "/usr/local/bin/yugabyted", line 3771, in kill_children

    p.wait_until_stop()

TypeError: ProcessManager.wait_until_stop() missing 1 required positional argument: 'pid'


During handling of the above exception, another exception occurred:


Traceback (most recent call last):

  File "/usr/local/bin/yugabyted", line 12731, in <module>

    ControlScript().run()

  File "/usr/local/bin/yugabyted", line 10461, in run

    Output.log_error_and_exit(traceback.format_exc())

  File "/usr/local/bin/yugabyted", line 12372, in log_error_and_exit

    Output.script_exit_func()

  File "/usr/local/bin/yugabyted", line 3771, in kill_children

    p.wait_until_stop()

TypeError: ProcessManager.wait_until_stop() missing 1 required positional argument: 'pid'

Exception ignored in atexit callback: <bound method ControlScript.kill_children of <__main__.ControlScript object at 0x7ff400f0cf50>>

Traceback (most recent call last):

  File "/usr/local/bin/yugabyted", line 3771, in kill_children

    p.wait_until_stop()

TypeError: ProcessManager.wait_until_stop() missing 1 required positional argument: 'pid'
```