### PR TITLE
[BACKPORT 2026.1][#31589] DocDB: Serve YSQL lease RPCs on the master high-priority thread pool

### DIFF
--- a/src/yb/integration-tests/object_lock-test.cc
+++ b/src/yb/integration-tests/object_lock-test.cc
@@ -31,7 +31,7 @@
 #include "yb/master/master.h"
 #include "yb/master/master_cluster_client.h"
 #include "yb/master/master_ddl.proxy.h"
-#include "yb/master/master_ddl_client.h"
+#include "yb/master/master_ysql_lease_client.h"
 #include "yb/master/mini_master.h"
 #include "yb/master/object_lock_info_manager.h"
 #include "yb/master/test_async_rpc_manager.h"
@@ -1343,13 +1343,14 @@ TEST_F(ExternalObjectLockTest, RefreshYsqlLease) {
       &master_proxy, tablet_server(1)->uuid(), kTxn1, kDatabaseID, kRelationId, kLeaseEpoch,
       nullptr, std::nullopt, kTimeout));
 
-  master::MasterDDLClient ddl_client{cluster_->GetLeaderMasterProxy<master::MasterDdlProxy>()};
+  master::MasterYsqlLeaseClient lease_client{
+      cluster_->GetLeaderMasterProxy<master::MasterYsqlLeaseProxy>()};
 
   auto lease_refresh_time_ms = MonoTime::Now().GetDeltaSinceMin().ToMilliseconds();
 
   // Request a lease refresh on behalf of ts with the correct lease epoch in the request.
   // Expect the master to omit most information and set new_lease to false.
-  auto info = ASSERT_RESULT(ddl_client.RefreshYsqlLease(
+  auto info = ASSERT_RESULT(lease_client.RefreshYsqlLease(
       ts->uuid(), ts->instance_id().instance_seqno(), lease_refresh_time_ms, kLeaseEpoch));
   ASSERT_FALSE(info.new_lease());
   ASSERT_FALSE(info.has_ddl_lock_entries());
@@ -1357,7 +1358,7 @@ TEST_F(ExternalObjectLockTest, RefreshYsqlLease) {
   // Request a lease refresh on behalf of ts with no lease epoch in the request.
   // Master should give us a new lease epoch, the acquired lock entries, and
   // new_lease.
-  info = ASSERT_RESULT(ddl_client.RefreshYsqlLease(
+  info = ASSERT_RESULT(lease_client.RefreshYsqlLease(
       ts->uuid(), ts->instance_id().instance_seqno(),
       lease_refresh_time_ms, {}));
   ASSERT_TRUE(info.new_lease());
@@ -1367,7 +1368,7 @@ TEST_F(ExternalObjectLockTest, RefreshYsqlLease) {
 
   // Request a lease refresh on behalf of ts with the incorrect lease epoch in the request.
   // Master should give us a new lease epoch, the acquired lock entries, and set new_lease.
-  info = ASSERT_RESULT(ddl_client.RefreshYsqlLease(
+  info = ASSERT_RESULT(lease_client.RefreshYsqlLease(
       ts->uuid(), ts->instance_id().instance_seqno(), lease_refresh_time_ms, 0));
   ASSERT_TRUE(info.new_lease());
   ASSERT_EQ(info.lease_epoch(), kLeaseEpoch + 2);
@@ -1726,8 +1727,9 @@ TEST_P(ExternalObjectLockTestLeaseLost, TSRejectsLockRequestsAfterLeaseExpiry) {
   ASSERT_OK(DisableLease(ts_to_lose_lease));
   ASSERT_OK(WaitForTServerLeaseToExpire(
       ts_to_lose_lease->uuid(), MonoDelta::FromMilliseconds(ysql_lease_ttl_ms() * 3)));
-  master::MasterDDLClient ddl_client{cluster_->GetLeaderMasterProxy<master::MasterDdlProxy>()};
-  auto lease_refresh_info = ASSERT_RESULT(ddl_client.RefreshYsqlLease(
+  master::MasterYsqlLeaseClient lease_client{
+      cluster_->GetLeaderMasterProxy<master::MasterYsqlLeaseProxy>()};
+  auto lease_refresh_info = ASSERT_RESULT(lease_client.RefreshYsqlLease(
       ts_to_lose_lease->uuid(), ts_to_lose_lease->instance_id().instance_seqno(),
       MonoTime::Now().GetDeltaSinceMin().ToMilliseconds(), std::nullopt));
   auto master_proxy = cluster_->GetLeaderMasterProxy<master::MasterDdlProxy>();

--- a/src/yb/master/CMakeLists.txt
+++ b/src/yb/master/CMakeLists.txt
@@ -39,7 +39,7 @@ YRPC_GENERATE(
   PROTO_FILES
       master_admin.proto master_client.proto master_cluster.proto master_dcl.proto
       master_encryption.proto master_heartbeat.proto master_replication.proto
-      master_backup.proto master_test.proto
+      master_backup.proto master_test.proto master_ysql_lease.proto
   MESSAGES_PROTO_FILES
       master_ddl.proto
   NO_SERVICE_MESSAGES_PROTO_FILES
@@ -113,6 +113,7 @@ set(MASTER_SRCS
   master_test_service.cc
   master_tserver.cc
   master_types.cc
+  master_ysql_lease_service.cc
   mini_master.cc
   multi_step_monitored_task.cc
   object_lock_info_manager.cc
@@ -243,6 +244,7 @@ set(MASTER_TEST_COMMON_SRCS
   master-test_base.cc
   master_cluster_client.cc
   master_ddl_client.cc
+  master_ysql_lease_client.cc
   ts_descriptor_test_util.cc)
 add_library(master_test_common ${MASTER_TEST_COMMON_SRCS})
 target_link_libraries(master_test_common

--- a/src/yb/master/catalog_entity_info.cc
+++ b/src/yb/master/catalog_entity_info.cc
@@ -52,6 +52,7 @@
 #include "yb/master/master_client.pb.h"
 #include "yb/master/master_defaults.h"
 #include "yb/master/master_error.h"
+#include "yb/master/master_ysql_lease.pb.h"
 #include "yb/master/ts_descriptor.h"
 #include "yb/master/xcluster/master_xcluster_util.h"
 #include "yb/master/xcluster_rpc_tasks.h"

--- a/src/yb/master/catalog_entity_info.h
+++ b/src/yb/master/catalog_entity_info.h
@@ -51,6 +51,7 @@
 #include "yb/master/master_client.fwd.h"
 #include "yb/master/master_ddl.pb.h"
 #include "yb/master/master_fwd.h"
+#include "yb/master/master_ysql_lease.fwd.h"
 #include "yb/master/sys_catalog_types.h"
 #include "yb/master/tasks_tracker.h"
 

--- a/src/yb/master/master-test.cc
+++ b/src/yb/master/master-test.cc
@@ -57,7 +57,7 @@
 #include "yb/master/master_cluster.proxy.h"
 #include "yb/master/master_cluster_client.h"
 #include "yb/master/master_ddl.proxy.h"
-#include "yb/master/master_ddl_client.h"
+#include "yb/master/master_ysql_lease_client.h"
 #include "yb/master/master_error.h"
 #include "yb/master/master_heartbeat.proxy.h"
 #include "yb/master/mini_master.h"
@@ -2770,8 +2770,8 @@ TEST_F(MasterTest, RefreshYsqlLeaseWithoutRegistration) {
   ANNOTATE_UNPROTECTED_WRITE(FLAGS_enable_ysql_operation_lease) = true;
 
   const char* kTsUUID = "my-ts-uuid";
-  auto ddl_client = MasterDDLClient{std::move(*proxy_ddl_)};
-  auto result = ddl_client.RefreshYsqlLease(
+  auto lease_client = MasterYsqlLeaseClient{std::move(*proxy_ysql_lease_)};
+  auto result = lease_client.RefreshYsqlLease(
       kTsUUID, 1, MonoTime::Now().GetDeltaSinceMin().ToMilliseconds(), {});
   ASSERT_NOK(result);
   ASSERT_TRUE(result.status().IsNotFound());
@@ -2785,10 +2785,10 @@ TEST_F(MasterTest, RefreshYsqlLease) {
   auto reg_resp1 = ASSERT_RESULT(SendNewTSRegistrationHeartbeat(kTsUUID, kSeqno));
   ASSERT_FALSE(reg_resp1.needs_reregister());
 
-  auto ddl_client = MasterDDLClient{std::move(*proxy_ddl_)};
+  auto lease_client = MasterYsqlLeaseClient{std::move(*proxy_ysql_lease_)};
   auto lease_refresh_send_time_ms = MonoTime::Now().GetDeltaSinceMin().ToMilliseconds();
   auto info =
-      ASSERT_RESULT(ddl_client.RefreshYsqlLease(kTsUUID, kSeqno, lease_refresh_send_time_ms, {}));
+      ASSERT_RESULT(lease_client.RefreshYsqlLease(kTsUUID, kSeqno, lease_refresh_send_time_ms, {}));
   ASSERT_TRUE(info.new_lease());
   ASSERT_EQ(info.lease_epoch(), 1);
   ASSERT_GT(
@@ -2799,20 +2799,22 @@ TEST_F(MasterTest, RefreshYsqlLease) {
   // Refresh lease again. Since we omitted current lease epoch, master leader should still say this
   // is a new lease.
   info =
-      ASSERT_RESULT(ddl_client.RefreshYsqlLease(kTsUUID, kSeqno, lease_refresh_send_time_ms, {}));
+      ASSERT_RESULT(lease_client.RefreshYsqlLease(kTsUUID, kSeqno, lease_refresh_send_time_ms, {}));
   ASSERT_TRUE(info.new_lease());
   ASSERT_EQ(info.lease_epoch(), 2);
   ASSERT_GT(info.lease_expiry_time_ms(), lease_refresh_send_time_ms);
 
   // Refresh lease again. We included current lease epoch but it's incorrect.
-  info = ASSERT_RESULT(ddl_client.RefreshYsqlLease(kTsUUID, kSeqno, lease_refresh_send_time_ms, 0));
+  info = ASSERT_RESULT(
+      lease_client.RefreshYsqlLease(kTsUUID, kSeqno, lease_refresh_send_time_ms, 0));
   ASSERT_TRUE(info.new_lease());
   ASSERT_EQ(info.lease_epoch(), 3);
   ASSERT_GT(info.lease_expiry_time_ms(), lease_refresh_send_time_ms);
 
   // Refresh lease again. Current lease epoch is correct so master leader should not set new lease
   // bit.
-  info = ASSERT_RESULT(ddl_client.RefreshYsqlLease(kTsUUID, kSeqno, lease_refresh_send_time_ms, 3));
+  info = ASSERT_RESULT(
+      lease_client.RefreshYsqlLease(kTsUUID, kSeqno, lease_refresh_send_time_ms, 3));
   ASSERT_FALSE(info.new_lease());
   ASSERT_GT(info.lease_expiry_time_ms(), lease_refresh_send_time_ms);
 }
@@ -2824,13 +2826,13 @@ TEST_F(MasterTest, RelinquishLease) {
   auto reg_resp1 = ASSERT_RESULT(SendNewTSRegistrationHeartbeat(kTsUUID, kSeqno1));
   ASSERT_FALSE(reg_resp1.needs_reregister());
 
-  auto ddl_client = MasterDDLClient{std::move(*proxy_ddl_)};
-  auto info1 = ASSERT_RESULT(ddl_client.RefreshYsqlLease(
+  auto lease_client = MasterYsqlLeaseClient{std::move(*proxy_ysql_lease_)};
+  auto info1 = ASSERT_RESULT(lease_client.RefreshYsqlLease(
       kTsUUID, kSeqno1, MonoTime::Now().GetDeltaSinceMin().ToMilliseconds(), {}));
   ASSERT_TRUE(info1.new_lease());
   ASSERT_EQ(info1.lease_epoch(), 1);
 
-  ASSERT_OK(ddl_client.RelinquishYsqlLease(kTsUUID, kSeqno1));
+  ASSERT_OK(lease_client.RelinquishYsqlLease(kTsUUID, kSeqno1));
   auto list_ts = ASSERT_RESULT(cluster_client_->ListTabletServers());
   ASSERT_EQ(list_ts.servers_size(), 1);
   ASSERT_FALSE(list_ts.servers(0).lease_info().is_live());
@@ -2839,7 +2841,7 @@ TEST_F(MasterTest, RelinquishLease) {
   constexpr uint64_t kSeqno2 = 2;
   auto reg_resp2 = ASSERT_RESULT(SendNewTSRegistrationHeartbeat(kTsUUID, kSeqno2));
   ASSERT_FALSE(reg_resp2.needs_reregister());
-  auto info2 = ASSERT_RESULT(ddl_client.RefreshYsqlLease(
+  auto info2 = ASSERT_RESULT(lease_client.RefreshYsqlLease(
       kTsUUID, kSeqno2, MonoTime::Now().GetDeltaSinceMin().ToMilliseconds(), {}));
   ASSERT_TRUE(info2.new_lease());
   ASSERT_EQ(info2.lease_epoch(), 2);
@@ -2852,8 +2854,8 @@ TEST_F(MasterTest, RelinquishLeaseOfReplacedTS) {
   auto reg_resp1 = ASSERT_RESULT(SendNewTSRegistrationHeartbeat(kTsUUID, kSeqno1));
   ASSERT_FALSE(reg_resp1.needs_reregister());
 
-  auto ddl_client = MasterDDLClient{std::move(*proxy_ddl_)};
-  auto info1 = ASSERT_RESULT(ddl_client.RefreshYsqlLease(
+  auto lease_client = MasterYsqlLeaseClient{std::move(*proxy_ysql_lease_)};
+  auto info1 = ASSERT_RESULT(lease_client.RefreshYsqlLease(
       kTsUUID, kSeqno1, MonoTime::Now().GetDeltaSinceMin().ToMilliseconds(), {}));
   ASSERT_TRUE(info1.new_lease());
   ASSERT_EQ(info1.lease_epoch(), 1);
@@ -2862,13 +2864,13 @@ TEST_F(MasterTest, RelinquishLeaseOfReplacedTS) {
   constexpr uint64_t kSeqno2 = 2;
   auto reg_resp2 = ASSERT_RESULT(SendNewTSRegistrationHeartbeat(kTsUUID, kSeqno2));
   ASSERT_FALSE(reg_resp2.needs_reregister());
-  auto info2 = ASSERT_RESULT(ddl_client.RefreshYsqlLease(
+  auto info2 = ASSERT_RESULT(lease_client.RefreshYsqlLease(
       kTsUUID, kSeqno2, MonoTime::Now().GetDeltaSinceMin().ToMilliseconds(), {}));
   ASSERT_TRUE(info2.new_lease());
   ASSERT_EQ(info2.lease_epoch(), 2);
 
   // Send relinquish lease request from the first ts instance.
-  auto status = ddl_client.RelinquishYsqlLease(kTsUUID, kSeqno1);
+  auto status = lease_client.RelinquishYsqlLease(kTsUUID, kSeqno1);
   ASSERT_NOK(status);
   ASSERT_STR_CONTAINS(
       status.ToString(), "Relinquish lease request for a replaced tserver instance");

--- a/src/yb/master/master-test_base.cc
+++ b/src/yb/master/master-test_base.cc
@@ -47,6 +47,7 @@
 #include "yb/master/master_ddl.proxy.h"
 #include "yb/master/master_heartbeat.proxy.h"
 #include "yb/master/master_replication.proxy.h"
+#include "yb/master/master_ysql_lease.proxy.h"
 #include "yb/master/mini_master.h"
 #include "yb/master/ts_descriptor.h"
 
@@ -100,6 +101,8 @@ void MasterTestBase::SetUp() {
   proxy_client_ = std::make_unique<MasterClientProxy>(
       &proxy_cache, mini_master_->bound_rpc_addr());
   proxy_ddl_ = std::make_unique<MasterDdlProxy>(
+      &proxy_cache, mini_master_->bound_rpc_addr());
+  proxy_ysql_lease_ = std::make_unique<MasterYsqlLeaseProxy>(
       &proxy_cache, mini_master_->bound_rpc_addr());
   proxy_heartbeat_ = std::make_unique<MasterHeartbeatProxy>(
       &proxy_cache, mini_master_->bound_rpc_addr());

--- a/src/yb/master/master-test_base.h
+++ b/src/yb/master/master-test_base.h
@@ -247,6 +247,7 @@ class MasterTestBase : public YBTest {
   std::unique_ptr<MiniMaster> mini_master_;
   std::unique_ptr<MasterClientProxy> proxy_client_;
   std::unique_ptr<MasterDdlProxy> proxy_ddl_;
+  std::unique_ptr<MasterYsqlLeaseProxy> proxy_ysql_lease_;
   std::unique_ptr<MasterHeartbeatProxy> proxy_heartbeat_;
   std::unique_ptr<MasterReplicationProxy> proxy_replication_;
   std::shared_ptr<RpcController> controller_;

--- a/src/yb/master/master.cc
+++ b/src/yb/master/master.cc
@@ -135,6 +135,10 @@ DEFINE_UNKNOWN_int32(master_svc_queue_length, 1000,
              "RPC queue length for master service");
 TAG_FLAG(master_svc_queue_length, advanced);
 
+DEFINE_NON_RUNTIME_int32(master_ysql_lease_svc_queue_length, 1000,
+             "RPC queue length for master YSQL lease service");
+TAG_FLAG(master_ysql_lease_svc_queue_length, advanced);
+
 DEFINE_UNKNOWN_int32(master_consensus_svc_queue_length, 1000,
              "RPC queue length for master consensus service");
 TAG_FLAG(master_consensus_svc_queue_length, advanced);
@@ -307,6 +311,9 @@ Status Master::RegisterServices() {
   RETURN_NOT_OK(RegisterService(FLAGS_master_svc_queue_length, MakeMasterClusterService(this)));
   RETURN_NOT_OK(RegisterService(FLAGS_master_svc_queue_length, MakeMasterDclService(this)));
   RETURN_NOT_OK(RegisterService(FLAGS_master_svc_queue_length, MakeMasterDdlService(this)));
+  RETURN_NOT_OK(RegisterService(
+      FLAGS_master_ysql_lease_svc_queue_length, MakeMasterYsqlLeaseService(this),
+      rpc::ServicePriority::kHigh));
   RETURN_NOT_OK(RegisterService(FLAGS_master_svc_queue_length, MakeMasterEncryptionService(this)));
   RETURN_NOT_OK(RegisterService(FLAGS_master_svc_queue_length, MakeMasterHeartbeatService(this)));
   RETURN_NOT_OK(RegisterService(FLAGS_master_svc_queue_length, MakeMasterReplicationService(this)));

--- a/src/yb/master/master_ddl.proto
+++ b/src/yb/master/master_ddl.proto
@@ -878,38 +878,6 @@ message GetObjectLockStatusResponsePB {
   repeated ObjectLockInfoPB object_lock_infos = 2;
 }
 
-message RefreshYsqlLeaseRequestPB {
-  optional NodeInstancePB instance = 1;
-  // The current lease epoch of the tserver making this request.
-  // Unset if the tserver doesn't think it has a live lease.
-  optional uint64 current_lease_epoch = 2;
-  optional uint64 local_request_send_time_ms = 3;
-}
-
-message RefreshYsqlLeaseInfoPB {
-  optional bool new_lease = 1;
-  optional uint64 lease_epoch = 2;
-  // TODO: If this ends up being too big, consider adding a way to break this up
-  // into multiple messages.
-  optional tserver.DdlLockEntriesPB ddl_lock_entries = 3;
-  optional uint64 lease_expiry_time_ms = 4;
-}
-
-message RefreshYsqlLeaseResponsePB {
-  oneof refresh_ysql_lease_payload {
-    MasterErrorPB error = 1;
-    RefreshYsqlLeaseInfoPB info = 2;
-  }
-}
-
-message RelinquishYsqlLeaseRequestPB {
-  optional NodeInstancePB instance = 1;
-}
-
-message RelinquishYsqlLeaseResponsePB {
-  optional MasterErrorPB error = 1;
-}
-
 service MasterDdl {
   option (yb.rpc.custom_service_name) = "yb.master.MasterService";
 
@@ -980,10 +948,6 @@ service MasterDdl {
       returns (ReleaseObjectLocksGlobalResponsePB) {
     option (yb.rpc.send_metadata) = true;
   }
-  rpc RefreshYsqlLease(RefreshYsqlLeaseRequestPB)
-      returns (RefreshYsqlLeaseResponsePB);
-  rpc RelinquishYsqlLease(RelinquishYsqlLeaseRequestPB)
-      returns (RelinquishYsqlLeaseResponsePB);
   rpc GetObjectLockStatus(GetObjectLockStatusRequestPB)
       returns (GetObjectLockStatusResponsePB);
 }

--- a/src/yb/master/master_ddl_client.cc
+++ b/src/yb/master/master_ddl_client.cc
@@ -76,34 +76,6 @@ Result<NamespaceId> MasterDDLClient::CreateNamespaceAndWait(
   return id;
 }
 
-Result<RefreshYsqlLeaseInfoPB> MasterDDLClient::RefreshYsqlLease(
-    const std::string& permanent_uuid, int64_t instance_seqno, uint64_t time_ms,
-    std::optional<uint64_t> current_lease_epoch) {
-  RefreshYsqlLeaseRequestPB req;
-  req.mutable_instance()->set_permanent_uuid(permanent_uuid);
-  req.mutable_instance()->set_instance_seqno(instance_seqno);
-  req.set_local_request_send_time_ms(time_ms);
-  if (current_lease_epoch) {
-    req.set_current_lease_epoch(*current_lease_epoch);
-  }
-  RefreshYsqlLeaseResponsePB resp;
-  rpc::RpcController rpc;
-  RETURN_NOT_OK(proxy_.RefreshYsqlLease(req, &resp, &rpc));
-  RETURN_NOT_OK(ResponseStatus(resp));
-  return resp.info();
-}
-
-Status MasterDDLClient::RelinquishYsqlLease(
-    const std::string& permanent_uuid, int64_t instance_seqno) {
-  RelinquishYsqlLeaseRequestPB req;
-  req.mutable_instance()->set_permanent_uuid(permanent_uuid);
-  req.mutable_instance()->set_instance_seqno(instance_seqno);
-  RelinquishYsqlLeaseResponsePB resp;
-  rpc::RpcController rpc;
-  RETURN_NOT_OK(proxy_.RelinquishYsqlLease(req, &resp, &rpc));
-  return ResponseStatus(resp);
-}
-
 Status MasterDDLClient::DeleteTable(const TableId& id, MonoDelta timeout) {
   DeleteTableRequestPB req;
   req.mutable_table()->set_table_id(id);

--- a/src/yb/master/master_ddl_client.h
+++ b/src/yb/master/master_ddl_client.h
@@ -36,12 +36,6 @@ class MasterDDLClient {
   Result<NamespaceId> CreateNamespaceAndWait(
       const NamespaceName& namespace_name, YQLDatabase namespace_type, MonoDelta timeout);
 
-  Result<RefreshYsqlLeaseInfoPB> RefreshYsqlLease(
-      const std::string& permanent_uuid, int64_t instance_seqno, uint64_t time_ms,
-      std::optional<uint64_t> current_lease_epoch);
-
-  Status RelinquishYsqlLease(const std::string& permanent_uuid, int64_t instance_seqno);
-
   Status DeleteTable(const TableId& id, MonoDelta timeout);
 
   Result<ListTablesResponsePB> ListTables();

--- a/src/yb/master/master_ddl_service.cc
+++ b/src/yb/master/master_ddl_service.cc
@@ -61,8 +61,6 @@ class MasterDdlServiceImpl : public MasterServiceBase, public MasterDdlIf {
     (ListUDTypes)
     (ReportYsqlDdlTxnStatus)
     (TruncateTable)
-    (RefreshYsqlLease)
-    (RelinquishYsqlLease)
     (RollbackDocdbSchemaToSubtxn)
     (IsRollbackDocdbSchemaToSubtxnDone)
   )

--- a/src/yb/master/master_fwd.h
+++ b/src/yb/master/master_fwd.h
@@ -73,6 +73,7 @@ class MasterHeartbeatProxy;
 class MasterReplicationProxy;
 class MasterSnapshotCoordinator;
 class MasterTestProxy;
+class MasterYsqlLeaseProxy;
 class NamespaceInfo;
 class ObjectLockInfoManager;
 class PermissionsManager;

--- a/src/yb/master/master_service.h
+++ b/src/yb/master/master_service.h
@@ -48,6 +48,7 @@ std::unique_ptr<rpc::ServiceIf> MakeMasterEncryptionService(Master* master);
 std::unique_ptr<rpc::ServiceIf> MakeMasterHeartbeatService(Master* master);
 std::unique_ptr<rpc::ServiceIf> MakeMasterReplicationService(Master* master);
 std::unique_ptr<rpc::ServiceIf> MakeMasterTestService(Master* master);
+std::unique_ptr<rpc::ServiceIf> MakeMasterYsqlLeaseService(Master* master);
 
 } // namespace master
 } // namespace yb

--- a/src/yb/master/master_ysql_lease.proto
+++ b/src/yb/master/master_ysql_lease.proto
@@ -1,0 +1,63 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+
+syntax = "proto2";
+
+package yb.master;
+
+option java_package = "org.yb.master";
+
+import "yb/common/wire_protocol.proto";
+import "yb/master/master_types.proto";
+import "yb/rpc/service.proto";
+import "yb/tserver/tserver.proto";
+
+message RefreshYsqlLeaseRequestPB {
+  optional NodeInstancePB instance = 1;
+  // The current lease epoch of the tserver making this request.
+  // Unset if the tserver doesn't think it has a live lease.
+  optional uint64 current_lease_epoch = 2;
+  optional uint64 local_request_send_time_ms = 3;
+}
+
+message RefreshYsqlLeaseInfoPB {
+  optional bool new_lease = 1;
+  optional uint64 lease_epoch = 2;
+  // TODO: If this ends up being too big, consider adding a way to break this up
+  // into multiple messages.
+  optional tserver.DdlLockEntriesPB ddl_lock_entries = 3;
+  optional uint64 lease_expiry_time_ms = 4;
+}
+
+message RefreshYsqlLeaseResponsePB {
+  oneof refresh_ysql_lease_payload {
+    MasterErrorPB error = 1;
+    RefreshYsqlLeaseInfoPB info = 2;
+  }
+}
+
+message RelinquishYsqlLeaseRequestPB {
+  optional NodeInstancePB instance = 1;
+}
+
+message RelinquishYsqlLeaseResponsePB {
+  optional MasterErrorPB error = 1;
+}
+
+service MasterYsqlLease {
+  option (yb.rpc.custom_service_name) = "yb.master.MasterService";
+
+  rpc RefreshYsqlLease(RefreshYsqlLeaseRequestPB)
+      returns (RefreshYsqlLeaseResponsePB);
+  rpc RelinquishYsqlLease(RelinquishYsqlLeaseRequestPB)
+      returns (RelinquishYsqlLeaseResponsePB);
+}

--- a/src/yb/master/master_ysql_lease_client.cc
+++ b/src/yb/master/master_ysql_lease_client.cc
@@ -1,0 +1,51 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/master/master_ysql_lease_client.h"
+
+#include "yb/common/wire_protocol.h"
+
+namespace yb::master {
+
+MasterYsqlLeaseClient::MasterYsqlLeaseClient(MasterYsqlLeaseProxy&& proxy) noexcept
+    : proxy_(std::move(proxy)) {}
+
+Result<RefreshYsqlLeaseInfoPB> MasterYsqlLeaseClient::RefreshYsqlLease(
+    const std::string& permanent_uuid, int64_t instance_seqno, uint64_t time_ms,
+    std::optional<uint64_t> current_lease_epoch) {
+  RefreshYsqlLeaseRequestPB req;
+  req.mutable_instance()->set_permanent_uuid(permanent_uuid);
+  req.mutable_instance()->set_instance_seqno(instance_seqno);
+  req.set_local_request_send_time_ms(time_ms);
+  if (current_lease_epoch) {
+    req.set_current_lease_epoch(*current_lease_epoch);
+  }
+  RefreshYsqlLeaseResponsePB resp;
+  rpc::RpcController rpc;
+  RETURN_NOT_OK(proxy_.RefreshYsqlLease(req, &resp, &rpc));
+  RETURN_NOT_OK(ResponseStatus(resp));
+  return resp.info();
+}
+
+Status MasterYsqlLeaseClient::RelinquishYsqlLease(
+    const std::string& permanent_uuid, int64_t instance_seqno) {
+  RelinquishYsqlLeaseRequestPB req;
+  req.mutable_instance()->set_permanent_uuid(permanent_uuid);
+  req.mutable_instance()->set_instance_seqno(instance_seqno);
+  RelinquishYsqlLeaseResponsePB resp;
+  rpc::RpcController rpc;
+  RETURN_NOT_OK(proxy_.RelinquishYsqlLease(req, &resp, &rpc));
+  return ResponseStatus(resp);
+}
+
+}  // namespace yb::master

--- a/src/yb/master/master_ysql_lease_client.h
+++ b/src/yb/master/master_ysql_lease_client.h
@@ -1,0 +1,36 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#pragma once
+
+#include "yb/master/master_ysql_lease.proxy.h"
+
+namespace yb::master {
+
+// Wrapper class around RPCs to the MasterYsqlLease service. All RPC wrapper methods check the error
+// field in response objects. For now only used in tests.
+class MasterYsqlLeaseClient {
+ public:
+  explicit MasterYsqlLeaseClient(MasterYsqlLeaseProxy&& proxy) noexcept;
+
+  Result<RefreshYsqlLeaseInfoPB> RefreshYsqlLease(
+      const std::string& permanent_uuid, int64_t instance_seqno, uint64_t time_ms,
+      std::optional<uint64_t> current_lease_epoch);
+
+  Status RelinquishYsqlLease(const std::string& permanent_uuid, int64_t instance_seqno);
+
+ private:
+  MasterYsqlLeaseProxy proxy_;
+};
+
+}  // namespace yb::master

--- a/src/yb/master/master_ysql_lease_service.cc
+++ b/src/yb/master/master_ysql_lease_service.cc
@@ -1,0 +1,43 @@
+// Copyright (c) YugabyteDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "yb/master/catalog_manager.h"
+#include "yb/master/master_service_base.h"
+#include "yb/master/master_service_base-internal.h"
+#include "yb/master/master_ysql_lease.service.h"
+
+namespace yb {
+namespace master {
+
+namespace {
+
+class MasterYsqlLeaseServiceImpl : public MasterServiceBase, public MasterYsqlLeaseIf {
+ public:
+  explicit MasterYsqlLeaseServiceImpl(Master* master)
+      : MasterServiceBase(master), MasterYsqlLeaseIf(master->metric_entity()) {}
+
+  MASTER_SERVICE_IMPL_ON_LEADER_WITH_LOCK(
+    CatalogManager,
+    (RefreshYsqlLease)
+    (RelinquishYsqlLease)
+  )
+};
+
+} // namespace
+
+std::unique_ptr<rpc::ServiceIf> MakeMasterYsqlLeaseService(Master* master) {
+  return std::make_unique<MasterYsqlLeaseServiceImpl>(master);
+}
+
+} // namespace master
+} // namespace yb

--- a/src/yb/master/object_lock_info_manager.cc
+++ b/src/yb/master/object_lock_info_manager.cc
@@ -35,6 +35,7 @@
 #include "yb/master/master.h"
 #include "yb/master/master_error.h"
 #include "yb/master/master_ddl.pb.h"
+#include "yb/master/master_ysql_lease.pb.h"
 #include "yb/master/scoped_leader_shared_lock.h"
 #include "yb/master/sys_catalog.h"
 #include "yb/master/ts_manager.h"

--- a/src/yb/master/object_lock_info_manager.h
+++ b/src/yb/master/object_lock_info_manager.h
@@ -22,6 +22,7 @@
 #include "yb/master/leader_epoch.h"
 #include "yb/master/master_ddl.pb.h"
 #include "yb/master/master_fwd.h"
+#include "yb/master/master_ysql_lease.fwd.h"
 
 #include "yb/util/monotime.h"
 #include "yb/util/status_callback.h"

--- a/src/yb/master/ts_descriptor.cc
+++ b/src/yb/master/ts_descriptor.cc
@@ -42,6 +42,7 @@
 #include "yb/master/catalog_manager_util.h"
 #include "yb/master/master_cluster.pb.h"
 #include "yb/master/master_ddl.pb.h"
+#include "yb/master/master_ysql_lease.pb.h"
 #include "yb/master/master_fwd.h"
 #include "yb/master/master_heartbeat.pb.h"
 #include "yb/master/master_util.h"

--- a/src/yb/tserver/ysql_lease_manager.cc
+++ b/src/yb/tserver/ysql_lease_manager.cc
@@ -11,6 +11,8 @@
 // under the License.
 //
 
+#include "yb/master/master_ysql_lease.pb.h"
+
 #include "yb/rpc/messenger.h"
 #include "yb/rpc/scheduler.h"
 

--- a/src/yb/tserver/ysql_lease_poller.cc
+++ b/src/yb/tserver/ysql_lease_poller.cc
@@ -17,7 +17,7 @@
 
 #include "yb/common/ysql_operation_lease.h"
 
-#include "yb/master/master_ddl.proxy.h"
+#include "yb/master/master_ysql_lease.proxy.h"
 #include "yb/master/master_rpc.h"
 
 #include "yb/server/server_base.proxy.h"
@@ -70,7 +70,7 @@ class YsqlLeasePoller : public MasterLeaderPollerInterface {
   TabletServer& server_;
   YsqlLeaderClientListener listener_;
   MasterLeaderFinder& finder_;
-  std::optional<master::MasterDdlProxy> proxy_;
+  std::optional<master::MasterYsqlLeaseProxy> proxy_;
 };
 
 class YsqlLeaseClient::Impl {
@@ -161,7 +161,7 @@ Status YsqlLeasePoller::Poll() {
   auto timeout =
       MonoDelta::FromMilliseconds(FLAGS_ysql_lease_refresher_rpc_timeout_ms);
   if (!proxy_) {
-    proxy_ = VERIFY_RESULT(finder_.CreateProxy<master::MasterDdlProxy>(timeout));
+    proxy_ = VERIFY_RESULT(finder_.CreateProxy<master::MasterYsqlLeaseProxy>(timeout));
   }
 
   master::RefreshYsqlLeaseRequestPB req;
@@ -207,7 +207,7 @@ std::future<Status> YsqlLeasePoller::RelinquishLease(MonoDelta timeout) const {
     promise.set_value(Status::OK());
     return promise.get_future();
   }
-  auto proxy = master::MasterDdlProxy(&finder_.get_proxy_cache(), current_host_port);
+  auto proxy = master::MasterYsqlLeaseProxy(&finder_.get_proxy_cache(), current_host_port);
   auto rpc = std::make_shared<rpc::RpcController>();
   rpc->set_timeout(timeout);
   master::RelinquishYsqlLeaseRequestPB req;

--- a/src/yb/tserver/ysql_lease_poller.h
+++ b/src/yb/tserver/ysql_lease_poller.h
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include "yb/master/master_ysql_lease.fwd.h"
+
 #include "yb/server/server_fwd.h"
 #include "yb/tserver/tserver_fwd.h"
 


### PR DESCRIPTION
DO NOT MERGE!! [CSI](<https://csiweb.dev.yugabyte.com/pull/33262/>) ⏳

Summary:
YSQL lease heartbeats from tservers to the master were handled by the
regular-priority RPC thread pool via the MasterDdl service. Under an overload of
regular-priority master RPCs (e.g. catalog cache reads or heartbeats
or GetTableSchema or GetTabletLocations) the lease refresh could
be backed up, and a lease failure kills all PG sessions on that tserver.

This moves RefreshYsqlLease and RelinquishYsqlLease into a dedicated
MasterYsqlLease service and registers it on the master's high-priority RPC thread
pool (rpc::ServicePriority::kHigh), isolating lease refreshes from regular master
RPC load. (Consensus is the other user of the high-priority pool.)

**Upgrade/Rollback safety:**
 The new service keeps custom_service_name = "yb.master.MasterService" and the
same method names, so the on-the-wire remote method is identical to when these
RPCs lived in MasterDdl. This makes the change compatible with any master/tserver
upgrade order: an old tserver's MasterDdlProxy and a new tserver's
MasterYsqlLeaseProxy produce byte-identical requests, resolved by whichever
service the master has registered. The only visible change is the RPC's metrics
group name (yb.master.MasterDdl -> yb.master.MasterYsqlLease).

Original commit: d212939a4eee2554679515671f1aef4381dde1c8 / D56573

Test Plan:
Existing tests exercise the lease RPCs through the new service/proxy:
  ./yb_build.sh fastdebug --clang21 --cxx-test object_lock-test
  ./yb_build.sh fastdebug --clang21 --cxx-test master-test

Reviewers: bkolagani, zdrudi, #db-approvers

Reviewed By: zdrudi, #db-approvers

Subscribers: ybase

Differential Revision: https://phorge.dev.yugabyte.com/D56573

## Merge conflicts

All four conflicts were context drift between `master` and `2026.1` (the release branch
predates some surrounding code). No logic from this change was altered.

- `src/yb/master/master_ddl.proto:951` — dropped the two lease RPCs from `service MasterDdl`
  as the commit does. Did **not** take the cherry-pick's `WaitForLockersMultipleGlobal` block,
  which was only adjacent context on `master`; that RPC does not exist on `2026.1`.
- `src/yb/master/master.cc:138` — added the new `master_ysql_lease_svc_queue_length` flag
  (`DEFINE_NON_RUNTIME_int32`, as on master; the macro exists on `2026.1`). Kept `2026.1`'s
  existing `DEFINE_UNKNOWN_int32` spelling for the adjacent `master_consensus_svc_queue_length`
  flag rather than the cherry-pick's `DEFINE_NON_RUNTIME_int32`.
- `src/yb/master/catalog_entity_info.cc:55` — added only `master_ysql_lease.pb.h` (needed: this
  file does member access on `RefreshYsqlLeaseRequestPB`). Did not pull in the cherry-pick's
  adjacent `sys_catalog_constants.h` include, which is master-only context.
- `src/yb/tserver/ysql_lease_poller.h:16` — added only `master_ysql_lease.fwd.h` (needed: the
  lease messages moved out of `master_ddl.proto`). Did not add the adjacent `#include <future>`,
  which is pre-existing context on `master` and absent here.

Verified after resolution: no duplicate message definitions between `master_ddl.proto` and the
new `master_ysql_lease.proto`, all four imports of the new proto exist on `2026.1`, and
`build-support/lint.sh --rev origin/2026.1` reports 0 errors / 0 warnings.
