### PR TITLE
[DOC-1422][2026.1.1] SKIP LOCKED in row locking modes

### DIFF
--- a/docs/content/stable/architecture/transactions/concurrency-control.md
+++ b/docs/content/stable/architecture/transactions/concurrency-control.md
@@ -1268,7 +1268,7 @@ Refer to [#5680](https://github.com/yugabyte/yugabyte-db/issues/5680) for limita
 
 ## Row-level explicit locking clauses
 
-YugabyteDB supports PostgreSQL's row-level explicit locking clauses, which provide advanced control over lock acquisition behavior in the presence of conflicts. The behavior of these clauses depends on the concurrency control policy:
+YugabyteDB supports PostgreSQL's row-level explicit locking clauses, which provide advanced control over lock acquisition behavior in the presence of conflicts. The behavior of these clauses depends on the concurrency control policy.
 
 ### NOWAIT clause
 
@@ -1284,13 +1284,11 @@ The `SKIP LOCKED` clause allows a transaction to skip rows that are already lock
 - **Supported in:** Both Fail-on-Conflict and Wait-on-Conflict concurrency control policies
 - **Not supported in:** Serializable isolation ([#5683](https://github.com/yugabyte/yugabyte-db/issues/5683))
 
-**Performance optimization for SKIP LOCKED:**
+YugabyteDB provides the following configuration parameters to optimize SKIP LOCKED performance:
 
-YugabyteDB provides two configuration parameters to optimize SKIP LOCKED performance:
+- [yb_explicit_row_locking_batch_size](../../../reference/configuration/yb-tserver/#ysql-yb-explicit-row-locking-batch-size): Controls the number of lock requests batched together. Default is 1024. Larger batches improve throughput; smaller batches reduce memory usage and latency.
 
-- [`yb_explicit_row_locking_batch_size`](../../../reference/configuration/yb-tserver/#ysql-yb-explicit-row-locking-batch-size): Controls the number of lock requests batched together. Default is 1024. Larger batches improve throughput; smaller batches reduce memory usage and latency.
-
-- [`yb_explicit_row_lock_skip_locked_max_read_ahead`](../../../reference/configuration/yb-tserver/#ysql-yb-explicit-row-lock-skip-locked-max-read-ahead) (v2026.1.1.0+): Controls parallelism when locking rows in a SKIP LOCKED query. Default is 1 (disabled). Values greater than 1 enable read-ahead optimization, allowing YugabyteDB to attempt locking multiple rows concurrently, significantly improving performance.
+- [yb_explicit_row_lock_skip_locked_max_read_ahead](../../../reference/configuration/yb-tserver/#ysql-yb-explicit-row-lock-skip-locked-max-read-ahead) (v2026.1.1.0+): Controls parallelism when locking rows in a SKIP LOCKED query. Default is 1 (disabled). Values greater than 1 enable read-ahead optimization, allowing YugabyteDB to attempt locking multiple rows concurrently, significantly improving performance.
 
 For detailed examples and configuration guidance, refer to [Explicit row locking modes](../../../explore/transactions/explicit-locking/#explicit-row-locking-modes).
 

--- a/docs/content/stable/architecture/transactions/concurrency-control.md
+++ b/docs/content/stable/architecture/transactions/concurrency-control.md
@@ -1268,9 +1268,31 @@ Refer to [#5680](https://github.com/yugabyte/yugabyte-db/issues/5680) for limita
 
 ## Row-level explicit locking clauses
 
-The `NOWAIT` clause for row-level explicit locking doesn't apply to the `Fail-on-Conflict` mode as there is no waiting. It does apply to the `Wait-on-Conflict` policy but is currently supported only for Read Committed isolation. [#12166](https://github.com/yugabyte/yugabyte-db/issues/12166) will extend support for this in the `Wait-on-Conflict` mode for the other isolation levels.
+YugabyteDB supports PostgreSQL's row-level explicit locking clauses, which provide advanced control over lock acquisition behavior in the presence of conflicts. The behavior of these clauses depends on the concurrency control policy:
 
-The `SKIP LOCKED` clause is supported in both concurrency control policies and provides a transaction with the capability to skip locking without any error when a conflict is detected. However, it isn't supported for Serializable isolation. [#11761](https://github.com/yugabyte/yugabyte-db/issues/5683) tracks support for `SKIP LOCKED` in Serializable isolation.
+### NOWAIT clause
+
+The `NOWAIT` clause causes a SELECT FOR UPDATE/SHARE to fail immediately with an error if the row is already locked, rather than waiting.
+
+- **Supported in:** Wait-on-Conflict policy with Read Committed isolation
+- **Not supported in:** Fail-on-Conflict policy (which never waits anyway), and Serializable isolation ([#12166](https://github.com/yugabyte/yugabyte-db/issues/12166))
+
+### SKIP LOCKED clause
+
+The `SKIP LOCKED` clause allows a transaction to skip rows that are already locked by other transactions, returning only the unlocked rows. This is useful for workloads that can process any available rows.
+
+- **Supported in:** Both Fail-on-Conflict and Wait-on-Conflict concurrency control policies
+- **Not supported in:** Serializable isolation ([#5683](https://github.com/yugabyte/yugabyte-db/issues/5683))
+
+**Performance optimization for SKIP LOCKED:**
+
+YugabyteDB provides two configuration parameters to optimize SKIP LOCKED performance:
+
+- **`yb_explicit_row_locking_batch_size`:** Controls the number of lock requests batched together. Default is 1024. Larger batches improve throughput; smaller batches reduce memory usage and latency.
+
+- **`yb_explicit_row_lock_skip_locked_max_read_ahead`** (v2026.1.1.0+): Controls parallelism when locking rows in a SKIP LOCKED query. Default is 1 (disabled). Values > 1 enable read-ahead optimization, allowing YugabyteDB to attempt locking multiple rows concurrently, significantly improving performance.
+
+For detailed examples and configuration guidance, refer to [Explicit row locking modes](../../../explore/transactions/explicit-locking/#explicit-row-locking-modes).
 
 ## Advisory locks
 

--- a/docs/content/stable/architecture/transactions/concurrency-control.md
+++ b/docs/content/stable/architecture/transactions/concurrency-control.md
@@ -1286,9 +1286,10 @@ The `SKIP LOCKED` clause allows a transaction to skip rows that are already lock
 
 YugabyteDB provides the following configuration parameters to optimize SKIP LOCKED performance:
 
-- [yb_explicit_row_locking_batch_size](../../../reference/configuration/yb-tserver/#ysql-yb-explicit-row-locking-batch-size): Controls the number of lock requests batched together. Default is 1024. Larger batches improve throughput; smaller batches reduce memory usage and latency.
+- [yb_explicit_row_locking_batch_size](../../../reference/configuration/yb-tserver/#ysql-yb-explicit-row-locking-batch-size): Controls the number of lock requests batched together. Applies to the WAIT and NOWAIT cases. Default is 1024. Larger batches improve both throughput and latency; smaller batches reduce memory usage (but only by small amounts).
 
-- [yb_explicit_row_lock_skip_locked_max_read_ahead](../../../reference/configuration/yb-tserver/#ysql-yb-explicit-row-lock-skip-locked-max-read-ahead) (v2026.1.1.0+): Controls parallelism when locking rows in a SKIP LOCKED query. Default is 1 (disabled). Values greater than 1 enable read-ahead optimization, allowing YugabyteDB to attempt locking multiple rows concurrently, significantly improving performance.
+- `yb_explicit_row_lock_skip_locked_max_read_ahead` (v2026.1.1.0+): Locking multiple rows in a single batch in SKIP LOCKED requires the execution engine to prefetch the candidate rows that are to be locked. This parameter controls how many rows are prefetched. Default is 1 (disabled, only the current row is fetched).
+To batch SKIP LOCKED queries, you must set both `yb_explicit_row_locking_batch_size` and `yb_explicit_row_lock_skip_locked_max_read_ahead` greater than 0 for improved performance.
 
 For detailed examples and configuration guidance, refer to [Explicit row locking modes](../../../explore/transactions/explicit-locking/#explicit-row-locking-modes).
 

--- a/docs/content/stable/architecture/transactions/concurrency-control.md
+++ b/docs/content/stable/architecture/transactions/concurrency-control.md
@@ -1288,9 +1288,9 @@ The `SKIP LOCKED` clause allows a transaction to skip rows that are already lock
 
 YugabyteDB provides two configuration parameters to optimize SKIP LOCKED performance:
 
-- **`yb_explicit_row_locking_batch_size`:** Controls the number of lock requests batched together. Default is 1024. Larger batches improve throughput; smaller batches reduce memory usage and latency.
+- [`yb_explicit_row_locking_batch_size`](../../../reference/configuration/yb-tserver/#ysql-yb-explicit-row-locking-batch-size): Controls the number of lock requests batched together. Default is 1024. Larger batches improve throughput; smaller batches reduce memory usage and latency.
 
-- **`yb_explicit_row_lock_skip_locked_max_read_ahead`** (v2026.1.1.0+): Controls parallelism when locking rows in a SKIP LOCKED query. Default is 1 (disabled). Values > 1 enable read-ahead optimization, allowing YugabyteDB to attempt locking multiple rows concurrently, significantly improving performance.
+- [`yb_explicit_row_lock_skip_locked_max_read_ahead`](../../../reference/configuration/yb-tserver/#ysql-yb-explicit-row-lock-skip-locked-max-read-ahead) (v2026.1.1.0+): Controls parallelism when locking rows in a SKIP LOCKED query. Default is 1 (disabled). Values greater than 1 enable read-ahead optimization, allowing YugabyteDB to attempt locking multiple rows concurrently, significantly improving performance.
 
 For detailed examples and configuration guidance, refer to [Explicit row locking modes](../../../explore/transactions/explicit-locking/#explicit-row-locking-modes).
 

--- a/docs/content/stable/explore/transactions/explicit-locking.md
+++ b/docs/content/stable/explore/transactions/explicit-locking.md
@@ -108,7 +108,9 @@ This should succeed.
 
 ### Explicit row locking modes
 
-YSQL supports PostgreSQL's explicit locking clauses that provide advanced control over lock acquisition behavior when conflicts occur.
+YSQL supports [PostgreSQL's explicit locking clause](https://www.postgresql.org/docs/15/sql-select.html#SQL-FOR-UPDATE-SHARE) that provides advanced control over lock acquisition behavior when conflicts occur.
+
+By default, the system waits to acquire locks when competing transactions hold the lock. You can modify this behavior using the NOWAIT and the SKIP LOCKED clauses. These locks can only be applied to row-level locks. They are not applicable to table locks.
 
 #### NOWAIT clause
 
@@ -124,6 +126,8 @@ For support details and limitations, see [Row-level explicit locking clauses](..
 #### SKIP LOCKED clause
 
 The `SKIP LOCKED` clause allows a SELECT FOR UPDATE/SHARE to skip rows that are locked, returning only the unlocked rows. This is useful for applications that can process any available rows.
+
+Skipping locked rows provides an inconsistent view of the data, so this is not suitable for general purpose work, but can be used to avoid lock contention with multiple consumers accessing a queue-like table.
 
 Example:
 ```sql

--- a/docs/content/stable/explore/transactions/explicit-locking.md
+++ b/docs/content/stable/explore/transactions/explicit-locking.md
@@ -86,9 +86,29 @@ This operation fails because it conflicts with the row-level lock and as per Fai
 
 Note that the error message appears after all [best-effort statement retries](../../../architecture/transactions/concurrency-control/#best-effort-internal-retries-for-first-statement-in-a-transaction) have been exhausted.
 
+Finally, in the first session, update the row and commit the transaction, as follows:
+
+```sql
+yugabyte=# UPDATE t SET v='v1.2' WHERE k='k1';
+```
+
+```output
+UPDATE 1
+```
+
+```sql
+yugabyte=# COMMIT;
+```
+
+```output
+COMMIT
+```
+
+This should succeed.
+
 ### Explicit row locking modes
 
-YugabyteDB's YSQL supports PostgreSQL's explicit locking clauses that provide advanced control over lock acquisition behavior when conflicts occur:
+YSQL supports PostgreSQL's explicit locking clauses that provide advanced control over lock acquisition behavior when conflicts occur.
 
 #### NOWAIT clause
 
@@ -111,26 +131,6 @@ SELECT * FROM orders WHERE status = 'pending' FOR UPDATE SKIP LOCKED LIMIT 10;
 ```
 
 For support details, limitations, and performance tuning options, see [Row-level explicit locking clauses](../../../architecture/transactions/concurrency-control/#row-level-explicit-locking-clauses) and [Explicit row locking flags](../../../reference/configuration/yb-tserver/#explicit-row-locking-flags).
-
-Finally, in the first session, update the row and commit the transaction, as follows:
-
-```sql
-yugabyte=# UPDATE t SET v='v1.2' WHERE k='k1';
-```
-
-```output
-UPDATE 1
-```
-
-```sql
-yugabyte=# COMMIT;
-```
-
-```output
-COMMIT
-```
-
-This should succeed.
 
 ## Advisory locks
 

--- a/docs/content/stable/explore/transactions/explicit-locking.md
+++ b/docs/content/stable/explore/transactions/explicit-locking.md
@@ -86,6 +86,79 @@ This operation fails because it conflicts with the row-level lock and as per Fai
 
 Note that the error message appears after all [best-effort statement retries](../../../architecture/transactions/concurrency-control/#best-effort-internal-retries-for-first-statement-in-a-transaction) have been exhausted.
 
+### Explicit row locking modes
+
+YugabyteDB's YSQL supports PostgreSQL's explicit locking clauses that provide advanced control over lock acquisition behavior:
+
+#### NOWAIT clause
+
+The `NOWAIT` clause prevents a transaction from waiting if a row lock conflict is detected. Instead, the operation fails immediately with an error.
+
+- **Supported in:** Wait-on-Conflict policy with Read Committed isolation
+- **Not supported in:** Fail-on-Conflict policy (which never waits), Serializable isolation (as of v2026.1; support is tracked in [#12166](https://github.com/yugabyte/yugabyte-db/issues/12166))
+
+Example:
+```sql
+SELECT * FROM account WHERE id = 100 FOR UPDATE NOWAIT;
+```
+
+If the row is already locked, this returns immediately with an error instead of waiting.
+
+#### SKIP LOCKED clause
+
+The `SKIP LOCKED` clause allows a transaction to skip rows that are already locked by other transactions, instead of blocking or aborting. This is useful for workloads that can process any available rows without needing specific ones.
+
+- **Supported in:** Both Fail-on-Conflict and Wait-on-Conflict concurrency control policies
+- **Not supported in:** Serializable isolation (as of v2026.1; support is tracked in [#5683](https://github.com/yugabyte/yugabyte-db/issues/5683))
+
+Example:
+```sql
+SELECT * FROM orders WHERE status = 'pending' FOR UPDATE SKIP LOCKED LIMIT 10;
+```
+
+This query locks and returns up to 10 rows that are not already locked by other transactions, skipping any locked rows.
+
+##### Performance tuning for SKIP LOCKED
+
+When using `SKIP LOCKED`, YugabyteDB provides two configuration parameters to optimize performance:
+
+**1. Batch size** (`yb_explicit_row_locking_batch_size`)
+
+Controls how many lock requests are batched together. The default is 1024 rows per batch.
+
+- Larger batches reduce round-trips to the server (better throughput)
+- Smaller batches reduce memory usage and latency for small result sets
+
+Example:
+```sql
+SET yb_explicit_row_locking_batch_size = 512;
+```
+
+**2. Read-ahead optimization** (`yb_explicit_row_lock_skip_locked_max_read_ahead`)
+
+Controls how many rows can be locked in parallel when processing `SKIP LOCKED` queries. By default, this is disabled (value = 1), meaning rows are processed sequentially. Enabling read-ahead (setting a value > 1) allows YugabyteDB to attempt locking multiple rows concurrently, significantly improving performance.
+
+Example:
+```sql
+-- Disable read-ahead (sequential processing)
+SET yb_explicit_row_lock_skip_locked_max_read_ahead = 1;
+
+-- Enable read-ahead with up to 10 parallel lock attempts
+SET yb_explicit_row_lock_skip_locked_max_read_ahead = 10;
+```
+
+**How they interact:**
+
+- `yb_explicit_row_locking_batch_size` determines the size of lock request batches sent to the server
+- `yb_explicit_row_lock_skip_locked_max_read_ahead` determines parallelism within `SKIP LOCKED` operations
+
+For example, with `batch_size=1024` and `read_ahead=10`:
+- YugabyteDB reads 1024 rows in a batch
+- It attempts to lock up to 10 rows in parallel
+- Locked rows are returned; conflicted rows are skipped
+
+This combination allows you to balance throughput (larger batches) with low latency (parallel read-ahead).
+
 Finally, in the first session, update the row and commit the transaction, as follows:
 
 ```sql

--- a/docs/content/stable/explore/transactions/explicit-locking.md
+++ b/docs/content/stable/explore/transactions/explicit-locking.md
@@ -88,76 +88,29 @@ Note that the error message appears after all [best-effort statement retries](..
 
 ### Explicit row locking modes
 
-YugabyteDB's YSQL supports PostgreSQL's explicit locking clauses that provide advanced control over lock acquisition behavior:
+YugabyteDB's YSQL supports PostgreSQL's explicit locking clauses that provide advanced control over lock acquisition behavior when conflicts occur:
 
 #### NOWAIT clause
 
-The `NOWAIT` clause prevents a transaction from waiting if a row lock conflict is detected. Instead, the operation fails immediately with an error.
-
-- **Supported in:** Wait-on-Conflict policy with Read Committed isolation
-- **Not supported in:** Fail-on-Conflict policy (which never waits), Serializable isolation (as of v2026.1; support is tracked in [#12166](https://github.com/yugabyte/yugabyte-db/issues/12166))
+The `NOWAIT` clause causes a SELECT FOR UPDATE/SHARE to fail immediately if a row is locked, rather than waiting or aborting.
 
 Example:
 ```sql
 SELECT * FROM account WHERE id = 100 FOR UPDATE NOWAIT;
 ```
 
-If the row is already locked, this returns immediately with an error instead of waiting.
+For support details and limitations, see [Row-level explicit locking clauses](../../../architecture/transactions/concurrency-control/#row-level-explicit-locking-clauses).
 
 #### SKIP LOCKED clause
 
-The `SKIP LOCKED` clause allows a transaction to skip rows that are already locked by other transactions, instead of blocking or aborting. This is useful for workloads that can process any available rows without needing specific ones.
-
-- **Supported in:** Both Fail-on-Conflict and Wait-on-Conflict concurrency control policies
-- **Not supported in:** Serializable isolation (as of v2026.1; support is tracked in [#5683](https://github.com/yugabyte/yugabyte-db/issues/5683))
+The `SKIP LOCKED` clause allows a SELECT FOR UPDATE/SHARE to skip rows that are locked, returning only the unlocked rows. This is useful for applications that can process any available rows.
 
 Example:
 ```sql
 SELECT * FROM orders WHERE status = 'pending' FOR UPDATE SKIP LOCKED LIMIT 10;
 ```
 
-This query locks and returns up to 10 rows that are not already locked by other transactions, skipping any locked rows.
-
-##### Performance tuning for SKIP LOCKED
-
-When using `SKIP LOCKED`, YugabyteDB provides two configuration parameters to optimize performance:
-
-**1. Batch size** (`yb_explicit_row_locking_batch_size`)
-
-Controls how many lock requests are batched together. The default is 1024 rows per batch.
-
-- Larger batches reduce round-trips to the server (better throughput)
-- Smaller batches reduce memory usage and latency for small result sets
-
-Example:
-```sql
-SET yb_explicit_row_locking_batch_size = 512;
-```
-
-**2. Read-ahead optimization** (`yb_explicit_row_lock_skip_locked_max_read_ahead`)
-
-Controls how many rows can be locked in parallel when processing `SKIP LOCKED` queries. By default, this is disabled (value = 1), meaning rows are processed sequentially. Enabling read-ahead (setting a value > 1) allows YugabyteDB to attempt locking multiple rows concurrently, significantly improving performance.
-
-Example:
-```sql
--- Disable read-ahead (sequential processing)
-SET yb_explicit_row_lock_skip_locked_max_read_ahead = 1;
-
--- Enable read-ahead with up to 10 parallel lock attempts
-SET yb_explicit_row_lock_skip_locked_max_read_ahead = 10;
-```
-
-**How they interact:**
-
-- `yb_explicit_row_locking_batch_size` determines the size of lock request batches sent to the server
-- `yb_explicit_row_lock_skip_locked_max_read_ahead` determines parallelism within `SKIP LOCKED` operations
-
-For example, with `batch_size=1024` and `read_ahead=10`:
-- YugabyteDB reads 1024 rows in a batch
-- It attempts to lock up to 10 rows in parallel
-- Locked rows are returned; conflicted rows are skipped
-
-This combination allows you to balance throughput (larger batches) with low latency (parallel read-ahead).
+For support details, limitations, and performance tuning options, see [Row-level explicit locking clauses](../../../architecture/transactions/concurrency-control/#row-level-explicit-locking-clauses) and [Explicit row locking flags](../../../reference/configuration/yb-tserver/#explicit-row-locking-flags).
 
 Finally, in the first session, update the row and commit the transaction, as follows:
 

--- a/docs/content/stable/reference/configuration/yb-master.md
+++ b/docs/content/stable/reference/configuration/yb-master.md
@@ -2407,6 +2407,7 @@ When set to false, Read Committed (and Read Uncommitted) isolation level of YSQL
 ##### --pg_client_use_shared_memory
 
 {{% tags/wrap %}}
+
 Default: `true`
 {{% /tags/wrap %}}
 

--- a/docs/content/stable/reference/configuration/yb-tserver.md
+++ b/docs/content/stable/reference/configuration/yb-tserver.md
@@ -2320,12 +2320,14 @@ To learn about explicit row locking, see [Row-level locks](../../../explore/tran
 ##### --ysql_yb_explicit_row_locking_batch_size
 
 {{% tags/wrap %}}
+
 Default: `1024`
 {{% /tags/wrap %}}
 
 Controls the batch size of explicit row locking operations. When YugabyteDB processes SELECT FOR UPDATE/SHARE statements, it batches lock requests to optimize performance. Larger batches improve throughput by reducing server round-trips but consume more memory. Smaller batches reduce memory usage and latency for small result sets.
 
 This flag can be set dynamically:
+
 ```sql
 SET yb_explicit_row_locking_batch_size = 512;
 ```
@@ -2335,6 +2337,7 @@ Works together with `yb_explicit_row_lock_skip_locked_max_read_ahead` for SKIP L
 ##### --ysql_yb_explicit_row_lock_skip_locked_max_read_ahead
 
 {{% tags/wrap %}}
+
 Default: `1` (disabled)
 {{% /tags/wrap %}}
 
@@ -2792,6 +2795,7 @@ When set to false, Read Committed (and Read Uncommitted) isolation level of YSQL
 ##### --pg_client_use_shared_memory
 
 {{% tags/wrap %}}
+
 Default: `true`
 {{% /tags/wrap %}}
 

--- a/docs/content/stable/reference/configuration/yb-tserver.md
+++ b/docs/content/stable/reference/configuration/yb-tserver.md
@@ -2350,6 +2350,27 @@ SET yb_explicit_row_lock_skip_locked_max_read_ahead = 10;
 
 Available from YugabyteDB 2026.1.1.0 and later.
 
+#### Performance tuning for SKIP LOCKED
+
+The `yb_explicit_row_locking_batch_size` and `yb_explicit_row_lock_skip_locked_max_read_ahead` flags work together to optimize SKIP LOCKED query performance:
+
+- **Batch size** determines how many rows are read from storage in one batch
+- **Read-ahead** determines how many rows within that batch are locked in parallel
+
+**Example interaction:**
+
+With `yb_explicit_row_locking_batch_size=1024` and `yb_explicit_row_lock_skip_locked_max_read_ahead=10`:
+1. YugabyteDB reads 1024 rows in a batch
+2. It attempts to lock up to 10 rows in parallel
+3. Successfully locked rows are returned; conflicted rows are skipped
+4. The process continues with the next batch
+
+**Tuning recommendations:**
+
+- **High throughput workloads:** Increase batch size (e.g., 2048) to reduce server round-trips
+- **Low latency workloads:** Decrease batch size and enable read-ahead (e.g., `batch_size=512, read_ahead=5`)
+- **Mixed workloads:** Use moderate values (e.g., `batch_size=1024, read_ahead=10`)
+
 ### Advisory lock flags
 
 To learn about advisory locks, see [Advisory locks](../../../architecture/transactions/concurrency-control/#advisory-locks).

--- a/docs/content/stable/reference/configuration/yb-tserver.md
+++ b/docs/content/stable/reference/configuration/yb-tserver.md
@@ -2323,12 +2323,14 @@ To learn about explicit row locking, see [Row-level locks](../../../explore/tran
 Default: `1024`
 {{% /tags/wrap %}}
 
-Controls the batch size of explicit row locking operations. When YugabyteDB processes SELECT FOR UPDATE/SHARE statements, it batches lock requests to optimize performance. A larger batch size can improve throughput by reducing round-trips, but may consume more memory.
+Controls the batch size of explicit row locking operations. When YugabyteDB processes SELECT FOR UPDATE/SHARE statements, it batches lock requests to optimize performance. Larger batches improve throughput by reducing server round-trips but consume more memory. Smaller batches reduce memory usage and latency for small result sets.
 
-This flag can be set dynamically using:
+This flag can be set dynamically:
 ```sql
 SET yb_explicit_row_locking_batch_size = 512;
 ```
+
+Works together with `yb_explicit_row_lock_skip_locked_max_read_ahead` for SKIP LOCKED query optimization. For tuning guidance, refer to [Row-level explicit locking clauses](../../../architecture/transactions/concurrency-control/#row-level-explicit-locking-clauses).
 
 ##### --ysql_yb_explicit_row_lock_skip_locked_max_read_ahead
 
@@ -2338,38 +2340,17 @@ Default: `1` (disabled)
 
 Controls the maximum number of rows that can be locked in parallel when the `SKIP LOCKED` clause is used. This flag enables read-ahead optimization for SKIP LOCKED operations, allowing YugabyteDB to prefetch and attempt to lock multiple rows concurrently rather than processing them sequentially.
 
-- **Default value `1`**: Disables read-ahead; SKIP LOCKED operations process rows one at a time sequentially
-- **Values > 1**: Enables read-ahead; YugabyteDB will attempt to lock up to this many rows in parallel
+- **Value `1` (default):** Disables read-ahead; rows are processed sequentially
+- **Values greater than 1:** Enables read-ahead; YugabyteDB attempts to lock up to this many rows in parallel
 
-Enabling read-ahead (setting a value > 1) can significantly improve performance for SKIP LOCKED queries by reducing latency when multiple rows are available for locking.
+Setting a value greater than 1 can significantly improve performance for SKIP LOCKED queries by reducing latency when multiple rows are available for locking.
 
-Example to enable read-ahead with up to 10 rows:
+Example:
 ```sql
 SET yb_explicit_row_lock_skip_locked_max_read_ahead = 10;
 ```
 
-Available from YugabyteDB 2026.1.1.0 and later.
-
-#### Performance tuning for SKIP LOCKED
-
-The `yb_explicit_row_locking_batch_size` and `yb_explicit_row_lock_skip_locked_max_read_ahead` flags work together to optimize SKIP LOCKED query performance:
-
-- **Batch size** determines how many rows are read from storage in one batch
-- **Read-ahead** determines how many rows within that batch are locked in parallel
-
-**Example interaction:**
-
-With `yb_explicit_row_locking_batch_size=1024` and `yb_explicit_row_lock_skip_locked_max_read_ahead=10`:
-1. YugabyteDB reads 1024 rows in a batch
-2. It attempts to lock up to 10 rows in parallel
-3. Successfully locked rows are returned; conflicted rows are skipped
-4. The process continues with the next batch
-
-**Tuning recommendations:**
-
-- **High throughput workloads:** Increase batch size (e.g., 2048) to reduce server round-trips
-- **Low latency workloads:** Decrease batch size and enable read-ahead (e.g., `batch_size=512, read_ahead=5`)
-- **Mixed workloads:** Use moderate values (e.g., `batch_size=1024, read_ahead=10`)
+Available from YugabyteDB 2026.1.1.0 and later. For performance tuning guidance, refer to [Row-level explicit locking clauses](../../../architecture/transactions/concurrency-control/#row-level-explicit-locking-clauses).
 
 ### Advisory lock flags
 

--- a/docs/content/stable/reference/configuration/yb-tserver.md
+++ b/docs/content/stable/reference/configuration/yb-tserver.md
@@ -2334,14 +2334,15 @@ SET yb_explicit_row_locking_batch_size = 512;
 
 Works together with `yb_explicit_row_lock_skip_locked_max_read_ahead` for SKIP LOCKED query optimization. For tuning guidance, refer to [Row-level explicit locking clauses](../../../architecture/transactions/concurrency-control/#row-level-explicit-locking-clauses).
 
-##### --ysql_yb_explicit_row_lock_skip_locked_max_read_ahead
+<!-- No ysql flag for this parameter
+##### yb_explicit_row_lock_skip_locked_max_read_ahead
 
 {{% tags/wrap %}}
 
 Default: `1` (disabled)
 {{% /tags/wrap %}}
 
-Controls the maximum number of rows that can be locked in parallel when the `SKIP LOCKED` clause is used. This flag enables read-ahead optimization for SKIP LOCKED operations, allowing YugabyteDB to prefetch and attempt to lock multiple rows concurrently rather than processing them sequentially.
+Controls the maximum number of rows that can be locked in parallel when the `SKIP LOCKED` clause is used. This parameter enables read-ahead optimization for SKIP LOCKED operations, allowing YugabyteDB to prefetch and attempt to lock multiple rows concurrently rather than processing them sequentially.
 
 - **Value `1` (default):** Disables read-ahead; rows are processed sequentially
 - **Values greater than 1:** Enables read-ahead; YugabyteDB attempts to lock up to this many rows in parallel
@@ -2349,11 +2350,13 @@ Controls the maximum number of rows that can be locked in parallel when the `SKI
 Setting a value greater than 1 can significantly improve performance for SKIP LOCKED queries by reducing latency when multiple rows are available for locking.
 
 Example:
+
 ```sql
 SET yb_explicit_row_lock_skip_locked_max_read_ahead = 10;
 ```
 
 Available from YugabyteDB 2026.1.1.0 and later. For performance tuning guidance, refer to [Row-level explicit locking clauses](../../../architecture/transactions/concurrency-control/#row-level-explicit-locking-clauses).
+-->
 
 ### Advisory lock flags
 

--- a/docs/content/stable/reference/configuration/yb-tserver.md
+++ b/docs/content/stable/reference/configuration/yb-tserver.md
@@ -2313,6 +2313,43 @@ Default: `false`
 
 Enable per table mutation (INSERT, UPDATE, DELETE) counting. The Auto Analyze service runs ANALYZE when the number of mutations of a table exceeds the threshold determined by the [ysql_auto_analyze_threshold](#ysql-auto-analyze-threshold) and [ysql_auto_analyze_scale_factor](#ysql-auto-analyze-scale-factor) settings.
 
+### Explicit row locking flags
+
+To learn about explicit row locking, see [Row-level locks](../../../explore/transactions/explicit-locking/#row-level-locks) and [Explicit row locking modes](../../../explore/transactions/explicit-locking/#explicit-row-locking-modes).
+
+##### --ysql_yb_explicit_row_locking_batch_size
+
+{{% tags/wrap %}}
+Default: `1024`
+{{% /tags/wrap %}}
+
+Controls the batch size of explicit row locking operations. When YugabyteDB processes SELECT FOR UPDATE/SHARE statements, it batches lock requests to optimize performance. A larger batch size can improve throughput by reducing round-trips, but may consume more memory.
+
+This flag can be set dynamically using:
+```sql
+SET yb_explicit_row_locking_batch_size = 512;
+```
+
+##### --ysql_yb_explicit_row_lock_skip_locked_max_read_ahead
+
+{{% tags/wrap %}}
+Default: `1` (disabled)
+{{% /tags/wrap %}}
+
+Controls the maximum number of rows that can be locked in parallel when the `SKIP LOCKED` clause is used. This flag enables read-ahead optimization for SKIP LOCKED operations, allowing YugabyteDB to prefetch and attempt to lock multiple rows concurrently rather than processing them sequentially.
+
+- **Default value `1`**: Disables read-ahead; SKIP LOCKED operations process rows one at a time sequentially
+- **Values > 1**: Enables read-ahead; YugabyteDB will attempt to lock up to this many rows in parallel
+
+Enabling read-ahead (setting a value > 1) can significantly improve performance for SKIP LOCKED queries by reducing latency when multiple rows are available for locking.
+
+Example to enable read-ahead with up to 10 rows:
+```sql
+SET yb_explicit_row_lock_skip_locked_max_read_ahead = 10;
+```
+
+Available from YugabyteDB 2026.1.1.0 and later.
+
 ### Advisory lock flags
 
 To learn about advisory locks, see [Advisory locks](../../../architecture/transactions/concurrency-control/#advisory-locks).

--- a/docs/content/v2025.1/architecture/transactions/concurrency-control.md
+++ b/docs/content/v2025.1/architecture/transactions/concurrency-control.md
@@ -1284,11 +1284,9 @@ The `SKIP LOCKED` clause allows a transaction to skip rows that are already lock
 - **Supported in:** Both Fail-on-Conflict and Wait-on-Conflict concurrency control policies
 - **Not supported in:** Serializable isolation ([#5683](https://github.com/yugabyte/yugabyte-db/issues/5683))
 
-**Performance optimization for SKIP LOCKED:**
+YugabyteDB provides the following configuration parameter to optimize SKIP LOCKED performance:
 
-YugabyteDB provides configuration parameter to optimize SKIP LOCKED performance:
-
-- **[`yb_explicit_row_locking_batch_size`](../../../reference/configuration/yb-tserver/#ysql-yb-explicit-row-locking-batch-size):** Controls the number of lock requests batched together. Default is 1024. Larger batches improve throughput; smaller batches reduce memory usage and latency.
+- [yb_explicit_row_locking_batch_size](../../../reference/configuration/yb-tserver/#ysql-yb-explicit-row-locking-batch-size): Controls the number of lock requests batched together. Default is 1024. Larger batches improve throughput; smaller batches reduce memory usage and latency.
 
 For detailed examples and configuration guidance, refer to [Explicit row locking modes](../../../explore/transactions/explicit-locking/#explicit-row-locking-modes).
 

--- a/docs/content/v2025.1/architecture/transactions/concurrency-control.md
+++ b/docs/content/v2025.1/architecture/transactions/concurrency-control.md
@@ -1268,9 +1268,29 @@ Refer to [#5680](https://github.com/yugabyte/yugabyte-db/issues/5680) for limita
 
 ## Row-level explicit locking clauses
 
-The `NOWAIT` clause for row-level explicit locking doesn't apply to the `Fail-on-Conflict` mode as there is no waiting. It does apply to the `Wait-on-Conflict` policy but is currently supported only for Read Committed isolation. [#12166](https://github.com/yugabyte/yugabyte-db/issues/12166) will extend support for this in the `Wait-on-Conflict` mode for the other isolation levels.
+YugabyteDB supports PostgreSQL's row-level explicit locking clauses, which provide advanced control over lock acquisition behavior in the presence of conflicts. The behavior of these clauses depends on the concurrency control policy:
 
-The `SKIP LOCKED` clause is supported in both concurrency control policies and provides a transaction with the capability to skip locking without any error when a conflict is detected. However, it isn't supported for Serializable isolation. [#11761](https://github.com/yugabyte/yugabyte-db/issues/5683) tracks support for `SKIP LOCKED` in Serializable isolation.
+### NOWAIT clause
+
+The `NOWAIT` clause causes a SELECT FOR UPDATE/SHARE to fail immediately with an error if the row is already locked, rather than waiting.
+
+- **Supported in:** Wait-on-Conflict policy with Read Committed isolation
+- **Not supported in:** Fail-on-Conflict policy (which never waits anyway), and Serializable isolation ([#12166](https://github.com/yugabyte/yugabyte-db/issues/12166))
+
+### SKIP LOCKED clause
+
+The `SKIP LOCKED` clause allows a transaction to skip rows that are already locked by other transactions, returning only the unlocked rows. This is useful for workloads that can process any available rows.
+
+- **Supported in:** Both Fail-on-Conflict and Wait-on-Conflict concurrency control policies
+- **Not supported in:** Serializable isolation ([#5683](https://github.com/yugabyte/yugabyte-db/issues/5683))
+
+**Performance optimization for SKIP LOCKED:**
+
+YugabyteDB provides configuration parameter to optimize SKIP LOCKED performance:
+
+- **`yb_explicit_row_locking_batch_size`:** Controls the number of lock requests batched together. Default is 1024. Larger batches improve throughput; smaller batches reduce memory usage and latency.
+
+For detailed examples and configuration guidance, refer to [Explicit row locking modes](../../../explore/transactions/explicit-locking/#explicit-row-locking-modes).
 
 ## Advisory locks
 

--- a/docs/content/v2025.1/architecture/transactions/concurrency-control.md
+++ b/docs/content/v2025.1/architecture/transactions/concurrency-control.md
@@ -1288,7 +1288,7 @@ The `SKIP LOCKED` clause allows a transaction to skip rows that are already lock
 
 YugabyteDB provides configuration parameter to optimize SKIP LOCKED performance:
 
-- **`yb_explicit_row_locking_batch_size`:** Controls the number of lock requests batched together. Default is 1024. Larger batches improve throughput; smaller batches reduce memory usage and latency.
+- **[`yb_explicit_row_locking_batch_size`](../../../reference/configuration/yb-tserver/#ysql-yb-explicit-row-locking-batch-size):** Controls the number of lock requests batched together. Default is 1024. Larger batches improve throughput; smaller batches reduce memory usage and latency.
 
 For detailed examples and configuration guidance, refer to [Explicit row locking modes](../../../explore/transactions/explicit-locking/#explicit-row-locking-modes).
 

--- a/docs/content/v2025.1/explore/transactions/explicit-locking.md
+++ b/docs/content/v2025.1/explore/transactions/explicit-locking.md
@@ -86,9 +86,29 @@ This operation fails because it conflicts with the row-level lock and as per Fai
 
 Note that the error message appears after all [best-effort statement retries](../../../architecture/transactions/concurrency-control/#best-effort-internal-retries-for-first-statement-in-a-transaction) have been exhausted.
 
+Finally, in the first session, update the row and commit the transaction, as follows:
+
+```sql
+yugabyte=# UPDATE t SET v='v1.2' WHERE k='k1';
+```
+
+```output
+UPDATE 1
+```
+
+```sql
+yugabyte=# COMMIT;
+```
+
+```output
+COMMIT
+```
+
+This should succeed.
+
 ### Explicit row locking modes
 
-YugabyteDB's YSQL supports PostgreSQL's explicit locking clauses that provide advanced control over lock acquisition behavior when conflicts occur:
+YSQL supports PostgreSQL's explicit locking clauses that provide advanced control over lock acquisition behavior when conflicts occur.
 
 #### NOWAIT clause
 
@@ -111,26 +131,6 @@ SELECT * FROM orders WHERE status = 'pending' FOR UPDATE SKIP LOCKED LIMIT 10;
 ```
 
 For support details, limitations, and performance tuning options, see [Row-level explicit locking clauses](../../../architecture/transactions/concurrency-control/#row-level-explicit-locking-clauses) and [Explicit row locking flags](../../../reference/configuration/yb-tserver/#explicit-row-locking-flags).
-
-Finally, in the first session, update the row and commit the transaction, as follows:
-
-```sql
-yugabyte=# UPDATE t SET v='v1.2' WHERE k='k1';
-```
-
-```output
-UPDATE 1
-```
-
-```sql
-yugabyte=# COMMIT;
-```
-
-```output
-COMMIT
-```
-
-This should succeed.
 
 ## Advisory locks
 

--- a/docs/content/v2025.1/explore/transactions/explicit-locking.md
+++ b/docs/content/v2025.1/explore/transactions/explicit-locking.md
@@ -86,6 +86,50 @@ This operation fails because it conflicts with the row-level lock and as per Fai
 
 Note that the error message appears after all [best-effort statement retries](../../../architecture/transactions/concurrency-control/#best-effort-internal-retries-for-first-statement-in-a-transaction) have been exhausted.
 
+### Explicit row locking modes
+
+YugabyteDB's YSQL supports PostgreSQL's explicit locking clauses that provide advanced control over lock acquisition behavior:
+
+#### NOWAIT clause
+
+The `NOWAIT` clause prevents a transaction from waiting if a row lock conflict is detected. Instead, the operation fails immediately with an error.
+
+- **Supported in:** Wait-on-Conflict policy with Read Committed isolation
+- **Not supported in:** Fail-on-Conflict policy (which never waits), Serializable isolation (as of v2025.1; support is tracked in [#12166](https://github.com/yugabyte/yugabyte-db/issues/12166))
+
+Example:
+```sql
+SELECT * FROM account WHERE id = 100 FOR UPDATE NOWAIT;
+```
+
+If the row is already locked, this returns immediately with an error instead of waiting.
+
+#### SKIP LOCKED clause
+
+The `SKIP LOCKED` clause allows a transaction to skip rows that are already locked by other transactions, instead of blocking or aborting. This is useful for workloads that can process any available rows without needing specific ones.
+
+- **Supported in:** Both Fail-on-Conflict and Wait-on-Conflict concurrency control policies
+- **Not supported in:** Serializable isolation (as of v2025.1; support is tracked in [#5683](https://github.com/yugabyte/yugabyte-db/issues/5683))
+
+Example:
+```sql
+SELECT * FROM orders WHERE status = 'pending' FOR UPDATE SKIP LOCKED LIMIT 10;
+```
+
+This query locks and returns up to 10 rows that are not already locked by other transactions, skipping any locked rows.
+
+##### Performance tuning for SKIP LOCKED
+
+When using `SKIP LOCKED`, the `yb_explicit_row_locking_batch_size` configuration parameter controls how many lock requests are batched together. The default is 1024 rows per batch.
+
+- Larger batches reduce round-trips to the server (better throughput)
+- Smaller batches reduce memory usage and latency for small result sets
+
+Example:
+```sql
+SET yb_explicit_row_locking_batch_size = 512;
+```
+
 Finally, in the first session, update the row and commit the transaction, as follows:
 
 ```sql

--- a/docs/content/v2025.1/explore/transactions/explicit-locking.md
+++ b/docs/content/v2025.1/explore/transactions/explicit-locking.md
@@ -88,47 +88,29 @@ Note that the error message appears after all [best-effort statement retries](..
 
 ### Explicit row locking modes
 
-YugabyteDB's YSQL supports PostgreSQL's explicit locking clauses that provide advanced control over lock acquisition behavior:
+YugabyteDB's YSQL supports PostgreSQL's explicit locking clauses that provide advanced control over lock acquisition behavior when conflicts occur:
 
 #### NOWAIT clause
 
-The `NOWAIT` clause prevents a transaction from waiting if a row lock conflict is detected. Instead, the operation fails immediately with an error.
-
-- **Supported in:** Wait-on-Conflict policy with Read Committed isolation
-- **Not supported in:** Fail-on-Conflict policy (which never waits), Serializable isolation (as of v2025.1; support is tracked in [#12166](https://github.com/yugabyte/yugabyte-db/issues/12166))
+The `NOWAIT` clause causes a SELECT FOR UPDATE/SHARE to fail immediately if a row is locked, rather than waiting or aborting.
 
 Example:
 ```sql
 SELECT * FROM account WHERE id = 100 FOR UPDATE NOWAIT;
 ```
 
-If the row is already locked, this returns immediately with an error instead of waiting.
+For support details and limitations, see [Row-level explicit locking clauses](../../../architecture/transactions/concurrency-control/#row-level-explicit-locking-clauses).
 
 #### SKIP LOCKED clause
 
-The `SKIP LOCKED` clause allows a transaction to skip rows that are already locked by other transactions, instead of blocking or aborting. This is useful for workloads that can process any available rows without needing specific ones.
-
-- **Supported in:** Both Fail-on-Conflict and Wait-on-Conflict concurrency control policies
-- **Not supported in:** Serializable isolation (as of v2025.1; support is tracked in [#5683](https://github.com/yugabyte/yugabyte-db/issues/5683))
+The `SKIP LOCKED` clause allows a SELECT FOR UPDATE/SHARE to skip rows that are locked, returning only the unlocked rows. This is useful for applications that can process any available rows.
 
 Example:
 ```sql
 SELECT * FROM orders WHERE status = 'pending' FOR UPDATE SKIP LOCKED LIMIT 10;
 ```
 
-This query locks and returns up to 10 rows that are not already locked by other transactions, skipping any locked rows.
-
-##### Performance tuning for SKIP LOCKED
-
-When using `SKIP LOCKED`, the `yb_explicit_row_locking_batch_size` configuration parameter controls how many lock requests are batched together. The default is 1024 rows per batch.
-
-- Larger batches reduce round-trips to the server (better throughput)
-- Smaller batches reduce memory usage and latency for small result sets
-
-Example:
-```sql
-SET yb_explicit_row_locking_batch_size = 512;
-```
+For support details, limitations, and performance tuning options, see [Row-level explicit locking clauses](../../../architecture/transactions/concurrency-control/#row-level-explicit-locking-clauses) and [Explicit row locking flags](../../../reference/configuration/yb-tserver/#explicit-row-locking-flags).
 
 Finally, in the first session, update the row and commit the transaction, as follows:
 

--- a/docs/content/v2025.1/reference/configuration/yb-tserver.md
+++ b/docs/content/v2025.1/reference/configuration/yb-tserver.md
@@ -2269,12 +2269,14 @@ To learn about explicit row locking, see [Row-level locks](../../../explore/tran
 ##### --ysql_yb_explicit_row_locking_batch_size
 
 {{% tags/wrap %}}
+
 Default: `1024`
 {{% /tags/wrap %}}
 
 Controls the batch size of explicit row locking operations. When YugabyteDB processes SELECT FOR UPDATE/SHARE statements, it batches lock requests to optimize performance. A larger batch size can improve throughput by reducing round-trips, but may consume more memory.
 
 This flag can be set dynamically using:
+
 ```sql
 SET yb_explicit_row_locking_batch_size = 512;
 ```
@@ -2702,6 +2704,7 @@ Enables Read Committed isolation. By default this flag is false and in this case
 ##### --pg_client_use_shared_memory
 
 {{% tags/wrap %}}
+
 Default: `true`
 {{% /tags/wrap %}}
 

--- a/docs/content/v2025.1/reference/configuration/yb-tserver.md
+++ b/docs/content/v2025.1/reference/configuration/yb-tserver.md
@@ -2262,6 +2262,23 @@ Default: `5000`
 
 Timeout, in milliseconds, for the node-level mutation reporting RPC to the Auto Analyze service.
 
+### Explicit row locking flags
+
+To learn about explicit row locking, see [Row-level locks](../../../explore/transactions/explicit-locking/#row-level-locks) and [Explicit row locking modes](../../../explore/transactions/explicit-locking/#explicit-row-locking-modes).
+
+##### --ysql_yb_explicit_row_locking_batch_size
+
+{{% tags/wrap %}}
+Default: `1024`
+{{% /tags/wrap %}}
+
+Controls the batch size of explicit row locking operations. When YugabyteDB processes SELECT FOR UPDATE/SHARE statements, it batches lock requests to optimize performance. A larger batch size can improve throughput by reducing round-trips, but may consume more memory.
+
+This flag can be set dynamically using:
+```sql
+SET yb_explicit_row_locking_batch_size = 512;
+```
+
 ### Advisory lock flags
 
 To learn about advisory locks, see [Advisory locks](../../../architecture/transactions/concurrency-control/#advisory-locks).

--- a/docs/content/v2025.2/architecture/transactions/concurrency-control.md
+++ b/docs/content/v2025.2/architecture/transactions/concurrency-control.md
@@ -1284,11 +1284,9 @@ The `SKIP LOCKED` clause allows a transaction to skip rows that are already lock
 - **Supported in:** Both Fail-on-Conflict and Wait-on-Conflict concurrency control policies
 - **Not supported in:** Serializable isolation ([#5683](https://github.com/yugabyte/yugabyte-db/issues/5683))
 
-**Performance optimization for SKIP LOCKED:**
+YugabyteDB provides the following configuration parameter to optimize SKIP LOCKED performance:
 
-YugabyteDB provides configuration parameter to optimize SKIP LOCKED performance:
-
-- **[`yb_explicit_row_locking_batch_size`](../../../reference/configuration/yb-tserver/#ysql-yb-explicit-row-locking-batch-size):** Controls the number of lock requests batched together. Default is 1024. Larger batches improve throughput; smaller batches reduce memory usage and latency.
+- [yb_explicit_row_locking_batch_size](../../../reference/configuration/yb-tserver/#ysql-yb-explicit-row-locking-batch-size): Controls the number of lock requests batched together. Default is 1024. Larger batches improve throughput; smaller batches reduce memory usage and latency.
 
 For detailed examples and configuration guidance, refer to [Explicit row locking modes](../../../explore/transactions/explicit-locking/#explicit-row-locking-modes).
 

--- a/docs/content/v2025.2/architecture/transactions/concurrency-control.md
+++ b/docs/content/v2025.2/architecture/transactions/concurrency-control.md
@@ -1268,9 +1268,29 @@ Refer to [#5680](https://github.com/yugabyte/yugabyte-db/issues/5680) for limita
 
 ## Row-level explicit locking clauses
 
-The `NOWAIT` clause for row-level explicit locking doesn't apply to the `Fail-on-Conflict` mode as there is no waiting. It does apply to the `Wait-on-Conflict` policy but is currently supported only for Read Committed isolation. [#12166](https://github.com/yugabyte/yugabyte-db/issues/12166) will extend support for this in the `Wait-on-Conflict` mode for the other isolation levels.
+YugabyteDB supports PostgreSQL's row-level explicit locking clauses, which provide advanced control over lock acquisition behavior in the presence of conflicts. The behavior of these clauses depends on the concurrency control policy:
 
-The `SKIP LOCKED` clause is supported in both concurrency control policies and provides a transaction with the capability to skip locking without any error when a conflict is detected. However, it isn't supported for Serializable isolation. [#11761](https://github.com/yugabyte/yugabyte-db/issues/5683) tracks support for `SKIP LOCKED` in Serializable isolation.
+### NOWAIT clause
+
+The `NOWAIT` clause causes a SELECT FOR UPDATE/SHARE to fail immediately with an error if the row is already locked, rather than waiting.
+
+- **Supported in:** Wait-on-Conflict policy with Read Committed isolation
+- **Not supported in:** Fail-on-Conflict policy (which never waits anyway), and Serializable isolation ([#12166](https://github.com/yugabyte/yugabyte-db/issues/12166))
+
+### SKIP LOCKED clause
+
+The `SKIP LOCKED` clause allows a transaction to skip rows that are already locked by other transactions, returning only the unlocked rows. This is useful for workloads that can process any available rows.
+
+- **Supported in:** Both Fail-on-Conflict and Wait-on-Conflict concurrency control policies
+- **Not supported in:** Serializable isolation ([#5683](https://github.com/yugabyte/yugabyte-db/issues/5683))
+
+**Performance optimization for SKIP LOCKED:**
+
+YugabyteDB provides configuration parameter to optimize SKIP LOCKED performance:
+
+- **`yb_explicit_row_locking_batch_size`:** Controls the number of lock requests batched together. Default is 1024. Larger batches improve throughput; smaller batches reduce memory usage and latency.
+
+For detailed examples and configuration guidance, refer to [Explicit row locking modes](../../../explore/transactions/explicit-locking/#explicit-row-locking-modes).
 
 ## Advisory locks
 

--- a/docs/content/v2025.2/architecture/transactions/concurrency-control.md
+++ b/docs/content/v2025.2/architecture/transactions/concurrency-control.md
@@ -1288,7 +1288,7 @@ The `SKIP LOCKED` clause allows a transaction to skip rows that are already lock
 
 YugabyteDB provides configuration parameter to optimize SKIP LOCKED performance:
 
-- **`yb_explicit_row_locking_batch_size`:** Controls the number of lock requests batched together. Default is 1024. Larger batches improve throughput; smaller batches reduce memory usage and latency.
+- **[`yb_explicit_row_locking_batch_size`](../../../reference/configuration/yb-tserver/#ysql-yb-explicit-row-locking-batch-size):** Controls the number of lock requests batched together. Default is 1024. Larger batches improve throughput; smaller batches reduce memory usage and latency.
 
 For detailed examples and configuration guidance, refer to [Explicit row locking modes](../../../explore/transactions/explicit-locking/#explicit-row-locking-modes).
 

--- a/docs/content/v2025.2/explore/transactions/explicit-locking.md
+++ b/docs/content/v2025.2/explore/transactions/explicit-locking.md
@@ -86,9 +86,29 @@ This operation fails because it conflicts with the row-level lock and as per Fai
 
 Note that the error message appears after all [best-effort statement retries](../../../architecture/transactions/concurrency-control/#best-effort-internal-retries-for-first-statement-in-a-transaction) have been exhausted.
 
+Finally, in the first session, update the row and commit the transaction, as follows:
+
+```sql
+yugabyte=# UPDATE t SET v='v1.2' WHERE k='k1';
+```
+
+```output
+UPDATE 1
+```
+
+```sql
+yugabyte=# COMMIT;
+```
+
+```output
+COMMIT
+```
+
+This should succeed.
+
 ### Explicit row locking modes
 
-YugabyteDB's YSQL supports PostgreSQL's explicit locking clauses that provide advanced control over lock acquisition behavior when conflicts occur:
+YSQL supports PostgreSQL's explicit locking clauses that provide advanced control over lock acquisition behavior when conflicts occur.
 
 #### NOWAIT clause
 
@@ -111,26 +131,6 @@ SELECT * FROM orders WHERE status = 'pending' FOR UPDATE SKIP LOCKED LIMIT 10;
 ```
 
 For support details, limitations, and performance tuning options, see [Row-level explicit locking clauses](../../../architecture/transactions/concurrency-control/#row-level-explicit-locking-clauses) and [Explicit row locking flags](../../../reference/configuration/yb-tserver/#explicit-row-locking-flags).
-
-Finally, in the first session, update the row and commit the transaction, as follows:
-
-```sql
-yugabyte=# UPDATE t SET v='v1.2' WHERE k='k1';
-```
-
-```output
-UPDATE 1
-```
-
-```sql
-yugabyte=# COMMIT;
-```
-
-```output
-COMMIT
-```
-
-This should succeed.
 
 ## Advisory locks
 

--- a/docs/content/v2025.2/explore/transactions/explicit-locking.md
+++ b/docs/content/v2025.2/explore/transactions/explicit-locking.md
@@ -86,6 +86,50 @@ This operation fails because it conflicts with the row-level lock and as per Fai
 
 Note that the error message appears after all [best-effort statement retries](../../../architecture/transactions/concurrency-control/#best-effort-internal-retries-for-first-statement-in-a-transaction) have been exhausted.
 
+### Explicit row locking modes
+
+YugabyteDB's YSQL supports PostgreSQL's explicit locking clauses that provide advanced control over lock acquisition behavior:
+
+#### NOWAIT clause
+
+The `NOWAIT` clause prevents a transaction from waiting if a row lock conflict is detected. Instead, the operation fails immediately with an error.
+
+- **Supported in:** Wait-on-Conflict policy with Read Committed isolation
+- **Not supported in:** Fail-on-Conflict policy (which never waits), Serializable isolation (as of v2025.2; support is tracked in [#12166](https://github.com/yugabyte/yugabyte-db/issues/12166))
+
+Example:
+```sql
+SELECT * FROM account WHERE id = 100 FOR UPDATE NOWAIT;
+```
+
+If the row is already locked, this returns immediately with an error instead of waiting.
+
+#### SKIP LOCKED clause
+
+The `SKIP LOCKED` clause allows a transaction to skip rows that are already locked by other transactions, instead of blocking or aborting. This is useful for workloads that can process any available rows without needing specific ones.
+
+- **Supported in:** Both Fail-on-Conflict and Wait-on-Conflict concurrency control policies
+- **Not supported in:** Serializable isolation (as of v2025.2; support is tracked in [#5683](https://github.com/yugabyte/yugabyte-db/issues/5683))
+
+Example:
+```sql
+SELECT * FROM orders WHERE status = 'pending' FOR UPDATE SKIP LOCKED LIMIT 10;
+```
+
+This query locks and returns up to 10 rows that are not already locked by other transactions, skipping any locked rows.
+
+##### Performance tuning for SKIP LOCKED
+
+When using `SKIP LOCKED`, the `yb_explicit_row_locking_batch_size` configuration parameter controls how many lock requests are batched together. The default is 1024 rows per batch.
+
+- Larger batches reduce round-trips to the server (better throughput)
+- Smaller batches reduce memory usage and latency for small result sets
+
+Example:
+```sql
+SET yb_explicit_row_locking_batch_size = 512;
+```
+
 Finally, in the first session, update the row and commit the transaction, as follows:
 
 ```sql

--- a/docs/content/v2025.2/explore/transactions/explicit-locking.md
+++ b/docs/content/v2025.2/explore/transactions/explicit-locking.md
@@ -88,47 +88,29 @@ Note that the error message appears after all [best-effort statement retries](..
 
 ### Explicit row locking modes
 
-YugabyteDB's YSQL supports PostgreSQL's explicit locking clauses that provide advanced control over lock acquisition behavior:
+YugabyteDB's YSQL supports PostgreSQL's explicit locking clauses that provide advanced control over lock acquisition behavior when conflicts occur:
 
 #### NOWAIT clause
 
-The `NOWAIT` clause prevents a transaction from waiting if a row lock conflict is detected. Instead, the operation fails immediately with an error.
-
-- **Supported in:** Wait-on-Conflict policy with Read Committed isolation
-- **Not supported in:** Fail-on-Conflict policy (which never waits), Serializable isolation (as of v2025.2; support is tracked in [#12166](https://github.com/yugabyte/yugabyte-db/issues/12166))
+The `NOWAIT` clause causes a SELECT FOR UPDATE/SHARE to fail immediately if a row is locked, rather than waiting or aborting.
 
 Example:
 ```sql
 SELECT * FROM account WHERE id = 100 FOR UPDATE NOWAIT;
 ```
 
-If the row is already locked, this returns immediately with an error instead of waiting.
+For support details and limitations, see [Row-level explicit locking clauses](../../../architecture/transactions/concurrency-control/#row-level-explicit-locking-clauses).
 
 #### SKIP LOCKED clause
 
-The `SKIP LOCKED` clause allows a transaction to skip rows that are already locked by other transactions, instead of blocking or aborting. This is useful for workloads that can process any available rows without needing specific ones.
-
-- **Supported in:** Both Fail-on-Conflict and Wait-on-Conflict concurrency control policies
-- **Not supported in:** Serializable isolation (as of v2025.2; support is tracked in [#5683](https://github.com/yugabyte/yugabyte-db/issues/5683))
+The `SKIP LOCKED` clause allows a SELECT FOR UPDATE/SHARE to skip rows that are locked, returning only the unlocked rows. This is useful for applications that can process any available rows.
 
 Example:
 ```sql
 SELECT * FROM orders WHERE status = 'pending' FOR UPDATE SKIP LOCKED LIMIT 10;
 ```
 
-This query locks and returns up to 10 rows that are not already locked by other transactions, skipping any locked rows.
-
-##### Performance tuning for SKIP LOCKED
-
-When using `SKIP LOCKED`, the `yb_explicit_row_locking_batch_size` configuration parameter controls how many lock requests are batched together. The default is 1024 rows per batch.
-
-- Larger batches reduce round-trips to the server (better throughput)
-- Smaller batches reduce memory usage and latency for small result sets
-
-Example:
-```sql
-SET yb_explicit_row_locking_batch_size = 512;
-```
+For support details, limitations, and performance tuning options, see [Row-level explicit locking clauses](../../../architecture/transactions/concurrency-control/#row-level-explicit-locking-clauses) and [Explicit row locking flags](../../../reference/configuration/yb-tserver/#explicit-row-locking-flags).
 
 Finally, in the first session, update the row and commit the transaction, as follows:
 

--- a/docs/content/v2025.2/reference/configuration/yb-master.md
+++ b/docs/content/v2025.2/reference/configuration/yb-master.md
@@ -2378,6 +2378,7 @@ When set to false, Read Committed (and Read Uncommitted) isolation level of YSQL
 ##### --pg_client_use_shared_memory
 
 {{% tags/wrap %}}
+
 Default: `true`
 {{% /tags/wrap %}}
 

--- a/docs/content/v2025.2/reference/configuration/yb-tserver.md
+++ b/docs/content/v2025.2/reference/configuration/yb-tserver.md
@@ -2260,6 +2260,23 @@ Default: `false`
 
 Enable per table mutation (INSERT, UPDATE, DELETE) counting. The Auto Analyze service runs ANALYZE when the number of mutations of a table exceeds the threshold determined by the [ysql_auto_analyze_threshold](#ysql-auto-analyze-threshold) and [ysql_auto_analyze_scale_factor](#ysql-auto-analyze-scale-factor) settings.
 
+### Explicit row locking flags
+
+To learn about explicit row locking, see [Row-level locks](../../../explore/transactions/explicit-locking/#row-level-locks) and [Explicit row locking modes](../../../explore/transactions/explicit-locking/#explicit-row-locking-modes).
+
+##### --ysql_yb_explicit_row_locking_batch_size
+
+{{% tags/wrap %}}
+Default: `1024`
+{{% /tags/wrap %}}
+
+Controls the batch size of explicit row locking operations. When YugabyteDB processes SELECT FOR UPDATE/SHARE statements, it batches lock requests to optimize performance. A larger batch size can improve throughput by reducing round-trips, but may consume more memory.
+
+This flag can be set dynamically using:
+```sql
+SET yb_explicit_row_locking_batch_size = 512;
+```
+
 ### Advisory lock flags
 
 To learn about advisory locks, see [Advisory locks](../../../architecture/transactions/concurrency-control/#advisory-locks).

--- a/docs/content/v2025.2/reference/configuration/yb-tserver.md
+++ b/docs/content/v2025.2/reference/configuration/yb-tserver.md
@@ -2267,12 +2267,14 @@ To learn about explicit row locking, see [Row-level locks](../../../explore/tran
 ##### --ysql_yb_explicit_row_locking_batch_size
 
 {{% tags/wrap %}}
+
 Default: `1024`
 {{% /tags/wrap %}}
 
 Controls the batch size of explicit row locking operations. When YugabyteDB processes SELECT FOR UPDATE/SHARE statements, it batches lock requests to optimize performance. A larger batch size can improve throughput by reducing round-trips, but may consume more memory.
 
 This flag can be set dynamically using:
+
 ```sql
 SET yb_explicit_row_locking_batch_size = 512;
 ```
@@ -2717,6 +2719,7 @@ When set to false, Read Committed (and Read Uncommitted) isolation level of YSQL
 ##### --pg_client_use_shared_memory
 
 {{% tags/wrap %}}
+
 Default: `true`
 {{% /tags/wrap %}}
 


### PR DESCRIPTION
- Explore section : https://deploy-preview-33263--infallible-bardeen-164bc9.netlify.app/stable/explore/transactions/explicit-locking/#explicit-row-locking-modes
- Row level explicit locking clauses reference section: https://deploy-preview-33263--infallible-bardeen-164bc9.netlify.app/stable/architecture/transactions/concurrency-control/#row-level-explicit-locking-clauses
- yb-tserver reference for the flags: https://deploy-preview-33263--infallible-bardeen-164bc9.netlify.app/stable/reference/configuration/yb-tserver/#explicit-row-locking-flags
