### PR TITLE
[PLAT-19448] YBA: Add roll batch size to k8s rolling restart and helm overrides

### DIFF
--- a/managed/src/main/java/api/v2/mappers/UniverseEditKubernetesOverridesParamsMapper.java
+++ b/managed/src/main/java/api/v2/mappers/UniverseEditKubernetesOverridesParamsMapper.java
@@ -2,6 +2,7 @@ package api.v2.mappers;
 
 import api.v2.models.UniverseEditKubernetesOverrides;
 import com.yugabyte.yw.forms.KubernetesOverridesUpgradeParams;
+import com.yugabyte.yw.forms.UpgradeTaskParams;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
@@ -13,7 +14,32 @@ public interface UniverseEditKubernetesOverridesParamsMapper {
       Mappers.getMapper(UniverseEditKubernetesOverridesParamsMapper.class);
 
   @Mapping(source = "overrides", target = "universeOverrides")
+  @Mapping(target = "sleepAfterTServerRestartMillis", source = "sleepAfterTserverRestartMillis")
+  @Mapping(target = "upgradeOption", source = "source")
+  @Mapping(target = "rollMaxBatchSize", source = "rollMaxBatchSize")
   KubernetesOverridesUpgradeParams copyToV1KubernetesOverridesParams(
       UniverseEditKubernetesOverrides source,
       @MappingTarget KubernetesOverridesUpgradeParams target);
+
+  default UpgradeTaskParams.UpgradeOption mapUpgradeOption(UniverseEditKubernetesOverrides source) {
+    if (source.getRollingUpgrade() == null || Boolean.TRUE.equals(source.getRollingUpgrade())) {
+      return UpgradeTaskParams.UpgradeOption.ROLLING_UPGRADE;
+    }
+    return UpgradeTaskParams.UpgradeOption.NON_ROLLING_UPGRADE;
+  }
+
+  default com.yugabyte.yw.forms.RollMaxBatchSize mapRollMaxBatchSize(
+      api.v2.models.RollMaxBatchSize source) {
+    if (source == null) {
+      return null;
+    }
+    com.yugabyte.yw.forms.RollMaxBatchSize target = new com.yugabyte.yw.forms.RollMaxBatchSize();
+    if (source.getPrimaryBatchSize() != null) {
+      target.setPrimaryBatchSize(source.getPrimaryBatchSize().intValue());
+    }
+    if (source.getReadReplicaBatchSize() != null) {
+      target.setReadReplicaBatchSize(source.getReadReplicaBatchSize().intValue());
+    }
+    return target;
+  }
 }

--- a/managed/src/main/java/api/v2/mappers/UniverseRestartParamsMapper.java
+++ b/managed/src/main/java/api/v2/mappers/UniverseRestartParamsMapper.java
@@ -6,18 +6,43 @@ import com.yugabyte.yw.forms.UpgradeTaskParams;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
-import org.mapstruct.control.DeepClone;
 import org.mapstruct.factory.Mappers;
 
-@Mapper(config = CentralConfig.class, mappingControl = DeepClone.class)
+@Mapper(config = CentralConfig.class)
 public interface UniverseRestartParamsMapper {
   UniverseRestartParamsMapper INSTANCE = Mappers.getMapper(UniverseRestartParamsMapper.class);
 
   @Mapping(target = "sleepAfterTServerRestartMillis", source = "sleepAfterTserverRestartMillis")
+  @Mapping(target = "upgradeOption", source = "source")
+  @Mapping(target = "rollMaxBatchSize", source = "rollMaxBatchSize")
   RestartTaskParams copyToV1RestartTaskParams(
       UniverseRestart source, @MappingTarget RestartTaskParams target);
 
   @Mapping(target = "sleepAfterTServerRestartMillis", source = "sleepAfterTserverRestartMillis")
+  @Mapping(target = "upgradeOption", source = "source")
+  @Mapping(target = "rollMaxBatchSize", source = "rollMaxBatchSize")
   UpgradeTaskParams copyToV1UpgradeTaskParams(
       UniverseRestart source, @MappingTarget UpgradeTaskParams target);
+
+  default UpgradeTaskParams.UpgradeOption mapUpgradeOption(UniverseRestart source) {
+    if (source.getRollingRestart() == null || Boolean.TRUE.equals(source.getRollingRestart())) {
+      return UpgradeTaskParams.UpgradeOption.ROLLING_UPGRADE;
+    }
+    return UpgradeTaskParams.UpgradeOption.NON_ROLLING_UPGRADE;
+  }
+
+  default com.yugabyte.yw.forms.RollMaxBatchSize mapRollMaxBatchSize(
+      api.v2.models.RollMaxBatchSize source) {
+    if (source == null) {
+      return null;
+    }
+    com.yugabyte.yw.forms.RollMaxBatchSize target = new com.yugabyte.yw.forms.RollMaxBatchSize();
+    if (source.getPrimaryBatchSize() != null) {
+      target.setPrimaryBatchSize(source.getPrimaryBatchSize().intValue());
+    }
+    if (source.getReadReplicaBatchSize() != null) {
+      target.setReadReplicaBatchSize(source.getReadReplicaBatchSize().intValue());
+    }
+    return target;
+  }
 }

--- a/managed/src/main/resources/openapi/components/schemas/UniverseEditKubernetesOverrides.yaml
+++ b/managed/src/main/resources/openapi/components/schemas/UniverseEditKubernetesOverrides.yaml
@@ -4,16 +4,20 @@ description: |
 
   Update all kubernetes overrides on the universe. Part of UniverseKubernetesOverridesReq 
 type: object
-properties:
-  overrides:
-    description: Global kubernetes overrides to apply across the entire universe.
-    type: string
-    example: |-
-      tserver:
-        podLabels:
-          env: test
-  az_overrides:
-    description: Granular kubernetes overrides per Availability Zone identified by AZ uuid.
-    example: 'az_uuid: "tserver:\n  podLabels:\n    env: test"'
-    additionalProperties:
-      type: string
+allOf:
+  - $ref: "./SleepAfterRestartSchema.yaml"
+  - $ref: "./UniverseUpgradeOptionRolling.yaml"
+  - type: object
+    properties:
+      overrides:
+        description: Global kubernetes overrides to apply across the entire universe.
+        type: string
+        example: |-
+          tserver:
+            podLabels:
+              env: test
+      az_overrides:
+        description: Granular kubernetes overrides per Availability Zone identified by AZ uuid.
+        example: 'az_uuid: "tserver:\n  podLabels:\n    env: test"'
+        additionalProperties:
+          type: string

--- a/managed/src/main/resources/openapi/components/schemas/UniverseRestart.yaml
+++ b/managed/src/main/resources/openapi/components/schemas/UniverseRestart.yaml
@@ -13,6 +13,10 @@ allOf:
         description: 'Perform a rolling restart of the universe. Otherwise, all nodes will be restarted at the same time.'
         type: boolean
         default: true
+      roll_max_batch_size:
+        description: Suggested number of tservers to roll during restart if available.
+        $ref: "./RollMaxBatchSize.yaml"
+        x-yba-api-visibility: internal
       restart_type:
         description: |
           The method to reboot the node. This is not required for kubernetes universes, as the pods 

--- a/managed/src/test/java/com/yugabyte/yw/api/v2/UniverseApiControllerUpgradeTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/api/v2/UniverseApiControllerUpgradeTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.emptyCollectionOf;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -29,6 +30,7 @@ import com.yugabyte.yba.v2.client.models.PerProviderResizeNodesSpec;
 import com.yugabyte.yba.v2.client.models.PerProviderUpdateProxyConfigSpec;
 import com.yugabyte.yba.v2.client.models.ResizeProviderNodeSpec;
 import com.yugabyte.yba.v2.client.models.ResizeProviderRootNodesSpec;
+import com.yugabyte.yba.v2.client.models.RollMaxBatchSize;
 import com.yugabyte.yba.v2.client.models.UniverseCertRotateSpec;
 import com.yugabyte.yba.v2.client.models.UniverseEditEncryptionInTransit;
 import com.yugabyte.yba.v2.client.models.UniverseEditKubernetesOverrides;
@@ -74,6 +76,7 @@ import com.yugabyte.yw.models.extended.FinalizeUpgradeInfoResponse;
 import com.yugabyte.yw.models.extended.SoftwareUpgradeInfoResponse;
 import com.yugabyte.yw.models.helpers.ProxyConfig;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -519,6 +522,11 @@ public class UniverseApiControllerUpgradeTest extends UniverseTestBase {
     Map<String, String> azOverrides = new HashMap<String, String>();
     azOverrides.put("az1", "az1_overrides");
     req.setAzOverrides(azOverrides);
+    req.setRollingUpgrade(true);
+    RollMaxBatchSize batchSize = new RollMaxBatchSize();
+    batchSize.setPrimaryBatchSize(new BigDecimal(2));
+    batchSize.setReadReplicaBatchSize(new BigDecimal(2));
+    req.setRollMaxBatchSize(batchSize);
     YBATask resp =
         apiClient.editKubernetesOverrides(customer.getUuid(), universe.getUniverseUUID(), req);
     ArgumentCaptor<KubernetesOverridesUpgradeParams> captor =
@@ -530,6 +538,10 @@ public class UniverseApiControllerUpgradeTest extends UniverseTestBase {
     assertEquals("my_overrides", params.universeOverrides);
     assertTrue(params.azOverrides.containsKey("az1"));
     assertEquals("az1_overrides", params.azOverrides.get("az1"));
+    assertEquals(UpgradeTaskParams.UpgradeOption.ROLLING_UPGRADE, params.upgradeOption);
+    assertNotNull(params.rollMaxBatchSize);
+    assertEquals(Integer.valueOf(2), params.rollMaxBatchSize.getPrimaryBatchSize());
+    assertEquals(Integer.valueOf(2), params.rollMaxBatchSize.getReadReplicaBatchSize());
   }
 
   @Test

--- a/managed/src/test/java/com/yugabyte/yw/api/v2/UniverseApiControllerUpgradeTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/api/v2/UniverseApiControllerUpgradeTest.java
@@ -30,7 +30,6 @@ import com.yugabyte.yba.v2.client.models.PerProviderResizeNodesSpec;
 import com.yugabyte.yba.v2.client.models.PerProviderUpdateProxyConfigSpec;
 import com.yugabyte.yba.v2.client.models.ResizeProviderNodeSpec;
 import com.yugabyte.yba.v2.client.models.ResizeProviderRootNodesSpec;
-import com.yugabyte.yba.v2.client.models.RollMaxBatchSize;
 import com.yugabyte.yba.v2.client.models.UniverseCertRotateSpec;
 import com.yugabyte.yba.v2.client.models.UniverseEditEncryptionInTransit;
 import com.yugabyte.yba.v2.client.models.UniverseEditKubernetesOverrides;
@@ -76,7 +75,6 @@ import com.yugabyte.yw.models.extended.FinalizeUpgradeInfoResponse;
 import com.yugabyte.yw.models.extended.SoftwareUpgradeInfoResponse;
 import com.yugabyte.yw.models.helpers.ProxyConfig;
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -522,11 +520,6 @@ public class UniverseApiControllerUpgradeTest extends UniverseTestBase {
     Map<String, String> azOverrides = new HashMap<String, String>();
     azOverrides.put("az1", "az1_overrides");
     req.setAzOverrides(azOverrides);
-    req.setRollingUpgrade(true);
-    RollMaxBatchSize batchSize = new RollMaxBatchSize();
-    batchSize.setPrimaryBatchSize(new BigDecimal(2));
-    batchSize.setReadReplicaBatchSize(new BigDecimal(2));
-    req.setRollMaxBatchSize(batchSize);
     YBATask resp =
         apiClient.editKubernetesOverrides(customer.getUuid(), universe.getUniverseUUID(), req);
     ArgumentCaptor<KubernetesOverridesUpgradeParams> captor =
@@ -538,6 +531,32 @@ public class UniverseApiControllerUpgradeTest extends UniverseTestBase {
     assertEquals("my_overrides", params.universeOverrides);
     assertTrue(params.azOverrides.containsKey("az1"));
     assertEquals("az1_overrides", params.azOverrides.get("az1"));
+  }
+
+  @Test
+  public void testV2KubernetesOverridesWithBatchSize() {
+    UUID taskUUID = UUID.randomUUID();
+    when(mockUpgradeUniverseHandler.upgradeKubernetesOverrides(any(), eq(customer), eq(universe)))
+        .thenReturn(taskUUID);
+    String path =
+        String.format(
+            "/api/v2/customers/%s/universes/%s/kubernetes-overrides",
+            customer.getUuid(), universe.getUniverseUUID());
+    ObjectNode body = Json.newObject();
+    body.put("overrides", "my_overrides");
+    body.put("rolling_upgrade", true);
+    body.set(
+        "roll_max_batch_size",
+        Json.newObject().put("primary_batch_size", 2).put("read_replica_batch_size", 2));
+    Result result = doRequestWithAuthTokenAndBody("POST", path, authToken, body);
+    assertEquals(200, result.status());
+
+    ArgumentCaptor<KubernetesOverridesUpgradeParams> captor =
+        ArgumentCaptor.forClass(KubernetesOverridesUpgradeParams.class);
+    verify(mockUpgradeUniverseHandler)
+        .upgradeKubernetesOverrides(captor.capture(), eq(customer), eq(universe));
+    KubernetesOverridesUpgradeParams params = captor.getValue();
+    assertEquals("my_overrides", params.universeOverrides);
     assertEquals(UpgradeTaskParams.UpgradeOption.ROLLING_UPGRADE, params.upgradeOption);
     assertNotNull(params.rollMaxBatchSize);
     assertEquals(Integer.valueOf(2), params.rollMaxBatchSize.getPrimaryBatchSize());

--- a/managed/src/test/java/com/yugabyte/yw/api/v2/UniverseUtilitiesTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/api/v2/UniverseUtilitiesTest.java
@@ -1,6 +1,7 @@
 package com.yugabyte.yw.api.v2;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -11,18 +12,23 @@ import com.yugabyte.yba.v2.client.ApiClient;
 import com.yugabyte.yba.v2.client.ApiException;
 import com.yugabyte.yba.v2.client.Configuration;
 import com.yugabyte.yba.v2.client.api.UniverseApi;
+import com.yugabyte.yba.v2.client.models.RollMaxBatchSize;
 import com.yugabyte.yba.v2.client.models.UniverseRestart;
 import com.yugabyte.yba.v2.client.models.YBATask;
 import com.yugabyte.yw.commissioner.Common;
 import com.yugabyte.yw.common.ModelFactory;
 import com.yugabyte.yw.controllers.UniverseControllerTestBase;
 import com.yugabyte.yw.controllers.handlers.UpgradeUniverseHandler;
+import com.yugabyte.yw.forms.RestartTaskParams;
+import com.yugabyte.yw.forms.UpgradeTaskParams;
 import com.yugabyte.yw.models.Customer;
 import com.yugabyte.yw.models.Universe;
 import com.yugabyte.yw.models.Users;
+import java.math.BigDecimal;
 import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import play.inject.guice.GuiceApplicationBuilder;
 
@@ -128,5 +134,46 @@ public class UniverseUtilitiesTest extends UniverseControllerTestBase {
         apiClient.restartUniverse(customer.getUuid(), k8sUniverse.getUniverseUUID(), payload);
     assertEquals(taskUUID, resp.getTaskUuid());
     verify(mockUpgradeUniverseHandler).restartUniverse(any(), eq(customer), eq(k8sUniverse));
+  }
+
+  @Test
+  public void testV2RestartRollingWithBatchSize() throws ApiException {
+    UUID taskUUID = UUID.randomUUID();
+    when(mockUpgradeUniverseHandler.restartUniverse(any(), eq(customer), eq(universe)))
+        .thenReturn(taskUUID);
+    UniverseRestart payload = new UniverseRestart();
+    payload.setRollingRestart(true);
+    RollMaxBatchSize batchSize = new RollMaxBatchSize();
+    batchSize.setPrimaryBatchSize(new BigDecimal(2));
+    batchSize.setReadReplicaBatchSize(new BigDecimal(2));
+    payload.setRollMaxBatchSize(batchSize);
+    YBATask resp =
+        apiClient.restartUniverse(customer.getUuid(), universe.getUniverseUUID(), payload);
+    assertEquals(taskUUID, resp.getTaskUuid());
+    ArgumentCaptor<RestartTaskParams> captor = ArgumentCaptor.forClass(RestartTaskParams.class);
+    verify(mockUpgradeUniverseHandler)
+        .restartUniverse(captor.capture(), eq(customer), eq(universe));
+    RestartTaskParams params = captor.getValue();
+    assertEquals(UpgradeTaskParams.UpgradeOption.ROLLING_UPGRADE, params.upgradeOption);
+    assertNotNull(params.rollMaxBatchSize);
+    assertEquals(Integer.valueOf(2), params.rollMaxBatchSize.getPrimaryBatchSize());
+    assertEquals(Integer.valueOf(2), params.rollMaxBatchSize.getReadReplicaBatchSize());
+  }
+
+  @Test
+  public void testV2RestartNonRolling() throws ApiException {
+    UUID taskUUID = UUID.randomUUID();
+    when(mockUpgradeUniverseHandler.restartUniverse(any(), eq(customer), eq(universe)))
+        .thenReturn(taskUUID);
+    UniverseRestart payload = new UniverseRestart();
+    payload.setRollingRestart(false);
+    YBATask resp =
+        apiClient.restartUniverse(customer.getUuid(), universe.getUniverseUUID(), payload);
+    assertEquals(taskUUID, resp.getTaskUuid());
+    ArgumentCaptor<RestartTaskParams> captor = ArgumentCaptor.forClass(RestartTaskParams.class);
+    verify(mockUpgradeUniverseHandler)
+        .restartUniverse(captor.capture(), eq(customer), eq(universe));
+    assertEquals(
+        UpgradeTaskParams.UpgradeOption.NON_ROLLING_UPGRADE, captor.getValue().upgradeOption);
   }
 }

--- a/managed/src/test/java/com/yugabyte/yw/api/v2/UniverseUtilitiesTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/api/v2/UniverseUtilitiesTest.java
@@ -8,11 +8,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static play.inject.Bindings.bind;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.yugabyte.yba.v2.client.ApiClient;
 import com.yugabyte.yba.v2.client.ApiException;
 import com.yugabyte.yba.v2.client.Configuration;
 import com.yugabyte.yba.v2.client.api.UniverseApi;
-import com.yugabyte.yba.v2.client.models.RollMaxBatchSize;
 import com.yugabyte.yba.v2.client.models.UniverseRestart;
 import com.yugabyte.yba.v2.client.models.YBATask;
 import com.yugabyte.yw.commissioner.Common;
@@ -24,13 +24,14 @@ import com.yugabyte.yw.forms.UpgradeTaskParams;
 import com.yugabyte.yw.models.Customer;
 import com.yugabyte.yw.models.Universe;
 import com.yugabyte.yw.models.Users;
-import java.math.BigDecimal;
 import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import play.inject.guice.GuiceApplicationBuilder;
+import play.libs.Json;
+import play.mvc.Result;
 
 public class UniverseUtilitiesTest extends UniverseControllerTestBase {
 
@@ -137,19 +138,21 @@ public class UniverseUtilitiesTest extends UniverseControllerTestBase {
   }
 
   @Test
-  public void testV2RestartRollingWithBatchSize() throws ApiException {
+  public void testV2RestartRollingWithBatchSize() {
     UUID taskUUID = UUID.randomUUID();
     when(mockUpgradeUniverseHandler.restartUniverse(any(), eq(customer), eq(universe)))
         .thenReturn(taskUUID);
-    UniverseRestart payload = new UniverseRestart();
-    payload.setRollingRestart(true);
-    RollMaxBatchSize batchSize = new RollMaxBatchSize();
-    batchSize.setPrimaryBatchSize(new BigDecimal(2));
-    batchSize.setReadReplicaBatchSize(new BigDecimal(2));
-    payload.setRollMaxBatchSize(batchSize);
-    YBATask resp =
-        apiClient.restartUniverse(customer.getUuid(), universe.getUniverseUUID(), payload);
-    assertEquals(taskUUID, resp.getTaskUuid());
+    String path =
+        String.format(
+            "/api/v2/customers/%s/universes/%s/restart",
+            customer.getUuid(), universe.getUniverseUUID());
+    ObjectNode body = Json.newObject();
+    body.put("rolling_restart", true);
+    body.set(
+        "roll_max_batch_size",
+        Json.newObject().put("primary_batch_size", 2).put("read_replica_batch_size", 2));
+    Result result = doRequestWithAuthTokenAndBody("POST", path, authToken, body);
+    assertEquals(200, result.status());
     ArgumentCaptor<RestartTaskParams> captor = ArgumentCaptor.forClass(RestartTaskParams.class);
     verify(mockUpgradeUniverseHandler)
         .restartUniverse(captor.capture(), eq(customer), eq(universe));

--- a/managed/src/test/java/com/yugabyte/yw/api/v2/mappers/UniverseEditGflagsMapperTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/api/v2/mappers/UniverseEditGflagsMapperTest.java
@@ -1,10 +1,13 @@
 package com.yugabyte.yw.api.v2.mappers;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import api.v2.mappers.UniverseEditGFlagsMapper;
+import api.v2.models.RollMaxBatchSize;
 import api.v2.models.UniverseEditGFlags;
 import com.yugabyte.yw.forms.GFlagsUpgradeParams;
+import java.math.BigDecimal;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -53,5 +56,19 @@ public class UniverseEditGflagsMapperTest {
     GFlagsUpgradeParams params = new GFlagsUpgradeParams();
     UniverseEditGFlagsMapper.INSTANCE.copyToV1GFlagsUpgradeParams(req, params);
     assertEquals(GFlagsUpgradeParams.UpgradeOption.NON_RESTART_UPGRADE, params.upgradeOption);
+  }
+
+  @Test
+  public void testRollMaxBatchSizeMap() {
+    UniverseEditGFlags req = new UniverseEditGFlags();
+    RollMaxBatchSize batchSize = new RollMaxBatchSize();
+    batchSize.setPrimaryBatchSize(new BigDecimal(2));
+    batchSize.setReadReplicaBatchSize(new BigDecimal(2));
+    req.setRollMaxBatchSize(batchSize);
+    GFlagsUpgradeParams params = new GFlagsUpgradeParams();
+    UniverseEditGFlagsMapper.INSTANCE.copyToV1GFlagsUpgradeParams(req, params);
+    assertNotNull(params.rollMaxBatchSize);
+    assertEquals(Integer.valueOf(2), params.rollMaxBatchSize.getPrimaryBatchSize());
+    assertEquals(Integer.valueOf(2), params.rollMaxBatchSize.getReadReplicaBatchSize());
   }
 }

--- a/managed/src/test/java/com/yugabyte/yw/api/v2/mappers/UniverseEditKubernetesOverridesParamsMapperTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/api/v2/mappers/UniverseEditKubernetesOverridesParamsMapperTest.java
@@ -1,0 +1,61 @@
+package com.yugabyte.yw.api.v2.mappers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import api.v2.mappers.UniverseEditKubernetesOverridesParamsMapper;
+import api.v2.models.RollMaxBatchSize;
+import api.v2.models.UniverseEditKubernetesOverrides;
+import com.yugabyte.yw.forms.KubernetesOverridesUpgradeParams;
+import com.yugabyte.yw.forms.UpgradeTaskParams;
+import java.math.BigDecimal;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UniverseEditKubernetesOverridesParamsMapperTest {
+  @Test
+  public void testRollingUpgradeWithBatchSize() {
+    UniverseEditKubernetesOverrides req = new UniverseEditKubernetesOverrides();
+    req.setOverrides("tserver:\n  podLabels:\n    env: test");
+    req.setRollingUpgrade(true);
+    req.setSleepAfterTserverRestartMillis(18000);
+    RollMaxBatchSize batchSize = new RollMaxBatchSize();
+    batchSize.setPrimaryBatchSize(new BigDecimal(2));
+    batchSize.setReadReplicaBatchSize(new BigDecimal(2));
+    req.setRollMaxBatchSize(batchSize);
+
+    KubernetesOverridesUpgradeParams params = new KubernetesOverridesUpgradeParams();
+    UniverseEditKubernetesOverridesParamsMapper.INSTANCE.copyToV1KubernetesOverridesParams(
+        req, params);
+
+    assertEquals("tserver:\n  podLabels:\n    env: test", params.universeOverrides);
+    assertEquals(UpgradeTaskParams.UpgradeOption.ROLLING_UPGRADE, params.upgradeOption);
+    assertEquals((Object) 18000, (Object) params.sleepAfterTServerRestartMillis);
+    assertNotNull(params.rollMaxBatchSize);
+    assertEquals(Integer.valueOf(2), params.rollMaxBatchSize.getPrimaryBatchSize());
+    assertEquals(Integer.valueOf(2), params.rollMaxBatchSize.getReadReplicaBatchSize());
+  }
+
+  @Test
+  public void testDefaultRollingWhenUnset() {
+    UniverseEditKubernetesOverrides req = new UniverseEditKubernetesOverrides();
+    KubernetesOverridesUpgradeParams params = new KubernetesOverridesUpgradeParams();
+    UniverseEditKubernetesOverridesParamsMapper.INSTANCE.copyToV1KubernetesOverridesParams(
+        req, params);
+    assertEquals(UpgradeTaskParams.UpgradeOption.ROLLING_UPGRADE, params.upgradeOption);
+    assertNull(params.rollMaxBatchSize);
+  }
+
+  @Test
+  public void testNonRollingUpgrade() {
+    UniverseEditKubernetesOverrides req = new UniverseEditKubernetesOverrides();
+    req.setRollingUpgrade(false);
+    KubernetesOverridesUpgradeParams params = new KubernetesOverridesUpgradeParams();
+    UniverseEditKubernetesOverridesParamsMapper.INSTANCE.copyToV1KubernetesOverridesParams(
+        req, params);
+    assertEquals(UpgradeTaskParams.UpgradeOption.NON_ROLLING_UPGRADE, params.upgradeOption);
+  }
+}

--- a/managed/src/test/java/com/yugabyte/yw/api/v2/mappers/UniverseRestartParamsMapperTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/api/v2/mappers/UniverseRestartParamsMapperTest.java
@@ -1,0 +1,54 @@
+package com.yugabyte.yw.api.v2.mappers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import api.v2.mappers.UniverseRestartParamsMapper;
+import api.v2.models.RollMaxBatchSize;
+import api.v2.models.UniverseRestart;
+import com.yugabyte.yw.forms.RestartTaskParams;
+import com.yugabyte.yw.forms.UpgradeTaskParams;
+import java.math.BigDecimal;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UniverseRestartParamsMapperTest {
+  @Test
+  public void testRollingRestartWithBatchSize() {
+    UniverseRestart req = new UniverseRestart();
+    req.setRollingRestart(true);
+    RollMaxBatchSize batchSize = new RollMaxBatchSize();
+    batchSize.setPrimaryBatchSize(new BigDecimal(2));
+    batchSize.setReadReplicaBatchSize(new BigDecimal(3));
+    req.setRollMaxBatchSize(batchSize);
+
+    RestartTaskParams params = new RestartTaskParams();
+    UniverseRestartParamsMapper.INSTANCE.copyToV1RestartTaskParams(req, params);
+
+    assertEquals(UpgradeTaskParams.UpgradeOption.ROLLING_UPGRADE, params.upgradeOption);
+    assertNotNull(params.rollMaxBatchSize);
+    assertEquals(Integer.valueOf(2), params.rollMaxBatchSize.getPrimaryBatchSize());
+    assertEquals(Integer.valueOf(3), params.rollMaxBatchSize.getReadReplicaBatchSize());
+  }
+
+  @Test
+  public void testDefaultRollingWhenUnset() {
+    UniverseRestart req = new UniverseRestart();
+    RestartTaskParams params = new RestartTaskParams();
+    UniverseRestartParamsMapper.INSTANCE.copyToV1RestartTaskParams(req, params);
+    assertEquals(UpgradeTaskParams.UpgradeOption.ROLLING_UPGRADE, params.upgradeOption);
+    assertNull(params.rollMaxBatchSize);
+  }
+
+  @Test
+  public void testNonRollingRestart() {
+    UniverseRestart req = new UniverseRestart();
+    req.setRollingRestart(false);
+    RestartTaskParams params = new RestartTaskParams();
+    UniverseRestartParamsMapper.INSTANCE.copyToV1RestartTaskParams(req, params);
+    assertEquals(UpgradeTaskParams.UpgradeOption.NON_ROLLING_UPGRADE, params.upgradeOption);
+  }
+}

--- a/managed/src/test/java/com/yugabyte/yw/common/operator/YBUniverseReconcilerTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/common/operator/YBUniverseReconcilerTest.java
@@ -42,6 +42,7 @@ import com.yugabyte.yw.forms.CertsRotateParams;
 import com.yugabyte.yw.forms.EncryptionAtRestConfig;
 import com.yugabyte.yw.forms.EncryptionAtRestConfig.OpType;
 import com.yugabyte.yw.forms.EncryptionAtRestKeyParams;
+import com.yugabyte.yw.forms.GFlagsUpgradeParams;
 import com.yugabyte.yw.forms.KubernetesOverridesUpgradeParams;
 import com.yugabyte.yw.forms.KubernetesProviderFormData;
 import com.yugabyte.yw.forms.KubernetesToggleImmutableYbcParams;
@@ -548,6 +549,84 @@ public class YBUniverseReconcilerTest extends FakeDBApplication {
         .upgradeKubernetesOverrides(uDTCaptor.capture(), any(Customer.class), any(Universe.class));
     assertTrue(uDTCaptor.getValue().universeOverrides.contains("bar"));
     // Verify upgrade handler is not called
+    Mockito.verifyNoInteractions(universeCRUDHandler);
+  }
+
+  @Test
+  public void testOverridesUpgradeHonorsRollMaxBatchSize() throws Exception {
+    String universeName = "test-overrides-roll-batch";
+    YBUniverse ybUniverse = ModelFactory.createYbUniverse(universeName, defaultProvider);
+    UniverseDefinitionTaskParams taskParams =
+        ybUniverseReconciler.createTaskParams(ybUniverse, defaultCustomer.getUuid());
+    Universe oldUniverse = Universe.create(taskParams, defaultCustomer.getId());
+
+    Mockito.when(
+            confGetter.getConfForScope(
+                any(Universe.class), eq(UniverseConfKeys.rollingOpsWaitAfterEachPodMs)))
+        .thenReturn(10000);
+
+    io.yugabyte.operator.v1alpha1.ybuniversespec.RollMaxBatchSize specBatchSize =
+        new io.yugabyte.operator.v1alpha1.ybuniversespec.RollMaxBatchSize();
+    specBatchSize.setPrimaryBatchSize(2L);
+    specBatchSize.setReadReplicaBatchSize(2L);
+    ybUniverse.getSpec().setRollMaxBatchSize(specBatchSize);
+
+    KubernetesOverrides ko = new KubernetesOverrides();
+    Map<String, String> nodeSelectorMap = new HashMap<>();
+    nodeSelectorMap.put("foo", "bar");
+    ko.setNodeSelector(nodeSelectorMap);
+    ybUniverse.getSpec().setKubernetesOverrides(ko);
+
+    ybUniverseReconciler.editUniverse(defaultCustomer, oldUniverse, ybUniverse);
+    ArgumentCaptor<KubernetesOverridesUpgradeParams> uDTCaptor =
+        ArgumentCaptor.forClass(KubernetesOverridesUpgradeParams.class);
+    Mockito.verify(upgradeUniverseHandler, Mockito.times(1))
+        .upgradeKubernetesOverrides(uDTCaptor.capture(), any(Customer.class), any(Universe.class));
+    KubernetesOverridesUpgradeParams captured = uDTCaptor.getValue();
+    assertTrue(captured.universeOverrides.contains("bar"));
+    assertNotNull(captured.rollMaxBatchSize);
+    assertEquals(Integer.valueOf(2), captured.rollMaxBatchSize.getPrimaryBatchSize());
+    assertEquals(Integer.valueOf(2), captured.rollMaxBatchSize.getReadReplicaBatchSize());
+    Mockito.verifyNoInteractions(universeCRUDHandler);
+  }
+
+  @Test
+  public void testGflagsUpgradeHonorsRollMaxBatchSize() throws Exception {
+    String universeName = "test-gflags-roll-batch";
+    YBUniverse ybUniverse = ModelFactory.createYbUniverse(universeName, defaultProvider);
+    UniverseDefinitionTaskParams taskParams =
+        ybUniverseReconciler.createTaskParams(ybUniverse, defaultCustomer.getUuid());
+    Universe oldUniverse = Universe.create(taskParams, defaultCustomer.getId());
+    // checkIfGFlagsChanged diffs per-node gflags, so the universe must have nodes.
+    oldUniverse = ModelFactory.addNodesToUniverse(oldUniverse.getUniverseUUID(), 3);
+
+    Mockito.when(
+            confGetter.getConfForScope(
+                any(Universe.class), eq(UniverseConfKeys.rollingOpsWaitAfterEachPodMs)))
+        .thenReturn(10000);
+
+    io.yugabyte.operator.v1alpha1.ybuniversespec.RollMaxBatchSize specBatchSize =
+        new io.yugabyte.operator.v1alpha1.ybuniversespec.RollMaxBatchSize();
+    specBatchSize.setPrimaryBatchSize(3L);
+    specBatchSize.setReadReplicaBatchSize(2L);
+    ybUniverse.getSpec().setRollMaxBatchSize(specBatchSize);
+
+    io.yugabyte.operator.v1alpha1.ybuniversespec.GFlags gflags =
+        new io.yugabyte.operator.v1alpha1.ybuniversespec.GFlags();
+    Map<String, String> tserverGFlags = new HashMap<>();
+    tserverGFlags.put("ysql_enable_packed_row", "true");
+    gflags.setTserverGFlags(tserverGFlags);
+    ybUniverse.getSpec().setGFlags(gflags);
+
+    ybUniverseReconciler.editUniverse(defaultCustomer, oldUniverse, ybUniverse);
+    ArgumentCaptor<GFlagsUpgradeParams> gflagsCaptor =
+        ArgumentCaptor.forClass(GFlagsUpgradeParams.class);
+    Mockito.verify(upgradeUniverseHandler, Mockito.times(1))
+        .upgradeGFlags(gflagsCaptor.capture(), any(Customer.class), any(Universe.class));
+    GFlagsUpgradeParams captured = gflagsCaptor.getValue();
+    assertNotNull(captured.rollMaxBatchSize);
+    assertEquals(Integer.valueOf(3), captured.rollMaxBatchSize.getPrimaryBatchSize());
+    assertEquals(Integer.valueOf(2), captured.rollMaxBatchSize.getReadReplicaBatchSize());
     Mockito.verifyNoInteractions(universeCRUDHandler);
   }
 

--- a/managed/src/test/java/com/yugabyte/yw/controllers/UpgradeUniverseControllerTest.java
+++ b/managed/src/test/java/com/yugabyte/yw/controllers/UpgradeUniverseControllerTest.java
@@ -71,8 +71,10 @@ import com.yugabyte.yw.forms.CertsRotateParams;
 import com.yugabyte.yw.forms.FinalizeUpgradeParams;
 import com.yugabyte.yw.forms.GFlagsUpgradeParams;
 import com.yugabyte.yw.forms.ITaskParams;
+import com.yugabyte.yw.forms.KubernetesOverridesUpgradeParams;
 import com.yugabyte.yw.forms.ResizeNodeParams;
 import com.yugabyte.yw.forms.RestartTaskParams;
+import com.yugabyte.yw.forms.RollMaxBatchSize;
 import com.yugabyte.yw.forms.RollbackUpgradeParams;
 import com.yugabyte.yw.forms.SoftwareUpgradeParams;
 import com.yugabyte.yw.forms.SystemdUpgradeParams;
@@ -351,6 +353,88 @@ public class UpgradeUniverseControllerTest extends PlatformGuiceApplicationBaseT
     assertThat(task.getTargetName(), allOf(notNullValue(), equalTo("Test Universe")));
     assertThat(
         task.getType(), allOf(notNullValue(), equalTo(CustomerTask.TaskType.RestartUniverse)));
+    assertAuditEntry(1, customer.getUuid());
+  }
+
+  @Test
+  public void testRestartUniverseRollingWithBatchSize() {
+    UUID fakeTaskUUID = FakeDBApplication.buildTaskInfo(null, TaskType.RestartUniverse);
+    when(mockCommissioner.submit(any(), any())).thenReturn(fakeTaskUUID);
+    UUID universeUUID = createUniverse(customer.getId()).getUniverseUUID();
+
+    String url =
+        "/api/customers/" + customer.getUuid() + "/universes/" + universeUUID + "/upgrade/restart";
+    ObjectNode bodyJson = Json.newObject().put("upgradeOption", "Rolling");
+    bodyJson.set(
+        "rollMaxBatchSize",
+        Json.newObject().put("primaryBatchSize", 2).put("readReplicaBatchSize", 2));
+    Result result = doRequestWithAuthTokenAndBody("POST", url, authToken, bodyJson);
+
+    assertOk(result);
+    ArgumentCaptor<UpgradeTaskParams> argCaptor = ArgumentCaptor.forClass(UpgradeTaskParams.class);
+    verify(mockCommissioner, times(1)).submit(eq(TaskType.RestartUniverse), argCaptor.capture());
+
+    UpgradeTaskParams taskParams = argCaptor.getValue();
+    assertEquals(UpgradeOption.ROLLING_UPGRADE, taskParams.upgradeOption);
+    assertNotNull(taskParams.rollMaxBatchSize);
+    assertEquals(Integer.valueOf(2), taskParams.rollMaxBatchSize.getPrimaryBatchSize());
+    assertEquals(Integer.valueOf(2), taskParams.rollMaxBatchSize.getReadReplicaBatchSize());
+    assertAuditEntry(1, customer.getUuid());
+  }
+
+  @Test
+  public void testRestartK8sUniverseRollingWithBatchSize() {
+    UUID fakeTaskUUID = FakeDBApplication.buildTaskInfo(null, TaskType.RestartUniverse);
+    when(mockCommissioner.submit(any(), any())).thenReturn(fakeTaskUUID);
+    k8sUniverse.updateConfig(Map.of(Universe.HELM2_LEGACY, "true"));
+    k8sUniverse.save();
+
+    Result result =
+        runUpgrade(
+            k8sUniverse,
+            p -> p.rollMaxBatchSize = RollMaxBatchSize.of(2, 2),
+            RestartTaskParams.class,
+            "restart");
+    assertOk(result);
+
+    ArgumentCaptor<RestartTaskParams> argCaptor = ArgumentCaptor.forClass(RestartTaskParams.class);
+    verify(mockCommissioner, times(1)).submit(eq(TaskType.RestartUniverse), argCaptor.capture());
+    RestartTaskParams taskParams = argCaptor.getValue();
+    assertEquals(UpgradeOption.ROLLING_UPGRADE, taskParams.upgradeOption);
+    assertNotNull(taskParams.rollMaxBatchSize);
+    assertEquals(Integer.valueOf(2), taskParams.rollMaxBatchSize.getPrimaryBatchSize());
+    assertEquals(Integer.valueOf(2), taskParams.rollMaxBatchSize.getReadReplicaBatchSize());
+    assertAuditEntry(1, customer.getUuid());
+  }
+
+  @Test
+  public void testKubernetesOverridesUpgradeWithBatchSize() {
+    UUID fakeTaskUUID = FakeDBApplication.buildTaskInfo(null, TaskType.KubernetesOverridesUpgrade);
+    when(mockCommissioner.submit(any(), any())).thenReturn(fakeTaskUUID);
+    k8sUniverse.updateConfig(Map.of(Universe.HELM2_LEGACY, "true"));
+    k8sUniverse.save();
+
+    Result result =
+        runUpgrade(
+            k8sUniverse,
+            p -> {
+              p.universeOverrides = "tserver:\n  podLabels:\n    env: test";
+              p.rollMaxBatchSize = RollMaxBatchSize.of(2, 2);
+            },
+            KubernetesOverridesUpgradeParams.class,
+            "kubernetes_overrides");
+    assertOk(result);
+
+    ArgumentCaptor<KubernetesOverridesUpgradeParams> argCaptor =
+        ArgumentCaptor.forClass(KubernetesOverridesUpgradeParams.class);
+    verify(mockCommissioner, times(1))
+        .submit(eq(TaskType.KubernetesOverridesUpgrade), argCaptor.capture());
+    KubernetesOverridesUpgradeParams taskParams = argCaptor.getValue();
+    assertEquals(UpgradeOption.ROLLING_UPGRADE, taskParams.upgradeOption);
+    assertEquals("tserver:\n  podLabels:\n    env: test", taskParams.universeOverrides);
+    assertNotNull(taskParams.rollMaxBatchSize);
+    assertEquals(Integer.valueOf(2), taskParams.rollMaxBatchSize.getPrimaryBatchSize());
+    assertEquals(Integer.valueOf(2), taskParams.rollMaxBatchSize.getReadReplicaBatchSize());
     assertAuditEntry(1, customer.getUuid());
   }
 
@@ -1371,6 +1455,43 @@ public class UpgradeUniverseControllerTest extends PlatformGuiceApplicationBaseT
     assertThat(task.getCustomerUUID(), allOf(notNullValue(), equalTo(customer.getUuid())));
     assertThat(task.getTargetName(), allOf(notNullValue(), equalTo("Test Universe")));
     assertThat(task.getType(), allOf(notNullValue(), equalTo(CustomerTask.TaskType.GFlagsUpgrade)));
+    assertAuditEntry(1, customer.getUuid());
+  }
+
+  @Test
+  public void testGFlagsUpgradeKubernetesWithBatchSize() {
+    UUID fakeTaskUUID = FakeDBApplication.buildTaskInfo(null, TaskType.GFlagsKubernetesUpgrade);
+    when(mockCommissioner.submit(any(), any())).thenReturn(fakeTaskUUID);
+    Universe universe =
+        createUniverse("GFlags Batch Universe", customer.getId(), CloudType.kubernetes);
+    Map<String, String> universeConfig = new HashMap<>();
+    universeConfig.put(Universe.HELM2_LEGACY, "helm");
+    universe.setConfig(universeConfig);
+    universe.save();
+
+    String url =
+        "/api/customers/"
+            + customer.getUuid()
+            + "/universes/"
+            + universe.getUniverseUUID()
+            + "/upgrade/gflags";
+    ObjectNode bodyJson = Json.newObject();
+    bodyJson.set("masterGFlags", Json.parse("{ \"master-flag\": \"123\"}"));
+    bodyJson.set("tserverGFlags", Json.parse("{ \"tserver-flag\": \"456\"}"));
+    bodyJson.set(
+        "rollMaxBatchSize",
+        Json.newObject().put("primaryBatchSize", 2).put("readReplicaBatchSize", 2));
+    Result result = doRequestWithAuthTokenAndBody("POST", url, authToken, bodyJson);
+
+    assertOk(result);
+    ArgumentCaptor<GFlagsUpgradeParams> argCaptor =
+        ArgumentCaptor.forClass(GFlagsUpgradeParams.class);
+    verify(mockCommissioner, times(1))
+        .submit(eq(TaskType.GFlagsKubernetesUpgrade), argCaptor.capture());
+    GFlagsUpgradeParams taskParams = argCaptor.getValue();
+    assertNotNull(taskParams.rollMaxBatchSize);
+    assertEquals(Integer.valueOf(2), taskParams.rollMaxBatchSize.getPrimaryBatchSize());
+    assertEquals(Integer.valueOf(2), taskParams.rollMaxBatchSize.getReadReplicaBatchSize());
     assertAuditEntry(1, customer.getUuid());
   }
 

--- a/managed/ui/src/components/common/forms/RollingUpgradeForm/RollingUpgradeForm.jsx
+++ b/managed/ui/src/components/common/forms/RollingUpgradeForm/RollingUpgradeForm.jsx
@@ -74,7 +74,8 @@ export default class RollingUpgradeForm extends Component {
         currentUniverse: {
           data: {
             universeDetails: { currentClusterType, clusters, nodePrefix, rootAndClientRootCASame },
-            universeUUID
+            universeUUID,
+            rollMaxBatchSize
           }
         }
       },
@@ -138,6 +139,11 @@ export default class RollingUpgradeForm extends Component {
       case 'rollingRestart': {
         payload.taskType = 'Restart';
         payload.upgradeOption = 'Rolling';
+        payload.rollMaxBatchSize = {
+          primaryBatchSize: values.numNodesToUpgradePrimary ?? rollMaxBatchSize?.primaryBatchSize,
+          readReplicaBatchSize:
+            values.numNodesToUpgradePrimary ?? rollMaxBatchSize?.readReplicaBatchSize
+        };
         //send read replica clsuter details in payload only for k8s universe
         if (
           getIsKubernetesUniverse(this.props.universe.currentUniverse.data) &&
@@ -162,6 +168,13 @@ export default class RollingUpgradeForm extends Component {
         payload.azOverrides = values.azOverrides;
         payload.upgradeOption = values.rollingUpgrade ? 'Rolling' : 'Non-Rolling';
         payload.runOnlyPrechecks = values.runOnlyPrechecks;
+        if (values.rollingUpgrade) {
+          payload.rollMaxBatchSize = {
+            primaryBatchSize: values.numNodesToUpgradePrimary ?? rollMaxBatchSize?.primaryBatchSize,
+            readReplicaBatchSize:
+              values.numNodesToUpgradePrimary ?? rollMaxBatchSize?.readReplicaBatchSize
+          };
+        }
         break;
       default:
         return;
@@ -444,11 +457,13 @@ export default class RollingUpgradeForm extends Component {
               this.props.change('rollingUpgrade', formValues.rollingUpgrade);
               this.props.change('timeDelay', formValues.timeDelay);
               this.props.change('runOnlyPrechecks', formValues.runOnlyPrechecks);
+              this.props.change('numNodesToUpgradePrimary', formValues.numNodesToUpgradePrimary);
               submitAction();
             }}
             editValues={editValues}
             editMode={true}
             forceUpdate={true}
+            rollMaxBatchSize={this.props.universe.currentUniverse.data.rollMaxBatchSize}
           />
         );
       }
@@ -661,6 +676,14 @@ export default class RollingUpgradeForm extends Component {
                 component={YBInputField}
                 label="Rolling Restart Delay Between Servers (secs)"
               />
+              {universe.currentUniverse?.data?.rollMaxBatchSize?.primaryBatchSize > 1 && (
+                <Field
+                  name="numNodesToUpgradePrimary"
+                  type="number"
+                  component={YBInputField}
+                  label="Max batch size"
+                />
+              )}
             </div>
             {errorAlert}
           </YBModal>

--- a/managed/ui/src/components/common/forms/RollingUpgradeForm/RollingUpgradeFormContainer.js
+++ b/managed/ui/src/components/common/forms/RollingUpgradeForm/RollingUpgradeFormContainer.js
@@ -121,6 +121,7 @@ function mapStateToProps(state, ownProps) {
   initialValues.timeDelay = TASK_LONG_TIMEOUT / 1000;
   initialValues.upgradeOption = 'Rolling';
   initialValues.rollingUpgrade = true;
+  initialValues.numNodesToUpgradePrimary = 1;
   initialValues.systemdValue = intialSystemdValue;
   initialValues.universeOverrides = '';
   initialValues.azOverrides = '';

--- a/managed/ui/src/components/universes/UniverseForm/HelmOverrides.tsx
+++ b/managed/ui/src/components/universes/UniverseForm/HelmOverrides.tsx
@@ -13,7 +13,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { toast } from 'react-toastify';
 import { Alert, Col, Row } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
-import { Box, Typography } from '@material-ui/core';
+import { Box, Tooltip, Typography } from '@material-ui/core';
 import { isEmpty } from 'lodash';
 import { Field, FieldArray, FormikProps } from 'formik';
 import { YBModalForm } from '../../common/forms';
@@ -36,6 +36,7 @@ import {
 import { getPrimaryCluster } from '../../../utils/UniverseUtils';
 import { useIsTaskNewUIEnabled } from '../../../redesign/features/tasks/TaskUtils';
 import Close from '../../universes/images/close.svg?img';
+import InfoMessageIcon from '../../../redesign/assets/info-message.svg?img';
 import './HelmOverrides.scss';
 
 interface HelmOverridesType {
@@ -43,6 +44,7 @@ interface HelmOverridesType {
   azOverrides: string[];
   rollingUpgrade: boolean;
   timeDelay: number;
+  numNodesToUpgradePrimary: number;
 }
 
 interface HelmOverridesUniversePage {
@@ -109,6 +111,7 @@ interface HelmOverridesModalProps {
   editValues?: Record<string, any>;
   editMode?: boolean;
   forceUpdate?: boolean;
+  rollMaxBatchSize?: { primaryBatchSize?: number; readReplicaBatchSize?: number };
 }
 
 interface NodeOverridesModalProps {
@@ -151,12 +154,14 @@ export const HelmOverridesModal: FC<HelmOverridesModalProps> = ({
   getConfiguretaskParams,
   editValues,
   editMode,
-  forceUpdate
+  forceUpdate,
+  rollMaxBatchSize
 }) => {
   const { t } = useTranslation();
   const [forceConfirm, setForceConfirm] = useState<boolean>(false);
   const [rollingUpgrade, setRollingUpgrade] = useState<boolean>(true);
   const [timeDelay, setTimeDelay] = useState<number>(180);
+  const [numNodesToUpgradePrimary, setNumNodesToUpgradePrimary] = useState<number>(1);
 
   const formik = useRef({} as FormikProps<HelmOverridesType>);
 
@@ -164,7 +169,8 @@ export const HelmOverridesModal: FC<HelmOverridesModalProps> = ({
     universeOverrides: '',
     azOverrides: [],
     rollingUpgrade: true,
-    timeDelay: 180
+    timeDelay: 180,
+    numNodesToUpgradePrimary: 1
   };
 
   if (editValues) {
@@ -194,6 +200,7 @@ export const HelmOverridesModal: FC<HelmOverridesModalProps> = ({
             azOverrides: reqValues.values.azOverrides,
             rollingUpgrade: rollingUpgrade,
             timeDelay: timeDelay,
+            numNodesToUpgradePrimary: numNodesToUpgradePrimary,
             runOnlyPrechecks: reqValues.values.runOnlyPrechecks
           });
           setValidationError(validation_errors_initial_state);
@@ -218,6 +225,7 @@ export const HelmOverridesModal: FC<HelmOverridesModalProps> = ({
             azOverrides: reqValues.values.azOverrides,
             rollingUpgrade: rollingUpgrade,
             timeDelay: timeDelay,
+            numNodesToUpgradePrimary: numNodesToUpgradePrimary,
             runOnlyPrechecks: reqValues.values.runOnlyPrechecks
           });
         } else {
@@ -284,6 +292,14 @@ export const HelmOverridesModal: FC<HelmOverridesModalProps> = ({
   const handleRollingUpgrade = (event: ChangeEvent<HTMLInputElement>) => {
     const isChecked = event.target.checked;
     setRollingUpgrade(isChecked);
+  };
+
+  const handleNumNodeChangePrimary = (event: ChangeEvent<HTMLInputElement>) => {
+    const fieldValue = Number(event.target.value);
+    const maxBatch = rollMaxBatchSize?.primaryBatchSize ?? 1;
+    if (fieldValue > maxBatch) setNumNodesToUpgradePrimary(maxBatch);
+    else if (fieldValue < 1) setNumNodesToUpgradePrimary(1);
+    else setNumNodesToUpgradePrimary(fieldValue);
   };
 
   const showAlert = validationError?.overridesErrors.length !== 0;
@@ -466,6 +482,40 @@ export const HelmOverridesModal: FC<HelmOverridesModalProps> = ({
                 </Box>
                 <Typography variant="body2">{t('common.seconds')}</Typography>
               </Box>
+              {rollingUpgrade && (rollMaxBatchSize?.primaryBatchSize ?? 0) > 1 && (
+                <Box
+                  display={'flex'}
+                  flexDirection={'row'}
+                  width="100%"
+                  alignItems={'center'}
+                  ml={1}
+                  mt={1}
+                >
+                  <YBLabel width="210px">
+                    {t('universeActions.helmOverrides.numNodesToRollingUpgrade')}
+                  </YBLabel>
+                  <Box width="160px" mr={1}>
+                    <YBInput
+                      type="number"
+                      value={numNodesToUpgradePrimary}
+                      onChange={handleNumNodeChangePrimary}
+                      fullWidth
+                      inputProps={{
+                        min: 1,
+                        max: rollMaxBatchSize?.primaryBatchSize,
+                        'data-testid': 'HelmOverrides-NumNodesToRollingUpgrade'
+                      }}
+                    />
+                  </Box>
+                  <Tooltip
+                    title={t('universeActions.helmOverrides.rollingUpgradeMsg')}
+                    arrow
+                    placement="top"
+                  >
+                    <img src={InfoMessageIcon} alt="info" />
+                  </Tooltip>
+                </Box>
+              )}
             </Box>
           </>
         );

--- a/managed/ui/src/redesign/features-v2/universe/create-universe/fields/k8s-helmoverrides/K8sHelmOverridesModal.tsx
+++ b/managed/ui/src/redesign/features-v2/universe/create-universe/fields/k8s-helmoverrides/K8sHelmOverridesModal.tsx
@@ -5,6 +5,7 @@ import { Box, Grid, IconButton, InputAdornment } from '@material-ui/core';
 import { toast } from 'react-toastify';
 import {
   YBInputField,
+  YBInput,
   YBCheckbox,
   YBAlert,
   AlertVariant,
@@ -19,6 +20,7 @@ import {
 import { createErrorMessage } from '@app/redesign/features/universe/universe-form/utils/helpers';
 import {
   ClusterPlacementSpec,
+  RollMaxBatchSize,
   UniverseValidateKubernetesOverridesReqBody
 } from '@app/v2/api/yugabyteDBAnywhereV2APIs.schemas';
 import { useValidateKubernetesOverrides } from '@app/v2/api/universe/universe';
@@ -30,13 +32,26 @@ import CircleAddIcon from '@app/redesign/assets/circle-add-v2.svg';
 const { YBModal } = yba;
 const { Typography } = mui;
 
+export interface HelmOverridesSubmitOptions {
+  rollingUpgrade?: boolean;
+  rollMaxBatchSize?: RollMaxBatchSize;
+  sleepAfterMasterRestartMillis?: number;
+  sleepAfterTserverRestartMillis?: number;
+}
+
 interface HelmOverridesModalProps {
   open: boolean;
   onClose: () => void;
-  onSubmit: (universeOverrides: string, azOverrides: Record<string, string>) => void;
+  onSubmit: (
+    universeOverrides: string,
+    azOverrides: Record<string, string>,
+    options?: HelmOverridesSubmitOptions
+  ) => void;
   initialValues: OverridesForm;
   placementSpec?: ClusterPlacementSpec;
   dbVersion?: string;
+  showRollingUpgradeOptions?: boolean;
+  maxBatchSize?: RollMaxBatchSize;
 }
 
 interface OverridesForm {
@@ -65,7 +80,9 @@ export const K8sHelmOverridesModal = ({
   onClose,
   onSubmit,
   placementSpec,
-  dbVersion
+  dbVersion,
+  showRollingUpgradeOptions = false,
+  maxBatchSize
 }: HelmOverridesModalProps): ReactElement => {
   const { t } = useTranslation();
   const validateOverrides = useValidateKubernetesOverrides();
@@ -74,9 +91,30 @@ export const K8sHelmOverridesModal = ({
     useState<K8sHelmOverridesError>(INITIAL_VAIDATION_ERRORS);
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const [forceConfirm, setForceConfirm] = useState(false);
+  const [rollingUpgrade, setRollingUpgrade] = useState(true);
+  const [timeDelay, setTimeDelay] = useState(180);
+  const [numNodesToUpgradePrimary, setNumNodesToUpgradePrimary] = useState(1);
+
+  const buildSubmitOptions = (): HelmOverridesSubmitOptions | undefined => {
+    if (!showRollingUpgradeOptions) {
+      return undefined;
+    }
+    const options: HelmOverridesSubmitOptions = {
+      rollingUpgrade,
+      sleepAfterMasterRestartMillis: timeDelay * 1000,
+      sleepAfterTserverRestartMillis: timeDelay * 1000
+    };
+    if (rollingUpgrade) {
+      options.rollMaxBatchSize = {
+        primary_batch_size: numNodesToUpgradePrimary,
+        read_replica_batch_size: numNodesToUpgradePrimary
+      };
+    }
+    return options;
+  };
 
   const setOverides = (universeOverrides: string, azOverrides: Record<string, string>) => {
-    onSubmit(universeOverrides, azOverrides);
+    onSubmit(universeOverrides, azOverrides, buildSubmitOptions());
     setValidationError(INITIAL_VAIDATION_ERRORS);
     onClose();
   };
@@ -307,6 +345,57 @@ export const K8sHelmOverridesModal = ({
           </Box>
         </Box>
       </Grid>
+      {showRollingUpgradeOptions && (
+        <Box mt={2} display="flex" flexDirection="column" gap={1}>
+          <YBCheckbox
+            checked={rollingUpgrade}
+            onChange={() => setRollingUpgrade(!rollingUpgrade)}
+            label={t('universeForm.helmOverrides.rollingUpgradeLabel')}
+            dataTestId="HelmOverridesModal-RollingUpgrade"
+          />
+          <Box display="flex" flexDirection="row" alignItems="center" ml={1} gap={1}>
+            <Typography variant="body2">
+              {t('universeForm.helmOverrides.upgradeDelayLabel')}
+            </Typography>
+            <YBInput
+              type="number"
+              value={timeDelay}
+              onChange={(event) => setTimeDelay(Number(event.target.value))}
+              disabled={!rollingUpgrade}
+              sx={{ width: '120px' }}
+              inputProps={{
+                min: 1,
+                'data-testid': 'HelmOverridesModal-TimeDelay'
+              }}
+            />
+            <Typography variant="body2">{t('common.seconds')}</Typography>
+          </Box>
+          {rollingUpgrade && (maxBatchSize?.primary_batch_size ?? 0) > 1 && (
+            <Box display="flex" flexDirection="row" alignItems="center" ml={1} gap={1}>
+              <Typography variant="body2">
+                {t('universeForm.helmOverrides.numNodesToRollingUpgrade')}
+              </Typography>
+              <YBInput
+                type="number"
+                value={numNodesToUpgradePrimary}
+                onChange={(event) => {
+                  const fieldValue = Number(event.target.value);
+                  const maxBatch = maxBatchSize?.primary_batch_size ?? 1;
+                  if (fieldValue > maxBatch) setNumNodesToUpgradePrimary(maxBatch);
+                  else if (fieldValue < 1) setNumNodesToUpgradePrimary(1);
+                  else setNumNodesToUpgradePrimary(fieldValue);
+                }}
+                sx={{ width: '120px' }}
+                inputProps={{
+                  min: 1,
+                  max: maxBatchSize?.primary_batch_size,
+                  'data-testid': 'HelmOverridesModal-NumNodesToRollingUpgrade'
+                }}
+              />
+            </Box>
+          )}
+        </Box>
+      )}
     </YBModal>
   );
 };

--- a/managed/ui/src/redesign/features-v2/universe/edit-universe/settings/AdvancedTab.tsx
+++ b/managed/ui/src/redesign/features-v2/universe/edit-universe/settings/AdvancedTab.tsx
@@ -22,7 +22,10 @@ import {
   EditNodeAcessModal,
   EditUserTagsModal
 } from '../edit-advanced';
-import { K8sHelmOverridesModal } from '../../create-universe/fields/k8s-helmoverrides/K8sHelmOverridesModal';
+import {
+  K8sHelmOverridesModal,
+  HelmOverridesSubmitOptions
+} from '../../create-universe/fields/k8s-helmoverrides/K8sHelmOverridesModal';
 import { useYBToast } from '../../create-universe/helpers/ToastUtils';
 import { RbacValidator } from '@app/redesign/features/rbac/common/RbacApiPermValidator';
 import { ApiPermissionMap } from '@app/redesign/features/rbac/ApiAndUserPermMapping';
@@ -161,11 +164,22 @@ const EditK8sHelmOverrides = () => {
     setHelmOverridesModal(false);
   };
 
-  const handleSubmit = (universeOverrides: string, azOverrides: Record<string, string>) => {
+  const handleSubmit = (
+    universeOverrides: string,
+    azOverrides: Record<string, string>,
+    options?: HelmOverridesSubmitOptions
+  ) => {
     editOverrides.mutate(
       {
         uniUUID,
-        data: { overrides: universeOverrides, az_overrides: azOverrides }
+        data: {
+          overrides: universeOverrides,
+          az_overrides: azOverrides,
+          rolling_upgrade: options?.rollingUpgrade,
+          roll_max_batch_size: options?.rollMaxBatchSize,
+          sleep_after_master_restart_millis: options?.sleepAfterMasterRestartMillis,
+          sleep_after_tserver_restart_millis: options?.sleepAfterTserverRestartMillis
+        }
       },
       {
         onSuccess: (resp) => {
@@ -245,6 +259,8 @@ const EditK8sHelmOverrides = () => {
           onSubmit={handleSubmit}
           dbVersion={dbVersion}
           open={openHelmOverridesModal}
+          showRollingUpgradeOptions
+          maxBatchSize={universeData?.info?.roll_max_batch_size}
         />
       )}
     </StyledPanel>

--- a/managed/ui/src/translations/en.json
+++ b/managed/ui/src/translations/en.json
@@ -269,6 +269,8 @@
         "title": "Kubernetes Overrides",
         "rollingUpgradeLabel": "Rolling upgrade (upgrade pods one at a time)",
         "upgradeDelayLabel": "Upgrade delay between Pods:",
+        "numNodesToRollingUpgrade": "Max batch size: ",
+        "rollingUpgradeMsg": "Refers to the number of nodes that can be unavailable during upgrade process across AZs. This can possibly affect the performance of the cluster till the upgrade is finished",
         "addAvailabilityZone": "Add Availability Zone",
         "forceUpgrade": "Force Upgrade",
         "forceApply": "Force Apply"
@@ -937,7 +939,11 @@
         "validateAndSaveSuccess": "Validated and Saved Successfully",
         "title": "Helm Overrides",
         "universeOverrides": "Universe Overrides",
-        "yamlErrorsTitle": "Errors in helm YAML"
+        "yamlErrorsTitle": "Errors in helm YAML",
+        "rollingUpgradeLabel": "Rolling upgrade (upgrade pods one at a time)",
+        "upgradeDelayLabel": "Upgrade delay between Pods:",
+        "numNodesToRollingUpgrade": "Max batch size: ",
+        "rollingUpgradeMsg": "Refers to the number of nodes that can be unavailable during upgrade process across AZs. This can possibly affect the performance of the cluster till the upgrade is finished"
       },
       "azOverrides": {
         "modalTitle": "AZ Resource Overrides",

--- a/managed/yba-cli/cmd/universe/universeutil/upgradeuniverseutil.go
+++ b/managed/yba-cli/cmd/universe/universeutil/upgradeuniverseutil.go
@@ -475,3 +475,32 @@ func IsDeviceInfoEmpty(deviceInfo ybaclient.DeviceInfo) bool {
 	return deviceInfo.NumVolumes == nil && deviceInfo.VolumeSize == nil &&
 		deviceInfo.StorageType == nil
 }
+
+// AddRollMaxBatchSizeFlags registers CLI flags for k8s/VM rolling batch size.
+func AddRollMaxBatchSizeFlags(cmd *cobra.Command) {
+	cmd.Flags().Int32("primary-batch-size", 1,
+		"[Optional] Number of primary-cluster tservers to restart in each rolling batch. "+
+			"Only applied when --upgrade-option is Rolling.")
+	cmd.Flags().Int32("read-replica-batch-size", 1,
+		"[Optional] Number of read-replica tservers to restart in each rolling batch. "+
+			"Only applied when --upgrade-option is Rolling.")
+}
+
+// RollMaxBatchSizeFromFlags builds RollMaxBatchSize from CLI flags when the upgrade is rolling.
+func RollMaxBatchSizeFromFlags(cmd *cobra.Command, upgradeOption string) *ybaclient.RollMaxBatchSize {
+	if !strings.EqualFold(upgradeOption, "Rolling") {
+		return nil
+	}
+	primaryBatchSize, err := cmd.Flags().GetInt32("primary-batch-size")
+	if err != nil {
+		logrus.Fatal(formatter.Colorize(err.Error()+"\n", formatter.RedColor))
+	}
+	readReplicaBatchSize, err := cmd.Flags().GetInt32("read-replica-batch-size")
+	if err != nil {
+		logrus.Fatal(formatter.Colorize(err.Error()+"\n", formatter.RedColor))
+	}
+	return &ybaclient.RollMaxBatchSize{
+		PrimaryBatchSize:     &primaryBatchSize,
+		ReadReplicaBatchSize: &readReplicaBatchSize,
+	}
+}

--- a/managed/yba-cli/cmd/universe/upgrade/gflags/set_gflagsuniverse.go
+++ b/managed/yba-cli/cmd/universe/upgrade/gflags/set_gflagsuniverse.go
@@ -256,6 +256,7 @@ var setGflagsUniverseCmd = &cobra.Command{
 			UpgradeOption:                  upgradeOption,
 			SleepAfterTServerRestartMillis: tserverDelay,
 			SleepAfterMasterRestartMillis:  masterDelay,
+			RollMaxBatchSize:               universeutil.RollMaxBatchSizeFromFlags(cmd, upgradeOption),
 		}
 
 		rUpgrade, response, err := authAPI.UpgradeGFlags(universeUUID).
@@ -304,6 +305,8 @@ func init() {
 		18000, "[Optional] Upgrade delay between Master servers (in miliseconds).")
 	setGflagsUniverseCmd.Flags().Int32("delay-between-tservers",
 		18000, "[Optional] Upgrade delay between Tservers (in miliseconds).")
+
+	universeutil.AddRollMaxBatchSizeFlags(setGflagsUniverseCmd)
 
 	setGflagsUniverseCmd.Flags().Bool("dry-run", false,
 		"[Optional] Only validate the input and do not actually set the GFlags.")

--- a/managed/yba-cli/cmd/universe/upgrade/restart_universe.go
+++ b/managed/yba-cli/cmd/universe/upgrade/restart_universe.go
@@ -86,6 +86,7 @@ var RestartCmd = &cobra.Command{
 			UpgradeOption:                  upgradeOption,
 			SleepAfterTServerRestartMillis: tserverDelay,
 			SleepAfterMasterRestartMillis:  masterDelay,
+			RollMaxBatchSize:               universeutil.RollMaxBatchSizeFromFlags(cmd, upgradeOption),
 		}
 
 		rUpgrade, response, err := authAPI.RestartUniverse(universeUUID).
@@ -123,4 +124,5 @@ func init() {
 		"[Optional] Upgrade Options, defaults to Rolling. "+
 			"Allowed values (case sensitive): Rolling, Non-Rolling (involves DB downtime). "+
 			"Only a \"Rolling\" type of restart is allowed on a Kubernetes universe.")
+	universeutil.AddRollMaxBatchSizeFlags(RestartCmd)
 }

--- a/managed/yba-cli/docs/yba_universe_restart.md
+++ b/managed/yba-cli/docs/yba_universe_restart.md
@@ -25,6 +25,8 @@ yba universe restart --name <universe-name>
       --delay-between-master-servers int32   [Optional] Upgrade delay between Master servers (in miliseconds). (default 18000)
       --delay-between-tservers int32         [Optional] Upgrade delay between Tservers (in miliseconds). (default 18000)
       --upgrade-option string                [Optional] Upgrade Options, defaults to Rolling. Allowed values (case sensitive): Rolling, Non-Rolling (involves DB downtime). Only a "Rolling" type of restart is allowed on a Kubernetes universe. (default "Rolling")
+      --primary-batch-size int32             [Optional] Number of primary-cluster tservers to restart in each rolling batch. Only applied when --upgrade-option is Rolling. (default 1)
+      --read-replica-batch-size int32        [Optional] Number of read-replica tservers to restart in each rolling batch. Only applied when --upgrade-option is Rolling. (default 1)
   -h, --help                                 help for restart
 ```
 

--- a/managed/yba-cli/docs/yba_universe_upgrade_gflags_set.md
+++ b/managed/yba-cli/docs/yba_universe_upgrade_gflags_set.md
@@ -25,6 +25,8 @@ yba universe upgrade gflags set -n <universe-name> \
       --upgrade-option string                [Optional] Upgrade Options, defaults to Rolling. Allowed values (case sensitive): Rolling, Non-Rolling (involves DB downtime), Non-Restart (default "Rolling")
       --delay-between-master-servers int32   [Optional] Upgrade delay between Master servers (in miliseconds). (default 18000)
       --delay-between-tservers int32         [Optional] Upgrade delay between Tservers (in miliseconds). (default 18000)
+      --primary-batch-size int32             [Optional] Number of primary-cluster tservers to restart in each rolling batch. Only applied when --upgrade-option is Rolling. (default 1)
+      --read-replica-batch-size int32        [Optional] Number of read-replica tservers to restart in each rolling batch. Only applied when --upgrade-option is Rolling. (default 1)
       --dry-run                              [Optional] Only validate the input and do not actually set the GFlags.
   -h, --help                                 help for set
 ```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Kubernetes rolling operations already honor `rollMaxBatchSize` in the upgrade task path (the same pod-batching added for GFlags edits in 2025.1). This change **exposes that control** on rolling restart and edit-Kubernetes-overrides, and adds regression coverage for paths that were already batched.

### Add batch control

- **YBA V1 rolling restart** — `POST …/upgrade/restart` already accepted `rollMaxBatchSize` on `UpgradeTaskParams`; tests now cover VM and Kubernetes.
- **YBA V2 rolling restart** — `UniverseRestart.roll_max_batch_size` (internal) mapped onto V1 `RestartTaskParams`. Also maps `rolling_restart: false` to `NON_ROLLING_UPGRADE`.
- **YBA UI rolling restart** — Universe restart modal sends `rollMaxBatchSize` and shows max batch size when the universe allows `primaryBatchSize > 1`.
- **YBA CLI rolling restart** — `yba universe restart --primary-batch-size` / `--read-replica-batch-size`.
- **YBA V1 edit Kubernetes overrides** — `POST …/upgrade/kubernetes_overrides` with `rollMaxBatchSize`.
- **YBA V2 edit Kubernetes overrides** — `UniverseEditKubernetesOverrides` now includes sleep + rolling-upgrade options (including `roll_max_batch_size`).
- **YBA UI edit Kubernetes overrides** — Helm overrides (v1 modal) and v2 edit-universe Advanced tab rolling options.
- **YBA CLI edit GFlags** — `yba universe upgrade gflags set` gets the same batch-size flags (API already batched).

### Already batched — verify / regression

- V1 Kubernetes GFlags upgrade with `rollMaxBatchSize`.
- V2 GFlags mapper copies `roll_max_batch_size`.
- Operator CR `spec.rollMaxBatchSize` is applied on Kubernetes overrides and GFlags reconcile via existing `applyUpgradeOptions`.

### Out of scope

- Operator CR rolling restart (no restart reconcile/trigger).
- YBA CLI edit Kubernetes overrides (no command).
- Runtime-config default roll batch size.

## Test plan

- [x] `go build` of `yba universe restart` / `yba universe upgrade gflags set` and shared util
- [x] V2 mapper tests: restart, kubernetes overrides, and GFlags `roll_max_batch_size` (12 passed)
- [ ] `UpgradeUniverseControllerTest` restart + kubernetes_overrides + GFlags batch tests
- [ ] `UniverseUtilitiesTest` V2 restart rolling/non-rolling + raw JSON batch size
- [ ] `UniverseApiControllerUpgradeTest` kubernetes overrides + raw JSON batch mapping
- [ ] `YBUniverseReconcilerTest` overrides and GFlags honor `spec.rollMaxBatchSize`
- [ ] Manual: rolling restart modal and helm-overrides modal show max batch size on a k8s universe with `primaryBatchSize > 1`
- [ ] Manual: `yba universe restart --primary-batch-size 2` and `yba universe upgrade gflags set --primary-batch-size 2`

Note: `roll_max_batch_size` is `x-yba-api-visibility: internal`, so the public V2 Java client does not expose setters. API tests POST snake_case JSON; mapper tests use generated server models.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-428a3f35-c7eb-418a-a4b2-033002182d70?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-428a3f35-c7eb-418a-a4b2-033002182d70&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

