### PR TITLE
[#33271] ClaudeCode: Add /backport-diff for Phorge backports

### DIFF
--- a/.claude/commands/backport-commit.md
+++ b/.claude/commands/backport-commit.md
@@ -1,11 +1,13 @@
 ---
-description: Backport a commit to one or more YugabyteDB release branches
+description: Backport a commit to one or more YugabyteDB release branches as GitHub PRs
 argument-hint: <commit-sha> [<branch> ...]
 allowed-tools: Bash(.agents/scripts/backport-commit.sh *)
 model: sonnet
 ---
 
 Backport a merged commit to one or more YugabyteDB release branches using the bundled `backport-commit.sh` at `.agents/scripts/backport-commit.sh`. The script handles cherry-picking, message rewriting, fork detection, push, and PR creation. Wrap it with conflict-resolution logic: trivial whitespace conflicts are fixed automatically; anything more complex is escalated to the user.
+
+**This command produces GitHub PRs.** A backport should go through the same review system the original went through, so if the original landed via Phorge — the argument is a `Dxxxxx` revision ID, or `git log -n1 --format=%b <commit>` shows a `Differential Revision:` line — stop and use `/backport-diff` instead. If neither pattern matches cleanly, ask the user rather than guessing.
 
 **Always pass the full branch list in a single invocation.** After each successful branch, the script chains the next branch's cherry-pick from the previous branch's task branch — so a conflict you resolve on `b2` carries forward, and `b3+` typically apply cleanly without re-resolving the same conflict.
 
@@ -17,7 +19,7 @@ Parse `$ARGUMENTS` (whitespace-separated):
 
 If `<commit>` is missing, stop and ask the user.
 
-If no `<branches>` are provided, ask the user which release branches to target before invoking the script. Do **not** rely on the script's interactive prompt mode — Claude Code's Bash tool cannot answer interactive `read -p` prompts and the run will hang.
+If no `<branches>` are provided, ask the user which release branches to target before invoking the script. Do **not** rely on the script's interactive prompt mode — Claude Code's Bash tool cannot answer interactive `read -p` prompts and the run will hang. Active stable branches: `curl -s https://release.dev.yugabyte.com/version/active/text`. Backport to the branches that actually carry the affected code.
 
 ```
 $ARGUMENTS
@@ -86,9 +88,9 @@ Once **all** conflicts are resolved (and only then):
 
 4. **Run the linter** from the repo root and confirm it is clean before re-running:
    ```
-   ./build-support/lint.sh
+   ./build-support/lint.sh --rev origin/<release-branch>
    ```
-   If the linter reports errors, fix them, `git add` the fixes, and `git commit --amend --no-edit`. Do not proceed until lint output is clean.
+   Pass `--rev` explicitly: a backport task branch has no `@{upstream}`, and `lint.py`'s fallback base is a guess at best. If the linter reports errors, fix them, `git add` the fixes, and `git commit --amend --no-edit`. Do not proceed until lint output is clean.
 
 5. Re-run the script with `-x <conflicted-branch>` and the **same full branch list** as the original invocation:
    ```

--- a/.claude/commands/backport-commit.md
+++ b/.claude/commands/backport-commit.md
@@ -19,7 +19,7 @@ Parse `$ARGUMENTS` (whitespace-separated):
 
 If `<commit>` is missing, stop and ask the user.
 
-If no `<branches>` are provided, ask the user which release branches to target before invoking the script. Do **not** rely on the script's interactive prompt mode — Claude Code's Bash tool cannot answer interactive `read -p` prompts and the run will hang. Active stable branches: `curl -s https://release.dev.yugabyte.com/version/active/text`. Backport to the branches that actually carry the affected code.
+If no `<branches>` are provided, ask the user which release branches to target before invoking the script. Do **not** rely on the script's interactive prompt mode — Claude Code's Bash tool cannot answer interactive `read -p` prompts and the run will hang. For the candidate list, see the supported release series at <https://docs.yugabyte.com/stable/releases/ybdb-releases/> — the release branch name is the series without the leading `v` (`v2025.2` → `2025.2`). Backport to the branches that actually carry the affected code.
 
 ```
 $ARGUMENTS

--- a/.claude/commands/backport-diff.md
+++ b/.claude/commands/backport-diff.md
@@ -1,0 +1,145 @@
+---
+description: Backport a Phorge-landed commit (or revision) to one or more YugabyteDB release branches as Phorge/arc revisions
+argument-hint: <commit-sha|Dxxxxx> [<branch> ...]
+allowed-tools: Bash(backport.sh *)
+model: sonnet
+---
+
+Backport a change that landed through Phorge to one or more YugabyteDB release branches using `backport.sh`. It cherry-picks (or `arc patch`es, for a `Dxxxxx` argument) onto each release branch, rewrites the message to `[BACKPORT <branch>] …` with an `Original commit: <sha> / <Dxxxxx>` line in the Summary, and publishes each branch with `arc diff -- origin/<branch>`. Wrap it with conflict-resolution logic: trivial whitespace conflicts are fixed automatically; anything more complex is escalated to the user.
+
+**This command produces Phorge/arc revisions.** A backport should go through the same review system the original went through, so if the original landed as a GitHub PR — subject ends `(#NNNNN)`, committer is `GitHub <noreply@github.com>`, and the body has no `Differential Revision:` line — stop and use `/backport-commit` instead. If neither pattern matches cleanly, ask the user rather than guessing.
+
+This command is self-contained by design: it shares no content with `/backport-commit`, so once YugabyteDB finishes moving to GitHub PRs, deleting this file is the whole cleanup.
+
+**Always pass the full branch list in a single invocation.** After each successful branch, the script chains the next branch's cherry-pick from the previous branch's task branch — so a conflict you resolve on `b2` carries forward, and `b3+` typically apply cleanly without re-resolving the same conflict.
+
+## Inputs
+
+Parse `$ARGUMENTS` (whitespace-separated):
+- `<commit>` = first token. Either a git SHA (>=7 hex chars, must be merged to `master` and reachable from `origin`) or a Phorge revision ID (`D` followed by digits).
+- `<branches>` = remaining tokens. **Optional.**
+
+If `<commit>` is missing, stop and ask the user.
+
+If no `<branches>` are provided, ask the user which release branches to target before invoking the script. Do **not** rely on the script's interactive prompt mode — Claude Code's Bash tool cannot answer interactive `read -p` prompts and the run will hang. Active stable branches: `curl -s https://release.dev.yugabyte.com/version/active/text`. Backport to the branches that actually carry the affected code.
+
+```
+$ARGUMENTS
+```
+
+## Prerequisites
+
+- `arc` on `PATH` and authenticated (`arc call-conduit -- user.whoami`).
+- `backport.sh` on `PATH`. Unlike `backport-commit.sh`, it is **not** shipped in this repo — it's a separate internal tool. If `which backport.sh` comes up empty, say so and stop rather than falling back to `/backport-commit`.
+- A clean backport workspace. The script clones/reuses `$YB_BACKPORT`, defaulting to `$HOME/code/backport-ybdb`; it is a **separate clone**, not the current worktree, so the current worktree's state is irrelevant. It aborts with exit `2` if that workspace is dirty — do **not** stash or `git checkout -- .` to clear it without confirming with the user; those changes may be in-progress work.
+
+## Workflow
+
+### Step 1: Run the backport script with all branches at once
+
+```
+EDITOR=true GIT_EDITOR=true backport.sh <commit|Dxxxxx> <branch1> <branch2> ... </dev/null 2>&1 | tee /tmp/claude/backport.log
+```
+
+Every part of that invocation matters:
+- `EDITOR=true GIT_EDITOR=true` — **required**, or `arc diff` opens vim and the run hangs forever.
+- `</dev/null` — the script falls back to `read -p` prompts (unknown revision ID, per-branch confirmation when no branches are given); redirecting stdin makes those fail fast instead of hanging.
+- Explicit branches — with none given, the script prompts per stable branch.
+
+Exit codes:
+- `0` — all branches succeeded. Revision URLs are the `https://phorge.dev.yugabyte.com/D...` lines `arc diff` prints, one per branch.
+- `2` — either the workspace was dirty (message: `Workspace ... is not clean`) or a cherry-pick hit conflicts (message: `Backport ERROR: Merge conflicts?` plus the workspace path, task branch `backport-<id>-<branch>`, and a suggested rerun line). Distinguish the two before acting.
+- other — pre-flight failure (malformed ID, unknown commit, clone failure). Report to the user.
+
+If the script warns `Could not find a Differential Revision ID in commit log` (or, for a `Dxxxxx` argument, `Could not find a landed commit ID in phabricator`), it wanted to prompt for a value and got EOF from `</dev/null`. That means the original's cross-reference is missing — ask the user what should go in the `Original commit:` line rather than letting it record `None`.
+
+### Step 2: Resolve conflicts (only if exit code 2 with a merge-conflict message)
+
+The script's failure message names the workspace and the conflicted task branch. `cd` to that workspace and run `git status` to list conflicted files.
+
+For **each** conflicted file, run `git diff` (and, if useful, `git diff --check` for whitespace-only markers) and classify the conflict:
+
+- **Trivial — resolve automatically without asking:**
+  - Pure whitespace differences (tabs vs. spaces, trailing whitespace, indentation only).
+  - Line-ending differences.
+  - Conflicts where both sides are byte-identical after whitespace normalization.
+  - Adjacent-but-non-overlapping hunks that git could have merged with a wider context window.
+
+- **Non-trivial — stop and ask the user:**
+  - Any logic, identifier, or signature change on either side.
+  - Code that has been refactored, renamed, moved, or restructured between `master` and the release branch.
+  - Anything where choosing a side requires understanding intent.
+
+  Show the user the conflicted file(s) and a summary of the conflict, then ask whether you should attempt the merge or whether they want to take over. Do not guess.
+
+After resolving each file:
+1. `git add <file>` — stage the resolution.
+
+Once **all** conflicts are resolved (and only then):
+
+2. `git cherry-pick --continue --no-edit` to land the resolved commit. The script strips the stale `Differential Revision:` line from `.git/MERGE_MSG` for you before exiting, so `--continue --no-edit` won't carry the original revision's tag onto the backport commit — don't re-add it. If the resolved diff is empty, run `git cherry-pick --skip` instead.
+
+3. **Track every resolution, trivial or not**, so a reviewer can see what was changed vs. the original commit. Record `<path>:<line>` and a short summary of the resolution. For trivial cases a one-liner is fine ("accepted cherry-pick's added block; branch had no code at that location"); for non-trivial cases, expand to one line per hunk you reasoned about. May be multiple lines per file. Also remember **which branch** the resolution was on.
+
+4. **Record those notes in the commit message**, not in a post-hoc comment — there is no Phorge equivalent of a GitHub PR body patch that doesn't risk an `arc diff --update` re-upload. Amend the body to add a `Merge conflicts:` block **inside the Summary section**, above the `Reviewers:`/`Subscribers:` fields. Free text placed after `Subscribers:` makes `arc diff` hang on a prompt. The script's own `git commit --amend` preserves the rest of the body verbatim, so the block survives into the published revision's summary. For example, the Summary section becomes:
+
+   ```
+   Summary:
+   Original commit: abc1234 / D50001
+   <original summary text>
+
+   Merge conflicts:
+   - src/yb/master/catalog_manager.cc:1843 — kept master's call signature; release branch lost the `epoch` arg
+   - src/yb/master/catalog_manager.h:412 — moved the new method below the existing private block
+   ```
+
+   Annotate **every** branch where you ran `git cherry-pick --continue`, trivial or not. "Trivial" describes how easy the resolution was, not whether it warrants disclosure. Branches that picked up a resolved diff via chaining need no annotation — that's already implicit in the branch they chained from.
+
+5. **Run the linter** from the repo root and confirm it is clean before re-running:
+   ```
+   ./build-support/lint.sh --rev origin/<release-branch>
+   ```
+   Pass `--rev` explicitly: a backport task branch has no `@{upstream}`, and `lint.py`'s fallback base is a guess at best. If the linter reports errors, fix them, `git add` the fixes, and `git commit --amend --no-edit`. Do not proceed until lint output is clean.
+
+6. Re-run the script with `-x <conflicted-branch>` and the **same full branch list** as the original invocation:
+   ```
+   EDITOR=true GIT_EDITOR=true backport.sh -x <conflicted-branch> <commit|Dxxxxx> <branch1> <branch2> ... </dev/null
+   ```
+   `-x` tells the script to accept the current commit on that task branch as the resolved change instead of re-applying it. Branches whose task branch already carries a `Differential Revision:` line are skipped (arc already posted them), so re-runs don't create duplicate revisions.
+
+If a *later* branch in the same run also hits conflicts, repeat this step for that branch (with a fresh `-x <new-conflicted-branch>`). Continue until the script exits `0`.
+
+### Step 3: Capture revision URLs
+
+Collect every `https://phorge.dev.yugabyte.com/D...` URL printed by `arc diff` across the (possibly multi-run) output. Each successfully backported branch produces one revision. If the output scrolled past, find them by task branch:
+
+```
+cd <workspace> && git log -n1 --format=%b backport-<id>-<branch> | grep 'Differential Revision:'
+```
+
+### Step 4: CI
+
+`arc diff` on a newly created revision **auto-fires** the Harbormaster builds, including `DB Builds/UnitTests (Trigger: db)`. Do **not** post an extra `trigger jenkins` comment — it dedups per diff-version and does nothing when a DB build already exists for the current diff. The DB build then stays `building` for hours until Detective reports back; success shows up as a `Diff ID: <diffid> Passed test criteria` comment on the revision.
+
+Only if a revision has no DB build at all should you post one:
+
+```
+echo '{"revision_id":<n>,"message":"trigger jenkins"}' | arc call-conduit differential.createcomment --
+```
+
+Check for an existing build first (`harbormaster.buildable.search` constrained on the revision PHID, then `harbormaster.build.search` on the buildable), or use the `phabricator_buildable_search` MCP tool.
+
+### Step 5: Report back to the user
+
+Output a single summary listing, per branch:
+- The revision URL.
+- Whether merge conflicts were resolved on that branch (and trivial vs. non-trivial), or whether it chained cleanly from a resolved predecessor.
+- Any branch that was skipped or aborted, and why.
+
+## Notes
+
+- The script keeps the original reviewers by default. Pass `-r "<names>"` only if the user asks for a different list.
+- `master` is silently skipped if passed as a branch — that's expected.
+- Do **not** pass `-n` (preview mode) unless the user explicitly asks for a dry run; the command is meant to actually publish revisions.
+- Do **not** run a manual `arc diff --update` against a backport revision as part of this workflow. If you ever must, it needs `-m "msg"` and `--base 'git:<parent-sha>'` (otherwise arc computes the base against `master` and the diff balloons to every master↔release difference), and `--verbatim` is incompatible with `--update`.
+- Landing these revisions is a separate step and is **not** part of this command. Don't `arc land` without being asked.


### PR DESCRIPTION
## Summary

The `/backport-commit` command only documented the GitHub-PR backport path (`.agents/scripts/backport-commit.sh`). Changes that landed through Phorge/arc are backported with `backport.sh`, which publishes arc revisions instead — and a backport should go through the same review system the original went through. Pointing `/backport-commit` at a Phorge-landed commit silently produced a backport in the wrong system.

Per review feedback, the Phorge path is a **separate command** rather than a second workflow inside `/backport-commit`: the two files share no content, so once YugabyteDB finishes moving to GitHub PRs, the cleanup is deleting `backport-diff.md` as a whole.

**`.claude/commands/backport-commit.md`** stays GitHub-only. The only addition is a stop-and-redirect: if the argument is a `Dxxxxx` revision ID or the commit body carries a `Differential Revision:` line, use `/backport-diff`; if neither pattern matches cleanly, ask the user rather than guessing.

**`.claude/commands/backport-diff.md`** (new) documents the arc path end to end:

- The `EDITOR=true GIT_EDITOR=true … </dev/null` invocation, with each part explained — without it `arc diff` opens an editor and the run hangs, and the script's `read -p` fallbacks hang instead of failing fast.
- Exit `2` disambiguated: the script uses it for both a dirty workspace and a merge conflict.
- The `-x <branch>` rerun, and the fact that task branches already carrying a `Differential Revision:` line are skipped, so reruns don't create duplicate revisions.
- Merge-conflict notes go into the commit message's Summary section rather than a post-hoc comment: the script's `git commit --amend` carries them into the published revision summary, and there's no safe Phorge equivalent of the GitHub body patch. They have to sit above the `Reviewers:`/`Subscribers:` trailers — free text after `Subscribers:` makes `arc diff` prompt.
- CI: creating a revision auto-fires Harbormaster, and a `trigger jenkins` comment dedups per diff-version, so posting one is a no-op unless the revision has no build at all.

Conflict classification, the lint gate, and reporting are deliberately duplicated in the new file rather than cross-referenced, to keep it independently deletable. In the shared conflict-resolution step, `lint.sh` is called with `--rev origin/<release-branch>`: a backport task branch has no `@{upstream}`, so the base would otherwise be inferred rather than pinned.

`backport.sh` is an internal tool and is not shipped in this repo; the new command's prerequisites say to stop rather than silently fall back to the GitHub path if it isn't on `PATH`.

## Test plan

- [x] Documentation-only change under `.claude/`; no product code or runtime behavior is affected.
- [x] Verified every documented interface against the actual tools rather than from memory: `backport.sh` flags (`-x`, `-r`, `-n`), both exit-`2` paths, the `.git/MERGE_MSG` rewrite that strips the stale `Differential Revision:` line, and the skip of task branches that already carry one; and `build-support/lint.py`'s `--rev` handling for branches with no `@{upstream}`.
- [ ] Not exercised end to end — running it would publish real backport revisions. The next real Phorge backport is the first live run.
