### PR TITLE
[#33252] DocDB: Reduce lock contention in LongOperationTracker

### DIFF
--- a/src/yb/util/debug-util-test.cc
+++ b/src/yb/util/debug-util-test.cc
@@ -469,6 +469,16 @@ class TestLogSink : public google::LogSink {
     return result;
   }
 
+  std::string FirstMessageContaining(const std::string& substring) {
+    std::lock_guard lock(mutex_);
+    for (const auto& message : log_messages_) {
+      if (message.find(substring) != std::string::npos) {
+        return message;
+      }
+    }
+    return std::string();
+  }
+
  private:
   std::mutex mutex_;
   std::vector<std::string> log_messages_;
@@ -543,9 +553,17 @@ TEST_F(DebugUtilTest, LongOperationTrackerStress) {
 }
 
 // Verifies that the checker thread keeps detecting overdue operations while registration
-// traffic is running, guarding against the checker thread being starved by continuous
-// registrations. Also verifies that operations completing before their deadline are not
-// reported and that moving a tracker does not produce duplicate warnings.
+// traffic is running, and that operations completing before their deadline are not reported.
+// A synchronous burst larger than the checker's per-iteration drain bound guarantees that the
+// bounded-drain path runs repeatedly while the overdue operations are pending. A genuine
+// indefinite overload, with producers outpacing the checker forever, cannot be reproduced
+// deterministically, so this test exercises the bounded-drain code path rather than proving
+// starvation freedom.
+//
+// Also verifies that move construction and move assignment clear the moved-from tracker: the
+// moved-from trackers are destroyed after the deadline has passed, so a stale reference left
+// behind by either move would produce an extra "took a long time" warning and fail the exact
+// count checks below.
 TEST_F(DebugUtilTest, LongOperationTrackerUnderLoad) {
 #ifndef NDEBUG
   const auto kTimeMultiplier = RegularBuildVsSanitizers(3, 10);
@@ -553,10 +571,12 @@ TEST_F(DebugUtilTest, LongOperationTrackerUnderLoad) {
   const auto kTimeMultiplier = 1;
 #endif
 
-  const auto kSentinelDuration = 100ms * kTimeMultiplier;
+  const auto kOverdueDuration = 100ms * kTimeMultiplier;
   // Long enough that traffic operations never expire, even on heavily loaded test hosts.
   const auto kTrafficDuration = 60s;
   constexpr int kNumThreads = 8;
+  // Significantly more than the checker's drain bound of 1000 registrations per iteration.
+  constexpr int kBurstSize = 50000;
 
   TestLogSink log_sink;
   google::AddLogSink(&log_sink);
@@ -569,36 +589,55 @@ TEST_F(DebugUtilTest, LongOperationTrackerUnderLoad) {
     thread_holder.AddThreadFunctor([&stop = thread_holder.stop_flag(), kTrafficDuration] {
       while (!stop.load(std::memory_order_acquire)) {
         LongOperationTracker tracker("TrafficOp", kTrafficDuration);
-        std::this_thread::sleep_for(100us);
+        std::this_thread::sleep_for(10us);
       }
     });
   }
 
   {
-    LongOperationTracker sentinel("SentinelOp", kSentinelDuration);
-    // Cover clearing of the move source: a stale reference left behind by either move would
-    // produce an extra "took a long time" warning, failing the exact count check below.
-    LongOperationTracker moved(std::move(sentinel));
-    sentinel = std::move(moved);
+    LongOperationTracker move_ctor_source("MoveCtorOp", kOverdueDuration);
+    LongOperationTracker move_ctor_target(std::move(move_ctor_source));
 
-    // The checker thread must report the overdue sentinel while traffic is still running.
+    LongOperationTracker move_assign_source("MoveAssignOp", kOverdueDuration);
+    LongOperationTracker move_assign_target;
+    move_assign_target = std::move(move_assign_source);
+
+    for (int i = 0; i != kBurstSize; ++i) {
+      LongOperationTracker tracker("TrafficOp", kTrafficDuration);
+    }
+
+    // The checker thread must report both overdue operations while traffic is still running.
     const auto deadline = CoarseMonoClock::now() + 10s * kTimeMultiplier;
-    while (!IsSanitizer() && log_sink.CountMessagesContaining("SentinelOp") == 0) {
+    while (!IsSanitizer() &&
+           (log_sink.CountMessagesContaining("MoveCtorOp") == 0 ||
+            log_sink.CountMessagesContaining("MoveAssignOp") == 0)) {
       ASSERT_LT(CoarseMonoClock::now(), deadline)
-          << "Timed out waiting for the sentinel operation warning";
+          << "Timed out waiting for the overdue operation warnings";
       std::this_thread::sleep_for(10ms);
     }
+    // All four trackers are destroyed here, after the deadline has passed. Only the two
+    // targets hold operations, so exactly one destructor warning per operation is expected.
   }
 
   thread_holder.Stop();
 
   if (IsSanitizer()) {
-    ASSERT_EQ(log_sink.CountMessagesContaining("SentinelOp"), 0);
+    ASSERT_EQ(log_sink.CountMessagesContaining("MoveCtorOp"), 0);
+    ASSERT_EQ(log_sink.CountMessagesContaining("MoveAssignOp"), 0);
     ASSERT_EQ(log_sink.CountMessagesContaining("TrafficOp"), 0);
   } else {
-    // Exactly two warnings for the sentinel: the stack trace warning from the checker thread
-    // and the "took a long time" warning from the destructor.
-    ASSERT_EQ(log_sink.CountMessagesContaining("SentinelOp"), 2);
+    for (const auto* operation : {"MoveCtorOp", "MoveAssignOp"}) {
+      // Exactly two warnings per overdue operation: the stack trace warning from the checker
+      // thread and the "took a long time" warning from the destructor of the move target.
+      ASSERT_EQ(log_sink.CountMessagesContaining(std::string(operation) + " running for"), 1)
+          << operation;
+      ASSERT_EQ(log_sink.CountMessagesContaining(std::string(operation) + " took a long time"), 1)
+          << operation;
+      ASSERT_EQ(log_sink.CountMessagesContaining(operation), 2) << operation;
+      // The checker thread warning identifies the thread that registered the operation.
+      ASSERT_STR_CONTAINS(
+          log_sink.FirstMessageContaining(std::string(operation) + " running for"), "in thread");
+    }
     // Operations that completed before their deadline must not be reported.
     ASSERT_EQ(log_sink.CountMessagesContaining("TrafficOp"), 0);
   }

--- a/src/yb/util/debug-util-test.cc
+++ b/src/yb/util/debug-util-test.cc
@@ -438,32 +438,43 @@ TEST_F(DebugUtilTest, TestStackTraceSignalDuringAllocation) {
   }
 }
 
+class TestLogSink : public google::LogSink {
+ public:
+  void send(google::LogSeverity severity, const char* full_filename,
+            const char* base_filename, int line,
+            const struct ::tm* tm_time,
+            const char* message, size_t message_len) override {
+    std::lock_guard lock(mutex_);
+    log_messages_.emplace_back(message, message_len);
+  }
+
+  size_t MessagesSize() {
+    std::lock_guard lock(mutex_);
+    return log_messages_.size();
+  }
+
+  std::string MessageAt(size_t idx) {
+    std::lock_guard lock(mutex_);
+    return log_messages_[idx];
+  }
+
+  size_t CountMessagesContaining(const std::string& substring) {
+    std::lock_guard lock(mutex_);
+    size_t result = 0;
+    for (const auto& message : log_messages_) {
+      if (message.find(substring) != std::string::npos) {
+        ++result;
+      }
+    }
+    return result;
+  }
+
+ private:
+  std::mutex mutex_;
+  std::vector<std::string> log_messages_;
+};
+
 TEST_F(DebugUtilTest, LongOperationTracker) {
-  class TestLogSink : public google::LogSink {
-   public:
-    void send(google::LogSeverity severity, const char* full_filename,
-              const char* base_filename, int line,
-              const struct ::tm* tm_time,
-              const char* message, size_t message_len) override {
-      std::lock_guard lock(mutex_);
-      log_messages_.emplace_back(message, message_len);
-    }
-
-    size_t MessagesSize() {
-      std::lock_guard lock(mutex_);
-      return log_messages_.size();
-    }
-
-    std::string MessageAt(size_t idx) {
-      std::lock_guard lock(mutex_);
-      return log_messages_[idx];
-    }
-
-   private:
-    std::mutex mutex_;
-    std::vector<std::string> log_messages_;
-  };
-
 #ifndef NDEBUG
   const auto kTimeMultiplier = RegularBuildVsSanitizers(3, 10);
 #else
@@ -529,6 +540,68 @@ TEST_F(DebugUtilTest, LongOperationTrackerStress) {
     });
   }
   thread_holder.WaitAndStop(kRunTime);
+}
+
+// Verifies that the checker thread keeps detecting overdue operations while registration
+// traffic is running, guarding against the checker thread being starved by continuous
+// registrations. Also verifies that operations completing before their deadline are not
+// reported and that moving a tracker does not produce duplicate warnings.
+TEST_F(DebugUtilTest, LongOperationTrackerUnderLoad) {
+#ifndef NDEBUG
+  const auto kTimeMultiplier = RegularBuildVsSanitizers(3, 10);
+#else
+  const auto kTimeMultiplier = 1;
+#endif
+
+  const auto kSentinelDuration = 100ms * kTimeMultiplier;
+  // Long enough that traffic operations never expire, even on heavily loaded test hosts.
+  const auto kTrafficDuration = 60s;
+  constexpr int kNumThreads = 8;
+
+  TestLogSink log_sink;
+  google::AddLogSink(&log_sink);
+  auto se = ScopeExit([&log_sink] {
+    google::RemoveLogSink(&log_sink);
+  });
+
+  TestThreadHolder thread_holder;
+  for (int i = 0; i != kNumThreads; ++i) {
+    thread_holder.AddThreadFunctor([&stop = thread_holder.stop_flag(), kTrafficDuration] {
+      while (!stop.load(std::memory_order_acquire)) {
+        LongOperationTracker tracker("TrafficOp", kTrafficDuration);
+        std::this_thread::sleep_for(100us);
+      }
+    });
+  }
+
+  {
+    LongOperationTracker sentinel("SentinelOp", kSentinelDuration);
+    // Cover clearing of the move source: a stale reference left behind by either move would
+    // produce an extra "took a long time" warning, failing the exact count check below.
+    LongOperationTracker moved(std::move(sentinel));
+    sentinel = std::move(moved);
+
+    // The checker thread must report the overdue sentinel while traffic is still running.
+    const auto deadline = CoarseMonoClock::now() + 10s * kTimeMultiplier;
+    while (!IsSanitizer() && log_sink.CountMessagesContaining("SentinelOp") == 0) {
+      ASSERT_LT(CoarseMonoClock::now(), deadline)
+          << "Timed out waiting for the sentinel operation warning";
+      std::this_thread::sleep_for(10ms);
+    }
+  }
+
+  thread_holder.Stop();
+
+  if (IsSanitizer()) {
+    ASSERT_EQ(log_sink.CountMessagesContaining("SentinelOp"), 0);
+    ASSERT_EQ(log_sink.CountMessagesContaining("TrafficOp"), 0);
+  } else {
+    // Exactly two warnings for the sentinel: the stack trace warning from the checker thread
+    // and the "took a long time" warning from the destructor.
+    ASSERT_EQ(log_sink.CountMessagesContaining("SentinelOp"), 2);
+    // Operations that completed before their deadline must not be reported.
+    ASSERT_EQ(log_sink.CountMessagesContaining("TrafficOp"), 0);
+  }
 }
 
 TEST_F(DebugUtilTest, YB_DISABLE_TEST_ON_MACOS(TestGetStackTraceWhileCreatingThreads)) {

--- a/src/yb/util/debug-util-test.cc
+++ b/src/yb/util/debug-util-test.cc
@@ -506,6 +506,31 @@ TEST_F(DebugUtilTest, LongOperationTracker) {
   }
 }
 
+// Stress concurrent registration and completion of tracked operations to exercise the
+// lock-free intake path of LongOperationTrackerHelper and reference transfer to the checker
+// thread.
+TEST_F(DebugUtilTest, LongOperationTrackerStress) {
+  constexpr int kNumThreads = 8;
+  const auto kRunTime = 3s;
+  // Deadline long enough that operations normally complete in time, short enough that the
+  // checker thread pops expired entries while the test is running.
+  const auto kDeadline = 500ms;
+
+  TestThreadHolder thread_holder;
+  for (int i = 0; i != kNumThreads; ++i) {
+    thread_holder.AddThreadFunctor([&stop = thread_holder.stop_flag(), kDeadline] {
+      while (!stop.load(std::memory_order_acquire)) {
+        LongOperationTracker tracker("StressOp", kDeadline);
+        // Cover move construction and move assignment while the operation is registered.
+        LongOperationTracker moved(std::move(tracker));
+        tracker = std::move(moved);
+        std::this_thread::sleep_for(100us);
+      }
+    });
+  }
+  thread_holder.WaitAndStop(kRunTime);
+}
+
 TEST_F(DebugUtilTest, YB_DISABLE_TEST_ON_MACOS(TestGetStackTraceWhileCreatingThreads)) {
   // This test makes sure we can collect stack traces while threads are being created.
   // We create 10 threads that create threads in a loop. Then we create 100 threads that collect

--- a/src/yb/util/debug/long_operation_tracker.cc
+++ b/src/yb/util/debug/long_operation_tracker.cc
@@ -63,7 +63,7 @@ struct TrackedOperationComparer {
 // registered operation is noticed within this interval, so a warning could be logged at most
 // this much later than the operation deadline. Since tracked durations are typically much
 // larger than this bound, the delay is not observable in practice.
-constexpr std::chrono::milliseconds kMaxWaitTime(100);
+constexpr auto kMaxWaitTime = std::chrono::milliseconds(100);
 
 // Deadlines below this threshold cannot rely on the periodic scan alone: the operation could
 // expire and complete entirely within one kMaxWaitTime sleep, losing the stack trace warning.

--- a/src/yb/util/debug/long_operation_tracker.cc
+++ b/src/yb/util/debug/long_operation_tracker.cc
@@ -13,25 +13,32 @@
 
 #include "yb/util/debug/long_operation_tracker.h"
 
+#include <algorithm>
 #include <condition_variable>
 #include <mutex>
 #include <queue>
-#include <thread>
+#include <vector>
 
 #include "yb/util/debug-util.h"
+#include "yb/util/lockfree.h"
 #include "yb/util/status_log.h"
 #include "yb/util/thread.h"
 #include "yb/util/tsan_util.h"
 
 namespace yb {
 
-struct LongOperationTracker::TrackedOperation {
+// While an operation is running, one reference is held by the LongOperationTracker returned to
+// the caller and one is transferred through LongOperationTrackerHelper's lock-free intake queue
+// to the checker thread. So HasOneRef() held by the checker thread means the operation has
+// completed.
+struct LongOperationTracker::TrackedOperation :
+    public RefCountedThreadSafe<LongOperationTracker::TrackedOperation>,
+    public MPSCQueueEntry<LongOperationTracker::TrackedOperation> {
   ThreadIdForStack thread_id;
   const char* message;
   CoarseTimePoint start;
   // time when we should log warning
   CoarseTimePoint time;
-  bool complete = false;
 
   TrackedOperation(
       ThreadIdForStack thread_id_, const char* message_, CoarseTimePoint start_,
@@ -42,7 +49,7 @@ struct LongOperationTracker::TrackedOperation {
 
 namespace {
 
-typedef std::shared_ptr<LongOperationTracker::TrackedOperation> TrackedOperationPtr;
+typedef scoped_refptr<LongOperationTracker::TrackedOperation> TrackedOperationPtr;
 
 struct TrackedOperationComparer {
   // Order is reversed, because priority_queue keeps track of the "largest" element.
@@ -51,8 +58,20 @@ struct TrackedOperationComparer {
   }
 };
 
+// Upper bound on how long the checker thread sleeps between scans of the intake queue. A newly
+// registered operation is noticed within this interval, so a warning could be logged at most
+// this much later than the operation deadline. Since tracked durations are much larger than
+// this bound, the delay is not observable in practice.
+constexpr std::chrono::milliseconds kMaxWaitTime(100);
+
 // Singleton that maintains queue of tracked operation and runs thread that checks for expired
 // operations.
+//
+// Synchronization strategy: operations are registered through the lock-free intake_ queue, so
+// registration does not contend on any mutex. The checker thread is the only consumer of
+// intake_ and exclusively owns the priority queue of pending operations (local to Execute).
+// mutex_ and cond_ protect only stop_ and are used only by the checker thread and the
+// destructor.
 class LongOperationTrackerHelper {
  public:
   LongOperationTrackerHelper() {
@@ -72,6 +91,9 @@ class LongOperationTrackerHelper {
     if (thread_) {
       thread_->Join();
     }
+    // Release references of operations that were registered after the checker thread performed
+    // its final drain.
+    ReleaseIntakeRefs();
   }
 
   static LongOperationTrackerHelper& Instance() {
@@ -84,64 +106,94 @@ class LongOperationTrackerHelper {
       return TrackedOperationPtr();
     }
     auto start = CoarseMonoClock::now();
-    auto result = std::make_shared<LongOperationTracker::TrackedOperation>(
-        Thread::CurrentThreadIdForStack(), message, start, start + duration * kTimeMultiplier);
-    {
-      std::lock_guard lock(mutex_);
-      queue_.push(result);
-    }
-
-    cond_.notify_one();
-
+    TrackedOperationPtr result(new LongOperationTracker::TrackedOperation(
+        Thread::CurrentThreadIdForStack(), message, start, start + duration * kTimeMultiplier));
+    // Transfer one reference through the intake queue as a raw pointer, keeping registration
+    // lock-free. The checker thread adopts it back into a TrackedOperationPtr.
+    result->AddRef();
+    intake_.Push(result.get());
     return result;
   }
 
  private:
-  void Execute() {
-    std::unique_lock<std::mutex> lock(mutex_);
-    while (!stop_) {
-      if (queue_.empty()) {
-        cond_.wait(lock);
-        continue;
-      }
+  // Wraps a raw pointer popped from intake_ back into a TrackedOperationPtr, dropping the extra
+  // reference that was added in Register.
+  static TrackedOperationPtr AdoptIntakeRef(LongOperationTracker::TrackedOperation* operation) {
+    TrackedOperationPtr result(operation);
+    operation->Release();
+    return result;
+  }
 
-      const CoarseTimePoint first_entry_time = queue_.top()->time;
-
-      auto now = CoarseMonoClock::now();
-      if (now < first_entry_time) {
-        if (cond_.wait_for(lock, first_entry_time - now) != std::cv_status::timeout) {
-          continue;
-        }
-        now = CoarseMonoClock::now();
-      }
-
-      TrackedOperationPtr operation = queue_.top();
-      queue_.pop();
-      if (operation.use_count() > 1) {
-        lock.unlock();
-        auto stack = DumpThreadStack(operation->thread_id);
-        // Make sure the task did not complete while we were dumping the stack. Else we could get
-        // some other innocent stack.
-        if (operation.use_count() > 1) {
-          LOG(WARNING) << operation->message << " running for " << MonoDelta(now - operation->start)
-                       << " in thread " << operation->thread_id << ":\n"
-                       << stack;
-        }
-        lock.lock();
-      }
+  void ReleaseIntakeRefs() {
+    while (auto* operation = intake_.Pop()) {
+      operation->Release();
     }
   }
 
-  std::priority_queue<
-      TrackedOperationPtr, std::vector<TrackedOperationPtr>, TrackedOperationComparer> queue_;
+  void Execute() {
+    // Owned exclusively by this thread, so no synchronization is needed.
+    std::priority_queue<
+        TrackedOperationPtr, std::vector<TrackedOperationPtr>, TrackedOperationComparer> queue;
 
+    for (;;) {
+      while (auto* operation = intake_.Pop()) {
+        queue.push(AdoptIntakeRef(operation));
+      }
+
+      for (;;) {
+        auto now = CoarseMonoClock::now();
+        if (queue.empty() || queue.top()->time > now) {
+          break;
+        }
+        TrackedOperationPtr operation = queue.top();
+        queue.pop();
+        // If we hold the last reference, then the operation has already completed.
+        if (!operation->HasOneRef()) {
+          auto stack = DumpThreadStack(operation->thread_id);
+          // Make sure the task did not complete while we were dumping the stack. Else we could
+          // get some other innocent stack.
+          if (!operation->HasOneRef()) {
+            LOG(WARNING) << operation->message << " running for "
+                         << MonoDelta(now - operation->start)
+                         << " in thread " << operation->thread_id << ":\n" << stack;
+          }
+        }
+      }
+
+      CoarseDuration wait_time = kMaxWaitTime;
+      if (!queue.empty()) {
+        wait_time = std::min<CoarseDuration>(
+            wait_time, queue.top()->time - CoarseMonoClock::now());
+      }
+
+      {
+        std::unique_lock<std::mutex> lock(mutex_);
+        if (stop_) {
+          break;
+        }
+        cond_.wait_for(lock, wait_time);
+        if (stop_) {
+          break;
+        }
+      }
+    }
+
+    // References held by queue are released by its destructor.
+    ReleaseIntakeRefs();
+  }
+
+  MPSCQueue<LongOperationTracker::TrackedOperation> intake_;
+
+  // Protects only stop_, see the synchronization strategy in the class comment.
   std::mutex mutex_;
   std::condition_variable cond_;
-  bool stop_;
+  bool stop_ = false;
   scoped_refptr<Thread> thread_;
 };
 
 } // namespace
+
+LongOperationTracker::LongOperationTracker() = default;
 
 LongOperationTracker::LongOperationTracker(const char* message, MonoDelta duration)
     : tracked_operation_(LongOperationTrackerHelper::Instance().Register(message, duration)) {
@@ -156,6 +208,18 @@ LongOperationTracker::~LongOperationTracker() {
     LOG(WARNING) << tracked_operation_->message << " took a long time: "
                  << MonoDelta(now - tracked_operation_->start);
   }
+}
+
+LongOperationTracker::LongOperationTracker(LongOperationTracker&& rhs) = default;
+
+LongOperationTracker& LongOperationTracker::operator=(LongOperationTracker&& rhs) {
+  if (this != &rhs) {
+    // scoped_refptr move assignment does not clear the source, so move through a temporary that
+    // steals rhs's pointer, then let it release our previous operation.
+    scoped_refptr<TrackedOperation> temp(std::move(rhs.tracked_operation_));
+    tracked_operation_.swap(temp);
+  }
+  return *this;
 }
 
 void LongOperationTracker::Swap(LongOperationTracker* rhs) {

--- a/src/yb/util/debug/long_operation_tracker.cc
+++ b/src/yb/util/debug/long_operation_tracker.cc
@@ -67,7 +67,7 @@ constexpr std::chrono::milliseconds kMaxWaitTime(100);
 
 // Deadlines below this threshold cannot rely on the periodic scan alone: the operation could
 // expire and complete entirely within one kMaxWaitTime sleep, losing the stack trace warning.
-// Registration of such operations additionally wakes the checker thread.
+// Registration of such operations additionally records a wakeup for the checker thread.
 constexpr auto kShortDeadlineThreshold = 2 * kMaxWaitTime;
 
 // Upper bound on the number of registrations adopted from the intake queue in one iteration of
@@ -79,10 +79,11 @@ constexpr size_t kMaxDrainPerIteration = 1000;
 // operations.
 //
 // Synchronization strategy: operations are registered through the lock-free intake_ queue, so
-// registration does not contend on any mutex. The checker thread is the only consumer of
-// intake_ and exclusively owns the priority queue of pending operations (local to Execute).
-// mutex_ and cond_ protect only stop_ and are used only by the checker thread and the
-// destructor.
+// typical registrations do not contend on any mutex. The checker thread is the only consumer
+// of intake_ and exclusively owns the priority queue of pending operations (local to Execute).
+// mutex_ and cond_ are used to sleep in and wake up the checker thread: the destructor and
+// registrations with unusually short deadlines record their wakeup condition under the mutex
+// before notifying, so wakeups cannot be lost.
 class LongOperationTrackerHelper {
  public:
   LongOperationTrackerHelper() {
@@ -127,9 +128,13 @@ class LongOperationTrackerHelper {
     result->AddRef();
     intake_.Push(result.get());
     if (deadline - start < kShortDeadlineThreshold) {
-      // The periodic scan is not frequent enough for this deadline, wake the checker thread.
-      // This is best effort: a wakeup that races with the start of a scan could be missed, in
-      // which case the periodic scan is still the backstop.
+      // The periodic scan is not frequent enough for this deadline. Record the wakeup under
+      // the mutex so that it cannot be lost, then wake the checker thread. Only these unusually
+      // short deadlines pay for the mutex.
+      {
+        std::lock_guard lock(mutex_);
+        short_deadline_pending_ = true;
+      }
       cond_.notify_one();
     }
     return result;
@@ -204,7 +209,10 @@ class LongOperationTrackerHelper {
         if (stop_.load(std::memory_order_acquire)) {
           break;
         }
-        cond_.wait_for(lock, wait_time);
+        cond_.wait_for(lock, wait_time, [this] {
+          return stop_.load(std::memory_order_acquire) || short_deadline_pending_;
+        });
+        short_deadline_pending_ = false;
       }
     }
 
@@ -214,11 +222,13 @@ class LongOperationTrackerHelper {
 
   MPSCQueue<LongOperationTracker::TrackedOperation> intake_;
 
-  // Used only to sleep in and wake up the checker thread, see the synchronization strategy in
-  // the class comment. stop_ is atomic so that the checker loops can poll it without the mutex.
+  // Used to sleep in and wake up the checker thread, see the synchronization strategy in the
+  // class comment. stop_ is atomic so that the checker loops can poll it without the mutex.
+  // short_deadline_pending_ is guarded by mutex_ so that short deadline wakeups cannot be lost.
   std::mutex mutex_;
   std::condition_variable cond_;
   std::atomic<bool> stop_{false};
+  bool short_deadline_pending_ = false;
   scoped_refptr<Thread> thread_;
 };
 

--- a/src/yb/util/debug/long_operation_tracker.cc
+++ b/src/yb/util/debug/long_operation_tracker.cc
@@ -14,6 +14,7 @@
 #include "yb/util/debug/long_operation_tracker.h"
 
 #include <algorithm>
+#include <atomic>
 #include <condition_variable>
 #include <mutex>
 #include <queue>
@@ -60,9 +61,19 @@ struct TrackedOperationComparer {
 
 // Upper bound on how long the checker thread sleeps between scans of the intake queue. A newly
 // registered operation is noticed within this interval, so a warning could be logged at most
-// this much later than the operation deadline. Since tracked durations are much larger than
-// this bound, the delay is not observable in practice.
+// this much later than the operation deadline. Since tracked durations are typically much
+// larger than this bound, the delay is not observable in practice.
 constexpr std::chrono::milliseconds kMaxWaitTime(100);
+
+// Deadlines below this threshold cannot rely on the periodic scan alone: the operation could
+// expire and complete entirely within one kMaxWaitTime sleep, losing the stack trace warning.
+// Registration of such operations additionally wakes the checker thread.
+constexpr auto kShortDeadlineThreshold = 2 * kMaxWaitTime;
+
+// Upper bound on the number of registrations adopted from the intake queue in one iteration of
+// the checker loop, so that expired operations and stop_ are still checked periodically while
+// producers are registering at a high rate.
+constexpr size_t kMaxDrainPerIteration = 1000;
 
 // Singleton that maintains queue of tracked operation and runs thread that checks for expired
 // operations.
@@ -84,8 +95,10 @@ class LongOperationTrackerHelper {
 
   ~LongOperationTrackerHelper() {
     {
+      // The lock prevents a lost wakeup: the checker thread cannot be between its stop_ check
+      // and cond_.wait_for while we hold the mutex.
       std::lock_guard lock(mutex_);
-      stop_ = true;
+      stop_.store(true, std::memory_order_release);
     }
     cond_.notify_one();
     if (thread_) {
@@ -106,12 +119,19 @@ class LongOperationTrackerHelper {
       return TrackedOperationPtr();
     }
     auto start = CoarseMonoClock::now();
+    const CoarseTimePoint deadline = start + duration * kTimeMultiplier;
     TrackedOperationPtr result(new LongOperationTracker::TrackedOperation(
-        Thread::CurrentThreadIdForStack(), message, start, start + duration * kTimeMultiplier));
+        Thread::CurrentThreadIdForStack(), message, start, deadline));
     // Transfer one reference through the intake queue as a raw pointer, keeping registration
     // lock-free. The checker thread adopts it back into a TrackedOperationPtr.
     result->AddRef();
     intake_.Push(result.get());
+    if (deadline - start < kShortDeadlineThreshold) {
+      // The periodic scan is not frequent enough for this deadline, wake the checker thread.
+      // This is best effort: a wakeup that races with the start of a scan could be missed, in
+      // which case the periodic scan is still the backstop.
+      cond_.notify_one();
+    }
     return result;
   }
 
@@ -135,12 +155,20 @@ class LongOperationTrackerHelper {
     std::priority_queue<
         TrackedOperationPtr, std::vector<TrackedOperationPtr>, TrackedOperationComparer> queue;
 
-    for (;;) {
-      while (auto* operation = intake_.Pop()) {
+    while (!stop_.load(std::memory_order_acquire)) {
+      // Adopt a bounded number of registrations, so that this loop terminates even when
+      // producers are registering operations faster than we drain them.
+      size_t drained = 0;
+      while (drained < kMaxDrainPerIteration) {
+        auto* operation = intake_.Pop();
+        if (!operation) {
+          break;
+        }
         queue.push(AdoptIntakeRef(operation));
+        ++drained;
       }
 
-      for (;;) {
+      while (!stop_.load(std::memory_order_acquire)) {
         auto now = CoarseMonoClock::now();
         if (queue.empty() || queue.top()->time > now) {
           break;
@@ -160,6 +188,11 @@ class LongOperationTrackerHelper {
         }
       }
 
+      if (drained == kMaxDrainPerIteration) {
+        // The intake queue could have more pending registrations, process them before sleeping.
+        continue;
+      }
+
       CoarseDuration wait_time = kMaxWaitTime;
       if (!queue.empty()) {
         wait_time = std::min<CoarseDuration>(
@@ -168,13 +201,10 @@ class LongOperationTrackerHelper {
 
       {
         std::unique_lock<std::mutex> lock(mutex_);
-        if (stop_) {
+        if (stop_.load(std::memory_order_acquire)) {
           break;
         }
         cond_.wait_for(lock, wait_time);
-        if (stop_) {
-          break;
-        }
       }
     }
 
@@ -184,10 +214,11 @@ class LongOperationTrackerHelper {
 
   MPSCQueue<LongOperationTracker::TrackedOperation> intake_;
 
-  // Protects only stop_, see the synchronization strategy in the class comment.
+  // Used only to sleep in and wake up the checker thread, see the synchronization strategy in
+  // the class comment. stop_ is atomic so that the checker loops can poll it without the mutex.
   std::mutex mutex_;
   std::condition_variable cond_;
-  bool stop_ = false;
+  std::atomic<bool> stop_{false};
   scoped_refptr<Thread> thread_;
 };
 

--- a/src/yb/util/debug/long_operation_tracker.h
+++ b/src/yb/util/debug/long_operation_tracker.h
@@ -13,8 +13,9 @@
 
 #pragma once
 
-#include <memory>
 #include <mutex>
+
+#include "yb/gutil/ref_counted.h"
 
 #include "yb/util/monotime.h"
 
@@ -25,22 +26,23 @@ namespace yb {
 // Warning contains stack trace of thread that created this tracker.
 class LongOperationTracker {
  public:
-  LongOperationTracker() = default;
   LongOperationTracker(const char* message, MonoDelta duration);
-  ~LongOperationTracker();
 
   LongOperationTracker(const LongOperationTracker&) = delete;
   void operator=(const LongOperationTracker&) = delete;
 
-  LongOperationTracker(LongOperationTracker&&) = default;
-  LongOperationTracker& operator=(LongOperationTracker&&) = default;
+  // Defined out-of-line because they require a complete TrackedOperation type.
+  LongOperationTracker();
+  ~LongOperationTracker();
+  LongOperationTracker(LongOperationTracker&& rhs);
+  LongOperationTracker& operator=(LongOperationTracker&& rhs);
 
   void Swap(LongOperationTracker* rhs);
 
   struct TrackedOperation;
 
  private:
-  std::shared_ptr<TrackedOperation> tracked_operation_;
+  scoped_refptr<TrackedOperation> tracked_operation_;
 };
 
 

--- a/src/yb/util/debug/long_operation_tracker.h
+++ b/src/yb/util/debug/long_operation_tracker.h
@@ -24,6 +24,12 @@ namespace yb {
 // Tracks long running operation.
 // If it does not complete within specified duration warning is added to log.
 // Warning contains stack trace of thread that created this tracker.
+//
+// Registration is lock-free: a background checker thread notices new operations within 100ms,
+// so a warning can be logged up to 100ms after the operation deadline. Registering an
+// operation with a duration shorter than 200ms additionally wakes the checker thread, so that
+// the stack trace warning is not missed if such an operation both expires and completes
+// between two scans.
 class LongOperationTracker {
  public:
   LongOperationTracker(const char* message, MonoDelta duration);

--- a/src/yb/util/debug/long_operation_tracker.h
+++ b/src/yb/util/debug/long_operation_tracker.h
@@ -25,11 +25,13 @@ namespace yb {
 // If it does not complete within specified duration warning is added to log.
 // Warning contains stack trace of thread that created this tracker.
 //
-// Registration is lock-free: a background checker thread notices new operations within 100ms,
-// so a warning can be logged up to 100ms after the operation deadline. Registering an
-// operation with a duration shorter than 200ms additionally wakes the checker thread, so that
-// the stack trace warning is not missed if such an operation both expires and completes
-// between two scans.
+// Registration is lock-free for typical durations: a background checker thread picks up new
+// operations when it scans its intake queue, at least every 100ms while it is otherwise idle.
+// A warning is therefore typically logged within 100ms of the operation deadline, though scans
+// can be delayed while the checker thread is dumping stacks of other overdue operations.
+// Registering an operation with a duration shorter than 200ms additionally wakes the checker
+// thread, so that the stack trace warning is not skipped when such an operation expires and
+// completes between two scans.
 class LongOperationTracker {
  public:
   LongOperationTracker(const char* message, MonoDelta duration);


### PR DESCRIPTION
## Summary

Fixes #33252. Initial review in Shopify/yugabyte-db#23.

Every `LongOperationTracker` registration went through a single process-wide mutex in `LongOperationTrackerHelper`: `Register` locked the mutex, pushed into a shared `std::priority_queue`, and issued an unconditional `notify_one` (a futex wake on nearly every registration, since the checker thread is almost always waiting). The woken checker thread immediately re-acquired the same mutex, contending with concurrent registrations. This sits on hot paths: every read query, every Raft `UpdateReplica`, log append, master heartbeat processing, and (in debug builds) every `ScopedRWOperation`.

Make registration lock-free instead:

- Operations are handed to the checker thread through the lock-free `MPSCQueue` from `yb/util/lockfree.h`. Registration is now one allocation plus one CAS, with no mutex and no condvar notify.
- `TrackedOperation` ownership switches from `std::shared_ptr` to intrusive ref-counting (`RefCountedThreadSafe` + `scoped_refptr`) so the queue's raw pointer can carry an owned reference; the `use_count() > 1` completion check becomes `!HasOneRef()`.
- The checker thread drains the intake queue (bounded to 1000 per iteration so deadline processing and shutdown are never starved) into a private, uncontended priority queue and sleeps until the next deadline, capped at 100ms. Reporting is unchanged: each overdue operation still logs its own message, exact elapsed time, and stack trace.
- Deadlines shorter than 200ms (possible via runtime flags such as `master_ts_heartbeat_long_operation_warning_ms`) additionally wake the checker thread through a mutex-protected predicate, so short-deadline warnings cannot be lost; typical (1s+) registrations never touch the mutex.
- Fix `stop_` being uninitialized.

Registration throughput on macOS arm64 (8 threads x 200k registrations): 4.2M/sec before vs 3.7-4.4M/sec after, i.e. parity within run-to-run noise on that platform. The expected production win is eliminating the per-registration futex wake and the mutex convoy between registering threads and the checker thread on Linux; a Linux perf/futex comparison is still to be collected.

## Test plan

- [x] `./yb_build.sh release --cxx-test debug-util-test --gtest_filter DebugUtilTest.LongOperationTracker` (also debug)
- [x] `./yb_build.sh release --cxx-test debug-util-test --gtest_filter DebugUtilTest.LongOperationTrackerStress` (new: concurrent registration/move churn; also debug)
- [x] `./yb_build.sh release --cxx-test debug-util-test --gtest_filter DebugUtilTest.LongOperationTrackerUnderLoad` (new: overdue operations detected under sustained registration traffic and a 50k burst exercising the bounded drain; exact warning counts validate move construction/assignment clearing; also debug, and 10x repeated in release)
- [x] `./yb_build.sh release daemons` (all call sites compile)
- [ ] Linux sanitizer (ASAN/TSAN) runs via CI (`Register` is a no-op under sanitizers, pre-existing; macOS prebuilt thirdparty lacks instrumented libc++ locally)
