### PR TITLE
yugabyted: Drop master addresses that are empty or no longer resolve

### DIFF
--- a/bin/yugabyted
+++ b/bin/yugabyted
@@ -750,6 +750,53 @@ def parse_master_addrs_csv(master_addrs_csv):
         return []
     return [ addr.strip() for addr in master_addrs_csv.split(",") if addr.strip() ]
 
+# Split "host:port", "[::1]:port" or a bare host into (host, port). port is None when absent.
+def split_master_addr(addr):
+    if addr.startswith("["):
+        host, sep, rest = addr[1:].partition("]")
+        if not sep:
+            return addr, None
+        return host, rest[1:] if rest.startswith(":") else None
+    host, sep, port = addr.rpartition(":")
+    if not sep:
+        return addr, None
+    return host, port
+
+def is_resolvable_master_addr(addr):
+    host, _ = split_master_addr(addr)
+    if not host:
+        return False
+    try:
+        socket.getaddrinfo(host, None)
+        return True
+    except socket.gaierror:
+        return False
+    except Exception as err:
+        # Keep the address on anything other than a definite lookup failure: a resolver that
+        # errors out for its own reasons is not evidence that this master is gone.
+        Output.log("Could not check whether master address {} resolves: {}".format(addr, err))
+        return True
+
+# yb-tserver's ResolveMasterAddresses() retries each entry for master_discovery_timeout_ms
+# (1h by default) before failing startup, so a single address that no longer resolves costs an
+# hour of silent hang. yugabyted only ever adds to current_masters, so an address can go stale
+# under it -- a container hostname from a previous run is the common case.
+# Returns (kept, dropped). keep_addr is never dropped, and if nothing resolves the list is left
+# alone: that is a DNS outage rather than a stale entry, and having no address at all is worse.
+def prune_unresolvable_master_addrs(master_addrs, keep_addr=None):
+    kept = []
+    dropped = []
+    for addr in master_addrs:
+        if addr in kept or addr in dropped:
+            continue
+        if addr == keep_addr or is_resolvable_master_addr(addr):
+            kept.append(addr)
+        else:
+            dropped.append(addr)
+    if not kept:
+        return list(master_addrs), []
+    return kept, dropped
+
 class ControlScript(object):
     def __init__(self):
         self.configs = None
@@ -6753,10 +6800,17 @@ class ControlScript(object):
                 master_flag))
             return
 
-        if len(full_master_list) < 3:
-            my_master_ip = "{}:{}".format(get_url_from_ip(self.advertise_ip()),
-                                          self.configs.saved_data.get("master_rpc_port"))
-            full_master_list = list(set(full_master_list + [ my_master_ip ]))
+        my_master_ip = "{}:{}".format(get_url_from_ip(self.advertise_ip()),
+                                      self.configs.saved_data.get("master_rpc_port"))
+
+        full_master_list, stale_masters = prune_unresolvable_master_addrs(
+            full_master_list, my_master_ip)
+        if stale_masters:
+            Output.log("Dropped master addresses that no longer resolve: {}".format(
+                stale_masters))
+
+        if len(full_master_list) < 3 and my_master_ip not in full_master_list:
+            full_master_list.append(my_master_ip)
             Output.log("Got full master addrs list: {}".format(full_master_list))
 
         new_master_flag = "--{}={}".format(TS_MASTER_ADDRS_FLAG, ",".join(full_master_list))

--- a/bin/yugabyted
+++ b/bin/yugabyted
@@ -743,6 +743,13 @@ def get_url_from_ip(ip):
         return "[" + str(ip) + "]"
     return str(ip)
 
+# Split a comma separated list of master addresses, dropping empty entries. "".split(",")
+# returns [""], and a host-less address makes the tserver block in ResolveMasterAddresses().
+def parse_master_addrs_csv(master_addrs_csv):
+    if not master_addrs_csv:
+        return []
+    return [ addr.strip() for addr in master_addrs_csv.split(",") if addr.strip() ]
+
 class ControlScript(object):
     def __init__(self):
         self.configs = None
@@ -6738,7 +6745,8 @@ class ControlScript(object):
     def update_tserver_master_addrs(self):
         tserver_cmd = self.processes["tserver"].cmd
         master_flag = [ flag for flag in tserver_cmd if flag.find(TS_MASTER_ADDRS_FLAG) >= 0 ]
-        full_master_list = self.configs.saved_data.get("current_masters").split(",")
+        full_master_list = parse_master_addrs_csv(
+            self.configs.saved_data.get("current_masters"))
 
         if not full_master_list:
             Output.log("Unable to get all masters list, keeping tserver flag: {}".format(
@@ -6804,8 +6812,15 @@ class ControlScript(object):
         if not master_addrs:
             master_web_addrs_ip = advertise_ip
             master_addrs = self.get_current_masters_from_api(advertise_ip)
-        self.configs.saved_data["current_masters"] = master_addrs
-        Output.log("Master address list updated, new list: {}".format(master_addrs))
+        # Both lookups go through the tserver web server, so they return empty while the
+        # tserver is down. Persisting that would lose the master list for every later start.
+        if master_addrs:
+            self.configs.saved_data["current_masters"] = master_addrs
+            Output.log("Master address list updated, new list: {}".format(master_addrs))
+        else:
+            master_addrs = self.configs.saved_data.get("current_masters")
+            Output.log("Unable to query master address list, keeping known list: {}".format(
+                master_addrs))
 
         master_web_addrs = "{}:{}".format(get_url_from_ip(master_web_addrs_ip),
                                           self.configs.saved_data.get("master_webserver_port"))
@@ -8049,7 +8064,8 @@ class ControlScript(object):
     def update_master_list_on_background_thread(self):
 
         # global _global_current_list_of_masters
-        current_master_list = self.configs.saved_data.get("current_masters").split(",")
+        current_master_list = parse_master_addrs_csv(
+            self.configs.saved_data.get("current_masters"))
         Output.log("thread-uml: current masters {}".format(current_master_list))
 
         # thread for updating the master address list in the background
@@ -8063,10 +8079,11 @@ class ControlScript(object):
                     "keeping masters list: {}".format(current_master_list))
                 return
 
-        full_master_list = masters_csv.split(",")
-        # check if masters have changed since last refresh, if not return
-        if_any_new_masters = set(full_master_list).difference(current_master_list)
-        if if_any_new_masters:
+        full_master_list = parse_master_addrs_csv(masters_csv)
+        # Check if masters have changed since last refresh. Compare both ways so that
+        # addresses which went away are picked up too.
+        if set(full_master_list) != set(current_master_list):
+            masters_csv = ",".join(full_master_list)
             self.configs.saved_data["current_masters"] = masters_csv
             Output.log("thread-uml: master list updated, old list: {} ".format(
                 current_master_list) + "new list: {}".format(full_master_list))
@@ -10626,6 +10643,14 @@ class Configs(object):
             except ValueError as e:
                 Output.log_error_and_exit(
                     "Failed to read config file {}: {}".format(config_file, str(e)))
+            # Older versions could persist a host-less entry here (e.g. ",host:7100"). Drop it
+            # so that such a config recovers on the next start.
+            saved_masters = configs.saved_data.get("current_masters")
+            normalized_masters = ",".join(parse_master_addrs_csv(saved_masters))
+            if normalized_masters != saved_masters:
+                Output.log("Dropped empty master addresses from saved config: {} -> {}".format(
+                    saved_masters, normalized_masters))
+                configs.saved_data["current_masters"] = normalized_masters
 
         configs.saved_data = Configs.expand_path_variables(configs.saved_data)
 

--- a/java/yb-yugabyted/src/test/java/org/yb/minicluster/YugabytedCommands.java
+++ b/java/yb-yugabyted/src/test/java/org/yb/minicluster/YugabytedCommands.java
@@ -1,12 +1,15 @@
 package org.yb.minicluster;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,6 +17,9 @@ import org.slf4j.LoggerFactory;
 public class YugabytedCommands {
 
     private static final Logger LOG = LoggerFactory.getLogger(YugabytedCommands.class);
+
+    /** Max time to wait for a `yugabyted start` invocation to return. */
+    private static final long START_WAIT_MS = 300000;
 
     public static String getYsqlConnectionCmd(String baseDir) {
         String binDir = YugabytedTestUtils.getYugabytedBinDir();
@@ -42,6 +48,50 @@ public class YugabytedCommands {
             return false;
         }
         return true;
+    }
+
+    public static String getStartCmd(String baseDir) {
+        String binDir = YugabytedTestUtils.getYugabytedBinDir();
+        return binDir + "/yugabyted start --base_dir " + baseDir;
+    }
+
+    /**
+     * Runs `yugabyted start` against an existing base_dir, i.e. a restart that picks up the
+     * persisted yugabyted.conf. Output is redirected to a temp file so that a chatty start
+     * cannot fill the pipe buffer and wedge the command, and the wait is bounded so that a
+     * start which never returns fails the test instead of hanging it.
+     */
+    public static boolean start(String baseDir) throws Exception {
+        String command = getStartCmd(baseDir);
+        LOG.info("Running command: " + command);
+        File startLog = File.createTempFile("yugabyted-start-", ".log");
+        ProcessBuilder procBuilder = new ProcessBuilder(command.split(" "));
+        procBuilder.redirectErrorStream(true);
+        procBuilder.redirectOutput(startLog);
+        Process proc = procBuilder.start();
+        boolean exited = proc.waitFor(START_WAIT_MS, TimeUnit.MILLISECONDS);
+        if (!exited) {
+            LOG.error("Yugabyted start command did not return within " + START_WAIT_MS + " ms");
+            proc.destroyForcibly();
+        }
+        LOG.info("Yugabyted start output:\n" + readFileQuietly(startLog));
+        if (!exited) {
+            return false;
+        }
+        int exitCode = proc.exitValue();
+        if (exitCode != 0) {
+            LOG.error("Yugabyted start command failed with exit code: " + exitCode);
+            return false;
+        }
+        return true;
+    }
+
+    private static String readFileQuietly(File file) {
+        try {
+            return new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            return "<unable to read " + file + ": " + e.getMessage() + ">";
+        }
     }
 
     public static String getStopCmd(String baseDir) {

--- a/java/yb-yugabyted/src/test/java/org/yb/yugabyted/TestYugabytedMasterAddrs.java
+++ b/java/yb-yugabyted/src/test/java/org/yb/yugabyted/TestYugabytedMasterAddrs.java
@@ -1,0 +1,158 @@
+package org.yb.yugabyted;
+
+import static org.yb.AssertionWrappers.assertEquals;
+import static org.yb.AssertionWrappers.assertFalse;
+import static org.yb.AssertionWrappers.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yb.YBTestRunner;
+import org.yb.minicluster.MiniYugabytedClusterParameters;
+import org.yb.minicluster.MiniYugabytedNodeConfigurations;
+import org.yb.minicluster.YugabytedCommands;
+import org.yb.minicluster.YugabytedTestUtils;
+import org.yb.util.Timeouts;
+
+import com.google.common.net.HostAndPort;
+
+/**
+ * Regression test for host-less entries in the saved master address list.
+ *
+ * yugabyted could persist a host-less entry in current_masters (e.g. ",127.0.0.1:7100"). On the
+ * next start that reached yb-tserver as --tserver_master_addrs=,127.0.0.1:7100, and the tserver
+ * retried DNS on the empty host inside ResolveMasterAddresses() for master_discovery_timeout_ms
+ * (1 hour by default) before logging anything past "Initializing tablet server...". yugabyted
+ * kept saving the bad value, so every later start hung the same way.
+ *
+ * Unit coverage of the parsing itself lives in
+ * python/yugabyte/test_yugabyted_master_addrs.py.
+ */
+@RunWith(value = YBTestRunner.class)
+public class TestYugabytedMasterAddrs extends BaseYbdClientTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TestYugabytedMasterAddrs.class);
+
+    private static final String CURRENT_MASTERS_KEY = "current_masters";
+
+    /** Max time to wait for the node to come back up after the poisoned restart. */
+    private static final long RESTART_TIMEOUT_MS = Timeouts.adjustTimeoutSecForBuildType(180000);
+    private static final long RESTART_POLL_MS = 5000;
+
+    /** Max time to wait for `yugabyted status` to report Stopped after `yugabyted stop`. */
+    private static final long STOP_TIMEOUT_MS = 60000;
+    private static final long STOP_POLL_MS = 5000;
+
+    public TestYugabytedMasterAddrs() {
+        clusterParameters = new MiniYugabytedClusterParameters.Builder()
+                                .numNodes(1)
+                                .build();
+
+        clusterConfigurations = new ArrayList<>();
+        for (int i = 0; i < clusterParameters.numNodes; i++) {
+            MiniYugabytedNodeConfigurations nodeConfigurations =
+                                    new MiniYugabytedNodeConfigurations.Builder()
+                .build();
+
+            clusterConfigurations.add(nodeConfigurations);
+        }
+    }
+
+    /**
+     * Writes a host-less entry into the saved config of a stopped node and checks that the next
+     * start recovers. Without the fix the tserver blocks on DNS for master_discovery_timeout_ms,
+     * so the node never reaches Running and this times out.
+     */
+    @Test(timeout = 900000)
+    public void testRestartWithHostLessMasterAddress() throws Exception {
+        String baseDir = clusterConfigurations.get(0).getBaseDir();
+        HostAndPort node = miniYugabytedCluster.getYugabytedNodes().keySet().iterator().next();
+        int ysqlPort = miniYugabytedCluster.getPostgresContactPoints().get(0).getPort();
+
+        String healthyMasters = readCurrentMasters(baseDir);
+        LOG.info("current_masters on the running node: " + healthyMasters);
+        assertFalse("current_masters should be set on a running node", healthyMasters.isEmpty());
+
+        // Stop first, so that the config we poison is the one the next start reads back.
+        assertTrue("yugabyted stop failed", YugabytedCommands.stop(baseDir));
+        waitForNodeToStop(baseDir);
+
+        String poisonedMasters = "," + healthyMasters;
+        writeCurrentMasters(baseDir, poisonedMasters);
+
+        assertTrue("yugabyted start failed after poisoning " + CURRENT_MASTERS_KEY,
+                YugabytedCommands.start(baseDir));
+        YugabytedTestUtils.waitForNodeToStart(baseDir, node.getHost(), ysqlPort,
+                RESTART_TIMEOUT_MS, RESTART_POLL_MS);
+
+        String recoveredMasters = readCurrentMasters(baseDir);
+        LOG.info("current_masters after the restart: " + recoveredMasters);
+        for (String addr : recoveredMasters.split(",", -1)) {
+            assertFalse("current_masters still has a host-less entry: " + recoveredMasters,
+                    addr.trim().isEmpty());
+        }
+        // The order of the list is not guaranteed, so compare the addresses as sets.
+        assertEquals("current_masters should be back to the pre-poisoning list",
+                sortedAddrs(healthyMasters), sortedAddrs(recoveredMasters));
+
+        // The tserver only serves YSQL once it has registered with a master, so a working
+        // connection also shows it was not started with a host-less --tserver_master_addrs.
+        assertTrue("YSQL is not reachable after the restart",
+                YugabytedTestUtils.testYsqlConnection(baseDir, node.getHost()));
+    }
+
+    private static void waitForNodeToStop(String baseDir) throws Exception {
+        long deadline = System.currentTimeMillis() + STOP_TIMEOUT_MS;
+        while (System.currentTimeMillis() < deadline) {
+            if (YugabytedTestUtils.checkNodeStatus(baseDir, "Stopped")) {
+                return;
+            }
+            Thread.sleep(STOP_POLL_MS);
+        }
+        throw new Exception("Node did not stop within " + (STOP_TIMEOUT_MS / 1000) + " seconds");
+    }
+
+    private static List<String> sortedAddrs(String mastersCsv) {
+        List<String> addrs = new ArrayList<>(Arrays.asList(mastersCsv.split(",")));
+        Collections.sort(addrs);
+        return addrs;
+    }
+
+    private static Path yugabytedConfPath(String baseDir) {
+        String expandedBaseDir = baseDir;
+        if (expandedBaseDir.startsWith("~")) {
+            expandedBaseDir = expandedBaseDir.replaceFirst("~", System.getProperty("user.home"));
+        }
+        return Paths.get(expandedBaseDir, "conf", "yugabyted.conf");
+    }
+
+    private static JSONObject readYugabytedConf(String baseDir) throws IOException {
+        Path confPath = yugabytedConfPath(baseDir);
+        return new JSONObject(
+                new String(Files.readAllBytes(confPath), StandardCharsets.UTF_8));
+    }
+
+    private static String readCurrentMasters(String baseDir) throws IOException {
+        return readYugabytedConf(baseDir).optString(CURRENT_MASTERS_KEY, "");
+    }
+
+    private static void writeCurrentMasters(String baseDir, String mastersCsv) throws IOException {
+        Path confPath = yugabytedConfPath(baseDir);
+        JSONObject conf = readYugabytedConf(baseDir);
+        conf.put(CURRENT_MASTERS_KEY, mastersCsv);
+        Files.write(confPath, conf.toString(4).getBytes(StandardCharsets.UTF_8));
+        LOG.info("Wrote " + CURRENT_MASTERS_KEY + "=" + mastersCsv + " to " + confPath);
+    }
+}

--- a/python/yugabyte/test_yugabyted_master_addrs.py
+++ b/python/yugabyte/test_yugabyted_master_addrs.py
@@ -14,10 +14,12 @@
 Unit tests for master address handling in bin/yugabyted (loaded dynamically; there is no
 yugabyted package).
 
-An empty entry in current_masters used to reach yb-tserver as --tserver_master_addrs=,host:7100.
-The tserver then retried DNS on the empty host inside ResolveMasterAddresses() for
-master_discovery_timeout_ms (1 hour by default) before logging anything past "Initializing tablet
-server...", and yugabyted persisted the bad value, so every later start hung the same way.
+yugabyted only ever adds to current_masters, so an address that stops resolving stays there. Both
+an empty entry (--tserver_master_addrs=,host:7100) and a hostname left over from a previous run
+(a container hostname, say) reach yb-tserver, whose ResolveMasterAddresses() retries each entry
+for master_discovery_timeout_ms (1 hour by default) before failing the startup, logging nothing
+past "Initializing tablet server...". yugabyted then persisted the bad value, so every later start
+hung the same way.
 
 Integration coverage lives in scripts/yugabyted/test/yugabyted-test.sh.
 """
@@ -27,10 +29,12 @@ import importlib.util
 import json
 import os
 import pathlib
+import socket
 import tempfile
 import types
 import unittest
-from typing import Any, ClassVar, Dict
+from typing import Any, ClassVar, Dict, List
+from unittest import mock
 
 
 def _repo_root() -> pathlib.Path:
@@ -100,8 +104,100 @@ class TestConfigMasterAddrsRecovery(unittest.TestCase):
         self.assertEqual(self._load_saved_masters({"current_masters": ""}), "")
 
 
+class TestSplitMasterAddr(unittest.TestCase):
+    yugabyted: ClassVar[types.ModuleType]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.yugabyted = _load_yugabyted_module()
+
+    def test_host_and_port(self) -> None:
+        self.assertEqual(self.yugabyted.split_master_addr("host:7100"), ("host", "7100"))
+
+    def test_ipv6_is_unwrapped(self) -> None:
+        # get_url_from_ip() brackets IPv6 addresses, so a bare rpartition(":") would split
+        # inside the address itself.
+        self.assertEqual(self.yugabyted.split_master_addr("[::1]:7100"), ("::1", "7100"))
+        self.assertEqual(self.yugabyted.split_master_addr("[::1]"), ("::1", None))
+
+    def test_bare_host_has_no_port(self) -> None:
+        self.assertEqual(self.yugabyted.split_master_addr("host"), ("host", None))
+
+
+class TestIsResolvableMasterAddr(unittest.TestCase):
+    yugabyted: ClassVar[types.ModuleType]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.yugabyted = _load_yugabyted_module()
+
+    def test_resolvable_host(self) -> None:
+        with mock.patch.object(self.yugabyted.socket, "getaddrinfo", return_value=[]) as lookup:
+            self.assertTrue(self.yugabyted.is_resolvable_master_addr("host:7100"))
+        lookup.assert_called_once_with("host", None)
+
+    def test_unknown_host(self) -> None:
+        with mock.patch.object(
+                self.yugabyted.socket, "getaddrinfo", side_effect=socket.gaierror("no such host")):
+            self.assertFalse(self.yugabyted.is_resolvable_master_addr("gone:7100"))
+
+    def test_host_less_address(self) -> None:
+        self.assertFalse(self.yugabyted.is_resolvable_master_addr(":7100"))
+
+    def test_resolver_error_keeps_the_address(self) -> None:
+        # Anything other than a definite lookup failure is not evidence that the master is gone.
+        with mock.patch.object(
+                self.yugabyted.socket, "getaddrinfo", side_effect=OSError("resolver is unwell")):
+            self.assertTrue(self.yugabyted.is_resolvable_master_addr("host:7100"))
+
+
+class TestPruneUnresolvableMasterAddrs(unittest.TestCase):
+    yugabyted: ClassVar[types.ModuleType]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.yugabyted = _load_yugabyted_module()
+
+    def _prune(self, addrs: List[str], resolvable: List[str], keep_addr: Any = None) -> Any:
+        with mock.patch.object(
+                self.yugabyted, "is_resolvable_master_addr",
+                side_effect=lambda addr: addr in resolvable):
+            return self.yugabyted.prune_unresolvable_master_addrs(addrs, keep_addr)
+
+    def test_stale_address_is_dropped(self) -> None:
+        kept, dropped = self._prune(
+            ["2647c43801a7:7100", "127.0.0.1:7100", "yugabyte:7100"],
+            resolvable=["127.0.0.1:7100", "yugabyte:7100"])
+        self.assertEqual(kept, ["127.0.0.1:7100", "yugabyte:7100"])
+        self.assertEqual(dropped, ["2647c43801a7:7100"])
+
+    def test_order_is_preserved(self) -> None:
+        addrs = ["c:7100", "a:7100", "b:7100"]
+        kept, dropped = self._prune(addrs, resolvable=addrs)
+        self.assertEqual(kept, addrs)
+        self.assertEqual(dropped, [])
+
+    def test_duplicates_are_collapsed(self) -> None:
+        kept, _ = self._prune(["a:7100", "a:7100", "b:7100"], resolvable=["a:7100", "b:7100"])
+        self.assertEqual(kept, ["a:7100", "b:7100"])
+
+    def test_keep_addr_survives_a_failed_lookup(self) -> None:
+        kept, dropped = self._prune(
+            ["gone:7100", "self:7100"], resolvable=[], keep_addr="self:7100")
+        self.assertEqual(kept, ["self:7100"])
+        self.assertEqual(dropped, ["gone:7100"])
+
+    def test_total_resolution_failure_leaves_the_list_alone(self) -> None:
+        # A DNS outage must not empty the list: with no address at all the tserver cannot find
+        # the cluster even once DNS recovers.
+        addrs = ["a:7100", "b:7100"]
+        kept, dropped = self._prune(addrs, resolvable=[])
+        self.assertEqual(kept, addrs)
+        self.assertEqual(dropped, [])
+
+
 class TestUpdateTserverMasterAddrs(unittest.TestCase):
-    """update_tserver_master_addrs() should never build a flag with a host-less address."""
+    """update_tserver_master_addrs() builds the flag the tserver is started with."""
 
     yugabyted: ClassVar[types.ModuleType]
 
@@ -109,7 +205,8 @@ class TestUpdateTserverMasterAddrs(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.yugabyted = _load_yugabyted_module()
 
-    def _run_update(self, current_masters: str) -> types.SimpleNamespace:
+    def _run_update(
+            self, current_masters: str, stale: Any = ()) -> types.SimpleNamespace:
         script = self.yugabyted.ControlScript.__new__(self.yugabyted.ControlScript)
         tserver_cmd = ["/home/yugabyte/bin/yb-tserver", "--tserver_master_addrs=host:7100"]
         script.processes = {"tserver": types.SimpleNamespace(cmd=tserver_cmd)}
@@ -118,7 +215,11 @@ class TestUpdateTserverMasterAddrs(unittest.TestCase):
             "master_rpc_port": 7100,
         })
         script.advertise_ip = lambda: "host"
-        script.update_tserver_master_addrs()
+        # Stub the resolver so the result does not depend on the test host's DNS.
+        with mock.patch.object(
+                self.yugabyted, "is_resolvable_master_addr",
+                side_effect=lambda addr: addr not in stale):
+            script.update_tserver_master_addrs()
         return types.SimpleNamespace(
             cmd=tserver_cmd, saved_data=script.configs.saved_data)
 
@@ -130,6 +231,13 @@ class TestUpdateTserverMasterAddrs(unittest.TestCase):
 
     def test_host_less_entry_is_not_passed_to_tserver(self) -> None:
         result = self._run_update(",host:7100")
+        flags = [arg for arg in result.cmd if arg.startswith("--tserver_master_addrs=")]
+        self.assertEqual(flags, ["--tserver_master_addrs=host:7100"])
+        self.assertEqual(result.saved_data["current_masters"], "host:7100")
+
+    def test_stale_address_is_not_passed_to_tserver(self) -> None:
+        # "gone" was this node's own hostname on an earlier run; it no longer resolves.
+        result = self._run_update("gone:7100,host:7100", stale=("gone:7100",))
         flags = [arg for arg in result.cmd if arg.startswith("--tserver_master_addrs=")]
         self.assertEqual(flags, ["--tserver_master_addrs=host:7100"])
         self.assertEqual(result.saved_data["current_masters"], "host:7100")

--- a/python/yugabyte/test_yugabyted_master_addrs.py
+++ b/python/yugabyte/test_yugabyted_master_addrs.py
@@ -1,0 +1,146 @@
+# Copyright (c) YugabyteDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on the "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations
+# under the License.
+
+"""
+Unit tests for master address handling in bin/yugabyted (loaded dynamically; there is no
+yugabyted package).
+
+An empty entry in current_masters used to reach yb-tserver as --tserver_master_addrs=,host:7100.
+The tserver then retried DNS on the empty host inside ResolveMasterAddresses() for
+master_discovery_timeout_ms (1 hour by default) before logging anything past "Initializing tablet
+server...", and yugabyted persisted the bad value, so every later start hung the same way.
+
+Integration coverage lives in scripts/yugabyted/test/yugabyted-test.sh.
+"""
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+import pathlib
+import tempfile
+import types
+import unittest
+from typing import Any, ClassVar, Dict
+
+
+def _repo_root() -> pathlib.Path:
+    return pathlib.Path(__file__).resolve().parents[2]
+
+
+def _load_yugabyted_module() -> types.ModuleType:
+    yugabyted_path = _repo_root() / "bin" / "yugabyted"
+    loader = importlib.machinery.SourceFileLoader("_yugabyted_under_test", str(yugabyted_path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    assert spec is not None
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+class TestParseMasterAddrsCsv(unittest.TestCase):
+    yugabyted: ClassVar[types.ModuleType]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.yugabyted = _load_yugabyted_module()
+
+    def test_empty_entries_are_dropped(self) -> None:
+        parse = self.yugabyted.parse_master_addrs_csv
+        self.assertEqual(parse(",host:7100"), ["host:7100"])
+        self.assertEqual(parse("a:7100,,b:7100"), ["a:7100", "b:7100"])
+        self.assertEqual(parse(" a:7100 , b:7100 "), ["a:7100", "b:7100"])
+
+    def test_no_addresses_gives_empty_list(self) -> None:
+        parse = self.yugabyted.parse_master_addrs_csv
+        # "".split(",") returns [""], which is truthy and passes an "if not list" guard.
+        self.assertEqual(parse(""), [])
+        self.assertEqual(parse(None), [])
+
+    def test_populated_list_is_unchanged(self) -> None:
+        parse = self.yugabyted.parse_master_addrs_csv
+        self.assertEqual(parse("a:7100,b:7100"), ["a:7100", "b:7100"])
+
+
+class TestConfigMasterAddrsRecovery(unittest.TestCase):
+    """parse_config_file() should drop a host-less entry left behind by an older version."""
+
+    yugabyted: ClassVar[types.ModuleType]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.yugabyted = _load_yugabyted_module()
+
+    def _load_saved_masters(self, saved_data: Dict[str, Any]) -> Any:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config_file = os.path.join(tmp_dir, "yugabyted.conf")
+            with open(config_file, "w") as f:
+                json.dump(saved_data, f)
+            configs = self.yugabyted.Configs.parse_config_file(config_file, tmp_dir)
+            return configs.saved_data.get("current_masters")
+
+    def test_host_less_entry_is_dropped_on_load(self) -> None:
+        self.assertEqual(
+            self._load_saved_masters({"current_masters": ",host:7100"}), "host:7100")
+
+    def test_valid_list_is_left_alone(self) -> None:
+        self.assertEqual(
+            self._load_saved_masters({"current_masters": "a:7100,b:7100"}), "a:7100,b:7100")
+
+    def test_empty_value_stays_empty(self) -> None:
+        self.assertEqual(self._load_saved_masters({"current_masters": ""}), "")
+
+
+class TestUpdateTserverMasterAddrs(unittest.TestCase):
+    """update_tserver_master_addrs() should never build a flag with a host-less address."""
+
+    yugabyted: ClassVar[types.ModuleType]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.yugabyted = _load_yugabyted_module()
+
+    def _run_update(self, current_masters: str) -> types.SimpleNamespace:
+        script = self.yugabyted.ControlScript.__new__(self.yugabyted.ControlScript)
+        tserver_cmd = ["/home/yugabyte/bin/yb-tserver", "--tserver_master_addrs=host:7100"]
+        script.processes = {"tserver": types.SimpleNamespace(cmd=tserver_cmd)}
+        script.configs = types.SimpleNamespace(saved_data={
+            "current_masters": current_masters,
+            "master_rpc_port": 7100,
+        })
+        script.advertise_ip = lambda: "host"
+        script.update_tserver_master_addrs()
+        return types.SimpleNamespace(
+            cmd=tserver_cmd, saved_data=script.configs.saved_data)
+
+    def test_empty_current_masters_keeps_existing_flag(self) -> None:
+        result = self._run_update("")
+        self.assertEqual(
+            [arg for arg in result.cmd if arg.startswith("--tserver_master_addrs=")],
+            ["--tserver_master_addrs=host:7100"])
+
+    def test_host_less_entry_is_not_passed_to_tserver(self) -> None:
+        result = self._run_update(",host:7100")
+        flags = [arg for arg in result.cmd if arg.startswith("--tserver_master_addrs=")]
+        self.assertEqual(flags, ["--tserver_master_addrs=host:7100"])
+        self.assertEqual(result.saved_data["current_masters"], "host:7100")
+
+    def test_multiple_masters_are_preserved(self) -> None:
+        result = self._run_update("a:7100,b:7100")
+        flags = [arg for arg in result.cmd if arg.startswith("--tserver_master_addrs=")]
+        self.assertEqual(len(flags), 1)
+        addrs = flags[0].split("=", 1)[1].split(",")
+        self.assertEqual(sorted(addrs), ["a:7100", "b:7100", "host:7100"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`update_tserver_master_addrs()` unions the local master address into `current_masters` and
never removes anything, so a bad entry, once in, stays. Two ways one gets in:

- **An empty entry.** `get_status_string()` persisted whatever `get_current_masters_from_api()`
  returned. Both of its lookups go through the tserver web server, so they return `""` whenever
  the tserver is down, and `"".split(",")` is `[""]` — truthy, so the `if not full_master_list`
  guard missed it. The tserver was then started with `--tserver_master_addrs=,host:7100`.
- **An address that stops resolving.** A node that comes back under a different hostname
  accumulates its old ones. A container restarted under a fresh Docker-assigned hostname ends up
  with `current_masters` listing hostnames of containers that no longer exist alongside its
  current one.

Either way the entry reaches yb-tserver, where `ResolveMasterAddresses()`
(`src/yb/server/server_base_options.cc:278`) walks the list and retries *each* entry until it
resolves, for `master_discovery_timeout_ms` — one hour by default — before failing startup
outright. It logs nothing past `Initializing tablet server...`, so every visible symptom is
downstream and misleading: the master reports `Not enough live tablet servers ... 0 are alive`,
`yugabyted status` prints `Bootstrapping.`, and the `yb-admin` calls it makes are handed
`--master_addresses ''`, because the lookup feeding them needs the tserver that never came up.
Nothing on the surface points at the address list.

This drops empty entries when the config is parsed, and prunes addresses that no longer resolve
before the tserver flag is built. The pruned list is what gets persisted, so a config that is
already poisoned heals on the next start instead of needing a hand edit.

Two deliberate limits on the pruning: the local master address is never dropped, and if
*nothing* in the list resolves the list is left untouched — that is a DNS outage rather than a
stale entry, and leaving the tserver with no address at all is worse than the hang. The list
also keeps its order now; it used to go through a `set()`, so the flag's address order changed
between runs.

Worth knowing: yugabyted now does one DNS lookup per master address each time it starts the
tserver.

## Test plan

- [x] `python3 -m unittest python.yugabyte.test_yugabyted_master_addrs` — 22 tests, 12 new. The
      resolver is stubbed throughout, so results don't depend on the test host's DNS.
- [x] Replayed a reported stuck `current_masters` through `update_tserver_master_addrs()` with a
      resolver that fails on the dead hostname: the stale entry is dropped and the persisted
      value heals to the reachable masters.
- [ ] `TestYugabytedMasterAddrs` (`java/yb-yugabyted`) — added on this branch, not run locally;
      needs CI.
