### PR TITLE
[BACKPORT 2024.2][#33169] Build: Quote PR title and body in the pr-title workflow (#33171)

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,13 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           TITLE_RE='^(\[(BACKPORT )?([0-9]+(\.[0-9]+)+)\])?'
           TITLE_RE+='\[((#[0-9]+(,#[0-9]+)*)|([A-Z]+-[0-9]+(,[A-Z]+-[0-9]+)*))\]'
           TITLE_RE+=' [a-zA-Z0-9_-]+(,[[a-zA-Z0-9_]-]+)*:'
           TITLE_RE+=' \S.{8,98}\S$'
 
-          if [[ ! "${{ github.event.pull_request.title }}" =~ $TITLE_RE ]]; then
+          if [[ ! "$PR_TITLE" =~ $TITLE_RE ]]; then
             echo "::error ::Pull Request title must include issue ID, code area,"
             echo "::error ::  and a short description, with no extra whitespace."
             echo "::error ::Issue referenced must be a github issue or YB-internal Jira ID."
@@ -33,20 +35,23 @@ jobs:
           fi
           echo "Pull Request title is valid."
       - name: Check Backport title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
           BACKPORT_RE='^\[(BACKPORT )?([0-9]+(\.[0-9]+)+)\]'
-          if [[ "${{ github.base_ref }}" == "master" ]]; then
-            if [[ "${{ github.event.pull_request.title }}" =~ $BACKPORT_RE ]]; then
+          if [[ "$BASE_REF" == "master" ]]; then
+            if [[ "$PR_TITLE" =~ $BACKPORT_RE ]]; then
               echo "::error ::Pull Request title should not specify target branch for master."
               exit 1
             fi
             echo "Pull Request title is valid for master branch."
           else
-            if [[ "${{ github.event.pull_request.title }}" =~ $BACKPORT_RE ]]; then
+            if [[ "$PR_TITLE" =~ $BACKPORT_RE ]]; then
               BACKPORT_BRANCH="${BASH_REMATCH[2]}"
-              if [[ "${BACKPORT_BRANCH}" != "${{ github.base_ref }}" ]]; then
+              if [[ "${BACKPORT_BRANCH}" != "$BASE_REF" ]]; then
                 echo "::error ::Backport branch in title (${BACKPORT_BRANCH}) does not match"
-                echo "::error :: Pull Request base ref (${{ github.base_ref }})."
+                echo "::error :: Pull Request base ref ($BASE_REF)."
                 exit 1
               fi
               echo "Pull Request title branch reference ($BACKPORT_BRANCH) matches base reference."
@@ -59,11 +64,14 @@ jobs:
             fi
           fi
       - name: Check Backport references
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           BACKPORT_RE='^\[BACKPORT ([0-9]+(\.[0-9]+)+)\]'
           # Check for true backport, not just target branch in title.
-          if [[ "${{ github.event.pull_request.title }}" =~ $BACKPORT_RE ]]; then
-            body="${{ github.event.pull_request.body }}"
+          if [[ "$PR_TITLE" =~ $BACKPORT_RE ]]; then
+            body="$PR_BODY"
             bp_error=0
             COMMIT_HDR_RE=($'\n'\|^)'Original commit(s)?:'
             COMMIT_LIST_RE='(- )?[0-9a-f]+ / [#D][0-9]+'


### PR DESCRIPTION
DO NOT MERGE!! [CSI](<https://csiweb.dev.yugabyte.com/pull/33288/>) ❌. Once CSI passes, comment `trigger jenkins` to clear this warning.

The `pr-title` workflow interpolated the PR title and body directly into
its
`run:` scripts with `${{ ... }}`. GitHub Actions substitutes those
expressions
**textually, before bash parses the script**, so the values were pasted
raw into
the shell source. In the *Check Backport references* step that happened
inside
double quotes:

```yaml
body="${{ github.event.pull_request.body }}"
```

Inside double quotes, backticks are command substitution — so a backport
PR whose
description contained a backtick had its description **executed as shell
code**,
and `bash -e` aborted the step on the first failing word. The check then
reported
failure with exit code 127 no matter how well-formed the title and the
original-commit reference actually were.

Since the step only runs for `[BACKPORT ...]` titles, every backport PR
that
mentioned a flag, function or file name in code formatting hit this.
#32113 is a
live example: its title and `Original commit:` line are both valid, but
the check
fails with

```
line 105: read_replica_placement: command not found
line 105: ./yb_build.sh: No such file or directory
command substitution: line 117: syntax error near unexpected token `('
##[error]Process completed with exit code 127
```

This change passes the title, body and base ref through each step's
`env:` block
so they arrive as ordinary environment variables and are never parsed as
shell
source. **No validation logic changes** — the regexes, the branch
comparison and
every error message are untouched.

It also removes an unintended code-execution path on the runner.
Exposure was
limited, since the workflow triggers on `pull_request` rather than
`pull_request_target` and so runs with a read-only token and no access
to
secrets, but PR-author-controlled text should not reach a shell parser.

tracking issue: #33169

Original commit: 886bdeca5979b0663167aa9205524c3e34b2c691 / #33171

## Test plan

The three `run:` scripts were extracted from the workflow before and
after the
change and executed under `bash -e` — the shell Actions uses, and the
reason this
fails at all; plain `bash` treats the command-not-found errors as
non-fatal.

Driven with the real title and body of #32113, a backport whose body
contains 22
lines with backticks plus a fenced `sql` block:

| | result |
|---|---|
| before | step 3 exits **127**, reproducing CI (`ALTER: command not
found`, `syntax error near unexpected token '('`) |
| after | step 3 exits **0** — `Found original commit info:
0af82c65c1a6e5487e50e6fa80059c58436646d2 / #31948` |

Confirmed the validation still rejects what it should, each at the
correct step:

- a master PR carrying a `[BACKPORT]` prefix → step 2
- a backport whose title branch disagrees with the base ref → step 2
- a backport body with no `Original commit` line → step 3
- a title with no issue ID → step 1

Also confirmed a well-formed master title passes all three steps, and
that the
only remaining `${{ }}` occurrences in the file are `env:` passthroughs.

## Backports

2026.1, 2025.2 and 2024.2 carry the same line and need this. 2025.1 does
not —
its copy of the workflow has no such interpolation.

Note that each backport PR will need a backtick-free description to get
past the
very check it is fixing, until this lands on that branch.

Co-authored-by: Kai Franz <kai-franz@users.noreply.github.com>