### PR TITLE
[PLAT-22071] YBA: Use target device info when rolling K8s pods on instance-type/full-restart edits

### DIFF
--- a/managed/src/main/java/com/yugabyte/yw/commissioner/KubernetesUpgradeTaskBase.java
+++ b/managed/src/main/java/com/yugabyte/yw/commissioner/KubernetesUpgradeTaskBase.java
@@ -389,7 +389,9 @@ public abstract class KubernetesUpgradeTaskBase extends KubernetesTaskBase {
           rootCAUUID,
           useExistingServerCert,
           null /* skipAZs */,
-          targetUniverseState);
+          targetUniverseState,
+          false /* useNewMasterDeviceInfo */,
+          false /* useNewTserverDeviceInfo */);
     }
 
     if (upgradeTservers) {
@@ -419,7 +421,9 @@ public abstract class KubernetesUpgradeTaskBase extends KubernetesTaskBase {
           rootCAUUID,
           useExistingServerCert,
           null /* skipAZs */,
-          targetUniverseState);
+          targetUniverseState,
+          false /* useNewMasterDeviceInfo */,
+          false /* useNewTserverDeviceInfo */);
 
       if (enableYbc) {
         Set<NodeDetails> primaryTservers = new HashSet<>(universe.getTServersInPrimaryCluster());
@@ -471,7 +475,9 @@ public abstract class KubernetesUpgradeTaskBase extends KubernetesTaskBase {
             rootCAUUID,
             useExistingServerCert,
             null /* skipAZs */,
-            targetUniverseState);
+            targetUniverseState,
+            false /* useNewMasterDeviceInfo */,
+            false /* useNewTserverDeviceInfo */);
 
         if (enableYbc) {
           Set<NodeDetails> replicaTservers =
@@ -509,7 +515,9 @@ public abstract class KubernetesUpgradeTaskBase extends KubernetesTaskBase {
           rootCAUUID,
           useExistingServerCert,
           null /* skipAZs */,
-          targetUniverseState);
+          targetUniverseState,
+          false /* useNewMasterDeviceInfo */,
+          false /* useNewTserverDeviceInfo */);
     }
   }
 

--- a/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/EditKubernetesUniverse.java
+++ b/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/EditKubernetesUniverse.java
@@ -684,6 +684,13 @@ public class EditKubernetesUniverse extends KubernetesTaskBase {
 
     // Now roll all the old pods that haven't been removed and aren't newly added.
     // This will update the master addresses as well as the instance type changes.
+    // A HELM_UPGRADE re-renders the whole per-AZ release (both the master and tserver
+    // StatefulSets), so the storage stanza it generates must reflect the target device info -
+    // which is what the cluster has already converged to after the disk-resize / move steps above.
+    // If we let it render the still-stale persisted intent, Kubernetes rejects the resulting
+    // immutable volumeClaimTemplates update on the (master) StatefulSet. Passing the "use new
+    // device info" flags keeps the rendered storage in sync with the live StatefulSets. Full-move
+    // AZs are excluded via skipAZs, so this only affects the in-place edited AZs.
     if (restartAllPods) {
       upgradePodsTask(
           universe.getName(),
@@ -702,7 +709,9 @@ public class EditKubernetesUniverse extends KubernetesTaskBase {
           PodUpgradeParams.DEFAULT,
           null /* ysqlMajorVersionUpgradeState */,
           null /* rootCAUUID */,
-          fullMoveMasterAZs);
+          fullMoveMasterAZs,
+          true /* useNewMasterDeviceInfo */,
+          true /* useNewTserverDeviceInfo */);
 
       upgradePodsTask(
           universe.getName(),
@@ -721,7 +730,9 @@ public class EditKubernetesUniverse extends KubernetesTaskBase {
           PodUpgradeParams.DEFAULT,
           null /* ysqlMajorVersionUpgradeState */,
           null /* rootCAUUID */,
-          fullMoveTserverAZs);
+          fullMoveTserverAZs,
+          true /* useNewMasterDeviceInfo */,
+          true /* useNewTserverDeviceInfo */);
     } else if (instanceTypeChanged) {
       upgradePodsTask(
           universe.getName(),
@@ -740,7 +751,9 @@ public class EditKubernetesUniverse extends KubernetesTaskBase {
           PodUpgradeParams.DEFAULT,
           null /* ysqlMajorVersionUpgradeState */,
           null /* rootCAUUID */,
-          fullMoveTserverAZs);
+          fullMoveTserverAZs,
+          true /* useNewMasterDeviceInfo */,
+          true /* useNewTserverDeviceInfo */);
     } else if (masterAddressesChanged) {
       // Update master_addresses flag on Master
       // and tserver_master_addrs flag on tserver without restart.

--- a/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/KubernetesTaskBase.java
+++ b/managed/src/main/java/com/yugabyte/yw/commissioner/tasks/KubernetesTaskBase.java
@@ -1183,7 +1183,61 @@ public abstract class KubernetesTaskBase extends UniverseDefinitionTaskBase {
         rootCAUUID,
         false /* useExistingServerCert */,
         skipAZs,
-        null /* targetUniverseState */);
+        null /* targetUniverseState */,
+        false /* useNewMasterDeviceInfo */,
+        false /* useNewTserverDeviceInfo */);
+  }
+
+  /**
+   * Same as the overload above, but allows the caller to control whether the Helm overrides use the
+   * target (new) device info for the master/tserver StatefulSets. This is needed by edit-universe
+   * flows: a HELM_UPGRADE re-renders the whole release (both master and tserver StatefulSets), so
+   * the storage stanza must reflect what the cluster has already converged to (e.g. after a disk
+   * resize). Otherwise the still-stale persisted intent would be rendered and Kubernetes rejects
+   * the immutable volumeClaimTemplates update on the StatefulSet.
+   */
+  public void upgradePodsTask(
+      String universeName,
+      KubernetesPlacement newPlacement,
+      String masterAddresses,
+      KubernetesPlacement currPlacement,
+      ServerType serverType,
+      String softwareVersion,
+      String universeOverridesStr,
+      Map<String, String> azsOverrides,
+      boolean newNamingStyle,
+      boolean isReadOnlyCluster,
+      CommandType commandType,
+      boolean enableYbc,
+      String ybcSoftwareVersion,
+      PodUpgradeParams podUpgradeParams,
+      YsqlMajorVersionUpgradeState ysqlMajorVersionUpgradeState,
+      UUID rootCAUUID,
+      Set<UUID> skipAZs,
+      boolean useNewMasterDeviceInfo,
+      boolean useNewTserverDeviceInfo) {
+    upgradePodsTask(
+        universeName,
+        newPlacement,
+        masterAddresses,
+        currPlacement,
+        serverType,
+        softwareVersion,
+        universeOverridesStr,
+        azsOverrides,
+        newNamingStyle,
+        isReadOnlyCluster,
+        commandType,
+        enableYbc,
+        ybcSoftwareVersion,
+        podUpgradeParams,
+        ysqlMajorVersionUpgradeState,
+        rootCAUUID,
+        false /* useExistingServerCert */,
+        skipAZs,
+        null /* targetUniverseState */,
+        useNewMasterDeviceInfo,
+        useNewTserverDeviceInfo);
   }
 
   public void upgradePodsTask(
@@ -1205,7 +1259,9 @@ public abstract class KubernetesTaskBase extends UniverseDefinitionTaskBase {
       UUID rootCAUUID,
       boolean useExistingServerCert,
       Set<UUID> skipAZs,
-      @Nullable Universe targetUniverseState) {
+      @Nullable Universe targetUniverseState,
+      boolean useNewMasterDeviceInfo,
+      boolean useNewTserverDeviceInfo) {
     Cluster primaryCluster = taskParams().getPrimaryCluster();
     if (primaryCluster == null) {
       primaryCluster =
@@ -1393,7 +1449,9 @@ public abstract class KubernetesTaskBase extends UniverseDefinitionTaskBase {
               null /* previousGflagsChecksumMap */,
               ysqlMajorVersionUpgradeState,
               rootCAUUID,
-              useExistingServerCert);
+              useExistingServerCert,
+              useNewMasterDeviceInfo,
+              useNewTserverDeviceInfo);
         }
 
         addParallelTasks(
@@ -2603,6 +2661,60 @@ public abstract class KubernetesTaskBase extends UniverseDefinitionTaskBase {
       YsqlMajorVersionUpgradeState ysqlMajorVersionUpgradeState,
       UUID rootCAUUID,
       boolean useExistingServerCert) {
+    createSingleKubernetesExecutorTaskForServerType(
+        universeName,
+        commandType,
+        pi,
+        az,
+        masterAddresses,
+        ybSoftwareVersion,
+        serverType,
+        config,
+        masterPartition,
+        tserverPartition,
+        universeOverrides,
+        azOverrides,
+        isReadOnlyCluster,
+        podName,
+        newDiskSize,
+        ignoreErrors,
+        enableYbc,
+        ybcSoftwareVersion,
+        usePreviousGflagsChecksum,
+        previousGflagsChecksumMap,
+        ysqlMajorVersionUpgradeState,
+        rootCAUUID,
+        useExistingServerCert,
+        false /* useNewMasterDeviceInfo */,
+        false /* useNewTserverDeviceInfo */);
+  }
+
+  public void createSingleKubernetesExecutorTaskForServerType(
+      String universeName,
+      KubernetesCommandExecutor.CommandType commandType,
+      PlacementInfo pi,
+      String az,
+      String masterAddresses,
+      String ybSoftwareVersion,
+      ServerType serverType,
+      Map<String, String> config,
+      int masterPartition,
+      int tserverPartition,
+      Map<String, Object> universeOverrides,
+      Map<String, Object> azOverrides,
+      boolean isReadOnlyCluster,
+      String podName,
+      String newDiskSize,
+      boolean ignoreErrors,
+      boolean enableYbc,
+      String ybcSoftwareVersion,
+      boolean usePreviousGflagsChecksum,
+      Map<ServerType, String> previousGflagsChecksumMap,
+      YsqlMajorVersionUpgradeState ysqlMajorVersionUpgradeState,
+      UUID rootCAUUID,
+      boolean useExistingServerCert,
+      boolean useNewMasterDeviceInfo,
+      boolean useNewTserverDeviceInfo) {
     SubTaskGroup subTaskGroup = createSubTaskGroup(commandType.getSubTaskGroupName(), ignoreErrors);
     subTaskGroup.addSubTask(
         getSingleKubernetesExecutorTaskForServerTypeTask(
@@ -2627,8 +2739,8 @@ public abstract class KubernetesTaskBase extends UniverseDefinitionTaskBase {
             previousGflagsChecksumMap,
             false /* usePreviousCertChecksum */,
             null /* previousCertChecksum */,
-            false /* useNewMasterDeviceInfo */,
-            false /* useNewTserverDeviceInfo */,
+            useNewMasterDeviceInfo,
+            useNewTserverDeviceInfo,
             ysqlMajorVersionUpgradeState,
             rootCAUUID,
             useExistingServerCert));
@@ -2801,6 +2913,30 @@ public abstract class KubernetesTaskBase extends UniverseDefinitionTaskBase {
       if (useNewMasterDeviceInfo || useNewTserverDeviceInfo) {
         // Only update the deviceInfo all other things remain same
         params.universeDetails = universe.getUniverseDetails();
+        // Carry over the target instance type / node resource spec from the task params.
+        // Rendering the storage stanza from the new device info (below) requires switching the
+        // base universeDetails to the persisted (DB) copy, which still holds the pre-edit instance
+        // type. Callers that also change the instance type (edit-universe) would otherwise have
+        // their resource change silently dropped by this Helm upgrade. This is a no-op for callers
+        // that do not change the instance type (e.g. disk resize / full move), since the copied
+        // values are identical to what is already persisted.
+        Cluster taskDeviceCluster =
+            isReadOnlyCluster
+                ? taskParams().getReadOnlyClusters().get(0)
+                : taskParams().getPrimaryCluster();
+        Cluster paramsDeviceCluster =
+            isReadOnlyCluster
+                ? params.universeDetails.getReadOnlyClusters().get(0)
+                : params.universeDetails.getPrimaryCluster();
+        if (taskDeviceCluster != null && paramsDeviceCluster != null) {
+          paramsDeviceCluster.userIntent.instanceType = taskDeviceCluster.userIntent.instanceType;
+          paramsDeviceCluster.userIntent.masterInstanceType =
+              taskDeviceCluster.userIntent.masterInstanceType;
+          paramsDeviceCluster.userIntent.tserverK8SNodeResourceSpec =
+              taskDeviceCluster.userIntent.tserverK8SNodeResourceSpec;
+          paramsDeviceCluster.userIntent.masterK8SNodeResourceSpec =
+              taskDeviceCluster.userIntent.masterK8SNodeResourceSpec;
+        }
         if (useNewTserverDeviceInfo) {
           if (isReadOnlyCluster) {
             params.universeDetails.getReadOnlyClusters().get(0).userIntent.deviceInfo =


### PR DESCRIPTION
## Summary

During a Kubernetes edit-universe, a `HELM_UPGRADE` re-renders the entire per-AZ Helm release — including **both** the master and tserver StatefulSets — regardless of which `serverType` is being rolled. The `upgradePodsTask` HELM_UPGRADE path always went through a `createSingleKubernetesExecutorTaskForServerType` overload that hardcoded `useNewMasterDeviceInfo` / `useNewTserverDeviceInfo` to `false`. As a result, `handleVolumeOverrides` rendered the storage stanza for master and tserver from the persisted (`savedUserIntent`) intent, which is only updated at the end of the edit via `createUpdateUniverseIntentTask`.

When an instance-type change (`instanceTypeChanged`) or full restart (`restartAllPods`) follows a disk resize in the same edit, the live master StatefulSet has already converged to the new volume geometry, but the helm upgrade rendered the stale/old volume. Kubernetes rejects the resulting update because `volumeClaimTemplates` are immutable ("updates to statefulset spec for fields other than 'replicas' ... are forbidden"), so the edit fails on the master StatefulSet.

### Fix

- Thread `useNewMasterDeviceInfo` / `useNewTserverDeviceInfo` through `upgradePodsTask` (and a new `createSingleKubernetesExecutorTaskForServerType` overload) so callers can request that the storage stanza reflect the target device info.
- In `EditKubernetesUniverse`, set both flags `true` for the `restartAllPods` (master + tserver) and `instanceTypeChanged` (tserver) helm upgrades so the rendered storage matches the live StatefulSets. Full-move AZs are still excluded via `skipAZs`.
- Setting the device flags switches the helm-override base `universeDetails` to the persisted (DB) copy, which still holds the pre-edit instance type. To avoid silently dropping the instance-type/resource change, the flags-true branch now also carries over the target `instanceType` / `masterInstanceType` / tserver + master `K8SNodeResourceSpec`. This is a no-op for callers that do not change the instance type (disk resize, full move), since those values already match what is persisted.

All existing callers (`KubernetesUpgradeTaskBase`, `UpgradeKubernetesUniverse`) retain the previous behavior by passing `false` for both flags.

## Test plan

- [x] `sbt compile` passes for the `managed` module.
- [ ] Edit a K8s universe changing the instance type (and, in a combined case, the disk size) and confirm the `HELM_UPGRADE` no longer fails on the master StatefulSet `volumeClaimTemplates` immutable-field update.
- [ ] Full-restart edit (e.g. instance type change from `dev`/`xsmall`) succeeds and the rolled pods pick up the new resources.
- [ ] Regression: software upgrade / gflags upgrade / disk-resize flows (which pass `false` for both flags) behave unchanged.
