### PR TITLE
[#33268] YSQL: Fix hang in PollTransactionStatusBase::Shutdown racing VerifyTransaction

### DIFF
--- a/src/yb/master/multi_step_monitored_task-test.cc
+++ b/src/yb/master/multi_step_monitored_task-test.cc
@@ -279,6 +279,10 @@ TEST(CatalogEntityTaskTest, TestAbortWithInFlightTransactionPoll) {
   auto abort_returned = std::make_shared<std::atomic<bool>>(false);
   std::thread abort_thread(
       [task, abort_returned, catalog_entity, thread_pool, messenger, client]() {
+        (void)catalog_entity;
+        (void)thread_pool;
+        (void)messenger;
+        (void)client;
         task->AbortAndReturnPrevState(STATUS(Aborted, "Test abort"));
         abort_returned->store(true);
       });

--- a/src/yb/master/multi_step_monitored_task-test.cc
+++ b/src/yb/master/multi_step_monitored_task-test.cc
@@ -11,12 +11,19 @@
 // under the License.
 //
 
+#include <atomic>
+#include <future>
+#include <thread>
+
 #include <gtest/gtest.h>
 
+#include "yb/client/client.h"
 #include "yb/master/catalog_entity_base.h"
 #include "yb/master/multi_step_monitored_task.h"
 #include "yb/master/tasks_tracker.h"
+#include "yb/master/ysql_ddl_verification_task.h"
 #include "yb/rpc/messenger.h"
+#include "yb/util/backoff_waiter.h"
 #include "yb/util/scope_exit.h"
 #include "yb/util/sync_point.h"
 #include "yb/util/test_macros.h"
@@ -170,6 +177,134 @@ TEST(CatalogEntityTaskTest, TestEpochChanges) {
   ASSERT_FALSE(catalog_entity.HasTasks());
   ASSERT_EQ(catalog_entity.NumTasks(), 0);
   ASSERT_EQ(catalog_entity.HasTasks(kTaskType), 0);
+}
+
+// Mirrors the shape of NamespaceVerificationTask and TableSchemaVerificationTask.
+class PollTransactionStatusTestTask : public MultiStepCatalogEntityTask,
+                                      public PollTransactionStatusBase {
+ public:
+  PollTransactionStatusTestTask(
+      CatalogEntityWithTasks& catalog_entity, ThreadPool& async_task_pool,
+      rpc::Messenger& messenger, const LeaderEpoch& epoch,
+      std::shared_future<client::YBClient*> client_future)
+      : MultiStepCatalogEntityTask(
+            [](const LeaderEpoch&) { return Status::OK(); }, async_task_pool, messenger,
+            catalog_entity, epoch),
+        PollTransactionStatusBase(TransactionMetadata(), std::move(client_future), "test task") {}
+
+  ~PollTransactionStatusTestTask() = default;
+
+  server::MonitoredTaskType type() const override {
+    return server::MonitoredTaskType::TableSchemaVerification;
+  }
+
+  std::string type_name() const override { return "Poll transaction status test task"; }
+
+  std::string description() const override { return "Poll transaction status test task"; }
+
+  Status poll_step_status_;
+
+ private:
+  Status FirstStep() override {
+    ScheduleNextStep(std::bind(&PollTransactionStatusTestTask::PollStep, this), "poll step");
+    return Status::OK();
+  }
+
+  // Runs while holding step_execution_mutex_, which is the mutex AbortAndReturnPrevState waits on.
+  Status PollStep() {
+    TEST_SYNC_POINT("PollTransactionStatusTestTask::PollStepEntered");
+    TEST_SYNC_POINT("PollTransactionStatusTestTask::ResumePollStep");
+    poll_step_status_ = VerifyTransaction();
+    return poll_step_status_;
+  }
+
+  // AbortAndReturnPrevState invokes it.
+  void PerformAbort() override {
+    MultiStepCatalogEntityTask::PerformAbort();
+    Shutdown();
+    TEST_SYNC_POINT("PollTransactionStatusTestTask::PerformAbortDone");
+  }
+
+  void TaskCompleted(const Status& status) override {
+    MultiStepCatalogEntityTask::TaskCompleted(status);
+    Shutdown();
+  }
+
+  // Only reachable from the RPC callback, which never fires in this test.
+  void TransactionPending() override {}
+  void FinishPollTransaction(bool aborted) override {}
+};
+
+// Aborting a task while one of its steps is polling the transaction status must not strand the
+// task's Synchronizer signal.
+TEST(CatalogEntityTaskTest, TestAbortWithInFlightTransactionPoll) {
+  google::SetVLOGLevel("multi_step*", 4);
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_enable_sync_points) = true;
+  yb::SyncPoint::GetInstance()->LoadDependency(
+      {{"PollTransactionStatusTestTask::PollStepEntered", "Test::ReachedPollStep"},
+       {"PollTransactionStatusTestTask::PerformAbortDone",
+        "PollTransactionStatusTestTask::ResumePollStep"}});
+  yb::SyncPoint::GetInstance()->EnableProcessing();
+
+  std::shared_ptr<ThreadPool> thread_pool;
+  {
+    std::unique_ptr<ThreadPool> thread_pool_holder;
+    ThreadPoolBuilder thread_pool_builder("Test");
+    ASSERT_OK(thread_pool_builder.Build(&thread_pool_holder));
+    thread_pool = std::move(thread_pool_holder);
+  }
+
+  rpc::MessengerBuilder messenger_builder("Test");
+  std::shared_ptr<rpc::Messenger> messenger(ASSERT_RESULT(messenger_builder.Build()).release());
+
+  auto catalog_entity = std::make_shared<CatalogEntityWithTasksMock>();
+
+  auto client = std::make_shared<client::MockYBClient>();
+  std::promise<client::YBClient*> client_promise;
+  client_promise.set_value(client.get());
+
+  auto task = std::make_shared<PollTransactionStatusTestTask>(
+      *catalog_entity, *thread_pool, *messenger, LeaderEpoch(1, 1),
+      client_promise.get_future().share());
+  task->Start();
+
+  // Wait until the poll step is running and holding step_execution_mutex_.
+  TEST_SYNC_POINT("Test::ReachedPollStep");
+
+  // At this point, the poll thread is parked on the sync point, ResumePollStep.
+  // We are going to start an abort thread, which will call AbortAndReturnPrevState.
+  // That will call PerformAbort and release the poll step.
+
+  auto abort_returned = std::make_shared<std::atomic<bool>>(false);
+  std::thread abort_thread(
+      [task, abort_returned, catalog_entity, thread_pool, messenger, client]() {
+        task->AbortAndReturnPrevState(STATUS(Aborted, "Test abort"));
+        abort_returned->store(true);
+      });
+
+  auto wait_status = WaitFor(
+      [abort_returned]() -> Result<bool> { return abort_returned->load(); },
+      MonoDelta::FromSeconds(30), "abort to complete");
+
+  if (!wait_status.ok()) {
+    // don't worry about the leaks, it failed
+    abort_thread.detach();
+    ASSERT_OK(wait_status.CloneAndPrepend(
+        "Abort deadlocked on the transaction status poll Synchronizer"));
+  }
+
+  abort_thread.join();
+
+  // Three exits in VerifyTransaction return IllegalState. Match the message so this fails if the
+  // step took any exit other than the shutdown check, the only one that strands the signal.
+  ASSERT_TRUE(task->poll_step_status_.IsIllegalState()) << task->poll_step_status_;
+  ASSERT_STR_CONTAINS(task->poll_step_status_.ToString(), "Task has been shut down");
+  ASSERT_FALSE(catalog_entity->HasTasks());
+
+  yb::SyncPoint::GetInstance()->DisableProcessing();
+  messenger->Shutdown();
+  thread_pool->Shutdown();
 }
 
 }  // namespace yb::master

--- a/src/yb/master/multi_step_monitored_task-test.cc
+++ b/src/yb/master/multi_step_monitored_task-test.cc
@@ -277,25 +277,24 @@ TEST(CatalogEntityTaskTest, TestAbortWithInFlightTransactionPoll) {
   // That will call PerformAbort and release the poll step.
 
   auto abort_returned = std::make_shared<std::atomic<bool>>(false);
-  std::thread abort_thread(
-      [task, abort_returned, catalog_entity, thread_pool, messenger, client]() {
-        (void)catalog_entity;
-        (void)thread_pool;
-        (void)messenger;
-        (void)client;
-        task->AbortAndReturnPrevState(STATUS(Aborted, "Test abort"));
-        abort_returned->store(true);
-      });
+  std::thread abort_thread([task, abort_returned, catalog_entity]() {
+    task->AbortAndReturnPrevState(STATUS(Aborted, "Test abort"));
+    abort_returned->store(true);
+  });
 
   auto wait_status = WaitFor(
       [abort_returned]() -> Result<bool> { return abort_returned->load(); },
       MonoDelta::FromSeconds(30), "abort to complete");
 
   if (!wait_status.ok()) {
-    // don't worry about the leaks, it failed
+    // Record the failure first, so the diagnostic lands even if the cleanup below blocks.
+    ADD_FAILURE() << wait_status.CloneAndPrepend(
+        "Abort deadlocked on the transaction status poll Synchronizer");
     abort_thread.detach();
-    ASSERT_OK(wait_status.CloneAndPrepend(
-        "Abort deadlocked on the transaction status poll Synchronizer"));
+    yb::SyncPoint::GetInstance()->DisableProcessing();
+    messenger->Shutdown();
+    thread_pool->Shutdown();
+    return;
   }
 
   abort_thread.join();

--- a/src/yb/master/ysql_ddl_verification_task.cc
+++ b/src/yb/master/ysql_ddl_verification_task.cc
@@ -633,7 +633,6 @@ Status PollTransactionStatusBase::VerifyTransaction() {
   }
 
   RETURN_NOT_OK(sync_.Wait());
-  sync_.Reset();
 
   std::lock_guard l(rpc_mutex_);
   SCHECK(
@@ -649,6 +648,9 @@ Status PollTransactionStatusBase::VerifyTransaction() {
   }
   // We need to query the TransactionCoordinator here.  Can't use TransactionStatusResolver in
   // TransactionParticipant since this TransactionMetadata may not have any actual data flushed yet.
+  // Clear sync_ only once this rpc is certain to be sent, so that every path returning above leaves
+  // it signaled and a concurrent Shutdown() is not left waiting for a callback that never runs.
+  sync_.Reset();
   auto sync_cb = sync_.AsStdStatusCallback();
   auto callback = [this, rpc_handle, user_cb = std::move(sync_cb)](
                       Status status, const tserver::GetTransactionStatusResponsePB& resp) {


### PR DESCRIPTION
## Summary

Fixes #33268.

`PollTransactionStatusBase` uses `sync_` as a one-token gate: signaled means no
`GetTransactionStatus` callback is outstanding. The constructor primes it, a send consumes the
token and hands the duty of re-signaling to the rpc callback, and `Shutdown()` waits for the
token to prove no callback is in flight before setting `shutdown_`.

`VerifyTransaction` consumed that token before it knew whether an rpc would actually be sent:

```
  RETURN_NOT_OK(sync_.Wait());
  sync_.Reset();                 // token consumed here

  std::lock_guard l(rpc_mutex_);
  SCHECK(!shutdown_, ...);       // returns without sending
  auto rpc_handle = rpcs_.Prepare();
  if (rpc_handle == rpcs_.InvalidHandle()) { return ...; }   // returns without sending
```

`Reset()` clears `assigned_`, so the latch is re-armed and now expects a callback. On either
early exit no rpc is sent, so no callback ever runs and nothing signals it again. A later
`Shutdown()` calls the untimed `sync_.Wait()` on that re-armed latch and blocks forever. The
wait is held under `rpc_mutex_`, so the task can no longer be torn down either, and the
destructor's `DCHECK(shutdown_)` can never be satisfied.

In the master this is reachable whenever an abort arrives while a DDL verification task is
polling: the abort path runs `PerformAbort()` -> `Shutdown()` while the task's own step is
inside `VerifyTransaction`. The aborting thread then hangs with no deadline and no log output.

The fix moves `sync_.Reset()` down to just before the callback is created, so the token is
consumed only on the path that actually sends. `Reset()` through `SendRpc()` now happens
entirely under `rpc_mutex_`, which `Shutdown()` also takes, so a concurrent `Shutdown()` can
only land on one side or the other: before, and `VerifyTransaction` sees `shutdown_` and
returns with the signal intact; after, and the rpc is already registered in `rpcs_`, so
`rpcs_.Shutdown()` aborts it and the callback fires. There is no longer a window where the
token is gone and no callback is pending.

`Reset()` is safe at its new position: `must_wait_` was cleared by the `Wait()` above, so
`EnsureWaitDone()` is a no-op.

Two alternatives were considered and rejected. Restoring the token on the early-exit paths
with a scope guard works but re-signals a latch that was never consumed for anything, and the
guard has to be cancelled before `AsStdStatusCallback` hands the token out or it double-assigns.
Moving the `Wait()` itself under `rpc_mutex_` is unsafe: the callback path can reach
`Shutdown()` via `FinishPollTransaction` -> `Complete()` -> `TaskCompleted()`, which takes
`rpc_mutex_` -- the deadlock already documented in `DdlRequesterLivenessTask`.

## Test plan

New regression test `CatalogEntityTaskTest.TestAbortWithInFlightTransactionPoll` in
`master_multi_step_monitored_task-test`. It uses sync points to park a task's step inside
`VerifyTransaction` past the point where the token is consumed, lets the abort path run
`Shutdown()` once, then releases the step so it returns via the `shutdown_` check. The abort
is run on a separate thread and the test waits on it with a 30 second bound, so a
reproduction fails with a named assertion instead of wedging the binary until the harness
kills it.

The test also asserts that the step exited at the shutdown `SCHECK` specifically, by matching
`"Task has been shut down"`. Three exits in `VerifyTransaction` return `IllegalState`, and
only that one strands the signal, so without the message check a reordering of the function
could make the test pass without exercising the bug.

- [x] `CatalogEntityTaskTest.TestAbortWithInFlightTransactionPoll` fails on the parent commit:
      30 second hang, then `Abort deadlocked on the transaction status poll Synchronizer`.
- [x] Same test passes with this fix, in 11ms.
- [x] `CatalogEntityTaskTest.TestMultipleSteps` passes (4005ms).
- [x] `CatalogEntityTaskTest.TestEpochChanges` passes (4009ms).
- [ ] CI.

Run with:

```
ybd --cxx-test master_multi_step_monitored_task-test \
  --gtest_filter CatalogEntityTaskTest.TestAbortWithInFlightTransactionPoll
```
