### PR TITLE
[#33248] DocDB: Fix self-deadlock in Synchronizer::Reset() and destructor

### DIFF
--- a/src/yb/util/async_util.cc
+++ b/src/yb/util/async_util.cc
@@ -32,7 +32,8 @@ void CallStatusCBMaybe(std::weak_ptr<Synchronizer> weak_sync, const Status& stat
 } // anonymous namespace
 
 Synchronizer::~Synchronizer() {
-  EnsureWaitDone();
+  std::unique_lock<std::mutex> lock(mutex_);
+  EnsureWaitDone(lock);
 }
 
 void Synchronizer::StatusCB(const Status& status) {
@@ -80,6 +81,11 @@ StdStatusCallback Synchronizer::AsStdStatusCallback(
 
 Status Synchronizer::WaitUntil(const std::chrono::steady_clock::time_point& time) {
   std::unique_lock<std::mutex> lock(mutex_);
+  return DoWaitUntil(lock, time);
+}
+
+Status Synchronizer::DoWaitUntil(
+    std::unique_lock<std::mutex>& lock, const std::chrono::steady_clock::time_point& time) {
   auto predicate = [this] { return assigned_; };
   if (time == std::chrono::steady_clock::time_point::max()) {
     cond_.wait(lock, predicate);
@@ -96,14 +102,14 @@ Status Synchronizer::WaitUntil(const std::chrono::steady_clock::time_point& time
 }
 
 void Synchronizer::Reset() {
-  std::lock_guard lock(mutex_);
-  EnsureWaitDone();
+  std::unique_lock<std::mutex> lock(mutex_);
+  EnsureWaitDone(lock);
   assigned_ = false;
   status_ = Status::OK();
   must_wait_ = false;
 }
 
-void Synchronizer::EnsureWaitDone() {
+void Synchronizer::EnsureWaitDone(std::unique_lock<std::mutex>& lock) {
   if (must_wait_) {
     static const char* kErrorMsg =
         "Synchronizer went out of scope, Wait() has returned success, callbacks may "
@@ -114,7 +120,8 @@ void Synchronizer::EnsureWaitDone() {
 #else
     const int kWaitSec = 10;
     YB_LOG_EVERY_N_SECS(DFATAL, 1) << kErrorMsg << " Waiting up to " << kWaitSec << " seconds";
-    CHECK_OK(WaitFor(MonoDelta::FromSeconds(kWaitSec)));
+    CHECK_OK(DoWaitUntil(
+        lock, std::chrono::steady_clock::now() + std::chrono::seconds(kWaitSec)));
 #endif
   }
 }

--- a/src/yb/util/async_util.h
+++ b/src/yb/util/async_util.h
@@ -95,8 +95,12 @@ class Synchronizer {
 
  private:
 
+  // Waits for the callback until the given time, using a lock already held on mutex_.
+  Status DoWaitUntil(
+      std::unique_lock<std::mutex>& lock, const std::chrono::steady_clock::time_point& time);
+
   // Invoked in the destructor and in Reset() to make sure Wait() was invoked if it had to be.
-  void EnsureWaitDone();
+  void EnsureWaitDone(std::unique_lock<std::mutex>& lock);
 
   std::mutex mutex_;
   std::condition_variable cond_;


### PR DESCRIPTION
## Summary

`Synchronizer::Reset()` and `~Synchronizer()` call `EnsureWaitDone()` while holding `mutex_`. When a callback is still outstanding (`must_wait_` is true), release builds take the recovery path that waits up to 10 seconds for that callback to fire, and they did so by calling the public `WaitUntil()`, which locks `mutex_` a second time on the same thread. Re-locking a non-recursive `std::mutex` is undefined behavior and hangs in practice, so instead of waiting out the outstanding callback the caller self-deadlocks.

Debug builds never reached this: `EnsureWaitDone()` takes `LOG(FATAL)` under `#ifndef NDEBUG` and only falls through to the wait under `NDEBUG`. That is why the deadlock is release-only.

### Fix

The waiting logic moves into a private `DoWaitUntil()` that operates on a lock the caller already holds:

- `WaitUntil()` acquires `mutex_` and delegates to `DoWaitUntil()`.
- `EnsureWaitDone()` takes the caller's `std::unique_lock<std::mutex>&` and passes it down, so the recovery wait reuses the lock already held instead of acquiring it again.

Because the private helpers now take the lock explicitly, the re-entrant call is no longer expressible rather than merely avoided.

The public API (`Wait()`, `WaitFor()`, `WaitUntil()`, `Reset()`, the callback accessors) is unchanged, so **no call site is affected**. Behavior is otherwise identical: the release path still bounds the wait at the same 10 second deadline, still `CHECK_OK()`s the callback status, and debug builds still `LOG(FATAL)`.

Fixes #33248.

## Test plan

No new test: reaching the repaired path needs a release build *and* a destructor or `Reset()` reached with a callback still outstanding, so the deadlock is removed by construction rather than demonstrated.

Ran tests that exercise `Synchronizer` indirectly in **both debug and release** builds to confirm no regression:

- [x] `CatalogEntityTaskTest.TestMultipleSteps` (`master_multi_step_monitored_task-test`) — exercises `Reset()` re-arm on a re-used synchronizer
- [x] `LogTest.TestWaitUntilAllFlushed` (`consensus_log-test`) — stack `Synchronizer` in `Log::WaitUntilAllFlushed()`
- [x] `LogTest.ConcurrentAllocateSegmentAndRollOver` (`consensus_log-test`) — stack `Synchronizer` in `Log::AllocateSegmentAndRollOver()`
- [x] `TabletPeerTest.TestActiveOperationPreventsLogGC` (`tablet_tablet_peer-test`)

```
./yb_build.sh --no-ccache --cxx-test master_multi_step_monitored_task-test \
  --gtest-filter CatalogEntityTaskTest.TestMultipleSteps
./yb_build.sh --no-ccache --cxx-test consensus_log-test \
  --gtest-filter LogTest.TestWaitUntilAllFlushed
./yb_build.sh --no-ccache --cxx-test consensus_log-test \
  --gtest-filter LogTest.ConcurrentAllocateSegmentAndRollOver
./yb_build.sh --no-ccache --cxx-test tablet_tablet_peer-test \
  --gtest-filter TabletPeerTest.TestActiveOperationPreventsLogGC
```

- [x] `async_util.cc` compiles clean in release (`-DNDEBUG`) and debug with `-Werror -Wall -Wextra -Wthread-safety-analysis`; five representative `async_util.h` includers (both `Reset()` call sites among them) compile clean.
