### PR TITLE
[#33356] YSQL: Preserve kDdlPostProcessingFailed across concurrent DD…

### DIFF
--- a/src/yb/master/ysql_ddl_handler.cc
+++ b/src/yb/master/ysql_ddl_handler.cc
@@ -219,6 +219,7 @@ Status CatalogManager::YsqlDdlTxnCompleteCallback(TableInfoPtr table,
 
   vector<TableInfoPtr> tables;
   std::unordered_set<TableId> processed_tables;
+  bool state_was_post_processing_failed = false;
   {
     LockGuard lock(ddl_txn_verifier_mutex_);
     auto verifier_state = FindOrNull(ysql_ddl_txn_verfication_state_map_, txn);
@@ -228,6 +229,8 @@ Status CatalogManager::YsqlDdlTxnCompleteCallback(TableInfoPtr table,
     }
 
     auto state = verifier_state->state;
+    state_was_post_processing_failed =
+        state == YsqlDdlVerificationState::kDdlPostProcessingFailed;
     auto txn_state = is_committed.has_value() ?
         (*is_committed ? TxnState::kCommitted : TxnState::kAborted) : TxnState::kNoChange;
     if (state == YsqlDdlVerificationState::kDdlPostProcessing) {
@@ -258,6 +261,12 @@ Status CatalogManager::YsqlDdlTxnCompleteCallback(TableInfoPtr table,
       if (verifier_state->txn_state != TxnState::kCommitted &&
           verifier_state->txn_state != TxnState::kAborted) {
         verifier_state->txn_state = txn_state;
+      }
+      if (state_was_post_processing_failed) {
+        LOG(INFO) << "Transaction " << txn
+                  << " moving from " << state
+                  << " to " << YsqlDdlVerificationState::kDdlPostProcessing
+                  << ", debug_caller_info " << debug_caller_info;
       }
       verifier_state->state = YsqlDdlVerificationState::kDdlPostProcessing;
     }
@@ -290,6 +299,7 @@ Status CatalogManager::YsqlDdlTxnCompleteCallback(TableInfoPtr table,
   }
 
   bool ddl_verification_success = true;
+  bool has_still_bound_table = false;
   for (auto& table : tables) {
     if (processed_tables.contains(table->id())) {
       VLOG(1) << "DDL already processed on table " << table->id();
@@ -312,6 +322,7 @@ Status CatalogManager::YsqlDdlTxnCompleteCallback(TableInfoPtr table,
       if (schema_version_txn != ddl_txns_waiting_for_schema_version.cend()) {
         LOG(INFO) << "table " << table->id() << " has no txn id but is waiting for "
                   << schema_version_txn->first << ". So it is still bound by txn " << txn;
+        has_still_bound_table = true;
         continue;
       }
 
@@ -356,13 +367,21 @@ Status CatalogManager::YsqlDdlTxnCompleteCallback(TableInfoPtr table,
         LOG(WARNING) << "YsqlDdlTxnCompleteCallback failed for table " << table->ToString()
                      << " txn " << txn << ": " << s.ToString();
         UpdateDdlVerificationState(txn, YsqlDdlVerificationState::kDdlPostProcessingFailed);
+        TEST_SYNC_POINT("CatalogManager::YsqlDdlTxnCompleteCallback:PostProcessingFailed");
       }
     });
     if (!s.ok()) {
       ddl_verification_success = false;
     }
   }
-  if (!ddl_verification_success) {
+  // A still-bound table stays in the transaction's entry until the alter that bumps its
+  // schema version is acknowledged (see HandleTabletSchemaVersionReport). When the state was
+  // kDdlPostProcessingFailed on entry, that alter may never have been sent, and this
+  // invocation scheduled no work for the still-bound table. kDdlPostProcessingFailed is the
+  // only state the re-trigger paths act on (see TriggerDdlVerificationIfNeeded), so restore
+  // it rather than leave the transaction in kDdlPostProcessing with nothing pending.
+  if (!ddl_verification_success ||
+      (state_was_post_processing_failed && has_still_bound_table)) {
     UpdateDdlVerificationState(txn, YsqlDdlVerificationState::kDdlPostProcessingFailed);
   }
   return Status::OK();

--- a/src/yb/yql/pgwrapper/pg_ddl_transaction-test.cc
+++ b/src/yb/yql/pgwrapper/pg_ddl_transaction-test.cc
@@ -26,6 +26,7 @@
 #include "yb/util/async_util.h"
 #include "yb/util/backoff_waiter.h"
 #include "yb/util/monotime.h"
+#include "yb/util/scope_exit.h"
 #include "yb/util/sync_point.h"
 #include "yb/util/test_thread_holder.h"
 #include "yb/yql/pgwrapper/libpq_test_base.h"
@@ -41,6 +42,7 @@ DECLARE_bool(ysql_ddl_transaction_wait_for_ddl_verification);
 DECLARE_bool(TEST_ysql_ddl_fail_transaction_status_poll);
 DECLARE_int32(TEST_ysql_ddl_atomicity_alter_table_request_delay_ms);
 DECLARE_double(TEST_ysql_ddl_verification_failure_probability);
+DECLARE_double(TEST_ysql_ddl_rollback_failure_probability);
 DECLARE_int32(ysql_ddl_post_processing_failed_verification_retry_secs);
 
 namespace yb::pgwrapper {
@@ -375,6 +377,80 @@ TEST_F(PgDdlTransactionMiniClusterTest, TestPostProcessingFailedPeriodicRetrigge
     },
     MonoDelta::FromSeconds(60),
     "DDL verification task should have been re-triggered"));
+}
+
+TEST_F(PgDdlTransactionMiniClusterTest, TestPostProcessingFailedNotClobberedByConcurrentCallback) {
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_ysql_ddl_post_processing_failed_verification_retry_secs) = -1;
+  auto conn = ASSERT_RESULT(Connect());
+  auto client = ASSERT_RESULT(cluster_->CreateClient());
+  auto& catalog_manager = ASSERT_RESULT(cluster_->GetLeaderMiniMaster())->catalog_manager_impl();
+
+  ASSERT_OK(conn.Execute("CREATE TABLE ddl_pp_failed_clobber (id INT PRIMARY KEY)"));
+
+  // Two callbacks can run for the same DDL transaction. The master's schema verification task
+  // delivers one and the tserver's ReportYsqlDdlTxnStatus delivers the other. Hold the report
+  // until the verification task's rollback work has failed and recorded
+  // kDdlPostProcessingFailed. The report's callback then sees a table that has no transaction
+  // id but still waits for a schema version, and must not leave the transaction in
+  // kDdlPostProcessing, a state no re-trigger path acts on.
+  SyncPoint::GetInstance()->LoadDependency({
+    {
+      "CatalogManager::YsqlDdlTxnCompleteCallback:PostProcessingFailed",
+      "PgClientSession::DdlAtomicityFinishTransaction:BeforeReportYsqlDdlTxnStatus"
+    }
+  });
+  SyncPoint::GetInstance()->ClearTrace();
+  SyncPoint::GetInstance()->EnableProcessing();
+  // Disable sync points even when an assert fails before the explicit disable below. A loaded
+  // dependency would otherwise park a later report RPC and hang teardown or the next test.
+  auto disable_sync_points = ScopeExit([] {
+    SyncPoint::GetInstance()->DisableProcessing();
+  });
+
+  // Fail the rollback after it clears the table's transaction state but before it sends the
+  // ALTER TABLE request. The table is then waiting for a schema version bump that has not
+  // been sent.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_ysql_ddl_rollback_failure_probability) = 1.0;
+  // Keep report_ysql_ddl_txn_status_to_master enabled. The report is the concurrent callback
+  // this test exercises. Turn off waiting for verification so that ROLLBACK returns while the
+  // rollback work is still incomplete.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_ysql_ddl_transaction_wait_for_ddl_verification) = false;
+
+  ASSERT_OK(conn.Execute("BEGIN"));
+  ASSERT_OK(conn.Execute("ALTER TABLE ddl_pp_failed_clobber ADD COLUMN c INT"));
+
+  const auto table_id =
+      ASSERT_RESULT(GetTableIdByTableName(client.get(), kDatabase, "ddl_pp_failed_clobber"));
+  auto table_info = catalog_manager.GetTableInfo(table_id);
+  ASSERT_NE(table_info, nullptr);
+  const auto txn_id_pb = table_info->LockForRead()->pb_transaction_id();
+  ASSERT_FALSE(txn_id_pb.empty());
+  const auto txn_id = ASSERT_RESULT(FullyDecodeTransactionId(txn_id_pb));
+
+  ASSERT_OK(conn.Execute("ROLLBACK"));
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_ysql_ddl_rollback_failure_probability) = 0.0;
+
+  // The report's callback completed before ROLLBACK returned. The transaction must still be
+  // in kDdlPostProcessingFailed so that a re-trigger can finish the rollback.
+  const auto state = catalog_manager.TEST_GetYsqlDdlVerificationState(txn_id);
+  ASSERT_TRUE(state.has_value()) << "DDL verification entry disappeared";
+  ASSERT_EQ(*state, master::YsqlDdlVerificationState::kDdlPostProcessingFailed);
+
+  // Re-enable the periodic re-trigger and wait for it to finish the rollback and clean up.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_ysql_ddl_post_processing_failed_verification_retry_secs) = 1;
+  ASSERT_OK(WaitFor(
+      [&] {
+        const auto st = catalog_manager.TEST_GetYsqlDdlVerificationState(txn_id);
+        return Result<bool>(!st.has_value());
+      },
+      MonoDelta::FromSeconds(60),
+      "DDL verification should complete and clean up"));
+
+  // The table is usable again end to end.
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_ysql_ddl_transaction_wait_for_ddl_verification) = true;
+  ASSERT_OK(conn.Execute("ALTER TABLE ddl_pp_failed_clobber ADD COLUMN d INT"));
 }
 
 TEST_F(PgDdlTransactionMiniClusterTest, TestPostProcessingFailedDueToFailedStatusPoll) {


### PR DESCRIPTION
…L verification callbacks

Fixes #33356

`YsqlDdlTxnCompleteCallback` can run more than once for one DDL transaction, and its entry block silently overwrites a recorded `kDdlPostProcessingFailed`, the only state the re-trigger paths act on. When the failure happened before a table's tablet ALTER was sent, the overwrite leaves the table bound to a finished transaction with nothing scheduled to unbind it, and DDL on the table is wedged until a master leader change. The issue has the full mechanism and a log of the race.

This change makes the callback repair what it destroyed. It captures whether the state was `kDdlPostProcessingFailed` at entry, logs the overwrite, which used to be silent, and restores `kDdlPostProcessingFailed` after the per-table loop when this invocation destroyed a recorded failure and skipped a still-bound table. Recovery then flows through the existing re-trigger. The re-trigger re-sends the ALTER, the schema version report unbinds the table, and the entry is erased.

## What changed

All changes are in `YsqlDdlTxnCompleteCallback`.

- The entry block records whether the state was `kDdlPostProcessingFailed` before moving the state to `kDdlPostProcessing`, and logs the transition. Every other state change in this callback logs through `UpdateDdlVerificationState`, and this one was silent.
- The per-table loop records whether it skipped a table that is still waiting for a schema version from this transaction.
- After the loop, the callback restores `kDdlPostProcessingFailed` when the state was `kDdlPostProcessingFailed` at entry and a still-bound table was skipped. The existing re-arm for a failed task submission keeps its behavior, and the restore extends that statement's condition.
- A test sync point fires after the failure handler records `kDdlPostProcessingFailed`, so a test can order a concurrent callback after the failure record.

## Why a restore instead of a guard

Either callback can play either role. In one hung stress run the tserver's report callback recorded the failure and the master's schema checker destroyed it with a nullopt verdict. In another the schema checker recorded the failure and the report destroyed it while carrying a real aborted verdict. A guard keyed to the nullopt report would miss the second case, so the restore keys on the destroyed state, not on the caller or the verdict.

A guard that blocks the entry overwrite when the state is `kDdlPostProcessingFailed` would misfire in the common case. The re-trigger path itself enters this callback to redo the failed work, and the move to `kDdlPostProcessing` is the in-flight marker that keeps further re-triggers from scheduling duplicate retries while the redo runs. In 50 stress runs on a checkout that logs the transition, the entry block moved a recorded `kDdlPostProcessingFailed` to `kDdlPostProcessing` 277 times, and the re-trigger redoing its own work accounted for 261. The overwrite is not the bug. The bug is a callback that destroys the recorded failure and then returns having scheduled nothing for a table that still needs its ALTER. The restore runs at the end of the callback and keys on that outcome.

## Why the restore is safe

The restore fires only when both conditions hold. The common duplicate-callback case enters with the state at `kDdlPostProcessing`, so nothing is restored. A callback that processed or unbound every table skipped nothing, so nothing is restored.

A restore when the skipped table's ALTER really is in flight is harmless. The re-trigger re-sends the alter for a finalized table, an alter for an already applied schema version is a no-op on the tablet, and `HandleTabletSchemaVersionReport` unbinds the table when the version is reported either way.

There is no livelock. The re-trigger's committed and aborted branches re-send the alter directly and do not rewrite the verification state, so a restored transaction converges instead of cycling. `UpdateDdlVerificationState` is a no-op when the entry was already erased, and rerunning the callback on already processed tables is a no-op through the early exit in `YsqlDdlTxnCompleteCallbackInternal`. The stress numbers below back this empirically.

## What this does not cover

The restore makes the observed wedge self-healing. It does not cover every path that can lose a recorded failure. Error returns inside the per-table loop leave the function through `VERIFY_RESULT` before the restore runs, and those paths keep their current behavior. A related wedge on the drop path, where a failed table delete leaves the table marked as processed, is a separate bug and is out of scope here.

## Testing

I added a new regression test `PgDdlTransactionMiniClusterTest.TestPostProcessingFailedNotClobberedByConcurrentCallback` which forces the interleave deterministically. It fails the completion callback with `TEST_ysql_ddl_rollback_failure_probability` set to 1, holds the tserver's status report until the new sync point fires after the failure state is recorded, and then releases the report so it becomes the concurrent second callback. It asserts that `kDdlPostProcessingFailed` survives the second callback, that the re-trigger then erases the transaction's entry, and that a follow-up ALTER on the table succeeds. With only the sync point and the new log line applied to the base commit, this test fails at the state assertion. The state sits at `kDdlPostProcessing` with no work pending, which is the wedge. With the fix from this branch applied, the test passes.

The three existing DDL verification tests in the same file pass on this branch. `TestWaitForSchemaVersionAfterRollback`, `TestPostProcessingFailedPeriodicRetrigger`, and `TestPostProcessingFailedDueToFailedStatusPoll` exercise the same entry block, re-trigger, and unbinding machinery.

The stress instance `PgDdlAtomicityStressTest.Main/colocated_partitioned_ddl_rollback_failure_probability` is the end-to-end check, and this wedge makes it flaky. Its failure injection fails the completion callback at the point where a real send or scheduling error would. Without this fix it hung at its 600 second timeout in five out of 100 local runs. On this branch, the same instance passed 100 consecutive runs, and the slowest run finished in 26 seconds. Across those 100 runs the entry block overwrote a recorded failure 446 times. The new log line shows those passes exercised the race rather than avoided it. 