### PR TITLE
[#33376] DocDB: Use separate thread pools for outbound RPC response callbacks

### DIFF
--- a/src/yb/rpc/messenger.cc
+++ b/src/yb/rpc/messenger.cc
@@ -98,6 +98,10 @@ DEPRECATE_FLAG(int32, rpc_queue_limit, "03_2024");
 
 DEFINE_NON_RUNTIME_int32(rpc_workers_limit, 1024, "Workers limit for rpc server");
 
+DEFINE_NON_RUNTIME_int32(rpc_callback_workers_limit, 0,
+    "Workers limit for the outbound RPC response callback thread pools. 0 means use the value of "
+    "rpc_workers_limit.");
+
 DEFINE_NON_RUNTIME_int32(rpc_reactor_task_timeout_ms, 0,
     "Report if reactor task task takes longer that specified amount of milliseconds. "
     "0 to disable monitoring.");
@@ -439,6 +443,16 @@ const ThreadPoolPtr& Messenger::ThreadPoolPtr(ServicePriority priority) {
   FATAL_INVALID_ENUM_VALUE(ServicePriority, priority);
 }
 
+rpc::ThreadPool& Messenger::CallbackThreadPool(ServicePriority priority) {
+  switch (priority) {
+    case ServicePriority::kNormal:
+      return *normal_callback_thread_pool_;
+    case ServicePriority::kHigh:
+      return *high_priority_callback_thread_pool_;
+  }
+  FATAL_INVALID_ENUM_VALUE(ServicePriority, priority);
+}
+
 Result<ThreadPoolPtr> Messenger::TaggedThreadPool(TaggedThreadPools::Tag tag) {
   return normal_thread_pools_->Pool(tag);
 }
@@ -453,6 +467,12 @@ Status Messenger::RegisterService(
 
 void Messenger::ShutdownThreadPools() {
   normal_thread_pools_->Shutdown();
+  if (normal_callback_thread_pool_) {
+    normal_callback_thread_pool_->Shutdown();
+  }
+  if (high_priority_callback_thread_pool_) {
+    high_priority_callback_thread_pool_->Shutdown();
+  }
   std::lock_guard lock(mutex_high_priority_thread_pool_);
   if (high_priority_thread_pool_) {
     high_priority_thread_pool_->Shutdown();
@@ -652,6 +672,21 @@ Reactor* Messenger::RemoteToReactor(const Endpoint& remote, uint32_t idx) {
 
 Status Messenger::Init(const MessengerBuilder &bld) {
   default_normal_thread_pool_ = VERIFY_RESULT(normal_thread_pools_->Pool(/*tag=*/0));
+
+  auto callback_workers_limit = FLAGS_rpc_callback_workers_limit > 0
+      ? FLAGS_rpc_callback_workers_limit : thread_pool_workers_limit_;
+  normal_callback_thread_pool_ = std::make_shared<rpc::ThreadPool>(
+      rpc::ThreadPoolOptions {
+        .name = name_ + "-cb",
+        .max_workers = callback_workers_limit,
+        .cgroup = system_med_cgroup_,
+      });
+  high_priority_callback_thread_pool_ = std::make_shared<rpc::ThreadPool>(
+      rpc::ThreadPoolOptions {
+        .name = name_ + "-high-pri-cb",
+        .max_workers = callback_workers_limit,
+        .cgroup = system_high_cgroup_,
+      });
 
   reactors_.reserve(bld.num_reactors_);
   ReactorMonitor* reactor_monitor = nullptr;

--- a/src/yb/rpc/messenger.cc
+++ b/src/yb/rpc/messenger.cc
@@ -446,11 +446,36 @@ const ThreadPoolPtr& Messenger::ThreadPoolPtr(ServicePriority priority) {
 rpc::ThreadPool& Messenger::CallbackThreadPool(ServicePriority priority) {
   switch (priority) {
     case ServicePriority::kNormal:
-      return *normal_callback_thread_pool_;
+      return GetOrCreateCallbackThreadPool(
+          &normal_callback_thread_pool_, &normal_callback_thread_pool_ready_, "-cb",
+          system_med_cgroup_);
     case ServicePriority::kHigh:
-      return *high_priority_callback_thread_pool_;
+      return GetOrCreateCallbackThreadPool(
+          &high_priority_callback_thread_pool_, &high_priority_callback_thread_pool_ready_,
+          "-high-pri-cb", system_high_cgroup_);
   }
   FATAL_INVALID_ENUM_VALUE(ServicePriority, priority);
+}
+
+rpc::ThreadPool& Messenger::GetOrCreateCallbackThreadPool(
+    rpc::ThreadPoolPtr* pool, std::atomic<bool>* ready, const std::string& name_suffix,
+    Cgroup* cgroup) {
+  if (ready->load(std::memory_order_acquire)) {
+    return **pool;
+  }
+  std::lock_guard lock(mutex_callback_thread_pools_);
+  if (ready->load(std::memory_order_acquire)) {
+    return **pool;
+  }
+  *pool = std::make_shared<rpc::ThreadPool>(
+      rpc::ThreadPoolOptions {
+        .name = name_ + name_suffix,
+        .max_workers = FLAGS_rpc_callback_workers_limit > 0
+            ? FLAGS_rpc_callback_workers_limit : thread_pool_workers_limit_,
+        .cgroup = cgroup,
+      });
+  ready->store(true, std::memory_order_release);
+  return **pool;
 }
 
 Result<ThreadPoolPtr> Messenger::TaggedThreadPool(TaggedThreadPools::Tag tag) {
@@ -467,11 +492,14 @@ Status Messenger::RegisterService(
 
 void Messenger::ShutdownThreadPools() {
   normal_thread_pools_->Shutdown();
-  if (normal_callback_thread_pool_) {
-    normal_callback_thread_pool_->Shutdown();
-  }
-  if (high_priority_callback_thread_pool_) {
-    high_priority_callback_thread_pool_->Shutdown();
+  {
+    std::lock_guard lock(mutex_callback_thread_pools_);
+    if (normal_callback_thread_pool_) {
+      normal_callback_thread_pool_->Shutdown();
+    }
+    if (high_priority_callback_thread_pool_) {
+      high_priority_callback_thread_pool_->Shutdown();
+    }
   }
   std::lock_guard lock(mutex_high_priority_thread_pool_);
   if (high_priority_thread_pool_) {
@@ -672,21 +700,6 @@ Reactor* Messenger::RemoteToReactor(const Endpoint& remote, uint32_t idx) {
 
 Status Messenger::Init(const MessengerBuilder &bld) {
   default_normal_thread_pool_ = VERIFY_RESULT(normal_thread_pools_->Pool(/*tag=*/0));
-
-  auto callback_workers_limit = FLAGS_rpc_callback_workers_limit > 0
-      ? FLAGS_rpc_callback_workers_limit : thread_pool_workers_limit_;
-  normal_callback_thread_pool_ = std::make_shared<rpc::ThreadPool>(
-      rpc::ThreadPoolOptions {
-        .name = name_ + "-cb",
-        .max_workers = callback_workers_limit,
-        .cgroup = system_med_cgroup_,
-      });
-  high_priority_callback_thread_pool_ = std::make_shared<rpc::ThreadPool>(
-      rpc::ThreadPoolOptions {
-        .name = name_ + "-high-pri-cb",
-        .max_workers = callback_workers_limit,
-        .cgroup = system_high_cgroup_,
-      });
 
   reactors_.reserve(bld.num_reactors_);
   ReactorMonitor* reactor_monitor = nullptr;

--- a/src/yb/rpc/messenger.h
+++ b/src/yb/rpc/messenger.h
@@ -259,9 +259,7 @@ class Messenger : public ProxyContext {
   const Protocol& DefaultProtocol() override { return listen_protocol_; }
   const Protocol& UncompressedProtocol() override { return uncompressed_protocol_; }
 
-  rpc::ThreadPool& CallbackThreadPool(ServicePriority priority) override {
-    return ThreadPool(priority);
-  }
+  rpc::ThreadPool& CallbackThreadPool(ServicePriority priority) override;
 
   Status QueueEventOnAllReactors(
       ServerEventListPtr server_event, const SourceLocation& source_location);
@@ -460,6 +458,11 @@ class Messenger : public ProxyContext {
   // This could be used for high-priority services such as Consensus.
   rpc::ThreadPoolPtr high_priority_thread_pool_;
   std::atomic<bool> high_priority_thread_pool_ready_;
+
+  // Pools used to invoke outbound call response callbacks, separate from the pools that serve
+  // inbound calls.
+  rpc::ThreadPoolPtr normal_callback_thread_pool_;
+  rpc::ThreadPoolPtr high_priority_callback_thread_pool_;
 
   std::unique_ptr<DnsResolver> resolver_;
 

--- a/src/yb/rpc/messenger.h
+++ b/src/yb/rpc/messenger.h
@@ -377,6 +377,10 @@ class Messenger : public ProxyContext {
 
   void ShutdownThreadPools();
 
+  rpc::ThreadPool& GetOrCreateCallbackThreadPool(
+      rpc::ThreadPoolPtr* pool, std::atomic<bool>* ready,
+      const std::string& name_suffix, Cgroup* cgroup);
+
   void BreakConnectivity(const IpAddress& address, bool incoming, bool outgoing);
   void RestoreConnectivity(const IpAddress& address, bool incoming, bool outgoing);
 
@@ -460,9 +464,13 @@ class Messenger : public ProxyContext {
   std::atomic<bool> high_priority_thread_pool_ready_;
 
   // Pools used to invoke outbound call response callbacks, separate from the pools that serve
-  // inbound calls.
+  // inbound calls. Created on first use: a messenger that never issues outbound calls of a given
+  // priority never creates the matching pool.
+  std::mutex mutex_callback_thread_pools_;
   rpc::ThreadPoolPtr normal_callback_thread_pool_;
+  std::atomic<bool> normal_callback_thread_pool_ready_{false};
   rpc::ThreadPoolPtr high_priority_callback_thread_pool_;
+  std::atomic<bool> high_priority_callback_thread_pool_ready_{false};
 
   std::unique_ptr<DnsResolver> resolver_;
 


### PR DESCRIPTION
## Summary

`Messenger::CallbackThreadPool` returned the same pool that serves inbound calls, so an inbound
handler that waits for an outbound completion could occupy every worker in the pool that has to
invoke that completion. The response arrives, its callback is enqueued, and no worker is ever free
to run it.

Give each messenger dedicated normal- and high-priority callback pools, sized by the new
`rpc_callback_workers_limit` flag, which defaults to `rpc_workers_limit`. Inbound handlers now
depend on outbound completions, and outbound completions no longer need an inbound handler slot.

## Test plan

- [x] `pg_txn-test` — hung before the change (`PgTxnTest.ManyCommitsWithSmallRpcWorkers`),
      passes after it.
- [x] `rpc-test`, `rpc_stub-test` — messenger init/shutdown with the added pools.
