### PR TITLE
[#33382] DocDB: Do not unregister a never-registered operation filter on abort

### DIFF
--- a/src/yb/tablet/operations/snapshot_operation.cc
+++ b/src/yb/tablet/operations/snapshot_operation.cc
@@ -150,11 +150,17 @@ bool SnapshotOperation::NeedOperationFilter() const {
 void SnapshotOperation::AddedAsPending(const TabletPtr& tablet) {
   if (NeedOperationFilter()) {
     tablet->RegisterOperationFilter(this);
+    filter_registered_.store(true, std::memory_order_release);
   }
 }
 
 void SnapshotOperation::RemovedFromPending(const TabletPtr& tablet) {
-  if (NeedOperationFilter()) {
+  // The operation can be aborted without ever having been added as pending: AddedAsPending runs
+  // at the end of Operation::AddedToLeader, whose earlier steps can fail (e.g. tablet_safe()
+  // while the tablet shuts down), while the abort path infers was_pending from OpId validity,
+  // which the operation driver sets before invoking the operation. Unregistering a
+  // never-registered filter would corrupt the tablet's operation-filter list.
+  if (filter_registered_.exchange(false, std::memory_order_acq_rel)) {
     tablet->UnregisterOperationFilter(this);
   }
 }

--- a/src/yb/tablet/operations/snapshot_operation.h
+++ b/src/yb/tablet/operations/snapshot_operation.h
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <mutex>
 #include <string>
 
@@ -73,6 +74,11 @@ class SnapshotOperation :
       const OpId& id, consensus::OperationType op_type) const override;
 
   Status DoCheckOperationRequirements();
+
+  // Whether AddedAsPending registered this operation as the tablet's operation filter. The abort
+  // path can run without the operation ever having been added as pending (see
+  // RemovedFromPending).
+  std::atomic<bool> filter_registered_{false};
 };
 
 }  // namespace tablet

--- a/src/yb/tablet/operations/split_operation.cc
+++ b/src/yb/tablet/operations/split_operation.cc
@@ -47,10 +47,18 @@ LWSplitTabletRequestPB* RequestTraits<LWSplitTabletRequestPB>::MutableRequest(
 
 void SplitOperation::AddedAsPending(const TabletPtr& tablet) {
   tablet->RegisterOperationFilter(this);
+  filter_registered_.store(true, std::memory_order_release);
 }
 
 void SplitOperation::RemovedFromPending(const TabletPtr& tablet) {
-  tablet->UnregisterOperationFilter(this);
+  // The operation can be aborted without ever having been added as pending: AddedAsPending runs
+  // at the end of Operation::AddedToLeader, whose earlier steps can fail (e.g. tablet_safe()
+  // while the tablet shuts down), while the abort path infers was_pending from OpId validity,
+  // which the operation driver sets before invoking the operation. Unregistering a
+  // never-registered filter would corrupt the tablet's operation-filter list.
+  if (filter_registered_.exchange(false, std::memory_order_acq_rel)) {
+    tablet->UnregisterOperationFilter(this);
+  }
 }
 
 Status SplitOperation::RejectionStatus(

--- a/src/yb/tablet/operations/split_operation.h
+++ b/src/yb/tablet/operations/split_operation.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <condition_variable>
 
 #include "yb/common/entity_ids_types.h"
@@ -68,6 +69,11 @@ class SplitOperation
       const OpId& id, consensus::OperationType op_type) const override;
 
   TabletSplitter& tablet_splitter_;
+
+  // Whether AddedAsPending registered this operation as the tablet's operation filter. The abort
+  // path can run without the operation ever having been added as pending (see
+  // RemovedFromPending).
+  std::atomic<bool> filter_registered_{false};
 };
 
 }  // namespace tablet

--- a/src/yb/tablet/tablet_peer-test.cc
+++ b/src/yb/tablet/tablet_peer-test.cc
@@ -58,14 +58,18 @@
 #include "yb/server/clock.h"
 #include "yb/server/logical_clock.h"
 
+#include "yb/tablet/operations/snapshot_operation.h"
+#include "yb/tablet/operations/split_operation.h"
 #include "yb/tablet/tablet-test-util.h"
 #include "yb/tablet/tablet.h"
 #include "yb/tablet/tablet_metadata.h"
 #include "yb/tablet/tablet_peer.h"
+#include "yb/tablet/tablet_splitter.h"
 #include "yb/tablet/write_query.h"
 
 #include "yb/tserver/tserver.messages.h"
 
+#include "yb/util/async_util.h"
 #include "yb/util/backoff_waiter.h"
 #include "yb/util/metrics.h"
 #include "yb/util/result.h"
@@ -425,6 +429,89 @@ TEST_F(TabletPeerTest, PendingStateCleanedUpWhenAddedToLeaderFails) {
   ASSERT_OK(ExecuteWriteAndReturnStatus(tablet_peer_.get(), retry_req));
   ASSERT_EQ(initial_op_id.index + 1, consensus->GetLastCommittedOpId().index);
   ASSERT_EQ(consensus->GetLastCommittedOpId(), tablet_peer_->log()->GetLatestEntryOpId());
+}
+
+namespace {
+
+class FakeTabletSplitter : public TabletSplitter {
+ public:
+  Status ApplyTabletSplit(
+      SplitOperation* operation, log::Log* raft_log,
+      std::optional<consensus::RaftConfigPB> raft_config) override {
+    LOG(FATAL) << "Unexpected ApplyTabletSplit call";
+  }
+
+  Status ApplyCloneTablet(
+      CloneOperation* operation, log::Log* raft_log,
+      std::optional<consensus::RaftConfigPB> raft_config) override {
+    LOG(FATAL) << "Unexpected ApplyCloneTablet call";
+  }
+};
+
+// Submits the operation on the leader with AddedToLeader failure injected and asserts a clean
+// abort: the failure status is surfaced, and -- because the operation registers an operation
+// filter in AddedAsPending, which never ran -- the abort path must not unregister a
+// never-registered filter (that corrupts the tablet's operation-filter list).
+void SubmitAndCheckAbortedBeforePending(
+    std::unique_ptr<Operation> operation, consensus::Consensus* consensus,
+    TabletPeer* tablet_peer) {
+  const auto initial_op_id = consensus->GetLastCommittedOpId();
+
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_fail_operation_added_to_leader) = true;
+  auto synchronizer = std::make_shared<Synchronizer>();
+  operation->set_completion_callback(
+      MakeWeakSynchronizerOperationCompletionCallback(synchronizer));
+  tablet_peer->Submit(std::move(operation), /* term= */ 1);
+  const auto status = synchronizer->Wait();
+  ANNOTATE_UNPROTECTED_WRITE(FLAGS_TEST_fail_operation_added_to_leader) = false;
+
+  ASSERT_TRUE(status.IsIllegalState()) << status;
+  ASSERT_STR_CONTAINS(status.message().ToBuffer(), "simulated AddedToLeader failure");
+  ASSERT_EQ(initial_op_id, consensus->GetLastCommittedOpId());
+  ASSERT_EQ(initial_op_id, tablet_peer->log()->GetLatestEntryOpId());
+}
+
+}  // namespace
+
+TEST_F(TabletPeerTest, SplitAbortBeforePendingDoesNotUnregisterFilter) {
+  ConsensusBootstrapInfo info;
+  ASSERT_OK(StartPeer(info));
+  auto consensus = ASSERT_RESULT(tablet_peer_->GetConsensus());
+  ASSERT_OK(LoggedWaitFor(
+      [&] {
+        const auto committed_op_id = consensus->GetLastCommittedOpId();
+        return committed_op_id.index > 0 &&
+               committed_op_id == tablet_peer_->log()->GetLatestEntryOpId();
+      },
+      MonoDelta::FromSeconds(5), "leader-election no-op to commit"));
+
+  FakeTabletSplitter fake_splitter;
+  auto operation = std::make_unique<SplitOperation>(
+      ASSERT_RESULT(tablet_peer_->shared_tablet()), &fake_splitter);
+  operation->AllocateRequest()->dup_tablet_id(tablet()->tablet_id());
+  ASSERT_NO_FATALS(SubmitAndCheckAbortedBeforePending(
+      std::move(operation), consensus.get(), tablet_peer_.get()));
+}
+
+TEST_F(TabletPeerTest, SnapshotAbortBeforePendingDoesNotUnregisterFilter) {
+  ConsensusBootstrapInfo info;
+  ASSERT_OK(StartPeer(info));
+  auto consensus = ASSERT_RESULT(tablet_peer_->GetConsensus());
+  ASSERT_OK(LoggedWaitFor(
+      [&] {
+        const auto committed_op_id = consensus->GetLastCommittedOpId();
+        return committed_op_id.index > 0 &&
+               committed_op_id == tablet_peer_->log()->GetLatestEntryOpId();
+      },
+      MonoDelta::FromSeconds(5), "leader-election no-op to commit"));
+
+  auto operation = std::make_unique<SnapshotOperation>(
+      ASSERT_RESULT(tablet_peer_->shared_tablet()));
+  // RESTORE operations are the ones that register an operation filter.
+  operation->AllocateRequest()->set_operation(
+      tserver::TabletSnapshotOpRequestPB::RESTORE_ON_TABLET);
+  ASSERT_NO_FATALS(SubmitAndCheckAbortedBeforePending(
+      std::move(operation), consensus.get(), tablet_peer_.get()));
 }
 
 // Ensure that Log::GC() doesn't delete logs with anchors.


### PR DESCRIPTION
## Summary

> **Stacked PR**: based on #33381 (`[#33380] DocDB: Roll back allocated Raft index when NotifyAddedToLeader fails`), whose commit this branch includes and whose `TEST_fail_operation_added_to_leader` hook the tests reuse. Only the top commit is new here. Once #33381 merges, this PR will be retargeted to `master` and rebased.

An operation aborted after its Raft OpId was assigned but before it was added as pending takes the was-pending abort path: `OperationDriver::AddedToLeader` stores `op_id_copy_` *before* invoking `Operation::AddedToLeader`, whose first step (`tablet_safe()`) can fail while the tablet shuts down -- before `AddedAsPending` runs -- while `OperationDriver::HandleFailure` infers `was_pending` from OpId validity (`operation_->Aborted(status, op_id_copy_.load().valid())`). `Operation::Aborted` then calls `RemovedFromPending` for an operation that was never added as pending.

`SplitOperation` (always) and `SnapshotOperation` (RESTORE operations) register an operation filter in `AddedAsPending` and unregistered it unconditionally in `RemovedFromPending`. Unregistering the never-registered filter erases an unlinked node from the tablet's intrusive operation-filter list (`operation_filters_.erase(operation_filters_.iterator_to(*filter))`), which is undefined behavior and crashes in practice.

This change tracks filter registration in both operations and unregisters only when the filter was actually registered. A deeper follow-up option is to track added-as-pending explicitly in the driver/operation instead of inferring it from OpId validity; these targeted guards keep the fix minimal -- happy to take that on if reviewers prefer the root fix.

## Test plan

- [x] `./yb_build.sh release --cxx-test tablet_peer-test --gtest_filter TabletPeerTest.SplitAbortBeforePendingDoesNotUnregisterFilter` -- a `SplitOperation` submitted with `TEST_fail_operation_added_to_leader` aborts cleanly (no SIGSEGV), and the committed and logged OpIds are unchanged.
- [x] `./yb_build.sh release --cxx-test tablet_peer-test --gtest_filter TabletPeerTest.SnapshotAbortBeforePendingDoesNotUnregisterFilter` -- same for a `RESTORE_ON_TABLET` `SnapshotOperation`.
